### PR TITLE
fix(nvidia): live models lose reasoning, vision, and coding capabilities

### DIFF
--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -69,12 +69,13 @@ openclaw onboard --auth-choice nvidia-api-key --nvidia-api-key "nvapi-..."
 When an NVIDIA API key is configured, setup and model-selection paths fetch
 NVIDIA's public featured-model catalog from
 `https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json` and
-cache the result for 24 hours (first 32 entries, imported as free text-input
-rows). New or republished featured models from build.nvidia.com therefore appear
-in setup and model-selection surfaces after the cache refreshes, without waiting
-for an OpenClaw release. A fresh NVIDIA catalog overrides bundled retirement
-metadata. When the live feed is available, its first model is preselected during
-NVIDIA setup.
+cache the result for 24 hours (first 32 entries, imported as free rows). Known
+models retain their bundled reasoning, image, and compatibility capabilities;
+unfamiliar models default to text input. New or republished featured models from
+build.nvidia.com therefore appear in setup and model-selection surfaces after
+the cache refreshes, without waiting for an OpenClaw release. A fresh NVIDIA
+catalog overrides bundled retirement metadata. When the live feed is available,
+its first model is preselected during NVIDIA setup.
 
 The fetch uses a fixed HTTPS host policy for `assets.ngc.nvidia.com`. If no
 NVIDIA API key is configured, or if the feed is unavailable or malformed,

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -250,6 +250,90 @@ describe("nvidia provider catalog", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    { surface: "live", build: buildLiveNvidiaProvider },
+    { surface: "selectable live", build: buildSelectableLiveNvidiaProvider },
+  ])("preserves bundled capabilities in the $surface featured catalog", async ({ build }) => {
+    mockFeaturedCatalogResponse({
+      "featured-models": [
+        {
+          model: "nemotron-3-ultra-550b-a55b",
+          "model-name": "Featured Ultra",
+          context: 524_288,
+          "max-output": 4_096,
+        },
+        {
+          model: "minimaxai/minimax-m3",
+          "model-name": "Featured MiniMax",
+          context: 196_608,
+          "max-output": 8_192,
+        },
+        {
+          model: "z-ai/glm-5.2",
+          "model-name": "Featured GLM",
+          context: 202_752,
+          "max-output": 8_192,
+        },
+        {
+          model: "qwen/qwen3.5-397b-a17b",
+          "model-name": "Republished Qwen",
+          context: 131_072,
+          "max-output": 16_384,
+        },
+        {
+          model: "new-vendor/new-model",
+          "model-name": "New Model",
+          context: 65_536,
+          "max-output": 4_096,
+        },
+      ],
+    });
+
+    const provider = await build();
+
+    expect(provider.models).toMatchObject([
+      {
+        id: "nvidia/nemotron-3-ultra-550b-a55b",
+        name: "Featured Ultra",
+        reasoning: true,
+        input: ["text"],
+        contextWindow: 524_288,
+        maxTokens: 4_096,
+        params: {
+          chat_template_kwargs: {
+            enable_thinking: false,
+            force_nonempty_content: true,
+          },
+        },
+      },
+      {
+        id: "minimaxai/minimax-m3",
+        reasoning: true,
+        input: ["text", "image"],
+      },
+      {
+        id: "z-ai/glm-5.2",
+        reasoning: true,
+        compat: { requiresStringContent: true, codeMode: "capable" },
+      },
+      {
+        id: "qwen/qwen3.5-397b-a17b",
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 131_072,
+        maxTokens: 16_384,
+      },
+      {
+        id: "new-vendor/new-model",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        compat: { requiresStringContent: true },
+      },
+    ]);
+    expect(provider.models[3]).not.toHaveProperty("status");
+  });
+
   it("falls back to the bundled catalog when the featured catalog is unavailable", async () => {
     mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
 

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -24,12 +24,6 @@ const FEATURED_MODEL_MAX_ID_LENGTH = 200;
 const FEATURED_MODEL_MAX_NAME_LENGTH = 200;
 const FEATURED_MODEL_MAX_CONTEXT_WINDOW = 10_000_000;
 const FEATURED_MODEL_MAX_OUTPUT_TOKENS = 1_000_000;
-const FEATURED_MODEL_COST = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-} as const;
 const NVIDIA_ULTRA_DEFAULT_PARAMS = {
   chat_template_kwargs: {
     enable_thinking: false,
@@ -146,9 +140,10 @@ async function loadNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | nul
 }
 
 function parseNvidiaFeaturedModels(rows: readonly unknown[]): ModelDefinitionConfig[] | null {
+  const bundledModels = new Map(buildNvidiaProvider().models.map((model) => [model.id, model]));
   const models = rows
     .slice(0, FEATURED_MODEL_MAX_ROWS)
-    .map(parseNvidiaFeaturedModel)
+    .map((row) => parseNvidiaFeaturedModel(row, bundledModels))
     .filter((model) => model !== null);
   return models.length > 0 ? models : null;
 }
@@ -176,7 +171,10 @@ function filterSelectableNvidiaModels(models: ModelDefinitionConfig[]): ModelDef
   return models.filter((model) => !DEPRECATED_NVIDIA_MODEL_IDS.has(model.id));
 }
 
-function parseNvidiaFeaturedModel(row: unknown): ModelDefinitionConfig | null {
+function parseNvidiaFeaturedModel(
+  row: unknown,
+  bundledModels: ReadonlyMap<string, ModelDefinitionConfig>,
+): ModelDefinitionConfig | null {
   if (!row || typeof row !== "object") {
     return null;
   }
@@ -194,15 +192,17 @@ function parseNvidiaFeaturedModel(row: unknown): ModelDefinitionConfig | null {
   if (!id || !name) {
     return null;
   }
+  const bundled = bundledModels.get(id);
   return {
     id,
     name,
-    reasoning: false,
-    input: ["text"],
+    reasoning: bundled?.reasoning ?? false,
+    input: bundled?.input ?? ["text"],
     contextWindow: entry.context,
     maxTokens: entry["max-output"],
-    cost: { ...FEATURED_MODEL_COST },
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     compat: {
+      ...bundled?.compat,
       requiresStringContent: true,
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where enabling NVIDIA's live featured-model catalog made every currently featured reasoning model appear unable to reason, removed image support from MiniMax M3, and dropped coding capabilities from GLM and DeepSeek models.

## Why This Change Was Made

The NVIDIA live catalog provides fresh model identities, names, ordering, context windows, and output limits but does not publish complete capability metadata. The canonical NVIDIA parser now prepares the bundled authoritative model catalog once and preserves known reasoning, image, and compatibility capabilities while retaining fresh vendor-owned values, existing Ultra defaults, republished models, and conservative text-only defaults for unfamiliar models. Production code remains net neutral.

## User Impact

NVIDIA's actual reasoning, vision, and coding models retain their supported capabilities when live model discovery is enabled instead of degrading silently during setup and selection.

## Evidence

- The real public NVIDIA featured-model endpoint reproduced reasoning loss for all five current rows, image loss for MiniMax M3, and missing coding capabilities for GLM and DeepSeek.
- NVIDIA's public MiniMax model documentation independently identifies the model as multimodal and accepts image input: https://build.nvidia.com/minimaxai/minimax-m3
- Authentic pre-fix regressions failed on both live catalog paths; repaired owner coverage now verifies both paths, the default Ultra model, image support, coding support, republished retired models, unfamiliar models, vendor limits, and model ordering.
- All 33 NVIDIA plugin tests passed; the final one-snapshot optimization additionally passed all 15 catalog owner tests and was rechecked against the real public provider feed.
- Documentation, focused lint, formatting, and independent complete-diff structured review pass.
