### PR TITLE
fix(skills): bound installer downloads

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -473,7 +473,9 @@ metadata:
       env vars are read but never overwritten.
     - **Download:** `url` (required), `archive` (`tar.gz` | `tar.bz2` | `zip`),
       `extract` (default: auto when archive detected), `stripComponents`,
-      `targetDir` (default: `~/.openclaw/tools/<skillKey>`).
+      `targetDir` (default: `~/.openclaw/tools/<skillKey>`). Response bodies
+      are capped at 256 MiB; larger transfers are aborted while streaming,
+      and partial staging data is removed.
   </Accordion>
   <Accordion title="Sandboxing notes">
     `requires.bins` is checked on the **host** at skill load time. If an agent

--- a/src/skills/lifecycle/install-download.test.ts
+++ b/src/skills/lifecycle/install-download.test.ts
@@ -1,5 +1,7 @@
 // Install download tests cover downloading skill archives before extraction.
 import fs from "node:fs/promises";
+import { createServer, type ServerResponse } from "node:http";
+import type { Socket } from "node:net";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -109,6 +111,64 @@ function createCancelableBody() {
   return { stream, wasCanceled: () => canceled };
 }
 
+async function withDownloadServer(
+  respond: (response: ServerResponse) => Promise<void> | void,
+  run: (origin: string, release: ReturnType<typeof vi.fn>) => Promise<void>,
+): Promise<void> {
+  const sockets = new Set<Socket>();
+  const server = createServer((_request, response) => {
+    void Promise.resolve(respond(response)).catch((error: unknown) => {
+      response.destroy(error instanceof Error ? error : undefined);
+    });
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected an ephemeral loopback server address");
+  }
+  const origin = `http://127.0.0.1:${address.port}`;
+  const release = vi.fn();
+  const actualFetchGuard = await vi.importActual<typeof import("../../infra/net/fetch-guard.js")>(
+    "../../infra/net/fetch-guard.js",
+  );
+  fetchWithSsrFGuardMock.mockImplementation(async (...args: unknown[]) => {
+    const params = args[0] as Parameters<typeof actualFetchGuard.fetchWithSsrFGuard>[0];
+    const guarded = await actualFetchGuard.fetchWithSsrFGuard({
+      ...params,
+      policy: { allowedOrigins: [origin] },
+    });
+    return {
+      ...guarded,
+      release: async () => {
+        release();
+        await guarded.release();
+      },
+    };
+  });
+
+  try {
+    await run(origin, release);
+  } finally {
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
 function runCommandResult(
   params?: Partial<Record<"code" | "stdout" | "stderr" | "stdoutTruncatedBytes", string | number>>,
 ) {
@@ -167,6 +227,121 @@ beforeEach(() => {
 });
 
 describe("installDownloadSpec extraction safety", () => {
+  it("aborts oversized chunked HTTP downloads and removes partial staging data", async () => {
+    const maxBytes = 256 * 1024 * 1024;
+    const chunk = Buffer.alloc(1024 * 1024);
+    let producedBytes = 0;
+    let producedPlannedTail = false;
+    let resolveConnectionClosed: (() => void) | undefined;
+    const connectionClosed = new Promise<void>((resolve) => {
+      resolveConnectionClosed = resolve;
+    });
+
+    await withDownloadServer(
+      async (response) => {
+        response.once("close", () => resolveConnectionClosed?.());
+        response.writeHead(200, { "content-type": "application/octet-stream" });
+
+        while (producedBytes < maxBytes && !response.destroyed) {
+          const writable = response.write(chunk);
+          producedBytes += chunk.byteLength;
+          if (!writable) {
+            await new Promise<void>((resolve) => {
+              const onDrain = () => {
+                response.off("close", onClose);
+                resolve();
+              };
+              const onClose = () => {
+                response.off("drain", onDrain);
+                resolve();
+              };
+              response.once("drain", onDrain);
+              response.once("close", onClose);
+            });
+          }
+        }
+
+        if (response.destroyed) {
+          return;
+        }
+        response.write(Buffer.from([1]));
+        producedBytes += 1;
+        const tailDeadline = setTimeout(() => {
+          producedPlannedTail = true;
+          response.end(chunk.subarray(0, 64 * 1024));
+        }, 3_000);
+        response.once("close", () => clearTimeout(tailDeadline));
+      },
+      async (origin, release) => {
+        const entry = buildEntry("oversized-http-download");
+        const toolsRoot = resolveSkillToolsRootDir(entry);
+        const result = await installDownloadSpec({
+          entry,
+          spec: {
+            kind: "download",
+            id: "dl",
+            url: `${origin}/oversized.bin`,
+            extract: false,
+            targetDir: "runtime",
+          },
+          timeoutMs: 30_000,
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.stderr).toContain("Skill download exceeds 268435456-byte limit");
+        await connectionClosed;
+        expect(producedBytes).toBe(maxBytes + 1);
+        expect(producedPlannedTail).toBe(false);
+        expect(release).toHaveBeenCalledOnce();
+        await expect(fileExists(path.join(toolsRoot, "runtime", "oversized.bin"))).resolves.toBe(
+          false,
+        );
+        await expect(
+          fs.readdir(path.join(toolsRoot, ".openclaw-download-staging")),
+        ).resolves.toEqual([]);
+      },
+    );
+  }, 45_000);
+
+  it("installs exact bytes from a chunked HTTP response and releases guarded resources", async () => {
+    const chunks = [Buffer.from("skill "), Buffer.from("artifact"), Buffer.from([0, 255])];
+
+    await withDownloadServer(
+      (response) => {
+        response.writeHead(200, { "content-type": "application/octet-stream" });
+        for (const chunk of chunks) {
+          response.write(chunk);
+        }
+        response.end();
+      },
+      async (origin, release) => {
+        const entry = buildEntry("successful-http-download");
+        const toolsRoot = resolveSkillToolsRootDir(entry);
+        const result = await installDownloadSpec({
+          entry,
+          spec: {
+            kind: "download",
+            id: "dl",
+            url: `${origin}/artifact.bin`,
+            extract: false,
+            targetDir: "runtime",
+          },
+          timeoutMs: 30_000,
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.stdout).toBe(`downloaded=${Buffer.concat(chunks).byteLength}`);
+        await expect(fs.readFile(path.join(toolsRoot, "runtime", "artifact.bin"))).resolves.toEqual(
+          Buffer.concat(chunks),
+        );
+        expect(release).toHaveBeenCalledOnce();
+        await expect(
+          fs.readdir(path.join(toolsRoot, ".openclaw-download-staging")),
+        ).resolves.toEqual([]);
+      },
+    );
+  });
+
   it("rejects targetDir escapes outside the per-skill tools root", async () => {
     const beforeFetchCalls = fetchWithSsrFGuardMock.mock.calls.length;
     const entry = buildEntry("relative-traversal");

--- a/src/skills/lifecycle/install-download.test.ts
+++ b/src/skills/lifecycle/install-download.test.ts
@@ -93,6 +93,7 @@ function mockArchiveResponse(buffer: Uint8Array): void {
       status: 200,
       statusText: "OK",
       body: Readable.from([Buffer.from(buffer)]),
+      headers: new Headers(),
     },
     release: async () => undefined,
   });
@@ -227,6 +228,99 @@ beforeEach(() => {
 });
 
 describe("installDownloadSpec extraction safety", () => {
+  it("rejects oversized advertised HTTP downloads before staging the response body", async () => {
+    let responseCompleted = false;
+    let resolveConnectionClosed: (() => void) | undefined;
+    const connectionClosed = new Promise<void>((resolve) => {
+      resolveConnectionClosed = resolve;
+    });
+
+    await withDownloadServer(
+      (response) => {
+        response.once("close", () => resolveConnectionClosed?.());
+        response.once("finish", () => {
+          responseCompleted = true;
+        });
+        response.writeHead(200, {
+          "content-length": "268435457",
+          "content-type": "application/octet-stream",
+        });
+        response.write(Buffer.from([1]));
+      },
+      async (origin, release) => {
+        const entry = buildEntry("oversized-advertised-http-download");
+        const toolsRoot = resolveSkillToolsRootDir(entry);
+        const result = await installDownloadSpec({
+          entry,
+          spec: {
+            kind: "download",
+            id: "dl",
+            url: `${origin}/oversized.bin`,
+            extract: false,
+            targetDir: "runtime",
+          },
+          timeoutMs: 1_000,
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.stderr).toBe(
+          "Skill download exceeds 268435456-byte limit (declared 268435457 bytes)",
+        );
+        await connectionClosed;
+        expect(responseCompleted).toBe(false);
+        expect(release).toHaveBeenCalledOnce();
+        await expect(fileExists(path.join(toolsRoot, "runtime", "oversized.bin"))).resolves.toBe(
+          false,
+        );
+        await expect(
+          fs.readdir(path.join(toolsRoot, ".openclaw-download-staging")),
+        ).resolves.toEqual([]);
+      },
+    );
+  }, 10_000);
+
+  it.each([
+    {
+      name: "encoded-response-length",
+      headers: new Headers({ "content-encoding": "gzip", "content-length": "268435457" }),
+    },
+    {
+      name: "malformed-response-length",
+      headers: new Headers({ "content-length": "1e9" }),
+    },
+  ])("streams a decoded response with an unusable declared length ($name)", async (testCase) => {
+    const body = Buffer.from("decoded skill artifact");
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(body, { status: 200, headers: testCase.headers }),
+      release,
+    });
+    const entry = buildEntry(testCase.name);
+    const toolsRoot = resolveSkillToolsRootDir(entry);
+
+    const result = await installDownloadSpec({
+      entry,
+      spec: {
+        kind: "download",
+        id: "dl",
+        url: "https://example.invalid/artifact.bin",
+        extract: false,
+        targetDir: "runtime",
+      },
+      timeoutMs: 30_000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.stdout).toBe(`downloaded=${body.byteLength}`);
+    await expect(fs.readFile(path.join(toolsRoot, "runtime", "artifact.bin"))).resolves.toEqual(
+      body,
+    );
+    expect(release).toHaveBeenCalledOnce();
+    await expect(fs.readdir(path.join(toolsRoot, ".openclaw-download-staging"))).resolves.toEqual(
+      [],
+    );
+  });
+
   it("aborts oversized chunked HTTP downloads and removes partial staging data", async () => {
     const maxBytes = 256 * 1024 * 1024;
     const chunk = Buffer.alloc(1024 * 1024);
@@ -433,6 +527,7 @@ describe("installDownloadSpec extraction safety", () => {
           ok: true,
           status: 200,
           statusText: "OK",
+          headers: new Headers(),
           body: Readable.from(
             (async function* () {
               yield Buffer.from("payload");

--- a/src/skills/lifecycle/install-download.ts
+++ b/src/skills/lifecycle/install-download.ts
@@ -2,7 +2,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { Readable } from "node:stream";
+import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
@@ -20,6 +20,9 @@ import { formatInstallFailureMessage } from "./install-output.js";
 import type { SkillInstallResult } from "./install-types.js";
 
 const extractModuleLoader = createLazyImportLoader(() => import("./install-extract.js"));
+// Skill downloads share ClawHub and marketplace's 256 MiB artifact ceiling;
+// changing this limit is a supported-artifact compatibility decision.
+const MAX_SKILL_DOWNLOAD_BYTES = 256 * 1024 * 1024;
 
 async function loadExtractModule() {
   return await extractModuleLoader.load();
@@ -112,7 +115,19 @@ async function downloadFile(params: {
     const readable = isNodeReadableStream(body)
       ? body
       : Readable.fromWeb(body as NodeReadableStream);
-    await pipeline(readable, file);
+    let downloadedBytes = 0;
+    const limitedBody = new Transform({
+      transform(chunk, encoding, callback) {
+        downloadedBytes +=
+          typeof chunk === "string" ? Buffer.byteLength(chunk, encoding) : chunk.byteLength;
+        if (downloadedBytes > MAX_SKILL_DOWNLOAD_BYTES) {
+          callback(new Error(`Skill download exceeds ${MAX_SKILL_DOWNLOAD_BYTES}-byte limit`));
+          return;
+        }
+        callback(null, chunk);
+      },
+    });
+    await pipeline(readable, limitedBody, file);
     const root = await fsRoot(params.rootDir);
     await root.copyIn(params.relativePath, tempPath);
     const stat = await fs.promises.stat(destPath);

--- a/src/skills/lifecycle/install-download.ts
+++ b/src/skills/lifecycle/install-download.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { isWindowsDrivePath } from "../../infra/archive-path.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -109,6 +110,20 @@ async function downloadFile(params: {
     if (!response.ok || !response.body) {
       await cancelIgnoredResponseBody(response);
       throw new Error(`Download failed (${response.status} ${response.statusText})`);
+    }
+    // Encoded Content-Length measures wire bytes, not the decoded stream we cap.
+    const contentEncoding = normalizeOptionalLowercaseString(
+      response.headers.get("content-encoding"),
+    );
+    const declaredBytes =
+      !contentEncoding || contentEncoding === "identity"
+        ? parseStrictNonNegativeInteger(response.headers.get("content-length"))
+        : undefined;
+    if (declaredBytes !== undefined && declaredBytes > MAX_SKILL_DOWNLOAD_BYTES) {
+      await cancelIgnoredResponseBody(response);
+      throw new Error(
+        `Skill download exceeds ${MAX_SKILL_DOWNLOAD_BYTES}-byte limit (declared ${declaredBytes} bytes)`,
+      );
     }
     const file = fs.createWriteStream(tempPath);
     const body = response.body as unknown;


### PR DESCRIPTION
Closes #81817

Supersedes #81818 while preserving @afurm and @vincentkoc contributor credit.

AI-assisted.

## What Problem This Solves

Fixes an issue where users installing skills with `metadata.openclaw.install` download specs could exhaust available disk space when an endpoint returned a successful HTTP response with a missing or inaccurate content length. The response body could stream without a bound into `.openclaw-download-staging` before the dependency was copied or extracted.

## Why This Change Was Made

Apply one fixed 256 MiB response-body policy at the skill download lifecycle owner, matching the existing ClawHub, marketplace, skill-upload, and archive ceilings. Current tracked downloads are 19.18–110.19 MiB, and inspected compatible VITS artifacts top out at 159.27 MiB. Encoding-aware advertised-size rejection cancels trustworthy oversized identity `Content-Length` responses before opening the staging writer; encoded or malformed declarations fall through to authoritative actual decoded stream counting. A byte-counting Transform sits before the staging writer, permits exactly the ceiling, and lets the pipeline abort upstream; the existing finally cleanup/release and atomic copy remain unchanged. SHA-256 verification is a separate concern and is not part of this PR.

## User Impact

Oversized trustworthy identity declarations are rejected before staging, while missing, lying, malformed, or encoded responses remain bounded during streaming. Oversized direct skill dependency downloads fail with a visible size-limit error, publish no artifact, and remove partial staging data. Supported bundled Sherpa downloads continue working.

## Evidence

- Pre-fix real chunked/no-`Content-Length` server crossed 256 MiB and returned success; the regression failed with `expected true to be false`.
- Pre-fix advertised-size real HTTP case returned `request timed out` instead of the expected advertised-size failure.
- Post-fix owner suite: 14/14 passed; the oversized real chunked/no-`Content-Length` HTTP case closes before its planned tail, releases once, publishes no artifact, and leaves staging empty; the focused case passed 3/3 repeated runs.
- Post-fix advertised-size real HTTP case immediately cancels the response, closes the connection, publishes no artifact, and leaves staging empty; the advertised case passed 3/3 repeated runs.
- Accepted ClawSweeper finding addressed: trustworthy oversized identity `Content-Length` declarations are rejected before staging, while encoded or malformed declarations rely on the authoritative decoded streaming cap.
- Live public HTTPS install of bundled `vits-piper-en_US-lessac-high.tar.bz2`: the 115,545,841-byte archive downloaded and extracted successfully in isolated state (57s).
- Changed gate passed for all three files; docs MDX, formatting, and `git diff --check` passed.
- Fresh autoreview: no accepted/actionable findings.
- LOC: production +32/-2 (net +30), tests +270, docs +3/-1 (net +2).
- Remaining gap: cross-platform behavior relies on exact-head CI for the new head, pending; no local Windows run.
