### PR TITLE
fix(ui): protect chat controls during text composition

### DIFF
--- a/ui/src/pages/chat/components/chat-controls-composition.test.ts
+++ b/ui/src/pages/chat/components/chat-controls-composition.test.ts
@@ -1,0 +1,122 @@
+import { render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderChatModelPicker } from "./chat-model-picker.ts";
+import { mountChatPaneHeader } from "./chat-pane-header.test-support.ts";
+
+type CompositionMode = "active" | "legacy" | "none";
+
+const containers: HTMLElement[] = [];
+
+afterEach(() => {
+  containers.splice(0).forEach((container) => container.remove());
+});
+
+function dispatchInputKey(target: Element, key: string, composition: CompositionMode) {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    isComposing: composition === "active",
+    key,
+  });
+  if (composition === "legacy") {
+    Object.defineProperty(event, "keyCode", { value: 229 });
+  }
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe("chat control IME composition", () => {
+  it.each([
+    { composition: "active", key: "Enter" },
+    { composition: "active", key: "Escape" },
+    { composition: "legacy", key: "Enter" },
+    { composition: "legacy", key: "Escape" },
+    { composition: "none", key: "Enter" },
+    { composition: "none", key: "Escape" },
+  ] as const)(
+    "routes session rename $key only outside $composition composition",
+    ({ composition, key }) => {
+      const { container, props } = mountChatPaneHeader(containers, {
+        editing: true,
+        renameValue: "研究",
+      });
+      const input = container.querySelector<HTMLInputElement>(".chat-pane__session-title-input");
+      expect(input).toBeInstanceOf(HTMLInputElement);
+
+      const event = dispatchInputKey(input!, key, composition);
+
+      expect(event.defaultPrevented).toBe(composition === "none");
+      expect(props.onCommitRename).toHaveBeenCalledTimes(
+        composition === "none" && key === "Enter" ? 1 : 0,
+      );
+      expect(props.onCancelRename).toHaveBeenCalledTimes(
+        composition === "none" && key === "Escape" ? 1 : 0,
+      );
+    },
+  );
+
+  it.each([
+    { composition: "active", key: "Enter" },
+    { composition: "active", key: "ArrowDown" },
+    { composition: "active", key: "ArrowUp" },
+    { composition: "legacy", key: "Enter" },
+    { composition: "legacy", key: "ArrowDown" },
+    { composition: "legacy", key: "ArrowUp" },
+    { composition: "none", key: "Enter" },
+    { composition: "none", key: "ArrowDown" },
+    { composition: "none", key: "ArrowUp" },
+  ] as const)(
+    "routes model search $key only outside $composition composition",
+    ({ composition, key }) => {
+      const onModelSelect = vi.fn(async () => true);
+      const container = document.createElement("div");
+      containers.push(container);
+      render(
+        renderChatModelPicker({
+          disabled: false,
+          modelSelectionLocked: false,
+          modelOptions: [
+            {
+              commitValue: "openai/alpha",
+              isDefault: false,
+              label: "Alpha",
+              provider: "openai",
+              value: "openai/alpha",
+            },
+            {
+              commitValue: "anthropic/beta",
+              isDefault: false,
+              label: "Beta",
+              provider: "anthropic",
+              value: "anthropic/beta",
+            },
+          ],
+          onModelSelect,
+          selectedModelValue: "openai/alpha",
+          sessionKey: "main",
+          triggerModelLabel: "Alpha",
+        }),
+        container,
+      );
+      const picker = container.querySelector<HTMLDetailsElement>(".chat-controls__model-picker");
+      const search = container.querySelector<HTMLInputElement>("[data-chat-model-search]");
+      expect(picker).toBeInstanceOf(HTMLDetailsElement);
+      expect(search).toBeInstanceOf(HTMLInputElement);
+      picker!.open = true;
+      search!.value = "beta";
+      search!.dispatchEvent(new InputEvent("input", { bubbles: true }));
+      const highlighted = search!.getAttribute("aria-activedescendant");
+
+      const event = dispatchInputKey(search!, key, composition);
+
+      expect(event.defaultPrevented).toBe(composition === "none");
+      expect(search!.getAttribute("aria-activedescendant")).toBe(highlighted);
+      const selected = composition === "none" && key === "Enter";
+      expect(picker!.open).toBe(!selected);
+      expect(onModelSelect).toHaveBeenCalledTimes(selected ? 1 : 0);
+      if (selected) {
+        expect(onModelSelect).toHaveBeenCalledWith("anthropic/beta", "main");
+      }
+    },
+  );
+});

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -193,7 +193,7 @@ export function clearChatModelSearchOnEscape(event: KeyboardEvent): boolean {
 function handleModelSearchKeydown(event: KeyboardEvent): void {
   const input = event.currentTarget as HTMLInputElement;
   const menu = pickerMenu(input);
-  if (!menu) {
+  if (!menu || event.isComposing || event.keyCode === 229) {
     return;
   }
   const rows = selectableModelRows(menu);

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -218,12 +218,12 @@ function renderSessionCrumb(props: ChatPaneHeaderProps) {
       @input=${(event: InputEvent) =>
         props.onRenameInput((event.currentTarget as HTMLInputElement).value)}
       @keydown=${(event: KeyboardEvent) => {
-        if (event.key === "Enter") {
+        if (event.isComposing || event.keyCode === 229) {
+          return;
+        }
+        if (event.key === "Enter" || event.key === "Escape") {
           event.preventDefault();
-          props.onCommitRename();
-        } else if (event.key === "Escape") {
-          event.preventDefault();
-          props.onCancelRename();
+          (event.key === "Enter" ? props.onCommitRename : props.onCancelRename)();
         }
       }}
       @blur=${props.onCommitRename}


### PR DESCRIPTION
## What Problem This Solves

Chat session renaming and model selection process IME composition key events as ordinary Enter, Escape, or navigation events. Japanese, Chinese, and Korean text entry can therefore accidentally persist an unfinished session name, discard a rename, switch models, or close the picker.

## Why This Change Was Made

Both chat controls ignored the modern `isComposing` signal and legacy key code 229, despite adjacent existing chat composers already protecting both. Their canonical keyboard owners now honor the same established composition contract, with no production growth.

## User Impact

Composing text no longer commits or cancels session renaming and no longer navigates or changes the model picker. Normal Enter, Escape, and arrow behavior is unchanged.

## Evidence

- Ten real rendered Lit/JSDOM composition regressions failed on pre-fix production code.
- Fifteen modern/legacy IME and ordinary-key regression cases now pass; 79 focused rendered chat/composer tests pass across four suites.
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-controls-composition.test.ts ui/src/pages/chat/components/chat-question-card.test.ts ui/src/pages/new-session/composer.test.ts ui/src/pages/chat/chat-composer.test.ts`
- Focused lint, formatting, stylelint, localization verification, and fresh independent structured review passed.
- Production delta: +6/-6 lines, net 0.
- Screenshot gap: this is temporal keyboard-composition behavior, not a persistent visual layout difference; the existing local UI dependency tree additionally lacks an already-declared Panzoom dependency. Rendered production controls are exercised directly instead.
