### PR TITLE
fix(crabbox): keep cloud worker credentials out of process arguments

### DIFF
--- a/extensions/crabbox/src/crabbox-worker-env-profile.ts
+++ b/extensions/crabbox/src/crabbox-worker-env-profile.ts
@@ -1,0 +1,40 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WorkerProviderError } from "openclaw/plugin-sdk/plugin-entry";
+
+export async function withCrabboxWorkerEnvProfile<Result>(
+  values: Record<string, string> | undefined,
+  run: (names: string[], path: string | undefined, childEnv: NodeJS.ProcessEnv) => Promise<Result>,
+): Promise<Result> {
+  const entries = Object.entries(values ?? {});
+  const names = entries.map(([name]) => name);
+  let directory: string | undefined;
+  try {
+    let profilePath: string | undefined;
+    if (entries.length > 0) {
+      const profile = entries
+        .map(([name, value]) => {
+          if (["\0", "\r", "\n", "`", "$("].some((unsafe) => value.includes(unsafe))) {
+            throw new WorkerProviderError(
+              `Crabbox setup environment value cannot be represented safely: ${name}`,
+            );
+          }
+          return `${name}="${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+        })
+        .join("\n");
+      directory = await mkdtemp(join(tmpdir(), "openclaw-crabbox-env-"));
+      profilePath = join(directory, "setup.env");
+      await writeFile(profilePath, `${profile}\n`, { mode: 0o600, flag: "wx" });
+    }
+    // Explicit deletion prevents profile-backed secrets from leaking through inherited SSH argv.
+    return await run(names, profilePath, {
+      ...Object.fromEntries(names.map((name) => [name, undefined])),
+      CRABBOX_ENV_ALLOW: ",",
+    });
+  } finally {
+    if (directory) {
+      await rm(directory, { force: true, recursive: true });
+    }
+  }
+}

--- a/extensions/crabbox/src/crabbox-worker-env-profile.ts
+++ b/extensions/crabbox/src/crabbox-worker-env-profile.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { WorkerProviderError } from "openclaw/plugin-sdk/plugin-entry";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 
 export async function withCrabboxWorkerEnvProfile<Result>(
   values: Record<string, string> | undefined,
@@ -23,7 +23,7 @@ export async function withCrabboxWorkerEnvProfile<Result>(
           return `${name}="${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
         })
         .join("\n");
-      directory = await mkdtemp(join(tmpdir(), "openclaw-crabbox-env-"));
+      directory = await mkdtemp(join(resolvePreferredOpenClawTmpDir(), "openclaw-crabbox-env-"));
       profilePath = join(directory, "setup.env");
       await writeFile(profilePath, `${profile}\n`, { mode: 0o600, flag: "wx" });
     }

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -642,7 +642,7 @@ describe("Crabbox worker provider", () => {
       name: "with only explicitly forwarded Gateway environment",
       setupEnv: ["OPENCLAW_WORKER_ARTIFACT_TOKEN", "CRABBOX_EMPTY_VALUE"],
       forwardedEnv: {
-        OPENCLAW_WORKER_ARTIFACT_TOKEN: "fixture-artifact-token",
+        OPENCLAW_WORKER_ARTIFACT_TOKEN: "fixture artifact #tag \"quoted\" \\path 'single'",
         CRABBOX_EMPTY_VALUE: "",
       },
     },
@@ -655,6 +655,11 @@ describe("Crabbox worker provider", () => {
         vi.stubEnv(name, value);
       }
       const calls: Array<{ argv: string[]; options: Parameters<CrabboxCommandRunner>[1] }> = [];
+      const profileObservations = new Map<
+        string,
+        { directoryMode: number; fileMode: number; valuesMatch: boolean }
+      >();
+      const setup = "command -v node || install-node";
       let warmed = false;
       const provider = providerWithRunner(async (argv, options) => {
         calls.push({ argv, options });
@@ -663,6 +668,24 @@ describe("Crabbox worker provider", () => {
           return commandResult({ stdout: `leased ${LEASE_ID} slug=test\n` });
         }
         if (argv[1] === "run") {
+          const expectedEnv =
+            options.input === setup
+              ? forwardedEnv
+              : { CRABBOX_WORKER_SETUP_CODE: "secret-setup-value" };
+          const profileFlagIndex = argv.indexOf("--env-from-profile");
+          const profilePath = profileFlagIndex < 0 ? undefined : argv[profileFlagIndex + 1];
+          if (expectedEnv && profilePath) {
+            const lines = fs.readFileSync(profilePath, "utf8").split("\n");
+            profileObservations.set(profilePath, {
+              directoryMode: fs.statSync(path.dirname(profilePath)).mode & 0o777,
+              fileMode: fs.statSync(profilePath).mode & 0o777,
+              valuesMatch: Object.entries(expectedEnv).every(([name, value]) =>
+                lines.includes(
+                  `${name}="${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`,
+                ),
+              ),
+            });
+          }
           return commandResult();
         }
         return warmed || argv.includes(LEASE_ID)
@@ -670,12 +693,53 @@ describe("Crabbox worker provider", () => {
           : commandResult({ code: 4, stderr: `lease/server not found: ${argv.at(-2)}` });
       });
 
-      const setup = "command -v node || install-node";
       const profile = { ...PROFILE, setup, ...(setupEnv ? { setupEnv } : {}) };
       await expect(provider.provision(profile, OPERATION_ID)).resolves.toMatchObject({
         leaseId: LEASE_ID,
       });
       const [setupCall, enrollmentCall] = calls.filter((call) => call.argv[1] === "run");
+      for (const [call, expectedEnv] of [
+        [setupCall, forwardedEnv],
+        [enrollmentCall, { CRABBOX_WORKER_SETUP_CODE: "secret-setup-value" }],
+      ] as const) {
+        expect(call).toBeDefined();
+        if (!call) {
+          continue;
+        }
+        const profileFlagIndex = call.argv.indexOf("--env-from-profile");
+        if (expectedEnv) {
+          expect(profileFlagIndex).toBeGreaterThanOrEqual(0);
+          const profilePath = call.argv[profileFlagIndex + 1];
+          expect(profilePath).toBeDefined();
+          if (!profilePath) {
+            continue;
+          }
+          expect(profileObservations.get(profilePath)).toEqual({
+            directoryMode: 0o700,
+            fileMode: 0o600,
+            valuesMatch: true,
+          });
+          expect(fs.existsSync(profilePath)).toBe(false);
+          expect(fs.existsSync(path.dirname(profilePath))).toBe(false);
+          for (const value of Object.values(expectedEnv).filter(Boolean)) {
+            expect(call.argv.some((argument) => argument.includes(value))).toBe(false);
+            expect(Object.values(call.options.env ?? {}).includes(value)).toBe(false);
+          }
+        } else {
+          expect(profileFlagIndex).toBe(-1);
+        }
+        expect(
+          call.argv.filter((argument, index, argv) => argv[index - 1] === "--allow-env"),
+        ).toEqual(Object.keys(expectedEnv ?? {}));
+        for (const name of Object.keys(expectedEnv ?? {})) {
+          expect(Object.hasOwn(call.options.env ?? {}, name)).toBe(true);
+          expect(call.options.env?.[name]).toBeUndefined();
+        }
+        expect(call.options.env).toStrictEqual({
+          ...Object.fromEntries(Object.keys(expectedEnv ?? {}).map((name) => [name, undefined])),
+          CRABBOX_ENV_ALLOW: ",",
+        });
+      }
       expect(setupCall?.argv.slice(1)).toEqual([
         "run",
         "--provider",
@@ -688,19 +752,15 @@ describe("Crabbox worker provider", () => {
         "--keep=true",
         "--no-sync",
         ...Object.keys(forwardedEnv ?? {}).flatMap((name) => ["--allow-env", name]),
+        ...(forwardedEnv
+          ? [
+              "--env-from-profile",
+              setupCall?.argv[setupCall.argv.indexOf("--env-from-profile") + 1],
+            ]
+          : []),
         "--script-stdin",
       ]);
-      expect(setupCall?.options.env).toEqual({
-        ...forwardedEnv,
-        CRABBOX_ENV_ALLOW: setupEnv?.join(",") || ",",
-      });
       expect(setupCall?.options.input).toBe(setup);
-      expect(enrollmentCall?.options.env).toEqual({
-        CRABBOX_WORKER_SETUP_CODE: "secret-setup-value",
-      });
-      expect(
-        enrollmentCall?.argv.filter((argument, index, argv) => argv[index - 1] === "--allow-env"),
-      ).toEqual(["CRABBOX_WORKER_SETUP_CODE"]);
       expect(
         calls.filter((call) => call.argv[1] !== "run").every((call) => !call.options.env),
       ).toBe(true);
@@ -724,6 +784,37 @@ describe("Crabbox worker provider", () => {
     });
     expect(runCommand).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { name: "a newline", value: "fixture\nvalue" },
+    { name: "a carriage return", value: "fixture\rvalue" },
+    { name: "a backtick", value: "fixture`value" },
+    { name: "command substitution", value: "fixture$(value)" },
+  ])(
+    "rejects profile setup environment containing $name without exposing its value",
+    async ({ value }) => {
+      const envName = "OPENCLAW_WORKER_ARTIFACT_TOKEN";
+      vi.stubEnv(envName, value);
+      const calls: string[][] = [];
+      const provider = providerWithRunner(async (argv) => {
+        calls.push(argv);
+        return argv[1] === "inspect"
+          ? commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) })
+          : commandResult();
+      });
+
+      const error = await provider
+        .provision({ ...PROFILE, setup: "install-node", setupEnv: [envName] }, OPERATION_ID)
+        .catch((cause: unknown) => cause);
+
+      expect(error).toMatchObject({
+        code: "invalid_profile",
+        message: `Crabbox setup environment value cannot be represented safely: ${envName}`,
+      });
+      expect(error instanceof Error && error.message.includes(value)).toBe(false);
+      expect(calls.map((argv) => argv[1])).toEqual(["warmup", "inspect", "stop"]);
+    },
+  );
 
   it("waits for post-setup SSH readiness and returns the final endpoint", async () => {
     const calls: string[][] = [];
@@ -860,34 +951,77 @@ describe("Crabbox worker provider", () => {
     expect(calls.map((argv) => argv[1])).toEqual(["warmup", "inspect", "run", "inspect", "stop"]);
   });
 
-  it("stops the lease when the profile setup command fails", async () => {
-    const calls: string[][] = [];
-    let warmed = false;
-    const provider = providerWithRunner(async (argv) => {
-      calls.push(argv);
-      if (argv[1] === "warmup") {
-        warmed = true;
-        return commandResult({ stdout: `leased ${LEASE_ID} slug=test\n` });
-      }
-      if (argv[1] === "run") {
-        return commandResult({ code: 7, stderr: "apt exploded" });
-      }
-      if (argv[1] === "stop") {
-        return commandResult();
-      }
-      return warmed || argv.includes(LEASE_ID)
-        ? commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) })
-        : commandResult({ code: 4, stderr: `lease/server not found: ${argv.at(-2)}` });
-    });
+  it.each([
+    {
+      name: "fails",
+      result: commandResult({ code: 7, stderr: "apt exploded" }),
+      message: "Crabbox setup failed with exit code 7",
+    },
+    {
+      name: "times out",
+      result: commandResult({ code: null, killed: true, termination: "timeout" }),
+      message: "Crabbox setup did not exit normally (timeout)",
+    },
+    {
+      name: "cannot start",
+      result: undefined,
+      message: "Crabbox setup could not start",
+    },
+  ])(
+    "stops the lease and removes its private env profile when setup $name",
+    async ({ result, message }) => {
+      const envName = "OPENCLAW_WORKER_ARTIFACT_TOKEN";
+      vi.stubEnv(envName, "fixture-artifact-token");
+      const calls: string[][] = [];
+      let profilePath: string | undefined;
+      let warmed = false;
+      const provider = providerWithRunner(async (argv) => {
+        calls.push(argv);
+        if (argv[1] === "warmup") {
+          warmed = true;
+          return commandResult({ stdout: `leased ${LEASE_ID} slug=test\n` });
+        }
+        if (argv[1] === "run") {
+          const candidateProfilePath = argv[argv.indexOf("--env-from-profile") + 1];
+          expect(candidateProfilePath).toBeDefined();
+          if (!candidateProfilePath) {
+            throw new Error("missing Crabbox environment profile path");
+          }
+          profilePath = candidateProfilePath;
+          expect(fs.existsSync(profilePath)).toBe(true);
+          if (!result) {
+            throw new Error("spawn unavailable");
+          }
+          return result;
+        }
+        if (argv[1] === "stop") {
+          return commandResult();
+        }
+        return warmed || argv.includes(LEASE_ID)
+          ? commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) })
+          : commandResult({ code: 4, stderr: `lease/server not found: ${argv.at(-2)}` });
+      });
 
-    await expect(
-      provider.provision({ ...PROFILE, setup: "install-node" }, OPERATION_ID),
-    ).rejects.toMatchObject({
-      code: "invalid_profile",
-      message: expect.stringContaining("Crabbox setup failed with exit code 7"),
-    });
-    expect(calls.some((argv) => argv[1] === "stop" && argv.includes(LEASE_ID))).toBe(true);
-  });
+      const provisioning = provider.provision(
+        { ...PROFILE, setup: "install-node", setupEnv: [envName] },
+        OPERATION_ID,
+      );
+      if (result) {
+        await expect(provisioning).rejects.toMatchObject({
+          code: "invalid_profile",
+          message: expect.stringContaining(message),
+        });
+      } else {
+        await expect(provisioning).rejects.toThrow(message);
+      }
+      expect(profilePath).toBeDefined();
+      if (profilePath) {
+        expect(fs.existsSync(profilePath)).toBe(false);
+        expect(fs.existsSync(path.dirname(profilePath))).toBe(false);
+      }
+      expect(calls.at(-1)).toEqual([SIBLING_BINARY, "stop", "--provider", "aws", "--id", LEASE_ID]);
+    },
+  );
 
   it("preserves the allocated lease and both failures when setup cleanup times out", async () => {
     let releaseCommitted = false;
@@ -920,32 +1054,6 @@ describe("Crabbox worker provider", () => {
     });
     expect(error.errors).toEqual([error.provisionError, error.cleanupError]);
     expect(releaseCommitted).toBe(true);
-  });
-
-  it("stops the lease when the profile setup command cannot start", async () => {
-    const calls: string[][] = [];
-    let warmed = false;
-    const provider = providerWithRunner(async (argv) => {
-      calls.push(argv);
-      if (argv[1] === "warmup") {
-        warmed = true;
-        return commandResult({ stdout: `leased ${LEASE_ID} slug=test\n` });
-      }
-      if (argv[1] === "run") {
-        throw new Error("spawn unavailable");
-      }
-      if (argv[1] === "stop") {
-        return commandResult();
-      }
-      return warmed || argv.includes(LEASE_ID)
-        ? commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) })
-        : commandResult({ code: 4, stderr: `lease/server not found: ${argv.at(-2)}` });
-    });
-
-    await expect(
-      provider.provision({ ...PROFILE, setup: "install-node" }, OPERATION_ID),
-    ).rejects.toThrow("Crabbox setup could not start");
-    expect(calls.at(-1)).toEqual([SIBLING_BINARY, "stop", "--provider", "aws", "--id", LEASE_ID]);
   });
 
   it("rejects an effective AWS instance profile after authoritative lease absence", async () => {
@@ -1863,9 +1971,11 @@ describe("Crabbox worker provider", () => {
       );
       expect(String(calls[2]?.options.input)).not.toContain("nohup");
       expect(String(calls[2]?.options.input)).not.toContain("secret-setup-value");
-      expect(calls[2]?.options.env).toMatchObject({
-        CRABBOX_WORKER_SETUP_CODE: "secret-setup-value",
+      expect(calls[2]?.options.env).toStrictEqual({
+        CRABBOX_WORKER_SETUP_CODE: undefined,
+        CRABBOX_ENV_ALLOW: ",",
       });
+      expect(calls[2]?.options.env?.CRABBOX_ENV_ALLOW).toBe(",");
       expect(calls[2]?.argv).toEqual(
         expect.arrayContaining(["--allow-env", "CRABBOX_WORKER_SETUP_CODE"]),
       );

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -6,7 +6,7 @@ import {
   type WorkerProfile,
   type WorkerProvider,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { runCommandWithTimeout, type SpawnResult } from "openclaw/plugin-sdk/process-runtime";
+import { runCommandWithTimeout } from "openclaw/plugin-sdk/process-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
@@ -24,6 +24,7 @@ import {
   createCrabboxWorkerDesktopEndpoint,
   createCrabboxWorkerDesktopSetup,
 } from "./crabbox-worker-desktop-setup.js";
+import { withCrabboxWorkerEnvProfile } from "./crabbox-worker-env-profile.js";
 import { createCrabboxHeartbeatManager } from "./crabbox-worker-heartbeat.js";
 import { parseInspectJson, type ParsedInspect } from "./crabbox-worker-inspect.js";
 import { createCrabboxMachineOptionsResolver } from "./crabbox-worker-machine-options.js";
@@ -216,7 +217,8 @@ const isUnusableProvisionState = (state: string) =>
 
 function crabboxLeaseRunArgs(
   context: LeaseCommandContext,
-  forwardedEnv?: Record<string, string>,
+  forwardedEnvNames: readonly string[] = [],
+  envProfilePath?: string,
 ): string[] {
   return [
     "run",
@@ -231,7 +233,8 @@ function crabboxLeaseRunArgs(
     // Workspace transfer is owned by the worker tunnel; lease scripts must not
     // rsync the gateway checkout into the box just to execute setup or diagnostics.
     "--no-sync",
-    ...Object.keys(forwardedEnv ?? {}).flatMap((name) => ["--allow-env", name]),
+    ...forwardedEnvNames.flatMap((name) => ["--allow-env", name]),
+    ...(envProfilePath ? ["--env-from-profile", envProfilePath] : []),
     "--script-stdin",
   ];
 }
@@ -300,44 +303,37 @@ async function waitForProvisionReady(
 // Setup runs on every provision attempt (including replay adoption), so commands
 // must be idempotent. A failed setup stops the lease before surfacing the error;
 // otherwise the caller cannot release a box it never learned about.
-async function runProvisionSetup(
+async function runProvisionSetupAndWaitReady(
   params: ProvisionInspectContext & {
     setup: string;
     timeoutMs?: number;
     forwardedEnv?: Record<string, string>;
-    env?: NodeJS.ProcessEnv;
-  },
-): Promise<void> {
-  let result: SpawnResult;
-  try {
-    result = await runCrabboxCommand({
-      action: "setup",
-      args: crabboxLeaseRunArgs({ ...params, id: params.inspect.id }, params.forwardedEnv),
-      binary: params.binary,
-      env: params.env ?? params.forwardedEnv,
-      input: params.setup,
-      runCommand: params.runCommand,
-      timeoutMs: remainingProvisionTimeout(
-        params.deadline,
-        params.timeoutMs ?? CRABBOX_SETUP_TIMEOUT_MS,
-      ),
-    });
-  } catch (error) {
-    return await failProvisionAfterCleanup({ ...params, id: params.inspect.id }, error);
-  }
-  if (result.termination === "exit" && result.code === 0) {
-    return;
-  }
-  const error = permanentCrabboxCommandError("setup", result);
-  return await failProvisionAfterCleanup({ ...params, id: params.inspect.id }, error);
-}
-
-async function runProvisionSetupAndWaitReady(
-  params: Parameters<typeof runProvisionSetup>[0] & {
     sleep: (milliseconds: number) => Promise<void>;
   },
 ): Promise<ParsedInspect> {
-  await runProvisionSetup(params);
+  try {
+    const result = await withCrabboxWorkerEnvProfile(
+      params.forwardedEnv,
+      (names, profilePath, childEnv) =>
+        runCrabboxCommand({
+          action: "setup",
+          args: crabboxLeaseRunArgs({ ...params, id: params.inspect.id }, names, profilePath),
+          binary: params.binary,
+          env: childEnv,
+          input: params.setup,
+          runCommand: params.runCommand,
+          timeoutMs: remainingProvisionTimeout(
+            params.deadline,
+            params.timeoutMs ?? CRABBOX_SETUP_TIMEOUT_MS,
+          ),
+        }),
+    );
+    if (result.termination !== "exit" || result.code !== 0) {
+      throw permanentCrabboxCommandError("setup", result);
+    }
+  } catch (error) {
+    return await failProvisionAfterCleanup({ ...params, id: params.inspect.id }, error);
+  }
   // Setup may restart SSH or change its endpoint. Re-read the authoritative lease before
   // returning any endpoint or security attestation to core bootstrap.
   return await waitForProvisionReady({ ...params, refresh: true });
@@ -617,7 +613,6 @@ export function createCrabboxWorkerProvider(
           ...inspectedParams,
           setup: parsed.setup,
           forwardedEnv,
-          env: { ...forwardedEnv, CRABBOX_ENV_ALLOW: parsed.setupEnv?.join(",") || "," },
           sleep,
         });
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where cloud-worker setup environment values could cross the intended secret-delivery boundary when an SSH-backed execution transport constructed its child command. A local process listing could then expose a configured setup credential while a worker was launching.

## Why This Change Was Made

The Crabbox worker provider now writes explicitly selected setup values to a private, one-run environment profile and passes only variable names plus the profile path to Crabbox. Selected names are removed from the child environment, ambient Crabbox forwarding is disabled, and the profile is removed after success, failure, timeout, or spawn failure. This replaces the ambient forwarding introduced in #128185 with Crabbox's existing profile transport.

## User Impact

Operators can launch Crabbox-backed cloud workers without selected setup credentials appearing in spawned process arguments. Existing cloud-worker configuration remains unchanged; unsupported multiline or executable profile values now fail closed with a value-free error instead of falling back to ambient forwarding.

## Evidence

- Pre-fix regression: the focused provider suite failed 10 credential-boundary cases.
- `node scripts/run-vitest.mjs extensions/crabbox/src/crabbox-worker-provider.test.ts` — 161 passed.
- `node scripts/check-changed.mjs -- extensions/crabbox/src/crabbox-worker-env-profile.ts extensions/crabbox/src/crabbox-worker-provider.ts extensions/crabbox/src/crabbox-worker-provider.test.ts` — passed.
- Exact-head CI — green: https://github.com/openclaw/openclaw/actions/runs/32911767143
- Exact PR head `704a909eba39686d5016359064fb359c947901e1` was deployed through the canonical immutable release owner; Gateway health and readiness both returned 200.
- Real coordinator-backed Crabbox profile run under the Gateway runtime user: selected value present, unselected value absent, zero selected/unselected assignment matches in spawned process arguments, run exit 0, and zero leases after cleanup.
- Upstream capability proof: Crabbox commit `8c671dd6` added `--env-from-profile`, first shipped in v0.13.0. OpenClaw's existing minimum is v0.41.1, so every supported binary already has the transport.
- Fresh structured autoreview — no accepted or actionable findings.

AI-assisted implementation; maintainer-reviewed and understood.
