### PR TITLE
fix(ui): usage filters hide sessions when multiple providers are selected

### DIFF
--- a/extensions/anthropic/cli-constants.ts
+++ b/extensions/anthropic/cli-constants.ts
@@ -4,6 +4,13 @@
  */
 /** Synthetic provider/backend id for Claude Code CLI-backed Anthropic models. */
 export const CLAUDE_CLI_BACKEND_ID = "claude-cli";
+/** Retired OpenClaw auth profile replaced by Claude CLI's native login. */
+export const CLAUDE_CLI_PROFILE_ID = `anthropic:${CLAUDE_CLI_BACKEND_ID}`;
+/** Explicit thinking opt-out for Claude CLI routes unsupported by Claude Code. */
+export const CLAUDE_CLI_OFF_THINKING_PROFILE = {
+  levels: [{ id: "off" }],
+  defaultLevel: "off",
+} as const;
 /** Non-secret marker telling OpenClaw that the installed Claude CLI owns auth. */
 export const CLAUDE_CLI_NATIVE_AUTH_MARKER = ["openclaw", "claude-cli-native-auth"].join(":");
 /** Default Claude CLI model ref for agent defaults and live tests. */

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -16,6 +16,7 @@ export {
   CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS,
   CLAUDE_CLI_DEFAULT_MODEL_REF,
   CLAUDE_CLI_MODEL_ALIASES,
+  CLAUDE_CLI_OFF_THINKING_PROFILE,
   CLAUDE_CLI_SESSION_ID_FIELDS,
 } from "./cli-constants.js";
 
@@ -116,12 +117,6 @@ type ClaudeCliEffortArgAction =
   | { mode: "preserve" }
   | { mode: "omit" }
   | { mode: "set"; effort: ClaudeCliEffort };
-
-/** Explicit thinking opt-out for Claude CLI routes unsupported by Claude Code. */
-export const CLAUDE_CLI_OFF_THINKING_PROFILE = {
-  levels: [{ id: "off" }],
-  defaultLevel: "off",
-} as const;
 
 /** Return whether a provider id refers to the Claude CLI backend. */
 export function isClaudeCliProvider(providerId: string): boolean {

--- a/extensions/anthropic/config-defaults.ts
+++ b/extensions/anthropic/config-defaults.ts
@@ -4,7 +4,6 @@ import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-scop
  * model refs and cache-retention params based on configured auth mode.
  */
 import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
-import { CLAUDE_CLI_PROFILE_ID } from "openclaw/plugin-sdk/provider-auth";
 import {
   isRecord,
   normalizeLowercaseStringOrEmpty,
@@ -13,7 +12,11 @@ import {
   resolveClaudeCliAnthropicModelRefs,
   resolveKnownAnthropicModelRef,
 } from "./claude-model-refs.js";
-import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "./cli-constants.js";
+import {
+  CLAUDE_CLI_BACKEND_ID,
+  CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS,
+  CLAUDE_CLI_PROFILE_ID,
+} from "./cli-constants.js";
 
 const ANTHROPIC_PROVIDER_API = "anthropic-messages";
 const ANTHROPIC_API_KEY_DEFAULT_ALLOWLIST_REFS = [

--- a/extensions/anthropic/provider-policy-api.ts
+++ b/extensions/anthropic/provider-policy-api.ts
@@ -2,14 +2,13 @@
  * Provider-policy API for Anthropic and Claude CLI. Core calls this lightweight
  * path for config defaults and thinking profiles.
  */
-import { CLAUDE_CLI_PROFILE_ID } from "openclaw/plugin-sdk/provider-auth";
 import {
   resolveClaudeModelIdentity,
   resolveClaudeMythos5ModelIdentity,
   resolveClaudeThinkingProfile,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
-import { CLAUDE_CLI_OFF_THINKING_PROFILE } from "./cli-shared.js";
+import { CLAUDE_CLI_OFF_THINKING_PROFILE, CLAUDE_CLI_PROFILE_ID } from "./cli-constants.js";
 import {
   applyAnthropicConfigDefaults,
   normalizeAnthropicProviderConfigForProvider,

--- a/test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts
@@ -9,6 +9,7 @@ function createExtensionCodexAppServerAttemptSupportVitestConfig(
       "extensions/codex/src/app-server/attempt-context.test.ts",
       "extensions/codex/src/app-server/attempt-notifications.test.ts",
       "extensions/codex/src/app-server/attempt-results.test.ts",
+      "extensions/codex/src/app-server/attempt-startup-retry.test.ts",
       "extensions/codex/src/app-server/attempt-startup.test.ts",
       "extensions/codex/src/app-server/attempt-timeouts.test.ts",
       "extensions/codex/src/app-server/attempt-turn-watches.test.ts",

--- a/ui/src/e2e/usage-cost-analysis.e2e.test.ts
+++ b/ui/src/e2e/usage-cost-analysis.e2e.test.ts
@@ -13,6 +13,7 @@ const suite = createControlUiE2eSuite({
 
 const recordVisuals = process.env.OPENCLAW_UI_E2E_RECORD === "1";
 const providerUsageArtifactDir = path.resolve(".artifacts/control-ui-e2e/provider-usage-outcomes");
+const usageFilterArtifactDir = path.resolve(".artifacts/control-ui-e2e/usage-filter-repair");
 
 const totals = {
   input: 1_200_000,
@@ -263,6 +264,90 @@ suite.define(() => {
 
         await expect.poll(() => cachedRow.count()).toBe(1);
         await expect.poll(() => pendingRow.count()).toBe(1);
+      },
+    );
+  });
+
+  it("keeps selected provider alternatives visible and finds quoted session labels", async () => {
+    const date = dayOffset(0);
+    const updatedAt = Date.now();
+    const sessions = [
+      { provider: "openai", label: "Team Planning" },
+      { provider: "anthropic", label: "Research Review" },
+    ].map(({ provider, label }) => ({
+      key: `agent:main:${provider}`,
+      label,
+      agentId: "main",
+      modelProvider: provider,
+      model: `${provider}-model`,
+      updatedAt,
+      usage: {
+        ...totals,
+        activityDates: [date],
+        dailyBreakdown: [{ date, cost: totals.totalCost, tokens: totals.totalTokens }],
+      },
+    }));
+    const empty = emptyUsageResponses();
+    if (recordVisuals) {
+      await mkdir(usageFilterArtifactDir, { recursive: true });
+    }
+
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1_000, width: 1_440 },
+        ...(recordVisuals
+          ? { recordVideo: { dir: usageFilterArtifactDir, size: { height: 1_000, width: 1_440 } } }
+          : {}),
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          methodResponses: {
+            "sessions.usage": { ...empty["sessions.usage"], sessions, totals },
+            "usage.cost": {
+              ...empty["usage.cost"],
+              daily: [dailyEntry(0, totals.totalCost, totals.totalTokens)],
+              totals,
+            },
+            "usage.status": { updatedAt, providers: [] },
+          },
+        });
+
+        await page.goto(`${suite.server.baseUrl}usage`);
+        const sessionLabels = page.locator(".session-bar-title");
+        await expect
+          .poll(async () => (await sessionLabels.allTextContents()).toSorted())
+          .toEqual(["Research Review", "Team Planning"]);
+
+        const providerFilter = page.locator(".usage-filter-select").filter({
+          has: page.locator(".usage-filter-trigger", { hasText: "Provider" }),
+        });
+        await providerFilter.locator(".usage-filter-trigger").click();
+        await providerFilter.locator('wa-dropdown-item[value="command:select-all"]').click();
+        await expect.poll(() => providerFilter.locator(".settings-count").textContent()).toBe("2");
+        await expect
+          .poll(async () => (await sessionLabels.allTextContents()).toSorted())
+          .toEqual(["Research Review", "Team Planning"]);
+        if (recordVisuals) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(usageFilterArtifactDir, "01-provider-alternatives.png"),
+          });
+        }
+
+        const query = page.locator(".usage-query-input");
+        await query.fill('label:"Team Planning"');
+        await query.press("Enter");
+        await expect.poll(() => sessionLabels.allTextContents()).toEqual(["Team Planning"]);
+        if (recordVisuals) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(usageFilterArtifactDir, "02-quoted-session-label.png"),
+          });
+        }
       },
     );
   });

--- a/ui/src/pages/usage/helpers.node.test.ts
+++ b/ui/src/pages/usage/helpers.node.test.ts
@@ -23,8 +23,78 @@ describe("usage-helpers", () => {
   });
 
   it("tokenizes query terms including quoted strings", () => {
-    const terms = extractQueryTerms('agent:main "model:gpt-5.2" has:errors');
-    expect(terms.map((t) => t.raw)).toEqual(["agent:main", "model:gpt-5.2", "has:errors"]);
+    const terms = extractQueryTerms(
+      'agent:main "model:gpt-5.2" label:"Team Planning" "free phrase" has:errors',
+    );
+    expect(terms).toEqual([
+      { key: "agent", value: "main", raw: "agent:main" },
+      { key: "model", value: "gpt-5.2", raw: "model:gpt-5.2" },
+      { key: "label", value: "Team Planning", raw: 'label:"Team Planning"' },
+      { value: "free phrase", raw: '"free phrase"' },
+      { key: "has", value: "errors", raw: "has:errors" },
+    ]);
+  });
+
+  it("matches quoted multi-word session labels", () => {
+    const session = { key: "planning", label: "Team Planning", usage: null };
+
+    expect(filterSessionsByQuery([session], 'label:"Team Planning"').sessions).toEqual([session]);
+    expect(filterSessionsByQuery([session], '"Team Planning"').sessions).toEqual([session]);
+  });
+
+  it("unions categorical values while intersecting categories and other constraints", () => {
+    const sessions = [
+      {
+        key: "openai",
+        channel: "discord",
+        modelProvider: "openai",
+        model: "gpt",
+        usage: {
+          totalTokens: 100,
+          messageCounts: { errors: 1 },
+          toolUsage: { totalCalls: 1, tools: [{ name: "read" }] },
+        },
+      },
+      {
+        key: "anthropic",
+        channel: "slack",
+        modelProvider: "anthropic",
+        model: "claude",
+        usage: {
+          totalTokens: 80,
+          messageCounts: { errors: 0 },
+          toolUsage: { totalCalls: 1, tools: [{ name: "write" }] },
+        },
+      },
+      {
+        key: "google",
+        channel: "discord",
+        modelProvider: "google",
+        model: "gemini",
+        usage: {
+          totalTokens: 60,
+          messageCounts: { errors: 1 },
+          toolUsage: { totalCalls: 1, tools: [{ name: "read" }] },
+        },
+      },
+    ];
+    const cases: Array<[query: string, keys: string[]]> = [
+      ["provider:openai provider:anthropic", ["openai", "anthropic"]],
+      ["provider: provider:openai", ["openai"]],
+      ["channel:discord channel:slack", ["openai", "anthropic", "google"]],
+      ["model:gpt model:claude", ["openai", "anthropic"]],
+      ["tool:read tool:write", ["openai", "anthropic", "google"]],
+      ["provider:openai provider:anthropic channel:discord", ["openai"]],
+      ["provider:openai provider:anthropic minTokens:90 has:errors has:tools", ["openai"]],
+      ["minTokens:50 minTokens:90", ["openai"]],
+      ["has:errors has:tools", ["openai", "google"]],
+    ];
+
+    for (const [query, keys] of cases) {
+      expect(filterSessionsByQuery(sessions, query).sessions.map((session) => session.key)).toEqual(
+        keys,
+      );
+    }
   });
 
   it("matches key: glob filters against session keys", () => {

--- a/ui/src/pages/usage/helpers.ts
+++ b/ui/src/pages/usage/helpers.ts
@@ -133,17 +133,16 @@ const parseQueryNumber = (value: string): number | null => {
 };
 
 export const extractQueryTerms = (query: string): UsageQueryTerm[] => {
-  // Tokenize by whitespace, but allow quoted values with spaces.
-  const rawTokens = query.match(/"[^"]+"|\S+/g) ?? [];
+  const rawTokens = query.match(/(?:[^\s"]|"[^"]*")+/g) ?? [];
   return rawTokens.map((token) => {
-    const cleaned = token.replace(/^"|"$/g, "");
+    const cleaned = token.replace(/^"(.*)"$/u, "$1");
     const idx = cleaned.indexOf(":");
     if (idx > 0) {
       const key = cleaned.slice(0, idx);
-      const value = cleaned.slice(idx + 1);
+      const value = cleaned.slice(idx + 1).replace(/^"(.*)"$/u, "$1");
       return { key, value, raw: cleaned };
     }
-    return { value: cleaned, raw: cleaned };
+    return { value: cleaned, raw: token };
   });
 };
 
@@ -230,6 +229,7 @@ const QUERY_KEYS = new Set([
   "has",
   ...Object.keys(NUMERIC_QUERY_SPECS),
 ]);
+const MULTI_VALUE_QUERY_KEYS = new Set(["channel", "provider", "model", "tool"]);
 
 const matchesUsageQuery = (session: UsageSessionQueryTarget, term: UsageQueryTerm): boolean => {
   const value = normalizeQueryText(term.value ?? "");
@@ -296,6 +296,7 @@ export const filterSessionsByQuery = <TSession extends UsageSessionQueryTarget>(
   }
 
   const warnings: string[] = [];
+  const categoricalTerms = new Map<string, UsageQueryTerm[]>();
   for (const term of terms) {
     if (!term.key) {
       continue;
@@ -304,6 +305,11 @@ export const filterSessionsByQuery = <TSession extends UsageSessionQueryTarget>(
     if (!QUERY_KEYS.has(normalizedKey)) {
       warnings.push(`Unknown filter: ${term.key}`);
       continue;
+    }
+    if (term.value && MULTI_VALUE_QUERY_KEYS.has(normalizedKey)) {
+      const alternatives = categoricalTerms.get(normalizedKey) ?? [];
+      alternatives.push(term);
+      categoricalTerms.set(normalizedKey, alternatives);
     }
     if (term.value === "") {
       warnings.push(`Missing value for ${term.key}`);
@@ -325,7 +331,14 @@ export const filterSessionsByQuery = <TSession extends UsageSessionQueryTarget>(
   }
 
   const filtered = sessions.filter((session) =>
-    terms.every((term) => matchesUsageQuery(session, term)),
+    terms.every((term) => {
+      const alternatives = term.key
+        ? categoricalTerms.get(normalizeQueryText(term.key))
+        : undefined;
+      return alternatives
+        ? alternatives.some((alternative) => matchesUsageQuery(session, alternative))
+        : matchesUsageQuery(session, term);
+    }),
   );
   return { sessions: filtered, warnings };
 };

--- a/ui/src/pages/usage/query.test.ts
+++ b/ui/src/pages/usage/query.test.ts
@@ -1,7 +1,40 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { buildSessionsCsv } from "./query.ts";
+import {
+  addQueryToken,
+  applySuggestionToQuery,
+  buildQuerySuggestions,
+  buildSessionsCsv,
+  removeQueryToken,
+  setQueryTokensForKey,
+} from "./query.ts";
 import type { UsageSessionEntry } from "./types.ts";
+
+describe("usage query token mutations", () => {
+  const quotedLabel = 'label:"Team  Planning"';
+
+  it("preserves quoted phrases when adding or replacing categorical tokens", () => {
+    expect(addQueryToken(`${quotedLabel} provider:openai`, "provider:anthropic")).toBe(
+      `${quotedLabel} provider:openai provider:anthropic `,
+    );
+    expect(setQueryTokensForKey(`${quotedLabel} provider:openai`, "provider", ["anthropic"])).toBe(
+      `${quotedLabel} provider:anthropic `,
+    );
+  });
+
+  it("removes an entire quoted term without leaving phrase fragments", () => {
+    expect(removeQueryToken(`${quotedLabel} provider:openai`, quotedLabel)).toBe(
+      "provider:openai ",
+    );
+  });
+
+  it("preserves quoted phrases when accepting a query suggestion", () => {
+    expect(applySuggestionToQuery(`${quotedLabel} provider:o`, "provider:openai")).toBe(
+      `${quotedLabel} provider:openai `,
+    );
+    expect(buildQuerySuggestions(quotedLabel, [])).toEqual([]);
+  });
+});
 
 describe("usage query CSV export", () => {
   it("omits invalid session updated timestamps instead of throwing", () => {

--- a/ui/src/pages/usage/query.ts
+++ b/ui/src/pages/usage/query.ts
@@ -141,7 +141,7 @@ const buildQuerySuggestions = (
   if (!trimmed) {
     return [];
   }
-  const tokens = trimmed.length ? trimmed.split(/\s+/) : [];
+  const tokens = extractQueryTerms(trimmed).map((term) => term.raw);
   const lastQueryWord = tokens.at(-1) ?? "";
   const [rawKey, rawValue] = lastQueryWord.includes(":")
     ? [
@@ -228,7 +228,7 @@ const applySuggestionToQuery = (query: string, suggestion: string): string => {
   if (!trimmed) {
     return `${suggestion} `;
   }
-  const tokens = trimmed.split(/\s+/);
+  const tokens = extractQueryTerms(trimmed).map((term) => term.raw);
   tokens[tokens.length - 1] = suggestion;
   return `${tokens.join(" ")} `;
 };
@@ -240,7 +240,7 @@ const addQueryToken = (query: string, token: string): string => {
   if (!trimmed) {
     return `${token} `;
   }
-  const tokens = trimmed.split(/\s+/);
+  const tokens = extractQueryTerms(trimmed).map((term) => term.raw);
   const last = tokens[tokens.length - 1] ?? "";
   const tokenKey = token.includes(":") ? token.split(":")[0] : null;
   const lastKey = last.includes(":") ? last.split(":")[0] : null;
@@ -255,7 +255,7 @@ const addQueryToken = (query: string, token: string): string => {
 };
 
 const removeQueryToken = (query: string, token: string): string => {
-  const tokens = query.trim().split(/\s+/).filter(Boolean);
+  const tokens = extractQueryTerms(query).map((term) => term.raw);
   const next = tokens.filter((entry) => entry !== token);
   return next.length ? `${next.join(" ")} ` : "";
 };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators selecting multiple providers, models, tools, or channels on the Usage dashboard would unexpectedly see no matching sessions. Session labels containing spaces also could not be found with quoted searches, and changing another filter could split or corrupt an existing quoted search.

## Why This Change Was Made

The existing Usage query owner now groups alternatives within each multi-select category while continuing to intersect separate categories, numeric thresholds, and `has:` requirements. One quote-aware tokenizer is reused for filtering, suggestions, adding/removing filter chips, and category replacement so every query surface preserves complete quoted terms.

## User Impact

Selecting multiple providers means sessions from any selected provider remain visible; narrowing by another category or threshold still works predictably. Searches such as `label:"Team Planning"` match the intended session and remain intact while other filters or suggestions are edited.

## Evidence

Before the fix, focused owner-boundary tests reproduced six independent failures: multiple selected providers returned zero rows; quoted labels were split and failed to match; adding, removing, and suggesting filters corrupted quoted terms. A subsequent browser screenshot exposed the related stale-suggestion branch, which was added as another authentic failing regression before repairing its canonical owner.

Selecting both providers now retains both sessions:

![Usage dashboard with both OpenAI and Anthropic selected while two matching sessions remain visible](https://github.com/user-attachments/assets/8b990e9d-648a-4562-a78c-b245e4ee9391)

Searching a quoted label now retains the one matching session:

![Usage dashboard matching exactly one session for a quoted multi-word label](https://github.com/user-attachments/assets/41f6ff49-d7aa-415b-bf43-5611ca910744)

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/pages/usage/helpers.node.test.ts ui/src/pages/usage/query.test.ts` — **28 passed**, including every formerly failing case.
- `OPENCLAW_UI_E2E_RECORD=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/usage-cost-analysis.e2e.test.ts` — **5 Chromium scenarios passed**; actual UI interactions select both providers and search a quoted session label.
- Changed-file formatting and lint pass.

Production LOC: +23/-10 (net +13); tests: +191/-3.
