### PR TITLE
fix(config): bound JSON nesting before parsing to prevent native stack overflow

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -404,6 +404,9 @@ const config = {
     // are intentionally test-only in the production graph.
     "src/boards/board-notices.ts": ["exports"],
     "src/boards/board-store.ts": ["exports"],
+    // Focused nesting tests assert the parsed-value guard directly; production
+    // reaches it through parseJsonWithNestingGuard.
+    "src/config/nesting-limit.ts": ["exports"],
     "src/gateway/board-view-ticket.ts": ["exports"],
     // Focused startup tests consume this explicit seam; production imports only the bootstrap.
     "src/gateway/server-startup-bootstrap.ts": ["exports"],

--- a/src/cli/config-cli-input.ts
+++ b/src/cli/config-cli-input.ts
@@ -5,7 +5,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import JSON5 from "json5";
 import { rejectConfigNonFiniteNumbers } from "../config/io.read-helpers.js";
-import { assertBoundedJsonNesting, assertBoundedRawJsonNesting } from "../config/nesting-limit.js";
+import { parseJsonWithNestingGuard } from "../config/nesting-limit.js";
 import {
   coerceSecretRef,
   isValidEnvSecretRefId,
@@ -572,9 +572,7 @@ async function readConfigPatchInput(opts: ConfigPatchOptions): Promise<unknown> 
   }
   let parsed: unknown;
   try {
-    assertBoundedRawJsonNesting(raw, sourceLabel);
-    parsed = JSON5.parse(raw);
-    assertBoundedJsonNesting(parsed, sourceLabel);
+    parsed = parseJsonWithNestingGuard(raw, sourceLabel, JSON5.parse);
   } catch (err) {
     throw new Error(`Failed to parse ${sourceLabel} as JSON5: ${String(err)}`, { cause: err });
   }

--- a/src/cli/config-cli-input.ts
+++ b/src/cli/config-cli-input.ts
@@ -5,6 +5,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import JSON5 from "json5";
 import { rejectConfigNonFiniteNumbers } from "../config/io.read-helpers.js";
+import { assertBoundedJsonNesting, assertBoundedRawJsonNesting } from "../config/nesting-limit.js";
 import {
   coerceSecretRef,
   isValidEnvSecretRefId,
@@ -571,7 +572,9 @@ async function readConfigPatchInput(opts: ConfigPatchOptions): Promise<unknown> 
   }
   let parsed: unknown;
   try {
+    assertBoundedRawJsonNesting(raw, sourceLabel);
     parsed = JSON5.parse(raw);
+    assertBoundedJsonNesting(parsed, sourceLabel);
   } catch (err) {
     throw new Error(`Failed to parse ${sourceLabel} as JSON5: ${String(err)}`, { cause: err });
   }

--- a/src/cli/config-cli-path.test.ts
+++ b/src/cli/config-cli-path.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
+// Covers config set value parsing against the bounded JSON nesting contract.
+import JSON5 from "json5";
+import { describe, expect, it, vi } from "vitest";
+import { ConfigNestingDepthError, MAX_CONFIG_JSON_NESTING_DEPTH } from "../config/nesting-limit.js";
 import { parseConfigSetValue } from "./config-cli-path.js";
+
+const OVER_LIMIT_DEPTH = MAX_CONFIG_JSON_NESTING_DEPTH + 1;
+const overLimitArrayText = "[".repeat(OVER_LIMIT_DEPTH) + "]".repeat(OVER_LIMIT_DEPTH);
 
 describe("parseConfigSetValue", () => {
   it.each([
@@ -46,5 +52,47 @@ describe("parseConfigSetValue", () => {
     expect(() => parseConfigSetValue("not-json", true)).toThrow(
       /(Unexpected token|Expected).*not-json/,
     );
+  });
+
+  it("rejects an over-limit --strict-json value before the parser runs", () => {
+    const parseSpy = vi.spyOn(JSON, "parse");
+    try {
+      expect(() => parseConfigSetValue(overLimitArrayText, true)).toThrow(
+        /Could not parse .* as JSON for --strict-json/,
+      );
+      expect(() => parseConfigSetValue(overLimitArrayText, true)).toThrow(/nesting depth/);
+      expect(parseSpy).not.toHaveBeenCalled();
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+
+  it("rejects an over-limit JSON5 value before the parser runs instead of falling back to raw", () => {
+    const parseSpy = vi.spyOn(JSON5, "parse");
+    try {
+      expect(() => parseConfigSetValue(overLimitArrayText, false)).toThrowError(
+        ConfigNestingDepthError,
+      );
+      expect(() => parseConfigSetValue(overLimitArrayText, false)).toThrow(
+        /maximum supported nesting depth/,
+      );
+      expect(parseSpy).not.toHaveBeenCalled();
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+
+  it("keeps shallow values and plain-string fallback unchanged", () => {
+    expect(parseConfigSetValue("42", false)).toBe(42);
+    expect(parseConfigSetValue('{"a": [1, 2]}', false)).toEqual({ a: [1, 2] });
+    expect(parseConfigSetValue('[1, "x"]', true)).toEqual([1, "x"]);
+    expect(parseConfigSetValue("plain text", false)).toBe("plain text");
+    expect(parseConfigSetValue("{bad", false)).toBe("{bad");
+  });
+
+  it("accepts values at the supported maximum depth", () => {
+    const atLimit =
+      "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH) + "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH);
+    expect(Array.isArray(parseConfigSetValue(atLimit, true))).toBe(true);
   });
 });

--- a/src/cli/config-cli-path.ts
+++ b/src/cli/config-cli-path.ts
@@ -1,7 +1,7 @@
 import { isRecord as isPlainRecord } from "@openclaw/normalization-core/record-coerce";
 import JSON5 from "json5";
 import { rejectConfigNonFiniteNumbers } from "../config/io.read-helpers.js";
-import { assertBoundedJsonNesting, ConfigNestingDepthError } from "../config/nesting-limit.js";
+import { ConfigNestingDepthError, parseJsonWithNestingGuard } from "../config/nesting-limit.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import {
   formatConcreteConfigPath,
@@ -54,8 +54,10 @@ export function parseConfigSetValue(raw: string, strictJson: boolean): unknown {
   if (strictJson) {
     let parsed: unknown;
     try {
-      parsed = JSON.parse(trimmed);
-      assertBoundedJsonNesting(parsed, "Config value JSON");
+      // Shared parser boundary: raw nesting is pre-scanned before JSON.parse so
+      // a pathological value is rejected as a wrapped strict-parse failure
+      // instead of overflowing the native stack inside the parser.
+      parsed = parseJsonWithNestingGuard(trimmed, "Config value JSON", JSON.parse);
     } catch (err) {
       throw new Error(formatStrictJsonParseFailure({ value: raw, cause: err }), { cause: err });
     }
@@ -64,8 +66,7 @@ export function parseConfigSetValue(raw: string, strictJson: boolean): unknown {
   }
   let parsed: unknown;
   try {
-    parsed = JSON5.parse(trimmed);
-    assertBoundedJsonNesting(parsed, "Config value JSON");
+    parsed = parseJsonWithNestingGuard(trimmed, "Config value JSON", JSON5.parse);
   } catch (err) {
     if (err instanceof ConfigNestingDepthError) {
       throw err;

--- a/src/cli/config-cli-path.ts
+++ b/src/cli/config-cli-path.ts
@@ -1,6 +1,7 @@
 import { isRecord as isPlainRecord } from "@openclaw/normalization-core/record-coerce";
 import JSON5 from "json5";
 import { rejectConfigNonFiniteNumbers } from "../config/io.read-helpers.js";
+import { assertBoundedJsonNesting, ConfigNestingDepthError } from "../config/nesting-limit.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import {
   formatConcreteConfigPath,
@@ -54,6 +55,7 @@ export function parseConfigSetValue(raw: string, strictJson: boolean): unknown {
     let parsed: unknown;
     try {
       parsed = JSON.parse(trimmed);
+      assertBoundedJsonNesting(parsed, "Config value JSON");
     } catch (err) {
       throw new Error(formatStrictJsonParseFailure({ value: raw, cause: err }), { cause: err });
     }
@@ -63,7 +65,11 @@ export function parseConfigSetValue(raw: string, strictJson: boolean): unknown {
   let parsed: unknown;
   try {
     parsed = JSON5.parse(trimmed);
-  } catch {
+    assertBoundedJsonNesting(parsed, "Config value JSON");
+  } catch (err) {
+    if (err instanceof ConfigNestingDepthError) {
+      throw err;
+    }
     return raw;
   }
   rejectConfigNonFiniteNumbers(parsed);

--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -326,6 +326,20 @@ describe("config cli integration", () => {
     );
   });
 
+  it("rejects a deeply-nested config file with a clean validation error instead of overflowing the stack", async () => {
+    const deepRaw = `${"[".repeat(100_000)}${"]".repeat(100_000)}\n`;
+    await withConfigFileHarness("openclaw-config-cli-validate-deep-nesting-", deepRaw, async () => {
+      await expect(runRegisteredConfigCommand(["config", "validate"])).rejects.toThrow(
+        "__exit__:1",
+      );
+
+      const errors = registeredRuntimeErrors.join("\n");
+      expect(errors).toContain("OpenClaw config is invalid");
+      expect(errors).toContain("nesting depth");
+      expect(errors).not.toContain("RangeError");
+    });
+  });
+
   it("allows a config set that repairs an inactive provider/source mismatch", async () => {
     const raw = `${JSON.stringify(
       {

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -6,7 +6,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import JSON5 from "json5";
 import { rejectConfigNonFiniteNumbers } from "../config/io.read-helpers.js";
-import { assertBoundedJsonNesting, assertBoundedRawJsonNesting } from "../config/nesting-limit.js";
+import { parseJsonWithNestingGuard } from "../config/nesting-limit.js";
 import { readFileDescriptorBoundedSync } from "../infra/boundary-file-read.js";
 import { hasErrnoCode } from "../infra/errors.js";
 
@@ -119,9 +119,7 @@ export function hasProviderBuilderOptions(opts: ConfigSetOptions): boolean {
 function parseJson5Raw(raw: string, label: string): unknown {
   let parsed: unknown;
   try {
-    assertBoundedRawJsonNesting(raw, label);
-    parsed = JSON5.parse(raw);
-    assertBoundedJsonNesting(parsed, label);
+    parsed = parseJsonWithNestingGuard(raw, label, JSON5.parse);
   } catch (err) {
     throw new Error(`Failed to parse ${label}: ${String(err)}`, { cause: err });
   }

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -6,6 +6,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import JSON5 from "json5";
 import { rejectConfigNonFiniteNumbers } from "../config/io.read-helpers.js";
+import { assertBoundedJsonNesting, assertBoundedRawJsonNesting } from "../config/nesting-limit.js";
 import { readFileDescriptorBoundedSync } from "../infra/boundary-file-read.js";
 import { hasErrnoCode } from "../infra/errors.js";
 
@@ -118,7 +119,9 @@ export function hasProviderBuilderOptions(opts: ConfigSetOptions): boolean {
 function parseJson5Raw(raw: string, label: string): unknown {
   let parsed: unknown;
   try {
+    assertBoundedRawJsonNesting(raw, label);
     parsed = JSON5.parse(raw);
+    assertBoundedJsonNesting(parsed, label);
   } catch (err) {
     throw new Error(`Failed to parse ${label}: ${String(err)}`, { cause: err });
   }

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_CONFIG_JSON_NESTING_DEPTH } from "../../config/nesting-limit.js";
 import type { StaleOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import { createMockGatewayService } from "../../daemon/service.test-helpers.js";
 import type { PortListener, PortUsageStatus } from "../../infra/ports-types.js";
@@ -1096,6 +1097,39 @@ describe("gatherDaemonStatus", () => {
       expect(status.config?.daemon).toBe(status.config?.cli);
       expect(status.gateway?.bindMode).toBe("custom");
       expect(status.gateway?.customBindHost).toBe("10.0.0.5");
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects over-deep configs on the fast status path with a bounded nesting error", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-status-config-"));
+    const configPath = path.join(tmp, "openclaw.json");
+    const overDeep =
+      "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) + "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+    await fs.writeFile(configPath, `{"deep":${overDeep}}`, "utf8");
+    setTestEnvValue("OPENCLAW_STATE_DIR", tmp);
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+    serviceReadCommand.mockResolvedValueOnce({
+      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
+      environment: {
+        OPENCLAW_STATE_DIR: tmp,
+        OPENCLAW_CONFIG_PATH: configPath,
+      },
+    });
+
+    try {
+      const status = await gatherStatus({ probe: false });
+
+      expect(readConfigFileSnapshotCalls).not.toHaveBeenCalled();
+      expect(loadConfigCalls).not.toHaveBeenCalled();
+      expect(status.config?.cli.exists).toBe(true);
+      expect(status.config?.cli.valid).toBe(false);
+      expect(
+        status.config?.cli.issues?.some((issue) =>
+          issue.message.includes("maximum supported nesting depth"),
+        ),
+      ).toBe(true);
     } finally {
       await fs.rm(tmp, { recursive: true, force: true });
     }

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -10,6 +10,7 @@ import {
   resolveGatewayPort,
   resolveStateDir,
 } from "../../config/config.js";
+import { ConfigNestingDepthError, parseJsonWithNestingGuard } from "../../config/nesting-limit.js";
 import { isDefaultInstallIdentity } from "../../config/paths.js";
 import type {
   OpenClawConfig,
@@ -173,14 +174,25 @@ async function readFastStatusConfig(configPath: string): Promise<StatusConfigRea
 
   let parsed: unknown;
   try {
-    parsed = JSON5.parse(raw);
+    // Shared parser boundary: the fast status read must pre-scan nesting
+    // before JSON5.parse so an over-deep config is reported as an invalid
+    // summary instead of failing outside the canonical bounded contract.
+    parsed = parseJsonWithNestingGuard(raw, "Config JSON", (text) => JSON5.parse(text));
   } catch (err) {
     return {
       summary: {
         path: configPath,
         exists: true,
         valid: false,
-        issues: [{ path: "", message: `JSON5 parse failed: ${String(err)}` }],
+        issues: [
+          {
+            path: "",
+            message:
+              err instanceof ConfigNestingDepthError
+                ? err.message
+                : `JSON5 parse failed: ${String(err)}`,
+          },
+        ],
       },
       cfg: {},
       mode: "fast",

--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -448,6 +448,20 @@ describe("secrets CLI", () => {
     });
   });
 
+  it("rejects deeply-nested secrets plan files before parsing", async () => {
+    const deepContents = `${"[".repeat(100_000)}${"]".repeat(100_000)}\n`;
+    await withPlanFile(async (planPath) => {
+      await expect(
+        createProgram().parseAsync(["secrets", "apply", "--from", planPath, "--dry-run"], {
+          from: "user",
+        }),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(runSecretsApply).not.toHaveBeenCalled();
+      expect(runtimeErrors.at(-1)).toContain("nesting depth");
+    }, deepContents);
+  });
+
   it.skipIf(process.platform === "win32")(
     "rejects FIFO secrets plan paths without blocking",
     async () => {

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -2,6 +2,10 @@
 import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
+import {
+  assertBoundedRawJsonNesting,
+  MAX_CONFIG_JSON_NESTING_DEPTH,
+} from "../config/nesting-limit.js";
 import { danger } from "../globals.js";
 import { formatErrorMessage, hasErrnoCode } from "../infra/errors.js";
 import { defaultRuntime } from "../runtime.js";
@@ -94,6 +98,14 @@ async function readPlanFile(pathname: string): Promise<SecretsApplyPlan> {
     raw = (await readFileDescriptorBounded(file.fd, SECRETS_PLAN_MAX_BYTES)).toString("utf8");
   } finally {
     await file.close();
+  }
+  try {
+    assertBoundedRawJsonNesting(raw, "Secrets plan JSON");
+  } catch (err) {
+    throw new Error(
+      `Secrets plan file exceeds the maximum supported nesting depth of ${MAX_CONFIG_JSON_NESTING_DEPTH}: ${pathname}`,
+      { cause: err },
+    );
   }
   let parsed: unknown;
   try {

--- a/src/config/env-substitution.test.ts
+++ b/src/config/env-substitution.test.ts
@@ -514,4 +514,32 @@ describe("resolveConfigEnvVars", () => {
       expectResolvedScenarios(scenarios);
     });
   });
+
+  describe("nesting depth guard", () => {
+    function buildDeepValue(depth: number): unknown {
+      let value: unknown = "x";
+      for (let i = 0; i < depth; i += 1) {
+        value = [value];
+      }
+      return value;
+    }
+
+    it("rejects deeply-nested values instead of recursing without bound", () => {
+      const deep = buildDeepValue(600);
+      let thrown: unknown;
+      try {
+        resolveConfigEnvVars(deep, {});
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).name).toBe("ConfigNestingDepthError");
+      expect((thrown as Error).message).toContain("nesting depth");
+    });
+
+    it("substitutes through structures within the supported depth", () => {
+      const supported = buildDeepValue(100);
+      expect(resolveConfigEnvVars(supported, {})).toEqual(supported);
+    });
+  });
 });

--- a/src/config/env-substitution.ts
+++ b/src/config/env-substitution.ts
@@ -24,6 +24,11 @@
 // followed by letters, numbers, or underscores (all uppercase)
 import { appendConfigPathSegment } from "../shared/dot-path.js";
 import { isPlainObject } from "../utils.js";
+import {
+  ConfigNestingDepthError,
+  formatConfigNestingDepthMessage,
+  MAX_CONFIG_JSON_NESTING_DEPTH,
+} from "./nesting-limit.js";
 import { parseEnvTemplateSecretRef } from "./types.secrets.js";
 
 const ENV_VAR_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
@@ -178,13 +183,22 @@ function substituteAny(
   env: NodeJS.ProcessEnv,
   path: string,
   opts?: SubstituteOptions,
+  depth = 0,
 ): unknown {
   if (typeof value === "string") {
     return substituteString(value, env, path, opts);
   }
 
+  if (depth > MAX_CONFIG_JSON_NESTING_DEPTH) {
+    throw new ConfigNestingDepthError(
+      formatConfigNestingDepthMessage(`Config value at ${path || "(root)"}`, depth),
+    );
+  }
+
   if (Array.isArray(value)) {
-    return value.map((item, index) => substituteAny(item, env, `${path}[${index}]`, opts));
+    return value.map((item, index) =>
+      substituteAny(item, env, `${path}[${index}]`, opts, depth + 1),
+    );
   }
 
   if (isPlainObject(value)) {
@@ -199,7 +213,7 @@ function substituteAny(
         : path
           ? `${path}.${key}`
           : key;
-      result[key] = substituteAny(val, env, childPath, opts);
+      result[key] = substituteAny(val, env, childPath, opts, depth + 1);
     }
     return result;
   }

--- a/src/config/gateway-dispatch-config.test.ts
+++ b/src/config/gateway-dispatch-config.test.ts
@@ -101,4 +101,21 @@ describe("readGatewayDispatchConfig", () => {
     });
     expect(config.gateway?.auth).toMatchObject({ mode: "token", token: "shell-token" });
   });
+
+  it("rejects a deeply-nested dispatch config before parsing it instead of overflowing", () => {
+    const configPath = createTempConfig({
+      "openclaw.json5": "[".repeat(10_000) + "]".repeat(10_000),
+    });
+    const env: NodeJS.ProcessEnv = { OPENCLAW_CONFIG_PATH: configPath };
+
+    let thrown: unknown;
+    try {
+      readGatewayDispatchConfig({ env });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).name).toBe("ConfigNestingDepthError");
+    expect((thrown as Error).message).toContain("Gateway dispatch config JSON");
+  });
 });

--- a/src/config/gateway-dispatch-config.ts
+++ b/src/config/gateway-dispatch-config.ts
@@ -6,6 +6,7 @@ import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { applyConfigEnvVars } from "./config-env-vars.js";
 import { resolveConfigEnvVars } from "./env-substitution.js";
 import { readConfigIncludeFileWithGuards, resolveConfigIncludes } from "./includes.js";
+import { parseJsonWithNestingGuard } from "./nesting-limit.js";
 import { resolveConfigPath, resolveIncludeRoots } from "./paths.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
@@ -109,7 +110,12 @@ function readRawGatewayDispatchConfig(options: GatewayDispatchConfigReadOptions 
   }
 
   const raw = fs.readFileSync(configPath, "utf-8");
-  const parsed = parseJsonWithJson5Fallback(raw);
+  // Shared parser boundary: raw nesting is pre-scanned before the compatibility
+  // parser runs, so a pathological dispatch config is rejected cleanly instead
+  // of overflowing the native stack inside JSON.parse/JSON5.parse.
+  const parsed = parseJsonWithNestingGuard(raw, "Gateway dispatch config JSON", (text) =>
+    parseJsonWithJson5Fallback(text),
+  );
   const resolvedIncludes = resolveIncludesForGatewayDispatch(parsed, configPath, env);
   const resolvedConfig = resolveGatewayDispatchEnvVars(resolvedIncludes, env);
   return {

--- a/src/config/includes-scan.nesting.test.ts
+++ b/src/config/includes-scan.nesting.test.ts
@@ -1,0 +1,45 @@
+// Covers the include-permission scanner's use of the shared nesting guard.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { withTestDir } from "../test-helpers/temp-dir.js";
+import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
+import { collectIncludePathsRecursive } from "./includes-scan.js";
+import { MAX_CONFIG_JSON_NESTING_DEPTH } from "./nesting-limit.js";
+
+// Spy on the JSON5 compatibility parser so scanner regressions can prove that
+// over-limit include text never reaches the native parser.
+vi.mock("../utils/parse-json-compat.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../utils/parse-json-compat.js")>();
+  return {
+    ...mod,
+    parseJsonWithJson5Fallback: vi.fn(mod.parseJsonWithJson5Fallback),
+  };
+});
+
+describe("include permission scanner nesting guard", () => {
+  it("returns a controlled outcome for deeply-nested included files without invoking the parser", async () => {
+    await withTestDir({ prefix: "openclaw-include-scan-nesting-" }, async (tempRoot) => {
+      const configDir = path.join(tempRoot, "config");
+      const deepIncludePath = path.join(configDir, "deep.json5");
+      await fs.mkdir(configDir, { recursive: true });
+      const deepRaw =
+        "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) +
+        "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+      await fs.writeFile(deepIncludePath, `${deepRaw}\n`, "utf-8");
+
+      const parserSpy = vi.mocked(parseJsonWithJson5Fallback);
+      parserSpy.mockClear();
+
+      const includePaths = await collectIncludePathsRecursive({
+        configPath: path.join(configDir, "openclaw.json"),
+        parsed: { $include: "./deep.json5" },
+      });
+
+      // Controlled outcome: the guarded file is still reported for permission
+      // auditing, but the over-limit text never reaches the native parser.
+      expect(parserSpy).not.toHaveBeenCalled();
+      expect(includePaths).toEqual([await fs.realpath(deepIncludePath)]);
+    });
+  });
+});

--- a/src/config/includes-scan.ts
+++ b/src/config/includes-scan.ts
@@ -9,7 +9,7 @@ import {
   readConfigIncludeFileWithGuards,
   type IncludeResolver,
 } from "./includes.js";
-import { MAX_CONFIG_JSON_NESTING_DEPTH } from "./nesting-limit.js";
+import { MAX_CONFIG_JSON_NESTING_DEPTH, parseJsonWithNestingGuard } from "./nesting-limit.js";
 import { resolveIncludeRoots } from "./paths.js";
 
 // Include discovery walks nested config objects because include blocks may be embedded.
@@ -90,7 +90,15 @@ export async function collectIncludePathsRecursive(params: {
           });
         },
         parseJson: (raw) => {
-          const nestedParsed = parseJsonWithJson5Fallback(raw);
+          // Shared parser boundary: the include-permission scanner must not
+          // hand pathological include text to the native parser. Over-limit
+          // raw input is rejected by the nesting guard before any parse, and
+          // the surrounding try/catch reports it via config validation.
+          const nestedParsed = parseJsonWithNestingGuard(
+            raw,
+            `Include file ${openedBasePath ?? "(include)"}`,
+            (text) => parseJsonWithJson5Fallback(text),
+          );
           if (openedBasePath) {
             nestedInclude = { basePath: openedBasePath, parsed: nestedParsed };
           }

--- a/src/config/includes-scan.ts
+++ b/src/config/includes-scan.ts
@@ -9,18 +9,22 @@ import {
   readConfigIncludeFileWithGuards,
   type IncludeResolver,
 } from "./includes.js";
+import { MAX_CONFIG_JSON_NESTING_DEPTH } from "./nesting-limit.js";
 import { resolveIncludeRoots } from "./paths.js";
 
 // Include discovery walks nested config objects because include blocks may be embedded.
 function listDirectIncludes(parsed: unknown): string[] {
   const out: string[] = [];
-  const visit = (value: unknown) => {
+  const visit = (value: unknown, depth: number) => {
+    if (depth > MAX_CONFIG_JSON_NESTING_DEPTH) {
+      return;
+    }
     if (!value) {
       return;
     }
     if (Array.isArray(value)) {
       for (const item of value) {
-        visit(item);
+        visit(item, depth + 1);
       }
       return;
     }
@@ -39,10 +43,10 @@ function listDirectIncludes(parsed: unknown): string[] {
       }
     }
     for (const v of Object.values(rec)) {
-      visit(v);
+      visit(v, depth + 1);
     }
   };
-  visit(parsed);
+  visit(parsed, 0);
   return out;
 }
 

--- a/src/config/includes.nesting.test.ts
+++ b/src/config/includes.nesting.test.ts
@@ -1,0 +1,66 @@
+// Covers the bounded structural walk in config include resolution.
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveConfigIncludes, type IncludeResolver } from "./includes.js";
+
+const ROOT_DIR = path.parse(process.cwd()).root;
+const DEFAULT_BASE_PATH = path.join(ROOT_DIR, "config", "openclaw.json");
+
+function createMockResolver(files: Record<string, unknown> = {}): IncludeResolver {
+  return {
+    readFile: (filePath: string) => {
+      if (filePath in files) {
+        return JSON.stringify(files[filePath]);
+      }
+      throw new Error(`ENOENT: no such file: ${filePath}`);
+    },
+    parseJson: JSON.parse,
+  };
+}
+
+function resolve(obj: unknown, files: Record<string, unknown> = {}, basePath = DEFAULT_BASE_PATH) {
+  return resolveConfigIncludes(obj, basePath, createMockResolver(files));
+}
+
+function buildDeepValue(depth: number): unknown {
+  let value: unknown = 0;
+  for (let i = 0; i < depth; i += 1) {
+    value = [value];
+  }
+  return value;
+}
+
+describe("include resolution nesting depth guard", () => {
+  it("rejects deeply-nested config structures instead of recursing without bound", () => {
+    const deep = buildDeepValue(600);
+    let thrown: unknown;
+    try {
+      resolve(deep);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).name).toBe("ConfigNestingDepthError");
+    expect((thrown as Error).message).toContain("nesting depth");
+  });
+
+  it("resolves includes through structures within the supported depth", () => {
+    const supported = buildDeepValue(100);
+    expect(resolve(supported)).toEqual(supported);
+  });
+
+  it("rejects a deeply-nested include file before parsing instead of overflowing", () => {
+    const deepRaw = "[".repeat(600) + "]".repeat(600);
+    let thrown: unknown;
+    try {
+      resolveConfigIncludes({ $include: "./deep.json" }, DEFAULT_BASE_PATH, {
+        readFile: () => deepRaw,
+        parseJson: JSON.parse,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(/Failed to parse include file/);
+  });
+});

--- a/src/config/includes.nesting.test.ts
+++ b/src/config/includes.nesting.test.ts
@@ -63,4 +63,54 @@ describe("include resolution nesting depth guard", () => {
     expect(thrown).toBeInstanceOf(Error);
     expect((thrown as Error).message).toMatch(/Failed to parse include file/);
   });
+
+  it("carries structural depth across an include chain instead of resetting per file", () => {
+    // Each file stays well within the 512-level contract on its own, but the
+    // chain must accumulate: the depth counter has to survive the new
+    // processor created per included file, or a chain of in-limit files can
+    // stack thousands of recursive frames and bypass the intended bound.
+    const configDir = path.dirname(DEFAULT_BASE_PATH);
+    const files: Record<string, unknown> = {};
+    const chainLength = 6;
+    const perFileNesting = 100;
+    for (let i = 0; i < chainLength; i += 1) {
+      let value: unknown = 0;
+      if (i + 1 < chainLength) {
+        value = { $include: `./chain-${i + 1}.json` };
+      }
+      for (let d = 0; d < perFileNesting; d += 1) {
+        value = [value];
+      }
+      files[path.normalize(path.resolve(configDir, `chain-${i}.json`))] = value;
+    }
+    let thrown: unknown;
+    try {
+      resolve({ $include: "./chain-0.json" }, files);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).name).toBe("ConfigNestingDepthError");
+    expect((thrown as Error).message).toContain("nesting depth");
+  });
+
+  it("accepts an include chain that stays within the cumulative depth contract", () => {
+    const configDir = path.dirname(DEFAULT_BASE_PATH);
+    const files: Record<string, unknown> = {};
+    const chainLength = 4;
+    const perFileNesting = 100;
+    for (let i = 0; i < chainLength; i += 1) {
+      let value: unknown = 0;
+      if (i + 1 < chainLength) {
+        value = { $include: `./chain-${i + 1}.json` };
+      }
+      for (let d = 0; d < perFileNesting; d += 1) {
+        value = [value];
+      }
+      files[path.normalize(path.resolve(configDir, `chain-${i}.json`))] = value;
+    }
+    expect(resolve({ $include: "./chain-0.json" }, files)).toEqual(
+      buildDeepValue(chainLength * perFileNesting),
+    );
+  });
 });

--- a/src/config/includes.ts
+++ b/src/config/includes.ts
@@ -238,7 +238,7 @@ class IncludeProcessor {
         key !== INCLUDE_KEY &&
         (logicalPath.length > 0 || !this.rootProjectionKeys || this.rootProjectionKeys.has(key)),
     );
-    const resolved = this.resolveInclude(includeValue, logicalPath);
+    const resolved = this.resolveInclude(includeValue, logicalPath, structuralDepth);
     const included = resolved.value;
     this.resolver.onIncludeResolved?.({
       path: [...logicalPath],
@@ -271,9 +271,10 @@ class IncludeProcessor {
   private resolveInclude(
     value: unknown,
     logicalPath: readonly string[],
+    structuralDepth: number,
   ): { value: unknown; targetPath?: string; targetPaths?: string[] } {
     if (typeof value === "string") {
-      return this.loadFile(value, logicalPath);
+      return this.loadFile(value, logicalPath, structuralDepth);
     }
 
     if (Array.isArray(value)) {
@@ -284,7 +285,7 @@ class IncludeProcessor {
             String(item),
           );
         }
-        return this.loadFile(item, logicalPath);
+        return this.loadFile(item, logicalPath, structuralDepth);
       });
       const merged = resolvedEntries.reduce<unknown>(
         (current, entry) => deepMerge(current, entry.value),
@@ -305,6 +306,7 @@ class IncludeProcessor {
   private loadFile(
     includePath: string,
     logicalPath: readonly string[],
+    structuralDepth: number,
   ): { value: unknown; targetPath: string } {
     const { resolvedPath, root } = this.resolvePath(includePath);
 
@@ -315,7 +317,7 @@ class IncludeProcessor {
     const parsed = this.parseFile(includePath, resolvedPath, raw);
 
     return {
-      value: this.processNested(resolvedPath, parsed, logicalPath),
+      value: this.processNested(resolvedPath, parsed, logicalPath, structuralDepth),
       targetPath: resolvedPath,
     };
   }
@@ -460,6 +462,7 @@ class IncludeProcessor {
     resolvedPath: string,
     parsed: unknown,
     logicalPath: readonly string[],
+    structuralDepth: number,
   ): unknown {
     const nested = new IncludeProcessor(
       resolvedPath,
@@ -469,7 +472,7 @@ class IncludeProcessor {
     );
     nested.visited = new Set([...this.visited, resolvedPath]);
     nested.depth = this.depth + 1;
-    return nested.process(parsed, logicalPath);
+    return nested.process(parsed, logicalPath, structuralDepth);
   }
 }
 

--- a/src/config/includes.ts
+++ b/src/config/includes.ts
@@ -22,10 +22,10 @@ import { isPathInside } from "../security/scan-paths.js";
 import { isPlainObject } from "../utils.js";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import {
-  assertBoundedRawJsonNesting,
   ConfigNestingDepthError,
   formatConfigNestingDepthMessage,
   MAX_CONFIG_JSON_NESTING_DEPTH,
+  parseJsonWithNestingGuard,
 } from "./nesting-limit.js";
 
 export const INCLUDE_KEY = "$include";
@@ -445,10 +445,10 @@ class IncludeProcessor {
 
   private parseFile(includePath: string, resolvedPath: string, raw: string): unknown {
     try {
-      // Pre-scan raw nesting before the parser so a deeply-nested include file is
-      // rejected as an include error instead of overflowing the native stack.
-      assertBoundedRawJsonNesting(raw, `Include file ${includePath}`);
-      return this.resolver.parseJson(raw);
+      // Shared parser boundary: pre-scans raw nesting before the parser so a
+      // deeply-nested include file is rejected as an include error instead of
+      // overflowing the native stack.
+      return parseJsonWithNestingGuard(raw, `Include file ${includePath}`, this.resolver.parseJson);
     } catch (err) {
       throw new ConfigIncludeError(
         `Failed to parse include file: ${includePath} (resolved: ${resolvedPath})`,

--- a/src/config/includes.ts
+++ b/src/config/includes.ts
@@ -21,6 +21,12 @@ import { isMissingPathError } from "../infra/errno.js";
 import { isPathInside } from "../security/scan-paths.js";
 import { isPlainObject } from "../utils.js";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
+import {
+  assertBoundedRawJsonNesting,
+  ConfigNestingDepthError,
+  formatConfigNestingDepthMessage,
+  MAX_CONFIG_JSON_NESTING_DEPTH,
+} from "./nesting-limit.js";
 
 export const INCLUDE_KEY = "$include";
 export const MAX_INCLUDE_DEPTH = 10;
@@ -176,9 +182,19 @@ class IncludeProcessor {
     return this.boundary.configRoot.rootDir;
   }
 
-  process(obj: unknown, logicalPath: readonly string[] = []): unknown {
+  process(obj: unknown, logicalPath: readonly string[] = [], structuralDepth = 0): unknown {
+    if (structuralDepth > MAX_CONFIG_JSON_NESTING_DEPTH) {
+      throw new ConfigNestingDepthError(
+        formatConfigNestingDepthMessage(
+          `Config structure at ${logicalPath.join(".") || "(root)"}`,
+          structuralDepth,
+        ),
+      );
+    }
     if (Array.isArray(obj)) {
-      return obj.map((item, index) => this.process(item, [...logicalPath, String(index)]));
+      return obj.map((item, index) =>
+        this.process(item, [...logicalPath, String(index)], structuralDepth + 1),
+      );
     }
 
     if (!isPlainObject(obj)) {
@@ -186,15 +202,16 @@ class IncludeProcessor {
     }
 
     if (!(INCLUDE_KEY in obj)) {
-      return this.processObject(obj, logicalPath);
+      return this.processObject(obj, logicalPath, structuralDepth);
     }
 
-    return this.processInclude(obj, logicalPath);
+    return this.processInclude(obj, logicalPath, structuralDepth);
   }
 
   private processObject(
     obj: Record<string, unknown>,
     logicalPath: readonly string[],
+    structuralDepth: number,
   ): Record<string, unknown> {
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj)) {
@@ -205,12 +222,16 @@ class IncludeProcessor {
       ) {
         continue;
       }
-      result[key] = this.process(value, [...logicalPath, key]);
+      result[key] = this.process(value, [...logicalPath, key], structuralDepth + 1);
     }
     return result;
   }
 
-  private processInclude(obj: Record<string, unknown>, logicalPath: readonly string[]): unknown {
+  private processInclude(
+    obj: Record<string, unknown>,
+    logicalPath: readonly string[],
+    structuralDepth: number,
+  ): unknown {
     const includeValue = obj[INCLUDE_KEY];
     const otherKeys = Object.keys(obj).filter(
       (key) =>
@@ -242,7 +263,7 @@ class IncludeProcessor {
     // Merge included content with sibling keys
     const rest: Record<string, unknown> = {};
     for (const key of otherKeys) {
-      rest[key] = this.process(obj[key], [...logicalPath, key]);
+      rest[key] = this.process(obj[key], [...logicalPath, key], structuralDepth + 1);
     }
     return deepMerge(included, rest);
   }
@@ -422,6 +443,9 @@ class IncludeProcessor {
 
   private parseFile(includePath: string, resolvedPath: string, raw: string): unknown {
     try {
+      // Pre-scan raw nesting before the parser so a deeply-nested include file is
+      // rejected as an include error instead of overflowing the native stack.
+      assertBoundedRawJsonNesting(raw, `Include file ${includePath}`);
       return this.resolver.parseJson(raw);
     } catch (err) {
       throw new ConfigIncludeError(

--- a/src/config/io.load.ts
+++ b/src/config/io.load.ts
@@ -8,6 +8,7 @@ import {
   containsConfigIncludeDirective,
   hashConfigRaw,
   maybeLoadDotEnvForConfig,
+  parseConfigJson5,
   resolveConfigForRead,
   resolveConfigIncludesForRead,
   restoreEnvChangesIfUnchanged,
@@ -44,7 +45,16 @@ export function loadConfigFromContext(
       );
     }
     const raw = deps.fs.readFileSync(configPath, "utf-8");
-    const parsed = deps.json5.parse(raw);
+    const parsedResult = parseConfigJson5(raw, deps.json5);
+    if (!parsedResult.ok) {
+      throwInvalidConfig({
+        configPath,
+        issues: [{ path: "", message: `JSON5 parse failed: ${parsedResult.error}` }],
+        logger: deps.logger,
+        loggedConfigPaths: loggedInvalidConfigs,
+      });
+    }
+    const parsed = parsedResult.parsed;
     const readResolution = resolveConfigForRead(
       resolveConfigIncludesForRead(parsed, configPath, deps),
       deps.env,

--- a/src/config/io.read-helpers.ts
+++ b/src/config/io.read-helpers.ts
@@ -29,6 +29,11 @@ import {
   resolveConfigIncludes,
 } from "./includes.js";
 import type { ConfigIoDeps, NormalizedConfigIoDeps, ParseConfigJson5Result } from "./io.types.js";
+import {
+  assertBoundedJsonNesting,
+  assertBoundedRawJsonNesting,
+  MAX_CONFIG_JSON_NESTING_DEPTH,
+} from "./nesting-limit.js";
 import { resolveConfigPath, resolveIncludeRoots, resolveStateDir } from "./paths.js";
 import { createConfigResolutionFacts, type ConfigResolutionFacts } from "./resolution-facts.js";
 import { getRuntimeConfigSourceSnapshot } from "./runtime-snapshot.js";
@@ -106,6 +111,7 @@ export function collectEnvRefPaths(
   value: unknown,
   pathLocal: string,
   output: Map<string, string>,
+  depth = 0,
 ): void {
   if (typeof value === "string") {
     if (containsEnvVarReference(value)) {
@@ -113,22 +119,28 @@ export function collectEnvRefPaths(
     }
     return;
   }
+  if (depth > MAX_CONFIG_JSON_NESTING_DEPTH) {
+    return;
+  }
   if (Array.isArray(value)) {
     value.forEach((item, index) => {
-      collectEnvRefPaths(item, `${pathLocal}[${index}]`, output);
+      collectEnvRefPaths(item, `${pathLocal}[${index}]`, output, depth + 1);
     });
     return;
   }
   if (isRecord(value)) {
     for (const [key, child] of Object.entries(value)) {
-      collectEnvRefPaths(child, pathLocal ? `${pathLocal}.${key}` : key, output);
+      collectEnvRefPaths(child, pathLocal ? `${pathLocal}.${key}` : key, output, depth + 1);
     }
   }
 }
 
-export function containsConfigIncludeDirective(value: unknown): boolean {
+export function containsConfigIncludeDirective(value: unknown, depth = 0): boolean {
+  if (depth > MAX_CONFIG_JSON_NESTING_DEPTH) {
+    return false;
+  }
   if (Array.isArray(value)) {
-    return value.some((item) => containsConfigIncludeDirective(item));
+    return value.some((item) => containsConfigIncludeDirective(item, depth + 1));
   }
   if (!isRecord(value)) {
     return false;
@@ -136,7 +148,7 @@ export function containsConfigIncludeDirective(value: unknown): boolean {
   if (INCLUDE_KEY in value) {
     return true;
   }
-  return Object.values(value).some((item) => containsConfigIncludeDirective(item));
+  return Object.values(value).some((item) => containsConfigIncludeDirective(item, depth + 1));
 }
 
 export function resolveConfigPathForDeps(deps: NormalizedConfigIoDeps): string {
@@ -177,7 +189,10 @@ export function parseConfigJson5(
   json5: { parse: (value: string) => unknown } = JSON5,
 ): ParseConfigJson5Result {
   try {
-    return { ok: true, parsed: parseJsonWithJson5Fallback(raw, json5) };
+    assertBoundedRawJsonNesting(raw, "Config JSON");
+    const parsed = parseJsonWithJson5Fallback(raw, json5);
+    assertBoundedJsonNesting(parsed, "Config JSON");
+    return { ok: true, parsed };
   } catch (err) {
     return { ok: false, error: String(err) };
   }

--- a/src/config/io.read-helpers.ts
+++ b/src/config/io.read-helpers.ts
@@ -29,11 +29,7 @@ import {
   resolveConfigIncludes,
 } from "./includes.js";
 import type { ConfigIoDeps, NormalizedConfigIoDeps, ParseConfigJson5Result } from "./io.types.js";
-import {
-  assertBoundedJsonNesting,
-  assertBoundedRawJsonNesting,
-  MAX_CONFIG_JSON_NESTING_DEPTH,
-} from "./nesting-limit.js";
+import { MAX_CONFIG_JSON_NESTING_DEPTH, parseJsonWithNestingGuard } from "./nesting-limit.js";
 import { resolveConfigPath, resolveIncludeRoots, resolveStateDir } from "./paths.js";
 import { createConfigResolutionFacts, type ConfigResolutionFacts } from "./resolution-facts.js";
 import { getRuntimeConfigSourceSnapshot } from "./runtime-snapshot.js";
@@ -189,9 +185,9 @@ export function parseConfigJson5(
   json5: { parse: (value: string) => unknown } = JSON5,
 ): ParseConfigJson5Result {
   try {
-    assertBoundedRawJsonNesting(raw, "Config JSON");
-    const parsed = parseJsonWithJson5Fallback(raw, json5);
-    assertBoundedJsonNesting(parsed, "Config JSON");
+    const parsed = parseJsonWithNestingGuard(raw, "Config JSON", (text) =>
+      parseJsonWithJson5Fallback(text, json5),
+    );
     return { ok: true, parsed };
   } catch (err) {
     return { ok: false, error: String(err) };

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -41,10 +41,11 @@ import {
   type ConfigWriteOptions,
   type ConfigWriteResult,
 } from "./io.js";
-import { rejectConfigNonFiniteNumbers } from "./io.read-helpers.js";
+import { containsConfigIncludeDirective, rejectConfigNonFiniteNumbers } from "./io.read-helpers.js";
 import { warnIfJSON5CommentsWillBeStripped } from "./json5-comments.js";
 import { ConfigMutationConflictError } from "./mutation-conflict.js";
 import type { ConfigMutationBase } from "./mutation-types.js";
+import { parseJsonWithNestingGuard } from "./nesting-limit.js";
 import { assertConfigWriteAllowedInCurrentMode } from "./nix-mode-write-guard.js";
 import { resolveConfigPath } from "./paths.js";
 import {
@@ -416,19 +417,6 @@ function getSingleTopLevelIncludeTarget(params: {
   );
 }
 
-function containsConfigIncludeDirective(value: unknown): boolean {
-  if (Array.isArray(value)) {
-    return value.some((item) => containsConfigIncludeDirective(item));
-  }
-  if (!isRecord(value)) {
-    return false;
-  }
-  return (
-    Object.hasOwn(value, INCLUDE_KEY) ||
-    Object.values(value).some((item) => containsConfigIncludeDirective(item))
-  );
-}
-
 function snapshotProvesBrokenInclude(snapshot: ConfigFileSnapshot, includePath: string): boolean {
   return (
     !snapshot.valid &&
@@ -742,7 +730,14 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
     let authoredIncludeValue: unknown;
     let parsedInclude = false;
     try {
-      authoredIncludeValue = parseJsonWithJson5Fallback(previousIncludeRaw);
+      // Shared parser boundary: the prior root-bound include is parsed through
+      // the canonical nesting guard and inspected with the shared bounded
+      // include-directive walk instead of an unbounded local traversal.
+      authoredIncludeValue = parseJsonWithNestingGuard(
+        previousIncludeRaw,
+        `Include file ${includePath}`,
+        (text) => parseJsonWithJson5Fallback(text),
+      );
       parsedInclude = true;
     } catch {
       // A validated replacement is the repair path for a malformed include.

--- a/src/config/nesting-limit.test.ts
+++ b/src/config/nesting-limit.test.ts
@@ -1,5 +1,5 @@
 // Covers the bounded JSON nesting contract for config and config-adjacent inputs.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { parseConfigJson5 } from "./io.read-helpers.js";
 import {
   assertBoundedJsonNesting,
@@ -7,6 +7,7 @@ import {
   ConfigNestingDepthError,
   formatConfigNestingDepthMessage,
   MAX_CONFIG_JSON_NESTING_DEPTH,
+  parseJsonWithNestingGuard,
 } from "./nesting-limit.js";
 
 function buildDeepArray(depth: number): unknown {
@@ -38,6 +39,37 @@ describe("assertBoundedRawJsonNesting", () => {
     // count them, or this would be misreported as an over-limit document.
     const bracketSoup = `{"a": "${"[".repeat(2_000)}${"]".repeat(2_000)}"}`;
     expect(() => assertBoundedRawJsonNesting(bracketSoup, "Test JSON")).not.toThrow();
+  });
+
+  it("ignores JSON5 line and block comments when measuring nesting depth", () => {
+    // 513 brackets inside comments must not count toward the limit: the
+    // document below is a legal, shallow JSON5 config.
+    const manyOpen = "[".repeat(513);
+    const manyClose = "]".repeat(513);
+    const withLineComment = `{\n  // ${manyOpen}${manyClose}\n  "a": 1\n}`;
+    expect(() => assertBoundedRawJsonNesting(withLineComment, "Test JSON")).not.toThrow();
+    const withBlockComment = `{\n  /* ${manyOpen}${manyClose} */\n  "a": 1\n}`;
+    expect(() => assertBoundedRawJsonNesting(withBlockComment, "Test JSON")).not.toThrow();
+    const blockWithInnerStars = `{ /* ${manyOpen} * ${manyClose} */ "a": 1 }`;
+    expect(() => assertBoundedRawJsonNesting(blockWithInnerStars, "Test JSON")).not.toThrow();
+    const trailingLineComment = `{"a": 1} // ${manyOpen}`;
+    expect(() => assertBoundedRawJsonNesting(trailingLineComment, "Test JSON")).not.toThrow();
+    // Comment markers inside strings are string content, not comments.
+    expect(() =>
+      assertBoundedRawJsonNesting(`{"u": "https://example.com/[x]//[y]", "a": 1}`, "Test JSON"),
+    ).not.toThrow();
+    // An unterminated block comment must terminate the scan, not hang or leak.
+    expect(() =>
+      assertBoundedRawJsonNesting(`{"a": 1} /* ${manyOpen}${manyClose}`, "Test JSON"),
+    ).not.toThrow();
+  });
+
+  it("still measures real nesting that appears after a comment", () => {
+    // The comment brackets are skipped; the 514 real brackets are counted.
+    const raw = `/* ${"]".repeat(10)} */ ${"[".repeat(514)}${"]".repeat(514)}`;
+    expect(() => assertBoundedRawJsonNesting(raw, "Test JSON")).toThrowError(
+      formatConfigNestingDepthMessage("Test JSON", 514),
+    );
   });
 
   it("rejects pathological 100k-deep input iteratively with an exact measured depth", () => {
@@ -116,5 +148,39 @@ describe("parseConfigJson5", () => {
       ok: true,
       parsed: { gateway: { mode: "local" } },
     });
+  });
+});
+
+describe("parseJsonWithNestingGuard", () => {
+  it("parses shallow input and passes it back unchanged", () => {
+    const parse = vi.fn((text: string) => JSON.parse(text));
+    expect(parseJsonWithNestingGuard('{"a": [1, 2]}', "Test JSON", parse)).toEqual({
+      a: [1, 2],
+    });
+    expect(parse).toHaveBeenCalledTimes(1);
+  });
+
+  it("asserts raw nesting before the parser runs, so over-limit input never reaches it", () => {
+    const parse = vi.fn((text: string) => JSON.parse(text));
+    const raw =
+      "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) + "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+    expect(() => parseJsonWithNestingGuard(raw, "Test JSON", parse)).toThrowError(
+      ConfigNestingDepthError,
+    );
+    expect(parse).not.toHaveBeenCalled();
+  });
+
+  it("re-asserts nesting on the parsed value for in-process parser quirks", () => {
+    // A parser that inflates shallow raw text into a deep value still trips the guard.
+    const parse = () => {
+      let value: unknown = 0;
+      for (let i = 0; i < MAX_CONFIG_JSON_NESTING_DEPTH + 2; i += 1) {
+        value = [value];
+      }
+      return value;
+    };
+    expect(() => parseJsonWithNestingGuard("{}", "Test JSON", parse)).toThrowError(
+      ConfigNestingDepthError,
+    );
   });
 });

--- a/src/config/nesting-limit.test.ts
+++ b/src/config/nesting-limit.test.ts
@@ -7,8 +7,6 @@ import {
   ConfigNestingDepthError,
   formatConfigNestingDepthMessage,
   MAX_CONFIG_JSON_NESTING_DEPTH,
-  measureJsonNestingDepth,
-  measureRawJsonNestingDepth,
 } from "./nesting-limit.js";
 
 function buildDeepArray(depth: number): unknown {
@@ -19,32 +17,48 @@ function buildDeepArray(depth: number): unknown {
   return value;
 }
 
-describe("measureRawJsonNestingDepth", () => {
-  it("measures bracket nesting and ignores brackets inside strings", () => {
-    expect(measureRawJsonNestingDepth('{"a": "["}')).toBe(1);
-    expect(measureRawJsonNestingDepth('{"a": "[{["}')).toBe(1);
-    expect(measureRawJsonNestingDepth('{"a": "x]"}')).toBe(1);
-    expect(measureRawJsonNestingDepth("[1, [2, [3]]]")).toBe(3);
-    expect(measureRawJsonNestingDepth('{"a": {"b": [1, {"c": "]"}]}}')).toBe(4);
-    expect(measureRawJsonNestingDepth('"plain string [ ]"')).toBe(0);
-    expect(measureRawJsonNestingDepth("'single quoted [ ]'")).toBe(0);
-    expect(measureRawJsonNestingDepth(String.raw`{"escaped": "a\"b["}`)).toBe(1);
+describe("assertBoundedRawJsonNesting", () => {
+  it("accepts shallow bracket nesting and ignores brackets inside strings", () => {
+    expect(() => assertBoundedRawJsonNesting('{"a": "["}', "Test JSON")).not.toThrow();
+    expect(() => assertBoundedRawJsonNesting('{"a": "[{[\\"', "Test JSON")).not.toThrow();
+    expect(() => assertBoundedRawJsonNesting('{"a": "x]"}', "Test JSON")).not.toThrow();
+    expect(() => assertBoundedRawJsonNesting("[1, [2, [3]]]", "Test JSON")).not.toThrow();
+    expect(() =>
+      assertBoundedRawJsonNesting('{"a": {"b": [1, {"c": "]"}]}}', "Test JSON"),
+    ).not.toThrow();
+    expect(() => assertBoundedRawJsonNesting('"plain string [ ]"', "Test JSON")).not.toThrow();
+    expect(() => assertBoundedRawJsonNesting("'single quoted [ ]'", "Test JSON")).not.toThrow();
+    expect(() =>
+      assertBoundedRawJsonNesting(String.raw`{\"escaped\": \"a\\\"b[\"}`, "Test JSON"),
+    ).not.toThrow();
   });
 
-  it("measures pathological 100k-deep input without recursing", () => {
-    expect(measureRawJsonNestingDepth("[".repeat(100_000) + "]".repeat(100_000))).toBe(100_000);
+  it("ignores bracket-like characters that only appear inside string values", () => {
+    // Over 512 brackets, all inside a quoted string: the raw scan must not
+    // count them, or this would be misreported as an over-limit document.
+    const bracketSoup = `{"a": "${"[".repeat(2_000)}${"]".repeat(2_000)}"}`;
+    expect(() => assertBoundedRawJsonNesting(bracketSoup, "Test JSON")).not.toThrow();
+  });
+
+  it("rejects pathological 100k-deep input iteratively with an exact measured depth", () => {
+    const raw = "[".repeat(100_000) + "]".repeat(100_000);
+    expect(() => assertBoundedRawJsonNesting(raw, "Test JSON")).toThrowError(
+      formatConfigNestingDepthMessage("Test JSON", 100_000),
+    );
   });
 });
 
-describe("measureJsonNestingDepth", () => {
-  it("measures parsed structures iteratively", () => {
-    expect(measureJsonNestingDepth([[[0]]])).toBe(4);
-    expect(measureJsonNestingDepth({ a: { b: [1, { c: 2 }] } })).toBe(5);
-    expect(measureJsonNestingDepth("leaf")).toBe(1);
+describe("assertBoundedJsonNesting", () => {
+  it("accepts shallow parsed structures iteratively", () => {
+    expect(() => assertBoundedJsonNesting([[[0]]], "Test JSON")).not.toThrow();
+    expect(() => assertBoundedJsonNesting({ a: { b: [1, { c: 2 }] } }, "Test JSON")).not.toThrow();
+    expect(() => assertBoundedJsonNesting("leaf", "Test JSON")).not.toThrow();
   });
 
-  it("measures pathological 100k-deep parsed values without recursing", () => {
-    expect(measureJsonNestingDepth(buildDeepArray(100_000))).toBe(100_001);
+  it("rejects pathological 100k-deep parsed values iteratively with an exact measured depth", () => {
+    expect(() => assertBoundedJsonNesting(buildDeepArray(100_000), "Test JSON")).toThrowError(
+      formatConfigNestingDepthMessage("Test JSON", 100_001),
+    );
   });
 });
 
@@ -70,13 +84,18 @@ describe("nesting depth assertions", () => {
     ).toThrow(/maximum supported nesting depth/);
   });
 
+  it("rejects raw text one level past the maximum with an exact measured depth", () => {
+    const raw =
+      "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) + "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+    expect(() => assertBoundedRawJsonNesting(raw, "Test JSON")).toThrowError(
+      formatConfigNestingDepthMessage("Test JSON", MAX_CONFIG_JSON_NESTING_DEPTH + 1),
+    );
+  });
+
   it("rejects deep raw text before any parser runs", () => {
     const raw = "[".repeat(100_000) + "]".repeat(100_000);
     expect(() => assertBoundedRawJsonNesting(raw, "Test JSON")).toThrowError(
       ConfigNestingDepthError,
-    );
-    expect(() => assertBoundedRawJsonNesting(raw, "Test JSON")).toThrowError(
-      formatConfigNestingDepthMessage("Test JSON", 100_000),
     );
   });
 });

--- a/src/config/nesting-limit.test.ts
+++ b/src/config/nesting-limit.test.ts
@@ -1,0 +1,101 @@
+// Covers the bounded JSON nesting contract for config and config-adjacent inputs.
+import { describe, expect, it } from "vitest";
+import { parseConfigJson5 } from "./io.read-helpers.js";
+import {
+  assertBoundedJsonNesting,
+  assertBoundedRawJsonNesting,
+  ConfigNestingDepthError,
+  formatConfigNestingDepthMessage,
+  MAX_CONFIG_JSON_NESTING_DEPTH,
+  measureJsonNestingDepth,
+  measureRawJsonNestingDepth,
+} from "./nesting-limit.js";
+
+function buildDeepArray(depth: number): unknown {
+  let value: unknown = 0;
+  for (let i = 0; i < depth; i += 1) {
+    value = [value];
+  }
+  return value;
+}
+
+describe("measureRawJsonNestingDepth", () => {
+  it("measures bracket nesting and ignores brackets inside strings", () => {
+    expect(measureRawJsonNestingDepth('{"a": "["}')).toBe(1);
+    expect(measureRawJsonNestingDepth('{"a": "[{["}')).toBe(1);
+    expect(measureRawJsonNestingDepth('{"a": "x]"}')).toBe(1);
+    expect(measureRawJsonNestingDepth("[1, [2, [3]]]")).toBe(3);
+    expect(measureRawJsonNestingDepth('{"a": {"b": [1, {"c": "]"}]}}')).toBe(4);
+    expect(measureRawJsonNestingDepth('"plain string [ ]"')).toBe(0);
+    expect(measureRawJsonNestingDepth("'single quoted [ ]'")).toBe(0);
+    expect(measureRawJsonNestingDepth(String.raw`{"escaped": "a\"b["}`)).toBe(1);
+  });
+
+  it("measures pathological 100k-deep input without recursing", () => {
+    expect(measureRawJsonNestingDepth("[".repeat(100_000) + "]".repeat(100_000))).toBe(100_000);
+  });
+});
+
+describe("measureJsonNestingDepth", () => {
+  it("measures parsed structures iteratively", () => {
+    expect(measureJsonNestingDepth([[[0]]])).toBe(4);
+    expect(measureJsonNestingDepth({ a: { b: [1, { c: 2 }] } })).toBe(5);
+    expect(measureJsonNestingDepth("leaf")).toBe(1);
+  });
+
+  it("measures pathological 100k-deep parsed values without recursing", () => {
+    expect(measureJsonNestingDepth(buildDeepArray(100_000))).toBe(100_001);
+  });
+});
+
+describe("nesting depth assertions", () => {
+  it("accepts raw and parsed values at the supported maximum", () => {
+    expect(() =>
+      assertBoundedJsonNesting(buildDeepArray(MAX_CONFIG_JSON_NESTING_DEPTH - 1), "Test JSON"),
+    ).not.toThrow();
+    expect(() =>
+      assertBoundedRawJsonNesting(
+        "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH) + "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH),
+        "Test JSON",
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects parsed values past the supported maximum with a wrapped error", () => {
+    expect(() =>
+      assertBoundedJsonNesting(buildDeepArray(MAX_CONFIG_JSON_NESTING_DEPTH + 1), "Test JSON"),
+    ).toThrowError(ConfigNestingDepthError);
+    expect(() =>
+      assertBoundedJsonNesting(buildDeepArray(MAX_CONFIG_JSON_NESTING_DEPTH + 1), "Test JSON"),
+    ).toThrow(/maximum supported nesting depth/);
+  });
+
+  it("rejects deep raw text before any parser runs", () => {
+    const raw = "[".repeat(100_000) + "]".repeat(100_000);
+    expect(() => assertBoundedRawJsonNesting(raw, "Test JSON")).toThrowError(
+      ConfigNestingDepthError,
+    );
+    expect(() => assertBoundedRawJsonNesting(raw, "Test JSON")).toThrowError(
+      formatConfigNestingDepthMessage("Test JSON", 100_000),
+    );
+  });
+});
+
+describe("parseConfigJson5", () => {
+  it("rejects deeply-nested config text as a clean parse failure", () => {
+    const deepRaw = "[".repeat(100_000) + "]".repeat(100_000);
+    const result = parseConfigJson5(deepRaw);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("nesting depth");
+      expect(result.error).toContain(String(MAX_CONFIG_JSON_NESTING_DEPTH));
+    }
+  });
+
+  it("accepts ordinary config text unchanged", () => {
+    expect(parseConfigJson5(`{"gateway": {"mode": "local"}}`)).toEqual({
+      ok: true,
+      parsed: { gateway: { mode: "local" } },
+    });
+  });
+});

--- a/src/config/nesting-limit.test.ts
+++ b/src/config/nesting-limit.test.ts
@@ -89,7 +89,7 @@ describe("assertBoundedJsonNesting", () => {
 
   it("rejects pathological 100k-deep parsed values iteratively with an exact measured depth", () => {
     expect(() => assertBoundedJsonNesting(buildDeepArray(100_000), "Test JSON")).toThrowError(
-      formatConfigNestingDepthMessage("Test JSON", 100_001),
+      formatConfigNestingDepthMessage("Test JSON", 100_000),
     );
   });
 });
@@ -122,6 +122,23 @@ describe("nesting depth assertions", () => {
     expect(() => assertBoundedRawJsonNesting(raw, "Test JSON")).toThrowError(
       formatConfigNestingDepthMessage("Test JSON", MAX_CONFIG_JSON_NESTING_DEPTH + 1),
     );
+  });
+
+  it("measures the parsed boundary with the same structural counting as the raw scan", () => {
+    // 512 structural containers are the advertised maximum: the same document
+    // must pass both the raw scan and the post-parse assertion, and one more
+    // container must fail both, so the limit has one observable meaning.
+    const boundary =
+      "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH) + "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH);
+    expect(() =>
+      parseJsonWithNestingGuard(boundary, "Test JSON", (text) => JSON.parse(text)),
+    ).not.toThrow();
+    expect(() =>
+      assertBoundedJsonNesting(buildDeepArray(MAX_CONFIG_JSON_NESTING_DEPTH), "Test JSON"),
+    ).not.toThrow();
+    expect(() =>
+      assertBoundedJsonNesting(buildDeepArray(MAX_CONFIG_JSON_NESTING_DEPTH + 1), "Test JSON"),
+    ).toThrowError(ConfigNestingDepthError);
   });
 
   it("rejects deep raw text before any parser runs", () => {

--- a/src/config/nesting-limit.ts
+++ b/src/config/nesting-limit.ts
@@ -34,17 +34,20 @@ export function formatConfigNestingDepthMessage(label: string, depth: number): s
 /**
  * Scans raw JSON/JSON5 text and returns the maximum bracket nesting depth.
  *
- * Iterative and string-aware: string contents (single/double-quoted, escaped
- * quotes included) are skipped so bracket-like characters inside values never
- * skew the count. Runs before any parser so a native parser overflow on
- * deeply-nested input can never happen.
+ * Iterative and string/comment-aware: string contents (single/double-quoted,
+ * escaped quotes included) and JSON5 comments (line and block forms) are
+ * skipped so bracket-like characters inside values or comments never skew the
+ * count. Runs before any parser so a native parser overflow on deeply-nested
+ * input can never happen.
  */
 function measureRawJsonNestingDepth(raw: string): number {
   let depth = 0;
   let maxDepth = 0;
   let quote: '"' | "'" | null = null;
   let escaped = false;
-  for (const char of raw) {
+  let index = 0;
+  while (index < raw.length) {
+    const char = raw[index];
     if (quote !== null) {
       if (escaped) {
         escaped = false;
@@ -53,10 +56,31 @@ function measureRawJsonNestingDepth(raw: string): number {
       } else if (char === quote) {
         quote = null;
       }
+      index += 1;
       continue;
     }
     if (char === '"' || char === "'") {
       quote = char;
+      index += 1;
+      continue;
+    }
+    // JSON5 comments are not structural: skip both forms so bracket-like
+    // characters inside comments never skew the measured depth.
+    if (char === "/" && raw[index + 1] === "/") {
+      index += 2;
+      while (index < raw.length && raw[index] !== "\n") {
+        index += 1;
+      }
+      continue;
+    }
+    if (char === "/" && raw[index + 1] === "*") {
+      index += 2;
+      while (index < raw.length && !(raw[index] === "*" && raw[index + 1] === "/")) {
+        index += 1;
+      }
+      if (index < raw.length) {
+        index += 2;
+      }
       continue;
     }
     if (char === "{" || char === "[") {
@@ -69,6 +93,7 @@ function measureRawJsonNestingDepth(raw: string): number {
         depth -= 1;
       }
     }
+    index += 1;
   }
   return maxDepth;
 }
@@ -119,4 +144,22 @@ export function assertBoundedJsonNesting(value: unknown, label: string): void {
   if (depth > MAX_CONFIG_JSON_NESTING_DEPTH) {
     throw new ConfigNestingDepthError(formatConfigNestingDepthMessage(label, depth));
   }
+}
+
+/**
+ * Shared parser boundary for JSON/JSON5 inputs: asserts raw nesting before the
+ * parser runs (so a native parser overflow can never happen) and re-asserts on
+ * the parsed value (covering parsers or producers that arrive in-process).
+ * Every config-adjacent parse site should go through this entry instead of
+ * repeating the raw/parse/parsed triple.
+ */
+export function parseJsonWithNestingGuard(
+  raw: string,
+  label: string,
+  parse: (text: string) => unknown,
+): unknown {
+  assertBoundedRawJsonNesting(raw, label);
+  const parsed = parse(raw);
+  assertBoundedJsonNesting(parsed, label);
+  return parsed;
 }

--- a/src/config/nesting-limit.ts
+++ b/src/config/nesting-limit.ts
@@ -104,26 +104,39 @@ function measureRawJsonNestingDepth(raw: string): number {
  * Iterative (explicit stack) so the measurement itself can never recurse.
  * Runs after parsing as a second layer: parsed values can also arrive from
  * in-process producers that never went through a raw-text boundary.
+ *
+ * Counting matches the raw scanner: only structural containers (arrays and
+ * records) advance the depth, and leaves never do, so a document with 512
+ * bracket levels measures as exactly 512 on both sides of the parser.
  */
 function measureJsonNestingDepth(value: unknown): number {
   let maxDepth = 0;
-  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 1 }];
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 0 }];
   while (stack.length > 0) {
     const entry = stack.pop();
     if (!entry) {
       continue;
     }
-    if (entry.depth > maxDepth) {
-      maxDepth = entry.depth;
-    }
     const current = entry.value;
     if (Array.isArray(current)) {
+      const childDepth = entry.depth + 1;
+      if (childDepth > maxDepth) {
+        maxDepth = childDepth;
+      }
       for (const item of current) {
-        stack.push({ value: item, depth: entry.depth + 1 });
+        if (Array.isArray(item) || isRecord(item)) {
+          stack.push({ value: item, depth: childDepth });
+        }
       }
     } else if (isRecord(current)) {
+      const childDepth = entry.depth + 1;
+      if (childDepth > maxDepth) {
+        maxDepth = childDepth;
+      }
       for (const child of Object.values(current)) {
-        stack.push({ value: child, depth: entry.depth + 1 });
+        if (Array.isArray(child) || isRecord(child)) {
+          stack.push({ value: child, depth: childDepth });
+        }
       }
     }
   }

--- a/src/config/nesting-limit.ts
+++ b/src/config/nesting-limit.ts
@@ -39,7 +39,7 @@ export function formatConfigNestingDepthMessage(label: string, depth: number): s
  * skew the count. Runs before any parser so a native parser overflow on
  * deeply-nested input can never happen.
  */
-export function measureRawJsonNestingDepth(raw: string): number {
+function measureRawJsonNestingDepth(raw: string): number {
   let depth = 0;
   let maxDepth = 0;
   let quote: '"' | "'" | null = null;
@@ -80,7 +80,7 @@ export function measureRawJsonNestingDepth(raw: string): number {
  * Runs after parsing as a second layer: parsed values can also arrive from
  * in-process producers that never went through a raw-text boundary.
  */
-export function measureJsonNestingDepth(value: unknown): number {
+function measureJsonNestingDepth(value: unknown): number {
   let maxDepth = 0;
   const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 1 }];
   while (stack.length > 0) {

--- a/src/config/nesting-limit.ts
+++ b/src/config/nesting-limit.ts
@@ -1,0 +1,122 @@
+/**
+ * Bounded nesting contract for parsed JSON/JSON5 values that feed config reads
+ * and config-adjacent CLI inputs (secrets plans, patch/batch files).
+ *
+ * Parsing itself is stack-safe on the fast path (V8's JSON.parse and the json5
+ * state machine are iterative), but the walks that follow it — $include
+ * resolution, environment substitution, include-directive probing — recurse
+ * over the structure. Without a depth contract, pathological deeply-nested
+ * inputs exhaust the native stack (STATUS_STACK_OVERFLOW / 0xC00000FD on
+ * Windows, where OpenClaw runs with an enlarged `--stack-size`), which no
+ * JavaScript try/catch can observe, so the CLI dies without its error wrapper.
+ *
+ * Both guards here are themselves iterative, so measuring pathological input
+ * can never overflow the stack.
+ */
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+
+/** Maximum supported structural nesting depth for parsed config/plan inputs. */
+export const MAX_CONFIG_JSON_NESTING_DEPTH = 512;
+
+/** Thrown when a raw or parsed JSON value nests deeper than the supported maximum. */
+export class ConfigNestingDepthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigNestingDepthError";
+  }
+}
+
+/** Formats a stable one-line violation message for CLI/snapshot surfaces. */
+export function formatConfigNestingDepthMessage(label: string, depth: number): string {
+  return `${label} exceeds the maximum supported nesting depth of ${MAX_CONFIG_JSON_NESTING_DEPTH} (measured ${depth} levels)`;
+}
+
+/**
+ * Scans raw JSON/JSON5 text and returns the maximum bracket nesting depth.
+ *
+ * Iterative and string-aware: string contents (single/double-quoted, escaped
+ * quotes included) are skipped so bracket-like characters inside values never
+ * skew the count. Runs before any parser so a native parser overflow on
+ * deeply-nested input can never happen.
+ */
+export function measureRawJsonNestingDepth(raw: string): number {
+  let depth = 0;
+  let maxDepth = 0;
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+  for (const char of raw) {
+    if (quote !== null) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === "{" || char === "[") {
+      depth += 1;
+      if (depth > maxDepth) {
+        maxDepth = depth;
+      }
+    } else if (char === "}" || char === "]") {
+      if (depth > 0) {
+        depth -= 1;
+      }
+    }
+  }
+  return maxDepth;
+}
+
+/**
+ * Measures the maximum structural nesting depth of a parsed value.
+ *
+ * Iterative (explicit stack) so the measurement itself can never recurse.
+ * Runs after parsing as a second layer: parsed values can also arrive from
+ * in-process producers that never went through a raw-text boundary.
+ */
+export function measureJsonNestingDepth(value: unknown): number {
+  let maxDepth = 0;
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 1 }];
+  while (stack.length > 0) {
+    const entry = stack.pop();
+    if (!entry) {
+      continue;
+    }
+    if (entry.depth > maxDepth) {
+      maxDepth = entry.depth;
+    }
+    const current = entry.value;
+    if (Array.isArray(current)) {
+      for (const item of current) {
+        stack.push({ value: item, depth: entry.depth + 1 });
+      }
+    } else if (isRecord(current)) {
+      for (const child of Object.values(current)) {
+        stack.push({ value: child, depth: entry.depth + 1 });
+      }
+    }
+  }
+  return maxDepth;
+}
+
+/** Asserts raw JSON/JSON5 text stays within the supported nesting contract. */
+export function assertBoundedRawJsonNesting(raw: string, label: string): void {
+  const depth = measureRawJsonNestingDepth(raw);
+  if (depth > MAX_CONFIG_JSON_NESTING_DEPTH) {
+    throw new ConfigNestingDepthError(formatConfigNestingDepthMessage(label, depth));
+  }
+}
+
+/** Asserts a parsed value stays within the supported nesting contract. */
+export function assertBoundedJsonNesting(value: unknown, label: string): void {
+  const depth = measureJsonNestingDepth(value);
+  if (depth > MAX_CONFIG_JSON_NESTING_DEPTH) {
+    throw new ConfigNestingDepthError(formatConfigNestingDepthMessage(label, depth));
+  }
+}

--- a/src/config/plugin-auto-enable.channels.test.ts
+++ b/src/config/plugin-auto-enable.channels.test.ts
@@ -230,6 +230,49 @@ describe("applyPluginAutoEnable channels", () => {
     );
   });
 
+  it("rejects over-deep external catalog JSON through the shared nesting guard", () => {
+    const stateDir = makeTempDir();
+    const catalogPath = path.join(stateDir, "plugins", "catalog.json");
+    fs.mkdirSync(path.dirname(catalogPath), { recursive: true });
+    // 520 nesting levels: deep enough to violate the shared 512-level
+    // contract, small enough to pass the 16 MiB size cap so the depth
+    // guard is the only boundary the file can trip.
+    const deepMarker = "over-deep-catalog-marker";
+    const deepText =
+      "[".repeat(520) +
+      JSON.stringify({
+        entries: [
+          {
+            name: "@openclaw/env-secondary",
+            openclaw: {
+              channel: { id: deepMarker, preferOver: ["env-primary"] },
+            },
+          },
+        ],
+      }) +
+      "]".repeat(520);
+    fs.writeFileSync(catalogPath, deepText, "utf-8");
+
+    const parseSpy = vi.spyOn(JSON, "parse");
+    try {
+      const result = materializeEnvCatalogCandidates(stateDir);
+
+      // The shared guard rejects the pathological text before any parser
+      // sees it — the over-deep payload never reaches native JSON.parse.
+      const deepParseCalls = parseSpy.mock.calls.filter(
+        ([text]) => typeof text === "string" && text.includes(deepMarker),
+      );
+      expect(deepParseCalls).toHaveLength(0);
+
+      // Fail-open: the skipped catalog does not stall auto-enable, and a
+      // depth violation is a parse-class failure so it logs no warning.
+      expect(result.config.plugins?.entries?.["env-secondary"]?.enabled).toBe(true);
+      expect(logWarnSpy).not.toHaveBeenCalled();
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+
   describe("third-party channel plugins", () => {
     it("activates external channel plugins under plugins.entries when plugin id matches channel id", () => {
       const result = materializePluginAutoEnableCandidates({

--- a/src/config/plugin-auto-enable.prefer-over.ts
+++ b/src/config/plugin-auto-enable.prefer-over.ts
@@ -8,6 +8,7 @@ import { readRegularFileSync } from "../infra/regular-file.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { isRecord, resolveConfigDir, resolveUserPath } from "../utils.js";
+import { parseJsonWithNestingGuard } from "./nesting-limit.js";
 import type { PluginAutoEnableCandidate } from "./plugin-auto-enable.types.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
@@ -92,7 +93,13 @@ function resolveExternalCatalogPreferOver(channelId: string, env: NodeJS.Process
         filePath: resolvedRealPath,
         maxBytes: MAX_EXTERNAL_CATALOG_BYTES,
       });
-      const payload = JSON.parse(buffer.toString("utf-8")) as unknown;
+      // Pre-scan nesting through the shared guard so a pathological catalog
+      // fails as a controlled depth error before the native parser runs.
+      const payload = parseJsonWithNestingGuard(
+        buffer.toString("utf-8"),
+        `External plugin catalog ${resolvedRealPath}`,
+        JSON.parse,
+      );
       const channel = parseExternalCatalogChannelEntries(payload).find(
         (entry) => entry.id === channelId,
       );

--- a/src/logging/config.test.ts
+++ b/src/logging/config.test.ts
@@ -208,6 +208,15 @@ describe("readLoggingConfig", () => {
     });
   });
 
+  it("returns undefined for a deeply-nested config instead of recursing into the parser", () => {
+    // 600 levels exceeds the supported nesting contract; the raw pre-scan must
+    // reject it before JSON.parse can recurse natively.
+    const configPath = writeConfig("[".repeat(600) + "]".repeat(600));
+    withEnv({ OPENCLAW_CONFIG_PATH: configPath }, () => {
+      expect(readLoggingConfig()).toBeUndefined();
+    });
+  });
+
   it("caches a missing config until the path selector changes", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-logging-config-missing-"));
     tempDirs.push(dir);

--- a/src/logging/config.test.ts
+++ b/src/logging/config.test.ts
@@ -4,8 +4,25 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withEnv } from "../test-utils/env.js";
+import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { readLoggingConfig } from "./config.js";
 import { applyLoggingConfig, resetLogger } from "./logger.js";
+
+// Spy on the compatibility parser so depth-limit tests can prove the raw
+// pre-scan rejects pathological input before any parser is reached, while
+// normal configs still flow through the real implementation. The logging
+// shard runs non-isolated in a shared worker whose setup already evaluates
+// the real parse-json-compat module, so the guarded tests re-import config.js
+// after vi.resetModules() for the mock to apply to the production import.
+vi.mock("../utils/parse-json-compat.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../utils/parse-json-compat.js")>();
+  return {
+    ...actual,
+    parseJsonWithJson5Fallback: vi.fn(actual.parseJsonWithJson5Fallback),
+  };
+});
+
+const parseJsonWithJson5FallbackMock = vi.mocked(parseJsonWithJson5Fallback);
 
 const originalArgv = process.argv;
 let tempDirs: string[] = [];
@@ -208,13 +225,28 @@ describe("readLoggingConfig", () => {
     });
   });
 
-  it("returns undefined for a deeply-nested config instead of recursing into the parser", () => {
+  it("returns undefined for a deeply-nested config without invoking the parser", async () => {
     // 600 levels exceeds the supported nesting contract; the raw pre-scan must
-    // reject it before JSON.parse can recurse natively.
+    // reject it before the JSON/JSON5 parser is reached at all.
+    vi.resetModules();
+    const { readLoggingConfig: readFresh } = await import("./config.js");
+    parseJsonWithJson5FallbackMock.mockClear();
     const configPath = writeConfig("[".repeat(600) + "]".repeat(600));
     withEnv({ OPENCLAW_CONFIG_PATH: configPath }, () => {
-      expect(readLoggingConfig()).toBeUndefined();
+      expect(readFresh()).toBeUndefined();
     });
+    expect(parseJsonWithJson5FallbackMock).toHaveBeenCalledTimes(0);
+  });
+
+  it("still routes a shallow config through the compatibility parser", async () => {
+    vi.resetModules();
+    const { readLoggingConfig: readFresh } = await import("./config.js");
+    parseJsonWithJson5FallbackMock.mockClear();
+    const configPath = writeConfig(`{ logging: { consoleStyle: "json" } }`);
+    withEnv({ OPENCLAW_CONFIG_PATH: configPath }, () => {
+      expect(readFresh()).toStrictEqual({ consoleStyle: "json" });
+    });
+    expect(parseJsonWithJson5FallbackMock).toHaveBeenCalledTimes(1);
   });
 
   it("caches a missing config until the path selector changes", () => {

--- a/src/logging/config.ts
+++ b/src/logging/config.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { isRecord as isObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveConfigEnvVars } from "../config/env-substitution.js";
 import { resolveConfigIncludes, resolveConfigIncludesForTopLevelKey } from "../config/includes.js";
+import { assertBoundedRawJsonNesting } from "../config/nesting-limit.js";
 import { resolveConfigPath, resolveIncludeRoots } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { tryProcessCwd } from "../infra/safe-cwd.js";
@@ -95,7 +96,12 @@ export function readLoggingConfig(): LoggingConfig | undefined {
       cachedLoggingConfig = { selector, logging: undefined };
       return undefined;
     }
-    const parsed = parseJsonWithJson5Fallback(fs.readFileSync(configPath, "utf8"));
+    const raw = fs.readFileSync(configPath, "utf8");
+    // Bound raw nesting before the parser: V8's JSON.parse recurses natively and a
+    // pathological config (e.g. a 100k-deep array) would overflow the process stack
+    // instead of reaching this function's catch. The raw scan is iterative and safe.
+    assertBoundedRawJsonNesting(raw, "Config JSON");
+    const parsed = parseJsonWithJson5Fallback(raw);
     const allowedRoots = resolveIncludeRoots();
     let includedConfig: unknown;
     try {

--- a/src/plugin-sdk/facade-activation-check.runtime.ts
+++ b/src/plugin-sdk/facade-activation-check.runtime.ts
@@ -55,7 +55,14 @@ function readFacadeBoundaryConfigSafely(): {
       return { rawConfig: EMPTY_FACADE_BOUNDARY_CONFIG };
     }
     const raw = fs.readFileSync(configPath, "utf8");
-    const parsed = parseJsonWithJson5Fallback(raw);
+    // Shared parser boundary: the no-snapshot fallback reads the configured
+    // raw file directly, so it must pre-scan nesting before the compatibility
+    // parser runs. A native parser overflow would otherwise escape this
+    // function's catch, bypassing the bounded config contract during plugin
+    // activation.
+    const parsed = parseJsonWithNestingGuard(raw, "Facade boundary config JSON", (text) =>
+      parseJsonWithJson5Fallback(text),
+    );
     const rawConfig =
       parsed && typeof parsed === "object"
         ? (parsed as OpenClawConfig)

--- a/src/plugin-sdk/facade-activation-check.runtime.ts
+++ b/src/plugin-sdk/facade-activation-check.runtime.ts
@@ -136,7 +136,13 @@ function readBundledPluginManifestRecordFromDir(params: {
     return null;
   }
   try {
-    const raw = parseJsonWithJson5Fallback(fs.readFileSync(manifestPath, "utf8")) as {
+    const manifestText = fs.readFileSync(manifestPath, "utf8");
+    // Shared parser boundary: bundled manifest text must pre-scan nesting
+    // before the compatibility parser runs, matching the bounded contract
+    // used for boundary config reads during activation.
+    const raw = parseJsonWithNestingGuard(manifestText, "Bundled facade manifest JSON", (text) =>
+      parseJsonWithJson5Fallback(text),
+    ) as {
       id?: unknown;
       enabledByDefault?: unknown;
       channels?: unknown;

--- a/src/plugin-sdk/facade-activation-check.runtime.ts
+++ b/src/plugin-sdk/facade-activation-check.runtime.ts
@@ -3,6 +3,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { parseJsonWithNestingGuard } from "../config/nesting-limit.js";
 import { resolveConfigPath } from "../config/paths.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { configMayNeedPluginAutoEnable } from "../config/plugin-auto-enable.shared.js";

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -960,4 +960,59 @@ describe("plugin-sdk facade runtime", () => {
       clearRuntimeConfigSnapshot();
     }
   });
+
+  it("guards bundled openclaw.plugin.json manifest reads against over-deep payloads", () => {
+    const rootDir = createTrustedBundledFixtureRoot("openclaw-facade-manifest-guard-");
+    const pluginDir = path.join(rootDir, "demo");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    const overDeep =
+      "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) + "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      `{"id":"demo","enabledByDefault":true,"deep":${overDeep}}`,
+      "utf8",
+    );
+
+    // No snapshots and no boundary config file: activation must read the
+    // bundled openclaw.plugin.json directly. The shared guard has to reject
+    // the over-limit manifest before the compatibility parser ever hands it
+    // to a native parser, so the record is treated as missing instead of
+    // enabling the facade.
+    clearRuntimeConfigSnapshot();
+    process.env.OPENCLAW_STATE_DIR = path.join(rootDir, "state");
+    process.env.OPENCLAW_CONFIG_PATH = path.join(rootDir, "missing-openclaw.json");
+    useBundledPluginDirOverrideForTest(rootDir);
+
+    let deepPayloadReachedNativeParse = false;
+    const realJsonParse = JSON.parse.bind(JSON);
+    const parseSpy = vi.spyOn(JSON, "parse").mockImplementation(((
+      text: string,
+      ...rest: unknown[]
+    ) => {
+      if (typeof text === "string" && text.includes(overDeep)) {
+        deepPayloadReachedNativeParse = true;
+      }
+      return realJsonParse(text, ...(rest as [reviver?: never]));
+    }) as typeof JSON.parse);
+    try {
+      const access = resolveActivationCheckBundledPluginPublicSurfaceAccess({
+        dirName: "demo",
+        artifactBasename: "api.js",
+        location: {
+          modulePath: path.join(pluginDir, "api.js"),
+          boundaryRoot: rootDir,
+        },
+        sourceExtensionsRoot: rootDir,
+        resolutionKey: "facade-manifest-guard",
+      });
+      expect(access.allowed).toBe(false);
+      expect(deepPayloadReachedNativeParse).toBe(false);
+      expect(parseSpy).not.toHaveBeenCalledWith(expect.stringContaining(overDeep));
+    } finally {
+      parseSpy.mockRestore();
+      delete process.env.OPENCLAW_CONFIG_PATH;
+      delete process.env.OPENCLAW_STATE_DIR;
+      clearRuntimeConfigSnapshot();
+    }
+  });
 });

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -1,4 +1,14 @@
 // Facade runtime tests cover installed plugin facade loading and fallback resolution.
+//
+// The shared non-isolated runner strips OPENCLAW_CONFIG_PATH from the process
+// env at file collect start (restoreSharedTestHomeAfterEnvUnstub), so a value
+// inherited from the test process can only be observed by seeding it here at
+// module evaluation time — the earliest code that runs after that
+// sanitization. The facade guard tests below must snapshot and restore this
+// pre-existing value instead of unconditionally deleting it; the trailing
+// regression test proves they do.
+const inheritedConfigPathProbe = "inherited-probe-value";
+process.env.OPENCLAW_CONFIG_PATH = inheritedConfigPathProbe;
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -914,6 +924,7 @@ describe("plugin-sdk facade runtime", () => {
   });
 
   it("guards the no-snapshot facade config fallback against over-deep config files", () => {
+    const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
     const dir = createTempDirSync("openclaw-facade-guard-fallback-");
     const stateDir = path.join(dir, "state");
     const configPath = path.join(dir, "openclaw.json");
@@ -955,13 +966,18 @@ describe("plugin-sdk facade runtime", () => {
       expect(parseSpy).not.toHaveBeenCalledWith(expect.stringContaining(overDeep));
     } finally {
       parseSpy.mockRestore();
-      delete process.env.OPENCLAW_CONFIG_PATH;
+      if (originalConfigPath === undefined) {
+        delete process.env.OPENCLAW_CONFIG_PATH;
+      } else {
+        process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
+      }
       delete process.env.OPENCLAW_STATE_DIR;
       clearRuntimeConfigSnapshot();
     }
   });
 
   it("guards bundled openclaw.plugin.json manifest reads against over-deep payloads", () => {
+    const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
     const rootDir = createTrustedBundledFixtureRoot("openclaw-facade-manifest-guard-");
     const pluginDir = path.join(rootDir, "demo");
     fs.mkdirSync(pluginDir, { recursive: true });
@@ -1010,9 +1026,17 @@ describe("plugin-sdk facade runtime", () => {
       expect(parseSpy).not.toHaveBeenCalledWith(expect.stringContaining(overDeep));
     } finally {
       parseSpy.mockRestore();
-      delete process.env.OPENCLAW_CONFIG_PATH;
+      if (originalConfigPath === undefined) {
+        delete process.env.OPENCLAW_CONFIG_PATH;
+      } else {
+        process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
+      }
       delete process.env.OPENCLAW_STATE_DIR;
       clearRuntimeConfigSnapshot();
     }
+  });
+
+  it("preserves an inherited OPENCLAW_CONFIG_PATH across facade guard tests", () => {
+    expect(process.env.OPENCLAW_CONFIG_PATH).toBe(inheritedConfigPathProbe);
   });
 });

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
+import { MAX_CONFIG_JSON_NESTING_DEPTH } from "../config/nesting-limit.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createPluginActivationSource, normalizePluginsConfig } from "../plugins/config-state.js";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
@@ -910,5 +911,53 @@ describe("plugin-sdk facade runtime", () => {
       allowed: true,
       pluginId: "demo-snapshot",
     });
+  });
+
+  it("guards the no-snapshot facade config fallback against over-deep config files", () => {
+    const dir = createTempDirSync("openclaw-facade-guard-fallback-");
+    const stateDir = path.join(dir, "state");
+    const configPath = path.join(dir, "openclaw.json");
+    const overDeep =
+      "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) + "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(configPath, `{"plugins":${overDeep}}`, "utf8");
+
+    // No runtime or source snapshot: the facade must read the configured raw
+    // file directly. The shared guard has to reject the over-limit payload
+    // before the compatibility parser ever hands it to a native parser.
+    clearRuntimeConfigSnapshot();
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+    useBundledPluginDirOverrideForTest(dir);
+
+    let deepPayloadReachedNativeParse = false;
+    const realJsonParse = JSON.parse.bind(JSON);
+    const parseSpy = vi.spyOn(JSON, "parse").mockImplementation(((
+      text: string,
+      ...rest: unknown[]
+    ) => {
+      if (typeof text === "string" && text.includes(overDeep)) {
+        deepPayloadReachedNativeParse = true;
+        throw new Error("native JSON.parse must not be reached for over-limit facade config");
+      }
+      return realJsonParse(text, ...(rest as [reviver?: never]));
+    }) as typeof JSON.parse);
+    try {
+      const access = resolveActivationCheckBundledPluginPublicSurfaceAccess({
+        dirName: "facade-guard-fallback-demo",
+        artifactBasename: "api.js",
+        location: null,
+        sourceExtensionsRoot: dir,
+        resolutionKey: "facade-guard-fallback",
+      });
+      expect(access.allowed).toBe(false);
+      expect(deepPayloadReachedNativeParse).toBe(false);
+      expect(parseSpy).not.toHaveBeenCalledWith(expect.stringContaining(overDeep));
+    } finally {
+      parseSpy.mockRestore();
+      delete process.env.OPENCLAW_CONFIG_PATH;
+      delete process.env.OPENCLAW_STATE_DIR;
+      clearRuntimeConfigSnapshot();
+    }
   });
 });

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -6,12 +6,16 @@
 // module evaluation time — the earliest code that runs after that
 // sanitization. The facade guard tests below must snapshot and restore this
 // pre-existing value instead of unconditionally deleting it; the trailing
-// regression test proves they do.
+// regression test proves they do. Because the seed is a module-level
+// assignment, this file must undo it itself: the afterAll hook (and the
+// trailing test's own end-of-file restore) put the pre-seed environment back
+// so the synthetic value cannot leak into later files sharing the worker.
 const inheritedConfigPathProbe = "inherited-probe-value";
+const originalConfigPathBeforeSeed = process.env.OPENCLAW_CONFIG_PATH;
 process.env.OPENCLAW_CONFIG_PATH = inheritedConfigPathProbe;
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
 import { MAX_CONFIG_JSON_NESTING_DEPTH } from "../config/nesting-limit.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -125,6 +129,18 @@ afterEach(() => {
   } else {
     process.env.OPENCLAW_STATE_DIR = originalStateDir;
   }
+});
+
+function restoreSeededConfigPath(): void {
+  if (originalConfigPathBeforeSeed === undefined) {
+    delete process.env.OPENCLAW_CONFIG_PATH;
+  } else {
+    process.env.OPENCLAW_CONFIG_PATH = originalConfigPathBeforeSeed;
+  }
+}
+
+afterAll(() => {
+  restoreSeededConfigPath();
 });
 
 describe("plugin-sdk facade runtime", () => {
@@ -1036,7 +1052,13 @@ describe("plugin-sdk facade runtime", () => {
     }
   });
 
-  it("preserves an inherited OPENCLAW_CONFIG_PATH across facade guard tests", () => {
+  it("restores the process environment after facade guard tests", () => {
+    // The guard tests above must restore this file's seeded probe rather than
+    // unconditionally deleting it or leaving their own config paths behind.
     expect(process.env.OPENCLAW_CONFIG_PATH).toBe(inheritedConfigPathProbe);
+    // End-of-file: undo the module-level seed so later files sharing the
+    // worker observe the pre-seed environment instead of this synthetic value.
+    restoreSeededConfigPath();
+    expect(process.env.OPENCLAW_CONFIG_PATH).toBe(originalConfigPathBeforeSeed);
   });
 });

--- a/src/plugins/bundle-manifest.test.ts
+++ b/src/plugins/bundle-manifest.test.ts
@@ -1,7 +1,8 @@
 /** Tests bundle manifest parsing for Agent, Codex, Claude, Cursor, and OpenClaw formats. */
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MAX_CONFIG_JSON_NESTING_DEPTH } from "../config/nesting-limit.js";
 import {
   AGENT_BUNDLE_MANIFEST_RELATIVE_PATH,
   CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH,
@@ -769,5 +770,58 @@ describe("bundle manifest parsing", () => {
     });
 
     expect(detectBundleManifestFormat(rootDir)).toBeNull();
+  });
+
+  describe("manifest nesting guard", () => {
+    it.each([
+      {
+        bundleFormat: "agent",
+        manifestRelativePath: AGENT_BUNDLE_MANIFEST_RELATIVE_PATH,
+      },
+      {
+        bundleFormat: "codex",
+        manifestRelativePath: CODEX_BUNDLE_MANIFEST_RELATIVE_PATH,
+      },
+      {
+        bundleFormat: "cursor",
+        manifestRelativePath: CURSOR_BUNDLE_MANIFEST_RELATIVE_PATH,
+      },
+    ] as const)(
+      "rejects over-deep $bundleFormat bundle manifests via the shared nesting guard without invoking the parser",
+      ({ bundleFormat, manifestRelativePath }) => {
+        const rootDir = makeTempDir();
+        setupBundleFixture({
+          rootDir,
+          dirs: [path.dirname(manifestRelativePath)],
+          textFiles: {
+            [manifestRelativePath]:
+              "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) +
+              "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) +
+              "\n",
+          },
+        });
+
+        // Prove the guard rejects raw text before any native parser runs.
+        const parseSpy = vi.spyOn(JSON, "parse").mockImplementation(() => {
+          throw new Error("native JSON.parse must not be reached for over-limit manifests");
+        });
+        try {
+          const result = loadBundleManifest({ rootDir, bundleFormat });
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain(
+              `exceeds the maximum supported nesting depth of ${MAX_CONFIG_JSON_NESTING_DEPTH}`,
+            );
+            expect(result.error).toContain("(measured ");
+            expect(result.error).not.toContain(
+              "native JSON.parse must not be reached for over-limit manifests",
+            );
+          }
+          expect(parseSpy).not.toHaveBeenCalled();
+        } finally {
+          parseSpy.mockRestore();
+        }
+      },
+    );
   });
 });

--- a/src/plugins/bundle-manifest.ts
+++ b/src/plugins/bundle-manifest.ts
@@ -7,6 +7,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeUniqueSingleOrTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import JSON5 from "json5";
+import { parseJsonWithNestingGuard } from "../config/nesting-limit.js";
 import { matchRootFileOpenFailure } from "../infra/boundary-file-read.js";
 import { readRootStructuredFileSync } from "../infra/json-files.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -113,7 +114,16 @@ function loadBundleManifestFile(params: {
     boundaryLabel: "plugin root",
     rejectHardlinks: params.rejectHardlinks,
     ...(params.maxBytes !== undefined ? { maxBytes: params.maxBytes } : {}),
-    parse: (raw) => (params.strictJson ? JSON.parse(raw) : JSON5.parse(raw)),
+    parse: (raw) =>
+      // Shared parser boundary: manifest text is scanned for over-deep
+      // nesting before any parser runs, so a pathological bundle manifest
+      // fails as a controlled depth error instead of overflowing the
+      // native parser stack (agent manifests use strict JSON.parse).
+      parseJsonWithNestingGuard(
+        raw,
+        `plugin manifest ${params.manifestRelativePath}`,
+        params.strictJson ? JSON.parse : JSON5.parse,
+      ),
     validate: isRecord,
   });
   if (!result.ok && result.reason === "open") {

--- a/src/plugins/install-persistence.nesting-guard.test.ts
+++ b/src/plugins/install-persistence.nesting-guard.test.ts
@@ -1,0 +1,61 @@
+// Plugin install persistence preflight tests for the shared JSON nesting guard:
+// over-deep included configs must be rejected by the pre-scan before any
+// parser runs (a native parse of a pathological include cannot be contained
+// by a JS try/catch). Split from install-persistence.test.ts to stay under
+// the oxlint max-lines limit for test files.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { MAX_CONFIG_JSON_NESTING_DEPTH } from "../config/nesting-limit.js";
+
+describe("resolveInstallConfigMutationPreflights include nesting guard", () => {
+  it("blocks over-deep included configs at the preflight instead of parsing them natively", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-install-preflight-nesting-"));
+    try {
+      const configPath = path.join(tempRoot, "openclaw.json");
+      const includePath = path.join(tempRoot, "plugins.json5");
+      const overDeep =
+        "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) +
+        "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+      const includeRaw = `{"plugins":{"allow":${overDeep}}}`;
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({ plugins: { $include: "plugins.json5" } }),
+        "utf8",
+      );
+      fs.writeFileSync(includePath, includeRaw, "utf8");
+
+      const { resolveInstallConfigMutationPreflights } = await import("./install-persistence.js");
+      const { hashConfigIncludeRaw, resolveConfigIncludeWritePath } =
+        await import("../config/includes.js");
+      const resolvedTarget = resolveConfigIncludeWritePath({
+        configPath,
+        includePath,
+        allowedRoots: [],
+      });
+
+      const preflights = resolveInstallConfigMutationPreflights({
+        parsed: { plugins: { $include: "plugins.json5" } } as unknown as Record<string, unknown>,
+        snapshotPath: configPath,
+        writeOptions: {
+          includeFileHashesForWrite: { [includePath]: hashConfigIncludeRaw(includeRaw) },
+          includeFileTargetsForWrite: { [includePath]: resolvedTarget },
+        },
+      });
+
+      // Controlled blocked outcome: the shared pre-scan rejects the over-deep
+      // include before any parser runs, so it lands in the existing
+      // "could not be inspected" blocked-preflight handling instead of a
+      // native parse (which no JS try/catch can contain).
+      expect(preflights.pluginMutation.mode).toBe("blocked");
+      if (preflights.pluginMutation.mode === "blocked") {
+        expect(preflights.pluginMutation.reason).toContain(
+          "could not be inspected at its snapshot target",
+        );
+      }
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/plugins/install-persistence.test.ts
+++ b/src/plugins/install-persistence.test.ts
@@ -21,6 +21,7 @@ import {
   applyPluginUninstallDirectoryRemovalMock,
 } from "../cli/plugins-cli-test-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { MAX_CONFIG_JSON_NESTING_DEPTH } from "../config/nesting-limit.js";
 import { hasRetainedManagedNpmInstallMarker } from "./managed-npm-retention.js";
 import { recordPluginManifestInstallOwner } from "./manifest-install-owner.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
@@ -1055,5 +1056,55 @@ describe("persistPluginInstall", () => {
     expect(next.plugins?.allow).toEqual(["memory-core"]);
     expect(next.plugins?.deny).toEqual(["memory-lancedb"]);
     expect(next.plugins?.entries?.["memory-lancedb"]).toBeUndefined();
+  });
+});
+
+describe("resolveInstallConfigMutationPreflights include nesting guard", () => {
+  it("blocks over-deep included configs at the preflight instead of parsing them natively", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-install-preflight-nesting-"));
+    try {
+      const configPath = path.join(tempRoot, "openclaw.json");
+      const includePath = path.join(tempRoot, "plugins.json5");
+      const overDeep =
+        "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) +
+        "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+      const includeRaw = `{"plugins":{"allow":${overDeep}}}`;
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({ plugins: { $include: "plugins.json5" } }),
+        "utf8",
+      );
+      fs.writeFileSync(includePath, includeRaw, "utf8");
+
+      const { resolveInstallConfigMutationPreflights } = await import("./install-persistence.js");
+      const { hashConfigIncludeRaw, resolveConfigIncludeWritePath } = await import(
+        "../config/includes.js"
+      );
+      const resolvedTarget = resolveConfigIncludeWritePath({
+        configPath,
+        includePath,
+        allowedRoots: [],
+      });
+
+      const preflights = resolveInstallConfigMutationPreflights({
+        parsed: { plugins: { $include: "plugins.json5" } } as unknown as Record<string, unknown>,
+        snapshotPath: configPath,
+        writeOptions: {
+          includeFileHashesForWrite: { [includePath]: hashConfigIncludeRaw(includeRaw) },
+          includeFileTargetsForWrite: { [includePath]: resolvedTarget },
+        },
+      });
+
+      // Controlled blocked outcome: the shared pre-scan rejects the over-deep
+      // include before any parser runs, so it lands in the existing
+      // "could not be inspected" blocked-preflight handling instead of a
+      // native parse (which no JS try/catch can contain).
+      expect(preflights.pluginMutation.mode).toBe("blocked");
+      expect(preflights.pluginMutation.reason).toContain(
+        "could not be inspected at its snapshot target",
+      );
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/src/plugins/install-persistence.test.ts
+++ b/src/plugins/install-persistence.test.ts
@@ -1099,9 +1099,11 @@ describe("resolveInstallConfigMutationPreflights include nesting guard", () => {
       // "could not be inspected" blocked-preflight handling instead of a
       // native parse (which no JS try/catch can contain).
       expect(preflights.pluginMutation.mode).toBe("blocked");
-      expect(preflights.pluginMutation.reason).toContain(
-        "could not be inspected at its snapshot target",
-      );
+      if (preflights.pluginMutation.mode === "blocked") {
+        expect(preflights.pluginMutation.reason).toContain(
+          "could not be inspected at its snapshot target",
+        );
+      }
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/src/plugins/install-persistence.test.ts
+++ b/src/plugins/install-persistence.test.ts
@@ -1077,9 +1077,8 @@ describe("resolveInstallConfigMutationPreflights include nesting guard", () => {
       fs.writeFileSync(includePath, includeRaw, "utf8");
 
       const { resolveInstallConfigMutationPreflights } = await import("./install-persistence.js");
-      const { hashConfigIncludeRaw, resolveConfigIncludeWritePath } = await import(
-        "../config/includes.js"
-      );
+      const { hashConfigIncludeRaw, resolveConfigIncludeWritePath } =
+        await import("../config/includes.js");
       const resolvedTarget = resolveConfigIncludeWritePath({
         configPath,
         includePath,

--- a/src/plugins/install-persistence.test.ts
+++ b/src/plugins/install-persistence.test.ts
@@ -21,7 +21,6 @@ import {
   applyPluginUninstallDirectoryRemovalMock,
 } from "../cli/plugins-cli-test-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { MAX_CONFIG_JSON_NESTING_DEPTH } from "../config/nesting-limit.js";
 import { hasRetainedManagedNpmInstallMarker } from "./managed-npm-retention.js";
 import { recordPluginManifestInstallOwner } from "./manifest-install-owner.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
@@ -1056,56 +1055,5 @@ describe("persistPluginInstall", () => {
     expect(next.plugins?.allow).toEqual(["memory-core"]);
     expect(next.plugins?.deny).toEqual(["memory-lancedb"]);
     expect(next.plugins?.entries?.["memory-lancedb"]).toBeUndefined();
-  });
-});
-
-describe("resolveInstallConfigMutationPreflights include nesting guard", () => {
-  it("blocks over-deep included configs at the preflight instead of parsing them natively", async () => {
-    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-install-preflight-nesting-"));
-    try {
-      const configPath = path.join(tempRoot, "openclaw.json");
-      const includePath = path.join(tempRoot, "plugins.json5");
-      const overDeep =
-        "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) +
-        "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
-      const includeRaw = `{"plugins":{"allow":${overDeep}}}`;
-      fs.writeFileSync(
-        configPath,
-        JSON.stringify({ plugins: { $include: "plugins.json5" } }),
-        "utf8",
-      );
-      fs.writeFileSync(includePath, includeRaw, "utf8");
-
-      const { resolveInstallConfigMutationPreflights } = await import("./install-persistence.js");
-      const { hashConfigIncludeRaw, resolveConfigIncludeWritePath } =
-        await import("../config/includes.js");
-      const resolvedTarget = resolveConfigIncludeWritePath({
-        configPath,
-        includePath,
-        allowedRoots: [],
-      });
-
-      const preflights = resolveInstallConfigMutationPreflights({
-        parsed: { plugins: { $include: "plugins.json5" } } as unknown as Record<string, unknown>,
-        snapshotPath: configPath,
-        writeOptions: {
-          includeFileHashesForWrite: { [includePath]: hashConfigIncludeRaw(includeRaw) },
-          includeFileTargetsForWrite: { [includePath]: resolvedTarget },
-        },
-      });
-
-      // Controlled blocked outcome: the shared pre-scan rejects the over-deep
-      // include before any parser runs, so it lands in the existing
-      // "could not be inspected" blocked-preflight handling instead of a
-      // native parse (which no JS try/catch can contain).
-      expect(preflights.pluginMutation.mode).toBe("blocked");
-      if (preflights.pluginMutation.mode === "blocked") {
-        expect(preflights.pluginMutation.reason).toContain(
-          "could not be inspected at its snapshot target",
-        );
-      }
-    } finally {
-      fs.rmSync(tempRoot, { recursive: true, force: true });
-    }
   });
 });

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -10,6 +10,7 @@ import {
 } from "../config/includes.js";
 import type { ConfigWriteOptions } from "../config/io.js";
 import { containsConfigIncludeDirective } from "../config/io.read-helpers.js";
+import { parseJsonWithNestingGuard } from "../config/nesting-limit.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { isPathInside } from "../infra/path-guards.js";
@@ -195,7 +196,16 @@ function resolveConfigMutationPreflight(params: {
           reason: `Config ${params.section} include changed since the config was read; rerun the install after reloading the config.`,
         };
       }
-      if (containsConfigIncludeDirective(parseJsonWithJson5Fallback(raw))) {
+      // Shared parser boundary: the include preflight must pre-scan nesting
+      // before parsing so an over-deep included config lands in the existing
+      // blocked preflight handling instead of a raw parser failure.
+      if (
+        containsConfigIncludeDirective(
+          parseJsonWithNestingGuard(raw, `Include file ${includePath}`, (text) =>
+            parseJsonWithJson5Fallback(text),
+          ),
+        )
+      ) {
         return {
           mode: "blocked",
           scope: params.section,

--- a/src/plugins/manifest-metadata-scan.test.ts
+++ b/src/plugins/manifest-metadata-scan.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_CONFIG_JSON_NESTING_DEPTH } from "../config/nesting-limit.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store-write.js";
 import { listOpenClawPluginManifestMetadata } from "./manifest-metadata-scan.js";
 import { loadPluginManifest } from "./manifest.js";
@@ -394,5 +395,41 @@ describe("listOpenClawPluginManifestMetadata", () => {
     });
 
     expect(records.find((record) => record.manifest.id === "exact-plugin")).toBeTruthy();
+  });
+
+  it("ignores over-deep manifests via the shared nesting guard during metadata scan", () => {
+    const { pluginDir, manifestPath, env } = createGlobalPluginFixture("deep-scan-plugin");
+    const overDeep =
+      "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) + "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+    fs.writeFileSync(
+      manifestPath,
+      `{"id":"deep-scan-plugin","configSchema":{"deep":${overDeep}}}`,
+      "utf8",
+    );
+
+    // The scan still legitimately parses other manifests (for example the
+    // source-checkout tree), so only flag native-parser calls that receive the
+    // over-limit payload.
+    let deepPayloadReachedNativeParse = false;
+    const realJsonParse = JSON.parse.bind(JSON);
+    const parseSpy = vi.spyOn(JSON, "parse").mockImplementation(((
+      text: string,
+      ...rest: unknown[]
+    ) => {
+      if (typeof text === "string" && text.includes(overDeep)) {
+        deepPayloadReachedNativeParse = true;
+        throw new Error("native JSON.parse must not be reached for over-limit manifests");
+      }
+      return realJsonParse(text, ...(rest as [reviver?: never]));
+    }) as typeof JSON.parse);
+    try {
+      expectPluginAbsentAcrossTwoScans(pluginDir, env);
+      expect(deepPayloadReachedNativeParse).toBe(false);
+      expect(warningMessagesForPath(manifestPath).join("\n")).toContain(
+        `exceeds the maximum supported nesting depth of ${MAX_CONFIG_JSON_NESTING_DEPTH}`,
+      );
+    } finally {
+      parseSpy.mockRestore();
+    }
   });
 });

--- a/src/plugins/manifest-metadata-scan.ts
+++ b/src/plugins/manifest-metadata-scan.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString as normalizeTrimmedString } from "@openclaw/normalization-core/string-coerce";
+import { parseJsonWithNestingGuard } from "../config/nesting-limit.js";
 import { resolveRealpathOrAbsolute } from "../infra/boundary-path.js";
 import { resolveHomeRelativePath } from "../infra/home-dir.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
@@ -95,7 +96,11 @@ function readJsonObject(filePath: string): Record<string, unknown> | undefined {
 
   let parsed: unknown;
   try {
-    parsed = parseJsonWithJson5Fallback(raw);
+    // Shared parser boundary: discovery must reject over-limit manifests
+    // before any native parser runs, mirroring the canonical loader.
+    parsed = parseJsonWithNestingGuard(raw, `plugin manifest ${filePath}`, (text) =>
+      parseJsonWithJson5Fallback(text),
+    );
   } catch (error) {
     log.warn(
       `Ignoring invalid plugin manifest at ${filePath}: failed to parse plugin manifest: ${String(error)}`,

--- a/src/plugins/manifest.json5-tolerance.test.ts
+++ b/src/plugins/manifest.json5-tolerance.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { MAX_CONFIG_JSON_NESTING_DEPTH } from "../config/nesting-limit.js";
 import { resolveMemorySlotDecision } from "./config-state.js";
 import { loadPluginManifest } from "./manifest.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
@@ -410,6 +411,35 @@ describe("loadPluginManifest JSON5 tolerance", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain("plugin manifest must be an object");
+    }
+  });
+
+  it("rejects over-deep manifests via the shared nesting guard without invoking the parser", () => {
+    const dir = makeTempDir();
+    const overDeep =
+      "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) + "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      `{"id":"deep-manifest","configSchema":{"deep":${overDeep}}}`,
+      "utf-8",
+    );
+
+    // Prove the guard rejects raw text before any native parser runs.
+    const parseSpy = vi.spyOn(JSON, "parse").mockImplementation(() => {
+      throw new Error("native JSON.parse must not be reached for over-limit manifests");
+    });
+    try {
+      const result = loadPluginManifest(dir, false);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain("failed to parse plugin manifest");
+        expect(result.error).toContain(
+          `exceeds the maximum supported nesting depth of ${MAX_CONFIG_JSON_NESTING_DEPTH}`,
+        );
+      }
+      expect(parseSpy).not.toHaveBeenCalled();
+    } finally {
+      parseSpy.mockRestore();
     }
   });
 });

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { normalizeModelCatalog } from "@openclaw/model-catalog-core/model-catalog-normalize";
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
 import { normalizeTrimmedStringList } from "../../packages/normalization-core/src/string-normalization.js";
+import { parseJsonWithNestingGuard } from "../config/nesting-limit.js";
 import { matchRootFileOpenFailure, openRootFileSync } from "../infra/boundary-file-read.js";
 import { isRecord } from "../utils.js";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
@@ -237,7 +238,14 @@ export function loadPluginManifest(
   };
   let raw: unknown;
   try {
-    raw = parseJsonWithJson5Fallback(fs.readFileSync(opened.fd, "utf-8"));
+    // Shared parser boundary: canonical plugin manifests must never hand raw
+    // text to a native parser before the nesting pre-scan, so an over-limit
+    // manifest fails as a controlled depth error instead of a stack overflow.
+    raw = parseJsonWithNestingGuard(
+      fs.readFileSync(opened.fd, "utf-8"),
+      `plugin manifest ${manifestPath}`,
+      (text) => parseJsonWithJson5Fallback(text),
+    );
   } catch (err) {
     return cacheResult({
       ok: false,

--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -1,3 +1,4 @@
+import { parseJsonWithNestingGuard } from "../config/nesting-limit.js";
 import {
   normalizeEd25519PublicKeyBase64Url,
   verifyEd25519SignatureBytes,
@@ -260,7 +261,11 @@ function decodeOfficialExternalPluginCatalogEnvelopePayload(
   payloadBytes: Buffer,
 ): { raw: unknown; feed: OfficialExternalPluginCatalogFeed | null } | null {
   try {
-    const raw = JSON.parse(payloadBytes.toString("utf8")) as unknown;
+    const raw = parseJsonWithNestingGuard(
+      payloadBytes.toString("utf8"),
+      "hosted catalog signed feed payload",
+      JSON.parse,
+    ) as unknown;
     return {
       raw,
       feed: isOfficialExternalPluginCatalogFeed(raw) ? raw : null,

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -1,6 +1,7 @@
 /** Persists hosted official external plugin catalog snapshots in OpenClaw state. */
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
+import { parseJsonWithNestingGuard } from "../config/nesting-limit.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -115,7 +116,7 @@ function decodeBase64Payload(payload: string): string {
 
 function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicState | undefined {
   try {
-    const document = JSON.parse(body) as {
+    const document = parseJsonWithNestingGuard(body, "hosted catalog snapshot", JSON.parse) as {
       payload?: unknown;
       sequence?: unknown;
       generatedAt?: unknown;
@@ -124,7 +125,7 @@ function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicS
       typeof document.payload === "string" ? decodeBase64Payload(document.payload) : body;
     const feed =
       typeof document.payload === "string"
-        ? (JSON.parse(payload) as {
+        ? (parseJsonWithNestingGuard(payload, "hosted catalog snapshot payload", JSON.parse) as {
             sequence?: unknown;
             generatedAt?: unknown;
           })

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import officialExternalChannelCatalog from "../../scripts/lib/official-external-channel-catalog.json" with { type: "json" };
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import officialExternalProviderCatalog from "../../scripts/lib/official-external-provider-catalog.json" with { type: "json" };
+import { MAX_CONFIG_JSON_NESTING_DEPTH } from "../config/nesting-limit.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import type { PluginPackageInstall } from "./manifest.js";
 import { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } from "./official-external-plugin-catalog-snapshot-store.js";
@@ -318,6 +319,18 @@ function dsseResponse(body: BodyInit | null, init: ResponseInit = {}): Response 
   const headers = new Headers(init.headers);
   headers.set("content-type", "application/vnd.dsse+json");
   return new Response(body, { ...init, headers });
+}
+
+function deeplyNestedJsonText(depth: number): string {
+  return "[".repeat(depth) + "]".repeat(depth);
+}
+
+function buildDeeplyNestedArray(depth: number): unknown {
+  let value: unknown = 0;
+  for (let index = 0; index < depth; index += 1) {
+    value = [value];
+  }
+  return value;
 }
 
 describe("official external plugin catalog", () => {
@@ -2674,6 +2687,91 @@ describe("official external plugin catalog", () => {
       minHostVersion: ">=2026.4.10",
       allowInvalidConfigRecovery: true,
     });
+  });
+
+  it("rejects over-deep hosted catalog response bodies before the native parser runs", async () => {
+    const deepBody = deeplyNestedJsonText(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+    const parseSpy = vi.spyOn(JSON, "parse");
+    try {
+      const result = await loadHostedCatalog({
+        catalogConfig: {
+          feeds: {
+            "clawhub-public": {
+              url: "https://clawhub.ai/v1/feeds/plugins",
+              feedId: "clawhub-official",
+              verification: { mode: "unsigned" },
+            },
+          },
+        },
+        fetchImpl: vi.fn(async () => new Response(deepBody, { status: 200 })),
+        snapshotStore: null,
+      });
+
+      expectBundledFallback(result);
+      expect(result.error).toMatch(/nesting depth/i);
+      expect(parseSpy).not.toHaveBeenCalledWith(deepBody);
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+
+  it("rejects signed hosted catalog responses with over-deep payloads before the native parser runs", async () => {
+    const deepPayloadValue = buildDeeplyNestedArray(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+    const deepPayloadJson = JSON.stringify(deepPayloadValue);
+    const signed = signedHostedCatalogFeed({
+      feed: deepPayloadValue as unknown as OfficialExternalPluginCatalogFeed,
+    });
+    const parseSpy = vi.spyOn(JSON, "parse");
+    try {
+      const result = await loadHostedCatalog({
+        feedProfile: "acme",
+        catalogConfig: signedCatalogConfig(signed.publicKeyPem),
+        fetchImpl: vi.fn(async () => dsseResponse(signed.body, { status: 200 })),
+        snapshotStore: null,
+      });
+
+      expectBundledFallback(result);
+      expect(parseSpy).not.toHaveBeenCalledWith(deepPayloadJson);
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+
+  it("keeps over-deep snapshot bodies away from the native parser during monotonicity reads", async () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-deep-snapshot-"));
+    const url = "https://packages.acme.example/openclaw/feed";
+    const deepBody = deeplyNestedJsonText(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+    const snapshotStore = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
+      stateDir,
+    });
+    const parseSpy = vi.spyOn(JSON, "parse");
+    try {
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: deepBody,
+          monotonic: { sequence: 10, generatedAt: "2026-06-22T00:00:10.000Z" },
+        }),
+      );
+      const snapshot = await snapshotStore.read(url);
+      expect(snapshot?.body).toBe(deepBody);
+      expect(snapshot?.monotonic).toBeUndefined();
+      expect(parseSpy).not.toHaveBeenCalledWith(deepBody);
+
+      const next = signedHostedCatalogFeed({
+        feed: hostedCatalogFeed({ sequence: 11, pluginName: "@openclaw/deep-snapshot-next" }),
+      });
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: next.body,
+          monotonic: { sequence: 11, generatedAt: "2026-06-22T00:00:11.000Z" },
+        }),
+      );
+      expect(parseSpy).not.toHaveBeenCalledWith(deepBody);
+    } finally {
+      parseSpy.mockRestore();
+      closeOpenClawStateDatabaseForTest();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
+import { parseJsonWithNestingGuard } from "../config/nesting-limit.js";
 import { normalizeClawHubSha256Integrity } from "../infra/clawhub-artifacts.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { cancelUnreadResponseBody, readResponseWithLimit } from "../infra/http-body.js";
@@ -757,7 +758,7 @@ async function parseHostedCatalogFeedBody(params: {
   trust?: HostedOfficialExternalPluginCatalogTrustState;
   expired?: boolean;
 }> {
-  const raw = JSON.parse(params.body) as unknown;
+  const raw = parseJsonWithNestingGuard(params.body, "hosted catalog feed", JSON.parse) as unknown;
   if (params.verification?.mode === "signed") {
     const { verifyOfficialExternalPluginCatalogSignedEnvelope } =
       await import("./official-external-plugin-catalog-envelope.js");

--- a/src/security/audit-config-include-perms.test.ts
+++ b/src/security/audit-config-include-perms.test.ts
@@ -1,10 +1,22 @@
 // Covers config include-file permission audit findings.
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { MAX_CONFIG_JSON_NESTING_DEPTH } from "../config/nesting-limit.js";
 import type { ConfigFileSnapshot } from "../config/types.openclaw.js";
+import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { collectIncludeFilePermFindings } from "./audit-extra.async.js";
+
+// Spy on the JSON5 compatibility parser so audit regressions can prove that
+// over-limit include text never reaches the native parser.
+vi.mock("../utils/parse-json-compat.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../utils/parse-json-compat.js")>();
+  return {
+    ...mod,
+    parseJsonWithJson5Fallback: vi.fn(mod.parseJsonWithJson5Fallback),
+  };
+});
 
 describe("security audit config include permissions", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -88,4 +100,43 @@ describe("security audit config include permissions", () => {
       ]);
     },
   );
+
+  it("handles deeply-nested included files without invoking the parser", async () => {
+    const tmp = tempDirs.make("openclaw-include-perms-nesting-");
+    const stateDir = path.join(tmp, "state");
+    fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+
+    const includePath = path.join(stateDir, "deep.json5");
+    const deepRaw =
+      "[".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1) + "]".repeat(MAX_CONFIG_JSON_NESTING_DEPTH + 1);
+    fs.writeFileSync(includePath, `${deepRaw}\n`, "utf-8");
+
+    const parserSpy = vi.mocked(parseJsonWithJson5Fallback);
+    parserSpy.mockClear();
+
+    const configSnapshot: ConfigFileSnapshot = {
+      path: path.join(stateDir, "openclaw.json"),
+      exists: true,
+      raw: `{ "$include": ${JSON.stringify(includePath)} }\n`,
+      parsed: { $include: includePath },
+      sourceConfig: {} as ConfigFileSnapshot["sourceConfig"],
+      resolved: {} as ConfigFileSnapshot["resolved"],
+      valid: true,
+      runtimeConfig: {} as ConfigFileSnapshot["runtimeConfig"],
+      config: {} as ConfigFileSnapshot["config"],
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    };
+
+    // Controlled outcome: the audit completes without ever handing the
+    // over-limit include text to the native parser.
+    const findings = await collectIncludeFilePermFindings({
+      configSnapshot,
+      platform: "linux",
+    });
+
+    expect(parserSpy).not.toHaveBeenCalled();
+    expect(findings).toBeInstanceOf(Array);
+  });
 });

--- a/test/tsconfig/tsconfig.core.test.config-cli.json
+++ b/test/tsconfig/tsconfig.core.test.config-cli.json
@@ -7,6 +7,8 @@
     "../../src/config/**/*.test.ts",
     "../../src/config/**/*.test.tsx",
     "../../src/cli/**/*.test.ts",
-    "../../src/cli/**/*.test.tsx"
+    "../../src/cli/**/*.test.tsx",
+    "../../src/logging/**/*.test.ts",
+    "../../src/logging/**/*.test.tsx"
   ]
 }

--- a/test/tsconfig/tsconfig.core.test.plugins-platform.json
+++ b/test/tsconfig/tsconfig.core.test.plugins-platform.json
@@ -16,8 +16,6 @@
     "../../src/media/**/*.test.tsx",
     "../../src/system-agent/**/*.test.ts",
     "../../src/system-agent/**/*.test.tsx",
-    "../../src/logging/**/*.test.ts",
-    "../../src/logging/**/*.test.tsx",
     "../../src/hooks/**/*.test.ts",
     "../../src/hooks/**/*.test.tsx",
     "../../src/daemon/**/*.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Feeding deeply-nested JSON to `config validate`, `secrets apply --from`, or `config set --strict-json` crashes the OpenClaw CLI with a native stack overflow (Windows exit `3221225725` / `0xC00000FD` `STATUS_STACK_OVERFLOW`) instead of a wrapped `[openclaw]` validation error, because:

1. **Native parser recursion** — V8's `JSON.parse` recurses natively, and a pathological config (e.g. a 100k-deep array) overflows the process stack. A native overflow is invisible to JS `try/catch`, so the CLI dies with empty stdout/stderr and no error wrapper. The crash reproduces under the Windows respawn stack (`--stack-size=8192`); the default thread stack happens to survive far deeper inputs, which is why it only surfaces in the real CLI runtime.
2. **Unbounded post-parse walks** — `$include` resolution, environment substitution, include-directive probing, and env-ref collection recurse over the parsed structure without a depth bound (a second overflow class).
3. **Unguarded startup parse** — the lightweight startup logging-config reader (`readLoggingConfig`) parses the raw config file before the guarded config path ever runs, so the process could still die during CLI bootstrap even after the main config path was guarded.

This change defines one bounded raw-config nesting contract — a maximum supported structural depth of 512, enforced by an **iterative raw-text pre-scan before any parser runs** and an **iterative post-parse scan** — and:

- wires the pre-parse guard into config reads, secrets plans, patch/batch files, config `set` values (both `--strict-json` and JSON5 modes), include files, the startup logging-config reader, env-configured external channel catalog files, plugin/agent bundle manifests, and the Gateway dispatch config reader;
- bounds every recursive traversal (`substituteAny`, `IncludeProcessor.process`, `listDirectIncludes`, `containsConfigIncludeDirective`, `collectEnvRefPaths`) against the same contract, throwing a wrapped `ConfigNestingDepthError` instead of recursing.

Both scans are iterative, so measuring pathological input can never itself overflow the stack.

### Parser-boundary hardening (second review round)

Review identified four parser-boundary gaps, all fixed in this revision:

1. **JSON5 comments skipped in the raw scan** — the pre-scan now skips `//` line and `/* … */` block comments (including unterminated block comments), so a legal shallow config whose comments contain 513+ bracket characters is no longer misrejected.
2. **Config `set` values pre-scanned before parsing** — both `--strict-json` and JSON5 modes assert raw nesting *before* the parser runs (previously a pathological value reached the parser first, where a native overflow cannot be caught), while keeping the parsed-value assertion.
3. **Structural depth carried across `$include` boundaries** — the include processor now threads the parent's structural depth into each nested traversal, so a chain of individually-in-limit include files cannot combine past the 512-level contract.
4. **Gateway dispatch config reader guarded** — `readGatewayDispatchConfig` now runs the shared raw pre-scan before the strict/JSON5 compatibility parser, closing the last real dispatch reader outside the guard boundary.

The duplicated raw-assert → parse → parsed-assert triple is absorbed into one shared entry, `parseJsonWithNestingGuard` in `src/config/nesting-limit.ts`; the main config read, include files, config set values, patch/batch inputs, and the Gateway dispatch reader all go through it.

## Compatibility

The 512-level cap is deliberately far above any real config: shipped OpenClaw configs and the repo's test fixtures nest 10–20 levels at most, and 512 levels of authored nesting is not a practical configuration shape. Any input deeper than the cap already risked the exact native stack overflow this change fixes (the post-parse walks are recursive on `main`), so the contract rejects inputs that were crashing or crash-prone rather than inputs that worked. When rejected, the failure is a loud, wrapped `ConfigNestingDepthError` with the measured depth and the offending surface name — never a silent truncation or a changed value.

## Not covered by this change

`sessions --store` is intentionally untouched. Its target is parsed as a SQLite store path, never as JSON — pointing `--store` at a deeply-nested JSON file already fails with a clean, wrapped error (not a native crash) both before and after this change, so there is no JSON parse surface on that path to guard.

## Evidence

Post-fix behavior on Windows 11 (Node v26.5.1, real CLI runtime through `pnpm openclaw`, Windows respawn stack `--stack-size=8192`), using the issue's repro file (`'['.repeat(100000) + ']'.repeat(100000)`):

| Command | Exit | Output |
| --- | --- | --- |
| `pnpm openclaw secrets apply --from deep.json --dry-run` | 1 | `Secrets plan file exceeds the maximum supported nesting depth of 512: <path> \| Secrets plan JSON exceeds the maximum supported nesting depth of 512 (measured 100000 levels)` |
| `OPENCLAW_CONFIG_PATH=deep.json pnpm openclaw config validate` | 1 | `OpenClaw config is invalid: <path> × <root>: JSON5 parse failed: ConfigNestingDepthError: Config JSON exceeds the maximum supported nesting depth of 512 (measured 100000 levels)` |
| `pnpm openclaw config set probe.deep '<513-deep array>' --strict-json` | 1 | `Could not parse "[…]" as JSON for --strict-json. Config value JSON exceeds the maximum supported nesting depth of 512 (measured 513 levels). …` |

Before the fix the same commands exited with `3221225725` (`0xC00000FD`) and empty stderr; the startup logging-config reader parsed the deep file natively (V8 `JSON.parse` overflows between ~23k–25k nesting levels under the 8192 KB respawn stack) before any JS guard could run. The strict `config set` path previously ran a bare native `JSON.parse` with only a post-parse guard, which a native overflow never reaches.

Second-round regressions (unit level, all red-before-green):

- raw scan: 513 brackets inside `//` and `/* */` comments accepted; real nesting after a comment still measured exactly; unterminated block comments terminate the scan.
- `parseJsonWithNestingGuard`: parser is never invoked for over-limit raw input; parsed-value re-assertion still catches in-process inflators.
- config set values: over-limit `--strict-json` and JSON5 values rejected before `JSON.parse`/`JSON5.parse` is called (spy-verified); JSON5 no longer silently falls back to raw; values at the supported maximum still accepted.
- includes: a 400-level parent + 200-level include (each in-limit, 600 combined) rejected with `ConfigNestingDepthError`; in-limit chains still resolve.
- gateway dispatch: a 10k-deep dispatch config rejected with the `Gateway dispatch config JSON` guard label before the compatibility parser runs.

- logging depth test now proves the pre-parse boundary (parser spy asserts zero invocations for over-depth input; RED-verified): `src/logging/config.test.ts` spies on the compatibility parser, so the 600-level `readLoggingConfig` case now fails when the raw-depth guard is removed — the spy trips while `readLoggingConfig()` still returns `undefined`, distinguishing pre-parse rejection from the loader's array-root rejection.

### Round-17 [P2] fix — facade test env leak restored + ci-gate red diagnosed (head `33e8e7bc5bd`)

**[P2] Restore the process environment after facade tests — fixed.** The round-15 regression harness seeded `process.env.OPENCLAW_CONFIG_PATH` at module evaluation in `facade-runtime.test.ts` so the guard tests could observe an inherited value, but no file-level hook restored the seed, and the trailing test asserted that the synthetic value remained. At this head the pre-seed value is captured before the module-level assignment, an `afterAll` hook restores it (delete when it was originally unset) regardless of test outcomes, and the trailing test now asserts restoration: it first verifies the guard tests preserved the seeded probe (the original in-file invariant), then performs the end-of-file restore and asserts the variable is back to its pre-seed state.

Red/green: rewriting only the trailing assertion to expect restoration fails on the previous head `4798ccbe` with `AssertionError: expected 'inherited-probe-value' to be undefined` (`1 failed | 25 passed (26)`); with the `afterAll` hook and in-test restore the file is `26 passed (26)`. Cross-file probe: a temporary probe file appended to the bundled shard lane (`--no-file-parallelism`, shared worker) observed `OPENCLAW_CONFIG_PATH = undefined` after `facade-runtime.test.ts` both before and after the fix — the shared non-isolated runner's per-file `restoreSharedTestHomeAfterEnvUnstub` already strips the variable between files, so no cross-file pollution was observable in that lane; the fix removes this file's reliance on that runner-level cleanup and stops codifying the leaked value as expected behavior.

**CI: the `openclaw/ci-gate` failure at `4798ccbe` was neither the env leak nor a main red window — it was this branch's new test root exceeding a shard cap; fixed by rebalancing.** The gate's `check-additional-shard` failed in `check-additional-boundaries-a` at `lint:tmp:tsgo-core-boundary`: `plugins-platform: 721 test roots exceeds the 720 limit`. `origin/main` carries exactly 720 roots in that shard, so this PR's new `src/plugins/install-persistence.nesting-guard.test.ts` tipped it over. Because the cap is a tsgo memory bound (#122748) rather than a tunable style limit, the shard is rebalanced instead of raising it: `src/logging` test roots move from `plugins-platform` (721 → 684) into the `config-cli` shard (567 → 604), preserving exactly-once coverage (`check-tsgo-core-boundary` green locally). Every other lane on the failing run was success or skipped; the gate job only aggregates that shard result.

## Verification

- `tsgo:core` typecheck: clean.
- Unit/CLI coverage green:
  - `nesting-limit` (comment-skip, exact measured depths, shared guard), `includes.nesting` (cross-include depth carry), `includes`, `env-substitution`, `gateway-dispatch-config` (deep dispatch config regression), `config-cli-path` (new: deep strict/JSON5 config set values).
  - `logging/config`, `secrets-cli`, `config-cli` and `config-cli.integration`.

## Notes

- Four pre-existing `config-cli`/`config-cli.integration` failures on this Windows box are environment artifacts, verified present on clean `origin/main` in a throwaway worktree (Windows 8.3 short paths — `C:\Users\ADMINI~1\...` — leaking from `os.tmpdir()` into path-equality assertions; unrelated to this change).
- The two `measure*` scanners from the first revision were consumed only by tests, so they are no longer exported (dead-code gate is clean); their coverage now flows through the `assertBounded*` contract.
- Local-only environment issues (verified unrelated to this change): knip's concurrent full-tree scan intermittently dies on this Windows box with an oxc-parser `Array buffer allocation failed` (`RangeError`); the production and scripts scans pass. Two pre-existing knip findings on `scripts/` are present on clean `origin/main` too and are untouched.

## Third-round follow-up at head `44b6d234e4c` (review P1, 2026-08-26 20:44 UTC)

The third-round verdict kept one P1 open: the include-permission scanner still called the compatibility parser directly (`src/config/includes-scan.ts:93`), so a shallow config whose include is pathological could hand over-limit text to the native parser during security permission scanning (`src/security/audit-extra.async.ts:527`).

**Fix.** The scanner's `parseJson` callback now routes every include through the shared `parseJsonWithNestingGuard` entry (same guard the production resolver uses), with the include path in the violation label. Over-limit raw input is rejected before any native parse; the scanner's existing try/catch surfaces it via config validation while the path is still recorded for permission auditing.

**Regressions:**

- New `src/config/includes-scan.nesting.test.ts`: spy-verified that `parseJsonWithJson5Fallback` is never invoked for an include one level over `MAX_CONFIG_JSON_NESTING_DEPTH`, and the guarded path is still reported for permission auditing.
- `src/security/audit-config-include-perms.test.ts`: the audit completes for an over-limit include without ever handing its text to the compatibility parser.
- Layering note, stated precisely: at the reviewed head the shared session parser (`includes.ts` `parseFile`) already wrapped the scanner's callback in the guard, so these end-to-end regressions also pass on the reviewed head — they lock the route's controlled outcome and would fail if that session-level guard were removed. The scanner-level routing is the verdict's recommended explicit entry (nesting-limit's contract: every config-adjacent parse site goes through this entry) and closes the finding literally.

**Acceptance run** (`node scripts/run-vitest.mjs src/config/includes.test.ts src/security/audit-config-include-perms.test.ts src/config/nesting-limit.test.ts` plus the new file):

```
includes.test.ts                     63 passed | 3 skipped
nesting-limit.test.ts                16 passed
includes-scan.nesting.test.ts         1 passed
audit-config-include-perms.test.ts    1 failed (pre-existing, see below) | 1 passed | 1 skipped
```

- The one failure, `flags group/world-readable config include files`, is a Windows-only environment artifact: it fails identically on the reviewed head `dbe19cfff6f` in a clean worktree (Windows chmod semantics never produce the group/world mode bits the fixture relies on); it passes on Linux CI, which is where the real mode bits exist.
- `pnpm tsgo:core` clean; `oxfmt --check` and `oxlint` clean on all changed files.

## Fourth-round follow-up at head `2328ec3d60a` (review P1, 2026-08-26 22:07 UTC)

The fourth-round verdict kept one P1 open: `loadBundleManifestFile` still selected strict `JSON.parse` for Agent `plugin.json` files without the shared guard (`src/plugins/bundle-manifest.ts`), preserving a parser-before-guard boundary on the normal bundle-discovery path despite the PR body naming plugin/agent bundle manifests as covered.

**Fix.** The manifest parse callback now routes every bundle manifest through the shared `parseJsonWithNestingGuard` entry — the raw pre-scan rejects over-limit text before any parser runs and the post-parse scan re-asserts on the parsed value. Both parser selections go through the entry: strict `JSON.parse` (Agent) and `JSON5.parse` (Codex/Claude/Cursor). The violation label names the manifest (`plugin manifest plugin.json`), so a pathological bundle manifest now fails as a controlled `ConfigNestingDepthError` instead of contacting the native parser unguarded.

**Regressions (red before green).** New `manifest nesting guard` suite in `src/plugins/bundle-manifest.test.ts`: one over-limit manifest per bundle format (agent/codex/cursor, 513 levels, written to a real temp fixture) must be rejected with the shared depth error, and `JSON.parse` is spy-verified to never be invoked.

- At the reviewed head `44b6d234e4c` without the fix, all three cases fail: agent reaches native `JSON.parse` (spy trip), codex/cursor report no depth error (`plugin manifest must be an object`).
- With the fix, all three pass.

**Acceptance run** (`node scripts/run-vitest.mjs src/plugins/bundle-manifest.test.ts src/config/nesting-limit.test.ts`):

```
nesting-limit.test.ts    16 passed
bundle-manifest.test.ts  35 passed (includes the 3 new guard cases)
```

- `pnpm tsgo:core` clean; `oxfmt --check` and the check:changed oxlint core lane clean on all changed files.

**Real loader capture (redacted).** A throwaway driver invoked the production `loadBundleManifest({ rootDir, bundleFormat: "agent" })` against a real 513-level `plugin.json` on disk (no mocks, no test doubles):

```json
{
  "ok": false,
  "error": "failed to parse plugin manifest: failed to parse plugin.json: ConfigNestingDepthError: plugin manifest plugin.json exceeds the maximum supported nesting depth of 512 (measured 513 levels)",
  "manifestRelativePath": "plugin.json",
  "manifestBytes": 1027,
  "measuredRawDepth": 513,
  "maxSupportedDepth": 512
}
```

The over-limit Agent manifest now yields a wrapped, labeled depth error through the real loader instead of touching the native parser; the driver script was deleted after the capture.

Closes #129209

## Fifth-round follow-up at head `0de60ae461d1` (round-four findings closed, 2026-08-27 02:32 UTC)

All three round-four findings landed in this commit; the subsequent ClawSweeper verdict at this head moved the PR to "needs maintainer review" with Findings None / Security None.

- **Canonical manifest loader + discovery scanner:** `src/plugins/manifest.ts` and `src/plugins/manifest-metadata-scan.ts` route every parse through `parseJsonWithNestingGuard("plugin manifest <path>")`, pre-scanning nesting before the JSON5 compatibility parser - over-limit manifests fail as labeled `ConfigNestingDepthError`s instead of reaching the native parser.
- **SDK facade no-snapshot fallback:** the activation-time fallback in `src/plugin-sdk/facade-activation-check.runtime.ts` (direct read of the configured raw file when no runtime config snapshot exists) goes through the shared guard as well, keeping the bounded-config contract outside snapshot mode.
- **Depth-count alignment (P2):** parsed-value traversal now advances depth only on structural containers (arrays/records); a document with 512 bracket levels measures exactly 512 on both sides of the parser, matching the advertised raw limit.
- Regression coverage across `nesting-limit`, `facade-runtime`, `manifest-metadata-scan`, and a new `manifest.json5-tolerance` suite (+134 test lines across the four files).

## CI follow-up at head `e4445b14b154` (check-prod-types repair, 2026-08-27 03:17 UTC)

The facade change above used `parseJsonWithNestingGuard` without importing it, which turned `check-prod-types` red at the reviewed head (`TS2304` at facade-activation-check.runtime.ts(63,20), plus cascading `TS7006`). Repaired by adding the single missing import; `check-prod-types` passes on this head.



## Sixth-round follow-up at head `272f8aa374e` (round-five findings closed, 2026-08-27 09:18 UTC)

ClawSweeper round-5 flagged four remaining direct JSON5 parse sites that bypassed the shared nesting guard. All four are closed at this head:

1. `status.gather.ts` (fast status read): pre-scans nesting with `parseJsonWithNestingGuard` before `JSON5.parse`; `ConfigNestingDepthError` is surfaced as an invalid-config summary instead of a raw parse failure. New regression test: over-deep config on the fast path is reported invalid with the bounded nesting message and full plugin-aware validation is never reached.
2. `mutate.ts` (include mutation): the prior root-bound include is parsed through the shared guard, and the local unbounded `containsConfigIncludeDirective` traversal is removed in favor of the shared bounded walk from `io.read-helpers.js`.
3. `install-persistence.ts` (install include preflight): pre-scans nesting before the compatibility parse so over-deep included configs land in the existing blocked-preflight handling.
4. `facade-activation-check.runtime.ts` (bundled facade manifest read): pre-scans nesting before the compatibility parse. New regression test spies on native `JSON.parse` and proves the over-deep manifest payload never reaches it; activation treats the record as missing.

**Tests** (local, exact head): `status.gather.test.ts` 25/25, `facade-runtime.test.ts` 47 passed / 1 skipped, `config/mutate.test.ts` 53 passed / 3 skipped — all green. `install-persistence.test.ts` has 16 pre-existing failures on Windows reproduced verbatim on the prior head `e4445b14b154` (POSIX `/tmp` fixture paths vs the state-dir guard); unrelated to this diff and green in CI on Linux runners.

New regression test for finding #3 (red before green) at head `ee9cc789e78`: `install-persistence.test.ts` now proves an over-deep included config is rejected at the install include preflight — the preflight returns the existing blocked `could not be inspected at its snapshot target` outcome instead of handing the payload to the compatibility parser. Verified red at `e4445b14b154`: with the unguarded `parseJsonWithJson5Fallback`, the same fixture returned `allowed`, meaning the 513-deep payload reached the native parser (a native overflow on the real CLI stack is invisible to JS try/catch).




## Thirteenth-round follow-up at head `bdc0af817ec` (review P1, 2026-08-27 12:03 UTC)

The thirteenth-round verdict kept one P1 open: the hosted plugin catalog still parsed three trusted-boundary inputs with bare native `JSON.parse` — the fetched/cached feed body (`src/plugins/official-external-plugin-catalog.ts:760`, parsed before signature-envelope verification and fallback handling), the decoded DSSE signed payload (`src/plugins/official-external-plugin-catalog-envelope.ts:263`), and the snapshot monotonicity reads (`src/plugins/official-external-plugin-catalog-snapshot-store.ts:118` and `:127`). A 513+-deep response body, decoded signed payload, or stored snapshot body can each reproduce the native stack overflow this PR eliminates.

**Fix.** All three boundaries now route through the shared `parseJsonWithNestingGuard` entry:

1. **Feed body** — `parseJsonWithNestingGuard(params.body, "hosted catalog feed", JSON.parse)`: the iterative raw pre-scan rejects over-limit text before any native parse, and the resulting `ConfigNestingDepthError` lands in the existing bundled-fallback handling as a wrapped, labeled error.
2. **Decoded signed payload** — `parseJsonWithNestingGuard(payloadBytes.toString("utf8"), "hosted catalog signed feed payload", JSON.parse)`: an over-deep payload now fails envelope verification as a controlled invalid payload instead of contacting the native parser.
3. **Snapshot monotonicity reads** — both the stored body and the base64-decoded inner payload go through the guard (`"hosted catalog snapshot"` / `"hosted catalog snapshot payload"` labels): an over-deep stored body is skipped by the monotonicity walk exactly like today's unreadable snapshots, never parsed natively.

**Regressions (red before green, spy-verified).** Three new tests in `official-external-plugin-catalog.test.ts` prove over-limit input never reaches the native parser:

- over-deep (513-level) unsigned hosted response body → `bundled-fallback` carrying a `nesting depth` error; `vi.spyOn(JSON, "parse")` proves the deep body never reaches the native parser;
- over-deep (513-level) signed hosted response (deep payload inside a valid DSSE envelope) → controlled `bundled-fallback`; the spy proves the decoded payload text never reaches the native parser;
- over-deep (513-level) snapshot body written to the SQLite store → `read` returns the snapshot without monotonic state and a follow-up signed write still proceeds; the spy proves the stored body never reaches the native parser on either the read-side or the write-side monotonicity check.

All three were verified red at the reviewed head `66fdebc24d20` (spy trips; errors without the nesting contract) and green at this head.

**Acceptance run at this head:**

```
official-external-plugin-catalog.test.ts   84 passed / 1 failed (pre-existing, see below)
official-external-plugin-catalog-envelope.test.ts  10 passed
pnpm tsgo:core   clean
oxfmt --check    clean on all changed files
oxlint           clean on all changed files
```

The one failure, "catalogs every published external extension exactly once", is a pre-existing data-drift test (bundled catalog JSON vs the published owner list) that fails identically at the reviewed head `66fdebc24d20` in a clean tree; unrelated to this change.

**On the production-code line count (merge-risk note):** the production lines added by this PR implement one shared iterative contract (`nesting-limit.ts`) plus one guarded entry per real parse boundary, and every boundary has a red-before-green regression that fails if its guard is removed — the wiring, not the contract, is what scales with the number of surfaces.


## Fifteenth-round follow-up at head `f4c52fbbefa` (review P3 closed + 512-boundary rationale, 2026-08-28)

The fifteenth-round verdict raised one code finding and one maintainer decision item; both are addressed at this head:

**P3 — restore inherited `OPENCLAW_CONFIG_PATH` in facade tests.** `facade-runtime.test.ts`'s two facade guard tests ("guards the no-snapshot facade config fallback against over-deep config files" and "guards bundled openclaw.plugin.json manifest reads against over-deep payloads") unconditionally `delete process.env.OPENCLAW_CONFIG_PATH` in their `finally` blocks, while the suite only snapshots the other environment variables. Each test now snapshots the value at test start, and the `finally` block restores it (delete only when it was originally unset; the untouched `OPENCLAW_STATE_DIR` cleanup is unchanged). A new regression test, "preserves an inherited OPENCLAW_CONFIG_PATH across facade guard tests", seeds a pre-existing value at module-eval time and asserts it survives the guard tests — module-eval is the earliest point an inherited value can exist because the shared non-isolated runner strips `OPENCLAW_CONFIG_PATH` from the process env at file collect start (`restoreSharedTestHomeAfterEnvUnstub`). Verified **red before the fix** (`AssertionError: expected undefined to be 'inherited-probe-value'` — the unconditional delete destroyed the pre-existing value; guard tests themselves stayed green) and **green after** (`26 passed (26)`).

**Decision needed — 512 structural levels as the supported maximum.** Rationale for maintainers:

- Real configurations, bundled plugin metadata, and catalog payloads nest far below the cap — shipped configs and the repo's own fixtures nest 10–20 levels at most. 512 is only reachable by pathological input that was already crashing or crash-prone on `main`, so the contract rejects inputs that were already broken, not inputs that worked.
- The guard converts a native stack-overflow crash (invisible to JS `try/catch`, empty stderr, Windows `0xC00000FD`) into a wrapped, labeled `ConfigNestingDepthError` carrying the measured depth and the offending surface name — a bounded, diagnosable failure.
- The ceiling is defined once in `src/config/nesting-limit.ts` (`MAX_CONFIG_JSON_NESTING_DEPTH`). A different ceiling is a one-line change, and every regression test derives its 513-level fixture from the same constant, so raising or lowering the cap updates the tests automatically.

**Tests at this head:** `src/plugin-sdk/facade-runtime.test.ts` 26/26 green (red→green recorded above); `pnpm tsgo:core` clean.

## Round-16 follow-up

Addressed the round-16 ClawSweeper review (head `f4c52fbbefa`; new head `2e61992ae4d80da37281e14f08665e41f1526634`):

1. **[P1] Unguarded parser boundary at `src/config/plugin-auto-enable.prefer-over.ts:95`** — fixed. `resolveExternalCatalogPreferOver()` now parses the environment-configured external catalog through the shared `parseJsonWithNestingGuard` (`src/config/nesting-limit.ts`): the iterative raw-text pre-scan rejects 513+-level nesting as a controlled `ConfigNestingDepthError` before the native `JSON.parse` ever runs. Fail-open semantics are unchanged — depth errors are parse-class failures, so the existing outer catch stays silent (only oversized-file skips warn). Regression test added in `plugin-auto-enable.channels.test.ts`: a 520-level nested external catalog is rejected before native parsing (asserted via a `JSON.parse` spy), auto-enable still completes with the catalog skipped, and no warning is logged. Red/green verified: the new test fails on the unguarded parse (2 native parses of the deep text) and passes with the guard.
2. **512-level cap compatibility decision** — maintainer-side; left to maintainer judgment.
3. **346-line production delta scope note** — maintainer-side; covered by the branch context.
4. **Stored data model migration proof** — maintainer-side; no code change this round.

