### PR TITLE
test: reuse embedded runner permission harness

### DIFF
--- a/src/agents/embedded-agent-runner/run.session-permissions.test.ts
+++ b/src/agents/embedded-agent-runner/run.session-permissions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
@@ -6,9 +6,14 @@ import {
   overflowBaseRunParams,
 } from "./run.overflow-compaction.harness.js";
 
+const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
+
 describe("embedded run session permissions", () => {
+  beforeEach(() => {
+    mockedRunEmbeddedAttempt.mockReset();
+  });
+
   it("prepares the exec mode with plugin-owned permission facts", async () => {
-    const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["OK"] }));
 
     await runEmbeddedAgent({
@@ -28,7 +33,6 @@ describe("embedded run session permissions", () => {
   });
 
   it("shares the final plugin-clamped exec mode with the outer run", async () => {
-    const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
     const execOverrides = {};
     mockedRunEmbeddedAttempt.mockImplementationOnce(async (attempt) => {
       expect(attempt.execOverrides).toBe(execOverrides);


### PR DESCRIPTION
## Summary

Reuse the embedded-runner permission harness across the two tests in this suite.

## Root Cause

Each test called `loadRunOverflowCompactionHarness()`, reloading the expensive embedded-runner module graph and rebuilding the harness.

Under hosted runner pressure, the first test completed but the second exceeded the 120-second test timeout before reaching its assertions.

## Changes

- load the embedded-runner harness once for the test file
- reset the mutable attempt mock before each test
- preserve independent permission assertions and production behavior

## Performance

- before: the second test timed out after 123 seconds
- after: both tests passed in 108 seconds total

## Verification

- 2 focused tests on Testbox
- formatting
- `git diff --check`
- autoreview
