### PR TITLE
fix(onboard): preserve manifest-equivalent alias validation

### DIFF
--- a/src/commands/onboard-custom-config.test.ts
+++ b/src/commands/onboard-custom-config.test.ts
@@ -1,9 +1,12 @@
 // Onboard custom config tests cover provider-specific config merging and context-window bounds.
+import { setCurrentManifestModelIdNormalizationRecords } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { describe, expect, it, vi } from "vitest";
 import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
+import * as providerModelNormalizationRuntime from "../agents/provider-model-normalization.runtime.js";
 import type { OpenClawConfig } from "../config/config.js";
 import * as currentPluginMetadataSnapshot from "../plugins/current-plugin-metadata-snapshot.js";
 import * as manifestContractEligibility from "../plugins/manifest-contract-eligibility.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import {
   applyCustomApiConfig,
   buildAnthropicVerificationProbeRequest,
@@ -14,6 +17,19 @@ import {
 } from "./onboard-custom-config.js";
 
 const EXPECTED_CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS = 128_000;
+const manifestPlugins = [
+  {
+    modelIdNormalization: {
+      providers: {
+        custom: {
+          aliases: {
+            latest: "modern-model",
+          },
+        },
+      },
+    },
+  },
+] satisfies Array<Pick<PluginManifestRecord, "modelIdNormalization">>;
 
 function buildCustomProviderConfig(contextWindow?: number) {
   if (contextWindow === undefined) {
@@ -124,6 +140,7 @@ it("rejects custom aliases already used by the selected agent", () => {
 });
 
 it("validates authored and inherited aliases without discovering plugin metadata", () => {
+  setCurrentManifestModelIdNormalizationRecords(undefined);
   const currentSnapshot = vi
     .spyOn(currentPluginMetadataSnapshot, "getCurrentPluginMetadataSnapshot")
     .mockImplementation(() => {
@@ -134,9 +151,20 @@ it("validates authored and inherited aliases without discovering plugin metadata
     .mockImplementation(() => {
       throw new Error("authored alias validation must not load plugin metadata");
     });
+  const runtimeNormalization = vi
+    .spyOn(providerModelNormalizationRuntime, "normalizeProviderModelIdWithRuntime")
+    .mockImplementation(() => {
+      throw new Error("authored alias validation must not load provider runtime");
+    });
   const cfg = {
     agents: {
-      defaults: { models: { "anthropic/global": { alias: "Global" } } },
+      defaults: {
+        models: {
+          "anthropic/global": { alias: "Global" },
+          "custom/latest": { alias: "Legacy" },
+          "custom/modern-model": { alias: "Canonical" },
+        },
+      },
       entries: { ops: { models: { "openai/ops": { alias: "Operations" } } } },
     },
   } as OpenClawConfig;
@@ -147,7 +175,8 @@ it("validates authored and inherited aliases without discovering plugin metadata
         raw: "Operations",
         cfg,
         agentId: "ops",
-        modelRef: "custom/new-model",
+        modelRef: { provider: "custom", model: "new-model" },
+        manifestPlugins,
       }),
     ).toBe("Alias Operations already points to openai/ops.");
     expect(
@@ -155,7 +184,8 @@ it("validates authored and inherited aliases without discovering plugin metadata
         raw: "Global",
         cfg,
         agentId: "ops",
-        modelRef: "custom/new-model",
+        modelRef: { provider: "custom", model: "new-model" },
+        manifestPlugins,
       }),
     ).toBe("Alias Global already points to anthropic/global.");
     expect(
@@ -163,12 +193,33 @@ it("validates authored and inherited aliases without discovering plugin metadata
         raw: "Operations",
         cfg,
         agentId: "ops",
-        modelRef: "openai/ops",
+        modelRef: { provider: "openai", model: "ops" },
+        manifestPlugins,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveCustomModelAliasError({
+        raw: "Legacy",
+        cfg,
+        agentId: "ops",
+        modelRef: { provider: "custom", model: "modern-model" },
+        manifestPlugins,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveCustomModelAliasError({
+        raw: "Canonical",
+        cfg,
+        agentId: "ops",
+        modelRef: { provider: "custom", model: "latest" },
+        manifestPlugins,
       }),
     ).toBeUndefined();
   } finally {
+    setCurrentManifestModelIdNormalizationRecords(undefined);
     currentSnapshot.mockRestore();
     loadedSnapshot.mockRestore();
+    runtimeNormalization.mockRestore();
   }
 });
 

--- a/src/commands/onboard-custom-config.ts
+++ b/src/commands/onboard-custom-config.ts
@@ -11,10 +11,12 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
-import { buildModelAliasIndex, modelKey } from "../agents/model-selection.js";
+import { normalizeConfiguredProviderCatalogModelId } from "../agents/model-ref-shared.js";
+import { buildModelAliasIndex, modelKey, type ModelRef } from "../agents/model-selection.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isSecretRef, type SecretInput } from "../config/types.secrets.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { applyPrimaryModel } from "../plugins/provider-model-primary.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import { normalizeAlias } from "./models/alias-name.js";
@@ -32,6 +34,7 @@ const DEFAULT_MAX_TOKENS = 4096;
 const AZURE_DEFAULT_CONTEXT_WINDOW = 400_000;
 const AZURE_DEFAULT_MAX_TOKENS = 16_384;
 type CustomModelInput = "text" | "image";
+type CustomAliasManifestPlugin = Pick<PluginManifestRecord, "modelIdNormalization">;
 
 /** Result of best-effort image-input inference for custom model ids. */
 type CustomModelImageInputInference = {
@@ -196,6 +199,7 @@ type ApplyCustomApiConfigParams = {
   supportsImageInput?: boolean;
   target?: OnboardingAgentTarget;
   setAsPrimary?: boolean;
+  manifestPlugins?: readonly CustomAliasManifestPlugin[];
 };
 
 /** Raw CLI flag values for non-interactive custom API setup. */
@@ -296,11 +300,22 @@ function resolveUniqueEndpointId(params: {
   return { providerId: candidate, renamed: true };
 }
 
+function configuredAliasModelKey(
+  ref: ModelRef,
+  manifestPlugins: readonly CustomAliasManifestPlugin[],
+): string {
+  return modelKey(
+    ref.provider,
+    normalizeConfiguredProviderCatalogModelId(ref.provider, ref.model, { manifestPlugins }),
+  );
+}
+
 /** Returns a human-readable alias collision error for a custom model ref. */
 export function resolveCustomModelAliasError(params: {
   raw: string;
   cfg: OpenClawConfig;
-  modelRef: string;
+  modelRef: ModelRef;
+  manifestPlugins: readonly CustomAliasManifestPlugin[];
   agentId?: string;
 }): string | undefined {
   const trimmed = params.raw.trim();
@@ -317,7 +332,7 @@ export function resolveCustomModelAliasError(params: {
     cfg: params.cfg,
     defaultProvider: DEFAULT_PROVIDER,
     agentId: params.agentId,
-    allowManifestNormalization: false,
+    manifestPlugins: params.manifestPlugins,
     allowPluginNormalization: false,
   });
   const aliasKey = normalizeLowercaseStringOrEmpty(normalized);
@@ -326,7 +341,10 @@ export function resolveCustomModelAliasError(params: {
     return undefined;
   }
   const existingKey = modelKey(existing.ref.provider, existing.ref.model);
-  if (existingKey === params.modelRef) {
+  if (
+    configuredAliasModelKey(existing.ref, params.manifestPlugins) ===
+    configuredAliasModelKey(params.modelRef, params.manifestPlugins)
+  ) {
     return undefined;
   }
   return `Alias ${normalized} already points to ${existingKey}.`;
@@ -596,13 +614,14 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
   });
   const providerId = providerIdResult.providerId;
   const providers = params.config.models?.providers ?? {};
-
   const modelRef = modelKey(providerId, modelId);
+
   const alias = normalizeOptionalString(params.alias) ?? "";
   const aliasError = resolveCustomModelAliasError({
     raw: alias,
     cfg: params.config,
-    modelRef,
+    modelRef: { provider: providerId, model: modelId },
+    manifestPlugins: params.manifestPlugins ?? [],
     agentId: params.target?.agentId,
   });
   if (aliasError) {

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -1,7 +1,13 @@
 // Onboard custom tests cover custom provider prompts and API-key credential handling.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ensureApiKeyFromEnvOrPrompt } from "../plugins/provider-auth-input.js";
 import { promptCustomApiConfig } from "./onboard-custom.js";
+
+const loadManifestMetadataSnapshot = vi.hoisted(() => vi.fn(() => ({ plugins: [] })));
+vi.mock("../plugins/manifest-contract-eligibility.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/manifest-contract-eligibility.js")>()),
+  loadManifestMetadataSnapshot,
+}));
 
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../plugins/current-plugin-metadata-snapshot.js")>()),
@@ -95,6 +101,11 @@ function expectOpenAiCompatResult(params: {
 }
 
 describe("promptCustomApiConfig", () => {
+  beforeEach(() => {
+    loadManifestMetadataSnapshot.mockReset();
+    loadManifestMetadataSnapshot.mockReturnValue({ plugins: [] });
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
@@ -140,6 +151,54 @@ describe("promptCustomApiConfig", () => {
     expect(aliasPrompt?.[0].validate("Operations")).toBe(
       "Alias Operations already points to openai/ops.",
     );
+  });
+
+  it("threads one workspace-scoped manifest snapshot through alias validation", async () => {
+    const preparedPlugins = [
+      {
+        modelIdNormalization: {
+          providers: {
+            custom: {
+              aliases: {
+                latest: "modern-model",
+              },
+            },
+          },
+        },
+      },
+    ];
+    loadManifestMetadataSnapshot.mockReturnValueOnce({ plugins: preparedPlugins } as never);
+    const prompter = createTestPrompter({
+      text: ["http://localhost:11434/v1", "", "modern-model", "custom", "Legacy"],
+      select: ["plaintext", "openai"],
+    });
+    stubFetchSequence([{ ok: true }]);
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "custom/latest": { alias: "Legacy" },
+          },
+        },
+      },
+    };
+    const target = {
+      agentId: "ops",
+      agentDir: "/tmp/ops-agent",
+      workspaceDir: "/tmp/ops-workspace",
+    };
+
+    const result = await runPromptCustomApi(prompter, config, target);
+
+    expect(loadManifestMetadataSnapshot).toHaveBeenCalledExactlyOnceWith({
+      config,
+      workspaceDir: target.workspaceDir,
+      env: process.env,
+    });
+    expect(loadManifestMetadataSnapshot.mock.invocationCallOrder[0]).toBeLessThan(
+      prompter.text.mock.invocationCallOrder[0]!,
+    );
+    expect(result.config.agents?.defaults?.models?.["custom/modern-model"]?.alias).toBe("Legacy");
   });
 
   it("cancels custom provider verification response bodies", async () => {

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -4,9 +4,9 @@
  * The pure config helpers are re-exported from here because setup and configure
  * flows import this command module as their custom API entrypoint.
  */
-import { modelKey } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SecretInput } from "../config/types.secrets.js";
+import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
 import { ensureApiKeyFromEnvOrPrompt } from "../plugins/provider-auth-input.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
@@ -244,6 +244,11 @@ export async function promptCustomApiConfig(params: {
   setAsPrimary?: boolean;
 }): Promise<CustomApiResult> {
   const { prompter, runtime, config } = params;
+  const manifestPlugins = loadManifestMetadataSnapshot({
+    config,
+    workspaceDir: params.target?.workspaceDir,
+    env: process.env,
+  }).plugins;
 
   const baseInput = await promptBaseUrlAndKey({
     prompter,
@@ -393,11 +398,11 @@ export async function promptCustomApiConfig(params: {
       });
       // Alias validation must use the post-collision provider id, otherwise a
       // renamed endpoint could incorrectly collide with the requested id.
-      const modelRef = modelKey(resolvedProvider.providerId, modelId);
       return resolveCustomModelAliasError({
         raw: value,
         cfg: config,
-        modelRef,
+        modelRef: { provider: resolvedProvider.providerId, model: modelId },
+        manifestPlugins,
         agentId: params.target?.agentId,
       });
     },
@@ -419,6 +424,7 @@ export async function promptCustomApiConfig(params: {
     apiKey,
     providerId: providerIdInput,
     alias: aliasInput,
+    manifestPlugins,
     supportsImageInput,
     ...(params.target ? { target: params.target } : {}),
     ...(params.setAsPrimary === false ? { setAsPrimary: false } : {}),

--- a/src/commands/onboard-non-interactive/local/auth-choice.test.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.test.ts
@@ -9,6 +9,12 @@ import { applyNonInteractiveAuthChoice } from "./auth-choice.js";
 const writeWizardConfigFile = vi.hoisted(() => vi.fn(async (config: OpenClawConfig) => config));
 vi.mock("../../../wizard/setup.shared.js", () => ({ writeWizardConfigFile }));
 
+const loadManifestMetadataSnapshot = vi.hoisted(() => vi.fn(() => ({ plugins: [] })));
+vi.mock("../../../plugins/manifest-contract-eligibility.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../plugins/manifest-contract-eligibility.js")>()),
+  loadManifestMetadataSnapshot,
+}));
+
 const formatAuthChoiceChoicesForCli = vi.hoisted(() =>
   vi.fn(() => "custom-api-key|skip|demo-provider-api-key"),
 );
@@ -48,6 +54,8 @@ beforeEach(() => {
   resolveManifestProviderAuthChoices.mockReturnValue([]);
   resolveDeprecatedProviderInstallCatalogEntry.mockReset();
   resolveDeprecatedProviderInstallCatalogEntry.mockReturnValue(undefined);
+  loadManifestMetadataSnapshot.mockReset();
+  loadManifestMetadataSnapshot.mockReturnValue({ plugins: [] });
 });
 
 function createRuntime() {
@@ -268,6 +276,11 @@ describe("applyNonInteractiveAuthChoice", () => {
     expect(apiKeyParams?.envVarName).toBe("CUSTOM_API_KEY");
     expect(apiKeyParams?.agentDir).toBe(target.agentDir);
     expect(apiKeyParams?.secretInputMode).toBe("ref");
+    expect(loadManifestMetadataSnapshot).toHaveBeenCalledExactlyOnceWith({
+      config: nextConfig,
+      workspaceDir: target.workspaceDir,
+      env: process.env,
+    });
   });
 
   it("keeps a custom provider model on the configured explicit-fleet system agent", async () => {

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -9,6 +9,7 @@ import { formatCliCommand } from "../../../cli/command-format.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { SecretInput } from "../../../config/types.secrets.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
+import { loadManifestMetadataSnapshot } from "../../../plugins/manifest-contract-eligibility.js";
 import { resolveManifestDeprecatedProviderAuthChoice } from "../../../plugins/provider-auth-choices.js";
 import { normalizeSecretInputModeInput } from "../../../plugins/provider-auth-input.js";
 import { resolveDeprecatedProviderInstallCatalogEntry } from "../../../plugins/provider-install-catalog.js";
@@ -231,6 +232,11 @@ export async function applyNonInteractiveAuthChoice(params: {
 
   if (authChoice === "custom-api-key") {
     try {
+      const manifestPlugins = loadManifestMetadataSnapshot({
+        config: nextConfig,
+        workspaceDir: params.target.workspaceDir,
+        env: process.env,
+      }).plugins;
       // Custom provider setup can be optional-key: some local endpoints do not
       // require auth, but flags and env refs still need validation if present.
       const customAuth = parseNonInteractiveCustomApiFlags({
@@ -280,6 +286,7 @@ export async function applyNonInteractiveAuthChoice(params: {
         compatibility: customAuth.compatibility,
         apiKey: customApiKeyInput,
         providerId: customAuth.providerId,
+        manifestPlugins,
         supportsImageInput: customAuth.supportsImageInput,
         target: params.target,
       });


### PR DESCRIPTION
Related: #129468

## What Problem This Solves

Custom provider onboarding could report a false alias collision when an existing configured model ID and the requested model ID are equivalent under a workspace-scoped manifest normalization policy.

The earlier repair in #129346 (`fee4e77d91e`) correctly stopped alias validation from discovering plugin/runtime metadata, but the follow-up comparison implicitly read a process-global policy map. Workspace-scoped onboarding deliberately does not publish its metadata there, so cold/scoped setup could still miss the equivalence.

## Root Cause And Canonical Fix

Alias validation had the right owner boundary but the wrong policy generation. It built the alias index from one static manifest snapshot while normalizing the existing and proposed references through an unrelated process-global default.

Interactive and non-interactive custom onboarding now prepare one workspace-scoped manifest snapshot and carry its plugin records through alias-index construction and both model-reference normalizations. Plugin/runtime normalization remains disabled, so validation uses one deterministic static generation without discovery on the validation path.

The direct reset path remains unchanged because it supplies no alias. No provider runtime, current global snapshot, or secondary manifest load is used by the alias comparison.

## User Impact

Aliases attached to legacy and canonical custom model IDs are recognized as the same target in either direction, including cold and workspace-scoped onboarding.

## Evidence

- Focused proof: 78 tests passed across:
  - `src/commands/onboard-custom-config.test.ts`
  - `src/commands/onboard-custom.test.ts`
  - `src/commands/onboard-non-interactive/local/auth-choice.test.ts`
- Regression coverage keeps the global policy unset, supplies explicit manifest records, and proves both configured legacy/requested canonical and configured canonical/requested legacy equivalence.
- Guard spies fail if alias validation loads the current plugin snapshot, another manifest snapshot, or provider runtime normalization.
- Caller coverage proves interactive onboarding prepares the snapshot before prompts and threads the target workspace; non-interactive coverage proves the same workspace-scoped handoff.
- The final head keeps all six reviewed source/test blobs byte-identical and removes only the release-owned `CHANGELOG.md` delta.
- Exact-head hosted CI and ClawSweeper re-review are required before landing.

## Repair Doctrine

- Architectural owner: custom provider onboarding snapshot preparation and alias validation.
- Canonical repair: one caller-owned manifest snapshot, reused for alias-index construction and both normalized identity comparisons.
- Removed path: implicit process-global policy lookup for this comparison.
- Sibling coverage: interactive and non-interactive custom onboarding.
- Production LOC: +41/-9 across three production files (net +32), justified by carrying the authoritative workspace-scoped policy through both onboarding flows. Tests: +128/-5.

## Release Note Context

Custom provider onboarding now accepts aliases whose legacy and canonical model IDs are equivalent under the workspace manifest policy, without loading plugin runtime metadata.

## Provenance

The static discovery opt-outs landed in #129346 at `fee4e77d91e`. The original defect report and implementation direction came from @vyctorbrzezowski in #129468, preserved in the commit co-author trailer.
