### PR TITLE
fix(discord): honor silent sticker and thread-reply delivery

### DIFF
--- a/extensions/discord/src/actions/handle-action.guild-admin.ts
+++ b/extensions/discord/src/actions/handle-action.guild-admin.ts
@@ -445,7 +445,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         content,
         mediaUrl: mediaUrl ?? undefined,
         replyTo: replyTo ?? undefined,
-        silent: readBooleanParam(actionParams, "silent") === true,
+        ...(readBooleanParam(actionParams, "silent") === true ? { silent: true } : {}),
       },
       cfg,
       actionOptions,

--- a/extensions/discord/src/actions/handle-action.guild-admin.ts
+++ b/extensions/discord/src/actions/handle-action.guild-admin.ts
@@ -6,6 +6,7 @@ import {
   readStringArrayParam,
   readStringParam,
 } from "openclaw/plugin-sdk/agent-runtime";
+import { readBooleanParam } from "openclaw/plugin-sdk/boolean-param";
 import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { handleDiscordAction } from "../../action-runtime-api.js";
@@ -444,6 +445,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         content,
         mediaUrl: mediaUrl ?? undefined,
         replyTo: replyTo ?? undefined,
+        silent: readBooleanParam(actionParams, "silent") === true,
       },
       cfg,
       actionOptions,

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -650,7 +650,6 @@ describe("handleDiscordMessageAction", () => {
         content: "thread update",
         mediaUrl: "/tmp/agent-root/report.md",
         replyTo: undefined,
-        silent: false,
       },
       cfg,
       options: {

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -650,6 +650,7 @@ describe("handleDiscordMessageAction", () => {
         content: "thread update",
         mediaUrl: "/tmp/agent-root/report.md",
         replyTo: undefined,
+        silent: false,
       },
       cfg,
       options: {

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -483,7 +483,7 @@ export async function handleDiscordMessageAction(
         to,
         stickerIds,
         content: readStringParam(params, "message"),
-        silent: readBooleanParam(params, "silent") === true,
+        ...(readBooleanParam(params, "silent") === true ? { silent: true } : {}),
       },
       cfg,
       actionOptions,

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -483,6 +483,7 @@ export async function handleDiscordMessageAction(
         to,
         stickerIds,
         content: readStringParam(params, "message"),
+        silent: readBooleanParam(params, "silent") === true,
       },
       cfg,
       actionOptions,

--- a/extensions/discord/src/actions/runtime.messaging.send.ts
+++ b/extensions/discord/src/actions/runtime.messaging.send.ts
@@ -188,7 +188,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
       await discordMessagingActionRuntime.sendStickerDiscord(
         to,
         stickerIds,
-        ctx.withOpts({ content, silent: ctx.params.silent === true }),
+        ctx.withOpts({ content, ...(ctx.params.silent === true ? { silent: true } : {}) }),
       );
       return jsonResult({ ok: true });
     }
@@ -417,7 +417,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
           mediaLocalRoots: ctx.options?.mediaLocalRoots,
           mediaReadFile: ctx.options?.mediaReadFile,
           reply: resolveActionReplyReference(ctx, replyTo),
-          silent: ctx.params.silent === true,
+          ...(ctx.params.silent === true ? { silent: true } : {}),
         },
       );
       return jsonResult({ ok: true, result });

--- a/extensions/discord/src/actions/runtime.messaging.send.ts
+++ b/extensions/discord/src/actions/runtime.messaging.send.ts
@@ -188,7 +188,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
       await discordMessagingActionRuntime.sendStickerDiscord(
         to,
         stickerIds,
-        ctx.withOpts({ content }),
+        ctx.withOpts({ content, silent: ctx.params.silent === true }),
       );
       return jsonResult({ ok: true });
     }
@@ -417,6 +417,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
           mediaLocalRoots: ctx.options?.mediaLocalRoots,
           mediaReadFile: ctx.options?.mediaReadFile,
           reply: resolveActionReplyReference(ctx, replyTo),
+          silent: ctx.params.silent === true,
         },
       );
       return jsonResult({ ok: true, result });

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -2130,15 +2130,24 @@ describe("handleDiscordMessagingAction", () => {
       label: "sendMessageDiscord",
     },
   ])(
-    "preserves silent delivery for the $action message action",
+    "preserves silent delivery and default options for the $action message action",
     async ({ action, params, sender, label }) => {
-      await handleDiscordMessageAction({
-        action,
-        params: { ...params, silent: true },
-        cfg: DISCORD_TEST_CFG,
-      });
+      for (const silent of [true, false, undefined]) {
+        const send = sender();
+        send.mockClear();
+        await handleDiscordMessageAction({
+          action,
+          params: { ...params, ...(silent === undefined ? {} : { silent }) },
+          cfg: DISCORD_TEST_CFG,
+        });
 
-      expect(mockObjectArg(sender(), label, 0, 2).silent).toBe(true);
+        const sendOptions = mockObjectArg(send, label, 0, 2);
+        if (silent === true) {
+          expect(sendOptions.silent).toBe(true);
+        } else {
+          expect(sendOptions).not.toHaveProperty("silent");
+        }
+      }
     },
   );
 

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -2116,6 +2116,32 @@ describe("handleDiscordMessagingAction", () => {
     expect(voiceOptions.mediaReadFile).toBe(mediaReadFile);
   });
 
+  it.each([
+    {
+      action: "sticker" as const,
+      params: { to: "channel:123", stickerId: ["sticker-1"] },
+      sender: () => discordSendMocks.sendStickerDiscord,
+      label: "sendStickerDiscord",
+    },
+    {
+      action: "thread-reply" as const,
+      params: { threadId: "thread-123", message: "quiet thread update" },
+      sender: () => sendMessageDiscord,
+      label: "sendMessageDiscord",
+    },
+  ])(
+    "preserves silent delivery for the $action message action",
+    async ({ action, params, sender, label }) => {
+      await handleDiscordMessageAction({
+        action,
+        params: { ...params, silent: true },
+        cfg: DISCORD_TEST_CFG,
+      });
+
+      expect(mockObjectArg(sender(), label, 0, 2).silent).toBe(true);
+    },
+  );
+
   it("preserves reader-free workspace authority for thread replies and ignores forged action data", async () => {
     const mediaAccess = {
       localRoots: ["/tmp/agent-workspace"],

--- a/extensions/discord/src/send.assets-and-retries.test-support.ts
+++ b/extensions/discord/src/send.assets-and-retries.test-support.ts
@@ -184,7 +184,11 @@ export function registerSendAssetsAndRetriesTests(deps: SendAssetsAndRetriesDeps
       expect(requestBody(postMock as unknown as MockCallSource).nonce).toMatch(/^[0-9a-f]{24}$/);
     });
 
-    it("combines silent and suppress-embeds flags for stickers", async () => {
+    it.each([
+      { silent: true, flags: MessageFlags.SuppressEmbeds | MessageFlags.SuppressNotifications },
+      { silent: false, flags: MessageFlags.SuppressEmbeds },
+      { silent: undefined, flags: MessageFlags.SuppressEmbeds },
+    ])("preserves sticker notification flags for silent=$silent", async ({ silent, flags }) => {
       const { rest, postMock } = makeDiscordRest();
       postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
 
@@ -193,12 +197,10 @@ export function registerSendAssetsAndRetriesTests(deps: SendAssetsAndRetriesDeps
         rest,
         token: "t",
         content: "https://example.com",
-        silent: true,
+        ...(silent === undefined ? {} : { silent }),
       });
 
-      expect(requestBody(postMock as unknown as MockCallSource).flags).toBe(
-        MessageFlags.SuppressEmbeds | MessageFlags.SuppressNotifications,
-      );
+      expect(requestBody(postMock as unknown as MockCallSource).flags).toBe(flags);
     });
 
     it("reuses a single nonce across a retried 502 for stickers", async () => {

--- a/extensions/discord/src/send.assets-and-retries.test-support.ts
+++ b/extensions/discord/src/send.assets-and-retries.test-support.ts
@@ -184,6 +184,23 @@ export function registerSendAssetsAndRetriesTests(deps: SendAssetsAndRetriesDeps
       expect(requestBody(postMock as unknown as MockCallSource).nonce).toMatch(/^[0-9a-f]{24}$/);
     });
 
+    it("combines silent and suppress-embeds flags for stickers", async () => {
+      const { rest, postMock } = makeDiscordRest();
+      postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+
+      await sendStickerDiscord("channel:789", ["123"], {
+        cfg: discordTestConfig,
+        rest,
+        token: "t",
+        content: "https://example.com",
+        silent: true,
+      });
+
+      expect(requestBody(postMock as unknown as MockCallSource).flags).toBe(
+        MessageFlags.SuppressEmbeds | MessageFlags.SuppressNotifications,
+      );
+    });
+
     it("reuses a single nonce across a retried 502 for stickers", async () => {
       const { rest, postMock } = makeDiscordRest();
       postMock

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -450,7 +450,7 @@ export async function sendStickerDiscord(
   const context = await resolveDiscordStructuredSendContext(to, opts);
   const { rewrittenContent, suppressEmbeds } = context;
   const stickers = normalizeStickerIds(stickerIds);
-  const flags = resolveDiscordMessageFlags({ suppressEmbeds });
+  const flags = resolveDiscordMessageFlags({ silent: opts.silent, suppressEmbeds });
   const body = {
     content: rewrittenContent || undefined,
     sticker_ids: stickers,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents sending Discord stickers or thread replies with `silent: true` would still trigger desktop and push notifications, even though ordinary messages, polls, components, and voice messages correctly honored the existing silent-delivery option.

## Why This Change Was Made

Preserve the existing silent-delivery option across the Discord action adapter, its private action runtime, and the channel-owned outbound serializer for both affected send paths. Reuse Discord's existing notification-suppression flag and keep the command-line surface, configuration, permissions, and action result contracts unchanged.

## User Impact

Discord sticker sends and thread replies requested through the existing agent message tool now arrive without push or desktop notifications when `silent: true` is set. Existing notifications, link-embed suppression, normal messages, polls, components, and voice messages retain their current behavior.

## Evidence

- Before the fix, focused owner-boundary regression tests failed in all three intended places: sticker actions and thread replies lost `silent: true`, and sticker REST payloads emitted flags `4` instead of `4100`; the other 205 existing tests passed.
- After the fix, `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/discord/src/actions/runtime.test.ts extensions/discord/src/actions/handle-action.test.ts extensions/discord/src/send.creates-thread.test.ts` passed all **245 tests**.
- Independent real-client proof exercised **20 production action-adapter → Discord RequestClient serialized HTTP cases** covering stickers, thread replies, ordinary messages, and polls; `silent: true` produced notification-suppression flags `4100`/`4096`, while `false` or omission preserved flags `4`/`0` with both link-embed settings.
- Posting deliberately unsuppressed control messages to a real Discord channel would trigger live recipient notifications, so the production HTTP-client boundary was used to verify Discord's documented wire contract without creating user-visible side effects.
- Changed-file formatting and direct extension-scoped lint both passed. The full local changed gate completed its format, plugin boundary, doctor contract, dependency, and dead-export checks, then encountered unrelated pre-existing type errors from stale shared worktree dependencies; no touched Discord file produced a diagnostic. Clean hosted CI is the authoritative full typecheck and lint gate.
- Fresh independent and authenticated full-diff reviews reported no actionable findings.
