### PR TITLE
refactor(test): speed up MCP Doctor coverage without repeated config mutations

### DIFF
--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -21,6 +21,17 @@ import {
 import { writeProbeMcpServer } from "./mcp-cli.test-support.js";
 import { runCliWithExitFinalization } from "./one-shot-exit.js";
 
+async function writeMcpDoctorServers(
+  home: string,
+  servers: Record<string, unknown>,
+): Promise<void> {
+  await fs.writeFile(
+    path.join(home, ".openclaw", "openclaw.json"),
+    `${JSON.stringify({ mcp: { servers } })}\n`,
+    "utf8",
+  );
+}
+
 describe("mcp cli", () => {
   beforeEach(() => {
     resetMcpCliTestState();
@@ -609,30 +620,31 @@ describe("mcp cli", () => {
   });
 
   it("reports ignored OAuth Authorization headers regardless of casing", async () => {
-    await withTempHome("openclaw-cli-mcp-home-", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async (home) => {
       const workspaceDir = await createWorkspace();
       vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
       readMcpOAuthCredentialsStatus.mockResolvedValue({ state: "authorized" });
 
-      for (const { name, header, oauth } of [
-        { name: "lowercase", header: "authorization", oauth: true },
-        { name: "titlecase", header: "Authorization", oauth: true },
-        { name: "uppercase", header: "AUTHORIZATION", oauth: true },
-        { name: "proxy", header: "Proxy-Authorization", oauth: true },
-        { name: "unrelated", header: "X-Tenant", oauth: true },
-        { name: "without-oauth", header: "AUTHORIZATION", oauth: false },
-      ]) {
-        await runMcpCommand([
-          "mcp",
-          "set",
-          name,
-          JSON.stringify({
-            url: "https://mcp.example.com/mcp",
-            headers: { [header]: "$MCP_HEADER" },
-            ...(oauth ? { auth: "oauth" } : {}),
-          }),
-        ]);
-      }
+      await writeMcpDoctorServers(
+        home,
+        Object.fromEntries(
+          [
+            { name: "lowercase", header: "authorization", oauth: true },
+            { name: "titlecase", header: "Authorization", oauth: true },
+            { name: "uppercase", header: "AUTHORIZATION", oauth: true },
+            { name: "proxy", header: "Proxy-Authorization", oauth: true },
+            { name: "unrelated", header: "X-Tenant", oauth: true },
+            { name: "without-oauth", header: "AUTHORIZATION", oauth: false },
+          ].map(({ name, header, oauth }) => [
+            name,
+            {
+              url: "https://mcp.example.com/mcp",
+              headers: { [header]: "$MCP_HEADER" },
+              ...(oauth ? { auth: "oauth" } : {}),
+            },
+          ]),
+        ),
+      );
       mockLog.mockClear();
 
       await runMcpCommand(["mcp", "doctor", "--json"]);
@@ -662,21 +674,22 @@ describe("mcp cli", () => {
   });
 
   it("bounds concurrent MCP doctor server checks", async () => {
-    await withTempHome("openclaw-cli-mcp-home-", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async (home) => {
       const workspaceDir = await createWorkspace();
       vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-      for (let index = 0; index < 6; index += 1) {
-        await runMcpCommand([
-          "mcp",
-          "set",
-          `server-${index}`,
-          JSON.stringify({
-            url: `https://mcp-${index}.example.com`,
-            transport: "streamable-http",
-            auth: "oauth",
-          }),
-        ]);
-      }
+      await writeMcpDoctorServers(
+        home,
+        Object.fromEntries(
+          Array.from({ length: 6 }, (_, index) => [
+            `server-${index}`,
+            {
+              url: `https://mcp-${index}.example.com`,
+              transport: "streamable-http",
+              auth: "oauth",
+            },
+          ]),
+        ),
+      );
 
       const checksBlocked = createDeferred();
       readMcpOAuthCredentialsStatus.mockImplementation(async () => {


### PR DESCRIPTION
## What Problem This Solves

The MCP CLI test suite spent several seconds exercising configuration-mutation machinery while preparing two Doctor-only behavior tests. A recently added six-server OAuth header case also repeated this setup six times, extending an already expensive neighboring concurrency test.

## Why This Change Was Made

Seed each existing Doctor test's complete six-server configuration with one direct temporary-home fixture write. Doctor's actual owner still reads that same canonical configuration, while the independent `mcp set` and OAuth mutation tests continue to exercise their real lifecycle, storage, and ownership boundaries.

## User Impact

No user-visible or production behavior changes. Maintainers and CI get faster, equally meaningful MCP Doctor coverage without a test-only production seam.

## Evidence

- Same isolated hosted machine; one worker; separate caches; excluded warmups; eight balanced ABBA baseline/candidate samples; unchanged two-test selection.
- End-to-end wall median: **13.735s -> 11.585s**, saving **2.150s (15.7%)**.
- Affected test-body median: **2.550s -> 0.521s**, saving **2.029s (79.6%)**.
- Baseline wall samples (seconds): `15.65, 14.45, 13.02, 19.70, 17.65, 11.18, 11.72, 11.27`.
- Candidate wall samples (seconds): `11.98, 12.86, 11.19, 12.52, 14.11, 10.69, 8.98, 9.27`.
- Full unchanged MCP CLI suite: all **35 tests passed** across baseline and candidate repetitions.
- Owner and sibling proof: **56 tests passed** across `src/cli/mcp-cli.test.ts`, `src/cli/mcp-cli.oauth.test.ts`, and `src/config/mcp-config.test.ts`.
- Reversible fault proof: making Authorization-header matching case-sensitive fails the retained titlecase/uppercase assertions; changing the Doctor concurrency bound from four to five fails the retained exact-concurrency assertion.
- Complete changed-file gate, formatting, diff checks, and structured autoreview: green before submission.
- Production LOC: **+0/-0**. Test LOC: **+46/-33**. No assertion, fixture-case, integration, or coverage removal.
