### PR TITLE
fix(ui): show failed cron completion beside execution status

### DIFF
--- a/ui/src/pages/cron/view-run-history.test.ts
+++ b/ui/src/pages/cron/view-run-history.test.ts
@@ -60,6 +60,81 @@ describe("cron view run history", () => {
     expect(onRunsFiltersChange).toHaveBeenCalledWith({ cronRunsStatuses: [] });
   });
 
+  it("distinguishes run completion from execution status without changing status filters", () => {
+    const onRunsFiltersChange = vi.fn();
+    const cases = [
+      {
+        jobId: "required-failed",
+        status: "ok",
+        completionStatus: "failed",
+        deliveryStatus: "not-delivered",
+        deliveryError: "chat unavailable",
+        expected: "required-failed · OK · Error",
+      },
+      {
+        jobId: "completion-unknown",
+        status: "ok",
+        completionStatus: "unknown",
+        deliveryStatus: "unknown",
+        expected: "completion-unknown · OK · Unknown",
+      },
+      {
+        jobId: "completion-succeeded",
+        status: "ok",
+        completionStatus: "succeeded",
+        deliveryStatus: "delivered",
+        expected: "completion-succeeded · OK",
+      },
+      {
+        jobId: "legacy-run",
+        status: "ok",
+        expected: "legacy-run · OK",
+      },
+      {
+        jobId: "execution-error",
+        status: "error",
+        completionStatus: "failed",
+        expected: "execution-error · Error",
+      },
+      {
+        jobId: "execution-skipped",
+        status: "skipped",
+        completionStatus: "unknown",
+        expected: "execution-skipped · Skipped",
+      },
+      {
+        jobId: "best-effort",
+        status: "ok",
+        completionStatus: "succeeded",
+        deliveryStatus: "not-delivered",
+        expected: "best-effort · OK",
+      },
+    ] as const;
+    const container = renderView({
+      listTab: "activity",
+      onRunsFiltersChange,
+      runs: cases.map(({ expected: _expected, ...entry }, index) => ({
+        ts: index,
+        action: "finished",
+        ...entry,
+      })),
+    });
+
+    const titles = Array.from(container.querySelectorAll(".cron-run-entry__title"), (title) =>
+      title.textContent?.replace(/\s+/g, " ").trim(),
+    );
+    expect(titles).toEqual(cases.toReversed().map(({ expected }) => expected));
+
+    const okOption = container.querySelector<HTMLElement>(
+      '[data-filter="status"] wa-dropdown-item[value="option:ok"]',
+    );
+    expect(okOption).not.toBeNull();
+    okOption
+      ?.closest("wa-dropdown")
+      ?.dispatchEvent(new CustomEvent("wa-select", { detail: { item: okOption }, bubbles: true }));
+    expect(onRunsFiltersChange).toHaveBeenCalledWith({ cronRunsStatuses: ["ok"] });
+  });
+
   it("formats run token counts and durations in the rendered entry", () => {
     const container = renderView({
       listTab: "activity",

--- a/ui/src/pages/cron/view-runs.ts
+++ b/ui/src/pages/cron/view-runs.ts
@@ -352,16 +352,16 @@ function formatRunNextLabel(nextRunAtMs: number, nowMs = Date.now()) {
   return nextRunAtMs > nowMs ? t("cron.runEntry.next", { rel }) : t("cron.runEntry.due", { rel });
 }
 
-export function runStatusLabel(value: string): string {
-  switch (value) {
+export function runStatusLabel(value: string, completion?: string): string {
+  switch (value === "failed" ? "error" : value) {
     case "ok":
-      return t("cron.runs.runStatusOk");
+      return completion && completion !== "succeeded"
+        ? `${t("cron.runs.runStatusOk")} · ${runStatusLabel(completion)}`
+        : t("cron.runs.runStatusOk");
     case "error":
       return t("cron.runs.runStatusError");
-    case "skipped":
-      return t("cron.runs.runStatusSkipped");
     default:
-      return t("cron.runs.runStatusUnknown");
+      return t(value === "skipped" ? "cron.runs.runStatusSkipped" : "cron.runs.runStatusUnknown");
   }
 }
 
@@ -393,7 +393,7 @@ function renderRun(
           basePath,
         }).href
       : null;
-  const status = runStatusLabel(entry.status ?? "unknown");
+  const status = runStatusLabel(entry.status ?? "unknown", entry.completionStatus);
   const delivery = runDeliveryLabel(entry.deliveryStatus ?? "not-requested");
   const usage = entry.usage;
   const usageSummary =


### PR DESCRIPTION
## Summary

Display failed or unknown whole-run completion beside the original cron execution result.

## Root cause

Cron history rendered only payload execution status. A successfully executed payload with failed required delivery therefore displayed `OK` even though the authoritative whole-run completion was failed or unknown. Replacing the execution label outright would have made the existing execution-status filters dishonest.

The existing status formatter now renders outcomes such as `OK · Error` and `OK · Unknown`, preserving the execution label, filter semantics, localization, skipped/error controls, and successful best-effort delivery.

## Validation

- Actual rendered DOM regression failed for failed and unknown completion before repair.
- 53 tests across six cron UI/accessibility/owner suites passed, including the unchanged `OK` filter callback.
- Formatting, targeted lint, accessibility/style checks, localization validation, and independent autoreview passed.
- Full repository UI typechecking remains blocked by pre-existing unrelated shared dependency/type failures; neither changed file has diagnostics.
- Real live-app screenshots are unavailable without rebuilding and reconfiguring the operator's running Gateway; rendered production DOM supplies the before/after proof.
- Production delta: +7/-7, net zero.
