### PR TITLE
fix(android): preserve background location during onboarding

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -15,6 +15,7 @@ import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.i18n.nativeText
 import ai.openclaw.app.i18n.resolveNativeTextResource
 import ai.openclaw.app.i18n.verbatimText
+import ai.openclaw.app.locationModeAfterBackgroundSettings
 import ai.openclaw.app.node.DeviceNotificationListenerService
 import ai.openclaw.app.photoReadPermissionsForRequest
 import ai.openclaw.app.ui.design.ClawDesignTheme
@@ -3310,6 +3311,16 @@ private fun rememberPermissionState(
       },
     )
 
+  val requestedLocationMode =
+    locationModeAfterBackgroundSettings(
+      previousMode = currentLocationMode.takeUnless { it == LocationMode.Off } ?: LocationMode.WhileUsing,
+      foregroundGranted = locationGranted,
+      backgroundGranted =
+        currentLocationMode == LocationMode.Always &&
+          SensitiveFeatureConfig.backgroundLocationEnabled &&
+          hasPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION),
+    )
+
   return PermissionState(
     rows = rows,
     requiresNodeApprovalAfterApply =
@@ -3317,13 +3328,13 @@ private fun rememberPermissionState(
         currentCameraEnabled = currentCameraEnabled,
         requestedCameraEnabled = cameraGranted,
         currentLocationMode = currentLocationMode,
-        requestedLocationMode = if (locationGranted) LocationMode.WhileUsing else LocationMode.Off,
+        requestedLocationMode = requestedLocationMode,
         currentSmsGranted = currentSmsGranted,
         requestedSmsGranted = smsGranted,
       ),
     applyToViewModel = {
       viewModel.setCameraEnabled(cameraGranted)
-      viewModel.setLocationMode(if (locationGranted) LocationMode.WhileUsing else LocationMode.Off)
+      viewModel.setLocationMode(requestedLocationMode)
       viewModel.setNotificationForwardingEnabled(notificationListenerGranted)
     },
   )

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -228,6 +228,31 @@ class OnboardingFlowLogicTest {
         currentLocationMode = LocationMode.WhileUsing,
         requestedLocationMode = LocationMode.WhileUsing,
       ),
+      PermissionApprovalCase(
+        expected = false,
+        currentLocationMode = LocationMode.Always,
+        requestedLocationMode = LocationMode.Always,
+      ),
+      PermissionApprovalCase(
+        expected = true,
+        currentLocationMode = LocationMode.Always,
+        requestedLocationMode = LocationMode.WhileUsing,
+      ),
+      PermissionApprovalCase(
+        expected = true,
+        currentLocationMode = LocationMode.Always,
+        requestedLocationMode = LocationMode.Off,
+      ),
+      PermissionApprovalCase(
+        expected = true,
+        currentLocationMode = LocationMode.WhileUsing,
+        requestedLocationMode = LocationMode.Always,
+      ),
+      PermissionApprovalCase(
+        expected = true,
+        currentLocationMode = LocationMode.Off,
+        requestedLocationMode = LocationMode.Always,
+      ),
     ).forEach { case ->
       assertBoolean(
         case.expected,


### PR DESCRIPTION
## Problem

The standalone Android app can already have its user-selected `Always` location mode and genuine Android foreground/background location grants when someone pairs another Gateway. Onboarding's permission owner flattened every granted location mode to `WhileUsing` twice: once when deciding whether the node needs renewed approval, and again when persisting the final settings.

Continuing setup therefore silently discarded an authorized background-location preference and stranded an already-approved device on an unnecessary **Approve node access** screen. Google Play does not offer background location and must continue clamping that mode.

## What changed

- Reuse the existing `locationModeAfterBackgroundSettings` owner to compute one location mode shared by approval detection and persistence.
- Preserve `Always` only when it was already selected, the standalone flavor enables background location, and Android currently grants `ACCESS_BACKGROUND_LOCATION`.
- Keep fresh foreground access at `WhileUsing`, never promote an existing `Off`/`WhileUsing` choice, and downgrade revoked background access to `WhileUsing` with genuine approval intact.
- Extend the existing onboarding approval table with unchanged `Always`, authorized downgrades, and attempted promotions.

Production: **+13/-2 (net +11)**, required for the explicit OS permission/flavor/consent boundary and one canonical value for both owner consumers. Tests: **+25/-0**.

## Evidence

The unchanged standalone APK and the repaired APK ran against the same real Android 36 emulator, real `ACCESS_COARSE_LOCATION`/`ACCESS_FINE_LOCATION`/`ACCESS_BACKGROUND_LOCATION` grants, an already-approved Gateway, the existing persisted `Always` preference, and the real onboarding **Continue** action.

**Before:** actual onboarding reopened node approval, persisted `WhileUsing`, and did not complete.

![Standalone Android before: unnecessary node approval after silently downgrading Always location](https://github.com/user-attachments/assets/96b84624-9f29-44d5-be02-f84c3486bcc4)

**After:** actual onboarding returned to Chat, preserved `Always`, and completed.

![Standalone Android after: onboarding completes into Chat while preserving approved Always location](https://github.com/user-attachments/assets/14acb7c6-d74d-45bb-b8ba-8d5aed307526)

**Revoked-permission control:** actually revoked `ACCESS_BACKGROUND_LOCATION` while keeping foreground permissions granted; the repaired app correctly persisted `WhileUsing` and required node approval. No permission is added, requested, or elevated.

## Validation

- Real standalone Android instrumentation: unchanged failure, repaired preservation, and actual background-permission revocation all verified.
- `:app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest`: **63 passed**.
- `:app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest`: **63 passed**.
- `:app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck`: **passed**.
- Combined full validation: **126 successful Gradle tasks**.
- Independent authenticated review: clean.
