### PR TITLE
fix(gateway): reconnect clients after failed WebSocket delivery

### DIFF
--- a/src/gateway/server-broadcast.serialization.test.ts
+++ b/src/gateway/server-broadcast.serialization.test.ts
@@ -86,7 +86,7 @@ describe("broadcast serialization failures", () => {
     ]);
   });
 
-  it("keeps a real healthy peer delivering while skipping a silently closing peer", async () => {
+  it("keeps a real healthy peer delivering while rejecting closing and failed peers", async () => {
     const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
     await once(server, "listening");
     const address = server.address() as AddressInfo;
@@ -98,6 +98,7 @@ describe("broadcast serialization failures", () => {
       return { peer, socket };
     };
     const retired = await connectPeer();
+    const broken = await connectPeer();
     const healthy = await connectPeer();
     const delivered: Array<{ event: string; seq: number }> = [];
     healthy.peer.on("message", (data: RawData) => {
@@ -110,25 +111,40 @@ describe("broadcast serialization failures", () => {
       usesSharedGatewayAuth: false,
     });
     const retiredClient = makeRealClient("real-retired", retired.socket);
+    const brokenClient = makeRealClient("real-broken", broken.socket);
     const healthyClient = makeRealClient("real-healthy", healthy.socket);
-    const clients = new Set([retiredClient, healthyClient]);
+    const clients = new Set([retiredClient, brokenClient, healthyClient]);
     const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
 
     try {
+      warnSpy.mockClear();
+      const brokenPeerClosed = vi.fn();
+      broken.peer.once("close", brokenPeerClosed);
+      vi.spyOn(broken.socket, "send").mockImplementationOnce(() => {
+        throw new Error("injected synchronous send failure");
+      });
       retired.socket.close(1000, "retiring peer");
       expect(retired.socket.readyState).toBe(WebSocket.CLOSING);
       const bufferedAtClose = retired.socket.bufferedAmount;
 
-      broadcast("skills.changed", { reason: "fanout" });
+      broadcast("chat", {
+        state: "final",
+        message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+      });
       broadcastToConnIds("skills.changed", { reason: "targeted" }, new Set(["real-healthy"]));
       await vi.waitFor(() => expect(delivered).toHaveLength(2));
+      await vi.waitFor(() => expect(brokenPeerClosed).toHaveBeenCalledOnce());
 
       expect(retired.socket.bufferedAmount).toBe(bufferedAtClose);
       expect(clients.has(retiredClient)).toBe(true);
       expect(delivered.map(({ event, seq }) => ({ event, seq }))).toEqual([
-        { event: "skills.changed", seq: 1 },
+        { event: "chat", seq: 1 },
         { event: "skills.changed", seq: 2 },
       ]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("real-broken: injected synchronous send failure"),
+        { event: "chat" },
+      );
 
       let callbackError: Error | undefined;
       retired.socket.send("dependency-callback-proof", (error) => {
@@ -138,6 +154,7 @@ describe("broadcast serialization failures", () => {
       await vi.waitFor(() => expect(callbackError).toBeInstanceOf(Error));
     } finally {
       retired.peer.terminate();
+      broken.peer.terminate();
       healthy.peer.terminate();
       for (const activeSocket of server.clients) {
         activeSocket.terminate();

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -387,9 +387,9 @@ export function createGatewayBroadcaster(params: {
       clientSeq.set(c, nextSeq);
       try {
         c.socket.send(frame);
-      } catch {
-        // The consumed seq makes this send failure visible to the client's
-        // gap detector on its next received frame.
+      } catch (err) {
+        log.error(`broadcast send failed conn=${c.connId}: ${formatErrorMessage(err)}`, { event });
+        c.socket.terminate();
       }
     }
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users waiting for a Gateway chat answer could receive no final response and no reconnect when their WebSocket connection synchronously failed to send the terminal event.

## Why This Change Was Made

The broadcaster consumed the per-client sequence number but silently swallowed synchronous transport failures and left the failed socket open. A lost terminal response has no guaranteed later event to expose the resulting sequence gap. Log the failed event and connection, then terminate the broken socket so its existing connection-lifecycle owner performs cleanup and the client can reconnect. Healthy recipients continue receiving the original broadcast.

## User Impact

Failed Gateway WebSocket deliveries now produce an actionable diagnostic and close the failed connection, allowing the existing client reconnection path to run. Healthy clients still receive the final answer without sequence disruption.

## Evidence

- Before the fix, an actual localhost WebSocket server injected a synchronous send failure for one connected peer; the healthy peer received the answer, but the failed peer remained open and its peer-close assertion failed.
- After the fix, the same real three-peer setup proves the failed peer closes, the event/connection/error are logged, the healthy peer receives the chat final at sequence 1 and its later targeted message at sequence 2, and an already-closing peer remains safely skipped.
- Rebased onto main `a665f9ab498dd509789af38b018554267552f352`; candidate `12b65bb016a358ce2d977056351dc3e1ca6173e0`.
- `node scripts/run-vitest.mjs src/gateway/server-broadcast.serialization.test.ts src/gateway/server/ws-connection.test.ts src/gateway/server-methods/chat-broadcast.test.ts` — all 36 tests passed again on the refreshed candidate.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/server-broadcast.ts src/gateway/server-broadcast.serialization.test.ts` — passed.
- Independent source-aware review inspected the actual installed WebSocket dependency's terminate/close lifecycle and found no actionable issues. Production LOC: +3/-3, net zero; tests: +21/-4.
- This regression proves actual transport closure, not a full client reconnect or UI recovery flow. Both local ws 8.21.1 and the upstream [pinned ws 8.21.3 source](https://github.com/websockets/ws/blob/8.21.3/lib/websocket.js#L492) were inspected directly; hosted CI installs 8.21.3.
- The earlier shared CI blocker is resolved by merged owner fixes #129387 and #129346, both included in the rebase. Required exact-head [CI run 33007026416](https://github.com/openclaw/openclaw/actions/runs/33007026416) passed. Fresh structured Codex autoreview passed with no actionable findings. The patch also preserves main's newer event scope guard and slow-consumer termination.
