### PR TITLE
fix(ui): show cached conversation during reconnect

### DIFF
--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -46,6 +46,10 @@ function routeLocationHref(location: RouteLocation): string {
   return `${location.pathname}${location.search}${location.hash}`;
 }
 
+function currentLocationHref(): string {
+  return `${globalThis.location?.pathname ?? ""}${globalThis.location?.search ?? ""}${globalThis.location?.hash ?? ""}`;
+}
+
 function isRouteNotFound(result: ChatRouteData | RouteNotFound): result is RouteNotFound {
   return "type" in result && result.type === "notFound";
 }
@@ -62,6 +66,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
   @state() private pendingGatewayUrl: string | null = null;
   @state() private onboarding = resolveOnboardingMode(globalThis.location?.search ?? "");
   @state() private focusDashboardRoute: FocusDashboardRouteState = { kind: "loading" };
+  @state() private savedTranscriptReady = false;
 
   private runtime: ApplicationRuntime | undefined;
   private readonly contextProvider = new ContextProvider(this, {
@@ -70,6 +75,9 @@ export class OpenClawApp extends OpenClawLightDomElement {
   private readonly subscriptions = new SubscriptionsController(this);
   private loginGatewaySource: ApplicationContext["gateway"] | null = null;
   private loginConnectionClient: GatewayBrowserClient | null = null;
+  private savedTranscriptLocation = "";
+  private savedTranscriptNavigationGeneration = 0;
+  private savedTranscriptAuthorizationEpoch = 0;
   private focusDashboardAbort: AbortController | null = null;
   private readonly loginGateLoader = new LazyCustomElementRequestController(this);
   private readonly lazyCustomElements = new LazyCustomElementRequestController(this, () =>
@@ -89,6 +97,13 @@ export class OpenClawApp extends OpenClawLightDomElement {
     return this.focusTarget?.kind === "terminal";
   }
 
+  private retireSavedTranscript(): void {
+    this.savedTranscriptAuthorizationEpoch += 1;
+    this.savedTranscriptReady = false;
+    this.savedTranscriptLocation = "";
+    this.savedTranscriptNavigationGeneration = 0;
+  }
+
   constructor() {
     super();
     this.subscriptions
@@ -96,6 +111,10 @@ export class OpenClawApp extends OpenClawLightDomElement {
         () => this.context?.gateway,
         (gateway, notify) => gateway.subscribe(notify),
         (gateway) => this.synchronizeGateway(gateway),
+      )
+      .watch(
+        () => this.runtime?.router,
+        (router, notify) => router.subscribe(notify),
       )
       .watch(
         () => (this.terminalOnly ? this.context?.config : undefined),
@@ -147,6 +166,38 @@ export class OpenClawApp extends OpenClawLightDomElement {
     // descendants reconnect and rebuild their controller-owned state afterward.
     this.contextProvider.setValue(context);
     this.syncLoginConnection();
+    const runtime = this.runtime;
+    const pathname = globalThis.location?.pathname ?? "";
+    const location = currentLocationHref();
+    const navigationGeneration = runtime.navigationGeneration;
+    const gateway = context.gateway;
+    const authorizationEpoch = this.savedTranscriptAuthorizationEpoch;
+    if (runtime.canPaintSavedTranscript) {
+      void import("./saved-transcript-probe.runtime.ts")
+        .then((probe) =>
+          probe.hasSavedTranscript({
+            basePath: context.basePath,
+            pathname,
+            persistedSessionKey: context.gateway.snapshot.sessionKey,
+          }),
+        )
+        .then((ready) => {
+          if (
+            ready &&
+            this.runtime === runtime &&
+            this.context?.gateway === gateway &&
+            runtime.navigationGeneration === navigationGeneration &&
+            this.savedTranscriptAuthorizationEpoch === authorizationEpoch &&
+            currentLocationHref() === location
+          ) {
+            this.savedTranscriptReady = true;
+            this.savedTranscriptLocation = location;
+            this.savedTranscriptNavigationGeneration = navigationGeneration;
+            runtime.releaseStartupRouteGate();
+          }
+        })
+        .catch(() => undefined);
+    }
     // The runtime is created after controller hostConnected hooks run. Ensure
     // their lazy source getters bind on both the initial mount and reconnect.
     this.requestUpdate();
@@ -167,6 +218,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
     this.loginGateLoader.abandon();
     this.runtime?.stop();
     this.runtime = undefined;
+    this.retireSavedTranscript();
     this.loginGatewaySource = null;
     this.loginConnectionClient = null;
     this.pendingGatewayUrl = null;
@@ -183,8 +235,12 @@ export class OpenClawApp extends OpenClawLightDomElement {
   private synchronizeGateway(gateway: ApplicationContext["gateway"]) {
     const sourceChanged = gateway !== this.loginGatewaySource;
     if (sourceChanged) {
+      const sourceReplaced = this.loginGatewaySource !== null;
       this.loginGatewaySource = gateway;
       this.loginConnectionClient = null;
+      if (sourceReplaced) {
+        this.retireSavedTranscript();
+      }
       this.resetLoginSensitivePresentation();
     }
     const snapshot = gateway.snapshot;
@@ -198,6 +254,8 @@ export class OpenClawApp extends OpenClawLightDomElement {
     }
     if (snapshot.phase === "connected") {
       this.loginGatePinned = false;
+    } else if (snapshot.lastError !== null) {
+      this.retireSavedTranscript();
     }
   }
 
@@ -571,12 +629,18 @@ export class OpenClawApp extends OpenClawLightDomElement {
       gatewaySnapshot.lastError === null &&
       (gatewaySnapshot.phase === "starting" ||
         (gatewaySnapshot.phase === "connecting" && !this.loginGatePinned));
-    if (initialConnectPending) {
+    const savedTranscriptPaintsConnection =
+      initialConnectPending &&
+      this.savedTranscriptReady &&
+      runtime.navigationGeneration === this.savedTranscriptNavigationGeneration &&
+      currentLocationHref() === this.savedTranscriptLocation;
+    if (initialConnectPending && !savedTranscriptPaintsConnection) {
       return renderConnectingSplash(gatewayStartupStatus);
     }
     const shellOwnsRecovery =
       gatewaySnapshot.phase === "reconnecting" || gatewaySnapshot.phase === "reload-required";
-    const showLoginGate = !gatewayConnected && !shellOwnsRecovery;
+    const showLoginGate =
+      !gatewayConnected && !shellOwnsRecovery && !savedTranscriptPaintsConnection;
     if (showLoginGate && !isOptionalElementDefined(LOGIN_GATE_ELEMENT)) {
       const loadState = this.loginGateLoader.visibleState;
       // Normal admission needs no login renderer. Keep failures visible and retryable
@@ -627,6 +691,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
               this.loginShowGatewayPassword = !this.loginShowGatewayPassword;
             },
             onConnect: () => {
+              this.retireSavedTranscript();
               this.loginGatePinned = true;
               context.gateway.connect({
                 gatewayUrl: this.loginGatewayUrl,

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -131,6 +131,9 @@ export type ApplicationRuntime = {
   } | null;
   readonly confirmPendingGatewayConnection: () => void;
   readonly cancelPendingGatewayConnection: () => void;
+  readonly canPaintSavedTranscript: boolean;
+  readonly releaseStartupRouteGate: () => void;
+  readonly navigationGeneration: number;
   start: () => Promise<void>;
   stop: () => void;
 };
@@ -142,7 +145,10 @@ type PendingRouterStartNavigation = {
 };
 
 export function bootstrapApplication(): ApplicationRuntime {
-  const history = createBrowserHistory();
+  let navigationGeneration = 0;
+  const history = createBrowserHistory(() => {
+    navigationGeneration += 1;
+  });
   const startupLocation = history.location();
   const [basePath, resourceBasePath] = resolveControlUiPaths(
     startupLocation.pathname || globalThis.location?.pathname || "/",
@@ -201,6 +207,11 @@ export function bootstrapApplication(): ApplicationRuntime {
   const firstRunDefaultLanding =
     startsApplicationRouter && isDefaultChatLanding(applicationLocation, basePath, routeIdFromPath);
   const hasPendingGateway = startup.pendingGatewayUrl !== null;
+  const canPaintSavedTranscript =
+    !startup.changed &&
+    startup.password === null &&
+    startup.pendingBootstrapToken === null &&
+    startup.pendingGatewayUrl === null;
   const gateway = createApplicationGateway(
     settings,
     startup.password ?? "",
@@ -449,6 +460,7 @@ export function bootstrapApplication(): ApplicationRuntime {
     options: ApplicationNavigationOptions | undefined,
     requested: "push" | "replace",
   ) => {
+    navigationGeneration += 1;
     const location = routeLocation(routeId, options);
     // Preserve pre-start navigation exactly as the fire-and-forget entry point does.
     if (!routerStarted) {
@@ -519,6 +531,11 @@ export function bootstrapApplication(): ApplicationRuntime {
     },
     confirmPendingGatewayConnection,
     cancelPendingGatewayConnection,
+    canPaintSavedTranscript,
+    releaseStartupRouteGate: () => resolveInitialFirstRunDecision?.(),
+    get navigationGeneration() {
+      return navigationGeneration;
+    },
     start: () => {
       const stopRouter = () => router.stop();
       if (startsApplicationRouter) {

--- a/ui/src/app/browser.ts
+++ b/ui/src/app/browser.ts
@@ -55,7 +55,7 @@ export function canGoBackInNativeEmbed(): boolean {
   return nativeEmbedHistoryDepth() > 0;
 }
 
-export function createBrowserHistory(): RouterHistory {
+export function createBrowserHistory(onNavigate?: () => void): RouterHistory {
   const embedded = isNativeEmbedHost();
   const listeners = new Set<(location: RouteLocation) => void>();
   let stopPopState: (() => void) | undefined;
@@ -65,6 +65,7 @@ export function createBrowserHistory(): RouterHistory {
       return;
     }
     const onPopState = () => {
+      onNavigate?.();
       const location = readLocation();
       for (const listener of listeners) {
         listener(location);

--- a/ui/src/app/saved-transcript-probe.runtime.ts
+++ b/ui/src/app/saved-transcript-probe.runtime.ts
@@ -1,0 +1,57 @@
+import { routeIdFromPath } from "../app-routes.ts";
+import { sessionRefFromPath } from "../app-session-route-paths.ts";
+import { normalizeAgentId, parseAgentSessionKey } from "../lib/sessions/session-key.ts";
+import { sessionKeyUuid } from "../pages/chat/route-loader-short-cache.ts";
+import { resolveChatSnapshotKey } from "../pages/chat/session-snapshot-invalidation.ts";
+import { readStoredChatSnapshot } from "../pages/chat/session-snapshot-store.ts";
+import { isDefaultChatLanding } from "../pages/model-setup/first-run.ts";
+
+type SavedTranscriptProbe = {
+  basePath: string;
+  pathname: string;
+  persistedSessionKey: string;
+};
+
+function localSessionKey(probe: SavedTranscriptProbe): string | null {
+  const target = sessionRefFromPath(probe.pathname, probe.basePath);
+  const persisted = probe.persistedSessionKey.trim();
+  if (!target) {
+    const location = { pathname: probe.pathname, search: "", hash: "" };
+    return isDefaultChatLanding(location, probe.basePath, routeIdFromPath) &&
+      parseAgentSessionKey(persisted)
+      ? persisted
+      : null;
+  }
+  if (target.kind === "literal") {
+    return target.slugCandidate ? null : target.sessionKey;
+  }
+  const parsed = parseAgentSessionKey(persisted);
+  if (
+    !persisted ||
+    (parsed && normalizeAgentId(parsed.agentId) !== normalizeAgentId(target.agentId))
+  ) {
+    return null;
+  }
+  if (target.kind === "main") {
+    if (parsed?.rest === "main") {
+      return persisted;
+    }
+    return !parsed && persisted.toLowerCase() === "main" ? persisted : null;
+  }
+  const uuid = sessionKeyUuid(persisted);
+  return uuid?.startsWith(target.shortId.toLowerCase().replaceAll("-", "")) ? persisted : null;
+}
+
+export async function hasSavedTranscript(probe: SavedTranscriptProbe): Promise<boolean> {
+  const sessionKey = localSessionKey(probe);
+  if (!sessionKey) {
+    return false;
+  }
+  const snapshot = await readStoredChatSnapshot(
+    resolveChatSnapshotKey(
+      { assistantAgentId: null, agentsList: null, hello: null },
+      { sessionKey },
+    ),
+  );
+  return Boolean(snapshot?.messages.length);
+}

--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -32,10 +32,16 @@ beforeEach(() => {
     ? createControlUiE2eArtifactDir("initial-connect-splash", artifactRoot)
     : undefined;
 });
+const builtControlUi = process.env.OPENCLAW_UI_E2E_USE_BUILT === "1";
+const delayedHelloMs = 2_000;
 const viewport = { height: 900, width: 1280 };
+const cachedSessionPath = "chat/main/telegram/12345";
+const cachedSessionKey = "agent:main:telegram:12345";
+const cachedTranscriptMarker = "cached-transcript-marker";
 
 let browser: Browser;
 let server: ControlUiE2eServer;
+let cachedTranscriptVisibleAfterMs: number | null = null;
 const openContexts = new Set<BrowserContext>();
 
 async function createPage(): Promise<Page> {
@@ -44,6 +50,12 @@ async function createPage(): Promise<Page> {
     ...(artifactDir ? { recordVideo: { dir: artifactDir, size: viewport } } : {}),
   });
   openContexts.add(context);
+  const page = await context.newPage();
+  page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
+  return page;
+}
+
+async function createPageIn(context: BrowserContext): Promise<Page> {
   const page = await context.newPage();
   page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
   return page;
@@ -137,6 +149,81 @@ async function traceLoginGateMounts(page: Page): Promise<() => Promise<boolean>>
     );
 }
 
+async function seedStoredTranscript(
+  page: Page,
+  messages: unknown[],
+  options: { version?: number } = {},
+): Promise<void> {
+  await page.evaluate(
+    async ({ cachedMessages, sessionKey, version }) => {
+      const request = indexedDB.open("openclaw-chat-snapshots", version);
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        request.addEventListener("upgradeneeded", () => {
+          for (const name of Array.from(request.result.objectStoreNames)) {
+            request.result.deleteObjectStore(name);
+          }
+          request.result.createObjectStore("snapshots", { keyPath: "sessionKey" });
+          if (version >= 2) {
+            request.result.createObjectStore("snapshotMetadata", { keyPath: "sessionKey" });
+          }
+        });
+        request.addEventListener("success", () => resolve(request.result));
+        request.addEventListener("error", () =>
+          reject(request.error ?? new Error("snapshot database open failed")),
+        );
+      });
+      await new Promise<void>((resolve, reject) => {
+        const storeNames = version >= 2 ? ["snapshots", "snapshotMetadata"] : ["snapshots"];
+        const transaction = database.transaction(storeNames, "readwrite");
+        const savedAt = Date.now();
+        transaction.objectStore("snapshots").put({
+          savedAt,
+          sessionId: null,
+          sessionKey,
+          snapshot: {
+            messages: cachedMessages,
+            pagination: { hasMore: false },
+            sessionId: null,
+          },
+        });
+        if (version >= 2) {
+          transaction.objectStore("snapshotMetadata").put({
+            savedAt,
+            sessionKey,
+            weight: JSON.stringify(cachedMessages).length,
+          });
+        }
+        transaction.addEventListener("complete", () => resolve());
+        transaction.addEventListener("error", () =>
+          reject(transaction.error ?? new Error("snapshot write failed")),
+        );
+      });
+      database.close();
+    },
+    { cachedMessages: messages, sessionKey: cachedSessionKey, version: options.version ?? 2 },
+  );
+}
+
+async function seedCachedSessionSettings(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ gatewayUrl, sessionKey }) => {
+      localStorage.setItem(
+        `openclaw.control.settings.v1:${gatewayUrl}`,
+        JSON.stringify({
+          gatewayUrl,
+          sessionsByGateway: {
+            [gatewayUrl]: { sessionKey, lastActiveSessionKey: sessionKey },
+          },
+        }),
+      );
+    },
+    {
+      gatewayUrl: server.baseUrl.replace(/^http/, "ws").replace(/\/$/, ""),
+      sessionKey: cachedSessionKey,
+    },
+  );
+}
+
 describeControlUiE2e("Control UI initial connect splash E2E", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
@@ -144,7 +231,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
         `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}.`,
       );
     }
-    server = await startControlUiE2eServer(undefined, { source: true });
+    server = await startControlUiE2eServer(undefined, { source: !builtControlUi });
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });
 
@@ -157,6 +244,215 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
   afterEach(async () => {
     await Promise.all([...openContexts].map((context) => context.close().catch(() => {})));
     openContexts.clear();
+  });
+
+  it("paints a stored transcript before a delayed first hello", async () => {
+    const page = await createPage();
+    await page.goto(new URL("favicon.svg", server.baseUrl).href);
+    await seedStoredTranscript(page, [
+      { role: "assistant", content: cachedTranscriptMarker, timestamp: 1 },
+    ]);
+    await seedCachedSessionSettings(page);
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["connect"],
+      historyMessages: [
+        { role: "assistant", content: cachedTranscriptMarker, timestamp: Date.now() },
+      ],
+    });
+    const startedAt = performance.now();
+
+    await page.goto(new URL(cachedSessionPath, server.baseUrl).href);
+    await gateway.waitForRequest("connect");
+    const helloTimer = builtControlUi
+      ? setTimeout(() => void gateway.resolveDeferred("connect"), delayedHelloMs)
+      : undefined;
+    try {
+      await page.getByText(cachedTranscriptMarker, { exact: true }).first().waitFor();
+    } finally {
+      if (helloTimer !== undefined) {
+        clearTimeout(helloTimer);
+      }
+    }
+    const visibleAfterMs = Math.round(performance.now() - startedAt);
+    cachedTranscriptVisibleAfterMs = visibleAfterMs;
+
+    expect(visibleAfterMs).toBeLessThan(builtControlUi ? delayedHelloMs : 10_000);
+    expect(await page.locator(".connect-splash").count()).toBe(0);
+    await captureProof(page, "cached-transcript-connecting", [
+      page.getByText(cachedTranscriptMarker, { exact: true }).first(),
+    ]);
+    await gateway.resolveDeferred("connect");
+    await page.locator("openclaw-app-shell").waitFor();
+    await captureProof(page, "cached-transcript-reconciled", [
+      page.getByText(cachedTranscriptMarker, { exact: true }).first(),
+    ]);
+  });
+
+  afterAll(() => {
+    if (cachedTranscriptVisibleAfterMs !== null) {
+      console.info(`cached-transcript-visible-after-ms=${cachedTranscriptVisibleAfterMs}`);
+    }
+  });
+
+  it("keeps the cached shell through retry and removes it on rejected credentials", async () => {
+    const page = await createPage();
+    await page.goto(new URL("favicon.svg", server.baseUrl).href);
+    await seedStoredTranscript(page, [
+      { role: "assistant", content: cachedTranscriptMarker, timestamp: 1 },
+    ]);
+    await seedCachedSessionSettings(page);
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+
+    await page.goto(new URL(cachedSessionPath, server.baseUrl).href);
+    await gateway.waitForRequest("connect");
+    await page.getByText(cachedTranscriptMarker, { exact: true }).first().waitFor();
+    const initialConnectCount = (await gateway.getRequests("connect")).length;
+    await gateway.deferNext("connect");
+    await gateway.rejectDeferred("connect", {
+      code: "UNAVAILABLE",
+      message: "gateway starting; retry shortly",
+      details: { reason: "startup-sidecars" },
+      retryable: true,
+    });
+    await expect
+      .poll(async () => (await gateway.getRequests("connect")).length)
+      .toBeGreaterThan(initialConnectCount);
+    expect(await page.getByText(cachedTranscriptMarker, { exact: true }).count()).toBeGreaterThan(
+      0,
+    );
+
+    await gateway.rejectDeferred("connect", {
+      code: "UNAUTHORIZED",
+      message: "unauthorized: gateway token mismatch",
+      details: { code: ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH },
+    });
+    await page.locator("openclaw-login-gate").waitFor();
+    expect(await page.getByText(cachedTranscriptMarker, { exact: true }).count()).toBe(0);
+    expect(await page.locator("openclaw-app-shell").count()).toBe(0);
+  });
+
+  it("shares one stored transcript across concurrently opening tabs", async () => {
+    const context = await browser.newContext({ viewport });
+    openContexts.add(context);
+    const writer = await createPageIn(context);
+    await writer.goto(new URL("favicon.svg", server.baseUrl).href);
+    await seedStoredTranscript(writer, [
+      { role: "assistant", content: cachedTranscriptMarker, timestamp: 1 },
+    ]);
+    await seedCachedSessionSettings(writer);
+
+    const pages = await Promise.all([createPageIn(context), createPageIn(context)]);
+    const gateways = await Promise.all(
+      pages.map((page) => installMockGateway(page, { deferredMethods: ["connect"] })),
+    );
+    await Promise.all(
+      pages.map((page) => page.goto(new URL(cachedSessionPath, server.baseUrl).href)),
+    );
+    await Promise.all(gateways.map((gateway) => gateway.waitForRequest("connect")));
+    await Promise.all(
+      pages.map((page) =>
+        page.getByText(cachedTranscriptMarker, { exact: true }).first().waitFor(),
+      ),
+    );
+    expect(await pages[0]!.locator(".connect-splash").count()).toBe(0);
+    expect(await pages[1]!.locator(".connect-splash").count()).toBe(0);
+  });
+
+  it("keeps the splash for an empty stored transcript", async () => {
+    const page = await createPage();
+    await page.goto(new URL("favicon.svg", server.baseUrl).href);
+    await seedStoredTranscript(page, []);
+    await seedCachedSessionSettings(page);
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+
+    await page.goto(new URL(cachedSessionPath, server.baseUrl).href);
+    await gateway.waitForRequest("connect");
+    await page.locator(".connect-splash").waitFor();
+    expect(await page.locator("openclaw-app-shell").count()).toBe(0);
+  });
+
+  it("keeps a saved transcript from releasing a non-chat startup route", async () => {
+    const page = await createPage();
+    await page.goto(new URL("favicon.svg", server.baseUrl).href);
+    await seedStoredTranscript(page, [
+      { role: "assistant", content: cachedTranscriptMarker, timestamp: 1 },
+    ]);
+    await seedCachedSessionSettings(page);
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+
+    await page.goto(new URL("settings/appearance", server.baseUrl).href);
+    await gateway.waitForRequest("connect");
+    await page.locator(".connect-splash").waitFor();
+    expect(await page.getByText(cachedTranscriptMarker, { exact: true }).count()).toBe(0);
+    expect(await page.locator("openclaw-app-shell").count()).toBe(0);
+  });
+
+  it("keeps the splash when an older snapshot database is upgraded", async () => {
+    const page = await createPage();
+    await page.goto(new URL("favicon.svg", server.baseUrl).href);
+    await seedStoredTranscript(
+      page,
+      [{ role: "assistant", content: cachedTranscriptMarker, timestamp: 1 }],
+      { version: 1 },
+    );
+    await seedCachedSessionSettings(page);
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+
+    await page.goto(new URL(cachedSessionPath, server.baseUrl).href);
+    await gateway.waitForRequest("connect");
+    await page.locator(".connect-splash").waitFor();
+    expect(await page.getByText(cachedTranscriptMarker, { exact: true }).count()).toBe(0);
+  });
+
+  it("does not remount a cached conversation after navigation before hello", async () => {
+    const page = await createPage();
+    await page.goto(new URL("favicon.svg", server.baseUrl).href);
+    await seedStoredTranscript(page, [
+      { role: "assistant", content: cachedTranscriptMarker, timestamp: 1 },
+    ]);
+    await seedCachedSessionSettings(page);
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+
+    await page.goto(new URL(cachedSessionPath, server.baseUrl).href);
+    await gateway.waitForRequest("connect");
+    await page.getByText(cachedTranscriptMarker, { exact: true }).first().waitFor();
+    await page.evaluate(() => {
+      const app = document.querySelector("openclaw-app") as HTMLElement & {
+        runtime?: { context: { navigate: (routeId: string) => void } };
+      };
+      app.runtime?.context.navigate("appearance");
+    });
+    await page.waitForURL("**/settings/appearance");
+    await page.locator(".connect-splash").waitFor();
+    expect(await page.getByText(cachedTranscriptMarker, { exact: true }).count()).toBe(0);
+    await gateway.resolveDeferred("connect");
+    await page.locator(".settings-page").waitFor();
+    expect(await page.getByText(cachedTranscriptMarker, { exact: true }).count()).toBe(0);
+  });
+
+  it("clears a cached conversation when a pending navigation is cancelled", async () => {
+    const page = await createPage();
+    await page.goto(new URL("favicon.svg", server.baseUrl).href);
+    await seedStoredTranscript(page, [
+      { role: "assistant", content: cachedTranscriptMarker, timestamp: 1 },
+    ]);
+    await seedCachedSessionSettings(page);
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+
+    await page.goto(new URL(cachedSessionPath, server.baseUrl).href);
+    await gateway.waitForRequest("connect");
+    await page.getByText(cachedTranscriptMarker, { exact: true }).first().waitFor();
+    await page.evaluate(() => {
+      const app = document.querySelector("openclaw-app") as HTMLElement & {
+        runtime?: { context: { navigate: (routeId: string, options: object) => void } };
+      };
+      app.runtime?.context.navigate("chat", { pathname: "/chat/main/unknown-session" });
+    });
+    await page.locator(".connect-splash").waitFor();
+    expect(await page.getByText(cachedTranscriptMarker, { exact: true }).count()).toBe(0);
+
+    await page.goBack();
+    expect(await page.getByText(cachedTranscriptMarker, { exact: true }).count()).toBe(0);
   });
 
   it("shows the splash instead of the login gate while a configured token connects", async () => {

--- a/ui/src/pages/chat/route-loader-main-local.ts
+++ b/ui/src/pages/chat/route-loader-main-local.ts
@@ -1,0 +1,25 @@
+import type { SessionPathTarget } from "../../app-session-route-paths.ts";
+import {
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveUiConfiguredMainKey,
+} from "../../lib/sessions/session-key.ts";
+import type { SessionRouteContext } from "./route-loader-context.ts";
+
+export function resolveLocalMainSessionKey(
+  context: SessionRouteContext,
+  target: Extract<SessionPathTarget, { kind: "main" }>,
+): string | null {
+  if (context.gateway.snapshot.phase === "connected") {
+    return null;
+  }
+  const sessionKey = context.gateway.snapshot.sessionKey;
+  const persisted = parseAgentSessionKey(sessionKey);
+  return persisted?.rest ===
+    resolveUiConfiguredMainKey({
+      agentsList: context.agents.state.agentsList,
+      hello: context.gateway.snapshot.hello,
+    }) && normalizeAgentId(persisted.agentId) === normalizeAgentId(target.agentId)
+    ? sessionKey
+    : null;
+}

--- a/ui/src/pages/chat/route-loader-short-cache.ts
+++ b/ui/src/pages/chat/route-loader-short-cache.ts
@@ -71,8 +71,14 @@ export function findCachedShortSession(
     .get(SESSION_NAVIGATION_KEY_PARAM)
     ?.trim();
   const handoffKey = consumeSessionNavigationHandoff(context.gateway, location.pathname);
-  const carriedKey = locationKey ?? handoffKey;
-  const carriedByCurrentNavigation = Boolean(handoffKey && handoffKey === carriedKey);
+  const persistedKey =
+    context.gateway.snapshot.phase === "connected"
+      ? ""
+      : context.gateway.snapshot.sessionKey.trim();
+  const carriedKey = (locationKey ?? handoffKey ?? persistedKey) || undefined;
+  const carriedByCurrentNavigation = Boolean(
+    (handoffKey && handoffKey === carriedKey) || (persistedKey && persistedKey === carriedKey),
+  );
   if (carriedKey) {
     const preserveLocationKeyForCanonicalReload = () => {
       if (locationKey) {

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -27,6 +27,7 @@ import {
 import { draftRouteDataFromLocation, draftSearchFromLocation } from "./route-draft.ts";
 import { loadCatalogShareRouteFromLocation } from "./route-loader-catalog-share.ts";
 import type { SessionRouteContext as ApplicationContext } from "./route-loader-context.ts";
+import { resolveLocalMainSessionKey } from "./route-loader-main-local.ts";
 import {
   missingSessionRouteData,
   querySessionReference,
@@ -342,9 +343,10 @@ export async function loadChatRoute(
     };
   }
   if (target.kind === "main") {
-    await waitForGatewayClient(context.gateway, signal);
-    const sessionKey = mainSessionKey(context, target);
-    if (preferenceDerived) {
+    const localSessionKey = resolveLocalMainSessionKey(context, target);
+    await (localSessionKey ? Promise.resolve() : waitForGatewayClient(context.gateway, signal));
+    const sessionKey = localSessionKey ?? mainSessionKey(context, target);
+    if (preferenceDerived && !localSessionKey) {
       const resolution = await querySessionReference(
         context,
         { key: sessionKey, agentId: target.agentId },

--- a/ui/src/pages/chat/session-snapshot-store.test.ts
+++ b/ui/src/pages/chat/session-snapshot-store.test.ts
@@ -22,7 +22,7 @@ import {
   clearStoredChatSnapshots,
   deleteStoredChatSnapshot,
 } from "./session-snapshot-invalidation.ts";
-import { SessionSnapshotStore } from "./session-snapshot-store.ts";
+import { readStoredChatSnapshot, SessionSnapshotStore } from "./session-snapshot-store.ts";
 
 function snapshot(message: unknown, sessionId = "session-1"): ChatSessionSnapshot {
   return {
@@ -176,6 +176,17 @@ describe("persistent chat session snapshots", () => {
     await writer.flush();
 
     expect(await new SessionSnapshotStore().read(sessionKey)).toEqual(cached);
+  });
+
+  it("serves large snapshots to the startup reader and rejects an empty cache miss", async () => {
+    const sessionKey = "agent:main:startup-large";
+    const largeBody = "x".repeat(5 * 1024 * 1024);
+    const writer = new SessionSnapshotStore();
+    writer.write(sessionKey, snapshot(largeBody));
+    await writer.flush();
+
+    expect((await readStoredChatSnapshot(sessionKey))?.messages[0]).toBe(largeBody);
+    expect(await readStoredChatSnapshot("agent:main:missing")).toBeNull();
   });
 
   it("does not let an append miss replace a richer persisted snapshot", async () => {

--- a/ui/src/pages/chat/session-snapshot-store.ts
+++ b/ui/src/pages/chat/session-snapshot-store.ts
@@ -167,6 +167,12 @@ async function readSnapshotRecord(sessionKey: string): Promise<SessionSnapshotRe
   }
 }
 
+export async function readStoredChatSnapshot(
+  sessionKey: string,
+): Promise<ChatSessionSnapshot | null> {
+  return (await readSnapshotRecord(sessionKey))?.snapshot ?? null;
+}
+
 async function readSnapshotMetadata(): Promise<SessionSnapshotMetadata[] | null> {
   const database = await openSessionSnapshotDatabase();
   if (!database) {


### PR DESCRIPTION
Closes #127880

## What Problem This Solves

Fixes an issue where reopening a saved Control UI conversation showed the full-document connect splash until the Gateway hello completed, even though the transcript was already available in this browser's IndexedDB cache.

## Why This Change Was Made

The initial render gate now asks the transcript snapshot owner whether the locally identified chat has a non-empty saved transcript. Eligible chat routes mount the normal shell immediately and retain the existing offline/connecting presentation while Gateway hello and delta reconciliation remain authoritative.

The authorization is one-shot and fenced by the exact Gateway, credential startup state, route, application navigation generation, browser history traversal, and an explicit retirement epoch. New credentials, Gateway replacement, terminal rejection, navigation, cancellation, and teardown retire it. Empty, invalid, legacy-upgraded, non-chat, and locally unresolved routes keep the existing splash. No storage schema, config, protocol, or CSS changes.

## User Impact

Returning operators see the conversation already stored on their device instead of waiting behind the mascot. When the Gateway connects, the same mounted transcript reconciles normally. If credentials are rejected, the cached shell disappears and the login gate takes over.

## Evidence

Built mocked-Gateway Chromium, 2 s delayed hello:

- Before on current main: cached transcript visible after 3,169 ms, only after hello.
- After on this head: cached transcript visible after 457 ms, before hello.
- Startup JS: 340,642 B gzip against the 340,900 B enforced limit, 258 B under budget; 8 requests.

Focused validation:

- `node scripts/run-vitest.mjs ui/src/app/app-host.gateway-lineage.test.ts ui/src/app/bootstrap.test.ts ui/src/pages/chat/route.test.ts ui/src/pages/chat/route-resolution.test.ts ui/src/pages/chat/session-snapshot-store.test.ts ui/src/pages/chat/chat-pane-snapshot-hydration.test.ts ui/src/pages/chat/chat-pane.test.ts`: 152/152 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/initial-connect-splash.e2e.test.ts`: 15/15 passed.
- `node scripts/check-changed.mjs`: passed.
- `pnpm ui:build`: passed.
- Final structured review: no accepted/actionable P0/P1 findings.

Required boundary scenarios:

- Connection drops and returns during cached paint: retry keeps the shell and transcript mounted, then reconciliation completes.
- Two concurrent tabs: both read and paint the same coherent IndexedDB snapshot before hello.
- Older persisted version: the existing v1-to-v2 cache reset remains canonical; startup keeps the splash and paints no stale transcript.
- Large and empty transcript: a 5 MiB snapshot round-trips through the startup reader; an empty snapshot keeps the splash.
- Cancellation/navigation before hello: route start, cancellation, SPA navigation, and browser history traversal retire both ready and in-flight probes.
- Rejected hello: `AUTH_TOKEN_MISMATCH` removes the transcript and shell, then shows only the login gate.

Cached transcript visible while hello is pending; the composer and account chrome visibly report offline state:

![Cached transcript before Gateway hello](https://github.com/user-attachments/assets/ff84ebbb-6737-49f0-a0c3-04ab754fb74a)

The same transcript after Gateway hello reconciles connected controls without remounting the splash:

![Reconciled transcript after Gateway hello](https://github.com/user-attachments/assets/48e606fa-0dcf-4b9c-80f5-8c921b704af3)

Inspected built-flow recording:

https://github.com/user-attachments/assets/a2626784-ddf8-4430-a54b-8931b25cac18

Production LOC: +188/-9 (net +179). Tests: +305/-2. Production growth owns the lazy local snapshot probe, pre-hello route resolution, and credential/navigation/history lifecycle fences; snapshot storage and normal chat reconciliation stay on their existing canonical paths.