### PR TITLE
chore: remove duplicate user-path test

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -302,9 +302,4 @@ describe("resolveUserPath", () => {
     expect(resolveUserPath("")).toBe("");
     expect(resolveUserPath("   ")).toBe("");
   });
-
-  it("returns empty string for undefined/null input", () => {
-    expect(resolveUserPath(undefined as unknown as string)).toBe("");
-    expect(resolveUserPath(null as unknown as string)).toBe("");
-  });
 });


### PR DESCRIPTION
## What Problem This Solves

The legacy shared-utility suite repeated the exact falsy-input assertion already owned by the canonical home-directory helper suite, adding maintenance and CI work without detecting a distinct regression.

## Why This Change Was Made

Remove only the duplicate undefined/null `resolveUserPath` case from the re-exporting utility suite. The canonical owner test retains the exact behavior contract, while six remaining utility-suite cases continue to prove the legacy re-export path.

AI-assisted test audit requested by @steipete.

## User Impact

No user-visible behavior changes. Contributors maintain the historical falsy-input contract in its canonical owner suite instead of two places.

## Evidence

- Baseline: home-directory owner 29/29; utility suite 30 passed with 3 existing skips.
- After cleanup: home-directory owner 29/29; utility suite 29 passed with 3 existing skips.
- `node scripts/check-changed.mjs -- src/utils.test.ts` passed the complete core-test changed gate.
- `git diff --check` passed.
- Fresh Codex autoreview reported no accepted/actionable findings.
- Production LOC: +0/-0; tests: +0/-5.
