### PR TITLE
fix(ui): automation actions fail and schedule changes unexpectedly

### DIFF
--- a/extensions/anthropic/cli-constants.ts
+++ b/extensions/anthropic/cli-constants.ts
@@ -4,6 +4,13 @@
  */
 /** Synthetic provider/backend id for Claude Code CLI-backed Anthropic models. */
 export const CLAUDE_CLI_BACKEND_ID = "claude-cli";
+/** Retired OpenClaw auth profile replaced by Claude CLI's native login. */
+export const CLAUDE_CLI_PROFILE_ID = `anthropic:${CLAUDE_CLI_BACKEND_ID}`;
+/** Explicit thinking opt-out for Claude CLI routes unsupported by Claude Code. */
+export const CLAUDE_CLI_OFF_THINKING_PROFILE = {
+  levels: [{ id: "off" }],
+  defaultLevel: "off",
+} as const;
 /** Non-secret marker telling OpenClaw that the installed Claude CLI owns auth. */
 export const CLAUDE_CLI_NATIVE_AUTH_MARKER = ["openclaw", "claude-cli-native-auth"].join(":");
 /** Default Claude CLI model ref for agent defaults and live tests. */

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -16,6 +16,7 @@ export {
   CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS,
   CLAUDE_CLI_DEFAULT_MODEL_REF,
   CLAUDE_CLI_MODEL_ALIASES,
+  CLAUDE_CLI_OFF_THINKING_PROFILE,
   CLAUDE_CLI_SESSION_ID_FIELDS,
 } from "./cli-constants.js";
 
@@ -116,12 +117,6 @@ type ClaudeCliEffortArgAction =
   | { mode: "preserve" }
   | { mode: "omit" }
   | { mode: "set"; effort: ClaudeCliEffort };
-
-/** Explicit thinking opt-out for Claude CLI routes unsupported by Claude Code. */
-export const CLAUDE_CLI_OFF_THINKING_PROFILE = {
-  levels: [{ id: "off" }],
-  defaultLevel: "off",
-} as const;
 
 /** Return whether a provider id refers to the Claude CLI backend. */
 export function isClaudeCliProvider(providerId: string): boolean {

--- a/extensions/anthropic/config-defaults.ts
+++ b/extensions/anthropic/config-defaults.ts
@@ -4,7 +4,6 @@ import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-scop
  * model refs and cache-retention params based on configured auth mode.
  */
 import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
-import { CLAUDE_CLI_PROFILE_ID } from "openclaw/plugin-sdk/provider-auth";
 import {
   isRecord,
   normalizeLowercaseStringOrEmpty,
@@ -13,7 +12,11 @@ import {
   resolveClaudeCliAnthropicModelRefs,
   resolveKnownAnthropicModelRef,
 } from "./claude-model-refs.js";
-import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "./cli-constants.js";
+import {
+  CLAUDE_CLI_BACKEND_ID,
+  CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS,
+  CLAUDE_CLI_PROFILE_ID,
+} from "./cli-constants.js";
 
 const ANTHROPIC_PROVIDER_API = "anthropic-messages";
 const ANTHROPIC_API_KEY_DEFAULT_ALLOWLIST_REFS = [

--- a/extensions/anthropic/provider-policy-api.ts
+++ b/extensions/anthropic/provider-policy-api.ts
@@ -2,14 +2,13 @@
  * Provider-policy API for Anthropic and Claude CLI. Core calls this lightweight
  * path for config defaults and thinking profiles.
  */
-import { CLAUDE_CLI_PROFILE_ID } from "openclaw/plugin-sdk/provider-auth";
 import {
   resolveClaudeModelIdentity,
   resolveClaudeMythos5ModelIdentity,
   resolveClaudeThinkingProfile,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
-import { CLAUDE_CLI_OFF_THINKING_PROFILE } from "./cli-shared.js";
+import { CLAUDE_CLI_OFF_THINKING_PROFILE, CLAUDE_CLI_PROFILE_ID } from "./cli-constants.js";
 import {
   applyAnthropicConfigDefaults,
   normalizeAnthropicProviderConfigForProvider,

--- a/test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts
@@ -9,6 +9,7 @@ function createExtensionCodexAppServerAttemptSupportVitestConfig(
       "extensions/codex/src/app-server/attempt-context.test.ts",
       "extensions/codex/src/app-server/attempt-notifications.test.ts",
       "extensions/codex/src/app-server/attempt-results.test.ts",
+      "extensions/codex/src/app-server/attempt-startup-retry.test.ts",
       "extensions/codex/src/app-server/attempt-startup.test.ts",
       "extensions/codex/src/app-server/attempt-timeouts.test.ts",
       "extensions/codex/src/app-server/attempt-turn-watches.test.ts",

--- a/ui/src/app/app-host-pairing-access.test.ts
+++ b/ui/src/app/app-host-pairing-access.test.ts
@@ -3,6 +3,7 @@
 import { render, type TemplateResult } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
+import "../components/app-sidebar.ts";
 import { waitForFast } from "../test-helpers/wait-for.ts";
 import type { ApplicationRuntime } from "./bootstrap.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "./context.ts";
@@ -30,8 +31,6 @@ type PairingSidebar = HTMLElement & {
 };
 
 type PairingAuth = { role: string; scopes?: string[] };
-
-let renderedSidebar = false;
 
 function createPairingShell(params: {
   auth: PairingAuth | null;
@@ -111,7 +110,6 @@ function createPairingShell(params: {
   const container = document.createElement("div");
 
   const renderSidebar = () => {
-    renderedSidebar = true;
     render(shell.render(), container);
     const sidebar = container.querySelector<PairingSidebar>("openclaw-app-sidebar");
     if (!sidebar) {
@@ -147,12 +145,8 @@ function createPairingShell(params: {
   };
 }
 
-afterEach(async () => {
+afterEach(() => {
   vi.useRealTimers();
-  if (renderedSidebar) {
-    await waitForFast(() => expect(customElements.get("openclaw-app-sidebar")).toBeDefined());
-    renderedSidebar = false;
-  }
   document.body.replaceChildren();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();

--- a/ui/src/e2e/cron-select-values.e2e.test.ts
+++ b/ui/src/e2e/cron-select-values.e2e.test.ts
@@ -81,6 +81,17 @@ suite.define(() => {
         // Control: delivery mode's default is also its first option.
         expect(await pickerValue("wa-select#cron-delivery-mode")).toBe("announce");
         expect(await pickerValue("wa-select#cron-delivery-channel")).toBe("last");
+
+        await action.click();
+        await page.getByRole("option", { name: "Post to main timeline", exact: true }).click();
+        await expect.poll(() => pickerValue("wa-select#cron-payload-kind")).toBe("systemEvent");
+        await expect.poll(() => pickerValue("wa-select#cron-session-target")).toBe("main");
+
+        const target = page.locator("wa-select#cron-session-target");
+        await target.click();
+        await page.getByRole("option", { name: "Isolated session", exact: true }).click();
+        await expect.poll(() => pickerValue("wa-select#cron-session-target")).toBe("isolated");
+        await expect.poll(() => pickerValue("wa-select#cron-payload-kind")).toBe("agentTurn");
       },
     );
   });

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -336,6 +336,65 @@ describe("cron controller", () => {
   });
 
   it.each([
+    {
+      changed: "payloadKind",
+      form: { sessionTarget: "isolated", payloadKind: "systemEvent" },
+      expected: { sessionTarget: "main", payloadKind: "systemEvent" },
+    },
+    {
+      changed: "payloadKind",
+      form: { sessionTarget: "main", payloadKind: "agentTurn" },
+      expected: { sessionTarget: "isolated", payloadKind: "agentTurn" },
+    },
+    {
+      changed: "sessionTarget",
+      form: { sessionTarget: "main", payloadKind: "agentTurn" },
+      expected: { sessionTarget: "main", payloadKind: "systemEvent" },
+    },
+    {
+      changed: "sessionTarget",
+      form: { sessionTarget: "isolated", payloadKind: "systemEvent" },
+      expected: { sessionTarget: "isolated", payloadKind: "agentTurn" },
+    },
+  ] as const)(
+    "keeps editable actions and sessions compatible when $changed changes",
+    (scenario) => {
+      const normalized = normalizeCronFormState(
+        { ...DEFAULT_CRON_FORM, ...scenario.form },
+        { [scenario.changed]: scenario.form[scenario.changed] },
+      );
+
+      expect(normalized).toMatchObject(scenario.expected);
+      if (normalized.sessionTarget === "main") {
+        expect(normalized.deliveryMode).toBe("none");
+      }
+    },
+  );
+
+  it.each(["current", "session:project-alpha"] as const)(
+    "preserves the supported %s target while editing an agent action",
+    (sessionTarget) => {
+      expect(
+        normalizeCronFormState(
+          { ...DEFAULT_CRON_FORM, sessionTarget },
+          { payloadKind: "agentTurn" },
+        ),
+      ).toMatchObject({ sessionTarget, payloadKind: "agentTurn" });
+    },
+  );
+
+  it("preserves locked main-session script payloads", () => {
+    expect(
+      normalizeCronFormState({
+        ...DEFAULT_CRON_FORM,
+        sessionTarget: "main",
+        payloadKind: "script",
+        payloadLocked: true,
+      }),
+    ).toMatchObject({ sessionTarget: "main", payloadKind: "script", deliveryMode: "none" });
+  });
+
+  it.each([
     ["cron.add", null],
     ["cron.update", "no-timeout-job"],
   ] as const)(
@@ -1229,6 +1288,23 @@ describe("cron controller", () => {
     expect(state.cronFieldErrors).toEqual({});
   });
 
+  it.each([
+    {
+      name: "anchored interval",
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: 1_725_000_000_123 },
+    },
+    {
+      name: "subsecond cron stagger",
+      schedule: { kind: "cron", expr: "0 * * * *", tz: "UTC", staggerMs: 1_234 },
+    },
+  ] as const)("preserves the exact $name schedule on metadata-only edits", async ({ schedule }) => {
+    const job = createCronJob({ id: "job-exact-schedule", name: "Exact schedule", schedule });
+    const { state, submit } = createCronEditHarness(job);
+    state.cronForm.description = "metadata only";
+
+    expect(requestPatch(await submit())).not.toHaveProperty("schedule");
+  });
+
   it("applies schedule edits when changing an on-exit job to a regular schedule", async () => {
     const job = createCronJob({
       id: "job-on-exit",
@@ -2059,6 +2135,58 @@ describe("cron controller", () => {
     );
   });
 
+  it.each([
+    { name: "precise one-shot", schedule: { kind: "at", at: "2030-01-02T03:04:56.789Z" } },
+    {
+      name: "anchored interval",
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: 1_725_000_000_123 },
+    },
+    {
+      name: "subsecond cron stagger",
+      schedule: { kind: "cron", expr: "0 * * * *", tz: "UTC", staggerMs: 1_234 },
+    },
+    { name: "process exit", schedule: { kind: "on-exit", command: "make build", cwd: "/repo" } },
+    {
+      name: "event stream",
+      schedule: { kind: "stream", command: ["node", "events.mjs"], batchMs: 1_234 },
+    },
+  ] as const)("clones the exact $name schedule while its fields remain unchanged", async (item) => {
+    const request = createCronRequest("job-schedule-clone");
+    const sourceJob = createCronJob({
+      id: "job-schedule-source",
+      name: "Source schedule",
+      schedule: item.schedule,
+      delivery: { mode: "none" },
+    });
+    const state = createStateWithRequest(request, { cronJobs: [sourceJob] });
+
+    startCronClone(state, sourceJob);
+    expect(await addCronJob(state)).toEqual({ saved: true, jobId: "job-schedule-clone" });
+
+    expect(requestPayload(findRequestCall(request.mock.calls, "cron.add")).schedule).toEqual(
+      item.schedule,
+    );
+  });
+
+  it("applies an edited schedule when cloning an existing automation", async () => {
+    const request = createCronRequest("job-schedule-clone");
+    const sourceJob = createCronJob({
+      id: "job-schedule-source",
+      name: "Source schedule",
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: 1_725_000_000_123 },
+    });
+    const state = createStateWithRequest(request, { cronJobs: [sourceJob] });
+
+    startCronClone(state, sourceJob);
+    state.cronForm.everyAmount = "2";
+    await addCronJob(state);
+
+    expect(requestPayload(findRequestCall(request.mock.calls, "cron.add")).schedule).toEqual({
+      kind: "every",
+      everyMs: 120_000,
+    });
+  });
+
   it("keeps an existing condition trigger when cloning a script into an editable agent task", async () => {
     const request = createCronRequest("job-script-clone");
     const sourceJob = createCronJob({
@@ -2815,7 +2943,7 @@ describe("cron every-interval lossless round-trip", () => {
 
       const updateCall = findRequestCall(request.mock.calls, "cron.update");
       const patch = requestPatch(updateCall);
-      expect(patch.schedule).toEqual({ kind: "every", everyMs });
+      expect(patch).not.toHaveProperty("schedule");
     }
   });
 

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -2148,7 +2148,7 @@ describe("cron controller", () => {
     { name: "process exit", schedule: { kind: "on-exit", command: "make build", cwd: "/repo" } },
     {
       name: "event stream",
-      schedule: { kind: "stream", command: ["node", "events.mjs"], batchMs: 1_234 },
+      schedule: { kind: "stream", command: Array.of("node", "events.mjs"), batchMs: 1_234 },
     },
   ] as const)("clones the exact $name schedule while its fields remain unchanged", async (item) => {
     const request = createCronRequest("job-schedule-clone");

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -231,6 +231,7 @@ export type CronState = {
   // Exact definition the editor was opened or refreshed against; cronJobs is
   // only the current filtered/paged table cache.
   cronEditingJob: CronJob | null;
+  cronCloningJob: CronJob | null;
   cronEditingJobId: string | null;
   cronEditingConfigRevision: string | null;
   cronRunsJobId: string | null;
@@ -288,6 +289,7 @@ export function createInitialCronState(
     cronCreateOpen: false,
     cronFieldErrors: {},
     cronEditingJob: null,
+    cronCloningJob: null,
     cronEditingJobId: null,
     cronEditingConfigRevision: null,
     cronRunsJobId: null,
@@ -313,15 +315,28 @@ function supportsAnnounceDelivery(
   return form.sessionTarget !== "main" && (form.payloadKind === "agentTurn" || form.payloadLocked);
 }
 
-export function normalizeCronFormState(form: CronFormState): CronFormState {
-  if (form.deliveryMode !== "announce") {
-    return form;
+export function normalizeCronFormState(
+  form: CronFormState,
+  changed: Partial<CronFormState> = {},
+): CronFormState {
+  let normalized = form;
+  if (!form.payloadLocked) {
+    if (changed.sessionTarget !== undefined) {
+      const payloadKind = form.sessionTarget === "main" ? "systemEvent" : "agentTurn";
+      if (form.payloadKind !== payloadKind) {
+        normalized = { ...normalized, payloadKind };
+      }
+    } else if (form.payloadKind === "systemEvent" && form.sessionTarget !== "main") {
+      normalized = { ...normalized, sessionTarget: "main" };
+    } else if (form.payloadKind === "agentTurn" && form.sessionTarget === "main") {
+      normalized = { ...normalized, sessionTarget: "isolated" };
+    }
   }
-  if (supportsAnnounceDelivery(form)) {
-    return form;
+  if (normalized.deliveryMode !== "announce" || supportsAnnounceDelivery(normalized)) {
+    return normalized;
   }
   return {
-    ...form,
+    ...normalized,
     deliveryMode: "none",
   };
 }
@@ -821,6 +836,7 @@ function resolveCronJobScheduleKind(job: CronJob): string | null {
 
 function clearCronEditState(state: CronState) {
   state.cronEditingJob = null;
+  state.cronCloningJob = null;
   state.cronEditingJobId = null;
   state.cronEditingConfigRevision = null;
 }
@@ -833,6 +849,7 @@ function clearCronRunsPage(state: CronState) {
 }
 
 function resetCronFormToDefaults(state: CronState, agentId: string | null) {
+  state.cronCloningJob = null;
   state.cronForm = { ...DEFAULT_CRON_FORM, agentId: agentId ?? "" };
   // A fresh form starts visually clean; validation re-arms on the first change
   // or submit so required-field errors do not greet the user immediately.
@@ -1015,6 +1032,30 @@ function jobToForm(job: CronJob, prev: CronFormState): CronFormState {
   return normalizeCronFormState(next);
 }
 
+function hasUnchangedCronSchedule(form: CronFormState, job: CronJob): boolean {
+  const schedule = job.schedule;
+  if (form.scheduleKind !== schedule.kind) {
+    return false;
+  }
+  if (schedule.kind === "at") {
+    return form.scheduleAt === formatDateTimeLocal(schedule.at);
+  }
+  if (schedule.kind === "every") {
+    return parseCronEveryMs(form.everyAmount, form.everyUnit) === schedule.everyMs;
+  }
+  if (schedule.kind === "cron") {
+    const stagger = parseStaggerSchedule(schedule.staggerMs);
+    return (
+      form.cronExpr.trim() === schedule.expr &&
+      form.cronTz.trim() === (schedule.tz ?? "") &&
+      form.scheduleExact === stagger.scheduleExact &&
+      form.staggerAmount.trim() === stagger.staggerAmount &&
+      form.staggerUnit === stagger.staggerUnit
+    );
+  }
+  return true;
+}
+
 function buildCronSchedule(form: CronFormState) {
   if (form.scheduleKind === "at") {
     const ms = Date.parse(form.scheduleAt);
@@ -1177,17 +1218,14 @@ export async function addCronJob(state: CronState): Promise<CronSaveResult> {
       ? requireCronConfigRevision(state.cronEditingConfigRevision)
       : undefined;
     const editingPayload = editingJob ? getCronJobPayload(editingJob) : null;
-    // Preserve a process-backed schedule while the form still points at it; if the
-    // user selects an editable schedule kind, the update must apply it.
-    const preserveSchedule = Boolean(
-      editingJob &&
-      (((editingJob?.schedule.kind === "on-exit" || editingJob?.schedule.kind === "stream") &&
-        form.scheduleKind === editingJob.schedule.kind) ||
-        (editingJob?.schedule.kind === "at" &&
-          form.scheduleKind === "at" &&
-          form.scheduleAt === formatDateTimeLocal(editingJob.schedule.at))),
-    );
-    const schedule = preserveSchedule ? undefined : buildCronSchedule(form);
+    const sourceJob = editingJob ?? state.cronCloningJob;
+    // Form fields cannot represent process commands, anchors, or full timestamp/stagger precision.
+    const schedule =
+      sourceJob && hasUnchangedCronSchedule(form, sourceJob)
+        ? editingJob
+          ? undefined
+          : sourceJob.schedule
+        : buildCronSchedule(form);
     const preserveLockedPayload = Boolean(
       editingJob && form.payloadLocked && isReadOnlyCronPayload(editingPayload),
     );
@@ -1575,6 +1613,7 @@ export function updateCronRunsFilter(
 
 function setCronEditState(state: CronState, job: CronJob, form: CronFormState) {
   state.cronEditingJob = job;
+  state.cronCloningJob = null;
   state.cronEditingJobId = job.id;
   state.cronEditingConfigRevision = job.configRevision ?? null;
   state.cronRunsJobId = job.id;
@@ -1605,6 +1644,7 @@ function buildCloneName(name: string, existingNames: Set<string>) {
 
 export function startCronClone(state: CronState, job: CronJob) {
   clearCronEditState(state);
+  state.cronCloningJob = job;
   state.cronRunsJobId = job.id;
   const existingNames = new Set(
     state.cronJobs.map((entry) => normalizeLowercaseStringOrEmpty(entry.name)),
@@ -1616,7 +1656,7 @@ export function startCronClone(state: CronState, job: CronJob) {
     cloned.payloadKind = DEFAULT_CRON_FORM.payloadKind;
     cloned.payloadText = "";
   }
-  state.cronForm = cloned;
+  state.cronForm = normalizeCronFormState(cloned, { payloadKind: cloned.payloadKind });
   state.cronFieldErrors = validateCronForm(state.cronForm);
 }
 

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -243,7 +243,7 @@ class CronPage extends OpenClawLightDomElement {
     if (!this.canManageCron) {
       return;
     }
-    this.cron.cronForm = normalizeCronFormState({ ...this.cron.cronForm, ...patch });
+    this.cron.cronForm = normalizeCronFormState({ ...this.cron.cronForm, ...patch }, patch);
     this.cron.cronFieldErrors = validateCronForm(this.cron.cronForm);
     this.requestCronUpdate();
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators creating an automation with the **Post to main timeline** action would receive a Gateway validation error because the Automations form silently kept the incompatible **Isolated session** target. Editing or duplicating an existing automation could also silently change its scheduled execution time, interval anchor, exact stagger, or process-backed schedule.

## Why This Change Was Made

The automation form now normalizes actions and session targets together at their existing state owner, using whichever selector the operator actually changed. The same owner retains the original job definition while editing or cloning and preserves its exact schedule whenever the visible scheduling fields remain unchanged, including one-shot timestamps, interval anchors, cron stagger precision, and process-backed schedules.

## User Impact

Operators can create timeline and isolated-task automations without guessing a compatible second selector. Renaming, updating metadata, and duplicating automations no longer unexpectedly reschedule them or turn process-triggered jobs into ordinary cron jobs; read-only command, script, heartbeat, named-session, and current-session behaviors stay intact.

## Evidence

The real isolated development Gateway previously rejected the exact user flow with `isolated cron jobs require payload.kind="agentTurn", "command", or "script"`. After this change, selecting **Post to main timeline** immediately switches **Runs in** to **Main session**, the Gateway accepts the automation, and it appears in the live automation list. Selecting **Isolated session** switches the action back to **Run agent task**.

Before:

![Before: the automation form pairs a main-timeline action with an isolated session and the Gateway rejects it](https://github.com/user-attachments/assets/69b4cd13-03f3-42eb-9378-9c450dddf8cd)

After:

![After: the action immediately selects the compatible main session and can be saved](https://github.com/user-attachments/assets/061a187d-7525-45dd-b83f-3972398dad7a)

- Before the implementation, the new owner-boundary regressions failed in 11 independent action/session, edit, and clone scenarios.
- `node scripts/run-vitest.mjs ui/src/lib/cron/index.test.ts` — **146 passed**, including all formerly failing cases.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/cron-select-values.e2e.test.ts` — **Chromium browser E2E passed**, exercising both selector directions.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/e2e/cron-select-values.e2e.test.ts ui/src/lib/cron/index.test.ts ui/src/lib/cron/index.ts ui/src/pages/cron/cron-page.ts` — passed.

Production LOC: +59/-19 (net +40), required to preserve exact source schedules and distinguish the operator-owned selector across both edit and clone lifecycles. Tests: +140/-1.
