### PR TITLE
fix(skills): restore evidence guidance and keep prompt assertions in their lane

### DIFF
--- a/src/auto-reply/reply/commands-learn.test.ts
+++ b/src/auto-reply/reply/commands-learn.test.ts
@@ -104,7 +104,7 @@ describe("learn command", () => {
     await handleLearnCommand(params, true);
     const instruction = (params.ctx as { BodyForAgent?: string }).BodyForAgent ?? "";
 
-    expect(instruction).toContain(buildLearnPrompt(request));
+    expect(instruction).toBe(buildLearnPrompt(request));
   });
 
   it("replies without continuing when the workshop is unavailable", async () => {

--- a/src/auto-reply/reply/commands-learn.test.ts
+++ b/src/auto-reply/reply/commands-learn.test.ts
@@ -2,8 +2,7 @@
 import { describe, expect, it } from "vitest";
 import { migratePersistedImplicitMainRoster } from "../../config/legacy.roster.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { DEFAULT_LEARN_REQUEST } from "../../skills/workshop/learn-prompt.js";
-import { SKILL_AUTHORING_STANDARDS_PROMPT } from "../../skills/workshop/skill-authoring-standards.js";
+import { buildLearnPrompt, DEFAULT_LEARN_REQUEST } from "../../skills/workshop/learn-prompt.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import { handleLearnCommand } from "./commands-learn.js";
 import type { HandleCommandsParams } from "./commands-types.js";
@@ -94,17 +93,18 @@ describe("learn command", () => {
     expect((params.ctx as { BodyForAgent?: string }).BodyForAgent).toContain(DEFAULT_LEARN_REQUEST);
   });
 
-  it("includes the load-bearing skill authoring standards", async () => {
-    const params = buildLearnParams("/learn what we just did");
+  // Asserts the wiring this lane owns: the command hands the agent the workshop
+  // learn prompt verbatim. The prompt's wording is asserted where it is authored
+  // (src/skills/workshop/*.test.ts); duplicating it here made a skills-lane edit
+  // land green on its own PR and break this lane on the next full main run.
+  it("hands the agent the workshop learn prompt", async () => {
+    const request = "what we just did";
+    const params = buildLearnParams(`/learn ${request}`);
 
     await handleLearnCommand(params, true);
     const instruction = (params.ctx as { BodyForAgent?: string }).BodyForAgent ?? "";
 
-    expect(instruction).toContain(
-      "Revise the best pending proposal or update the best Workshop-owned skill before creating anything new.",
-    );
-    expect(instruction).toContain("Make at most one proposal mutation.");
-    expect(instruction).toContain(SKILL_AUTHORING_STANDARDS_PROMPT);
+    expect(instruction).toContain(buildLearnPrompt(request));
   });
 
   it("replies without continuing when the workshop is unavailable", async () => {

--- a/src/skills/workshop/learn-prompt.test.ts
+++ b/src/skills/workshop/learn-prompt.test.ts
@@ -10,6 +10,7 @@ describe("buildLearnPrompt", () => {
     expect(prompt).toContain("SOURCES and REQUIREMENTS");
     expect(prompt).toContain("never fetch only the first source");
     expect(prompt).toContain("update the best Workshop-owned skill before creating anything new");
+    expect(prompt).toContain("Make at most one proposal mutation.");
     expect(prompt).toContain("no durable reusable procedure");
     expect(prompt).not.toContain("NEVER capture");
     expect(buildLearnPrompt(" ")).toContain(DEFAULT_LEARN_REQUEST);

--- a/src/skills/workshop/skill-authoring-standards.test.ts
+++ b/src/skills/workshop/skill-authoring-standards.test.ts
@@ -12,6 +12,7 @@ describe("skill authoring standards", () => {
     expect(SKILL_AUTHORING_STANDARDS_PROMPT).toContain("2–4 words");
     expect(SKILL_AUTHORING_STANDARDS_PROMPT).toContain("completion criterion");
     expect(SKILL_AUTHORING_STANDARDS_PROMPT).toContain("one source per meaning");
+    expect(SKILL_AUTHORING_STANDARDS_PROMPT).toContain("never invent flags, commands, paths, APIs");
     expect(SKILL_AUTHORING_STANDARDS_PROMPT).toContain("never the failed attempts");
   });
 

--- a/src/skills/workshop/skill-authoring-standards.ts
+++ b/src/skills/workshop/skill-authoring-standards.ts
@@ -6,5 +6,5 @@ export const SKILL_AUTHORING_STANDARDS_PROMPT = [
   "- Name: the class of work, 2–4 words.",
   "- Steps: ordered actions, each ending on a completion criterion the agent can check. Steps come before reference; reference appears only where a step consults it.",
   '- Language: positive imperatives ("run X, then verify Y"); one source per meaning; every sentence changes behavior versus the default. Sentences that restate defaults, duplicate another line, or describe a one-off are deleted.',
-  "- Evidence: every step comes from the observed trajectory or the existing skill. Capture the recovery that worked, never the failed attempts.",
+  "- Evidence: every step comes from the observed trajectory or the existing skill; never invent flags, commands, paths, APIs, tool behavior, or requirements. Capture the recovery that worked, never the failed attempts.",
 ].join("\n");


### PR DESCRIPTION
Heals `main`. Follows #129282 and builds on the narrower consumer-test alignment landed by #129370.

## What Problem This Solves

The shared Skill Workshop guidance lost its explicit rule never to invent flags, commands, paths, APIs, tool behavior, or requirements. The `/learn` command test also duplicated Workshop-owned wording, so a skills-only change could pass its selected PR lanes and later break the auto-reply lane on a full `main` run.

## Why This Change Was Made

Restore the evidence rule at its canonical prompt owner. Then make the command test assert only the behavior its lane owns: `/learn` hands the agent `buildLearnPrompt(request)` verbatim. Workshop wording remains asserted in Workshop tests, including the proposal-mutation and evidence-provenance rules that previously had no owner-local assertions.

This removes the cross-lane assertion trap without adding a wrapper, fallback, configuration surface, or runtime branch.

## User Impact

Agents learning reusable skills are again told not to fabricate product capabilities or requirements. Maintainers get owner-local prompt coverage, so future wording changes fail in the PR that makes them instead of a later full run.

## Evidence

- Exact head: `5e456431d4947c673df6ea682d808053ed49a251`; base: `66bfdeffb9b4e60e858e17a4f11aea1eb401e94a`.
- All three commits have valid signatures.
- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-learn.test.ts src/skills/workshop/learn-prompt.test.ts src/skills/workshop/skill-authoring-standards.test.ts` - **3 files, 12 tests passed** on the exact head.
- `git diff --check` - clean.
- Fresh exact-head structured Codex autoreview (`gpt-5.6-sol`, high) - no accepted/actionable findings; patch correct at 0.99 confidence.
- Native review artifacts validate with `READY FOR /prepare-pr` and zero findings.
- Blacksmith Testbox changed-scope proof on parent `bda1b6779bd1cf3d8a357ef173a23ef3e7fe0b31` passed every selected guard, core production typecheck, core test typecheck, and targeted lint: https://github.com/openclaw/openclaw/actions/runs/32892169830.
- Exact-head hosted CI is not green: compact shards 9 and 12 timed out in unrelated suites, and shard 11 exposed the separate Codex test-owner gap tracked by #129584. No failure is waived; exact-head Testbox remains mandatory after CI is green.

Production LOC: +1/-1 (net 0) | Tests: +14/-11 (net +3).
