### PR TITLE
fix(logbook): index frame and batch queries

### DIFF
--- a/extensions/logbook/src/store.test.ts
+++ b/extensions/logbook/src/store.test.ts
@@ -9,6 +9,14 @@ import type { LogbookCardDraft } from "./types.js";
 
 const DAY = "2026-07-03";
 
+function queryPlanDetails(database: DatabaseSync, sql: string): string[] {
+  return (
+    database.prepare(`EXPLAIN QUERY PLAN ${sql}`).all() as Array<{
+      detail: string;
+    }>
+  ).map((row) => row.detail);
+}
+
 function draft(overrides: Partial<LogbookCardDraft> = {}): LogbookCardDraft {
   const base = new Date(`${DAY}T10:00:00`).getTime();
   return {
@@ -99,6 +107,107 @@ describe("LogbookStore", () => {
       );
     } finally {
       database.close();
+    }
+  });
+
+  it.each([
+    {
+      operation: "batch frame reads",
+      sql: "SELECT id FROM frames WHERE batch_id = 1 ORDER BY captured_at_ms ASC",
+      expectedIndex: "idx_logbook_frames_batch",
+      scannedTable: "frames",
+      ordered: true,
+    },
+    {
+      operation: "observation replacement",
+      sql: "DELETE FROM observations WHERE batch_id = 1",
+      expectedIndex: "idx_logbook_observations_batch",
+      scannedTable: "observations",
+      ordered: false,
+    },
+    {
+      operation: "frame pruning foreign-key maintenance",
+      sql: "DELETE FROM frames WHERE id = 1",
+      expectedIndex: "idx_logbook_cards_keyframe",
+      scannedTable: "cards",
+      ordered: false,
+    },
+    {
+      operation: "latest frame reads",
+      sql: "SELECT id FROM frames ORDER BY captured_at_ms DESC LIMIT 1",
+      expectedIndex: "idx_logbook_frames_captured_at",
+      scannedTable: "frames",
+      ordered: true,
+    },
+    {
+      operation: "frame range reads",
+      sql: "SELECT id FROM frames WHERE captured_at_ms >= 1 AND captured_at_ms < 2 ORDER BY captured_at_ms ASC",
+      expectedIndex: "idx_logbook_frames_captured_at",
+      scannedTable: "frames",
+      ordered: true,
+    },
+  ])(
+    "uses the supporting index for $operation",
+    ({ sql, expectedIndex, scannedTable, ordered }) => {
+      const database = new DatabaseSync(path.join(dir, "logbook.sqlite"), { readOnly: true });
+      try {
+        const plan = queryPlanDetails(database, sql);
+        expect(plan).toEqual(expect.arrayContaining([expect.stringContaining(expectedIndex)]));
+        expect(
+          plan.some(
+            (detail) => detail.startsWith(`SCAN ${scannedTable}`) && !detail.includes(" USING "),
+          ),
+        ).toBe(false);
+        if (ordered) {
+          expect(plan).not.toEqual(
+            expect.arrayContaining([expect.stringContaining("USE TEMP B-TREE FOR ORDER BY")]),
+          );
+        }
+      } finally {
+        database.close();
+      }
+    },
+  );
+
+  it("restores missing schema-1 indexes on reopen without changing the version", () => {
+    store.close();
+    const databasePath = path.join(dir, "logbook.sqlite");
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      DROP INDEX IF EXISTS idx_logbook_frames_captured_at;
+      DROP INDEX IF EXISTS idx_logbook_frames_batch;
+      DROP INDEX IF EXISTS idx_logbook_observations_batch;
+      DROP INDEX IF EXISTS idx_logbook_cards_keyframe;
+    `);
+    expect(database.prepare("PRAGMA user_version").get()).toEqual({ user_version: 1 });
+    database.close();
+
+    store = new LogbookStore(dir);
+
+    const reopened = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      const indexes = reopened
+        .prepare(
+          `SELECT name FROM sqlite_schema
+           WHERE type = 'index'
+             AND name IN (
+               'idx_logbook_frames_batch',
+               'idx_logbook_frames_captured_at',
+               'idx_logbook_observations_batch',
+               'idx_logbook_cards_keyframe'
+             )
+           ORDER BY name`,
+        )
+        .all();
+      expect(indexes).toEqual([
+        { name: "idx_logbook_cards_keyframe" },
+        { name: "idx_logbook_frames_batch" },
+        { name: "idx_logbook_frames_captured_at" },
+        { name: "idx_logbook_observations_batch" },
+      ]);
+      expect(reopened.prepare("PRAGMA user_version").get()).toEqual({ user_version: 1 });
+    } finally {
+      reopened.close();
     }
   });
 

--- a/extensions/logbook/src/store.ts
+++ b/extensions/logbook/src/store.ts
@@ -54,7 +54,9 @@ CREATE TABLE IF NOT EXISTS frames (
   batch_id INTEGER REFERENCES batches(id) ON DELETE SET NULL
 ) STRICT;
 CREATE INDEX IF NOT EXISTS idx_logbook_frames_day ON frames (day, captured_at_ms);
+CREATE INDEX IF NOT EXISTS idx_logbook_frames_captured_at ON frames (captured_at_ms);
 CREATE INDEX IF NOT EXISTS idx_logbook_frames_unbatched ON frames (batch_id) WHERE batch_id IS NULL;
+CREATE INDEX IF NOT EXISTS idx_logbook_frames_batch ON frames (batch_id, captured_at_ms) WHERE batch_id IS NOT NULL;
 CREATE TABLE IF NOT EXISTS observations (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   batch_id INTEGER NOT NULL REFERENCES batches(id) ON DELETE CASCADE,
@@ -64,6 +66,7 @@ CREATE TABLE IF NOT EXISTS observations (
   text TEXT NOT NULL
 ) STRICT;
 CREATE INDEX IF NOT EXISTS idx_logbook_observations_day ON observations (day, start_ms);
+CREATE INDEX IF NOT EXISTS idx_logbook_observations_batch ON observations (batch_id);
 CREATE TABLE IF NOT EXISTS cards (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   day TEXT NOT NULL,
@@ -80,6 +83,7 @@ CREATE TABLE IF NOT EXISTS cards (
   updated_ms INTEGER NOT NULL
 ) STRICT;
 CREATE INDEX IF NOT EXISTS idx_logbook_cards_day ON cards (day, start_ms);
+CREATE INDEX IF NOT EXISTS idx_logbook_cards_keyframe ON cards (keyframe_id) WHERE keyframe_id IS NOT NULL;
 CREATE TABLE IF NOT EXISTS standups (
   day TEXT PRIMARY KEY,
   text TEXT NOT NULL,


### PR DESCRIPTION
Audit: https://gist.github.com/vincentkoc/10826f918dde7e23020cf2f390af95d3

## What Problem This Solves

Fixes an issue where Logbook capture, batch analysis, observation replacement,
and frame cleanup scan or sort growing SQLite tables on normal paths.

## Why This Change Was Made

Adds four indexes for global capture timestamps, completed-batch frame reads,
batch-owned observations, and card keyframe foreign-key maintenance. Logbook
continues to use schema version 1; its canonical schema runs idempotently on
open, so existing databases receive the indexes without a migration bump.

This is a bounded query-plan improvement under the SQLite review checkpoint.
The timestamp index is justified by the hot `lastFrame()` path, not by an
unmeasured retention claim.

## User Impact

Periodic capture and batch processing avoid table-wide scans as Logbook history
grows. Frame cleanup no longer scans every card to maintain keyframe references.

## Evidence

- `pnpm test:extension logbook`: 66 passed.
- Planner coverage proves the four indexes and rejects unindexed scans or
  temporary ordering where relevant.
- Schema-1 reopen coverage drops all four indexes, reopens the store, and proves
  restoration without changing the version.
- Manual 400,000-row benchmarks:
  - batch frame read: 11.485 ms -> 0.802 ms, 14.3x
  - observation replace/delete: 10.507 ms -> 2.841 ms, 3.70x
  - keyframe FK maintenance: 21.624 ms -> 0.0197 ms, 1098x
  - latest frame lookup: 11.697 ms -> 0.005 ms, 2339x
- Measured build/storage cost:
  - batch index: 5.84 MB, 106 ms
  - observation index: 4.26 MB, 83 ms
  - keyframe index: 4.39 MB, 83 ms
  - captured-at index: 4.76 MB, about 94 ms
- Production delta: +4 SQL lines. Tests: +109.

AI-assisted: yes. The implementation, benchmarks, and review findings were
independently verified before push.
