### PR TITLE
fix(imessage): prevent ordinary quoted messages from disappearing

### DIFF
--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -441,6 +441,26 @@ describe("resolveIMessageInboundDecision echo detection", () => {
     expect(decision.contextKey).toContain("imessage:reaction:added");
   });
 
+  it.each([
+    { text: "Loved “Dune” and the soundtrack was incredible" },
+    { text: 'Liked "your plan" but Wednesday works better' },
+    { text: "Removed a heart from “the old post” yesterday", mode: "off" as const },
+    { text: 'Removed a like from "that post" yesterday', mode: "all" as const },
+    { text: 'Loved “Dune"', mode: "own" as const },
+  ])(
+    "dispatches ordinary quoted prose instead of dropping it as a tapback: $text",
+    async ({ text, mode }) => {
+      const decision = await resolveDecision({
+        message: { text },
+        messageText: text,
+        bodyText: text,
+        ...(mode ? { reactionNotifications: mode } : {}),
+      });
+
+      expect(decision.kind).toBe("dispatch");
+    },
+  );
+
   it("uses the iMessage reply cache to recognize tool-sent messages as bot-authored reaction targets", async () => {
     const decision = await resolveDecision({
       message: {
@@ -689,6 +709,40 @@ describe("resolveIMessageReactionContext", () => {
       targetText: "Hello",
     });
     expect(resolveIMessageReactionContext({}, "Loved the movie")).toBeNull();
+  });
+
+  it.each([
+    ["Loved", "added", "❤️"],
+    ["Liked", "added", "👍"],
+    ["Disliked", "added", "👎"],
+    ["Laughed at", "added", "😂"],
+    ["Emphasized", "added", "‼️"],
+    ["Questioned", "added", "❓"],
+    ["Removed a heart from", "removed", "❤️"],
+    ["Removed a like from", "removed", "👍"],
+    ["Removed a dislike from", "removed", "👎"],
+    ["Removed a laugh from", "removed", "😂"],
+    ["Removed an emphasis from", "removed", "‼️"],
+    ["Removed a question from", "removed", "❓"],
+  ])("preserves complete legacy %s tapback wrappers", (prefix, action, emoji) => {
+    for (const [open, close] of [
+      ['"', '"'],
+      ["“", "”"],
+    ]) {
+      expect(resolveIMessageReactionContext({}, `${prefix} ${open}Hello${close}`)).toStrictEqual({
+        action,
+        emoji,
+        targetText: "Hello",
+      });
+    }
+  });
+
+  it("preserves complete multiline and nested legacy tapback wrappers", () => {
+    expect(resolveIMessageReactionContext({}, "Loved “  she said “hello”\nand left  ”")).toEqual({
+      action: "added",
+      emoji: "❤️",
+      targetText: "she said “hello”\nand left",
+    });
   });
 
   it("detects imsg tapback flags and associated message types", async () => {

--- a/extensions/imessage/src/monitor/reaction-context.ts
+++ b/extensions/imessage/src/monitor/reaction-context.ts
@@ -61,16 +61,13 @@ function resolveTapbackTextContext(bodyText: string): IMessageReactionContext | 
       continue;
     }
     const afterPrefix = bodyText.slice(pattern.prefix.length).trim();
-    if (!/^["“]/u.test(afterPrefix)) {
+    if (!/^(?:"[\s\S]*"|“[\s\S]*”)$/u.test(afterPrefix)) {
       continue;
     }
     return {
       action: pattern.action,
       emoji: pattern.emoji,
-      targetText: afterPrefix
-        .replace(/^["“]/u, "")
-        .replace(/["”]$/u, "")
-        .trim(),
+      targetText: afterPrefix.slice(1, -1).trim(),
     };
   }
   return null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iMessage users sending ordinary messages such as `Loved “Dune” and the soundtrack was incredible` or `Removed a heart from “the old post” yesterday` would receive no response because their real messages were mistaken for tapback reactions.

## Why This Change Was Made

The iMessage-owned legacy tapback classifier accepted any supported reaction prefix followed by an opening quote, even when ordinary conversation continued after its quoted phrase. Require a complete, consistently paired ASCII or curly quoted envelope before identifying text-only legacy reactions; authoritative structured reactions remain unchanged. This removes three production lines while preserving all twelve shipped reaction forms, nested/multiline targets, reaction approvals, and question reactions.

## User Impact

Ordinary iMessage conversations containing quoted phrases are reliably delivered to the agent instead of silently disappearing or being rewritten as reaction notifications. Existing real iMessage reactions and legacy complete reaction messages continue working.

## Evidence

- Before: five real inbound-decision regression cases failed; ordinary quoted add/remove prose was dropped in the default and disabled reaction modes or misrouted as a reaction in all-notifications mode.
- After: `node scripts/run-vitest.mjs extensions/imessage/src/monitor/inbound-processing.test.ts` passes **51 tests**, including all five reproductions, every legacy add/remove phrase with ASCII and curly quotes, mismatched quotes, nested quotes, and multiline targets.
- Independent reviewer passed **94 tests** spanning inbound decisions, reaction approvals, approval authentication, approval polling, and question reactions; directly verified all 24 valid phrase/quote combinations, all 24 trailing-prose variants, each notification mode, and authoritative structured reaction GUIDs.
- Direct type-aware lint and formatting pass for both changed files; production delta is **-3 lines**. The configured authenticated pre-commit and exact-commit reviews both returned clean.
- Exact reviewed head: `43497272062f5780f2b5d0cfd06ceded4a9f581d`.
