### PR TITLE
fix(http): stop waiting on already disconnected requests

### DIFF
--- a/src/infra/http-body.test.ts
+++ b/src/infra/http-body.test.ts
@@ -300,6 +300,71 @@ describe("http body limits", () => {
     }
   });
 
+  it("immediately classifies a request closed before its body reader starts", async () => {
+    const req = createMockRequest({ emitEnd: false });
+    req.complete = true;
+    Object.defineProperty(req, "readableEnded", { value: false });
+    req.destroy();
+    req.emit("close");
+
+    await expectRequestBodyLimitError(
+      readRequestBodyWithLimit(req, { maxBytes: 128, timeoutMs: 1 }),
+      {
+        code: "CONNECTION_CLOSED",
+        message: "RequestBodyConnectionClosed",
+        statusCode: 400,
+      },
+    );
+    for (const event of ["data", "end", "error", "close"] as const) {
+      expect(req.listenerCount(event), event).toBe(0);
+    }
+  });
+
+  it("disposes a body guard immediately when its request was already closed", () => {
+    const req = createMockRequest({
+      headers: { "content-length": "9999" },
+      emitEnd: false,
+    });
+    req.complete = true;
+    Object.defineProperty(req, "readableEnded", { value: false });
+    req.destroy();
+    req.emit("close");
+    const res = createMockServerResponse();
+
+    const guard = installRequestBodyLimitGuard(req, res, { maxBytes: 128, timeoutMs: 1 });
+    try {
+      expect(guard.isTripped()).toBe(false);
+      expect(guard.code()).toBeNull();
+      expect(res.headersSent).toBe(false);
+      expect(res.body).toBeUndefined();
+      for (const event of ["data", "end", "error", "close"] as const) {
+        expect(req.listenerCount(event), event).toBe(0);
+      }
+    } finally {
+      guard.dispose();
+    }
+  });
+
+  it("keeps concurrent body guards, readers, and foreign request listeners independent", async () => {
+    const req = createMockRequest({ chunks: ['{"ok":true}'] });
+    const res = createMockServerResponse();
+    const events = ["data", "end", "error", "close"] as const;
+    const foreignListener = () => {};
+    for (const event of events) {
+      req.on(event, foreignListener);
+    }
+
+    const guard = installRequestBodyLimitGuard(req, res, { maxBytes: 128 });
+    await expect(readRequestBodyWithLimit(req, { maxBytes: 128 })).resolves.toBe('{"ok":true}');
+
+    expect(guard.isTripped()).toBe(false);
+    expect(res.headersSent).toBe(false);
+    for (const event of events) {
+      expect(req.listeners(event)).toEqual([foreignListener]);
+    }
+    guard.dispose();
+  });
+
   it("classifies request stream errors as a closed connection", async () => {
     const req = createMockRequest({ emitEnd: false });
     const promise = readJsonBodyWithLimit(req, { maxBytes: 128 });

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -386,7 +386,6 @@ export async function readRequestBodyWithLimit(
 
   return await new Promise((resolve, reject) => {
     let done = false;
-    let ended = false;
     let totalBytes = 0;
     const chunks: Buffer[] = [];
 
@@ -433,7 +432,6 @@ export async function readRequestBodyWithLimit(
     };
 
     const onEnd = () => {
-      ended = true;
       finish(() =>
         resolve(
           chunks.length === 1
@@ -451,9 +449,6 @@ export async function readRequestBodyWithLimit(
     };
 
     const onClose = () => {
-      if (done || ended) {
-        return;
-      }
       fail(new RequestBodyLimitError({ code: "CONNECTION_CLOSED" }));
     };
 
@@ -461,6 +456,9 @@ export async function readRequestBodyWithLimit(
     req.on("end", onEnd);
     req.on("error", onError);
     req.on("close", onClose);
+    if (req.destroyed && !req.readableEnded) {
+      onClose();
+    }
   });
 }
 
@@ -531,14 +529,13 @@ export function installRequestBodyLimitGuard(
   let tripped = false;
   let reason: RequestBodyLimitErrorCode | null = null;
   let done = false;
-  let ended = false;
   let totalBytes = 0;
 
   const cleanup = () => {
     req.removeListener("data", onData);
-    req.removeListener("end", onEnd);
-    req.removeListener("close", onClose);
-    req.removeListener("error", onError);
+    req.removeListener("end", finish);
+    req.removeListener("close", finish);
+    req.removeListener("error", finish);
     clearNodeTimeout(timer);
   };
 
@@ -586,33 +583,19 @@ export function installRequestBodyLimitGuard(
     }
   };
 
-  const onEnd = () => {
-    ended = true;
-    finish();
-  };
-
-  const onClose = () => {
-    if (done || ended) {
-      return;
-    }
-    finish();
-  };
-
-  const onError = () => {
-    finish();
-  };
-
   const timer = setNodeTimeout(() => {
     trip(new RequestBodyLimitError({ code: "REQUEST_BODY_TIMEOUT" }));
   }, timeoutMs);
 
   req.on("data", onData);
-  req.on("end", onEnd);
-  req.on("close", onClose);
-  req.on("error", onError);
+  req.on("end", finish);
+  req.on("close", finish);
+  req.on("error", finish);
 
   const declaredLength = parseContentLengthHeader(req);
-  if (declaredLength !== null && declaredLength > maxBytes) {
+  if (req.destroyed && !req.readableEnded) {
+    finish();
+  } else if (declaredLength !== null && declaredLength > maxBytes) {
     trip(new RequestBodyLimitError({ code: "PAYLOAD_TOO_LARGE" }));
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where webhook clients that disconnect before OpenClaw begins reading their request body would leave the Gateway or channel plugin waiting for the full body timeout, then incorrectly classify the closed connection as a request timeout. The sibling request-body guard could also retain its timer and attempt a timeout or oversized-body response on a connection that was already gone.

This shared request-body path is used by the Gateway and multiple bundled channels, including Slack, Feishu, Telegram, LINE, Mattermost, and voice-call webhooks.

## Why This Change Was Made

Node emits an incoming request's `close` event only once. If authorization or other asynchronous preparation finishes after the client disconnects, listeners attached by either body owner can miss that event permanently. Checking `req.destroyed && !req.readableEnded` immediately after registering owned listeners distinguishes a prematurely closed unread request from a normally completed stream; `req.complete` alone is insufficient because Node can mark the HTTP message complete while buffered body bytes remain unread.

The reader now immediately returns the existing typed `CONNECTION_CLOSED` failure. The independent limit guard cleans up silently without tripping or writing a response, even when a now-disconnected request advertised an oversized body. Redundant terminal flags and three duplicate guard callbacks are removed, shrinking production code by **17 lines** while preserving shared-request listener ownership and existing active 413/408 response behavior.

## User Impact

Closed webhook requests stop occupying Gateway/channel work for the default 30-second body timeout, and disconnected clients are no longer misreported as 408 timeouts or sent ghost error responses. Normal successful requests, active body limits, shared Slack/Feishu request readers, and authentication order are unchanged.

## Evidence

Real `node:http` server plus raw TCP client that disconnects **before** either body owner attaches its listeners:

Before:

```json
[
  {"mode":"reader","destroyed":true,"readableEnded":false,"code":"REQUEST_BODY_TIMEOUT","elapsedMs":47},
  {"mode":"guard","destroyed":true,"readableEnded":false,"tripped":true,"code":"REQUEST_BODY_TIMEOUT","headersSent":false,"elapsedMs":66}
]
```

After:

```json
[
  {"mode":"reader","destroyed":true,"readableEnded":false,"code":"CONNECTION_CLOSED","elapsedMs":0},
  {"mode":"guard","destroyed":true,"readableEnded":false,"tripped":false,"code":null,"headersSent":false,"elapsedMs":66}
]
```

Both new regression tests were run against the original production owner first and failed for their intended reasons: the reader returned `REQUEST_BODY_TIMEOUT` instead of `CONNECTION_CLOSED`, and the guard tripped and attempted a response after the connection had already closed. A third regression verifies that a body guard, simultaneous reader, and preexisting foreign listeners remain independent on the same request.

```text
node scripts/run-vitest.mjs run src/infra/http-body.test.ts src/plugin-sdk/webhook-request-guards.test.ts extensions/feishu/src/monitor.webhook-security.test.ts extensions/telegram/src/miniapp/routes.test.ts
4 suites, 65 tests passed

node scripts/check-changed.mjs -- src/infra/http-body.ts src/infra/http-body.test.ts
All changed-file formatting, architecture, ratchets, dead-code and production core typecheck pass.
The final unrelated core-test shard also fails on clean current main because the local managed
dependency tree lacks pako declarations (ui/vite.config.ts:8, TS7016); reproduced independently
on untouched main. Fresh hosted CI installs the exact lockfile and is the authoritative full gate.

Fresh independent Codex autoreview: clean; no actionable findings.
Production: +12/-29 (net -17). Tests: +65/-0.
```

Named follow-up: Node's optional `optimizeEmptyRequests` mode can deliver already-ended, bodyless requests without emitting a later `end` event. OpenClaw does not currently enable that option; its separate successful-empty-request lifecycle should be investigated independently rather than broadening this premature-disconnect repair.
