### PR TITLE
fix: keep session catalog mirroring within isolated profiles

### DIFF
--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -55,6 +55,7 @@ function fakeCatalog(params: {
   hostKind?: string;
   onList?: () => unknown;
   onRead?: (threadId: string) => unknown;
+  processHomeFallbackAllowed?: boolean;
 }): ActiveSessionCatalog {
   const host: SessionCatalogHost = {
     hostId: "gateway:local",
@@ -77,6 +78,7 @@ function fakeCatalog(params: {
     pluginId: params.id,
     id: params.id,
     label: params.id,
+    processHomeFallbackAllowed: params.processHomeFallbackAllowed ?? true,
     list: async () => {
       await params.onList?.();
       return [host];
@@ -813,6 +815,28 @@ describe("createBeamMirrorRunner", () => {
     });
     await runner.tick();
     expect(sent).toHaveLength(0);
+  });
+
+  it("warns once when profile isolation disables process-HOME fallback", async () => {
+    const warnings: string[] = [];
+    const catalog = fakeCatalog({
+      id: "claude",
+      sessions: [],
+      processHomeFallbackAllowed: false,
+    });
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig({ catalogs: ["claude"] })),
+      logger: { warn: (message) => warnings.push(message), info: () => {} },
+      now: () => NOW,
+      listCatalogs: () => [catalog],
+    });
+
+    await runner.tick();
+    await runner.tick();
+
+    expect(warnings).toEqual([
+      "beam mirror process-HOME fallback disabled: isolated state; only explicit catalog roots can be mirrored",
+    ]);
   });
 
   it("sends one completed upload when a session leaves the active window", async () => {

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -281,6 +281,7 @@ export function createBeamMirrorRunner(params: {
   const controller = new AbortController();
   const { signal } = controller;
   let lastWarnAt = 0;
+  let warnedProcessHomeIsolation = false;
   let redirectBlockedEndpoint: string | undefined;
   let activeTick: Promise<void> | undefined;
   let stopPromise: Promise<void> | undefined;
@@ -458,6 +459,15 @@ export function createBeamMirrorRunner(params: {
           // would otherwise re-mirror each other's rows forever.
           catalog.id !== "beam" && mirror.catalogs.includes(catalog.id),
       );
+      if (
+        !warnedProcessHomeIsolation &&
+        catalogs.some((catalog) => !catalog.processHomeFallbackAllowed)
+      ) {
+        warnedProcessHomeIsolation = true;
+        params.logger.warn(
+          "beam mirror process-HOME fallback disabled: isolated state; only explicit catalog roots can be mirrored",
+        );
+      }
       const catalogById = new Map(catalogs.map((catalog) => [catalog.id, catalog]));
       const candidates: BeamMirrorCandidate[] = [];
       for (const catalog of catalogs) {

--- a/src/gateway/server-methods/session-catalog.home-isolation.test.ts
+++ b/src/gateway/server-methods/session-catalog.home-isolation.test.ts
@@ -144,6 +144,7 @@ describe("session catalog Gateway HOME isolation", () => {
 
     await withProfile(undefined, async () => {
       const [catalog] = listActiveSessionCatalogs();
+      expect(catalog?.processHomeFallbackAllowed).toBe(true);
       await expect(catalog?.list({})).resolves.toEqual([localHost]);
       await expect(
         catalog?.read({ hostId: "gateway:local", threadId: "known-thread" }),
@@ -151,6 +152,7 @@ describe("session catalog Gateway HOME isolation", () => {
     });
     await withProfile("dev", async () => {
       const [catalog] = listActiveSessionCatalogs();
+      expect(catalog?.processHomeFallbackAllowed).toBe(false);
       await expect(catalog?.list({})).resolves.toEqual([]);
       await expect(
         catalog?.read({ hostId: "gateway:local", threadId: "known-thread" }),

--- a/src/gateway/server-methods/session-catalog.home-isolation.test.ts
+++ b/src/gateway/server-methods/session-catalog.home-isolation.test.ts
@@ -17,6 +17,7 @@ const hoisted = vi.hoisted(() => ({
 
 vi.mock("../../plugins/runtime.js", () => ({
   getActivePluginRegistry: () => hoisted.activeRegistry,
+  getActivePluginSessionExtensionRegistry: () => hoisted.activeRegistry,
   requireActivePluginRegistry: () => hoisted.activeRegistry,
 }));
 vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => ({
@@ -25,6 +26,7 @@ vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => (
 }));
 
 const { sessionCatalogHandlers } = await import("./session-catalog.js");
+const { listActiveSessionCatalogs } = await import("../../plugins/session-catalog-active.js");
 
 function provider(
   id: string,
@@ -119,6 +121,50 @@ describe("session catalog Gateway HOME isolation", () => {
       "external session catalog HOME fallback skipped: isolated state; configure an explicit root to enable",
       { reason: "isolated_state" },
     );
+  });
+
+  it("binds HOME isolation into the internal read-only catalog facade", async () => {
+    const localHost = {
+      hostId: "gateway:local",
+      label: "Local",
+      kind: "gateway" as const,
+      connected: true,
+      sessions: [],
+    };
+    const list = vi.fn(async (request: { allowProcessHomeFallback?: boolean }) =>
+      request.allowProcessHomeFallback === false ? [] : [localHost],
+    );
+    const read = vi.fn(async (request: Parameters<SessionCatalogProvider["read"]>[0]) => {
+      if (request.allowProcessHomeFallback === false) {
+        throw new Error("local Test sessions are unavailable in isolated state");
+      }
+      return { hostId: request.hostId, threadId: request.threadId, items: [] };
+    });
+    hoisted.activeRegistry.sessionCatalogs = [{ provider: provider("test", { list, read }) }];
+
+    await withProfile(undefined, async () => {
+      const [catalog] = listActiveSessionCatalogs();
+      await expect(catalog?.list({})).resolves.toEqual([localHost]);
+      await expect(
+        catalog?.read({ hostId: "gateway:local", threadId: "known-thread" }),
+      ).resolves.toMatchObject({ threadId: "known-thread" });
+    });
+    await withProfile("dev", async () => {
+      const [catalog] = listActiveSessionCatalogs();
+      await expect(catalog?.list({})).resolves.toEqual([]);
+      await expect(
+        catalog?.read({ hostId: "gateway:local", threadId: "known-thread" }),
+      ).rejects.toThrow("local Test sessions are unavailable in isolated state");
+    });
+
+    expect(list.mock.calls.map(([request]) => request.allowProcessHomeFallback)).toEqual([
+      true,
+      false,
+    ]);
+    expect(read.mock.calls.map(([request]) => request.allowProcessHomeFallback)).toEqual([
+      true,
+      false,
+    ]);
   });
 
   it.each([

--- a/src/plugins/session-catalog-active.ts
+++ b/src/plugins/session-catalog-active.ts
@@ -1,3 +1,4 @@
+import { allowsProcessHomeSessionScan } from "../config/paths.js";
 import { getActivePluginSessionExtensionRegistry } from "./runtime.js";
 import type { SessionCatalogProvider } from "./session-catalog.js";
 
@@ -16,13 +17,16 @@ export type ActiveSessionCatalog = {
  */
 export function listActiveSessionCatalogs(): ActiveSessionCatalog[] {
   const registrations = getActivePluginSessionExtensionRegistry()?.sessionCatalogs ?? [];
+  const allowProcessHomeFallback = allowsProcessHomeSessionScan();
   return registrations
     .map(({ pluginId, provider }) => ({
       pluginId,
       id: provider.id,
       label: provider.label,
-      list: provider.list.bind(provider),
-      read: provider.read.bind(provider),
+      list: (params: Parameters<SessionCatalogProvider["list"]>[0]) =>
+        provider.list({ ...params, allowProcessHomeFallback }),
+      read: (params: Parameters<SessionCatalogProvider["read"]>[0]) =>
+        provider.read({ ...params, allowProcessHomeFallback }),
     }))
     .toSorted((left, right) => left.id.localeCompare(right.id));
 }

--- a/src/plugins/session-catalog-active.ts
+++ b/src/plugins/session-catalog-active.ts
@@ -6,6 +6,7 @@ export type ActiveSessionCatalog = {
   pluginId: string;
   id: string;
   label: string;
+  processHomeFallbackAllowed: boolean;
   list: SessionCatalogProvider["list"];
   read: SessionCatalogProvider["read"];
 };
@@ -23,6 +24,7 @@ export function listActiveSessionCatalogs(): ActiveSessionCatalog[] {
       pluginId,
       id: provider.id,
       label: provider.label,
+      processHomeFallbackAllowed: allowProcessHomeFallback,
       list: (params: Parameters<SessionCatalogProvider["list"]>[0]) =>
         provider.list({ ...params, allowProcessHomeFallback }),
       read: (params: Parameters<SessionCatalogProvider["read"]>[0]) =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running a named or relocated state profile could still have process-user HOME session catalog entries selected by an internal background consumer, despite the profile's catalog isolation policy.

## Why This Change Was Made

The existing process-HOME decision is now bound at the shared read-only active-catalog facade. This keeps every internal list/read consumer on the same policy as Gateway RPC, terminal, and upstream-monitor paths without adding consumer-specific enforcement or changing the provider contract.

The private facade also carries the evaluated policy fact so Beam can report once when process-HOME fallback is unavailable. The warning explains that isolated profiles can mirror only explicitly configured catalog roots, avoiding a silent configured no-op.

## User Impact

Session catalog mirroring and future read-only catalog consumers now stay within the selected profile's isolation boundary. Default-profile behavior and explicitly configured catalog homes remain available. Operators whose mirror configuration depends on process-HOME discovery receive an actionable warning.

## Evidence

Production-path terminal probe using the real active-catalog facade and the registered provider call boundary:

Before the fix, an isolated profile forwarded no decision:

```text
[["list",null],["read",null]]
Error: isolated active-catalog facade omitted allowProcessHomeFallback=false
```

At this head, both the allowed default path and isolated named-profile path reach the provider with the expected decision:

```text
[["default","list",true],["default","read",true],["dev","list",false],["dev","read",false]]
```

The configured Beam runner reports the isolated outcome once:

```text
beam mirror process-HOME fallback disabled: isolated state; only explicit catalog roots can be mirrored
```

Focused and sibling validation:

```text
pnpm test src/gateway/server-methods/session-catalog.home-isolation.test.ts extensions/beam/src/mirror.test.ts
2 files, 37 tests passed

pnpm test extensions/anthropic/session-catalog.test.ts extensions/codex/src/session-catalog-archive.test.ts extensions/opencode/session-catalog.test.ts extensions/acpx/src/pi-session-catalog.test.ts
4 files, 114 tests passed

pnpm check:changed
passed

autoreview --mode local
clean; no accepted or actionable findings
```

The hosted review's silent-suppression finding is addressed by the lifecycle-scoped Beam diagnostic and focused regression coverage.

Scope: four files; production +18/-2 (net +16), tests +72/-0. The production growth carries one canonical policy fact across the private runtime seam and provides the required operator-visible outcome. No config, protocol, public API, or default change.
