### PR TITLE
fix: prevent cold cron session test timeouts

### DIFF
--- a/src/cron/isolated-agent.mocks.ts
+++ b/src/cron/isolated-agent.mocks.ts
@@ -65,6 +65,12 @@ vi.mock("../agents/runtime-plugins.js", () => ({
   loadAgentRuntimePluginRegistryHandle: vi.fn(),
 }));
 
+// Provider-policy loading is covered at its plugin boundary; these orchestration fixtures use the
+// generic thinking profile and must not JIT-load bundled provider surfaces during a cron turn.
+vi.mock("../plugins/provider-thinking.js", () => ({
+  resolveEffectiveThinkingProfile: vi.fn(),
+}));
+
 vi.mock("../agents/subagents/announce/subagent-announce.js", () => ({
   runSubagentAnnounceFlow: vi.fn(),
 }));

--- a/src/cron/isolated-agent.session-identity.test.ts
+++ b/src/cron/isolated-agent.session-identity.test.ts
@@ -2,7 +2,7 @@
 import "./isolated-agent.mocks.js";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as modelThinkingDefault from "../agents/model-thinking-default.js";
 import { SessionManager } from "../agents/sessions/index.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
@@ -26,10 +26,8 @@ import { setupRunCronIsolatedAgentTurnSuite } from "./isolated-agent/run.suite-h
 import {
   dispatchCronDeliveryMock,
   loadSessionEntryMock,
-  makeCronSession,
   mockRunCronFallbackPassthrough,
   patchSessionEntryMock,
-  resetRunCronIsolatedAgentTurnHarness,
   resolveCronSessionMock,
   runEmbeddedAgentMock,
 } from "./isolated-agent/run.test-harness.js";
@@ -132,16 +130,6 @@ function mockEmbeddedTranscriptWrite(
 }
 
 describe("runCronIsolatedAgentTurn session identity", () => {
-  beforeAll(async () => {
-    resetRunCronIsolatedAgentTurnHarness();
-    resolveCronSessionMock.mockReturnValue(makeCronSession());
-    vi.spyOn(modelThinkingDefault, "resolveThinkingDefault").mockReturnValue("off");
-    mockRunCronFallbackPassthrough();
-    await withTempHome(async (home) => {
-      await runCronTurn(home, { jobPayload: DEFAULT_AGENT_TURN_PAYLOAD });
-    });
-  });
-
   beforeEach(() => {
     vi.spyOn(modelThinkingDefault, "resolveThinkingDefault").mockReturnValue("off");
     runEmbeddedAgentMock.mockClear();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the cold `isolated-agent.session-identity` cron suite could exceed Vitest's 180-second `beforeAll` timeout while warming a runtime path unrelated to session identity.

## Why This Change Was Made

The shared isolated-agent fixtures now mock the provider-thinking policy boundary, whose fallback resolution JIT-loaded bundled provider surfaces through jiti on the first cron turn. With that cold setup owned by the test harness, the assertion-free warm-up cron turn is removed without changing production behavior or timeout policy.

AI-assisted: yes (OpenClaw Codex agent). I inspected and understand the change.

## User Impact

No production or user-visible behavior changes. Cron tests retain their real session-identity behavior while avoiding unrelated bundled-provider setup in the timed hook.

Production LOC: 0. Test support: +6. Test: +1/-13.

## Evidence

- Before editing, the untouched focused suite passed locally in 33.44s, with the warm-up and tests consuming 23.88s; the reported cold CI path can cross the 180s hook limit.
- A cold CPU profile traced the setup to `prepareCronRunContext → isThinkingLevelSupported → resolveEffectiveThinkingProfile → bundled provider policy surface → jiti`.
- Fresh module-cache focused proof: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=<fresh-dir> node scripts/run-vitest.mjs src/cron/isolated-agent.session-identity.test.ts --reporter=verbose` — 14/14 passed; Vitest 13.21s, first test 1.476s.
- Shared fixture siblings: `node scripts/run-vitest.mjs src/cron/isolated-agent.delivery-awareness.test.ts src/cron/isolated-agent.hook-content-wrapping.test.ts --reporter=verbose` — 8/8 passed.
- Thinking/model siblings: `node scripts/run-vitest.mjs src/cron/isolated-agent/run.cron-runtime-model-thinking.test.ts src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts --reporter=verbose` — 31/31 passed.
- Provider-policy owner: `node scripts/run-vitest.mjs src/plugins/provider-thinking.external-policy.test.ts --reporter=verbose` — 2/2 passed.
- `pnpm test:changed` — 22/22 passed.
- `node scripts/check-changed.mjs -- src/cron/isolated-agent.mocks.ts src/cron/isolated-agent.session-identity.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Mandatory autoreview against `origin/main` — clean, no accepted/actionable findings.
