### PR TITLE
[AI-assisted] fix(crabbox): keep the tail of provider failure output in command errors

### DIFF
--- a/extensions/crabbox/src/crabbox-worker-command-error.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-command-error.test.ts
@@ -1,0 +1,91 @@
+import type { SpawnResult } from "openclaw/plugin-sdk/process-runtime";
+import { describe, expect, it } from "vitest";
+import {
+  crabboxCommandError,
+  permanentCrabboxCommandError,
+} from "./crabbox-worker-command-error.js";
+
+function commandResult(overrides: Partial<SpawnResult> = {}): SpawnResult {
+  return {
+    stdout: "",
+    stderr: "",
+    code: 0,
+    signal: null,
+    killed: false,
+    termination: "exit",
+    ...overrides,
+  };
+}
+
+describe("crabboxCommandError", () => {
+  it("keeps short provider output intact", () => {
+    const error = crabboxCommandError(
+      "warmup",
+      commandResult({ code: 2, stderr: "provider=aws quota exhausted" }),
+    );
+    expect(error.message).toBe(
+      "Crabbox warmup failed with exit code 2: provider=aws quota exhausted",
+    );
+  });
+
+  it("falls back to stdout when stderr is empty", () => {
+    const error = crabboxCommandError("inspect", commandResult({ code: 1, stdout: "quota page" }));
+    expect(error.message).toBe("Crabbox inspect failed with exit code 1: quota page");
+  });
+
+  it("omits output detail when the command did not exit", () => {
+    const error = crabboxCommandError(
+      "inspect",
+      commandResult({ code: null, killed: true, termination: "timeout", stderr: "partial" }),
+    );
+    expect(error.message).toBe("Crabbox inspect did not exit normally (timeout)");
+  });
+
+  it("keeps the failure reason at the tail of long provider output", () => {
+    const progress = "pulling layer 9/12".padEnd(900, ".");
+    const reason = "terminal reason: instance profile not authorized";
+    const error = crabboxCommandError(
+      "warmup",
+      commandResult({ code: 2, stderr: `${progress}\n${reason}` }),
+    );
+    expect(error.message.startsWith("Crabbox warmup failed with exit code 2: …")).toBe(true);
+    expect(error.message.endsWith(reason)).toBe(true);
+    expect(error.message).not.toContain("pulling layer");
+  });
+
+  it("leaves 512-character output unmarked", () => {
+    const detail = "x".repeat(512);
+    const error = crabboxCommandError("inspect", commandResult({ code: 1, stderr: detail }));
+    expect(error.message).toBe(`Crabbox inspect failed with exit code 1: ${detail}`);
+  });
+
+  it("bounds the kept detail to 512 characters including the marker", () => {
+    const prefix = "Crabbox inspect failed with exit code 1: ";
+    const error = crabboxCommandError(
+      "inspect",
+      commandResult({ code: 1, stderr: "y".repeat(2000) }),
+    );
+    const kept = error.message.slice(prefix.length);
+    expect(kept).toHaveLength(512);
+    expect(kept.startsWith("…")).toBe(true);
+    expect(kept.endsWith("y".repeat(511))).toBe(true);
+  });
+
+  it("does not leave a dangling surrogate half at the cut boundary", () => {
+    // The cut lands on the low surrogate of the emoji; the pair must be dropped whole.
+    const stderr = `${"a".repeat(599)}\u{1F600}${"b".repeat(510)}`;
+    const error = crabboxCommandError("setup", commandResult({ code: 7, stderr }));
+    expect(error.message).not.toContain("\u{1F600}");
+    expect(error.message.endsWith("b".repeat(510))).toBe(true);
+  });
+});
+
+describe("permanentCrabboxCommandError", () => {
+  it("carries the same message as the retryable variant", () => {
+    const error = permanentCrabboxCommandError(
+      "setup",
+      commandResult({ code: 7, stderr: "apt exploded" }),
+    );
+    expect(error.message).toBe("Crabbox setup failed with exit code 7: apt exploded");
+  });
+});

--- a/extensions/crabbox/src/crabbox-worker-command-error.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-command-error.test.ts
@@ -33,10 +33,25 @@ describe("crabboxCommandError", () => {
     expect(error.message).toBe("Crabbox inspect failed with exit code 1: quota page");
   });
 
-  it("omits output detail when the command did not exit", () => {
+  it("keeps the captured tail when the command did not exit", () => {
     const error = crabboxCommandError(
       "inspect",
-      commandResult({ code: null, killed: true, termination: "timeout", stderr: "partial" }),
+      commandResult({
+        code: null,
+        killed: true,
+        termination: "timeout",
+        stderr: "provider never answered",
+      }),
+    );
+    expect(error.message).toBe(
+      "Crabbox inspect did not exit normally (timeout): provider never answered",
+    );
+  });
+
+  it("omits the detail when a non-exit termination produced no output", () => {
+    const error = crabboxCommandError(
+      "inspect",
+      commandResult({ code: null, killed: true, termination: "timeout" }),
     );
     expect(error.message).toBe("Crabbox inspect did not exit normally (timeout)");
   });

--- a/extensions/crabbox/src/crabbox-worker-command-error.ts
+++ b/extensions/crabbox/src/crabbox-worker-command-error.ts
@@ -1,7 +1,7 @@
 import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import { WorkerProviderError } from "openclaw/plugin-sdk/plugin-entry";
 import type { SpawnResult } from "openclaw/plugin-sdk/process-runtime";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 const MAX_COMMAND_DETAIL_CHARS = 512;
 
@@ -11,8 +11,12 @@ function crabboxCommandDetail(result: SpawnResult): string {
     return "";
   }
   const compressed = redactSensitiveText(raw).replace(/\s+/gu, " ");
-  const redacted = truncateUtf16Safe(compressed, MAX_COMMAND_DETAIL_CHARS);
-  return redacted ? `: ${redacted}` : "";
+  if (compressed.length <= MAX_COMMAND_DETAIL_CHARS) {
+    return `: ${compressed}`;
+  }
+  // Provider CLIs print progress first and the actual failure reason last, so the
+  // tail is what explains the rejection.
+  return `: …${sliceUtf16Safe(compressed, -(MAX_COMMAND_DETAIL_CHARS - 1))}`;
 }
 
 export function crabboxCommandError(action: string, result: SpawnResult): Error {

--- a/extensions/crabbox/src/crabbox-worker-command-error.ts
+++ b/extensions/crabbox/src/crabbox-worker-command-error.ts
@@ -21,7 +21,9 @@ function crabboxCommandDetail(result: SpawnResult): string {
 
 export function crabboxCommandError(action: string, result: SpawnResult): Error {
   if (result.termination !== "exit") {
-    return new Error(`Crabbox ${action} did not exit normally (${result.termination})`);
+    return new Error(
+      `Crabbox ${action} did not exit normally (${result.termination})${crabboxCommandDetail(result)}`,
+    );
   }
   const exitCode = result.code === null ? "unknown" : String(result.code);
   return new Error(

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -2418,7 +2418,7 @@ describe("Crabbox worker provider", () => {
     const error = await provider.inspect(lifecycleLease()).catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(Error);
     const message = error instanceof Error ? error.message : "";
-    expect(message).toBe(`${INSPECT_FAILURE_PREFIX}${prefix}`);
+    expect(message).toBe(`${INSPECT_FAILURE_PREFIX}…${"x".repeat(504)}😀after`);
     expect(hasLoneSurrogate(message)).toBe(false);
   });
 
@@ -2431,7 +2431,7 @@ describe("Crabbox worker provider", () => {
     const error = await provider.inspect(lifecycleLease()).catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(Error);
     const message = error instanceof Error ? error.message : "";
-    expect(message).toBe(`${INSPECT_FAILURE_PREFIX}${detail}`);
+    expect(message).toBe(`${INSPECT_FAILURE_PREFIX}…${"x".repeat(504)}😀after`);
     expect(hasLoneSurrogate(message)).toBe(false);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Closes #129013.

When Crabbox worker creation fails, the surfaced error keeps only the first 512 UTF-16 units of the provider CLI's output. Provider CLIs print progress and banner noise first and the actual failure reason last, so the message users get (`Crabbox warmup failed with exit code 2: <progress banner...>`) drops the one line that explains the rejection.

## Why This Change Was Made

`crabboxCommandDetail` truncated with `truncateUtf16Safe(compressed, 512)`, which keeps the head of the output. It now keeps the tail (`sliceUtf16Safe(compressed, -511)`) with a leading `…` marker, matching the marker-plus-tail pattern already used elsewhere in the repo (e.g. `extensions/telegram/src/model-buttons.ts`, `extensions/acpx/src/runtime.ts`). Redaction and whitespace collapsing still happen before the cut, so no secret can leak through the tail. The 512-unit budget including the marker is unchanged.

## User Impact

Failed worker creation now shows the provider's terminal failure line (quota, authorization, unsupported flag) instead of the first 512 chars of progress output. Short outputs render exactly as before.

## Evidence

- New unit tests in `crabbox-worker-command-error.test.ts` (8 cases): short output unchanged, stdout fallback, non-exit termination carries no detail, long output keeps the tail with the reason visible, 512-char output unmarked, detail bounded at 512 including the marker, no dangling surrogate half at the cut boundary, permanent variant carries the same message.
- Two existing assertions in `crabbox-worker-provider.test.ts` pinned the old head-keeping behavior and were updated to the tail contract (surrogate boundary cases, same shapes).
- `node scripts/run-vitest.mjs run extensions/crabbox`: 143 passed.
- `check:changed`: all lanes pass except `bundled-plugin-metadata` (geolocation plugin missing from the expected startup lists), which fails identically on a clean upstream/main checkout and is unrelated.
- Not live-tested against a real cloud provider (needs a paid Crabbox provider account); the changed path is covered by the unit and provider-level tests above.

This PR is AI-assisted (Kimi K3).


Update 2: non-exit terminations now keep the captured tail as well (8312b0e), and real-process behavior proof is in the comment below.

@clawsweeper re-review