### PR TITLE
fix(mcp): stop resource access after app grant revocation

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -900,7 +900,7 @@ Notes:
 
 ## MCP Apps
 
-OpenClaw can render tools that implement the stable [MCP Apps extension](https://modelcontextprotocol.io/extensions/apps). Apps are opt-in because their HTML comes from the configured MCP server and can request app-visible tools or resources from that same server.
+OpenClaw can render tools that implement the stable [MCP Apps extension](https://modelcontextprotocol.io/extensions/apps). Apps are opt-in because their HTML comes from the configured MCP server. A view with current App-interaction authority can request app-visible tools and resources from that same server.
 
 Enable the host bridge:
 
@@ -948,8 +948,9 @@ Behavior and security boundaries:
 - Only `ui://` resources with the exact `text/html;profile=mcp-app` MIME type render.
 - UI resources are capped at 2 MiB, placed behind a double-iframe proxy on a dedicated outer origin, loaded into an opaque inner App origin, and constrained by CSP derived from the resource metadata.
 - App-only tools (`_meta.ui.visibility: ["app"]`) stay out of model tool lists. Apps can call only app-visible tools on their owning server that also pass the effective OpenClaw tool policy for the run that created the view.
+- Same-server resource listing and reads require that same current App-interaction authority. OpenClaw rechecks after upstream resource work, so a grant revoked in flight cannot return resource data to the App.
 - Origin-bound App permissions such as camera, microphone, and geolocation are not granted while inner App documents use opaque origins for cross-App isolation.
-- App HTML, complete tool arguments, and raw results live in a bounded ten-minute in-memory view lease and are not written to disk or copied into transcript preview metadata. The transcript stores only a bounded server/tool/resource descriptor tied to the original tool-call ID. After a Gateway restart, the Control UI can verify that descriptor against the authenticated session transcript and refetch the `ui://` resource; reconstructed views are read-only until a fresh run establishes current tool permissions.
+- App HTML, complete tool arguments, and raw results live in a bounded ten-minute in-memory view lease and are not written to disk or copied into transcript preview metadata. The transcript stores only a bounded server/tool/resource descriptor tied to the original tool-call ID. After a Gateway restart, the Control UI can verify that descriptor against the authenticated session transcript and refetch the `ui://` document for display; reconstructed views cannot call tools or use the resource bridge until a fresh run establishes current App-interaction authority.
 - In channel conversations, the latest successful App view in a turn adds one **Open App**-style action to the final assistant reply. Telegram DMs use a native Mini App button; Slack and Discord render the same portable action as a link. Other channels keep the original reply text and append an understandable HTTPS link.
 - Channel launch links are available only when Gateway Tailscale exposure has prepared a published HTTPS origin. `gateway.tailscale.mode: "serve"` is reachable only from the tailnet; password-authenticated `"funnel"` is reachable from the public internet. Externally managed Funnel routes targeting the ordinary Gateway listener must migrate to managed `"funnel"` mode before OpenClaw can publish an internet-reachable origin. See [Tailscale](/gateway/tailscale).
 - Launch tickets are opaque, minted only while materializing the final channel reply, and expire after at most two minutes or when the underlying view lease expires, whichever comes first. The URL does not contain Gateway bearer credentials, session keys, view metadata, App HTML, tool input, or tool results.

--- a/docs/web/dashboard-architecture.md
+++ b/docs/web/dashboard-architecture.md
@@ -156,8 +156,9 @@ Shared infrastructure underneath (this is where the simplification lands):
   the natural case.
 - **One authorization model.** A widget's reach is a granted allowlist,
   whatever its kind: for `html` widgets, host tools; for `mcp-app` widgets,
-  the server's app-visible tools (via the existing `allowedAppToolNames`
-  mechanism, made durable per widget instead of per-minting-run).
+  the server's app-visible tools and same-server resources (via the existing
+  live App-interaction authority, made durable per widget instead of
+  per-minting-run).
 - **Host tools for `html` widgets** (exposed over the widget bridge, checked
   against the grant):
   - `openclaw.prompt.send` — tier 2; routed through the visible composer,
@@ -248,10 +249,11 @@ on staleness). Chat inline MCP app views get the same **Pin to dashboard**
 affordance as agent widgets. Re-opened views are read-only today by design;
 pinned apps that should stay interactive get a durable grant over the server's
 app-visible tools (explicit allowlist shown to the operator on pin), decoupled
-from the minting run. Ungranted pins stay read-only — still useful for display
-dashboards. v1 pins to the originating session's board; cross-session pinning
-needs a lease broker and waits. Coordinate with open PR #109807 (`ui/message`
-composer routing, theme/size propagation).
+from the minting run. Ungranted pins can render their fetched App HTML but
+cannot call tools or access the same-server resource bridge. v1 pins to the
+originating session's board; cross-session pinning needs a lease broker and
+waits. Coordinate with open PR #109807 (`ui/message` composer routing,
+theme/size propagation).
 
 ### WorkBoard integration
 

--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -117,9 +117,9 @@ being interrupted.
 
 If your gateway has MCP servers configured, interactive MCP apps that appear
 in chat can be pinned like any widget. Pinned apps come back to life on the
-board with fresh sessions; by default they are display-only, and granting the
-widget its declared server tools makes it fully interactive — with the same
-one-tap, revision-bound approval as everything else.
+board with fresh sessions. By default they render without server tools or
+same-server resource access. Granting the widget its declared server tools
+enables both bridges while that revision-bound grant remains active.
 
 ## A2UI widgets
 

--- a/src/gateway/mcp-app-operations.ts
+++ b/src/gateway/mcp-app-operations.ts
@@ -178,6 +178,20 @@ export async function withMcpAppActiveView<T>(
   }
 }
 
+async function withMcpAppResourceAuthority<T>(
+  active: McpAppActiveView,
+  operation: () => Promise<T>,
+): Promise<T> {
+  return await withMcpAppActiveView(active, "read", async () => {
+    await requireMcpAppInteraction(active.view);
+    const result = await operation();
+    // Resource results may contain protected data. Recheck after upstream work
+    // so a grant revoked in flight cannot disclose the completed response.
+    await requireMcpAppInteraction(active.view);
+    return result;
+  });
+}
+
 export async function executeMcpAppOperation(
   active: McpAppActiveView,
   operation: McpAppOperation,
@@ -227,7 +241,7 @@ export async function executeMcpAppOperation(
         return result;
       });
     case "resources/list":
-      return await withMcpAppActiveView(active, "read", async () => {
+      return await withMcpAppResourceAuthority(active, async () => {
         if (!runtime.listResources) {
           throw new Error("MCP resources/list is unavailable");
         }
@@ -237,7 +251,7 @@ export async function executeMcpAppOperation(
         return Array.isArray(resources) ? { resources } : resources;
       });
     case "resources/templates/list":
-      return await withMcpAppActiveView(active, "read", async () => {
+      return await withMcpAppResourceAuthority(active, async () => {
         if (!runtime.listResourceTemplates) {
           throw new Error("MCP resources/templates/list is unavailable");
         }
@@ -247,7 +261,7 @@ export async function executeMcpAppOperation(
         );
       });
     case "resources/read":
-      return await withMcpAppActiveView(active, "read", async () => {
+      return await withMcpAppResourceAuthority(active, async () => {
         if (!runtime.readResource) {
           throw new Error("MCP resources/read is unavailable");
         }

--- a/src/gateway/mcp-app-standalone.test.ts
+++ b/src/gateway/mcp-app-standalone.test.ts
@@ -516,9 +516,16 @@ describe("MCP App standalone host", () => {
     expect(runtime.callTool).not.toHaveBeenCalled();
   });
 
-  it("keeps reconstructed views read-only while preserving resource reads", async () => {
+  it("denies resource reads from reconstructed read-only views", async () => {
     Object.assign(view, { readOnly: true });
     const issued = issueTicket({ sessionKey: "agent:main:main", view, nowMs, secret });
+    const payload = await request({
+      url: "/__openclaw__/mcp-app/view",
+      authorization: `MCP-App ${issued.ticket}`,
+    });
+    expect(JSON.parse(String(payload.end.mock.calls[0]?.[0]))).toMatchObject({
+      serverResources: false,
+    });
     const invoke = (body: unknown) =>
       request({
         url: "/__openclaw__/mcp-app/view",
@@ -533,10 +540,11 @@ describe("MCP App standalone host", () => {
     expect(
       (await invoke({ method: "resources/read", params: { uri: "ui://demo/state" } })).res
         .statusCode,
-    ).toBe(200);
+    ).toBe(403);
+    expect(runtime.readResource).not.toHaveBeenCalled();
   });
 
-  it("does not accept standalone tool operations without explicit run authority", async () => {
+  it("does not accept standalone server operations without explicit run authority", async () => {
     Object.assign(view, { allowedAppToolNames: undefined });
     const issued = issueTicket({ sessionKey: "agent:main:main", view, nowMs, secret });
     const invoke = (body: unknown) =>
@@ -555,7 +563,7 @@ describe("MCP App standalone host", () => {
     expect(
       (await invoke({ method: "resources/read", params: { uri: "ui://demo/state" } })).res
         .statusCode,
-    ).toBe(200);
+    ).toBe(403);
     expect(runtime.callTool).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -17,6 +17,7 @@ import {
   executeMcpAppOperation,
   type McpAppActiveView,
   parseMcpAppOperation,
+  requireMcpAppInteraction,
   withMcpAppActiveView,
 } from "./mcp-app-operations.js";
 
@@ -209,6 +210,15 @@ function supportsStandaloneToolOperations(
   // The ticket is the short-lived grant. Tool authority still requires the
   // originating run's explicit allowlist and is revalidated on every request.
   return view.allowedAppToolNames !== undefined && view.readOnly !== true;
+}
+
+async function supportsStandaloneResourceOperations(view: McpAppViewLease): Promise<boolean> {
+  try {
+    await requireMcpAppInteraction(view);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function sendJsonRepresentation(
@@ -685,8 +695,10 @@ export async function handleMcpAppStandaloneHttpRequest(
   }
 
   try {
-    return await withMcpAppActiveView(active, "read", () => {
+    return await withMcpAppActiveView(active, "read", async () => {
       const { runtime, view } = active;
+      const serverResources =
+        runtime.readResource !== undefined && (await supportsStandaloneResourceOperations(view));
       sendJsonRepresentation(req, res, 200, {
         sandboxUrl: buildMcpAppSandboxPath(view.csp),
         sandboxPort,
@@ -696,7 +708,7 @@ export async function handleMcpAppStandaloneHttpRequest(
         toolInput: view.toolInput,
         toolResult: view.toolResult,
         serverTools: supportsStandaloneToolOperations(view),
-        serverResources: runtime.readResource !== undefined,
+        serverResources,
         ...(view.requestTimeoutMs !== undefined
           ? {
               // Keep the browser's outer deadline behind the SDK request

--- a/src/gateway/server-methods/mcp-app.test.ts
+++ b/src/gateway/server-methods/mcp-app.test.ts
@@ -86,6 +86,11 @@ function runtime() {
         },
       ],
     })),
+    listResources: vi.fn(async () => [{ uri: "ui://demo/state", name: "state" }]),
+    listResourceTemplates: vi.fn(async () => ({ resourceTemplates: [] })),
+    readResource: vi.fn(async (_serverName: string, uri: string) => ({
+      contents: [{ uri, text: "resource" }],
+    })),
   };
 }
 
@@ -383,6 +388,8 @@ describe("MCP App gateway bridge", () => {
   });
 
   it("rechecks current widget authority for every interactive capability", async () => {
+    const activeRuntime = runtime();
+    mocks.peekSessionMcpRuntime.mockReturnValue(activeRuntime);
     view.authorizeAppInteraction = vi.fn(async () => false);
     const params = { sessionKey: "agent:main:main", viewId: "cv_app" };
 
@@ -400,8 +407,75 @@ describe("MCP App gateway bridge", () => {
     expect(listed.mock.calls[0]?.[0]).toBe(false);
     const called = await invoke("mcp.app.callTool", { ...params, toolName: "shared" });
     expect(called.mock.calls[0]?.[0]).toBe(false);
-    expect(view.authorizeAppInteraction).toHaveBeenCalledTimes(4);
+    const resources = await invoke("mcp.app.listResources", params);
+    expect(resources.mock.calls[0]?.[0]).toBe(false);
+    const templates = await invoke("mcp.app.listResourceTemplates", params);
+    expect(templates.mock.calls[0]?.[0]).toBe(false);
+    const resource = await invoke("mcp.app.readResource", {
+      ...params,
+      uri: "ui://demo/state",
+    });
+    expect(resource.mock.calls[0]?.[0]).toBe(false);
+    expect(view.authorizeAppInteraction).toHaveBeenCalledTimes(7);
+    expect(activeRuntime.listResources).not.toHaveBeenCalled();
+    expect(activeRuntime.listResourceTemplates).not.toHaveBeenCalled();
+    expect(activeRuntime.readResource).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      capability: "resource list",
+      method: "mcp.app.listResources" as const,
+      params: {},
+      runtimeMethod: "listResources" as const,
+      result: [{ uri: "ui://demo/state", name: "state" }],
+    },
+    {
+      capability: "resource template list",
+      method: "mcp.app.listResourceTemplates" as const,
+      params: {},
+      runtimeMethod: "listResourceTemplates" as const,
+      result: { resourceTemplates: [{ uriTemplate: "ui://demo/{id}", name: "demo" }] },
+    },
+    {
+      capability: "resource read",
+      method: "mcp.app.readResource" as const,
+      params: { uri: "ui://demo/state" },
+      runtimeMethod: "readResource" as const,
+      result: { contents: [{ uri: "ui://demo/state", text: "protected" }] },
+    },
+  ])(
+    "withholds $capability results when widget authority is revoked in flight",
+    async (testCase) => {
+      const resourceStarted = createDeferred();
+      const releaseResource = createDeferred<unknown>();
+      const activeRuntime = runtime();
+      activeRuntime[testCase.runtimeMethod].mockImplementationOnce(async () => {
+        resourceStarted.resolve();
+        return (await releaseResource.promise) as never;
+      });
+      mocks.peekSessionMcpRuntime.mockReturnValue(activeRuntime);
+      let grantActive = true;
+      view.authorizeAppInteraction = vi.fn(async () => grantActive);
+
+      const pending = invoke(testCase.method, {
+        sessionKey: "agent:main:main",
+        viewId: "cv_app",
+        ...testCase.params,
+      });
+      await resourceStarted.promise;
+      expect(view.authorizeAppInteraction).toHaveBeenCalledOnce();
+      grantActive = false;
+      releaseResource.resolve(testCase.result);
+
+      const denied = await pending;
+      expect(denied.mock.calls[0]?.[0]).toBe(false);
+      expect(denied.mock.calls[0]?.[2]).toMatchObject({
+        message: "MCP App widget grant is no longer active",
+      });
+      expect(view.authorizeAppInteraction).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it("filters model-only tools from app discovery and execution", async () => {
     const params = { sessionKey: "agent:main:main", viewId: "cv_app" };

--- a/test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts
@@ -129,6 +129,23 @@ async function postStandalone(params: {
   });
 }
 
+async function readStandaloneResource(params: {
+  gateway: GatewayHandle;
+  ticket: string;
+}): Promise<Response> {
+  return await fetch(new URL("/__openclaw__/mcp-app/view", params.gateway.baseUrl), {
+    method: "POST",
+    headers: {
+      Authorization: `MCP-App ${params.ticket}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      method: "resources/read",
+      params: { uri: "ui://parity/app" },
+    }),
+  });
+}
+
 describe("Gateway MCP App board grant revalidation", () => {
   it(
     "rejects a standalone tool call revoked during a real catalog refresh",
@@ -256,6 +273,11 @@ describe("Gateway MCP App board grant revalidation", () => {
         const ticket = standaloneUrl.hash.slice(1);
         expect(ticket).not.toBe("");
 
+        const allowedResource = await readStandaloneResource({ gateway, ticket });
+        const allowedResourceBody: unknown = await allowedResource.json();
+        expect(allowedResource.status).toBe(200);
+        expect(JSON.stringify(allowedResourceBody)).toContain("Parity MCP App");
+
         await fs.writeFile(armPath, "armed\n");
         const notificationCall = await postStandalone({
           gateway,
@@ -274,14 +296,22 @@ describe("Gateway MCP App board grant revalidation", () => {
 
         const denied = await pendingCall;
         const deniedBody: unknown = await denied.json();
+        const deniedResource = await readStandaloneResource({ gateway, ticket });
+        const deniedResourceBody: unknown = await deniedResource.json();
         const executedMarkers = await readExecutedMarkers(eventPath);
         expect({
           status: denied.status,
           error: isRecord(deniedBody) ? deniedBody.error : undefined,
+          resourceStatus: deniedResource.status,
+          resourceError: isRecord(deniedResourceBody) ? deniedResourceBody.error : undefined,
+          leakedResource: JSON.stringify(deniedResourceBody).includes("Parity MCP App"),
           postRevocationExecuted: executedMarkers.includes(POST_REVOCATION_MARKER),
         }).toEqual({
           status: 403,
           error: "MCP App widget grant is no longer active",
+          resourceStatus: 403,
+          resourceError: "MCP App widget grant is no longer active",
+          leakedResource: false,
           postRevocationExecuted: false,
         });
       } catch (error) {

--- a/ui/src/components/mcp-app-security.test.ts
+++ b/ui/src/components/mcp-app-security.test.ts
@@ -14,11 +14,14 @@ describe("MCP App sandbox security", () => {
   });
 
   it("advertises update-model-context text support only when the handler path exists", () => {
-    expect(buildMcpAppHostCapabilities(undefined, true, true)).toMatchObject({
+    expect(buildMcpAppHostCapabilities(undefined, true, true, true)).toMatchObject({
       message: { text: {} },
+      serverResources: {},
       updateModelContext: { text: {} },
     });
-    expect(buildMcpAppHostCapabilities(undefined, true, false)).not.toHaveProperty(
+    const readOnly = buildMcpAppHostCapabilities(undefined, false, false, false);
+    expect(readOnly).not.toHaveProperty("serverResources");
+    expect(buildMcpAppHostCapabilities(undefined, true, false, true)).not.toHaveProperty(
       "updateModelContext",
     );
   });

--- a/ui/src/components/mcp-app-security.ts
+++ b/ui/src/components/mcp-app-security.ts
@@ -102,12 +102,13 @@ export function buildMcpAppHostCapabilities(
   csp?: McpAppHostSandboxCsp,
   supportsMessage = false,
   supportsUpdateModelContext = false,
+  supportsServerResources = false,
 ): McpAppHostCapabilities {
   return {
     openLinks: {},
-    serverResources: {},
     serverTools: {},
     sandbox: { csp: csp ?? {} },
+    ...(supportsServerResources ? { serverResources: {} } : {}),
     ...(supportsMessage ? { message: { text: {} } } : {}),
     ...(supportsUpdateModelContext ? { updateModelContext: { text: {} } } : {}),
   };

--- a/ui/src/components/mcp-app-view.test.ts
+++ b/ui/src/components/mcp-app-view.test.ts
@@ -198,7 +198,10 @@ describe("mcp-app-view localization", () => {
 
   it("accepts only focused visible plain-text ui/message requests through the chat seam", async () => {
     const { bridge, frame, view } = await mountBridge(`view-message-${crypto.randomUUID()}`);
-    expect(bridge.capabilities).toMatchObject({ message: { text: {} } });
+    expect(bridge.capabilities).toMatchObject({
+      message: { text: {} },
+      serverResources: {},
+    });
     expect(bridge.messageHandler).toBeTypeOf("function");
 
     const received: string[] = [];
@@ -297,6 +300,7 @@ describe("mcp-app-view localization", () => {
     expect(bridge.capabilities).not.toHaveProperty("message");
     expect(bridge.messageHandler).toBeUndefined();
     expect(bridge.capabilities).not.toHaveProperty("updateModelContext");
+    expect(bridge.capabilities).not.toHaveProperty("serverResources");
     expect(bridge.updateModelContextHandler).toBeUndefined();
   });
 

--- a/ui/src/components/mcp-app-view.ts
+++ b/ui/src/components/mcp-app-view.ts
@@ -369,6 +369,7 @@ export class McpAppView extends LitElement {
           payload.csp,
           payload.messageSupported === true,
           payload.updateModelContextSupported === true,
+          payload.messageSupported === true,
         ),
         { hostContext: hostContext(mount, this.height) },
       );

--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -44,6 +44,8 @@ const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM 
 const describeConformance = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const authValue = "test";
 const sessionKey = "agent:main:mcp-app-conformance";
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.resolve(".artifacts/control-ui-e2e/mcp-app-resource-revocation");
 
 let browser: Browser;
 let controlUiServer: ControlUiE2eServer;
@@ -526,7 +528,15 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
   }, 120_000);
 
   it("drives the authenticated Control UI and ticketed standalone bridges", async () => {
-    const controlContext = await browser.newContext({ permissions: ["local-network-access"] });
+    if (captureUiProof) {
+      await fs.mkdir(proofDir, { recursive: true });
+    }
+    const controlContext = await browser.newContext({
+      permissions: ["local-network-access"],
+      ...(captureUiProof
+        ? { recordVideo: { dir: proofDir, size: { width: 1280, height: 800 } } }
+        : {}),
+    });
     openContexts.add(controlContext);
     const controlPage = await controlContext.newPage();
     const browserDiagnostics: string[] = [];
@@ -597,6 +607,11 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
     await waitForTextContaining(app.locator("#model-tool"), "denied:");
     await app.locator("#read-resource").click();
     await waitForTextContaining(app.locator("#resource"), "resource-ok");
+    if (captureUiProof) {
+      await controlPage.screenshot({
+        path: path.join(proofDir, "control-ui-resource-allowed.png"),
+      });
+    }
     const confirmedPrompts: string[] = [];
     controlPage.on("dialog", async (dialog) => {
       confirmedPrompts.push(dialog.message());
@@ -629,7 +644,12 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
     expect(detachedDiagnostic).toBeGreaterThan(teardownDiagnostic);
     await expect.poll(() => controlPage.frames().length).toBe(1);
 
-    const standaloneContext = await browser.newContext({ permissions: ["local-network-access"] });
+    const standaloneContext = await browser.newContext({
+      permissions: ["local-network-access"],
+      ...(captureUiProof
+        ? { recordVideo: { dir: proofDir, size: { width: 1280, height: 800 } } }
+        : {}),
+    });
     openContexts.add(standaloneContext);
     const authorizationHeaders: string[] = [];
     const requestUrls: string[] = [];
@@ -680,6 +700,46 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
     await waitForTextContaining(app.locator("#result"), "initial-result");
     await app.locator("#call-app").click();
     await waitForTextContaining(app.locator("#app-tool"), "companion-called");
+
+    const activeView = getMcpAppViewLease(viewId, runtime);
+    if (!activeView) {
+      throw new Error("MCP App conformance view expired before revocation proof");
+    }
+    activeView.authorizeAppInteraction = async () => false;
+
+    // The already-initialized App retains its capability snapshot, so the
+    // authoritative request-time check must still withhold the resource.
+    await app.locator("#read-resource").click();
+    await waitForTextContaining(app.locator("#resource"), "denied:");
+    await waitForTextContaining(app.locator("#resource"), "resource-ok", false);
+    if (captureUiProof) {
+      await standalonePage.screenshot({
+        path: path.join(proofDir, "standalone-resource-revoked.png"),
+      });
+    }
+
+    await standalonePage.reload();
+    app = await findAppFrame(standalonePage);
+    await waitForTextContaining(app.locator("#capabilities"), "serverResources", false);
+    await app.locator("#read-resource").click();
+    await waitForTextContaining(app.locator("#resource"), "denied:");
+
+    const revokedControlPage = await controlContext.newPage();
+    await mountControlUiHost(revokedControlPage);
+    const revokedControlApp = await findAppFrame(revokedControlPage);
+    await waitForTextContaining(
+      revokedControlApp.locator("#capabilities"),
+      "serverResources",
+      false,
+    );
+    await revokedControlApp.locator("#read-resource").click();
+    await waitForTextContaining(revokedControlApp.locator("#resource"), "denied:");
+    if (captureUiProof) {
+      await revokedControlPage.screenshot({
+        path: path.join(proofDir, "control-ui-resource-revoked.png"),
+      });
+    }
+    await revokedControlPage.close();
 
     const tampered = `${absoluteStandaloneUrl.slice(0, -1)}${absoluteStandaloneUrl.endsWith("a") ? "b" : "a"}`;
     const tamperedPage = await standaloneContext.newPage();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an MCP App view could continue listing or reading resources from its owning server after the view's App-interaction authority was revoked. A resource request already in flight could also return its result after revocation.

## Why This Change Was Made

Resource list, template-list, and read operations now share one Gateway-owned authority boundary that validates the current App grant before upstream work and again before returning results. Initially unauthorized views no longer advertise the server-resource capability, while already-rendered views stay mounted and receive an explicit denial instead of being torn down.

The change intentionally leaves initial `ui://` document rendering, view/ticket lifetimes, and native Codex MCP App bindings unchanged.

## User Impact

Read-only, reconstructed, rejected, or revoked MCP App views can still render their fetched App document but cannot use the same-server resource bridge. Legitimately authorized Apps retain their existing resource and tool workflows.

## Evidence

- Pre-fix focused proof returned HTTP 200 for resource reads from read-only and missing-authority views; the regression tests now require HTTP 403 and verify that the upstream resource handler is not called.
- Focused Gateway and Control UI tests: 56 passed locally and on clean Linux.
- Real Gateway lifecycle E2E: allowed resource read before board removal, denied read through the same still-valid ticket after removal.
- Real Chromium + official MCP Apps bridge E2E: covers authorized access, live revocation with a stale initialization capability snapshot, reload after revocation, and authenticated Control UI denial.
- Clean-Linux Testbox proof, including a fresh production build and both real E2Es: https://github.com/openclaw/openclaw/actions/runs/32882889681
- `pnpm check:changed`, documentation MDX validation, link checking, and formatting checks passed locally.
