### PR TITLE
fix(android): captions disappear when sharing multiple images

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/AssistantLaunch.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AssistantLaunch.kt
@@ -122,9 +122,13 @@ fun parseShareLaunchIntent(
   val action = intent?.action ?: return null
   if (action != Intent.ACTION_SEND && action != Intent.ACTION_SEND_MULTIPLE) return null
 
+  val indexedText =
+    if (action == Intent.ACTION_SEND_MULTIPLE) intent.getCharSequenceArrayListExtra(Intent.EXTRA_TEXT) else null
   val text =
-    listOf(intent.getStringExtra(Intent.EXTRA_SUBJECT), intent.getCharSequenceExtra(Intent.EXTRA_TEXT)?.toString())
-      .mapNotNull { value -> value?.trim()?.takeIf { it.isNotEmpty() } }
+    listOf(intent.getStringExtra(Intent.EXTRA_SUBJECT))
+      .plus(indexedText ?: listOfNotNull(intent.getCharSequenceExtra(Intent.EXTRA_TEXT)))
+      .plus(intent.clipData?.run { (0 until itemCount).map { getItemAt(it).text } }.orEmpty())
+      .mapNotNull { value -> value?.toString()?.trim()?.takeIf { it.isNotEmpty() } }
       .distinct()
       .joinToString(separator = "\n\n")
       .ifEmpty { null }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ShareLaunchTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ShareLaunchTest.kt
@@ -51,6 +51,78 @@ class ShareLaunchTest {
   }
 
   @Test
+  fun preservesIndexedCaptionsAcrossMultipleAttachmentsWithoutRepeatingSubjectOrClipData() {
+    val first = Uri.parse("content://photos/shared/first")
+    val second = Uri.parse("content://photos/shared/second")
+    val parsed =
+      parseShare(
+        Intent(Intent.ACTION_SEND_MULTIPLE)
+          .setType("image/png")
+          .putExtra(Intent.EXTRA_SUBJECT, "  First caption  ")
+          .putCharSequenceArrayListExtra(Intent.EXTRA_TEXT, arrayListOf("First caption", "Second caption"))
+          .putParcelableArrayListExtra(Intent.EXTRA_STREAM, arrayListOf(first, second))
+          .apply {
+            clipData =
+              ClipData("shared", arrayOf("image/png"), ClipData.Item("First caption", null, first)).apply {
+                addItem(ClipData.Item("Second caption", null, second))
+              }
+          },
+      )
+
+    requireNotNull(parsed)
+    assertEquals("First caption\n\nSecond caption", parsed.text)
+    assertEquals(listOf(first, second), parsed.attachments.map(SharedAttachment::uri))
+    assertEquals(0, parsed.droppedAttachmentCount)
+  }
+
+  @Test
+  fun acceptsTextOnlyMultipleShareArrayAtTheExistingParserBoundary() {
+    val parsed =
+      parseShare(
+        Intent(Intent.ACTION_SEND_MULTIPLE)
+          .setType("text/plain")
+          .putCharSequenceArrayListExtra(Intent.EXTRA_TEXT, arrayListOf("First note", "Second note")),
+      )
+
+    requireNotNull(parsed)
+    assertEquals("First note\n\nSecond note", parsed.text)
+    assertEquals(emptyList<SharedAttachment>(), parsed.attachments)
+  }
+
+  @Test
+  fun readsProviderBackedImageCaptionDirectlyFromClipData() {
+    val image = Uri.parse("content://photos/shared/captioned-clip")
+    val parsed =
+      parseShare(
+        Intent(Intent.ACTION_SEND)
+          .setType("image/png")
+          .apply {
+            clipData = ClipData("shared", arrayOf("image/png"), ClipData.Item("Clip caption", null, image))
+          },
+      )
+
+    requireNotNull(parsed)
+    assertEquals("Clip caption", parsed.text)
+    assertEquals(listOf(image), parsed.attachments.map(SharedAttachment::uri))
+  }
+
+  @Test
+  fun preservesLegacyScalarCaptionForMultipleAttachmentSenders() {
+    val image = Uri.parse("content://photos/shared/legacy-caption")
+    val parsed =
+      parseShare(
+        Intent(Intent.ACTION_SEND_MULTIPLE)
+          .setType("image/png")
+          .putExtra(Intent.EXTRA_TEXT, "Legacy scalar caption")
+          .putParcelableArrayListExtra(Intent.EXTRA_STREAM, arrayListOf(image)),
+      )
+
+    requireNotNull(parsed)
+    assertEquals("Legacy scalar caption", parsed.text)
+    assertEquals(listOf(image), parsed.attachments.map(SharedAttachment::uri))
+  }
+
+  @Test
   fun readsProviderBackedImageFromClipData() {
     val image = Uri.parse("content://photos/shared/clip")
     val parsed =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sharing multiple images to OpenClaw on Android would see the image attachments in the chat composer but lose the captions supplied by the sending app.

## Why This Change Was Made

Android's `ACTION_SEND_MULTIPLE` contract supplies indexed captions as `ArrayList<CharSequence>` in `EXTRA_TEXT`, and the framework may mirror those captions into `ClipData.Item.text`. The existing share-launch owner only read the scalar `EXTRA_TEXT` form. Read the documented indexed captions and raw in-memory clip text at the existing producer while retaining legacy scalar shares, subject-first ordering, trimming, deduplication, and all existing URI/MIME/grant/attachment-limit behavior. Production delta: **+6/-2 lines (net +4)**, justified by the documented Android framework contract.

## User Impact

Sharing several images from another Android app now carries the associated captions into the existing chat composer exactly once and in sender order. Both image previews remain present. The change does not add permissions, broaden URI access, read content in the share parser, change the manifest, or automatically send a message.

## Evidence

The unchanged owner reproduced three real regressions (**24 tests, 3 failures**). The fixed owner and adjacent activity, view-model, and composer suites then passed **113/113 tests**, together with all four hosted-equivalent Android formatting checks: app, benchmark, wear, and wear-shared. Independent authenticated review reported no actionable findings.

The same real Android API 36 instrumentation created two app-owned MediaStore PNGs, launched the manifest-supported `image/png` `ACTION_SEND_MULTIPLE` intent with genuine `content://` attachments and indexed captions, and exercised the actual production activity and chat composer. Both frozen and fixed runs passed their respective before/after assertions; both retained two image previews, and the fixed run preserved both captions in the correct order without duplicating the mirrored clip text. The instrumentation removed only its own temporary MediaStore rows.

Before: both images are attached, but the second caption is silently absent.

![Android multi-image share before: two image previews, only the first caption](https://github.com/user-attachments/assets/63741ef8-47dd-44b9-82e6-1646e1e80241)

After: the same multi-image share displays both captions, ordered exactly once.

![Android multi-image share after: two image previews and both ordered captions](https://github.com/user-attachments/assets/6c66c3b4-44fe-45e1-892b-469d87c3a3fd)
