### PR TITLE
refactor(link-understanding): reuse media scope resolver

### DIFF
--- a/src/link-understanding/runner.test.ts
+++ b/src/link-understanding/runner.test.ts
@@ -72,6 +72,39 @@ describe("runLinkUnderstanding", () => {
     mocks.runCommandWithTimeout.mockReset();
   });
 
+  it("applies shared media scope rules to link message context", async () => {
+    const result = await runLinkUnderstanding({
+      cfg: {
+        tools: {
+          links: {
+            enabled: true,
+            scope: {
+              default: "allow",
+              rules: [
+                {
+                  action: "deny",
+                  match: { channel: "slack", chatType: "channel", keyPrefix: "agent:main:" },
+                },
+              ],
+            },
+            models: [{ type: "cli", command: "summarize" }],
+          },
+        },
+      } as OpenClawConfig,
+      ctx: {
+        Body: "see https://example.com/page",
+        ChatType: "channel",
+        Provider: "discord",
+        SessionKey: "agent:main:slack:channel:C123",
+        Surface: "slack",
+      } as MsgContext,
+    });
+
+    expect(result).toEqual({ urls: [], outputs: [] });
+    expect(fetchWithSsrFGuard).not.toHaveBeenCalled();
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
+  });
+
   it("fetches links through the SSRF guard before passing content to CLI stdin", async () => {
     const release = mockGuardedFetch("page body", "https://example.com/final");
     mockCommand("summarized page");

--- a/src/link-understanding/runner.ts
+++ b/src/link-understanding/runner.ts
@@ -7,11 +7,7 @@ import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { cancelUnreadResponseBody, readResponseWithLimit } from "../infra/http-body.js";
 import { fetchWithSsrFGuard, GUARDED_FETCH_MODE } from "../infra/net/fetch-guard.js";
 import { CLI_OUTPUT_MAX_BUFFER } from "../media-understanding/defaults.js";
-import { resolveTimeoutMs } from "../media-understanding/resolve.js";
-import {
-  normalizeMediaUnderstandingChatType,
-  resolveMediaUnderstandingScope,
-} from "../media-understanding/scope.js";
+import { resolveScopeDecision, resolveTimeoutMs } from "../media-understanding/resolve.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { DEFAULT_LINK_TIMEOUT_SECONDS } from "./defaults.js";
 import { extractLinksFromMessage } from "./detect.js";
@@ -20,18 +16,6 @@ type LinkUnderstandingResult = {
   urls: string[];
   outputs: string[];
 };
-
-function resolveScopeDecision(params: {
-  config?: LinkToolsConfig;
-  ctx: MsgContext;
-}): "allow" | "deny" {
-  return resolveMediaUnderstandingScope({
-    scope: params.config?.scope,
-    sessionKey: params.ctx.SessionKey,
-    channel: params.ctx.Surface ?? params.ctx.Provider,
-    chatType: normalizeMediaUnderstandingChatType(params.ctx.ChatType),
-  });
-}
 
 function resolveTimeoutMsFromConfig(params: {
   config?: LinkToolsConfig;
@@ -217,7 +201,7 @@ export async function runLinkUnderstanding(params: {
     return { urls: [], outputs: [] };
   }
 
-  const scopeDecision = resolveScopeDecision({ config, ctx: params.ctx });
+  const scopeDecision = resolveScopeDecision({ scope: config.scope, ctx: params.ctx });
   if (scopeDecision === "deny") {
     if (shouldLogVerbose()) {
       logVerbose("Link understanding disabled by scope policy.");


### PR DESCRIPTION
## What Problem This Solves

Link understanding carried a second private implementation of the message-context-to-scope mapping already owned by media understanding. Both surfaces use the same `MediaUnderstandingScopeConfig`, so keeping two copies created an unnecessary drift point for channel, chat type, and session-key policy.

## Why This Change Was Made

This removes the link-local adapter and calls the canonical media `resolveScopeDecision` helper directly. The existing `Surface ?? Provider`, chat-type normalization, session-key mapping, default decision, network guard, provider execution, and configuration contracts are unchanged. A link-runner boundary test now covers a matching channel/chat/session denial before fetch or command execution.

Alternatives rejected: retaining the duplicate leaves two policy owners; adding another shared wrapper would increase surface without removing a path. No open PR was touching either changed file when this lane started.

## User Impact

No user-visible behavior change. Link and media understanding continue applying the same configured scope policy, now through one canonical implementation.

## Evidence

- Exact reviewed head: `2a1da186202f5f9d7182cd4a7d775c480960a1ce`
- Production LOC: +2/−18 (net −16); tests: +33/−0
- `node scripts/run-vitest.mjs src/link-understanding/runner.test.ts src/link-understanding/runner.transport.test.ts src/media-understanding/media-understanding-misc.test.ts` — 31/31 passed
- `node scripts/check-changed.mjs -- src/link-understanding/runner.ts src/link-understanding/runner.test.ts` — passed format, Knip, core/core-test type checks, lint, and repository guards
- Deslop pass — clean, no edits
- Structured autoreview — clean, no accepted/actionable findings
- Separate read-only Codex exact-head review — no actionable findings; approved the exact head
- Direct Codex ownership check: `codex-rs/protocol/src/user_input.rs:15-43`, `codex-rs/protocol/src/models.rs:1923-1984`, and `codex-rs/core/src/session/turn.rs:694-708` confirm Codex owns downstream text/media input conversion, not OpenClaw link scope resolution

AI-assisted change; implementation and proof were reviewed against the complete owner path.
