### PR TITLE
fix(kilocode): paid default router incorrectly reports zero cost

### DIFF
--- a/extensions/kilocode/provider-models.test.ts
+++ b/extensions/kilocode/provider-models.test.ts
@@ -13,7 +13,11 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   }),
 }));
 
-import { discoverKilocodeModels, KILOCODE_MODELS_URL } from "./provider-models.js";
+import {
+  discoverKilocodeModels,
+  KILOCODE_DEFAULT_COST,
+  KILOCODE_MODELS_URL,
+} from "./provider-models.js";
 
 type MockKilocodeFetch = ((url: string, init?: RequestInit) => Promise<Response>) & {
   mock: { calls: unknown[][] };
@@ -187,6 +191,69 @@ describe("discoverKilocodeModels (fetch path)", () => {
       expect(sonnet.maxTokens).toBe(8192);
     });
   });
+
+  it.each([
+    {
+      label: "negative routing rates with missing cache prices",
+      pricing: { prompt: "-1", completion: "-1" },
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    {
+      label: "unknown routing rates with valid cache prices",
+      pricing: {
+        prompt: "unavailable",
+        completion: "-1",
+        input_cache_read: "0.0000003",
+        input_cache_write: "0.00000375",
+      },
+      cacheRead: 0.3,
+      cacheWrite: 3.75,
+    },
+  ])(
+    "preserves known default-model pricing for $label",
+    async ({ pricing, cacheRead, cacheWrite }) => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: [
+            makeAutoModel({ pricing }),
+            makeGatewayModel({
+              id: "kilo-auto/frontier",
+              pricing: { prompt: "-1", completion: "-1" },
+            }),
+            makeGatewayModel({
+              id: "kilo-auto/free",
+              pricing: {
+                prompt: "0",
+                completion: "0",
+                input_cache_read: "0",
+                input_cache_write: "0",
+              },
+            }),
+          ],
+        }),
+      );
+
+      await withFetchPathTest(mockFetch, async () => {
+        const models = await discoverKilocodeModels();
+
+        expect(requireModelById(models, "kilo-auto/balanced").cost).toEqual({
+          input: KILOCODE_DEFAULT_COST.input,
+          output: KILOCODE_DEFAULT_COST.output,
+          cacheRead,
+          cacheWrite,
+        });
+        for (const id of ["kilo-auto/frontier", "kilo-auto/free"]) {
+          expect(requireModelById(models, id).cost).toEqual({
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+          });
+        }
+      });
+    },
+  );
 
   it("falls back to static catalog on network error", async () => {
     const mockFetch = vi.fn().mockRejectedValue(new Error("network error"));

--- a/extensions/kilocode/provider-models.ts
+++ b/extensions/kilocode/provider-models.ts
@@ -70,15 +70,9 @@ interface GatewayModelEntry {
   supported_parameters?: string[];
 }
 
-function toPricePerMillion(perToken: string | undefined): number {
-  if (!perToken) {
-    return 0;
-  }
+function toPricePerMillion(perToken: string | undefined, fallback = 0): number {
   const num = Number(perToken);
-  if (!Number.isFinite(num) || num < 0) {
-    return 0;
-  }
-  return num * 1_000_000;
+  return Number.isFinite(num) && num >= 0 ? num * 1_000_000 : fallback;
 }
 
 function parseModality(entry: GatewayModelEntry): Array<"text" | "image"> {
@@ -101,14 +95,15 @@ function parseReasoning(entry: GatewayModelEntry): boolean {
 }
 
 function toModelDefinition(entry: GatewayModelEntry): ModelDefinitionConfig {
+  const fallbackCost = entry.id === KILOCODE_DEFAULT_MODEL_ID ? KILOCODE_DEFAULT_COST : undefined;
   return {
     id: entry.id,
     name: entry.name || entry.id,
     reasoning: parseReasoning(entry),
     input: parseModality(entry),
     cost: {
-      input: toPricePerMillion(entry.pricing.prompt),
-      output: toPricePerMillion(entry.pricing.completion),
+      input: toPricePerMillion(entry.pricing.prompt, fallbackCost?.input),
+      output: toPricePerMillion(entry.pricing.completion, fallbackCost?.output),
       cacheRead: toPricePerMillion(entry.pricing.input_cache_read),
       cacheWrite: toPricePerMillion(entry.pricing.input_cache_write),
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Kilo's paid default router was displayed as costing `$0.0000` when its live model catalog returned a dynamic negative price sentinel, despite OpenClaw already having authoritative prices for that default model.

## Why This Change Was Made

The provider-owned price conversion now applies the existing authoritative default-model rates only when that specific default model's dynamic input/output price is invalid or unavailable. Genuine free models remain free, unknown prices on other dynamic routers remain unknown, and cache-rate behavior is unchanged. Simplifying the converter removes five production lines.

## User Impact

Usage estimates for the paid default Kilo router are accurate again without fabricating prices for other routers or changing legitimately free models.

## Evidence

- Real unauthenticated Kilo public catalog and OpenClaw's actual usage formatter: 1 million input plus 1 million output tokens changed from incorrect `$0.0000` to the existing authoritative `$2.27` estimate.
- Actual provider discovery still preserves genuine free models and leaves non-default variable-priced routers unknown.
- `node scripts/run-vitest.mjs extensions/kilocode`: **4 files, 35 tests passed**, including two regressions shown failing before repair.
- Provider documents the paid versus free auto-model tiers and gateway billing behavior: https://kilo.ai/docs/code-with-ai/agents/auto-model and https://kilo.ai/docs/gateway/usage-and-billing.
- Type-aware lint, formatting, and independent whole-change review passed.
- Production LOC: **+5/-10, net -5**; tests: **+68/-1**.
