### PR TITLE
fix(gateway): project canonical session events

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -3574,6 +3574,49 @@ describe("agent event handler", () => {
     });
   });
 
+  it("tombstones cleared agent status and observer digest in lifecycle snapshots", async () => {
+    vi.mocked(loadGatewaySessionRow).mockReturnValue({
+      key: "session-finished",
+      kind: "direct",
+      updatedAt: 1_700,
+      status: "done",
+    });
+    const { broadcastToConnIds, sessionEventSubscribers, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-finished",
+    });
+    sessionEventSubscribers.subscribe("conn-session");
+    registerAgentRunContext("run-finished", {
+      sessionKey: "session-finished",
+      verboseLevel: "off",
+    });
+
+    emitAgentEvent(
+      handler,
+      "run-finished",
+      "lifecycle",
+      { phase: "end", endedAt: 1_700 },
+      { seq: 2, ts: 1_800 },
+    );
+
+    await waitForFast(() => {
+      expect(
+        broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+      ).toHaveLength(1);
+    });
+    const payload = requireRecord(
+      // oxlint-disable-next-line unicorn/prefer-structured-clone -- verify the gateway JSON wire shape
+      JSON.parse(
+        JSON.stringify(requireMockArg(broadcastToConnIds, 0, 1, "sessions changed payload")),
+      ),
+      "serialized sessions changed payload",
+    );
+    expectRecordFields(payload, { agentStatus: null, observerDigest: null });
+    expectRecordFields(requireRecord(payload.session, "nested session"), {
+      agentStatus: null,
+      observerDigest: null,
+    });
+  });
+
   it("omits goal state from unscoped global lifecycle snapshots", async () => {
     vi.mocked(loadGatewaySessionRow).mockReturnValue({
       key: "global",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -18,7 +18,6 @@ import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../auto-re
 import { normalizeVerboseLevel } from "../auto-reply/thinking.js";
 import { normalizeAgentPlanSteps } from "../channels/streaming.js";
 import { getRuntimeConfig } from "../config/io.js";
-import { sessionEntryForkedFromParent } from "../config/sessions/session-entry-lineage.js";
 import {
   type AgentEventPayload,
   type AgentEventRuntimePayload,
@@ -53,14 +52,9 @@ import type {
   ToolEventRecipientRegistry,
 } from "./server-chat-state.js";
 import { hasSessionChangeReceivers } from "./session-change-receivers.js";
+import { buildGatewaySessionSnapshot } from "./session-event-payload.js";
 import {
-  buildGatewaySessionEventRow,
-  projectSessionEventActiveRunIds,
-} from "./session-event-payload.js";
-import {
-  deriveGatewaySessionLifecycleProjectionPatch,
   isRestartRecoveryLifecycleEvent,
-  isStaleLifecycleEventForSession,
   persistGatewaySessionLifecycleEvent,
 } from "./session-lifecycle-state.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "./session-request-agent.js";
@@ -585,33 +579,6 @@ export function createAgentEventHandler({
       snapshotOptions,
     );
     const { lifecycleRunId, row } = lifecycleSnapshot;
-    const omitUnscopedGlobalGoal = sessionKey === "global" && !agentId;
-    const lifecyclePatch =
-      evt &&
-      !isStaleLifecycleEventForSession({
-        owningSessionId: evt.sessionId,
-        currentSessionId: row?.sessionId,
-        eventRunId: evt.runId,
-        currentRunId: lifecycleRunId,
-        eventStartedAt: evt.data?.startedAt,
-        currentStartedAt: row?.startedAt,
-      })
-        ? deriveGatewaySessionLifecycleProjectionPatch({
-            entry: row
-              ? {
-                  updatedAt: row.updatedAt ?? undefined,
-                  status: row.status,
-                  lastRunError: row.lastRunError,
-                  lastRunId: row.lastRunId,
-                  startedAt: row.startedAt,
-                  endedAt: row.endedAt,
-                  runtimeMs: row.runtimeMs,
-                  abortedLastRun: row.abortedLastRun,
-                }
-              : undefined,
-            event: evt,
-          })
-        : {};
     const activeRunState = includeActiveRunState
       ? resolveSessionActiveRunState?.({
           requestedKey: sessionKey,
@@ -620,95 +587,15 @@ export function createAgentEventHandler({
           ...(agentId ? { agentId } : {}),
         })
       : undefined;
-    // Agent lifecycle broadcasts merge into cached session rows in the UI. Replace
-    // run identities only when the Gateway owns the complete exact set.
-    const activeRunFields = activeRunState
-      ? {
-          hasActiveRun: activeRunState.active,
-          activeRunIds: projectSessionEventActiveRunIds(activeRunState),
-        }
-      : {};
-    const clearsLastRunError =
-      Object.hasOwn(lifecyclePatch, "lastRunError") && lifecyclePatch.lastRunError === undefined;
-    const clearsLastRunId =
-      Object.hasOwn(lifecyclePatch, "lastRunId") && lifecyclePatch.lastRunId === undefined;
-    const projectedRow = row
-      ? lifecycleProjection
-        ? buildGatewaySessionEventRow(row, { lifecycle: true })
-        : row
-      : undefined;
-    const session = projectedRow
-      ? {
-          ...projectedRow,
-          ...lifecyclePatch,
-          ...activeRunFields,
-          // JSON drops undefined values, so starts/successes need tombstones
-          // for terminal fields retained in the subscribed client row.
-          ...(clearsLastRunError ? { lastRunError: null } : {}),
-          ...(clearsLastRunId ? { lastRunId: null } : {}),
-        }
-      : undefined;
-    if (session && omitUnscopedGlobalGoal) {
-      delete session.goal;
-    }
-    const snapshotSource = session ?? lifecyclePatch;
-    return {
-      ...(session ? { session } : {}),
-      updatedAt: snapshotSource.updatedAt,
-      sessionId: row?.sessionId,
-      kind: row?.kind,
-      channel: row?.channel,
-      subject: row?.subject,
-      groupChannel: row?.groupChannel,
-      space: row?.space,
-      chatType: row?.chatType,
-      origin: row?.origin,
-      spawnedBy: row?.spawnedBy,
-      spawnedWorkspaceDir: row?.spawnedWorkspaceDir,
-      spawnedCwd: row?.spawnedCwd,
-      forkedFromParent: sessionEntryForkedFromParent(row ?? undefined) ? true : undefined,
-      spawnDepth: row?.spawnDepth,
-      subagentRole: row?.subagentRole,
-      subagentControlScope: row?.subagentControlScope,
-      label: row?.label,
-      displayName: row?.displayName,
-      deliveryContext: row?.deliveryContext,
-      parentSessionKey: row?.parentSessionKey,
-      childSessions: row?.childSessions,
-      thinkingLevel: row?.thinkingLevel,
-      fastMode: row?.fastMode,
-      toolOverrides: row?.toolOverrides,
-      verboseLevel: row?.verboseLevel,
-      traceLevel: row?.traceLevel,
-      reasoningLevel: row?.reasoningLevel,
-      elevatedLevel: row?.elevatedLevel,
-      sendPolicy: row?.sendPolicy,
-      systemSent: row?.systemSent,
-      inputTokens: row?.inputTokens,
-      outputTokens: row?.outputTokens,
-      lastChannel: row?.lastChannel,
-      lastTo: row?.lastTo,
-      lastAccountId: row?.lastAccountId,
-      lastThreadId: row?.lastThreadId,
-      totalTokens: projectedRow?.totalTokens,
-      totalTokensFresh: projectedRow?.totalTokensFresh,
-      ...(omitUnscopedGlobalGoal ? {} : { goal: row?.goal ?? null }),
-      contextTokens: projectedRow?.contextTokens,
-      estimatedCostUsd: projectedRow?.estimatedCostUsd,
-      responseUsage: row?.responseUsage,
-      // Carry the row-built channel-aware effective mode so the chat snapshot
-      // matches the session-event/list projections.
-      effectiveResponseUsage: row?.effectiveResponseUsage,
-      modelProvider: projectedRow?.modelProvider,
-      model: projectedRow?.model,
-      ...activeRunFields,
-      status: snapshotSource.status,
-      lastRunError: snapshotSource.lastRunError ?? null,
-      startedAt: snapshotSource.startedAt,
-      endedAt: snapshotSource.endedAt,
-      runtimeMs: snapshotSource.runtimeMs,
-      abortedLastRun: snapshotSource.abortedLastRun,
-    };
+    return buildGatewaySessionSnapshot({
+      sessionRow: row,
+      agentId,
+      includeSession: true,
+      lifecycle: lifecycleProjection,
+      event: evt,
+      lifecycleRunId,
+      activeRunState,
+    });
   };
 
   const resolveSessionDeliveryKeys = (sessionKey: string, agentId?: string) => {

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -24,7 +24,7 @@ import {
 import { resolveEffectiveChatHistoryMaxChars } from "../chat-display-projection.js";
 import { resolveClaudeCliBindingSessionId } from "../cli-session-history.js";
 import { getMaxChatHistoryMessagesBytes } from "../server-constants.js";
-import { buildGatewaySessionSnapshot } from "../server-session-events.js";
+import { buildGatewaySessionSnapshot } from "../session-event-payload.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-agent.js";
 import { capArrayByJsonBytes } from "../session-transcript-readers.js";
 import {
@@ -466,8 +466,7 @@ async function handleChatHistoryRequest({
       sessionRow: deltaSessionRow,
       agentId: sessionAgentId,
       includeSession: true,
-      hasActiveRun: activeRunState.active,
-      activeRunIds: activeRunState.runIds,
+      activeRunState,
     });
     let delta: ReturnType<typeof readChatHistoryDelta>;
     try {

--- a/src/gateway/server-methods/session-change-event.ts
+++ b/src/gateway/server-methods/session-change-event.ts
@@ -1,10 +1,7 @@
 // Shared sessions.changed broadcaster for gateway RPC and chat-command mutations.
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { hasSessionChangeReceivers } from "../session-change-receivers.js";
-import {
-  buildGatewaySessionEventFields,
-  projectSessionEventActiveRunIds,
-} from "../session-event-payload.js";
+import { buildGatewaySessionSnapshot } from "../session-event-payload.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-agent.js";
 import { invalidateSessionSharingSnapshot } from "../session-sharing.js";
 import { loadGatewaySessionRow } from "../session-utils.js";
@@ -96,18 +93,12 @@ function broadcastSessionsChanged(
       ts: Date.now(),
       ...(sessionRow
         ? {
-            ...buildGatewaySessionEventFields({
+            ...buildGatewaySessionSnapshot({
               sessionRow,
               agentId: effectiveAgentId,
+              activeRunState,
               status: activeRunState?.active ? (activeRunState.status ?? "running") : undefined,
-              hasActiveRun: activeRunState?.active,
-              activeRunIds: projectSessionEventActiveRunIds(activeRunState),
             }),
-            effectiveFastMode: sessionRow.effectiveFastMode,
-            effectiveFastModeSource: sessionRow.effectiveFastModeSource,
-            fastAutoOnSeconds: sessionRow.fastAutoOnSeconds,
-            traceLevel: sessionRow.traceLevel,
-            pluginExtensions: sessionRow.pluginExtensions,
           }
         : {}),
     },

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -487,11 +487,13 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
     expect(payload).not.toHaveProperty("session.thinkingDefault");
   });
 
-  it("emits an explicit null when the thinking override is cleared", async () => {
+  it("emits explicit tombstones in transcript snapshots", async () => {
     sessionRow.thinkingLevel = undefined;
 
     await expect(emitAssistantTranscriptUpdate(false)).resolves.toMatchObject({
-      session: { thinkingLevel: null },
+      agentStatus: null,
+      observerDigest: null,
+      session: { thinkingLevel: null, agentStatus: null, observerDigest: null },
     });
   });
 
@@ -522,7 +524,10 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
     expect(resolveEmbeddedAgentRunProgressStateMock).toHaveBeenCalledWith("sess-main");
   });
 
-  it("routes an ownerless bare transcript event through the persisted fixed-store owner", async () => {
+  it.each([
+    { name: "routes a bare event without disclosing the persisted owner's goal" },
+    { name: "publishes the qualified owner's goal", agentId: "ops" },
+  ])("$name", async ({ agentId }) => {
     runtimeConfigState.value = {
       session: { store: "/tmp/owned-shared.sqlite" },
       agents: {
@@ -532,6 +537,18 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       },
     };
     sessionRow.key = "global";
+    const goal = {
+      schemaVersion: 1 as const,
+      id: "goal-ops",
+      objective: "Ops only",
+      status: "active" as const,
+      createdAt: 1,
+      updatedAt: 2,
+      tokenStart: 0,
+      tokensUsed: 3,
+      continuationTurns: 0,
+    };
+    loadGatewaySessionRowMock.mockReturnValue({ ...sessionRow, goal });
     const getSessionMessageSubscribers = vi.fn((sessionKey: string) =>
       sessionKey === "global"
         ? new Set(["conn-global"])
@@ -549,6 +566,7 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
 
     await handler({
       sessionKey: "global",
+      ...(agentId ? { agentId } : {}),
       message: { role: "assistant", content: [{ type: "text", text: "Owner reply" }] },
       messageId: "message-global-owner",
       messageSeq: 1,
@@ -565,6 +583,14 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       expect.objectContaining({ sessionKey: "global" }),
       new Set(["conn-scoped", "conn-global"]),
     );
+    const payload = broadcastToConnIds.mock.calls[0]?.[1];
+    if (agentId) {
+      expect(payload).toMatchObject({ agentId: "ops", goal, session: { goal } });
+    } else {
+      expect(payload).not.toHaveProperty("agentId");
+      expect(payload).not.toHaveProperty("goal");
+      expect(payload).not.toHaveProperty("session.goal");
+    }
   });
 
   it("broadcasts user idempotency keys in session.message metadata", async () => {
@@ -882,7 +908,10 @@ describe("createLifecycleEventBroadcastHandler", () => {
     }
   });
 
-  it("projects active state for a bare lifecycle event through the persisted owner", () => {
+  it.each([
+    { name: "projects bare active state without disclosing the persisted owner's goal" },
+    { name: "publishes active state and goal for the qualified owner", agentId: "ops" },
+  ])("$name", ({ agentId }) => {
     runtimeConfigState.value = {
       session: { store: "/tmp/owned-shared.sqlite" },
       agents: {
@@ -892,6 +921,18 @@ describe("createLifecycleEventBroadcastHandler", () => {
       },
     };
     sessionRow.key = "global";
+    const goal = {
+      schemaVersion: 1 as const,
+      id: "goal-ops",
+      objective: "Ops only",
+      status: "active" as const,
+      createdAt: 1,
+      updatedAt: 2,
+      tokenStart: 0,
+      tokensUsed: 3,
+      continuationTurns: 0,
+    };
+    loadGatewaySessionRowMock.mockReturnValue({ ...sessionRow, goal });
     const activeRun = {
       ...createActiveRun(true),
       agentId: "ops",
@@ -904,7 +945,7 @@ describe("createLifecycleEventBroadcastHandler", () => {
       chatAbortControllers: new Map([["run-before-finalize", activeRun]]),
     });
 
-    handler({ sessionKey: "global", reason: "updated" });
+    handler({ sessionKey: "global", ...(agentId ? { agentId } : {}), reason: "updated" });
 
     expect(loadGatewaySessionRowMock).toHaveBeenCalledWith("global", { agentId: "ops" });
     expect(broadcastToConnIds).toHaveBeenCalledWith(
@@ -917,5 +958,13 @@ describe("createLifecycleEventBroadcastHandler", () => {
       new Set(["conn-1"]),
       { dropIfSlow: true },
     );
+    const payload = broadcastToConnIds.mock.calls[0]?.[1];
+    if (agentId) {
+      expect(payload).toMatchObject({ agentId: "ops", goal });
+    } else {
+      expect(payload).not.toHaveProperty("agentId");
+      expect(payload).not.toHaveProperty("goal");
+      expect(payload).not.toHaveProperty("session.goal");
+    }
   });
 });

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -24,22 +24,14 @@ import type {
 } from "./server-chat.js";
 import { resolveVisibleActiveSessionRunState } from "./server-methods/session-active-runs.js";
 import { hasSessionChangeReceivers } from "./session-change-receivers.js";
-import {
-  buildGatewaySessionEventFields,
-  buildGatewaySessionEventRow,
-  projectSessionEventActiveRunIds,
-} from "./session-event-payload.js";
+import { buildGatewaySessionSnapshot } from "./session-event-payload.js";
 import {
   resolveSessionSubscriptionKey,
   resolveSessionSubscriptionKeys,
 } from "./session-subscription-keys.js";
 import { projectSessionMessagePayload } from "./session-transcript-message.js";
 import { readSessionMessageCountAsync } from "./session-transcript-readers.js";
-import {
-  loadGatewaySessionRow,
-  loadGatewaySessionEntryReadOnly,
-  type GatewaySessionRow,
-} from "./session-utils.js";
+import { loadGatewaySessionRow, loadGatewaySessionEntryReadOnly } from "./session-utils.js";
 
 type SessionEventSubscribers = Pick<SessionEventSubscriberRegistry, "getAll">;
 type SessionMessageSubscribers = Pick<SessionMessageSubscriberRegistry, "get">;
@@ -76,60 +68,6 @@ function readTranscriptUpdateLifecycleOwner(
   }
   const lifecycleRevision = normalizeOptionalString(entry.lifecycleRevision);
   return lifecycleRevision ? { lifecycleRevision } : {};
-}
-
-export function buildGatewaySessionSnapshot(params: {
-  sessionRow: GatewaySessionRow | null | undefined;
-  agentId?: string;
-  includeSession?: boolean;
-  label?: string;
-  displayName?: string;
-  parentSessionKey?: string;
-  status?: GatewaySessionRow["status"];
-  hasActiveRun?: boolean;
-  activeRunIds?: string[] | null;
-}): Record<string, unknown> {
-  const { sessionRow } = params;
-  if (!sessionRow) {
-    return {};
-  }
-  // Nested snapshots are the UI merge source, so preserve explicit clear semantics there too.
-  const session: Record<string, unknown> | undefined = params.includeSession
-    ? {
-        ...buildGatewaySessionEventRow(sessionRow),
-        createdActor: sessionRow.createdActor ?? null,
-        thinkingLevel: sessionRow.thinkingLevel ?? null,
-      }
-    : undefined;
-  if (session && sessionRow.key === "global" && !params.agentId) {
-    // The unscoped global row hides goal state to avoid presenting one agent's
-    // scoped goal as the global/default session goal.
-    delete session.goal;
-  }
-  if (session && params.status !== undefined) {
-    session.status = params.status;
-  }
-  if (session && params.hasActiveRun !== undefined) {
-    session.hasActiveRun = params.hasActiveRun;
-  }
-  if (session && params.activeRunIds !== undefined) {
-    session.activeRunIds = params.activeRunIds;
-  }
-  return {
-    ...(session ? { session } : {}),
-    ...buildGatewaySessionEventFields({
-      sessionRow,
-      agentId: params.agentId,
-      label: params.label,
-      displayName: params.displayName,
-      parentSessionKey: params.parentSessionKey,
-      status: params.status,
-      hasActiveRun: params.hasActiveRun,
-      activeRunIds: params.activeRunIds,
-    }),
-    subagentRunState: sessionRow.subagentRunState,
-    hasActiveSubagentRun: sessionRow.hasActiveSubagentRun,
-  };
 }
 
 /** Creates a serialized transcript-update broadcaster for session websocket clients. */
@@ -361,11 +299,10 @@ async function handleTranscriptUpdateBroadcast(
       : null;
   const sessionSnapshot = buildGatewaySessionSnapshot({
     sessionRow,
-    agentId: routingAgentId,
+    agentId: visibleAgentId,
     includeSession: true,
+    activeRunState,
     status: activeRunState?.active ? (activeRunState.status ?? "running") : undefined,
-    hasActiveRun: activeRunState?.active,
-    activeRunIds: projectSessionEventActiveRunIds(activeRunState),
   });
   if (update.message === undefined) {
     // A committed batch without individually proven cursors must invalidate
@@ -472,11 +409,11 @@ export function createLifecycleEventBroadcastHandler(params: {
         ts: Date.now(),
         ...buildGatewaySessionSnapshot({
           sessionRow,
+          agentId: eventAgentId,
           label: event.label,
           displayName: event.displayName,
           parentSessionKey: event.parentSessionKey,
-          hasActiveRun: activeRunState?.active,
-          activeRunIds: projectSessionEventActiveRunIds(activeRunState),
+          activeRunState,
         }),
         ...(swarmEvent.swarmGroupId
           ? {

--- a/src/gateway/session-event-payload.test.ts
+++ b/src/gateway/session-event-payload.test.ts
@@ -1,5 +1,8 @@
 import { expect, it } from "vitest";
-import { buildGatewaySessionEventFields } from "./session-event-payload.js";
+import {
+  buildGatewaySessionEventFields,
+  buildGatewaySessionSnapshot,
+} from "./session-event-payload.js";
 
 it("projects session actors and explicitly clears absent attribution", () => {
   expect(
@@ -60,4 +63,102 @@ it("projects the prepared permission boundary only for an explicit mode", () => 
       },
     }),
   ).toMatchObject({ permissionMode: "workspace", sessionRoot: "/workspace/project" });
+});
+
+it("serializes merge tombstones without flattening row-only execution fields", () => {
+  // oxlint-disable-next-line unicorn/prefer-structured-clone -- verify the gateway JSON wire shape
+  const snapshot = JSON.parse(
+    JSON.stringify(
+      buildGatewaySessionSnapshot({
+        sessionRow: {
+          key: "agent:main:project",
+          kind: "direct",
+          updatedAt: 5,
+          traceLevel: "full",
+          worktree: { id: "wt-1", branch: "feature", repoRoot: "/private/repo" },
+          execNode: "private-node",
+          execCwd: "/private/cwd",
+        },
+        includeSession: true,
+      }),
+    ),
+  ) as Record<string, unknown>;
+
+  expect(snapshot).toMatchObject({
+    agentStatus: null,
+    observerDigest: null,
+    traceLevel: "full",
+    session: {
+      agentStatus: null,
+      observerDigest: null,
+      traceLevel: "full",
+      worktree: { id: "wt-1", branch: "feature", repoRoot: "/private/repo" },
+      execNode: "private-node",
+      execCwd: "/private/cwd",
+    },
+  });
+  for (const field of ["worktree", "execNode", "execCwd", "placement"]) {
+    expect(snapshot, field).not.toHaveProperty(field);
+  }
+});
+
+it("scopes the global goal to its resolved agent", () => {
+  const sessionRow = {
+    key: "global",
+    kind: "global" as const,
+    updatedAt: 6,
+    goal: {
+      schemaVersion: 1 as const,
+      id: "goal-1",
+      objective: "Scoped objective",
+      status: "active" as const,
+      createdAt: 1,
+      updatedAt: 2,
+      tokenStart: 0,
+      tokensUsed: 3,
+      continuationTurns: 0,
+    },
+  };
+
+  const unscoped = buildGatewaySessionSnapshot({ sessionRow, includeSession: true });
+  expect(unscoped).not.toHaveProperty("goal");
+  expect(unscoped).not.toHaveProperty("session.goal");
+
+  const scoped = buildGatewaySessionSnapshot({ sessionRow, agentId: "main", includeSession: true });
+  expect(scoped).toMatchObject({ goal: sessionRow.goal, session: { goal: sessionRow.goal } });
+});
+
+it("preserves active run id ownership across omitted, liveness, and exact states", () => {
+  const build = (activeRunState?: { active: boolean; runIds?: string[] }) =>
+    // oxlint-disable-next-line unicorn/prefer-structured-clone -- verify the gateway JSON wire shape
+    JSON.parse(
+      JSON.stringify(
+        buildGatewaySessionSnapshot({
+          sessionRow: { key: "agent:main:main", kind: "global", updatedAt: 7 },
+          includeSession: true,
+          activeRunState,
+        }),
+      ),
+    ) as Record<string, unknown>;
+
+  const omitted = build();
+  expect(omitted).not.toHaveProperty("hasActiveRun");
+  expect(omitted).not.toHaveProperty("activeRunIds");
+  expect(omitted).not.toHaveProperty("session.hasActiveRun");
+  expect(omitted).not.toHaveProperty("session.activeRunIds");
+  expect(build({ active: true })).toMatchObject({
+    hasActiveRun: true,
+    activeRunIds: null,
+    session: { hasActiveRun: true, activeRunIds: null },
+  });
+  expect(build({ active: false, runIds: [] })).toMatchObject({
+    hasActiveRun: false,
+    activeRunIds: [],
+    session: { hasActiveRun: false, activeRunIds: [] },
+  });
+  expect(build({ active: true, runIds: ["run-1"] })).toMatchObject({
+    hasActiveRun: true,
+    activeRunIds: ["run-1"],
+    session: { hasActiveRun: true, activeRunIds: ["run-1"] },
+  });
 });

--- a/src/gateway/session-event-payload.ts
+++ b/src/gateway/session-event-payload.ts
@@ -1,4 +1,9 @@
 import { sessionEntryForkedFromParent } from "../config/sessions/session-entry-lineage.js";
+import type { AgentEventPayload } from "../infra/agent-events.js";
+import {
+  deriveGatewaySessionLifecycleProjectionPatch,
+  isStaleLifecycleEventForSession,
+} from "./session-lifecycle-state.js";
 import type { GatewaySessionRow } from "./session-utils.js";
 
 /**
@@ -6,35 +11,6 @@ import type { GatewaySessionRow } from "./session-utils.js";
  * Picker metadata comes from catalog-backed list/patch responses; emitting a
  * locally reconstructed subset here would replace richer client state.
  */
-export function buildGatewaySessionEventRow(
-  sessionRow: GatewaySessionRow,
-  options: { lifecycle?: boolean } = {},
-): GatewaySessionRow {
-  const session = { ...sessionRow };
-  delete session.thinkingLevels;
-  delete session.thinkingOptions;
-  delete session.thinkingDefault;
-  if (options.lifecycle) {
-    delete session.modelProvider;
-    delete session.model;
-    delete session.agentRuntime;
-    if (session.totalTokensFresh !== true) {
-      delete session.totalTokens;
-      delete session.totalTokensFresh;
-      delete session.contextTokens;
-      delete session.estimatedCostUsd;
-    }
-  }
-  return session;
-}
-
-/** Incremental events clear cached exact IDs when the current owner exposes only liveness. */
-export function projectSessionEventActiveRunIds(
-  state: { runIds?: string[] } | null | undefined,
-): string[] | null | undefined {
-  return state ? (state.runIds ?? null) : undefined;
-}
-
 export function buildGatewaySessionEventFields(params: {
   sessionRow: GatewaySessionRow;
   agentId?: string;
@@ -101,8 +77,12 @@ export function buildGatewaySessionEventFields(params: {
     // Explicit null lets subscribed clients clear an override during merge-reconcile.
     thinkingLevel: sessionRow.thinkingLevel ?? null,
     fastMode: sessionRow.fastMode,
+    effectiveFastMode: sessionRow.effectiveFastMode,
+    effectiveFastModeSource: sessionRow.effectiveFastModeSource,
+    fastAutoOnSeconds: sessionRow.fastAutoOnSeconds,
     toolOverrides: sessionRow.toolOverrides ?? null,
     verboseLevel: sessionRow.verboseLevel,
+    traceLevel: sessionRow.traceLevel,
     reasoningLevel: sessionRow.reasoningLevel,
     elevatedLevel: sessionRow.elevatedLevel,
     sendPolicy: sessionRow.sendPolicy,
@@ -139,5 +119,81 @@ export function buildGatewaySessionEventFields(params: {
     runtimeMs: sessionRow.runtimeMs,
     compactionCheckpointCount: sessionRow.compactionCheckpointCount,
     latestCompactionCheckpoint: sessionRow.latestCompactionCheckpoint,
+    pluginExtensions: sessionRow.pluginExtensions,
+  };
+}
+
+export function buildGatewaySessionSnapshot(params: {
+  sessionRow: GatewaySessionRow | null | undefined;
+  agentId?: string;
+  includeSession?: boolean;
+  lifecycle?: boolean;
+  event?: AgentEventPayload;
+  lifecycleRunId?: string;
+  label?: string;
+  displayName?: string;
+  parentSessionKey?: string;
+  activeRunState?: { active: boolean; runIds?: string[]; status?: "queued" } | null;
+  status?: GatewaySessionRow["status"];
+}): Record<string, unknown> {
+  const { event, sessionRow: storedRow } = params;
+  if (!storedRow) {
+    return {};
+  }
+  const lifecycleRow = { ...storedRow, updatedAt: storedRow.updatedAt ?? undefined };
+  const patch =
+    event &&
+    !isStaleLifecycleEventForSession({
+      owningSessionId: event.sessionId,
+      currentSessionId: storedRow.sessionId,
+      eventRunId: event.runId,
+      currentRunId: params.lifecycleRunId,
+      eventStartedAt: event.data?.startedAt,
+      currentStartedAt: storedRow.startedAt,
+    })
+      ? deriveGatewaySessionLifecycleProjectionPatch({ entry: lifecycleRow, event })
+      : {};
+  const sessionRow = { ...storedRow, ...patch };
+  for (const key of ["thinkingLevels", "thinkingOptions", "thinkingDefault"] as const) {
+    delete sessionRow[key];
+  }
+  if (params.lifecycle) {
+    delete sessionRow.modelProvider;
+    delete sessionRow.model;
+    delete sessionRow.agentRuntime;
+    if (sessionRow.totalTokensFresh !== true) {
+      delete sessionRow.totalTokens;
+      delete sessionRow.totalTokensFresh;
+      delete sessionRow.contextTokens;
+      delete sessionRow.estimatedCostUsd;
+    }
+  }
+  const eventFields = buildGatewaySessionEventFields({
+    sessionRow,
+    agentId: params.agentId,
+    label: params.label,
+    displayName: params.displayName,
+    parentSessionKey: params.parentSessionKey,
+    status: params.status,
+    hasActiveRun: params.activeRunState?.active,
+    // Presence means an exact set; null clears stale IDs when only liveness is known.
+    activeRunIds: params.activeRunState ? (params.activeRunState.runIds ?? null) : undefined,
+  });
+  const session: Record<string, unknown> | undefined = params.includeSession
+    ? {
+        ...sessionRow,
+        ...Object.fromEntries(
+          Object.entries(eventFields).filter(([, value]) => value !== undefined),
+        ),
+      }
+    : undefined;
+  if (session && sessionRow.key === "global" && !params.agentId) {
+    delete session.goal;
+  }
+  return {
+    ...(session ? { session } : {}),
+    ...eventFields,
+    subagentRunState: sessionRow.subagentRunState,
+    hasActiveSubagentRun: sessionRow.hasActiveSubagentRun,
   };
 }

--- a/ui/src/lib/sessions/reconcile.test.ts
+++ b/ui/src/lib/sessions/reconcile.test.ts
@@ -116,7 +116,7 @@ test("reconciling the same sessions.changed twice keeps result identity on the s
   expect(second.result).toBe(first.result);
 });
 
-test("sessions.changed deletes every null-tombstoned field, not a hand-kept list", () => {
+test("sessions.changed deletes every nested null tombstone, not a hand-kept list", () => {
   // The gateway tombstones more fields than the old per-field cascade knew
   // about; these five leaked literal null into rows typed optional-not-null.
   const result: SessionsListResult = {
@@ -130,6 +130,15 @@ test("sessions.changed deletes every null-tombstoned field, not a hand-kept list
         kind: "direct",
         updatedAt: 1,
         toolOverrides: { profile: "coding" },
+        agentStatus: { state: "needs_attention", message: "Reply requested" },
+        observerDigest: {
+          agentId: "main",
+          runId: "run-stale",
+          headline: "Waiting",
+          health: "needs_attention",
+          updatedAt: 1,
+          revision: 1,
+        },
         controlOwnerSessionKey: "agent:main:owner",
         restartRecoveryStatus: "pending",
         goal: "ship it",
@@ -140,18 +149,24 @@ test("sessions.changed deletes every null-tombstoned field, not a hand-kept list
   const reconciled = reconcileSessionChanged(result, {
     sessionKey: "agent:main:main",
     reason: "patch",
-    updatedAt: 2,
-    toolOverrides: null,
-    observerDigest: null,
-    controlOwnerSessionKey: null,
-    restartRecoveryStatus: null,
-    goal: null,
+    session: {
+      key: "agent:main:main",
+      kind: "direct",
+      updatedAt: 2,
+      toolOverrides: null,
+      agentStatus: null,
+      observerDigest: null,
+      controlOwnerSessionKey: null,
+      restartRecoveryStatus: null,
+      goal: null,
+    },
   } as never);
 
   expect(reconciled.applied).toBe(true);
   const row = reconciled.result?.sessions[0] as Record<string, unknown> | undefined;
   for (const field of [
     "toolOverrides",
+    "agentStatus",
     "observerDigest",
     "controlOwnerSessionKey",
     "restartRecoveryStatus",


### PR DESCRIPTION
## Summary

- Use one canonical Gateway projector for transcript, live-session, and agent-event updates.
- Keep session payloads on the flat privacy allowlist while carrying only scoped goals and active identifiers.
- Fence lifecycle-owned global goals from unrelated or unscoped agent events.

## Root cause

Several Gateway paths independently projected overlapping session state. Their payloads diverged in both lifecycle scope and privacy shape, so one path could leave the sidebar stale while another exposed transcript-derived or fallback-owned facts outside the exact agent lifecycle that owned them.

The current-main reconstruction records and projects the canonical facts once, preserves upstream session changes, and applies the same cross-agent privacy and lifecycle-scope rules to chat history, live session events, and agent events.

## User impact

- Active sessions and status update consistently after relevant Gateway activity.
- Transcript-derived fields stay within the existing privacy allowlist.
- Global fallback goals cannot leak into unrelated unscoped agent events.
- No protocol-version, public API, configuration, persistence, or fallback change is introduced.

## Verification

- Two transcript/lifecycle privacy regressions were RED before the correction and GREEN afterward in the focused 35-test owner proof.
- Broad Gateway owner and sibling coverage: 246/246 passed.
- Swift client compatibility and assertion-safety, typed lint, formatting, and privacy/goal/active-ID guards passed.
- Independent verification and mandatory local and committed-branch reviews completed without findings.

## Surface

- Exact Gateway projector, owner tests, and protocol/client fixtures required by the canonical projection.
- Production: net -130 lines.
- Tests preserve flat privacy, nested tombstones, scoped goals, lifecycle freshness, and active-run tri-state behavior.
