### PR TITLE
fix(onboard): JSON commands return no output without a terminal

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -369,6 +369,8 @@ Output: `--suppress-gateway-token-output` disables the automatic Control UI hand
 
 <Note>
 `--json` does not imply non-interactive mode in guided or classic onboarding.
+Without an interactive terminal, both onboarding modes return a structured
+JSON error; add `--non-interactive --accept-risk` for automation.
 With `--modern`, JSON is a one-shot OpenClaw overview and exits after that
 single result. Use `--non-interactive` for other scripts.
 </Note>

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -270,14 +270,21 @@ describe("setupWizardCommand", () => {
   it.each([
     ["guided", { reset: true }],
     ["classic", { reset: true, classic: true }],
+    ["guided JSON", { reset: true, json: true }],
+    ["classic JSON", { reset: true, classic: true, json: true }],
   ] as const)("rejects headless %s onboarding before reset", async (_label, options) => {
     const runtime = makeRuntime();
     mocks.hasInteractiveOnboardingTty.mockReturnValue(false);
 
     await setupWizardCommand(options, runtime);
 
-    expect(runtime.error).toHaveBeenCalledWith(
-      "Onboarding needs an interactive TTY. Use `openclaw onboard --non-interactive --accept-risk ...` for automation.",
+    const message =
+      "Onboarding needs an interactive TTY. Use `openclaw onboard --non-interactive --accept-risk ...` for automation.";
+    expect(runtime.error).toHaveBeenCalledWith(message);
+    expect(vi.mocked(runtime.log).mock.calls).toEqual(
+      "json" in options
+        ? [[JSON.stringify({ ok: false, phase: "options", message }, null, 2)]]
+        : [],
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -644,8 +644,7 @@ export async function setupWizardCommand(
   if (!normalizedOpts.nonInteractive && !hasInteractiveOnboardingTty()) {
     // Reset is destructive, so prove the selected interactive surface can run
     // before reading or moving any operator state.
-    runtime.error(t("wizard.guided.ttyRequired"));
-    runtime.exit(1);
+    rejectOption(normalizedOpts, runtime, t("wizard.guided.ttyRequired"));
     return;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw setup --json` or `openclaw onboard --json` on a fresh installation would receive no machine-readable output when an interactive terminal was unavailable. Guided and classic onboarding both exited with only a human-readable diagnostic, leaving callers unable to distinguish the expected onboarding preflight failure from a crash.

## Why This Change Was Made

The interactive-terminal preflight bypassed the canonical onboarding option-rejection owner already used by neighboring validation failures. Route that existing rejection through the shared owner so JSON mode emits exactly one structured failure while retaining the same human diagnostic, exit status, and preflight ordering before configuration reads or reset operations. Production code decreases by one line.

## User Impact

Fresh-install automation and macOS onboarding integrations now receive `{ "ok": false, "phase": "options", "message": "..." }` when interactive onboarding cannot run. Normal terminal output and recovery guidance remain unchanged. The onboarding CLI reference now explains that automation requires `--non-interactive --accept-risk`.

## Evidence

- Authentic pre-fix owner regression: guided and classic JSON cases both failed because stdout was never written, while both human-output cases passed.
- Focused owner and real-parser sibling suites: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/onboard.test.ts src/cli/program/register.onboard.test.ts src/cli/program/register.setup.test.ts` — **179 tests passed**.
- Real source CLI with isolated temporary state: `node --import tsx src/entry.ts setup --json`, `node --import tsx src/entry.ts onboard --json`, and `node --import tsx src/entry.ts onboard --classic --json` each return one structured options error, preserve the human-readable diagnostic, and exit with status 1.
- Focused formatter and lint checks passed; independent review and structured Codex autoreview found no actionable issues.
