### PR TITLE
fix(ui): chat file copy hides successful and failed outcomes

### DIFF
--- a/ui/src/app/app-host-pairing-access.test.ts
+++ b/ui/src/app/app-host-pairing-access.test.ts
@@ -304,7 +304,7 @@ describe("application shell pairing access", () => {
     button?.click();
 
     await waitForFast(() => expect(button?.textContent?.trim()).toBe("Copy failed"));
-    expect(button?.getAttribute("aria-label")).toBe("Copy failed");
+    expect(button?.getAttribute("aria-label")).toBeNull();
     expect(button?.querySelector("svg")).not.toBeNull();
     expect(writeText).toHaveBeenCalledWith("pair-mobile-secret");
     expect(execCommand).toHaveBeenCalledWith("copy");
@@ -316,7 +316,7 @@ describe("application shell pairing access", () => {
     reset();
 
     expect(button?.textContent?.trim()).toBe("Copy setup code");
-    expect(button?.getAttribute("aria-label")).toBe("Copy setup code");
+    expect(button?.getAttribute("aria-label")).toBeNull();
   });
 
   it("expires a node setup link from the pairing clock", async () => {

--- a/ui/src/components/copy-button.ts
+++ b/ui/src/components/copy-button.ts
@@ -18,17 +18,18 @@ function readButtonLabel(button: HTMLButtonElement) {
 }
 
 function setButtonLabel(button: HTMLButtonElement, label: string, showFeedback = false) {
-  button.setAttribute("aria-label", label);
   // Feedback sits beside fixed-size icons; actionable tooltips dismiss on click.
   const feedback = button.parentElement?.querySelector<HTMLElement>("[data-copy-feedback]");
   if (feedback) {
     feedback.hidden = !showFeedback;
     feedback.textContent = label;
   }
-  // Preserve Lit's marker nodes so a later locale change can rerender this label.
+  // Keep Lit markers; a separate aria-label goes stale when visible text rerenders.
   const visibleLabel = button.querySelector("[data-copy-label]")?.lastChild;
   if (visibleLabel?.nodeType === Node.TEXT_NODE) {
     visibleLabel.nodeValue = label;
+  } else {
+    button.setAttribute("aria-label", label);
   }
 }
 

--- a/ui/src/components/copy-button.ts
+++ b/ui/src/components/copy-button.ts
@@ -11,13 +11,13 @@ export function copyMarkdownLabel(): string {
   return t("chat.actions.copyAsMarkdown");
 }
 
-function setButtonLabel(button: HTMLButtonElement, label: string) {
+function setButtonLabel(button: HTMLButtonElement, label: string, showFeedback = false) {
   button.setAttribute("aria-label", label);
   // Feedback sits beside fixed-size icons; actionable tooltips dismiss on click.
   const feedback = button.parentElement?.querySelector<HTMLElement>("[data-copy-feedback]");
   if (feedback) {
-    feedback.hidden = !button.dataset.copied && !button.dataset.error;
-    feedback.textContent = feedback.hidden ? "" : label;
+    feedback.hidden = !showFeedback;
+    feedback.textContent = label;
   }
   // Preserve Lit's marker nodes so a later locale change can rerender this label.
   const visibleLabel = button.querySelector("[data-copy-label]")?.lastChild;
@@ -28,41 +28,38 @@ function setButtonLabel(button: HTMLButtonElement, label: string) {
 
 export async function handleCopyButton(event: Event, text: string, idleLabel: string) {
   const button = event.currentTarget as HTMLButtonElement | null;
-  if (!button || button.dataset.copying === "1") {
+  if (!button || button.dataset.copyState === "copying") {
     return false;
   }
 
   // Older reset timers must not replace feedback from a newer copy attempt.
   const attempt = String(Number(button.dataset.copyAttempt ?? "0") + 1);
   button.dataset.copyAttempt = attempt;
-  button.dataset.copying = "1";
+  button.dataset.copyState = "copying";
   button.setAttribute("aria-busy", "true");
   button.disabled = true;
-  delete button.dataset.copied;
-  delete button.dataset.error;
   setButtonLabel(button, idleLabel);
 
   // Retired buttons must not overwrite a newer copy through the legacy fallback.
   const isCurrent = () => button.isConnected && button.dataset.copyAttempt === attempt;
   const copied = await copyToClipboard(text, isCurrent);
-  delete button.dataset.copying;
+  delete button.dataset.copyState;
   button.removeAttribute("aria-busy");
   button.disabled = false;
   if (!isCurrent()) {
     return false;
   }
 
-  const feedback = copied ? "copied" : "error";
-  button.dataset[feedback] = "1";
+  button.dataset.copyState = copied ? "copied" : "error";
   const feedbackLabel = t(copied ? "common.copied" : "common.copyFailed");
-  setButtonLabel(button, feedbackLabel);
+  setButtonLabel(button, feedbackLabel, true);
 
   const duration = copied ? COPIED_FOR_MS : ERROR_FOR_MS;
   window.setTimeout(() => {
     if (!isCurrent()) {
       return;
     }
-    delete button.dataset[feedback];
+    delete button.dataset.copyState;
     // A locale rerender can replace the idle label while feedback is still active.
     const renderedLabel =
       button.querySelector("[data-copy-label]")?.textContent ?? button.getAttribute("aria-label");
@@ -74,7 +71,11 @@ export async function handleCopyButton(event: Event, text: string, idleLabel: st
   return copied;
 }
 
-function createCopyButton(text: string, idleLabel: string, bare = false): TemplateResult {
+export function renderCopyButton(
+  text: string,
+  idleLabel = copyMarkdownLabel(),
+  bare = false,
+): TemplateResult {
   // Chat footers own their ghost chrome; .btn backgrounds would box the icon.
   return html`
     <openclaw-tooltip .content=${idleLabel}>
@@ -94,10 +95,6 @@ function createCopyButton(text: string, idleLabel: string, bare = false): Templa
   `;
 }
 
-export function renderCopyButton(text: string, label?: string): TemplateResult {
-  return createCopyButton(text, label ?? copyMarkdownLabel());
-}
-
 export function renderCopyAsMarkdownButton(markdown: string): TemplateResult {
-  return createCopyButton(markdown, copyMarkdownLabel(), true);
+  return renderCopyButton(markdown, copyMarkdownLabel(), true);
 }

--- a/ui/src/components/copy-button.ts
+++ b/ui/src/components/copy-button.ts
@@ -11,16 +11,14 @@ export function copyMarkdownLabel(): string {
   return t("chat.actions.copyAsMarkdown");
 }
 
-type CopyButtonOptions = {
-  text: () => string;
-  label?: string;
-  // Chat message footers style their buttons as ghost icons; the .btn chrome
-  // (light-mode background overrides) would outrank those rules and box them.
-  bare?: boolean;
-};
-
 function setButtonLabel(button: HTMLButtonElement, label: string) {
   button.setAttribute("aria-label", label);
+  // Feedback sits beside fixed-size icons; actionable tooltips dismiss on click.
+  const feedback = button.parentElement?.querySelector<HTMLElement>("[data-copy-feedback]");
+  if (feedback) {
+    feedback.hidden = !button.dataset.copied && !button.dataset.error;
+    feedback.textContent = feedback.hidden ? "" : label;
+  }
   // Preserve Lit's marker nodes so a later locale change can rerender this label.
   const visibleLabel = button.querySelector("[data-copy-label]")?.lastChild;
   if (visibleLabel?.nodeType === Node.TEXT_NODE) {
@@ -40,6 +38,9 @@ export async function handleCopyButton(event: Event, text: string, idleLabel: st
   button.dataset.copying = "1";
   button.setAttribute("aria-busy", "true");
   button.disabled = true;
+  delete button.dataset.copied;
+  delete button.dataset.error;
+  setButtonLabel(button, idleLabel);
 
   // Retired buttons must not overwrite a newer copy through the legacy fallback.
   const isCurrent = () => button.isConnected && button.dataset.copyAttempt === attempt;
@@ -52,7 +53,6 @@ export async function handleCopyButton(event: Event, text: string, idleLabel: st
   }
 
   const feedback = copied ? "copied" : "error";
-  delete button.dataset[copied ? "error" : "copied"];
   button.dataset[feedback] = "1";
   const feedbackLabel = t(copied ? "common.copied" : "common.copyFailed");
   setButtonLabel(button, feedbackLabel);
@@ -74,29 +74,30 @@ export async function handleCopyButton(event: Event, text: string, idleLabel: st
   return copied;
 }
 
-function createCopyButton(options: CopyButtonOptions): TemplateResult {
-  const idleLabel = options.label ?? copyMarkdownLabel();
+function createCopyButton(text: string, idleLabel: string, bare = false): TemplateResult {
+  // Chat footers own their ghost chrome; .btn backgrounds would box the icon.
   return html`
     <openclaw-tooltip .content=${idleLabel}>
       <button
-        class=${options.bare ? "chat-copy-btn" : "btn btn--xs chat-copy-btn"}
+        class=${bare ? "chat-copy-btn" : "btn btn--xs chat-copy-btn"}
         type="button"
         aria-label=${idleLabel}
-        @click=${(event: Event) => void handleCopyButton(event, options.text(), idleLabel)}
+        @click=${(event: Event) => void handleCopyButton(event, text, idleLabel)}
       >
         <span class="chat-copy-btn__icon" aria-hidden="true">
           <span class="chat-copy-btn__icon-copy">${icons.copy}</span>
           <span class="chat-copy-btn__icon-check">${icons.check}</span>
         </span>
       </button>
+      <span data-copy-feedback role="status" hidden></span>
     </openclaw-tooltip>
   `;
 }
 
 export function renderCopyButton(text: string, label?: string): TemplateResult {
-  return createCopyButton({ text: () => text, label });
+  return createCopyButton(text, label ?? copyMarkdownLabel());
 }
 
 export function renderCopyAsMarkdownButton(markdown: string): TemplateResult {
-  return createCopyButton({ text: () => markdown, bare: true });
+  return createCopyButton(markdown, copyMarkdownLabel(), true);
 }

--- a/ui/src/components/copy-button.ts
+++ b/ui/src/components/copy-button.ts
@@ -58,7 +58,7 @@ export async function handleCopyButton(event: Event, text: string, idleLabel: st
 
   button.dataset.copyState = copied ? "copied" : "error";
   // Keep a locale rerender that landed while the clipboard write was pending.
-  idleLabel = readButtonLabel(button) ?? idleLabel;
+  const resetLabel = readButtonLabel(button) ?? idleLabel;
   const feedbackLabel = t(copied ? "common.copied" : "common.copyFailed");
   setButtonLabel(button, feedbackLabel, true);
 
@@ -72,7 +72,7 @@ export async function handleCopyButton(event: Event, text: string, idleLabel: st
     const renderedLabel = readButtonLabel(button);
     setButtonLabel(
       button,
-      renderedLabel && renderedLabel !== feedbackLabel ? renderedLabel : idleLabel,
+      renderedLabel && renderedLabel !== feedbackLabel ? renderedLabel : resetLabel,
     );
   }, duration);
   return copied;

--- a/ui/src/components/copy-button.ts
+++ b/ui/src/components/copy-button.ts
@@ -11,6 +11,12 @@ export function copyMarkdownLabel(): string {
   return t("chat.actions.copyAsMarkdown");
 }
 
+function readButtonLabel(button: HTMLButtonElement) {
+  return (
+    button.querySelector("[data-copy-label]")?.textContent ?? button.getAttribute("aria-label")
+  );
+}
+
 function setButtonLabel(button: HTMLButtonElement, label: string, showFeedback = false) {
   button.setAttribute("aria-label", label);
   // Feedback sits beside fixed-size icons; actionable tooltips dismiss on click.
@@ -51,6 +57,8 @@ export async function handleCopyButton(event: Event, text: string, idleLabel: st
   }
 
   button.dataset.copyState = copied ? "copied" : "error";
+  // Keep a locale rerender that landed while the clipboard write was pending.
+  idleLabel = readButtonLabel(button) ?? idleLabel;
   const feedbackLabel = t(copied ? "common.copied" : "common.copyFailed");
   setButtonLabel(button, feedbackLabel, true);
 
@@ -61,8 +69,7 @@ export async function handleCopyButton(event: Event, text: string, idleLabel: st
     }
     delete button.dataset.copyState;
     // A locale rerender can replace the idle label while feedback is still active.
-    const renderedLabel =
-      button.querySelector("[data-copy-label]")?.textContent ?? button.getAttribute("aria-label");
+    const renderedLabel = readButtonLabel(button);
     setButtonLabel(
       button,
       renderedLabel && renderedLabel !== feedbackLabel ? renderedLabel : idleLabel,

--- a/ui/src/components/file-preview-modal.test.ts
+++ b/ui/src/components/file-preview-modal.test.ts
@@ -68,6 +68,8 @@ describe("openclaw-file-preview-modal", () => {
     container.replaceChildren();
     container.remove();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete (document as unknown as { execCommand?: unknown }).execCommand;
   });
 
   it("filters files by path or contents", async () => {
@@ -241,40 +243,73 @@ describe("openclaw-file-preview-modal", () => {
     });
   });
 
-  it("rerenders default copy when the locale changes", async () => {
-    const modal = await renderPreview();
-    i18n.registerTranslation("pt-BR", {
-      common: { close: "Fechar" },
-      filePreview: {
-        label: "Arquivos de suporte",
-        listLabel: "Arquivos",
-        searchPlaceholder: "Buscar arquivos…",
-        readOnly: "somente leitura",
-        emptyTitle: "Nenhum arquivo corresponde",
-        emptySubtitle: "Tente outro nome ou conteúdo.",
-        copyFile: "Copiar arquivo",
-        fileCount: "{count} arquivos",
-        filteredFileCount: "{count}/{total} arquivos",
-        noMatches: "Nenhum arquivo corresponde.",
-        navigate: "navegar",
-        kind: {
-          text: "Texto",
-          shell: "Shell",
-          file: "Arquivo",
+  it.each([true, false])(
+    "restores localized file-copy labels after pending success %s",
+    async (copied) => {
+      const write = Promise.withResolvers<void>();
+      const writeText = vi.fn(() => write.promise);
+      vi.stubGlobal("navigator", { clipboard: { writeText } });
+      Object.defineProperty(document, "execCommand", { configurable: true, value: () => false });
+      const schedule = vi.spyOn(window, "setTimeout");
+      const modal = await renderPreview();
+      const button = modal.shadowRoot!.querySelector<HTMLButtonElement>(".chat-copy-btn")!;
+      button.click();
+      expect(button.disabled).toBe(true);
+      i18n.registerTranslation("pt-BR", {
+        common: { close: "Fechar", copied: "Copiado!", copyFailed: "Falha ao copiar" },
+        filePreview: {
+          label: "Arquivos de suporte",
+          listLabel: "Arquivos",
+          searchPlaceholder: "Buscar arquivos…",
+          readOnly: "somente leitura",
+          emptyTitle: "Nenhum arquivo corresponde",
+          emptySubtitle: "Tente outro nome ou conteúdo.",
+          copyFile: "Copiar arquivo",
+          fileCount: "{count} arquivos",
+          filteredFileCount: "{count}/{total} arquivos",
+          noMatches: "Nenhum arquivo corresponde.",
+          navigate: "navegar",
+          kind: {
+            text: "Texto",
+            shell: "Shell",
+            file: "Arquivo",
+          },
         },
-      },
-    });
+      });
 
-    await i18n.setLocale("pt-BR");
-    await modal.updateComplete;
+      await i18n.setLocale("pt-BR");
+      await modal.updateComplete;
 
-    expect(
-      modal.shadowRoot?.querySelector<HTMLElement & { label: string }>("openclaw-modal-dialog")
-        ?.label,
-    ).toBe("Arquivos de suporte");
-    expect(shadowText(modal)).toContain("2 arquivos");
-    expect(shadowText(modal)).toContain("Fechar");
-  });
+      expect(
+        modal.shadowRoot?.querySelector<HTMLElement & { label: string }>("openclaw-modal-dialog")
+          ?.label,
+      ).toBe("Arquivos de suporte");
+      expect(shadowText(modal)).toContain("2 arquivos");
+      expect(shadowText(modal)).toContain("Fechar");
+      expect(button.getAttribute("aria-label")).toBe("Copiar arquivo");
+      if (copied) {
+        write.resolve();
+      } else {
+        write.reject(new DOMException("Clipboard access denied"));
+      }
+      const feedback = modal.shadowRoot!.querySelector<HTMLElement>("[role=status]")!;
+      await vi.waitFor(() =>
+        expect(feedback.textContent).toBe(copied ? "Copiado!" : "Falha ao copiar"),
+      );
+      expect(feedback.hidden).toBe(false);
+      expect(button.getAttribute("aria-label")).toBe(feedback.textContent);
+      expect(writeText).toHaveBeenCalledWith(files[0].contents);
+      const reset = schedule.mock.calls.find(
+        ([, delay]) => delay === (copied ? 1_500 : 2_000),
+      )?.[0];
+      if (typeof reset !== "function") {
+        throw new Error("Expected copy feedback to schedule its reset");
+      }
+      reset();
+      expect(button.getAttribute("aria-label")).toBe("Copiar arquivo");
+      expect(feedback.hidden).toBe(true);
+    },
+  );
 
   it("localizes generic file-kind chips", async () => {
     i18n.registerTranslation("pt-BR", {

--- a/ui/src/components/file-preview-modal.test.ts
+++ b/ui/src/components/file-preview-modal.test.ts
@@ -247,7 +247,7 @@ describe("openclaw-file-preview-modal", () => {
   it.each([true, false])(
     "restores localized file-copy labels after pending success %s",
     async (copied) => {
-      const write = createDeferred<void>();
+      const write = createDeferred();
       const writeText = vi.fn(() => write.promise);
       vi.stubGlobal("navigator", { clipboard: { writeText } });
       Object.defineProperty(document, "execCommand", { configurable: true, value: () => false });

--- a/ui/src/components/file-preview-modal.test.ts
+++ b/ui/src/components/file-preview-modal.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { i18n } from "../i18n/index.ts";
 import { OpenClawFilePreviewModal } from "./file-preview-modal.ts";
 
@@ -246,7 +247,7 @@ describe("openclaw-file-preview-modal", () => {
   it.each([true, false])(
     "restores localized file-copy labels after pending success %s",
     async (copied) => {
-      const write = Promise.withResolvers<void>();
+      const write = createDeferred<void>();
       const writeText = vi.fn(() => write.promise);
       vi.stubGlobal("navigator", { clipboard: { writeText } });
       Object.defineProperty(document, "execCommand", { configurable: true, value: () => false });
@@ -298,7 +299,7 @@ describe("openclaw-file-preview-modal", () => {
       );
       expect(feedback.hidden).toBe(false);
       expect(button.getAttribute("aria-label")).toBe(feedback.textContent);
-      expect(writeText).toHaveBeenCalledWith(files[0].contents);
+      expect(writeText).toHaveBeenCalledWith("Morning digest template");
       const reset = schedule.mock.calls.find(
         ([, delay]) => delay === (copied ? 1_500 : 2_000),
       )?.[0];

--- a/ui/src/components/file-preview-modal.test.ts
+++ b/ui/src/components/file-preview-modal.test.ts
@@ -237,7 +237,7 @@ describe("openclaw-file-preview-modal", () => {
 
     await vi.waitFor(() => {
       expect(writeText).toHaveBeenCalledWith(contents);
-      expect(copyButton?.dataset.copied).toBe("1");
+      expect(copyButton?.getAttribute("aria-label")).toBe("Copied!");
     });
   });
 

--- a/ui/src/components/file-preview-modal.ts
+++ b/ui/src/components/file-preview-modal.ts
@@ -175,7 +175,8 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       opacity: 1;
     }
 
-    .item-icon svg {
+    .item-icon svg,
+    .chat-copy-btn svg {
       width: 16px;
       height: 16px;
       stroke: currentColor;
@@ -283,10 +284,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       transition: opacity 150ms ease;
     }
 
-    .chat-copy-btn__icon-check {
-      opacity: 0;
-    }
-
+    .chat-copy-btn__icon-check,
     .chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-copy {
       opacity: 0;
     }
@@ -310,16 +308,6 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       border-color: var(--ok-subtle);
       background: var(--ok-subtle);
       color: var(--ok);
-    }
-
-    .chat-copy-btn svg {
-      width: 16px;
-      height: 16px;
-      stroke: currentColor;
-      fill: none;
-      stroke-width: 1.5px;
-      stroke-linecap: round;
-      stroke-linejoin: round;
     }
 
     .chips {

--- a/ui/src/components/file-preview-modal.ts
+++ b/ui/src/components/file-preview-modal.ts
@@ -287,26 +287,26 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       opacity: 0;
     }
 
-    .chat-copy-btn[data-copied="1"] .chat-copy-btn__icon-copy {
+    .chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-copy {
       opacity: 0;
     }
 
-    .chat-copy-btn[data-copied="1"] .chat-copy-btn__icon-check {
+    .chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-check {
       opacity: 1;
     }
 
-    .chat-copy-btn[data-copying="1"] {
+    .chat-copy-btn[data-copy-state="copying"] {
       opacity: 0;
       pointer-events: none;
     }
 
-    .chat-copy-btn[data-error="1"] {
+    .chat-copy-btn[data-copy-state="error"] {
       border-color: var(--danger-subtle);
       background: var(--danger-subtle);
       color: var(--danger);
     }
 
-    .chat-copy-btn[data-copied="1"] {
+    .chat-copy-btn[data-copy-state="copied"] {
       border-color: var(--ok-subtle);
       background: var(--ok-subtle);
       color: var(--ok);

--- a/ui/src/components/login-gate.test.ts
+++ b/ui/src/components/login-gate.test.ts
@@ -201,7 +201,7 @@ describe("login gate failure recovery", () => {
       }
 
       await vi.waitFor(() => expect(button?.getAttribute("aria-label")).toBe("Copy failed"));
-      expect(button?.dataset.error).toBe("1");
+      expect(command?.querySelector('[role="status"]')?.textContent).toBe("Copy failed");
       expect(writeText).toHaveBeenCalledOnce();
       expect(writeText).toHaveBeenCalledWith("openclaw status");
       expect(execCommand).toHaveBeenCalledOnce();
@@ -230,10 +230,16 @@ describe("login gate failure recovery", () => {
   });
 
   it("keeps the latest command-copy feedback until its own reset", async () => {
+    let finishCopy!: () => void;
     const writeText = vi
       .fn()
       .mockRejectedValueOnce(new DOMException("Clipboard access denied"))
-      .mockResolvedValueOnce(undefined);
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishCopy = resolve;
+          }),
+      );
     const execCommand = vi.fn(() => false);
     vi.stubGlobal("navigator", { clipboard: { writeText } });
     Object.defineProperty(document, "execCommand", { configurable: true, value: execCommand });
@@ -250,13 +256,19 @@ describe("login gate failure recovery", () => {
     }
 
     command?.click();
+    expect(button?.disabled).toBe(true);
+    expect(button?.getAttribute("aria-label")).toBe("Copy command");
+    expect(command?.querySelector<HTMLElement>('[role="status"]')?.hidden).toBe(true);
+    failedReset();
+    expect(command?.querySelector<HTMLElement>('[role="status"]')?.hidden).toBe(true);
+    finishCopy();
     await vi.waitFor(() => expect(button?.getAttribute("aria-label")).toBe("Copied!"));
     expect(button?.dataset.error).toBeUndefined();
     expect(button?.dataset.copied).toBe("1");
 
     failedReset();
     expect(button?.getAttribute("aria-label")).toBe("Copied!");
-    expect(button?.dataset.copied).toBe("1");
+    expect(command?.querySelector('[role="status"]')?.textContent).toBe("Copied!");
 
     const successfulReset = schedule.mock.calls.find(([, delay]) => delay === 1_500)?.[0];
     if (typeof successfulReset !== "function") {
@@ -266,6 +278,7 @@ describe("login gate failure recovery", () => {
 
     expect(button?.getAttribute("aria-label")).toBe("Copy command");
     expect(button?.dataset.copied).toBeUndefined();
+    expect(command?.querySelector<HTMLElement>('[role="status"]')?.hidden).toBe(true);
     expect(writeText).toHaveBeenCalledTimes(2);
     expect(execCommand).toHaveBeenCalledOnce();
   });

--- a/ui/src/components/login-gate.test.ts
+++ b/ui/src/components/login-gate.test.ts
@@ -222,11 +222,11 @@ describe("login gate failure recovery", () => {
     buttons[1]?.click();
 
     await vi.waitFor(() => {
-      expect(buttons[0]?.dataset.copied).toBe("1");
-      expect(buttons[1]?.dataset.copied).toBe("1");
+      expect(buttons[0]?.getAttribute("aria-label")).toBe("Copied!");
+      expect(buttons[1]?.getAttribute("aria-label")).toBe("Copied!");
     });
     expect(writeText.mock.calls).toEqual([["openclaw status"], ["openclaw gateway run"]]);
-    expect(buttons[2]?.dataset.copied).toBeUndefined();
+    expect(buttons[2]?.getAttribute("aria-label")).toBe("Copy command");
   });
 
   it("keeps the latest command-copy feedback until its own reset", async () => {
@@ -263,8 +263,7 @@ describe("login gate failure recovery", () => {
     expect(command?.querySelector<HTMLElement>('[role="status"]')?.hidden).toBe(true);
     finishCopy();
     await vi.waitFor(() => expect(button?.getAttribute("aria-label")).toBe("Copied!"));
-    expect(button?.dataset.error).toBeUndefined();
-    expect(button?.dataset.copied).toBe("1");
+    expect(command?.querySelector<HTMLElement>('[role="status"]')?.hidden).toBe(false);
 
     failedReset();
     expect(button?.getAttribute("aria-label")).toBe("Copied!");
@@ -277,7 +276,6 @@ describe("login gate failure recovery", () => {
     successfulReset();
 
     expect(button?.getAttribute("aria-label")).toBe("Copy command");
-    expect(button?.dataset.copied).toBeUndefined();
     expect(command?.querySelector<HTMLElement>('[role="status"]')?.hidden).toBe(true);
     expect(writeText).toHaveBeenCalledTimes(2);
     expect(execCommand).toHaveBeenCalledOnce();

--- a/ui/src/e2e/chat-flow.clipboard.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.clipboard.e2e.test.ts
@@ -167,6 +167,10 @@ suite.define(() => {
         if (!button) {
           throw new Error(`Missing ${surface} copy button`);
         }
+        const hasAccessibleName = (name: string) =>
+          page
+            .getByRole(surface === "selection" ? "menuitem" : "button", { name, exact: true })
+            .evaluate((element, original) => element === original, button);
         await button.click();
         await expect
           .poll(async () => (await readClipboardFailureProof(page)).legacyAttempts)
@@ -178,7 +182,7 @@ suite.define(() => {
           });
         }
         expect(await button.evaluate((element) => element.isConnected)).toBe(true);
-        expect(await button.getAttribute("aria-label")).toBe("Copy failed");
+        expect(await hasAccessibleName("Copy failed")).toBe(true);
         const copiedValue = (await readClipboardFailureProof(page)).value;
         expect(copiedValue).toBe(
           surface === "tool-diff" ? "-before\n+after" : surface === "selection" ? text : "main",
@@ -196,11 +200,11 @@ suite.define(() => {
         if (surface === "selection") {
           await expect.poll(() => page.locator(".chat-reply-context-menu").count()).toBe(0);
         } else {
-          await expect.poll(() => button.getAttribute("aria-label")).toBe("Copied!");
+          await expect.poll(() => hasAccessibleName("Copied!")).toBe(true);
           expect(await button.isDisabled()).toBe(false);
           await expect
-            .poll(() => button.getAttribute("aria-label"))
-            .toBe(surface === "agent-id" ? "Copy ID" : "Copy");
+            .poll(() => hasAccessibleName(surface === "agent-id" ? "Copy ID" : "Copy"))
+            .toBe(true);
         }
         expect(await gateway.getRequests("chat.send")).toHaveLength(0);
       } finally {

--- a/ui/src/e2e/chat-flow.clipboard.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.clipboard.e2e.test.ts
@@ -462,4 +462,54 @@ suite.define(() => {
       await suite.closeBrowserContext(context);
     }
   });
+
+  it.each([1280, 390])(
+    "keeps message-copy failure readable after leaving the control at %dpx",
+    async (width) => {
+      const context = await suite.newBrowserContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width },
+      });
+      const page = await context.newPage();
+      await installDeniedClipboard(page);
+      await installMockGateway(page, {
+        historyMessages: [
+          { content: [{ text: "Copy this complete message.", type: "text" }], role: "assistant" },
+        ],
+      });
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const message = page.locator(".chat-group.assistant").filter({
+          hasText: "Copy this complete message.",
+        });
+        await message.locator(".chat-text").click();
+        await message.hover();
+        const copy = message.getByRole("button", { name: "Copy as markdown", exact: true });
+        await copy.click();
+        await page.locator(".agent-chat__composer-combobox textarea").focus();
+        await page.mouse.move(0, 0);
+        const feedback = message.getByRole("status").filter({ hasText: "Copy failed" });
+        await feedback.waitFor({ state: "visible" });
+        expect(
+          await feedback.evaluate((element) =>
+            element.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true }),
+          ),
+        ).toBe(true);
+        const bounds = await feedback.boundingBox();
+        expect(bounds).not.toBeNull();
+        expect(bounds!.x).toBeGreaterThanOrEqual(0);
+        expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(width);
+        expect(await readClipboardFailureProof(page)).toEqual({
+          asyncAttempts: 1,
+          legacyAttempts: 1,
+          value: "Copy this complete message.",
+        });
+        await feedback.waitFor({ state: "hidden" });
+        await expect.poll(() => copy.getAttribute("aria-label")).toBe("Copy as markdown");
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    },
+  );
 });

--- a/ui/src/e2e/session-management.archived-actions.e2e.test.ts
+++ b/ui/src/e2e/session-management.archived-actions.e2e.test.ts
@@ -133,11 +133,9 @@ suite.define(() => {
         await userBubble.click({ button: "right" });
         const initialMenu = page.locator(".chat-reply-context-menu");
         await initialMenu.waitFor({ state: "visible" });
-        const initialLabels = await initialMenu
-          .locator("button")
-          .evaluateAll((buttons) => buttons.map((button) => button.getAttribute("aria-label")));
-        expect(initialLabels).toContain("Rewind to here");
-        await initialMenu.locator('[aria-label="Rewind to here"]').click();
+        const rewind = initialMenu.getByRole("menuitem", { name: "Rewind to here", exact: true });
+        expect(await rewind.count()).toBe(1);
+        await rewind.click();
         await page.locator(".chat-confirm-popover").waitFor({ state: "visible" });
 
         await gateway.emitGatewayEvent("sessions.changed", {
@@ -168,11 +166,18 @@ suite.define(() => {
         await userBubble.click({ button: "right" });
         const menu = page.locator(".chat-reply-context-menu");
         await menu.waitFor({ state: "visible" });
-        expect(
-          await menu
-            .locator("button")
-            .evaluateAll((buttons) => buttons.map((button) => button.getAttribute("aria-label"))),
-        ).toEqual(["Copy", "Fork from here"]);
+        const actions = menu.locator("button");
+        expect(await actions.count()).toBe(2);
+        for (const [index, name] of ["Copy", "Fork from here"].entries()) {
+          expect(
+            await menu
+              .getByRole("menuitem", { name, exact: true })
+              .evaluate(
+                (element, expected) => element === expected,
+                await actions.nth(index).elementHandle(),
+              ),
+          ).toBe(true);
+        }
         await captureUiProof(page, `archived-actions-${viewport.label}.png`);
         expect(
           await page.evaluate(() => {
@@ -190,7 +195,7 @@ suite.define(() => {
           }),
         ).toEqual({ documentOverflows: false, menuFits: true });
 
-        await menu.locator('[aria-label="Copy"]').click();
+        await menu.getByRole("menuitem", { name: "Copy", exact: true }).click();
         await expect
           .poll(() => page.evaluate(() => navigator.clipboard.readText()))
           .toBe(messageText);
@@ -198,7 +203,7 @@ suite.define(() => {
         await userBubble.click({ button: "right" });
         await page
           .locator(".chat-reply-context-menu")
-          .locator('[aria-label="Fork from here"]')
+          .getByRole("menuitem", { name: "Fork from here", exact: true })
           .click();
         const fork = await gateway.waitForRequest("sessions.fork");
         expect(requireRecord(fork.params)).toMatchObject({

--- a/ui/src/pages/agents/github-identity-view.ts
+++ b/ui/src/pages/agents/github-identity-view.ts
@@ -249,7 +249,6 @@ function renderGitHubAuthorization(controller: GitHubIdentityController) {
           <button
             type="button"
             class="btn"
-            aria-label=${copyLabel}
             @click=${(event: Event) =>
               void handleCopyButton(event, authorization.userCode, copyLabel)}
           >

--- a/ui/src/pages/channels/wizard-view.test.ts
+++ b/ui/src/pages/channels/wizard-view.test.ts
@@ -193,7 +193,7 @@ describe("renderChannelWizard", () => {
 
     await vi.waitFor(() => expect(execCommand).toHaveBeenCalledWith("copy"));
     await vi.waitFor(() => expect(copy?.textContent?.trim()).toBe("Copied!"));
-    expect(copy?.getAttribute("aria-label")).toBe("Copied!");
+    expect(copy?.getAttribute("aria-label")).toBeNull();
     expect(copiedText).toBe("openclaw channels add");
     expect(document.querySelector("textarea")).toBeNull();
   });
@@ -246,6 +246,7 @@ describe("renderChannelWizard", () => {
         await i18n.setLocale("de");
         render(renderChannelWizard(props), container);
         expect(button?.textContent?.trim()).toBe("Kopieren");
+        expect(button?.getAttribute("aria-label")).toBeNull();
       }
       if (copied) {
         write.resolve();
@@ -261,7 +262,7 @@ describe("renderChannelWizard", () => {
             ? "Copied!"
             : "Copy failed";
       await vi.waitFor(() => expect(button?.textContent?.trim()).toBe(feedback));
-      expect(button?.getAttribute("aria-label")).toBe(feedback);
+      expect(button?.getAttribute("aria-label")).toBeNull();
       expect(writeText).toHaveBeenCalledWith("openclaw channels add");
       expect(execCommand).toHaveBeenCalledTimes(copied ? 0 : 1);
 
@@ -269,6 +270,7 @@ describe("renderChannelWizard", () => {
         await i18n.setLocale("de");
         expect(() => render(renderChannelWizard(props), container)).not.toThrow();
         expect(button?.textContent?.trim()).toBe("Kopieren");
+        expect(button?.getAttribute("aria-label")).toBeNull();
       }
       const reset = schedule.mock.calls.find(
         ([, delay]) => delay === (copied ? 1_500 : 2_000),
@@ -278,7 +280,12 @@ describe("renderChannelWizard", () => {
       }
       reset();
       expect(button?.textContent?.trim()).toBe("Kopieren");
-      expect(button?.getAttribute("aria-label")).toBe("Kopieren");
+      expect(button?.getAttribute("aria-label")).toBeNull();
+
+      await i18n.setLocale("en");
+      render(renderChannelWizard(props), container);
+      expect(button?.textContent?.trim()).toBe("Copy");
+      expect(button?.getAttribute("aria-label")).toBeNull();
     },
   );
 });

--- a/ui/src/pages/channels/wizard-view.test.ts
+++ b/ui/src/pages/channels/wizard-view.test.ts
@@ -2,6 +2,7 @@
 
 import { nothing, render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { i18n } from "../../i18n/index.ts";
 import { renderChannelWizard } from "./wizard-view.ts";
 
@@ -202,7 +203,7 @@ describe("renderChannelWizard", () => {
   )(
     "keeps channel-copy success $copied accessible across a $phase locale rerender",
     async ({ copied, phase }) => {
-      const write = Promise.withResolvers<void>();
+      const write = createDeferred<void>();
       const writeText = vi.fn(() => write.promise);
       const execCommand = vi.fn(() => false);
       vi.stubGlobal("navigator", { clipboard: { writeText } });

--- a/ui/src/pages/channels/wizard-view.test.ts
+++ b/ui/src/pages/channels/wizard-view.test.ts
@@ -259,7 +259,6 @@ describe("renderChannelWizard", () => {
         reset();
         expect(button?.textContent?.trim()).toBe("Kopieren");
         expect(button?.getAttribute("aria-label")).toBe("Kopieren");
-        expect(button?.dataset[copied ? "copied" : "error"]).toBeUndefined();
       } finally {
         await i18n.setLocale("en");
       }

--- a/ui/src/pages/channels/wizard-view.test.ts
+++ b/ui/src/pages/channels/wizard-view.test.ts
@@ -10,7 +10,8 @@ describe("renderChannelWizard", () => {
     await i18n.setLocale("en");
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await i18n.setLocale("en");
     for (const container of document.body.querySelectorAll("div")) {
       render(nothing, container);
     }
@@ -196,14 +197,13 @@ describe("renderChannelWizard", () => {
     expect(document.querySelector("textarea")).toBeNull();
   });
 
-  it.each([true, false])(
-    "keeps channel-copy success %s accessible across locale rerenders",
-    async (copied) => {
-      const writeText = vi.fn().mockImplementation(async () => {
-        if (!copied) {
-          throw new DOMException("Clipboard access denied");
-        }
-      });
+  it.each(
+    [true, false].flatMap((copied) => ["pending", "feedback"].map((phase) => ({ copied, phase }))),
+  )(
+    "keeps channel-copy success $copied accessible across a $phase locale rerender",
+    async ({ copied, phase }) => {
+      const write = Promise.withResolvers<void>();
+      const writeText = vi.fn(() => write.promise);
       const execCommand = vi.fn(() => false);
       vi.stubGlobal("navigator", { clipboard: { writeText } });
       Object.defineProperty(document, "execCommand", { configurable: true, value: execCommand });
@@ -240,28 +240,44 @@ describe("renderChannelWizard", () => {
 
       button?.click();
 
-      const feedback = copied ? "Copied!" : "Copy failed";
+      if (phase === "pending") {
+        expect(button?.disabled).toBe(true);
+        await i18n.setLocale("de");
+        render(renderChannelWizard(props), container);
+        expect(button?.textContent?.trim()).toBe("Kopieren");
+      }
+      if (copied) {
+        write.resolve();
+      } else {
+        write.reject(new DOMException("Clipboard access denied"));
+      }
+      const feedback =
+        phase === "pending"
+          ? copied
+            ? "Kopiert!"
+            : "Kopieren fehlgeschlagen"
+          : copied
+            ? "Copied!"
+            : "Copy failed";
       await vi.waitFor(() => expect(button?.textContent?.trim()).toBe(feedback));
       expect(button?.getAttribute("aria-label")).toBe(feedback);
       expect(writeText).toHaveBeenCalledWith("openclaw channels add");
       expect(execCommand).toHaveBeenCalledTimes(copied ? 0 : 1);
 
-      await i18n.setLocale("de");
-      try {
+      if (phase === "feedback") {
+        await i18n.setLocale("de");
         expect(() => render(renderChannelWizard(props), container)).not.toThrow();
         expect(button?.textContent?.trim()).toBe("Kopieren");
-        const reset = schedule.mock.calls.find(
-          ([, delay]) => delay === (copied ? 1_500 : 2_000),
-        )?.[0];
-        if (typeof reset !== "function") {
-          throw new Error("Expected copy feedback to schedule its reset");
-        }
-        reset();
-        expect(button?.textContent?.trim()).toBe("Kopieren");
-        expect(button?.getAttribute("aria-label")).toBe("Kopieren");
-      } finally {
-        await i18n.setLocale("en");
       }
+      const reset = schedule.mock.calls.find(
+        ([, delay]) => delay === (copied ? 1_500 : 2_000),
+      )?.[0];
+      if (typeof reset !== "function") {
+        throw new Error("Expected copy feedback to schedule its reset");
+      }
+      reset();
+      expect(button?.textContent?.trim()).toBe("Kopieren");
+      expect(button?.getAttribute("aria-label")).toBe("Kopieren");
     },
   );
 });

--- a/ui/src/pages/channels/wizard-view.test.ts
+++ b/ui/src/pages/channels/wizard-view.test.ts
@@ -203,7 +203,7 @@ describe("renderChannelWizard", () => {
   )(
     "keeps channel-copy success $copied accessible across a $phase locale rerender",
     async ({ copied, phase }) => {
-      const write = createDeferred<void>();
+      const write = createDeferred();
       const writeText = vi.fn(() => write.promise);
       const execCommand = vi.fn(() => false);
       vi.stubGlobal("navigator", { clipboard: { writeText } });

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -8088,6 +8088,19 @@ describe("right-click Reply", () => {
     return event;
   }
 
+  function getContextMenuAction(name: string): HTMLButtonElement {
+    const matches = [
+      ...document.querySelectorAll<HTMLButtonElement>(
+        '.chat-reply-context-menu button[role="menuitem"]',
+      ),
+    ].filter((button) => button.textContent?.trim() === name);
+    expect(matches).toHaveLength(1);
+    const button = expectDefined(matches[0], `${name} context-menu action`);
+    expect(button.getAttribute("aria-label")).toBeNull();
+    expect(button.getAttribute("aria-labelledby")).toBeNull();
+    return button;
+  }
+
   function renderChatBubble(
     chatOverrides: Partial<ChatProps> = {},
     bubbleOverrides: Parameters<typeof appendChatBubble>[1] = {},
@@ -8117,7 +8130,7 @@ describe("right-click Reply", () => {
       button.textContent?.trim(),
     );
     expect(labels).toEqual(["Reply", "Rewind to here", "Fork from here"]);
-    document.querySelector<HTMLButtonElement>('[aria-label="Fork from here"]')!.click();
+    getContextMenuAction("Fork from here").click();
     expect(onForkMessage).toHaveBeenCalledWith("persisted-user");
 
     group.className = "chat-group assistant";
@@ -8141,7 +8154,7 @@ describe("right-click Reply", () => {
     ).toBeNull();
 
     dispatchContextMenu(bubble);
-    document.querySelector<HTMLButtonElement>('[aria-label="Copy as markdown"]')!.click();
+    getContextMenuAction("Copy as markdown").click();
     expect(onCopy).toHaveBeenCalledOnce();
   });
 
@@ -8197,17 +8210,11 @@ describe("right-click Reply", () => {
 
     dispatchContextMenu(bubble);
 
-    expect(
-      document.querySelector<HTMLButtonElement>('[aria-label="Rewind to here"]')?.disabled,
-    ).toBe(true);
-    expect(
-      document.querySelector<HTMLButtonElement>('[aria-label="Fork from here"]')?.disabled,
-    ).toBe(true);
-    expect(
-      document
-        .querySelector<HTMLElement>('[aria-label="Rewind to here"]')
-        ?.closest("openclaw-tooltip")?.content,
-    ).toBe("Rewind is unavailable while the agent is working");
+    expect(getContextMenuAction("Rewind to here").disabled).toBe(true);
+    expect(getContextMenuAction("Fork from here").disabled).toBe(true);
+    expect(getContextMenuAction("Rewind to here").closest("openclaw-tooltip")?.content).toBe(
+      "Rewind is unavailable while the agent is working",
+    );
   });
 
   it("opens context menu and calls onSetReply when Reply is selected", () => {
@@ -8308,11 +8315,9 @@ describe("right-click Reply", () => {
 
     dispatchContextMenu(bubble);
     flushFrames();
-    const rewindButton = document.querySelector<HTMLButtonElement>(
-      '.chat-reply-context-menu [aria-label="Rewind to here"]',
-    );
+    const rewindButton = getContextMenuAction("Rewind to here");
     expect(rewindButton).toBeInstanceOf(HTMLButtonElement);
-    rewindButton!.click();
+    rewindButton.click();
     flushFrames();
 
     const cancel = document.querySelector<HTMLButtonElement>(".chat-confirm-popover__cancel");
@@ -8348,9 +8353,7 @@ describe("right-click Reply", () => {
 
     dispatchContextMenu(bubble);
     flushFrames();
-    document
-      .querySelector<HTMLButtonElement>('.chat-reply-context-menu [aria-label="Rewind to here"]')!
-      .click();
+    getContextMenuAction("Rewind to here").click();
     flushFrames();
 
     resetThreadPresentation("pane-b");
@@ -8494,7 +8497,7 @@ describe("right-click Reply", () => {
         button.textContent?.trim(),
       ),
     ).toEqual(["Copy", "Reply"]);
-    document.querySelector<HTMLButtonElement>('[aria-label="Copy"]')!.click();
+    getContextMenuAction("Copy").click();
     await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith("selectable"));
 
     selectedRange = document.createRange();

--- a/ui/src/pages/chat/components/chat-session-workspace-rail.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace-rail.test.ts
@@ -82,7 +82,9 @@ describe("session workspace path actions", () => {
     await vi.waitFor(() => expect(copy!.getAttribute("aria-label")).toBe(testCase.feedback));
 
     expect(writeText).toHaveBeenCalledWith(testCase.path);
-    expect(copy!.dataset[testCase.failed ? "error" : "copied"]).toBe("1");
+    const feedback = copy!.parentElement?.querySelector<HTMLElement>('[role="status"]');
+    expect(feedback?.textContent).toBe(testCase.feedback);
+    expect(feedback?.hidden).toBe(false);
     expect(rowClick).not.toHaveBeenCalled();
     expect(onOpenFile).not.toHaveBeenCalled();
 

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -359,7 +359,6 @@ function createMessageActionContextButton(params: {
   button.type = "button";
   button.disabled = params.disabled;
   button.setAttribute("role", "menuitem");
-  button.setAttribute("aria-label", params.label);
   const label = document.createElement("span");
   label.dataset.copyLabel = "";
   label.textContent = params.label;

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -501,6 +501,89 @@ describe("tool-cards", () => {
     }
   });
 
+  it.each(
+    [
+      {
+        name: "edit",
+        args: { path: "src/edit.ts", oldText: "old edit", newText: "new edit" },
+        copiedText: "new edit",
+      },
+      {
+        name: "write",
+        args: { path: "src/write.ts", content: "new file\n" },
+        copiedText: "new file",
+      },
+      {
+        name: "apply_patch",
+        args: {
+          changes: [
+            {
+              path: "src/patch.ts",
+              kind: { type: "update" },
+              diff: "--- a/src/patch.ts\n+++ b/src/patch.ts\n@@ -1 +1 @@\n-old patch\n+new patch\n",
+            },
+          ],
+        },
+        copiedText: "new patch",
+      },
+    ].flatMap((tool) =>
+      [
+        { failed: false, feedback: "Copied!" },
+        { failed: true, feedback: "Copy failed" },
+      ].map((outcome) => ({
+        name: tool.name,
+        args: tool.args,
+        copiedText: tool.copiedText,
+        failed: outcome.failed,
+        feedback: outcome.feedback,
+      })),
+    ),
+  )("shows $feedback after copying a completed $name diff", async (tool) => {
+    const writeText = tool.failed
+      ? vi.fn().mockRejectedValue(new DOMException("Clipboard access denied", "NotAllowedError"))
+      : vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const container = document.body.appendChild(document.createElement("div"));
+    const onOpenSidebar = vi.fn();
+
+    try {
+      render(
+        renderToolCard(
+          {
+            id: `msg:${tool.name}:copy`,
+            name: tool.name,
+            args: tool.args,
+            completed: true,
+          },
+          { expanded: true, onToggleExpanded: vi.fn(), onOpenSidebar },
+        ),
+        container,
+      );
+
+      const copyButton = container.querySelector<HTMLButtonElement>(
+        '.chat-tool-card__actions button[aria-label="Copy"]',
+      );
+      expect(copyButton).toBeInstanceOf(HTMLButtonElement);
+      copyButton!.click();
+
+      await vi.waitFor(() => expect(copyButton!.getAttribute("aria-label")).toBe(tool.feedback));
+
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining(tool.copiedText));
+      expect(copyButton!.dataset[tool.failed ? "error" : "copied"]).toBe("1");
+
+      const sidebarButton = container.querySelector<HTMLButtonElement>(
+        `.chat-tool-card__actions button[aria-label="${t("chat.toolCards.openDetails")}"]`,
+      );
+      expect(sidebarButton).toBeInstanceOf(HTMLButtonElement);
+      expect([...sidebarButton!.classList]).toEqual(["chat-tool-card__action-btn"]);
+      sidebarButton!.click();
+      expect(onOpenSidebar).toHaveBeenCalledOnce();
+    } finally {
+      container.remove();
+      vi.unstubAllGlobals();
+    }
+  });
+
   it.each([
     { name: "read", args: { path: "packages/app/src/read.ts" }, path: "packages/app/src/read.ts" },
     {

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -569,13 +569,14 @@ describe("tool-cards", () => {
       await vi.waitFor(() => expect(copyButton!.getAttribute("aria-label")).toBe(tool.feedback));
 
       expect(writeText).toHaveBeenCalledWith(expect.stringContaining(tool.copiedText));
-      expect(copyButton!.dataset[tool.failed ? "error" : "copied"]).toBe("1");
+      const feedback = copyButton!.parentElement?.querySelector<HTMLElement>('[role="status"]');
+      expect(feedback?.textContent).toBe(tool.feedback);
+      expect(feedback?.hidden).toBe(false);
 
       const sidebarButton = container.querySelector<HTMLButtonElement>(
         `.chat-tool-card__actions button[aria-label="${t("chat.toolCards.openDetails")}"]`,
       );
       expect(sidebarButton).toBeInstanceOf(HTMLButtonElement);
-      expect([...sidebarButton!.classList]).toEqual(["chat-tool-card__action-btn"]);
       sidebarButton!.click();
       expect(onOpenSidebar).toHaveBeenCalledOnce();
     } finally {

--- a/ui/src/pages/chat/components/chat-workspace-conflict.test.ts
+++ b/ui/src/pages/chat/components/chat-workspace-conflict.test.ts
@@ -72,7 +72,7 @@ describe("workspace conflict copy actions", () => {
     button?.click();
 
     await vi.waitFor(() => expect(button?.textContent?.trim()).toBe(expected));
-    expect(button?.getAttribute("aria-label")).toBe(expected);
+    expect(button?.getAttribute("aria-label")).toBeNull();
     expect(writeText).toHaveBeenCalledWith(
       "git show 'refs/openclaw/worker-results/claim-test:src/local.ts'",
     );

--- a/ui/src/pages/chat/components/chat-workspace-conflict.ts
+++ b/ui/src/pages/chat/components/chat-workspace-conflict.ts
@@ -14,7 +14,6 @@ function renderConflictCopyAction(text: string, label: string) {
   return html`<button
     class="btn btn--sm chat-copy-btn"
     type="button"
-    aria-label=${label}
     @click=${(event: Event) => void handleCopyButton(event, text, label)}
   >
     <span data-copy-label>${label}</span>

--- a/ui/src/pages/chat/components/session-diff-panel.test.ts
+++ b/ui/src/pages/chat/components/session-diff-panel.test.ts
@@ -189,7 +189,9 @@ describe("SessionDiffPanel", () => {
       await vi.waitFor(() => expect(button?.getAttribute("aria-label")).toBe(feedback));
 
       expect(writeText).toHaveBeenCalledWith(surface === "file" ? "example.txt" : "/workspace");
-      expect(button?.dataset[failed ? "error" : "copied"]).toBe("1");
+      const status = button?.parentElement?.querySelector<HTMLElement>('[role="status"]');
+      expect(status?.textContent).toBe(feedback);
+      expect(status?.hidden).toBe(false);
       expect(panel.querySelector("openclaw-session-diff-menu")).toBe(menu);
     },
   );

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -983,7 +983,7 @@ describe("renderModelSetup", () => {
 
     const feedback = copied ? "Copied!" : "Copy failed";
     await vi.waitFor(() => expect(copy?.textContent?.trim()).toBe(feedback));
-    expect(copy?.getAttribute("aria-label")).toBe(feedback);
+    expect(copy?.getAttribute("aria-label")).toBeNull();
     expect(execCommand).toHaveBeenCalledWith("copy");
     expect(writeText).toHaveBeenCalledTimes(copied ? 0 : 1);
     expect(document.querySelector("textarea")).toBeNull();

--- a/ui/src/pages/usage/view-overview.test.ts
+++ b/ui/src/pages/usage/view-overview.test.ts
@@ -630,7 +630,7 @@ describe("renderSessionsCard", () => {
     copyButton?.click();
     await vi.waitFor(() => {
       expect(copyButton?.textContent?.trim()).toBe(feedback);
-      expect(copyButton?.getAttribute("aria-label")).toBe(feedback);
+      expect(copyButton?.getAttribute("aria-label")).toBeNull();
     });
     expect(writeText).toHaveBeenCalledWith("Selected thread");
     expect(onSelectSession).toHaveBeenCalledOnce();

--- a/ui/src/pages/usage/view-overview.test.ts
+++ b/ui/src/pages/usage/view-overview.test.ts
@@ -633,8 +633,6 @@ describe("renderSessionsCard", () => {
       expect(copyButton?.getAttribute("aria-label")).toBe(feedback);
     });
     expect(writeText).toHaveBeenCalledWith("Selected thread");
-    expect(copyButton?.dataset[copied ? "copied" : "error"]).toBe("1");
-    expect(copyButton?.dataset[copied ? "error" : "copied"]).toBeUndefined();
     expect(onSelectSession).toHaveBeenCalledOnce();
     rows[0]?.querySelector<HTMLElement>(".session-bar-value")?.click();
     expect(onSelectSession).toHaveBeenCalledWith(

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -924,26 +924,26 @@ img.chat-avatar.chat-avatar--logo {
   opacity: 0;
 }
 
-.chat-copy-btn[data-copied="1"] .chat-copy-btn__icon-copy {
+.chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-copy {
   opacity: 0;
 }
 
-.chat-copy-btn[data-copied="1"] .chat-copy-btn__icon-check {
+.chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-check {
   opacity: 1;
 }
 
-.chat-copy-btn[data-copying="1"] {
+.chat-copy-btn[data-copy-state="copying"] {
   opacity: 0;
   pointer-events: none;
 }
 
-.chat-copy-btn[data-error="1"] {
+.chat-copy-btn[data-copy-state="error"] {
   border-color: var(--danger-subtle);
   background: var(--danger-subtle);
   color: var(--danger);
 }
 
-.chat-copy-btn[data-copied="1"] {
+.chat-copy-btn[data-copy-state="copied"] {
   border-color: var(--ok-subtle);
   background: var(--ok-subtle);
   color: var(--ok);

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -898,6 +898,13 @@ img.chat-avatar.chat-avatar--logo {
   color: var(--muted);
 }
 
+.chat-group:has([data-copy-feedback]:not([hidden])) {
+  --chat-footer-disclosure-opacity: 1;
+  --chat-footer-disclosure-pointer-events: auto;
+  --chat-footer-detail-position: static;
+  --chat-persistent-footer-opacity: 1;
+}
+
 .chat-copy-btn__icon {
   display: inline-flex;
   width: 14px;

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -920,10 +920,7 @@ img.chat-avatar.chat-avatar--logo {
   transition: opacity 150ms ease;
 }
 
-.chat-copy-btn__icon-check {
-  opacity: 0;
-}
-
+.chat-copy-btn__icon-check,
 .chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-copy {
   opacity: 0;
 }

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -689,7 +689,8 @@
   margin-inline-start: auto;
 }
 
-.chat-tool-card__action-btn {
+.chat-tool-card__action-btn,
+.chat-tool-card__actions :where(.chat-copy-btn) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -707,7 +708,8 @@
 }
 
 .chat-tool-card__action-btn:hover,
-.chat-tool-card__action-btn:focus-visible {
+.chat-tool-card__action-btn:focus-visible,
+.chat-tool-card__actions :where(.chat-copy-btn:hover, .chat-copy-btn:focus-visible) {
   color: var(--text);
   background: color-mix(in srgb, var(--bg-hover) 70%, transparent);
 }


### PR DESCRIPTION
## Readiness: verified for landing

Pushed branch head: `9537a90f70d85c97f321997f5289326ba97cb88c`, based on `dd7e0ea97498862f679845b94234eaae3afb5d83`.

The final ordinary full build **passes at 343387 B versus the unchanged 343442 B limit**, with normal Gateway build metadata. **549 focused tests, 24 GUI cases, and the full 20-path changed-file gate pass**, including the repaired desktop/mobile archived-action cases. GitHub's PR and branch refs match the final head. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33045881246) **passed: 68 successful jobs, 17 skipped, zero failures**, including all four UI browser shards, real-Gateway checks, and the required aggregate gate. Fresh independent source-blind verification **passes all nine contract clauses**, with no accepted behavioral findings, blockers, or untested clauses.

## What Problem This Solves

Shared icon-only copy controls lacked readable success/failure feedback, and pending retries could display an earlier result. Further QA reproduced two related defects: a language change during a pending copy reset to the old language, and text buttons could keep an old screen-reader name after their visible text changed.

## Why This Change Was Made

One shared copy lifecycle now renders temporary readable feedback beside the fixed-size icon, clears old feedback when an attempt begins, and keeps chat-footer outcomes visible after pointer/focus departure. It captures the rendered idle label when the pending write completes and respects later locale rerenders.

Text controls use their visible text as their accessible name; icon-only controls retain an explicit accessible label. The setter updates the existing Lit text node **or** the icon label, not both. Three redundant matching labels are removed from the GitHub authorization, workspace-conflict, and text context-menu producers. No observer, runtime compatibility shim, extra timer, or second state owner is introduced.

Main #130612 independently routed tool cards through this owner and fenced legacy fallback after a copy button is retired. This branch preserves that predicate, the boolean result/selection-menu contract, and all 15 GUI cases. The already-landed routing is not counted as new work here.

The renderer/options pass-through, mutually exclusive state flags, and duplicate glyph declarations are consolidated. Four-state computed-style parity covers global and shadow controls, including seven SVG properties. Production **+61/-64 (net -3)**; tests **+331/-113 (net +218)**, across 20 files. No configuration, dependency, protocol, storage, or budget changes.

## User Impact

Copy actions show readable “Copied!” or “Copy failed”, clear stale outcomes during retries, reset automatically, and recover. Language changes stay selected after pending operations. Visible text and screen-reader names agree throughout pending, feedback, reset, and later idle language changes.

## Validation

- **549 unique focused tests in 16 files** pass, including the entire current-main chat-view suite. **24 GUI cases in three files** pass after the final test-only repair. The GUI count includes 20 clipboard cases, three archived-session cases, and the existing GitHub authorization route test; that route test does not click copy and is not live GitHub auth/API or dedicated clipboard proof.
- The final **20-path changed-file gate passed with exit 0**. Coverage: guards, dead-export checks, formatting, i18n, core-test/UI types, lint, and styles. No check was disabled.
- The broader hosted UI suite found five context-menu tests, then two newly landed archived-session browser cases, still selecting the removed redundant `aria-label`. All five failed locally before the test-only repair. Tests now require a unique exact-text menuitem button with no competing ARIA name, preserving original click, disabled-state, tooltip, portal ownership, and selection assertions. This jsdom contract is not a browser accessibility-name algorithm. The archived browser cases use actual role/name queries and verify ordered original element identity, preserving exact menu membership, focus cleanup, native clipboard readbacks, and zero forbidden RPCs. Their two fail-before cases reproduced locally. The expanded suites pass; combined final review is clean.
- Four pending-locale regressions fail before the locale repair and pass after. Four additional accessible-name regressions fail before the name repair and pass after. Six native browser cases with 24 visible/name samples likewise fail before and pass after.
- Fresh independent source-blind verification passes all nine clauses. The normal built UI served by its matching Gateway passes three distinct tool-card diffs, assistant Markdown, native success, simulated failure, unchanged clipboard, focus/pointer-away visibility, automatic reset, recovery, independent controls, correct details navigation, and held-pending retries at desktop and narrow widths. Separate real-component preview and wizard fixtures pass native readbacks, fixed 32×32 preview geometry, painted status/check icon, duplicate suppression, narrow layout, settled and rapid English/German transitions, and visible/native accessible-name agreement through pending, feedback, reset, and idle. All 33 captures were inspected; every override was removed and reload/native recovery checked on all three targets. An initial global pending-status observation was preserved and resolved by screenshot plus control-scoped repeat: it belonged to an independent sibling's feedback, not stale feedback on the retried action.
- Fresh combined Codex review reports no P0/P1 findings; this is not an exhaustive lower-severity-review claim. The lead inspected the owner, clipboard transport, tooltip, all eight text producers, icon siblings, current-main integration, and installed Lit's marker/text/attribute update contracts.
- All 34,204 tracked paths match the final committed head between the source and isolated runtime. Only two authorized synthetic component fixtures are untracked. These are real components, not a full Gateway or configured-channel substitute. No external provider or real channel account is used.

## Before / After

Synthetic local component content only. Clipboard failure/delay is injected solely at the browser boundary; successful writes and all readbacks are native. Pixels show visible feedback; native role/name queries, not screenshots alone, prove accessibility.

Pinned-main preview after failed copy: the red icon has no readable failure text.

![Pinned main preview failure without readable outcome](https://github.com/user-attachments/assets/83d33cdc-818c-4a40-9412-5e4ae3f1d469)

Candidate preview after failed copy:

![Candidate preview with readable Copy failed outcome](https://github.com/user-attachments/assets/e1347eac-aee6-4c51-b27f-619100ecebf9)

Pinned main after choosing Deutsch during a pending copy: the control resets to English “Copy”.

![Pinned main stale English copy label after German selection](https://github.com/user-attachments/assets/8bd722bb-c219-4057-b0f5-a9a4a2579d47)

Candidate independent recheck: the control resets to “Kopieren”, with the same native accessible name.

![Candidate German copy label after reset](https://github.com/user-attachments/assets/07aca7b8-dda3-4b0e-abfd-4e691c466dcf)

Final normal production bundle, served by its matching Gateway: readable tool-card failure after pointer/focus departure at desktop and 390px widths. These screenshots use a fresh normal agent turn with actual write/edit/patch tools and synthetic files; model-provider responses are simulated. Successful copies were checked against the native clipboard; failure injection affects only the two browser clipboard transports.

![Final built UI desktop tool-card failure](https://github.com/user-attachments/assets/a678dbbc-2f4c-4281-ab54-e370509a4a04)

![Final built UI narrow tool-card failure](https://github.com/user-attachments/assets/ab2f1cec-28a2-4065-9db4-af10e0e2b59d)

## Build History and Proof Limits

Old-base ordinary builds failed the same unchanged startup ratchet: cf876e measured 343458 B, 827d9ea measured 343455 B, and 0bb23e measured 343466 B. These failures remain recorded; no threshold increase, hash selection, manual metadata finalizer, or mixed-version Gateway was used.

The current-main integration is different source. Main consolidated chat-startup UI, and CI's merge tree 08c01c92 passed at 343355 B; an ordinary isolated full build of that exact tree independently passed at 343364 B with all 770 sidecars and normal Gateway metadata. A clean rebase onto its pinned base retained all eight PR patches identically and produced the same tree. The remaining integration failures were stale selectors in a new archived-session test, now repaired without production changes. Final 9537a90f then passed its ordinary full build at 343387 B. No separate performance patch was necessary.

[Previous CI 33043002377](https://github.com/openclaw/openclaw/actions/runs/33043002377) ended with 66 successful jobs, 17 skipped and two failed jobs (one GUI shard plus aggregate); both actual failing cases are the now-repaired archived test. No previous result is substituted for final-head CI.

Final full-app proof uses the normal built UI and matching isolated Gateway, with a fresh normal agent turn executing real write/edit/patch tools against synthetic files and a simulated provider. All seven full-app clauses and both separate component clauses passed independently in a fresh run; no prior PASS was carried forward. No live-provider, actual browser-permission-denial, all-browser or installed-package claim is made.

Named follow-up: synthetic cold-start history latency. Initial development and built-UI navigation attempts exceeded their original 30-second history wait. Gateway logs later showed 126-second initial history/startup work and 31.7-second startup work after restart; a ready-session startup completed in 219ms. Failed attempts are retained, and no timeout was increased. This is an observed separate cold-start performance concern, not a demonstrated clipboard regression. Prior development proof displayed a build-update notice because its short development build ID differed from normal timestamped Gateway metadata; final full-app proof uses the unchanged normal built UI and matching Gateway build ID, with the served entry asset hash matching the built artifact.

Latest ClawSweeper review (06:15 UTC, previous head) identified no patch defect and requested an exact-head integration passing the unchanged startup ratchet and failing UI shard. The ordinary final build and exact-head CI now both pass, including all UI shards and real-Gateway checks. Independent full-app and component proof also pass. Main's fallback fence is intact.

Regression provenance: pending-label behavior was carried forward by [#118651](https://github.com/openclaw/openclaw/pull/118651), commit [`e99f6dc4c3e24`](https://github.com/openclaw/openclaw/commit/e99f6dc4c3e24f5f006d3040f9c74a09701293ce), authored and merged by @steipete on 2026-08-03. Accessible-label assignment reaches a shallow history boundary, so its first introduction is unknown. The original discarded tool-copy result was present in [`540ea124e09ac`](https://github.com/openclaw/openclaw/commit/540ea124e09ac), authored by Vyctor H. Brzezowski on 2026-08-18; main owns that routing repair through #130612.
