### PR TITLE
fix(ui): stop cloud tasks from silently switching to local execution

### DIFF
--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -1,6 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createPluginMetadataSnapshot } from "../../config/plugin-auto-enable.test-helpers.js";
-import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
 import {
   prepareModelRunCapabilities,
   resolvePreparedModelThinkingCompat,
@@ -204,19 +202,11 @@ describe("embedded model resolution consistency", () => {
     };
 
     expect(
-      withPluginMetadataSnapshotScope(
-        createPluginMetadataSnapshot({
-          config,
-          manifestRegistry: { plugins: [], diagnostics: [] },
-        }),
-        () =>
-          resolveInitialEmbeddedRunModel({
-            config,
-            agentId: "worker",
-            model: "worker-haiku",
-          }),
-        { config },
-      ),
+      resolveInitialEmbeddedRunModel({
+        config,
+        agentId: "worker",
+        model: "worker-haiku",
+      }),
     ).toEqual({ provider: "anthropic", modelId: "claude-haiku-4-5" });
   });
 

--- a/ui/src/e2e/new-session-page.places-live.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places-live.e2e.test.ts
@@ -71,13 +71,26 @@ suite.define(() => {
     }
   });
 
-  it("disables cloud profiles whose execution mode does not match the selected runtime", async () => {
+  it("keeps an explicitly selected cloud destination when its runtime becomes incompatible", async () => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
-      agentModel: "openai/gpt-5.6-luna",
+      agentModel: "anthropic/claude-sonnet-4-6",
       models: [
         {
+          available: true,
+          id: "claude-sonnet-4-6",
+          name: "Claude Sonnet 4.6",
+          provider: "anthropic",
+          agentRuntime: {
+            id: "openclaw",
+            cloudPlacementSupported: true,
+            cloudPlacementExecutionMode: "worker-turn",
+            source: "model",
+          },
+        },
+        {
+          available: true,
           id: "gpt-5.6-luna",
           name: "GPT-5.6 Luna",
           provider: "openai",
@@ -100,6 +113,10 @@ suite.define(() => {
               providerId: "crabbox",
               executionMode: "worker-turn",
               executionModes: ["worker-turn"],
+              machines: [
+                { id: "standard", label: "Standard", default: true },
+                { id: "fast", label: "Fast" },
+              ],
             },
           ],
         },
@@ -110,14 +127,42 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}new`);
       await gateway.waitForRequest("environments.list");
       await gateway.waitForRequest("chat.metadata");
-      await page.locator("#new-session-where-trigger").click();
+      const where = page.locator("#new-session-where-trigger");
+      const model = page.locator('[data-chat-model-select="true"]');
+      const start = page.getByRole("button", { name: "Start session" });
+      await where.click();
 
       const profile = page.locator('[data-value="cloud:aws"]');
+      await profile.click();
+      await where.click();
+      await page.locator('[data-value="machine:fast"]').click();
+      await page.keyboard.press("Escape");
+      await page.locator(".new-session-page__message").fill("keep this task on the cloud");
+      await expect.poll(() => start.isEnabled()).toBe(true);
+
+      await model.click();
+      await page.locator('[data-chat-model-option="openai/gpt-5.6-luna"]').click();
+      await expect.poll(() => model.textContent()).toContain("GPT-5.6 Luna");
+      await expect.poll(() => where.getAttribute("data-cloud-profile")).toBe("aws");
+      await expect.poll(() => where.getAttribute("data-machine-class")).toBe("fast");
+      await expect.poll(() => start.isDisabled()).toBe(true);
+      expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
+      expect(await gateway.getRequests("sessions.dispatch")).toHaveLength(0);
+
+      await where.click();
+
       await profile.waitFor();
       await expect.poll(() => profile.isDisabled()).toBe(true);
       expect(await profile.getAttribute("title")).toBe(
         "The codex runtime cannot use this cloud worker. Choose a compatible cloud worker or run locally.",
       );
+      await page.keyboard.press("Escape");
+
+      await model.click();
+      await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
+      await expect.poll(() => where.getAttribute("data-cloud-profile")).toBe("aws");
+      await expect.poll(() => where.getAttribute("data-machine-class")).toBe("fast");
+      await expect.poll(() => start.isEnabled()).toBe(true);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/update-coalesced.e2e.test.ts
+++ b/ui/src/e2e/update-coalesced.e2e.test.ts
@@ -81,10 +81,6 @@ suite.define(() => {
         );
         await captureUpdateProof(page, artifactDir, "disabled-update.png");
 
-        const actionBounds = await action.boundingBox();
-        if (!actionBounds) {
-          throw new Error("disabled update action is not visible");
-        }
         const tooltip = updateIssue.locator("openclaw-tooltip wa-tooltip");
         await tooltip.evaluate((element) => {
           element.addEventListener(
@@ -93,10 +89,7 @@ suite.define(() => {
             { once: true },
           );
         });
-        await page.touchscreen.tap(
-          actionBounds.x + actionBounds.width / 2,
-          actionBounds.y + actionBounds.height / 2,
-        );
+        await updateIssue.locator(".sidebar-update-card__actions").tap();
         await expect.poll(() => tooltip.getAttribute("data-e2e-after-show")).not.toBeNull();
         expect(await tooltip.textContent()).toContain("Administrator access is required");
         expect(await gateway.getRequests("update.run")).toHaveLength(0);

--- a/ui/src/pages/new-session/draft-place-state.test.ts
+++ b/ui/src/pages/new-session/draft-place-state.test.ts
@@ -102,16 +102,21 @@ describe("DraftPlaceState cloud machine selection", () => {
 
   it.each([
     {
-      name: "clears a one-mode cloud profile when the runtime becomes incompatible",
+      name: "preserves a recovered one-mode cloud profile when the runtime becomes incompatible",
       executionModes: ["worker-turn"] as const,
-      compatible: false,
+      selectedByUser: false,
+    },
+    {
+      name: "preserves an explicitly chosen one-mode cloud profile when the runtime becomes incompatible",
+      executionModes: ["worker-turn"] as const,
+      selectedByUser: true,
     },
     {
       name: "retains a two-mode cloud profile and its machine when the runtime changes",
       executionModes: ["worker-turn", "remote-exec"] as const,
-      compatible: true,
+      selectedByUser: false,
     },
-  ])("$name", ({ executionModes, compatible }) => {
+  ])("$name", ({ executionModes, selectedByUser }) => {
     const persistPreference = vi.fn();
     const cloudProfiles: DraftCloudProfile[] = [
       {
@@ -149,7 +154,15 @@ describe("DraftPlaceState cloud machine selection", () => {
       cloudPlacementExecutionMode: "worker-turn",
       source: "model",
     });
-    state.applyPendingPlacement({ agentId: "main", profileId: "aws", machineClass: "fast" });
+    if (selectedByUser) {
+      vi.spyOn(state, "isAdmin").mockReturnValue(true);
+      vi.spyOn(state, "worktreeAvailable").mockReturnValue(true);
+      state.selectCloudProfile("aws");
+      state.cloudMachines.select("aws", "fast", cloudProfiles);
+      persistPreference.mockClear();
+    } else {
+      state.applyPendingPlacement({ agentId: "main", profileId: "aws", machineClass: "fast" });
+    }
     state.restorePreferenceSelections();
     expect(state.cloudProfileId).toBe("aws");
     expect(state.machineClass).toBe("fast");
@@ -162,19 +175,9 @@ describe("DraftPlaceState cloud machine selection", () => {
     });
     state.restorePreferenceSelections();
 
-    if (compatible) {
-      expect(state.cloudProfileId).toBe("aws");
-      expect(state.machineClass).toBe("fast");
-      expect(state.worktree).toBe(true);
-      expect(persistPreference).not.toHaveBeenCalled();
-    } else {
-      expect(state.cloudProfileId).toBe("");
-      expect(state.worktree).toBe(false);
-      expect(persistPreference).toHaveBeenLastCalledWith(
-        "main",
-        "",
-        expect.objectContaining({ where: { kind: "local" }, worktree: false }),
-      );
-    }
+    expect(state.cloudProfileId).toBe("aws");
+    expect(state.machineClass).toBe("fast");
+    expect(state.worktree).toBe(true);
+    expect(persistPreference).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/pages/new-session/draft-place-state.ts
+++ b/ui/src/pages/new-session/draft-place-state.ts
@@ -606,17 +606,6 @@ export class DraftPlaceState {
   }
 
   restorePreferenceSelections() {
-    const selectedCloudProfile = this.gateway.cloudProfiles.find(
-      (profile) => profile.id === this.cloudProfileIdValue,
-    );
-    if (
-      selectedCloudProfile &&
-      this.modelControl.cloudRuntimeUnsupportedReason(selectedCloudProfile) &&
-      !this.read().pendingPlacementSessionKey
-    ) {
-      this.selectDevice("");
-      return;
-    }
     let changed = false;
     const preferredWhere = this.whereSelectedByUser ? null : this.preferredWhereRestore;
     let preferredProject = this.projectSelectedByUser ? "" : this.preferredProjectRestore;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a cloud session would silently run the task locally when changing to a model whose runtime cannot use their explicitly selected cloud worker.

## Why This Change Was Made

The session composer already owns a visible submit gate for incompatible cloud runtimes, but preference restoration previously erased the selected cloud destination before that gate could run. Remove that obsolete fallback so explicit and recovered cloud destinations retain their worker, machine, and worktree; genuinely stale saved preferences remain rejected by the existing restoration owner.

Early CI also exposed unrelated auth/compaction fixture failures and a public Plugin SDK surface regression already present on the original base. Rebased onto their independent upstream repairs in #129397, #129383, #129387, #129507, and #129582. Current main also already contains the stronger canonical `/learn` standards assertion, so no unrelated authoring-test change remains in this PR.

The same CI run also reproduced an existing read-only mobile update regression test flake: a sidebar layout shift invalidated cached tap coordinates before the tooltip could open. Replace those coordinates with Playwright's stable, enabled ancestor locator. This keeps a genuine touchscreen tap, the real tooltip event and explanation, and the assertion that no privileged update request is sent.

Current main additionally merged two conflicting changes to the embedded model-resolution fixture: one wrapped its per-agent alias assertion in a real plugin metadata scope, while the next replaced that module with a lightweight mock that did not export the scope function. Keep the efficient mock and remove the now-redundant real scope wrapper, preserving the identical selected-agent alias assertion while deleting ten net test lines.

## User Impact

Cloud tasks never silently switch to local execution when the selected model is incompatible. The Start button explains the incompatibility, no session is created or dispatched, and switching back to a compatible model restores the same cloud worker and machine selection.

## Evidence

- A live isolated Gateway with 17 real plugins, native Claude runtime, a real cloud-worker profile, and actual Chromium reproduced the original defect: after selecting the cloud profile and switching to the available native Claude model, the destination silently changed to Local, Start became enabled, and no warning appeared. With the fix, the cloud destination stays selected, Start stays disabled, Enter visibly explains `The claude-cli runtime does not support cloud workers.`, and no create or dispatch request is sent.
- Fail-first owner regression: two cases failed with `expected '' to be 'aws'` for explicitly selected and recovered cloud destinations.
- `node scripts/run-vitest.mjs ui/src/pages/new-session/draft-place-state.test.ts` — all five placement-owner tests passed on the final rebased head; earlier owner proof also confirmed all nine upstream `/learn` and two repaired embedded-permission tests pass.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model-resolution-consistency.test.ts` — first reproduced the exact hosted missing-mock-export failure in one of eight tests; after deleting the redundant scope wrapper, all eight model-resolution cases passed with the original alias assertion unchanged.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.places-live.e2e.test.ts ui/src/e2e/update-coalesced.e2e.test.ts` — all 12 Chromium browser tests passed, including incompatible runtime blocking, zero create/dispatch requests, restoration of the selected cloud worker and machine, and real read-only mobile tooltip behavior.
- The mobile update browser failure was independently reproduced under a deterministic 64px sidebar movement, then passed after replacing stale tap coordinates with the action container locator; three additional independent mobile runs also passed without weakening tooltip, privilege, or timeout assertions.
- `pnpm plugin-sdk:surface:check` — confirms the repaired base preserves 4,340 public exports, 2,581 callable exports, and 50 wildcard re-exports.
- Production change: 11 lines deleted; no new production path or configuration surface.
- AI-assisted; independently reviewed with the repository's structured Codex autoreview workflow.

![Before: explicitly selected cloud task silently switches to Local with Start enabled](https://github.com/user-attachments/assets/c98b47e6-8c52-4982-b4bf-0a25e46e4139)

![After: cloud target remains selected, Start is disabled, and runtime incompatibility is explained](https://github.com/user-attachments/assets/cd7956b2-0e51-45af-a6a5-2a622b11859f)
