### PR TITLE
fix(maintainers): avoid skipped CI runs blocking PR landing

### DIFF
--- a/scripts/watch-pr-ci.mts
+++ b/scripts/watch-pr-ci.mts
@@ -67,7 +67,11 @@ const RollupResponseSchema = z.object({
     repository: z.object({ pullRequest: RollupPageSchema.nullish() }).nullish(),
   }),
 });
-const RunListItemSchema = z.object({ id: z.number(), workflow_id: optionalNumber });
+const RunListItemSchema = z.object({
+  id: z.number(),
+  workflow_id: optionalNumber,
+  conclusion: optionalNullable(z.string()),
+});
 const RunListSchema = z
   .object({ workflow_runs: validArray(RunListItemSchema) })
   .transform((response) => response.workflow_runs)
@@ -308,9 +312,9 @@ const readPr = (pr: number, repo: string) =>
     ),
   );
 export const buildFindRunArgs = (repo: string, sha: string) =>
-  workflowRunsApiArgs(repo, sha, "pull_request", 1);
+  workflowRunsApiArgs(repo, sha, "pull_request", 20);
 export const selectRunAfter = (runs: RunListItem[], after?: number) =>
-  runs.find((run) => after === undefined || run.id > after);
+  runs.find((run) => run.conclusion !== "skipped" && (after === undefined || run.id > after));
 const findRun = (repo: string, sha: string, after?: number) =>
   selectRunAfter(
     RunListSchema.parse(execGhJson(buildFindRunArgs(repo, sha), GH_READ_OPTIONS)),

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { chmodSync, writeFileSync } from "node:fs";
+import { delimiter, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   buildFindRunArgs,
   classifyAttachedCiRun,
@@ -10,8 +13,10 @@ import {
   sanitizeCheckName,
   selectRunAfter,
 } from "../../scripts/watch-pr-ci.mts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const sha = "a".repeat(40);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("watch-pr-ci", () => {
   it("parses defaults and overrides", () => {
@@ -77,7 +82,7 @@ describe("watch-pr-ci", () => {
       "-f",
       `head_sha=${sha}`,
       "-f",
-      "per_page=1",
+      "per_page=20",
     ]);
   });
 
@@ -88,6 +93,76 @@ describe("watch-pr-ci", () => {
     expect(selectRunAfter(runs, 102)).toBeUndefined();
     expect(selectRunAfter(runs)).toBe(newer);
   });
+
+  it("skips newer draft runs without weakening the --after boundary", () => {
+    const skipped = { id: 103, conclusion: "skipped" };
+    const successful = { id: 102, conclusion: "success" };
+
+    expect(selectRunAfter([skipped, successful])).toBe(successful);
+    expect(selectRunAfter([skipped, successful], 101)).toBe(successful);
+    expect(selectRunAfter([skipped, successful], 102)).toBeUndefined();
+    expect(selectRunAfter([skipped])).toBeUndefined();
+    for (const conclusion of [null, "failure", "cancelled"]) {
+      const attachable = { id: 102, conclusion };
+      expect(selectRunAfter([skipped, attachable])).toBe(attachable);
+    }
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "attaches to real CI when a newer draft workflow was skipped",
+    () => {
+      const binDir = tempDirs.make("openclaw-watch-pr-ci-");
+      const ghPath = join(binDir, "gh");
+      writeFileSync(
+        ghPath,
+        `#!/usr/bin/env bash
+case "$1 $2" in
+  "pr view") printf '{"state":"OPEN","mergeable":true,"headRefOid":"${sha}"}\\n' ;;
+  "api --method")
+    case " $* " in
+      *" per_page=1 "*) printf '{"workflow_runs":[{"id":202,"conclusion":"skipped"}]}\\n' ;;
+      *) printf '{"workflow_runs":[{"id":202,"conclusion":"skipped"},{"id":201,"conclusion":"success"}]}\\n' ;;
+    esac
+    ;;
+  "run view")
+    if [ "$3" = "202" ]; then
+      printf '{"status":"completed","conclusion":"skipped"}\\n'
+    else
+      printf '{"status":"completed","conclusion":"success"}\\n'
+    fi
+    ;;
+  *) printf 'unexpected gh invocation: %s\\n' "$*" >&2; exit 2 ;;
+esac
+`,
+      );
+      chmodSync(ghPath, 0o755);
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          "scripts/watch-pr-ci.mjs",
+          "42",
+          sha,
+          "--completion",
+          "ci-run",
+          "--attach-timeout",
+          "1",
+          "--timeout",
+          "1",
+          "--interval",
+          "1",
+        ],
+        {
+          encoding: "utf8",
+          env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}` },
+        },
+      );
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("ATTACHED run=201");
+      expect(result.stdout).toContain("GREEN");
+    },
+  );
 
   it("sanitizes untrusted check names for terminal output", () => {
     expect(sanitizeCheckName("plain ASCII / check (1)")).toBe("plain ASCII / check (1)");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers landing a pull request could wait up to 15 minutes for CI even though successful CI already existed for the exact reviewed commit, when a newer draft workflow run was skipped.

## Why This Change Was Made

The CI watcher now considers the same bounded 20-run window already used by the CI dispatch sibling and ignores skipped runs before selecting the newest eligible workflow run. Run discovery remains restricted to the canonical CI workflow, the `pull_request` event, and the exact commit SHA; strict `--after` boundaries, failed/cancelled runs, final run-state verification, and independent required-check enforcement are unchanged.

## User Impact

Maintainers can land pull requests immediately after their exact-head CI succeeds instead of silently exhausting the watcher attachment timeout behind an unrelated skipped draft invocation. No application, configuration, or public API behavior changes.

## Evidence

- Before the fix, the new executable watcher regression exited `13` with `NO-RUN-ATTACHED` after seeing skipped run 202 instead of successful run 201; the selection regression also chose the skipped run. Both failed against the frozen main baseline while 38 existing watcher tests passed.
- After the fix, the actual `scripts/watch-pr-ci.mjs --completion ci-run` process attaches to run 201 and reports `GREEN`; selection coverage also preserves pending, failed, cancelled, skipped-only, and strict `--after` behavior.
- `node scripts/run-vitest.mjs test/scripts/watch-pr-ci.test.ts test/scripts/verify-pr-hosted-gates.test.ts test/scripts/pr-ci-dispatch.test.ts test/scripts/plain-gh.test.ts` — 4 files, 137 tests passed.
- `node scripts/run-vitest.mjs test/scripts/pr-merge.test.ts test/scripts/watch-pr-ci.test.ts` — 2 files, 55 tests passed, including the native merge caller's independent required-check authority.
- `node scripts/check-changed.mjs -- scripts/watch-pr-ci.mts test/scripts/watch-pr-ci.test.ts` — complete scripts, root-test, and tooling gate passed, including both TypeScript projects, formatting, lint, and ownership guards.
- One live, exact-SHA, workflow-scoped GitHub API read confirmed successful and skipped `pull_request` runs coexist for the same commit and expose the conclusion and current attempt used by the existing watcher.
- Production: +7/-3 (net +4), required to retain the previously discarded nullable workflow conclusion at its authoritative reader. Tests: +77/-2.
