### PR TITLE
fix(cli): honor prefixed channel targets when creating threads

### DIFF
--- a/src/cli/program/message/register.thread.test.ts
+++ b/src/cli/program/message/register.thread.test.ts
@@ -97,6 +97,56 @@ describe("registerMessageThreadCommands", () => {
     expect(remappedCall?.[1]).not.toHaveProperty("threadName");
   });
 
+  it.each([
+    {
+      description: "infers the action owner from a registered channel-prefixed target",
+      channel: undefined,
+      target: "topic-chat:room-1",
+      action: "topic-create",
+    },
+    {
+      description: "prefers an explicit channel over a conflicting target prefix",
+      channel: "plain-chat",
+      target: "topic-chat:room-1",
+      action: "thread-create",
+    },
+    {
+      description: "keeps prefixed channels without an action remap unchanged",
+      channel: undefined,
+      target: "plain-chat:room-1",
+      action: "thread-create",
+    },
+    {
+      description: "keeps an explicit action owner over a conflicting target prefix",
+      channel: "topic-chat",
+      target: "plain-chat:room-1",
+      action: "topic-create",
+    },
+  ])("$description", async ({ action, channel, target }) => {
+    const message = new Command().exitOverride();
+    registerMessageThreadCommands(message, createHelpers(runMessageAction));
+
+    await message.parseAsync(
+      [
+        "thread",
+        "create",
+        ...(channel ? ["--channel", channel] : []),
+        "--target",
+        target,
+        "--thread-name",
+        "Build Updates",
+      ],
+      { from: "user" },
+    );
+
+    const call = firstMessageActionCall(runMessageAction);
+    expect(call?.[0]).toBe(action);
+    expect(call?.[1]?.channel).toBe(channel);
+    expect(call?.[1]?.target).toBe(target);
+    expect(call?.[1]?.[action === "topic-create" ? "name" : "threadName"]).toBe("Build Updates");
+    expect(call?.[1]).not.toHaveProperty(action === "topic-create" ? "threadName" : "name");
+  });
+
   it("keeps default thread create params when the channel does not remap the action", async () => {
     const message = new Command().exitOverride();
     registerMessageThreadCommands(message, createHelpers(runMessageAction));

--- a/src/cli/program/message/register.thread.ts
+++ b/src/cli/program/message/register.thread.ts
@@ -1,12 +1,12 @@
 // Thread command registration, including channel-specific create request normalization.
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
 import { getChannelPlugin } from "../../../channels/plugins/index.js";
 import type { ChannelMessageActionName } from "../../../channels/plugins/types.public.js";
+import { resolveMessageSecretScope } from "../../message-secret-scope.js";
 import type { MessageCliHelpers } from "./helpers.js";
 
 function resolveThreadCreateRequest(opts: Record<string, unknown>) {
-  const channel = normalizeLowercaseStringOrEmpty(opts.channel);
+  const { channel } = resolveMessageSecretScope(opts);
   if (channel) {
     const request = getChannelPlugin(channel)?.actions?.resolveCliActionRequest?.({
       action: "thread-create",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users creating a Telegram forum topic or another plugin-owned thread through a channel-prefixed target would get an unsupported thread action when they omitted the otherwise unnecessary `--channel` option.

## Why This Change Was Made

Thread creation previously inspected only the explicit channel flag before asking the owning plugin to normalize its action. It now reuses the existing target-aware message channel resolver already used by the shared message action runner, so prefixed targets select the correct registered channel while explicit channel selections retain precedence.

## User Impact

Commands such as `openclaw message thread create --target telegram:-100123 --thread-name Deployments` now reach Telegram's existing forum-topic action without needing a redundant `--channel telegram`. Third-party registered channels receive the same behavior, and ordinary Discord-style thread creation remains unchanged.

## Evidence

- Tests-first real Commander reproduction failed before the change: a registered `topic-chat:room-1` target dispatched unsupported `thread-create` instead of the plugin-owned `topic-create` request.
- Final proof: **102 tests passed across seven real CLI-owner, message-helper, channel-scope, Telegram-public-adapter, and Telegram-threading suites**.
- Regression coverage verifies target-prefix inference, explicit channel precedence over conflicting prefixes, unmodified channels without remapping hooks, and whitespace-normalized explicit channel selections.
- Independent owner-boundary review and fresh authenticated Codex autoreview both passed; max-lines and assertion-safety ratchets and targeted formatting passed.
- The linked checkout has no local dependency installation, so exact-head hosted `check-prod-types` and `check-test-types` provide authoritative compiler proof.
- Production: **+2/-2 (net zero)**. Regression tests: **+50**.
- Reviewed head: `f86a6d575a8e823881401fd714e18c0606281d88`.
