### PR TITLE
fix(agent-exec): avoid Windows cleanup failures after SQLite use

### DIFF
--- a/src/commands/agent-exec.cleanup.test.ts
+++ b/src/commands/agent-exec.cleanup.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  closeOpenClawAgentDatabasesUnderStateDir,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { agentExecCommand } from "./agent-exec.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function createRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+function successResult(text = "ok") {
+  return {
+    payloads: [{ text }],
+    meta: {
+      durationMs: 1,
+      finalAssistantVisibleText: text,
+      agentMeta: {
+        sessionId: "cleanup-test-session",
+        provider: "proof",
+        model: "proof",
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("agent exec temporary SQLite cleanup", () => {
+  it("closes temporary agent and shared-state databases before removing their directory", async () => {
+    const runtime = createRuntime();
+    let observedStateDir = "";
+    let stateDatabasePath = "";
+    let agentDatabase: ReturnType<typeof openOpenClawAgentDatabase> | undefined;
+    let stateDatabase: ReturnType<typeof openOpenClawStateDatabase> | undefined;
+
+    try {
+      const result = await agentExecCommand("inspect", {}, runtime, {
+        runAgent: vi.fn(async () => {
+          observedStateDir = process.env.OPENCLAW_STATE_DIR ?? "";
+          stateDatabasePath = resolveOpenClawStateSqlitePath();
+          stateDatabase = openOpenClawStateDatabase();
+          agentDatabase = openOpenClawAgentDatabase({ agentId: "main" });
+          return successResult();
+        }),
+      });
+
+      expect(result).toMatchObject({ exitCode: 0, envelope: { status: "ok", final: "ok" } });
+      expect(agentDatabase?.db.isOpen).toBe(false);
+      expect(stateDatabase?.db.isOpen).toBe(false);
+      await expect(fs.stat(observedStateDir)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      if (observedStateDir) {
+        closeOpenClawAgentDatabasesUnderStateDir(observedStateDir);
+      }
+      if (stateDatabasePath) {
+        closeOpenClawStateDatabaseByPath(stateDatabasePath);
+      }
+      if (observedStateDir) {
+        await fs.rm(observedStateDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("leaves process-held databases outside the temporary state directory open", async () => {
+    const externalStateDir = tempDirs.make("openclaw-agent-exec-external-state-");
+    const externalEnv = { ...process.env, OPENCLAW_STATE_DIR: externalStateDir };
+    const externalStateDatabasePath = resolveOpenClawStateSqlitePath(externalEnv);
+    const externalStateDatabase = openOpenClawStateDatabase({ env: externalEnv });
+    const externalAgentDatabase = openOpenClawAgentDatabase({
+      agentId: "external-owner",
+      env: externalEnv,
+    });
+    const runtime = createRuntime();
+
+    try {
+      const result = await agentExecCommand("inspect", {}, runtime, {
+        runAgent: vi.fn(async () => {
+          openOpenClawStateDatabase();
+          openOpenClawAgentDatabase({ agentId: "main" });
+          return successResult();
+        }),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(externalAgentDatabase.db.isOpen).toBe(true);
+      expect(externalStateDatabase.db.isOpen).toBe(true);
+    } finally {
+      closeOpenClawAgentDatabasesUnderStateDir(externalStateDir);
+      closeOpenClawStateDatabaseByPath(externalStateDatabasePath);
+    }
+  });
+});

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -575,6 +575,8 @@ export async function agentExecCommand(
   let runtimePaths: typeof import("../config/paths.js") | undefined;
   let configIo: typeof import("../config/io.js") | undefined;
   let stopLocalAuditWriter: (() => Promise<void>) | undefined;
+  let closeTemporaryAgentDatabases: (() => void) | undefined;
+  let closeTemporaryStateDatabase: (() => void) | undefined;
   let stateLock: EmbeddedStateLockHandle | null | undefined;
   let signalBridge:
     | ReturnType<
@@ -654,6 +656,21 @@ export async function agentExecCommand(
     restoreEnvironment = setAgentExecEnvironment({ stateDir, cwd });
     runtimePaths = await import("../config/paths.js");
     runtimePaths.pinRuntimePaths();
+    if (temporaryStateDir) {
+      const ownedTemporaryStateDir = temporaryStateDir;
+      const [agentDatabase, stateDatabase, stateDatabasePaths] = await Promise.all([
+        import("../state/openclaw-agent-db.js"),
+        import("../state/openclaw-state-db.js"),
+        import("../state/openclaw-state-db.paths.js"),
+      ]);
+      const temporaryStateDatabasePath = stateDatabasePaths.resolveOpenClawStateSqlitePath();
+      closeTemporaryAgentDatabases = () => {
+        agentDatabase.closeOpenClawAgentDatabasesUnderStateDir(ownedTemporaryStateDir);
+      };
+      closeTemporaryStateDatabase = () => {
+        stateDatabase.closeOpenClawStateDatabaseByPath(temporaryStateDatabasePath);
+      };
+    }
     if (opts.stateDir) {
       const { acquireEmbeddedStateLock, createEmbeddedStateSignalBridge } =
         await import("../infra/embedded-state-lock.js");
@@ -765,6 +782,10 @@ export async function agentExecCommand(
       cleanupError ??= error;
     }
   };
+  // Agent database close releases its lease through shared state. Close it
+  // first so that lease cleanup cannot reopen shared state after it is closed.
+  runCleanupStep(() => closeTemporaryAgentDatabases?.());
+  runCleanupStep(() => closeTemporaryStateDatabase?.());
   runCleanupStep(() => restoreEnvironment?.());
   runCleanupStep(() => restoreConfigEnvironment?.());
   runCleanupStep(() => configIo?.clearConfigCache());

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -631,6 +631,27 @@ export function closeOpenClawAgentDatabaseByPath(pathname: string): boolean {
   return true;
 }
 
+/** Close cached agent databases owned by one lexical state directory. */
+export function closeOpenClawAgentDatabasesUnderStateDir(stateDir: string): number {
+  const resolvedStateDir = path.resolve(stateDir);
+  let closed = 0;
+  for (const pathname of Array.from(cachedDatabases.keys())) {
+    const relativePath = path.relative(resolvedStateDir, pathname);
+    const belongsToStateDir =
+      relativePath === "" ||
+      (!path.isAbsolute(relativePath) &&
+        relativePath !== ".." &&
+        !relativePath.startsWith(`..${path.sep}`));
+    if (!belongsToStateDir) {
+      continue;
+    }
+    if (closeOpenClawAgentDatabaseByPath(pathname)) {
+      closed += 1;
+    }
+  }
+  return closed;
+}
+
 /** Close and unregister one unambiguous transient agent database by filesystem identity. */
 export function disposeOpenClawAgentDatabaseByPath(
   pathname: string,


### PR DESCRIPTION
Related: #116797

## What Problem This Solves

Fixes an issue where Windows users running `openclaw agent exec` without an explicit state directory could receive a cleanup failure after an otherwise successful run when the command opened agent or shared-state SQLite databases. Windows retained the process-owned handles, so removing the command-created state directory failed with `EBUSY` and changed the command result to an error.

## Why This Change Was Made

The command now closes only agent databases lexically owned by its temporary state directory, then closes that temporary shared-state database before restoring process state and deleting the directory. Agent databases close first because releasing their leases uses shared state.

Explicit caller-owned `--state-dir` databases and process-held databases outside the temporary directory are deliberately left open. Timeout behavior from #116797 remains out of scope.

## User Impact

A successful default `openclaw agent exec` run on Windows no longer fails during final cleanup or leaves its temporary state directory behind after SQLite-backed agent work.

## Evidence

Current-main production-path reproduction before this change:

```json
{"exitCode":1,"status":"error","final":"","cleanupError":"Agent exec cleanup failed: EBUSY ... openclaw.sqlite","stateDirExistsAfterCommand":true,"stateDirRemovedAfterOwnerClose":true}
```

The same real production-path driver at this PR head:

```json
{"exitCode":0,"status":"ok","final":"ok","runtimeErrors":[],"stateDirExistsAfterCommand":false,"stateDirRemovedAfterOwnerClose":true}
```

Focused regression coverage:

- Temporary agent and shared-state databases are closed before directory removal.
- Process-held databases outside the command-owned temporary directory remain open.
- `pnpm test src/commands/agent-exec.cleanup.test.ts`: 2/2 passed.
- `pnpm tsgo:core`: passed.
- `pnpm tsgo:test:src`: passed.
- Focused `oxlint`, `oxfmt`, and `git diff --check`: passed.