### PR TITLE
fix(compaction): summarize the prepared window and always restore audited identifiers

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1673,7 +1673,7 @@ src/agents/agent-bundle-mcp-runtime-shared.ts	2
 src/agents/agent-bundle-mcp-runtime.ts	9
 src/agents/agent-command-restart-recovery.ts	3
 src/agents/agent-command.ts	1
-src/agents/agent-hooks/compaction-safeguard.ts	19
+src/agents/agent-hooks/compaction-safeguard.ts	14
 src/agents/agent-model-discovery.ts	5
 src/agents/agent-project-settings-snapshot.ts	5
 src/agents/agent-run-terminal-delivery.ts	1

--- a/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
@@ -306,6 +306,36 @@ describe("OpenAI ChatGPT Responses inference streaming", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("classifies a direct HTTP rejection as a provider failure without logging its text", async () => {
+    const logWarn = vi.fn();
+    configureAiTransportHost({ logWarn });
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { message: "hostile prompt echo in a 400 body", code: "invalid_request" },
+        }),
+        { status: 400, statusText: "Bad Request" },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await streamOpenAICodexResponses(model, context, {
+      apiKey: createJwt({
+        "https://api.openai.com/auth": { chatgpt_account_id: "acct-1" },
+      }),
+      transport: "sse",
+    }).result();
+
+    expect(result.stopReason).toBe("error");
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    const logged = logWarn.mock.calls[0]?.[2];
+    expect(logged).toMatchObject({ stopReason: "error", failureKind: "provider-failure" });
+    const serialized = JSON.stringify(logged);
+    for (const hostile of ["hostile", "invalid_request", "400 body"]) {
+      expect(serialized).not.toContain(hostile);
+    }
+  });
+
   it.each(["sse", "websocket"] as const)(
     "preserves failed response identity and provider error details over %s",
     async (transport) => {

--- a/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
@@ -296,7 +296,7 @@ describe("OpenAI ChatGPT Responses inference streaming", () => {
       {
         api: "openai-chatgpt-responses",
         elapsedMs: expect.any(Number),
-        errorName: "Error",
+        failureKind: "caller-abort",
         model: "gpt-5.6-luna",
         provider: "openai",
         stopReason: "aborted",
@@ -314,7 +314,11 @@ describe("OpenAI ChatGPT Responses inference streaming", () => {
         response: {
           id: "resp_failed",
           status: "failed",
-          error: { code: "invalid_prompt", message: "rejected" },
+          error: {
+            code: "invalid_prompt",
+            type: "hostile type: user prompt echoed here",
+            message: "rejected",
+          },
         },
       };
       const logWarn = vi.fn();
@@ -373,13 +377,19 @@ describe("OpenAI ChatGPT Responses inference streaming", () => {
       // log keeps timing and classification and never the message body.
       expect(logWarn).toHaveBeenCalledTimes(1);
       const logged = logWarn.mock.calls[0]?.[2];
-      expect(logged).toMatchObject({
+      expect(logged).toEqual({
+        api: "openai-chatgpt-responses",
+        elapsedMs: expect.any(Number),
+        failureKind: "provider-failure",
+        model: "gpt-5.6-luna",
+        provider: "openai",
         stopReason: "error",
-        errorName: "ResponsesStreamFailure",
         transport,
       });
-      expect(logged).not.toHaveProperty("errorMessage");
-      expect(JSON.stringify(logged)).not.toContain("rejected");
+      const serialized = JSON.stringify(logged);
+      for (const hostile of ["rejected", "invalid_prompt", "hostile type", "echoed"]) {
+        expect(serialized).not.toContain(hostile);
+      }
       if (transport === "websocket") {
         expect(fetchMock).not.toHaveBeenCalled();
       }

--- a/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
@@ -296,7 +296,7 @@ describe("OpenAI ChatGPT Responses inference streaming", () => {
       {
         api: "openai-chatgpt-responses",
         elapsedMs: expect.any(Number),
-        errorMessage: "Compaction timed out",
+        errorName: "Error",
         model: "gpt-5.6-luna",
         provider: "openai",
         stopReason: "aborted",
@@ -317,6 +317,8 @@ describe("OpenAI ChatGPT Responses inference streaming", () => {
           error: { code: "invalid_prompt", message: "rejected" },
         },
       };
+      const logWarn = vi.fn();
+      configureAiTransportHost({ logWarn });
       const fetchMock = vi.fn();
       vi.stubGlobal("fetch", fetchMock);
 
@@ -367,6 +369,17 @@ describe("OpenAI ChatGPT Responses inference streaming", () => {
           errorMessage: "invalid_prompt: rejected",
         },
       });
+      // Provider message text reaches the stream consumer only; the transport
+      // log keeps timing and classification and never the message body.
+      expect(logWarn).toHaveBeenCalledTimes(1);
+      const logged = logWarn.mock.calls[0]?.[2];
+      expect(logged).toMatchObject({
+        stopReason: "error",
+        errorName: "ResponsesStreamFailure",
+        transport,
+      });
+      expect(logged).not.toHaveProperty("errorMessage");
+      expect(JSON.stringify(logged)).not.toContain("rejected");
       if (transport === "websocket") {
         expect(fetchMock).not.toHaveBeenCalled();
       }

--- a/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
@@ -262,6 +262,50 @@ describe("OpenAI ChatGPT Responses inference streaming", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("logs the caller abort reason with bounded ChatGPT transport metadata", async () => {
+    const logWarn = vi.fn();
+    configureAiTransportHost({ logWarn });
+    const controller = new AbortController();
+    class AbortedWebSocket extends EventTarget {
+      constructor() {
+        super();
+        queueMicrotask(() => this.dispatchEvent(new Event("open")));
+      }
+
+      send(): void {
+        controller.abort(new Error("Compaction timed out"));
+      }
+
+      close(): void {}
+    }
+    vi.stubGlobal("WebSocket", AbortedWebSocket);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await streamOpenAICodexResponses(model, context, {
+      apiKey: createJwt({
+        "https://api.openai.com/auth": { chatgpt_account_id: "acct-1" },
+      }),
+      signal: controller.signal,
+    }).result();
+
+    expect(result).toMatchObject({ stopReason: "aborted", errorMessage: "Request was aborted" });
+    expect(logWarn).toHaveBeenCalledWith(
+      "openai-transport",
+      "ChatGPT Responses stream terminated",
+      {
+        api: "openai-chatgpt-responses",
+        elapsedMs: expect.any(Number),
+        errorMessage: "Compaction timed out",
+        model: "gpt-5.6-luna",
+        provider: "openai",
+        stopReason: "aborted",
+        transport: "auto",
+      },
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it.each(["sse", "websocket"] as const)(
     "preserves failed response identity and provider error details over %s",
     async (transport) => {

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -257,7 +257,10 @@ function classifyStreamFailure(
   if (signal?.aborted) {
     return "caller-abort";
   }
-  return error instanceof ResponsesStreamFailure ? "provider-failure" : "transport";
+  // CodexApiError carries a non-OK HTTP reply; both are provider decisions, not transport faults.
+  return error instanceof ResponsesStreamFailure || error instanceof CodexApiError
+    ? "provider-failure"
+    : "transport";
 }
 
 function formatRequestTimeoutError(timeoutMs: number, cause: unknown): Error {

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -6,6 +6,7 @@ import {
   resolveTimerTimeoutMs,
   clampTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type {
   Tool as OpenAITool,
   ResponseCreateParamsStreaming,
@@ -288,6 +289,7 @@ export const streamOpenAICodexResponses: StreamFunction<
   const stream = new AssistantMessageEventStream();
 
   void (async () => {
+    const startedAt = Date.now();
     let requestTimeoutMs: number | undefined;
     let requestTimeoutSignal: AbortSignal | undefined;
     let activeSignal: AbortSignal | undefined;
@@ -631,6 +633,22 @@ export const streamOpenAICodexResponses: StreamFunction<
         delete (block as { partialJson?: string }).partialJson;
       }
       const terminal = projectProviderError(normalizedError, options?.signal);
+      const diagnostic = projectProviderError(
+        options?.signal?.aborted && options.signal.reason !== undefined
+          ? options.signal.reason
+          : normalizedError,
+        options?.signal,
+      );
+      // Record only bounded transport metadata; never request or response content.
+      getAiTransportHost().logWarn("openai-transport", "ChatGPT Responses stream terminated", {
+        provider: model.provider,
+        api: model.api,
+        model: model.id,
+        transport: options?.transport || "auto",
+        elapsedMs: Math.max(0, Date.now() - startedAt),
+        stopReason: diagnostic.stopReason,
+        errorMessage: truncateUtf16Safe(diagnostic.errorMessage, 500),
+      });
       Object.assign(output, terminal);
       stream.push({ type: "error", reason: terminal.stopReason, error: output });
       stream.end();

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -6,7 +6,6 @@ import {
   resolveTimerTimeoutMs,
   clampTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type {
   Tool as OpenAITool,
   ResponseCreateParamsStreaming,
@@ -242,6 +241,23 @@ function isRequestTimeoutError(
     error.name === "TimeoutError" ||
     error.message === "Request was aborted"
   );
+}
+
+type StreamFailureKind = "timeout" | "caller-abort" | "provider-failure" | "transport";
+
+/** Local-only failure category for transport diagnostics; never provider text. */
+function classifyStreamFailure(
+  error: unknown,
+  signal: AbortSignal | undefined,
+  requestTimedOut: boolean,
+): StreamFailureKind {
+  if (requestTimedOut) {
+    return "timeout";
+  }
+  if (signal?.aborted) {
+    return "caller-abort";
+  }
+  return error instanceof ResponsesStreamFailure ? "provider-failure" : "transport";
 }
 
 function formatRequestTimeoutError(timeoutMs: number, cause: unknown): Error {
@@ -623,9 +639,11 @@ export const streamOpenAICodexResponses: StreamFunction<
       });
       stream.end();
     } catch (error) {
-      const normalizedError =
+      const requestTimedOut =
         isRequestTimeoutError(error, options?.signal, requestTimeoutSignal, requestTimeoutMs) &&
-        requestTimeoutMs !== undefined
+        requestTimeoutMs !== undefined;
+      const normalizedError =
+        requestTimedOut && requestTimeoutMs !== undefined
           ? formatRequestTimeoutError(requestTimeoutMs, error)
           : error;
       for (const block of output.content) {
@@ -633,26 +651,18 @@ export const streamOpenAICodexResponses: StreamFunction<
         delete (block as { partialJson?: string }).partialJson;
       }
       const terminal = projectProviderError(normalizedError, options?.signal);
-      const diagnosticSource =
-        options?.signal?.aborted && options.signal.reason !== undefined
-          ? options.signal.reason
-          : normalizedError;
-      const diagnostic = projectProviderError(diagnosticSource, options?.signal);
-      // Log only timing, stop classification, and structured codes. The projected
-      // message is excluded: provider message/body text survives redaction and can
-      // carry prompt- or response-derived content.
+      // Log only locally-derived facts: timing and a fixed failure category. No
+      // projected provider field (message, body, code, type, name) is logged —
+      // all of them are provider-controlled text that can carry prompt- or
+      // response-derived content.
       getAiTransportHost().logWarn("openai-transport", "ChatGPT Responses stream terminated", {
         provider: model.provider,
         api: model.api,
         model: model.id,
         transport: options?.transport || "auto",
         elapsedMs: Math.max(0, Date.now() - startedAt),
-        stopReason: diagnostic.stopReason,
-        ...(diagnosticSource instanceof Error
-          ? { errorName: truncateUtf16Safe(diagnosticSource.name, 64) }
-          : {}),
-        ...(diagnostic.errorCode ? { errorCode: diagnostic.errorCode } : {}),
-        ...(diagnostic.errorType ? { errorType: diagnostic.errorType } : {}),
+        stopReason: terminal.stopReason,
+        failureKind: classifyStreamFailure(error, options?.signal, requestTimedOut),
       });
       Object.assign(output, terminal);
       stream.push({ type: "error", reason: terminal.stopReason, error: output });

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -633,13 +633,14 @@ export const streamOpenAICodexResponses: StreamFunction<
         delete (block as { partialJson?: string }).partialJson;
       }
       const terminal = projectProviderError(normalizedError, options?.signal);
-      const diagnostic = projectProviderError(
+      const diagnosticSource =
         options?.signal?.aborted && options.signal.reason !== undefined
           ? options.signal.reason
-          : normalizedError,
-        options?.signal,
-      );
-      // Record only bounded transport metadata; never request or response content.
+          : normalizedError;
+      const diagnostic = projectProviderError(diagnosticSource, options?.signal);
+      // Log only timing, stop classification, and structured codes. The projected
+      // message is excluded: provider message/body text survives redaction and can
+      // carry prompt- or response-derived content.
       getAiTransportHost().logWarn("openai-transport", "ChatGPT Responses stream terminated", {
         provider: model.provider,
         api: model.api,
@@ -647,7 +648,11 @@ export const streamOpenAICodexResponses: StreamFunction<
         transport: options?.transport || "auto",
         elapsedMs: Math.max(0, Date.now() - startedAt),
         stopReason: diagnostic.stopReason,
-        errorMessage: truncateUtf16Safe(diagnostic.errorMessage, 500),
+        ...(diagnosticSource instanceof Error
+          ? { errorName: truncateUtf16Safe(diagnosticSource.name, 64) }
+          : {}),
+        ...(diagnostic.errorCode ? { errorCode: diagnostic.errorCode } : {}),
+        ...(diagnostic.errorType ? { errorType: diagnostic.errorType } : {}),
       });
       Object.assign(output, terminal);
       stream.push({ type: "error", reason: terminal.stopReason, error: output });

--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -100,8 +100,11 @@ function hasRequiredSummarySections(summary: string): boolean {
 
 type SummaryQualityRetentionPlan = {
   minimumChars: number;
-  /** True when the body omits a strict source identifier that render() restores. */
-  restoresIdentifiers: boolean;
+  /**
+   * True when render() must rebuild even a body that fits: a strict source
+   * identifier is missing, or an audit-bearing section exceeds its share cap.
+   */
+  needsRebuild: (maxChars: number) => boolean;
   /** Null when even the protected facts cannot fit `maxChars`. */
   render: (maxChars: number) => { text: string; trimmed: boolean } | null;
 };
@@ -200,24 +203,35 @@ export function createSummaryQualityRetentionPlan(
     marker,
     ...minimumBlocks.slice(QUALITY_PROTECTED_SECTION_START),
   ].join("\n\n");
+  // Audit-bearing sections (pending asks, exact identifiers) are funded first so
+  // a runaway earlier section cannot starve them, but each is hard-capped: an
+  // uncapped identifier list re-distills into the whole budget — even while the
+  // artifact still fits — and leaves every other section as a bare heading.
+  const protectedCapFor = (maxChars: number) =>
+    Math.floor(Math.max(0, maxChars - minimumSummary.length) * MAX_PROTECTED_SECTION_CONTENT_SHARE);
+  const protectedWithinCap = (maxChars: number) =>
+    contents
+      .slice(QUALITY_PROTECTED_SECTION_START)
+      .every((content) => content.length <= protectedCapFor(maxChars));
 
   return {
     minimumChars: minimumSummary.length,
-    restoresIdentifiers: !bodyHasIdentifiers,
+    needsRebuild: (maxChars) => !bodyHasIdentifiers || !protectedWithinCap(maxChars),
     render(maxChars) {
       const bodyHasRequiredAskContext = !requiredAskContext || summary.includes(requiredAskContext);
-      if (summary.length <= maxChars && bodyHasRequiredAskContext && bodyHasIdentifiers) {
+      if (
+        summary.length <= maxChars &&
+        bodyHasRequiredAskContext &&
+        bodyHasIdentifiers &&
+        protectedWithinCap(maxChars)
+      ) {
         return { text: summary, trimmed: false };
       }
       if (maxChars < minimumSummary.length) {
         return null;
       }
       const contentBudget = maxChars - minimumSummary.length;
-      // Audit-bearing sections (pending asks, exact identifiers) are funded first
-      // so a runaway earlier section cannot starve them, but each is capped: an
-      // uncapped identifier list re-distills into the whole budget and leaves
-      // every other section as a bare heading.
-      const protectedCap = Math.floor(contentBudget * MAX_PROTECTED_SECTION_CONTENT_SHARE);
+      const protectedCap = protectedCapFor(maxChars);
       const allocations = contents.map((content, index) =>
         index >= QUALITY_PROTECTED_SECTION_START ? Math.min(content.length, protectedCap) : 0,
       );
@@ -231,8 +245,14 @@ export function createSummaryQualityRetentionPlan(
         allocations[index] =
           optionalTotal > 0 ? Math.floor((optionalBudget * content.length) / optionalTotal) : 0;
       }
-      let remainder = contentBudget - allocations.reduce((total, chars) => total + chars, 0);
-      for (const [index, content] of contents.entries()) {
+      // Surplus returns to the optional sections only; the protected caps stay
+      // hard so short decisions cannot hand the budget back to the identifier dump.
+      let remainder =
+        optionalBudget -
+        allocations
+          .slice(0, QUALITY_PROTECTED_SECTION_START)
+          .reduce((total, chars) => total + chars, 0);
+      for (const [index, content] of optionalContents.entries()) {
         const allocation = allocations[index] ?? 0;
         const extra = Math.min(remainder, Math.max(0, content.length - allocation));
         allocations[index] = allocation + extra;

--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -138,18 +138,14 @@ export function createSummaryQualityRetentionPlan(
   }
   const enforceIdentifiers = (params.identifierPolicy ?? "strict") === "strict";
   const auditSummary = params.auditSummary ?? summary;
-  if (
-    enforceIdentifiers &&
-    params.identifiers.some((identifier) => !summaryIncludesIdentifier(auditSummary, identifier))
-  ) {
-    return null;
-  }
   if (!hasAskOverlap(auditSummary, params.latestAsk)) {
     return null;
   }
   const pendingAsk = contents[QUALITY_PROTECTED_SECTION_START] ?? "";
   const requiredAskContext = params.requiredAskContext?.trim() ?? "";
   const exactIdentifiers = contents[QUALITY_PROTECTED_SECTION_START + 1] ?? "";
+  // Source identifiers are audit facts, not model-owned output. Restore them
+  // here so a model omission cannot disable the retention plan that repairs it.
   const missingIdentifiers = enforceIdentifiers
     ? params.identifiers.filter(
         (identifier) => !summaryIncludesIdentifier(exactIdentifiers, identifier),

--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -20,6 +20,9 @@ const REQUIRED_SUMMARY_SECTIONS = [
   "## Exact identifiers",
 ] as const;
 const QUALITY_PROTECTED_SECTION_START = 3;
+const PENDING_ASK_SECTION_INDEX = 3;
+const EXACT_IDENTIFIERS_SECTION_INDEX = 4;
+const MAX_PROTECTED_SECTION_CONTENT_SHARE = 0.25;
 const STRICT_EXACT_IDENTIFIERS_INSTRUCTION =
   "For ## Exact identifiers, preserve literal values exactly as seen (IDs, URLs, file paths, ports, hashes, dates, times).";
 const POLICY_OFF_EXACT_IDENTIFIERS_INSTRUCTION =
@@ -123,7 +126,14 @@ function parseRequiredSummarySectionContents(summary: string): string[] | null {
   return contents.map((lines) => lines.join("\n").trim());
 }
 
-/** Plan truncation that keeps audit-required headings, pending asks, and exact identifiers. */
+/**
+ * Plan truncation that keeps the audit facts and lets everything else shrink.
+ * Only the headings, the bounded latest-ask context, and the audited source
+ * identifiers are untrimmable. Model-written section text — including the
+ * "## Exact identifiers" list — is optional content; protecting it verbatim let
+ * a re-distilled identifier dump grow past the whole artifact budget while the
+ * real sections were starved to empty headings.
+ */
 export function createSummaryQualityRetentionPlan(
   summary: string,
   truncatedMarker: string,
@@ -144,41 +154,52 @@ export function createSummaryQualityRetentionPlan(
   if (!hasAskOverlap(auditSummary, params.latestAsk)) {
     return null;
   }
-  const pendingAsk = contents[QUALITY_PROTECTED_SECTION_START] ?? "";
   const requiredAskContext = params.requiredAskContext?.trim() ?? "";
-  const exactIdentifiers = contents[QUALITY_PROTECTED_SECTION_START + 1] ?? "";
-  // Source identifiers are audit facts, not model-owned output. Restore them
-  // here so a model omission cannot disable the retention plan that repairs it.
-  const missingIdentifiers = enforceIdentifiers
-    ? params.identifiers.filter(
-        (identifier) => !summaryIncludesIdentifier(exactIdentifiers, identifier),
-      )
-    : [];
-  const protectedContents = [
-    [
-      pendingAsk,
-      requiredAskContext && !pendingAsk.includes(requiredAskContext) ? requiredAskContext : "",
-    ]
-      .filter(Boolean)
-      .join("\n"),
-    [exactIdentifiers, ...missingIdentifiers].filter(Boolean).join("\n"),
-  ];
+  const auditedIdentifiers = enforceIdentifiers ? params.identifiers : [];
   const marker = truncatedMarker.trim();
-  const protectedBlocks = REQUIRED_SUMMARY_SECTIONS.slice(QUALITY_PROTECTED_SECTION_START).map(
-    (heading, index) => {
-      const content = protectedContents[index];
+  // Protected tails render after each section's optional content so the audit
+  // facts survive regardless of how much model text the budget keeps.
+  const protectedTails = REQUIRED_SUMMARY_SECTIONS.map((_, index) =>
+    index === PENDING_ASK_SECTION_INDEX
+      ? requiredAskContext
+      : index === EXACT_IDENTIFIERS_SECTION_INDEX
+        ? auditedIdentifiers.join("\n")
+        : "",
+  );
+  const bodyHasIdentifiers = auditedIdentifiers.every((identifier) =>
+    summaryIncludesIdentifier(summary, identifier),
+  );
+  const renderSections = (sectionContents: string[]) =>
+    REQUIRED_SUMMARY_SECTIONS.map((heading, index) => {
+      const content = sectionContents[index];
       return content ? `${heading}\n${content}` : heading;
-    },
+    });
+  const joinSectionContent = (index: number, optional: string) => {
+    const tail = protectedTails[index] ?? "";
+    if (!tail) {
+      return optional;
+    }
+    if (index === PENDING_ASK_SECTION_INDEX && optional.includes(tail)) {
+      return optional;
+    }
+    if (index === EXACT_IDENTIFIERS_SECTION_INDEX) {
+      const missing = auditedIdentifiers.filter(
+        (identifier) => !summaryIncludesIdentifier(optional, identifier),
+      );
+      return [optional, ...missing].filter(Boolean).join("\n");
+    }
+    return [optional, tail].filter(Boolean).join("\n");
+  };
+  // Reserve every heading/content/tail separator up front so trimmed optional
+  // text can never push the rendered artifact past `maxChars`.
+  const minimumBlocks = REQUIRED_SUMMARY_SECTIONS.map(
+    (heading, index) => `${heading}\n\n${protectedTails[index] ?? ""}`,
   );
-  const optionalHeadings = REQUIRED_SUMMARY_SECTIONS.slice(0, QUALITY_PROTECTED_SECTION_START);
-  const optionalContents = contents.slice(0, QUALITY_PROTECTED_SECTION_START);
-  const optionalScaffolds = optionalHeadings.map((heading, index) =>
-    optionalContents[index] ? `${heading}\n` : heading,
-  );
-  const minimumSummary = [...optionalScaffolds, marker, ...protectedBlocks].join("\n\n");
-  const bodyHasIdentifiers =
-    !enforceIdentifiers ||
-    params.identifiers.every((identifier) => summaryIncludesIdentifier(summary, identifier));
+  const minimumSummary = [
+    ...minimumBlocks.slice(0, QUALITY_PROTECTED_SECTION_START),
+    marker,
+    ...minimumBlocks.slice(QUALITY_PROTECTED_SECTION_START),
+  ].join("\n\n");
 
   return {
     minimumChars: minimumSummary.length,
@@ -192,33 +213,42 @@ export function createSummaryQualityRetentionPlan(
         return null;
       }
       const contentBudget = maxChars - minimumSummary.length;
-      const totalContentChars = optionalContents.reduce(
-        (total, content) => total + content.length,
+      // Audit-bearing sections (pending asks, exact identifiers) are funded first
+      // so a runaway earlier section cannot starve them, but each is capped: an
+      // uncapped identifier list re-distills into the whole budget and leaves
+      // every other section as a bare heading.
+      const protectedCap = Math.floor(contentBudget * MAX_PROTECTED_SECTION_CONTENT_SHARE);
+      const allocations = contents.map((content, index) =>
+        index >= QUALITY_PROTECTED_SECTION_START ? Math.min(content.length, protectedCap) : 0,
+      );
+      const optionalBudget = Math.max(
         0,
+        contentBudget - allocations.reduce((total, chars) => total + chars, 0),
       );
-      const allocations = optionalContents.map((content) =>
-        totalContentChars > 0
-          ? Math.floor((contentBudget * content.length) / totalContentChars)
-          : 0,
-      );
-      let remainder = contentBudget - allocations.reduce((total, chars) => total + chars, 0);
+      const optionalContents = contents.slice(0, QUALITY_PROTECTED_SECTION_START);
+      const optionalTotal = optionalContents.reduce((total, content) => total + content.length, 0);
       for (const [index, content] of optionalContents.entries()) {
+        allocations[index] =
+          optionalTotal > 0 ? Math.floor((optionalBudget * content.length) / optionalTotal) : 0;
+      }
+      let remainder = contentBudget - allocations.reduce((total, chars) => total + chars, 0);
+      for (const [index, content] of contents.entries()) {
         const allocation = allocations[index] ?? 0;
         const extra = Math.min(remainder, Math.max(0, content.length - allocation));
         allocations[index] = allocation + extra;
         remainder -= extra;
       }
-      const optionalBlocks = optionalHeadings.map((heading, index) => {
-        const content = truncateUtf16Safe(optionalContents[index] ?? "", allocations[index] ?? 0);
-        return content ? `${heading}\n${content}` : heading;
-      });
-      // The marker only belongs in an artifact that actually lost body text;
-      // an under-budget rebuild that merely restores audited facts is complete.
-      const trimmed = optionalContents.some(
-        (content, index) => content.length > (allocations[index] ?? 0),
+      const trimmed = contents.some((content, index) => content.length > (allocations[index] ?? 0));
+      const sectionContents = contents.map((content, index) =>
+        joinSectionContent(index, truncateUtf16Safe(content, allocations[index] ?? 0)),
       );
+      const blocks = renderSections(sectionContents);
       return {
-        text: [...optionalBlocks, ...(trimmed ? [marker] : []), ...protectedBlocks].join("\n\n"),
+        text: [
+          ...blocks.slice(0, QUALITY_PROTECTED_SECTION_START),
+          ...(trimmed ? [marker] : []),
+          ...blocks.slice(QUALITY_PROTECTED_SECTION_START),
+        ].join("\n\n"),
         trimmed,
       };
     },

--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -97,7 +97,10 @@ function hasRequiredSummarySections(summary: string): boolean {
 
 type SummaryQualityRetentionPlan = {
   minimumChars: number;
-  render: (maxChars: number) => string | null;
+  /** True when the body omits a strict source identifier that render() restores. */
+  restoresIdentifiers: boolean;
+  /** Null when even the protected facts cannot fit `maxChars`. */
+  render: (maxChars: number) => { text: string; trimmed: boolean } | null;
 };
 
 function parseRequiredSummarySectionContents(summary: string): string[] | null {
@@ -173,16 +176,17 @@ export function createSummaryQualityRetentionPlan(
     optionalContents[index] ? `${heading}\n` : heading,
   );
   const minimumSummary = [...optionalScaffolds, marker, ...protectedBlocks].join("\n\n");
+  const bodyHasIdentifiers =
+    !enforceIdentifiers ||
+    params.identifiers.every((identifier) => summaryIncludesIdentifier(summary, identifier));
 
   return {
     minimumChars: minimumSummary.length,
+    restoresIdentifiers: !bodyHasIdentifiers,
     render(maxChars) {
       const bodyHasRequiredAskContext = !requiredAskContext || summary.includes(requiredAskContext);
-      const bodyHasIdentifiers =
-        !enforceIdentifiers ||
-        params.identifiers.every((identifier) => summaryIncludesIdentifier(summary, identifier));
       if (summary.length <= maxChars && bodyHasRequiredAskContext && bodyHasIdentifiers) {
-        return summary;
+        return { text: summary, trimmed: false };
       }
       if (maxChars < minimumSummary.length) {
         return null;
@@ -208,7 +212,15 @@ export function createSummaryQualityRetentionPlan(
         const content = truncateUtf16Safe(optionalContents[index] ?? "", allocations[index] ?? 0);
         return content ? `${heading}\n${content}` : heading;
       });
-      return [...optionalBlocks, marker, ...protectedBlocks].join("\n\n");
+      // The marker only belongs in an artifact that actually lost body text;
+      // an under-budget rebuild that merely restores audited facts is complete.
+      const trimmed = optionalContents.some(
+        (content, index) => content.length > (allocations[index] ?? 0),
+      );
+      return {
+        text: [...optionalBlocks, ...(trimmed ? [marker] : []), ...protectedBlocks].join("\n\n"),
+        trimmed,
+      };
     },
   };
 }

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2223,6 +2223,61 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
   });
 
+  it("keeps real sections when a re-distilled identifier list outgrows the budget", async () => {
+    mockSummarizeInStages.mockReset();
+    const latestAsk = "preserve the pending deployment status";
+    const identifier = "/tmp/source-only-compaction-id.log";
+    // A model that hoards every identifier it has ever seen: the list alone is
+    // larger than the whole artifact budget while the real sections stay small.
+    const hoardedIdentifiers = Array.from(
+      { length: 400 },
+      (_, index) => `- /home/vac/clawd/tmp/session-artifacts/run-${index}/output.log`,
+    ).join("\n");
+    const generatedSummary = [
+      "## Decisions",
+      "Deployment stays paused until the backup is verified.",
+      "## Open TODOs",
+      "Verify the backup.",
+      "## Constraints/Rules",
+      "Preserve exact context.",
+      "## Pending user asks",
+      latestAsk,
+      "## Exact identifiers",
+      hoardedIdentifiers,
+    ].join("\n");
+    expect(generatedSummary.length).toBeGreaterThan(MAX_COMPACTION_SUMMARY_CHARS);
+    mockSummarizeInStages.mockResolvedValue(summaryResult(generatedSummary));
+
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model: createAnthropicModelFixture(),
+      recentTurnsPreserve: 0,
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 1,
+    });
+    const event = createCompactionEvent({
+      messageText: `${latestAsk} ${identifier}`,
+      tokensBefore: 1_500,
+    });
+    (event.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4_000,
+    };
+
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "test-key" });
+
+    const summary = expectCompactionResult(result).summary;
+    expect(summary.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    expect(summary).toContain(
+      "## Decisions\nDeployment stays paused until the backup is verified.",
+    );
+    expect(summary).toContain("## Open TODOs\nVerify the backup.");
+    expect(summary).toContain(`## Pending user asks\n${latestAsk}`);
+    expect(summary).toContain(identifier);
+    expect(summary).toContain("run-0/output.log");
+    expect(summary).not.toContain("run-399/output.log");
+    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+  });
+
   it("restores source identifiers omitted by a generated summary that fits the budget", async () => {
     mockSummarizeInStages.mockReset();
     const latestAsk = "preserve the pending deployment status";

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -3822,6 +3822,88 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(JSON.stringify(messages)).not.toContain("behind reset");
   });
 
+  it("recovers real conversation the preparation omitted from its boundary-scoped range", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(summaryResult("range summary"));
+
+    const now = Date.now();
+    const entry = (id: string, parentId: string | null, offset: number, message: AgentMessage) => ({
+      type: "message",
+      id,
+      parentId,
+      timestamp: new Date(now + offset).toISOString(),
+      message: { ...message, timestamp: now + offset },
+    });
+    const omittedUser = { role: "user", content: "verify the deploy status now" } as AgentMessage;
+    const toolCallAssistant = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call-1", name: "exec", arguments: {} }],
+    } as AgentMessage;
+    const toolResult = {
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "exec",
+      content: [{ type: "text", text: "deploy green" }],
+    } as AgentMessage;
+    const sessionManager = {
+      ...stubSessionManager(),
+      getBranch: () => [
+        entry("old-user", null, 0, {
+          role: "user",
+          content: "old request behind reset",
+        } as AgentMessage),
+        {
+          type: "reset",
+          id: "reset-1",
+          parentId: "old-user",
+          timestamp: new Date(now + 1).toISOString(),
+          reason: "new",
+          firstKeptEntryId: "reset-1",
+        },
+        entry("omitted-user", "reset-1", 2, omittedUser),
+        entry("assistant-1", "omitted-user", 3, toolCallAssistant),
+        entry("tool-1", "assistant-1", 4, toolResult),
+        entry("kept-user", "tool-1", 5, { role: "user", content: "and then?" } as AgentMessage),
+      ],
+    } as ExtensionContext["sessionManager"];
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    // The preparation covers everything before "kept-user" but lost the user turn.
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [toolCallAssistant, toolResult],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "kept-user",
+        tokensBefore: 38085,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4000 },
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+    const { result } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: "test-key",
+    });
+
+    expect(expectCompactionResult(result).summary).toContain("range summary");
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
+    const messages = requireArray(summarizeCall.messages);
+    expect(messages.map((message) => requireRecord(message).role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+    ]);
+    const serialized = JSON.stringify(messages);
+    expect(serialized).toContain("verify the deploy status now");
+    expect(serialized).not.toContain("behind reset");
+    expect(serialized).not.toContain("and then?");
+  });
+
   it("writes the anti-loop boundary for a tool-only window when nothing anchors it", async () => {
     mockSummarizeInStages.mockReset();
     const sessionManager = stubSessionManager();

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2180,6 +2180,49 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
   });
 
+  it("restores source identifiers omitted by an oversized generated summary", async () => {
+    mockSummarizeInStages.mockReset();
+    const latestAsk = "preserve the pending deployment status";
+    const identifier = "/tmp/source-only-compaction-id.log";
+    const generatedSummary = [
+      "## Decisions",
+      "x".repeat(MAX_COMPACTION_SUMMARY_CHARS),
+      "## Open TODOs",
+      "None.",
+      "## Constraints/Rules",
+      "Preserve exact context.",
+      "## Pending user asks",
+      latestAsk,
+      "## Exact identifiers",
+      "None.",
+    ].join("\n");
+    mockSummarizeInStages.mockResolvedValue(summaryResult(generatedSummary));
+
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model: createAnthropicModelFixture(),
+      recentTurnsPreserve: 0,
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 1,
+    });
+    const event = createCompactionEvent({
+      messageText: `${latestAsk} ${identifier}`,
+      tokensBefore: 1_500,
+    });
+    (
+      event.preparation as { settings?: { reserveTokens: number }; isSplitTurn?: boolean }
+    ).settings = { reserveTokens: 4_000 };
+    (event.preparation as { isSplitTurn?: boolean }).isSplitTurn = false;
+
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "test-key" });
+
+    const summary = expectCompactionResult(result).summary;
+    expect(summary.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    expect(summary).toContain(`## Exact identifiers\nNone.\n${identifier}`);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+  });
+
   it("fails closed when audit-required tail sections cannot fit the artifact cap", async () => {
     mockSummarizeInStages.mockReset();
     const latestAsk = "preserve the pending deployment status";

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2275,6 +2275,94 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(summary).toContain(identifier);
     expect(summary).toContain("run-0/output.log");
     expect(summary).not.toContain("run-399/output.log");
+    const identifiersSection = summary.slice(summary.indexOf("## Exact identifiers"));
+    expect(identifiersSection.length).toBeLessThanOrEqual(
+      MAX_COMPACTION_SUMMARY_CHARS * 0.25 + 200,
+    );
+    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+  });
+
+  it("keeps surplus budget out of the protected sections when trimming", () => {
+    const identifier = "/tmp/surplus-compaction-id.log";
+    const latestAsk = "preserve the pending deployment status";
+    // The re-distilled shape seen in production: every optional section is an
+    // empty heading, so all surplus would otherwise flow to the identifier list.
+    const body = [
+      "## Decisions",
+      "## Open TODOs",
+      "## Constraints/Rules",
+      "## Pending user asks",
+      latestAsk,
+      "## Exact identifiers",
+      [identifier, ...Array.from({ length: 300 }, (_, i) => `- /tmp/run-${i}/out.log`)].join("\n"),
+    ].join("\n");
+    const maxChars = 4_000;
+    expect(body.length).toBeGreaterThan(maxChars);
+
+    const finalized = budgetCompactionSummary(body, "", maxChars, {
+      identifiers: [identifier],
+      latestAsk,
+      identifierPolicy: "strict",
+    });
+
+    const structural = (finalized as { structuralSummary: string }).structuralSummary;
+    expect(structural.length).toBeLessThanOrEqual(maxChars);
+    expect(structural).toContain("## Decisions");
+    expect(structural).toContain(identifier);
+    const identifiersSection = structural.slice(structural.indexOf("## Exact identifiers"));
+    expect(identifiersSection.length).toBeLessThanOrEqual(maxChars * 0.25 + 100);
+  });
+
+  it("caps an identifier list that outgrew its share while the summary still fits", async () => {
+    mockSummarizeInStages.mockReset();
+    const latestAsk = "preserve the pending deployment status";
+    const identifier = "/tmp/source-only-compaction-id.log";
+    const hoardedIdentifiers = Array.from(
+      { length: 200 },
+      (_, index) => `- /home/vac/clawd/tmp/session-artifacts/run-${index}/output.log`,
+    ).join("\n");
+    const generatedSummary = [
+      "## Decisions",
+      "Deployment stays paused until the backup is verified.",
+      "## Open TODOs",
+      "Verify the backup.",
+      "## Constraints/Rules",
+      "Preserve exact context.",
+      "## Pending user asks",
+      latestAsk,
+      "## Exact identifiers",
+      `${identifier}\n${hoardedIdentifiers}`,
+    ].join("\n");
+    expect(generatedSummary.length).toBeLessThan(MAX_COMPACTION_SUMMARY_CHARS);
+    mockSummarizeInStages.mockResolvedValue(summaryResult(generatedSummary));
+
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model: createAnthropicModelFixture(),
+      recentTurnsPreserve: 0,
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 1,
+    });
+    const event = createCompactionEvent({
+      messageText: `${latestAsk} ${identifier}`,
+      tokensBefore: 1_500,
+    });
+    (event.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4_000,
+    };
+
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "test-key" });
+
+    const summary = expectCompactionResult(result).summary;
+    expect(summary).toContain(
+      "## Decisions\nDeployment stays paused until the backup is verified.",
+    );
+    expect(summary).toContain(identifier);
+    expect(summary).not.toContain("run-199/output.log");
+    const identifiersSection = summary.slice(summary.indexOf("## Exact identifiers"));
+    expect(identifiersSection.length).toBeLessThanOrEqual(
+      MAX_COMPACTION_SUMMARY_CHARS * 0.25 + 200,
+    );
     expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
   });
 

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2223,6 +2223,48 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
   });
 
+  it("restores source identifiers omitted by a generated summary that fits the budget", async () => {
+    mockSummarizeInStages.mockReset();
+    const latestAsk = "preserve the pending deployment status";
+    const identifier = "/tmp/source-only-compaction-id.log";
+    const generatedSummary = [
+      "## Decisions",
+      "Deployment stays paused.",
+      "## Open TODOs",
+      "None.",
+      "## Constraints/Rules",
+      "Preserve exact context.",
+      "## Pending user asks",
+      latestAsk,
+      "## Exact identifiers",
+      "None.",
+    ].join("\n");
+    mockSummarizeInStages.mockResolvedValue(summaryResult(generatedSummary));
+
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model: createAnthropicModelFixture(),
+      recentTurnsPreserve: 0,
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 1,
+    });
+    const event = createCompactionEvent({
+      messageText: `${latestAsk} ${identifier}`,
+      tokensBefore: 1_500,
+    });
+    (event.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4_000,
+    };
+
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "test-key" });
+
+    const summary = expectCompactionResult(result).summary;
+    expect(summary).toContain(`## Exact identifiers\nNone.\n${identifier}`);
+    expect(summary).not.toContain(SUMMARY_TRUNCATED_MARKER.trim());
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+  });
+
   it("fails closed when audit-required tail sections cannot fit the artifact cap", async () => {
     mockSummarizeInStages.mockReset();
     const latestAsk = "preserve the pending deployment status";
@@ -3629,61 +3671,80 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(getApiKeyAndHeadersMock).toHaveBeenCalledWith(model);
   });
 
-  it("falls back to visible custom session branch entries before writing an empty boundary", async () => {
+  it("summarizes only the prepared tool-only window when the context anchors it", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue(summaryResult("branch summary"));
+    mockSummarizeInStages.mockResolvedValue(summaryResult("tool window summary"));
 
     const now = Date.now();
+    // History behind a reset and a compaction boundary: the old fallback re-read
+    // all of it through getBranch() and summarized the whole session again.
     const sessionManager = {
       ...stubSessionManager(),
       getBranch: () => [
         {
-          type: "custom_message",
-          id: "custom-1",
+          type: "message",
+          id: "old-user",
           parentId: null,
           timestamp: new Date(now).toISOString(),
-          customType: "cron-request",
-          content: "prepare the daily report",
-          display: true,
+          message: { role: "user", content: "old request behind reset", timestamp: now },
         },
         {
           type: "message",
-          id: "assistant-1",
-          parentId: "custom-1",
+          id: "old-assistant",
+          parentId: "old-user",
           timestamp: new Date(now + 1).toISOString(),
           message: {
             role: "assistant",
-            content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }],
+            content: [{ type: "text", text: "old reply behind reset" }],
             timestamp: now + 1,
           },
         },
         {
-          type: "message",
-          id: "tool-1",
-          parentId: "assistant-1",
+          type: "reset",
+          id: "reset-1",
+          parentId: "old-assistant",
           timestamp: new Date(now + 2).toISOString(),
-          message: {
-            role: "toolResult",
-            toolCallId: "call-1",
-            toolName: "read",
-            content: [{ type: "text", text: "report source data" }],
-            timestamp: now + 2,
-          },
+          reason: "new",
+          firstKeptEntryId: "old-assistant",
+        },
+        {
+          type: "compaction",
+          id: "compaction-1",
+          parentId: "reset-1",
+          timestamp: new Date(now + 3).toISOString(),
+          summary: "## Decisions\nUser asked for the deploy status.",
+          firstKeptEntryId: "compaction-1",
+          tokensBefore: 90_000,
+          fromHook: true,
         },
       ],
     } as ExtensionContext["sessionManager"];
     const model = createAnthropicModelFixture();
     setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
 
+    const toolOnlyWindow = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call-1", name: "exec", arguments: {} }],
+        timestamp: now + 4,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call-1",
+        toolName: "exec",
+        content: [{ type: "text", text: "deploy green" }],
+        timestamp: now + 5,
+      },
+    ] as AgentMessage[];
     const mockEvent = {
       preparation: {
-        messagesToSummarize: [] as AgentMessage[],
+        messagesToSummarize: toolOnlyWindow,
         turnPrefixMessages: [] as AgentMessage[],
-        firstKeptEntryId: "entry-5",
+        firstKeptEntryId: "entry-6",
         tokensBefore: 38085,
         fileOps: { read: [], edited: [], written: [] },
         settings: { reserveTokens: 4000 },
-        isSplitTurn: true,
+        isSplitTurn: false,
       },
       customInstructions: "",
       signal: new AbortController().signal,
@@ -3695,442 +3756,22 @@ describe("compaction-safeguard double-compaction guard", () => {
     });
 
     const compaction = expectCompactionResult(result);
-    expect(compaction.summary).toContain("branch summary");
-    expect(compaction.summary).not.toContain("No prior history.");
-    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
-    const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
-    const messages = requireArray(summarizeCall.messages);
-    expect(
-      messages.some((message) => {
-        const record = requireRecord(message);
-        return (
-          record.role === "custom" &&
-          record.customType === "cron-request" &&
-          record.content === "prepare the daily report"
-        );
-      }),
-    ).toBe(true);
-    expect(
-      messages.some((message) => {
-        const record = requireRecord(message);
-        return record.role === "toolResult" && record.toolName === "read";
-      }),
-    ).toBe(true);
-  });
-
-  it.each([
-    { assistantText: "bee reply", completed: true },
-    { assistantText: " \t\n ", completed: false },
-  ])(
-    "drops delegated branch turns only after meaningful terminal output ($completed)",
-    async ({ assistantText, completed }) => {
-      mockSummarizeInStages.mockReset();
-      mockSummarizeInStages.mockResolvedValue(summaryResult("branch summary"));
-
-      const now = Date.now();
-      const sessionManager = {
-        ...stubSessionManager(),
-        getBranch: () => [
-          {
-            type: "message",
-            id: "user-1",
-            parentId: null,
-            timestamp: new Date(now).toISOString(),
-            message: {
-              role: "user",
-              content: "say bee",
-              provenance: {
-                kind: "inter_session",
-                sourceSessionKey: "agent:pm",
-                sourceTool: "sessions_send",
-              },
-              timestamp: now,
-            },
-          },
-          {
-            type: "message",
-            id: "assistant-1",
-            parentId: "user-1",
-            timestamp: new Date(now + 1).toISOString(),
-            message: {
-              role: "assistant",
-              content: [{ type: "text", text: assistantText }],
-              timestamp: now + 1,
-            },
-          },
-        ],
-      } as ExtensionContext["sessionManager"];
-      const model = createAnthropicModelFixture();
-      setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
-
-      const mockEvent = {
-        preparation: {
-          messagesToSummarize: [] as AgentMessage[],
-          turnPrefixMessages: [] as AgentMessage[],
-          firstKeptEntryId: "entry-7",
-          tokensBefore: 38085,
-          fileOps: { read: [], edited: [], written: [] },
-          settings: { reserveTokens: 4000 },
-          isSplitTurn: true,
-        },
-        customInstructions: "",
-        signal: new AbortController().signal,
-      };
-      const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
-        sessionManager,
-        event: mockEvent,
-        apiKey: "dummy",
-      });
-
-      const compaction = expectCompactionResult(result);
-      if (completed) {
-        expect(compaction.summary).toContain("No prior history.");
-        expect(mockSummarizeInStages).not.toHaveBeenCalled();
-        expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
-        return;
-      }
-      expect(compaction.summary).toContain("branch summary");
-      expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
-      expect(getApiKeyAndHeadersMock).toHaveBeenCalledTimes(1);
-      const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
-      expect(
-        requireArray(summarizeCall.messages).map((message) => requireRecord(message).role),
-      ).toEqual(["user", "assistant"]);
-    },
-  );
-
-  it.each([
-    { toolName: "read", expectedRoles: ["user", "assistant", "toolResult"] },
-    { toolName: "functions.sessions_send", expectedRoles: ["user", "assistant"] },
-  ])("preserves unfinished inter-session work after a $toolName result", async (scenario) => {
-    mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue(summaryResult("unfinished branch summary"));
-
-    const now = Date.now();
-    const sessionManager = {
-      ...stubSessionManager(),
-      getBranch: () => [
-        {
-          type: "message",
-          id: "user-1",
-          parentId: null,
-          timestamp: new Date(now).toISOString(),
-          message: {
-            role: "user",
-            content: "continue the delegated task",
-            provenance: {
-              kind: "inter_session",
-              sourceSessionKey: "agent:pm",
-              sourceTool: "sessions_send",
-            },
-            timestamp: now,
-          },
-        },
-        {
-          type: "message",
-          id: "assistant-1",
-          parentId: "user-1",
-          timestamp: new Date(now + 1).toISOString(),
-          message: {
-            role: "assistant",
-            content: [
-              {
-                type: "toolCall",
-                id: "call-tool",
-                name: scenario.toolName,
-                arguments: {},
-              },
-            ],
-            timestamp: now + 1,
-          },
-        },
-        {
-          type: "message",
-          id: "tool-1",
-          parentId: "assistant-1",
-          timestamp: new Date(now + 2).toISOString(),
-          message: {
-            role: "toolResult",
-            toolCallId: "call-tool",
-            toolName: scenario.toolName,
-            content: [{ type: "text", text: "partial evidence" }],
-            timestamp: now + 2,
-          },
-        },
-      ],
-    } as ExtensionContext["sessionManager"];
-    const model = createAnthropicModelFixture();
-    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
-
-    const mockEvent = {
-      preparation: {
-        messagesToSummarize: [] as AgentMessage[],
-        turnPrefixMessages: [] as AgentMessage[],
-        firstKeptEntryId: "entry-8",
-        tokensBefore: 38085,
-        fileOps: { read: [], edited: [], written: [] },
-        settings: { reserveTokens: 4000 },
-        isSplitTurn: true,
-      },
-      customInstructions: "",
-      signal: new AbortController().signal,
-    };
-    const { result } = await runCompactionScenario({
-      sessionManager,
-      event: mockEvent,
-      apiKey: "dummy",
-    });
-
-    const compaction = expectCompactionResult(result);
-    expect(compaction.summary).toContain("unfinished branch summary");
-    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
-    const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
-    const messages = requireArray(summarizeCall.messages);
-    expect(messages.map((message) => requireRecord(message).role)).toEqual(scenario.expectedRoles);
-  });
-
-  it("keeps source-session sends as inert status history", async () => {
-    mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue(summaryResult("completed send summary"));
-
-    const now = Date.now();
-    const sessionManager = {
-      ...stubSessionManager(),
-      getBranch: () => [
-        {
-          type: "message",
-          id: "user-1",
-          parentId: null,
-          timestamp: new Date(now).toISOString(),
-          message: {
-            role: "user",
-            content: "ask the bee session to respond",
-            timestamp: now,
-          },
-        },
-        {
-          type: "message",
-          id: "assistant-1",
-          parentId: "user-1",
-          timestamp: new Date(now + 1).toISOString(),
-          message: {
-            role: "assistant",
-            content: [
-              {
-                type: "toolCall",
-                id: "call-1",
-                name: "functions.sessions_send",
-                arguments: { sessionKey: "agent:bee", message: "say bee" },
-              },
-              {
-                type: "toolCall",
-                id: "call-2",
-                name: "tools/sessions_send",
-                arguments: { sessionKey: "agent:wasp", message: "say wasp" },
-              },
-              {
-                type: "toolCall",
-                id: "call-3",
-                name: "sessions_send",
-                arguments: { sessionKey: "agent:ant", message: "say ant" },
-              },
-            ],
-            timestamp: now + 1,
-          },
-        },
-        {
-          type: "message",
-          id: "tool-1",
-          parentId: "assistant-1",
-          timestamp: new Date(now + 2).toISOString(),
-          message: {
-            role: "toolResult",
-            toolCallId: "call-1",
-            toolName: "functions.sessions_send",
-            content: [{ type: "text", text: '{"status":"ok","reply":"bee replied"}' }],
-            timestamp: now + 2,
-          },
-        },
-        {
-          type: "message",
-          id: "tool-3",
-          parentId: "tool-1",
-          timestamp: new Date(now + 3).toISOString(),
-          message: {
-            role: "toolResult",
-            toolCallId: "call-3",
-            toolName: "sessions_send",
-            content: [{ type: "text", text: '{"status":"error","error":"ant unavailable"}' }],
-            timestamp: now + 3,
-          },
-        },
-      ],
-    } as ExtensionContext["sessionManager"];
-    const model = createAnthropicModelFixture();
-    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
-
-    const mockEvent = {
-      preparation: {
-        messagesToSummarize: [] as AgentMessage[],
-        turnPrefixMessages: [] as AgentMessage[],
-        firstKeptEntryId: "entry-8",
-        tokensBefore: 38085,
-        fileOps: { read: [], edited: [], written: [] },
-        settings: { reserveTokens: 4000 },
-        isSplitTurn: true,
-      },
-      customInstructions: "",
-      signal: new AbortController().signal,
-    };
-    const { result } = await runCompactionScenario({
-      sessionManager,
-      event: mockEvent,
-      apiKey: "dummy",
-    });
-
-    const compaction = expectCompactionResult(result);
-    expect(compaction.summary).toContain("completed send summary");
-    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
-    const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
-    const messages = requireArray(summarizeCall.messages);
-    expect(messages.map((message) => requireRecord(message).role)).toEqual(["user", "assistant"]);
-    expect(JSON.stringify(messages)).toContain("sessions_send result received");
-    expect(JSON.stringify(messages)).toContain("sessions_send result missing");
-    expect(JSON.stringify(messages)).toContain("bee replied");
-    expect(JSON.stringify(messages)).toContain("ant unavailable");
-    expect(JSON.stringify(messages)).toContain("agent:wasp");
-    expect(JSON.stringify(messages)).toContain("say wasp");
-    expect(JSON.stringify(messages)).not.toContain("sessions_send completed");
-    expect(JSON.stringify(messages)).not.toContain("functions.sessions_send");
-    expect(JSON.stringify(messages)).not.toContain("tools/sessions_send");
-  });
-
-  it("preserves completed historical inter-session turns outside the active tail", async () => {
-    mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue(summaryResult("historical branch summary"));
-
-    const now = Date.now();
-    const sessionManager = {
-      ...stubSessionManager(),
-      getBranch: () => [
-        {
-          type: "message",
-          id: "user-1",
-          parentId: null,
-          timestamp: new Date(now).toISOString(),
-          message: {
-            role: "user",
-            content: "historical inter-session request",
-            provenance: {
-              kind: "inter_session",
-              sourceSessionKey: "agent:pm",
-              sourceTool: "sessions_send",
-            },
-            timestamp: now,
-          },
-        },
-        {
-          type: "message",
-          id: "assistant-1",
-          parentId: "user-1",
-          timestamp: new Date(now + 1).toISOString(),
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "historical reply" }],
-            timestamp: now + 1,
-          },
-        },
-        {
-          type: "message",
-          id: "user-2",
-          parentId: "assistant-1",
-          timestamp: new Date(now + 2).toISOString(),
-          message: { role: "user", content: "later user request", timestamp: now + 2 },
-        },
-        {
-          type: "message",
-          id: "assistant-2",
-          parentId: "user-2",
-          timestamp: new Date(now + 3).toISOString(),
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "later reply" }],
-            timestamp: now + 3,
-          },
-        },
-      ],
-    } as ExtensionContext["sessionManager"];
-    const model = createAnthropicModelFixture();
-    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
-
-    const mockEvent = {
-      preparation: {
-        messagesToSummarize: [] as AgentMessage[],
-        turnPrefixMessages: [] as AgentMessage[],
-        firstKeptEntryId: "entry-8",
-        tokensBefore: 38085,
-        fileOps: { read: [], edited: [], written: [] },
-        settings: { reserveTokens: 4000 },
-        isSplitTurn: true,
-      },
-      customInstructions: "",
-      signal: new AbortController().signal,
-    };
-    const { result } = await runCompactionScenario({
-      sessionManager,
-      event: mockEvent,
-      apiKey: "dummy",
-    });
-
-    const compaction = expectCompactionResult(result);
-    expect(compaction.summary).toContain("historical branch summary");
+    expect(compaction.summary).toContain("tool window summary");
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
     const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
     const messages = requireArray(summarizeCall.messages);
     expect(messages.map((message) => requireRecord(message).role)).toEqual([
-      "user",
       "assistant",
-      "user",
-      "assistant",
+      "toolResult",
     ]);
-    expect(JSON.stringify(messages)).toContain("historical inter-session request");
-    expect(JSON.stringify(messages)).toContain("historical reply");
+    expect(JSON.stringify(messages)).not.toContain("behind reset");
   });
 
-  it("recovers user and assistant branch turns when compaction preparation has only tool output", async () => {
+  it("writes the anti-loop boundary for a tool-only window when nothing anchors it", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue(summaryResult("branch summary with visible turns"));
-
-    const now = Date.now();
-    const sessionManager = {
-      ...stubSessionManager(),
-      getBranch: () => [
-        {
-          type: "message",
-          id: "user-1",
-          parentId: null,
-          timestamp: new Date(now).toISOString(),
-          message: {
-            role: "user",
-            content: "what is the deployment status?",
-            timestamp: now,
-          },
-        },
-        {
-          type: "message",
-          id: "assistant-1",
-          parentId: "user-1",
-          timestamp: new Date(now + 1).toISOString(),
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "I will check the deploy." }],
-            timestamp: now + 1,
-          },
-        },
-      ],
-    } as ExtensionContext["sessionManager"];
+    const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture();
-    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+    setCompactionSafeguardRuntime(sessionManager, { model });
 
     const mockEvent = {
       preparation: {
@@ -4138,32 +3779,29 @@ describe("compaction-safeguard double-compaction guard", () => {
           {
             role: "toolResult",
             toolCallId: "call-1",
-            toolName: "status",
-            content: [{ type: "text", text: "deploy green" }],
-            timestamp: now + 2,
+            toolName: "exec",
+            content: [{ type: "text", text: "heartbeat probe ok" }],
+            timestamp: Date.now(),
           },
         ] as AgentMessage[],
         turnPrefixMessages: [] as AgentMessage[],
-        firstKeptEntryId: "entry-6",
-        tokensBefore: 38085,
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1500,
         fileOps: { read: [], edited: [], written: [] },
-        settings: { reserveTokens: 4000 },
-        isSplitTurn: true,
       },
       customInstructions: "",
       signal: new AbortController().signal,
     };
-    const { result } = await runCompactionScenario({
+    const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
       apiKey: "test-key",
     });
 
     const compaction = expectCompactionResult(result);
-    expect(compaction.summary).toContain("branch summary with visible turns");
-    const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
-    const messages = requireArray(summarizeCall.messages);
-    expect(messages.map((message) => requireRecord(message).role)).toEqual(["user", "assistant"]);
+    expect(compaction.summary).toContain("No prior history.");
+    expect(mockSummarizeInStages).not.toHaveBeenCalled();
+    expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
   });
 
   it("continues when messages include real conversation content", async () => {

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -499,13 +499,13 @@ function budgetCompactionSummary(
 ) {
   const suffix = normalizeCompactionSuffix(suffixInput);
   const joined = `${summaryBody}${suffix.text}`;
-  // Source identifiers are audit facts the model may omit even when the body
-  // fits; the retention plan restores them, so an under-budget body only skips
-  // it when nothing is missing.
+  // A body that fits still goes through the retention plan when it omits an
+  // audited identifier or lets an audit section outgrow its cap; both would
+  // re-distill into the next summary otherwise.
   const retentionPlan = qualityRetention
     ? createSummaryQualityRetentionPlan(summaryBody, SUMMARY_TRUNCATED_MARKER, qualityRetention)
     : null;
-  if (maxChars <= 0 || (joined.length <= maxChars && !retentionPlan?.restoresIdentifiers)) {
+  if (maxChars <= 0 || (joined.length <= maxChars && !retentionPlan?.needsRebuild(maxChars))) {
     return {
       summary: joined,
       structuralSummary: summaryBody,

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -3,8 +3,6 @@
 import fs from "node:fs";
 import path from "node:path";
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
-import { parseDateFirstTimestampMs } from "@openclaw/normalization-core/number-coercion";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   capCompactionSummary,
@@ -27,7 +25,6 @@ import {
   getCompactionProvider,
   type CompactionProvider,
 } from "../../plugins/compaction-provider.js";
-import { normalizeInputProvenance } from "../../sessions/input-provenance.js";
 import { normalizeAcceptedSessionSpawnResult } from "../accepted-session-spawn.js";
 import { computeAdaptiveChunkRatioWithWorker } from "../compaction-planning-worker.js";
 import { buildHistoryPrunePlan } from "../compaction-planning.js";
@@ -48,7 +45,11 @@ import { collectTextContentBlocks } from "../content-blocks.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "../copilot-dynamic-headers.js";
 import { isTimeoutError } from "../failover-error.js";
 import { stripRuntimeContextCustomMessages } from "../internal-runtime-context.js";
-import type { AgentMessage } from "../runtime/index.js";
+import {
+  buildSessionContext as buildCoreSessionContext,
+  type AgentMessage,
+  type SessionTreeEntry as CoreSessionTreeEntry,
+} from "../runtime/index.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import type { ExtensionAPI, ExtensionContext } from "../sessions/index.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
@@ -93,7 +94,6 @@ const MAX_QUALITY_GUARD_MAX_RETRIES = 3;
 const MAX_RECENT_TURN_TEXT_CHARS = 600;
 const MAX_REQUIRED_ASK_CONTEXT_CHARS = 2_000;
 const REQUIRED_ASK_CONTEXT_TRUNCATED_MARKER = "\n[... split-turn ask context truncated ...]\n";
-const TOOL_CALL_BLOCK_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
 const PREVIOUS_SUMMARY_REDISTILL_PREFIX =
   "Previous compaction summary to re-distill with the current conversation. " +
   "Prune stale, duplicate, or superseded details instead of preserving it verbatim.";
@@ -130,172 +130,20 @@ function prependPreviousSummaryForRedistill(params: {
   ];
 }
 
-function coerceTimestamp(value: unknown): number {
-  return parseDateFirstTimestampMs(value) ?? 0;
-}
-
-function sessionBranchEntryToMessage(entry: Record<string, unknown>): unknown {
-  if (entry.type === "message" && entry.message && typeof entry.message === "object") {
-    return entry.message;
-  }
-  if (entry.type === "custom_message") {
-    return {
-      role: "custom",
-      customType: typeof entry.customType === "string" ? entry.customType : "custom",
-      content: entry.content,
-      display: entry.display !== false,
-      details: entry.details,
-      timestamp: coerceTimestamp(entry.timestamp),
-    };
-  }
-  if (entry.type === "branch_summary") {
-    return {
-      role: "branchSummary",
-      summary: typeof entry.summary === "string" ? entry.summary : "",
-      fromId: typeof entry.fromId === "string" ? entry.fromId : "root",
-      timestamp: coerceTimestamp(entry.timestamp),
-    };
-  }
-  return undefined;
-}
-
-function collectSessionBranchMessages(sessionManager: unknown): AgentMessage[] {
+/**
+ * Messages the model currently sees: the last reset/compaction boundary's kept
+ * tail plus everything after it. Never the raw branch — that re-reads history
+ * behind every boundary and turns one compaction into dozens of model calls.
+ */
+function collectSessionContextMessages(sessionManager: unknown): AgentMessage[] {
   try {
     const entries: unknown = (sessionManager as { getBranch?: () => unknown })?.getBranch?.();
     return Array.isArray(entries)
-      ? entries.flatMap((entry) => {
-          const message =
-            entry && typeof entry === "object"
-              ? sessionBranchEntryToMessage(entry as Record<string, unknown>)
-              : undefined;
-          return message ? [message as AgentMessage] : [];
-        })
+      ? (buildCoreSessionContext(entries as CoreSessionTreeEntry[]).messages as AgentMessage[])
       : [];
   } catch {
     return [];
   }
-}
-
-function isSessionsSendToolName(value: unknown): boolean {
-  return (
-    normalizeOptionalString(value)
-      ?.toLowerCase()
-      .replace(/^(?:functions?|tools?)[./_-]/, "") === "sessions_send"
-  );
-}
-
-function sanitizeSourceSessionSends(messages: AgentMessage[]): AgentMessage[] {
-  const sendCallIds = new Set(
-    messages.flatMap((message) =>
-      message.role === "assistant"
-        ? extractToolCallsFromAssistant(message)
-            .filter((call) => isSessionsSendToolName(call.name))
-            .map((call) => call.id.trim())
-            .filter(Boolean)
-        : [],
-    ),
-  );
-  const resultTextByCallId = new Map<string, string>();
-
-  for (const message of messages) {
-    if (message.role !== "toolResult") {
-      continue;
-    }
-    const callId = extractToolResultId(message);
-    if (!callId || !sendCallIds.has(callId)) {
-      continue;
-    }
-    resultTextByCallId.set(
-      callId,
-      extractMessageText(message) || formatNonTextPlaceholder(message.content) || "",
-    );
-  }
-
-  return messages.flatMap((message) => {
-    if (message.role === "assistant" && Array.isArray(message.content)) {
-      let replaced = false;
-      const content = message.content.map((block) => {
-        if (!block || typeof block !== "object") {
-          return block;
-        }
-        const record = block as {
-          type?: unknown;
-          id?: unknown;
-          name?: unknown;
-          arguments?: unknown;
-        };
-        if (
-          typeof record.type !== "string" ||
-          !TOOL_CALL_BLOCK_TYPES.has(record.type) ||
-          !isSessionsSendToolName(record.name)
-        ) {
-          return block;
-        }
-        replaced = true;
-        const callId = typeof record.id === "string" ? record.id.trim() : "";
-        const resultText = callId ? resultTextByCallId.get(callId) : undefined;
-        const resolved = Boolean(callId && resultTextByCallId.has(callId));
-        const requestText = JSON.stringify({ callId: callId || undefined, args: record.arguments });
-        const resultSuffix = resolved ? `\nResult: ${resultText || "[empty]"}` : "";
-        return {
-          type: "text",
-          text: `sessions_send result ${resolved ? "received" : "missing"}; delivery call omitted from replay.\nRequest: ${requestText}${resultSuffix}`,
-        };
-      });
-      return replaced ? [{ ...message, content } as AgentMessage] : [message];
-    }
-    if (message.role === "toolResult") {
-      const callId = extractToolResultId(message);
-      if ((callId && sendCallIds.has(callId)) || isSessionsSendToolName(message.toolName)) {
-        return [];
-      }
-    }
-    return [message];
-  });
-}
-
-function filterReplayUnsafeSessionBranchMessages(messages: AgentMessage[]): AgentMessage[] {
-  const sanitizedMessages = sanitizeSourceSessionSends(messages);
-  let turnStart = sanitizedMessages.length;
-  while (turnStart > 0) {
-    const role = (sanitizedMessages[turnStart - 1] as { role?: unknown }).role;
-    if (role !== "assistant" && role !== "toolResult") {
-      break;
-    }
-    turnStart -= 1;
-  }
-
-  const tailMessage = messages.at(-1);
-  const endsWithTerminalAssistantText =
-    tailMessage !== undefined &&
-    tailMessage.role === "assistant" &&
-    Boolean(extractMessageText(tailMessage).trim()) &&
-    (!Array.isArray(tailMessage.content) ||
-      !tailMessage.content.some((block) => {
-        if (!block || typeof block !== "object") {
-          return false;
-        }
-        const type = (block as { type?: unknown }).type;
-        return typeof type === "string" && TOOL_CALL_BLOCK_TYPES.has(type);
-      }));
-  const activeInput = sanitizedMessages[turnStart - 1];
-  const activeInputProvenance =
-    activeInput?.role === "user"
-      ? normalizeInputProvenance((activeInput as { provenance?: unknown }).provenance)
-      : undefined;
-
-  // A completed sessions_send target run is already delivered to its caller.
-  // Require terminal text so compaction after tool output can still recover unfinished work.
-  if (
-    endsWithTerminalAssistantText &&
-    turnStart < sanitizedMessages.length &&
-    turnStart > 0 &&
-    activeInputProvenance?.kind === "inter_session" &&
-    activeInputProvenance.sourceTool === "sessions_send"
-  ) {
-    return sanitizedMessages.slice(0, turnStart - 1);
-  }
-  return sanitizedMessages;
 }
 
 function containsRealConversation(messages: AgentMessage[]): boolean {
@@ -621,7 +469,13 @@ function budgetCompactionSummary(
 ) {
   const suffix = normalizeCompactionSuffix(suffixInput);
   const joined = `${summaryBody}${suffix.text}`;
-  if (maxChars <= 0 || joined.length <= maxChars) {
+  // Source identifiers are audit facts the model may omit even when the body
+  // fits; the retention plan restores them, so an under-budget body only skips
+  // it when nothing is missing.
+  const retentionPlan = qualityRetention
+    ? createSummaryQualityRetentionPlan(summaryBody, SUMMARY_TRUNCATED_MARKER, qualityRetention)
+    : null;
+  if (maxChars <= 0 || (joined.length <= maxChars && !retentionPlan?.restoresIdentifiers)) {
     return {
       summary: joined,
       structuralSummary: summaryBody,
@@ -632,9 +486,6 @@ function budgetCompactionSummary(
     };
   }
 
-  const retentionPlan = qualityRetention
-    ? createSummaryQualityRetentionPlan(summaryBody, SUMMARY_TRUNCATED_MARKER, qualityRetention)
-    : null;
   const bodyCapacity = retentionPlan ? maxChars : summaryBody.length;
   const bodyFloor = Math.min(
     bodyCapacity,
@@ -643,14 +494,15 @@ function budgetCompactionSummary(
   );
   const suffixReservation = Math.min(suffix.text.length, maxChars);
   const bodySlot = Math.min(bodyCapacity, Math.max(bodyFloor, maxChars - suffixReservation));
-  const cappedBody = retentionPlan?.render(bodySlot) ?? capCompactionSummary(summaryBody, bodySlot);
+  const rendered = retentionPlan?.render(bodySlot);
+  const cappedBody = rendered?.text ?? capCompactionSummary(summaryBody, bodySlot);
   const suffixBudget = Math.max(0, maxChars - cappedBody.length);
   const cappedSuffix = capCompactionSuffix(suffix, suffixBudget);
   return {
     summary: `${cappedBody}${cappedSuffix}`,
     structuralSummary: cappedBody,
     bodyBudget: bodySlot,
-    bodyTrimmed: cappedBody.length < summaryBody.length,
+    bodyTrimmed: rendered ? rendered.trimmed : cappedBody.length < summaryBody.length,
     suffixTrimmed: cappedSuffix.length < suffix.text.length,
     qualityRetentionInfeasible: retentionPlan !== null && retentionPlan.minimumChars > maxChars,
   };
@@ -1044,29 +896,22 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       thinkingLevel,
       streamFn,
     } = event;
-    const rawTurnPrefixMessages = preparation.turnPrefixMessages ?? [];
-    let baseMessagesToSummarize = stripRuntimeContextCustomMessages(
+    const baseMessagesToSummarize = stripRuntimeContextCustomMessages(
       preparation.messagesToSummarize,
     );
-    let baseTurnPrefixMessages = stripRuntimeContextCustomMessages(rawTurnPrefixMessages);
-    let hasRealSummarizable = containsRealConversation(baseMessagesToSummarize);
-    let hasRealTurnPrefix = containsRealConversation(baseTurnPrefixMessages);
-    if (!hasRealSummarizable && !hasRealTurnPrefix) {
-      const branchMessages = filterReplayUnsafeSessionBranchMessages(
-        stripRuntimeContextCustomMessages(collectSessionBranchMessages(ctx.sessionManager)),
+    const baseTurnPrefixMessages = stripRuntimeContextCustomMessages(
+      preparation.turnPrefixMessages ?? [],
+    );
+    // A prepared window of pure tool traffic is still real work when the current
+    // context anchors it (a kept user turn or a prior compaction summary); only a
+    // context with no real conversation at all gets the anti-loop boundary below.
+    const hasRealConversation =
+      containsRealConversation([...baseMessagesToSummarize, ...baseTurnPrefixMessages]) ||
+      containsRealConversation(
+        stripRuntimeContextCustomMessages(collectSessionContextMessages(ctx.sessionManager)),
       );
-      if (containsRealConversation(branchMessages)) {
-        log.info(
-          "Compaction safeguard: using session branch messages after compaction preparation omitted real conversation content.",
-        );
-        baseMessagesToSummarize = branchMessages;
-        baseTurnPrefixMessages = [];
-        hasRealSummarizable = true;
-        hasRealTurnPrefix = false;
-      }
-    }
     setCompactionSafeguardCancelReason(ctx.sessionManager, undefined);
-    if (!hasRealSummarizable && !hasRealTurnPrefix) {
+    if (!hasRealConversation) {
       // When there are no summarizable messages AND no real turn-prefix content,
       // cancelling compaction leaves context unchanged but the SDK re-triggers
       // _checkCompaction after every assistant response — creating a cancel loop

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -136,11 +136,41 @@ function prependPreviousSummaryForRedistill(params: {
  * behind every boundary and turns one compaction into dozens of model calls.
  */
 function collectSessionContextMessages(sessionManager: unknown): AgentMessage[] {
+  return projectBranchEntries(readSessionBranch(sessionManager));
+}
+
+/**
+ * The boundary-scoped range a preparation was meant to cover: everything the
+ * current context holds before its kept tail, minus the prior summary message
+ * (that is re-distilled separately). Bounded by construction — it can never
+ * reach behind the last reset/compaction boundary.
+ */
+function collectPreparationRangeMessages(
+  sessionManager: unknown,
+  firstKeptEntryId: string,
+): AgentMessage[] {
+  const entries = readSessionBranch(sessionManager);
+  const firstKeptIndex = entries.findIndex((entry) => entry.id === firstKeptEntryId);
+  if (firstKeptIndex < 0) {
+    return [];
+  }
+  return projectBranchEntries(entries.slice(0, firstKeptIndex)).filter(
+    (message) => message.role !== "compactionSummary",
+  );
+}
+
+function readSessionBranch(sessionManager: unknown): CoreSessionTreeEntry[] {
   try {
     const entries: unknown = (sessionManager as { getBranch?: () => unknown })?.getBranch?.();
-    return Array.isArray(entries)
-      ? (buildCoreSessionContext(entries as CoreSessionTreeEntry[]).messages as AgentMessage[])
-      : [];
+    return Array.isArray(entries) ? (entries as CoreSessionTreeEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function projectBranchEntries(entries: CoreSessionTreeEntry[]): AgentMessage[] {
+  try {
+    return buildCoreSessionContext(entries).messages as AgentMessage[];
   } catch {
     return [];
   }
@@ -896,12 +926,27 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       thinkingLevel,
       streamFn,
     } = event;
-    const baseMessagesToSummarize = stripRuntimeContextCustomMessages(
+    let baseMessagesToSummarize = stripRuntimeContextCustomMessages(
       preparation.messagesToSummarize,
     );
-    const baseTurnPrefixMessages = stripRuntimeContextCustomMessages(
+    let baseTurnPrefixMessages = stripRuntimeContextCustomMessages(
       preparation.turnPrefixMessages ?? [],
     );
+    if (!containsRealConversation([...baseMessagesToSummarize, ...baseTurnPrefixMessages])) {
+      // Safety net for a preparation that dropped real conversation from the
+      // range it covers: summarize that boundary-scoped range instead. It is
+      // never the raw branch, which re-read every reset and prior compaction.
+      const rangeMessages = stripRuntimeContextCustomMessages(
+        collectPreparationRangeMessages(ctx.sessionManager, preparation.firstKeptEntryId),
+      );
+      if (containsRealConversation(rangeMessages)) {
+        log.info(
+          "Compaction safeguard: summarizing the boundary-scoped preparation range after compaction preparation omitted real conversation content.",
+        );
+        baseMessagesToSummarize = rangeMessages;
+        baseTurnPrefixMessages = [];
+      }
+    }
     // A prepared window of pure tool traffic is still real work when the current
     // context anchors it (a kept user turn or a prior compaction summary); only a
     // context with no real conversation at all gets the anti-loop boundary below.


### PR DESCRIPTION
Related: #125641, #81182, #120162
Regressions introduced by #112988 (via #78390) and #122824 (via #128968).

AI-assisted by Codex and Claude.

## What Problem This Solves

Auto-compaction on long, tool-heavy sessions fails closed in three ways, all observed in production on the same Telegram sessions on 2026-08-25 (`openai/gpt-5.6-sol`, also `minimax/MiniMax-M3` on a cron lane):

**A. `Compaction timed out` after the full `timeoutSeconds` budget.** Every timeout in the logs is preceded by `Compaction safeguard: using session branch messages after compaction preparation omitted real conversation content`; every success lacks that line. Transport diagnostics (added in this PR) show the in-flight ChatGPT Responses stream was only 18–52 s old when the 900 s watchdog fired — nothing hung, the safeguard was simply on model call #N of dozens.

**B. `finalized summary failed quality checks; reasonCodes=missing_identifiers` → `guard_blocked`.** Both summary generations complete, then the audit rejects the artifact and the session is left `livenessState=blocked suggestedAction=reset_or_new`.

**C. `required quality facts exceed finalized artifact budget; requiredChars>16000 identifierCount=12` → cancel.** Seen after A and B were fixed and deployed: the audited identifiers total 368 chars, but the *previous* summary's `## Exact identifiers` section was 13,568 of its 13,953 chars and every other section was an empty heading.

Any of these leaves the operator with a dead session that only `/new` recovers.

## Why This Change Was Made

### A. The safeguard re-summarized the entire session branch

`compaction-safeguard.ts` decides whether there is anything to summarize with `containsRealConversation()` (user/assistant text, or tool results within 20 messages of such an anchor). After a compaction, an agent that keeps running tools produces a prepared window with **no** text — on the reporting session, 63 messages = 47 tool results + 15 assistant messages that contain only tool calls + 1 user turn kept in the tail. That window fails the check, and the fallback added in #78390 replaced it with `sessionManager.getBranch()`.

`getBranch()` is the whole path from root. When #78390 landed, `/new` created a new session file, so that was bounded to one session. #112988 (2026-07-23) made `/new` a `reset` entry inside the same transcript; `prepareCompaction` and `buildSessionContext` were taught to stop at that boundary, the safeguard fallback was not. The reporting session has 30 `reset` entries and 2 compactions: 3,565 messages / 5.2 MB / ~1.3M tokens. `summarizeInStages` chunks that at ~100K tokens per call, sequentially, with retries — 15 minutes is not enough.

The original reason for the fallback — Pi's preparation omitting `custom_message` content — is handled by core `projectSessionEntryMessage` today, so the fallback is pure liability. This PR:

- Summarizes **only the prepared window** (`preparation.messagesToSummarize` + `turnPrefixMessages`), which is what `prepareCompaction` already cut for exactly this purpose.
- Decides "nothing to summarize" from the **boundary-scoped context** (`buildSessionContext(getBranch())`: previous compaction summary + kept tail + newer entries). A tool-only window is real work when a kept user turn or a prior compaction summary anchors it; only a context with no real conversation at all (heartbeat-only cron lanes, #41981) gets the anti-loop boundary.
- Keeps a **bounded safety net** for the case the original fallback was written for (a preparation that omits real conversation): when the prepared window has no conversation, the safeguard projects the branch entries the preparation covered — after the last reset/compaction boundary, before `firstKeptEntryId` — through the same core `buildSessionContext`, and summarizes that range if it contains conversation the preparation dropped. By construction it cannot reach behind a boundary, so it can never re-read the whole session. When preparation is correct, the range's conversation content equals the window's and nothing is substituted.
- Deletes the fallback plus `sanitizeSourceSessionSends` / `filterReplayUnsafeSessionBranchMessages` (#93293), which existed only to make the raw-branch replay safe, and their five dead-path tests (all of them fed an empty preparation, a state `prepareCompaction` never emits).

Net production change in `compaction-safeguard.ts`: −155 lines.

### B. Audited identifiers were extracted from text the summary could never contain

The audit's identifier oracle is `extractOpaqueIdentifiers(oracleMessages.slice(-10))`. #122824 (2026-08-13) changed `oracleMessages` from the post-split messages (what the summarizer sees) to the pre-split messages, which include the "recent turns preserved verbatim" that go into the suffix at **600 chars per message, 8 KB per section, oldest dropped** (#25554, #123827). An identifier that lives only in a 50 KB tool result never reaches the summarizer and is cut from the suffix — so the audit fails, the corrective retry cannot fix what the model never saw, and compaction cancels. The log signature is exactly `finalized artifact truncated; loss=preserved-turn-head` followed by `missing_identifiers`.

#128968 added `createSummaryQualityRetentionPlan()`, which restores missing identifiers deterministically from the audit facts — but (1) it returned `null` whenever the audit summary omitted an identifier (the contradiction the first commit of this PR removes), and (2) `budgetCompactionSummary()` only invoked it when body+suffix exceeded 16,000 chars. Case (2) is the one in the production logs: the artifact fit the budget, so the repair never ran.

This PR runs the retention plan whenever a strict identifier is missing from the body, regardless of budget, and only emits the `[Compaction summary truncated to fit budget]` marker when body text was actually trimmed. Summaries that already carry their identifiers pass through byte-identical (covered by the existing `returns the first finalized retry that passes the source audit` test).

### C. The retention plan protected the model's identifier list verbatim, so it snowballed

#128968's `createSummaryQualityRetentionPlan()` treated the whole model-written `## Pending user asks` and `## Exact identifiers` sections as untrimmable and gave the remaining budget to the other three sections. Each compaction re-distills the previous summary, and the strict instruction ("preserve all opaque identifiers exactly as written") makes the model carry every identifier forward — so the protected list only grows. Once it filled the budget, the other sections were rendered as bare headings; once it passed 16 K on its own, `minimumChars > maxChars` flagged the plan infeasible and compaction cancelled. That is the exact 20:40 UTC-4 failure on the reporting session.

This PR protects only what the audit needs — the five headings, the bounded latest-ask context (≤ 2,000 chars), and the ≤ 12 audited identifiers. The audit-bearing sections are funded before the others (so an oversized `## Decisions` still cannot starve them — the existing tests for that invariant pass unchanged) but each is **hard-capped** at 25 % of the content budget; the rest is split across decisions, TODOs, and constraints. Two details make the cap actually bite (ClawSweeper P1s on an earlier head): the retention plan runs even when the summary still fits the 16 K budget if an audit section exceeds its cap — otherwise the 13.9 K dump on the reporting session would have passed through untouched into the next re-distill — and surplus budget is returned to the optional sections only, never to the protected ones (with all optional sections empty, the old remainder loop handed the whole surplus back to the identifier list). The 25 % share is a safeguard-owned budget policy, not a config surface.

### Transport diagnostic (ClawSweeper P1 addressed)

The stream-termination warning no longer logs `errorMessage`: `projectProviderError` keeps provider message/body text after credential redaction, so it could carry prompt- or response-derived content. It now logs only locally-derived facts — timing, stop classification, and a fixed `failureKind` enum (`timeout` / `caller-abort` / `provider-failure` / `transport`) computed from local `instanceof` checks (`ResponsesStreamFailure` and direct non-OK HTTP replies via `CodexApiError` both classify as `provider-failure`). No projected provider field (message, body, code, type, name) is logged; the failed-response test feeds hostile `code`/`type`/`message` values and asserts none reach the log.

### Kept from the earlier revision

- Removal of the `createSummaryQualityRetentionPlan` early return (#129423 first commit).
- ChatGPT Responses stream-termination diagnostics (`provider/api/model/transport/elapsedMs/stopReason/failureKind`) — these are what proved the timeout was call volume, not a hung stream.

### Scope

`compaction-safeguard.ts` is the provider-agnostic hook for every model in `safeguard` mode (Anthropic, OpenAI, MiniMax, Ollama, …). Harnesses that own compaction natively (Codex app-server, Claude CLI) still fall through to it when the native path declines.

Not addressed here, tracked separately: #126469 (tool-result truncation aborts on idempotency-key conflict, which blocked the `compact_then_truncate` route once in the same logs), #120162 (quality retry shares the compaction timeout), #81182 (truncate before waiting for compaction).

## User Impact

- Tool-heavy sessions compact in one bounded pass instead of timing out; no more `Compaction timed out` from summarizing history behind `/new` and prior compactions.
- Summaries that omit an audited identifier are repaired instead of cancelling compaction, so `missing_identifiers` no longer strands a session.
- Identifier-dense sessions keep their decisions/TODOs/asks across re-distills instead of degrading into a bare identifier list, and can no longer cancel with "required facts exceed the budget".
- Heartbeat-only lanes keep the anti-loop boundary behavior.
- Operators who raised `agents.defaults.compaction.timeoutSeconds` to work around A can return to the default.

## Evidence

- Production logs, 2026-08-25 (redacted): six `Compaction timed out` events, each 900 s after `using session branch messages …`; concurrent stream diagnostics `elapsedMs=37365 / 18037 / 52017 stopReason=aborted` at the watchdog. Two `guard_blocked` events with `loss=preserved-turn-head` → `reasonCodes=missing_identifiers`.
- Session store forensics on the reporting session: 3,646 branch events, 30 `reset` entries, 2 `compaction` entries, 5.2 MB of message text; post-compaction window 63 messages / 47 tool results / 15 text-less assistant messages / 1 user turn; six ~51 KB tool results.
- Post-deploy proof (fixes A+B live since 20:18 UTC-4): `topic:1` compacted in 1 s at 20:27, `topic:52972` in 36 s, `topic:8428` in 2 min, MiniMax cron lane twice — no timeouts, no branch fallback. The 20:40 failure on `topic:1` was cause C; session-store forensics show the prior summary at 13,953 chars with a 13,568-char identifiers section and empty `Decisions`/`Open TODOs`/`Constraints`/`Pending user asks` headings.
- Regression tests (each fails on the pre-fix production code, verified by stashing the production file under test):
  - `summarizes only the prepared tool-only window when the context anchors it` — branch with history behind a reset + compaction; asserts `summarizeInStages` receives only the prepared `assistant/toolResult` pair and none of the reset-era text.
  - `restores source identifiers omitted by a generated summary that fits the budget` — under-16K summary missing a source path; asserts it is restored under `## Exact identifiers` without the truncation marker and with no cancel reason.
  - `keeps real sections when a re-distilled identifier list outgrows the budget` — 400-line hoarded identifier list; pre-fix cancels, post-fix keeps decisions/TODOs/asks, keeps the audited identifier, trims the list head-first, stays ≤ 16 K, identifier section ≤ 25 % of the budget.
  - `caps an identifier list that outgrew its share while the summary still fits` — 200-line list, total under 16 K; pre-fix passes it through unchanged, post-fix caps it and keeps the other sections.
  - `keeps surplus budget out of the protected sections when trimming` — all optional sections empty (production shape); pre-fix the identifier section takes 3,804 of a 4,000 budget, post-fix ≤ 25 %.
  - `classifies a direct HTTP rejection as a provider failure without logging its text` — direct 400 with a hostile body; `failureKind: "provider-failure"`, no body text in the log.
  - `recovers real conversation the preparation omitted from its boundary-scoped range` — branch with history behind a reset, a user turn the preparation dropped, a tool-only prepared window; asserts the summarizer receives the dropped user turn plus the window and nothing from behind the reset. Fails pre-fix (summarizes only the tool window).
  - `writes the anti-loop boundary for a tool-only window when nothing anchors it` — protects the #41981 boundary behavior.
  - `preserves failed response identity and provider error details over sse|websocket` now feeds hostile provider `code`/`type`/`message` values and asserts the log equals exactly the local field set with none of that text.
- `node scripts/run-vitest.mjs src/agents/agent-hooks src/agents/embedded-agent-runner/compact src/agents/sessions/agent-session-compaction src/agents/compaction packages/ai/src/providers/openai-chatgpt-responses` — 443 tests passed.
- `node scripts/check-changed.mjs` — exit 0 (format, typecheck, lint, knip, boundary and ratchet guards). Assertion-safety baseline shrank by the 5 removed assertions (`--prune`).
- Production LOC vs `main`: `compaction-safeguard.ts` +67/−177, `compaction-safeguard-quality.ts` +89/−51, `openai-chatgpt-responses.ts` +35/−2; tests net −190.
