### PR TITLE
fix(compaction): protect manual commands from stale recovery

### DIFF
--- a/src/auto-reply/reply/commands-compact.lifecycle.test.ts
+++ b/src/auto-reply/reply/commands-compact.lifecycle.test.ts
@@ -13,6 +13,7 @@ import {
   waitForEmbeddedAgentRunEnd,
 } from "./commands-compact.test-support.js";
 import type { HandleCommandsParams } from "./commands-types.js";
+import { createReplyOperation } from "./reply-run-registry.js";
 
 describe("handleCompactCommand lifecycle authority", () => {
   beforeEach(resetCompactCommandMocks);
@@ -69,6 +70,40 @@ describe("handleCompactCommand lifecycle authority", () => {
     expect(vi.mocked(abortEmbeddedAgentRun)).toHaveBeenCalledWith("session-1");
     expect(vi.mocked(waitForEmbeddedAgentRunEnd)).toHaveBeenCalledWith("session-1", 15_000);
     expect(vi.mocked(compactEmbeddedAgentSession)).toHaveBeenCalledOnce();
+  });
+
+  it("marks manual compaction as maintenance until the command finishes", async () => {
+    const replyOperation = createReplyOperation({
+      sessionKey: "agent:main:telegram:slash:test",
+      sessionId: "command-operation",
+      resetTriggered: false,
+    });
+    replyOperation.setPhase("running");
+    vi.mocked(compactEmbeddedAgentSession).mockImplementationOnce(async () => {
+      expect(replyOperation.phase).toBe("preflight_compacting");
+      return { ok: true, compacted: false };
+    });
+
+    try {
+      await handleCompactCommand(
+        {
+          ...buildCompactParams("/compact", {
+            commands: { text: true },
+            channels: { whatsapp: { allowFrom: ["*"] } },
+          } as OpenClawConfig),
+          opts: { replyOperation },
+          sessionEntry: {
+            sessionId: "session-1",
+            updatedAt: Date.now(),
+          },
+        } as HandleCommandsParams,
+        true,
+      );
+
+      expect(replyOperation.phase).toBe("running");
+    } finally {
+      replyOperation.complete();
+    }
   });
 
   it("does not replace an active run when abort drain times out", async () => {

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -287,7 +287,9 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   if (failure) {
     return failure;
   }
-  const result = await runtime.compactEmbeddedAgentSession({
+  const replyOperation = params.opts?.replyOperation;
+  replyOperation?.setPhase("preflight_compacting");
+  const compaction = runtime.compactEmbeddedAgentSession({
     abortSignal: params.opts?.abortSignal,
     contextEngineAgentId: sessionAgentId,
     sessionId,
@@ -342,6 +344,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       senderIsOwner: params.command.senderIsOwner,
     }),
   });
+  const result = await compaction.finally(() => replyOperation?.setPhase("running"));
   failure = authorityFailure();
   if (failure) {
     return failure;

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -14,8 +14,9 @@ import type {
   ThinkingCatalogEntry,
   VerboseLevel,
 } from "../thinking.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { ReplyPayload } from "../types.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
+import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import type { TypingController } from "./typing.js";
 
 /** Normalized command metadata derived from an inbound message. */
@@ -66,7 +67,7 @@ export type HandleCommandsParams = {
   storePath?: string;
   sessionScope?: SessionScope;
   workspaceDir: string;
-  opts?: GetReplyOptions;
+  opts?: InternalGetReplyOptions;
   defaultGroupActivation: () => "always" | "mention";
   /** Catalog snapshot prepared by model selection for status rendering. */
   thinkingCatalog?: ThinkingCatalogEntry[];


### PR DESCRIPTION
## Summary

### High Level TLDR

Manual `/compact` runs were left in the generic `running` lifecycle phase, so stale-session recovery could abort a healthy long-running compaction after five minutes. Mark manual compaction with the existing compaction-maintenance phase while the provider operation is active, then restore the normal running phase.

## Root Cause

The manual command path in `src/auto-reply/reply/commands-compact.ts` awaited `compactEmbeddedAgentSession` without updating the dispatch-owned reply operation. Stale-session recovery already grants `preflight_compacting` operations the configured compaction safety window, and automatic preflight compaction already uses that phase, but the manual path did not carry its internal reply operation into the command contract or set the phase.

Observed before behavior in a managed Gateway:

- A manual `/compact` request remained active for 357,580 ms while staged summarization calls were still progressing.
- The operation then failed with `Reply operation expired as stale` at the generic five-minute stale threshold.
- The active provider request was aborted by that recovery action; the configured compaction watchdog had not expired.
- The affected private chat/topic/session identifiers and raw log context are intentionally omitted.

## Real behavior proof

This PR includes only redacted proof of the observed failure, not a post-patch live-runtime claim. The managed-Gateway observation above showed a still-active manual compaction terminated by generic stale recovery after 357,580 ms with `Reply operation expired as stale`.

## Verification

- Before production changes: `pnpm exec vitest run src/auto-reply/reply/commands-compact.lifecycle.test.ts` — new regression failed because the phase was `running`, not `preflight_compacting`.
- Exact head: `pnpm exec vitest run src/auto-reply/reply/commands-compact.lifecycle.test.ts` — 1 file passed, 6 tests passed.
- `pnpm exec oxfmt --check src/auto-reply/reply/commands-types.ts src/auto-reply/reply/commands-compact.ts src/auto-reply/reply/commands-compact.lifecycle.test.ts` — all matched files use the correct format.
- `git diff --check` — passed.

## What was not tested

- No post-patch deployment or live Telegram `/compact` was run, so this PR does not claim live proof of the fix.
- The full repository test suite and a performance benchmark were not run.


## Worked on by
- @VACInc
