### PR TITLE
fix(postinstall): avoid registry state migration

### DIFF
--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -533,62 +533,6 @@ export function pruneInstalledPackageDist(params = {}) {
   return removed;
 }
 
-function resolveDistModuleUrl(packageRoot, distPath) {
-  return pathToFileURL(join(packageRoot, distPath)).href;
-}
-
-async function importInstalledDistModule(params, distPath) {
-  const packageRoot = params.packageRoot ?? DEFAULT_PACKAGE_ROOT;
-  const pathExists = params.existsSync ?? existsSync;
-  const modulePath = join(packageRoot, distPath);
-  if (!pathExists(modulePath)) {
-    return null;
-  }
-  const importModule = params.importModule ?? ((specifier) => import(specifier));
-  return await importModule(resolveDistModuleUrl(packageRoot, distPath));
-}
-
-export async function runPluginRegistryPostinstallMigration(params = {}) {
-  const log = params.log ?? console;
-  const packageRoot = params.packageRoot ?? DEFAULT_PACKAGE_ROOT;
-  const env = params.env ?? process.env;
-  const pathExists = params.existsSync ?? existsSync;
-
-  // Registry migration belongs to installed-package upgrades. Source checkouts
-  // can contain stale dist from a different build and must not touch operator state.
-  if (isSourceCheckoutRoot({ packageRoot, existsSync: pathExists })) {
-    return { status: "skipped", reason: "source-checkout" };
-  }
-
-  try {
-    const migrationModule = await importInstalledDistModule(
-      { ...params, existsSync: pathExists },
-      "dist/commands/doctor/shared/plugin-registry-migration.js",
-    );
-    if (!migrationModule) {
-      return { status: "skipped", reason: "missing-dist-entry" };
-    }
-    if (typeof migrationModule.migratePluginRegistryForInstall !== "function") {
-      return { status: "skipped", reason: "missing-dist-contract" };
-    }
-
-    const result = await migrationModule.migratePluginRegistryForInstall({
-      env,
-      packageRoot,
-    });
-    if (result.migrated) {
-      log.log(
-        `[postinstall] migrated plugin registry: ${result.current.plugins.length} plugin(s) indexed`,
-      );
-    }
-    return result;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    log.warn(`[postinstall] could not migrate plugin registry: ${message}`);
-    return { status: "failed", error: message };
-  }
-}
-
 export function isSourceCheckoutRoot(params) {
   const pathExists = params.existsSync ?? existsSync;
   const hasPostinstallInventory = pathExists(join(params.packageRoot, DIST_INVENTORY_PATH));
@@ -650,5 +594,4 @@ export function isDirectPostinstallInvocation(params = {}) {
 
 if (isDirectPostinstallInvocation()) {
   runBundledPluginPostinstall();
-  await runPluginRegistryPostinstallMigration();
 }

--- a/src/commands/doctor-plugin-registry.ts
+++ b/src/commands/doctor-plugin-registry.ts
@@ -41,12 +41,12 @@ import {
 import type { DoctorPrompter } from "./doctor-prompter.js";
 import {
   InvalidPluginInstallRecordStateError,
-  migratePluginRegistryForInstall,
-  preflightPluginRegistryInstallMigration,
-  type PluginRegistryInstallMigrationParams,
+  migratePluginRegistryForDoctor,
+  preflightPluginRegistryDoctorMigration,
+  type PluginRegistryDoctorMigrationParams,
 } from "./doctor/shared/plugin-registry-migration.js";
 
-type PluginRegistryDoctorRepairParams = Omit<PluginRegistryInstallMigrationParams, "config"> &
+type PluginRegistryDoctorRepairParams = Omit<PluginRegistryDoctorMigrationParams, "config"> &
   InstalledPluginIndexRecordStoreOptions & {
     config: OpenClawConfig;
     prompter: Pick<DoctorPrompter, "shouldRepair">;
@@ -397,7 +397,7 @@ async function loadInstallRecordsWithoutPluginIds(
 export async function detectPluginRegistryHealthIssues(
   params: PluginRegistryDoctorRepairParams,
 ): Promise<PluginRegistryHealthIssue[]> {
-  const preflight = preflightPluginRegistryInstallMigration(params);
+  const preflight = preflightPluginRegistryDoctorMigration(params);
   const issues: PluginRegistryHealthIssue[] = [];
   if (preflight.action === "migrate") {
     issues.push({
@@ -605,9 +605,9 @@ function assertNeverPluginRegistryIssue(issue: never): never {
 export async function maybeRepairPluginRegistryState(
   params: PluginRegistryDoctorRepairParams,
 ): Promise<PluginRegistryDoctorRepairResult> {
-  let preflight: ReturnType<typeof preflightPluginRegistryInstallMigration>;
+  let preflight: ReturnType<typeof preflightPluginRegistryDoctorMigration>;
   try {
-    preflight = preflightPluginRegistryInstallMigration(params);
+    preflight = preflightPluginRegistryDoctorMigration(params);
   } catch (error) {
     if (!(error instanceof InvalidPluginInstallRecordStateError)) {
       throw error;
@@ -648,7 +648,7 @@ export async function maybeRepairPluginRegistryState(
   }
 
   if (preflight.action !== "skip-existing") {
-    const result = await migratePluginRegistryForInstall({
+    const result = await migratePluginRegistryForDoctor({
       ...migrationParams,
       ...(shouldPersistRepairedInstallRecords
         ? {

--- a/src/commands/doctor/shared/plugin-registry-migration.test.ts
+++ b/src/commands/doctor/shared/plugin-registry-migration.test.ts
@@ -18,7 +18,7 @@ import {
 } from "../../../plugins/test-helpers/fs-fixtures.js";
 import * as stateDbReadOnly from "../../../state/openclaw-state-db-readonly.js";
 import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
-import { migratePluginRegistryForInstall } from "./plugin-registry-migration.js";
+import { migratePluginRegistryForDoctor } from "./plugin-registry-migration.js";
 const tempDirs: string[] = [];
 
 afterEach(() => {
@@ -103,7 +103,7 @@ function expectSha256(value: unknown) {
 }
 
 function requireMigratedIndex(
-  result: Awaited<ReturnType<typeof migratePluginRegistryForInstall>>,
+  result: Awaited<ReturnType<typeof migratePluginRegistryForDoctor>>,
 ): InstalledPluginIndex {
   if (result.status !== "migrated") {
     throw new Error(`Expected migration result to be migrated, got ${result.status}`);
@@ -148,7 +148,7 @@ function insertStalePersistedIndexRow(stateDir: string, installRecordsJson = "{}
   );
 }
 
-describe("plugin registry install migration", () => {
+describe("doctor plugin registry migration", () => {
   it("stops migration with the original error when the shared registry read fails", async () => {
     const stateDir = makeTempDir();
     const records = { authoritative: { source: "npm", spec: "authoritative@1.0.0" } };
@@ -164,7 +164,7 @@ describe("plugin registry install migration", () => {
     const readConfig = vi.fn(() => ({}));
     await expect
       .soft(
-        migratePluginRegistryForInstall({
+        migratePluginRegistryForDoctor({
           stateDir,
           readConfig,
           candidates: [],
@@ -185,7 +185,7 @@ describe("plugin registry install migration", () => {
       { env: { OPENCLAW_STATE_DIR: stateDir } },
     );
     expect(row).toMatchObject({ updated_at_ms: 123 });
-    const restored = await migratePluginRegistryForInstall({
+    const restored = await migratePluginRegistryForDoctor({
       stateDir,
       readConfig,
       candidates: [],
@@ -200,7 +200,7 @@ describe("plugin registry install migration", () => {
     await writePersistedInstalledPluginIndex(createCurrentIndex(), { stateDir });
     const readConfig = vi.fn(async () => ({}));
 
-    const result = await migratePluginRegistryForInstall({
+    const result = await migratePluginRegistryForDoctor({
       stateDir,
       readConfig,
       env: hermeticEnv(),
@@ -222,7 +222,7 @@ describe("plugin registry install migration", () => {
     fs.mkdirSync(pluginDir, { recursive: true });
     insertStalePersistedIndexRow(stateDir);
 
-    const result = await migratePluginRegistryForInstall({
+    const result = await migratePluginRegistryForDoctor({
       stateDir,
       candidates: [createCandidate(pluginDir)],
       readConfig: async () => ({}),
@@ -246,7 +246,7 @@ describe("plugin registry install migration", () => {
     insertStalePersistedIndexRow(stateDir, installRecordsJson);
 
     await expect(
-      migratePluginRegistryForInstall({
+      migratePluginRegistryForDoctor({
         stateDir,
         readConfig: async () => ({}),
         env: hermeticEnv(),
@@ -283,7 +283,7 @@ describe("plugin registry install migration", () => {
     ) as OpenClawConfig;
 
     await expect(
-      migratePluginRegistryForInstall({
+      migratePluginRegistryForDoctor({
         stateDir,
         readConfig: async () => invalidConfig,
         env: hermeticEnv(),
@@ -303,7 +303,7 @@ describe("plugin registry install migration", () => {
     fs.mkdirSync(disabledDir, { recursive: true });
     fs.mkdirSync(unusedBundledDir, { recursive: true });
 
-    const result = await migratePluginRegistryForInstall({
+    const result = await migratePluginRegistryForDoctor({
       stateDir,
       candidates: [
         createCandidate(enabledDir, "enabled-demo"),
@@ -344,7 +344,7 @@ describe("plugin registry install migration", () => {
     fs.mkdirSync(openaiDir, { recursive: true });
     fs.mkdirSync(unusedBundledDir, { recursive: true });
 
-    const result = await migratePluginRegistryForInstall({
+    const result = await migratePluginRegistryForDoctor({
       stateDir,
       candidates: [
         createCandidate(openaiDir, "openai", "bundled", { enabledByDefault: true }),
@@ -370,7 +370,7 @@ describe("plugin registry install migration", () => {
     fs.mkdirSync(migrationDir, { recursive: true });
     fs.mkdirSync(unusedBundledDir, { recursive: true });
 
-    const result = await migratePluginRegistryForInstall({
+    const result = await migratePluginRegistryForDoctor({
       stateDir,
       candidates: [
         createCandidate(migrationDir, "migrate-demo", "bundled", {
@@ -399,7 +399,7 @@ describe("plugin registry install migration", () => {
     fs.mkdirSync(openaiDir, { recursive: true });
     fs.mkdirSync(unusedBundledDir, { recursive: true });
 
-    const result = await migratePluginRegistryForInstall({
+    const result = await migratePluginRegistryForDoctor({
       stateDir,
       candidates: [
         createCandidate(openaiDir, "openai", "bundled"),
@@ -431,7 +431,7 @@ describe("plugin registry install migration", () => {
     fs.mkdirSync(memoryDir, { recursive: true });
     fs.mkdirSync(unusedBundledDir, { recursive: true });
 
-    const result = await migratePluginRegistryForInstall({
+    const result = await migratePluginRegistryForDoctor({
       stateDir,
       candidates: [
         createCandidate(memoryDir, "memory-core", "bundled", {
@@ -467,7 +467,7 @@ describe("plugin registry install migration", () => {
     const stateDir = makeTempDir();
     const readConfig = vi.fn(async () => ({}));
 
-    const result = await migratePluginRegistryForInstall({
+    const result = await migratePluginRegistryForDoctor({
       stateDir,
       dryRun: true,
       readConfig,
@@ -488,7 +488,7 @@ describe("plugin registry install migration", () => {
     fs.mkdirSync(pluginDir, { recursive: true });
     const candidate = createCandidate(pluginDir);
 
-    const result = await migratePluginRegistryForInstall({
+    const result = await migratePluginRegistryForDoctor({
       stateDir,
       candidates: [candidate],
       config: {},
@@ -514,7 +514,7 @@ describe("plugin registry install migration", () => {
     const pluginDir = path.join(stateDir, "plugins", "demo");
     fs.mkdirSync(pluginDir, { recursive: true });
 
-    const result = await migratePluginRegistryForInstall({
+    const result = await migratePluginRegistryForDoctor({
       stateDir,
       candidates: [createCandidate(pluginDir, "demo", "global", { installOwner: "demo" })],
       readConfig: async () => ({
@@ -561,7 +561,7 @@ describe("plugin registry install migration", () => {
     const stateDir = makeTempDir();
     const pluginDir = path.join(stateDir, "plugins", "missing");
 
-    const result = await migratePluginRegistryForInstall({
+    const result = await migratePluginRegistryForDoctor({
       stateDir,
       candidates: [],
       readConfig: async () => ({

--- a/src/commands/doctor/shared/plugin-registry-migration.ts
+++ b/src/commands/doctor/shared/plugin-registry-migration.ts
@@ -32,7 +32,7 @@ const DOCTOR_PLUGIN_ID_ALIASES: Readonly<Record<string, readonly string[]>> = {
   openai: ["openai-codex"],
 };
 
-type PluginRegistryInstallMigrationPreflight =
+type PluginRegistryDoctorMigrationPreflight =
   | {
       /** Migration action selected before reading or writing registry state. */
       action: "skip-existing";
@@ -46,16 +46,16 @@ type PluginRegistryInstallMigrationPreflight =
       filePath: string;
     };
 
-type PluginRegistryInstallMigrationResult =
+type PluginRegistryDoctorMigrationResult =
   | {
       status: "skip-existing" | "dry-run";
       migrated: false;
-      preflight: PluginRegistryInstallMigrationPreflight;
+      preflight: PluginRegistryDoctorMigrationPreflight;
     }
   | {
       status: "migrated";
       migrated: true;
-      preflight: PluginRegistryInstallMigrationPreflight;
+      preflight: PluginRegistryDoctorMigrationPreflight;
       current: InstalledPluginIndex;
     };
 
@@ -71,17 +71,17 @@ function invalidPersistedInstallRecordMessage(filePath: string): string {
 const INVALID_CONFIG_INSTALL_RECORD_MESSAGE =
   "plugins.installs contains invalid records. Back up openclaw.json, correct or remove the invalid retired plugins.installs record, then rerun `openclaw doctor --fix`.";
 
-export type PluginRegistryInstallMigrationParams = LoadInstalledPluginIndexParams &
+export type PluginRegistryDoctorMigrationParams = LoadInstalledPluginIndexParams &
   InstalledPluginIndexStoreOptions & {
     dryRun?: boolean;
     existsSync?: (path: string) => boolean;
     readConfig?: () => Promise<OpenClawConfig> | OpenClawConfig;
   };
 
-/** Decide whether plugin install registry migration should run for this environment. */
-export function preflightPluginRegistryInstallMigration(
-  params: PluginRegistryInstallMigrationParams = {},
-): PluginRegistryInstallMigrationPreflight {
+/** Decide whether Doctor should migrate the plugin registry in this environment. */
+export function preflightPluginRegistryDoctorMigration(
+  params: PluginRegistryDoctorMigrationParams = {},
+): PluginRegistryDoctorMigrationPreflight {
   const filePath = resolveInstalledPluginIndexStorePath(params);
   const persistedState = inspectPersistedInstalledPluginIndexInstallRecordsSync(params);
   if (persistedState.status === "invalid") {
@@ -120,7 +120,7 @@ export function preflightPluginRegistryInstallMigration(
 }
 
 async function readMigrationConfig(
-  params: PluginRegistryInstallMigrationParams,
+  params: PluginRegistryDoctorMigrationParams,
 ): Promise<OpenClawConfig> {
   if (params.config) {
     return params.config;
@@ -297,11 +297,11 @@ function listMigrationRelevantPluginRecords(params: {
   });
 }
 
-/** Persist a migrated plugin install registry from legacy config/install records when needed. */
-export async function migratePluginRegistryForInstall(
-  params: PluginRegistryInstallMigrationParams = {},
-): Promise<PluginRegistryInstallMigrationResult> {
-  const preflight = preflightPluginRegistryInstallMigration(params);
+/** Persist Doctor's migrated plugin registry from legacy config/install records when needed. */
+export async function migratePluginRegistryForDoctor(
+  params: PluginRegistryDoctorMigrationParams = {},
+): Promise<PluginRegistryDoctorMigrationResult> {
+  const preflight = preflightPluginRegistryDoctorMigration(params);
   if (preflight.action === "skip-existing") {
     return { status: "skip-existing", migrated: false, preflight };
   }

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { readFileSync as readFileSyncOriginal } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { writePackageDistInventory } from "../../scripts/lib/package-dist-inventory.ts";
@@ -14,7 +15,6 @@ import {
   pruneInstalledPackageDist,
   pruneLegacyPluginRuntimeDepsState,
   runBundledPluginPostinstall,
-  runPluginRegistryPostinstallMigration,
 } from "../../scripts/postinstall-bundled-plugins.mjs";
 import { createSourcePluginDependenciesFixture } from "./source-plugin-dependencies-fixture.js";
 import { createScriptTestHarness } from "./test-helpers.js";
@@ -193,102 +193,96 @@ describe("bundled plugin postinstall", () => {
     await expectPathExists(staleFile);
   });
 
-  it("migrates the plugin registry during postinstall from built dist contracts", async () => {
-    const packageRoot = await createTempDirAsync("openclaw-postinstall-registry-");
-    const log = { log: vi.fn(), warn: vi.fn() };
-    const migratePluginRegistryForInstall = vi.fn(async () => ({
-      status: "migrated",
-      migrated: true,
-      preflight: {
-        deprecationWarnings: [],
-      },
-      current: {
-        plugins: [{ pluginId: "demo" }],
-      },
-    }));
-    const importModule = vi.fn(async (specifier: string) => {
-      if (specifier.endsWith("/dist/commands/doctor/shared/plugin-registry-migration.js")) {
-        return { migratePluginRegistryForInstall };
-      }
-      throw new Error(`unexpected import: ${specifier}`);
-    });
-
-    const result = await runPluginRegistryPostinstallMigration({
+  it("does not run plugin registry migration during packaged postinstall", async () => {
+    const packageRoot = await createTempDirAsync("openclaw-postinstall-registry-skip-");
+    const scriptRoot = path.join(packageRoot, "scripts");
+    const migrationModule = path.join(
       packageRoot,
-      existsSync: vi.fn((filePath: string) =>
-        filePath.endsWith(
-          path.join("dist", "commands", "doctor", "shared", "plugin-registry-migration.js"),
-        ),
-      ),
-      importModule,
-      env: { OPENCLAW_HOME: "/tmp/home" },
-      log,
-    });
-
-    expect(result).toEqual({
-      current: {
-        plugins: [{ pluginId: "demo" }],
-      },
-      migrated: true,
-      preflight: {
-        deprecationWarnings: [],
-      },
-      status: "migrated",
-    });
-    expect(migratePluginRegistryForInstall).toHaveBeenCalledWith({
-      env: { OPENCLAW_HOME: "/tmp/home" },
-      packageRoot,
-    });
-    expect(log.log).toHaveBeenCalledWith(
-      "[postinstall] migrated plugin registry: 1 plugin(s) indexed",
+      "dist",
+      "commands",
+      "doctor",
+      "shared",
+      "plugin-registry-migration.js",
     );
-  });
+    const stateDir = path.join(packageRoot, "state-root");
+    const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+    await fs.mkdir(scriptRoot, { recursive: true });
+    await fs.mkdir(path.dirname(migrationModule), { recursive: true });
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    await fs.writeFile(
+      path.join(packageRoot, "package.json"),
+      '{"name":"openclaw","type":"module","version":"2026.8.1-beta.3"}\n',
+    );
+    await fs.copyFile(
+      fileURLToPath(new URL("../../scripts/postinstall-bundled-plugins.mjs", import.meta.url)),
+      path.join(scriptRoot, "postinstall-bundled-plugins.mjs"),
+    );
+    const database = new DatabaseSync(databasePath);
+    try {
+      database.exec(`
+        CREATE TABLE schema_meta (
+          meta_key TEXT NOT NULL PRIMARY KEY,
+          role TEXT NOT NULL,
+          schema_version INTEGER NOT NULL,
+          agent_id TEXT,
+          app_version TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        ) STRICT;
+        PRAGMA user_version = 5;
+        INSERT INTO schema_meta (
+          meta_key, role, schema_version, agent_id, app_version, created_at, updated_at
+        ) VALUES ('primary', 'global', 5, NULL, '2026.8.1-beta.2', 0, 0);
+      `);
+    } finally {
+      database.close();
+    }
+    await fs.writeFile(
+      migrationModule,
+      [
+        "import { DatabaseSync } from 'node:sqlite';",
+        "import { join } from 'node:path';",
+        "export async function migratePluginRegistryForInstall({ env }) {",
+        "  const db = new DatabaseSync(join(env.OPENCLAW_STATE_DIR, 'state', 'openclaw.sqlite'));",
+        "  try {",
+        "    db.exec(\"PRAGMA user_version = 9; UPDATE schema_meta SET schema_version = 9 WHERE meta_key = 'primary';\");",
+        "  } finally {",
+        "    db.close();",
+        "  }",
+        "  return { status: 'migrated', migrated: true, current: { plugins: [] } };",
+        "}",
+        "",
+      ].join("\n"),
+    );
 
-  it("does not migrate operator plugin state from a source checkout", async () => {
-    const packageRoot = "/source";
-    const existingPaths = new Set([
-      path.join(packageRoot, ".git"),
-      path.join(packageRoot, "src"),
-      path.join(packageRoot, "extensions"),
-      path.join(
-        packageRoot,
-        "dist",
-        "commands",
-        "doctor",
-        "shared",
-        "plugin-registry-migration.js",
-      ),
-    ]);
-    const importModule = vi.fn();
+    const result = spawnSync(
+      process.execPath,
+      [path.join(scriptRoot, "postinstall-bundled-plugins.mjs")],
+      {
+        cwd: packageRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: path.join(packageRoot, "home"),
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL: undefined,
+          OPENCLAW_HOME: path.join(packageRoot, "home"),
+          OPENCLAW_STATE_DIR: stateDir,
+          STATE_DIRECTORY: undefined,
+        },
+      },
+    );
 
-    await expect(
-      runPluginRegistryPostinstallMigration({
-        packageRoot,
-        existsSync: vi.fn((filePath: string) => existingPaths.has(filePath)),
-        importModule,
-        log: { log: vi.fn(), warn: vi.fn() },
-      }),
-    ).resolves.toEqual({
-      status: "skipped",
-      reason: "source-checkout",
-    });
-    expect(importModule).not.toHaveBeenCalled();
-  });
-
-  it("keeps plugin registry postinstall migration non-fatal when dist entries are unavailable", async () => {
-    const warn = vi.fn();
-
-    await expect(
-      runPluginRegistryPostinstallMigration({
-        packageRoot: "/pkg",
-        existsSync: vi.fn(() => false),
-        log: { log: vi.fn(), warn },
-      }),
-    ).resolves.toEqual({
-      status: "skipped",
-      reason: "missing-dist-entry",
-    });
-    expect(warn).not.toHaveBeenCalled();
+    expect(result.status, result.stderr).toBe(0);
+    const after = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(after.prepare("PRAGMA user_version").get()).toEqual({ user_version: 5 });
+      expect(
+        after.prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'").get(),
+      ).toEqual({ schema_version: 5 });
+    } finally {
+      after.close();
+    }
   });
 
   it("prunes stale dist files from packaged installs", async () => {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -400,8 +400,6 @@ function buildCoreDistEntries(): Record<string, string> {
     "task-registry-control.runtime": "src/tasks/task-registry-control.runtime.ts",
     "link-understanding/apply.runtime": "src/link-understanding/apply.runtime.ts",
     "media-understanding/apply.runtime": "src/media-understanding/apply.runtime.ts",
-    "commands/doctor/shared/plugin-registry-migration":
-      "src/commands/doctor/shared/plugin-registry-migration.ts",
     "commands/status.summary.runtime": "src/status/summary.runtime.ts",
     "infra/boundary-file-read": "src/infra/boundary-file-read.ts",
     "plugins/provider-discovery.runtime": "src/plugins/provider-discovery.runtime.ts",


### PR DESCRIPTION
Fixes #128782.

## What Problem This Solves

The published package postinstall imported Doctor's plugin-registry migration. Opening the writable shared state database during `npm install` could migrate its schema before the new binary ran. An older Gateway then rejected that database on restart, so reinstalling the old package was not a safe rollback.

The failing install action never executes the OpenClaw binary.

## Root Cause

The package lifecycle had a second owner for persisted registry repair:

1. `scripts/postinstall-bundled-plugins.mjs` dynamically imported the Doctor migration.
2. The migration wrote the installed-plugin index through the normal shared-state write path.
3. The write path upgraded an older SQLite schema before persisting the index.

## Fix

- Remove the Doctor migration import and call from package postinstall.
- Remove the standalone build entry that existed only for that dynamic import.
- Rename the internal migration contract to Doctor-owned names.
- Keep bundled-plugin package cleanup in postinstall.
- Keep all registry migration and repair behind explicit `openclaw doctor --fix` ownership.

## Rollback Safety

Package installation now leaves an older state database at its current schema, so the older binary can still open it. A database already migrated by an affected package still requires a compatible backup restore before an older binary can run.

## Evidence

Published-package reproduction used an isolated copy created by `openclaw@2026.7.2-beta.4`:

- Before install: `user_version=5`, `schema_version=5`, SHA-256 `ee715a43d651c6c42d95a7e081688c8d2feedac827c3bfcb6d57bd21d7390827`.
- `npm install openclaw@2026.8.1` changed the copy to `user_version=15`, `schema_version=15`, SHA-256 `18b510aa37aef9b71343a71b8fce10a0f8738730e9d11eba0dd12054786660a4`.
- The older Doctor then failed with `SqliteSchemaVersionError` because it supports schema 5.
- The untouched schema-5 copy still opened successfully with the older Doctor.

Current-main and exact-head product-path proof uses the direct packaged postinstall entrypoint with a real SQLite mutation sentinel:

- Current main `644c895bdbe1043acc0acf1677c9076d5df4a8e2`: schema 5 changed to 9.
- Exact head `eb1ac32a08680491a96b42db729c8517e222e87b`: schema 5 remained 5.

Focused validation on the exact head:

- `node scripts/run-vitest.mjs test/scripts/postinstall-bundled-plugins.test.ts src/commands/doctor/shared/plugin-registry-migration.test.ts src/commands/doctor-plugin-registry.test.ts`: 57 passed.
- Targeted `oxfmt` and `oxlint`: passed.
- `git diff --check`: passed.
- Local TypeScript typecheck and package build were not run because this host forbids them; exact-head CI owns both gates.

## Change Size

- Production/tooling: 59 lines removed, no net additions.
- Tests: 86 additions and 92 removals, net 6 lines removed.
