### PR TITLE
fix(status): display native Claude CLI authentication ownership

### DIFF
--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -1895,23 +1895,9 @@ describe("buildStatusReply subagent summary", () => {
     );
   });
 
-  it("uses Claude CLI OAuth auth labels for anthropic models running on the Claude CLI runtime", async () => {
+  it("uses native Claude CLI auth labels for anthropic models running on the Claude CLI runtime", async () => {
     await withTempHome(
-      async (dir) => {
-        const authPath = path.join(dir, ".claude", ".credentials.json");
-        fs.mkdirSync(path.dirname(authPath), { recursive: true });
-        fs.writeFileSync(
-          authPath,
-          JSON.stringify({
-            claudeAiOauth: {
-              accessToken: "access-token",
-              refreshToken: "refresh-token",
-              expiresAt: Date.now() + 60_000,
-            },
-          }),
-          "utf8",
-        );
-
+      async () => {
         const text = await buildStatusText({
           cfg: {
             ...baseCfg,
@@ -1922,7 +1908,7 @@ describe("buildStatusReply subagent summary", () => {
             },
           },
           sessionEntry: {
-            sessionId: "sess-status-claude-cli-oauth",
+            sessionId: "sess-status-claude-cli-native",
             updatedAt: 0,
           },
           sessionKey: "agent:main:main",
@@ -1943,7 +1929,8 @@ describe("buildStatusReply subagent summary", () => {
 
         const normalized = normalizeTestText(text);
         expect(normalized).toContain("Model: anthropic/claude-opus-4-7");
-        expect(normalized).toContain("oauth (claude-cli)");
+        expect(normalized).toContain("native (claude-cli)");
+        expect(providerUsageMock.loadProviderUsageSummary).not.toHaveBeenCalled();
       },
       {
         env: {

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -41,6 +41,30 @@ describe("buildStatusMessage current time", () => {
   });
 });
 
+describe("buildStatusMessage authentication", () => {
+  it.each([
+    { label: "api-key (profile)", visible: true },
+    { label: "oauth (profile)", visible: true },
+    { label: "token (profile)", visible: true },
+    { label: "aws-sdk (profile)", visible: true },
+    { label: "mixed (profile)", visible: true },
+    { label: "native (claude-cli)", visible: true },
+    { label: "unknown", visible: false },
+    { label: "unsupported (profile)", visible: false },
+  ])("renders only recognized authentication labels: $label", ({ label, visible }) => {
+    const text = buildStatusMessage({
+      config: {},
+      agent: { model: "anthropic/claude-opus-4-7" },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "steer", depth: 0 },
+      modelAuth: label,
+    });
+
+    expect(text.includes(`Auth: ${label}`)).toBe(visible);
+  });
+});
+
 describe("buildStatusMessageParts presentation", () => {
   it("mirrors the text body as a titled status table with context lines", () => {
     const parts = buildStatusMessageParts({

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -124,32 +124,17 @@ type StatusArgs = {
   now?: number;
 };
 
-type NormalizedAuthMode = "api-key" | "oauth" | "token" | "aws-sdk" | "mixed" | "unknown";
-
-function normalizeAuthMode(value?: string): NormalizedAuthMode | undefined {
+function normalizeAuthMode(value?: string) {
   const normalized = normalizeOptionalLowercaseString(value);
   if (!normalized) {
     return undefined;
   }
-  if (normalized === "api-key" || normalized.startsWith("api-key ")) {
-    return "api-key";
+  for (const mode of ["api-key", "oauth", "token", "aws-sdk", "mixed", "native"] as const) {
+    if (normalized === mode || normalized.startsWith(`${mode} `)) {
+      return mode;
+    }
   }
-  if (normalized === "oauth" || normalized.startsWith("oauth ")) {
-    return "oauth";
-  }
-  if (normalized === "token" || normalized.startsWith("token ")) {
-    return "token";
-  }
-  if (normalized === "aws-sdk" || normalized.startsWith("aws-sdk ")) {
-    return "aws-sdk";
-  }
-  if (normalized === "mixed" || normalized.startsWith("mixed ")) {
-    return "mixed";
-  }
-  if (normalized === "unknown") {
-    return "unknown";
-  }
-  return undefined;
+  return normalized === "unknown" ? "unknown" : undefined;
 }
 
 function resolveConfiguredTextVerbosity(params: {


### PR DESCRIPTION
## Summary

- Restore the existing `native (claude-cli)` authentication display in `/status`.
- Remove obsolete test assumptions that Claude CLI authentication is OpenClaw-owned OAuth.
- Unblock unrelated hosted Node test shards broken by the earlier native-auth ownership change.

## Root cause

The Claude CLI provider was correctly changed to report its existing `native (claude-cli)` ownership contract, but the status presentation owner still recognized only older authentication labels. It therefore dropped the Auth line entirely, while an integration regression still expected `oauth (claude-cli)` and created an obsolete Claude credential file. The deterministic failure propagated into unrelated PR CI shards.

## Validation

- Reproduced the exact failing hosted `commands-status.test.ts` assertion and independently reproduced the status renderer dropping the new native label.
- `env -u OPENAI_API_KEY node scripts/run-vitest.mjs src/status/status-message.test.ts src/auto-reply/reply/commands-status.test.ts` — 68 tests passed.
- Regression matrix preserves API-key, OAuth, token, AWS SDK, and mixed labels; native is displayed; unknown/unsupported labels remain hidden.
- Claude CLI credentials are never read or synthesized, and native status never triggers provider-usage credential inspection.
- Focused type-aware lint, formatting, `git diff --check`, changed-lane classification, and fresh independent Codex autoreview passed.
- Presentation-only production change removes 15 lines; no authentication, authorization, credential storage, provider routing, configuration, or persistence behavior changes.
