### PR TITLE
fix(plugins): TypeScript plugins load the wrong compiled module

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -1505,6 +1505,69 @@ describe("discoverOpenClawPlugins", () => {
     },
   );
 
+  it.each([
+    {
+      name: "keeps standard TypeScript on JavaScript output",
+      sourceExtension: ".ts",
+      availableExtensions: [".js", ".mjs", ".cjs"],
+      expectedExtension: ".js",
+    },
+    {
+      name: "prefers ECMAScript output for ECMAScript TypeScript",
+      sourceExtension: ".mts",
+      availableExtensions: [".js", ".mjs", ".cjs"],
+      expectedExtension: ".mjs",
+    },
+    {
+      name: "prefers CommonJS output for CommonJS TypeScript",
+      sourceExtension: ".cts",
+      availableExtensions: [".js", ".mjs", ".cjs"],
+      expectedExtension: ".cjs",
+    },
+    {
+      name: "retains JavaScript fallback when ECMAScript output is absent",
+      sourceExtension: ".mts",
+      availableExtensions: [".js", ".cjs"],
+      expectedExtension: ".js",
+    },
+    {
+      name: "retains JavaScript fallback when CommonJS output is absent",
+      sourceExtension: ".cts",
+      availableExtensions: [".js", ".mjs"],
+      expectedExtension: ".js",
+    },
+  ])(
+    "matches inferred plugin and setup runtimes to source module flavor: $name",
+    async ({ sourceExtension, availableExtensions, expectedExtension }) => {
+      const stateDir = makeTempDir();
+      const pluginDir = path.join(stateDir, "extensions", "runtime-flavor-pack");
+      mkdirSafe(path.join(pluginDir, "src"));
+      mkdirSafe(path.join(pluginDir, "dist"));
+
+      writePluginPackageManifest({
+        packageDir: pluginDir,
+        packageName: "@openclaw/runtime-flavor-pack",
+        extensions: [`./src/index${sourceExtension}`],
+        setupEntry: `./src/setup-entry${sourceExtension}`,
+      });
+      writePluginEntry(path.join(pluginDir, "src", `index${sourceExtension}`));
+      writePluginEntry(path.join(pluginDir, "src", `setup-entry${sourceExtension}`));
+      for (const extension of availableExtensions) {
+        writePluginEntry(path.join(pluginDir, "dist", `index${extension}`));
+        writePluginEntry(path.join(pluginDir, "dist", `setup-entry${extension}`));
+      }
+
+      const { candidates } = await discoverWithStateDir(stateDir, {});
+      const candidate = requireCandidateById(candidates, "runtime-flavor-pack");
+      expect(fs.realpathSync(candidate.source)).toBe(
+        fs.realpathSync(path.join(pluginDir, "dist", `index${expectedExtension}`)),
+      );
+      expect(fs.realpathSync(candidate.setupSource ?? "")).toBe(
+        fs.realpathSync(path.join(pluginDir, "dist", `setup-entry${expectedExtension}`)),
+      );
+    },
+  );
+
   it("uses explicit runtime extension entries for installed package plugins", async () => {
     const stateDir = makeTempDir();
     const pluginDir = path.join(stateDir, "extensions", "runtime-pack");

--- a/src/plugins/package-entrypoints.ts
+++ b/src/plugins/package-entrypoints.ts
@@ -18,11 +18,9 @@ export function listBuiltRuntimeEntryCandidates(entryPath: string): string[] {
   const distWithoutExtension = normalizedRelative.startsWith("src/")
     ? `./dist/${normalizedRelative.slice("src/".length).replace(/\.[^.]+$/u, "")}`
     : `./dist/${withoutExtension.replace(/^\.\//u, "")}`;
-  const withJavaScriptExtensions = (basePath: string) => [
-    `${basePath}.js`,
-    `${basePath}.mjs`,
-    `${basePath}.cjs`,
-  ];
+  const preferredOutputExtension = path.extname(normalized).toLowerCase().replace("t", "j");
+  const withJavaScriptExtensions = (basePath: string) =>
+    [preferredOutputExtension, ".js", ".mjs", ".cjs"].map((extension) => `${basePath}${extension}`);
   const candidates = [
     ...withJavaScriptExtensions(distWithoutExtension),
     ...withJavaScriptExtensions(withoutExtension),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where installed plugins authored as `.mts` or `.cts` could silently load a neighboring `.js` artifact instead of their matching `.mjs` or `.cjs` build, affecting both normal plugin startup and setup entrypoints.

## Why This Change Was Made

The shared plugin entrypoint owner now prioritizes the JavaScript module flavor produced by the declared TypeScript source while retaining the existing fallback candidates and ordinary `.ts` ordering. Runtime discovery and setup both consume the same corrected owner. Production code shrinks by two lines.

## User Impact

Plugins with multiple compiled artifacts now consistently launch the build matching their declared ESM or CommonJS source, instead of loading the wrong artifact or failing under the wrong module system.

## Evidence

- Inspected TypeScript's real compiler output-extension contract: `.mts` emits `.mjs`; `.cts` emits `.cjs`.
- Authentic real-filesystem discovery table failed on both `.mts` and `.cts` before the fix; all five source/fallback variants pass afterward.
- Real production runtime and setup resolvers previously selected an existing package's `index.js` over its valid `index.mjs`; both now select `index.mjs`.
- Affected runtime/setup sibling group: **15 tests passed**; real install boundary: **9 passed**; package-manifest contracts: **47 passed**.
- Formatting, focused type-aware lint, and independent whole-change review passed.
- Production LOC: **+3/-5, net -2**; tests: **+63**.
