### PR TITLE
fix(gateway): point admin auto-approve warnings at identityScopes

### DIFF
--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -271,7 +271,7 @@ export async function prepareGatewayServerBootstrap(input: {
     trustedProxyDeviceAutoApprove.scopes?.some((scope) => scope.trim() === ADMIN_SCOPE)
   ) {
     log.warn(
-      "SECURITY WARNING: gateway.auth.trustedProxy.deviceAutoApprove.scopes includes operator.admin; every proxy-authenticated user can auto-approve a new browser device with full admin, and requests without scopes receive full admin automatically. Remove operator.admin to require manual approval until per-identity roles are available.",
+      "SECURITY WARNING: gateway.auth.trustedProxy.deviceAutoApprove.scopes includes operator.admin; every proxy-authenticated user can auto-approve a new browser device with full admin, and requests without scopes receive full admin automatically. Remove operator.admin and grant admin per identity via gateway.auth.identityScopes instead.",
     );
   }
   const resolvedStartupAuthOverride = startupAuthOverride

--- a/src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts
+++ b/src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts
@@ -212,7 +212,7 @@ describe("trusted-proxy browser device auto-approval", () => {
     expect(
       warnings.filter((message) =>
         message.includes(
-          "SECURITY WARNING: gateway.auth.trustedProxy.deviceAutoApprove.scopes includes operator.admin; every proxy-authenticated user can auto-approve a new browser device with full admin, and requests without scopes receive full admin automatically. Remove operator.admin to require manual approval until per-identity roles are available.",
+          "SECURITY WARNING: gateway.auth.trustedProxy.deviceAutoApprove.scopes includes operator.admin; every proxy-authenticated user can auto-approve a new browser device with full admin, and requests without scopes receive full admin automatically. Remove operator.admin and grant admin per identity via gateway.auth.identityScopes instead.",
         ),
       ),
     ).toHaveLength(1);

--- a/src/security/audit-gateway-config.ts
+++ b/src/security/audit-gateway-config.ts
@@ -373,7 +373,7 @@ export function collectGatewayConfigFindings(
           detail:
             "gateway.auth.trustedProxy.deviceAutoApprove.scopes includes operator.admin, so every proxy-authenticated user can auto-approve a new browser device with full admin; requests without scopes receive full admin automatically.",
           remediation:
-            "Remove operator.admin and approve admin access manually, or use per-identity roles when they become available.",
+            "Remove operator.admin and approve admin access manually, or grant admin per identity via gateway.auth.identityScopes.",
         });
       }
     }

--- a/src/security/audit-gateway-exposure.test.ts
+++ b/src/security/audit-gateway-exposure.test.ts
@@ -504,7 +504,7 @@ describe("security audit gateway exposure findings", () => {
       detail:
         "gateway.auth.trustedProxy.deviceAutoApprove.scopes includes operator.admin, so every proxy-authenticated user can auto-approve a new browser device with full admin; requests without scopes receive full admin automatically.",
       remediation:
-        "Remove operator.admin and approve admin access manually, or use per-identity roles when they become available.",
+        "Remove operator.admin and approve admin access manually, or grant admin per identity via gateway.auth.identityScopes.",
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

The startup `SECURITY WARNING` for `gateway.auth.trustedProxy.deviceAutoApprove.scopes` containing `operator.admin`, and the remediation text of the critical `gateway.trusted_proxy_device_auto_approve_admin` security-audit finding, still tell operators to require manual approval "until per-identity roles are available". Per-identity admin grants shipped as `gateway.auth.identityScopes` (documented and recommended in `docs/gateway/trusted-proxy-auth.md`), so the runtime guidance points operators at a nonexistent future feature instead of the shipped fix.

This is operator-facing guidance on a critical finding, and stale guidance has real cost: on team.openclaw.ai an interim host-side "approve everything" script outlived its reason for existing precisely because the guidance never got updated to name the shipped alternative.

## Why This Change Was Made

Both strings (plus their exact-string test copies) now direct operators to grant admin per identity via `gateway.auth.identityScopes`, matching what the trusted-proxy docs already recommend. Repo-wide grep shows no other "per-identity roles are available/become available" stragglers.

## User Impact

Operators who enable admin device auto-approval (or run `openclaw security audit` against such a config) now get remediation guidance naming the shipped config surface instead of being told to wait for a feature that already exists. No behavior change: message text only.

## Evidence

- String-only diff: 4 files, 4 lines changed, production LOC net 0 (two message literals + two exact-string test expectations).
- `node scripts/run-vitest.mjs src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts src/security/audit-gateway-exposure.test.ts` — 12 tests passed across both shards.
- `oxfmt --check` clean on all four files.
- Autoreview (Codex, gpt-5.6-sol, high): clean, no accepted/actionable findings.
