### PR TITLE
fix(reply): hide malformed reply directives from messages

### DIFF
--- a/src/agents/embedded-agent-subscribe.reply-tags.test.ts
+++ b/src/agents/embedded-agent-subscribe.reply-tags.test.ts
@@ -143,6 +143,12 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
     emitAssistantTextDelta({ emit, delta: "[[reply_to_" });
     emitAssistantTextDelta({ emit, delta: "current] Visible reply" });
     emitAssistantTextEnd({ emit });
+
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "[[reply_to_current] Visible reply" }],
+    } as AssistantMessage;
+    emit({ type: "message_end", message: assistantMessage });
     await subscription.waitForPendingEvents();
 
     expect(onBlockReply).toHaveBeenCalledTimes(1);

--- a/src/agents/embedded-agent-subscribe.reply-tags.test.ts
+++ b/src/agents/embedded-agent-subscribe.reply-tags.test.ts
@@ -135,4 +135,20 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
       expect(call[0]?.text?.includes("[[reply_to")).toBe(false);
     }
   });
+
+  it("strips a malformed reply prefix from the final block reply", () => {
+    const { emit, onBlockReply } = createBlockReplyHarness();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "[[reply_to_" });
+    emitAssistantTextDelta({ emit, delta: "current] Visible reply" });
+    emitAssistantTextEnd({ emit });
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    const payload = replyPayloadAt(onBlockReply, 0);
+    expect(payload.text).toBe("Visible reply");
+    expect(payload.replyToCurrent).toBeUndefined();
+    expect(payload.replyToTag).toBeUndefined();
+    expect(payload.text).not.toContain("[[reply_to");
+  });
 });

--- a/src/agents/embedded-agent-subscribe.reply-tags.test.ts
+++ b/src/agents/embedded-agent-subscribe.reply-tags.test.ts
@@ -154,8 +154,8 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
     expect(onBlockReply).toHaveBeenCalledTimes(1);
     const payload = replyPayloadAt(onBlockReply, 0);
     expect(payload.text).toBe("Visible reply");
-    expect(payload.replyToCurrent).toBeUndefined();
-    expect(payload.replyToTag).toBeUndefined();
+    expect(payload.replyToCurrent).toBeFalsy();
+    expect(payload.replyToTag).toBeFalsy();
     expect(payload.text).not.toContain("[[reply_to");
   });
 });

--- a/src/agents/embedded-agent-subscribe.reply-tags.test.ts
+++ b/src/agents/embedded-agent-subscribe.reply-tags.test.ts
@@ -34,7 +34,7 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
     const { session, emit } = createStubSessionHarness();
     const onBlockReply = vi.fn();
 
-    subscribeEmbeddedAgentSession({
+    const subscription = subscribeEmbeddedAgentSession({
       session,
       runId: "run",
       onBlockReply,
@@ -46,7 +46,7 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
       },
     });
 
-    return { emit, onBlockReply };
+    return { emit, onBlockReply, subscription };
   }
 
   it("carries reply_to_current across tag-only block chunks", () => {
@@ -136,13 +136,14 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
     }
   });
 
-  it("strips a malformed reply prefix from the final block reply", () => {
-    const { emit, onBlockReply } = createBlockReplyHarness();
+  it("strips a malformed reply prefix from the final block reply", async () => {
+    const { emit, onBlockReply, subscription } = createBlockReplyHarness();
 
     emit({ type: "message_start", message: { role: "assistant" } });
     emitAssistantTextDelta({ emit, delta: "[[reply_to_" });
     emitAssistantTextDelta({ emit, delta: "current] Visible reply" });
     emitAssistantTextEnd({ emit });
+    await subscription.waitForPendingEvents();
 
     expect(onBlockReply).toHaveBeenCalledTimes(1);
     const payload = replyPayloadAt(onBlockReply, 0);

--- a/src/agents/embedded-agent-subscribe.reply-tags.test.ts
+++ b/src/agents/embedded-agent-subscribe.reply-tags.test.ts
@@ -111,4 +111,28 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
       expect(call[0]?.text?.includes("[[reply_to")).toBe(false);
     }
   });
+
+  it("strips a malformed reply prefix when the stream ends", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onPartialReply = vi.fn();
+
+    subscribeEmbeddedAgentSession({
+      session,
+      runId: "run",
+      onPartialReply,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "[[reply_to_" });
+    emitAssistantTextDelta({ emit, delta: "current] Visible reply" });
+    emitAssistantTextEnd({ emit });
+
+    const payload = lastReplyPayload(onPartialReply);
+    expect(payload.text).toBe("Visible reply");
+    expect(payload.replyToCurrent).toBeUndefined();
+    expect(payload.replyToTag).toBeUndefined();
+    for (const call of onPartialReply.mock.calls) {
+      expect(call[0]?.text?.includes("[[reply_to")).toBe(false);
+    }
+  });
 });

--- a/src/agents/sessions/session-manager.persistence-compat.test.ts
+++ b/src/agents/sessions/session-manager.persistence-compat.test.ts
@@ -66,9 +66,11 @@ describe("SessionManager persistence compatibility", () => {
     ].join("\n");
     const codeExample = buildAssistantMessage(codeExampleText);
     const indentedCode = buildAssistantMessage("    [[reply_to_current]]\n    [[audio_as_voice]]");
+    const malformed = buildAssistantMessage("[[reply_to_current]\nVisible reply");
     manager.appendMessage(tagged);
     manager.appendMessage(codeExample);
     manager.appendMessage(indentedCode);
+    manager.appendMessage(malformed);
 
     expect(tagged.content).toEqual([{ type: "text", text: "Final answer" }]);
     expect(tagged).toMatchObject({
@@ -91,15 +93,18 @@ describe("SessionManager persistence compatibility", () => {
     expect(codeExample.content).toEqual([{ type: "text", text: codeExampleText }]);
     expect(codeExample).not.toHaveProperty("openclawDelivery");
     expect(indentedCode).not.toHaveProperty("openclawDelivery");
+    expect(malformed.content).toEqual([{ type: "text", text: "Visible reply" }]);
+    expect(malformed).not.toHaveProperty("openclawDelivery");
 
     const persistedMessages = (await loadTranscriptEvents(scope))
       .filter((event) => (event as { type?: unknown }).type === "message")
       .map((event) => (event as { message: unknown }).message);
-    expect(persistedMessages).toEqual([tagged, codeExample, indentedCode]);
+    expect(persistedMessages).toEqual([tagged, codeExample, indentedCode, malformed]);
     expect(SessionManager.open(scope, dir).buildSessionContext().messages).toEqual([
       tagged,
       codeExample,
       indentedCode,
+      malformed,
     ]);
   });
 

--- a/src/agents/sessions/session-manager.persistence-compat.test.ts
+++ b/src/agents/sessions/session-manager.persistence-compat.test.ts
@@ -105,13 +105,7 @@ describe("SessionManager persistence compatibility", () => {
     const persistedMessages = (await loadTranscriptEvents(scope))
       .filter((event) => (event as { type?: unknown }).type === "message")
       .map((event) => (event as { message: unknown }).message);
-    expect(persistedMessages).toEqual([
-      tagged,
-      codeExample,
-      indentedCode,
-      malformed,
-      laterLiteral,
-    ]);
+    expect(persistedMessages).toEqual([tagged, codeExample, indentedCode, malformed, laterLiteral]);
     expect(SessionManager.open(scope, dir).buildSessionContext().messages).toEqual([
       tagged,
       codeExample,

--- a/src/agents/sessions/session-manager.persistence-compat.test.ts
+++ b/src/agents/sessions/session-manager.persistence-compat.test.ts
@@ -67,10 +67,12 @@ describe("SessionManager persistence compatibility", () => {
     const codeExample = buildAssistantMessage(codeExampleText);
     const indentedCode = buildAssistantMessage("    [[reply_to_current]]\n    [[audio_as_voice]]");
     const malformed = buildAssistantMessage("[[reply_to_current]\nVisible reply");
+    const laterLiteral = buildAssistantMessage("Visible reply\n[[reply_to_current] literally");
     manager.appendMessage(tagged);
     manager.appendMessage(codeExample);
     manager.appendMessage(indentedCode);
     manager.appendMessage(malformed);
+    manager.appendMessage(laterLiteral);
 
     expect(tagged.content).toEqual([{ type: "text", text: "Final answer" }]);
     expect(tagged).toMatchObject({
@@ -95,16 +97,27 @@ describe("SessionManager persistence compatibility", () => {
     expect(indentedCode).not.toHaveProperty("openclawDelivery");
     expect(malformed.content).toEqual([{ type: "text", text: "Visible reply" }]);
     expect(malformed).not.toHaveProperty("openclawDelivery");
+    expect(laterLiteral.content).toEqual([
+      { type: "text", text: "Visible reply\n[[reply_to_current] literally" },
+    ]);
+    expect(laterLiteral).not.toHaveProperty("openclawDelivery");
 
     const persistedMessages = (await loadTranscriptEvents(scope))
       .filter((event) => (event as { type?: unknown }).type === "message")
       .map((event) => (event as { message: unknown }).message);
-    expect(persistedMessages).toEqual([tagged, codeExample, indentedCode, malformed]);
+    expect(persistedMessages).toEqual([
+      tagged,
+      codeExample,
+      indentedCode,
+      malformed,
+      laterLiteral,
+    ]);
     expect(SessionManager.open(scope, dir).buildSessionContext().messages).toEqual([
       tagged,
       codeExample,
       indentedCode,
       malformed,
+      laterLiteral,
     ]);
   });
 

--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -1,6 +1,9 @@
 /** Parses inline reply directives such as media, reply targets, audio, and silence. */
 import { splitMediaFromOutput } from "../../media/parse.js";
-import { parseInlineDirectives } from "../../utils/directive-tags.js";
+import {
+  parseInlineDirectives,
+  stripInlineDirectiveTagsForDelivery,
+} from "../../utils/directive-tags.js";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../tokens.js";
 
 /** Parsed outbound reply directives and media extracted from model text. */
@@ -42,6 +45,7 @@ export function parseReplyDirectives(
   if (replyParsed.hasReplyTag) {
     text = replyParsed.text;
   }
+  text = stripInlineDirectiveTagsForDelivery(text).text;
 
   const silentToken = options.silentToken ?? SILENT_REPLY_TOKEN;
   const isSilent = isSilentReplyPayloadText(text, silentToken);

--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -42,10 +42,9 @@ export function parseReplyDirectives(
     stripReplyTags: true,
   });
 
-  if (replyParsed.hasReplyTag) {
-    text = replyParsed.text;
-  }
-  text = stripInlineDirectiveTagsForDelivery(text).text;
+  text = stripInlineDirectiveTagsForDelivery(
+    replyParsed.hasReplyTag ? replyParsed.text : text,
+  ).text;
 
   const silentToken = options.silentToken ?? SILENT_REPLY_TOKEN;
   const isSilent = isSilentReplyPayloadText(text, silentToken);

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -295,7 +295,7 @@ describe("normalizeReplyPayload", () => {
     expect(expectNormalizedReply(result).text).toBe("The user is saying hello");
   });
 
-  it.each<[string, string[]]>([
+  it.each([
     ["NO_REPLY\n\nThe user is saying hello", "The user is saying hello"],
     ["NO_REPLY\r\nThe user is saying hello", "The user is saying hello"],
     ["NO_REPLY NO_REPLY\nThe user is saying hello", "The user is saying hello"],
@@ -1491,7 +1491,7 @@ describe("createStreamingDirectiveAccumulator", () => {
     expect(`${first?.text ?? ""}${final?.text ?? ""}`).toBe(text);
   });
 
-  it.each([
+  it.each<[string, string[]]>([
     ["inline prose", ["Explain [[reply_to_", "current] literally."]],
     ["inline code", ["Use `[[reply_to_", "current]` literally."]],
     ["fenced code", ["```text\n[[reply_to_", "current]\n```"]],

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1467,16 +1467,17 @@ describe("createStreamingDirectiveAccumulator", () => {
     },
   );
 
-  it.each(["answer part A msg [[E1008]timeout] answer part B", "answer ending ["])(
-    "releases malformed directive-looking final text verbatim: %s",
-    (text) => {
-      const accumulator = createStreamingDirectiveAccumulator();
-      const first = accumulator.consume(text);
-      const final = accumulator.consume("", { final: true });
+  it.each([
+    "answer part A msg [[E1008]timeout] answer part B",
+    "Explain [[reply_to_current] literally.",
+    "answer ending [",
+  ])("releases malformed directive-looking final text verbatim: %s", (text) => {
+    const accumulator = createStreamingDirectiveAccumulator();
+    const first = accumulator.consume(text);
+    const final = accumulator.consume("", { final: true });
 
-      expect(`${first?.text ?? ""}${final?.text ?? ""}`).toBe(text);
-    },
-  );
+    expect(`${first?.text ?? ""}${final?.text ?? ""}`).toBe(text);
+  });
 
   it.each([
     ["answer [[", "bogus]] tail", "answer [[bogus]] tail"],
@@ -1633,6 +1634,37 @@ describe("createStreamingDirectiveAccumulator", () => {
       mediaUrls: ["/tmp/final.png"],
     });
   });
+});
+
+describe("parseReplyDirectives malformed reply prefixes", () => {
+  it.each([
+    ["[[reply_to_current] Visible reply", "Visible reply"],
+    ["[[reply_to_current", ""],
+    ["[[reply_to:message-7] Visible reply", "Visible reply"],
+    ["[[reply_to:", ""],
+  ])("strips %s without treating it as reply intent", (input, text) => {
+    expect(parseReplyDirectives(input)).toMatchObject({
+      text,
+      replyToId: undefined,
+      replyToCurrent: undefined,
+      replyToTag: false,
+    });
+  });
+
+  it.each([
+    "Use `[[reply_to_current]` literally.",
+    ["```text", "[[reply_to_current]", "```"].join("\n"),
+    "    [[reply_to_current]",
+  ])("preserves malformed reply examples in code: %s", (text) => {
+    expect(parseReplyDirectives(text).text).toBe(text);
+  });
+
+  it.each(["answer part A msg [[E1008]timeout] answer part B", "answer ending ["])(
+    "preserves unrelated malformed bracket text: %s",
+    (text) => {
+      expect(parseReplyDirectives(text).text).toBe(text);
+    },
+  );
 });
 
 describe("extractShortModelName", () => {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -295,7 +295,7 @@ describe("normalizeReplyPayload", () => {
     expect(expectNormalizedReply(result).text).toBe("The user is saying hello");
   });
 
-  it.each([
+  it.each<[string, string[]]>([
     ["NO_REPLY\n\nThe user is saying hello", "The user is saying hello"],
     ["NO_REPLY\r\nThe user is saying hello", "The user is saying hello"],
     ["NO_REPLY NO_REPLY\nThe user is saying hello", "The user is saying hello"],
@@ -1444,6 +1444,18 @@ describe("createStreamingDirectiveAccumulator", () => {
     expect(result?.replyToCurrent).toBe(true);
   });
 
+  it("strips a malformed leading reply prefix split across chunks", () => {
+    const accumulator = createStreamingDirectiveAccumulator();
+    expect(accumulator.consume("[[reply_to_")).toBeNull();
+    expect(accumulator.consume("current] Visible reply")).toBeNull();
+
+    expect(accumulator.consume("", { final: true })).toMatchObject({
+      text: "Visible reply",
+      replyToCurrent: false,
+      replyToTag: false,
+    });
+  });
+
   it("preserves padding when a buffered trailing reply tag stays incomplete", () => {
     const accumulator = createStreamingDirectiveAccumulator();
 
@@ -1477,6 +1489,20 @@ describe("createStreamingDirectiveAccumulator", () => {
     const final = accumulator.consume("", { final: true });
 
     expect(`${first?.text ?? ""}${final?.text ?? ""}`).toBe(text);
+  });
+
+  it.each([
+    ["inline prose", ["Explain [[reply_to_", "current] literally."]],
+    ["inline code", ["Use `[[reply_to_", "current]` literally."]],
+    ["fenced code", ["```text\n[[reply_to_", "current]\n```"]],
+    ["indented code", ["    [[reply_to_", "current]"]],
+    ["ambiguous explicit prefix", ["[[reply_to:message-7", " Visible reply"]],
+  ])("preserves split malformed %s", (_name, chunks) => {
+    const accumulator = createStreamingDirectiveAccumulator();
+    const streamed = chunks.map((chunk) => accumulator.consume(chunk)?.text ?? "").join("");
+    const final = accumulator.consume("", { final: true });
+
+    expect(`${streamed}${final?.text ?? ""}`).toBe(chunks.join(""));
   });
 
   it.each([

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1690,12 +1690,9 @@ describe("parseReplyDirectives malformed reply prefixes", () => {
     "answer part A msg [[E1008]timeout] answer part B",
     "Visible reply\n[[reply_to_current] literally",
     "answer ending [",
-  ])(
-    "preserves unrelated malformed bracket text: %s",
-    (text) => {
-      expect(parseReplyDirectives(text).text).toBe(text);
-    },
-  );
+  ])("preserves unrelated malformed bracket text: %s", (text) => {
+    expect(parseReplyDirectives(text).text).toBe(text);
+  });
 });
 
 describe("extractShortModelName", () => {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1493,6 +1493,7 @@ describe("createStreamingDirectiveAccumulator", () => {
 
   it.each<[string, string[]]>([
     ["inline prose", ["Explain [[reply_to_", "current] literally."]],
+    ["later line", ["Visible reply\n", "[[reply_to_", "current] literally"]],
     ["inline code", ["Use `[[reply_to_", "current]` literally."]],
     ["fenced code", ["```text\n[[reply_to_", "current]\n```"]],
     ["indented code", ["    [[reply_to_", "current]"]],
@@ -1685,7 +1686,11 @@ describe("parseReplyDirectives malformed reply prefixes", () => {
     expect(parseReplyDirectives(text).text).toBe(text);
   });
 
-  it.each(["answer part A msg [[E1008]timeout] answer part B", "answer ending ["])(
+  it.each([
+    "answer part A msg [[E1008]timeout] answer part B",
+    "Visible reply\n[[reply_to_current] literally",
+    "answer ending [",
+  ])(
     "preserves unrelated malformed bracket text: %s",
     (text) => {
       expect(parseReplyDirectives(text).text).toBe(text);

--- a/src/auto-reply/reply/streaming-directives.ts
+++ b/src/auto-reply/reply/streaming-directives.ts
@@ -1,7 +1,10 @@
 import { expectDefined } from "@openclaw/normalization-core";
 // Converts streaming reply directives into payload delivery decisions.
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
-import { parseInlineDirectives } from "../../utils/directive-tags.js";
+import {
+  parseInlineDirectives,
+  stripInlineDirectiveTagsForDelivery,
+} from "../../utils/directive-tags.js";
 import {
   isSilentReplyPrefixText,
   isSilentReplyText,
@@ -79,16 +82,11 @@ export const splitTrailingDirective = (text: string): { text: string; tail: stri
 };
 
 const parseChunk = (raw: string, options?: { silentToken?: string }): ParsedChunk => {
-  let text = raw ?? "";
-
-  const replyParsed = parseInlineDirectives(text, {
+  const replyParsed = parseInlineDirectives(raw ?? "", {
     stripAudioTag: true,
     stripReplyTags: true,
   });
-
-  if (replyParsed.hasReplyTag || replyParsed.hasAudioTag) {
-    text = replyParsed.text;
-  }
+  let text = stripInlineDirectiveTagsForDelivery(replyParsed.text).text;
 
   const silentToken = options?.silentToken ?? SILENT_REPLY_TOKEN;
   const isSilent =

--- a/src/auto-reply/reply/streaming-directives.ts
+++ b/src/auto-reply/reply/streaming-directives.ts
@@ -82,11 +82,14 @@ export const splitTrailingDirective = (text: string): { text: string; tail: stri
 };
 
 const parseChunk = (raw: string, options?: { silentToken?: string }): ParsedChunk => {
-  const replyParsed = parseInlineDirectives(raw ?? "", {
+  let text = raw ?? "";
+  const replyParsed = parseInlineDirectives(text, {
     stripAudioTag: true,
     stripReplyTags: true,
   });
-  let text = stripInlineDirectiveTagsForDelivery(replyParsed.text).text;
+  if (replyParsed.hasReplyTag || replyParsed.hasAudioTag) {
+    text = replyParsed.text;
+  }
 
   const silentToken = options?.silentToken ?? SILENT_REPLY_TOKEN;
   const isSilent =
@@ -116,12 +119,14 @@ export function createStreamingDirectiveAccumulator() {
   let pendingSeparator = "";
   let pendingReply: PendingReplyState = { sawCurrent: false, hasTag: false };
   let activeReply: PendingReplyState = { sawCurrent: false, hasTag: false };
+  let hasReturnedText = false;
 
   const reset = () => {
     pendingTail = "";
     pendingSeparator = "";
     pendingReply = { sawCurrent: false, hasTag: false };
     activeReply = { sawCurrent: false, hasTag: false };
+    hasReturnedText = false;
   };
 
   const consume = (raw: string, options: ConsumeOptions = {}): ReplyDirectiveParseResult | null => {
@@ -152,6 +157,11 @@ export function createStreamingDirectiveAccumulator() {
     const parsed = parseChunk(combined, { silentToken: options.silentToken });
     if (hadPendingTail && heldSeparator && parsed.text.startsWith("[")) {
       parsed.text = `${heldSeparator}${parsed.text}`;
+    }
+    // Only a message-leading malformed marker is delivery control. Once text has
+    // streamed, a later marker is literal content whose Markdown opener may be gone.
+    if (options.final && !hasReturnedText) {
+      parsed.text = stripInlineDirectiveTagsForDelivery(parsed.text).text;
     }
     const hasTag = activeReply.hasTag || pendingReply.hasTag || parsed.replyToTag;
     const sawCurrent =
@@ -185,6 +195,7 @@ export function createStreamingDirectiveAccumulator() {
       hasTag,
     };
     pendingReply = { sawCurrent: false, hasTag: false };
+    hasReturnedText ||= Boolean(combinedResult.text);
     return combinedResult;
   };
 

--- a/src/config/sessions/transcript-assistant-delivery.ts
+++ b/src/config/sessions/transcript-assistant-delivery.ts
@@ -1,7 +1,10 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AssistantDeliveryTtsFacts } from "../../llm/types.js";
 import { extractTtsDirectiveFacts } from "../../tts/directive-facts.js";
-import { parseInlineDirectives } from "../../utils/directive-tags.js";
+import {
+  parseInlineDirectives,
+  stripInlineDirectiveTagsForDelivery,
+} from "../../utils/directive-tags.js";
 
 type AssistantDirectiveMessage = {
   content?: unknown;
@@ -46,12 +49,17 @@ export function applyAssistantDeliveryDirectives<T extends AssistantDirectiveMes
       continue;
     }
     const parsed = parseInlineDirectives(block.text);
-    const tts = extractTtsDirectiveFacts(parsed.text);
-    if (!parsed.hasAudioTag && !parsed.hasReplyTag && !tts.facts) {
+    const stripped = stripInlineDirectiveTagsForDelivery(parsed.text);
+    const tts = extractTtsDirectiveFacts(stripped.text);
+    const hasDeliveryFacts = parsed.hasAudioTag || parsed.hasReplyTag || Boolean(tts.facts);
+    if (!stripped.changed && !hasDeliveryFacts) {
+      continue;
+    }
+    block.text = tts.facts ? tts.cleanedText.trim() : tts.cleanedText;
+    if (!hasDeliveryFacts) {
       continue;
     }
     facts ??= {};
-    block.text = tts.facts ? tts.cleanedText.trim() : tts.cleanedText;
     Object.assign(facts, {
       ...(parsed.audioAsVoice ? { audioAsVoice: true as const } : {}),
       ...(parsed.replyToCurrent ? { replyToCurrent: true as const } : {}),

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -667,6 +667,13 @@ describe("OutboundPayloadPlan projections", () => {
     expect(normalized?.replyToCurrent).toBeUndefined();
   });
 
+  it("preserves an ambiguous unterminated explicit reply prefix", () => {
+    const text = "[[reply_to:message-7 Visible reply";
+    const [normalized] = normalizeReplyPayloadsForDelivery([{ text }]);
+
+    expect(normalized).toMatchObject({ text, replyToTag: false });
+  });
+
   it("projects transport payloads without no-reply or reasoning entries", () => {
     const plan = createOutboundPayloadPlan(matrix);
     expect(projectOutboundPayloadPlanForOutbound(plan)).toEqual([

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -653,6 +653,20 @@ describe("OutboundPayloadPlan projections", () => {
     );
   });
 
+  it.each([
+    ["current tag with one closing bracket", "[[reply_to_current] Visible reply"],
+    ["explicit tag with one closing bracket", "[[reply_to:message-7] Visible reply"],
+  ])("strips a malformed %s without creating reply metadata", (_name, text) => {
+    const [normalized] = normalizeReplyPayloadsForDelivery([{ text }]);
+
+    expect(normalized).toMatchObject({
+      text: "Visible reply",
+      replyToTag: false,
+    });
+    expect(normalized?.replyToId).toBeUndefined();
+    expect(normalized?.replyToCurrent).toBeUndefined();
+  });
+
   it("projects transport payloads without no-reply or reasoning entries", () => {
     const plan = createOutboundPayloadPlan(matrix);
     expect(projectOutboundPayloadPlanForOutbound(plan)).toEqual([

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -69,6 +69,11 @@ describe("stripInlineDirectiveTagsForDelivery", () => {
     expect(result.changed).toBe(false);
     expect(result.text).toBe(input);
   });
+
+  test("preserves an ambiguous unterminated explicit reply prefix", () => {
+    const input = "[[reply_to:message-7 Visible reply";
+    expect(stripInlineDirectiveTagsForDelivery(input)).toEqual({ text: input, changed: false });
+  });
 });
 
 describe("parseInlineDirectives markdown code", () => {

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -74,6 +74,11 @@ describe("stripInlineDirectiveTagsForDelivery", () => {
     const input = "[[reply_to:message-7 Visible reply";
     expect(stripInlineDirectiveTagsForDelivery(input)).toEqual({ text: input, changed: false });
   });
+
+  test("preserves a malformed reply prefix after visible text", () => {
+    const input = "Visible reply\n[[reply_to_current] literally";
+    expect(stripInlineDirectiveTagsForDelivery(input)).toEqual({ text: input, changed: false });
+  });
 });
 
 describe("parseInlineDirectives markdown code", () => {

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -26,7 +26,7 @@ type InlineDirectiveParseOptions = {
 const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
 const INLINE_DIRECTIVE_TAG_WITH_PADDING_RE =
-  /(?:\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*|^[\t ]*\[\[\s*(?:reply_to_current(?:[\t ]*\](?!\])|(?=[\t ]+\S)|[\t ]*$)|reply_to\s*:\s*(?:[^\]\r\n]*\](?!\])|[^\]\r\n]*$))[\t ]*)/gimu;
+  /(?:\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*|^[\t ]*\[\[\s*(?:reply_to_current(?:[\t ]*\](?!\])|(?=[\t ]+\S)|[\t ]*$)|reply_to\s*:\s*(?:[^\]\r\n]*\](?!\])|[\t ]*$))[\t ]*)/gimu;
 const MAX_REPLY_DIRECTIVE_ID_LENGTH = 256;
 const NO_INLINE_DIRECTIVES = {
   audioAsVoice: false,

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -26,7 +26,7 @@ type InlineDirectiveParseOptions = {
 const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
 const INLINE_DIRECTIVE_TAG_WITH_PADDING_RE =
-  /\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*/gi;
+  /(?:\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*|^[\t ]*\[\[\s*(?:reply_to_current(?:[\t ]*\](?!\])|(?=[\t ]+\S)|[\t ]*$)|reply_to\s*:\s*(?:[^\]\r\n]*\](?!\])|[^\]\r\n]*$))[\t ]*)/gimu;
 const MAX_REPLY_DIRECTIVE_ID_LENGTH = 256;
 const NO_INLINE_DIRECTIVES = {
   audioAsVoice: false,
@@ -156,7 +156,11 @@ export function stripInlineDirectiveTagsForDelivery(text: string): StripInlineDi
   if (!text) {
     return { text, changed: false };
   }
-  const stripped = replaceOutsideCodeRegions(text, INLINE_DIRECTIVE_TAG_WITH_PADDING_RE, () => " ");
+  // Malformed prefixes are untrusted text, not reply intent. The regex keeps
+  // complete tags distinguishable while the code-region scanner preserves examples.
+  const stripped = replaceOutsideCodeRegions(text, INLINE_DIRECTIVE_TAG_WITH_PADDING_RE, (match) =>
+    match.includes("]]") ? " " : "",
+  );
   const changed = stripped !== text;
   return {
     text: changed ? stripped.trim() : text,

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -156,8 +156,8 @@ export function stripInlineDirectiveTagsForDelivery(text: string): StripInlineDi
   if (!text) {
     return { text, changed: false };
   }
-  // Malformed prefixes are untrusted text, not reply intent. The regex keeps
-  // complete tags distinguishable while the code-region scanner preserves examples.
+  // Only malformed prefixes at the absolute message start are control text; keep
+  // the regex non-multiline while code-region scanning preserves literal examples.
   const stripped = replaceOutsideCodeRegions(text, INLINE_DIRECTIVE_TAG_WITH_PADDING_RE, (match) =>
     match.includes("]]") ? " " : "",
   );

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -26,7 +26,7 @@ type InlineDirectiveParseOptions = {
 const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
 const INLINE_DIRECTIVE_TAG_WITH_PADDING_RE =
-  /(?:\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*|^[\t ]*\[\[\s*(?:reply_to_current(?:[\t ]*\](?!\])|(?=[\t ]+\S)|[\t ]*$)|reply_to\s*:\s*(?:[^\]\r\n]*\](?!\])|[\t ]*$))[\t ]*)/gimu;
+  /(?:\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*|^[\t ]*\[\[\s*(?:reply_to_current(?:[\t ]*\](?!\])|(?=[\t ]+\S)|[\t ]*$)|reply_to\s*:\s*(?:[^\]\r\n]*\](?!\])|[\t ]*$))[\t ]*)/giu;
 const MAX_REPLY_DIRECTIVE_ID_LENGTH = 256;
 const NO_INLINE_DIRECTIVES = {
   audioAsVoice: false,


### PR DESCRIPTION
Closes #129154

## Problem

A malformed message-leading reply control such as `[[reply_to_current]` could appear in a user-visible reply. A broad multiline repair could also remove the same marker-looking text when it appeared later as literal content.

## Root cause

The shared directive parser stripped only complete `]]` controls. Streaming finalization and transcript persistence could therefore keep the malformed leading prefix.

## Fix

The shared delivery normalizer now removes a malformed reply control only at the absolute start of an assistant message. Direct parsing, streaming finalization, outbound payload planning, embedded-agent delivery, and transcript persistence use the same rule. Later literal marker text and code examples remain unchanged.

## Proof

- Current-main reproduction at `fa1915015574`: the direct parser returned the full leading `[[reply_to_current]` marker.
- Exact head `2768fc0c3476`: the same probe removed the leading marker and retained `VISIBLE-INTRO\n[[reply_to_current] LATER-LITERAL-PRESERVED`.
- Focused local tests: 232 tests passed across directive parsing, streaming, embedded-agent delivery, outbound payloads, and session persistence.
- Local ClawSweeper review: tier A, `patch is correct`, zero findings, zero security concerns, no maintainer decision, and no Rank-up moves.
- [Exact-head CI run 33051566222](https://github.com/openclaw/openclaw/actions/runs/33051566222): successful with `openclaw/ci-gate` green.
- Real Telegram user proof: the deterministic provider emitted one malformed leading marker and one later literal marker. Telegram delivered one reply after two typing events. The leading marker was hidden, `LEADING-MALFORMED-HIDDEN` remained visible, and the later literal `[[reply_to_current] LATER-LITERAL-PRESERVED` remained visible. The gateway recorded a successful send and the provider recorded one request.

## Merge result and size

- The latest GitHub virtual merge applies cleanly, and current `main` has not changed any touched path since the successful CI merge base.
- The hosted stream-cancellation finding does not exist in GitHub's PR diff or virtual merge. Both contain only the nine reply-related paths listed above and preserve `packages/ai` from `main`. The exact-head local ClawSweeper gate passed tier A with zero findings.
- Production: `+37/-13`, net `+24`.
- Tests: `+162/-12`, net `+150`.
- The production growth keeps one canonical owner across direct, streaming, outbound, embedded, and persistence paths. It does not add a Telegram-only guard.
