### PR TITLE
fix(macos): stop reporting broken Gateway executables as ready

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
@@ -196,6 +196,15 @@ enum GatewayEnvironment {
                 gatewayBin: gatewayBin,
                 projectRoot: projectRoot,
                 searchPaths: searchPaths)
+            if let gatewayBin, installedRaw == nil {
+                let message = "OpenClaw Gateway at \(gatewayBin) could not be verified; reinstall or repair it."
+                return GatewayEnvironmentStatus(
+                    kind: .error(message),
+                    nodeVersion: runtime.version.description,
+                    gatewayVersion: nil,
+                    requiredGateway: expectedString,
+                    message: message)
+            }
             let installed = Semver.parse(installedRaw)
 
             if let expected, let installedRaw, installed != nil,
@@ -253,10 +262,8 @@ enum GatewayEnvironment {
         projectRoot: URL,
         searchPaths: [String]) async -> String?
     {
-        if let gatewayBin,
-           let version = await self.readGatewayVersion(binary: gatewayBin, searchPaths: searchPaths)
-        {
-            return version
+        if let gatewayBin {
+            return await self.readGatewayVersion(binary: gatewayBin, searchPaths: searchPaths)
         }
         return self.readLocalGatewayVersion(projectRoot: projectRoot)
     }
@@ -269,6 +276,7 @@ enum GatewayEnvironment {
                 arguments: ["--version"],
                 environment: ["PATH": searchPaths.joined(separator: ":")],
                 timeout: CommandResolver.versionProbeTimeout)
+            guard result.terminationStatus == 0 else { return nil }
             let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
             if elapsedMs > 500 {
                 self.logger.warning(

--- a/apps/macos/Sources/OpenClaw/RuntimeLocator.swift
+++ b/apps/macos/Sources/OpenClaw/RuntimeLocator.swift
@@ -148,6 +148,7 @@ enum RuntimeLocator {
                 arguments: ["--version"],
                 environment: ["PATH": pathEnv],
                 timeout: CommandResolver.versionProbeTimeout)
+            guard result.terminationStatus == 0 else { return nil }
             let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
             if elapsedMs > 500 {
                 self.logger.warning(

--- a/apps/macos/Tests/OpenClawIPCTests/CLIInstallerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CLIInstallerTests.swift
@@ -418,7 +418,11 @@ struct CLIInstallerTests {
         #expect(status == .ready(location: executable.path, version: "2026.7.3"))
     }
 
-    @Test func `matching external CLI with unsupported Node is unusable`() async throws {
+    @Test(arguments: [("v20.18.0", 0), ("v24.15.0", 1)])
+    func `matching external CLI with an unusable Node runtime needs repair`(
+        version: String,
+        exitCode: Int) async throws
+    {
         let root = FileManager().temporaryDirectory.appendingPathComponent(
             "openclaw-old-node-cli-\(UUID().uuidString)")
         defer { try? FileManager().removeItem(at: root) }
@@ -429,7 +433,7 @@ struct CLIInstallerTests {
             to: executable,
             atomically: true,
             encoding: .utf8)
-        try "#!/bin/sh\necho 'v20.18.0'\n".write(
+        try "#!/bin/sh\necho '\(version)'\nexit \(exitCode)\n".write(
             to: node,
             atomically: true,
             encoding: .utf8)

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
@@ -41,7 +41,7 @@ struct GatewayEnvironmentTests {
         #expect(Semver.parse(normalized2) == Semver(major: 2026, minor: 4, patch: 2))
     }
 
-    @Test func `failed global version probe falls back to local package`() async throws {
+    @Test func `failed global version probe does not borrow the local package version`() async throws {
         let projectRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("openclaw-gateway-environment-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: projectRoot, withIntermediateDirectories: true)
@@ -54,7 +54,58 @@ struct GatewayEnvironmentTests {
             projectRoot: projectRoot,
             searchPaths: ["/usr/bin"])
 
-        #expect(version == "2026.7.29")
+        #expect(version == nil)
+        #expect(await GatewayEnvironment.installedGatewayVersion(
+            gatewayBin: nil,
+            projectRoot: projectRoot,
+            searchPaths: ["/usr/bin"]) == "2026.7.29")
+    }
+
+    @Test func `failed gateway probe cannot validate version output from a broken executable`() async throws {
+        let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let gateway = root.appendingPathComponent("openclaw")
+        try "#!/bin/sh\necho OpenClaw 2026.7.30\nexit 1\n"
+            .write(to: gateway, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: gateway.path)
+
+        let version = await GatewayEnvironment.installedGatewayVersion(
+            gatewayBin: gateway.path,
+            projectRoot: root,
+            searchPaths: [root.path, "/usr/bin", "/bin"])
+
+        #expect(version == nil)
+    }
+
+    @Test func `broken global gateway remains an actionable error beside a valid checkout`() async throws {
+        let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let bin = root.appendingPathComponent("node_modules/.bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        let node = bin.appendingPathComponent("node")
+        let gateway = bin.appendingPathComponent("openclaw")
+        try "#!/bin/sh\necho v24.15.0\n".write(to: node, atomically: true, encoding: .utf8)
+        try "#!/bin/sh\nexit 1\n".write(to: gateway, atomically: true, encoding: .utf8)
+        for executable in [node, gateway] {
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        }
+        let version = GatewayEnvironment.expectedGatewayVersionString() ?? "2026.7.30"
+        try Data(#"{"version":"\#(version)"}"#.utf8).write(to: root.appendingPathComponent("package.json"))
+
+        await TestIsolation.withIsolatedState(
+            defaults: ["openclaw.gatewayProjectRootPath": root.path])
+        {
+            let gatewayStatus = await GatewayEnvironment.check()
+
+            guard case let .error(message) = gatewayStatus.kind else {
+                Issue.record("Expected an actionable gateway failure, got \(gatewayStatus)")
+                return
+            }
+            #expect(message.contains(gateway.path))
+            #expect(message.contains("repair"))
+            #expect(gatewayStatus.gatewayVersion == nil)
+            #expect(gatewayStatus.nodeVersion == "24.15.0")
+        }
     }
 
     @Test func `gateway version probe tolerates loaded host delay`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/RuntimeLocatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/RuntimeLocatorTests.swift
@@ -118,6 +118,23 @@ struct RuntimeLocatorTests {
         #expect(path == node.path)
     }
 
+    @Test func `resolve rejects a failing node shim that prints a supported version`() async throws {
+        let node = try self.makeTempExecutable(contents: """
+        #!/bin/sh
+        echo v24.15.0
+        exit 1
+        """)
+
+        let result = await RuntimeLocator.resolve(searchPaths: [node.deletingLastPathComponent().path])
+
+        guard case let .failure(.versionParse(_, raw, path, _)) = result else {
+            Issue.record("Expected the failed runtime probe to be rejected, got \(result)")
+            return
+        }
+        #expect(raw == "(unreadable)")
+        #expect(path == node.path)
+    }
+
     @Test func `describe failure includes paths`() {
         let msg = RuntimeLocator.describeFailure(.notFound(searchPaths: ["/tmp/a", "/tmp/b"]))
         #expect(msg.contains("Node >=22.22.3 <23, >=24.15.0 <25, or >=25.9.0"))


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users setting up or checking their local Gateway could see a healthy Node runtime, a ready CLI, or a green Gateway status even though the selected executable failed its version probe. A broken installed Gateway could also appear healthy by silently borrowing the version of an unrelated OpenClaw source checkout.

## Why This Change Was Made

Both executable-discovery owners now require a successful subprocess exit before trusting version output. Gateway environment discovery keeps source-checkout version lookup only for an actual source-checkout launch; a selected installed executable that cannot be verified instead produces the existing actionable error outcome. Missing, unsupported, incompatible, managed-install, named-profile, and checkout-only behavior remain unchanged.

## User Impact

First-run onboarding no longer accepts a broken Node version-manager shim as a usable runtime. A broken installed Gateway is reported as an error with its actual executable path and a repair instruction, rather than displaying a misleading green status or the version of an unrelated checkout.

## Evidence

- Authentic pre-fix native reproduction: five real executable regressions failed: a Node shim that printed a supported version before exiting unsuccessfully was accepted; onboarding incorrectly classified that CLI as ready; a failed installed Gateway inherited a checkout version; a Gateway that printed a version before failing was accepted; and the real Gateway environment check incorrectly returned `.ok` with the borrowed version.
- After repairing the owning boundaries, `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path apps/macos --filter 'RuntimeLocatorTests|GatewayEnvironmentTests|CLIInstallerTests|CommandResolverTests' --no-parallel -j 4` passed all 72 native tests across runtime discovery, Gateway environment reporting, onboarding CLI installation, and sibling command resolution.
- Focused SwiftFormat and SwiftLint checks passed; an independent frozen-diff review and the configured structured Codex review reported no actionable findings.
- Production: +13/-4 (net +9). The additional lines represent the two required executable exit-status checks and the existing typed, actionable Gateway failure outcome; the incorrect cross-executable version fallback was removed. Tests: +76/-4.
- Before/after screenshots and launching the operator's signed macOS app are unavailable in this isolated repair lane because modifying signing, TCC, the operator's running Gateway/launchd, or the user-owned VM is outside the explicitly authorized scope. The existing user-facing Settings rendering was directly inspected, and a real `GatewayEnvironment.check()` regression verifies the previous green `.ok` outcome changes to the actionable existing error outcome.
