### PR TITLE
fix(qa): reject impossible empty scenario evidence

### DIFF
--- a/extensions/qa-lab/src/confidence-report.test.ts
+++ b/extensions/qa-lab/src/confidence-report.test.ts
@@ -383,30 +383,18 @@ describe("qa confidence report", () => {
     },
   );
 
-  it("accepts a positive count-only suite without scenario rows", async () => {
-    const report = await buildStrictSuiteReport({
-      counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
-    });
-
-    expect(report.pass).toBe(true);
-    expect(report.globalPass).toBe(true);
-    expect(report.lanes[0]).toMatchObject({ status: "pass" });
-  });
-
-  it.each([
-    [{ total: 1, passed: 1, failed: 0, skipped: 0 }, "count/scenario mismatch"],
-    [{ total: 3, passed: 2, failed: 0 }, "no executed scenarios"],
-  ] as const)(
-    "rejects positive counts with explicitly empty scenario rows",
-    async (counts, expectedDetail) => {
-      const report = await buildStrictSuiteReport({ counts, scenarios: [] });
-
-      expect(report.pass).toBe(false);
-      expect(report.globalPass).toBe(false);
-      expect(report.lanes[0]).toMatchObject({ status: "unknown" });
+  it("distinguishes omitted scenario rows from explicitly empty evidence", async () => {
+    for (const [counts, pass, expectedDetail] of [
+      [{ total: 1, passed: 1, failed: 0, skipped: 0 }, true, "counts.failed=0"],
+      [{ total: 1, passed: 1, failed: 0, skipped: 0 }, false, "count/scenario mismatch"],
+      [{ total: 3, passed: 2, failed: 0 }, false, "no executed scenarios"],
+    ] as const) {
+      const report = await buildStrictSuiteReport({ counts, ...(pass ? {} : { scenarios: [] }) });
+      expect(report).toMatchObject({ pass, globalPass: pass });
+      expect(report.lanes[0]).toMatchObject({ status: pass ? "pass" : "unknown" });
       expect(report.lanes[0]?.details).toContain(expectedDetail);
-    },
-  );
+    }
+  });
 
   it("infers skipped suite rows from totals and scenario status", async () => {
     for (const [artifact, expectedDetail] of [

--- a/extensions/qa-lab/src/confidence-report.test.ts
+++ b/extensions/qa-lab/src/confidence-report.test.ts
@@ -72,7 +72,6 @@ describe("qa confidence report", () => {
   it("passes strict zero-unknowns when every lane passes or has an allowed blocked verdict", async () => {
     await writeJson("tool-defaults/qa-suite-summary.json", {
       counts: { total: 20, passed: 18, skipped: 2, failed: 0 },
-      scenarios: [],
     });
     await writeJson("token/qa-runtime-token-efficiency-summary.json", {
       status: "estimated",
@@ -174,7 +173,6 @@ describe("qa confidence report", () => {
   it("does not let optional lanes block strict gates", async () => {
     await writeJson("required/qa-suite-summary.json", {
       counts: { total: 1, passed: 1, skipped: 0, failed: 0 },
-      scenarios: [],
     });
 
     const report = await buildQaConfidenceReport({
@@ -310,7 +308,6 @@ describe("qa confidence report", () => {
   it("fails strict global pass for skipped suite rows until a backfill lane passes", async () => {
     const report = await buildStrictSuiteReport({
       counts: { total: 3, passed: 2, skipped: 1, failed: 0 },
-      scenarios: [],
     });
 
     expect(report.zeroUnknowns).toBe(true);
@@ -396,9 +393,24 @@ describe("qa confidence report", () => {
     expect(report.lanes[0]).toMatchObject({ status: "pass" });
   });
 
+  it.each([
+    [{ total: 1, passed: 1, failed: 0, skipped: 0 }, "count/scenario mismatch"],
+    [{ total: 3, passed: 2, failed: 0 }, "no executed scenarios"],
+  ] as const)(
+    "rejects positive counts with explicitly empty scenario rows",
+    async (counts, expectedDetail) => {
+      const report = await buildStrictSuiteReport({ counts, scenarios: [] });
+
+      expect(report.pass).toBe(false);
+      expect(report.globalPass).toBe(false);
+      expect(report.lanes[0]).toMatchObject({ status: "unknown" });
+      expect(report.lanes[0]?.details).toContain(expectedDetail);
+    },
+  );
+
   it("infers skipped suite rows from totals and scenario status", async () => {
     for (const [artifact, expectedDetail] of [
-      [{ counts: { total: 3, passed: 2, failed: 0 }, scenarios: [] }, "counts.skipped=1"],
+      [{ counts: { total: 3, passed: 2, failed: 0 } }, "counts.skipped=1"],
       [
         {
           counts: { total: 2, passed: 2, failed: 0 },
@@ -533,7 +545,7 @@ describe("qa confidence report", () => {
 
   it("passes strict global pass when skipped suite rows are backfilled by a passing lane", async () => {
     const report = await buildStrictSuiteReport(
-      { counts: { total: 3, passed: 2, skipped: 1, failed: 0 }, scenarios: [] },
+      { counts: { total: 3, passed: 2, skipped: 1, failed: 0 } },
       true,
     );
 
@@ -561,7 +573,6 @@ describe("qa confidence report", () => {
           text: "OpenAI quota exceeded",
         },
       ],
-      scenarios: [],
     });
 
     const report = await buildQaConfidenceReport({

--- a/extensions/qa-lab/src/confidence-report.ts
+++ b/extensions/qa-lab/src/confidence-report.ts
@@ -412,7 +412,7 @@ function evaluateQaSuiteSummary(payload: unknown): QaConfidenceLaneEvaluation {
       (scenario) =>
         isRecord(scenario) && (scenario.status === "pass" || scenario.status === "fail"),
     ) === true ||
-    ((scenarios?.length ?? 0) === 0 && (passedCount ?? 0) > 0);
+    (scenarios === undefined && (passedCount ?? 0) > 0);
   const gatewayLogSentinels = collectGatewayLogSentinels(payload);
   if (gatewayLogSentinels.length > 0) {
     const allEnvironmentBlocked = gatewayLogSentinels.every(

--- a/extensions/qa-lab/src/suite-summary.test.ts
+++ b/extensions/qa-lab/src/suite-summary.test.ts
@@ -128,6 +128,13 @@ describe("qa suite summary helpers", () => {
         scenarios: [{ status: "pass" }, { status: "pass" }],
       },
     },
+    {
+      name: "positive counts without their claimed scenario rows",
+      summary: {
+        counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
+        scenarios: [],
+      },
+    },
   ])("rejects complete suite accounting with $name", async ({ summary }) => {
     for (const reader of [
       readQaSuiteFailedScenarioCountFromFile,

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -228,7 +228,7 @@ export function findQaSuiteSummaryAccountingError(summary: unknown): string | un
   }
 
   const counts = { total, passed, failed, skipped };
-  if (Array.isArray(summary.scenarios) && summary.scenarios.length > 0) {
+  if (Array.isArray(summary.scenarios)) {
     const statuses = summary.scenarios.map((scenario) =>
       isRecord(scenario) ? scenario.status : undefined,
     );


### PR DESCRIPTION
## Summary

Reject impossible QA reports that claim passed scenarios while explicitly containing no scenario evidence.

## Root cause

The central QA accounting owner skipped scenario-cardinality validation for explicitly empty arrays, and the confidence owner separately treated empty rows like omitted legacy rows. As a result, both complete and partially populated positive-count reports could pass strict confidence despite containing zero executed scenarios.

Validate explicitly present rows in the canonical accounting owner and reserve counts-only compatibility for reports that truly omit scenario rows. Normalize contradictory old test fixtures to honest legacy counts-only shapes.

## Validation

- Three authentic accounting/confidence regressions failed before repair, including complete counts and incomplete legacy counts with explicit empty rows.
- 159 summary, confidence, suite-reader, and parity-report tests plus 22 actual QA CLI gate tests passed.
- Valid count-only legacy reports remain supported; genuine empty suites remain unknown rather than passing.
- Formatting, focused lint, and independent autoreview passed.
- Production delta: +2/-2, net zero.
