### PR TITLE
refactor(canvas): share HTML escaping

### DIFF
--- a/src/canvas/documents.ts
+++ b/src/canvas/documents.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { sanitizeUntrustedFileName } from "../infra/fs-safe-advanced.js";
 import { root as fsRoot } from "../infra/fs-safe.js";
+import { escapeHtml } from "../shared/html-escape.js";
 import { resolveUserPath } from "../utils.js";
 import { CANVAS_DOCUMENTS_PATH } from "./constants.js";
 
@@ -51,15 +52,6 @@ export type CanvasDocumentManifest = {
     contentType?: string;
   }>;
 };
-
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
 
 function isPdfPathLike(value: string): boolean {
   return /\.pdf(?:[?#].*)?$/i.test(value.trim());

--- a/src/canvas/wrap.ts
+++ b/src/canvas/wrap.ts
@@ -1,11 +1,4 @@
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
+import { escapeHtml } from "../shared/html-escape.js";
 
 const WIDGET_THEME_TOKENS = [
   "surface",


### PR DESCRIPTION
## What Problem This Solves

Canvas document and widget rendering each carried a private copy of the same five-character HTML escaping policy already owned by the shared text utility. Keeping three byte-identical implementations created unnecessary drift risk at a browser-sensitive boundary.

## Why This Change Was Made

Routes both Canvas call sites through the existing dependency-free `src/shared/html-escape.ts` owner and deletes only the two local copies. The function bodies and replacement order were verified byte-for-byte identical; no escaping policy, DOM structure, rendering order, or public API changes.

Alternatives rejected: adding a Canvas-specific facade would preserve rather than remove the duplicate owner; changing escaping policy or broadening helper behavior is outside this behavior-preserving cleanup.

## User Impact

No user-visible change. Canvas PDF/media wrappers and widget titles produce the same bytes as before.

Production LOC: +2/-17 (net -15) | Tests: +0/-0

## Evidence

Exact head: `7928d77e6da047a4a9180eba549284d55c771359`

- `node scripts/run-vitest.mjs src/canvas/documents.test.ts src/canvas/wrap.test.ts src/plugin-sdk/text-utility-runtime.test.ts` — 12/12 passed across two Vitest shards.
- `node scripts/check-changed.mjs` — passed core/core-tests typecheck, formatting, lint, dead-export, import-cycle, and repository guard lanes.
- Existing widget byte-stability assertion remained unchanged: 15,592 bytes, SHA-256 `30ea7be77ec728493e29996b32e1dd7c31322814087352459c0849d45fb4663e`.
- Canonical helper coverage verifies all five HTML-sensitive characters and existing entity markers; Canvas inputs are required strings, so no nullish contract changed.
- Deslop: clean, no edits.
- Structured autoreview: clean, no accepted/actionable findings.
- Separate exact-head Codex review: PASS, no blockers; sibling Codex inspection found no protocol/runtime coupling to this Canvas-only helper.
- Exact-head GitHub CI: pending.
