### PR TITLE
test(agents): pin the plugin harness route in session-permission proof

### DIFF
--- a/src/agents/embedded-agent-runner/run.session-permissions.test.ts
+++ b/src/agents/embedded-agent-runner/run.session-permissions.test.ts
@@ -4,27 +4,39 @@ import {
   loadRunOverflowCompactionHarness,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
+  useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
 
 const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
 
+// The mocked harness only supports the OpenAI route, so these params keep the
+// plugin harness selected. Falling back to the built-in host harness would drag
+// the whole OpenClaw tool graph into this shard and prove the wrong owner.
+const pluginHarnessRunParams = {
+  ...overflowBaseRunParams,
+  provider: "openai",
+  model: "gpt-5.6-luna",
+  sessionRoot: "/tmp/openclaw-plugin-session-root",
+} as const;
+
 describe("embedded run session permissions", () => {
   beforeEach(() => {
     mockedRunEmbeddedAttempt.mockReset();
+    useOpenAIPlatformAuthFixture();
   });
 
   it("prepares the exec mode with plugin-owned permission facts", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["OK"] }));
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...pluginHarnessRunParams,
       permissionMode: "workspace",
-      sessionRoot: "/tmp/openclaw-plugin-session-root",
       runId: "run-plugin-session-permissions",
     });
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
       expect.objectContaining({
+        agentHarnessId: "codex",
         execOverrides: expect.objectContaining({ mode: "auto" }),
         permissionMode: "workspace",
         sessionRoot: "/tmp/openclaw-plugin-session-root",
@@ -43,9 +55,8 @@ describe("embedded run session permissions", () => {
     });
 
     await runEmbeddedAgent({
-      ...overflowBaseRunParams,
+      ...pluginHarnessRunParams,
       permissionMode: "full",
-      sessionRoot: "/tmp/openclaw-plugin-session-root",
       execOverrides,
       runId: "run-plugin-clamped-session-permissions",
     });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where every OpenClaw pull request was blocked by a red required check. `src/agents/embedded-agent-runner/run.session-permissions.test.ts` failed deterministically on `main`, taking down `checks-node-compact-large-21` (vitest project `unit-fast-isolated`, shard `core-unit-fast-isolated-hosted-2`) for all contributors. Both of its tests failed: the first timed out at 120 s, and the second reported `expected { mode: 'full' } to deeply equal { mode: 'auto' }`.

## Why This Change Was Made

The suite set no `provider`, so the model resolved to the harness default `anthropic`/`test-model`. The mocked `codex` harness registered by `resetMockAgentHarness` only claims `provider === "codex" || "openai"`, so it never matched and selection fell through to the **built-in `openclaw` host harness**. Two consequences:

1. A test named for *plugin-owned* permission facts was actually proving the host path. Instrumentation confirmed `agentHarnessId: "openclaw"`, `provider: "anthropic"`.
2. That route pays a one-time module-compilation cost inside the test body — the reason `warmRunOverflowCompactionHarness` exists ("Move one-time runner compilation out of individual behavior timings"). A 4 s ticker placed inside the test fired exactly once, at t=162904 ms: the event loop was starved end to end, not waiting on I/O.

The starvation is what produced both failures. The first test blocks past 120 s; when the loop frees up, Vitest's timeout fires *and* the orphaned run continues into the next `beforeEach` reset and consumes the second test's `mockImplementationOnce`. The second test's own attempt then gets the empty mock, never flips the mode, and its outer object still reads `{ mode: "full" }` — in 325 ms, because the graph is warm by then.

The runner and the assertions were both correct: `resolveSessionPermissionExecMode` maps `workspace → auto` and `full → full`, and `run-attempt-dispatch.ts` seeds then shares that exact object. Only the harness route was wrong. The fix pins `provider`/`model` so the plugin harness stays selected (matching every sibling suite in this harness family), installs the harness's own `useOpenAIPlatformAuthFixture()`, and adds an `agentHarnessId: "codex"` assertion so a future silent fall-back to the host harness fails loudly instead of only going slow.

## User Impact

Contributors and maintainers get a green required check again — no more unrelated PRs blocked by this shard. The suite now actually proves the plugin-owned permission-clamping contract it is named for, and that CI shard gets roughly two minutes back.

## Evidence

Local repro on current `main` (macOS, Node 24), before the fix:

```
❯ |unit-fast-isolated| run.session-permissions.test.ts (2 tests | 2 failed) 136035ms
  × prepares the exec mode with plugin-owned permission facts 135848ms
  × shares the final plugin-clamped exec mode with the outer run 187ms
Error: Test timed out in 120000ms.
AssertionError: expected { mode: 'full' } to deeply equal { mode: 'auto' }
```

Same command after the fix:

```
Test Files  1 passed (1)
     Tests  2 passed (2)
  Duration  13.79s (transform 7.77s, import 12.33s, tests 1.32s)
```

Test time drops from 136 s-and-timeout to **1.32 s**.

Supporting measurements that isolate the cause:

- `run.harness-auth-failover.test.ts` — same harness, same public entrypoint, but provider-pinned — completes in **14.5 s total**, so the cost is route-specific rather than a generic first-run tax.
- `run.shared-integration.test.ts` pays the same expensive route deliberately in `beforeAll` and then runs 71 tests inside 165 s.
- Pinning the provider alone cut test time from ~160 s to **1.02 s** (failing only on the missing auth fixture, `No route-compatible authentication source is configured for openai`), which confirmed the route as the cost driver before the fixture was added.

Gates: `node scripts/check-changed.mjs -- src/agents/embedded-agent-runner/run.session-permissions.test.ts` exits 0 (formatting, ratchets, Knip dead-export scans, core-test typecheck, lint). Fresh Codex `$autoreview` on the diff: clean, no accepted/actionable findings.

Production LOC: +0/-0 (net 0) | Tests: +14/-3

Refs #129385
