### PR TITLE
fix: include Codex startup retry coverage in full CI

### DIFF
--- a/test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts
@@ -9,6 +9,7 @@ function createExtensionCodexAppServerAttemptSupportVitestConfig(
       "extensions/codex/src/app-server/attempt-context.test.ts",
       "extensions/codex/src/app-server/attempt-notifications.test.ts",
       "extensions/codex/src/app-server/attempt-results.test.ts",
+      "extensions/codex/src/app-server/attempt-startup-retry.test.ts",
       "extensions/codex/src/app-server/attempt-startup.test.ts",
       "extensions/codex/src/app-server/attempt-timeouts.test.ts",
       "extensions/codex/src/app-server/attempt-turn-watches.test.ts",


### PR DESCRIPTION
Related: #129505

## What Problem This Solves

Fixes an issue where the main full-suite Vitest inventory failed because the Codex app-server startup retry regression test had no canonical project owner.

## Why This Change Was Made

Registers the existing process-boundary retry test with the Codex app-server attempt-support project beside the related attempt startup tests. The test itself is unchanged; no inventory baseline or ignore is weakened.

## User Impact

No runtime behavior changes. Main CI can run the Codex startup retry regression through the canonical full-suite project inventory again.

Production LOC: +0/-0 (net 0) | Tests/test tooling: +1/-0

## Evidence

- Before (`origin/main` `66bfdeffb9b4e60e858e17a4f11aea1eb401e94a`): `test/vitest-projects-config.test.ts` failed its full-suite ownership assertion with only `extensions/codex/src/app-server/attempt-startup-retry.test.ts` missing.
- After: the same focused ownership assertion passed, and the complete config test file passed 23/23.
- Canonical owner proof: direct run through `test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts` passed the retry file 4/4 under project `extension-codex-app-server-attempt-support`.
- Changed gate: `node scripts/check-changed.mjs -- test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts` passed formatting, test-root typecheck, scripts lint, and repository guards.
- `git diff --check` passed.
- Fresh Codex autoreview: clean, no accepted/actionable findings.
- Direct sibling Codex source inspection at `openai/codex` `97729885d4707a123db31ae80f5fb0eeda6b7706`: `codex-rs/app-server/src/lib.rs:601-608` surfaces SQLite state-runtime initialization failure from app-server startup; `codex-rs/rollout/src/state_db.rs:40-109` owns state-runtime initialization and preserves the nested `failed to initialize state runtime at ...` error exercised by the retry test.

AI-assisted: yes. I inspected the ownership model, test boundary, runtime owner, upstream Codex source, and validation results directly.
