### PR TITLE
fix(buzz): stop named account setup from replacing the existing bot identity

### DIFF
--- a/extensions/buzz/src/setup-core.test.ts
+++ b/extensions/buzz/src/setup-core.test.ts
@@ -40,6 +40,29 @@ describe("buzzSetupContract", () => {
     expect(cfg.channels?.buzz).toEqual(buzz);
   });
 
+  it("rejects named environment-backed setup without changing the existing bot identity", () => {
+    const existingPrivateKey = "11".repeat(32);
+    vi.stubEnv("BUZZ_PRIVATE_KEY", existingPrivateKey);
+    const buzz = {
+      enabled: false,
+      relayUrl: "wss://original.example.com",
+      authTag: '["auth","owner","kind=9","signature"]',
+    };
+    const cfg = { channels: { buzz } } as OpenClawConfig;
+    const input = { relayUrl: "wss://new.example.com", useEnv: true };
+    const requestedAccountId = "ada";
+    const resolvedAccountId =
+      buzzSetupContract.resolveAccountId?.({ cfg, accountId: requestedAccountId, input }) ??
+      requestedAccountId;
+
+    expect(resolvedAccountId).toBe(requestedAccountId);
+    expect(buzzSetupContract.validateInput?.({ cfg, accountId: resolvedAccountId, input })).toBe(
+      "Buzz currently supports only the default account.",
+    );
+    expect(cfg.channels?.buzz).toEqual(buzz);
+    expect(process.env.BUZZ_PRIVATE_KEY).toBe(existingPrivateKey);
+  });
+
   it("validates and applies BUZZ_PRIVATE_KEY setup without storing the key", () => {
     expect(buzzSetupContract.metadata.fields.find((field) => field.key === "useEnv")).toMatchObject(
       {

--- a/extensions/buzz/src/setup-core.test.ts
+++ b/extensions/buzz/src/setup-core.test.ts
@@ -7,6 +7,39 @@ describe("buzzSetupContract", () => {
     vi.unstubAllEnvs();
   });
 
+  it.each([
+    {
+      name: "plaintext private key",
+      privateKey: "11".repeat(32),
+    },
+    {
+      name: "private-key SecretRef",
+      privateKey: { source: "env" as const, provider: "default", id: "BUZZ_EXISTING_KEY" },
+    },
+  ])("rejects named account setup without changing the existing $name", ({ privateKey }) => {
+    const buzz = {
+      enabled: false,
+      relayUrl: "wss://original.example.com",
+      privateKey,
+      authTag: '["auth","owner","kind=9","signature"]',
+    };
+    const cfg = { channels: { buzz } } as OpenClawConfig;
+    const input = {
+      relayUrl: "wss://new.example.com",
+      privateKey: "22".repeat(32),
+    };
+    const requestedAccountId = "ada";
+    const resolvedAccountId =
+      buzzSetupContract.resolveAccountId?.({ cfg, accountId: requestedAccountId, input }) ??
+      requestedAccountId;
+
+    expect(resolvedAccountId).toBe(requestedAccountId);
+    expect(buzzSetupContract.validateInput?.({ cfg, accountId: resolvedAccountId, input })).toBe(
+      "Buzz currently supports only the default account.",
+    );
+    expect(cfg.channels?.buzz).toEqual(buzz);
+  });
+
   it("validates and applies BUZZ_PRIVATE_KEY setup without storing the key", () => {
     expect(buzzSetupContract.metadata.fields.find((field) => field.key === "useEnv")).toMatchObject(
       {

--- a/extensions/buzz/src/setup-core.ts
+++ b/extensions/buzz/src/setup-core.ts
@@ -42,7 +42,6 @@ export function isSameBuzzIdentity(currentKey?: string, nextKey?: string): boole
 }
 
 const buzzSetupAdapter: ChannelSetupAdapter<BuzzSetupInput> = {
-  resolveAccountId: () => DEFAULT_ACCOUNT_ID,
   applyAccountName: ({ cfg, accountId, name }) =>
     applyAccountNameToChannelSection({
       cfg,


### PR DESCRIPTION
Closes #123200.

Supersedes the credential-loss portion of #123266 and #119076 without introducing a new Buzz multi-account configuration, credential inheritance, or migration surface.

## What Problem This Solves

Fixes an issue where operators adding a named Buzz account would silently overwrite the existing default account's private key and bot identity instead of being told that Buzz currently supports only one account.

## Why This Change Was Made

Buzz already rejects unsupported non-default accounts, but its own account resolver replaced every requested account ID with `default` before that validation ran. Removing the unnecessary plugin-specific resolver restores the shared setup pipeline's canonical account normalization, so the existing owner validation fails before any account name, credential, enabled state, or configuration can be changed.

This intentionally preserves the shipped single-account configuration and existing SecretRef ownership. Full multi-account support remains a separate product/configuration decision rather than being bundled into a release-scope data-loss fix.

## User Impact

`openclaw channels add --channel buzz --account ada ...` now exits with `Buzz currently supports only the default account.` and leaves the existing identity untouched. Omitting `--account` or explicitly selecting `--account default` continues to configure the default account normally.

## Evidence

- Regression-first proof: all three new owner-boundary cases failed against the original code with `expected 'default' to be 'ada'`, covering an existing plaintext private key, an existing SecretRef, and an environment-backed private key.
- Focused owner and sibling proof: `node scripts/run-vitest.mjs extensions/buzz/src/setup-core.test.ts extensions/buzz/src/setup-surface.test.ts extensions/buzz/src/types.test.ts src/channels/plugins/account-config-mutation.test.ts` — four test files, 27 tests passed.
- Real setup-owner boundary: the actual `prepareChannelAccountConfiguration` and Buzz setup plugin reject named accounts for both plaintext and SecretRef credentials before mutation, preserving the original key, relay, auth tag, and channel-disabled state; the actual `applyPreparedChannelAccountConfiguration` still updates the default account successfully. Environment-backed setup separately preserves both the existing config and environment credential.
- Changed gate: `node scripts/check-changed.mjs -- extensions/buzz/src/setup-core.ts extensions/buzz/src/setup-core.test.ts`.
- Targeted formatting and `git diff --check` passed.
- Fresh structured autoreview: no accepted/actionable findings.
- Production LOC: +0/-1. Tests: +56/-0.
- Thanks to @chachi-max for the precise reproduction and @yu-xin-c and @atlas-maxjb for the earlier investigation and proposed fixes; both PR authors are preserved as commit co-authors.

AI-assisted: yes.
