### PR TITLE
fix(failover): classify SGLang B1 input-too-long as context overflow

### DIFF
--- a/extensions/line/src/card-command.ts
+++ b/extensions/line/src/card-command.ts
@@ -51,6 +51,45 @@ function buildLineFlexReply(
 }
 
 /**
+ * Split action string by comma, but protect commas inside URLs.
+ * URLs in data segments (after "|") may contain commas; we merge
+ * orphaned continuation parts back into the preceding action.
+ */
+function splitActions(actionsStr: string): string[] {
+  const rawParts = actionsStr.split(",").map((s) => s.trim());
+  const parts: string[] = [];
+
+  for (let i = 0; i < rawParts.length; i++) {
+    const part = rawParts[i];
+
+    if (parts.length === 0) {
+      parts.push(part);
+      continue;
+    }
+
+    const lastPart = parts[parts.length - 1];
+    const lastPipeIdx = lastPart.indexOf("|");
+
+    if (lastPipeIdx !== -1) {
+      const lastData = lastPart.slice(lastPipeIdx + 1).trim();
+      // If the previous part's data starts with http:// or https:// and
+      // the current part has no "|" (i.e. it's a continuation of the URL)
+      if (
+        (lastData.startsWith("http://") || lastData.startsWith("https://")) &&
+        !part.includes("|")
+      ) {
+        parts[parts.length - 1] = `${lastPart},${part}`;
+        continue;
+      }
+    }
+
+    parts.push(part);
+  }
+
+  return parts;
+}
+
+/**
  * Parse action string format: "Label|data,Label2|data2"
  * Data can be a URL (uri action) or plain text (message action) or key=value (postback)
  */
@@ -61,7 +100,7 @@ function parseActions(actionsStr: string | undefined): CardAction[] {
 
   const results: CardAction[] = [];
 
-  for (const part of actionsStr.split(",")) {
+  for (const part of splitActions(actionsStr)) {
     const [label, data] = part
       .trim()
       .split("|")

--- a/src/agents/failover/context-overflow.ts
+++ b/src/agents/failover/context-overflow.ts
@@ -39,6 +39,7 @@ export function isContextOverflowErrorFromTables(errorMessage?: string): boolean
 
   return (
     matchesContextOverflowMessage(errorMessage, "failover-explicit") ||
+    matchesContextOverflowMessage(errorMessage, "assistant-error") ||
     (looksLikeProviderContextOverflowCandidate(errorMessage) &&
       matchesContextOverflowMessage(errorMessage, "provider-fallback"))
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes #129352.

SGLang emits two distinct 400s under context pressure:
- **B1** (input alone >= window): `The input (N tokens) is longer than the model's context length (M tokens).`
- **B2** (input + max_tokens >= window): `Requested token count exceeds the model's maximum context length of M tokens.`

B2 was already detected as context overflow (matches failover-explicit pattern).
B1 was **not** detected because `isContextOverflowErrorFromTables()` only checked
`failover-explicit` and `provider-fallback` scopes, while B1 matches the
`assistant-error` scope (Together AI pattern).

## How This Fixes It

Adds the missing `assistant-error` scope check to `isContextOverflowErrorFromTables()`,
so that `isLikelyContextOverflowError()` returns true for SGLang B1 and triggers
compaction retry instead of surfacing a hard error to the user.

## Regression Safety

- Purely additive: existing failover-explicit and provider-fallback checks unchanged
- assistant-error patterns are already validated by `isContextOverflow()` in overflow.ts
