### PR TITLE
fix(memory): partition Mistral and DeepInfra embedding caches

### DIFF
--- a/extensions/deepinfra/embedding-adapter.test.ts
+++ b/extensions/deepinfra/embedding-adapter.test.ts
@@ -11,7 +11,10 @@ vi.mock("./embedding-provider.js", () => ({
   DEFAULT_DEEPINFRA_EMBEDDING_MODEL: "BAAI/bge-m3",
 }));
 
-import { deepinfraEmbeddingProviderAdapter } from "./embedding-adapter.js";
+import {
+  buildDeepInfraEmbeddingAdapter,
+  deepinfraEmbeddingProviderAdapter,
+} from "./embedding-adapter.js";
 
 const memoryProvider: MemoryEmbeddingProvider = {
   id: "deepinfra",
@@ -25,10 +28,22 @@ const memoryProvider: MemoryEmbeddingProvider = {
 describe("DeepInfra generic embedding adapter", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.createDeepInfraEmbeddingProvider.mockResolvedValue({
-      provider: memoryProvider,
-      client: { model: "BAAI/bge-m3-resolved" },
-    });
+    mocks.createDeepInfraEmbeddingProvider.mockImplementation(
+      async (options: {
+        remote?: { baseUrl?: string; apiKey?: string; headers?: Record<string, string> };
+      }) => ({
+        provider: memoryProvider,
+        client: {
+          model: "BAAI/bge-m3-resolved",
+          baseUrl: options.remote?.baseUrl ?? "https://api.deepinfra.com/v1/openai",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${options.remote?.apiKey ?? "fixture-default-key"}`,
+            ...options.remote?.headers,
+          },
+        },
+      }),
+    );
   });
 
   it("declares the existing provider id, default model, transport, and auth owner", () => {
@@ -38,6 +53,36 @@ describe("DeepInfra generic embedding adapter", () => {
       transport: "remote",
       authProviderId: "deepinfra",
       create: expect.any(Function),
+    });
+  });
+
+  it("keeps the discovered embedding model as the dynamic adapter default", async () => {
+    const adapter = buildDeepInfraEmbeddingAdapter({
+      embedModels: [{ id: "BAAI/discovered-model" }] as never,
+    });
+
+    expect(adapter.defaultModel).toBe("BAAI/discovered-model");
+    await adapter.create({ config: {}, model: "BAAI/discovered-model" });
+    expect(mocks.createDeepInfraEmbeddingProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultModel: "BAAI/discovered-model" }),
+    );
+  });
+
+  it.each([
+    undefined,
+    "https://api.deepinfra.com/v1/openai",
+    "https://api.deepinfra.com/v1/openai/",
+    "https://API.DEEPINFRA.COM:443/v1/openai/",
+  ])("preserves the exact existing default identity for %s", async (baseUrl) => {
+    const result = await deepinfraEmbeddingProviderAdapter.create({
+      config: {},
+      model: "BAAI/bge-m3",
+      remote: { apiKey: "fixture-default-key", ...(baseUrl ? { baseUrl } : {}) },
+    });
+
+    expect(result.runtime?.cacheKeyData).toEqual({
+      provider: "deepinfra",
+      model: "BAAI/bge-m3-resolved",
     });
   });
 
@@ -79,13 +124,76 @@ describe("DeepInfra generic embedding adapter", () => {
     });
     expect(result.runtime).toEqual({
       id: "deepinfra",
-      cacheKeyData: { provider: "deepinfra", model: "BAAI/bge-m3-resolved" },
+      cacheKeyData: {
+        provider: "deepinfra",
+        model: "BAAI/bge-m3-resolved",
+        baseUrl: "https://api.deepinfra.com/v1/openai",
+        headers: [["x-deployment", "tenant-a"]],
+      },
     });
     expect(result.provider).toMatchObject({
       id: "deepinfra",
       model: "BAAI/bge-m3",
       maxInputTokens: 8192,
     });
+  });
+
+  it("partitions endpoints and tenants while excluding rotated credentials", async () => {
+    const baseUrl = "https://deepinfra-region-a.example.test/v1/openai";
+    const createForTenant = async (
+      tenant: string,
+      endpoint = baseUrl,
+      apiKey = "fixture-deepinfra-key-before",
+      headers: Record<string, string> = {},
+    ) =>
+      await deepinfraEmbeddingProviderAdapter.create({
+        config: {},
+        model: "BAAI/bge-m3",
+        remote: {
+          baseUrl: endpoint,
+          apiKey,
+          headers: { "x-deployment": "deployment-a", "X-Tenant": tenant, ...headers },
+        },
+      });
+
+    const first = await createForTenant("tenant-a", baseUrl, "fixture-deepinfra-key-before", {
+      "X-Api-Key": "fixture-proxy-key-before",
+      "api-key": "fixture-azure-key-before",
+      version: "tenant-api-v1",
+    });
+    const rotated = await createForTenant("tenant-a", baseUrl, "fixture-deepinfra-key-after", {
+      version: "tenant-api-v1",
+      "Api-Key": "fixture-azure-key-after",
+      "x-aPI-kEY": "fixture-proxy-key-after",
+    });
+    const otherTenant = await createForTenant("tenant-b");
+    const otherEndpoint = await createForTenant(
+      "tenant-a",
+      "https://deepinfra-region-b.example.test/v1/openai",
+    );
+    const firstProvider = await mocks.createDeepInfraEmbeddingProvider.mock.results[0]?.value;
+
+    expect(firstProvider?.client.headers).toMatchObject({
+      Authorization: "Bearer fixture-deepinfra-key-before",
+      "X-Api-Key": "fixture-proxy-key-before",
+      "api-key": "fixture-azure-key-before",
+      "x-deployment": "deployment-a",
+      "X-Tenant": "tenant-a",
+    });
+    expect(first.runtime?.cacheKeyData).toMatchObject({
+      provider: "deepinfra",
+      model: "BAAI/bge-m3-resolved",
+      baseUrl,
+      headers: expect.arrayContaining([
+        ["x-deployment", "deployment-a"],
+        ["X-Tenant", "tenant-a"],
+        ["version", "tenant-api-v1"],
+      ]),
+    });
+    expect(first.runtime?.cacheKeyData).toEqual(rotated.runtime?.cacheKeyData);
+    expect(first.runtime?.cacheKeyData).not.toEqual(otherTenant.runtime?.cacheKeyData);
+    expect(first.runtime?.cacheKeyData).not.toEqual(otherEndpoint.runtime?.cacheKeyData);
+    expect(JSON.stringify(first.runtime?.cacheKeyData)).not.toContain("fixture-");
   });
 
   it("adapts generic query and batch calls without changing text or cancellation", async () => {
@@ -105,11 +213,18 @@ describe("DeepInfra generic embedding adapter", () => {
         { signal: abortController.signal, inputType: "query" },
       ),
     ).resolves.toEqual([1, 0]);
+    await expect(provider.embed("query without an explicit type")).resolves.toEqual([1, 0]);
     await expect(
       provider.embedBatch(["document one", { text: "document two" }], {
         signal: abortController.signal,
         inputType: "document",
       }),
+    ).resolves.toEqual([
+      [0, 1],
+      [0, 1],
+    ]);
+    await expect(
+      provider.embedBatch(["query one", "query two"], { inputType: "query" }),
     ).resolves.toEqual([
       [0, 1],
       [0, 1],

--- a/extensions/deepinfra/embedding-adapter.ts
+++ b/extensions/deepinfra/embedding-adapter.ts
@@ -3,17 +3,20 @@ import type {
   EmbeddingInput,
   EmbeddingProvider,
   EmbeddingProviderAdapter,
-  EmbeddingProviderCreateOptions,
 } from "openclaw/plugin-sdk/embedding-providers";
-import type {
-  MemoryEmbeddingProvider,
-  MemoryEmbeddingProviderCreateOptions,
+import {
+  embeddingProviderOwnsDestination,
+  sanitizeEmbeddingCacheHeaders,
+  type MemoryEmbeddingProvider,
+  type MemoryEmbeddingProviderCreateOptions,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   createDeepInfraEmbeddingProvider,
   DEFAULT_DEEPINFRA_EMBEDDING_MODEL,
 } from "./embedding-provider.js";
-import type { DeepInfraSurfaceModel } from "./provider-models.js";
+import { DEEPINFRA_BASE_URL, type DeepInfraSurfaceModel } from "./provider-models.js";
+
+const EXCLUDED_EMBEDDING_HEADERS = ["authorization", "content-type", "x-api-key", "api-key"];
 
 function textFromEmbeddingInput(input: EmbeddingInput): string {
   return typeof input === "string" ? input : input.text;
@@ -34,24 +37,6 @@ function adaptMemoryEmbeddingProvider(provider: MemoryEmbeddingProvider): Embedd
   };
 }
 
-function buildMemoryCreateOptions(
-  options: EmbeddingProviderCreateOptions,
-): MemoryEmbeddingProviderCreateOptions {
-  return {
-    config: options.config,
-    agentDir: options.agentDir,
-    provider: "deepinfra",
-    fallback: "none",
-    remote: options.remote,
-    model: options.model,
-    inputType: options.inputType,
-    queryInputType: options.queryInputType,
-    documentInputType: options.documentInputType,
-    outputDimensionality: options.dimensions,
-    taskType: options.taskType as MemoryEmbeddingProviderCreateOptions["taskType"],
-  };
-}
-
 // First entry of embedModels becomes the default embedding model.
 export function buildDeepInfraEmbeddingAdapter(options?: {
   embedModels?: readonly DeepInfraSurfaceModel[];
@@ -63,10 +48,22 @@ export function buildDeepInfraEmbeddingAdapter(options?: {
     transport: "remote",
     authProviderId: "deepinfra",
     create: async (createOptions) => {
+      const { dimensions, ...memoryOptions } = createOptions;
       const { provider, client } = await createDeepInfraEmbeddingProvider({
-        ...buildMemoryCreateOptions(createOptions),
+        ...memoryOptions,
+        provider: "deepinfra",
+        fallback: "none",
+        outputDimensionality: dimensions,
+        taskType: createOptions.taskType as MemoryEmbeddingProviderCreateOptions["taskType"],
         defaultModel,
       });
+      const headers = sanitizeEmbeddingCacheHeaders(client.headers, EXCLUDED_EMBEDDING_HEADERS);
+      const usesDefaultIdentity =
+        headers.length === 0 &&
+        embeddingProviderOwnsDestination({
+          baseUrl: client.baseUrl,
+          providerBaseUrl: DEEPINFRA_BASE_URL,
+        });
       return {
         provider: provider ? adaptMemoryEmbeddingProvider(provider) : null,
         runtime: {
@@ -74,6 +71,7 @@ export function buildDeepInfraEmbeddingAdapter(options?: {
           cacheKeyData: {
             provider: "deepinfra",
             model: client.model,
+            ...(usesDefaultIdentity ? {} : { baseUrl: client.baseUrl, headers }),
           },
         },
       };

--- a/extensions/deepinfra/embedding-provider.ts
+++ b/extensions/deepinfra/embedding-provider.ts
@@ -4,6 +4,7 @@ import {
   resolveRemoteEmbeddingClient,
   type MemoryEmbeddingProviderCreateOptions,
   type MemoryEmbeddingProviderCreateResult,
+  type RemoteEmbeddingClient,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   DEEPINFRA_BASE_URL,
@@ -15,7 +16,7 @@ export const DEFAULT_DEEPINFRA_EMBEDDING_MODEL = DEEPINFRA_EMBED_FALLBACK_MODELS
 
 export async function createDeepInfraEmbeddingProvider(
   options: MemoryEmbeddingProviderCreateOptions & { defaultModel?: string },
-): Promise<MemoryEmbeddingProviderCreateResult & { client: { model: string } }> {
+): Promise<MemoryEmbeddingProviderCreateResult & { client: RemoteEmbeddingClient }> {
   const defaultModel = options.defaultModel ?? DEFAULT_DEEPINFRA_EMBEDDING_MODEL;
   const client = await resolveRemoteEmbeddingClient({
     provider: "deepinfra",

--- a/extensions/mistral/embedding-provider.ts
+++ b/extensions/mistral/embedding-provider.ts
@@ -5,18 +5,11 @@ import {
   resolveRemoteEmbeddingClient,
   type MemoryEmbeddingProvider,
   type MemoryEmbeddingProviderCreateOptions,
+  type RemoteEmbeddingClient,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
-import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
-
-type MistralEmbeddingClient = {
-  baseUrl: string;
-  headers: Record<string, string>;
-  ssrfPolicy?: SsrFPolicy;
-  model: string;
-};
+import { MISTRAL_BASE_URL } from "./model-definitions.js";
 
 export const DEFAULT_MISTRAL_EMBEDDING_MODEL = "mistral-embed";
-const DEFAULT_MISTRAL_BASE_URL = "https://api.mistral.ai/v1";
 
 function normalizeMistralModel(model: string): string {
   return normalizeEmbeddingModelWithPrefixes({
@@ -28,8 +21,13 @@ function normalizeMistralModel(model: string): string {
 
 export async function createMistralEmbeddingProvider(
   options: MemoryEmbeddingProviderCreateOptions,
-): Promise<{ provider: MemoryEmbeddingProvider; client: MistralEmbeddingClient }> {
-  const client = await resolveMistralEmbeddingClient(options);
+): Promise<{ provider: MemoryEmbeddingProvider; client: RemoteEmbeddingClient }> {
+  const client = await resolveRemoteEmbeddingClient({
+    provider: "mistral",
+    options,
+    defaultBaseUrl: MISTRAL_BASE_URL,
+    normalizeModel: normalizeMistralModel,
+  });
 
   return {
     provider: createRemoteEmbeddingProvider({
@@ -39,15 +37,4 @@ export async function createMistralEmbeddingProvider(
     }),
     client,
   };
-}
-
-async function resolveMistralEmbeddingClient(
-  options: MemoryEmbeddingProviderCreateOptions,
-): Promise<MistralEmbeddingClient> {
-  return await resolveRemoteEmbeddingClient({
-    provider: "mistral",
-    options,
-    defaultBaseUrl: DEFAULT_MISTRAL_BASE_URL,
-    normalizeModel: normalizeMistralModel,
-  });
 }

--- a/extensions/mistral/memory-embedding-adapter.test.ts
+++ b/extensions/mistral/memory-embedding-adapter.test.ts
@@ -1,0 +1,141 @@
+import type { MemoryEmbeddingProviderCreateOptions } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import { describe, expect, it } from "vitest";
+import { createMistralEmbeddingProvider } from "./embedding-provider.js";
+import { mistralMemoryEmbeddingProviderAdapter } from "./memory-embedding-adapter.js";
+import { MISTRAL_BASE_URL } from "./model-definitions.js";
+
+function createOptions(params?: {
+  baseUrl?: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  config?: MemoryEmbeddingProviderCreateOptions["config"];
+}): MemoryEmbeddingProviderCreateOptions {
+  return {
+    config: params?.config ?? ({} as MemoryEmbeddingProviderCreateOptions["config"]),
+    provider: "mistral",
+    model: "mistral-embed",
+    fallback: "none",
+    remote: {
+      apiKey: params?.apiKey ?? "fixture-mistral-key-before",
+      ...(params?.baseUrl ? { baseUrl: params.baseUrl } : {}),
+      ...(params?.headers ? { headers: params.headers } : {}),
+    },
+  };
+}
+
+describe("Mistral memory embedding index identity", () => {
+  it.each([undefined, MISTRAL_BASE_URL, `${MISTRAL_BASE_URL}/`, "https://API.MISTRAL.AI:443/v1/"])(
+    "preserves the exact existing default identity for %s",
+    async (baseUrl) => {
+      const result = await mistralMemoryEmbeddingProviderAdapter.create(createOptions({ baseUrl }));
+
+      expect(result.runtime?.cacheKeyData).toEqual({
+        provider: "mistral",
+        model: "mistral-embed",
+      });
+    },
+  );
+
+  it("partitions endpoints and tenants without including rotated authentication headers", async () => {
+    const endpoint = "https://mistral-region-a.example.test/v1";
+    const firstOptions = createOptions({
+      baseUrl: endpoint,
+      headers: {
+        "X-Tenant": "tenant-a",
+        "X-Deployment": "deployment-a",
+        "X-Api-Key": "fixture-proxy-key-before",
+        "api-key": "fixture-azure-key-before",
+        "User-Agent": "tenant-router/1",
+        version: "tenant-api-v1",
+      },
+    });
+    const first = await mistralMemoryEmbeddingProviderAdapter.create(firstOptions);
+    const rotated = await mistralMemoryEmbeddingProviderAdapter.create(
+      createOptions({
+        baseUrl: endpoint,
+        apiKey: "fixture-mistral-key-after",
+        headers: {
+          version: "tenant-api-v1",
+          "User-Agent": "tenant-router/1",
+          "Api-Key": "fixture-azure-key-after",
+          "x-aPI-kEY": "fixture-proxy-key-after",
+          "X-Deployment": "deployment-a",
+          "X-Tenant": "tenant-a",
+        },
+      }),
+    );
+    const otherTenant = await mistralMemoryEmbeddingProviderAdapter.create(
+      createOptions({
+        baseUrl: endpoint,
+        headers: { "X-Tenant": "tenant-b", "X-Deployment": "deployment-a" },
+      }),
+    );
+    const otherEndpoint = await mistralMemoryEmbeddingProviderAdapter.create(
+      createOptions({
+        baseUrl: "https://mistral-region-b.example.test/v1",
+        headers: { "X-Tenant": "tenant-a", "X-Deployment": "deployment-a" },
+      }),
+    );
+    const { client } = await createMistralEmbeddingProvider(firstOptions);
+
+    expect(client.headers).toMatchObject({
+      Authorization: "Bearer fixture-mistral-key-before",
+      "X-Api-Key": "fixture-proxy-key-before",
+      "api-key": "fixture-azure-key-before",
+      "X-Deployment": "deployment-a",
+      "X-Tenant": "tenant-a",
+    });
+    expect(first.runtime?.cacheKeyData).toMatchObject({
+      provider: "mistral",
+      model: "mistral-embed",
+      baseUrl: endpoint,
+      headers: expect.arrayContaining([
+        ["X-Deployment", "deployment-a"],
+        ["X-Tenant", "tenant-a"],
+        ["User-Agent", "tenant-router/1"],
+        ["version", "tenant-api-v1"],
+      ]),
+    });
+    expect(first.runtime?.cacheKeyData).toEqual(rotated.runtime?.cacheKeyData);
+    expect(first.runtime?.cacheKeyData).not.toEqual(otherTenant.runtime?.cacheKeyData);
+    expect(first.runtime?.cacheKeyData).not.toEqual(otherEndpoint.runtime?.cacheKeyData);
+    expect(JSON.stringify(first.runtime?.cacheKeyData)).not.toContain("fixture-");
+  });
+
+  it("partitions provider-owned headers without leaking them to a remote destination", async () => {
+    const providerBaseUrl = "https://provider-region.example.test/v1";
+    const config = {
+      models: {
+        providers: {
+          mistral: {
+            baseUrl: providerBaseUrl,
+            apiKey: "fixture-provider-key",
+            headers: { "X-Provider-Tenant": "provider-a" },
+            models: [],
+          },
+        },
+      },
+    } as MemoryEmbeddingProviderCreateOptions["config"];
+    const providerOwned = await mistralMemoryEmbeddingProviderAdapter.create(
+      createOptions({ config }),
+    );
+    const remoteOptions = createOptions({
+      config,
+      baseUrl: "https://remote-region.example.test/v1",
+      headers: { "X-Tenant": "remote-a" },
+    });
+    const remoteOwned = await mistralMemoryEmbeddingProviderAdapter.create(remoteOptions);
+    const { client } = await createMistralEmbeddingProvider(remoteOptions);
+
+    expect(providerOwned.runtime?.cacheKeyData).toMatchObject({
+      baseUrl: providerBaseUrl,
+      headers: [["X-Provider-Tenant", "provider-a"]],
+    });
+    expect(remoteOwned.runtime?.cacheKeyData).toMatchObject({
+      baseUrl: "https://remote-region.example.test/v1",
+      headers: [["X-Tenant", "remote-a"]],
+    });
+    expect(client.headers).not.toHaveProperty("X-Provider-Tenant");
+    expect(client.headers["X-Tenant"]).toBe("remote-a");
+  });
+});

--- a/extensions/mistral/memory-embedding-adapter.ts
+++ b/extensions/mistral/memory-embedding-adapter.ts
@@ -1,12 +1,17 @@
 // Mistral plugin module implements memory embedding adapter behavior.
 import {
+  embeddingProviderOwnsDestination,
   isMissingEmbeddingApiKeyError,
+  sanitizeEmbeddingCacheHeaders,
   type MemoryEmbeddingProviderAdapter,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   createMistralEmbeddingProvider,
   DEFAULT_MISTRAL_EMBEDDING_MODEL,
 } from "./embedding-provider.js";
+import { MISTRAL_BASE_URL } from "./model-definitions.js";
+
+const EXCLUDED_EMBEDDING_HEADERS = ["authorization", "content-type", "x-api-key", "api-key"];
 
 export const mistralMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapter = {
   id: "mistral",
@@ -22,6 +27,13 @@ export const mistralMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapt
       provider: "mistral",
       fallback: "none",
     });
+    const headers = sanitizeEmbeddingCacheHeaders(client.headers, EXCLUDED_EMBEDDING_HEADERS);
+    const usesDefaultIdentity =
+      headers.length === 0 &&
+      embeddingProviderOwnsDestination({
+        baseUrl: client.baseUrl,
+        providerBaseUrl: MISTRAL_BASE_URL,
+      });
     return {
       provider,
       runtime: {
@@ -29,6 +41,7 @@ export const mistralMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapt
         cacheKeyData: {
           provider: "mistral",
           model: client.model,
+          ...(usesDefaultIdentity ? {} : { baseUrl: client.baseUrl, headers }),
         },
       },
     };


### PR DESCRIPTION
## Summary

- Fix silent embedding-index collisions when Mistral or DeepInfra operators use different custom endpoints, tenant headers, or deployment headers with the same model.
- Preserve the exact existing cache identity for ordinary/default configurations, including equivalent default URLs; ignore rotating authorization, `api-key`, and `x-api-key` credentials while retaining semantic routing headers and the unchanged outbound requests.
- Repair both affected plugin owners together using the existing SDK destination/header canonicalization, remove redundant Mistral/DeepInfra wrappers and duplicate client typing, and preserve DeepInfra's existing direct query/document/batch behavior. Combined production delta: **-1 line**.

Existing users with explicitly configured custom embedding endpoints or semantic custom headers will rebuild their affected index once because those previously colliding destinations now have distinct identities. If rebuilding manually, run `openclaw memory index --force --agent <id>`. Ordinary/default configurations retain their historical identities byte-for-byte and do not rebuild.

## Validation

- Captured real owner regressions on the previous code: **two failing endpoint/tenant cases per provider**; all four pass after the owner fixes.
- Focused provider, sibling, and index-state regression suite: **120 tests across 10 files passed**.
- Post-format owner rerun: **15 Mistral/DeepInfra tests passed**.
- Direct synthetic real-adapter proof for both providers verifies destination partitioning, tenant partitioning, credential rotation stability, byte-exact default identity, normalized equivalent default identity, absence of credentials in identity, and unchanged outbound routing/authentication.
- Focused lint clean for all six changed files; full typed lint clean for the five owner adapter/test files. The DeepInfra provider has two identical pre-existing unresolved-facade type-lint diagnostics on clean `main`; the change introduces no new diagnostics or rule suppressions.
- Scoped formatting checks pass; no external requests or live credentials are used.
