### PR TITLE
fix(slack): keep bot-started threads active

### DIFF
--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -155,7 +155,7 @@ describe("sendMessageSlack thread participation", () => {
     expect(hasSlackThreadParticipation("default", "C123", "1781932168.648159")).toBe(false);
   });
 
-  it("does not record participation for unthreaded sends", async () => {
+  it("records each top-level send as a thread root", async () => {
     clearSlackThreadParticipationCache();
     const client = createSlackSendTestClient();
 
@@ -165,7 +165,7 @@ describe("sendMessageSlack thread participation", () => {
       client,
     });
 
-    expect(hasSlackThreadParticipation("default", "C123", "1712345678.123456")).toBe(false);
+    expect(hasSlackThreadParticipation("default", "C123", "171234.567")).toBe(true);
   });
 
   it("does not record participation for invalid thread ids", async () => {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -1094,8 +1094,11 @@ export async function sendMessageSlack(
       delivery,
     }),
   );
-  const threadTs = result.threadTs ?? normalizeSlackThreadTsCandidate(queuedOpts.threadTs);
-  if (threadTs && result.channelId && account.accountId) {
+  for (const messageId of result.threadTs ? [result.threadTs] : result.receipt.platformMessageIds) {
+    const threadTs = normalizeSlackThreadTsCandidate(messageId);
+    if (!threadTs || !result.channelId || !account.accountId) {
+      continue;
+    }
     recordSlackThreadParticipation(account.accountId, result.channelId, threadTs, {
       teamId: delivery.teamId,
     });


### PR DESCRIPTION
## What Problem This Solves

Slack bot-started top-level messages were not registered in thread participation state. With `requireMention=true`, a later bot reply in that thread was ignored unless it repeated the mention, even when `allowBots=true`.

Closes #129436

## Why This Change Was Made

`sendMessageSlack` only recorded `result.threadTs`. Top-level sends have no `threadTs`, but their message timestamps are available in `receipt.platformMessageIds`. The change records those IDs as thread roots when the send is top-level, while preserving the existing threaded-send behavior.

## User Impact

Bots can continue participating in threads they start without requiring another explicit mention. Chunked top-level sends register each emitted message root.

## Evidence

- Deterministic pre-fix probe: top-level participation was `false`.
- Focused Slack extension test: 4 tests passed.
- Added regression coverage for top-level sends.
- `git diff --check` passed.

AI-assisted change; reviewed and verified with a focused deterministic test.
