### PR TITLE
test: repair Anthropic auth fixtures and runtime mocks

### DIFF
--- a/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
+++ b/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
@@ -182,7 +182,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
   }
 
   it("falls back to main agent credentials when secondary agent token is expired and refresh fails", async () => {
-    const profileId = "anthropic:claude-cli";
+    const profileId = "anthropic:default";
     const now = Date.now();
     const expiredTime = now - 60 * 60 * 1000; // 1 hour ago
     const freshTime = now + 60 * 60 * 1000; // 1 hour from now
@@ -229,7 +229,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
   });
 
   it("adopts newer OAuth token from main agent even when secondary token is still valid", async () => {
-    const profileId = "anthropic:claude-cli";
+    const profileId = "anthropic:default";
     const now = Date.now();
     const secondaryExpiry = now + 30 * 60 * 1000;
     const mainExpiry = now + 2 * 60 * 60 * 1000;
@@ -266,7 +266,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
   });
 
   it("adopts main token when secondary expires is NaN/malformed", async () => {
-    const profileId = "anthropic:claude-cli";
+    const profileId = "anthropic:default";
     const now = Date.now();
     const mainExpiry = now + 2 * 60 * 60 * 1000;
 
@@ -340,7 +340,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
   });
 
   it("throws error when both secondary and main agent credentials are expired", async () => {
-    const profileId = "anthropic:claude-cli";
+    const profileId = "anthropic:default";
     const now = Date.now();
     const expiredTime = now - 60 * 60 * 1000; // 1 hour ago
 
@@ -361,7 +361,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
   });
 
   it("still falls back to main agent credentials when the refresh-token-reused retry throws", async () => {
-    const profileId = "anthropic:claude-cli";
+    const profileId = "anthropic:default";
     const now = Date.now();
     const expiredTime = now - 60 * 60 * 1000;
     const freshTime = now + 60 * 60 * 1000;

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -85,6 +85,7 @@ vi.mock("../plugins/provider-runtime.js", () => {
   return {
     buildProviderMissingAuthMessageWithPlugin: () => undefined,
     resolveExternalAuthProfilesWithPlugins: () => [],
+    resolveProviderDeprecatedAuthProfileIds: () => [],
     shouldDeferProviderSyntheticProfileAuthWithPlugin: (params: {
       context?: { resolvedApiKey?: string };
     }) => params.context?.resolvedApiKey === "synthetic-defer",

--- a/src/agents/runtime-plan/prepare-auth.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.test.ts
@@ -15,6 +15,7 @@ import {
 // coverage; keep those runtimes out of this focused planner test.
 vi.mock("../../plugins/provider-runtime.js", () => ({
   buildProviderMissingAuthMessageWithPlugin: () => undefined,
+  resolveProviderDeprecatedAuthProfileIds: () => [],
   resolveProviderSyntheticAuthWithPlugin: () => undefined,
   shouldDeferProviderSyntheticProfileAuthWithPlugin: () => undefined,
 }));


### PR DESCRIPTION
## Summary

Repair the Anthropic auth test fixtures and complete provider-runtime mocks so the suites exercise current behavior.

This updates test infrastructure for the native Claude authentication contract introduced by #129052.

## Root Cause

Five generic OAuth fallback tests still used `anthropic:claude-cli`, which #129052 retired. Production therefore returned `null` before the tests reached the fallback behavior they claimed to cover.

Two complete `provider-runtime` mocks also omitted the deprecated-profile resolver added for that migration, causing their suites to fail during module setup.

## Changes

- use the ordinary managed Anthropic profile in generic OAuth fallback tests
- add the neutral deprecated-profile resolver to both complete provider-runtime mocks
- leave production code unchanged

## Verification

- 155 focused tests
- formatting
- Oxlint
- autoreview

## Landing Record

GitHub created verified squash commit `18234ea96456fde53ac81f56a3370f9409fc7d66` on `main` but did not update this pull request's merge state after returning a GraphQL error. The pull request was closed after confirming that the commit parent and tree exactly matched the reviewed change.
