### PR TITLE
fix(ai): add SGLang B1 context-overflow pattern to failover-explicit scope

### DIFF
--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -95,6 +95,7 @@ const FAILOVER_EXPLICIT_OVERFLOW_PATTERNS = [
   /context_window_exceeded/i,
   // FIXED(refactor-06): PR 2 removed the embedded-429 false positive; this is provider overflow.
   /input length [\d,]+\s+tokens? exceeds the model limit/i,
+  /input \(\d+ tokens\) is longer than the model'?s context length \(\d+ tokens\)/i, // SGLang B1 / Together AI
   /上下文过长|上下文超出|上下文长度超|超出最大上下文|请压缩上下文/,
 ];
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #129352.

SGLang emits two distinct 400s under context pressure:
- **B1** (input alone >= window): `The input (N tokens) is longer than the model's context length (M tokens).`
- **B2** (input + max_tokens >= window): `Requested token count exceeds the model's maximum context length of M tokens.`

B2 was already detected (matches `failover-explicit`).
B1 was missed because it matches the Together AI pattern in `assistant-error`,
but `isContextOverflowErrorFromTables()` only checks `failover-explicit`
and `provider-fallback` scopes.

## Previous Attempt (closed)

PR #129361 originally added `assistant-error` to the strict classifier,
but that broke `classifyFailoverReason` rate-limit separation
(see ClawSweeper review: too-many-tokens-per-request sample flipped
from null to context_overflow).

## How This Fixes It

Adds the specific SGLang/Together AI pattern directly to
`FAILOVER_EXPLICIT_OVERFLOW_PATTERNS` so it is picked up by the strict
path without affecting other classifications.

## Regression Safety

- Pattern is already present in `ASSISTANT_OVERFLOW_PATTERNS`; this just
duplicates it into the strict scope where it belongs.
- Does not change any other classifier behavior.
- Existing test: `keeps too-many-tokens-per-request context overflow errors
out of the rate-limit lane` continues to expect null.
