### PR TITLE
fix(media): enforce generation model and reference limits

### DIFF
--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -1,5 +1,6 @@
 // image_generate tool tests cover provider/model selection, edit inputs,
 // background task handling, media saving, and duplicate-generation guards.
+import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -2405,7 +2406,21 @@ describe("createImageGenerateTool", () => {
     });
   });
 
-  it("ignores non-finite mediaMaxMb when loading reference images", async () => {
+  it("rejects oversized inline references at the canonical image cap before generation", async () => {
+    stubImageGenerationProviders();
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage");
+    const tool = createToolWithPrimaryImageModel("google/gemini-3-pro-image-preview");
+
+    await expect(
+      tool.execute("call-oversized-inline-reference", {
+        prompt: "Use this reference.",
+        image: `data:image/png;base64,${Buffer.alloc(MAX_IMAGE_BYTES + 1).toString("base64")}`,
+      }),
+    ).rejects.toThrow("Invalid data URL: payload exceeds size limit.");
+    expect(generateImage).not.toHaveBeenCalled();
+  });
+
+  it("uses the canonical image cap when mediaMaxMb is non-finite", async () => {
     stubImageGenerationProviders();
     stubEditedImageFlow({ width: 3200, height: 1800 });
     const tool = requireImageGenerateTool(
@@ -2432,7 +2447,7 @@ describe("createImageGenerateTool", () => {
     expect(typeof mockCallArg(webMedia.loadWebMedia, 0, "loadWebMedia", 0)).toBe("string");
     expect(mockCallArg(webMedia.loadWebMedia, 0, "loadWebMedia", 1)).toHaveProperty(
       "maxBytes",
-      undefined,
+      MAX_IMAGE_BYTES,
     );
   });
 

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -26,10 +26,7 @@ import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { parseImageGenerationModelRef } from "../../media-generation/model-ref.js";
 import { resolveCapabilityModelCandidates } from "../../media-generation/runtime-shared.js";
-import {
-  resolveConfiguredMediaMaxBytes,
-  resolveGeneratedMediaMaxBytes,
-} from "../../media/configured-max-bytes.js";
+import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { getImageMetadata } from "../../media/media-services.js";
 import { saveMediaBuffer } from "../../media/store.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
@@ -70,6 +67,7 @@ import {
   buildMediaReferenceDetails,
   buildTaskRunDetails,
   createCapabilityProviderRuntimeDeps,
+  hasExplicitMediaModel,
   hasGenerationToolAvailability,
   loadMediaToolReferences,
   normalizeMediaReferenceInputs,
@@ -79,11 +77,7 @@ import {
   resolveGenerateAction,
   resolveSelectedCapabilityProvider,
 } from "./media-tool-shared.js";
-import {
-  coerceToolModelConfig,
-  hasToolModelConfig,
-  type ToolModelConfig,
-} from "./model-config.helpers.js";
+import type { ToolModelConfig } from "./model-config.helpers.js";
 import type { AnyAgentTool, SandboxFsBridge, ToolFsPolicy } from "./tool-runtime.helpers.js";
 
 const DEFAULT_COUNT = 1;
@@ -227,6 +221,7 @@ function resolveImageGenerationModelConfigForTool(params: {
   workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
+  modelOverride?: string;
 }): ToolModelConfig | null {
   return resolveCapabilityModelConfigForTool({
     cfg: params.cfg,
@@ -234,6 +229,7 @@ function resolveImageGenerationModelConfigForTool(params: {
     agentDir: params.agentDir,
     authStore: params.authStore,
     modelConfig: params.cfg?.agents?.defaults?.mediaModels?.image,
+    modelOverride: params.modelOverride,
     providers: () => listRuntimeImageGenerationProviders({ config: params.cfg }),
   });
 }
@@ -242,10 +238,6 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.imageGenerateToolTestApi")] = {
     resolveImageGenerationModelConfigForTool,
   };
-}
-
-function hasExplicitImageGenerationModelConfig(cfg?: OpenClawConfig): boolean {
-  return hasToolModelConfig(coerceToolModelConfig(cfg?.agents?.defaults?.mediaModels?.image));
 }
 
 function resolveRequestedCount(args: Record<string, unknown>): number {
@@ -530,7 +522,7 @@ type ImageGenerateSandboxConfig = {
 
 async function loadReferenceImages(params: {
   imageInputs: string[];
-  maxBytes?: number;
+  maxBytes: number;
   workspaceDir?: string;
   sandboxConfig: { root: string; bridge: SandboxFsBridge; workspaceOnly: boolean } | null;
   ssrfPolicy?: SsrFPolicy;
@@ -839,20 +831,17 @@ export function createImageGenerateTool(options?: {
       }
 
       const model = readToolStringParam(params, "model");
-      const configuredImageGenerationModelConfig = coerceToolModelConfig(
-        cfg.agents?.defaults?.mediaModels?.image,
-      );
-      const imageGenerationModelConfig =
-        resolveImageGenerationModelConfigForTool({
-          cfg,
-          workspaceDir: options?.workspaceDir,
-          agentDir: options?.agentDir,
-          authStore: options?.authProfileStore,
-        }) ?? (model ? { ...configuredImageGenerationModelConfig, primary: model } : null);
+      const imageGenerationModelConfig = resolveImageGenerationModelConfigForTool({
+        cfg,
+        workspaceDir: options?.workspaceDir,
+        agentDir: options?.agentDir,
+        authStore: options?.authProfileStore,
+        modelOverride: model,
+      });
       if (!imageGenerationModelConfig) {
         throw new ToolInputError("No image-generation model configured.");
       }
-      const explicitModelConfig = hasExplicitImageGenerationModelConfig(cfg);
+      const explicitModelConfig = hasExplicitMediaModel(cfg.agents?.defaults?.mediaModels?.image);
       const effectiveCfg =
         applyAgentDefaultModelConfig(cfg, "image", imageGenerationModelConfig) ?? cfg;
       const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
@@ -944,10 +933,10 @@ export function createImageGenerateTool(options?: {
         resolution: explicitResolution,
         explicitResolution: Boolean(explicitResolution),
       });
-      const configuredMediaMaxBytes = resolveConfiguredMediaMaxBytes(effectiveCfg);
+      const referenceMaxBytes = resolveGeneratedMediaMaxBytes(effectiveCfg, "image");
       const loadedReferenceImages = await loadReferenceImages({
         imageInputs,
-        maxBytes: configuredMediaMaxBytes,
+        maxBytes: referenceMaxBytes,
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -334,9 +334,12 @@ export function resolveCapabilityModelConfigForTool(params: {
   agentDir?: string;
   authStore?: AuthProfileStore;
   modelConfig?: AgentModelConfig;
+  modelOverride?: string;
   providers: CapabilityProviderSource;
 }): ToolModelConfig | null {
-  const explicit = coerceToolModelConfig(params.modelConfig);
+  const configured = coerceToolModelConfig(params.modelConfig);
+  const modelOverride = normalizeOptionalString(params.modelOverride);
+  const explicit = modelOverride ? { ...configured, primary: modelOverride } : configured;
   if (hasToolModelConfig(explicit)) {
     return explicit;
   }
@@ -369,6 +372,10 @@ export function resolveCapabilityModelConfigForTool(params: {
         authStore: params.authStore,
       }),
   });
+}
+
+export function hasExplicitMediaModel(modelConfig?: AgentModelConfig): boolean {
+  return hasToolModelConfig(coerceToolModelConfig(modelConfig));
 }
 
 /**
@@ -606,7 +613,7 @@ export async function loadMediaToolReferences<T>(params: {
   expectedKind: "image" | "video" | "audio";
   sandbox: SandboxedBridgeMediaPathConfig | null;
   workspaceDir?: string;
-  maxBytes?: number;
+  maxBytes: number;
   ssrfPolicy?: SsrFPolicy;
   timeoutMs?: number;
   signal?: AbortSignal;
@@ -651,10 +658,7 @@ export async function loadMediaToolReferences<T>(params: {
     if (reference.isDataUrl) {
       const { decodeDataUrl } = await import("./image-tool.helpers.js");
       params.signal?.throwIfAborted();
-      media = decodeDataUrl(
-        resolvedInput,
-        params.toolName === "image_generate" ? { maxBytes: params.maxBytes } : undefined,
-      );
+      media = decodeDataUrl(resolvedInput, { maxBytes: params.maxBytes });
     } else {
       const { loadWebMedia } = await import("../../media/web-media.js");
       params.signal?.throwIfAborted();
@@ -669,7 +673,7 @@ export async function loadMediaToolReferences<T>(params: {
           : undefined;
       try {
         media = await loadWebMedia(resolvedPath ?? resolvedInput, {
-          ...(params.toolName === "music_generate" ? {} : { maxBytes: params.maxBytes }),
+          maxBytes: params.maxBytes,
           ...(params.sandbox
             ? {
                 sandboxValidated: true,

--- a/src/agents/tools/music-generate-tool.test.ts
+++ b/src/agents/tools/music-generate-tool.test.ts
@@ -600,6 +600,97 @@ describe("createMusicGenerateTool", () => {
     expect(detailsOf(overrideResult).timeoutMs).toBe(180_000);
   });
 
+  it("runs explicit deployment refs and preserves timeout-only music defaults", async () => {
+    const provider = {
+      id: "music-plugin",
+      models: [],
+      capabilities: {},
+      isConfigured: () => true,
+      generateMusic: vi.fn(async () => ({
+        tracks: [{ buffer: Buffer.from("music"), mimeType: "audio/mpeg" }],
+      })),
+    };
+    musicGenerationRuntimeMocks.listRuntimeMusicGenerationProviders.mockReturnValue([provider]);
+    musicGenerationRuntimeMocks.generateMusic.mockResolvedValue({
+      provider: "music-plugin",
+      model: "deployment",
+      attempts: [],
+      ignoredOverrides: [],
+      tracks: [{ buffer: Buffer.from("music"), mimeType: "audio/mpeg" }],
+    });
+    mediaStoreMocks.saveMediaBuffer.mockResolvedValue({
+      path: "/tmp/deployment.mp3",
+      id: "deployment.mp3",
+      size: 5,
+      contentType: "audio/mpeg",
+    });
+    const tool = expectMusicGenerateTool(
+      createMusicGenerateTool({
+        config: asConfig({
+          agents: { defaults: { musicGenerationModel: { timeoutMs: 180_000 } } },
+        }),
+        preparedModelRuntime: {
+          mediaCapabilityProviders: { musicGenerationProviders: [provider] },
+        } as never,
+      }),
+    );
+
+    const result = await tool.execute("call-explicit-deployment", {
+      prompt: "night-drive synthwave",
+      model: "music-plugin/deployment",
+    });
+
+    expect(generateMusicOptions()).toMatchObject({
+      modelOverride: "music-plugin/deployment",
+      timeoutMs: 180_000,
+    });
+    expect(detailsOf(result).timeoutMs).toBe(180_000);
+  });
+
+  it("rejects oversized inline reference images before music generation", async () => {
+    musicGenerationRuntimeMocks.listRuntimeMusicGenerationProviders.mockReturnValue([
+      {
+        id: "minimax",
+        defaultModel: "music-2.6",
+        models: ["music-2.6"],
+        capabilities: { edit: { enabled: true, maxInputImages: 1 } },
+      },
+    ]);
+    musicGenerationRuntimeMocks.generateMusic.mockResolvedValue({
+      provider: "minimax",
+      model: "music-2.6",
+      attempts: [],
+      ignoredOverrides: [],
+      tracks: [{ buffer: Buffer.from("music"), mimeType: "audio/mpeg" }],
+    });
+    mediaStoreMocks.saveMediaBuffer.mockResolvedValue({
+      path: "/tmp/generated.mp3",
+      id: "generated.mp3",
+      size: 5,
+      contentType: "audio/mpeg",
+    });
+    const tool = expectMusicGenerateTool(
+      createMusicGenerateTool({
+        config: asConfig({
+          agents: {
+            defaults: {
+              mediaMaxMb: 8 / (1024 * 1024),
+              musicGenerationModel: { primary: "minimax/music-2.6" },
+            },
+          },
+        }),
+      }),
+    );
+
+    await expect(
+      tool.execute("call-oversized-inline-reference", {
+        prompt: "night-drive synthwave",
+        image: `data:image/png;base64,${Buffer.alloc(9).toString("base64")}`,
+      }),
+    ).rejects.toThrow("Invalid data URL: payload exceeds size limit.");
+    expect(musicGenerationRuntimeMocks.generateMusic).not.toHaveBeenCalled();
+  });
+
   it("keeps provider lyrics and generated attachment metadata from becoming delivery directives", async () => {
     const lyrics = [
       [

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -46,6 +46,7 @@ import {
   buildMediaReferenceDetails,
   buildTaskRunDetails,
   createCapabilityProviderRuntimeDeps,
+  hasExplicitMediaModel,
   hasGenerationToolAvailability,
   loadMediaToolReferences,
   normalizeMediaReferenceInputs,
@@ -55,11 +56,7 @@ import {
   resolveRemoteMediaSsrfPolicy,
   resolveSelectedCapabilityProvider,
 } from "./media-tool-shared.js";
-import {
-  coerceToolModelConfig,
-  hasToolModelConfig,
-  type ToolModelConfig,
-} from "./model-config.helpers.js";
+import type { ToolModelConfig } from "./model-config.helpers.js";
 import {
   createMusicGenerateDuplicateGuardResult,
   createMusicGenerateListActionResult,
@@ -133,6 +130,7 @@ function resolveMusicGenerationModelConfigForTool(params: {
   workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
+  modelOverride?: string;
 }): ToolModelConfig | null {
   return resolveCapabilityModelConfigForTool({
     cfg: params.cfg,
@@ -140,12 +138,9 @@ function resolveMusicGenerationModelConfigForTool(params: {
     agentDir: params.agentDir,
     authStore: params.authStore,
     modelConfig: params.cfg?.agents?.defaults?.mediaModels?.music,
+    modelOverride: params.modelOverride,
     providers: () => listRuntimeMusicGenerationProviders({ config: params.cfg }),
   });
-}
-
-function hasExplicitMusicGenerationModelConfig(cfg?: OpenClawConfig): boolean {
-  return hasToolModelConfig(coerceToolModelConfig(cfg?.agents?.defaults?.mediaModels?.music));
 }
 
 function resolveSelectedMusicGenerationProvider(params: {
@@ -267,6 +262,7 @@ const defaultScheduleMusicGenerateBackgroundWork = createDefaultMediaGenerateBac
 
 async function loadReferenceImages(params: {
   inputs: string[];
+  maxBytes: number;
   workspaceDir?: string;
   sandboxConfig: { root: string; bridge: SandboxFsBridge; workspaceOnly: boolean } | null;
   ssrfPolicy?: SsrFPolicy;
@@ -285,6 +281,7 @@ async function loadReferenceImages(params: {
     expectedKind: "image",
     sandbox: params.sandboxConfig,
     workspaceDir: params.workspaceDir,
+    maxBytes: params.maxBytes,
     ssrfPolicy: params.ssrfPolicy,
     timeoutMs: params.timeoutMs,
     signal: params.signal,
@@ -577,16 +574,18 @@ export function createMusicGenerateTool(options?: {
         );
       }
 
+      const model = readToolStringParam(args, "model");
       const musicGenerationModelConfig = resolveMusicGenerationModelConfigForTool({
         cfg,
         workspaceDir: options?.workspaceDir,
         agentDir: options?.agentDir,
         authStore: options?.authProfileStore,
+        modelOverride: model,
       });
       if (!musicGenerationModelConfig) {
         throw new ToolInputError("No music-generation model configured.");
       }
-      const explicitModelConfig = hasExplicitMusicGenerationModelConfig(cfg);
+      const explicitModelConfig = hasExplicitMediaModel(cfg.agents?.defaults?.mediaModels?.music);
       const effectiveCfg =
         applyAgentDefaultModelConfig(cfg, "music", musicGenerationModelConfig) ?? cfg;
       const prompt = readToolStringParam(args, "prompt", { required: true });
@@ -601,7 +600,6 @@ export function createMusicGenerateTool(options?: {
 
       const lyrics = readToolStringParam(args, "lyrics");
       const instrumental = readBooleanToolParam(args, "instrumental");
-      const model = readToolStringParam(args, "model");
       const durationSeconds = readNumberParam(args, "durationSeconds", {
         positiveInteger: true,
         strict: true,
@@ -660,6 +658,7 @@ export function createMusicGenerateTool(options?: {
       const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
       const loadedReferenceImages = await loadReferenceImages({
         inputs: imageInputs,
+        maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "image"),
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -742,6 +742,68 @@ describe("createVideoGenerateTool", () => {
     expect(resultDetails(overrideResult).timeoutMs).toBe(12_345);
   });
 
+  it("runs explicit deployment refs and preserves timeout-only video defaults", async () => {
+    const provider = {
+      id: "video-plugin",
+      models: [],
+      capabilities: {},
+      isConfigured: () => true,
+      generateVideo: vi.fn(async () => ({
+        videos: [{ buffer: Buffer.from("video"), mimeType: "video/mp4" }],
+      })),
+    };
+    vi.spyOn(videoGenerationRuntime, "listRuntimeVideoGenerationProviders").mockReturnValue([
+      provider,
+    ]);
+    const generateSpy = mockSavedVideoResult("deployment.mp4");
+    const tool = expectVideoGenerateTool(
+      createVideoGenerateTool({
+        config: asConfig({
+          agents: { defaults: { videoGenerationModel: { timeoutMs: 180_000 } } },
+        }),
+        preparedModelRuntime: {
+          mediaCapabilityProviders: { videoGenerationProviders: [provider] },
+        } as never,
+      }),
+    );
+
+    const result = await tool.execute("call-explicit-deployment", {
+      prompt: "friendly lobster surfing",
+      model: "video-plugin/deployment",
+    });
+
+    expect(firstMockCallArg(generateSpy)).toMatchObject({
+      modelOverride: "video-plugin/deployment",
+      timeoutMs: 180_000,
+    });
+    expect(resultDetails(result).timeoutMs).toBe(180_000);
+  });
+
+  it("rejects oversized inline reference images before video generation", async () => {
+    mockVideoPluginProvider({ imageToVideo: { enabled: true, maxInputImages: 1 } });
+    const generateSpy = mockSavedVideoResult();
+    const tool = expectVideoGenerateTool(
+      createVideoGenerateTool({
+        config: asConfig({
+          agents: {
+            defaults: {
+              mediaMaxMb: 8 / (1024 * 1024),
+              videoGenerationModel: { primary: "video-plugin/vid-v1" },
+            },
+          },
+        }),
+      }),
+    );
+
+    await expect(
+      tool.execute("call-oversized-inline-reference", {
+        prompt: "friendly lobster surfing",
+        image: `data:image/png;base64,${Buffer.alloc(9).toString("base64")}`,
+      }),
+    ).rejects.toThrow("Invalid data URL: payload exceeds size limit.");
+    expect(generateSpy).not.toHaveBeenCalled();
+  });
+
   it("uses the video media cap when mediaMaxMb is not configured", async () => {
     vi.spyOn(videoGenerationRuntime, "generateVideo").mockResolvedValue({
       provider: "qwen",

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -53,6 +53,7 @@ import {
   buildMediaReferenceDetails,
   buildTaskRunDetails,
   createCapabilityProviderRuntimeDeps,
+  hasExplicitMediaModel,
   hasGenerationToolAvailability,
   loadMediaToolReferences,
   normalizeMediaReferenceInputs,
@@ -66,7 +67,6 @@ import {
 import {
   hasAuthForProvider,
   coerceToolModelConfig,
-  hasToolModelConfig,
   type ToolModelConfig,
 } from "./model-config.helpers.js";
 import type { AnyAgentTool, SandboxFsBridge, ToolFsPolicy } from "./tool-runtime.helpers.js";
@@ -210,6 +210,7 @@ function resolveVideoGenerationModelConfigForTool(params: {
   workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
+  modelOverride?: string;
 }): ToolModelConfig | null {
   return resolveCapabilityModelConfigForTool({
     cfg: params.cfg,
@@ -217,6 +218,7 @@ function resolveVideoGenerationModelConfigForTool(params: {
     agentDir: params.agentDir,
     authStore: params.authStore,
     modelConfig: params.cfg?.agents?.defaults?.mediaModels?.video,
+    modelOverride: params.modelOverride,
     providers: () => listRuntimeVideoGenerationProviders({ config: params.cfg }),
   });
 }
@@ -225,10 +227,6 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.videoGenerateToolTestApi")] = {
     resolveVideoGenerationModelConfigForTool,
   };
-}
-
-function hasExplicitVideoGenerationModelConfig(cfg?: OpenClawConfig): boolean {
-  return hasToolModelConfig(coerceToolModelConfig(cfg?.agents?.defaults?.mediaModels?.video));
 }
 
 function collectVideoGenerationModelProviderIds(params: {
@@ -442,7 +440,7 @@ const defaultScheduleVideoGenerateBackgroundWork = createDefaultMediaGenerateBac
 async function loadReferenceAssets(params: {
   inputs: string[];
   expectedKind: "image" | "video" | "audio";
-  maxBytes?: number;
+  maxBytes: number;
   workspaceDir?: string;
   sandboxConfig: { root: string; bridge: SandboxFsBridge; workspaceOnly: boolean } | null;
   ssrfPolicy?: SsrFPolicy;
@@ -863,16 +861,18 @@ export function createVideoGenerateTool(options?: {
         );
       }
 
+      const model = readToolStringParam(args, "model");
       const videoGenerationModelConfig = resolveVideoGenerationModelConfigForTool({
         cfg,
         workspaceDir: options?.workspaceDir,
         agentDir: options?.agentDir,
         authStore: options?.authProfileStore,
+        modelOverride: model,
       });
       if (!videoGenerationModelConfig) {
         throw new ToolInputError("No video-generation model configured.");
       }
-      const explicitModelConfig = hasExplicitVideoGenerationModelConfig(cfg);
+      const explicitModelConfig = hasExplicitMediaModel(cfg.agents?.defaults?.mediaModels?.video);
       const effectiveCfg =
         applyAgentDefaultModelConfig(cfg, "video", videoGenerationModelConfig) ?? cfg;
       const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
@@ -886,7 +886,6 @@ export function createVideoGenerateTool(options?: {
         return activeDuplicateGuardResult;
       }
 
-      const model = readToolStringParam(args, "model");
       const filename = readToolStringParam(args, "filename");
       const size = readToolStringParam(args, "size");
       const aspectRatio = normalizeAspectRatio(readToolStringParam(args, "aspectRatio"));
@@ -998,6 +997,7 @@ export function createVideoGenerateTool(options?: {
       const loadedReferenceImages = await loadReferenceAssets({
         inputs: imageInputs,
         expectedKind: "image",
+        maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "image"),
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,
@@ -1014,6 +1014,7 @@ export function createVideoGenerateTool(options?: {
       const loadedReferenceVideos = await loadReferenceAssets({
         inputs: videoInputs,
         expectedKind: "video",
+        maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "video"),
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,
@@ -1029,6 +1030,7 @@ export function createVideoGenerateTool(options?: {
       const loadedReferenceAudios = await loadReferenceAssets({
         inputs: audioInputs,
         expectedKind: "audio",
+        maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "audio"),
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,

--- a/src/media/configured-max-bytes.ts
+++ b/src/media/configured-max-bytes.ts
@@ -6,21 +6,15 @@ import { MEDIA_MAX_BYTES } from "./store.js";
 const MB = 1024 * 1024;
 type GeneratedMediaKind = Extract<MediaKind, "audio" | "image" | "video">;
 
-/** Resolves the global generated-media byte cap from the user-facing MB config value. */
-export function resolveConfiguredMediaMaxBytes(cfg?: OpenClawConfig): number | undefined {
-  const configured = cfg?.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * MB);
-  }
-  return undefined;
-}
-
 /** Returns the configured media cap, falling back to the media-core per-kind default. */
 export function resolveGeneratedMediaMaxBytes(
   cfg: OpenClawConfig | undefined,
   kind: GeneratedMediaKind,
 ) {
-  return resolveConfiguredMediaMaxBytes(cfg) ?? maxBytesForKind(kind);
+  const configured = cfg?.agents?.defaults?.mediaMaxMb;
+  return typeof configured === "number" && Number.isFinite(configured) && configured > 0
+    ? Math.floor(configured * MB)
+    : maxBytesForKind(kind);
 }
 
 /** Reads channel/account media caps from raw channel config without requiring typed account schemas. */


### PR DESCRIPTION
## Summary

- Route per-request image, music, and video model overrides through the shared capability-model resolver before provider selection.
- Require every generation reference loader to receive the resolved per-kind byte cap, covering data URLs, local/sandbox paths, and fetched media consistently.
- Remove duplicated explicit-model helpers and the stale optional configured-limit helper so one owner defines selection and size policy.

## Root cause

Music and video accepted a request-level model but resolved the configured/default model first, so the override could arrive too late to own capability selection. Reference loading also treated byte limits as optional in shared and wrapper contracts, leaving some media kinds able to decode or fetch before the configured cap was enforced.

The shared model resolver now receives the request override as an input, and all three generation tools pass a mandatory resolved limit into the shared reference boundary. The current-main reconstruction preserves the canonical generation-action resolution introduced by e66731ac while keeping model selection and preallocation limits at their actual owners.

## User impact

- Explicit image, music, and video model overrides select the requested generation route consistently.
- Configured media reference limits are enforced before decoding or transport work for every supported reference kind.
- No new config key, public API, authentication behavior, or fallback path is introduced.

## Verification

- Four focused regressions reproduced the failures before the fix and pass afterward.
- Owner and sibling suites: 277/277 passed on the current-main reconstruction.
- Independent final review, focused type-aware lint, formatting, diff checks, and Knip passed.
- The required maxBytes contract is enforced through the shared loader and all three wrappers.

## Surface

- Exact eight files across the shared policy owner, three tools, their focused tests, and the existing byte-limit owner.
- Production: net -12 lines.
- Tests: focused regression and sibling-limit coverage only.
