### PR TITLE
test: isolate turn model differential imports

### DIFF
--- a/src/agents/command/model-selection.turn-model-differential.test.ts
+++ b/src/agents/command/model-selection.turn-model-differential.test.ts
@@ -21,6 +21,11 @@ vi.mock("../agent-scope.js", () => ({
   resolveAgentConfig: () => undefined,
   resolveAgentEffectiveModelPrimary: () => undefined,
 }));
+vi.mock("../../auto-reply/thinking.js", () => ({
+  formatThinkingLevels: () => "",
+  isThinkingLevelSupported: () => true,
+  normalizeThinkLevel: (value: string | undefined) => value,
+}));
 vi.mock("../../channels/model-overrides.js", () => ({
   resolveChannelModelOverride: (params: {
     cfg: OpenClawConfig;
@@ -47,6 +52,9 @@ vi.mock("../../channels/model-overrides.js", () => ({
       ? { channel, model, matchKey: matchKey ?? "*", matchSource: matchKey ? "exact" : "wildcard" }
       : null;
   },
+}));
+vi.mock("../../utils/message-channel.js", () => ({
+  isDeliverableMessageChannel: (value: string) => value !== "internal",
 }));
 
 vi.mock("../auth-profiles/order.js", () => ({


### PR DESCRIPTION
## Summary

Keep the turn model-differential suite focused on model selection instead of loading unrelated runtime barrels.

## Root Cause

The test mocked its model-selection dependencies but left the thinking-level and message-channel runtime modules unmocked.

Importing those heavyweight barrels stalled module initialization before Vitest could start the test cases.

## Changes

- provide focused thinking-level helpers for the suite
- provide focused deliverable-channel classification
- leave production model-selection behavior unchanged

## Performance

- before: no test output after 225.52 seconds
- after: 8/8 tests pass in 6.38 seconds

## Verification

- 8 focused tests
- formatting
- Oxlint
- `git diff --check`
- autoreview
