### PR TITLE
fix: report native Claude CLI models as available

### DIFF
--- a/src/gateway/server-methods/models-list-auth-resolver.ts
+++ b/src/gateway/server-methods/models-list-auth-resolver.ts
@@ -9,13 +9,21 @@ import {
 } from "../../agents/model-auth-availability.js";
 import { createOpenAIModelRoutesResolver } from "../../agents/openai-model-routes.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isManifestPluginAvailableForControlPlane } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 
 function listEnabledSyntheticAuthProviderRefs(
   metadataSnapshot: PluginMetadataSnapshot,
+  config: OpenClawConfig,
 ): readonly string[] {
-  return metadataSnapshot.index.plugins
-    .filter((plugin) => plugin.enabled)
+  return metadataSnapshot.plugins
+    .filter((plugin) =>
+      isManifestPluginAvailableForControlPlane({
+        snapshot: metadataSnapshot,
+        plugin,
+        config,
+      }),
+    )
     .flatMap((plugin) => plugin.syntheticAuthRefs ?? []);
 }
 
@@ -40,7 +48,10 @@ export function createModelsListAuthResolver(params: {
     preparedRuntimeAuthModes: params.preparedRuntimeAuthModes,
     preparedRuntimeAuthMaterializations: params.preparedRuntimeAuthMaterializations,
     skipSetupProviderFallback: true,
-    syntheticAuthProviderRefs: listEnabledSyntheticAuthProviderRefs(params.metadataSnapshot),
+    syntheticAuthProviderRefs: listEnabledSyntheticAuthProviderRefs(
+      params.metadataSnapshot,
+      params.cfg,
+    ),
     externalCliProviderIds: resolveExternalCliAuthScopeFromConfig(params.cfg)?.providerIds ?? [],
     preparedRuntimeAuthStore: params.preparedAuthStore,
     routeResolverFactory: params.routeResolverFactory,

--- a/src/gateway/server-methods/models-list-auth-resolver.ts
+++ b/src/gateway/server-methods/models-list-auth-resolver.ts
@@ -9,21 +9,13 @@ import {
 } from "../../agents/model-auth-availability.js";
 import { createOpenAIModelRoutesResolver } from "../../agents/openai-model-routes.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { isManifestPluginAvailableForControlPlane } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 
 function listEnabledSyntheticAuthProviderRefs(
   metadataSnapshot: PluginMetadataSnapshot,
-  config: OpenClawConfig,
 ): readonly string[] {
-  return metadataSnapshot.plugins
-    .filter((plugin) =>
-      isManifestPluginAvailableForControlPlane({
-        snapshot: metadataSnapshot,
-        plugin,
-        config,
-      }),
-    )
+  return metadataSnapshot.index.plugins
+    .filter((plugin) => plugin.enabled)
     .flatMap((plugin) => plugin.syntheticAuthRefs ?? []);
 }
 
@@ -48,10 +40,7 @@ export function createModelsListAuthResolver(params: {
     preparedRuntimeAuthModes: params.preparedRuntimeAuthModes,
     preparedRuntimeAuthMaterializations: params.preparedRuntimeAuthMaterializations,
     skipSetupProviderFallback: true,
-    syntheticAuthProviderRefs: listEnabledSyntheticAuthProviderRefs(
-      params.metadataSnapshot,
-      params.cfg,
-    ),
+    syntheticAuthProviderRefs: listEnabledSyntheticAuthProviderRefs(params.metadataSnapshot),
     externalCliProviderIds: resolveExternalCliAuthScopeFromConfig(params.cfg)?.providerIds ?? [],
     preparedRuntimeAuthStore: params.preparedAuthStore,
     routeResolverFactory: params.routeResolverFactory,

--- a/src/gateway/server-methods/models-list-result.cli-runtime-availability.test.ts
+++ b/src/gateway/server-methods/models-list-result.cli-runtime-availability.test.ts
@@ -1,14 +1,9 @@
-import fs from "node:fs";
-import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   listModels,
   providerCatalogEntry,
 } from "./models-list-result.openai-routes.test-support.js";
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const config = {
   agents: {
@@ -25,11 +20,11 @@ const config = {
   },
 } satisfies OpenClawConfig;
 
-async function listClaudeCliModel() {
+async function listClaudeCliModel(cfg: OpenClawConfig = config) {
   return await listModels({
     catalog: [],
     staticEntries: [providerCatalogEntry("anthropic", "claude-opus-5")],
-    cfg: config,
+    cfg,
     view: "configured",
   });
 }
@@ -43,30 +38,19 @@ describe("models.list CLI runtime availability", () => {
     vi.unstubAllEnvs();
   });
 
-  it("marks a Claude CLI runtime model available with ambient CLI OAuth", async () => {
-    const homeDir = tempDirs.make("models-list-claude-cli-");
-    const credentialDir = path.join(homeDir, ".claude");
-    fs.mkdirSync(credentialDir, { recursive: true, mode: 0o700 });
-    fs.writeFileSync(
-      path.join(credentialDir, ".credentials.json"),
-      JSON.stringify({
-        claudeAiOauth: {
-          accessToken: "test-access",
-          refreshToken: "test-refresh",
-          expiresAt: Date.now() + 3_600_000,
-        },
-      }),
-      { mode: 0o600 },
-    );
-    vi.stubEnv("HOME", homeDir);
-
+  it("marks a Claude CLI runtime model available through bundled synthetic auth", async () => {
     await expect(listClaudeCliModel()).resolves.toEqual({
       models: [expect.objectContaining({ id: "claude-opus-5", available: true })],
     });
   });
 
-  it("marks a Claude CLI runtime model unavailable without ambient CLI OAuth", async () => {
-    await expect(listClaudeCliModel()).resolves.toEqual({
+  it("does not use synthetic auth from an explicitly disabled Anthropic plugin", async () => {
+    await expect(
+      listClaudeCliModel({
+        ...config,
+        plugins: { entries: { anthropic: { enabled: false } } },
+      }),
+    ).resolves.toEqual({
       models: [expect.objectContaining({ id: "claude-opus-5", available: false })],
     });
   });

--- a/src/gateway/server-methods/models-list-result.cli-runtime-availability.test.ts
+++ b/src/gateway/server-methods/models-list-result.cli-runtime-availability.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import {
   listModels,
   providerCatalogEntry,
@@ -20,11 +22,17 @@ const config = {
   },
 } satisfies OpenClawConfig;
 
-async function listClaudeCliModel(cfg: OpenClawConfig = config) {
+async function listClaudeCliModel(
+  params: {
+    cfg?: OpenClawConfig;
+    metadataSnapshot?: PluginMetadataSnapshot;
+  } = {},
+) {
   return await listModels({
     catalog: [],
     staticEntries: [providerCatalogEntry("anthropic", "claude-opus-5")],
-    cfg,
+    cfg: params.cfg ?? config,
+    ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
     view: "configured",
   });
 }
@@ -47,8 +55,56 @@ describe("models.list CLI runtime availability", () => {
   it("does not use synthetic auth from an explicitly disabled Anthropic plugin", async () => {
     await expect(
       listClaudeCliModel({
-        ...config,
-        plugins: { entries: { anthropic: { enabled: false } } },
+        cfg: {
+          ...config,
+          plugins: { entries: { anthropic: { enabled: false } } },
+        },
+      }),
+    ).resolves.toEqual({
+      models: [expect.objectContaining({ id: "claude-opus-5", available: false })],
+    });
+  });
+
+  it("does not use synthetic auth when plugins are globally disabled", async () => {
+    await expect(
+      listClaudeCliModel({
+        cfg: {
+          ...config,
+          plugins: { enabled: false },
+        },
+      }),
+    ).resolves.toEqual({
+      models: [expect.objectContaining({ id: "claude-opus-5", available: false })],
+    });
+  });
+
+  it("does not choose between multiple active runtime owners", async () => {
+    const metadataSnapshot = loadManifestMetadataSnapshot({ config, env: process.env });
+    const anthropic = metadataSnapshot.plugins.find((plugin) => plugin.id === "anthropic");
+    if (!anthropic) {
+      throw new Error("Anthropic manifest missing from model availability fixture");
+    }
+    const duplicate = { ...anthropic, id: "anthropic-duplicate" };
+    const providerOwners = new Map(metadataSnapshot.owners.providers);
+    providerOwners.set("anthropic", [...(providerOwners.get("anthropic") ?? []), duplicate.id]);
+    const cliBackendOwners = new Map(metadataSnapshot.owners.cliBackends);
+    cliBackendOwners.set("claude-cli", [
+      ...(cliBackendOwners.get("claude-cli") ?? []),
+      duplicate.id,
+    ]);
+
+    await expect(
+      listClaudeCliModel({
+        metadataSnapshot: {
+          ...metadataSnapshot,
+          plugins: [...metadataSnapshot.plugins, duplicate],
+          byPluginId: new Map([...metadataSnapshot.byPluginId, [duplicate.id, duplicate]]),
+          owners: {
+            ...metadataSnapshot.owners,
+            providers: providerOwners,
+            cliBackends: cliBackendOwners,
+          },
+        },
       }),
     ).resolves.toEqual({
       models: [expect.objectContaining({ id: "claude-opus-5", available: false })],

--- a/src/gateway/server-methods/models-list-result.openai-routes.test-support.ts
+++ b/src/gateway/server-methods/models-list-result.openai-routes.test-support.ts
@@ -3,6 +3,7 @@ import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import type { createOpenAIModelRoutesResolver } from "../../agents/openai-model-routes.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import {
   type PreparedGatewayModelCatalogSnapshot,
   registerGatewayModelCatalogPrivateAccess,
@@ -46,6 +47,7 @@ export async function listModels(params: {
   staticEntries?: ModelCatalogEntry[];
   cfg?: OpenClawConfig;
   discoveryModes?: Record<string, "refreshable" | "runtime" | "static">;
+  metadataSnapshot?: PluginMetadataSnapshot;
   routeResolverFactory?: typeof createOpenAIModelRoutesResolver;
   view?: "all" | "configured" | "provider-config" | "default";
 }) {
@@ -62,7 +64,8 @@ export async function listModels(params: {
       authStore: loadAuthProfileStoreWithoutExternalProfiles("/tmp/models-list-openai-agent", {
         allowKeychainPrompt: false,
       }),
-      metadataSnapshot: loadManifestMetadataSnapshot({ config, env: process.env }),
+      metadataSnapshot:
+        params.metadataSnapshot ?? loadManifestMetadataSnapshot({ config, env: process.env }),
       entries: params.catalog,
       routeVariants: params.catalog,
       ...(params.staticEntries ? { staticEntries: params.staticEntries } : {}),

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -45,6 +45,7 @@ import { preparedModelRuntimeConfigsMatch } from "../../agents/prepared-model-ru
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getRuntimeConfigSourceSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isManifestPluginAvailableForControlPlane } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import type { ProviderCatalogOutcome } from "../../plugins/provider-catalog.types.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -71,6 +72,35 @@ type ModelsListResult = {
 
 let loggedSlowModelsListCatalog = false;
 
+function resolvePreparedCliRuntimeProvider(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  entry: ModelCatalogEntry;
+  metadataSnapshot: PluginMetadataSnapshot;
+}): string | undefined {
+  const runtime = resolveModelChoiceAgentRuntime({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    entry: params.entry,
+  })?.id;
+  if (!runtime || runtime === "openclaw") {
+    return undefined;
+  }
+  const provider = normalizeProviderId(params.entry.provider);
+  const runtimeOwners = params.metadataSnapshot.owners.cliBackends.get(runtime) ?? [];
+  const providerOwners = new Set(params.metadataSnapshot.owners.providers.get(provider) ?? []);
+  const ownerId = runtimeOwners.find((pluginId) => providerOwners.has(pluginId));
+  const owner = ownerId ? params.metadataSnapshot.byPluginId.get(ownerId) : undefined;
+  return owner &&
+    isManifestPluginAvailableForControlPlane({
+      snapshot: params.metadataSnapshot,
+      plugin: owner,
+      config: params.cfg,
+    })
+    ? runtime
+    : undefined;
+}
+
 function resolveModelsListView(params: Record<string, unknown>): ModelCatalogBrowseView {
   const view = params.view;
   return view === "configured" || view === "provider-config" || view === "all" ? view : "default";
@@ -88,19 +118,26 @@ function resolveLegacyEntryAvailability(params: {
     return true;
   }
   let available = params.primaryAvailability;
-  const runtimeProvider = resolveCliRuntimeExecutionProvider({
-    provider: params.entry.provider,
-    cfg: params.cfg,
-    agentId: params.agentId,
-    modelId: params.entry.id,
-    metadataSnapshot: params.metadataSnapshot,
-  });
+  const runtimeProvider =
+    resolveCliRuntimeExecutionProvider({
+      provider: params.entry.provider,
+      cfg: params.cfg,
+      agentId: params.agentId,
+      modelId: params.entry.id,
+      metadataSnapshot: params.metadataSnapshot,
+    }) ??
+    resolvePreparedCliRuntimeProvider({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      entry: params.entry,
+      metadataSnapshot: params.metadataSnapshot,
+    });
   if (
     runtimeProvider &&
     normalizeProviderId(runtimeProvider) !== normalizeProviderId(params.entry.provider)
   ) {
     const runtimeAvailable = params.authResolver.resolveProviderAuthAvailability(runtimeProvider);
-    if (runtimeAvailable === true) {
+    if (runtimeAvailable === true || params.authResolver.hasSyntheticAuth(runtimeProvider)) {
       return true;
     }
     if (available === false && runtimeAvailable === undefined) {

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -45,7 +45,8 @@ import { preparedModelRuntimeConfigsMatch } from "../../agents/prepared-model-ru
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getRuntimeConfigSourceSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { isManifestPluginAvailableForControlPlane } from "../../plugins/manifest-contract-eligibility.js";
+import { normalizePluginsConfig } from "../../plugins/config-state.js";
+import { isActivatedManifestOwner } from "../../plugins/manifest-owner-policy.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import type { ProviderCatalogOutcome } from "../../plugins/provider-catalog.types.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -72,33 +73,34 @@ type ModelsListResult = {
 
 let loggedSlowModelsListCatalog = false;
 
-function resolvePreparedCliRuntimeProvider(params: {
+function resolvePreparedSyntheticCliRuntime(params: {
   cfg: OpenClawConfig;
   agentId: string;
   entry: ModelCatalogEntry;
   metadataSnapshot: PluginMetadataSnapshot;
+  activatedPluginIds: ReadonlySet<string>;
 }): string | undefined {
-  const runtime = resolveModelChoiceAgentRuntime({
-    cfg: params.cfg,
-    agentId: params.agentId,
-    entry: params.entry,
-  })?.id;
+  const runtime = normalizeProviderId(
+    resolveModelChoiceAgentRuntime({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      entry: params.entry,
+    })?.id ?? "",
+  );
   if (!runtime || runtime === "openclaw") {
     return undefined;
   }
   const provider = normalizeProviderId(params.entry.provider);
-  const runtimeOwners = params.metadataSnapshot.owners.cliBackends.get(runtime) ?? [];
   const providerOwners = new Set(params.metadataSnapshot.owners.providers.get(provider) ?? []);
-  const ownerId = runtimeOwners.find((pluginId) => providerOwners.has(pluginId));
-  const owner = ownerId ? params.metadataSnapshot.byPluginId.get(ownerId) : undefined;
-  return owner &&
-    isManifestPluginAvailableForControlPlane({
-      snapshot: params.metadataSnapshot,
-      plugin: owner,
-      config: params.cfg,
-    })
-    ? runtime
-    : undefined;
+  const owners = (params.metadataSnapshot.owners.cliBackends.get(runtime) ?? []).filter(
+    (pluginId) =>
+      providerOwners.has(pluginId) &&
+      params.activatedPluginIds.has(pluginId) &&
+      params.metadataSnapshot.byPluginId
+        .get(pluginId)
+        ?.syntheticAuthRefs?.some((candidate) => normalizeProviderId(candidate) === runtime),
+  );
+  return owners.length === 1 ? runtime : undefined;
 }
 
 function resolveModelsListView(params: Record<string, unknown>): ModelCatalogBrowseView {
@@ -113,11 +115,19 @@ function resolveLegacyEntryAvailability(params: {
   cfg: OpenClawConfig;
   agentId: string;
   metadataSnapshot: PluginMetadataSnapshot;
+  activatedPluginIds: ReadonlySet<string>;
 }): ModelAuthAvailability {
   if (params.primaryAvailability === true) {
     return true;
   }
   let available = params.primaryAvailability;
+  const preparedSyntheticRuntime = resolvePreparedSyntheticCliRuntime({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    entry: params.entry,
+    metadataSnapshot: params.metadataSnapshot,
+    activatedPluginIds: params.activatedPluginIds,
+  });
   const runtimeProvider =
     resolveCliRuntimeExecutionProvider({
       provider: params.entry.provider,
@@ -125,19 +135,13 @@ function resolveLegacyEntryAvailability(params: {
       agentId: params.agentId,
       modelId: params.entry.id,
       metadataSnapshot: params.metadataSnapshot,
-    }) ??
-    resolvePreparedCliRuntimeProvider({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      entry: params.entry,
-      metadataSnapshot: params.metadataSnapshot,
-    });
+    }) ?? preparedSyntheticRuntime;
   if (
     runtimeProvider &&
     normalizeProviderId(runtimeProvider) !== normalizeProviderId(params.entry.provider)
   ) {
     const runtimeAvailable = params.authResolver.resolveProviderAuthAvailability(runtimeProvider);
-    if (runtimeAvailable === true || params.authResolver.hasSyntheticAuth(runtimeProvider)) {
+    if (runtimeAvailable === true || preparedSyntheticRuntime === runtimeProvider) {
       return true;
     }
     if (available === false && runtimeAvailable === undefined) {
@@ -159,6 +163,18 @@ function createModelsListEntryEvaluator(params: {
   entry: ModelCatalogEntry,
   routeVariants?: readonly ModelCatalogEntry[],
 ) => Promise<ModelAuthAvailabilityEvaluation> {
+  const normalizedPluginConfig = normalizePluginsConfig(params.cfg.plugins);
+  const activatedPluginIds = new Set(
+    params.metadataSnapshot.plugins
+      .filter((plugin) =>
+        isActivatedManifestOwner({
+          plugin,
+          normalizedConfig: normalizedPluginConfig,
+          rootConfig: params.cfg,
+        }),
+      )
+      .map((plugin) => plugin.id),
+  );
   const pending = new Map<string, Promise<ModelAuthAvailabilityEvaluation>>();
   return (entry, routeVariants = [entry]) => {
     const identity = openAIModelCatalogRoutePolicy.resolveIdentity(entry);
@@ -188,6 +204,7 @@ function createModelsListEntryEvaluator(params: {
                 cfg: params.cfg,
                 agentId: params.agentId,
                 metadataSnapshot: params.metadataSnapshot,
+                activatedPluginIds,
               }),
             }
           : evaluation;

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -58,6 +58,7 @@ const modelPluginMetadataSnapshot = vi.hoisted(() => {
       skills: [],
       hooks: [],
       origin: "bundled",
+      enabledByDefault: true,
       rootDir: "/test/anthropic",
       source: "/test/anthropic/index.js",
       manifestPath: "/test/anthropic/openclaw.plugin.json",

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -1632,7 +1632,7 @@ describe("models.list", () => {
     });
   });
 
-  it("keeps catalog models available through a refresh-owned CLI runtime", async () => {
+  it("keeps catalog models available through a native CLI runtime", async () => {
     await withoutAnthropicEnvAuth(async () => {
       await withModelsTestState(
         {
@@ -1641,34 +1641,7 @@ describe("models.list", () => {
           agentEnv: "main",
         },
         async (state) => {
-          const store = {
-            version: 1,
-            profiles: {
-              "anthropic:claude-cli": {
-                type: "oauth",
-                provider: "claude-cli",
-                access: "claude-cli-access",
-                refresh: "claude-cli-refresh",
-                expires: Date.now() - 60_000,
-              },
-            },
-          } as const;
-          await state.writeAuthProfiles(store);
-          replaceRuntimeAuthProfileStoreSnapshots([
-            {
-              agentDir: state.agentDir(),
-              store: Object.assign({}, store, {
-                runtimeExternalCliProfileIds: ["anthropic:claude-cli"],
-              }),
-            },
-          ]);
-
           const runtimeConfig = {
-            auth: {
-              profiles: {
-                "anthropic:claude-cli": { provider: "anthropic", mode: "token" },
-              },
-            },
             agents: {
               defaults: {
                 models: {


### PR DESCRIPTION
## Summary

Configured Anthropic models routed through the native Claude CLI runtime were reported unavailable unless OpenClaw had a copied OAuth credential. Claude CLI owns that login, so model availability must not depend on copied bearer tokens.

This is a follow-up to #129052, which moved Claude authentication ownership back to the native CLI.

## Root Cause

After #129052 removed copied Claude credentials, the legacy `models.list` availability path could resolve the configured CLI runtime but had no prepared ownership check that tied together:

- the model provider
- the CLI runtime
- the synthetic-auth declaration
- the active plugin that owns all three

Without that complete binding, native Claude CLI authentication could not make the configured Anthropic model selectable safely.

## Changes

- derive active plugin owners from the canonical plugin activation policy
- use prepared metadata owner maps to require one plugin to own the provider, CLI runtime, and matching synthetic-auth reference
- reject explicitly disabled, globally disabled, and ambiguous ownership
- remove copied Claude credential state from the Gateway regression fixture

## Verification

- 42 focused Gateway tests
- positive native Claude CLI availability
- explicit and global plugin disablement
- ambiguous runtime ownership
- formatting
- core typecheck
- autoreview

## Follow-up

#129374 moved the ownership resolver into the model-list auth module and removed the stale test callback after the core lint gate found a max-lines violation and an unused parameter.

Fixes #129326
