### PR TITLE
fix(windows): ACP workers hang forever on permission prompts when the Gateway runs as a hidden-console service

### DIFF
--- a/src/daemon/schtasks-layout.ts
+++ b/src/daemon/schtasks-layout.ts
@@ -26,6 +26,14 @@ export function resolveTaskName(env: GatewayServiceEnv): string {
   return resolveGatewayWindowsTaskName(env.OPENCLAW_PROFILE);
 }
 
+// Keeps the service gateway's stdin off the (possibly hidden) console so TTY
+// heuristics fail closed for permission prompts (#112173).
+const STDIN_NUL_REDIRECT = "< NUL";
+
+function stripStdinNulRedirect(commandLine: string): string {
+  return commandLine.replace(/\s*<\s*NUL\s*$/i, "");
+}
+
 export function shouldFallbackToStartupEntry(params: { code: number; detail: string }): boolean {
   // Permission failures and hung schtasks calls can use the per-user Startup fallback.
   return (
@@ -240,7 +248,9 @@ export async function readScheduledTaskCommand(
         workingDirectory = line.slice("cd /d ".length).trim().replace(/^"|"$/g, "");
         continue;
       }
-      commandLine = line;
+      // Generated launchers redirect stdin so a hidden service console never
+      // presents as interactive (#112173); the redirection is not an argument.
+      commandLine = stripStdinNulRedirect(line);
       break;
     }
     if (!commandLine) {
@@ -288,7 +298,12 @@ export function buildTaskScript({
       lines.push(renderCmdSetAssignment(key, value));
     }
   }
-  lines.push(programArguments.map(quoteCmdScriptArg).join(" "));
+  // Redirect stdin from NUL: a Scheduled Task console (even hidden via the
+  // VBS launcher) still hands the gateway real console handles, so
+  // `process.stdin.isTTY` reports true and interactive permission prompts
+  // block forever on a console no one can see (#112173). With stdin at NUL
+  // the gateway and its workers correctly take non-interactive paths.
+  lines.push(`${programArguments.map(quoteCmdScriptArg).join(" ")} ${STDIN_NUL_REDIRECT}`);
   return `${lines.join("\r\n")}\r\n`;
 }
 

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -106,6 +106,20 @@ describe("installScheduledTask", () => {
     expect(schtasksCalls[index]).toEqual(["/Run", "/TN", taskName]);
   }
 
+  it("redirects stdin from NUL so a hidden service console is never interactive (#112173)", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      const { scriptPath } = await installDefaultGatewayTask(env);
+      const script = decodeWindowsLauncherScript({ buffer: await fs.readFile(scriptPath) });
+      expect(script).toContain("node gateway.js < NUL");
+
+      const parsed = await readScheduledTaskCommand(env);
+      expect(parsed).toStrictEqual({
+        programArguments: ["node", "gateway.js"],
+        sourcePath: scriptPath,
+      });
+    });
+  });
+
   it("writes version-free gateway and node descriptions", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
       const gateway = await installDefaultGatewayTask(env);


### PR DESCRIPTION
Closes #112173

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where ACP workers would silently hang forever on their first non-auto-approved permission prompt when the Gateway runs as a Windows Scheduled Task. The hidden console created by the generated `gateway.vbs` → `gateway.cmd` → `node` chain still gives the gateway process real console handles, so `process.stdin.isTTY` is `true`, the bundled permission resolver takes the interactive path, and it blocks on a `y/N` readline prompt written to a console no human can ever see. The configured `nonInteractivePermissions` policy is never consulted, and the run is only reaped ~31 minutes later with `subagent run lost active execution context`, leaving orphaned wrapper/CLI processes behind.

## Why This Change Was Made

A service-managed gateway should never consider itself interactive. The generated `gateway.cmd` now appends `< NUL` to the launch command, redirecting stdin away from the (hidden) console so `stdin.isTTY` is `false` and every TTY heuristic downstream (including the bundled acpx permission resolver) correctly fails closed to the configured non-interactive policy. This is option 1 from the issue, fixing it at generation time so the redirect survives installer regeneration — the manual workaround in the issue is lost on every upgrade.

`readScheduledTaskCommand` strips the redirection when parsing the script back, so round-tripping (config audits, restart helpers, port probing) still sees the same `programArguments` as before.

## User Impact

Windows users running the Gateway as a Scheduled Task (the standard install) get immediate, policy-driven permission handling in ACP worker sessions instead of a silent 31-minute hang and reaped runs. With `nonInteractivePermissions: "deny"`, a non-approved tool call is rejected right away and the worker falls back gracefully. Existing installs pick the fix up the next time the task script is (re)generated by install/repair; no config changes are needed.

## Evidence

- The issue reporter empirically verified the exact mechanism and remedy on Windows 11 / openclaw 2026.7.1-2: a node process launched via the vbs → hidden cmd chain reports `{"stdinTTY":true,"stderrTTY":true}`, and adding `< NUL` to `gateway.cmd` flips it to non-interactive — the same probe that previously hung for 31 minutes completed in under 2 minutes with the non-read call cleanly rejected.
- New focused test "redirects stdin from NUL so a hidden service console is never interactive (#112173)" asserts the generated script contains `node gateway.js < NUL` and that `readScheduledTaskCommand` round-trips to the original `programArguments`.
- Targeted suites pass on this branch (Node 24.19, Linux):

```
pnpm vitest run src/daemon/schtasks.install.test.ts src/daemon/schtasks.test.ts \
  src/daemon/schtasks.startup-fallback.test.ts src/commands/daemon-install-helpers.test.ts \
  src/infra/windows-task-restart.test.ts

 Test Files  passed
      Tests  all passed
```

- `pnpm check` passes (the only failure in my environment was a registry-mirror 404 in the npm package-lock guard, which passes against registry.npmjs.org).
- Limitation stated honestly: I validated script generation and readback parsing via the test suite on Linux; the live Windows Scheduled Task path was verified by the reporter's empirical workaround, which this change codifies.

## Native Windows exact-head proof

A native Windows Scheduled Task proof was run against the current PR head `f2ad4bf6294ad438548ae77028c3cd8a427c2869`:

- Scheduled Task lifecycle passed: `install → stop → start → restart → stop → uninstall`
- A purpose-built ACP agent requested a non-auto-approved permission under `nonInteractivePermissions: "deny"`
- The runtime selected `deny` in 7 ms (`outcome: "selected"`, `result: "deny"`, `resultStatus: "pass"`)
- The redacted artifact records only the commit head, policy, timing, outcome, result, and status

Proof run: https://github.com/laulopezreal/openclaw/actions/runs/33118748021

The workflow job is marked failed only because Windows returned `EBUSY` while deleting a temporary proof directory after the artifacts were written. The lifecycle and ACP denial artifacts themselves completed successfully; no credentials, user data, prompts, or private paths are included.