### PR TITLE
fix(macos): confirm closing onboarding during API key verification

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -22,18 +22,7 @@ final class OnboardingAISetupModel {
     static let providerAuthRequestTimeoutMs: Double = 1_200_000
 
     private(set) var phase: Phase = .idle {
-        didSet {
-            // Close-guard: quitting mid-test is confirmable, not silent.
-            OnboardingController.shared.busyReason = if self.phase == .testing {
-                "OpenClaw is testing your AI connection."
-            } else if self.activeAuthOption != nil {
-                self.isPreparingModel
-                    ? "OpenClaw is preparing a local model."
-                    : "OpenClaw is completing provider sign-in."
-            } else {
-                nil
-            }
-        }
+        didSet { self.updateBusyReason() }
     }
 
     private(set) var candidates: [Candidate] = []
@@ -49,15 +38,7 @@ final class OnboardingAISetupModel {
     private(set) var authStep: WizardStep?
     private(set) var authError: Failure?
     private(set) var authBusy = false {
-        didSet {
-            if self.activeAuthOption != nil {
-                OnboardingController.shared.busyReason = self.isPreparingModel
-                    ? "OpenClaw is preparing a local model."
-                    : "OpenClaw is completing provider sign-in."
-            } else if self.phase != .testing {
-                OnboardingController.shared.busyReason = nil
-            }
-        }
+        didSet { self.updateBusyReason() }
     }
 
     var authText = ""
@@ -76,7 +57,10 @@ final class OnboardingAISetupModel {
 
     var manualProviderID = ""
     var manualKey: String = ""
-    private(set) var manualTesting = false
+    private(set) var manualTesting = false {
+        didSet { self.updateBusyReason() }
+    }
+
     private(set) var manualError: Failure?
     var showManualEntry = false
 
@@ -117,6 +101,19 @@ final class OnboardingAISetupModel {
         self.defaults = defaults
         self.routeIdentityProvider = routeIdentityProvider
         self.connectionModeProvider = connectionModeProvider
+    }
+
+    private func updateBusyReason() {
+        // Every connection attempt must make quitting mid-setup confirmable.
+        OnboardingController.shared.busyReason = if self.phase == .testing || self.manualTesting {
+            "OpenClaw is testing your AI connection."
+        } else if self.activeAuthOption != nil {
+            self.isPreparingModel
+                ? "OpenClaw is preparing a local model."
+                : "OpenClaw is completing provider sign-in."
+        } else {
+            nil
+        }
     }
 
     func startIfNeeded() {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -3234,7 +3234,10 @@ struct OnboardingAISetupTests {
         model.manualKey = "old-route-secret"
 
         model.submitManualKey()
+        #expect(model.manualTesting)
+        #expect(OnboardingController.shared.busyReason == "OpenClaw is testing your AI connection.")
         model.resetForGatewayChange()
+        #expect(OnboardingController.shared.busyReason == nil)
         config.setToken("route-b-token")
         routeIdentity.set("remote:id:gateway-b")
         await settleQueuedAISetupTasks()


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users connecting OpenClaw with an API key during macOS onboarding could accidentally close the setup window while their connection was still being verified, without the confirmation already shown for detected accounts and provider sign-in.

## Why This Change Was Made

All in-flight AI connection modes now update the same existing onboarding close-confirmation state. This removes duplicated lifecycle logic while preserving candidate testing, provider sign-in, local-model preparation, Gateway switching, and existing credential/configuration behavior.

## User Impact

Closing onboarding during manual API-key verification now shows the existing “Setup is still working” confirmation instead of silently abandoning setup. The warning disappears normally when verification finishes or the Gateway changes.

## Evidence

- Authentic pre-fix regression in the existing real Gateway-switch onboarding test: `OnboardingController.shared.busyReason` was `nil` immediately after manual verification started.
- After the owner-boundary fix, all 94 native AI-onboarding tests pass: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path apps/macos --filter OpenClawIPCTests.OnboardingAISetupTests --no-parallel -j 4`.
- Changed production source passes SwiftFormat and strict SwiftLint; production delta is 19 additions and 22 deletions.
- Independent review and structured Codex autoreview both reported no actionable findings.
- Native before/after screenshots are unavailable because the pristine macOS guest currently has no logged-in graphical console, installed runtime, or signed interactive OpenClaw app; the real native window-delegate owner and complete compiled Swift onboarding suite provide the available evidence.

AI-assisted.
