### PR TITLE
fix(ui): show debug snapshot refresh state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI debug snapshots:** show in-card refresh progress and stable offline guidance while preserving the last successful diagnostics. (#39777) Thanks @Shennng.
 - **Update readiness:** select declared health-check owners before loading plugin APIs, preventing unrelated optional Doctor checks from interrupting upgrades while retaining mandatory readiness failures.
 
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI debug snapshots:** show in-card refresh progress and stable offline guidance while preserving the last successful diagnostics. (#39777) Thanks @Shennng.
 - **Update readiness:** select declared health-check owners before loading plugin APIs, preventing unrelated optional Doctor checks from interrupting upgrades while retaining mandatory readiness failures.
 
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.

--- a/ui/src/e2e/debug-diagnostics.e2e.test.ts
+++ b/ui/src/e2e/debug-diagnostics.e2e.test.ts
@@ -115,6 +115,44 @@ suite.define(() => {
             path: path.join(proofDir, "models-snapshot.png"),
           });
         }
+
+        const refresh = snapshots.getByRole("button", { name: "Refresh" });
+        const statusRequestCount = (await gateway.getRequests("status")).length;
+        await gateway.deferNext("status");
+        await refresh.click();
+        await gateway.waitForRequest("status", { after: statusRequestCount });
+        await expect
+          .poll(() => snapshots.textContent())
+          .toContain("Refreshing Gateway diagnostics.");
+        await expect.poll(() => snapshots.textContent()).toContain("diagnostics-e2e");
+        expect(
+          await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+        ).toBe(true);
+        if (captureUiProof) {
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(proofDir, "refreshing-desktop.png"),
+          });
+        }
+
+        await gateway.resolveDeferred("status");
+        await expect.poll(() => refresh.textContent()).toMatch(/^\s*Refresh\s*$/u);
+        await gateway.setOnline(false);
+        await expect
+          .poll(() => snapshots.textContent())
+          .toMatch(/Offline\s+Connect to the Gateway/u);
+        expect(await refresh.isDisabled()).toBe(true);
+        await expect.poll(() => snapshots.textContent()).toContain("diagnostics-e2e");
+        await page.setViewportSize({ height: 844, width: 390 });
+        expect(
+          await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+        ).toBe(true);
+        if (captureUiProof) {
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(proofDir, "offline-mobile.png"),
+          });
+        }
       },
     );
   });

--- a/ui/src/i18n/locales/en-debug.ts
+++ b/ui/src/i18n/locales/en-debug.ts
@@ -6,6 +6,8 @@ const enDebug = {
   debug: {
     snapshotsTitle: "Snapshots",
     snapshotsSubtitle: "Status, health, and heartbeat data.",
+    refreshingSnapshots: "Refreshing Gateway diagnostics.",
+    offlineSnapshots: "Connect to the Gateway to refresh diagnostics.",
     status: "Status",
     health: "Health",
     lastHeartbeat: "Last heartbeat",

--- a/ui/src/pages/debug/debug-page.ts
+++ b/ui/src/pages/debug/debug-page.ts
@@ -193,6 +193,8 @@ class DebugPage extends OpenClawLightDomElement {
 
   override render() {
     const debugView = renderDebug({
+      connected: this.gateway.connected,
+      offlineStable: this.gateway.snapshot?.offlineStable ?? false,
       loading: this.diagnosticsTask.status === TaskStatus.PENDING,
       status: this.debugStatus,
       health: this.debugHealth,

--- a/ui/src/pages/debug/view.test.ts
+++ b/ui/src/pages/debug/view.test.ts
@@ -62,10 +62,15 @@ function deferred<T>() {
 
 function createDebugApplicationContext(
   request: (method: string) => Promise<unknown>,
+  phase: ApplicationGatewaySnapshot["phase"] = "connected",
 ): ApplicationContext {
   const client = { request } as unknown as GatewayBrowserClient;
   const gateway = {
-    snapshot: { phase: "connected", client } as ApplicationGatewaySnapshot,
+    snapshot: {
+      phase,
+      client: phase === "connected" ? client : null,
+      offlineStable: phase === "offline",
+    } as ApplicationGatewaySnapshot,
     eventLog: [],
     subscribe: () => () => undefined,
     subscribeEventLog: () => () => undefined,
@@ -128,6 +133,8 @@ function expectSnapshots(page: TestDebugPage, marker: string): void {
 
 function createProps(overrides: Partial<DebugProps> = {}): DebugProps {
   return {
+    connected: true,
+    offlineStable: false,
     loading: false,
     status: null,
     health: null,
@@ -167,6 +174,39 @@ afterEach(async () => {
 });
 
 describe("renderDebug", () => {
+  it("disables refresh and explains how to recover while disconnected", () => {
+    const container = document.createElement("div");
+    render(
+      renderDebug(
+        createProps({
+          connected: false,
+          offlineStable: true,
+        }),
+      ),
+      container,
+    );
+    expect(container.querySelector<HTMLButtonElement>("button")?.disabled).toBe(true);
+    expect(normalizedText(container.querySelector(".settings-section"))).toContain(
+      "Offline Connect to the Gateway to refresh diagnostics.",
+    );
+  });
+  it("shows in-card refresh progress without hiding last-good snapshots", () => {
+    const container = document.createElement("div");
+    render(
+      renderDebug(
+        createProps({
+          loading: true,
+          status: { version: "last-good" },
+        }),
+      ),
+      container,
+    );
+    expect(normalizedText(container.querySelector(".settings-section"))).toContain(
+      "Refreshing… Refreshing Gateway diagnostics.",
+    );
+    expect(container.textContent).toContain("last-good");
+  });
+
   it("keeps the security audit command styled as monospace", async () => {
     await i18n.setLocale("zh-CN");
     const container = document.createElement("div");
@@ -261,6 +301,17 @@ describe("renderDebug", () => {
 });
 
 describe("DebugPage", () => {
+  it("does not report a transient Gateway reconnect as offline", async () => {
+    const request = vi.fn(async (method: string) => diagnosticResponse(method));
+    const page = document.createElement("openclaw-debug-page") as TestDebugPage;
+    page.context = createDebugApplicationContext(request, "reconnecting");
+    document.body.append(page);
+    await page.updateComplete;
+    const refresh = page.querySelector<HTMLButtonElement>("button");
+    expect(refresh?.disabled).toBe(true);
+    expect(normalizedText(page.querySelector(".settings-section"))).not.toContain("Offline");
+  });
+
   it.each([
     { label: "response", staleError: false },
     { label: "error", staleError: true },

--- a/ui/src/pages/debug/view.ts
+++ b/ui/src/pages/debug/view.ts
@@ -21,6 +21,8 @@ import { DEBUG_OVERLAY_SHORTCUT_LABEL } from "./debug-overlay-contract.ts";
 import { renderCommandLaneRows } from "./lane-table.ts";
 
 type DebugProps = {
+  connected: boolean;
+  offlineStable: boolean;
   loading: boolean;
   status: Record<string, unknown> | null;
   health: Record<string, unknown> | null;
@@ -98,6 +100,21 @@ function renderDiagnosticsError(error: string | null) {
   `;
 }
 
+function renderSnapshotActivity(props: DebugProps) {
+  const active = props.connected ? props.loading : props.offlineStable;
+  if (!active) {
+    return nothing;
+  }
+  const refreshing = props.connected;
+  return renderSettingsRow({
+    title: renderSettingsStatus({
+      kind: refreshing ? "accent" : "muted",
+      label: t(refreshing ? "common.refreshing" : "common.offline"),
+    }),
+    description: t(refreshing ? "debug.refreshingSnapshots" : "debug.offlineSnapshots"),
+  });
+}
+
 function renderEventRow(evt: EventLogEntry) {
   return renderSettingsRow({
     title: evt.event,
@@ -109,19 +126,24 @@ ${unsafeHTML(highlightJsonHtml(formatEventPayload(evt.payload)))}</pre>`,
 }
 
 export function renderDebug(props: DebugProps) {
+  const refreshPending = props.connected && props.loading;
   const snapshotsSection = renderSettingsSection(
     {
       title: t("debug.snapshotsTitle"),
       description: t("debug.snapshotsSubtitle"),
       actions: html`
-        <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
-          ${props.loading ? t("common.refreshing") : t("common.refresh")}
+        <button
+          class="btn"
+          ?disabled=${!props.connected || props.loading}
+          @click=${props.onRefresh}
+        >
+          ${refreshPending ? t("common.refreshing") : t("common.refresh")}
         </button>
       `,
     },
     html`
-      ${renderDiagnosticsError(props.diagnosticsError)} ${renderSecurityRow(props)}
-      ${renderJsonRow(t("debug.status"), props.status)}
+      ${renderSnapshotActivity(props)} ${renderDiagnosticsError(props.diagnosticsError)}
+      ${renderSecurityRow(props)} ${renderJsonRow(t("debug.status"), props.status)}
       ${renderJsonRow(t("debug.health"), props.health)}
       ${renderJsonRow(t("debug.lastHeartbeat"), props.heartbeat)}
     `,


### PR DESCRIPTION
Closes #39777

Supersedes https://github.com/openclaw/openclaw/pull/39806 while preserving the original contributor credit.

## What Problem This Solves

Debug > Snapshots had two silent states:

- refresh changed only the button label, with no in-card progress feedback;
- Refresh remained actionable while disconnected even though the page owner returned without making a request.

## Root Cause And Fix

`GatewayPageController` already owns the authoritative connection lifecycle, including the delayed `offlineStable` fact. The Debug page owned diagnostics task state and last-good snapshots, but its view received only the task state.

This change threads the existing `connected` and `offlineStable` facts into the pure view. The Snapshots card now:

- disables Refresh while loading or disconnected;
- shows localized in-card Refreshing or stable Offline guidance;
- keeps the last successful status, health, and heartbeat rows visible;
- avoids labeling transient reconnects as Offline.

No parallel connection state, CSS, configuration, schema, protocol, fallback, Code Mode, or Talk surface was added.

## Verification

Pre-fix proof on fresh main:

- `node scripts/run-vitest.mjs ui/src/pages/debug/view.test.ts`: 2 new regressions failed; 16 existing tests passed.
- mocked-Gateway E2E: failed because the card contained only `Refreshing...`, not `Refreshing Gateway diagnostics.`; the harness retained a failure screenshot.

Exact head `d6b0291b00ff619f774504bcff55d3094aaaa3d9`:

- `node scripts/run-vitest.mjs ui/src/pages/debug/view.test.ts`: 18 passed.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/debug-diagnostics.e2e.test.ts`: 1 passed.
- desktop 1280x1000 and mobile 390x844 screenshots plus video confirm visible state, retained last-good rows, disabled offline Refresh, and no horizontal overflow.
- `pnpm tsgo:ui`: passed.
- `pnpm ui:i18n:verify`: passed.
- changed production files: Lit analyzer found 0 problems.
- changed files: formatting, oxlint, stylelint, conflict-marker, changelog-attribution, and `git diff --check` gates passed.
- independent `gpt-5.6-sol` high-reasoning review: scoped clean at P0-P2, confidence 0.94.

The repo-wide Lit analyzer currently reports 296 pre-existing errors in 125 untouched files; neither changed production file appears in that output.

## Historical CI Classification

The six failures on the prior head were unrelated to this Debug UI surface:

1. `checks-ui-e2e (1/4)`: cron authoring browser promise was garbage-collected.
2. `checks-node-compact-large-12`: fast-abort dispatch test timed out.
3. `checks-node-compact-large-11`: Vitest project-ownership baseline omitted an existing retry test.
4. `checks-node-compact-large-9`: selected-agent model-resolution test timed out.
5. `checks-node-compact-small-6`: custom onboarding alias test timed out.
6. `openclaw/ci-gate`: aggregate failure caused by the five jobs above.

None touched the six files in this refreshed commit. The current exact-head CI run is authoritative.

## Surface

- Production: +30/-4 (net +26).
- Tests: +90/-1 (net +89).
- Changelog: +1.
- Removed paths: none; the repair reuses the existing Gateway lifecycle and settings-row primitives.

Maintainer LOC decision: accept the net +26 production lines. A net-neutral rewrite would require either moving Debug-specific presentation policy into the shared Gateway lifecycle owner, removing the required in-card outcome, or obscuring the two-state mapping in dense template logic. The added surface is limited to two existing lifecycle facts, two localized strings, and one settings-row projection.

Test coverage is split intentionally: pure-view/component tests cover state projection and transient reconnect behavior, while the mocked-Gateway Playwright lane covers the real request boundary, retained snapshots, responsive layout, and visual output.
