### PR TITLE
fix(gateway): isolate portal cookies across lifetimes

### DIFF
--- a/docs/gateway/portals.md
+++ b/docs/gateway/portals.md
@@ -89,7 +89,7 @@ One consequence worth planning for: portal listeners bind the same interfaces as
 
 Each portal uses a separate origin on its own port and binds to the same interfaces as the Gateway. Access requires the token in the portal URL. On the first request, the proxy stores that token in an HttpOnly cookie and removes it from subsequent upstream requests. The proxy validates this cookie itself and never forwards it to the application.
 
-Browser cookies are hostname-scoped rather than port-scoped, so the proxy isolates each application's cookie jar with an `oc_portal_<targetPort>_` name prefix. Requests forward only cookies with that portal's prefix and strip it before reaching the application; Gateway cookies, unprefixed cookies, and cookies for other portals are dropped. Application `Set-Cookie` responses receive the prefix, and any `Domain` attribute is removed so the cookie stays host-only.
+Browser cookies are hostname-scoped rather than port-scoped, so the proxy gives each portal instance a random `oc_portal_<instance>_` cookie-name prefix. Requests forward only cookies with the current portal's prefix and strip it before reaching the application; Gateway cookies, unprefixed cookies, and cookies from sibling or closed portals are dropped. Application `Set-Cookie` responses receive the prefix, and any `Domain` attribute is removed so the cookie stays host-only.
 
 Portals proxy only the selected local development server. They never serve Gateway data, and every portal ends when the Gateway restarts.
 
@@ -97,7 +97,7 @@ Portals proxy only the selected local development server. They never serve Gatew
 
 - The development server must run on the Gateway host. Remote worker support is planned.
 - A proxy or tunnel in front of the Gateway does not automatically expose portal listener ports. The Control UI detects this and shows a reachable URL with retry guidance instead of mounting a dead iframe.
-- Browser-side cookie code sees the prefixed names in `document.cookie`. Applications that manage cookies in browser code must account for the prefix; unprefixed cookies written directly by browser code are not forwarded to the target.
+- The prefix isolates cookies forwarded to each target; it does not create separate browser cookie jars. Browser-side code can see non-`HttpOnly` cookies for sibling portals on the same hostname through `document.cookie`. Use `HttpOnly` for sensitive application cookies. Applications that manage cookies in browser code must account for the prefix; unprefixed cookies written directly by browser code are not forwarded to the target.
 
 ## Troubleshooting
 

--- a/src/gateway/portals/portal-http-proxy.test.ts
+++ b/src/gateway/portals/portal-http-proxy.test.ts
@@ -123,14 +123,18 @@ async function httpCall(params: {
   });
 }
 
-function storeResponseCookies(jar: Map<string, string>, result: HttpResult): void {
-  for (const cookie of result.headers["set-cookie"] ?? []) {
+function storeCookies(jar: Map<string, string>, cookies: readonly string[] | undefined): void {
+  for (const cookie of cookies ?? []) {
     const pair = cookie.split(";", 1)[0];
     const separator = pair?.indexOf("=") ?? -1;
     if (pair && separator > 0) {
       jar.set(pair.slice(0, separator), pair.slice(separator + 1));
     }
   }
+}
+
+function storeResponseCookies(jar: Map<string, string>, result: HttpResult): void {
+  storeCookies(jar, result.headers["set-cookie"]);
 }
 
 function cookieJarHeader(jar: ReadonlyMap<string, string>): string {
@@ -149,6 +153,29 @@ function webSocketMessageText(data: RawData): string {
       ? Buffer.from(data)
       : data;
   return bytes.toString("utf8");
+}
+
+async function openWebSocket(
+  url: string,
+  headers?: Record<string, string>,
+): Promise<{ socket: WebSocket; setCookies: string[] | undefined }> {
+  let setCookies: string[] | undefined;
+  const socket = new WebSocket(url, headers ? { headers } : undefined);
+  socket.once("upgrade", (response) => {
+    setCookies = response.headers["set-cookie"];
+  });
+  await new Promise<void>((resolve, reject) => {
+    socket.once("open", resolve);
+    socket.once("error", reject);
+  });
+  return { socket, setCookies };
+}
+
+async function closeWebSocket(socket: WebSocket): Promise<void> {
+  await new Promise<void>((resolve) => {
+    socket.once("close", resolve);
+    socket.close();
+  });
 }
 
 async function browserCall(
@@ -323,11 +350,16 @@ describe("portal HTTP proxy", () => {
       port: portalB.listenPort,
       path: `/set?${portalB.tokenQuery}`,
     });
-    expect(initialA.headers["set-cookie"]).toContain(
-      `oc_portal_${targetPort}_session=a; Path=/; HttpOnly`,
+    const targetCookieA = initialA.headers["set-cookie"]?.find((cookie) =>
+      cookie.startsWith("oc_portal_"),
     );
-    expect(initialB.headers["set-cookie"]).toContain(
-      `oc_portal_${targetPortB}_session=b; Path=/; HttpOnly`,
+    const targetCookieB = initialB.headers["set-cookie"]?.find((cookie) =>
+      cookie.startsWith("oc_portal_"),
+    );
+    expect(targetCookieA).toMatch(/^oc_portal_[a-f0-9]{32}_session=a; Path=\/; HttpOnly$/u);
+    expect(targetCookieB).toMatch(/^oc_portal_[a-f0-9]{32}_session=b; Path=\/; HttpOnly$/u);
+    expect(targetCookieA?.split("_session=", 1)[0]).not.toBe(
+      targetCookieB?.split("_session=", 1)[0],
     );
     expect(
       [...(initialA.headers["set-cookie"] ?? []), ...(initialB.headers["set-cookie"] ?? [])].join(
@@ -349,6 +381,41 @@ describe("portal HTTP proxy", () => {
     });
     expect(receivedCookiesA).toEqual([undefined, "session=a"]);
     expect(receivedCookiesB).toEqual([undefined, "session=b"]);
+  });
+
+  it("does not forward cookies from a closed portal when its target port is reused", async () => {
+    targetHandler = (_req, res) => {
+      res.setHeader("Set-Cookie", "session=portal-a-secret; Path=/; HttpOnly");
+      res.end("target-a");
+    };
+    const service = portalService();
+    const portalA = await service.open({ targetPort });
+    const jar = new Map<string, string>();
+    await browserCall(jar, {
+      port: portalA.listenPort,
+      path: `/?${portalA.tokenQuery}`,
+    });
+    await service.close(portalA.id);
+
+    const receivedCookiesB: Array<string | undefined> = [];
+    targetHandler = (req, res) => {
+      receivedCookiesB.push(req.headers.cookie);
+      if (req.url === "/set") {
+        res.setHeader("Set-Cookie", "session=portal-b; Path=/; HttpOnly");
+      }
+      res.end("target-b");
+    };
+    const portalB = await service.open({ targetPort });
+    expect(portalB.tokenQuery).not.toBe(portalA.tokenQuery);
+
+    await browserCall(jar, {
+      port: portalB.listenPort,
+      path: `/?${portalB.tokenQuery}`,
+    });
+    await browserCall(jar, { port: portalB.listenPort, path: "/set" });
+    await browserCall(jar, { port: portalB.listenPort });
+
+    expect(receivedCookiesB).toEqual([undefined, undefined, "session=portal-b"]);
   });
 
   it("forces no-referrer and never forwards a token-bearing referrer", async () => {
@@ -472,7 +539,10 @@ describe("portal HTTP proxy", () => {
     expect(await echoed).toBe("hot reload");
     expect(targetWebSocketPath).toBe("/hmr?channel=dev");
     expect(targetWebSocketCookie).toBeUndefined();
-    expect(upgradeCookies).toEqual([`oc_portal_${targetPort}_socket=ready; Path=/; HttpOnly`]);
+    expect(upgradeCookies).toHaveLength(1);
+    expect(upgradeCookies?.[0]).toMatch(
+      /^oc_portal_[a-f0-9]{32}_socket=ready; Path=\/; HttpOnly$/u,
+    );
 
     const closed = new Promise<void>((resolve) => {
       ws.once("close", () => resolve());
@@ -521,5 +591,35 @@ describe("portal HTTP proxy", () => {
       ws.once("close", () => resolve());
       ws.close();
     });
+  });
+
+  it("does not forward WebSocket cookies from a closed portal when its target port is reused", async () => {
+    const service = portalService();
+    const portalA = await service.open({ targetPort });
+    targetWebSocketSetCookie = "socket=portal-a-secret; Path=/; HttpOnly";
+    const connectionA = await openWebSocket(
+      `ws://127.0.0.1:${portalA.listenPort}/hmr?${portalA.tokenQuery}`,
+    );
+    const jar = new Map<string, string>();
+    storeCookies(jar, connectionA.setCookies);
+    await closeWebSocket(connectionA.socket);
+    await service.close(portalA.id);
+
+    const portalB = await service.open({ targetPort });
+    targetWebSocketSetCookie = "socket=portal-b; Path=/; HttpOnly";
+    const connectionB = await openWebSocket(
+      `ws://127.0.0.1:${portalB.listenPort}/hmr?${portalB.tokenQuery}`,
+      { Cookie: cookieJarHeader(jar) },
+    );
+    expect(targetWebSocketCookie).toBeUndefined();
+    storeCookies(jar, connectionB.setCookies);
+    await closeWebSocket(connectionB.socket);
+
+    const connectionBAgain = await openWebSocket(
+      `ws://127.0.0.1:${portalB.listenPort}/hmr?${portalB.tokenQuery}`,
+      { Cookie: cookieJarHeader(jar) },
+    );
+    expect(targetWebSocketCookie).toBe("socket=portal-b");
+    await closeWebSocket(connectionBAgain.socket);
   });
 });

--- a/src/gateway/portals/portal-http-proxy.ts
+++ b/src/gateway/portals/portal-http-proxy.ts
@@ -16,8 +16,8 @@ function portalAuthCookieName(listenPort: number): string {
   return `${PORTAL_AUTH_NAME}_${listenPort}`;
 }
 
-// Cookies are hostname-scoped, not port-scoped. Per-target prefixes keep Gateway
-// and sibling portal cookies from leaking into an agent-run application.
+// Cookies are hostname-scoped, not port-scoped. Per-instance prefixes keep cookies
+// from sibling or closed portals out of the current agent-run application.
 const PORTAL_COOKIE_PREFIX = "oc_portal_";
 // The portal URL carries the bearer token in its query, so the browser must never
 // attach it as a Referer. The target controls its own response headers, so this is
@@ -40,6 +40,7 @@ type PortalProxyTarget = {
   listenPort: number;
   targetPort: number;
   token: string;
+  cookieNamespace: string;
 };
 
 type PortalAuthorization =
@@ -72,15 +73,15 @@ function readPortalCookie(
   return undefined;
 }
 
-function portalCookiePrefix(targetPort: number): string {
-  return `${PORTAL_COOKIE_PREFIX}${targetPort}_`;
+function portalCookiePrefix(cookieNamespace: string): string {
+  return `${PORTAL_COOKIE_PREFIX}${cookieNamespace}_`;
 }
 
 function readTargetCookies(
   cookieHeader: string | undefined,
-  targetPort: number,
+  cookieNamespace: string,
 ): string | undefined {
-  const prefix = portalCookiePrefix(targetPort);
+  const prefix = portalCookiePrefix(cookieNamespace);
   const retained = (cookieHeader?.split(";") ?? []).flatMap((segment) => {
     const separator = segment.indexOf("=");
     if (separator <= 0) {
@@ -96,7 +97,7 @@ function readTargetCookies(
   return normalized || undefined;
 }
 
-function rewriteTargetCookie(cookie: string, targetPort: number): string | undefined {
+function rewriteTargetCookie(cookie: string, cookieNamespace: string): string | undefined {
   const [cookiePair, ...attributes] = cookie.split(";");
   const separator = cookiePair?.indexOf("=") ?? -1;
   if (!cookiePair || separator <= 0) {
@@ -108,7 +109,7 @@ function rewriteTargetCookie(cookie: string, targetPort: number): string | undef
   }
   const retainedAttributes = attributes.filter((attribute) => !/^\s*domain\s*=/iu.test(attribute));
   const suffix = retainedAttributes.length > 0 ? `;${retainedAttributes.join(";")}` : "";
-  return `${portalCookiePrefix(targetPort)}${name}=${cookiePair.slice(separator + 1)}${suffix}`;
+  return `${portalCookiePrefix(cookieNamespace)}${name}=${cookiePair.slice(separator + 1)}${suffix}`;
 }
 
 function parsePortalUrl(req: IncomingMessage): URL | undefined {
@@ -152,7 +153,7 @@ function setProxyResponseHeader(
   res: ServerResponse,
   name: string,
   value: string | string[] | number,
-  targetPort: number,
+  cookieNamespace: string,
 ): void {
   if (name !== "set-cookie") {
     res.setHeader(name, value);
@@ -163,7 +164,7 @@ function setProxyResponseHeader(
     existing === undefined ? [] : Array.isArray(existing) ? existing : [existing];
   const targetCookies = Array.isArray(value) ? value : [String(value)];
   const rewrittenCookies = targetCookies.flatMap((cookie) => {
-    const rewritten = rewriteTargetCookie(cookie, targetPort);
+    const rewritten = rewriteTargetCookie(cookie, cookieNamespace);
     return rewritten ? [rewritten] : [];
   });
   const cookies = [...existingCookies.map(String), ...rewrittenCookies];
@@ -212,7 +213,7 @@ function connectionHeaderTokens(headers: IncomingHttpHeaders): Set<string> {
   );
 }
 
-function proxyHeaders(headers: IncomingHttpHeaders, targetPort?: number): OutgoingHttpHeaders {
+function proxyHeaders(headers: IncomingHttpHeaders, cookieNamespace?: string): OutgoingHttpHeaders {
   const result: OutgoingHttpHeaders = {};
   const connectionTokens = connectionHeaderTokens(headers);
   for (const [name, value] of Object.entries(headers)) {
@@ -224,8 +225,11 @@ function proxyHeaders(headers: IncomingHttpHeaders, targetPort?: number): Outgoi
     ) {
       continue;
     }
-    if (normalized === "cookie" && targetPort !== undefined) {
-      const cookie = readTargetCookies(Array.isArray(value) ? value.join("; ") : value, targetPort);
+    if (normalized === "cookie" && cookieNamespace !== undefined) {
+      const cookie = readTargetCookies(
+        Array.isArray(value) ? value.join("; ") : value,
+        cookieNamespace,
+      );
       if (cookie) {
         result.cookie = cookie;
       }
@@ -258,7 +262,7 @@ export function handlePortalProxyRequest(params: {
     res.setHeader("Set-Cookie", portalCookie(target, tls));
   }
 
-  const headers = proxyHeaders(req.headers, target.targetPort);
+  const headers = proxyHeaders(req.headers, target.cookieNamespace);
   const originalHost = req.headers.host;
   headers.host = `localhost:${target.targetPort}`;
   headers["x-forwarded-for"] = req.socket.remoteAddress ?? "";
@@ -280,7 +284,7 @@ export function handlePortalProxyRequest(params: {
   proxyReq.once("response", (proxyRes) => {
     for (const [name, value] of Object.entries(proxyHeaders(proxyRes.headers))) {
       if (value !== undefined) {
-        setProxyResponseHeader(res, name, value, target.targetPort);
+        setProxyResponseHeader(res, name, value, target.cookieNamespace);
       }
     }
     // Overwrite, never default: a target answering with `unsafe-url` would otherwise
@@ -300,7 +304,12 @@ export function handlePortalProxyRequest(params: {
   req.pipe(proxyReq);
 }
 
-function websocketHeaders(req: IncomingMessage, targetPort: number, requestPath: string): string {
+function websocketHeaders(
+  req: IncomingMessage,
+  targetPort: number,
+  cookieNamespace: string,
+  requestPath: string,
+): string {
   const lines = [`${req.method ?? "GET"} ${requestPath} HTTP/1.1`];
   for (const [name, value] of Object.entries(req.headers)) {
     const normalized = name.toLowerCase();
@@ -314,7 +323,10 @@ function websocketHeaders(req: IncomingMessage, targetPort: number, requestPath:
       continue;
     }
     if (normalized === "cookie") {
-      const cookie = readTargetCookies(Array.isArray(value) ? value.join("; ") : value, targetPort);
+      const cookie = readTargetCookies(
+        Array.isArray(value) ? value.join("; ") : value,
+        cookieNamespace,
+      );
       if (cookie) {
         lines.push(`cookie: ${cookie}`);
       }
@@ -341,7 +353,7 @@ function rejectPortalUpgrade(socket: Duplex): void {
 function forwardWebSocketResponse(
   targetSocket: Socket,
   browserSocket: Duplex,
-  targetPort: number,
+  cookieNamespace: string,
 ): void {
   let pending = Buffer.alloc(0);
   const onData = (chunk: Buffer) => {
@@ -362,7 +374,7 @@ function forwardWebSocketResponse(
       if (separator <= 0 || line.slice(0, separator).trim().toLowerCase() !== "set-cookie") {
         return [line];
       }
-      const rewritten = rewriteTargetCookie(line.slice(separator + 1).trimStart(), targetPort);
+      const rewritten = rewriteTargetCookie(line.slice(separator + 1).trimStart(), cookieNamespace);
       return rewritten ? [`${line.slice(0, separator)}: ${rewritten}`] : [];
     });
     browserSocket.write(`${rewrittenLines.join("\r\n")}\r\n\r\n`);
@@ -410,8 +422,10 @@ export function handlePortalProxyUpgrade(params: {
   socket.once("error", () => targetSocket.destroy());
   targetSocket.once("error", () => socket.destroy());
   targetSocket.once("connect", () => {
-    forwardWebSocketResponse(targetSocket, socket, target.targetPort);
-    targetSocket.write(websocketHeaders(req, target.targetPort, authorization.requestPath));
+    forwardWebSocketResponse(targetSocket, socket, target.cookieNamespace);
+    targetSocket.write(
+      websocketHeaders(req, target.targetPort, target.cookieNamespace, authorization.requestPath),
+    );
     if (head.length > 0) {
       targetSocket.write(head);
     }

--- a/src/gateway/portals/portal-service.ts
+++ b/src/gateway/portals/portal-service.ts
@@ -20,6 +20,7 @@ type PortalEntry = {
   path?: string;
   targetPort: number;
   token: string;
+  cookieNamespace: string;
   listenPort: number;
   createdAtMs: number;
 };
@@ -169,6 +170,7 @@ export function createGatewayPortalService(params: {
           ...(input.path ? { path: input.path } : {}),
           targetPort: input.targetPort,
           token: randomBytes(32).toString("hex"),
+          cookieNamespace: randomBytes(16).toString("hex"),
           listenPort: 0,
           createdAtMs: Date.now(),
         };


### PR DESCRIPTION
## What Problem This Solves

Reopening a portal for the same target port could forward application cookies retained from the previous portal lifetime to the replacement target.

## Why This Change Was Made

The portal service now creates a separate non-secret application-cookie namespace for each portal lifetime. That lifetime-owned value flows through the shared HTTP and WebSocket proxy paths, which both reject cookies from prior lifetimes and continue to round-trip cookies set by the current target.

The public docs also clarify the precise boundary: the proxy isolates which cookies it forwards upstream, but hostname-scoped non-`HttpOnly` cookies remain visible to browser JavaScript.

## User Impact

Closing and reopening a portal no longer lets the replacement target receive application cookies retained from the prior portal lifetime. Existing portal authentication and current-lifetime application cookies continue to work normally.

## Evidence Map

- Entry point: browser HTTP and WebSocket traffic through a token-authenticated portal listener.
- Lifecycle owner: `src/gateway/portals/portal-service.ts` creates a fresh namespace with every new portal entry.
- Enforcement owner: `src/gateway/portals/portal-http-proxy.ts` uses that namespace for inbound filtering and response rewriting.
- Sibling paths: HTTP requests/responses and WebSocket upgrades/handshakes use the same lifetime value.
- Regression: close portal A, replace the target on the same port, open portal B, preserve the browser cookie jar, reject A's cookie over HTTP and WebSocket, then accept B's own cookie over both transports.
- Compatibility: portals are unreleased on stable; no persisted state, config, protocol, or public API shape changes.
- Diff composition: production `+37/-21` (net `+16`), tests `+107/-7`, docs `+2/-2`. The production growth carries one owner-created namespace through the two existing proxy transports; no parallel policy path was added.

## Real Behavior Proof

Exact PR head: `e163639c5f29c7549c299961bcdbebb5ac74370c`.

- Provider: Blacksmith Testbox
- Lease: `tbx_01m0xcgps2eyst7rsy0twfs2vy`
- [Testbox run](https://github.com/openclaw/openclaw/actions/runs/32900140459)
- Command: full `pnpm build`, repo-pinned Chromium install, then an isolated foreground Gateway plus real `portal.open`/`portal.close` RPCs and one retained Chromium profile.
- Result: pass. The browser retained portal A's prior cookie namespace. After close/reopen on the same target port, target B observed no stale cookie on its document request, focused HTTP request, or WebSocket handshake. After B set its own cookie, B observed `session=B-secret` over both HTTP and WebSocket.

```json
{
  "sameTargetPort": true,
  "distinctPortalUrls": true,
  "browserRetainedPriorCookieNamespace": true,
  "staleCookieReachedReplacementTarget": false,
  "currentCookieReachedReplacementTarget": {
    "http": true,
    "websocket": true
  },
  "replacementTargetObservations": [
    { "transport": "http", "path": "/", "cookie": "" },
    { "transport": "http", "path": "/http-before", "cookie": "" },
    { "transport": "websocket", "path": "/socket", "cookie": "" },
    { "transport": "http", "path": "/http-after", "cookie": "session=B-secret" },
    { "transport": "websocket", "path": "/socket", "cookie": "session=B-secret" }
  ]
}
```

Testbox sync adds a proof-only driver commit. A separate [provenance run](https://github.com/openclaw/openclaw/actions/runs/32900749193) verified its parent is the exact PR head above and its only delta is `scripts/.portal-cookie-lifetime-proof.mjs`:

```text
base_pr_head=e163639c5f29c7549c299961bcdbebb5ac74370c
proof_only_delta=scripts/.portal-cookie-lifetime-proof.mjs
```

## Verification

- `node scripts/run-vitest.mjs src/gateway/portals` — 60/60 passed on exact head.
- `node scripts/check-changed.mjs` — passed.
- `pnpm build` — passed on exact head locally and in Testbox.
- `pnpm docs:check-mdx` — passed.
- `pnpm format:docs:check` — passed.
- Real Gateway + Chromium close/reopen proof — passed locally and in Testbox.
- Exact-head autoreview — clean, patch correct at 0.99 confidence, no accepted/actionable findings.

### Unrelated CI classification

`checks-node-compact-large-9` fails in `src/agents/embedded-agent-runner/model-resolution-consistency.test.ts` because its plugin-metadata mock omits an upstream export. That test and the mocked production module are byte-identical to `origin/main`; this PR changes only the portal files listed above. The failure is therefore unrelated to this branch and is not a portal validation gap. The failing aggregate `openclaw/ci-gate` check is only the downstream reflection of that same unrelated shard; all branch-related checks are green.
