### PR TITLE
fix(matrix): preserve explicit replies when threading is disabled

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -183,9 +183,10 @@ export function createMatrixReplyDispatcher(config: {
           );
         }
 
-        const payloadReplyToId = normalizeOptionalString(payload.replyToId);
         const payloadReplyMismatch =
-          !threadTarget && payloadReplyToId !== draftController.currentReplyToId();
+          !threadTarget &&
+          (replyToMode !== "off" || payload.replyToTag || payload.replyToCurrent) &&
+          normalizeOptionalString(payload.replyToId) !== draftController.currentReplyToId();
         let mustDeliverFinalNormally = draftStream.mustDeliverFinalNormally();
         const canPotentiallyFinalizeDraft =
           Boolean(payload.text?.trim()) &&

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -185,9 +185,7 @@ export function createMatrixReplyDispatcher(config: {
 
         const payloadReplyToId = normalizeOptionalString(payload.replyToId);
         const payloadReplyMismatch =
-          replyToMode !== "off" &&
-          !threadTarget &&
-          payloadReplyToId !== draftController.currentReplyToId();
+          !threadTarget && payloadReplyToId !== draftController.currentReplyToId();
         let mustDeliverFinalNormally = draftStream.mustDeliverFinalNormally();
         const canPotentiallyFinalizeDraft =
           Boolean(payload.text?.trim()) &&

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -4785,6 +4785,24 @@ describe("matrix monitor handler draft streaming", () => {
     },
   );
 
+  it("finalizes the existing draft when an implicit reply is suppressed by off mode", async () => {
+    const { dispatch, redactEventMock } = createStreamingHarness({ replyToMode: "off" });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Partial reply" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+
+    deliverMatrixRepliesMock.mockClear();
+    await deliver({ text: "Final text", replyToId: "$suppressed_implicit" }, { kind: "final" });
+
+    expect(editMessageMatrixMock).toHaveBeenCalledOnce();
+    expect(redactEventMock).not.toHaveBeenCalled();
+    expect(deliverMatrixRepliesMock).not.toHaveBeenCalled();
+    await finish();
+  });
+
   it("redacts stale draft when final payload intentionally drops reply threading", async () => {
     const { dispatch, redactEventMock } = createStreamingHarness({ replyToMode: "first" });
     const { deliver, opts, finish } = await dispatch();

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -4749,27 +4749,41 @@ describe("matrix monitor handler draft streaming", () => {
     await finish();
   });
 
-  it("redacts stale draft when payload reply target mismatches", async () => {
-    const { dispatch, redactEventMock } = createStreamingHarness({ replyToMode: "first" });
-    const { deliver, opts, finish } = await dispatch();
+  it.each([
+    {
+      name: "an implicit reply with reply mode first",
+      replyToMode: "first" as const,
+      payload: { text: "Final text", replyToId: "$different_msg" },
+    },
+    {
+      name: "an explicit reply tag with reply mode off",
+      replyToMode: "off" as const,
+      payload: { text: "Final text", replyToId: "$different_msg", replyToTag: true },
+    },
+  ])(
+    "redacts stale draft when $name targets a different event",
+    async ({ replyToMode, payload }) => {
+      const { dispatch, redactEventMock } = createStreamingHarness({ replyToMode });
+      const { deliver, opts, finish } = await dispatch();
 
-    // Simulate streaming: partial reply creates draft message.
-    opts.onPartialReply?.({ text: "Partial reply" });
-    await waitForMatrixState(() => {
-      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
-    });
+      // Simulate streaming: partial reply creates draft message.
+      opts.onPartialReply?.({ text: "Partial reply" });
+      await waitForMatrixState(() => {
+        expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+      });
 
-    // Final delivery carries a different replyToId than the draft's.
-    deliverMatrixRepliesMock.mockClear();
-    await deliver({ text: "Final text", replyToId: "$different_msg" }, { kind: "final" });
+      // Final delivery carries a different replyToId than the draft's.
+      deliverMatrixRepliesMock.mockClear();
+      await deliver(payload, { kind: "final" });
 
-    expect(editMessageMatrixMock).not.toHaveBeenCalled();
-    // Draft should be redacted since it can't change reply relation.
-    expect(redactEventMock).toHaveBeenCalledWith("!room:example.org", "$draft1");
-    // Final answer delivered via normal path.
-    expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
-    await finish();
-  });
+      expect(editMessageMatrixMock).not.toHaveBeenCalled();
+      // Draft should be redacted since it can't change reply relation.
+      expect(redactEventMock).toHaveBeenCalledWith("!room:example.org", "$draft1");
+      // Final answer delivered via normal path.
+      expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
+      await finish();
+    },
+  );
 
   it("redacts stale draft when final payload intentionally drops reply threading", async () => {
     const { dispatch, redactEventMock } = createStreamingHarness({ replyToMode: "first" });

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -82,6 +82,7 @@ describe("deliverMatrixReplies", () => {
     channel: {
       text: {
         resolveMarkdownTableMode: (params: unknown) => resolveMarkdownTableModeMock(params),
+        resolveTextChunkLimit: () => 4000,
         convertMarkdownTables: (text: string) => convertMarkdownTablesMock(text),
         resolveChunkMode: (cfgLocal: unknown, channel: unknown, accountId?: unknown) =>
           resolveChunkModeMock(cfgLocal, channel, accountId),
@@ -111,6 +112,82 @@ describe("deliverMatrixReplies", () => {
       chunks: text ? [text] : [],
     }));
   });
+
+  const offModeReplyCases: Array<{
+    name: string;
+    reply: Parameters<typeof deliverMatrixReplies>[0]["replies"][number];
+    expectedReplyToId?: string;
+    threadId?: string;
+  }> = [
+    {
+      name: "an explicit reply tag",
+      reply: { text: "hello", replyToId: "$chosen", replyToTag: true },
+      expectedReplyToId: "$chosen",
+    },
+    {
+      name: "an explicit current-message reply",
+      reply: { text: "hello", replyToId: "$chosen", replyToCurrent: true },
+      expectedReplyToId: "$chosen",
+    },
+    {
+      name: "an implicit payload reply",
+      reply: { text: "hello", replyToId: "$implicit" },
+    },
+    {
+      name: "an ambient implicit reply",
+      reply: { text: "hello" },
+    },
+    {
+      name: "a status notice whose explicit reply was stripped upstream",
+      reply: { text: "hello", replyToCurrent: true, isCompactionNotice: true },
+    },
+    {
+      name: "a thread's ambient fallback reply",
+      reply: { text: "hello" },
+      expectedReplyToId: "$ambient",
+      threadId: "$thread",
+    },
+  ];
+
+  it.each(offModeReplyCases)(
+    "encodes the actual Matrix provider reply relation for $name when replyToMode=off",
+    async ({ reply, expectedReplyToId, threadId }) => {
+      const actualSend = await vi.importActual<typeof import("../send.js")>("../send.js");
+      sendMessageMatrixMock.mockImplementation(actualSend.sendMessageMatrix);
+      const sendMessage = vi.fn(
+        async (_roomId: string, _content: Record<string, unknown>) => "$sent",
+      );
+      const client = {
+        sendMessage,
+        prepareRoomForMessageSend: async () => "m.room.message",
+        getJoinedRoomMembers: async () => [],
+        getUserId: async () => "@bot:example.org",
+      } as unknown as MatrixClient;
+
+      const result = await deliverMatrixReplies({
+        cfg,
+        replies: [reply],
+        roomId: "!room:example.org",
+        client,
+        runtime: runtimeEnv,
+        textLimit: 4000,
+        replyToMode: "off",
+        replyToId: "$ambient",
+        threadId,
+      });
+
+      expect(result.visibleReplySent).toBe(true);
+      expect(sendMessage).toHaveBeenCalledOnce();
+      const content = sendMessage.mock.calls[0]?.[1];
+      const relation = content?.["m.relates_to"] as
+        | { "m.in_reply_to"?: { event_id?: string }; event_id?: string }
+        | undefined;
+      expect(relation?.["m.in_reply_to"]?.event_id).toBe(expectedReplyToId);
+      if (threadId) {
+        expect(relation?.event_id).toBe(threadId);
+      }
+    },
+  );
 
   it("keeps replyToId on first reply only when replyToMode=first", async () => {
     chunkMatrixTextMock.mockImplementation((text: string) => ({

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -250,6 +250,50 @@ describe("deliverMatrixReplies", () => {
     expect(hasRepliedRef.value).toBe(true);
   });
 
+  it.each(["first", "off"] as const)(
+    "preserves explicit replies after shared reply state is consumed when replyToMode=%s",
+    async (replyToMode) => {
+      const hasRepliedRef = { value: false };
+      const delivery = {
+        cfg,
+        roomId: "room:1",
+        client: {} as MatrixClient,
+        runtime: runtimeEnv,
+        textLimit: 4000,
+        replyToMode,
+        replyToId: "ambient-reply",
+        hasRepliedRef,
+      };
+
+      await deliverMatrixReplies({
+        ...delivery,
+        replies: [
+          {
+            text: "consume implicit slot",
+            replyToId: "first-reply",
+            ...(replyToMode === "off" ? { replyToTag: true } : {}),
+          },
+        ],
+      });
+      await deliverMatrixReplies({
+        ...delivery,
+        replies: [{ text: "explicit tag", replyToId: "tag-reply", replyToTag: true }],
+      });
+      await deliverMatrixReplies({
+        ...delivery,
+        replies: [{ text: "explicit current", replyToId: "current-reply", replyToCurrent: true }],
+      });
+      await deliverMatrixReplies({ ...delivery, replies: [{ text: "implicit follow-up" }] });
+
+      expect(hasRepliedRef.value).toBe(true);
+      expect(sendMessageMatrixMock).toHaveBeenCalledTimes(4);
+      expect(sendOptions(0).replyToId).toBe("first-reply");
+      expect(sendOptions(1).replyToId).toBe("tag-reply");
+      expect(sendOptions(2).replyToId).toBe("current-reply");
+      expect(sendOptions(3).replyToId).toBeUndefined();
+    },
+  );
+
   it("does not consume the first reply when Matrix delivery fails", async () => {
     const hasRepliedRef = { value: false };
     const delivery = {

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -153,12 +153,12 @@ export async function deliverMatrixReplies(params: {
         params.runtime.error?.("matrix reply missing text/media");
         continue;
       }
+      const explicitReplyToId =
+        reply.replyToTag || reply.replyToCurrent ? reply.replyToId?.trim() : undefined;
       const replyToId =
         params.threadId || params.replyToMode !== "off"
           ? (reply.replyToId ?? params.replyToId)?.trim()
-          : reply.replyToTag || reply.replyToCurrent
-            ? reply.replyToId?.trim()
-            : undefined;
+          : explicitReplyToId;
       const rawText = visibleText ?? "";
       const mediaList = reply.mediaUrls?.length
         ? reply.mediaUrls
@@ -166,9 +166,11 @@ export async function deliverMatrixReplies(params: {
           ? [reply.mediaUrl]
           : [];
 
-      const shouldIncludeReply = (id?: string) =>
-        Boolean(id) && (params.threadId || params.replyToMode === "all" || !hasRepliedRef.value);
-      const replyToIdForReply = shouldIncludeReply(replyToId) ? replyToId : undefined;
+      const replyToIdForReply =
+        explicitReplyToId ||
+        (params.threadId || params.replyToMode === "all" || !hasRepliedRef.value
+          ? replyToId
+          : undefined);
       const onDeliveryResult = (result: MatrixSendResult) => {
         // A concrete event consumes the first-reply slot even when a later event fails.
         acceptedResults.push(result);

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -155,10 +155,6 @@ export async function deliverMatrixReplies(params: {
       }
       const explicitReplyToId =
         reply.replyToTag || reply.replyToCurrent ? reply.replyToId?.trim() : undefined;
-      const replyToId =
-        params.threadId || params.replyToMode !== "off"
-          ? (reply.replyToId ?? params.replyToId)?.trim()
-          : explicitReplyToId;
       const rawText = visibleText ?? "";
       const mediaList = reply.mediaUrls?.length
         ? reply.mediaUrls
@@ -168,8 +164,9 @@ export async function deliverMatrixReplies(params: {
 
       const replyToIdForReply =
         explicitReplyToId ||
-        (params.threadId || params.replyToMode === "all" || !hasRepliedRef.value
-          ? replyToId
+        (params.threadId ||
+        (params.replyToMode !== "off" && (params.replyToMode === "all" || !hasRepliedRef.value))
+          ? (reply.replyToId ?? params.replyToId)?.trim()
           : undefined);
       const onDeliveryResult = (result: MatrixSendResult) => {
         // A concrete event consumes the first-reply slot even when a later event fails.

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -153,12 +153,12 @@ export async function deliverMatrixReplies(params: {
         params.runtime.error?.("matrix reply missing text/media");
         continue;
       }
-      const replyToIdRaw = (reply.replyToId ?? params.replyToId)?.trim();
-      const replyToId = params.threadId
-        ? replyToIdRaw
-        : params.replyToMode === "off"
-          ? undefined
-          : replyToIdRaw;
+      const replyToId =
+        params.threadId || params.replyToMode !== "off"
+          ? (reply.replyToId ?? params.replyToId)?.trim()
+          : reply.replyToTag || reply.replyToCurrent
+            ? reply.replyToId?.trim()
+            : undefined;
       const rawText = visibleText ?? "";
       const mediaList = reply.mediaUrls?.length
         ? reply.mediaUrls


### PR DESCRIPTION
## Summary

Honor explicitly requested Matrix replies even when automatic reply threading is disabled or an earlier delivery has already consumed the implicit first-reply slot.

## Root cause

The default Matrix delivery owner discarded every reply target in `replyToMode: off`, including explicit current-message and message-ID tags required by the shared reply contract. Its shared first-reply state also suppressed later explicit targets. The optional streaming owner separately compared raw payload IDs instead of their effective Matrix relations, both missing explicit mismatches and incorrectly discarding compatible drafts for suppressed implicit replies.

Derive actual explicit and implicit reply eligibility at the canonical delivery and streaming owners. Preserve explicitly requested targets across shared delivery state, keep ordinary first/off-mode implicit suppression, reconcile genuinely mismatched drafts, and finalize compatible implicit-off drafts without needless redaction. Never revive implicit ambient targets or stripped status/compaction notices.

## Validation

- Authentic pre-fix Matrix-client provider payloads lacked `m.relates_to.m.in_reply_to` for explicit current-message and message-ID tags.
- The first ClawSweeper finding exposed a second explicit reply lost after an earlier delivery; authentic ordered `first` and `off` mode regressions now prove explicit replies survive consumed shared state while subsequent implicit replies remain suppressed.
- A fresh independent full-branch review exposed an off-mode streaming draft incorrectly redacted for a suppressed implicit ID; a real dispatcher regression now proves compatible drafts finalize in place while truly mismatched explicit drafts are replaced.
- **295 direct delivery, handler, send, and outbound tests passed**, including the authentic ordered delivery and streaming regressions.
- Direct installed `matrix-js-sdk` source confirms the exact native reply relation contract.
- Formatting, targeted type-aware lint, and a final independent full-branch review passed with no P0/P1 findings.
- Production delta: **+10/-12, net -2**; tests are separate.
