### PR TITLE
refactor(update): remove unreachable install retry indirection

### DIFF
--- a/src/infra/update-package-manager.ts
+++ b/src/infra/update-package-manager.ts
@@ -11,7 +11,7 @@ type BuildManager = "pnpm" | "bun" | "npm";
 
 type UpdatePackageManagerRequirement = "allow-fallback" | "require-preferred";
 
-export type UpdatePackageManagerFailureReason =
+type UpdatePackageManagerFailureReason =
   | "preferred-manager-unavailable"
   | "pnpm-corepack-enable-failed"
   | "pnpm-corepack-missing"

--- a/src/infra/update-runner-git-commands.ts
+++ b/src/infra/update-runner-git-commands.ts
@@ -1,9 +1,5 @@
 import { DEV_BRANCH } from "./update-channels.js";
-import {
-  managerInstallIgnoreScriptsArgs,
-  type UpdatePackageManagerFailureReason,
-} from "./update-package-manager.js";
-import type { UpdateRunResult, UpdateStepResult } from "./update-runner-types.js";
+import type { UpdateStepResult } from "./update-runner-types.js";
 
 const BUILD_MAX_OLD_SPACE_MB = 8192;
 const DEV_PREFLIGHT_LINT_ENV: NodeJS.ProcessEnv = {
@@ -12,19 +8,7 @@ const DEV_PREFLIGHT_LINT_ENV: NodeJS.ProcessEnv = {
 };
 const DEV_PREFLIGHT_LINT_OPT_IN_ENV = "OPENCLAW_UPDATE_PREFLIGHT_LINT";
 
-export function mapManagerResolutionFailure(
-  reason: UpdatePackageManagerFailureReason,
-): NonNullable<UpdateRunResult["reason"]> {
-  return reason;
-}
-
-export function shouldRetryWindowsInstallIgnoringScripts(manager: "pnpm" | "bun" | "npm"): boolean {
-  return process.platform === "win32" && manager === "pnpm";
-}
-
-export function shouldPreferIgnoreScriptsForWindowsPreflight(
-  manager: "pnpm" | "bun" | "npm",
-): boolean {
+export function shouldInstallWithoutScriptsOnWindows(manager: "pnpm" | "bun" | "npm"): boolean {
   return process.platform === "win32" && manager === "pnpm";
 }
 
@@ -77,20 +61,12 @@ function isSupersededInstallFailure(
   step: UpdateStepResult,
   steps: readonly UpdateStepResult[],
 ): boolean {
-  if (step.exitCode === 0) {
-    return false;
-  }
-  if (step.name === "deps install") {
-    return steps.some(
+  return (
+    step.name === "deps install" &&
+    steps.some(
       (candidate) => candidate.name === "deps install (ignore scripts)" && candidate.exitCode === 0,
-    );
-  }
-  const preflightMatch = /^preflight deps install \((.+)\)$/.exec(step.name);
-  if (!preflightMatch) {
-    return false;
-  }
-  const retryName = `preflight deps install (ignore scripts) (${preflightMatch[1]})`;
-  return steps.some((candidate) => candidate.name === retryName && candidate.exitCode === 0);
+    )
+  );
 }
 
 function isPreflightCandidateFailure(step: UpdateStepResult): boolean {
@@ -140,8 +116,4 @@ export function shouldRunDevPreflightLint(env: NodeJS.ProcessEnv = process.env):
 
 export function resolveDevPreflightLintEnv(env: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {
   return { ...env, ...DEV_PREFLIGHT_LINT_ENV };
-}
-
-export function resolveRetryInstallArgs(manager: "pnpm" | "bun" | "npm") {
-  return managerInstallIgnoreScriptsArgs(manager);
 }

--- a/src/infra/update-runner-git-preflight.ts
+++ b/src/infra/update-runner-git-preflight.ts
@@ -13,13 +13,10 @@ import {
 } from "./update-package-manager.js";
 import { MAX_LOG_CHARS, runStep } from "./update-runner-command.js";
 import {
-  mapManagerResolutionFailure,
   resolveBuildEnv,
   resolveDevPreflightLintEnv,
   resolveInstallEnv,
-  resolveRetryInstallArgs,
-  shouldPreferIgnoreScriptsForWindowsPreflight,
-  shouldRetryWindowsInstallIgnoringScripts,
+  shouldInstallWithoutScriptsOnWindows,
   shouldRunDevPreflightLint,
 } from "./update-runner-git-commands.js";
 import type {
@@ -327,7 +324,7 @@ async function testPreflightCandidates(params: {
       "require-preferred",
     );
     if (manager.kind === "missing-required") {
-      managerReason = mapManagerResolutionFailure(manager.reason);
+      managerReason = manager.reason;
       params.steps.push({
         name: `preflight package manager (${shortSha})`,
         command: `resolve ${manager.preferred} package manager`,
@@ -339,7 +336,7 @@ async function testPreflightCandidates(params: {
       continue;
     }
     try {
-      const preferIgnoreScripts = shouldPreferIgnoreScriptsForWindowsPreflight(manager.manager);
+      const preferIgnoreScripts = shouldInstallWithoutScriptsOnWindows(manager.manager);
       const ignoreScriptsArgv = managerInstallIgnoreScriptsArgs(manager.manager);
       const installArgv =
         preferIgnoreScripts && ignoreScriptsArgv
@@ -351,26 +348,9 @@ async function testPreflightCandidates(params: {
         ? `preflight deps install (ignore scripts) (${shortSha})`
         : `preflight deps install (${shortSha})`;
       const installEnv = resolveInstallEnv(manager.manager, manager.env);
-      let installStep = await runStep(
+      const installStep = await runStep(
         params.step(installName, installArgv, params.worktreeDir, installEnv),
       );
-      if (
-        installStep.exitCode !== 0 &&
-        !preferIgnoreScripts &&
-        shouldRetryWindowsInstallIgnoringScripts(manager.manager)
-      ) {
-        const retryArgv = resolveRetryInstallArgs(manager.manager);
-        if (retryArgv) {
-          installStep = await runStep(
-            params.step(
-              `preflight deps install (ignore scripts) (${shortSha})`,
-              retryArgv,
-              params.worktreeDir,
-              installEnv,
-            ),
-          );
-        }
-      }
       if (installStep.exitCode !== 0) {
         sawOtherFailure = true;
         continue;

--- a/src/infra/update-runner-git-recovery.ts
+++ b/src/infra/update-runner-git-recovery.ts
@@ -4,6 +4,7 @@ import { resolveControlUiAssetHealth } from "./control-ui-assets.js";
 import type { UpdateChannel } from "./update-channels.js";
 import {
   managerInstallArgs,
+  managerInstallIgnoreScriptsArgs,
   managerScriptArgs,
   resolveUpdateBuildManager,
 } from "./update-package-manager.js";
@@ -11,8 +12,7 @@ import { runStep } from "./update-runner-command.js";
 import {
   resolveBuildEnv,
   resolveInstallEnv,
-  resolveRetryInstallArgs,
-  shouldRetryWindowsInstallIgnoringScripts,
+  shouldInstallWithoutScriptsOnWindows,
 } from "./update-runner-git-commands.js";
 import type { CommandRunner, UpdateStepResult } from "./update-runner-types.js";
 
@@ -89,8 +89,8 @@ export async function rebuildRolledBackGitRuntime(params: {
       }),
       installEnv,
     );
-    if (!installed && shouldRetryWindowsInstallIgnoringScripts(manager.manager)) {
-      const retryArgv = resolveRetryInstallArgs(manager.manager);
+    if (!installed && shouldInstallWithoutScriptsOnWindows(manager.manager)) {
+      const retryArgv = managerInstallIgnoreScriptsArgs(manager.manager);
       installed = retryArgv
         ? await appendStep("git rollback deps install (ignore scripts)", retryArgv, installEnv)
         : false;

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -9,6 +9,7 @@ import { resolveStableNodePath } from "./stable-node-path.js";
 import { DEV_BRANCH, type UpdateChannel } from "./update-channels.js";
 import {
   managerInstallArgs,
+  managerInstallIgnoreScriptsArgs,
   managerScriptArgs,
   resolveUpdateBuildManager,
 } from "./update-package-manager.js";
@@ -19,11 +20,9 @@ import {
 } from "./update-runner-doctor.js";
 import {
   findBlockingGitFailure,
-  mapManagerResolutionFailure,
   resolveBuildEnv,
   resolveInstallEnv,
-  resolveRetryInstallArgs,
-  shouldRetryWindowsInstallIgnoringScripts,
+  shouldInstallWithoutScriptsOnWindows,
 } from "./update-runner-git-commands.js";
 import { runGitDevPreflight } from "./update-runner-git-preflight.js";
 import { rebuildRolledBackGitRuntime } from "./update-runner-git-recovery.js";
@@ -399,7 +398,7 @@ export async function updateGitCheckout(params: {
     "require-preferred",
   );
   if (manager.kind === "missing-required") {
-    return await rollbackError(mapManagerResolutionFailure(manager.reason));
+    return await rollbackError(manager.reason);
   }
   try {
     const installEnv = resolveInstallEnv(manager.manager, manager.env);
@@ -413,8 +412,8 @@ export async function updateGitCheckout(params: {
         installEnv,
       ),
     );
-    if (installStep.exitCode !== 0 && shouldRetryWindowsInstallIgnoringScripts(manager.manager)) {
-      const retryArgv = resolveRetryInstallArgs(manager.manager);
+    if (installStep.exitCode !== 0 && shouldInstallWithoutScriptsOnWindows(manager.manager)) {
+      const retryArgv = managerInstallIgnoreScriptsArgs(manager.manager);
       if (retryArgv) {
         installStep = await runStep(
           step("deps install (ignore scripts)", retryArgv, gitRoot, installEnv),


### PR DESCRIPTION
## What Problem This Solves

The Git checkout updater maintained duplicate Windows package-install policies, redundant forwarding helpers, and a preflight retry path that could never execute. This made the update and rollback flows harder to reason about without providing any additional recovery behavior.

## Why This Change Was Made

Use one Windows/pnpm install policy across development preflight, live updates, and rollback recovery. Call the package-manager owner directly for retry arguments and failure reasons, remove the contradictory preflight retry and its unreachable failure-suppression branch, and keep its now-unused failure-reason type private to that owner.

## User Impact

No user-visible behavior changes. Windows development preflight still uses `pnpm install --ignore-scripts` on its first attempt; live updates and rollback recovery still retry failed Windows/pnpm installs with the same arguments, error reasons, ordering, and recovery outcomes.

## Evidence

- Production: +21/-70, net -49 lines across five internal updater files; no test changes.
- Existing real updater and sibling coverage: `node scripts/run-vitest.mjs src/infra/update-runner.test.ts src/infra/update-dev-target.test.ts src/infra/update-post-core-context.test.ts src/infra/update-doctor-result.test.ts` — 4 files, 98 tests passed, including simulated Windows preflight/live retries, package-manager failures, stable/dev updates, and rollback recovery.
- Full unrestricted `node scripts/check-changed.mjs` passed, including all three unused-export scans with zero findings, core and core-test typechecks, changed-file lint, import-cycle checks, and architecture guards.
- Fresh pre-commit Codex review reported no actionable findings; separate independent source and exact-head reviews verified the same updater-owner boundary.
