### PR TITLE
feat(deepgram): support Flux models for voice-note transcription

### DIFF
--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -612,7 +612,7 @@ Configuring a custom/local provider `baseUrl` is also the narrow network trust d
     - `request.auth`: auth strategy override. Modes: `"provider-default"` (use provider's built-in auth), `"authorization-bearer"` (with `token`), `"header"` (with `headerName`, `value`, optional `prefix`).
     - `request.proxy`: HTTP proxy override. Modes: `"env-proxy"` (use `HTTP_PROXY`/`HTTPS_PROXY` env vars), `"explicit-proxy"` (with `url`). Both modes accept an optional `tls` sub-object.
     - `request.tls`: TLS override for direct connections. Fields: `ca`, `cert`, `key`, `passphrase` (all accept SecretRef), `serverName`, `insecureSkipVerify`.
-    - `request.allowPrivateNetwork`: when `true`, allow model-provider HTTP requests to private, CGNAT, or similar ranges through the provider HTTP fetch guard. Custom/local provider base URLs already trust the exact configured origin, except metadata, link-local, and local-use NAT64 (`64:ff9b:1::/48`) origins, which remain blocked without explicit opt-in. Set this to `false` to opt out of exact-origin trust. WebSocket uses the same `request` for headers/TLS but not that fetch SSRF gate. Default `false`.
+    - `request.allowPrivateNetwork`: when `true`, allow guarded model-provider HTTP and WebSocket requests to private, CGNAT, or similar ranges through the shared private-network policy. Custom/local provider base URLs already trust the exact configured origin, except metadata, link-local, and local-use NAT64 (`64:ff9b:1::/48`) origins, which remain blocked without explicit opt-in. Set this to `false` to opt out of exact-origin trust. Default `false`.
 
   </Accordion>
   <Accordion title="Model catalog entries">

--- a/docs/providers/deepgram.md
+++ b/docs/providers/deepgram.md
@@ -11,8 +11,9 @@ Deepgram is a speech-to-text API. OpenClaw uses it for inbound audio/voice-note
 transcription through `tools.media.audio` and for Voice Call streaming STT
 through `plugins.entries.voice-call.config.streaming`.
 
-Batch transcription uploads the complete audio file to Deepgram and injects
-the transcript into the reply pipeline (`{{Transcript}}` + `[Audio]` block).
+Batch transcription uploads the complete audio file to Deepgram. Flux models
+use Deepgram's one-shot WebSocket instead. Both paths inject the transcript
+into the reply pipeline (`{{Transcript}}` + `[Audio]` block).
 Voice Call streaming forwards live G.711 u-law frames over Deepgram's
 WebSocket `listen` endpoint and emits partial/final transcripts as Deepgram
 returns them.
@@ -102,6 +103,19 @@ Deepgram `/listen` request, so any Deepgram-supported param name works
   </Tab>
 </Tabs>
 
+### Flux models
+
+Use `flux-general-en` or `flux-general-multi` for Deepgram Flux. OpenClaw
+converts the voice note to 16 kHz mono linear16 audio with `ffmpeg`, then sends
+it to Deepgram's `/v2/listen` WebSocket endpoint.
+Set `tools.media.models[].model` to either Flux model in the getting-started
+configuration above.
+
+Flux supports `eager_eot_threshold`, `eot_threshold`, `eot_timeout_ms`,
+`keyterm`, `language_hint`, `mip_opt_out`, `numerals`, `profanity_filter`,
+`redact`, and `tag` in `providerOptions.deepgram`. OpenClaw ignores batch-only
+options such as `detect_language`, `punctuate`, and `smart_format` on Flux.
+
 ## Voice Call streaming STT
 
 The bundled `deepgram` plugin also registers a realtime transcription provider
@@ -168,6 +182,10 @@ Twilio media frames can be forwarded directly.
   <Accordion title="Output behavior">
     Output follows the same audio rules as other providers (size caps, timeouts,
     transcript injection).
+  </Accordion>
+  <Accordion title="Flux requires ffmpeg">
+    Install `ffmpeg` with the gateway host's package manager before selecting a
+    Flux model.
   </Accordion>
 </AccordionGroup>
 

--- a/extensions/deepgram/audio-flux.test.ts
+++ b/extensions/deepgram/audio-flux.test.ts
@@ -1,0 +1,225 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { AudioTranscriptionRequest } from "openclaw/plugin-sdk/media-understanding";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RawData, WebSocket } from "ws";
+import { WebSocketServer } from "ws";
+import { isDeepgramFluxModel } from "./audio-flux.js";
+import { transcribeDeepgramAudio } from "./audio.js";
+
+const runCommandBuffered = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>()),
+  resolveFfmpegBin: () => "/usr/bin/ffmpeg",
+}));
+vi.mock("openclaw/plugin-sdk/process-runtime", () => ({ runCommandBuffered }));
+
+const cleanups: Array<() => Promise<void>> = [];
+
+function parseClientMessage(data: RawData): Record<string, unknown> | undefined {
+  if (typeof data !== "string" && !Buffer.isBuffer(data)) {
+    return undefined;
+  }
+  const parsed: unknown = JSON.parse(data.toString());
+  return asOptionalRecord(parsed);
+}
+
+async function createFluxServer(params: {
+  onCloseStream: (socket: WebSocket) => void;
+  onRequest?: (url: URL, headers: Record<string, string | string[] | undefined>) => void;
+}) {
+  const server = createServer();
+  const websocketServer = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
+  const audioFrames: Buffer[] = [];
+  server.on("upgrade", (request, socket, head) => {
+    params.onRequest?.(new URL(request.url ?? "/", "http://127.0.0.1"), request.headers);
+    websocketServer.handleUpgrade(request, socket, head, (client) => {
+      client.on("message", (data, isBinary) => {
+        if (isBinary) {
+          const bytes = Array.isArray(data)
+            ? Buffer.concat(data)
+            : Buffer.isBuffer(data)
+              ? data
+              : Buffer.from(data);
+          audioFrames.push(bytes);
+          return;
+        }
+        if (parseClientMessage(data)?.type === "CloseStream") {
+          params.onCloseStream(client);
+        }
+      });
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+  cleanups.push(
+    async () =>
+      await new Promise<void>((resolve, reject) => {
+        for (const client of websocketServer.clients) {
+          client.terminate();
+        }
+        websocketServer.close(() => server.close((error) => (error ? reject(error) : resolve())));
+      }),
+  );
+  return { audioFrames, baseUrl: `http://127.0.0.1:${port}/v1` };
+}
+
+function fluxRequest(
+  baseUrl: string,
+  extra: Partial<AudioTranscriptionRequest> = {},
+): AudioTranscriptionRequest {
+  return {
+    buffer: Buffer.from("source audio"),
+    fileName: "note.ogg",
+    apiKey: "default-key",
+    baseUrl,
+    model: "flux-general-multi",
+    timeoutMs: 5000,
+    request: { allowPrivateNetwork: true },
+    ...extra,
+  };
+}
+
+function mockDecodedPcm(pcm: Buffer): void {
+  runCommandBuffered.mockResolvedValueOnce({
+    stdout: pcm,
+    stderr: Buffer.alloc(0),
+    code: 0,
+    signal: null,
+    killed: false,
+    termination: "exit",
+  });
+}
+
+describe("Deepgram Flux audio", () => {
+  afterEach(async () => {
+    runCommandBuffered.mockReset();
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+  });
+
+  it("routes documented Flux models only", () => {
+    expect(isDeepgramFluxModel("flux-general-en")).toBe(true);
+    expect(isDeepgramFluxModel(" Flux-General-Multi ")).toBe(true);
+    expect(isDeepgramFluxModel("flux")).toBe(false);
+    expect(isDeepgramFluxModel("reflux-general-en")).toBe(false);
+    expect(isDeepgramFluxModel("nova-3")).toBe(false);
+  });
+
+  it("uses resolved auth and Flux protocol fields through the guarded socket", async () => {
+    const pcm = Buffer.alloc(6000, 1);
+    mockDecodedPcm(pcm);
+    let requestUrl: URL | undefined;
+    let authorization: string | string[] | undefined;
+    const server = await createFluxServer({
+      onRequest: (url, headers) => {
+        requestUrl = url;
+        authorization = headers.authorization;
+      },
+      onCloseStream: (socket) => {
+        socket.send(
+          JSON.stringify({ type: "TurnInfo", event: "EndOfTurn", transcript: "life moves" }),
+        );
+        socket.send(
+          JSON.stringify({ type: "TurnInfo", event: "EndOfTurn", transcript: "pretty fast" }),
+        );
+        socket.close();
+      },
+    });
+
+    const result = await transcribeDeepgramAudio(
+      fluxRequest(server.baseUrl, {
+        language: " en ",
+        query: {
+          eot_threshold: 0.7,
+          numerals: true,
+          profanity_filter: true,
+          smart_format: true,
+        },
+        request: {
+          allowPrivateNetwork: true,
+          auth: {
+            mode: "header",
+            headerName: "authorization",
+            value: "Token configured-key",
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({ model: "flux-general-multi", text: "life moves pretty fast" });
+    expect(authorization).toBe("Token configured-key");
+    expect(requestUrl?.pathname).toBe("/v2/listen");
+    expect(requestUrl?.searchParams.get("encoding")).toBe("linear16");
+    expect(requestUrl?.searchParams.get("sample_rate")).toBe("16000");
+    expect(requestUrl?.searchParams.get("language_hint")).toBe("en");
+    expect(requestUrl?.searchParams.get("eot_threshold")).toBe("0.7");
+    expect(requestUrl?.searchParams.get("numerals")).toBe("true");
+    expect(requestUrl?.searchParams.get("profanity_filter")).toBe("true");
+    expect(requestUrl?.searchParams.has("smart_format")).toBe(false);
+    expect(server.audioFrames.map((frame) => frame.byteLength)).toEqual([2560, 2560, 880]);
+    expect(Buffer.concat(server.audioFrames)).toEqual(pcm);
+    expect(runCommandBuffered).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        "/usr/bin/ffmpeg",
+        "-t",
+        "1200",
+        "-c:a",
+        "pcm_s16le",
+        "-ar",
+        "16000",
+      ]),
+      expect.objectContaining({
+        maxOutputBytes: { stdout: 38_400_000, stderr: 65_536 },
+        terminateOnOutputError: true,
+      }),
+    );
+  });
+
+  it.each(["null", "[]", "42"])("rejects valid non-object server JSON: %s", async (payload) => {
+    mockDecodedPcm(Buffer.alloc(10, 1));
+    const server = await createFluxServer({
+      onCloseStream: (socket) => socket.send(payload),
+    });
+    await expect(transcribeDeepgramAudio(fluxRequest(server.baseUrl))).rejects.toThrow(
+      "malformed JSON response",
+    );
+  });
+
+  it("rejects retained transcript growth above the provider limit", async () => {
+    mockDecodedPcm(Buffer.alloc(10, 1));
+    const server = await createFluxServer({
+      onCloseStream: (socket) =>
+        socket.send(
+          JSON.stringify({
+            type: "TurnInfo",
+            event: "EndOfTurn",
+            transcript: "x".repeat(256 * 1024 + 1),
+          }),
+        ),
+    });
+    await expect(transcribeDeepgramAudio(fluxRequest(server.baseUrl))).rejects.toThrow(
+      "transcript exceeds size limit",
+    );
+  });
+
+  it("does not open a private socket without the request-policy opt-in", async () => {
+    mockDecodedPcm(Buffer.alloc(10, 1));
+    let opened = false;
+    const server = await createFluxServer({
+      onRequest: () => {
+        opened = true;
+      },
+      onCloseStream: () => undefined,
+    });
+    await expect(
+      transcribeDeepgramAudio(
+        fluxRequest(server.baseUrl, { request: { allowPrivateNetwork: false } }),
+      ),
+    ).rejects.toThrow(/private|loopback|blocked/iu);
+    expect(opened).toBe(false);
+  });
+});

--- a/extensions/deepgram/audio-flux.ts
+++ b/extensions/deepgram/audio-flux.ts
@@ -1,0 +1,326 @@
+// Deepgram Flux voice-note transcription uses the provider's one-shot WebSocket protocol.
+import {
+  MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS,
+  resolveFfmpegBin,
+} from "openclaw/plugin-sdk/media-runtime";
+import type {
+  AudioTranscriptionRequest,
+  AudioTranscriptionResult,
+} from "openclaw/plugin-sdk/media-understanding";
+import { runCommandBuffered } from "openclaw/plugin-sdk/process-runtime";
+import {
+  createProviderOperationDeadline,
+  createProviderOperationTimeoutResolver,
+  openProviderWebSocket,
+  requireTranscriptionText,
+} from "openclaw/plugin-sdk/provider-http";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const DEEPGRAM_FLUX_SAMPLE_RATE = 16_000;
+// Deepgram recommends 80 ms chunks. 16 kHz mono linear16 contains 32 bytes per millisecond.
+const DEEPGRAM_FLUX_AUDIO_CHUNK_BYTES = 2_560;
+const DEEPGRAM_FLUX_MAX_MESSAGE_BYTES = 1024 * 1024;
+const DEEPGRAM_FLUX_MAX_TRANSCRIPT_BYTES = 256 * 1024;
+const DEEPGRAM_FLUX_MAX_PCM_BYTES =
+  DEEPGRAM_FLUX_SAMPLE_RATE * 2 * MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS;
+const DEEPGRAM_FLUX_QUERY_KEYS = new Set([
+  "eager_eot_threshold",
+  "eot_threshold",
+  "eot_timeout_ms",
+  "keyterm",
+  "language_hint",
+  "mip_opt_out",
+  "numerals",
+  "profanity_filter",
+  "redact",
+  "tag",
+]);
+
+type DeepgramFluxRequestConfig = {
+  allowPrivateNetwork: boolean;
+  baseUrl: string;
+  dispatcherPolicy?: Parameters<typeof openProviderWebSocket>[0]["dispatcherPolicy"];
+  headers: Headers;
+  trustConfiguredBaseUrlOrigin: boolean;
+};
+
+export function isDeepgramFluxModel(model?: string): boolean {
+  return model?.trim().toLowerCase().startsWith("flux-") ?? false;
+}
+
+function buildDeepgramFluxUrl(params: {
+  baseUrl: string;
+  language?: string;
+  model: string;
+  query?: Record<string, string | number | boolean | undefined>;
+}): string {
+  let url: URL;
+  try {
+    url = new URL(params.baseUrl);
+  } catch {
+    throw new Error("Invalid Deepgram baseUrl: value is not a valid URL");
+  }
+  if (url.protocol === "http:") {
+    url.protocol = "ws:";
+  } else if (url.protocol === "https:") {
+    url.protocol = "wss:";
+  } else if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+    throw new Error(
+      `Invalid Deepgram baseUrl: unsupported scheme "${url.protocol}" (expected http, https, ws, or wss)`,
+    );
+  }
+  const basePath = url.pathname.replace(/\/+$/u, "");
+  url.pathname = `${basePath ? basePath.replace(/\/v1$/u, "/v2") : "/v2"}/listen`;
+  url.search = "";
+  url.searchParams.set("model", params.model);
+  url.searchParams.set("encoding", "linear16");
+  url.searchParams.set("sample_rate", String(DEEPGRAM_FLUX_SAMPLE_RATE));
+  if (params.language?.trim()) {
+    url.searchParams.set("language_hint", params.language.trim());
+  }
+  for (const [key, value] of Object.entries(params.query ?? {})) {
+    if (value !== undefined && DEEPGRAM_FLUX_QUERY_KEYS.has(key)) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+function readFluxEvent(data: Buffer | ArrayBuffer | Buffer[]): Record<string, unknown> {
+  const bytes = Array.isArray(data)
+    ? Buffer.concat(data)
+    : Buffer.isBuffer(data)
+      ? data
+      : Buffer.from(data);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error("Audio transcription failed: malformed JSON response");
+  }
+  const event = asOptionalRecord(parsed);
+  if (!event) {
+    throw new Error("Audio transcription failed: malformed JSON response");
+  }
+  return event;
+}
+
+function readFluxErrorDetail(event: Record<string, unknown>): string {
+  const nested = asOptionalRecord(event.error);
+  for (const value of [event.description, event.message, nested?.message]) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return "Deepgram Flux transcription error";
+}
+
+type DeepgramFluxSocket = Awaited<ReturnType<typeof openProviderWebSocket>>;
+
+function sendSocketFrame(socket: DeepgramFluxSocket, data: Buffer | string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    socket.send(data, (error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function decodeDeepgramFluxAudio(params: {
+  buffer: Buffer;
+  signal?: AbortSignal;
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const result = await runCommandBuffered(
+    [
+      resolveFfmpegBin(),
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-i",
+      "pipe:0",
+      "-t",
+      String(MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS),
+      "-vn",
+      "-sn",
+      "-dn",
+      "-c:a",
+      "pcm_s16le",
+      "-ar",
+      String(DEEPGRAM_FLUX_SAMPLE_RATE),
+      "-ac",
+      "1",
+      "-f",
+      "s16le",
+      "pipe:1",
+    ],
+    {
+      input: params.buffer,
+      maxOutputBytes: { stdout: DEEPGRAM_FLUX_MAX_PCM_BYTES, stderr: 64 * 1024 },
+      signal: params.signal,
+      terminateOnOutputError: true,
+      timeoutMs: params.timeoutMs,
+    },
+  );
+  if (result.termination === "exit" && result.code === 0) {
+    return result.stdout;
+  }
+  if (result.termination === "output-limit") {
+    throw new Error("Audio transcription failed: decoded audio exceeds size limit");
+  }
+  const detail = result.stderr.toString("utf8").trim();
+  throw new Error(
+    `Audio transcription failed: ffmpeg ${result.termination}${detail ? `: ${detail}` : ""}`,
+    { cause: result.error },
+  );
+}
+
+export async function transcribeDeepgramFluxAudio(params: {
+  request: AudioTranscriptionRequest;
+  requestConfig: DeepgramFluxRequestConfig;
+  model: string;
+}): Promise<AudioTranscriptionResult> {
+  const deadline = createProviderOperationDeadline({
+    timeoutMs: params.request.timeoutMs,
+    label: "Deepgram Flux transcription",
+  });
+  const resolveTimeoutMs = createProviderOperationTimeoutResolver({
+    deadline,
+    defaultTimeoutMs: params.request.timeoutMs,
+  });
+  const pcm = await decodeDeepgramFluxAudio({
+    buffer: params.request.buffer,
+    signal: params.request.signal,
+    timeoutMs: resolveTimeoutMs(),
+  });
+  if (pcm.byteLength === 0) {
+    throw new Error("Audio transcription failed: decoded audio is empty");
+  }
+
+  const url = buildDeepgramFluxUrl({
+    baseUrl: params.requestConfig.baseUrl,
+    language: params.request.language,
+    model: params.model,
+    query: params.request.query,
+  });
+  const timeoutMs = resolveTimeoutMs();
+  const socket = await openProviderWebSocket({
+    allowPrivateNetwork: params.requestConfig.allowPrivateNetwork,
+    baseUrl: params.requestConfig.baseUrl,
+    dispatcherPolicy: params.requestConfig.dispatcherPolicy,
+    headers: params.requestConfig.headers,
+    maxPayloadBytes: DEEPGRAM_FLUX_MAX_MESSAGE_BYTES,
+    signal: params.request.signal,
+    timeoutMs,
+    trustConfiguredBaseUrlOrigin: params.requestConfig.trustConfiguredBaseUrlOrigin,
+    url,
+  });
+
+  const transcript = await new Promise<string>((resolve, reject) => {
+    const finalizedTurns: string[] = [];
+    let finalizedTranscriptBytes = 0;
+    let lastPartial = "";
+    let settled = false;
+    let closeStreamSent = false;
+
+    const settle = (outcome: { error?: Error; text?: string }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      socket.terminate();
+      if (outcome.error) {
+        reject(outcome.error);
+      } else {
+        resolve(outcome.text ?? "");
+      }
+    };
+    const timer = setTimeout(
+      () => settle({ error: new Error("Deepgram Flux transcription timed out") }),
+      timeoutMs,
+    );
+
+    socket.on("open", () => {
+      void (async () => {
+        try {
+          for (let offset = 0; offset < pcm.byteLength; offset += DEEPGRAM_FLUX_AUDIO_CHUNK_BYTES) {
+            await sendSocketFrame(
+              socket,
+              pcm.subarray(offset, offset + DEEPGRAM_FLUX_AUDIO_CHUNK_BYTES),
+            );
+          }
+          await sendSocketFrame(socket, JSON.stringify({ type: "CloseStream" }));
+          closeStreamSent = true;
+        } catch (error) {
+          settle({
+            error: new Error(
+              `Audio transcription failed: ${error instanceof Error ? error.message : String(error)}`,
+            ),
+          });
+        }
+      })();
+    });
+
+    socket.on("message", (data) => {
+      try {
+        const event = readFluxEvent(data);
+        if (event.type === "Error" || event.type === "error") {
+          settle({
+            error: new Error(`Audio transcription failed: ${readFluxErrorDetail(event)}`),
+          });
+          return;
+        }
+        if (event.type !== "TurnInfo" || typeof event.transcript !== "string") {
+          return;
+        }
+        if (event.event === "EndOfTurn") {
+          finalizedTranscriptBytes += Buffer.byteLength(event.transcript, "utf8");
+          finalizedTurns.push(event.transcript);
+          lastPartial = "";
+        } else {
+          lastPartial = event.transcript;
+        }
+        if (
+          finalizedTranscriptBytes + Buffer.byteLength(lastPartial, "utf8") >
+          DEEPGRAM_FLUX_MAX_TRANSCRIPT_BYTES
+        ) {
+          settle({ error: new Error("Audio transcription failed: transcript exceeds size limit") });
+        }
+      } catch (error) {
+        settle({ error: error instanceof Error ? error : new Error(String(error)) });
+      }
+    });
+
+    socket.on("error", (error) => {
+      settle({ error: new Error(`Audio transcription failed: ${error.message}`) });
+    });
+
+    socket.on("close", (code, reason) => {
+      if (!closeStreamSent) {
+        settle({ error: new Error("Audio transcription failed: Flux closed before flush") });
+        return;
+      }
+      if (code !== 1000 && code !== 1005) {
+        const detail = reason.toString().trim();
+        settle({
+          error: new Error(
+            `Audio transcription failed: Flux closed abnormally (code ${code}${detail ? `: ${detail}` : ""})`,
+          ),
+        });
+        return;
+      }
+      settle({
+        text: [...finalizedTurns, lastPartial]
+          .map((part) => part.trim())
+          .filter(Boolean)
+          .join(" "),
+      });
+    });
+  });
+
+  return {
+    text: requireTranscriptionText(
+      transcript || undefined,
+      "Audio transcription response missing transcript",
+    ),
+    model: params.model,
+  };
+}

--- a/extensions/deepgram/audio.live.test.ts
+++ b/extensions/deepgram/audio.live.test.ts
@@ -71,7 +71,9 @@ describeLive("deepgram live", () => {
       baseUrl: DEEPGRAM_BASE_URL,
       timeoutMs: 20000,
     });
-    expect(result.text.trim().length).toBeGreaterThan(0);
+    expect(result.text.toLowerCase().replaceAll(/[^a-z0-9]/gu, "")).toContain(
+      "lifemovesprettyfast",
+    );
   }, 30000);
 
   it("streams realtime STT through the registered transcription provider", async () => {

--- a/extensions/deepgram/audio.ts
+++ b/extensions/deepgram/audio.ts
@@ -7,10 +7,11 @@ import {
   assertOkOrThrowHttpError,
   postTranscriptionRequest,
   readProviderJsonObjectResponse,
-  resolveProviderHttpRequestConfig,
+  resolveProviderHttpRequestConfigWithOriginTrust,
   requireTranscriptionText,
 } from "openclaw/plugin-sdk/provider-http";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isDeepgramFluxModel, transcribeDeepgramFluxAudio } from "./audio-flux.js";
 
 export const DEFAULT_DEEPGRAM_AUDIO_BASE_URL = "https://api.deepgram.com/v1";
 export const DEFAULT_DEEPGRAM_AUDIO_MODEL = "nova-3";
@@ -48,22 +49,26 @@ function readDeepgramTranscript(payload: Record<string, unknown>): string | unde
 export async function transcribeDeepgramAudio(
   params: AudioTranscriptionRequest,
 ): Promise<AudioTranscriptionResult> {
-  const fetchFn = params.fetchFn ?? fetch;
   const model = resolveModel(params.model);
-  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
-    resolveProviderHttpRequestConfig({
-      baseUrl: params.baseUrl,
-      defaultBaseUrl: DEFAULT_DEEPGRAM_AUDIO_BASE_URL,
-      headers: params.headers,
-      request: params.request,
-      defaultHeaders: {
-        authorization: `Token ${params.apiKey}`,
-        "content-type": params.mime ?? "application/octet-stream",
-      },
-      provider: "deepgram",
-      capability: "audio",
-      transport: "media-understanding",
-    });
+  const flux = isDeepgramFluxModel(model);
+  const requestConfig = resolveProviderHttpRequestConfigWithOriginTrust({
+    baseUrl: params.baseUrl,
+    defaultBaseUrl: DEFAULT_DEEPGRAM_AUDIO_BASE_URL,
+    headers: params.headers,
+    request: params.request,
+    defaultHeaders: {
+      authorization: `Token ${params.apiKey}`,
+      ...(flux ? {} : { "content-type": params.mime ?? "application/octet-stream" }),
+    },
+    provider: "deepgram",
+    capability: "audio",
+    transport: "media-understanding",
+  });
+  if (flux) {
+    return await transcribeDeepgramFluxAudio({ request: params, requestConfig, model });
+  }
+  const fetchFn = params.fetchFn ?? fetch;
+  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } = requestConfig;
 
   const url = new URL(`${baseUrl}/listen`);
   url.searchParams.set("model", model);

--- a/package.json
+++ b/package.json
@@ -2068,6 +2068,7 @@
     "grammy": "1.45.1",
     "highlight.js": "11.12.0",
     "hosted-git-info": "10.1.1",
+    "https-proxy-agent": "7.0.6",
     "iconv-lite": "0.7.3",
     "ignore": "7.0.6",
     "jiti": "2.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       hosted-git-info:
         specifier: 10.1.1
         version: 10.1.1
+      https-proxy-agent:
+        specifier: 7.0.6
+        version: 7.0.6(supports-color@10.2.2)
       iconv-lite:
         specifier: 0.7.3
         version: 0.7.3

--- a/src/infra/net/provider-websocket.test.ts
+++ b/src/infra/net/provider-websocket.test.ts
@@ -1,0 +1,153 @@
+import { once } from "node:events";
+import { createServer as createHttpServer } from "node:http";
+import { createServer as createHttpsServer } from "node:https";
+import net, { type AddressInfo } from "node:net";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../../test/helpers/tls-fixture.js";
+import { openProviderWebSocket } from "./provider-websocket.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+async function createLocalWebSocketServer(options: { tls?: boolean } = {}) {
+  const server = options.tls
+    ? createHttpsServer({ cert: TEST_TLS_CERT_PEM, key: TEST_TLS_KEY_PEM })
+    : createHttpServer();
+  const websocketServer = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
+  const requestHeaders: Array<Record<string, string | string[] | undefined>> = [];
+  server.on("upgrade", (request, socket, head) => {
+    requestHeaders.push(request.headers);
+    websocketServer.handleUpgrade(request, socket, head, (client) => {
+      websocketServer.emit("connection", client, request);
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+  cleanups.push(
+    async () =>
+      await new Promise<void>((resolve, reject) => {
+        for (const client of websocketServer.clients) {
+          client.terminate();
+        }
+        websocketServer.close(() => server.close((error) => (error ? reject(error) : resolve())));
+      }),
+  );
+  return {
+    requestHeaders,
+    url: `${options.tls ? "wss" : "ws"}://127.0.0.1:${port}/listen`,
+  };
+}
+
+async function createConnectProxy(proxyHostname = "127.0.0.1") {
+  const server = createHttpServer();
+  let connectCount = 0;
+  server.on("connect", (request, clientSocket, head) => {
+    connectCount += 1;
+    const [hostname, rawPort] = (request.url ?? "").split(":");
+    const targetSocket = net.connect(Number(rawPort), hostname, () => {
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head.byteLength > 0) {
+        targetSocket.write(head);
+      }
+      targetSocket.pipe(clientSocket);
+      clientSocket.pipe(targetSocket);
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+  cleanups.push(
+    async () =>
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  );
+  return { connectCount: () => connectCount, url: `http://${proxyHostname}:${port}` };
+}
+
+describe("openProviderWebSocket", () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+  });
+
+  it.each([
+    { name: "private", allowPrivateNetwork: false },
+    { name: "pre-aborted", allowPrivateNetwork: true, signal: AbortSignal.abort() },
+  ])("does not open a $name socket", async (testCase) => {
+    const server = await createLocalWebSocketServer();
+    await expect(
+      openProviderWebSocket({
+        allowPrivateNetwork: testCase.allowPrivateNetwork,
+        baseUrl: server.url,
+        headers: { authorization: "Token test" },
+        ...(testCase.signal ? { signal: testCase.signal } : {}),
+        timeoutMs: 1000,
+        trustConfiguredBaseUrlOrigin: false,
+        url: server.url,
+      }),
+    ).rejects.toThrow(/private|loopback|blocked|aborted/iu);
+    expect(server.requestHeaders).toHaveLength(0);
+  });
+
+  it("opens an allowed socket with resolved request headers", async () => {
+    const server = await createLocalWebSocketServer();
+    const socket = await openProviderWebSocket({
+      allowPrivateNetwork: true,
+      baseUrl: server.url,
+      headers: { authorization: "Token configured", "x-provider": "deepgram" },
+      timeoutMs: 1000,
+      trustConfiguredBaseUrlOrigin: false,
+      url: server.url,
+    });
+    await once(socket, "open");
+    expect(server.requestHeaders[0]?.authorization).toBe("Token configured");
+    expect(server.requestHeaders[0]?.["x-provider"]).toBe("deepgram");
+    socket.close();
+    await once(socket, "close");
+  });
+
+  it("applies target TLS settings to the WebSocket handshake", async () => {
+    const server = await createLocalWebSocketServer({ tls: true });
+    const socket = await openProviderWebSocket({
+      allowPrivateNetwork: true,
+      baseUrl: server.url,
+      dispatcherPolicy: { mode: "direct", connect: { rejectUnauthorized: false } },
+      timeoutMs: 1000,
+      trustConfiguredBaseUrlOrigin: false,
+      url: server.url,
+    });
+    await once(socket, "open");
+    expect(server.requestHeaders).toHaveLength(1);
+    socket.close();
+    await once(socket, "close");
+  });
+
+  it("routes the WebSocket handshake through an explicit proxy", async () => {
+    const target = await createLocalWebSocketServer();
+    const connectSpy = vi.spyOn(net, "connect");
+    const proxy = await createConnectProxy("localhost");
+    const socket = await openProviderWebSocket({
+      allowPrivateNetwork: true,
+      baseUrl: target.url,
+      dispatcherPolicy: { mode: "explicit-proxy", proxyUrl: proxy.url },
+      timeoutMs: 1000,
+      trustConfiguredBaseUrlOrigin: false,
+      url: target.url,
+    });
+    await once(socket, "open");
+    expect(proxy.connectCount()).toBe(1);
+    expect(target.requestHeaders).toHaveLength(1);
+    expect(
+      connectSpy.mock.calls.some(
+        ([options]) => typeof asOptionalRecord(options)?.lookup === "function",
+      ),
+    ).toBe(true);
+    socket.close();
+    await once(socket, "close");
+  });
+});

--- a/src/infra/net/provider-websocket.ts
+++ b/src/infra/net/provider-websocket.ts
@@ -1,0 +1,210 @@
+// Provider WebSocket connector applies the same auth, proxy, TLS, and SSRF policy as provider HTTP.
+import http from "node:http";
+import type { Agent as HttpAgent } from "node:http";
+import https from "node:https";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import WebSocket from "ws";
+import { resolveProviderTransportSsrFPolicy } from "../../agents/provider-transport-fetch.js";
+import { racePromiseWithAbortSignal } from "../abort-signal.js";
+import { resolveEnvNodeProxyUrlForTarget } from "./node-proxy-agent.js";
+import { resolveActiveManagedProxyTlsOptions } from "./proxy/active-managed-proxy-tls.js";
+import {
+  assertHostnameAllowedWithPolicy,
+  resolvePinnedHostnameWithPolicy,
+  type PinnedDispatcherPolicy,
+  type SsrFPolicy,
+} from "./ssrf.js";
+
+const DEFAULT_PROVIDER_WEBSOCKET_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
+
+type OpenProviderWebSocketParams = {
+  allowPrivateNetwork: boolean;
+  baseUrl: string;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+  headers?: HeadersInit;
+  maxPayloadBytes?: number;
+  signal?: AbortSignal;
+  timeoutMs: number;
+  trustConfiguredBaseUrlOrigin: boolean;
+  url: string;
+};
+
+function toHttpUrl(value: string): string {
+  const url = new URL(value);
+  if (url.protocol === "ws:") {
+    url.protocol = "http:";
+  } else if (url.protocol === "wss:") {
+    url.protocol = "https:";
+  }
+  return url.toString();
+}
+
+function targetTlsOptions(policy: PinnedDispatcherPolicy | undefined): Record<string, unknown> {
+  return policy?.mode === "direct" || policy?.mode === "env-proxy" ? { ...policy.connect } : {};
+}
+
+function proxyPolicy(
+  policy: SsrFPolicy | undefined,
+  allowPrivateProxy: boolean,
+): SsrFPolicy | undefined {
+  if (!policy && !allowPrivateProxy) {
+    return undefined;
+  }
+  return {
+    ...policy,
+    hostnameAllowlist: undefined,
+    ...(allowPrivateProxy ? { allowPrivateNetwork: true } : {}),
+  };
+}
+
+async function createProxyAgent(params: {
+  policy: SsrFPolicy | undefined;
+  proxyUrl: URL;
+  proxyTls?: Record<string, unknown>;
+  allowPrivateProxy: boolean;
+}): Promise<HttpAgent> {
+  const pinnedProxy = await resolvePinnedHostnameWithPolicy(params.proxyUrl.hostname, {
+    policy: proxyPolicy(params.policy, params.allowPrivateProxy),
+  });
+  return new HttpsProxyAgent(params.proxyUrl, {
+    ...params.proxyTls,
+    lookup: pinnedProxy.lookup,
+  });
+}
+
+async function createProviderWebSocketAgent(params: {
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+  policy: SsrFPolicy | undefined;
+  url: URL;
+}): Promise<HttpAgent> {
+  const targetTls = targetTlsOptions(params.dispatcherPolicy);
+  if (params.dispatcherPolicy?.mode === "explicit-proxy") {
+    let proxyUrl: URL;
+    try {
+      proxyUrl = new URL(params.dispatcherPolicy.proxyUrl);
+    } catch {
+      throw new Error("Invalid explicit proxy URL");
+    }
+    if (proxyUrl.protocol !== "http:" && proxyUrl.protocol !== "https:") {
+      throw new Error("Explicit proxy URL must use http or https");
+    }
+    // The proxy resolves the final target. Check that hostname before sending
+    // credentials, and pin the separately configured proxy host in createProxyAgent.
+    assertHostnameAllowedWithPolicy(params.url.hostname, params.policy);
+    return await createProxyAgent({
+      policy: params.policy,
+      proxyUrl,
+      proxyTls: params.dispatcherPolicy.proxyTls,
+      allowPrivateProxy: params.dispatcherPolicy.allowPrivateProxy === true,
+    });
+  }
+
+  const useEnvProxy =
+    params.dispatcherPolicy?.mode === "env-proxy" || params.dispatcherPolicy === undefined;
+  const envProxyUrl = useEnvProxy ? resolveEnvNodeProxyUrlForTarget(params.url) : undefined;
+  if (envProxyUrl) {
+    // Environment proxies are operator-owned DNS boundaries, matching guarded HTTP.
+    // The target hostname still passes policy before the handshake carries credentials.
+    assertHostnameAllowedWithPolicy(params.url.hostname, params.policy);
+    return await createProxyAgent({
+      policy: params.policy,
+      proxyUrl: envProxyUrl,
+      proxyTls:
+        params.dispatcherPolicy?.mode === "env-proxy"
+          ? params.dispatcherPolicy.proxyTls
+          : resolveActiveManagedProxyTlsOptions({ proxyUrl: envProxyUrl.href }),
+      allowPrivateProxy: true,
+    });
+  }
+
+  const pinned = await resolvePinnedHostnameWithPolicy(params.url.hostname, {
+    policy: params.policy,
+  });
+  const options = { keepAlive: false, ...targetTls, lookup: pinned.lookup };
+  return params.url.protocol === "wss:" ? new https.Agent(options) : new http.Agent(options);
+}
+
+async function resolveAgentWithinDeadline(params: {
+  create: () => Promise<HttpAgent>;
+  signal?: AbortSignal;
+  timeoutMs: number;
+}): Promise<HttpAgent> {
+  const timeoutSignal = AbortSignal.timeout(Math.max(1, params.timeoutMs));
+  const signal = params.signal ? AbortSignal.any([params.signal, timeoutSignal]) : timeoutSignal;
+  let abandoned = signal.aborted;
+  signal.addEventListener(
+    "abort",
+    () => {
+      abandoned = true;
+    },
+    { once: true },
+  );
+  const pending = params.create();
+  void pending.then(
+    (agent) => abandoned && agent.destroy(),
+    () => undefined,
+  );
+  try {
+    return await racePromiseWithAbortSignal(pending, signal);
+  } catch (error) {
+    if (timeoutSignal.aborted) {
+      throw new Error("Provider WebSocket connection timed out", { cause: error });
+    }
+    if (params.signal?.aborted) {
+      throw new Error("Provider WebSocket connection aborted", { cause: error });
+    }
+    throw error;
+  }
+}
+
+/** Opens a provider WebSocket through resolved request policy and pinned network targets. */
+export async function openProviderWebSocket(
+  params: OpenProviderWebSocketParams,
+): Promise<WebSocket> {
+  let url: URL;
+  try {
+    url = new URL(params.url);
+  } catch {
+    throw new Error("Invalid provider WebSocket URL");
+  }
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+    throw new Error("Provider WebSocket URL must use ws or wss");
+  }
+  const policy = resolveProviderTransportSsrFPolicy({
+    baseUrl: toHttpUrl(params.baseUrl),
+    url: toHttpUrl(url.toString()),
+    allowPrivateNetwork: params.allowPrivateNetwork,
+    trustConfiguredBaseUrlOrigin: params.trustConfiguredBaseUrlOrigin,
+  });
+  const agent = await resolveAgentWithinDeadline({
+    create: async () =>
+      await createProviderWebSocketAgent({
+        dispatcherPolicy: params.dispatcherPolicy,
+        policy,
+        url,
+      }),
+    signal: params.signal,
+    timeoutMs: params.timeoutMs,
+  });
+  let socket: WebSocket;
+  try {
+    socket = new WebSocket(url, {
+      agent,
+      headers: Object.fromEntries(new Headers(params.headers).entries()),
+      handshakeTimeout: Math.max(1, params.timeoutMs),
+      maxPayload: params.maxPayloadBytes ?? DEFAULT_PROVIDER_WEBSOCKET_MAX_PAYLOAD_BYTES,
+      perMessageDeflate: false,
+      ...targetTlsOptions(params.dispatcherPolicy),
+    });
+  } catch (error) {
+    agent.destroy();
+    throw error;
+  }
+  socket.once("close", () => agent.destroy());
+  if (params.signal) {
+    const onAbort = () => socket.terminate();
+    params.signal.addEventListener("abort", onAbort, { once: true });
+    socket.once("close", () => params.signal?.removeEventListener("abort", onAbort));
+  }
+  return socket;
+}

--- a/src/plugin-sdk/provider-http.ts
+++ b/src/plugin-sdk/provider-http.ts
@@ -42,11 +42,13 @@ export {
   postTranscriptionRequest,
   resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
+  resolveProviderHttpRequestConfigWithOriginTrust,
   resolveAudioTranscriptionUploadFileName,
   requireTranscriptionText,
   sanitizeConfiguredModelProviderRequest,
   waitProviderOperationPollInterval,
 } from "../media-understanding/shared.js";
+export { openProviderWebSocket } from "../infra/net/provider-websocket.js";
 export type {
   ProviderOperationDeadline,
   ProviderOperationTimeoutMs,

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -328,11 +328,25 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => ({
   pollProviderOperationJson: providerHttpMocks.pollProviderOperationJsonMock,
   postJsonRequest: providerHttpMocks.postJsonRequestMock,
   postMultipartRequest: providerHttpMocks.postMultipartRequestMock,
+  postTranscriptionRequest: (
+    await importActual<typeof import("openclaw/plugin-sdk/provider-http")>()
+  ).postTranscriptionRequest,
   providerOperationRetryConfig: (_stage: string) => true,
   readProviderJsonResponse: providerHttpMocks.readProviderJsonResponseMock,
+  readProviderJsonObjectResponse: (
+    await importActual<typeof import("openclaw/plugin-sdk/provider-http")>()
+  ).readProviderJsonObjectResponse,
+  requireTranscriptionText: (
+    await importActual<typeof import("openclaw/plugin-sdk/provider-http")>()
+  ).requireTranscriptionText,
   resolveProviderOperationTimeoutMs: ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
     defaultTimeoutMs,
   resolveProviderHttpRequestConfig: providerHttpMocks.resolveProviderHttpRequestConfigMock,
+  resolveProviderHttpRequestConfigWithOriginTrust: (
+    await importActual<typeof import("openclaw/plugin-sdk/provider-http")>()
+  ).resolveProviderHttpRequestConfigWithOriginTrust,
+  openProviderWebSocket: (await importActual<typeof import("openclaw/plugin-sdk/provider-http")>())
+    .openProviderWebSocket,
   resolveProviderRequestHeaders: providerHttpMocks.resolveProviderRequestHeadersMock,
   [providerHttpMockKeys.sanitizeConfiguredModelProviderRequest]:
     providerHttpMocks.sanitizeConfiguredModelProviderRequestMock,


### PR DESCRIPTION
Closes #129452

## What Problem This Solves

Deepgram Flux models only accept the `/v2/listen` WebSocket protocol. OpenClaw sent every voice note to the prerecorded `/v1/listen` HTTP endpoint, so `flux-general-en` and `flux-general-multi` failed on every transcription.

## Root cause

The Deepgram audio owner had one HTTP-only transport path. The earlier PR added a raw plugin-local WebSocket, but that path bypassed the existing provider request contract for auth, headers, proxy, TLS, and private-network blocking.

## Fix

- Resolve the provider request contract before choosing HTTP or Flux.
- Add one guarded Plugin SDK WebSocket connector with DNS pinning, private-network policy, proxy routing, TLS overrides, deadlines, abort handling, and bounded messages.
- Keep Flux URL, query, event, and transcript rules in the Deepgram plugin.
- Decode input through the trusted bounded `ffmpeg` process path.
- Stream documented 80 ms linear16 frames and bound decoded audio plus retained transcript bytes.
- Reject malformed JSON values inside the transcription promise.

Voice Call streaming transcription remains unchanged. It uses a separate operator-owned streaming config and does not consume `tools.media` request overrides.

`https-proxy-agent@7.0.6` is promoted from an existing transitive package to a direct core dependency because the shared connector owns explicit proxy tunnels. The dependency report shows 0 added, 0 removed, and 0 changed resolved packages. The exact artifact is MIT-licensed, registry-signed, integrity-pinned, and has no OSV advisory. A final-effect test proves the pinned DNS lookup reaches a hostname-based proxy connection.

## Evidence

Same stored Deepgram key, public `Bueller-Life-moves-pretty-fast.wav` sample, model `flux-general-multi`, and existing `extensions/deepgram/audio.live.test.ts` path:

- `origin/main` `267b0799b63c178e5be80122bb33d711f79e57e9`: failed in 2.6 s with HTTP 400 `V2_MODEL_ON_V1_LISTEN_ENDPOINT`.
- PR head `bc3b021ad0057677175ee070c8c85da7cefd0939`: passed in 16.5 s and matched `life moves pretty fast`.
- Control on the PR head with `nova-3`: passed in 3.2 s.

The key came from `bws_get_secret OPENCLAW_DEEPGRAM_API_KEY`. No credential was printed or stored.

## Validation

- Full extension-media Vitest: 335 passed.
- Guarded WebSocket and lint-suppression Vitest: 9 passed.
- `pnpm deadcode:full`: passed.
- Dependency pins, import cycles, Plugin SDK exports/surface, Oxlint, Oxfmt, and `git diff --check`: passed.
- Local typecheck/build skipped by repository host policy; CI owns type checking.

## Change size

- Production and dependency declarations: +544 net lines.
- Tests and test support: +394 net lines.
- Docs: +18 net lines.
- Lockfile: +3 lines, with no new resolved package.

Distillation removed 39 changed lines from the previous repair head without removing live, proxy, TLS, private-network, abort, or bounds proof. The remaining growth adds the missing Flux protocol and its reusable network security boundary.

🤖 AI-assisted repair. The endpoint contract and final behavior were verified against the real Deepgram service.
