### PR TITLE
feat(agents): prioritize shared private vLLM requests

### DIFF
--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -3,6 +3,7 @@ summary: "Run OpenClaw on local LLMs (LM Studio, vLLM, LiteLLM, custom OpenAI en
 read_when:
   - You want to serve models from your own GPU box
   - You are wiring LM Studio or an OpenAI-compatible proxy
+  - You want one vLLM engine to prioritize interactive and background traffic
   - You need the safest local model guidance
 title: "Local models"
 ---
@@ -248,6 +249,134 @@ Compat overrides for stricter OpenAI-compatible backends:
     },
   }
   ```
+
+## One shared vLLM engine with priority lanes
+
+For mixed interactive and background workloads, keep one vLLM engine and use
+request priority instead of loading three copies of the model. The three lanes
+are logical request classes, not separate processes:
+
+| Lane       | vLLM priority | OpenClaw provenance                                                                   |
+| ---------- | ------------: | ------------------------------------------------------------------------------------- |
+| Foreground |        `-100` | A current inbound `user_request`, `external_user` input, or direct user-triggered run |
+| Normal     |           `0` | Spawned work, trusted handoffs, inter-session/internal input, or unclassified work    |
+| Background |         `100` | Cron, heartbeat, commitment-only, or memory work                                      |
+
+Lower numbers are handled earlier when requests contend. Requests with the same
+priority use arrival order. A background classification wins if a run also
+carries foreground-looking metadata, so scheduler and maintenance work cannot
+accidentally enter the foreground lane. Normal delegated provenance likewise
+wins over a generic user trigger.
+
+This layout has one copy of the target and draft model, one global sequence and
+batch budget, and one KV block pool. With automatic prefix caching enabled,
+requests that share the same token prefix can reuse cached KV blocks. The lanes
+do not reserve GPU capacity, create hard concurrency quotas, or isolate memory:
+when no foreground request is waiting, background work can use the whole
+engine.
+
+### Server requirements
+
+vLLM must start with priority scheduling. Nonzero request priorities are
+rejected by a server running the default FCFS scheduler.
+
+```bash
+vllm serve <model-id> \
+  --served-model-name <canonical-name> <stable-alias> \
+  --scheduling-policy priority \
+  --enable-prefix-caching
+```
+
+Keep every alias immediately after `--served-model-name` and before the next
+option. In array-based launchers, inserting an alias after `--host` or another
+option separates that option from its value and produces an invalid command.
+
+Priority does not replace the normal capacity controls. Size
+`--max-num-seqs`, `--max-num-batched-tokens`, the context limit, and GPU memory
+utilization for the one shared engine. See the
+[vLLM scheduler reference](https://docs.vllm.ai/en/stable/api/vllm/config/scheduler/)
+and [automatic prefix caching design](https://docs.vllm.ai/en/stable/design/prefix_caching/)
+for the upstream behavior.
+
+### OpenClaw routing boundary
+
+Dynamic routing is opt-in per configured model. Add the neutral marker
+`priority: 0` under the model's configured `extraBody` or `extra_body` params:
+
+```json5
+{
+  agents: {
+    defaults: {
+      models: {
+        "custom-vllm/my-local-model": {
+          params: {
+            extraBody: { priority: 0 },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+The provider ID can be any configured name. The provenance router recognizes
+the marker when the selected model uses `openai-completions` and its `baseUrl`
+host is `localhost` or a private/loopback IP address. It rewrites the neutral
+marker to the per-run class while preserving sibling fields. A configured
+nonzero value or a request-scoped priority of any value without the configured
+marker does not opt in; any such priority is removed.
+
+Model fallbacks can inherit agent-level request parameters. When the selected
+route does not meet the private OpenAI-completions boundary, OpenClaw removes
+the inherited `priority` field while leaving the rest of the extra body intact.
+This prevents a vLLM scheduling hint from leaking to a hosted or otherwise
+unrelated endpoint.
+
+Use only the neutral configured marker, not a static `-100` or `100`. The
+runtime class is authoritative for each attempt, including a new attempt
+selected during model fallback.
+
+Compaction calls triggered within a run, including overflow and timeout
+recovery, inherit that run's urgency. An interactive run therefore keeps
+foreground priority while recovering context; overflow is not intrinsically a
+background lane.
+
+### Verification
+
+Verify the two sides independently before relying on lane behavior:
+
+1. Inspect the running server command and confirm there is one engine with
+   `--scheduling-policy priority` and `--enable-prefix-caching`.
+2. Query `/v1/models` and confirm the canonical model name and any stable alias
+   resolve to the same loaded model.
+3. Run the focused OpenClaw priority tests:
+
+   ```bash
+   node scripts/run-vitest.mjs src/agents/embedded-agent-runner/vllm-priority.test.ts
+   ```
+
+4. Submit a synchronized burst of long requests at `-100`, `0`, and `100`, then
+   inspect server request logs or metrics. Repeat the burst: wall-clock order
+   from a single short request is not reliable evidence of scheduler behavior.
+5. Exercise one hosted fallback and confirm its outgoing request body contains
+   no `priority` while sibling `extra_body` fields remain present.
+
+### Rollback
+
+Keep a timestamped launcher backup before changing scheduler or served-name
+arguments. To return to FCFS safely:
+
+1. Remove the configured `priority: 0` opt-in marker and deploy OpenClaw so it
+   stops sending dynamic nonzero priorities.
+2. Restart vLLM without `--scheduling-policy priority`, or explicitly select
+   `fcfs`.
+3. Confirm ordinary local requests and every configured fallback still work.
+
+Do not blindly restore an older launcher. Diff it first and retain the corrected
+served-name argument order: the canonical name and all aliases must remain
+contiguous after `--served-model-name`. A backup from before that correction can
+undo the scheduler change and reintroduce a broken alias command at the same
+time.
 
 ## Smaller or stricter backends
 

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -600,6 +600,7 @@ describe("applyExtraParamsToAgent", () => {
     extraParamsOverride?: Record<string, unknown>;
     payload?: Record<string, unknown>;
     thinkingLevel?: Parameters<typeof applyExtraParamsToAgent>[5];
+    applyOptions?: Parameters<typeof applyExtraParamsToAgent>[11];
   }) {
     // Mutates a caller-owned payload through onPayload, matching how the runtime
     // finalizes provider request bodies.
@@ -609,14 +610,31 @@ describe("applyExtraParamsToAgent", () => {
       return {} as ReturnType<StreamFn>;
     };
     const agent = { streamFn: baseStreamFn };
-    applyExtraParamsToAgent(
-      agent,
-      params.cfg as Parameters<typeof applyExtraParamsToAgent>[1],
-      params.applyProvider,
-      params.applyModelId,
-      params.extraParamsOverride,
-      params.thinkingLevel,
-    );
+    if (params.applyOptions) {
+      applyExtraParamsToAgent(
+        agent,
+        params.cfg as Parameters<typeof applyExtraParamsToAgent>[1],
+        params.applyProvider,
+        params.applyModelId,
+        params.extraParamsOverride,
+        params.thinkingLevel,
+        undefined,
+        undefined,
+        params.model,
+        undefined,
+        undefined,
+        params.applyOptions,
+      );
+    } else {
+      applyExtraParamsToAgent(
+        agent,
+        params.cfg as Parameters<typeof applyExtraParamsToAgent>[1],
+        params.applyProvider,
+        params.applyModelId,
+        params.extraParamsOverride,
+        params.thinkingLevel,
+      );
+    }
     const context: Context = { messages: [] };
     void agent.streamFn?.(params.model, context, params.options ?? {});
     return payload;
@@ -1261,6 +1279,42 @@ describe("applyExtraParamsToAgent", () => {
 
     expect(payload.google).toEqual({ thinking_config: { thinking_budget: 0 } });
     expect(payload).not.toHaveProperty("store");
+  });
+
+  it("writes opted-in vLLM urgency into the top-level transport payload", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "local",
+      applyModelId: "qwen",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "local/qwen": {
+                params: {
+                  extraBody: { priority: 0 },
+                },
+              },
+            },
+          },
+        },
+      },
+      extraParamsOverride: {
+        extra_body: { request_field: true },
+      },
+      applyOptions: {
+        vllmPriority: { urgency: "foreground" },
+      },
+      model: {
+        api: "openai-completions",
+        provider: "local",
+        id: "qwen",
+        baseUrl: "http://127.0.0.1:8000/v1",
+      } as Model<"openai-completions">,
+      payload: { messages: [] },
+    });
+
+    expect(payload.priority).toBe(-100);
+    expect(payload.request_field).toBe(true);
   });
 
   it("forwards chat_template_kwargs params as top-level openai-completions payload fields", () => {

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1064,6 +1064,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionAgentId: "main",
       effectiveWorkspace: "/tmp/workspace",
       agentDir: "/tmp/workspace",
+      modelCallUrgency: "foreground",
       runtimePlan: {
         auth: { forwardedAuthProfileId: "openai:profile-1" },
         transport: { resolveExtraParams: vi.fn(() => undefined) },
@@ -1091,6 +1092,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       "/tmp/workspace",
       undefined,
       expectRecordFields(mockCallArg(applyExtraParamsToAgentMock, 0, 11), {
+        vllmPriority: { urgency: "foreground" },
         nativeWebSearchPolicyContext: {
           sessionKey: undefined,
           webSearchEnabled: false,

--- a/src/agents/embedded-agent-runner/compact.types.ts
+++ b/src/agents/embedded-agent-runner/compact.types.ts
@@ -19,6 +19,7 @@ import type { AgentRunSessionTarget } from "../run-session-target.js";
 import type { AgentRuntimeAuthPlan, AgentRuntimePlan } from "../runtime-plan/types.js";
 import type { ScheduledToolPolicyContext } from "../scheduled-tool-policy.js";
 import type { TrustedSubagentCompletionHandoff } from "../subagents/announce/subagent-announce-handoff.js";
+import type { ModelCallUrgency } from "./vllm-priority.js";
 
 export type CompactEmbeddedAgentSessionParams = {
   /** Explicit session owner captured before fallback agent resolution. */
@@ -61,6 +62,8 @@ export type CompactEmbeddedAgentSessionParams = {
   /** Parent session key for subagent policy inheritance. */
   spawnedBy?: string | null;
   inputProvenance?: InputProvenance;
+  /** Urgency inherited from the run that requested this auxiliary model call. */
+  modelCallUrgency?: ModelCallUrgency;
   /** Consumed in-process subagent-completion capability; never derived from public input. */
   trustedInternalHandoff?: TrustedSubagentCompletionHandoff;
   toolsAllow?: string[];

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.ts
@@ -355,6 +355,7 @@ export function buildEmbeddedCompactionRuntimeContext(
     skillsSnapshot: params.skillsSnapshot,
     senderIsOwner: params.senderIsOwner,
     senderId: params.senderId ?? undefined,
+    modelCallUrgency: params.modelCallUrgency,
     provider: resolved.provider,
     runtimeProvider: resolved.runtimeProvider,
     model: resolved.model,

--- a/src/agents/embedded-agent-runner/compaction-session-agent.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-agent.ts
@@ -12,6 +12,7 @@ import {
   resolveEmbeddedAgentStreamFn,
 } from "./stream-resolution.js";
 import { mapThinkingLevelForProvider } from "./utils.js";
+import type { ModelCallUrgency } from "./vllm-priority.js";
 
 export async function prepareCompactionSessionAgent(params: {
   session: { agent: { streamFn?: unknown } };
@@ -38,6 +39,7 @@ export async function prepareCompactionSessionAgent(params: {
   groupChannel?: string | null;
   groupSpace?: string | null;
   spawnedBy?: string | null;
+  modelCallUrgency?: ModelCallUrgency;
   senderId?: string | null;
   senderName?: string | null;
   senderUsername?: string | null;
@@ -123,6 +125,7 @@ export async function prepareCompactionSessionAgent(params: {
         senderUsername: params.senderUsername,
         senderE164: params.senderE164,
       },
+      vllmPriority: { urgency: params.modelCallUrgency ?? "normal" },
     },
   );
   return { ...extraParams, transportApiKey };

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -274,6 +274,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             groupChannel: params.groupChannel,
             groupSpace: params.groupSpace,
             spawnedBy: params.spawnedBy,
+            modelCallUrgency: params.modelCallUrgency,
             senderId: params.senderId,
             senderName: params.senderName,
             senderUsername: params.senderUsername,

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -48,6 +48,7 @@ import type { SettingsManager } from "../sessions/index.js";
 import { log } from "./logger.js";
 import { parseCacheRetention, resolveCacheRetention } from "./prompt-cache-retention.js";
 import type { ProviderThinkLevel } from "./utils.js";
+import { type ModelCallUrgency, prepareVllmPriorityExtraParams } from "./vllm-priority.js";
 
 function requireBaseStreamFn(streamFn: StreamFn | undefined): StreamFn {
   if (!streamFn) {
@@ -1112,6 +1113,7 @@ export function applyExtraParamsToAgent(
   options?: {
     preparedExtraParams?: Record<string, unknown>;
     nativeWebSearchPolicyContext?: NativeWebSearchToolPolicyParams;
+    vllmPriority?: { urgency: ModelCallUrgency };
   },
 ): { effectiveExtraParams: Record<string, unknown> } {
   const resolvedExtraParams = resolveExtraParams({
@@ -1120,7 +1122,7 @@ export function applyExtraParamsToAgent(
     modelId,
     agentId,
   });
-  const override =
+  let override =
     extraParamsOverride && Object.keys(extraParamsOverride).length > 0
       ? sanitizeExtraParamsRecord(
           Object.fromEntries(
@@ -1128,7 +1130,7 @@ export function applyExtraParamsToAgent(
           ),
         )
       : undefined;
-  const effectiveExtraParams =
+  let effectiveExtraParams =
     options?.preparedExtraParams ??
     resolvePreparedExtraParams({
       cfg,
@@ -1143,6 +1145,17 @@ export function applyExtraParamsToAgent(
       model,
       resolvedTransport,
     });
+  if (options?.vllmPriority) {
+    const preparedVllmPriority = prepareVllmPriorityExtraParams({
+      configuredExtraParams: resolvedExtraParams,
+      effectiveExtraParams,
+      extraParamsOverride: override,
+      model,
+      urgency: options.vllmPriority.urgency,
+    });
+    effectiveExtraParams = preparedVllmPriority.effectiveExtraParams;
+    override = preparedVllmPriority.extraParamsOverride;
+  }
   const wrapperContext: ApplyExtraParamsContext = {
     agent,
     cfg,

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -166,6 +166,7 @@ describe("compactEmbeddedRunForRecovery", () => {
       makeRecoveryInput({
         runParams: {
           ...baseRunParams,
+          trigger: "user",
           modelSelectionLocked: true,
           modelFallbacksOverride: [],
         },
@@ -205,6 +206,7 @@ describe("compactEmbeddedRunForRecovery", () => {
         modelSelectionLocked: true,
         modelFallbacksOverride: [],
         authProfileId: "openai:work",
+        modelCallUrgency: "foreground",
         promptCache,
       },
     });

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-helpers.ts
@@ -35,6 +35,7 @@ import { deriveContextPromptTokens, type NormalizedUsage } from "../../usage.js"
 import { buildEmbeddedCompactionRuntimeContext } from "../compaction-runtime-context.js";
 import { resolveContextEngineCapabilities } from "../context-engine-capabilities.js";
 import { log } from "../logger.js";
+import { resolveModelCallUrgency } from "../vllm-priority.js";
 import { shouldInjectHeartbeatPromptForTrigger } from "./trigger-policy.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
@@ -518,6 +519,12 @@ type AfterTurnRuntimeContextAttempt = Pick<
   | "authProfileIdSource"
   | "runtimePlan"
   | "userTurnTranscriptRecorder"
+  | "trigger"
+  | "bootstrapContextRunKind"
+  | "currentInboundEventKind"
+  | "inputProvenance"
+  | "spawnedBy"
+  | "trustedInternalHandoff"
 > & {
   sessionId?: EmbeddedRunAttemptParams["sessionId"];
 };
@@ -582,6 +589,7 @@ export function buildAfterTurnRuntimeContext(params: {
       config: params.attempt.config,
       skillsSnapshot: params.attempt.skillsSnapshot,
       senderId: params.attempt.senderId,
+      modelCallUrgency: resolveModelCallUrgency(params.attempt),
       provider: params.attempt.provider,
       modelId: params.attempt.modelId,
       harnessRuntime: params.attempt.agentHarnessId,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -43,6 +43,7 @@ import {
   resolveEmbeddedAgentStreamFn,
 } from "../stream-resolution.js";
 import type { ProviderThinkLevel } from "../utils.js";
+import { resolveModelCallUrgency } from "../vllm-priority.js";
 import { joinWithRunLivenessDeadline, RUN_LIVENESS_JOIN_TIMEOUT_MS } from "./abortable.js";
 import {
   shouldWaitForCompletionRequiredAsyncTasks,
@@ -606,6 +607,7 @@ export async function prepareEmbeddedAttemptTransport(input: {
     {
       preparedExtraParams: effectiveExtraParams,
       nativeWebSearchPolicyContext,
+      vllmPriority: { urgency: resolveModelCallUrgency(attempt) },
     },
   );
   if (input.codeModeControlsEnabled) {

--- a/src/agents/embedded-agent-runner/run/compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-runtime.ts
@@ -13,6 +13,7 @@ import {
 } from "../compaction-safety-timeout.js";
 import { resolveContextEngineCapabilities } from "../context-engine-capabilities.js";
 import { log } from "../logger.js";
+import { resolveModelCallUrgency } from "../vllm-priority.js";
 import type { EmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
 import type { PreparedEmbeddedRunInput } from "./execution-context.js";
 import type { RunEmbeddedAgentParams } from "./params.js";
@@ -105,6 +106,7 @@ export async function compactEmbeddedRunForRecovery(
       toolOverrides: runParams.toolOverrides,
       skillsSnapshot: runParams.skillsSnapshot,
       senderId: runParams.senderId,
+      modelCallUrgency: resolveModelCallUrgency(runParams),
       provider: input.provider,
       modelId: input.modelId,
       harnessRuntime: input.harnessRuntime,

--- a/src/agents/embedded-agent-runner/vllm-priority.test.ts
+++ b/src/agents/embedded-agent-runner/vllm-priority.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { prepareVllmPriorityExtraParams, resolveModelCallUrgency } from "./vllm-priority.js";
+
+const localModel = {
+  provider: "local",
+  id: "qwen",
+  api: "openai-completions" as const,
+  baseUrl: "http://192.168.100.11:8000/v1",
+  input: ["text"],
+};
+
+describe("resolveModelCallUrgency", () => {
+  it.each([
+    ["channel request", { currentInboundEventKind: "user_request" as const }],
+    ["external user", { inputProvenance: { kind: "external_user" as const } }],
+    ["direct CLI or gateway user", { trigger: "user" as const }],
+  ])("classifies %s as foreground", (_name, provenance) => {
+    expect(resolveModelCallUrgency(provenance)).toBe("foreground");
+  });
+
+  it.each([
+    ["inter-session input", { inputProvenance: { kind: "inter_session" as const } }],
+    ["internal input", { inputProvenance: { kind: "internal_system" as const } }],
+    ["spawned work", { trigger: "user" as const, spawnedBy: "agent:parent:main" }],
+    ["trusted handoff", { trigger: "user" as const, trustedInternalHandoff: true }],
+  ])("classifies %s as normal", (_name, provenance) => {
+    expect(resolveModelCallUrgency(provenance)).toBe("normal");
+  });
+
+  it.each([
+    ["cron trigger", { trigger: "cron" as const }],
+    ["heartbeat run", { bootstrapContextRunKind: "heartbeat" as const }],
+    ["memory run", { trigger: "memory" as const }],
+  ])("classifies %s as background", (_name, provenance) => {
+    expect(resolveModelCallUrgency(provenance)).toBe("background");
+  });
+
+  it("keeps heartbeat precedence over external-user and spawned signals", () => {
+    expect(
+      resolveModelCallUrgency({
+        trigger: "heartbeat",
+        currentInboundEventKind: "user_request",
+        inputProvenance: { kind: "external_user" },
+        spawnedBy: "agent:parent:main",
+      }),
+    ).toBe("background");
+  });
+});
+
+describe("prepareVllmPriorityExtraParams", () => {
+  it("rewrites a camel-case neutral marker and preserves body siblings", () => {
+    expect(
+      prepareVllmPriorityExtraParams({
+        configuredExtraParams: { extraBody: { priority: 0 } },
+        effectiveExtraParams: {
+          temperature: 0.2,
+          extraBody: { priority: 0, guided_decoding_backend: "outlines" },
+        },
+        model: localModel,
+        urgency: "foreground",
+      }),
+    ).toEqual({
+      effectiveExtraParams: {
+        temperature: 0.2,
+        extraBody: { priority: -100, guided_decoding_backend: "outlines" },
+      },
+    });
+  });
+
+  it("supports a snake-case neutral marker and request body override", () => {
+    expect(
+      prepareVllmPriorityExtraParams({
+        configuredExtraParams: { extra_body: { priority: 0 } },
+        effectiveExtraParams: { extra_body: { priority: 0, service_tier: "auto" } },
+        extraParamsOverride: { extra_body: { guided_decoding_backend: "outlines" } },
+        model: localModel,
+        urgency: "background",
+      }),
+    ).toEqual({
+      effectiveExtraParams: { extraBody: { priority: 100, service_tier: "auto" } },
+      extraParamsOverride: {
+        extraBody: { priority: 100, guided_decoding_backend: "outlines" },
+      },
+    });
+  });
+
+  it("accepts an arbitrary provider id for an opted-in private endpoint", () => {
+    expect(
+      prepareVllmPriorityExtraParams({
+        configuredExtraParams: { extraBody: { priority: 0 } },
+        effectiveExtraParams: { extraBody: { priority: 0, service_tier: "auto" } },
+        model: { ...localModel, provider: "spark2" },
+        urgency: "foreground",
+      }),
+    ).toEqual({
+      effectiveExtraParams: { extraBody: { priority: -100, service_tier: "auto" } },
+    });
+  });
+
+  it("does not treat a legacy nonzero priority as opt-in", () => {
+    expect(
+      prepareVllmPriorityExtraParams({
+        configuredExtraParams: { extraBody: { priority: -100 } },
+        effectiveExtraParams: { extraBody: { priority: -100, service_tier: "auto" } },
+        model: localModel,
+        urgency: "foreground",
+      }),
+    ).toEqual({
+      effectiveExtraParams: { extraBody: { service_tier: "auto" } },
+    });
+  });
+
+  it("rejects a request-scoped neutral marker without configured opt-in", () => {
+    expect(
+      prepareVllmPriorityExtraParams({
+        configuredExtraParams: { temperature: 0.2 },
+        effectiveExtraParams: { extraBody: { priority: 0, service_tier: "auto" } },
+        extraParamsOverride: { extraBody: { priority: 0, request_field: true } },
+        model: localModel,
+        urgency: "foreground",
+      }),
+    ).toEqual({
+      effectiveExtraParams: { extraBody: { service_tier: "auto" } },
+      extraParamsOverride: { extraBody: { request_field: true } },
+    });
+  });
+
+  it("strips the private-endpoint priority marker from cloud fallback without dropping siblings", () => {
+    expect(
+      prepareVllmPriorityExtraParams({
+        configuredExtraParams: { extraBody: { priority: 0 } },
+        effectiveExtraParams: { extraBody: { priority: 0, service_tier: "auto" } },
+        extraParamsOverride: { extra_body: { priority: 0, request_field: true } },
+        model: {
+          provider: "kilo",
+          id: "cloud-model",
+          api: "openai-completions",
+          baseUrl: "https://api.kilo.ai/v1",
+          input: ["text"],
+        },
+        urgency: "background",
+      }),
+    ).toEqual({
+      effectiveExtraParams: { extraBody: { service_tier: "auto" } },
+      extraParamsOverride: { extraBody: { request_field: true } },
+    });
+  });
+});

--- a/src/agents/embedded-agent-runner/vllm-priority.ts
+++ b/src/agents/embedded-agent-runner/vllm-priority.ts
@@ -1,0 +1,154 @@
+import { isPrivateOrLoopbackIpAddress } from "@openclaw/net-policy/ip";
+import type { InboundEventKind } from "../../channels/inbound-event/kind.js";
+import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import type { InputProvenance } from "../../sessions/input-provenance.js";
+import type { BootstrapContextRunKind } from "../bootstrap-mode.js";
+import type { TrustedSubagentCompletionHandoff } from "../subagents/announce/subagent-announce-handoff.js";
+import type { EmbeddedRunTrigger } from "./run/params.js";
+
+export type ModelCallUrgency = "foreground" | "normal" | "background";
+
+type VllmPriorityProvenance = {
+  trigger?: EmbeddedRunTrigger;
+  bootstrapContextRunKind?: BootstrapContextRunKind;
+  currentInboundEventKind?: InboundEventKind;
+  inputProvenance?: InputProvenance;
+  spawnedBy?: string | null;
+  trustedInternalHandoff?: boolean | TrustedSubagentCompletionHandoff;
+};
+
+type VllmPriority = -100 | 0 | 100;
+
+function isPrivateModelEndpoint(baseUrl: string | undefined): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    return hostname === "localhost" || isPrivateOrLoopbackIpAddress(hostname);
+  } catch {
+    return false;
+  }
+}
+
+function isVllmCompatibleModel(model: ProviderRuntimeModel | undefined): boolean {
+  return model?.api === "openai-completions" && isPrivateModelEndpoint(model.baseUrl);
+}
+
+export function resolveModelCallUrgency(provenance: VllmPriorityProvenance): ModelCallUrgency {
+  const backgroundRunKind =
+    provenance.bootstrapContextRunKind === "cron" ||
+    provenance.bootstrapContextRunKind === "heartbeat";
+  const backgroundTrigger =
+    provenance.trigger === "cron" ||
+    provenance.trigger === "heartbeat" ||
+    provenance.trigger === "memory";
+  if (backgroundRunKind || backgroundTrigger) {
+    return "background";
+  }
+  if (
+    provenance.spawnedBy ||
+    Boolean(provenance.trustedInternalHandoff) ||
+    provenance.inputProvenance?.kind === "inter_session" ||
+    provenance.inputProvenance?.kind === "internal_system"
+  ) {
+    return "normal";
+  }
+  if (
+    provenance.currentInboundEventKind === "user_request" ||
+    provenance.inputProvenance?.kind === "external_user" ||
+    provenance.trigger === "user"
+  ) {
+    return "foreground";
+  }
+  return "normal";
+}
+
+function priorityForUrgency(urgency: ModelCallUrgency): VllmPriority {
+  switch (urgency) {
+    case "foreground":
+      return -100;
+    case "background":
+      return 100;
+    default:
+      return 0;
+  }
+}
+
+function readExtraBody(extraParams: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!extraParams) {
+    return {};
+  }
+  const value = Object.hasOwn(extraParams, "extra_body")
+    ? extraParams.extra_body
+    : extraParams.extraBody;
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function hasExtraBodyParam(extraParams: Record<string, unknown> | undefined): boolean {
+  return Boolean(
+    extraParams &&
+    (Object.hasOwn(extraParams, "extra_body") || Object.hasOwn(extraParams, "extraBody")),
+  );
+}
+
+function withPriority(
+  extraParams: Record<string, unknown>,
+  priority: VllmPriority,
+): Record<string, unknown> {
+  const { extra_body: _extraBodySnake, extraBody: _extraBodyCamel, ...rest } = extraParams;
+  return {
+    ...rest,
+    extraBody: {
+      ...readExtraBody(extraParams),
+      priority,
+    },
+  };
+}
+
+function withoutPriority(extraParams: Record<string, unknown>): Record<string, unknown> {
+  const extraBody = readExtraBody(extraParams);
+  if (!Object.hasOwn(extraBody, "priority")) {
+    return extraParams;
+  }
+  const { priority: _priority, ...extraBodyWithoutPriority } = extraBody;
+  const { extra_body: _extraBodySnake, extraBody: _extraBodyCamel, ...rest } = extraParams;
+  return Object.keys(extraBodyWithoutPriority).length > 0
+    ? { ...rest, extraBody: extraBodyWithoutPriority }
+    : rest;
+}
+
+/**
+ * Rewrites the neutral configured marker into a request priority. The marker is
+ * intentionally read from configured params so request overrides cannot opt an
+ * arbitrary OpenAI-compatible endpoint into vLLM-only payload fields.
+ */
+export function prepareVllmPriorityExtraParams(params: {
+  configuredExtraParams?: Record<string, unknown>;
+  effectiveExtraParams: Record<string, unknown>;
+  extraParamsOverride?: Record<string, unknown>;
+  model?: ProviderRuntimeModel;
+  urgency: ModelCallUrgency;
+}): {
+  effectiveExtraParams: Record<string, unknown>;
+  extraParamsOverride?: Record<string, unknown>;
+} {
+  const optedIn =
+    isVllmCompatibleModel(params.model) &&
+    readExtraBody(params.configuredExtraParams).priority === 0;
+  const priority = priorityForUrgency(params.urgency);
+  const effectiveExtraParams = optedIn
+    ? withPriority(params.effectiveExtraParams, priority)
+    : withoutPriority(params.effectiveExtraParams);
+  if (!params.extraParamsOverride) {
+    return { effectiveExtraParams };
+  }
+  const extraParamsOverride = hasExtraBodyParam(params.extraParamsOverride)
+    ? optedIn
+      ? withPriority(params.extraParamsOverride, priority)
+      : withoutPriority(params.extraParamsOverride)
+    : params.extraParamsOverride;
+  return { effectiveExtraParams, extraParamsOverride };
+}

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -279,6 +279,7 @@ type CompactEmbeddedAgentSessionParams = {
   force?: boolean;
   forcePreflight?: boolean;
   modelSelectionLocked?: boolean;
+  modelCallUrgency?: "foreground" | "normal" | "background";
   preflightRequired?: boolean;
   preflightCompactionTrigger?: string;
   sessionEntry?: SessionEntry;
@@ -1875,6 +1876,82 @@ describe("runMemoryFlushIfNeeded", () => {
       expect(compactCall.contextTokenBudget).toBe(258_000);
     },
   );
+
+  it.each([
+    {
+      name: "direct interactive input",
+      runOverrides: {},
+      expectedUrgency: "foreground" as const,
+    },
+    {
+      name: "inter-session input",
+      runOverrides: { inputProvenance: { kind: "inter_session" as const } },
+      expectedUrgency: "normal" as const,
+    },
+    {
+      name: "spawned work",
+      runOverrides: { spawnedBy: "agent:parent:main" },
+      expectedUrgency: "normal" as const,
+    },
+  ])("passes $expectedUrgency urgency for $name preflight compaction", async (testCase) => {
+    const sessionFile = path.join(rootDir, `urgency-${testCase.expectedUrgency}.jsonl`);
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 245_000,
+      totalTokensFresh: true,
+      totalTokensVersion: 1,
+      compactionCount: 0,
+    };
+    const followupRun = createTestFollowupRun({
+      sessionId: "session",
+      sessionFile,
+      sessionKey: "agent:main:main",
+      ...testCase.runOverrides,
+    });
+    await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun,
+      defaultModel: "anthropic/claude-opus-4-6",
+      modelContextTokens: 258_000,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(requireCompactEmbeddedAgentSessionCall().modelCallUrgency).toBe(
+      testCase.expectedUrgency,
+    );
+  });
+
+  it("skips preflight compaction for a heartbeat run", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 245_000,
+      totalTokensFresh: true,
+      totalTokensVersion: 1,
+    };
+
+    const result = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({ sessionKey: "agent:main:main" }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      modelContextTokens: 258_000,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      isHeartbeat: true,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(result).toBe(sessionEntry);
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+  });
+
   it("preflight compacts a fresh session when the current prompt estimate pushes the next request over budget", async () => {
     registerMemoryFlushPlanResolverForTest(() =>
       createModifiedMemoryFlushPlan({ softThresholdTokens: 0, reserveTokensFloor: 10 }),

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -15,6 +15,7 @@ import { estimateMessagesTokens } from "../../agents/compaction.js";
 import { isBenignCompactionSkipResult } from "../../agents/embedded-agent-runner/compact-reasons.js";
 import { runEmbeddedAgentEntry } from "../../agents/embedded-agent-runner/run-entry.js";
 import { createToolResultPromptProjectionState } from "../../agents/embedded-agent-runner/session-prompt-state.js";
+import { resolveModelCallUrgency } from "../../agents/embedded-agent-runner/vllm-priority.js";
 import { isCliRuntimeAliasForProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-routing.js";
@@ -980,6 +981,12 @@ export async function runPreflightCompactionIfNeeded(params: {
       thinkLevel: params.followupRun.run.thinkLevel,
       bashElevated: params.followupRun.run.bashElevated,
       trigger: "budget",
+      modelCallUrgency: resolveModelCallUrgency({
+        trigger: params.isHeartbeat ? "heartbeat" : "user",
+        currentInboundEventKind: params.followupRun.currentInboundEventKind,
+        inputProvenance: params.followupRun.run.inputProvenance,
+        spawnedBy: params.followupRun.run.spawnedBy,
+      }),
       force: true,
       forcePreflight: true,
       preflightRequired: true,


### PR DESCRIPTION
## What Problem This Solves

Operators who share one private vLLM engine across interactive, delegated, and
background OpenClaw work currently cannot derive request priority from run
provenance. Under contention, cron or maintenance traffic can delay direct user
requests, while a static vLLM-only request field can also be inherited by an
unrelated hosted fallback.

## Why This Change Was Made

This adds three provenance-derived urgency classes (`-100`, `0`, and `100`) at
the shared OpenAI-completions request boundary. Routing is explicitly opt-in via
a configured neutral `priority: 0` marker and applies only to private or
loopback endpoints; provider IDs remain arbitrary. The selected model is checked
again on every fallback attempt, non-eligible routes strip the vLLM-only field
without dropping sibling request fields, and run-triggered compaction inherits
the originating urgency.

This is AI-assisted work. I reviewed the implementation and its tests and
understand the behavior and boundaries described above.

## User Impact

An operator can keep one model process, KV block pool, and prefix cache while
giving direct user traffic foreground priority, delegated/internal work normal
priority, and cron/heartbeat/memory work background priority. Hosted or public
fallbacks do not receive the private vLLM scheduling hint.

The server must run with `--scheduling-policy priority`; the documented shared
deployment also uses `--enable-prefix-caching`. The Spark-side prerequisite was
verified independently and is documented in the companion draft PR:
https://github.com/gitcommit90/qwen38-27b-dgx-spark/pull/1

There is no claim of a live OpenClaw end-to-end acceptance run yet. This PR
remains draft until that acceptance and exact-commit package proof are attached.

## Evidence

Exact rebased-head proof (`9564aa4d5a6a56e5a51ca28ac78ac76549d1b1ad`):

- Five focused test files passed, 394 tests total:
  - `src/agents/embedded-agent-runner/vllm-priority.test.ts`
  - `src/agents/embedded-agent-runner-extraparams.test.ts`
  - `src/agents/embedded-agent-runner/compact.hooks.test.ts`
  - `src/agents/embedded-agent-runner/run.overflow-compaction.test.ts`
  - `src/auto-reply/reply/agent-runner-memory.test.ts`
- `pnpm tsgo:core`
- targeted `oxfmt` over the rebased 16-file diff
- targeted `oxlint` over the touched source and test files
- `pnpm check:docs`
- `git diff --check origin/main...HEAD`

Earlier-iteration proof only: `pnpm check` and `pnpm build` passed before the
final small provider-boundary and preflight-provenance corrections. They are not
presented as exact-head proof. An exact-commit full build/package run will be
added before the PR leaves draft.

No live OpenClaw state, service configuration, credentials, backup files, or
runtime artifacts are included in this change.
