### PR TITLE
fix(ollama): cancelled cloud setup continues and returns credentials

### DIFF
--- a/extensions/ollama/src/setup.cancellation.test.ts
+++ b/extensions/ollama/src/setup.cancellation.test.ts
@@ -3,10 +3,12 @@ import { requestUrl } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { promptAndConfigureOllama } from "./setup.js";
 
-function createLocalPrompter(): WizardPrompter {
+function createOllamaSetupPrompter(mode: "local-only" | "cloud-only"): WizardPrompter {
   return {
-    select: vi.fn().mockResolvedValueOnce("local-only"),
-    text: vi.fn().mockResolvedValueOnce("http://127.0.0.1:11434"),
+    select: vi.fn().mockResolvedValueOnce(mode),
+    text: vi
+      .fn()
+      .mockResolvedValueOnce(mode === "cloud-only" ? "test-ollama-key" : "http://127.0.0.1:11434"),
     note: vi.fn(async () => undefined),
   } as unknown as WizardPrompter;
 }
@@ -22,40 +24,55 @@ describe("Ollama setup cancellation", () => {
     vi.unstubAllGlobals();
   });
 
-  it("aborts pending model discovery with the setup session", async () => {
-    const controller = new AbortController();
-    let markTagsStarted!: () => void;
-    const tagsStarted = new Promise<void>((resolve) => {
-      markTagsStarted = resolve;
-    });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-        if (!requestUrl(input).endsWith("/api/tags")) {
-          throw new Error(`Unexpected fetch: ${requestUrl(input)}`);
-        }
-        markTagsStarted();
-        return await new Promise<Response>((_resolve, reject) => {
-          const signal = init?.signal;
-          if (!signal) {
-            reject(new Error("expected model discovery abort signal"));
-            return;
+  it.each(["local-only", "cloud-only"] as const)(
+    "aborts pending %s model discovery with the setup session",
+    async (mode) => {
+      const controller = new AbortController();
+      let markTagsStarted!: () => void;
+      let rejectPendingFetch!: (reason: Error) => void;
+      let requestSignal: AbortSignal | undefined;
+      const tagsStarted = new Promise<void>((resolve) => {
+        markTagsStarted = resolve;
+      });
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+          if (!requestUrl(input).endsWith("/api/tags")) {
+            throw new Error(`Unexpected fetch: ${requestUrl(input)}`);
           }
-          signal.addEventListener("abort", () => reject(abortReasonAsError(signal)), {
-            once: true,
+          markTagsStarted();
+          return await new Promise<Response>((_resolve, reject) => {
+            rejectPendingFetch = reject;
+            const signal = init?.signal;
+            requestSignal = signal;
+            if (!signal) {
+              reject(new Error("expected model discovery abort signal"));
+              return;
+            }
+            signal.addEventListener("abort", () => reject(abortReasonAsError(signal)), {
+              once: true,
+            });
           });
-        });
-      }),
-    );
+        }),
+      );
 
-    const setup = promptAndConfigureOllama({
-      cfg: {},
-      prompter: createLocalPrompter(),
-      signal: controller.signal,
-    });
-    await tagsStarted;
-    controller.abort();
+      const setup = promptAndConfigureOllama({
+        cfg: {},
+        env: {},
+        prompter: createOllamaSetupPrompter(mode),
+        allowSecretRefPrompt: false,
+        signal: controller.signal,
+      });
+      await tagsStarted;
+      controller.abort();
 
-    await expect(setup).rejects.toMatchObject({ name: "AbortError" });
-  });
+      try {
+        expect(requestSignal?.aborted).toBe(true);
+        await expect(setup).rejects.toMatchObject({ name: "AbortError" });
+      } finally {
+        rejectPendingFetch(new Error("Ollama test completed"));
+        await setup.catch(() => undefined);
+      }
+    },
+  );
 });

--- a/extensions/ollama/src/setup.cancellation.test.ts
+++ b/extensions/ollama/src/setup.cancellation.test.ts
@@ -44,7 +44,7 @@ describe("Ollama setup cancellation", () => {
           return await new Promise<Response>((_resolve, reject) => {
             rejectPendingFetch = reject;
             const signal = init?.signal;
-            requestSignal = signal;
+            requestSignal = signal ?? undefined;
             if (!signal) {
               reject(new Error("expected model discovery abort signal"));
               return;

--- a/extensions/ollama/src/setup.runtime.ts
+++ b/extensions/ollama/src/setup.runtime.ts
@@ -53,7 +53,7 @@ const OLLAMA_SUGGESTED_MODELS_CLOUD = OLLAMA_CLOUD_DEFAULT_MODELS.map((model) =>
 const OLLAMA_SUGGESTED_MODELS_LOCAL_CLOUD = OLLAMA_CLOUD_DEFAULT_MODELS.map(
   (model) => `${model.id}:cloud`,
 );
-const OLLAMA_CLOUD_MAX_DISCOVERED_MODELS = 500;
+const OLLAMA_CLOUD_MODEL_CAP = 500;
 const OLLAMA_RECOMMENDED_TOOLS_MODEL = "gemma4:e4b";
 const OLLAMA_RECOMMENDED_TOOLS_MODEL_SIZE = "about 9.6 GB";
 
@@ -414,11 +414,11 @@ export async function promptAndConfigureOllama(params: {
       secretInputMode: params.secretInputMode,
       allowSecretRefPrompt: params.allowSecretRefPrompt,
     });
-    const { models: rawDiscoveredModels } = await fetchOllamaModels(OLLAMA_CLOUD_BASE_URL, {
+    const { models } = await fetchOllamaModels(OLLAMA_CLOUD_BASE_URL, {
       apiKey: discoveryApiKey,
+      signal: params.signal,
     });
-    const discoveredModels = rawDiscoveredModels.slice(0, OLLAMA_CLOUD_MAX_DISCOVERED_MODELS);
-    const discoveredModelNames = discoveredModels.map((model) => model.name);
+    const discoveredModelNames = models.slice(0, OLLAMA_CLOUD_MODEL_CAP).map((model) => model.name);
     const modelNames =
       discoveredModelNames.length > 0
         ? mergeUniqueModelNames(OLLAMA_SUGGESTED_MODELS_CLOUD, discoveredModelNames)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users cancelling Ollama cloud-only setup would still wait for the hosted model catalog and could receive completed credentials and provider configuration after setup had already been cancelled.

## Why This Change Was Made

Cloud-only model discovery now receives the setup session's existing cancellation signal, exactly like local Ollama discovery. The provider-owned flow remains canonical, preserves the existing 500-model limit, and changes no authentication or configuration contracts. Production code is line-neutral.

## User Impact

Cancelling Ollama cloud setup immediately cancels its pending hosted model request and exits without accepting the cancelled setup result.

## Evidence

- Authentic pre-fix owner regression: local cancellation passed while cloud cancellation failed because its actual fetch signal remained un-aborted.
- Actual cloud setup before: pending request survived cancellation and returned credential plus provider configuration. After: pending request aborts and setup rejects with `AbortError`.
- `node scripts/run-vitest.mjs extensions/ollama/src/setup.cancellation.test.ts extensions/ollama/src/setup.test.ts extensions/ollama/src/setup.non-interactive-auth.test.ts extensions/ollama/src/setup-model-selection.test.ts extensions/ollama/src/provider-models.test.ts`: **5 files, 95 tests passed**.
- Focused type-aware lint, formatting, and independent whole-change review passed.
- Production LOC: **+4/-4, net 0**; tests: **+52/-35**.
