### PR TITLE
fix(models): preserve provider-defined reasoning levels across model catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,6 @@ Docs: https://docs.openclaw.ai
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.
-- **Provider reasoning levels:** preserve provider-defined effort mappings across model discovery, configured route selection, thinking controls, and compaction so unsupported levels stay hidden and mapped advanced levels remain available. Thanks @ekinnee.
 - **iOS fresh-install setup:** atomically redact spent setup credentials before Keychain cleanup so a deferred item deletion no longer disconnects a successfully paired device. Fixes #107591. Thanks @dagmarjeeves-lab.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ Docs: https://docs.openclaw.ai
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.
+- **Provider reasoning levels:** preserve provider-defined effort mappings across model discovery, configured route selection, thinking controls, and compaction so unsupported levels stay hidden and mapped advanced levels remain available. Thanks @ekinnee.
 - **iOS fresh-install setup:** atomically redact spent setup credentials before Keychain cleanup so a deferred item deletion no longer disconnects a successfully paired device. Fixes #107591. Thanks @dagmarjeeves-lab.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -68,6 +68,23 @@ describe("resolveEmbeddedCompactionThinkingLevel", () => {
     ).toBe("high");
   });
 
+  it("revalidates the compaction default against provider-denied thinking levels", () => {
+    expect(
+      resolveEmbeddedCompactionThinkingLevel({
+        provider: "custom",
+        modelId: "reasoning-model",
+        catalog: [
+          {
+            provider: "custom",
+            id: "reasoning-model",
+            reasoning: true,
+            thinkingLevelMap: { minimal: null, low: null, medium: null },
+          },
+        ],
+      }),
+    ).toBe("high");
+  });
+
   it("defaults compaction to low without inheriting the session level", () => {
     expect(
       resolveEmbeddedCompactionThinkingLevel({

--- a/src/agents/embedded-agent-runner/direct-compaction-preparation.ts
+++ b/src/agents/embedded-agent-runner/direct-compaction-preparation.ts
@@ -292,6 +292,7 @@ export async function prepareDirectCompactionAttempt(
     id: runtimeModel.id,
     api: runtimeModel.api,
     reasoning: runtimeModel.reasoning,
+    ...(runtimeModel.thinkingLevelMap ? { thinkingLevelMap: runtimeModel.thinkingLevelMap } : {}),
     params: runtimeModel.params,
     ...(thinkingCompat ? { compat: thinkingCompat } : {}),
   } satisfies ThinkingCatalogEntry;

--- a/src/agents/model-catalog-route.test.ts
+++ b/src/agents/model-catalog-route.test.ts
@@ -39,6 +39,7 @@ const platformEntry: ModelCatalogEntry = {
   contextWindow: 1_000_000,
   contextTokens: 272_000,
   reasoning: true,
+  thinkingLevelMap: { off: "none", xhigh: "xhigh", max: "max" },
   input: ["text", "image"],
   params: { platformOnly: true },
   compat: { supportsTools: false },
@@ -53,6 +54,7 @@ const chatGPTEntry: ModelCatalogEntry = {
   contextWindow: 400_000,
   contextTokens: 300_000,
   reasoning: true,
+  thinkingLevelMap: { off: null, xhigh: null, max: "max" },
   input: ["text"],
   params: { chatGPTOnly: true },
   compat: { supportsTools: true },
@@ -103,6 +105,7 @@ describe("projectModelCatalogEntryForRoute", () => {
       contextWindow: 1_000_000,
       contextTokens: 272_000,
       reasoning: true,
+      thinkingLevelMap: { off: "none", xhigh: "xhigh", max: "max" },
       input: ["text", "image"],
     });
 
@@ -121,6 +124,7 @@ describe("projectModelCatalogEntryForRoute", () => {
       contextWindow: 400_000,
       contextTokens: 300_000,
       reasoning: true,
+      thinkingLevelMap: { off: null, xhigh: null, max: "max" },
       input: ["text"],
     });
   });
@@ -177,7 +181,13 @@ describe("projectModelCatalogEntryForRoute", () => {
         providers: {
           openai: {
             baseUrl: "https://api.openai.com/v1",
-            models: [{ id: "gpt-5.5", contextTokens: 160_000 }],
+            models: [
+              {
+                id: "gpt-5.5",
+                contextTokens: 160_000,
+                thinkingLevelMap: { off: "none", max: null },
+              },
+            ],
           },
         },
       },
@@ -198,6 +208,7 @@ describe("projectModelCatalogEntryForRoute", () => {
       api: "openai-chatgpt-responses",
       baseUrl: "https://chatgpt.com/backend-api/codex",
       contextTokens: 160_000,
+      thinkingLevelMap: { off: "none", max: null },
     });
   });
 

--- a/src/agents/model-catalog-route.ts
+++ b/src/agents/model-catalog-route.ts
@@ -36,7 +36,13 @@ export type ModelCatalogRouteProjection =
 type ModelCatalogLogicalOverrides = Partial<
   Pick<
     ModelCatalogEntry,
-    "name" | "contextWindow" | "contextTokens" | "reasoning" | "configuredReasoning" | "input"
+    | "name"
+    | "contextWindow"
+    | "contextTokens"
+    | "reasoning"
+    | "configuredReasoning"
+    | "thinkingLevelMap"
+    | "input"
   >
 >;
 
@@ -69,6 +75,7 @@ export function resolveConfiguredModelCatalogOverrides(params: {
     ...(model?.contextTokens !== undefined ? { contextTokens: model.contextTokens } : {}),
     ...(model?.reasoning !== undefined ? { reasoning: model.reasoning } : {}),
     ...(model?.reasoning !== undefined ? { configuredReasoning: model.reasoning } : {}),
+    ...(model?.thinkingLevelMap ? { thinkingLevelMap: model.thinkingLevelMap } : {}),
     ...(model?.input !== undefined ? { input: model.input } : {}),
   };
   return Object.keys(overrides).length > 0 ? overrides : undefined;
@@ -180,6 +187,7 @@ export function projectModelCatalogEntryForRoute(params: {
       ...(donor?.contextWindow !== undefined ? { contextWindow: donor.contextWindow } : {}),
       ...(donor?.contextTokens !== undefined ? { contextTokens: donor.contextTokens } : {}),
       ...(donor?.reasoning !== undefined ? { reasoning: donor.reasoning } : {}),
+      ...(donor?.thinkingLevelMap ? { thinkingLevelMap: donor.thinkingLevelMap } : {}),
       ...(donor?.input !== undefined ? { input: donor.input } : {}),
     },
     params.overrides,

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -100,6 +100,7 @@ describe("prepared model catalog builder", () => {
           name: "Alpha",
           provider: "alpha",
           contextWindow: 64_000,
+          thinkingLevelMap: { off: null, max: "max" },
           input: ["text", "image"],
         },
       ],
@@ -109,6 +110,7 @@ describe("prepared model catalog builder", () => {
       "alpha/a",
       "beta/z",
     ]);
+    expect(snapshot.entries[0]?.thinkingLevelMap).toEqual({ off: null, max: "max" });
     expect(snapshot.routeVariants).toEqual(snapshot.entries);
   });
 
@@ -164,6 +166,7 @@ describe("prepared model catalog builder", () => {
                   { id: "1m", label: "1M", contextWindow: 1_000_000 },
                 ],
                 contextWindowDefault: "1m",
+                thinkingLevelMap: { off: null, xhigh: "xhigh", max: "max" },
               },
             ],
           },
@@ -186,6 +189,7 @@ describe("prepared model catalog builder", () => {
         { id: "1m", label: "1M", contextWindow: 1_000_000 },
       ],
       contextWindowDefault: "1m",
+      thinkingLevelMap: { off: null, xhigh: "xhigh", max: "max" },
     });
   });
 
@@ -524,6 +528,7 @@ describe("prepared model catalog builder", () => {
                 contextWindow: 32_000,
                 maxTokens: 4_096,
                 reasoning: true,
+                thinkingLevelMap: { off: null, xhigh: "xhigh" },
                 input: ["text", "image"],
                 cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
               },
@@ -551,6 +556,7 @@ describe("prepared model catalog builder", () => {
       api: "openai-completions",
       contextWindow: 32_000,
       reasoning: true,
+      thinkingLevelMap: { off: null, xhigh: "xhigh" },
       input: ["text", "image"],
     });
     expect(snapshot.routeVariants).toHaveLength(2);
@@ -564,6 +570,7 @@ describe("prepared model catalog builder", () => {
         provider: "custom",
         api: "openai-completions",
         baseUrl: "https://route-b.example.test/v1",
+        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
         compat: { supportsTools: false },
       },
     ]);
@@ -597,6 +604,7 @@ describe("prepared model catalog builder", () => {
           provider: "custom",
           api: "openai-responses",
           baseUrl: "https://route-a.example.test/v1",
+          thinkingLevelMap: { xhigh: null, max: null },
           compat: { supportsTools: true },
         },
       ],
@@ -608,6 +616,7 @@ describe("prepared model catalog builder", () => {
     ).toMatchObject({
       api: "openai-responses",
       baseUrl: "https://route-a.example.test/v1",
+      thinkingLevelMap: { xhigh: null, max: null },
       compat: { supportsTools: true },
     });
   });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -57,6 +57,7 @@ type DiscoveredModel = {
   contextWindow?: number;
   contextTokens?: number;
   reasoning?: boolean;
+  thinkingLevelMap?: ModelCatalogEntry["thinkingLevelMap"];
   input?: ModelInputType[];
   params?: ModelCatalogEntry["params"];
   compat?: ModelCatalogEntry["compat"];
@@ -183,6 +184,7 @@ function clearRouteBoundCatalogMetadata(entry: ModelCatalogEntry): ModelCatalogE
     contextWindowDefault: _contextWindowDefault,
     contextTokens: _contextTokens,
     reasoning: _reasoning,
+    thinkingLevelMap: _thinkingLevelMap,
     input: _input,
     params: _params,
     compat: _compat,
@@ -196,7 +198,7 @@ function overlayCatalogMetadata(
   base: ModelCatalogEntry,
   overlay: ModelCatalogEntry,
   options?: {
-    catalogCompatRoute?: ModelCatalogEntry;
+    catalogRoute?: ModelCatalogEntry;
     preserveBaseCompat?: boolean;
     preserveBaseName?: boolean;
   },
@@ -207,6 +209,7 @@ function overlayCatalogMetadata(
   const routeChanged = catalogRouteChanges(base, overlay);
   const routeBase = routeChanged ? clearRouteBoundCatalogMetadata(base) : base;
   const params = mergeCatalogParams(routeBase.params, overlay.params);
+  const thinkingLevelMap = overlay.thinkingLevelMap ?? options?.catalogRoute?.thinkingLevelMap;
   // Options + default are one normalized unit (default ∈ options): an overlay
   // that replaces the options list must also own the default, or a base default
   // absent from the new list would leak through the field-by-field merge.
@@ -243,6 +246,7 @@ function overlayCatalogMetadata(
     ...(overlay.contextWindow !== undefined ? { contextWindow: overlay.contextWindow } : {}),
     ...(overlay.contextTokens !== undefined ? { contextTokens: overlay.contextTokens } : {}),
     ...(overlay.reasoning !== undefined ? { reasoning: overlay.reasoning } : {}),
+    ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
     ...(overlay.input !== undefined ? { input: overlay.input } : {}),
     ...(params ? { params } : {}),
     ...(overlay.mediaInput !== undefined ? { mediaInput: overlay.mediaInput } : {}),
@@ -253,8 +257,8 @@ function overlayCatalogMetadata(
     ...(overlay.replacedBy !== undefined ? { replacedBy: overlay.replacedBy } : {}),
     compat: options?.preserveBaseCompat
       ? resolveCatalogOwnedModelCompat({
-          catalogRoute: options.catalogCompatRoute ?? base,
-          catalogCompat: (options.catalogCompatRoute ?? base).compat,
+          catalogRoute: options.catalogRoute ?? base,
+          catalogCompat: (options.catalogRoute ?? base).compat,
           configuredRoute: {
             api: overlay.api ?? base.api,
             baseUrl: overlay.baseUrl ?? base.baseUrl,
@@ -279,7 +283,7 @@ function mergeCatalogEntries(
   models: ModelCatalogEntry[],
   entries: ModelCatalogEntry[],
   options?: {
-    catalogCompatRoutes?: readonly ModelCatalogEntry[];
+    catalogRoutes?: readonly ModelCatalogEntry[];
     preserveBaseCompat?: boolean;
     preserveBaseName?: boolean;
   },
@@ -297,16 +301,16 @@ function mergeCatalogEntries(
     }
     const existing = models.at(existingIndex);
     if (existing) {
-      // The logical row may currently represent a sibling physical route. Compat
-      // must come from the catalog variant selected by config, not that sibling.
-      const catalogCompatRoute = options?.preserveBaseCompat
-        ? options.catalogCompatRoutes?.find(
+      // Logical rows can represent a sibling route; capabilities must come
+      // from the exact catalog variant selected by config, not that sibling.
+      const catalogRoute = options?.preserveBaseCompat
+        ? options.catalogRoutes?.find(
             (candidate) => catalogRouteVariantKey(candidate) === catalogRouteVariantKey(entry),
           )
         : undefined;
       models[existingIndex] = overlayCatalogMetadata(existing, entry, {
         ...options,
-        catalogCompatRoute,
+        catalogRoute,
       });
     }
   }
@@ -454,6 +458,9 @@ export function loadManifestModelCatalog(params: {
     if (typeof row.reasoning === "boolean") {
       entry.reasoning = row.reasoning;
     }
+    if (row.thinkingLevelMap) {
+      entry.thinkingLevelMap = { ...row.thinkingLevelMap };
+    }
     if (row.input?.length) {
       entry.input = [...row.input];
     }
@@ -561,6 +568,7 @@ export async function buildPreparedModelCatalogSnapshot(
         contextWindow,
         ...(contextTokens !== undefined ? { contextTokens } : {}),
         reasoning,
+        ...(entry.thinkingLevelMap ? { thinkingLevelMap: entry.thinkingLevelMap } : {}),
         input,
         ...(modelParams ? { params: modelParams } : {}),
         compat,
@@ -606,7 +614,7 @@ export async function buildPreparedModelCatalogSnapshot(
     if (configuredModels.length > 0) {
       const entriesForAugment = [...models];
       mergeCatalogEntries(entriesForAugment, configuredModels, {
-        catalogCompatRoutes: routeVariants.entries,
+        catalogRoutes: routeVariants.entries,
         preserveBaseCompat: true,
         preserveBaseName: true,
       });
@@ -692,7 +700,7 @@ export async function buildPreparedModelCatalogSnapshot(
     if (configuredModels.length > 0) {
       mergeCatalogRouteVariants(routeVariants, configuredModels, { preserveBaseCompat: true });
       mergeCatalogEntries(models, configuredModels, {
-        catalogCompatRoutes: routeVariants.entries,
+        catalogRoutes: routeVariants.entries,
         preserveBaseCompat: true,
         preserveBaseName: true,
       });

--- a/src/agents/model-catalog.types.ts
+++ b/src/agents/model-catalog.types.ts
@@ -5,6 +5,7 @@
  */
 import type { ModelCatalogStatus } from "@openclaw/model-catalog-core/model-catalog-types";
 import type { ModelApi, ModelCompatConfig, ModelMediaInputConfig } from "../config/types.models.js";
+import type { ThinkingLevelMap } from "../llm/types.js";
 import type { ProviderCatalogOutcome } from "../plugins/provider-catalog-outcome.js";
 
 /** Input modalities a catalog entry can advertise. */
@@ -36,6 +37,8 @@ export type ModelCatalogEntry = {
   configuredReasoning?: boolean;
   /** Concrete runtime owner of thinking policy; internal and never project to clients. */
   thinkingPolicyProvider?: string;
+  /** Provider-owned effort support for this exact physical model route. */
+  thinkingLevelMap?: ThinkingLevelMap;
   input?: ModelInputType[];
   params?: Record<string, unknown>;
   compat?: ModelCompatConfig;

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -1458,6 +1458,7 @@ export function buildConfiguredModelCatalog(params: {
         contextTokens,
         reasoning,
         ...(typeof model?.reasoning === "boolean" ? { configuredReasoning: model.reasoning } : {}),
+        ...(model.thinkingLevelMap ? { thinkingLevelMap: model.thinkingLevelMap } : {}),
         input,
         ...(modelParams ? { params: modelParams } : {}),
         compat,

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -827,6 +827,7 @@ describe("model-selection", () => {
                   id: "Qwen/Qwen3-8B",
                   name: "Qwen 3 8B",
                   reasoning: true,
+                  thinkingLevelMap: { off: null, max: "max" },
                   compat: {
                     thinkingFormat: "qwen-chat-template",
                   },
@@ -843,6 +844,7 @@ describe("model-selection", () => {
       expect(model?.compat).toEqual({ thinkingFormat: "qwen-chat-template" });
       expect(model?.reasoning).toBe(true);
       expect(model?.configuredReasoning).toBe(true);
+      expect(model?.thinkingLevelMap).toEqual({ off: null, max: "max" });
     });
 
     it("carries configured model params into catalog entries for provider policy", () => {

--- a/src/agents/prepared-model-runtime.configured.ts
+++ b/src/agents/prepared-model-runtime.configured.ts
@@ -75,6 +75,7 @@ export function toStaticCatalogEntry(model: ProviderRuntimeModel): ModelCatalogE
     ...(model.contextWindowDefault ? { contextWindowDefault: model.contextWindowDefault } : {}),
     ...(model.contextTokens ? { contextTokens: model.contextTokens } : {}),
     ...(model.reasoning !== undefined ? { reasoning: model.reasoning } : {}),
+    ...(model.thinkingLevelMap ? { thinkingLevelMap: model.thinkingLevelMap } : {}),
     ...(model.input ? { input: model.input } : {}),
     ...(model.params ? { params: model.params } : {}),
     ...(model.compat ? { compat: model.compat } : {}),

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -82,6 +82,7 @@ const mocks = vi.hoisted(() => {
                   id: "gpt-5.5",
                   name: "GPT-5.5",
                   reasoning: true,
+                  thinkingLevelMap: { off: null, max: "max" },
                   input: ["text"],
                   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
                   contextWindow: 128_000,
@@ -560,6 +561,10 @@ describe("prepared model runtime Gateway catalog mode", () => {
         "openai/gpt-5.5",
       ]);
     }
+    expect(
+      snapshot?.modelCatalog.staticEntries?.find((entry) => entry.provider === "openai")
+        ?.thinkingLevelMap,
+    ).toEqual({ off: null, max: "max" });
     expect(mocks.prepareStaticCatalog).toHaveBeenCalledWith(
       expect.objectContaining({
         providerDiscoveryProviderIds: [provider, "openai"],

--- a/src/auto-reply/thinking.shared.ts
+++ b/src/auto-reply/thinking.shared.ts
@@ -5,6 +5,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "../../packages/normalization-core/src/string-coerce.js";
+import type { ThinkingLevelMap } from "../llm/types.js";
 
 export { normalizeFastMode };
 export type { FastMode };
@@ -36,6 +37,7 @@ export type ThinkingCatalogEntry = {
   configuredReasoning?: boolean;
   /** Concrete runtime owner of thinking policy; internal and never project to clients. */
   thinkingPolicyProvider?: string;
+  thinkingLevelMap?: ThinkingLevelMap;
   input?: readonly ("text" | "image" | "audio" | "video" | "document")[];
   params?: Record<string, unknown>;
   compat?: {

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -603,6 +603,67 @@ describe("listThinkingLevels", () => {
     ).toEqual(["off", "minimal", "low", "medium", "high"]);
   });
 
+  it("honors provider-owned thinking maps before compat and derives OpenClaw Ultra", () => {
+    const catalog = [
+      {
+        provider: "custom",
+        id: "reasoning-model",
+        reasoning: true,
+        thinkingLevelMap: {
+          off: "none",
+          minimal: null,
+          low: null,
+          medium: null,
+          high: "high",
+          xhigh: null,
+          max: "max",
+        },
+        compat: { supportedReasoningEfforts: ["high", "xhigh", "max"] },
+      },
+    ];
+
+    expect(listThinkingLevels("custom", "reasoning-model", catalog, "openclaw")).toEqual([
+      "off",
+      "high",
+      "max",
+      "ultra",
+    ]);
+    expect(
+      resolveThinkingDefaultForModel({
+        provider: "custom",
+        model: "reasoning-model",
+        catalog,
+        agentRuntime: "openclaw",
+      }),
+    ).toBe("high");
+    expect(listThinkingLevels("custom", "reasoning-model", catalog, "codex")).toEqual([
+      "off",
+      "high",
+      "max",
+    ]);
+  });
+
+  it("exposes mapped advanced efforts without requiring duplicate compat metadata", () => {
+    const catalog = [
+      {
+        provider: "custom",
+        id: "mapped-model",
+        reasoning: true,
+        thinkingLevelMap: { off: null, xhigh: "xhigh", max: "max" },
+      },
+    ];
+
+    expect(listThinkingLevels("custom", "mapped-model", catalog, "openclaw")).toEqual([
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultra",
+    ]);
+  });
+
   it("matches provider-qualified catalog ids for provider thinking profiles", () => {
     providerRuntimeMocks.resolveProviderThinkingProfile.mockImplementation(({ context }) =>
       context.reasoning === true && context.compat?.thinkingFormat === "qwen-chat-template"
@@ -714,6 +775,7 @@ describe("listThinkingLevels", () => {
         provider: "zai",
         id: "glm-4.7",
         name: "GLM 4.7",
+        thinkingLevelMap: { off: null, xhigh: "xhigh", max: "max" },
         compat: { supportedReasoningEfforts: ["xhigh"] },
       },
     ];

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -108,6 +108,7 @@ function resolveThinkingPolicyContext(params: {
     modelKey,
     api: candidate?.api,
     reasoning: params.configuredReasoning ?? candidate?.configuredReasoning ?? candidate?.reasoning,
+    thinkingLevelMap: candidate?.thinkingLevelMap,
     ...(candidate?.params ? { params: candidate.params } : {}),
     compat: candidate?.compat,
   };
@@ -169,21 +170,29 @@ function appendProfileLevel(profile: ResolvedThinkingProfile, id: ThinkLevel) {
   profile.levels = profile.levels.toSorted((a, b) => a.rank - b.rank);
 }
 
-const CATALOG_ADVANCED_THINKING_LEVELS = new Set<ThinkLevel>(["adaptive", "xhigh", "max"]);
-
 function appendCatalogAdvancedThinkingLevels(
   profile: ResolvedThinkingProfile,
   compat: ThinkingCatalogEntry["compat"],
+  thinkingLevelMap: ThinkingCatalogEntry["thinkingLevelMap"],
   agentRuntime?: string | null,
 ) {
-  const efforts = compat?.supportedReasoningEfforts;
-  if (!Array.isArray(efforts)) {
-    return;
+  if (thinkingLevelMap) {
+    for (const level of ["xhigh", "max"] as const) {
+      if (thinkingLevelMap[level] !== undefined && thinkingLevelMap[level] !== null) {
+        appendProfileLevel(profile, level);
+      }
+    }
+    profile.levels = profile.levels.filter(
+      ({ id }) => id === "adaptive" || id === "ultra" || thinkingLevelMap[id] !== null,
+    );
   }
-  let supportsMax = false;
-  for (const effort of efforts) {
+  let supportsMax = profile.levels.some(({ id }) => id === "max");
+  for (const effort of compat?.supportedReasoningEfforts ?? []) {
     const level = normalizeThinkLevel(effort);
-    if (level && CATALOG_ADVANCED_THINKING_LEVELS.has(level)) {
+    if (
+      (level === "adaptive" || level === "xhigh" || level === "max") &&
+      (level === "adaptive" || thinkingLevelMap?.[level] !== null)
+    ) {
       appendProfileLevel(profile, level);
       supportsMax ||= level === "max";
     }
@@ -253,7 +262,12 @@ export function resolveThinkingProfile(params: {
   }
 
   const profile = buildBaseThinkingProfile();
-  appendCatalogAdvancedThinkingLevels(profile, context.compat, params.agentRuntime);
+  appendCatalogAdvancedThinkingLevels(
+    profile,
+    context.compat,
+    context.thinkingLevelMap,
+    params.agentRuntime,
+  );
   return profile;
 }
 


### PR DESCRIPTION
## Summary

Preserve provider-owned reasoning-effort capabilities across OpenClaw's existing model catalog, exact physical-route selection, configured/static snapshots, and direct compaction.

Replaces #126013, which GitHub closed when its contributor fork was deleted. The original contribution is preserved with Erick Kinnee's commit co-author attribution.

This is the independently useful contribution from the original pull request. The original New Session discovery/lifecycle stack is superseded by #129307, so this branch no longer depends on #128863 and does not add a second discovery worker, Gateway readiness contract, protocol surface, Control UI path, config option, startup fallback, or SDK change.

## Root cause and architectural owner

Providers can publish a `thinkingLevelMap`, including null entries for unsupported efforts, but catalog reconstruction and route donation previously retained only compatibility metadata. As a result, provider-defined effort capabilities were lost as models crossed existing catalog/route boundaries, and direct compaction could select an effort the physical provider does not support.

The repair keeps the map in the existing provider-owned model entry contract and carries it through the canonical catalog constructors and exact physical-route donor. Changing a route discards its previous route's capabilities; an explicit override receives only its exact matching route's capabilities. Thinking-level selection respects null exclusions and provider-defined `xhigh`/`max`, derives the existing OpenClaw `ultra` alias from `max`, preserves provider-plugin thinking-profile precedence, and chooses the first supported default. Direct compaction receives the same capabilities as the selected model.

Gateway public model responses continue using their existing explicit allowlist; internal provider capability metadata is not leaked.

## Proof

Three focused regressions fail on the pre-fix owner paths: physical-route donation loses the provider map, an explicit route override loses it, and direct compaction selects unsupported `low`. All pass with the owner-boundary repair.

- Six focused existing suites pass: **293 tests** covering catalog reconstruction, model selection, route donation/override, prepared static startup, thinking profiles/null exclusions, and compaction runtime context.
- Core TypeScript typechecking passes.
- Changed-file formatting and independent structured branch review pass.
- No persistent-store schema, Gateway protocol, public SDK, configuration, startup discovery, or provider-network behavior changes.

Direct sibling Codex source confirms model listing preserves provider-published supported reasoning efforts and default effort at the dependency boundary: [catalog processor](https://github.com/openai/codex/blob/d1d51f6315f84a1737c655cb4d78104d030d5102/codex-rs/app-server/src/request_processors/catalog_processor.rs#L241-L292), [model projection](https://github.com/openai/codex/blob/d1d51f6315f84a1737c655cb4d78104d030d5102/codex-rs/app-server/src/models.rs#L1-L68), and [protocol Model](https://github.com/openai/codex/blob/d1d51f6315f84a1737c655cb4d78104d030d5102/codex-rs/app-server-protocol/src/protocol/v2/model.rs#L53-L151).

## Scope

The original **111-file** proposal has been reduced to **14 files**: production **+59/-21** (net +38) and tests **+107/-1**. The remaining production growth implements the concrete provider reasoning-capability contract across its existing catalog/route/compaction owners; it introduces no parallel compatibility or discovery path. Release-note context and contributor credit are retained here because the root changelog is release-owned.

Thanks @ekinnee for the original provider-capability contribution.
