### PR TITLE
fix(ci): stop inherited auth test from timing out cache warmer

### DIFF
--- a/src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts
+++ b/src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { listAgentIds } from "../agent-scope-config.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
@@ -9,7 +9,10 @@ import {
   mockedBuildEmbeddedRunPayloads,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
+  resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
+
+const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
 
 function projectSetupExecutionConfig(source: OpenClawConfig): OpenClawConfig {
   return {
@@ -25,6 +28,8 @@ function projectSetupExecutionConfig(source: OpenClawConfig): OpenClawConfig {
 }
 
 describe("embedded setup inference inherited auth owner", () => {
+  beforeEach(resetSharedRunIntegrationHarnessMocks);
+
   it.each([
     { name: "a pre-roster config", source: {} },
     { name: "a sole-agent config", source: { agents: { entries: { main: {} } } } },
@@ -34,7 +39,6 @@ describe("embedded setup inference inherited auth owner", () => {
       const config = projectSetupExecutionConfig(source);
       expect(listAgentIds(config)).toEqual(["main", "openclaw"]);
 
-      const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
       mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "OK" }]);
       mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["OK"] }));
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the trusted Vitest cache warmer fails to publish a new transform-cache generation after a dependency refresh because its inherited-auth ownership regression test exceeds the 120-second test limit. Without that cache, unrelated pull requests and main builds repeatedly run expensive cold test graphs and can time out on both hosted and Blacksmith runners.

## Why This Change Was Made

The inherited-auth ownership test rebuilt the complete embedded-agent module graph and its mocked dependencies separately for each table case. Reuse its existing harness once per test module and reset only the existing shared test state between cases, matching the already-landed sibling permission-test pattern from #129385. Both original ownership cases and all authorization assertions remain intact.

## User Impact

Developers and operators regain reliable cache-warming and CI validation without any production, authorization, provider, timeout, workflow, or cache-policy changes.

## Evidence

- Failing trusted cache warmer: https://github.com/openclaw/openclaw/actions/runs/32876437870/job/97895543631
- Before: the second inherited-auth case ran for 144,365 ms and exceeded its 120,000 ms limit; a local baseline took 119,306 ms for the first case alone.
- After: the previously failing case completes in 208 ms, with both inherited-auth cases and both sibling permission cases passing (4 tests total).
- Focused owner and sibling proof: `OPENCLAW_VITEST_MAX_WORKERS=1 node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.unit-fast-isolated.config.ts src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts src/agents/embedded-agent-runner/run.session-permissions.test.ts --reporter=verbose`
- Full changed gate: `node scripts/check-changed.mjs`, including core-test typechecking, lint, formatting, all dead-export scans, and repository guards.
- Production LOC: +0/-0. Tests: +6/-2.
