### PR TITLE
fix(macos): failed service commands incorrectly report success

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -362,7 +362,7 @@ extension GatewayLaunchAgentManager {
         let message = (parsed?.object["error"] as? String) ?? (parsed?.object["message"] as? String)
         let payload = parsed?.text.data(using: .utf8)
             ?? (response.stdout.isEmpty ? response.stderr : response.stdout).data(using: .utf8)
-        let success = ok ?? response.success
+        let success = response.success && (ok ?? true)
         if success {
             return CommandResult(success: true, payload: payload, message: nil)
         }

--- a/apps/macos/Sources/OpenClaw/NodeServiceManager.swift
+++ b/apps/macos/Sources/OpenClaw/NodeServiceManager.swift
@@ -129,7 +129,7 @@ extension NodeServiceManager {
         let message = parsed?.error ?? parsed?.message
         let payload = parsed?.text.data(using: .utf8)
             ?? (response.stdout.isEmpty ? response.stderr : response.stdout).data(using: .utf8)
-        let success = ok ?? response.success
+        let success = response.success && (ok ?? true)
         if success {
             return CommandResult(success: true, payload: payload, message: nil, parsed: parsed)
         }

--- a/apps/macos/Tests/OpenClawIPCTests/NodeServiceManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/NodeServiceManagerTests.swift
@@ -97,6 +97,46 @@ import Testing
         }
     }
 
+    @Test(arguments: [
+        "failed-start", "failed-stop", "failed-restart", "json-success", "plain-success", "json-failure",
+    ])
+    func `node lifecycle respects process exit and optional JSON status`(_ scenario: String) async throws {
+        let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await TestIsolation.withIsolatedState(
+            env: ["OPENCLAW_NODE_SERVICE_TEST_CASE": scenario],
+            defaults: ["openclaw.gatewayProjectRootPath": nil])
+        {
+            CommandResolver.setProjectRoot(root.path)
+            let executable = root.appendingPathComponent("node_modules/.bin/openclaw")
+            try makeExecutableForTests(at: executable)
+            let script = """
+            #!/bin/sh
+            case "$OPENCLAW_NODE_SERVICE_TEST_CASE" in
+              failed-*) printf '{"ok":true}'; printf 'cleanup failed' >&2; exit 23 ;;
+              json-failure) printf '{"ok":false,"error":"reported failure"}' ;;
+              plain-success) printf 'service started' ;;
+              *) printf '{"ok":true}' ;;
+            esac
+            """
+            try script.write(to: executable, atomically: false, encoding: .utf8)
+
+            let action = switch scenario {
+            case "failed-stop": "stop"
+            case "failed-restart": "restart"
+            default: "start"
+            }
+            let expectedError: String? = switch scenario {
+            case "failed-start", "failed-stop", "failed-restart": "cleanup failed"
+            case "json-failure": "reported failure"
+            default: nil
+            }
+
+            #expect(await self.runNodeServiceAction(action, profile: AppProfile(environment: [:])) == expectedError)
+        }
+    }
+
     @Test func `reads node service ownership command directly from launchd`() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("openclaw-node-\(UUID().uuidString).plist")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS node and Gateway service actions could report success after their underlying command failed or timed out whenever stale command output happened to include `{"ok":true}`.

## Why This Change Was Made

Both existing service managers now require the actual subprocess to succeed before accepting its optional JSON status. Explicit JSON failures, successful commands without JSON, normal successful JSON, and existing Gateway test isolation remain unchanged. Production code remains net neutral.

## User Impact

Failed or timed-out node/Gateway start, stop, and restart operations are surfaced correctly instead of leaving the native app believing a dead service started successfully.

## Evidence

- Authentic pre-fix native regressions executed an isolated real shell command that printed `{"ok":true}` but exited 23; node start, stop, and restart all incorrectly reported success.
- After repair, all 26 tests pass across `NodeServiceManagerTests`, `GatewayLaunchAgentManagerTests`, and `ShellExecutorTimeoutTests`, including real timeout cleanup and JSON/no-JSON success/failure controls.
- The existing Gateway test-only fail-closed process guard remains intact; no operator service or Gateway was started.
- SwiftFormat, strict SwiftLint, and independent complete-diff structured review pass.
