### PR TITLE
fix: streaming a reply no longer builds an extension context for events no extension handles

### DIFF
--- a/src/agents/sessions/extensions/runner.test.ts
+++ b/src/agents/sessions/extensions/runner.test.ts
@@ -227,3 +227,58 @@ describe("ExtensionRunner handler dispatch", () => {
     expect(laterHandler).not.toHaveBeenCalled();
   });
 });
+
+describe("ExtensionRunner context construction", () => {
+  function messageUpdateEvent() {
+    return {
+      type: "message_update",
+      message: { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      assistantMessageEvent: { type: "text_delta", delta: "hi", contentIndex: 0 },
+    } as Parameters<ExtensionRunner["emit"]>[0];
+  }
+
+  it("skips building a context when no handler is registered for the event", async () => {
+    const noExtensions = buildRunner([]);
+    const noExtensionsSpy = vi.spyOn(noExtensions, "createContext");
+    await noExtensions.emit(messageUpdateEvent());
+    expect(noExtensionsSpy).not.toHaveBeenCalled();
+
+    const otherHandlersOnly = buildRunner([buildExtension({ user_bash: [async () => undefined] })]);
+    const otherHandlersSpy = vi.spyOn(otherHandlersOnly, "createContext");
+    await otherHandlersOnly.emit(messageUpdateEvent());
+    expect(otherHandlersSpy).not.toHaveBeenCalled();
+  });
+
+  it("builds one shared context for every handler of a dispatch", async () => {
+    const seen: unknown[] = [];
+    const record: TestHandler = async (_event, ctx) => {
+      seen.push(ctx);
+      return undefined;
+    };
+    const runner = buildRunner([
+      buildExtension({ message_update: [record] }, "/tmp/first.ts"),
+      buildExtension({ message_update: [record] }, "/tmp/second.ts"),
+    ]);
+    const spy = vi.spyOn(runner, "createContext");
+
+    await runner.emit(messageUpdateEvent());
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toBe(seen[1]);
+  });
+
+  it("skips building a context for tool_call when no handler is registered", async () => {
+    const runner = buildRunner([buildExtension({ user_bash: [async () => undefined] })]);
+    const spy = vi.spyOn(runner, "createContext");
+
+    await runner.emitToolCall({
+      type: "tool_call",
+      toolName: "custom",
+      toolCallId: "call-1",
+      input: {},
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/sessions/extensions/runner.ts
+++ b/src/agents/sessions/extensions/runner.ts
@@ -721,12 +721,20 @@ export class ExtensionRunner {
       ctx: ExtensionContext,
       extensionPath: string,
     ) => Promise<TResult | undefined>,
-    ctx = this.createContext(),
+    ctx?: ExtensionContext,
   ): Promise<TResult | undefined> {
+    // Built on first handler rather than up front: per-delta events (message_update,
+    // tool_execution_update) reach this funnel on every stream chunk, and createContext()
+    // allocates a closure per context field. One context is still shared across every
+    // handler of a dispatch, exactly as an eagerly built one was.
+    let handlerCtx = ctx;
     for (const ext of this.extensions) {
       for (const handler of ext.handlers.get(eventType) ?? []) {
+        // Outside the try: a context-construction failure is a runner fault, not the
+        // extension's, and must not be reported against ext.path as a handler error.
+        handlerCtx ??= this.createContext();
         try {
-          const result = await invoke(handler, ctx, ext.path);
+          const result = await invoke(handler, handlerCtx, ext.path);
           if (result !== undefined) {
             return result;
           }
@@ -816,7 +824,7 @@ export class ExtensionRunner {
   }
 
   async emitToolCall(event: ToolCallEvent): Promise<ToolCallEventResult | undefined> {
-    const ctx = this.createContext();
+    let ctx: ExtensionContext | undefined;
     let result: ToolCallEventResult | undefined;
 
     for (const ext of this.extensions) {
@@ -826,6 +834,7 @@ export class ExtensionRunner {
       }
 
       for (const handler of handlers) {
+        ctx ??= this.createContext();
         const handlerResult = await handler(event, ctx);
 
         if (handlerResult) {

--- a/src/agents/sessions/extensions/runner.ts
+++ b/src/agents/sessions/extensions/runner.ts
@@ -723,15 +723,12 @@ export class ExtensionRunner {
     ) => Promise<TResult | undefined>,
     ctx?: ExtensionContext,
   ): Promise<TResult | undefined> {
-    // Built on first handler rather than up front: per-delta events (message_update,
-    // tool_execution_update) reach this funnel on every stream chunk, and createContext()
-    // allocates a closure per context field. One context is still shared across every
-    // handler of a dispatch, exactly as an eagerly built one was.
     let handlerCtx = ctx;
     for (const ext of this.extensions) {
       for (const handler of ext.handlers.get(eventType) ?? []) {
-        // Outside the try: a context-construction failure is a runner fault, not the
-        // extension's, and must not be reported against ext.path as a handler error.
+        // Built on the first handler, not up front: per-delta events reach this funnel on
+        // every stream chunk. Still one context per dispatch, and outside the try so a
+        // construction failure stays a runner fault instead of ext.path's handler error.
         handlerCtx ??= this.createContext();
         try {
           const result = await invoke(handler, handlerCtx, ext.path);


### PR DESCRIPTION
## What Problem This Solves

`ExtensionRunner.dispatchHandlers` received the extension context as a **default parameter**, so it was constructed on every dispatch whose caller omitted the argument — which is every caller except `emitBeforeAgentStart`. Two of the events routed through that funnel, `message_update` and `tool_execution_update`, fire on every streamed chunk of every assistant reply (`src/agents/sessions/agent-session-base.ts:516` and `:540`). With no extensions installed — the default configuration — each delta therefore built a context and immediately dropped it, because the loop that follows found no handlers.

`createContext()` allocates 14 arrow closures plus an object literal carrying 7 getters and 7 method properties, each closing over one of those closures.

`emitToolCall` had the same shape: it built the context ahead of the loop that `continue`s past every extension without a `tool_call` handler.

## Why This Change Was Made

The class already has the guard and already applies it elsewhere. `hasHandlers()` (`runner.ts:518`) gates `emitSessionShutdownEvent` at `:207` and `emitContext` at `:859`, where the comment states the reasoning directly: skip the expensive per-turn work "unless a context handler is actually registered". The generic dispatch funnel was simply not covered by that rule, so this makes the treatment consistent rather than adding a new mechanism.

Deferring construction to the first handler, rather than pre-checking with `hasHandlers()`, was chosen because it needs no second traversal of the extension list and it keeps the existing contract that one context is shared across every handler of a dispatch. An explicitly supplied context (`emitBeforeAgentStart`) is still used as-is.

## User Impact

No behavioral change. Handlers receive the same context object they did before — one per dispatch, shared across handlers, with the same lazy getters resolving through `this` at access time, so staleness checks behave identically. The only difference is that a context is not built when nothing will receive it.

Streaming a reply with no extensions installed now performs no extension-context work. The saving scales with reply length times concurrent sessions, since the path is per-delta rather than per-turn.

## Evidence

**Provenance, stated up front.** The `0.8% self time` profile figure comes from the compiled dist of `v2026.7.1-2` under a 16-concurrent-agent load rig, not from current `main`. Everything else below I ran on this branch, on `main` @ `7a5de93228f`.

Root cause and owner: the dispatch funnel `ExtensionRunner.dispatchHandlers` owns context construction for every event except `tool_call`; `emitToolCall` owns its own. Both were fixed at the owner rather than at any caller. Production LOC delta **+9/−3**; no path removed, no new helper.

Regression test, and it fails on pre-fix code for the intended reason. With `runner.ts` restored to `main` and the new tests in place:

```
× skips building a context when no handler is registered for the event
× skips building a context for tool_call when no handler is registered
AssertionError: expected "createContext" to not be called at all, but actually been called 1 times
Tests  2 failed | 26 passed (28)
```

After the fix, `28 passed (28)`.

The third new test — one shared context per dispatch, asserting both handlers receive the identical object and `createContext` is called exactly once — passes both before and after. That is deliberate: it pins the sharing contract that the lazy construction must not break.

Microbench on this branch, Node 22.22.3, `main` @ `7a5de93228f`:

emit() on a runner with no extensions, i.e. exactly the per-delta zero-handler case:

  before   4.596 us/call   (min 4.533, max 4.623, n=5x100k)
  after    0.097 us/call   (min 0.091, max 0.102, n=5x100k)

createContext() measured on its own, unchanged by this PR, which confirms the saving
comes from not calling it rather than from making it cheaper:

  before   4.436 us/call   (min 4.413, max 4.536, n=5x200k)
  after    4.426 us/call   (min 4.409, max 4.499, n=5x200k)

Same script, same host, medians of 5 timed batches after a warmup batch, driving the
real ExtensionRunner from source via tsx.

Validation run:

- `node scripts/run-vitest.mjs src/agents/sessions/extensions` — 4 files, 28 tests, all passing.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` — exit 0.
- `node scripts/run-tsgo-core-test-shards.mjs src` — exit 0.
- `node scripts/check-changed.mjs` — exit 0, covering the oxlint core/extensions/scripts shards and the runtime import-cycle check (0 cycles).
- `node_modules/.bin/oxfmt` on both changed files.
- `pnpm build` — exit 0.

Scope of what was validated, stated precisely: the extension-runner suite, core and src-test typechecks, the lint and import-cycle lanes, and a full build. I did not run the full test suite. No live-channel or UI proof: this change is provider-, channel-, and UI-independent, and produces no user-visible output difference to capture.

Authorship disclosure: implemented and written with AI assistance (Claude). The reproduction, the pre-fix failure, the microbench, and every cited line anchor were verified by running them.

Closes #129359

## Review follow-ups

Both ClawSweeper rank-up moves are applied.

**Comment compressed to the 1–3 line form.** The two separate notes (4 lines plus 2) are now one 3-line comment at the single site that needs it.

**Lazy-context expression minimized, to the limit the lint rules allow.** I tried the smaller shape first — drop the `handlerCtx` local and assign the optional parameter directly with `ctx ??= this.createContext()`. That is rejected:

```
src/agents/sessions/extensions/runner.ts:731:9: error eslint(no-param-reassign):
Assignment to function parameter 'ctx'.
```

So the local stays; it is what makes the deferral expressible without reassigning a parameter. Noting it here so the shape does not read as an oversight.

**Rebased** onto current `main`; the change applied unchanged, with no conflicts in `runner.ts`.
