### PR TITLE
fix(plugins): resolve provider auth owner lazily

### DIFF
--- a/src/plugins/provider-auth-choice.test.ts
+++ b/src/plugins/provider-auth-choice.test.ts
@@ -20,7 +20,8 @@ vi.mock("../wizard/setup.post-install-migration.js", () => ({
   offerPostInstallMigrations,
 }));
 
-const { runProviderPluginAuthMethodUnpersisted } = await import("./provider-auth-choice.js");
+const { runProviderPluginAuthMethod, runProviderPluginAuthMethodUnpersisted } =
+  await import("./provider-auth-choice.js");
 
 describe("runProviderPluginAuthMethodUnpersisted", () => {
   it("delegates remote browser destinations to structured wizard clients", async () => {
@@ -46,5 +47,35 @@ describe("runProviderPluginAuthMethodUnpersisted", () => {
     });
 
     expect(openUrl).toHaveBeenCalledWith("https://provider.example/oauth?state=state-1");
+  });
+});
+
+describe("runProviderPluginAuthMethod agent ownership", () => {
+  it("accepts a fully-scoped call on an explicit multi-agent roster", async () => {
+    // The configure wizard supplies agentDir/workspaceDir but no agentId, so the
+    // owner is never needed. Resolving it eagerly used to throw
+    // AgentSelectionRequiredError here and abort provider setup.
+    const method: ProviderPlugin["auth"][number] = {
+      id: "api-key",
+      label: "API key",
+      kind: "api_key",
+      run: async () => ({ profiles: [] }),
+    };
+
+    const applied = await runProviderPluginAuthMethod({
+      config: {
+        agents: {
+          ownership: "explicit",
+          entries: { main: { agentDir: "/tmp/main" }, ops: { agentDir: "/tmp/ops" } },
+        },
+      },
+      runtime: createNonExitingRuntime(),
+      prompter: createWizardPrompter(),
+      method,
+      agentDir: "/tmp/agent",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(applied.config).toBeDefined();
   });
 });

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -339,6 +339,18 @@ export async function runProviderPluginAuthMethod(params: {
   };
 }
 
+/**
+ * Defers owner resolution until a directory fallback actually needs it, so
+ * fully-scoped callers never trip agent selection on multi-agent rosters.
+ */
+function createLazyOwnerAgentId(params: {
+  agentId?: string;
+  config: OpenClawConfig;
+}): () => string {
+  let resolved: string | undefined;
+  return () => (resolved ??= params.agentId ?? resolveDefaultAgentId(params.config));
+}
+
 async function prepareProviderPluginAuthMethod(
   params: Parameters<typeof runProviderPluginAuthMethod>[0],
 ): Promise<{
@@ -347,11 +359,14 @@ async function prepareProviderPluginAuthMethod(
   authProfiles: ProviderAuthResult["profiles"];
   persistAuthProfiles: (profiles?: ProviderAuthResult["profiles"]) => Promise<void>;
 }> {
-  const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
-  const agentDir = params.agentDir ?? resolveAgentDir(params.config, agentId);
+  // Resolve the owner lazily: callers that already supply both directories never
+  // need an agent id, and eager resolution fails closed on explicit multi-agent
+  // rosters that have no sole owner.
+  const ownerAgentId = createLazyOwnerAgentId(params);
+  const agentDir = params.agentDir ?? resolveAgentDir(params.config, ownerAgentId());
   const workspaceDir =
     params.workspaceDir ??
-    resolveAgentWorkspaceDir(params.config, agentId) ??
+    resolveAgentWorkspaceDir(params.config, ownerAgentId()) ??
     resolveDefaultAgentWorkspaceDir();
   const result = await runProviderPluginAuthMethodUnpersisted({
     config: params.config,
@@ -405,10 +420,10 @@ async function prepareProviderPluginAuthMethod(
 export async function prepareAuthChoiceLoadedPluginProvider(
   params: ApplyProviderAuthChoiceParams,
 ): Promise<PreparedApplyProviderAuthChoiceResult | null> {
-  const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
+  const ownerAgentId = createLazyOwnerAgentId(params);
   const workspaceDir =
     params.workspaceDir ??
-    resolveAgentWorkspaceDir(params.config, agentId) ??
+    resolveAgentWorkspaceDir(params.config, ownerAgentId()) ??
     resolveDefaultAgentWorkspaceDir();
   let nextConfig = params.config;
   let enabledConfig = params.config;


### PR DESCRIPTION
## What Problem This Solves

The configure/model-picker flow calls `runProviderPluginAuthMethod` with `agentDir` and `workspaceDir` already resolved but no `agentId`. The owner was resolved eagerly even though it only feeds those two directory fallbacks, so a fully-scoped call still ran `resolveDefaultAgentId` and threw `AgentSelectionRequiredError` on an explicit multi-agent roster with no sole owner. Provider setup aborted before it began.

## Why This Change Was Made

Resolve the owner through a memoized thunk so it is computed only when a directory fallback actually needs it. Callers that omit the directories keep the previous behavior, including failing closed — this narrows *when* the owner is required, not *whether* it is enforced.

## User Impact

Provider setup completes on an explicit multi-agent roster with no sole owner. Previously it aborted with `AgentSelectionRequiredError` before any auth method ran.

## Evidence

`openclaw configure` exposes no non-interactive mode (only `--section`), so the reproduction drives the same production entry point the model picker calls — `runProviderPluginAuthMethod`, imported from `src/plugins/provider-auth-choice.ts` — with the identical caller shape: `agentDir` and `workspaceDir` supplied, `agentId` omitted, against a five-agent `agents.entries` roster with no sole owner. Identical harness on both builds; only the code differs.

**Before — `origin/main` at `930f740f83a`:**

```
roster: 5 agents in agents.entries, no sole owner
call:   runProviderPluginAuthMethod({ agentDir, workspaceDir, /* no agentId */ })
OUTCOME: AgentSelectionRequiredError
         Multiple agents are configured, but this operation has no explicit owner. Select an agent explicitly; CLI callers can pass --agent <id>, channels can add a bind
VERDICT: BLOCKED before provider setup — agent selection required.
```

**After — this branch:**

```
roster: 5 agents in agents.entries, no sole owner
call:   runProviderPluginAuthMethod({ agentDir, workspaceDir, /* no agentId */ })
OUTCOME: TypeError
         params.method.run is not a function
VERDICT: passed owner resolution; failed later in the auth method (expected with a stub).
```

The `TypeError` is the harness's stub auth method, reached only because owner resolution no longer throws. That change of failure point is the fix.

**Unit coverage:** `src/plugins/provider-auth-choice.test.ts` — 2 tests pass, cherry-picked onto current `main`.
