### PR TITLE
fix(compaction): exclude private reasoning from summaries

### DIFF
--- a/packages/agent-core/src/harness/compaction/branch-summarization.test.ts
+++ b/packages/agent-core/src/harness/compaction/branch-summarization.test.ts
@@ -60,7 +60,7 @@ function createResponseStream(model: Model, content?: AssistantMessage["content"
   return stream;
 }
 
-function createCapturingStream(model: Model) {
+function createCapturingStream(model: Model, responseContent?: AssistantMessage["content"]) {
   let prompt = "";
   let systemPrompt = "";
   let maxOutputTokens: number | undefined;
@@ -75,7 +75,7 @@ function createCapturingStream(model: Model) {
         : userMessage.content.map((block) => (block.type === "text" ? block.text : "")).join("");
     systemPrompt = context.systemPrompt ?? "";
     maxOutputTokens = options?.maxTokens;
-    return createResponseStream(model);
+    return createResponseStream(model, responseContent);
   });
   return {
     streamFn,
@@ -158,16 +158,16 @@ describe("branch summarization", () => {
   it("preserves valid summary whitespace, preamble, and file metadata", async () => {
     const model = createModel(128_000);
     const summaryText = "  Branch summary body  \ncontinues ";
-    const streamFn = vi.fn<StreamFn>(() =>
-      createResponseStream(model, [
-        { type: "text", text: "  Branch summary body  " },
-        { type: "text", text: "continues " },
-      ]),
-    );
+    const capture = createCapturingStream(model, [
+      { type: "text", text: "  Branch summary body  " },
+      { type: "text", text: "continues " },
+    ]);
     const entries: SessionTreeEntry[] = [
       createMessageEntry({ role: "user", content: "inspect files", timestamp: 1 }, 0),
       createMessageEntry(
         createResponse(model, [
+          { type: "thinking", thinking: "PRIVATE_BRANCH_REASONING" },
+          { type: "text", text: "Visible branch answer" },
           { type: "toolCall", id: "read-1", name: "read", arguments: { path: "src/read.ts" } },
           {
             type: "toolCall",
@@ -184,7 +184,7 @@ describe("branch summarization", () => {
       model,
       apiKey: "test-key",
       signal: new AbortController().signal,
-      streamFn,
+      streamFn: capture.streamFn,
     });
 
     expect(result.ok).toBe(true);
@@ -207,6 +207,11 @@ src/write.ts
       readFiles: ["src/read.ts"],
       modifiedFiles: ["src/write.ts"],
     });
+    expect(capture.readCapture().prompt).toContain("[Assistant]: Visible branch answer");
+    expect(capture.readCapture().prompt).toContain(
+      '[Assistant tool calls]: read(path="src/read.ts"); write(path="src/write.ts")',
+    );
+    expect(capture.readCapture().prompt).not.toContain("PRIVATE_BRANCH_REASONING");
   });
 
   it("retains failed tool results when preparing a branch", () => {

--- a/packages/agent-core/src/harness/compaction/compaction-summary-cap.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-summary-cap.test.ts
@@ -48,7 +48,19 @@ describe("split-turn compaction summary cap", () => {
       maxTokens: 8_000,
     };
     let prefixSummary = "prefix summary";
-    const streamFn = vi.fn<StreamFn>(() => {
+    const prompts: string[] = [];
+    const streamFn = vi.fn<StreamFn>((_model, context) => {
+      const promptMessage = context.messages[0];
+      if (!promptMessage || promptMessage.role !== "user") {
+        throw new Error("expected a user message containing the split-turn prompt");
+      }
+      prompts.push(
+        typeof promptMessage.content === "string"
+          ? promptMessage.content
+          : promptMessage.content
+              .map((block) => (block.type === "text" ? block.text : ""))
+              .join(""),
+      );
       const stream = createAssistantMessageEventStream();
       setTimeout(() => {
         stream.push({
@@ -73,7 +85,21 @@ describe("split-turn compaction summary cap", () => {
         {
           firstKeptEntryId: "kept-entry",
           messagesToSummarize: [],
-          turnPrefixMessages: [{ role: "user", content: "prefix", timestamp: 2 }],
+          turnPrefixMessages: [
+            {
+              ...createAssistant("visible prefix", createUsage(1)),
+              content: [
+                { type: "thinking", thinking: "PRIVATE_PREFIX_REASONING" },
+                { type: "text", text: "visible prefix" },
+                {
+                  type: "toolCall",
+                  id: "prefix-call",
+                  name: "read",
+                  arguments: { path: "prefix.ts" },
+                },
+              ],
+            },
+          ],
           isSplitTurn: true,
           tokensBefore: 100,
           previousSummary,
@@ -101,6 +127,9 @@ describe("split-turn compaction summary cap", () => {
     expect(normalResult.value.summary).toBe(
       "previous summary\n\n---\n\n**Turn Context (split turn):**\n\nprefix summary\n\n<read-files>\nsrc/read.ts\n</read-files>\n\n<modified-files>\nsrc/write.ts\n</modified-files>",
     );
+    expect(prompts[0]).toContain("[Assistant]: visible prefix");
+    expect(prompts[0]).toContain('[Assistant tool calls]: read(path="prefix.ts")');
+    expect(prompts[0]).not.toContain("PRIVATE_PREFIX_REASONING");
 
     const nearCapResult = await runCompaction();
     expect(nearCapResult.ok).toBe(true);

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -133,16 +133,29 @@ describe("file operation provenance", () => {
 
 describe("serializeConversation", () => {
   it("omits provider thinking while preserving visible assistant state", () => {
-    const messages = [
+    const messages: Message[] = [
       {
         role: "assistant",
         content: [
           { type: "thinking", thinking: "PRIVATE_REASONING_SENTINEL" },
           { type: "text", text: "Visible answer" },
-          { type: "toolCall", name: "read", arguments: { path: "src/index.ts" } },
+          { type: "toolCall", id: "call-1", name: "read", arguments: { path: "src/index.ts" } },
         ],
+        api: "test-api",
+        provider: "test-provider",
+        model: "test-model",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 1,
       },
-    ] as unknown as Message[];
+    ];
 
     expect(serializeConversation(messages)).toBe(
       '[Assistant]: Visible answer\n\n[Assistant tool calls]: read(path="src/index.ts")',

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -132,6 +132,23 @@ describe("file operation provenance", () => {
 });
 
 describe("serializeConversation", () => {
+  it("omits provider thinking while preserving visible assistant state", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "PRIVATE_REASONING_SENTINEL" },
+          { type: "text", text: "Visible answer" },
+          { type: "toolCall", name: "read", arguments: { path: "src/index.ts" } },
+        ],
+      },
+    ] as unknown as Message[];
+
+    expect(serializeConversation(messages)).toBe(
+      '[Assistant]: Visible answer\n\n[Assistant tool calls]: read(path="src/index.ts")',
+    );
+  });
+
   it.each([
     {
       name: "Codex nested toolResult text",

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -232,14 +232,11 @@ export function serializeConversation(messages: Message[]): string {
       }
     } else if (msg.role === "assistant") {
       const textParts: string[] = [];
-      const thinkingParts: string[] = [];
       const toolCalls: string[] = [];
 
       for (const block of msg.content) {
         if (block.type === "text") {
           textParts.push(block.text);
-        } else if (block.type === "thinking") {
-          thinkingParts.push(block.thinking);
         } else if (block.type === "toolCall") {
           const argsStr = Object.entries(block.arguments)
             .map(([k, v]) => `${k}=${stringifyCompactionValue(v)}`)
@@ -248,9 +245,6 @@ export function serializeConversation(messages: Message[]): string {
         }
       }
 
-      if (thinkingParts.length > 0) {
-        parts.push(`[Assistant thinking]: ${thinkingParts.join("\n")}`);
-      }
       if (textParts.length > 0) {
         parts.push(`[Assistant]: ${textParts.join("\n")}`);
       }


### PR DESCRIPTION
Closes #129518

## What Problem This Solves

Session compaction copied provider-private assistant reasoning into the prompt sent to the summary model. A provider could reject that prompt, and accepted prompts still exposed reasoning that should stay private.

## Why This Change Was Made

The shared compaction serializer now carries visible assistant text and tool calls, but it does not render private reasoning. Ordinary compaction, split-turn compaction, and branch summaries all use this serializer.

The fix deletes the reasoning-render path. It does not add provider-specific policy, configuration, protocol changes, or compatibility code.

## User Impact

Long sessions can compact without forwarding private reasoning to the summary provider. Visible assistant answers, tool calls, tool results, and persisted summaries continue to work.

## Evidence

- Exact current-main red revision: `5c1a4661e787230a169302a2e9c5593984178332`.
- Exact repaired head: `f25db95d7a63888362c55becc66841e28d264a2b`.
- A real Ollama 0.33.0 `qwen3:0.6b` compaction received the synthetic private reasoning sentinel and `[Assistant thinking]` on current main.
- The same real provider flow on the repaired head received neither private value, while visible assistant text and the `read` tool call remained in the request.
- The provider returned separate thinking and visible text, and OpenClaw persisted one SQLite compaction summary without private reasoning in replay context.
- The repaired tests failed three caller-boundary assertions on pre-fix production code for the intended leak.
- The exact repaired head passed all 85 tests in the six-file compaction suite.
- Type-aware lint, formatting, core production type-check, core test type-check, repository ratchets, and `git diff --check` passed.
- Production delta: 0 additions and 6 deletions. Test delta: 75 additions and 11 deletions.

Alix-007 contributed the production repair and initial proof. Codex assisted with investigation, caller-boundary tests, live verification, and PR preparation.
