### PR TITLE
fix(plugins): surface invalid background and discovery services

### DIFF
--- a/src/plugins/registry-registrars-operations.ts
+++ b/src/plugins/registry-registrars-operations.ts
@@ -366,23 +366,34 @@ export function createOperationRegistrars(state: PluginRegistryState) {
     });
   };
 
-  const registerService = (record: PluginRecord, service: OpenClawPluginService) => {
+  const resolveServiceRegistrationId = (
+    record: PluginRecord,
+    service: { id: string },
+    kind: "service" | "gateway discovery service",
+  ) => {
     const id = service.id.trim();
-    if (!id) {
-      return;
+    const registrations =
+      kind === "service" ? registry.services : registry.gatewayDiscoveryServices;
+    const existing = id ? registrations.find((entry) => entry.service.id.trim() === id) : undefined;
+    if (id && !existing) {
+      return id;
     }
-    const existing = registry.services.find((entry) => entry.service.id.trim() === id);
-    if (existing) {
-      // Snapshot and activating loads can both register the same owner; keep the first.
-      if (existing.pluginId === record.id) {
-        return;
-      }
+    // Snapshot and activating loads can both register the same owner; keep the first.
+    if (existing?.pluginId !== record.id) {
       pushDiagnostic({
         level: "error",
         pluginId: record.id,
         source: record.source,
-        message: `service already registered: ${id} (${existing.pluginId})`,
+        message: existing
+          ? `${kind} already registered: ${id} (${existing.pluginId})`
+          : `${kind} registration missing id`,
       });
+    }
+  };
+
+  const registerService = (record: PluginRecord, service: OpenClawPluginService) => {
+    const id = resolveServiceRegistrationId(record, service, "service");
+    if (!id) {
       return;
     }
     record.services.push(id);
@@ -401,21 +412,8 @@ export function createOperationRegistrars(state: PluginRegistryState) {
     record: PluginRecord,
     service: OpenClawGatewayDiscoveryService,
   ) => {
-    const id = service.id.trim();
+    const id = resolveServiceRegistrationId(record, service, "gateway discovery service");
     if (!id) {
-      return;
-    }
-    const existing = registry.gatewayDiscoveryServices.find((row) => row.service.id.trim() === id);
-    if (existing) {
-      if (existing.pluginId === record.id) {
-        return;
-      }
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `gateway discovery service already registered: ${id} (${existing.pluginId})`,
-      });
       return;
     }
     record.gatewayDiscoveryServiceIds.push(id);

--- a/src/plugins/registry-registrars-operations.ts
+++ b/src/plugins/registry-registrars-operations.ts
@@ -389,6 +389,7 @@ export function createOperationRegistrars(state: PluginRegistryState) {
           : `${kind} registration missing id`,
       });
     }
+    return undefined;
   };
 
   const registerService = (record: PluginRecord, service: OpenClawPluginService) => {

--- a/src/plugins/registry.service-registration.test.ts
+++ b/src/plugins/registry.service-registration.test.ts
@@ -43,6 +43,51 @@ function createRegistrationFixture() {
 
 describe("plugin service registration identity", () => {
   it.each([
+    { surface: "service", id: "" },
+    { surface: "service", id: "   " },
+    { surface: "service", id: "\t\n" },
+    { surface: "discovery", id: "" },
+    { surface: "discovery", id: "   " },
+    { surface: "discovery", id: "\t\n" },
+  ] as const)("reports a blank $surface service id ($id)", async ({ surface, id }) => {
+    const { builder, createRecord } = createRegistrationFixture();
+    const record = createRecord("invalid-service-owner");
+    const api = builder.createApi(record, { config: {} });
+    const service = new ClassBackedLifecycleService(id);
+
+    if (surface === "service") {
+      api.registerService(service);
+    } else {
+      api.registerGatewayDiscoveryService(service);
+    }
+
+    const registrations =
+      surface === "service" ? builder.registry.services : builder.registry.gatewayDiscoveryServices;
+    const recordIds = surface === "service" ? record.services : record.gatewayDiscoveryServiceIds;
+    expect(registrations).toEqual([]);
+    expect(recordIds).toEqual([]);
+    expect(builder.registry.diagnostics).toEqual([
+      {
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message:
+          surface === "service"
+            ? "service registration missing id"
+            : "gateway discovery service registration missing id",
+      },
+    ]);
+
+    if (surface === "service") {
+      const handle = await startPluginServices({ registry: builder.registry, config: {} });
+      expect(service.starts).toBe(0);
+      await handle.stop();
+    } else {
+      expect(service.advertisements).toBe(0);
+    }
+  });
+
+  it.each([
     { surface: "service", sameOwner: false, paddedFirst: true },
     { surface: "service", sameOwner: false, paddedFirst: false },
     { surface: "service", sameOwner: true, paddedFirst: true },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing a plugin with a blank or whitespace-only background-service or Gateway-discovery service identifier would see a healthy loaded plugin even though its service never started and its Gateway was never advertised.

## Why This Change Was Made

Both service-registration surfaces duplicated identifier admission and silently discarded malformed identifiers before the existing plugin diagnostic owner could record the failure. Consolidate trimming, same-owner idempotence, and cross-owner collision handling into one private registration owner that also reports malformed identifiers through the canonical plugin diagnostics path.

## User Impact

Plugin inspection and plugin doctor now expose actionable, owner-attributed errors for invalid background-service and Gateway-discovery registrations. Valid services retain their original object identity, lifecycle, trust metadata, independent namespaces, and duplicate-registration behavior.

## Evidence

- Regression-first proof: six real owner-boundary cases initially failed because empty, spaces-only, and tab/newline-only identifiers produced zero diagnostics across both registration surfaces; all eight existing duplicate/idempotence/class-identity scenarios already passed.
- After the canonical owner repair, **43 tests passed** across plugin service registration, service lifecycle, and service replacement.
- Existing same-owner no-op, exact cross-owner error wording, original class-backed service instances, namespace separation, and background-service metadata are preserved.
- Production code: **+22/-24, net -2 lines**. Focused regression tests: **+45**.
- Targeted formatting, diff validation, max-lines ratchet, and assertion-safety ratchet all passed.
- Independent owner-boundary review and fresh authenticated Codex autoreview both returned zero actionable findings.
- A broader package-snapshot suite assumes checkout-local node_modules; it is not a valid proof in this linked checkout, so the change is verified through the canonical registration and service-lifecycle owners plus exact-head CI.
