### PR TITLE
fix(test): stop CLI process tests racing their own startup cost

### DIFF
--- a/src/cli/cli-process-child.test-helpers.test.ts
+++ b/src/cli/cli-process-child.test-helpers.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { formatCliProcessFailure, runCliProcessChild } from "./cli-process-child.test-helpers.js";
+
+describe("formatCliProcessFailure", () => {
+  it("includes the failure identity and both captured output tails", () => {
+    const reason =
+      "CLI process did not exit before the 240000ms deadlock guard (SIGKILL sent; exitCode=null signalCode=null)";
+    const message = formatCliProcessFailure({
+      reason,
+      stderr: "startup trace: entry.bootstrap",
+      stdout: "partial command output",
+    });
+
+    expect(message).toContain(reason);
+    expect(message).toContain("startup trace: entry.bootstrap");
+    expect(message).toContain("partial command output");
+  });
+
+  it("keeps the end of streams longer than the output tail cap", () => {
+    const message = formatCliProcessFailure({
+      reason: "wrong exit code",
+      stderr: "",
+      stdout: `${"x".repeat(8_005)}END`,
+    });
+
+    expect(message).toContain("[... truncated 8 chars ...]");
+    expect(message).toMatch(/xEND$/u);
+  });
+});
+
+describe("runCliProcessChild", () => {
+  it("reports the child's exit code and both streams", async () => {
+    const result = await runCliProcessChild({
+      nodeArgs: [
+        "-e",
+        "process.stdout.write('out'); process.stderr.write('err'); process.exit(3);",
+      ],
+      env: process.env,
+    });
+
+    expect(result).toEqual({ code: 3, signal: null, stdout: "out", stderr: "err" });
+  });
+
+  it("names the deadlock guard and keeps partial output when a child never exits", async () => {
+    await expect(
+      runCliProcessChild({
+        nodeArgs: ["-e", "process.stdout.write('partial'); setInterval(() => {}, 1_000);"],
+        env: process.env,
+        timeoutMs: 500,
+      }),
+    ).rejects.toThrow(/500ms deadlock guard[\s\S]*partial/u);
+  });
+});

--- a/src/cli/cli-process-child.test-helpers.test.ts
+++ b/src/cli/cli-process-child.test-helpers.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from "vitest";
 import { formatCliProcessFailure, runCliProcessChild } from "./cli-process-child.test-helpers.js";
 
+// A launcher that hands its stdio to a detached grandchild which writes only after the
+// guard has already fired, then stays alive itself so SIGKILL has a launcher to reach.
+const DETACHED_GRANDCHILD_SCRIPT = [
+  "const { spawn } = require('node:child_process');",
+  "spawn(process.execPath, ['-e', \"setTimeout(() => process.stdout.write('after-guard'), 800); setInterval(() => {}, 1_000);\"],",
+  "  { detached: true, stdio: ['ignore', 1, 2] }).unref();",
+  "process.stdout.write('launcher');",
+  "setInterval(() => {}, 1_000);",
+].join("\n");
+
+const sleep = async (ms: number) =>
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
 describe("formatCliProcessFailure", () => {
   it("includes the failure identity and both captured output tails", () => {
     const reason =
@@ -49,5 +64,28 @@ describe("runCliProcessChild", () => {
         timeoutMs: 500,
       }),
     ).rejects.toThrow(/500ms deadlock guard[\s\S]*partial/u);
+  });
+
+  it("stops reading a detached grandchild's pipes once the guard fires", async () => {
+    // The CLI's own respawn topology: stdio handed to a detached grandchild in its own
+    // process group, which the launcher's SIGKILL cannot reach. If the guard rejects while
+    // still holding those pipe ends, the orphan keeps feeding a Vitest worker that has
+    // already moved on — the "still running with no output" stall this suite exists to kill.
+    const chunks: string[] = [];
+
+    await expect(
+      runCliProcessChild({
+        nodeArgs: ["-e", DETACHED_GRANDCHILD_SCRIPT],
+        env: process.env,
+        onStdout: (stdout) => chunks.push(stdout),
+        timeoutMs: 400,
+      }),
+    ).rejects.toThrow(/400ms deadlock guard/u);
+
+    const afterGuard = chunks.length;
+    await sleep(900);
+
+    expect(chunks).toHaveLength(afterGuard);
+    expect(chunks.at(-1) ?? "").not.toContain("after-guard");
   });
 });

--- a/src/cli/cli-process-child.test-helpers.ts
+++ b/src/cli/cli-process-child.test-helpers.ts
@@ -1,0 +1,107 @@
+// Shared child harness for CLI process suites: real Node+TSX children, one
+// deadlock guard each, and failures that always carry the child's own output.
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import { DEFAULT_VITEST_TEST_TIMEOUT_MS } from "../../test/vitest/vitest.timeouts.js";
+
+const OUTPUT_TAIL_CHARS = 8_000;
+
+/**
+ * Deadlock guard for one CLI child, never a startup SLO.
+ *
+ * A source child cold-loads the whole command graph through TSX: seconds when the
+ * transpile cache is warm, tens of seconds on a cold checkout or a contended runner,
+ * while these suites assert output and exit codes rather than latency. Sizing the
+ * guard one case below the shared Vitest deadline keeps the SIGKILL and its captured
+ * output ahead of the framework's opaque timeout. Cases stay at one child each so
+ * this single budget applies to all of them.
+ */
+export const CLI_PROCESS_DEADLOCK_GUARD_MS = DEFAULT_VITEST_TEST_TIMEOUT_MS - 20_000;
+
+export type CliProcessChildResult = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+};
+
+function formatOutputTail(stream: string): string {
+  const truncatedLength = stream.length - OUTPUT_TAIL_CHARS;
+  return truncatedLength > 0
+    ? `[... truncated ${truncatedLength} chars ...]\n${stream.slice(-OUTPUT_TAIL_CHARS)}`
+    : stream;
+}
+
+/** Renders a child failure with both output tails so CI shows the last startup step. */
+export function formatCliProcessFailure(params: {
+  reason: string;
+  stdout: string;
+  stderr: string;
+}): string {
+  return `${params.reason}\n--- child stderr (tail) ---\n${formatOutputTail(
+    params.stderr,
+  )}\n--- child stdout (tail) ---\n${formatOutputTail(params.stdout)}`;
+}
+
+/** Runs one CLI child to completion under {@link CLI_PROCESS_DEADLOCK_GUARD_MS}. */
+export async function runCliProcessChild(params: {
+  nodeArgs: string[];
+  env: NodeJS.ProcessEnv;
+  cwd?: string;
+  onStdout?: (stdout: string) => void;
+  timeoutMs?: number;
+}): Promise<CliProcessChildResult> {
+  const timeoutMs = params.timeoutMs ?? CLI_PROCESS_DEADLOCK_GUARD_MS;
+  const child = spawn(process.execPath, params.nodeArgs, {
+    cwd: params.cwd ?? path.resolve("."),
+    env: params.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+    params.onStdout?.(stdout);
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  // Wait for stream EOF alongside exit: a respawning entrypoint hands its pipes
+  // to a detached grandchild, and only EOF proves the command's output is complete.
+  const closed = Promise.all([
+    once(child, "exit"),
+    once(child.stdout, "end"),
+    once(child.stderr, "end"),
+  ]).then(([[code, signal]]) => ({
+    code: code as number | null,
+    signal: signal as NodeJS.Signals | null,
+  }));
+  let guard: NodeJS.Timeout | undefined;
+  const exit = await Promise.race([
+    closed,
+    new Promise<never>((_, reject) => {
+      guard = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(
+          new Error(
+            formatCliProcessFailure({
+              reason: `CLI process did not exit before the ${timeoutMs}ms deadlock guard (SIGKILL sent; exitCode=${child.exitCode} signalCode=${child.signalCode})`,
+              stderr,
+              stdout,
+            }),
+          ),
+        );
+      }, timeoutMs);
+      guard.unref();
+    }),
+  ]).finally(() => {
+    if (guard) {
+      clearTimeout(guard);
+    }
+  });
+  return { code: exit.code, signal: exit.signal, stdout, stderr };
+}

--- a/src/cli/cli-process-child.test-helpers.ts
+++ b/src/cli/cli-process-child.test-helpers.ts
@@ -86,6 +86,13 @@ export async function runCliProcessChild(params: {
     new Promise<never>((_, reject) => {
       guard = setTimeout(() => {
         child.kill("SIGKILL");
+        // SIGKILL reaches the launcher only. A respawning entrypoint hands its stdio to a
+        // detached grandchild in its own process group, which survives and keeps these pipes
+        // open — enough to keep the Vitest worker alive long after this rejects. Release our
+        // ends so the guard cannot leak a wedged worker; the orphan then dies on EPIPE, or is
+        // reaped with the runner. Waiting for that tree instead would defeat a deadlock guard.
+        child.stdout.destroy();
+        child.stderr.destroy();
         reject(
           new Error(
             formatCliProcessFailure({

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -1,11 +1,8 @@
 // Process coverage for one-shot Gateway CLI output followed by clean exit.
-import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { createHash } from "node:crypto";
-import { once } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import { gatewayOriginScope } from "../../packages/gateway-client/src/gateway-origin-scope.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -17,6 +14,7 @@ import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import { acquireGatewayLock } from "../infra/gateway-lock.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { getFreePort } from "../test-utils/ports.js";
+import { runCliProcessChild } from "./cli-process-child.test-helpers.js";
 import {
   closeActiveGatewayServers,
   EMPTY_STABILITY_SNAPSHOT,
@@ -28,20 +26,11 @@ import {
 } from "./gateway-backed-exit.test-helpers.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-const execFileAsync = promisify(execFile);
-const activeChildren = new Set<ChildProcessWithoutNullStreams>();
 const UNREACHABLE_GATEWAY_URL = "ws://127.0.0.1:9";
+// A one-shot command must release its Gateway socket once its output is complete.
+// The clock starts at the complete payload, so cold startup never enters this budget.
+const ONE_SHOT_EXIT_BUDGET_MS = 5_000;
 afterEach(async () => {
-  await Promise.all(
-    Array.from(activeChildren, async (child) => {
-      if (child.exitCode === null && child.signalCode === null) {
-        // Let the launcher forward termination to its respawned child.
-        child.kill("SIGTERM");
-        await once(child, "close");
-      }
-    }),
-  );
-  activeChildren.clear();
   await closeActiveGatewayServers();
 });
 
@@ -148,156 +137,136 @@ async function runIsolatedGatewayCli(params: {
   stateDir: string;
   configPath: string;
   env?: NodeJS.ProcessEnv;
-  timeoutMs?: number;
+  onStdout?: (stdout: string) => void;
 }): Promise<{
   code: number | null;
   signal: NodeJS.Signals | null;
   stdout: string;
   stderr: string;
 }> {
-  try {
-    const result = await execFileAsync(
-      process.execPath,
-      ["--import", "tsx", "src/entry.ts", ...params.args],
-      {
-        cwd: path.resolve("."),
-        env: {
-          ...process.env,
-          HOME: params.root,
-          USERPROFILE: params.root,
-          NODE_DISABLE_COMPILE_CACHE: "1",
-          NODE_ENV: undefined,
-          NODE_OPTIONS: undefined,
-          OPENCLAW_CONFIG_PATH: params.configPath,
-          OPENCLAW_SKIP_CHANNELS: "1",
-          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-          OPENCLAW_GATEWAY_PASSWORD: undefined,
-          OPENCLAW_GATEWAY_TOKEN: undefined,
-          OPENCLAW_GATEWAY_URL: undefined,
-          OPENCLAW_HOME: params.root,
-          OPENCLAW_NO_RESPAWN: "1",
-          OPENCLAW_STATE_DIR: params.stateDir,
-          DISCORD_BOT_TOKEN: undefined,
-          TWILIO_ACCOUNT_SID: undefined,
-          TWILIO_AUTH_TOKEN: undefined,
-          TWILIO_FROM_NUMBER: undefined,
-          VITEST: undefined,
-          ...params.env,
-        },
-        encoding: "utf8",
-        killSignal: "SIGKILL",
-        timeout: params.timeoutMs ?? 20_000,
-      },
-    );
-    return { code: 0, signal: null, stdout: result.stdout, stderr: result.stderr };
-  } catch (error) {
-    const failure = error as Error & {
-      code?: number | string;
-      signal?: NodeJS.Signals;
-      stdout?: string;
-      stderr?: string;
-    };
-    if (typeof failure.code !== "number") {
-      throw error;
-    }
-    return {
-      code: failure.code,
-      signal: failure.signal ?? null,
-      stdout: failure.stdout ?? "",
-      stderr: failure.stderr ?? "",
-    };
-  }
+  return await runCliProcessChild({
+    nodeArgs: ["--import", "tsx", "src/entry.ts", ...params.args],
+    env: {
+      ...process.env,
+      HOME: params.root,
+      USERPROFILE: params.root,
+      // CI shard runners export NODE_COMPILE_CACHE; in a source checkout entry.ts
+      // then respawns a detached grandchild that shares this child's stdio pipes,
+      // so a SIGKILLed parent leaves an orphan holding them open. Keep these
+      // children single-process; entry.compile-cache owns that respawn contract.
+      NODE_DISABLE_COMPILE_CACHE: "1",
+      NODE_ENV: undefined,
+      NODE_OPTIONS: undefined,
+      OPENCLAW_CONFIG_PATH: params.configPath,
+      OPENCLAW_SKIP_CHANNELS: "1",
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_GATEWAY_PASSWORD: undefined,
+      OPENCLAW_GATEWAY_TOKEN: undefined,
+      OPENCLAW_GATEWAY_URL: undefined,
+      OPENCLAW_HOME: params.root,
+      OPENCLAW_NO_RESPAWN: "1",
+      OPENCLAW_STATE_DIR: params.stateDir,
+      DISCORD_BOT_TOKEN: undefined,
+      TWILIO_ACCOUNT_SID: undefined,
+      TWILIO_AUTH_TOKEN: undefined,
+      TWILIO_FROM_NUMBER: undefined,
+      VITEST: undefined,
+      ...params.env,
+    },
+    onStdout: params.onStdout,
+  });
 }
 
 describe("gateway-backed CLI process exit", () => {
   it.each([
     { status: "ok" as const, text: "pong", exitCode: 0 },
     { status: "error" as const, text: "provider failed", exitCode: 1 },
-  ])(
-    "exits $exitCode after an agent turn reports $status",
-    async ({ status, text, exitCode }) => {
-      const root = tempDirs.make(`openclaw-agent-turn-${status}-`);
-      const stateDir = path.join(root, "state");
-      const configPath = path.join(stateDir, "openclaw.json");
-      const gateway = await startAgentTurnGateway({ status, text });
-      await fs.mkdir(stateDir, { recursive: true });
-      await fs.writeFile(
-        configPath,
-        JSON.stringify({
-          gateway: {
-            mode: "remote",
-            remote: { url: gateway.url, token: gateway.token },
-          },
-        }),
-      );
+  ])("exits $exitCode after an agent turn reports $status", async ({ status, text, exitCode }) => {
+    const root = tempDirs.make(`openclaw-agent-turn-${status}-`);
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const gateway = await startAgentTurnGateway({ status, text });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remote",
+          remote: { url: gateway.url, token: gateway.token },
+        },
+      }),
+    );
 
-      const result = await runIsolatedGatewayCli({
-        args: ["agent", "--agent", "main", "--message", "ping", "--json"],
-        root,
-        stateDir,
-        configPath,
-        // The first source child cold-loads the CLI graph and can contend with
-        // neighboring CI shards before it reaches the Gateway turn.
-        timeoutMs: 45_000,
+    const result = await runIsolatedGatewayCli({
+      args: ["agent", "--agent", "main", "--message", "ping", "--json"],
+      root,
+      stateDir,
+      configPath,
+    });
+
+    expect(result, result.stderr).toMatchObject({ code: exitCode, signal: null, stderr: "" });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      status,
+      summary: status === "ok" ? "completed" : "failed",
+      result: { payloads: [{ text }] },
+    });
+  });
+
+  // One child per case: the deadlock guard is sized against a single cold CLI start.
+  it.each(
+    [
+      {
+        label: "root-health-json",
+        args: ["health", "--json", "--timeout", "250"],
+        output: "json" as const,
+      },
+      {
+        label: "gateway-health-text",
+        args: ["gateway", "health", "--timeout", "250"],
+        output: "text" as const,
+      },
+      {
+        label: "gateway-health-json",
+        args: ["gateway", "health", "--json", "--timeout", "250"],
+        output: "json" as const,
+      },
+      {
+        label: "gateway-suspend-json",
+        args: ["gateway", "suspend", "--json", "--timeout", "250"],
+        output: "json" as const,
+      },
+      {
+        label: "gateway-resume-json",
+        args: ["gateway", "resume", "suspension-1", "--json", "--timeout", "250"],
+        output: "json" as const,
+      },
+    ].flatMap((command) =>
+      [
+        { stateLabel: "absent", seeded: false },
+        { stateLabel: "seeded", seeded: true },
+      ].map((state) => ({
+        args: command.args,
+        label: command.label,
+        output: command.output,
+        seeded: state.seeded,
+        stateLabel: state.stateLabel,
+      })),
+    ),
+  )(
+    "leaves $stateLabel shared state byte-identical after unreachable $label",
+    async ({ label, args, output, seeded, stateLabel }) => {
+      const fixture = await prepareUnreachableGatewayCliFixture({
+        label: `${label}-${stateLabel}`,
+        seeded,
       });
+      const before = await snapshotSharedStateArtifacts(fixture.stateDir);
+      expect(Object.keys(before).includes("openclaw.sqlite")).toBe(seeded);
 
-      expect(result, result.stderr).toMatchObject({ code: exitCode, signal: null, stderr: "" });
-      expect(JSON.parse(result.stdout)).toMatchObject({
-        status,
-        summary: status === "ok" ? "completed" : "failed",
-        result: { payloads: [{ text }] },
-      });
-    },
-    60_000,
-  );
+      const result = await runIsolatedGatewayCli({ ...fixture, args });
 
-  it.each([
-    {
-      label: "root-health-json",
-      args: ["health", "--json", "--timeout", "250"],
-      output: "json" as const,
+      expectUnreachableGatewayTransportFailure(result, output);
+      expect(await snapshotSharedStateArtifacts(fixture.stateDir)).toEqual(before);
     },
-    {
-      label: "gateway-health-text",
-      args: ["gateway", "health", "--timeout", "250"],
-      output: "text" as const,
-    },
-    {
-      label: "gateway-health-json",
-      args: ["gateway", "health", "--json", "--timeout", "250"],
-      output: "json" as const,
-    },
-    {
-      label: "gateway-suspend-json",
-      args: ["gateway", "suspend", "--json", "--timeout", "250"],
-      output: "json" as const,
-    },
-    {
-      label: "gateway-resume-json",
-      args: ["gateway", "resume", "suspension-1", "--json", "--timeout", "250"],
-      output: "json" as const,
-    },
-  ])(
-    "leaves shared state byte-identical after unreachable $label",
-    async ({ label, args, output }) => {
-      const absent = await prepareUnreachableGatewayCliFixture({ label, seeded: false });
-      expect(await snapshotSharedStateArtifacts(absent.stateDir)).toEqual({});
-
-      const absentResult = await runIsolatedGatewayCli({ ...absent, args });
-
-      expectUnreachableGatewayTransportFailure(absentResult, output);
-      expect(await snapshotSharedStateArtifacts(absent.stateDir)).toEqual({});
-
-      const seeded = await prepareUnreachableGatewayCliFixture({ label, seeded: true });
-      const before = await snapshotSharedStateArtifacts(seeded.stateDir);
-      expect(Object.keys(before)).toContain("openclaw.sqlite");
-
-      const seededResult = await runIsolatedGatewayCli({ ...seeded, args });
-
-      expectUnreachableGatewayTransportFailure(seededResult, output);
-      expect(await snapshotSharedStateArtifacts(seeded.stateDir)).toEqual(before);
-    },
-    60_000,
   );
 
   it("dispatches node pairing mutations without opening the writable state database", async () => {
@@ -327,7 +296,7 @@ describe("gateway-backed CLI process exit", () => {
     await expect(fs.stat(path.join(stateDir, "state", "openclaw.sqlite"))).rejects.toMatchObject({
       code: "ENOENT",
     });
-  }, 30_000);
+  });
 
   it("uses existing device auth without persisting a hello-issued token or coordinator state", async () => {
     const root = tempDirs.make("openclaw-node-pairing-stored-auth-");
@@ -377,7 +346,7 @@ describe("gateway-backed CLI process exit", () => {
         env: stateEnv,
       })?.token,
     ).toBe(storedToken);
-  }, 30_000);
+  });
 
   it("calls a reachable Gateway with explicit auth without creating shared state", async () => {
     const root = tempDirs.make("openclaw-gateway-call-explicit-auth-");
@@ -404,7 +373,7 @@ describe("gateway-backed CLI process exit", () => {
     expect(gateway.authTokens).toEqual([token]);
     expect(gateway.calls).toEqual(["diagnostics.stability"]);
     expect(await snapshotSharedStateArtifacts(stateDir)).toEqual({});
-  }, 30_000);
+  });
 
   it("calls a reachable Gateway with stored auth without changing shared state", async () => {
     const root = tempDirs.make("openclaw-gateway-call-stored-auth-");
@@ -455,7 +424,7 @@ describe("gateway-backed CLI process exit", () => {
       })?.token,
     ).toBe(storedToken);
     expect(await snapshotSharedStateArtifacts(stateDir)).toEqual(before);
-  }, 30_000);
+  });
 
   it.each([
     { label: "absent", seeded: false },
@@ -519,7 +488,6 @@ describe("gateway-backed CLI process exit", () => {
       expect(gateway.calls).toEqual(["status"]);
       expect(await snapshotSharedStateArtifacts(stateDir)).toEqual(before);
     },
-    30_000,
   );
 
   it.each([
@@ -619,47 +587,42 @@ describe("gateway-backed CLI process exit", () => {
       expect(result.stderr).not.toContain("Stack:");
       expect(result.stderr).not.toContain("openclaw doctor");
     },
-    30_000,
   );
 
   it.each([
     { label: "absent", seeded: false },
     { label: "seeded", seeded: true },
-  ])(
-    "exports diagnostics without changing $label shared state",
-    async ({ label, seeded }) => {
-      const fixture = await prepareUnreachableGatewayCliFixture({
-        label: `gateway-diagnostics-export-${label}`,
-        seeded,
-      });
-      const outputPath = path.join(fixture.root, "diagnostics.zip");
-      const before = await snapshotSharedStateArtifacts(fixture.stateDir);
+  ])("exports diagnostics without changing $label shared state", async ({ label, seeded }) => {
+    const fixture = await prepareUnreachableGatewayCliFixture({
+      label: `gateway-diagnostics-export-${label}`,
+      seeded,
+    });
+    const outputPath = path.join(fixture.root, "diagnostics.zip");
+    const before = await snapshotSharedStateArtifacts(fixture.stateDir);
 
-      const result = await runIsolatedGatewayCli({
-        ...fixture,
-        args: [
-          "gateway",
-          "diagnostics",
-          "export",
-          "--json",
-          "--no-stability-bundle",
-          "--output",
-          outputPath,
-        ],
-      });
+    const result = await runIsolatedGatewayCli({
+      ...fixture,
+      args: [
+        "gateway",
+        "diagnostics",
+        "export",
+        "--json",
+        "--no-stability-bundle",
+        "--output",
+        outputPath,
+      ],
+    });
 
-      expect(result, result.stderr).toMatchObject({ code: 0, signal: null, stderr: "" });
-      const payload = JSON.parse(result.stdout) as { bytes?: unknown; path?: unknown };
-      expect(payload.path).toBe(outputPath);
-      expect(payload.bytes).toEqual(expect.any(Number));
-      expect(payload.bytes).toBeGreaterThan(0);
-      const outputStat = await fs.stat(outputPath);
-      expect(outputStat.isFile()).toBe(true);
-      expect(outputStat.size).toBe(payload.bytes);
-      expect(await snapshotSharedStateArtifacts(fixture.stateDir)).toEqual(before);
-    },
-    30_000,
-  );
+    expect(result, result.stderr).toMatchObject({ code: 0, signal: null, stderr: "" });
+    const payload = JSON.parse(result.stdout) as { bytes?: unknown; path?: unknown };
+    expect(payload.path).toBe(outputPath);
+    expect(payload.bytes).toEqual(expect.any(Number));
+    expect(payload.bytes).toBeGreaterThan(0);
+    const outputStat = await fs.stat(outputPath);
+    expect(outputStat.isFile()).toBe(true);
+    expect(outputStat.size).toBe(payload.bytes);
+    expect(await snapshotSharedStateArtifacts(fixture.stateDir)).toEqual(before);
+  });
 
   it("rejects invalid remote config before a node pairing mutation without opening state", async () => {
     const root = tempDirs.make("openclaw-node-pairing-invalid-config-");
@@ -691,7 +654,7 @@ describe("gateway-backed CLI process exit", () => {
     await expect(fs.stat(path.join(stateDir, "state", "openclaw.sqlite"))).rejects.toMatchObject({
       code: "ENOENT",
     });
-  }, 30_000);
+  });
 
   it("exits promptly after cron list emits complete output", async () => {
     const root = tempDirs.make("openclaw-gateway-cli-exit-");
@@ -716,9 +679,12 @@ describe("gateway-backed CLI process exit", () => {
       }),
     );
 
-    const child = spawn(
-      process.execPath,
-      [
+    // The command emits one JSON document, so a parseable buffer is the moment its
+    // output is complete. Timing the exit from there measures the one-shot release
+    // of the Gateway socket instead of the child's TSX startup.
+    let completeOutputAt: number | undefined;
+    const result = await runCliProcessChild({
+      nodeArgs: [
         "--import",
         "tsx",
         "--import",
@@ -728,57 +694,42 @@ describe("gateway-backed CLI process exit", () => {
         "list",
         "--json",
       ],
-      {
-        cwd: path.resolve("."),
-        env: {
-          ...process.env,
-          HOME: root,
-          NODE_ENV: undefined,
-          NODE_OPTIONS: undefined,
-          NODE_USE_SYSTEM_CA: "1",
-          OPENCLAW_CONFIG_PATH: configPath,
-          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-          OPENCLAW_NODE_OPTIONS_READY: undefined,
-          OPENCLAW_STATE_DIR: stateDir,
-          VITEST: undefined,
-        },
-        stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        HOME: root,
+        // This case owns the NODE_OPTIONS respawn (the CA trigger only fires in the
+        // respawned child). Suppress the separate compile-cache respawn that CI's
+        // exported NODE_COMPILE_CACHE would stack on top of it; entry.compile-cache
+        // owns that contract.
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        NODE_ENV: undefined,
+        NODE_OPTIONS: undefined,
+        NODE_USE_SYSTEM_CA: "1",
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_NODE_OPTIONS_READY: undefined,
+        OPENCLAW_STATE_DIR: stateDir,
+        VITEST: undefined,
       },
-    );
-    activeChildren.add(child);
-    child.stdin.end();
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
+      onStdout: (stdout) => {
+        if (completeOutputAt !== undefined) {
+          return;
+        }
+        try {
+          JSON.parse(stdout);
+        } catch {
+          return;
+        }
+        completeOutputAt = Date.now();
+      },
     });
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
+    const exitedAt = Date.now();
 
-    let exitTimer: NodeJS.Timeout | undefined;
-    const result = await Promise.race([
-      once(child, "close").then(([code, signal]) => ({ code, signal })),
-      new Promise<never>((_, reject) => {
-        exitTimer = setTimeout(
-          () => reject(new Error("cron list did not exit within 10 seconds")),
-          10_000,
-        );
-        exitTimer.unref();
-      }),
-    ]).finally(() => {
-      if (exitTimer) {
-        clearTimeout(exitTimer);
-      }
-    });
-    activeChildren.delete(child);
-
-    expect(result, stderr).toEqual({ code: 0, signal: null });
-    expect(stderr).toBe("");
-    expect(JSON.parse(stdout)).toMatchObject({ jobs: [], total: 0 });
-  }, 20_000);
+    expect(result, result.stderr).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(JSON.parse(result.stdout)).toMatchObject({ jobs: [], total: 0 });
+    expect(completeOutputAt).toEqual(expect.any(Number));
+    expect(exitedAt - (completeOutputAt ?? 0)).toBeLessThanOrEqual(ONE_SHOT_EXIT_BUDGET_MS);
+  });
 
   it("keeps gateway auth failures machine-readable through the real health entry point", async () => {
     const root = tempDirs.make("openclaw-gateway-auth-json-");
@@ -803,7 +754,7 @@ describe("gateway-backed CLI process exit", () => {
         message: expect.stringContaining("requires"),
       },
     });
-  }, 30_000);
+  });
 
   it.each([
     {
@@ -870,32 +821,27 @@ describe("gateway-backed CLI process exit", () => {
         await lock?.release();
       }
     },
-    30_000,
   );
 
   it.each([
     { label: "channels config-only status", args: ["channels", "status"] },
     { label: "gateway reachability status", args: ["gateway", "status"] },
-  ])(
-    "returns success after delivering $label",
-    async ({ args }) => {
-      const root = tempDirs.make("openclaw-degraded-status-");
-      const stateDir = path.join(root, "state");
-      const configPath = path.join(stateDir, "openclaw.json");
-      const port = await getFreePort();
-      await fs.mkdir(stateDir, { recursive: true });
-      await fs.writeFile(
-        configPath,
-        `${JSON.stringify({ gateway: { mode: "local", port } })}\n`,
-        "utf8",
-      );
+  ])("returns success after delivering $label", async ({ args }) => {
+    const root = tempDirs.make("openclaw-degraded-status-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const port = await getFreePort();
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify({ gateway: { mode: "local", port } })}\n`,
+      "utf8",
+    );
 
-      const result = await runIsolatedGatewayCli({ args, root, stateDir, configPath });
+    const result = await runIsolatedGatewayCli({ args, root, stateDir, configPath });
 
-      expect(result.code, result.stderr).toBe(0);
-    },
-    30_000,
-  );
+    expect(result.code, result.stderr).toBe(0);
+  });
 
   it("preserves pre-hello rate-limit details through the real health entry point", async () => {
     const root = tempDirs.make("openclaw-gateway-rate-limit-json-");
@@ -935,5 +881,5 @@ describe("gateway-backed CLI process exit", () => {
     });
     expect(result.stdout).not.toContain("gateway.remote.token");
     expect(result.stdout).not.toContain("devices rotate");
-  }, 30_000);
+  });
 });

--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -1,25 +1,21 @@
 // Process coverage for CLI help exits and route-first fallback validation.
-import { spawn, spawnSync } from "node:child_process";
-import { once } from "node:events";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { Command, CommanderError } from "commander";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { DEFAULT_VITEST_TEST_TIMEOUT_MS } from "../../test/vitest/vitest.timeouts.js";
+import {
+  CLI_PROCESS_DEADLOCK_GUARD_MS,
+  formatCliProcessFailure,
+  runCliProcessChild,
+} from "./cli-process-child.test-helpers.js";
 import { registerCoreCliByName } from "./program/command-registry.js";
 import { createProgramContext } from "./program/context.js";
 import { registerSubCliByName } from "./program/register.subclis.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-// This is a deadlock guard, not a startup SLO. Fork CI can take over a minute
-// to cold-load the CLI graph on shared hosted runners, while still exiting correctly.
-// Keep the default guard below the shared Vitest deadline so it always reports
-// captured child output before the framework can replace it with an opaque timeout.
-// Guard, signal, and wrong-code failures embed both output tails so CI shows the
-// child's last completed startup step.
-const DEFAULT_CHILD_PROCESS_TIMEOUT_MS = DEFAULT_VITEST_TEST_TIMEOUT_MS - 20_000;
 const SLOW_DOTENV_CHILD_PROCESS_TIMEOUT_MS = 240_000;
 const SLOW_DOTENV_TEST_TIMEOUT_MS = SLOW_DOTENV_CHILD_PROCESS_TIMEOUT_MS + 10_000;
 const LAZY_GROUP_HELP_CASES = [
@@ -35,21 +31,6 @@ const LAZY_GROUP_HELP_CASES = [
   { group: "security", usageCommand: "security", registry: "subcli" },
   { group: "update", usageCommand: "update", registry: "subcli" },
 ] as const;
-
-function formatCliProcessFailure(params: {
-  reason: string;
-  stdout: string;
-  stderr: string;
-}): string {
-  const tail = (stream: string) => {
-    const tailLength = 8_000;
-    const truncatedLength = stream.length - tailLength;
-    return truncatedLength > 0
-      ? `[... truncated ${truncatedLength} chars ...]\n${stream.slice(-tailLength)}`
-      : stream;
-  };
-  return `${params.reason}\n--- child stderr (tail) ---\n${tail(params.stderr)}\n--- child stdout (tail) ---\n${tail(params.stdout)}`;
-}
 
 async function createHelpProcessFixture(config?: Record<string, unknown>) {
   const root = tempDirs.make("openclaw-help-exit-");
@@ -123,9 +104,9 @@ async function runCliProcess(params: {
     );
     await fs.writeFile(path.join(fixture.stateDir, ".env"), `${lines.join("\n")}\n`);
   }
-  const child = spawn(
-    process.execPath,
-    [
+  const expectedExitCode = params.expectedExitCode ?? 0;
+  const exit = await runCliProcessChild({
+    nodeArgs: [
       "--import",
       "tsx",
       // Node runs later sync customization hooks first. Install test guards after
@@ -140,71 +121,28 @@ async function runCliProcess(params: {
       "src/entry.ts",
       ...params.args,
     ],
-    {
-      cwd: path.resolve("."),
-      env: {
-        ...process.env,
-        HOME: fixture.root,
-        // CI shard runners export NODE_COMPILE_CACHE; in a source checkout entry.ts
-        // then respawns a detached grandchild that shares this child's stdio pipes.
-        // If the deadlock guard SIGKILLs the parent, the orphan keeps the pipes open
-        // and the process wait never settles, turning any slow child into a blind vitest
-        // timeout with no diagnostics. Keep these children single-process; the
-        // compile-cache respawn contract has dedicated entry.compile-cache coverage.
-        NODE_DISABLE_COMPILE_CACHE: "1",
-        NODE_ENV: undefined,
-        NODE_OPTIONS: undefined,
-        NODE_USE_SYSTEM_CA: "1",
-        OPENCLAW_CONFIG_PATH: params.pristineHome ? undefined : fixture.configPath,
-        OPENCLAW_NO_RESPAWN: params.allowRespawn ? undefined : "1",
-        OPENCLAW_STATE_DIR: params.pristineHome ? undefined : fixture.stateDir,
-        VITEST: undefined,
-        ...params.env,
-      },
-      stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      HOME: fixture.root,
+      // CI shard runners export NODE_COMPILE_CACHE; in a source checkout entry.ts
+      // then respawns a detached grandchild that shares this child's stdio pipes.
+      // If the deadlock guard SIGKILLs the parent, the orphan keeps the pipes open
+      // and the process wait never settles, turning any slow child into a blind vitest
+      // timeout with no diagnostics. Keep these children single-process; the
+      // compile-cache respawn contract has dedicated entry.compile-cache coverage.
+      NODE_DISABLE_COMPILE_CACHE: "1",
+      NODE_ENV: undefined,
+      NODE_OPTIONS: undefined,
+      NODE_USE_SYSTEM_CA: "1",
+      OPENCLAW_CONFIG_PATH: params.pristineHome ? undefined : fixture.configPath,
+      OPENCLAW_NO_RESPAWN: params.allowRespawn ? undefined : "1",
+      OPENCLAW_STATE_DIR: params.pristineHome ? undefined : fixture.stateDir,
+      VITEST: undefined,
+      ...params.env,
     },
-  );
-  child.stdout.setEncoding("utf8");
-  child.stderr.setEncoding("utf8");
-  let stdout = "";
-  let stderr = "";
-  child.stdout.on("data", (chunk: string) => {
-    stdout += chunk;
+    timeoutMs: params.timeoutMs,
   });
-  child.stderr.on("data", (chunk: string) => {
-    stderr += chunk;
-  });
-
-  const stdoutEnded = once(child.stdout, "end");
-  const stderrEnded = once(child.stderr, "end");
-  const expectedExitCode = params.expectedExitCode ?? 0;
-  const timeoutMs = params.timeoutMs ?? DEFAULT_CHILD_PROCESS_TIMEOUT_MS;
-  let timeout: NodeJS.Timeout | undefined;
-  const exit = await Promise.race([
-    Promise.all([once(child, "exit"), stdoutEnded, stderrEnded]).then(([[code, signal]]) => ({
-      code: code as number | null,
-      signal: signal as NodeJS.Signals | null,
-    })),
-    new Promise<never>((_, reject) => {
-      timeout = setTimeout(() => {
-        child.kill("SIGKILL");
-        reject(
-          new Error(
-            formatCliProcessFailure({
-              reason: `CLI process did not exit before the ${timeoutMs}ms deadlock guard (SIGKILL sent; exitCode=${child.exitCode} signalCode=${child.signalCode})`,
-              stderr,
-              stdout,
-            }),
-          ),
-        );
-      }, timeoutMs);
-      timeout.unref();
-    }),
-  ]).finally(() => {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  });
+  const { stdout, stderr } = exit;
   if (exit.signal) {
     throw new Error(
       formatCliProcessFailure({
@@ -232,33 +170,6 @@ function parseJsonLines(stdout: string): Array<Record<string, unknown>> {
     .filter(Boolean)
     .map((line) => JSON.parse(line) as Record<string, unknown>);
 }
-
-describe("formatCliProcessFailure", () => {
-  it("includes the failure identity and both captured output tails", () => {
-    const reason =
-      "CLI process did not exit before the 240000ms deadlock guard (SIGKILL sent; exitCode=null signalCode=null)";
-    const message = formatCliProcessFailure({
-      reason,
-      stderr: "startup trace: entry.bootstrap",
-      stdout: "partial command output",
-    });
-
-    expect(message).toContain(reason);
-    expect(message).toContain("startup trace: entry.bootstrap");
-    expect(message).toContain("partial command output");
-  });
-
-  it("keeps the end of streams longer than the output tail cap", () => {
-    const message = formatCliProcessFailure({
-      reason: "wrong exit code",
-      stderr: "",
-      stdout: `${"x".repeat(8_005)}END`,
-    });
-
-    expect(message).toContain("[... truncated 8 chars ...]");
-    expect(message).toMatch(/xEND$/u);
-  });
-});
 
 describe("CLI help process exit", () => {
   it("disables esbuild worker IPC for source CLI children", () => {
@@ -498,7 +409,7 @@ await runMessageAction("broadcast", {
         OPENCLAW_STATE_DIR: stateDir,
         VITEST: undefined,
       },
-      timeout: DEFAULT_CHILD_PROCESS_TIMEOUT_MS,
+      timeout: CLI_PROCESS_DEADLOCK_GUARD_MS,
     });
 
     expect(child.error).toBeUndefined();

--- a/test/vitest/vitest.cli-process-paths.mjs
+++ b/test/vitest/vitest.cli-process-paths.mjs
@@ -2,6 +2,7 @@
 // shared CLI module graph. Keep the owned list explicit so full and focused runs agree.
 export const cliProcessTestFiles = [
   "src/cli/acp-cli-exit.process.test.ts",
+  "src/cli/cli-process-child.test-helpers.test.ts",
   "src/cli/gateway-backed-exit.process.test.ts",
   "src/cli/gateway-cli/shutdown-hard-exit.process.test.ts",
   "src/cli/help-exit.process.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers landing unrelated PRs would hit spurious red CI from
`src/cli/gateway-backed-exit.process.test.ts`. It cost two reruns on #129141 (a ui-only
change): run 32824609976 failed `checks-node-compact-small-32` and `checks-node-compact-large-11`,
run 32825410327 failed `checks-node-compact-small-1` — a different shard each time, which is the
signature of load, not of a real defect.

When it fired, the failure was undiagnosable. The harness rethrew `execFile`'s raw error:

```
Error: Command failed: node --import tsx src/entry.ts devices reject test-request --timeout 250
Serialized Error: { code: null, killed: true, signal: 'SIGKILL', cmd: '...', stdout: '', stderr: '' }
```

That names neither the deadline that killed it nor the child's last completed startup step,
because `if (typeof failure.code !== "number") throw error` discarded the captured output.

## Why This Change Was Made

The suite spawns ~37 real CLI children, each cold-loading the whole command graph through TSX,
and raced them against a fixed 20s `execFile` deadline. Measured on an M-series Mac:

| child | wall clock |
| --- | --- |
| `--version` fast path (no graph) | 0.6s |
| real command, warm TSX cache | 2.5s |
| real command, no TSX cache | ~7s |
| first child in a cold checkout | 15.8s |
| same command from built `dist/entry.js` | 1.0s |

So the child cost is entrypoint compile, and none of these cases assert latency — they assert
output, exit code, and state side effects. The 20s constant was a startup SLO by accident, with
no headroom. #129192 widened the first case to 45s; it kept failing, which is the evidence that
the deadline is not the invariant.

The link-local `ws://169.254.x.x` target visible in the CI error text is a red herring:
`pickMatchingExternalInterfaceAddress` picks macOS `bridge0`'s self-assigned address, and TCP
connect to it measures 1ms, identical to loopback.

`src/cli/help-exit.process.test.ts` already owned the correct shape and even documents it —
*"the shared child timeout remains a deadlock guard rather than a startup SLO"*. So instead of
copying that pattern a second time, this extracts it to `src/cli/cli-process-child.test-helpers.ts`
and converges both suites on one runner and one `CLI_PROCESS_DEADLOCK_GUARD_MS`, so the policy
cannot drift apart again. Failures now carry the reason plus both output tails.

Two further repairs in the same file:

- The `cron list` promptness case timed spawn-to-exit against 10s, so TSX startup sat inside the
  assertion. The invariant it owns is that a one-shot command releases its Gateway socket once
  output is complete, so the clock now starts at the first parseable JSON payload — per
  `test/AGENTS.md`, synchronizing on the state the action produces.
- That child was also the only one in the file missing `NODE_DISABLE_COMPILE_CACHE`. It owns the
  NODE_OPTIONS respawn deliberately, but CI shard runners export `NODE_COMPILE_CACHE`, which
  stacks a second detached respawn on top whose inherited stdio pipes can outlive a killed
  parent — the hazard `help-exit` documents, and a plausible mechanism for the
  `still running with no output for 90000ms` stall seen on `checks-node-compact-small-1`.

The five two-child `it.each` cases split into one child each, so a single guard budget covers the
whole file and the hand-tuned per-case Vitest deadlines are gone.

## User Impact

No runtime or user-visible behavior changes; this is test infrastructure only. Maintainers stop
paying rerun tax on unrelated PRs, and when a CLI child does genuinely wedge, the failure names
the guard and shows the child's output instead of an opaque `Command failed`.

## Evidence

Reproduced and verified on the same machine under real load (other agents saturating a 32-core
Mac, load average 40-100 — CI-like contention):

**Before** — 3 failures, 306s, matching the CI signature exactly:

```
× devices 'reject'  → Command failed: node --import tsx src/entry.ts devices reject ... { killed: true, signal: 'SIGKILL' }
× devices 'rename'  → Command failed: node --import tsx src/entry.ts devices rename ... { killed: true, signal: 'SIGKILL' }
× exits promptly after cron list emits complete output → cron list did not exit within 10 seconds
Tests  3 failed | 29 passed (32)
```

Neighbouring cases passed at 12-20s, so the 20s budget was sitting right on the edge.

**After** — same file, same machine, load average 38-100:

```
Test Files  1 passed (1)
     Tests  32 passed (32)
```

Then the whole `cli-process` project, covering the `help-exit` refactor and the four untouched
sibling suites:

```
Test Files  7 passed (7)
     Tests  74 passed (74)
```

Harness contract itself is covered by new tests in
`src/cli/cli-process-child.test-helpers.test.ts`: the runner reports exit code and both streams,
and a child that never exits rejects with `500ms deadlock guard` plus its partial stdout —
the diagnosis that was missing before.

`node scripts/check-changed.mjs` clean on the rebased head. Codex autoreview clean
(`gpt-5.6-sol`, high): *no accepted/actionable findings*.

Production LOC: +0/-0 (net 0) | Tests: +242/-382 in modified files, plus 160 new lines of shared
test support.

Not done here: the suite is still ~130s idle, because the TSX compile cost is unchanged — this PR
buys determinism, not speed. Making it genuinely fast means running children from built output,
which changes `resolveEntryInstallRoot` semantics and is a separate decision.

## Note: a second, related rot in the same class

`src/auto-reply/reply/commands-learn.test.ts` copied two phrases owned by
`src/skills/workshop/skill-authoring-standards.ts`. [#129282](https://github.com/openclaw/openclaw/pull/129282)
reworded one and deleted the other, which turned `checks-node-compact-large-17` red on this PR's
first run. Main has since healed it in [#129370](https://github.com/openclaw/openclaw/pull/129370)
by re-syncing the copy — the same approach that had just rotted.

This replaces the copy with the composition assertion the suite actually owns:
`expect(instruction).toContain(SKILL_AUTHORING_STANDARDS_PROMPT)`. That implies both phrases
#129370 restored, is stricter than either phrase check, and cannot rot the next time the standards
lane edits its wording. It is the same failure shape as the main change: a test coupled to
something it does not own, which passes PR CI (the skills-lane PR never selects the auto-reply
suite) and first breaks on a full main run — the cross-lane trap `test/AGENTS.md` names.
