### PR TITLE
refactor(tts): consolidate speech provider ordering

### DIFF
--- a/src/tts/directives.ts
+++ b/src/tts/directives.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import type { AssistantDeliveryTtsFacts } from "../llm/types.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
 import { extractTtsDirectiveFacts } from "./directive-facts.js";
+import { compareSpeechProviderOrder } from "./provider-registry-core.js";
 import { listSpeechProviders } from "./provider-registry.js";
 import type {
   SpeechModelOverridePolicy,
@@ -31,20 +32,9 @@ type TtsDirectiveTextStreamCleaner = {
   hasBufferedDirectiveText: () => boolean;
 };
 
-function buildProviderOrder(left: SpeechProviderPlugin, right: SpeechProviderPlugin): number {
-  const leftOrder = left.autoSelectOrder ?? Number.MAX_SAFE_INTEGER;
-  const rightOrder = right.autoSelectOrder ?? Number.MAX_SAFE_INTEGER;
-  if (leftOrder !== rightOrder) {
-    return leftOrder - rightOrder;
-  }
-  return left.id.localeCompare(right.id);
-}
-
 function resolveDirectiveProviders(options?: ParseTtsDirectiveOptions): SpeechProviderPlugin[] {
-  if (options?.providers) {
-    return [...options.providers].toSorted(buildProviderOrder);
-  }
-  return listSpeechProviders(options?.cfg).toSorted(buildProviderOrder);
+  const providers = options?.providers ?? listSpeechProviders(options?.cfg);
+  return providers.toSorted(compareSpeechProviderOrder);
 }
 
 function resolveDirectiveProviderConfig(

--- a/src/tts/provider-registry-core.ts
+++ b/src/tts/provider-registry-core.ts
@@ -20,6 +20,19 @@ export function normalizeSpeechProviderId(
   return normalizeCapabilityProviderId(providerId);
 }
 
+/** Order speech providers by priority and provider ID for deterministic equal-priority fallback. */
+export function compareSpeechProviderOrder(
+  left: SpeechProviderPlugin,
+  right: SpeechProviderPlugin,
+): number {
+  const leftOrder = left.autoSelectOrder ?? Number.MAX_SAFE_INTEGER;
+  const rightOrder = right.autoSelectOrder ?? Number.MAX_SAFE_INTEGER;
+  if (leftOrder !== rightOrder) {
+    return leftOrder - rightOrder;
+  }
+  return left.id.localeCompare(right.id);
+}
+
 /** Create a registry facade with canonical listing, alias lookup, and ID canonicalization. */
 export function createSpeechProviderRegistry(resolver: SpeechProviderRegistryResolver) {
   const buildResolvedProviderMaps = (cfg?: OpenClawConfig) =>

--- a/src/tts/provider-registry.test.ts
+++ b/src/tts/provider-registry.test.ts
@@ -96,10 +96,11 @@ describe("speech provider registry", () => {
     expect(registry.canonicalizeSpeechProviderId("edge")).toBe("microsoft");
   });
 
-  it("resolves fallback order and aliases from a supplied provider inventory", () => {
+  it("resolves deterministic fallback order and aliases from a supplied provider inventory", () => {
     const inventory = [
       { ...createSpeechProvider("openai", ["oai"]), autoSelectOrder: 5 },
       { ...createSpeechProvider("google"), autoSelectOrder: 1 },
+      { ...createSpeechProvider("azure"), autoSelectOrder: 1 },
       { ...createSpeechProvider("elevenlabs"), autoSelectOrder: 3 },
     ];
 
@@ -109,7 +110,7 @@ describe("speech provider registry", () => {
         undefined,
         inventory,
       ),
-    ).toEqual(["openai", "google", "elevenlabs"]);
+    ).toEqual(["openai", "azure", "google", "elevenlabs"]);
   });
 
   it("selects the first configured provider entirely from prepared facts", () => {

--- a/src/tts/tts-provider-resolution.ts
+++ b/src/tts/tts-provider-resolution.ts
@@ -10,6 +10,7 @@ import type {
   TtsProvider,
 } from "../config/types.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
+import { compareSpeechProviderOrder } from "./provider-registry-core.js";
 import {
   canonicalizeSpeechProviderId,
   getSpeechProvider,
@@ -64,14 +65,7 @@ function sortSpeechProvidersForAutoSelection(
   cfg?: OpenClawConfig,
   providers?: readonly SpeechProviderPlugin[],
 ) {
-  return [...(providers ?? listSpeechProviders(cfg))].toSorted((left, right) => {
-    const leftOrder = left.autoSelectOrder ?? Number.MAX_SAFE_INTEGER;
-    const rightOrder = right.autoSelectOrder ?? Number.MAX_SAFE_INTEGER;
-    if (leftOrder !== rightOrder) {
-      return leftOrder - rightOrder;
-    }
-    return left.id.localeCompare(right.id);
-  });
+  return [...(providers ?? listSpeechProviders(cfg))].toSorted(compareSpeechProviderOrder);
 }
 
 function canonicalizeSpeechProviderIdFromInventory(


### PR DESCRIPTION
## What Problem This Solves

Speech-provider auto-selection used two independent copies of the same ordering policy: directive routing and synthesis fallback resolution each sorted by `autoSelectOrder`, then provider ID. Keeping the policy duplicated made future drift possible.

## Why This Change Was Made

Move the comparator to the speech provider registry core and make both consumers use that canonical owner. The ordering semantics, provider inventory, configuration, aliases, and public/plugin surfaces are unchanged.

Production LOC: +18/-21 (net -3) | Tests: +3/-2 (net +1)

## User Impact

No user-visible behavior change. Equal-priority providers remain deterministically ordered by provider ID in directive routing and buffered/streaming synthesis fallback paths.

## Evidence

- `pnpm test src/tts/directives.test.ts src/tts/provider-registry.test.ts src/tts/tts-runtime-fallbacks.test.ts src/tts/tts-runtime-models.test.ts` — 83 tests passed on exact head `4ebc2a0ace6256921edd655d668571f1b7118636`.
- `node scripts/check-changed.mjs -- src/tts/directives.ts src/tts/provider-registry-core.ts src/tts/provider-registry.test.ts src/tts/tts-provider-resolution.ts` — format, dead-export scan, core/core-test tsgo, lint, import-cycle, and repository guards passed.
- Deslop — clean; no behavior-neutral findings.
- Autoreview (`gpt-5.6-sol`, high) — clean, no accepted/actionable findings.
- Independent frozen-head Codex review — no findings; exact head clean.
- Upstream Codex boundary check at `openai/codex@a10c8127f732d50015a75472ffebd8e1ec7d7923`: [`UserInput` owns audio inputs](https://github.com/openai/codex/blob/a10c8127f732d50015a75472ffebd8e1ec7d7923/codex-rs/protocol/src/user_input.rs#L15-L43), while [realtime output modality is a text/audio protocol choice](https://github.com/openai/codex/blob/a10c8127f732d50015a75472ffebd8e1ec7d7923/codex-rs/protocol/src/protocol.rs#L231-L234) and [speech append accepts text](https://github.com/openai/codex/blob/a10c8127f732d50015a75472ffebd8e1ec7d7923/codex-rs/core/src/realtime_conversation.rs#L1762-L1769); none owns OpenClaw TTS provider ordering.

AI-assisted cleanup requested as part of the maintainer-authorized consolidation campaign.