### PR TITLE
fix(qa): self-check passes replies sent to the wrong recipient

### DIFF
--- a/extensions/qa-lab/src/self-check-scenario.ts
+++ b/extensions/qa-lab/src/self-check-scenario.ts
@@ -1,30 +1,39 @@
 // Qa Lab plugin module implements self check scenario behavior.
 import { extractQaToolPayload } from "./extract-tool-payload.js";
+import type { QaTransportState } from "./qa-transport.js";
+import type { QaBusMessage } from "./runtime-api.js";
 import type { QaScenarioDefinition } from "./scenario.js";
+import { waitForOutboundMessage } from "./suite-runtime-transport.js";
 
 export function createQaSelfCheckScenario(options?: {
   waitTimeoutMs?: number;
 }): QaScenarioDefinition {
   const waitTimeoutMs = options?.waitTimeoutMs ?? 5_000;
-  let lifecycleTarget: string | undefined;
+  let lifecycle: { target: string; message: QaBusMessage } | undefined;
+  const waitForReply = (state: QaTransportState, inbound: QaBusMessage) =>
+    waitForOutboundMessage(
+      state,
+      (message) =>
+        message.conversation.id === inbound.conversation.id &&
+        message.conversation.kind === inbound.conversation.kind &&
+        message.threadId === inbound.threadId &&
+        message.text.includes(`qa-echo: ${inbound.text}`),
+      waitTimeoutMs,
+      { accountId: inbound.accountId },
+    );
   return {
     name: "Synthetic Slack-class roundtrip",
     steps: [
       {
         name: "DM echo roundtrip",
         async run({ state }) {
-          await state.addInboundMessage({
+          const inbound = await state.addInboundMessage({
             conversation: { id: "alice", kind: "direct" },
             senderId: "alice",
             senderName: "Alice",
             text: "hello from qa",
           });
-          await state.waitFor({
-            kind: "message-text",
-            textIncludes: "qa-echo: hello from qa",
-            direction: "outbound",
-            timeoutMs: waitTimeoutMs,
-          });
+          await waitForReply(state, inbound);
         },
       },
       {
@@ -44,9 +53,8 @@ export function createQaSelfCheckScenario(options?: {
           if (!threadId || !threadPayload?.target) {
             throw new Error("thread-create did not return thread id and target");
           }
-          lifecycleTarget = threadPayload.target;
 
-          await state.addInboundMessage({
+          const inbound = await state.addInboundMessage({
             conversation: { id: "qa-room", kind: "channel", title: "QA Room" },
             senderId: "alice",
             senderName: "Alice",
@@ -54,12 +62,10 @@ export function createQaSelfCheckScenario(options?: {
             threadId,
             threadTitle: "QA thread",
           });
-          await state.waitFor({
-            kind: "message-text",
-            textIncludes: "qa-echo: inside thread",
-            direction: "outbound",
-            timeoutMs: waitTimeoutMs,
-          });
+          lifecycle = {
+            target: threadPayload.target,
+            message: await waitForReply(state, inbound),
+          };
           return threadId;
         },
       },
@@ -69,21 +75,13 @@ export function createQaSelfCheckScenario(options?: {
           if (!performAction) {
             throw new Error("self-check action dispatcher is not configured");
           }
-          const outboundMessage = (
-            await state.searchMessages({
-              query: "qa-echo: inside thread",
-              conversationId: "qa-room",
-            })
-          ).at(-1);
-          if (!outboundMessage) {
-            throw new Error("threaded outbound message not found");
+          if (!lifecycle) {
+            throw new Error("threaded outbound message and target not found");
           }
-          if (!lifecycleTarget) {
-            throw new Error("thread target not found");
-          }
+          const { target, message: outboundMessage } = lifecycle;
 
           await performAction("react", {
-            to: lifecycleTarget,
+            to: target,
             messageId: outboundMessage.id,
             emoji: "white_check_mark",
           });
@@ -96,7 +94,7 @@ export function createQaSelfCheckScenario(options?: {
           }
 
           await performAction("edit", {
-            to: lifecycleTarget,
+            to: target,
             messageId: outboundMessage.id,
             text: "qa-echo: inside thread (edited)",
           });
@@ -109,7 +107,7 @@ export function createQaSelfCheckScenario(options?: {
           }
 
           await performAction("delete", {
-            to: lifecycleTarget,
+            to: target,
             messageId: outboundMessage.id,
           });
           const deleted = await state.readMessage({ messageId: outboundMessage.id });

--- a/extensions/qa-lab/src/self-check.test.ts
+++ b/extensions/qa-lab/src/self-check.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createQaBusState } from "./bus-state.js";
+import { runQaScenario } from "./scenario.js";
 import { createQaSelfCheckScenario } from "./self-check-scenario.js";
 import type { QaSelfCheckResult } from "./self-check.js";
 import { isQaSelfCheckSuccessful, resolveQaSelfCheckOutputPath } from "./self-check.js";
@@ -67,22 +68,29 @@ describe("resolveQaSelfCheckOutputPath", () => {
 });
 
 describe("createQaSelfCheckScenario", () => {
-  it("binds lifecycle actions to the seeded message thread", async () => {
+  function createSelfCheckHarness(delivery?: {
+    directAccountId?: string;
+    directTarget?: string;
+    threadedTarget?: string;
+  }) {
     const state = createQaBusState();
-    const scenario = createQaSelfCheckScenario();
-    const threadStep = scenario.steps[1];
-    const lifecycleStep = scenario.steps[2];
-    if (!threadStep || !lifecycleStep) {
-      throw new Error("self-check thread lifecycle steps are missing");
-    }
     const targets: unknown[] = [];
     const testState = {
       ...state,
       addInboundMessage: (input: Parameters<typeof state.addInboundMessage>[0]) => {
         const inbound = state.addInboundMessage(input);
+        if (input.text === "hello from qa") {
+          state.addOutboundMessage({
+            accountId: delivery?.directAccountId,
+            to: delivery?.directTarget ?? "dm:alice",
+            text: "qa-echo: hello from qa",
+          });
+        }
         if (input.text === "inside thread") {
           state.addOutboundMessage({
-            to: `thread:${input.conversation.id}/${String(input.threadId)}`,
+            to:
+              delivery?.threadedTarget ??
+              `thread:${input.conversation.id}/${String(input.threadId)}`,
             text: "qa-echo: inside thread",
           });
         }
@@ -91,12 +99,20 @@ describe("createQaSelfCheckScenario", () => {
     };
     const performAction = async (action: string, args: Record<string, unknown>) => {
       if (action === "thread-create") {
+        const thread = state.createThread({
+          conversationId: String(args.channelId),
+          title: String(args.title),
+        });
         return {
           details: {
-            target: "thread:qa-room/thread-1",
-            thread: { id: "thread-1" },
+            target: `thread:${thread.conversationId}/${thread.id}`,
+            thread,
           },
         };
+      }
+      const message = state.readMessage({ messageId: String(args.messageId) });
+      if (args.to !== `thread:${message.conversation.id}/${String(message.threadId)}`) {
+        throw new Error("qa-channel message is not in the selected conversation");
       }
       targets.push(args.to);
       if (action === "react") {
@@ -117,13 +133,34 @@ describe("createQaSelfCheckScenario", () => {
       throw new Error(`unexpected action: ${action}`);
     };
 
-    await threadStep.run({ state: testState, performAction });
-    await lifecycleStep.run({ state: testState, performAction });
+    return {
+      state,
+      targets,
+      run: async () =>
+        await runQaScenario(createQaSelfCheckScenario({ waitTimeoutMs: 20 }), {
+          state: testState,
+          performAction,
+        }),
+    };
+  }
+
+  it("runs every roundtrip and binds lifecycle actions to the seeded message thread", async () => {
+    const { state, targets, run } = createSelfCheckHarness();
+    const result = await run();
+
+    expect(result.status).toBe("pass");
+    expect(result.steps.map((step) => step.name)).toEqual([
+      "DM echo roundtrip",
+      "Thread create and threaded echo",
+      "Reaction, edit, delete lifecycle",
+    ]);
+    const thread = state.getSnapshot().threads[0];
+    expect(thread).toBeDefined();
 
     expect(targets).toEqual([
-      "thread:qa-room/thread-1",
-      "thread:qa-room/thread-1",
-      "thread:qa-room/thread-1",
+      `thread:qa-room/${String(thread?.id)}`,
+      `thread:qa-room/${String(thread?.id)}`,
+      `thread:qa-room/${String(thread?.id)}`,
     ]);
     const deletedMessage = state.getSnapshot().messages.find((message) => message.deleted);
     if (!deletedMessage) {
@@ -133,5 +170,37 @@ describe("createQaSelfCheckScenario", () => {
     expect(
       state.searchMessages({ query: "inside thread" }).map((message) => message.id),
     ).not.toContain(deletedMessage.id);
+  });
+
+  it.each([
+    { name: "another conversation", directTarget: "dm:mallory" },
+    { name: "another account", directAccountId: "foreign", directTarget: "dm:alice" },
+  ])("fails the complete self-check when Alice's reply is sent to $name", async (delivery) => {
+    const { state, targets, run } = createSelfCheckHarness(delivery);
+    const result = await run();
+
+    expect(
+      state
+        .searchMessages({ conversationId: "alice", conversationKind: "direct" })
+        .filter((message) => message.direction === "outbound"),
+    ).toHaveLength(0);
+    expect(result.status).toBe("fail");
+    expect(result.steps).toEqual([
+      expect.objectContaining({ name: "DM echo roundtrip", status: "fail" }),
+    ]);
+    expect(targets).toHaveLength(0);
+  });
+
+  it("fails threaded delivery at its owner before running lifecycle actions", async () => {
+    const { targets, run } = createSelfCheckHarness({
+      threadedTarget: "thread:qa-room/unrelated-thread",
+    });
+    const result = await run();
+
+    expect(result.status).toBe("fail");
+    expect(result.steps.at(-1)).toEqual(
+      expect.objectContaining({ name: "Thread create and threaded echo", status: "fail" }),
+    );
+    expect(targets).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the default QA self-check reported a successful direct-message roundtrip even when the expected recipient received no reply. A matching message sent to another account or conversation was incorrectly accepted, and a wrong-thread reply was diagnosed only after unrelated lifecycle actions began.

## Why This Change Was Made

The QA scenario now uses its existing canonical outbound matcher with the authoritative account, conversation, and thread facts from each inbound message. It carries the matched threaded reply directly into reaction/edit/delete lifecycle checks instead of rediscovering an unrelated room-wide message. Production code decreases by two lines.

## User Impact

The default QA command now fails when messages go to the wrong account, recipient, or thread instead of falsely reporting a healthy messaging roundtrip.

## Evidence

- Three authentic complete-scenario regressions failed before repair: wrong recipient, wrong account, and wrong thread.
- All 103 focused scenario, bus, action-target, and transport sibling tests pass; three actual QA CLI/self-check integration tests also pass.
- Legitimate full roundtrips preserve all three lifecycle actions with their exact thread target.
- Targeted type-aware lint, formatting, and independent complete-diff P1 structured review pass.
- Two unrelated stale Crabline dependency fixtures encountered in an exploratory wider suite were left unchanged; all relevant owner and CLI tests are green.
