### PR TITLE
chore: test trigger thresholds at the selection boundary

### DIFF
--- a/extensions/active-memory/trigger-recall.test.ts
+++ b/extensions/active-memory/trigger-recall.test.ts
@@ -7,7 +7,6 @@ import {
   scoreTriggerMatch,
   resolveTriggerRecall,
   selectStrongTriggerMatches,
-  STRONG_TRIGGER_MATCH_SCORE,
 } from "./trigger-recall.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -51,12 +50,9 @@ describe("active-memory trigger recall", () => {
     ).toBeLessThan(0.65);
     // Single-word concept triggers (the promotion writer's output) cap at
     // 0.85 * 0.8 = 0.68 with zero relevance; the 0.65 threshold must admit them.
-    expect(
-      scoreTriggerMatch("Project status", result({ score: 0, triggers: "project" })),
-    ).toBeCloseTo(0.68);
-    expect(
-      scoreTriggerMatch("Project status", result({ score: 0, triggers: "project" })),
-    ).toBeGreaterThanOrEqual(STRONG_TRIGGER_MATCH_SCORE);
+    const singleWordTrigger = result({ score: 0, triggers: "project" });
+    expect(scoreTriggerMatch("Project status", singleWordTrigger)).toBeCloseTo(0.68);
+    expect(selectStrongTriggerMatches("Project status", [singleWordTrigger])).toHaveLength(1);
   });
 
   it("limits automatic injection to curated or trusted-origin entries", () => {

--- a/extensions/active-memory/trigger-recall.ts
+++ b/extensions/active-memory/trigger-recall.ts
@@ -277,4 +277,4 @@ function waitForTriggerLookup<T>(work: Promise<T>, signal?: AbortSignal): Promis
   });
 }
 
-export { MAX_TRIGGER_CONTEXT_CHARS, STRONG_TRIGGER_MATCH_SCORE };
+export { MAX_TRIGGER_CONTEXT_CHARS };


### PR DESCRIPTION
## What Problem This Solves

The active-memory trigger recall test evaluated the same edge-case score twice and exported the private admission threshold solely so the test could compare the two implementation values.

## Why This Change Was Made

The test now proves the scoring formula once and verifies the meaningful contract at `selectStrongTriggerMatches`: a zero-relevance, single-word promoted trigger is admitted. The internal threshold remains private.

## User Impact

No user-visible behavior changes. The test is less implementation-coupled while retaining the regression guard that prevents promoted single-word triggers from being silently excluded.

Production LOC: +1/-1 (net 0; removes one test-only export binding) | Tests: +3/-7

## Evidence

- Baseline: `node scripts/run-vitest.mjs extensions/active-memory/trigger-recall.test.ts` — 19/19 passed.
- Post-change: same command — 19/19 passed.
- `node scripts/check-changed.mjs -- extensions/active-memory/trigger-recall.ts extensions/active-memory/trigger-recall.test.ts` — passed extension production/test typechecks, lint, formatting, dead-export scan, plugin boundaries, import cycles, and changed-file guards.
- `git diff --check` — passed.
- Fresh autoreview — clean, no accepted/actionable findings.
