### PR TITLE
fix(ios): preserve keyboard feedback during voice capture

### DIFF
--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -4652,6 +4652,7 @@ extension TalkModeManager {
         let forceSpeaker = TalkDefaults.speakerphoneEnabled()
         let options = TalkAudioRoute.categoryOptions(speakerphoneEnabled: forceSpeaker)
         try session.setCategory(.playAndRecord, mode: mode, options: options)
+        try session.setAllowHapticsAndSystemSoundsDuringRecording(true)
         try? session.setPreferredSampleRate(48000)
         try? session.setPreferredIOBufferDuration(0.02)
         try session.setActive(true, options: [])

--- a/apps/ios/Sources/Voice/VoiceWakeManager.swift
+++ b/apps/ios/Sources/Voice/VoiceWakeManager.swift
@@ -525,6 +525,7 @@ final class VoiceWakeManager: NSObject {
             .allowBluetoothHFP,
             .defaultToSpeaker,
         ])
+        try session.setAllowHapticsAndSystemSoundsDuringRecording(true)
         try session.setActive(true, options: [])
     }
 

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -9,6 +9,23 @@ import Testing
 struct TalkModeManagerTests {
     private struct CloseError: Error {}
 
+    @Test func `recording sessions preserve system keyboard feedback`() throws {
+        let session = AVAudioSession.sharedInstance()
+        let previousSetting = session.allowHapticsAndSystemSoundsDuringRecording
+        defer {
+            try? session.setAllowHapticsAndSystemSoundsDuringRecording(previousSetting)
+            try? session.setActive(false, options: [.notifyOthersOnDeactivation])
+        }
+
+        try session.setAllowHapticsAndSystemSoundsDuringRecording(false)
+        try TalkModeManager.configureAudioSession()
+        #expect(session.allowHapticsAndSystemSoundsDuringRecording)
+
+        try session.setAllowHapticsAndSystemSoundsDuringRecording(false)
+        try TalkModeManager.configureRealtimeAudioSession()
+        #expect(session.allowHapticsAndSystemSoundsDuringRecording)
+    }
+
     private static func parse(_ config: [String: Any]) -> TalkModeGatewayConfigState {
         TalkModeGatewayConfigParser.parse(
             config: config,


### PR DESCRIPTION
## Summary

Fixes #119866.

- Enable Apple's existing `AVAudioSession` recording setting that permits system keyboard haptics and sounds while microphone input is active.
- Apply the setting at both app-owned recording-session owners: Voice Wake and the shared native/realtime-relay Talk setup.
- Preserve continuous voice capture and the user's existing iOS keyboard-feedback preferences; no composer workaround, synthetic feedback, or new setting is introduced.
- Cover both regular and realtime Talk configurations with an actual hosted iOS audio-session regression.

## Root cause

The iOS app configured `.playAndRecord` sessions for Voice Wake and Talk without enabling `allowHapticsAndSystemSoundsDuringRecording`. Apple's installed `AVAudioSession` SDK explicitly documents that this setting defaults to `false` and that setting it to `true` permits system sounds and haptics while audio input remains active. The issue reporter independently confirmed the behavior on a physical iPhone: disabling voice capture restores keyboard haptics, while enabling capture suppresses them.

The previously suggested tradeoff between continuous voice capture and keyboard feedback is therefore unnecessary. Both app-owned recording-session configurations now enable Apple's supported behavior before activation. The separate direct WebRTC transport is intentionally unchanged: its `RTCAudioSession` dependency expressly forbids calling setters on the underlying `AVAudioSession`, and its configuration/proxy currently exposes no corresponding haptics setter. Supporting that transport requires an upstream WebRTC proxy capability, not an unsafe owner-boundary violation here.

Production: +2/-0 lines. Tests: +17/-0 lines.

## Validation

- Fail-first hosted iPhone simulator: 59 existing Talk tests passed; the new `recording sessions preserve system keyboard feedback` case failed against unmodified production code.
- Fixed hosted iPhone simulator: all 70 Talk, realtime Talk, Voice Wake state, and Voice Wake suppression tests passed.
- Full changed-file verification passed, including SwiftLint and the native-state schema guard.
- Independent pre-commit review completed with no accepted or actionable findings.
- Physical-device A/B reproduction came from the issue reporter; the post-fix proof directly observes the actual `AVAudioSession` setting in a hosted simulator, not physical haptic hardware.
