### PR TITLE
test(skills): align learn prompts with authoring standards

### DIFF
--- a/src/auto-reply/reply/commands-learn.test.ts
+++ b/src/auto-reply/reply/commands-learn.test.ts
@@ -103,8 +103,10 @@ describe("learn command", () => {
       "Revise the best pending proposal or update the best Workshop-owned skill before creating anything new.",
     );
     expect(instruction).toContain("Make at most one proposal mutation.");
-    expect(instruction).toContain("first ~60 characters");
-    expect(instruction).toContain("never invent flags, commands, paths, APIs");
+    expect(instruction).toContain("within the first 60 characters");
+    expect(instruction).toContain(
+      "every step comes from the observed trajectory or the existing skill",
+    );
   });
 
   it("replies without continuing when the workshop is unavailable", async () => {


### PR DESCRIPTION
Update two strict existing learn-command assertions to match the current canonical skill-authoring standards. This test-only correction repairs the reproducible cache-warmer failure without changing production behavior, weakening assertions, or replacing contributor work. Validation: the pristine focused test fails, the corrected learn-command and standards suites pass all 11 tests, formatting and core lint pass, and the canonical changed-target planner selects exactly the changed test plus the mandatory boundary Node job. Production line delta: zero.