### PR TITLE
fix(gateway): stop persisting passive chat greetings into the durable logbook

### DIFF
--- a/src/gateway/server-methods/system-agent-greeting-welcome.test.ts
+++ b/src/gateway/server-methods/system-agent-greeting-welcome.test.ts
@@ -13,7 +13,9 @@ const inferenceFallbackMocks = vi.hoisted(() => ({
 const transcriptStoreMocks = vi.hoisted(() => ({
   appendTranscriptReset: vi.fn(),
   appendTranscriptTurn: vi.fn(),
-  readTranscriptTail: vi.fn(() => []),
+  readTranscriptTail: vi.fn(
+    (): Array<{ role: "user" | "assistant"; text: string; at: number }> => [],
+  ),
 }));
 const greetingMocks = vi.hoisted(() => ({
   acknowledgeSystemAgentGreetingDelivery: vi.fn(),
@@ -57,12 +59,12 @@ type FakeEngine = {
 };
 
 function makeEngine(): FakeEngine {
-  // Mirrors persistEngineHistory's contract: noted assistant messages appear
-  // in historySince so the welcome is persisted before acknowledgement.
   const history: Array<{ role: "user" | "assistant"; text: string }> = [];
   return {
     handle: vi.fn(async () => ({ text: "did the thing", action: "none" })),
-    seedHistory: vi.fn(),
+    seedHistory: vi.fn((turns: typeof history) => {
+      history.push(...turns);
+    }),
     historyLength: vi.fn(() => history.length),
     historySince: vi.fn((index: number) => history.slice(index)),
     getPendingOperatorProposal: vi.fn(() => null),
@@ -126,6 +128,8 @@ const quickActions = {
 
 beforeEach(() => {
   createdEngines.length = 0;
+  transcriptStoreMocks.appendTranscriptTurn.mockReset();
+  transcriptStoreMocks.readTranscriptTail.mockReset().mockReturnValue([]);
   inferenceFallbackMocks.verifySystemAgentInferenceWithFallback.mockResolvedValue({
     ok: true,
     binding: {},
@@ -141,9 +145,13 @@ beforeEach(() => {
     source: "model",
   });
   greetingMocks.buildSystemAgentGreetingQuestion.mockReturnValue(quickActions);
-  onboardingWelcomeMocks.buildOnboardingWelcome.mockResolvedValue({
-    text: "Inference is ready. Let's finish setup.",
-  });
+  onboardingWelcomeMocks.buildOnboardingWelcome.mockImplementation(
+    async ({ engine }: { engine: { noteAssistantMessage: (text: string) => void } }) => {
+      const text = "Inference is ready. Let's finish setup.";
+      engine.noteAssistantMessage(text);
+      return { text };
+    },
+  );
 });
 
 afterEach(() => {
@@ -153,6 +161,37 @@ afterEach(() => {
 });
 
 describe("openclaw.chat caretaker welcome", () => {
+  it.each([
+    { label: "caretaker", welcomeVariant: undefined },
+    { label: "onboarding", welcomeVariant: "onboarding" },
+    { label: "new-agent", welcomeVariant: "new-agent" },
+  ])(
+    "does not replay an earlier passive $label welcome on reconnect",
+    async ({ welcomeVariant }) => {
+      const transcript: Array<{ role: "user" | "assistant"; text: string; at: number }> = [];
+      transcriptStoreMocks.appendTranscriptTurn.mockImplementation(
+        (turn: { role: "user" | "assistant"; text: string; at: number }) => {
+          transcript.push(turn);
+        },
+      );
+      transcriptStoreMocks.readTranscriptTail.mockImplementation(() => transcript.slice());
+      const context = makeContext(new Map());
+      const variant = welcomeVariant ? { welcomeVariant } : {};
+
+      const first = await callChat(context, { sessionId: "first-welcome", ...variant });
+      const second = await callChat(context, { sessionId: "second-welcome", ...variant });
+
+      expect(first.ok).toBe(true);
+      expect(second.payload).toMatchObject({
+        reply: expectDefined(first.payload as { reply?: string }, "first welcome").reply,
+      });
+      expect(
+        expectDefined(createdEngines[1], "second welcome engine").seedHistory,
+      ).toHaveBeenCalledWith([]);
+      expect(transcript).toEqual([]);
+    },
+  );
+
   it("returns caretaker quick actions and persists the resolved greeting", async () => {
     greetingMocks.loadSystemAgentGreetingFacts.mockReturnValueOnce({
       updateAvailable: "2026.7.20",

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -743,7 +743,7 @@ describe("openclaw.chat", () => {
     );
   });
 
-  it("seeds a new engine with the persisted tail before recording its welcome", async () => {
+  it("seeds a new engine with the persisted tail without recording an idle welcome", async () => {
     stubEngineOverview();
     transcriptStoreMocks.readTranscriptTail.mockReturnValue([
       { role: "user", text: "Earlier question", at: 1 },
@@ -761,9 +761,7 @@ describe("openclaw.chat", () => {
       { role: "user", text: "Earlier question" },
       { role: "assistant", text: "Earlier answer" },
     ]);
-    expect(transcriptStoreMocks.appendTranscriptTurn).toHaveBeenCalledWith(
-      expect.objectContaining({ role: "assistant", text: expect.any(String) }),
-    );
+    expect(transcriptStoreMocks.appendTranscriptTurn).not.toHaveBeenCalled();
   });
 
   it("persists only the mask marker for a sensitive hosted-wizard answer", async () => {

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -604,6 +604,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
             );
           }
           const welcomeHistoryStart = engine.historyLength();
+          let persistWelcome = !welcomeOnly;
           let welcome: string;
           let welcomeQuestion: SystemAgentChatQuestion | undefined;
           try {
@@ -617,6 +618,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
               const overview = await engine.loadOverview();
               const facts = loadSystemAgentGreetingFacts();
               greetingAuditSequence = facts.auditSequence;
+              persistWelcome ||= facts.recentExternalEdit;
               welcome = (
                 await resolveSystemAgentGreeting({
                   overview,
@@ -636,7 +638,11 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
             respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, error.message));
             return;
           }
-          persistEngineHistory(engine, welcomeHistoryStart);
+          // Passive welcomes are ephemeral; an external-edit alert must survive
+          // before delivery acknowledges the audit cursor that would hide it.
+          if (persistWelcome) {
+            persistEngineHistory(engine, welcomeHistoryStart);
+          }
           await evictOldestSession(sessions, context);
           session = {
             engine,


### PR DESCRIPTION
## What Problem This Solves

On a zero-history fresh profile, the first thing an operator sees after onboarding is the system-agent greeting duplicated: the live "Inference is ready" welcome plus an identical copy under an "EARLIER" divider, and another copy accumulates on every chat reconnect. Captured live during a macOS onboarding round (obt826, main 203024eb33e):

![Duplicate greeting under EARLIER on a fresh profile](https://github.com/user-attachments/assets/b1982d4d-c01a-406a-a211-ba0ed1f90cca)

Mechanism: the `openclaw.chat` session owner ([system-agent.ts](src/gateway/server-methods/system-agent.ts)) seeds each new engine from the durable logbook tail, generates the welcome, then **unconditionally persisted that welcome** into the logbook (`persistEngineHistory`, unconditional since 8c7f09a3c4d). The embedded Control UI custodian loads `openclaw.chat.history` independently and labels the seeded tail "EARLIER", so the previous session's identical greeting renders below the fresh one.

## Why This Change Was Made

Record facts where they happen: a passive greeting that produced no user interaction is not conversation history. The welcome is now persisted only when the initial request carries genuine user input, or when a caretaker welcome delivers the one-shot external-edit alert (`facts.recentExternalEdit`) — that alert's audit cursor advances on delivery, so it must remain recoverable in the logbook (contract from 629de998f95, preserved). Ordinary caretaker, onboarding, and new-agent welcome-only connections keep their greeting in live engine/model context without durable rows. Reset boundaries (`reset: true` keeps the logbook, clean model context) and real conversational persistence are untouched.

Alternatives rejected: filtering at `seedHistory` loses because the Control UI loads the unfiltered durable history itself; tagging greeting rows adds persisted/protocol surface for ephemeral state; dropping every greeting unconditionally would break the external-edit durability contract.

## User Impact

Fresh installs and every subsequent app launch show one greeting, once. The durable logbook stops accumulating identical passive greetings; externally-edited-config alerts still survive delivery.

## Evidence

Regression tests fail pre-fix for all three greeting variants (caretaker, onboarding, new-agent): two consecutive welcome-only connections must not replay the prior greeting (3 failed pre-fix, all pass post-fix). Focused gateway suites green: 43 tests across system-agent-greeting-welcome, system-agent, reset-boundary, and session-lifecycle. Full `check-changed` green. Autoreview clean ("patch is correct (0.99)"). Production delta +6 lines, justified by the external-edit durability boundary.
