### PR TITLE
fix(cli): match hook info and mutation selector precedence

### DIFF
--- a/src/cli/hooks-cli.format.ts
+++ b/src/cli/hooks-cli.format.ts
@@ -174,11 +174,11 @@ export function formatHooksList(report: HookStatusReport, opts: HooksListOptions
  * Format detailed info for a single hook
  */
 export function formatHookInfo(
-  report: HookStatusReport,
+  { hooks }: HookStatusReport,
   hookName: string,
   opts: HookInfoOptions,
 ): string {
-  const hook = report.hooks.find((h) => h.name === hookName || h.hookKey === hookName);
+  const hook = hooks.find((h) => h.name === hookName) ?? hooks.find((h) => h.hookKey === hookName);
 
   if (!hook) {
     if (opts.json) {

--- a/src/cli/hooks-cli.toggle.test.ts
+++ b/src/cli/hooks-cli.toggle.test.ts
@@ -238,6 +238,14 @@ describe("hooks CLI metadata config keys", () => {
             : [exactNameHook, collidingKeyHook],
       });
 
+      await createHooksProgram().parseAsync(["hooks", "info", "shared", "--json"], {
+        from: "user",
+      });
+      expect(JSON.parse(capture.runtimeLogs.at(-1) ?? "null")).toMatchObject({
+        name: "shared",
+        hookKey: "metadata-key",
+      });
+
       await createHooksProgram().parseAsync(["hooks", "disable", "shared"], {
         from: "user",
       });


### PR DESCRIPTION
## Summary

Make `hooks info` inspect the same hook that `hooks enable` and `hooks disable` select.

## Root cause

Hook inspection matched the first hook whose name or configuration key equaled the selector. Mutation commands correctly prefer an exact hook name over another hook's colliding configuration key, so inspection and mutation silently targeted different hooks depending on discovery order.

The formatter now resolves exact names first, then falls back to configuration keys, matching the existing mutation owner.

## Validation

- Extended the existing real-CLI two-order mutation regression to inspect the selected hook immediately before disabling it; the key-first case failed before the fix.
- 62 focused hook inspection and mutation tests passed.
- Formatting, type-aware lint, and independent autoreview passed.
- Production delta: +2/-2, net zero.
