### PR TITLE
fix(gateway): preserve replies after hidden user turns

### DIFF
--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -889,25 +889,17 @@ describe("streamProxy loopback /api/stream", () => {
         throw new Error("expected loopback server address");
       }
 
-      const result = await resultWithinMs(
-        streamProxy(model, context, {
-          authToken: "token",
-          proxyUrl: `http://127.0.0.1:${address.port}`,
-          timeoutMs: 3_000,
-        }),
-        1_000,
-      );
+      const result = await streamProxy(model, context, {
+        authToken: "token",
+        proxyUrl: `http://127.0.0.1:${address.port}`,
+        timeoutMs: 3_000,
+      }).result();
+      // Native cancellation closes the remote socket asynchronously; the test owns the deadline.
+      await closed;
       expect(result).toMatchObject({
         ...entry.expected,
         content: [{ type: "text", text: "visible" }],
       });
-      const socketClosed = await Promise.race([
-        closed.then(() => true),
-        new Promise<boolean>((resolve) => {
-          setTimeout(() => resolve(false), 300);
-        }),
-      ]);
-      expect(socketClosed).toBe(true);
     },
   );
 

--- a/src/gateway/chat-display-projection.history.ts
+++ b/src/gateway/chat-display-projection.history.ts
@@ -405,7 +405,7 @@ export function filterVisibleProjectedHistoryMessages(
       continue;
     }
     if (
-      isDuplicateAcpGatewayInjectedMessage(current, visible.at(-1)) ||
+      isDuplicateAcpGatewayInjectedMessage(current, messages[i - 1]) ||
       isDuplicateChannelFinalDeliveryMirror(current, messages[i - 1])
     ) {
       changed = true;

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -1242,6 +1242,62 @@ describe("session history HTTP endpoints", () => {
     });
   });
 
+  test("keeps repeated assistant replies from separate hidden user turns in REST and SSE history", async () => {
+    const storePath = await createSessionStoreFile();
+    const sessionId = "sess-hidden-turn-replies";
+    const sessionKey = "agent:main:main";
+    await writeSessionStore({
+      entries: { main: { sessionId, updatedAt: Date.now() } },
+      storePath,
+    });
+    const assistantMessage = (text: string, model: string) =>
+      makeTranscriptAssistantMessage({ text, provider: "openclaw", model });
+    await replaceTranscriptEvents({ agentId: AGENT_ID, sessionId, sessionKey, storePath }, [
+      { type: "session", version: 1, id: sessionId },
+      { message: assistantMessage("First reply.", "acp-runtime") },
+      { message: { role: "user", content: "" } },
+      { message: assistantMessage("First reply.", "gateway-injected") },
+      { message: assistantMessage("Second reply.", "acp-runtime") },
+      { message: { role: "user", content: HEARTBEAT_PROMPT } },
+      { message: assistantMessage("Second reply.", "gateway-injected") },
+      { message: assistantMessage("Third reply.", "acp-runtime") },
+      { message: { role: "user", content: HEARTBEAT_PROMPT } },
+      { message: { role: "assistant", content: "HEARTBEAT_OK" } },
+      { message: assistantMessage("Third reply.", "gateway-injected") },
+    ]);
+
+    const expectedRows = [
+      "1:assistant:First reply.",
+      "3:assistant:First reply.",
+      "4:assistant:Second reply.",
+      "6:assistant:Second reply.",
+      "7:assistant:Third reply.",
+      "10:assistant:Third reply.",
+    ];
+    await withGatewayHarness(async (harness) => {
+      const history = await readSessionHistoryBody(harness.port, sessionKey);
+      expect(history.messages?.map(sessionHistoryRowIdentity)).toEqual(expectedRows);
+      expect(history.messages?.map((message) => message.__openclaw?.turnBoundary)).toEqual([
+        undefined,
+        undefined,
+        undefined,
+        true,
+        undefined,
+        true,
+      ]);
+
+      const stream = await openSessionHistorySse(harness.port, sessionKey);
+      try {
+        const event = await readSseEvent(stream.reader, stream.streamState);
+        expect(event.event).toBe("history");
+        const streamedHistory = event.data as SessionHistoryBody;
+        expect(streamedHistory.messages?.map(sessionHistoryRowIdentity)).toEqual(expectedRows);
+      } finally {
+        await stream.reader.cancel();
+      }
+    });
+  });
+
   test.each([
     { name: "all-silent tail", heartbeatBoundary: false, silentMessages: 40 },
     { name: "heartbeat context boundary", heartbeatBoundary: true, silentMessages: 39 },

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -1277,7 +1277,7 @@ describe("session history HTTP endpoints", () => {
     await withGatewayHarness(async (harness) => {
       const history = await readSessionHistoryBody(harness.port, sessionKey);
       expect(history.messages?.map(sessionHistoryRowIdentity)).toEqual(expectedRows);
-      expect(history.messages?.map((message) => message.__openclaw?.turnBoundary)).toEqual([
+      expect(history.messages?.map((message) => message["__openclaw"]?.turnBoundary)).toEqual([
         undefined,
         undefined,
         undefined,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing a session history would lose a real assistant reply when that reply matched an earlier answer and an empty hidden user turn, heartbeat prompt, or heartbeat acknowledgment separated the two turns.

## Why This Change Was Made

ACP reply deduplication compared the candidate against the previous visible message, so filtering an intervening user turn made answers from distinct turns appear adjacent. Compare against the preceding original message instead, matching the existing channel-final duplicate owner. This preserves same-turn duplicate suppression without changing stored transcripts, SQLite, public protocols, or configuration.

## User Impact

Actual assistant answers remain visible in both Gateway session-history HTTP responses and server-sent events after hidden user or heartbeat turns, while legitimate adjacent duplicate replies remain suppressed.

## Evidence

- Before the fix, an actual local Gateway HTTP request returned only assistant transcript rows 1, 4, and 7; the genuine later-turn replies at rows 3, 6, and 10 were incorrectly missing.
- After the fix, the same running Gateway returns all six expected replies through both REST and SSE, with heartbeat turn-boundary metadata preserved.
- Rebased onto main `c3d95c2d8071539aa66b4adce1da96ef8e32c3b4`; final candidate with test-only CI repair `f8d47e6cdd49053dcadf55f9b3a0ac27fff7b00f`.
- `env OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/agents/runtime/proxy.test.ts src/gateway/sessions-history-http.test.ts src/gateway/session-history-state.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/chat-display-projection.test.ts` — all 385 tests passed, including 89 real HTTP/SSE tests and 23 proxy tests.
- Targeted core lint and `git diff origin/main...HEAD --check` passed on the refreshed candidate.
- `git diff --check`, formatting, architecture/plugin-boundary guards, dependency guards, and production/full-tree/script dead-export scans passed.
- The earlier CI failure was the main-branch provider-runtime auth-loading regression; its owner fixes #129387 and #129346 are now merged and included in this rebase. Hosted CI supplies clean-install validation because this linked checkout shares an older dependency install.
- Independent source-aware review and structured Codex autoreview of the original repair and test cleanup: no actionable findings. Production LOC: +1/-1, net zero; tests: +63/-15, net +48.
- This is a read-time HTTP/SSE projection repair. No persistent-storage projection, schema, writer, store format, or user-visible persistence semantics are changed.

### CI cleanup included

The refreshed CI run 33006398458 exposed a flaky native proxy cleanup test from #117887: it required the remote socket-close event within an unsupported 300 ms. The test now awaits the actual close event under Vitest's existing deadline and checks the terminal content afterward. This removes eight test lines and two competing timing races without altering production behavior. As a mutation check, removing only the production terminal-cancellation call made all three success/error/malformed terminal cases fail; restoring it made all 23 proxy tests pass. The mutation was not committed.

`node scripts/check-changed.mjs -- src/agents/runtime/proxy.test.ts` passed format, architecture, dependency, and all three dead-export guards, then hit this linked checkout's existing stale Google/Markdown/TUI dependency types during core-test typechecking. Targeted lint passed separately. Exact-head [CI run 33010607499](https://github.com/openclaw/openclaw/actions/runs/33010607499) is now green, including production/test typechecks and the formerly failing proxy shard. Structured Codex autoreview of the complete final branch passed with no actionable findings.
