### PR TITLE
fix(codex): channel-aware hooks reject authenticated users

### DIFF
--- a/extensions/codex/src/app-server/event-projector-options.ts
+++ b/extensions/codex/src/app-server/event-projector-options.ts
@@ -1,3 +1,4 @@
+import type { runAgentHarnessBeforeCompactionHook } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { AgentPlanStep } from "openclaw/plugin-sdk/channel-outbound";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import type { CodexThreadItem, JsonValue } from "./protocol.js";
@@ -7,6 +8,7 @@ import type { CodexTrajectoryRecorder } from "./trajectory.js";
 export type CodexAsyncDeliverySettlement = "settled" | "retry";
 
 export type CodexAppServerEventProjectorOptions = {
+  agentHookContext?: Parameters<typeof runAgentHarnessBeforeCompactionHook>[0]["ctx"];
   initialContextTokens?: number;
   nativePostToolUseRelayEnabled?: boolean;
   asyncUserMessageAllowed?: boolean;

--- a/extensions/codex/src/app-server/event-projector.test-harness.ts
+++ b/extensions/codex/src/app-server/event-projector.test-harness.ts
@@ -149,7 +149,7 @@ export function registerCodexEventProjectorTestLifecycle(): void {
   });
 }
 
-export async function createProjectorWithHooks() {
+export async function createProjectorWithHooks(options?: CodexAppServerEventProjectorOptions) {
   const beforeCompaction = vi.fn();
   const afterCompaction = vi.fn();
   initializeGlobalHookRunner(
@@ -158,7 +158,7 @@ export async function createProjectorWithHooks() {
       { hookName: "after_compaction", handler: afterCompaction },
     ]),
   );
-  const projector = await createProjector();
+  const projector = await createProjector(undefined, options);
   return { projector, beforeCompaction, afterCompaction };
 }
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -481,16 +481,7 @@ export class CodexAppServerEventProjector {
       await runAgentHarnessBeforeCompactionHook({
         sessionFile: this.params.sessionFile,
         messages: await this.toolTranscriptProjection.readMirroredSessionMessages(),
-        ctx: {
-          runId: this.params.runId,
-          agentId: this.params.agentId,
-          sessionKey: this.params.sessionKey,
-          sessionId: this.params.sessionId,
-          workspaceDir: this.params.workspaceDir,
-          messageProvider: this.params.messageProvider ?? undefined,
-          trigger: this.params.trigger,
-          channelId: this.params.messageChannel ?? this.params.messageProvider ?? undefined,
-        },
+        ctx: this.options.agentHookContext ?? {},
       });
       this.emitAgentEvent({
         stream: "compaction",
@@ -545,16 +536,7 @@ export class CodexAppServerEventProjector {
         sessionFile: this.params.sessionFile,
         messages: await this.toolTranscriptProjection.readMirroredSessionMessages(),
         compactedCount: -1,
-        ctx: {
-          runId: this.params.runId,
-          agentId: this.params.agentId,
-          sessionKey: this.params.sessionKey,
-          sessionId: this.params.sessionId,
-          workspaceDir: this.params.workspaceDir,
-          messageProvider: this.params.messageProvider ?? undefined,
-          trigger: this.params.trigger,
-          channelId: this.params.messageChannel ?? this.params.messageProvider ?? undefined,
-        },
+        ctx: this.options.agentHookContext ?? {},
       });
       await persistCodexContextCompactionActivity({
         sessionTarget: this.params.sessionTarget,

--- a/extensions/codex/src/app-server/event-projector.verbose-hooks.test.ts
+++ b/extensions/codex/src/app-server/event-projector.verbose-hooks.test.ts
@@ -341,7 +341,22 @@ describe("CodexAppServerEventProjector verbose output and hook projection", () =
   });
 
   it("fires before_compaction and after_compaction hooks for codex compaction items", async () => {
-    const { projector, beforeCompaction, afterCompaction } = await createProjectorWithHooks();
+    const agentHookContext = {
+      runId: "run-1",
+      sessionId: "session-1",
+      accountId: "account-a",
+      channel: "telegram",
+      channelId: "chat-a",
+      chatId: "chat-a",
+      senderId: "sender-a",
+      channelContext: {
+        sender: { id: "sender-a" },
+        chat: { id: "chat-a" },
+      },
+    };
+    const { projector, beforeCompaction, afterCompaction } = await createProjectorWithHooks({
+      agentHookContext,
+    });
     const openSpy = vi.spyOn(SessionManager, "open");
 
     await projector.handleNotification(
@@ -370,6 +385,7 @@ describe("CodexAppServerEventProjector verbose output and hook projection", () =
     );
     expect(beforeContext.runId).toBe("run-1");
     expect(beforeContext.sessionId).toBe("session-1");
+    expect(beforeContext).toMatchObject(agentHookContext);
     const afterPayload = requireRecord(
       mockCallArg(afterCompaction, 0, 0, "afterCompaction"),
       "after payload",
@@ -383,6 +399,7 @@ describe("CodexAppServerEventProjector verbose output and hook projection", () =
     );
     expect(afterContext.runId).toBe("run-1");
     expect(afterContext.sessionId).toBe("session-1");
+    expect(afterContext).toMatchObject(agentHookContext);
   });
 
   it("projects codex hook started and completed notifications into agent events", async () => {

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -52,7 +52,7 @@ export async function activateCodexAttemptTurn(
     pendingNativePreToolUseFailures,
   } = resources;
   const { context, turnState } = prompt;
-  const { runtime, attemptTools } = context;
+  const { runtime, attemptTools, hookContext } = context;
   const { connection } = runtime;
   const {
     params,
@@ -107,6 +107,7 @@ export async function activateCodexAttemptTurn(
     resourceState.thread.threadId,
     activeTurnId,
     {
+      agentHookContext: hookContext,
       initialContextTokens: connection.mutable.startupContextTokens,
       nativePostToolUseRelayEnabled:
         resourceState.nativeHookRelay?.allowedEvents.includes("post_tool_use") === true &&

--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -105,7 +105,7 @@ export async function prepareCodexAttemptContext(
     workspaceDir: params.workspaceDir,
     trigger: params.trigger,
     ...buildAgentHookContextChannelFields({
-      sessionKey: sandboxSessionKey,
+      sessionKey: contextSessionKey,
       messageChannel: params.messageChannel,
       messageProvider: params.messageProvider,
       currentChannelId: hookChannelId,

--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -1,5 +1,6 @@
 import {
   bootstrapHarnessContextEngine,
+  buildAgentHookContextChannelFields,
   buildHarnessContextEngineRuntimeContext,
   CODEX_APP_SERVER_CONTEXT_ENGINE_HOST,
   embeddedAgentLog,
@@ -102,9 +103,17 @@ export async function prepareCodexAttemptContext(
     sessionKey: contextSessionKey,
     sessionId: params.sessionId,
     workspaceDir: params.workspaceDir,
-    messageProvider: params.messageProvider ?? undefined,
     trigger: params.trigger,
-    channelId: hookChannelId,
+    ...buildAgentHookContextChannelFields({
+      sessionKey: sandboxSessionKey,
+      messageChannel: params.messageChannel,
+      messageProvider: params.messageProvider,
+      currentChannelId: hookChannelId,
+      messageTo: params.messageTo,
+      senderId: params.senderId,
+      agentAccountId: params.agentAccountId,
+    }),
+    channelContext: params.channelContext,
     ...hookContextWindowFields,
   };
   const hookRunner = getAgentHarnessHookRunner();

--- a/extensions/codex/src/app-server/run-attempt.auth-context.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.auth-context.test.ts
@@ -74,4 +74,60 @@ describe("runCodexAppServerAttempt authenticated hook context", () => {
       expect(hookContext).toMatchObject(expectedContext);
     }
   });
+
+  it("omits sender and chat identity from non-user prompt and compaction hooks", async () => {
+    const beforePromptBuild = vi.fn(() => undefined);
+    const beforeCompaction = vi.fn(() => undefined);
+    const afterCompaction = vi.fn(() => undefined);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "before_prompt_build", handler: beforePromptBuild },
+        { hookName: "before_compaction", handler: beforeCompaction },
+        { hookName: "after_compaction", handler: afterCompaction },
+      ]),
+    );
+    const params = createParams(
+      path.join(tempDir, "system-compaction.jsonl"),
+      path.join(tempDir, "system-compaction-workspace"),
+    );
+    params.trigger = "heartbeat";
+    params.messageChannel = "telegram";
+    params.messageProvider = "telegram";
+    params.currentChannelId = "telegram:-100123";
+    params.agentAccountId = "account-a";
+    params.senderId = "must-not-leak";
+    params.channelContext = {
+      sender: { id: "must-not-leak" },
+      chat: { id: "must-not-leak" },
+    };
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.notify(
+      itemNotification("item/started", { type: "contextCompaction", id: "compact-1" }),
+    );
+    await harness.notify(
+      itemNotification("item/completed", { type: "contextCompaction", id: "compact-1" }),
+    );
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    for (const [hookName, hook] of [
+      ["before_prompt_build", beforePromptBuild],
+      ["before_compaction", beforeCompaction],
+      ["after_compaction", afterCompaction],
+    ] as const) {
+      expect(hook).toHaveBeenCalledOnce();
+      const [, hookContext] = mockCall(hook, hookName) as [unknown, Record<string, unknown>];
+      expect(hookContext).toMatchObject({
+        accountId: "account-a",
+        channel: "telegram",
+        trigger: "heartbeat",
+      });
+      expect(hookContext).not.toHaveProperty("senderId");
+      expect(hookContext).not.toHaveProperty("chatId");
+      expect(hookContext).not.toHaveProperty("channelContext");
+    }
+  });
 });

--- a/extensions/codex/src/app-server/run-attempt.auth-context.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.auth-context.test.ts
@@ -29,6 +29,7 @@ describe("runCodexAppServerAttempt authenticated hook context", () => {
     const sessionFile = path.join(tempDir, "authenticated-compaction.jsonl");
     const workspaceDir = path.join(tempDir, "authenticated-compaction-workspace");
     const params = createParams(sessionFile, workspaceDir);
+    params.sandboxSessionKey = "global";
     params.messageChannel = "telegram";
     params.messageProvider = "telegram";
     params.currentChannelId = "telegram:-100123";
@@ -55,6 +56,7 @@ describe("runCodexAppServerAttempt authenticated hook context", () => {
     const expectedContext = {
       accountId: "account-a",
       channel: "telegram",
+      sessionKey: "agent:main:session-1",
       messageProvider: "telegram",
       channelId: "-100123",
       chatId: "-100123",

--- a/extensions/codex/src/app-server/run-attempt.auth-context.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.auth-context.test.ts
@@ -1,0 +1,77 @@
+import path from "node:path";
+import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
+import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { itemNotification } from "./protocol.test-helpers.js";
+import {
+  createParams,
+  createStartedThreadHarness,
+  mockCall,
+  runCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  tempDir,
+} from "./run-attempt-test-harness.js";
+
+setupRunAttemptTestHooks();
+
+describe("runCodexAppServerAttempt authenticated hook context", () => {
+  it("preserves authenticated channel context across prompt and compaction hooks", async () => {
+    const beforePromptBuild = vi.fn(() => undefined);
+    const beforeCompaction = vi.fn(() => undefined);
+    const afterCompaction = vi.fn(() => undefined);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "before_prompt_build", handler: beforePromptBuild },
+        { hookName: "before_compaction", handler: beforeCompaction },
+        { hookName: "after_compaction", handler: afterCompaction },
+      ]),
+    );
+    const sessionFile = path.join(tempDir, "authenticated-compaction.jsonl");
+    const workspaceDir = path.join(tempDir, "authenticated-compaction-workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.messageChannel = "telegram";
+    params.messageProvider = "telegram";
+    params.currentChannelId = "telegram:-100123";
+    params.messageTo = "telegram:-100123";
+    params.agentAccountId = "account-a";
+    params.senderId = "sender-a";
+    params.channelContext = {
+      sender: { id: "stale-sender", profile: "sender-profile" },
+      chat: { id: "stale-chat", thread: "chat-thread" },
+    };
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.notify(
+      itemNotification("item/started", { type: "contextCompaction", id: "compact-1" }),
+    );
+    await harness.notify(
+      itemNotification("item/completed", { type: "contextCompaction", id: "compact-1" }),
+    );
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const expectedContext = {
+      accountId: "account-a",
+      channel: "telegram",
+      messageProvider: "telegram",
+      channelId: "-100123",
+      chatId: "-100123",
+      senderId: "sender-a",
+      channelContext: {
+        sender: { id: "sender-a", profile: "sender-profile" },
+        chat: { id: "-100123", thread: "chat-thread" },
+      },
+    };
+    for (const [hookName, hook] of [
+      ["before_prompt_build", beforePromptBuild],
+      ["before_compaction", beforeCompaction],
+      ["after_compaction", afterCompaction],
+    ] as const) {
+      expect(hook).toHaveBeenCalledOnce();
+      const [, hookContext] = mockCall(hook, hookName) as [unknown, Record<string, unknown>];
+      expect(hookContext).toMatchObject(expectedContext);
+    }
+  });
+});

--- a/extensions/codex/src/app-server/run-attempt.hooks.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.hooks.test.ts
@@ -21,6 +21,7 @@ import {
 import { GPT5_BEHAVIOR_CONTRACT as CODEX_GPT5_BEHAVIOR_CONTRACT } from "openclaw/plugin-sdk/provider-model-shared";
 import { describe, expect, it, vi } from "vitest";
 import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
+import { itemNotification } from "./protocol.test-helpers.js";
 import {
   assistantMessage,
   createAppServerHarness,
@@ -51,6 +52,66 @@ function flushDiagnosticEvents() {
 setupRunAttemptTestHooks();
 
 describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
+  it("preserves authenticated channel context across prompt and compaction hooks", async () => {
+    const beforePromptBuild = vi.fn(() => undefined);
+    const beforeCompaction = vi.fn(() => undefined);
+    const afterCompaction = vi.fn(() => undefined);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "before_prompt_build", handler: beforePromptBuild },
+        { hookName: "before_compaction", handler: beforeCompaction },
+        { hookName: "after_compaction", handler: afterCompaction },
+      ]),
+    );
+    const sessionFile = path.join(tempDir, "authenticated-compaction.jsonl");
+    const workspaceDir = path.join(tempDir, "authenticated-compaction-workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.messageChannel = "telegram";
+    params.messageProvider = "telegram";
+    params.currentChannelId = "telegram:-100123";
+    params.messageTo = "telegram:-100123";
+    params.agentAccountId = "account-a";
+    params.senderId = "sender-a";
+    params.channelContext = {
+      sender: { id: "stale-sender", profile: "sender-profile" },
+      chat: { id: "stale-chat", thread: "chat-thread" },
+    };
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.notify(
+      itemNotification("item/started", { type: "contextCompaction", id: "compact-1" }),
+    );
+    await harness.notify(
+      itemNotification("item/completed", { type: "contextCompaction", id: "compact-1" }),
+    );
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const expectedContext = {
+      accountId: "account-a",
+      channel: "telegram",
+      messageProvider: "telegram",
+      channelId: "-100123",
+      chatId: "-100123",
+      senderId: "sender-a",
+      channelContext: {
+        sender: { id: "sender-a", profile: "sender-profile" },
+        chat: { id: "-100123", thread: "chat-thread" },
+      },
+    };
+    for (const [hookName, hook] of [
+      ["before_prompt_build", beforePromptBuild],
+      ["before_compaction", beforeCompaction],
+      ["after_compaction", afterCompaction],
+    ] as const) {
+      expect(hook).toHaveBeenCalledOnce();
+      const [, hookContext] = mockCall(hook, hookName) as [unknown, Record<string, unknown>];
+      expect(hookContext).toMatchObject(expectedContext);
+    }
+  });
+
   it.each([
     { label: "completed", status: "completed" as const, error: undefined },
     { label: "failed", status: "failed" as const, error: "codex exploded" },

--- a/extensions/codex/src/app-server/run-attempt.hooks.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.hooks.test.ts
@@ -21,7 +21,6 @@ import {
 import { GPT5_BEHAVIOR_CONTRACT as CODEX_GPT5_BEHAVIOR_CONTRACT } from "openclaw/plugin-sdk/provider-model-shared";
 import { describe, expect, it, vi } from "vitest";
 import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
-import { itemNotification } from "./protocol.test-helpers.js";
 import {
   assistantMessage,
   createAppServerHarness,
@@ -52,66 +51,6 @@ function flushDiagnosticEvents() {
 setupRunAttemptTestHooks();
 
 describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
-  it("preserves authenticated channel context across prompt and compaction hooks", async () => {
-    const beforePromptBuild = vi.fn(() => undefined);
-    const beforeCompaction = vi.fn(() => undefined);
-    const afterCompaction = vi.fn(() => undefined);
-    initializeGlobalHookRunner(
-      createMockPluginRegistry([
-        { hookName: "before_prompt_build", handler: beforePromptBuild },
-        { hookName: "before_compaction", handler: beforeCompaction },
-        { hookName: "after_compaction", handler: afterCompaction },
-      ]),
-    );
-    const sessionFile = path.join(tempDir, "authenticated-compaction.jsonl");
-    const workspaceDir = path.join(tempDir, "authenticated-compaction-workspace");
-    const params = createParams(sessionFile, workspaceDir);
-    params.messageChannel = "telegram";
-    params.messageProvider = "telegram";
-    params.currentChannelId = "telegram:-100123";
-    params.messageTo = "telegram:-100123";
-    params.agentAccountId = "account-a";
-    params.senderId = "sender-a";
-    params.channelContext = {
-      sender: { id: "stale-sender", profile: "sender-profile" },
-      chat: { id: "stale-chat", thread: "chat-thread" },
-    };
-    const harness = createStartedThreadHarness();
-
-    const run = runCodexAppServerAttempt(params);
-    await harness.waitForMethod("turn/start");
-    await harness.notify(
-      itemNotification("item/started", { type: "contextCompaction", id: "compact-1" }),
-    );
-    await harness.notify(
-      itemNotification("item/completed", { type: "contextCompaction", id: "compact-1" }),
-    );
-    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await run;
-
-    const expectedContext = {
-      accountId: "account-a",
-      channel: "telegram",
-      messageProvider: "telegram",
-      channelId: "-100123",
-      chatId: "-100123",
-      senderId: "sender-a",
-      channelContext: {
-        sender: { id: "sender-a", profile: "sender-profile" },
-        chat: { id: "-100123", thread: "chat-thread" },
-      },
-    };
-    for (const [hookName, hook] of [
-      ["before_prompt_build", beforePromptBuild],
-      ["before_compaction", beforeCompaction],
-      ["after_compaction", afterCompaction],
-    ] as const) {
-      expect(hook).toHaveBeenCalledOnce();
-      const [, hookContext] = mockCall(hook, hookName) as [unknown, Record<string, unknown>];
-      expect(hookContext).toMatchObject(expectedContext);
-    }
-  });
-
   it.each([
     { label: "completed", status: "completed" as const, error: undefined },
     { label: "failed", status: "failed" as const, error: "codex exploded" },

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3212,6 +3212,78 @@ describe("runCodexAppServerAttempt", () => {
     expect(JSON.stringify(llmInputPayload)).not.toContain("previous turn");
   });
 
+  it.each([
+    {
+      channel: "whatsapp",
+      currentChannelId: "whatsapp:chat-wa",
+      expectedChatId: "chat-wa",
+    },
+    {
+      channel: "telegram",
+      currentChannelId: "telegram:-100123",
+      expectedChatId: "-100123",
+    },
+    {
+      channel: "imessage",
+      currentChannelId: "imessage:any;-;chat-imessage",
+      expectedChatId: "any;-;chat-imessage",
+    },
+  ])(
+    "provides authenticated $channel context to before_prompt_build",
+    async ({ channel, currentChannelId, expectedChatId }) => {
+      const beforePromptBuild = vi.fn(() => undefined);
+      initializeGlobalHookRunner(
+        createMockPluginRegistry([{ hookName: "before_prompt_build", handler: beforePromptBuild }]),
+      );
+      const { sessionFile, workspaceDir } = createRunPaths();
+      const harness = createStartedThreadHarness();
+      const params = createParams(sessionFile, workspaceDir);
+      params.messageChannel = channel;
+      params.messageProvider = channel;
+      params.currentChannelId = currentChannelId;
+      params.messageTo = currentChannelId;
+      params.agentAccountId = "account-a";
+      params.senderId = `sender-${channel}`;
+      params.channelContext = {
+        sender: { id: "stale-sender", profile: `${channel}-profile` },
+        chat: { id: "stale-chat", thread: `${channel}-thread` },
+      };
+
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("turn/start");
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      await run;
+
+      const [, hookContext] = mockCall(beforePromptBuild, "before_prompt_build") as [
+        unknown,
+        {
+          accountId?: string;
+          channel?: string;
+          channelContext?: {
+            chat?: { id?: string; thread?: string };
+            sender?: { id?: string; profile?: string };
+          };
+          channelId?: string;
+          chatId?: string;
+          messageProvider?: string;
+          senderId?: string;
+        },
+      ];
+      expect(hookContext).toMatchObject({
+        accountId: "account-a",
+        channel,
+        messageProvider: channel,
+        channelId: expectedChatId,
+        chatId: expectedChatId,
+        senderId: `sender-${channel}`,
+        channelContext: {
+          sender: { id: `sender-${channel}`, profile: `${channel}-profile` },
+          chat: { id: expectedChatId, thread: `${channel}-thread` },
+        },
+      });
+    },
+  );
+
   it("fails closed when before_prompt_build restricts Codex tools", async () => {
     const authorizedEnrichment = vi.fn(() => ({ prependContext: "private recalled context" }));
     initializeGlobalHookRunner(

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -714,7 +714,10 @@ describe("runCopilotAttempt", () => {
   });
 
   it("runs generic prompt and lifecycle hooks through the standard harness helpers", async () => {
-    const params = makeParams({ sandboxSessionKey: "agent:agent-1:policy" });
+    const params = makeParams({
+      agentAccountId: "account-a",
+      sandboxSessionKey: "agent:agent-1:policy",
+    });
     const beforePromptBuild = vi.fn(() => ({
       prependContext: "Use the current repository state.",
       appendContext: "Finish with the current test status.",
@@ -756,6 +759,7 @@ describe("runCopilotAttempt", () => {
     expect(beforePromptBuild).toHaveBeenCalledWith(
       expect.objectContaining({ prompt: "hello" }),
       expect.objectContaining({
+        accountId: "account-a",
         runId: "run-1",
         sessionId: "session-1",
         sessionKey: params.sessionKey,
@@ -834,7 +838,7 @@ describe("runCopilotAttempt", () => {
       });
     });
 
-    const attempt = runCopilotAttempt(makeParams(), {
+    const attempt = runCopilotAttempt(makeParams({ agentAccountId: "account-a" }), {
       createToolBridge,
       pool: makeFakePool(sdk),
     });
@@ -862,7 +866,7 @@ describe("runCopilotAttempt", () => {
         messageCount: -1,
         sessionFile: "session.json",
       }),
-      expect.objectContaining({ runId: "run-1", sessionId: "session-1" }),
+      expect.objectContaining({ accountId: "account-a", runId: "run-1", sessionId: "session-1" }),
     );
     expect(afterCompaction).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -870,7 +874,7 @@ describe("runCopilotAttempt", () => {
         messageCount: -1,
         sessionFile: "session.json",
       }),
-      expect.objectContaining({ runId: "run-1", sessionId: "session-1" }),
+      expect.objectContaining({ accountId: "account-a", runId: "run-1", sessionId: "session-1" }),
     );
     expect(beforeCompaction.mock.calls[0]?.[0]).not.toHaveProperty("messages");
   });

--- a/extensions/qa-lab/src/codex-authenticated-hook-context.e2e.test.ts
+++ b/extensions/qa-lab/src/codex-authenticated-hook-context.e2e.test.ts
@@ -67,7 +67,7 @@ function expectAuthenticatedContext(ctx: CapturedContext | undefined) {
       chat: { id: CONVERSATION.id },
     },
   });
-  expect(ctx?.sessionKey).toContain("qa-channel:default:direct:ahmad");
+  expect(ctx?.sessionKey).toBe("agent:qa:main");
 }
 
 describe("Codex authenticated hook context product proof", () => {

--- a/extensions/qa-lab/src/codex-authenticated-hook-context.e2e.test.ts
+++ b/extensions/qa-lab/src/codex-authenticated-hook-context.e2e.test.ts
@@ -1,0 +1,180 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { afterEach, describe, expect, it } from "vitest";
+import { startQaBusServer } from "./bus-server.js";
+import { createQaBusState } from "./bus-state.js";
+import { createQaGatewayChild } from "./gateway-child.js";
+import { startQaMockOpenAiServer } from "./providers/mock-openai/server.js";
+import { createQaChannelTransport } from "./qa-channel-transport.js";
+
+const PLUGIN_ID = "qa-codex-hook-context-proof";
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const PLUGIN_DIR = path.join(
+  REPO_ROOT,
+  "extensions/qa-lab/test-fixtures/codex-hook-context-proof-plugin",
+);
+const CONVERSATION = { id: "authenticated-team-room", kind: "direct" as const };
+
+type CapturedContext = {
+  accountId?: string;
+  senderId?: string;
+  chatId?: string;
+  channel?: string;
+  sessionKey?: string;
+  channelContext?: Record<string, unknown>;
+};
+
+type HookCaptures = {
+  beforePromptBuild: CapturedContext[];
+  beforeCompaction: CapturedContext[];
+  afterCompaction: CapturedContext[];
+};
+
+function withFixturePlugin(config: OpenClawConfig): OpenClawConfig {
+  return {
+    ...config,
+    plugins: {
+      ...config.plugins,
+      enabled: true,
+      allow: [...new Set([...(config.plugins?.allow ?? []), PLUGIN_ID])],
+      load: {
+        ...config.plugins?.load,
+        paths: [...new Set([...(config.plugins?.load?.paths ?? []), PLUGIN_DIR])],
+      },
+      entries: {
+        ...config.plugins?.entries,
+        [PLUGIN_ID]: {
+          enabled: true,
+          hooks: {
+            allowConversationAccess: true,
+            allowPromptInjection: true,
+          },
+        },
+      },
+    },
+  };
+}
+
+function expectAuthenticatedContext(ctx: CapturedContext | undefined) {
+  expect(ctx).toMatchObject({
+    accountId: "default",
+    senderId: "ahmad",
+    chatId: CONVERSATION.id,
+    channel: "qa-channel",
+    channelContext: {
+      sender: { id: "ahmad" },
+      chat: { id: CONVERSATION.id },
+    },
+  });
+  expect(ctx?.sessionKey).toContain("qa-channel:default:direct:ahmad");
+}
+
+describe("Codex authenticated hook context product proof", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.splice(0).toReversed()) {
+      await cleanup();
+    }
+  });
+
+  it("preserves admitted qa-channel identity through prompt and native compaction hooks", async () => {
+    const state = createQaBusState();
+    const transport = createQaChannelTransport(state);
+    const bus = await startQaBusServer({ state });
+    cleanups.push(() => bus.stop());
+
+    const mock = await startQaMockOpenAiServer();
+    cleanups.push(() => mock.stop());
+
+    const gatewayOwner = createQaGatewayChild();
+    cleanups.push(async () => {
+      expect((await gatewayOwner.stop()).errors).toEqual([]);
+    });
+    const gateway = await gatewayOwner.start({
+      repoRoot: REPO_ROOT,
+      useRepoCli: true,
+      providerBaseUrl: `${mock.baseUrl}/v1`,
+      providerMode: "mock-openai",
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      alternateModel: "mock-openai/gpt-5.6-luna-alt",
+      forcedRuntime: "codex",
+      codexMockAutoCompactTokenLimit: 1,
+      transport,
+      transportBaseUrl: bus.baseUrl,
+      controlUiEnabled: false,
+      mutateConfig: withFixturePlugin,
+    });
+    await transport.waitReady({ gateway });
+
+    const outboundStartIndex = state
+      .getSnapshot()
+      .messages.filter((message) => message.direction === "outbound").length;
+    await transport.sendInbound({
+      accountId: "default",
+      conversation: CONVERSATION,
+      senderId: "ahmad",
+      senderName: "Ahmad",
+      text: `Preserve this authenticated sender while compacting. ${"context ".repeat(8_000)}`,
+    });
+    await transport.waitForOutbound({
+      conversation: CONVERSATION,
+      sinceIndex: outboundStartIndex,
+      timeoutMs: 120_000,
+    });
+    const secondOutboundIndex = state
+      .getSnapshot()
+      .messages.filter((message) => message.direction === "outbound").length;
+    await transport.sendInbound({
+      accountId: "default",
+      conversation: CONVERSATION,
+      senderId: "ahmad",
+      senderName: "Ahmad",
+      text: "Continue after preserving the authenticated sender.",
+    });
+    await transport.waitForOutbound({
+      conversation: CONVERSATION,
+      sinceIndex: secondOutboundIndex,
+      timeoutMs: 120_000,
+    });
+
+    const response = await fetch(`${gateway.baseUrl}/qa/codex-hook-context-proof`, {
+      headers: { Authorization: `Bearer ${gateway.token}` },
+      signal: AbortSignal.timeout(30_000),
+    });
+    expect(response.status).toBe(200);
+    const captures = (await response.json()) as HookCaptures;
+    expectAuthenticatedContext(captures.beforePromptBuild.at(-1));
+    expect(captures.beforeCompaction.length).toBeGreaterThan(0);
+    expect(captures.afterCompaction.length).toBeGreaterThan(0);
+    expectAuthenticatedContext(captures.beforeCompaction.at(-1));
+    expectAuthenticatedContext(captures.afterCompaction.at(-1));
+    const verdictPath = process.env.OPENCLAW_QA_VERDICT_PATH?.trim();
+    if (verdictPath) {
+      await fs.mkdir(path.dirname(verdictPath), { recursive: true });
+      await fs.writeFile(
+        verdictPath,
+        `${JSON.stringify(
+          {
+            scenario: "codex-authenticated-hook-context",
+            passed: true,
+            channel: "qa-channel",
+            provider: "mock-openai",
+            runtime: "codex",
+            gateway: "ephemeral-child-process",
+            captures: {
+              beforePromptBuild: captures.beforePromptBuild.length,
+              beforeCompaction: captures.beforeCompaction.length,
+              afterCompaction: captures.afterCompaction.length,
+            },
+            authenticatedContext: captures.afterCompaction.at(-1),
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+    }
+  }, 240_000);
+});

--- a/extensions/qa-lab/src/gateway-child-env.ts
+++ b/extensions/qa-lab/src/gateway-child-env.ts
@@ -136,6 +136,7 @@ export async function stageQaCodexMockModelCatalog(params: {
   providerMode: QaProviderMode;
   primaryModel?: string;
   alternateModel?: string;
+  autoCompactTokenLimit?: number;
 }): Promise<string | undefined> {
   if (params.forcedRuntime !== "codex" || params.providerMode !== "mock-openai") {
     return undefined;
@@ -144,11 +145,16 @@ export async function stageQaCodexMockModelCatalog(params: {
   const selectedModelRefs = [params.primaryModel, params.alternateModel].filter(
     (model): model is string => typeof model === "string" && model.length > 0,
   );
-  await fs.writeFile(
-    modelCatalogPath,
-    `${JSON.stringify({ models: listMockCodexModelInfos(selectedModelRefs) }, null, 2)}\n`,
-    { encoding: "utf8", mode: 0o600 },
-  );
+  const models = listMockCodexModelInfos(selectedModelRefs);
+  if (params.autoCompactTokenLimit !== undefined) {
+    for (const model of models) {
+      Object.assign(model, { auto_compact_token_limit: params.autoCompactTokenLimit });
+    }
+  }
+  await fs.writeFile(modelCatalogPath, `${JSON.stringify({ models }, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
   return modelCatalogPath;
 }
 

--- a/extensions/qa-lab/src/gateway-child-setup.ts
+++ b/extensions/qa-lab/src/gateway-child-setup.ts
@@ -76,6 +76,7 @@ export type QaGatewayChildParams = {
   fastMode?: boolean;
   thinkingDefault?: QaThinkingLevel;
   forcedRuntime?: RuntimeId;
+  codexMockAutoCompactTokenLimit?: number;
   claudeCliAuthMode?: QaCliBackendAuthMode;
   controlUiEnabled?: boolean;
   enabledPluginIds?: string[];
@@ -201,6 +202,7 @@ export async function prepareQaGatewayChild(
     providerMode,
     primaryModel: params.primaryModel,
     alternateModel: params.alternateModel,
+    autoCompactTokenLimit: params.codexMockAutoCompactTokenLimit,
   });
   const resolvedProvider = getQaProvider(providerMode);
   const liveProviderIds = resolvedProvider.usesModelProviderPlugins

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -487,6 +487,7 @@ describe("Gateway child fixture helpers", () => {
       providerMode: "mock-openai",
       primaryModel: "mock-openai/gpt-5.6-luna",
       alternateModel: "mock-openai/gpt-5.6-luna-alt",
+      autoCompactTokenLimit: 1,
     });
 
     expect(modelCatalogPath).toBe(path.join(tempRoot, "codex-model-catalog.json"));
@@ -496,12 +497,14 @@ describe("Gateway child fixture helpers", () => {
     expect(catalog.models).toEqual([
       expect.objectContaining({
         slug: "gpt-5.6-luna",
+        auto_compact_token_limit: 1,
         apply_patch_tool_type: "freeform",
         supports_reasoning_summary_parameter: true,
         tool_mode: "direct",
       }),
       expect.objectContaining({
         slug: "gpt-5.6-luna-alt",
+        auto_compact_token_limit: 1,
         apply_patch_tool_type: "freeform",
         supports_reasoning_summary_parameter: true,
         tool_mode: "direct",

--- a/extensions/qa-lab/test-fixtures/codex-hook-context-proof-plugin/index.js
+++ b/extensions/qa-lab/test-fixtures/codex-hook-context-proof-plugin/index.js
@@ -1,0 +1,47 @@
+const captures = {
+  beforePromptBuild: [],
+  beforeCompaction: [],
+  afterCompaction: [],
+};
+
+function selectAuthenticatedContext(ctx) {
+  return {
+    accountId: ctx.accountId,
+    senderId: ctx.senderId,
+    chatId: ctx.chatId,
+    channel: ctx.channel,
+    sessionKey: ctx.sessionKey,
+    channelContext: ctx.channelContext,
+  };
+}
+
+function writeJson(res, body) {
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(`${JSON.stringify(body)}\n`);
+}
+
+export default {
+  id: "qa-codex-hook-context-proof",
+  register(api) {
+    api.on("before_prompt_build", (_event, ctx) => {
+      captures.beforePromptBuild.push(selectAuthenticatedContext(ctx));
+    });
+    api.on("before_compaction", (_event, ctx) => {
+      captures.beforeCompaction.push(selectAuthenticatedContext(ctx));
+    });
+    api.on("after_compaction", (_event, ctx) => {
+      captures.afterCompaction.push(selectAuthenticatedContext(ctx));
+    });
+    api.registerHttpRoute({
+      path: "/qa/codex-hook-context-proof",
+      auth: "gateway",
+      match: "exact",
+      gatewayRuntimeScopeSurface: "trusted-operator",
+      async handler(_req, res) {
+        writeJson(res, captures);
+        return true;
+      },
+    });
+  },
+};

--- a/extensions/qa-lab/test-fixtures/codex-hook-context-proof-plugin/openclaw.plugin.json
+++ b/extensions/qa-lab/test-fixtures/codex-hook-context-proof-plugin/openclaw.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "qa-codex-hook-context-proof",
+  "activation": {
+    "onStartup": true
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/src/agents/harness/hook-context.ts
+++ b/src/agents/harness/hook-context.ts
@@ -27,6 +27,7 @@ export type AgentHarnessHookContext = {
   modelProviderId?: string;
   modelId?: string;
   messageProvider?: string;
+  accountId?: string;
   trigger?: string;
   channelId?: string;
   contextTokenBudget?: number;
@@ -52,6 +53,7 @@ export function buildAgentHookContext(params: AgentHarnessHookContext): PluginHo
     ...(params.modelProviderId ? { modelProviderId: params.modelProviderId } : {}),
     ...(params.modelId ? { modelId: params.modelId } : {}),
     ...(params.messageProvider ? { messageProvider: params.messageProvider } : {}),
+    ...(params.accountId ? { accountId: params.accountId } : {}),
     ...(params.channel ? { channel: params.channel } : {}),
     ...(params.trigger ? { trigger: params.trigger } : {}),
     ...(params.channelId ? { channelId: params.channelId } : {}),

--- a/src/agents/harness/hook-context.ts
+++ b/src/agents/harness/hook-context.ts
@@ -53,6 +53,8 @@ export function buildAgentHookContext(params: AgentHarnessHookContext): PluginHo
     ...(params.modelProviderId ? { modelProviderId: params.modelProviderId } : {}),
     ...(params.modelId ? { modelId: params.modelId } : {}),
     ...(params.messageProvider ? { messageProvider: params.messageProvider } : {}),
+    // The agent's configured channel account is routing context, not requester identity.
+    // Keep it on non-user turns while the identity projection below withholds sender/chat facts.
     ...(params.accountId ? { accountId: params.accountId } : {}),
     ...(params.channel ? { channel: params.channel } : {}),
     ...(params.trigger ? { trigger: params.trigger } : {}),

--- a/src/agents/harness/prompt-compaction-hook-helpers.test.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.test.ts
@@ -213,6 +213,46 @@ describe("resolveAgentHarnessBeforePromptBuildResult", () => {
     expect(result.prompt).toBe("heartbeat context\n\nprompt context\n\nhello");
   });
 
+  it("preserves authenticated channel identity in prompt-build hook context", async () => {
+    const handler = vi.fn(() => undefined);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_prompt_build", handler }]),
+    );
+
+    await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: "hello",
+      developerInstructions: "base instructions",
+      messages: [],
+      ctx: {
+        trigger: "user",
+        accountId: "account-a",
+        channel: "telegram",
+        channelId: "chat-a",
+        senderId: "sender-a",
+        chatId: "chat-a",
+        channelContext: {
+          sender: { id: "sender-a" },
+          chat: { id: "chat-a" },
+        },
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        accountId: "account-a",
+        channel: "telegram",
+        channelId: "chat-a",
+        senderId: "sender-a",
+        chatId: "chat-a",
+        channelContext: {
+          sender: { id: "sender-a" },
+          chat: { id: "chat-a" },
+        },
+      }),
+    );
+  });
+
   it("runs authorized enrichment after restrictive hooks finalize the tool surface", async () => {
     const calls: string[] = [];
     initializeGlobalHookRunner(

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -7,6 +7,7 @@ export function createExtensionCodexAppServerAttemptExtraVitestConfig(
   return createScopedVitestConfig(
     [
       "extensions/codex/src/app-server/run-attempt.agent-end-context.test.ts",
+      "extensions/codex/src/app-server/run-attempt.auth-context.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts",


### PR DESCRIPTION
Closes #129401

Related: #70313, #91903, #114819, #124556, #124557

AI-assisted: yes. Codex helped isolate the context-loss boundaries, build the cross-channel and native-compaction regressions, refresh the branch, and validate the final diff. The author reviewed the implementation, identity semantics, and evidence.

## What Problem This Solves

Authenticated WhatsApp, Telegram, iMessage, and other channel users handled by Codex could be rejected by channel-aware plugins because prompt and native-compaction hooks lost the admitted account, sender, chat, and channel metadata.

## Why This Change Was Made

The Codex attempt now prepares one canonical agent-hook context with the shared channel-field projection and passes that same admitted snapshot to prompt, lifecycle, completion, and both native-compaction hook paths. The shared harness also preserves configured `accountId` when rebuilding hook context.

This restores the existing hook contract. It adds no identity source, public API, configuration, or persistence. Host-admitted fields override stale nested values, and non-user turns still omit requester identity.

## User Impact

Codex-backed hooks receive the same authenticated channel context as core during prompt construction, lifecycle observation, completion, and native compaction. Valid users are no longer falsely rejected because the Codex path dropped admitted identity.

No migration, session reset, transcript rewrite, or operator action is required.

## Evidence

Exact reviewed head: `eb89ebfae70b4fdb01927b908fdc738fd3a456d1`.

Rebased onto `main` at `eb0d8830e7dc795e1bb927b5800b61a67470c8ae`. The complete seven-commit series is patch-identical to the pre-rebase series (`git range-diff`: 7/7 equivalent); the native proof below was nevertheless rerun on the literal current head after the rebase. GitHub `main` advanced again afterward; the PR remains conflict-free.

OpenClaw pins `@openai/codex` 0.151.0. The matching upstream implementation was inspected at [`rust-v0.151.0` commit `78c290807ce7`](https://github.com/openai/codex/commit/78c290807ce710180111df227df3b7a4fe845452): its automatic-compaction regression drives turns past `AUTO_COMPACT_LIMIT`, then requires one `ContextCompaction` item to start and complete with the same ID ([source](https://github.com/openai/codex/blob/rust-v0.151.0/codex-rs/app-server/tests/suite/v2/compaction.rs#L45-L97)). The QA scenario's injected `auto_compact_token_limit` exercises that trigger through bundled native Codex.

The checked-in scenario passed on the exact head through an ephemeral authenticated Gateway, synthetic `qa-channel`, mock OpenAI endpoint, fixture plugin, and bundled Codex 0.151.0 app-server:

```text
scenario=codex-authenticated-hook-context
passed=true
runtime=codex
gateway=ephemeral-child-process
before_prompt_build=2
before_compaction=1
after_compaction=1
account_id=default
sender_id=ahmad
chat_id=authenticated-team-room
channel=qa-channel
session_key=agent:qa:main
channel_context.sender.id=ahmad
channel_context.chat.id=authenticated-team-room
```

This is actual Gateway/native-Codex behavior, not a mocked hook call. The exact-head scenario is checked in at [`codex-authenticated-hook-context.e2e.test.ts`](https://github.com/openclaw/openclaw/blob/eb89ebfae70b4fdb01927b908fdc738fd3a456d1/extensions/qa-lab/src/codex-authenticated-hook-context.e2e.test.ts).

Exact-head validation:

- Gateway/native-Codex product proof: 1 test passed in 9.70s on the literal current head.
- `git diff --check` passed.
- Hosted CI completed on this exact head: 256 passed, 43 skipped, 0 failed, and 0 pending checks.

No live OpenClaw configuration, workspace, session, transcript, database, or Gateway was read or modified.
