### PR TITLE
fix(plugins): replace stale source entries without breaking runtime order

### DIFF
--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -243,23 +243,54 @@ describe("plugin authoring commands", () => {
     ).toEqual([]);
   });
 
-  it("aligns package metadata with the selected runtime extension entry", () => {
-    expect(
-      buildToolPluginPackageManifest({
-        packageManifest: {
-          name: "demo",
-          openclaw: { setupEntry: "./setup.ts", extensions: ["./src/other.ts"] },
-        },
-        entry: "./src/index.ts",
-      }),
-    ).toEqual({
-      name: "demo",
-      openclaw: {
+  it.each([
+    {
+      name: "preserves a distinct existing entry",
+      extensions: ["./src/other.ts"],
+      expected: ["./src/other.ts", "./dist/index.js"],
+    },
+    {
+      name: "replaces the source entry with its compiled runtime entry",
+      extensions: ["./src/index.ts"],
+      expected: ["./dist/index.js"],
+    },
+    {
+      name: "preserves positional runtime metadata for sibling entries",
+      extensions: ["./src/index.ts", "./src/other.ts"],
+      runtimeExtensions: ["./dist/index.js", "./dist/other.js"],
+      expected: ["./dist/index.js", "./src/other.ts"],
+    },
+    {
+      name: "keeps an existing compiled runtime entry stable",
+      extensions: ["./dist/index.js", "./src/other.ts"],
+      runtimeExtensions: ["./dist/index.js", "./dist/other.js"],
+      expected: ["./dist/index.js", "./src/other.ts"],
+    },
+  ])(
+    "aligns package metadata with the selected entry: $name",
+    ({ extensions, runtimeExtensions, expected }) => {
+      const existingOpenClaw = {
         setupEntry: "./setup.ts",
-        extensions: ["./src/other.ts", "./src/index.ts"],
-      },
-    });
-  });
+        extensions,
+        ...(runtimeExtensions ? { runtimeExtensions } : {}),
+      };
+      expect(
+        buildToolPluginPackageManifest({
+          packageManifest: {
+            name: "demo",
+            openclaw: existingOpenClaw,
+          },
+          entry: "./dist/index.js",
+        }),
+      ).toEqual({
+        name: "demo",
+        openclaw: {
+          ...existingOpenClaw,
+          extensions: expected,
+        },
+      });
+    },
+  );
 
   it("validates manifest tools and package entry metadata", () => {
     const metadata = createDemoMetadata();

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { jsonSchemaValuesEqual } from "@openclaw/normalization-core/json-schema";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { filterStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { formatCwdRelativePathOrAbsolute as formatOutputPath } from "../infra/safe-cwd.js";
 import { getToolPluginMetadata, type ToolPluginMetadata } from "../plugin-sdk/tool-plugin.js";
 import {
@@ -222,10 +222,8 @@ export function buildToolPluginPackageManifest(params: {
     !Array.isArray(params.packageManifest.openclaw)
       ? { ...(params.packageManifest.openclaw as JsonObject) }
       : {};
-  const existingExtensions = Array.isArray(openclaw.extensions)
-    ? openclaw.extensions.filter((entry): entry is string => typeof entry === "string")
-    : [];
-  const extensions = uniqueStrings([...existingExtensions, params.entry]);
+  const entries = [...filterStringEntries(openclaw.extensions), params.entry];
+  const extensions = [...new Map(entries.map((entry) => [path.parse(entry).name, entry])).values()];
   return {
     ...params.packageManifest,
     openclaw: {


### PR DESCRIPTION
## Summary

Replace stale plugin source entrypoints when selecting compiled runtime entries, preserving multi-plugin runtime order.

## Root cause

The plugin authoring owner appended `dist/index.js` beside an existing `src/index.ts`. Both entries derive the same plugin identifier; discovery rejects the collision, and packages with `runtimeExtensions` also fail installation because source/runtime entry counts no longer match. The authoring validator incorrectly reported these broken packages as valid.

Deduplicate by the existing derived basename identity while preserving first insertion position and the newest selected entry. Genuine unrelated plugin entries and positional runtime mappings remain intact.

## Validation

- Two producer regressions and the actual plugin installer rejected generated packages before repair.
- All 28 authoring, 47 manifest-contract, and nine real installation tests passed.
- Actual generated package now contains the aligned compiled entry and passes the real installer.
- Formatting, targeted lint, and independent autoreview passed.
- Production delta: +3/-5, net -2.
