### PR TITLE
fix(nodes): keep a container-isolated worker running while its container starts

### DIFF
--- a/src/node-host/node-worker-container-engine.ts
+++ b/src/node-host/node-worker-container-engine.ts
@@ -33,6 +33,12 @@ const LAUNCH_LABEL = "openclaw.node-worker.launch";
 const CONTAINER_NODE_EXECUTABLE = "node";
 const CONTAINER_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const CONTAINER_ID_PATTERN = /^[a-f0-9]{64}$/u;
+// `.State.Running` is false for a container that has never started and for one
+// that already exited; collapsing the two hands a container the engine is still
+// starting to the terminal path, so `.State.Status` disambiguates it. Podman
+// spells its pre-start states `configured`/`initialized`, Docker `created`.
+const CONTAINER_PRESTART_STATUSES = new Set(["configured", "created", "initialized"]);
+const CONTAINER_STATE_FORMAT = "{{.State.Status}}\t{{.State.Running}}";
 const ENCODED_LAUNCH_PATTERN = /^[A-Za-z0-9_-]+$/u;
 
 function hostNamespace(bundleRoot: string): string {
@@ -340,11 +346,11 @@ export async function inspectNodeWorkerContainer(
   engine: NodeWorkerContainerEngine,
   containerId: string,
   expected?: NodeWorkerContainerExpectedOwner,
-): Promise<"live" | "dead" | "reused" | "unknown"> {
+): Promise<"live" | "created" | "dead" | "reused" | "unknown"> {
   try {
     const format = expected
-      ? `{{.State.Running}}\t{{index .Config.Labels "${HOST_LABEL}"}}\t{{index .Config.Labels "${GATEWAY_LABEL}"}}\t{{index .Config.Labels "${LAUNCH_LABEL}"}}`
-      : "{{.State.Running}}";
+      ? `${CONTAINER_STATE_FORMAT}\t{{index .Config.Labels "${HOST_LABEL}"}}\t{{index .Config.Labels "${GATEWAY_LABEL}"}}\t{{index .Config.Labels "${LAUNCH_LABEL}"}}`
+      : CONTAINER_STATE_FORMAT;
     const state = await runContainerCommand(engine, [
       "inspect",
       "--type",
@@ -353,7 +359,7 @@ export async function inspectNodeWorkerContainer(
       format,
       containerId,
     ]);
-    const [running, owner, gateway, launch, extra] = state.split("\t");
+    const [status, running, owner, gateway, launch, extra] = state.split("\t");
     if (expected) {
       if (
         extra !== undefined ||
@@ -365,6 +371,9 @@ export async function inspectNodeWorkerContainer(
       }
     } else if (owner !== undefined) {
       return "unknown";
+    }
+    if (CONTAINER_PRESTART_STATUSES.has(status ?? "")) {
+      return "created";
     }
     return running === "true" ? "live" : running === "false" ? "dead" : "unknown";
   } catch (error) {

--- a/src/node-host/node-worker-container-lifecycle.ts
+++ b/src/node-host/node-worker-container-lifecycle.ts
@@ -63,7 +63,7 @@ export class NodeWorkerContainerLifecycle {
   async inspect(
     container: NodeWorkerContainerIdentity,
     owner: NodeWorkerContainerOwner,
-  ): Promise<"live" | "dead" | "reused" | "unknown"> {
+  ): Promise<"live" | "created" | "dead" | "reused" | "unknown"> {
     return await inspectNodeWorkerContainer(
       this.requireMatchingEngine(container),
       container.containerId,

--- a/src/node-host/node-worker-supervisor.container.test.ts
+++ b/src/node-host/node-worker-supervisor.container.test.ts
@@ -147,7 +147,7 @@ if (command === "version") {
   }
   const entry = args.at(-1);
   const image = args.at(-2);
-  const container = { id, labels, env, mounts, image, entry, running: false, pid: null };
+  const container = { id, labels, env, mounts, image, entry, status: "created", pid: null };
   save(container);
   record({ argv: args, container, journal: journalState(launchIdFor(container)) });
   releaseAfterMarker("hold-create", () => process.stdout.write(id + "\n"));
@@ -167,12 +167,18 @@ if (command === "version") {
       process.stderr.write("container worker executed before its exact identity was journaled\n");
       process.exit(67);
     }
+    // Hold the container in its created state until the marker clears, or until
+    // it is removed: a real engine fails a start whose container disappeared.
+    while (fs.existsSync(path.join(engineRoot, "hold-start")) && fs.existsSync(statePath(container.id))) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    readContainer(container.id);
     const child = spawn(process.execPath, [container.entry], {
       detached: process.platform !== "win32",
       env: container.env,
       stdio: ["pipe", "inherit", "inherit"],
     });
-    container.running = true;
+    container.status = "running";
     container.pid = child.pid;
     save(container);
     child.stdin.end(descriptor);
@@ -183,7 +189,7 @@ if (command === "version") {
     child.once("exit", (code, signal) => {
       if (fs.existsSync(statePath(container.id))) {
         const current = load(container.id);
-        current.running = false;
+        current.status = "exited";
         current.pid = null;
         save(current);
       }
@@ -198,7 +204,14 @@ if (command === "version") {
   record({ argv: args });
   const container = readContainer(id);
   const format = args[args.indexOf("--format") + 1];
-  const columns = [String(container.running)];
+  // Render the requested state fields the way the engines do: State.Running is
+  // false for a created container as well as an exited one.
+  const columns = format
+    .split("\t")
+    .filter((field) => field.startsWith("{{.State."))
+    .map((field) =>
+      field === "{{.State.Status}}" ? container.status : String(container.status === "running")
+    );
   if (format.includes("openclaw.node-worker.host")) {
     columns.push(
       container.labels["openclaw.node-worker.host"] ?? "",
@@ -210,11 +223,11 @@ if (command === "version") {
 } else if (command === "kill") {
   const container = readContainer(args.at(-1));
   record({ argv: args, journal: journalState(launchIdFor(container)) });
-  if (!container.running) {
+  if (container.status !== "running") {
     process.stderr.write("container is not running\n");
     process.exit(1);
   }
-  container.running = false;
+  container.status = "exited";
   save(container);
   if (container.pid) {
     try {
@@ -263,7 +276,7 @@ type FakeContainer = {
   mounts: string[];
   image: string;
   entry: string;
-  running: boolean;
+  status: "created" | "running" | "exited";
   pid: number | null;
 };
 
@@ -339,7 +352,12 @@ function containerFixture(
         .split("\n")
         .map((line) => JSON.parse(line) as EngineEvent);
     },
-    seed(params: { id: string; launchId: string; owner?: string; running?: boolean }) {
+    seed(params: {
+      id: string;
+      launchId: string;
+      owner?: string;
+      status?: FakeContainer["status"];
+    }) {
       const container: FakeContainer = {
         id: params.id,
         labels: {
@@ -351,7 +369,7 @@ function containerFixture(
         mounts: [],
         image: "node:22-slim",
         entry: bundleEntry,
-        running: params.running ?? true,
+        status: params.status ?? "running",
         pid: null,
       };
       fs.writeFileSync(
@@ -479,6 +497,26 @@ describe("node worker supervisor container isolation", () => {
         state: "running",
         container_json: JSON.stringify(running.container),
       });
+    } finally {
+      await fixture.supervisor.close();
+    }
+  });
+
+  it("keeps a created container's launch running until the engine starts it", async () => {
+    const fixture = containerFixture();
+    const hold = path.join(fixture.engineRoot, "hold-start");
+    fs.writeFileSync(hold, "");
+    const input = testWorkerLaunchInput(fixture.workspaceDir, "container-created-status");
+    try {
+      const running = await fixture.supervisor.launch(input, endpoint);
+      expect(running.state).toBe("running");
+      const created = await fixture.supervisor.status(input.launchId);
+      expect(created?.state).toBe("running");
+      expect(fixture.exists(running.container!.containerId)).toBe(true);
+      fs.unlinkSync(hold);
+      const completed = await waitForTerminal(fixture.supervisor, input.launchId);
+      expect(completed?.state).toBe("completed");
+      expect(fixture.events().some((event) => event.argv[0] === "rm")).toBe(true);
     } finally {
       await fixture.supervisor.close();
     }
@@ -667,7 +705,7 @@ describe("node worker supervisor container isolation", () => {
   it("interrupts a stale running journal after verifying its dead container identity", async () => {
     const fixture = containerFixture();
     const launchId = "container-dead-recovery";
-    const container = fixture.seed({ id: "c".repeat(64), launchId, running: false });
+    const container = fixture.seed({ id: "c".repeat(64), launchId, status: "exited" });
     claimFixtureLaunch(fixture, launchId, container.id);
 
     try {

--- a/src/node-host/node-worker-supervisor.ts
+++ b/src/node-host/node-worker-supervisor.ts
@@ -217,7 +217,9 @@ class NodeWorkerSupervisor {
         if (inspection === "reused") {
           throw new Error(`node worker launch ${launchId} lost its container ownership`);
         }
-        if (inspection === "live") {
+        // A container the engine has not started yet is not a finished one; only a
+        // dead attach client can fence it, never the terminal-cleanup path below.
+        if (inspection === "live" || inspection === "created") {
           const clientState = inspectNodeWorkerProcessIdentity(active.worker);
           if (clientState !== "dead" && clientState !== "reused") {
             return this.store.get(launchId);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running node-hosted worker sessions with `nodeHost.workerRuns.isolation=container` would see a healthy session die with a `failed` receipt seconds after it started, with no useful error. The session never ran: the node host killed and removed the container it had just launched.

The window is narrow but real, and it is a silent-failure class defect on the isolated-worker path — the run ends with no visible cause. It also surfaced as a flake in `src/node-host/node-worker-supervisor.container.test.ts` on loaded CI shards (for example run 32818483012 attempt 1, `checks-node-compact-large-2`, which passed on attempt 2 with no code change).

## Why This Change Was Made

`inspectNodeWorkerContainer` asked the engine for `{{.State.Running}}` and mapped `false` to `dead`. Both Docker and Podman report `Running=false` for a container that has **never started** as well as one that **already exited**. `NodeWorkerSupervisor.status()` treats `dead` as terminal, so it ran `docker kill` + `docker rm --force` and then recorded the attach client's non-zero exit as a failed run.

The Gateway polls `worker.status.v1` every 250ms (`DEFAULT_POLL_INTERVAL_MS` in `src/gateway/worker-environments/node-launch-adapter.ts`), starting as soon as `launch` returns — and `launch` returns once the descriptor reaches the attach client's stdin, before the daemon has flipped the container to `running`. Any poll landing in that window destroyed the session.

The fix asks for `{{.State.Status}}` alongside `{{.State.Running}}` and reports a not-yet-started container as `created`. `Running` stays the live/dead authority for every other state, so no existing mapping changes. Podman spells its pre-start states `configured`/`initialized` (`libpod/define/containerstate.go`), Docker `created`. `status()` routes `created` through the same attach-client identity check as `live`, so only a dead client can fence a container that never started; `recoverNodeWorkerLaunch` and `cancel` already handled the pre-start case correctly and are unchanged.

Production LOC: +9 net (4 of which are the comment recording the invariant). Tests: +48/-10.

## User Impact

Container-isolated node worker sessions no longer fail at random during startup. Operators on slower or busier container daemons — where the `created` → `running` transition can exceed one status poll — were the most exposed; those sessions now run to completion.

## Evidence

**Live proof against real Docker 29.4.0**, driving `inspectNodeWorkerContainer` through a real container's full lifecycle:

```
post-fix:  created -> created   running -> live   exited -> dead   removed -> dead
pre-fix:   created -> dead      running -> live   exited -> dead   removed -> dead
```

**Regression test**: `keeps a created container's launch running until the engine starts it` holds the container in `created`, calls `supervisor.status()`, and asserts the launch survives and later completes. Against pre-fix production code it fails in 661ms with the exact production symptom:

```
AssertionError: expected 'failed' to be 'running' // Object.is equality
 ❯ src/node-host/node-worker-supervisor.container.test.ts:514:30
```

**Local validation**
- `node scripts/run-vitest.mjs src/node-host/node-worker-supervisor.container.test.ts` — 14 passed
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/node-host` — 41 files, 561 passed / 2 skipped
- `node scripts/check-changed.mjs` — exit 0
- Codex autoreview (`gpt-5.6-sol`, high) — clean, no accepted findings
