### PR TITLE
fix(cli): avoid state migration for pristine invalid profiles

### DIFF
--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -387,6 +387,7 @@ describe("rejected CLI process state isolation", () => {
         "--profile",
         profile,
       ],
+      env: { EXA_API_KEY: "synthetic-fixture" },
       expectedExitCode: 1,
       pristineHome: true,
     });

--- a/src/commands/doctor/shared/pristine-startup-state.test.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.test.ts
@@ -126,6 +126,22 @@ describe("pristine startup state", () => {
     expect(fs.existsSync(stateDir)).toBe(false);
   });
 
+  it.each([
+    ["web search", { EXA_API_KEY: "synthetic-fixture" }],
+    ["model provider", { GROQ_API_KEY: "synthetic-fixture" }],
+    ["browser search", { BRAVE_API_KEY: "synthetic-fixture" }],
+    ["channel", { QQBOT_APP_ID: "synthetic-app", QQBOT_CLIENT_SECRET: "synthetic-fixture" }],
+  ])(
+    "does not mistake ambient-only %s credentials for persisted migration state",
+    (_label, env) => {
+      const fixture = { ...createFixture({}), ...env };
+      const expected = { skipAllStateMigrations: true, skipCoreStateMigrations: true };
+
+      expect(planPristineStartupStateMigrations(fixture)).toEqual(expected);
+      expect(planPristineStartupConfigMigrations({}, fixture)).toEqual(expected);
+    },
+  );
+
   it("accepts the core-only Gateway benchmark config", () => {
     const env = createFixture({
       browser: { enabled: false },

--- a/src/commands/doctor/shared/pristine-startup-state.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.ts
@@ -225,7 +225,7 @@ function configIsPristineStateSafe(
   }
   return !configMayRequireStartupPluginConvergence({
     config: config as OpenClawConfig,
-    env,
+    env: {},
   });
 }
 

--- a/src/commands/doctor/shared/startup-plugin-convergence-plan.test.ts
+++ b/src/commands/doctor/shared/startup-plugin-convergence-plan.test.ts
@@ -43,6 +43,19 @@ describe("startup plugin convergence planning", () => {
     });
   });
 
+  it.each([
+    ["web search", { EXA_API_KEY: "synthetic-fixture" }],
+    ["model provider", { GROQ_API_KEY: "synthetic-fixture" }],
+    ["browser search", { BRAVE_API_KEY: "synthetic-fixture" }],
+    ["channel", { QQBOT_APP_ID: "synthetic-app", QQBOT_CLIENT_SECRET: "synthetic-fixture" }],
+  ])("retains real Gateway convergence for ambient-only %s credentials", async (_label, env) => {
+    await expect(planStartupPluginConvergence({ config: {}, env })).resolves.toEqual({
+      required: true,
+      installRecords: {},
+    });
+    expect(loadInstalledPluginIndexInstallRecords).toHaveBeenCalledWith({ env });
+  });
+
   it("retains convergence for explicit plugin and runtime configuration", () => {
     expect(
       configMayRequireStartupPluginConvergence({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where running an invalid onboarding command with a selected, previously nonexistent profile could still create that profile's state directory before the command rejected its invalid options.

## Why This Change Was Made

Determine whether historical state requires startup migration from persisted configuration rather than unrelated ambient provider or channel credentials. Real startup plugin safety checks and Gateway convergence continue to use the actual environment, so configured integrations, first-start behavior, and approval protections remain intact.

## User Impact

An invalid onboarding command now exits promptly without creating an unwanted profile directory. Existing configured plugins and environment-enabled Gateway integrations continue to activate normally.

## Evidence

- The original real selected-profile onboarding process failed before the fix, created state directories, and ran for 33–41 seconds; afterward it passes in 1.89 seconds without creating the profile directory.
- Five focused Doctor, migration-planning, plugin-convergence, channel, and QQBot security suites pass all 109 tests.
- Four synthetic provider/channel environment families verify pristine migration planning separately from actual Gateway environment-driven convergence.
- Regression coverage preserves real environment-based plugin activation and locked approval behavior.
- Production change: one line replaced with one line; existing focused regression suites gain 30 lines.
- Targeted formatting, lint, changed-file guards, and independent structured review all pass.
