### PR TITLE
feat(memory): add governed lifecycle-aware retrieval

### DIFF
--- a/extensions/memory-core/src/memory-search-tool-query.ts
+++ b/extensions/memory-core/src/memory-search-tool-query.ts
@@ -130,9 +130,10 @@ export async function executeMemorySearchToolQuery(params: {
         : "memory index identity is missing or mismatched"
       : undefined;
   if (pausedIndexIdentityReason) {
+    const rawResults: MemorySearchResult[] = [];
     return {
       status,
-      rawResults: [] as MemorySearchResult[],
+      rawResults,
       pausedIndexIdentityReason,
       searchMode: undefined,
       debug: undefined,

--- a/extensions/memory-core/src/memory-search-tool-query.ts
+++ b/extensions/memory-core/src/memory-search-tool-query.ts
@@ -2,6 +2,7 @@
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type {
   MemorySearchManager,
+  MemorySearchResult,
   MemorySearchRuntimeDebug,
   MemorySource,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
@@ -131,7 +132,7 @@ export async function executeMemorySearchToolQuery(params: {
   if (pausedIndexIdentityReason) {
     return {
       status,
-      rawResults: [],
+      rawResults: [] as MemorySearchResult[],
       pausedIndexIdentityReason,
       searchMode: undefined,
       debug: undefined,

--- a/extensions/memory-core/src/memory-tool-contract.ts
+++ b/extensions/memory-core/src/memory-tool-contract.ts
@@ -27,6 +27,7 @@ const MemorySearchSchema = {
     maxResults: { type: "integer", minimum: 1 },
     minScore: { type: "number" },
     corpus: { type: "string", enum: ["memory", "wiki", "all", "sessions"] },
+    lifecycle: { type: "string", enum: ["auto", "current", "all"] },
   },
   required: ["query"],
   additionalProperties: false,
@@ -87,7 +88,7 @@ export const MEMORY_SEARCH_TOOL_CONTRACT = {
   name: "memory_search",
   parameters: MemorySearchSchema,
   describe: ({ search }: MemorySourceContract) =>
-    `Mandatory recall step: semantically search ${search} before answering questions about prior work, decisions, dates, people, preferences, or todos. Optional \`corpus=wiki\` or \`corpus=all\` also searches registered compiled-wiki supplements. \`corpus=memory\` restricts hits to indexed memory files (excludes session transcript chunks from ranking). \`corpus=sessions\` restricts hits to the session corpus under the same visibility rules as session history tools. ${SEARCH_CORPUS_OUTCOME_GUIDANCE} If response has disabled=true or stale=true, tell the user and include the warning/action guidance.`,
+    `Mandatory recall step: semantically search ${search} before answering questions about prior work, decisions, dates, people, preferences, or todos. Optional \`corpus=wiki\` or \`corpus=all\` also searches registered compiled-wiki supplements. \`corpus=memory\` restricts hits to indexed memory files (excludes session transcript chunks from ranking). \`corpus=sessions\` restricts hits to the session corpus under the same visibility rules as session history tools. \`lifecycle=current\` prefers active governed semantic records and excludes superseded/historical records; \`auto\` applies that behavior to current/latest/now/today queries, while \`all\` preserves full lineage. ${SEARCH_CORPUS_OUTCOME_GUIDANCE} If response has disabled=true or stale=true, tell the user and include the warning/action guidance.`,
 } as const;
 
 export const MEMORY_GET_TOOL_CONTRACT = {

--- a/extensions/memory-core/src/semantic-lifecycle.test.ts
+++ b/extensions/memory-core/src/semantic-lifecycle.test.ts
@@ -1,0 +1,73 @@
+import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+import { describe, expect, it, vi } from "vitest";
+import {
+  filterCurrentSemanticLifecycle,
+  shouldApplyCurrentLifecycle,
+} from "./semantic-lifecycle.js";
+
+function hit(path: string, score: number, source: "memory" | "sessions" = "memory") {
+  return {
+    path,
+    startLine: 1,
+    endLine: 2,
+    score,
+    snippet: path,
+    source,
+  } satisfies MemorySearchResult;
+}
+
+function frontmatter(status: string): string {
+  return `---\nschema_version: openclaw.semantic_memory.v2\nstatus: ${status}\n---\n# Record`;
+}
+
+describe("semantic lifecycle filtering", () => {
+  it("detects current-state intent unless explicitly disabled", () => {
+    expect(shouldApplyCurrentLifecycle({ query: "what is the current gate?" })).toBe(true);
+    expect(shouldApplyCurrentLifecycle({ query: "show the history", mode: "current" })).toBe(true);
+    expect(shouldApplyCurrentLifecycle({ query: "current gate", mode: "all" })).toBe(false);
+  });
+
+  it("ranks active before review states and excludes historical lifecycle states", async () => {
+    const hits = [
+      hit("superseded.md", 0.99),
+      hit("review.md", 0.98),
+      hit("active.md", 0.8),
+      hit("legacy.md", 0.79),
+      hit("sessions/one.jsonl", 0.7, "sessions"),
+      hit("historical.md", 0.6),
+    ];
+    const content = new Map([
+      ["superseded.md", frontmatter("superseded")],
+      ["review.md", frontmatter("review_due")],
+      ["active.md", frontmatter("active")],
+      ["legacy.md", "# Legacy"],
+      ["historical.md", frontmatter("historical")],
+    ]);
+    const readFile = vi.fn(async ({ relPath }: { relPath: string }) => ({
+      text: content.get(relPath) ?? "",
+    }));
+
+    const result = await filterCurrentSemanticLifecycle({
+      query: "current state",
+      hits,
+      readFile,
+    });
+
+    expect(result.map((entry) => entry.path)).toEqual([
+      "active.md",
+      "review.md",
+      "legacy.md",
+      "sessions/one.jsonl",
+    ]);
+    expect(readFile).toHaveBeenCalledTimes(5);
+  });
+
+  it("preserves original results when current lifecycle filtering is not requested", async () => {
+    const hits = [hit("historical.md", 0.9)];
+    const readFile = vi.fn();
+    await expect(
+      filterCurrentSemanticLifecycle({ query: "show history", hits, readFile }),
+    ).resolves.toBe(hits);
+    expect(readFile).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/memory-core/src/semantic-lifecycle.ts
+++ b/extensions/memory-core/src/semantic-lifecycle.ts
@@ -1,0 +1,118 @@
+// Memory Core plugin module implements governed semantic-memory lifecycle filtering.
+import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+
+export type MemoryLifecycleMode = "auto" | "current" | "all";
+
+type GovernedLifecycle = "active" | "review_due" | "disputed" | "superseded" | "historical";
+
+const CURRENT_INTENT_RE = /\b(current|currently|latest|now|today|presently)\b/iu;
+const GOVERNED_SCHEMA = "openclaw.semantic_memory.v2";
+const FRONTMATTER_READ_LINES = 40;
+
+function parseGovernedLifecycle(text: string): GovernedLifecycle | undefined {
+  const lines = text.split(/\r?\n/u);
+  if (lines[0]?.trim() !== "---") {
+    return undefined;
+  }
+  const end = lines.indexOf("---", 1);
+  if (end < 0) {
+    return undefined;
+  }
+  let schema: string | undefined;
+  let status: string | undefined;
+  for (const line of lines.slice(1, end)) {
+    const separator = line.indexOf(":");
+    if (separator < 1) {
+      continue;
+    }
+    const key = line.slice(0, separator).trim();
+    const value = line
+      .slice(separator + 1)
+      .trim()
+      .replace(/^(["'])(.*)\1$/u, "$2");
+    if (key === "schema_version") {
+      schema = value;
+    } else if (key === "status") {
+      status = value;
+    }
+  }
+  if (schema !== GOVERNED_SCHEMA) {
+    return undefined;
+  }
+  return status === "active" ||
+    status === "review_due" ||
+    status === "disputed" ||
+    status === "superseded" ||
+    status === "historical"
+    ? status
+    : undefined;
+}
+
+export function shouldApplyCurrentLifecycle(params: {
+  query: string;
+  mode?: MemoryLifecycleMode;
+}): boolean {
+  if (params.mode === "all") {
+    return false;
+  }
+  return params.mode === "current" || CURRENT_INTENT_RE.test(params.query);
+}
+
+export async function filterCurrentSemanticLifecycle(params: {
+  query: string;
+  mode?: MemoryLifecycleMode;
+  hits: MemorySearchResult[];
+  readFile: (params: {
+    relPath: string;
+    from?: number;
+    lines?: number;
+  }) => Promise<{ text: string }>;
+}): Promise<MemorySearchResult[]> {
+  if (!shouldApplyCurrentLifecycle({ query: params.query, mode: params.mode })) {
+    return params.hits;
+  }
+
+  const lifecycleByPath = new Map<string, GovernedLifecycle | undefined>();
+  await Promise.all(
+    Array.from(
+      new Set(params.hits.filter((hit) => hit.source === "memory").map((hit) => hit.path)),
+    ).map(async (path) => {
+      try {
+        // Lifecycle reads are opt-in/intent-gated and bounded to frontmatter. The manager
+        // owns path resolution for both builtin and QMD backends.
+        const result = await params.readFile({
+          relPath: path,
+          from: 1,
+          lines: FRONTMATTER_READ_LINES,
+        });
+        lifecycleByPath.set(path, parseGovernedLifecycle(result.text));
+      } catch {
+        // A lifecycle read must not hide an otherwise valid ungoverned memory hit.
+        lifecycleByPath.set(path, undefined);
+      }
+    }),
+  );
+
+  const rank = (hit: MemorySearchResult): number => {
+    if (hit.source !== "memory") {
+      return 2;
+    }
+    const lifecycle = lifecycleByPath.get(hit.path);
+    if (lifecycle === "active") {
+      return 0;
+    }
+    if (lifecycle === "review_due" || lifecycle === "disputed") {
+      return 1;
+    }
+    return 2;
+  };
+
+  return params.hits
+    .filter((hit) => {
+      const lifecycle = hit.source === "memory" ? lifecycleByPath.get(hit.path) : undefined;
+      return lifecycle !== "superseded" && lifecycle !== "historical";
+    })
+    .map((hit, index) => ({ hit, index }))
+    .toSorted((left, right) => rank(left.hit) - rank(right.hit) || left.index - right.index)
+    .map(({ hit }) => hit);
+}

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -13,6 +13,7 @@ import {
   setMemoryCloseImpl,
   setMemoryCustomStatus,
   setMemoryPendingSyncSources,
+  setMemoryReadFileImpl,
   setMemorySearchImpl,
   setMemorySearchManagerImpl,
   setMemorySourceCounts,
@@ -63,6 +64,10 @@ describe("memory tool schemas", () => {
     expect(MEMORY_GET_TOOL_CONTRACT.parameters.properties.corpus).toEqual({
       type: "string",
       enum: ["memory", "wiki", "all"],
+    });
+    expect(MEMORY_SEARCH_TOOL_CONTRACT.parameters.properties.lifecycle).toEqual({
+      type: "string",
+      enum: ["auto", "current", "all"],
     });
   });
 });
@@ -129,6 +134,53 @@ describe("memory_search unavailable payloads", () => {
     });
 
     expect(seenMinScore).toBe(0.8);
+  });
+
+  it("overfetches and filters governed lifecycle records for current-state queries", async () => {
+    let seenMaxResults: number | undefined;
+    setMemorySearchImpl(async (opts) => {
+      seenMaxResults = opts?.maxResults;
+      return [
+        {
+          path: "memory/semantic/old.md",
+          startLine: 1,
+          endLine: 2,
+          score: 0.99,
+          snippet: "old",
+          source: "memory" as const,
+        },
+        {
+          path: "memory/semantic/current.md",
+          startLine: 1,
+          endLine: 2,
+          score: 0.8,
+          snippet: "current",
+          source: "memory" as const,
+        },
+      ];
+    });
+    setMemoryReadFileImpl(async (params) => ({
+      text: `---\nschema_version: openclaw.semantic_memory.v2\nstatus: ${
+        params.relPath.endsWith("old.md") ? "superseded" : "active"
+      }\n---`,
+      path: params.relPath,
+    }));
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+      },
+    });
+
+    const result = await tool.execute("current-lifecycle", {
+      query: "what is the current gate?",
+      maxResults: 2,
+    });
+
+    expect(seenMaxResults).toBe(8);
+    expect((result.details as { results?: Array<{ path: string }> }).results).toEqual([
+      expect.objectContaining({ path: "memory/semantic/current.md" }),
+    ]);
   });
 
   it("preserves manager ranking when public scores omit path precedence", async () => {

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -160,6 +160,7 @@ describe("memory_search unavailable payloads", () => {
       ];
     });
     setMemoryReadFileImpl(async (params) => ({
+      status: "ok",
       text: `---\nschema_version: openclaw.semantic_memory.v2\nstatus: ${
         params.relPath.endsWith("old.md") ? "superseded" : "active"
       }\n---`,

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -43,6 +43,11 @@ import {
   resolveMemorySearchAbortError,
   runMemorySearchWithDeadline,
 } from "./memory/search-deadline.js";
+import {
+  filterCurrentSemanticLifecycle,
+  shouldApplyCurrentLifecycle,
+  type MemoryLifecycleMode,
+} from "./semantic-lifecycle.js";
 import { recordShortTermRecalls } from "./short-term-promotion.js";
 import {
   decorateCitations,
@@ -98,6 +103,17 @@ function readCorpusParam<T extends string>(
     return raw as T;
   }
   throw new Error(`corpus must be one of: ${allowed.join(", ")}`);
+}
+
+function readLifecycleParam(rawParams: Record<string, unknown>): MemoryLifecycleMode | undefined {
+  const raw = readStringParam(rawParams, "lifecycle");
+  if (raw === undefined) {
+    return undefined;
+  }
+  if (raw === "auto" || raw === "current" || raw === "all") {
+    return raw;
+  }
+  throw new Error("lifecycle must be one of: auto, current, all");
 }
 
 function resolveMemorySearchToolCooldownKey(options: {
@@ -283,6 +299,7 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
         const query = readStringParam(rawParams, "query", { required: true });
         const maxResults = readPositiveIntegerParam(rawParams, "maxResults");
         const minScore = readFiniteNumberParam(rawParams, "minScore");
+        const lifecycleMode = readLifecycleParam(rawParams);
         const modelRequestedCorpus = readCorpusParam(rawParams, [
           "memory",
           "wiki",
@@ -347,7 +364,7 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
                   : requestedCorpus === "memory"
                     ? ["memory"]
                     : undefined;
-              return await executeMemorySearchToolQuery({
+              const executed = await executeMemorySearchToolQuery({
                 initialManager: { manager: memory.manager, managerMs: memory.debug?.managerMs },
                 refreshManager: async () => {
                   const refreshed = trackMemoryManager(
@@ -364,7 +381,9 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
                 },
                 query: {
                   text: query,
-                  resultLimit: maxResults ?? settings?.query.maxResults ?? 10,
+                  resultLimit: shouldApplyCurrentLifecycle({ query, mode: lifecycleMode })
+                    ? Math.max(1, maxResults ?? settings?.query.maxResults ?? 10) * 4
+                    : (maxResults ?? settings?.query.maxResults ?? 10),
                   minScore,
                   explicitSources,
                   defaultSources,
@@ -377,6 +396,15 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
                 visibility: { cfg, agentId, sandboxed: options.sandboxed === true },
                 signal,
               });
+              return {
+                ...executed,
+                rawResults: await filterCurrentSemanticLifecycle({
+                  query,
+                  mode: lifecycleMode,
+                  hits: executed.rawResults,
+                  readFile: async (readParams) => await memory.manager.readFile(readParams),
+                }),
+              };
             },
           });
           if (attempted.outcome !== "ok") {


### PR DESCRIPTION
## Summary

- add governed semantic-memory lifecycle filtering with `auto`, `current`, and `all` modes
- rank active records first for current-state queries while preserving review states
- exclude superseded and historical records from current-state retrieval without deleting history
- expose the lifecycle option through both eager and lazy-loaded memory tool schemas

## What Problem This Solves

Governed semantic records retain their revision lineage. Without native lifecycle-aware retrieval, superseded records can outrank the active state and produce stale answers. This change makes current-state retrieval explicit while retaining `all` for audits and historical analysis.

## Evidence

- `pnpm exec vitest run extensions/memory-core/src/semantic-lifecycle.test.ts extensions/memory-core/src/tools.test.ts extensions/memory-core/index.test.ts`
- 3 test files passed; 69 tests passed
- `git diff --check`
- previously validated in a local production build and live A/B retrieval against governed records

## Compatibility

The lifecycle parameter is optional. `auto` preserves intent-sensitive behavior, `current` explicitly selects active/current state, and `all` preserves the full lineage.
