### PR TITLE
fix(plugins): generated providers fail to compile after installation

### DIFF
--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -826,7 +826,12 @@ describe("plugin authoring commands", () => {
     const indexSource = fs.readFileSync(path.join(projectDir, "src/index.ts"), "utf8");
     expect(indexSource).toContain("definePluginEntry");
     expect(indexSource).toContain("api.registerProvider");
-    expect(indexSource).toContain("buildSingleProviderApiKeyCatalog");
+    const hostPackage = JSON.parse(
+      fs.readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ) as { exports: Record<string, { types?: string }> };
+    for (const [, subpath] of indexSource.matchAll(/from "openclaw\/plugin-sdk\/([^"]+)"/gu)) {
+      expect(hostPackage.exports[`./plugin-sdk/${subpath}`], subpath).toHaveProperty("types");
+    }
 
     expect(fs.readFileSync(path.join(projectDir, "src/index.test.ts"), "utf8")).toContain(
       "OpenClawPluginApi",

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -640,37 +640,12 @@ function writeProviderPluginScaffold(params: { rootDir: string; id: string; name
     `Replace https://api.example.com/v1 with your ${params.name} API base URL.`,
   );
   const indexSource = `import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
-import { buildSingleProviderApiKeyCatalog } from "openclaw/plugin-sdk/provider-catalog-shared";
-import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
 
 const PLUGIN_ID = ${idLiteral};
 const PROVIDER_ID = PLUGIN_ID;
 const DEFAULT_MODEL_ID = ${defaultModelIdLiteral};
 const DEFAULT_MODEL_REF = ${defaultModelRefLiteral};
-
-function buildProvider(): ModelProviderConfig {
-  return {
-    api: "openai-completions",
-    baseUrl: "https://api.example.com/v1",
-    models: [
-      {
-        id: DEFAULT_MODEL_ID,
-        name: "Example Chat",
-        reasoning: false,
-        input: ["text"],
-        cost: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-        },
-        contextWindow: 128000,
-        maxTokens: 8192,
-      },
-    ],
-  };
-}
 
 export default definePluginEntry({
   id: PLUGIN_ID,
@@ -700,13 +675,32 @@ export default definePluginEntry({
       ],
       catalog: {
         order: "simple",
-        run: (ctx) =>
-          buildSingleProviderApiKeyCatalog({
-            ctx,
-            providerId: PROVIDER_ID,
-            buildProvider,
-            allowExplicitBaseUrl: true,
-          }),
+        run: async (ctx) => {
+          const providerId = PROVIDER_ID.trim().toLowerCase();
+          const apiKey = ctx.resolveProviderApiKey(providerId).apiKey;
+          if (!apiKey) return null;
+          const configuredBaseUrl = Object.entries(ctx.config.models?.providers ?? {}).find(
+            ([id]) => id.trim().toLowerCase() === providerId,
+          )?.[1]?.baseUrl?.trim();
+          return {
+            provider: {
+              api: "openai-completions",
+              baseUrl: configuredBaseUrl || "https://api.example.com/v1",
+              apiKey,
+              models: [
+                {
+                  id: DEFAULT_MODEL_ID,
+                  name: "Example Chat",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 8192,
+                },
+              ],
+            },
+          };
+        },
       },
     });
   },


### PR DESCRIPTION
> Landing paused: main now includes an overlapping scaffold repair from #133616, merged as c093e85957b6ac9a3bda486a8de4fd43eafe57c8. The native current-main check and local merge-tree report conflicts in both files. The exact reviewed candidate below is preserved; implementation reconciliation requires maintainer review before CI/native landing can continue.

## What Problem This Solves

Provider plugins generated by `openclaw plugins init --type provider` fail strict TypeScript compilation after installation: three private SDK subpaths do not ship public declarations.

## What Changes

The generator uses the public `plugin-entry` and `provider-auth` entrypoints and the public catalog context directly. Credential gating, normalized provider IDs, explicit base-URL overrides, model metadata, and auth registration are preserved. No SDK exports, dependencies, configuration, or release files change.

This is the exact original two-file patch from b17296e676458f02d56fddbf7597444b0e8858c2 applied on the verified main baseline 964fa991c0aff81e2ae46a0c9f99ebc0ab349d1a, committed as 9448ee4badcf9586ea1e1df1778ced4a632e1e36. Stable patch ID: `d0164bb14d3c2d07a13a786f3bffbf9941979c86`. Production +27/-33 (net -6); tests +6/-1 (net +5).

## Validation

- Real installed registry package and locally built/packed/installed candidate tarball: the old generated source produces three `TS7016` compiler errors; the repaired generated source compiles and its test passes. The installed candidate CLI generates byte-identical repaired source. This is local package validation, not publication.
- Six real catalog before/after cases preserve missing-key gating, normal credentials, explicit and blank base URLs, normalized configured provider IDs, and unrelated-provider behavior; auth metadata also matches.
- `pnpm test:plugins:init-provider-scaffold` with isolated home/state/temp directories passes; Inspector reports 0 breakages, 0 warnings, 0 issues.
- Focused plugin-authoring, provider catalog/auth/discovery and SDK sibling tests: 77 pass. Public SDK export/package tests: 15 pass. The new regression fails against the old generator as expected.
- Full canonical build, npm pack inventory/integrity and installed-package import checks pass. Changed-file gates, UI style lint, formatting and `git diff --check` pass.
- Main baseline already contains the CSS repair: largest boot CSS is 349,082 raw / 54,732 gzip bytes, below the unchanged 54,784-byte limit. No CSS or budget change is included here.
- Fresh independent review of the frozen candidate reports no actionable findings. Exact-head hosted CI and native prepare/merge remain required before landing.

## Review Disposition / Limits

The latest ClawSweeper review has no code findings. Its remaining CI and maintainer-review items are addressed by fresh independent review and the new exact-head CI run; the rank-up request is to resolve the old red checks before merging. A fresh bot review is requested because its prior review is over 12 hours old.

No authenticated provider inference or operator Gateway was needed: the repaired contract is standalone installed-package compilation and catalog behavior. Introduction provenance is unknown in the available shallow history; the released package failure was reproduced directly. No release, version, or changelog change.
