### PR TITLE
fix(node): broken Node service suggests repairing the Gateway

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -24,6 +24,12 @@ const loadConfig = vi.fn<() => OpenClawConfig>(() => ({
 const writeGatewayRestartIntentSync = vi.fn();
 const clearGatewayRestartIntentSync = vi.fn();
 const appendGatewayLifecycleAudit = vi.fn();
+const SERVICE_REPAIR_COMMAND_CASES = [
+  ["Gateway", "", "", "openclaw gateway"],
+  ["Node", "", "", "openclaw node"],
+  ["Node", "work", "", "openclaw --profile work node"],
+  ["Node", "work", "demo", "openclaw --container demo node"],
+] as const;
 const createGatewayLifecycleMutationAudit = vi.fn(
   (params: { action: string; source?: string }) => (mutation: { mode: string; pid?: number }) =>
     appendGatewayLifecycleAudit({
@@ -777,46 +783,54 @@ describe("runServiceRestart token drift", () => {
     expect(appendGatewayLifecycleAudit).not.toHaveBeenCalled();
   });
 
-  it("warns in json when an already-running gateway definition needs repair", async () => {
-    service.readRuntime.mockResolvedValue({ status: "running", pid: 4242 });
-    service.readCommand.mockResolvedValue({
-      programArguments: ["openclaw", "gateway", "--port", "18789"],
-    });
+  it.each(SERVICE_REPAIR_COMMAND_CASES)(
+    "warns in json with the correct %s service restart command",
+    async (serviceNoun, profile, container, command) => {
+      vi.stubEnv("OPENCLAW_PROFILE", profile);
+      vi.stubEnv("OPENCLAW_CONTAINER_HINT", container);
+      service.readRuntime.mockResolvedValue({ status: "running", pid: 4242 });
+      service.readCommand.mockResolvedValue({
+        programArguments: ["openclaw", serviceNoun.toLowerCase(), "--port", "18789"],
+      });
 
-    await runServiceStart({ ...createServiceRunArgs(), expectedPort: 19_001 });
+      await runServiceStart({ ...createServiceRunArgs(), serviceNoun, expectedPort: 19_001 });
 
-    const payload = readJsonLog<{ result?: string; warnings?: string[] }>();
-    expect(payload.result).toBe("already-running");
-    expect(payload.warnings).toEqual([
-      expect.stringMatching(
-        /^Gateway service already running, but its installed service definition needs repair: service port 18789 does not match current gateway config port 19001; run `openclaw gateway restart` to apply\.$/,
-      ),
-    ]);
-    expect(service.start).not.toHaveBeenCalled();
-  });
+      const payload = readJsonLog<{ result?: string; warnings?: string[] }>();
+      expect(payload.result).toBe("already-running");
+      expect(payload.warnings).toEqual([
+        `${serviceNoun} service already running, but its installed service definition needs repair: service port 18789 does not match current gateway config port 19001; run \`${command} restart\` to apply.`,
+      ]);
+      expect(service.start).not.toHaveBeenCalled();
+    },
+  );
 
-  it("prints one warning line when an already-running gateway definition needs repair", async () => {
-    service.readRuntime.mockResolvedValue({ status: "running", pid: 4242 });
-    service.readCommand.mockResolvedValue({
-      programArguments: ["openclaw", "gateway", "--port", "18789"],
-    });
+  it.each(["Gateway", "Node"])(
+    "prints one warning line when an already-running %s service needs repair",
+    async (serviceNoun) => {
+      service.readRuntime.mockResolvedValue({ status: "running", pid: 4242 });
+      service.readCommand.mockResolvedValue({
+        programArguments: ["openclaw", serviceNoun.toLowerCase(), "--port", "18789"],
+      });
 
-    await runServiceStart({
-      serviceNoun: "Gateway",
-      service,
-      renderStartHints: () => [],
-      expectedPort: 19_001,
-    });
+      await runServiceStart({
+        serviceNoun,
+        service,
+        renderStartHints: () => [],
+        expectedPort: 19_001,
+      });
 
-    const repairWarnings = lifecycleRuntimeLogs.filter((line) =>
-      line.startsWith(
-        "Gateway service already running, but its installed service definition needs repair:",
-      ),
-    );
-    expect(repairWarnings).toHaveLength(1);
-    expect(repairWarnings[0]).toContain("run `openclaw gateway restart` to apply.");
-    expect(service.start).not.toHaveBeenCalled();
-  });
+      const repairWarnings = lifecycleRuntimeLogs.filter((line) =>
+        line.startsWith(
+          `${serviceNoun} service already running, but its installed service definition needs repair:`,
+        ),
+      );
+      expect(repairWarnings).toHaveLength(1);
+      expect(repairWarnings[0]).toContain(
+        `run \`openclaw ${serviceNoun.toLowerCase()} restart\` to apply.`,
+      );
+      expect(service.start).not.toHaveBeenCalled();
+    },
+  );
 
   it("audits a service start that actually mutates the gateway", async () => {
     service.start.mockImplementationOnce(async (args?: GatewayServiceControlArgs) => {
@@ -936,21 +950,43 @@ describe("runServiceRestart token drift", () => {
     expect(payload.service?.loaded).toBe(true);
   });
 
-  it("fails start with an install hint when port drift has no repair callback", async () => {
-    service.readCommand.mockResolvedValue({
-      programArguments: ["openclaw", "gateway", "--port", "18789"],
-    });
+  it.each(SERVICE_REPAIR_COMMAND_CASES)(
+    "fails %s service start with its own install hint when repair is required",
+    async (serviceNoun, profile, container, command) => {
+      vi.stubEnv("OPENCLAW_PROFILE", profile);
+      vi.stubEnv("OPENCLAW_CONTAINER_HINT", container);
+      service.readCommand.mockResolvedValue({
+        programArguments: ["openclaw", serviceNoun.toLowerCase(), "--port", "18789"],
+      });
 
-    await expect(
-      runServiceStart({ ...createServiceRunArgs(), expectedPort: 19_001 }),
-    ).rejects.toThrow("__exit__:1");
+      await expect(
+        runServiceStart({ ...createServiceRunArgs(), serviceNoun, expectedPort: 19_001 }),
+      ).rejects.toThrow("__exit__:1");
 
-    const payload = readJsonLog<{ ok?: boolean; error?: string; hints?: string[] }>();
-    expect(payload.ok).toBe(false);
-    expect(payload.error).toContain("service needs repair");
-    expect(payload.hints).toEqual(["openclaw gateway install --force"]);
-    expect(service.start).not.toHaveBeenCalled();
-  });
+      const payload = readJsonLog<{
+        ok?: boolean;
+        error?: string;
+        hints?: string[];
+        hintItems?: Array<{ kind: string; text: string }>;
+      }>();
+      expect(payload.ok).toBe(false);
+      expect(payload.error).toContain("service needs repair");
+      expect(payload.hints).toEqual([`${command} install --force`]);
+      expect(payload.hintItems).toEqual([{ kind: "install", text: `${command} install --force` }]);
+
+      resetLifecycleRuntimeLogs();
+      await expect(
+        runServiceStart({
+          ...createServiceRunArgs(),
+          serviceNoun,
+          opts: { json: false },
+          expectedPort: 19_001,
+        }),
+      ).rejects.toThrow("__exit__:1");
+      expect(lifecycleRuntimeLogs).toContain(`Tip: ${command} install --force`);
+      expect(service.start).not.toHaveBeenCalled();
+    },
+  );
 
   it("fails start when starting a stopped installed service errors", async () => {
     service.isLoaded.mockResolvedValue(false);

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -24,11 +24,12 @@ const loadConfig = vi.fn<() => OpenClawConfig>(() => ({
 const writeGatewayRestartIntentSync = vi.fn();
 const clearGatewayRestartIntentSync = vi.fn();
 const appendGatewayLifecycleAudit = vi.fn();
+const MISSING_SERVICE_PROGRAM = "/openclaw-test-missing-runtime/node";
 const SERVICE_REPAIR_COMMAND_CASES = [
-  ["Gateway", "", "", "openclaw gateway"],
-  ["Node", "", "", "openclaw node"],
-  ["Node", "work", "", "openclaw --profile work node"],
-  ["Node", "work", "demo", "openclaw --container demo node"],
+  ["Gateway", "", "", "openclaw gateway", "restart"],
+  ["Node", "", "", "openclaw node", "install --force"],
+  ["Node", "work", "", "openclaw --profile work node", "install --force"],
+  ["Node", "work", "demo", "openclaw --container demo node", "install --force"],
 ] as const;
 const createGatewayLifecycleMutationAudit = vi.fn(
   (params: { action: string; source?: string }) => (mutation: { mode: string; pid?: number }) =>
@@ -784,39 +785,46 @@ describe("runServiceRestart token drift", () => {
   });
 
   it.each(SERVICE_REPAIR_COMMAND_CASES)(
-    "warns in json with the correct %s service restart command",
-    async (serviceNoun, profile, container, command) => {
+    "warns in json with the %s service repair command and active context",
+    async (serviceNoun, profile, container, command, repairAction) => {
       vi.stubEnv("OPENCLAW_PROFILE", profile);
       vi.stubEnv("OPENCLAW_CONTAINER_HINT", container);
       service.readRuntime.mockResolvedValue({ status: "running", pid: 4242 });
       service.readCommand.mockResolvedValue({
-        programArguments: ["openclaw", serviceNoun.toLowerCase(), "--port", "18789"],
+        programArguments: [MISSING_SERVICE_PROGRAM, "openclaw", serviceNoun.toLowerCase()],
       });
 
-      await runServiceStart({ ...createServiceRunArgs(), serviceNoun, expectedPort: 19_001 });
+      await runServiceStart({
+        ...createServiceRunArgs(),
+        serviceNoun,
+        repairLoadedService: serviceNoun === "Gateway" ? vi.fn(async () => null) : undefined,
+      });
 
       const payload = readJsonLog<{ result?: string; warnings?: string[] }>();
       expect(payload.result).toBe("already-running");
       expect(payload.warnings).toEqual([
-        `${serviceNoun} service already running, but its installed service definition needs repair: service port 18789 does not match current gateway config port 19001; run \`${command} restart\` to apply.`,
+        `${serviceNoun} service already running, but its installed service definition needs repair: service command points at a missing path: ${MISSING_SERVICE_PROGRAM}; run \`${command} ${repairAction}\` to apply.`,
       ]);
       expect(service.start).not.toHaveBeenCalled();
     },
   );
 
-  it.each(["Gateway", "Node"])(
+  it.each([
+    ["Gateway", "restart"],
+    ["Node", "install --force"],
+  ])(
     "prints one warning line when an already-running %s service needs repair",
-    async (serviceNoun) => {
+    async (serviceNoun, repairAction) => {
       service.readRuntime.mockResolvedValue({ status: "running", pid: 4242 });
       service.readCommand.mockResolvedValue({
-        programArguments: ["openclaw", serviceNoun.toLowerCase(), "--port", "18789"],
+        programArguments: [MISSING_SERVICE_PROGRAM, "openclaw", serviceNoun.toLowerCase()],
       });
 
       await runServiceStart({
         serviceNoun,
         service,
         renderStartHints: () => [],
-        expectedPort: 19_001,
+        repairLoadedService: serviceNoun === "Gateway" ? vi.fn(async () => null) : undefined,
       });
 
       const repairWarnings = lifecycleRuntimeLogs.filter((line) =>
@@ -826,7 +834,7 @@ describe("runServiceRestart token drift", () => {
       );
       expect(repairWarnings).toHaveLength(1);
       expect(repairWarnings[0]).toContain(
-        `run \`openclaw ${serviceNoun.toLowerCase()} restart\` to apply.`,
+        `run \`openclaw ${serviceNoun.toLowerCase()} ${repairAction}\` to apply.`,
       );
       expect(service.start).not.toHaveBeenCalled();
     },
@@ -956,12 +964,12 @@ describe("runServiceRestart token drift", () => {
       vi.stubEnv("OPENCLAW_PROFILE", profile);
       vi.stubEnv("OPENCLAW_CONTAINER_HINT", container);
       service.readCommand.mockResolvedValue({
-        programArguments: ["openclaw", serviceNoun.toLowerCase(), "--port", "18789"],
+        programArguments: [MISSING_SERVICE_PROGRAM, "openclaw", serviceNoun.toLowerCase()],
       });
 
-      await expect(
-        runServiceStart({ ...createServiceRunArgs(), serviceNoun, expectedPort: 19_001 }),
-      ).rejects.toThrow("__exit__:1");
+      await expect(runServiceStart({ ...createServiceRunArgs(), serviceNoun })).rejects.toThrow(
+        "__exit__:1",
+      );
 
       const payload = readJsonLog<{
         ok?: boolean;
@@ -980,7 +988,6 @@ describe("runServiceRestart token drift", () => {
           ...createServiceRunArgs(),
           serviceNoun,
           opts: { json: false },
-          expectedPort: 19_001,
         }),
       ).rejects.toThrow("__exit__:1");
       expect(lifecycleRuntimeLogs).toContain(`Tip: ${command} install --force`);

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -212,6 +212,7 @@ export async function runServiceStart(params: {
   expectedPort?: number;
 }) {
   const json = Boolean(params.opts?.json);
+  const serviceCommand = formatCliCommand(`openclaw ${params.serviceNoun.toLowerCase()}`);
   const { stdout, warnings, emit, fail } = createDaemonActionContext({ action: "start", json });
   const warn = json ? (message: string) => warnings.push(message) : undefined;
   const loaded = await resolveServiceLoadedOrFail({
@@ -254,8 +255,7 @@ export async function runServiceStart(params: {
         return;
       }
     } catch (err) {
-      const hints = params.renderStartHints();
-      fail(`${params.serviceNoun} start failed: ${String(err)}`, hints);
+      fail(`${params.serviceNoun} start failed: ${String(err)}`, params.renderStartHints());
       return;
     }
   }
@@ -286,7 +286,7 @@ export async function runServiceStart(params: {
       if (startResult.issues.length > 0) {
         const warning = `${params.serviceNoun} service already running, but its installed service definition needs repair: ${startResult.issues
           .map((issue) => issue.message)
-          .join("; ")}; run \`openclaw gateway restart\` to apply.`;
+          .join("; ")}; run \`${serviceCommand} restart\` to apply.`;
         warnings.push(warning);
         if (!json) {
           defaultRuntime.log(warning);
@@ -330,15 +330,14 @@ export async function runServiceStart(params: {
           return;
         }
       } catch (err) {
-        const hints = params.renderStartHints();
-        fail(`${params.serviceNoun} repair failed: ${String(err)}`, hints);
+        fail(`${params.serviceNoun} repair failed: ${String(err)}`, params.renderStartHints());
         return;
       }
       fail(
         `${params.serviceNoun} service needs repair before it can start: ${startResult.issues
           .map((issue) => issue.message)
           .join("; ")}`,
-        [formatCliCommand("openclaw gateway install --force")],
+        [`${serviceCommand} install --force`],
       );
       return;
     }
@@ -350,8 +349,7 @@ export async function runServiceStart(params: {
       warnings: warnings.length ? warnings : undefined,
     });
   } catch (err) {
-    const hints = params.renderStartHints();
-    fail(`${params.serviceNoun} start failed: ${String(err)}`, hints);
+    fail(`${params.serviceNoun} start failed: ${String(err)}`, params.renderStartHints());
   }
 }
 

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -284,9 +284,11 @@ export async function runServiceStart(params: {
     }
     if (startResult.outcome === "already-running") {
       if (startResult.issues.length > 0) {
+        // Only services with a repair callback can rebuild their definition during restart.
+        const repairAction = params.repairLoadedService ? "restart" : "install --force";
         const warning = `${params.serviceNoun} service already running, but its installed service definition needs repair: ${startResult.issues
           .map((issue) => issue.message)
-          .join("; ")}; run \`${serviceCommand} restart\` to apply.`;
+          .join("; ")}; run \`${serviceCommand} ${repairAction}\` to apply.`;
         warnings.push(warning);
         if (!json) {
           defaultRuntime.log(warning);


### PR DESCRIPTION
## What Problem This Solves

The shared service-start code told operators to repair the Gateway when the broken installed service was a Node host. The earlier version of this PR changed the running-service hint to `node restart`, but native testing showed that restart does not rebuild a stale Node service definition: it retains the missing executable and can leave the service failed.

Both stopped and already-running Node services now recommend `openclaw node install --force` when their installed definition needs repair. Gateway keeps its existing recovery commands.

## Why This Change Was Made

The fix stays in the shared lifecycle message owner. It derives the service command through the existing profile/container-aware formatter and selects restart only when the caller supplies the repair callback that can rebuild the definition. Node has no such callback; Gateway does. Redundant hint temporaries are removed, and structured install hints retain `kind=install`. No service lifecycle behavior, profile selection, or ownership guard changes.

Source at `32f18a840e4c1ddfff77639154d50790756ffef3`:

- [Shared start/recovery owner](https://github.com/openclaw/openclaw/blob/32f18a840e4c1ddfff77639154d50790756ffef3/src/cli/daemon-cli/lifecycle-core.ts#L285).
- [Node start/restart callers](https://github.com/openclaw/openclaw/blob/32f18a840e4c1ddfff77639154d50790756ffef3/src/cli/node-cli/daemon.ts#L240), [Node install owner](https://github.com/openclaw/openclaw/blob/32f18a840e4c1ddfff77639154d50790756ffef3/src/cli/node-cli/daemon.ts#L112), and [native systemd lifecycle](https://github.com/openclaw/openclaw/blob/32f18a840e4c1ddfff77639154d50790756ffef3/src/daemon/systemd-lifecycle.ts#L41).
- [Gateway sibling repair callback](https://github.com/openclaw/openclaw/blob/32f18a840e4c1ddfff77639154d50790756ffef3/src/cli/daemon-cli/lifecycle.ts#L484).

Combined delta against `18c801daa1165f0bb7f30576b52f6642ff023233`: production **+8/-8, net 0**; tests **+91/-48, net +43**. Only the lifecycle owner and its existing test file change.

## Verification

- Fail-first against the previous PR patch: four regression failures expected Node `install --force` but received `restart`. Tests now use an actually missing executable, without supplying the artificial `expectedPort` that the real Node caller never passes.
- Lifecycle, response, Node daemon, Node registration, and profile suites: **188 tests passed**. The final test-title clarification was followed by another **46/46** lifecycle pass; these are a rerun, not additional unique tests.
- Full local changed-file gate: **passed**, including formatting, core production/core-test typechecks, type-aware changed-file lint, guards, Knip, and zero runtime import cycles. The first attempt resolved the wrong transitive Pako version because this worktree lacked its UI workspace dependency link; linking the matching private pinned install fixed the setup, without changing dependencies or source.
- Fresh combined Codex autoreview: no accepted/actionable findings. Root review also checked the complete two-file change and the final test-title-only edit.
- Pinned-dependency Linux `pnpm build`: passed. Actual native-service proof and an independent source-blind operator validation both passed. The runtime contains the production bytes in the published head; the final subsequent source edit only clarified a test title.

The native proof used [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/33032800341), a dedicated disposable OS account with its canonical HOME/state and systemd user manager, and a credential-free environment. A task-owned executable was started by a real native unit and then deleted while its process remained running. No operator services were used. This proves the missing-executable recovery path; it is not provider, Gateway connectivity, or package-publication proof.

### Native CLI and service evidence

Redacted excerpts from the captured native runs; isolated paths/PIDs are replaced and unrelated output fields are omitted. `openclaw` was invoked through the supplied built CLI executable. The old and new commands were exercised on the candidate's unchanged lifecycle implementation, not on a separately built historical binary.

The earlier proposed command did not repair the definition:

```text
$ openclaw node restart --json
{
  "action": "restart",
  "ok": true,
  "result": "restarted",
  "service": {
    "label": "systemd user",
    "loaded": true,
    "loadedText": "enabled",
    "notLoadedText": "disabled"
  }
}

Captured native observation:
staleDefinitionRetained: true
nativeState: failed
```

The independent operator then followed the new hint exactly, replacing only the executable spelling with the supplied built CLI path:

```text
$ openclaw node start
Node service already running, but its installed service definition needs repair: service command points at a missing path: <isolated-home>/openclaw-node.service-old-runtime; run `openclaw node install --force` to apply.
Node service already running (pid <original-pid>).

$ openclaw node install --force
Installed systemd service: <isolated-home>/.config/systemd/user/openclaw-node.service
Previous unit backed up to: <isolated-home>/.config/systemd/user/openclaw-node.service.bak

$ systemctl --user is-active openclaw-node.service
active

$ systemctl --user show openclaw-node.service ...
MainPID=<repaired-pid>
Id=openclaw-node.service
ActiveState=active
SubState=running

$ systemctl --user cat openclaw-node.service
[Service]
ExecStart=<isolated-home>/bin/node <isolated-home>/runtime/dist/index.js node run --host 127.0.0.1 --port 18789 --no-tls

$ openclaw node start
Node service already running (pid <repaired-pid>).
```

The JSON start also had no repair warning afterward. Native PID, process start time, loaded `ExecStart`, and the on-disk unit were checked independently of CLI success. Before repair, human/JSON starts preserved the original process and definition. Gateway human/JSON starts still recommended `openclaw gateway restart` and retained their original process/definition; Gateway repair was not executed. Profile and container formatting were checked separately and together, with container context winning.

A wrapper unexpectedly synchronized the source checkout despite `--no-sync`, so independent validation paused. The production source hash still matched the built candidate, and all dist mtimes preceded that sync. Validation resumed against a separate copied runtime mounted read-only. Its 11,793-file dist digest matched before copying, after copying, and after validation: `f05c8768990097e5c7b2e05855850d678b67c4102824879cee2001e4ea79b42e`. No pre-sync aggregate digest is claimed.

Cleanup passed: both disposable services, the test accounts, canonical state, runtime copies, and mounts were removed. The Testbox was stopped and its provider status independently read back as `completed`.

## Explicit Scope / Follow-up

**Node named-profile service support and actionable ownership refusal** remains a separate follow-up. The actual `openclaw --profile work node install --force --json` command is rejected by the existing guard:

```text
Node install failed: Error: service management skipped: named profiles cannot override OPENCLAW_SYSTEMD_UNIT for Linux service management. Unset OPENCLAW_SYSTEMD_UNIT so OpenClaw derives the native service identity from OPENCLAW_PROFILE to install or rewrite the gateway service, or keep this profile runtime-only without a native service.
```

The Node adapter supplies the fixed Node service identity itself; unsetting the caller's selector does not remove it. Existing history and the [native install-identity contract](https://docs.openclaw.ai/cli/gateway#install-identity) do not establish named-profile Node service support. This PR does not weaken that guard or discard profile context. **Default native repair is proved; profile command formatting is proved; named-profile installation and actual container dispatch are not claimed.**

## Provenance

The stopped-service Gateway install hint was added in [3b1a020ebaec](https://github.com/openclaw/openclaw/commit/3b1a020ebaecfd788cac6a8b66271603bb20db23), authored and committed by @steipete on 2026-05-02; GitHub returned no associated PR. The running-service Gateway restart warning was added by [#110583](https://github.com/openclaw/openclaw/pull/110583), commit `fab3cdf1d8e2e716e006d6840ba34bcb1d347c4a`, authored by @steipete and merged by @steipete on 2026-07-18. This PR is also authored by @steipete. Provenance was verified through live commit patches/PR metadata because local blame stops at a shallow-history boundary.

The latest ClawSweeper request for current-base focused proof and actual operator output is addressed above. Exact-head hosted CI and the final maintainer landing decision remain required; this body does not claim that the PR is merged.
