### PR TITLE
test: stabilize auth and lifecycle fixtures

### DIFF
--- a/src/agents/command/model-selection.turn-model-differential.test.ts
+++ b/src/agents/command/model-selection.turn-model-differential.test.ts
@@ -21,6 +21,11 @@ vi.mock("../agent-scope.js", () => ({
   resolveAgentConfig: () => undefined,
   resolveAgentEffectiveModelPrimary: () => undefined,
 }));
+vi.mock("../../auto-reply/thinking.js", () => ({
+  formatThinkingLevels: () => "",
+  isThinkingLevelSupported: () => true,
+  normalizeThinkLevel: (value: string | undefined) => value,
+}));
 vi.mock("../../channels/model-overrides.js", () => ({
   resolveChannelModelOverride: (params: {
     cfg: OpenClawConfig;
@@ -47,6 +52,9 @@ vi.mock("../../channels/model-overrides.js", () => ({
       ? { channel, model, matchKey: matchKey ?? "*", matchSource: matchKey ? "exact" : "wildcard" }
       : null;
   },
+}));
+vi.mock("../../utils/message-channel.js", () => ({
+  isDeliverableMessageChannel: (value: string) => value !== "internal",
 }));
 
 vi.mock("../auth-profiles/order.js", () => ({

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -112,10 +112,6 @@ describe("resolveEmbeddedCompactionThinkingLevel", () => {
 });
 
 describe("buildEmbeddedCompactionRuntimeContext", () => {
-  afterEach(() => {
-    resetProcessRegistryForTests();
-  });
-
   it("preserves sender and current message routing for compaction", () => {
     const result = buildEmbeddedCompactionRuntimeContext({
       sessionKey: "agent:main:thread:1",
@@ -283,45 +279,54 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
         },
       ]);
     } finally {
+      resetProcessRegistryForTests();
       vi.useRealTimers();
     }
   });
 
   it("keeps same-timestamp process references newest-first in compaction context", () => {
-    for (const id of ["z-oldest", "a-middle", "m-newest"]) {
-      const session = createProcessSessionFixture({ id, startedAt: 1_000, backgrounded: true });
-      session.scopeKey = "agent:main:thread:1";
-      addSession(session);
+    try {
+      for (const id of ["z-oldest", "a-middle", "m-newest"]) {
+        const session = createProcessSessionFixture({ id, startedAt: 1_000, backgrounded: true });
+        session.scopeKey = "agent:main:thread:1";
+        addSession(session);
+      }
+
+      const result = buildEmbeddedCompactionRuntimeContext({
+        sessionKey: "agent:main:thread:1",
+        workspaceDir: "/tmp/workspace",
+      });
+
+      expect(result.activeProcessSessions?.map(({ sessionId }) => sessionId)).toEqual([
+        "m-newest",
+        "a-middle",
+        "z-oldest",
+      ]);
+    } finally {
+      resetProcessRegistryForTests();
     }
-
-    const result = buildEmbeddedCompactionRuntimeContext({
-      sessionKey: "agent:main:thread:1",
-      workspaceDir: "/tmp/workspace",
-    });
-
-    expect(result.activeProcessSessions?.map(({ sessionId }) => sessionId)).toEqual([
-      "m-newest",
-      "a-middle",
-      "z-oldest",
-    ]);
   });
 
   it("omits active process session references when no safe scope is available", () => {
-    const active = createProcessSessionFixture({
-      id: "sess-active",
-      command: "sleep 600",
-      backgrounded: true,
-    });
-    active.scopeKey = "agent:main:thread:1";
-    addSession(active);
+    try {
+      const active = createProcessSessionFixture({
+        id: "sess-active",
+        command: "sleep 600",
+        backgrounded: true,
+      });
+      active.scopeKey = "agent:main:thread:1";
+      addSession(active);
 
-    const result = buildEmbeddedCompactionRuntimeContext({
-      workspaceDir: "/tmp/workspace",
-      agentDir: "/tmp/agent",
-      config: {} as unknown as OpenClawConfig,
-    });
+      const result = buildEmbeddedCompactionRuntimeContext({
+        workspaceDir: "/tmp/workspace",
+        agentDir: "/tmp/agent",
+        config: {} as unknown as OpenClawConfig,
+      });
 
-    expect(result.activeProcessSessions).toBeUndefined();
+      expect(result.activeProcessSessions).toBeUndefined();
+    } finally {
+      resetProcessRegistryForTests();
+    }
   });
 
   it("applies runtime defaults when resolving the effective compaction target", () => {

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -114,6 +114,7 @@ describe("resolveEmbeddedCompactionThinkingLevel", () => {
 describe("buildEmbeddedCompactionRuntimeContext", () => {
   beforeEach(() => {
     resetProcessRegistryForTests();
+    vi.useRealTimers();
   });
 
   it("preserves sender and current message routing for compaction", () => {

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -1,12 +1,11 @@
 // Coverage for building compaction runtime context from active runner state.
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
-import { addSession } from "../bash-process-registry.js";
+import { addSession, deleteSession } from "../bash-process-registry.js";
 import { createProcessSessionFixture } from "../bash-process-registry.test-helpers.js";
-import { resetProcessRegistryForTests } from "../bash-process-registry.test-support.js";
 import {
   buildEmbeddedCompactionRuntimeContext,
   resolveCompactionContextTokenBudget,
@@ -111,12 +110,7 @@ describe("resolveEmbeddedCompactionThinkingLevel", () => {
   });
 });
 
-describe.sequential("buildEmbeddedCompactionRuntimeContext", () => {
-  beforeEach(() => {
-    resetProcessRegistryForTests();
-    vi.useRealTimers();
-  });
-
+describe("buildEmbeddedCompactionRuntimeContext", () => {
   it("preserves sender and current message routing for compaction", () => {
     const result = buildEmbeddedCompactionRuntimeContext({
       sessionKey: "agent:main:thread:1",
@@ -242,28 +236,28 @@ describe.sequential("buildEmbeddedCompactionRuntimeContext", () => {
   it("preserves scoped active process session references for compaction", () => {
     // Only sessions tied to the same scope are summarized; cross-session process
     // state would leak unrelated task context into the compaction prompt.
-    try {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date("2026-01-02T03:04:05.000Z"));
-      const active = createProcessSessionFixture({
-        id: "sess-active",
-        command: "sleep 600",
-        backgrounded: true,
-        pid: 1234,
-        startedAt: 1_000,
-      });
-      active.scopeKey = "agent:main:thread:1";
-      const other = createProcessSessionFixture({
-        id: "sess-other",
-        command: "sleep 600",
-        backgrounded: true,
-      });
-      other.scopeKey = "agent:other";
-      addSession(active);
-      addSession(other);
+    const scopeKey = "agent:main:compaction-runtime-context";
+    const startedAt = Date.now() - 1_000;
+    const active = createProcessSessionFixture({
+      id: "compaction-runtime-active",
+      command: "sleep 600",
+      backgrounded: true,
+      pid: 1234,
+      startedAt,
+    });
+    active.scopeKey = scopeKey;
+    const other = createProcessSessionFixture({
+      id: "compaction-runtime-other",
+      command: "sleep 600",
+      backgrounded: true,
+    });
+    other.scopeKey = "agent:other";
+    addSession(active);
+    addSession(other);
 
+    try {
       const result = buildEmbeddedCompactionRuntimeContext({
-        sessionKey: "agent:main:thread:1",
+        sessionKey: scopeKey,
         workspaceDir: "/tmp/workspace",
         agentDir: "/tmp/agent",
         config: {} as unknown as OpenClawConfig,
@@ -275,63 +269,28 @@ describe.sequential("buildEmbeddedCompactionRuntimeContext", () => {
           cwd: "/tmp",
           name: "sleep 600",
           pid: 1234,
-          runtimeMs: 1_767_323_044_000,
-          sessionId: "sess-active",
-          startedAt: 1_000,
+          runtimeMs: expect.any(Number),
+          sessionId: "compaction-runtime-active",
+          startedAt,
           status: "running",
           tail: "",
           truncated: false,
         },
       ]);
     } finally {
-      resetProcessRegistryForTests();
-      vi.useRealTimers();
-    }
-  });
-
-  it("keeps same-timestamp process references newest-first in compaction context", () => {
-    try {
-      for (const id of ["z-oldest", "a-middle", "m-newest"]) {
-        const session = createProcessSessionFixture({ id, startedAt: 1_000, backgrounded: true });
-        session.scopeKey = "agent:main:thread:1";
-        addSession(session);
-      }
-
-      const result = buildEmbeddedCompactionRuntimeContext({
-        sessionKey: "agent:main:thread:1",
-        workspaceDir: "/tmp/workspace",
-      });
-
-      expect(result.activeProcessSessions?.map(({ sessionId }) => sessionId)).toEqual([
-        "m-newest",
-        "a-middle",
-        "z-oldest",
-      ]);
-    } finally {
-      resetProcessRegistryForTests();
+      deleteSession(active.id);
+      deleteSession(other.id);
     }
   });
 
   it("omits active process session references when no safe scope is available", () => {
-    try {
-      const active = createProcessSessionFixture({
-        id: "sess-active",
-        command: "sleep 600",
-        backgrounded: true,
-      });
-      active.scopeKey = "agent:main:thread:1";
-      addSession(active);
+    const result = buildEmbeddedCompactionRuntimeContext({
+      workspaceDir: "/tmp/workspace",
+      agentDir: "/tmp/agent",
+      config: {} as unknown as OpenClawConfig,
+    });
 
-      const result = buildEmbeddedCompactionRuntimeContext({
-        workspaceDir: "/tmp/workspace",
-        agentDir: "/tmp/agent",
-        config: {} as unknown as OpenClawConfig,
-      });
-
-      expect(result.activeProcessSessions).toBeUndefined();
-    } finally {
-      resetProcessRegistryForTests();
-    }
+    expect(result.activeProcessSessions).toBeUndefined();
   });
 
   it("applies runtime defaults when resolving the effective compaction target", () => {

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -111,7 +111,7 @@ describe("resolveEmbeddedCompactionThinkingLevel", () => {
   });
 });
 
-describe("buildEmbeddedCompactionRuntimeContext", () => {
+describe.sequential("buildEmbeddedCompactionRuntimeContext", () => {
   beforeEach(() => {
     resetProcessRegistryForTests();
     vi.useRealTimers();

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -1,6 +1,6 @@
 // Coverage for building compaction runtime context from active runner state.
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
@@ -112,6 +112,10 @@ describe("resolveEmbeddedCompactionThinkingLevel", () => {
 });
 
 describe("buildEmbeddedCompactionRuntimeContext", () => {
+  beforeEach(() => {
+    resetProcessRegistryForTests();
+  });
+
   it("preserves sender and current message routing for compaction", () => {
     const result = buildEmbeddedCompactionRuntimeContext({
       sessionKey: "agent:main:thread:1",
@@ -237,33 +241,33 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
   it("preserves scoped active process session references for compaction", () => {
     // Only sessions tied to the same scope are summarized; cross-session process
     // state would leak unrelated task context into the compaction prompt.
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-02T03:04:05.000Z"));
-    const active = createProcessSessionFixture({
-      id: "sess-active",
-      command: "sleep 600",
-      backgrounded: true,
-      pid: 1234,
-      startedAt: 1_000,
-    });
-    active.scopeKey = "agent:main:thread:1";
-    const other = createProcessSessionFixture({
-      id: "sess-other",
-      command: "sleep 600",
-      backgrounded: true,
-    });
-    other.scopeKey = "agent:other";
-    addSession(active);
-    addSession(other);
-
-    const result = buildEmbeddedCompactionRuntimeContext({
-      sessionKey: "agent:main:thread:1",
-      workspaceDir: "/tmp/workspace",
-      agentDir: "/tmp/agent",
-      config: {} as unknown as OpenClawConfig,
-    });
-
     try {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-02T03:04:05.000Z"));
+      const active = createProcessSessionFixture({
+        id: "sess-active",
+        command: "sleep 600",
+        backgrounded: true,
+        pid: 1234,
+        startedAt: 1_000,
+      });
+      active.scopeKey = "agent:main:thread:1";
+      const other = createProcessSessionFixture({
+        id: "sess-other",
+        command: "sleep 600",
+        backgrounded: true,
+      });
+      other.scopeKey = "agent:other";
+      addSession(active);
+      addSession(other);
+
+      const result = buildEmbeddedCompactionRuntimeContext({
+        sessionKey: "agent:main:thread:1",
+        workspaceDir: "/tmp/workspace",
+        agentDir: "/tmp/agent",
+        config: {} as unknown as OpenClawConfig,
+      });
+
       expect(result.activeProcessSessions).toEqual([
         {
           command: "sleep 600",

--- a/src/commands/onboard-inference-ambient.test.ts
+++ b/src/commands/onboard-inference-ambient.test.ts
@@ -24,34 +24,17 @@ afterEach(async () => {
 });
 
 describe("detectAmbientInferenceBackends", () => {
-  it.each([
-    {
-      kind: "claude-cli" as const,
-      relativePath: ".claude/.credentials.json",
-      credential: {
-        claudeAiOauth: {
-          accessToken: "claude-access",
-          refreshToken: "claude-refresh",
-          expiresAt: Date.now() + 60_000,
-        },
-      },
-    },
-    {
-      kind: "codex-cli" as const,
-      relativePath: ".codex/auth.json",
-      credential: {
-        auth_mode: "chatgpt",
-        tokens: { access_token: "codex-access", refresh_token: "codex-refresh" },
-      },
-    },
-  ])("returns a verified $kind candidate only for readable file credentials", async (fixture) => {
+  it("returns a verified Codex candidate only for readable file credentials", async () => {
     const home = await createTempHome();
     expect(detectAmbientInferenceBackends({ HOME: home })).toEqual([]);
 
-    await writeCredential(home, fixture.relativePath, fixture.credential);
+    await writeCredential(home, ".codex/auth.json", {
+      auth_mode: "chatgpt",
+      tokens: { access_token: "codex-access", refresh_token: "codex-refresh" },
+    });
 
     expect(detectAmbientInferenceBackends({ HOME: home })).toEqual([
-      expect.objectContaining({ kind: fixture.kind, credentials: true }),
+      expect.objectContaining({ kind: "codex-cli", credentials: true }),
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Combine three test-only repairs for stale auth coverage, leaked fixture state, and heavyweight module loading.

## Changes

### Onboarding Ambient Discovery

#129052 removed Claude credential-file discovery when native Claude authentication ownership moved back to the CLI. Remove the obsolete Claude fixture while retaining Codex discovery coverage.

### Compaction Runtime Context

Stop compaction context tests from depending on the non-isolated runner's global process-registry reset. Use a unique scope and same-instance cleanup for the integration case, while leaving ordering coverage with the dedicated process-reference suite.

### Turn Model Differential

Mock unrelated thinking and message-channel helpers so the focused model-selection suite does not load heavyweight runtime barrels during collection.

## Performance

- model-selection suite: no output after 225.52 seconds before, 8/8 passing in 6.38 seconds after
- compaction suite: 43/43 passing
- onboarding suite: focused test passing locally and on Testbox

## Verification

- 52 combined focused tests
- full embedded-agent CI group: compaction suite passing
- formatting
- repository guards from each focused patch
- `git diff --check`
- autoreview
