### PR TITLE
fix(heartbeat): legitimate scheduled reminders silently disappear

### DIFF
--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -155,6 +155,8 @@ describe("heartbeat event classification", () => {
     { value: "heartbeat_ok: already handled", expected: false },
     { value: "heartbeat poll: noop", expected: false },
     { value: "heartbeat wake: noop", expected: false },
+    { value: "Cron: investigate heartbeat wake failures", expected: true },
+    { value: "Reminder: review heartbeat poll results", expected: true },
     { value: "exec finished: ok", expected: false },
     { value: "Exec finished (node=abc, code 0)", expected: false },
     { value: "Exec completed (abc12345, code 0)", expected: false },

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -196,8 +196,8 @@ function isHeartbeatNoiseEvent(evt: string): boolean {
   }
   return (
     isHeartbeatAckEvent(lower) ||
-    lower.includes("heartbeat poll") ||
-    lower.includes("heartbeat wake")
+    lower.startsWith("heartbeat poll") ||
+    lower.startsWith("heartbeat wake")
   );
 }
 

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -312,16 +312,26 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(sendTelegram).toHaveBeenCalled();
   });
 
-  it("uses CRON_EVENT_PROMPT when an actionable cron event exists", async () => {
-    const { result, sendTelegram, calledCtx } = await runCronReminderCase(
-      "openclaw-cron-",
-      (sessionKey) => {
-        enqueueSystemEvent("Reminder: Check Base Scout results", { sessionKey });
+  it.each([
+    "Reminder: Check Base Scout results",
+    "Reminder: investigate heartbeat wake failures",
+    "Reminder: review heartbeat poll results",
+  ])("uses CRON_EVENT_PROMPT for actionable cron events: %s", async (reminder) => {
+    const { result, sendTelegram, calledCtx, sessionKey } = await runHeartbeatCase({
+      tmpPrefix: "openclaw-cron-",
+      replyText: "Relay this reminder now",
+      reason: "cron:reminder-job",
+      enqueue: (key) => {
+        enqueueSystemEvent(reminder, { sessionKey: key, contextKey: "cron:reminder-job" });
       },
-    );
+    });
+
     expect(result.status).toBe("ran");
-    expectCronEventPrompt(calledCtx, "Reminder: Check Base Scout results");
-    expect(sendTelegram).toHaveBeenCalled();
+    expect(calledCtx?.Provider).toBe("cron-event");
+    expect(calledCtx?.Body).toContain("scheduled reminder has been triggered");
+    expect(calledCtx?.Body).toContain(reminder);
+    expect(sendTelegram).toHaveBeenCalledOnce();
+    expect(peekSystemEvents(sessionKey)).toEqual([]);
   });
 
   it("runs the tagged cron payload outside heartbeat active hours", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where legitimate reminders such as "investigate heartbeat wake failures" or "review heartbeat poll results" silently disappeared. The heartbeat classified the reminder as internal noise, omitted it from the agent prompt, and permanently consumed it.

## Why This Change Was Made

The existing heartbeat event owner now recognizes actual internal heartbeat noise by its leading event phrase instead of matching those words anywhere inside an unrelated user-authored reminder. Genuine internal poll/wake events, existing acknowledgment handling, and neighboring execution-event policy remain unchanged. Production code remains net neutral.

## User Impact

Scheduled reminders containing normal discussion of heartbeat polling or wake failures now reach the agent and their intended conversation instead of being silently deleted.

## Evidence

- Authentic pre-fix classifier and actual heartbeat prompt/delivery regressions both failed for each legitimate reminder phrase while ordinary reminders remained correct.
- All 133 event-classifier, real heartbeat reminder, and neighboring system-event tests pass.
- Real owner verification confirms both reminders remain in the agent prompt while genuine leading heartbeat-noise events remain excluded.
- Type-aware lint, formatting, and independent complete-diff structured review pass.
