### PR TITLE
fix(openai): preserve Azure embedding index across key rotation

### DIFF
--- a/extensions/openai/memory-embedding-adapter.test.ts
+++ b/extensions/openai/memory-embedding-adapter.test.ts
@@ -105,68 +105,94 @@ describe("OpenAI memory embedding adapter", () => {
     expect(JSON.stringify(current.cacheKeyData)).not.toContain("fixture-secret");
   });
 
-  it("keeps rotated proxy credentials out of tenant-specific embedding cache identity", async () => {
-    const createForTenant = async (
-      tenant: string,
-      proxyApiKey: string,
-      proxyHeaderName = "X-Api-Key",
-    ) => {
-      const client = await resolveRemoteEmbeddingBearerClient({
-        provider: "bailian-embedding",
-        defaultBaseUrl: "https://embeddings.example/v1",
-        options: {
-          config: { models: {} } as never,
-          model: "text-embedding-v3",
-          remote: {
-            apiKey: "fixture-secret",
-            headers: {
-              [proxyHeaderName]: proxyApiKey,
-              "X-Deployment": tenant,
-              "X-Tenant": tenant,
-              version: "tenant-api-v2",
-              "User-Agent": "tenant-client/2",
+  it.each([
+    {
+      name: "proxy",
+      providerId: "bailian-embedding",
+      baseUrl: "https://embeddings.example/v1",
+      headerName: "X-Api-Key",
+      rotatedHeaderName: "x-aPI-kEY",
+    },
+    {
+      name: "Azure OpenAI",
+      providerId: "openai",
+      baseUrl: "https://qa-resource.openai.azure.com/openai/v1",
+      headerName: "api-key",
+      rotatedHeaderName: "Api-Key",
+    },
+  ])(
+    "keeps rotated $name credentials out of tenant-specific embedding cache identity",
+    async ({ providerId, baseUrl, headerName, rotatedHeaderName }) => {
+      const createForTenant = async (
+        tenant: string,
+        proxyApiKey: string,
+        proxyHeaderName = headerName,
+      ) => {
+        const client = await resolveRemoteEmbeddingBearerClient({
+          provider: providerId,
+          defaultBaseUrl: baseUrl,
+          options: {
+            config: { models: {} } as never,
+            model: "text-embedding-v3",
+            remote: {
+              baseUrl,
+              apiKey: "fixture-secret",
+              headers: {
+                [proxyHeaderName]: proxyApiKey,
+                "X-Deployment": tenant,
+                "X-Tenant": tenant,
+                version: "tenant-api-v2",
+                "User-Agent": "tenant-client/2",
+              },
             },
           },
-        },
-      });
-      expect(client.headers).toMatchObject({
-        Authorization: "Bearer fixture-secret",
-        [proxyHeaderName]: proxyApiKey,
-        "X-Deployment": tenant,
-      });
-      mocks.createOpenAiEmbeddingProvider.mockResolvedValueOnce({
-        provider,
-        client: { ...client, model: "text-embedding-v3" },
-      });
-      return await openAiMemoryEmbeddingProviderAdapter.create({
-        config: {} as never,
-        provider: "bailian-embedding",
-        model: "text-embedding-v3",
-        fallback: "none",
-      });
-    };
+        });
+        expect(client.headers).toMatchObject({
+          Authorization: "Bearer fixture-secret",
+          [proxyHeaderName]: proxyApiKey,
+          "X-Deployment": tenant,
+        });
+        mocks.createOpenAiEmbeddingProvider.mockResolvedValueOnce({
+          provider,
+          client: { ...client, model: "text-embedding-v3" },
+        });
+        return await openAiMemoryEmbeddingProviderAdapter.create({
+          config: {} as never,
+          provider: providerId,
+          model: "text-embedding-v3",
+          fallback: "none",
+        });
+      };
 
-    const first = await createForTenant("tenant-a", "proxy-key-before-rotation");
-    const rotated = await createForTenant("tenant-a", "proxy-key-after-rotation", "x-aPI-kEY");
-    const second = await createForTenant("tenant-b", "proxy-key-after-rotation");
-    const headers = first.runtime?.cacheKeyData?.headers;
+      const first = await createForTenant("tenant-a", "proxy-key-before-rotation");
+      const rotated = await createForTenant(
+        "tenant-a",
+        "proxy-key-after-rotation",
+        rotatedHeaderName,
+      );
+      const second = await createForTenant("tenant-b", "proxy-key-after-rotation");
+      const headers = first.runtime?.cacheKeyData?.headers;
 
-    expect(headers).toEqual(
-      expect.arrayContaining([
-        ["X-Deployment", "tenant-a"],
-        ["X-Tenant", "tenant-a"],
-        ["version", "tenant-api-v2"],
-        ["User-Agent", "tenant-client/2"],
-      ]),
-    );
-    expect(first.runtime?.cacheKeyData).toEqual(rotated.runtime?.cacheKeyData);
-    expect(hashText(JSON.stringify(first.runtime?.cacheKeyData))).toBe(
-      hashText(JSON.stringify(rotated.runtime?.cacheKeyData)),
-    );
-    expect(first.runtime?.cacheKeyData).not.toEqual(second.runtime?.cacheKeyData);
-    expect(JSON.stringify(first.runtime?.cacheKeyData)).not.toContain("fixture-secret");
-    expect(JSON.stringify(first.runtime?.cacheKeyData)).not.toContain("proxy-key-before-rotation");
-  });
+      expect(headers).toEqual(
+        expect.arrayContaining([
+          ["X-Deployment", "tenant-a"],
+          ["X-Tenant", "tenant-a"],
+          ["version", "tenant-api-v2"],
+          ["User-Agent", "tenant-client/2"],
+        ]),
+      );
+      expect(first.runtime?.cacheKeyData).toEqual(rotated.runtime?.cacheKeyData);
+      expect(hashText(JSON.stringify(first.runtime?.cacheKeyData))).toBe(
+        hashText(JSON.stringify(rotated.runtime?.cacheKeyData)),
+      );
+      expect(first.runtime?.cacheKeyData).not.toEqual(second.runtime?.cacheKeyData);
+      expect(JSON.stringify(first.runtime?.cacheKeyData)).not.toContain("fixture-secret");
+      expect(JSON.stringify(first.runtime?.cacheKeyData)).not.toContain(
+        "proxy-key-before-rotation",
+      );
+      expect(first.runtime?.cacheKeyData).toMatchObject({ provider: providerId, baseUrl });
+    },
+  );
 
   it("sends document input_type in OpenAI batch embedding requests", async () => {
     const result = await openAiMemoryEmbeddingProviderAdapter.create({

--- a/extensions/openai/memory-embedding-adapter.ts
+++ b/extensions/openai/memory-embedding-adapter.ts
@@ -12,7 +12,7 @@ import {
 } from "./embedding-provider.js";
 
 function resolveEmbeddingCacheExcludedHeaders(providerId: string, baseUrl: string): string[] {
-  const excludedHeaders = ["authorization", "x-api-key"];
+  const excludedHeaders = ["authorization", "x-api-key", "api-key"];
   if (providerId !== "openai") {
     return excludedHeaders;
   }


### PR DESCRIPTION
## What Problem This Solves

[Azure OpenAI's embeddings API](https://learn.microsoft.com/en-us/rest/api/microsoft-foundry/azureopenai/embeddings) officially authenticates with the `api-key` request header. The OpenAI embedding adapter still included that credential in memory-index identity, so rotating an Azure API key changed the index hash and paused semantic recall even though the deployment, model, and tenant remained unchanged.

The related `X-Api-Key` proxy credential was already handled in #129177; Azure uses the different, documented `api-key` spelling.

## Why This Change Was Made

Exclude Azure's `api-key` alongside `Authorization` and `X-Api-Key` in the owning OpenAI embedding adapter. Header matching remains case-insensitive, outbound authentication headers are unchanged, and deployment/tenant headers still distinguish separate indexes. Production lines are net-neutral.

The shared SDK sanitizer and unrelated provider adapters remain unchanged: its public contract intentionally excludes only headers named by each provider owner.

## User Impact

Future Azure API-key rotations preserve the existing memory index. Ordinary OpenAI and previously supported proxy configurations retain their exact prior index identity.

Existing configurations that explicitly supplied an `api-key` header have one intentional identity transition because their previous identity incorrectly included that credential. Rebuild once with `openclaw memory index --force --agent <id>`; subsequent Azure API-key rotations no longer invalidate the index.

## Evidence

- Regression captured red on current `main`: the existing proxy case passed, while the new Azure case failed because mixed-case `api-key` rotation changed index identity.
- After the owner-boundary fix, the parameterized regression passes for both proxy and Azure credentials, including preserved outbound credentials, unchanged native defaults, deployment and tenant separation, and case-insensitive rotation.
- Direct real-adapter execution with synthetic credentials confirmed Azure endpoint recognition, credential-free identity, stable key rotation, preserved deployment identity, and tenant isolation without network access.
- Safe owner/sibling coverage: 91 tests across six files and three Vitest shards:
  `env -u OPENAI_API_KEY OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-r3-azure-green OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --configLoader runner extensions/openai/memory-embedding-adapter.test.ts extensions/openai/embedding-provider.test.ts extensions/google/memory-embedding-adapter.test.ts extensions/lmstudio/src/embedding-provider.test.ts extensions/ollama/src/embedding-provider.test.ts packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.test.ts`
- Final post-format owner regression: six tests passed.
- Formatting, whitespace, and scoped plugin lint passed; fresh Codex autoreview reported no accepted or actionable findings.
- Production delta: +1/-1; tests: +84/-58 (existing test reindented by the formatter under parameterized coverage).
