### PR TITLE
fix(sessions): isolate maintenance from channel plugin resolvers

### DIFF
--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -7,6 +7,7 @@ import {
   writePersistedAuthProfileStateRaw,
 } from "../../agents/auth-profiles/sqlite.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
@@ -15,6 +16,7 @@ import {
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { appendSqliteTrajectoryRuntimeEvents } from "../../trajectory/runtime-store.sqlite.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { readSessionArchiveContentSync } from "./archive-compression.js";
@@ -1658,6 +1660,65 @@ describe("sqlite session normalization", () => {
         storePath: paths.sqlitePath,
       }).map((summary) => summary.sessionKey),
     ).toEqual(["agent:main:newer", "agent:main:newest"]);
+  });
+
+  it("commits unrelated channel sessions without invoking stored channel plugin resolvers", async () => {
+    vi.mocked(getRuntimeConfig).mockReturnValue({
+      session: { maintenance: { mode: "enforce", pruneAfter: "1d", maxEntries: 2 } },
+    });
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const scopeFor = (sessionKey: string) => ({
+      agentId: "main",
+      env,
+      sessionKey,
+      storePath: paths.sqlitePath,
+    });
+    const storedKey = "agent:main:broken:group:room:thread:reply";
+    const storedEntry = {
+      sessionId: "stored-channel-session",
+      updatedAt: Date.now() - 2 * 24 * 60 * 60 * 1000,
+    };
+    await patchSessionEntryCore(scopeFor(storedKey), () => storedEntry, {
+      fallbackEntry: storedEntry,
+      replaceEntry: true,
+      skipMaintenance: true,
+    });
+
+    const resolveSessionConversation = vi.fn(() => {
+      throw new Error("channel resolver must not run inside a SQLite write");
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "broken",
+          source: "test",
+          plugin: {
+            id: "broken",
+            meta: { label: "Broken" },
+            messaging: { resolveSessionConversation },
+          },
+        },
+      ]),
+    );
+
+    try {
+      for (const channel of ["telegram", "discord"]) {
+        const sessionKey = `agent:main:${channel}:direct:user`;
+        const entry = { sessionId: `${channel}-session`, updatedAt: Date.now() };
+        await expect(
+          patchSessionEntryCore(scopeFor(sessionKey), () => entry, {
+            fallbackEntry: entry,
+            replaceEntry: true,
+          }),
+        ).resolves.toMatchObject(entry);
+        expect(loadSessionEntry(scopeFor(sessionKey))).toMatchObject(entry);
+      }
+
+      expect(loadSessionEntry(scopeFor(storedKey))).toMatchObject(storedEntry);
+      expect(resolveSessionConversation).not.toHaveBeenCalled();
+    } finally {
+      resetPluginRuntimeStateForTest();
+    }
   });
 
   it("persists automatic dashboard archiving before stale-entry pruning", async () => {

--- a/src/config/sessions/store-maintenance-recent-preservation.test.ts
+++ b/src/config/sessions/store-maintenance-recent-preservation.test.ts
@@ -1,18 +1,83 @@
 // Recent-session preservation tests cover the operator-configured retention shield.
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { enforceSessionDiskBudget } from "./disk-budget.js";
 import {
   capEntryCount,
   pruneStaleEntries,
   resolveMaintenanceConfigFromInput,
+  shouldPreserveMaintenanceEntry,
 } from "./store-maintenance.js";
 import type { SessionEntry } from "./types.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 describe("recent session maintenance preservation", () => {
+  it.each(["classification", "pruning", "capping"] as const)(
+    "preserves external conversations during %s without invoking channel plugins",
+    (boundary) => {
+      const resolveSessionConversation = vi.fn(() => {
+        throw new Error("channel resolver must not run during session maintenance");
+      });
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "broken",
+            source: "test",
+            plugin: {
+              id: "broken",
+              meta: { label: "Broken" },
+              messaging: { resolveSessionConversation },
+            },
+          },
+        ]),
+      );
+
+      const updatedAt = Date.now() - 31 * DAY_MS;
+      const protectedKeys = [
+        "agent:main:broken:group:room:thread:reply",
+        "agent:main:broken:channel:room:with:colon",
+        "agent:main:telegram:dm:user:topic:77",
+        "agent:main:opaque:thread:reply",
+      ];
+      const removableKeys = [
+        "agent:main:old",
+        "agent:main:subagent:worker",
+        "agent:main:opaque:topic:unrelated",
+      ];
+      const store: Record<string, SessionEntry> = Object.fromEntries(
+        [...protectedKeys, ...removableKeys].map((key) => [key, { sessionId: key, updatedAt }]),
+      );
+
+      try {
+        if (boundary === "classification") {
+          for (const key of protectedKeys) {
+            expect(shouldPreserveMaintenanceEntry({ key, entry: store[key] })).toBe(true);
+          }
+          for (const key of removableKeys) {
+            expect(shouldPreserveMaintenanceEntry({ key, entry: store[key] })).toBe(false);
+          }
+        } else if (boundary === "pruning") {
+          expect(pruneStaleEntries(store, 30 * DAY_MS, { log: false })).toBe(removableKeys.length);
+        } else {
+          expect(capEntryCount(store, protectedKeys.length, { log: false })).toBe(
+            removableKeys.length,
+          );
+        }
+
+        for (const key of protectedKeys) {
+          expect(store).toHaveProperty(key);
+        }
+        expect(resolveSessionConversation).not.toHaveBeenCalled();
+      } finally {
+        resetPluginRuntimeStateForTest();
+      }
+    },
+  );
+
   it("is opt-in and keeps recent interactive sessions through prune and cap pressure", () => {
     const now = Date.now();
     const recentKey = "agent:main:dashboard:recent";

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -11,10 +11,10 @@ import {
   isCronSessionKey,
   isSubagentSessionKey,
   parseAgentSessionKey,
+  parseThreadSessionSuffix,
 } from "../../sessions/session-key-utils.js";
 import { sessionDeliveryOrigin } from "../../utils/delivery-context.shared.js";
 import type { SessionMaintenanceConfig, SessionMaintenanceMode } from "../types.base.js";
-import { parseSessionThreadInfoFast } from "./thread-info.js";
 import type { SessionEntry } from "./types.js";
 
 const log = createSubsystemLogger("sessions/store");
@@ -533,7 +533,7 @@ function isProtectedSessionMaintenanceEntry(
   if (isPrimarySessionMaintenanceKey(sessionKey)) {
     return true;
   }
-  if (parseSessionThreadInfoFast(sessionKey).threadId) {
+  if (parseThreadSessionSuffix(sessionKey).threadId) {
     return true;
   }
   if (isTelegramTopicSessionKey(sessionKey)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #121252.

A loaded channel plugin could execute its conversation resolver while synchronous session-store maintenance was classifying unrelated session keys. If that resolver threw, the SQLite write transaction rolled back and unrelated Telegram or Discord turns silently lost their replies.

## Why This Change Was Made

The maintenance owner only needs structural thread-suffix detection. Replace its plugin-dispatching thread parser with the existing pure session-key suffix parser, removing all channel-plugin execution from synchronous maintenance while preserving primary sessions, synthetic entries, generic threads, Telegram topics, external group/channel conversations, archived rows, and pinned rows.

Production LOC: +2/-2 (net 0). Tests: +127/-1.

## User Impact

A faulty or incompatible channel plugin can no longer abort unrelated inbound Telegram or Discord session writes. Their replies are delivered normally, and the faulty plugin's group session remains preserved by the existing retention policy.

Thanks @arividar for identifying the shared-maintenance failure mechanism.

## Evidence

- Four targeted owner-boundary regressions fail on unmodified `main` and pass with the repair.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/config/sessions/store-maintenance-recent-preservation.test.ts src/config/sessions/store.pruning.test.ts src/config/sessions/session-accessor.conformance.test.ts src/channels/turn/run-channel-turn.finalize.test.ts`: all 127 tests pass.
- Real isolated SQLite plus actual prepared Telegram and Discord inbound turns: each sends one final reply, commits its session transaction, preserves the faulty channel group, and calls the faulty resolver zero times. The unmodified baseline rolls back both writes and sends zero replies.
- `env -u OPENCLAW_TESTBOX OPENCLAW_LOCAL_CHECK=1 node scripts/check-changed.mjs -- src/config/sessions/store-maintenance.ts src/config/sessions/store-maintenance-recent-preservation.test.ts src/config/sessions/session-accessor.conformance.test.ts`: complete changed gate passes, including production/test typechecking, lint, formatting, dead-code checks, and database/schema guards.
- Fresh structured autoreview: clean; independent maintainer review: approved.
- Proposed head: `d76aff7bf695a22141bf8c075dd51f7f6495fb9d`.
