### PR TITLE
fix(agents): record Claude subscription rate-limit facts from the CLI stream

### DIFF
--- a/src/agents/cli-output-contracts.ts
+++ b/src/agents/cli-output-contracts.ts
@@ -45,6 +45,9 @@ export type CliSubscriptionRateLimit = {
   overageDisabledReason?: string;
   isUsingOverage?: boolean;
   errorCode?: string;
+  /** Set with `credits_required`: whether buying credits or a saved card can recover the turn. */
+  canUserPurchaseCredits?: boolean;
+  hasChargeableSavedPaymentMethod?: boolean;
 };
 
 /** Normalized result from a CLI-backed model provider turn. */

--- a/src/agents/cli-output-contracts.ts
+++ b/src/agents/cli-output-contracts.ts
@@ -35,6 +35,18 @@ export type CliTerminalInterruption = {
   reason: "aborted" | "timeout";
 };
 
+export type CliSubscriptionRateLimit = {
+  status: "allowed" | "allowed_warning" | "rejected";
+  /** Wire id of the binding window (`five_hour`, `seven_day`); Anthropic may add ids without notice. */
+  rateLimitType?: string;
+  /** Utilization 0..1 and unix-second reset per wire window id, in wire order. */
+  windows: Record<string, { utilization: number; resetsAt: number }>;
+  overageStatus?: "allowed" | "allowed_warning" | "rejected";
+  overageDisabledReason?: string;
+  isUsingOverage?: boolean;
+  errorCode?: string;
+};
+
 /** Normalized result from a CLI-backed model provider turn. */
 export type CliOutput = {
   text: string;
@@ -52,6 +64,7 @@ export type CliOutput = {
   terminalInterruption?: CliTerminalInterruption;
   diagnostics?: {
     process?: CliProcessDiagnostics;
+    rateLimit?: CliSubscriptionRateLimit;
   };
   finalPromptText?: string;
   didSendViaMessagingTool?: boolean;

--- a/src/agents/cli-output-records.test.ts
+++ b/src/agents/cli-output-records.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { parseClaudeCliRateLimit } from "./cli-output-records.js";
 import { createCliJsonlStreamingParser } from "./cli-output-stream.js";
 import { parseCliOutput } from "./cli-output.js";
 
@@ -542,6 +543,32 @@ describe("parseCliOutput", () => {
 });
 
 describe("parseCliJsonl record usage", () => {
+  it("synthesizes a window from the SDK-typed top-level shape", () => {
+    expect(
+      parseClaudeCliRateLimit({
+        backend: {
+          command: "claude",
+          output: "jsonl",
+          jsonlDialect: "claude-stream-json",
+        },
+        providerId: "claude-cli",
+        parsed: {
+          type: "rate_limit_event",
+          rate_limit_info: {
+            status: "allowed",
+            rateLimitType: "five_hour",
+            utilization: 0.5,
+            resetsAt: 1787680200,
+          },
+        },
+      }),
+    ).toEqual({
+      status: "allowed",
+      rateLimitType: "five_hour",
+      windows: { five_hour: { utilization: 0.5, resetsAt: 1787680200 } },
+    });
+  });
+
   it("ignores cumulative usage from result events to avoid cache_read inflation", () => {
     const parser = createCliJsonlStreamingParser({
       backend: {

--- a/src/agents/cli-output-records.test.ts
+++ b/src/agents/cli-output-records.test.ts
@@ -543,6 +543,19 @@ describe("parseCliOutput", () => {
 });
 
 describe("parseCliJsonl record usage", () => {
+  it("drops a record whose reset time cannot form a Date", () => {
+    expect(
+      parseClaudeCliRateLimit({
+        backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+        providerId: "claude-cli",
+        parsed: {
+          type: "rate_limit_event",
+          rate_limit_info: { status: "allowed", rateLimitType: "five_hour", resetsAt: 9e15 },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
   it("synthesizes a window from the SDK-typed top-level shape", () => {
     expect(
       parseClaudeCliRateLimit({

--- a/src/agents/cli-output-records.ts
+++ b/src/agents/cli-output-records.ts
@@ -510,13 +510,15 @@ export function parseClaudeCliJsonlResult(params: {
 }
 
 const rateLimitStatusSchema = z.enum(["allowed", "allowed_warning", "rejected"]);
+// Largest unix-second value `Date` can represent; a larger reset would throw in the digest formatter.
+const rateLimitResetSchema = z.number().min(0).max(8_640_000_000_000);
 const claudeCliRateLimitRecordSchema = z.object({
   type: z.literal("rate_limit_event"),
   rate_limit_info: z.object({
     status: rateLimitStatusSchema,
     rateLimitType: z.string().optional(),
     utilization: z.number().min(0).max(1).optional(),
-    resetsAt: z.number().nonnegative().optional(),
+    resetsAt: rateLimitResetSchema.optional(),
     overageStatus: rateLimitStatusSchema.optional(),
     overageDisabledReason: z.string().optional(),
     isUsingOverage: z.boolean().optional(),
@@ -524,7 +526,7 @@ const claudeCliRateLimitRecordSchema = z.object({
     unifiedWindows: z
       .record(
         z.string(),
-        z.object({ utilization: z.number().min(0).max(1), resetsAt: z.number().nonnegative() }),
+        z.object({ utilization: z.number().min(0).max(1), resetsAt: rateLimitResetSchema }),
       )
       .optional(),
   }),

--- a/src/agents/cli-output-records.ts
+++ b/src/agents/cli-output-records.ts
@@ -523,6 +523,8 @@ const claudeCliRateLimitRecordSchema = z.object({
     overageDisabledReason: z.string().optional(),
     isUsingOverage: z.boolean().optional(),
     errorCode: z.string().optional(),
+    canUserPurchaseCredits: z.boolean().optional(),
+    hasChargeableSavedPaymentMethod: z.boolean().optional(),
     unifiedWindows: z
       .record(
         z.string(),

--- a/src/agents/cli-output-records.ts
+++ b/src/agents/cli-output-records.ts
@@ -1,8 +1,14 @@
 import { extractBalancedJsonFragments } from "@openclaw/normalization-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { z } from "zod";
 import type { CliBackendConfig } from "../plugins/cli-backend.types.js";
-import type { CliOutput, CliTerminalFailure, CliUsage } from "./cli-output-contracts.js";
+import type {
+  CliOutput,
+  CliSubscriptionRateLimit,
+  CliTerminalFailure,
+  CliUsage,
+} from "./cli-output-contracts.js";
 import { normalizeUsage, type UsageLike } from "./usage.js";
 
 function isClaudeCliProvider(providerId: string): boolean {
@@ -501,6 +507,49 @@ export function parseClaudeCliJsonlResult(params: {
     return { text: "", sessionId: params.sessionId, usage: params.usage };
   }
   return null;
+}
+
+const rateLimitStatusSchema = z.enum(["allowed", "allowed_warning", "rejected"]);
+const claudeCliRateLimitRecordSchema = z.object({
+  type: z.literal("rate_limit_event"),
+  rate_limit_info: z.object({
+    status: rateLimitStatusSchema,
+    rateLimitType: z.string().optional(),
+    utilization: z.number().min(0).max(1).optional(),
+    resetsAt: z.number().nonnegative().optional(),
+    overageStatus: rateLimitStatusSchema.optional(),
+    overageDisabledReason: z.string().optional(),
+    isUsingOverage: z.boolean().optional(),
+    errorCode: z.string().optional(),
+    unifiedWindows: z
+      .record(
+        z.string(),
+        z.object({ utilization: z.number().min(0).max(1), resetsAt: z.number().nonnegative() }),
+      )
+      .optional(),
+  }),
+});
+
+export function parseClaudeCliRateLimit(params: {
+  backend: CliBackendConfig;
+  providerId: string;
+  parsed: Record<string, unknown>;
+}): CliSubscriptionRateLimit | undefined {
+  if (!isClaudeStreamJsonDialect(params) || params.parsed.type !== "rate_limit_event") {
+    return undefined;
+  }
+  // A malformed optional field drops the whole diagnostic record instead of partially recording it.
+  const result = claudeCliRateLimitRecordSchema.safeParse(params.parsed);
+  if (!result.success) {
+    return undefined;
+  }
+  const { unifiedWindows, utilization, resetsAt, ...rateLimit } = result.data.rate_limit_info;
+  // The SDK-typed shape carries only the binding window at top level; fold it into the window map.
+  const bindingWindow =
+    rateLimit.rateLimitType !== undefined && utilization !== undefined && resetsAt !== undefined
+      ? { [rateLimit.rateLimitType]: { utilization, resetsAt } }
+      : {};
+  return { ...rateLimit, windows: unifiedWindows ?? bindingWindow };
 }
 
 // A tool-split turn streams pre-tool answer text the terminal result envelope

--- a/src/agents/cli-output-stream.test.ts
+++ b/src/agents/cli-output-stream.test.ts
@@ -109,7 +109,96 @@ function claudeSyntheticNoResponse(text = "No response requested.") {
   };
 }
 
+const CLAUDE_RATE_LIMIT_EVENT = {
+  type: "rate_limit_event",
+  rate_limit_info: {
+    status: "allowed",
+    rateLimitType: "five_hour",
+    overageStatus: "rejected",
+    overageDisabledReason: "org_level_disabled",
+    isUsingOverage: false,
+    unifiedWindows: {
+      five_hour: { utilization: 0.36, resetsAt: 1787680200 },
+      seven_day: { utilization: 0.28, resetsAt: 1788138000 },
+    },
+  },
+  uuid: "rate-limit-event",
+  session_id: "session-rate-limit",
+};
+
+const CLAUDE_RATE_LIMIT = {
+  status: "allowed" as const,
+  rateLimitType: "five_hour",
+  overageStatus: "rejected" as const,
+  overageDisabledReason: "org_level_disabled",
+  isUsingOverage: false,
+  windows: {
+    five_hour: { utilization: 0.36, resetsAt: 1787680200 },
+    seven_day: { utilization: 0.28, resetsAt: 1788138000 },
+  },
+};
+
 describe("createCliJsonlStreamingParser", () => {
+  it.each([
+    {
+      name: "success result",
+      result: { type: "result", result: "done" },
+      expected: {
+        text: "done",
+        sessionId: "session-rate-limit",
+        usage: undefined,
+        diagnostics: { rateLimit: CLAUDE_RATE_LIMIT },
+      },
+    },
+    {
+      name: "error result",
+      result: {
+        type: "result",
+        is_error: true,
+        result:
+          "API Error: 400 Third-party apps now draw from your extra usage, not your plan limits.",
+      },
+      expected: {
+        text: "",
+        sessionId: "session-rate-limit",
+        usage: undefined,
+        errorText:
+          "API Error: 400 Third-party apps now draw from your extra usage, not your plan limits.",
+        diagnostics: { rateLimit: CLAUDE_RATE_LIMIT },
+      },
+    },
+  ])("retains rate-limit facts with a $name", ({ result, expected }) => {
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+      providerId: "claude-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(joinJsonlFrames(CLAUDE_RATE_LIMIT_EVENT, result, ""));
+    parser.finish();
+
+    expect(parser.getOutput()).toEqual(expected);
+  });
+
+  it("ignores malformed rate-limit records without throwing", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+      providerId: "claude-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(
+      joinJsonlFrames(
+        { type: "rate_limit_event", rate_limit_info: { status: "allowed", utilization: 7 } },
+        { type: "result", result: "done" },
+        "",
+      ),
+    );
+    parser.finish();
+
+    expect(parser.getOutput()).toEqual({ text: "done", sessionId: undefined, usage: undefined });
+  });
+
   it.each(OPENAI_COMPATIBLE_CLI_USAGE_CASES)(
     "normalizes $name while incrementally streaming CLI JSONL",
     ({ raw, normalized }) => {

--- a/src/agents/cli-output-stream.ts
+++ b/src/agents/cli-output-stream.ts
@@ -9,6 +9,7 @@ import type {
 import type {
   CliJsonlStreamingParserOptions,
   CliOutput,
+  CliSubscriptionRateLimit,
   CliStreamJsonOutputLimits,
   CliUsage,
 } from "./cli-output-contracts.js";
@@ -35,6 +36,7 @@ import {
   isStreamJsonDialect,
   missingMessageBoundarySeparator,
   parseClaudeCliJsonlResult,
+  parseClaudeCliRateLimit,
   parseClaudeCliStreamingDelta,
   pickCliResumeCheckpointId,
   pickCliSessionId,
@@ -131,6 +133,7 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
   let usage: CliUsage | undefined;
   let diagnosticUsage: CliUsage | undefined;
   let output: CliOutput | null = null;
+  let rateLimit: CliSubscriptionRateLimit | undefined;
   let parseErrorText = "";
   let rawChars = 0;
   let rawLines = 0;
@@ -301,6 +304,10 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
   const handleParsedRecord = (parsed: Record<string, unknown>) => {
     if (parseErrorText) {
       return;
+    }
+    const parsedRateLimit = parseClaudeCliRateLimit({ ...params, parsed });
+    if (parsedRateLimit) {
+      rateLimit = parsedRateLimit;
     }
     const parsedSessionId = pickCliSessionId(parsed, params.backend);
     if (parsed.type === "result" && isStreamJsonDialect(params)) {
@@ -650,47 +657,53 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
       return sawTerminalResult;
     },
     getOutput() {
-      if (parseErrorText) {
-        return {
-          text: "",
-          sessionId,
-          usage,
-          ...(diagnosticUsage ? { diagnosticUsage } : {}),
-          errorText: parseErrorText,
-        };
-      }
-      if (output) {
-        return output;
-      }
-      if (rawLines === 0) {
-        return null;
-      }
-      if (sawCustomJsonlEvent) {
-        return { text: texts.join("\n").trim() || assistantText.trim(), sessionId, usage };
-      }
-      if (isStreamJsonDialect(params) && assistantText.trim()) {
-        return {
-          text: assistantText.trim(),
-          sessionId,
-          usage,
-          ...(resumeCheckpointId ? { resumeCheckpointId } : {}),
-        };
-      }
-      if (isGeminiStreamJsonDialect(params) && sawGeminiStructuredOutput) {
-        return { text: "", sessionId, usage };
-      }
-      if (isStreamJsonDialect(params)) {
-        return {
-          text: "",
-          sessionId,
-          usage,
-          errorText: CLI_STREAM_JSON_MISSING_RESULT_ERROR,
-        };
-      }
-      const text = texts.join("\n").trim();
-      return text
-        ? { text, sessionId, usage, ...(resumeCheckpointId ? { resumeCheckpointId } : {}) }
-        : null;
+      const buildOutput = (): CliOutput | null => {
+        if (parseErrorText) {
+          return {
+            text: "",
+            sessionId,
+            usage,
+            ...(diagnosticUsage ? { diagnosticUsage } : {}),
+            errorText: parseErrorText,
+          };
+        }
+        if (output) {
+          return output;
+        }
+        if (rawLines === 0) {
+          return null;
+        }
+        if (sawCustomJsonlEvent) {
+          return { text: texts.join("\n").trim() || assistantText.trim(), sessionId, usage };
+        }
+        if (isStreamJsonDialect(params) && assistantText.trim()) {
+          return {
+            text: assistantText.trim(),
+            sessionId,
+            usage,
+            ...(resumeCheckpointId ? { resumeCheckpointId } : {}),
+          };
+        }
+        if (isGeminiStreamJsonDialect(params) && sawGeminiStructuredOutput) {
+          return { text: "", sessionId, usage };
+        }
+        if (isStreamJsonDialect(params)) {
+          return {
+            text: "",
+            sessionId,
+            usage,
+            errorText: CLI_STREAM_JSON_MISSING_RESULT_ERROR,
+          };
+        }
+        const text = texts.join("\n").trim();
+        return text
+          ? { text, sessionId, usage, ...(resumeCheckpointId ? { resumeCheckpointId } : {}) }
+          : null;
+      };
+      const builtOutput = buildOutput();
+      return rateLimit && builtOutput
+        ? { ...builtOutput, diagnostics: { ...builtOutput.diagnostics, rateLimit } }
+        : builtOutput;
     },
   };
 }

--- a/src/agents/cli-runner/execute-process.ts
+++ b/src/agents/cli-runner/execute-process.ts
@@ -24,7 +24,11 @@ import { executePluginOwnedProcess } from "./execute-plugin.js";
 import type { CliToolTracking } from "./execute-tool-tracking.js";
 import { createCliExitFailoverError, createCliFailoverError } from "./exit-error.js";
 import { buildCliSupervisorScopeKey } from "./helpers.js";
-import { cliBackendLog, formatCliBackendOutputDigest } from "./log.js";
+import {
+  cliBackendLog,
+  formatCliBackendOutputDigest,
+  formatCliSubscriptionRateLimitDigest,
+} from "./log.js";
 import type { createClaudeCliModelCallDiagnostics } from "./model-call-diagnostics.js";
 import {
   createCliTimeoutError,
@@ -501,8 +505,11 @@ export async function executeCliProcess(params: {
     throw parsedError;
   }
   const rawText = parsed.text;
+  const rateLimitDigest = parsed.diagnostics?.rateLimit
+    ? ` ${formatCliSubscriptionRateLimitDigest(parsed.diagnostics.rateLimit)}`
+    : "";
   cliBackendLog.info(
-    `cli turn: provider=${runParams.provider} model=${context.modelId} durationMs=${Date.now() - params.cliTurnStartedAt} ${formatCliBackendOutputDigest(rawText)}`,
+    `cli turn: provider=${runParams.provider} model=${context.modelId} durationMs=${Date.now() - params.cliTurnStartedAt} ${formatCliBackendOutputDigest(rawText)}${rateLimitDigest}`,
   );
   return {
     ...parsed,

--- a/src/agents/cli-runner/log.ts
+++ b/src/agents/cli-runner/log.ts
@@ -38,6 +38,12 @@ export function formatCliSubscriptionRateLimitDigest(rateLimit: CliSubscriptionR
   if (rateLimit.errorCode) {
     parts.push(`error=${rateLimit.errorCode}`);
   }
+  if (rateLimit.canUserPurchaseCredits !== undefined) {
+    parts.push(`canPurchaseCredits=${rateLimit.canUserPurchaseCredits}`);
+  }
+  if (rateLimit.hasChargeableSavedPaymentMethod !== undefined) {
+    parts.push(`savedPaymentMethod=${rateLimit.hasChargeableSavedPaymentMethod}`);
+  }
   if (rateLimit.isUsingOverage) {
     parts.push("usingOverage");
   }

--- a/src/agents/cli-runner/log.ts
+++ b/src/agents/cli-runner/log.ts
@@ -3,6 +3,7 @@
  */
 import crypto from "node:crypto";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { CliSubscriptionRateLimit } from "../cli-output-contracts.js";
 
 /** Subsystem logger for CLI backend execution diagnostics. */
 export const cliBackendLog = createSubsystemLogger("agent/cli-backend");
@@ -16,4 +17,29 @@ export function formatCliBackendOutputDigest(text: string): string {
   const outBytes = Buffer.byteLength(text, "utf8");
   const outHash = crypto.createHash("sha256").update(text).digest("hex").slice(0, 12);
   return `outBytes=${outBytes} outHash=${outHash}`;
+}
+
+function formatRateLimitResetTime(resetsAt: number): string {
+  return `${new Date(resetsAt * 1000).toISOString().slice(0, 16)}Z`;
+}
+
+export function formatCliSubscriptionRateLimitDigest(rateLimit: CliSubscriptionRateLimit): string {
+  const parts = [`rateLimit=${rateLimit.status}`];
+  for (const [name, window] of Object.entries(rateLimit.windows)) {
+    const reset =
+      name === rateLimit.rateLimitType ? `→${formatRateLimitResetTime(window.resetsAt)}` : "";
+    parts.push(`${name}=${Math.round(window.utilization * 100)}%${reset}`);
+  }
+  if (rateLimit.overageStatus) {
+    parts.push(
+      `overage=${rateLimit.overageStatus}${rateLimit.overageDisabledReason ? `(${rateLimit.overageDisabledReason})` : ""}`,
+    );
+  }
+  if (rateLimit.errorCode) {
+    parts.push(`error=${rateLimit.errorCode}`);
+  }
+  if (rateLimit.isUsingOverage) {
+    parts.push("usingOverage");
+  }
+  return parts.join(" ");
 }

--- a/src/agents/cli-runner/output-error.test.ts
+++ b/src/agents/cli-runner/output-error.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { CliOutput, CliSubscriptionRateLimit } from "../cli-output-contracts.js";
+import { parseClaudeCliRateLimit } from "../cli-output-records.js";
 import { formatCliSubscriptionRateLimitDigest } from "./log.js";
 import { createCliOutputFailoverError } from "./output-error.js";
 
@@ -51,6 +52,34 @@ describe("createCliOutputFailoverError", () => {
       `${BASE_ERROR} Subscription rate limit: rateLimit=allowed five_hour=36%→2026-08-25T17:50Z seven_day=28% overage=rejected(org_level_disabled).`,
     );
     expect(error?.rawError).toBe(BASE_ERROR);
+  });
+
+  it("carries credits-required recovery facts from the stream event into the billing error", () => {
+    const rateLimit = parseClaudeCliRateLimit({
+      backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+      providerId: "claude-cli",
+      parsed: {
+        type: "rate_limit_event",
+        rate_limit_info: {
+          status: "rejected",
+          errorCode: "credits_required",
+          canUserPurchaseCredits: true,
+          hasChargeableSavedPaymentMethod: false,
+        },
+      },
+    });
+    const output: CliOutput = { text: "", errorText: BASE_ERROR, diagnostics: { rateLimit } };
+
+    const error = createCliOutputFailoverError({
+      output,
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+    });
+
+    expect(error?.reason).toBe("billing");
+    expect(error?.message).toBe(
+      `${BASE_ERROR} Subscription rate limit: rateLimit=rejected error=credits_required canPurchaseCredits=true savedPaymentMethod=false.`,
+    );
   });
 
   it("does not append facts to unrelated failures", () => {

--- a/src/agents/cli-runner/output-error.test.ts
+++ b/src/agents/cli-runner/output-error.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { CliOutput, CliSubscriptionRateLimit } from "../cli-output-contracts.js";
+import { formatCliSubscriptionRateLimitDigest } from "./log.js";
+import { createCliOutputFailoverError } from "./output-error.js";
+
+const OBSERVED_RATE_LIMIT: CliSubscriptionRateLimit = {
+  status: "allowed",
+  rateLimitType: "five_hour",
+  overageStatus: "rejected",
+  overageDisabledReason: "org_level_disabled",
+  isUsingOverage: false,
+  windows: {
+    five_hour: { utilization: 0.36, resetsAt: 1787680200 },
+    seven_day: { utilization: 0.28, resetsAt: 1788138000 },
+  },
+};
+
+const BASE_ERROR =
+  "API Error: 400 Third-party apps now draw from your extra usage, not your plan limits.";
+
+describe("formatCliSubscriptionRateLimitDigest", () => {
+  it("formats the observed subscription windows", () => {
+    expect(formatCliSubscriptionRateLimitDigest(OBSERVED_RATE_LIMIT)).toBe(
+      "rateLimit=allowed five_hour=36%→2026-08-25T17:50Z seven_day=28% overage=rejected(org_level_disabled)",
+    );
+  });
+
+  it("formats the minimum rate-limit record", () => {
+    expect(formatCliSubscriptionRateLimitDigest({ status: "rejected", windows: {} })).toBe(
+      "rateLimit=rejected",
+    );
+  });
+});
+
+describe("createCliOutputFailoverError", () => {
+  it("appends subscription facts to billing failures while preserving rawError", () => {
+    const output: CliOutput = {
+      text: "",
+      errorText: BASE_ERROR,
+      diagnostics: { rateLimit: OBSERVED_RATE_LIMIT },
+    };
+
+    const error = createCliOutputFailoverError({
+      output,
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+    });
+
+    expect(error?.reason).toBe("billing");
+    expect(error?.message).toBe(
+      `${BASE_ERROR} Subscription rate limit: rateLimit=allowed five_hour=36%→2026-08-25T17:50Z seven_day=28% overage=rejected(org_level_disabled).`,
+    );
+    expect(error?.rawError).toBe(BASE_ERROR);
+  });
+
+  it("does not append facts to unrelated failures", () => {
+    const output: CliOutput = {
+      text: "",
+      errorText: "unrelated failure",
+      diagnostics: { rateLimit: { status: "rejected", windows: {} } },
+    };
+
+    const error = createCliOutputFailoverError({
+      output,
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+    });
+
+    expect(error?.message).toBe("unrelated failure");
+  });
+});

--- a/src/agents/cli-runner/output-error.ts
+++ b/src/agents/cli-runner/output-error.ts
@@ -2,6 +2,7 @@ import type { CliOutput } from "../cli-output-contracts.js";
 import { formatCliOutputError } from "../cli-output.js";
 import { classifyFailoverReason } from "../embedded-agent-helpers.js";
 import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
+import { formatCliSubscriptionRateLimitDigest } from "./log.js";
 
 export function createCliOutputFailoverError(params: {
   output: CliOutput;
@@ -22,6 +23,10 @@ export function createCliOutputFailoverError(params: {
   const reason = syntheticNoResponse
     ? "format"
     : (classifyFailoverReason(message, { provider: params.provider }) ?? "unknown");
+  const messageWithRateLimit =
+    params.output.diagnostics?.rateLimit && (reason === "billing" || reason === "rate_limit")
+      ? `${message} Subscription rate limit: ${formatCliSubscriptionRateLimitDigest(params.output.diagnostics.rateLimit)}.`
+      : message;
   const code =
     params.output.terminalFailure?.reason === "max_turns"
       ? "cli_max_turns"
@@ -30,7 +35,7 @@ export function createCliOutputFailoverError(params: {
         : reason === "context_overflow"
           ? "cli_context_overflow"
           : undefined;
-  return new FailoverError(message, {
+  return new FailoverError(messageWithRateLimit, {
     reason,
     provider: params.provider,
     model: params.model,


### PR DESCRIPTION
## What Problem This Solves

A Claude CLI turn on a production gateway (Agent SDK 0.3.232, native `claude` login) failed with `API Error: 400 Third-party apps now draw from your extra usage, not your plan limits…`. OpenClaw classified it `billing` and recorded nothing else. The Claude stream-json output of every turn carries a `rate_limit_event` (SDK `SDKRateLimitInfo`: status, binding window, utilization, reset time, overage status/reason, error code) emitted right before the `result`, and OpenClaw discarded it — so there was no record of the subscription state at the moment of the failure, and no way to tell plan exhaustion from an Anthropic-side billing classification without re-running the turn.

## Why This Change Was Made

Record the fact where it happens (Product Doctrine: recorded fact at the owning boundary, not multi-signal inference later).

- `src/agents/cli-output-contracts.ts`: `CliOutput.diagnostics.rateLimit` (`CliSubscriptionRateLimit`): status, binding window id, a `windows` map of utilization/reset per wire window id, overage status/reason, `isUsingOverage`, `errorCode`.
- `src/agents/cli-output-records.ts`: `parseClaudeCliRateLimit`, a zod schema over the whole `rate_limit_event` record, gated on the Claude stream-json dialect. The wire `unifiedWindows` map becomes `windows` verbatim; the SDK-typed shape (top-level `rateLimitType`/`utilization`/`resetsAt`, no `unifiedWindows`) folds into a one-entry map. A malformed optional field drops the whole diagnostic record rather than partially recording it (accepted tradeoff, commented).
- `src/agents/cli-output-stream.ts`: the streaming parser keeps the last record and attaches it once in `getOutput`, so it survives both success and `is_error` results.
- `src/agents/cli-runner/log.ts`: `formatCliSubscriptionRateLimitDigest` renders one compact line, e.g. `rateLimit=allowed five_hour=36%→2026-08-25T17:50Z seven_day=28% overage=rejected(org_level_disabled)`; the reset time is shown only on the binding window.
- `src/agents/cli-runner/execute-process.ts`: the `cli turn:` info line appends the digest.
- `src/agents/cli-runner/output-error.ts`: `billing` / `rate_limit` `FailoverError` messages append ` Subscription rate limit: <digest>.`; `rawError` stays the original CLI text.

No config, env, storage, or plugin-SDK surface. Not touched: `extensions/`, docs, CHANGELOG.

## User Impact

- Every Claude CLI turn logs its subscription window state on the existing `cli turn:` line (`agent/cli-backend` subsystem, info level).
- A billing / rate-limit failure now carries the plan state in its error message, so the operator can tell "5h window exhausted" from "overage disabled at org level" from "credits required" without a second probe.
- Non-Claude CLI backends and non-stream-json output are unchanged.

## Evidence

- Live proof on a Linux gateway host, isolated `OPENCLAW_STATE_DIR` and dist built from this head, one `openclaw agent --local` turn through the Agent SDK path (`anthropic/claude-fable-5`):
  ```
  cli turn: provider=claude-cli model=claude-fable-5 durationMs=3742 outBytes=46 outHash=0ac7a7b49da7 rateLimit=allowed five_hour=54%→2026-08-25T17:50Z seven_day=31% seven_day_overage_included=46% overage=rejected(org_level_disabled)
  ```
  The same turn on the pre-change dist logs `cli turn: … outBytes=2 outHash=2689367b205c` with no rate-limit facts. Note the third wire window (`seven_day_overage_included`) that the SDK type does not declare — the window map is keyed by wire id for that reason.
- Rejection path (`error=credits_required`, message enrichment) is covered by unit test only: 160 live probe turns on the same account (80 with the stock Claude Code prompt, 80 with OpenClaw's appended system prompt) all returned `status=allowed`, so the 400 could not be reproduced on demand.
- `node scripts/run-vitest.mjs src/agents/cli-output-stream.test.ts src/agents/cli-output-records.test.ts src/agents/cli-runner/output-error.test.ts` — green (new: retain on success/error result, malformed record dropped, SDK-typed shape folds to one window, observed-record digest, minimal digest, billing failover enrichment, unrelated failure untouched). The new tests fail on pre-change code for the intended reasons (missing `diagnostics.rateLimit`, missing digest export, unenriched billing message).
- `oxfmt`, `scripts/run-oxlint.mjs` on changed files, `git diff --check` — clean. `pnpm build` — clean (the two `INEFFECTIVE_DYNAMIC_IMPORT` warnings are pre-existing UI-side).
- Local ClawSweeper review (`gpt-5.6-terra`, high) on `3ced009` raised one P2: a finite `resetsAt` above `Date` range would throw in the digest formatter and fail a successful turn. Fixed in `b28d410` by bounding the reset at the schema (record dropped), with a regression test.
- Production LOC: +108 / −4 raw numstat; `cli-output-stream.ts` 54/41 is a re-indent of the unchanged `getOutput` body into `buildOutput` (pure move), so net new production ≈ +95. Justified by a new recorded fact at its owning boundary. Tests +187.
