### PR TITLE
refactor(cli): consolidate image option validation

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2368,7 +2368,7 @@ src/cli/acp-cli.ts	7
 src/cli/attach-cli.ts	3
 src/cli/capability-cli/audio.ts	3
 src/cli/capability-cli/embedding.ts	3
-src/cli/capability-cli/image.ts	21
+src/cli/capability-cli/image.ts	17
 src/cli/capability-cli/model.ts	4
 src/cli/capability-cli/shared.ts	6
 src/cli/capability-cli/tts.ts	6

--- a/src/cli/capability-cli/image.ts
+++ b/src/cli/capability-cli/image.ts
@@ -26,6 +26,7 @@ import {
 } from "../../media-understanding/runtime.js";
 import { getImageMetadata } from "../../media/media-services.js";
 import { defaultRuntime } from "../../runtime.js";
+import { formatHumanList } from "../../shared/human-list.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { getModelsCommandSecretTargetIds } from "../command-secret-targets.js";
 import { readInputFiles, writeOutputAsset } from "../media-output.js";
@@ -48,6 +49,8 @@ import {
 
 const IMAGE_OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
 const IMAGE_BACKGROUNDS = ["transparent", "opaque", "auto"] as const;
+const IMAGE_QUALITIES = ["low", "medium", "high", "auto"] as const;
+const IMAGE_OPENAI_MODERATIONS = ["low", "auto"] as const;
 
 async function runImageGenerate(params: {
   capability: "image.generate" | "image.edit";
@@ -232,60 +235,20 @@ async function runImageDescribe(params: {
   } satisfies CapabilityEnvelope;
 }
 
-function normalizeImageOutputFormat(
+function normalizeImageOption<T extends string>(
   raw: string | undefined,
-): ImageGenerationOutputFormat | undefined {
+  values: readonly T[],
+  label: string,
+): T | undefined {
   const normalized = normalizeLowercaseStringOrEmpty(raw);
   if (!normalized) {
     return undefined;
   }
-  if ((IMAGE_OUTPUT_FORMATS as readonly string[]).includes(normalized)) {
-    return normalized as ImageGenerationOutputFormat;
+  const match = values.find((value) => value === normalized);
+  if (match) {
+    return match;
   }
-  throw new Error("--output-format must be one of png, jpeg, or webp");
-}
-
-function normalizeImageBackground(
-  raw: string | undefined,
-  label = "--background",
-): ImageGenerationBackground | undefined {
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
-  if (!normalized) {
-    return undefined;
-  }
-  if ((IMAGE_BACKGROUNDS as readonly string[]).includes(normalized)) {
-    return normalized as ImageGenerationBackground;
-  }
-  throw new Error(`${label} must be one of transparent, opaque, or auto`);
-}
-
-function normalizeImageQuality(raw: string | undefined): ImageGenerationQuality | undefined {
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
-  if (!normalized) {
-    return undefined;
-  }
-  if (
-    normalized === "low" ||
-    normalized === "medium" ||
-    normalized === "high" ||
-    normalized === "auto"
-  ) {
-    return normalized;
-  }
-  throw new Error("--quality must be one of low, medium, high, or auto");
-}
-
-function normalizeOpenAIModeration(
-  raw: string | undefined,
-): ImageGenerationOpenAIModeration | undefined {
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
-  if (!normalized) {
-    return undefined;
-  }
-  if (normalized === "low" || normalized === "auto") {
-    return normalized;
-  }
-  throw new Error("--openai-moderation must be one of low or auto");
+  throw new Error(`${label} must be one of ${formatHumanList(values)}`);
 }
 
 function resolveImageDescribeInput(filePath: string): string {
@@ -322,14 +285,27 @@ function resolveImageGenerationOptions(opts: Record<string, unknown>, command: C
     size: opts.size as string | undefined,
     aspectRatio: opts.aspectRatio as string | undefined,
     resolution: opts.resolution as "1K" | "2K" | "4K" | undefined,
-    outputFormat: normalizeImageOutputFormat(opts.outputFormat as string | undefined),
-    background: normalizeImageBackground(opts.background as string | undefined),
-    openaiBackground: normalizeImageBackground(
+    outputFormat: normalizeImageOption(
+      opts.outputFormat as string | undefined,
+      IMAGE_OUTPUT_FORMATS,
+      "--output-format",
+    ),
+    background: normalizeImageOption(
+      opts.background as string | undefined,
+      IMAGE_BACKGROUNDS,
+      "--background",
+    ),
+    openaiBackground: normalizeImageOption(
       opts.openaiBackground as string | undefined,
+      IMAGE_BACKGROUNDS,
       "--openai-background",
     ),
-    openaiModeration: normalizeOpenAIModeration(opts.openaiModeration as string | undefined),
-    quality: normalizeImageQuality(opts.quality as string | undefined),
+    openaiModeration: normalizeImageOption(
+      opts.openaiModeration as string | undefined,
+      IMAGE_OPENAI_MODERATIONS,
+      "--openai-moderation",
+    ),
+    quality: normalizeImageOption(opts.quality as string | undefined, IMAGE_QUALITIES, "--quality"),
     timeoutMs: parseOptionalTimeoutMs(opts.timeoutMs as string | number | undefined),
     output: opts.output as string | undefined,
   };


### PR DESCRIPTION
## What Problem This Solves

Image-generation CLI options repeated the same lowercasing, allowed-value checks, and operator-facing error formatting in four separate validators, with four unnecessary type assertions.

## Why This Change Was Made

Consolidate image output format, background, quality, and OpenAI moderation validation into one typed, image-owner-local helper. Reuse the existing human-readable list formatter so every allowed value, option default, case/whitespace normalization rule, provider payload, and exact existing rejection message stays unchanged.

## User Impact

No user-visible behavior changes. Image commands retain the same options and errors while production code shrinks by 24 lines and the assertion-safety ratchet improves from 21 to 17.

## Evidence

- `node scripts/run-vitest.mjs src/cli/capability-cli.test.ts src/cli/capability-cli.lazy.test.ts src/cli/cli-utils.test.ts`: 243 tests passed, including valid image generation/edit options and all five exact invalid-option error messages.
- Real Commander registration fingerprint is unchanged across all 24 audio, image, video, speech, web, and embedding command leaves, including all five image leaves, options, defaults, argument contracts, and help text.
- `./node_modules/.bin/oxlint src/cli/capability-cli/image.ts` passes; the assertion-safety ratchet, all changed-code guards, production typechecking, and core-test typechecking pass.
- The frozen branch baseline predates the already-landed doctor-test lint fix on current main (`ecf063`), so the final whole-tree lint step reports the known unrelated `src/commands/doctor-auth.profile-health.test.ts:179` missing-sort-comparator violation. No unrelated doctor code is changed here; the exact GitHub merge-ref CI must pass before landing.
- Fresh automated review and separate independent source review report no findings.

