### PR TITLE
fix(browser): cancelled tab creation leaves orphan browser tabs

### DIFF
--- a/extensions/browser/src/browser/server-context.remote-profile-tab-ops.fallback.test.ts
+++ b/extensions/browser/src/browser/server-context.remote-profile-tab-ops.fallback.test.ts
@@ -389,6 +389,41 @@ describe("browser remote profile fallback and attachOnly behavior", () => {
     });
   });
 
+  it.each([
+    { method: "PUT", retryWithGet: false },
+    { method: "GET", retryWithGet: true },
+  ])("cancels pending /json/new $method tab creation with the caller", async ({ retryWithGet }) => {
+    vi.spyOn(deps.pwAiModule, "getPwAiModule").mockResolvedValue(null);
+    vi.spyOn(deps.cdpModule, "createTargetViaCdp").mockRejectedValue(
+      new Error("Target.createTarget unavailable"),
+    );
+
+    const controller = new AbortController();
+    let requestStarted!: () => void;
+    const pendingRequest = new Promise<void>((resolve) => {
+      requestStarted = resolve;
+    });
+    const fetchMock = vi.fn(async (...args: unknown[]) => {
+      const init = args[1] as RequestInit | undefined;
+      if (retryWithGet && init?.method === "PUT") {
+        return new Response(null, { status: 405 });
+      }
+      requestStarted();
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    });
+    const { state, remote } = deps.createRemoteRouteHarness(fetchMock);
+    state.resolved.remoteCdpTimeoutMs = 250;
+
+    const opening = remote.openTab("https://example.com", { signal: controller.signal });
+    await pendingRequest;
+    controller.abort(new Error("caller cancelled pending tab creation"));
+
+    await expect(opening).rejects.toThrow("caller cancelled pending tab creation");
+    expect(fetchMock).toHaveBeenCalledTimes(retryWithGet ? 2 : 1);
+  });
+
   it("uses the remote HTTP timeout for /json/new fallback tab opens", async () => {
     vi.spyOn(deps.pwAiModule, "getPwAiModule").mockResolvedValue(null);
     vi.spyOn(deps.cdpModule, "createTargetViaCdp").mockRejectedValue(

--- a/extensions/browser/src/browser/server-context.remote-profile-tab-ops.fallback.test.ts
+++ b/extensions/browser/src/browser/server-context.remote-profile-tab-ops.fallback.test.ts
@@ -410,7 +410,14 @@ describe("browser remote profile fallback and attachOnly behavior", () => {
       }
       requestStarted();
       return await new Promise<Response>((_resolve, reject) => {
-        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+        init?.signal?.addEventListener(
+          "abort",
+          () => {
+            const reason = init.signal?.reason;
+            reject(reason instanceof Error ? reason : new Error(String(reason)));
+          },
+          { once: true },
+        );
       });
     });
     const { state, remote } = deps.createRemoteRouteHarness(fetchMock);

--- a/extensions/browser/src/browser/server-context.tab-ops.ts
+++ b/extensions/browser/src/browser/server-context.tab-ops.ts
@@ -420,16 +420,14 @@ export function createProfileTabOps({ profile, state, runtime }: TabOpsDeps): Pr
     const created = await fetchJson<CdpTarget>(
       endpoint,
       cdpActionTimeouts?.httpTimeoutMs ?? CDP_JSON_NEW_TIMEOUT_MS,
-      {
-        method: "PUT",
-      },
+      { method: "PUT", signal: opts?.signal },
       getCdpControlPolicy(),
     ).catch(async (err: unknown) => {
       if (String(err).includes("HTTP 405")) {
         return await fetchJson<CdpTarget>(
           endpoint,
           cdpActionTimeouts?.httpTimeoutMs ?? CDP_JSON_NEW_TIMEOUT_MS,
-          undefined,
+          { signal: opts?.signal },
           getCdpControlPolicy(),
         );
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where canceling remote browser tab creation left the request running and created an orphaned tab after the owning operation had already stopped. Both the normal CDP PUT request and HTTP 405 GET fallback were affected.

## Why This Change Was Made

The existing browser tab-creation owner now forwards its already available lifecycle cancellation signal through both CDP request paths. Existing timeout behavior, retry semantics, guarded transport, and browser ownership remain unchanged. Production code decreases by two lines.

## User Impact

Canceled browser operations stop immediately and do not create unexpected tabs after cancellation.

## Evidence

- Two real owner regressions failed before repair for PUT and 405-to-GET fallback.
- Actual isolated localhost CDP requests previously created orphan tabs after cancellation; repaired PUT/GET requests stop in 7 ms/3 ms respectively with zero orphaned tabs.
- All 99 browser tab-owner, CDP helper, and CDP sibling tests pass.
- Focused lint, formatting, and independent complete-diff structured review pass.
