### PR TITLE
fix(telegram): show errors when message-only agent runs fail

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
@@ -46,6 +46,26 @@ const visibleFinalReceipt = {
   anyVisibleDelivered: true,
 } as const;
 
+function createMessageToolOnlyGroupContext(): TelegramMessageContext {
+  return createContext({
+    chatId: -1001234,
+    isGroup: true,
+    ctxPayload: {
+      SessionKey: "agent:test:telegram:group:-1001234",
+      ChatType: "group",
+    } as TelegramMessageContext["ctxPayload"],
+    primaryCtx: {
+      message: { chat: { id: -1001234, type: "supergroup" } },
+    } as TelegramMessageContext["primaryCtx"],
+    msg: {
+      chat: { id: -1001234, type: "supergroup" },
+      message_id: 456,
+    } as TelegramMessageContext["msg"],
+    threadSpec: { id: undefined, scope: "none" },
+    replyThreadId: undefined,
+  });
+}
+
 describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
   it("uses resolved DM config for auto-topic-label overrides", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
@@ -172,23 +192,7 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
     });
 
     await dispatchWithContext({
-      context: createContext({
-        chatId: -1001234,
-        isGroup: true,
-        ctxPayload: {
-          SessionKey: "agent:test:telegram:group:-1001234",
-          ChatType: "group",
-        } as TelegramMessageContext["ctxPayload"],
-        primaryCtx: {
-          message: { chat: { id: -1001234, type: "supergroup" } },
-        } as TelegramMessageContext["primaryCtx"],
-        msg: {
-          chat: { id: -1001234, type: "supergroup" },
-          message_id: 456,
-        } as TelegramMessageContext["msg"],
-        threadSpec: { id: undefined, scope: "none" },
-        replyThreadId: undefined,
-      }),
+      context: createMessageToolOnlyGroupContext(),
       streamMode: "off",
     });
 
@@ -219,6 +223,34 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
     expect(deliverReplies).toHaveBeenCalledWith(
       expect.objectContaining({
         replies: [{ text: "No response generated. Please try again." }],
+      }),
+    );
+  });
+
+  it("delivers a visible failure when a message-tool-only agent run fails after admission", async () => {
+    const channelInbound = await import("openclaw/plugin-sdk/channel-inbound");
+    vi.spyOn(channelInbound, "readAgentRunTerminalOutcome").mockReturnValueOnce("failed");
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    await dispatchWithContext({
+      context: createMessageToolOnlyGroupContext(),
+      retryDispatchErrors: true,
+      streamMode: "off",
+      suppressFailureFallback: true,
+    });
+
+    expect(deliverReplies).toHaveBeenCalledOnce();
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [
+          {
+            text: "Something went wrong while processing your request. Please try again.",
+          },
+        ],
       }),
     );
   });

--- a/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
@@ -234,7 +234,7 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
       dispatchThroughSharedOwner({
         ...params,
         replyResolver: async (_ctx, options) => {
-          options?.onAgentRunStart?.("provider-500-run");
+          options?.onAgentRunTerminalOutcome?.("failed");
           throw providerError;
         },
       }),

--- a/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
@@ -2,6 +2,7 @@ import {
   createOutboundPayloadPlan,
   projectOutboundPayloadPlanForDelivery,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { dispatchReplyWithBufferedBlockDispatcher as dispatchThroughSharedOwner } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { describe, expect, it, vi } from "vitest";
 import {
   describeTelegramDispatch,
@@ -227,16 +228,20 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
     );
   });
 
-  it("delivers a visible failure when a message-tool-only agent run fails after admission", async () => {
-    const channelInbound = await import("openclaw/plugin-sdk/channel-inbound");
-    vi.spyOn(channelInbound, "readAgentRunTerminalOutcome").mockReturnValueOnce("failed");
-    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
-      queuedFinal: false,
-      counts: { block: 0, final: 0, tool: 0 },
-      sourceReplyDeliveryMode: "message_tool_only",
-    });
+  it("delivers exactly one replay fallback when the provider fails before visible output", async () => {
+    const providerError = new Error("provider returned HTTP 500");
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async (params) =>
+      dispatchThroughSharedOwner({
+        ...params,
+        replyResolver: async (_ctx, options) => {
+          options?.onAgentRunStart?.("provider-500-run");
+          throw providerError;
+        },
+      }),
+    );
 
     await dispatchWithContext({
+      cfg: { messages: { groupChat: { visibleReplies: "message_tool" } } },
       context: createMessageToolOnlyGroupContext(),
       retryDispatchErrors: true,
       streamMode: "off",

--- a/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
@@ -246,11 +246,13 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
       retryDispatchErrors: true,
       streamMode: "off",
       suppressFailureFallback: true,
+      telegramCfg: { silentErrorReplies: true },
     });
 
     expect(deliverReplies).toHaveBeenCalledOnce();
     expect(deliverReplies).toHaveBeenCalledWith(
       expect.objectContaining({
+        silent: true,
         replies: [
           {
             text: "Something went wrong while processing your request. Please try again.",

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -426,15 +426,16 @@ export const dispatchTelegramMessage = async (
 
   const deliverySummary = turn.deliveryState.snapshot();
   let sentFallback = false;
+  const terminalFailure = turn.dispatchError || turn.agentRunFailed;
   const shouldSendFailureFallback =
     !isRoomEvent &&
-    !suppressFailureFallback &&
+    (!suppressFailureFallback || turn.agentRunFailed) &&
     !turn.finalAnswerDelivered &&
-    (turn.dispatchError ||
+    (terminalFailure ||
       deliverySummary.failedNonSilent > 0 ||
       (deliverySummary.skippedNonSilent > 0 && !turn.suppressSilentReplyFallback));
   if (shouldSendFailureFallback) {
-    const fallbackText = turn.dispatchError
+    const fallbackText = terminalFailure
       ? "Something went wrong while processing your request. Please try again."
       : EMPTY_RESPONSE_FALLBACK;
     const result = await deliverFallback(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -442,7 +442,7 @@ export const dispatchTelegramMessage = async (
       turn,
       [{ text: fallbackText }],
       telegramCfg.silentErrorReplies === true &&
-        (turn.dispatchError != null || turn.hadErrorReplyFailureOrSkip),
+        Boolean(terminalFailure || turn.hadErrorReplyFailureOrSkip),
     );
     sentFallback = result.delivered;
   }

--- a/qa/scenarios/channels/telegram-provider-failure-before-output.yaml
+++ b/qa/scenarios/channels/telegram-provider-failure-before-output.yaml
@@ -9,13 +9,16 @@ scenario:
       - channels.streaming-final-reply
   objective: Verify Telegram sends one fallback when the provider fails before producing visible output.
   successCriteria:
-    - A provider failure before visible output produces exactly one non-empty Telegram fallback.
+    - With silent error replies enabled, a provider failure before visible output produces exactly one non-empty Telegram fallback.
   codeRefs:
     - src/auto-reply/reply/dispatch-from-config.execute.ts
     - extensions/telegram/src/bot-message-dispatch.ts
     - extensions/qa-lab/src/providers/mock-openai/server.ts
     - extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
   gatewayConfigPatch:
+    channels:
+      telegram:
+        silentErrorReplies: true
     agents:
       defaults:
         model:

--- a/qa/scenarios/channels/telegram-provider-failure-before-output.yaml
+++ b/qa/scenarios/channels/telegram-provider-failure-before-output.yaml
@@ -1,0 +1,69 @@
+title: Telegram provider failure before output
+
+scenario:
+  id: telegram-provider-failure-before-output
+  surface: channels
+  category: channels.conversation-routing-and-delivery
+  coverage:
+    primary:
+      - channels.streaming-final-reply
+  objective: Verify Telegram sends one fallback when the provider fails before producing visible output.
+  successCriteria:
+    - A provider failure before visible output produces exactly one non-empty Telegram fallback.
+  codeRefs:
+    - src/auto-reply/reply/dispatch-from-config.execute.ts
+    - extensions/telegram/src/bot-message-dispatch.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
+    - extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
+  gatewayConfigPatch:
+    agents:
+      defaults:
+        model:
+          fallbacks: []
+      entries:
+        qa:
+          model:
+            fallbacks: []
+  execution:
+    kind: flow
+    channel: telegram
+    summary: Inject a provider failure before visible output and verify one Telegram fallback remains.
+    config:
+      requiredProviderMode: mock-openai
+      partialMarker: TELEGRAM-VISIBLE-PARTIAL-BEFORE-FAILURE
+
+flow:
+  steps:
+    - name: sends one fallback when no output became visible
+      actions:
+        - assert:
+            expr: env.providerMode === config.requiredProviderMode
+            message: this Telegram recovery scenario requires mock-openai
+        - call: waitForGatewayHealthy
+          args: [{ ref: env }, 60000]
+        - call: waitForTransportReady
+          args: [{ ref: env }, 60000]
+        - resetTransport: true
+        - set: outboundStart
+          value:
+            expr: "getTransportSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation: { id: telegram-provider-failure-room, kind: group }
+            senderId: qa-telegram-recovery-operator
+            senderName: Telegram Recovery Operator
+            text: "@openclaw Telegram unsent failure QA check"
+        - waitForOutbound:
+            conversation: { id: telegram-provider-failure-room, kind: group }
+            sinceIndex: { ref: outboundStart }
+            timeoutMs: 75000
+          saveAs: fallbackReply
+        - call: sleep
+          args: [4000]
+        - set: messages
+          value:
+            expr: "getTransportSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStart)"
+        - assert:
+            expr: "messages.length === 1 && fallbackReply.text.trim().length > 0 && messages[0].text.trim().length > 0 && !messages[0].text.includes(config.partialMarker)"
+            message:
+              expr: "`expected one non-empty Telegram fallback without partial text; saw ${messages.length}: ${messages.map((message) => message.text).join(' | ')}`"
+      detailsExpr: "JSON.stringify({ count: messages.length, text: messages.map((message) => message.text).join(' | ') })"

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -130,6 +130,8 @@ export type GetReplyOptions = {
     runId: string,
     executionIdentityToken?: ExecutionIdentityAdmissionToken,
   ) => void;
+  /** Reports the terminal agent-run classification to the shared dispatch owner. */
+  onAgentRunTerminalOutcome?: (outcome: "completed" | "failed") => void;
   /**
    * Canonical adoption lifecycle (adopted / deferred / abandoned / settled + pre-adoption abort).
    */

--- a/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
@@ -76,6 +76,17 @@ function createOpenAiServiceUnavailableError() {
 }
 
 describe("executeAgentTurn: provider failures", () => {
+  it("reports the terminal provider failure to the dispatch owner", async () => {
+    const onAgentRunTerminalOutcome = vi.fn();
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(new Error("provider returned HTTP 500"));
+
+    const result = await executeTestTurn({ opts: { onAgentRunTerminalOutcome } });
+
+    expect(result.kind).toBe("final");
+    expect(onAgentRunTerminalOutcome).toHaveBeenCalledOnce();
+    expect(onAgentRunTerminalOutcome).toHaveBeenCalledWith("failed");
+  });
+
   it.each(NON_DIRECT_FAILURE_SURFACE_CASES)(
     "keeps raw runner failure boilerplate out of $label chats",
     async (testCase) => {
@@ -707,10 +718,11 @@ describe("executeAgentTurn: provider failures", () => {
     const abortController = new AbortController();
     const { replyOperation } = createMockReplyOperation({ abortSignal: abortController.signal });
     const onBlockReply = vi.fn();
+    const onAgentRunTerminalOutcome = vi.fn();
 
     const resultPromise = executeAgentTurn(
       createMinimalRunAgentTurnParams({
-        opts: { onBlockReply },
+        opts: { onAgentRunTerminalOutcome, onBlockReply },
         replyOperation,
       }),
     );
@@ -721,6 +733,7 @@ describe("executeAgentTurn: provider failures", () => {
       payload: { text: SILENT_REPLY_TOKEN },
     });
     expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+    expect(onAgentRunTerminalOutcome).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(30_000);
     expect(onBlockReply).not.toHaveBeenCalled();
     const agentEvents = await import("../../infra/agent-events.js");

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -16,7 +16,6 @@ import {
   classifyFailoverReason,
   isContextOverflowError,
 } from "../../agents/embedded-agent-helpers.js";
-import { hasCompletedSourceReplyDeliveryEvidence } from "../../agents/embedded-agent-runner/delivery-evidence.js";
 import type { EmbeddedAgentExecutionPhase } from "../../agents/embedded-agent-runner/execution-phase.js";
 import type { RunEmbeddedAgentParams } from "../../agents/embedded-agent-runner/run/params.js";
 import { runEmbeddedAgent } from "../../agents/embedded-agent.js";
@@ -36,9 +35,7 @@ import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent
 import { emitAgentRunStatusEvent } from "../../infra/agent-run-status-events.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { recordMessageToolRunOutcome } from "../../infra/message-tool-run-outcome-store.js";
 import { logSessionTurnCreated } from "../../logging/diagnostic.js";
-import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   bindGatewayContextResolver,
   getPluginRuntimeGatewayRequestScope,
@@ -70,6 +67,7 @@ import {
   executeAgentFallbackCycle,
   type AgentFallbackCycleState,
 } from "./agent-runner-fallback-cycle.js";
+import { recordMessageToolOnlyRunOutcome } from "./agent-runner-message-tool-outcome.js";
 import { createAgentTurnPresentation } from "./agent-runner-presentation.js";
 import { createAgentTurnTimingTracker } from "./agent-runner-turn-timing.js";
 import { resolveQueuedReplyRuntimeConfig } from "./agent-runner-utils.js";
@@ -91,8 +89,6 @@ type InternalFollowupRun = FollowupRun & {
   currentTurnImagesPrepared?: true;
   mediaImageLayout?: CurrentTurnImages["mediaImageLayout"];
 };
-
-const messageToolOutcomeLog = createSubsystemLogger("auto-reply/message-tool-outcome");
 
 function resolveRunStartupPhase(
   phase: EmbeddedAgentExecutionPhase,
@@ -676,58 +672,6 @@ async function executeAgentTurnOutcome(params: AgentTurnParams): Promise<AgentTu
   }
 }
 
-function recordMessageToolOnlyRunOutcome(
-  params: AgentTurnParams,
-  result: AgentTurnExecutionResult | undefined,
-): void {
-  const sourceReplyDeliveryMode =
-    params.followupRun.run.sourceReplyDeliveryMode ?? params.opts?.sourceReplyDeliveryMode;
-  if (sourceReplyDeliveryMode !== "message_tool_only") {
-    return;
-  }
-  const sessionKey = params.sessionKey ?? params.followupRun.run.sessionKey;
-  if (!sessionKey) {
-    messageToolOutcomeLog.warn("message-tool-only run outcome missing session key", {
-      runId: result?.runId ?? params.opts?.runId,
-      agentId: params.followupRun.run.agentId,
-    });
-    return;
-  }
-  const outcome = result?.outcome;
-  const resolved =
-    outcome?.kind === "settled" || outcome?.kind === "rejected" ? outcome.resolved : undefined;
-  const provider = resolved?.provider ?? params.followupRun.run.provider;
-  const model = resolved?.model ?? params.followupRun.run.model;
-  const runStatus: "completed" | "errored" | "aborted" =
-    outcome?.kind === "aborted" || (outcome?.kind === "settled" && outcome.abortReason)
-      ? "aborted"
-      : !outcome || outcome.kind === "rejected" || outcome.status === "failed"
-        ? "errored"
-        : "completed";
-  const toolDelivered =
-    outcome?.kind === "settled" && hasCompletedSourceReplyDeliveryEvidence(outcome.result);
-  const values = {
-    runId: result?.runId ?? params.opts?.runId ?? "unknown",
-    sessionKey,
-    agentId: params.followupRun.run.agentId,
-    provider,
-    model,
-    outcome: toolDelivered ? ("tool_delivered" as const) : ("mute" as const),
-    runStatus,
-    occurredAt: Date.now(),
-    storePath: params.storePath,
-  };
-  try {
-    recordMessageToolRunOutcome(values);
-    messageToolOutcomeLog.info("recorded message-tool-only run outcome", values);
-  } catch (error) {
-    messageToolOutcomeLog.warn("failed to record message-tool-only run outcome", {
-      ...values,
-      error: formatErrorMessage(error),
-    });
-  }
-}
-
 /** Runs the agent turn and records its message-tool-only visible-outcome fact once. */
 export async function executeAgentTurn(params: AgentTurnParams): Promise<AgentTurnExecutionResult> {
   const runId = params.opts?.runId ?? crypto.randomUUID();
@@ -735,9 +679,20 @@ export async function executeAgentTurn(params: AgentTurnParams): Promise<AgentTu
     params.opts?.runId === runId ? params : { ...params, opts: { ...params.opts, runId } };
   try {
     const result = await executeAgentTurnOutcome(executionParams);
+    const terminalOutcome =
+      result.outcome.kind === "aborted" ||
+      (result.outcome.kind === "settled" && result.outcome.abortReason)
+        ? undefined
+        : result.outcome.kind === "rejected" || result.outcome.status === "failed"
+          ? "failed"
+          : "completed";
+    if (terminalOutcome) {
+      executionParams.opts?.onAgentRunTerminalOutcome?.(terminalOutcome);
+    }
     recordMessageToolOnlyRunOutcome(executionParams, result);
     return result;
   } catch (error) {
+    executionParams.opts?.onAgentRunTerminalOutcome?.("failed");
     recordMessageToolOnlyRunOutcome(executionParams, undefined);
     throw error;
   }

--- a/src/auto-reply/reply/agent-runner-message-tool-outcome.ts
+++ b/src/auto-reply/reply/agent-runner-message-tool-outcome.ts
@@ -1,0 +1,59 @@
+import { hasCompletedSourceReplyDeliveryEvidence } from "../../agents/embedded-agent-runner/delivery-evidence.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { recordMessageToolRunOutcome } from "../../infra/message-tool-run-outcome-store.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { AgentTurnExecutionResult, AgentTurnParams } from "./agent-runner-execution.types.js";
+
+const messageToolOutcomeLog = createSubsystemLogger("auto-reply/message-tool-outcome");
+
+export function recordMessageToolOnlyRunOutcome(
+  params: AgentTurnParams,
+  result: AgentTurnExecutionResult | undefined,
+): void {
+  const sourceReplyDeliveryMode =
+    params.followupRun.run.sourceReplyDeliveryMode ?? params.opts?.sourceReplyDeliveryMode;
+  if (sourceReplyDeliveryMode !== "message_tool_only") {
+    return;
+  }
+  const sessionKey = params.sessionKey ?? params.followupRun.run.sessionKey;
+  if (!sessionKey) {
+    messageToolOutcomeLog.warn("message-tool-only run outcome missing session key", {
+      runId: result?.runId ?? params.opts?.runId,
+      agentId: params.followupRun.run.agentId,
+    });
+    return;
+  }
+  const outcome = result?.outcome;
+  const resolved =
+    outcome?.kind === "settled" || outcome?.kind === "rejected" ? outcome.resolved : undefined;
+  const provider = resolved?.provider ?? params.followupRun.run.provider;
+  const model = resolved?.model ?? params.followupRun.run.model;
+  const runStatus: "completed" | "errored" | "aborted" =
+    outcome?.kind === "aborted" || (outcome?.kind === "settled" && outcome.abortReason)
+      ? "aborted"
+      : !outcome || outcome.kind === "rejected" || outcome.status === "failed"
+        ? "errored"
+        : "completed";
+  const toolDelivered =
+    outcome?.kind === "settled" && hasCompletedSourceReplyDeliveryEvidence(outcome.result);
+  const values = {
+    runId: result?.runId ?? params.opts?.runId ?? "unknown",
+    sessionKey,
+    agentId: params.followupRun.run.agentId,
+    provider,
+    model,
+    outcome: toolDelivered ? ("tool_delivered" as const) : ("mute" as const),
+    runStatus,
+    occurredAt: Date.now(),
+    storePath: params.storePath,
+  };
+  try {
+    recordMessageToolRunOutcome(values);
+    messageToolOutcomeLog.info("recorded message-tool-only run outcome", values);
+  } catch (error) {
+    messageToolOutcomeLog.warn("failed to record message-tool-only run outcome", {
+      ...values,
+      error: formatErrorMessage(error),
+    });
+  }
+}

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -601,7 +601,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     const admittedAgentRun = getAgentRunTerminalOutcome() === "completed";
     if (
       params.replyOptions?.isHeartbeat === true ||
-      !admittedAgentRun ||
+      (!admittedAgentRun && !didDeliverVisiblePartialReply) ||
       isDispatchOperationAborted()
     ) {
       throw error;

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -598,10 +598,10 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
         `dispatch-from-config: deferred final text fallback failed: ${formatErrorMessage(fallbackError)}`,
       );
     }
-    const admittedAgentRun = getAgentRunTerminalOutcome() === "completed";
+    const failedAgentRun = getAgentRunTerminalOutcome() === "failed";
     if (
       params.replyOptions?.isHeartbeat === true ||
-      (!admittedAgentRun && !didDeliverVisiblePartialReply) ||
+      (!failedAgentRun && !didDeliverVisiblePartialReply) ||
       isDispatchOperationAborted()
     ) {
       throw error;

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -41,6 +41,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     dispatcher,
     failDispatchReplyOperation,
     flushPendingCommentaryProgress,
+    getAgentRunTerminalOutcome,
     getDispatchAbortOperation,
     getDispatchAbortSignal,
     hookRunner,
@@ -597,14 +598,18 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
         `dispatch-from-config: deferred final text fallback failed: ${formatErrorMessage(fallbackError)}`,
       );
     }
+    const admittedAgentRun = getAgentRunTerminalOutcome() === "completed";
     if (
       params.replyOptions?.isHeartbeat === true ||
-      !didDeliverVisiblePartialReply ||
+      !admittedAgentRun ||
       isDispatchOperationAborted()
     ) {
       throw error;
     }
     failDispatchReplyOperation(error, "failed");
+    if (!didDeliverVisiblePartialReply) {
+      return undefined;
+    }
     return buildTerminalAgentRunFailureReplyPayload({
       visibleReplyDelivered: true,
       sessionCtx: ctx,

--- a/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
@@ -473,6 +473,14 @@ export function createDispatchReplyOperationCoordinator(params: {
       params.messageAuditTerminal?.observeRunId(runId);
       params.replyOptions?.onAgentRunStart?.(runId, executionIdentityToken);
     };
+    const onAgentRunTerminalOutcome: NonNullable<
+      NonNullable<DispatchFromConfigParams["replyOptions"]>["onAgentRunTerminalOutcome"]
+    > = (outcome) => {
+      if (outcome === "failed" || agentRunTerminalOutcome === undefined) {
+        agentRunTerminalOutcome = outcome;
+      }
+      params.replyOptions?.onAgentRunTerminalOutcome?.(outcome);
+    };
     return {
       ...params.replyOptions,
       ...(abortSignal
@@ -482,6 +490,7 @@ export function createDispatchReplyOperationCoordinator(params: {
           }
         : {}),
       onAgentRunStart,
+      onAgentRunTerminalOutcome,
       ...(dispatchReplyOperation ? { replyOperation: dispatchReplyOperation } : {}),
     };
   };

--- a/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
@@ -142,7 +142,22 @@ describe("dispatchReplyFromConfig terminal visible admission recovery", () => {
     );
   });
 
-  it("records an admitted failure before the first visible reply", async () => {
+  it("rethrows post-run dispatch errors after a completed run with no visible reply", async () => {
+    const resolverError = new Error("final delivery failed after completion");
+    const replyResolver: NonNullable<DispatchFromConfigParams["replyResolver"]> = async (
+      _ctx,
+      options,
+    ) => {
+      options?.onAgentRunTerminalOutcome?.("completed");
+      throw resolverError;
+    };
+
+    await expect(dispatchReplyFromConfig(createVisibleDispatchParams(replyResolver))).rejects.toBe(
+      resolverError,
+    );
+  });
+
+  it("records a terminal agent failure before the first visible reply", async () => {
     const resolverError = new Error("provider failed before output");
     let replyOperation: ReturnType<typeof createReplyOperation> | undefined;
     const replyResolver: NonNullable<DispatchFromConfigParams["replyResolver"]> = async (
@@ -153,7 +168,7 @@ describe("dispatchReplyFromConfig terminal visible admission recovery", () => {
         throw new Error("reply options required for terminal failure");
       }
       replyOperation = options.replyOperation;
-      options.onAgentRunStart?.("failed-before-output");
+      options.onAgentRunTerminalOutcome?.("failed");
       throw resolverError;
     };
     const dispatchParams = {

--- a/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
@@ -141,4 +141,38 @@ describe("dispatchReplyFromConfig terminal visible admission recovery", () => {
       expect.objectContaining({ text: expect.stringContaining("Something went wrong") }),
     );
   });
+
+  it("records an admitted failure before the first visible reply", async () => {
+    const resolverError = new Error("provider failed before output");
+    let replyOperation: ReturnType<typeof createReplyOperation> | undefined;
+    const replyResolver: NonNullable<DispatchFromConfigParams["replyResolver"]> = async (
+      _ctx,
+      options,
+    ) => {
+      if (!options) {
+        throw new Error("reply options required for terminal failure");
+      }
+      replyOperation = options.replyOperation;
+      options.onAgentRunStart?.("failed-before-output");
+      throw resolverError;
+    };
+    const dispatchParams = {
+      ...createVisibleDispatchParams(replyResolver),
+      replyOptions: { sourceReplyDeliveryMode: "message_tool_only" as const },
+    };
+
+    const result = await dispatchReplyFromConfig(dispatchParams);
+
+    expect(replyOperation?.result).toEqual({
+      kind: "failed",
+      code: "run_failed",
+      cause: resolverError,
+    });
+    expect(result).toMatchObject({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(readAgentRunTerminalOutcome(result)).toBe("failed");
+    expect(dispatchParams.dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
 });

--- a/test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts
@@ -115,6 +115,7 @@ test("visibly settles a message-tool-only Telegram turn after a provider failure
                         botToken: BOT_TOKEN,
                         apiRoot,
                         groupPolicy: "open",
+                        silentErrorReplies: true,
                         groups: {
                           [String(CHAT_ID)]: {
                             groupPolicy: "open",
@@ -155,6 +156,7 @@ test("visibly settles a message-tool-only Telegram turn after a provider failure
                 providerRequests,
                 sends: telegramSends.map((send) => ({
                   chatId: send.chat_id,
+                  silent: send.disable_notification,
                   text: send.text,
                 })),
               }),
@@ -162,7 +164,7 @@ test("visibly settles a message-tool-only Telegram turn after a provider failure
             )
             .toEqual({
               providerRequests: expect.any(Number),
-              sends: [{ chatId: String(CHAT_ID), text: FAILURE_TEXT }],
+              sends: [{ chatId: String(CHAT_ID), silent: true, text: FAILURE_TEXT }],
             });
           expect(providerRequests).toBeGreaterThan(0);
         } finally {

--- a/test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts
@@ -1,0 +1,176 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import path from "node:path";
+import { withServer, withTempDir } from "openclaw/plugin-sdk/test-env";
+import { expect, test } from "vitest";
+import { startQaGatewayChild, writeJson } from "../../../../extensions/qa-lab/api.js";
+
+type JsonObject = Record<string, unknown>;
+
+const BOT_TOKEN = `424242:${"A".repeat(35)}`;
+const CHAT_ID = -1001234;
+const SENDER_ID = 777;
+const FAILURE_TEXT = "Something went wrong while processing your request. Please try again.";
+
+async function readRequest(req: IncomingMessage): Promise<JsonObject> {
+  let text = "";
+  for await (const chunk of req) {
+    text += chunk;
+  }
+  return text ? (JSON.parse(text) as JsonObject) : {};
+}
+
+function succeed(res: ServerResponse, result: unknown = true) {
+  writeJson(res, 200, { ok: true, result });
+}
+
+test("visibly settles a message-tool-only Telegram turn after a provider failure", async () => {
+  const pendingPolls = new Set<ServerResponse>();
+  const telegramSends: JsonObject[] = [];
+  let providerRequests = 0;
+  let updateDelivered = false;
+
+  const update = {
+    update_id: 1,
+    message: {
+      message_id: 456,
+      date: 1_754_000_000,
+      chat: { id: CHAT_ID, type: "supergroup", title: "QA" },
+      from: { id: SENDER_ID, is_bot: false, first_name: "QA" },
+      text: "Please investigate this request. This turn should visibly settle even if the agent fails.",
+    },
+  };
+
+  const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
+    const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+    if (pathname.startsWith("/v1/")) {
+      providerRequests += 1;
+      writeJson(res, 500, { error: { message: "provider returned HTTP 500" } });
+      return;
+    }
+
+    const [, token = "", method = ""] = pathname.match(/^\/bot([^/]+)\/([^/]+)$/) ?? [];
+    const body = await readRequest(req);
+    if (token !== BOT_TOKEN) {
+      writeJson(res, 401, { ok: false, error_code: 401, description: "Unexpected bot token" });
+      return;
+    }
+    if (method === "getMe") {
+      succeed(res, {
+        id: 424242,
+        is_bot: true,
+        first_name: "QA Failure",
+        username: "qa_failure_bot",
+      });
+      return;
+    }
+    if (method === "getUpdates") {
+      if (!updateDelivered) {
+        updateDelivered = true;
+        succeed(res, [update]);
+      } else {
+        pendingPolls.add(res);
+        req.on("close", () => pendingPolls.delete(res));
+      }
+      return;
+    }
+    if (method === "sendMessage") {
+      telegramSends.push(body);
+      succeed(res, {
+        message_id: 10_000 + telegramSends.length,
+        date: 1_754_000_000,
+        chat: { id: CHAT_ID, type: "supergroup" },
+        text: body.text,
+      });
+      return;
+    }
+    succeed(res);
+  };
+
+  await withServer(
+    (req, res) => {
+      void handleRequest(req, res).catch((error: unknown) => {
+        writeJson(res, 500, { error: error instanceof Error ? error.message : String(error) });
+      });
+    },
+    async (apiRoot) =>
+      await withTempDir("openclaw-telegram-failure-settlement-", async (workspace) => {
+        let gateway: Awaited<ReturnType<typeof startQaGatewayChild>> | undefined;
+        try {
+          const repoRoot = path.resolve(import.meta.dirname, "../../../..");
+          gateway = await startQaGatewayChild({
+            repoRoot,
+            useRepoCli: true,
+            providerBaseUrl: `${apiRoot}/v1`,
+            transportBaseUrl: apiRoot,
+            transport: {
+              requiredPluginIds: ["telegram"],
+              createGatewayConfig: () => ({
+                channels: {
+                  telegram: {
+                    enabled: true,
+                    defaultAccount: "proof",
+                    accounts: {
+                      proof: {
+                        enabled: true,
+                        botToken: BOT_TOKEN,
+                        apiRoot,
+                        groupPolicy: "open",
+                        groups: {
+                          [String(CHAT_ID)]: {
+                            groupPolicy: "open",
+                            requireMention: false,
+                          },
+                        },
+                        streaming: { mode: "off" },
+                      },
+                    },
+                  },
+                },
+              }),
+            },
+            controlUiEnabled: false,
+            runtimeEnvPatch: {
+              OPENCLAW_SKIP_CHANNELS: undefined,
+              OPENCLAW_SKIP_PROVIDERS: undefined,
+              OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+              TELEGRAM_BOT_TOKEN: undefined,
+            },
+            mutateConfig: (cfg) => {
+              cfg.agents!.defaults!.workspace = workspace;
+              cfg.messages = {
+                ...cfg.messages,
+                groupChat: { ...cfg.messages?.groupChat, visibleReplies: "message_tool" },
+              };
+              cfg.bindings = [
+                ...(cfg.bindings ?? []),
+                { agentId: "qa", match: { channel: "telegram", accountId: "proof" } },
+              ];
+              return cfg;
+            },
+          });
+
+          await expect
+            .poll(
+              () => ({
+                providerRequests,
+                sends: telegramSends.map((send) => ({
+                  chatId: send.chat_id,
+                  text: send.text,
+                })),
+              }),
+              { interval: 100, timeout: 30_000 },
+            )
+            .toEqual({
+              providerRequests: expect.any(Number),
+              sends: [{ chatId: String(CHAT_ID), text: FAILURE_TEXT }],
+            });
+          expect(providerRequests).toBeGreaterThan(0);
+        } finally {
+          await gateway?.stop();
+          for (const poll of pendingPolls) {
+            poll.destroy();
+          }
+        }
+      }),
+  );
+}, 120_000);


### PR DESCRIPTION
Related: #127710
Related: #127850

## What Problem This Solves

Fixes an issue where Telegram users could receive no visible response when an agent run failed before producing output, including message-tool-only spool replays whose fallback is normally suppressed.

## Why This Change Was Made

The agent-runner owner now reports its terminal classification to the shared reply dispatcher. A failed outcome remains sticky through dispatch finalization, so Telegram can distinguish a terminal agent failure from a successful message-tool-only turn and bypass replay suppression exactly once. Completed runs still preserve the existing retry path for later dispatch errors, aborted runs remain silent, and visible-partial recovery is unchanged.

## User Impact

Telegram users now see one generic retryable error instead of an inbound request disappearing after the provider fails.

## Evidence

- Exact pushed head: `cab500b55d5c588cca00ff6505bc56670b002d87`, confirmed by GitHub PR metadata and the remote test banner `OpenClaw 2026.8.1 (cab500b)`.
- Provider: Crabbox with Blacksmith Testbox (`blacksmith-testbox`).
- Lease: `tbx_01m10sajkbtzyt2cf6hwj3667s` (`amber-krill`).
- Run: https://github.com/openclaw/openclaw/actions/runs/33041026003
- Exact command:

  ```sh
  node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --id tbx_01m10sajkbtzyt2cf6hwj3667s --timing-json --shell -- 'test "$(git rev-parse HEAD)" = "cab500b55d5c588cca00ff6505bc56670b002d87" && CI=1 node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts --reporter=verbose'
  ```

- Scenario: a real QA Gateway consumes one Telegram group update through a fake Telegram Bot API; its configured OpenAI-compatible provider returns HTTP 500 before visible output, with `visibleReplies: message_tool` and Telegram streaming disabled. The test requires a real provider request and exactly one generic Telegram fallback.
- Result: pass, 1/1 test; Vitest duration 252.59s; wrapper exit code 0 and `runStatus: succeeded`.
- Cleanup: `blacksmith testbox stop --id tbx_01m10sajkbtzyt2cf6hwj3667s` returned `stopped (completed)`; the subsequent provider list showed no active lease.
- Validation: 472 core tests, 40 Telegram/replay tests, committed-SHA local Gateway E2E, all-lane `node scripts/check-changed.mjs`, and exact-commit autoreview passed.

AI-assisted: yes.
