### PR TITLE
test(vitest): assign startup retry regression to its project

### DIFF
--- a/test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts
@@ -9,6 +9,7 @@ function createExtensionCodexAppServerAttemptSupportVitestConfig(
       "extensions/codex/src/app-server/attempt-context.test.ts",
       "extensions/codex/src/app-server/attempt-notifications.test.ts",
       "extensions/codex/src/app-server/attempt-results.test.ts",
+      "extensions/codex/src/app-server/attempt-startup-retry.test.ts",
       "extensions/codex/src/app-server/attempt-startup.test.ts",
       "extensions/codex/src/app-server/attempt-timeouts.test.ts",
       "extensions/codex/src/app-server/attempt-turn-watches.test.ts",


### PR DESCRIPTION
## What Problem This Solves

The full-suite Vitest project inventory on current `main` fails because a newly merged test file, `extensions/codex/src/app-server/attempt-startup-retry.test.ts`, is not assigned to any configured test project. This breaks otherwise unrelated CI jobs, including the focused provider fix in #129536.

## Why This Change Was Made

The broader app-server support project deliberately excludes `attempt-*.test.ts`; the dedicated attempt-support project instead owns an explicit filename list. Add the new test filename to that existing owner list. The change is strictly central test-project routing: one configuration line, zero production changes, and no runtime behavior changes.

## User Impact

Restores complete, exactly-once Vitest project ownership and allows unrelated pull-request and `main` CI runs to pass the existing repository-wide inventory guard.

## Evidence

- Fresh current `main` at `66bfdeffb9b4e60e858e17a4f11aea1eb401e94a`: the focused inventory suite failed with **1 failure and 22 passes**, reporting the new filename as its sole unassigned test.
- After adding the single project-owned filename: the identical inventory suite passed **23 tests** with zero missing or duplicate assignments.
- Reproduction and verification: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-r3-cache-main-vitest-inventory OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs --configLoader runner test/vitest-projects-config.test.ts`.
- Focused checks: `node_modules/.bin/oxfmt --check test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts`; `node_modules/.bin/oxlint --config .oxlintrc.json test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts`; `git diff --check`.
- Two independent reviews and mandatory structured autoreview passed with no actionable findings.
- Scope: one test-project configuration insertion; **zero production lines**.
