### PR TITLE
fix: accept newer Codex prereleases on the release branch

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -253,10 +253,11 @@ If the normal app-server runtime would be `danger-full-access`, enabling
 permission profile instead. Codex-managed network enforcement is sandboxed
 networking, so a full-access profile would not protect outbound traffic.
 
-The plugin accepts exactly stable Codex app-server `0.146.0`. Older or newer
-versions, prereleases, build-suffixed versions, and unversioned app-server
-handshakes are rejected. The same exact-version requirement applies to explicit
-custom executables, remote app-servers, and macOS desktop binaries.
+The plugin requires Codex app-server `0.146.0` or newer. Newer stable releases
+and prereleases above that compatibility floor proceed through normal startup
+validation; build metadata does not change version precedence. Older, malformed,
+and unversioned handshakes are rejected. This applies to explicit custom
+executables, remote app-servers, and macOS desktop binaries.
 
 OpenClaw treats non-loopback WebSocket app-server URLs as remote and requires
 identity-bearing WebSocket auth through `appServer.authToken` or an
@@ -305,7 +306,7 @@ configured plugin's details to reserve the denied app IDs. It does not scan
 unrelated marketplaces or install, enable, or authenticate the disabled plugin;
 missing ownership fails closed.
 
-Only connect OpenClaw to a `0.146.0` remote app-server trusted to accept
+Only connect OpenClaw to a compatible remote app-server trusted to accept
 configured marketplace plugin installs and inventory refreshes. Missing modern
 inventory methods and server, authentication, or transport failures fail closed.
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -66,10 +66,11 @@ channel is the communication surface.
 
 - The official `@openclaw/codex` plugin installed. Include `codex` in
   `plugins.allow` if your config uses an allowlist.
-- Codex app-server `0.146.0`. The plugin ships and manages `@openai/codex`
+- Codex app-server `0.146.0` or newer. The plugin ships and manages `@openai/codex`
   `0.146.0` by default, so a `codex` command on `PATH` does not affect normal
   startup. Explicit custom, remote, and macOS desktop-owned app-servers must
-  report the same exact stable `0.146.0` version.
+  meet the same compatibility floor. Newer prereleases are accepted and still
+  pass through normal startup validation.
 - Node.js on the remote Codex app-server host when `remoteWorkspaceRoot` is set
   and cross-machine workspace attachments must be transferred.
 - Codex auth through `openclaw models auth login --provider openai`, an
@@ -1189,11 +1190,11 @@ instead of a plain OpenAI API-key failure.
 Doctor rewrites legacy model refs to `openai/*`, removes stale session and
 whole-agent runtime pins, and preserves existing auth-profile overrides.
 
-**The app-server is rejected:** use exactly stable Codex `0.146.0`. Older or
-newer versions, prereleases, build-suffixed versions, and unversioned servers
-are rejected because OpenClaw validates generated schemas and runtime contracts
-against the Codex version it ships. Update or remove custom, remote, or desktop
-binary overrides that select another version.
+**The app-server is rejected:** use Codex `0.146.0` or newer. Older, malformed,
+and unversioned servers are rejected during the initialize handshake. Newer
+stable releases and prereleases above the compatibility floor continue through
+normal startup validation. Update incompatible custom, remote, or desktop
+binary overrides, or remove them to use the managed binary.
 
 **`/codex status` cannot connect:** check that the `codex` plugin
 is enabled, that `plugins.allow` includes it when an allowlist is

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -22,9 +22,9 @@ working.
 - The agent runtime must be the native Codex harness.
 - `plugins.entries.codex.enabled` is `true`.
 - `plugins.entries.codex.config.codexPlugins.enabled` is `true`.
-- Codex app-server reports exactly stable `0.146.0`. The official plugin ships
+- Codex app-server reports `0.146.0` or newer. The official plugin ships
   `@openai/codex` `0.146.0`; custom, remote, and macOS desktop-owned binaries
-  must use the same exact version.
+  must meet the same compatibility floor, including newer prereleases.
 - The target Codex app-server can see the expected marketplace, plugin, and
   app inventory.
 - Migration supports only `openai-curated` plugins that it observed as

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -259,8 +259,9 @@ For operator setup, model prefix examples, and Codex-only configs, see
 
 The Codex plugin enforces the minimum app-server version documented in
 [Codex Harness](/plugins/codex-harness). It checks the initialize handshake and
-blocks older or unversioned servers, so OpenClaw only runs against the protocol
-surface it has tested.
+blocks older, malformed, or unversioned servers. Newer runtimes, including
+prereleases above the compatibility floor, continue through normal startup
+validation.
 
 ### Tool-result middleware
 

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "dependencies": {
     "@openai/codex": "0.146.0",
+    "semver": "7.8.5",
     "smol-toml": "1.7.1",
     "typebox": "1.3.6",
     "ws": "8.21.1",

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -361,7 +361,7 @@ describe("CodexAppServerClient", () => {
     });
 
     await expect(initializing).rejects.toThrow(
-      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required, but detected 0.124.9`,
+      `Codex app-server ${CODEX_APP_SERVER_VERSION} or newer is required, but detected 0.124.9`,
     );
     expect(harness.writes).toHaveLength(1);
   });
@@ -374,7 +374,7 @@ describe("CodexAppServerClient", () => {
     });
 
     await expect(initializing).rejects.toThrow(
-      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required, but detected 0.145.0`,
+      `Codex app-server ${CODEX_APP_SERVER_VERSION} or newer is required, but detected 0.145.0`,
     );
     expect(harness.writes).toHaveLength(1);
   });
@@ -387,22 +387,23 @@ describe("CodexAppServerClient", () => {
     });
 
     await expect(initializing).rejects.toThrow(
-      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required, but detected 0.146.0-alpha.2`,
+      `Codex app-server ${CODEX_APP_SERVER_VERSION} or newer is required, but detected 0.146.0-alpha.2`,
     );
     expect(harness.writes).toHaveLength(1);
   });
 
-  it("blocks Codex app-server build metadata on the exact supported version", async () => {
+  it("accepts compatible build metadata on the minimum supported version", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const { harness, initializing, outbound } = startInitialize();
     harness.send({
       id: outbound.id,
-      result: { userAgent: "openclaw/0.146.0+alpha.2 (macOS; test)" },
+      result: { userAgent: "openclaw/0.146.0+desktop (macOS; test)" },
     });
 
-    await expect(initializing).rejects.toThrow(
-      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required, but detected 0.146.0+alpha.2`,
-    );
-    expect(harness.writes).toHaveLength(1);
+    await expect(initializing).resolves.toBeUndefined();
+    expect(harness.client.getServerVersion()).toBe("0.146.0+desktop");
+    expect(JSON.parse(harness.writes[1] ?? "{}")).toEqual({ method: "initialized" });
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("blocks Codex app-server prereleases outside generated stable schemas", async () => {
@@ -413,7 +414,7 @@ describe("CodexAppServerClient", () => {
     });
 
     await expect(initializing).rejects.toThrow(
-      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required`,
+      `Codex app-server ${CODEX_APP_SERVER_VERSION} or newer is required`,
     );
     expect(harness.writes).toHaveLength(1);
   });
@@ -426,14 +427,15 @@ describe("CodexAppServerClient", () => {
     });
 
     await expect(initializing).rejects.toThrow(
-      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required`,
+      `Codex app-server ${CODEX_APP_SERVER_VERSION} or newer is required`,
     );
     expect(harness.writes).toHaveLength(1);
   });
 
-  it.each(["0.146.1", "0.149.0"])(
-    "accepts newer stable Codex app-server version %s",
+  it.each(["0.146.1", "0.147.0-alpha.9", "0.149.0", "1.0.0"])(
+    "accepts a newer app-server version %s for normal startup validation",
     async (newerVersion) => {
+      const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
       const { harness, initializing, outbound } = startInitialize();
       harness.send({
         id: outbound.id,
@@ -441,7 +443,28 @@ describe("CodexAppServerClient", () => {
       });
 
       await expect(initializing).resolves.toBeUndefined();
-      expect(harness.writes).toHaveLength(2);
+      expect(harness.client.getServerVersion()).toBe(newerVersion);
+      expect(JSON.parse(harness.writes[1] ?? "{}")).toEqual({ method: "initialized" });
+      expect(warn).toHaveBeenCalledWith(
+        "codex app-server is newer than OpenClaw's managed runtime; continuing with normal startup validation",
+        { detectedVersion: newerVersion, validatedVersion: CODEX_APP_SERVER_VERSION },
+      );
+    },
+  );
+
+  it.each(["0.146.00", "0.147.0-alpha..9", "0.147.0-alpha.09"])(
+    "blocks malformed app-server version %s during initialize",
+    async (version) => {
+      const { harness, initializing, outbound } = startInitialize();
+      harness.send({
+        id: outbound.id,
+        result: { userAgent: `openclaw/${version} (macOS; test)` },
+      });
+
+      await expect(initializing).rejects.toThrow(
+        `Codex app-server ${CODEX_APP_SERVER_VERSION} or newer is required`,
+      );
+      expect(harness.writes).toHaveLength(1);
     },
   );
 
@@ -450,7 +473,7 @@ describe("CodexAppServerClient", () => {
     harness.send({ id: outbound.id, result: {} });
 
     await expect(initializing).rejects.toThrow(
-      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required`,
+      `Codex app-server ${CODEX_APP_SERVER_VERSION} or newer is required`,
     );
     expect(harness.writes).toHaveLength(1);
   });

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import { embeddedAgentLog, OPENCLAW_VERSION } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { parse as parseSemver } from "semver";
 import { resolveCodexAppServerRuntimeOptions, type CodexAppServerStartOptions } from "./config.js";
 import {
   type CodexAppServerRequestMethod,
@@ -1038,7 +1039,7 @@ class CodexAppServerVersionError extends Error {
       ? `detected ${detectedVersion}`
       : "OpenClaw could not determine the running Codex version";
     super(
-      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required, but ${detected}. Update the configured Codex app-server binary, or remove custom command overrides to use the managed binary.`,
+      `Codex app-server ${CODEX_APP_SERVER_VERSION} or newer is required, but ${detected}. Update the configured Codex app-server binary, or remove custom command overrides to use the managed binary.`,
     );
     this.name = "CodexAppServerVersionError";
     this.detectedVersion = detectedVersion;
@@ -1047,16 +1048,16 @@ class CodexAppServerVersionError extends Error {
 
 function assertSupportedCodexAppServerVersion(response: CodexInitializeResponse): string {
   const detectedVersion = readCodexVersionFromUserAgent(response.userAgent);
-  // External app-servers may advance independently of OpenClaw's bundled runtime.
-  // Keep the reviewed stable release as a compatibility floor, not an exact pin.
-  if (
-    !detectedVersion ||
-    !/^\d+\.\d+\.\d+$/.test(detectedVersion) ||
-    detectedVersion.localeCompare(CODEX_APP_SERVER_VERSION, "en", { numeric: true }) < 0
-  ) {
+  if (!detectedVersion) {
     throw new CodexAppServerVersionError(detectedVersion);
   }
-  if (detectedVersion !== CODEX_APP_SERVER_VERSION) {
+  // External app-servers may advance independently of OpenClaw's bundled runtime.
+  // Keep the reviewed stable release as a compatibility floor, not an exact pin.
+  const detected = parseSemver(detectedVersion);
+  if (!detected || detected.compare(CODEX_APP_SERVER_VERSION) < 0) {
+    throw new CodexAppServerVersionError(detectedVersion);
+  }
+  if (detected.compare(CODEX_APP_SERVER_VERSION) > 0) {
     embeddedAgentLog.warn(
       "codex app-server is newer than OpenClaw's managed runtime; continuing with normal startup validation",
       { detectedVersion, validatedVersion: CODEX_APP_SERVER_VERSION },

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -260,7 +260,7 @@ describe("shared Codex app-server client", () => {
     await sendInitializeResult(harness, "openclaw/0.117.9 (macOS; test)");
 
     await expect(listPromise).rejects.toThrow(
-      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required`,
+      `Codex app-server ${CODEX_APP_SERVER_VERSION} or newer is required`,
     );
     expect(harness.process.stdin.destroyed).toBe(true);
     startSpy.mockRestore();

--- a/extensions/codex/src/app-server/version.ts
+++ b/extensions/codex/src/app-server/version.ts
@@ -1,7 +1,7 @@
 /**
  * Version and package pins for the managed Codex app-server runtime.
  */
-/** Exact Codex app-server version shipped and supported by the OpenClaw Codex bridge. */
+/** Bundled Codex app-server version and compatibility floor for external runtimes. */
 export const CODEX_APP_SERVER_VERSION = "0.146.0";
 /** npm package name for the managed Codex app-server binary. */
 export const MANAGED_CODEX_APP_SERVER_PACKAGE = "@openai/codex";

--- a/extensions/codex/src/manifest.test.ts
+++ b/extensions/codex/src/manifest.test.ts
@@ -24,7 +24,7 @@ describe("codex package manifest", () => {
 
     expect(packageJson.devDependencies).toHaveProperty("@openclaw/plugin-sdk");
     expect(packageJson.dependencies?.["@openai/codex"]).toBe(CODEX_APP_SERVER_VERSION);
-    expect(packageJson.dependencies).not.toHaveProperty("semver");
+    expect(packageJson.dependencies?.semver).toBe("7.8.5");
     expect(packageJson.openclaw?.release?.requireLatestDependencies).toEqual(["@openai/codex"]);
     expect(packageJson.openclaw?.install?.requiredPlatformPackages).toEqual([
       "@openai/codex-linux-x64",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,9 @@ importers:
       '@openai/codex':
         specifier: 0.146.0
         version: 0.146.0
+      semver:
+        specifier: 7.8.5
+        version: 7.8.5
       smol-toml:
         specifier: 1.7.1
         version: 1.7.1


### PR DESCRIPTION
The release branch accepts newer stable Codex app-servers, but rejects newer prereleases before normal startup validation. This backports the semantic-version comparison already merged in [#125883](https://github.com/openclaw/openclaw/pull/125883) and [#126450](https://github.com/openclaw/openclaw/pull/126450).

The bundled Codex version and compatibility floor remain at 0.146.0. Newer prereleases are accepted, build metadata does not change version precedence, and older or malformed handshakes still fail. No runtime upgrade, configuration change, or state migration is included.

Upstream commits: e00f86019827d2a8b41a4e137ceb1faab94d3563 and 841f25eae629668639e880c26c14ab6fa0f09a56. The backport is based on release commit 0b45d2db94a69fbaf7843cc8afc309d4a2223198 and preserves that branch's existing version floor. AI-assisted.

The exact backport head now completes real initialization and a thread-list request against the public 0.149.0 and 0.150.0-alpha.9 binaries. The [process trace and direct Codex source review](https://github.com/openclaw/openclaw/pull/129553#issuecomment-5415606153) describe what was checked and the limits of that proof.
