### PR TITLE
fix(ui): clarify sidebar catalog hierarchy

### DIFF
--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
 import { repeat } from "lit/directives/repeat.js";
 import type { SessionCatalog } from "../../../packages/gateway-protocol/src/index.ts";
 import type { GatewaySessionRow } from "../api/types.ts";
@@ -58,6 +59,7 @@ function renderSessionSection(params: {
 }) {
   const { host, section } = params;
   const totalRowCount = section.totalRowCount;
+  const canCollapse = totalRowCount > 0;
   const group = section.category;
   const personOwner = section.personOwner;
   // Pinned rows render in the nav zone; renderHeader records whether this list
@@ -143,14 +145,17 @@ function renderSessionSection(params: {
               <button
                 type="button"
                 class="sidebar-session-group-toggle"
-                aria-expanded=${String(!collapsed)}
+                aria-expanded=${ifDefined(canCollapse ? (collapsed ? "false" : "true") : undefined)}
                 aria-label=${label}
-                @click=${() => host.toggleSection(section.id)}
+                ?disabled=${!canCollapse}
+                @click=${canCollapse ? () => host.toggleSection(section.id) : nothing}
               >
                 <span class="sidebar-session-group-toggle__lead" aria-hidden="true">
-                  <span class="sidebar-session-group-toggle__icon"
-                    >${collapsed ? icons.chevronRight : icons.chevronDown}</span
-                  >
+                  ${canCollapse
+                    ? html`<span class="sidebar-session-group-toggle__icon"
+                        >${collapsed ? icons.chevronRight : icons.chevronDown}</span
+                      >`
+                    : nothing}
                 </span>
                 ${personOwner
                   ? html`<openclaw-viewer-avatar
@@ -166,7 +171,7 @@ function renderSessionSection(params: {
                     ></openclaw-viewer-avatar>`
                   : nothing}
                 <span class="sidebar-recent-sessions__label-text">${label}</span>
-                ${collapsed && totalRowCount > 0
+                ${totalRowCount === 0 || collapsed
                   ? html`<span class="sidebar-session-group-count">${totalRowCount}</span>`
                   : nothing}
                 ${collapsedRunningDot

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -566,6 +566,20 @@ suite.define(() => {
           };
         });
       expect(projectLabelTone.distanceToText).toBeLessThan(projectLabelTone.distanceToMuted);
+      const catalogLabelWeight = await section
+        .locator(":scope > .sidebar-recent-sessions__head .sidebar-recent-sessions__label-text")
+        .evaluate((label) => Number.parseInt(getComputedStyle(label).fontWeight, 10));
+      const projectLabelTypography = await openclawProject
+        .locator(".sidebar-session-catalog-project__label")
+        .evaluate((label) => {
+          const style = getComputedStyle(label);
+          return {
+            fontWeight: Number.parseInt(style.fontWeight, 10),
+            letterSpacing: style.letterSpacing,
+          };
+        });
+      expect(projectLabelTypography.fontWeight).toBeLessThan(catalogLabelWeight);
+      expect(projectLabelTypography.letterSpacing).toBe("normal");
       expect(
         await section
           .locator('[data-session-catalog-project="/Users/dev/other"]')
@@ -1038,3 +1052,4 @@ suite.define(() => {
     await page.close();
   });
 });
+/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -906,6 +906,7 @@ suite.define(() => {
       featureMethods: [
         "chat.metadata",
         "chat.startup",
+        "sessions.create",
         "sessions.groups.list",
         "sessions.groups.put",
       ],
@@ -918,6 +919,16 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}chat`);
       const firstGroup = page.locator('[data-session-section="category:First group"]');
       await firstGroup.waitFor({ state: "visible" });
+      const firstGroupToggle = firstGroup.getByRole("button", { name: "First group", exact: true });
+      expect(await firstGroupToggle.isDisabled()).toBe(true);
+      expect(await firstGroupToggle.getAttribute("aria-expanded")).toBeNull();
+      expect(await firstGroupToggle.locator(".sidebar-session-group-count").textContent()).toBe(
+        "0",
+      );
+      expect(await firstGroup.locator(".sidebar-new-session").isDisabled()).toBe(false);
+      expect(await firstGroup.locator(".sidebar-session-group-actions").last().isDisabled()).toBe(
+        false,
+      );
 
       // A header-menu-created group starts empty and still gets a section.
       await firstGroup.locator(".sidebar-recent-sessions__head").hover();
@@ -993,7 +1004,10 @@ suite.define(() => {
           .toBe(1);
         const toggle = group.getByRole("button", { name, exact: true });
         await toggle.waitFor({ state: "visible" });
-        await expect.poll(() => toggle.getAttribute("aria-expanded")).toBe("true");
+        expect(await toggle.isDisabled()).toBe(true);
+        expect(await toggle.getAttribute("aria-expanded")).toBeNull();
+        expect(await toggle.locator(".sidebar-session-group-toggle__icon").count()).toBe(0);
+        expect(await toggle.locator(".sidebar-session-group-count").textContent()).toBe("0");
       }
 
       await expect.poll(() => emptyGroups.locator(".sidebar-session-empty-hint").count()).toBe(0);
@@ -1009,8 +1023,15 @@ suite.define(() => {
       await captureUiProof(page, "sidebar-empty-cross-agent-groups.png");
 
       const toggle = firstEmptyGroup.locator(".sidebar-session-group-toggle");
-      await toggle.click();
-      await expect.poll(() => toggle.getAttribute("aria-expanded")).toBe("false");
+      const collapsedSectionsBefore = await page.evaluate(
+        (key) => localStorage.getItem(key),
+        collapsedSessionSectionsStorageKey,
+      );
+      await toggle.evaluate((element) => (element as HTMLButtonElement).click());
+      expect(await toggle.getAttribute("aria-expanded")).toBeNull();
+      expect(
+        await page.evaluate((key) => localStorage.getItem(key), collapsedSessionSectionsStorageKey),
+      ).toBe(collapsedSectionsBefore);
       await expect.poll(groupHeight).toBe(expandedHeight);
       await expect
         .poll(() => firstEmptyGroup.locator(".sidebar-session-empty-hint").count())

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1690,9 +1690,9 @@ openclaw-settings-save-indicator:empty {
   stroke-width: 1.8px;
 }
 
-/* Structural label, not content: at the session row's 13px/500 a group reads as
-   just another session. Type carries the whole split because the head color
-   stays near `--text` for readability; case stays as authored (project names). */
+/* Structural label, not content: keep project names smaller than session rows
+   and lighter than the parent catalog heading. Indentation and disclosure carry
+   the hierarchy while case stays as authored. */
 .sidebar-session-catalog-project__label {
   flex: 1 1 auto;
   min-width: 0;
@@ -1700,8 +1700,8 @@ openclaw-settings-save-indicator:empty {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: calc(12px * var(--control-ui-text-scale));
-  font-weight: 650;
-  letter-spacing: 0.03em;
+  font-weight: 500;
+  letter-spacing: normal;
 }
 
 .sidebar-session-catalog-project__count {


### PR DESCRIPTION
## Summary

- reduce nested Codex project label weight from 650 to 500 and remove artificial letter spacing so project rows read as children of their catalog
- keep zero-session custom groups visible with count `0`, while omitting the caret, `aria-expanded`, and collapse toggle
- preserve create/menu actions for empty groups and normal collapse behavior for non-empty groups

## Verification

- `pnpm exec vitest run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.groups.e2e.test.ts ui/src/e2e/codex-sessions.e2e.test.ts` — 2 files passed, 18 tests passed
- `pnpm exec oxfmt --check ui/src/components/app-sidebar-session-list-render.ts ui/src/e2e/codex-sessions.e2e.test.ts ui/src/e2e/session-management.groups.e2e.test.ts ui/src/styles/layout.css` — passed
- `pnpm exec stylelint --config config/stylelint.config.mjs ui/src/components/app-sidebar-session-list-render.ts ui/src/e2e/codex-sessions.e2e.test.ts ui/src/e2e/session-management.groups.e2e.test.ts ui/src/styles/layout.css` — passed
- `node scripts/run-oxlint.mjs --openclaw-focused-config ui/src/components/app-sidebar-session-list-render.ts ui/src/e2e/codex-sessions.e2e.test.ts ui/src/e2e/session-management.groups.e2e.test.ts` — 0 warnings, 0 errors
- pre-publish autoreview — clean
