### PR TITLE
fix(status): scope doctor hints to active profile and container

### DIFF
--- a/src/commands/status.format.test.ts
+++ b/src/commands/status.format.test.ts
@@ -1,6 +1,12 @@
 // Status format tests cover compact token and prompt-cache display helpers.
 import { describe, expect, it } from "vitest";
-import { formatKTokens, formatPromptCacheCompact, formatTokensCompact } from "./status.format.js";
+import { withEnv } from "../test-utils/env.js";
+import {
+  formatKTokens,
+  formatPromptCacheCompact,
+  formatStatusConfigDiagnosticEntries,
+  formatTokensCompact,
+} from "./status.format.js";
 
 describe("status cache formatting", () => {
   it("formats explicit cache details for verbose status output", () => {
@@ -67,5 +73,27 @@ describe("status cache formatting", () => {
         totalTokens: 21_300,
       }),
     ).toBe("56% hit · read 12k · write 300");
+  });
+});
+
+describe("status config diagnostic formatting", () => {
+  it.each([
+    ["default", undefined, undefined, "openclaw doctor --fix"],
+    ["profile", "work", undefined, "openclaw --profile work doctor --fix"],
+    ["container", undefined, "staging", "openclaw --container staging doctor --fix"],
+    ["container over profile", "work", "staging", "openclaw --container staging doctor --fix"],
+  ])("keeps the %s target in its repair command", (_context, profile, container, command) => {
+    const entries = withEnv({ OPENCLAW_PROFILE: profile, OPENCLAW_CONTAINER_HINT: container }, () =>
+      formatStatusConfigDiagnosticEntries({
+        path: "/tmp/openclaw.json",
+        issues: [{ path: "gateway.port", message: "invalid" }],
+      }),
+    );
+
+    expect(entries).toEqual([
+      "- Config file is invalid: /tmp/openclaw.json",
+      "- gateway.port: invalid",
+      `- Fix: ${command}`,
+    ]);
   });
 });

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -3,6 +3,7 @@
 
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { formatCliCommand } from "../cli/command-format.js";
 import type { BestEffortConfigSnapshot } from "../config/io.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { getSystemdCgroupHygieneSummary } from "../daemon/service-runtime.js";
@@ -15,15 +16,13 @@ export { shortenText } from "./text-format.js";
 export const formatKTokens = formatTokenCount;
 
 /** Formats the actionable entries shown under status config diagnostic headings. */
-export function formatStatusConfigDiagnosticEntries(
+export const formatStatusConfigDiagnosticEntries = (
   diagnostics: NonNullable<BestEffortConfigSnapshot["configDiagnostics"]>,
-): string[] {
-  return [
-    `- Config file is invalid: ${sanitizeTerminalText(diagnostics.path)}`,
-    ...formatConfigIssueLines(diagnostics.issues, "-", { normalizeRoot: true }),
-    "- Fix: openclaw doctor --fix",
-  ];
-}
+): string[] => [
+  `- Config file is invalid: ${sanitizeTerminalText(diagnostics.path)}`,
+  ...formatConfigIssueLines(diagnostics.issues, "-", { normalizeRoot: true }),
+  `- Fix: ${formatCliCommand("openclaw doctor --fix")}`,
+];
 
 /** Formats a duration or returns `unknown` for missing/non-finite values. */
 export const formatDuration = (ms: number | null | undefined) => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1148,7 +1148,7 @@ describe("statusCommand", () => {
       expect(output).toContain("Config diagnostics:");
       expect(output).toContain("Config file is invalid: /tmp/openclaw.json");
       expect(output).toContain("gateway.port: Invalid input: expected number, received string");
-      expect(output).toContain("Fix: openclaw doctor --fix");
+      expect(output).toContain("Fix: openclaw --profile isolated doctor --fix");
     }
 
     expect((await runStatusAndGetLogs()).join("\n")).not.toContain("Config diagnostics:");


### PR DESCRIPTION
## Summary

Preserve the active profile or container in invalid-configuration recovery commands printed by `openclaw status` and `openclaw status --all`.

## Root cause

Both status renderers shared a hardcoded `openclaw doctor --fix` recovery hint. Under a named profile or container, copying that command repaired the wrong installation instead of the configuration being reported.

Format the command through the existing canonical context-aware CLI owner and simplify the small shared status formatter. Update the real integration expectation to honor its existing suite-wide `isolated` profile.

## Validation

- Genuine shared-owner regression failed for profile/container contexts before repair.
- All 109 full status, status-all, shared formatter, and CLI profile tests passed, including default, profile, container, and container-over-profile precedence.
- Formatting, type-aware lint, and independent autoreview passed.
- Production delta: +7/-8, net -1.
