### PR TITLE
fix(gateway): stop dispatch after HTTP responses finish

### DIFF
--- a/src/gateway/server-http.request-trace.test.ts
+++ b/src/gateway/server-http.request-trace.test.ts
@@ -106,6 +106,47 @@ describe("gateway HTTP request trace scope", () => {
 });
 
 describe("gateway HTTP request error cleanup", () => {
+  it.each([
+    { label: "completed", destroy: false },
+    { label: "destroyed", destroy: true },
+  ])("does not invoke later routes after an earlier response is $label", async ({ destroy }) => {
+    const handleWatchNodeRequest = vi.fn(async () => true);
+    const server = createGatewayHttpServer({
+      clients: new Set(),
+      controlUiEnabled: false,
+      controlUiBasePath: "",
+      openAiChatCompletionsEnabled: false,
+      openResponsesEnabled: false,
+      handleHooksRequest: async (_req, res) => {
+        if (destroy) {
+          res.destroy();
+        } else {
+          res.end("already finished");
+        }
+        return false;
+      },
+      handleWatchNodeRequest,
+      resolvedAuth,
+      getRuntimeConfig: () => ({}),
+    });
+    const port = await listen(server);
+
+    try {
+      const request = fetch(`http://127.0.0.1:${port}/api/nodes/watch/example`);
+      if (destroy) {
+        await expect(request).rejects.toMatchObject({ name: "TypeError" });
+      } else {
+        const response = await request;
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe("already finished");
+      }
+      expect(handleWatchNodeRequest).not.toHaveBeenCalled();
+    } finally {
+      server.closeAllConnections();
+      await closeServer(server);
+    }
+  });
+
   it("preserves a response the route already completed before throwing", async () => {
     const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
     const server = createGatewayHttpServer({

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -140,17 +140,6 @@ function isWebSocketUpgradeRequest(req: IncomingMessage): boolean {
 
 type GatewayHttpRequestStage = () => Promise<boolean> | boolean;
 
-async function runGatewayHttpRequestStages(
-  stages: readonly GatewayHttpRequestStage[],
-): Promise<boolean> {
-  for (const stage of stages) {
-    if (await stage()) {
-      return true;
-    }
-  }
-  return false;
-}
-
 /** Creates the gateway HTTP/HTTPS server and ordered request-stage router. */
 export function createGatewayHttpServer(opts: {
   clients: Set<GatewayWsClient>;
@@ -640,8 +629,11 @@ export function createGatewayHttpServer(opts: {
       );
       addRequestStage(controlUiEnabled, handleControlUiRequest);
 
-      if (await runGatewayHttpRequestStages(requestStages)) {
-        return;
+      // A completed or disconnected response owns the request even when a stage reports fallthrough.
+      for (const stage of requestStages) {
+        if ((await stage()) || res.destroyed || res.writableEnded) {
+          return;
+        }
       }
 
       // Startup owns sidecar readiness. The plugin registry is still empty here, so an


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway routes could continue running later handlers after an earlier handler had already completed the response or the client connection had been destroyed. This could invoke unrelated watch, plugin, authentication, admission, or fallback work for a request whose transport no longer exists.

## Why This Change Was Made

The Gateway's sole-use stage runner trusted only a handler's Boolean claim, ignoring the authoritative response lifecycle. Remove that redundant helper and let the existing owner stop dispatch when a stage claims the request or its response is already ended/destroyed. The predicate matches the existing Gateway failure-response owner and deliberately does not confuse valid streaming headers or consumed keep-alive requests with terminal responses.

The shared production owner is **5 lines added, 13 deleted: net -8 lines**. There is no configuration, protocol, persistence, authorization, or public API change.

## User Impact

Completed responses keep their original bytes and status; disconnected requests no longer run downstream route handlers, authenticate unrelated paths, acquire extra admission, or attempt a second response. Ordinary fallthrough, streaming, keep-alive, and unclaimed-route behavior remain unchanged.

## Evidence

Actual `createGatewayHttpServer`, ephemeral localhost listener, and real HTTP client before the fix:

```json
{"status":200,"body":"already finished","laterHandlerCalls":1,"expectedLaterHandlerCalls":0}
```

The identical real-server command after the fix:

```json
{"status":200,"body":"already finished","laterHandlerCalls":0,"expectedLaterHandlerCalls":0}
```

Both new real-loopback regressions demonstrably failed before repair: one handler completes a normal response and returns `false`; the other destroys the response transport and returns `false`. Both now prove the later watch handler is never invoked while preserving the actual response or disconnect outcome.

```text
node scripts/run-vitest.mjs run \
  src/gateway/server-http.request-trace.test.ts \
  src/gateway/http-common.test.ts \
  src/gateway/server-http.hooks-delivery.test.ts \
  src/gateway/server-http-plugin-auth.test.ts \
  src/gateway/server-http.openai-compat.test.ts \
  src/gateway/server-http.mcp-app-admission.test.ts

Test Files  6 passed (6)
     Tests  66 passed (66)
```

Fresh independent Codex autoreview passed with confidence 0.99. Targeted formatter/linter, production core typecheck, and approximately 18 changed-file architecture/boundary guards passed. The final local test-typecheck also reproduces an unrelated pristine-checkout baseline missing `pako` declaration (`ui/vite.config.ts:8`, TS7016); hosted CI installs the canonical lockfile and is authoritative for that unchanged dependency.
