### PR TITLE
feat(ui): stack the docked progress card under the suggestion tray

### DIFF
--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -112,14 +112,15 @@ suite.define(() => {
             const composerBounds = await visiblePane
               .locator(".agent-chat__composer-shell")
               .boundingBox();
-            if (!dockBounds || !composerBounds) {
+            const threadBounds = await visiblePane.locator(".chat-thread").boundingBox();
+            if (!dockBounds || !composerBounds || !threadBounds) {
               return false;
             }
+            // Clear of the centered composer, and anchored to the top of the
+            // conversation rather than floating above the composer.
             return (
               dockBounds.x >= composerBounds.x + composerBounds.width &&
-              Math.abs(
-                dockBounds.y + dockBounds.height - (composerBounds.y + composerBounds.height),
-              ) <= 1
+              dockBounds.y < threadBounds.y + threadBounds.height / 2
             );
           })
           .toBe(true);
@@ -162,6 +163,80 @@ suite.define(() => {
           .poll(() => visiblePane.locator('[data-progress-card-placement="composer"]').isVisible())
           .toBe(true);
         await captureProof(page, "composer-adjacent.png");
+      },
+    );
+  });
+
+  it("stacks the docked card under a suggestion tray instead of letting it be covered", async () => {
+    const sessionKey = "agent:main:progress-stacked";
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1600 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "progressCard.get",
+            "taskSuggestions.list",
+            "taskSuggestions.accept",
+            "taskSuggestions.dismiss",
+          ],
+          methodResponses: {
+            "progressCard.get": {
+              card: {
+                revision: 1,
+                sessionKey,
+                steps: [
+                  { step: "Inspect", status: "completed" },
+                  { step: "Implement", status: "in_progress" },
+                ],
+                updatedAt: 1,
+              },
+            },
+            "taskSuggestions.list": {
+              suggestions: [
+                {
+                  id: "task_stacked",
+                  title: "Follow-up worth keeping",
+                  prompt: "Inspect the related implementation and tests.",
+                  tldr: "This tray must not cover the progress card.",
+                  cwd: "/projects/example",
+                  sessionKey: "main",
+                  agentId: "main",
+                  createdAt: 1,
+                },
+              ],
+            },
+            "sessions.list": chatSessionListResponse([
+              { key: sessionKey, kind: "direct", label: "Stacked progress", updatedAt: 1 },
+            ]),
+          },
+          sessionKey,
+        });
+
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+        const visiblePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible");
+        const tray = visiblePane.locator(".task-suggestions");
+        const dock = visiblePane.locator('[data-progress-card-placement="dock"]');
+        await tray.waitFor({ state: "visible", timeout: 10_000 });
+        await expect.poll(() => dock.count()).toBe(1);
+        await expect
+          .poll(async () => {
+            const trayBounds = await tray.boundingBox();
+            const dockBounds = await dock.boundingBox();
+            if (!trayBounds || !dockBounds) {
+              return false;
+            }
+            // The card sits fully below the tray, not underneath it.
+            return dockBounds.y >= trayBounds.y + trayBounds.height;
+          })
+          .toBe(true);
+        await captureProof(page, "stacked-under-tray.png");
       },
     );
   });

--- a/ui/src/pages/chat/chat-pane-rails.ts
+++ b/ui/src/pages/chat/chat-pane-rails.ts
@@ -16,9 +16,9 @@ type ChatPaneGatewaySnapshot = Parameters<typeof isDesktopPanelAvailable>[0];
 
 export type ChatProgressCardPlacement = "composer" | "dock" | "rail";
 
-/* Narrowest gutter that still holds a readable card: the dock keeps a 12px gap
- * from the composer and clears the transcript scrollbar strip on the far side,
- * so this leaves it ~250px of its own. */
+/* Narrowest gutter that still clears the composer: the dock is a fixed
+ * --chat-progress-dock-width (250px) inside .chat-gutter-stack, which holds it
+ * 14px off the pane edge and a --space-3 gap clear of the composer. */
 const PROGRESS_CARD_DOCK_MIN_GUTTER_PX = 280;
 
 /** Picks the single live progress-card placement for one chat pane. */

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -479,6 +479,18 @@ export function renderChat(props: ChatProps) {
     onRemoveAttachment: props.onRemoveAttachment,
     onOpenImage: openImmediateImage,
   });
+  const taskSuggestionTray = renderChatTaskSuggestionTray(props);
+  const dockedProgressCard =
+    props.progressCard?.placement === "dock"
+      ? renderSessionProgressCard(props.progressCard.card, "dock", props.onDismissProgressCard)
+      : nothing;
+  // One column owns the conversation's top-right gutter. Both members float over
+  // the transcript, so sharing a stack is what stops the wider suggestion tray
+  // from silently covering the progress card when they appear together.
+  const gutterStack =
+    taskSuggestionTray === nothing && dockedProgressCard === nothing
+      ? nothing
+      : html`<div class="chat-gutter-stack">${taskSuggestionTray}${dockedProgressCard}</div>`;
   const scrollToBottomButton =
     props.showNewMessages && props.onScrollToBottom
       ? html`
@@ -577,7 +589,7 @@ export function renderChat(props: ChatProps) {
                         })}
                       </div>`
                     : nothing}
-                  ${renderChatTaskSuggestionTray(props)}
+                  ${gutterStack}
                   ${renderChatPullRequests({
                     pullRequests: props.pullRequests ?? [],
                     branch: props.pullRequestsBranch,
@@ -605,13 +617,6 @@ export function renderChat(props: ChatProps) {
                     sessions: props.swarmSessions ?? [],
                     sessionKey: props.sessionKey,
                   })}
-                  ${props.progressCard?.placement === "dock"
-                    ? renderSessionProgressCard(
-                        props.progressCard.card,
-                        "dock",
-                        props.onDismissProgressCard,
-                      )
-                    : nothing}
                   ${showModelSetupSplash ? nothing : chatColumnFooter}
                 </div>
               </div>

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -18,6 +18,10 @@ openclaw-chat-page {
      both, so the two never overlap and their bottoms stay on one line. */
   --chat-composer-side-inset: 36px;
   --chat-composer-bottom-gap: 14px;
+  /* Docked progress-card width. Kept in step with PROGRESS_CARD_DOCK_MIN_GUTTER_PX
+     in chat-pane-rails.ts, which gates the placement on a gutter wide enough for
+     this card plus the gutter stack's insets. */
+  --chat-progress-dock-width: 250px;
   --chat-thread-side-inset: clamp(6px, 1vw, 12px);
 
   position: relative;
@@ -1697,8 +1701,29 @@ button.chat-reply-preview--message:disabled {
   margin: 8px auto var(--chat-composer-bottom-gap, 14px);
 }
 
-/* Floating tray pinned to the conversation's top-right (the positioned
-   ancestor is .chat-main__conversation); content scrolls underneath it. */
+/* The conversation's top-right gutter, owned by one column so its members
+   stack instead of overlapping (the positioned ancestor is
+   .chat-main__conversation); content scrolls underneath it. The column is as
+   wide as its widest member — the suggestion tray, which deliberately overhangs
+   the transcript — and narrower members right-align inside it. */
+.chat-gutter-stack {
+  position: absolute;
+  z-index: 24;
+  top: 10px;
+  right: 14px;
+  display: grid;
+  width: min(450px, calc(100% - 28px));
+  justify-items: end;
+  gap: var(--space-3);
+  /* The column spans the tray's width even when only a narrow member renders,
+     so it must not swallow clicks aimed at the transcript beneath it. */
+  pointer-events: none;
+}
+
+.chat-gutter-stack > * {
+  pointer-events: auto;
+}
+
 .task-suggestions {
   --task-suggestion-card-bg: color-mix(in srgb, var(--panel-strong) 72%, var(--panel-hover) 28%);
   --task-suggestion-path-bg: color-mix(in srgb, var(--panel-hover) 84%, var(--text) 16%);
@@ -1706,12 +1731,11 @@ button.chat-reply-preview--message:disabled {
   --task-suggestion-action-bg: color-mix(in srgb, var(--accent) 82%, var(--panel) 18%);
   --task-suggestion-action-fg: var(--primary-foreground);
 
-  position: absolute;
-  z-index: 24;
-  top: 10px;
-  right: 14px;
+  /* Relative, not static: the --stack variant's offset shadow is positioned
+     against this box. Geometry otherwise comes from .chat-gutter-stack. */
+  position: relative;
   display: grid;
-  width: min(450px, calc(100% - 28px));
+  width: 100%;
   overflow: visible;
   overscroll-behavior: contain;
 }

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -400,25 +400,16 @@
   animation: fade-in 0.2s var(--ease-out);
 }
 
-/* Docked in the conversation's right gutter, beside the centered composer.
-   The inline-start edge repeats the composer's own half-width formula
-   (.agent-chat__composer-shell, capped at the transcript width) so the two
-   never overlap at any transcript-width setting; the pane only renders this
-   placement once the measured gutter can hold the card. */
+/* Docked in the conversation's right gutter, below any suggestion tray sharing
+   .chat-gutter-stack. The width is fixed rather than derived from the gutter:
+   the pane only renders this placement once it has measured a gutter wide
+   enough for this card plus the stack's insets, so the clearance is already
+   guaranteed and a stable card beats one that grows with the window.
+   Top-anchored by the stack, so appended steps extend downward instead of
+   shifting the rows already being read. */
 .session-progress-card--dock {
-  position: absolute;
-  z-index: 3;
-  inset-block-end: var(--chat-composer-bottom-gap, 14px);
-  inset-inline-end: var(--chat-thread-gutter);
-  inset-inline-start: calc(
-    50% +
-      min(
-        50% - var(--chat-composer-side-inset, 36px) / 2,
-        var(--chat-thread-max-width, 48rem) / 2
-      ) +
-      var(--space-3)
-  );
-  max-height: min(46%, 420px);
+  width: var(--chat-progress-dock-width);
+  max-height: min(50vh, 420px);
   overflow-y: auto;
   padding: 10px 12px;
   border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--border));


### PR DESCRIPTION
Follow-up to #129141.

## What Problem This Solves

Two things share the conversation's top-right area and neither knew about the other. The suggested-task tray is `450px` at `z-index: 24`; the progress card docked in #129141 sat at `z-index: 3`. Whenever a suggestion arrived while a plan was live, the tray covered the card outright — session state vanishing with no trace, which is the worst failure class in this repo.

Separately, the card was pinned to the composer's bottom edge, so it grew *upward*: every appended step or longer note shifted the rows you were already reading, and the empty gutter sat above the card, making it read as having sunk to the floor of an empty column.

## Why This Change Was Made

The gutter gets a single owner. `.chat-gutter-stack` is one absolutely positioned column at top-right; the tray and the card are its children, so they cannot overlap by construction rather than by luck. The tray keeps its exact geometry — same inset, same `min(450px, …)` width, and `position: relative` purely so its stacked-card shadow still anchors to itself. The card right-aligns beneath it.

The card is now top-anchored, so new steps extend downward and the whitespace falls below it. Its width becomes a token (`--chat-progress-dock-width: 250px`) instead of gutter-derived `calc()` arithmetic: the pane already gates this placement on a measured gutter wide enough to hold the card plus the stack's insets, so the clearance is guaranteed and a stable card beats one that grows with the window. That deletes the trickiest expression in the previous change.

Non-goals: the composer-bar and companion-rail placements are untouched, and no new setting is introduced.

## User Impact

A live progress card can no longer be hidden by a task suggestion — they stack. The card reads as session status at the top of the gutter instead of an appendage floating above the composer, and its checklist no longer jumps as steps land.

## Evidence

Screenshots below: the two together (tray above, card beneath, nothing covered), plus the before/after of the anchor change that motivated it.

- New placement case in `ui/src/e2e/session-progress-live-placement.e2e.test.ts` asserts the card's top edge is at or below the tray's bottom edge when both render — the regression test for the occlusion. The existing dock case now asserts top-anchoring instead of composer-bottom alignment. 4/4 passing.
- `ui/src/e2e/chat-flow.task-suggestions.e2e.test.ts` passes unchanged (5/5), which is what proves the tray's own geometry survived becoming a flow item.
- `chat-responsive.browser.test.ts` + `chat-view` + `chat-task-suggestions` unit suites: 369/369.
- `node scripts/check-changed.mjs`, `tsgo:ui`, oxlint, stylelint clean.
- Codex autoreview (`gpt-5.6-sol`, high, single pass): no accepted or actionable findings.

Production LOC: +56/-36 (net +20) | Tests: +79/-4. The production growth is the stack rule and its pointer-events guard; the card's own CSS got smaller by dropping the `calc()` inset math.

![pr2-stacked](https://github.com/user-attachments/assets/b0b815cd-d5d6-47f0-a893-8263cc012bad)

![pr2-before-bottom](https://github.com/user-attachments/assets/81e80cf6-774f-4196-81a1-89ed36eda05d)

![pr2-after-top](https://github.com/user-attachments/assets/917bc4a1-da06-4ef3-8dae-2880996578f6)