### PR TITLE
fix(android): preserve document-only chat messages

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -7130,20 +7130,21 @@ internal fun parseChatMessageContent(el: JsonElement): ChatMessageContent? {
       )
     }
 
-    "attachment" -> {
-      val attachment = obj["attachment"].asObjectOrNull() ?: return null
+    "attachment", "file" -> {
+      val attachment = obj["attachment"].asObjectOrNull() ?: obj
       val mimeType = attachment["mimeType"].asStringOrNull()
       val type =
         when {
           attachment["kind"].asStringOrNull() == "audio" || mimeType?.startsWith("audio/") == true -> "audio"
           attachment["kind"].asStringOrNull() == "video" || mimeType?.startsWith("video/") == true -> "video"
+          attachment["kind"].asStringOrNull() == "document" || !attachment.containsKey("kind") -> "file"
           else -> return null
         }
       val url = attachment["url"].asStringOrNull()
       ChatMessageContent(
         type = type,
         mimeType = mimeType,
-        fileName = attachment["fileName"].asStringOrNull() ?: attachment["label"].asStringOrNull(),
+        fileName = attachment["fileName"].asStringOrNull() ?: (attachment["label"] ?: attachment["name"]).asStringOrNull(),
         artifactId = attachment["artifactId"].asStringOrNull() ?: managedMediaArtifactId(url),
         url = url,
         openUrl = attachment["openUrl"].asStringOrNull(),

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -1752,7 +1752,7 @@ internal fun ChatBubble(
           visible
         }
         "canvas" -> normalizedRole == "assistant" && part.widget != null
-        else -> part.isAudioAttachment() || part.isVideoAttachment()
+        else -> part.type == "file" || part.isAudioAttachment() || part.isVideoAttachment()
       }
     }
   val omittedImageCount = (visibleImageCount - 4).coerceAtLeast(0)

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
@@ -376,6 +376,66 @@ class ChatMessageContentParsingTest {
   }
 
   @Test
+  fun preservesFlatGatewayDocumentAttachment() {
+    val attachment =
+      Json.parseToJsonElement(
+        """{"type":"attachment","name":"report.txt","url":"https://example.test/report.txt"}""",
+      )
+
+    assertEquals(
+      ChatMessageContent(type = "file", fileName = "report.txt", url = "https://example.test/report.txt"),
+      parseChatMessageContent(attachment),
+    )
+  }
+
+  @Test
+  fun preservesNestedGatewayDocumentAttachment() {
+    val attachment =
+      Json.parseToJsonElement(
+        """{"type":"attachment","attachment":{"kind":"document","label":"pasted-note.txt","mimeType":"text/plain","sizeBytes":48,"url":"/__openclaw__/pasted-note.txt"}}""",
+      )
+
+    assertEquals(
+      ChatMessageContent(
+        type = "file",
+        mimeType = "text/plain",
+        fileName = "pasted-note.txt",
+        url = "/__openclaw__/pasted-note.txt",
+        sizeBytes = 48,
+      ),
+      parseChatMessageContent(attachment),
+    )
+  }
+
+  @Test
+  fun preservesHistoricalFileAttachment() {
+    val attachment =
+      Json.parseToJsonElement(
+        """{"type":"file","fileName":"summary.pdf","mimeType":"application/pdf","url":"/files/summary.pdf"}""",
+      )
+
+    assertEquals(
+      ChatMessageContent(
+        type = "file",
+        mimeType = "application/pdf",
+        fileName = "summary.pdf",
+        url = "/files/summary.pdf",
+      ),
+      parseChatMessageContent(attachment),
+    )
+  }
+
+  @Test
+  fun dropsUnknownAttachmentKinds() {
+    val attachment =
+      Json.parseToJsonElement(
+        """{"type":"attachment","attachment":{"kind":"future","label":"unknown.bin"}}""",
+      )
+
+    assertNull(parseChatMessageContent(attachment))
+  }
+
+  @Test
   fun parsesDirectAndAttachmentAudioVideoBlocks() {
     val direct =
       Json.parseToJsonElement(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMessageViewsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMessageViewsTest.kt
@@ -165,6 +165,55 @@ class ChatMessageViewsTest {
   }
 
   @Test
+  fun attachmentOnlyAssistantTurnShowsDocumentFilenameWithoutLoadingItsUrl() {
+    var artifactRequests = 0
+
+    composeRule.setContent {
+      ChatBubble(
+        messageId = "document-message",
+        entryId = null,
+        role = "assistant",
+        live = false,
+        content =
+          listOf(
+            ChatMessageContent(
+              type = "file",
+              mimeType = "application/pdf",
+              fileName = "quarterly-report.pdf",
+              url = "https://example.test/quarterly-report.pdf",
+            ),
+          ),
+        timestampMs = null,
+        onReplyMessage = {},
+        sessionActionsEnabled = false,
+        onRewindMessage = {},
+        onForkMessage = {},
+        speechState = null,
+        onToggleListen = { _, _ -> },
+        inlineMediaPlaybackBlocked = false,
+        inlineWidgetResolverReady = false,
+        resolveInlineWidgetResource = { _, _ ->
+          artifactRequests += 1
+          null
+        },
+        loadImageArtifact = {
+          artifactRequests += 1
+          null
+        },
+        loadMediaArtifact = { _, _, _ ->
+          artifactRequests += 1
+          null
+        },
+      )
+    }
+
+    composeRule
+      .onNode(hasContentDescription("OpenClaw") and hasText("quarterly-report.pdf"))
+      .assertIsDisplayed()
+    assertEquals(0, artifactRequests)
+  }
+
+  @Test
   fun managedImageCompositionRequestsItsArtifact() {
     val artifactId = "artifact_managed_image_11111111-1111-4111-8111-111111111111"
     val requested = mutableListOf<String>()


### PR DESCRIPTION
## What Problem This Solves

Android silently discarded legitimate document and file attachments returned by chat history. If an assistant response consisted only of such an attachment, the entire message disappeared from the conversation, even though the Gateway preserved it and the Apple and web chat surfaces displayed it.

The parser recognized only audio/video attachment envelopes and rejected historical flat attachments, canonical nested document attachments, and historical file blocks. The existing chat bubble also filtered file parts before its already-implemented filename fallback could render them.

## What Changed

- Normalize existing flat attachment, nested document attachment, and historical file shapes through the existing chat attachment parser.
- Admit normalized files into the existing passive filename fallback in chat bubbles.
- Preserve audio/video handling, reject unknown attachment kinds, and never open, download, resolve, or fetch document URLs.
- Production delta: **+1 net line** across the existing parser and bubble owner; no dependency, permission, configuration, protocol, or security-boundary change.

## Evidence

- Unchanged frozen production fail-first: **28 tests, four genuine failures** covering all three legitimate Gateway document shapes and an actual Compose attachment-only assistant message that was not displayed; 24 existing controls passed.
- Reviewed repair: **44/44 tests pass**: 24 parser/attachment-owner cases, five real Compose message-view cases, and 15 chat-screen sibling cases.
- Existing audio, video, images, canvas sandboxing, unknown attachment kinds, and document URL non-resolution remain covered.
- All four hosted-equivalent Android lint suites pass: app, benchmark, wear, and wear-shared.
- Independent automated code review: clean, with no actionable findings.
- Real Android 36 proof runs the actual production parser and production chat bubble inside a resumed app activity: unchanged production parses **0/3** valid attachments and shows no assistant bubbles; the repair parses and visibly displays all **3/3** (`report.txt`, `pasted-note.txt`, and `summary.pdf`). Both runs make **zero** attachment URL, image-artifact, media-artifact, or widget-resource requests.

### Before

![Before: three valid document-only assistant responses are completely invisible](https://github.com/user-attachments/assets/7357831c-1a17-45c6-a87f-32dd7037e7ce)

### After

![After: all three assistant document filenames are visibly preserved](https://github.com/user-attachments/assets/271cf63a-0e07-4ea6-a597-5b467cd96bf6)
