### PR TITLE
fix(ci): preserve real plugin metadata scope in model regression

### DIFF
--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -140,10 +140,6 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
   prepareProviderRuntimeAuth: vi.fn(async () => undefined),
 }));
 
-vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
-  getCurrentPluginMetadataSnapshot: () => ({ plugins: [] }),
-}));
-
 vi.mock("../provider-secret-egress.js", () => ({
   protectPreparedProviderRuntimeAuth: (value: unknown) => value,
   unwrapSecretSentinelsForProviderEgress: (value: unknown) => value,


### PR DESCRIPTION
## Summary
- Remove the incomplete hoisted plugin metadata snapshot mock that hides the actual snapshot scope export.
- Preserve the real snapshot lifecycle and restore the exact known-good model regression test from merged PR #129548.
- Repair the deterministic selected-agent model alias failure introduced by merged PR #129451; production code is unchanged and the test shrinks by four lines.

## Validation
- Reproduced the current-main missing snapshot scope export before the change; the exact selected-agent alias regression passes afterward.
- Full affected owner suite: 8 tests passed.
- Provider model normalization siblings: 11 tests passed.
- Real snapshot lifecycle and security siblings: 36 tests passed.
- Complete unsuppressed changed gate passed, including core test types, formatting, lint, dead-code scans, and repository guards.
- Independent review and structured automated review reported no findings.