### PR TITLE
perf: stop provider policy loads from compiling the transport graph

### DIFF
--- a/extensions/amazon-bedrock/provider-policy-api.ts
+++ b/extensions/amazon-bedrock/provider-policy-api.ts
@@ -2,7 +2,7 @@
  * Provider-policy API for Amazon Bedrock. Core asks this plugin for thinking
  * profiles without importing provider registration or streaming code.
  */
-import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { resolveBedrockClaudeThinkingProfile } from "./thinking-policy.js";
 
 /** Resolve the Bedrock thinking profile for a provider/model pair. */

--- a/extensions/anthropic-vertex/provider-policy-api.ts
+++ b/extensions/anthropic-vertex/provider-policy-api.ts
@@ -2,7 +2,7 @@
  * Provider-policy API for Anthropic Vertex. Core asks for thinking profiles
  * without importing the provider entry or stream runtime.
  */
-import { resolveClaudeThinkingProfile } from "openclaw/plugin-sdk/provider-model-shared";
+import { resolveClaudeThinkingProfile } from "openclaw/plugin-sdk/claude-model-runtime";
 
 /** Resolve Anthropic Vertex thinking profile for a provider/model pair. */
 export function resolveThinkingProfile(params: {

--- a/extensions/anthropic/provider-policy-api.ts
+++ b/extensions/anthropic/provider-policy-api.ts
@@ -6,7 +6,7 @@ import {
   resolveClaudeModelIdentity,
   resolveClaudeMythos5ModelIdentity,
   resolveClaudeThinkingProfile,
-} from "openclaw/plugin-sdk/provider-model-shared";
+} from "openclaw/plugin-sdk/claude-model-runtime";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { CLAUDE_CLI_OFF_THINKING_PROFILE, CLAUDE_CLI_PROFILE_ID } from "./cli-constants.js";
 import {

--- a/extensions/ollama/provider-policy-api.ts
+++ b/extensions/ollama/provider-policy-api.ts
@@ -1,10 +1,11 @@
+import { isCloudModelRef } from "@openclaw/model-catalog-core/model-catalog-refs";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 // Ollama API module exposes the plugin public contract.
 import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderNormalizeResolvedModelContext,
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { isCloudModelRef, normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { OLLAMA_CLOUD_PROVIDER_ID, OLLAMA_DEFAULT_BASE_URL } from "./src/defaults.js";
 import { supportsOllamaCloudFullThinkingEffort } from "./src/model-reasoning.js";

--- a/extensions/opencode/provider-policy-api.ts
+++ b/extensions/opencode/provider-policy-api.ts
@@ -1,9 +1,9 @@
+import { resolveClaudeThinkingProfile } from "openclaw/plugin-sdk/claude-model-runtime";
 // Opencode API module exposes the plugin public contract.
 import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { resolveClaudeThinkingProfile } from "openclaw/plugin-sdk/provider-model-shared";
 
 const FIXED_REASONING_PROFILE = {
   levels: [{ id: "off", label: "always on" }],

--- a/extensions/tsconfig.package-boundary.paths.json
+++ b/extensions/tsconfig.package-boundary.paths.json
@@ -134,6 +134,9 @@
       "openclaw/plugin-sdk/cli-backend": [
         "../packages/plugin-sdk/dist/src/plugin-sdk/cli-backend.d.ts"
       ],
+      "openclaw/plugin-sdk/claude-model-runtime": [
+        "../packages/plugin-sdk/dist/src/plugin-sdk/claude-model-runtime.d.ts"
+      ],
       "openclaw/plugin-sdk/codex-mcp-projection": [
         "../packages/plugin-sdk/dist/src/plugin-sdk/codex-mcp-projection.d.ts"
       ],

--- a/extensions/xai/tsconfig.json
+++ b/extensions/xai/tsconfig.json
@@ -128,6 +128,9 @@
       "openclaw/plugin-sdk/cli-backend": [
         "../../packages/plugin-sdk/dist/src/plugin-sdk/cli-backend.d.ts"
       ],
+      "openclaw/plugin-sdk/claude-model-runtime": [
+        "../../packages/plugin-sdk/dist/src/plugin-sdk/claude-model-runtime.d.ts"
+      ],
       "openclaw/plugin-sdk/codex-mcp-projection": [
         "../../packages/plugin-sdk/dist/src/plugin-sdk/codex-mcp-projection.d.ts"
       ],

--- a/package.json
+++ b/package.json
@@ -791,6 +791,9 @@
     "./plugin-sdk/cli-backend": {
       "default": "./dist/plugin-sdk/cli-backend.js"
     },
+    "./plugin-sdk/claude-model-runtime": {
+      "default": "./dist/plugin-sdk/claude-model-runtime.js"
+    },
     "./plugin-sdk/codex-mcp-projection": {
       "default": "./dist/plugin-sdk/codex-mcp-projection.js"
     },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "!dist/plugin-sdk/channel-test-helpers.d.ts",
     "!dist/plugin-sdk/chat-channel-ids.d.ts",
     "!dist/plugin-sdk/cli-backend.d.ts",
+    "!dist/plugin-sdk/claude-model-runtime.d.ts",
     "!dist/plugin-sdk/cli-runtime.d.ts",
     "!dist/plugin-sdk/codex-mcp-projection.d.ts",
     "!dist/plugin-sdk/codex-session-transcript-runtime.d.ts",

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -111,6 +111,7 @@
   "cli-argv",
   "cli-runtime",
   "cli-backend",
+  "claude-model-runtime",
   "codex-mcp-projection",
   "native-hook-relay-runtime",
   "codex-session-transcript-runtime",

--- a/scripts/lib/plugin-sdk-private-local-only-subpaths.json
+++ b/scripts/lib/plugin-sdk-private-local-only-subpaths.json
@@ -28,6 +28,7 @@
   "channel-targets",
   "channel-test-helpers",
   "chat-channel-ids",
+  "claude-model-runtime",
   "cli-backend",
   "cli-runtime",
   "codex-mcp-projection",

--- a/src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts
+++ b/src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { listAgentIds } from "../agent-scope-config.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
@@ -10,7 +10,7 @@ import {
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
   resetSharedRunIntegrationHarnessMocks,
-  warmRunOverflowCompactionHarness,
+  useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
 
 const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
@@ -29,11 +29,12 @@ function projectSetupExecutionConfig(source: OpenClawConfig): OpenClawConfig {
 }
 
 describe("embedded setup inference inherited auth owner", () => {
-  beforeAll(async () => {
-    await warmRunOverflowCompactionHarness(runEmbeddedAgent);
+  // Provider-pinned runs stay on the mocked plugin harness, so no host-route
+  // warmup is needed here; see overflowBaseRunParams for the route trap.
+  beforeEach(() => {
+    resetSharedRunIntegrationHarnessMocks();
+    useOpenAIPlatformAuthFixture();
   });
-
-  beforeEach(resetSharedRunIntegrationHarnessMocks);
 
   it.each([
     { name: "a pre-roster config", source: {} },
@@ -49,6 +50,11 @@ describe("embedded setup inference inherited auth owner", () => {
 
       await runEmbeddedAgent({
         ...overflowBaseRunParams,
+        // Auth-owner resolution is provider-agnostic. Route through the mocked
+        // plugin harness so this shard does not compile the bundled Anthropic
+        // provider policy from source just to assert an agent directory.
+        provider: "openai",
+        model: "gpt-5.6-luna",
         agentId: "main",
         config,
         runId: `run-setup-inference-owner-${name}`,

--- a/src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts
+++ b/src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts
@@ -66,6 +66,11 @@ describe("embedded setup inference inherited auth owner", () => {
         value.endsWith(path.join("agents", "main", "agent")),
       );
       expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
+      // A silent fall-back to the built-in host harness would still pass the
+      // auth-owner assertions; fail loudly on the route instead.
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
+        expect.objectContaining({ agentHarnessId: "codex" }),
+      );
     },
   );
 });

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -442,6 +442,10 @@ const mockedHasUsableCustomProviderApiKey = vi.fn(() => false);
 const mockedMarkAuthProfileSuccess = vi.fn(async () => {});
 const mockedShouldPreferExplicitConfigApiKeyAuth = vi.fn(() => false);
 
+// No provider here means model resolution defaults to anthropic/test-model, which
+// the mocked codex harness does not claim: such runs select the built-in openclaw
+// host harness and pay its one-time source-compile cost. Suites proving plugin
+// harness behavior must pin provider "openai" (see run.session-permissions.test.ts).
 export const overflowBaseRunParams = {
   agentId: "main",
   sessionId: "test-session",

--- a/src/plugin-sdk/claude-model-runtime.ts
+++ b/src/plugin-sdk/claude-model-runtime.ts
@@ -1,0 +1,11 @@
+/**
+ * Claude model-family policy helpers for provider policy artifacts.
+ *
+ * Provider policy artifacts (`provider-policy-api.js`) load eagerly whenever a
+ * provider is resolved, so their module graph must stay leaf-light. This
+ * subpath re-exports the Claude identity and thinking helpers from their leaf
+ * owners; importing them through `provider-model-shared` drags the transport
+ * and compat graph into every policy load (~60s under jiti in source checkouts).
+ */
+export { resolveClaudeModelIdentity, resolveClaudeMythos5ModelIdentity } from "@openclaw/llm-core";
+export { resolveClaudeThinkingProfile } from "../plugins/provider-claude-thinking.js";


### PR DESCRIPTION
Related: #129582

## What Problem This Solves

Resolves a problem where resolving a provider from a source checkout could stall the event loop for over a minute. Provider policy artifacts (`provider-policy-api.js`) load eagerly whenever a provider is resolved, but five of them imported the `provider-model-shared` barrel at runtime, dragging the transports/compat/state graph into every policy load. In contexts without a native TS require hook (Vitest workers, non-tsx source runs) jiti compiled that entire graph: ~65 s of event-loop starvation on the first embedded run. That cost is what pushed `run.session-permissions.test.ts` past its 120 s timeout before #129582, and it still taxed every suite touching the built-in host harness route (`run.shared-integration.test.ts` spent 167 s largely warming it).

## Why This Change Was Made

The policy artifact's own contract says "lightweight," and the plugin-SDK guide forbids exactly this shape ("do not route a lightweight contract file back through heavier policy or runtime modules"). The helpers the artifacts actually need live in leaf modules already: the Claude identity/thinking helpers in `@openclaw/llm-core` and `src/plugins/provider-claude-thinking.ts` (a deliberately dependency-light leaf), and the id/ref helpers in `@openclaw/model-catalog-core` leaves that are already plugin-visible.

This adds `openclaw/plugin-sdk/claude-model-runtime` — a narrow, family-level, **local-only** subpath (zero public-API growth; it carries a helper marked `@deprecated` for third parties, so local-only is also semantically required) re-exporting those three Claude helpers from their leaf owners. The `anthropic`, `anthropic-vertex`, and `opencode` policy artifacts switch to it; `amazon-bedrock` and `ollama` switch to the `@openclaw/model-catalog-core` leaves (precedent: `extensions/ollama/index.ts`). The barrel keeps re-exporting the same symbols, so no existing consumer changes. jiti itself remains, correctly, for its one real job: loading external plugins that ship TS without a build step; production dist never touches it for bundled plugins.

Test-side, `run.inherited-auth-owner.test.ts` pins the mocked plugin-harness route (its assertions are provider-agnostic), superseding the host-route warmup #129528 added there, and `overflowBaseRunParams` now documents the no-provider default-route trap.

## User Impact

Developers and CI stop paying a ~65 s one-time stall on the first embedded run in source checkouts. `run.shared-integration.test.ts` drops from 167 s to 65 s; `run.inherited-auth-owner.test.ts` from 46 s to sub-second test time. No runtime behavior changes: dist output for the policy artifacts resolves the same functions through leaf chunks (verified in the built artifact), and the public plugin-SDK API surface is unchanged.

## Evidence

CPU profile (`--cpu-prof`, Vitest worker, default-params embedded run) before: jiti 23.4 s self, `statSync` 18.6 s, babel 7.6 s — call path `plugin-module-loader-cache → jiti → extensions/anthropic/provider-policy-api.ts → plugin-sdk/provider-model-shared → provider-model-compat → transports`. After: jiti 1.3 s, `statSync` 0.7 s.

Measured first/second run on the host route: `firstMs=65540 / secondMs=248` before → `firstMs=6627 / secondMs=169` after (residual is Vitest worker overhead, not module compile).

Gates: `plugin-sdk:sync-exports` and `plugin-sdk:surface:check` green (no public entrypoint/export growth — the subpath is local-only); harness family green on the rebased head; policy artifact suites 13 files / 260 tests green; `pnpm build` green with zero `[INEFFECTIVE_DYNAMIC_IMPORT]` and `dist/plugin-sdk/claude-model-runtime.js` importing only leaf chunks; `check-changed` over all touched files exit 0; fresh Codex autoreview clean.

Production LOC: +24/-5 (new re-export facade + registry/exports entries, all declarative, justified by the module-boundary contract) | Tests: +15/-2
