### PR TITLE
fix(ui): show channel configuration save errors inside the editor

### DIFF
--- a/src/gateway/server-methods/agent.base.test-utils.ts
+++ b/src/gateway/server-methods/agent.base.test-utils.ts
@@ -1491,13 +1491,7 @@ describe("gateway agent handler", () => {
       vi.useFakeTimers({ toFake: ["Date"] });
       setDateOnlyFakeClockActive(true);
       vi.setSystemTime(now);
-      mocks.readTranscriptStatsSync.mockReturnValue({
-        eventCount: 1,
-        lastMutationAtMs: now - 1_000,
-        lastObservedMutationAtMs: now - 10_000,
-        maxSeq: 0,
-        sizeBytes: 64,
-      });
+      mocks.hasTerminalMainSessionTranscriptNewerThanRegistrySync.mockReturnValue(true);
 
       await withTestDir({ prefix: "openclaw-gateway-terminal-main-newer-" }, async (root) => {
         const sessionsDir = `${root}/sessions`;

--- a/src/gateway/server-methods/agent.test-harness.ts
+++ b/src/gateway/server-methods/agent.test-harness.ts
@@ -740,6 +740,7 @@ export async function runMainAgent(message: string, idempotencyKey: string) {
 }
 
 export async function runMainAgentAndCaptureEntry(idempotencyKey: string) {
+  mocks.agentCommand.mockClear();
   const loaded = mocks.loadSessionEntry();
   const canonicalKey = loaded?.canonicalKey ?? "agent:main:main";
   const existingEntry = structuredClone(loaded?.entry ?? buildExistingMainStoreEntry());

--- a/src/gateway/server-methods/agent.test-harness.ts
+++ b/src/gateway/server-methods/agent.test-harness.ts
@@ -68,6 +68,7 @@ const mocks = vi.hoisted(() => ({
       lastInteractionAt: entry?.lastInteractionAt,
     }),
   ),
+  hasTerminalMainSessionTranscriptNewerThanRegistrySync: vi.fn(() => false),
   lifecycleGeneration: "test-generation",
 }));
 
@@ -97,6 +98,8 @@ vi.mock("../../config/sessions.js", async () => {
       return m?.[1] ?? "main";
     },
     resolveExplicitAgentSessionKey: mocks.resolveExplicitAgentSessionKey,
+    hasTerminalMainSessionTranscriptNewerThanRegistrySync:
+      mocks.hasTerminalMainSessionTranscriptNewerThanRegistrySync,
     resolveAgentMainSessionKey: ({
       cfg,
       agentId,
@@ -740,7 +743,6 @@ export async function runMainAgent(message: string, idempotencyKey: string) {
 }
 
 export async function runMainAgentAndCaptureEntry(idempotencyKey: string) {
-  mocks.agentCommand.mockClear();
   const loaded = mocks.loadSessionEntry();
   const canonicalKey = loaded?.canonicalKey ?? "agent:main:main";
   const existingEntry = structuredClone(loaded?.entry ?? buildExistingMainStoreEntry());
@@ -1049,6 +1051,7 @@ export const describe0AfterEach0 = () => {
         lastInteractionAt: entry?.lastInteractionAt,
       }),
     );
+  mocks.hasTerminalMainSessionTranscriptNewerThanRegistrySync.mockReset().mockReturnValue(false);
   mocks.lifecycleGeneration = "test-generation";
   dateOnlyFakeClockActive = false;
   vi.useRealTimers();

--- a/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
+++ b/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
@@ -1,4 +1,6 @@
 // Control UI tests cover WhatsApp logout feedback against a mocked Gateway.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { expect, it } from "vitest";
 import { installMockGateway, waitForConfirmModal } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -11,8 +13,130 @@ const suite = createControlUiE2eSuite({
 
 const QR_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=";
+const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const uiProofArtifactDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "channels-save-failure",
+);
 
 suite.define(() => {
+  it("shows rejected channel configuration saves in the open editor without losing the draft", async () => {
+    if (captureUiProofEnabled) {
+      await mkdir(uiProofArtifactDir, { recursive: true });
+    }
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+        ...(captureUiProofEnabled
+          ? { recordVideo: { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } } }
+          : {}),
+      },
+      async ({ page }) => {
+        const config = { channels: { whatsapp: { enabled: true } } };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "channels.status": {
+              ts: Date.now(),
+              channelOrder: ["whatsapp"],
+              channelLabels: { whatsapp: "WhatsApp" },
+              channels: {
+                whatsapp: {
+                  configured: true,
+                  linked: true,
+                  running: true,
+                  connected: true,
+                  reconnectAttempts: 0,
+                },
+              },
+              channelAccounts: {},
+              channelDefaultAccountId: {},
+            },
+            "channels.pairing.list": {
+              accounts: [],
+              requests: [],
+              commandOwnerConfigured: true,
+              limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
+            },
+            "config.get": {
+              config,
+              hash: "channel-config-1",
+              raw: JSON.stringify(config),
+              valid: true,
+              issues: [],
+            },
+            "config.schema": {
+              generatedAt: "2026-08-25T00:00:00.000Z",
+              version: "e2e",
+              uiHints: { "channels.whatsapp.enabled": { advanced: false } },
+              schema: {
+                type: "object",
+                properties: {
+                  channels: {
+                    type: "object",
+                    properties: {
+                      whatsapp: {
+                        type: "object",
+                        properties: { enabled: { type: "boolean", title: "Enabled" } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        expect((await page.goto(`${suite.server.baseUrl}settings/channels`))?.status()).toBe(200);
+        await page.locator(".channels-item", { hasText: "WhatsApp" }).first().click();
+        const detail = page.locator(".channels-detail");
+        await detail.getByRole("switch", { name: "Enabled" }).waitFor();
+        if (captureUiProofEnabled) {
+          await detail.screenshot({ path: path.join(uiProofArtifactDir, "00-editor-before.png") });
+        }
+
+        await gateway.deferNext("config.set");
+        await detail.locator("wa-switch").first().click();
+        await gateway.waitForRequest("config.set");
+        await gateway.rejectDeferred("config.set", {
+          code: "INVALID_REQUEST",
+          message: "automatic channel save rejected",
+        });
+        const alert = detail.getByRole("alert");
+        await expect.poll(() => alert.textContent()).toContain("automatic channel save rejected");
+
+        const save = detail.getByRole("button", { name: "Save", exact: true });
+        await expect.poll(() => save.isEnabled()).toBe(true);
+        const writesBefore = (await gateway.getRequests("config.set")).length;
+        const readsBefore = (await gateway.getRequests("config.get")).length;
+        await gateway.deferNext("config.set");
+        await save.click();
+        const request = await gateway.waitForRequest("config.set", { after: writesBefore });
+        expect(request.params).toMatchObject({ baseHash: "channel-config-1" });
+        await gateway.rejectDeferred("config.set", {
+          code: "INVALID_REQUEST",
+          message:
+            "channel rejected: OPENAI_API_KEY=sk-1234567890abcdef <img src=x onerror=alert(1)>",
+        });
+
+        await expect.poll(() => alert.textContent()).toContain("channel rejected");
+        const message = await alert.textContent();
+        expect(message).toContain("OPENAI_API_KEY=sk-123...cdef");
+        expect(message).not.toContain("sk-1234567890abcdef");
+        expect(await alert.locator("img").count()).toBe(0);
+        expect(await save.isEnabled()).toBe(true);
+        expect(await detail.getByRole("switch", { name: "Enabled" }).isChecked()).toBe(false);
+        expect(await gateway.getRequests("config.get")).toHaveLength(readsBefore);
+        if (captureUiProofEnabled) {
+          await detail.screenshot({ path: path.join(uiProofArtifactDir, "01-visible-error.png") });
+        }
+      },
+    );
+  });
+
   it("confirms the explicit default account and preserves a no-op logout", async () => {
     await suite.withPage(
       {

--- a/ui/src/pages/channels/channels-page.test.ts
+++ b/ui/src/pages/channels/channels-page.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { NostrProfile } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { createChannelCapability } from "../../lib/channels/index.ts";
@@ -191,6 +191,98 @@ describe("ChannelsPage lifecycle", () => {
     expect(page.pairingPrompt).toBeNull();
     expect(page.pairingChannelFilter).toBeNull();
     expect(page.pairingAccountFilter).toBeNull();
+    source.runtimeConfig.dispose();
+    source.channels.dispose();
+  });
+
+  it("keeps rejected channel configuration visible in its editor without reloading the draft", async () => {
+    const gateway = createGateway();
+    gateway.emit({
+      hello: {
+        auth: { role: "operator", scopes: ["operator.admin", "operator.read"] },
+        features: { methods: ["config.set", "config.schema"] },
+      } as unknown as ApplicationGatewaySnapshot["hello"],
+    });
+    const source = createContext(gateway);
+    const config = { channels: { whatsapp: { enabled: true } } };
+    const channel = {
+      configured: true,
+      linked: true,
+      running: true,
+      connected: true,
+      reconnectAttempts: 0,
+    };
+    source.channels.state.channelsSnapshot = {
+      ts: 0,
+      channelOrder: ["whatsapp"],
+      channelLabels: { whatsapp: "WhatsApp" },
+      channels: { whatsapp: channel },
+      channelAccounts: {},
+      channelDefaultAccountId: {},
+    };
+    source.channels.state.pairingSnapshot = {
+      accounts: [],
+      requests: [],
+      commandOwnerConfigured: true,
+      limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
+    };
+    Object.assign(source.runtimeConfig.state, {
+      configSnapshot: { config, hash: "test", raw: JSON.stringify(config) },
+      configForm: structuredClone(config),
+      configFormOriginal: structuredClone(config),
+      configDraftBaseHash: "test",
+      configSchema: {
+        type: "object",
+        properties: {
+          channels: {
+            type: "object",
+            properties: {
+              whatsapp: {
+                type: "object",
+                properties: { enabled: { type: "boolean", title: "Enabled" } },
+              },
+            },
+          },
+        },
+      },
+      configUiHints: { "channels.whatsapp.enabled": { advanced: false } },
+    });
+    const refreshConfig = vi.spyOn(source.runtimeConfig, "refresh");
+    const refreshChannels = vi.spyOn(source.channels, "refresh");
+    const request = vi.spyOn(gateway.snapshot.client!, "request");
+    request.mockRejectedValueOnce(
+      new GatewayRequestError({
+        code: "INVALID_REQUEST",
+        message:
+          "channel rejected: OPENAI_API_KEY=sk-1234567890abcdef <img src=x onerror=alert(1)>",
+      }),
+    );
+    const page = document.createElement("openclaw-channels-page") as ChannelsPageTestElement;
+    page.context = source.context;
+    document.body.append(page);
+    await page.updateComplete;
+
+    page.querySelector<HTMLButtonElement>(".channels-item")!.click();
+    await page.updateComplete;
+    source.runtimeConfig.patchForm(["channels", "whatsapp", "enabled"], false);
+    await page.updateComplete;
+    const save = page.querySelector<HTMLButtonElement>(".channels-detail .btn.primary")!;
+    expect(save.disabled).toBe(false);
+    save.click();
+
+    await vi.waitFor(() => {
+      const alert = page.querySelector<HTMLElement>(".channels-detail [role=alert]");
+      expect(alert?.textContent).toContain("channel rejected");
+      expect(alert?.textContent).toContain("OPENAI_API_KEY=sk-123...cdef");
+      expect(alert?.textContent).not.toContain("sk-1234567890abcdef");
+      expect(alert?.querySelector("img")).toBeNull();
+    });
+    expect(source.runtimeConfig.state.configFormDirty).toBe(true);
+    expect(source.runtimeConfig.state.configForm).toEqual({
+      channels: { whatsapp: { enabled: false } },
+    });
+    expect(refreshConfig).not.toHaveBeenCalled();
+    expect(refreshChannels).not.toHaveBeenCalled();
     source.runtimeConfig.dispose();
     source.channels.dispose();
   });

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -263,17 +263,9 @@ class ChannelsPage extends OpenClawLightDomElement {
     if (!context) {
       return;
     }
-    const saved = await context.runtimeConfig.save();
-    const saveError = context.runtimeConfig.state.lastError;
-    if (!saved) {
-      await context.runtimeConfig.refresh();
-      if (saveError && !context.runtimeConfig.state.lastError) {
-        context.runtimeConfig.state.lastError = saveError;
-      }
-      this.requestUpdate();
-      return;
+    if (await context.runtimeConfig.save()) {
+      await context.channels.refresh(true);
     }
-    await context.channels.refresh(true);
   }
 
   private async reloadChannelConfig() {
@@ -689,6 +681,7 @@ class ChannelsPage extends OpenClawLightDomElement {
           configForm: config.configForm,
           configUiHints: config.configUiHints,
           configSaving: config.configSaving,
+          configError: config.lastError,
           configFormDirty: config.configFormDirty,
           showAdvancedSettings: this.showAdvancedSettings,
           nostrProfileFormState: this.nostrProfileFormState,

--- a/ui/src/pages/channels/view.config.ts
+++ b/ui/src/pages/channels/view.config.ts
@@ -148,6 +148,9 @@ export function renderChannelConfigSection(params: { channelId: string; props: C
             onShowAdvanced: props.onShowAdvancedSettings,
             onPatch: props.onConfigPatch,
           })}
+      ${props.configError
+        ? html`<div class="callout danger" role="alert">${props.configError}</div>`
+        : null}
       <div class="settings-row__control">
         <button
           class="btn primary"

--- a/ui/src/pages/channels/view.pairing.test.ts
+++ b/ui/src/pages/channels/view.pairing.test.ts
@@ -63,6 +63,7 @@ function createProps(overrides: Partial<ChannelsProps> = {}): ChannelsProps {
     configForm: null,
     configUiHints: {},
     configSaving: false,
+    configError: null,
     configFormDirty: false,
     showAdvancedSettings: false,
     nostrProfileFormState: null,

--- a/ui/src/pages/channels/view.test.ts
+++ b/ui/src/pages/channels/view.test.ts
@@ -44,6 +44,7 @@ function createProps(snapshot: ChannelsProps["snapshot"]): ChannelsProps {
     configForm: null,
     configUiHints: {},
     configSaving: false,
+    configError: null,
     configFormDirty: false,
     showAdvancedSettings: false,
     nostrProfileFormState: null,
@@ -160,6 +161,7 @@ function renderChannelDetailFixture(
   options: {
     label?: string;
     loading?: boolean;
+    configError?: string;
     onRefresh?: ChannelsProps["onRefresh"];
   } = {},
 ) {
@@ -175,6 +177,7 @@ function renderChannelDetailFixture(
     channelDefaultAccountId: accounts?.length ? { [channelId]: accounts[0]!.accountId } : {},
   });
   props.loading = options.loading ?? false;
+  props.configError = options.configError ?? null;
   if (options.onRefresh) {
     props.onRefresh = options.onRefresh;
   }
@@ -301,6 +304,24 @@ describe("channel config advanced tier", () => {
 });
 
 describe("channel detail", () => {
+  it.each(["telegram", "whatsapp", "nostr"] as const)(
+    "shows an escaped configuration save error inside the %s editor",
+    (channelId) => {
+      const data: ChannelsChannelData =
+        channelId === "whatsapp"
+          ? { whatsapp: createWhatsAppStatus() }
+          : channelId === "nostr"
+            ? { nostr: null }
+            : { telegram: { configured: true, running: true } };
+      const message = 'Gateway rejected <img src="x" onerror="alert(1)">';
+      const container = renderChannelDetailFixture(channelId, data, { configError: message });
+      const alert = container.querySelector(".channels-detail [role=alert]");
+
+      expect(alert?.textContent).toBe(message);
+      expect(alert?.querySelector("img")).toBeNull();
+    },
+  );
+
   it("links every channel to its docs page", () => {
     const props = createProps({
       ts: Date.now(),

--- a/ui/src/pages/channels/view.types.ts
+++ b/ui/src/pages/channels/view.types.ts
@@ -53,6 +53,7 @@ export type ChannelsProps = {
   configForm: Record<string, unknown> | null;
   configUiHints: ConfigUiHints;
   configSaving: boolean;
+  configError: string | null;
   configFormDirty: boolean;
   showAdvancedSettings: boolean;
   nostrProfileFormState: NostrProfileFormState | null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users saving Telegram, WhatsApp, Nostr, or other channel settings would receive no actionable error inside the open channel editor when the Gateway rejected the configuration update.

## Why This Change Was Made

Keep failed saves owned by the runtime configuration capability, which already preserves the draft, publishes the failure, and redacts sensitive text. Remove the Channels page's redundant reload and direct error-state mutation, then present the authoritative sanitized error in the existing shared channel editor.

This simplifies the owner boundary and removes three production lines overall. It changes no configuration format, Gateway protocol, authentication, persistence, or channel-specific behavior.

## User Impact

Operators immediately see why a channel save failed, retain their unsaved settings, and can retry directly in the same dialog. Secret-like values stay redacted and server-provided HTML remains inert.

## Evidence

The focused real-page regression failed against unmodified production because the editor exposed no alert. After the repair, all 44 focused Channels tests pass, including Telegram, WhatsApp, and Nostr rendering, owner-redacted synthetic credentials, HTML escaping, draft preservation, and the absence of unnecessary refreshes. All four full real-Chromium channel-management scenarios also pass, exercising actual mocked-Gateway WebSocket configuration saves; the full UI typecheck passes.

```text
pnpm --dir ui test src/pages/channels/channels-page.test.ts \
  src/pages/channels/view.test.ts src/pages/channels/view.pairing.test.ts
# 44 passed

node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts \
  --configLoader runner ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
# 4 passed

pnpm tsgo:ui
# passed
```

Before the save attempt:

![Channel editor before a rejected configuration save](https://github.com/user-attachments/assets/7f353996-f3db-462b-bcf8-4098140944c9)

After the rejected save, the editor preserves the draft and displays a safely redacted inline error:

![Channel editor showing the redacted save error beside the preserved draft](https://github.com/user-attachments/assets/4137628a-b885-4b8c-a506-9f0209021050)

Full real-browser recording with synthetic fixtures only:

https://github.com/user-attachments/assets/5e755b94-e287-473f-9aed-986217f55f58
