### PR TITLE
fix(macos): show the correct first-run onboarding progress

### DIFF
--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -746,7 +746,7 @@ struct OnboardingView: View {
 
     var pageOrder: [Int] {
         Self.pageOrder(
-            for: self.state.connectionMode,
+            for: self.selectedConnectionMode,
             requiresCLIInstall: !self.cliInstalled)
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -152,6 +152,7 @@ struct OnboardingViewSmokeTests {
 
         #expect(view.selectedConnectionMode == .local)
         #expect(view.isConnectionSelectionBlocking)
+        #expect(view.pageOrder == [0, 1, 2, 3])
         #expect(state.connectionMode == .unconfigured)
     }
 
@@ -163,6 +164,7 @@ struct OnboardingViewSmokeTests {
 
         #expect(view.selectedConnectionMode == .unconfigured)
         #expect(!view.isConnectionSelectionBlocking)
+        #expect(view.pageOrder == [0, 1, 9])
         #expect(state.connectionMode == .unconfigured)
     }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening macOS onboarding for the first time would see the three-step “set up later” progress and ready page even though “This Mac” was already recommended and selected. Continuing unexpectedly replaced that route with the CLI and AI setup pages, causing the visible progress indicators and page sequence to change mid-flow.

## Why This Change Was Made

Build the onboarding page sequence from the same existing selected connection mode that drives the visible connection choice. This keeps first-run local setup, explicit “set up later,” previously configured local/remote connections, and the existing connection-commit boundary on one canonical owner path without changing persisted connection state or adding production code.

## User Impact

First-run macOS onboarding immediately shows the complete recommended local route: welcome, connection, CLI setup, and AI setup. Explicit “set up later” still shows its existing welcome, connection, and ready route.

## Evidence

- Authentic pre-fix native owner regression: the existing fresh-onboarding Swift smoke test failed because the actual page sequence was `[0, 1, 9]` instead of `[0, 1, 2, 3]`; the other 27 onboarding tests, including explicit “configure later,” passed.
- After the canonical one-line fix, `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path apps/macos --filter OpenClawIPCTests.OnboardingViewSmokeTests --no-parallel -j 4` passed all 28 native onboarding tests, covering first run, configure later, local/remote route transitions, CLI readiness, AI gating, and dashboard handoff.
- `swiftformat --lint apps/macos/Sources/OpenClaw/Onboarding.swift apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift --config config/swiftformat` passed; production change is +1/-1 lines, with two added existing-test assertions.
- Live-app before/after screenshots were not feasible: the isolated macOS guest has no authenticated desktop session or installed app bundle, and launching or modifying the operator’s signed installed app/TCC state is outside the authorized isolation boundary. The real native SwiftUI owner regression above provides executable before/after proof without touching that app.
