### PR TITLE
fix(codex): restore Computer Use after marketplace source upgrades

### DIFF
--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -1112,6 +1112,90 @@ describe("Codex Computer Use setup", () => {
   });
 
   it.each([
+    "/Applications/ChatGPT.app/Contents/Resources/plugins/openai-bundled",
+    "/Applications/Codex.app/Contents/Resources/plugins/openai-bundled",
+  ])("migrates the legacy bundled marketplace source through Codex", async (legacySource) => {
+    const { agentDir, client, managedMarketplacePath } = createManagedMarketplaceHarness(
+      tempDirs.make("openclaw-codex-managed-marketplace-"),
+    );
+    const request = createBundledMarketplaceComputerUseRequest(managedMarketplacePath, {
+      configuredSource: legacySource,
+    });
+
+    const status = await ensureCodexComputerUse({
+      agentDir,
+      client,
+      pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+      request,
+    });
+
+    expectStatusFields(status, {
+      ready: true,
+      reason: "ready",
+      marketplaceName: "openai-bundled",
+    });
+    expect(
+      requestCalls(request)
+        .filter(([method]) => method.startsWith("marketplace/"))
+        .map(([method, params]) => [method, params]),
+    ).toStrictEqual([
+      ["marketplace/remove", { marketplaceName: "openai-bundled" }],
+      ["marketplace/add", { source: managedMarketplacePath }],
+    ]);
+
+    await expect(
+      ensureCodexComputerUse({
+        agentDir,
+        client,
+        pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+        request,
+      }),
+    ).resolves.toMatchObject({ ready: true, reason: "ready" });
+    expect(
+      requestCalls(request).filter(([method]) => method === "marketplace/remove"),
+    ).toHaveLength(1);
+  });
+
+  it("preserves a custom source that uses the reserved bundled marketplace name", async () => {
+    const { agentDir, client, managedMarketplacePath } = createManagedMarketplaceHarness(
+      tempDirs.make("openclaw-codex-managed-marketplace-"),
+    );
+    const request = createBundledMarketplaceComputerUseRequest(managedMarketplacePath, {
+      configuredSource: "/opt/company/openai-bundled",
+    });
+
+    await expect(
+      ensureCodexComputerUse({
+        agentDir,
+        client,
+        pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+        request,
+      }),
+    ).rejects.toThrow("already added from a different source");
+    expectRequestMethodNotCalled(request, "marketplace/remove");
+  });
+
+  it("preserves a legacy source owned by a non-user config layer", async () => {
+    const { agentDir, client, managedMarketplacePath } = createManagedMarketplaceHarness(
+      tempDirs.make("openclaw-codex-managed-marketplace-"),
+    );
+    const request = createBundledMarketplaceComputerUseRequest(managedMarketplacePath, {
+      configuredSource: "/Applications/ChatGPT.app/Contents/Resources/plugins/openai-bundled",
+      configuredSourceOrigin: "system",
+    });
+
+    await expect(
+      ensureCodexComputerUse({
+        agentDir,
+        client,
+        pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+        request,
+      }),
+    ).rejects.toThrow("already added from a different source");
+    expectRequestMethodNotCalled(request, "marketplace/remove");
+  });
+
+  it.each([
     {
       label: "config-selected default marketplace",
       commandSource: "config" as const,
@@ -1932,18 +2016,55 @@ function createMultiMarketplaceComputerUseRequest(): CodexComputerUseRequest {
 
 function createBundledMarketplaceComputerUseRequest(
   bundledMarketplacePath: string,
+  options: { configuredSource?: string; configuredSourceOrigin?: "system" | "user" } = {},
 ): CodexComputerUseRequest {
-  let registered = false;
+  let configuredSource = options.configuredSource;
+  let registered = configuredSource === bundledMarketplacePath;
   let installed = false;
   let threadStartCalls = 0;
   return vi.fn(async (method: string, requestParams?: unknown) => {
     if (method === "experimentalFeature/enablement/set") {
       return { enablement: { plugins: true } };
     }
+    if (method === "config/read") {
+      return {
+        config: configuredSource
+          ? {
+              marketplaces: {
+                "openai-bundled": { source_type: "local", source: configuredSource },
+              },
+            }
+          : {},
+        origins: configuredSource
+          ? {
+              "marketplaces.openai-bundled.source": {
+                name:
+                  options.configuredSourceOrigin === "system"
+                    ? { type: "system", file: "/etc/codex/config.toml" }
+                    : { type: "user", file: "/codex/config.toml", profile: null },
+                version: "legacy-config",
+              },
+            }
+          : {},
+        layers: null,
+      };
+    }
+    if (method === "marketplace/remove") {
+      expect(requestParams).toEqual({ marketplaceName: "openai-bundled" });
+      configuredSource = undefined;
+      registered = false;
+      return { marketplaceName: "openai-bundled", installedRoot: null };
+    }
     if (method === "marketplace/add") {
       expect(requestParams).toEqual({
         source: bundledMarketplacePath,
       });
+      if (configuredSource && configuredSource !== bundledMarketplacePath) {
+        throw new Error(
+          "marketplace 'openai-bundled' is already added from a different source; remove it before adding this source | -32600",
+        );
+      }
+      configuredSource = bundledMarketplacePath;
       registered = true;
       return {
         marketplaceName: "openai-bundled",
@@ -2024,6 +2145,28 @@ function createBundledMarketplaceComputerUseRequest(
     }
     throw new Error(`unexpected request ${method}`);
   }) as CodexComputerUseRequest;
+}
+
+function createManagedMarketplaceHarness(root: string): {
+  agentDir: string;
+  client: ReturnType<typeof createClientHarness>["client"];
+  managedMarketplacePath: string;
+} {
+  const agentDir = path.join(root, "agent");
+  const codexHome = path.join(agentDir, "codex-home");
+  const managedMarketplacePath = path.join(
+    codexHome,
+    ".tmp",
+    "bundled-marketplaces",
+    "openai-bundled",
+  );
+  fs.mkdirSync(managedMarketplacePath, { recursive: true });
+  const client = createClientHarness().client;
+  vi.spyOn(client, "getRuntimeIdentity").mockReturnValue({
+    serverVersion: "0.149.1",
+    codexHome,
+  });
+  return { agentDir, client, managedMarketplacePath };
 }
 
 function marketplaceEntry(marketplaceName: string, installed: boolean) {

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -70,6 +70,8 @@ vi.mock("./desktop-app-paths.js", async (importOriginal) => {
     ...actual,
     resolveMacOSDesktopCodexAppPathCandidates: (platform?: NodeJS.Platform) =>
       actual.resolveMacOSDesktopCodexAppPathCandidates(platform ?? "darwin"),
+    resolveMacOSDesktopCodexBundledMarketplaceCandidates: (platform?: NodeJS.Platform) =>
+      actual.resolveMacOSDesktopCodexBundledMarketplaceCandidates(platform ?? "darwin"),
   };
 });
 

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -1197,6 +1197,26 @@ describe("Codex Computer Use setup", () => {
     expectRequestMethodNotCalled(request, "marketplace/remove");
   });
 
+  it("preserves a legacy source owned by a selected user profile", async () => {
+    const { agentDir, client, managedMarketplacePath } = createManagedMarketplaceHarness(
+      tempDirs.make("openclaw-codex-managed-marketplace-"),
+    );
+    const request = createBundledMarketplaceComputerUseRequest(managedMarketplacePath, {
+      configuredSource: "/Applications/ChatGPT.app/Contents/Resources/plugins/openai-bundled",
+      configuredSourceProfile: "work",
+    });
+
+    await expect(
+      ensureCodexComputerUse({
+        agentDir,
+        client,
+        pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+        request,
+      }),
+    ).rejects.toThrow("already added from a different source");
+    expectRequestMethodNotCalled(request, "marketplace/remove");
+  });
+
   it.each([
     {
       label: "config-selected default marketplace",
@@ -2018,8 +2038,13 @@ function createMultiMarketplaceComputerUseRequest(): CodexComputerUseRequest {
 
 function createBundledMarketplaceComputerUseRequest(
   bundledMarketplacePath: string,
-  options: { configuredSource?: string; configuredSourceOrigin?: "system" | "user" } = {},
+  options: {
+    configuredSource?: string;
+    configuredSourceOrigin?: "system" | "user";
+    configuredSourceProfile?: string;
+  } = {},
 ): CodexComputerUseRequest {
+  const codexHome = path.resolve(bundledMarketplacePath, "../../..");
   let configuredSource = options.configuredSource;
   let registered = configuredSource === bundledMarketplacePath;
   let installed = false;
@@ -2043,7 +2068,13 @@ function createBundledMarketplaceComputerUseRequest(
                 name:
                   options.configuredSourceOrigin === "system"
                     ? { type: "system", file: "/etc/codex/config.toml" }
-                    : { type: "user", file: "/codex/config.toml", profile: null },
+                    : {
+                        type: "user",
+                        file: options.configuredSourceProfile
+                          ? path.join(codexHome, `${options.configuredSourceProfile}.config.toml`)
+                          : path.join(codexHome, "config.toml"),
+                        profile: options.configuredSourceProfile ?? null,
+                      },
                 version: "legacy-config",
               },
             }

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -22,7 +22,10 @@ import {
   type CodexComputerUseConfig,
   type ResolvedCodexComputerUseConfig,
 } from "./config.js";
-import { resolveFirstExistingMacOSDesktopCodexBundledMarketplacePath } from "./desktop-app-paths.js";
+import {
+  resolveFirstExistingMacOSDesktopCodexBundledMarketplacePath,
+  resolveMacOSDesktopCodexBundledMarketplaceCandidates,
+} from "./desktop-app-paths.js";
 import { isManagedCodexDesktopCommand } from "./managed-binary.js";
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
 import type {
@@ -207,8 +210,9 @@ type PluginInspection =
     };
 
 const CURATED_MARKETPLACE_POLL_INTERVAL_MS = 2_000;
+const BUNDLED_MARKETPLACE_NAME = "openai-bundled";
 const COMPUTER_USE_MARKETPLACE_NAME_PRIORITY = [
-  "openai-bundled",
+  BUNDLED_MARKETPLACE_NAME,
   "openai-curated",
   "openai-api-curated",
   "openai-curated-remote",
@@ -430,6 +434,7 @@ async function inspectCodexComputerUseWithoutFence(
     signal: params.signal,
     defaultBundledMarketplacePath: params.defaultBundledMarketplacePath ?? managedMarketplacePath,
     defaultBundledMarketplacePathCandidates: params.defaultBundledMarketplacePathCandidates,
+    migrateLegacyBundledSource: Boolean(managedMarketplacePath),
   });
   if (!marketplace.marketplace) {
     return unavailableStatus(
@@ -795,6 +800,7 @@ async function resolveMarketplaceRef(params: {
   signal?: AbortSignal;
   defaultBundledMarketplacePath?: string;
   defaultBundledMarketplacePathCandidates?: readonly string[];
+  migrateLegacyBundledSource: boolean;
 }): Promise<MarketplaceResolution> {
   let preferredMarketplaceName = params.config.marketplaceName;
   if (params.config.marketplaceSource && params.allowAdd) {
@@ -818,6 +824,13 @@ async function resolveMarketplaceRef(params: {
     bundledMarketplacePath &&
     shouldAddBundledComputerUseMarketplace(params)
   ) {
+    if (params.migrateLegacyBundledSource) {
+      await migrateLegacyBundledMarketplaceSource({
+        request: params.request,
+        bundledMarketplacePath,
+        legacySources: params.defaultBundledMarketplacePathCandidates,
+      });
+    }
     const added = await params.request<{ marketplaceName?: string }>("marketplace/add", {
       source: bundledMarketplacePath,
     } satisfies CodexRequestObject);
@@ -863,6 +876,35 @@ async function resolveMarketplaceRef(params: {
   }
   const marketplace = candidates[0];
   return marketplace ? { marketplace } : {};
+}
+
+async function migrateLegacyBundledMarketplaceSource(params: {
+  request: CodexComputerUseRequest;
+  bundledMarketplacePath: string;
+  legacySources?: readonly string[];
+}): Promise<void> {
+  const response = await params.request<{
+    config: { marketplaces?: Record<string, { source_type?: string; source?: string }> };
+    origins: Record<string, { name: { type: string } }>;
+  }>("config/read", { includeLayers: false });
+  const bundled = response.config.marketplaces?.[BUNDLED_MARKETPLACE_NAME];
+  const sourceOrigin = response.origins[`marketplaces.${BUNDLED_MARKETPLACE_NAME}.source`];
+  if (bundled?.source_type !== "local" || !bundled.source || sourceOrigin?.name.type !== "user") {
+    return;
+  }
+
+  // Codex hides a reserved marketplace whose old direct source violates its
+  // managed-root policy. Remove only sources OpenClaw previously provisioned.
+  const configuredSource = path.resolve(bundled.source);
+  if (configuredSource === path.resolve(params.bundledMarketplacePath)) {
+    return;
+  }
+  const legacySources =
+    params.legacySources ?? resolveMacOSDesktopCodexBundledMarketplaceCandidates();
+  if (!legacySources.some((source) => path.resolve(source) === configuredSource)) {
+    return;
+  }
+  await params.request("marketplace/remove", { marketplaceName: BUNDLED_MARKETPLACE_NAME });
 }
 
 async function listComputerUseMarketplaceCandidates(

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -30,6 +30,7 @@ import { isManagedCodexDesktopCommand } from "./managed-binary.js";
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
 import type {
   CodexListMcpServerStatusResponse,
+  CodexConfigReadResponse,
   CodexMcpServerStatus,
   CodexPluginDetail,
   CodexPluginListResponse,
@@ -421,11 +422,11 @@ async function inspectCodexComputerUseWithoutFence(
     params.client,
     params.agentDir,
   );
-  if (params.installPlugin && managedMarketplacePath) {
-    const codexHome = params.client?.getRuntimeIdentity()?.codexHome;
-    if (codexHome) {
-      await assertNotSymlink(path.join(codexHome, "config.toml"), "Codex config");
-    }
+  const managedCodexHome = managedMarketplacePath
+    ? params.client?.getRuntimeIdentity()?.codexHome
+    : undefined;
+  if (params.installPlugin && managedCodexHome) {
+    await assertNotSymlink(path.join(managedCodexHome, "config.toml"), "Codex config");
   }
   const marketplace = await resolveMarketplaceRef({
     request,
@@ -434,7 +435,7 @@ async function inspectCodexComputerUseWithoutFence(
     signal: params.signal,
     defaultBundledMarketplacePath: params.defaultBundledMarketplacePath ?? managedMarketplacePath,
     defaultBundledMarketplacePathCandidates: params.defaultBundledMarketplacePathCandidates,
-    migrateLegacyBundledSource: Boolean(managedMarketplacePath),
+    managedCodexHome,
   });
   if (!marketplace.marketplace) {
     return unavailableStatus(
@@ -800,7 +801,7 @@ async function resolveMarketplaceRef(params: {
   signal?: AbortSignal;
   defaultBundledMarketplacePath?: string;
   defaultBundledMarketplacePathCandidates?: readonly string[];
-  migrateLegacyBundledSource: boolean;
+  managedCodexHome?: string;
 }): Promise<MarketplaceResolution> {
   let preferredMarketplaceName = params.config.marketplaceName;
   if (params.config.marketplaceSource && params.allowAdd) {
@@ -824,11 +825,12 @@ async function resolveMarketplaceRef(params: {
     bundledMarketplacePath &&
     shouldAddBundledComputerUseMarketplace(params)
   ) {
-    if (params.migrateLegacyBundledSource) {
+    if (params.managedCodexHome) {
       await migrateLegacyBundledMarketplaceSource({
         request: params.request,
         bundledMarketplacePath,
         legacySources: params.defaultBundledMarketplacePathCandidates,
+        userConfigPath: path.join(params.managedCodexHome, "config.toml"),
       });
     }
     const added = await params.request<{ marketplaceName?: string }>("marketplace/add", {
@@ -882,14 +884,22 @@ async function migrateLegacyBundledMarketplaceSource(params: {
   request: CodexComputerUseRequest;
   bundledMarketplacePath: string;
   legacySources?: readonly string[];
+  userConfigPath: string;
 }): Promise<void> {
-  const response = await params.request<{
-    config: { marketplaces?: Record<string, { source_type?: string; source?: string }> };
-    origins: Record<string, { name: { type: string } }>;
-  }>("config/read", { includeLayers: false });
+  const response = await params.request<
+    CodexConfigReadResponse & {
+      config: { marketplaces?: Record<string, { source_type?: string; source?: string }> };
+    }
+  >("config/read", { includeLayers: false });
   const bundled = response.config.marketplaces?.[BUNDLED_MARKETPLACE_NAME];
   const sourceOrigin = response.origins[`marketplaces.${BUNDLED_MARKETPLACE_NAME}.source`];
-  if (bundled?.source_type !== "local" || !bundled.source || sourceOrigin?.name.type !== "user") {
+  if (
+    bundled?.source_type !== "local" ||
+    !bundled.source ||
+    sourceOrigin?.name.type !== "user" ||
+    sourceOrigin.name.profile !== null ||
+    path.resolve(sourceOrigin.name.file) !== path.resolve(params.userConfigPath)
+  ) {
     return;
   }
 

--- a/extensions/codex/src/app-server/protocol-control-plane.ts
+++ b/extensions/codex/src/app-server/protocol-control-plane.ts
@@ -212,6 +212,7 @@ export type CodexHooksListResponse = {
 
 export type CodexConfigReadResponse = {
   config: JsonObject;
+  origins: Record<string, CodexConfigLayerMetadata | undefined>;
   layers?: JsonValue[] | null;
 };
 


### PR DESCRIPTION
Closes #129521

## What Problem This Solves

Fixes an issue where existing Codex Computer Use users could lose every agent reply after upgrading across #127778 when their isolated Codex home still registered `openai-bundled` from the standard ChatGPT.app or Codex.app bundle path.

## Why This Change Was Made

The managed Computer Use startup path now reads the effective Codex configuration and converges only an exact base-user legacy desktop source before registering the managed wrapper. It uses Codex app-server's supported `marketplace/remove` operation. Custom, system-managed, and selected-profile sources remain untouched, and the separately stored Computer Use enablement remains enabled.

This is a missing compatibility migration. #127778 changed the canonical source without adding a convergence step for existing isolated homes.

## User Impact

Affected users can upgrade without manually editing Codex configuration. The first Computer Use startup migrates the legacy marketplace registration, and later startups are idempotent.

## Evidence

### Regression and focused validation

- Pre-fix: both standard legacy-source cases failed with the observed `-32600` source conflict (`2 expected failures, 51 passes`).
- Post-fix: `55/55` focused Computer Use tests pass, including ChatGPT.app, Codex.app, custom-source, system-origin, selected-profile, enablement-preservation, and repeated-startup coverage.
- The selected-profile regression failed before the review repair because startup removed the base marketplace and returned ready. The repaired code preserves the profile-owned source and surfaces the original source conflict without calling `marketplace/remove`.
- Extension production and test typechecks pass.
- Focused Oxlint, Oxfmt 0.60.0, and `git diff --check` pass.
- The changed-scope gate passes. Its runtime-sidecar guard was rerun successfully with the main checkout's installed `playwright-core` because linked worktrees do not reconcile dependencies.
- Autoreview of the review repair reports no actionable findings (`patch is correct`, confidence `0.99`).

### Direct Codex 0.149.1 contract proof

An isolated real app-server run started with the legacy ChatGPT.app source and enabled Computer Use, then observed:

```json
{
  "beforeSource": "/Applications/ChatGPT.app/Contents/Resources/plugins/openai-bundled",
  "beforeOrigin": "user",
  "removedName": "openai-bundled",
  "addedName": "openai-bundled",
  "afterSource": "$CODEX_HOME/.tmp/bundled-marketplaces/openai-bundled",
  "pluginEnabled": true
}
```

The dependency contract was checked directly at Codex tag `rust-v0.149.1` (`980a6d12110b110d29ec13bdcbe14011100b3566`). `config/read` supplies effective values and leaf origins. A base user origin has `profile: null`; a selected profile has a non-null profile name. `marketplace/remove` edits only `$CODEX_HOME/config.toml` and deletes the named installed root when present. `marketplace/add` persists the managed source, while plugin enablement is stored independently.

The migration therefore requires all three facts before removal: the exact legacy desktop source, a base-user origin, and the exact managed `$CODEX_HOME/config.toml` path.

### Real OCM-managed Gateway proof

Before loading this branch, the protected `primary` Gateway reproduced the failure on every observed attempt:

```text
2026-08-25T10:49:53.789-07:00 Codex Computer Use readiness failed: marketplace 'openai-bundled' is already added from a different source; remove it before adding this source | -32600
2026-08-25T10:50:13.370-07:00 Embedded agent failed before reply: ... | -32600
2026-08-25T10:51:52.606-07:00 Embedded agent failed before reply: ... | -32600
2026-08-25T10:52:07.578-07:00 Embedded agent failed before reply: ... | -32600
```

After loading commit `2deed8f108f` as the installed OCM runtime:

```text
runtime: primary-oc-ed9-2deed8f-clean1
description: oc-ed9/codex-marketplace-source-migration 2deed8f108f
runtime verify: healthy=true
service: running=true desiredRunning=true childRestartCount=0 childPid=8400 port=18789
gateway health: ok=true eventLoop.degraded=false codex=loaded cua-computer=loaded
persisted source: $CODEX_HOME/.tmp/bundled-marketplaces/openai-bundled
computer-use@openai-bundled.enabled: true
post-deployment marketplace source conflicts: 0
2026-08-25T11:45:25.292-07:00 [agent/embedded] codex app-server context-engine projection decision
2026-08-25T11:45:28.080-07:00 [agent/embedded] codex app-server wrote context-engine thread binding
```

This live result proves the reported base-user upgrade path. The later review repair at `04d059008ef` preserves that path and adds the selected-profile ownership guard.

The live proof collection was observational. It did not restart, upgrade, edit configuration, or change service lifecycle state.

### Change size

- Production: `+60/-7` (net `+53`) for the compatibility migration, canonical `config/read` origin contract, and ownership gates.
- Tests: `+177/-1` (net `+176`).
