### PR TITLE
fix(ai): local-model tool calls fail in standalone library streams

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -505,10 +505,10 @@ export const streamOpenAICompletions: StreamFunction<
         }
 
         if (choice.finish_reason) {
-          const finishReasonResult = mapOpenAIStopReason(choice.finish_reason);
-          output.stopReason = finishReasonResult.stopReason;
-          if (finishReasonResult.errorMessage) {
-            output.errorMessage = finishReasonResult.errorMessage;
+          const reason = mapOpenAIStopReason(choice.finish_reason, { allowSingularToolCall: true });
+          output.stopReason = reason.stopReason;
+          if (reason.errorMessage) {
+            output.errorMessage = reason.errorMessage;
           }
           hasFinishReason = true;
         }

--- a/packages/ai/src/transports/openai-completions-stream.integration.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.integration.test.ts
@@ -1,6 +1,8 @@
 import { createServer } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import { streamWithIdleTimeout } from "../../../../src/agents/embedded-agent-runner/run/llm-idle-timeout.js";
+import { registerBuiltInApiProviders } from "../providers/register-builtins.js";
+import { createLlmRuntime } from "../stream.js";
 import { shouldEmitOpenAICompletionsReasoning } from "./openai-completions-stream.js";
 import { createOpenAICompletionsTransportStreamFn } from "./openai-completions-transport.js";
 import { makeCompletionsChunk, makeCompletionsModel } from "./openai-completions.test-support.js";
@@ -125,6 +127,88 @@ describe("openai completions stream", () => {
       } as never),
     ).toBe(true);
   });
+
+  it.each([
+    { finishReason: "tool_call", emitsTool: true, stopReason: "toolUse" },
+    { finishReason: "tool_call", emitsTool: false, stopReason: "stop" },
+    { finishReason: "tool_calls", emitsTool: true, stopReason: "toolUse" },
+    { finishReason: "function_call", emitsTool: true, stopReason: "toolUse" },
+    { finishReason: "unknown", emitsTool: true, stopReason: "error" },
+  ])(
+    "handles $finishReason with emitsTool=$emitsTool through the public LLM runtime",
+    async ({ finishReason, emitsTool, stopReason }) => {
+      const server = createServer((req, res) => {
+        req.resume();
+        req.on("end", () => {
+          res.writeHead(200, { "content-type": "text/event-stream; charset=utf-8" });
+          const delta = emitsTool
+            ? {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_lookup",
+                    type: "function",
+                    function: { name: "lookup", arguments: '{"query":"local"}' },
+                  },
+                ],
+              }
+            : { role: "assistant", content: "No tool required." };
+          for (const chunk of [
+            makeCompletionsChunk(delta),
+            makeCompletionsChunk({}, finishReason),
+          ]) {
+            res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+          }
+          res.end("data: [DONE]\n\n");
+        });
+      });
+
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      try {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("Missing loopback server address");
+        }
+        const model = makeCompletionsModel({
+          id: "minimax-m2.5-8bit",
+          provider: "mlx-lm",
+          baseUrl: `http://127.0.0.1:${address.port}/v1`,
+          reasoning: false,
+        });
+        const runtime = createLlmRuntime();
+        registerBuiltInApiProviders(runtime.registry);
+        const stream = runtime.streamSimple(
+          model,
+          { messages: [{ role: "user", content: "Look it up.", timestamp: 1 }] },
+          { apiKey: "synthetic-test-key" },
+        );
+        const result = await stream.result();
+
+        expect(result.stopReason).toBe(stopReason);
+        const toolCalls = result.content.filter((block) => block.type === "toolCall");
+        if (stopReason === "toolUse") {
+          expect(toolCalls).toEqual([
+            expect.objectContaining({
+              id: "call_lookup",
+              name: "lookup",
+              arguments: { query: "local" },
+            }),
+          ]);
+        } else {
+          expect(toolCalls).toEqual([]);
+        }
+        if (finishReason === "unknown") {
+          expect(result.errorMessage).toBe("Provider finish_reason: unknown");
+        }
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
 
   it.concurrent.each(["reasoning_content", "reasoning"] as const)(
     "keeps hidden local %s streams alive beyond the model idle timeout",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers using the published [`@openclaw/ai` standalone-runtime quick start](https://github.com/openclaw/openclaw/blob/main/docs/reference/openclaw-ai.md#quick-start) would lose valid executable tool calls from OpenAI-compatible local servers that finish with the singular `tool_call` reason. The direct built-in provider instead returned `Provider finish_reason: tool_call` and discarded the parsed tool.

The existing managed-transport regression already documents this observed local-server compatibility shape with `mlx-lm` and a MiniMax model, but the separately published runtime's direct registered adapter did not apply the same compatibility option.

## Why This Change Was Made

Opt the direct OpenAI-completions provider into the same existing canonical finish-reason compatibility already used by the managed sibling. Preserve the shared mapper's strict default, reject unknown finish reasons, and downgrade a tool finish without an actual executable tool. Production code is net-zero lines.

## User Impact

Standalone `@openclaw/ai` consumers and other direct built-in-provider callers can now execute valid tool calls from local OpenAI-compatible servers that return `finish_reason: "tool_call"`.

The ordinary embedded Gateway already uses the managed OpenAI-completions transport and was not affected; this change repairs the documented standalone-library/direct-consumer surface.

## Evidence

- Exercised the documented `createLlmRuntime()`, `registerBuiltInApiProviders()`, and `runtime.streamSimple()` flow against a real ephemeral localhost HTTP/SSE server using synthetic credentials.
- Before: a valid streamed `lookup` tool returned `stopReason: "error"`, `Provider finish_reason: tool_call`, and zero executable tools. After: the identical response returned `stopReason: "toolUse"` and the parsed `lookup` tool.
- Added a five-case real-HTTP regression covering singular tool use, singular finish without a tool, plural tool use, legacy function calls, and unknown-reason rejection. The two singular cases failed before the production change; all five passed afterward.
- Final focused direct-provider, managed-transport, mapper, streaming, reasoning, tool-assembly, and usage suites: **8 files, 122 tests passed**.
- Focused formatting and lint checks passed; two independent reviews and the final mandatory automated review found no actionable issues.
- Production: `+4/-4` (net zero). Regression tests: `+84/-0`.
