### PR TITLE
fix(tailscale): sweep orphaned foreground route children before claiming

### DIFF
--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { existsSync, symlinkSync, watch } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -333,4 +334,53 @@ describe("tailscale helpers", () => {
 
     await expect(hasTailscaleFunnelRouteForPort(18789, exec)).rejects.toBe(failure);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "kills an orphaned foreground route child reparented to PID 1 before claiming a fresh route",
+    async () => {
+      process.env.OPENCLAW_TEST_TAILSCALE_BINARY = fileURLToPath(
+        new URL("../../test/fixtures/tailscale-foreground-fixture.mjs", import.meta.url),
+      );
+      const fixturePath = fileURLToPath(
+        new URL("../../test/fixtures/tailscale-foreground-fixture.mjs", import.meta.url),
+      );
+
+      // Reproduce the exact orphan shape left behind when a route-owner
+      // worker is killed ungracefully: spawn a detached fixture child from a
+      // throwaway "grandparent" that exits immediately, so the OS reparents
+      // the child to PID 1 while it is still holding its foreground route.
+      const spawner = spawnSync(
+        process.execPath,
+        [
+          "-e",
+          "const {spawn}=require('node:child_process');" +
+            "const c=spawn(process.argv[1],process.argv.slice(2),{detached:true,stdio:'ignore'});" +
+            "c.unref();process.stdout.write(String(c.pid));",
+          fixturePath,
+          "serve",
+          "--yes",
+          "--bg=false",
+          "50999",
+        ],
+        { encoding: "utf8" },
+      );
+      const orphanPid = Number.parseInt(spawner.stdout.trim(), 10);
+      expect(Number.isFinite(orphanPid) && orphanPid > 0).toBe(true);
+
+      await vi.waitFor(() => {
+        const ppid = spawnSync("ps", ["-o", "ppid=", "-p", String(orphanPid)], {
+          encoding: "utf8",
+        }).stdout.trim();
+        expect(ppid).toBe("1");
+      });
+
+      const claim = await claimTailscaleRoute("serve", 18789);
+      try {
+        expect(claim.isActive()).toBe(true);
+        expect(() => process.kill(orphanPid, 0)).toThrow();
+      } finally {
+        await claim.stop();
+      }
+    },
+  );
 });

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -14,6 +14,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { runExec } from "../process/exec.js";
 import { signalProcessTree } from "../process/kill-tree.js";
+import { sleep } from "../utils/sleep.js";
 import { isVitestRuntimeEnv } from "./env.js";
 import { toErrorObject } from "./errors.js";
 import { retryAsync } from "./retry.js";
@@ -393,10 +394,78 @@ async function startTailscaleRouteOwner(argv: string[]): Promise<TailscaleRouteC
   }
 }
 
+const ORPHAN_SWEEP_TIMEOUT_MS = 3_000;
+const ORPHAN_KILL_GRACE_MS = 500;
+
+/**
+ * `startTailscaleRouteOwner` spawns a detached `tailscale serve/funnel
+ * --bg=false` foreground child that only its route-owner worker knows how to
+ * release (IPC `disconnect` or an explicit `stop`). If that worker dies
+ * ungracefully — SIGKILL, crash, an unclean Gateway restart — the child is
+ * reparented to PID 1 and keeps holding the route. Every later claim attempt
+ * then fails with TailscaleRouteOwnershipConflictError and there is no
+ * recovery path short of manually finding and killing the orphan. A PID-1
+ * parent is the reliable signal: any still-owned foreground child keeps its
+ * spawning worker as parent, so this can never match a live route.
+ */
+function parseOrphanedTailscaleRouteOwnerPids(psOutput: string): number[] {
+  const pids: number[] = [];
+  for (const line of psOutput.split("\n")) {
+    const match = /^\s*(\d+)\s+(\d+)\s+(.*)$/.exec(line);
+    if (!match) {
+      continue;
+    }
+    const [, pidRaw, ppidRaw, command] = match;
+    if (ppidRaw !== "1") {
+      continue;
+    }
+    const lower = (command ?? "").toLowerCase();
+    if (!lower.includes("tailscale")) {
+      continue;
+    }
+    if (!/\b(serve|funnel)\b/.test(lower) || !lower.includes("--bg=false")) {
+      continue;
+    }
+    const pid = Number.parseInt(pidRaw ?? "", 10);
+    if (Number.isFinite(pid) && pid > 0) {
+      pids.push(pid);
+    }
+  }
+  return pids;
+}
+
+async function sweepOrphanedTailscaleRouteOwners(exec: typeof runExec = runExec): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
+  let stdout: string;
+  try {
+    ({ stdout } = await exec("ps", ["-axww", "-o", "pid=,ppid=,command="], {
+      timeoutMs: ORPHAN_SWEEP_TIMEOUT_MS,
+      maxBuffer: 400_000,
+    }));
+  } catch {
+    // Best-effort probe; a failed scan should not block a fresh claim attempt.
+    return;
+  }
+  const pids = parseOrphanedTailscaleRouteOwnerPids(stdout);
+  if (pids.length === 0) {
+    return;
+  }
+  for (const pid of pids) {
+    signalProcessTree(pid, "SIGTERM", { detached: true });
+  }
+  await sleep(ORPHAN_KILL_GRACE_MS);
+  for (const pid of pids) {
+    signalProcessTree(pid, "SIGKILL", { detached: true });
+  }
+}
+
 export async function claimTailscaleRoute(
   mode: "serve" | "funnel",
   target: number | string,
 ): Promise<TailscaleRouteClaim> {
+  await sweepOrphanedTailscaleRouteOwners();
   const tailscaleBin = await getTailscaleBinary();
   const args = [mode, "--yes", "--bg=false", `${target}`];
   try {


### PR DESCRIPTION
## What Problem This Solves

A detached `tailscale serve/funnel --bg=false` foreground child is only released by its route-owner worker's graceful IPC path. If that worker is killed ungracefully (crash, force-kill, an unclean Gateway restart) the child is reparented to PID 1 and keeps holding the route, so every later claim attempt fails with `TailscaleRouteOwnershipConflictError` and the Gateway crash-loops with no recovery path short of manually finding and killing the orphan.

## Why This Change Was Made

`claimTailscaleRoute` now sweeps the process table for exactly that shape — a `tailscale serve/funnel --bg=false` child reparented to PID 1 — before attempting a fresh claim. This mirrors the existing stale-gateway-pid sweep in `restart-stale-pids.ts` rather than introducing a new recovery concept.

## User Impact

A Tailscale-fronted Gateway recovers automatically after an unclean restart instead of crash-looping until an operator finds and kills the orphaned child by hand. No configuration change.

## Evidence

- `src/infra/tailscale.test.ts`: 32 tests pass, cherry-picked onto current `main`.
- Encountered in production on a Tailscale-fronted Gateway, where the orphan squatted the route and the Gateway crash-looped with no self-recovery.
