### PR TITLE
fix(auth): reject retired profiles from cold external providers

### DIFF
--- a/src/plugins/provider-runtime.external-policy.test.ts
+++ b/src/plugins/provider-runtime.external-policy.test.ts
@@ -1,0 +1,43 @@
+// Verifies cold retired-profile policy resolution for trusted external providers.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+
+const fixtureState = vi.hoisted(() => ({ pluginRoot: "" }));
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const externalPluginRoot = tempDirs.make("openclaw-provider-retired-auth-external-");
+fs.writeFileSync(
+  path.join(externalPluginRoot, "provider-policy-api.js"),
+  'export const deprecatedProfileIds = ["fixture-provider:legacy"];\n',
+  "utf8",
+);
+fixtureState.pluginRoot = externalPluginRoot;
+
+vi.mock("./current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: () => ({
+    manifestRegistry: {
+      plugins: [
+        {
+          id: "fixture-provider",
+          origin: "external",
+          trustedOfficialInstall: true,
+          rootDir: fixtureState.pluginRoot,
+          providers: ["fixture-provider"],
+          cliBackends: [],
+        },
+      ],
+    },
+  }),
+  isCurrentPluginMetadataSnapshotRuntimeGeneration: () => false,
+}));
+
+const { resolveProviderDeprecatedAuthProfileIds } = await import("./provider-runtime.js");
+
+describe("trusted external provider retired auth policy", () => {
+  it("resolves retired profile ids while the provider runtime remains cold", () => {
+    expect(resolveProviderDeprecatedAuthProfileIds({ provider: "fixture-provider" })).toEqual([
+      "fixture-provider:legacy",
+    ]);
+  });
+});

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -33,6 +33,8 @@ type ResolveOwningPluginIdsForProvider =
   typeof import("./providers.js").resolveOwningPluginIdsForProvider;
 type ResolveBundledProviderPolicySurface =
   typeof import("./provider-public-artifacts.js").resolveBundledProviderPolicySurface;
+type ResolveProviderPolicySurface =
+  typeof import("./provider-public-artifacts.js").resolveProviderPolicySurface;
 
 const resolvePluginProvidersMock = vi.fn<ResolvePluginProviders>((_) => [] as ProviderPlugin[]);
 const isPluginProvidersLoadInFlightMock = vi.fn<IsPluginProvidersLoadInFlight>((_) => false);
@@ -50,6 +52,7 @@ const resolveOwningPluginIdsForProviderMock = vi.fn<ResolveOwningPluginIdsForPro
 const resolveBundledProviderPolicySurfaceMock = vi.fn<ResolveBundledProviderPolicySurface>(
   (_) => null,
 );
+const resolveProviderPolicySurfaceMock = vi.fn<ResolveProviderPolicySurface>((_) => null);
 const providerRuntimeWarnMock = vi.fn();
 
 let getAiTransportHost: typeof import("@openclaw/ai").getAiTransportHost;
@@ -271,6 +274,8 @@ describe("provider-runtime", () => {
       resolveBundledProviderPolicySurface: (
         ...args: Parameters<ResolveBundledProviderPolicySurface>
       ) => resolveBundledProviderPolicySurfaceMock(...args),
+      resolveProviderPolicySurface: (...args: Parameters<ResolveProviderPolicySurface>) =>
+        resolveProviderPolicySurfaceMock(...args),
     }));
     vi.doMock("./providers.js", () => ({
       resolveCatalogHookProviderPluginIds: (params: unknown) =>
@@ -370,6 +375,8 @@ describe("provider-runtime", () => {
     resolveOwningPluginIdsForProviderMock.mockReturnValue(undefined);
     resolveBundledProviderPolicySurfaceMock.mockReset();
     resolveBundledProviderPolicySurfaceMock.mockReturnValue(null);
+    resolveProviderPolicySurfaceMock.mockReset();
+    resolveProviderPolicySurfaceMock.mockReturnValue(null);
     providerRuntimeWarnMock.mockReset();
   });
 
@@ -1674,7 +1681,7 @@ describe("provider-runtime", () => {
   });
 
   it("reads deprecated profile ids without loading provider runtime", () => {
-    resolveBundledProviderPolicySurfaceMock.mockReturnValue({
+    resolveProviderPolicySurfaceMock.mockReturnValue({
       deprecatedProfileIds: ["anthropic:claude-cli"],
     });
 

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -41,7 +41,10 @@ import {
   type ProviderRuntimePluginHandle,
   wrapProviderStreamFn,
 } from "./provider-hook-runtime.js";
-import { resolveBundledProviderPolicySurface } from "./provider-public-artifacts.js";
+import {
+  resolveBundledProviderPolicySurface,
+  resolveProviderPolicySurface,
+} from "./provider-public-artifacts.js";
 import { matchesProviderPluginRef } from "./provider-registry-shared.js";
 import type { ProviderRuntimeModel } from "./provider-runtime-model.types.js";
 import {
@@ -899,8 +902,17 @@ export function resolveProviderDeprecatedAuthProfileIds(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 }): readonly string[] {
+  const metadataSnapshot = getCurrentPluginMetadataSnapshot({
+    config: params.config,
+    env: params.env,
+    workspaceDir: params.workspaceDir,
+    allowScopedSnapshot: true,
+    allowWorkspaceScopedSnapshot: true,
+  });
   return (
-    resolveBundledProviderPolicySurface(params.provider)?.deprecatedProfileIds ??
+    resolveProviderPolicySurface(params.provider, {
+      manifestRegistry: metadataSnapshot?.manifestRegistry,
+    })?.deprecatedProfileIds ??
     resolveLoadedProviderRuntimePlugin(params)?.deprecatedProfileIds ??
     []
   );


### PR DESCRIPTION
Related: #129387

## What Problem This Solves

Fixes an issue where users of trusted official external provider plugins could have a retired stored authentication profile selected when that provider's runtime had not yet loaded.

## Why This Change Was Made

Retired-profile lookup now uses the existing registry-aware provider policy resolver with the compatible current manifest snapshot. This preserves cold/lazy provider runtime behavior, keeps the already-loaded runtime fallback, and does not add a parallel policy abstraction.

## User Impact

Trusted official external providers can reliably retire legacy authentication profiles before runtime activation, preventing generic credential selection from using credentials the provider no longer supports.

## Evidence

- True pre-fix regression: `provider-runtime.external-policy.test.ts` failed with `expected [] to deeply equal ["fixture-provider:legacy"]` on the merged implementation.
- After the fix, the cold external-provider regression passes without activating a provider runtime.
- Relevant plugin suites: 4 files, 91 tests passed.
- Frozen-base changed tests: 2 files, 68 tests passed via `pnpm test:changed`.
- Frozen-base changed checks: `pnpm check:changed` passed, including core production/test typechecks, changed-file lint, dead-export checks, and zero runtime import cycles.
- Full `pnpm build` passed, including plugin control-plane loads and all 147 public plugin SDK subpaths.
- Exact-branch autoreview: clean, no P0/P1 findings (0.93 confidence).
- Exact-diff TruffleHog: clean.

Production LOC: +14/-2 (net +12) | Tests: +51/-1

AI-assisted: yes. I reviewed the owner path, regression, implementation, and validation results.
## Maintainer risk disposition

- **Compatibility behavior accepted.** This makes the new provider-owned `deprecatedProfileIds` contract complete for cold trusted official external plugins. The contract is not present in stable `v2026.7.1-2`, and the current published official external-provider inventory declares no retired profile IDs; only bundled Anthropic currently exports one. There is therefore no existing external-plugin credential-selection behavior to migrate for this PR.
- **Recovery path verified.** Explicit retired-profile selection already fails with the actionable `openclaw doctor --fix` instruction in `src/agents/model-auth-provider.ts`. Doctor removes retired profile references, preserves the provider-owned runtime selection, and schedules cleanup for every affected agent store in `src/commands/doctor-auth-legacy-oauth.ts`, with focused coverage in `src/commands/doctor-auth.deprecated-cli-profiles.test.ts`.
- **Production growth accepted.** The +14/-2 production delta is the smallest owner-correct form: it carries the lifecycle-compatible manifest registry into the existing trusted `resolveProviderPolicySurface` seam. Moving snapshot lookup into that resolver, rebuilding metadata, loading provider runtime, or threading registry types through auth callers would broaden ownership or restore the original runtime-loading defect.
- **No data-model change.** The review's vector/embedding metadata marker is a filename-classification false positive from the test fixture; this PR changes no persisted schema or metadata format.

No source or test change is needed for these review items. The remaining gate is exact-head CI after the independently owned test-inventory repair lands.