### PR TITLE
refactor(auto-reply): simplify origin destination routing

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -23,11 +23,7 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { ReplyPayload, ReplyThreadingPolicy } from "../types.js";
 import { formatBunFetchSocketError, isBunFetchSocketError } from "./agent-runner-utils.js";
 import { createBlockReplyContentKey, type BlockReplyPipeline } from "./block-reply-pipeline.js";
-import {
-  resolveOriginAccountId,
-  resolveOriginMessageProvider,
-  resolveOriginMessageTo,
-} from "./origin-routing.js";
+import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { normalizeReplyPayloadDirectives } from "./reply-delivery.js";
 import {
   applyReplyThreading,
@@ -234,9 +230,7 @@ export async function buildReplyPayloads(params: {
     originatingChannel: params.originatingChannel,
     provider: params.messageProvider,
   });
-  const accountId = resolveOriginAccountId({
-    originatingAccountId: params.accountId,
-  });
+  const accountId = params.accountId;
   const replyDelivery = createReplyDeliveryContext(params.replyToMode, params.originatingChatType);
   const replyDeliverySource = messageProvider
     ? {
@@ -299,9 +293,7 @@ export async function buildReplyPayloads(params: {
   let dedupedPayloads = threadedPayloads;
   if (shouldCheckMessagingToolDedupe) {
     const dedupeRuntime = await loadReplyPayloadsDedupeRuntime();
-    const originatingTo = resolveOriginMessageTo({
-      originatingTo: params.originatingTo,
-    });
+    const originatingTo = params.originatingTo;
     dedupedPayloads = [];
     for (const payload of threadedPayloads) {
       // Source mirrors exist because an internal sink send must reach the UI and

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -46,7 +46,6 @@ import { resolveResponseUsageLine } from "./agent-runner-usage-line.js";
 import { attachMcpAppChannelAction } from "./mcp-app-channel-action.js";
 import { attachMcpConnectChannelAction } from "./mcp-connect-channel-action.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
-import { resolveOriginMessageTo } from "./origin-routing.js";
 import { createReplyToModeFilterForChannel } from "./reply-threading.js";
 import { buildSessionsYieldAcknowledgmentPayload } from "./sessions-yield-acknowledgment.js";
 import { resolveStrandedReplyRecovery } from "./stranded-reply-recovery.js";
@@ -217,10 +216,7 @@ export async function prepareReplyAgentPayloads(state: {
         messagingToolSentTargets: runResult.messagingToolSentTargets,
         messagingToolSentTexts: runResult.messagingToolSentTexts,
         messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
-        originatingTo: resolveOriginMessageTo({
-          originatingTo: sessionCtx.OriginatingTo,
-          to: sessionCtx.To,
-        }),
+        originatingTo: sessionCtx.OriginatingTo ?? sessionCtx.To,
         originatingThreadId: replyRouteThreadId,
         accountId: sessionCtx.AccountId,
       }));
@@ -265,10 +261,7 @@ export async function prepareReplyAgentPayloads(state: {
       messagingToolSentTargets: runResult.messagingToolSentTargets,
       originatingChannel: sessionCtx.OriginatingChannel,
       originatingChatType: sessionCtx.ChatType,
-      originatingTo: resolveOriginMessageTo({
-        originatingTo: sessionCtx.OriginatingTo,
-        to: sessionCtx.To,
-      }),
+      originatingTo: sessionCtx.OriginatingTo ?? sessionCtx.To,
       originatingThreadId: replyRouteThreadId,
       accountId: sessionCtx.AccountId,
       normalizeMediaPaths: replyMediaContext.normalizePayload,

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -28,7 +28,7 @@ import type { TemplateContext } from "../templating.js";
 import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
 import { buildEmbeddedRunBaseParams as buildEmbeddedRunBaseParamsCore } from "./agent-runner-run-params.js";
 import { hasInboundAudio } from "./inbound-media.js";
-import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
+import { resolveOriginMessageProvider } from "./origin-routing.js";
 import type { FollowupRun } from "./queue.js";
 import { readChannelSourceTurnId } from "./source-turn-id.js";
 export { resolveModelFallbackOptions } from "./agent-runner-run-params.js";
@@ -128,10 +128,7 @@ export function buildThreadingToolContext(params: {
     originatingChannel: sessionCtx.OriginatingChannel,
     provider: sessionCtx.Provider,
   });
-  const originTo = resolveOriginMessageTo({
-    originatingTo: sessionCtx.OriginatingTo,
-    to: sessionCtx.To,
-  });
+  const originTo = sessionCtx.OriginatingTo ?? sessionCtx.To;
   if (!config) {
     return {
       currentMessageId,
@@ -280,10 +277,7 @@ function buildEmbeddedContextFromTemplate(params: {
     }),
     ...(sessionCtx.ChatType ? { chatType: sessionCtx.ChatType } : {}),
     agentAccountId: sessionCtx.AccountId,
-    messageTo: resolveOriginMessageTo({
-      originatingTo: sessionCtx.OriginatingTo,
-      to: sessionCtx.To,
-    }),
+    messageTo: sessionCtx.OriginatingTo ?? sessionCtx.To,
     messageThreadId: sessionCtx.MessageThreadId ?? undefined,
     chatId:
       normalizeOptionalString(sessionCtx.NativeChannelId) ??

--- a/src/auto-reply/reply/followup-delivery-payloads.ts
+++ b/src/auto-reply/reply/followup-delivery-payloads.ts
@@ -6,11 +6,7 @@ import { stripHeartbeatToken } from "../heartbeat.js";
 import { copyReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import type { OriginatingChannelType } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
-import {
-  resolveOriginAccountId,
-  resolveOriginMessageProvider,
-  resolveOriginMessageTo,
-} from "./origin-routing.js";
+import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { applyReplyTagsToPayload, isRenderablePayload } from "./reply-payloads-base.js";
 import { filterMessagingToolReplyPayload } from "./reply-payloads.js";
 import {
@@ -49,9 +45,7 @@ export function resolveFollowupDeliveryPayloads(params: {
       params.originatingAccountId,
       params.originatingChatType,
     );
-  const accountId = resolveOriginAccountId({
-    originatingAccountId: params.originatingAccountId,
-  });
+  const accountId = params.originatingAccountId;
   const replyDelivery = createReplyDeliveryContext(replyToMode, params.originatingChatType);
   const replyDeliverySource = replyMessageProvider
     ? {
@@ -80,9 +74,7 @@ export function resolveFollowupDeliveryPayloads(params: {
       sanitizedPayloads.push(sanitized);
     }
   }
-  const originatingTo = resolveOriginMessageTo({
-    originatingTo: params.originatingTo,
-  });
+  const originatingTo = params.originatingTo;
   const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
   return sanitizedPayloads.flatMap((payload) =>
     filterMessagingToolReplyPayload({

--- a/src/auto-reply/reply/origin-routing.test.ts
+++ b/src/auto-reply/reply/origin-routing.test.ts
@@ -1,12 +1,8 @@
-// Tests origin routing helpers that preserve message provider, account, and target ids.
+// Tests canonical message-provider resolution for reply routing.
 import { describe, expect, it } from "vitest";
-import {
-  resolveOriginAccountId,
-  resolveOriginMessageProvider,
-  resolveOriginMessageTo,
-} from "./origin-routing.js";
+import { resolveOriginMessageProvider } from "./origin-routing.js";
 
-describe("origin-routing helpers", () => {
+describe("resolveOriginMessageProvider", () => {
   it("prefers originating channel over provider for message provider", () => {
     const provider = resolveOriginMessageProvider({
       originatingChannel: "QuietChat",
@@ -31,23 +27,5 @@ describe("origin-routing helpers", () => {
         provider: "imessage",
       }),
     ).toBe("imessage");
-  });
-
-  it("prefers originating destination over fallback destination", () => {
-    const to = resolveOriginMessageTo({
-      originatingTo: "channel:C1",
-      to: "channel:C2",
-    });
-
-    expect(to).toBe("channel:C1");
-  });
-
-  it("prefers originating account over fallback account", () => {
-    const accountId = resolveOriginAccountId({
-      originatingAccountId: "work",
-      accountId: "personal",
-    });
-
-    expect(accountId).toBe("work");
   });
 });

--- a/src/auto-reply/reply/origin-routing.ts
+++ b/src/auto-reply/reply/origin-routing.ts
@@ -11,19 +11,3 @@ export function resolveOriginMessageProvider(params: {
     normalizeMessageChannel(params.originatingChannel) ?? normalizeMessageChannel(params.provider)
   );
 }
-
-/** Resolves the original message target before reply redirection. */
-export function resolveOriginMessageTo(params: {
-  originatingTo?: string;
-  to?: string;
-}): string | undefined {
-  return params.originatingTo ?? params.to;
-}
-
-/** Resolves the original account id before reply redirection. */
-export function resolveOriginAccountId(params: {
-  originatingAccountId?: string;
-  accountId?: string;
-}): string | undefined {
-  return params.originatingAccountId ?? params.accountId;
-}

--- a/src/plugin-sdk/direct-dm.test.ts
+++ b/src/plugin-sdk/direct-dm.test.ts
@@ -2,7 +2,6 @@
  * Tests direct-message guard policy helpers exposed through the SDK.
  */
 import { describe, expect, it, vi } from "vitest";
-import { resolveOriginMessageTo } from "../auto-reply/reply/origin-routing.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveImplicitMessageActionTarget } from "../infra/outbound/message-action-normalization.js";
 import {
@@ -299,10 +298,7 @@ describe("channel-inbound direct-message helpers", () => {
     expect(result.ctxPayload.NativeDirectUserId).toBe("clawstudio");
     expect(result.ctxPayload.OriginatingTo).toBe("reef:clawstudio");
     expect(result.ctxPayload.CommandAuthorized).toBe(true);
-    const currentChannelId = resolveOriginMessageTo({
-      originatingTo: result.ctxPayload.OriginatingTo,
-      to: result.ctxPayload.To,
-    });
+    const currentChannelId = result.ctxPayload.OriginatingTo ?? result.ctxPayload.To;
     expect(
       resolveImplicitMessageActionTarget({ currentChannelId, currentChannelProvider: "reef" }),
     ).toBe("reef:clawstudio");


### PR DESCRIPTION
## What Problem This Solves

Reply delivery routed destinations and account IDs through two internal helpers that only reimplemented nullish coalescing. Their object-argument wrappers obscured simple precedence at real delivery owners, added unnecessary work on reply paths, and encouraged an SDK test to import a private core implementation.

## Why This Change Was Made

Resolve origin destination fallback directly at reply, queued-delivery, threading, and direct-message owner boundaries, and use account IDs directly when no fallback exists. Delete both obsolete internal wrappers and their implementation-only tests while retaining the separate channel-provider normalization owner and the actual SDK direct-message boundary assertion.

## User Impact

No user-visible behavior changes. Existing Telegram, Discord, WhatsApp, and direct-message routing keeps the same destination precedence, account isolation, channel aliases, reply threading, and empty-string semantics. Production decreases by 45 lines; tests decrease by 26 lines without removing meaningful owner-boundary coverage.

## Evidence

- Before: 176 focused owner, cross-channel, threading, and direct-message tests pass; after: 174 pass, with exactly two removed tests that only asserted the deleted nullish-coalescing wrappers.
- Clean automated source review and separate independent, read-only exact-commit review report no findings.
- The full production, full-tree, and script dead-export scans pass with zero entries.
- All four TypeScript lanes pass: core, core tests, extensions, and extension tests.
- Targeted core lint, full extension lint, plugin boundaries, deprecated APIs, wrapper shadowing, dependency patches, database/schema, media, runtime sidecars, import cycles, webhook authorization, and pairing guards pass.
- Known pre-existing baseline exception: the public Plugin SDK surface-budget guard reports 4,342 exports against a 4,340 limit on the untouched, clean frozen main checkout and unchanged current main. This change modifies no public SDK production code or export inventory. All 12 prior and all 20 subsequent canonical selected checks were executed and passed unchanged. Exact-head hosted required CI must pass before landing.
