### PR TITLE
fix(agents): make terminal CLI failures diagnosable

### DIFF
--- a/src/agents/cli-runner.terminal-failure-log.test.ts
+++ b/src/agents/cli-runner.terminal-failure-log.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
+import { createTestAdmittedRunContext } from "./admitted-run-context.test-support.js";
+import { testing as cliBackendsTesting } from "./cli-backends.test-support.js";
+import { runCliAgent } from "./cli-runner.js";
+import { cliBackendLog } from "./cli-runner/log.js";
+
+const tempDirs = new Set<string>();
+
+afterEach(() => {
+  cliBackendsTesting.resetDepsForTest();
+  vi.restoreAllMocks();
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+describe("CLI terminal failure logging", () => {
+  it("records one redacted warning after a real CLI subprocess exhausts recovery", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-terminal-log-"));
+    tempDirs.add(dir);
+    const scriptPath = path.join(dir, "fail.mjs");
+    const sessionFile = path.join(dir, "agents", "main", "sessions", "session-test.jsonl");
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    fs.writeFileSync(
+      sessionFile,
+      `${JSON.stringify({
+        type: "session",
+        version: CURRENT_SESSION_VERSION,
+        id: "session-test",
+        timestamp: new Date(0).toISOString(),
+        cwd: dir,
+      })}\n`,
+      "utf8",
+    );
+    const secret = "sk-abcdefghijklmnopqrstuv";
+    fs.writeFileSync(
+      scriptPath,
+      `process.stderr.write("Authorization: Bearer ${secret}\\n"); process.exitCode = 1;\n`,
+      "utf8",
+    );
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: () => undefined,
+      resolvePluginSetupRegistry: () => ({ cliBackends: [] }) as never,
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "fixture-cli",
+          pluginId: "fixture",
+          config: {
+            command: process.execPath,
+            args: [scriptPath],
+            output: "text",
+            input: "arg",
+            sessionMode: "none",
+            systemPromptWhen: "never",
+          },
+        },
+      ],
+    });
+    const warn = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => {});
+    const runId = "run-terminal-failure";
+
+    await expect(
+      runCliAgent({
+        admittedRunContext: createTestAdmittedRunContext(runId),
+        sessionId: "session-test",
+        sessionKey: "agent:main:private-session",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "fail now",
+        provider: "fixture-cli",
+        model: "fixture-model",
+        timeoutMs: 5_000,
+        runId,
+        config: { agents: { defaults: { workspace: dir } } },
+      }),
+    ).rejects.toThrow();
+
+    const terminalWarnings = warn.mock.calls
+      .map(([message]) => String(message))
+      .filter((message) => message.startsWith("cli terminal failure:"));
+    expect(terminalWarnings).toHaveLength(1);
+    expect(terminalWarnings[0]).toContain("provider=fixture-cli");
+    expect(terminalWarnings[0]).toContain("model=fixture-model");
+    expect(terminalWarnings[0]).toContain(`runId=${runId}`);
+    expect(terminalWarnings[0]).toContain("durationMs=");
+    expect(terminalWarnings[0]).toContain("Authorization: Bearer");
+    expect(terminalWarnings[0]).not.toContain(secret);
+    expect(terminalWarnings[0]).not.toContain("private-session");
+  });
+});

--- a/src/agents/cli-runner.terminal-failure-log.test.ts
+++ b/src/agents/cli-runner.terminal-failure-log.test.ts
@@ -1,29 +1,27 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
+import { hasInternalDiagnosticEventListeners } from "../infra/diagnostic-event-listener-presence.js";
+import { flushLogger, resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { createTestAdmittedRunContext } from "./admitted-run-context.test-support.js";
 import { testing as cliBackendsTesting } from "./cli-backends.test-support.js";
 import { runCliAgent } from "./cli-runner.js";
-import { cliBackendLog } from "./cli-runner/log.js";
 
-const tempDirs = new Set<string>();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-afterEach(() => {
+afterEach(async () => {
+  await flushLogger();
   cliBackendsTesting.resetDepsForTest();
-  vi.restoreAllMocks();
-  for (const dir of tempDirs) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-  tempDirs.clear();
+  resetLogger();
 });
 
 describe("CLI terminal failure logging", () => {
-  it("records one redacted warning after a real CLI subprocess exhausts recovery", async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-terminal-log-"));
-    tempDirs.add(dir);
+  it("writes one redacted warning after a real CLI subprocess exhausts recovery", async () => {
+    const dir = tempDirs.make("openclaw-cli-terminal-log-");
     const scriptPath = path.join(dir, "fail.mjs");
+    const logFile = path.join(dir, "openclaw.log");
     const sessionFile = path.join(dir, "agents", "main", "sessions", "session-test.jsonl");
     fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
     fs.writeFileSync(
@@ -44,8 +42,6 @@ describe("CLI terminal failure logging", () => {
       "utf8",
     );
     cliBackendsTesting.setDepsForTest({
-      resolvePluginSetupCliBackend: () => undefined,
-      resolvePluginSetupRegistry: () => ({ cliBackends: [] }) as never,
       resolveRuntimeCliBackends: () => [
         {
           id: "fixture-cli",
@@ -61,8 +57,9 @@ describe("CLI terminal failure logging", () => {
         },
       ],
     });
-    const warn = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => {});
+    setLoggerOverride({ level: "warn", consoleLevel: "silent", file: logFile });
     const runId = "run-terminal-failure";
+    expect(hasInternalDiagnosticEventListeners()).toBe(false);
 
     await expect(
       runCliAgent({
@@ -80,9 +77,12 @@ describe("CLI terminal failure logging", () => {
       }),
     ).rejects.toThrow();
 
-    const terminalWarnings = warn.mock.calls
-      .map(([message]) => String(message))
-      .filter((message) => message.startsWith("cli terminal failure:"));
+    await flushLogger();
+    expect(hasInternalDiagnosticEventListeners()).toBe(false);
+    const terminalWarnings = fs
+      .readFileSync(logFile, "utf8")
+      .split("\n")
+      .filter((line) => line.includes("cli terminal failure:"));
     expect(terminalWarnings).toHaveLength(1);
     expect(terminalWarnings[0]).toContain("provider=fixture-cli");
     expect(terminalWarnings[0]).toContain("model=fixture-model");

--- a/src/agents/cli-runner/cli-run-recovery.ts
+++ b/src/agents/cli-runner/cli-run-recovery.ts
@@ -80,6 +80,14 @@ export async function runCliRecovery<TAttempt>(params: {
   const reusableCliSessionId = resolveCliSessionId(context.reusableCliSession);
   const resumeCheckpointId = runParams.cliSessionBinding?.resumeCheckpointId;
   let retryableSessionId = reusableCliSessionId;
+  const failTerminal = async (error: unknown): Promise<never> => {
+    // Record only after every eligible recovery path is exhausted.
+    cliBackendLog.warn(
+      `cli terminal failure: provider=${runParams.provider} model=${context.modelId} durationMs=${Date.now() - context.started} runId=${runParams.runId} error=${formatErrorMessage(error)}`,
+    );
+    await params.onTerminalFailure(error);
+    throw error;
+  };
   try {
     return await params.finishAttempt(
       await params.executeAttempt(
@@ -207,12 +215,10 @@ export async function runCliRecovery<TAttempt>(params: {
           if (deliveredRetryFailure) {
             return deliveredRetryFailure;
           }
-          await params.onTerminalFailure(retryErr);
-          throw retryErr;
+          return await failTerminal(retryErr);
         }
       }
     }
-    await params.onTerminalFailure(recoveryError);
-    throw recoveryError;
+    return await failTerminal(recoveryError);
   }
 }


### PR DESCRIPTION
Closes #126400

## What Problem This Solves

An unrecovered CLI-backed agent turn called the terminal hook and rethrew the error, but it wrote no durable run-correlated operator warning when no internal diagnostic listener was installed. Operators could see the turn fail without the provider, model, duration, or run ID needed to correlate it.

## Root cause

`runCliRecovery` owns delivered-failure handling and every eligible retry. Its two unrecovered exits called `onTerminalFailure` and threw directly. The callback only runs agent-end hook side effects, so listener-free runs had no ordinary terminal record.

## Fix

Both unrecovered exits now use one terminal helper in `runCliRecovery`. The helper writes one redacted warning after recovery is exhausted, then preserves the existing terminal callback and thrown error. Delivered failures and successful retries still return before this boundary.

## Evidence

- Exact current main `6549b0a7c534750d9d6cbef305233b162704b291`: a real temporary Node CLI subprocess wrote a synthetic bearer value and exited `1`. With no diagnostic listener, the real JSON Lines log sink contained `0` terminal warnings.
- Exact proposed head `c209f6a6b4cd0fef707686ce71807c9a2863f49b`: the same flow rejected and wrote exactly one terminal warning with provider, model, numeric duration, and run ID. The bearer value and private session key were absent.
- Focused tests: `src/agents/cli-runner.terminal-failure-log.test.ts`, `src/agents/cli-runner.reliability.test.ts`, and `src/agents/cli-runner.before-agent-reply-cron.test.ts` passed, `131/131`.
- The regression test uses the real subprocess and real flushed file logger without a diagnostic listener.
- Focused Oxfmt, Oxlint, `git diff --check`, test-temp, import-cycle, assertion, dependency, plugin-boundary, and repository guard checks passed.

## Scope

- Production: `+10/-4`, net `+6`. The shared helper absorbs both terminal exits; the new lines are the missing operator record.
- Tests: `+95/-0`.
- No configuration, schema, protocol, retry policy, delivered-result behavior, or documented behavior changes.
