### PR TITLE
fix(ai): recover input-only provider context overflows

### DIFF
--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -90,7 +90,7 @@ const FAILOVER_EXPLICIT_OVERFLOW_PATTERNS = [
   /exceed context limit/i,
   /exceeds the model'?s maximum context/i,
   /max_tokens[\s\S]*exceed[\s\S]*context/i,
-  /input length[\s\S]*exceed[\s\S]*context/i,
+  /input(?: length[\s\S]*exceed[\s\S]*context| \([\d,]+\s*tokens?\) is longer than (?:the )?model'?s context length)/i,
   /413[\s\S]*too large/i,
   /context_window_exceeded/i,
   // FIXED(refactor-06): PR 2 removed the embedded-429 false positive; this is provider overflow.

--- a/src/agents/failover/context-overflow.legacy.test.ts
+++ b/src/agents/failover/context-overflow.legacy.test.ts
@@ -147,6 +147,11 @@ describe("isLikelyContextOverflowError", () => {
     for (const sample of samples) {
       expect(isLikelyContextOverflowError(sample)).toBe(true);
     }
+    expect(
+      classifyFailoverReason(
+        "The input (263000 tokens) is longer than the model's context length (262144 tokens).",
+      ),
+    ).toBe("context_overflow");
   });
 
   it("excludes context window too small errors", () => {

--- a/src/agents/failover/context-overflow.legacy.test.ts
+++ b/src/agents/failover/context-overflow.legacy.test.ts
@@ -89,6 +89,9 @@ describe("isContextOverflowError", () => {
       "This request exceeds the model's maximum context length",
       "LLM request rejected: max_tokens would exceed context window",
       "input length would exceed context budget for this model",
+      "The input (263000 tokens) is longer than the model's context length (262144 tokens).",
+      "The input (263,000 tokens) is longer than the model's context length (262,144 tokens).",
+      "The input (1 token) is longer than the model's context length (1 token).",
     ];
     for (const sample of samples) {
       expect(isContextOverflowError(sample)).toBe(true);
@@ -139,6 +142,7 @@ describe("isLikelyContextOverflowError", () => {
       "Model context window is 128k tokens, you requested 256k tokens",
       "Context window exceeded: requested 12000 tokens",
       "Prompt too large for this model",
+      "The input (263000 tokens) is longer than the model's context length (262144 tokens).",
     ];
     for (const sample of samples) {
       expect(isLikelyContextOverflowError(sample)).toBe(true);
@@ -165,6 +169,7 @@ describe("isLikelyContextOverflowError", () => {
       "This request would exceed your account's rate limit",
       "429 Too Many Requests: request exceeds rate limit",
       "AWS Bedrock: Too many tokens per day. Please try again tomorrow.",
+      "Rate limit exceeded: The input (263000 tokens) is longer than the model's context length (262144 tokens).",
     ];
     for (const sample of samples) {
       expect(isLikelyContextOverflowError(sample)).toBe(false);
@@ -182,6 +187,7 @@ describe("isLikelyContextOverflowError", () => {
       "402 Payment Required: request token limit exceeded for this billing plan",
       "insufficient credits: request size exceeds your current plan limits",
       "Your credit balance is too low. Maximum request token limit exceeded.",
+      "402 Payment Required: The input (263000 tokens) is longer than the model's context length (262144 tokens).",
     ];
     for (const sample of samples) {
       expect(isBillingErrorMessage(sample)).toBe(true);

--- a/src/agents/failover/failover-classification.overflow.cases.ts
+++ b/src/agents/failover/failover-classification.overflow.cases.ts
@@ -133,13 +133,6 @@ export const overflowCases = [
       },
     ],
     [
-      "patterns-context-input-longer-than-model",
-      {
-        message:
-          "The input (263000 tokens) is longer than the model's context length (262144 tokens).",
-      },
-    ],
-    [
       "patterns-context-ds4",
       {
         message: "400 Prompt has 256468 tokens, but the configured context size is 256000 tokens",

--- a/src/agents/failover/failover-classification.overflow.cases.ts
+++ b/src/agents/failover/failover-classification.overflow.cases.ts
@@ -133,6 +133,13 @@ export const overflowCases = [
       },
     ],
     [
+      "patterns-context-input-longer-than-model",
+      {
+        message:
+          "The input (263000 tokens) is longer than the model's context length (262144 tokens).",
+      },
+    ],
+    [
       "patterns-context-ds4",
       {
         message: "400 Prompt has 256468 tokens, but the configured context size is 256000 tokens",


### PR DESCRIPTION
## What Problem This Solves

Closes #129352. Supersedes #129380 with credit to @KhanCold.

SGLang and other OpenAI-compatible providers reject a prompt that already fills the context window with an HTTP 400 such as:

> The input (263000 tokens) is longer than the model's context length (262144 tokens).

OpenClaw already recognized this message when inspecting an assistant error, but its separate strict failover classifier did not. The embedded agent therefore returned a hard provider error instead of compacting the session and retrying.

The dependency contract is explicit in SGLang's canonical source and its real OpenAI-compatible integration tests:

- [SGLang request validator and exact HTTP 400 message](https://github.com/sgl-project/sglang/blob/96a73c4e15a2b98672b83b91af47d1e3bada707c/rust/sglang-server/src/tokenizer_manager/to_scheduler.rs#L628-L651)
- [SGLang OpenAI-compatible nonstreaming and streaming request-validation tests](https://github.com/sgl-project/sglang/blob/96a73c4e15a2b98672b83b91af47d1e3bada707c/test/registered/openai_server/validation/test_request_length_validation.py#L39-L86)

## Why This Change Was Made

The original contributor correctly identified the missing strict classification. This version improves the existing canonical generic input/context expression instead of duplicating an existing provider-specific expression in another table.

- Preserve the prior input-length/exceeds/context branch exactly.
- Add the bounded input-token/model-context wording shared by SGLang and Together AI, including comma-formatted token counts and singular `token`.
- Preserve existing B2 context errors, billing/quota classification, rate limits, and unrelated user text.
- Keep the change at the owning overflow classifier; do not weaken provider fallback gates or merge assistant-error policy into strict failover.

Production change: **+1/-1 (net zero)**. Scoped owner regression tests: **+11 lines**.

Thanks to @KhanCold for the original diagnosis and focused contributor patch in #129380.

## User Impact

When an OpenAI-compatible local inference server rejects a prompt that already fills its context window, the agent recognizes real context exhaustion and can follow its existing compaction-and-retry path. Rate-limit and billing errors continue to receive their existing handling.

## Evidence

Before the fix, the newly added strict and likely overflow checks failed, and the full failover classifier classified the exact SGLang HTTP 400 message as `null` instead of `context_overflow`:

```text
context-overflow.legacy.test.ts: 2 failed, 16 passed
failover-classification.corpus.test.ts: 1 failed, 616 passed
```

The initial hosted run also exposed that adding a new row to the shared failover corpus invalidates frozen retry-decision inventories in other CI shards. The final version keeps the equivalent end-to-end classification assertion in the existing owner test and leaves the shared corpus and its downstream inventories unchanged.

After the canonical owner repair and scoped regression correction:

```text
node scripts/run-vitest.mjs \
  src/agents/failover/context-overflow.legacy.test.ts \
  src/llm/utils/retry.test.ts \
  src/agents/failover/failover-classification.corpus.test.ts \
  --configLoader runner

context-overflow.legacy.test.ts: 18 passed
src/llm/utils/retry.test.ts: 630 passed
failover-classification.corpus.test.ts: 616 passed
Total: 1,264 passed
```

The expanded coverage includes the exact SGLang wording, comma-formatted counts, singular `token`, existing B2-style context errors, rate-limit lookalikes, billing lookalikes, and the complete production failover classification corpus. Changed-file formatting, scoped lint, structured independent review, and mandatory autoreview all pass.

An isolated synthetic upstream exercised the real production OpenAI-completions transport twice over localhost: first the exact official SGLang HTTP 400, then a successful HTTP 200 server-sent-event completion after the classified retry. The production strict classifier, likely-overflow classifier, and failover classifier all recognized the first response as context exhaustion. Invoked separately after the successful retry to avoid unrelated local plugin-registry initialization, the real embedded-run overflow recovery owner also returned `{ action: "retry" }` and incremented its recovery counter:

```json
{
  "requests": 2,
  "httpStatuses": [400, 200],
  "firstStopReason": "error",
  "officialErrorObserved": true,
  "patchedOwnerExplicit": true,
  "productionStrict": true,
  "productionLikely": true,
  "productionFailoverReason": "context_overflow",
  "productionRecoveryAction": "retry",
  "recoveryAttempts": 1,
  "retryStopReason": "stop",
  "retryText": "Recovered after compaction"
}
```

This uses a synthetic SGLang-shaped upstream rather than claiming access to a live SGLang deployment or a full automatic agent compaction. No real credentials, configuration, models, or user state were used or changed.
