### PR TITLE
fix(ci): model-resolution tests fail after metadata scope changes

### DIFF
--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -140,11 +140,6 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
   prepareProviderRuntimeAuth: vi.fn(async () => undefined),
 }));
 
-vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
-  getCurrentPluginMetadataSnapshot: () => ({ plugins: [] }),
-  withPluginMetadataSnapshotScope: (_snapshot: unknown, run: () => unknown) => run(),
-}));
-
 vi.mock("../provider-secret-egress.js", () => ({
   protectPreparedProviderRuntimeAuth: (value: unknown) => value,
   unwrapSecretSentinelsForProviderEgress: (value: unknown) => value,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Repairs the test owner after two independently valid pull requests interacted on main: the embedded-agent model-resolution suite imported `withPluginMetadataSnapshotScope`, while its full-module mock initially omitted that export. A later identity export stopped the crash, but bypassed the real AsyncLocalStorage-backed scope that the regression is intended to exercise.

## Why This Change Was Made

Pull request #129548 added a scoped plugin-metadata regression for selected-agent model aliases. Pull request #129451 added a whole-module mock for the metadata snapshot owner. Main commit `5ac1b3c558f` temporarily completed that mock with an identity scope callback. Removing the obsolete whole-module mock is smaller and preserves the real owner behavior without changing production code, assertions, dependencies, or timeouts.

## User Impact

No production behavior changes. Maintainers retain the selected-agent alias regression while testing the actual plugin-metadata scope and lifecycle contract.

## Evidence

- Baseline at `46e4520bd5db`: the focused owner suite failed 1 of 8 tests with `No "withPluginMetadataSnapshotScope" export is defined`.
- Exact head `79963120228fdd81dddb755983f8d0d8ed62d4bf`: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model-resolution-consistency.test.ts` passes 8/8.
- Exact-head sibling coverage: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/current-plugin-metadata-snapshot.test.ts src/agents/model-selection.test.ts` passes 170/170.
- `git diff --check origin/main...HEAD` passes.
- Test audit: the retained regression has a demonstrated cross-merge failure and now exercises the real scope; no assertion, duplicate test, test-only production seam, or broad mock was added.
- Deslop, structured branch autoreview, and a separate exact-head read-only Codex review found no actionable findings.
- Production lines changed: 0. Test lines: +0/-5.