### PR TITLE
fix(ci): restore main qualification

### DIFF
--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -70,6 +70,18 @@ vi.mock("./model.js", () => ({
   resolveModelAsync: resolveModelAsyncMock,
 }));
 
+vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: () => ({ plugins: [] }),
+}));
+
+vi.mock("../../plugins/manifest-contract-eligibility.js", () => ({
+  loadManifestMetadataSnapshot: () => ({ plugins: [] }),
+}));
+
+vi.mock("../provider-model-normalization.runtime.js", () => ({
+  normalizeProviderModelIdWithRuntime: () => undefined,
+}));
+
 vi.mock("../harness/runtime-plugin.js", () => ({
   ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
 }));

--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -70,14 +70,6 @@ vi.mock("./model.js", () => ({
   resolveModelAsync: resolveModelAsyncMock,
 }));
 
-vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
-  getCurrentPluginMetadataSnapshot: () => ({ plugins: [] }),
-}));
-
-vi.mock("../../plugins/manifest-contract-eligibility.js", () => ({
-  loadManifestMetadataSnapshot: () => ({ plugins: [] }),
-}));
-
 vi.mock("../provider-model-normalization.runtime.js", () => ({
   normalizeProviderModelIdWithRuntime: () => undefined,
 }));
@@ -150,11 +142,6 @@ vi.mock("../runtime-plan/resolve-auth.js", () => ({
 
 vi.mock("../../plugins/provider-runtime.js", () => ({
   prepareProviderRuntimeAuth: vi.fn(async () => undefined),
-}));
-
-vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
-  getCurrentPluginMetadataSnapshot: () => ({ plugins: [] }),
-  withPluginMetadataSnapshotScope: (_snapshot: unknown, run: () => unknown) => run(),
 }));
 
 vi.mock("../provider-secret-egress.js", () => ({

--- a/src/cron/isolated-agent.mocks.ts
+++ b/src/cron/isolated-agent.mocks.ts
@@ -61,6 +61,10 @@ vi.mock("../agents/model-selection.js", async () => {
   };
 });
 
+vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
+  normalizeProviderModelIdWithRuntime: () => undefined,
+}));
+
 vi.mock("../agents/runtime-plugins.js", () => ({
   loadAgentRuntimePluginRegistryHandle: vi.fn(),
 }));

--- a/src/cron/isolated-agent.session-identity.test.ts
+++ b/src/cron/isolated-agent.session-identity.test.ts
@@ -2,9 +2,10 @@
 import "./isolated-agent.mocks.js";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as modelThinkingDefault from "../agents/model-thinking-default.js";
 import { SessionManager } from "../agents/sessions/index.js";
+import * as thinking from "../auto-reply/thinking.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
 import {
@@ -26,10 +27,8 @@ import { setupRunCronIsolatedAgentTurnSuite } from "./isolated-agent/run.suite-h
 import {
   dispatchCronDeliveryMock,
   loadSessionEntryMock,
-  makeCronSession,
   mockRunCronFallbackPassthrough,
   patchSessionEntryMock,
-  resetRunCronIsolatedAgentTurnHarness,
   resolveCronSessionMock,
   runEmbeddedAgentMock,
 } from "./isolated-agent/run.test-harness.js";
@@ -132,18 +131,9 @@ function mockEmbeddedTranscriptWrite(
 }
 
 describe("runCronIsolatedAgentTurn session identity", () => {
-  beforeAll(async () => {
-    resetRunCronIsolatedAgentTurnHarness();
-    resolveCronSessionMock.mockReturnValue(makeCronSession());
-    vi.spyOn(modelThinkingDefault, "resolveThinkingDefault").mockReturnValue("off");
-    mockRunCronFallbackPassthrough();
-    await withTempHome(async (home) => {
-      await runCronTurn(home, { jobPayload: DEFAULT_AGENT_TURN_PAYLOAD });
-    });
-  });
-
   beforeEach(() => {
     vi.spyOn(modelThinkingDefault, "resolveThinkingDefault").mockReturnValue("off");
+    vi.spyOn(thinking, "isThinkingLevelSupported").mockReturnValue(true);
     runEmbeddedAgentMock.mockClear();
     mockRunCronFallbackPassthrough();
   });


### PR DESCRIPTION
## What Problem This Solves

Restores deterministic main qualification for the embedded-model and cron session-identity suites. Both suites were loading unrelated runtime/plugin policy during focused ownership tests; the cron suite also performed an assertion-free warmup turn that could time out before any session assertion ran.

## Why This Change Was Made

Current `main` already contains the onboarding alias owner fix and its stronger behavior regression, so the semantic rebase dropped that superseded production/test commit.

The remaining change keeps only unique test-boundary repairs:

- model consistency uses the real scoped plugin metadata snapshot and isolates provider model normalization;
- cron session identity removes the assertion-free warmup and isolates provider normalization plus thinking-capability policy.

This preserves current-main behavior and leaves the branch source/test-only. No generated locales, onboarding changes, timeout increases, or unrelated qualification repairs remain.

The original model/cron isolation commits are by Jason O'Neal from https://github.com/openclaw/openclaw/pull/126986.

## User Impact

No product behavior changes. Main qualification now tests model resolution and cron session identity without depending on unrelated plugin/provider discovery or a hidden warmup turn.

## Evidence

Semantic rebase:

- Rebased once onto `e1e2818a6ab0bb4e8426cd80b03f4e03b5c9882f`.
- Exact pushed head: `c60b20728d7b654ae8d443a913e9257fd523cca5`.
- Live `main` later advanced to `c3eca4f50813307a9aa13245529495065b3ca1c5`; those commits do not touch this PR's files and a merge simulation is conflict-free.

Focused tests:

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model-resolution-consistency.test.ts` - 8/8 passed.
- `node scripts/run-vitest.mjs src/commands/onboard-custom-config.test.ts` - 39/39 passed, confirming the upstream replacement.
- `node scripts/run-vitest.mjs src/cron/isolated-agent.session-identity.test.ts` - 14/14 passed.

Static verification:

- `pnpm tsgo:core` - passed.
- Focused core-test type shards for agents, commands, and services/cron - passed.
- Exact changed-file Oxlint - passed.
- Exact changed-file formatting - passed.
- `git diff --check` - passed.
- Generated-locale scope check - clean.
- Autoreview TruffleHog scan - clean.

The full `pnpm tsgo:core:test` fanout was attempted. It reached an unrelated shared-install failure in `ui/vite.config.ts`: the current linked `node_modules` lacks a declaration for `pako`. Repository policy forbids installing inside this worktree; the three owning type shards above passed.

Structured autoreview could not start because the official standalone Codex CLI is not installed (`codex-standalone-install`). No review finding was emitted.

## LOC

- Production: `+0/-0`
- Tests and test support: `+11/-18`
- Files: 3

## Scope

- `src/agents/embedded-agent-runner/model-resolution-consistency.test.ts`
- `src/cron/isolated-agent.mocks.ts`
- `src/cron/isolated-agent.session-identity.test.ts`

No changelog entry: this is qualification isolation only.
