### PR TITLE
fix(whatsapp): keep QR login owner-scoped

### DIFF
--- a/extensions/whatsapp/agent-tools-api.ts
+++ b/extensions/whatsapp/agent-tools-api.ts
@@ -1,0 +1,9 @@
+// WhatsApp agent tool facade keeps the bundled entrypoint light during discovery.
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import { registerWhatsAppCallTool } from "./src/agent-tools-call.js";
+import { registerWhatsAppLoginTool } from "./src/agent-tools-login.js";
+
+export function registerWhatsAppAgentTools(api: OpenClawPluginApi): void {
+  registerWhatsAppCallTool(api);
+  registerWhatsAppLoginTool(api);
+}

--- a/extensions/whatsapp/call-tool-api.ts
+++ b/extensions/whatsapp/call-tool-api.ts
@@ -1,2 +1,0 @@
-// WhatsApp call tool facade keeps the bundled entrypoint light during discovery.
-export { registerWhatsAppCallTool } from "./src/agent-tools-call.js";

--- a/extensions/whatsapp/index.ts
+++ b/extensions/whatsapp/index.ts
@@ -5,12 +5,12 @@ import {
 } from "openclaw/plugin-sdk/channel-entry-contract";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
 
-function registerWhatsAppCallTool(api: OpenClawPluginApi): void {
+function registerWhatsAppAgentTools(api: OpenClawPluginApi): void {
   const registerTool = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(
     import.meta.url,
     {
-      specifier: "./call-tool-api.js",
-      exportName: "registerWhatsAppCallTool",
+      specifier: "./agent-tools-api.js",
+      exportName: "registerWhatsAppAgentTools",
     },
   );
   registerTool(api);
@@ -29,5 +29,5 @@ export default defineBundledChannelEntry({
     specifier: "./runtime-setter-api.js",
     exportName: "setWhatsAppRuntime",
   },
-  registerFull: registerWhatsAppCallTool,
+  registerFull: registerWhatsAppAgentTools,
 });

--- a/extensions/whatsapp/openclaw.plugin.json
+++ b/extensions/whatsapp/openclaw.plugin.json
@@ -12,7 +12,7 @@
     "onStartup": false
   },
   "contracts": {
-    "tools": ["whatsapp_call"]
+    "tools": ["whatsapp_call", "whatsapp_login"]
   },
   "channels": ["whatsapp"],
   "configSchema": {

--- a/extensions/whatsapp/src/agent-tools-login.test.ts
+++ b/extensions/whatsapp/src/agent-tools-login.test.ts
@@ -1,7 +1,13 @@
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginToolContext,
+} from "openclaw/plugin-sdk/core";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 // Whatsapp tests cover agent tools login plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { startWebLoginWithQr, waitForWebLogin } from "../login-qr-api.js";
-import { createWhatsAppLoginTool } from "./agent-tools-login.js";
+import { registerWhatsAppLoginTool } from "./agent-tools-login.js";
 
 vi.mock("../login-qr-api.js", () => ({
   startWebLoginWithQr: vi.fn(),
@@ -11,13 +17,63 @@ vi.mock("../login-qr-api.js", () => ({
 const startWebLoginWithQrMock = vi.mocked(startWebLoginWithQr);
 const waitForWebLoginMock = vi.mocked(waitForWebLogin);
 
+function resolveRegisteredLoginTool(context: OpenClawPluginToolContext): AnyAgentTool | null {
+  const registerTool = vi.fn<OpenClawPluginApi["registerTool"]>();
+  const api = createTestPluginApi({ registerTool });
+  registerWhatsAppLoginTool(api);
+  const factory = registerTool.mock.calls[0]?.[0];
+  if (typeof factory !== "function") {
+    throw new Error("WhatsApp login tool factory was not registered");
+  }
+  expect(registerTool.mock.calls[0]?.[1]).toEqual({ name: "whatsapp_login" });
+  const tool = factory(context);
+  if (Array.isArray(tool)) {
+    throw new Error("expected one WhatsApp login tool");
+  }
+  return tool ?? null;
+}
+
+function createOwnerLoginTool(context: OpenClawPluginToolContext = { senderIsOwner: true }) {
+  const tool = resolveRegisteredLoginTool(context);
+  if (!tool) {
+    throw new Error("expected WhatsApp login tool for owner sender");
+  }
+  return tool;
+}
+
 describe("createWhatsAppLoginTool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
+  it.each([false, undefined])("hides the login tool when owner status is %s", (senderIsOwner) => {
+    expect(resolveRegisteredLoginTool({ senderIsOwner })).toBeNull();
+  });
+
+  it("rejects credential persistence after the owning tool execution closes", async () => {
+    const tool = createOwnerLoginTool();
+    const controller = new AbortController();
+    let beforeCredentialPersistence: (() => Promise<void>) | undefined;
+    startWebLoginWithQrMock.mockImplementationOnce(async (options) => {
+      beforeCredentialPersistence = options?.beforeCredentialPersistence;
+      return { message: "login started" };
+    });
+
+    await tool.execute("tool-call-active", { action: "start" }, controller.signal);
+    await expect(beforeCredentialPersistence?.()).resolves.toBeUndefined();
+    controller.abort();
+
+    await expect(
+      tool.execute("tool-call-retained", { action: "start" }, controller.signal),
+    ).rejects.toThrow("WhatsApp login authority is no longer active");
+    await expect(beforeCredentialPersistence?.()).rejects.toThrow(
+      "WhatsApp login authority is no longer active",
+    );
+    expect(startWebLoginWithQrMock).toHaveBeenCalledOnce();
+  });
+
   it("fully anchors the QR data URL pattern for grammar-constrained models", () => {
-    const tool = createWhatsAppLoginTool();
+    const tool = createOwnerLoginTool();
     const pattern = (tool.parameters as { properties: { currentQrDataUrl?: { pattern?: string } } })
       .properties.currentQrDataUrl?.pattern;
 
@@ -39,7 +95,7 @@ describe("createWhatsAppLoginTool", () => {
       qrDataUrl: "data:image/png;base64,next-qr",
     });
 
-    const tool = createWhatsAppLoginTool();
+    const tool = createOwnerLoginTool();
     const result = await tool.execute("tool-call-1", {
       action: "wait",
       timeoutMs: "5000",
@@ -79,22 +135,27 @@ describe("createWhatsAppLoginTool", () => {
       qrDataUrl: "data:image/png;base64,current-qr",
     });
 
-    const tool = createWhatsAppLoginTool();
-    await tool.execute("tool-call-start", {
-      action: "start",
-      timeoutMs: "6000",
-      accountId: "account-3",
-    });
+    const tool = createOwnerLoginTool();
+    await tool.execute(
+      "tool-call-start",
+      {
+        action: "start",
+        timeoutMs: "6000",
+        accountId: "account-3",
+      },
+      new AbortController().signal,
+    );
 
     expect(startWebLoginWithQrMock).toHaveBeenCalledWith({
       accountId: "account-3",
       timeoutMs: 6000,
       force: false,
+      beforeCredentialPersistence: expect.any(Function),
     });
   });
 
   it("rejects fractional timeoutMs before login actions", async () => {
-    const tool = createWhatsAppLoginTool();
+    const tool = createOwnerLoginTool();
 
     await expect(
       tool.execute("tool-call-start", {
@@ -117,8 +178,12 @@ describe("createWhatsAppLoginTool", () => {
       message: "✅ Linked! WhatsApp is ready.",
     });
 
-    const tool = createWhatsAppLoginTool();
-    await tool.execute("tool-call-start", { action: "start", accountId });
+    const tool = createOwnerLoginTool();
+    await tool.execute(
+      "tool-call-start",
+      { action: "start", accountId },
+      new AbortController().signal,
+    );
     await tool.execute("tool-call-wait", { action: "wait", timeoutMs: 5000, accountId });
 
     expect(waitForWebLoginMock).toHaveBeenCalledWith({

--- a/extensions/whatsapp/src/agent-tools-login.ts
+++ b/extensions/whatsapp/src/agent-tools-login.ts
@@ -4,6 +4,7 @@ import {
   readPositiveIntegerParam,
 } from "openclaw/plugin-sdk/channel-actions";
 import type { ChannelAgentTool } from "openclaw/plugin-sdk/channel-contract";
+import type { OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk/core";
 import { hasNonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { Type } from "typebox";
 import { startWebLoginWithQr, waitForWebLogin } from "../login-qr-api.js";
@@ -14,7 +15,12 @@ function readLoginStringPreservingWhitespace(value: unknown): string | undefined
   return hasNonEmptyString(value) ? value : undefined;
 }
 
-export function createWhatsAppLoginTool(): ChannelAgentTool {
+export function createWhatsAppLoginTool(
+  context: OpenClawPluginToolContext,
+): ChannelAgentTool | null {
+  if (context.senderIsOwner !== true) {
+    return null;
+  }
   return {
     label: "WhatsApp Login",
     name: "whatsapp_login",
@@ -33,7 +39,12 @@ export function createWhatsAppLoginTool(): ChannelAgentTool {
         }),
       ),
     }),
-    execute: async (_toolCallId, args) => {
+    execute: async (_toolCallId, args, signal) => {
+      const beforeCredentialPersistence = async () => {
+        if (!signal || signal.aborted) {
+          throw new Error("WhatsApp login authority is no longer active.");
+        }
+      };
       const renderQrReply = (params: {
         message: string;
         qrDataUrl: string;
@@ -81,9 +92,11 @@ export function createWhatsAppLoginTool(): ChannelAgentTool {
         };
       }
 
+      await beforeCredentialPersistence();
       const result = await startWebLoginWithQr({
         accountId,
         timeoutMs,
+        beforeCredentialPersistence,
         force:
           typeof (args as { force?: unknown }).force === "boolean"
             ? (args as { force?: boolean }).force
@@ -109,4 +122,8 @@ export function createWhatsAppLoginTool(): ChannelAgentTool {
       });
     },
   };
+}
+
+export function registerWhatsAppLoginTool(api: OpenClawPluginApi): void {
+  api.registerTool((context) => createWhatsAppLoginTool(context), { name: "whatsapp_login" });
 }

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -8,7 +8,6 @@ import {
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
 import { resolveWhatsAppAccount, type ResolvedWhatsAppAccount } from "./accounts.js";
-import { createWhatsAppLoginTool } from "./agent-tools-login.js";
 import { whatsappApprovalCapability } from "./approval-native.js";
 import type { WebChannelStatus } from "./auto-reply/types.js";
 import {
@@ -92,7 +91,6 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
         isConfigured: (account) => Boolean(account.authDir),
         isLinked: async (account) => await readWhatsAppAccountLinkState(account.authDir),
       }),
-      agentTools: () => [createWhatsAppLoginTool()],
       allowlist: buildDmGroupAccountAllowlistAdapter({
         channelId: "whatsapp",
         resolveAccount: resolveWhatsAppAccount,

--- a/extensions/whatsapp/src/login-qr.test.ts
+++ b/extensions/whatsapp/src/login-qr.test.ts
@@ -182,6 +182,7 @@ describe("login-qr", () => {
   });
 
   it("restarts login once on status 515 and completes", async () => {
+    const beforeCredentialPersistence = vi.fn(async () => {});
     waitForWaConnectionMock
       // Baileys v7 wraps the error: { error: BoomError(515) }
       .mockRejectedValueOnce({ error: { output: { statusCode: 515 } } })
@@ -193,6 +194,7 @@ describe("login-qr", () => {
     const start = await startWebLoginWithQr({
       timeoutMs: 5000,
       accountId: rotatingAccountId,
+      beforeCredentialPersistence,
     });
     expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
 
@@ -205,6 +207,12 @@ describe("login-qr", () => {
     await flushTasks();
 
     expect(createWaSocketMock).toHaveBeenCalledTimes(2);
+    expect(createWaSocketMock).toHaveBeenNthCalledWith(
+      2,
+      false,
+      false,
+      expect.objectContaining({ beforeCredentialPersistence: expect.any(Function) }),
+    );
     const result = await resultPromise;
 
     expect(result.connected).toBe(true);
@@ -231,6 +239,7 @@ describe("login-qr", () => {
 
   it("clears auth and returns a replacement QR when WhatsApp is logged out", async () => {
     const accountId = "logged-out-replacement-qr";
+    const beforeCredentialPersistence = vi.fn(async () => {});
     queueQrSocket("qr-data");
     queueQrSocket("qr-after-logout");
     waitForWaConnectionMock
@@ -239,7 +248,11 @@ describe("login-qr", () => {
       })
       .mockImplementation(waitForever);
 
-    const start = await startWebLoginWithQr({ timeoutMs: 5000, accountId });
+    const start = await startWebLoginWithQr({
+      timeoutMs: 5000,
+      accountId,
+      beforeCredentialPersistence,
+    });
     expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
 
     const result = await waitForWebLogin({
@@ -254,6 +267,9 @@ describe("login-qr", () => {
       qrDataUrl: encodedQr("qr-after-logout"),
     });
     expect(logoutWebMock).toHaveBeenCalledOnce();
+    expect(logoutWebMock).toHaveBeenCalledWith(
+      expect.objectContaining({ beforeCredentialPersistence: expect.any(Function) }),
+    );
   });
 
   it("keeps the linked shortcut when existing auth has an active listener", async () => {
@@ -273,6 +289,7 @@ describe("login-qr", () => {
 
   it("clears saved auth for an explicit fresh QR relink", async () => {
     const accountId = "force-fresh-qr";
+    const beforeCredentialPersistence = vi.fn(async () => {});
     getActiveWebListenerMock.mockReturnValue({} as never);
     waitForWaConnectionMock.mockImplementation(waitForever);
     readWebAuthExistsForDecisionMock.mockResolvedValueOnce({
@@ -284,6 +301,7 @@ describe("login-qr", () => {
       timeoutMs: 5000,
       accountId,
       force: true,
+      beforeCredentialPersistence,
     });
 
     expectScanQrResult(result);
@@ -291,6 +309,125 @@ describe("login-qr", () => {
       authDir: expect.stringContaining(accountId),
       isLegacyAuthDir: false,
       runtime: expect.anything(),
+      beforeCredentialPersistence,
+    });
+    expect(createWaSocketMock).toHaveBeenCalledWith(
+      false,
+      false,
+      expect.objectContaining({ beforeCredentialPersistence: expect.any(Function) }),
+    );
+  });
+
+  it("transfers credential writes to the exact active login instance", async () => {
+    let hostActive = true;
+    const beforeCredentialPersistence = vi.fn(async () => {
+      if (!hostActive) {
+        throw new Error("plugin tool host authority is no longer active");
+      }
+    });
+    waitForWaConnectionMock.mockImplementation(waitForever);
+
+    const start = await startWebLoginWithQr({
+      timeoutMs: 5000,
+      accountId: "active-operation-authority",
+      beforeCredentialPersistence,
+    });
+    expectScanQrResult(start);
+    const operationGuard = createWaSocketMock.mock.calls[0]?.[2]?.beforeCredentialPersistence;
+    expect(operationGuard).toEqual(expect.any(Function));
+    expect(operationGuard).not.toBe(beforeCredentialPersistence);
+
+    hostActive = false;
+    await expect(operationGuard?.()).resolves.toBeUndefined();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 3 * 60_000 + 1);
+    await expect(
+      waitForWebLogin({ timeoutMs: 1000, accountId: "active-operation-authority" }),
+    ).resolves.toEqual({
+      connected: false,
+      message: "The login QR expired. Ask me to generate a new one.",
+    });
+    await expect(operationGuard?.()).rejects.toThrow("WhatsApp login is no longer active");
+  });
+
+  it("revalidates authority after auth inspection and before forced credential cleanup", async () => {
+    const accountId = "revoked-force-fresh-qr";
+    let resolveAuthState: ((value: { outcome: "stable"; exists: true }) => void) | undefined;
+    const authState = new Promise<{ outcome: "stable"; exists: true }>((resolve) => {
+      resolveAuthState = resolve;
+    });
+    let active = true;
+    const beforeCredentialPersistence = vi.fn(async () => {
+      if (!active) {
+        throw new Error("plugin tool host authority is no longer active");
+      }
+    });
+    readWebAuthExistsForDecisionMock.mockReturnValueOnce(authState);
+    logoutWebMock.mockImplementationOnce(async (options) => {
+      await options.beforeCredentialPersistence?.();
+      return true;
+    });
+
+    const resultPromise = startWebLoginWithQr({
+      timeoutMs: 5000,
+      accountId,
+      force: true,
+      beforeCredentialPersistence,
+    });
+    await vi.waitFor(() => expect(readWebAuthExistsForDecisionMock).toHaveBeenCalledOnce());
+    active = false;
+    resolveAuthState?.({ outcome: "stable", exists: true });
+
+    await expect(resultPromise).resolves.toEqual({
+      message:
+        "WhatsApp login failed: formatted:Error: plugin tool host authority is no longer active",
+    });
+    expect(beforeCredentialPersistence).toHaveBeenCalledOnce();
+    expect(createWaSocketMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects ownership transfer when bootstrap authority closes during socket creation", async () => {
+    let releaseSocket: (() => void) | undefined;
+    const socketReleased = new Promise<void>((resolve) => {
+      releaseSocket = resolve;
+    });
+    let socketStarted: (() => void) | undefined;
+    const socketStarting = new Promise<void>((resolve) => {
+      socketStarted = resolve;
+    });
+    createWaSocketMock.mockImplementationOnce(async (_printQr, _verbose, options) => {
+      await options?.beforeCredentialPersistence?.();
+      socketStarted?.();
+      await socketReleased;
+      return { ws: { close: vi.fn() } } as never;
+    });
+    let active = true;
+    const beforeCredentialPersistence = vi.fn(async () => {
+      if (!active) {
+        throw new Error("plugin tool host authority is no longer active");
+      }
+    });
+
+    const resultPromise = startWebLoginWithQr({
+      timeoutMs: 5000,
+      accountId: "revoked-before-transfer",
+      beforeCredentialPersistence,
+    });
+    await socketStarting;
+    active = false;
+    releaseSocket?.();
+
+    await expect(resultPromise).resolves.toEqual({
+      message:
+        "Failed to start WhatsApp login: Error: plugin tool host authority is no longer active",
+    });
+    expect(beforeCredentialPersistence).toHaveBeenCalledTimes(2);
+    await expect(
+      waitForWebLogin({ timeoutMs: 1000, accountId: "revoked-before-transfer" }),
+    ).resolves.toEqual({
+      connected: false,
+      message: "No active WhatsApp login in progress.",
     });
   });
 
@@ -309,11 +446,14 @@ describe("login-qr", () => {
     const result = await startWebLoginWithQr({ timeoutMs: 5000, accountId });
 
     expectScanQrResult(result, "qr-after-restart-logout");
-    expect(logoutWebMock).toHaveBeenCalledWith({
-      authDir: expect.stringContaining(accountId),
-      isLegacyAuthDir: false,
-      runtime: expect.anything(),
-    });
+    expect(logoutWebMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authDir: expect.stringContaining(accountId),
+        isLegacyAuthDir: false,
+        runtime: expect.anything(),
+        beforeCredentialPersistence: expect.any(Function),
+      }),
+    );
     expect(createWaSocketMock).toHaveBeenCalledTimes(2);
   });
 

--- a/extensions/whatsapp/src/login-qr.ts
+++ b/extensions/whatsapp/src/login-qr.ts
@@ -57,6 +57,7 @@ type ActiveLogin = {
   verbose: boolean;
   runtime: RuntimeEnv;
   socketTiming: WhatsAppSocketTimingOptions;
+  beforeCredentialPersistence?: () => Promise<void>;
 };
 
 type LoginQrRaceResult =
@@ -89,8 +90,10 @@ function closeSocket(sock: WaSocket) {
 async function resetActiveLogin(accountId: string, reason?: string) {
   const login = activeLogins.get(accountId);
   if (login) {
-    closeSocket(login.sock);
+    // Revoke the operation before closing its socket so close-triggered credential
+    // work cannot race through with authority from the retired login instance.
     activeLogins.delete(accountId);
+    closeSocket(login.sock);
   }
   if (reason) {
     logInfo(reason);
@@ -201,6 +204,7 @@ function attachLoginWaiter(accountId: string, login: ActiveLogin) {
     verbose: login.verbose,
     runtime: login.runtime,
     socketTiming: login.socketTiming,
+    beforeCredentialPersistence: login.beforeCredentialPersistence,
     onQr: (qr) => {
       const current = activeLogins.get(accountId);
       if (!current || current.id !== login.id) {
@@ -322,6 +326,7 @@ export async function startWebLoginWithQr(
     force?: boolean;
     accountId?: string;
     runtime?: RuntimeEnv;
+    beforeCredentialPersistence?: () => Promise<void>;
   } = {},
 ): Promise<StartWebLoginWithQrResult> {
   const runtime = opts.runtime ?? defaultRuntime;
@@ -348,6 +353,7 @@ export async function startWebLoginWithQr(
         authDir: account.authDir,
         isLegacyAuthDir: account.isLegacyAuthDir,
         runtime,
+        beforeCredentialPersistence: opts.beforeCredentialPersistence,
       });
       if (!cleared) {
         return {
@@ -389,10 +395,22 @@ export async function startWebLoginWithQr(
   let sock: WaSocket;
   let pendingQr: string | null = null;
   const loginId = randomUUID();
+  const operationOwner: { current?: ActiveLogin } = {};
+  const beforeCredentialPersistence = async () => {
+    const login = operationOwner.current;
+    if (!login) {
+      await opts.beforeCredentialPersistence?.();
+      return;
+    }
+    if (activeLogins.get(account.accountId) !== login || !isLoginFresh(login)) {
+      throw new Error("WhatsApp login is no longer active.");
+    }
+  };
   try {
     sock = await createWaSocket(false, Boolean(opts.verbose), {
       authDir: account.authDir,
       ...socketTiming,
+      beforeCredentialPersistence,
       onQr: (qr: string) => {
         pendingQr = qr;
         const current = activeLogins.get(account.accountId);
@@ -421,7 +439,7 @@ export async function startWebLoginWithQr(
       message: `Failed to start WhatsApp login: ${String(err)}`,
     };
   }
-  const login: ActiveLogin = {
+  const nextLogin: ActiveLogin = {
     accountId: account.accountId,
     authDir: account.authDir,
     isLegacyAuthDir: account.isLegacyAuthDir,
@@ -437,23 +455,36 @@ export async function startWebLoginWithQr(
     verbose: Boolean(opts.verbose),
     runtime,
     socketTiming,
+    beforeCredentialPersistence,
   };
-  resetQrUpdateSignal(login);
-  activeLogins.set(account.accountId, login);
+  try {
+    // Bootstrap authority is checked immediately before ownership transfers to
+    // this exact login instance; stale, expired, or replaced instances fail later writes.
+    await opts.beforeCredentialPersistence?.();
+  } catch (err) {
+    clearTimeout(qrTimer);
+    closeSocket(sock);
+    return {
+      message: `Failed to start WhatsApp login: ${String(err)}`,
+    };
+  }
+  operationOwner.current = nextLogin;
+  resetQrUpdateSignal(nextLogin);
+  activeLogins.set(account.accountId, nextLogin);
   if (pendingQr) {
-    const qrVersion = updateLoginQrState(login, pendingQr);
+    const qrVersion = updateLoginQrState(nextLogin, pendingQr);
     renderLatestQrDataUrlInBackground({
       accountId: account.accountId,
-      loginId: login.id,
+      loginId: nextLogin.id,
       qr: pendingQr,
       qrVersion,
     });
   }
-  attachLoginWaiter(account.accountId, login);
+  attachLoginWaiter(account.accountId, nextLogin);
 
   const loginStartResult = await waitForQrOrRecoveredLogin({
     accountId: account.accountId,
-    login,
+    login: nextLogin,
     qrPromise,
   });
   clearTimeout(qrTimer);
@@ -475,8 +506,8 @@ export async function startWebLoginWithQr(
     };
   }
 
-  const qr = login.qr ?? loginStartResult.qr;
-  const qrVersion = login.qrVersion;
+  const qr = nextLogin.qr ?? loginStartResult.qr;
+  const qrVersion = nextLogin.qrVersion;
   if (qrVersion === 0) {
     await resetActiveLogin(account.accountId);
     return {
@@ -488,7 +519,7 @@ export async function startWebLoginWithQr(
   try {
     qrDataUrl = await ensureQrDataUrl({
       accountId: account.accountId,
-      loginId: login.id,
+      loginId: nextLogin.id,
       qr,
       qrVersion,
     });

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -2557,7 +2557,8 @@
       "openclaw": {
         "contracts": {
           "tools": [
-            "whatsapp_call"
+            "whatsapp_call",
+            "whatsapp_login"
           ]
         },
         "channel": {

--- a/src/gateway/tools-invoke-http.abort.test.ts
+++ b/src/gateway/tools-invoke-http.abort.test.ts
@@ -154,7 +154,7 @@ describe("POST /tools/invoke request cancellation", () => {
     }
   });
 
-  it("passes a request-owned abort signal to the tool and releases its disconnect watcher", async () => {
+  it("revokes the tool signal after a successful request and releases its disconnect watcher", async () => {
     const response = await invokeAbortProbe();
 
     expect(response.status).toBe(200);
@@ -163,7 +163,7 @@ describe("POST /tools/invoke request cancellation", () => {
 
     const toolSignal = lifecycle.execute.mock.calls[0]?.[2];
     expect(toolSignal).toBeInstanceOf(AbortSignal);
-    expect(toolSignal?.aborted).toBe(false);
+    expect(toolSignal?.aborted).toBe(true);
     expect(lifecycle.beforeHook).toHaveBeenCalledWith(
       expect.objectContaining({ signal: toolSignal }),
     );

--- a/src/gateway/tools-invoke-shared.ts
+++ b/src/gateway/tools-invoke-shared.ts
@@ -169,8 +169,7 @@ function resolveToolSource(tool: AnyAgentTool): "core" | "plugin" | "channel" {
   return "core";
 }
 
-/** Resolves, authorizes, and invokes one gateway-visible core/plugin/channel tool. */
-export async function invokeGatewayTool(params: {
+type InvokeGatewayToolParams = {
   cfg: OpenClawConfig;
   input: ToolsInvokeInput;
   messageChannel?: string;
@@ -185,7 +184,11 @@ export async function invokeGatewayTool(params: {
   toolCallIdPrefix: string;
   approvalMode?: "request" | "report";
   signal?: AbortSignal;
-}): Promise<ToolsInvokeOutcome> {
+};
+
+async function invokeGatewayToolWithSignal(
+  params: InvokeGatewayToolParams & { signal: AbortSignal },
+): Promise<ToolsInvokeOutcome> {
   const conversationReadOrigin = normalizeConversationReadInvocationOrigin(
     params.conversationReadOrigin,
   );
@@ -455,5 +458,20 @@ export async function invokeGatewayTool(params: {
       toolName,
       error: { type: "tool_error", message: "tool execution failed" },
     };
+  }
+}
+
+/** Resolves, authorizes, and invokes one gateway-visible core/plugin/channel tool. */
+export async function invokeGatewayTool(
+  params: InvokeGatewayToolParams,
+): Promise<ToolsInvokeOutcome> {
+  const requestAbort = new AbortController();
+  const signal = params.signal
+    ? AbortSignal.any([params.signal, requestAbort.signal])
+    : requestAbort.signal;
+  try {
+    return await invokeGatewayToolWithSignal({ ...params, signal });
+  } finally {
+    requestAbort.abort();
   }
 }

--- a/test/e2e/qa-lab/runtime/gateway-whatsapp-login-authority.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-whatsapp-login-authority.e2e.test.ts
@@ -1,0 +1,133 @@
+// QA Lab proof for WhatsApp login authorization through the real Gateway plugin path.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ADMIN_SCOPE, WRITE_SCOPE } from "../../../../src/gateway/operator-scopes.js";
+import {
+  connectGatewayClient,
+  disconnectGatewayClient,
+} from "../../../../src/gateway/test-helpers.e2e.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "../../../helpers/openclaw-test-instance.js";
+
+type ToolsInvokeResult = {
+  ok: boolean;
+  toolName: string;
+  output?: unknown;
+  source?: string;
+  error?: { code?: string; message?: string };
+};
+
+let instance: OpenClawTestInstance | undefined;
+
+afterEach(async () => {
+  await instance?.cleanup();
+  instance = undefined;
+});
+
+describe("Gateway WhatsApp login authority", () => {
+  it(
+    "hides credential relinking from non-owners and preserves the owner wait flow",
+    { timeout: 120_000 },
+    async () => {
+      instance = await createOpenClawTestInstance({
+        name: "qa-whatsapp-login-authority",
+        env: {
+          OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(process.cwd(), "dist", "extensions"),
+        },
+        config: {
+          plugins: {
+            enabled: true,
+            allow: ["whatsapp"],
+            entries: { whatsapp: { enabled: true } },
+          },
+          agents: {
+            list: [
+              {
+                id: "main",
+                default: true,
+                tools: { allow: ["whatsapp_login"] },
+              },
+            ],
+          },
+          gateway: { tools: { allow: ["whatsapp_login"] } },
+        },
+      });
+
+      const credsPath = path.join(
+        instance.stateDir,
+        "credentials",
+        "whatsapp",
+        "default",
+        "creds.json",
+      );
+      const sentinel = `${JSON.stringify({ registered: true, proof: "preserve" })}\n`;
+      await fs.mkdir(path.dirname(credsPath), { recursive: true });
+      await fs.writeFile(credsPath, sentinel, "utf8");
+      await instance.startGateway();
+
+      const nonOwner = await connectGatewayClient({
+        url: instance.url,
+        token: instance.gatewayToken,
+        scopes: [WRITE_SCOPE],
+        clientDisplayName: "whatsapp-login-non-owner",
+        deviceFamily: "whatsapp-login-non-owner",
+        timeoutMs: 30_000,
+      });
+      const owner = await connectGatewayClient({
+        url: instance.url,
+        token: instance.gatewayToken,
+        scopes: [ADMIN_SCOPE, WRITE_SCOPE],
+        clientDisplayName: "whatsapp-login-owner",
+        deviceFamily: "whatsapp-login-owner",
+        timeoutMs: 30_000,
+      });
+
+      try {
+        const denied = await nonOwner.request<ToolsInvokeResult>("tools.invoke", {
+          name: "whatsapp_login",
+          args: { action: "start", force: true, timeoutMs: 1 },
+          sessionKey: "main",
+        });
+        expect(denied).toEqual({
+          ok: false,
+          toolName: "whatsapp_login",
+          error: {
+            code: "not_found",
+            message: "Tool not available: whatsapp_login",
+          },
+        });
+        await expect(fs.readFile(credsPath, "utf8")).resolves.toBe(sentinel);
+
+        const allowed = await owner.request<ToolsInvokeResult>("tools.invoke", {
+          name: "whatsapp_login",
+          args: { action: "wait", timeoutMs: 1 },
+          sessionKey: "main",
+        });
+        expect(allowed).toMatchObject({
+          ok: true,
+          toolName: "whatsapp_login",
+          source: "plugin",
+          output: {
+            content: [{ type: "text", text: "No active WhatsApp login in progress." }],
+            details: { connected: false },
+          },
+        });
+
+        console.log(
+          `[qa-whatsapp-login-authority] ${JSON.stringify({
+            nonOwner: "tool-hidden",
+            credentialSentinel: "preserved",
+            ownerWait: "allowed",
+            source: allowed.source,
+          })}`,
+        );
+      } finally {
+        await disconnectGatewayClient(owner);
+        await disconnectGatewayClient(nonOwner);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

The WhatsApp QR relink tool was registered through the channel-tool surface, which does not receive the trusted sender-owner fact. A write-scoped non-owner could therefore discover the tool and request a forced relink, whose normal implementation may clear saved credentials before creating a replacement linked-device session.

## Root Cause And Owner Boundary

Current plugin tool factories receive senderIsOwner from the admitted run or direct Gateway request. The older channel-tool registration bypassed that owner-aware factory boundary.

Credential mutation also outlives the first synchronous checks: forced logout, socket bootstrap, credential saves, and replacement sockets can happen after awaited work. The request must remain active until ownership transfers to the exact active WhatsApp login operation; stale, expired, reset, or replaced operations must then fail before later persistence.

The canonical owners are:

- the plugin factory for owner-only tool visibility;
- the standard tool execution signal for the originating run or direct Gateway request;
- the exact active WhatsApp login instance for delayed credential persistence after a valid transfer.

## Implementation

- Registers whatsapp_login through the existing plugin tool factory and omits it unless senderIsOwner is true.
- Removes the obsolete channel agentTools registration path and declares the tool in the plugin contract/catalog.
- Gives direct Gateway tool invocation a request-owned execution signal and aborts it when the request settles.
- Revalidates that execution signal before forced logout, socket bootstrap, and ownership transfer.
- Transfers delayed persistence to the exact active, fresh login instance; reset, expiry, or replacement revokes the prior instance before socket shutdown can trigger more writes.
- Threads the operation guard through initial and replacement socket/logout paths.
- Keeps the normal owner wait flow and CLI/setup login paths unchanged.

## Authorization And Lifecycle Matrix

| Actor / lifecycle | Entry surface | Requested action | Required gate | Enforced result |
|---|---|---|---|---|
| Write-scoped non-owner | Gateway tools.invoke | whatsapp_login start force:true | owner | tool absent; credential sentinel unchanged |
| Admin owner | Gateway tools.invoke | whatsapp_login wait | owner + active request | normal plugin result returned |
| Request revoked during auth inspection or socket bootstrap | plugin execution | start/relink | active execution signal | persistence rejects before transfer |
| Active QR operation after valid transfer | WhatsApp login owner | credential/socket continuation | exact active, fresh login instance | allowed |
| Expired, reset, or replaced QR operation | delayed callback | credential write/logout/socket replacement | exact active, fresh login instance | persistence rejects |

## Proof

The real-Gateway QA test:

1. starts the built Gateway and bundled WhatsApp plugin;
2. creates a disposable saved-credential sentinel;
3. connects a client with operator.write only and proves whatsapp_login is not available;
4. verifies the credential sentinel remains byte-identical;
5. connects an operator.admin owner and proves the legitimate wait workflow returns the plugin result.

A live WhatsApp account is intentionally not relinked because the protected final effect is local credential replacement. The test exercises that production boundary without mutating an external account.

Exact-head remote Testbox proof: [Actions run 32907375526](https://github.com/openclaw/openclaw/actions/runs/32907375526) (lease tbx_01m0xhcka0rnajpbxb6qw68098, succeeded and stopped).

Command: node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --timing-json -- CI=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm test test/e2e/qa-lab/runtime/gateway-whatsapp-login-authority.e2e.test.ts

Result: 1 test file and 1 test passed. Built runtime: OpenClaw 2026.8.1 (cb42299). Verdict: non-owner tool hidden, credential sentinel preserved, owner wait allowed, source=plugin.

## Local Verification

- Exact-head focused suites: 4 files, 83 tests passed.
- Full changed-surface gate passed: formatting, contract/metadata checks, plugin boundaries, dead-export scans, all core/plugin/root-test type graphs, full core/plugin/script lint, storage guards, and import-cycle checks.
- Structured autoreview: clean; no accepted/actionable findings, correctness confidence 0.98.
- git diff --check: passed.

Focused coverage includes non-owner omission, the positive owner flow, direct-request signal revocation, forced credential cleanup, bootstrap revocation, exact-operation transfer, 515 socket replacement, 401 logout/relink, expiry, reset, and replacement.

## Sibling And Compatibility Audit

- Existing owner-aware plugin tools were checked; they use the same trusted factory context but do not share WhatsApp credential-relink ownership.
- The login operation already exposes one persistence guard through socket creation, credential stores, and logout; this change supplies the correct lifecycle owner instead of adding a parallel persistence path.
- Channel CLI/setup login remains on its existing operator-owned path.
- No config, protocol, storage schema, public API, or default changes.

## Change Surface

- Production TypeScript: +95/-24 (net +71).
- Tests: +358/-20 (net +338).
- Manifest/generated catalog: +3/-2 (net +1).

The positive production delta is the request-to-operation ownership transfer and the guard propagation needed to stop stale final effects. It is implemented at the existing factory, execution-signal, active-login, socket, and auth-store owner boundaries; no compatibility wrapper or duplicate policy path is added.

## User Impact

Owner-authorized agent and direct Gateway workflows retain WhatsApp QR login. Non-owner and unknown-owner runs no longer receive account relinking capability. Active authorized login operations continue after request completion only while that exact login instance remains current and fresh.



