### PR TITLE
fix(postinstall): honor the postinstall opt-out for the registry migration

### DIFF
--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -823,6 +823,13 @@ export async function runPluginRegistryPostinstallMigration(params = {}) {
   const env = params.env ?? process.env;
   const pathExists = params.existsSync ?? existsSync;
 
+  // The documented postinstall opt-out has to cover this path too. Without it the
+  // flag stops the bundled-plugin half while this migration still runs and still
+  // touches operator state, so an operator who opted out gets migrated anyway.
+  if (env?.[DISABLE_POSTINSTALL_ENV]?.trim()) {
+    return { status: "skipped", reason: "postinstall-disabled" };
+  }
+
   // Registry migration belongs to installed-package upgrades. Source checkouts
   // can contain stale dist from a different build and must not touch operator state.
   if (isSourceCheckoutRoot({ packageRoot, existsSync: pathExists })) {

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -470,6 +470,27 @@ describe("bundled plugin postinstall", () => {
     );
   });
 
+  it("skips the registry migration when the postinstall opt-out is set", async () => {
+    // The flag already short-circuits runBundledPluginPostinstall. It has to cover
+    // this path too, or an operator who opted out still gets operator state touched.
+    const packageRoot = await createTempDirAsync("postinstall-registry-optout-");
+    const log = { log: vi.fn(), warn: vi.fn() };
+    const migratePluginRegistryForInstall = vi.fn();
+    const importModule = vi.fn(async () => ({ migratePluginRegistryForInstall }));
+
+    const result = await runPluginRegistryPostinstallMigration({
+      packageRoot,
+      existsSync: vi.fn(() => true),
+      importModule,
+      env: { OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL: "1", OPENCLAW_HOME: "/tmp/home" },
+      log,
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: "postinstall-disabled" });
+    expect(migratePluginRegistryForInstall).not.toHaveBeenCalled();
+    expect(importModule).not.toHaveBeenCalled();
+  });
+
   it("does not migrate operator plugin state from a source checkout", async () => {
     const packageRoot = "/source";
     const existingPaths = new Set([


### PR DESCRIPTION
Part of #128782.

## What Problem This Solves

`OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL` is the documented way to stop the postinstall from doing work, and #128782 reports that setting it does not prevent install from touching `~/.openclaw` state. That part reproduces from the source: the flag covers one of the two things postinstall runs, and not the other.

```js
if (isDirectPostinstallInvocation()) {
  runBundledPluginPostinstall();                  // returns early on the flag
  await runPluginRegistryPostinstallMigration();  // never checked it
}
```

`runBundledPluginPostinstall` short-circuits on the flag (`scripts/postinstall-bundled-plugins.mjs`, `shouldRunBundledPluginPostinstall` plus its own early return). `runPluginRegistryPostinstallMigration` only guarded `isSourceCheckoutRoot`, so on an installed package it imported the migration entry and ran `migratePluginRegistryForInstall` regardless of the opt-out.

## Why This Change Was Made

An opt-out that covers half the postinstall is worse than none, because the operator believes they have prevented the side effect. The same flag is now checked before the migration entry is imported, so nothing is loaded and no operator state is touched when it is set.

The skip returns `{ status: "skipped", reason: "postinstall-disabled" }`, matching the existing skip shapes in that function (`source-checkout`, `missing-dist-entry`, `missing-dist-contract`) rather than inventing a new result type.

**Scope, stated plainly:** this fixes the opt-out, not the default. #128782's main complaint is that a plain `npm install` migrates the state DB at all, with no flag set. That is a product decision about whether install may touch operator state, and AGENTS.md is fairly pointed about migrations being doctor-owned, so I did not want to change the default behaviour unilaterally inside a bug fix. Happy to follow up if you want the default changed too, or to close this if you would rather solve the whole thing in one pass.

## User Impact

An operator who sets `OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL=1` now actually gets no postinstall side effects, including no plugin-registry migration. Default installs behave exactly as before.

## Evidence

Regression test in the existing suite, `test/scripts/postinstall-bundled-plugins.test.ts`:

```
skips the registry migration when the postinstall opt-out is set
  -> { status: "skipped", reason: "postinstall-disabled" }
  -> migratePluginRegistryForInstall not called
  -> importModule not called
```

It asserts the import never happens, not just that the migration function was skipped, so the dist entry is not even loaded.

Verified it fails on the unfixed script by reverting only `scripts/postinstall-bundled-plugins.mjs` and rerunning:

```
× skips the registry migration when the postinstall opt-out is set
Tests  1 failed | 37 passed (38)
```

With the fix: 38 passed.

Also at `adc27236620`, 0 behind:

- `node scripts/run-vitest.mjs test/scripts` : 733 passed, 1 failed
- `run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json` : exit 0
- oxlint clean on both changed files

The one `test/scripts` failure is `telegram-user-observer.test.ts > records streaming, actions, and wipes without exposing bystanders`. It is pre-existing: it fails the same way on pristine `main` at `ecf06317796` with my change stashed. Untouched here.

Production delta is +7 in one script; the rest is the test.

---
AI-assisted: the source trace, patch and test were produced with AI help, then reviewed and run locally by me. I could not reproduce the full `npm install` scenario from #128782 in a dev checkout, so this covers the opt-out half that is verifiable from source rather than claiming the whole report.
