### PR TITLE
docs(plugins): CLI backend example fails to compile after installation

### DIFF
--- a/docs/plugins/cli-backend-plugins.md
+++ b/docs/plugins/cli-backend-plugins.md
@@ -108,10 +108,9 @@ runtime behavior. Runtime behavior starts when the plugin entry calls
 
   <Step title="Register the backend">
     ```typescript index.ts
-    import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-    import type { CliBackendPlugin } from "openclaw/plugin-sdk/cli-backend";
+    import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 
-    function buildAcmeCliBackend(): CliBackendPlugin {
+    function buildAcmeCliBackend(): Parameters<OpenClawPluginApi["registerCliBackend"]>[0] {
       return {
         id: "acme-cli",
         liveTest: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers following the documented CLI backend plugin example received a TypeScript `TS7016` error because the example imported a private SDK entrypoint that is not included in installed npm packages.

## Why This Change Was Made

The complete documented example now derives the backend type directly from the existing public plugin registration API and imports both required symbols from the already supported public SDK entrypoint. No runtime code, SDK exports, configuration, or package contents change; the example becomes one line shorter.

## User Impact

Developers can copy the official CLI backend plugin example and compile it successfully against an actual installed OpenClaw package.

## Evidence

- The exact complete documented example failed with `TS7016` against a real offline-packed and installed npm tarball before the change.
- The same installed tarball and complete corrected documentation example now compile successfully under strict TypeScript settings.
- MDX validation, formatting, all 6,569 internal documentation links, and independent structured review pass.
