### PR TITLE
fix(linux): Quick Chat ignores the configured Gateway accent

### DIFF
--- a/apps/linux/src-tauri/src/gateway_ws.rs
+++ b/apps/linux/src-tauri/src/gateway_ws.rs
@@ -431,6 +431,7 @@ struct GatewayClientInner {
     agents_cache: Mutex<Option<CachedAgents>>,
     identity: Mutex<Option<GatewayDeviceIdentityStore>>,
     canvas_surface: Mutex<CanvasSurfaceState>,
+    user_accent: Mutex<Option<String>>,
     connection_notice: Mutex<Option<String>>,
     connection_state: AtomicU64,
     reconnect_paused: AtomicBool,
@@ -453,6 +454,7 @@ impl GatewayClient {
                 agents_cache: Mutex::new(None),
                 identity: Mutex::new(None),
                 canvas_surface: Mutex::new(CanvasSurfaceState::default()),
+                user_accent: Mutex::new(None),
                 connection_notice: Mutex::new(None),
                 connection_state: AtomicU64::new(GatewayConnectionState::Down as u64),
                 reconnect_paused: AtomicBool::new(false),
@@ -540,7 +542,12 @@ impl GatewayClient {
         webview
             .emit(
                 GATEWAY_STATE_EVENT,
-                GatewayStateEvent::new(self.connection_state(), notice, self.canvas_surface_url()),
+                GatewayStateEvent::new(
+                    self.connection_state(),
+                    notice,
+                    self.canvas_surface_url(),
+                    self.user_accent(),
+                ),
             )
             .map_err(|error| format!("Could not report Gateway connectivity: {error}"))
     }
@@ -898,7 +905,15 @@ impl GatewayClient {
             inline_widgets_available,
         )
         .map_err(RequestFailure::transport)?;
-        let dispatch = |frame: &Value| dispatch_chat_event(app, frame);
+        let config_changed = AtomicBool::new(false);
+        let dispatch = |frame: &Value| {
+            dispatch_chat_event(app, frame);
+            if frame.get("type").and_then(Value::as_str) == Some("event")
+                && frame.get("event").and_then(Value::as_str) == Some("config.changed")
+            {
+                config_changed.store(true, Ordering::SeqCst);
+            }
+        };
         let hello =
             match request_on_socket(&mut socket, "connect", params, REQUEST_TIMEOUT, &dispatch)
                 .await
@@ -923,10 +938,12 @@ impl GatewayClient {
         );
 
         let agents = request_agents_list(&mut socket, REQUEST_TIMEOUT, &dispatch).await?;
+        let accent = request_gateway_accent(&mut socket, &dispatch).await?;
         if self.inner.config_generation.load(Ordering::SeqCst) != generation {
             return Ok(());
         }
         self.cache_agents(agents);
+        self.set_user_accent(generation, accent);
         self.set_connection_state(app, GatewayConnectionState::Up, None);
         let mut last_gateway_activity = Instant::now();
 
@@ -938,6 +955,16 @@ impl GatewayClient {
                 )
             {
                 return Ok(());
+            }
+            if config_changed.swap(false, Ordering::SeqCst) {
+                let accent = request_gateway_accent(&mut socket, &dispatch).await?;
+                if self.inner.config_generation.load(Ordering::SeqCst) != generation {
+                    return Ok(());
+                }
+                if self.set_user_accent(generation, accent) {
+                    self.emit_connection_state(app, GatewayConnectionState::Up, None);
+                }
+                last_gateway_activity = Instant::now();
             }
             tokio::select! {
                 command = receiver.recv() => {
@@ -966,7 +993,7 @@ impl GatewayClient {
                     }
                 }
                 incoming = socket.next() => {
-                    handle_idle_message(app, &mut socket, incoming).await?;
+                    handle_idle_message(&dispatch, &mut socket, incoming).await?;
                     last_gateway_activity = Instant::now();
                 }
                 _ = tokio::time::sleep(DRIVER_TICK) => {
@@ -1077,6 +1104,27 @@ impl GatewayClient {
         self.canvas_surface_state().url
     }
 
+    fn set_user_accent(&self, generation: u64, accent: Option<String>) -> bool {
+        let mut current = self
+            .inner
+            .user_accent
+            .lock()
+            .expect("gateway user accent mutex poisoned");
+        if self.inner.config_generation.load(Ordering::SeqCst) != generation || *current == accent {
+            return false;
+        }
+        *current = accent;
+        true
+    }
+
+    fn user_accent(&self) -> Option<String> {
+        self.inner
+            .user_accent
+            .lock()
+            .expect("gateway user accent mutex poisoned")
+            .clone()
+    }
+
     fn is_connected(&self) -> bool {
         self.connection_state() == GatewayConnectionState::Up
     }
@@ -1098,6 +1146,7 @@ impl GatewayClient {
                 .lock()
                 .expect("gateway agents cache mutex poisoned") = None;
             self.set_canvas_surface_url(self.inner.config_generation.load(Ordering::SeqCst), None);
+            self.set_user_accent(self.inner.config_generation.load(Ordering::SeqCst), None);
         }
         let notice_changed = {
             let mut current = self
@@ -1120,10 +1169,19 @@ impl GatewayClient {
         if !state_changed && !notice_changed {
             return;
         }
+        self.emit_connection_state(app, state, notice);
+    }
+
+    fn emit_connection_state(
+        &self,
+        app: &AppHandle,
+        state: GatewayConnectionState,
+        notice: Option<String>,
+    ) {
         let _ = app.emit_to(
             QUICKCHAT_LABEL,
             GATEWAY_STATE_EVENT,
-            GatewayStateEvent::new(state, notice, self.canvas_surface_url()),
+            GatewayStateEvent::new(state, notice, self.canvas_surface_url(), self.user_accent()),
         );
     }
 }
@@ -1136,6 +1194,8 @@ struct GatewayStateEvent {
     notice: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     canvas_surface_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    accent: Option<String>,
 }
 
 impl GatewayStateEvent {
@@ -1143,11 +1203,13 @@ impl GatewayStateEvent {
         state: GatewayConnectionState,
         notice: Option<String>,
         canvas_surface_url: Option<String>,
+        accent: Option<String>,
     ) -> Self {
         Self {
             state: state.event_name(),
             notice,
             canvas_surface_url,
+            accent,
         }
     }
 }
@@ -1507,6 +1569,34 @@ where
     })
 }
 
+async fn request_gateway_accent<F>(
+    socket: &mut GatewaySocket,
+    dispatch: &F,
+) -> Result<Option<String>, RequestFailure>
+where
+    F: Fn(&Value),
+{
+    let config =
+        request_on_socket(socket, "config.get", json!({}), REQUEST_TIMEOUT, dispatch).await?;
+    Ok(gateway_user_accent(&config))
+}
+
+fn gateway_user_accent(config: &Value) -> Option<String> {
+    [
+        config.pointer("/config/ui/prefs/accent"),
+        config.pointer("/config/ui/seamColor"),
+    ]
+    .into_iter()
+    .flatten()
+    .filter_map(Value::as_str)
+    .find(|value| {
+        value.len() == 7
+            && value.starts_with('#')
+            && value.as_bytes()[1..].iter().all(u8::is_ascii_hexdigit)
+    })
+    .map(str::to_ascii_lowercase)
+}
+
 struct ValidatedHello {
     device_token: Option<String>,
     tick_watch_timeout: Duration,
@@ -1695,11 +1785,14 @@ async fn next_json(socket: &mut GatewaySocket) -> Result<Value, RequestFailure> 
     }
 }
 
-async fn handle_idle_message(
-    app: &AppHandle,
+async fn handle_idle_message<F>(
+    dispatch: &F,
     socket: &mut GatewaySocket,
     incoming: Option<Result<Message, tokio_tungstenite::tungstenite::Error>>,
-) -> Result<(), RequestFailure> {
+) -> Result<(), RequestFailure>
+where
+    F: Fn(&Value),
+{
     let message = incoming
         .ok_or_else(|| RequestFailure::transport("Gateway connection closed."))?
         .map_err(|error| {
@@ -1708,7 +1801,7 @@ async fn handle_idle_message(
     match message {
         Message::Text(text) => {
             if let Ok(value) = serde_json::from_str::<Value>(text.as_ref()) {
-                dispatch_chat_event(app, &value);
+                dispatch(&value);
             }
             Ok(())
         }
@@ -2095,6 +2188,31 @@ mod tests {
     }
 
     #[test]
+    fn gateway_user_accent_prefers_valid_user_preferences() {
+        for (config, expected) in [
+            (
+                json!({ "config": { "ui": { "prefs": { "accent": "#ABC123" }, "seamColor": "#654321" } } }),
+                Some("#abc123"),
+            ),
+            (
+                json!({ "config": { "ui": { "prefs": { "accent": "invalid" }, "seamColor": "#654321" } } }),
+                Some("#654321"),
+            ),
+            (
+                json!({ "config": { "ui": { "prefs": { "accent": "abc123" }, "seamColor": "#12345" } } }),
+                None,
+            ),
+            (
+                json!({ "config": { "ui": { "prefs": { "accent": "#12345g" }, "seamColor": " #654321" } } }),
+                None,
+            ),
+            (json!({ "config": {} }), None),
+        ] {
+            assert_eq!(gateway_user_accent(&config).as_deref(), expected);
+        }
+    }
+
+    #[test]
     fn sleep_gateway_routes_are_loopback_only() {
         for route in [
             "ws://localhost:18789",
@@ -2158,6 +2276,7 @@ mod tests {
             GatewayConnectionState::Up,
             None,
             Some("https://gateway.example/__openclaw__/cap/fixture-capability".to_string()),
+            Some("#abc123".to_string()),
         ))
         .expect("serialize gateway state");
 
@@ -2165,6 +2284,7 @@ mod tests {
             event["canvasSurfaceUrl"],
             "https://gateway.example/__openclaw__/cap/fixture-capability"
         );
+        assert_eq!(event["accent"], "#abc123");
         assert!(event.get("canvas_surface_url").is_none());
     }
 

--- a/apps/linux/ui/quickchat.css
+++ b/apps/linux/ui/quickchat.css
@@ -125,7 +125,7 @@ body.shown .composer {
   outline: 0;
   color: #f7f7f8;
   font: 400 14px/1.4 inherit;
-  caret-color: #ff6b6b;
+  caret-color: var(--accent, #ff6b6b);
   background: transparent;
 }
 
@@ -145,7 +145,7 @@ body.shown .composer {
   border-radius: 50%;
   color: #1c1c1e;
   cursor: pointer;
-  background: #ff6b6b;
+  background: var(--accent, #ff6b6b);
   transition:
     opacity 120ms ease,
     transform 120ms ease;

--- a/apps/linux/ui/quickchat.js
+++ b/apps/linux/ui/quickchat.js
@@ -346,6 +346,11 @@ function setGatewayState(payload) {
   const wasUp = gatewayState === "up";
   gatewayState = payload?.state || "down";
   gatewayNotice = typeof payload?.notice === "string" ? payload.notice : "";
+  if (typeof payload?.accent === "string") {
+    document.documentElement.style.setProperty("--accent", payload.accent);
+  } else {
+    document.documentElement.style.removeProperty("--accent");
+  }
   const nextCanvasSurfaceUrl =
     gatewayState === "up" && typeof payload?.canvasSurfaceUrl === "string"
       ? payload.canvasSurfaceUrl

--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -138,6 +138,10 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
   prepareProviderRuntimeAuth: vi.fn(async () => undefined),
 }));
 
+vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: () => ({ plugins: [] }),
+}));
+
 vi.mock("../provider-secret-egress.js", () => ({
   protectPreparedProviderRuntimeAuth: (value: unknown) => value,
   unwrapSecretSentinelsForProviderEgress: (value: unknown) => value,

--- a/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
@@ -528,6 +528,8 @@ describe("dispatchReplyFromConfig", () => {
       }),
       cfg: emptyConfig,
       dispatcher: createDispatcher(),
+      fastAbortResolver: mocks.tryFastAbortFromMessage,
+      formatAbortReplyTextResolver: () => "⚙️ Agent was aborted.",
       replyOptions: { onModelSelected },
     });
 

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -3,6 +3,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ensureApiKeyFromEnvOrPrompt } from "../plugins/provider-auth-input.js";
 import { promptCustomApiConfig } from "./onboard-custom.js";
 
+vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: () => ({ plugins: [] }),
+}));
+
 vi.mock("../plugins/provider-auth-input.js", () => ({
   ensureApiKeyFromEnvOrPrompt: vi.fn(
     async (params: Parameters<typeof ensureApiKeyFromEnvOrPrompt>[0]) => {

--- a/test/linux-quickchat-stream.test.ts
+++ b/test/linux-quickchat-stream.test.ts
@@ -53,6 +53,7 @@ const { assembleChatDelta, chatMessageText, chatMessageWidgets, resolveInlineWid
 function createFakeElement(tagName = "div") {
   const classes = new Set();
   const children: any[] = [];
+  const styles = new Map<string, string>();
   return {
     tagName: tagName.toUpperCase(),
     children,
@@ -71,7 +72,17 @@ function createFakeElement(tagName = "div") {
         return enabled;
       },
     },
-    style: { setProperty() {} },
+    style: {
+      setProperty(name: string, value: string) {
+        styles.set(name, value);
+      },
+      removeProperty(name: string) {
+        styles.delete(name);
+      },
+      getPropertyValue(name: string) {
+        return styles.get(name) ?? "";
+      },
+    },
     value: "",
     textContent: "",
     hidden: false,
@@ -176,6 +187,7 @@ function createQuickChatHarness(): Record<string, any> {
   };
   const document = {
     body: createFakeElement(),
+    documentElement: createFakeElement("html"),
     createElement: (tagName: string) => createFakeElement(tagName),
     createTextNode: (text: string) => ({ textContent: text }),
     querySelector(selector: string) {
@@ -214,6 +226,7 @@ this.harness = {
   },
   advanceTime(ms) { advanceTime(ms); },
   emitGatewayState(payload) { setGatewayState(payload); },
+  accent() { return document.documentElement.style.getPropertyValue("--accent"); },
   setMessage(value) { elements.input.value = value; },
   pendingCount() { return pendingChatEvents.length; },
   activeRunId() { return activeReply?.runId ?? null; },
@@ -249,6 +262,20 @@ test("visibility operations share one monotonic sequence", () => {
   assert.equal(harness.nextVisibilityOperation(), 1);
   assert.equal(harness.nextVisibilityOperation(), 2);
   assert.equal(harness.nextVisibilityOperation(), 3);
+});
+
+test("gateway state updates and clears the Quick Chat user accent", () => {
+  const harness = createQuickChatHarness();
+  harness.setGatewayUp();
+
+  harness.emitGatewayState({ state: "up", accent: "#45b6fe" });
+  assert.equal(harness.accent(), "#45b6fe");
+
+  harness.emitGatewayState({ state: "up", accent: "#52c99a" });
+  assert.equal(harness.accent(), "#52c99a");
+
+  harness.emitGatewayState({ state: "up" });
+  assert.equal(harness.accent(), "");
 });
 
 test("widget child webviews inherit no Quick Chat Tauri capability", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Linux users choosing an accent in the Control UI would still see the Quick Chat caret and send button permanently rendered in a different hardcoded red.

## Why This Change Was Made

Quick Chat now reads the existing Gateway configuration over its existing WebSocket connection, strictly validates `#rrggbb` values, and applies the shared `ui.prefs.accent` → `ui.seamColor` precedence. Gateway `config.changed` notifications trigger a fresh `config.get` and reuse the existing quickchat Gateway-state event, so an already-open chat updates immediately; the tray shell and its fixed brand colors remain unchanged.

## User Impact

The Linux Quick Chat composer immediately matches the user's chosen Gateway accent, falls back to the operator-configured accent when the user preference is absent or invalid, and preserves its existing red when neither value is valid.

## Evidence

- Before the fix, a Gateway event requesting `#45b6fe` left both controls at `rgb(255, 107, 107)`.
- After the fix, both controls render `rgb(69, 182, 254)` for `#45b6fe`, immediately change to `rgb(82, 201, 154)` when a subsequent event supplies `#52c99a`, and restore `rgb(255, 107, 107)` when the accent is removed.
- `cargo test --locked --all-targets`: **111 unit tests and 10 integration tests passed**; one existing logind integration test remains intentionally ignored.
- `cargo fmt -- --check` passed.
- Focused Rust coverage verifies preference precedence, uppercase normalization, invalid-user fallback, missing values, and strict rejection of malformed colors; the existing Gateway-state serialization test also verifies the accent reaches the renderer payload.
- Before/after screenshots below use a sanitized local Quick Chat fixture.

![Before: Quick Chat keeps its hardcoded red](https://github.com/user-attachments/assets/f1ca9e24-f5aa-457d-8425-f42ed15f8f4b)

![After: Quick Chat adopts the Gateway accent](https://github.com/user-attachments/assets/b094d708-6b74-4cac-a9d4-20587c01c557)