### PR TITLE
fix(workboard): scope attempt ids to the owning card

### DIFF
--- a/extensions/workboard/src/store-card-helpers.ts
+++ b/extensions/workboard/src/store-card-helpers.ts
@@ -67,21 +67,35 @@ export function syncExecutionAttemptMetadata(
   metadata: WorkboardMetadata,
   execution: WorkboardExecution | undefined,
   now: number,
+  cardId?: string,
 ): WorkboardMetadata {
   if (!execution) {
     return metadata;
   }
   const attemptStatus = executionAttemptStatus(execution);
   const attempts = [...(metadata.attempts ?? [])];
-  const key = execution.runId ?? execution.sessionKey ?? execution.id;
+  // `workboard_card_attempts.id` is a global PRIMARY KEY, but `sessionKey` and
+  // `id` are shared by every card touched in one dashboard session. Without a
+  // card prefix, two cards mint the same attempt id and the second insert dies
+  // on the primary key forever — the row delete in insertChildren is scoped to
+  // `card_id`, so it can never clear the row the other card owns. `runId` is
+  // already per-run, so it stays unprefixed and existing rows keep matching.
+  const legacyKey = execution.runId ?? execution.sessionKey ?? execution.id;
+  const key = execution.runId ?? (cardId ? `${cardId}:${legacyKey}` : legacyKey);
   const existingIndex = attempts.findIndex(
     (attempt) =>
       (execution.runId && attempt.runId === execution.runId) ||
-      (!execution.runId && attempt.id === key),
+      // Match the legacy id too so an upgrade rewrites the existing attempt in
+      // place instead of appending a duplicate beside it.
+      (!execution.runId && (attempt.id === key || attempt.id === legacyKey)),
   );
   const existingAttempt = existingIndex >= 0 ? attempts[existingIndex] : undefined;
   const nextAttempt: WorkboardRunAttempt = {
-    id: existingAttempt?.id ?? key,
+    // Always adopt `key`, never the stored id: an attempt already persisted
+    // under the legacy shared id must migrate to the card-scoped one, or the
+    // collision survives the upgrade. When `runId` is set, `key` is that runId,
+    // so this is identical to the previous behavior.
+    id: key,
     status: attemptStatus,
     startedAt: existingAttempt?.startedAt ?? execution.startedAt,
     mode: execution.mode,

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -593,8 +593,10 @@ export class WorkboardCoreStore {
       },
       { allowDependencyLinks: false, allowArchivedAt: false },
     );
+    // Resolved before the attempt sync so attempt ids can be scoped to this card.
+    const cardId = options.cardId ?? randomUUID();
     const syncedMetadata = trimMetadataToBudget(
-      syncExecutionAttemptMetadata(metadata, execution, now),
+      syncExecutionAttemptMetadata(metadata, execution, now, cardId),
     );
     const boardId = syncedMetadata.automation?.boardId ?? "default";
     const position = Number.isFinite(normalizedPosition)
@@ -606,7 +608,7 @@ export class WorkboardCoreStore {
             .map((card) => card.position),
         ) + POSITION_STEP;
     let card: WorkboardCard = {
-      id: options.cardId ?? randomUUID(),
+      id: cardId,
       title: normalizeTitle(input.title),
       status,
       priority: normalizePriority(input.priority, "normal"),
@@ -868,7 +870,7 @@ export class WorkboardCoreStore {
       ...(completedAt ? { completedAt } : {}),
     });
     next.metadata = trimMetadataToBudget(
-      syncExecutionAttemptMetadata(next.metadata ?? {}, execution, now),
+      syncExecutionAttemptMetadata(next.metadata ?? {}, execution, now, next.id),
       options,
     );
     next.events = appendEvent(

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -961,7 +961,9 @@ describe("WorkboardStore", () => {
       metadata: {
         attempts: [
           expect.objectContaining({
-            id: "agent:main:dashboard:1",
+            // Card-scoped: `sessionKey` is shared by every card touched in one
+            // dashboard session, so it cannot be the global attempt PRIMARY KEY.
+            id: `${card.id}:agent:main:dashboard:1`,
             status: "running",
             engine: "claude",
             mode: "manual",
@@ -971,6 +973,44 @@ describe("WorkboardStore", () => {
         ],
       },
     });
+  });
+
+  it("scopes sessionKey-derived attempt ids per card so two cards can share a session", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const sessionKey = "agent:main:dashboard:shared";
+    const execution = {
+      kind: "agent-session" as const,
+      engine: "claude" as const,
+      mode: "manual" as const,
+      status: "running" as const,
+      model: "anthropic/claude-sonnet-4-6",
+      sessionKey,
+      startedAt: 10,
+      updatedAt: 10,
+    };
+
+    // Same session, no runId — both fall back to sessionKey for the attempt id.
+    const first = await store.create({
+      title: "First card",
+      execution: { ...execution, id: "exec-a" },
+    });
+    const second = await store.create({
+      title: "Second card",
+      execution: { ...execution, id: "exec-b" },
+    });
+
+    const firstId = first.metadata?.attempts?.[0]?.id;
+    const secondId = second.metadata?.attempts?.[0]?.id;
+
+    expect(firstId).toBe(`${first.id}:${sessionKey}`);
+    expect(secondId).toBe(`${second.id}:${sessionKey}`);
+    // The regression: unscoped ids collided on workboard_card_attempts.id, and
+    // insertChildren's DELETE is scoped to card_id so it could never clear the
+    // row the other card owned — the second write failed on every sync forever.
+    expect(firstId).not.toBe(secondId);
+
+    const reloaded = await store.list();
+    expect(reloaded.filter((card) => [first.id, second.id].includes(card.id))).toHaveLength(2);
   });
 
   it("ignores dependency links from generic metadata writes", async () => {


### PR DESCRIPTION
## What Problem This Solves

`sessionKey` and execution id are shared across every card touched in one dashboard session, so two cards minted the same `workboard_card_attempts` id. The second insert died on the primary key permanently: the row delete in `insertChildren` is scoped to `card_id` and could never clear the row the other card owned.

## Why This Change Was Made

Prefix the attempt key with the card id when `runId` is absent, so the id is unique to its owning card. Lookup still matches the legacy unprefixed id, so an upgrade rewrites the existing attempt row in place instead of stranding it.

## User Impact

Multiple cards touched in a single dashboard session record their attempts correctly, instead of the second and later cards failing permanently on a primary-key collision. Existing rows are rewritten in place on upgrade; no manual migration or data loss.

## Evidence

- `extensions/workboard/src/store.test.ts`: 141 tests pass, cherry-picked onto current `main`.
- Regression coverage added for the two-cards-one-session collision and for legacy-id rewrite on upgrade.
