### PR TITLE
fix(gateway): Land PR works with configured repository hooks

### DIFF
--- a/src/gateway/github-publication-base.ts
+++ b/src/gateway/github-publication-base.ts
@@ -55,7 +55,7 @@ export function githubPublicationUnsafeConfigArgs(scope: "--local" | "--worktree
     scope,
     "--includes",
     "--get-regexp",
-    "^(core\\.(alternaterefscommand|askpass|fsmonitor|gitproxy|hookspath|sshcommand|worktree)|credential\\..*helper|filter\\..*|http\\..*|include(if)?\\..*|push\\..*|remote\\..*\\.(proxy|receivepack|uploadpack|vcs)|uploadpack\\.packobjectshook|url\\..*\\.(insteadof|pushinsteadof))$",
+    "^(core\\.(alternaterefscommand|askpass|fsmonitor|gitproxy|sshcommand|worktree)|credential\\..*helper|filter\\..*|http\\..*|include(if)?\\..*|push\\..*|remote\\..*\\.(proxy|receivepack|uploadpack|vcs)|uploadpack\\.packobjectshook|url\\..*\\.(insteadof|pushinsteadof))$",
   ];
 }
 

--- a/src/gateway/github-publication-executor.ts
+++ b/src/gateway/github-publication-executor.ts
@@ -555,12 +555,7 @@ export async function executeGitHubPublication(params: {
       GIT_CONFIG_GLOBAL: os.devNull,
       GIT_CONFIG_SYSTEM: os.devNull,
     };
-    const pushArgs = [
-      "git",
-      "-c",
-      `core.hooksPath=${os.devNull}`,
-      ...githubPublicationPushArgs(httpsRemote, headCommit, branch).slice(1),
-    ];
+    const pushArgs = githubPublicationPushArgs(httpsRemote, headCommit, branch);
     const observeRemoteHead = async () => {
       const observed = await requireCommand(githubPublicationRemoteHeadArgs(httpsRemote, branch), {
         cwd: worktree.path,

--- a/src/gateway/github-publication-git-index.test.ts
+++ b/src/gateway/github-publication-git-index.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runCommandBuffered } from "../process/exec.js";
@@ -14,6 +15,8 @@ import {
 import {
   assertGitHubPublicationTreeHasNoFilters,
   assertSafeGitPublicationWorkspace,
+  githubPublicationPushArgs,
+  githubPublicationUpdateRefArgs,
 } from "./github-publication-git-transport.js";
 
 let testState: OpenClawTestState;
@@ -112,6 +115,92 @@ describe("GitHub publication index update", () => {
           }),
       ),
     ).resolves.toBeUndefined();
+  });
+
+  it.each([
+    { scope: "--local" as const, label: "repository-local" },
+    { scope: "--worktree" as const, label: "worktree-scoped" },
+  ])("publishes and recovers with $label hooks without executing them", async ({ scope }) => {
+    const fixture = await createFixture();
+    const remote = await makeDirectory("remote");
+    const hooks = await makeDirectory("hooks");
+    const marker = path.join(hooks, "invoked");
+    const hookEnv = { ...process.env, OPENCLAW_PUBLICATION_HOOK_MARKER: marker };
+    await git(remote, ["init", "--bare"]);
+    await Promise.all(
+      ["pre-push", "post-index-change", "reference-transaction"].map(
+        async (hook) =>
+          await fs.writeFile(
+            path.join(hooks, hook),
+            '#!/bin/sh\nprintf invoked > "$OPENCLAW_PUBLICATION_HOOK_MARKER"\nexit 97\n',
+            { mode: 0o755 },
+          ),
+      ),
+    );
+    if (scope === "--worktree") {
+      await git(fixture.cwd, ["config", "--local", "extensions.worktreeConfig", "true"]);
+    }
+    await git(fixture.cwd, ["config", scope, "core.hooksPath", hooks]);
+
+    await expect(
+      assertSafeGitPublicationWorkspace(
+        fixture.cwd,
+        async (argv, options) =>
+          await runCommandBuffered(argv, {
+            cwd: options?.cwd ?? fixture.cwd,
+            env: options?.env,
+            timeoutMs: 10_000,
+            maxOutputBytes: 64 * 1024,
+          }),
+      ),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      updateGitHubPublicationBranchAndIndex({
+        ...publicationIndexParams(fixture),
+        env: hookEnv,
+        updateRef: async () => {
+          await git(
+            fixture.cwd,
+            githubPublicationUpdateRefArgs("main", fixture.headCommit, fixture.previousHead).slice(
+              1,
+            ),
+            undefined,
+            hookEnv,
+          );
+          throw new Error("response lost");
+        },
+      }),
+    ).rejects.toThrow("workspace recovery is pending");
+    await fs.rm(path.join(fixture.cwd, ".git", "index.lock"));
+    const hardenedGit = ["-c", `core.hooksPath=${os.devNull}`, "-c", "core.fsmonitor=false"];
+    await git(
+      fixture.cwd,
+      [...hardenedGit, "update-index", "--force-remove", "artifact.txt"],
+      undefined,
+      hookEnv,
+    );
+    await git(fixture.cwd, [...hardenedGit, "add", "artifact.txt"], undefined, hookEnv);
+    await recoverGitHubPublicationBranchAndIndex({
+      cwd: fixture.cwd,
+      requestId: REQUEST_ID,
+      branch: "main",
+      sourceHeadCommit: fixture.previousHead,
+      workspaceTree: fixture.workspaceTree,
+      assertCurrent: () => undefined,
+      run: async (argv, options) =>
+        await git(fixture.cwd, argv.slice(1), options?.input, options?.env ?? hookEnv),
+    });
+    await expect(fs.access(marker)).rejects.toThrow();
+    await git(
+      fixture.cwd,
+      githubPublicationPushArgs(remote, fixture.headCommit, "publication").slice(1),
+      undefined,
+      hookEnv,
+    );
+
+    expect(await git(remote, ["rev-parse", "refs/heads/publication"])).toBe(fixture.headCommit);
+    await expect(fs.access(marker)).rejects.toThrow();
   });
 
   it("rejects a filter from Git's default global attributes file", async () => {

--- a/src/gateway/github-publication-git-index.ts
+++ b/src/gateway/github-publication-git-index.ts
@@ -6,6 +6,8 @@ import path from "node:path";
 
 type GitCommandOptions = { cwd?: string; env?: NodeJS.ProcessEnv; input?: string };
 
+const HARDENED_GIT = ["git", "-c", `core.hooksPath=${os.devNull}`, "-c", "core.fsmonitor=false"];
+
 class GitHubPublicationRefCasRejectedError extends Error {}
 export class GitHubPublicationRecoveryPendingError extends Error {}
 
@@ -121,7 +123,7 @@ export async function recoverGitHubPublicationBranchAndIndex(params: {
       ["git", "rev-parse", "--verify", `refs/heads/${params.branch}`],
       { cwd: params.cwd },
     );
-    const indexTree = await params.run(["git", "write-tree"], { cwd: params.cwd });
+    const indexTree = await params.run([...HARDENED_GIT, "write-tree"], { cwd: params.cwd });
     if (
       branchHead === params.sourceHeadCommit ||
       (indexTree === params.workspaceTree && (await publicationCommitMatches(params, branchHead)))
@@ -206,8 +208,7 @@ export async function updateGitHubPublicationBranchAndIndex(params: {
       GIT_CONFIG_GLOBAL: os.devNull,
       GIT_CONFIG_SYSTEM: os.devNull,
     };
-    const hardenedGit = ["git", "-c", `core.hooksPath=${os.devNull}`, "-c", "core.fsmonitor=false"];
-    await params.run([...hardenedGit, "read-tree", params.headCommit], {
+    await params.run([...HARDENED_GIT, "read-tree", params.headCommit], {
       cwd: params.cwd,
       env: { ...gitEnv, GIT_INDEX_FILE: replacementIndex },
     });
@@ -275,7 +276,7 @@ export async function updateGitHubPublicationBranchAndIndex(params: {
       });
     }
     await fs.copyFile(indexPath, observedIndex);
-    const currentIndexTree = await params.run([...hardenedGit, "write-tree"], {
+    const currentIndexTree = await params.run([...HARDENED_GIT, "write-tree"], {
       cwd: params.cwd,
       env: { ...gitEnv, GIT_INDEX_FILE: observedIndex },
     });

--- a/src/gateway/github-publication-git-transport.ts
+++ b/src/gateway/github-publication-git-transport.ts
@@ -173,6 +173,8 @@ export function githubPublicationPushArgs(
 ): string[] {
   return [
     ...GITHUB_CREDENTIAL_ARGS,
+    "-c",
+    `core.hooksPath=${os.devNull}`,
     "push",
     "--porcelain",
     "--no-follow-tags",

--- a/src/gateway/github-publication.test.ts
+++ b/src/gateway/github-publication.test.ts
@@ -74,7 +74,8 @@ describe("Gateway GitHub publication", () => {
         candidate.includes("update-ref") ||
         candidate.includes("read-tree") ||
         candidate.includes("add") ||
-        candidate.includes("reset"),
+        candidate.includes("reset") ||
+        candidate.includes("push"),
     )) {
       expect(argv, argv.join(" ")).toContain(`core.hooksPath=${os.devNull}`);
     }


### PR DESCRIPTION
Fixes #129573

AI-assisted; reviewed and verified by the submitting maintainer.

## What Problem This Solves

Fixes an issue where users requesting "Land PR" would get `workspace_changed` and no pull request when their approved repository or linked worktree configured the normal Git `core.hooksPath` setting.

## Why This Change Was Made

The GitHub publication owner incorrectly classified ordinary repository-local and worktree-scoped hook paths as unsafe before it could push or create a missing pull request. Permit `core.hooksPath` during workspace validation, explicitly disable hooks and filesystem monitoring for every hook-capable managed Git mutation, including push and interrupted-recovery `write-tree`, and continue rejecting every other unsafe Git configuration.

## User Impact

"Land PR" can safely publish an approved branch and create a pull request when none exists, including in normal OpenClaw checkouts and linked worktrees that configure repository hooks. Repository-controlled Git hooks and filesystem monitors remain unable to execute during managed publication, and unrelated unsafe Git configuration remains rejected.

## Evidence

- Production LOC: `+9/-11` (net `-2`); tests: `+91/-1` (net `+90`).
- `node scripts/run-vitest.mjs src/gateway/github-publication-git-index.test.ts src/gateway/github-publication-boundaries.test.ts src/gateway/github-publication.test.ts` — 3 files passed, 61 tests passed.
- `node scripts/check-changed.mjs -- src/gateway/github-publication-base.ts src/gateway/github-publication-executor.ts src/gateway/github-publication-git-index.ts src/gateway/github-publication-git-transport.ts src/gateway/github-publication-git-index.test.ts src/gateway/github-publication.test.ts` — all applicable changed-file gates passed.
- `git diff --check origin/main...HEAD` — passed.
- Fresh mandatory autoreview of the final repair — clean, with no accepted/actionable findings.
- Real-Git regression coverage exercises repository-local and worktree-scoped `pre-push`, `post-index-change`, and `reference-transaction` hooks, along with interrupted publication recovery; these tests verify the hooks never execute.
- Security invariant: configured hook paths may exist, but hook-capable managed mutations explicitly disable hooks and filesystem monitoring, and all other unsafe Git configuration continues to fail closed.
- Live proof gap: a live deployed Team gateway reproduction cannot be run pre-merge because the fixed publisher is not deployed yet. The real-Git integration tests are owner-boundary proof, not live Gateway proof.
