### PR TITLE
fix(ui): prevent deleting replacement sessions after confirmation

### DIFF
--- a/ui/src/e2e/session-management.delete.e2e.test.ts
+++ b/ui/src/e2e/session-management.delete.e2e.test.ts
@@ -253,6 +253,75 @@ suite.define(() => {
     }
   });
 
+  it("keeps bulk deletion fenced to the session selected before confirmation", async () => {
+    const key = "agent:main:confirmed";
+    const original = sessionRow(key, "Original session", 1, {
+      sessionId: "confirmed-session",
+    });
+    const replacement = sessionRow(key, "Replacement session", 2, {
+      sessionId: "replacement-session",
+    });
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      recordVideo: captureUiProofEnabled
+        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        : undefined,
+    });
+    const page = await context.newPage();
+    const proofVideo = page.video();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.delete": { ok: true, deleted: true },
+        "sessions.list": sessionsListResponse([original]),
+      },
+      sessionKey: "agent:main:main",
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}sessions`);
+      const replacementLabel = page.locator(".sessions-table").getByText("Replacement session", {
+        exact: true,
+      });
+      await page.getByRole("checkbox", { name: `Select session: ${key}` }).check();
+      await page.locator(".data-table-bulk-bar").getByRole("button", { name: "Delete" }).click();
+      const confirmModal = await waitForConfirmModal(page);
+      await captureUiProof(page, "sessions-bulk-delete-original-confirm.png");
+
+      await gateway.setMethodResponse("sessions.list", sessionsListResponse([replacement]));
+      await gateway.emitGatewayEvent("sessions.changed", {
+        ...replacement,
+        reason: "update",
+        sessionKey: key,
+      });
+      await replacementLabel.waitFor();
+      await gateway.deferNext("sessions.delete");
+      await confirmModal.getByRole("button", { name: "Delete", exact: true }).click();
+
+      const request = await gateway.waitForRequest("sessions.delete");
+      expect(request).toMatchObject({
+        params: { expectedSessionId: "confirmed-session", key },
+      });
+      await gateway.rejectDeferred("sessions.delete", {
+        code: "INVALID_REQUEST",
+        message: `Session ${key} changed before deletion. Retry.`,
+      });
+      await expect
+        .poll(() => page.locator(".sessions-error[role=alert]").textContent())
+        .toContain("changed before deletion. Retry.");
+      await replacementLabel.waitFor();
+      await captureUiProof(page, "sessions-bulk-delete-replacement-protected.png");
+    } finally {
+      await context.close();
+      if (proofVideo) {
+        await proofVideo.saveAs(
+          path.join(uiProofArtifactDir, "sessions-bulk-delete-replaced.webm"),
+        );
+      }
+    }
+  });
+
   it("rejects deleting a same-key replacement after the in-app confirm", async () => {
     const key = "agent:main:research";
     const context = await suite.browser.newContext({

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -581,6 +581,60 @@ describe("sessions page lifecycle", () => {
     expect(page.selectedKeys).toEqual(new Set());
   });
 
+  it.each([
+    {
+      scenario: "the selected row is replaced by an archived generation",
+      originalArchived: false,
+      replacement: { sessionId: "replacement-session", archived: true },
+    },
+    {
+      scenario: "the selected row disappears from the roster",
+      originalArchived: false,
+      replacement: null,
+    },
+    {
+      scenario: "an archived selection is replaced by an active generation",
+      originalArchived: true,
+      replacement: { sessionId: "replacement-session", archived: false },
+    },
+  ])(
+    "preserves confirmed deletion identity when $scenario",
+    async ({ originalArchived, replacement }) => {
+      const key = "agent:main:confirmed";
+      const confirmation = deferred<boolean>();
+      vi.mocked(showConfirmDialog).mockReturnValueOnce(confirmation.promise);
+      const sessions = createSessions({
+        deleteMany: vi.fn(async () => ({ deleted: [], errors: [], preservedWorktrees: [] })),
+      });
+      const page = await createPage(
+        createContext(createGateway({} as GatewayBrowserClient).gateway, sessions),
+      );
+      page.result = {
+        count: 1,
+        sessions: [{ key, sessionId: "confirmed-session", archived: originalArchived }],
+      } as SessionsListResult;
+      page.selectedKeys = new Set([key]);
+
+      const deleting = page.deleteSelected();
+      expect(showConfirmDialog).toHaveBeenCalledOnce();
+      page.result = {
+        count: replacement ? 1 : 0,
+        sessions: replacement ? [{ key, ...replacement }] : [],
+      } as SessionsListResult;
+      confirmation.resolve(true);
+      await deleting;
+
+      expect(sessions.deleteMany).toHaveBeenCalledWith([
+        {
+          key,
+          agentId: undefined,
+          expectedSessionId: "confirmed-session",
+          ...(originalArchived ? { archivedOnly: true } : {}),
+        },
+      ]);
+    },
+  );
+
   it("adopts a managed snapshot that arrives under the bulk-delete lock after its tail refresh", async () => {
     const deleted = deferred<{
       deleted: string[];

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -670,6 +670,9 @@ class SessionsPage extends OpenClawLightDomElement {
     if (!scope) {
       return;
     }
+    // Snapshot identity and archive authority before a replacement can change them.
+    const rowsByKey = new Map(this.result?.sessions.map((row) => [row.key, row]) ?? []);
+    const rows = keys.map((key) => rowsByKey.get(key) ?? { key });
     const message = t(
       keys.length === 1
         ? "sessionsView.deleteSelectedConfirmOne"
@@ -686,10 +689,7 @@ class SessionsPage extends OpenClawLightDomElement {
     ) {
       return;
     }
-    const rowsByKey = new Map(this.result?.sessions.map((row) => [row.key, row]) ?? []);
-    // Only current row state may opt into write-scoped archive deletion.
-    // Unknown selections stay unflagged and therefore admin-only.
-    await this.deleteSessions(keys.map((key) => rowsByKey.get(key) ?? { key }));
+    await this.deleteSessions(rows);
   }
 
   private async deleteSessions(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users deleting selected sessions could delete a newly created replacement session, or apply the wrong archived-session authority, if the sessions list changed while the confirmation dialog was open.

## Why This Change Was Made

Capture each selected session's generation and archive state before awaiting confirmation, matching the existing single-session deletion ownership boundary. Keep the Gateway's generation fence intact so replacement or disappeared sessions are rejected instead of silently borrowing newly observed identity or authority.

The repair changes no protocol, scopes, persistence, or configuration and adds zero production lines. Focused regression coverage proves replacement, disappearance, and archived-to-active transitions.

## User Impact

Operators only authorize deletion of the exact sessions shown when they confirm. If one is replaced in the meantime, the replacement remains visible and the UI explains that the session changed before deletion.

## Evidence

The regression cases failed against unmodified `main` and now pass. The complete Sessions owner suite passes all 33 tests, and the full real-Chromium session-management suite passes all four scenarios against a mocked Gateway WebSocket, including a live `sessions.changed` event during confirmation and a rejected stale-generation delete request.

```text
node scripts/run-vitest.mjs ui/src/pages/sessions/sessions-page.test.ts
# 33 passed

node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts \
  --configLoader runner ui/src/e2e/session-management.delete.e2e.test.ts
# 4 passed
```

Before confirmation, the operator approves the original session:

![Original selected session awaiting delete confirmation](https://github.com/user-attachments/assets/030bdd4f-b8aa-4198-945f-184b6df1f810)

After the session is replaced, the deletion is rejected and the replacement remains present:

![Replacement session protected with a visible stale-generation error](https://github.com/user-attachments/assets/8f36dcfa-344e-4eb3-881a-ff5288109e2b)

Full browser recording:

https://github.com/user-attachments/assets/80c66e2d-f44a-468d-bb4f-6798cec5f29f
