### PR TITLE
test(agents): mock the provider-runtime export prepare-auth now calls

### DIFF
--- a/src/agents/runtime-plan/prepare-auth.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.test.ts
@@ -15,6 +15,7 @@ import {
 // coverage; keep those runtimes out of this focused planner test.
 vi.mock("../../plugins/provider-runtime.js", () => ({
   buildProviderMissingAuthMessageWithPlugin: () => undefined,
+  resolveProviderDeprecatedAuthProfileIds: () => [],
   resolveProviderSyntheticAuthWithPlugin: () => undefined,
   shouldDeferProviderSyntheticProfileAuthWithPlugin: () => undefined,
 }));


### PR DESCRIPTION
## What Problem This Solves

`src/agents/runtime-plan/prepare-auth.test.ts` fails on `main`, so every pull request whose merge ref includes the break inherits it.

```
FAIL src/agents/runtime-plan/prepare-auth.test.ts > prepareAgentRuntimeAuthPlan >
     keeps profile auth ahead of a literal provider apiKey fallback
Error: [vitest] No "resolveProviderDeprecatedAuthProfileIds" export is defined on
       the "../../plugins/provider-runtime.js" mock.
  ❯ getDeprecatedProfileIds src/agents/model-auth-provider.ts:124:7
  ❯ resolveApiKeyForProviderCore src/agents/model-auth-provider.ts:155:29
  ❯ Module.getApiKeyForModelCore src/agents/model-auth-model.ts:249:10
  ❯ src/agents/runtime-plan/prepare-auth.test.ts:1266:35
```

The test replaces `../../plugins/provider-runtime.js` with a factory returning three exports. `resolveProviderDeprecatedAuthProfileIds` became a fourth one the module under test reaches: `model-auth-provider.ts:121-125` memoizes it through `getDeprecatedProfileIds`, which `resolveApiKeyForProviderCore` calls. The export and the call both arrived in `750a64e7cd4` (*fix(anthropic): keep Claude CLI authentication native*, #129052); the mock factory was not updated with them.

## Why This Change Was Made

The mock returns `[]`, which is what the real function returns for these fixtures. `resolveProviderDeprecatedAuthProfileIds` is `resolveProviderRuntimePlugin(params)?.deprecatedProfileIds ?? []` (`src/plugins/provider-runtime.ts:896-903`), and no provider runtime plugin is registered in this suite, so the unmocked value would be `[]` as well. Nothing in the test's behavior changes; the missing entry is restored rather than the assertions being relaxed.

Adding the export to the factory rather than switching the whole file to `importOriginal` keeps the existing explicit-surface style, where the factory names exactly what this suite intends to stub.

## Evidence

On a clean checkout of `41e87013ae4`:

```
before   Test Files  1 failed (1)     Tests  1 failed | 62 passed (63)
after    Test Files  1 passed (1)     Tests  63 passed (63)
```

Command: `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-support.config.ts src/agents/runtime-plan/prepare-auth.test.ts`

Gates: `format:check` clean (30,132 files), `tsgo:core` 0 errors, `oxlint` on the changed file exit 0.

## User Impact

None at runtime. This is a test-only change that unblocks CI.
