### PR TITLE
fix(qa): reject incomplete manual lane responses

### DIFF
--- a/extensions/qa-lab/src/manual-lane.runtime.test.ts
+++ b/extensions/qa-lab/src/manual-lane.runtime.test.ts
@@ -177,6 +177,30 @@ describe("runQaManualLane", () => {
       reply: "   ",
       error: "manual lane did not produce a successful reply",
     },
+    {
+      label: "legacy completed run without an outbound reply",
+      waited: { status: "error", error: "completed" },
+      reply: null,
+      error: "manual lane did not produce a successful reply",
+    },
+    {
+      label: "legacy completed run with a whitespace-only reply",
+      waited: { status: "error", error: " completed " },
+      reply: "   ",
+      error: "manual lane did not produce a successful reply",
+    },
+    {
+      label: "timed-out run without an outbound reply",
+      waited: { status: "timeout", error: "provider stalled" },
+      reply: null,
+      error: "manual lane did not produce a successful reply",
+    },
+    {
+      label: "failed run with a whitespace-only reply",
+      waited: { status: "error", error: "authentication failed" },
+      reply: "   ",
+      error: "manual lane did not produce a successful reply",
+    },
   ])("rejects a $label after resource cleanup", async ({ waited, reply, error }) => {
     outboundReply = reply;
     gatewayCall.mockReset().mockResolvedValueOnce({ runId: "run-1" }).mockResolvedValueOnce(waited);

--- a/extensions/qa-lab/src/manual-lane.runtime.test.ts
+++ b/extensions/qa-lab/src/manual-lane.runtime.test.ts
@@ -41,8 +41,10 @@ describe("runQaManualLane", () => {
   const gatewayStop = vi.fn();
   const mockStop = vi.fn();
   const labStop = vi.fn();
+  let outboundReply: string | null;
 
   beforeEach(() => {
+    outboundReply = "Protocol note: mock reply.";
     gatewayCall.mockReset();
     gatewayStop.mockReset();
     mockStop.mockReset();
@@ -78,13 +80,16 @@ describe("runQaManualLane", () => {
         searchMessages: vi.fn(() => []),
         waitFor: vi.fn(),
         getSnapshot: () => ({
-          messages: [
-            {
-              direction: "outbound",
-              conversation: { id: "qa-operator" },
-              text: "Protocol note: mock reply.",
-            },
-          ],
+          messages:
+            outboundReply === null
+              ? []
+              : [
+                  {
+                    direction: "outbound",
+                    conversation: { id: "qa-operator" },
+                    text: outboundReply,
+                  },
+                ],
         }),
       },
       stop: labStop,
@@ -145,6 +150,73 @@ describe("runQaManualLane", () => {
     );
     expect(mockStop).toHaveBeenCalledTimes(1);
     expect(labStop).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      label: "timed-out run despite a stale reply",
+      waited: { status: "timeout", error: "provider stalled" },
+      reply: "stale assistant reply",
+      error: "provider stalled",
+    },
+    {
+      label: "failed run despite a stale reply",
+      waited: { status: "error", error: "authentication failed" },
+      reply: "stale assistant reply",
+      error: "authentication failed",
+    },
+    {
+      label: "successful run without an outbound reply",
+      waited: { status: "ok" },
+      reply: null,
+      error: "manual lane did not produce a successful reply",
+    },
+    {
+      label: "successful run with a whitespace-only reply",
+      waited: { status: "ok" },
+      reply: "   ",
+      error: "manual lane did not produce a successful reply",
+    },
+  ])("rejects a $label after resource cleanup", async ({ waited, reply, error }) => {
+    outboundReply = reply;
+    gatewayCall.mockReset().mockResolvedValueOnce({ runId: "run-1" }).mockResolvedValueOnce(waited);
+
+    await expect(
+      runQaManualLane({
+        repoRoot: "/tmp/openclaw-repo",
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        alternateModel: "mock-openai/gpt-5.6-luna-alt",
+        message: "check the kickoff file",
+        replySettleMs: 0,
+      }),
+    ).rejects.toThrow(error);
+
+    expect(gatewayStop).toHaveBeenCalledOnce();
+    expect(cleanupTransportBeforeGatewayStop).toHaveBeenCalledOnce();
+    expect(cleanupTransportAfterGatewayStop).toHaveBeenCalledOnce();
+    expect(mockStop).toHaveBeenCalledOnce();
+    expect(labStop).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { status: "ok" },
+    { status: "completed" },
+    { status: "succeeded" },
+    { status: "error", error: " completed " },
+  ])("accepts the canonical successful agent wait result %#", async (waited) => {
+    gatewayCall.mockReset().mockResolvedValueOnce({ runId: "run-1" }).mockResolvedValueOnce(waited);
+
+    await expect(
+      runQaManualLane({
+        repoRoot: "/tmp/openclaw-repo",
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        alternateModel: "mock-openai/gpt-5.6-luna-alt",
+        message: "check the kickoff file",
+        replySettleMs: 0,
+      }),
+    ).resolves.toMatchObject({ waited, reply: "Protocol note: mock reply." });
   });
 
   it("skips the mock provider bootstrap for live frontier runs", async () => {

--- a/extensions/qa-lab/src/manual-lane.runtime.ts
+++ b/extensions/qa-lab/src/manual-lane.runtime.ts
@@ -174,12 +174,7 @@ export async function runQaManualLane(params: QaManualLaneParams) {
             candidate.direction === "outbound" && candidate.conversation.id === "qa-operator",
         )?.text ?? null;
 
-    result = {
-      model: params.primaryModel,
-      waited,
-      reply,
-      watchUrl: lab.baseUrl,
-    };
+    result = { model: params.primaryModel, waited, reply, watchUrl: lab.baseUrl };
   } catch (error) {
     runError = error;
   } finally {
@@ -208,8 +203,13 @@ export async function runQaManualLane(params: QaManualLaneParams) {
     throw cleanupError;
   }
 
-  if (!result) {
-    throw new Error("manual lane did not produce a result");
+  if (
+    !result?.reply?.trim() ||
+    (result.waited.status === "error"
+      ? result.waited.error?.trim().toLowerCase() !== "completed"
+      : !["ok", "completed", "succeeded"].includes(result.waited.status ?? ""))
+  ) {
+    throw new Error(result?.waited.error ?? "manual lane did not produce a successful reply");
   }
   return result;
 }

--- a/extensions/qa-lab/src/manual-lane.runtime.ts
+++ b/extensions/qa-lab/src/manual-lane.runtime.ts
@@ -209,7 +209,8 @@ export async function runQaManualLane(params: QaManualLaneParams) {
       ? result.waited.error?.trim().toLowerCase() !== "completed"
       : !["ok", "completed", "succeeded"].includes(result.waited.status ?? ""))
   ) {
-    throw new Error(result?.waited.error ?? "manual lane did not produce a successful reply");
+    const providerError = result?.reply?.trim() && result.waited.error;
+    throw new Error(providerError || "manual lane did not produce a successful reply");
   }
   return result;
 }


### PR DESCRIPTION
## Summary

Stop the manual QA lane from reporting success after timeouts, provider failures, or missing assistant replies.

## Root cause

The manual lane constructed a successful result from any completed `agent.wait` request, regardless of its terminal status or whether an outbound assistant reply existed. Its CLI and character-evaluation consumer therefore accepted provider errors, stalled runs, and empty conversations as passing QA.

Validate the terminal owner result after existing cleanup, preserve provider error details, and accept all already-supported success variants including the legacy `error: completed` shape.

## Validation

- Four actual owner regressions failed before repair: timeout, provider error with stale reply, no reply, and whitespace-only reply.
- Incorporated a valid reviewer finding: successful legacy `error: completed` results with missing/blank replies now report the missing-reply diagnostic instead of misleadingly saying `completed`; real terminal errors retain their provider diagnostic when an actual reply exists.
- 80 focused owner/agent-process/character-evaluation tests and seven manual CLI consumer tests passed.
- A broader unrelated CLI suite still contains two pre-existing Crabline artifact-name expectation failures; neither exercises this owner.
- Formatting, focused lint, changed-scope classification, and independent autoreview passed.
- Production delta: +9/-8, net +1; the additional line is required to distinguish absent replies from actual provider failures.
