### PR TITLE
fix(ui): serialize remote session permissions before sending

### DIFF
--- a/test/e2e/qa-lab/runtime/node-worker-container-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-container-wire.e2e.test.ts
@@ -49,6 +49,12 @@ type ControlUiProof = {
   browser: Browser;
   context: BrowserContext;
   page: Page;
+  fullAccessPatch: {
+    arm(): void;
+    held: Promise<void>;
+    prematureChatSend: Promise<"premature-chat-send">;
+    release(): void;
+  };
 };
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -131,7 +137,57 @@ async function startControlUiProof(gateway: WireGateway): Promise<ControlUiProof
     },
     { gatewayUrl: gateway.wsUrl, token: gateway.token },
   );
-  return { artifactDir, browser, context, page: await context.newPage() };
+  let patchArmed = false;
+  let releaseHeldPatch: (() => void) | undefined;
+  let notifyPatchHeld: () => void;
+  let notifyPrematureChatSend: () => void;
+  const patchHeld = new Promise<void>((resolve) => {
+    notifyPatchHeld = resolve;
+  });
+  const prematureChatSend = new Promise<"premature-chat-send">((resolve) => {
+    notifyPrematureChatSend = () => resolve("premature-chat-send");
+  });
+  await context.routeWebSocket(gateway.wsUrl, (socket) => {
+    const upstream = socket.connectToServer();
+    socket.onMessage((message) => {
+      const request = JSON.parse(message.toString()) as {
+        method?: string;
+        params?: { key?: string; permissionMode?: string };
+      };
+      if (
+        patchArmed &&
+        request.method === "sessions.patch" &&
+        request.params?.key === SESSION_KEY &&
+        request.params.permissionMode === "full"
+      ) {
+        patchArmed = false;
+        releaseHeldPatch = () => {
+          releaseHeldPatch = undefined;
+          upstream.send(message);
+        };
+        notifyPatchHeld();
+        return;
+      }
+      if (releaseHeldPatch && request.method === "chat.send") {
+        notifyPrematureChatSend();
+      }
+      upstream.send(message);
+    });
+  });
+  return {
+    artifactDir,
+    browser,
+    context,
+    page: await context.newPage(),
+    fullAccessPatch: {
+      arm: () => {
+        patchArmed = true;
+      },
+      held: patchHeld,
+      prematureChatSend,
+      release: () => releaseHeldPatch?.(),
+    },
+  };
 }
 
 async function captureControlUiProof(proof: ControlUiProof, name: string): Promise<void> {
@@ -262,13 +318,24 @@ describe.runIf(CONTAINER_WIRE_ENABLED)("node worker real Docker wire", () => {
           await controlUiProof.page.goto(`${gateway.baseUrl}${sessionPath}`);
           const permission = controlUiProof.page.locator('[data-chat-permission-select="true"]');
           await permission.waitFor({ state: "visible", timeout: 60_000 });
+          await controlUiProof.page.locator(".agent-chat__composer-combobox textarea").fill(PROMPT);
+          controlUiProof.fullAccessPatch.arm();
           await permission.click();
           await controlUiProof.page.locator('[data-chat-permission-option="full"]').click();
+          await controlUiProof.fullAccessPatch.held;
+          await controlUiProof.page.getByRole("button", { name: "Send message" }).click();
+          const sendOrdering = await Promise.race([
+            controlUiProof.fullAccessPatch.prematureChatSend,
+            controlUiProof.page
+              .locator(".chat-queue")
+              .getByText("Applying chat settings")
+              .waitFor({ state: "visible", timeout: 30_000 })
+              .then(() => "queued-behind-settings" as const),
+          ]);
+          expect(sendOrdering).toBe("queued-behind-settings");
+          controlUiProof.fullAccessPatch.release();
           await expect.poll(() => permission.getAttribute("data-chat-select-value")).toBe("full");
           await captureControlUiProof(controlUiProof, "03-full-access-selected");
-
-          await controlUiProof.page.locator(".agent-chat__composer-combobox textarea").fill(PROMPT);
-          await controlUiProof.page.getByRole("button", { name: "Send message" }).click();
           const activeOperator = operator;
           await vi.waitFor(
             async () => {
@@ -383,6 +450,7 @@ describe.runIf(CONTAINER_WIRE_ENABLED)("node worker real Docker wire", () => {
         ).resolves.toBe("");
       } finally {
         if (controlUiProof) {
+          controlUiProof.fullAccessPatch.release();
           await controlUiProof.context.close();
           await controlUiProof.browser.close();
           console.info(

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -677,7 +677,20 @@ suite.define(() => {
     }
   });
 
-  it("shows a pending send while a model override update is still pending", async () => {
+  it.each([
+    {
+      label: "model override",
+      trigger: '[data-chat-model-select="true"]',
+      option: '[data-chat-model-option="bedrock/claude-opus-4.5"]',
+      patch: { model: "bedrock/claude-opus-4.5" },
+    },
+    {
+      label: "Full Access permission",
+      trigger: '[data-chat-permission-select="true"]',
+      option: '[data-chat-permission-option="full"]',
+      patch: { permissionMode: "full" },
+    },
+  ])("shows a pending send while a $label update is still pending", async (setting) => {
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -687,7 +700,15 @@ suite.define(() => {
     const gateway = await installMockGateway(page, {
       deferredMethods: ["sessions.patch"],
       methodResponses: {
-        "sessions.list": chatSessionListResponse(),
+        "sessions.list": chatSessionListResponse([
+          {
+            key: "agent:main:session-a",
+            kind: "direct",
+            label: "Session A",
+            permissionMode: "workspace",
+            updatedAt: 2,
+          },
+        ]),
       },
       models: [
         { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
@@ -700,11 +721,15 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}chat`);
 
       const main = page.getByRole("main");
-      await main.locator('[data-chat-model-select="true"]').click();
-      await main.locator('[data-chat-model-option="bedrock/claude-opus-4.5"]').click();
-      await gateway.waitForRequest("sessions.patch");
+      await main.locator(setting.trigger).click();
+      await main.locator(setting.option).click();
+      const patchRequest = await gateway.waitForRequest("sessions.patch");
+      expect(requireRecord(patchRequest.params)).toMatchObject({
+        key: "agent:main:session-a",
+        ...setting.patch,
+      });
 
-      const prompt = "send while the model save is pending";
+      const prompt = `send while the ${setting.label} save is pending`;
       await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
       await page.getByRole("button", { name: "Send message" }).click();
 

--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -179,11 +179,9 @@ suite.define(() => {
         await expect
           .poll(() => visiblePane.locator('[data-progress-card-placement="rail"]').count())
           .toBe(0);
-        await visiblePane.locator(".side-panel__minimize").evaluate((button) => {
-          if (button instanceof HTMLElement) {
-            button.click();
-          }
-        });
+        const sidePanel = visiblePane.locator(".sidebar-region__right-runtime .side-panel");
+        await sidePanel.locator(".side-panel__minimize").click();
+        await sidePanel.waitFor({ state: "hidden" });
         await expect.poll(() => visiblePane.locator(".session-progress-card").count()).toBe(1);
         await expect
           .poll(() => visiblePane.locator('[data-progress-card-placement="composer"]').isVisible())

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -2,10 +2,12 @@
 
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import {
   renderChatPaneComposerControls,
   resolveChatModelCatalogState,
 } from "./chat-pane-session-controls.ts";
+import { getPendingChatPickerPatch } from "./chat-settings-patches.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { renderChatPermissionPicker } from "./components/chat-permission-picker.ts";
 
@@ -169,7 +171,7 @@ describe("chat pane composer controls", () => {
     expect(patch).toHaveBeenCalledWith(
       "agent:main:permission-test",
       { permissionMode: "guarded" },
-      {},
+      expect.objectContaining({ agentId: undefined }),
     );
 
     dropdown?.setAttribute("open", "");
@@ -178,7 +180,7 @@ describe("chat pane composer controls", () => {
     expect(patch).toHaveBeenLastCalledWith(
       "agent:main:permission-test",
       { permissionMode: null },
-      {},
+      expect.objectContaining({ agentId: undefined }),
     );
   });
 
@@ -240,6 +242,175 @@ describe("chat pane composer controls", () => {
         }),
       );
     }
+  });
+
+  it("holds the session send barrier until a Full Access selection settles", async () => {
+    const pending = createDeferred<Record<string, never>>();
+    const state = {
+      chatRunId: null,
+      connected: true,
+      connectionEpoch: 1,
+      client: {},
+      chatLoading: false,
+      chatModelCatalog: [],
+      sessions: { state: { modelOverrides: {} }, patch: vi.fn(() => pending.promise) },
+      chatModelSwitchPromises: {},
+      sessionKey: "agent:main:remote-worker",
+      chatModelsLoading: false,
+      chatSending: false,
+      sessionsResult: null,
+      chatStream: null,
+    } as unknown as ChatPageHost;
+    const controls = renderChatPaneComposerControls({
+      state,
+      selectedSession: { key: state.sessionKey, kind: "direct" },
+      agentDefaultModel: undefined,
+      modelAccess: { allowed: true, requiredScope: "operator.write" },
+      effortAccess: { allowed: true, requiredScope: "operator.write" },
+      permissionAccess: { allowed: true, requiredScope: "operator.write" },
+      canSelectFull: true,
+      toastAnchor: document.createElement("div"),
+      onModelSetup: vi.fn(),
+    });
+
+    const selection = controls.permissionPicker.onSelect("full");
+    expect(getPendingChatPickerPatch(state, state.sessionKey)).toBeDefined();
+
+    pending.resolve({});
+    await selection;
+    expect(getPendingChatPickerPatch(state, state.sessionKey)).toBeUndefined();
+  });
+
+  it.each([
+    {
+      label: "successful update after switching sessions",
+      result: "success",
+      invalidate: (state: ChatPageHost) => {
+        state.sessionKey = "agent:main:other-session";
+      },
+    },
+    {
+      label: "failed update after switching sessions",
+      result: "failure",
+      invalidate: (state: ChatPageHost) => {
+        state.sessionKey = "agent:main:other-session";
+      },
+    },
+    {
+      label: "successful global-session update after switching agents",
+      result: "success",
+      initialSessionKey: "global",
+      invalidate: (state: ChatPageHost) => {
+        state.assistantAgentId = "research";
+      },
+    },
+    {
+      label: "successful update after reconnecting",
+      result: "success",
+      invalidate: (state: ChatPageHost) => {
+        state.connectionEpoch += 1;
+      },
+    },
+    {
+      label: "successful update after replacing the Gateway client",
+      result: "success",
+      invalidate: (state: ChatPageHost) => {
+        state.client = {} as ChatPageHost["client"];
+      },
+    },
+    {
+      label: "unavailable update after switching sessions",
+      result: "null",
+      invalidate: (state: ChatPageHost) => {
+        state.sessionKey = "agent:main:other-session";
+      },
+    },
+  ] as const)("suppresses alerts for a $label", async (lifecycleCase) => {
+    const { invalidate, result } = lifecycleCase;
+    showToastMock.mockClear();
+    const pending = createDeferred<Record<string, never> | null>();
+    const state = {
+      assistantAgentId: "main",
+      chatRunId: "remote-worker-run",
+      chatError: null,
+      connected: true,
+      connectionEpoch: 1,
+      client: {},
+      chatLoading: false,
+      chatModelCatalog: [],
+      sessions: { state: { modelOverrides: {} }, patch: vi.fn(() => pending.promise) },
+      chatModelSwitchPromises: {},
+      sessionKey:
+        "initialSessionKey" in lifecycleCase
+          ? lifecycleCase.initialSessionKey
+          : "agent:main:remote-worker",
+      chatModelsLoading: false,
+      chatSending: false,
+      sessionsResult: null,
+      chatStream: null,
+      requestUpdate: vi.fn(),
+    } as unknown as ChatPageHost;
+    const controls = renderChatPaneComposerControls({
+      state,
+      selectedSession: { key: state.sessionKey, kind: "direct", hasActiveRun: true },
+      agentDefaultModel: undefined,
+      modelAccess: { allowed: true, requiredScope: "operator.write" },
+      effortAccess: { allowed: true, requiredScope: "operator.write" },
+      permissionAccess: { allowed: true, requiredScope: "operator.write" },
+      canSelectFull: true,
+      toastAnchor: document.createElement("div"),
+      onModelSetup: vi.fn(),
+    });
+
+    const selection = controls.permissionPicker.onSelect("full");
+    invalidate(state);
+    if (result === "failure") {
+      pending.reject(new Error("original remote worker disconnected"));
+    } else {
+      pending.resolve(result === "null" ? null : {});
+    }
+    await selection;
+
+    expect(showToastMock).not.toHaveBeenCalled();
+    expect(state.chatError).toBeNull();
+  });
+
+  it("reports an unavailable permission update on the current session", async () => {
+    showToastMock.mockClear();
+    const state = {
+      chatRunId: "remote-worker-run",
+      chatError: null,
+      connected: true,
+      connectionEpoch: 1,
+      client: {},
+      chatLoading: false,
+      chatModelCatalog: [],
+      sessions: { state: { modelOverrides: {} }, patch: vi.fn(async () => null) },
+      chatModelSwitchPromises: {},
+      sessionKey: "agent:main:remote-worker",
+      chatModelsLoading: false,
+      chatSending: false,
+      sessionsResult: null,
+      chatStream: null,
+      requestUpdate: vi.fn(),
+    } as unknown as ChatPageHost;
+    const controls = renderChatPaneComposerControls({
+      state,
+      selectedSession: { key: state.sessionKey, kind: "direct", hasActiveRun: true },
+      agentDefaultModel: undefined,
+      modelAccess: { allowed: true, requiredScope: "operator.write" },
+      effortAccess: { allowed: true, requiredScope: "operator.write" },
+      permissionAccess: { allowed: true, requiredScope: "operator.write" },
+      canSelectFull: true,
+      toastAnchor: document.createElement("div"),
+      onModelSetup: vi.fn(),
+    });
+
+    await controls.permissionPicker.onSelect("full");
+
+    expect(showToastMock).not.toHaveBeenCalled();
+    expect(state.chatError).toContain("Failed to update permissions");
+    expect(state.requestUpdate).toHaveBeenCalledOnce();
   });
 
   it("refreshes the configured model catalog when the picker opens", async () => {

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -17,6 +17,7 @@ import {
   switchChatModel,
   switchChatThinkingLevel,
 } from "./chat-session.ts";
+import { patchChatSessionSettings } from "./chat-settings-patches.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { refreshChatModelCatalogOnDemand } from "./chat-state-refresh.ts";
 import type { ChatProps } from "./chat-view.ts";
@@ -162,13 +163,30 @@ export function renderChatPaneComposerControls(params: {
         const runWasActive =
           Boolean(state.chatRunId) ||
           Boolean(selectedSession && isSessionRunActive(selectedSession));
+        const sessionKey = state.sessionKey;
+        const client = state.client;
+        const connectionEpoch = state.connectionEpoch;
+        const agentScope = scopedAgentParamsForSession(state, sessionKey);
+        const ownsSelection = () =>
+          state.connected &&
+          state.sessionKey === sessionKey &&
+          state.client === client &&
+          state.connectionEpoch === connectionEpoch &&
+          scopedAgentParamsForSession(state, sessionKey).agentId === agentScope.agentId;
         try {
           state.chatError = null;
-          await state.sessions.patch(
-            state.sessionKey,
+          const patched = await patchChatSessionSettings(
+            state,
+            sessionKey,
             { permissionMode },
-            scopedAgentParamsForSession(state, state.sessionKey),
+            agentScope,
           );
+          if (!ownsSelection()) {
+            return;
+          }
+          if (!patched) {
+            throw new Error("Session capability is unavailable");
+          }
           if (runWasActive) {
             const topbarHeight = toastAnchor
               .querySelector(".chat-pane__header")
@@ -182,6 +200,9 @@ export function renderChatPaneComposerControls(params: {
             });
           }
         } catch (error) {
+          if (!ownsSelection()) {
+            return;
+          }
           state.chatError = t("chat.permissionControls.updateFailed", {
             error: String(error),
           });

--- a/ui/src/pages/chat/chat-settings-patches.ts
+++ b/ui/src/pages/chat/chat-settings-patches.ts
@@ -112,10 +112,7 @@ function trackPendingChatSettingsPatch(
 export function patchChatSessionSettings(
   host: ChatPickerPatchHost,
   sessionKey: string,
-  patch: Pick<
-    SessionPatch,
-    "model" | "contextWindow" | "thinkingLevel" | "fastMode" | "toolOverrides"
-  >,
+  patch: SessionPatch,
   options: {
     agentId?: string;
     deferModelOverride?: boolean;
@@ -125,7 +122,7 @@ export function patchChatSessionSettings(
 ): Promise<SessionsPatchResult | null> {
   const previous = getPendingChatPickerPatch(host, sessionKey, options.agentId);
   const operation = (async () => {
-    // Model-dependent settings and sends share this canonical per-session tail.
+    // Run-affecting settings and sends share this canonical per-session tail.
     // The capability captures this route before waiting, so a reconnect cannot
     // redirect queued intent to a replacement Gateway.
     const result = await host.sessions.patch(sessionKey, patch, {


### PR DESCRIPTION
## What Problem This Solves

Selecting Full Access in a remote session and immediately pressing Send could start the turn under the old Workspace permission mode because the permission picker bypassed the existing per-session settings-before-send barrier. A delayed permission result could also show its success toast or failure on a different session, agent, or Gateway connection; an unavailable update falsely showed success.

## Why This Change Was Made

- Route permission changes through the existing canonical chat-settings patch queue so every direct or queued send waits for the selected permission mode, exactly like model, reasoning, and speed changes already do.
- Bind post-update UI effects to the original session, Gateway client, connection epoch, and scoped agent, preventing stale Full Access notices/errors after navigation, reconnect, or shared-global-agent switches.
- Surface a genuinely unavailable permission update on the current session instead of showing a false success toast; preserve intentional next-run notices for still-current active runs.
- Extend the existing model-setting browser regression into a model/Full Access table and strengthen the real paired-node Docker proof by holding the actual browser-to-Gateway permission frame until the immediate send is visibly queued.

Production owner: `ui/src/pages/chat/chat-settings-patches.ts` and `ui/src/pages/chat/chat-pane-session-controls.ts`. No new settings queue, fallback, configuration, protocol, database schema, or dependency.

## User Impact

Remote sessions now honor a just-selected Full Access mode even when operators immediately send a command. No approval prompt or permission denial can result from racing the previous Workspace mode, and alerts never leak into another agent/session after switching or reconnecting.

## Evidence

Before the fix, seven owner regressions failed; the real Chromium Full Access case failed while its existing model case passed. After the owner repair:

```sh
node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-session-controls.test.ts ui/src/pages/chat/chat-send.test.ts ui/src/pages/chat/chat-send-submit.test.ts --reporter verbose
# 323 passed

node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
# 13 actual Chromium scenarios passed

OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/ui.js build --configLoader runner

OPENCLAW_E2E_USE_PREBUILT_DIST=1 OPENCLAW_DOCKER_NODE_WORKER_E2E=1 OPENCLAW_DOCKER_NODE_WORKER_UI_PROOF=1 node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/node-worker-container-wire.e2e.test.ts --reporter verbose
# actual paired node + Docker + rebuilt Gateway-served UI: held permission frame,
# immediate send queued, real Full Access execution, reconciliation, zero approvals, cleanup

OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --timed -- test/e2e/qa-lab/runtime/node-worker-container-wire.e2e.test.ts ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts ui/src/pages/chat/chat-pane-session-controls.test.ts ui/src/pages/chat/chat-pane-session-controls.ts ui/src/pages/chat/chat-settings-patches.ts
```

Fresh independent structured review: clean, no actionable findings.

## Before / after: real paired Docker worker

Full Access selected; the permission update is serialized ahead of the immediately submitted remote command:

![Real paired Docker worker with Full Access selected](https://github.com/user-attachments/assets/359f60a2-e70c-46b7-8a90-e106f760cca8)

The actual Docker turn completes after the permission update, with no approval dialog or pending request:

![Full Access Docker worker completed without approval alerts](https://github.com/user-attachments/assets/4baea73d-222d-47b1-804e-33249cb320d0)

Recorded real Gateway, paired node, Docker worker, and Chromium proof:

https://github.com/user-attachments/assets/1c9feb3b-bd1e-4136-892b-23dbb8b6c97e
