### PR TITLE
perf(test): make Workboard browser proof capture opt-in

### DIFF
--- a/ui/src/pages/workboard/workboard.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard.e2e.test.ts
@@ -26,6 +26,7 @@ const suite = createControlUiE2eSuite({
     `Playwright Chromium is not installed at ${executablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
 });
 
+const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/workboard");
 const viewport = { height: 1000, width: 2400 };
 const baseTime = Date.parse("2026-06-01T18:00:00.000Z");
@@ -299,20 +300,18 @@ async function newRecordedPage(
   label: string,
   options: { hasTouch?: boolean } = {},
 ): Promise<RecordedPage> {
-  await mkdir(artifactDir, { recursive: true });
   const rawVideoDir = path.join(artifactDir, `${label}-raw`);
-  await rm(rawVideoDir, { force: true, recursive: true });
-  await mkdir(rawVideoDir, { recursive: true });
+  if (captureUiProofEnabled) {
+    await rm(rawVideoDir, { force: true, recursive: true });
+    await mkdir(rawVideoDir, { recursive: true });
+  }
   let context: BrowserContext | undefined;
   let page: Page | undefined;
   try {
     context = await suite.browser.newContext({
       hasTouch: options.hasTouch,
       locale: "en-US",
-      recordVideo: {
-        dir: rawVideoDir,
-        size: viewport,
-      },
+      recordVideo: captureUiProofEnabled ? { dir: rawVideoDir, size: viewport } : undefined,
       serviceWorkers: "block",
       viewport,
     });
@@ -322,7 +321,9 @@ async function newRecordedPage(
   } catch (error) {
     await page?.close().catch(() => {});
     await context?.close().catch(() => {});
-    await rm(rawVideoDir, { force: true, recursive: true });
+    if (captureUiProofEnabled) {
+      await rm(rawVideoDir, { force: true, recursive: true });
+    }
     throw error;
   }
 }
@@ -332,6 +333,9 @@ async function captureScreenshot(
   artifacts: ProofArtifacts,
   name: string,
 ): Promise<void> {
+  if (!captureUiProofEnabled) {
+    return;
+  }
   const screenshotPath = path.join(artifactDir, `${name}.png`);
   await page.screenshot({ fullPage: true, path: screenshotPath });
   artifacts.screenshots.push(screenshotPath);
@@ -353,13 +357,17 @@ async function closeRecordedPage(
     await copyFile(rawVideoPath, videoPath);
     artifacts.videos.push(videoPath);
   } finally {
-    await rm(recorded.rawVideoDir, { force: true, recursive: true });
+    if (captureUiProofEnabled) {
+      await rm(recorded.rawVideoDir, { force: true, recursive: true });
+    }
   }
 }
 
 suite.define(() => {
   it("persists Workboard create, edit, running move, lifecycle sync, reload, and read-only state", async () => {
-    await rm(artifactDir, { force: true, recursive: true });
+    if (captureUiProofEnabled) {
+      await rm(artifactDir, { force: true, recursive: true });
+    }
     const artifacts: ProofArtifacts = { screenshots: [], videos: [] };
     const createdCard = card({
       id: "card-1",
@@ -743,11 +751,13 @@ suite.define(() => {
       await closeRecordedPage(readOnly, artifacts, "workboard-read-only");
     }
 
-    await writeFile(
-      path.join(artifactDir, "manifest.json"),
-      `${JSON.stringify(artifacts, null, 2)}\n`,
-      "utf-8",
-    );
+    if (captureUiProofEnabled) {
+      await writeFile(
+        path.join(artifactDir, "manifest.json"),
+        `${JSON.stringify(artifacts, null, 2)}\n`,
+        "utf-8",
+      );
+    }
   });
 
   it("keeps card titles visible when a column overflows its height", async () => {


### PR DESCRIPTION
## What Problem This Solves

Ordinary Control UI Workboard E2E runs always recorded five full-resolution browser videos, captured fourteen screenshots, copied the resulting media, and wrote a proof manifest even though normal CI never consumes those artifacts. A recent Workboard expansion added another recorded browser context and more screenshots, increasing the recurring cost of otherwise unchanged behavioral coverage.

## Why This Change Was Made

Reuse the existing `OPENCLAW_CAPTURE_UI_PROOF=1` opt-in already used by sibling Control UI suites. Normal runs retain every real Chromium context, mocked-Gateway interaction, lifecycle wait, read-only authorization assertion, and Workboard behavior check while skipping optional media generation. Explicit capture retains all existing screenshot filenames, five videos, and the original manifest.

## User Impact

No user-visible or production behavior changes. Maintainers and CI get faster Workboard browser coverage without weakening lifecycle, persistence, integration, or authorization proof.

## Evidence

- One owned Blacksmith Testbox; one Vitest worker; independent filesystem module-cache paths; import diagnostics; `/usr/bin/time -v`; excluded warmups; eight interleaved, order-balanced samples per version.
- Median scoped wall time: **21.77s -> 20.79s**, saving **0.98s (4.5%)** despite host-speed drift. Every balanced four-run block improved; average paired block saving was **2.72s**.
- Median actual browser-test body time: **14.16s -> 9.84s**, saving **4.32s (30.5%)**.
- Baseline wall samples (seconds): `21.44, 19.26, 19.72, 19.00, 22.10, 25.14, 30.04, 27.32`.
- Candidate wall samples (seconds): `18.39, 20.93, 15.42, 15.65, 20.65, 21.34, 26.57, 23.29`.
- Every baseline/candidate run retained **5 passing real-browser tests** and **10 measured imported modules**.
- Default capture-off proof: all 5 tests passed and the suite created **zero** Workboard artifacts.
- Explicit capture-on proof: all 5 tests passed and reproduced **14 PNGs, 5 WebMs, and the original manifest containing 10 screenshots and 2 first-scenario videos**.
- Owner/sibling proof: all **10 tests passed** across the Workboard behavior, routing, and status-persistence E2E suites.
- Reversible authorization fault proof: temporarily forcing the production page to expose write access for a read-only operator made the unchanged browser regression fail on the unexpected `New card` control; restoring the owner returned all 10 sibling tests to green.
- Complete changed-file gate, formatting, repository guards, core-test typecheck, UI i18n verification, and fresh structured review: green before submission.
- Production LOC: **+0/-0**. Test LOC: **+25/-15**. No assertion, browser-context, lifecycle wait, security boundary, or existing proof-mode artifact was removed.
