### PR TITLE
fix(ui): usage copy actions silently hide clipboard failures

### DIFF
--- a/ui/src/pages/usage/view-overview.test.ts
+++ b/ui/src/pages/usage/view-overview.test.ts
@@ -627,7 +627,6 @@ describe("renderSessionsCard", () => {
     );
 
     const copyButton = rows[0]?.querySelector<HTMLButtonElement>(".session-bar-actions button");
-    expect(copyButton?.className).toBe("btn btn--sm btn--ghost");
     copyButton?.click();
     await vi.waitFor(() => {
       expect(copyButton?.textContent?.trim()).toBe(feedback);

--- a/ui/src/pages/usage/view-overview.test.ts
+++ b/ui/src/pages/usage/view-overview.test.ts
@@ -82,6 +82,7 @@ function renderDailyChart(
 afterEach(() => {
   document.body.replaceChildren();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 function directText(element: Element | null | undefined): string | undefined {
@@ -557,7 +558,16 @@ describe("renderCostWindowComparison", () => {
 describe("renderSessionsCard", () => {
   const noop = () => {};
 
-  it("renders named native session toggles while preserving shift selection and separate copy", () => {
+  it.each([
+    { copied: true, feedback: "Copied!" },
+    { copied: false, feedback: "Copy failed" },
+  ])("keeps session selection separate while showing $feedback", async ({ copied, feedback }) => {
+    const writeText = vi.fn(async () => {
+      if (!copied) {
+        throw new Error("Clipboard access denied");
+      }
+    });
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
     const container = document.createElement("div");
     document.body.append(container);
     const onSelectSession = vi.fn<(key: string, shiftKey: boolean) => void>();
@@ -616,7 +626,16 @@ describe("renderSessionsCard", () => {
       sessions.map((s) => s.key),
     );
 
-    rows[0]?.querySelector<HTMLButtonElement>(".session-bar-actions button")?.click();
+    const copyButton = rows[0]?.querySelector<HTMLButtonElement>(".session-bar-actions button");
+    expect(copyButton?.className).toBe("btn btn--sm btn--ghost");
+    copyButton?.click();
+    await vi.waitFor(() => {
+      expect(copyButton?.textContent?.trim()).toBe(feedback);
+      expect(copyButton?.getAttribute("aria-label")).toBe(feedback);
+    });
+    expect(writeText).toHaveBeenCalledWith("Selected thread");
+    expect(copyButton?.dataset[copied ? "copied" : "error"]).toBe("1");
+    expect(copyButton?.dataset[copied ? "error" : "copied"]).toBeUndefined();
     expect(onSelectSession).toHaveBeenCalledOnce();
     rows[0]?.querySelector<HTMLElement>(".session-bar-value")?.click();
     expect(onSelectSession).toHaveBeenCalledWith(

--- a/ui/src/pages/usage/view-overview.ts
+++ b/ui/src/pages/usage/view-overview.ts
@@ -4,10 +4,10 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Control UI view renders usage render overview screen content.
 import { html, nothing } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { handleCopyButton } from "../../components/copy-button.ts";
 import { renderSettingsSection } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import "../../components/tooltip.ts";
-import { copyToClipboard } from "../../lib/clipboard.ts";
 import { formatDurationCompact } from "../../lib/format.ts";
 import {
   buildUsageCostWindows,
@@ -926,10 +926,10 @@ function renderSessionsCard(
             class="btn btn--sm btn--ghost"
             @click=${(e: MouseEvent) => {
               e.stopPropagation();
-              void copyToClipboard(formatSessionListLabel(s));
+              void handleCopyButton(e, formatSessionListLabel(s), t("usage.sessions.copy"));
             }}
           >
-            ${t("usage.sessions.copy")}
+            <span data-copy-label>${t("usage.sessions.copy")}</span>
           </button>
           <div class="session-bar-value">
             ${isTokenMode ? formatUsageTokens(value) : formatAnalysisCost(value)}


### PR DESCRIPTION
## What Problem This Solves

The Usage page's session Copy action discarded the clipboard result, leaving both successful and failed attempts without visible or accessible feedback.

## Why This Change Was Made

The row now reuses the existing shared copy-button owner for temporary visible and accessible success/failure feedback. It retains the native button, localization, and separate session-selection action. The newer visible-order Shift-click contract from #130375 is preserved. No new clipboard implementation, configuration, dependency, storage, or fallback path is added.

## User Impact

Successful session copies display `Copied!`; failed writes display `Copy failed`, with corresponding screen-reader labels. Copying a different session does not select it or disturb an existing selection.

## Evidence

Refreshed head: `c801ac0c531f49102ed2e585395eb658beda111c`. Production **+3/-3, net 0**; tests **+20/-2**. A brittle exact CSS-class assertion was removed; the regression protects actual feedback and selection behavior.

- Fresh pre-fix reproduction fails exactly the two feedback cases (18 other cases pass); the repaired owner and siblings pass **69 tests across six files**.
- Fresh independent whole-change P1 review reports no actionable findings. Targeted formatting, type-aware lint, styles, and localization checks pass.
- A clean pinned-dependency snapshot passes `node scripts/run-tsgo-core-test-shards.mjs` and the complete matching runtime build. All 34,121 tracked source blobs match the candidate before/after build and after the baseline proof was restored. The final commit only removes one test assertion; runtime production is identical.
- Full real Control UI connected to a matching real Gateway, using fresh isolated synthetic state. Sessions were created/injected through supported CLI calls; no real account, credentials, or provider call was used. This supersedes the earlier standalone-component screenshots.
- Independent source-blind Chromium validation: **12 checks pass, no failures or blockers**, plus two explicitly excluded scopes. Actual clipboard readback covered three different names including `Résumé – café`; success → failure → recovery, copying unselected rows, visible-order adjacent/nonadjacent Shift-click, page reload, and toolbar Refresh all preserved the expected selection behavior.
- Ordinary exact-head [CI run 33028300461](https://github.com/openclaw/openclaw/actions/runs/33028300461) is green, including the [required gate](https://github.com/openclaw/openclaw/actions/runs/33028300461/job/98377220003), UI browser shards, real-Gateway UI E2E, production/test types, lint, build, and selected test shards. No CI rerun was needed for this refreshed head.

Before, on the exact pre-fix owner: a real successful write and a simulated failed write both leave `Copy` unchanged.

![Before: full Usage page leaves both copy outcomes silent](https://github.com/user-attachments/assets/dd221353-47dd-4f15-9df0-ba41881354e1)

After, in the same full app: the successful action shows `Copied!`, the failed action shows `Copy failed`, and the untouched action remains `Copy`.

![After: full Usage page reports successful and failed copy outcomes](https://github.com/user-attachments/assets/d6a0348a-6520-403d-9f99-519a0e679fd6)

The independent validator also captured [successful copying](https://github.com/user-attachments/assets/3e2417b2-32dc-4f73-837e-bf768d5945e1) and [failed copying with unchanged selection](https://github.com/user-attachments/assets/76d4de84-f6c2-4bfb-8c13-f10f6f9d9743). Every published screenshot was inspected and contains only synthetic data.

Limitations: clipboard failure was explicitly simulated by rejecting the primary write and disabling the copy fallback; success/readback used the real clipboard. This is not a claim of actual browser permission denial, live-provider testing, other-browser coverage, or a packaged release. An optional Testbox attempt timed out during source sync and is not counted as passing proof. The original local shared install had stale dependency exports; the clean pinned snapshot and exact-head hosted type checks pass without source/type workarounds.

ClawSweeper's prior rank-up requested a refresh and green exact-head checks; both are complete. Its recorded live-command failure waited for a test-name substring even though its attached Vitest output showed 20 passed. Fresh fail-first, browser proof, and exact-head CI verify the actual behavior. A fresh re-review was requested once and remains separately in progress.
