### PR TITLE
chore: remove duplicate Cloudflare wrapper test

### DIFF
--- a/extensions/cloudflare-ai-gateway/stream-wrappers.test.ts
+++ b/extensions/cloudflare-ai-gateway/stream-wrappers.test.ts
@@ -115,28 +115,6 @@ describe("wrapCloudflareAiGatewayProviderStream", () => {
     warnMock.mockClear();
   });
 
-  it("patches Anthropic Messages models", () => {
-    const payload = {
-      thinking: { type: "enabled" },
-      messages: [
-        { role: "user", content: "Return JSON." },
-        { role: "assistant", content: "{" },
-      ],
-    };
-    const wrapped = wrapCloudflareAiGatewayProviderStream({
-      model: { api: "anthropic-messages" },
-      streamFn: createPayloadBaseStream(payload),
-    } as never);
-
-    void wrapped?.(
-      { provider: "cloudflare-ai-gateway", api: "anthropic-messages" } as never,
-      {} as never,
-      {},
-    );
-
-    expect(payload.messages).toEqual([{ role: "user", content: "Return JSON." }]);
-  });
-
   it("leaves non-Anthropic model APIs on the original stream path", () => {
     let onPayloadWasInstalled = false;
     const baseStreamFn: StreamFn = (_model, _context, options) => {


### PR DESCRIPTION
## What Problem This Solves

The Cloudflare AI Gateway suite repeated the same Anthropic thinking-prefill success path in both a direct wrapper test and the plugin registration test. The direct case added maintenance cost without protecting an independent behavior.

## Why This Change Was Made

Remove only the direct wrapper replay. The surviving registration test captures the real provider, invokes its registered `wrapStreamFn`, executes the actual wrapped stream, and asserts the same assistant-prefill removal. The focused wrapper suite still covers warning details, multiple trailing prefills, disabled thinking, tool-use preservation, non-Anthropic bypass, and the missing-API default.

AI-assisted test audit requested by the maintainer.

## User Impact

No user-visible behavior changes. The extension suite keeps its unique behavior and wiring coverage with one fewer duplicate test.

## Evidence

- Baseline: `node scripts/run-vitest.mjs extensions/cloudflare-ai-gateway/index.test.ts extensions/cloudflare-ai-gateway/stream-wrappers.test.ts` — 8/8 tests passed.
- After cleanup: the same focused command — 7/7 retained tests passed.
- `node scripts/check-changed.mjs --dry-run -- extensions/cloudflare-ai-gateway/stream-wrappers.test.ts` — classified the extension-test lane.
- `node scripts/check-changed.mjs -- extensions/cloudflare-ai-gateway/stream-wrappers.test.ts` — passed, including extension-test typecheck and type-aware lint.
- `git diff --check` — passed.
- Fresh autoreview reported no actionable findings; correctness confidence 0.99.
- Production LOC: +0/-0. Test LOC: +0/-22.