### PR TITLE
fix(google): retain provider-returned response model

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -863,6 +863,8 @@ describe("google transport stream", () => {
   ])(
     "retains the concrete provider-returned model only when it actually differs ($provider, $requested)",
     async ({ provider, requested, returned, expected }) => {
+      vi.stubEnv("GOOGLE_CLOUD_PROJECT", "fixture-google-project");
+      vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
       guardedFetchMock.mockResolvedValueOnce(
         buildSseResponse(
           returned.map((modelVersion, index) => ({
@@ -898,8 +900,6 @@ describe("google transport stream", () => {
           { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
           {
             apiKey: "fixture-google-api-key",
-            project: "fixture-google-project",
-            location: "global",
           },
         ),
       );
@@ -936,6 +936,8 @@ describe("google transport stream", () => {
   ])(
     "keeps the registered $provider model identity across actual localhost HTTP SSE",
     async ({ provider, requested, returned, expected }) => {
+      vi.stubEnv("GOOGLE_CLOUD_PROJECT", "fixture-google-project");
+      vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
       const observedRequests: Array<{ method?: string; url?: string }> = [];
       const server = createServer((request, response) => {
         observedRequests.push({ method: request.method, url: request.url });
@@ -989,8 +991,6 @@ describe("google transport stream", () => {
             { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
             {
               apiKey: "fixture-google-api-key",
-              project: "fixture-google-project",
-              location: "global",
             },
           ),
         );

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -850,6 +850,41 @@ describe("google transport stream", () => {
       returned: ["gemini-2.5-pro"],
     },
     {
+      provider: "google-vertex",
+      requested: "gemini-2.5-pro",
+      returned: ["publishers/google/models/gemini-2.5-pro"],
+    },
+    {
+      provider: "google-vertex",
+      requested: "gemini-2.5-pro",
+      returned: [
+        "projects/fixture-project/locations/global/publishers/google/models/gemini-2.5-pro",
+      ],
+    },
+    {
+      provider: "google-vertex",
+      requested: "publishers/google/models/gemini-2.5-pro",
+      returned: ["gemini-2.5-pro"],
+    },
+    {
+      provider: "google-vertex",
+      requested:
+        "projects/fixture-project/locations/global/publishers/google/models/gemini-2.5-pro",
+      returned: ["gemini-2.5-pro"],
+    },
+    {
+      provider: "google-vertex",
+      requested: "gemini-2.5-pro",
+      returned: ["publishers/meta/models/gemini-2.5-pro"],
+      expected: "publishers/meta/models/gemini-2.5-pro",
+    },
+    {
+      provider: "google-vertex",
+      requested: "gemini-2.5-pro",
+      returned: ["tunedModels/gemini-2.5-pro"],
+      expected: "tunedModels/gemini-2.5-pro",
+    },
+    {
       provider: "google",
       requested: "gemini-2.5-pro",
       returned: [undefined, "", "   "],
@@ -932,6 +967,16 @@ describe("google transport stream", () => {
       provider: "google",
       requested: "models/gemini-2.5-pro",
       returned: "gemini-2.5-pro",
+    },
+    {
+      provider: "google-vertex",
+      requested: "gemini-2.5-pro",
+      returned: "publishers/google/models/gemini-2.5-pro",
+    },
+    {
+      provider: "google-vertex",
+      requested: "gemini-2.5-pro",
+      returned: "projects/fixture-project/locations/global/publishers/google/models/gemini-2.5-pro",
     },
   ])(
     "keeps the registered $provider model identity across actual localhost HTTP SSE",

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -803,6 +803,221 @@ describe("google transport stream", () => {
 
   it.each([
     {
+      provider: "google",
+      requested: "gemini-2.5-pro",
+      returned: ["gemini-2.5-pro-002"],
+      expected: "gemini-2.5-pro-002",
+    },
+    {
+      provider: "google-vertex",
+      requested: "gemini-2.5-pro",
+      returned: ["gemini-2.5-pro-002"],
+      expected: "gemini-2.5-pro-002",
+    },
+    {
+      provider: "google",
+      requested: "gemini-2.5-pro",
+      returned: ["gemini-2.5-pro"],
+    },
+    {
+      provider: "google",
+      requested: "google/gemini-2.5-pro",
+      returned: ["gemini-2.5-pro"],
+    },
+    {
+      provider: "google",
+      requested: "models/gemini-2.5-pro",
+      returned: ["gemini-2.5-pro"],
+    },
+    {
+      provider: "google",
+      requested: "gemini-2.5-pro",
+      returned: ["models/gemini-2.5-pro"],
+    },
+    {
+      provider: "google",
+      requested: "gemini-2.5-pro",
+      returned: ["google/gemini-2.5-pro"],
+    },
+    {
+      provider: "google",
+      requested: "tunedModels/fixture-gemini",
+      returned: ["tunedModels/fixture-gemini"],
+    },
+    {
+      provider: "google-vertex",
+      requested: "google/gemini-2.5-pro",
+      returned: ["gemini-2.5-pro"],
+    },
+    {
+      provider: "google",
+      requested: "gemini-2.5-pro",
+      returned: [undefined, "", "   "],
+    },
+    {
+      provider: "google",
+      requested: "gemini-2.5-pro",
+      returned: ["", "gemini-2.5-pro-002", "gemini-2.5-pro-003"],
+      expected: "gemini-2.5-pro-002",
+    },
+  ])(
+    "retains the concrete provider-returned model only when it actually differs ($provider, $requested)",
+    async ({ provider, requested, returned, expected }) => {
+      guardedFetchMock.mockResolvedValueOnce(
+        buildSseResponse(
+          returned.map((modelVersion, index) => ({
+            ...(modelVersion === undefined ? {} : { modelVersion }),
+            ...(index === returned.length - 1
+              ? {
+                  responseId: "actual-google-response",
+                  candidates: [
+                    { content: { parts: [{ text: "actual response" }] }, finishReason: "STOP" },
+                  ],
+                }
+              : {}),
+          })),
+        ),
+      );
+
+      const model =
+        provider === "google"
+          ? buildGeminiModel({ id: requested })
+          : buildGoogleVertexModel({ id: requested });
+      const { buildGoogleProvider } = await import("./provider-registration.js");
+      const streamFn = buildGoogleProvider().createStreamFn?.({
+        provider,
+        modelId: requested,
+        model,
+      });
+      if (!streamFn) {
+        throw new Error(`Missing registered ${provider} stream`);
+      }
+      const stream = await Promise.resolve(
+        streamFn(
+          model,
+          { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+          {
+            apiKey: "fixture-google-api-key",
+            project: "fixture-google-project",
+            location: "global",
+          },
+        ),
+      );
+      const result = await stream.result();
+
+      expect(result.responseId).toBe("actual-google-response");
+      expect(result.stopReason).toBe("stop");
+      if (expected) {
+        expect(result.responseModel).toBe(expected);
+      } else {
+        expect(result).not.toHaveProperty("responseModel");
+      }
+    },
+  );
+
+  it.each([
+    {
+      provider: "google",
+      requested: "google/gemini-2.5-pro",
+      returned: "gemini-2.5-pro-002",
+      expected: "gemini-2.5-pro-002",
+    },
+    {
+      provider: "google-vertex",
+      requested: "google/gemini-2.5-pro",
+      returned: "gemini-2.5-pro-002",
+      expected: "gemini-2.5-pro-002",
+    },
+    {
+      provider: "google",
+      requested: "models/gemini-2.5-pro",
+      returned: "gemini-2.5-pro",
+    },
+  ])(
+    "keeps the registered $provider model identity across actual localhost HTTP SSE",
+    async ({ provider, requested, returned, expected }) => {
+      const observedRequests: Array<{ method?: string; url?: string }> = [];
+      const server = createServer((request, response) => {
+        observedRequests.push({ method: request.method, url: request.url });
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        response.end(
+          `data: ${JSON.stringify({
+            responseId: "loopback-google-response",
+            modelVersion: returned,
+            candidates: [
+              { content: { parts: [{ text: "actual response" }] }, finishReason: "STOP" },
+            ],
+          })}\n\ndata: [DONE]\n\n`,
+        );
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+          server.off("error", reject);
+          resolve();
+        });
+      });
+
+      try {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("Missing Google loopback server address");
+        }
+        buildGuardedModelFetchMock.mockReturnValue(fetch);
+        const model =
+          provider === "google"
+            ? buildGeminiModel({
+                id: requested,
+                baseUrl: `http://127.0.0.1:${address.port}/v1beta`,
+              })
+            : buildGoogleVertexModel({
+                id: requested,
+                baseUrl: `http://127.0.0.1:${address.port}`,
+              });
+        const { buildGoogleProvider } = await import("./provider-registration.js");
+        const streamFn = buildGoogleProvider().createStreamFn?.({
+          provider,
+          modelId: requested,
+          model,
+        });
+        if (!streamFn) {
+          throw new Error(`Missing registered ${provider} stream`);
+        }
+        const stream = await Promise.resolve(
+          streamFn(
+            model,
+            { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+            {
+              apiKey: "fixture-google-api-key",
+              project: "fixture-google-project",
+              location: "global",
+            },
+          ),
+        );
+        const result = await stream.result();
+
+        expect(observedRequests).toEqual([
+          { method: "POST", url: expect.stringContaining(":streamGenerateContent?alt=sse") },
+        ]);
+        expect(result).toMatchObject({
+          responseId: "loopback-google-response",
+          stopReason: "stop",
+        });
+        if (expected) {
+          expect(result.responseModel).toBe(expected);
+        } else {
+          expect(result).not.toHaveProperty("responseModel");
+        }
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
+
+  it.each([
+    {
       name: "includes billed tool-result prompt tokens in input accounting",
       usageMetadata: {
         promptTokenCount: 10,

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -121,6 +121,9 @@ type GoogleVideoSlots = Map<Record<string, unknown>, VideoContent>;
 const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_DEFAULT_MS = 45_000;
 const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_ENV = "OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS";
 const GOOGLE_SSE_EVENT_BOUNDARY_RE = /(?:\r\n|\r(?!\n)|\n){2}/u;
+// Compare Google-owned publisher resources without changing outbound request paths.
+const GOOGLE_VERTEX_MODEL_RESOURCE_PREFIX =
+  /^(?:projects\/[^/]+\/locations\/[^/]+\/)?publishers\/google\/models\//u;
 
 type GoogleTransportContentBlock =
   | { type: "text"; text: string; textSignature?: string }
@@ -1553,7 +1556,8 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
           const responseModel = normalizeOptionalString(chunk.modelVersion);
           if (
             responseModel &&
-            resolveGoogleModelPath(model.id) !== resolveGoogleModelPath(responseModel)
+            resolveGoogleModelPath(model.id.replace(GOOGLE_VERTEX_MODEL_RESOURCE_PREFIX, "")) !==
+              resolveGoogleModelPath(responseModel.replace(GOOGLE_VERTEX_MODEL_RESOURCE_PREFIX, ""))
           ) {
             output.responseModel ||= responseModel;
           }

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -142,6 +142,7 @@ const GOOGLE_VERTEX_DEFAULT_API_VERSION = "v1";
 
 type GoogleSseChunk = {
   responseId?: string;
+  modelVersion?: string;
   promptFeedback?: {
     blockReason?: string;
     blockReasonMessage?: string;
@@ -1549,6 +1550,13 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
               })(sse.firstChunk);
         for await (const chunk of chunks) {
           output.responseId ||= chunk.responseId;
+          const responseModel = normalizeOptionalString(chunk.modelVersion);
+          if (
+            responseModel &&
+            resolveGoogleModelPath(model.id) !== resolveGoogleModelPath(responseModel)
+          ) {
+            output.responseModel ||= responseModel;
+          }
           updateUsage(output, model, chunk, knownUsage);
           const candidate = chunk.candidates?.[0];
           const promptFeedback = chunk.promptFeedback;

--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -1,4 +1,5 @@
 // Google shared provider tests cover response conversion and finish reasons.
+import { createServer } from "node:http";
 import {
   ApiError,
   BlockedReason,
@@ -146,6 +147,7 @@ type GoogleResponseFixture = {
   finishReason?: FinishReason;
   finishMessage?: string;
   responseId?: string;
+  modelVersion?: string;
   usageMetadata?: GenerateContentResponse["usageMetadata"];
   promptFeedback?: GenerateContentResponse["promptFeedback"];
 };
@@ -320,6 +322,85 @@ describe("consumeGoogleGenerateContentStream", () => {
     });
     expect(output.usage.cost.total).toBeGreaterThan(0);
   });
+
+  it.each([
+    {
+      api: "google-generative-ai",
+      requested: "gemini-test",
+      returned: ["gemini-test-002"],
+      expected: "gemini-test-002",
+    },
+    {
+      api: "google-vertex",
+      requested: "gemini-test",
+      returned: ["gemini-test-002"],
+      expected: "gemini-test-002",
+    },
+    { api: "google-generative-ai", requested: "gemini-test", returned: ["gemini-test"] },
+    { api: "google-generative-ai", requested: "google/gemini-test", returned: ["gemini-test"] },
+    { api: "google-generative-ai", requested: "models/gemini-test", returned: ["gemini-test"] },
+    { api: "google-generative-ai", requested: "gemini-test", returned: ["models/gemini-test"] },
+    {
+      api: "google-vertex",
+      requested: "publishers/google/models/gemini-test",
+      returned: ["gemini-test"],
+    },
+    {
+      api: "google-vertex",
+      requested: "projects/fixture-project/locations/global/publishers/google/models/gemini-test",
+      returned: ["gemini-test"],
+    },
+    {
+      api: "google-vertex",
+      requested: "gemini-test",
+      returned: ["publishers/google/models/gemini-test"],
+    },
+    {
+      api: "google-vertex",
+      requested: "publishers/meta/models/gemini-test",
+      returned: ["gemini-test"],
+      expected: "gemini-test",
+    },
+    {
+      api: "google-generative-ai",
+      requested: "tunedModels/fixture-gemini",
+      returned: ["tunedModels/fixture-gemini"],
+    },
+    {
+      api: "google-generative-ai",
+      requested: "gemini-test",
+      returned: ["", "gemini-test-002", "gemini-test-003"],
+      expected: "gemini-test-002",
+    },
+  ] as const)(
+    "retains an actually different $api SDK response model for $requested",
+    async ({ api, requested, returned, expected }) => {
+      const targetModel = {
+        ...model,
+        id: requested,
+        api,
+        provider: api === "google-vertex" ? "google-vertex" : "google",
+      } satisfies Model<"google-generative-ai" | "google-vertex">;
+      const { result } = await runGoogleFixture(
+        returned.map((modelVersion, index) =>
+          googleResponse({
+            modelVersion,
+            ...(index === returned.length - 1
+              ? { parts: [{ text: "actual response" }], finishReason: FinishReason.STOP }
+              : {}),
+          }),
+        ),
+        { targetModel },
+      );
+
+      expect(result.stopReason).toBe("stop");
+      if (expected) {
+        expect(result.responseModel).toBe(expected);
+      } else {
+        expect(result).not.toHaveProperty("responseModel");
+      }
+    },
+  );
 
   it.each([
     {
@@ -591,6 +672,59 @@ describe("consumeGoogleGenerateContentStream", () => {
 });
 
 describe("runGoogleGenerateContentLifecycle", () => {
+  it("retains the actual SDK response model across localhost HTTP SSE", async () => {
+    const observedRequests: Array<{ method?: string; url?: string }> = [];
+    const server = createServer((request, response) => {
+      observedRequests.push({ method: request.method, url: request.url });
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.end(
+        `data: ${JSON.stringify({
+          responseId: "sdk-google-response",
+          modelVersion: "gemini-test-002",
+          candidates: [{ content: { parts: [{ text: "actual response" }] }, finishReason: "STOP" }],
+        })}\n\n`,
+      );
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing Google SDK loopback server address");
+      }
+      const { result } = await runGoogleFixture([], {
+        createClient: () =>
+          new GoogleGenAI({
+            apiKey: "fixture-google-api-key",
+            httpOptions: { baseUrl: `http://127.0.0.1:${address.port}` },
+          }),
+        buildParams: () => ({
+          model: model.id,
+          contents: [{ role: "user", parts: [{ text: "hello" }] }],
+        }),
+      });
+
+      expect(observedRequests).toEqual([
+        { method: "POST", url: expect.stringContaining(":streamGenerateContent?alt=sse") },
+      ]);
+      expect(result).toMatchObject({
+        responseId: "sdk-google-response",
+        responseModel: "gemini-test-002",
+        stopReason: "stop",
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("reports SDK stream acceptance without fabricated HTTP metadata", async () => {
     const acceptanceObserver = vi.fn();
     const options = withProviderAcceptanceObserver({}, acceptanceObserver);

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -49,6 +49,10 @@ import {
 
 type GoogleApiType = "google-generative-ai" | "google-vertex";
 
+// Google-owned SDK resource spellings identify the same model; other publishers do not.
+const GOOGLE_MODEL_RESOURCE_PREFIX =
+  /^(?:(?:projects\/[^/]+\/locations\/[^/]+\/)?publishers\/google\/models\/|google\/|models\/)/u;
+
 type GoogleThinkingLevel = `${ThinkingLevel}`;
 
 type GoogleToolChoice = "auto" | "none" | "any";
@@ -801,6 +805,14 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
 
   for await (const chunk of params.chunks) {
     params.output.responseId ||= chunk.responseId;
+    const responseModel = chunk.modelVersion?.trim();
+    if (
+      responseModel &&
+      params.model.id.replace(GOOGLE_MODEL_RESOURCE_PREFIX, "") !==
+        responseModel.replace(GOOGLE_MODEL_RESOURCE_PREFIX, "")
+    ) {
+      params.output.responseModel ||= responseModel;
+    }
     if (chunk.usageMetadata) {
       for (const field of Object.keys(knownUsage) as Array<keyof typeof knownUsage>) {
         const value = chunk.usageMetadata[field];


### PR DESCRIPTION
## What Problem This Solves

Google-backed agent turns lost the concrete model version returned by Gemini or Vertex. Requests made against aliases therefore recorded the requested alias in transcripts and terminal receipts instead of the model that actually generated the answer.

OpenClaw has two independently reachable Google streaming owners: the public `@openclaw/ai/providers` SDK adapters and the Google plugin transport selected by `buildGoogleProvider().createStreamFn`. The original contributor fix repaired only the SDK adapter; normal plugin-backed agent runs still lost the provider-returned identity.

## Why This Change Was Made

Both streaming owners now retain the first non-empty, genuinely different Google `modelVersion` as the existing optional `AssistantMessage.responseModel`. Both owners recognize Google's documented bare, `google/`, `models/`, partial Google publisher-resource, and full Google publisher-resource spellings. The registered plugin normalizes Google-owned publisher resources only when comparing response identities; its existing outbound request URL construction is unchanged.

This symmetric comparison prevents equivalent model spellings from incorrectly marking terminal receipts as rerouted. Distinct tuned resources and non-Google publishers remain distinct. The requested model, provider routing, authentication, configuration, catalogs, and public API are unchanged.

Original contributor: @Alix-007, preserved as the primary commit author.

## User Impact

Gemini and Vertex operators now see the concrete served model in agent metadata, persisted assistant messages, and terminal receipts when Google serves a different revision. Equivalent Google resource spellings no longer produce false reroute signals, and ordinary same-model responses remain unchanged.

## Evidence

The pinned `@google/genai` 2.17.1 types document `GenerateContentResponse.modelVersion` as optional output-only response metadata and explicitly document the supported Google model-resource spellings.

Before repair, independent focused regressions against frozen main failed on both live streaming owners: direct Gemini, Vertex, and first-different streamed responses each lost their provider-returned model.

After repair and a preserving refresh onto current `main`, all 288 relevant tests passed:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs packages/ai/src/providers/google-shared.test.ts packages/ai/src/providers/google-shared.convert.test.ts extensions/google/transport-stream.test.ts src/agents/embedded-agent-runner/run/terminal-preparation.test.ts

packages/ai/src/providers/google-shared.test.ts + google-shared.convert.test.ts: 104 passed
src/agents/embedded-agent-runner/run/terminal-preparation.test.ts: 18 passed
extensions/google/transport-stream.test.ts: 166 passed
```

The SDK suite creates a real pinned `GoogleGenAI` client and observes an actual localhost HTTP POST/SSE response. The plugin suite separately obtains the real stream function through Google provider registration and observes actual localhost HTTP POST/SSE responses for Gemini, Vertex, and equivalent partial/full Google publisher-resource controls. The canonical terminal-receipt suite verifies that genuinely distinct response models are recorded without replacing the requested model.

Regression coverage includes first-different ownership, omitted/empty/blank values, bare and prefixed Google names, full and partial Google publisher resources, tuned models, and non-Google publisher isolation.

The latest ClawSweeper findings were addressed at the registered plugin's actual response-model producer, not in a downstream receipt: equivalent partial/full Google publisher resources no longer produce false `responseModel` or `rerouted` values, while non-Google publishers and tuned resources remain distinct. The newly added regression matrix initially failed six cases, including two actual registered Vertex localhost HTTP/SSE requests, and now passes all 22 focused cases. Reverse identity comparisons are covered at the producer; sending full resource names as requested models through the plugin's existing Vertex URL builder would produce an invalid provider URL, so no misleading reverse network fixture was added.

Both exact test-type owners also pass:

```text
pnpm tsgo:extensions:test
pnpm tsgo:test:packages
```

An earlier candidate exposed an unrelated shared frontend CSS build-budget regression; this branch was refreshed only after the canonical upstream cleanup landed. The refresh also preserves the independently landed Google tool-call identities, unspecified-finish handling, and unframed terminal-error protections, including their real HTTP/SSE and conversion regressions. The exact refreshed head completed its full hosted CI run and required Actions-owned gate successfully.

Authenticated live-provider proof on the exact reviewed head executed the actual registered Google plugin through its unchanged production HTTPS/SSRF transport and the actual terminal-receipt owner. Exactly one official Google request returned HTTP 200 and proved that the served model, assistant response model, and terminal receipt agree:

```json
{
  "candidate": "6199c5313933c2cfe117504ac2141fd3946bb155",
  "owner": "registered-google-plugin",
  "officialGoogleHttpsRequests": 1,
  "httpStatus": 200,
  "requestedModel": "gemini-flash-latest",
  "actualProviderModelVersion": "gemini-3.7-flash",
  "assistantResponseModel": "gemini-3.7-flash",
  "terminalReceipt": {
    "requestedModel": "gemini-flash-latest",
    "responseModel": "gemini-3.7-flash",
    "rerouted": true
  },
  "outputTokens": 13,
  "maximumOutputTokens": 16
}
```

No credential, request URL, headers, prompt, response text, or private user data is included. Production delta: +24 lines across two independently live owner boundaries. Test delta: +394 lines, including both HTTP/SSE integrations and the provider-resource regressions. Independent source review approved the complete change; fresh whole-branch structured review reported no actionable findings (confidence 0.96).
