### PR TITLE
fix(agents): worktree sessions inject shared AGENTS.md bootstrap instead of worktree files

### DIFF
--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -50,7 +50,13 @@ import {
   type SessionSuspensionParams,
 } from "../session-suspension.js";
 import { resolveSystemPromptRepoRoot } from "../system-prompt-params.js";
-import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
+import {
+  redactRunIdentifier,
+  resolveRunBootstrapWorkspaceDir,
+  resolveRunWorkspaceDir,
+} from "../workspace-run.js";
+import { getRegistryWorktree } from "../worktrees/registry.js";
+import { resolveWorktreeIdForPath } from "../worktrees/run-lease.js";
 import { runEmbeddedAgentViaCliBackendIfEligible } from "./cli-backend-dispatch.js";
 import { waitForDeferredTurnMaintenanceForSession } from "./context-engine-maintenance.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
@@ -367,6 +373,21 @@ async function runEmbeddedAgentInternal(
             resolveAgentWorkspaceDir(preparedModelRuntime.config, preparedAgentId),
           );
           const isCanonicalWorkspace = canonicalWorkspace === resolvedWorkspace;
+          // Managed worktree checkouts own their bootstrap files. Keeping the
+          // shared agent home here leaves absolute .openclaw/workspace paths in
+          // the system prompt and lets one exec escape rewrite AGENTS.md for
+          // every later worktree session.
+          const managedWorktreeId = await resolveWorktreeIdForPath({
+            candidatePaths: [resolvedWorkspace, params.cwd],
+          }).catch(() => undefined);
+          const managedWorktreeDir = managedWorktreeId
+            ? getRegistryWorktree(process.env, managedWorktreeId)?.path
+            : undefined;
+          const bootstrapWorkspaceDir = resolveRunBootstrapWorkspaceDir({
+            canonicalWorkspaceDir: canonicalWorkspace,
+            sessionWorkspaceDir: resolvedWorkspace,
+            managedWorktreeDir,
+          });
           const redactedSessionId = redactRunIdentifier(params.sessionId);
           const redactedSessionKey = redactRunIdentifier(params.sessionKey);
           const redactedWorkspace = redactRunIdentifier(resolvedWorkspace);
@@ -447,7 +468,7 @@ async function runEmbeddedAgentInternal(
             agentDir,
             workspaceResolution,
             workspaceDir: resolvedWorkspace,
-            bootstrapWorkspaceDir: canonicalWorkspace,
+            bootstrapWorkspaceDir,
             isCanonicalWorkspace,
             globalLane,
             hookRunner,

--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -373,12 +373,12 @@ async function runEmbeddedAgentInternal(
             resolveAgentWorkspaceDir(preparedModelRuntime.config, preparedAgentId),
           );
           const isCanonicalWorkspace = canonicalWorkspace === resolvedWorkspace;
-          // Managed worktree checkouts own their bootstrap files. Keeping the
-          // shared agent home here leaves absolute .openclaw/workspace paths in
-          // the system prompt and lets one exec escape rewrite AGENTS.md for
-          // every later worktree session.
+          // Managed worktree checkouts own their bootstrap files only when the
+          // session workspace itself was remounted into that checkout. A
+          // cwd-only worktree binding must not inject unrelated worktree
+          // AGENTS.md into a still-canonical session.
           const managedWorktreeId = await resolveWorktreeIdForPath({
-            candidatePaths: [resolvedWorkspace, params.cwd],
+            candidatePaths: [resolvedWorkspace],
           }).catch(() => undefined);
           const managedWorktreeDir = managedWorktreeId
             ? getRegistryWorktree(process.env, managedWorktreeId)?.path

--- a/src/agents/embedded-agent-runner/run/attempt-bootstrap-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bootstrap-prepare.test.ts
@@ -71,6 +71,59 @@ describe("prepareEmbeddedAttemptBootstrap", () => {
     );
   });
 
+  it("keeps managed-worktree bootstrap on the session checkout only", async () => {
+    // Worktree sessions must not inject shared agent-home AGENTS.md/SOUL.md, or a
+    // rewritten shared file poisons every later worktree prompt.
+    const agentWorkspace = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-home-")),
+    );
+    const worktreeWorkspace = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-worktree-")),
+    );
+    tempDirs.push(agentWorkspace, worktreeWorkspace);
+    await fs.writeFile(path.join(agentWorkspace, "AGENTS.md"), "Shared home instructions");
+    await fs.writeFile(path.join(agentWorkspace, "SOUL.md"), "Shared home soul");
+    await fs.writeFile(path.join(worktreeWorkspace, "AGENTS.md"), "Worktree instructions");
+    await fs.writeFile(path.join(worktreeWorkspace, "SOUL.md"), "Worktree soul");
+
+    const result = await prepareEmbeddedAttemptBootstrap({
+      attempt: {
+        sessionId: "session-1",
+        sessionKey: "agent:main:dashboard:worktree",
+        trigger: "user",
+        isCanonicalWorkspace: false,
+        config: { agents: { defaults: { workspace: agentWorkspace } } },
+      } as EmbeddedRunAttemptParams,
+      bootstrapWorkspaceDir: worktreeWorkspace,
+      effectiveWorkspace: worktreeWorkspace,
+      hasReadTool: true,
+      isRawModelRun: false,
+      markStage: () => undefined,
+      resolvedWorkspace: worktreeWorkspace,
+      sessionAgentId: "main",
+      sessionLabel: "agent:main:dashboard:worktree",
+    });
+
+    expect(result.contextFiles).toContainEqual(
+      expect.objectContaining({
+        path: path.join(worktreeWorkspace, "AGENTS.md"),
+        content: "Worktree instructions",
+      }),
+    );
+    expect(result.contextFiles).toContainEqual(
+      expect.objectContaining({
+        path: path.join(worktreeWorkspace, "SOUL.md"),
+        content: "Worktree soul",
+      }),
+    );
+    expect(result.contextFiles).not.toContainEqual(
+      expect.objectContaining({ path: path.join(agentWorkspace, "AGENTS.md") }),
+    );
+    expect(result.contextFiles).not.toContainEqual(
+      expect.objectContaining({ path: path.join(agentWorkspace, "SOUL.md") }),
+    );
+  });
+
   it("keeps same-workspace bootstrap output byte-identical", async () => {
     const workspace = await fs.realpath(
       await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-same-workspace-")),

--- a/src/agents/workspace-run.test.ts
+++ b/src/agents/workspace-run.test.ts
@@ -3,9 +3,40 @@
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveRunWorkspaceDir } from "./workspace-run.js";
+import { resolveRunBootstrapWorkspaceDir, resolveRunWorkspaceDir } from "./workspace-run.js";
 
 vi.unmock("./agent-scope-config.js");
+
+describe("resolveRunBootstrapWorkspaceDir", () => {
+  it("keeps canonical bootstrap when the run is not a managed worktree", () => {
+    expect(
+      resolveRunBootstrapWorkspaceDir({
+        canonicalWorkspaceDir: "/home/user/.openclaw/workspace",
+        sessionWorkspaceDir: "/home/user/.openclaw/workspace",
+      }),
+    ).toBe("/home/user/.openclaw/workspace");
+  });
+
+  it("uses the remounted session workspace when it sits in the managed worktree", () => {
+    expect(
+      resolveRunBootstrapWorkspaceDir({
+        canonicalWorkspaceDir: "/home/user/.openclaw/workspace",
+        sessionWorkspaceDir: "/home/user/.openclaw/worktrees/abc/wt-1/nested",
+        managedWorktreeDir: "/home/user/.openclaw/worktrees/abc/wt-1",
+      }),
+    ).toBe("/home/user/.openclaw/worktrees/abc/wt-1/nested");
+  });
+
+  it("falls back to the managed worktree root when only cwd is bound", () => {
+    expect(
+      resolveRunBootstrapWorkspaceDir({
+        canonicalWorkspaceDir: "/home/user/.openclaw/workspace",
+        sessionWorkspaceDir: "/home/user/.openclaw/workspace",
+        managedWorktreeDir: "/home/user/.openclaw/worktrees/abc/wt-1",
+      }),
+    ).toBe("/home/user/.openclaw/worktrees/abc/wt-1");
+  });
+});
 
 describe("resolveRunWorkspaceDir", () => {
   it("resolves explicit workspace values without fallback", () => {

--- a/src/agents/workspace-run.test.ts
+++ b/src/agents/workspace-run.test.ts
@@ -27,14 +27,16 @@ describe("resolveRunBootstrapWorkspaceDir", () => {
     ).toBe("/home/user/.openclaw/worktrees/abc/wt-1/nested");
   });
 
-  it("falls back to the managed worktree root when only cwd is bound", () => {
+  it("keeps canonical bootstrap when only cwd would bind a worktree", () => {
+    // Isolation: a canonical session must not inherit worktree AGENTS.md just
+    // because exec/cwd happens to sit inside a managed checkout.
     expect(
       resolveRunBootstrapWorkspaceDir({
         canonicalWorkspaceDir: "/home/user/.openclaw/workspace",
         sessionWorkspaceDir: "/home/user/.openclaw/workspace",
         managedWorktreeDir: "/home/user/.openclaw/worktrees/abc/wt-1",
       }),
-    ).toBe("/home/user/.openclaw/worktrees/abc/wt-1");
+    ).toBe("/home/user/.openclaw/workspace");
   });
 });
 

--- a/src/agents/workspace-run.ts
+++ b/src/agents/workspace-run.ts
@@ -1,8 +1,10 @@
+import path from "node:path";
 /**
  * Agent run workspace resolver.
  *
  * Selects per-run workspace directories and redacts run identifiers for logs/prompts.
  */
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
 import { redactIdentifier } from "../logging/redact-identifier.js";
@@ -154,4 +156,26 @@ export function resolveRunWorkspaceDir(params: {
     agentId,
     agentIdSource,
   };
+}
+
+/**
+ * Choose which directory supplies AGENTS.md / SOUL.md / BOOTSTRAP.md for a run.
+ * Managed worktree sessions must use their checkout so shared agent-home
+ * rewrites cannot poison later worktree prompts.
+ */
+export function resolveRunBootstrapWorkspaceDir(params: {
+  canonicalWorkspaceDir: string;
+  sessionWorkspaceDir: string;
+  managedWorktreeDir?: string | null;
+}): string {
+  const managed = normalizeOptionalString(params.managedWorktreeDir);
+  if (!managed) {
+    return params.canonicalWorkspaceDir;
+  }
+  const session = path.resolve(params.sessionWorkspaceDir);
+  const root = path.resolve(managed);
+  if (session === root || session.startsWith(`${root}${path.sep}`)) {
+    return params.sessionWorkspaceDir;
+  }
+  return managed;
 }

--- a/src/agents/workspace-run.ts
+++ b/src/agents/workspace-run.ts
@@ -160,8 +160,9 @@ export function resolveRunWorkspaceDir(params: {
 
 /**
  * Choose which directory supplies AGENTS.md / SOUL.md / BOOTSTRAP.md for a run.
- * Managed worktree sessions must use their checkout so shared agent-home
- * rewrites cannot poison later worktree prompts.
+ * Managed worktree sessions must use their remounted checkout so shared
+ * agent-home rewrites cannot poison later worktree prompts. A cwd-only
+ * worktree binding must not steal bootstrap away from a canonical session.
  */
 export function resolveRunBootstrapWorkspaceDir(params: {
   canonicalWorkspaceDir: string;
@@ -177,5 +178,5 @@ export function resolveRunBootstrapWorkspaceDir(params: {
   if (session === root || session.startsWith(`${root}${path.sep}`)) {
     return params.sessionWorkspaceDir;
   }
-  return managed;
+  return params.canonicalWorkspaceDir;
 }


### PR DESCRIPTION
Closes #129411
Related: #129404 #129405

## What Problem This Solves

Fixes an issue where managed worktree sessions would inject `AGENTS.md` / `SOUL.md` / `BOOTSTRAP.md` from the shared agent home into the system prompt. After one agent used `exec` to rewrite shared `AGENTS.md`, later worktree sessions inherited the poisoned shared bootstrap and stopped following their own checkout.

## Why This Change Was Made

`runEmbeddedAgent` always passed `bootstrapWorkspaceDir: canonicalWorkspace` even when the session workspace was a managed worktree. Bootstrap loading and prompt file headings therefore stayed on the shared home. This change binds bootstrap to the managed worktree checkout **only when the resolved session workspace itself is remounted inside that worktree**. A cwd-only worktree binding no longer steals bootstrap identity for a still-canonical session.

Related remount work for the Working directory / file-tool root: #129405. This PR owns the bootstrap source separately.

## User Impact

Managed worktree sessions now receive bootstrap context from their own checkout. Rewriting shared `.openclaw/workspace/AGENTS.md` no longer rewrites the injected identity for later worktree sessions. Canonical sessions whose cwd happens to sit inside a managed worktree keep agent-home bootstrap.

## Evidence

### Isolation fix (ClawSweeper P1)

- `resolveWorktreeIdForPath` candidate list is `[resolvedWorkspace]` only (no `params.cwd`).
- `resolveRunBootstrapWorkspaceDir` returns canonical when the session workspace is outside the managed worktree root.
- Regression: canonical session + managed worktree supplied (cwd-only case) keeps `/…/workspace` bootstrap, not `/…/worktrees/…`.

### After-fix redacted selector trace

```json
{
  "scenario_remounted": {
    "sessionWorkspace": "/home/USER/tmp/ID/worktrees/0746a04e/wt-demo",
    "toolWorkspaceRoot": "/home/USER/tmp/ID/worktrees/0746a04e/wt-demo",
    "bootstrapWorkspaceDir": "/home/USER/tmp/ID/worktrees/0746a04e/wt-demo",
    "bootstrapAgentsContent": "WORKTREE_ONLY"
  },
  "scenario_cwd_only_must_stay_canonical": {
    "sessionWorkspace": "/home/USER/tmp/ID/workspace",
    "cwdInsideWorktree": "/home/USER/tmp/ID/worktrees/0746a04e/wt-demo",
    "bootstrapWorkspaceDir": "/home/USER/tmp/ID/workspace",
    "bootstrapAgentsContent": "SHARED_HOME"
  }
}
```

### Focused tests

- `prepareEmbeddedAttemptBootstrap` regression: when `bootstrapWorkspaceDir` is the worktree, injected files are worktree-only and exclude shared home `AGENTS.md`/`SOUL.md`.
- Focused Vitest: `workspace-run` + `attempt-bootstrap-prepare` suites passed (16 + 3) after the isolation fix.