### PR TITLE
test: remove stale Claude ambient discovery fixture

### DIFF
--- a/src/commands/onboard-inference-ambient.test.ts
+++ b/src/commands/onboard-inference-ambient.test.ts
@@ -24,34 +24,17 @@ afterEach(async () => {
 });
 
 describe("detectAmbientInferenceBackends", () => {
-  it.each([
-    {
-      kind: "claude-cli" as const,
-      relativePath: ".claude/.credentials.json",
-      credential: {
-        claudeAiOauth: {
-          accessToken: "claude-access",
-          refreshToken: "claude-refresh",
-          expiresAt: Date.now() + 60_000,
-        },
-      },
-    },
-    {
-      kind: "codex-cli" as const,
-      relativePath: ".codex/auth.json",
-      credential: {
-        auth_mode: "chatgpt",
-        tokens: { access_token: "codex-access", refresh_token: "codex-refresh" },
-      },
-    },
-  ])("returns a verified $kind candidate only for readable file credentials", async (fixture) => {
+  it("returns a verified Codex candidate only for readable file credentials", async () => {
     const home = await createTempHome();
     expect(detectAmbientInferenceBackends({ HOME: home })).toEqual([]);
 
-    await writeCredential(home, fixture.relativePath, fixture.credential);
+    await writeCredential(home, ".codex/auth.json", {
+      auth_mode: "chatgpt",
+      tokens: { access_token: "codex-access", refresh_token: "codex-refresh" },
+    });
 
     expect(detectAmbientInferenceBackends({ HOME: home })).toEqual([
-      expect.objectContaining({ kind: fixture.kind, credentials: true }),
+      expect.objectContaining({ kind: "codex-cli", credentials: true }),
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Remove the obsolete Claude credential-file discovery fixture from onboarding tests.

## Root Cause

#129052 moved Claude authentication ownership back to the native CLI and removed ambient Claude credential-file discovery from `detectAmbientInferenceBackends`.

The test still created a Claude credentials file and expected a verified `claude-cli` candidate, so it asserted behavior that production intentionally no longer provides.

## Change

- remove the retired Claude credential-file fixture and expectation
- retain Codex CLI credential-file discovery coverage
- leave production onboarding behavior unchanged

## Verification

- pre-fix expected failure
- focused test passed locally and on Testbox
- formatting
- remote changed-path guards
- autoreview

Refs #129052
