### PR TITLE
fix(ui): reflect active plugin account runtime state

### DIFF
--- a/ui/src/pages/channels/view.shared.ts
+++ b/ui/src/pages/channels/view.shared.ts
@@ -36,37 +36,33 @@ function resolveChannelStatus(
     : undefined;
 }
 
-function resolveDefaultChannelAccount(
-  key: ChannelKey,
-  props: ChannelsProps,
-): ChannelAccountSnapshot | null {
-  const accounts = resolveChannelAccounts(props.snapshot?.channelAccounts, key);
-  const defaultAccountIds = props.snapshot?.channelDefaultAccountId;
-  const defaultAccountId =
-    defaultAccountIds && Object.hasOwn(defaultAccountIds, key) ? defaultAccountIds[key] : undefined;
-  return (
-    (defaultAccountId
-      ? accounts.find((account) => account.accountId === defaultAccountId)
-      : undefined) ??
-    accounts[0] ??
-    null
-  );
-}
-
 export function resolveChannelDisplayState(
   key: ChannelKey,
   props: ChannelsProps,
 ): ChannelDisplayState {
   const status = resolveChannelStatus(key, props);
-  const defaultAccount = resolveDefaultChannelAccount(key, props);
+  const accounts = resolveChannelAccounts(props.snapshot?.channelAccounts, key);
+  const defaultAccountIds = props.snapshot?.channelDefaultAccountId;
+  const defaultAccountId =
+    defaultAccountIds && Object.hasOwn(defaultAccountIds, key) ? defaultAccountIds[key] : undefined;
+  const defaultAccount =
+    (defaultAccountId
+      ? accounts.find((account) => account.accountId === defaultAccountId)
+      : undefined) ??
+    accounts[0] ??
+    null;
   const configured =
     typeof status?.configured === "boolean"
       ? status.configured
-      : typeof defaultAccount?.configured === "boolean"
-        ? defaultAccount.configured
-        : null;
-  const running = typeof status?.running === "boolean" ? status.running : null;
-  const connected = typeof status?.connected === "boolean" ? status.connected : null;
+      : (defaultAccount?.configured ?? null);
+  const running =
+    typeof status?.running === "boolean"
+      ? status.running
+      : accounts.some((account) => account.running === true) || null;
+  const connected =
+    typeof status?.connected === "boolean"
+      ? status.connected
+      : accounts.some((account) => account.connected === true) || null;
 
   return {
     configured,

--- a/ui/src/pages/channels/view.test.ts
+++ b/ui/src/pages/channels/view.test.ts
@@ -444,6 +444,83 @@ describe("channel detail", () => {
 });
 
 describe("channel display selectors", () => {
+  it.each([
+    {
+      name: "the default account reports a running transport",
+      status: { configured: true },
+      accounts: [{ accountId: "default", configured: true, running: true }],
+      running: true,
+      connected: null,
+      hubStatus: "Running",
+    },
+    {
+      name: "the default account reports a connected transport",
+      status: { configured: true },
+      accounts: [{ accountId: "default", configured: true, connected: true }],
+      running: null,
+      connected: true,
+      hubStatus: "Running",
+    },
+    {
+      name: "a nondefault account owns the live transport",
+      status: { configured: true },
+      accounts: [
+        { accountId: "default", configured: true, running: false },
+        { accountId: "work", configured: true, running: true },
+      ],
+      running: true,
+      connected: null,
+      hubStatus: "Running",
+    },
+    {
+      name: "explicit channel runtime facts override stale account facts",
+      status: { configured: true, running: false, connected: false },
+      accounts: [{ accountId: "default", configured: true, running: true, connected: true }],
+      running: false,
+      connected: false,
+      hubStatus: "Configured",
+    },
+    {
+      name: "account false values do not replace an unknown channel runtime",
+      status: { configured: true },
+      accounts: [{ accountId: "default", configured: true, running: false, connected: false }],
+      running: null,
+      connected: null,
+      hubStatus: "Configured",
+    },
+    {
+      name: "disabled channels remain outside the connected channel list",
+      status: { configured: false },
+      accounts: [{ accountId: "default", configured: false, running: false, connected: false }],
+      running: null,
+      connected: null,
+      hubStatus: null,
+    },
+  ])(
+    "projects account runtime when $name",
+    ({ status, accounts, running, connected, hubStatus }) => {
+      const props = createProps({
+        ts: Date.now(),
+        channelOrder: ["guildchat"],
+        channelLabels: { guildchat: "Guild Chat" },
+        channels: { guildchat: status },
+        channelAccounts: { guildchat: accounts },
+        channelDefaultAccountId: { guildchat: "default" },
+      });
+      const displayState = resolveChannelDisplayState("guildchat", props);
+      const container = document.createElement("div");
+      render(renderChannels(props), container);
+
+      expect(displayState.running).toBe(running);
+      expect(displayState.connected).toBe(connected);
+      expect(channelEnabled("guildchat", props)).toBe(hubStatus !== null);
+      expect(
+        container.querySelector("button.channels-item .settings-status")?.textContent?.trim() ??
+          null,
+      ).toBe(hubStatus);
+    },
+  );
+
   it("returns the channel summary configured flag when present", () => {
     const props = createProps({
       ts: Date.now(),


### PR DESCRIPTION
## Summary

Show running generic plugin channels as running when their authoritative account snapshots are active.

## Root cause

The Gateway's supported generic-channel fallback emits only `{ configured: true }` in its aggregate summary and records real running/connected facts on per-account snapshots. The shared Control UI projection dropped those account facts, so healthy plugins incorrectly appeared gray and merely configured.

Resolve accounts once in the shared projection owner, preserve explicit aggregate boolean precedence, elevate authoritative account-level true facts, retain unknown/null semantics for false accounts, and remove an obsolete one-use helper.

## Validation

- Three actual rendered-channel DOM cases failed before repair; explicit-false, disabled, and unknown controls already passed.
- 122 focused tests across nine channel UI, wizard, capability, pairing, and agent-status suites passed.
- Formatting, lint, style, localization, and independent autoreview passed.
- A live-app screenshot would require modifying or replacing the operator's running Gateway; authentic production Lit/DOM before/after rendering is recorded instead.
- Production delta: +19/-23, net -4.
