### PR TITLE
test: add comparator to Doctor profile sort

### DIFF
--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -176,10 +176,9 @@ describe("noteAuthProfileHealth", () => {
       } as OpenClawConfig,
     });
 
-    expect(findings.map((finding) => finding.target).toSorted()).toEqual([
-      "anthropic:custom-cli",
-      "anthropic:static-cli",
-    ]);
+    expect(
+      findings.map((finding) => finding.target).toSorted((a, b) => a.localeCompare(b)),
+    ).toEqual(["anthropic:custom-cli", "anthropic:static-cli"]);
   });
 
   it("still warns once a custom Claude CLI access token is expired", async () => {

--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -177,7 +177,9 @@ describe("noteAuthProfileHealth", () => {
     });
 
     expect(
-      findings.map((finding) => finding.target).toSorted((a, b) => a.localeCompare(b)),
+      findings
+        .map((finding) => finding.target)
+        .toSorted((a, b) => String(a).localeCompare(String(b))),
     ).toEqual(["anthropic:custom-cli", "anthropic:static-cli"]);
   });
 


### PR DESCRIPTION
## Summary

Sort Doctor auth profile finding targets with an explicit lexical comparator.

## Root Cause

The retired Claude fixture cleanup in #129375 changed this assertion to `toSorted()` without a comparator. That violates the repository's required explicit-sort contract.

## Verification

- 23 Doctor profile-health tests
- oxlint on the changed file
- formatting
- `git diff --check`
- autoreview
