### PR TITLE
fix(macos): stop remote onboarding from installing a local gateway

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
@@ -26,6 +26,12 @@ extension OnboardingView {
         GatewayDiscoveryPreferences.setPreferredStableID(nil)
     }
 
+    func handleRemoteSelection() {
+        defaultsToLocalGateway = false
+        state.connectionMode = .remote
+        showRemoteChoices.toggle()
+    }
+
     func selectRemoteGateway(_ gateway: GatewayDiscoveryModel.DiscoveredGateway) {
         let shouldResetGatewayState = Self.shouldResetGatewayBoundAIState(
             connectionMode: state.connectionMode,

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -103,9 +103,7 @@ extension OnboardingView {
                         systemImage: "network",
                         selected: self.selectedConnectionMode == .remote)
                     {
-                        withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) {
-                            self.showRemoteChoices.toggle()
-                        }
+                        self.handleRemoteSelection()
                     }
 
                     if self.showRemoteChoices || self.selectedConnectionMode == .remote {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -179,6 +179,22 @@ struct OnboardingViewSmokeTests {
         #expect(state.connectionMode == .local)
     }
 
+    @Test func `choosing another computer never commits the recommended local gateway`() {
+        let state = AppState(preview: true)
+        state.onboardingSeen = false
+        state.connectionMode = .unconfigured
+        let view = OnboardingView(state: state)
+
+        view.handleRemoteSelection()
+
+        #expect(view.selectedConnectionMode == .remote)
+        #expect(state.connectionMode == .remote)
+
+        view.commitRecommendedConnectionIfNeeded(for: view.connectionPageIndex)
+
+        #expect(state.connectionMode == .remote)
+    }
+
     @Test func `automatic CLI setup waits for the initial status probe`() {
         #expect(!OnboardingView.shouldAutoInstallCLI(
             onCLIPage: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users choosing “On another computer” during first-run macOS onboarding would still have “On this Mac” selected internally. Pressing Next could then commit local mode and start installing or launching a Gateway on the wrong computer instead of continuing remote setup.

## Why This Change Was Made

Make the actual remote-choice action select remote mode immediately while preserving its existing discovery-panel disclosure. The existing connection-mode observer, manual/discovered Gateway configuration, remote connection verification, CLI/node preparation, and explicit configure-later/local flows remain their canonical owners.

## User Impact

Choosing “On another computer” now actually selects remote onboarding, highlights that choice, and keeps Next behind the existing remote Gateway verification gate. It no longer silently installs or starts a local Gateway after the user explicitly chose a different computer.

## Evidence

- Authentic pre-fix native action regression: invoking the real remote-choice owner left the displayed selection at `.local`, the persisted connection mode at `.unconfigured`, and the existing Next-selection commit changed it to `.local`; the other 28 onboarding smoke tests passed.
- After the fix, `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path apps/macos --filter 'OpenClawIPCTests\.(OnboardingViewSmokeTests|OnboardingRemoteAuthPromptTests|OnboardingAISetupTests|OnboardingMascotMoodTests)' --no-parallel -j 4` passed all **140 tests across four native suites**, covering remote verification, manual/discovered endpoint selection, explicit configure later, recommended local setup, CLI preparation, AI setup, resume, and route changes.
- `swiftformat --lint apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift --config config/swiftformat` passed; production is +7/-3 lines, with a real owner-boundary regression test.
- Live before/after screenshots were unavailable because the isolated macOS guest has no authenticated desktop session or installed app bundle, and launching or modifying the operator’s signed installed app/TCC state is outside the authorized isolation boundary. The actual native remote-selection action regression provides executable before/after proof without touching that app.
