### PR TITLE
fix(feishu): deliver rich-post attachments in order without duplicate downloads

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -407,65 +407,48 @@ export async function resolveFeishuMediaList(params: {
 
   const out: FeishuMediaInfo[] = [];
   if (messageType === "post") {
-    const { imageKeys, mediaKeys } = parsePostContent(content);
-    if (imageKeys.length === 0 && mediaKeys.length === 0) {
+    const { attachments } = parsePostContent(content);
+    if (attachments.length === 0) {
       return [];
     }
-    if (imageKeys.length > 0) {
-      log?.(`feishu: post message contains ${imageKeys.length} embedded image(s)`);
-    }
-    if (mediaKeys.length > 0) {
-      log?.(`feishu: post message contains ${mediaKeys.length} embedded media file(s)`);
-    }
-
-    for (const imageKey of imageKeys) {
-      try {
-        const result = await saveMessageResourceFeishu({
-          cfg,
-          messageId,
-          fileKey: imageKey,
-          type: "image",
-          accountId,
-          maxBytes,
-        });
-        const saved = await resolveSavedFeishuMedia({ result, maxBytes });
-        out.push({
-          path: saved.path,
-          contentType: saved.contentType,
-          kind: "image",
-        });
-        log?.(`feishu: downloaded embedded image ${imageKey}, saved to ${saved.path}`);
-      } catch (err) {
-        out.push({ kind: "image" });
-        log?.(`feishu: failed to download embedded image ${imageKey}: ${String(err)}`);
+    log?.(`feishu: post message contains ${attachments.length} embedded attachment(s)`);
+    const seenAttachments = new Set<string>();
+    for (const attachment of attachments) {
+      const identity = `${attachment.kind}:${attachment.key}`;
+      if (seenAttachments.has(identity)) {
+        continue;
       }
-    }
-
-    for (const media of mediaKeys) {
+      seenAttachments.add(identity);
+      const fileName = attachment.kind === "file" ? attachment.fileName : undefined;
+      const mediaKind = attachment.kind === "image" ? "image" : "video";
       try {
         const result = await saveMessageResourceFeishu({
           cfg,
           messageId,
-          fileKey: media.fileKey,
-          type: "file",
+          fileKey: attachment.key,
+          type: attachment.kind,
           accountId,
           maxBytes,
-          originalFilename: media.fileName,
+          ...(fileName ? { originalFilename: fileName } : {}),
         });
         const saved = await resolveSavedFeishuMedia({
           result,
           maxBytes,
-          originalFilename: media.fileName,
+          ...(fileName ? { originalFilename: fileName } : {}),
         });
         out.push({
           path: saved.path,
           contentType: saved.contentType,
-          kind: "video",
+          kind: mediaKind,
         });
-        log?.(`feishu: downloaded embedded media ${media.fileKey}, saved to ${saved.path}`);
+        log?.(
+          `feishu: downloaded embedded ${attachment.kind} ${attachment.key}, saved to ${saved.path}`,
+        );
       } catch (err) {
-        out.push({ kind: "video" });
-        log?.(`feishu: failed to download embedded media ${media.fileKey}: ${String(err)}`);
+        out.push({ kind: mediaKind });
+        log?.(
+          `feishu: failed to download embedded ${attachment.kind} ${attachment.key}: ${String(err)}`,
+        );
       }
     }
     return out;

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2373,6 +2373,86 @@ describe("handleFeishuMessage command authorization", () => {
     expect(typeof mockCallArg(mockSaveMediaBuffer, 0, 3)).toBe("number");
   });
 
+  it("delivers unique rich-post attachments in their original mixed-media order", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockDownloadMessageResourceFeishu.mockImplementation(
+      async (params: { fileKey: string; originalFilename?: string; type: "file" | "image" }) => ({
+        buffer: Buffer.from(params.fileKey),
+        contentType: params.type === "image" ? "image/png" : "video/mp4",
+        fileName: params.originalFilename ?? `${params.fileKey}.png`,
+      }),
+    );
+    mockSaveMediaBuffer.mockImplementation(
+      async (
+        buffer: Buffer,
+        contentType: string,
+        _direction: string,
+        _limit: number,
+        name: string,
+      ) => ({
+        id: name,
+        path: `/tmp/${name}`,
+        size: buffer.length,
+        contentType,
+      }),
+    );
+
+    await dispatchMessage({
+      cfg: createFeishuTestConfig({ dmPolicy: "open" }),
+      event: createFeishuTestEvent({
+        messageId: "msg-post-mixed-attachments",
+        senderOpenId: "ou-sender",
+        messageType: "post",
+        content: JSON.stringify({
+          title: "Rich text",
+          content: [
+            [
+              { tag: "media", file_key: "file_first", file_name: "first.mov" },
+              { tag: "img", image_key: "img_shared" },
+              { tag: "media", file_key: "file_last", file_name: "last.mov" },
+              { tag: "img", image_key: "img_shared" },
+              { tag: "media", file_key: "file_first", file_name: "first.mov" },
+              { tag: "img", image_key: "file_first" },
+            ],
+          ],
+        }),
+      }),
+    });
+
+    expect(
+      mockDownloadMessageResourceFeishu.mock.calls.map((_call, index) => {
+        const request = mockCallArg<{ fileKey: string; originalFilename?: string; type: string }>(
+          mockDownloadMessageResourceFeishu,
+          index,
+          0,
+        );
+        return {
+          fileKey: request.fileKey,
+          ...(request.originalFilename ? { fileName: request.originalFilename } : {}),
+          type: request.type,
+        };
+      }),
+    ).toEqual([
+      { fileKey: "file_first", fileName: "first.mov", type: "file" },
+      { fileKey: "img_shared", type: "image" },
+      { fileKey: "file_last", fileName: "last.mov", type: "file" },
+      { fileKey: "file_first", type: "image" },
+    ]);
+
+    const context = mockCallArg<{ MediaPaths?: string[]; MediaTypes?: string[] }>(
+      mockFinalizeInboundContext,
+      0,
+      0,
+    );
+    expect(context.MediaPaths).toEqual([
+      "/tmp/first.mov",
+      "/tmp/img_shared.png",
+      "/tmp/last.mov",
+      "/tmp/file_first.png",
+    ]);
+    expect(context.MediaTypes).toEqual(["video/mp4", "image/png", "video/mp4", "image/png"]);
+  });
+
   it("removes failed rich-post media markers while preserving post text", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockDownloadMessageResourceFeishu.mockRejectedValueOnce(new Error("expired image key"));

--- a/extensions/feishu/src/dedupe-key.test.ts
+++ b/extensions/feishu/src/dedupe-key.test.ts
@@ -87,4 +87,47 @@ describe("resolveFeishuMessageDedupeKey", () => {
       JSON.stringify(["om_media", "image_key:img_123"]),
     );
   });
+
+  it.each([
+    {
+      label: "interleaved image and file attachments",
+      content: [
+        { tag: "media", file_key: "file_first" },
+        { tag: "img", image_key: "img_middle" },
+        { tag: "media", file_key: "file_last" },
+      ],
+      expected: ["image_key:img_middle", "file_key:file_first", "file_key:file_last"],
+    },
+    {
+      label: "duplicate occurrences and the same key in both resource types",
+      content: [
+        { tag: "media", file_key: "shared" },
+        { tag: "img", image_key: "shared" },
+        { tag: "img", image_key: "shared" },
+        { tag: "media", file_key: "shared" },
+      ],
+      expected: ["image_key:shared", "image_key:shared", "file_key:shared", "file_key:shared"],
+    },
+    {
+      label: "invalid resource keys",
+      content: [
+        { tag: "img", image_key: "invalid/key" },
+        { tag: "media", file_key: "file_valid" },
+      ],
+      expected: ["file_key:file_valid"],
+    },
+  ])("preserves the persisted rich-post replay key for $label", ({ content, expected }) => {
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-user" } },
+      message: {
+        message_id: "om_post",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "post",
+        content: JSON.stringify({ title: "", content: [content] }),
+      },
+    };
+
+    expect(resolveFeishuMessageDedupeKey(event)).toBe(JSON.stringify(["om_post", ...expected]));
+  });
 });

--- a/extensions/feishu/src/dedupe-key.ts
+++ b/extensions/feishu/src/dedupe-key.ts
@@ -25,11 +25,13 @@ function buildMediaDedupeKey(messageId: string, mediaParts: string[]): string {
 }
 
 function resolvePostMediaParts(content: string): string[] {
-  const parsed = parsePostContent(content);
-  return [
-    ...parsed.imageKeys.map((imageKey) => `image_key:${imageKey}`),
-    ...parsed.mediaKeys.map((media) => `file_key:${media.fileKey}`),
-  ];
+  const { attachments } = parsePostContent(content);
+  // Replay keys live for 24 hours across restarts; keep their shipped grouped order and duplicates.
+  return (["image", "file"] as const).flatMap((kind) =>
+    attachments
+      .filter((attachment) => attachment.kind === kind)
+      .map((attachment) => `${kind}_key:${attachment.key}`),
+  );
 }
 
 function resolveMessageMediaParts(messageType: string, content: string): string[] {

--- a/extensions/feishu/src/post.test.ts
+++ b/extensions/feishu/src/post.test.ts
@@ -26,7 +26,7 @@ describe("parsePostContent", () => {
     expect(result.textContent).toBe(
       "Daily \\*Plan\\*\n\n**Bold** *Italic* <u>Underline</u> ~~Strike~~ `Code`",
     );
-    expect(result.imageKeys).toStrictEqual([]);
+    expect(result.attachments).toStrictEqual([]);
     expect(result.mentionedOpenIds).toStrictEqual([]);
   });
 
@@ -54,7 +54,7 @@ describe("parsePostContent", () => {
     expect(result.mentionedOpenIds).toEqual(["ou_123"]);
   });
 
-  it("inserts image placeholders and collects image keys", () => {
+  it("inserts image placeholders and collects image attachments", () => {
     const content = JSON.stringify({
       title: "",
       content: [
@@ -70,12 +70,37 @@ describe("parsePostContent", () => {
     const result = parsePostContent(content);
 
     expect(result.textContent).toBe("Before ![image] after\n![image]");
-    expect(result.imageKeys).toEqual(["img_1", "img_2"]);
+    expect(result.attachments).toEqual([
+      { kind: "image", key: "img_1" },
+      { kind: "image", key: "img_2" },
+    ]);
     expect(result.mentionedOpenIds).toStrictEqual([]);
     expect(
       parsePostContent(content, { renderMediaPlaceholders: false, emptyTextFallback: "" })
         .textContent,
     ).toBe("Before  after");
+  });
+
+  it("preserves interleaved rich-post attachment occurrences in their original order", () => {
+    const content = JSON.stringify({
+      title: "Attachments",
+      content: [
+        [
+          { tag: "media", file_key: "file_first", file_name: "first.mov" },
+          { tag: "img", image_key: "img_shared" },
+          { tag: "media", file_key: "file_last", file_name: "last.mov" },
+          { tag: "img", image_key: "img_shared" },
+          { tag: "media", file_key: "invalid/key" },
+        ],
+      ],
+    });
+
+    expect(parsePostContent(content).attachments).toEqual([
+      { kind: "file", key: "file_first", fileName: "first.mov" },
+      { kind: "image", key: "img_shared" },
+      { kind: "file", key: "file_last", fileName: "last.mov" },
+      { kind: "image", key: "img_shared" },
+    ]);
   });
 
   it("supports locale wrappers", () => {
@@ -96,14 +121,12 @@ describe("parsePostContent", () => {
 
     expect(parsePostContent(wrappedByPost)).toEqual({
       textContent: "标题\n\n内容A",
-      imageKeys: [],
-      mediaKeys: [],
+      attachments: [],
       mentionedOpenIds: [],
     });
     expect(parsePostContent(wrappedByLocale)).toEqual({
       textContent: "标题\n\n内容B",
-      imageKeys: [],
-      mediaKeys: [],
+      attachments: [],
       mentionedOpenIds: [],
     });
   });

--- a/extensions/feishu/src/post.ts
+++ b/extensions/feishu/src/post.ts
@@ -10,8 +10,9 @@ const MARKDOWN_SPECIAL_CHARS = /([\\`*_{}[\]()#+\-!|>~])/g;
 
 type PostParseResult = {
   textContent: string;
-  imageKeys: string[];
-  mediaKeys: Array<{ fileKey: string; fileName?: string }>;
+  attachments: Array<
+    { kind: "image"; key: string } | { kind: "file"; key: string; fileName?: string }
+  >;
   mentionedOpenIds: string[];
 };
 
@@ -129,8 +130,7 @@ function renderCodeBlockElement(element: Record<string, unknown>): string {
 
 function renderElement(
   element: unknown,
-  imageKeys: string[],
-  mediaKeys: Array<{ fileKey: string; fileName?: string }>,
+  attachments: PostParseResult["attachments"],
   mentionedOpenIds: string[],
   renderMediaPlaceholders: boolean,
 ): string {
@@ -156,7 +156,7 @@ function renderElement(
     case "img": {
       const imageKey = normalizeFeishuExternalKey(toStringOrEmpty(element.image_key));
       if (imageKey) {
-        imageKeys.push(imageKey);
+        attachments.push({ kind: "image", key: imageKey });
       }
       return renderMediaPlaceholders ? "![image]" : "";
     }
@@ -164,7 +164,7 @@ function renderElement(
       const fileKey = normalizeFeishuExternalKey(toStringOrEmpty(element.file_key));
       if (fileKey) {
         const fileName = toStringOrEmpty(element.file_name) || undefined;
-        mediaKeys.push({ fileKey, fileName });
+        attachments.push({ kind: "file", key: fileKey, ...(fileName ? { fileName } : {}) });
       }
       return renderMediaPlaceholders ? "[media]" : "";
     }
@@ -244,14 +244,12 @@ export function parsePostContent(
     if (!payload) {
       return {
         textContent: FALLBACK_POST_TEXT,
-        imageKeys: [],
-        mediaKeys: [],
+        attachments: [],
         mentionedOpenIds: [],
       };
     }
 
-    const imageKeys: string[] = [];
-    const mediaKeys: Array<{ fileKey: string; fileName?: string }> = [];
+    const attachments: PostParseResult["attachments"] = [];
     const mentionedOpenIds: string[] = [];
     const paragraphs: string[] = [];
 
@@ -263,8 +261,7 @@ export function parsePostContent(
       for (const element of paragraph) {
         renderedParagraph += renderElement(
           element,
-          imageKeys,
-          mediaKeys,
+          attachments,
           mentionedOpenIds,
           options.renderMediaPlaceholders !== false,
         );
@@ -278,11 +275,10 @@ export function parsePostContent(
 
     return {
       textContent: textContent || (options.emptyTextFallback ?? FALLBACK_POST_TEXT),
-      imageKeys,
-      mediaKeys,
+      attachments,
       mentionedOpenIds,
     };
   } catch {
-    return { textContent: FALLBACK_POST_TEXT, imageKeys: [], mediaKeys: [], mentionedOpenIds: [] };
+    return { textContent: FALLBACK_POST_TEXT, attachments: [], mentionedOpenIds: [] };
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending Feishu rich-text posts with interleaved images and videos would have their attachments delivered to the agent in the wrong order, while repeated references triggered duplicate authenticated downloads and duplicate model-visible attachments.

## Why This Change Was Made

The Feishu post parser now owns one ordered, discriminated attachment sequence instead of partitioning images and files into separate arrays. The inbound downloader consumes that sequence in original document order and downloads each resource kind/key pair once, while the existing durable 24-hour replay-guard projection deliberately retains its exact shipped grouped ordering and duplicate occurrences.

This removes 19 production lines, preserves attachment filenames, malformed-key rejection, unavailable-resource placeholders, and distinct resource kinds sharing a key, and changes no public configuration, SDK surface, database schema, authentication, or persistent state.

## User Impact

Agents receive Feishu post attachments in the same order people see them, without redundant downloads or duplicate attachments. Existing persisted replay identities remain byte-for-byte compatible across upgrades and restarts.

## Evidence

- Before the fix, the actual inbound message handler downloaded six incorrectly ordered resources for four unique mixed attachments; its regression test and ordered-parser test both failed against current main.
- After the fix: `node scripts/run-vitest.mjs extensions/feishu/src/post.test.ts extensions/feishu/src/dedupe-key.test.ts extensions/feishu/src/dedup.test.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/bot.helpers.test.ts extensions/feishu/src/feishu-ingress.test.ts extensions/feishu/src/message-content-loopback.test.ts extensions/feishu/src/interactive-message-content.test.ts` — 8 suites, 158 tests passed.
- Independent verification: 10 Feishu suites and 217 tests passed, including persisted replay, durable ingress, broadcasts, and the real Lark SDK HTTP loopback.
- The official Lark SDK made authenticated localhost HTTP requests in exact original file → image → file → same-key-image order, with no duplicate resource requests.
- Independent old-versus-new comparison covered 2,801 mixed, duplicate, and malformed post permutations with zero differences in persisted replay-key bytes.
- Focused type-aware lint and formatting passed; independent source review and authenticated full-commit review found no actionable issues.
- Frozen baseline: `9cfb4ff956c9b50e713f8774b576d9edd8db50a7`; reviewed head: `bdc0e3544e6b262ac122abdae853c7f09556f5cb`; production delta: -19 lines.
