### PR TITLE
chore: remove retired provider discovery alias guards

### DIFF
--- a/src/plugins/provider-discovery.test.ts
+++ b/src/plugins/provider-discovery.test.ts
@@ -1,6 +1,4 @@
 /** Tests provider discovery normalization, grouping, and manifest contribution handling. */
-import fs from "node:fs";
-import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.js";
 import {
@@ -9,7 +7,6 @@ import {
   runProviderCatalog,
   runProviderStaticCatalog,
 } from "./provider-discovery.js";
-import * as providerDiscoveryModule from "./provider-discovery.js";
 import type { ProviderCatalogOrder, ProviderPlugin } from "./types.js";
 
 function makeProvider(params: {
@@ -91,25 +88,6 @@ type NormalizePluginDiscoveryResultCase = {
   result: Parameters<typeof normalizePluginDiscoveryResult>[0]["result"];
   expected: Record<string, unknown>;
 };
-
-describe("resolveInstalledPluginProviderContributionIds", () => {
-  it("keeps current production callers off the ambiguous runtime-discovery alias", () => {
-    const callerPaths = [
-      "src/agents/models-config.providers.implicit.ts",
-      "src/commands/models/list.row-sources.ts",
-    ];
-
-    for (const callerPath of callerPaths) {
-      expect(fs.readFileSync(path.join(process.cwd(), callerPath), "utf-8")).not.toContain(
-        "resolvePluginDiscoveryProviders",
-      );
-    }
-  });
-
-  it("does not keep exporting the ambiguous runtime-discovery alias", () => {
-    expect(Object.keys(providerDiscoveryModule)).not.toContain("resolvePluginDiscoveryProviders");
-  });
-});
 
 describe("groupPluginDiscoveryProvidersByOrder", () => {
   it.each([


### PR DESCRIPTION
## What Problem This Solves

The provider discovery suite retained two one-time migration guards for an internal alias that was removed on the same day it was renamed. They grepped two source files and enumerated module exports rather than testing provider discovery behavior.

## Why This Change Was Made

Remove the stale alias guards and their test-only filesystem, path, and namespace imports. TypeScript compilation rejects imports of the absent alias, while the remaining provider discovery suites exercise the runtime owner, normalization, catalog hooks, discovery scope, and plugin SDK boundaries.

AI-assisted test audit requested by the maintainer.

## User Impact

No user-visible behavior changes. The core suite no longer carries refactor-era assertions for a retired internal spelling.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/provider-discovery.test.ts` — 13/13 retained tests passed.
- `node scripts/check-changed.mjs --dry-run -- src/plugins/provider-discovery.test.ts` — classified the core-test lane.
- `node scripts/check-changed.mjs -- src/plugins/provider-discovery.test.ts` — passed, including full core test typecheck and type-aware lint.
- `git diff --check` — passed.
- Fresh autoreview reported no actionable findings; correctness confidence 0.99.
- Production LOC: +0/-0. Test LOC: +0/-22.
