### PR TITLE
fix(agents): worktree sessions write outside sandbox from prompt workspace path

### DIFF
--- a/src/agents/command/prepare.ts
+++ b/src/agents/command/prepare.ts
@@ -38,7 +38,10 @@ import { AGENT_LANE_SUBAGENT } from "../lanes.js";
 import type { ModelManifestNormalizationContext } from "../model-ref-shared.js";
 import { buildConfiguredModelCatalog, resolveConfiguredModelRef } from "../model-selection.js";
 import type { PreparedModelRuntimePluginGeneration } from "../prepared-model-runtime.types.js";
-import { normalizeSpawnedRunMetadata } from "../spawned-context.js";
+import {
+  normalizeSpawnedRunMetadata,
+  resolvePreparedAgentCommandWorkspaceDir,
+} from "../spawned-context.js";
 import { resolveEffectiveAgentRuntime } from "../thinking-runtime.js";
 import { resolveAgentTimeoutMs } from "../timeout.js";
 import { ensureAgentWorkspace } from "../workspace.js";
@@ -272,11 +275,22 @@ export async function prepareAgentCommandExecution(
     agentId: sessionAgentId,
     sessionKey,
   });
-  const workspaceDirRaw =
-    normalizedSpawned.workspaceDir ?? resolveAgentWorkspaceDir(cfg, sessionAgentId);
-  const workspaceDir = resolveUserPath(workspaceDirRaw);
   const cwd =
     normalizeOptionalString(opts.cwd) ?? normalizeOptionalString(sessionEntryRaw?.spawnedCwd);
+  // Managed worktree sessions persist spawnedCwd; remount that checkout as
+  // workspaceDir so system prompt + bootstrap match the file-tool sandbox root.
+  // Without this, prepare inherits cwd from the session while leaving workspace
+  // on the canonical agent home and models write outside the worktree.
+  const workspaceDirRaw = resolvePreparedAgentCommandWorkspaceDir({
+    configuredWorkspaceDir: resolveAgentWorkspaceDir(cfg, sessionAgentId),
+    explicitWorkspaceDir: normalizedSpawned.workspaceDir,
+    session: {
+      spawnedBy: sessionEntryRaw?.spawnedBy ?? normalizedSpawned.spawnedBy,
+      spawnedWorkspaceDir: sessionEntryRaw?.spawnedWorkspaceDir,
+      spawnedCwd: sessionEntryRaw?.spawnedCwd,
+    },
+  });
+  const workspaceDir = resolveUserPath(workspaceDirRaw);
   const agentDir = resolveAgentDir(cfg, sessionAgentId);
   const pluginsEnabled = normalizePluginsConfig(cfg.plugins).enabled;
   const preparedMetadataSnapshot = runtimeContext?.pluginGeneration.pluginMetadataSnapshot;

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -181,7 +181,7 @@ export type AgentCommandOpts = {
   fastModeAutoOnSeconds?: number;
   /** Explicit workspace directory override (for subagents to inherit parent workspace). */
   workspaceDir?: SpawnedRunMetadata["workspaceDir"];
-  /** Explicit task working directory for this run. Bootstrap still uses workspaceDir. */
+  /** Explicit task working directory for this run. When unset, session spawnedCwd is used. Managed worktree sessions remount that cwd as workspaceDir. */
   cwd?: string;
   /** Force bundled MCP teardown when a one-shot local run completes. */
   cleanupBundleMcpOnRunEnd?: boolean;

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
@@ -297,7 +297,10 @@ export async function prepareEmbeddedAttemptSystemPrompt(params: {
     embeddedSystemPrompt: {
       config: attempt.config,
       agentId: params.sessionAgentId,
-      workspaceDir: params.effectiveWorkspace,
+      // File tools sandbox to effectiveCwd; prompt Working directory must match
+      // (same rule as CLI runtimeWorkspaceDir) so models do not write to the
+      // bootstrap agent home when cwd is a managed worktree or task checkout.
+      workspaceDir: params.effectiveCwd || params.effectiveWorkspace,
       defaultThinkLevel: attempt.thinkLevel,
       reasoningLevel: attempt.reasoningLevel ?? "off",
       extraSystemPrompt,

--- a/src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts
@@ -59,6 +59,14 @@ describe("runEmbeddedAttempt cwd/workspace split", () => {
     expect(toolsCall?.workspaceDir).toBe(bootstrapCall?.workspaceDir);
     expect(toolsCall?.spawnWorkspaceDir).toBe(bootstrapCall?.workspaceDir);
 
+    // Prompt Working directory must name the file-tool root (cwd), not the
+    // bootstrap agent home — otherwise models write into the wrong tree.
+    const promptInput = hoisted.embeddedSystemPromptInputs.at(-1) as
+      | { workspaceDir?: string }
+      | undefined;
+    expect(promptInput?.workspaceDir).toBe(taskRepo);
+    expect(promptInput?.workspaceDir).not.toBe(bootstrapCall?.workspaceDir);
+
     const resourceLoaderInit = hoisted.defaultResourceLoaderInitMock.mock.calls[0]?.[0] as
       | { cwd?: string }
       | undefined;

--- a/src/agents/spawned-context.test.ts
+++ b/src/agents/spawned-context.test.ts
@@ -5,6 +5,7 @@ import {
   mapToolContextToSpawnedRunMetadata,
   normalizeSpawnedRunMetadata,
   resolveIngressWorkspaceOverrideForSessionRun,
+  resolvePreparedAgentCommandWorkspaceDir,
   resolveSpawnedWorkspaceInheritance,
 } from "./spawned-context.js";
 
@@ -110,5 +111,51 @@ describe("resolveIngressWorkspaceOverrideForSessionRun", () => {
       }),
     ).toBe("/tmp/worktree");
     expect(resolveIngressWorkspaceOverrideForSessionRun()).toBeUndefined();
+  });
+});
+
+describe("resolvePreparedAgentCommandWorkspaceDir", () => {
+  it("remounts managed worktree cwd over explicit and configured agent homes", () => {
+    // agentCommand prepare must remount even when a caller still passes the
+    // canonical .openclaw/workspace; otherwise the system prompt shows that
+    // home while file tools sandbox to the worktree.
+    expect(
+      resolvePreparedAgentCommandWorkspaceDir({
+        configuredWorkspaceDir: "/home/user/.openclaw/workspace",
+        explicitWorkspaceDir: "/home/user/.openclaw/workspace",
+        session: {
+          spawnedCwd: "/home/user/.openclaw/worktrees/abc/wt-1",
+        },
+      }),
+    ).toBe("/home/user/.openclaw/worktrees/abc/wt-1");
+  });
+
+  it("keeps spawned-run workspace inheritance instead of remounting task cwd", () => {
+    expect(
+      resolvePreparedAgentCommandWorkspaceDir({
+        configuredWorkspaceDir: "/home/user/.openclaw/workspace",
+        explicitWorkspaceDir: "/home/user/.openclaw/workspace-coder",
+        session: {
+          spawnedBy: "agent:main:subagent:parent",
+          spawnedWorkspaceDir: "/home/user/.openclaw/workspace-coder",
+          spawnedCwd: "/tmp/task-repo",
+        },
+      }),
+    ).toBe("/home/user/.openclaw/workspace-coder");
+  });
+
+  it("falls back to explicit then configured workspace when no session remount applies", () => {
+    expect(
+      resolvePreparedAgentCommandWorkspaceDir({
+        configuredWorkspaceDir: "/home/user/.openclaw/workspace",
+        explicitWorkspaceDir: "/tmp/explicit",
+        session: {},
+      }),
+    ).toBe("/tmp/explicit");
+    expect(
+      resolvePreparedAgentCommandWorkspaceDir({
+        configuredWorkspaceDir: "/home/user/.openclaw/workspace",
+      }),
+    ).toBe("/home/user/.openclaw/workspace");
   });
 });

--- a/src/agents/spawned-context.ts
+++ b/src/agents/spawned-context.ts
@@ -95,3 +95,27 @@ export function resolveIngressWorkspaceOverrideForSessionRun(
   // also the workspace that sandbox setup must mount on every later turn.
   return normalizeOptionalString(metadata?.cwd);
 }
+
+/**
+ * Resolve the workspaceDir agentCommand prepare must bind for one session run.
+ * Session remount (managed worktree cwd) wins over an explicit call-site
+ * workspace so prompt/bootstrap and file-tool roots stay the same checkout.
+ */
+export function resolvePreparedAgentCommandWorkspaceDir(params: {
+  configuredWorkspaceDir: string;
+  explicitWorkspaceDir?: string | null;
+  session?: {
+    spawnedBy?: string | null;
+    spawnedWorkspaceDir?: string | null;
+    spawnedCwd?: string | null;
+  } | null;
+}): string {
+  const remount = resolveIngressWorkspaceOverrideForSessionRun({
+    spawnedBy: params.session?.spawnedBy,
+    workspaceDir: params.session?.spawnedWorkspaceDir,
+    cwd: params.session?.spawnedCwd,
+  });
+  return (
+    remount ?? normalizeOptionalString(params.explicitWorkspaceDir) ?? params.configuredWorkspaceDir
+  );
+}

--- a/src/auto-reply/reply/get-reply-run-context.ts
+++ b/src/auto-reply/reply/get-reply-run-context.ts
@@ -1,7 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentConfig } from "../../agents/agent-scope.js";
 import { resolveEmbeddedFullAccessState } from "../../agents/embedded-agent-runner/sandbox-info.js";
-import { resolveIngressWorkspaceOverrideForSessionRun } from "../../agents/spawned-context.js";
+import { resolvePreparedAgentCommandWorkspaceDir } from "../../agents/spawned-context.js";
 import type { SilentReplyPromptMode } from "../../agents/system-prompt.types.js";
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
 import { copyChannelParticipantAdmissionEvidence } from "../../channels/message-access/admission-evidence.js";
@@ -319,19 +319,21 @@ export async function prepareReplyRunContext(params: RunPreparedReplyParams) {
           rawBodyTrimmed.length > 0)));
   const startupAction =
     softResetTriggered || /^\/reset(?:\s|$)/i.test(normalizedCommandBody) ? "reset" : "new";
-  const sessionWorkspaceOverride = resolveIngressWorkspaceOverrideForSessionRun({
-    spawnedBy: sessionEntry?.spawnedBy,
-    workspaceDir: sessionEntry?.spawnedWorkspaceDir,
-    cwd: sessionEntry?.spawnedCwd,
+  const workspaceDir = resolvePreparedAgentCommandWorkspaceDir({
+    configuredWorkspaceDir,
+    session: {
+      spawnedBy: sessionEntry?.spawnedBy,
+      spawnedWorkspaceDir: sessionEntry?.spawnedWorkspaceDir,
+      spawnedCwd: sessionEntry?.spawnedCwd,
+    },
   });
-  const workspaceDir = sessionWorkspaceOverride ?? configuredWorkspaceDir;
   const bareResetPromptState =
     isBareSessionReset && workspaceDir
       ? await resolveBareSessionResetPromptState({
           cfg,
           workspaceDir,
           isPrimaryRun: !isSubagentSessionKey(sessionKey) && !isAcpSessionKey(sessionKey),
-          isCanonicalWorkspace: !sessionWorkspaceOverride,
+          isCanonicalWorkspace: workspaceDir === configuredWorkspaceDir,
           hasBootstrapFileAccess: () =>
             resolveBareResetBootstrapFileAccess({
               cfg,


### PR DESCRIPTION
Closes #129404

## What Problem This Solves

Fixes an issue where users running managed worktree sessions would get the shared agent workspace path and bootstrap files (`AGENTS.md`, `BOOTSTRAP.md`, â€¦) in the system prompt while file tools were sandboxed to the session worktree. Agents then wrote to `.openclaw/workspace/...`, hit `Path escapes sandbox root`, tried to leave the worktree (including via `exec`), and could rewrite shared bootstrap so later agents inherited poisoned instructions.

## Why This Change Was Made

Dashboard worktree sessions already remount managed `spawnedCwd` as `workspaceDir` at gateway/auto-reply ingress. `agentCommand` prepare only inherited `spawnedCwd` as `cwd` and left `workspaceDir` on the canonical agent home, so prompt/bootstrap and the file-tool root diverged. This change makes remount the shared owner for prepare (`resolvePreparedAgentCommandWorkspaceDir`) and uses `effectiveCwd` for the embedded prompt Working directory (same rule as CLI), so prompt path and bootstrap load from the worktree checkout.

Non-goal: changing `exec` host containment. That remains a separate policy surface.

## User Impact

Managed worktree sessions now see their own worktree as the workspace in the system prompt and load bootstrap from that checkout. Agents stop being steered toward the shared `.openclaw/workspace` for file tools, and a corrupted shared `AGENTS.md` no longer becomes the injected identity for every new worktree session that remounts correctly.

## Evidence

- Focused remount unit tests: `resolvePreparedAgentCommandWorkspaceDir` / `resolveIngressWorkspaceOverrideForSessionRun` (4 passed).
- Regression assertion in `attempt.cwd-split.test.ts`: when cwd and bootstrap workspace differ, embedded system prompt `workspaceDir` follows the file-tool cwd.
- Before: prompt showed `.../.openclaw/workspace/BOOTSTRAP.md` while sandbox root was `.../.openclaw/worktrees/<fp>/<name>`; writes failed with `Path escapes sandbox root`.
- After (intended): prepare remounts worktree as `workspaceDir`, so bootstrap resolution and prompt Working directory use the same checkout as file tools.