### PR TITLE
fix(ui): align sidebar unread dot with pull-request rows

### DIFF
--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -405,6 +405,101 @@ suite.define(() => {
     }
   });
 
+  it("keeps the trailing unread dot on one axis with and without a pull-request icon", async () => {
+    const plainKey = "agent:main:unread-plain";
+    const pullRequestKey = "agent:main:unread-pr";
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD],
+      methodResponses: {
+        [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD]: { subscribed: true },
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:main", "Main", Date.now()),
+          sessionRow(plainKey, "Unread plain", Date.now() - 1, { unread: true }),
+          sessionRow(pullRequestKey, "Unread with PR", Date.now() - 2, {
+            unread: true,
+            worktree: {
+              id: "unread-pr-worktree",
+              branch: "fix/unread-pr",
+              repoRoot: "/tmp/openclaw",
+            },
+          }),
+        ]),
+      },
+      sessionKey: "agent:main:main",
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      // Worktree rows land in the Coding zone, which starts collapsed.
+      const codingToggle = page.locator(
+        '[data-session-section="work"] .sidebar-session-group-toggle',
+      );
+      await codingToggle.waitFor({ state: "visible" });
+      await codingToggle.click();
+      await expect
+        .poll(async () => {
+          const requests = await gateway.getRequests(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD);
+          return requests.some((request) => {
+            const sessionKeys = requireRecord(request.params).sessionKeys;
+            return Array.isArray(sessionKeys) && sessionKeys.includes(pullRequestKey);
+          });
+        })
+        .toBe(true);
+      await gateway.emitGatewayEvent(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, {
+        sessions: {
+          [pullRequestKey]: {
+            pullRequests: [
+              {
+                branch: "fix/unread-pr",
+                number: 1,
+                owner: "openclaw",
+                repo: "openclaw",
+                state: "merged",
+                title: "Unread row pull request",
+                url: "https://example.test/openclaw/openclaw/pull/1",
+              },
+            ],
+            rateLimited: false,
+            status: "ready",
+          },
+        },
+      });
+
+      const plainRow = page.locator(`[data-session-key="${plainKey}"]`);
+      const pullRequestRow = page.locator(`[data-session-key="${pullRequestKey}"]`);
+      await plainRow.waitFor({ state: "visible", timeout: 10_000 });
+      await expect
+        .poll(() => pullRequestRow.locator("[data-session-pr-state='merged']").isVisible())
+        .toBe(true);
+
+      const dotInsetFromRowRight = async (row: typeof plainRow) => {
+        const [rowBounds, dotBounds] = await Promise.all([
+          row.boundingBox(),
+          row.locator(".session-unread-dot").boundingBox(),
+        ]);
+        if (!rowBounds || !dotBounds) {
+          throw new Error("Expected visible row and unread dot geometry");
+        }
+        return rowBounds.x + rowBounds.width - (dotBounds.x + dotBounds.width / 2);
+      };
+      // The dot is the trailing glyph either way, so a PR icon ahead of it must
+      // not pull it off the axis dot-only rows share with the action icons.
+      // Centring the whole endcap group as one box moved it 3.5px inboard.
+      expect(await dotInsetFromRowRight(pullRequestRow)).toBeCloseTo(
+        await dotInsetFromRowRight(plainRow),
+        0,
+      );
+    } finally {
+      await context.close();
+    }
+  });
+
   it("draws every row glyph at one size", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5758,19 +5758,18 @@ td.data-table-key-col {
   pointer-events: none;
 }
 
-/* Sized to its glyphs. The old 24px box matched the action button this used to
-   trade places with, which padded a 7px unread dot with 8.5px a side and broke
-   the endcap's even 6px rhythm. Nothing trades now, so it sizes to content. */
+/* One 14px track per glyph puts the 16px PR icon, 11px ring, and 7px unread dot
+   each on the action-icon axis the endcap padding aligns to. Centring them as
+   one box held only for a single glyph: a PR icon ahead of the trailing dot
+   pushed it 3.5px inboard of the dot-only rows. 14px, not the 24px action-button
+   box, which padded a 7px dot with 8.5px a side and broke the 6px rhythm. */
 .session-row-state {
-  display: inline-flex;
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 14px;
   align-items: center;
-  justify-content: center;
+  justify-items: center;
   gap: var(--row-glyph-gap, 6px);
-  /* The ring and the unread dot are bare shapes, not icons in a box, so
-     right-flush they hung 2-4px past the icon column above them. One glyph-wide
-     floor plus the centring above puts whatever the row is showing on the same
-     axis as the icons. */
-  min-width: 14px;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the red unread dot in the sidebar session list sat off-axis on rows that also carry a pull-request icon. On a plain unread row the dot lines up with the row action icons above it, but on an unread row whose worktree has an open or merged PR the dot shifted 3.5px inboard, so scanning down the sidebar showed a ragged column of dots instead of one straight line.

## Why This Change Was Made

The trailing `.session-row-state` box centred its contents as a single flex box with a `min-width` floor. That floor only lands the glyph on the icon column when the box holds exactly one glyph; put a 16px PR icon ahead of the 7px dot and the pair centres as a unit, pushing the dot inward by half the extra content. Making the box a grid with one fixed 14px track per glyph gives every glyph — PR icon, run ring, unread dot — its own centred column, so the trailing glyph keeps that axis regardless of what precedes it. The 14px track is the same column width the endcap padding already aligns to, so no other row geometry moves.

## User Impact

Unread dots now form one straight column down the sidebar in every combination: dot only, PR icon plus dot, and icon only. No behavior, accessibility labels, or other row spacing changed.

## Evidence

Before / after, dark theme, 2x, against the mocked Gateway (`pnpm dev:ui:mock`). Top row is unread with a merged-PR icon; the rows below it are dot-only.

**Before** — the dot on the merged-PR row sits inboard of the dots below it:

![before](https://github.com/user-attachments/assets/264de7b6-1747-4d91-90ff-485200a16873)

**After** — every dot shares one axis:

![after](https://github.com/user-attachments/assets/aff3f13e-5428-4d78-94fa-a318fc4e2dce)

Measured dot-centre inset from each row's right edge, same rows and viewport:

| row | before | after |
| --- | --- | --- |
| unread + merged PR icon | 12.5px | 16.0px |
| unread only | 16.0px | 16.0px |
| PR icon only | 16.0px | 16.0px |

Regression test `keeps the trailing unread dot on one axis with and without a pull-request icon` added to `ui/src/e2e/session-management.trailing-state.e2e.test.ts`, next to the existing trailing-column pitch tests that own this invariant. It drives real PR state through `controlUi.sessionPullRequests.subscribe` rather than stubbing the host, fails on pre-fix code for the intended reason (`expected 12.5 to be close to 16, received difference is 3.5`), and passes with the fix.

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.trailing-state.e2e.test.ts
Test Files  1 passed (1)
     Tests  9 passed (9)
```

`node scripts/check-changed.mjs` (lanes: coreTests, ui) exits 0 — all guards, both typecheck lanes, core lint, and UI style lint green. Fresh Codex autoreview on the committed change reports no accepted or actionable findings.

Production LOC delta: `ui/src/styles/components.css` +9/-10 (net -1). The remaining +95 is the regression test.
