### PR TITLE
test(ci): stabilize exact-head validation owners

### DIFF
--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -1405,6 +1405,7 @@ describe("anthropic provider replay hooks", () => {
   });
 
   it("resolves claude-cli with a non-secret native auth marker", async () => {
+    probeClaudeCliAuthStatusMock.mockReturnValue({ status: "available" });
     const provider = await registerSingleProviderPlugin(anthropicPlugin);
 
     const runtimeAuth = provider.resolveSyntheticAuth?.({
@@ -1412,12 +1413,24 @@ describe("anthropic provider replay hooks", () => {
     } as never);
     const discoveryAuth = anthropicProviderDiscovery.resolveSyntheticAuth?.({
       provider: "claude-cli",
+      purpose: "discovery",
     } as never);
     for (const auth of [runtimeAuth, discoveryAuth]) {
       expect(auth?.apiKey).toBe(CLAUDE_CLI_NATIVE_AUTH_MARKER);
       expect(auth?.source).toBe("Claude CLI native auth");
       expect(auth?.mode).toBe("oauth");
     }
+  });
+
+  it("does not publish native readiness when Claude CLI is logged out", async () => {
+    probeClaudeCliAuthStatusMock.mockReturnValue({ status: "missing" });
+
+    expect(
+      anthropicProviderDiscovery.resolveSyntheticAuth?.({
+        provider: "claude-cli",
+        purpose: "discovery",
+      } as never),
+    ).toBeUndefined();
   });
 
   it("does not copy native Claude auth during anthropic cli migration", async () => {

--- a/extensions/anthropic/provider-discovery.ts
+++ b/extensions/anthropic/provider-discovery.ts
@@ -3,11 +3,15 @@
  * synthetic auth for catalog/runtime discovery without full Anthropic registration.
  */
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import { probeClaudeCliAuthStatus } from "./cli-auth-seam.js";
 import { CLAUDE_CLI_NATIVE_AUTH_MARKER } from "./cli-constants.js";
 
 const CLAUDE_CLI_BACKEND_ID = "claude-cli";
 
-export function resolveClaudeCliSyntheticAuth() {
+export function resolveClaudeCliSyntheticAuth(params?: { verifyNativeLogin?: boolean }) {
+  if (params?.verifyNativeLogin && probeClaudeCliAuthStatus().status !== "available") {
+    return undefined;
+  }
   return {
     apiKey: CLAUDE_CLI_NATIVE_AUTH_MARKER,
     source: "Claude CLI native auth",
@@ -20,8 +24,10 @@ const anthropicProviderDiscovery: ProviderPlugin = {
   label: "Claude CLI",
   docsPath: "/providers/models",
   auth: [],
-  resolveSyntheticAuth: ({ provider }) =>
-    provider === CLAUDE_CLI_BACKEND_ID ? resolveClaudeCliSyntheticAuth() : undefined,
+  resolveSyntheticAuth: ({ provider, purpose }) =>
+    provider === CLAUDE_CLI_BACKEND_ID
+      ? resolveClaudeCliSyntheticAuth({ verifyNativeLogin: purpose === "discovery" })
+      : undefined,
 };
 
 export default anthropicProviderDiscovery;

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -1177,9 +1177,9 @@ export function buildAnthropicProvider(): ProviderPlugin {
       );
     },
     normalizeResolvedModel: (ctx) => normalizeAnthropicResolvedModel(ctx),
-    resolveSyntheticAuth: ({ provider }) =>
+    resolveSyntheticAuth: ({ provider, purpose }) =>
       normalizeLowercaseStringOrEmpty(provider) === CLAUDE_CLI_BACKEND_ID
-        ? resolveClaudeCliSyntheticAuth()
+        ? resolveClaudeCliSyntheticAuth({ verifyNativeLogin: purpose === "discovery" })
         : undefined,
     // Publish Claude CLI rows through the provider catalog hook.
     augmentModelCatalog: () => buildClaudeCliCatalogEntries(),

--- a/src/agents/agent-auth-discovery.external-cli.test.ts
+++ b/src/agents/agent-auth-discovery.external-cli.test.ts
@@ -133,6 +133,7 @@ describe("resolveAgentDiscoveryAuthFacts external CLI scoping", () => {
         config: undefined,
         provider: "fireworks",
         providerConfig: undefined,
+        purpose: "discovery",
       },
     });
   });

--- a/src/agents/agent-auth-discovery.ts
+++ b/src/agents/agent-auth-discovery.ts
@@ -53,6 +53,7 @@ export function resolveAmbientAgentCredentialsForDiscovery(
           config: options.config,
           provider,
           providerConfig: options.config?.models?.providers?.[provider],
+          purpose: "discovery",
         },
       }));
   for (const provider of syntheticAuthProviderRefs) {

--- a/src/agents/agent-model-discovery.synthetic-auth.test.ts
+++ b/src/agents/agent-model-discovery.synthetic-auth.test.ts
@@ -81,6 +81,7 @@ describe("agent model discovery synthetic auth", () => {
           config: undefined,
           provider: "claude-cli",
           providerConfig: undefined,
+          purpose: "discovery",
         },
       });
       expect(credentials["claude-cli"]).toEqual({

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -257,7 +257,7 @@ async function tryResolveOAuthProfile(
   params: ResolveApiKeyForProfileParams,
 ): Promise<ResolveApiKeyForProfileResult | null> {
   const { cfg, store, profileId } = params;
-  if (isRetiredOAuthProfileId(profileId)) {
+  if (isRetiredAuthProfileId(profileId)) {
     return null;
   }
   const cred = store.profiles[profileId];
@@ -296,7 +296,7 @@ async function tryResolveOAuthProfile(
   });
 }
 
-function isRetiredOAuthProfileId(profileId: string): boolean {
+export function isRetiredAuthProfileId(profileId: string): boolean {
   return profileId === CLAUDE_CLI_PROFILE_ID;
 }
 
@@ -391,7 +391,7 @@ export async function resolveApiKeyForProfile(
   }
   // Claude owns this native login slot. Legacy persisted copies must never
   // resolve, refresh, or leave OpenClaw as bearer tokens.
-  if (isRetiredOAuthProfileId(profileId)) {
+  if (isRetiredAuthProfileId(profileId)) {
     return null;
   }
   const configForRefResolution = cfg ?? getRuntimeConfig();

--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -140,9 +140,16 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
   prepareProviderRuntimeAuth: vi.fn(async () => undefined),
 }));
 
-vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
-  getCurrentPluginMetadataSnapshot: () => ({ plugins: [] }),
-}));
+vi.mock("../../plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../plugins/current-plugin-metadata-snapshot.js")>();
+  return {
+    getCurrentPluginMetadataSnapshot: (
+      ...args: Parameters<typeof actual.getCurrentPluginMetadataSnapshot>
+    ) => actual.getCurrentPluginMetadataSnapshot(...args) ?? { plugins: [] },
+    withPluginMetadataSnapshotScope: actual.withPluginMetadataSnapshotScope,
+  };
+});
 
 vi.mock("../provider-secret-egress.js", () => ({
   protectPreparedProviderRuntimeAuth: (value: unknown) => value,

--- a/src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts
+++ b/src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { listAgentIds } from "../agent-scope-config.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
@@ -10,6 +10,7 @@ import {
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
   resetSharedRunIntegrationHarnessMocks,
+  warmRunOverflowCompactionHarness,
 } from "./run.overflow-compaction.harness.js";
 
 const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
@@ -28,6 +29,10 @@ function projectSetupExecutionConfig(source: OpenClawConfig): OpenClawConfig {
 }
 
 describe("embedded setup inference inherited auth owner", () => {
+  beforeAll(async () => {
+    await warmRunOverflowCompactionHarness(runEmbeddedAgent);
+  });
+
   beforeEach(resetSharedRunIntegrationHarnessMocks);
 
   it.each([

--- a/src/agents/embedded-agent-runner/run.session-permissions.test.ts
+++ b/src/agents/embedded-agent-runner/run.session-permissions.test.ts
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
   useOpenAIPlatformAuthFixture,
+  warmRunOverflowCompactionHarness,
 } from "./run.overflow-compaction.harness.js";
 
 const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
@@ -20,6 +21,10 @@ const pluginHarnessRunParams = {
 } as const;
 
 describe("embedded run session permissions", () => {
+  beforeAll(async () => {
+    await warmRunOverflowCompactionHarness(runEmbeddedAgent);
+  });
+
   beforeEach(() => {
     mockedRunEmbeddedAttempt.mockReset();
     useOpenAIPlatformAuthFixture();

--- a/src/agents/model-auth-availability.test.ts
+++ b/src/agents/model-auth-availability.test.ts
@@ -146,6 +146,42 @@ describe("createModelAuthAvailabilityResolver", () => {
     });
   });
 
+  it("keeps native runtime readiness scoped to the exact runtime owner", () => {
+    const metadataSnapshot = {
+      index: { plugins: [] },
+      plugins: [
+        {
+          id: "anthropic",
+          providerAuthAliases: { "claude-cli": "anthropic" },
+        },
+      ],
+    } as unknown as PluginMetadataSnapshot;
+    const resolver = createModelAuthAvailabilityResolver({
+      cfg: {},
+      authStore: authStore(),
+      env: {},
+      metadataSnapshot,
+      preparedRuntimeAuthModes: { "claude-cli": "api_key" },
+      syntheticAuthProviderRefs: ["claude-cli"],
+    });
+
+    expect(resolver.evaluateModelAuth("claude-cli")).toMatchObject({
+      availability: true,
+      evidence: "runtime",
+    });
+    expect(resolver.evaluateModelAuth("anthropic").availability).not.toBe(true);
+
+    const apiOnlyResolver = createModelAuthAvailabilityResolver({
+      cfg: {},
+      authStore: authStore(),
+      env: {},
+      metadataSnapshot,
+      preparedRuntimeAuthModes: { anthropic: "api_key" },
+      syntheticAuthProviderRefs: ["claude-cli"],
+    });
+    expect(apiOnlyResolver.evaluateModelAuth("claude-cli").availability).not.toBe(true);
+  });
+
   it.each([
     { mode: "api_key" as const, selectedRoute: platformRoute },
     { mode: "oauth" as const, selectedRoute: subscriptionRoute },

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -622,7 +622,14 @@ export function createModelAuthAvailabilityResolver(
         evidence: "aws-sdk",
       };
     }
-    const preparedRuntimeAuthMode = params.preparedRuntimeAuthModes?.[normalizeProvider(provider)];
+    // Synthetic runtime owners are exact: API-provider auth must not authorize a native CLI route.
+    const exactProvider = normalizeProviderId(provider);
+    const exactPreparedRuntimeAuthMode = params.preparedRuntimeAuthModes?.[exactProvider];
+    const preparedRuntimeAuthMode =
+      exactPreparedRuntimeAuthMode ??
+      (synthetic.has(exactProvider)
+        ? undefined
+        : params.preparedRuntimeAuthModes?.[normalizeProvider(provider)]);
     if (preparedRuntimeAuthMode) {
       return {
         availability: modeAllowed(provider, target, preparedRuntimeAuthMode),

--- a/src/agents/model-auth-provider.ts
+++ b/src/agents/model-auth-provider.ts
@@ -25,6 +25,7 @@ import {
 } from "./auth-profiles.js";
 import { assertAuthProfileMigrationReady } from "./auth-profiles/legacy-source-diagnostic.js";
 import { OAuthRefreshFailureError } from "./auth-profiles/oauth-refresh-failure.js";
+import { isRetiredAuthProfileId } from "./auth-profiles/oauth.js";
 import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { assertAuthModeAllowedForModel, isAuthModeAllowedForModel } from "./model-auth-openai.js";
 import * as authConfig from "./model-auth-provider-config.js";
@@ -39,24 +40,15 @@ export type ProviderCredentialPrecedence = "profile-first" | "env-first";
 
 const log = createSubsystemLogger("model-auth");
 
-function isAuthProfileRetired(params: {
-  profileId: string;
-  deprecatedProfileIds: ReadonlySet<string>;
-  provider: string;
-  store: AuthProfileStore;
-}): boolean {
-  if (!params.deprecatedProfileIds.has(params.profileId)) {
-    return false;
-  }
-  return true;
-}
-
-function assertAuthProfileNotRetired(params: Parameters<typeof isAuthProfileRetired>[0]): void {
-  if (!isAuthProfileRetired(params)) {
+function assertAuthProfileNotRetired(
+  profileId: string,
+  providerDeprecatedProfileIds: ReadonlySet<string>,
+): void {
+  if (!isRetiredAuthProfileId(profileId) && !providerDeprecatedProfileIds.has(profileId)) {
     return;
   }
   throw new Error(
-    `Auth profile "${params.profileId}" is retired. Run ${formatCliCommand("openclaw doctor --fix")}.`,
+    `Auth profile "${profileId}" is retired. Run ${formatCliCommand("openclaw doctor --fix")}.`,
   );
 }
 
@@ -118,11 +110,14 @@ export async function resolveApiKeyForProviderCore(params: {
   secretSentinels?: boolean;
 }): Promise<ResolvedProviderAuth> {
   const { provider, cfg, profileId, preferredProfile } = params;
-  let deprecatedProfileIds: ReadonlySet<string> | undefined;
-  const getDeprecatedProfileIds = () =>
-    (deprecatedProfileIds ??= new Set(
+  let providerDeprecatedProfileIds: ReadonlySet<string> | undefined;
+  const getProviderDeprecatedProfileIds = () =>
+    (providerDeprecatedProfileIds ??= new Set(
       resolveProviderDeprecatedAuthProfileIds({ provider, config: cfg }),
     ));
+  const isRetiredProfile = (candidateProfileId: string) =>
+    isRetiredAuthProfileId(candidateProfileId) ||
+    getProviderDeprecatedProfileIds().has(candidateProfileId);
   const agentDir = params.agentDir?.trim() || (cfg ? resolveDefaultAgentDir(cfg) : undefined);
   // Pending credential files own this agent's auth route until Doctor commits
   // and archives them; do not fall through to env/config credentials.
@@ -150,12 +145,7 @@ export async function resolveApiKeyForProviderCore(params: {
       return awsSdkProfileAuth;
     }
     const store = getScopedStore(profileId);
-    assertAuthProfileNotRetired({
-      profileId,
-      deprecatedProfileIds: getDeprecatedProfileIds(),
-      provider,
-      store,
-    });
+    assertAuthProfileNotRetired(profileId, getProviderDeprecatedProfileIds());
     const configuredProfileType = store.profiles[profileId]?.type;
     if (configuredProfileType) {
       assertAuthModeAllowedForModel({
@@ -308,12 +298,10 @@ export async function resolveApiKeyForProviderCore(params: {
     store: providerEntryStore,
   });
   if ("profileId" in providerEntryReference) {
-    assertAuthProfileNotRetired({
-      profileId: providerEntryReference.profileId,
-      deprecatedProfileIds: getDeprecatedProfileIds(),
-      provider,
-      store: providerEntryStore,
-    });
+    assertAuthProfileNotRetired(
+      providerEntryReference.profileId,
+      getProviderDeprecatedProfileIds(),
+    );
   }
   const providerEntryBinding = await authConfig.resolveProviderEntryApiKeyBinding({
     cfg,
@@ -417,15 +405,7 @@ export async function resolveApiKeyForProviderCore(params: {
           provider,
           preferredProfile,
           forModel: params.modelId,
-        }).filter(
-          (candidateProfileId) =>
-            !isAuthProfileRetired({
-              profileId: candidateProfileId,
-              deprecatedProfileIds: getDeprecatedProfileIds(),
-              provider,
-              store,
-            }),
-        );
+        }).filter((candidateProfileId) => !isRetiredProfile(candidateProfileId));
   let deferredAuthProfileResult: ResolvedProviderAuth | null = null;
   let refreshFailure: OAuthRefreshFailureError | undefined;
   for (const candidate of order) {

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -393,6 +393,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
       config,
       provider: "openai",
       providerConfig: undefined,
+      purpose: "discovery",
     });
     expect(mocks.discoverModels).toHaveBeenLastCalledWith(
       mocks.authStorage,

--- a/src/agents/prepared-model-runtime.synthetic-auth.ts
+++ b/src/agents/prepared-model-runtime.synthetic-auth.ts
@@ -48,6 +48,7 @@ export function resolvePreparedSyntheticAuth(params: {
       providerConfig: Object.entries(params.config.models?.providers ?? {}).find(
         ([providerId]) => normalizeProviderId(providerId) === normalizedProvider,
       )?.[1],
+      purpose: "discovery",
     }) ?? undefined
   );
 }

--- a/src/agents/tool-fs-policy.test.ts
+++ b/src/agents/tool-fs-policy.test.ts
@@ -2,10 +2,25 @@
 // profiles decide workspace-only access and root expansion.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveSessionPermissionCoreToolPolicy } from "./session-permission-exec-mode.js";
 import {
   resolveEffectiveToolFsRootExpansionAllowed,
   resolveEffectiveToolFsWorkspaceOnly,
 } from "./tool-fs-policy.js";
+
+describe("resolveSessionPermissionCoreToolPolicy", () => {
+  it.each([
+    { mode: "read-only" as const, execMode: "deny", workspaceOnly: true },
+    { mode: "guarded" as const, execMode: "ask", workspaceOnly: true },
+    { mode: "workspace" as const, execMode: "auto", workspaceOnly: true },
+    { mode: "full" as const, execMode: "full", workspaceOnly: false },
+  ])("maps $mode to $execMode execution", ({ mode, execMode, workspaceOnly }) => {
+    expect(resolveSessionPermissionCoreToolPolicy({ mode })).toMatchObject({
+      execMode,
+      workspaceOnly,
+    });
+  });
+});
 
 describe("resolveEffectiveToolFsWorkspaceOnly", () => {
   it("returns false by default when tools.fs.workspaceOnly is unset", () => {

--- a/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
@@ -510,36 +510,6 @@ describe("dispatchReplyFromConfig", () => {
     });
   });
 
-  it("seeds direct fast-abort prefixes from the session-selected model", async () => {
-    mocks.tryFastAbortFromMessage.mockResolvedValue({ handled: true, aborted: true });
-    sessionStoreMocks.currentEntry = {
-      providerOverride: "anthropic",
-      modelOverride: "claude-opus-4-6-20260205",
-      thinkingLevel: "high",
-    };
-    const onModelSelected = vi.fn();
-
-    await dispatchReplyFromConfig({
-      ctx: buildTestCtx({
-        Provider: "telegram",
-        Surface: "telegram",
-        Body: "/stop",
-        SessionKey: "agent:main:telegram:direct:123",
-      }),
-      cfg: emptyConfig,
-      dispatcher: createDispatcher(),
-      fastAbortResolver: mocks.tryFastAbortFromMessage,
-      formatAbortReplyTextResolver: () => "⚙️ Agent was aborted.",
-      replyOptions: { onModelSelected },
-    });
-
-    expect(onModelSelected).toHaveBeenCalledWith({
-      provider: "anthropic",
-      model: "claude-opus-4-6-20260205",
-      thinkLevel: "high",
-    });
-  });
-
   it("carries session prefix context through the actual routed fast-abort delivery", async () => {
     mocks.tryFastAbortFromMessage.mockResolvedValue({ handled: true, aborted: true });
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.fast-abort-model.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.fast-abort-model.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createDispatcher,
   emptyConfig,
@@ -12,7 +12,7 @@ import {
 } from "./dispatch-from-config.test-harness.js";
 import { buildTestCtx } from "./test-ctx.js";
 
-beforeAll(globalBeforeAll0);
+await globalBeforeAll0();
 
 describe("dispatchReplyFromConfig fast-abort model selection", () => {
   beforeEach(describe0BeforeEach0);

--- a/src/auto-reply/reply/dispatch-from-config.fast-abort-model.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.fast-abort-model.test.ts
@@ -1,0 +1,49 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createDispatcher,
+  emptyConfig,
+  mocks,
+  sessionStoreMocks,
+} from "./dispatch-from-config.shared.test-harness.js";
+import {
+  describe0BeforeEach0,
+  dispatchReplyFromConfig,
+  globalBeforeAll0,
+} from "./dispatch-from-config.test-harness.js";
+import { buildTestCtx } from "./test-ctx.js";
+
+beforeAll(globalBeforeAll0);
+
+describe("dispatchReplyFromConfig fast-abort model selection", () => {
+  beforeEach(describe0BeforeEach0);
+
+  it("seeds direct fast-abort prefixes from the session-selected model", async () => {
+    mocks.tryFastAbortFromMessage.mockResolvedValue({ handled: true, aborted: true });
+    sessionStoreMocks.currentEntry = {
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-6-20260205",
+      thinkingLevel: "high",
+    };
+    const onModelSelected = vi.fn();
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "telegram",
+        Surface: "telegram",
+        Body: "/stop",
+        SessionKey: "agent:main:telegram:direct:123",
+      }),
+      cfg: emptyConfig,
+      dispatcher: createDispatcher(),
+      fastAbortResolver: mocks.tryFastAbortFromMessage,
+      formatAbortReplyTextResolver: () => "⚙️ Agent was aborted.",
+      replyOptions: { onModelSelected },
+    });
+
+    expect(onModelSelected).toHaveBeenCalledWith({
+      provider: "anthropic",
+      model: "claude-opus-4-6-20260205",
+      thinkLevel: "high",
+    });
+  });
+});

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -21,7 +21,6 @@ import {
   resolveApiKeyForProfile,
   resolveProfileUnusableUntilForDisplay,
 } from "../agents/auth-profiles.js";
-import { CLAUDE_CLI_PROFILE_ID } from "../agents/auth-profiles/constants.js";
 import { formatAuthDoctorHint } from "../agents/auth-profiles/doctor.js";
 import {
   buildAuthProfileUnusableHint,
@@ -344,14 +343,7 @@ function isAuthProfileHealthIssue(profile: AuthHealthSummary["profiles"][number]
   if (profile.type === "api_key") {
     return profile.status === "missing";
   }
-  // Native Claude owns refresh while Doctor waits to commit its queued retired-profile cleanup.
-  const isNativeClaudeRefresh =
-    profile.profileId === CLAUDE_CLI_PROFILE_ID &&
-    profile.provider === "claude-cli" &&
-    profile.type === "oauth" &&
-    profile.status === "expiring";
   return (
-    !isNativeClaudeRefresh &&
     (profile.type === "oauth" || profile.type === "token") &&
     (profile.status === "expired" || profile.status === "expiring" || profile.status === "missing")
   );

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -21,6 +21,7 @@ import {
   resolveApiKeyForProfile,
   resolveProfileUnusableUntilForDisplay,
 } from "../agents/auth-profiles.js";
+import { CLAUDE_CLI_PROFILE_ID } from "../agents/auth-profiles/constants.js";
 import { formatAuthDoctorHint } from "../agents/auth-profiles/doctor.js";
 import {
   buildAuthProfileUnusableHint,
@@ -343,7 +344,14 @@ function isAuthProfileHealthIssue(profile: AuthHealthSummary["profiles"][number]
   if (profile.type === "api_key") {
     return profile.status === "missing";
   }
+  // Native Claude owns refresh while Doctor waits to commit its queued retired-profile cleanup.
+  const isNativeClaudeRefresh =
+    profile.profileId === CLAUDE_CLI_PROFILE_ID &&
+    profile.provider === "claude-cli" &&
+    profile.type === "oauth" &&
+    profile.status === "expiring";
   return (
+    !isNativeClaudeRefresh &&
     (profile.type === "oauth" || profile.type === "token") &&
     (profile.status === "expired" || profile.status === "expiring" || profile.status === "missing")
   );

--- a/src/commands/onboard-inference-ambient.test.ts
+++ b/src/commands/onboard-inference-ambient.test.ts
@@ -24,6 +24,19 @@ afterEach(async () => {
 });
 
 describe("detectAmbientInferenceBackends", () => {
+  it("does not treat native Claude token files as ambient credentials", async () => {
+    const home = await createTempHome();
+    await writeCredential(home, ".claude/.credentials.json", {
+      claudeAiOauth: {
+        accessToken: "claude-access",
+        refreshToken: "claude-refresh",
+        expiresAt: Date.now() + 60_000,
+      },
+    });
+
+    expect(detectAmbientInferenceBackends({ HOME: home })).toEqual([]);
+  });
+
   it("returns a verified Codex candidate only for readable file credentials", async () => {
     const home = await createTempHome();
     expect(detectAmbientInferenceBackends({ HOME: home })).toEqual([]);

--- a/src/node-host/desktop-stream-command.test.ts
+++ b/src/node-host/desktop-stream-command.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
+import { createDeferred } from "../../test/helpers/promise.js";
 import {
   invokeNodeDesktopStream,
   invokeNodeWorkerDesktopStream,
@@ -196,17 +197,21 @@ describe("node desktop stream command", () => {
     const wss = new WebSocketServer({ server: httpServer });
     const streams: Array<{
       accessHeaders: [string | undefined, string | undefined];
+      attached: Promise<void>;
       closed: boolean;
     }> = [];
     wss.on("connection", (ws, request) => {
+      const attached = createDeferred();
       const stream = {
         accessHeaders: [
           request.headers["cf-access-client-id"],
           request.headers["cf-access-client-secret"],
         ] as [string | undefined, string | undefined],
+        attached: attached.promise,
         closed: false,
       };
       streams.push(stream);
+      ws.once("message", () => attached.resolve());
       ws.once("close", () => {
         stream.closed = true;
       });
@@ -227,7 +232,12 @@ describe("node desktop stream command", () => {
 
     for (const kind of ["public", "worker"] as const) {
       const controller = new AbortController();
-      const emitStatus = vi.fn(async () => undefined);
+      const publicAttached = createDeferred();
+      const emitStatus = vi.fn(async (message: string) => {
+        if (message === "desktop stream attached\n") {
+          publicAttached.resolve();
+        }
+      });
       const connection = {
         paramsJSON: JSON.stringify({
           ticket: TICKET,
@@ -256,7 +266,10 @@ describe("node desktop stream command", () => {
       }
       expect(stream.accessHeaders).toEqual(["desktop-client-id", "desktop-client-secret"]);
       if (kind === "public") {
+        await publicAttached.promise;
         expect(emitStatus).toHaveBeenCalledWith("desktop stream attached\n");
+      } else {
+        await stream.attached;
       }
 
       controller.abort();

--- a/src/plugins/provider-external-auth.types.ts
+++ b/src/plugins/provider-external-auth.types.ts
@@ -16,6 +16,7 @@ export type ProviderResolveSyntheticAuthContext = {
   config?: OpenClawConfig;
   provider: string;
   providerConfig?: ModelProviderConfig;
+  purpose?: "discovery" | "runtime";
 };
 
 /** Synthetic provider credential returned by plugin auth helpers. */

--- a/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
+++ b/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
@@ -345,21 +345,39 @@ suite.define(() => {
         await activityPage.locator(".activity-feed__people-clear").click();
         await expect.poll(() => new URL(page.url()).searchParams.get("person")).toBeNull();
         await page.setViewportSize({ height: 844, width: 390 });
+        await page.evaluate(
+          () =>
+            new Promise<void>((resolve) => {
+              requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+            }),
+        );
 
-        const peopleControl = activityPage.locator(".activity-feed__people-control");
-        const timeButtonTops = await timeFilter
-          .locator(".settings-segmented__btn")
-          .evaluateAll((buttons) =>
-            buttons.map((button) => Math.round(button.getBoundingClientRect().top)),
-          );
-        const [timeFilterBox, peopleControlBox] = await Promise.all([
-          timeFilter.boundingBox(),
-          peopleControl.boundingBox(),
-        ]);
-        expect(new Set(timeButtonTops)).toHaveLength(1);
-        expect(timeFilterBox).not.toBeNull();
-        expect(peopleControlBox).not.toBeNull();
-        expect(Math.abs(timeFilterBox!.y - peopleControlBox!.y)).toBeLessThan(2);
+        // Sample related controls in one browser frame so viewport scroll anchoring
+        // cannot shift one box between independent Playwright requests.
+        const toolbarGeometry = await activityPage
+          .locator(".activity-feed__toolbar")
+          .evaluate((toolbar) => {
+            const timeControl = toolbar.querySelector<HTMLElement>(".activity-feed__time-filter");
+            const peopleControl = toolbar.querySelector<HTMLElement>(
+              ".activity-feed__people-control",
+            );
+            if (!timeControl || !peopleControl) {
+              throw new Error("Expected activity toolbar controls");
+            }
+            return {
+              peopleTop: peopleControl.getBoundingClientRect().top,
+              timeButtonTops: Array.from(
+                timeControl.querySelectorAll<HTMLElement>(".settings-segmented__btn"),
+                (button) => Math.round(button.getBoundingClientRect().top),
+              ),
+              timeTop: timeControl.getBoundingClientRect().top,
+            };
+          });
+        expect(new Set(toolbarGeometry.timeButtonTops)).toHaveLength(1);
+        expect(
+          Math.abs(toolbarGeometry.timeTop - toolbarGeometry.peopleTop),
+          JSON.stringify(toolbarGeometry),
+        ).toBeLessThan(2);
         const automationGroupChildTops = await automationGroup
           .locator(":scope > *")
           .evaluateAll((children) =>


### PR DESCRIPTION
## What Problem This Solves

The production native Claude authentication defect originally tracked here is now fixed on `main` by #129346. During exact-head validation of that repair, CI exposed several independent test-owner defects: cold integration bootstrap was charged to individual test budgets, one selected-model assertion lived inside a 391-test aggregate, desktop cancellation raced carrier attachment, responsive Activity geometry was sampled during viewport settlement, copied Claude credential files lacked an explicit negative ambient-discovery regression, and an explicit plugin metadata mock stopped exercising the real scoped-snapshot contract.

This PR now retains only those test and CI repairs. It contains no production behavior change and no longer closes #129333.

## Why This Change Was Made

Each repair stays at the boundary that owns the evidence:

- embedded runner integration harnesses load and warm once per file, while each test resets only mutable mock state;
- the fast-abort selected-model contract has a focused file instead of paying unrelated aggregate bootstrap cost;
- the model-resolution fixture delegates scoped metadata behavior to the real owner while preserving the empty-plugin fallback outside a scope;
- desktop stream tests wait for metadata/status attachment events before cancellation rather than treating WebSocket acceptance as attachment;
- Activity geometry waits for two animation frames after viewport resize and samples related controls atomically;
- ambient onboarding explicitly proves copied native Claude token files are not credentials OpenClaw may adopt.

## User Impact

No runtime behavior changes. The production fix is #129346. This branch makes its surrounding validation deterministic and keeps future regressions from being hidden by cold-start budgets, lifecycle races, or test mocks that replace the contract under test.

## Evidence

- `pnpm check:changed`
- Final reduced-scope proof: 24/24 tests passed across the embedded harness owners, model-resolution consistency, onboarding ambient discovery, fast-abort model selection, and desktop stream lifecycle suites.
- The inherited-auth owner originally took 354 seconds and timed out both cases; one-time harness warm-up now keeps both ownership assertions inside their actual case budgets.
- The isolated fast-abort assertion executes its test body in approximately 0.3 seconds locally instead of inheriting the 391-test dispatch aggregate.
- Desktop attachment synchronization passed its focused unit and Gateway integration coverage.
- Activity geometry passed a bounded 10-run stress loop plus a final post-rebase run; the complete Control UI suite passed 10,728 tests across 747 files.
- Exact-head run https://github.com/openclaw/openclaw/actions/runs/32899825110 exposed the incomplete plugin metadata mock. The repaired model-resolution suite passes 8/8 while retaining the real scoped-snapshot implementation and its bounded empty-plugin fallback.
- Fresh Codex autoreview of the final test-only branch reported no accepted/actionable findings.

LOC classification against current `main`:

- production: 0;
- tests/test support: +79 net lines.
