### PR TITLE
chore(codex): remove duplicate approval policy test

### DIFF
--- a/extensions/codex/src/app-server/app-server-policy.test.ts
+++ b/extensions/codex/src/app-server/app-server-policy.test.ts
@@ -5,14 +5,9 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { resolveCodexAppServerForModelProvider } from "./app-server-policy.js";
 import { assertCodexModelBackedReviewerEffectiveConfig } from "./config-reviewer.js";
-import { withMcpElicitationsApprovalPolicy } from "./config-security.js";
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
 
 describe("Codex app-server policy", () => {
-  it("preserves mandatory per-command approvals while permitting MCP elicitation", () => {
-    expect(withMcpElicitationsApprovalPolicy("untrusted")).toBe("untrusted");
-  });
-
   it("revalidates effective Guardian config at each boundary and skips human reviewers", async () => {
     const request = vi.fn(async () => ({ config: { model_provider: "openai" }, origins: {} }));
     const client = { request };


### PR DESCRIPTION
## What Problem This Solves

The Codex app-server policy suite repeated the exact same approval-policy assertion already owned by the app-server config suite, adding maintenance cost without detecting another failure mode.

## Why This Change Was Made

Remove the stray duplicate test and its now-unused import. The canonical byte-for-byte assertion and broader `withMcpElicitationsApprovalPolicy` coverage remain in `config.test.ts`.

AI-assisted test audit requested by @steipete.

## User Impact

No user-visible behavior changes. Maintainers keep the same policy coverage with one fewer duplicate test.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/app-server-policy.test.ts extensions/codex/src/app-server/config.test.ts` — 2 files passed, 188 tests passed
- `node scripts/check-changed.mjs -- extensions/codex/src/app-server/app-server-policy.test.ts` — passed
- `git diff --check` — passed
- Autoreview (`gpt-5.6-sol`, high) — no accepted/actionable findings
