### PR TITLE
fix(plugins): preserve profile and container in install recovery hints

### DIFF
--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -12,6 +12,7 @@ import {
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstall,
 } from "../plugins/official-external-plugin-catalog.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import {
   applyExclusiveSlotSelectionMock,
@@ -2550,28 +2551,61 @@ describe("plugins cli install", () => {
     expect(npmInstallCall().mode).toBe("update");
   });
 
-  it("suggests update or --force when npm plugin install target already exists", async () => {
-    pluginCliConfigMock.mockReturnValue({} as OpenClawConfig);
-    mockClawHubPackageNotFound("@example/lossless-claw");
-    installPluginFromNpmSpecMock.mockResolvedValue({
-      ok: false,
-      error:
-        "plugin already exists: /home/openclaw/.openclaw/extensions/lossless-claw (delete it first)",
-    });
-    installHooksFromNpmSpecMock.mockResolvedValue({
-      ok: false,
-      error: "package.json missing openclaw.hooks",
-    });
+  it.each([
+    {
+      context: "default",
+      profile: undefined,
+      container: undefined,
+      command: "openclaw plugins update <id-or-npm-spec>",
+    },
+    {
+      context: "profile",
+      profile: "work",
+      container: undefined,
+      command: "openclaw --profile work plugins update <id-or-npm-spec>",
+    },
+    {
+      context: "container",
+      profile: undefined,
+      container: "staging",
+      command: "openclaw --container staging plugins update <id-or-npm-spec>",
+    },
+    {
+      context: "container over profile",
+      profile: "work",
+      container: "staging",
+      command: "openclaw --container staging plugins update <id-or-npm-spec>",
+    },
+  ])(
+    "suggests a $context update when the npm plugin install target already exists",
+    async ({ profile, container, command }) => {
+      pluginCliConfigMock.mockReturnValue({} as OpenClawConfig);
+      mockClawHubPackageNotFound("@example/lossless-claw");
+      installPluginFromNpmSpecMock.mockResolvedValue({
+        ok: false,
+        error:
+          "plugin already exists: /home/openclaw/.openclaw/extensions/lossless-claw (delete it first)",
+      });
+      installHooksFromNpmSpecMock.mockResolvedValue({
+        ok: false,
+        error: "package.json missing openclaw.hooks",
+      });
 
-    await expect(
-      runAcknowledgedPluginsInstallCommand(["plugins", "install", "@example/lossless-claw"]),
-    ).rejects.toThrow("__exit__:1");
+      await withEnvAsync(
+        { OPENCLAW_PROFILE: profile, OPENCLAW_CONTAINER_HINT: container },
+        async () => {
+          await expect(
+            runAcknowledgedPluginsInstallCommand(["plugins", "install", "@example/lossless-claw"]),
+          ).rejects.toThrow("__exit__:1");
+        },
+      );
 
-    expect(runtimeErrors.at(-1)).toContain(
-      "Use `openclaw plugins update <id-or-npm-spec>` to upgrade the tracked plugin, or rerun install with `--force` to replace it.",
-    );
-    expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
-  });
+      expect(runtimeErrors.at(-1)).toContain(
+        `Use \`${command}\` to upgrade the tracked plugin, or rerun install with \`--force\` to replace it.`,
+      );
+      expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
+    },
+  );
 
   it("does not append hook-pack fallback details for managed extensions boundary failures", async () => {
     const localPluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-plugin-"));

--- a/src/cli/plugins-command-helpers.ts
+++ b/src/cli/plugins-command-helpers.ts
@@ -4,6 +4,7 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { HOOK_INSTALL_ERROR_CODE } from "../hooks/install.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
+import { formatCliCommand } from "./command-format.js";
 export { quietPluginJsonLogger } from "./plugins-json-logger.js";
 
 type HookInternalEntryLike = Record<string, unknown> & { enabled?: boolean };
@@ -85,9 +86,8 @@ export function formatPluginInstallWithHookFallbackError(
   hookFallback: { error: string; code?: string },
 ): string {
   const formattedPluginError = formatPluginInstallAttemptError(pluginError);
-  const formattedHookError = formatPluginInstallAttemptError(hookFallback.error);
   if (/plugin already exists: .+ \(delete it first\)/.test(pluginError)) {
-    return `${formattedPluginError}\nUse \`openclaw plugins update <id-or-npm-spec>\` to upgrade the tracked plugin, or rerun install with \`--force\` to replace it.`;
+    return `${formattedPluginError}\nUse \`${formatCliCommand("openclaw plugins update <id-or-npm-spec>")}\` to upgrade the tracked plugin, or rerun install with \`--force\` to replace it.`;
   }
   if (
     pluginError.startsWith("Invalid extensions directory:") ||
@@ -98,7 +98,7 @@ export function formatPluginInstallWithHookFallbackError(
   if (hookFallback.code === HOOK_INSTALL_ERROR_CODE.MISSING_OPENCLAW_HOOKS) {
     return formattedPluginError;
   }
-  return `${formattedPluginError}\nAlso not a valid hook pack: ${formattedHookError}`;
+  return `${formattedPluginError}\nAlso not a valid hook pack: ${formatPluginInstallAttemptError(hookFallback.error)}`;
 }
 
 const MISSING_GIT_FOR_NPM_DEPENDENCY_HINT =


### PR DESCRIPTION
## Summary

Preserve the active profile and container in duplicate plugin-install recovery commands.

## Root cause

Both local and npm plugin installation delegate duplicate-install diagnostics to the same owner, which hardcoded an unscoped `openclaw plugins update` command. Copying that hint under a named profile or container silently targeted the default installation.

Use the existing canonical CLI formatter and avoid eagerly formatting unrelated hook-fallback errors.

## Validation

- Actual production-owner reproduction failed under a named profile before repair.
- Existing real install integration now covers default context, profile, container, and container-over-profile precedence; focused installer and command-format suites passed all selected cases.
- Generic hook errors, missing Git guidance, and managed-plugin boundary behavior remain unchanged.
- Formatting, type-aware lint, maximum-line checks, and independent autoreview passed.
- Production delta: +3/-3, net zero.
