### PR TITLE
fix: report unattended completion install outcomes

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -203,7 +203,7 @@ export function registerCompletionCli(program: Command) {
       // introduce unrelated plugin failures before the cache can be checked or installed.
       if (options.install && !options.writeState) {
         const targetShell = options.shell ?? resolveShellFromEnv();
-        await installCompletion(targetShell, Boolean(options.yes), program.name());
+        await installCompletion(targetShell, false, program.name());
         return;
       }
 
@@ -239,7 +239,7 @@ export function registerCompletionCli(program: Command) {
 
       if (options.install) {
         const targetShell = options.shell ?? resolveShellFromEnv();
-        await installCompletion(targetShell, Boolean(options.yes), program.name());
+        await installCompletion(targetShell, false, program.name());
         return;
       }
 

--- a/src/cli/completion-cli.write-state.test.ts
+++ b/src/cli/completion-cli.write-state.test.ts
@@ -7,7 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   COMPLETION_SHELLS,
+  formatCompletionReloadCommand,
   resolveCompletionCachePath,
+  resolveCompletionProfileHint,
   resolveCompletionProfilePath,
   type CompletionShell,
 } from "./completion-runtime.js";
@@ -144,6 +146,7 @@ describe("completion-cli write-state", () => {
 
   afterEach(async () => {
     restoreStderrWriteSpy?.();
+    vi.restoreAllMocks();
   });
 
   it.each(COMPLETION_SHELLS)(
@@ -291,25 +294,35 @@ describe("completion-cli write-state", () => {
   );
 
   it.each(COMPLETION_SHELLS)(
-    "installs cached %s completion without registering commands or plugins",
+    "installs cached %s completion visibly and idempotently without registering commands or plugins",
     async (shell) => {
       const { registerCompletionCli } = await import("./completion-cli.js");
 
       await withIsolatedCompletionState(async () => {
         const cachePath = resolveCompletionCachePath(shell, "openclaw");
+        const profilePath = resolveCompletionProfilePath(shell);
+        const log = vi.spyOn(console, "log").mockImplementation(() => {});
+        vi.spyOn(console, "warn").mockImplementation(() => {});
         await fs.mkdir(path.dirname(cachePath), { recursive: true });
         await fs.writeFile(cachePath, "# cached completion\n", "utf8");
 
         const program = new Command().name("openclaw");
         registerCompletionCli(program);
-        await program.parseAsync(["completion", "--shell", shell, "--install", "--yes"], {
-          from: "user",
-        });
+        const args = ["completion", "--shell", shell, "--install", "--yes"];
+        await program.parseAsync(args, { from: "user" });
 
-        await expect(fs.readFile(resolveCompletionProfilePath(shell), "utf8")).resolves.toContain(
-          cachePath,
+        const installedProfile = await fs.readFile(profilePath, "utf8");
+        expect(installedProfile).toContain(cachePath);
+        expect(log).toHaveBeenCalledWith(
+          `Completion installed. Restart your shell or run: ${formatCompletionReloadCommand(shell, resolveCompletionProfileHint(shell))}`,
         );
         await expect(fs.readFile(cachePath, "utf8")).resolves.toBe("# cached completion\n");
+
+        log.mockClear();
+        await program.parseAsync(args, { from: "user" });
+
+        expect(log).toHaveBeenCalledWith(`Completion already installed in ${profilePath}`);
+        await expect(fs.readFile(profilePath, "utf8")).resolves.toBe(installedProfile);
         expectCompletionInstallationToSkipRegistration();
       });
     },
@@ -366,6 +379,8 @@ describe("completion-cli write-state", () => {
     const { registerCompletionCli } = await import("./completion-cli.js");
 
     await withIsolatedCompletionState(async () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
+      vi.spyOn(console, "warn").mockImplementation(() => {});
       const program = new Command().name("openclaw");
       registerCompletionCli(program);
       await program.parseAsync(
@@ -377,6 +392,9 @@ describe("completion-cli write-state", () => {
       await expect(fs.readFile(cachePath, "utf8")).resolves.toContain("#compdef openclaw");
       await expect(fs.readFile(resolveCompletionProfilePath("zsh"), "utf8")).resolves.toContain(
         cachePath,
+      );
+      expect(log).toHaveBeenCalledWith(
+        "Completion installed. Restart your shell or run: source ~/.zshrc",
       );
       expect(registerSubCliByNameMock.mock.calls).toEqual([
         [program, "qa", process.argv, { purpose: "completion" }],


### PR DESCRIPTION
Closes #129319

## What Problem This Solves

Users running `openclaw completion --install --yes` received no installed/already-installed result or shell reload guidance even though the command successfully modified or recognized their shell profile.

## Why This Change Was Made

The direct completion command forwarded its public `--yes` flag into the shared installer's internal quiet mode. Quiet mode is correct for Doctor and onboarding, which render their own outcomes, but the direct command has no confirmation prompt and no alternate status owner. Both direct install call sites now request the installer's existing visible outcome while keeping `--yes` accepted and noninteractive. No new reporting path or installer behavior is added.

## User Impact

Unattended completion installs say whether completion was installed or already present. Fresh installs include the canonical shell-specific reload command for zsh, bash, fish, and PowerShell. Stdout remains clean; existing CLI log routing keeps these human messages on stderr. Profile paths, bytes, cache publication, permissions, and quiet Doctor/onboarding/update callers remain unchanged.

## Evidence

Current candidate: `7f382fc54d04d8f2deb4d2b19aa5f9c520763c3b`.

- Five regression cases failed before the repair because no installation outcome was emitted.
- Current-head focused proof: 239 tests passed across completion/runtime, Doctor, onboarding, Gateway native-model availability, status, and SDK surface reporting. Exact commands and resolved previous CI blockers are in the [maintainer proof comment](https://github.com/openclaw/openclaw/pull/129320#issuecomment-5410696230).
- Current-head `pnpm build`, `pnpm check:changed`, and `git diff --check origin/main...HEAD` passed, including formatting, lint, type checks, architecture guards, and import-cycle checks.
- Current-head real built-CLI process proof used isolated temporary HOME/config/state and a minimal credential-free environment. All four shell targets passed fresh/repeat installation: exit 0, zero stdout bytes, installed/reload or already-installed guidance on stderr, and unchanged profile bytes on repeat. Combined zsh `--write-state --install --yes` also passed. This checks installer behavior on macOS, not execution of every native shell runtime.
- Current-head independent P1 autoreview found no actionable findings (correct, confidence 0.96).
- Historical broader proof: 229 focused tests, 108 changed tests, and piped/dual-TTY built-process runs passed before the mechanical rebase. These are not represented as current-head reruns.
- Production +2/-2 (net zero); tests +24/-6. Regression coverage extends the existing shell table and combined-install fixture, without a new production test seam.

The prior exact-head run was blocked by independent native-auth and SDK failures. Owner repairs [#129346](https://github.com/openclaw/openclaw/pull/129346), [#129375](https://github.com/openclaw/openclaw/pull/129375), and [#129383](https://github.com/openclaw/openclaw/pull/129383) are included in the refreshed base, and their focused regressions pass. Fresh exact-head hosted CI remains the landing gate and addresses the latest ClawSweeper rank-up move.

ClawSweeper's previous live attempt timed out during an uncached build and is not counted as passing proof. Its filename-based stored-data warning does not describe this diff: output ownership alone changes, with no state schema, migration, or profile-format change. The existing documentation already defines `--yes` as noninteractive rather than silent: https://docs.openclaw.ai/cli/completion.
