### PR TITLE
fix(agents): avoid decoding binary documents in read

### DIFF
--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -4,6 +4,7 @@ import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import JSZip from "jszip";
 import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
@@ -37,6 +38,47 @@ function createTinyBmp(): Buffer {
   buffer[56] = 0xff;
   return buffer;
 }
+
+async function createOoxmlDocument(params: {
+  mainMime: string;
+  partPath: string;
+}): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `<Types><Override PartName="${params.partPath}" ContentType="${params.mainMime}.main+xml"/></Types>`,
+  );
+  zip.file(params.partPath.slice(1), "<xml/>");
+  return await zip.generateAsync({ type: "nodebuffer" });
+}
+
+const DOCUMENT_FIXTURES = [
+  ["PDF", async () => Buffer.from("%PDF-1.7\n1 0 obj\n<<>>\nendobj\n%%EOF", "ascii")],
+  [
+    "DOCX",
+    () =>
+      createOoxmlDocument({
+        mainMime: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        partPath: "/word/document.xml",
+      }),
+  ],
+  [
+    "XLSX",
+    () =>
+      createOoxmlDocument({
+        mainMime: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        partPath: "/xl/workbook.xml",
+      }),
+  ],
+  [
+    "PPTX",
+    () =>
+      createOoxmlDocument({
+        mainMime: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        partPath: "/ppt/presentation.xml",
+      }),
+  ],
+] as const;
 
 function textContent(
   result: Awaited<ReturnType<ReturnType<typeof createReadToolDefinition>["execute"]>>,
@@ -366,6 +408,54 @@ describe("read tool", () => {
     );
 
     expect(textContent(result)).toBe("plain text");
+  });
+
+  it.each(DOCUMENT_FIXTURES)(
+    "does not decode %s bytes from a renamed .bin file",
+    async (label, createDocument) => {
+      const document = await createDocument();
+      const fileName = `${label.toLowerCase()}.bin`;
+      const tempDir = tempDirs.make("openclaw-read-document-");
+      await fs.writeFile(path.join(tempDir, fileName), document);
+      const readFile = vi.fn(async () => document);
+      const tool =
+        label === "PDF"
+          ? createReadToolDefinition(tempDir)
+          : createReadToolDefinition("/workspace", {
+              operations: { access: async () => {}, readFile },
+            });
+      const result = await tool.execute(
+        "call-document",
+        { path: fileName },
+        undefined,
+        undefined,
+        {} as never,
+      );
+      expect(textContent(result)).toMatch(
+        /^Read did not return file contents because it detected a binary document \[.+\]\. Use an available document parser or converter, or convert the file to text, Markdown, or CSV, then read the converted file\.$/,
+      );
+      expect(result.details.kind).toBe("text");
+      expect(readFile).toHaveBeenCalledTimes(label === "PDF" ? 0 : 1);
+    },
+  );
+
+  it.each([
+    ["plaintext named DOCX", "notes.docx", "plain text"],
+    ["JSON", "data.json", '{"ready":true}'],
+    ["YAML", "config.yaml", "ready: true"],
+  ])("keeps %s output unchanged", async (_label, fileName, contents) => {
+    const tool = createReadToolDefinition("/workspace", {
+      operations: { access: async () => {}, readFile: async () => Buffer.from(contents) },
+    });
+
+    const result = await tool.execute(
+      "call-text",
+      { path: fileName },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    expect(textContent(result)).toBe(contents);
   });
 
   it("resolves one Unicode-equivalent filename and names the correction", async () => {

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -2,6 +2,7 @@ import { constants } from "node:fs";
 import { access as fsAccess, readdir as fsReaddir, stat as fsStat } from "node:fs/promises";
 import { basename, dirname, isAbsolute, relative, resolve as resolvePath, sep } from "node:path";
 import { Text } from "@earendil-works/pi-tui";
+import { classifyAttachmentBytes } from "@openclaw/media-core/attachment-classify";
 import { hasErrnoCode, toErrorObject } from "../../../infra/errors.js";
 import { readRegularFile } from "../../../infra/regular-file.js";
 import { decodeWindowsTextFileBuffer } from "../../../infra/windows-encoding.js";
@@ -551,10 +552,18 @@ export function createReadToolDefinition(
               return;
             }
             const mimeType = await detectReadImageMimeType(ops, buffer, absolutePath);
+            const attachment = mimeType ? undefined : await classifyAttachmentBytes({ buffer });
             let content: (TextContent | ImageContent)[];
             let truncated: Parameters<typeof createReadToolDetails>[1];
             const nonVisionImageNote = getNonVisionImageNote(ctx?.model);
-            if (mimeType) {
+            if (attachment?.class === "document") {
+              content = [
+                {
+                  type: "text",
+                  text: `Read did not return file contents because it detected a binary document [${attachment.mime ?? "unknown"}]. Use an available document parser or converter, or convert the file to text, Markdown, or CSV, then read the converted file.`,
+                },
+              ];
+            } else if (mimeType) {
               const base64 = buffer.toString("base64");
               const processed = await processImage(
                 { type: "image", data: base64, mimeType },


### PR DESCRIPTION
Closes #35406

## What Problem This Solves

Fixes an issue where users asking the `read` tool to inspect PDF or Office documents could receive raw binary or ZIP bytes as model-visible text, wasting context and giving the agent unusable output.

## Why This Change Was Made

The shared session read boundary now classifies the buffer it already read, after the existing image path, and intercepts only byte-confirmed documents. It returns an explicit non-outcome plus the next action instead of adding extraction, extension allowlists, config, or a second read.

Classification reuses `@openclaw/media-core/attachment-classify`, so renamed `.bin` DOCX, XLSX, and PPTX files are handled from bytes while plaintext files with document-looking names continue through normal text decoding.

## User Impact

PDF and Office document reads no longer inject garbled binary data into the model context. The tool tells the agent to use an available document parser or converter, or convert the file to text, Markdown, or CSV first.

Reported by @xx77yy in #35406. Prior exploration in #35494 by @Sid-Qin and #57600 by @jackdark425 helped establish the failure mode; this implementation is independent and targets the current shared owner boundary.

## Evidence

Current-main reproduction with only the production hunk removed:

```text
src/agents/sessions/tools/read.test.ts
4 failed | 41 passed

PDF, renamed .bin DOCX, XLSX, and PPTX all returned decoded raw bytes.
```

Repaired head `9797067a822ea3f504e18f4eeff34c927faf8553`:

```text
node scripts/run-vitest.mjs src/agents/sessions/tools/read.test.ts
1 file passed | 45 tests passed

node scripts/run-vitest.mjs packages/media-core/src/attachment-classify.test.ts packages/media-core/src/mime.test.ts
2 files passed | 204 tests passed

git diff --check origin/main...HEAD
passed

pnpm format src/agents/sessions/tools/read.ts src/agents/sessions/tools/read.test.ts
passed
```

`node scripts/check-changed.mjs -- src/agents/sessions/tools/read.ts src/agents/sessions/tools/read.test.ts` passed all guards, formatting, dead-export checks, and core typecheck. Its core-test typecheck could not complete locally because this linked worktree's shared install predates current-main `pako` and lacks its declarations; repository policy forbids reconciling dependencies in this worktree. Two Blacksmith Testbox attempts stopped before command execution because delegated file sync timed out. Hosted CI is the clean-install proof for the published head.

Autoreview on the complete branch diff:

```text
gpt-5.6-sol, high reasoning
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.98)
```

Production delta: `+10/-1`. Test delta: `+90/-0`. The positive production delta is the owner-boundary behavior: one shared byte classification plus one explicit document non-outcome.
