### PR TITLE
fix(ci): restore onboarding config shard

### DIFF
--- a/src/commands/onboard-custom-config.ts
+++ b/src/commands/onboard-custom-config.ts
@@ -317,6 +317,8 @@ export function resolveCustomModelAliasError(params: {
     cfg: params.cfg,
     defaultProvider: DEFAULT_PROVIDER,
     agentId: params.agentId,
+    allowManifestNormalization: false,
+    allowPluginNormalization: false,
   });
   const aliasKey = normalizeLowercaseStringOrEmpty(normalized);
   const existing = aliasIndex.byAlias.get(aliasKey);

--- a/src/commands/onboard-inference-ambient.test.ts
+++ b/src/commands/onboard-inference-ambient.test.ts
@@ -24,34 +24,17 @@ afterEach(async () => {
 });
 
 describe("detectAmbientInferenceBackends", () => {
-  it.each([
-    {
-      kind: "claude-cli" as const,
-      relativePath: ".claude/.credentials.json",
-      credential: {
-        claudeAiOauth: {
-          accessToken: "claude-access",
-          refreshToken: "claude-refresh",
-          expiresAt: Date.now() + 60_000,
-        },
-      },
-    },
-    {
-      kind: "codex-cli" as const,
-      relativePath: ".codex/auth.json",
-      credential: {
-        auth_mode: "chatgpt",
-        tokens: { access_token: "codex-access", refresh_token: "codex-refresh" },
-      },
-    },
-  ])("returns a verified $kind candidate only for readable file credentials", async (fixture) => {
+  it("returns a verified Codex candidate only for readable file credentials", async () => {
     const home = await createTempHome();
     expect(detectAmbientInferenceBackends({ HOME: home })).toEqual([]);
 
-    await writeCredential(home, fixture.relativePath, fixture.credential);
+    await writeCredential(home, ".codex/auth.json", {
+      auth_mode: "chatgpt",
+      tokens: { access_token: "codex-access", refresh_token: "codex-refresh" },
+    });
 
     expect(detectAmbientInferenceBackends({ HOME: home })).toEqual([
-      expect.objectContaining({ kind: fixture.kind, credentials: true }),
+      expect.objectContaining({ kind: "codex-cli", credentials: true }),
     ]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes two onboarding failures from the `main` CI run at `9cfb4ff956c9b50e713f8774b576d9edd8db50a7`: ambient inference still expected OpenClaw to read Claude CLI credentials after #129052 moved native auth ownership to Claude, and custom alias validation loaded manifest/plugin normalization until the test timed out.

The same run's Doctor lint failure from #129375 is now fixed on `main` by #129409. Together, current `main` and this PR cover all three failures from the red run.

Related: #129375

## Why This Change Was Made

Ambient detection now retains only the Codex file-credential contract; Claude CLI owns its native login state. Custom alias collision validation reads the already-persisted aliases without loading manifest or plugin normalization, which cannot affect those configured alias keys.

This is AI-assisted.

## User Impact

No intended user-visible behavior change. The required `main` onboarding shard can validate agent-scoped aliases without a two-minute normalization stall, and its ambient-auth test matches the current native Claude ownership boundary.

## Evidence

Pre-existing failures on unmodified `main` SHA `9cfb4ff956c9b50e713f8774b576d9edd8db50a7`:

- CI run: https://github.com/openclaw/openclaw/actions/runs/32866251792
- `checks-node-compact-small-26`: `onboard-custom.test.ts` timed out after 120000 ms and `onboard-inference-ambient.test.ts` expected a Claude candidate but received `[]`.
- Local focused reproduction on the same SHA: ambient inference failed with the same `[]` result; 37 other focused tests passed.
- `check-lint-core-3`: `doctor-auth.profile-health.test.ts:179` failed `typescript(require-array-sort-compare)`. This was subsequently fixed on `main` by #129409.

Passing after this change, rebased on current `origin/main`:

- `node scripts/run-vitest.mjs src/commands/onboard-inference-ambient.test.ts src/commands/onboard-custom.test.ts src/commands/doctor-auth.profile-health.test.ts` (`37 passed`)
- `node scripts/run-vitest.mjs src/commands/onboard-custom-config.test.ts` (`38 passed`)
- `node scripts/check-changed.mjs -- src/commands/onboard-inference-ambient.test.ts src/commands/onboard-custom-config.ts`
- `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.6-sol --thinking high` (`clean`, no actionable findings)

Direct Codex contract inspection: `codex-rs/login/src/auth/storage.rs:38-51,150-152,179-199` defines and reads `$CODEX_HOME/auth.json`; `codex-rs/login/tests/suite/login_server_e2e.rs:176-186` verifies persisted access and refresh tokens.

Production LOC: `+2/-0`. Tests: `+6/-23`.

An additional local run of the full onboarding-config shard showed both originally failing tests passing, but the loaded host timed out in unrelated `auth-choice.model-check` and `onboard-inference` cases. Exact-head PR CI remains the authoritative full-shard proof.
