### PR TITLE
fix(anthropic): keep provider policy imports lightweight

### DIFF
--- a/extensions/anthropic/cli-constants.ts
+++ b/extensions/anthropic/cli-constants.ts
@@ -4,6 +4,13 @@
  */
 /** Synthetic provider/backend id for Claude Code CLI-backed Anthropic models. */
 export const CLAUDE_CLI_BACKEND_ID = "claude-cli";
+/** Legacy auth profile id retained for native Claude CLI compatibility. */
+export const CLAUDE_CLI_PROFILE_ID = "anthropic:claude-cli";
+/** Explicit thinking opt-out for Claude CLI routes unsupported by Claude Code. */
+export const CLAUDE_CLI_OFF_THINKING_PROFILE = {
+  levels: [{ id: "off" }],
+  defaultLevel: "off",
+} as const;
 /** Non-secret marker telling OpenClaw that the installed Claude CLI owns auth. */
 export const CLAUDE_CLI_NATIVE_AUTH_MARKER = ["openclaw", "claude-cli-native-auth"].join(":");
 /** Default Claude CLI model ref for agent defaults and live tests. */

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -16,6 +16,7 @@ export {
   CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS,
   CLAUDE_CLI_DEFAULT_MODEL_REF,
   CLAUDE_CLI_MODEL_ALIASES,
+  CLAUDE_CLI_OFF_THINKING_PROFILE,
   CLAUDE_CLI_SESSION_ID_FIELDS,
 } from "./cli-constants.js";
 
@@ -116,12 +117,6 @@ type ClaudeCliEffortArgAction =
   | { mode: "preserve" }
   | { mode: "omit" }
   | { mode: "set"; effort: ClaudeCliEffort };
-
-/** Explicit thinking opt-out for Claude CLI routes unsupported by Claude Code. */
-export const CLAUDE_CLI_OFF_THINKING_PROFILE = {
-  levels: [{ id: "off" }],
-  defaultLevel: "off",
-} as const;
 
 /** Return whether a provider id refers to the Claude CLI backend. */
 export function isClaudeCliProvider(providerId: string): boolean {

--- a/extensions/anthropic/config-defaults.ts
+++ b/extensions/anthropic/config-defaults.ts
@@ -4,7 +4,6 @@ import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-scop
  * model refs and cache-retention params based on configured auth mode.
  */
 import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
-import { CLAUDE_CLI_PROFILE_ID } from "openclaw/plugin-sdk/provider-auth";
 import {
   isRecord,
   normalizeLowercaseStringOrEmpty,
@@ -13,7 +12,11 @@ import {
   resolveClaudeCliAnthropicModelRefs,
   resolveKnownAnthropicModelRef,
 } from "./claude-model-refs.js";
-import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "./cli-constants.js";
+import {
+  CLAUDE_CLI_BACKEND_ID,
+  CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS,
+  CLAUDE_CLI_PROFILE_ID,
+} from "./cli-constants.js";
 
 const ANTHROPIC_PROVIDER_API = "anthropic-messages";
 const ANTHROPIC_API_KEY_DEFAULT_ALLOWLIST_REFS = [

--- a/extensions/anthropic/provider-policy-api.ts
+++ b/extensions/anthropic/provider-policy-api.ts
@@ -2,14 +2,13 @@
  * Provider-policy API for Anthropic and Claude CLI. Core calls this lightweight
  * path for config defaults and thinking profiles.
  */
-import { CLAUDE_CLI_PROFILE_ID } from "openclaw/plugin-sdk/provider-auth";
 import {
   resolveClaudeModelIdentity,
   resolveClaudeMythos5ModelIdentity,
   resolveClaudeThinkingProfile,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
-import { CLAUDE_CLI_OFF_THINKING_PROFILE } from "./cli-shared.js";
+import { CLAUDE_CLI_OFF_THINKING_PROFILE, CLAUDE_CLI_PROFILE_ID } from "./cli-constants.js";
 import {
   applyAnthropicConfigDefaults,
   normalizeAnthropicProviderConfigForProvider,


### PR DESCRIPTION
## What Problem This Solves

Anthropic's documented lightweight provider-policy/config-default path imports heavyweight runtime graphs through `openclaw/plugin-sdk/provider-auth` and `./cli-shared.js`. Under compact CI shard contention, unchanged runtime-config snapshots, agent worktree admission, embedded model resolution, dispatch, cron, and onboarding tests reach their 120/180-second limits. The later `undefined` versus `cache-ttl` assertion and managed-worktree removal rejection are timeout/teardown fallout, not configuration or worktree behavior regressions.

The regression entered in two steps: #129052 made config defaults import provider auth, and #129387 made provider policy import that same auth path. Provider policy also imported the runtime-heavy CLI adapter for one static thinking profile.

## Why This Change Was Made

Move the exact static Claude CLI profile id and off-thinking profile to the plugin-local zero-import `cli-constants.ts` owner. Existing `cli-shared.ts` consumers retain the same re-export, while provider policy and config defaults no longer import heavyweight auth/runtime graphs.

The public plugin SDK export and every existing value/config default remain unchanged. A new public constants subpath, direct host-internal import, timeout increase, and test-only production seam were rejected.

Production LOC: +14/-10 (net +4). Test LOC: unchanged.

## User Impact

Anthropic/Claude CLI behavior and configuration are unchanged. Lightweight config/policy loading no longer pays for unrelated runtime graphs, removing the current-main contention cascade that blocks unrelated PRs.

## Evidence

- Frozen head: `b6bae036fc7ec2bb96af3422066cfee8eb64b28f`; base: `66bfdeffb9b4e60e858e17a4f11aea1eb401e94a`.
- Runtime-config before: **2 failed / 19 passed**; snapshot reuse timed out at 124,251 ms and the next test received `undefined` instead of `cache-ttl`; wall 136.74 s, max RSS 1,359,920 KiB.
- Runtime-config after: **21/21 passed**; snapshot reuse 34,156 ms in the clean comparison; wall 46.07 s, max RSS 1,073,812 KiB.
- Worktree before: **2/2 passed only narrowly**; first test 114,448 ms, wall 130.56 s, max RSS 1,892,780 KiB. Failed hosted shards then emitted the removal rejection during teardown.
- Worktree after: **2/2 passed**; first test 33,119 ms in the clean comparison; wall 49.51 s, max RSS 1,475,828 KiB.
- Anthropic policy/CLI ownership: `provider-policy-api.test.ts`, `cli-shared.test.ts`, and `cli-shared.execution-env.test.ts` — **3 files, 71/71 passed**.
- `pnpm check:changed` passed across extension production/tests, formatting, boundaries, dead exports, typechecks, lint, schema/database/media/sidecar guards, and import cycles.
- `pnpm build` passed in the linked worktree environment. Anthropic startup profiler imported successfully at 298.3 MB RSS.
- Test audit: existing runtime-config/worktree suites are the direct failure proof; a new import-shape test would be implementation-coupled. No test-only production seam was added.
- Deslop: clean; no defensive wrappers, timeout changes, compatibility aliases, or unrelated cleanup.
- Structured exact-head autoreview: clean, patch-correct confidence 0.99, no actionable findings.
- Separate read-only Codex review: **non-blocking**; verified preserved values/re-exports and the plugin-local ownership boundary.

Duplicate/history searches found no competing repair. #129528 mixes the now-landed `/learn` assertion work with unrelated embedded-runner changes and is not a substitute. #129370 has since landed the deterministic `/learn` assertion repair separately, so this remains a focused runtime/import repair.
