### PR TITLE
fix(ci): recover distant pull request bases in shallow checkouts

### DIFF
--- a/.github/actions/ensure-base-commit/action.yml
+++ b/.github/actions/ensure-base-commit/action.yml
@@ -33,7 +33,11 @@ runs:
           exit 2
         fi
 
-        if git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
+        has_base_commit() {
+          GIT_NO_LAZY_FETCH=1 git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1
+        }
+
+        if has_base_commit; then
           echo "Base commit already present: $BASE_SHA"
           exit 0
         fi
@@ -41,34 +45,38 @@ runs:
         fetch_base_ref() {
           timeout --signal=TERM --kill-after=10s 30s git \
             -c protocol.version=2 \
-            fetch "$@"
+            fetch --filter=blob:none "$@"
         }
 
         echo "Base commit missing; fetching exact SHA before branch history."
         if ! fetch_base_ref --no-tags --depth=1 origin "$BASE_SHA"; then
           echo "::warning title=ensure-base-commit exact fetch failed::Failed to fetch exact base SHA $BASE_SHA"
         fi
-        if git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
+        if has_base_commit; then
           echo "Resolved base commit after exact fetch: $BASE_SHA"
           exit 0
         fi
 
-        for deepen_by in 25 100 300; do
+        for deepen_by in 25 100 300 1000; do
           echo "Base commit missing; deepening $FETCH_REF by $deepen_by."
           if ! fetch_base_ref --no-tags --deepen="$deepen_by" origin -- "$FETCH_REF"; then
             echo "::warning title=ensure-base-commit fetch failed::Failed to deepen $FETCH_REF by $deepen_by while looking for $BASE_SHA"
           fi
-          if git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
+          if has_base_commit; then
             echo "Resolved base commit after deepening: $BASE_SHA"
             exit 0
           fi
         done
 
         echo "Base commit still missing; fetching full history for $FETCH_REF."
-        if ! fetch_base_ref --no-tags origin -- "$FETCH_REF"; then
+        full_history_args=(--no-tags)
+        if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+          full_history_args+=(--unshallow)
+        fi
+        if ! fetch_base_ref "${full_history_args[@]}" origin -- "$FETCH_REF"; then
           echo "::warning title=ensure-base-commit fetch failed::Failed to fetch full history for $FETCH_REF while looking for $BASE_SHA"
         fi
-        if git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
+        if has_base_commit; then
           echo "Resolved base commit after full ref fetch: $BASE_SHA"
           exit 0
         fi

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -900,6 +900,90 @@ function runGit(cwd: string, args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 }
 
+function runEnsureBaseCommitFixture(shallow: boolean) {
+  const root = tempDirs.make("openclaw-ensure-base-commit-");
+  const origin = path.join(root, "origin.git");
+  const checkout = path.join(root, "checkout");
+  const fakeBin = path.join(root, "bin");
+  const fetchLog = path.join(root, "fetch.log");
+  runGit(root, ["init", "--bare", "--initial-branch=main", origin]);
+  runGit(root, ["--git-dir", origin, "config", "uploadpack.allowFilter", "true"]);
+
+  const historyDepth = shallow ? 470 : 1;
+  const commits = Array.from({ length: historyDepth + 1 }, (_, index) => {
+    const message = `fixture ${index}`;
+    const content = `fixture ${index}\n`;
+    const parent = index === 0 ? "" : `from :${index}\n`;
+    return (
+      `commit refs/heads/main\nmark :${index + 1}\n` +
+      `committer CI Fixture <ci-fixture@example.invalid> ${1_700_000_000 + index} +0000\n` +
+      `data ${Buffer.byteLength(message)}\n${message}\n${parent}` +
+      `M 100644 inline fixture.txt\ndata ${Buffer.byteLength(content)}\n${content}`
+    );
+  }).join("\n");
+  execFileSync("git", ["--git-dir", origin, "fast-import", "--quiet"], {
+    input: `${commits}\ndone\n`,
+    encoding: "utf8",
+  });
+
+  const cloneArgs = ["clone", "--quiet", "--no-local"];
+  if (shallow) {
+    cloneArgs.push("--depth=2");
+  }
+  runGit(root, [...cloneArgs, origin, checkout]);
+
+  let baseSha = runGit(root, ["--git-dir", origin, "rev-parse", `main~${historyDepth}`]);
+  if (!shallow) {
+    const parent = runGit(root, ["--git-dir", origin, "rev-parse", "main"]);
+    const message = "remote update";
+    const content = "remote update\n";
+    const update =
+      `commit refs/heads/main\n` +
+      `committer CI Fixture <ci-fixture@example.invalid> 1700000010 +0000\n` +
+      `data ${Buffer.byteLength(message)}\n${message}\nfrom ${parent}\n` +
+      `M 100644 inline fixture.txt\ndata ${Buffer.byteLength(content)}\n${content}\ndone\n`;
+    execFileSync("git", ["--git-dir", origin, "fast-import", "--quiet"], {
+      input: update,
+      encoding: "utf8",
+    });
+    baseSha = runGit(root, ["--git-dir", origin, "rev-parse", "main"]);
+  }
+
+  mkdirSync(fakeBin);
+  const realGit = execFileSync("bash", ["-lc", "command -v git"], { encoding: "utf8" }).trim();
+  writeExecutable(path.join(fakeBin, "git"), [
+    "#!/usr/bin/env bash",
+    'if [[ " $* " == *" fetch "* ]]; then',
+    '  printf "%s\\n" "$*" >> "$FETCH_LOG"',
+    '  if [[ "${@: -1}" == "$BASE_SHA" ]]; then exit 128; fi',
+    '  if [[ "$BLOCK_DEEPEN" == "1" && " $* " == *" --deepen="* ]]; then exit 128; fi',
+    "fi",
+    'exec "$REAL_GIT" "$@"',
+  ]);
+
+  const action = parse(readFileSync(".github/actions/ensure-base-commit/action.yml", "utf8"));
+  const run = runWorkflowShellScript(action.runs.steps[0].run as string, {
+    cwd: checkout,
+    env: {
+      ...process.env,
+      BASE_SHA: baseSha,
+      BLOCK_DEEPEN: shallow ? "0" : "1",
+      FETCH_LOG: fetchLog,
+      FETCH_REF: "main",
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      REAL_GIT: realGit,
+    },
+  });
+
+  return {
+    baseSha,
+    checkout,
+    fetches: existsSync(fetchLog) ? readFileSync(fetchLog, "utf8") : "",
+    output: `${run.stdout}${run.stderr}`,
+    run,
+  };
+}
+
 function runPushDiffBaseFixture(options: {
   commitCount: 1 | 2 | 3;
   eventBaseSha: string | "parent";
@@ -5483,15 +5567,47 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
   it("bounds shared base commit fetches", () => {
     const action = readFileSync(".github/actions/ensure-base-commit/action.yml", "utf8");
     const exactFetch = action.indexOf('fetch_base_ref --no-tags --depth=1 origin "$BASE_SHA"');
-    const branchDeepening = action.indexOf("for deepen_by in 25 100 300");
+    const branchDeepening = action.indexOf("for deepen_by in 25 100 300 1000");
 
     expect(action).toContain("fetch_base_ref()");
     expect(action).toContain("timeout --signal=TERM --kill-after=10s 30s git");
     expect(action).toContain("-c protocol.version=2");
+    expect(action).toContain('fetch --filter=blob:none "$@"');
+    expect(action).toContain('GIT_NO_LAZY_FETCH=1 git rev-parse --verify "$BASE_SHA^{commit}"');
+    expect(action.match(/if has_base_commit; then/gu)).toHaveLength(4);
+    expect(action).toContain("git rev-parse --is-shallow-repository");
+    expect(action).toContain("--unshallow");
     expect(action).not.toContain("if ! git fetch --no-tags");
     expect(exactFetch).toBeGreaterThan(-1);
     expect(branchDeepening).toBeGreaterThan(exactFetch);
     expect(action).toContain("::error title=ensure-base-commit missing base::");
+  });
+
+  it("recovers filtered shallow base history beyond the initial deepening budget", () => {
+    const fixture = runEnsureBaseCommitFixture(true);
+
+    expect(fixture.run.status, fixture.output).toBe(0);
+    expect(fixture.fetches).toContain("--filter=blob:none");
+    expect(fixture.fetches).toContain("--deepen=1000");
+    expect(runGit(fixture.checkout, ["rev-parse", "--verify", `${fixture.baseSha}^{commit}`])).toBe(
+      fixture.baseSha,
+    );
+    expect(runGit(fixture.checkout, ["diff", "--name-only", fixture.baseSha, "HEAD"])).toBe(
+      "fixture.txt",
+    );
+    expect(runGit(fixture.checkout, ["show", `${fixture.baseSha}:fixture.txt`])).toBe("fixture 0");
+  });
+
+  it("fetches a missing base from a complete checkout without unshallowing it", () => {
+    const fixture = runEnsureBaseCommitFixture(false);
+
+    expect(fixture.run.status, fixture.output).toBe(0);
+    expect(fixture.fetches).toContain("--filter=blob:none");
+    expect(fixture.fetches).not.toContain("--unshallow");
+    expect(runGit(fixture.checkout, ["rev-parse", "--is-shallow-repository"])).toBe("false");
+    expect(runGit(fixture.checkout, ["show", `${fixture.baseSha}:fixture.txt`])).toBe(
+      "remote update",
+    );
   });
 
   it("bounds specialized early checkout fetches", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where pull requests fail security scanning and other hosted checks when their original base commit is farther behind main than a shallow checkout can recover.

The failure is reproducible on #128594: the exact-SHA fetch times out, the existing 25/100/300 deepening steps stop short of the 470-commit-old base, and the final supposedly full-history fetch does not actually unshallow the repository.

## Why This Change Was Made

Keep the shared base-commit action as the single owner of bounded history recovery. Fetch commit history without blobs, add a bounded 1000-commit deepening step, and genuinely unshallow only when the checkout is shallow and the previous steps cannot recover its base. Every explicit fetch retains the existing 30-second timeout, strict SHA/ref validation, and protocol-v2 boundary.

Blobless fetches establish a promisor remote, so ordinary commit-existence checks can otherwise perform an implicit, unbounded lazy network fetch. Centralize all four checks behind a process-scoped local-only object probe while keeping downstream historical-blob hydration available.

## User Impact

Developers can run security scanning, workflow checks, and other shared base-dependent CI against older pull requests without manually rebasing or reopening them. The normal checkout remains shallow and blobless whenever progressive recovery suffices.

## Evidence

- A real local bare Git origin with 471 commits, filtered-fetch support, a depth-two checkout, and intentionally denied exact-SHA requests now exercises the actual composite-action shell successfully.
- Regression coverage proves the 1000-commit deepening path, bounded filtered fetches, real base-to-head diff generation, lazy historical-file access, and complete-checkout recovery without invalid unshallowing.
- The three owner-focused workflow guard tests pass; the wider suite passes 130 tests and skips two. Its sole unrelated baseline failure is an existing package-manager cache fixture whose private local registry cannot serve @pnpm/exe.
- Installed actionlint, composite-action input-interpolation checks, conflict-marker checks, formatting, patch validation, independent read-only review, and structured pre-commit review all pass.
- Full local workflow-policy aggregation cannot complete because the unchanged bootstrap pins pre-commit 4.6.2, which is unavailable from this machine's configured package index; its available individual checks were run directly. Hosted Workflow Sanity remains the authoritative complete gate.

Related: #128594
