### PR TITLE
fix(browser): stop hangs after modal dialog handling fails

### DIFF
--- a/extensions/browser/src/browser/pw-session-dialogs.ts
+++ b/extensions/browser/src/browser/pw-session-dialogs.ts
@@ -58,11 +58,11 @@ export function clearArmedDialogResponse(state: PageState): void {
   state.armedDialogResponse = undefined;
 }
 
-function abortActionsBlockedByDialog(state: PageState): void {
+function abortActionsBlockedByDialog(state: PageState, reason?: unknown): void {
   if (state.dialogAbortControllers.size === 0) {
     return;
   }
-  const err = new BrowserObservedDialogBlockedError(serializeObservedBrowserState(state));
+  const err = reason ?? new BrowserObservedDialogBlockedError(serializeObservedBrowserState(state));
   for (const controller of state.dialogAbortControllers) {
     if (!controller.signal.aborted) {
       controller.abort(err);
@@ -95,9 +95,6 @@ export async function settleObservedDialog(params: {
     }
   } catch (err) {
     if (!isNoDialogShowingError(err)) {
-      if (params.closedBy === "agent") {
-        state.pendingDialogs.push(pending);
-      }
       throw err;
     }
     closedBy = "remote";
@@ -139,7 +136,7 @@ export function observeDialog(pageState: PageState, dialog: Dialog): void {
       accept: armed.accept,
       ...(armed.promptText !== undefined ? { promptText: armed.promptText } : {}),
       closedBy: "armed",
-    }).catch(() => {});
+    }).catch((err: unknown) => abortActionsBlockedByDialog(pageState, err));
     return;
   }
   if (armed) {

--- a/extensions/browser/src/browser/pw-session.dialogs.test.ts
+++ b/extensions/browser/src/browser/pw-session.dialogs.test.ts
@@ -103,6 +103,73 @@ describe("observed browser dialogs", () => {
     observed.cleanup();
   });
 
+  it.each([true, false])(
+    "aborts every in-flight action with the original armed dialog failure (accept: %s)",
+    async (accept) => {
+      const { page, emit } = createPageHarness();
+      ensurePageState(page);
+      const dialog = createDialog();
+      const failure = new Error("Browser dialog response failed");
+      dialog[accept ? "accept" : "dismiss"].mockRejectedValue(failure);
+      const first = createObservedDialogAbortSignalForPage({ page });
+      const second = createObservedDialogAbortSignalForPage({ page });
+
+      armObservedDialogResponseOnPage({ page, accept, timeoutMs: 1000 });
+      emit("dialog", dialog);
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(first.signal.reason).toBe(failure);
+      expect(second.signal.reason).toBe(failure);
+      expect(getObservedBrowserStateForPage(page).dialogs).toEqual({ pending: [], recent: [] });
+      first.cleanup();
+      second.cleanup();
+    },
+  );
+
+  it.each([true, false])(
+    "does not requeue a consumed dialog when an explicit response fails (accept: %s)",
+    async (accept) => {
+      const { page, emit } = createPageHarness();
+      ensurePageState(page);
+      const dialog = createDialog();
+      const failure = new Error("Browser dialog response failed");
+      dialog[accept ? "accept" : "dismiss"].mockRejectedValue(failure);
+      emit("dialog", dialog);
+
+      await expect(respondToObservedDialogOnPage({ page, dialogId: "d1", accept })).rejects.toBe(
+        failure,
+      );
+
+      expect(getObservedBrowserStateForPage(page).dialogs).toEqual({ pending: [], recent: [] });
+      await expect(respondToObservedDialogOnPage({ page, dialogId: "d1", accept })).rejects.toThrow(
+        'Dialog "d1" is not pending.',
+      );
+    },
+  );
+
+  it.each([true, false])(
+    "records an already-closed dialog as remotely handled (accept: %s)",
+    async (accept) => {
+      const { page, emit } = createPageHarness();
+      ensurePageState(page);
+      const dialog = createDialog();
+      dialog[accept ? "accept" : "dismiss"].mockRejectedValue(
+        new Error("Protocol error: No dialog is showing"),
+      );
+      emit("dialog", dialog);
+
+      const closed = await respondToObservedDialogOnPage({ page, dialogId: "d1", accept });
+
+      expect(closed.closedBy).toBe("remote");
+      expect(getObservedBrowserStateForPage(page).dialogs).toMatchObject({
+        pending: [],
+        recent: [{ id: "d1", closedBy: "remote" }],
+      });
+    },
+  );
+
   it("uses the default arm-next-dialog timeout for non-finite timeoutMs", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users automating a browser would see actions hang indefinitely or an already-consumed modal dialog remain falsely actionable when accepting or dismissing that dialog fails at the browser protocol boundary.

## Why This Change Was Made

Playwright marks each dialog handled before awaiting its protocol response, so a failed handle cannot be retried. The browser plugin now treats that failure as terminal: armed responses abort every active action with the original error, while explicit responses remove the consumed dialog instead of offering an impossible retry.

This stays within the existing private dialog lifecycle owner, preserves successful and remotely closed dialogs, changes no public configuration or security boundary, and removes three net production lines.

## User Impact

Browser actions fail promptly with the real accept/dismiss error instead of silently hanging, and browser state no longer advertises permanently unhandleable dialogs as pending.

## Evidence

- Before the fix, four authentic owner regressions failed: armed accept/dismiss discarded the original failure and left both active actions running; explicit accept/dismiss retained a consumed dialog that could never be retried.
- After the fix, all 13 focused owner tests pass, including both accept/dismiss variants and remotely closed dialogs.
- Independent verification passed six browser owner, cancellation, batch, and HTTP-route suites: 75 tests.
- Independent actual-production EventEmitter verification passed 11 lifecycle scenarios covering armed and explicit failures, remote closure, successful handling, unarmed dialogs, parent cancellation, and page closure.
- Pinned Playwright 1.62.1 source confirms one-shot handling is committed before the awaited protocol operation.
- Targeted type-aware lint, formatting, and whitespace checks pass; independent authenticated code review reports no actionable findings.
- Reviewed head: c83e1e02c831ec0de4285266dc128b226096c4a1. Production delta: +3/-6; regression tests: +67.
