### PR TITLE
refactor(scripts): share SQLite compaction payload proof

### DIFF
--- a/scripts/lib/sqlite-reliability-compaction.ts
+++ b/scripts/lib/sqlite-reliability-compaction.ts
@@ -3,13 +3,12 @@ import fs from "node:fs";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import type { SnapshotDatabaseIdentity } from "../../src/snapshot/snapshot-provider.js";
-import type { ReliabilityReport, ReliabilityStateProof } from "./sqlite-reliability-contract.js";
-
-type CompactionPayloadProof = {
-  bytes: number;
-  idSum: number;
-  rows: number;
-};
+import {
+  assertSameCompactionPayload,
+  type CompactionPayloadProof,
+  type ReliabilityReport,
+  type ReliabilityStateProof,
+} from "./sqlite-reliability-contract.js";
 
 type CompactionTarget = {
   identity: SnapshotDatabaseIdentity;
@@ -47,22 +46,6 @@ function assertSameState(
   ) {
     throw new Error(
       `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
-    );
-  }
-}
-
-function assertSamePayload(
-  actual: CompactionPayloadProof,
-  expected: CompactionPayloadProof,
-  label: string,
-): void {
-  if (
-    actual.bytes !== expected.bytes ||
-    actual.idSum !== expected.idSum ||
-    actual.rows !== expected.rows
-  ) {
-    throw new Error(
-      `${label} changed compaction payload: expected rows=${expected.rows} bytes=${expected.bytes} idSum=${expected.idSum}, got rows=${actual.rows} bytes=${actual.bytes} idSum=${actual.idSum}`,
     );
   }
 }
@@ -241,7 +224,11 @@ export async function runVacuumInterruptionProof(params: {
       );
     }
     const payloadAfterRecovery = params.readPayload();
-    assertSamePayload(payloadAfterRecovery, params.expectedPayload, "vacuum crash recovery");
+    assertSameCompactionPayload(
+      payloadAfterRecovery,
+      params.expectedPayload,
+      "vacuum crash recovery",
+    );
     const journalBytesAfterRecovery = fileSize(`${params.target.path}-journal`);
     const walBytesAfterRecovery = fileSize(`${params.target.path}-wal`);
     if (journalBytesAfterRecovery !== 0 || walBytesAfterRecovery !== 0) {

--- a/scripts/lib/sqlite-reliability-contract.ts
+++ b/scripts/lib/sqlite-reliability-contract.ts
@@ -31,11 +31,33 @@ export type CliOptions = {
   stateDir: string | null;
 };
 
+export type CompactionPayloadProof = {
+  bytes: number;
+  idSum: number;
+  rows: number;
+};
+
 export type ReliabilityStateProof = {
   batches: number;
   rows: number;
   sha256: string;
 };
+
+export function assertSameCompactionPayload(
+  actual: CompactionPayloadProof,
+  expected: CompactionPayloadProof,
+  label: string,
+): void {
+  if (
+    actual.bytes !== expected.bytes ||
+    actual.idSum !== expected.idSum ||
+    actual.rows !== expected.rows
+  ) {
+    throw new Error(
+      `${label} changed compaction payload: expected rows=${expected.rows} bytes=${expected.bytes} idSum=${expected.idSum}, got rows=${actual.rows} bytes=${actual.bytes} idSum=${actual.idSum}`,
+    );
+  }
+}
 
 export type ReliabilityReport = {
   arch: string;
@@ -106,16 +128,8 @@ export type ReliabilityReport = {
         signal: NodeJS.Signals | null;
       };
       journalBytesObserved: number;
-      payloadAfterRecovery: {
-        bytes: number;
-        idSum: number;
-        rows: number;
-      };
-      payloadBeforeKill: {
-        bytes: number;
-        idSum: number;
-        rows: number;
-      };
+      payloadAfterRecovery: CompactionPayloadProof;
+      payloadBeforeKill: CompactionPayloadProof;
       recoveryVerified: true;
       stateAfterRecovery: ReliabilityStateProof;
       stateBeforeKill: ReliabilityStateProof;
@@ -137,11 +151,7 @@ export type ReliabilityReport = {
           signal: NodeJS.Signals | null;
         };
         incompleteEntries: 0;
-        payload: {
-          bytes: number;
-          idSum: number;
-          rows: number;
-        };
+        payload: CompactionPayloadProof;
         repositoryVerified: true;
         retryCreated: true;
         sourcePayloadPreserved: true;
@@ -158,11 +168,7 @@ export type ReliabilityReport = {
           signal: NodeJS.Signals | null;
         };
         incompleteEntries: 1;
-        payload: {
-          bytes: number;
-          idSum: number;
-          rows: number;
-        };
+        payload: CompactionPayloadProof;
         repositoryVerified: true;
         retryCreated: true;
         sourcePayloadPreserved: true;
@@ -179,11 +185,7 @@ export type ReliabilityReport = {
           signal: NodeJS.Signals | null;
         };
         incompleteEntries: 0;
-        payload: {
-          bytes: number;
-          idSum: number;
-          rows: number;
-        };
+        payload: CompactionPayloadProof;
         repositoryVerified: true;
         retryCreated: true;
         sourcePayloadPreserved: true;
@@ -200,11 +202,7 @@ export type ReliabilityReport = {
           code: number | null;
           signal: NodeJS.Signals | null;
         };
-        payloadAfterRecovery: {
-          bytes: number;
-          idSum: number;
-          rows: number;
-        };
+        payloadAfterRecovery: CompactionPayloadProof;
         recoveryVerified: true;
         repositoryVerified: true;
         retryRestored: false;
@@ -219,11 +217,7 @@ export type ReliabilityReport = {
           code: number | null;
           signal: NodeJS.Signals | null;
         };
-        payloadAfterRecovery: {
-          bytes: number;
-          idSum: number;
-          rows: number;
-        };
+        payloadAfterRecovery: CompactionPayloadProof;
         recoveryVerified: true;
         repositoryVerified: true;
         retryRestored: true;

--- a/scripts/lib/sqlite-reliability-repository.ts
+++ b/scripts/lib/sqlite-reliability-repository.ts
@@ -8,19 +8,22 @@ import {
   type SnapshotDatabaseIdentity,
   type SnapshotSummary,
 } from "../../src/snapshot/snapshot-provider.js";
-import type { ReliabilityReport, ReliabilityStateProof } from "./sqlite-reliability-contract.js";
+import {
+  assertSameCompactionPayload,
+  type CompactionPayloadProof,
+  type ReliabilityReport,
+  type ReliabilityStateProof,
+} from "./sqlite-reliability-contract.js";
 
 type RepositoryCrashPoint = "after-commit" | "before-pending" | "pending";
 type RepositoryExit =
   ReliabilityReport["maintenanceProof"]["repositoryInterruption"]["beforePending"]["exit"];
-type RepositoryPayload =
-  ReliabilityReport["maintenanceProof"]["repositoryInterruption"]["beforePending"]["payload"];
 type CrashPointResult = {
   crashSnapshotVerifiedAfterCrash: boolean;
   crashSnapshotVisibleAfterCrash: boolean;
   exit: RepositoryExit;
   incompleteEntries: number;
-  payload: RepositoryPayload;
+  payload: CompactionPayloadProof;
   stagingEntries: number;
   state: ReliabilityStateProof;
   visibleSnapshotsAfterCrash: number;
@@ -43,22 +46,6 @@ function assertSameState(
   ) {
     throw new Error(
       `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
-    );
-  }
-}
-
-function assertSamePayload(
-  actual: RepositoryPayload,
-  expected: RepositoryPayload,
-  label: string,
-): void {
-  if (
-    actual.bytes !== expected.bytes ||
-    actual.idSum !== expected.idSum ||
-    actual.rows !== expected.rows
-  ) {
-    throw new Error(
-      `${label} changed compaction payload: expected rows=${expected.rows} bytes=${expected.bytes} idSum=${expected.idSum}, got rows=${actual.rows} bytes=${actual.bytes} idSum=${actual.idSum}`,
     );
   }
 }
@@ -158,17 +145,21 @@ function assertForcedExit(exit: RepositoryExit): void {
 }
 
 async function verifySnapshot(params: {
-  expectedPayload: RepositoryPayload;
+  expectedPayload: CompactionPayloadProof;
   expectedState: ReliabilityStateProof;
   provider: ReturnType<typeof createLocalSqliteSnapshotProvider>;
   snapshot: SnapshotSummary;
-  verifyPayload: (databasePath: string) => RepositoryPayload;
+  verifyPayload: (databasePath: string) => CompactionPayloadProof;
   verifyState: (databasePath: string) => ReliabilityStateProof;
 }): Promise<void> {
   await params.provider.verify(params.snapshot.ref);
   const artifactPath = path.join(params.snapshot.ref.path, SNAPSHOT_SQLITE_FILENAME);
   assertSameState(params.verifyState(artifactPath), params.expectedState, artifactPath);
-  assertSamePayload(params.verifyPayload(artifactPath), params.expectedPayload, artifactPath);
+  assertSameCompactionPayload(
+    params.verifyPayload(artifactPath),
+    params.expectedPayload,
+    artifactPath,
+  );
 }
 
 function listRepositoryEntries(repositoryPath: string): string[] {
@@ -177,14 +168,14 @@ function listRepositoryEntries(repositoryPath: string): string[] {
 
 async function runCrashPoint(params: {
   crashPoint: RepositoryCrashPoint;
-  expectedPayload: RepositoryPayload;
+  expectedPayload: CompactionPayloadProof;
   expectedState: ReliabilityStateProof;
   identity: SnapshotDatabaseIdentity;
   provider: ReturnType<typeof createLocalSqliteSnapshotProvider>;
   repositoryPath: string;
   sourcePath: string;
   validationRootPath: string;
-  verifyPayload: (databasePath: string) => RepositoryPayload;
+  verifyPayload: (databasePath: string) => CompactionPayloadProof;
   verifyState: (databasePath: string) => ReliabilityStateProof;
 }): Promise<CrashPointResult> {
   const visibleBefore = await params.provider.list();
@@ -248,7 +239,11 @@ async function runCrashPoint(params: {
     const sourceState = params.verifyState(params.sourcePath);
     assertSameState(sourceState, params.expectedState, `${params.crashPoint} source`);
     const sourcePayload = params.verifyPayload(params.sourcePath);
-    assertSamePayload(sourcePayload, params.expectedPayload, `${params.crashPoint} source`);
+    assertSameCompactionPayload(
+      sourcePayload,
+      params.expectedPayload,
+      `${params.crashPoint} source`,
+    );
 
     const crashSnapshotNames = new Set(
       crashSnapshots.map((snapshot) => path.basename(snapshot.ref.path)),
@@ -302,13 +297,13 @@ async function runCrashPoint(params: {
 }
 
 export async function runRepositoryInterruptionProof(params: {
-  expectedPayload: RepositoryPayload;
+  expectedPayload: CompactionPayloadProof;
   expectedState: ReliabilityStateProof;
   identity: SnapshotDatabaseIdentity;
   repositoryPath: string;
   sourcePath: string;
   validationRootPath: string;
-  verifyPayload: (databasePath: string) => RepositoryPayload;
+  verifyPayload: (databasePath: string) => CompactionPayloadProof;
   verifyState: (databasePath: string) => ReliabilityStateProof;
 }): Promise<ReliabilityReport["maintenanceProof"]["repositoryInterruption"]> {
   const provider = createLocalSqliteSnapshotProvider({

--- a/scripts/lib/sqlite-reliability-restore.ts
+++ b/scripts/lib/sqlite-reliability-restore.ts
@@ -4,17 +4,20 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createLocalSqliteSnapshotProvider } from "../../src/snapshot/local-repository.js";
-import type { ReliabilityReport, ReliabilityStateProof } from "./sqlite-reliability-contract.js";
+import {
+  assertSameCompactionPayload,
+  type CompactionPayloadProof,
+  type ReliabilityReport,
+  type ReliabilityStateProof,
+} from "./sqlite-reliability-contract.js";
 
 type RestoreCrashPoint = "after-publish" | "before-publish";
 type RestoreExit =
   ReliabilityReport["maintenanceProof"]["restoreInterruption"]["beforePublish"]["exit"];
-type RestorePayloadProof =
-  ReliabilityReport["maintenanceProof"]["restoreInterruption"]["beforePublish"]["payloadAfterRecovery"];
 type RestoreCrashResult = {
   existingTargetPreserved: boolean;
   exit: RestoreExit;
-  payloadAfterRecovery: RestorePayloadProof;
+  payloadAfterRecovery: CompactionPayloadProof;
   recoveryVerified: true;
   repositoryVerified: true;
   retryRestored: boolean;
@@ -46,22 +49,6 @@ function assertSameState(
   ) {
     throw new Error(
       `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
-    );
-  }
-}
-
-function assertSamePayload(
-  actual: RestorePayloadProof,
-  expected: RestorePayloadProof,
-  label: string,
-): void {
-  if (
-    actual.bytes !== expected.bytes ||
-    actual.idSum !== expected.idSum ||
-    actual.rows !== expected.rows
-  ) {
-    throw new Error(
-      `${label} changed compaction payload: expected rows=${expected.rows} bytes=${expected.bytes} idSum=${expected.idSum}, got rows=${actual.rows} bytes=${actual.bytes} idSum=${actual.idSum}`,
     );
   }
 }
@@ -267,7 +254,7 @@ async function assertRepositorySnapshotAvailable(params: {
 
 async function runCrashPoint(params: {
   crashPoint: RestoreCrashPoint;
-  expectedPayload: RestorePayloadProof;
+  expectedPayload: CompactionPayloadProof;
   expectedSnapshotBytes: number;
   expectedState: ReliabilityStateProof;
   provider: ReturnType<typeof createLocalSqliteSnapshotProvider>;
@@ -275,7 +262,7 @@ async function runCrashPoint(params: {
   scratchPath: string;
   snapshotPath: string;
   validationRootPath: string;
-  verifyPayload: (databasePath: string) => RestorePayloadProof;
+  verifyPayload: (databasePath: string) => CompactionPayloadProof;
   verifyState: (databasePath: string) => ReliabilityStateProof;
 }): Promise<RestoreCrashResult> {
   const targetPath = path.join(params.scratchPath, `${params.crashPoint}.sqlite`);
@@ -370,7 +357,11 @@ async function runCrashPoint(params: {
     const stateAfterRecovery = params.verifyState(targetPath);
     assertSameState(stateAfterRecovery, params.expectedState, `${params.crashPoint} restore`);
     const payloadAfterRecovery = params.verifyPayload(targetPath);
-    assertSamePayload(payloadAfterRecovery, params.expectedPayload, `${params.crashPoint} restore`);
+    assertSameCompactionPayload(
+      payloadAfterRecovery,
+      params.expectedPayload,
+      `${params.crashPoint} restore`,
+    );
     await assertRepositorySnapshotAvailable({
       expectedSnapshotBytes: params.expectedSnapshotBytes,
       provider: params.provider,
@@ -407,14 +398,14 @@ async function runCrashPoint(params: {
 }
 
 export async function runRestoreInterruptionProof(params: {
-  expectedPayload: RestorePayloadProof;
+  expectedPayload: CompactionPayloadProof;
   expectedSnapshotBytes: number;
   expectedState: ReliabilityStateProof;
   repositoryPath: string;
   scratchPath: string;
   snapshotPath: string;
   validationRootPath: string;
-  verifyPayload: (databasePath: string) => RestorePayloadProof;
+  verifyPayload: (databasePath: string) => CompactionPayloadProof;
   verifyState: (databasePath: string) => ReliabilityStateProof;
 }): Promise<ReliabilityReport["maintenanceProof"]["restoreInterruption"]> {
   if (params.expectedSnapshotBytes < MIN_STAGED_RESTORE_BYTES * 2) {


### PR DESCRIPTION
## What Problem This Solves

SQLite reliability developer tooling encoded the same compaction-payload proof shape seven times and copied the same equality/error check into three interruption-proof modules. That duplicated one proof invariant across independent owners and made future behavior or diagnostic drift possible.

## Why This Change Was Made

The existing SQLite reliability contract now owns the `CompactionPayloadProof` shape and its equality assertion. Vacuum, repository, and restore interruption proofs consume that owner while preserving the exact comparison fields and thrown message bytes.

Canonical root cause: each interruption proof embedded its own copy when the proof phases were added independently, even though their reports share the same compaction payload contract. A broader state-proof consolidation was intentionally rejected because open PR #122612 actively modifies the runner copy; this change stays overlap-free.

## User Impact

No CLI, report, or error-output behavior changes. Developers have one compaction payload proof contract instead of three assertions and seven structural type copies.

Production LOC: +79/-112 (net -33) | Tests: +0/-0

## Evidence

Exact head: `207b927c35e66ad328eb245e13eb45d7e7eada4d`

- Rebases cleanly onto `888c8422013e13023164c62d734f31ebb54ff572`, which contains `/learn` repair `0452458d0dc52f87e0c4c8b18ae2d89a70b9c0a1` and contention repair `99fbe2207f21e9a546c7864b225a0f317847be75`.
- `node scripts/run-vitest.mjs test/scripts/bench-sqlite-reliability.test.ts` — 1 file, 5 tests passed; exercises vacuum, repository, and restore interruption proofs.
- Direct `assertSameCompactionPayload` check — equal payload accepted and mismatch retained the exact prior error string.
- `node scripts/check-changed.mjs` — scripts/tooling typecheck, lint, format, erasability, and guards passed.
- Targeted `oxfmt --check` and `git diff --check origin/main...HEAD` — passed.
- Deslop — no findings or edits.
- Structured branch autoreview (`--max-priority P1`) — clean, correctness 0.99; no accepted/actionable findings.
- Independent read-only Codex exact-head review — no P0-P2 findings; confirmed unchanged error/report semantics and clean contract ownership.
- Active-PR overlap check — none for the four changed files; the overlapping runner path was excluded.

Credit: maintenance cleanup derived from current-main history; no external issue or contributor patch.
