### PR TITLE
refactor(plugins): centralize host registration diagnostics

### DIFF
--- a/src/node-host/desktop-stream-command.test.ts
+++ b/src/node-host/desktop-stream-command.test.ts
@@ -256,7 +256,9 @@ describe("node desktop stream command", () => {
       }
       expect(stream.accessHeaders).toEqual(["desktop-client-id", "desktop-client-secret"]);
       if (kind === "public") {
-        expect(emitStatus).toHaveBeenCalledWith("desktop stream attached\n");
+        await vi.waitFor(() =>
+          expect(emitStatus).toHaveBeenCalledWith("desktop stream attached\n"),
+        );
       }
 
       controller.abort();

--- a/src/plugins/registry-registrars-host.ts
+++ b/src/plugins/registry-registrars-host.ts
@@ -71,6 +71,9 @@ function normalizeHostHookStringList(value: unknown): string[] | undefined | nul
 
 export function createHostRegistrars(state: PluginRegistryState) {
   const { registry, registryParams, pushDiagnostic } = state;
+  const reportRegistrationError = (record: PluginRecord, message: string) => {
+    pushDiagnostic({ level: "error", pluginId: record.id, source: record.source, message });
+  };
 
   const validateSessionActionSchema = (
     record: PluginRecord,
@@ -81,24 +84,17 @@ export function createHostRegistrars(state: PluginRegistryState) {
       return true;
     }
     if (!isPluginJsonValue(schema)) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `session action schema must be JSON-compatible: ${id}`,
-      });
+      reportRegistrationError(record, `session action schema must be JSON-compatible: ${id}`);
       return false;
     }
     if (
       typeof schema !== "boolean" &&
       (!schema || typeof schema !== "object" || Array.isArray(schema))
     ) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `session action schema must be a JSON schema object or boolean: ${id}`,
-      });
+      reportRegistrationError(
+        record,
+        `session action schema must be a JSON schema object or boolean: ${id}`,
+      );
       return false;
     }
     try {
@@ -109,12 +105,10 @@ export function createHostRegistrars(state: PluginRegistryState) {
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `session action schema is not valid JSON Schema: ${id}: ${message}`,
-      });
+      reportRegistrationError(
+        record,
+        `session action schema is not valid JSON Schema: ${id}: ${message}`,
+      );
       return false;
     }
     return true;
@@ -146,24 +140,14 @@ export function createHostRegistrars(state: PluginRegistryState) {
       }
     }
     if (invalidMessage) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: invalidMessage,
-      });
+      reportRegistrationError(record, invalidMessage);
       return;
     }
     const existing = registry.sessionExtensions.find(
       (entry) => entry.pluginId === record.id && entry.extension.namespace === namespace,
     );
     if (existing) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `session extension already registered: ${namespace}`,
-      });
+      reportRegistrationError(record, `session extension already registered: ${namespace}`);
       return;
     }
     if (normalizedSessionEntrySlotKey) {
@@ -179,12 +163,10 @@ export function createHostRegistrars(state: PluginRegistryState) {
         );
       });
       if (existingSlot) {
-        pushDiagnostic({
-          level: "error",
-          pluginId: record.id,
-          source: record.source,
-          message: `sessionEntrySlotKey already registered: ${normalizedSessionEntrySlotKey}`,
-        });
+        reportRegistrationError(
+          record,
+          `sessionEntrySlotKey already registered: ${normalizedSessionEntrySlotKey}`,
+        );
         return;
       }
     }
@@ -209,45 +191,37 @@ export function createHostRegistrars(state: PluginRegistryState) {
     policy: PluginTrustedToolPolicyRegistration,
   ) => {
     if (!policy || typeof policy !== "object") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "trusted tool policy registration requires id, description, and evaluate()",
-      });
+      reportRegistrationError(
+        record,
+        "trusted tool policy registration requires id, description, and evaluate()",
+      );
       return;
     }
     const id = normalizeHostHookString(policy.id);
     const description = normalizeHostHookString(policy.description);
     const matcher = normalizePluginToolMatcher(policy.matcher);
     if (!id || !description || typeof policy.evaluate !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "trusted tool policy registration requires id, description, and evaluate()",
-      });
+      reportRegistrationError(
+        record,
+        "trusted tool policy registration requires id, description, and evaluate()",
+      );
       return;
     }
     if (
       record.origin !== "bundled" &&
       !(record.contracts?.trustedToolPolicies ?? []).includes(id)
     ) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `plugin must declare contracts.trustedToolPolicies for: ${id}`,
-      });
+      reportRegistrationError(
+        record,
+        `plugin must declare contracts.trustedToolPolicies for: ${id}`,
+      );
       return;
     }
     if (record.origin !== "bundled" && !(record.enabled && record.explicitlyEnabled === true)) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `plugin must be explicitly enabled to register trusted tool policy: ${id}`,
-      });
+      reportRegistrationError(
+        record,
+        `plugin must be explicitly enabled to register trusted tool policy: ${id}`,
+      );
       return;
     }
     const policies = registry.trustedToolPolicies;
@@ -255,12 +229,10 @@ export function createHostRegistrars(state: PluginRegistryState) {
       (entry) => entry.pluginId === record.id && entry.policy.id === id,
     );
     if (existing) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `trusted tool policy already registered: ${id} (${existing.pluginId})`,
-      });
+      reportRegistrationError(
+        record,
+        `trusted tool policy already registered: ${id} (${existing.pluginId})`,
+      );
       return;
     }
     const registration: PluginTrustedToolPolicyRegistryRegistration = {
@@ -286,12 +258,7 @@ export function createHostRegistrars(state: PluginRegistryState) {
   const registerToolMetadata = (record: PluginRecord, metadata: PluginToolMetadataRegistration) => {
     const toolName = normalizeHostHookString(metadata.toolName);
     if (!toolName) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "tool metadata registration missing toolName",
-      });
+      reportRegistrationError(record, "tool metadata registration missing toolName");
       return;
     }
     const undeclared = findUndeclaredPluginToolNames({
@@ -299,12 +266,10 @@ export function createHostRegistrars(state: PluginRegistryState) {
       toolNames: [toolName],
     });
     if (undeclared.length > 0) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `plugin must declare contracts.tools for tool metadata: ${undeclared.join(", ")}`,
-      });
+      reportRegistrationError(
+        record,
+        `plugin must declare contracts.tools for tool metadata: ${undeclared.join(", ")}`,
+      );
       return;
     }
     // Metadata ownership is scoped to plugin + tool, preventing cross-plugin decoration.
@@ -312,12 +277,10 @@ export function createHostRegistrars(state: PluginRegistryState) {
       (entry) => entry.pluginId === record.id && entry.metadata.toolName === toolName,
     );
     if (existing) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `tool metadata already registered: ${toolName} (${existing.pluginId})`,
-      });
+      reportRegistrationError(
+        record,
+        `tool metadata already registered: ${toolName} (${existing.pluginId})`,
+      );
       return;
     }
     const displayName = normalizeOptionalHostHookString(metadata.displayName);
@@ -329,12 +292,10 @@ export function createHostRegistrars(state: PluginRegistryState) {
       tags === null ||
       (metadata.risk !== undefined && !["low", "medium", "high"].includes(metadata.risk))
     ) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `tool metadata registration has invalid metadata: ${toolName}`,
-      });
+      reportRegistrationError(
+        record,
+        `tool metadata registration has invalid metadata: ${toolName}`,
+      );
       return;
     }
     registry.toolMetadata.push({
@@ -372,24 +333,19 @@ export function createHostRegistrars(state: PluginRegistryState) {
       placement === "" ||
       requiredScopes === null
     ) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message:
-          "control UI descriptor registration requires id, surface, label, and valid optional fields",
-      });
+      reportRegistrationError(
+        record,
+        "control UI descriptor registration requires id, surface, label, and valid optional fields",
+      );
       return;
     }
     if (requiredScopes !== undefined) {
       const unknownScope = requiredScopes.find((scope) => !isOperatorScope(scope));
       if (unknownScope !== undefined) {
-        pushDiagnostic({
-          level: "error",
-          pluginId: record.id,
-          source: record.source,
-          message: `control UI descriptor requiredScopes contains unknown operator scope: ${unknownScope}`,
-        });
+        reportRegistrationError(
+          record,
+          `control UI descriptor requiredScopes contains unknown operator scope: ${unknownScope}`,
+        );
         return;
       }
     }
@@ -397,24 +353,17 @@ export function createHostRegistrars(state: PluginRegistryState) {
       return;
     }
     if (descriptor.schema !== undefined && !isPluginJsonValue(descriptor.schema)) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `control UI descriptor schema must be JSON-compatible: ${id}`,
-      });
+      reportRegistrationError(
+        record,
+        `control UI descriptor schema must be JSON-compatible: ${id}`,
+      );
       return;
     }
     const existing = registry.controlUiDescriptors.find(
       (entry) => entry.pluginId === record.id && entry.descriptor.id === id,
     );
     if (existing) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `control UI descriptor already registered: ${id}`,
-      });
+      reportRegistrationError(record, `control UI descriptor already registered: ${id}`);
       return;
     }
     const icon = normalizeOptionalHostHookString(descriptor.icon);
@@ -424,12 +373,10 @@ export function createHostRegistrars(state: PluginRegistryState) {
       tabPath === undefined ||
       (tabPath.startsWith("/") && !tabPath.startsWith("//") && !tabPath.startsWith("/\\"));
     if (!isLocalAbsolutePath) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `control UI descriptor path must be a gateway-local absolute path: ${id}`,
-      });
+      reportRegistrationError(
+        record,
+        `control UI descriptor path must be a gateway-local absolute path: ${id}`,
+      );
       return;
     }
     const group =
@@ -467,33 +414,18 @@ export function createHostRegistrars(state: PluginRegistryState) {
   ) => {
     const id = normalizePluginHostHookId(lifecycle.id);
     if (!id) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "runtime lifecycle registration missing id",
-      });
+      reportRegistrationError(record, "runtime lifecycle registration missing id");
       return;
     }
     const existing = registry.runtimeLifecycles.find(
       (entry) => entry.pluginId === record.id && entry.lifecycle.id === id,
     );
     if (existing) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `runtime lifecycle already registered: ${id}`,
-      });
+      reportRegistrationError(record, `runtime lifecycle already registered: ${id}`);
       return;
     }
     if (lifecycle.cleanup !== undefined && typeof lifecycle.cleanup !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `runtime lifecycle cleanup must be a function: ${id}`,
-      });
+      reportRegistrationError(record, `runtime lifecycle cleanup must be a function: ${id}`);
       return;
     }
     registry.runtimeLifecycles.push({
@@ -511,34 +443,25 @@ export function createHostRegistrars(state: PluginRegistryState) {
   ) => {
     const id = normalizePluginHostHookId(subscription.id);
     if (!id || typeof subscription.handle !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "agent event subscription registration requires id and handle",
-      });
+      reportRegistrationError(
+        record,
+        "agent event subscription registration requires id and handle",
+      );
       return;
     }
     const streams = normalizeHostHookStringList(subscription.streams);
     if (streams === null) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `agent event subscription streams must be an array of strings: ${id}`,
-      });
+      reportRegistrationError(
+        record,
+        `agent event subscription streams must be an array of strings: ${id}`,
+      );
       return;
     }
     const existing = registry.agentEventSubscriptions.find(
       (entry) => entry.pluginId === record.id && entry.subscription.id === id,
     );
     if (existing) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `agent event subscription already registered: ${id}`,
-      });
+      reportRegistrationError(record, `agent event subscription already registered: ${id}`);
       return;
     }
     registry.agentEventSubscriptions.push({
@@ -563,30 +486,18 @@ export function createHostRegistrars(state: PluginRegistryState) {
         (entry) => entry.pluginId === record.id && entry.job.id === jobId,
       )
     ) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `session scheduler job already registered: ${jobId}`,
-      });
+      reportRegistrationError(record, `session scheduler job already registered: ${jobId}`);
       return undefined;
     }
     if (!jobId || !sessionKey || !kind) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "session scheduler job registration requires unique id, sessionKey, and kind",
-      });
+      reportRegistrationError(
+        record,
+        "session scheduler job registration requires unique id, sessionKey, and kind",
+      );
       return undefined;
     }
     if (job.cleanup !== undefined && typeof job.cleanup !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `session scheduler job cleanup must be a function: ${jobId}`,
-      });
+      reportRegistrationError(record, `session scheduler job cleanup must be a function: ${jobId}`);
       return undefined;
     }
     if (registryParams.activateGlobalSideEffects === false) {
@@ -606,12 +517,10 @@ export function createHostRegistrars(state: PluginRegistryState) {
       job: { ...job, id: jobId, sessionKey, kind },
     });
     if (!handle) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "session scheduler job registration requires unique id, sessionKey, and kind",
-      });
+      reportRegistrationError(
+        record,
+        "session scheduler job registration requires unique id, sessionKey, and kind",
+      );
       return undefined;
     }
     registry.sessionSchedulerJobs.push({
@@ -639,23 +548,19 @@ export function createHostRegistrars(state: PluginRegistryState) {
       requiredScopes === null ||
       typeof action.handler !== "function"
     ) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "session action registration requires id, handler, and valid optional fields",
-      });
+      reportRegistrationError(
+        record,
+        "session action registration requires id, handler, and valid optional fields",
+      );
       return;
     }
     if (requiredScopes !== undefined) {
       const unknownScope = requiredScopes.find((scope) => !isOperatorScope(scope));
       if (unknownScope !== undefined) {
-        pushDiagnostic({
-          level: "error",
-          pluginId: record.id,
-          source: record.source,
-          message: `session action requiredScopes contains unknown operator scope: ${unknownScope}`,
-        });
+        reportRegistrationError(
+          record,
+          `session action requiredScopes contains unknown operator scope: ${unknownScope}`,
+        );
         return;
       }
     }
@@ -666,12 +571,7 @@ export function createHostRegistrars(state: PluginRegistryState) {
       (entry) => entry.pluginId === record.id && entry.action.id === id,
     );
     if (existing) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `session action already registered: ${id}`,
-      });
+      reportRegistrationError(record, `session action already registered: ${id}`);
       return;
     }
     registry.sessionActions.push({


### PR DESCRIPTION
## What Problem This Solves

Plugin host registration repeated identical error-diagnostic construction across 33 validation branches, making the registration owner unnecessarily large and making consistent plugin attribution harder to inspect.

## Why This Change Was Made

Centralize host-registration error construction in one private lexical helper at the existing registrar owner. Every registration keeps the same validation conditions, rejection order, diagnostic severity, plugin ID, source, exact message, return value, and successful side effects. Native Control UI route ownership continues to receive the original diagnostic callback unchanged.

Production LOC: +99/-199 (net -100). Tests: +0/-0. No public SDK, configuration, provider, storage, or dependency changes.

## User Impact

No user-visible behavior changes. Invalid plugin registrations retain their existing actionable, plugin-attributed diagnostics and security-sensitive rejection behavior.

## Evidence

- Baseline and candidate both passed all 121 tests across host-hook contracts, session-action contracts, Control UI ownership, and registry sibling contracts: `node scripts/run-vitest.mjs src/plugins/contracts/host-hooks.contract.test.ts src/plugins/contracts/session-actions.contract.test.ts src/plugins/registry.control-ui.test.ts src/plugins/contracts/registry.retry.test.ts src/plugins/contracts/registry.contract.test.ts`.
- Full changed-file gate passed without skips: `node scripts/check-changed.mjs -- src/plugins/registry-registrars-host.ts`, including production/full-tree/scripts dead-export scans, core and test TypeScript checks, lint, plugin boundaries, import cycles, and repository safety guards.
- Fresh structured Codex review returned no findings, and a separate independent owner-boundary source review confirmed unchanged rejection behavior and diagnostic payloads.
