### PR TITLE
fix: keep retired auth profile lookup runtime-free

### DIFF
--- a/extensions/anthropic/provider-policy-api.test.ts
+++ b/extensions/anthropic/provider-policy-api.test.ts
@@ -3,6 +3,7 @@ import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-t
 import { describe, expect, it } from "vitest";
 import {
   applyConfigDefaults,
+  deprecatedProfileIds,
   normalizeConfig,
   resolveThinkingProfile,
 } from "./provider-policy-api.js";
@@ -39,6 +40,10 @@ function levelIds(levels: readonly { id: string }[] | undefined): string[] {
 }
 
 describe("anthropic provider policy public artifact", () => {
+  it("publishes native Claude profiles retired from generic auth", () => {
+    expect(deprecatedProfileIds).toEqual(["anthropic:claude-cli"]);
+  });
+
   it("normalizes Anthropic provider config", () => {
     const normalized = normalizeConfig({
       provider: "anthropic",

--- a/extensions/anthropic/provider-policy-api.ts
+++ b/extensions/anthropic/provider-policy-api.ts
@@ -2,6 +2,7 @@
  * Provider-policy API for Anthropic and Claude CLI. Core calls this lightweight
  * path for config defaults and thinking profiles.
  */
+import { CLAUDE_CLI_PROFILE_ID } from "openclaw/plugin-sdk/provider-auth";
 import {
   resolveClaudeModelIdentity,
   resolveClaudeMythos5ModelIdentity,
@@ -13,6 +14,9 @@ import {
   applyAnthropicConfigDefaults,
   normalizeAnthropicProviderConfigForProvider,
 } from "./config-defaults.js";
+
+/** Profile ids that native Claude auth has retired from OpenClaw ownership. */
+export const deprecatedProfileIds = [CLAUDE_CLI_PROFILE_ID] as const;
 
 /** Normalize Anthropic provider config without importing runtime registration. */
 export function normalizeConfig(params: { provider: string; providerConfig: ModelProviderConfig }) {

--- a/src/plugins/provider-policy-surface.test.ts
+++ b/src/plugins/provider-policy-surface.test.ts
@@ -16,6 +16,7 @@ describe("direct provider policy surface", () => {
     const resolveModelRoutes = vi.fn();
     const isResponseModelEquivalent = vi.fn();
     const loadBundledPluginPublicArtifactModuleSync = vi.fn(() => ({
+      deprecatedProfileIds: ["demo:legacy"],
       resolveModelRoutes,
       isResponseModelEquivalent,
     }));
@@ -36,6 +37,7 @@ describe("direct provider policy surface", () => {
 
     expect(surface?.resolveModelRoutes).toBe(resolveModelRoutes);
     expect(surface?.isResponseModelEquivalent).toBe(isResponseModelEquivalent);
+    expect(surface?.deprecatedProfileIds).toEqual(["demo:legacy"]);
     expect(loadBundledPluginPublicArtifactModuleSync).toHaveBeenCalledWith({
       dirName: "openai",
       artifactBasename: "provider-policy-api.js",

--- a/src/plugins/provider-policy-surface.ts
+++ b/src/plugins/provider-policy-surface.ts
@@ -51,6 +51,7 @@ export type InspectEmbeddingProviderSetup = (params: {
 
 /** Provider policy hooks supported by bundled and trusted official plugins. */
 export type ProviderPolicySurface = {
+  deprecatedProfileIds?: readonly string[];
   normalizeConfig?: (ctx: ProviderNormalizeConfigContext) => ModelProviderConfig | null | undefined;
   applyConfigDefaults?: (
     ctx: ProviderApplyConfigDefaultsContext,
@@ -103,6 +104,12 @@ const PROVIDER_POLICY_HOOK_KEYS = [
 
 function extractProviderPolicySurface(mod: Record<string, unknown>): ProviderPolicySurface | null {
   const surface: ProviderPolicySurface = {};
+  if (
+    Array.isArray(mod.deprecatedProfileIds) &&
+    mod.deprecatedProfileIds.every((value) => typeof value === "string")
+  ) {
+    surface.deprecatedProfileIds = mod.deprecatedProfileIds;
+  }
   for (const key of PROVIDER_POLICY_HOOK_KEYS) {
     const hook = mod[key];
     if (typeof hook === "function") {

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -76,6 +76,7 @@ let resolveProviderStreamFn: typeof import("./provider-runtime.js").resolveProvi
 let resolveProviderTransportTurnStateWithPlugin: typeof import("./provider-runtime.js").resolveProviderTransportTurnStateWithPlugin;
 let resolveProviderCacheTtlEligibility: typeof import("./provider-runtime.js").resolveProviderCacheTtlEligibility;
 let resolveProviderModernModelRef: typeof import("./provider-runtime.js").resolveProviderModernModelRef;
+let resolveProviderDeprecatedAuthProfileIds: typeof import("./provider-runtime.js").resolveProviderDeprecatedAuthProfileIds;
 let resolveProviderReasoningOutputModeWithPlugin: typeof import("./provider-runtime.js").resolveProviderReasoningOutputModeWithPlugin;
 let resolveProviderSystemPromptContribution: typeof import("./provider-runtime.js").resolveProviderSystemPromptContribution;
 let resolveExternalAuthProfilesWithPlugins: typeof import("./provider-runtime.js").resolveExternalAuthProfilesWithPlugins;
@@ -322,6 +323,7 @@ describe("provider-runtime", () => {
       resolveProviderTransportTurnStateWithPlugin,
       resolveProviderCacheTtlEligibility,
       resolveProviderModernModelRef,
+      resolveProviderDeprecatedAuthProfileIds,
       resolveProviderReasoningOutputModeWithPlugin,
       resolveProviderSystemPromptContribution,
       resolveExternalAuthProfilesWithPlugins,
@@ -1634,6 +1636,17 @@ describe("provider-runtime", () => {
     ).toBeUndefined();
 
     expect(normalizeConfig).toHaveBeenCalledTimes(1);
+    expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
+  });
+
+  it("reads deprecated profile ids without loading provider runtime", () => {
+    resolveBundledProviderPolicySurfaceMock.mockReturnValue({
+      deprecatedProfileIds: ["anthropic:claude-cli"],
+    });
+
+    expect(resolveProviderDeprecatedAuthProfileIds({ provider: "anthropic" })).toEqual([
+      "anthropic:claude-cli",
+    ]);
     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
 

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -899,7 +899,11 @@ export function resolveProviderDeprecatedAuthProfileIds(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 }): readonly string[] {
-  return resolveProviderRuntimePlugin(params)?.deprecatedProfileIds ?? [];
+  return (
+    resolveBundledProviderPolicySurface(params.provider)?.deprecatedProfileIds ??
+    resolveLoadedProviderRuntimePlugin(params)?.deprecatedProfileIds ??
+    []
+  );
 }
 
 export function buildProviderMissingAuthMessageWithPlugin(params: {


### PR DESCRIPTION
## Summary

Keep retired auth-profile lookup on the lightweight provider-policy path instead of loading provider runtimes.

## Root Cause

#129052 added provider-owned retired profile metadata, but `resolveProviderDeprecatedAuthProfileIds` read it through `resolveProviderRuntimePlugin`.

That path cold-loaded provider runtimes during generic auth resolution even though the requested fact is static manifest-owned policy. The unnecessary runtime graph caused four auth and media suites to exceed their test timeout under normal runner pressure.

## Changes

- expose retired profile IDs through the existing provider-policy artifact
- publish the retired Claude CLI profile ID from the Anthropic policy module
- resolve bundled retired-profile metadata without loading provider runtime
- preserve the loaded-plugin fallback for external providers
- validate the new policy field before exposing it

## Performance

- before: four focused suites timed out
- after: all four suites finish in under seven seconds

## Verification

- 119 focused tests on Testbox
- formatting
- core and extension lint
- plugin boundary checks
- `git diff --check`
- autoreview

Refs #129052
