### PR TITLE
fix(mattermost): surface websocket authentication failures with backoff

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -179,30 +179,6 @@ describe("mattermost websocket monitor", () => {
     expect((failure as Error).message).toBe("websocket closed before open (code 1006)");
   });
 
-  it("rejects when the websocket closes before authentication completes", async () => {
-    const socket = new FakeWebSocket();
-    const connectOnce = createMattermostConnectOnce({
-      wsUrl: "wss://example.invalid/api/v4/websocket",
-      botToken: "revoked-token",
-      runtime: testRuntime(),
-      nextSeq: () => 1,
-      onPosted: async () => {},
-      webSocketFactory: () => socket,
-    });
-
-    queueMicrotask(() => {
-      socket.emitOpen();
-      // Mattermost rejects the challenge token by closing without any reply.
-      socket.emitClose(1006);
-    });
-
-    await expect(connectOnce()).rejects.toMatchObject({
-      name: "WebSocketClosedBeforeAuthenticationError",
-      code: 1006,
-      message: expect.stringContaining("closed before authentication"),
-    });
-  });
-
   it("reports a transient pre-authentication close without asserting a token failure", async () => {
     const socket = new FakeWebSocket();
     const connectOnce = createMattermostConnectOnce({
@@ -293,13 +269,12 @@ describe("mattermost websocket monitor", () => {
       nextSeq: () => 1,
       onPosted: async () => {},
       webSocketFactory: () => socket,
-      authTimeoutMs: 100,
     });
 
     const connected = connectOnce();
     socket.emitOpen();
 
-    await vi.advanceTimersByTimeAsync(99);
+    await vi.advanceTimersByTimeAsync(29_999);
     expect(socket.terminateCalls).toBe(0);
     await vi.advanceTimersByTimeAsync(1);
     expect(socket.terminateCalls).toBe(1);
@@ -324,14 +299,13 @@ describe("mattermost websocket monitor", () => {
       nextSeq: () => 1,
       onPosted: async () => {},
       webSocketFactory: () => socket,
-      authTimeoutMs: 100,
     });
 
     const connected = connectOnce();
     socket.emitOpen();
     socket.emitMessage(authOkFrame(1));
 
-    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(30_000);
     expect(socket.terminateCalls).toBe(0);
 
     socket.emitClose(1000);

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -203,6 +203,43 @@ describe("mattermost websocket monitor", () => {
     });
   });
 
+  it("reports a transient pre-authentication close without asserting a token failure", async () => {
+    const socket = new FakeWebSocket();
+    const connectOnce = createMattermostConnectOnce({
+      wsUrl: "wss://example.invalid/api/v4/websocket",
+      botToken: "valid-token",
+      runtime: testRuntime(),
+      nextSeq: () => 1,
+      onPosted: async () => {},
+      webSocketFactory: () => socket,
+    });
+
+    queueMicrotask(() => {
+      socket.emitOpen();
+      // A restarting server or resetting proxy closes mid-authentication with
+      // the same client-visible shape as a token rejection.
+      socket.emitClose(1001, "server restarting");
+    });
+
+    let failure: unknown;
+    try {
+      await connectOnce();
+    } catch (caught) {
+      failure = caught;
+    }
+    expect(failure).toMatchObject({
+      name: "WebSocketClosedBeforeAuthenticationError",
+      code: 1001,
+      reason: "server restarting",
+    });
+    // The client cannot distinguish the causes, so the diagnostic must keep
+    // both visible instead of pinning the close on the token alone.
+    const message = (failure as Error).message;
+    expect(message).toContain("closed before authentication completed (code 1001)");
+    expect(message).toContain("bot token");
+    expect(message).toContain("connection dropped");
+  });
+
   it("backs off across attempts when authentication never completes", async () => {
     const connectOnce = createMattermostConnectOnce({
       wsUrl: "wss://example.invalid/api/v4/websocket",

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -115,6 +115,10 @@ const testRuntime = (): RuntimeEnv =>
     }) as RuntimeEnv["exit"],
   }) as RuntimeEnv;
 
+// Mirrors the server's acknowledgement of a valid authentication_challenge.
+const authOkFrame = (seq: number): Buffer =>
+  Buffer.from(JSON.stringify({ status: "OK", seq_reply: seq }));
+
 async function startStalledWebSocketHandshakeServer(): Promise<{
   url: string;
   close: () => Promise<void>;
@@ -175,6 +179,129 @@ describe("mattermost websocket monitor", () => {
     expect((failure as Error).message).toBe("websocket closed before open (code 1006)");
   });
 
+  it("rejects when the websocket closes before authentication completes", async () => {
+    const socket = new FakeWebSocket();
+    const connectOnce = createMattermostConnectOnce({
+      wsUrl: "wss://example.invalid/api/v4/websocket",
+      botToken: "revoked-token",
+      runtime: testRuntime(),
+      nextSeq: () => 1,
+      onPosted: async () => {},
+      webSocketFactory: () => socket,
+    });
+
+    queueMicrotask(() => {
+      socket.emitOpen();
+      // Mattermost rejects the challenge token by closing without any reply.
+      socket.emitClose(1006);
+    });
+
+    await expect(connectOnce()).rejects.toMatchObject({
+      name: "WebSocketClosedBeforeAuthenticationError",
+      code: 1006,
+      message: expect.stringContaining("closed before authentication"),
+    });
+  });
+
+  it("backs off across attempts when authentication never completes", async () => {
+    const connectOnce = createMattermostConnectOnce({
+      wsUrl: "wss://example.invalid/api/v4/websocket",
+      botToken: "revoked-token",
+      runtime: testRuntime(),
+      nextSeq: (() => {
+        let seq = 1;
+        return () => seq++;
+      })(),
+      onPosted: async () => {},
+      webSocketFactory: () => {
+        const socket = new FakeWebSocket();
+        queueMicrotask(() => {
+          socket.emitOpen();
+          socket.emitClose(1006);
+        });
+        return socket;
+      },
+    });
+
+    const connectErrors: string[] = [];
+    const reconnectDelays: number[] = [];
+    await runWithReconnect(connectOnce, {
+      initialDelayMs: 10,
+      maxDelayMs: 1000,
+      jitterRatio: 0,
+      shouldReconnect: ({ attempt }) => attempt < 2,
+      onError: (err) => {
+        connectErrors.push(err instanceof Error ? err.name : String(err));
+      },
+      onReconnect: (delayMs) => reconnectDelays.push(delayMs),
+    });
+
+    // Every attempt fails authentication, so the delay doubles instead of resetting to the floor.
+    expect(connectErrors).toEqual([
+      "WebSocketClosedBeforeAuthenticationError",
+      "WebSocketClosedBeforeAuthenticationError",
+      "WebSocketClosedBeforeAuthenticationError",
+    ]);
+    expect(reconnectDelays).toEqual([10, 20]);
+  });
+
+  it("terminates the connection when the authentication reply never arrives", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeWebSocket();
+    const runtime = testRuntime();
+    const connectOnce = createMattermostConnectOnce({
+      wsUrl: "wss://example.invalid/api/v4/websocket",
+      botToken: "token",
+      runtime,
+      nextSeq: () => 1,
+      onPosted: async () => {},
+      webSocketFactory: () => socket,
+      authTimeoutMs: 100,
+    });
+
+    const connected = connectOnce();
+    socket.emitOpen();
+
+    await vi.advanceTimersByTimeAsync(99);
+    expect(socket.terminateCalls).toBe(0);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(socket.terminateCalls).toBe(1);
+    expect(runtime.error).toHaveBeenCalledWith(
+      "mattermost websocket authentication timed out — reconnecting",
+    );
+
+    socket.emitClose(1006);
+    await expect(connected).rejects.toMatchObject({
+      name: "WebSocketClosedBeforeAuthenticationError",
+    });
+    vi.useRealTimers();
+  });
+
+  it("does not trip the auth deadline once the challenge is acknowledged", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeWebSocket();
+    const connectOnce = createMattermostConnectOnce({
+      wsUrl: "wss://example.invalid/api/v4/websocket",
+      botToken: "token",
+      runtime: testRuntime(),
+      nextSeq: () => 1,
+      onPosted: async () => {},
+      webSocketFactory: () => socket,
+      authTimeoutMs: 100,
+    });
+
+    const connected = connectOnce();
+    socket.emitOpen();
+    socket.emitMessage(authOkFrame(1));
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(socket.terminateCalls).toBe(0);
+
+    socket.emitClose(1000);
+    await connected;
+    vi.useRealTimers();
+  });
+
   it("retries when first attempt errors before open and next attempt succeeds", async () => {
     const patches: Array<Record<string, unknown>> = [];
     const sockets: FakeWebSocket[] = [];
@@ -202,6 +329,7 @@ describe("mattermost websocket monitor", () => {
             return;
           }
           socket.emitOpen();
+          socket.emitMessage(authOkFrame(1));
           socket.emitClose(1000);
         });
         return socket;
@@ -223,7 +351,7 @@ describe("mattermost websocket monitor", () => {
       data: { token: "token" },
       seq: 1,
     });
-    expect(countMatching(patches, (patch) => patch.connected === true)).toBe(1);
+    expect(countMatching(patches, (patch) => patch.connected === true)).toBe(2);
     expect(countMatching(patches, (patch) => patch.connected === false)).toBe(3);
     expect(patches).toContainEqual(expect.objectContaining({ lifecycle: "starting" }));
     expect(patches).toContainEqual(expect.objectContaining({ lifecycle: "recovering" }));
@@ -289,6 +417,7 @@ describe("mattermost websocket monitor", () => {
     const onPosted = vi.fn(async () => {});
     server.on("connection", (socket) => {
       socket.once("message", () => {
+        socket.send(JSON.stringify({ status: "OK", seq_reply: 1 }));
         socket.send(
           JSON.stringify({
             event: "posted",
@@ -344,6 +473,7 @@ describe("mattermost websocket monitor", () => {
     const connected = connectOnce();
     queueMicrotask(() => {
       socket.emitOpen();
+      socket.emitMessage(authOkFrame(1));
       socket.emitMessage(
         Buffer.from(
           JSON.stringify({
@@ -404,6 +534,7 @@ describe("mattermost websocket monitor", () => {
 
     const connected = connectOnce();
     socket.emitOpen();
+    socket.emitMessage(authOkFrame(1));
     socket.emitMessage(
       Buffer.from(
         JSON.stringify({
@@ -445,6 +576,7 @@ describe("mattermost websocket monitor", () => {
 
     const connected = connectOnce();
     socket.emitOpen();
+    socket.emitMessage(authOkFrame(1));
 
     // Let initial getBotUpdateAt resolve
     await vi.advanceTimersByTimeAsync(0);
@@ -482,6 +614,7 @@ describe("mattermost websocket monitor", () => {
 
     const connected = connectOnce();
     socket.emitOpen();
+    socket.emitMessage(authOkFrame(1));
 
     await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(300);
@@ -508,6 +641,7 @@ describe("mattermost websocket monitor", () => {
 
     const connected = connectOnce();
     socket.emitOpen();
+    socket.emitMessage(authOkFrame(1));
 
     await vi.advanceTimersByTimeAsync(100);
     expect(socket.pingCalls).toBe(1);
@@ -547,6 +681,7 @@ describe("mattermost websocket monitor", () => {
 
     const connected = connectOnce();
     socket.emitOpen();
+    socket.emitMessage(authOkFrame(1));
 
     await vi.advanceTimersByTimeAsync(0);
     expect(pollCount).toBe(1);
@@ -591,6 +726,7 @@ describe("mattermost websocket monitor", () => {
 
     const connected = connectOnce();
     socket.emitOpen();
+    socket.emitMessage(authOkFrame(1));
 
     await vi.advanceTimersByTimeAsync(0);
 
@@ -631,6 +767,7 @@ describe("mattermost websocket monitor", () => {
 
     const connected = connectOnce();
     socket.emitOpen();
+    socket.emitMessage(authOkFrame(1));
 
     await vi.advanceTimersByTimeAsync(0);
     expect(runtime.error).toHaveBeenCalledWith(
@@ -674,6 +811,7 @@ describe("mattermost websocket monitor", () => {
 
     const connected = connectOnce();
     socket.emitOpen();
+    socket.emitMessage(authOkFrame(1));
 
     await vi.advanceTimersByTimeAsync(0);
     expect(pollCount).toBe(1);

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -57,6 +57,9 @@ export type MattermostWebSocketFactory = (
 const MATTERMOST_WEBSOCKET_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
 // A TCP peer can accept without completing the HTTP upgrade; ws has no default deadline.
 const MATTERMOST_WEBSOCKET_HANDSHAKE_TIMEOUT_MS = 30_000;
+// After the challenge the server contract is reply-OK or close; this bounds a
+// peer that does neither so the channel cannot sit unauthenticated forever.
+const MATTERMOST_WEBSOCKET_AUTH_TIMEOUT_MS = 30_000;
 const MattermostEventPayloadSchema = z.object({
   event: z.string().optional(),
   status: z.string().optional(),
@@ -104,6 +107,18 @@ class WebSocketClosedBeforeOpenError extends Error {
   }
 }
 
+class WebSocketClosedBeforeAuthenticationError extends Error {
+  constructor(
+    public readonly code: number,
+    public readonly reason?: string,
+  ) {
+    super(
+      `websocket closed before authentication completed (code ${code}) — check the Mattermost bot token`,
+    );
+    this.name = "WebSocketClosedBeforeAuthenticationError";
+  }
+}
+
 type CreateMattermostConnectOnceOpts = {
   wsUrl: string;
   botToken: string;
@@ -125,6 +140,7 @@ type CreateMattermostConnectOnceOpts = {
   healthCheckIntervalMs?: number;
   pingIntervalMs?: number;
   pongTimeoutMs?: number;
+  authTimeoutMs?: number;
 };
 
 const defaultMattermostWebSocketFactory: MattermostWebSocketFactory = (url, options) => {
@@ -142,6 +158,7 @@ export function createMattermostConnectOnce(
   const healthCheckIntervalMs = opts.healthCheckIntervalMs ?? 30_000;
   const pingIntervalMs = opts.pingIntervalMs ?? 30_000;
   const pongTimeoutMs = opts.pongTimeoutMs ?? 10_000;
+  const authTimeoutMs = opts.authTimeoutMs ?? MATTERMOST_WEBSOCKET_AUTH_TIMEOUT_MS;
   return async () => {
     const flowId = randomUUID();
     const ws = webSocketFactory(opts.wsUrl, {
@@ -155,6 +172,7 @@ export function createMattermostConnectOnce(
     try {
       return await new Promise<void>((resolve, reject) => {
         let opened = false;
+        let authenticated = false;
         let settled = false;
         let healthCheckEnabled = getBotUpdateAt != null;
         let healthCheckInFlight = false;
@@ -164,11 +182,16 @@ export function createMattermostConnectOnce(
         let protocolPongTimer: ReturnType<typeof setTimeout> | undefined;
         let initialUpdateAt: number | undefined;
         let authenticationSeq: number | undefined;
+        let authTimer: ReturnType<typeof setTimeout> | undefined;
 
         const clearTimers = () => {
           if (healthCheckTimer !== undefined) {
             clearTimeout(healthCheckTimer);
             healthCheckTimer = undefined;
+          }
+          if (authTimer !== undefined) {
+            clearTimeout(authTimer);
+            authTimer = undefined;
           }
           if (protocolPingTimer !== undefined) {
             clearTimeout(protocolPingTimer);
@@ -315,6 +338,15 @@ export function createMattermostConnectOnce(
             meta: { subsystem: "mattermost-websocket", eventType: "authentication_challenge" },
           });
           ws.send(authPayload);
+          authTimer = setTimeout(() => {
+            authTimer = undefined;
+            if (settled) {
+              return;
+            }
+            opts.runtime.error?.("mattermost websocket authentication timed out — reconnecting");
+            stopHealthChecks();
+            ws.terminate();
+          }, authTimeoutMs);
           scheduleProtocolPing();
 
           // Periodically check if the bot account was modified (e.g. disable/enable).
@@ -351,6 +383,11 @@ export function createMattermostConnectOnce(
           }
 
           if (payload.status === "OK" && payload.seq_reply === authenticationSeq) {
+            authenticated = true;
+            if (authTimer !== undefined) {
+              clearTimeout(authTimer);
+              authTimer = undefined;
+            }
             opts.statusSink?.(channelReadyPatch());
             return;
           }
@@ -405,8 +442,16 @@ export function createMattermostConnectOnce(
               error: message || undefined,
             },
           });
-          if (opened) {
+          if (opened && authenticated) {
             resolveOnce();
+            return;
+          }
+          if (opened) {
+            // Mattermost answers a failed authentication_challenge by closing the
+            // socket with no challenge reply (server platform/websocket_router.go),
+            // so an unauthenticated close is a failed attempt: rejecting routes it
+            // through reconnect backoff and the visible connection-failed error.
+            rejectOnce(new WebSocketClosedBeforeAuthenticationError(code, message || undefined));
             return;
           }
           rejectOnce(new WebSocketClosedBeforeOpenError(code, message || undefined));

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -112,8 +112,10 @@ class WebSocketClosedBeforeAuthenticationError extends Error {
     public readonly code: number,
     public readonly reason?: string,
   ) {
+    // A rejected token and a transient drop (server restart, proxy reset) close
+    // with the same pre-auth shape; the message must not assert a single cause.
     super(
-      `websocket closed before authentication completed (code ${code}) — check the Mattermost bot token`,
+      `websocket closed before authentication completed (code ${code}) — either the bot token was rejected or the connection dropped (server restart, proxy reset); check the Mattermost bot token if this repeats`,
     );
     this.name = "WebSocketClosedBeforeAuthenticationError";
   }

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -142,7 +142,6 @@ type CreateMattermostConnectOnceOpts = {
   healthCheckIntervalMs?: number;
   pingIntervalMs?: number;
   pongTimeoutMs?: number;
-  authTimeoutMs?: number;
 };
 
 const defaultMattermostWebSocketFactory: MattermostWebSocketFactory = (url, options) => {
@@ -160,7 +159,6 @@ export function createMattermostConnectOnce(
   const healthCheckIntervalMs = opts.healthCheckIntervalMs ?? 30_000;
   const pingIntervalMs = opts.pingIntervalMs ?? 30_000;
   const pongTimeoutMs = opts.pongTimeoutMs ?? 10_000;
-  const authTimeoutMs = opts.authTimeoutMs ?? MATTERMOST_WEBSOCKET_AUTH_TIMEOUT_MS;
   return async () => {
     const flowId = randomUUID();
     const ws = webSocketFactory(opts.wsUrl, {
@@ -348,7 +346,7 @@ export function createMattermostConnectOnce(
             opts.runtime.error?.("mattermost websocket authentication timed out — reconnecting");
             stopHealthChecks();
             ws.terminate();
-          }, authTimeoutMs);
+          }, MATTERMOST_WEBSOCKET_AUTH_TIMEOUT_MS);
           scheduleProtocolPing();
 
           // Periodically check if the bot account was modified (e.g. disable/enable).


### PR DESCRIPTION
## What problem this solves

Mattermost closes an opened WebSocket without replying when it rejects an `authentication_challenge`. OpenClaw treated every close after `open` as a successful connection outcome.

The channel then retried silently at its minimum delay. Operators saw no actionable `lastError`.

## Root cause

`createMattermostConnectOnce` tracked the transport open event but not authentication completion. Its close handler resolved before the matching `status: "OK"` response arrived.

`runWithReconnect` resets backoff after a resolved attempt and grows backoff only after a rejected attempt.

## Fix

- Track the matching authentication acknowledgement in the WebSocket connection owner.
- Reject a close before acknowledgement with `WebSocketClosedBeforeAuthenticationError`.
- Name both possible causes: token rejection or a transient connection drop.
- Bound the authentication phase and clear that deadline after acknowledgement.
- Keep authenticated closes on the existing normal reconnect path.

## Evidence

Tested with real Mattermost 11.10.1 and the real `/api/v4/websocket` authentication flow.

| Scenario | Exact current main `d5412d73acfb` | Repaired head `99e2930d9319` |
| --- | --- | --- |
| Valid session | Reached `ready` | Reached `ready` |
| Invalid challenge errors | None across four closes | Four `WebSocketClosedBeforeAuthenticationError` results |
| Published `lastError` | Missing | Present and actionable |
| Reconnect delays | `200, 200, 200` ms | `200, 400, 800` ms |

Mattermost's upstream contract matches the observation. Invalid session lookup closes the socket without a reply, while valid authentication sends `status: OK` with the matching request sequence: [`websocket_router.go`](https://github.com/mattermost/mattermost/blob/f9deca984f8a8d38a5f5e50600b45e22c90ebca1/server/channels/app/platform/websocket_router.go#L39-L77).

## Validation

- Target tests fail on pre-fix production: 3 expected failures.
- `monitor-websocket.test.ts` and `reconnect.test.ts`: 29/29 pass.
- `pnpm check:changed`: pass, including extension types, test types, lint, format, and repository ratchets.
- Production delta: +45 lines. Tests: +149 lines.
- Removed a test-only production timeout override and a duplicate regression test from the original patch.
