### PR TITLE
fix(parallels): add frozen auth prerequisite contract

### DIFF
--- a/scripts/e2e/parallels/npm-update-smoke.ts
+++ b/scripts/e2e/parallels/npm-update-smoke.ts
@@ -51,6 +51,7 @@ import {
 import { runWindowsBackgroundPowerShell } from "./guest-transports.ts";
 import { linuxUpdateScript, macosUpdateScript, windowsUpdateScript } from "./npm-update-scripts.ts";
 import { ensureVmRunning, resolveMacosVmName, resolveUbuntuVmName } from "./parallels-vm.ts";
+import { runParallelsPrerequisiteEval } from "./provider-auth-prerequisite.mjs";
 import { expectedPackageTargetVersion, startSmokeArtifactServer } from "./smoke-common.ts";
 import { runTimedUpdateJob } from "./update-job-timeout.ts";
 
@@ -155,15 +156,29 @@ function resolveSecondsTimerMs(timeoutSeconds: number): number {
   return finiteSecondsToTimerSafeMilliseconds(timeoutSeconds) ?? 1;
 }
 
-const updateTimeoutSeconds = readPositiveIntEnv("OPENCLAW_PARALLELS_NPM_UPDATE_TIMEOUT_S", 2700);
 const updateCleanupBackstopMs = 60_000;
-const updateTimeoutMs = resolveSecondsTimerMs(updateTimeoutSeconds);
-const updateWithCleanupTimeoutMs =
-  addTimerTimeoutGraceMs(updateTimeoutMs, updateCleanupBackstopMs) ?? 1;
-const freshLaneTimeoutKillGraceMs = readPositiveIntEnv(
-  "OPENCLAW_PARALLELS_NPM_UPDATE_FRESH_TIMEOUT_KILL_GRACE_MS",
-  2_000,
-);
+type UpdateTimeouts = { seconds: number; timeoutMs: number; withCleanupMs: number };
+let cachedUpdateTimeouts: UpdateTimeouts | undefined;
+let cachedFreshLaneTimeoutKillGraceMs: number | undefined;
+
+function resolveUpdateTimeouts(): UpdateTimeouts {
+  return (cachedUpdateTimeouts ??= (() => {
+    const seconds = readPositiveIntEnv("OPENCLAW_PARALLELS_NPM_UPDATE_TIMEOUT_S", 2700);
+    const timeoutMs = resolveSecondsTimerMs(seconds);
+    return {
+      seconds,
+      timeoutMs,
+      withCleanupMs: addTimerTimeoutGraceMs(timeoutMs, updateCleanupBackstopMs) ?? 1,
+    };
+  })());
+}
+
+function resolveFreshLaneTimeoutKillGraceMs(): number {
+  return (cachedFreshLaneTimeoutKillGraceMs ??= readPositiveIntEnv(
+    "OPENCLAW_PARALLELS_NPM_UPDATE_FRESH_TIMEOUT_KILL_GRACE_MS",
+    2_000,
+  ));
+}
 const activeLoggedChildren = new Set<ReturnType<typeof spawn>>();
 const loggedParentSignalHandlers = new Map<NodeJS.Signals, () => void>();
 let loggedExitCleanupInstalled = false;
@@ -203,7 +218,7 @@ export function spawnLoggedCommand(
     const timeoutMs = resolveOptionalTimerMs(options.timeoutMs);
     const timeoutKillGraceMs =
       options.timeoutKillGraceMs === undefined
-        ? resolveRequiredTimerMs(freshLaneTimeoutKillGraceMs)
+        ? resolveRequiredTimerMs(resolveFreshLaneTimeoutKillGraceMs())
         : resolveRequiredTimerMs(options.timeoutKillGraceMs);
     const timeoutTimer =
       timeoutMs !== undefined
@@ -408,6 +423,7 @@ Options:
   --api-key-env <var>        Host env var name for provider API key.
   --openai-api-key-env <var> Alias for --api-key-env (backward compatible)
   --json                     Print machine-readable JSON summary.
+  --prerequisite-check       Check provider credentials without starting smoke work. Requires --json.
   -h, --help                 Show help.
 `;
 }
@@ -626,6 +642,7 @@ export class NpmUpdateSmoke {
   private windowsVm: string;
   private linuxVm = linuxVmDefault;
   private options: NpmUpdateOptions;
+  private readonly updateTimeouts: UpdateTimeouts;
 
   private freshStatus = platformRecord("skip");
   private freshTargetStatus = platformRecord("skip");
@@ -634,6 +651,8 @@ export class NpmUpdateSmoke {
   private timings: NpmUpdateSummary["timings"] = [];
 
   constructor(options: NpmUpdateOptions) {
+    this.updateTimeouts = resolveUpdateTimeouts();
+    resolveFreshLaneTimeoutKillGraceMs();
     this.options = options;
     this.windowsVm = options.windowsVm ?? windowsVmDefault;
     this.auth = resolveProviderAuth({
@@ -1063,8 +1082,8 @@ export class NpmUpdateSmoke {
         append,
         label,
         run: ({ signal }) => fn({ append, logPath, signal }),
-        timeoutDescription: `${updateTimeoutSeconds}s plus cleanup backstop`,
-        timeoutMs: updateWithCleanupTimeoutMs,
+        timeoutDescription: `${this.updateTimeouts.seconds}s plus cleanup backstop`,
+        timeoutMs: this.updateTimeouts.withCleanupMs,
         writeLog: async () => undefined,
       });
     })().finally(() => {
@@ -1075,15 +1094,15 @@ export class NpmUpdateSmoke {
   }
 
   private async runMacosUpdate(ctx: UpdateJobContext): Promise<void> {
-    await this.guestMacos(this.updateScript("macos"), updateTimeoutMs, ctx);
+    await this.guestMacos(this.updateScript("macos"), this.updateTimeouts.timeoutMs, ctx);
   }
 
   private runWindowsUpdate(ctx: UpdateJobContext): Promise<void> {
-    return this.guestWindows(this.updateScript("windows"), updateTimeoutMs, ctx);
+    return this.guestWindows(this.updateScript("windows"), this.updateTimeouts.timeoutMs, ctx);
   }
 
   private async runLinuxUpdate(ctx: UpdateJobContext): Promise<void> {
-    await this.guestLinux(this.updateScript("linux"), updateTimeoutMs, ctx);
+    await this.guestLinux(this.updateScript("linux"), this.updateTimeouts.timeoutMs, ctx);
   }
 
   private updateScript(platform: Platform): string {
@@ -1387,7 +1406,7 @@ export class NpmUpdateSmoke {
       let timedOut = false;
       let killTimer: NodeJS.Timeout | undefined;
       let forceKillAt: number | undefined;
-      const timeoutKillGraceMs = freshLaneTimeoutKillGraceMs;
+      const timeoutKillGraceMs = resolveFreshLaneTimeoutKillGraceMs();
       const signalChild = (signal: NodeJS.Signals): void => {
         if (!child.pid) {
           return;
@@ -1701,10 +1720,17 @@ export class NpmUpdateSmoke {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
-  const options = parseArgs(process.argv.slice(2));
-  const runSmoke = () => new NpmUpdateSmoke(options).run();
-  const runPromise = options.json ? withProgressOnStderr(runSmoke) : runSmoke();
-  await runPromise.catch((error: unknown) => {
-    die(error instanceof Error ? error.message : String(error));
-  });
+  const argv = process.argv.slice(2);
+  if ((argv[0] === "--" ? argv[1] : argv[0]) === "--prerequisite-check") {
+    process.exitCode = runParallelsPrerequisiteEval(argv, process.env, {
+      write: (value) => process.stdout.write(value),
+    });
+  } else {
+    const options = parseArgs(argv);
+    const runSmoke = () => new NpmUpdateSmoke(options).run();
+    const runPromise = options.json ? withProgressOnStderr(runSmoke) : runSmoke();
+    await runPromise.catch((error: unknown) => {
+      die(error instanceof Error ? error.message : String(error));
+    });
+  }
 }

--- a/scripts/e2e/parallels/provider-auth-prerequisite.d.mts
+++ b/scripts/e2e/parallels/provider-auth-prerequisite.d.mts
@@ -1,0 +1,18 @@
+import type { Platform, Provider, ProviderAuth } from "./types.ts";
+
+type ProviderAuthResult =
+  | { auth: ProviderAuth; reason: null; status: "ready" }
+  | { auth: ProviderAuth; reason: "credential_missing"; status: "blocked" };
+
+export function resolveParallelsProviderAuth(
+  input: { apiKeyEnv?: string; modelId?: string; platform?: Platform; provider: Provider },
+  env: Record<string, string | undefined>,
+): ProviderAuthResult;
+
+export function parsePlatformList(value: string): Set<Platform>;
+
+export function runParallelsPrerequisiteEval(
+  argv: string[],
+  env: Record<string, string | undefined>,
+  io: { write(value: string): unknown },
+): 0 | 1;

--- a/scripts/e2e/parallels/provider-auth-prerequisite.mjs
+++ b/scripts/e2e/parallels/provider-auth-prerequisite.mjs
@@ -1,0 +1,108 @@
+const INVALID_ARGUMENTS = new Error("invalid arguments");
+const PLATFORMS = ["macos", "windows", "linux"];
+const DEFAULT_MODELS = {
+  anthropic: "anthropic/claude-sonnet-4-6",
+  minimax: "minimax/MiniMax-M2.7",
+  openai: "openai/gpt-5.6-luna",
+};
+
+export function parsePlatformList(value) {
+  const entries = value.replaceAll(" ", "").replace(/^all$/u, PLATFORMS.join(",")).split(",");
+  const result = new Set();
+  for (const entry of entries) {
+    if (!PLATFORMS.includes(entry)) {
+      throw new Error(`invalid --platform entry: ${entry}`);
+    }
+    if (result.has(entry)) {
+      throw new Error(`duplicate --platform entry: ${entry}`);
+    }
+    result.add(entry);
+  }
+  return result;
+}
+
+export function resolveParallelsProviderAuth(input, env) {
+  const defaultModel = Object.hasOwn(DEFAULT_MODELS, input.provider)
+    ? DEFAULT_MODELS[input.provider]
+    : undefined;
+  if (!defaultModel) {
+    throw INVALID_ARGUMENTS;
+  }
+  const apiKeyEnv = input.apiKeyEnv || `${input.provider.toUpperCase()}_API_KEY`;
+  const apiKeyValue = Object.hasOwn(env, apiKeyEnv) ? (env[apiKeyEnv] ?? "") : "";
+  const genericModel = env[`OPENCLAW_PARALLELS_${input.provider.toUpperCase()}_MODEL`];
+  const windowsOpenAi = input.platform === "windows" && input.provider === "openai";
+  const auth = {
+    apiKeyEnv,
+    apiKeyValue,
+    authChoice: input.provider === "minimax" ? "minimax-global-api" : "apiKey",
+    authKeyFlag: `${input.provider}-api-key`,
+    modelId:
+      input.modelId ||
+      (windowsOpenAi ? env.OPENCLAW_PARALLELS_WINDOWS_OPENAI_MODEL?.trim() : undefined) ||
+      (windowsOpenAi ? genericModel?.trim() && genericModel : genericModel) ||
+      defaultModel,
+    ...(input.provider === "minimax" ? {} : { tokenProvider: input.provider }),
+  };
+  return auth.apiKeyValue
+    ? { auth, reason: null, status: "ready" }
+    : { auth, reason: "credential_missing", status: "blocked" };
+}
+
+export function runParallelsPrerequisiteEval(argv, env, io) {
+  let reason;
+  try {
+    const args = argv[0] === "--" ? argv.slice(1) : argv;
+    if (args[0] !== "--prerequisite-check") {
+      throw INVALID_ARGUMENTS;
+    }
+    const input = { provider: "openai" };
+    let platforms = parsePlatformList("all");
+    const seen = new Set();
+    for (let index = 1; index < args.length; index++) {
+      const key =
+        args[index] === "--only"
+          ? "--platform"
+          : args[index].replace(/^--openai-api-key-env$/u, "--api-key-env");
+      if (
+        seen.has(key) ||
+        !["--api-key-env", "--json", "--model", "--platform", "--provider"].includes(key)
+      ) {
+        throw INVALID_ARGUMENTS;
+      }
+      seen.add(key);
+      if (key === "--json") {
+        continue;
+      }
+      const value = args[++index];
+      if (!value || value.startsWith("-")) {
+        throw INVALID_ARGUMENTS;
+      }
+      if (key === "--api-key-env") {
+        input.apiKeyEnv = value;
+      } else if (key === "--model") {
+        input.modelId = value;
+      } else if (key === "--platform") {
+        try {
+          platforms = parsePlatformList(value);
+        } catch {
+          throw INVALID_ARGUMENTS;
+        }
+      } else {
+        input.provider = value;
+      }
+    }
+    if (!seen.has("--json")) {
+      throw INVALID_ARGUMENTS;
+    }
+    reason =
+      [...platforms]
+        .map((platform) => resolveParallelsProviderAuth({ ...input, platform }, env))
+        .find((result) => result.reason !== null)?.reason ?? null;
+  } catch (error) {
+    reason = error === INVALID_ARGUMENTS ? "invalid_arguments" : "internal_error";
+  }
+  const status = reason === null ? "ready" : "blocked";
+  io.write(`${JSON.stringify({ schema: "openclaw.parallels-prerequisite.v1", status, reason })}\n`);
+  return status === "ready" ? 0 : 1;
+}

--- a/scripts/e2e/parallels/provider-auth.ts
+++ b/scripts/e2e/parallels/provider-auth.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { parsePositiveInt, readPositiveIntEnv } from "./env-limits.ts";
 import { die, run } from "./host-command.ts";
+import * as frozenProviderAuth from "./provider-auth-prerequisite.mjs";
 import type { Mode, Platform, Provider, ProviderAuth } from "./types.ts";
 
 type ResolveLatestVersionDeps = {
@@ -30,59 +31,17 @@ export function resolveProviderAuth(input: {
   provider: Provider;
   apiKeyEnv?: string;
   modelId?: string;
+  platform?: Platform;
 }): ProviderAuth {
-  const providerDefaults: Record<Provider, Omit<ProviderAuth, "apiKeyValue">> = {
-    anthropic: {
-      apiKeyEnv: input.apiKeyEnv || "ANTHROPIC_API_KEY",
-      authChoice: "apiKey",
-      authKeyFlag: "anthropic-api-key",
-      modelId:
-        input.modelId ||
-        process.env.OPENCLAW_PARALLELS_ANTHROPIC_MODEL ||
-        "anthropic/claude-sonnet-4-6",
-      tokenProvider: "anthropic",
-    },
-    minimax: {
-      apiKeyEnv: input.apiKeyEnv || "MINIMAX_API_KEY",
-      authChoice: "minimax-global-api",
-      authKeyFlag: "minimax-api-key",
-      modelId:
-        input.modelId || process.env.OPENCLAW_PARALLELS_MINIMAX_MODEL || "minimax/MiniMax-M2.7",
-    },
-    openai: {
-      apiKeyEnv: input.apiKeyEnv || "OPENAI_API_KEY",
-      authChoice: "apiKey",
-      authKeyFlag: "openai-api-key",
-      modelId:
-        input.modelId || process.env.OPENCLAW_PARALLELS_OPENAI_MODEL || "openai/gpt-5.6-luna",
-      tokenProvider: "openai",
-    },
-  };
-  const resolved = providerDefaults[input.provider];
-  const apiKeyValue = process.env[resolved.apiKeyEnv] ?? "";
-  if (!apiKeyValue) {
-    die(`${resolved.apiKeyEnv} is required`);
+  const result = frozenProviderAuth.resolveParallelsProviderAuth(input, process.env);
+  if (result.status === "blocked") {
+    die(`${result.auth.apiKeyEnv} is required`);
   }
-  return { ...resolved, apiKeyValue };
+  return result.auth;
 }
 
-export function resolveWindowsProviderAuth(input: {
-  provider: Provider;
-  apiKeyEnv?: string;
-  modelId?: string;
-}): ProviderAuth {
-  const auth = resolveProviderAuth(input);
-  if (input.provider !== "openai" || input.modelId) {
-    return auth;
-  }
-  const windowsModel = process.env.OPENCLAW_PARALLELS_WINDOWS_OPENAI_MODEL?.trim();
-  if (windowsModel) {
-    return { ...auth, modelId: windowsModel };
-  }
-  if (process.env.OPENCLAW_PARALLELS_OPENAI_MODEL?.trim()) {
-    return auth;
-  }
-  return { ...auth, modelId: "openai/gpt-5.6-luna" };
+export function resolveWindowsProviderAuth(input: Parameters<typeof resolveProviderAuth>[0]) {
+  return resolveProviderAuth({ ...input, platform: "windows" });
 }
 
 export function providerIdFromModelId(modelId: string): string {
@@ -186,25 +145,11 @@ export function parseMode(value: string): Mode {
 }
 
 export function parsePlatformList(value: string): Set<Platform> {
-  const normalized = value.replaceAll(" ", "");
-  if (normalized === "all") {
-    return new Set(["macos", "windows", "linux"]);
+  try {
+    return frozenProviderAuth.parsePlatformList(value);
+  } catch (error) {
+    return die((error as Error).message);
   }
-  const result = new Set<Platform>();
-  for (const entry of normalized.split(",")) {
-    if (entry === "macos" || entry === "windows" || entry === "linux") {
-      if (result.has(entry)) {
-        die(`duplicate --platform entry: ${entry}`);
-      }
-      result.add(entry);
-    } else {
-      die(`invalid --platform entry: ${entry}`);
-    }
-  }
-  if (result.size === 0) {
-    die("--platform must include at least one platform");
-  }
-  return result;
 }
 
 export function resolveLatestVersion(

--- a/test/scripts/parallels-npm-update-smoke.test.ts
+++ b/test/scripts/parallels-npm-update-smoke.test.ts
@@ -1,5 +1,6 @@
 // Parallels Npm Update Smoke tests cover parallels npm update smoke script behavior.
-import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -95,12 +96,158 @@ function extractWindowsBackgroundControlMarkers(decoded: string): {
   };
 }
 
+function runPrerequisiteCli(args: string[], env: NodeJS.ProcessEnv = {}) {
+  const childEnv = { ...process.env };
+  for (const name of ["ANTHROPIC_API_KEY", "MINIMAX_API_KEY", "OPENAI_API_KEY"]) {
+    delete childEnv[name];
+  }
+  return spawnSync(process.execPath, ["--import", "tsx", SCRIPT_PATH, ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...childEnv,
+      ...env,
+      OPENCLAW_PARALLELS_NPM_UPDATE_FRESH_TIMEOUT_KILL_GRACE_MS: "invalid",
+      OPENCLAW_PARALLELS_NPM_UPDATE_FRESH_TIMEOUT_S: "invalid",
+      OPENCLAW_PARALLELS_NPM_UPDATE_TIMEOUT_S: "invalid",
+    },
+    timeout: 10_000,
+  });
+}
+
+function runFrozenPrerequisiteHelper(env: NodeJS.ProcessEnv = {}) {
+  const source = readFileSync("scripts/e2e/parallels/provider-auth-prerequisite.mjs", "utf8");
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+  const emptyCwd = tempDirs.make("openclaw-parallels-prerequisite-cwd-");
+  const childEnv = { ...process.env };
+  delete childEnv.OPENAI_API_KEY;
+  const program = `
+const helper = await import(process.argv[1]);
+const exports = Object.keys(helper).sort();
+if (JSON.stringify(exports) !== '["parsePlatformList","resolveParallelsProviderAuth","runParallelsPrerequisiteEval"]') {
+  throw new Error("unexpected helper exports");
+}
+const writes = [];
+const code = helper.runParallelsPrerequisiteEval(
+  ["--prerequisite-check", "--json"],
+  process.env,
+  { write: (value) => writes.push(value) },
+);
+if (writes.length !== 1) {
+  throw new Error("unexpected prerequisite write count");
+}
+process.stdout.write(writes[0]);
+process.exitCode = code;
+`;
+  return spawnSync(process.execPath, ["--input-type=module", "--eval", program, dataUrl], {
+    cwd: emptyCwd,
+    encoding: "utf8",
+    env: { ...childEnv, ...env },
+    timeout: 10_000,
+  });
+}
+
 afterEach(() => {
   vi.useRealTimers();
   tempDirs.cleanup();
 });
 
 describe("parallels npm update smoke", () => {
+  it("reports exact ready prerequisites for default and explicit providers", () => {
+    const defaultSecret = "sentinel-default-provider-secret";
+    const defaultResult = runPrerequisiteCli(["--prerequisite-check", "--json"], {
+      OPENAI_API_KEY: defaultSecret,
+    });
+    expect(defaultResult.status).toBe(0);
+    expect(defaultResult.stdout).toBe(
+      '{"schema":"openclaw.parallels-prerequisite.v1","status":"ready","reason":null}\n',
+    );
+    expect(defaultResult.stderr).toBe("");
+    expect(defaultResult.stdout).not.toContain(defaultSecret);
+
+    const explicitSecret = "sentinel-explicit-provider-secret";
+    const explicitResult = runPrerequisiteCli(
+      [
+        "--",
+        "--prerequisite-check",
+        "--only",
+        "linux",
+        "--provider",
+        "anthropic",
+        "--model",
+        "anthropic/custom",
+        "--api-key-env",
+        "CUSTOM_ANTHROPIC_KEY",
+        "--json",
+      ],
+      { CUSTOM_ANTHROPIC_KEY: explicitSecret },
+    );
+    expect(explicitResult.status).toBe(0);
+    expect(explicitResult.stdout).toBe(defaultResult.stdout);
+    expect(explicitResult.stderr).toBe("");
+    expect(`${explicitResult.stdout}${explicitResult.stderr}`).not.toContain(explicitSecret);
+    expect(explicitResult.stdout).not.toContain("CUSTOM_ANTHROPIC_KEY");
+    expect(explicitResult.stdout).not.toContain("anthropic/custom");
+  });
+
+  it("blocks missing credentials before smoke-only validation or side effects", () => {
+    const root = tempDirs.make("openclaw-parallels-prerequisite-");
+    const binDir = path.join(root, "bin");
+    const marker = path.join(root, "side-effect");
+    mkdirSync(binDir);
+    for (const command of ["bash", "git", "npm", "prlctl"]) {
+      const commandPath = path.join(binDir, command);
+      writeFileSync(
+        commandPath,
+        `#!/bin/sh\nprintf invoked >>${JSON.stringify(marker)}\nexit 99\n`,
+      );
+      chmodSync(commandPath, 0o755);
+    }
+    const result = runPrerequisiteCli(
+      [
+        "--prerequisite-check",
+        "--provider",
+        "minimax",
+        "--api-key-env",
+        "CUSTOM_MISSING_KEY",
+        "--json",
+      ],
+      {
+        CUSTOM_MISSING_KEY: "",
+        OPENAI_API_KEY: "sentinel-unselected-provider-secret",
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe(
+      '{"schema":"openclaw.parallels-prerequisite.v1","status":"blocked","reason":"credential_missing"}\n',
+    );
+    expect(result.stderr).toBe("");
+    expect(result.stdout).not.toContain("CUSTOM_MISSING_KEY");
+    expect(result.stdout).not.toContain("sentinel-unselected-provider-secret");
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("runs the exact helper source with plain Node from an empty cwd", () => {
+    const ready = runFrozenPrerequisiteHelper({
+      OPENAI_API_KEY: "sentinel-frozen-helper-secret",
+    });
+    expect(ready.status).toBe(0);
+    expect(ready.stdout).toBe(
+      '{"schema":"openclaw.parallels-prerequisite.v1","status":"ready","reason":null}\n',
+    );
+    expect(ready.stderr).toBe("");
+    expect(ready.stdout).not.toContain("sentinel-frozen-helper-secret");
+
+    const blocked = runFrozenPrerequisiteHelper();
+    expect(blocked.status).toBe(1);
+    expect(blocked.stdout).toBe(
+      '{"schema":"openclaw.parallels-prerequisite.v1","status":"blocked","reason":"credential_missing"}\n',
+    );
+    expect(blocked.stderr).toBe("");
+  });
+
   it("accepts one prepared tarball target for update and fresh install", () => {
     expect(
       parseArgs([

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -64,6 +64,10 @@ import {
   windowsProviderOnlyPluginIsolationScript,
   windowsCodexPlatformPackageRepairFunction,
 } from "../../scripts/e2e/parallels/plugin-isolation.ts";
+import {
+  resolveParallelsProviderAuth,
+  runParallelsPrerequisiteEval,
+} from "../../scripts/e2e/parallels/provider-auth-prerequisite.mjs";
 import { parseArgs as parseWindowsSmokeArgs } from "../../scripts/e2e/parallels/windows-smoke.ts";
 import { withEnv } from "../../src/test-utils/env.js";
 import { spawnNodeEvalSync } from "../../src/test-utils/node-process.js";
@@ -76,6 +80,8 @@ const WRAPPERS = {
   windows: "scripts/e2e/parallels-windows-smoke.sh",
 };
 const WINDOWS_PREPARE_WRAPPER = "scripts/e2e/parallels-windows-prepare.sh";
+const PROVIDER_AUTH_PREREQUISITE_PATH = "scripts/e2e/parallels/provider-auth-prerequisite.mjs";
+const PROVIDER_AUTH_PREREQUISITE_SOURCE = readFileSync(PROVIDER_AUTH_PREREQUISITE_PATH, "utf8");
 
 const TS_PATHS = {
   agentWorkspace: "scripts/e2e/parallels/agent-workspace.ts",
@@ -438,7 +444,6 @@ describe("Parallels smoke model selection", () => {
     parallelsVm,
     phaseRunner,
     powershell,
-    providerAuth,
     snapshots,
     smokeCommon,
     windows,
@@ -787,14 +792,10 @@ ensure_vm_running`,
     }
   });
 
-  it("keeps provider auth and model defaults in the shared TypeScript helper", () => {
-    expect(providerAuth).toContain("OPENCLAW_PARALLELS_OPENAI_MODEL");
-    expect(providerAuth).toContain("OPENCLAW_PARALLELS_WINDOWS_OPENAI_MODEL");
-    expect(providerAuth).toContain("openai/gpt-5.6-luna");
-    expect(providerAuth).toContain('authChoice: "apiKey"');
-    expect(providerAuth).toContain('authChoice: "minimax-global-api"');
-    expect(providerAuth).toContain('tokenProvider: "openai"');
-    expect(providerAuth).toContain('tokenProvider: "anthropic"');
+  it("keeps provider auth and model defaults in the shared helper", () => {
+    expect(PROVIDER_AUTH_PREREQUISITE_SOURCE).toContain("OPENCLAW_PARALLELS_WINDOWS_OPENAI_MODEL");
+    expect(PROVIDER_AUTH_PREREQUISITE_SOURCE).toContain("openai/gpt-5.6-luna");
+    expect(PROVIDER_AUTH_PREREQUISITE_SOURCE).toContain("tokenProvider: input.provider");
 
     for (const scriptPath of [...OS_TS_PATHS, TS_PATHS.npmUpdate]) {
       const script = readFileSync(scriptPath, "utf8");
@@ -1324,6 +1325,43 @@ if (commandArgs[0] === "list") {
 
   it("resolves provider defaults and explicit model overrides", () => {
     expect(
+      resolveParallelsProviderAuth({ provider: "openai" }, { OPENAI_API_KEY: "sk-openai" }),
+    ).toMatchObject({
+      auth: { apiKeyEnv: "OPENAI_API_KEY", modelId: "openai/gpt-5.6-luna" },
+      reason: null,
+      status: "ready",
+    });
+    expect(
+      resolveParallelsProviderAuth(
+        {
+          apiKeyEnv: "CUSTOM_ANTHROPIC_KEY",
+          provider: "anthropic",
+        },
+        {
+          CUSTOM_ANTHROPIC_KEY: "sk-anthropic",
+          OPENCLAW_PARALLELS_ANTHROPIC_MODEL: "  anthropic/custom  ",
+        },
+      ),
+    ).toMatchObject({
+      auth: { apiKeyEnv: "CUSTOM_ANTHROPIC_KEY", modelId: "  anthropic/custom  " },
+      reason: null,
+      status: "ready",
+    });
+    const inheritedCredentials = Object.create(null) as Record<string, string>;
+    for (const name of ["constructor", "toString", "__proto__"]) {
+      Object.defineProperty(inheritedCredentials, name, { value: "inherited-secret" });
+    }
+    const inheritedEnv = Object.create(inheritedCredentials) as Record<string, string>;
+    for (const apiKeyEnv of ["constructor", "toString", "__proto__"]) {
+      expect(
+        resolveParallelsProviderAuth({ apiKeyEnv, provider: "openai" }, inheritedEnv),
+      ).toMatchObject({
+        auth: { apiKeyValue: "" },
+        reason: "credential_missing",
+        status: "blocked",
+      });
+    }
+    expect(
       withEnv({ OPENAI_API_KEY: "sk-openai" }, () =>
         resolveProviderAuthDirect({ provider: "openai" }),
       ),
@@ -1335,6 +1373,36 @@ if (commandArgs[0] === "list") {
       modelId: "openai/gpt-5.6-luna",
       tokenProvider: "openai",
     });
+
+    const windowsEnv = {
+      OPENAI_API_KEY: "sk-openai",
+      OPENCLAW_PARALLELS_OPENAI_MODEL: "openai/generic",
+      OPENCLAW_PARALLELS_WINDOWS_OPENAI_MODEL: "openai/windows",
+    };
+    const frozenWindows = resolveParallelsProviderAuth(
+      { platform: "windows", provider: "openai" },
+      windowsEnv,
+    );
+    expect(frozenWindows).toMatchObject({
+      auth: { modelId: "openai/windows" },
+      reason: null,
+      status: "ready",
+    });
+    expect(withEnv(windowsEnv, () => resolveWindowsProviderAuth({ provider: "openai" }))).toEqual(
+      frozenWindows.auth,
+    );
+    expect(
+      resolveParallelsProviderAuth(
+        { modelId: "openai/explicit", platform: "windows", provider: "openai" },
+        windowsEnv,
+      ).auth.modelId,
+    ).toBe("openai/explicit");
+    const whitespaceEnv = { OPENAI_API_KEY: "sk-openai", OPENCLAW_PARALLELS_OPENAI_MODEL: "   " };
+    expect([
+      resolveParallelsProviderAuth({ platform: "windows", provider: "openai" }, whitespaceEnv).auth
+        .modelId,
+      withEnv(whitespaceEnv, () => resolveWindowsProviderAuth({ provider: "openai" }).modelId),
+    ]).toEqual(["openai/gpt-5.6-luna", "openai/gpt-5.6-luna"]);
 
     expect(
       withEnv({ CUSTOM_ANTHROPIC_KEY: "sk-anthropic" }, () =>
@@ -1354,36 +1422,67 @@ if (commandArgs[0] === "list") {
     });
   });
 
-  it("uses the shared GPT-5.6 Luna model for Windows smoke unless overridden", () => {
-    expect(
-      withEnv({ OPENAI_API_KEY: "sk-openai" }, () =>
-        resolveWindowsProviderAuth({ provider: "openai" }),
-      ),
-    ).toEqual({
-      apiKeyEnv: "OPENAI_API_KEY",
-      apiKeyValue: "sk-openai",
-      authChoice: "apiKey",
-      authKeyFlag: "openai-api-key",
-      modelId: "openai/gpt-5.6-luna",
-      tokenProvider: "openai",
-    });
+  it("keeps prerequisite adapter failures sanitized and closed", () => {
+    const cases = [
+      ["--prerequisite-check", "--json", "--provider", "openai", "--provider", "anthropic"],
+      ["--prerequisite-check", "--json", "--unknown"],
+      ["--prerequisite-check", "--json", "--provider"],
+      ["--prerequisite-check", "--json", "--provider", "unsupported-secret"],
+      ["--prerequisite-check", "--json", "--provider", "constructor"],
+      ["--prerequisite-check", "--json", "--platform", "private-platform"],
+      ["--prerequisite-check", "--json", "--only", "windows,windows"],
+      ["--prerequisite-check"],
+    ];
+    for (const args of cases) {
+      const output: string[] = [];
+      expect(runParallelsPrerequisiteEval(args, {}, { write: (value) => output.push(value) })).toBe(
+        1,
+      );
+      expect(output).toEqual([
+        '{"schema":"openclaw.parallels-prerequisite.v1","status":"blocked","reason":"invalid_arguments"}\n',
+      ]);
+      expect(output[0]).not.toContain("unsupported-secret");
+    }
 
-    expect(
-      withEnv(
-        {
-          OPENAI_API_KEY: "sk-openai",
-          OPENCLAW_PARALLELS_WINDOWS_OPENAI_MODEL: "openai/custom-windows",
-        },
-        () => resolveWindowsProviderAuth({ provider: "openai" }),
-      ),
-    ).toEqual({
-      apiKeyEnv: "OPENAI_API_KEY",
-      apiKeyValue: "sk-openai",
-      authChoice: "apiKey",
-      authKeyFlag: "openai-api-key",
-      modelId: "openai/custom-windows",
-      tokenProvider: "openai",
+    const inheritedCredentials = Object.create(null) as Record<string, string>;
+    for (const name of ["constructor", "toString", "__proto__"]) {
+      Object.defineProperty(inheritedCredentials, name, { value: "inherited-secret" });
+    }
+    for (const apiKeyEnv of ["constructor", "toString", "__proto__"]) {
+      const output: string[] = [];
+      expect(
+        runParallelsPrerequisiteEval(
+          ["--prerequisite-check", "--json", "--api-key-env", apiKeyEnv],
+          Object.create(inheritedCredentials) as Record<string, string>,
+          { write: (value) => output.push(value) },
+        ),
+      ).toBe(1);
+      expect(output).toEqual([
+        '{"schema":"openclaw.parallels-prerequisite.v1","status":"blocked","reason":"credential_missing"}\n',
+      ]);
+    }
+
+    const output: string[] = [];
+    const env = { OPENAI_API_KEY: "sk-openai" };
+    Object.defineProperty(env, "OPENCLAW_PARALLELS_WINDOWS_OPENAI_MODEL", {
+      get: () => {
+        throw new Error("sentinel-secret");
+      },
     });
+    const write = (value: string) => output.push(value);
+    expect(
+      [
+        ["--prerequisite-check", "--json"],
+        ["--prerequisite-check", "--json", "--platform", "windows"],
+        ["--prerequisite-check", "--json", "--only", "linux"],
+      ].map((args) => runParallelsPrerequisiteEval(args, env, { write })),
+    ).toEqual([1, 1, 0]);
+    expect(output).toEqual([
+      '{"schema":"openclaw.parallels-prerequisite.v1","status":"blocked","reason":"internal_error"}\n',
+      '{"schema":"openclaw.parallels-prerequisite.v1","status":"blocked","reason":"internal_error"}\n',
+      '{"schema":"openclaw.parallels-prerequisite.v1","status":"ready","reason":null}\n',
+    ]);
+    expect(output.join("")).not.toContain("sentinel-secret");
   });
 
   it("rejects invalid providers and missing keys before touching guests", () => {


### PR DESCRIPTION
## What This Changes

Adds a dependency-free, side-effect-free Parallels provider-auth prerequisite contract. The helper can be evaluated directly from the exact frozen Git blob without a checkout, installed dependencies, or repository cwd.

The TypeScript auth path delegates shared provider, model, credential, and platform selection to the same implementation. Selection preserves explicit model precedence, the Windows OpenAI override, generic provider model environments, and defaults. The prerequisite emits one sanitized versioned JSON result and never starts VM, package, registry, network, or smoke work.

## Scope And Ownership

This PR is W1A: a staged internal contract for the private Full Release Validation qualification controller.

Existing `scripts/release-beta-smoke.ts` behavior is intentionally unchanged. W1B remains the mandatory admission owner because it owns the frozen validation SHA, identical-hosted-identity dedupe, global throttle, campaign accounting, classified retry allocation, and fetched-ref release.

## Activation Contract

W1B must:

- evaluate the helper blob from the exact `validation_sha`;
- use the same platform, provider, model, API-key-env, and optional `op run --env-file` selection as real execution;
- consume campaign or retry state only after a validated `ready`;
- consume nothing and release fetched-ref ownership for blocked, malformed, or failed evaluation;
- preserve the dependency-install-before-Parallels retry path.

## Evidence

- Exact head: `c3cf13ab8e907702bb8721987018948ac2595edc`.
- Semantic rebase preserves https://github.com/openclaw/openclaw/pull/130658's artifact and registry lifecycle, cross-platform registry propagation, Windows VM selection, and deep RPC readiness.
- Focused local proof passed 171/171 tests across the two Parallels files and `prepublish-plugin-registry-artifact.test.ts`.
- Exact-head Blacksmith Testbox run passed the same W1A surface: 111/111, 47/47, and 13/13.
- The long Testbox command later hit three unrelated `node-worker-transfer-client.test.ts` assertions because the host's native umask is `0002`, producing `0664`/`0775` while the test hard-codes `0644`/`0755`.
- Fresh current main `5f3324587e40cea0ec0cd80c9840533f990e9240` reproduced those exact three failures locally under umask `0002` and on targeted Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/33049327612; the same current-main file passed under umask `0022`. This is baseline test brittleness, not a W1A regression.
- The original long Testbox lease then lost its provisioned Node binary (`ENOENT`) after 1h36m and was already stopped by the provider. The unchanged full graph was not retried.
- Frozen-helper ABI probes passed ready, blocked, malformed, internal-error, exact JSON key order/LF/exit, one stdout write, zero stderr, empty cwd, and secret-redaction cases.
- `pnpm build`, `pnpm check`, formatting, targeted oxlint, declaration parity, `node --check`, script erasability, privacy scans, and `git diff --check` passed.
- Exact-head ClawSweeper found no actionable defects. Its remaining W1A/W1B note is the intentional staged boundary above.
- Production/tooling: `+185/-88` (net `+97`). Tests: `+284/-38` (net `+246`).

## Landing

Exact-head CI and merge verification remain required. The ambient-umask test repair is tracked separately rather than widening this Parallels contract.
