### PR TITLE
fix(codex): suppress under-development features warning in chat

### DIFF
--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -675,6 +675,7 @@ describe("runCodexAppServerSideQuestion", () => {
       "features.code_mode": true,
       "features.code_mode_only": false,
       "features.apply_patch_streaming_events": true,
+      suppress_unstable_features_warning: true,
       "features.standalone_web_search": false,
       web_search: "cached",
     });

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -120,6 +120,7 @@ const DEFAULT_CODEX_RUNTIME_THREAD_CONFIG = {
   "features.code_mode": true,
   "features.code_mode_only": false,
   "features.apply_patch_streaming_events": true,
+  suppress_unstable_features_warning: true,
   "features.standalone_web_search": false,
   web_search: "cached",
 } as const;

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -1500,6 +1500,7 @@ describe("Codex app-server native code mode config", () => {
       "features.goals": false,
       "tools.update_plan.enabled": false,
       "features.apply_patch_streaming_events": true,
+      suppress_unstable_features_warning: true,
       "features.standalone_web_search": false,
       web_search: "cached",
     });
@@ -1647,6 +1648,7 @@ describe("Codex app-server native code mode config", () => {
       "features.goals": false,
       "tools.update_plan.enabled": false,
       "features.apply_patch_streaming_events": true,
+      suppress_unstable_features_warning: true,
       "features.multi_agent": false,
       "features.standalone_web_search": false,
       web_search: "cached",
@@ -1777,6 +1779,7 @@ describe("Codex app-server native code mode config", () => {
       "features.goals": false,
       "tools.update_plan.enabled": false,
       "features.apply_patch_streaming_events": true,
+      suppress_unstable_features_warning: true,
       "features.standalone_web_search": false,
       web_search: "cached",
     });
@@ -1801,6 +1804,7 @@ describe("Codex app-server native code mode config", () => {
       "features.goals": false,
       "tools.update_plan.enabled": false,
       "features.apply_patch_streaming_events": true,
+      suppress_unstable_features_warning: true,
       "features.standalone_web_search": false,
       web_search: "cached",
     });
@@ -1861,6 +1865,7 @@ describe("Codex app-server native code mode config", () => {
       "features.goals": false,
       "tools.update_plan.enabled": false,
       "features.apply_patch_streaming_events": true,
+      suppress_unstable_features_warning: true,
       "features.standalone_web_search": false,
       web_search: "cached",
     });
@@ -1941,6 +1946,7 @@ describe("Codex app-server native code mode config", () => {
       "features.goals": false,
       "tools.update_plan.enabled": false,
       "features.apply_patch_streaming_events": true,
+      suppress_unstable_features_warning: true,
       "features.standalone_web_search": false,
       web_search: "cached",
     });
@@ -1976,6 +1982,7 @@ describe("Codex app-server native code mode config", () => {
       "features.goals": false,
       "tools.update_plan.enabled": false,
       "features.apply_patch_streaming_events": true,
+      suppress_unstable_features_warning: true,
       "features.standalone_web_search": false,
       web_search: "cached",
     });
@@ -2180,6 +2187,7 @@ describe("Codex app-server turn params", () => {
         "features.goals": false,
         "tools.update_plan.enabled": false,
         "features.apply_patch_streaming_events": true,
+        suppress_unstable_features_warning: true,
         "features.standalone_web_search": false,
         web_search: "cached",
       },

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -36,10 +36,13 @@ import { resolveCodexWebSearchPlan, type CodexNativeWebSearchSupport } from "./w
 export const CODEX_RING_ZERO_BASE_INSTRUCTIONS = "";
 
 // Stream structured patch snapshots so large generated edits keep the turn active.
+// OpenClaw opts into these under-development features deliberately, so silence
+// Codex's chat warning that tells operators to edit the managed codex-home config.
 const CODEX_CODE_MODE_THREAD_CONFIG: JsonObject = {
   "features.code_mode": true,
   "features.code_mode_only": false,
   "features.apply_patch_streaming_events": true,
+  suppress_unstable_features_warning: true,
 };
 
 const CODEX_GOAL_CONTINUATION_DISABLED_THREAD_CONFIG: JsonObject = {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -71,6 +71,7 @@
     "features.goals": false,
     "features.standalone_web_search": false,
     "project_doc_max_bytes": 131072,
+    "suppress_unstable_features_warning": true,
     "tools.update_plan.enabled": false,
     "web_search": "cached"
   },
@@ -115,6 +116,7 @@
     "features.goals": false,
     "features.standalone_web_search": false,
     "project_doc_max_bytes": 131072,
+    "suppress_unstable_features_warning": true,
     "tools.update_plan.enabled": false,
     "web_search": "cached"
   },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -71,6 +71,7 @@
     "features.goals": false,
     "features.standalone_web_search": false,
     "project_doc_max_bytes": 131072,
+    "suppress_unstable_features_warning": true,
     "tools.update_plan.enabled": false,
     "web_search": "cached"
   },
@@ -115,6 +116,7 @@
     "features.goals": false,
     "features.standalone_web_search": false,
     "project_doc_max_bytes": 131072,
+    "suppress_unstable_features_warning": true,
     "tools.update_plan.enabled": false,
     "web_search": "cached"
   },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -71,6 +71,7 @@
     "features.goals": false,
     "features.standalone_web_search": false,
     "project_doc_max_bytes": 131072,
+    "suppress_unstable_features_warning": true,
     "tools.update_plan.enabled": false,
     "web_search": "cached"
   },
@@ -116,6 +117,7 @@
     "features.goals": false,
     "features.standalone_web_search": false,
     "project_doc_max_bytes": 131072,
+    "suppress_unstable_features_warning": true,
     "tools.update_plan.enabled": false,
     "web_search": "cached"
   },


### PR DESCRIPTION
## What Problem This Solves

Codex 0.149 added a session-configure warning that fires whenever any `UnderDevelopment`-stage feature is enabled (`codex-rs/features/src/lib.rs`, `unstable_features_warning_event`). OpenClaw deliberately enables two of them — `features.code_mode` and `features.apply_patch_streaming_events` — for every native-code-mode Codex thread, and relays every Codex `warning` notification verbatim into chat. The result is an ugly SYSTEM card in every Codex session:

> Under-development features enabled: apply_patch_streaming_events, code_mode. … To suppress this warning, set `suppress_unstable_features_warning = true` in /home/…/codex-home/config.toml.

The operator never opted into those features and should never hand-edit the managed codex-home `config.toml` the message points at, so the card is pure default-path noise.

## Why This Change Was Made

Suppress at the source instead of pattern-filtering message text. Codex exposes `suppress_unstable_features_warning` (top-level `ConfigToml` key), and app-server thread-start `config` overrides flow through `json_to_toml` into the same config layer stack the warning reads (`codex-rs/app-server/src/config_manager.rs`, `load_with_cli_overrides`) — proven by the fact that the warning lists exactly the features OpenClaw sends through that channel. So the flag is added to `CODEX_CODE_MODE_THREAD_CONFIG`, the exact block that enables the flagged features.

Scoping: when native code mode is disabled, OpenClaw does not send the flag, so a user who enables under-development features in their own config still gets the (then-legitimate) warning. The generic warning relay in `event-projector-events.ts` is untouched — real config warnings still surface in chat.

## User Impact

Codex sessions no longer show the "Under-development features enabled" SYSTEM card on every thread start. No other warnings are affected.

## Evidence

- Live boundary proof against the pinned `@openai/codex` 0.149.1 app-server binary (fresh `CODEX_HOME`, JSON-RPC `initialize` → `thread/start`):
  - config `{"features.code_mode": true, "features.apply_patch_streaming_events": true}` → one `warning` notification with the exact message from the screenshot above.
  - same config plus `"suppress_unstable_features_warning": true` → zero warning notifications.
  This is the changed path end-to-end on the Codex side; the OpenClaw relay is unchanged, so no notification means no SYSTEM card.
- Codex source inspected: `codex-rs/features/src/lib.rs:1594` (gate returns `None` when the flag is set), `codex-rs/core/src/session/session.rs:1050` (emission site), `codex-rs/config/src/config_toml.rs:467` (config key), `codex-rs/app-server/src/config_manager.rs` (`load_with_cli_overrides` merges request `config` overrides as dotted-key TOML into the layer stack).
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/{run-attempt,thread-lifecycle.binding,thread-lifecycle,side-question}.test.ts` — 487/487 pass.
- `pnpm prompt:snapshots:gen` refreshed the three codex-runtime happy-path fixtures (config dump now includes the flag); `test/scripts/prompt-snapshots.test.ts` passes.
- `node scripts/check-changed.mjs` — green.
- Production LOC delta: +3 (one config key, two comment lines); everything else is test expectations and regenerated snapshot fixtures.
