### PR TITLE
fix(models): normalize mixed aliases consistently

### DIFF
--- a/src/agents/model-selection-manifest-workspace.test.ts
+++ b/src/agents/model-selection-manifest-workspace.test.ts
@@ -331,6 +331,52 @@ describe("configured model manifest workspace scope", () => {
     expect(normalizeProviderModelIdWithRuntimeMock.mock.calls.length).toBe(1);
   });
 
+  it.each([
+    {
+      name: "default-provider first",
+      models: [
+        ["openai/legacy", { alias: "Legacy" }],
+        ["custom/ops", { alias: "Operations" }],
+      ],
+    },
+    {
+      name: "provider-owned first",
+      models: [
+        ["custom/ops", { alias: "Operations" }],
+        ["openai/legacy", { alias: "Legacy" }],
+      ],
+    },
+  ])("normalizes mixed aliases consistently with $name", async ({ models }) => {
+    loadManifestMetadataSnapshotMock.mockReturnValue({
+      plugins: [
+        {
+          modelIdNormalization: {
+            providers: {
+              custom: { prefixWhenBare: "workspace-custom" },
+              openai: { aliases: { legacy: "normalized" } },
+            },
+          },
+        },
+      ],
+    });
+    const { buildModelAliasIndex } = await import("./model-selection-shared.js");
+    const cfg = {
+      agents: { defaults: { models: Object.fromEntries(models) } },
+    } as unknown as OpenClawConfig;
+
+    const aliases = buildModelAliasIndex({ cfg, defaultProvider: "openai" });
+
+    expect(aliases.byAlias.get("legacy")?.ref).toEqual({
+      provider: "openai",
+      model: "normalized",
+    });
+    expect(aliases.byAlias.get("operations")?.ref).toEqual({
+      provider: "custom",
+      model: "workspace-custom/ops",
+    });
+    expect(loadManifestMetadataSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves manifest discovery for default-provider configured API-owner mappings", async () => {
     const { buildModelAliasIndex } = await import("./model-selection-shared.js");
     const cfg = {

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -68,6 +68,20 @@ type EffectiveModelAlias = ModelAliasCandidate & {
   ref: ModelRef;
 };
 
+function isStaticDefaultProviderAliasCandidate(
+  candidate: ModelAliasCandidate,
+  cfg: OpenClawConfig,
+): boolean {
+  const raw = candidate.keyRaw.trim();
+  const slash = raw.indexOf("/");
+  return (
+    slash > 0 &&
+    slash < raw.length - 1 &&
+    normalizeProviderId(raw.slice(0, slash)) === normalizeProviderId(DEFAULT_PROVIDER) &&
+    !findExactConfiguredProviderRefParts({ cfg, raw })
+  );
+}
+
 type ExactConfiguredProviderRefParts = {
   configuredProvider: string;
   modelRaw: string;
@@ -164,30 +178,27 @@ function buildEffectiveModelAliases(
   if (candidates.length === 0) {
     return { aliases: [], disabledKeys: new Set() };
   }
+  // One alias index must use one manifest generation. Skip discovery only when
+  // every candidate is a default-provider identity transform.
+  const useStaticDefaultProviderAliases =
+    params.allowManifestNormalization !== false &&
+    candidates.every((candidate) => isStaticDefaultProviderAliasCandidate(candidate, params.cfg)) &&
+    params.manifestPluginContext.peek() === undefined &&
+    !getActivePluginRegistryWorkspaceDirFromState() &&
+    !getCurrentPluginMetadataSnapshot({ config: params.cfg, env: process.env });
+  const manifestPlugins = useStaticDefaultProviderAliases
+    ? undefined
+    : params.manifestPluginContext.get();
   for (const candidate of candidates) {
-    const isColdDefaultProviderAlias =
-      params.allowManifestNormalization !== false &&
-      hasSlashFormModelRef(candidate.keyRaw) &&
-      normalizeProviderId(candidate.keyRaw.slice(0, candidate.keyRaw.indexOf("/"))) ===
-        normalizeProviderId(DEFAULT_PROVIDER) &&
-      !findExactConfiguredProviderRefParts({ cfg: params.cfg, raw: candidate.keyRaw }) &&
-      params.manifestPluginContext.peek() === undefined &&
-      !getActivePluginRegistryWorkspaceDirFromState() &&
-      !getCurrentPluginMetadataSnapshot({ config: params.cfg, env: process.env });
-    // The default-provider owner declares no manifest or runtime model normalizer;
-    // cold alias indexing must not discover every plugin for an identity transform.
-    const manifestPlugins = isColdDefaultProviderAlias
-      ? undefined
-      : params.manifestPluginContext.get();
     const ref = parseModelRefWithCompatAlias({
       cfg: params.cfg,
       agentId: params.agentId,
       raw: candidate.keyRaw,
       defaultProvider: params.defaultProvider,
-      allowManifestNormalization: isColdDefaultProviderAlias
+      allowManifestNormalization: useStaticDefaultProviderAliases
         ? false
         : params.allowManifestNormalization,
-      allowPluginNormalization: isColdDefaultProviderAlias
+      allowPluginNormalization: useStaticDefaultProviderAliases
         ? false
         : params.allowPluginNormalization,
       manifestPlugins,


### PR DESCRIPTION
Related: #129510

## What Problem This Solves

Fixes a regression where a model alias could resolve to different provider/model references solely because configured aliases appeared in a different object insertion order. The regression was introduced by #129510's cold default-provider optimization and was caught by its final structured review immediately after merge.

## Why This Change Was Made

Decide once for the complete alias candidate set whether every entry is a static default-provider identity transform. If any candidate requires provider-owned manifest normalization, load one manifest generation before indexing and apply it consistently to every alias. The all-static default-provider fast path still avoids plugin discovery.

## User Impact

Mixed model alias configurations now resolve deterministically regardless of declaration order. Operators retain the plugin-discovery performance improvement from #129510 without risking an earlier alias being frozen before a later provider-owned alias loads normalization policy.

## Evidence

- New parameterized regression covers both `openai/legacy`-first and provider-owned-alias-first orderings; both resolve the OpenAI alias through the same manifest policy and the custom alias through its provider prefix.
- The regression would fail on #129510's merged head in the default-provider-first ordering.
- Focused caller and sibling proof passed 473 tests across commands, auto-reply, agents-core, and embedded-agent projects.
- `node scripts/check-changed.mjs` passed formatting, production/core-test typechecking, lint, dead-export scans, plugin boundaries, runtime-sidecar, database-first, import-cycle, and authorization guards.
- `git diff --check` passed.
- Fresh mandatory P1 autoreview reported no accepted or actionable findings (`patch is correct`, confidence 0.94).
- Production delta: +27/-16 (net +11) in the alias owner; tests: +46/-0. The production growth replaces the per-candidate policy decision with one candidate-set decision and one shared manifest generation.

AI-assisted; the maintainer verified the merged regression, owner boundary, both candidate orders, and the retained cold-path optimization.