### PR TITLE
fix(vercel): exclude non-language gateway models from chat catalog

### DIFF
--- a/extensions/vercel-ai-gateway/models.ts
+++ b/extensions/vercel-ai-gateway/models.ts
@@ -30,6 +30,7 @@ type VercelPricingShape = {
 
 type VercelGatewayModelShape = {
   id?: string;
+  type?: string;
   name?: string;
   context_window?: number;
   max_tokens?: number;
@@ -158,11 +159,13 @@ export function getStaticVercelAiGatewayModelCatalog(): ModelDefinitionConfig[] 
   return STATIC_VERCEL_AI_GATEWAY_MODEL_CATALOG.map(buildStaticModelDefinition);
 }
 
-function buildDiscoveredModelDefinition(
-  model: VercelGatewayModelShape,
-): ModelDefinitionConfig | null {
+function buildDiscoveredModelDefinition(value: unknown): ModelDefinitionConfig | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Vercel AI Gateway model list: malformed JSON response");
+  }
+  const model = value as VercelGatewayModelShape;
   const id = typeof model.id === "string" ? model.id.trim() : "";
-  if (!id) {
+  if (!id || (model.type !== undefined && model.type !== "language")) {
     return null;
   }
 
@@ -201,13 +204,6 @@ function buildDiscoveredModelDefinition(
   };
 }
 
-function asVercelGatewayModelShape(value: unknown): VercelGatewayModelShape {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error("Vercel AI Gateway model list: malformed JSON response");
-  }
-  return value as VercelGatewayModelShape;
-}
-
 export async function discoverVercelAiGatewayModels(): Promise<ModelDefinitionConfig[]> {
   if (process.env.VITEST || process.env.NODE_ENV === "test") {
     return getStaticVercelAiGatewayModelCatalog();
@@ -227,7 +223,6 @@ export async function discoverVercelAiGatewayModels(): Promise<ModelDefinitionCo
     fetchGuard: (params) => fetchWithSsrFGuard(withTrustedEnvProxyGuardedFetchMode(params)),
     projectRows: (rows) =>
       rows
-        .map(asVercelGatewayModelShape)
         .map(buildDiscoveredModelDefinition)
         .filter((entry): entry is ModelDefinitionConfig => entry !== null),
   });

--- a/extensions/vercel-ai-gateway/provider-catalog.test.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.test.ts
@@ -129,6 +129,43 @@ describe("vercel ai gateway provider catalog", () => {
     });
   });
 
+  it("excludes non-language models while preserving vision and legacy catalog rows", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: jsonResponse({
+        data: [
+          {
+            id: "alibaba/qwen3-235b-a22b-thinking",
+            type: "language",
+            tags: ["vision", "reasoning"],
+          },
+          ...[
+            ["embedding", "alibaba/qwen3-embedding-0.6b"],
+            ["image", "bfl/flux-2-flex"],
+            ["video", "alibaba/wan-v2.5-t2v-preview"],
+            ["reranking", "cohere/rerank-v3.5"],
+            ["speech", "fish-audio/s1"],
+            ["transcription", "fish-audio/transcribe-1"],
+            ["realtime", "openai/gpt-realtime-1.5"],
+          ].map(([type, id]) => ({ id, type })),
+          { id: "custom/legacy-model" },
+        ],
+      }),
+      release: async () => {},
+      finalUrl: `${VERCEL_AI_GATEWAY_BASE_URL}/v1/models`,
+    });
+
+    await withLiveDiscovery(async () => {
+      expect((await buildVercelAiGatewayProvider()).models).toMatchObject([
+        {
+          id: "alibaba/qwen3-235b-a22b-thinking",
+          reasoning: true,
+          input: ["text", "image"],
+        },
+        { id: "custom/legacy-model", input: ["text"] },
+      ]);
+    });
+  });
+
   it("falls back to the static catalog for malformed successful model list payloads", async () => {
     for (const payload of [[], { data: {} }, { data: [null] }]) {
       clearLiveCatalogCacheForTests();


### PR DESCRIPTION
## Summary

Stop advertising non-language Vercel AI Gateway models as selectable chat models.

## Root cause

The live unauthenticated Vercel model-discovery endpoint returns language models alongside embedding, image, video, reranking, speech, transcription, and realtime models. The provider owner ignored the documented `type` field and projected every row into an Anthropic-compatible chat model, producing guaranteed-invalid model selections.

Validate each discovered row in its canonical owner, keep only explicitly declared language models, preserve legacy rows without a type, and remove the redundant shape-adapter layer. Language models with vision tags remain image-capable.

## Real provider proof

- Actual public provider endpoint and actual OpenClaw provider builder before repair: 351 selectable models, including 117 non-language models across seven incompatible categories.
- Same unauthenticated production discovery and provider builder after repair: 234 language models; sampled embedding, image, video, reranking, speech, transcription, and realtime IDs are absent; image-capable language models retain `text` and `image` input.
- Official provider contracts document model `type` and language filtering: https://vercel.com/docs/ai-gateway/sdks-and-apis/rest-api#list-models and https://vercel.com/docs/ai-gateway/models-and-providers#dynamic-model-discovery.
- All 15 provider owner/catalog tests, formatting, targeted lint, and independent autoreview passed.
- Production delta: +7/-12, net -5; no static catalog, manifest, configuration, credentials, or package changes.
