### PR TITLE
refactor(pairing): reuse canonical pairing request record

### DIFF
--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -19,7 +19,7 @@ import {
   sqliteOptionsForEnv,
   writeChannelPairingStateToDatabase,
 } from "./pairing-store-sqlite.js";
-import type { PairingChannel } from "./pairing-store.types.js";
+import type { PairingChannel, PairingRequestRecord } from "./pairing-store.types.js";
 
 const PAIRING_CODE_LENGTH = 8;
 const PAIRING_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
@@ -27,13 +27,7 @@ const PAIRING_CODE_MAX_ATTEMPTS = 500;
 export const CHANNEL_PAIRING_PENDING_TTL_MS = 60 * 60 * 1000;
 export const CHANNEL_PAIRING_PENDING_MAX = 3;
 
-export type PairingRequest = {
-  id: string;
-  code: string;
-  createdAt: string;
-  lastSeenAt: string;
-  meta?: Record<string, string>;
-};
+export type PairingRequest = PairingRequestRecord;
 
 /** Stable opaque id for approving a request without exposing its human pairing code. */
 export function resolveChannelPairingRequestId(


### PR DESCRIPTION
## What Problem This Solves

The pairing request contract had two structurally identical owners. `PairingRequest` predates SQLite storage; PR #105802 introduced the canonical, persistence-neutral `PairingRequestRecord` type but left the older duplicate declaration in the pairing store, creating a future drift risk.

## Why This Change Was Made

Reuse `PairingRequestRecord` as the canonical owner while preserving the existing `PairingRequest` module and name as a type alias for compatibility. This is an erased, type-only consolidation: there is no runtime JavaScript, persistence, security, protocol, public API, plugin SDK, or configuration change.

Alternatives rejected:

- Keep both declarations: preserves duplicate ownership and allows drift.
- Rename consumers or re-export only the canonical name: creates compatibility churn without simplifying behavior further.
- Move the canonical type back into the pairing store: regresses the persistence-neutral ownership graph established by PR #105802.

Production LOC: +2/-8 (net -6) | Tests: +0/-0

Exact head: `54f563d1421d975c21ed623919a9e0b6b243362a`

## User Impact

None. This is an internal, behavior-preserving type-owner consolidation.

## Evidence

- Pairing-store focused suite: 8/8 passed.
- Full actual changed gate passed.
- `git diff --check` passed.
- Deslop review: clean.
- Independent exact-head verifier: `PUBLISH`.
- Structured autoreview: clean.
- Separate exact-head, read-only Codex review: `CLEAN`.
- No new test: existing owner-boundary coverage already exercises the pairing store, and this alias is erased from runtime output.
- Before publication, live searches found no existing PR or remote branch for this head, no matching open pairing request PR, no open PR touching `src/pairing/pairing-store.ts`, and no stacked PR whose base or head used this task branch. All matching open results and stacked bases were inspected; none overlapped.
- No live credentials were required or used; this change has no live-provider boundary.

Risk and remaining uncertainty are minimal: compile-time consumers retain the same exported name and structural shape, while runtime output is unchanged. Exact-head CI is left to attach after draft creation.

AI-assisted change; the frozen implementation and verification evidence were reviewed before publication.
