### PR TITLE
fix(skills): load trusted Bun and Nix package hardlinks safely

### DIFF
--- a/src/plugins/hardlink-policy.test.ts
+++ b/src/plugins/hardlink-policy.test.ts
@@ -34,4 +34,14 @@ describe("plugin hardlink policy", () => {
       }),
     ).toBe(true);
   });
+
+  it("allows hardlinked immutable Nix-store plugin files in Nix mode", () => {
+    expect(
+      shouldRejectHardlinkedPluginFiles({
+        origin: "config",
+        rootDir: "/nix/store/openclaw-plugin",
+        env: nixEnv,
+      }),
+    ).toBe(false);
+  });
 });

--- a/src/skills/lifecycle/install.test.ts
+++ b/src/skills/lifecycle/install.test.ts
@@ -24,7 +24,7 @@ vi.mock("../../process/exec.js", () => ({
 }));
 
 vi.mock("../loading/plugin-skills.js", () => ({
-  resolvePluginSkillDirs: () => [],
+  resolvePluginSkillRoots: () => [],
 }));
 
 async function writeInstallableSkill(workspaceDir: string, name: string): Promise<string> {

--- a/src/skills/loading/agents-directory.test.ts
+++ b/src/skills/loading/agents-directory.test.ts
@@ -13,7 +13,7 @@ import {
 import { buildSkillSnapshot } from "./workspace-skill-prompt.js";
 
 vi.mock("./plugin-skills.js", () => ({
-  resolvePluginSkillDirs: () => [],
+  resolvePluginSkillRoots: () => [],
 }));
 
 const tempDirs = createTempDirTracker();

--- a/src/skills/loading/bundled-context.ts
+++ b/src/skills/loading/bundled-context.ts
@@ -35,6 +35,7 @@ export function resolveBundledSkillsContext(
   const result = loadSkillsFromDirSafe({
     dir,
     source: "openclaw-bundled",
+    rejectHardlinks: false,
     onDiagnostic: (diagnostic) =>
       skillsLogger.warn(
         `Skipping bundled skill with invalid frontmatter (${diagnostic.path}): ${diagnostic.message}`,

--- a/src/skills/loading/local-loader.ts
+++ b/src/skills/loading/local-loader.ts
@@ -29,6 +29,7 @@ function readSkillFileSync(params: {
   rootRealPath: string;
   filePath: string;
   maxBytes?: number;
+  rejectHardlinks?: boolean;
   onDiagnostic?: (diagnostic: LocalSkillLoadDiagnostic) => void;
 }): string | null {
   const opened = openRootFileSync({
@@ -39,6 +40,7 @@ function readSkillFileSync(params: {
     // Operator skill roots are commonly symlinked; fs-safe still rejects hops
     // whose canonical target escapes the skill root.
     rejectSymlinks: false,
+    rejectHardlinks: params.rejectHardlinks !== false,
   });
   if (!opened.ok) {
     if (!isRootFileMissingFailure(opened)) {
@@ -68,6 +70,7 @@ function loadSingleSkillDirectory(params: {
   source: string;
   rootRealPath: string;
   maxBytes?: number;
+  rejectHardlinks?: boolean;
   onDiagnostic?: (diagnostic: LocalSkillLoadDiagnostic) => void;
 }): LoadedLocalSkill | null {
   const skillFilePath = path.join(params.skillDir, "SKILL.md");
@@ -75,6 +78,7 @@ function loadSingleSkillDirectory(params: {
     rootRealPath: params.rootRealPath,
     filePath: skillFilePath,
     maxBytes: params.maxBytes,
+    rejectHardlinks: params.rejectHardlinks,
     onDiagnostic: params.onDiagnostic,
   });
   if (raw === null) {
@@ -144,6 +148,7 @@ export function loadSkillsFromDirSafe(params: {
   dir: string;
   source: string;
   maxBytes?: number;
+  rejectHardlinks?: boolean;
   onDiagnostic?: (diagnostic: LocalSkillLoadDiagnostic) => void;
 }): {
   skills: Skill[];
@@ -162,6 +167,7 @@ export function loadSkillsFromDirSafe(params: {
     source: params.source,
     rootRealPath,
     maxBytes: params.maxBytes,
+    rejectHardlinks: params.rejectHardlinks,
     onDiagnostic: params.onDiagnostic,
   });
   if (rootSkill) {
@@ -178,6 +184,7 @@ export function loadSkillsFromDirSafe(params: {
         source: params.source,
         rootRealPath,
         maxBytes: params.maxBytes,
+        rejectHardlinks: params.rejectHardlinks,
         onDiagnostic: params.onDiagnostic,
       }),
     )
@@ -197,6 +204,7 @@ export function readSkillFrontmatterSafe(params: {
   rootDir: string;
   filePath: string;
   maxBytes?: number;
+  rejectHardlinks?: boolean;
 }): Record<string, string> | null {
   let rootRealPath: string;
   try {
@@ -208,6 +216,7 @@ export function readSkillFrontmatterSafe(params: {
     rootRealPath,
     filePath: path.resolve(params.filePath),
     maxBytes: params.maxBytes,
+    rejectHardlinks: params.rejectHardlinks,
   });
   if (raw === null) {
     return null;

--- a/src/skills/loading/plugin-skills.test.ts
+++ b/src/skills/loading/plugin-skills.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../acp/runtime/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { PluginManifestRegistry } from "../../plugins/manifest-registry.js";
+import type { PluginOrigin } from "../../plugins/plugin-origin.types.js";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 
 const hoisted = vi.hoisted(() => {
@@ -50,8 +51,8 @@ vi.mock("../../plugins/plugin-metadata-snapshot.js", () => ({
   resolvePluginMetadataSnapshot: hoisted.resolvePluginMetadataSnapshot,
 }));
 
-let resolvePluginSkillDirs: typeof import("./plugin-skills.js").resolvePluginSkillDirs;
-let resolvePluginSkillDirsFromMetadata: typeof import("./plugin-skills.js").resolvePluginSkillDirsFromMetadata;
+let resolvePluginSkillRoots: typeof import("./plugin-skills.js").resolvePluginSkillRoots;
+let resolvePluginSkillRootsFromMetadata: typeof import("./plugin-skills.js").resolvePluginSkillRootsFromMetadata;
 
 const tempDirs = createTrackedTempDirs();
 
@@ -105,6 +106,7 @@ function createSinglePluginRegistry(params: {
   format?: "openclaw" | "bundle";
   bundleFormat?: "agent" | "codex" | "claude" | "cursor";
   legacyPluginIds?: string[];
+  origin?: PluginOrigin;
 }): PluginManifestRegistry {
   return {
     diagnostics: [],
@@ -120,7 +122,7 @@ function createSinglePluginRegistry(params: {
         legacyPluginIds: params.legacyPluginIds,
         skills: params.skills,
         hooks: [],
-        origin: "workspace",
+        origin: params.origin ?? "workspace",
         rootDir: params.pluginRoot,
         source: params.pluginRoot,
         manifestPath: path.join(params.pluginRoot, "openclaw.plugin.json"),
@@ -192,9 +194,9 @@ afterEach(async () => {
   await tempDirs.cleanup();
 });
 
-describe("resolvePluginSkillDirs", () => {
+describe("resolvePluginSkillRoots", () => {
   beforeAll(async () => {
-    ({ resolvePluginSkillDirs, resolvePluginSkillDirsFromMetadata } =
+    ({ resolvePluginSkillRoots, resolvePluginSkillRootsFromMetadata } =
       await import("./plugin-skills.js"));
   });
 
@@ -203,7 +205,7 @@ describe("resolvePluginSkillDirs", () => {
     registerHealthyAcpBackend();
     const manifestRegistry = buildRegistry({ acpxRoot, helperRoot });
 
-    const dirs = resolvePluginSkillDirsFromMetadata({
+    const roots = resolvePluginSkillRootsFromMetadata({
       workspaceDir,
       config: {
         acp: { enabled: true },
@@ -215,7 +217,10 @@ describe("resolvePluginSkillDirs", () => {
       } as never,
     });
 
-    expect(dirs).toEqual([path.resolve(acpxRoot, "skills"), path.resolve(helperRoot, "skills")]);
+    expect(roots).toEqual([
+      { dir: path.resolve(acpxRoot, "skills"), rejectHardlinks: true },
+      { dir: path.resolve(helperRoot, "skills"), rejectHardlinks: true },
+    ]);
     expect(hoisted.loadPluginMetadataSnapshot).not.toHaveBeenCalled();
   });
 
@@ -230,6 +235,33 @@ describe("resolvePluginSkillDirs", () => {
     hoisted.loadPluginRegistrySnapshot.mockReset();
     hoisted.loadPluginRegistrySnapshot.mockReturnValue({ plugins: [] });
   });
+
+  it.each([
+    { origin: "bundled" as const, rejectHardlinks: false },
+    { origin: "global" as const, rejectHardlinks: true },
+    { origin: "workspace" as const, rejectHardlinks: true },
+    { origin: "config" as const, rejectHardlinks: true },
+  ])(
+    "preserves authoritative $origin plugin hardlink policy on skill roots",
+    async ({ origin, rejectHardlinks }) => {
+      const workspaceDir = await tempDirs.make("openclaw-");
+      const pluginRoot = await tempDirs.make("openclaw-plugin-");
+      const skillDir = path.join(pluginRoot, "skills");
+      await fs.mkdir(skillDir, { recursive: true });
+      hoisted.loadPluginManifestRegistryForInstalledIndex.mockReturnValue(
+        createSinglePluginRegistry({ pluginRoot, skills: ["./skills"], origin }),
+      );
+
+      expect(
+        resolvePluginSkillRoots({
+          workspaceDir,
+          config: {
+            plugins: { entries: { helper: { enabled: true } } },
+          } as OpenClawConfig,
+        }),
+      ).toEqual([{ dir: skillDir, rejectHardlinks }]);
+    },
+  );
 
   it.each([
     {
@@ -263,7 +295,7 @@ describe("resolvePluginSkillDirs", () => {
       registerHealthyAcpBackend();
     }
 
-    const dirs = resolvePluginSkillDirs({
+    const roots = resolvePluginSkillRoots({
       workspaceDir,
       config: {
         acp: { enabled: acpEnabled },
@@ -276,7 +308,7 @@ describe("resolvePluginSkillDirs", () => {
       } as OpenClawConfig,
     });
 
-    expect(dirs).toEqual(expectedDirs({ acpxRoot, helperRoot }));
+    expect(roots.map((root) => root.dir)).toEqual(expectedDirs({ acpxRoot, helperRoot }));
   });
 
   it("reuses current lifecycle metadata before falling back to a cold load", async () => {
@@ -289,7 +321,7 @@ describe("resolvePluginSkillDirs", () => {
       normalizePluginId: (pluginId: string) => pluginId,
     });
 
-    const dirs = resolvePluginSkillDirs({
+    const roots = resolvePluginSkillRoots({
       workspaceDir,
       config: {
         acp: { enabled: true },
@@ -297,7 +329,10 @@ describe("resolvePluginSkillDirs", () => {
       } as OpenClawConfig,
     });
 
-    expect(dirs).toEqual([path.resolve(acpxRoot, "skills"), path.resolve(helperRoot, "skills")]);
+    expect(roots.map((root) => root.dir)).toEqual([
+      path.resolve(acpxRoot, "skills"),
+      path.resolve(helperRoot, "skills"),
+    ]);
     expect(hoisted.resolvePluginMetadataSnapshot).toHaveBeenCalledOnce();
     expect(hoisted.loadPluginMetadataSnapshot).not.toHaveBeenCalled();
   });
@@ -316,7 +351,7 @@ describe("resolvePluginSkillDirs", () => {
         : hoisted.loadPluginMetadataSnapshot(params),
     );
 
-    expect(resolvePluginSkillDirs({ workspaceDir })).toEqual([]);
+    expect(resolvePluginSkillRoots({ workspaceDir })).toEqual([]);
     expect(hoisted.loadPluginMetadataSnapshot).not.toHaveBeenCalled();
   });
 
@@ -352,22 +387,22 @@ describe("resolvePluginSkillDirs", () => {
         registerHealthyAcpBackend();
       }
 
-      const first = resolvePluginSkillDirs({ workspaceDir, config });
+      const first = resolvePluginSkillRoots({ workspaceDir, config });
 
       if (initiallyAvailable) {
         acpRuntimeTesting.resetAcpRuntimeBackendsForTests();
       } else {
         registerHealthyAcpBackend();
       }
-      const second = resolvePluginSkillDirs({ workspaceDir, config });
+      const second = resolvePluginSkillRoots({ workspaceDir, config });
 
       const dirsForState = (includeAcpx: boolean) => [
         ...(includeAcpx ? [path.resolve(acpxRoot, "skills")] : []),
         path.resolve(helperRoot, "skills"),
       ];
-      expect(first).toEqual(dirsForState(firstIncludesAcpx));
-      expect(second).toEqual(dirsForState(secondIncludesAcpx));
-      expect(resolvePluginSkillDirs({ workspaceDir, config })).toBe(second);
+      expect(first.map((root) => root.dir)).toEqual(dirsForState(firstIncludesAcpx));
+      expect(second.map((root) => root.dir)).toEqual(dirsForState(secondIncludesAcpx));
+      expect(resolvePluginSkillRoots({ workspaceDir, config })).toBe(second);
     },
   );
 
@@ -384,7 +419,7 @@ describe("resolvePluginSkillDirs", () => {
       }),
     );
 
-    const dirs = resolvePluginSkillDirs({
+    const roots = resolvePluginSkillRoots({
       workspaceDir,
       config: {
         plugins: {
@@ -395,7 +430,7 @@ describe("resolvePluginSkillDirs", () => {
       } as OpenClawConfig,
     });
 
-    expect(dirs).toEqual([path.resolve(pluginRoot, "skills")]);
+    expect(roots).toEqual([{ dir: path.resolve(pluginRoot, "skills"), rejectHardlinks: true }]);
   });
 
   it("rejects plugin skill symlinks that resolve outside plugin root", async () => {
@@ -415,7 +450,7 @@ describe("resolvePluginSkillDirs", () => {
       }),
     );
 
-    const dirs = resolvePluginSkillDirs({
+    const roots = resolvePluginSkillRoots({
       workspaceDir,
       config: {
         plugins: {
@@ -426,7 +461,7 @@ describe("resolvePluginSkillDirs", () => {
       } as OpenClawConfig,
     });
 
-    expect(dirs).toStrictEqual([]);
+    expect(roots).toStrictEqual([]);
   });
 
   it("cleans up generated plugin skill links when the plugin registry is empty", async () => {
@@ -442,13 +477,13 @@ describe("resolvePluginSkillDirs", () => {
       plugins: [],
     });
 
-    const dirs = resolvePluginSkillDirs({
+    const roots = resolvePluginSkillRoots({
       workspaceDir,
       config: {} as OpenClawConfig,
       pluginSkillsDir,
     });
 
-    expect(dirs).toStrictEqual([]);
+    expect(roots).toStrictEqual([]);
     await expectPathMissing(path.join(pluginSkillsDir, "stale-skill"));
   });
 
@@ -459,13 +494,13 @@ describe("resolvePluginSkillDirs", () => {
     await fs.mkdir(staleSkill, { recursive: true });
     fsSync.symlinkSync(staleSkill, path.join(pluginSkillsDir, "stale-skill"), "dir");
 
-    const dirs = resolvePluginSkillDirs({
+    const roots = resolvePluginSkillRoots({
       workspaceDir: undefined,
       config: {} as OpenClawConfig,
       pluginSkillsDir,
     });
 
-    expect(dirs).toStrictEqual([]);
+    expect(roots).toStrictEqual([]);
     await expectPathMissing(path.join(pluginSkillsDir, "stale-skill"));
   });
 
@@ -483,7 +518,7 @@ describe("resolvePluginSkillDirs", () => {
       }),
     );
 
-    const dirs = resolvePluginSkillDirs({
+    const roots = resolvePluginSkillRoots({
       workspaceDir,
       config: {
         plugins: {
@@ -494,7 +529,7 @@ describe("resolvePluginSkillDirs", () => {
       } as OpenClawConfig,
     });
 
-    expect(dirs).toEqual([
+    expect(roots.map((root) => root.dir)).toEqual([
       path.resolve(pluginRoot, "skills"),
       path.resolve(pluginRoot, "commands"),
     ]);
@@ -523,7 +558,7 @@ describe("resolvePluginSkillDirs", () => {
       }),
     );
 
-    const dirs = resolvePluginSkillDirs({
+    const roots = resolvePluginSkillRoots({
       workspaceDir,
       pluginSkillsDir,
       config: {
@@ -531,7 +566,7 @@ describe("resolvePluginSkillDirs", () => {
       } as OpenClawConfig,
     });
 
-    expect(dirs).toEqual([validSkill]);
+    expect(roots).toEqual([{ dir: validSkill, rejectHardlinks: true }]);
     expect(fsSync.readlinkSync(path.join(pluginSkillsDir, "valid"))).toBe(validSkill);
     expect(fsSync.existsSync(path.join(pluginSkillsDir, "deep"))).toBe(false);
     expect(fsSync.existsSync(path.join(pluginSkillsDir, "skills"))).toBe(false);
@@ -550,7 +585,7 @@ describe("resolvePluginSkillDirs", () => {
       }),
     );
 
-    const dirs = resolvePluginSkillDirs({
+    const roots = resolvePluginSkillRoots({
       workspaceDir,
       config: {
         plugins: {
@@ -561,13 +596,13 @@ describe("resolvePluginSkillDirs", () => {
       } as OpenClawConfig,
     });
 
-    expect(dirs).toEqual([path.resolve(pluginRoot, "skills")]);
+    expect(roots).toEqual([{ dir: path.resolve(pluginRoot, "skills"), rejectHardlinks: true }]);
   });
 });
 
 describe("publishPluginSkills", () => {
   beforeAll(async () => {
-    ({ resolvePluginSkillDirs } = await import("./plugin-skills.js"));
+    ({ resolvePluginSkillRoots } = await import("./plugin-skills.js"));
   });
 
   function publishPluginSkills(skillDirs: string[], opts: { pluginSkillsDir: string }): void {
@@ -588,7 +623,7 @@ describe("publishPluginSkills", () => {
       diagnostics: [],
       plugins,
     });
-    resolvePluginSkillDirs({
+    resolvePluginSkillRoots({
       workspaceDir: opts.pluginSkillsDir,
       pluginSkillsDir: opts.pluginSkillsDir,
       config: {

--- a/src/skills/loading/plugin-skills.ts
+++ b/src/skills/loading/plugin-skills.ts
@@ -11,6 +11,7 @@ import {
   resolvePolicyPluginActivationState,
 } from "../../plugins/config-policy.js";
 import { resolveMemorySlotDecision } from "../../plugins/config-state.js";
+import { shouldRejectHardlinkedPluginFiles } from "../../plugins/hardlink-policy.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "../../plugins/plugin-metadata-lifecycle.js";
 import { resolvePluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
@@ -22,27 +23,32 @@ const log = createSubsystemLogger("skills");
 
 type PluginSkillLinkType = "dir" | "junction";
 
+export type PluginSkillRoot = {
+  dir: string;
+  rejectHardlinks: boolean;
+};
+
 // Plugin metadata is process-stable while the gateway runs, but this resolver sits on the
 // per-turn skills-refresh path. ACP availability changes outside that metadata lifecycle, so it
 // stays in the memo identity to prevent stale ACPX skill exposure without repeating directory IO.
-let pluginSkillDirsMemo: {
+let pluginSkillRootsMemo: {
   workspaceDir: string;
   config: OpenClawConfig | undefined;
   snapshot: unknown;
   acpRuntimeAvailable: boolean;
-  dirs: string[];
+  roots: PluginSkillRoot[];
 } | null = null;
 
 registerPluginMetadataProcessMemoLifecycleClear(() => {
-  pluginSkillDirsMemo = null;
+  pluginSkillRootsMemo = null;
 });
 
-export function resolvePluginSkillDirs(params: {
+export function resolvePluginSkillRoots(params: {
   workspaceDir: string | undefined;
   config?: OpenClawConfig;
   /** Override the plugin skills directory for testing. */
   pluginSkillsDir?: string;
-}): string[] {
+}): PluginSkillRoot[] {
   const workspaceDir = (params.workspaceDir ?? "").trim();
   if (!workspaceDir) {
     publishPluginSkills([], {
@@ -55,15 +61,15 @@ export function resolvePluginSkillDirs(params: {
     config: params.config,
     env: process.env,
   });
-  return resolvePluginSkillDirsFromMetadata({ ...params, metadataSnapshot });
+  return resolvePluginSkillRootsFromMetadata({ ...params, metadataSnapshot });
 }
 
-export function resolvePluginSkillDirsFromMetadata(params: {
+export function resolvePluginSkillRootsFromMetadata(params: {
   workspaceDir: string | undefined;
   config?: OpenClawConfig;
   pluginSkillsDir?: string;
   metadataSnapshot: PluginMetadataSnapshot;
-}): string[] {
+}): PluginSkillRoot[] {
   const workspaceDir = (params.workspaceDir ?? "").trim();
   if (!workspaceDir) {
     publishPluginSkills([], { pluginSkillsDir: params.pluginSkillsDir });
@@ -82,13 +88,13 @@ export function resolvePluginSkillDirsFromMetadata(params: {
   const canMemoize = params.pluginSkillsDir === undefined;
   if (
     canMemoize &&
-    pluginSkillDirsMemo &&
-    pluginSkillDirsMemo.workspaceDir === workspaceDir &&
-    pluginSkillDirsMemo.config === params.config &&
-    pluginSkillDirsMemo.snapshot === metadataSnapshot &&
-    pluginSkillDirsMemo.acpRuntimeAvailable === acpRuntimeAvailable
+    pluginSkillRootsMemo &&
+    pluginSkillRootsMemo.workspaceDir === workspaceDir &&
+    pluginSkillRootsMemo.config === params.config &&
+    pluginSkillRootsMemo.snapshot === metadataSnapshot &&
+    pluginSkillRootsMemo.acpRuntimeAvailable === acpRuntimeAvailable
   ) {
-    return pluginSkillDirsMemo.dirs;
+    return pluginSkillRootsMemo.roots;
   }
   const normalizedPlugins = normalizePluginsConfigWithResolver(
     config.plugins,
@@ -97,7 +103,7 @@ export function resolvePluginSkillDirsFromMetadata(params: {
   const memorySlot = normalizedPlugins.slots.memory;
   let selectedMemoryPluginId: string | null = null;
   const seen = new Set<string>();
-  const resolved: string[] = [];
+  const resolved: PluginSkillRoot[] = [];
 
   for (const record of registry.plugins) {
     if (!record.skills || record.skills.length === 0) {
@@ -129,6 +135,10 @@ export function resolvePluginSkillDirsFromMetadata(params: {
     if (memoryDecision.selected && hasKind(record.kind, "memory")) {
       selectedMemoryPluginId = record.id;
     }
+    const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
+      origin: record.origin,
+      rootDir: record.rootDir,
+    });
     for (const raw of record.skills) {
       const trimmed = raw.trim();
       if (!trimmed) {
@@ -150,22 +160,25 @@ export function resolvePluginSkillDirsFromMetadata(params: {
           continue;
         }
         seen.add(resolvedCandidate);
-        resolved.push(resolvedCandidate);
+        resolved.push({ dir: resolvedCandidate, rejectHardlinks });
       }
     }
   }
 
-  publishPluginSkills(resolved, {
-    pluginSkillsDir: params.pluginSkillsDir,
-  });
+  publishPluginSkills(
+    resolved.map((root) => root.dir),
+    {
+      pluginSkillsDir: params.pluginSkillsDir,
+    },
+  );
 
   if (canMemoize) {
-    pluginSkillDirsMemo = {
+    pluginSkillRootsMemo = {
       workspaceDir,
       config: params.config,
       snapshot: metadataSnapshot,
       acpRuntimeAvailable,
-      dirs: resolved,
+      roots: resolved,
     };
   }
   return resolved;

--- a/src/skills/loading/skill-path-containment.test.ts
+++ b/src/skills/loading/skill-path-containment.test.ts
@@ -15,7 +15,7 @@ import { readSkillFrontmatterSafe } from "./local-loader.js";
 import { loadWorkspaceSkills } from "./workspace-skill-loader.js";
 
 vi.mock("./plugin-skills.js", () => ({
-  resolvePluginSkillDirs: () => [],
+  resolvePluginSkillRoots: () => [],
 }));
 
 let fakeHome = "";
@@ -27,6 +27,15 @@ async function createTempWorkspaceDir() {
   const workspaceDir = path.join(tempRoot, `workspace-${++workspaceCaseIndex}`);
   await fs.mkdir(workspaceDir, { recursive: true });
   return workspaceDir;
+}
+
+async function writeHardlinkedSkill(params: { dir: string; name: string; description: string }) {
+  const sourceDir = path.join(tempRoot, `hardlink-source-${++workspaceCaseIndex}`);
+  await writeSkill({ ...params, dir: sourceDir });
+  await fs.mkdir(params.dir, { recursive: true });
+  const skillFilePath = path.join(params.dir, "SKILL.md");
+  await fs.link(path.join(sourceDir, "SKILL.md"), skillFilePath);
+  expect((await fs.stat(skillFilePath)).nlink).toBeGreaterThan(1);
 }
 
 function captureWarningLogger() {
@@ -97,6 +106,90 @@ afterAll(async () => {
 });
 
 describe("skill path containment", () => {
+  it.each([
+    { source: "bundled", expectedSource: "openclaw-bundled" },
+    { source: "custodian", expectedSource: "openclaw-custodian" },
+  ] as const)("loads hardlinked packaged $source skills", async ({ source, expectedSource }) => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const bundledSkillsDir = path.join(workspaceDir, "package", "skills");
+    const skillRoot =
+      source === "bundled"
+        ? bundledSkillsDir
+        : path.join(path.dirname(bundledSkillsDir), "custodian-skills");
+    const skillName = `${source}-hardlinked-skill`;
+    await writeHardlinkedSkill({
+      dir: path.join(skillRoot, skillName),
+      name: skillName,
+      description: `Packaged ${source} skill`,
+    });
+    const warn = captureWarningLogger();
+
+    const entries = loadTestWorkspaceSkills(workspaceDir, {
+      bundledSkillsDir,
+      agentId: "ops",
+      config: {
+        agents: {
+          defaults: { systemAgent: { agentId: "ops" } },
+          entries: { ops: {} },
+        },
+      },
+    });
+
+    expect(entries).toEqual([
+      expect.objectContaining({
+        skill: expect.objectContaining({ name: skillName, source: expectedSource }),
+      }),
+    ]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { source: "workspace", expectedSource: "openclaw-workspace" },
+    { source: "managed", expectedSource: "openclaw-managed" },
+    { source: "config-extra", expectedSource: "openclaw-extra" },
+  ] as const)(
+    "rejects hardlinked $source skills while preserving ordinary files",
+    async ({ source, expectedSource }) => {
+      const workspaceDir = await createTempWorkspaceDir();
+      const skillRoot =
+        source === "workspace"
+          ? path.join(workspaceDir, "skills")
+          : source === "managed"
+            ? path.join(workspaceDir, ".managed")
+            : path.join(workspaceDir, "extra-skills");
+      const rejectedSkillName = `${source}-hardlinked-skill`;
+      const acceptedSkillName = `${source}-ordinary-skill`;
+      await writeHardlinkedSkill({
+        dir: path.join(skillRoot, rejectedSkillName),
+        name: rejectedSkillName,
+        description: `Untrusted ${source} hardlink`,
+      });
+      await writeSkill({
+        dir: path.join(skillRoot, acceptedSkillName),
+        name: acceptedSkillName,
+        description: `Ordinary ${source} skill`,
+      });
+      const warn = captureWarningLogger();
+
+      const entries = loadTestWorkspaceSkills(
+        workspaceDir,
+        source === "config-extra"
+          ? { config: { skills: { load: { extraDirs: [skillRoot] } } } }
+          : undefined,
+      );
+
+      expect(entries).toEqual([
+        expect.objectContaining({
+          skill: expect.objectContaining({ name: acceptedSkillName, source: expectedSource }),
+        }),
+      ]);
+      const warningLine = firstWarningLine(warn);
+      expect(warningLine).toContain("Skipping invalid skill:");
+      expect(warningLine).toContain(rejectedSkillName);
+      expect(warningLine).toMatch(/hardlink/iu);
+    },
+  );
+
   it.runIf(process.platform !== "win32")(
     "skips workspace skill paths that resolve outside the workspace root",
     async () => {

--- a/src/skills/loading/skill-root-discovery.test.ts
+++ b/src/skills/loading/skill-root-discovery.test.ts
@@ -9,7 +9,7 @@ import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { loadWorkspaceSkills } from "./workspace-skill-loader.js";
 
 vi.mock("./plugin-skills.js", () => ({
-  resolvePluginSkillDirs: () => [],
+  resolvePluginSkillRoots: () => [],
 }));
 
 let tempRoot = "";

--- a/src/skills/loading/skills.test.ts
+++ b/src/skills/loading/skills.test.ts
@@ -29,7 +29,7 @@ import { shouldIncludeSkill } from "./config.js";
 import { buildSkillSnapshot } from "./workspace-skill-prompt.js";
 
 vi.mock("./plugin-skills.js", () => ({
-  resolvePluginSkillDirs: () => [],
+  resolvePluginSkillRoots: () => [],
 }));
 
 const fixtureSuite = createFixtureSuite("openclaw-skills-suite-");

--- a/src/skills/loading/workspace-precedence.test.ts
+++ b/src/skills/loading/workspace-precedence.test.ts
@@ -19,7 +19,7 @@ const buildWorkspaceSkillsPrompt = (
 ): string => buildSkillSnapshot(workspaceDir, opts).prompt;
 
 vi.mock("./plugin-skills.js", () => ({
-  resolvePluginSkillDirs: () => [],
+  resolvePluginSkillRoots: () => [],
 }));
 
 const fixtureSuite = createFixtureSuite("openclaw-skills-prompt-suite-");

--- a/src/skills/loading/workspace-skill-loader.test.ts
+++ b/src/skills/loading/workspace-skill-loader.test.ts
@@ -363,6 +363,43 @@ describe("loadWorkspaceSkills", () => {
     await expectMissingPath(path.join(workspaceDir, ".plugin-skills", "browser-automation"));
   });
 
+  it("loads hardlinked skills only from trusted bundled plugins", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const packageCacheDir = path.join(workspaceDir, ".package-cache");
+    await fs.mkdir(packageCacheDir, { recursive: true });
+
+    for (const plugin of [
+      { id: "browser", skill: "bundled-hardlinked-skill" },
+      { id: "workspace-skills", skill: "workspace-hardlinked-skill" },
+    ]) {
+      const pluginRoot = path.join(workspaceDir, ".openclaw", "extensions", plugin.id);
+      await writePluginWithSkill({
+        pluginRoot,
+        pluginId: plugin.id,
+        skillId: plugin.skill,
+        skillDescription: `${plugin.id} hardlink fixture`,
+      });
+      const skillFile = path.join(pluginRoot, "skills", plugin.skill, "SKILL.md");
+      await fs.link(skillFile, path.join(packageCacheDir, `${plugin.skill}.md`));
+      expect((await fs.stat(skillFile)).nlink).toBeGreaterThan(1);
+    }
+
+    const warn = captureWarningLogger();
+    const entries = loadTestWorkspaceSkills(workspaceDir, {
+      config: {
+        plugins: {
+          entries: { browser: { enabled: true }, "workspace-skills": { enabled: true } },
+        },
+      },
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("bundled-hardlinked-skill");
+    expect(entries.map((entry) => entry.skill.name)).not.toContain("workspace-hardlinked-skill");
+    expect(warn.mock.calls.map(([line]) => String(line))).toEqual(
+      expect.arrayContaining([expect.stringContaining("workspace-hardlinked-skill")]),
+    );
+  });
+
   it("loads frontmatter edge cases in one workspace", async () => {
     const workspaceDir = await createTempWorkspaceDir();
     const skillDir = path.join(workspaceDir, "skills", "fallback-name");

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { shouldRejectHardlinkedPluginFiles } from "../../plugins/hardlink-policy.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { CONFIG_DIR, resolveUserPath } from "../../utils.js";
@@ -40,7 +41,11 @@ import {
   readSkillFrontmatterSafe,
   type LocalSkillLoadDiagnostic,
 } from "./local-loader.js";
-import { resolvePluginSkillDirs, resolvePluginSkillDirsFromMetadata } from "./plugin-skills.js";
+import {
+  resolvePluginSkillRoots,
+  resolvePluginSkillRootsFromMetadata,
+  type PluginSkillRoot,
+} from "./plugin-skills.js";
 import type { Skill } from "./skill-contract.js";
 import { compactSkillPath, resolveSkillsUserHomeDir } from "./skill-paths.js";
 import {
@@ -51,6 +56,7 @@ import {
   type CandidateSkillDir,
   type ResolvedSkillDiscoveryLimits,
 } from "./skill-root-discovery.js";
+import { resolveSkillTelemetrySourceValue } from "./source.js";
 import { resolveAllowedSkillSymlinkTargetRealPaths, tryRealpath } from "./symlink-targets.js";
 
 const skillsLogger = createSubsystemLogger("skills");
@@ -64,6 +70,7 @@ const reportedSkillCollisions = new Map<string, true>();
 type LoadedSkillRecord = {
   skill: Skill;
   frontmatter?: ParsedSkillFrontmatter;
+  rejectHardlinks: boolean;
   syncSourceDir?: string;
   syncDirName?: string;
 };
@@ -187,18 +194,21 @@ function loadContainedSkillRecords(params: {
   source: string;
   maxSkillFileBytes: number;
   canonicalSkillDir?: string;
+  rejectHardlinks: boolean;
 }): LoadedSkillRecord[] {
   const expectedBaseDir = path.resolve(params.skillDir);
   const loaded = loadSkillsFromDirSafe({
     dir: params.skillDir,
     source: params.source,
     maxBytes: params.maxSkillFileBytes,
+    rejectHardlinks: params.rejectHardlinks,
     onDiagnostic: (diagnostic) => warnInvalidSkill(params.source, diagnostic),
   });
   const records = loaded.skills
     .map((skill) => ({
       skill,
       frontmatter: loaded.frontmatterByFilePath.get(skill.filePath),
+      rejectHardlinks: params.rejectHardlinks,
     }))
     .filter((record) => path.resolve(record.skill.baseDir) === expectedBaseDir);
   const canonicalSkillDir = params.canonicalSkillDir;
@@ -290,6 +300,7 @@ function loadDiscoveredSkillRecords(params: {
   source: string;
   limits: ResolvedSkillDiscoveryLimits;
   allowedSymlinkTargetRealPaths: readonly string[];
+  rejectHardlinks: boolean;
 }): LoadedSkillRecord[] {
   const discovered = discoverSkillCandidates(params);
   const maxSkillsLoadedPerSource = Math.max(0, params.limits.maxSkillsLoadedPerSource);
@@ -299,6 +310,7 @@ function loadDiscoveredSkillRecords(params: {
       source: params.source,
       maxSkillFileBytes: params.limits.maxSkillFileBytes,
       canonicalSkillDir: canonicalSkillDirForSource(params.source, candidate.skillDirRealPath),
+      rejectHardlinks: params.rejectHardlinks,
     });
   if (discovered.configuredRootCandidate) {
     const rootRecords = loadCandidate(discovered.configuredRootCandidate);
@@ -324,18 +336,26 @@ function loadDiscoveredSkillRecords(params: {
 
 function loadGeneratedPluginSkillRecords(params: {
   pluginSkillsDir: string;
-  pluginSkillDirs: readonly string[];
+  pluginSkillRoots: readonly PluginSkillRoot[];
   source: string;
   limits: ResolvedSkillDiscoveryLimits;
 }): LoadedSkillRecord[] {
-  const candidates = discoverPluginSkills(params);
+  const candidates = discoverPluginSkills({
+    ...params,
+    pluginSkillDirs: params.pluginSkillRoots.map((root) => root.dir),
+  });
   const maxSkillsLoadedPerSource = Math.max(0, params.limits.maxSkillsLoadedPerSource);
   const loadedSkills: LoadedSkillRecord[] = [];
   for (const candidate of candidates) {
+    const pluginRoot = params.pluginSkillRoots.find((root) => {
+      const rootRealPath = tryRealpath(root.dir);
+      return rootRealPath !== null && isPathInside(rootRealPath, candidate.skillDirRealPath);
+    });
     const loadedRecords = loadContainedSkillRecords({
       skillDir: candidate.skillDir,
       source: params.source,
       maxSkillFileBytes: params.limits.maxSkillFileBytes,
+      rejectHardlinks: pluginRoot?.rejectHardlinks ?? true,
     });
     loadedSkills.push(
       ...loadedRecords.map((record) =>
@@ -403,8 +423,23 @@ function loadSkillEntries(
 
   const limits = resolveSkillDiscoveryLimits(opts?.config);
   const allowedSymlinkTargetRealPaths = resolveAllowedSkillSymlinkTargetRealPaths(opts?.config);
-  const loadSkills = (params: { dir: string; source: string }): LoadedSkillRecord[] =>
-    loadDiscoveredSkillRecords({ ...params, limits, allowedSymlinkTargetRealPaths });
+  const loadSkills = (params: {
+    dir: string;
+    source: string;
+    rejectHardlinks?: boolean;
+  }): LoadedSkillRecord[] =>
+    loadDiscoveredSkillRecords({
+      ...params,
+      limits,
+      allowedSymlinkTargetRealPaths,
+      rejectHardlinks:
+        params.rejectHardlinks ??
+        shouldRejectHardlinkedPluginFiles({
+          origin:
+            resolveSkillTelemetrySourceValue(params.source) === "bundled" ? "bundled" : "workspace",
+          rootDir: params.dir,
+        }),
+    });
   const managedSkillsDir = opts?.managedSkillsDir ?? path.join(CONFIG_DIR, "skills");
   const bundledSkillsDir = workspaceOnly
     ? undefined
@@ -412,17 +447,16 @@ function loadSkillEntries(
   const pluginSkillsDir = opts?.pluginSkillsDir ?? path.join(CONFIG_DIR, "plugin-skills");
   const extraDirsRaw = workspaceOnly ? [] : (opts?.config?.skills?.load?.extraDirs ?? []);
   const extraDirs = normalizeTrimmedStringList(extraDirsRaw);
-  const pluginSkillDirs = workspaceOnly
+  const pluginSkillRoots = workspaceOnly
     ? []
     : opts?.pluginMetadataSnapshot
-      ? resolvePluginSkillDirsFromMetadata({
+      ? resolvePluginSkillRootsFromMetadata({
           workspaceDir,
           config: opts.config,
           pluginSkillsDir,
           metadataSnapshot: opts.pluginMetadataSnapshot,
         })
-      : resolvePluginSkillDirs({ workspaceDir, config: opts?.config, pluginSkillsDir });
-  const mergedExtraDirs = [...extraDirs, ...pluginSkillDirs];
+      : resolvePluginSkillRoots({ workspaceDir, config: opts?.config, pluginSkillsDir });
 
   const bundledSkills = bundledSkillsDir
     ? loadSkills({ dir: bundledSkillsDir, source: "openclaw-bundled" })
@@ -435,12 +469,19 @@ function loadSkillEntries(
     ? loadSkills({ dir: custodianSkillsDir, source: "openclaw-custodian" })
     : [];
   const extraSkills = [
-    ...mergedExtraDirs.flatMap((dir) =>
+    ...extraDirs.flatMap((dir) =>
       loadSkills({ dir: resolveUserPath(dir), source: "openclaw-extra" }),
+    ),
+    ...pluginSkillRoots.flatMap((root) =>
+      loadSkills({
+        dir: root.dir,
+        source: "openclaw-extra",
+        rejectHardlinks: root.rejectHardlinks,
+      }),
     ),
     ...loadGeneratedPluginSkillRecords({
       pluginSkillsDir,
-      pluginSkillDirs,
+      pluginSkillRoots,
       source: "openclaw-extra",
       limits,
     }),
@@ -509,6 +550,7 @@ function loadSkillEntries(
           rootDir: skill.baseDir,
           filePath: skill.filePath,
           maxBytes: limits.maxSkillFileBytes,
+          rejectHardlinks: record.rejectHardlinks,
         }) ??
         ({} as ParsedSkillFrontmatter);
       const invocation = resolveSkillInvocationPolicy(frontmatter);

--- a/src/skills/loading/workspace-skill-snapshot.test.ts
+++ b/src/skills/loading/workspace-skill-snapshot.test.ts
@@ -18,7 +18,7 @@ import {
 import { buildSkillSnapshot } from "./workspace-skill-prompt.js";
 
 vi.mock("./plugin-skills.js", () => ({
-  resolvePluginSkillDirs: () => [],
+  resolvePluginSkillRoots: () => [],
 }));
 
 const fixtureSuite = createFixtureSuite("openclaw-skills-snapshot-suite-");

--- a/src/skills/loading/workspace-skill-sync.runtime.test.ts
+++ b/src/skills/loading/workspace-skill-sync.runtime.test.ts
@@ -10,10 +10,12 @@ import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { buildSkillSnapshot } from "./workspace-skill-prompt.js";
 import { syncWorkspaceSkills } from "./workspace-skill-sync.runtime.js";
 
-const mockResolvePluginSkillDirs = vi.hoisted(() => vi.fn(() => [] as string[]));
+const mockResolvePluginSkillRoots = vi.hoisted(() =>
+  vi.fn(() => [] as Array<{ dir: string; rejectHardlinks: boolean }>),
+);
 
 vi.mock("./plugin-skills.js", () => ({
-  resolvePluginSkillDirs: mockResolvePluginSkillDirs,
+  resolvePluginSkillRoots: mockResolvePluginSkillRoots,
 }));
 
 async function pathExists(filePath: string): Promise<boolean> {
@@ -758,7 +760,9 @@ describe("syncWorkspaceSkills for plugin skills", () => {
       process.platform === "win32" ? "junction" : "dir",
     );
 
-    mockResolvePluginSkillDirs.mockReturnValueOnce([realPluginSkillDir]);
+    mockResolvePluginSkillRoots.mockReturnValueOnce([
+      { dir: realPluginSkillDir, rejectHardlinks: true },
+    ]);
 
     const skillUsagePaths = await syncWorkspaceSkills({
       sourceWorkspaceDir: sourceWorkspace,
@@ -827,7 +831,10 @@ describe("syncWorkspaceSkills for plugin skills", () => {
       process.platform === "win32" ? "junction" : "dir",
     );
 
-    mockResolvePluginSkillDirs.mockReturnValueOnce([realSkillA, realSkillB]);
+    mockResolvePluginSkillRoots.mockReturnValueOnce([
+      { dir: realSkillA, rejectHardlinks: true },
+      { dir: realSkillB, rejectHardlinks: true },
+    ]);
 
     await syncWorkspaceSkills({
       sourceWorkspaceDir: sourceWorkspace,
@@ -870,7 +877,7 @@ describe("syncWorkspaceSkills for plugin skills", () => {
 
     // Mock returns an allowed root that doesn't include the escaped skill
     const allowedRoot = await createCaseDir("allowed-root");
-    mockResolvePluginSkillDirs.mockReturnValueOnce([allowedRoot]);
+    mockResolvePluginSkillRoots.mockReturnValueOnce([{ dir: allowedRoot, rejectHardlinks: true }]);
 
     await syncWorkspaceSkills({
       sourceWorkspaceDir: sourceWorkspace,

--- a/src/skills/runtime/refresh.test.ts
+++ b/src/skills/runtime/refresh.test.ts
@@ -40,8 +40,10 @@ const watchMock = vi.fn(() => {
   return watcher;
 });
 const pluginSkillsMocks = vi.hoisted(() => ({
-  resolvePluginSkillDirs: vi.fn((): string[] => []),
-  resolvePluginSkillDirsFromMetadata: vi.fn((): string[] => []),
+  resolvePluginSkillRoots: vi.fn((): Array<{ dir: string; rejectHardlinks: boolean }> => []),
+  resolvePluginSkillRootsFromMetadata: vi.fn(
+    (): Array<{ dir: string; rejectHardlinks: boolean }> => [],
+  ),
 }));
 
 let refreshModule: typeof import("./refresh.js");
@@ -52,8 +54,8 @@ vi.mock("chokidar", () => ({
 }));
 
 vi.mock("../loading/plugin-skills.js", () => ({
-  resolvePluginSkillDirs: pluginSkillsMocks.resolvePluginSkillDirs,
-  resolvePluginSkillDirsFromMetadata: pluginSkillsMocks.resolvePluginSkillDirsFromMetadata,
+  resolvePluginSkillRoots: pluginSkillsMocks.resolvePluginSkillRoots,
+  resolvePluginSkillRootsFromMetadata: pluginSkillsMocks.resolvePluginSkillRootsFromMetadata,
 }));
 
 describe("ensureSkillsWatcher", () => {
@@ -65,8 +67,8 @@ describe("ensureSkillsWatcher", () => {
   beforeEach(() => {
     watchMock.mockClear();
     createdWatchers.length = 0;
-    pluginSkillsMocks.resolvePluginSkillDirs.mockClear();
-    pluginSkillsMocks.resolvePluginSkillDirsFromMetadata.mockClear();
+    pluginSkillsMocks.resolvePluginSkillRoots.mockClear();
+    pluginSkillsMocks.resolvePluginSkillRootsFromMetadata.mockClear();
   });
 
   afterEach(async () => {
@@ -557,9 +559,9 @@ describe("ensureSkillsWatcher", () => {
       pluginMetadataSnapshot,
     });
 
-    expect(pluginSkillsMocks.resolvePluginSkillDirs).not.toHaveBeenCalled();
-    expect(pluginSkillsMocks.resolvePluginSkillDirsFromMetadata).toHaveBeenCalledTimes(2);
-    expect(pluginSkillsMocks.resolvePluginSkillDirsFromMetadata).toHaveBeenLastCalledWith({
+    expect(pluginSkillsMocks.resolvePluginSkillRoots).not.toHaveBeenCalled();
+    expect(pluginSkillsMocks.resolvePluginSkillRootsFromMetadata).toHaveBeenCalledTimes(2);
+    expect(pluginSkillsMocks.resolvePluginSkillRootsFromMetadata).toHaveBeenLastCalledWith({
       workspaceDir: "/tmp/workspace",
       config,
       metadataSnapshot: pluginMetadataSnapshot,
@@ -699,7 +701,9 @@ describe("ensureSkillsWatcher", () => {
         "---\nname: demo\ndescription: Demo\n---\n",
       );
       const pluginSkills = await import("../loading/plugin-skills.js");
-      vi.mocked(pluginSkills.resolvePluginSkillDirs).mockReturnValueOnce([pluginDir]);
+      vi.mocked(pluginSkills.resolvePluginSkillRoots).mockReturnValueOnce([
+        { dir: pluginDir, rejectHardlinks: true },
+      ]);
 
       refreshModule.ensureSkillsWatcher({ workspaceDir: "/tmp/workspace" });
 
@@ -722,7 +726,9 @@ describe("ensureSkillsWatcher", () => {
     );
     try {
       const pluginSkills = await import("../loading/plugin-skills.js");
-      vi.mocked(pluginSkills.resolvePluginSkillDirs).mockReturnValueOnce([pluginDir]);
+      vi.mocked(pluginSkills.resolvePluginSkillRoots).mockReturnValueOnce([
+        { dir: pluginDir, rejectHardlinks: true },
+      ]);
 
       refreshModule.ensureSkillsWatcher({ workspaceDir: "/tmp/workspace" });
 
@@ -754,7 +760,9 @@ describe("ensureSkillsWatcher", () => {
         );
         await fs.symlink(outsideDir, path.join(pluginDir, "skills", "untrusted"), "dir");
         const pluginSkills = await import("../loading/plugin-skills.js");
-        vi.mocked(pluginSkills.resolvePluginSkillDirs).mockReturnValueOnce([pluginDir]);
+        vi.mocked(pluginSkills.resolvePluginSkillRoots).mockReturnValueOnce([
+          { dir: pluginDir, rejectHardlinks: true },
+        ]);
 
         refreshModule.ensureSkillsWatcher({ workspaceDir: "/tmp/workspace" });
 

--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -11,8 +11,8 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { CONFIG_DIR, resolveUserPath } from "../../utils.js";
 import {
-  resolvePluginSkillDirs,
-  resolvePluginSkillDirsFromMetadata,
+  resolvePluginSkillRoots,
+  resolvePluginSkillRootsFromMetadata,
 } from "../loading/plugin-skills.js";
 import {
   resolveAllowedSkillSymlinkTargetRealPaths,
@@ -128,13 +128,14 @@ function resolveWatchTargets(
     .map((d) => normalizeOptionalString(d) ?? "")
     .filter(Boolean)
     .map((dir) => resolveUserPath(dir));
-  const pluginSkillDirs = pluginMetadataSnapshot
-    ? resolvePluginSkillDirsFromMetadata({
+  const pluginSkillRoots = pluginMetadataSnapshot
+    ? resolvePluginSkillRootsFromMetadata({
         workspaceDir,
         config,
         metadataSnapshot: pluginMetadataSnapshot,
       })
-    : resolvePluginSkillDirs({ workspaceDir, config });
+    : resolvePluginSkillRoots({ workspaceDir, config });
+  const pluginSkillDirs = pluginSkillRoots.map((root) => root.dir);
   const allowedSymlinkTargetRealPaths = resolveAllowedSkillSymlinkTargetRealPaths(config);
   const signature = JSON.stringify({
     basePaths: baseRoots.map((root) => toWatchRoot(root.path)),


### PR DESCRIPTION
Closes #116594. Follow-up to #129589.

## What Problem This Solves

Linux Bun installations and optimized immutable Nix stores legitimately hardlink package files, but OpenClaw treated every hardlinked `SKILL.md` as hostile. As a result, trusted bundled skills, custodian skills, and bundled-plugin skills were silently omitted or emitted repeated `path must not be hardlinked` warnings during normal skills listing, doctor, and updates.

## Why This Change Was Made

Carry an explicit, default-strict hardlink policy to the common descriptor-pinned skill file reader. Derive trusted package policy from authoritative bundled/custodian source ownership and preserve the actual plugin manifest origin throughout direct plugin skill discovery, generated skill aliases, and skill watchers. Reuse OpenClaw's existing bundled-versus-immutable-Nix plugin hardlink policy instead of weakening root containment, symlink validation, ClawHub integrity guards, or third-party/workspace security.

## User Impact

Skills bundled with Bun-installed OpenClaw and its bundled plugins load normally. Immutable Nix-store skill roots use the same verified Nix-mode policy already established for plugins. Hardlinked workspace, managed, configured-extra, and installed third-party plugin skills remain rejected; ordinary skills in those locations continue to load.

## Evidence

- Before the fix, three real-filesystem `fs.link` regressions failed independently for core bundled skills, custodian skills, and bundled-plugin skills; hostile mutable-root controls already passed.
- Focused owner/sibling coverage: 211 tests across 14 suites passed, including real bundled/custodian hardlinks, direct/generated bundled-plugin provenance, workspace/managed/configured-extra/plugin rejection, preserved symlink containment, immutable-Nix policy, watcher discovery, and existing skill lifecycle security guards.
- The full changed-code repository gate passed, including production/test typechecks, lint, plugin boundaries, dead exports, storage policy, import cycles, and security guards.
- Independent structured security review: clean, with no actionable findings.
- Real remote Hetzner Crabbox proof with official Bun 1.4 and genuinely hardlinked package files (`nlink=2`): published OpenClaw 2026.7.1-2 silently exposes zero bundled skills and emits no warning; the exact PR head restores 55 bundled skills, including weather and a bundled plugin, without bundled hardlink warnings.
- The same installed CLI rejects genuinely hardlinked malicious skills separately in managed, workspace, and explicitly configured-extra roots while accepting ordinary skills from each location; the real installed `doctor --non-interactive` exits successfully. Recorded run: https://crabbox.openclaw.ai/portal/runs/run_9e5a9b2b6f0f
- Independent strictly source-blind replay using only the installed CLI separately confirmed Bun 1.4.0, real `nlink=2`, 55 bundled skills, all three malicious-root rejections, all three ordinary controls, successful doctor, and preserved custom Bun installation ownership: https://crabbox.openclaw.ai/portal/runs/run_24568fc930a8
- Exact-head GitHub CI run 32908975741 passed all 202 checks.

Thanks @eva-nebot for the independently reported Nix-store reproduction in #116594.
