### PR TITLE
fix(parallels): macOS dev upgrade needlessly rebuilds the checkout

### DIFF
--- a/scripts/e2e/parallels/macos-smoke.ts
+++ b/scripts/e2e/parallels/macos-smoke.ts
@@ -273,7 +273,7 @@ class MacosSmoke {
       );
       say(`Run logs: ${this.runDir}`);
 
-      if (await this.needsHostTgz()) {
+      if (this.needsHostTgz()) {
         this.artifact = await packOpenClaw({
           destination: this.tgzDir,
           packageSpec: this.options.targetPackageSpec,
@@ -384,11 +384,10 @@ class MacosSmoke {
     return Boolean(spec && !/^(https?:|file:|\/|\.\/|\.\.\/|.*\.tgz$)/.test(spec));
   }
 
-  private async needsHostTgz(): Promise<boolean> {
-    if (!this.options.targetPackageSpec) {
-      return true;
-    }
-    return !this.targetInstallsDirectly();
+  private needsHostTgz(): boolean {
+    return this.options.targetPackageSpec
+      ? !this.targetInstallsDirectly()
+      : this.options.mode !== "upgrade";
   }
 
   private artifactLabel(): string {

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -651,7 +651,7 @@ export function resolveVitestSpawnParams(
   platform: NodeJS.Platform = process.platform,
 ): PnpmRunnerParams {
   return {
-    env: resolveVitestProcessEnv(env),
+    env: resolveVitestProcessEnv(resolveVitestCompileCacheSafeEnv(env)),
     detached: shouldUseDetachedVitestProcessGroup(platform),
     stdio: ["inherit", "pipe", "pipe"],
   };

--- a/src/node-host/node-worker-bundle-installer.test.ts
+++ b/src/node-host/node-worker-bundle-installer.test.ts
@@ -39,6 +39,7 @@ describe("node worker bundle installer", () => {
       workerSource?: string;
       fixtureName?: string;
       bundlePrewarm?: 1;
+      compileCacheDisabled?: boolean;
     } = {},
   ): Promise<{
     archive: Buffer;
@@ -48,10 +49,12 @@ describe("node worker bundle installer", () => {
     const source = path.join(root, `source-${fixtureName}`);
     const archivePath = path.join(root, `bundle-${fixtureName}.tgz`);
     await fs.mkdir(source, { recursive: true });
+    const compileCacheDisabled =
+      options.compileCacheDisabled ?? process.env.NODE_DISABLE_COMPILE_CACHE !== undefined;
     const workerSource =
       options.workerSource ??
       (options.prewarmMarker
-        ? `import fs from "node:fs";\nif (process.argv[2] !== "--internal-worker-prewarm" || !process.env.NODE_COMPILE_CACHE || process.env.NODE_DISABLE_COMPILE_CACHE) throw new Error("worker bundle was not prewarmed with compile cache");\nfs.writeFileSync(${JSON.stringify(options.prewarmMarker)}, "ready");\n`
+        ? `import fs from "node:fs";\nconst cacheDisabled = process.env.NODE_DISABLE_COMPILE_CACHE === "1";\nif (process.argv[2] !== "--internal-worker-prewarm" || cacheDisabled !== ${compileCacheDisabled} || (cacheDisabled ? process.env.NODE_COMPILE_CACHE : !process.env.NODE_COMPILE_CACHE)) throw new Error("worker bundle was not prewarmed with the requested compile-cache mode");\nfs.writeFileSync(${JSON.stringify(options.prewarmMarker)}, "ready");\n`
         : "export {};\n");
     await fs.writeFile(path.join(source, "worker.mjs"), workerSource, { mode: 0o700 });
     const archiveEntries = ["worker.mjs"];
@@ -115,7 +118,11 @@ describe("node worker bundle installer", () => {
 
   it("atomically installs, reuses, and cleans prior-hash crash staging", async () => {
     const prewarmMarker = path.join(root, "worker-prewarmed");
-    const fixture = await bundleFixture({ prewarmMarker, bundlePrewarm: 1 });
+    const fixture = await bundleFixture({
+      prewarmMarker,
+      bundlePrewarm: 1,
+      compileCacheDisabled: false,
+    });
     const staleBundleHash = "f".repeat(64);
     const staleStaging = path.join(
       root,
@@ -125,7 +132,10 @@ describe("node worker bundle installer", () => {
     );
     await fs.mkdir(staleStaging, { recursive: true });
     const served = await serve(fixture.archive, fixture.input.archive.token);
-    const installer = new NodeWorkerBundleInstaller({ root });
+    const installer = new NodeWorkerBundleInstaller({
+      root,
+      env: { ...process.env, NODE_DISABLE_COMPILE_CACHE: undefined },
+    });
 
     await expect(
       installer.ensure({ input: fixture.input, gatewayUrl: served.gatewayUrl }),
@@ -149,6 +159,25 @@ describe("node worker bundle installer", () => {
         "utf8",
       ),
     ).resolves.toContain(fixture.input.build.bundleHash);
+  });
+
+  it("prewarms bundles while honoring an explicitly disabled compile cache", async () => {
+    const prewarmMarker = path.join(root, "worker-prewarmed-without-cache");
+    const fixture = await bundleFixture({
+      prewarmMarker,
+      bundlePrewarm: 1,
+      compileCacheDisabled: true,
+    });
+    const served = await serve(fixture.archive, fixture.input.archive.token);
+    const installer = new NodeWorkerBundleInstaller({
+      root,
+      env: { ...process.env, NODE_COMPILE_CACHE: undefined, NODE_DISABLE_COMPILE_CACHE: "1" },
+    });
+
+    await expect(
+      installer.ensure({ input: fixture.input, gatewayUrl: served.gatewayUrl }),
+    ).resolves.toEqual(fixture.input.build);
+    await expect(fs.readFile(prewarmMarker, "utf8")).resolves.toBe("ready");
   });
 
   it("reuses a v1 install when Windows cannot retain Unix artifact modes", async () => {

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -622,6 +622,65 @@ describe("Parallels smoke model selection", () => {
     ).toBe(false);
   });
 
+  it("starts the default macOS upgrade without building or packaging the host checkout", () => {
+    const tempDir = makeTempDir(tempDirs, "openclaw-macos-upgrade-no-pack-");
+    writeNodeFakePrlctl(
+      tempDir,
+      `if (args.includes("list")) {
+         console.log(JSON.stringify([{ name: "macOS Tahoe", status: "running" }]));
+         process.exit(0);
+       }
+       if (args.includes("exec") && args.includes("whoami")) {
+         console.log("runner");
+         process.exit(0);
+       }
+       process.stderr.write("FAKE_GUEST_COMMAND_BOUNDARY\\n");
+       process.exit(73);`,
+    );
+    const fakePnpm = join(tempDir, "pnpm");
+    writeFileSync(
+      fakePnpm,
+      '#!/usr/bin/env node\nprocess.stderr.write("UNEXPECTED_HOST_PACKAGE_BUILD\\n"); process.exit(86);\n',
+    );
+    chmodSync(fakePnpm, 0o755);
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        TS_PATHS.macos,
+        "--mode",
+        "upgrade",
+        "--host-ip",
+        "127.0.0.1",
+        "--latest-version",
+        "2026.8.25",
+        "--api-key-env",
+        "OPENCLAW_PARALLELS_TEST_API_KEY",
+        "--json",
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ...fakePrlctlEnv(tempDir),
+          OPENCLAW_PARALLELS_ARTIFACT_ROOT: join(tempDir, "artifacts"),
+          OPENCLAW_PARALLELS_SKIP_SNAPSHOT_RESTORE: "1",
+          OPENCLAW_PARALLELS_TEST_API_KEY: "fixture-not-a-real-credential",
+          TMPDIR: tempDir,
+          npm_execpath: fakePnpm,
+        },
+      },
+    );
+
+    expect(result.stderr).toContain("upgrade.restore-snapshot");
+    expect(result.stderr).toContain("upgrade.reset-state");
+    expect(result.stderr).toContain("FAKE_GUEST_COMMAND_BOUNDARY");
+    expect(result.stderr).not.toContain("UNEXPECTED_HOST_PACKAGE_BUILD");
+  });
+
   it("rejects short flags as Parallels smoke option values", () => {
     const cases = [
       [parseLinuxSmokeArgs, "--mode", "-h"],

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -688,6 +688,17 @@ describe("scripts/run-vitest", () => {
         "--coverage=false",
       ]),
     ).toMatchObject({ NODE_DISABLE_COMPILE_CACHE: "1" });
+    expect(
+      resolveVitestSpawnParams(
+        {
+          CI: "true",
+          NODE_COMPILE_CACHE: "/tmp/node-compile",
+          NODE_COMPILE_CACHE_PORTABLE: "1",
+          PATH: "/usr/bin",
+        },
+        "linux",
+      ).env,
+    ).toEqual({ CI: "true", NODE_DISABLE_COMPILE_CACHE: "1", PATH: "/usr/bin" });
   });
 
   it("uses a longer default stall watchdog for broad e2e and project shard configs", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running the default macOS release-to-development upgrade smoke would unnecessarily rebuild the checkout, build the Control UI, package OpenClaw, and start an artifact server before the guest upgrade even begins.

## Why This Change Was Made

The macOS packaging-decision owner ignored the requested smoke mode whenever no explicit target package was configured. Match the existing Windows sibling: the default upgrade installs the published baseline and runs the guest updater directly, while fresh/combined runs and explicit tarball targets retain their existing packaging behavior. Direct registry targets still install without a host tarball.

While investigating an unrelated recurring hosted test failure, bounded CI-runner QA also found that packed test-project runs bypassed the existing rule that every Vitest child must disable inherited Node bytecode caches. Apply the existing sanitizer at the shared child-spawn boundary, preserving caches for orchestration and builds. Correct the existing worker-prewarm test fixture to cover both explicitly enabled and explicitly disabled cache modes without changing the production worker environment or operator opt-out contract. The runner invariant violation is independently reproduced; its causal relationship to the unrelated Gateway test failure is not established.

Production tooling: net -1 line across both repairs. Regression tests: +99 lines.

## User Impact

The standard macOS release-to-development smoke starts its guest upgrade directly, avoiding needless host builds, generated-artifact churn, packaging locks, and HTTP-server startup. Fresh-install coverage, explicit package targets, snapshots, guest behavior, and credentials are unchanged. Packed Vitest children now receive the same safe environment as directly launched Vitest children.

## Evidence

An executable regression runs the real macOS smoke CLI with an isolated fake Parallels command, a clearly synthetic provider value, and a failing fake package manager; it never touches a real guest or builds an artifact.

Before the fix, the real CLI fails before the guest lane:

```text
==> Build dist for current head
UNEXPECTED_HOST_PACKAGE_BUILD
error: command failed (86): pnpm build
```

Afterward it reaches the fake guest restore/reset boundary without starting any host build. The child-spawn regression also failed before its repair because packed Vitest inherited `NODE_COMPILE_CACHE` and `NODE_COMPILE_CACHE_PORTABLE` instead of setting `NODE_DISABLE_COMPILE_CACHE=1`.

```text
NODE_COMPILE_CACHE=/tmp/synthetic-cache node scripts/run-vitest.mjs src/node-host/node-worker-bundle-installer.test.ts test/scripts/run-vitest.test.ts test/scripts/test-projects.test.ts test/scripts/ci-run-node-test-shard.test.ts test/scripts/parallels-smoke-model.test.ts test/scripts/plugin-sdk-surface-report.test.ts
Test Files  6 passed (6)
Tests       517 passed (517)
```

The actual packaging owner was additionally exercised against default upgrade, fresh, combined, explicit tarball, and direct-registry targets. The worker fixture regression first reproduced the exact hosted two-test failure and now independently exercises real worker prewarming with caching enabled and explicitly disabled. A trusted Linux run of the original packed CLI-plus-Gateway CI sequence passed 3,779 tests, demonstrating that the recurring Gateway failure was not reproduced by operating system, project order, or fresh caches alone. Focused formatting, direct script lint, independent owner/sibling review, and structured Codex review all pass.
