### PR TITLE
fix(macos): expose channel account failures in settings

### DIFF
--- a/apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelState.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelState.swift
@@ -423,23 +423,19 @@ extension ChannelsSettings {
     func channelDetails(_ channel: ChannelItem) -> String? {
         switch channel.id {
         case "whatsapp":
-            return self.whatsAppDetails
+            self.whatsAppDetails
         case "telegram":
-            return self.telegramDetails
+            self.telegramDetails
         case "discord":
-            return self.discordDetails
+            self.discordDetails
         case "googlechat":
-            return self.googlechatDetails
+            self.googlechatDetails
         case "signal":
-            return self.signalDetails
+            self.signalDetails
         case "imessage":
-            return self.imessageDetails
+            self.imessageDetails
         default:
-            let status = self.channelStatusDictionary(channel.id)
-            if let err = status?["lastError"]?.stringValue, !err.isEmpty {
-                return "Error: \(err)"
-            }
-            return nil
+            self.channelError(channel).map { "Error: \($0)" }
         }
     }
 
@@ -487,35 +483,18 @@ extension ChannelsSettings {
     }
 
     func channelHasError(_ channel: ChannelItem) -> Bool {
-        switch channel.id {
-        case "whatsapp":
-            guard let status = self.channelStatus("whatsapp", as: ChannelsStatusSnapshot.WhatsAppStatus.self)
-            else { return false }
-            return status.lastError?.isEmpty == false || status.lastDisconnect?.loggedOut == true
-        case "telegram":
-            guard let status = self.channelStatus("telegram", as: ChannelsStatusSnapshot.TelegramStatus.self)
-            else { return false }
-            return status.lastError?.isEmpty == false || status.probe?.ok == false
-        case "discord":
-            guard let status = self.channelStatus("discord", as: ChannelsStatusSnapshot.DiscordStatus.self)
-            else { return false }
-            return status.lastError?.isEmpty == false || status.probe?.ok == false
-        case "googlechat":
-            guard let status = self.channelStatus("googlechat", as: ChannelsStatusSnapshot.GoogleChatStatus.self)
-            else { return false }
-            return status.lastError?.isEmpty == false || status.probe?.ok == false
-        case "signal":
-            guard let status = self.channelStatus("signal", as: ChannelsStatusSnapshot.SignalStatus.self)
-            else { return false }
-            return status.lastError?.isEmpty == false || status.probe?.ok == false
-        case "imessage":
-            guard let status = self.channelStatus("imessage", as: ChannelsStatusSnapshot.IMessageStatus.self)
-            else { return false }
-            return status.lastError?.isEmpty == false || status.probe?.ok == false
-        default:
-            let status = self.channelStatusDictionary(channel.id)
-            return status?["lastError"]?.stringValue?.isEmpty == false
-        }
+        let status = self.channelStatusDictionary(channel.id)
+        if self.channelError(channel) != nil { return true }
+        if status?["probe"]?.dictionaryValue?["ok"]?.boolValue == false { return true }
+        return channel.id == "whatsapp" &&
+            status?["lastDisconnect"]?.dictionaryValue?["loggedOut"]?.boolValue == true
+    }
+
+    private func channelError(_ channel: ChannelItem) -> String? {
+        let statusError = self.channelStatusDictionary(channel.id)?["lastError"]?.stringValue
+        if let statusError, !statusError.isEmpty { return statusError }
+        return self.store.snapshot?.channelAccounts[channel.id]?
+            .first(where: { $0.lastError?.isEmpty == false })?.lastError
     }
 
     private func resolveChannelTitle(_ id: String) -> String {

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
@@ -38,9 +38,111 @@ private func makeChannelsStore(
     return store
 }
 
+@MainActor
+private func makeChannelsSettings(snapshot: String) throws -> ChannelsSettings {
+    let store = ChannelsStore(isPreview: true)
+    store.snapshot = try JSONDecoder().decode(
+        ChannelsStatusSnapshot.self,
+        from: Data(snapshot.utf8))
+    return ChannelsSettings(store: store)
+}
+
 @Suite(.serialized)
 @MainActor
 struct ChannelsSettingsSmokeTests {
+    @Test func `generic channel account errors replace misleading active status`() throws {
+        let settings = try makeChannelsSettings(snapshot: """
+        {
+          "ts": 1,
+          "channelOrder": ["matrix", "mattermost", "disabled"],
+          "channelLabels": {"matrix": "Matrix", "mattermost": "Mattermost", "disabled": "Disabled"},
+          "channels": {
+            "matrix": {"configured": true},
+            "mattermost": {"configured": true, "lastError": "Channel summary failed"},
+            "disabled": {"configured": false}
+          },
+          "channelAccounts": {
+            "matrix": [
+              {"accountId": "healthy", "configured": true},
+              {"accountId": "failed", "configured": true, "lastError": "First account probe failed"},
+              {"accountId": "later", "configured": true, "lastError": "Later account failed"}
+            ],
+            "mattermost": [
+              {"accountId": "default", "configured": true, "lastError": "Account failure"}
+            ],
+            "disabled": []
+          },
+          "channelDefaultAccountId": {
+            "matrix": "healthy",
+            "mattermost": "default",
+            "disabled": "default"
+          }
+        }
+        """)
+        let channels = Dictionary(uniqueKeysWithValues: settings.orderedChannels.map { ($0.id, $0) })
+        let matrix = try #require(channels["matrix"])
+        let mattermost = try #require(channels["mattermost"])
+        let disabled = try #require(channels["disabled"])
+
+        #expect(settings.channelEnabled(matrix))
+        #expect(settings.channelHasError(matrix))
+        #expect(settings.channelSummary(matrix) == "Error")
+        #expect(settings.channelDetails(matrix) == "Error: First account probe failed")
+
+        #expect(settings.channelHasError(mattermost))
+        #expect(settings.channelDetails(mattermost) == "Error: Channel summary failed")
+
+        #expect(!settings.channelEnabled(disabled))
+        #expect(!settings.channelHasError(disabled))
+        #expect(settings.channelSummary(disabled) == "Not configured")
+        #expect(settings.channelDetails(disabled) == nil)
+    }
+
+    @Test func `failed channel probes remain visible across generic and bundled channels`() throws {
+        let settings = try makeChannelsSettings(snapshot: """
+        {
+          "ts": 1,
+          "channelOrder": ["matrix", "telegram"],
+          "channelLabels": {"matrix": "Matrix", "telegram": "Telegram"},
+          "channels": {
+            "matrix": {"configured": true, "probe": {"ok": false}},
+            "telegram": {"configured": true, "running": true, "probe": {"ok": false}}
+          },
+          "channelAccounts": {"matrix": [], "telegram": []},
+          "channelDefaultAccountId": {"matrix": "default", "telegram": "default"}
+        }
+        """)
+
+        for channel in settings.orderedChannels {
+            #expect(settings.channelHasError(channel), "\(channel.id) should surface its failed probe")
+        }
+    }
+
+    @Test func `whatsapp logout remains a channel error without a message`() throws {
+        let settings = try makeChannelsSettings(snapshot: """
+        {
+          "ts": 1,
+          "channelOrder": ["whatsapp"],
+          "channelLabels": {"whatsapp": "WhatsApp"},
+          "channels": {
+            "whatsapp": {
+              "configured": true,
+              "linked": true,
+              "running": false,
+              "connected": false,
+              "reconnectAttempts": 0,
+              "lastDisconnect": {"at": 1, "loggedOut": true}
+            }
+          },
+          "channelAccounts": {"whatsapp": []},
+          "channelDefaultAccountId": {"whatsapp": "default"}
+        }
+        """)
+        let channel = try #require(settings.orderedChannels.first)
+
+        #expect(settings.channelHasError(channel))
+    }
+
     @Test func `whatsapp login wait result keeps latest qr until connected`() {
         let store = makeChannelsStore(channels: [:])
         store.whatsappLoginQrDataUrl = "data:image/png;base64,initial"


### PR DESCRIPTION
## Summary

Display failed generic plugin channel accounts as errors in macOS channel settings.

## Root cause

The Gateway records plugin probe failures on per-account snapshots while generic aggregate channel summaries intentionally contain only configuration facts. The macOS settings owner inspected aggregate errors only, silently labeling failed accounts green and active despite the web client already handling account failures correctly.

Consolidate duplicate channel-specific status branches into one account-aware error owner. Preserve top-level error precedence, deterministic multiaccount failure selection, generic/bundled probe failures, disabled state, and WhatsApp logout behavior.

## Validation

- Existing Swift settings smoke coverage first failed four genuine account/probe assertions, then all 11 tests passed.
- Focused SwiftPM proof: `swift test --package-path apps/macos --filter OpenClawIPCTests.ChannelsSettingsSmokeTests -Xlinker -rpath -Xlinker <worktree>/apps/macos/.build/out/Products/Debug`; the explicit path is needed only for this fresh worktree's cached Sparkle artifact.
- SwiftFormat, strict SwiftLint, and independent autoreview passed.
- A real app screenshot is unavailable because this task must not launch an unsigned modified app against the operator's saved Keychain; the existing native settings controller and real decoded Gateway snapshots provide before/after proof.
- Production delta: +19/-40, net -21.
