### PR TITLE
fix(ui): reject secret deletion after Gateway client replacement

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -6599,6 +6599,7 @@ export const en: TranslationMap = {
     partial: "{saved}/{total}: {error}",
     confirmDelete: "Delete {name}?",
     deleted: "Deleted {name}.",
+    deleteFailed: "The secret was not deleted. Reload the list and try again.",
   },
   cron: {
     adminRequired: "Browsing only. Automation changes require operator.admin access.",

--- a/ui/src/pages/secrets/secrets-page.ts
+++ b/ui/src/pages/secrets/secrets-page.ts
@@ -274,7 +274,10 @@ class SecretsPage extends OpenClawLightDomElement {
   }
 
   private async removeEntry(entry: (typeof this.store.entries)[number]) {
+    const gateway = this.context.gateway;
+    const client = this.store.client;
     if (
+      !client ||
       !this.canDelete ||
       !(await showConfirmDialog({
         title: t("common.delete"),
@@ -286,6 +289,11 @@ class SecretsPage extends OpenClawLightDomElement {
       return;
     }
     this.notice = null;
+    if (this.context.gateway !== gateway || this.store.client !== client || !this.canDelete) {
+      this.store.error = t("secretsStore.deleteFailed");
+      this.requestUpdate();
+      return;
+    }
     await this.runStoreTask(async (store) => {
       const result = await deleteSecretsStoreEntry(store, entry.name);
       if (result && this.store === store) {

--- a/ui/src/pages/secrets/secrets-page.ts
+++ b/ui/src/pages/secrets/secrets-page.ts
@@ -274,6 +274,8 @@ class SecretsPage extends OpenClawLightDomElement {
   }
 
   private async removeEntry(entry: (typeof this.store.entries)[number]) {
+    // A confirmation belongs to the client that opened it. Same-client reconnects remain valid,
+    // but a replacement client must never inherit this destructive action.
     const gateway = this.context.gateway;
     const client = this.store.client;
     if (

--- a/ui/src/pages/secrets/secrets.e2e.test.ts
+++ b/ui/src/pages/secrets/secrets.e2e.test.ts
@@ -84,6 +84,27 @@ async function tableBodyContrast(page: Page): Promise<number> {
     });
 }
 
+async function activeGatewayIdentity(page: Page) {
+  return await page.evaluate(() => {
+    const app = document.querySelector("openclaw-app") as HTMLElement & {
+      runtime?: {
+        context: {
+          gateway: {
+            connection: { gatewayUrl: string };
+            snapshot: { client: { instanceId: string } | null; phase: string };
+          };
+        };
+      };
+    };
+    const gateway = app.runtime?.context.gateway;
+    return {
+      clientInstanceId: gateway?.snapshot.client?.instanceId,
+      gatewayUrl: gateway?.connection.gatewayUrl,
+      phase: gateway?.snapshot.phase,
+    };
+  });
+}
+
 suite.define(() => {
   it("blocks empty protected values without rejecting empty environment entries", async () => {
     await suite.withPage({}, async ({ page }) => {
@@ -303,6 +324,129 @@ suite.define(() => {
         await capture(page, "01-populated-dark.png");
       },
     );
+  });
+
+  it("rejects a confirmed deletion after same-URL credentials replace the Gateway client", async () => {
+    await suite.withPage({}, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["secrets.store.list", "secrets.store.delete"],
+        methodResponses: {
+          "secrets.store.list": {
+            sequence: [{ entries: [envEntry] }, { entries: [envEntry] }, { entries: [] }],
+          },
+          "secrets.store.delete": { ok: true, reloaded: false },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}settings/secrets`);
+      const entryRow = page.getByRole("row", { name: /SERVICE_URL/u });
+      await entryRow.getByRole("button", { name: "Actions: SERVICE_URL" }).click();
+      await entryRow.locator('wa-dropdown-item[value="delete"]').click();
+      const confirmation = page.locator('openclaw-modal-dialog[label="Delete"]');
+      await confirmation.getByText("Delete SERVICE_URL?", { exact: true }).waitFor();
+
+      const socketCount = await gateway.getSocketCount();
+      const listCount = (await gateway.getRequests("secrets.store.list")).length;
+      const originalGateway = await page.evaluate(() => {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: {
+            context: {
+              gateway: {
+                connection: { gatewayUrl: string };
+                connect: (options: { token: string }) => void;
+                snapshot: { client: { instanceId: string } | null };
+              };
+            };
+          };
+        };
+        const activeGateway = app.runtime?.context.gateway;
+        const client = activeGateway?.snapshot.client;
+        if (!activeGateway || !client) {
+          throw new Error("Expected a connected Gateway client before confirmation");
+        }
+        const identity = {
+          clientInstanceId: client.instanceId,
+          gatewayUrl: activeGateway.connection.gatewayUrl,
+        };
+        activeGateway.connect({ token: "replacement-secret-delete-proof" });
+        return identity;
+      });
+      await expect.poll(() => gateway.getSocketCount()).toBeGreaterThan(socketCount);
+      await expect
+        .poll(async () => (await gateway.getRequests("secrets.store.list")).length)
+        .toBeGreaterThan(listCount);
+      await expect
+        .poll(() => activeGatewayIdentity(page))
+        .toMatchObject({
+          gatewayUrl: originalGateway.gatewayUrl,
+          phase: "connected",
+        });
+      const replacementGateway = await activeGatewayIdentity(page);
+      expect(replacementGateway.clientInstanceId).not.toBe(originalGateway.clientInstanceId);
+      await expect
+        .poll(() => entryRow.getByRole("button", { name: "Actions: SERVICE_URL" }).isEnabled())
+        .toBe(true);
+
+      await confirmation.getByRole("button", { name: "Delete", exact: true }).click();
+
+      await expect
+        .poll(async () => ({
+          alerts: await page.getByRole("alert").count(),
+          deletes: (await gateway.getRequests("secrets.store.delete")).length,
+        }))
+        .not.toEqual({ alerts: 0, deletes: 0 });
+      expect(await gateway.getRequests("secrets.store.delete")).toHaveLength(0);
+      await page
+        .getByRole("alert")
+        .getByText("The secret was not deleted. Reload the list and try again.", { exact: true })
+        .waitFor();
+      await capture(page, "06-client-replacement-delete-rejected.png");
+      await entryRow.waitFor();
+    });
+  });
+
+  it("deletes a confirmed entry after the same Gateway client reconnects", async () => {
+    await suite.withPage({}, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["secrets.store.list", "secrets.store.delete"],
+        methodResponses: {
+          "secrets.store.list": {
+            sequence: [{ entries: [envEntry] }, { entries: [envEntry] }, { entries: [] }],
+          },
+          "secrets.store.delete": { ok: true, reloaded: false },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}settings/secrets`);
+      const entryRow = page.getByRole("row", { name: /SERVICE_URL/u });
+      await entryRow.getByRole("button", { name: "Actions: SERVICE_URL" }).click();
+      await entryRow.locator('wa-dropdown-item[value="delete"]').click();
+      const confirmation = page.locator('openclaw-modal-dialog[label="Delete"]');
+      await confirmation.getByText("Delete SERVICE_URL?", { exact: true }).waitFor();
+
+      const originalGateway = await activeGatewayIdentity(page);
+      const socketCount = await gateway.getSocketCount();
+      const listCount = (await gateway.getRequests("secrets.store.list")).length;
+      await gateway.closeLatest(1012, "secret delete confirmation reconnect proof");
+      await expect.poll(() => gateway.getSocketCount()).toBeGreaterThan(socketCount);
+      await expect
+        .poll(async () => (await gateway.getRequests("secrets.store.list")).length)
+        .toBeGreaterThan(listCount);
+      await expect
+        .poll(() => activeGatewayIdentity(page))
+        .toMatchObject({
+          clientInstanceId: originalGateway.clientInstanceId,
+          gatewayUrl: originalGateway.gatewayUrl,
+          phase: "connected",
+        });
+
+      await confirmation.getByRole("button", { name: "Delete", exact: true }).click();
+
+      await expect
+        .poll(async () => (await gateway.getRequests("secrets.store.delete")).length)
+        .toBe(1);
+      await expect.poll(() => entryRow.count()).toBe(0);
+    });
   });
 
   it("keeps optional store actions hidden when the Gateway omits method discovery", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a user could open a secret deletion confirmation on one Gateway client, replace the same-URL connection credentials while the dialog was open, and then delete the same-named entry through the replacement client.

The confirmation belonged to the old client, but the delayed action used the new one.

## Why This Change Was Made

The Secrets page now captures the Gateway and client that own the confirmation, then revalidates both immediately after the user confirms.

A replacement client or lost delete permission stops the action and shows a reload-and-retry message. A reconnect by the same client remains valid.

This matches the destructive-confirmation boundary used by the Cloud Workers page. It adds no state, fallback, protocol, config, or compatibility path.

## User Impact

A stale confirmation can no longer delete an entry through a replacement Gateway client. The entry stays visible and the page explains how to retry.

Ordinary reconnects do not interrupt a confirmed deletion.

## Evidence

- Current-main red: `32bd1602e54009287f24157f8a1776691f56f77e` sent one `secrets.store.delete` request after same-URL credentials replaced the Gateway client. Expected: zero.
- Exact-head green: `07649bb956a9fe8533d61a59bdeeeea4fe3ee0c5` sent zero delete requests after replacement, retained the row, and showed `The secret was not deleted. Reload the list and try again.` The final head adds only an explanatory invariant comment to the proven behavior.
- Same-client reconnect control sent exactly one delete request and removed the row.
- Browser command: `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/pages/secrets/secrets.e2e.test.ts` — 5 passed.
- Focused owner and authorization tests: 253 passed across the Secrets store, Gateway page lifecycle, Gateway client lifecycle, Secrets server methods, and method scopes.
- `oxfmt --check`, direct non-type-aware `oxlint`, Control UI localization verification, repository ratchets, and `git diff --check` pass.
- Production delta: `+11/-0`, including the required two-line ownership comment. Test delta: `+144/-0`.
- Earlier patch-identical real-Gateway Chromium proof and media remain in [artifact 9597523952](https://github.com/Alix-007/openclaw/actions/runs/32942873237/artifacts/9597523952).
