### PR TITLE
fix(auth): bind native availability to runtime authority

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.misc-owners.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.misc-owners.test.ts
@@ -1,6 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../auth-profiles.js";
 import { markAuthProfileSuccess } from "../auth-profiles.js";
+import {
+  clearAllRuntimeAuthMaterializations,
+  getPreparedRuntimeAuthMaterializations,
+} from "../auth-profiles/runtime-materializations.js";
 import {
   markEmbeddedRunAuthProfileSuccess,
   reportEmbeddedRunSuccessfulAuthBinding,
@@ -13,7 +17,21 @@ vi.mock("../auth-profiles.js", () => ({
   markAuthProfileSuccess: vi.fn(),
 }));
 
+vi.mock("../../plugins/provider-model-routes.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../plugins/provider-model-routes.js")>();
+  return {
+    ...actual,
+    resolveProviderModelRoutes: (
+      params: Parameters<typeof actual.resolveProviderModelRoutes>[0],
+    ) => (params.provider === "anthropic" ? null : actual.resolveProviderModelRoutes(params)),
+  };
+});
+
 const mockedMarkAuthProfileSuccess = vi.mocked(markAuthProfileSuccess);
+
+afterEach(() => {
+  clearAllRuntimeAuthMaterializations();
+});
 
 describe("markEmbeddedRunAuthProfileSuccess", () => {
   beforeEach(() => {
@@ -51,6 +69,7 @@ describe("reportEmbeddedRunSuccessfulAuthBinding", () => {
 
   it("uses a harness-owned SecretRef fingerprint when the harness resolves it", () => {
     const onSuccessfulAuthBinding = vi.fn();
+    const agentDir = "/tmp/openclaw-secretref-materialization";
 
     reportEmbeddedRunSuccessfulAuthBinding({
       profileId: "openai:work",
@@ -60,8 +79,10 @@ describe("reportEmbeddedRunSuccessfulAuthBinding", () => {
         authBindingFingerprint: "resolved-secretref-fingerprint",
       } as EmbeddedRunAttemptResult,
       provider: "openai",
+      agentDir,
       modelId: "gpt-5.4",
       modelApi: "openai-responses",
+      modelBaseUrl: "https://api.openai.com/v1",
       agentHarnessId: "codex",
       pluginHarnessOwnsTransport: true,
       pluginHarnessOwnsAuthBootstrap: true,
@@ -77,6 +98,18 @@ describe("reportEmbeddedRunSuccessfulAuthBinding", () => {
       runtimeOwnerKind: "plugin-harness",
       runtimeOwnerId: "codex",
     });
+    expect(getPreparedRuntimeAuthMaterializations(agentDir)).toEqual([
+      {
+        provider: "openai",
+        modelId: "gpt-5.4",
+        modelApi: "openai-responses",
+        modelBaseUrl: "https://api.openai.com/v1",
+        requestTransportOverrides: "none",
+        authMode: "api-key",
+        runtimeOwnerId: "codex",
+        authProfileId: "openai:work",
+      },
+    ]);
   });
 
   it("binds opaque harness auth to the exact captured runtime artifact", () => {
@@ -111,6 +144,110 @@ describe("reportEmbeddedRunSuccessfulAuthBinding", () => {
       runtimeArtifactId: runtimeArtifact.id,
       runtimeArtifactFingerprint: runtimeArtifact.fingerprint,
     });
+  });
+
+  it("records exact native auth only after a credential-free harness succeeds", () => {
+    const agentDir = "/tmp/openclaw-native-auth-materialization";
+    reportEmbeddedRunSuccessfulAuthBinding({
+      profileStore: { version: 1, profiles: {} },
+      apiKeyInfo: null,
+      attempt: {} as EmbeddedRunAttemptResult,
+      provider: "anthropic",
+      agentDir,
+      modelId: "claude-opus-5",
+      modelApi: "anthropic-messages",
+      modelBaseUrl: "https://api.anthropic.com",
+      requestTransportOverrides: "none",
+      agentHarnessId: "claude-cli",
+      pluginHarnessOwnsTransport: true,
+      pluginHarnessOwnsAuthBootstrap: true,
+    });
+
+    expect(getPreparedRuntimeAuthMaterializations(agentDir)).toEqual([
+      {
+        provider: "anthropic",
+        modelId: "claude-opus-5",
+        modelApi: "anthropic-messages",
+        modelBaseUrl: "https://api.anthropic.com",
+        requestTransportOverrides: "none",
+        authMode: "native",
+        runtimeOwnerId: "claude-cli",
+      },
+    ]);
+  });
+
+  it.each([
+    {
+      label: "transport ownership",
+      overrides: { pluginHarnessOwnsTransport: false },
+    },
+    {
+      label: "auth-bootstrap ownership",
+      overrides: { pluginHarnessOwnsAuthBootstrap: false },
+    },
+    {
+      label: "an unbound profile id",
+      overrides: { profileId: "anthropic:missing" },
+    },
+    {
+      label: "a SecretRef profile",
+      overrides: {
+        profileId: "anthropic:ref",
+        profileStore: {
+          version: 1,
+          profiles: {
+            "anthropic:ref": {
+              type: "api_key",
+              provider: "anthropic",
+              keyRef: { source: "env", provider: "default", id: "ANTHROPIC_API_KEY" },
+            },
+          },
+        },
+      },
+    },
+    {
+      label: "an inline profile credential",
+      overrides: {
+        profileId: "anthropic:inline",
+        profileStore: {
+          version: 1,
+          profiles: {
+            "anthropic:inline": {
+              type: "api_key",
+              provider: "anthropic",
+              key: "inline-test-key",
+            },
+          },
+        },
+      },
+    },
+    {
+      label: "forwarded auth material",
+      overrides: {
+        apiKeyInfo: { apiKey: "forwarded-test-key", mode: "api-key", source: "test" },
+      },
+    },
+  ] satisfies Array<{
+    label: string;
+    overrides: Partial<Parameters<typeof reportEmbeddedRunSuccessfulAuthBinding>[0]>;
+  }>)("does not record native auth without $label", ({ overrides }) => {
+    const agentDir = `/tmp/openclaw-unowned-native-auth-${overrides.profileId ?? "owner"}`;
+    reportEmbeddedRunSuccessfulAuthBinding({
+      profileStore: { version: 1, profiles: {} },
+      apiKeyInfo: null,
+      attempt: {} as EmbeddedRunAttemptResult,
+      provider: "anthropic",
+      agentDir,
+      modelId: "claude-opus-5",
+      modelApi: "anthropic-messages",
+      modelBaseUrl: "https://api.anthropic.com",
+      agentHarnessId: "claude-cli",
+      pluginHarnessOwnsTransport: true,
+      pluginHarnessOwnsAuthBootstrap: true,
+      ...overrides,
+    });
+
+    expect(getPreparedRuntimeAuthMaterializations(agentDir)).toEqual([]);
   });
 });
 

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.misc-owners.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.misc-owners.test.ts
@@ -176,7 +176,10 @@ describe("reportEmbeddedRunSuccessfulAuthBinding", () => {
     ]);
   });
 
-  it.each([
+  const nativeAuthDenialCases: Array<{
+    label: string;
+    overrides: Partial<Parameters<typeof reportEmbeddedRunSuccessfulAuthBinding>[0]>;
+  }> = [
     {
       label: "transport ownership",
       overrides: { pluginHarnessOwnsTransport: false },
@@ -227,10 +230,9 @@ describe("reportEmbeddedRunSuccessfulAuthBinding", () => {
         apiKeyInfo: { apiKey: "forwarded-test-key", mode: "api-key", source: "test" },
       },
     },
-  ] satisfies Array<{
-    label: string;
-    overrides: Partial<Parameters<typeof reportEmbeddedRunSuccessfulAuthBinding>[0]>;
-  }>)("does not record native auth without $label", ({ overrides }) => {
+  ];
+
+  it.each(nativeAuthDenialCases)("does not record native auth without $label", ({ overrides }) => {
     const agentDir = `/tmp/openclaw-unowned-native-auth-${overrides.profileId ?? "owner"}`;
     reportEmbeddedRunSuccessfulAuthBinding({
       profileStore: { version: 1, profiles: {} },

--- a/src/agents/embedded-agent-runner/run/auth-profile-success.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-success.ts
@@ -159,7 +159,12 @@ export function reportEmbeddedRunSuccessfulAuthBinding(input: {
       modelApi: materializedRoute.api,
       modelBaseUrl: materializedRoute.baseUrl,
       requestTransportOverrides: materializedRoute.requestTransportOverrides,
-      authMode: materializedRoute.authRequirement === "subscription" ? "oauth" : "api-key",
+      authMode:
+        "authMode" in materializedRoute
+          ? materializedRoute.authMode
+          : materializedRoute.authRequirement === "subscription"
+            ? "oauth"
+            : "api-key",
       runtimeOwnerId: input.agentHarnessId,
       ...(input.profileId ? { authProfileId: input.profileId } : {}),
     });
@@ -187,6 +192,7 @@ function resolveOpaqueHarnessMaterialization(
   credential: AuthProfileStore["profiles"][string] | undefined,
 ) {
   if (
+    !input.pluginHarnessOwnsTransport ||
     !input.pluginHarnessOwnsAuthBootstrap ||
     input.apiKeyInfo ||
     hasInlineCredentialMaterial(credential) ||
@@ -202,22 +208,32 @@ function resolveOpaqueHarnessMaterialization(
     config: input.config,
     requestTransportOverrides: input.requestTransportOverrides ?? "none",
   });
-  if (resolution?.kind !== "routes") {
-    return undefined;
+  if (resolution?.kind === "routes") {
+    const routes = resolution.routes.filter(
+      (route) =>
+        route.api === input.modelApi &&
+        route.requestTransportOverrides === (input.requestTransportOverrides ?? "none") &&
+        (!input.modelBaseUrl ||
+          modelMatchesProviderModelRoute({
+            provider: input.provider,
+            api: input.modelApi,
+            baseUrl: input.modelBaseUrl,
+            route,
+          })),
+    );
+    return routes.length === 1 ? routes[0] : undefined;
   }
-  const routes = resolution.routes.filter(
-    (route) =>
-      route.api === input.modelApi &&
-      route.requestTransportOverrides === (input.requestTransportOverrides ?? "none") &&
-      (!input.modelBaseUrl ||
-        modelMatchesProviderModelRoute({
-          provider: input.provider,
-          api: input.modelApi,
-          baseUrl: input.modelBaseUrl,
-          route,
-        })),
-  );
-  return routes.length === 1 ? routes[0] : undefined;
+  const baseUrl = input.modelBaseUrl?.trim();
+  // Only a completed credential-free harness run owns native auth proof;
+  // profiles and forwarded credentials must stay on their explicit paths.
+  return resolution === null && !input.profileId && baseUrl
+    ? {
+        api: input.modelApi,
+        baseUrl,
+        requestTransportOverrides: input.requestTransportOverrides ?? "none",
+        authMode: "native",
+      }
+    : undefined;
 }
 
 function isModelApi(value: string): value is ModelApi {

--- a/src/agents/model-auth-availability.test.ts
+++ b/src/agents/model-auth-availability.test.ts
@@ -52,6 +52,7 @@ function authStore(
 }
 
 function evaluate(params: {
+  provider?: string;
   cfg?: OpenClawConfig | Record<string, unknown>;
   env?: NodeJS.ProcessEnv;
   ref?: ModelAuthAvailabilityRef;
@@ -66,12 +67,14 @@ function evaluate(params: {
     cfg: (params.cfg ?? {}) as OpenClawConfig,
     authStore: params.store ?? authStore(),
     env: params.env ?? {},
-    routeResolverFactory: routeResolverFactory(params.resolution ?? dualRoutes),
+    routeResolverFactory: routeResolverFactory(
+      params.resolution === undefined ? dualRoutes : params.resolution,
+    ),
     syntheticAuthProviderRefs: params.syntheticAuthProviderRefs,
     preparedRuntimeAuthModes: params.preparedRuntimeAuthModes,
     preparedRuntimeAuthStore: params.preparedRuntimeAuthStore,
     preparedRuntimeAuthMaterializations: params.preparedRuntimeAuthMaterializations,
-  }).evaluateModelAuth("openai", params.ref);
+  }).evaluateModelAuth(params.provider ?? "openai", params.ref);
 }
 
 describe("createModelAuthAvailabilityResolver", () => {
@@ -220,6 +223,90 @@ describe("createModelAuthAvailabilityResolver", () => {
       evidence: "provider-config",
       selectedRoute: platformRoute,
     });
+  });
+
+  it("uses only an exact credential-free native runtime materialization", () => {
+    const materialization = {
+      provider: "anthropic",
+      modelId: "claude-opus-5",
+      modelApi: "anthropic-messages",
+      modelBaseUrl: "https://api.anthropic.com/",
+      requestTransportOverrides: "none",
+      authMode: "native",
+      runtimeOwnerId: "claude-cli",
+    } as const;
+    const ref = {
+      modelId: "claude-opus-5",
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com",
+      runtimeOwnerId: "claude-cli",
+      requestTransportOverrides: "none",
+    } as const;
+    const evaluateNative = (
+      target: ModelAuthAvailabilityRef,
+      facts: readonly RuntimeAuthMaterialization[] = [materialization],
+    ) =>
+      evaluate({
+        provider: "anthropic",
+        resolution: null,
+        ref: target,
+        preparedRuntimeAuthMaterializations: facts,
+      });
+
+    expect(evaluateNative(ref)).toMatchObject({
+      availability: true,
+      evidence: "runtime",
+      selectedAuthMode: "native",
+    });
+
+    const physicalRoute = {
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com",
+    } as const;
+    const physicalRef = {
+      modelId: ref.modelId,
+      runtimeOwnerId: ref.runtimeOwnerId,
+      requestTransportOverrides: ref.requestTransportOverrides,
+      observedRoutes: [physicalRoute, physicalRoute],
+    } as const;
+    expect(evaluateNative(physicalRef)).toMatchObject({
+      availability: true,
+      evidence: "runtime",
+      selectedAuthMode: "native",
+    });
+
+    expect(evaluateNative({ ...physicalRef, observedRoutes: [] }).availability).not.toBe(true);
+
+    expect(
+      evaluateNative(
+        {
+          ...physicalRef,
+          observedRoutes: [
+            physicalRoute,
+            { ...physicalRoute, baseUrl: "https://proxy.example.test" },
+          ],
+        },
+        [materialization, { ...materialization, modelBaseUrl: "https://proxy.example.test" }],
+      ).availability,
+    ).not.toBe(true);
+
+    const mismatches: RuntimeAuthMaterialization[] = [
+      { ...materialization, provider: "openai" },
+      { ...materialization, modelId: "claude-sonnet-5" },
+      { ...materialization, modelApi: "openai-responses" },
+      { ...materialization, modelBaseUrl: "https://proxy.example.test" },
+      { ...materialization, requestTransportOverrides: "present" },
+      { ...materialization, runtimeOwnerId: "openclaw" },
+      { ...materialization, authMode: "oauth" },
+      { ...materialization, authProfileId: "anthropic:default" },
+    ];
+    for (const mismatch of mismatches) {
+      expect(evaluateNative(ref, [mismatch]).availability).not.toBe(true);
+    }
+
+    expect(evaluateNative({ ...ref, lockedProfileId: "anthropic:locked" }).availability).not.toBe(
+      true,
+    );
   });
 
   it.each([

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -14,6 +14,7 @@ import type {
   ProviderModelRouteCandidate,
   ProviderModelRouteResolution,
   ProviderModelRouteSource,
+  ProviderRouteOverridePresence,
 } from "../plugin-sdk/provider-model-types.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { isValidSecretRef } from "../secrets/ref-contract.js";
@@ -96,6 +97,10 @@ export type ModelAuthAvailabilityRef = {
   preferredProfileId?: string;
   /** Explicit user/session lock; model-id suffixes are transport identity only. */
   lockedProfileId?: string;
+  /** Exact successful native runtime owner required for this availability check. */
+  runtimeOwnerId?: string;
+  /** Exact request behavior that the runtime successfully reproduced. */
+  requestTransportOverrides?: ProviderRouteOverridePresence;
 };
 export type ModelAuthAvailabilityEvaluation = {
   availability: ModelAuthAvailability;
@@ -164,6 +169,11 @@ function normalizeModelIdForProvider(provider: string, modelId: string): string 
   return normalizeProviderIdForAuth(trimmed.slice(0, slash)) === provider
     ? trimmed.slice(slash + 1).trim() || undefined
     : undefined;
+}
+
+function normalizeMaterializedBaseUrl(value: unknown): string | undefined {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed ? trimmed.replace(/\/+$/u, "") : undefined;
 }
 
 /** Builds one snapshot-scoped read-only auth evaluator. */
@@ -319,6 +329,51 @@ export function createModelAuthAvailabilityResolver(
       api: ref.api ?? configuredModel?.api ?? configured?.api,
       baseUrl: ref.baseUrl ?? configuredModel?.baseUrl ?? configured?.baseUrl,
     };
+  };
+  const resolveNativeRuntimeMaterialization = (
+    provider: string,
+    target: AuthTarget,
+  ): RuntimeAuthMaterialization | undefined => {
+    const runtimeOwnerId = target.runtimeOwnerId?.trim().toLowerCase();
+    const modelId = target.modelId
+      ? normalizeModelIdForProvider(provider, target.modelId)?.toLowerCase()
+      : undefined;
+    const requestTransportOverrides = target.requestTransportOverrides;
+    const physicalRoutes = target.observedRoutes?.length
+      ? target.observedRoutes
+      : [{ api: target.api, baseUrl: target.baseUrl }];
+    const routeKeys = new Set<string>();
+    for (const route of physicalRoutes) {
+      const api = typeof route.api === "string" ? route.api.trim().toLowerCase() : "";
+      const baseUrl = normalizeMaterializedBaseUrl(route.baseUrl);
+      if (api && baseUrl) {
+        routeKeys.add(`${api}\0${baseUrl}`);
+      }
+    }
+    if (
+      target.lockedProfileId?.trim() ||
+      !runtimeOwnerId ||
+      !modelId ||
+      routeKeys.size === 0 ||
+      !requestTransportOverrides
+    ) {
+      return undefined;
+    }
+    // Native proof is profile-free and exact-route scoped; an explicit profile lock
+    // always owns selection and cannot be displaced by a prior harness success.
+    const matches = params.preparedRuntimeAuthMaterializations?.filter(
+      (fact) =>
+        normalizeProvider(fact.provider) === normalizeProvider(provider) &&
+        fact.modelId === modelId &&
+        routeKeys.has(
+          `${fact.modelApi.trim().toLowerCase()}\0${normalizeMaterializedBaseUrl(fact.modelBaseUrl) ?? ""}`,
+        ) &&
+        fact.requestTransportOverrides === requestTransportOverrides &&
+        fact.runtimeOwnerId === runtimeOwnerId &&
+        fact.authMode === "native" &&
+        fact.authProfileId === undefined,
+    );
+    return matches?.length === 1 ? matches[0] : undefined;
   };
   const providerBinding = (provider: string) =>
     resolveProviderEntryApiKeyProfileReference({
@@ -809,6 +864,14 @@ export function createModelAuthAvailabilityResolver(
   ): AuthSourceEvaluation => {
     const provider = normalizeProviderIdForAuth(rawProvider);
     const target = preparedTarget ?? prepareAuthTarget(provider, ref);
+    const nativeRuntimeMaterialization = resolveNativeRuntimeMaterialization(provider, target);
+    if (nativeRuntimeMaterialization) {
+      return {
+        availability: true,
+        selectedAuthMode: "native",
+        evidence: "runtime",
+      };
+    }
     const profileLock = ref.lockedProfileId?.trim();
     const policy = directPolicy(provider, target);
     if (!profileLock && policy.binding.kind === "profile-incompatible") {

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -85,7 +85,7 @@ const EXTERNAL_CLI_REFRESH_PROVIDER_IDS = new Set(
   listExternalCliSyncProviderIds().map(normalizeProviderIdForAuth),
 );
 
-export type ModelAuthAvailability = boolean | undefined;
+type ModelAuthAvailability = boolean | undefined;
 type ModelAuthAvailabilityEvidence = Exclude<ProviderModelAuthEvidence, "none">;
 export type ModelAuthAvailabilityRef = {
   modelId?: string;

--- a/src/commands/onboard-inference-ambient.test.ts
+++ b/src/commands/onboard-inference-ambient.test.ts
@@ -24,6 +24,19 @@ afterEach(async () => {
 });
 
 describe("detectAmbientInferenceBackends", () => {
+  it("does not treat native Claude token files as ambient credentials", async () => {
+    const home = await createTempHome();
+    await writeCredential(home, ".claude/.credentials.json", {
+      claudeAiOauth: {
+        accessToken: "claude-access",
+        refreshToken: "claude-refresh",
+        expiresAt: Date.now() + 60_000,
+      },
+    });
+
+    expect(detectAmbientInferenceBackends({ HOME: home })).toEqual([]);
+  });
+
   it("returns a verified Codex candidate only for readable file credentials", async () => {
     const home = await createTempHome();
     expect(detectAmbientInferenceBackends({ HOME: home })).toEqual([]);

--- a/src/gateway/server-methods/models-list-result.cli-runtime-availability.test.ts
+++ b/src/gateway/server-methods/models-list-result.cli-runtime-availability.test.ts
@@ -22,18 +22,18 @@ import type { GatewayRequestContext } from "./types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+const mainAgent = {
+  id: "main",
+  default: true,
+  models: {
+    "anthropic/claude-opus-5": { agentRuntime: { id: "claude-cli" } },
+  },
+};
+
 const config = {
   agents: {
     defaults: { model: { primary: "anthropic/claude-opus-5" } },
-    list: [
-      {
-        id: "main",
-        default: true,
-        models: {
-          "anthropic/claude-opus-5": { agentRuntime: { id: "claude-cli" } },
-        },
-      },
-    ],
+    list: [mainAgent],
   },
 } satisfies OpenClawConfig;
 
@@ -135,7 +135,7 @@ describe("models.list CLI runtime availability", () => {
       ...config,
       agents: {
         ...config.agents,
-        list: [{ ...config.agents.list[0], agentDir }],
+        list: [{ ...mainAgent, agentDir }],
       },
     } satisfies OpenClawConfig;
     const catalogEntry = {

--- a/src/gateway/server-methods/models-list-result.cli-runtime-availability.test.ts
+++ b/src/gateway/server-methods/models-list-result.cli-runtime-availability.test.ts
@@ -1,11 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  clearRuntimeAuthMaterializations,
+  getPreparedRuntimeAuthMaterializations,
+  revokeRuntimeAuthMaterializations,
+} from "../../agents/auth-profiles/runtime-materializations.js";
+import { reportEmbeddedRunSuccessfulAuthBinding } from "../../agents/embedded-agent-runner/run/auth-profile-success.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import {
+  buildModelsListResult,
+  createGatewayAgentModelCatalogProjector,
+} from "./models-list-result.js";
+import {
   listModels,
   providerCatalogEntry,
 } from "./models-list-result.openai-routes.test-support.js";
+import type { GatewayRequestContext } from "./types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const config = {
   agents: {
@@ -40,15 +55,18 @@ async function listClaudeCliModel(
 describe("models.list CLI runtime availability", () => {
   beforeEach(() => {
     vi.stubEnv("ANTHROPIC_API_KEY", "");
+    vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "");
+    vi.stubEnv("CLAUDE_API_KEY", "");
+    vi.stubEnv("CLAUDE_CODE_OAUTH_TOKEN", "");
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("marks a Claude CLI runtime model available through bundled synthetic auth", async () => {
+  it("does not treat an activated native runtime owner as successful auth", async () => {
     await expect(listClaudeCliModel()).resolves.toEqual({
-      models: [expect.objectContaining({ id: "claude-opus-5", available: true })],
+      models: [expect.objectContaining({ id: "claude-opus-5", available: false })],
     });
   });
 
@@ -109,5 +127,110 @@ describe("models.list CLI runtime availability", () => {
     ).resolves.toEqual({
       models: [expect.objectContaining({ id: "claude-opus-5", available: false })],
     });
+  });
+
+  it("tracks exact native runtime availability through success and revocation", async () => {
+    const agentDir = tempDirs.make("models-list-native-materialization-");
+    const runtimeConfig = {
+      ...config,
+      agents: {
+        ...config.agents,
+        list: [{ ...config.agents.list[0], agentDir }],
+      },
+    } satisfies OpenClawConfig;
+    const catalogEntry = {
+      id: "claude-opus-5",
+      name: "Claude Opus 5",
+      provider: "anthropic",
+      api: "anthropic-messages" as const,
+      baseUrl: "https://api.anthropic.com",
+    };
+    clearRuntimeAuthMaterializations(agentDir);
+    setRuntimeConfigSnapshot(runtimeConfig, runtimeConfig);
+    try {
+      reportEmbeddedRunSuccessfulAuthBinding({
+        profileStore: { version: 1, profiles: {} },
+        apiKeyInfo: null,
+        attempt: {} as never,
+        provider: catalogEntry.provider,
+        agentDir,
+        modelId: catalogEntry.id,
+        modelApi: catalogEntry.api,
+        modelBaseUrl: catalogEntry.baseUrl,
+        agentHarnessId: "claude-cli",
+        pluginHarnessOwnsTransport: true,
+        pluginHarnessOwnsAuthBootstrap: true,
+      });
+      const snapshot = { entries: [catalogEntry], routeVariants: [catalogEntry] };
+      const buildCatalog = async (locked = false) => {
+        const projector = createGatewayAgentModelCatalogProjector({
+          cfg: runtimeConfig,
+          agentId: "main",
+          snapshot,
+          metadataSnapshot: loadManifestMetadataSnapshot({
+            config: runtimeConfig,
+            env: process.env,
+          }),
+          preparedAuthStore: {
+            version: 1,
+            profiles: locked
+              ? {
+                  "anthropic:locked": {
+                    type: "api_key",
+                    provider: "anthropic",
+                    key: "",
+                  },
+                }
+              : {},
+          },
+          preparedRuntimeAuthMaterializations: getPreparedRuntimeAuthMaterializations(agentDir),
+          ...(locked ? { lockedProfileId: "anthropic:locked" } : {}),
+        });
+        const context = {
+          getRuntimeConfig: () => runtimeConfig,
+          loadGatewayModelCatalogSnapshot: vi.fn(),
+          logGateway: { debug: vi.fn() },
+        } as unknown as GatewayRequestContext;
+        return await buildModelsListResult({
+          context,
+          agentId: "main",
+          params: { view: "all" },
+          preloadedCatalog: {
+            agentId: "main",
+            config: runtimeConfig,
+            snapshot,
+            fullyDiscovered: true,
+          },
+          preloadedOnly: true,
+          catalogProjector: projector,
+        });
+      };
+      const expectAvailability = async (available: boolean, locked = false) => {
+        await expect(buildCatalog(locked)).resolves.toMatchObject({
+          models: [
+            {
+              id: catalogEntry.id,
+              provider: catalogEntry.provider,
+              available,
+              agentRuntime: { id: "claude-cli", source: "model" },
+            },
+          ],
+        });
+      };
+
+      await expectAvailability(true);
+      await expectAvailability(false, true);
+      expect(
+        revokeRuntimeAuthMaterializations({
+          agentDir,
+          provider: catalogEntry.provider,
+          runtimeOwnerId: "claude-cli",
+        }),
+      ).toBe(true);
+      await expectAvailability(false);
+    } finally {
+      clearRuntimeAuthMaterializations(agentDir);
+      clearRuntimeConfigSnapshot();
+    }
   });
 });

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -8,7 +8,6 @@ import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import { resolveConfiguredModelEntries } from "../../agents/configured-model-entries.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import type {
-  ModelAuthAvailability,
   ModelAuthAvailabilityEvaluation,
   ModelAuthAvailabilityResolver,
 } from "../../agents/model-auth-availability.js";
@@ -44,6 +43,7 @@ import { publishedModelCatalogOwnerMatchesAgent } from "../../agents/prepared-mo
 import { preparedModelRuntimeConfigsMatch } from "../../agents/prepared-model-runtime.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getRuntimeConfigSourceSnapshot } from "../../config/config.js";
+import { resolveModelProviderRouteOverridePresence } from "../../config/model-provider-config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import type { ProviderCatalogOutcome } from "../../plugins/provider-catalog.types.js";
@@ -79,43 +79,6 @@ function resolveModelsListView(params: Record<string, unknown>): ModelCatalogBro
   return view === "configured" || view === "provider-config" || view === "all" ? view : "default";
 }
 
-function resolveLegacyEntryAvailability(params: {
-  authResolver: ModelAuthAvailabilityResolver;
-  entry: ModelCatalogEntry;
-  primaryAvailability: ModelAuthAvailability;
-  cfg: OpenClawConfig;
-  agentId: string;
-  metadataSnapshot: PluginMetadataSnapshot;
-  resolvePreparedSyntheticCliRuntime: (entry: ModelCatalogEntry) => string | undefined;
-}): ModelAuthAvailability {
-  if (params.primaryAvailability === true) {
-    return true;
-  }
-  let available = params.primaryAvailability;
-  const preparedSyntheticRuntime = params.resolvePreparedSyntheticCliRuntime(params.entry);
-  const runtimeProvider =
-    resolveCliRuntimeExecutionProvider({
-      provider: params.entry.provider,
-      cfg: params.cfg,
-      agentId: params.agentId,
-      modelId: params.entry.id,
-      metadataSnapshot: params.metadataSnapshot,
-    }) ?? preparedSyntheticRuntime;
-  if (
-    runtimeProvider &&
-    normalizeProviderId(runtimeProvider) !== normalizeProviderId(params.entry.provider)
-  ) {
-    const runtimeAvailable = params.authResolver.resolveProviderAuthAvailability(runtimeProvider);
-    if (runtimeAvailable === true || preparedSyntheticRuntime === runtimeProvider) {
-      return true;
-    }
-    if (available === false && runtimeAvailable === undefined) {
-      available = undefined;
-    }
-  }
-  return available;
-}
-
 function createModelsListEntryEvaluator(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -142,6 +105,30 @@ function createModelsListEntryEvaluator(params: {
       return cached;
     }
     const next = Promise.resolve().then(() => {
+      const legacyProvider = normalizeProviderId(entry.provider) !== "openai";
+      const configuredRuntime = legacyProvider
+        ? resolveCliRuntimeExecutionProvider({
+            provider: entry.provider,
+            cfg: params.cfg,
+            agentId: params.agentId,
+            modelId: entry.id,
+            metadataSnapshot: params.metadataSnapshot,
+          })
+        : undefined;
+      const preparedRuntimeOwner = legacyProvider
+        ? resolvePreparedSyntheticCliRuntime(entry)
+        : undefined;
+      const runtimeProvider = configuredRuntime ?? preparedRuntimeOwner;
+      const isAlternateRuntime =
+        runtimeProvider !== undefined &&
+        normalizeProviderId(runtimeProvider) !== normalizeProviderId(entry.provider);
+      const exactNativeRuntime =
+        isAlternateRuntime &&
+        configuredRuntime &&
+        preparedRuntimeOwner &&
+        normalizeProviderId(configuredRuntime) === normalizeProviderId(preparedRuntimeOwner)
+          ? configuredRuntime
+          : undefined;
       const evaluation = params.authResolver.evaluateModelAuth(entry.provider, {
         modelId: identity?.id ?? entry.id,
         ...(params.preferredProfileId ? { preferredProfileId: params.preferredProfileId } : {}),
@@ -150,22 +137,38 @@ function createModelsListEntryEvaluator(params: {
           api: variant.api,
           baseUrl: variant.baseUrl,
         })),
-      });
-      const resolved =
-        evaluation.routeResolution === null && normalizeProviderId(entry.provider) !== "openai"
+        ...(exactNativeRuntime
           ? {
-              ...evaluation,
-              availability: resolveLegacyEntryAvailability({
-                authResolver: params.authResolver,
-                entry,
-                primaryAvailability: evaluation.availability,
-                cfg: params.cfg,
-                agentId: params.agentId,
-                metadataSnapshot: params.metadataSnapshot,
-                resolvePreparedSyntheticCliRuntime,
+              api: entry.api,
+              baseUrl: entry.baseUrl,
+              runtimeOwnerId: exactNativeRuntime,
+              requestTransportOverrides: resolveModelProviderRouteOverridePresence({
+                provider: entry.provider,
+                modelId: entry.id,
+                authoredConfig: getRuntimeConfigSourceSnapshot() ?? params.cfg,
               }),
             }
-          : evaluation;
+          : {}),
+      });
+      const legacyRoute = legacyProvider && evaluation.routeResolution === null;
+      let availability = evaluation.availability;
+      // A prepared native owner without a successful exact fact is not auth evidence.
+      if (legacyRoute && availability !== true && isAlternateRuntime && !exactNativeRuntime) {
+        const runtimeAvailable = params.authResolver.resolveProviderAuthAvailability(
+          runtimeProvider,
+          {
+            ...(params.preferredProfileId ? { preferredProfileId: params.preferredProfileId } : {}),
+            ...(params.lockedProfileId ? { lockedProfileId: params.lockedProfileId } : {}),
+          },
+        );
+        availability =
+          runtimeAvailable === true
+            ? true
+            : availability === false && runtimeAvailable === undefined
+              ? undefined
+              : availability;
+      }
+      const resolved = legacyRoute ? { ...evaluation, availability } : evaluation;
       const provider = normalizeProviderId(entry.provider);
       // Stored credentials prove presence, not acceptance. Apply the live rejection only to the
       // profile discovery tested; widening it would hide routes backed by another valid profile.

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -1633,7 +1633,7 @@ describe("models.list", () => {
     });
   });
 
-  it("keeps catalog models available through a native CLI runtime", async () => {
+  it("keeps catalog models unavailable until a native CLI runtime succeeds", async () => {
     await withoutAnthropicEnvAuth(async () => {
       await withModelsTestState(
         {
@@ -1683,7 +1683,7 @@ describe("models.list", () => {
                     devicePlacementSupported: false,
                     source: "model",
                   },
-                  available: true,
+                  available: false,
                   tags: ["configured"],
                 },
               ],


### PR DESCRIPTION
## Summary

- Record native runtime authority only after a successful exact physical provider route.
- Project native model availability from one unique, profile-free, unlocked materialization; missing or ambiguous matches fail closed.
- Invalidate materialized authority on lock, revocation, replacement, or lifecycle closure before Gateway projection.
- Keep ambient onboarding inference privacy-safe and avoid treating native CLI credentials as OpenClaw-managed input.

## Root cause

Gateway model availability could not distinguish a configured native route from authority that the runtime had actually materialized. Reconstructing availability from indirect configuration signals either hid a working native model or risked treating stale, locked, revoked, or ambiguous state as usable.

The runtime boundary now records the bounded fact where successful native authority is established. Gateway consumes that fact without receiving or persisting raw credentials or tokens.

## Verification

- Focused producer, matcher, Gateway, model-list, and ambient-privacy suites: 71/71 passed.
- Independent proportional verification: 71/71 passed.
- Formatting, focused lint, type-aware lint, dependency checks, diff checks, and authority/privacy guards passed.
- Fresh-main reconstruction preserves the current resolver, status, aliases, fallback fixtures, and newer upstream coverage.
- The corrected exact head merges cleanly with the current main merge tree.

## Surface

- Production: +82 lines net, implementing the lifecycle-owned authority fact and fail-closed projection boundary.
- Tests: +362 lines net, covering exact-route materialization, ambiguity, lock/revocation/replacement/closure invalidation, Gateway projection, and privacy.
