### PR TITLE
fix(browser): detect selected profile executable consistently

### DIFF
--- a/extensions/browser/src/browser/routes/basic.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/basic.existing-session.test.ts
@@ -78,6 +78,7 @@ function createManagedProfileState(
     isHttpReachable?: (timeoutMs?: number, signal?: AbortSignal) => Promise<boolean>;
     isTransportAvailable?: (timeoutMs?: number, signal?: AbortSignal) => Promise<boolean>;
   },
+  executablePath?: string,
 ) {
   return {
     resolved: {
@@ -85,7 +86,7 @@ function createManagedProfileState(
       headless: false,
       headlessSource: "default",
       noSandbox: false,
-      executablePath: undefined,
+      executablePath,
     },
     profiles: new Map(),
     forProfile: () =>
@@ -112,8 +113,9 @@ function createManagedProfileState(
 }
 
 async function callBasicRouteWithState(params: {
+  route?: "/" | "/doctor";
   query?: Record<string, string>;
-  state: ReturnType<typeof createExistingSessionProfileState>;
+  state: ReturnType<typeof createExistingSessionProfileState | typeof createManagedProfileState>;
   signal?: AbortSignal;
 }) {
   const { app, getHandlers } = createBrowserRouteApp();
@@ -122,7 +124,7 @@ async function callBasicRouteWithState(params: {
     forProfile: params.state.forProfile,
   } as never);
 
-  const handler = getHandlers.get("/");
+  const handler = getHandlers.get(params.route ?? "/");
   expect(handler).toBeTypeOf("function");
 
   const response = createBrowserRouteResponse();
@@ -224,6 +226,66 @@ describe("basic browser routes", () => {
     expect(response.statusCode).toBe(200);
     expect(ensureBrowserAvailable).toHaveBeenCalledOnce();
     expect(ensureTabAvailable).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["/", "/doctor"] as const)(
+    "detects the local managed profile executable for %s",
+    async (route) => {
+      const response = await callBasicRouteWithState({
+        route,
+        query: { profile: "openclaw" },
+        state: createManagedProfileState(
+          { executablePath: process.execPath, headless: true },
+          undefined,
+          "/definitely-missing-global-chromium",
+        ),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = responseBodyRecord(response);
+      const browserStatus = route === "/doctor" ? responseBodyRecord({ body: body.status }) : body;
+      expect(browserStatus).toMatchObject({
+        executablePath: process.execPath,
+        detectedBrowser: "custom",
+        detectedExecutablePath: process.execPath,
+        detectError: null,
+      });
+      if (route === "/doctor") {
+        expect(body.ok).toBe(true);
+      }
+    },
+  );
+
+  it.each([
+    { name: "loopback attach-only", profile: { attachOnly: true } },
+    {
+      name: "remote CDP",
+      profile: {
+        cdpHost: "remote.example",
+        cdpIsLoopback: false,
+        cdpUrl: "http://remote.example:9222",
+      },
+    },
+    { name: "extension relay", profile: { driver: "extension", attachOnly: true } },
+    { name: "existing session", profile: { driver: "existing-session", attachOnly: true } },
+  ])("ignores a non-owning $name profile executable override", async ({ profile }) => {
+    const ignoredExecutable = "/definitely-missing-ignored-profile-chromium";
+    const response = await callBasicRouteWithState({
+      query: { profile: "openclaw" },
+      state: createManagedProfileState(
+        { ...profile, executablePath: ignoredExecutable, headless: true },
+        undefined,
+        process.execPath,
+      ),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(responseBodyRecord(response)).toMatchObject({
+      executablePath: ignoredExecutable,
+      detectedBrowser: "custom",
+      detectedExecutablePath: process.execPath,
+      detectError: null,
+    });
   });
 
   it("reports Linux no-display headless fallback for local managed profiles", async () => {

--- a/extensions/browser/src/browser/routes/basic.ts
+++ b/extensions/browser/src/browser/routes/basic.ts
@@ -202,16 +202,16 @@ async function buildBrowserStatus(
           }),
       )
     : null;
-  let detectedBrowser: string | null = null;
-  let detectedExecutablePath: string | null = null;
+  let detected: ReturnType<typeof resolveBrowserExecutableForPlatform> = null;
   let detectError: string | null = null;
 
   try {
-    const detected = resolveBrowserExecutableForPlatform(current.resolved, process.platform);
-    if (detected) {
-      detectedBrowser = detected.kind;
-      detectedExecutablePath = detected.path;
-    }
+    detected = resolveBrowserExecutableForPlatform(
+      capabilities.mode === "local-managed" && capabilities.browserFilesystemLocal
+        ? { ...current.resolved, executablePath: profileCtx.profile.executablePath }
+        : current.resolved,
+      process.platform,
+    );
   } catch (err) {
     detectError = String(err);
   }
@@ -248,8 +248,8 @@ async function buildBrowserStatus(
     cdpPort: capabilities.usesChromeMcp ? null : profileCtx.profile.cdpPort,
     cdpUrl: profileCtx.profile.cdpUrl ? (redactCdpUrl(profileCtx.profile.cdpUrl) ?? null) : null,
     chosenBrowser: profileState?.running?.exe.kind ?? null,
-    detectedBrowser,
-    detectedExecutablePath,
+    detectedBrowser: detected?.kind ?? null,
+    detectedExecutablePath: detected?.path ?? null,
     detectError,
     userDataDir: profileState?.running?.userDataDir ?? profileCtx.profile.userDataDir ?? null,
     color: profileCtx.profile.color,


### PR DESCRIPTION
## Summary

Make browser status and doctor detect the executable actually selected by a locally managed browser profile.

## Root cause

Profile configuration and Chrome launch correctly apply a per-profile executable override, but the shared status/doctor owner independently ran executable detection using only global configuration. A valid profile Chrome therefore produced a false missing-browser error and failed doctor whenever the global path was missing or different.

Detect the effective profile executable only for genuinely local managed browser processes. Existing-session, extension relay, remote CDP, and loopback attach-only modes keep their existing global detection semantics.

## Validation

- Authentic registered `GET /` and `GET /doctor` regressions failed before repair while 26 sibling controls passed.
- 225 browser configuration, actual launch-owner, autodetection, doctor, profile reload, client, and CLI tests passed; two existing tests remain skipped.
- A real installed Chrome executable was exercised through both registered routes without network or browser launch: both now report its actual path and doctor returns success.
- Formatting, type-aware/type-checking lint, and independent autoreview passed.
- Production delta: +9/-9, net zero.
