### PR TITLE
refactor(plugins): remove obsolete compaction registry facade

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -413,7 +413,6 @@ const config = {
     // Runtime reason values are exported now so protocol schemas can derive from one tuple later.
     "src/agents/failover/signal.ts": ["exports"],
     "src/context-engine/registry.ts": ["exports", "types"],
-    "src/plugins/compaction-provider.ts": ["exports"],
     "src/plugins/interactive-registry.ts": ["exports"],
     "src/plugins/memory-state.ts": ["exports", "types"],
     "src/plugins/session-discussion-registry.ts": ["exports"],

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -9,7 +9,10 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { CompactionProvider } from "../../plugins/compaction-provider.js";
-import { requireActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  requireActivePluginRegistry,
+  resetPluginRuntimeStateForTest,
+} from "../../plugins/runtime.js";
 import * as compactionModule from "../compaction.js";
 import { buildEmbeddedExtensionFactories } from "../embedded-agent-runner/extensions.js";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
@@ -134,6 +137,7 @@ beforeEach(() => {
 
 afterEach(() => {
   testing.setSummarizeInStagesForTest();
+  resetPluginRuntimeStateForTest();
 });
 
 function installCompactionProviderForTest(provider: CompactionProvider): void {

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -8,10 +8,8 @@ import { createAssistantMessageEventStream, type Model } from "openclaw/plugin-s
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import {
-  clearCompactionProviders,
-  registerCompactionProvider,
-} from "../../plugins/compaction-provider.js";
+import type { CompactionProvider } from "../../plugins/compaction-provider.js";
+import { requireActivePluginRegistry } from "../../plugins/runtime.js";
 import * as compactionModule from "../compaction.js";
 import { buildEmbeddedExtensionFactories } from "../embedded-agent-runner/extensions.js";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
@@ -136,8 +134,11 @@ beforeEach(() => {
 
 afterEach(() => {
   testing.setSummarizeInStagesForTest();
-  clearCompactionProviders();
 });
+
+function installCompactionProviderForTest(provider: CompactionProvider): void {
+  requireActivePluginRegistry().compactionProviders.push({ provider });
+}
 
 function stubSessionManager(): ExtensionContext["sessionManager"] {
   const stub: ExtensionContext["sessionManager"] = {
@@ -2804,7 +2805,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
       name: "AbortError",
     });
     const failingProviderSummarize = vi.fn().mockRejectedValue(providerAbortErr);
-    registerCompactionProvider({
+    installCompactionProviderForTest({
       id: "disconnecting-provider",
       label: "Disconnecting Provider",
       summarize: failingProviderSummarize,
@@ -2851,7 +2852,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
       name: "AbortError",
     });
     const failingProviderSummarize = vi.fn().mockRejectedValue(providerAbortErr);
-    registerCompactionProvider({
+    installCompactionProviderForTest({
       id: "aborted-provider",
       label: "Aborted Provider",
       summarize: failingProviderSummarize,
@@ -2895,7 +2896,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
   it("passes compaction instructions to providers and preserves suffix context", async () => {
     mockSummarizeInStages.mockReset();
     const providerSummarize = vi.fn().mockResolvedValue("provider summary body");
-    registerCompactionProvider({
+    installCompactionProviderForTest({
       id: "test-provider",
       label: "Test Provider",
       summarize: providerSummarize,
@@ -2970,7 +2971,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
   it("preserves an above-half provider body byte-for-byte when the joined artifact fits", async () => {
     const providerBody = `BODY-START${"b".repeat(4_480)}BODY-MIDDLE${"b".repeat(4_480)}BODY-END`;
     const providerSummarize = vi.fn().mockResolvedValue(providerBody);
-    registerCompactionProvider({
+    installCompactionProviderForTest({
       id: "within-budget-provider",
       label: "Within Budget Provider",
       summarize: providerSummarize,
@@ -3009,7 +3010,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
   it("emits one redacted provider warning when the preserved-turn producer truncates", async () => {
     const sensitiveSentinel = "preserved-secret-never-log";
     const providerSummarize = vi.fn().mockResolvedValue("provider summary body");
-    registerCompactionProvider({
+    installCompactionProviderForTest({
       id: "preserved-overflow-provider",
       label: "Preserved Overflow Provider",
       summarize: providerSummarize,
@@ -3054,7 +3055,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     const sensitiveSentinel = "credential-sentinel-never-log";
     const providerBody = `BODY-START${"b".repeat(3_400)}BODY-MIDDLE${"b".repeat(3_400)}BODY-END`;
     const providerSummarize = vi.fn().mockResolvedValue(providerBody);
-    registerCompactionProvider({
+    installCompactionProviderForTest({
       id: "overflow-provider",
       label: "Overflow Provider",
       summarize: providerSummarize,
@@ -3108,7 +3109,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
   it("starts a finally trimmed raw split-turn suffix at a complete message boundary", async () => {
     const providerBody = `BODY-START${"b".repeat(6_760)}BODY-END`;
     const providerSummarize = vi.fn().mockResolvedValue(providerBody);
-    registerCompactionProvider({
+    installCompactionProviderForTest({
       id: "boundary-provider",
       label: "Boundary Provider",
       summarize: providerSummarize,
@@ -3155,7 +3156,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
   it("finally trims a raw tool interaction only at its atomic boundary", async () => {
     const providerSummarize = vi.fn().mockResolvedValue(`BODY-START${"b".repeat(9_000)}BODY-END`);
-    registerCompactionProvider({
+    installCompactionProviderForTest({
       id: "tool-boundary-provider",
       label: "Tool Boundary Provider",
       summarize: providerSummarize,

--- a/src/plugins/compaction-provider.test.ts
+++ b/src/plugins/compaction-provider.test.ts
@@ -1,10 +1,14 @@
 /** Covers canonical plugin compaction provider registration and runtime lookup. */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { getCompactionProvider, type CompactionProvider } from "./compaction-provider.js";
 import { createPluginRecord } from "./loader-records.js";
 import { createPluginRegistry } from "./registry.js";
-import { setActivePluginRegistry } from "./runtime.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
 import type { PluginRuntime } from "./runtime/types.js";
+
+afterEach(() => {
+  resetPluginRuntimeStateForTest();
+});
 
 function createTestRegistry() {
   return createPluginRegistry({

--- a/src/plugins/compaction-provider.test.ts
+++ b/src/plugins/compaction-provider.test.ts
@@ -1,19 +1,33 @@
-/** Covers plugin compaction provider registration and lookup behavior. */
-import { afterEach, describe, expect, it } from "vitest";
-import {
-  clearCompactionProviders,
-  getCompactionProvider,
-  getRegisteredCompactionProvider,
-  listRegisteredCompactionProviders,
-  registerCompactionProvider,
-  type CompactionProvider,
-} from "./compaction-provider.js";
-import { createEmptyPluginRegistry } from "./registry-empty.js";
-import { setActivePluginRegistry, withPluginRegistrationContext } from "./runtime.js";
+/** Covers canonical plugin compaction provider registration and runtime lookup. */
+import { describe, expect, it } from "vitest";
+import { getCompactionProvider, type CompactionProvider } from "./compaction-provider.js";
+import { createPluginRecord } from "./loader-records.js";
+import { createPluginRegistry } from "./registry.js";
+import { setActivePluginRegistry } from "./runtime.js";
+import type { PluginRuntime } from "./runtime/types.js";
 
-afterEach(() => {
-  clearCompactionProviders();
-});
+function createTestRegistry() {
+  return createPluginRegistry({
+    logger: {
+      info() {},
+      warn() {},
+      error() {},
+      debug() {},
+    },
+    runtime: {} as PluginRuntime,
+    activateGlobalSideEffects: false,
+  });
+}
+
+function createRecord(id: string) {
+  return createPluginRecord({
+    id,
+    source: `/plugins/${id}/index.ts`,
+    origin: "global",
+    enabled: true,
+    configSchema: false,
+  });
+}
 
 function makeProvider(id: string, label?: string): CompactionProvider {
   return {
@@ -25,134 +39,43 @@ function makeProvider(id: string, label?: string): CompactionProvider {
   };
 }
 
-function requireCompactionProvider(id: string): CompactionProvider {
-  const provider = getCompactionProvider(id);
-  if (!provider) {
-    throw new Error(`Expected compaction provider ${id}`);
-  }
-  return provider;
-}
-
-function listCompactionProviderIdsForTest(): string[] {
-  return listRegisteredCompactionProviders().map((entry) => entry.provider.id);
-}
-
 describe("compaction provider registry", () => {
-  it("starts empty", () => {
-    expect(listCompactionProviderIdsForTest()).toStrictEqual([]);
-    expect(listRegisteredCompactionProviders()).toStrictEqual([]);
-  });
+  it("reads providers registered through the plugin API from the active registry", async () => {
+    const pluginRegistry = createTestRegistry();
+    const provider = makeProvider("owned");
+    pluginRegistry
+      .createApi(createRecord("owner"), { config: {} })
+      .registerCompactionProvider(provider);
+    setActivePluginRegistry(pluginRegistry.registry);
 
-  it("returns undefined for an unknown id", () => {
-    expect(getCompactionProvider("nonexistent")).toBeUndefined();
-    expect(getRegisteredCompactionProvider("nonexistent")).toBeUndefined();
-  });
-
-  it("registers and retrieves a provider", () => {
-    const p = makeProvider("test-compactor");
-    registerCompactionProvider(p);
-
-    expect(getCompactionProvider("test-compactor")).toBe(p);
-  });
-
-  it("tracks ownerPluginId", () => {
-    const p = makeProvider("owned");
-    registerCompactionProvider(p, { ownerPluginId: "my-plugin" });
-
-    const entry = getRegisteredCompactionProvider("owned");
-    expect(entry?.provider).toBe(p);
-    expect(entry?.ownerPluginId).toBe("my-plugin");
-  });
-
-  it("writes direct registration helpers into the synchronous builder context", () => {
-    const active = createEmptyPluginRegistry();
-    const building = createEmptyPluginRegistry();
-    setActivePluginRegistry(active);
-    const provider = makeProvider("builder-owned");
-
-    withPluginRegistrationContext(building, "builder-plugin", () => {
-      registerCompactionProvider(provider);
-    });
-
-    expect(active.compactionProviders).toStrictEqual([]);
-    expect(building.compactionProviders).toEqual([{ provider, ownerPluginId: "builder-plugin" }]);
-  });
-
-  it("does not let a registering plugin displace another owner's provider", () => {
-    const building = createEmptyPluginRegistry();
-    const original = makeProvider("shared", "original");
-    building.compactionProviders.push({ provider: original, ownerPluginId: "first-plugin" });
-
-    expect(() =>
-      withPluginRegistrationContext(building, "failing-plugin", () => {
-        registerCompactionProvider(makeProvider("shared", "replacement"));
-      }),
-    ).toThrow("compaction provider shared already registered by first-plugin");
-    expect(building.compactionProviders).toEqual([
-      { provider: original, ownerPluginId: "first-plugin" },
+    expect(pluginRegistry.registry.compactionProviders).toEqual([
+      { provider, ownerPluginId: "owner" },
     ]);
+    await expect(getCompactionProvider("owned")?.summarize({ messages: [] })).resolves.toBe(
+      "summary-from-owned",
+    );
   });
 
-  it("lists registered provider ids", () => {
-    registerCompactionProvider(makeProvider("alpha"));
-    registerCompactionProvider(makeProvider("beta"));
+  it("keeps the first provider when another plugin registers the same id", () => {
+    const pluginRegistry = createTestRegistry();
+    const first = makeProvider("shared", "first");
+    const second = makeProvider("shared", "second");
+    pluginRegistry
+      .createApi(createRecord("first-owner"), { config: {} })
+      .registerCompactionProvider(first);
+    pluginRegistry
+      .createApi(createRecord("second-owner"), { config: {} })
+      .registerCompactionProvider(second);
 
-    expect(listCompactionProviderIdsForTest()).toEqual(["alpha", "beta"]);
-  });
-
-  it("lists registered entries with owner metadata", () => {
-    registerCompactionProvider(makeProvider("a"), { ownerPluginId: "plugin-a" });
-    registerCompactionProvider(makeProvider("b"));
-
-    const entries = listRegisteredCompactionProviders();
-    expect(entries).toHaveLength(2);
-    expect(entries[0]?.provider.id).toBe("a");
-    expect(entries[0]?.ownerPluginId).toBe("plugin-a");
-    expect(entries[1]?.provider.id).toBe("b");
-    expect(entries[1]?.ownerPluginId).toBeUndefined();
-  });
-
-  it("supports multiple providers", () => {
-    registerCompactionProvider(makeProvider("a"));
-    registerCompactionProvider(makeProvider("b"));
-    registerCompactionProvider(makeProvider("c"));
-
-    expect(getCompactionProvider("a")?.id).toBe("a");
-    expect(getCompactionProvider("b")?.id).toBe("b");
-    expect(getCompactionProvider("c")?.id).toBe("c");
-    expect(listCompactionProviderIdsForTest()).toHaveLength(3);
-  });
-
-  it("calls summarize and returns expected result", async () => {
-    registerCompactionProvider(makeProvider("my-compactor"));
-
-    const provider = requireCompactionProvider("my-compactor");
-    const result = await provider.summarize({ messages: [] });
-
-    expect(result).toBe("summary-from-my-compactor");
-  });
-
-  it("overwrites when re-registering the same id", () => {
-    const first = makeProvider("dup", "first-label");
-    const second = makeProvider("dup", "second-label");
-
-    registerCompactionProvider(first);
-    registerCompactionProvider(second);
-
-    expect(getCompactionProvider("dup")).toBe(second);
-    expect(getCompactionProvider("dup")?.label).toBe("second-label");
-    expect(listCompactionProviderIdsForTest()).toEqual(["dup"]);
-  });
-
-  describe("lifecycle", () => {
-    it("clear removes all providers", () => {
-      registerCompactionProvider(makeProvider("a"));
-      registerCompactionProvider(makeProvider("b"));
-      expect(listCompactionProviderIdsForTest()).toHaveLength(2);
-
-      clearCompactionProviders();
-      expect(listCompactionProviderIdsForTest()).toStrictEqual([]);
-      expect(getCompactionProvider("a")).toBeUndefined();
-    });
+    expect(pluginRegistry.registry.compactionProviders).toEqual([
+      { provider: first, ownerPluginId: "first-owner" },
+    ]);
+    expect(pluginRegistry.registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        pluginId: "second-owner",
+        message: "compaction provider already registered: shared (owner: first-owner)",
+      }),
+    );
   });
 });

--- a/src/plugins/compaction-provider.ts
+++ b/src/plugins/compaction-provider.ts
@@ -1,55 +1,9 @@
-import type {
-  CompactionProvider,
-  RegisteredCompactionProvider,
-} from "./registry-contribution-types.js";
-import {
-  assertDirectPluginRegistrationReplacement,
-  requireActivePluginRegistry,
-  resolveDirectPluginRegistrationOwner,
-} from "./runtime.js";
+import type { CompactionProvider } from "./registry-contribution-types.js";
+import { requireActivePluginRegistry } from "./runtime.js";
 
 export type { CompactionProvider } from "./registry-contribution-types.js";
 
-const getProviders = () => requireActivePluginRegistry().compactionProviders;
-
-export function registerCompactionProvider(
-  provider: CompactionProvider,
-  options?: { ownerPluginId?: string },
-): void {
-  const providers = getProviders();
-  const ownerPluginId = resolveDirectPluginRegistrationOwner(options?.ownerPluginId);
-  const entry = {
-    provider,
-    ownerPluginId,
-  };
-  const index = providers.findIndex((registered) => registered.provider.id === provider.id);
-  if (index !== -1) {
-    assertDirectPluginRegistrationReplacement(
-      providers[index]?.ownerPluginId,
-      `compaction provider ${provider.id}`,
-    );
-  }
-  if (index === -1) {
-    providers.push(entry);
-  } else {
-    providers.splice(index, 1, entry);
-  }
-}
-
 export function getCompactionProvider(id: string): CompactionProvider | undefined {
-  return getProviders().find((entry) => entry.provider.id === id)?.provider;
-}
-
-export function getRegisteredCompactionProvider(
-  id: string,
-): RegisteredCompactionProvider | undefined {
-  return getProviders().find((entry) => entry.provider.id === id);
-}
-
-export function listRegisteredCompactionProviders(): RegisteredCompactionProvider[] {
-  return [...getProviders()];
-}
-
-export function clearCompactionProviders(): void {
-  getProviders().length = 0;
+  return requireActivePluginRegistry().compactionProviders.find((entry) => entry.provider.id === id)
+    ?.provider;
 }


### PR DESCRIPTION
## What Problem This Solves

The compaction provider path retained an obsolete internal registration facade after plugin contributions moved into the canonical registry bundle. Its mutation, listing, and reset helpers had no production callers, duplicated registry ownership rules, and required a dead-export allowlist exception.

## Why This Change Was Made

Remove the dead facade operations and keep the one runtime lookup needed by the compaction safeguard. Plugin API registration, validation, duplicate rejection, owner attribution, rollback, and lifecycle remain owned by the canonical plugin registry registrar. Focused tests now exercise that public plugin API path, and stateful safeguard tests reset the complete active plugin runtime after each case.

Production LOC: +4/-50 (net -46). Tests: +81/-149 (net -68). Tooling: +0/-1 (net -1). No public Plugin SDK, config, protocol, schema, dependency, or user-visible behavior changes.

## User Impact

No user-visible behavior changes. Plugins continue to register compaction providers through `api.registerCompactionProvider(...)`; configured providers retain the same active/request-scoped lookup and fallback behavior.

## Evidence

- Exact reviewed head: `da1738e5f0274de92c1ac7e56bc8817a907147b4` on base `648c60775d0a74dac9e8038bec3842e3af308bcf`. Current main has not changed any PR-owned or adjacent owner file since that base.
- Focused provider, safeguard, loader, and boundary proof: `node scripts/run-vitest.mjs src/plugins/compaction-provider.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts src/plugins/loader.test.ts src/plugins/contracts/boundary-invariants.test.ts src/plugins/contracts/core-extension-facade-boundary.test.ts` — 335 tests passed across four shards.
- Changed-file gate: `node scripts/check-changed.mjs -- config/knip.config.ts src/plugins/compaction-provider.ts src/plugins/compaction-provider.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts` — passed formatting, dead exports, typechecks, lint, plugin boundaries, import cycles, and repository safety guards.
- `git diff --check` passed.
- Fresh structured autoreview: clean, no findings, patch correct (0.99 confidence).
- Separate exact-head ephemeral read-only Codex review: `CLEAN`.
- Fresh exact-head [ClawSweeper review](https://github.com/openclaw/openclaw/pull/129565#issuecomment-5418046970): no correctness or security findings; the canonical-owner deletion is the optimal fix. Its optional current-head-check rank-up move is satisfied by the local proof and hosted CI below.
- Exact-head hosted [CI run 32906195085](https://github.com/openclaw/openclaw/actions/runs/32906195085), attempt 2: all required checks passed. The failed shard from attempt 1 was an unrelated order-sensitive gateway test; its complete file passed locally, 284/284, before the exact-head rerun passed.
- PR #129423 adds a disjoint safeguard-test hunk; #129432 and #117935 do not overlap this facade cleanup.

Team sessions: [cleanup](https://ampcode.com/threads/T-01a037b7-827c-72ea-b58b-6fef778d08fe), [independent test-isolation verification](https://ampcode.com/threads/T-01a03a1a-d1fb-75ef-a904-7083040e37f1)
