### PR TITLE
fix(cli): emit JSON failures when existing config is invalid

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -370,7 +370,8 @@ Output: `--suppress-gateway-token-output` disables the automatic Control UI hand
 <Note>
 `--json` does not imply non-interactive mode in guided or classic onboarding.
 With `--modern`, JSON is a one-shot OpenClaw overview and exits after that
-single result. Use `--non-interactive` for other scripts.
+single result. Use `--non-interactive` for other scripts. Invalid existing
+configuration also returns one JSON failure; repair guidance remains on stderr.
 </Note>
 
 ## Provider prefiltering

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -684,7 +684,21 @@ describe("gateway-backed CLI process exit", () => {
       configPath,
     });
 
-    expect(result).toMatchObject({ code: 1, signal: null, stdout: "" });
+    expect(result).toMatchObject({ code: 1, signal: null });
+    expect(JSON.parse(result.stdout)).toEqual({
+      ok: false,
+      error: {
+        type: "cli_error",
+        message: expect.stringContaining("OpenClaw config is invalid:"),
+      },
+      issues: [
+        {
+          path: "gateway.mode",
+          message: expect.stringContaining("Invalid input"),
+          allowedValues: ["local", "remote"],
+        },
+      ],
+    });
     expect(result.stderr).toContain("OpenClaw config is invalid");
     expect(result.stderr).toContain("gateway.mode");
     expect(gateway.calls).toEqual([]);

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -47,6 +47,7 @@ function makeSnapshot() {
 
 function makeRuntime() {
   return {
+    log: vi.fn(),
     error: vi.fn(),
     exit: vi.fn(),
   };
@@ -821,6 +822,73 @@ describe("ensureConfigReady", () => {
     expect(confirm).not.toHaveBeenCalled();
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
+
+  it.each([
+    {
+      name: "blocked JSON commands",
+      commandPath: ["onboard"],
+      argv: ["node", "openclaw", "onboard", "--json"],
+      exitCode: 1,
+      writesJson: true,
+    },
+    {
+      name: "protocol-owned stdout",
+      commandPath: ["mcp", "serve"],
+      argv: ["node", "openclaw", "mcp", "serve"],
+      exitCode: 1,
+      writesJson: false,
+    },
+    {
+      name: "allowed read-only JSON diagnostics",
+      commandPath: ["status"],
+      argv: ["node", "openclaw", "status", "--json"],
+      exitCode: undefined,
+      writesJson: false,
+    },
+    {
+      name: "blocked JSON gateway startup",
+      commandPath: ["gateway", "run"],
+      argv: ["node", "openclaw", "gateway", "run", "--json"],
+      exitCode: 78,
+      writesJson: true,
+    },
+  ])(
+    "preserves output ownership for $name",
+    async ({ commandPath, argv, exitCode, writesJson }) => {
+      setInvalidSnapshot();
+      const runtime = makeRuntime();
+      const originalArgv = process.argv;
+      process.argv = argv;
+      try {
+        await ensureConfigReady({
+          runtime,
+          commandPath,
+          suppressDoctorStdout: true,
+        });
+      } finally {
+        process.argv = originalArgv;
+      }
+
+      if (writesJson) {
+        expect(runtime.log).toHaveBeenCalledOnce();
+        expect(JSON.parse(String(runtime.log.mock.calls[0]?.[0]))).toMatchObject({
+          ok: false,
+          error: {
+            type: "cli_error",
+            message: "OpenClaw config is invalid: /tmp/openclaw.json",
+          },
+          issues: [{ path: "channels.quietchat", message: "invalid" }],
+        });
+      } else {
+        expect(runtime.log).not.toHaveBeenCalled();
+      }
+      if (exitCode === undefined) {
+        expect(runtime.exit).not.toHaveBeenCalled();
+      } else {
+        expect(runtime.exit).toHaveBeenCalledWith(exitCode);
+      }
+    },
+  );
 
   it("keeps invalid Nix-managed config on the manual recovery path", async () => {
     setInvalidSnapshot();

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -15,7 +15,7 @@ import {
 import type { ConfigFileSnapshot } from "../../config/types.js";
 import { resolveExecApprovalsPath } from "../../infra/exec-approvals-config.js";
 import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
-import { ExitError, type RuntimeEnv } from "../../runtime.js";
+import { ExitError, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import type { InvalidConfigRecoveryDeps } from "../invalid-config-recovery.js";
 
 const ALLOWED_INVALID_COMMANDS = new Set(["audit", "doctor", "logs", "health", "help", "status"]);
@@ -328,10 +328,11 @@ export async function ensureConfigReady(
         subcommandName &&
         ALLOWED_INVALID_GATEWAY_SUBCOMMANDS.has(subcommandName))
     : false;
-  const [{ formatConfigIssueLines }, { renderConfigValidationIssueLines }] = await Promise.all([
-    import("../../config/issue-format.js"),
-    import("../../config/issue-location.js"),
-  ]);
+  const [{ formatConfigIssueLines, normalizeConfigIssues }, { renderConfigValidationIssueLines }] =
+    await Promise.all([
+      import("../../config/issue-format.js"),
+      import("../../config/issue-location.js"),
+    ]);
   const issues =
     snapshot.exists && !snapshot.valid ? renderConfigValidationIssueLines(snapshot) : [];
   const legacyIssues =
@@ -399,6 +400,16 @@ export async function ensureConfigReady(
       "Audit, status, health, logs, tasks list/audit, and doctor commands still run with invalid config.",
     ),
   );
+  if (
+    mustBlockInvalid &&
+    (await import("../json-output-mode.js")).isJsonOutputModeActive(process.argv)
+  ) {
+    const { formatCliJsonFailure } = await import("../failure-output.js");
+    writeRuntimeJson(params.runtime, {
+      ...formatCliJsonFailure(`OpenClaw config is invalid: ${shortenHomePath(snapshot.path)}`),
+      issues: normalizeConfigIssues(snapshot.issues),
+    });
+  }
   if (isPluginPackagingFailure && isGatewayStartup) {
     params.runtime.exit(78);
     return;

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -139,6 +139,57 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     vi.clearAllMocks();
   });
 
+  it.each([false, true])(
+    "rejects invalid existing config without writes while honoring JSON output (json: %s)",
+    async (json) => {
+      await withStateDir("state-invalid-config-", async (stateDir) => {
+        const snapshot = await readConfigFileSnapshotMock();
+        readConfigFileSnapshotMock.mockResolvedValueOnce({
+          ...snapshot,
+          exists: true,
+          valid: false,
+          issues: [{ path: "gateway.port", message: "invalid" }],
+        });
+        const output = vi.fn();
+        const error = vi.fn();
+        const captureRuntime: RuntimeEnv = {
+          log: output,
+          error,
+          exit: (code) => {
+            throw new Error(`exit:${code}`);
+          },
+        };
+        const message = "Config invalid. Run `openclaw doctor` to repair it, then re-run setup.";
+
+        await expect(
+          runNonInteractiveSetup(
+            {
+              ...createOnboardLocalDaemonOptions(stateDir),
+              installDaemon: false,
+              skipHealth: true,
+              json,
+            },
+            captureRuntime,
+          ),
+        ).rejects.toThrow("exit:1");
+
+        expect(error).toHaveBeenCalledWith(message);
+        if (json) {
+          expect(output).toHaveBeenCalledOnce();
+          expect(JSON.parse(String(output.mock.calls[0]?.[0]))).toEqual({
+            ok: false,
+            phase: "options",
+            message,
+          });
+        } else {
+          expect(output).not.toHaveBeenCalled();
+        }
+        expect(capturedReplaceConfigFileCalls).toHaveLength(0);
+        expect(ensureWorkspaceAndSessionsMock).not.toHaveBeenCalled();
+      });
+    },
+  );
+
   it("rejects concurrent onboarding runs sharing one state directory", async () => {
     await withStateDir("state-concurrent-onboard-", async (stateDir) => {
       let workspaceSetupCalls = 0;

--- a/src/commands/onboard-non-interactive.ts
+++ b/src/commands/onboard-non-interactive.ts
@@ -98,10 +98,11 @@ async function runNonInteractiveSetupExclusive(opts: OnboardOptions, runtime: Ru
   if (snapshot.exists && !snapshot.valid) {
     // Avoid rewriting an invalid config snapshot; doctor owns recovery so setup
     // does not erase malformed user state.
-    runtime.error(
+    rejectOnboardingOption(
+      opts,
+      runtime,
       `Config invalid. Run \`${formatCliCommand("openclaw doctor")}\` to repair it, then re-run setup.`,
     );
-    runtime.exit(1);
     return;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators automating onboarding with `--json` received an empty stdout and exit code 1 when the existing OpenClaw configuration was invalid. Both `openclaw onboard` and `openclaw setup` failed silently from the perspective of their JSON consumers, even though human recovery guidance appeared on stderr.

## Why This Change Was Made

The generic CLI configuration guard now emits the existing canonical JSON failure envelope and normalized validation issues before rejecting invalid configuration. The separate non-interactive setup owner reuses the existing onboarding rejection helper. JSON emission is limited to actual resolved JSON output mode and blocked commands, preserving protocol-owned stdout, allowed read-only diagnostics, existing human recovery guidance, and gateway exit code 78.

## User Impact

Automation always receives one parseable failure for invalid existing configuration, including actionable validation issues or the established onboarding options error. Human users, protocol clients, Nix and plugin-packaging recovery paths, configuration persistence, and gateway exit behavior remain unchanged.

## Evidence

- Authentic pre-fix regressions: shared guard JSON onboarding and gateway cases failed while protocol and allowed-status controls passed; setup JSON failed while its human sibling passed.
- Real CLI before repair: both `onboard --non-interactive --accept-risk --mode remote --remote-url wss://example.invalid --json` and the equivalent `setup` invocation exited 1 with zero stdout bytes against `OPENCLAW_CONFIG_PATH=/dev/null` and isolated temporary state.
- Real CLI after repair: onboarding emits exactly one canonical `{ok:false,error:{type:"cli_error",message:"OpenClaw config is invalid: /dev/null"},issues:[...]}`; setup emits exactly one `{ok:false,phase:"options",message:"Config invalid. Run openclaw doctor ..."}`. Both human siblings retain empty stdout, existing stderr recovery guidance, and exit 1.
- `node scripts/run-vitest.mjs src/cli/program/config-guard.test.ts src/cli/program/preaction.test.ts src/cli/json-output-mode.test.ts src/commands/onboard-non-interactive.gateway.test.ts src/commands/onboard.test.ts` — 257 tests passed across five owner and sibling suites.
- Focused typed oxlint, formatting, `git diff --check`, independent review, and mandatory structured Codex review passed.
- Production: +19/-7, net +12, justified by adding the missing generic machine-readable failure capability at the existing CLI owner. Tests: +119; documentation: net +1.

AI-assisted.