### PR TITLE
fix(auth): load provider worker from source

### DIFF
--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -3,12 +3,11 @@
  * keeps per-agent auth snapshots process-current so model listing can avoid
  * repeated env/profile/plugin discovery on hot paths.
  */
-import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
 import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { toErrorObject } from "../infra/errors.js";
+import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import {
   listAgentIds,
   resolveAgentDir,
@@ -483,18 +482,6 @@ export async function buildCurrentProviderAuthStateSnapshot(
   return serializeProviderAuthStates(states);
 }
 
-function resolveProviderAuthWarmWorkerUrl(currentModuleUrl: string): URL {
-  const currentPath = fileURLToPath(currentModuleUrl);
-  const distMarker = `${path.sep}dist${path.sep}`;
-  const distIndex = currentPath.lastIndexOf(distMarker);
-  if (distIndex >= 0) {
-    const distRoot = currentPath.slice(0, distIndex + distMarker.length - 1);
-    return pathToFileURL(path.join(distRoot, "agents", "model-provider-auth.worker.js"));
-  }
-  const extension = path.extname(currentPath) || ".js";
-  return new URL(`./model-provider-auth.worker${extension}`, currentModuleUrl);
-}
-
 function isProviderAuthWarmSnapshot(value: unknown): value is ProviderAuthWarmSnapshot {
   if (
     !value ||
@@ -607,7 +594,15 @@ function runProviderAuthWarmWorker(params: {
   isCancelled: () => boolean;
   workerUrl?: URL;
 }): Promise<ProviderAuthWarmSnapshot> {
-  const worker = new Worker(params.workerUrl ?? resolveProviderAuthWarmWorkerUrl(import.meta.url), {
+  const workerUrl =
+    params.workerUrl ??
+    resolveRuntimeWorkerUrl({
+      currentModuleUrl: import.meta.url,
+      sourceWorkerName: "model-provider-auth.worker",
+      distWorkerPath: "agents/model-provider-auth.worker.js",
+    });
+  const sourceWorkerExecArgv = workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : undefined;
+  const worker = new Worker(workerUrl, {
     workerData: {
       cfg: params.cfg,
       ...(params.runtimeAuthStores?.length ? { runtimeAuthStores: params.runtimeAuthStores } : {}),
@@ -616,6 +611,7 @@ function runProviderAuthWarmWorker(params: {
         : {}),
       ...(params.omitFalseProviderAuth ? { omitFalseProviderAuth: true } : {}),
     },
+    execArgv: sourceWorkerExecArgv,
   });
   worker.unref?.();
   const handle = {

--- a/src/agents/model-provider-auth.worker.test.ts
+++ b/src/agents/model-provider-auth.worker.test.ts
@@ -9,7 +9,10 @@ import {
   clearRuntimeAuthProfileStoreSnapshots,
   resolveInlineProviderApiKeyUsageId,
 } from "./auth-profiles.js";
-import { clearCurrentProviderAuthState } from "./model-provider-auth.js";
+import {
+  clearCurrentProviderAuthState,
+  warmCurrentProviderAuthStateOffMainThread,
+} from "./model-provider-auth.js";
 import { runProviderAuthWarmWorkerInput } from "./model-provider-auth.worker.js";
 
 const tempDirs: string[] = [];
@@ -44,6 +47,12 @@ describe("provider auth warm worker", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("launches the default source worker without an injected URL", async () => {
+    await expect(
+      warmCurrentProviderAuthStateOffMainThread({ agents: { list: [] } }, { timeoutMs: 30_000 }),
+    ).resolves.toBeUndefined();
+  }, 30_000);
 
   it("preserves runtime-only auth profile snapshots in the worker warm input", async () => {
     // Runtime-only profiles are not persisted to disk, so the worker input must


### PR DESCRIPTION
Related: #86281

## What Problem This Solves

Source-checkout gateway startup could fail to warm provider authentication because the worker thread tried to execute a TypeScript entry without the `tsx` loader. Packaged JavaScript builds were unaffected.

## Why This Change Was Made

The provider-auth warmer now uses the shared source-or-dist worker URL resolver and adds `--import tsx` only when the resolved default worker is TypeScript. Packaged `.js` workers remain loader-free. A regression test launches the real default source worker without injecting a test URL.

This keeps worker logic, credential IPC, provider-auth semantics, package metadata, and lockfiles unchanged.

## User Impact

Developers and maintainers running OpenClaw from source can start the provider-auth warm worker successfully. Packaged installations keep the existing JavaScript worker path.

## Evidence

- Exact head: `d28d4fa2b0e54b01371d02d2a442225b94ef2b7e`, signed and GitHub-verified.
- Focused local Vitest: 2 shards, 28 tests passed in 15.02s.
- Changed-file gate: dry run passed in 0.33s; the full run passed every branch-relevant conflict, policy, format, boundary, production-type, and dead-export check. Its terminal core-test type failure reproduced unchanged on current main and is superseded by exact-head hosted CI.
- `git diff --check origin/main...HEAD` passed. Production LOC: +11/-15 (net -4). Tests: +10/-1 (net +9).
- Fresh final autoreview: clean, with no accepted or actionable findings.
- Fresh Linux Testbox run: https://github.com/openclaw/openclaw/actions/runs/33089747739
  - exact SHA verified before execution;
  - focused Vitest passed 28/28 in 22s;
  - `corepack pnpm build` passed in 251s;
  - direct launch of `dist/agents/model-provider-auth.worker.js` with `execArgv: []` returned `status=ok` in 1s.
- The Testbox update smoke installed and upgraded to `2026.8.1`, then its final `doctor --repair` step twice timed out waiting for `core:plugin-lifecycle/global`. No branch differential was established, so this is not classified as a W3C regression; the changed auth-worker path had already passed focused source and built-dist execution.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/33088303982
  - attempt 1 had ten GitHub fetch/throttle failures; the bundled suite itself passed 206/206 before its base fetch failed;
  - contemporaneous current-main CI was independently red;
  - one failed-jobs-only retry cleared every failed lane, and exact-head `openclaw/ci-gate` is green.
- Historical run https://github.com/openclaw/openclaw/actions/runs/32891819200 was unrelated timeout/test-inventory fallout with no branch differential. It is superseded by the exact-head evidence above.

Root cause: `src/agents/model-provider-auth.ts` had a private copy of worker URL resolution but did not pair source `.ts` resolution with the required loader. The canonical owner is the shared runtime-worker URL boundary.

Best-fix verdict: this is the canonical narrow repair. Adding a loader to every worker would unnecessarily alter packaged startup; keeping the duplicate resolver would preserve the drift that caused the defect.

AI-assisted: yes. The scoped diff and generated commit were reviewed directly before publication.
