### PR TITLE
fix(sqlite): index agent session lookups

### DIFF
--- a/docs/.generated/sqlite-session-transcript-schema-baseline.sha256
+++ b/docs/.generated/sqlite-session-transcript-schema-baseline.sha256
@@ -1,1 +1,1 @@
-64ea7280cd15cf0d1076c2141cb6fdf010d5af233f38f535798bec92ab1d0e45  sqlite-session-transcript-schema-baseline.sql
+86f711ef3894b8cf03df2e715d9675d4b279f47c694b324927497e540e44fcd3  sqlite-session-transcript-schema-baseline.sql

--- a/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
+++ b/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
@@ -60,6 +60,11 @@ export function historicalV15AgentSchemaSql(): string {
   );
   sql = removeSchemaRange(
     sql,
+    "CREATE INDEX IF NOT EXISTS idx_agent_session_windows_session_key",
+    "CREATE INDEX IF NOT EXISTS idx_agent_session_windows_created_at",
+  );
+  sql = removeSchemaRange(
+    sql,
     "-- Older same-version writers preserve the envelope while updating the association.",
     "CREATE INDEX IF NOT EXISTS idx_agent_session_conversations_conversation",
   );
@@ -67,6 +72,11 @@ export function historicalV15AgentSchemaSql(): string {
     sql,
     "CREATE TABLE IF NOT EXISTS message_tool_run_outcomes (",
     "CREATE TABLE IF NOT EXISTS transcript_events (",
+  );
+  sql = removeSchemaRange(
+    sql,
+    "CREATE INDEX IF NOT EXISTS idx_agent_transcript_event_identity_sequence",
+    "CREATE INDEX IF NOT EXISTS idx_agent_transcript_event_parent",
   );
   sql = removeSchemaRange(
     sql,

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3420,7 +3420,7 @@ describe("openclaw agent database", () => {
     ).toThrow(/UNIQUE constraint failed/iu);
   });
 
-  it("repairs every canonical agent-state named index", () => {
+  it("repairs every missing or drifted canonical agent-state named index", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
@@ -3431,6 +3431,10 @@ describe("openclaw agent database", () => {
     const { DatabaseSync } = requireNodeSqlite();
     const drifted = new DatabaseSync(databasePath);
     try {
+      drifted.exec(`
+        DROP INDEX idx_agent_session_windows_session_key;
+        DROP INDEX idx_agent_transcript_event_identity_sequence;
+      `);
       expect(replaceNamedIndexesWithNoncanonicalIndexes(drifted).length).toBeGreaterThan(25);
       expect(drifted.prepare("PRAGMA integrity_check").get()).toEqual({
         integrity_check: "ok",
@@ -3444,6 +3448,7 @@ describe("openclaw agent database", () => {
     expect(normalizeSqliteSchemaShapeSql(collectSqliteSchemaShape(reopened.db))).toEqual(
       canonicalShape,
     );
+    expect(readSqliteNumberPragma(reopened.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
   });
 
   it("repairs physical ordinary-index drift before cold-open reads", () => {

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -144,6 +144,9 @@ CREATE TABLE IF NOT EXISTS session_windows (
 CREATE INDEX IF NOT EXISTS idx_agent_session_windows_updated_at
   ON session_windows(updated_at DESC, session_id);
 
+CREATE INDEX IF NOT EXISTS idx_agent_session_windows_session_key
+  ON session_windows(session_key, updated_at DESC, session_id);
+
 CREATE INDEX IF NOT EXISTS idx_agent_session_windows_created_at
   ON session_windows(created_at DESC, session_id);
 
@@ -455,6 +458,9 @@ CREATE TABLE IF NOT EXISTS transcript_event_identities (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_transcript_message_idempotency
   ON transcript_event_identities(session_id, message_idempotency_key)
   WHERE message_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_agent_transcript_event_identity_sequence
+  ON transcript_event_identities(session_id, seq);
 
 CREATE INDEX IF NOT EXISTS idx_agent_transcript_event_parent
   ON transcript_event_identities(session_id, parent_id)

--- a/src/state/sqlite-query-plan.test.ts
+++ b/src/state/sqlite-query-plan.test.ts
@@ -178,8 +178,29 @@ describe("sqlite hot query plans", () => {
           FROM session_nodes
          WHERE current_session_id = ?
          ORDER BY updated_at DESC, session_key ASC
+        LIMIT 1
+      `,
+    });
+    const latestWindowPlan = explainQueryPlan(
+      database.db,
+      `
+        SELECT session_id, updated_at
+          FROM session_windows
+         WHERE session_key = ?
+         ORDER BY updated_at DESC, session_id ASC
          LIMIT 1
       `,
+      ["agent:worker-1:main"],
+    );
+    expect(latestWindowPlan).toContain("idx_agent_session_windows_session_key");
+    expect(latestWindowPlan).not.toContain("SCAN session_windows");
+    expect(latestWindowPlan).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+
+    expectPlanUsesIndex({
+      db: database.db,
+      indexName: "idx_agent_session_windows_session_key",
+      params: ["agent:worker-1:main"],
+      sql: "DELETE FROM session_nodes WHERE session_key = ?",
     });
     expectPlanUsesIndex({
       db: database.db,
@@ -235,6 +256,12 @@ describe("sqlite hot query plans", () => {
           FROM transcript_event_identities
          WHERE session_id = ? AND event_type = ?
       `,
+    });
+    expectPlanUsesIndex({
+      db: database.db,
+      indexName: "idx_agent_transcript_event_identity_sequence",
+      params: ["session-1", 1],
+      sql: "DELETE FROM transcript_events WHERE session_id = ? AND seq = ?",
     });
 
     expectPlanIncludes({
@@ -341,7 +368,7 @@ describe("sqlite hot query plans", () => {
     expect(visibleDeltaPayloadPlan).toContain(
       "sqlite_autoindex_session_transcript_active_events_1",
     );
-    expect(visibleDeltaPayloadPlan).toContain("idx_agent_transcript_event_sequence");
+    expect(visibleDeltaPayloadPlan).toContain("idx_agent_transcript_event_identity_sequence");
     expect(visibleDeltaPayloadPlan).not.toContain("USE TEMP B-TREE FOR ORDER BY");
 
     const historyAnchorPlan = explainQueryPlan(


### PR DESCRIPTION
Audit: https://gist.github.com/vincentkoc/10826f918dde7e23020cf2f390af95d3

## What Problem This Solves

Fixes an issue where growing per-agent databases scan `session_windows` for
session-key lookups and foreign-key maintenance, while transcript-event deletes
can traverse every identity in a large session.

## Why This Change Was Made

Adds canonical indexes for
`session_windows(session_key, updated_at DESC, session_id)` and
`transcript_event_identities(session_id, seq)`. Existing databases receive them
through the established same-version canonical schema repair; the agent schema
version and persistence semantics do not change.

This is a bounded query-plan improvement under the SQLite review checkpoint.
The audit records the measured read, write, and disk tradeoffs.

## User Impact

Session lookup and cleanup remain predictable as agent history grows. Typical
transcript deletes improve modestly; the identity index primarily prevents
large-session cleanup from degrading with session length.

## Evidence

- Focused Vitest: 109 passed, 4 skipped.
- Historical v14/v15 migration fixtures: 2 passed with exact hashes preserved.
- Kysely generation check and session-schema baseline check passed.
- Same-version reopen test drops both indexes and proves canonical repair.
- Manual 200,000-window / 400,000-event benchmark:
  - latest window lookup: 4.8505 ms -> 0.00436 ms, 1112x
  - session-node cascade: 10.804 ms -> 0.5577 ms, 19.4x
  - 1,000-event transcript cascade: 0.1378 ms -> 0.0856 ms, 1.61x
  - 100,000-event transcript cascade: 5.746 ms -> 0.0923 ms, 62.3x
- Measured index cost:
  - session-window index: 10.51 MB for 200,000 rows; 69.8 ms build
  - identity index: 10.46 MB for 400,000 rows; about 26 bytes per row; 97.3 ms build
- Production delta: +6 SQL lines. Tests/test support: +44/-2. Generated baseline: hash refresh only.

AI-assisted: yes. The implementation, benchmarks, and review findings were
independently verified before push.
