### PR TITLE
perf(test): skip routine Workboard sibling proof capture

### DIFF
--- a/ui/src/pages/workboard/workboard-routing.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard-routing.e2e.test.ts
@@ -15,6 +15,7 @@ const suite = createControlUiE2eSuite({
     `Playwright Chromium is not installed at ${executablePath}.`,
 });
 
+const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/workboard-routing");
 const boards = [
   { id: "default", total: 0, active: 0, archived: 0, byStatus: {} },
@@ -57,13 +58,16 @@ async function newRecordedPage(label: string): Promise<{
   page: Page;
   rawVideoDir: string;
 }> {
-  await mkdir(artifactDir, { recursive: true });
   const rawVideoDir = path.join(artifactDir, `${label}-raw`);
-  await rm(rawVideoDir, { force: true, recursive: true });
-  await mkdir(rawVideoDir, { recursive: true });
+  if (captureUiProofEnabled) {
+    await rm(rawVideoDir, { force: true, recursive: true });
+    await mkdir(rawVideoDir, { recursive: true });
+  }
   const context = await suite.browser.newContext({
     locale: "en-US",
-    recordVideo: { dir: rawVideoDir, size: { width: 1600, height: 1000 } },
+    recordVideo: captureUiProofEnabled
+      ? { dir: rawVideoDir, size: { width: 1600, height: 1000 } }
+      : undefined,
     serviceWorkers: "block",
     viewport: { width: 1600, height: 1000 },
   });
@@ -81,12 +85,16 @@ async function closeRecordedPage(
   if (video) {
     await copyFile(await video.path(), path.join(artifactDir, `${label}.webm`));
   }
-  await rm(recorded.rawVideoDir, { force: true, recursive: true });
+  if (captureUiProofEnabled) {
+    await rm(recorded.rawVideoDir, { force: true, recursive: true });
+  }
 }
 
 suite.define(() => {
   it("routes, pins, persists, and normalizes Workboard boards", async () => {
-    await rm(artifactDir, { force: true, recursive: true });
+    if (captureUiProofEnabled) {
+      await rm(artifactDir, { force: true, recursive: true });
+    }
     const recorded = await newRecordedPage("routing");
     const { page } = recorded;
     try {
@@ -107,10 +115,12 @@ suite.define(() => {
       await expect.poll(() => headerGlyph.textContent()).toContain("⚙");
       await expect.poll(() => headerGlyph.getAttribute("style")).toContain("#22c55e");
       await page.locator(".workboard-select--toolbar-board").waitFor();
-      await page.screenshot({
-        fullPage: true,
-        path: path.join(artifactDir, "01-board-route.png"),
-      });
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "01-board-route.png"),
+        });
+      }
 
       const sidebar = page.locator("openclaw-app-sidebar");
       await sidebar.locator(".sidebar-nav__head-action").click();
@@ -126,10 +136,12 @@ suite.define(() => {
       const pinnedBoard = sidebar.locator('[data-sidebar-entry="workboard:ops"] a');
       await pinnedBoard.waitFor();
       expect(await pinnedBoard.getAttribute("href")).toBe("/workboard/ops");
-      await page.screenshot({
-        fullPage: true,
-        path: path.join(artifactDir, "02-pinned-board.png"),
-      });
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "02-pinned-board.png"),
+        });
+      }
 
       await page.goto(`${suite.server.baseUrl}workboard?board=ops&agent=main`);
       await waitForControlUiRoute(page, {
@@ -143,10 +155,12 @@ suite.define(() => {
       await page.reload();
       await sidebar.locator('[data-sidebar-entry="workboard:ops"] a').waitFor();
       await page.locator(".workboard-page-title", { hasText: "Operations" }).waitFor();
-      await page.screenshot({
-        fullPage: true,
-        path: path.join(artifactDir, "03-legacy-normalized-and-persisted.png"),
-      });
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "03-legacy-normalized-and-persisted.png"),
+        });
+      }
 
       await page.goto(`${suite.server.baseUrl}workboard/deleted?agent=main`);
       await waitForControlUiRoute(page, {

--- a/ui/src/pages/workboard/workboard-status-persistence.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard-status-persistence.e2e.test.ts
@@ -19,6 +19,7 @@ import {
 const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const artifactDir = path.join(
   process.cwd(),
@@ -232,7 +233,9 @@ describeControlUiE2e("Control UI Workboard status persistence E2E", () => {
         `Playwright Chromium is not installed at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, set PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH to a compatible browser, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
       );
     }
-    await mkdir(artifactDir, { recursive: true });
+    if (captureUiProofEnabled) {
+      await mkdir(artifactDir, { recursive: true });
+    }
     server = await startControlUiE2eServer();
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });
@@ -363,7 +366,9 @@ describeControlUiE2e("Control UI Workboard status persistence E2E", () => {
   it("persists edit/reopen fields and does not bounce a dragged linked card from stale lifecycle", async () => {
     const context = await browser.newContext({
       locale: "en-US",
-      recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },
+      recordVideo: captureUiProofEnabled
+        ? { dir: artifactDir, size: { height: 900, width: 1280 } }
+        : undefined,
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
     });
@@ -502,10 +507,12 @@ describeControlUiE2e("Control UI Workboard status persistence E2E", () => {
         .poll(() => page.getByLabel("Notes").inputValue())
         .toBe("Edited notes survive reopening.");
       await expect.poll(() => workboardSelectValue(page, "Priority")).toBe("High");
-      await page.screenshot({
-        fullPage: true,
-        path: path.join(artifactDir, "workboard-edit-reopen.png"),
-      });
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "workboard-edit-reopen.png"),
+        });
+      }
       await page
         .locator('openclaw-modal-dialog[label="Edit card"] .workboard-modal__actions')
         .last()
@@ -527,10 +534,12 @@ describeControlUiE2e("Control UI Workboard status persistence E2E", () => {
         timeout: 10_000,
       });
       await waitForRequestCount(gateway, "workboard.cards.update", 1);
-      await page.screenshot({
-        fullPage: true,
-        path: path.join(artifactDir, "workboard-drag-running-persisted.png"),
-      });
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "workboard-drag-running-persisted.png"),
+        });
+      }
     } finally {
       await context.close();
     }


### PR DESCRIPTION
## What Problem This Solves

Routine Workboard routing and status-persistence browser tests always recorded two videos and five screenshots, even though ordinary CI never uploads those success-path artifacts. This made the suites slower, used unnecessary CPU, and caused otherwise healthy Chromium runs to fail when Playwright's optional FFmpeg runtime was absent.

## Why This Change Was Made

Use the existing `OPENCLAW_CAPTURE_UI_PROOF=1` opt-in already established by the neighboring Workboard browser suite. Keep every Chromium, mocked-Gateway, routing, persistence, optimistic-concurrency, execution-identity, and lifecycle assertion unchanged; preserve independent failure diagnostics and explicit screenshot/video capture.

## User Impact

No production or user-visible behavior changes. Developers and CI run the same Workboard browser coverage faster, and normal runs no longer require FFmpeg solely for discarded success artifacts.

## Evidence

- Same task-owned Linux Testbox, one Vitest worker, distinct module-cache paths, one excluded warmup, and 16 interleaved/order-balanced samples: median wall `16.295s -> 15.295s` (`-1.000s`, `-6.14%`); mean wall `16.606s -> 15.064s` (`-1.543s`, `-9.29%`); mean test-body `8.684s -> 7.426s` (`-1.258s`, `-14.48%`); mean user CPU `16.150s -> 12.966s` (`-19.71%`). Both arms retained 5 passing tests and 20 imports.
- Explicit proof mode still produced all 5 screenshots and both videos.
- With the Playwright FFmpeg executable temporarily unavailable, all three Workboard browser suites passed: **3 files, 10 tests**.
- Reversible owner fault changed the optimistic-lock payload from `expectedUpdatedAt: 2000` to `2001`; the existing execution-owned-session browser assertion failed for that exact difference. Production was immediately restored.
- Full Linux `pnpm check:changed`: all guards, dead-code scans, i18n verification, core-test typecheck, and changed-file lint passed with 0 warnings and 0 errors.
- Independent structured review passed with no actionable findings.
- Testbox proof: https://github.com/openclaw/openclaw/actions/runs/32891614501
- Production LOC: `+0/-0`; tests: `+51/-28` across two files. Related prior sibling change: #129554.
