### PR TITLE
fix(diffs): resolve viewer assets in unified builds

### DIFF
--- a/extensions/diffs/src/viewer-assets.test.ts
+++ b/extensions/diffs/src/viewer-assets.test.ts
@@ -3,8 +3,21 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const VIEWER_LOADER_PATH = "/plugins/diffs/assets/viewer.js";
+const LANGUAGE_PACK_VIEWER_LOADER_PATH = "/plugins/diffs-language-pack/assets/viewer.js";
 const BUILT_RUNTIME_PATH = fileURLToPath(new URL("./assets/viewer-runtime.js", import.meta.url));
 const SOURCE_RUNTIME_PATH = fileURLToPath(new URL("../assets/viewer-runtime.js", import.meta.url));
+const ROOT_BUNDLE_RUNTIME_PATH = fileURLToPath(
+  new URL("./extensions/diffs/assets/viewer-runtime.js", import.meta.url),
+);
+const LANGUAGE_PACK_SOURCE_RUNTIME_PATH = fileURLToPath(
+  new URL("../../diffs-language-pack/assets/viewer-runtime.js", import.meta.url),
+);
+const LANGUAGE_PACK_FALLBACK_RUNTIME_PATH = fileURLToPath(
+  new URL("../diffs-language-pack/assets/viewer-runtime.js", import.meta.url),
+);
+const ROOT_BUNDLE_LANGUAGE_PACK_RUNTIME_PATH = fileURLToPath(
+  new URL("./extensions/diffs-language-pack/assets/viewer-runtime.js", import.meta.url),
+);
 
 function missingFile(path: string): NodeJS.ErrnoException {
   return Object.assign(new Error(`missing: ${path}`), { code: "ENOENT" });
@@ -23,6 +36,24 @@ async function loadViewerWithRuntimeAt(runtimePath: string) {
   );
   const { getServedViewerAsset } = await import("./viewer-assets.js");
   const loader = await getServedViewerAsset(VIEWER_LOADER_PATH);
+  expect(loader?.contentType).toBe("text/javascript; charset=utf-8");
+  expect(String(loader?.body)).toContain("./viewer-runtime.js?v=");
+  return stat;
+}
+
+async function loadLanguagePackViewerWithRuntimeAt(runtimePath: string) {
+  const stat = vi.spyOn(fs, "stat").mockImplementation(async (path) => {
+    const candidate = String(path);
+    if (candidate === runtimePath) {
+      return { mtimeMs: 1 } as never;
+    }
+    throw missingFile(candidate);
+  });
+  vi.spyOn(fs, "readFile").mockResolvedValue(
+    Buffer.from("window.openclawDiffsReady = true;\n") as never,
+  );
+  const { getServedLanguagePackViewerAsset } = await import("./viewer-assets.js");
+  const loader = await getServedLanguagePackViewerAsset(LANGUAGE_PACK_VIEWER_LOADER_PATH);
   expect(loader?.contentType).toBe("text/javascript; charset=utf-8");
   expect(String(loader?.body)).toContain("./viewer-runtime.js?v=");
   return stat;
@@ -47,5 +78,23 @@ describe("viewer runtime resolution", () => {
     expect(stat).toHaveBeenNthCalledWith(1, BUILT_RUNTIME_PATH);
     expect(stat).toHaveBeenNthCalledWith(2, SOURCE_RUNTIME_PATH);
     expect(stat).toHaveBeenNthCalledWith(3, SOURCE_RUNTIME_PATH);
+  });
+
+  it("serves the runtime from the unified root bundle layout", async () => {
+    const stat = await loadViewerWithRuntimeAt(ROOT_BUNDLE_RUNTIME_PATH);
+
+    expect(stat).toHaveBeenNthCalledWith(1, BUILT_RUNTIME_PATH);
+    expect(stat).toHaveBeenNthCalledWith(2, SOURCE_RUNTIME_PATH);
+    expect(stat).toHaveBeenNthCalledWith(3, ROOT_BUNDLE_RUNTIME_PATH);
+    expect(stat).toHaveBeenNthCalledWith(4, ROOT_BUNDLE_RUNTIME_PATH);
+  });
+
+  it("serves the language pack from the unified root bundle layout", async () => {
+    const stat = await loadLanguagePackViewerWithRuntimeAt(ROOT_BUNDLE_LANGUAGE_PACK_RUNTIME_PATH);
+
+    expect(stat).toHaveBeenNthCalledWith(1, LANGUAGE_PACK_SOURCE_RUNTIME_PATH);
+    expect(stat).toHaveBeenNthCalledWith(2, LANGUAGE_PACK_FALLBACK_RUNTIME_PATH);
+    expect(stat).toHaveBeenNthCalledWith(3, ROOT_BUNDLE_LANGUAGE_PACK_RUNTIME_PATH);
+    expect(stat).toHaveBeenNthCalledWith(4, ROOT_BUNDLE_LANGUAGE_PACK_RUNTIME_PATH);
   });
 });

--- a/extensions/diffs/src/viewer-assets.ts
+++ b/extensions/diffs/src/viewer-assets.ts
@@ -10,13 +10,17 @@ export const LANGUAGE_PACK_VIEWER_ASSET_PREFIX = "/plugins/diffs-language-pack/a
 const LANGUAGE_PACK_VIEWER_LOADER_PATH = `${LANGUAGE_PACK_VIEWER_ASSET_PREFIX}viewer.js`;
 const LANGUAGE_PACK_VIEWER_RUNTIME_PATH = `${LANGUAGE_PACK_VIEWER_ASSET_PREFIX}viewer-runtime.js`;
 const VIEWER_RUNTIME_RELATIVE_IMPORT_PATH = "./viewer-runtime.js";
+// Unified builds hoist this module to the dist root while plugin assets stay under dist/extensions.
+// Keep those candidates last so package and source layouts retain their first-hit paths.
 const VIEWER_RUNTIME_CANDIDATE_RELATIVE_PATHS = [
   "./assets/viewer-runtime.js",
   "../assets/viewer-runtime.js",
+  "./extensions/diffs/assets/viewer-runtime.js",
 ] as const;
 const LANGUAGE_PACK_RUNTIME_CANDIDATE_RELATIVE_PATHS = [
   "../../diffs-language-pack/assets/viewer-runtime.js",
   "../diffs-language-pack/assets/viewer-runtime.js",
+  "./extensions/diffs-language-pack/assets/viewer-runtime.js",
 ] as const;
 
 type ServedViewerAsset = {

--- a/extensions/diffs/src/viewer-assets.ts
+++ b/extensions/diffs/src/viewer-assets.ts
@@ -37,39 +37,8 @@ type RuntimeAssetCache = {
 let runtimeAssetCache: RuntimeAssetCache | null = null;
 let languagePackRuntimeAssetCache: RuntimeAssetCache | null = null;
 
-type ViewerRuntimeFileUrlParams = {
-  baseUrl?: string | URL;
-  stat?: (path: string) => Promise<unknown>;
-};
-
 function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
-}
-
-async function resolveViewerRuntimeFileUrl(params: ViewerRuntimeFileUrlParams = {}): Promise<URL> {
-  const baseUrl = params.baseUrl ?? import.meta.url;
-  const stat = params.stat ?? ((path: string) => fs.stat(path));
-  let missingFileError: NodeJS.ErrnoException | null = null;
-
-  for (const relativePath of VIEWER_RUNTIME_CANDIDATE_RELATIVE_PATHS) {
-    const candidateUrl = new URL(relativePath, baseUrl);
-    try {
-      await stat(fileURLToPath(candidateUrl));
-      return candidateUrl;
-    } catch (error) {
-      if (isMissingFileError(error)) {
-        missingFileError = error;
-        continue;
-      }
-      throw error;
-    }
-  }
-
-  if (missingFileError) {
-    throw missingFileError;
-  }
-
-  throw new Error("viewer runtime asset candidates were not checked");
 }
 
 export async function getServedViewerAsset(pathname: string): Promise<ServedViewerAsset | null> {
@@ -135,7 +104,7 @@ export async function getServedLanguagePackViewerAsset(
 }
 
 async function loadViewerAssets(): Promise<RuntimeAssetCache> {
-  const runtimeUrl = await resolveViewerRuntimeFileUrl();
+  const runtimeUrl = await resolveRuntimeFileUrl(VIEWER_RUNTIME_CANDIDATE_RELATIVE_PATHS);
   return loadRuntimeAssets({
     runtimeUrl,
     cache: runtimeAssetCache,


### PR DESCRIPTION
## Summary

### High Level TLDR

Fixes the Diffs viewer asset lookup in unified builds. The shared viewer module is emitted at the root of `dist`, while its browser runtimes remain under `dist/extensions/...`; the resolver now recognizes that real build layout after its existing package and source candidates.

### Root Cause

PR #127040 moved viewer loading behind the shared lazy runtime path. In a unified build, the shared `viewer-assets` module executes from `dist/viewer-assets-*.js`, but the static assets are copied to:

```text
dist/extensions/diffs/assets/viewer-runtime.js
dist/extensions/diffs-language-pack/assets/viewer-runtime.js
```

The resolver only checked package and source layouts, so requesting the viewer loader reached `ENOENT` and the HTTP route returned a broken viewer response.

The fix stays at the asset-resolution owner: it adds the two actual unified-build locations, keeps existing lookup precedence, and routes both base lookups through the existing generic resolver instead of retaining duplicate policy.

### ClawSweeper sibling review

ClawSweeper correctly asked for proof of the independently served `diffs-language-pack` route. Artifact inspection showed that plugin is emitted at `dist/extensions/diffs-language-pack/index.js` beside `dist/extensions/diffs-language-pack/assets/`, so its existing first candidate (`./assets/viewer-runtime.js`) already matches the built layout. It is not hoisted into the shared root chunk.

The final emitted-route E2E exercised both the shared fallback route and the independently registered external plugin route; both served the language-pack loader and runtime with HTTP 200. No speculative fallback was added to the unaffected external plugin.

### Production and test surface

- Production: +5 / -32 lines (net -27)
- Tests: +49 lines
- Removed path: the base viewer's duplicate parameterized resolver

## What Problem This Solves

Users opening a diff viewer from a unified OpenClaw build could receive a failed asset response because the browser runtime was looked up relative to the wrong emitted module location.

## Why This Change Was Made

The resolver now follows the build's actual output contract. It does not duplicate static assets, weaken HTTP errors, or change package/source lookup precedence.

## User Impact

Base and language-pack diff viewers load their JavaScript assets normally from unified builds.

## Evidence

Final source was validated on AWS Crabbox lease `cbx_37339d314b56`:

- Focused Vitest: 6/6 passed across `extensions/diffs/src/viewer-assets.test.ts` and `extensions/diffs-language-pack/src/plugin.test.ts`.
- Full `pnpm build`: passed, including unified build, 61 external-plugin local dists, static-asset copy, runtime-postbuild, SDK export checks, and Control UI build. Run: `run_f926a63eb8d4`.
- Emitted-route HTTP E2E: passed against that exact build. Run: `run_a06b9e4ff5ff`.

```text
GET /plugins/diffs/assets/viewer.js                          -> 200
GET /plugins/diffs/assets/viewer-runtime.js                  -> 200
GET /plugins/diffs-language-pack/assets/viewer.js            -> 200
GET /plugins/diffs-language-pack/assets/viewer-runtime.js    -> 200
external diffs-language-pack registered route                -> 200
```

- `git diff --check`: passed.
- Autoreview on the local cleanup: clean (0.99).
- Autoreview on the complete branch against `origin/main`: clean (0.99).

### What was not tested

- The managed production Gateway was not restarted or modified.
- No external channel was needed; the failing boundary is the built plugin HTTP asset route and was exercised directly from the emitted artifacts.

Worked on by:
- @VACInc
