### PR TITLE
refactor(memory): centralize provenance projection

### DIFF
--- a/src/memory/memory-artifact-provenance.ts
+++ b/src/memory/memory-artifact-provenance.ts
@@ -114,6 +114,14 @@ function normalizeStoredProvenance(
   return value;
 }
 
+function toPublicProvenance(stored: StoredMemoryArtifactProvenance): MemoryArtifactProvenance {
+  return {
+    fileHash: stored.fileHash,
+    originClass: stored.originClass,
+    observedAt: stored.observedAt,
+  };
+}
+
 export async function recordMemoryArtifactWriteProvenance(params: {
   workspaceDir: string;
   relativePath: string;
@@ -188,13 +196,7 @@ export async function readMemoryArtifactProvenance(params: {
     return undefined;
   }
   const stored = normalizeStoredProvenance(openStore().lookup(address.storeKey), address);
-  return stored
-    ? {
-        fileHash: stored.fileHash,
-        originClass: stored.originClass,
-        observedAt: stored.observedAt,
-      }
-    : undefined;
+  return stored ? toPublicProvenance(stored) : undefined;
 }
 
 export async function listMemoryArtifactProvenance(params: {
@@ -213,16 +215,7 @@ export async function listMemoryArtifactProvenance(params: {
       };
       const stored = normalizeStoredProvenance(entry.value, address);
       return stored
-        ? [
-            {
-              relativePath: stored.relativePath,
-              provenance: {
-                fileHash: stored.fileHash,
-                originClass: stored.originClass,
-                observedAt: stored.observedAt,
-              },
-            },
-          ]
+        ? [{ relativePath: stored.relativePath, provenance: toPublicProvenance(stored) }]
         : [];
     });
 }


### PR DESCRIPTION
## What Problem This Solves

Memory provenance reads and listings independently selected the same public fields from richer stored records. That duplicated the public-field allowlist across two policy paths that could drift as the stored representation evolves.

## Why This Change Was Made

Both APIs now use one private projection helper. Returned values, storage records, schema/versioning, public signatures, and security semantics are unchanged; the cleanup removes 7 net production lines.

## User Impact

No user-visible behavior changes. Memory provenance reads and listings continue returning only `fileHash`, `originClass`, and `observedAt`.

## Evidence

- Production LOC: +10/-17 (net -7) | Tests: +0/-0
- `node scripts/run-vitest.mjs src/memory/memory-artifact-provenance.test.ts extensions/memory-core/src/memory/memory-path-provenance.test.ts` — 7 tests passed across 2 shards
- `node scripts/check-changed.mjs -- src/memory/memory-artifact-provenance.ts` — passed on exact head
- Deslop — clean, no edits needed
- Autoreview (Codex, branch against `origin/main`) — no accepted/actionable findings
- Separate exact-head Codex review — `CLEAN`
- Existing tests already exercise both read and list public projections, so no implementation-coupled test was added
- Live overlap searches found no open issue or PR naming this file, type, or list API


### Real SQLite-backed behavior proof

Ran the exact head against an isolated temporary `OPENCLAW_STATE_DIR` and physical workspace using the production plugin-state SQLite store (no mocks). The flow persisted one provenance record, then exercised both public read and list APIs and asserted their complete key sets and values. Temporary paths were redacted and removed after the run.

```text
real sqlite write/read/list: PASS
read={"fileHash":"8e2a0ca7f5b64cb0b55292d609e391b9dd974b2cab73f67c4f283e58feedf56a","originClass":"agent","observedAt":1777000000000}
list=[{"relativePath":"memory/2026-08-25.md","provenance":{"fileHash":"8e2a0ca7f5b64cb0b55292d609e391b9dd974b2cab73f67c4f283e58feedf56a","originClass":"agent","observedAt":1777000000000}}]
publicKeys=["fileHash","observedAt","originClass"]
stateFiles=state/openclaw.sqlite
homeFiles=
```
