### PR TITLE
chore: remove duplicate Google thinking tests

### DIFF
--- a/extensions/google/thinking.test.ts
+++ b/extensions/google/thinking.test.ts
@@ -77,18 +77,6 @@ describe("google thinking policy", () => {
     ).toBe(expected);
   });
 
-  it("removes thinkingBudget=0 for Gemini 2.5 Pro", () => {
-    const payload = {
-      config: {
-        thinkingConfig: { thinkingBudget: 0 },
-      },
-    };
-
-    sanitizeGoogleThinkingPayload({ payload, modelId: "google/gemini-2.5-pro-preview" });
-
-    expect(payload.config).not.toHaveProperty("thinkingConfig");
-  });
-
   it("rewrites Gemini 3 thinking budgets to thinkingLevel", () => {
     const payload = {
       generationConfig: {
@@ -123,25 +111,6 @@ describe("google thinking policy", () => {
 
     expect(payload.generationConfig.thinkingConfig).toEqual({
       includeThoughts: true,
-    });
-  });
-
-  it("maps Gemini 2.5 adaptive thinking to dynamic thinkingBudget", () => {
-    const payload = {
-      config: {
-        thinkingConfig: { thinkingBudget: 8192, includeThoughts: true },
-      },
-    };
-
-    sanitizeGoogleThinkingPayload({
-      payload,
-      modelId: "gemini-2.5-flash",
-      thinkingLevel: "adaptive",
-    });
-
-    expect(payload.config.thinkingConfig).toEqual({
-      includeThoughts: true,
-      thinkingBudget: -1,
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

The Google plugin thinking suite repeated two sanitizer scenarios already covered byte-for-byte at the shared implementation owner, adding maintenance and CI work without detecting a distinct regression.

## Why This Change Was Made

Remove only the duplicate provider-prefix zero-budget and Gemini 2.5 adaptive-budget cases from the plugin suite. The canonical sanitizer tests remain at the owner boundary, while the plugin suite keeps its unique Gemini 3, Gemma 4, model-mapping, and re-export-path coverage.

AI-assisted test audit requested by @steipete.

## User Impact

No user-visible behavior changes. Contributors maintain one canonical assertion for each of these two sanitizer behaviors.

## Evidence

- Baseline: canonical owner 11/11 and plugin 36/36 passed.
- After cleanup: canonical owner 11/11 and plugin 34/34 passed.
- `node scripts/check-changed.mjs -- extensions/google/thinking.test.ts` passed.
- `git diff --check` passed.
- Fresh Codex autoreview reported no accepted/actionable findings.
- Production LOC: +0/-0; tests: +0/-31.
