### PR TITLE
fix(macos): remote mode displays stale browser import banners

### DIFF
--- a/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
+++ b/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
@@ -115,7 +115,7 @@ final class BrowserProfileImportModel {
     /// while it was in flight — "phase is .hidden again" alone cannot tell a
     /// just-dismissed banner apart from one that never appeared.
     private func setPhase(_ phase: Phase) {
-        self.phase = phase
+        self.phase = self.isLocalMode() ? phase : .hidden
         self.phaseGeneration += 1
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
@@ -24,6 +24,7 @@ private final class BrowserImportTransportStub {
     var requests: [BrowserProfileImportRequest] = []
     var failingPaths: Set<String> = []
     var beforeStatusResponse: (@MainActor () async -> Void)?
+    var beforeImportResponse: (@MainActor () async -> Void)?
     var statusJSON = """
     {
       "enabled": true,
@@ -45,6 +46,10 @@ private final class BrowserImportTransportStub {
                 self.requests.append(request)
                 if request.path == "/system-profile-import/status", let hook = self.beforeStatusResponse {
                     self.beforeStatusResponse = nil
+                    await hook()
+                }
+                if request.path == "/profiles/import", let hook = self.beforeImportResponse {
+                    self.beforeImportResponse = nil
                     await hook()
                 }
                 if self.failingPaths.contains(request.path) {
@@ -220,6 +225,37 @@ struct BrowserProfileImportModelTests {
 
         model.retry()
         #expect(model.phase == .offering(retry))
+    }
+
+    @Test(arguments: [false, true])
+    func `late import outcomes stay hidden after switching to a remote gateway`(_ shouldFail: Bool) async {
+        let stub = BrowserImportTransportStub()
+        let eligibility = BrowserImportEligibilityGate()
+        eligibility.isLocalMode = true
+        let model = stub.makeModel(isLocalMode: { eligibility.isLocalMode })
+        let gate = ContinuationBox()
+
+        await model.refresh(force: false)
+        stub.beforeImportResponse = {
+            await withCheckedContinuation { gate.continuation = $0 }
+        }
+        if shouldFail {
+            stub.failingPaths.insert("/profiles/import")
+        }
+
+        let importing = Task { await model.importProfile(Self.chromeProfile) }
+        while gate.continuation == nil {
+            await Task.yield()
+        }
+
+        eligibility.isLocalMode = false
+        model.handleConnectionModeChange()
+        #expect(model.phase == .hidden)
+
+        gate.continuation?.resume()
+        await importing.value
+        #expect(model.phase == .hidden)
+        #expect(BrowserProfileImportBannerContent.content(for: model.phase) == nil)
     }
 
     @Test func `dismissing an offer persists the dismissal`() async {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users who switched from a Local Gateway to a Remote Gateway while browser import was in flight would still see a stale browser-import success or failure banner after the operation completed.

## Why This Change Was Made

The existing browser-import phase owner now respects the current Gateway mode when publishing asynchronous completion state. This fences both late successes and late failures at their lifecycle owner without changing imports, cookie handling, authentication, or normal Local-mode behavior. Production code remains line-neutral.

## User Impact

Browser-import banners disappear and stay hidden in Remote Gateway mode, even when an earlier Local-mode import finishes afterward. Local-mode success, failure, retry, and dismissal continue to work normally.

## Evidence

Actual production SwiftUI rendered against the same sanitized synthetic async import race; no user state, app, Gateway, cookies, or credentials were accessed.

Before: a completed Local-mode import incorrectly publishes its banner over the Remote Gateway.

![Before: stale browser import success banner appears in Remote Gateway mode](https://github.com/user-attachments/assets/cf01936c-577f-4558-a79d-bf2754b7e3e6)

After: Remote Gateway mode correctly remains free of the stale browser import banner.

![After: Remote Gateway mode correctly suppresses stale browser import banners](https://github.com/user-attachments/assets/9220219c-be2c-445e-b8cb-3c53e8743264)

- Authentic pre-fix macOS XCTest: four assertions failed across late success and late failure, including the actual rendered banner labels.
- Existing owner and rendering siblings after fix: **19 native tests passed**.
- `swiftformat --lint` and strict `swiftlint` both passed; independent whole-change review found no P0/P1 findings.
- Production LOC: **+1/-1, net 0**; meaningful native lifecycle regressions: **+36 test lines**.
