### PR TITLE
test(doctor): assert auth health targets in collection order

### DIFF
--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -176,7 +176,7 @@ describe("noteAuthProfileHealth", () => {
       } as OpenClawConfig,
     });
 
-    expect(findings.map((finding) => finding.target).toSorted()).toEqual([
+    expect(findings.map((finding) => finding.target)).toEqual([
       "anthropic:custom-cli",
       "anthropic:static-cli",
     ]);


### PR DESCRIPTION
## What Problem This Solves

`check-lint-core-3` is red on `main` since #129375: `src/commands/doctor-auth.profile-health.test.ts:179` calls `toSorted()` with no compare function, which `typescript/require-array-sort-compare` rejects (`main` `d53ea9cf4`, job `check-lint-core-3`).

## Why This Change Was Made

The findings are collected in a fixed target order (`targets` map insertion in `src/commands/doctor-auth.ts`), so the test asserts that order directly, like the sibling assertion at line 206. Test-only change; no behavior change.

## User Impact

None at runtime. Restores the `check-lint-core-3` gate on `main`.

## Evidence

- `node scripts/run-oxlint.mjs src/commands/doctor-auth.profile-health.test.ts` — clean.
- `node scripts/run-vitest.mjs src/commands/doctor-auth.profile-health.test.ts` — 23 passed.
- LOC: production 0; tests +4 / −3 (comparator-based first push failed `check-test-types-core-1`: `target` is optional).
- Other `main` failures (`checks-node-compact-*` auth-resolution hangs from #129052) are not addressed here; a separate PR carries that fix.
