### PR TITLE
fix(openshell): sandbox cleanup, workspace sync, and gateway setup failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **OpenShell sandbox reliability:** preserve failed or unavailable sandbox runtimes for recovery, report actual readiness, securely synchronize nested workspaces without Git metadata, validate remote roots, and document verified gateway, policy, and lifecycle setup.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **OpenShell sandbox reliability:** preserve failed or unavailable sandbox runtimes for recovery, report actual readiness, securely synchronize nested workspaces without Git metadata, validate remote roots, and document verified gateway, policy, and lifecycle setup.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -832,7 +832,7 @@ Defaults shown above (`off`/`docker`/`agent`/`none`/`bookworm-slim` image/`none`
 
 - `docker`: local Docker runtime (default)
 - `ssh`: generic SSH-backed remote runtime
-- `openshell`: OpenShell runtime
+- `openshell`: OpenShell-managed local or remote runtime
 
 When `backend: "openshell"` is selected, runtime-specific settings move to
 `plugins.entries.openshell.config`.
@@ -889,8 +889,10 @@ When `backend: "openshell"` is selected, runtime-specific settings move to
           remoteAgentWorkspaceDir: "/agent",
           gateway: "lab", // optional
           gatewayEndpoint: "https://lab.example", // optional
-          policy: "strict", // optional OpenShell policy id
+          workspace: "research", // optional existing OpenShell workspace
+          policy: "/etc/openclaw/openshell-policy.yaml", // optional host-side YAML file
           providers: ["openai"], // optional
+          gpu: false,
           autoProviders: true,
           timeoutSeconds: 120,
         },
@@ -907,6 +909,7 @@ When `backend: "openshell"` is selected, runtime-specific settings move to
 
 In `remote` mode, host-local edits made outside OpenClaw are not synced into the sandbox automatically after the seed step.
 Transport is SSH into the OpenShell sandbox, but the plugin owns sandbox lifecycle and optional mirror sync.
+`workspace` selects an existing OpenShell control-plane workspace for the whole plugin; it is separate from the agent's filesystem workspace. `policy` must point to a YAML file readable by the OpenClaw Gateway, not a named policy ID. See [OpenShell](/gateway/openshell) for setup, prerequisites, and troubleshooting.
 
 **`setupCommand`** runs once after container creation (via `sh -lc`). Needs network egress, writable root, root user.
 

--- a/docs/gateway/openshell.md
+++ b/docs/gateway/openshell.md
@@ -185,8 +185,9 @@ All OpenShell config lives under `plugins.entries.openshell.config`:
 
 `remoteWorkspaceDir` and `remoteAgentWorkspaceDir` must be absolute paths and
 stay under the managed roots `/sandbox` or `/agent`; other absolute paths are
-rejected. The two directories must not be identical or nested inside each
-other because OpenClaw manages their contents independently.
+rejected. Choose distinct, non-overlapping directories because OpenClaw manages
+their contents independently; previously configured overlapping roots remain
+accepted for upgrade compatibility.
 
 `timeoutSeconds` applies to ordinary OpenShell CLI operations. Sandbox creation
 always receives at least 300 seconds so image builds and first-time provisioning

--- a/docs/gateway/openshell.md
+++ b/docs/gateway/openshell.md
@@ -2,14 +2,16 @@
 summary: "Use OpenShell as a managed sandbox backend for OpenClaw agents"
 title: OpenShell
 read_when:
-  - You want cloud-managed sandboxes instead of local Docker
+  - You want OpenShell-managed local or remote sandboxes
   - You are setting up the OpenShell plugin
   - You need to choose between mirror and remote workspace modes
 ---
 
-OpenShell is a managed sandbox backend: instead of running Docker containers
-locally, OpenClaw delegates sandbox lifecycle to the `openshell` CLI, which
-provisions remote environments and executes commands over SSH.
+OpenShell is a managed sandbox backend: OpenClaw delegates sandbox lifecycle to
+the `openshell` CLI and executes commands over SSH. The selected OpenShell
+gateway can manage sandboxes locally with Docker, Podman, or virtualization, or
+run them on separate infrastructure. This OpenShell gateway is distinct from the
+OpenClaw Gateway, which continues to run the agent and host-side plugins.
 
 The plugin reuses the same SSH transport and remote filesystem bridge as the
 generic [SSH backend](/gateway/sandboxing#ssh-backend), and adds OpenShell
@@ -18,13 +20,39 @@ workspace sync mode.
 
 ## Prerequisites
 
-- OpenShell plugin installed (`openclaw plugins install @openclaw/openshell-sandbox`)
-- `openshell` CLI on `PATH` (or a custom path via
+- `openshell` CLI installed and on the OpenClaw Gateway process's `PATH` (or a
+  custom absolute path via
   `plugins.entries.openshell.config.command`)
 - OpenSSH client available on the Gateway host
 - OpenShell `v0.0.88` or newer when configuring an OpenShell workspace
-- An OpenShell account with sandbox access
+- An active, reachable OpenShell gateway with permission to create sandboxes;
+  local gateways do not require a cloud account
+- A supported compute runtime on the OpenShell gateway host when using local
+  sandboxes
 - OpenClaw Gateway running on the host
+
+Install the CLI and configure an OpenShell gateway using the
+[NVIDIA OpenShell documentation](https://docs.nvidia.com/openshell/latest).
+Before configuring OpenClaw, verify the OpenShell CLI as the same operating
+system user that runs the OpenClaw Gateway:
+
+```bash
+openshell --version
+openshell gateway list
+openshell sandbox list
+```
+
+`gateway list` marks the active gateway with `*`. If no gateway is selected,
+run `openshell gateway select <gateway-name>`. To register an existing local
+gateway endpoint, run `openshell gateway add http://127.0.0.1:8080 --local`;
+replace the endpoint with the address of your running gateway. For an
+authenticated remote gateway, follow its login flow with
+`openshell gateway login <gateway-name>`.
+
+The OpenClaw Gateway service must see the same OpenShell CLI, gateway
+registration, credentials, and workspace selection as these preflight commands.
+A shell-only `PATH` or `OPENSHELL_WORKSPACE` setting does not automatically
+reach a background service.
 
 ## Quick start
 
@@ -58,13 +86,25 @@ openclaw plugins install @openclaw/openshell-sandbox
 }
 ```
 
-Restart the Gateway. On the next agent turn OpenClaw creates an OpenShell
-sandbox and routes tool execution through it. Verify with:
+Validate the configuration and restart the OpenClaw Gateway:
 
 ```bash
+openclaw config validate
+openclaw gateway restart
+```
+
+On the next agent turn OpenClaw creates an OpenShell sandbox and routes tool
+execution through it. Verify both the plugin and the effective sandbox:
+
+```bash
+openclaw plugins inspect openshell --runtime --json
 openclaw sandbox list
 openclaw sandbox explain
+openshell sandbox list
 ```
+
+`openclaw sandbox list` is empty until a sandboxed agent turn first needs a
+runtime.
 
 ## Workspace modes
 
@@ -135,7 +175,7 @@ All OpenShell config lives under `plugins.entries.openshell.config`:
 | `gateway`                 | `string`                 | unset         | OpenShell gateway name (top-level `--gateway`)                                         |
 | `gatewayEndpoint`         | `string`                 | unset         | OpenShell gateway endpoint (top-level `--gateway-endpoint`)                            |
 | `workspace`               | `string`                 | unset         | Existing OpenShell control-plane workspace used for every CLI operation                |
-| `policy`                  | `string`                 | unset         | OpenShell policy ID for sandbox creation                                               |
+| `policy`                  | `string`                 | unset         | Path to a sandbox policy YAML file on the OpenClaw Gateway host                        |
 | `providers`               | `string[]`               | `[]`          | Provider names attached at sandbox creation (deduped, one `--provider` flag per entry) |
 | `gpu`                     | `boolean`                | `false`       | Request GPU resources (`--gpu`)                                                        |
 | `autoProviders`           | `boolean`                | `true`        | Pass `--auto-providers` (or `--no-auto-providers` when false) during create            |
@@ -145,7 +185,25 @@ All OpenShell config lives under `plugins.entries.openshell.config`:
 
 `remoteWorkspaceDir` and `remoteAgentWorkspaceDir` must be absolute paths and
 stay under the managed roots `/sandbox` or `/agent`; other absolute paths are
-rejected.
+rejected. The two directories must not be identical or nested inside each
+other because OpenClaw manages their contents independently.
+
+`timeoutSeconds` applies to ordinary OpenShell CLI operations. Sandbox creation
+always receives at least 300 seconds so image builds and first-time provisioning
+are not cut short by the default 120-second command timeout.
+
+`policy` is a file path, not a policy name or ID. Prefer an absolute path such
+as `/etc/openclaw/openshell-policy.yaml`; relative paths are resolved from the
+agent's local workspace during sandbox creation. An explicit policy overrides
+the OpenShell CLI's `OPENSHELL_SANDBOX_POLICY` environment variable. When
+neither is set, OpenShell uses its normal policy selection and defaults.
+
+`providers` names existing OpenShell credential providers in the selected
+workspace. With `autoProviders: true`, OpenShell may create missing providers
+from credentials already available to the Gateway process. With
+`autoProviders: false`, create required providers first and verify them with
+`openshell --workspace <workspace-name> provider list`. Keep API keys in
+OpenShell providers rather than adding them to sandbox environment variables.
 
 `workspace` must match OpenShell's current workspace-name contract: 1-19
 lowercase alphanumeric characters or single hyphens, with no leading,
@@ -253,7 +311,7 @@ Sandbox-level settings (`mode`, `scope`, `workspaceAccess`) live under
           gateway: "lab",
           gatewayEndpoint: "https://lab.example",
           workspace: "research",
-          policy: "strict",
+          policy: "/etc/openclaw/openshell-policy.yaml",
         },
       },
     },
@@ -272,6 +330,10 @@ openclaw sandbox explain
 
 # Recreate (deletes remote workspace, re-seeds on next use)
 openclaw sandbox recreate --all
+
+# Recreate only one agent or the exact session scope shown by sandbox list
+openclaw sandbox recreate --agent researcher
+openclaw sandbox recreate --session "agent:researcher:main"
 ```
 
 For `remote` mode, recreate is especially important: it deletes the canonical
@@ -297,6 +359,20 @@ Recreate after changing any of:
 - `plugins.entries.openshell.config.from`
 - `plugins.entries.openshell.config.mode`
 - `plugins.entries.openshell.config.policy`
+- `plugins.entries.openshell.config.providers`, `gpu`, or `autoProviders`
+- `plugins.entries.openshell.config.remoteWorkspaceDir` or
+  `remoteAgentWorkspaceDir`
+
+When changing the OpenShell gateway or control-plane workspace, recreate the
+affected sandboxes while the old gateway and workspace are still selected;
+otherwise cleanup targets the new location instead of the existing sandbox.
+
+If OpenShell cannot delete a sandbox, OpenClaw reports the failure and keeps the
+runtime registry entry so recreation or pruning can be retried safely. Restore
+the original gateway, workspace, authentication, and connectivity, inspect the
+runtime with `openshell --workspace <workspace-name> sandbox get <sandbox-name>`,
+and rerun the scoped `openclaw sandbox recreate` command. Do not switch the
+configured workspace or delete the registry entry to hide the failure.
 
 ## Security hardening
 
@@ -304,6 +380,10 @@ The mirror-mode filesystem bridge pins the local workspace root and rechecks
 canonical paths (via realpath) before every read, write, mkdir, remove, and
 rename, rejecting mid-path symlinks. A symlink swap or remounted workspace
 cannot redirect file access outside the mirrored tree.
+
+Workspace synchronization excludes `.git`, `hooks`, and `git-hooks` in both
+directions. Repository credentials, history, and trusted hook code remain on
+the OpenClaw Gateway host instead of being copied into an untrusted sandbox.
 
 ## Custom image contract
 
@@ -317,6 +397,28 @@ Custom images used with the OpenClaw filesystem bridge must provide:
 - `python3` or `python` for pinned write, edit, rename, and remove operations
 - GNU-compatible `stat` and `find`
 - standard `mkdir`, `mv`, `rm`, and `rmdir` utilities
+
+When the agent workspace differs from the sandbox workspace, the sandbox user
+and policy also need write access to both configured remote roots. Standard
+unprivileged images often cannot create the default `/agent` directory. Either
+create and grant access to `/agent` in the image and policy, or configure two
+non-overlapping directories beneath the already-writable sandbox root:
+
+```json5
+{
+  plugins: {
+    entries: {
+      openshell: {
+        enabled: true,
+        config: {
+          remoteWorkspaceDir: "/sandbox/workspace",
+          remoteAgentWorkspaceDir: "/sandbox/agent",
+        },
+      },
+    },
+  },
+}
+```
 
 Package installation and private certificate roots must be included in the
 source image or installed from inside the sandbox. The selected OpenShell
@@ -337,6 +439,61 @@ filesystem must permit the writes. `sandbox.docker.network`,
 - Native plugin code and Gateway RPC stay on the Gateway host. Plugin-owned and
   MCP tools are available to sandboxed sessions only when sandbox tool policy
   allows them.
+
+## Troubleshooting
+
+First separate OpenClaw Gateway health, plugin activation, and OpenShell
+gateway connectivity:
+
+```bash
+openclaw gateway status --deep --require-rpc
+openclaw plugins inspect openshell --runtime --json
+openclaw sandbox explain
+openclaw sandbox list
+openshell gateway list
+openshell sandbox list
+openclaw logs --follow
+```
+
+- **Plugin missing or backend unavailable:** Install
+  `@openclaw/openshell-sandbox`, set `plugins.entries.openshell.enabled: true`,
+  validate the config, and restart the OpenClaw Gateway. Run
+  `openclaw plugins inspect openshell --runtime --json` to check the running
+  Gateway rather than only the on-disk plugin registration.
+- **`openshell` not found:** Install the CLI for the user running the Gateway,
+  or set `plugins.entries.openshell.config.command` to its absolute executable
+  path. A working interactive shell does not prove the managed service has the
+  same `PATH`.
+- **No active gateway, unauthorized, or connection failed:** Check
+  `openshell gateway list`, select the intended gateway, and reauthenticate with
+  `openshell gateway login <gateway-name>` when its deployment requires login.
+  Set `plugins.entries.openshell.config.gateway` explicitly when the service
+  should not depend on the interactive CLI's active selection.
+- **Workspace missing or the wrong sandbox list:** Verify the selected
+  control-plane workspace with `openshell workspace list`, then run
+  `openshell --workspace <workspace-name> sandbox list`. Create missing
+  workspaces with `openshell workspace create --name <workspace-name>` before
+  enabling them in OpenClaw. Remember that the Gateway service may not inherit
+  `OPENSHELL_WORKSPACE` from your interactive shell.
+- **Policy file cannot be read or outbound traffic is denied:** Configure an
+  existing YAML policy file using an absolute host path, check its permissions,
+  and verify that the policy permits the destination and requesting binary.
+  Inspect a running sandbox with
+  `openshell sandbox get <sandbox-name> --policy-only`. Docker network settings
+  do not change OpenShell policy.
+- **Provider creation fails:** Inspect the selected workspace with
+  `openshell provider list`, then create or refresh the required provider using
+  OpenShell's documented credential flow. If `autoProviders` is disabled,
+  required providers must already exist.
+- **Remote files are missing locally:** This is expected in `remote` mode;
+  remote files are canonical and are not synchronized back to the host. Use
+  `mirror` mode when host-visible changes are required. Recreating a remote
+  sandbox destroys its remote-only files.
+- **Recreate or prune cannot delete a sandbox:** Restore access to the original
+  OpenShell gateway and workspace, confirm the sandbox still exists with
+  `openshell --workspace <workspace-name> sandbox get <sandbox-name>`, and retry
+  the scoped recreation. OpenClaw retains the registry entry until deletion
+  succeeds.
 
 ## How it works
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -840,7 +840,9 @@ Native dependency policy:
 - Scope:
   - Reuses an active local OpenShell gateway
   - Creates a sandbox from a temporary local Dockerfile
-  - Exercises OpenClaw's OpenShell backend over real `sandbox ssh-config` + SSH exec
+  - Exercises remote and default mirrored OpenShell backends over real SSH
+  - Creates an isolated non-default OpenShell workspace and custom workspace roots
+  - Verifies nested mirrored file writes and excludes host Git metadata and hooks
   - Verifies remote-canonical filesystem behavior through the sandbox fs bridge
 - Expectations:
   - Opt-in only; not part of the default `pnpm test:e2e` run
@@ -851,7 +853,7 @@ Native dependency policy:
   - `OPENCLAW_E2E_OPENSHELL=1` to enable the test when running the broader e2e suite manually
   - `OPENCLAW_E2E_OPENSHELL_COMMAND=/path/to/openshell` to point at a non-default CLI binary or wrapper script
   - `OPENCLAW_E2E_OPENSHELL_CONFIG_HOME=/path/to/config` to expose the registered gateway config to the isolated test
-  - `OPENCLAW_E2E_OPENSHELL_HOST_IP=172.18.0.1` to override the Docker gateway IP used by the host policy fixture
+  - `OPENCLAW_E2E_OPENSHELL_HOST_IP=172.18.0.1` to override the sandbox-visible `host.openshell.internal` address used by the network policy fixture; Docker Desktop may resolve this differently from the bridge gateway
 
 ### Live (real providers + real models)
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -583,7 +583,7 @@ Sandbox scope can be per-agent (default), per-session, or shared; each scope get
 For full configuration, images, security notes, and multi-agent profiles:
 
 - [Sandboxing](/gateway/sandboxing) -- complete sandbox reference
-- [OpenShell](/gateway/openshell) -- interactive shell access to sandbox containers
+- [OpenShell](/gateway/openshell) -- OpenShell-managed local or remote sandbox backend
 - [Multi-Agent Sandbox and Tools](/tools/multi-agent-sandbox-tools) -- per-agent overrides
 
 ### Quick enable

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -168,14 +168,14 @@ Other behavior: the runner preflights Docker by default, cleans stale OpenClaw E
 
 ### Sandbox compatibility lanes
 
-| Command                                      | Verifies                                                                                                                                                           |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `pnpm test:e2e:openshell`                    | Real OpenShell gateway, custom image build, managed sandbox lifecycle, SSH execution, remote filesystem bridge, seeded workspace, and deny/allow network policies. |
-| `pnpm test:docker:package-install`           | Packed OpenClaw npm artifact installation into a clean global prefix, then CLI version and help startup from the installed package.                                |
-| `pnpm test:docker:openai-web-search-minimal` | Mocked TLS endpoint with a private test CA, isolated Gateway startup, and web-search request handling through the configured certificate trust path.               |
-| `pnpm test:docker:browser-cdp-snapshot`      | Chromium startup, raw CDP connectivity, isolated Gateway browser commands, doctor output, and accessibility snapshot roles.                                        |
-| `pnpm test:docker:kitchen-sink-rpc`          | Installed plugin commands and catalog tools, read-only Gateway RPC traversal, authentication boundaries, channel lifecycle, and resource ceilings.                 |
-| `pnpm test:docker:kitchen-sink-plugin`       | Packaged and registry plugin install flows, plugin execution, expected unsupported-version failures, ClawHub fallback, and npm-to-ClawHub migration.               |
+| Command                                      | Verifies                                                                                                                                                                                                         |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm test:e2e:openshell`                    | Real OpenShell gateway, isolated control-plane workspace, custom image, remote and mirrored filesystems, nested mirror writes, protected host metadata, sandbox lifecycle, SSH, and deny/allow network policies. |
+| `pnpm test:docker:package-install`           | Packed OpenClaw npm artifact installation into a clean global prefix, then CLI version and help startup from the installed package.                                                                              |
+| `pnpm test:docker:openai-web-search-minimal` | Mocked TLS endpoint with a private test CA, isolated Gateway startup, and web-search request handling through the configured certificate trust path.                                                             |
+| `pnpm test:docker:browser-cdp-snapshot`      | Chromium startup, raw CDP connectivity, isolated Gateway browser commands, doctor output, and accessibility snapshot roles.                                                                                      |
+| `pnpm test:docker:kitchen-sink-rpc`          | Installed plugin commands and catalog tools, read-only Gateway RPC traversal, authentication boundaries, channel lifecycle, and resource ceilings.                                                               |
+| `pnpm test:docker:kitchen-sink-plugin`       | Packaged and registry plugin install flows, plugin execution, expected unsupported-version failures, ClawHub fallback, and npm-to-ClawHub migration.                                                             |
 
 ## Local PR gate
 

--- a/extensions/openshell/README.md
+++ b/extensions/openshell/README.md
@@ -2,7 +2,9 @@
 
 Official NVIDIA OpenShell sandbox backend for OpenClaw.
 
-This plugin lets OpenClaw use OpenShell-managed sandboxes with mirrored local workspaces and SSH command execution.
+This plugin lets OpenClaw use OpenShell-managed local or remote sandboxes with
+SSH command execution. Choose `mirror` mode for a synchronized local workspace
+or `remote` mode for a remote-canonical workspace.
 
 Configuring an OpenShell workspace requires OpenShell `v0.0.88` or newer. The
 plugin supports OpenShell control-plane workspaces through
@@ -21,6 +23,23 @@ openclaw plugins install @openclaw/openshell-sandbox
 Restart the Gateway after installing or updating the plugin.
 
 ## Configure
+
+Install and configure the OpenShell CLI before enabling the backend. As the same
+operating system user that runs the OpenClaw Gateway, verify:
+
+```bash
+openshell --version
+openshell gateway list
+openshell sandbox list
+```
+
+Set `agents.defaults.sandbox.backend` to `"openshell"`, enable
+`plugins.entries.openshell`, and restart the OpenClaw Gateway. OpenShell
+settings belong under `plugins.entries.openshell.config`.
+
+The optional `policy` setting must be the path to a readable OpenShell policy
+YAML file on the Gateway host; it is not a policy name or ID. Use an absolute
+path to avoid resolving it relative to an agent workspace.
 
 Use the OpenShell docs for credentials, workspace mirroring, runtime selection, and troubleshooting:
 

--- a/extensions/openshell/openclaw.plugin.json
+++ b/extensions/openshell/openclaw.plugin.json
@@ -54,11 +54,13 @@
       },
       "remoteWorkspaceDir": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "pattern": "^\\/(?:sandbox|agent)(?:\\/|$)"
       },
       "remoteAgentWorkspaceDir": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "pattern": "^\\/(?:sandbox|agent)(?:\\/|$)"
       },
       "timeoutSeconds": {
         "type": "number",

--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -11,7 +11,10 @@ import {
   createSandboxSshConfig,
 } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
-import { createOpenShellSandboxBackendFactory } from "./backend.js";
+import {
+  createOpenShellSandboxBackendFactory,
+  createOpenShellSandboxBackendManager,
+} from "./backend.js";
 import { resolveOpenShellPluginConfig } from "./config.js";
 
 const OPENCLAW_OPENSHELL_E2E = process.env.OPENCLAW_E2E_OPENSHELL === "1";
@@ -218,22 +221,27 @@ async function resolveOpenShellHostIp(): Promise<string> {
     const gateway = await runCommand({
       command: "docker",
       args: [
-        "network",
-        "inspect",
+        "run",
+        "--rm",
+        "--network",
         network,
-        "--format",
-        "{{range .IPAM.Config}}{{.Gateway}}{{end}}",
+        "--add-host",
+        "host.openshell.internal:host-gateway",
+        "python:3.13-alpine",
+        "python3",
+        "-c",
+        "import socket; print(socket.gethostbyname('host.openshell.internal'))",
       ],
       allowFailure: true,
-      timeoutMs: 20_000,
+      timeoutMs: 60_000,
     });
     const hostIp = gateway.stdout.trim();
-    if (gateway.code === 0 && hostIp) {
+    if (gateway.code === 0 && net.isIP(hostIp)) {
       return hostIp;
     }
   }
   throw new Error(
-    "OpenShell E2E could not resolve the OpenShell Docker network gateway; set OPENCLAW_E2E_OPENSHELL_HOST_IP",
+    "OpenShell E2E could not resolve host.openshell.internal on the OpenShell Docker network; set OPENCLAW_E2E_OPENSHELL_HOST_IP",
   );
 }
 
@@ -475,7 +483,7 @@ describe("OpenShell gateway discovery", () => {
 
 describe("openshell sandbox backend e2e", () => {
   it.runIf(process.platform !== "win32" && OPENCLAW_OPENSHELL_E2E)(
-    "creates a remote-canonical sandbox through OpenShell and executes over SSH",
+    "runs remote and mirrored sandboxes in a non-default OpenShell workspace",
     { timeout: OPENCLAW_OPENSHELL_E2E_TIMEOUT_MS },
     async () => {
       if (!(await dockerReady())) {
@@ -505,6 +513,7 @@ describe("openshell sandbox backend e2e", () => {
       const previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
       const previousXdgCacheHome = process.env.XDG_CACHE_HOME;
       const workspaceDir = path.join(rootDir, "workspace");
+      const mirrorWorkspaceDir = path.join(rootDir, "mirror-workspace");
       const dockerfileDir = path.join(rootDir, "custom-image");
       const dockerfilePath = path.join(dockerfileDir, "Dockerfile");
       const denyPolicyPath = path.join(rootDir, "deny-policy.yaml");
@@ -513,7 +522,9 @@ describe("openshell sandbox backend e2e", () => {
       const scopeKey = `session:openshell-e2e-deny:${scopeSuffix}`;
       const testRunId = `${process.pid.toString(36)}${Date.now().toString(36)}`;
       const allowSandboxName = `oc-a-${testRunId.slice(-14)}`;
+      const openShellWorkspace = `oc-w-${testRunId.slice(-14)}`;
       let hostPolicyServer: HostPolicyServer | null | undefined;
+      let workspaceCreated = false;
       const sandboxCfg = {
         mode: "all" as const,
         backend: "openshell" as const,
@@ -540,6 +551,7 @@ describe("openshell sandbox backend e2e", () => {
       const pluginConfig = resolveOpenShellPluginConfig({
         command: OPENCLAW_OPENSHELL_COMMAND,
         gateway: gatewayName,
+        workspace: openShellWorkspace,
         from: dockerfilePath,
         mode: "remote",
         autoProviders: false,
@@ -553,6 +565,25 @@ describe("openshell sandbox backend e2e", () => {
         agentWorkspaceDir: workspaceDir,
         cfg: sandboxCfg,
       });
+      const mirrorPluginConfig = resolveOpenShellPluginConfig({
+        command: OPENCLAW_OPENSHELL_COMMAND,
+        gateway: gatewayName,
+        workspace: openShellWorkspace,
+        from: dockerfilePath,
+        autoProviders: false,
+        policy: denyPolicyPath,
+        remoteWorkspaceDir: "/sandbox/project",
+        remoteAgentWorkspaceDir: "/sandbox/agent",
+      });
+      const mirrorBackend = await createOpenShellSandboxBackendFactory({
+        pluginConfig: mirrorPluginConfig,
+      })({
+        sessionKey: `session:openshell-e2e-mirror:${scopeSuffix}`,
+        scopeKey: `session:openshell-e2e-mirror:${scopeSuffix}`,
+        workspaceDir: mirrorWorkspaceDir,
+        agentWorkspaceDir: mirrorWorkspaceDir,
+        cfg: sandboxCfg,
+      });
 
       try {
         process.env.HOME = env.HOME;
@@ -563,6 +594,7 @@ describe("openshell sandbox backend e2e", () => {
           throw new Error("failed to start host policy server");
         }
         await fs.mkdir(workspaceDir, { recursive: true });
+        await fs.mkdir(mirrorWorkspaceDir, { recursive: true });
         await fs.mkdir(dockerfileDir, { recursive: true });
         const isolatedConfigHome = env.XDG_CONFIG_HOME;
         if (!isolatedConfigHome) {
@@ -574,7 +606,24 @@ describe("openshell sandbox backend e2e", () => {
           path.join(isolatedConfigHome, "openshell"),
           { recursive: true },
         );
+        await runCommand({
+          command: OPENCLAW_OPENSHELL_COMMAND,
+          args: ["workspace", "create", "--name", openShellWorkspace],
+          env,
+          timeoutMs: 30_000,
+        });
+        workspaceCreated = true;
         await fs.writeFile(path.join(workspaceDir, "seed.txt"), "seed-from-local\n", "utf8");
+        await fs.writeFile(
+          path.join(mirrorWorkspaceDir, "mirror-seed.txt"),
+          "mirror-from-local\n",
+          "utf8",
+        );
+        for (const protectedDirectory of [".git", "hooks", "git-hooks"]) {
+          const protectedPath = path.join(mirrorWorkspaceDir, protectedDirectory);
+          await fs.mkdir(protectedPath, { recursive: true });
+          await fs.writeFile(path.join(protectedPath, "host-only.txt"), "private\n", "utf8");
+        }
         await fs.writeFile(dockerfilePath, CUSTOM_IMAGE_DOCKERFILE, "utf8");
         await fs.writeFile(
           denyPolicyPath,
@@ -606,6 +655,24 @@ describe("openshell sandbox backend e2e", () => {
         expect(stdout).toContain("/sandbox");
         expect(stdout).toContain("openclaw-openshell-e2e");
         expect(stdout).toContain("seed-from-local");
+
+        const manager = createOpenShellSandboxBackendManager({ pluginConfig });
+        const registryEntry = {
+          containerName: backend.runtimeId,
+          backendId: "openshell",
+          runtimeLabel: backend.runtimeLabel,
+          sessionKey: scopeKey,
+          createdAtMs: Date.now(),
+          lastUsedAtMs: Date.now(),
+          image: pluginConfig.from,
+          configLabelKind: "Source",
+        };
+        await expect(
+          manager.describeRuntime({ entry: registryEntry, config: {} }),
+        ).resolves.toMatchObject({
+          running: true,
+          configLabelMatch: true,
+        });
 
         const curlPathResult = await runBackendExec({
           backend,
@@ -646,7 +713,7 @@ describe("openshell sandbox backend e2e", () => {
 
         const verifyResult = await runCommand({
           command: OPENCLAW_OPENSHELL_COMMAND,
-          args: ["sandbox", "ssh-config", backend.runtimeId],
+          args: ["--workspace", openShellWorkspace, "sandbox", "ssh-config", backend.runtimeId],
           env,
           timeoutMs: 60_000,
         });
@@ -662,9 +729,53 @@ describe("openshell sandbox backend e2e", () => {
         expect(blockedGetResult.code).not.toBe(0);
         expect(`${blockedGetResult.stdout}\n${blockedGetResult.stderr}`).toMatch(/403|deny/i);
 
+        const mirrorExecResult = await runBackendExec({
+          backend: mirrorBackend,
+          command:
+            "pwd && cat mirror-seed.txt && test ! -e .git && test ! -e hooks && test ! -e git-hooks",
+          timeoutMs: 2 * 60_000,
+        });
+        expect(mirrorExecResult.stdout).toContain("/sandbox/project");
+        expect(mirrorExecResult.stdout).toContain("mirror-from-local");
+        for (const protectedDirectory of [".git", "hooks", "git-hooks"]) {
+          await expect(
+            fs.readFile(path.join(mirrorWorkspaceDir, protectedDirectory, "host-only.txt"), "utf8"),
+          ).resolves.toBe("private\n");
+        }
+
+        const mirrorSandbox = createSandboxTestContext({
+          overrides: {
+            backendId: "openshell",
+            workspaceDir: mirrorWorkspaceDir,
+            agentWorkspaceDir: mirrorWorkspaceDir,
+            runtimeId: mirrorBackend.runtimeId,
+            runtimeLabel: mirrorBackend.runtimeLabel,
+            containerName: mirrorBackend.runtimeId,
+            containerWorkdir: mirrorBackend.workdir,
+            backend: mirrorBackend,
+          },
+        });
+        const mirrorBridge = mirrorBackend.createFsBridge?.({ sandbox: mirrorSandbox });
+        if (!mirrorBridge) {
+          throw new Error("openshell mirror backend did not create a filesystem bridge");
+        }
+        await mirrorBridge.writeFile({
+          filePath: "nested/mirror-note.txt",
+          data: "mirror-write\n",
+          mkdir: true,
+        });
+        await expect(
+          fs.readFile(path.join(mirrorWorkspaceDir, "nested", "mirror-note.txt"), "utf8"),
+        ).resolves.toBe("mirror-write\n");
+        await expect(
+          runBackendExec({ backend: mirrorBackend, command: "cat nested/mirror-note.txt" }),
+        ).resolves.toMatchObject({ code: 0, stdout: "mirror-write\n" });
+
         const allowedGetResult = await runCommand({
           command: OPENCLAW_OPENSHELL_COMMAND,
           args: [
+            "--workspace",
+            openShellWorkspace,
             "sandbox",
             "create",
             "--name",
@@ -690,20 +801,24 @@ describe("openshell sandbox backend e2e", () => {
         expect(allowedGetResult.code).toBe(0);
         expect(allowedGetResult.stdout).toContain('"message":"hello-from-host"');
       } finally {
-        await runCommand({
-          command: OPENCLAW_OPENSHELL_COMMAND,
-          args: ["sandbox", "delete", backend.runtimeId],
-          env,
-          allowFailure: true,
-          timeoutMs: 2 * 60_000,
-        });
-        await runCommand({
-          command: OPENCLAW_OPENSHELL_COMMAND,
-          args: ["sandbox", "delete", allowSandboxName],
-          env,
-          allowFailure: true,
-          timeoutMs: 2 * 60_000,
-        });
+        for (const sandboxName of [backend.runtimeId, mirrorBackend.runtimeId, allowSandboxName]) {
+          await runCommand({
+            command: OPENCLAW_OPENSHELL_COMMAND,
+            args: ["--workspace", openShellWorkspace, "sandbox", "delete", sandboxName],
+            env,
+            allowFailure: true,
+            timeoutMs: 2 * 60_000,
+          });
+        }
+        if (workspaceCreated) {
+          await runCommand({
+            command: OPENCLAW_OPENSHELL_COMMAND,
+            args: ["workspace", "delete", openShellWorkspace],
+            env,
+            allowFailure: true,
+            timeoutMs: 30_000,
+          });
+        }
         await hostPolicyServer?.close().catch(() => {});
         await fs.rm(rootDir, { recursive: true, force: true });
         if (previousHome === undefined) {

--- a/extensions/openshell/src/backend.exec-workdir.test.ts
+++ b/extensions/openshell/src/backend.exec-workdir.test.ts
@@ -11,6 +11,7 @@ import {
   createSandboxBrowserConfig,
   createSandboxPruneConfig,
   createSandboxSshConfig,
+  createSandboxTestContext,
 } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createOpenShellSandboxBackendFactory } from "./backend.js";
@@ -111,6 +112,11 @@ describe("openshell backend exec workdir validation", () => {
     tempWorkspaces.push(workspace);
     const workspaceDir = workspace.dir;
     await fs.writeFile(path.join(workspaceDir, "seed.txt"), "seed", "utf8");
+    for (const protectedDirectory of [".git", "hooks", "git-hooks"]) {
+      const protectedPath = path.join(workspaceDir, protectedDirectory);
+      await fs.mkdir(protectedPath, { recursive: true });
+      await fs.writeFile(path.join(protectedPath, "private.txt"), "host-only", "utf8");
+    }
     const backendFactory = createOpenShellSandboxBackendFactory({
       pluginConfig: resolveOpenShellPluginConfig({
         command: "openshell",
@@ -144,7 +150,35 @@ describe("openshell backend exec workdir validation", () => {
         "--no-git-ignore",
         backend.runtimeId,
         expect.stringMatching(/\/seed\.txt$/),
-        "/sandbox",
+        "/sandbox/",
+      ],
+      cwd: workspaceDir,
+    });
+    const nestedFile = path.join(workspaceDir, "nested", "note.txt");
+    const bridge = backend.createFsBridge?.({
+      sandbox: createSandboxTestContext({
+        overrides: {
+          backendId: "openshell",
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+          containerWorkdir: backend.workdir,
+          backend,
+        },
+      }),
+    });
+    if (!bridge) {
+      throw new Error("Expected OpenShell mirror filesystem bridge");
+    }
+    await bridge.writeFile({ filePath: "nested/note.txt", data: "nested", mkdir: true });
+    expect(cliMocks.runOpenShellCli).toHaveBeenLastCalledWith({
+      context: expect.objectContaining({ sandboxName: backend.runtimeId }),
+      args: [
+        "sandbox",
+        "upload",
+        "--no-git-ignore",
+        backend.runtimeId,
+        nestedFile,
+        "/sandbox/nested/note.txt",
       ],
       cwd: workspaceDir,
     });

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -59,7 +59,7 @@ function buildOpenShellDirectoryUploadArgs(params: {
     "--no-git-ignore",
     params.sandboxName,
     params.localPath,
-    normalizeRemotePath(params.remotePath),
+    `${normalizeRemotePath(params.remotePath)}/`,
   ];
 }
 
@@ -230,24 +230,27 @@ export function createOpenShellSandboxBackendManager(params: {
       };
       const result = await runOpenShellCli({
         context: execContext,
-        args: ["sandbox", "get", entry.containerName],
+        args: ["sandbox", "get", entry.containerName, "--output", "json"],
       });
       const configuredSource = execContext.config.from;
       return {
-        running: result.code === 0,
+        running: result.code === 0 && parseOpenShellSandboxPhase(result.stdout) === "Ready",
         actualConfigLabel: entry.image,
         configLabelMatch: entry.image === configuredSource,
       };
     },
-    async removeRuntime({ entry }) {
+    async removeRuntime({ entry, config }) {
       const execContext: OpenShellExecContext = {
-        config: params.pluginConfig,
+        config: resolveOpenShellPluginConfigFromConfig(config, params.pluginConfig),
         sandboxName: entry.containerName,
       };
-      await runOpenShellCli({
+      const result = await runOpenShellCli({
         context: execContext,
         args: ["sandbox", "delete", entry.containerName],
       });
+      if (result.code !== 0) {
+        throw new Error(result.stderr.trim() || "openshell sandbox delete failed");
+      }
     },
   };
 }
@@ -620,7 +623,7 @@ class OpenShellSandboxBackendImpl {
         "--no-git-ignore",
         this.params.execContext.sandboxName,
         localPath,
-        path.posix.dirname(remotePath),
+        remotePath,
       ],
       cwd: this.params.createParams.workspaceDir,
     });
@@ -690,6 +693,9 @@ class OpenShellSandboxBackendImpl {
     }
     if (this.params.legacyRuntimeAdopted) {
       throw this.buildLegacyRuntimeUnavailableError(getResult.stderr.trim());
+    }
+    if (!/\bsandbox not found\b/iu.test(getResult.stderr)) {
+      throw new Error(getResult.stderr.trim() || "openshell sandbox get failed");
     }
     const createArgs = [
       "sandbox",
@@ -875,6 +881,7 @@ class OpenShellSandboxBackendImpl {
         await stageDirectoryContents({
           sourceDir: localPath,
           targetDir: stagedRoot,
+          excludeDirs: DEFAULT_OPEN_SHELL_MIRROR_EXCLUDE_DIRS,
         });
         const stagedEntries = (await fs.readdir(stagedRoot)).toSorted();
         for (const entry of stagedEntries) {
@@ -985,6 +992,18 @@ function parseOpenShellSandboxPhasePage(
       }
     }
     return { count: parsed.length };
+  } catch {
+    return undefined;
+  }
+}
+
+function parseOpenShellSandboxPhase(stdout: string): string | undefined {
+  try {
+    const parsed: unknown = JSON.parse(stdout);
+    if (typeof parsed !== "object" || parsed === null || !("phase" in parsed)) {
+      return undefined;
+    }
+    return typeof parsed.phase === "string" ? parsed.phase : undefined;
   } catch {
     return undefined;
   }

--- a/extensions/openshell/src/config.test.ts
+++ b/extensions/openshell/src/config.test.ts
@@ -65,13 +65,11 @@ describe("openshell plugin config", () => {
     ["/sandbox/project", "/sandbox/project/agent"],
     ["/agent/worker/project", "/agent/worker"],
   ])(
-    "rejects overlapping workspace roots %s and %s",
+    "preserves shipped overlapping workspace roots %s and %s",
     (remoteWorkspaceDir, remoteAgentWorkspaceDir) => {
       const config = { remoteWorkspaceDir, remoteAgentWorkspaceDir };
-      expect(createOpenShellPluginConfigSchema().safeParse?.(config).success).toBe(false);
-      expect(() => resolveOpenShellPluginConfig(config)).toThrow(
-        "remote workspace roots must not overlap",
-      );
+      expect(createOpenShellPluginConfigSchema().safeParse?.(config).success).toBe(true);
+      expect(resolveOpenShellPluginConfig(config)).toMatchObject(config);
     },
   );
 

--- a/extensions/openshell/src/config.test.ts
+++ b/extensions/openshell/src/config.test.ts
@@ -27,6 +27,11 @@ describe("openshell plugin config", () => {
   });
 
   it("rejects relative remote paths", () => {
+    expect(
+      createOpenShellPluginConfigSchema().safeParse?.({
+        remoteWorkspaceDir: "sandbox",
+      }).success,
+    ).toBe(false);
     expect(() =>
       resolveOpenShellPluginConfig({
         remoteWorkspaceDir: "sandbox",
@@ -35,12 +40,40 @@ describe("openshell plugin config", () => {
   });
 
   it("rejects remote paths outside managed sandbox roots", () => {
+    expect(
+      createOpenShellPluginConfigSchema().safeParse?.({
+        remoteWorkspaceDir: "/tmp/victim",
+      }).success,
+    ).toBe(false);
     expect(() =>
       resolveOpenShellPluginConfig({
         remoteWorkspaceDir: "/tmp/victim",
       }),
     ).toThrow("OpenShell remoteWorkspaceDir must stay under /sandbox or /agent");
   });
+
+  it("rejects normalized paths that escape managed sandbox roots during config validation", () => {
+    expect(
+      createOpenShellPluginConfigSchema().safeParse?.({
+        remoteAgentWorkspaceDir: "/agent/../../etc",
+      }).success,
+    ).toBe(false);
+  });
+
+  it.each([
+    ["/sandbox/project", "/sandbox/project"],
+    ["/sandbox/project", "/sandbox/project/agent"],
+    ["/agent/worker/project", "/agent/worker"],
+  ])(
+    "rejects overlapping workspace roots %s and %s",
+    (remoteWorkspaceDir, remoteAgentWorkspaceDir) => {
+      const config = { remoteWorkspaceDir, remoteAgentWorkspaceDir };
+      expect(createOpenShellPluginConfigSchema().safeParse?.(config).success).toBe(false);
+      expect(() => resolveOpenShellPluginConfig(config)).toThrow(
+        "remote workspace roots must not overlap",
+      );
+    },
+  );
 
   it("normalizes managed sandbox subpaths", () => {
     expect(

--- a/extensions/openshell/src/config.ts
+++ b/extensions/openshell/src/config.ts
@@ -68,6 +68,18 @@ function normalizeProviders(value: string[] | undefined): string[] {
 const nonEmptyTrimmedString = (message: string) =>
   z.string({ error: message }).trim().min(1, { error: message });
 
+const openShellManagedRemotePath = (fieldName: string) =>
+  nonEmptyTrimmedString(`${fieldName} must be a non-empty string`)
+    .regex(/^\/(?:sandbox|agent)(?:\/|$)/, {
+      error: (issue) =>
+        String(issue.input).startsWith("/")
+          ? `OpenShell ${fieldName} must stay under /sandbox or /agent`
+          : `OpenShell ${fieldName} must be absolute`,
+    })
+    .refine((value) => isManagedOpenShellRemotePath(path.posix.normalize(value)), {
+      error: `OpenShell ${fieldName} must stay under /sandbox or /agent`,
+    });
+
 const openShellWorkspaceName = z
   .string({ error: "workspace must be a valid OpenShell workspace name" })
   .trim()
@@ -78,42 +90,58 @@ const openShellWorkspaceName = z
       "workspace must contain lowercase alphanumeric characters or single hyphens and must not start or end with a hyphen",
   });
 
-const OpenShellPluginConfigSchema = z.strictObject({
-  mode: z.enum(["mirror", "remote"], { error: "mode must be one of mirror, remote" }).optional(),
-  command: nonEmptyTrimmedString("command must be a non-empty string").optional(),
-  gateway: nonEmptyTrimmedString("gateway must be a non-empty string").optional(),
-  gatewayEndpoint: nonEmptyTrimmedString("gatewayEndpoint must be a non-empty string").optional(),
-  workspace: openShellWorkspaceName.optional(),
-  from: nonEmptyTrimmedString("from must be a non-empty string").optional(),
-  policy: nonEmptyTrimmedString("policy must be a non-empty string").optional(),
-  providers: z
-    .array(
-      z.string({ error: "providers must be an array of strings" }).trim().min(1, {
-        error: "providers must be an array of strings",
-      }),
-      {
-        error: "providers must be an array of strings",
-      },
-    )
-    .optional(),
-  gpu: z.boolean({ error: "gpu must be a boolean" }).optional(),
-  autoProviders: z.boolean({ error: "autoProviders must be a boolean" }).optional(),
-  remoteWorkspaceDir: nonEmptyTrimmedString(
-    "remoteWorkspaceDir must be a non-empty string",
-  ).optional(),
-  remoteAgentWorkspaceDir: nonEmptyTrimmedString(
-    "remoteAgentWorkspaceDir must be a non-empty string",
-  ).optional(),
-  timeoutSeconds: z
-    .number({
-      error: `timeoutSeconds must be a number between 1 and ${MAX_TIMER_TIMEOUT_SECONDS}`,
-    })
-    .min(1, { error: "timeoutSeconds must be a number >= 1" })
-    .max(MAX_TIMER_TIMEOUT_SECONDS, {
-      error: `timeoutSeconds must be a number <= ${MAX_TIMER_TIMEOUT_SECONDS}`,
-    })
-    .optional(),
-});
+const OpenShellPluginConfigSchema = z
+  .strictObject({
+    mode: z.enum(["mirror", "remote"], { error: "mode must be one of mirror, remote" }).optional(),
+    command: nonEmptyTrimmedString("command must be a non-empty string").optional(),
+    gateway: nonEmptyTrimmedString("gateway must be a non-empty string").optional(),
+    gatewayEndpoint: nonEmptyTrimmedString("gatewayEndpoint must be a non-empty string").optional(),
+    workspace: openShellWorkspaceName.optional(),
+    from: nonEmptyTrimmedString("from must be a non-empty string").optional(),
+    policy: nonEmptyTrimmedString("policy must be a non-empty string").optional(),
+    providers: z
+      .array(
+        z.string({ error: "providers must be an array of strings" }).trim().min(1, {
+          error: "providers must be an array of strings",
+        }),
+        {
+          error: "providers must be an array of strings",
+        },
+      )
+      .optional(),
+    gpu: z.boolean({ error: "gpu must be a boolean" }).optional(),
+    autoProviders: z.boolean({ error: "autoProviders must be a boolean" }).optional(),
+    remoteWorkspaceDir: openShellManagedRemotePath("remoteWorkspaceDir").optional(),
+    remoteAgentWorkspaceDir: openShellManagedRemotePath("remoteAgentWorkspaceDir").optional(),
+    timeoutSeconds: z
+      .number({
+        error: `timeoutSeconds must be a number between 1 and ${MAX_TIMER_TIMEOUT_SECONDS}`,
+      })
+      .min(1, { error: "timeoutSeconds must be a number >= 1" })
+      .max(MAX_TIMER_TIMEOUT_SECONDS, {
+        error: `timeoutSeconds must be a number <= ${MAX_TIMER_TIMEOUT_SECONDS}`,
+      })
+      .optional(),
+  })
+  .superRefine((config, ctx) => {
+    const workspaceRoot = path.posix.normalize(
+      config.remoteWorkspaceDir ?? DEFAULT_REMOTE_WORKSPACE_DIR,
+    );
+    const agentRoot = path.posix.normalize(
+      config.remoteAgentWorkspaceDir ?? DEFAULT_REMOTE_AGENT_WORKSPACE_DIR,
+    );
+    if (
+      workspaceRoot === agentRoot ||
+      workspaceRoot.startsWith(`${agentRoot}/`) ||
+      agentRoot.startsWith(`${workspaceRoot}/`)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["remoteAgentWorkspaceDir"],
+        message: "OpenShell remote workspace roots must not overlap",
+      });
+    }
+  });
 
 function isManagedOpenShellRemotePath(value: string): boolean {
   return OPEN_SHELL_MANAGED_REMOTE_ROOTS.some(

--- a/extensions/openshell/src/config.ts
+++ b/extensions/openshell/src/config.ts
@@ -90,58 +90,38 @@ const openShellWorkspaceName = z
       "workspace must contain lowercase alphanumeric characters or single hyphens and must not start or end with a hyphen",
   });
 
-const OpenShellPluginConfigSchema = z
-  .strictObject({
-    mode: z.enum(["mirror", "remote"], { error: "mode must be one of mirror, remote" }).optional(),
-    command: nonEmptyTrimmedString("command must be a non-empty string").optional(),
-    gateway: nonEmptyTrimmedString("gateway must be a non-empty string").optional(),
-    gatewayEndpoint: nonEmptyTrimmedString("gatewayEndpoint must be a non-empty string").optional(),
-    workspace: openShellWorkspaceName.optional(),
-    from: nonEmptyTrimmedString("from must be a non-empty string").optional(),
-    policy: nonEmptyTrimmedString("policy must be a non-empty string").optional(),
-    providers: z
-      .array(
-        z.string({ error: "providers must be an array of strings" }).trim().min(1, {
-          error: "providers must be an array of strings",
-        }),
-        {
-          error: "providers must be an array of strings",
-        },
-      )
-      .optional(),
-    gpu: z.boolean({ error: "gpu must be a boolean" }).optional(),
-    autoProviders: z.boolean({ error: "autoProviders must be a boolean" }).optional(),
-    remoteWorkspaceDir: openShellManagedRemotePath("remoteWorkspaceDir").optional(),
-    remoteAgentWorkspaceDir: openShellManagedRemotePath("remoteAgentWorkspaceDir").optional(),
-    timeoutSeconds: z
-      .number({
-        error: `timeoutSeconds must be a number between 1 and ${MAX_TIMER_TIMEOUT_SECONDS}`,
-      })
-      .min(1, { error: "timeoutSeconds must be a number >= 1" })
-      .max(MAX_TIMER_TIMEOUT_SECONDS, {
-        error: `timeoutSeconds must be a number <= ${MAX_TIMER_TIMEOUT_SECONDS}`,
-      })
-      .optional(),
-  })
-  .superRefine((config, ctx) => {
-    const workspaceRoot = path.posix.normalize(
-      config.remoteWorkspaceDir ?? DEFAULT_REMOTE_WORKSPACE_DIR,
-    );
-    const agentRoot = path.posix.normalize(
-      config.remoteAgentWorkspaceDir ?? DEFAULT_REMOTE_AGENT_WORKSPACE_DIR,
-    );
-    if (
-      workspaceRoot === agentRoot ||
-      workspaceRoot.startsWith(`${agentRoot}/`) ||
-      agentRoot.startsWith(`${workspaceRoot}/`)
-    ) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["remoteAgentWorkspaceDir"],
-        message: "OpenShell remote workspace roots must not overlap",
-      });
-    }
-  });
+const OpenShellPluginConfigSchema = z.strictObject({
+  mode: z.enum(["mirror", "remote"], { error: "mode must be one of mirror, remote" }).optional(),
+  command: nonEmptyTrimmedString("command must be a non-empty string").optional(),
+  gateway: nonEmptyTrimmedString("gateway must be a non-empty string").optional(),
+  gatewayEndpoint: nonEmptyTrimmedString("gatewayEndpoint must be a non-empty string").optional(),
+  workspace: openShellWorkspaceName.optional(),
+  from: nonEmptyTrimmedString("from must be a non-empty string").optional(),
+  policy: nonEmptyTrimmedString("policy must be a non-empty string").optional(),
+  providers: z
+    .array(
+      z.string({ error: "providers must be an array of strings" }).trim().min(1, {
+        error: "providers must be an array of strings",
+      }),
+      {
+        error: "providers must be an array of strings",
+      },
+    )
+    .optional(),
+  gpu: z.boolean({ error: "gpu must be a boolean" }).optional(),
+  autoProviders: z.boolean({ error: "autoProviders must be a boolean" }).optional(),
+  remoteWorkspaceDir: openShellManagedRemotePath("remoteWorkspaceDir").optional(),
+  remoteAgentWorkspaceDir: openShellManagedRemotePath("remoteAgentWorkspaceDir").optional(),
+  timeoutSeconds: z
+    .number({
+      error: `timeoutSeconds must be a number between 1 and ${MAX_TIMER_TIMEOUT_SECONDS}`,
+    })
+    .min(1, { error: "timeoutSeconds must be a number >= 1" })
+    .max(MAX_TIMER_TIMEOUT_SECONDS, {
+      error: `timeoutSeconds must be a number <= ${MAX_TIMER_TIMEOUT_SECONDS}`,
+    })
+    .optional(),
+});
 
 function isManagedOpenShellRemotePath(value: string): boolean {
   return OPEN_SHELL_MANAGED_REMOTE_ROOTS.some(

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -308,6 +308,9 @@ class OpenShellFsBridge implements SandboxFsBridge {
       const hostPath = relative
         ? path.resolve(workspaceRoot, ...relative.split("/"))
         : workspaceRoot;
+      if (!isPathInside(workspaceRoot, hostPath)) {
+        throw new Error(`Sandbox path escapes allowed mounts; cannot access: ${input}`);
+      }
       return {
         hostPath,
         relativePath: relative,
@@ -326,6 +329,9 @@ class OpenShellFsBridge implements SandboxFsBridge {
     ) {
       const relative = path.posix.relative(agentContainerRoot, input) || "";
       const hostPath = relative ? path.resolve(agentRoot, ...relative.split("/")) : agentRoot;
+      if (!isPathInside(agentRoot, hostPath)) {
+        throw new Error(`Sandbox path escapes allowed mounts; cannot access: ${input}`);
+      }
       return {
         hostPath,
         relativePath: relative ? agentContainerRoot + "/" + relative : agentContainerRoot,

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -336,6 +336,29 @@ describe("openshell backend manager", () => {
     );
   });
 
+  it.each([
+    ["gateway authentication expired", "gateway authentication expired"],
+    ["", "openshell sandbox get failed"],
+  ])(
+    "does not create a sandbox after a failed control-plane lookup: %s",
+    async (stderr, expected) => {
+      cliMocks.runOpenShellCli.mockResolvedValue({ code: 1, stdout: "", stderr });
+      const factory = createOpenShellSandboxBackendFactory({
+        pluginConfig: resolveOpenShellPluginConfig({ command: "openshell", mode: "remote" }),
+      });
+      const backend = await factory({
+        sessionKey: "agent:main:turn",
+        scopeKey: "agent:main",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/workspace",
+        cfg: createOpenShellBackendSandboxConfig(),
+      });
+
+      await expect(backend.runShellCommand({ script: "true" })).rejects.toThrow(expected);
+      expect(cliMocks.runOpenShellCli).toHaveBeenCalledOnce();
+    },
+  );
+
   it("does not execute a registered legacy sandbox that is no longer ready", async () => {
     const scopeKey = "agent:main";
     const legacyRuntimeId = "openclaw-agent-main-25bffc4d";
@@ -470,7 +493,7 @@ describe("openshell backend manager", () => {
   it("checks runtime status with config override from OpenClaw config", async () => {
     cliMocks.runOpenShellCli.mockResolvedValue({
       code: 0,
-      stdout: "{}",
+      stdout: JSON.stringify({ phase: "Ready" }),
       stderr: "",
     });
 
@@ -521,11 +544,41 @@ describe("openshell backend manager", () => {
         sandboxName: "openclaw-session-1234",
         config: expectedConfig,
       },
-      args: ["sandbox", "get", "openclaw-session-1234"],
+      args: ["sandbox", "get", "openclaw-session-1234", "--output", "json"],
     });
   });
 
-  it("removes runtimes via openshell sandbox delete", async () => {
+  it.each(["Provisioning", "Stopped", "Error", "Deleting"])(
+    "does not report an OpenShell runtime in phase %s as running",
+    async (phase) => {
+      cliMocks.runOpenShellCli.mockResolvedValue({
+        code: 0,
+        stdout: JSON.stringify({ phase }),
+        stderr: "",
+      });
+      const manager = createOpenShellSandboxBackendManager({
+        pluginConfig: resolveOpenShellPluginConfig({ command: "openshell" }),
+      });
+
+      await expect(
+        manager.describeRuntime({
+          entry: {
+            containerName: "openclaw-session-1234",
+            backendId: "openshell",
+            runtimeLabel: "openclaw-session-1234",
+            sessionKey: "agent:main",
+            createdAtMs: 1,
+            lastUsedAtMs: 1,
+            image: "openclaw",
+            configLabelKind: "Source",
+          },
+          config: {},
+        }),
+      ).resolves.toMatchObject({ running: false });
+    },
+  );
+
+  it("removes runtimes using the current OpenShell control-plane configuration", async () => {
     cliMocks.runOpenShellCli.mockResolvedValue({
       code: 0,
       stdout: "",
@@ -564,6 +617,76 @@ describe("openshell backend manager", () => {
       },
       args: ["sandbox", "delete", "openclaw-session-5678"],
     });
+
+    await manager.removeRuntime({
+      entry: {
+        containerName: "openclaw-session-5678",
+        backendId: "openshell",
+        runtimeLabel: "openclaw-session-5678",
+        sessionKey: "agent:main",
+        createdAtMs: 1,
+        lastUsedAtMs: 1,
+        image: "openclaw",
+        configLabelKind: "Source",
+      },
+      config: {
+        plugins: {
+          entries: {
+            openshell: {
+              enabled: true,
+              config: {
+                command: "/opt/openshell/bin/openshell",
+                gateway: "research",
+                workspace: "team-1",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(cliMocks.runOpenShellCli).toHaveBeenLastCalledWith({
+      context: {
+        sandboxName: "openclaw-session-5678",
+        config: resolveOpenShellPluginConfig({
+          command: "/opt/openshell/bin/openshell",
+          gateway: "research",
+          workspace: "team-1",
+        }),
+      },
+      args: ["sandbox", "delete", "openclaw-session-5678"],
+    });
+  });
+
+  it.each([
+    ["gateway unavailable", "gateway unavailable"],
+    ["", "openshell sandbox delete failed"],
+  ])("preserves deletion failures for sandbox lifecycle owners: %s", async (stderr, expected) => {
+    cliMocks.runOpenShellCli.mockResolvedValue({
+      code: 1,
+      stdout: "",
+      stderr,
+    });
+
+    const manager = createOpenShellSandboxBackendManager({
+      pluginConfig: resolveOpenShellPluginConfig({ command: "openshell" }),
+    });
+
+    await expect(
+      manager.removeRuntime({
+        entry: {
+          containerName: "openclaw-session-5678",
+          backendId: "openshell",
+          runtimeLabel: "openclaw-session-5678",
+          sessionKey: "agent:main",
+          createdAtMs: 1,
+          lastUsedAtMs: 1,
+          image: "openclaw",
+          configLabelKind: "Source",
+        },
+        config: {},
+      }),
+    ).rejects.toThrow(expected);
   });
 
   it("rejects malformed exec commands before opening an OpenShell SSH session", async () => {
@@ -854,6 +977,36 @@ describe("openshell fs bridges", () => {
   beforeAll(installOpenShellBackendMocks);
   afterAll(uninstallOpenShellBackendMocks);
   beforeEach(resetOpenShellBackendMocks);
+
+  it.each(["/sandbox/../outside.txt", "/sandbox/nested/../../outside.txt"])(
+    "rejects workspace container paths that escape the managed root: %s",
+    async (filePath) => {
+      await using workspace = await createOpenShellTestWorkspace("fs-path");
+      const { bridge } = await createMirrorFsBridgeFixture(workspace.dir);
+
+      expect(() => bridge.resolvePath({ filePath })).toThrow("Sandbox path escapes allowed mounts");
+    },
+  );
+
+  it("rejects agent container paths that escape the managed root", async () => {
+    await using workspace = await createOpenShellTestWorkspace("fs-path");
+    await using agentWorkspace = await createOpenShellTestWorkspace("fs-agent");
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir: workspace.dir,
+        agentWorkspaceDir: agentWorkspace.dir,
+        workspaceAccess: "rw",
+        containerWorkdir: "/sandbox",
+      },
+    });
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend: createMirrorBackendMock() });
+
+    expect(() => bridge.resolvePath({ filePath: "/agent/../outside.txt" })).toThrow(
+      "Sandbox path escapes allowed mounts",
+    );
+  });
 
   it.each(["remote", "mirror"] as const)(
     "keeps the factory backend as the canonical owner of the %s filesystem bridge",

--- a/src/agents/sandbox/manage.test.ts
+++ b/src/agents/sandbox/manage.test.ts
@@ -3,6 +3,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 let listSandboxBrowsers: typeof import("./manage.js").listSandboxBrowsers;
+let removeSandboxContainer: typeof import("./manage.js").removeSandboxContainer;
 let removeSandboxBrowserContainer: typeof import("./manage.js").removeSandboxBrowserContainer;
 let BROWSER_BRIDGES: typeof import("./browser-bridges.js").BROWSER_BRIDGES;
 
@@ -56,7 +57,8 @@ vi.mock("./docker-backend.js", () => ({
 
 beforeAll(async () => {
   ({ BROWSER_BRIDGES } = await import("./browser-bridges.js"));
-  ({ listSandboxBrowsers, removeSandboxBrowserContainer } = await import("./manage.js"));
+  ({ listSandboxBrowsers, removeSandboxContainer, removeSandboxBrowserContainer } =
+    await import("./manage.js"));
 });
 
 function firstDescribeRuntimeInput(): { agentId?: string; entry?: { configLabelKind?: string } } {
@@ -181,6 +183,27 @@ describe("listSandboxBrowsers", () => {
     expect(removeInput?.entry?.runtimeLabel).toBe("browser-1");
     expect(removeInput?.entry?.backendId).toBe("docker");
     expect(registryMocks.removeBrowserRegistryEntry).toHaveBeenCalledWith("browser-1");
+  });
+
+  it("preserves a sandbox registry entry when its backend plugin is unavailable", async () => {
+    registryMocks.readRegistry.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openshell-1",
+          backendId: "openshell",
+          runtimeLabel: "openshell-1",
+          sessionKey: "agent:coder:main",
+          createdAtMs: 1,
+          lastUsedAtMs: 1,
+          image: "openclaw",
+        },
+      ],
+    });
+
+    await expect(removeSandboxContainer("openshell-1")).rejects.toThrow(
+      'Sandbox backend "openshell" is unavailable',
+    );
+    expect(registryMocks.removeRegistryEntry).not.toHaveBeenCalled();
   });
 
   it("retains the exact bridge owner when cleanup fails", async () => {

--- a/src/agents/sandbox/manage.ts
+++ b/src/agents/sandbox/manage.ts
@@ -100,8 +100,14 @@ export async function removeSandboxContainer(containerName: string): Promise<voi
   const registry = await readRegistry();
   const entry = registry.entries.find((item) => item.containerName === containerName);
   if (entry) {
-    const manager = getSandboxBackendManager(entry.backendId ?? "docker");
-    await manager?.removeRuntime({
+    const backendId = entry.backendId ?? "docker";
+    const manager = getSandboxBackendManager(backendId);
+    if (!manager) {
+      throw new Error(
+        `Sandbox backend "${backendId}" is unavailable; enable its plugin before removing this runtime.`,
+      );
+    }
+    await manager.removeRuntime({
       entry,
       config,
       agentId: resolveSandboxAgentId(entry.sessionKey),

--- a/src/agents/sandbox/prune.test.ts
+++ b/src/agents/sandbox/prune.test.ts
@@ -11,6 +11,7 @@ const configMocks = vi.hoisted(() => ({
 }));
 
 const backendMocks = vi.hoisted(() => ({
+  getSandboxBackendManager: vi.fn(),
   removeRuntime: vi.fn(),
 }));
 
@@ -38,7 +39,7 @@ vi.mock("../../runtime.js", () => ({
 }));
 
 vi.mock("./backend.js", () => ({
-  getSandboxBackendManager: vi.fn(() => backendMocks),
+  getSandboxBackendManager: backendMocks.getSandboxBackendManager,
 }));
 
 vi.mock("./docker-backend.js", () => ({
@@ -109,6 +110,7 @@ describe("maybePruneSandboxes", () => {
   beforeEach(async () => {
     vi.resetModules();
     configMocks.getRuntimeConfig.mockReset();
+    backendMocks.getSandboxBackendManager.mockReset().mockReturnValue(backendMocks);
     backendMocks.removeRuntime.mockReset();
     registryMocks.readBrowserRegistry.mockReset();
     registryMocks.readRegistry.mockReset();
@@ -153,6 +155,28 @@ describe("maybePruneSandboxes", () => {
     expect(registryMocks.removeRegistryEntry).not.toHaveBeenCalled();
     expect(runtimeMocks.error).toHaveBeenCalledWith(
       "Sandbox prune failed to remove sandbox-1: docker rm failed",
+    );
+  });
+
+  it("keeps the registry entry when its sandbox backend plugin is unavailable", async () => {
+    backendMocks.getSandboxBackendManager.mockReturnValueOnce(null);
+    registryMocks.readRegistry.mockResolvedValueOnce({
+      entries: [
+        {
+          containerName: "openshell-1",
+          backendId: "openshell",
+          createdAtMs: Date.now() - 4 * 60 * 60 * 1000,
+          lastUsedAtMs: Date.now() - 2 * 60 * 60 * 1000,
+          image: "openclaw",
+        },
+      ],
+    });
+
+    await maybePruneSandboxes(buildPruneConfig());
+
+    expect(registryMocks.removeRegistryEntry).not.toHaveBeenCalled();
+    expect(runtimeMocks.error).toHaveBeenCalledWith(
+      'Sandbox prune failed to remove openshell-1: Sandbox backend "openshell" is unavailable; enable its plugin before removing this runtime.',
     );
   });
 

--- a/src/agents/sandbox/prune.ts
+++ b/src/agents/sandbox/prune.ts
@@ -86,8 +86,14 @@ async function pruneSandboxContainers(cfg: SandboxConfig) {
     read: readRegistry,
     remove: removeRegistryEntry,
     removeRuntime: async (entry) => {
-      const manager = getSandboxBackendManager(entry.backendId ?? "docker");
-      await manager?.removeRuntime({
+      const backendId = entry.backendId ?? "docker";
+      const manager = getSandboxBackendManager(backendId);
+      if (!manager) {
+        throw new Error(
+          `Sandbox backend "${backendId}" is unavailable; enable its plugin before removing this runtime.`,
+        );
+      }
+      await manager.removeRuntime({
         entry,
         config,
       });

--- a/src/agents/sandbox/ssh-backend.test.ts
+++ b/src/agents/sandbox/ssh-backend.test.ts
@@ -376,6 +376,37 @@ describe("ssh sandbox backend", () => {
     expect(commandParams.remoteCommand).toContain('rm -rf -- "$1"');
   });
 
+  it.each([
+    ["permission denied", "permission denied"],
+    ["", "exit 1"],
+  ])(
+    "rejects failed SSH runtime removal instead of orphaning its registry entry: %s",
+    async (stderr, expected) => {
+      sshMocks.runSshSandboxCommand.mockResolvedValueOnce({
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.from(stderr),
+        code: 1,
+      });
+
+      await expect(
+        sshSandboxBackendManager.removeRuntime({
+          entry: {
+            containerName: "openclaw-ssh-worker-abcd1234",
+            backendId: "ssh",
+            runtimeLabel: "openclaw-ssh-worker-abcd1234",
+            sessionKey: "agent:worker",
+            createdAtMs: 1,
+            lastUsedAtMs: 1,
+            image: "peter@example.com:2222",
+            configLabelKind: "Target",
+          },
+          config: createConfig(),
+        }),
+      ).rejects.toThrow(expected);
+      expect(sshMocks.disposeSshSandboxSession).toHaveBeenCalledOnce();
+    },
+  );
+
   it("creates a remote-canonical backend that seeds once and reuses ssh exec", async () => {
     sshMocks.runSshSandboxCommand
       .mockResolvedValueOnce({

--- a/src/agents/sandbox/ssh-backend.ts
+++ b/src/agents/sandbox/ssh-backend.ts
@@ -108,7 +108,7 @@ export const sshSandboxBackendManager: SandboxBackendManager = {
       target: cfg.ssh.target,
     });
     try {
-      await runSshSandboxCommand({
+      const result = await runSshSandboxCommand({
         session,
         remoteCommand: buildRemoteCommand([
           "/bin/sh",
@@ -119,6 +119,10 @@ export const sshSandboxBackendManager: SandboxBackendManager = {
         ]),
         allowFailure: true,
       });
+      if (result.code !== 0) {
+        const detail = result.stderr.toString("utf8").trim() || `exit ${result.code}`;
+        throw new Error(`Failed to remove SSH sandbox runtime ${entry.containerName}: ${detail}`);
+      }
     } finally {
       await disposeSshSandboxSession(session);
     }

--- a/src/gateway/server-methods/agent.test-harness.ts
+++ b/src/gateway/server-methods/agent.test-harness.ts
@@ -1073,6 +1073,8 @@ export const describe0AfterEach0 = () => {
   resetAgentTaskRegistryForTests();
   resetSubagentRegistryForTests({ persist: false });
   applyGatewaySubagentRegistryTestDeps();
+  mocks.agentCommand.mockReset();
+  mocks.updateSessionStore.mockReset().mockResolvedValue(undefined);
   mocks.loadConfigReturn = {};
   mocks.emitGatewaySessionEndPluginHook.mockReset();
   mocks.emitGatewaySessionStartPluginHook.mockReset();

--- a/test/e2e/qa-lab/runtime/channel-health-monitor-lifecycle-runtime.ts
+++ b/test/e2e/qa-lab/runtime/channel-health-monitor-lifecycle-runtime.ts
@@ -152,6 +152,7 @@ export async function runChannelHealthMonitorLifecycleProof(): Promise<MonitorPr
 
     const operations: string[] = [];
     let snapshotCalls = 0;
+    let firstSnapshotAt: number | undefined;
     let activeSnapshots = 0;
     let maxActiveSnapshots = 0;
     let failNextSnapshot = true;
@@ -166,6 +167,7 @@ export async function runChannelHealthMonitorLifecycleProof(): Promise<MonitorPr
     const manager = {
       getRuntimeSnapshot() {
         snapshotCalls += 1;
+        firstSnapshotAt ??= Date.now();
         activeSnapshots += 1;
         maxActiveSnapshots = Math.max(maxActiveSnapshots, activeSnapshots);
         try {
@@ -204,21 +206,23 @@ export async function runChannelHealthMonitorLifecycleProof(): Promise<MonitorPr
       isAutoRestartScheduled: () => false,
     } as unknown as ChannelManager;
 
+    const monitorStartupGraceMs = 250;
+    const monitorStartedAt = Date.now();
     const monitor = startChannelHealthMonitor({
       channelManager: manager,
       checkIntervalMs: 20,
       cooldownCycles: 2,
       maxRestartsPerHour: 1,
       timing: {
-        monitorStartupGraceMs: 250,
+        monitorStartupGraceMs,
         channelConnectGraceMs: 0,
         staleEventThresholdMs: 100,
       },
     });
 
-    await sleep(40);
-    const graceRespected = snapshotCalls === 0;
     await waitFor(() => operations.includes("start:qa-channel:monitored"), "first restart");
+    const graceRespected =
+      firstSnapshotAt !== undefined && firstSnapshotAt - monitorStartedAt >= monitorStartupGraceMs;
     await waitFor(() => snapshotCalls >= 3, "settled rearm");
     const callsAfterRecovery = snapshotCalls;
     await sleep(55);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using OpenShell sandboxes could lose track of failed deletions, see stopped sandboxes reported as healthy, accidentally recreate sandboxes after gateway or authentication failures, and experience broken nested workspace synchronization or unsafe local metadata exposure.

## Why This Change Was Made

Keep sandbox lifecycle authority with the backend and retain registry ownership until remote deletion actually succeeds. Consume OpenShell's real readiness, missing-sandbox, and upload contracts; reject escaping remote workspace roots while preserving previously shipped root layouts; exclude Git metadata and hooks in both synchronization directions; and apply the same deletion invariant to the SSH backend.

## User Impact

OpenShell operators can reliably create, inspect, synchronize, and remove isolated sandboxes across custom gateway workspaces and remote directories. The updated setup, policy, security, image, lifecycle, and troubleshooting documentation now matches the live integration.

## Evidence

- Reproduced the original OpenShell owner failures and generic/SSH lifecycle failures with regression tests before applying the fixes.
- Preserved the shipped overlapping-root configuration contract from stable releases `v2026.6.34` and `v2026.7.1`; all three equal, parent, and child root layouts first failed and now pass an owner-boundary upgrade regression. New configurations are guided toward non-overlapping roots without silently rewriting existing remote data.
- Focused owner and sibling suites: eight files, 125 passing tests.
- A required remote gateway shard exposed pre-existing cross-test leakage in its shared owner harness. Resetting both the agent-command mock and session-store mock at the existing lifecycle boundary takes the original failure from 153 cascading CI failures to all 284 gateway-agent tests passing locally.
- Current `main` independently landed both the dedicated Gateway methods-isolation project and the hosted shard ownership repair. This PR is rebased on those canonical changes, preserving all 284 hosted handler tests without duplicating either project or changing runner capacity; the canonical planner and project-ownership regressions pass.
- A separate required QA shard exposed a scheduler-sensitive channel-health proof. Replacing its sleep-based startup-grace inference with the timestamp of the first actual health snapshot passes the QA proof and all 54 adjacent channel-health policy tests without increasing timeouts.
- Full repository changed-code validation: `node scripts/check-changed.mjs` passed, including typechecks, lint, plugin boundaries, metadata, database-first guards, and security checks.
- Real OpenShell gateway integration: `pnpm test:e2e:openshell` passed four live tests twice, covering remote execution, custom control-plane workspaces, nested mirrored directories, protected metadata exclusion, runtime readiness, and both denied and allowed network policies.
- The real run exposed an OrbStack host-gateway address mismatch; the live harness now resolves the exact `host.openshell.internal` address on the OpenShell Docker network.
- Documentation lint, MDX parsing, formatting, glossary validation, all 6,570 internal links, and all 1,193 configuration examples passed.
- Direct upstream source confirms the [sandbox JSON phase field](https://github.com/NVIDIA/OpenShell/blob/88cf35efe426024eb19fdc403f594a1602f44d49/crates/openshell-cli/src/run.rs#L2095-L2111), [file-versus-directory upload semantics](https://github.com/NVIDIA/OpenShell/blob/88cf35efe426024eb19fdc403f594a1602f44d49/crates/openshell-cli/src/ssh.rs#L1003-L1045), and [missing-sandbox error](https://github.com/NVIDIA/OpenShell/blob/88cf35efe426024eb19fdc403f594a1602f44d49/crates/openshell-server/src/grpc/sandbox.rs#L115-L137); live tests independently exercised all three contracts.
- Production code: +71/-20 lines (net +51), justified by explicit deletion ownership, readiness and dependency-contract validation, and path-containment security. Regression, live tests, and test-only support: +450/-33 lines.
- ClawSweeper rank-up disposition: the breaking overlap validation was removed and stable-release compatibility is covered; upstream contracts were checked directly and live-tested; the root changelog remains untouched because native PR preparation reserves it for release automation, while the user-visible release-note context is preserved in this PR body.
