### PR TITLE
fix(discord): prevent accidental mentions inside unfinished code

### DIFF
--- a/extensions/discord/src/mentions.test.ts
+++ b/extensions/discord/src/mentions.test.ts
@@ -101,6 +101,21 @@ describe("rewriteDiscordKnownMentions", () => {
       input: "outside @alice then ``inside @alice",
       expected: "outside <@123456789> then ``inside @alice",
     },
+    {
+      name: "escaped literal backticks",
+      input: "literal \\` outside @alice",
+      expected: "literal \\` outside <@123456789>",
+    },
+    {
+      name: "backticks after an even number of backslashes",
+      input: "literal \\\\` inside @alice",
+      expected: "literal \\\\` inside @alice",
+    },
+    {
+      name: "escaped backticks before real unterminated code",
+      input: "literal \\` outside @alice then `inside @alice",
+      expected: "literal \\` outside <@123456789> then `inside @alice",
+    },
   ])("does not rewrite mentions inside $name", ({ input, expected }) => {
     rememberDiscordDirectoryUser({
       accountId: "default",

--- a/extensions/discord/src/mentions.test.ts
+++ b/extensions/discord/src/mentions.test.ts
@@ -85,19 +85,29 @@ describe("rewriteDiscordKnownMentions", () => {
     expect(rewritten).toBe("hello @unknown @everyone @here");
   });
 
-  it("does not rewrite mentions inside markdown code spans", () => {
+  it.each([
+    {
+      name: "balanced inline and fenced code",
+      input: "inline `@alice` fence ```\n@alice\n``` text @alice",
+      expected: "inline `@alice` fence ```\n@alice\n``` text <@123456789>",
+    },
+    {
+      name: "unterminated single-backtick code",
+      input: "outside @alice then `inside @alice",
+      expected: "outside <@123456789> then `inside @alice",
+    },
+    {
+      name: "unterminated double-backtick code",
+      input: "outside @alice then ``inside @alice",
+      expected: "outside <@123456789> then ``inside @alice",
+    },
+  ])("does not rewrite mentions inside $name", ({ input, expected }) => {
     rememberDiscordDirectoryUser({
       accountId: "default",
       userId: "123456789",
       handles: ["alice"],
     });
-    const rewritten = rewriteDiscordKnownMentions(
-      "inline `@alice` fence ```\n@alice\n``` text @alice",
-      {
-        accountId: "default",
-      },
-    );
-    expect(rewritten).toBe("inline `@alice` fence ```\n@alice\n``` text <@123456789>");
+    expect(rewriteDiscordKnownMentions(input, { accountId: "default" })).toBe(expected);
   });
 
   it("does not end longer code fences at triple-backtick literals inside the body", () => {

--- a/extensions/discord/src/mentions.ts
+++ b/extensions/discord/src/mentions.ts
@@ -155,16 +155,16 @@ function findNextMarkdownCodeSegment(
   text: string,
   startIndex: number,
 ): { startIndex: number; endIndex: number } | null {
-  const segmentStart = text.indexOf("`", startIndex);
-  if (segmentStart === -1) {
+  const segmentOffset = text.slice(startIndex).search(/(?<=(?:^|[^\\])(?:\\\\)*)`/);
+  if (segmentOffset === -1) {
     return null;
   }
+  const segmentStart = startIndex + segmentOffset;
   const runLength = countBacktickRun(text, segmentStart);
-  const inlineEndIndex = findSameLineBacktickRun(text, segmentStart + runLength, runLength);
   return {
     startIndex: segmentStart,
     endIndex:
-      inlineEndIndex ??
+      findSameLineBacktickRun(text, segmentStart + runLength, runLength) ??
       (runLength >= 3 ? findFenceEnd(text, segmentStart, runLength) : text.length),
   };
 }

--- a/extensions/discord/src/mentions.ts
+++ b/extensions/discord/src/mentions.ts
@@ -155,26 +155,18 @@ function findNextMarkdownCodeSegment(
   text: string,
   startIndex: number,
 ): { startIndex: number; endIndex: number } | null {
-  let searchIndex = startIndex;
-  while (searchIndex < text.length) {
-    const segmentStart = text.indexOf("`", searchIndex);
-    if (segmentStart === -1) {
-      return null;
-    }
-    const runLength = countBacktickRun(text, segmentStart);
-    const inlineEndIndex = findSameLineBacktickRun(text, segmentStart + runLength, runLength);
-    if (inlineEndIndex !== null) {
-      return { startIndex: segmentStart, endIndex: inlineEndIndex };
-    }
-    if (runLength >= 3) {
-      return {
-        startIndex: segmentStart,
-        endIndex: findFenceEnd(text, segmentStart, runLength),
-      };
-    }
-    searchIndex = segmentStart + runLength;
+  const segmentStart = text.indexOf("`", startIndex);
+  if (segmentStart === -1) {
+    return null;
   }
-  return null;
+  const runLength = countBacktickRun(text, segmentStart);
+  const inlineEndIndex = findSameLineBacktickRun(text, segmentStart + runLength, runLength);
+  return {
+    startIndex: segmentStart,
+    endIndex:
+      inlineEndIndex ??
+      (runLength >= 3 ? findFenceEnd(text, segmentStart, runLength) : text.length),
+  };
 }
 
 export function rewriteDiscordKnownMentions(

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -683,6 +683,8 @@ describe("sendMessageDiscord", () => {
   it.each([
     { input: "ping @Alice", expected: "ping <@123456789012345678>" },
     { input: "Run `notify @Alice", expected: "Run `notify @Alice" },
+    { input: "literal \\` ping @Alice", expected: "literal \\` ping <@123456789012345678>" },
+    { input: "literal \\\\` inside @Alice", expected: "literal \\\\` inside @Alice" },
   ])(
     "rewrites cached @username mentions only outside code: $input",
     async ({ input, expected }) => {

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -680,27 +680,33 @@ describe("sendMessageDiscord", () => {
     expect(body).not.toHaveProperty("flags");
   });
 
-  it("rewrites cached @username mentions to id-based mentions", async () => {
-    rememberDiscordDirectoryUser({
-      accountId: "default",
-      userId: "123456789012345678",
-      handles: ["Alice"],
-    });
-    const { rest, postMock, getMock } = makeDiscordRest();
-    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });
-    postMock.mockResolvedValue({
-      id: "msg1",
-      channel_id: "789",
-    });
-    await sendMessageDiscord("channel:789", "ping @Alice", {
-      rest,
-      token: "t",
-      cfg: DISCORD_TEST_CFG,
-      accountId: "default",
-    });
-    expectRestRoute(postMock, 0, Routes.channelMessages("789"));
-    expect(requireRestBody(postMock).content).toBe("ping <@123456789012345678>");
-  });
+  it.each([
+    { input: "ping @Alice", expected: "ping <@123456789012345678>" },
+    { input: "Run `notify @Alice", expected: "Run `notify @Alice" },
+  ])(
+    "rewrites cached @username mentions only outside code: $input",
+    async ({ input, expected }) => {
+      rememberDiscordDirectoryUser({
+        accountId: "default",
+        userId: "123456789012345678",
+        handles: ["Alice"],
+      });
+      const { rest, postMock, getMock } = makeDiscordRest();
+      getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });
+      postMock.mockResolvedValue({
+        id: "msg1",
+        channel_id: "789",
+      });
+      await sendMessageDiscord("channel:789", input, {
+        rest,
+        token: "t",
+        cfg: DISCORD_TEST_CFG,
+        accountId: "default",
+      });
+      expectRestRoute(postMock, 0, Routes.channelMessages("789"));
+      expect(requireRestBody(postMock).content).toBe(expected);
+    },
+  );
 
   it("rewrites configured @username aliases to id-based mentions", async () => {
     const { rest, postMock, getMock } = makeDiscordRest();

--- a/extensions/discord/src/send.webhook.proxy.test.ts
+++ b/extensions/discord/src/send.webhook.proxy.test.ts
@@ -153,12 +153,18 @@ describe("sendWebhookMessageDiscord proxy support", () => {
     globalFetchMock.mockRestore();
   });
 
-  it("does not rewrite webhook mentions inside unterminated inline code", async () => {
+  it.each([
+    { input: "Run `notify @OpsLead", expected: "Run `notify @OpsLead" },
+    {
+      input: "literal \\` ping @OpsLead",
+      expected: "literal \\` ping <@123456789012345678>",
+    },
+  ])("only rewrites webhook mentions outside inline code: $input", async ({ input, expected }) => {
     const globalFetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response(JSON.stringify({ id: "msg-code" }), { status: 200 }));
 
-    await sendWebhookMessageDiscord("Run `notify @OpsLead", {
+    await sendWebhookMessageDiscord(input, {
       cfg: {
         channels: {
           discord: {
@@ -173,7 +179,9 @@ describe("sendWebhookMessageDiscord proxy support", () => {
       wait: true,
     });
 
-    expect(globalFetchMock.mock.calls[0]?.[1]?.body).toContain('"content":"Run `notify @OpsLead"');
+    expect(globalFetchMock.mock.calls[0]?.[1]?.body).toContain(
+      `"content":${JSON.stringify(expected)}`,
+    );
   });
 
   it("accepts Discord's no-body webhook response when wait is false", async () => {

--- a/extensions/discord/src/send.webhook.proxy.test.ts
+++ b/extensions/discord/src/send.webhook.proxy.test.ts
@@ -153,6 +153,29 @@ describe("sendWebhookMessageDiscord proxy support", () => {
     globalFetchMock.mockRestore();
   });
 
+  it("does not rewrite webhook mentions inside unterminated inline code", async () => {
+    const globalFetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ id: "msg-code" }), { status: 200 }));
+
+    await sendWebhookMessageDiscord("Run `notify @OpsLead", {
+      cfg: {
+        channels: {
+          discord: {
+            token: "Bot test-token",
+            mentionAliases: { opslead: "123456789012345678" },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "default",
+      webhookId: "123",
+      webhookToken: "abc",
+      wait: true,
+    });
+
+    expect(globalFetchMock.mock.calls[0]?.[1]?.body).toContain('"content":"Run `notify @OpsLead"');
+  });
+
   it("accepts Discord's no-body webhook response when wait is false", async () => {
     const response = new Response(null, { status: 204 });
     const jsonSpy = vi.spyOn(response, "json");


### PR DESCRIPTION
## What Problem This Solves

Discord rewrites a harmless name inside unfinished inline Markdown code into a real native user mention, generating an unintended notification through both ordinary bot messages and persona webhooks.

## Why This Change Was Made

The Discord mention owner's private Markdown scanner skipped unmatched one- and two-backtick openers, while the canonical Markdown code-span owner already treats those spans as protected through the end of the message. The scanner now locates the first genuine unescaped code delimiter, honors odd/even preceding backslashes, and protects real unfinished code through the end of the message. Simplifying the owner removes eight production lines overall.

## User Impact

Messages such as `Run \`notify @Alice` remain literal unfinished code instead of unexpectedly pinging Alice. Escaped literal backticks do not suppress later legitimate mentions; odd/even backslash parity, balanced inline code, fenced code, ordinary intentional mentions, bot delivery, and persona webhooks keep their existing behavior.

## Evidence

- Four authentic owner and provider-boundary regressions failed before the original repair; four additional escaped-delimiter owner/transport regressions failed before the review follow-up.
- `node scripts/run-vitest.mjs extensions/discord/src/mentions.test.ts extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/send.webhook.proxy.test.ts` passed all 123 tests.
- Actual production Discord bot REST and webhook HTTP payloads were independently exercised using local fake transports; neither emits a native user mention after the fix.
- Focused type-aware lint, formatting, maximum-lines/assertion ratchets, odd/even backslash parity cases, and fresh independent complete-branch structured review passed.
- Production delta: +11/-19 lines, net -8.
