### PR TITLE
fix: report native Claude CLI auth in status

### DIFF
--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -150,7 +150,9 @@ export function shouldPreferActiveRuntimeAliasAuthLabel(params: {
   return (
     selectedAuth === "unknown" ||
     (Boolean(selectedAuth?.startsWith("api-key")) &&
-      (activeAuth.startsWith("oauth") || activeAuth.startsWith("token")))
+      (activeAuth.startsWith("oauth") ||
+        activeAuth.startsWith("token") ||
+        activeAuth.startsWith("native")))
   );
 }
 

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -1895,23 +1895,9 @@ describe("buildStatusReply subagent summary", () => {
     );
   });
 
-  it("uses Claude CLI OAuth auth labels for anthropic models running on the Claude CLI runtime", async () => {
+  it("uses native Claude CLI auth labels for anthropic models running on the Claude CLI runtime", async () => {
     await withTempHome(
-      async (dir) => {
-        const authPath = path.join(dir, ".claude", ".credentials.json");
-        fs.mkdirSync(path.dirname(authPath), { recursive: true });
-        fs.writeFileSync(
-          authPath,
-          JSON.stringify({
-            claudeAiOauth: {
-              accessToken: "access-token",
-              refreshToken: "refresh-token",
-              expiresAt: Date.now() + 60_000,
-            },
-          }),
-          "utf8",
-        );
-
+      async () => {
         const text = await buildStatusText({
           cfg: {
             ...baseCfg,
@@ -1943,7 +1929,7 @@ describe("buildStatusReply subagent summary", () => {
 
         const normalized = normalizeTestText(text);
         expect(normalized).toContain("Model: anthropic/claude-opus-4-7");
-        expect(normalized).toContain("oauth (claude-cli)");
+        expect(normalized).toContain("native (claude-cli)");
       },
       {
         env: {
@@ -1954,7 +1940,7 @@ describe("buildStatusReply subagent summary", () => {
     );
   });
 
-  it("prefers active Claude CLI OAuth over selected env API-key labels for runtime aliases", async () => {
+  it("prefers active native Claude CLI auth over selected env API-key labels for runtime aliases", async () => {
     const text = await buildStatusText({
       cfg: {
         ...baseCfg,
@@ -1993,12 +1979,12 @@ describe("buildStatusReply subagent summary", () => {
       isGroup: false,
       defaultGroupActivation: () => "mention",
       modelAuthOverride: "api-key (env: ANTHROPIC_API_KEY)",
-      activeModelAuthOverride: "oauth (claude-cli)",
+      activeModelAuthOverride: "native (claude-cli)",
     });
 
     const normalized = normalizeTestText(text);
     expect(normalized).toContain("Model: anthropic/claude-opus-4-7");
-    expect(normalized).toContain("oauth (claude-cli)");
+    expect(normalized).toContain("native (claude-cli)");
     expect(normalized).not.toContain("api-key (env: ANTHROPIC_API_KEY)");
     expect(normalized).not.toContain("Usage:");
   });

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -124,7 +124,14 @@ type StatusArgs = {
   now?: number;
 };
 
-type NormalizedAuthMode = "api-key" | "oauth" | "token" | "aws-sdk" | "mixed" | "unknown";
+type NormalizedAuthMode =
+  | "api-key"
+  | "oauth"
+  | "token"
+  | "aws-sdk"
+  | "native"
+  | "mixed"
+  | "unknown";
 
 function normalizeAuthMode(value?: string): NormalizedAuthMode | undefined {
   const normalized = normalizeOptionalLowercaseString(value);
@@ -142,6 +149,9 @@ function normalizeAuthMode(value?: string): NormalizedAuthMode | undefined {
   }
   if (normalized === "aws-sdk" || normalized.startsWith("aws-sdk ")) {
     return "aws-sdk";
+  }
+  if (normalized === "native" || normalized.startsWith("native ")) {
+    return "native";
   }
   if (normalized === "mixed" || normalized.startsWith("mixed ")) {
     return "mixed";


### PR DESCRIPTION
## Summary

Make `/status` report native Claude CLI authentication accurately.

This is a presentation follow-up to #129052, which changed Claude CLI authentication from copied OAuth state to a native runtime-owned label.

## Root Cause

The status auth-mode normalizer recognized API keys, OAuth, tokens, AWS SDK auth, mixed auth, and unknown auth, but not the `native` mode introduced by the ownership change in #129052.

The runtime-alias precedence helper also allowed active OAuth or token auth to replace a selected API-key label, while omitting active native auth. As a result, `/status` could drop `native (claude-cli)` or show an environment API key instead of the authentication actually used.

## Changes

- recognize `native` as a status authentication mode
- prefer active native runtime auth over a selected API-key label for equivalent runtime aliases
- keep existing OAuth, token, and non-alias behavior unchanged
- remove the copied Claude credential setup from the status regression fixture

## Verification

- 96 focused and sibling tests
- formatting
- Oxlint
- core typecheck
- autoreview
- independent review

Refs #129333
