### PR TITLE
fix(doctor): preserve managed container services

### DIFF
--- a/scripts/e2e/lib/doctor-install-switch/scenario.sh
+++ b/scripts/e2e/lib/doctor-install-switch/scenario.sh
@@ -9,12 +9,13 @@ export npm_config_fund=false
 export npm_config_audit=false
 export OPENCLAW_DISABLE_BUNDLED_PLUGINS=1
 
-# Stub systemd/loginctl so doctor + daemon flows work in Docker.
+# Stub the systemd manager and loginctl so doctor + daemon flows work in Docker.
 export PATH="/tmp/openclaw-bin:$PATH"
 mkdir -p /tmp/openclaw-bin
 cp scripts/e2e/lib/doctor-install-switch/shims/systemctl /tmp/openclaw-bin/systemctl
 cp scripts/e2e/lib/doctor-install-switch/shims/loginctl /tmp/openclaw-bin/loginctl
-chmod +x /tmp/openclaw-bin/systemctl /tmp/openclaw-bin/loginctl
+cp scripts/e2e/lib/doctor-install-switch/shims/busctl /tmp/openclaw-bin/busctl
+chmod +x /tmp/openclaw-bin/systemctl /tmp/openclaw-bin/loginctl /tmp/openclaw-bin/busctl
 
 package_tgz="${OPENCLAW_CURRENT_PACKAGE_TGZ:?missing OPENCLAW_CURRENT_PACKAGE_TGZ}"
 git_root="/tmp/openclaw-git"
@@ -101,6 +102,9 @@ assert_entrypoint() {
   entrypoint="${entrypoint#\"}"
   if [ "$entrypoint" != "$expected" ]; then
     echo "Expected entrypoint $expected, got $entrypoint"
+    if [ -n "${doctor_log:-}" ] && [ -f "$doctor_log" ]; then
+      grep -E "Gateway service entrypoint|operator-owned systemd drop-in|managed externally" "$doctor_log" || true
+    fi
     exit 1
   fi
 }

--- a/scripts/e2e/lib/doctor-install-switch/shims/busctl
+++ b/scripts/e2e/lib/doctor-install-switch/shims/busctl
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const manager = "org.freedesktop.systemd1";
+const rootObjectPath = "/org/freedesktop/systemd1";
+const args = process.argv.slice(2);
+
+function fail() {
+  process.stderr.write("doctor-switch busctl shim: unexpected invocation or unavailable unit\n");
+  process.exit(1);
+}
+
+function splitWords(value) {
+  const words = [];
+  let word = "";
+  let quote = "";
+  let escaped = false;
+  for (const character of value) {
+    if (escaped) {
+      word += character;
+      escaped = false;
+    } else if (character === "\\" && quote !== "'") {
+      escaped = true;
+    } else if (quote) {
+      if (character === quote) {
+        quote = "";
+      } else {
+        word += character;
+      }
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (/\s/u.test(character)) {
+      if (word) {
+        words.push(word);
+        word = "";
+      }
+    } else {
+      word += character;
+    }
+  }
+  if (quote || escaped) {
+    fail();
+  }
+  if (word) {
+    words.push(word);
+  }
+  return words;
+}
+
+function encodeUnitName(name) {
+  return Array.from(Buffer.from(name), (byte) =>
+    (byte >= 48 && byte <= 57) || (byte >= 65 && byte <= 90) || (byte >= 97 && byte <= 122)
+      ? String.fromCharCode(byte)
+      : `_${byte.toString(16).padStart(2, "0")}`,
+  ).join("");
+}
+
+function writeProperties(properties) {
+  process.stdout.write(properties.map((property) => JSON.stringify(property)).join("\n") + "\n");
+}
+
+if (args[0] !== "--user" || args[1] !== "--json=short") {
+  fail();
+}
+
+const invocation = args.slice(2);
+if (invocation[0] === "call") {
+  const [command, destination, objectPath, interfaceName, method, signature, unitName] = invocation;
+  if (
+    invocation.length !== 7 ||
+    command !== "call" ||
+    destination !== manager ||
+    objectPath !== rootObjectPath ||
+    interfaceName !== `${manager}.Manager` ||
+    method !== "LoadUnit" ||
+    signature !== "s" ||
+    !unitName.endsWith(".service") ||
+    path.basename(unitName) !== unitName ||
+    !fs.existsSync(path.join(process.env.HOME, ".config/systemd/user", unitName))
+  ) {
+    fail();
+  }
+  writeProperties([{ type: "o", data: [`${rootObjectPath}/unit/${encodeUnitName(unitName)}`] }]);
+  process.exit(0);
+}
+
+if (invocation[0] !== "get-property" || invocation[1] !== manager) {
+  fail();
+}
+
+const unitName = `${process.env.OPENCLAW_SYSTEMD_UNIT || "openclaw-gateway"}`.replace(
+  /(?:\.service)?$/u,
+  ".service",
+);
+const unitPath = path.join(process.env.HOME, ".config/systemd/user", unitName);
+if (invocation[2] !== `${rootObjectPath}/unit/${encodeUnitName(unitName)}`) {
+  fail();
+}
+
+if (invocation[3] === `${manager}.Unit`) {
+  if (
+    invocation.length !== 7 ||
+    invocation.slice(4).join(" ") !== "FragmentPath DropInPaths NeedDaemonReload"
+  ) {
+    fail();
+  }
+  writeProperties([
+    { type: "s", data: unitPath },
+    { type: "as", data: [] },
+    { type: "b", data: false },
+  ]);
+  process.exit(0);
+}
+
+if (
+  invocation[3] !== `${manager}.Service` ||
+  invocation.length !== 9 ||
+  invocation.slice(4).join(" ") !==
+    "ExecStart WorkingDirectory Environment EnvironmentFiles UnsetEnvironment"
+) {
+  fail();
+}
+
+let programArguments = [];
+let workingDirectory = "";
+const environment = new Map();
+const environmentFiles = [];
+const unsetEnvironment = [];
+const expandHome = (value) =>
+  value.replace(/%%|%h/gu, (match) => (match === "%h" ? process.env.HOME : "%"));
+
+let content;
+try {
+  content = fs.readFileSync(unitPath, "utf8");
+} catch {
+  fail();
+}
+
+for (const rawLine of content.split(/\r?\n/u)) {
+  const line = rawLine.trim();
+  const separator = line.indexOf("=");
+  if (separator < 0 || line.startsWith("#") || line.startsWith(";")) {
+    continue;
+  }
+  const directive = line.slice(0, separator);
+  const value = line.slice(separator + 1).trim();
+  if (directive === "ExecStart") {
+    programArguments = splitWords(value).map(expandHome);
+  } else if (directive === "WorkingDirectory") {
+    workingDirectory = expandHome(splitWords(value)[0] || "").replace(/^-/, "");
+  } else if (directive === "Environment") {
+    if (!value) {
+      environment.clear();
+    }
+    for (const assignment of splitWords(value)) {
+      const assignmentSeparator = assignment.indexOf("=");
+      if (assignmentSeparator <= 0) {
+        fail();
+      }
+      environment.set(
+        assignment.slice(0, assignmentSeparator),
+        expandHome(assignment.slice(assignmentSeparator + 1)),
+      );
+    }
+  } else if (directive === "EnvironmentFile") {
+    if (!value) {
+      environmentFiles.length = 0;
+    }
+    for (const filename of splitWords(value)) {
+      const optional = filename.startsWith("-");
+      environmentFiles.push([expandHome(optional ? filename.slice(1) : filename), optional]);
+    }
+  } else if (directive === "UnsetEnvironment") {
+    if (!value) {
+      unsetEnvironment.length = 0;
+    } else {
+      unsetEnvironment.push(...splitWords(value));
+    }
+  }
+}
+
+if (!programArguments.length) {
+  fail();
+}
+
+writeProperties([
+  {
+    type: "a(sasbttttuii)",
+    data: [[programArguments[0], programArguments, false, 0, 0, 0, 0, 0, 0, 0]],
+  },
+  { type: "s", data: workingDirectory },
+  { type: "as", data: Array.from(environment, ([key, value]) => `${key}=${value}`) },
+  { type: "a(sb)", data: environmentFiles },
+  { type: "as", data: unsetEnvironment },
+]);

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -12,7 +12,6 @@ import {
 } from "./doctor-service-repair-policy.js";
 
 const service = vi.hoisted(() => ({
-  hasInstalledDefinition: vi.fn(),
   isLoaded: vi.fn(),
   readRuntime: vi.fn(),
   restart: vi.fn(),
@@ -40,6 +39,11 @@ const formatGatewayRuntimeSummary = vi.hoisted(() => vi.fn((): string | null => 
 const renderSystemdUnavailableHints = vi.hoisted(() => vi.fn((): string[] => []));
 const isDefaultInstallIdentity = vi.hoisted(() => vi.fn(() => true));
 const isContainerEnvironment = vi.hoisted(() => vi.fn(() => false));
+const findInstalledSystemdGatewayScope = vi.hoisted(() =>
+  vi.fn<(typeof import("../daemon/systemd.js"))["findInstalledSystemdGatewayScope"]>(
+    async () => null,
+  ),
+);
 const resolveGatewayBindHost = vi.hoisted(() => vi.fn(async () => "127.0.0.1"));
 
 vi.mock("../config/config.js", async () => {
@@ -87,6 +91,11 @@ vi.mock("../daemon/service.js", async () => {
     resolveGatewayService: () => service,
   };
 });
+
+vi.mock("../daemon/systemd.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../daemon/systemd.js")>()),
+  findInstalledSystemdGatewayScope,
+}));
 
 vi.mock("../daemon/systemd-hints.js", () => ({
   renderSystemdUnavailableHints,
@@ -172,7 +181,7 @@ describe("maybeRepairGatewayDaemon", () => {
     vi.clearAllMocks();
     formatGatewayClosedDiagnostic.mockReset();
     formatGatewayClosedDiagnostic.mockReturnValue(undefined);
-    service.hasInstalledDefinition.mockResolvedValue(false);
+    findInstalledSystemdGatewayScope.mockReset().mockResolvedValue(null);
     service.isLoaded.mockResolvedValue(true);
     service.readRuntime.mockResolvedValue({ status: "running" });
     service.readCommand.mockResolvedValue(null);
@@ -370,7 +379,7 @@ describe("maybeRepairGatewayDaemon", () => {
       expect(inspectPortUsage).toHaveBeenCalledOnce();
       expect(note).toHaveBeenCalledWith("Port 18789 is already in use.", "Gateway port");
       expect(note).toHaveBeenCalledWith(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
-      expect(service.hasInstalledDefinition).toHaveBeenCalledTimes(scenario.detected ? 1 : 0);
+      expect(findInstalledSystemdGatewayScope).toHaveBeenCalledTimes(scenario.detected ? 1 : 0);
       expect(service.isLoaded).not.toHaveBeenCalled();
       expect(service.readRuntime).not.toHaveBeenCalled();
       expect(service.readCommand).not.toHaveBeenCalled();
@@ -383,7 +392,11 @@ describe("maybeRepairGatewayDaemon", () => {
   it("inspects an installed OpenClaw service through a reachable Docker systemd manager", async () => {
     setPlatform("linux");
     isContainerEnvironment.mockReturnValue(true);
-    service.hasInstalledDefinition.mockResolvedValue(true);
+    findInstalledSystemdGatewayScope.mockResolvedValue({
+      scope: "user",
+      unitName: "openclaw-gateway.service",
+      unitPath: "/home/alice/.config/systemd/user/openclaw-gateway.service",
+    });
 
     await runNonInteractiveRepair();
 

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./doctor-service-repair-policy.js";
 
 const service = vi.hoisted(() => ({
+  hasInstalledDefinition: vi.fn(),
   isLoaded: vi.fn(),
   readRuntime: vi.fn(),
   restart: vi.fn(),
@@ -171,6 +172,7 @@ describe("maybeRepairGatewayDaemon", () => {
     vi.clearAllMocks();
     formatGatewayClosedDiagnostic.mockReset();
     formatGatewayClosedDiagnostic.mockReturnValue(undefined);
+    service.hasInstalledDefinition.mockResolvedValue(false);
     service.isLoaded.mockResolvedValue(true);
     service.readRuntime.mockResolvedValue({ status: "running" });
     service.readCommand.mockResolvedValue(null);
@@ -341,13 +343,14 @@ describe("maybeRepairGatewayDaemon", () => {
   });
 
   it.each([
-    { environment: "detected container", detected: true, kubernetes: false },
-    { environment: "Kubernetes pod without container markers", detected: false, kubernetes: true },
+    { environment: "container without an OpenClaw service", detected: true },
+    { environment: "Kubernetes pod without container markers", kubernetes: true },
+    { environment: "globally external supervisor", external: true },
   ])(
     "keeps port diagnostics but never probes host services in a $environment",
     async (scenario) => {
       setPlatform("linux");
-      isContainerEnvironment.mockReturnValue(scenario.detected);
+      isContainerEnvironment.mockReturnValue(scenario.detected === true);
       inspectPortUsage.mockResolvedValueOnce({
         port: 18789,
         status: "busy",
@@ -359,16 +362,15 @@ describe("maybeRepairGatewayDaemon", () => {
         {
           KUBERNETES_SERVICE_HOST: scenario.kubernetes ? "10.96.0.1" : undefined,
           KUBERNETES_SERVICE_PORT: scenario.kubernetes ? "443" : undefined,
+          OPENCLAW_SUPERVISOR_MODE: scenario.external ? "external" : undefined,
         },
         runNonInteractiveRepair,
       );
 
       expect(inspectPortUsage).toHaveBeenCalledOnce();
       expect(note).toHaveBeenCalledWith("Port 18789 is already in use.", "Gateway port");
-      expect(note).toHaveBeenCalledWith(
-        "Container lifecycle is externally managed; skipping host service installation.",
-        "Gateway",
-      );
+      expect(note).toHaveBeenCalledWith(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
+      expect(service.hasInstalledDefinition).toHaveBeenCalledTimes(scenario.detected ? 1 : 0);
       expect(service.isLoaded).not.toHaveBeenCalled();
       expect(service.readRuntime).not.toHaveBeenCalled();
       expect(service.readCommand).not.toHaveBeenCalled();
@@ -377,6 +379,18 @@ describe("maybeRepairGatewayDaemon", () => {
       expect(findSystemGatewayServices).not.toHaveBeenCalled();
     },
   );
+
+  it("inspects an installed OpenClaw service through a reachable Docker systemd manager", async () => {
+    setPlatform("linux");
+    isContainerEnvironment.mockReturnValue(true);
+    service.hasInstalledDefinition.mockResolvedValue(true);
+
+    await runNonInteractiveRepair();
+
+    expect(service.isLoaded).toHaveBeenCalledWith({ env: process.env, timeoutMs: 5_000 });
+    expect(service.readRuntime).toHaveBeenCalledOnce();
+    expect(note).not.toHaveBeenCalledWith(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
+  });
 
   it("reports recent restart handoffs during deep doctor", async () => {
     vi.useFakeTimers();

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -25,10 +25,7 @@ import {
 import { renderSystemdUnavailableHints } from "../daemon/systemd-hints.js";
 import { classifySystemdUnavailableDetail } from "../daemon/systemd-unavailable.js";
 import { resolveGatewayBindHost, resolveGatewayRequiredListenHosts } from "../gateway/net.js";
-import {
-  isGatewayHostServiceEnvironment,
-  NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON,
-} from "../infra/gateway-supervision.js";
+import { NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON } from "../infra/gateway-supervision.js";
 import { formatPortDiagnostics, isExpectedGatewayListeners } from "../infra/ports-format.js";
 import { inspectPortConnections, inspectPortUsage } from "../infra/ports-inspect.js";
 import type { PortConnection } from "../infra/ports-types.js";
@@ -53,6 +50,7 @@ import {
   isServiceRepairExternallyManaged,
   resolveServiceRepairPolicy,
   SERVICE_REPAIR_POLICY_ENV,
+  shouldManageGatewayService,
 } from "./doctor-service-repair-policy.js";
 import { resolveGatewayInstallToken } from "./gateway-install-token.js";
 import { formatGatewayClosedDiagnostic, formatHealthCheckFailure } from "./health-format.js";
@@ -234,14 +232,11 @@ export async function maybeRepairGatewayDaemon(params: {
     return;
   }
 
-  if (!isGatewayHostServiceEnvironment()) {
+  if (!(await shouldManageGatewayService())) {
     if (params.cfg.gateway?.mode !== "remote") {
       await noteGatewayPortDiagnostics(params.cfg, params.options.deep ?? false);
     }
-    note(
-      "Container lifecycle is externally managed; skipping host service installation.",
-      "Gateway",
-    );
+    note(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
     return;
   }
 

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -1729,30 +1729,35 @@ describe("maybeRepairGatewayServiceConfig", () => {
     );
   });
 
-  it("reports service config drift but skips service rewrite when service repair policy is external", async () => {
-    await withEnvAsync({ OPENCLAW_SERVICE_REPAIR_POLICY: "external" }, async () => {
-      setupGatewayEntrypointRepairScenario({
-        currentEntrypoint: "/Users/test/Library/npm/node_modules/openclaw/dist/entry.js",
-        installEntrypoint: "/Users/test/Library/npm/node_modules/openclaw/dist/index.js",
-        installWorkingDirectory: "/tmp",
+  it.each(["OPENCLAW_SERVICE_REPAIR_POLICY", "OPENCLAW_SUPERVISOR_MODE"])(
+    "reports service config drift but skips repair when %s is external",
+    async (envKey) => {
+      await withEnvAsync({ [envKey]: "external" }, async () => {
+        setupGatewayEntrypointRepairScenario({
+          currentEntrypoint: "/Users/test/Library/npm/node_modules/openclaw/dist/entry.js",
+          installEntrypoint: "/Users/test/Library/npm/node_modules/openclaw/dist/index.js",
+          installWorkingDirectory: "/tmp",
+        });
+        const prompter = makeDoctorPrompts();
+
+        await maybeRepairGatewayServiceConfig({ gateway: {} }, "local", makeDoctorIo(), prompter);
+
+        expect(mocks.auditGatewayServiceConfig).toHaveBeenCalledOnce();
+        expectNoteContaining(
+          "Gateway service entrypoint does not match the current install.",
+          "Gateway service config",
+        );
+        expect(mocks.note).toHaveBeenCalledWith(
+          EXTERNAL_SERVICE_REPAIR_NOTE,
+          "Gateway service config",
+        );
+        expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
+        expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+        expect(mocks.stage).not.toHaveBeenCalled();
+        expect(mocks.install).not.toHaveBeenCalled();
       });
-
-      await runRepair({ gateway: {} });
-
-      expect(mocks.auditGatewayServiceConfig).toHaveBeenCalledTimes(1);
-      expectNoteContaining(
-        "Gateway service entrypoint does not match the current install.",
-        "Gateway service config",
-      );
-      expect(mocks.note).toHaveBeenCalledWith(
-        EXTERNAL_SERVICE_REPAIR_NOTE,
-        "Gateway service config",
-      );
-      expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
-      expect(mocks.stage).not.toHaveBeenCalled();
-      expect(mocks.install).not.toHaveBeenCalled();
-    });
-  });
+    },
+  );
 
   it("warns when the gateway service entrypoint resolves to a source checkout", async () => {
     await withEnvAsync({}, async () => {
@@ -1985,7 +1990,7 @@ describe("maybeScanExtraGatewayServices", () => {
     expect(mocks.findExtraGatewayServices).toHaveBeenCalledWith(process.env, { deep: true });
   });
 
-  it("skips structured host-service discovery in externally managed containers", async () => {
+  it("skips structured host-service discovery in containers without an OpenClaw service", async () => {
     mocks.isContainerEnvironment.mockReturnValue(true);
 
     await expect(detectExtraGatewayServiceIssues({ deep: true })).resolves.toEqual([]);
@@ -2385,22 +2390,26 @@ describe("maybeResolveDuelingSystemdGatewayScopes", () => {
     expect(mocks.renderGatewayServiceCleanupHints).toHaveBeenCalled();
   });
 
-  it("skips removal and prompts nothing when service repair is externally managed", async () => {
-    mockProcessPlatform("linux");
-    process.env.OPENCLAW_SERVICE_REPAIR_POLICY = "external";
-    mocks.findSystemdGatewayInstallation.mockResolvedValue(duelingInstallation);
-    mocks.isSystemUnitActiveAndEnabled.mockResolvedValue(true);
-    const prompter = makeDoctorPrompts();
+  it.each(["OPENCLAW_SERVICE_REPAIR_POLICY", "OPENCLAW_SUPERVISOR_MODE"])(
+    "skips removal and repair confirmation when %s is external",
+    async (envKey) => {
+      mockProcessPlatform("linux");
+      mocks.findSystemdGatewayInstallation.mockResolvedValue(duelingInstallation);
+      mocks.isSystemUnitActiveAndEnabled.mockResolvedValue(true);
+      const prompter = makeDoctorPrompts();
 
-    await maybeResolveDuelingSystemdGatewayScopes(makeDoctorIo(), prompter);
+      await withEnvAsync({ [envKey]: "external" }, async () => {
+        await maybeResolveDuelingSystemdGatewayScopes(makeDoctorIo(), prompter);
+      });
 
-    expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
-    expect(mocks.uninstallUserSystemdGatewayUnit).not.toHaveBeenCalled();
-    expect(mocks.note).toHaveBeenCalledWith(
-      EXTERNAL_SERVICE_REPAIR_NOTE,
-      "Gateway cleanup skipped",
-    );
-  });
+      expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
+      expect(mocks.uninstallUserSystemdGatewayUnit).not.toHaveBeenCalled();
+      expect(mocks.note).toHaveBeenCalledWith(
+        EXTERNAL_SERVICE_REPAIR_NOTE,
+        "Gateway cleanup skipped",
+      );
+    },
+  );
 
   it("keeps the user unit when the system unit is enabled but not running", async () => {
     mockProcessPlatform("linux");

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -50,10 +50,7 @@ import {
 } from "../daemon/systemd.js";
 import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
 import { isTruthyEnvValue } from "../infra/env.js";
-import {
-  isGatewayHostServiceEnvironment,
-  NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON,
-} from "../infra/gateway-supervision.js";
+import { NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON } from "../infra/gateway-supervision.js";
 import { readWindowsProcessArgsSync } from "../infra/windows-port-pids.js";
 import { runExec } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -67,6 +64,7 @@ import {
   EXTERNAL_SERVICE_REPAIR_NOTE,
   isServiceRepairExternallyManaged,
   resolveServiceRepairPolicy,
+  shouldManageGatewayService,
 } from "./doctor-service-repair-policy.js";
 import {
   UPDATE_IN_PROGRESS_ENV,
@@ -369,7 +367,7 @@ async function filterInactiveExtraGatewayServices(
 export async function detectExtraGatewayServiceIssues(
   options: Pick<DoctorOptions, "deep"> = {},
 ): Promise<readonly ExtraGatewayService[]> {
-  if (!isDefaultInstallIdentity(process.env) || !isGatewayHostServiceEnvironment()) {
+  if (!isDefaultInstallIdentity(process.env) || !(await shouldManageGatewayService())) {
     return [];
   }
   const detectedExtraServices = await findExtraGatewayServices(process.env, {

--- a/src/commands/doctor-service-repair-policy.test.ts
+++ b/src/commands/doctor-service-repair-policy.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
+import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
+import { createDoctorPrompter } from "./doctor-prompter.js";
+import {
+  confirmDoctorServiceRepair,
+  shouldManageGatewayService,
+} from "./doctor-service-repair-policy.js";
+
+const mocks = vi.hoisted(() => ({
+  hasInstalledDefinition: vi.fn(async () => true),
+  isContainerEnvironment: vi.fn(() => false),
+  isLoaded: vi.fn(async () => false),
+  resolveGatewayService: vi.fn(),
+}));
+
+vi.mock("../infra/container-environment.js", () => ({
+  isContainerEnvironment: mocks.isContainerEnvironment,
+}));
+
+vi.mock("../daemon/service.js", () => ({
+  resolveGatewayService: mocks.resolveGatewayService,
+}));
+
+describe("doctor gateway service repair policy", () => {
+  beforeEach(() => {
+    mocks.hasInstalledDefinition.mockReset().mockResolvedValue(true);
+    mocks.isContainerEnvironment.mockReset().mockReturnValue(false);
+    mocks.isLoaded.mockReset().mockResolvedValue(false);
+    mocks.resolveGatewayService.mockReset().mockReturnValue({
+      hasInstalledDefinition: mocks.hasInstalledDefinition,
+      isLoaded: mocks.isLoaded,
+    });
+    mockProcessPlatform("linux");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    { name: "native host", env: {}, expected: true, probes: "none" },
+    {
+      name: "Doctor-only external repair policy on a native host",
+      env: { OPENCLAW_SERVICE_REPAIR_POLICY: "external" },
+      expected: true,
+      probes: "none",
+    },
+    {
+      name: "globally external supervision",
+      env: { OPENCLAW_SUPERVISOR_MODE: "external" },
+      container: true,
+      expected: false,
+      probes: "none",
+    },
+    {
+      name: "Kubernetes orchestration",
+      env: { KUBERNETES_SERVICE_HOST: "10.96.0.1", KUBERNETES_SERVICE_PORT: "443" },
+      container: true,
+      expected: false,
+      probes: "none",
+    },
+    {
+      name: "Docker without an installed OpenClaw service",
+      env: {},
+      container: true,
+      installed: false,
+      expected: false,
+      probes: "definition",
+    },
+    {
+      name: "Docker without installed-definition capability",
+      env: {},
+      container: true,
+      missingCapability: true,
+      expected: false,
+      probes: "missing-capability",
+    },
+    {
+      name: "Docker with an installed but unloaded service and reachable manager",
+      env: {},
+      container: true,
+      expected: true,
+      probes: "manager",
+    },
+    {
+      name: "Docker with an installed service and unavailable manager",
+      env: {},
+      container: true,
+      unavailableManager: true,
+      expected: false,
+      probes: "manager",
+    },
+    {
+      name: "Docker with a failed installed-definition probe",
+      env: {},
+      container: true,
+      failedDefinition: true,
+      expected: false,
+      probes: "definition",
+    },
+    {
+      name: "non-Linux container",
+      env: {},
+      container: true,
+      platform: "darwin" as const,
+      expected: false,
+      probes: "none",
+    },
+  ])("applies native service ownership in $name", async (scenario) => {
+    mocks.isContainerEnvironment.mockReturnValue(scenario.container === true);
+    if (scenario.platform) {
+      mockProcessPlatform(scenario.platform);
+    }
+    if (scenario.installed === false) {
+      mocks.hasInstalledDefinition.mockResolvedValue(false);
+    }
+    if (scenario.failedDefinition) {
+      mocks.hasInstalledDefinition.mockRejectedValue(new Error("service discovery failed"));
+    }
+    if (scenario.missingCapability) {
+      mocks.resolveGatewayService.mockReturnValue({ isLoaded: mocks.isLoaded });
+    }
+    if (scenario.unavailableManager) {
+      mocks.isLoaded.mockRejectedValue(new Error("systemd user manager unavailable"));
+    }
+
+    await expect(shouldManageGatewayService(scenario.env)).resolves.toBe(scenario.expected);
+
+    if (scenario.probes === "none") {
+      expect(mocks.resolveGatewayService).not.toHaveBeenCalled();
+      expect(mocks.hasInstalledDefinition).not.toHaveBeenCalled();
+    } else if (scenario.probes !== "missing-capability") {
+      expect(mocks.hasInstalledDefinition).toHaveBeenCalledWith({
+        env: scenario.env,
+        timeoutMs: 5_000,
+      });
+    }
+    if (scenario.probes === "manager") {
+      expect(mocks.isLoaded).toHaveBeenCalledWith({ env: scenario.env, timeoutMs: 5_000 });
+    } else {
+      expect(mocks.isLoaded).not.toHaveBeenCalled();
+    }
+  });
+
+  it.each(["OPENCLAW_SERVICE_REPAIR_POLICY", "OPENCLAW_SUPERVISOR_MODE"])(
+    "never confirms a Doctor repair when %s is external",
+    async (envKey) => {
+      const prompter = createDoctorPrompter({
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        options: { repair: true },
+      });
+      const confirm = vi.spyOn(prompter, "confirmRuntimeRepair");
+
+      await withEnvAsync({ [envKey]: "external" }, async () => {
+        await expect(
+          confirmDoctorServiceRepair(prompter, { message: "Repair gateway service?" }),
+        ).resolves.toBe(false);
+      });
+
+      expect(confirm).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/commands/doctor-service-repair-policy.test.ts
+++ b/src/commands/doctor-service-repair-policy.test.ts
@@ -8,7 +8,13 @@ import {
 } from "./doctor-service-repair-policy.js";
 
 const mocks = vi.hoisted(() => ({
-  hasInstalledDefinition: vi.fn(async () => true),
+  findInstalledSystemdGatewayScope: vi.fn<
+    (typeof import("../daemon/systemd.js"))["findInstalledSystemdGatewayScope"]
+  >(async () => ({
+    scope: "user",
+    unitName: "openclaw-gateway.service",
+    unitPath: "/home/alice/.config/systemd/user/openclaw-gateway.service",
+  })),
   isContainerEnvironment: vi.fn(() => false),
   isLoaded: vi.fn(async () => false),
   resolveGatewayService: vi.fn(),
@@ -22,13 +28,20 @@ vi.mock("../daemon/service.js", () => ({
   resolveGatewayService: mocks.resolveGatewayService,
 }));
 
+vi.mock("../daemon/systemd.js", () => ({
+  findInstalledSystemdGatewayScope: mocks.findInstalledSystemdGatewayScope,
+}));
+
 describe("doctor gateway service repair policy", () => {
   beforeEach(() => {
-    mocks.hasInstalledDefinition.mockReset().mockResolvedValue(true);
+    mocks.findInstalledSystemdGatewayScope.mockReset().mockResolvedValue({
+      scope: "user",
+      unitName: "openclaw-gateway.service",
+      unitPath: "/home/alice/.config/systemd/user/openclaw-gateway.service",
+    });
     mocks.isContainerEnvironment.mockReset().mockReturnValue(false);
     mocks.isLoaded.mockReset().mockResolvedValue(false);
     mocks.resolveGatewayService.mockReset().mockReturnValue({
-      hasInstalledDefinition: mocks.hasInstalledDefinition,
       isLoaded: mocks.isLoaded,
     });
     mockProcessPlatform("linux");
@@ -66,15 +79,7 @@ describe("doctor gateway service repair policy", () => {
       container: true,
       installed: false,
       expected: false,
-      probes: "definition",
-    },
-    {
-      name: "Docker without installed-definition capability",
-      env: {},
-      container: true,
-      missingCapability: true,
-      expected: false,
-      probes: "missing-capability",
+      probes: "scope",
     },
     {
       name: "Docker with an installed but unloaded service and reachable manager",
@@ -82,6 +87,14 @@ describe("doctor gateway service repair policy", () => {
       container: true,
       expected: true,
       probes: "manager",
+    },
+    {
+      name: "Docker with an installed system-scoped OpenClaw service",
+      env: {},
+      container: true,
+      scope: "system" as const,
+      expected: false,
+      probes: "scope",
     },
     {
       name: "Docker with an installed service and unavailable manager",
@@ -92,12 +105,12 @@ describe("doctor gateway service repair policy", () => {
       probes: "manager",
     },
     {
-      name: "Docker with a failed installed-definition probe",
+      name: "Docker with failed installed-scope discovery",
       env: {},
       container: true,
-      failedDefinition: true,
+      failedScope: true,
       expected: false,
-      probes: "definition",
+      probes: "scope",
     },
     {
       name: "non-Linux container",
@@ -112,14 +125,20 @@ describe("doctor gateway service repair policy", () => {
     if (scenario.platform) {
       mockProcessPlatform(scenario.platform);
     }
+    if (scenario.scope === "system") {
+      mocks.findInstalledSystemdGatewayScope.mockResolvedValue({
+        scope: "system",
+        unitName: "openclaw-gateway.service",
+        unitPath: "/etc/systemd/system/openclaw-gateway.service",
+      });
+    }
     if (scenario.installed === false) {
-      mocks.hasInstalledDefinition.mockResolvedValue(false);
+      mocks.findInstalledSystemdGatewayScope.mockResolvedValue(null);
     }
-    if (scenario.failedDefinition) {
-      mocks.hasInstalledDefinition.mockRejectedValue(new Error("service discovery failed"));
-    }
-    if (scenario.missingCapability) {
-      mocks.resolveGatewayService.mockReturnValue({ isLoaded: mocks.isLoaded });
+    if (scenario.failedScope) {
+      mocks.findInstalledSystemdGatewayScope.mockRejectedValue(
+        new Error("service discovery failed"),
+      );
     }
     if (scenario.unavailableManager) {
       mocks.isLoaded.mockRejectedValue(new Error("systemd user manager unavailable"));
@@ -128,17 +147,16 @@ describe("doctor gateway service repair policy", () => {
     await expect(shouldManageGatewayService(scenario.env)).resolves.toBe(scenario.expected);
 
     if (scenario.probes === "none") {
+      expect(mocks.findInstalledSystemdGatewayScope).not.toHaveBeenCalled();
       expect(mocks.resolveGatewayService).not.toHaveBeenCalled();
-      expect(mocks.hasInstalledDefinition).not.toHaveBeenCalled();
-    } else if (scenario.probes !== "missing-capability") {
-      expect(mocks.hasInstalledDefinition).toHaveBeenCalledWith({
-        env: scenario.env,
-        timeoutMs: 5_000,
-      });
+    } else {
+      expect(mocks.findInstalledSystemdGatewayScope).toHaveBeenCalledWith(scenario.env);
     }
     if (scenario.probes === "manager") {
+      expect(mocks.resolveGatewayService).toHaveBeenCalledOnce();
       expect(mocks.isLoaded).toHaveBeenCalledWith({ env: scenario.env, timeoutMs: 5_000 });
     } else {
+      expect(mocks.resolveGatewayService).not.toHaveBeenCalled();
       expect(mocks.isLoaded).not.toHaveBeenCalled();
     }
   });

--- a/src/commands/doctor-service-repair-policy.ts
+++ b/src/commands/doctor-service-repair-policy.ts
@@ -1,12 +1,46 @@
-/** Policy wrapper for doctor repairs to services managed by external supervisors. */
+/** Doctor policy for native gateway service ownership and repair. */
+import { isContainerEnvironment } from "../infra/container-environment.js";
+import { isGatewayExternallySupervised } from "../infra/gateway-supervision.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
 type ServiceRepairPolicy = "auto" | "external";
+const GATEWAY_SERVICE_MANAGER_TIMEOUT_MS = 5_000;
 
 export const SERVICE_REPAIR_POLICY_ENV = "OPENCLAW_SERVICE_REPAIR_POLICY";
 
 export const EXTERNAL_SERVICE_REPAIR_NOTE =
   "Gateway service is managed externally; skipped service install/start repair. Start or repair the gateway through your supervisor.";
+
+export async function shouldManageGatewayService(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  if (
+    isGatewayExternallySupervised(env) ||
+    (env.KUBERNETES_SERVICE_HOST?.trim() && env.KUBERNETES_SERVICE_PORT?.trim())
+  ) {
+    return false;
+  }
+  if (!isContainerEnvironment()) {
+    return true;
+  }
+  if (process.platform !== "linux") {
+    return false;
+  }
+  try {
+    const { resolveGatewayService } = await import("../daemon/service.js");
+    const service = resolveGatewayService();
+    const args = { env, timeoutMs: GATEWAY_SERVICE_MANAGER_TIMEOUT_MS };
+    // Container placement is not lifecycle ownership; Doctor may use native service
+    // paths only when the OpenClaw definition and its manager both exist.
+    if (!(await service.hasInstalledDefinition?.(args))) {
+      return false;
+    }
+    await service.isLoaded(args);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /** Resolves whether doctor may repair managed services or must defer to an external supervisor. */
 export function resolveServiceRepairPolicy(
@@ -15,14 +49,14 @@ export function resolveServiceRepairPolicy(
   return env[SERVICE_REPAIR_POLICY_ENV]?.trim().toLowerCase() === "external" ? "external" : "auto";
 }
 
-/** Returns true when service repairs should only emit external-supervisor guidance. */
+/** Returns true when Doctor service mutations must defer to an external supervisor. */
 export function isServiceRepairExternallyManaged(
   policy: ServiceRepairPolicy = resolveServiceRepairPolicy(),
 ): boolean {
-  return policy === "external";
+  return policy === "external" || isGatewayExternallySupervised();
 }
 
-/** Confirms a service repair unless the service repair policy is external. */
+/** Confirms a service repair unless Doctor mutations are externally managed. */
 export async function confirmDoctorServiceRepair(
   prompter: DoctorPrompter,
   params: Parameters<DoctorPrompter["confirmRuntimeRepair"]>[0],

--- a/src/commands/doctor-service-repair-policy.ts
+++ b/src/commands/doctor-service-repair-policy.ts
@@ -27,15 +27,14 @@ export async function shouldManageGatewayService(
     return false;
   }
   try {
-    const { resolveGatewayService } = await import("../daemon/service.js");
-    const service = resolveGatewayService();
-    const args = { env, timeoutMs: GATEWAY_SERVICE_MANAGER_TIMEOUT_MS };
-    // Container placement is not lifecycle ownership; Doctor may use native service
-    // paths only when the OpenClaw definition and its manager both exist.
-    if (!(await service.hasInstalledDefinition?.(args))) {
+    const { findInstalledSystemdGatewayScope } = await import("../daemon/systemd.js");
+    // Container placement is not ownership; user Doctor can repair only its
+    // installed user unit through a reachable systemd user manager.
+    if ((await findInstalledSystemdGatewayScope(env))?.scope !== "user") {
       return false;
     }
-    await service.isLoaded(args);
+    const { resolveGatewayService } = await import("../daemon/service.js");
+    await resolveGatewayService().isLoaded({ env, timeoutMs: GATEWAY_SERVICE_MANAGER_TIMEOUT_MS });
     return true;
   } catch {
     return false;

--- a/src/commands/doctor-web-fetch-proxy.ts
+++ b/src/commands/doctor-web-fetch-proxy.ts
@@ -4,8 +4,8 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveGatewayService, type GatewayService } from "../daemon/service.js";
-import { isGatewayHostServiceEnvironment } from "../infra/gateway-supervision.js";
 import { hasEnvHttpProxyConfigured } from "../infra/net/proxy-env.js";
+import { shouldManageGatewayService } from "./doctor-service-repair-policy.js";
 
 const DIRECT_PROBE_HOST = "docs.openclaw.ai";
 const DIRECT_PROBE_PORT = 443;
@@ -54,7 +54,7 @@ async function resolveProxyEnvSources(params: {
   if (hasEnvHttpProxyConfigured("https", params.env)) {
     sources.push({ env: params.env, label: "doctor process" });
   }
-  if (!isGatewayHostServiceEnvironment(params.env)) {
+  if (!(await shouldManageGatewayService(params.env))) {
     return sources;
   }
   const command = await params.service.readCommand(params.env).catch(() => null);

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -139,7 +139,9 @@ describe("resolveGatewayService", () => {
 
 describe("readGatewayServiceState", () => {
   it("tracks installed, loaded, and running separately", async () => {
+    const hasInstalledDefinition = vi.fn(async () => false);
     const service = createService({
+      hasInstalledDefinition,
       isLoaded: vi.fn(async () => true),
       readCommand: vi.fn(async () => ({
         programArguments: ["openclaw", "gateway", "run"],
@@ -156,6 +158,29 @@ describe("readGatewayServiceState", () => {
     expect(state.loadState).toEqual({ status: "loaded" });
     expect(state.running).toBe(true);
     expect(state.env.OPENCLAW_GATEWAY_PORT).toBe("18789");
+    expect(hasInstalledDefinition).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "system-scoped OpenClaw service", definition: true, installed: true },
+    { name: "missing OpenClaw service definition", definition: false, installed: false },
+    { name: "failed service definition inspection", failure: true, installed: false },
+  ])("preserves installed ownership for a $name without command details", async (scenario) => {
+    const hasInstalledDefinition = vi.fn(async () => {
+      if (scenario.failure) {
+        throw new Error("service definition inspection failed");
+      }
+      return scenario.definition ?? false;
+    });
+    const service = createService({ hasInstalledDefinition });
+    const env = { OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service" };
+
+    const state = await readGatewayServiceState(service, { env, timeoutMs: 100 });
+
+    expect(state.installed).toBe(scenario.installed);
+    expect(state.command).toBeNull();
+    expect(state.env).toBe(env);
+    expect(hasInstalledDefinition).toHaveBeenCalledWith({ env, timeoutMs: 100 });
   });
 
   it("keeps the caller-selected service identity when merging persisted env", async () => {

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -203,7 +203,10 @@ export async function readGatewayServiceState(
   // Callers that may mutate the selected service can reject persisted selector
   // drift before isLoaded/readRuntime invoke the native service manager.
   args.validateEnvBeforeStatusRead?.(env);
-  const [loadState, runtime] = await Promise.all([
+  const [installed, loadState, runtime] = await Promise.all([
+    command !== null
+      ? true
+      : (service.hasInstalledDefinition?.({ env, timeoutMs }).catch(() => false) ?? false),
     readGatewayServiceLoadState(service, { env, timeoutMs }),
     service.readRuntime(env, { timeoutMs }).catch(
       (error: unknown) =>
@@ -214,7 +217,7 @@ export async function readGatewayServiceState(
     ),
   ]);
   return {
-    installed: command !== null,
+    installed,
     loadState,
     running: runtime?.status === "running",
     env,

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -829,14 +829,13 @@ describe("doctor gateway runtime checks", () => {
     expect(mocks.readGatewayServiceState).not.toHaveBeenCalled();
   });
 
-  it("skips host-service findings for an externally managed container gateway", async () => {
+  it("skips host-service findings for a container without an OpenClaw service", async () => {
     mocks.isContainerEnvironment.mockReturnValue(true);
 
     await expect(
       collectGatewayDaemonFindings({ cfg: { gateway: { mode: "local" } } }),
     ).resolves.toEqual([]);
 
-    expect(mocks.resolveGatewayService).not.toHaveBeenCalled();
     expect(mocks.readGatewayServiceState).not.toHaveBeenCalled();
   });
 });

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -31,6 +31,7 @@ import {
 } from "../agents/tool-schema-projection.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { projectDoctorSecretRuntimeDegradations } from "../commands/doctor-secret-runtime-degradation.js";
+import { shouldManageGatewayService } from "../commands/doctor-service-repair-policy.js";
 import { collectUnavailableAgentSkills } from "../commands/doctor-skills-core.js";
 import {
   GATEWAY_HEALTH_RATE_LIMITED_MESSAGE,
@@ -49,7 +50,6 @@ import {
 } from "../gateway/call.js";
 import { isGatewaySecretRefUnavailableError } from "../gateway/credentials.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { isGatewayHostServiceEnvironment } from "../infra/gateway-supervision.js";
 import {
   formatLocalAudioSelection,
   inspectLocalAudioSelection,
@@ -205,7 +205,7 @@ function gatewayRuntimeStatus(runtime: GatewayServiceRuntime | undefined): strin
 export async function collectGatewayDaemonFindings(
   ctx: Pick<HealthCheckContext, "cfg">,
 ): Promise<readonly HealthFinding[]> {
-  if (ctx.cfg.gateway?.mode === "remote" || !isGatewayHostServiceEnvironment()) {
+  if (ctx.cfg.gateway?.mode === "remote" || !(await shouldManageGatewayService())) {
     return [];
   }
   const service = resolveGatewayService();

--- a/src/flows/doctor-health-contribution-runners.gateway.ts
+++ b/src/flows/doctor-health-contribution-runners.gateway.ts
@@ -1,9 +1,7 @@
 import { note } from "../../packages/terminal-core/src/note.js";
+import { shouldManageGatewayService } from "../commands/doctor-service-repair-policy.js";
 import { isDefaultInstallIdentity } from "../config/paths.js";
-import {
-  isGatewayHostServiceEnvironment,
-  NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON,
-} from "../infra/gateway-supervision.js";
+import { NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON } from "../infra/gateway-supervision.js";
 import { runCoreContributionHealth } from "./doctor-health-contribution-core.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
 import {
@@ -27,7 +25,7 @@ export async function runGatewayServicesHealth(ctx: DoctorHealthFlowContext): Pr
     note(NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON, "Gateway");
     return;
   }
-  if (!isGatewayHostServiceEnvironment(ctx.env ?? process.env)) {
+  if (!(await shouldManageGatewayService(ctx.env ?? process.env))) {
     return;
   }
   const {

--- a/src/flows/doctor-health-contribution-runners.workspace.ts
+++ b/src/flows/doctor-health-contribution-runners.workspace.ts
@@ -1,6 +1,6 @@
 import type { DoctorOptions } from "../commands/doctor-prompter.js";
+import { shouldManageGatewayService } from "../commands/doctor-service-repair-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { isGatewayHostServiceEnvironment } from "../infra/gateway-supervision.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
 import { resolveDoctorWorkspaceSuggestionScopes } from "./doctor-workspace-suggestion-scopes.js";
 import type { HealthCheckContext, HealthFinding } from "./health-checks.js";
@@ -86,7 +86,7 @@ export async function collectWorkspaceStatusPluginVersionDrift(params: {
   cfg: OpenClawConfig;
   options?: Pick<DoctorOptions, "allowExec" | "deep" | "nonInteractive">;
 }): Promise<PluginVersionDriftReport | undefined> {
-  if (params.cfg.gateway?.mode === "remote" || !isGatewayHostServiceEnvironment()) {
+  if (params.cfg.gateway?.mode === "remote" || !(await shouldManageGatewayService())) {
     return undefined;
   }
   try {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -196,8 +196,10 @@ const mocks = vi.hoisted(() => ({
   ),
   shortenHomePath: vi.fn((p: string) => p),
   formatCliCommand: vi.fn((cmd: string) => cmd),
-  findInstalledSystemdGatewayScope: vi.fn(async () => ({
-    scope: "user" as "user" | "system",
+  findInstalledSystemdGatewayScope: vi.fn<
+    (typeof import("../daemon/systemd.js"))["findInstalledSystemdGatewayScope"]
+  >(async () => ({
+    scope: "user",
     unitName: "openclaw-gateway.service",
     unitPath: "/home/alice/.config/systemd/user/openclaw-gateway.service",
   })),
@@ -1951,10 +1953,6 @@ describe("doctor health contributions", () => {
 
   it("repairs an installed Gateway service during an authorized update inside Docker", async () => {
     mocks.isContainerEnvironment.mockReturnValue(true);
-    mocks.resolveGatewayService.mockReturnValue({
-      hasInstalledDefinition: vi.fn(async () => true),
-      isLoaded: mocks.gatewayServiceIsLoaded,
-    });
 
     await withProcessPlatform("linux", async () => {
       const ctx = createDoctorContext({
@@ -1974,6 +1972,7 @@ describe("doctor health contributions", () => {
 
   it("silently skips the host-service contribution in a container without an OpenClaw service", async () => {
     mocks.isContainerEnvironment.mockReturnValue(true);
+    mocks.findInstalledSystemdGatewayScope.mockResolvedValue(null);
     const contribution = requireDoctorContribution("doctor:gateway-services");
     const ctx = createDoctorContext({
       cfg: { gateway: { mode: "local" } },
@@ -2535,11 +2534,6 @@ describe("doctor health contributions", () => {
 
   it("skips user lingering for a reachable system-scoped Gateway service in a container", async () => {
     mocks.isContainerEnvironment.mockReturnValue(true);
-    const hasInstalledDefinition = vi.fn(async () => true);
-    mocks.resolveGatewayService.mockReturnValue({
-      hasInstalledDefinition,
-      isLoaded: mocks.gatewayServiceIsLoaded,
-    });
     mocks.findInstalledSystemdGatewayScope.mockResolvedValue({
       scope: "system",
       unitName: "openclaw-gateway.service",
@@ -2561,7 +2555,8 @@ describe("doctor health contributions", () => {
       });
     });
 
-    expect(hasInstalledDefinition).toHaveBeenCalledTimes(2);
+    expect(mocks.findInstalledSystemdGatewayScope).toHaveBeenCalledTimes(2);
+    expect(mocks.gatewayServiceIsLoaded).not.toHaveBeenCalled();
     expect(mocks.isSystemdUserServiceAvailable).not.toHaveBeenCalled();
     expect(mocks.readSystemdUserLingerStatus).not.toHaveBeenCalled();
     expect(lintResult).toMatchObject({ checksRun: 1, findings: [] });
@@ -2570,6 +2565,7 @@ describe("doctor health contributions", () => {
 
   it("never probes systemd linger inside a container without an OpenClaw service", async () => {
     mocks.isContainerEnvironment.mockReturnValue(true);
+    mocks.findInstalledSystemdGatewayScope.mockResolvedValue(null);
     const checks = await resolveDoctorContributionHealthChecks();
     const lingerCheck = checks.find((check) => check.id === "core/doctor/systemd-linger");
     expect(lingerCheck).toBeDefined();

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1938,7 +1938,30 @@ describe("doctor health contributions", () => {
     );
   });
 
-  it("silently skips the host-service contribution in an externally managed container", async () => {
+  it("repairs an installed Gateway service during an authorized update inside Docker", async () => {
+    mocks.isContainerEnvironment.mockReturnValue(true);
+    mocks.resolveGatewayService.mockReturnValue({
+      hasInstalledDefinition: vi.fn(async () => true),
+      isLoaded: mocks.gatewayServiceIsLoaded,
+    });
+
+    await withProcessPlatform("linux", async () => {
+      const ctx = createDoctorContext({
+        cfg: { gateway: { mode: "local" } },
+        shouldRepair: true,
+        env: {
+          OPENCLAW_UPDATE_IN_PROGRESS: "1",
+          OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR: "1",
+        },
+      });
+
+      await requireDoctorContribution("doctor:gateway-services").run(ctx);
+
+      expect(mocks.maybeRepairGatewayServiceConfig).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("silently skips the host-service contribution in a container without an OpenClaw service", async () => {
     mocks.isContainerEnvironment.mockReturnValue(true);
     const contribution = requireDoctorContribution("doctor:gateway-services");
     const ctx = createDoctorContext({
@@ -2486,7 +2509,7 @@ describe("doctor health contributions", () => {
     expect(mocks.readSystemdUserLingerStatus).not.toHaveBeenCalled();
   });
 
-  it("never probes systemd linger when selected inside an externally managed container", async () => {
+  it("never probes systemd linger inside a container without an OpenClaw service", async () => {
     mocks.isContainerEnvironment.mockReturnValue(true);
     const checks = await resolveDoctorContributionHealthChecks();
     const lingerCheck = checks.find((check) => check.id === "core/doctor/systemd-linger");

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -196,6 +196,11 @@ const mocks = vi.hoisted(() => ({
   ),
   shortenHomePath: vi.fn((p: string) => p),
   formatCliCommand: vi.fn((cmd: string) => cmd),
+  findInstalledSystemdGatewayScope: vi.fn(async () => ({
+    scope: "user" as "user" | "system",
+    unitName: "openclaw-gateway.service",
+    unitPath: "/home/alice/.config/systemd/user/openclaw-gateway.service",
+  })),
   isSystemdUserServiceAvailable: vi.fn(async () => true),
   readSystemdUserLingerStatus: vi.fn(
     async (_params: {
@@ -303,6 +308,7 @@ vi.mock("../daemon/systemd.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../daemon/systemd.js")>();
   return {
     ...actual,
+    findInstalledSystemdGatewayScope: mocks.findInstalledSystemdGatewayScope,
     isSystemdUserServiceAvailable: mocks.isSystemdUserServiceAvailable,
     readSystemdUserLingerStatus: mocks.readSystemdUserLingerStatus,
     resolveSystemdUserServiceAccount: mocks.resolveSystemdUserServiceAccount,
@@ -812,6 +818,11 @@ describe("doctor health contributions", () => {
     mocks.collectBundledChannelPackageStateLoadFailures.mockReset().mockReturnValue([]);
     mocks.collectStalePluginRuntimeSymlinkHealthFindings.mockReset().mockResolvedValue([]);
     mocks.collectChannelPreviewWarningHealthFindings.mockReset().mockResolvedValue([]);
+    mocks.findInstalledSystemdGatewayScope.mockReset().mockResolvedValue({
+      scope: "user",
+      unitName: "openclaw-gateway.service",
+      unitPath: "/home/alice/.config/systemd/user/openclaw-gateway.service",
+    });
     mocks.isSystemdUserServiceAvailable.mockReset().mockResolvedValue(true);
     mocks.readSystemdUserLingerStatus
       .mockReset()
@@ -2484,6 +2495,19 @@ describe("doctor health contributions", () => {
     });
   });
 
+  it("preserves interactive linger repair for a user-scoped Gateway service", async () => {
+    const contribution = requireDoctorContribution("doctor:systemd-linger");
+    const ctx = createDoctorContext({
+      cfg: { gateway: { mode: "local" } },
+    });
+
+    await withProcessPlatform("linux", async () => {
+      await contribution.run(ctx);
+    });
+
+    expect(mocks.readSystemdUserLingerStatus).toHaveBeenCalledOnce();
+  });
+
   it("keeps selected systemd linger quiet when the gateway service is not loaded", async () => {
     mocks.gatewayServiceIsLoaded.mockResolvedValue(false);
     const contributionChecks = await resolveDoctorContributionHealthChecks();
@@ -2507,6 +2531,41 @@ describe("doctor health contributions", () => {
       });
     });
     expect(mocks.readSystemdUserLingerStatus).not.toHaveBeenCalled();
+  });
+
+  it("skips user lingering for a reachable system-scoped Gateway service in a container", async () => {
+    mocks.isContainerEnvironment.mockReturnValue(true);
+    const hasInstalledDefinition = vi.fn(async () => true);
+    mocks.resolveGatewayService.mockReturnValue({
+      hasInstalledDefinition,
+      isLoaded: mocks.gatewayServiceIsLoaded,
+    });
+    mocks.findInstalledSystemdGatewayScope.mockResolvedValue({
+      scope: "system",
+      unitName: "openclaw-gateway.service",
+      unitPath: "/etc/systemd/system/openclaw-gateway.service",
+    });
+    const contribution = requireDoctorContribution("doctor:systemd-linger");
+    const checks = await resolveDoctorContributionHealthChecks();
+    const lingerCheck = checks.find((check) => check.id === "core/doctor/systemd-linger");
+    expect(lingerCheck).toBeDefined();
+    const lintResult = await withProcessPlatform("linux", async () => {
+      await contribution.run(
+        createDoctorContext({
+          cfg: { gateway: { mode: "local" } },
+        }),
+      );
+      return await runDoctorLintChecks(createDoctorLintFixture({ gateway: { mode: "local" } }), {
+        checks: [lingerCheck!],
+        onlyIds: ["core/doctor/systemd-linger"],
+      });
+    });
+
+    expect(hasInstalledDefinition).toHaveBeenCalledTimes(2);
+    expect(mocks.isSystemdUserServiceAvailable).not.toHaveBeenCalled();
+    expect(mocks.readSystemdUserLingerStatus).not.toHaveBeenCalled();
+    expect(lintResult).toMatchObject({ checksRun: 1, findings: [] });
+    expect(JSON.stringify(lintResult)).not.toContain("loginctl enable-linger");
   });
 
   it("never probes systemd linger inside a container without an OpenClaw service", async () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -2,7 +2,7 @@
 // exposing the same checks to structured lint and repair commands.
 import fs from "node:fs";
 import { isDeepStrictEqual } from "node:util";
-import { isGatewayHostServiceEnvironment } from "../infra/gateway-supervision.js";
+import { shouldManageGatewayService } from "../commands/doctor-service-repair-policy.js";
 import { scrubDoctorErrorMessage } from "./doctor-error-message.js";
 import { hasActiveGatewayExecCredential } from "./doctor-gateway-exec-credential.js";
 import {
@@ -307,7 +307,7 @@ async function runSystemdLingerHealth(ctx: DoctorHealthFlowContext): Promise<voi
     ctx.options.nonInteractive === true ||
     process.platform !== "linux" ||
     resolveDoctorMode(ctx.cfg) !== "local" ||
-    !isGatewayHostServiceEnvironment(ctx.env ?? process.env)
+    !(await shouldManageGatewayService(ctx.env ?? process.env))
   ) {
     return;
   }
@@ -337,7 +337,7 @@ async function detectSystemdLingerFindings(
   if (
     process.platform !== "linux" ||
     resolveDoctorMode(ctx.cfg) !== "local" ||
-    !isGatewayHostServiceEnvironment(ctx.env ?? process.env)
+    !(await shouldManageGatewayService(ctx.env ?? process.env))
   ) {
     return [];
   }

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -302,12 +302,18 @@ async function runLegacyStateHealth(ctx: DoctorHealthFlowContext): Promise<void>
   }
 }
 
+async function hasUserScopedSystemdGatewayService(env: NodeJS.ProcessEnv): Promise<boolean> {
+  const { findInstalledSystemdGatewayScope } = await import("../daemon/systemd.js");
+  return (await findInstalledSystemdGatewayScope(env))?.scope === "user";
+}
+
 async function runSystemdLingerHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   if (
     ctx.options.nonInteractive === true ||
     process.platform !== "linux" ||
     resolveDoctorMode(ctx.cfg) !== "local" ||
-    !(await shouldManageGatewayService(ctx.env ?? process.env))
+    !(await shouldManageGatewayService(ctx.env ?? process.env)) ||
+    !(await hasUserScopedSystemdGatewayService(ctx.env ?? process.env))
   ) {
     return;
   }
@@ -337,7 +343,8 @@ async function detectSystemdLingerFindings(
   if (
     process.platform !== "linux" ||
     resolveDoctorMode(ctx.cfg) !== "local" ||
-    !(await shouldManageGatewayService(ctx.env ?? process.env))
+    !(await shouldManageGatewayService(ctx.env ?? process.env)) ||
+    !(await hasUserScopedSystemdGatewayService(ctx.env ?? process.env))
   ) {
     return [];
   }

--- a/src/infra/gateway-supervision.ts
+++ b/src/infra/gateway-supervision.ts
@@ -1,7 +1,6 @@
 // Defines gateway lifecycle ownership shared by service, restart, and update paths.
 import { isDefaultInstallIdentity, resolveNativeServiceProfileConflict } from "../config/paths.js";
 import { resolveGatewayNativeServiceIdentityConflict } from "../daemon/constants.js";
-import { isContainerEnvironment } from "./container-environment.js";
 
 const GATEWAY_SUPERVISOR_MODE_ENV = "OPENCLAW_SUPERVISOR_MODE";
 export const EXTERNAL_SUPERVISOR_UPDATE_REQUIRED_REASON = "external-supervisor-update-required";
@@ -10,11 +9,6 @@ export const NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON =
 
 export function isGatewayExternallySupervised(env: NodeJS.ProcessEnv = process.env): boolean {
   return env[GATEWAY_SUPERVISOR_MODE_ENV]?.trim().toLowerCase() === "external";
-}
-
-export function isGatewayHostServiceEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
-  const { KUBERNETES_SERVICE_HOST: host, KUBERNETES_SERVICE_PORT: port } = env;
-  return !isContainerEnvironment() && !(host?.trim() && port?.trim());
 }
 
 export function formatExternalSupervisorActionRequired(action: string): string {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -83,6 +83,7 @@ const PLUGIN_UPDATE_PROBE_PATH = "scripts/e2e/lib/plugin-update/probe.mjs";
 const PLUGIN_LIFECYCLE_MATRIX_DOCKER_E2E_PATH = "scripts/e2e/plugin-lifecycle-matrix-docker.sh";
 const DOCTOR_SWITCH_DOCKER_E2E_PATH = "scripts/e2e/doctor-install-switch-docker.sh";
 const DOCTOR_SWITCH_SCENARIO_PATH = "scripts/e2e/lib/doctor-install-switch/scenario.sh";
+const DOCTOR_SWITCH_BUSCTL_SHIM_PATH = "scripts/e2e/lib/doctor-install-switch/shims/busctl";
 const DOCTOR_SWITCH_LOGINCTL_SHIM_PATH = "scripts/e2e/lib/doctor-install-switch/shims/loginctl";
 const DOCTOR_SWITCH_SYSTEMCTL_SHIM_PATH = "scripts/e2e/lib/doctor-install-switch/shims/systemctl";
 const PACKAGE_COMPAT_PATH = "scripts/e2e/lib/package-compat.mjs";
@@ -4881,6 +4882,7 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     expectTextToIncludeAll(doctorScenario, [
       "cp scripts/e2e/lib/doctor-install-switch/shims/systemctl",
       "cp scripts/e2e/lib/doctor-install-switch/shims/loginctl",
+      "cp scripts/e2e/lib/doctor-install-switch/shims/busctl",
       "OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR=1",
       "scripts/e2e/lib/package-compat.mjs",
     ]);
@@ -4927,6 +4929,109 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     expect(loadState.stdout.trim()).toBe("not-found");
     expect(unitPath.status).toBe(0);
     expect(unitPath.stdout).toContain("/etc/systemd/system");
+  });
+
+  it("reports the installed doctor switch unit through the systemd manager", () => {
+    const home = tempDirs.make("openclaw-doctor-busctl-shim-");
+    const serviceName = "openclaw-gateway.service";
+    const unitPath = join(home, ".config", "systemd", "user", serviceName);
+    mkdirSync(join(home, ".config", "systemd", "user"), { recursive: true });
+    writeFileSync(
+      unitPath,
+      [
+        "[Service]",
+        'ExecStart=/usr/bin/node "/opt/openclaw git/dist/index.js" gateway --port 18789',
+        'WorkingDirectory="/opt/openclaw git"',
+        'Environment="GREETING=hello world" OPENCLAW_PROFILE=fixture',
+        "EnvironmentFile=-%h/.openclaw/gateway.systemd.env",
+        "UnsetEnvironment=STALE_FLAG",
+      ].join("\n"),
+    );
+
+    const manager = "org.freedesktop.systemd1";
+    const objectPath = "/org/freedesktop/systemd1/unit/openclaw_2dgateway_2eservice";
+    const programArguments = [
+      "/usr/bin/node",
+      "/opt/openclaw git/dist/index.js",
+      "gateway",
+      "--port",
+      "18789",
+    ];
+    const runBusctl = (args: string[]) => {
+      const result = spawnSync(
+        DOCTOR_SWITCH_BUSCTL_SHIM_PATH,
+        ["--user", "--json=short", ...args],
+        {
+          encoding: "utf8",
+          env: { ...process.env, HOME: home },
+        },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      return result.stdout
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+    };
+
+    expect(
+      runBusctl([
+        "call",
+        manager,
+        "/org/freedesktop/systemd1",
+        `${manager}.Manager`,
+        "LoadUnit",
+        "s",
+        serviceName,
+      ]),
+    ).toEqual([{ type: "o", data: [objectPath] }]);
+    expect(
+      runBusctl([
+        "get-property",
+        manager,
+        objectPath,
+        `${manager}.Service`,
+        "ExecStart",
+        "WorkingDirectory",
+        "Environment",
+        "EnvironmentFiles",
+        "UnsetEnvironment",
+      ]),
+    ).toEqual([
+      {
+        type: "a(sasbttttuii)",
+        data: [[programArguments[0], programArguments, false, ...Array(7).fill(0)]],
+      },
+      { type: "s", data: "/opt/openclaw git" },
+      { type: "as", data: ["GREETING=hello world", "OPENCLAW_PROFILE=fixture"] },
+      { type: "a(sb)", data: [[join(home, ".openclaw", "gateway.systemd.env"), true]] },
+      { type: "as", data: ["STALE_FLAG"] },
+    ]);
+    expect(
+      runBusctl([
+        "get-property",
+        manager,
+        objectPath,
+        `${manager}.Unit`,
+        "FragmentPath",
+        "DropInPaths",
+        "NeedDaemonReload",
+      ]),
+    ).toEqual([
+      { type: "s", data: unitPath },
+      { type: "as", data: [] },
+      { type: "b", data: false },
+    ]);
+
+    const unexpected = spawnSync(
+      DOCTOR_SWITCH_BUSCTL_SHIM_PATH,
+      ["--user", "--json=short", "list"],
+      {
+        encoding: "utf8",
+        env: { ...process.env, HOME: home },
+      },
+    );
+    expect(unexpected.status).toBe(1);
+    expect(unexpected.stderr).toContain("unexpected invocation");
   });
 
   it("routes doctor install switch commands through the E2E timeout helper", () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

Related: #125796

## What Problem This Solves

Fixes an issue where operators switching a managed OpenClaw installation between npm and a Git checkout would retain the previous Gateway service executable when repair ran inside a Linux container with a reachable native service manager. Package Acceptance run https://github.com/openclaw/openclaw/actions/runs/32831263538 expected `/tmp/openclaw-git/dist/index.js` after the npm-to-Git switch but instead retained `/tmp/npm-prefix/lib/node_modules/openclaw/dist/index.js`.

The regression was introduced by cd3a87f79f1 in #125796: a blanket container-placement predicate skipped Doctor's service owners before checking whether an OpenClaw user service was actually installed, whether its native user manager was reachable, or whether the update parent had authorized repair.

## Why This Change Was Made

Doctor now owns one canonical native-service policy shared by all eight affected callers. An explicitly external global supervisor and Kubernetes always veto native service management; ordinary non-container hosts retain their existing behavior; a detected Linux container is eligible only when the canonical systemd owner discovers an installed **user-scoped** OpenClaw Gateway unit and its user manager is reachable. A system-scoped unit in a detected container is externally managed relative to user Doctor repair: Doctor cannot read or rewrite that unit through its user-unit service owner, so it is excluded before any manager probe instead of silently claiming repairability. No privileged system-unit mutation, root escalation, fallback, or parallel repair path is introduced.

User lingering remains a separate user-service invariant: both the interactive repair and structured diagnostic additionally require the installed Gateway unit to be user-scoped. This separate guard remains necessary defense in depth on ordinary hosts, where the existing broad diagnostics behavior is intentionally unchanged.

The packaged reproduction also exposed an incomplete simulated systemd manager: production correctly rejected unknown operator drop-ins because the fixture lacked `busctl`. The checked-in fixture now reports the exact installed managed-user-unit contract through a narrow `busctl` shim; operator-owned drop-in protection remains intact.

Named follow-up: **desktop-stream status-callback synchronization** remains intentionally out of scope. The previously carried test-only synchronization heal was dropped so this PR preserves the reviewed Doctor-only repair; that independent integration-test race should be handled in a separate change.

## User Impact

Managed npm-to-Git and Git-to-npm installation switches now update the actual user-scoped Gateway service executable in supported Linux containers, including cross-state approved repairs. Externally supervised deployments, Kubernetes, detected containers without an installed user-scoped OpenClaw unit, system-scoped units, and unreachable user managers remain protected from unauthorized mutation. Ordinary-host diagnostics and existing web-fetch proxy cleanup and wrapper persistence continue to work.

## Evidence

- Original failing packaged acceptance run: https://github.com/openclaw/openclaw/actions/runs/32831263538.
- Fail-first current-head system-scope regression: `node scripts/run-vitest.mjs src/commands/doctor-service-repair-policy.test.ts` failed with `expected true to be false` while a detected container contained only a system-scoped OpenClaw unit; the same policy matrix passes after the canonical scope-owner repair.
- `node scripts/run-vitest.mjs src/commands/doctor-service-repair-policy.test.ts src/commands/doctor-gateway-daemon-flow.test.ts` — 51 tests passed, including detected-container user scope, unloaded-but-reachable user managers, no installed definition, system scope without a manager probe, failed scope discovery, unreachable managers, Kubernetes/global external vetoes, non-Linux containers, ordinary-host behavior, and the downstream daemon flow.
- `node scripts/run-vitest.mjs src/commands/doctor-service-repair-policy.test.ts src/commands/doctor-gateway-services.test.ts src/flows/doctor-health-contributions.test.ts src/daemon/service.test.ts` — 251 tests passed across three Vitest projects, including the preserved independent linger guard and the existing system-scoped installed-state contract.
- `pnpm test:docker:doctor-switch` — passed with exit 0 on the fresh final source/package path: rebuilt all production bundles and plugins, checked the npm tarball inventory/import graph, built the Docker image, then completed `npm-to-git`, `git-to-npm`, `cross-state-approvals`, `proxy-env-cleanup`, and `wrapper-persistence` with the unchanged checked-in systemd fixture.
- `node scripts/check-changed.mjs -- src/commands/doctor-service-repair-policy.ts src/commands/doctor-service-repair-policy.test.ts src/commands/doctor-gateway-daemon-flow.test.ts src/flows/doctor-health-contributions.test.ts` — passed the selected `core` and `coreTests` lanes, including formatting, production/test typechecks, focused lint, dead-export analysis, import cycles, database-first, native-state, webhook, and auth guards.
- `git diff --check` — passed.
- Prior packaged Blacksmith Testbox evidence remains available at https://github.com/openclaw/openclaw/actions/runs/32899041820; the fresh local packaged proof above additionally exercises the corrected final source/package path.
- Final PR diff: production +68/-40 (net +28); tests +473/-48 (net +425); tooling +202/-2 (net +200). The P1 follow-up itself removes one net production line by replacing redundant broad installed-definition probing with canonical user-scope discovery; the two existing downstream suites were updated because they explicitly asserted the obsolete probe.
- No `CHANGELOG.md` edit: normal OpenClaw pull requests leave release-note generation to the release workflow.
