### PR TITLE
fix(telegram): preserve sent replies when required pins fail

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -588,6 +588,9 @@ async function maybePinFirstDeliveredMessage(params: {
       disable_notification: !notify,
     });
   } catch (err) {
+    if (typeof params.pin === "object" && params.pin.required === true) {
+      throw err;
+    }
     logVerbose(
       `telegram pinChatMessage failed chat=${params.chatId} message=${params.firstDeliveredMessageId}: ${formatErrorMessage(err)}`,
     );
@@ -912,6 +915,7 @@ export async function deliverReplies(params: {
           replyToId,
           replyToMode: params.replyToMode,
           progress,
+          acceptedMessageIds,
           recordMessageId,
           onPlatformSendDispatch: params.onPlatformSendDispatch,
         });

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -3121,6 +3121,25 @@ describe("deliverReplies", () => {
     expect(pinChatMessage).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves accepted text delivery when a required pin fails", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 201, chat: { id: "123" } });
+    const pinChatMessage = vi.fn().mockRejectedValue(new Error("pin failed"));
+
+    await expect(
+      deliverWith({
+        replies: [{ text: "hello", delivery: { pin: { enabled: true, required: true } } }],
+        runtime: createRuntime(),
+        bot: createBot({ sendMessage, pinChatMessage }),
+      }),
+    ).rejects.toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: { messageIds: ["201"], visibleReplySent: true },
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(pinChatMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("rethrows VOICE_MESSAGES_FORBIDDEN when no text fallback is available", async () => {
     const { runtime, sendVoice, sendMessage, bot } = createVoiceFailureHarness({
       voiceError: createVoiceMessagesForbiddenError(),


### PR DESCRIPTION
## What Problem This Solves

Telegram reports success when an explicitly required message pin fails. Naively propagating the pin failure also loses the already-sent message identity and causes slash-command fallback handlers to send a second visible reply.

## Why This Change Was Made

The Telegram delivery owner swallowed all pin errors and omitted its existing accepted-message-ID collector when sending ordinary text, even though media and text fallback siblings already preserve those IDs. Required pin errors now propagate, and the original successful text delivery is recorded before the post-send pin fails.

## User Impact

Required pin failures are visible as accurate partial delivery, including the original accepted Telegram message identifier; duplicate fallback replies are prevented. Optional pins remain best-effort and preserve existing successful-send behavior.

## Evidence

- The actual production Telegram delivery owner incorrectly succeeded before repair and correctly reports partial delivery afterward, with exactly one send and one pin attempt.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/bot-native-command-dispatch.delivery.test.ts` passed all 132 owner and slash-command sibling tests.
- The isolated worktree's missing local `undici` importer required a temporary test-runner alias to the already-installed parent dependency; the alias was restored immediately after proof and is not included in this change.
- Focused type-aware lint, formatting, maximum-lines ratchet, and fresh independent structured review passed.
- Production delta: +4 lines, justified by required-operation failure propagation and authoritative accepted-message identity.
