### PR TITLE
fix(sessions): keep disk cleanup isolated from channel plugins

### DIFF
--- a/src/config/sessions/store-maintenance-recent-preservation.test.ts
+++ b/src/config/sessions/store-maintenance-recent-preservation.test.ts
@@ -15,37 +15,43 @@ import type { SessionEntry } from "./types.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+function installThrowingConversationResolver() {
+  const resolveSessionConversation = vi.fn(() => {
+    throw new Error("channel resolver must not run during session maintenance");
+  });
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "broken",
+        source: "test",
+        plugin: {
+          id: "broken",
+          meta: { label: "Broken" },
+          messaging: { resolveSessionConversation },
+        },
+      },
+    ]),
+  );
+  return resolveSessionConversation;
+}
+
 describe("recent session maintenance preservation", () => {
   it.each(["classification", "pruning", "capping"] as const)(
     "preserves external conversations during %s without invoking channel plugins",
     (boundary) => {
-      const resolveSessionConversation = vi.fn(() => {
-        throw new Error("channel resolver must not run during session maintenance");
-      });
-      setActivePluginRegistry(
-        createTestRegistry([
-          {
-            pluginId: "broken",
-            source: "test",
-            plugin: {
-              id: "broken",
-              meta: { label: "Broken" },
-              messaging: { resolveSessionConversation },
-            },
-          },
-        ]),
-      );
+      const resolveSessionConversation = installThrowingConversationResolver();
 
       const updatedAt = Date.now() - 31 * DAY_MS;
       const protectedKeys = [
         "agent:main:broken:group:room:thread:reply",
         "agent:main:broken:channel:room:with:colon",
+        "agent:main:telegram:direct:user:topic:77",
         "agent:main:telegram:dm:user:topic:77",
         "agent:main:opaque:thread:reply",
       ];
       const removableKeys = [
         "agent:main:old",
-        "agent:main:subagent:worker",
+        "agent:main:subagent:worker:thread:reply",
         "agent:main:opaque:topic:unrelated",
       ];
       const store: Record<string, SessionEntry> = Object.fromEntries(
@@ -113,38 +119,51 @@ describe("recent session maintenance preservation", () => {
     expect(store).not.toHaveProperty(staleKey);
   });
 
-  it("keeps recent interactive sessions under file-store disk pressure", async () => {
-    await withTestDir({ prefix: "openclaw-preserve-recent-budget-" }, async (dir) => {
-      const now = Date.now();
-      const recentKey = "agent:main:dashboard:recent";
-      const staleKey = "agent:main:dashboard:stale";
-      const store: Record<string, SessionEntry> = {
-        [recentKey]: {
-          sessionId: "recent",
-          updatedAt: now,
-          displayName: "r".repeat(4_000),
-        },
-        [staleKey]: {
-          sessionId: "stale",
-          updatedAt: now - 8 * DAY_MS,
-          displayName: "s".repeat(4_000),
-        },
-      };
+  it("keeps recent and external sessions under disk pressure without invoking plugins", async () => {
+    const resolveSessionConversation = installThrowingConversationResolver();
+    try {
+      await withTestDir({ prefix: "openclaw-preserve-recent-budget-" }, async (dir) => {
+        const now = Date.now();
+        const recentKey = "agent:main:dashboard:recent";
+        const staleKey = "agent:main:dashboard:stale";
+        const externalKey = "agent:main:broken:group:room:thread:reply";
+        const store: Record<string, SessionEntry> = {
+          [recentKey]: {
+            sessionId: "recent",
+            updatedAt: now,
+            displayName: "r".repeat(4_000),
+          },
+          [staleKey]: {
+            sessionId: "stale",
+            updatedAt: now - 8 * DAY_MS,
+            displayName: "s".repeat(4_000),
+          },
+          [externalKey]: {
+            sessionId: "external",
+            updatedAt: now - 9 * DAY_MS,
+            displayName: "e".repeat(4_000),
+          },
+        };
 
-      const result = await enforceSessionDiskBudget({
-        store,
-        storePath: path.join(dir, "sessions.json"),
-        maintenance: {
-          highWaterBytes: 1,
-          maxDiskBytes: 1,
-          preserveRecentMs: 7 * DAY_MS,
-        },
-        warnOnly: false,
+        const result = await enforceSessionDiskBudget({
+          store,
+          storePath: path.join(dir, "sessions.json"),
+          maintenance: {
+            highWaterBytes: 1,
+            maxDiskBytes: 1,
+            preserveRecentMs: 7 * DAY_MS,
+          },
+          warnOnly: false,
+        });
+
+        expect(result?.removedEntries).toBe(1);
+        expect(store).toHaveProperty(recentKey);
+        expect(store).toHaveProperty(externalKey);
+        expect(store).not.toHaveProperty(staleKey);
+        expect(resolveSessionConversation).not.toHaveBeenCalled();
       });
-
-      expect(result?.removedEntries).toBe(1);
-      expect(store).toHaveProperty(recentKey);
-      expect(store).not.toHaveProperty(staleKey);
-    });
+    } finally {
+      resetPluginRuntimeStateForTest();
+    }
   });
 });

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -501,16 +501,13 @@ export function isRecentSessionMaintenanceEntry(params: {
   return activityAt > 0 && now - activityAt <= params.preserveRecentMs;
 }
 
-function isTelegramTopicSessionKey(sessionKey: string): boolean {
+function isProtectedExternalConversationSessionKey(sessionKey: string): boolean {
   const parsed = parseAgentSessionKey(sessionKey);
   const rest = normalizeLowercaseStringOrEmpty(parsed?.rest ?? sessionKey);
-  return /^telegram:(?:group|channel|direct|dm):.+:topic:[^:]+$/.test(rest);
-}
-
-function isExternalGroupOrChannelSessionKey(sessionKey: string): boolean {
-  const parsed = parseAgentSessionKey(sessionKey);
-  const rest = normalizeLowercaseStringOrEmpty(parsed?.rest ?? sessionKey);
-  return /^[^:]+:(?:group|channel):.+$/.test(rest);
+  return (
+    /^[^:]+:(?:group|channel):.+$/.test(rest) ||
+    /^telegram:(?:direct|dm):.+:topic:[^:]+$/.test(rest)
+  );
 }
 
 function isPrimarySessionMaintenanceKey(sessionKey: string): boolean {
@@ -536,10 +533,7 @@ function isProtectedSessionMaintenanceEntry(
   if (parseThreadSessionSuffix(sessionKey).threadId) {
     return true;
   }
-  if (isTelegramTopicSessionKey(sessionKey)) {
-    return true;
-  }
-  if (isExternalGroupOrChannelSessionKey(sessionKey)) {
+  if (isProtectedExternalConversationSessionKey(sessionKey)) {
     return true;
   }
   const chatType = normalizeLowercaseStringOrEmpty(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running several messaging channels could have session cleanup fail under disk pressure when an unrelated channel plugin's conversation resolver throws. Follow-up to #129490 and the cross-channel reply-loss report #121252.

## Why This Change Was Made

Session maintenance owns structural retention decisions and must never execute channel-plugin hooks. Consolidate duplicated external-conversation classification into one canonical structural predicate, preserve all group/channel conversations and Telegram direct-message topics, and exercise the previously uncovered disk-budget eviction boundary with a real throwing plugin fixture.

Production LOC: +6/-12 (net -6). Tests: +67/-48 (net +19).

## User Impact

A faulty channel plugin cannot abort session cleanup under disk pressure or jeopardize unrelated conversation history. Existing group/channel conversations, Telegram direct-message topics, recently active sessions, and disposable synthetic threaded sessions retain their existing behavior.

## Evidence

- Before the fix, the new disk-budget regression fails with `channel resolver must not run during session maintenance`; the stack proves `disk-budget.ts` calls the maintenance classifier, which invokes the loaded plugin resolver.
- After the fix, `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/config/sessions/store-maintenance-recent-preservation.test.ts src/config/sessions/store.pruning.test.ts src/config/sessions/session-accessor.conformance.test.ts src/channels/turn/run-channel-turn.finalize.test.ts` passes all 127 session-retention, real-SQLite, Telegram, and Discord regression tests.
- Production typechecking, formatting, dependency/architecture guards, and dead-export checks pass. Full local core-test typechecking reaches an existing unrelated `ui/vite.config.ts` missing-`pako`-declarations error in this linked checkout's shared dependency install; exact-head hosted CI remains the authoritative complete gate.
- Fresh structured independent code review reports no actionable findings.
