### PR TITLE
fix(gateway): settle Codex live harness startup

### DIFF
--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -2156,6 +2156,7 @@ describeLive("gateway live (Codex harness)", () => {
           auth: { mode: "token", token },
           controlUiEnabled: false,
         });
+        await server.startupSettled;
         client = await connectTestGatewayClient({
           url: `ws://127.0.0.1:${port}`,
           token,
@@ -2480,6 +2481,7 @@ describeLive("gateway live (Codex harness)", () => {
               auth: { mode: "token", token },
               controlUiEnabled: false,
             });
+            await server.startupSettled;
             client = await connectTestGatewayClient({
               url: `ws://127.0.0.1:${port}`,
               token,


### PR DESCRIPTION
Related: #128965

## What Problem This Solves

Fixes an issue where the Codex live restart/resume harness could connect before Gateway sidecar startup had published the prepared runtime, causing release validation to fail even though the production runtime path was healthy.

## Why This Change Was Made

The harness now awaits the Gateway's public `startupSettled` lifecycle handle before its initial client connection and after every restart. This keeps the repair at the fixture lifecycle boundary and excludes the unrelated agent-default cleanup from #128965.

Codex contract inspection at `414782450952a196bbb64b1605a458c2531c47b6` confirmed that `thread/resume` preserves the requested thread identity and persisted history in `codex-rs/app-server/src/request_processors/thread_processor.rs`, spawned agents retain parent lineage in `codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs`, and terminal turns are emitted through `TurnCompleted` in `codex-rs/app-server/src/bespoke_event_handling.rs`.

## User Impact

Maintainers can run the Codex restart/resume and subagent-delivery proof without a fixture-induced startup race. There is no production runtime behavior change.

## Evidence

- `git diff --check` - passed.
- `node_modules/.bin/oxfmt --check src/gateway/gateway-codex-harness.live.test.ts` - passed.
- `node scripts/check-changed.mjs -- src/gateway/gateway-codex-harness.live.test.ts` - all scoped guards and dead-export scans passed; final core-test typecheck encountered unrelated stale shared dependency typings in `packages/ai`, `packages/markdown-core`, and `src/tui`.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` - clean, no actionable findings.
- Exact-head Blacksmith Testbox restart/resume/subagent proof - pending.

Production LOC: `+0/-0`. Test/live-test support: `+2/-0`.

Co-authored with @jalehman; replacement for the distinct Codex startup-settlement slice of #128965.

AI-assisted: yes. I reviewed the complete diff, Gateway lifecycle owner, restart harness, sibling behavior, and Codex app-server contracts directly.
