### PR TITLE
fix(matrix): await persistence shutdown

### DIFF
--- a/extensions/matrix/src/matrix/client-resolver.test-helpers.ts
+++ b/extensions/matrix/src/matrix/client-resolver.test-helpers.ts
@@ -46,7 +46,7 @@ export function createMockMatrixClient(): MatrixClient {
     start: vi.fn(async () => undefined),
     stop: vi.fn(() => undefined),
     stopAndPersist: vi.fn(async () => undefined),
-    stopWithoutPersist: vi.fn(() => undefined),
+    stopWithoutPersist: vi.fn(async () => undefined),
   } as unknown as MatrixClient;
 }
 

--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -891,14 +891,24 @@ describe("shared Matrix client generations", () => {
     const ownerAbort = expectMatrixStartupAbort(ownerStart);
     const waiterAbort = expectMatrixStartupAbort(waiterStart);
 
-    await Promise.all([stopSharedClientForAccount(auth), ownerAbort, waiterAbort]);
+    const retirement = stopSharedClientForAccount(auth);
+    await Promise.all([ownerAbort, waiterAbort]);
     expect(callerAbort.signal.aborted).toBe(false);
     expect(startupSignal?.aborted).toBe(true);
     expect(owner.abortSignal.aborted).toBe(true);
     expect(waiter.abortSignal.aborted).toBe(true);
+    expect(firstClient.stopAndPersist).not.toHaveBeenCalled();
+
+    let retirementSettled = false;
+    void retirement.then(() => {
+      retirementSettled = true;
+    });
+    await Promise.resolve();
+    expect(retirementSettled).toBe(false);
 
     start.resolve();
-    await Promise.resolve();
+    await retirement;
+    expect(firstClient.stopAndPersist).toHaveBeenCalledTimes(1);
     const replacement = await acquireSharedMatrixClient({ auth, startClient: false });
     expect(replacement.client).toBe(replacementClient);
     await replacement.release({ mode: "discard" });

--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -391,7 +391,12 @@ describe("shared Matrix client generations", () => {
   it("bounds non-cooperative transient drain and replaces after every late release", async () => {
     vi.useFakeTimers();
     const callOrder: string[] = [];
+    const discard = createDeferred<void>();
     const client = createMockClient("main", callOrder);
+    client.stopWithoutPersist.mockImplementation(async () => {
+      callOrder.push("discard");
+      await discard.promise;
+    });
     const replacementClient = createMockClient("replacement");
     createMatrixClientMock.mockResolvedValueOnce(client).mockResolvedValueOnce(replacementClient);
     const auth = authFor("main");
@@ -421,6 +426,14 @@ describe("shared Matrix client generations", () => {
     expect(client.stopWithoutPersist).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(1);
+    await vi.waitFor(() => {
+      expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
+    });
+    await expect(stopSharedClientForAccount(auth)).rejects.toMatchObject({
+      message: "Matrix transient leases did not drain within 5000ms",
+    });
+
+    discard.resolve();
     await expect(retirementError).resolves.toMatchObject({
       message: "Matrix transient leases did not drain within 5000ms",
     });
@@ -432,6 +445,12 @@ describe("shared Matrix client generations", () => {
       message: "Matrix transient leases did not drain within 5000ms",
     });
     expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
+    await expect(stopSharedClientForAccount(auth)).rejects.toMatchObject({
+      message: "Matrix transient leases did not drain within 5000ms",
+    });
+    await expect(stopSharedClientForAccount(auth)).rejects.toMatchObject({
+      message: "Matrix transient leases did not drain within 5000ms",
+    });
 
     const firstLateRelease = firstTransient.release({ mode: "persist" });
     const duplicateLateRelease = firstTransient.release({ mode: "persist" });
@@ -440,6 +459,9 @@ describe("shared Matrix client generations", () => {
     expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
     expect(client.stopAndPersist).not.toHaveBeenCalled();
     await expect(acquireSharedMatrixClient({ auth })).rejects.toMatchObject({
+      message: "Matrix transient leases did not drain within 5000ms",
+    });
+    await expect(stopSharedClientForAccount(auth)).rejects.toMatchObject({
       message: "Matrix transient leases did not drain within 5000ms",
     });
     expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
@@ -462,7 +484,7 @@ describe("shared Matrix client generations", () => {
     const cause = new Error("monitor cleanup failed");
     const client = createMockClient("main");
     createMatrixClientMock.mockResolvedValue(client);
-    const auth = authFor("main");
+    const auth = authFor("late-monitor-cleanup");
     const monitor = await acquireSharedMatrixClient({
       auth,
       role: "monitor",
@@ -499,7 +521,7 @@ describe("shared Matrix client generations", () => {
       }
     });
     createMatrixClientMock.mockResolvedValue(client);
-    const auth = authFor("main");
+    const auth = authFor("poisoned-decryption-drain");
     const monitor = await acquireSharedMatrixClient({
       auth,
       role: "monitor",
@@ -735,7 +757,7 @@ describe("shared Matrix client generations", () => {
     const cause = new Error("monitor cleanup failed");
     const client = createMockClient("main");
     createMatrixClientMock.mockResolvedValue(client);
-    const auth = authFor("main");
+    const auth = authFor("monitor-cleanup-failure");
     const monitor = await acquireSharedMatrixClient({
       auth,
       role: "monitor",
@@ -961,11 +983,67 @@ describe("shared Matrix client generations", () => {
 
     discard.resolve();
     await discard.promise;
-    await Promise.resolve();
-    const replacement = await acquireSharedMatrixClient({ auth, startClient: false });
+    let replacement: Awaited<ReturnType<typeof acquireSharedMatrixClient>> | undefined;
+    await vi.waitFor(async () => {
+      replacement = await acquireSharedMatrixClient({ auth, startClient: false });
+    });
+    if (!replacement) {
+      throw new Error("expected replacement Matrix client");
+    }
     expect(replacement.client).toBe(replacementClient);
     expect(createMatrixClientMock).toHaveBeenCalledTimes(2);
     await replacement.release({ mode: "discard" });
+  });
+
+  it("retires monitor ownership when late startup discard fails", async () => {
+    vi.useFakeTimers();
+    const start = createDeferred<void>();
+    const monitorTasks = createDeferred<void>();
+    const discardFailure = new Error("late discard failed");
+    const client = createMockClient("first");
+    client.start.mockReturnValue(start.promise);
+    client.stopWithoutPersist.mockRejectedValue(discardFailure);
+    createMatrixClientMock.mockResolvedValue(client);
+    const auth = authFor("late-discard-failure");
+    const monitor = await acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    });
+    const monitorRetirement = createMonitorRetirement([]);
+    monitorRetirement.waitForTasks.mockReturnValue(monitorTasks.promise);
+    monitor.registerMonitorRetirement(monitorRetirement);
+    const startup = monitor.start();
+
+    await vi.waitFor(() => {
+      expect(client.start).toHaveBeenCalledTimes(1);
+    });
+    const retirementError = stopSharedClientForAccount(auth).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await expectMatrixStartupAbort(startup);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(retirementError).resolves.toMatchObject({
+      message: "Matrix client startup did not settle within 5000ms during retirement",
+    });
+    expect(monitorRetirement.closeTaskAdmission).toHaveBeenCalledTimes(1);
+    expect(monitorRetirement.detachListeners).toHaveBeenCalledTimes(1);
+    expect(monitorRetirement.waitForTasks).toHaveBeenCalledTimes(1);
+
+    start.resolve();
+    await vi.waitFor(() => {
+      expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
+    });
+    monitorTasks.resolve();
+    await vi.waitFor(() => {
+      expect(monitorRetirement.cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    await expect(acquireSharedMatrixClient({ auth, startClient: false })).rejects.toBe(
+      discardFailure,
+    );
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not let one aborted startup waiter remove another lease", async () => {

--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -87,6 +87,13 @@ async function expectMatrixStartupAbort(promise: Promise<unknown>): Promise<void
   });
 }
 
+async function expectPending(promise: Promise<unknown>): Promise<void> {
+  const settled = vi.fn();
+  void promise.then(settled, settled);
+  await Promise.resolve();
+  expect(settled).not.toHaveBeenCalled();
+}
+
 describe("shared Matrix client generations", () => {
   beforeAll(async () => {
     ({ acquireSharedMatrixClient, stopSharedClientForAccount } = await import("./shared.js"));
@@ -231,12 +238,7 @@ describe("shared Matrix client generations", () => {
     });
     const lateRelease = monitor.release({ mode: "persist" });
     expect(monitor.release({ mode: "discard" })).toBe(lateRelease);
-    let lateReleaseSettled = false;
-    void lateRelease.then(() => {
-      lateReleaseSettled = true;
-    });
-    await Promise.resolve();
-    expect(lateReleaseSettled).toBe(false);
+    await expectPending(lateRelease);
 
     waitForTasks.resolve();
     await Promise.all([forcedRetirement, lateRelease]);
@@ -437,18 +439,10 @@ describe("shared Matrix client generations", () => {
     await expect(retirementError).resolves.toMatchObject({
       message: "Matrix transient leases did not drain within 5000ms",
     });
-    expect(firstTransient.abortSignal.aborted).toBe(true);
     expect(finalTransient.abortSignal.aborted).toBe(true);
     expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
     expect(client.stopAndPersist).not.toHaveBeenCalled();
     await expect(acquireSharedMatrixClient({ auth })).rejects.toMatchObject({
-      message: "Matrix transient leases did not drain within 5000ms",
-    });
-    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
-    await expect(stopSharedClientForAccount(auth)).rejects.toMatchObject({
-      message: "Matrix transient leases did not drain within 5000ms",
-    });
-    await expect(stopSharedClientForAccount(auth)).rejects.toMatchObject({
       message: "Matrix transient leases did not drain within 5000ms",
     });
 
@@ -456,17 +450,19 @@ describe("shared Matrix client generations", () => {
     const duplicateLateRelease = firstTransient.release({ mode: "persist" });
     expect(duplicateLateRelease).toBe(firstLateRelease);
     await firstLateRelease;
-    expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
-    expect(client.stopAndPersist).not.toHaveBeenCalled();
     await expect(acquireSharedMatrixClient({ auth })).rejects.toMatchObject({
       message: "Matrix transient leases did not drain within 5000ms",
     });
     await expect(stopSharedClientForAccount(auth)).rejects.toMatchObject({
       message: "Matrix transient leases did not drain within 5000ms",
     });
-    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
 
-    await finalTransient.release({ mode: "persist" });
+    const finalLateRelease = finalTransient.release({ mode: "persist" });
+    const finalRepeatedForce = stopSharedClientForAccount(auth);
+    await finalLateRelease;
+    await expect(finalRepeatedForce).rejects.toMatchObject({
+      message: "Matrix transient leases did not drain within 5000ms",
+    });
 
     const [firstReplacement, secondReplacement] = await Promise.all([
       acquireSharedMatrixClient({ auth, startClient: false }),
@@ -770,6 +766,8 @@ describe("shared Matrix client generations", () => {
     await expect(monitor.release({ mode: "persist" })).rejects.toBe(cause);
     expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
     await expect(acquireSharedMatrixClient({ auth })).rejects.toBe(cause);
+    await expect(stopSharedClientForAccount(auth)).rejects.toBe(cause);
+    await expect(acquireSharedMatrixClient({ auth })).rejects.toBe(cause);
     expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
   });
 
@@ -843,26 +841,76 @@ describe("shared Matrix client generations", () => {
     await replacement.release({ mode: "discard" });
   });
 
-  it("preserves and propagates an earlier persist requirement when final lease discards", async () => {
-    const cause = new Error("crypto persist failed");
+  it.each([
+    {
+      name: "normal discard",
+      mode: "discard" as const,
+      configure: (client: ReturnType<typeof createMockClient>, failure: Error) => {
+        client.stopWithoutPersist.mockRejectedValue(failure);
+      },
+    },
+    {
+      name: "strict persistence fallback",
+      mode: "persist" as const,
+      configure: (client: ReturnType<typeof createMockClient>, failure: Error) => {
+        client.stopAndPersist.mockRejectedValue(new Error("crypto persist failed"));
+        client.stopWithoutPersist.mockRejectedValue(failure);
+      },
+    },
+    {
+      name: "final-drain discard",
+      mode: "persist" as const,
+      configure: (client: ReturnType<typeof createMockClient>, failure: Error) => {
+        client.drainPendingDecryptions
+          .mockResolvedValueOnce(undefined)
+          .mockRejectedValueOnce(new Error("final decryption drain timed out"));
+        client.stopWithoutPersist.mockRejectedValue(failure);
+      },
+    },
+  ])("retains a generation when $name shutdown fails", async ({ name, mode, configure }) => {
+    const failure = new Error(`${name} shutdown failed`);
+    const client = createMockClient("main");
+    configure(client, failure);
+    createMatrixClientMock.mockResolvedValue(client);
+    const auth = authFor(`${name}-failure`);
+    const lease = await acquireSharedMatrixClient({ auth, startClient: false });
+
+    await expect(lease.release({ mode })).rejects.toBe(failure);
+    await expect(acquireSharedMatrixClient({ auth, startClient: false })).rejects.toBe(failure);
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("awaits discard fallback before surfacing strict persistence failure", async () => {
+    const persistFailure = new Error("crypto persist failed");
+    const persist = createDeferred<void>();
+    const discard = createDeferred<void>();
     const firstClient = createMockClient("first");
     const replacementClient = createMockClient("replacement");
-    firstClient.stopAndPersist.mockRejectedValue(cause);
+    firstClient.stopAndPersist.mockReturnValue(persist.promise);
+    firstClient.stopWithoutPersist.mockReturnValue(discard.promise);
     createMatrixClientMock
       .mockResolvedValueOnce(firstClient)
       .mockResolvedValueOnce(replacementClient);
-    const auth = authFor("main");
-    const first = await acquireSharedMatrixClient({ auth, startClient: false });
-    const final = await acquireSharedMatrixClient({ auth, startClient: false });
+    const auth = authFor("strict-persist-failure");
+    const lease = await acquireSharedMatrixClient({ auth, startClient: false });
 
-    await first.release({ mode: "persist" });
-    expect(firstClient.stopAndPersist).not.toHaveBeenCalled();
-    await expect(final.release({ mode: "discard" })).rejects.toBe(cause);
-    expect(firstClient.stopWithoutPersist).not.toHaveBeenCalled();
+    const releaseError = expect(lease.release({ mode: "persist" })).rejects.toBe(persistFailure);
+    persist.reject(persistFailure);
+    await vi.waitFor(() => {
+      expect(firstClient.stopWithoutPersist).toHaveBeenCalledTimes(1);
+    });
+    const blockedAcquire = acquireSharedMatrixClient({ auth, startClient: false });
+    await expect(blockedAcquire).rejects.toBe(persistFailure);
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
+    const forcedRetirement = stopSharedClientForAccount(auth);
+    await expectPending(forcedRetirement);
 
+    discard.resolve();
+    await releaseError;
+    await expect(forcedRetirement).resolves.toBeUndefined();
     const replacement = await acquireSharedMatrixClient({ auth, startClient: false });
     expect(replacement.client).toBe(replacementClient);
-    await replacement.release();
+    await replacement.release({ mode: "discard" });
   });
 
   it("discards and replaces a generation when the final decryption drain fails", async () => {
@@ -921,12 +969,7 @@ describe("shared Matrix client generations", () => {
     expect(waiter.abortSignal.aborted).toBe(true);
     expect(firstClient.stopAndPersist).not.toHaveBeenCalled();
 
-    let retirementSettled = false;
-    void retirement.then(() => {
-      retirementSettled = true;
-    });
-    await Promise.resolve();
-    expect(retirementSettled).toBe(false);
+    await expectPending(retirement);
 
     start.resolve();
     await retirement;

--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -50,7 +50,7 @@ function createMockClient(name: string, callOrder: string[] = []) {
     stopAndPersist: vi.fn(async () => {
       callOrder.push("persist");
     }),
-    stopWithoutPersist: vi.fn(() => {
+    stopWithoutPersist: vi.fn(async () => {
       callOrder.push("discard");
     }),
     drainPendingDecryptions: vi.fn(async (reason: string) => {
@@ -794,6 +794,31 @@ describe("shared Matrix client generations", () => {
 
     expect(client.stopAndPersist).not.toHaveBeenCalled();
     expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a discarded generation unavailable until async cleanup settles", async () => {
+    const discard = createDeferred<void>();
+    const client = createMockClient("main");
+    const replacementClient = createMockClient("replacement");
+    client.stopWithoutPersist.mockReturnValue(discard.promise);
+    createMatrixClientMock.mockResolvedValueOnce(client).mockResolvedValueOnce(replacementClient);
+    const auth = authFor("main");
+    const lease = await acquireSharedMatrixClient({ auth, startClient: false });
+
+    const release = lease.release({ mode: "discard" });
+    await vi.waitFor(() => {
+      expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
+    });
+    const replacementPromise = acquireSharedMatrixClient({ auth, startClient: false });
+    await Promise.resolve();
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
+
+    discard.resolve();
+    await release;
+    const replacement = await replacementPromise;
+    expect(replacement.client).toBe(replacementClient);
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(2);
+    await replacement.release({ mode: "discard" });
   });
 
   it("preserves and propagates an earlier persist requirement when final lease discards", async () => {

--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -866,7 +866,7 @@ describe("shared Matrix client generations", () => {
     await replacement.release({ mode: "discard" });
   });
 
-  it("aborts a first starter and waiter during forced retirement without late reuse", async () => {
+  it("joins an in-flight startup during forced retirement", async () => {
     const start = createDeferred<void>();
     const firstClient = createMockClient("first");
     const replacementClient = createMockClient("replacement");
@@ -911,6 +911,60 @@ describe("shared Matrix client generations", () => {
     expect(firstClient.stopAndPersist).toHaveBeenCalledTimes(1);
     const replacement = await acquireSharedMatrixClient({ auth, startClient: false });
     expect(replacement.client).toBe(replacementClient);
+    await replacement.release({ mode: "discard" });
+  });
+
+  it("bounds forced retirement while startup remains stuck and fences late cleanup", async () => {
+    vi.useFakeTimers();
+    const start = createDeferred<void>();
+    const discard = createDeferred<void>();
+    const firstClient = createMockClient("first");
+    const replacementClient = createMockClient("replacement");
+    firstClient.start.mockReturnValue(start.promise);
+    firstClient.stopWithoutPersist.mockReturnValue(discard.promise);
+    createMatrixClientMock
+      .mockResolvedValueOnce(firstClient)
+      .mockResolvedValueOnce(replacementClient);
+    const auth = authFor("main");
+    const lease = await acquireSharedMatrixClient({ auth, startClient: false });
+    const startup = lease.start();
+    await vi.waitFor(() => {
+      expect(firstClient.start).toHaveBeenCalledTimes(1);
+    });
+
+    const retirementError = stopSharedClientForAccount(auth).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await expectMatrixStartupAbort(startup);
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(firstClient.stopWithoutPersist).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(retirementError).resolves.toMatchObject({
+      message: "Matrix client startup did not settle within 5000ms during retirement",
+    });
+    await expect(acquireSharedMatrixClient({ auth, startClient: false })).rejects.toMatchObject({
+      message: "Matrix client startup did not settle within 5000ms during retirement",
+    });
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
+
+    start.resolve();
+    await vi.waitFor(() => {
+      expect(firstClient.stopWithoutPersist).toHaveBeenCalledTimes(1);
+    });
+    expect(firstClient.stopAndPersist).not.toHaveBeenCalled();
+    await expect(acquireSharedMatrixClient({ auth, startClient: false })).rejects.toMatchObject({
+      message: "Matrix client startup did not settle within 5000ms during retirement",
+    });
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
+
+    discard.resolve();
+    await discard.promise;
+    await Promise.resolve();
+    const replacement = await acquireSharedMatrixClient({ auth, startClient: false });
+    expect(replacement.client).toBe(replacementClient);
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(2);
     await replacement.release({ mode: "discard" });
   });
 

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -36,14 +36,7 @@ export type SharedMatrixClientLease = {
   release: (params?: { mode?: MatrixClientReleaseMode }) => Promise<void>;
 };
 
-type SharedMatrixClientPhase =
-  | "open"
-  | "quiescing"
-  | "closing"
-  | "late-drain"
-  | "late-drain-stopped";
-
-type PoisonDisposition = "replace-after-stop" | "replace-after-late-drain" | "retain";
+type SharedMatrixClientPhase = "open" | "quiescing" | "closing" | "late-drain";
 
 type SharedMatrixClientLeaseState = {
   abortController: AbortController;
@@ -138,12 +131,6 @@ function deleteSharedClientState(state: SharedMatrixClientState): void {
     sharedClientStates.delete(state.key);
   }
   sharedClientPromises.delete(state.key);
-}
-
-function deleteSharedClientStateAfterLateDrain(state: SharedMatrixClientState): void {
-  if (state.phase === "late-drain-stopped" && state.leases.size === 0) {
-    deleteSharedClientState(state);
-  }
 }
 
 async function ensureSharedClientStarted(
@@ -354,25 +341,6 @@ async function waitForRetirementDrain(
   }
 }
 
-async function continueLateGenerationRetirement(
-  state: SharedMatrixClientState,
-  startup: Promise<void>,
-  monitorLeases: SharedMatrixClientLeaseState[],
-): Promise<void> {
-  const outcomes = await Promise.allSettled([
-    retireMonitorLeases(state, monitorLeases),
-    startup.catch(() => undefined).then(() => state.client.stopWithoutPersist()),
-  ]);
-  const failure = outcomes.find((outcome) => outcome.status === "rejected");
-  if (failure?.status === "rejected") {
-    state.poisonError = toRetirementError(failure.reason);
-    return;
-  }
-  state.started = false;
-  state.phase = "late-drain-stopped";
-  deleteSharedClientStateAfterLateDrain(state);
-}
-
 function beginGenerationRetirement(params: {
   state: SharedMatrixClientState;
   monitorLeases?: SharedMatrixClientLeaseState[];
@@ -382,8 +350,9 @@ function beginGenerationRetirement(params: {
     return state.retirementPromise;
   }
   state.phase = "quiescing";
-  state.retirementPromise = Promise.resolve().then(async () => {
-    let poisonDisposition: PoisonDisposition = "replace-after-stop";
+  const result = createDeferred<void>();
+  state.retirementPromise = result.promise;
+  const owner = Promise.resolve().then(async () => {
     const startup = state.startPromise;
     if (startup) {
       try {
@@ -395,9 +364,23 @@ function beginGenerationRetirement(params: {
         );
       } catch (error) {
         state.poisonError = toRetirementError(error);
-        // The SDK cannot cancel crypto initialization. Keep this generation keyed
-        // and stop it without persistence as soon as the owned startup settles.
-        void continueLateGenerationRetirement(state, startup, params.monitorLeases ?? []);
+        result.reject(state.poisonError);
+        const outcomes = await Promise.allSettled([
+          startup
+            .catch(() => undefined)
+            .then(async () => {
+              state.started = false;
+              await state.client.stopWithoutPersist();
+            }),
+          retireMonitorLeases(state, params.monitorLeases ?? []),
+          state.noLeases.promise,
+        ]);
+        const failure = outcomes.find((outcome) => outcome.status === "rejected");
+        if (failure) {
+          state.poisonError = toRetirementError(failure.reason);
+        } else {
+          deleteSharedClientState(state);
+        }
         throw state.poisonError;
       }
     }
@@ -409,14 +392,16 @@ function beginGenerationRetirement(params: {
       state.poisonError = toRetirementError(error);
     }
 
+    let monitorRetired = true;
     try {
       await retireMonitorLeases(state, params.monitorLeases ?? []);
     } catch (error) {
       state.poisonError ??= toRetirementError(error);
-      poisonDisposition = "retain";
+      monitorRetired = false;
     }
 
     state.phase = "closing";
+    let lateLeaseDrain: Promise<void> | null = null;
     try {
       await waitForRetirementDrain(
         state,
@@ -426,55 +411,52 @@ function beginGenerationRetirement(params: {
       );
     } catch (error) {
       state.poisonError ??= toRetirementError(error);
-      if (poisonDisposition !== "retain") {
-        poisonDisposition = "replace-after-late-drain";
-      }
+      result.reject(state.poisonError);
+      lateLeaseDrain = state.noLeases.promise;
     }
 
-    if (state.poisonError) {
-      const decryptionsDrained = await state.client
-        .drainPendingDecryptions("matrix poisoned client shutdown")
-        .then(
+    let failure = state.poisonError;
+    let canDelete = monitorRetired;
+    if (failure) {
+      canDelete =
+        (await state.client.drainPendingDecryptions("matrix poisoned client shutdown").then(
           () => true,
           () => false,
-        );
-      await state.client.stopWithoutPersist();
-      if (decryptionsDrained) {
-        if (poisonDisposition === "replace-after-stop") {
-          deleteSharedClientState(state);
-        } else if (poisonDisposition === "replace-after-late-drain") {
-          // The timeout cannot revoke ownership. Keep the stopped generation keyed
-          // until every operation that crossed the deadline genuinely returns.
-          state.phase = "late-drain-stopped";
-          deleteSharedClientStateAfterLateDrain(state);
-        }
+        )) && canDelete;
+    } else {
+      try {
+        await state.client.drainPendingDecryptions("matrix shared client final shutdown");
+      } catch (error) {
+        failure = state.poisonError = toRetirementError(error);
       }
-      throw state.poisonError;
     }
 
-    try {
-      await state.client.drainPendingDecryptions("matrix shared client final shutdown");
-    } catch (error) {
-      state.poisonError = toRetirementError(error);
+    let discard = failure !== null || state.releaseMode === "discard";
+    if (!discard) {
       try {
-        await state.client.stopWithoutPersist();
-      } finally {
-        deleteSharedClientState(state);
-      }
-      throw state.poisonError;
-    }
-    try {
-      if (state.releaseMode === "persist") {
         await state.client.stopAndPersist();
-      } else if (state.releaseMode === "discard") {
-        await state.client.stopWithoutPersist();
-      } else {
-        await state.client.stopAndPersist().catch(() => state.client.stopWithoutPersist());
+      } catch (error) {
+        discard = true;
+        if (state.releaseMode === "persist") {
+          failure = state.poisonError = toRetirementError(error);
+        }
       }
-    } finally {
+    }
+    if (discard) {
+      await state.client.stopWithoutPersist().catch((error: unknown) => {
+        failure = state.poisonError = toRetirementError(error);
+        canDelete = false;
+      });
+    }
+    await lateLeaseDrain;
+    if (canDelete) {
       deleteSharedClientState(state);
     }
+    if (failure) {
+      throw failure;
+    }
   });
+  void owner.then(result.resolve, result.reject);
   abortTransientLeases(state);
   return state.retirementPromise;
 }
@@ -535,9 +517,8 @@ function createSharedMatrixClientLease(
         state.noLeases.resolve();
       }
 
-      if (state.phase === "late-drain" || state.phase === "late-drain-stopped") {
+      if (state.phase === "late-drain") {
         leaseState.releasePromise = Promise.resolve();
-        deleteSharedClientStateAfterLateDrain(state);
         return leaseState.releasePromise;
       }
 
@@ -583,7 +564,7 @@ export async function acquireSharedMatrixClient(
 }
 
 async function forceRetireState(state: SharedMatrixClientState): Promise<void> {
-  if (state.phase === "late-drain" || state.phase === "late-drain-stopped") {
+  if (state.phase === "late-drain") {
     throw state.poisonError ?? new Error("Matrix client generation is still retiring");
   }
   state.releaseMode = mergeReleaseMode(state.releaseMode, "stop");
@@ -592,16 +573,12 @@ async function forceRetireState(state: SharedMatrixClientState): Promise<void> {
     monitorLeases: Array.from(state.leases).filter((lease) => lease.role === "monitor"),
   });
   forceReleaseLeases(state, retirementPromise);
-  await retirementPromise.catch((error: unknown) => {
-    if (state.phase === "late-drain" || state.phase === "late-drain-stopped") {
-      throw error;
+  try {
+    await retirementPromise;
+  } catch (error) {
+    if (sharedClientStates.get(state.key) === state) {
+      throw state.poisonError ?? error;
     }
-    if (!state.poisonError) {
-      throw error;
-    }
-  });
-  if (state.poisonError) {
-    deleteSharedClientState(state);
   }
 }
 

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -323,26 +323,26 @@ function forceReleaseLeases(
   state.noLeases.resolve();
 }
 
-async function waitForRetirementDrain(params: {
-  state: SharedMatrixClientState;
-  task: Promise<unknown>;
-  isPending: () => boolean;
-  timeoutMessage: string;
-}): Promise<void> {
-  if (!params.isPending()) {
+async function waitForRetirementDrain(
+  state: SharedMatrixClientState,
+  task: Promise<unknown>,
+  isPending: () => boolean,
+  timeoutMessage: string,
+): Promise<void> {
+  if (!isPending()) {
     return;
   }
   let deadline: NodeJS.Timeout | undefined;
   try {
     await Promise.race([
-      params.task,
+      task,
       new Promise<never>((_, reject) => {
         deadline = setTimeout(() => {
-          if (!params.isPending()) {
+          if (!isPending()) {
             return;
           }
-          params.state.phase = "late-drain";
-          reject(new Error(params.timeoutMessage));
+          state.phase = "late-drain";
+          reject(new Error(timeoutMessage));
         }, MATRIX_RETIREMENT_DRAIN_TIMEOUT_MS);
         deadline.unref?.();
       }),
@@ -354,31 +354,22 @@ async function waitForRetirementDrain(params: {
   }
 }
 
-async function waitForLeaseDrain(state: SharedMatrixClientState): Promise<void> {
-  await waitForRetirementDrain({
-    state,
-    task: state.noLeases.promise,
-    isPending: () => state.leases.size > 0,
-    timeoutMessage: `Matrix transient leases did not drain within ${MATRIX_RETIREMENT_DRAIN_TIMEOUT_MS}ms`,
-  });
-}
-
 async function continueLateGenerationRetirement(
   state: SharedMatrixClientState,
   startup: Promise<void>,
   monitorLeases: SharedMatrixClientLeaseState[],
 ): Promise<void> {
-  await startup.catch(() => undefined);
-  try {
-    await state.client.stopWithoutPersist();
-    state.started = false;
-    await retireMonitorLeases(state, monitorLeases);
-  } catch (error) {
-    state.poisonError = toRetirementError(error);
+  const outcomes = await Promise.allSettled([
+    retireMonitorLeases(state, monitorLeases),
+    startup.catch(() => undefined).then(() => state.client.stopWithoutPersist()),
+  ]);
+  const failure = outcomes.find((outcome) => outcome.status === "rejected");
+  if (failure?.status === "rejected") {
+    state.poisonError = toRetirementError(failure.reason);
     return;
   }
+  state.started = false;
   state.phase = "late-drain-stopped";
-  state.startPromise = null;
   deleteSharedClientStateAfterLateDrain(state);
 }
 
@@ -396,21 +387,17 @@ function beginGenerationRetirement(params: {
     const startup = state.startPromise;
     if (startup) {
       try {
-        await waitForRetirementDrain({
+        await waitForRetirementDrain(
           state,
-          task: startup.catch(() => undefined),
-          isPending: () => state.startPromise === startup,
-          timeoutMessage: `Matrix client startup did not settle within ${MATRIX_RETIREMENT_DRAIN_TIMEOUT_MS}ms during retirement`,
-        });
+          startup.catch(() => undefined),
+          () => state.startPromise === startup,
+          `Matrix client startup did not settle within ${MATRIX_RETIREMENT_DRAIN_TIMEOUT_MS}ms during retirement`,
+        );
       } catch (error) {
         state.poisonError = toRetirementError(error);
         // The SDK cannot cancel crypto initialization. Keep this generation keyed
         // and stop it without persistence as soon as the owned startup settles.
-        state.startPromise = continueLateGenerationRetirement(
-          state,
-          startup,
-          params.monitorLeases ?? [],
-        );
+        void continueLateGenerationRetirement(state, startup, params.monitorLeases ?? []);
         throw state.poisonError;
       }
     }
@@ -431,7 +418,12 @@ function beginGenerationRetirement(params: {
 
     state.phase = "closing";
     try {
-      await waitForLeaseDrain(state);
+      await waitForRetirementDrain(
+        state,
+        state.noLeases.promise,
+        () => state.leases.size > 0,
+        `Matrix transient leases did not drain within ${MATRIX_RETIREMENT_DRAIN_TIMEOUT_MS}ms`,
+      );
     } catch (error) {
       state.poisonError ??= toRetirementError(error);
       if (poisonDisposition !== "retain") {
@@ -591,7 +583,7 @@ export async function acquireSharedMatrixClient(
 }
 
 async function forceRetireState(state: SharedMatrixClientState): Promise<void> {
-  if (state.phase === "late-drain" && state.startPromise) {
+  if (state.phase === "late-drain" || state.phase === "late-drain-stopped") {
     throw state.poisonError ?? new Error("Matrix client generation is still retiring");
   }
   state.releaseMode = mergeReleaseMode(state.releaseMode, "stop");
@@ -600,13 +592,8 @@ async function forceRetireState(state: SharedMatrixClientState): Promise<void> {
     monitorLeases: Array.from(state.leases).filter((lease) => lease.role === "monitor"),
   });
   forceReleaseLeases(state, retirementPromise);
-  if (state.poisonError) {
-    await retirementPromise.catch(() => undefined);
-    deleteSharedClientState(state);
-    return;
-  }
   await retirementPromise.catch((error: unknown) => {
-    if (state.phase === "late-drain" && state.startPromise) {
+    if (state.phase === "late-drain" || state.phase === "late-drain-stopped") {
       throw error;
     }
     if (!state.poisonError) {

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -395,7 +395,7 @@ function beginGenerationRetirement(params: {
           () => true,
           () => false,
         );
-      state.client.stopWithoutPersist();
+      await state.client.stopWithoutPersist();
       if (decryptionsDrained) {
         if (poisonDisposition === "replace-after-stop") {
           deleteSharedClientState(state);
@@ -414,7 +414,7 @@ function beginGenerationRetirement(params: {
     } catch (error) {
       state.poisonError = toRetirementError(error);
       try {
-        state.client.stopWithoutPersist();
+        await state.client.stopWithoutPersist();
       } finally {
         deleteSharedClientState(state);
       }
@@ -424,7 +424,7 @@ function beginGenerationRetirement(params: {
       if (state.releaseMode === "persist") {
         await state.client.stopAndPersist();
       } else if (state.releaseMode === "discard") {
-        state.client.stopWithoutPersist();
+        await state.client.stopWithoutPersist();
       } else {
         await state.client.stopAndPersist().catch(() => state.client.stopWithoutPersist());
       }

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -15,7 +15,7 @@ const loadMatrixCreateClientDeps = createLazyRuntimeModule(() =>
     createMatrixClient: runtime.createMatrixClient,
   })),
 );
-const MATRIX_TRANSIENT_LEASE_DRAIN_TIMEOUT_MS = 5_000;
+const MATRIX_RETIREMENT_DRAIN_TIMEOUT_MS = 5_000;
 
 export type MatrixClientLeaseRole = "monitor" | "transient";
 export type MatrixClientReleaseMode = "stop" | "persist" | "discard";
@@ -323,26 +323,27 @@ function forceReleaseLeases(
   state.noLeases.resolve();
 }
 
-async function waitForLeaseDrain(state: SharedMatrixClientState): Promise<void> {
-  if (state.leases.size === 0) {
+async function waitForRetirementDrain(params: {
+  state: SharedMatrixClientState;
+  task: Promise<unknown>;
+  isPending: () => boolean;
+  timeoutMessage: string;
+}): Promise<void> {
+  if (!params.isPending()) {
     return;
   }
   let deadline: NodeJS.Timeout | undefined;
   try {
     await Promise.race([
-      state.noLeases.promise,
+      params.task,
       new Promise<never>((_, reject) => {
         deadline = setTimeout(() => {
-          if (state.leases.size === 0) {
+          if (!params.isPending()) {
             return;
           }
-          state.phase = "late-drain";
-          reject(
-            new Error(
-              `Matrix transient leases did not drain within ${MATRIX_TRANSIENT_LEASE_DRAIN_TIMEOUT_MS}ms`,
-            ),
-          );
-        }, MATRIX_TRANSIENT_LEASE_DRAIN_TIMEOUT_MS);
+          params.state.phase = "late-drain";
+          reject(new Error(params.timeoutMessage));
+        }, MATRIX_RETIREMENT_DRAIN_TIMEOUT_MS);
         deadline.unref?.();
       }),
     ]);
@@ -351,6 +352,34 @@ async function waitForLeaseDrain(state: SharedMatrixClientState): Promise<void> 
       clearTimeout(deadline);
     }
   }
+}
+
+async function waitForLeaseDrain(state: SharedMatrixClientState): Promise<void> {
+  await waitForRetirementDrain({
+    state,
+    task: state.noLeases.promise,
+    isPending: () => state.leases.size > 0,
+    timeoutMessage: `Matrix transient leases did not drain within ${MATRIX_RETIREMENT_DRAIN_TIMEOUT_MS}ms`,
+  });
+}
+
+async function continueLateGenerationRetirement(
+  state: SharedMatrixClientState,
+  startup: Promise<void>,
+  monitorLeases: SharedMatrixClientLeaseState[],
+): Promise<void> {
+  await startup.catch(() => undefined);
+  try {
+    await state.client.stopWithoutPersist();
+    state.started = false;
+    await retireMonitorLeases(state, monitorLeases);
+  } catch (error) {
+    state.poisonError = toRetirementError(error);
+    return;
+  }
+  state.phase = "late-drain-stopped";
+  state.startPromise = null;
+  deleteSharedClientStateAfterLateDrain(state);
 }
 
 function beginGenerationRetirement(params: {
@@ -364,9 +393,27 @@ function beginGenerationRetirement(params: {
   state.phase = "quiescing";
   state.retirementPromise = Promise.resolve().then(async () => {
     let poisonDisposition: PoisonDisposition = "replace-after-stop";
-    // Startup owns SDK initialization until its underlying task settles. Joining
-    // it prevents a canceled generation from starting or persisting after stop.
-    await state.startPromise?.catch(() => undefined);
+    const startup = state.startPromise;
+    if (startup) {
+      try {
+        await waitForRetirementDrain({
+          state,
+          task: startup.catch(() => undefined),
+          isPending: () => state.startPromise === startup,
+          timeoutMessage: `Matrix client startup did not settle within ${MATRIX_RETIREMENT_DRAIN_TIMEOUT_MS}ms during retirement`,
+        });
+      } catch (error) {
+        state.poisonError = toRetirementError(error);
+        // The SDK cannot cancel crypto initialization. Keep this generation keyed
+        // and stop it without persistence as soon as the owned startup settles.
+        state.startPromise = continueLateGenerationRetirement(
+          state,
+          startup,
+          params.monitorLeases ?? [],
+        );
+        throw state.poisonError;
+      }
+    }
     try {
       await state.client.quiesceSync();
       state.started = false;
@@ -544,6 +591,9 @@ export async function acquireSharedMatrixClient(
 }
 
 async function forceRetireState(state: SharedMatrixClientState): Promise<void> {
+  if (state.phase === "late-drain" && state.startPromise) {
+    throw state.poisonError ?? new Error("Matrix client generation is still retiring");
+  }
   state.releaseMode = mergeReleaseMode(state.releaseMode, "stop");
   const retirementPromise = beginGenerationRetirement({
     state,
@@ -556,6 +606,9 @@ async function forceRetireState(state: SharedMatrixClientState): Promise<void> {
     return;
   }
   await retirementPromise.catch((error: unknown) => {
+    if (state.phase === "late-drain" && state.startPromise) {
+      throw error;
+    }
     if (!state.poisonError) {
       throw error;
     }

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -6,7 +6,7 @@ import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { CoreConfig } from "../../types.js";
 import type { MatrixClient } from "../sdk.js";
 import { LogService } from "../sdk/logger.js";
-import { awaitMatrixStartupWithAbort } from "../startup-abort.js";
+import { awaitMatrixStartupWithAbort, throwIfMatrixStartupAborted } from "../startup-abort.js";
 import { resolveMatrixAuth, resolveMatrixAuthContext } from "./config.js";
 import type { MatrixAuth } from "./types.js";
 
@@ -171,7 +171,8 @@ async function ensureSharedClientStarted(
       }
     }
 
-    await awaitMatrixStartupWithAbort(state.client.start({ abortSignal }), abortSignal);
+    await state.client.start({ abortSignal });
+    throwIfMatrixStartupAborted(abortSignal);
     state.started = true;
   })();
   const guardedStart = startPromise.finally(() => {
@@ -363,6 +364,9 @@ function beginGenerationRetirement(params: {
   state.phase = "quiescing";
   state.retirementPromise = Promise.resolve().then(async () => {
     let poisonDisposition: PoisonDisposition = "replace-after-stop";
+    // Startup owns SDK initialization until its underlying task settles. Joining
+    // it prevents a canceled generation from starting or persisting after stop.
+    await state.startPromise?.catch(() => undefined);
     try {
       await state.client.quiesceSync();
       state.started = false;

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1532,6 +1532,34 @@ describe("MatrixClient request hardening", () => {
     });
   });
 
+  it("single-flights concurrent shutdown after discard starts", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-sdk-discard-"));
+    clearMatrixSyncApiForNeverStartedClient();
+
+    try {
+      const client = new MatrixClient("https://matrix.example.org", "token", {
+        storageRootDir: tempDir,
+      });
+      const store = lastCreateClientOpts?.store as
+        | { discardPendingSyncCursorPersistence: () => void }
+        | undefined;
+      if (!store) {
+        throw new Error("expected Matrix sync store");
+      }
+      const discardSpy = vi.spyOn(store, "discardPendingSyncCursorPersistence");
+
+      const first = client.stopWithoutPersist();
+      const second = client.stopWithoutPersist();
+      const persist = client.stopAndPersist();
+      await Promise.all([first, second, persist]);
+
+      expect(discardSpy).toHaveBeenCalledTimes(1);
+      expect(matrixJsClient.stopClient).toHaveBeenCalledTimes(1);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("arms and removes the STOPPED waiter around protected classic sync stop", async () => {
     const client = new MatrixClient("https://matrix.example.org", "token");
     await client.start();

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -12,15 +12,21 @@ import { EventStatus } from "matrix-js-sdk/lib/models/event-status.js";
 import { SyncApi, SyncState } from "matrix-js-sdk/lib/sync.js";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 // Matrix tests cover sdk plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { installMatrixTestRuntime } from "../test-runtime.js";
 import type { CoreConfig } from "../types.js";
-import { readMatrixRecoveryKeyStateForPath } from "./crypto-state-store.js";
+import {
+  readMatrixIdbSnapshotJson,
+  readMatrixRecoveryKeyStateForPath,
+} from "./crypto-state-store.js";
 import { MatrixDecryptBridge } from "./sdk/decrypt-bridge.js";
+import { LogService } from "./sdk/logger.js";
 
 const createSharedMatrixClientMock = vi.hoisted(() => vi.fn());
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("./client/create-client.js", () => ({
   createMatrixClient: createSharedMatrixClientMock,
@@ -2042,7 +2048,7 @@ describe("MatrixClient event bridge", () => {
     rejectSdkDecryption?.(new Error("late SDK decryption failure"));
     await Promise.resolve();
     expect(matrixJsClient.stopClient).not.toHaveBeenCalled();
-    client.stopWithoutPersist();
+    await client.stopWithoutPersist();
   });
 
   it("retries failed decryptions immediately on crypto key update signals", async () => {
@@ -2289,7 +2295,7 @@ describe("MatrixClient event bridge", () => {
       expect(encrypted.attemptDecryption).toHaveBeenCalledTimes(1);
       expect(delivered).toEqual(["m.room.message"]);
     } finally {
-      client.stopWithoutPersist();
+      await client.stopWithoutPersist();
     }
   });
 
@@ -2323,7 +2329,7 @@ describe("MatrixClient event bridge", () => {
     await vi.advanceTimersByTimeAsync(200_000);
     expect(encrypted.attemptDecryption).toHaveBeenCalledTimes(8);
 
-    client.stopWithoutPersist();
+    await client.stopWithoutPersist();
     encrypted.attemptDecryption.mockClear();
     encrypted.onAttemptDecryption(() => {
       encrypted.markDecrypted({
@@ -2397,7 +2403,7 @@ describe("MatrixClient event bridge", () => {
       await Promise.resolve();
       expect(delivered).toEqual(["m.room.message"]);
     } finally {
-      client.stopWithoutPersist();
+      await client.stopWithoutPersist();
     }
   });
 
@@ -2576,7 +2582,7 @@ describe("MatrixClient event bridge", () => {
     const client = new MatrixClient("https://matrix.example.org", "token");
 
     await client.start();
-    client.stopWithoutPersist();
+    await client.stopWithoutPersist();
 
     await expect(client.start()).rejects.toThrow(
       "Matrix client has been fully stopped and cannot be restarted; acquire a new shared client generation",
@@ -2978,28 +2984,61 @@ describe("MatrixClient crypto bootstrapping", () => {
     });
   });
 
-  it("schedules periodic crypto snapshot persistence", async () => {
-    const databasesSpy = vi.spyOn(indexedDB, "databases").mockResolvedValue([]);
+  it("awaits and cancels active periodic crypto persistence during discard shutdown", async () => {
+    resetPluginStateStoreForTests();
+    installMatrixTestRuntime();
+    const tempDir = tempDirs.make("matrix-idb-interval-");
+    const pendingDatabases = createDeferred<IDBDatabaseInfo[]>();
+    const databasesSpy = vi
+      .spyOn(indexedDB, "databases")
+      .mockResolvedValueOnce([])
+      .mockReturnValueOnce(pendingDatabases.promise);
     const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const warnSpy = vi.spyOn(LogService, "warn").mockImplementation(() => {});
+    let shutdown: Promise<void> | undefined;
 
-    const client = new MatrixClient("https://matrix.example.org", "token", {
-      encryption: true,
-      idbSnapshotPath: path.join(os.tmpdir(), "matrix-idb-interval.json"),
-      cryptoDatabasePrefix: "openclaw-matrix-interval",
-    });
+    try {
+      const client = new MatrixClient("https://matrix.example.org", "token", {
+        encryption: true,
+        idbSnapshotPath: path.join(tempDir, "crypto-idb-snapshot.json"),
+        cryptoDatabasePrefix: "openclaw-matrix-interval",
+      });
 
-    await client.start();
+      await client.start();
 
-    expect(databasesSpy).toHaveBeenCalled();
-    const intervalCall = setIntervalSpy.mock.calls.find((call) => call[1] === 60_000) as
-      | unknown[]
-      | undefined;
-    if (!intervalCall) {
-      throw new Error("expected Matrix IDB snapshot interval");
+      const intervalCall = setIntervalSpy.mock.calls.find((call) => call[1] === 60_000) as
+        | unknown[]
+        | undefined;
+      if (!intervalCall || typeof intervalCall[0] !== "function") {
+        throw new Error("expected Matrix IDB snapshot interval");
+      }
+      intervalCall[0]();
+      intervalCall[0]();
+      await vi.waitFor(() => {
+        expect(databasesSpy).toHaveBeenCalledTimes(2);
+      });
+
+      shutdown = Promise.resolve(client.stopWithoutPersist());
+      let shutdownSettled = false;
+      void shutdown.then(() => {
+        shutdownSettled = true;
+      });
+      await vi.waitFor(() => {
+        expect(matrixJsClient.stopClient).toHaveBeenCalledTimes(1);
+      });
+      expect(shutdownSettled).toBe(false);
+
+      pendingDatabases.resolve([]);
+      await shutdown;
+      expect(readMatrixIdbSnapshotJson(tempDir)).toBeNull();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      pendingDatabases.resolve([]);
+      await shutdown?.catch(() => undefined);
+      warnSpy.mockRestore();
+      databasesSpy.mockRestore();
+      setIntervalSpy.mockRestore();
     }
-    expect(intervalCall[0]).toBeTypeOf("function");
-    expect(intervalCall[1]).toBe(60_000);
-    client.stop();
   });
 
   it("reports own verification status when crypto marks device as verified", async () => {

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -2648,9 +2648,8 @@ describe("MatrixClient crypto bootstrapping", () => {
     const tempDir = tempDirs.make("matrix-idb-startup-abort-");
     const databasePrefix = "openclaw-matrix-startup-abort";
     const initCrypto = createDeferred<void>();
-    const pendingDatabases = createDeferred<IDBDatabaseInfo[]>();
     matrixJsClient.initRustCrypto.mockReturnValue(initCrypto.promise);
-    const databasesSpy = vi.spyOn(indexedDB, "databases").mockReturnValue(pendingDatabases.promise);
+    const databasesSpy = vi.spyOn(indexedDB, "databases");
     const abortController = new AbortController();
 
     try {
@@ -2664,25 +2663,17 @@ describe("MatrixClient crypto bootstrapping", () => {
       await vi.waitFor(() => {
         expect(matrixJsClient.initRustCrypto).toHaveBeenCalledTimes(1);
       });
-      initCrypto.resolve();
-      await vi.waitFor(() => {
-        expect(databasesSpy).toHaveBeenCalledTimes(1);
-      });
-
       abortController.abort();
-      pendingDatabases.resolve([
-        {
-          name: `${databasePrefix}::matrix-sdk-crypto`,
-          version: 1,
-        },
-      ]);
+      expect(matrixJsClient.startClient).not.toHaveBeenCalled();
+      expect(databasesSpy).not.toHaveBeenCalled();
 
+      initCrypto.resolve();
       await expectAbortError(startup);
       expect(readMatrixIdbSnapshotJson(tempDir)).toBeNull();
+      expect(databasesSpy).not.toHaveBeenCalled();
       expect(matrixJsClient.startClient).not.toHaveBeenCalled();
     } finally {
       initCrypto.resolve();
-      pendingDatabases.resolve([]);
       databasesSpy.mockRestore();
       await clearAllIndexedDbState({ databasePrefix });
       resetPluginStateStoreForTests();

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -23,6 +23,7 @@ import {
   readMatrixRecoveryKeyStateForPath,
 } from "./crypto-state-store.js";
 import { MatrixDecryptBridge } from "./sdk/decrypt-bridge.js";
+import { clearAllIndexedDbState } from "./sdk/idb-persistence.test-helpers.js";
 import { LogService } from "./sdk/logger.js";
 
 const createSharedMatrixClientMock = vi.hoisted(() => vi.fn());
@@ -2639,6 +2640,53 @@ describe("MatrixClient crypto bootstrapping", () => {
     expect(matrixJsClient.initRustCrypto).toHaveBeenCalledWith({
       cryptoDatabasePrefix: "openclaw-matrix-test",
     });
+  });
+
+  it("does not persist or start sync when startup aborts during crypto initialization", async () => {
+    resetPluginStateStoreForTests();
+    installMatrixTestRuntime();
+    const tempDir = tempDirs.make("matrix-idb-startup-abort-");
+    const databasePrefix = "openclaw-matrix-startup-abort";
+    const initCrypto = createDeferred<void>();
+    const pendingDatabases = createDeferred<IDBDatabaseInfo[]>();
+    matrixJsClient.initRustCrypto.mockReturnValue(initCrypto.promise);
+    const databasesSpy = vi.spyOn(indexedDB, "databases").mockReturnValue(pendingDatabases.promise);
+    const abortController = new AbortController();
+
+    try {
+      const client = new MatrixClient("https://matrix.example.org", "token", {
+        encryption: true,
+        idbSnapshotPath: path.join(tempDir, "crypto-idb-snapshot.json"),
+        cryptoDatabasePrefix: databasePrefix,
+      });
+      const startup = client.start({ abortSignal: abortController.signal });
+
+      await vi.waitFor(() => {
+        expect(matrixJsClient.initRustCrypto).toHaveBeenCalledTimes(1);
+      });
+      initCrypto.resolve();
+      await vi.waitFor(() => {
+        expect(databasesSpy).toHaveBeenCalledTimes(1);
+      });
+
+      abortController.abort();
+      pendingDatabases.resolve([
+        {
+          name: `${databasePrefix}::matrix-sdk-crypto`,
+          version: 1,
+        },
+      ]);
+
+      await expectAbortError(startup);
+      expect(readMatrixIdbSnapshotJson(tempDir)).toBeNull();
+      expect(matrixJsClient.startClient).not.toHaveBeenCalled();
+    } finally {
+      initCrypto.resolve();
+      pendingDatabases.resolve([]);
+      databasesSpy.mockRestore();
+      await clearAllIndexedDbState({ databasePrefix });
+      resetPluginStateStoreForTests();
+    }
   });
 
   it("bootstraps cross-signing with setupNewCrossSigning enabled", async () => {

--- a/extensions/matrix/src/matrix/sdk/client-base.ts
+++ b/extensions/matrix/src/matrix/sdk/client-base.ts
@@ -276,25 +276,6 @@ export abstract class MatrixClientBase {
 
   protected idbPersistTimer: ReturnType<typeof setInterval> | null = null;
 
-  private startPeriodicIdbPersist(persistIdbToDisk: MatrixCryptoRuntime["persistIdbToDisk"]): void {
-    if (this.idbPersistPromise) {
-      return;
-    }
-    const abortController = new AbortController();
-    const persistPromise = persistIdbToDisk({
-      snapshotPath: this.idbSnapshotPath,
-      databasePrefix: this.cryptoDatabasePrefix,
-      abortSignal: abortController.signal,
-    })
-      .catch(noop)
-      .finally(() => {
-        this.idbPersistPromise = null;
-        this.idbPersistAbortController = null;
-      });
-    this.idbPersistAbortController = abortController;
-    this.idbPersistPromise = persistPromise;
-  }
-
   protected async ensureCryptoSupportInitialized(): Promise<void> {
     if (
       this.decryptBridge &&
@@ -630,27 +611,17 @@ export abstract class MatrixClientBase {
   }
 
   async stopAndPersist(): Promise<void> {
-    if (!this.stopPersistPromise) {
-      const stopPromise = this.stopClientGeneration(true);
-      const guardedStop = stopPromise.catch((error: unknown) => {
-        if (this.stopPersistPromise === guardedStop) {
-          this.stopPersistPromise = null;
-        }
-        throw error;
-      });
-      this.stopPersistPromise = guardedStop;
-    }
+    this.stopPersistPromise ??= this.stopClientGeneration(true);
     await this.stopPersistPromise;
   }
 
   async stopWithoutPersist(): Promise<void> {
-    if (this.stopPersistPromise) {
-      try {
-        await this.stopPersistPromise;
-        return;
-      } catch {
-        // A failed durable stop still requires non-persisting cleanup.
-      }
+    const alreadyStopped = await this.stopPersistPromise?.then(
+      () => true,
+      () => false,
+    );
+    if (alreadyStopped) {
+      return;
     }
     this.stopPersistPromise = this.stopClientGeneration(false);
     await this.stopPersistPromise;
@@ -737,7 +708,21 @@ export abstract class MatrixClientBase {
 
       // Periodically persist to capture new Olm sessions and room keys.
       this.idbPersistTimer = setInterval(() => {
-        this.startPeriodicIdbPersist(persistIdbToDisk);
+        if (this.idbPersistPromise) {
+          return;
+        }
+        const abortController = new AbortController();
+        this.idbPersistAbortController = abortController;
+        this.idbPersistPromise = persistIdbToDisk({
+          snapshotPath: this.idbSnapshotPath,
+          databasePrefix: this.cryptoDatabasePrefix,
+          abortSignal: abortController.signal,
+        })
+          .catch(noop)
+          .finally(() => {
+            this.idbPersistPromise = null;
+            this.idbPersistAbortController = null;
+          });
       }, MATRIX_IDB_PERSIST_INTERVAL_MS);
       this.idbPersistTimer.unref?.();
     } catch (err) {

--- a/extensions/matrix/src/matrix/sdk/client-base.ts
+++ b/extensions/matrix/src/matrix/sdk/client-base.ts
@@ -148,6 +148,8 @@ export abstract class MatrixClientBase {
   protected transactionScopePromise: Promise<string> | null = null;
   private readonly messageWireDispatchGuards = new Map<string, MatrixMessageWireDispatchGuard>();
   private sdkStopped = false;
+  private idbPersistPromise: Promise<void> | null = null;
+  private idbPersistAbortController: AbortController | null = null;
 
   readonly dms = {
     update: async (): Promise<boolean> => {
@@ -273,6 +275,25 @@ export abstract class MatrixClientBase {
   }
 
   protected idbPersistTimer: ReturnType<typeof setInterval> | null = null;
+
+  private startPeriodicIdbPersist(persistIdbToDisk: MatrixCryptoRuntime["persistIdbToDisk"]): void {
+    if (this.idbPersistPromise) {
+      return;
+    }
+    const abortController = new AbortController();
+    const persistPromise = persistIdbToDisk({
+      snapshotPath: this.idbSnapshotPath,
+      databasePrefix: this.cryptoDatabasePrefix,
+      abortSignal: abortController.signal,
+    })
+      .catch(noop)
+      .finally(() => {
+        this.idbPersistPromise = null;
+        this.idbPersistAbortController = null;
+      });
+    this.idbPersistAbortController = abortController;
+    this.idbPersistPromise = persistPromise;
+  }
 
   protected async ensureCryptoSupportInitialized(): Promise<void> {
     if (
@@ -547,10 +568,6 @@ export abstract class MatrixClientBase {
     if (this.sdkStopped) {
       return;
     }
-    if (this.idbPersistTimer) {
-      clearInterval(this.idbPersistTimer);
-      this.idbPersistTimer = null;
-    }
     this.currentSyncState = null;
     this.currentSyncError = undefined;
     this.client.stopClient();
@@ -583,15 +600,23 @@ export abstract class MatrixClientBase {
       .catch(noop);
   }
 
-  async stopAndPersist(): Promise<void> {
-    if (this.stopPersistPromise) {
-      await this.stopPersistPromise;
-      return;
-    }
-    this.stopPersistPromise = (async () => {
+  private async stopClientGeneration(persist: boolean): Promise<void> {
+    if (persist) {
       await this.quiesceSync();
-      this.stopSdkClient();
-      this.decryptBridge?.stop();
+    } else {
+      await this.quiesceSync().catch(noop);
+      this.syncStore?.discardPendingSyncCursorPersistence();
+    }
+    if (this.idbPersistTimer) {
+      clearInterval(this.idbPersistTimer);
+      this.idbPersistTimer = null;
+    }
+    this.idbPersistAbortController?.abort();
+    const activePeriodicPersist = this.idbPersistPromise;
+    this.stopSdkClient();
+    this.decryptBridge?.stop();
+    await activePeriodicPersist;
+    if (persist) {
       const runtime = loadedMatrixCryptoRuntime ?? (await loadMatrixCryptoRuntime());
       await runtime.persistIdbToDisk({
         snapshotPath: this.idbSnapshotPath,
@@ -600,15 +625,34 @@ export abstract class MatrixClientBase {
       });
       this.syncStore?.markCleanShutdown();
       await this.syncStore?.flush();
-    })();
+    }
+  }
+
+  async stopAndPersist(): Promise<void> {
+    if (!this.stopPersistPromise) {
+      const stopPromise = this.stopClientGeneration(true);
+      const guardedStop = stopPromise.catch((error: unknown) => {
+        if (this.stopPersistPromise === guardedStop) {
+          this.stopPersistPromise = null;
+        }
+        throw error;
+      });
+      this.stopPersistPromise = guardedStop;
+    }
     await this.stopPersistPromise;
   }
 
-  stopWithoutPersist(): void {
-    this.syncStore?.discardPendingSyncCursorPersistence();
-    this.stopSdkClient();
-    this.decryptBridge?.stop();
-    this.stopPersistPromise = Promise.resolve();
+  async stopWithoutPersist(): Promise<void> {
+    if (this.stopPersistPromise) {
+      try {
+        await this.stopPersistPromise;
+        return;
+      } catch {
+        // A failed durable stop still requires non-persisting cleanup.
+      }
+    }
+    this.stopPersistPromise = this.stopClientGeneration(false);
+    await this.stopPersistPromise;
   }
 
   protected async bootstrapCryptoIfNeeded(abortSignal?: AbortSignal): Promise<void> {
@@ -691,10 +735,7 @@ export abstract class MatrixClientBase {
 
       // Periodically persist to capture new Olm sessions and room keys.
       this.idbPersistTimer = setInterval(() => {
-        persistIdbToDisk({
-          snapshotPath: this.idbSnapshotPath,
-          databasePrefix: this.cryptoDatabasePrefix,
-        }).catch(noop);
+        this.startPeriodicIdbPersist(persistIdbToDisk);
       }, MATRIX_IDB_PERSIST_INTERVAL_MS);
       this.idbPersistTimer.unref?.();
     } catch (err) {

--- a/extensions/matrix/src/matrix/sdk/client-base.ts
+++ b/extensions/matrix/src/matrix/sdk/client-base.ts
@@ -148,6 +148,7 @@ export abstract class MatrixClientBase {
   protected transactionScopePromise: Promise<string> | null = null;
   private readonly messageWireDispatchGuards = new Map<string, MatrixMessageWireDispatchGuard>();
   private sdkStopped = false;
+  private stopDiscardPromise: Promise<void> | null = null;
   private idbPersistPromise: Promise<void> | null = null;
   private idbPersistAbortController: AbortController | null = null;
 
@@ -615,16 +616,14 @@ export abstract class MatrixClientBase {
     await this.stopPersistPromise;
   }
 
-  async stopWithoutPersist(): Promise<void> {
-    const alreadyStopped = await this.stopPersistPromise?.then(
-      () => true,
-      () => false,
-    );
-    if (alreadyStopped) {
-      return;
+  stopWithoutPersist(): Promise<void> {
+    // Memoization closes concurrent callers; durable failure still requires discard cleanup.
+    if (!this.stopPersistPromise) {
+      this.stopPersistPromise = this.stopDiscardPromise = this.stopClientGeneration(false);
     }
-    this.stopPersistPromise = this.stopClientGeneration(false);
-    await this.stopPersistPromise;
+    return (this.stopDiscardPromise ??= this.stopPersistPromise.catch(() =>
+      this.stopClientGeneration(false),
+    ));
   }
 
   protected async bootstrapCryptoIfNeeded(abortSignal?: AbortSignal): Promise<void> {

--- a/extensions/matrix/src/matrix/sdk/client-base.ts
+++ b/extensions/matrix/src/matrix/sdk/client-base.ts
@@ -515,6 +515,7 @@ export abstract class MatrixClientBase {
     throwIfMatrixStartupAborted(opts.abortSignal);
     this.registerBridge();
     await this.initializeCryptoIfNeeded(opts.abortSignal);
+    throwIfMatrixStartupAborted(opts.abortSignal);
 
     await this.client.startClient({
       initialSyncLimit: this.initialSyncLimit,
@@ -730,6 +731,7 @@ export abstract class MatrixClientBase {
       await persistIdbToDisk({
         snapshotPath: this.idbSnapshotPath,
         databasePrefix: this.cryptoDatabasePrefix,
+        abortSignal,
       });
       throwIfMatrixStartupAborted(abortSignal);
 
@@ -739,6 +741,7 @@ export abstract class MatrixClientBase {
       }, MATRIX_IDB_PERSIST_INTERVAL_MS);
       this.idbPersistTimer.unref?.();
     } catch (err) {
+      throwIfMatrixStartupAborted(abortSignal);
       LogService.warn("MatrixClientLite", "Failed to initialize rust crypto:", err);
     }
   }

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.test.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.test.ts
@@ -3,6 +3,7 @@ import "fake-indexeddb/auto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { resetFileLockStateForTest } from "openclaw/plugin-sdk/file-lock";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -180,6 +181,40 @@ describe("Matrix IndexedDB persistence", () => {
         }),
       ).rejects.toBe(cause);
     } finally {
+      databasesSpy.mockRestore();
+    }
+  });
+
+  it("cancels an active snapshot before writing without warning", async () => {
+    const snapshotPath = path.join(tmpDir, "crypto-idb-snapshot.json");
+    await seedDatabase({
+      name: cryptoDatabaseName,
+      storeName: "sessions",
+      records: [{ key: "room-1", value: { session: "abc123" } }],
+    });
+    const databaseList = await indexedDB.databases();
+    const pendingDatabases = createDeferred<IDBDatabaseInfo[]>();
+    const databasesSpy = vi.spyOn(indexedDB, "databases").mockReturnValue(pendingDatabases.promise);
+    const abortController = new AbortController();
+
+    try {
+      const persistence = persistIdbToDisk({
+        snapshotPath,
+        databasePrefix: DATABASE_PREFIX,
+        abortSignal: abortController.signal,
+      });
+      await vi.waitFor(() => {
+        expect(databasesSpy).toHaveBeenCalledTimes(1);
+      });
+
+      abortController.abort();
+      pendingDatabases.resolve(databaseList);
+
+      await expect(persistence).resolves.toBeUndefined();
+      expect(readMatrixIdbSnapshotJson(tmpDir)).toBeNull();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      pendingDatabases.resolve(databaseList);
       databasesSpy.mockRestore();
     }
   });

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.ts
@@ -307,6 +307,7 @@ export async function persistIdbToDisk(params?: {
   snapshotPath?: string;
   databasePrefix?: string;
   strict?: boolean;
+  abortSignal?: AbortSignal;
 }): Promise<void> {
   const snapshotPath = params?.snapshotPath ?? resolveDefaultIdbSnapshotPath();
   let callbackStarted = false;
@@ -330,7 +331,7 @@ export async function persistIdbToDisk(params?: {
         }
         throwIfLegacySnapshotNeedsDoctor(snapshotPath, storedSnapshotJson);
         const snapshot = await dumpIndexedDatabases(params?.databasePrefix);
-        if (snapshot.length === 0) {
+        if (params?.abortSignal?.aborted || snapshot.length === 0) {
           return 0;
         }
         writeMatrixIdbSnapshotJson({

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client-internals.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client-internals.ts
@@ -39,15 +39,15 @@ export function createMatrixQaE2eeClientLifecycle(params: {
   drainPendingDecryptions: () => Promise<void>;
   shutdownTimeoutMs: number;
   stopAndPersist: () => Promise<void>;
-  stopWithoutPersist: () => void;
+  stopWithoutPersist: () => Promise<void>;
 }) {
   const activeOperations = new Set<Promise<unknown>>();
   let shutdownStarted = false;
   let stopPromise: Promise<void> | undefined;
 
-  const failShutdown = (phase: string, cause: unknown): never => {
+  const failShutdown = async (phase: string, cause: unknown): Promise<never> => {
     try {
-      params.stopWithoutPersist();
+      await params.stopWithoutPersist();
     } catch {
       // Preserve the lifecycle failure that explains why persistence was skipped.
     }
@@ -70,17 +70,15 @@ export function createMatrixQaE2eeClientLifecycle(params: {
           Promise.allSettled(activeOperations),
           graceMs,
           "active Matrix SDK operations did not settle before shutdown",
-        ).catch((error: unknown) => {
-          failShutdown("waiting for active Matrix SDK operations", error);
-        });
+        ).catch((error: unknown) =>
+          failShutdown("waiting for active Matrix SDK operations", error),
+        );
       }
       await withMatrixQaE2eeTimeout(
         params.drainPendingDecryptions(),
         Math.max(0, deadline - Date.now()),
         "pending Matrix decryptions did not drain before shutdown",
-      ).catch((error: unknown) => {
-        failShutdown("draining pending Matrix decryptions", error);
-      });
+      ).catch((error: unknown) => failShutdown("draining pending Matrix decryptions", error));
       await params.stopAndPersist();
     })();
     return stopPromise;

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.test.ts
@@ -21,6 +21,7 @@ const testing = {
 
 describe("matrix qa e2ee client storage", () => {
   function createLifecycleFixture(options?: {
+    discard?: () => Promise<void>;
     drain?: () => Promise<void>;
     shutdownTimeoutMs?: number;
   }) {
@@ -35,7 +36,10 @@ describe("matrix qa e2ee client storage", () => {
       stopAndPersist: vi.fn(async () => {
         calls.push("stop-and-persist");
       }),
-      stopWithoutPersist: vi.fn(() => calls.push("stop-and-discard")),
+      stopWithoutPersist: vi.fn(async () => {
+        calls.push("stop-and-discard");
+        await options?.discard?.();
+      }),
     });
     return { calls, lifecycle };
   }
@@ -100,7 +104,12 @@ describe("matrix qa e2ee client storage", () => {
   it("discards without persisting when active operation grace expires", async () => {
     vi.useFakeTimers();
     try {
+      let finishDiscard: (() => void) | undefined;
       const { calls, lifecycle } = createLifecycleFixture({
+        discard: () =>
+          new Promise<void>((resolve) => {
+            finishDiscard = resolve;
+          }),
         shutdownTimeoutMs: 100,
       });
       void lifecycle.runOperation({
@@ -118,8 +127,16 @@ describe("matrix qa e2ee client storage", () => {
 
       await vi.advanceTimersByTimeAsync(100);
 
-      await rejection;
+      let rejected = false;
+      void stop.catch(() => {
+        rejected = true;
+      });
+      await Promise.resolve();
+      expect(rejected).toBe(false);
       expect(calls).toEqual(["operation", "detach", "stop-and-discard"]);
+
+      finishDiscard?.();
+      await rejection;
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/120168

## What Problem This Solves

Fixes Matrix shutdown races where client startup, monitor cleanup, encrypted-state persistence, SDK discard, or QA discard cleanup could outlive the generation that owned them. It also keeps caller-visible shutdown bounded when `matrix-js-sdk` crypto initialization never settles.

## Why This Change Was Made

Generation retirement had overlapping deletion and late-drain state machines. Late lease release and forced retirement could delete a keyed generation independently of the retirement owner, persistence failure could surface before discard fallback settled, and `stopWithoutPersist()` could yield before claiming its shutdown flight.

`beginGenerationRetirement()` is now the sole generation-deletion owner:

- a startup timeout rejects the caller after five seconds while the keyed, non-admitting generation continues to own startup settlement, monitor retirement, original leases, and SDK discard;
- late release only resolves lease drainage;
- repeated forced retirement rejects during `late-drain`, otherwise joins the active owner and never deletes directly;
- monitor, normal discard, final-drain discard, or persistence-fallback failure retains the poisoned key;
- strict persistence failure awaits discard fallback; successful fallback deletes and then surfaces the persistence error, while failed fallback retains and surfaces the discard error;
- `stopWithoutPersist()` synchronously single-flights discard-first, persist-first, and mixed concurrent shutdown through the existing stop flight plus one private fallback promise.

The existing periodic persistence owner fix, post-abort SDK/persistence fences, and QA asynchronous discard handling remain intact.

## User Impact

Matrix shutdown cannot admit a replacement over unresolved startup, monitor work, transient borrowers, or SDK discard. Failed cleanup remains visibly poisoned instead of silently replacing the client. No configuration or workflow changes.

## Evidence

- Exact head: `81fdd67f5d7d2a9ba2ef892589c1273a3a82b3d1`.
- Repair parent: `9295072c2dec01d79e8ae2c875a779abf3b53ff9`; no rebase was performed.
- Branch merge base: `5ac1b3c558f6826e636203a9b27273801d6f9fae`.
- Current `origin/main`: `df9b7a5fbe9b94b0ab25dc404db7784797feadca`.
- Read-only merge-tree against current main succeeds. `d2052167ec8088e1bed53d0162b71a149247103b` / #128907 transfers replay-claim ownership inside already tracked Matrix handlers without changing monitor task admission, listener detachment, task waiting, cleanup registration, or this repair's write scope. The subsequent `df9b7a5fbe9b` commit is UI-only. No rebase is required.

Owner proof:

- `extensions/matrix/src/matrix/client/shared.ts` has one authoritative retirement flow and only `beginGenerationRetirement()` decides whether the keyed generation can be deleted.
- Late lease release only resolves ownership drainage. Forced retirement never deletes and rethrows while the same failed state remains keyed.
- Startup timeout keeps the generation fenced while startup settlement, monitor retirement, lease drainage, and SDK discard are observed independently.
- `extensions/matrix/src/matrix/sdk/client-base.ts` synchronously claims one stop flight and awaits any failed-persistence discard fallback.

Direct dependency proof from pinned `matrix-js-sdk@41.9.0` source and types:

- `startClient()` starts sync and services without an `AbortSignal`;
- `initRustCrypto()` exposes no cancellation or timeout;
- `stopClient()` is synchronous and stops an initialized crypto backend even when startup was incomplete;
- the SDK warns that multiple clients connected to the same IndexedDB can corrupt crypto state, which is why replacement admission must remain fenced until retirement owns a terminal outcome.

Validation:

- Focused Matrix owner/SDK/persistence tests: **183/183 passed**.
- Focused QA lifecycle tests: **12/12 passed**.
- Seven regressions failed on parent head `9295072c2dec` and now cover late-release deletion ownership, repeated forced late-drain retirement, normal discard failure retention, strict persistence fallback joining, failed fallback retention, final-drain discard failure retention, and mixed shutdown single-flight.
- Existing regressions continue to cover live startup joining, bounded stuck startup, immediate monitor admission closure, monitor cleanup despite late discard rejection, abort while `initRustCrypto()` is pending, periodic persistence cancellation/awaiting, and QA deferred discard.
- Extension production/test types, changed-file lint, formatting, package/plugin boundaries, doctor contracts, dependency pins, database-first/runtime-sidecar/import-cycle guards, and `git diff --check` passed.
- Exact-head independent review and final structured P0/P1 autoreview are clean.
- Pre-ready exact-head CI completed with 83 successful/skipped checks and no attention items.
- Deleted-symbol scan has zero matches for `late-drain-stopped`, `PoisonDisposition`, `deleteSharedClientStateAfterLateDrain`, `continueLateGenerationRetirement`, and `StopOutcome`.

Live-smoke infeasibility: no authenticated Matrix credentials or accessible E2EE room are available in this execution environment, so a real homeserver/WASM shutdown-restart smoke cannot be performed. Mock lifecycle coverage plus direct `matrix-js-sdk@41.9.0` source/type contract inspection is the best available proof.

## Judged LOC

- Production: +158/-110, **net +48**. The growth owns bounded retirement, poison retention, and dependency-required stop fencing at the generation lifecycle owner.
- Tests/test support: +424/-56, net +368.
- Final repair cycle: production +72/-96, net -24; tests +106/-35, net +71.

## Release Note

Fix Matrix shutdown so unresolved startup, monitor ownership, encrypted-state persistence, and asynchronous discard cleanup cannot outlive or prematurely replace their client generation.
