### PR TITLE
fix(ollama): recognize mapped IPv6 loopback endpoints

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -2055,33 +2055,36 @@ describe("ollama plugin", () => {
     },
   );
 
-  it("treats custom 127/8 Ollama providers as loopback for implicit discovery", async () => {
-    const provider = registerProvider();
-    mockDiscoveredOllamaProvider([], { once: true });
+  it.each(["127.0.0.2", "[::ffff:127.0.0.2]", "[::ffff:7f00:2]"])(
+    "treats custom 127/8 Ollama provider %s as loopback for implicit discovery",
+    async (hostname) => {
+      const provider = registerProvider();
+      mockDiscoveredOllamaProvider([], { once: true });
 
-    const result = await provider.catalog.run({
-      config: {
-        models: {
-          providers: {
-            "ollama-alt-local": {
-              api: "ollama",
-              baseUrl: "http://127.0.0.2:11434",
-              models: [{ id: "llama3.2", name: "Llama 3.2" }],
+      const result = await provider.catalog.run({
+        config: {
+          models: {
+            providers: {
+              "ollama-alt-local": {
+                api: "ollama",
+                baseUrl: `http://${hostname}:11434`,
+                models: [{ id: "llama3.2", name: "Llama 3.2" }],
+              },
             },
           },
         },
-      },
-      env: { NODE_ENV: "development", OLLAMA_API_KEY: "ollama-live" },
-      resolveProviderApiKey: () => ({ apiKey: "ollama-live" }),
-    } as never);
+        env: { NODE_ENV: "development", OLLAMA_API_KEY: "ollama-live" },
+        resolveProviderApiKey: () => ({ apiKey: "ollama-live" }),
+      } as never);
 
-    const resultProvider = requireRecord(result?.provider, "catalog provider");
-    expect(resultProvider.baseUrl).toBe("http://127.0.0.1:11434");
-    expect(resultProvider.api).toBe("ollama");
-    expect(buildOllamaProviderMock).toHaveBeenCalledWith(undefined, {
-      quiet: false,
-    });
-  });
+      const resultProvider = requireRecord(result?.provider, "catalog provider");
+      expect(resultProvider.baseUrl).toBe("http://127.0.0.1:11434");
+      expect(resultProvider.api).toBe("ollama");
+      expect(buildOllamaProviderMock).toHaveBeenCalledWith(undefined, {
+        quiet: false,
+      });
+    },
+  );
 
   it.each([
     {

--- a/extensions/ollama/src/discovery-shared.test.ts
+++ b/extensions/ollama/src/discovery-shared.test.ts
@@ -16,6 +16,9 @@ describe("isLocalOllamaBaseUrl", () => {
     "http://127.0.0.1:11434",
     "http://127.0.0.2:11434",
     "http://127.1.2.3:11434",
+    "http://[::ffff:127.0.0.1]:11434",
+    "http://[::ffff:127.0.0.2]:11434",
+    "http://[::ffff:7f00:2]:11434",
     "http://0.0.0.0:11434",
     "http://[::1]:11434",
     "http://10.0.0.5:11434",
@@ -42,6 +45,8 @@ describe("isLocalOllamaBaseUrl", () => {
     "http://172.32.0.1:11434",
     "http://193.168.1.1:11434",
     "http://[2001:4860:4860::8888]:11434",
+    "http://[::ffff:10.0.0.5]:11434",
+    "http://[::ffff:8.8.8.8]:11434",
     "http://10.example.com:11434",
     "not a url",
   ])("classifies %s as remote", (baseUrl) => {
@@ -334,28 +339,34 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
     expect(result?.provider.models).toEqual([cloudModel]);
   });
 
-  it.each(["localhost", "127.0.0.1", "127.0.0.2", "127.1.2.3", "10.0.0.5"])(
-    "keeps ambient cloud credentials away from the local endpoint %s",
-    async (hostname) => {
-      const provider = {
-        baseUrl: `http://${hostname}:11434`,
-        api: "ollama" as const,
-        models: [cloudModel],
-      };
-      const result = await resolveOllamaDiscoveryResult({
-        ctx: {
-          config: { models: { providers: { ollama: provider } } },
-          env: { OLLAMA_API_KEY: "ambient-cloud-credential" },
-          resolveProviderApiKey: () => ({}),
-        },
-        pluginConfig: {},
-        buildProvider: buildMockProvider,
-      });
+  it.each([
+    "localhost",
+    "127.0.0.1",
+    "127.0.0.2",
+    "127.1.2.3",
+    "[::ffff:127.0.0.1]",
+    "[::ffff:127.0.0.2]",
+    "[::ffff:7f00:2]",
+    "10.0.0.5",
+  ])("keeps ambient cloud credentials away from the local endpoint %s", async (hostname) => {
+    const provider = {
+      baseUrl: `http://${hostname}:11434`,
+      api: "ollama" as const,
+      models: [cloudModel],
+    };
+    const result = await resolveOllamaDiscoveryResult({
+      ctx: {
+        config: { models: { providers: { ollama: provider } } },
+        env: { OLLAMA_API_KEY: "ambient-cloud-credential" },
+        resolveProviderApiKey: () => ({}),
+      },
+      pluginConfig: {},
+      buildProvider: buildMockProvider,
+    });
 
-      expect(result?.provider.apiKey).toBe("ollama-local");
-      expect(shouldUseSyntheticOllamaAuth(provider)).toBe(true);
-    },
-  );
+    expect(result?.provider.apiKey).toBe("ollama-local");
+    expect(shouldUseSyntheticOllamaAuth(provider)).toBe(true);
+  });
 
   it("does not call buildProvider for remote base URL without explicit models", async () => {
     let providerCalled = false;

--- a/extensions/ollama/src/discovery-shared.ts
+++ b/extensions/ollama/src/discovery-shared.ts
@@ -5,6 +5,7 @@ import type {
   ModelDefinitionConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { coerceSecretRef } from "openclaw/plugin-sdk/secret-input-runtime";
+import { isLoopbackHost } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { OLLAMA_DEFAULT_API_KEY, OLLAMA_DEFAULT_BASE_URL } from "./defaults.js";
 import { readProviderBaseUrl } from "./provider-base-url.js";
@@ -113,17 +114,6 @@ const LOCAL_OLLAMA_HOSTNAMES = new Set([
 ]);
 const LOOPBACK_OLLAMA_HOSTNAMES = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "::"]);
 
-function isIpv4Loopback(host: string): boolean {
-  if (!/^\d+\.\d+\.\d+\.\d+$/.test(host)) {
-    return false;
-  }
-  const octets = host.split(".").map((part) => Number.parseInt(part, 10));
-  if (octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
-    return false;
-  }
-  return octets[0] === 127;
-}
-
 function isIpv4PrivateRange(host: string): boolean {
   if (!/^\d+\.\d+\.\d+\.\d+$/.test(host)) {
     return false;
@@ -160,7 +150,7 @@ export function isLocalOllamaBaseUrl(baseUrl: string | undefined | null): boolea
   }
   return (
     LOCAL_OLLAMA_HOSTNAMES.has(host) ||
-    isIpv4Loopback(host) ||
+    isLoopbackHost(host) ||
     host.endsWith(".local") ||
     isIpv4PrivateRange(host) ||
     isIpv6LocalRange(host) ||
@@ -198,7 +188,7 @@ function isLoopbackOllamaBaseUrl(baseUrl: string | undefined | null): boolean {
   if (host.startsWith("[") && host.endsWith("]")) {
     host = host.slice(1, -1);
   }
-  return LOOPBACK_OLLAMA_HOSTNAMES.has(host) || isIpv4Loopback(host);
+  return LOOPBACK_OLLAMA_HOSTNAMES.has(host) || isLoopbackHost(host);
 }
 
 function hasExplicitRemoteOllamaApiProvider(


### PR DESCRIPTION
## Summary

- Treat IPv4-mapped IPv6 loopback endpoints as local during Ollama discovery and synthetic-auth selection.
- Reuse the plugin SDK's canonical loopback classifier in both Ollama discovery decisions and remove the duplicate IPv4-only parser.
- Preserve the existing classifications for non-loopback private/public mapped addresses, bind-all aliases, direct private networks, and remote providers.

The WHATWG URL parser normalizes `[::ffff:127.0.0.1]` into `[::ffff:7f00:1]`. Ollama's duplicate IPv4 parser missed that form, classified the same loopback server as remote, forwarded an ambient Ollama cloud credential to its discovery request, and incorrectly suppressed implicit discovery for mapped-loopback custom providers. The canonical plugin-SDK loopback helper already handles these representations and is already used by the same plugin's streaming path.

Production code is net **-10 lines**; this does not expand the set of trusted private-network endpoints.

## Validation

- Added regression cases first: **8 failures, 181 passes** on unchanged production code across the Ollama owner and plugin catalog tests.
- Focused Ollama discovery, catalog, streaming, web-search, embedding, and provider-discovery suites: **494 tests passed across seven files**.
- Real ephemeral localhost HTTP proof with a synthetic credential: before the fix, ordinary `127.0.0.1` omitted `Authorization` while the same listener reached through IPv4-mapped loopback received it; after the fix, ordinary, mapped dotted, and mapped canonical-hex requests all omitted `Authorization`.
- IPv4-mapped public and non-loopback private addresses remain classified as remote.
- Changed-file formatting and targeted extension lint pass; independent structured autoreview is clean.
