### PR TITLE
fix(macos): paused Gateway setup loses recovery after CLI installation

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
@@ -162,9 +162,8 @@ extension OnboardingView {
             (false, "OpenClaw is paused. Resume it, then retry setup to start the Gateway.")
         case let .failed(reason):
             (false, Self.gatewayStartFailureMessage(
-                prefix: afterFreshInstall
-                    ? "OpenClaw was installed, but the Gateway did not start. Retry setup."
-                    : "OpenClaw is installed, but the Gateway did not start. Retry setup.",
+                prefix: "OpenClaw \(afterFreshInstall ? "was" : "is") installed, " +
+                    "but the Gateway did not start. Retry setup.",
                 reason: reason))
         }
     }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
@@ -148,18 +148,24 @@ extension OnboardingView {
             return
         }
 
+        (cliInstalled, cliStatus) = Self.localGatewayActivationOutcome(result, afterFreshInstall: false)
+    }
+
+    static func localGatewayActivationOutcome(
+        _ result: CLIInstaller.LocalGatewayActivation,
+        afterFreshInstall: Bool) -> (ready: Bool, status: String)
+    {
         switch result {
         case .ready:
-            cliInstalled = true
-            cliStatus = "OpenClaw Gateway is ready."
+            (true, "OpenClaw Gateway is ready.")
         case .deferred:
-            cliInstalled = false
-            cliStatus = "OpenClaw is paused. Resume it, then retry setup to start the Gateway."
+            (false, "OpenClaw is paused. Resume it, then retry setup to start the Gateway.")
         case let .failed(reason):
-            cliInstalled = false
-            cliStatus = Self.gatewayStartFailureMessage(
-                prefix: "OpenClaw is installed, but the Gateway did not start. Retry setup.",
-                reason: reason)
+            (false, Self.gatewayStartFailureMessage(
+                prefix: afterFreshInstall
+                    ? "OpenClaw was installed, but the Gateway did not start. Retry setup."
+                    : "OpenClaw is installed, but the Gateway did not start. Retry setup.",
+                reason: reason))
         }
     }
 
@@ -211,18 +217,9 @@ extension OnboardingView {
         // The step checklist shows one spinner at a time: install first,
         // then the service start.
         self.cliInstallPhase = .startingService
-        switch await CLIInstaller.activateLocalGateway() {
-        case .ready:
-            cliStatus = "OpenClaw Gateway is ready."
-        case .deferred:
-            cliStatus = "OpenClaw is installed. The Gateway will start when This Mac is active and resumed."
-        case let .failed(reason):
-            cliStatus = Self.gatewayStartFailureMessage(
-                prefix: "OpenClaw was installed, but the Gateway did not start. Retry setup.",
-                reason: reason)
-            return
-        }
-        cliInstalled = true
+        (cliInstalled, cliStatus) = await Self.localGatewayActivationOutcome(
+            CLIInstaller.activateLocalGateway(),
+            afterFreshInstall: true)
     }
 
     func refreshCLIStatus() async {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -234,6 +234,36 @@ struct OnboardingViewSmokeTests {
         #expect(!OnboardingView.shouldActivateLocalGateway(afterCLIInstallFor: .remote))
     }
 
+    @Test func `paused gateway keeps CLI setup and recovery visible after every install path`() {
+        for afterFreshInstall in [false, true] {
+            let outcome = OnboardingView.localGatewayActivationOutcome(
+                .deferred,
+                afterFreshInstall: afterFreshInstall)
+
+            #expect(!outcome.ready)
+            #expect(OnboardingView.pageOrder(for: .local, requiresCLIInstall: !outcome.ready) == [0, 1, 2, 3])
+            #expect(outcome.status == "OpenClaw is paused. Resume it, then retry setup to start the Gateway.")
+        }
+    }
+
+    @Test func `local gateway activation preserves readiness and concrete failure reasons`() {
+        for afterFreshInstall in [false, true] {
+            let ready = OnboardingView.localGatewayActivationOutcome(
+                .ready,
+                afterFreshInstall: afterFreshInstall)
+            #expect(ready.ready)
+            #expect(ready.status == "OpenClaw Gateway is ready.")
+
+            let failure = OnboardingView.localGatewayActivationOutcome(
+                .failed(reason: "launchd disabled"),
+                afterFreshInstall: afterFreshInstall)
+            #expect(!failure.ready)
+            #expect(failure.status == (afterFreshInstall
+                    ? "OpenClaw was installed, but the Gateway did not start. Retry setup. (launchd disabled)"
+                    : "OpenClaw is installed, but the Gateway did not start. Retry setup. (launchd disabled)"))
+        }
+    }
+
     @Test func `later gateway readiness revises a pinned CLI activation failure`() {
         #expect(OnboardingView.shouldReviseCLIActivationFailure(
             gatewayStatus: .running(details: "pid 4242"),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users completing a fresh local CLI installation while OpenClaw was paused would be moved to AI setup without a running Gateway, while the installation page, pause explanation, and recovery button disappeared.

## Why This Change Was Made

Local Gateway activation now has one onboarding-owned outcome projection for both fresh and existing CLI installations. Only a ready Gateway completes local setup; deferred and failed activation preserve the actionable setup page, while remote onboarding and each existing concrete failure message remain unchanged. The consolidation removes three production lines.

## User Impact

When the Gateway is paused, onboarding stays on the installation page and explains how to resume OpenClaw and retry. Users no longer get stranded on an AI setup page that cannot connect.

## Evidence

The owner-level regression failed against the original fresh-install behavior in three observable ways: activation was incorrectly marked ready, the CLI recovery page disappeared from the actual onboarding page order, and the actionable pause/retry message was replaced.

After the fix, the complete relevant native onboarding, installer, and AI-setup suites pass: **147 tests across 3 suites**.

```text
swift test --package-path apps/macos --filter 'OpenClawIPCTests\.(OnboardingViewSmokeTests|CLIInstallerTests|OnboardingAISetupTests)' --no-parallel -j 4
Test run with 147 tests in 3 suites passed.
```

SwiftFormat, strict production SwiftLint, independent owner-boundary review, and configured structured Codex autoreview are clean. Live macOS GUI screenshots were not possible because the available test guest had no logged-in GUI and was restored/stopped; the actual native onboarding activation owner, real page ordering, paused installer contract, remote bypass, and failure recovery are covered directly by the native suites.
