### PR TITLE
refactor(discord): unify reaction client resolution

### DIFF
--- a/extensions/discord/src/send.reactions.ts
+++ b/extensions/discord/src/send.reactions.ts
@@ -12,17 +12,12 @@ import {
   formatReactionEmoji,
   normalizeReactionEmoji,
 } from "./send.shared.js";
-import type {
-  DiscordReactionRuntimeContext,
-  DiscordReactionSummary,
-  DiscordReactOpts,
-} from "./send.types.js";
-
-function createDiscordReactionRuntimeClient(opts: DiscordReactionRuntimeContext) {
-  return createDiscordClient(opts);
-}
+import type { DiscordReactionSummary, DiscordReactOpts } from "./send.types.js";
 
 function resolveDiscordReactionClient(opts: DiscordReactOpts) {
+  if (opts.rest && opts.cfg && opts.accountId) {
+    return createDiscordClient(opts);
+  }
   if (!opts.cfg) {
     throw new Error(
       "Discord reactions requires a resolved runtime config. Load and resolve config at the command or gateway boundary, then pass cfg through the runtime path.",
@@ -32,21 +27,13 @@ function resolveDiscordReactionClient(opts: DiscordReactOpts) {
   return createDiscordClient({ ...opts, cfg });
 }
 
-function isDiscordReactionRuntimeContext(
-  opts: DiscordReactOpts,
-): opts is DiscordReactionRuntimeContext {
-  return Boolean(opts.rest && opts.cfg && opts.accountId);
-}
-
 export async function reactMessageDiscord(
   channelId: string,
   messageId: string,
   emoji: string,
   opts: DiscordReactOpts,
 ) {
-  const { rest, request } = isDiscordReactionRuntimeContext(opts)
-    ? createDiscordReactionRuntimeClient(opts)
-    : resolveDiscordReactionClient(opts);
+  const { rest, request } = resolveDiscordReactionClient(opts);
   const encoded = normalizeReactionEmoji(emoji);
   await request(() => createOwnMessageReaction(rest, channelId, messageId, encoded), "react");
   return { ok: true };
@@ -58,9 +45,7 @@ export async function removeReactionDiscord(
   emoji: string,
   opts: DiscordReactOpts,
 ) {
-  const { rest, request } = isDiscordReactionRuntimeContext(opts)
-    ? createDiscordReactionRuntimeClient(opts)
-    : resolveDiscordReactionClient(opts);
+  const { rest, request } = resolveDiscordReactionClient(opts);
   const encoded = normalizeReactionEmoji(emoji);
   await request(
     () => deleteOwnMessageReaction(rest, channelId, messageId, encoded),
@@ -74,9 +59,7 @@ export async function removeOwnReactionsDiscord(
   messageId: string,
   opts: DiscordReactOpts,
 ): Promise<{ ok: true; removed: string[] }> {
-  const { rest, request } = isDiscordReactionRuntimeContext(opts)
-    ? createDiscordReactionRuntimeClient(opts)
-    : resolveDiscordReactionClient(opts);
+  const { rest, request } = resolveDiscordReactionClient(opts);
   const message = await request(
     () => getChannelMessage(rest, channelId, messageId),
     "reaction-list",
@@ -111,9 +94,7 @@ export async function fetchReactionsDiscord(
   messageId: string,
   opts: DiscordReactOpts & { limit?: number },
 ): Promise<DiscordReactionSummary[]> {
-  const { rest, request } = isDiscordReactionRuntimeContext(opts)
-    ? createDiscordReactionRuntimeClient(opts)
-    : resolveDiscordReactionClient(opts);
+  const { rest, request } = resolveDiscordReactionClient(opts);
   const message = await request(
     () => getChannelMessage(rest, channelId, messageId),
     "reaction-list",

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -1270,7 +1270,12 @@ describe("reactMessageDiscord", () => {
     },
   ])("$name", async ({ emoji, encoded }) => {
     const { rest, putMock } = makeDiscordRest();
-    await reactMessageDiscord("chan1", "msg1", emoji, { rest, token: "t", cfg: DISCORD_TEST_CFG });
+    await reactMessageDiscord("chan1", "msg1", emoji, {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      accountId: "default",
+    });
     expect(putMock).toHaveBeenCalledWith(
       Routes.channelMessageOwnReaction("chan1", "msg1", encoded),
     );
@@ -1284,7 +1289,12 @@ describe("removeReactionDiscord", () => {
 
   it("removes a unicode emoji reaction", async () => {
     const { rest, deleteMock } = makeDiscordRest();
-    await removeReactionDiscord("chan1", "msg1", "✅", { rest, token: "t", cfg: DISCORD_TEST_CFG });
+    await removeReactionDiscord("chan1", "msg1", "✅", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      accountId: "default",
+    });
     expect(deleteMock).toHaveBeenCalledWith(
       Routes.channelMessageOwnReaction("chan1", "msg1", "%E2%9C%85"),
     );
@@ -1328,6 +1338,7 @@ describe("removeOwnReactionsDiscord", () => {
       rest,
       token: "t",
       cfg: DISCORD_TEST_CFG,
+      accountId: "default",
     });
     expect(res).toEqual({ ok: true, removed: ["✅", "party_blob:123"] });
     expect(deleteMock).toHaveBeenCalledWith(
@@ -1414,6 +1425,7 @@ describe("fetchReactionsDiscord", () => {
       rest,
       token: "t",
       cfg: DISCORD_TEST_CFG,
+      accountId: "default",
     });
     expect(res).toEqual([
       {


### PR DESCRIPTION
## What Problem This Solves

Discord reaction operations duplicated runtime-client selection across adding, removing, clearing, and listing reactions. Separate private wrappers obscured which owner preserves prepared account-scoped REST clients.

## Why This Change Was Made

Move the existing prepared-client decision into the private Discord reaction client resolver and delete both redundant wrappers. All four operations now use one canonical owner without changing account selection, token resolution, retries, request routes, error handling, exported contracts, or observable behavior.

## User Impact

No user-visible behavior change. Discord reaction delivery and acknowledgement handling retain their existing account-scoped transport semantics.

## Evidence

Baseline and candidate both pass 321 Discord owner, action, retry, acknowledgement, and subagent tests:

```
node scripts/run-vitest.mjs extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/send.creates-thread.test.ts extensions/discord/src/actions/runtime.test.ts extensions/discord/src/monitor/message-handler.process.ack.test.ts extensions/discord/src/subagent-progress.test.ts
```

Existing real REST-route assertions now exercise the prepared account-scoped client path for adding, removing, clearing, and listing reactions; existing retries and errors continue covering the ordinary client path.

```
node scripts/check-changed.mjs -- extensions/discord/src/send.reactions.ts extensions/discord/src/send.sends-basic-channel-messages.test.ts
```

The complete changed gate passed, including dead exports, production/test TypeScript, lint, plugin boundaries, doctor guards, and import cycles. Independent source review and structured precommit review found no actionable issues. Production: +8/-27 (net -19); tests: +14/-2.
