### PR TITLE
fix(doctor): preserve native Claude CLI token ownership

### DIFF
--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -164,12 +164,20 @@ describe("noteAuthProfileHealth", () => {
       },
     });
 
-    const findings = await collectAuthProfileHealthFindings({
-      cfg: {
-        agents: { list: [{ id: "main", default: true, agentDir: mainDir }] },
-      } as OpenClawConfig,
+    const cfg = {
+      agents: { list: [{ id: "main", default: true, agentDir: mainDir }] },
+    } as OpenClawConfig;
+    const findings = await collectAuthProfileHealthFindings({ cfg });
+    const confirmAutoFix = vi.fn(async () => true);
+
+    await noteAuthProfileHealth({
+      cfg,
+      prompter: { confirmAutoFix } as unknown as DoctorPrompter,
+      allowKeychainPrompt: false,
     });
 
+    expect(confirmAutoFix).not.toHaveBeenCalled();
+    expect(authProfileMocks.resolveApiKeyForProfile).not.toHaveBeenCalled();
     expect(findings).toEqual([]);
   });
 

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -21,6 +21,7 @@ import {
   resolveApiKeyForProfile,
   resolveProfileUnusableUntilForDisplay,
 } from "../agents/auth-profiles.js";
+import { CLAUDE_CLI_PROFILE_ID } from "../agents/auth-profiles/constants.js";
 import { formatAuthDoctorHint } from "../agents/auth-profiles/doctor.js";
 import {
   buildAuthProfileUnusableHint,
@@ -340,12 +341,17 @@ function authProfileCooldownToHealthFinding(params: {
 }
 
 function isAuthProfileHealthIssue(profile: AuthHealthSummary["profiles"][number]): boolean {
-  if (profile.type === "api_key") {
-    return profile.status === "missing";
-  }
+  // Native Claude owns refresh until Doctor commits removal of its legacy profile.
   return (
-    (profile.type === "oauth" || profile.type === "token") &&
-    (profile.status === "expired" || profile.status === "expiring" || profile.status === "missing")
+    profile.status === "missing" ||
+    ((profile.type === "oauth" || profile.type === "token") &&
+      (profile.status === "expired" ||
+        (profile.status === "expiring" &&
+          !(
+            profile.type === "oauth" &&
+            profile.provider === "claude-cli" &&
+            profile.profileId === CLAUDE_CLI_PROFILE_ID
+          ))))
   );
 }
 
@@ -398,19 +404,12 @@ async function collectAuthProfileHealthFindingsForTarget(params: {
   });
   const issues = summary.profiles.filter(isAuthProfileHealthIssue);
   for (const issue of issues) {
-    const authIssue: AuthIssue = {
-      profileId: issue.profileId,
-      provider: issue.provider,
-      status: issue.status,
-      reasonCode: issue.reasonCode,
-      remainingMs: issue.remainingMs,
-    };
     findings.push(
       authProfileIssueToHealthFinding({
-        issue: authIssue,
+        issue,
         target: params.target,
         labelAgents: params.labelAgents,
-        hint: await resolveAuthIssueHint(authIssue, params.cfg, store),
+        hint: await resolveAuthIssueHint(issue, params.cfg, store),
       }),
     );
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running doctor with an expiring Claude CLI-managed OAuth session received an incorrect reauthentication warning and could be prompted to replace a token whose refresh lifecycle belongs to the Claude CLI.

## Why This Change Was Made

Restore the narrowly scoped CLI-owned refresh exemption at the shared doctor profile-health decision owner. The exemption applies only to the canonical Claude CLI profile when its provider and credential type both match and its status is expiring; expired profiles, other providers, custom profile IDs, static tokens, missing credentials, and cooldown handling retain their existing behavior. Remove a redundant intermediate issue projection so the production implementation remains net-negative.

## User Impact

Doctor no longer asks users to reauthenticate or refresh a healthy Claude CLI-owned expiring session, while preserving warnings and repair guidance for every other authentication state.

## Evidence

- The two existing affected regression scenarios failed before the repair and pass afterward; the enhanced interactive scenario proves doctor neither prompts for confirmation nor forces a token refresh.
- Five focused profile-health, authentication-migration, and atomic-configuration owner suites pass all 157 tests.
- Independent exhaustive authentication matrices cover 135, 240, and 300 state combinations and change only the intended canonical OAuth/expiring/Claude-CLI profile.
- Targeted lint, formatting, assertion-safety and file-size ratchets, and the doctor deprecation guard pass.
- Shipped production owner: 13 added and 14 deleted lines; the existing regression suite gains eight net lines.
