### PR TITLE
refactor(lobster): unify managed flow parsing

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -640,7 +640,7 @@ extensions/lmstudio/src/models.ts	2
 extensions/lmstudio/src/stream.ts	3
 extensions/lobster/index.ts	2
 extensions/lobster/src/lobster-runner.ts	4
-extensions/lobster/src/lobster-tool.ts	2
+extensions/lobster/src/lobster-tool.ts	1
 extensions/logbook/index.ts	5
 extensions/logbook/src/analyze.ts	8
 extensions/logbook/src/config.ts	1

--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -106,7 +106,7 @@ describe("lobster plugin tool", () => {
     expect(approval.resumeToken).toBe("resume-token-1");
   });
 
-  it("keeps ordinary run on the embedded runner when flow defaults are injected", async () => {
+  it("keeps ordinary run on the runner for neutral flow defaults and ignores resume credentials", async () => {
     const runner = {
       run: vi.fn().mockResolvedValue({
         ok: true,
@@ -126,8 +126,15 @@ describe("lobster plugin tool", () => {
     const res = await tool.execute("call-default-flow-run", {
       action: "run",
       pipeline: "noop",
+      token: 42,
+      approve: "yes",
+      flowControllerId: " ",
+      flowGoal: "",
       flowStateJson: "{}",
-      flowExpectedRevision: 0,
+      flowId: " ",
+      flowExpectedRevision: "0",
+      flowCurrentStep: "",
+      flowWaitingStep: " ",
     });
 
     expect(taskFlow.createManaged).not.toHaveBeenCalled();
@@ -164,7 +171,7 @@ describe("lobster plugin tool", () => {
     },
   );
 
-  it("keeps ordinary resume on the embedded runner when flow defaults are injected", async () => {
+  it("keeps ordinary resume on the runner for neutral flow defaults", async () => {
     const runner = {
       run: vi.fn().mockResolvedValue({
         ok: true,
@@ -180,8 +187,13 @@ describe("lobster plugin tool", () => {
       action: "resume",
       token: "resume-token-1",
       approve: true,
+      flowControllerId: " ",
+      flowGoal: "",
       flowStateJson: "{}",
-      flowExpectedRevision: 0,
+      flowId: " ",
+      flowExpectedRevision: "0",
+      flowCurrentStep: "",
+      flowWaitingStep: " ",
     });
 
     expect(taskFlow.resume).not.toHaveBeenCalled();
@@ -196,6 +208,20 @@ describe("lobster plugin tool", () => {
     const details = requireRecord(res.details, "ordinary resume with flow defaults details");
     expect(details.ok).toBe(true);
     expect(details.status).toBe("ok");
+  });
+
+  it("rejects malformed resume credentials before ordinary fallback", async () => {
+    const runner = { run: vi.fn() };
+    const tool = createLobsterTool(fakeApi(), { runner });
+
+    await expect(
+      tool.execute("call-ordinary-resume-invalid-credentials", {
+        action: "resume",
+        token: 42,
+        approve: "yes",
+      }),
+    ).rejects.toThrow("token must be a string");
+    expect(runner.run).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -221,21 +247,73 @@ describe("lobster plugin tool", () => {
     expect(runner.run).not.toHaveBeenCalled();
   });
 
-  it("rejects resume with a non-default flow revision but no flowId", async () => {
+  it.each([
+    [
+      { action: "run", flowCurrentStep: "run_lobster" },
+      "flowControllerId required when using managed TaskFlow run mode",
+    ],
+    [
+      { action: "run", flowWaitingStep: "await_review" },
+      "flowControllerId required when using managed TaskFlow run mode",
+    ],
+    [
+      { action: "run", flowControllerId: "tests/lobster" },
+      "flowGoal required when using managed TaskFlow run mode",
+    ],
+    [
+      { action: "resume", token: "resume-token-1", approve: true, flowExpectedRevision: 1 },
+      "flowId required when using managed TaskFlow resume mode",
+    ],
+    [
+      { action: "resume", token: "resume-token-1", approve: true, flowId: "flow-1" },
+      "flowExpectedRevision required when using managed TaskFlow resume mode",
+    ],
+    [
+      {
+        action: "resume",
+        token: "resume-token-1",
+        approve: true,
+        flowCurrentStep: "resume_lobster",
+      },
+      "flowId required when using managed TaskFlow resume mode",
+    ],
+    [
+      { action: "resume", token: "resume-token-1", approve: true, flowWaitingStep: "await_review" },
+      "flowId required when using managed TaskFlow resume mode",
+    ],
+    [
+      { action: "resume", approve: true, flowId: "flow-1", flowExpectedRevision: 1 },
+      "token or approvalId required when using managed TaskFlow resume mode",
+    ],
+    [
+      { action: "resume", token: "resume-token-1", flowId: "flow-1", flowExpectedRevision: 1 },
+      "approve required when using managed TaskFlow resume mode",
+    ],
+  ])("requires managed TaskFlow fields", async (params, error) => {
     const runner = { run: vi.fn() };
     const tool = createLobsterTool(fakeApi(), {
       runner,
       taskFlow: createFakeTaskFlow(),
     });
 
-    await expect(
-      tool.execute("call-revision-without-flow-id", {
-        action: "resume",
-        token: "resume-token-1",
-        approve: true,
-        flowExpectedRevision: 1,
-      }),
-    ).rejects.toThrow(/flowId required when using managed TaskFlow resume mode/);
+    await expect(tool.execute("call-missing-managed-field", params)).rejects.toThrow(error);
+    expect(runner.run).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      { action: "run", flowControllerId: 42, flowId: "flow-1" },
+      "flowControllerId must be a string",
+    ],
+    [{ action: "resume", token: 42, flowControllerId: "tests/lobster" }, "token must be a string"],
+  ])("preserves mixed-invalid field error precedence", async (params, error) => {
+    const runner = { run: vi.fn() };
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      taskFlow: createFakeTaskFlow(),
+    });
+
+    await expect(tool.execute("call-mixed-invalid-fields", params)).rejects.toThrow(error);
     expect(runner.run).not.toHaveBeenCalled();
   });
 
@@ -431,7 +509,7 @@ describe("lobster plugin tool", () => {
     ).rejects.toThrow(/flowStateJson must be valid JSON/);
   });
 
-  it("can resume managed TaskFlow mode with only approvalId", async () => {
+  it("can resume managed TaskFlow revision zero with only approvalId", async () => {
     const runner = {
       run: vi.fn().mockResolvedValue({
         ok: true,
@@ -448,14 +526,14 @@ describe("lobster plugin tool", () => {
       approvalId: "approval-1",
       approve: true,
       flowId: "flow-1",
-      flowExpectedRevision: 1,
+      flowExpectedRevision: 0,
       flowStateJson: "{}",
       flowCurrentStep: "resume_lobster",
     });
 
     expect(taskFlow.resume).toHaveBeenCalledWith({
       flowId: "flow-1",
-      expectedRevision: 1,
+      expectedRevision: 0,
       status: "running",
       currentStep: "resume_lobster",
     });
@@ -488,7 +566,7 @@ describe("lobster plugin tool", () => {
 
     await tool.execute("call-managed-resume-string-revision", {
       action: "resume",
-      approvalId: "approval-1",
+      token: " resume-token-1 ",
       approve: true,
       flowId: "flow-1",
       flowExpectedRevision: "1",
@@ -501,38 +579,14 @@ describe("lobster plugin tool", () => {
       status: "running",
       currentStep: "resume_lobster",
     });
-  });
-
-  it("rejects managed TaskFlow resume mode without a token or approvalId", async () => {
-    const tool = createLobsterTool(fakeApi(), {
-      runner: { run: vi.fn() },
-      taskFlow: createFakeTaskFlow(),
+    expect(runner.run).toHaveBeenCalledWith({
+      action: "resume",
+      token: " resume-token-1 ",
+      approve: true,
+      cwd: process.cwd(),
+      timeoutMs: 20_000,
+      maxStdoutBytes: 512_000,
     });
-
-    await expect(
-      tool.execute("call-missing-resume-token", {
-        action: "resume",
-        flowId: "flow-1",
-        flowExpectedRevision: 1,
-        approve: true,
-      }),
-    ).rejects.toThrow(/token or approvalId required when using managed TaskFlow resume mode/);
-  });
-
-  it("rejects managed TaskFlow resume mode without approve", async () => {
-    const tool = createLobsterTool(fakeApi(), {
-      runner: { run: vi.fn() },
-      taskFlow: createFakeTaskFlow(),
-    });
-
-    await expect(
-      tool.execute("call-missing-resume-approve", {
-        action: "resume",
-        token: "resume-token",
-        flowId: "flow-1",
-        flowExpectedRevision: 1,
-      }),
-    ).rejects.toThrow(/approve required when using managed TaskFlow resume mode/);
   });
 
   it("requires action", async () => {

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -29,21 +29,6 @@ type LobsterToolOptions = {
   taskFlow?: BoundTaskFlow;
 };
 
-type ManagedFlowRunParams = {
-  controllerId: string;
-  goal: string;
-  currentStep?: string;
-  waitingStep?: string;
-  stateJson?: JsonLike;
-};
-
-type ManagedFlowResumeParams = {
-  flowId: string;
-  expectedRevision: number;
-  currentStep?: string;
-  waitingStep?: string;
-};
-
 function readOptionalTrimmedString(value: unknown, fieldName: string): string | undefined {
   if (value === undefined) {
     return undefined;
@@ -99,50 +84,54 @@ function isEmptyJsonObject(value: JsonLike | undefined): boolean {
   );
 }
 
-function parseRunFlowParams(params: Record<string, unknown>): ManagedFlowRunParams | null {
-  const controllerId = readOptionalTrimmedString(params.flowControllerId, "flowControllerId");
-  const goal = readOptionalTrimmedString(params.flowGoal, "flowGoal");
-  const currentStep = readOptionalTrimmedString(params.flowCurrentStep, "flowCurrentStep");
-  const waitingStep = readOptionalTrimmedString(params.flowWaitingStep, "flowWaitingStep");
-  const stateJson = parseOptionalFlowStateJson(params.flowStateJson);
-  const resumeFlowId = readOptionalTrimmedString(params.flowId, "flowId");
-  const resumeRevision = readOptionalNumber(params.flowExpectedRevision, "flowExpectedRevision");
-  const stateJsonSignalsRunMode = stateJson !== undefined && !isEmptyJsonObject(stateJson);
+function parseManagedFlowParams(
+  action: "run" | "resume",
+  params: Record<string, unknown>,
+  runnerParams: LobsterRunnerParams,
+) {
+  if (action === "run") {
+    const controllerId = readOptionalTrimmedString(params.flowControllerId, "flowControllerId");
+    const goal = readOptionalTrimmedString(params.flowGoal, "flowGoal");
+    const currentStep = readOptionalTrimmedString(params.flowCurrentStep, "flowCurrentStep");
+    const waitingStep = readOptionalTrimmedString(params.flowWaitingStep, "flowWaitingStep");
+    const stateJson = parseOptionalFlowStateJson(params.flowStateJson);
+    const resumeFlowId = readOptionalTrimmedString(params.flowId, "flowId");
+    const resumeRevision = readOptionalNumber(params.flowExpectedRevision, "flowExpectedRevision");
+    const stateJsonSignalsRunMode = stateJson !== undefined && !isEmptyJsonObject(stateJson);
 
-  if (resumeFlowId !== undefined || (resumeRevision !== undefined && resumeRevision !== 0)) {
-    throw new Error("run action does not accept flowId or flowExpectedRevision");
+    if (resumeFlowId !== undefined || (resumeRevision !== undefined && resumeRevision !== 0)) {
+      throw new Error("run action does not accept flowId or flowExpectedRevision");
+    }
+    if (
+      controllerId === undefined &&
+      goal === undefined &&
+      currentStep === undefined &&
+      waitingStep === undefined &&
+      !stateJsonSignalsRunMode
+    ) {
+      return null;
+    }
+    if (!controllerId) {
+      throw new Error("flowControllerId required when using managed TaskFlow run mode");
+    }
+    if (!goal) {
+      throw new Error("flowGoal required when using managed TaskFlow run mode");
+    }
+    return {
+      action,
+      controllerId,
+      goal,
+      ...(currentStep ? { currentStep } : {}),
+      ...(waitingStep ? { waitingStep } : {}),
+      ...(stateJson !== undefined ? { stateJson } : {}),
+    };
   }
 
-  const hasRunFields =
-    controllerId !== undefined ||
-    goal !== undefined ||
-    currentStep !== undefined ||
-    waitingStep !== undefined ||
-    stateJsonSignalsRunMode;
-
-  if (!hasRunFields) {
-    return null;
-  }
-  if (!controllerId) {
-    throw new Error("flowControllerId required when using managed TaskFlow run mode");
-  }
-  if (!goal) {
-    throw new Error("flowGoal required when using managed TaskFlow run mode");
-  }
-  return {
-    controllerId,
-    goal,
-    ...(currentStep ? { currentStep } : {}),
-    ...(waitingStep ? { waitingStep } : {}),
-    ...(stateJson !== undefined ? { stateJson } : {}),
-  };
-}
-
-function parseResumeFlowParams(params: Record<string, unknown>): ManagedFlowResumeParams | null {
   const flowId = readOptionalTrimmedString(params.flowId, "flowId");
   const expectedRevision = readOptionalNumber(params.flowExpectedRevision, "flowExpectedRevision");
   const currentStep = readOptionalTrimmedString(params.flowCurrentStep, "flowCurrentStep");
   const waitingStep = readOptionalTrimmedString(params.flowWaitingStep, "flowWaitingStep");
+  // Credential validation stays resume-only and before fallback; run intentionally ignores these fields.
   const token = readOptionalTrimmedString(params.token, "token");
   const approvalId = readOptionalTrimmedString(params.approvalId, "approvalId");
   const approve = readOptionalBoolean(params.approve, "approve");
@@ -170,17 +159,29 @@ function parseResumeFlowParams(params: Record<string, unknown>): ManagedFlowResu
   if (expectedRevision === undefined) {
     throw new Error("flowExpectedRevision required when using managed TaskFlow resume mode");
   }
-  if (!token && !approvalId) {
+  const credentialParams = token
+    ? { token: runnerParams.token ?? token }
+    : approvalId
+      ? { approvalId: runnerParams.approvalId ?? approvalId }
+      : null;
+  if (!credentialParams) {
     throw new Error("token or approvalId required when using managed TaskFlow resume mode");
   }
   if (approve === undefined) {
     throw new Error("approve required when using managed TaskFlow resume mode");
   }
   return {
+    action,
     flowId,
     expectedRevision,
     ...(currentStep ? { currentStep } : {}),
     ...(waitingStep ? { waitingStep } : {}),
+    runnerParams: {
+      ...runnerParams,
+      ...credentialParams,
+      action,
+      approve,
+    } satisfies Parameters<typeof resumeManagedLobsterFlow>[0]["runnerParams"],
   };
 }
 
@@ -262,40 +263,33 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
       };
 
       const taskFlow = options?.taskFlow;
-      if (action === "run") {
-        const flowParams = parseRunFlowParams(params);
-        if (flowParams) {
-          return resolveManagedFlowToolResult(
-            await runManagedLobsterFlow({
-              taskFlow: requireTaskFlowRuntime(taskFlow, "run"),
-              runner,
-              runnerParams,
-              controllerId: flowParams.controllerId,
-              goal: flowParams.goal,
-              ...(flowParams.stateJson !== undefined ? { stateJson: flowParams.stateJson } : {}),
-              ...(flowParams.currentStep ? { currentStep: flowParams.currentStep } : {}),
-              ...(flowParams.waitingStep ? { waitingStep: flowParams.waitingStep } : {}),
-            }),
-          );
-        }
-      } else {
-        const flowParams = parseResumeFlowParams(params);
-        if (flowParams) {
-          return resolveManagedFlowToolResult(
-            await resumeManagedLobsterFlow({
-              taskFlow: requireTaskFlowRuntime(taskFlow, "resume"),
-              runner,
-              runnerParams: runnerParams as LobsterRunnerParams & {
-                action: "resume";
-                approve: boolean;
-              } & ({ token: string } | { approvalId: string }),
-              flowId: flowParams.flowId,
-              expectedRevision: flowParams.expectedRevision,
-              ...(flowParams.currentStep ? { currentStep: flowParams.currentStep } : {}),
-              ...(flowParams.waitingStep ? { waitingStep: flowParams.waitingStep } : {}),
-            }),
-          );
-        }
+      const flowParams = parseManagedFlowParams(action, params, runnerParams);
+      if (flowParams?.action === "run") {
+        return resolveManagedFlowToolResult(
+          await runManagedLobsterFlow({
+            taskFlow: requireTaskFlowRuntime(taskFlow, "run"),
+            runner,
+            runnerParams,
+            controllerId: flowParams.controllerId,
+            goal: flowParams.goal,
+            ...(flowParams.stateJson !== undefined ? { stateJson: flowParams.stateJson } : {}),
+            ...(flowParams.currentStep ? { currentStep: flowParams.currentStep } : {}),
+            ...(flowParams.waitingStep ? { waitingStep: flowParams.waitingStep } : {}),
+          }),
+        );
+      }
+      if (flowParams?.action === "resume") {
+        return resolveManagedFlowToolResult(
+          await resumeManagedLobsterFlow({
+            taskFlow: requireTaskFlowRuntime(taskFlow, "resume"),
+            runner,
+            runnerParams: flowParams.runnerParams,
+            flowId: flowParams.flowId,
+            expectedRevision: flowParams.expectedRevision,
+            ...(flowParams.currentStep ? { currentStep: flowParams.currentStep } : {}),
+            ...(flowParams.waitingStep ? { waitingStep: flowParams.waitingStep } : {}),
+          }),
+        );
       }
 
       const envelope = await runner.run(runnerParams);


### PR DESCRIPTION
## What Problem This Solves

Lobster's managed-flow run and resume paths separately owned admission and dispatch policy. That duplication made neutral defaults, cross-action validation, and resume credentials vulnerable to semantic drift as either path evolved.

## Why This Change Was Made

This change makes one local action-discriminated parser the canonical owner while retaining separate run and resume validation branches and separate TaskFlow lifecycle execution. It removes the unsafe resume-parameter cast without changing the flat tool schema or public fields.

## User Impact

No user-visible behavior change is intended. Existing ordinary and managed Lobster workflows keep their current defaults, validation order, errors, and lifecycle behavior.

## Evidence

- All three focused Lobster suites passed: 66/66 tests.
- Targeted formatting, lint, assertion-safety ratchet, dead-export, privacy, and diff checks passed.
- Autoreview completed cleanly with no findings and 0.98 correctness confidence.
- Production LOC: +81/-87, net -6.
- Tests: +102/-48.
- The broader changed typecheck is not counted as proof because the linked dependency install is stale for unrelated CUA, Markdown, Crabline, and TUI surfaces. It reported no Lobster diagnostics.
