### PR TITLE
fix(macos): select a supported Node version during onboarding

### DIFF
--- a/apps/macos/Sources/OpenClaw/CommandResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CommandResolver.swift
@@ -220,26 +220,17 @@ enum CommandResolver {
             return []
         }
 
-        func parseVersion(_ name: String) -> [Int] {
-            let trimmed = name.hasPrefix("v") ? String(name.dropFirst()) : name
-            return trimmed.split(separator: ".").compactMap { Int($0) }
-        }
-
-        let sorted = entries.sorted { a, b in
-            let va = parseVersion(a)
-            let vb = parseVersion(b)
-            let maxCount = max(va.count, vb.count)
-            for i in 0..<maxCount {
-                let ai = i < va.count ? va[i] : 0
-                let bi = i < vb.count ? vb[i] : 0
-                if ai != bi { return ai > bi }
-            }
-            // If identical numerically, keep stable ordering.
-            return a > b
+        let sorted = entries.compactMap { entry -> (name: String, version: RuntimeVersion)? in
+            guard let version = RuntimeVersion.from(string: entry),
+                  RuntimeLocator.isSupportedNodeVersion(version)
+            else { return nil }
+            return (entry, version)
+        }.sorted { first, second in
+            first.version == second.version ? first.name > second.name : first.version > second.version
         }
 
         var paths: [String] = []
-        for entry in sorted {
+        for (entry, _) in sorted {
             let binDir = base.appendingPathComponent(entry).appendingPathComponent(suffix)
             let node = binDir.appendingPathComponent("node")
             if FileManager().isExecutableFile(atPath: node.path) {
@@ -721,10 +712,4 @@ enum CommandResolver {
         args.append(contentsOf: remoteCommand)
         return args
     }
-
-    #if SWIFT_PACKAGE
-    static func _testNodeManagerBinPaths(home: URL) -> [String] {
-        self.nodeManagerBinPaths(home: home)
-    }
-    #endif
 }

--- a/apps/macos/Tests/OpenClawIPCTests/NodeManagerPathsTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/NodeManagerPathsTests.swift
@@ -3,28 +3,79 @@ import Testing
 @testable import OpenClaw
 
 struct NodeManagerPathsTests {
-    @Test func `fnm node bins prefer newest installed version`() throws {
+    @Test func `fnm node bins prefer the newest supported installed version`() throws {
         let home = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: home) }
 
-        let v20Bin = home
-            .appendingPathComponent(".local/share/fnm/node-versions/v20.19.5/installation/bin/node")
-        let v25Bin = home
-            .appendingPathComponent(".local/share/fnm/node-versions/v25.1.0/installation/bin/node")
-        try makeExecutableForTests(at: v20Bin)
-        try makeExecutableForTests(at: v25Bin)
+        let v22Node = home
+            .appendingPathComponent(".local/share/fnm/node-versions/v22.22.3/installation/bin/node")
+        let v25Node = home
+            .appendingPathComponent(".local/share/fnm/node-versions/v25.9.0/installation/bin/node")
+        try makeExecutableForTests(at: v22Node)
+        try makeExecutableForTests(at: v25Node)
 
-        let bins = CommandResolver._testNodeManagerBinPaths(home: home)
-        #expect(bins.first == v25Bin.deletingLastPathComponent().path)
-        #expect(bins.contains(v20Bin.deletingLastPathComponent().path))
+        let paths = CommandResolver.preferredPaths(home: home, current: [], projectRoot: home)
+        let newestIndex = try #require(paths.firstIndex(of: v25Node.deletingLastPathComponent().path))
+        let olderIndex = try #require(paths.firstIndex(of: v22Node.deletingLastPathComponent().path))
+
+        #expect(newestIndex < olderIndex)
+    }
+
+    @Test(arguments: [
+        (".local/share/fnm/node-versions", "installation/bin"),
+        (".nvm/versions/node", "bin"),
+    ])
+    func `unsupported newer manager runtimes cannot hide a supported installed Node`(
+        managerRoot: String,
+        binarySuffix: String) async throws
+    {
+        let home = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let versions = ["v25.8.1", "v24.15.0", "v23.11.0", "v22.22.3"]
+
+        for version in versions {
+            let node = home
+                .appendingPathComponent(managerRoot)
+                .appendingPathComponent(version)
+                .appendingPathComponent(binarySuffix)
+                .appendingPathComponent("node")
+            try makeExecutableForTests(at: node)
+            try "#!/bin/sh\necho \(version)\n".write(to: node, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: node.path)
+        }
+
+        let unsupported = home
+            .appendingPathComponent(managerRoot)
+            .appendingPathComponent("v25.8.1")
+            .appendingPathComponent(binarySuffix)
+        let expectedNode = home
+            .appendingPathComponent(managerRoot)
+            .appendingPathComponent("v24.15.0")
+            .appendingPathComponent(binarySuffix)
+            .appendingPathComponent("node")
+        let searchPaths = CommandResolver.preferredPaths(
+            home: home,
+            current: [unsupported.path],
+            projectRoot: home)
+
+        let result = await RuntimeLocator.resolve(searchPaths: searchPaths)
+
+        guard case let .success(runtime) = result else {
+            Issue.record("A newer unsupported manager runtime hid an installed supported Node: \(result)")
+            return
+        }
+        #expect(runtime.path == expectedNode.path)
+        #expect(runtime.version == RuntimeVersion(major: 24, minor: 15, patch: 0))
     }
 
     @Test func `ignores entries without node executable`() throws {
         let home = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: home) }
         let missingNodeBin = home
             .appendingPathComponent(".local/share/fnm/node-versions/v99.0.0/installation/bin")
         try FileManager().createDirectory(at: missingNodeBin, withIntermediateDirectories: true)
 
-        let bins = CommandResolver._testNodeManagerBinPaths(home: home)
-        #expect(!bins.contains(missingNodeBin.path))
+        let paths = CommandResolver.preferredPaths(home: home, current: [], projectRoot: home)
+        #expect(!paths.contains(missingNodeBin.path))
     }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users with multiple Node versions installed through fnm or nvm could be told that no usable Node runtime was available even though a fully supported version was already installed. An unsupported newer version, such as Node 25.8 or Node 23, was selected ahead of an installed supported Node 24, Node 22, or Homebrew runtime, breaking local Gateway setup and first-run onboarding.

## Why This Change Was Made

The canonical version-manager PATH discovery now uses the same existing runtime parser, supported-version policy, and version comparison already used to launch the Gateway. Unsupported versioned fnm/nvm directories are removed before PATH assembly, supported versions retain deterministic newest-first precedence, inherited shell paths remain behind valid discovered runtimes, and dynamic Volta/asdf shims and managed profile behavior are unchanged. The obsolete private version parser/comparator and a test-only production wrapper were removed.

## User Impact

Mac onboarding and local Gateway discovery automatically select the newest installed supported Node runtime instead of failing because an unsupported version-manager installation happens to have a higher version number. Users no longer need to uninstall other Node versions or manually reorder their PATH to complete setup.

## Evidence

- Authentic pre-fix native regression used temporary real executable `node` scripts for both fnm and nvm, built the actual production search PATH, and invoked the actual runtime resolver. Both manager families failed with `unsupported(found: 25.8.1)` even though the same PATH contained supported Node 24.15 and Node 22.22, plus the normal Homebrew fallback.
- After the owner-boundary refactor, `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path apps/macos --filter 'NodeManagerPathsTests|RuntimeLocatorTests|GatewayEnvironmentTests|CLIInstallerTests|CommandResolverTests|OnboardingViewSmokeTests' --no-parallel -j 4` passed all 103 native tests across version-manager discovery, runtime compatibility, Gateway environment, CLI setup, command resolution, and first-run onboarding.
- Focused SwiftFormat and strict SwiftLint both passed for the two changed files; the configured structured Codex review and independent frozen-diff review found no actionable issues.
- Production: +8/-23 (net -15). Tests: +63/-12. No config, profile, public CLI contract, storage, schema, signing, operator Gateway/launchd, or VM changes.
- Live owner-boundary filesystem proof executes real temporary fnm/nvm-shaped Node binaries. Full app/VM GUI proof is unavailable because the isolated guest had no authenticated login and was already restored/stopped; no signing or operator-service changes were made.
