### PR TITLE
fix(i18n): refresh native locales when locale inventory changes

### DIFF
--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -19,6 +19,7 @@ on:
       - scripts/android-app-i18n.ts
       - scripts/apple-app-i18n.ts
       - scripts/native-app-i18n.ts
+      - scripts/native-i18n-locales.ts
       - ui/src/i18n/.i18n/glossary.*.json
       - .github/actions/create-generated-pr-tokens/action.yml
       - .github/actions/publish-generated-pr/action.yml
@@ -334,6 +335,7 @@ jobs:
             scripts/android-app-i18n.ts
             scripts/apple-app-i18n.ts
             scripts/native-app-i18n.ts
+            scripts/native-i18n-locales.ts
             ui/src/i18n/.i18n/glossary.*.json
             .github/actions/create-generated-pr-tokens/action.yml
             .github/actions/publish-generated-pr/action.yml

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -103,7 +103,7 @@ class NativeGeneratedArtifactsMixedError extends Error {}
 const CHROMIUM_UI_TEST_SCOPE_RE =
   /^(ui\/|extensions\/browser\/chrome-extension\/|test\/vitest\/vitest\.(?:shared|ui-e2e)\.config\.ts$|scripts\/ensure-playwright-chromium\.mts$|package\.json$|\.github\/workflows\/ci\.yml$)/;
 const NATIVE_I18N_SCOPE_RE =
-  /^(?:apps\/\.i18n\/|apps\/android\/(?:app\/src\/(?:main|play|thirdParty)\/|wear\/src\/main\/)|apps\/ios\/|apps\/macos\/Sources\/|apps\/shared\/OpenClawKit\/Sources\/|scripts\/(?:android-app-i18n|apple-app-i18n|native-app-i18n)\.ts$|test\/scripts\/(?:android-app-i18n|apple-app-i18n|native-app-i18n)\.test\.ts$|\.github\/workflows\/(?:ci|native-app-locale-refresh)\.yml$)/;
+  /^(?:apps\/\.i18n\/|apps\/android\/(?:app\/src\/(?:main|play|thirdParty)\/|wear\/src\/main\/)|apps\/ios\/|apps\/macos\/Sources\/|apps\/shared\/OpenClawKit\/Sources\/|scripts\/(?:android-app-i18n|apple-app-i18n|native-(?:app-i18n|i18n-locales))\.ts$|test\/scripts\/(?:android-app-i18n|apple-app-i18n|native-app-i18n)\.test\.ts$|\.github\/workflows\/(?:ci|native-app-locale-refresh)\.yml$)/;
 // Android base resources are co-owned: source PRs edit their English content,
 // while the generator rewrites managed sections. Treat them as generated only
 // alongside a hard-generated artifact so neither ownership path blocks the other.

--- a/src/scripts/ci-changed-scope.native-i18n.test.ts
+++ b/src/scripts/ci-changed-scope.native-i18n.test.ts
@@ -4,6 +4,16 @@ const { assertNativeGeneratedArtifactsIsolated, shouldRunNativeI18n, shouldStric
   await import("../../scripts/ci-changed-scope.mjs");
 
 describe("native i18n changed scope", () => {
+  it.each([
+    "scripts/android-app-i18n.ts",
+    "scripts/apple-app-i18n.ts",
+    "scripts/native-app-i18n.ts",
+    "scripts/native-i18n-locales.ts",
+  ])("routes native locale source %s without requiring generated parity", (sourcePath) => {
+    expect(shouldRunNativeI18n([sourcePath])).toBe(true);
+    expect(shouldStrictNativeI18n([sourcePath])).toBe(false);
+  });
+
   it("routes Android flavor sources through native i18n", () => {
     expect(
       shouldRunNativeI18n([

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2131,8 +2131,17 @@ NODE
     expect(workflow.on.push.paths).toContain("apps/android/app/src/play/**");
     expect(workflow.on.push.paths).toContain("apps/android/app/src/thirdParty/**");
     expect(workflow.on.push.paths).toContain("apps/android/wear/src/main/**");
-    expect(workflow.on.push.paths).toContain("scripts/android-app-i18n.ts");
-    expect(workflow.on.push.paths).toContain("scripts/apple-app-i18n.ts");
+    for (const generatorInput of [
+      "scripts/android-app-i18n.ts",
+      "scripts/apple-app-i18n.ts",
+      "scripts/native-app-i18n.ts",
+      "scripts/native-i18n-locales.ts",
+    ]) {
+      expect(workflow.on.push.paths).toContain(generatorInput);
+      expect(nativePublishStep.with["invalidation-paths"].trim().split("\n")).toContain(
+        generatorInput,
+      );
+    }
     expect(refreshStep.run).toContain("run_refresh anthropic");
     expect(refreshStep.run).toContain("retrying with OpenAI");
     expect(refreshStep.run).toContain("run_openai_refresh");
@@ -2167,8 +2176,6 @@ NODE
       "apps/ios/ShareExtension/*.lproj/InfoPlist.strings",
       "apps/ios/ActivityWidget/*.lproj/InfoPlist.strings",
     ]);
-    expect(nativePublishStep.with["invalidation-paths"]).toContain("scripts/android-app-i18n.ts");
-    expect(nativePublishStep.with["invalidation-paths"]).toContain("scripts/apple-app-i18n.ts");
     expect(nativePublishStep.with["invalidation-paths"]).toContain("apps/.i18n/native-source.json");
     expect(nativePublishStep.with["invalidation-paths"]).toContain("apps/android/app/src/play");
     expect(nativePublishStep.with["invalidation-paths"]).toContain(


### PR DESCRIPTION
## What Problem This Solves

Changing the shared native-app locale inventory did not schedule native localization validation, trigger the native locale refresh workflow, or invalidate stale generated-locale publication. Adding or removing a supported language could therefore leave Android, iOS, and macOS translations stale without a native CI warning.

## Why This Change Was Made

Recognize the existing canonical locale inventory alongside the Android, Apple, and native generators in the current changed-scope owner and both required static workflow path inventories. Generated-artifact parity remains non-strict for source-only changes; workflow ownership, permissions, concurrency, and publication policy are unchanged.

## User Impact

Supported-language inventory changes now automatically receive native localization CI and refresh generated native app translations. Existing native source changes and generated-artifact ownership keep their previous behavior.

## Evidence

- Before repair, the real changed-scope owner and parsed refresh workflow reported `ciNativeLane=false`, `refreshTrigger=false`, and `publicationInvalidation=false` for `scripts/native-i18n-locales.ts`; both new owner-boundary regressions failed for that exact missing input.
- After repair, the same real-boundary probe reports `ciNativeLane=true`, `refreshTrigger=true`, `publicationInvalidation=true`, and unchanged `strictGeneratedParity=false`.
- `node scripts/run-vitest.mjs src/scripts/ci-changed-scope.native-i18n.test.ts test/scripts/ci-workflow-guards.test.ts -t 'native i18n changed scope|keeps locale refresh matrices alive and publishes each aggregate through a PR'` — nine tests passed; the table covers all four existing generator inputs against CI routing and both workflow inventories.
- `actionlint .github/workflows/native-app-locale-refresh.yml` — passed. Focused changed-source lint, core-test lint, core-test typecheck, root-test typecheck, formatting, and 18 preceding changed-file guards passed.
- Baseline limitation: the full changed-file gate on the intentionally frozen parent stopped only on the already-existing `src/commands/doctor-auth.profile-health.test.ts:179` missing sort comparator. That unrelated defect was repaired on current main by commit `ecf06317796ce74dc49511f8aca02ebde48af510` (PR #129409); exact-head GitHub PR CI validates this branch against the repaired merge reference before landing.
- Broader optional tooling has pre-existing environment gaps unrelated to this change: the fake-registry hardlink test cannot fetch `@pnpm/exe`, and the repository-wide workflow wrapper requests `pre-commit==4.6.2`, which is unavailable from the configured Python package index. The actual changed workflow passes actionlint and its parsed contract regression.
- Fresh automated review, independent source review, and separate read-only exact-head review passed. Production classifier LOC is net zero; the two added workflow entries are the required static trigger and invalidation paths.
