### PR TITLE
fix(tui): preserve active session runs and hidden tool output

### DIFF
--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -736,12 +736,12 @@ describe.sequential("TUI PTY harness", () => {
     "preserves xAI account limit errors in terminal output",
     async () => {
       await fixture.run.write("xai limit proof\r");
-      await fixture.run.waitForOutput("monthly spending limit");
-      expect(fixture.run.visibleOutput()).not.toContain("Run /auth");
       await fixture.waitForLogEntry(
         (entry) =>
           entry.method === "sendChat" && objectFieldEquals(entry, "message", "xai limit proof"),
       );
+      await fixture.run.waitForOutput("monthly spending limit");
+      expect(fixture.run.visibleOutput()).not.toContain("Run /auth");
     },
     TEST_TIMEOUT_MS,
   );

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -366,7 +366,6 @@ describe("tui session actions", () => {
       const invalidateRunOwnership = vi.fn();
       const clearLocalRunIds = vi.fn();
       const clearAll = vi.fn();
-      const clearPendingUsers = vi.fn();
       const btw = createBtwPresenter();
       const { refreshAgents } = createTestSessionActions({
         client: makeTuiBackend({
@@ -378,7 +377,7 @@ describe("tui session actions", () => {
             agents: [{ id: "ops" }],
           }),
         }),
-        chatLog: makeChatLog({ clearAll, clearPendingUsers }),
+        chatLog: makeChatLog({ clearAll }),
         btw,
         state,
         invalidateRunOwnership,
@@ -406,7 +405,6 @@ describe("tui session actions", () => {
       expect(invalidateRunOwnership).toHaveBeenCalledOnce();
       expect(clearLocalRunIds).toHaveBeenCalledOnce();
       expect(clearAll).toHaveBeenCalledOnce();
-      expect(clearPendingUsers).toHaveBeenCalledOnce();
       expect(btw.clear).toHaveBeenCalledOnce();
       expect(loadHistory).not.toHaveBeenCalled();
     },
@@ -1531,26 +1529,72 @@ describe("tui session actions", () => {
     }
   });
 
-  it("preserves run ownership when reloading the same session selection", async () => {
-    const sessionKey = "agent:main:main";
-    const invalidateRunOwnership = vi.fn();
-    const state = createBaseState({ currentSessionKey: sessionKey });
-    const { setSession } = createTestSessionActions({
-      client: makeTuiBackend({
-        listSessions: vi.fn(),
-        loadHistory: vi.fn().mockResolvedValue({
-          sessionId: "session-main",
-          sessionInfo: { key: sessionKey, sessionId: "session-main" },
-          messages: [],
+  it.each(["agent:main:main", "main"])(
+    "preserves run ownership when reselecting the same session as %s",
+    async (selectedKey) => {
+      const sessionKey = "agent:main:main";
+      const activeRunId = "run-active";
+      const pendingRunId = "run-pending";
+      const pendingText = "still waiting for the Gateway";
+      const invalidateRunOwnership = vi.fn();
+      const clearLocalRunIds = vi.fn();
+      const loadHistory = vi.fn();
+      const state = createBaseState({
+        currentSessionKey: sessionKey,
+        activeChatRunId: activeRunId,
+        pendingSubmit: acceptedSubmit(pendingRunId, pendingText),
+        activityStatus: "streaming",
+        historyLoaded: true,
+      });
+      sendPendingUser(state, pendingRunId, pendingText);
+      const chatLog = new ChatLog();
+      chatLog.addPendingUser(pendingRunId, pendingText);
+      const { setSession } = createTestSessionActions({
+        client: makeTuiBackend({
+          listSessions: vi.fn(),
+          loadHistory,
         }),
-      }),
+        chatLog,
+        state,
+        invalidateRunOwnership,
+        clearLocalRunIds,
+        setActivityStatus: (activityStatus) => {
+          state.activityStatus = activityStatus;
+        },
+      });
+
+      await setSession(selectedKey);
+
+      expect(state.activeChatRunId).toBe(activeRunId);
+      expect(state.pendingSubmit).toEqual(acceptedSubmit(pendingRunId, pendingText));
+      expect(state.activityStatus).toBe("streaming");
+      expect(chatLog.render(120).join("\n")).toContain(pendingText);
+      expect(invalidateRunOwnership).not.toHaveBeenCalled();
+      expect(clearLocalRunIds).not.toHaveBeenCalled();
+      expect(loadHistory).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reloads the current session when its initial history never loaded", async () => {
+    const sessionKey = "agent:main:main";
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-main",
+      sessionInfo: { key: sessionKey, sessionId: "session-main" },
+      messages: [],
+    });
+    const state = createBaseState({
+      currentSessionKey: sessionKey,
+      historyLoaded: false,
+    });
+    const { setSession } = createTestSessionActions({
+      client: makeTuiBackend({ listSessions: vi.fn(), loadHistory }),
       state,
-      invalidateRunOwnership,
     });
 
     await setSession(sessionKey);
 
-    expect(invalidateRunOwnership).not.toHaveBeenCalled();
+    expect(loadHistory).toHaveBeenCalledOnce();
+    expect(state.historyLoaded).toBe(true);
   });
 
   it("adopts an in-flight run with no buffered text (Codex) and shows streaming", async () => {
@@ -2440,9 +2484,9 @@ describe("tui session actions", () => {
       chatLog: Object.assign(chatLog, { dropPendingUser }),
       state,
       setActivityStatus,
-      resolveSessionSelection: vi.fn((raw?: string) => ({
+      resolveSessionSelection: vi.fn((raw?: string, agentId?: string) => ({
         key: raw ?? state.currentSessionKey,
-        agentId: state.currentAgentId,
+        agentId: agentId ?? state.currentAgentId,
       })),
     });
 
@@ -2451,10 +2495,7 @@ describe("tui session actions", () => {
       sessionKey: initialKey,
       ...(initialKey === "global" ? { agentId: "main" } : {}),
     });
-    if (initialKey === "global") {
-      state.currentAgentId = "work";
-    }
-    await setSession(nextKey);
+    await setSession(nextKey, initialKey === "global" ? "work" : undefined);
     state.activeChatRunId = "second-active-run";
     state.pendingSubmit = acceptedSubmit("second-pending-run", "second draft");
     addSystem.mockClear();
@@ -2788,6 +2829,51 @@ describe("tui session actions", () => {
 
     await expect(loadHistory()).resolves.toEqual({ loaded: true, runOutcome });
   });
+
+  it.each([
+    { verboseLevel: "off", showsTool: false, showsOutput: false },
+    { verboseLevel: "on", showsTool: true, showsOutput: false },
+    { verboseLevel: "full", showsTool: true, showsOutput: true },
+  ] as const)(
+    "preserves $verboseLevel tool-output visibility when rebuilding history",
+    async ({ verboseLevel, showsTool, showsOutput }) => {
+      const privateOutput = "TUI_PRIVATE_TOOL_OUTPUT";
+      const chatLog = new ChatLog();
+      const startTool = vi.spyOn(chatLog, "startTool");
+      const state = createBaseState({
+        sessionInfo: { verboseLevel },
+      });
+      const { loadHistory } = createTestSessionActions({
+        client: makeTuiBackend({
+          listSessions: vi.fn(),
+          loadHistory: vi.fn().mockResolvedValue({
+            sessionId: "session-main",
+            sessionInfo: {
+              key: "agent:main:main",
+              sessionId: "session-main",
+              verboseLevel,
+            },
+            messages: [
+              {
+                role: "toolResult",
+                toolCallId: "tool-private",
+                toolName: "read_file",
+                content: [{ type: "text", text: privateOutput }],
+                details: { accessToken: "TUI_PRIVATE_TOOL_DETAILS" },
+              },
+            ],
+          }),
+        }),
+        chatLog,
+        state,
+      });
+
+      await loadHistory();
+
+      expect(startTool).toHaveBeenCalledTimes(showsTool ? 1 : 0);
+      expect(chatLog.render(120).join("\n").includes(privateOutput)).toBe(showsOutput);
+    },
+  );
 
   it("restores attachment-only assistant rows from history without exposing references", async () => {
     const loadHistory = vi.fn().mockResolvedValue({

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -91,42 +91,39 @@ export function createSessionActions(context: SessionActionContext) {
 
   const applySessionSelection = (nextSelection: { key: string; agentId: string }) => {
     const previousSelection = captureSessionSelection();
-    const selectionChanged = !(
+    if (
       nextSelection.agentId === previousSelection.agentId &&
       agentSessionKeysMatchByRequestKey(nextSelection.key, previousSelection.sessionKey)
-    );
-    if (selectionChanged) {
-      // Retire the previous session's runs before history can adopt a new
-      // in-flight owner; otherwise its completion can promote an old run.
-      invalidateRunOwnership?.();
-      reduceTuiSessionProjection(state, {
-        type: "sessionReset",
-        scope: readTuiSessionProjectionScope(state),
-      });
+    ) {
+      return false;
     }
+
+    // Retire the previous session's runs before history can adopt a new
+    // in-flight owner; otherwise its completion can promote an old run.
+    invalidateRunOwnership?.();
+    reduceTuiSessionProjection(state, {
+      type: "sessionReset",
+      scope: readTuiSessionProjectionScope(state),
+    });
     state.currentAgentId = nextSelection.agentId;
     state.currentSessionKey = nextSelection.key;
     state.activeChatRunId = null;
     submit.clearPendingSubmit(state);
     setActivityStatus("idle");
-    if (selectionChanged) {
-      state.currentSessionId = null;
-      state.sessionInfo.displayName = undefined;
-      clearTuiSessionModeOverrides(state.sessionInfo);
-    }
+    state.currentSessionId = null;
+    state.sessionInfo.displayName = undefined;
+    clearTuiSessionModeOverrides(state.sessionInfo);
     // Session keys can move backwards in updatedAt ordering; drop previous session freshness
     // so refresh data for the newly selected session isn't rejected as stale.
     state.sessionInfo.updatedAt = null;
     state.historyLoaded = false;
-    if (selectionChanged) {
-      // Live prompt identities belong to the old selection, not its pending successor.
-      chatLog.clearAll();
-    }
-    chatLog.clearPendingUsers();
+    // Live prompt identities belong to the old selection, not its pending successor.
+    chatLog.clearAll();
     clearLocalRunIds?.();
     btw.clear();
     updateHeader();
     updateFooter();
+    return true;
   };
 
   const isCurrentSessionSelection = (selection: { sessionKey: string; agentId: string }): boolean =>
@@ -580,15 +577,17 @@ export function createSessionActions(context: SessionActionContext) {
           const toolName = formatPrimitiveString(message.toolName, "tool");
           const component = chatLog.startTool(toolCallId, toolName, {});
           component.setResult(
-            {
-              content: Array.isArray(message.content)
-                ? (message.content as Record<string, unknown>[])
-                : [],
-              details:
-                typeof message.details === "object" && message.details
-                  ? (message.details as Record<string, unknown>)
-                  : undefined,
-            },
+            state.sessionInfo.verboseLevel === "full"
+              ? {
+                  content: Array.isArray(message.content)
+                    ? (message.content as Record<string, unknown>[])
+                    : [],
+                  details:
+                    typeof message.details === "object" && message.details
+                      ? (message.details as Record<string, unknown>)
+                      : undefined,
+                }
+              : { content: [] },
             { isError: Boolean(message.isError) },
           );
         }
@@ -643,8 +642,9 @@ export function createSessionActions(context: SessionActionContext) {
   };
 
   const setSession = async (rawKey: string, agentId?: string) => {
-    applySessionSelection(resolveSessionSelection(rawKey, agentId));
-    await loadHistory();
+    if (applySessionSelection(resolveSessionSelection(rawKey, agentId)) || !state.historyLoaded) {
+      await loadHistory();
+    }
   };
 
   const abortActive = async (params?: { preferActive?: boolean }) => {

--- a/src/tui/tui-session-identity-pty.e2e.test.ts
+++ b/src/tui/tui-session-identity-pty.e2e.test.ts
@@ -105,6 +105,33 @@ it("clears the previous display name when the selected session is unnamed", asyn
   }
 }, 65_000);
 
+it("keeps the active stream when the current session is selected again", async () => {
+  const fixture = await startTuiFixture();
+  try {
+    await fixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+    await fixture.run.write("streaming prompt\r", { delay: false });
+    await fixture.run.waitForOutput("PTY_STREAMING: streaming prompt", STARTUP_TIMEOUT_MS);
+    const historyLoadsBefore = (await readFixtureLog(fixture.logPath)).filter(
+      (entry) => entry.method === "loadHistory",
+    ).length;
+
+    await fixture.run.write("/session main\r/think\r", { delay: false });
+    await fixture.run.waitForOutput("usage: /think", STARTUP_TIMEOUT_MS);
+    const rows = await waitForSynchronizedFrameRows(
+      fixture.run,
+      (frame) => frame.some((row) => row.includes("PTY_STREAMING: streaming prompt")),
+      STARTUP_TIMEOUT_MS,
+    );
+
+    expect(rows.join("\n")).not.toContain("local ready | idle");
+    expect(
+      (await readFixtureLog(fixture.logPath)).filter((entry) => entry.method === "loadHistory"),
+    ).toHaveLength(historyLoadsBefore);
+  } finally {
+    await fixture.cleanup();
+  }
+}, 65_000);
+
 it("hides a stale approval when startup restores the remembered session", async () => {
   const stateDir = tempDirs.make("openclaw-tui-identity-");
   await seedRememberedSession(stateDir);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who reselected the current terminal session while an answer was streaming would lose the visible response and see a falsely idle session even though the run was still active. It also prevents saved tool results from appearing after a history reload when `/verbose on` intentionally hides those results during live execution.

## Why This Change Was Made

Session selection now treats canonical and short aliases for the already-loaded session as the same selection, preserving live run ownership and avoiding destructive redundant history reloads. Failed initial history loads remain retryable, actual agent/session switches still retire the complete old session, and historical tool cards now use the same `off` / `on` / `full` visibility contract as live tool events, including withholding structured details outside `full` mode.

## User Impact

Active answers, pending prompts, and streaming status remain stable when selecting the current session again. Tool output stays hidden at normal verbose levels after reconnects or history reloads, while `/verbose full` continues to show it.

## Evidence

- Both owner regressions failed against unchanged `main`: reselecting the current session erased `run-active`, and `/verbose on` exposed the fixture value `TUI_PRIVATE_TOOL_OUTPUT`.
- Real terminal before: submitting `streaming prompt` and then `/session main` replaced the streaming response with `local ready | idle`.
- Real terminal after: the active streaming response and status remain visible, and the fake backend records no redundant history request.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts --configLoader runner src/tui/tui-session-actions.test.ts src/tui/tui-event-handlers.test.ts src/tui/components/chat-log.test.ts src/tui/components/chat-log-run-state.test.ts` — 337 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts --configLoader runner src/tui` — all 1,330 tests across 46 TUI files passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts --configLoader runner src/tui/tui-pty-harness.e2e.test.ts` — all 63 real-terminal scenarios passed, including a causally ordered fix for the existing billing-error proof.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts --configLoader runner src/tui/tui-session-identity-pty.e2e.test.ts` — all 9 real-PTY identity, reconnect, startup, and active-stream scenarios passed.
- Independent automated code review passed with no actionable findings.
- Production LOC: +31/-31 (net 0). Tests: +138/-25.
