### PR TITLE
fix(llama-cpp): existing-server setup chooses ready models first

### DIFF
--- a/extensions/llama-cpp/src/external-server/setup.test.ts
+++ b/extensions/llama-cpp/src/external-server/setup.test.ts
@@ -206,31 +206,68 @@ describe("llama-server setup", () => {
     expect(discoverMock).not.toHaveBeenCalled();
   });
 
-  it("does not select a failed router model while a healthy model is available", async () => {
+  it.each([
+    {
+      name: "prefers a loaded model over an unloaded higher-ranked family",
+      models: [
+        { id: "meta-llama/Llama-3.3-8B", status: "loaded" },
+        { id: "google/gemma-4-27b", status: "unloaded" },
+      ],
+      expected: "llama-cpp/meta-llama/Llama-3.3-8B",
+    },
+    {
+      name: "prefers a sleeping model over an unloaded higher-ranked family",
+      models: [
+        { id: "meta-llama/Llama-3.3-8B", status: "sleeping" },
+        { id: "google/gemma-4-27b", status: "unloaded" },
+      ],
+      expected: "llama-cpp/meta-llama/Llama-3.3-8B",
+    },
+    {
+      name: "preserves family preference among loaded models",
+      models: [
+        { id: "meta-llama/Llama-3.3-8B", status: "loaded" },
+        { id: "google/gemma-4-27b", status: "loaded" },
+      ],
+      expected: "llama-cpp/google/gemma-4-27b",
+    },
+    {
+      name: "preserves family preference when no model is loaded",
+      models: [
+        { id: "meta-llama/Llama-3.3-8B", status: "unloaded" },
+        { id: "google/gemma-4-27b", status: "unloaded" },
+      ],
+      expected: "llama-cpp/google/gemma-4-27b",
+    },
+    {
+      name: "prefers a healthy unloaded model over a failed loaded model",
+      models: [
+        { id: "google/gemma-4-27b", status: "loaded", failed: true },
+        { id: "meta-llama/Llama-3.3-8B", status: "unloaded" },
+      ],
+      expected: "llama-cpp/meta-llama/Llama-3.3-8B",
+    },
+    {
+      name: "returns no candidate for an empty model catalog",
+      models: [],
+      expected: null,
+    },
+  ] as const)("$name", async ({ models, expected }) => {
     const discovery = successfulDiscovery();
     const baseModel = discovery.models[0];
     if (!baseModel) {
       throw new Error("expected discovery fixture model");
     }
-    discovery.models = [
-      {
-        ...baseModel,
-        config: { ...baseModel.config, id: "qwen-failed", name: "qwen-failed" },
-        status: "unloaded",
-        failed: true,
-      },
-      {
-        ...baseModel,
-        config: { ...baseModel.config, id: "healthy-model", name: "healthy-model" },
-        status: "unloaded",
-        failed: false,
-      },
-    ];
+    discovery.models = models.map((model) => ({
+      ...baseModel,
+      config: { ...baseModel.config, id: model.id, name: model.id },
+      status: model.status,
+      failed: "failed" in model && model.failed,
+    }));
     discoverMock.mockResolvedValue(discovery);
 
-    await expect(detectLlamaServerSetup({ config: {}, env: {} })).resolves.toMatchObject({
-      modelRef: "llama-cpp/healthy-model",
-    });
+    const result = await detectLlamaServerSetup({ config: {}, env: {} });
+    expect(result?.modelRef ?? null).toBe(expected);
   });
 
   it("prefers configured Authorization over ambient auth during guided detection", async () => {

--- a/extensions/llama-cpp/src/external-server/setup.ts
+++ b/extensions/llama-cpp/src/external-server/setup.ts
@@ -40,12 +40,10 @@ import { buildLlamaServerProviderConfig } from "./models.js";
 function selectSetupModelId(discovery: Extract<LlamaServerDiscoveryResult, { kind: "success" }>) {
   const healthy = discovery.models.filter((model) => !model.failed);
   const candidates = healthy.length > 0 ? healthy : discovery.models;
-  const ordered = candidates.toSorted((left, right) => {
-    const leftLoaded = left.status === "loaded" || left.status === "sleeping";
-    const rightLoaded = right.status === "loaded" || right.status === "sleeping";
-    return Number(rightLoaded) - Number(leftLoaded);
-  });
-  const ids = ordered.map((model) => model.config.id);
+  const ready = candidates.filter(
+    (model) => model.status === "loaded" || model.status === "sleeping",
+  );
+  const ids = (ready.length > 0 ? ready : candidates).map((model) => model.config.id);
   return selectPreferredLocalModelId(ids) ?? ids[0];
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users connecting OpenClaw to an existing llama.cpp router could have guided, interactive, or non-interactive setup select an unloaded model even though a healthy model was already loaded or sleeping. A higher-ranked but unloaded model family could trigger an avoidable cold load, probe timeout, or setup failure.

## Why This Change Was Made

The llama.cpp provider owner sorted ready models first but then passed every model to global family ranking, which discarded that readiness ordering. Select the healthy loaded-or-sleeping tier first, then apply the existing family preference only within that tier; when no models are ready, preserve the existing healthy-catalog fallback. The shared owner covers all three setup flows without changing explicit model choices or other providers. Production code decreases by two lines.

## User Impact

Existing llama.cpp server setup now consistently prefers an already-available healthy model instead of unexpectedly choosing an unloaded higher-ranked family. Existing family ordering, failed-model exclusion, empty catalogs, and explicit requested model selection retain their current behavior.

## Evidence

- Before the fix, the owner regression suite failed exactly twice: loaded and sleeping Llama 3 models both incorrectly lost to an unloaded Gemma 4 model; the other 25 existing cases passed.
- A real ephemeral localhost llama-server fixture exercised `/health`, `/models`, and `/props?model=...&autoload=false`; before the fix both ready states selected the unloaded model, and after the fix both selected the loaded or sleeping model without changing the external server.
- Six table-driven owner cases cover loaded precedence, sleeping precedence, family ranking among loaded models, family ranking when none are loaded, a failed loaded model versus a healthy unloaded model, and an empty catalog.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-r3-qa-setup node scripts/run-vitest.mjs extensions/llama-cpp/src/external-server/setup.test.ts extensions/llama-cpp/src/external-server/discovery.test.ts extensions/llama-cpp/src/external-server/models.test.ts extensions/llama-cpp/src/external-server/endpoint.test.ts extensions/llama-cpp/src/external-server/auth.test.ts extensions/lmstudio/src/setup.test.ts extensions/ollama/src/setup-model-selection.test.ts --configLoader runner` — 106 tests passed across seven files and two Vitest projects.
- `node_modules/.bin/oxfmt --check extensions/llama-cpp/src/external-server/setup.ts extensions/llama-cpp/src/external-server/setup.test.ts`
- `node_modules/.bin/oxlint --config .oxlintrc.json extensions/llama-cpp/src/external-server/setup.ts extensions/llama-cpp/src/external-server/setup.test.ts`
- Mandatory independent autoreview completed with no accepted or actionable findings.
