### PR TITLE
fix(test): prevent shared-worker metadata resets from breaking unrelated suites

### DIFF
--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -50,15 +50,6 @@ function fixtureFiles(): Record<string, string> {
   const agentEventsPath = JSON.stringify(path.join(repoRoot, "src", "infra", "agent-events.ts"));
   const loggingConsolePath = JSON.stringify(path.join(repoRoot, "src", "logging", "console.ts"));
   const loggingStatePath = JSON.stringify(path.join(repoRoot, "src", "logging", "state.ts"));
-  const pluginMetadataStatePath = JSON.stringify(
-    path.join(repoRoot, "src", "plugins", "current-plugin-metadata-state.ts"),
-  );
-  const pluginMetadataRuntimePath = JSON.stringify(
-    path.join(repoRoot, "src", "plugins", "plugin-metadata-snapshot.runtime.ts"),
-  );
-  const pluginMetadataLifecyclePath = JSON.stringify(
-    path.join(repoRoot, "src", "plugins", "plugin-metadata-lifecycle.ts"),
-  );
 
   return {
     "01-dep.ts": 'export function flavor(): string {\n  return "real";\n}\n',
@@ -205,56 +196,6 @@ function fixtureFiles(): Record<string, string> {
       "});",
       "",
     ].join("\n"),
-    "07-a-plugin-metadata.test.ts": [
-      `import { setCurrentPluginMetadataSnapshotState } from ${pluginMetadataStatePath};`,
-      `import { getCurrentPluginMetadataSnapshotRuntime, registerPluginMetadataSnapshotReaders } from ${pluginMetadataRuntimePath};`,
-      `import { registerPluginMetadataProcessMemoLifecycleClear } from ${pluginMetadataLifecyclePath};`,
-      'import { expect, it } from "vitest";',
-      'it("seeds process-global plugin metadata readers and their snapshot", () => {',
-      '  const snapshot = { source: "first-file" };',
-      '  const readerKey = Symbol.for("openclaw.pluginMetadataSnapshotReaders");',
-      '  const probeKey = Symbol.for("openclaw.test.pluginMetadataLifecycle");',
-      "  const store = globalThis as Record<PropertyKey, unknown>;",
-      "  const probe = { clears: 0, readers: store[readerKey] };",
-      "  store[probeKey] = probe;",
-      "  registerPluginMetadataProcessMemoLifecycleClear(() => { probe.clears += 1; });",
-      '  setCurrentPluginMetadataSnapshotState(snapshot, "first-file");',
-      "  registerPluginMetadataSnapshotReaders({",
-      "    getCurrentPluginMetadataSnapshot: () => snapshot,",
-      "    resolvePluginMetadataSnapshot: () => snapshot,",
-      "  });",
-      "  expect(getCurrentPluginMetadataSnapshotRuntime({ config: {} })).toBe(snapshot);",
-      "});",
-      "",
-    ].join("\n"),
-    "07-b-plugin-metadata.test.ts": [
-      `import { getCurrentPluginMetadataSnapshotState } from ${pluginMetadataStatePath};`,
-      `import { getCurrentPluginMetadataSnapshotRuntime } from ${pluginMetadataRuntimePath};`,
-      'import { expect, it } from "vitest";',
-      'it("clears process-global plugin metadata snapshots and reader closures", () => {',
-      '  const readerKey = Symbol.for("openclaw.pluginMetadataSnapshotReaders");',
-      '  const probeKey = Symbol.for("openclaw.test.pluginMetadataLifecycle");',
-      "  const store = globalThis as Record<PropertyKey, unknown>;",
-      "  const probe = store[probeKey] as { clears: number; readers: object };",
-      "  const readers = store[readerKey] as Record<string, unknown>;",
-      "  expect({",
-      "    clears: probe.clears,",
-      "    getterPresent: typeof readers.getCurrentPluginMetadataSnapshot === 'function',",
-      "    resolverPresent: typeof readers.resolvePluginMetadataSnapshot === 'function',",
-      "    readerIdentityRetained: readers === probe.readers,",
-      "    snapshot: getCurrentPluginMetadataSnapshotState().snapshot,",
-      "    readerSnapshot: getCurrentPluginMetadataSnapshotRuntime({ config: {} }),",
-      "  }).toEqual({",
-      "    clears: 1,",
-      "    getterPresent: false,",
-      "    resolverPresent: false,",
-      "    readerIdentityRetained: true,",
-      "    snapshot: undefined,",
-      "    readerSnapshot: undefined,",
-      "  });",
-      "});",
-      "",
-    ].join("\n"),
   };
 }
 
@@ -310,7 +251,7 @@ it("cleans every shared runner surface between files", async () => {
     // The collection failure is intentional. Every behavior test after it must
     // pass; any leaked surface turns the summary into a second failure.
     expect(output).toContain("synthetic collect failure");
-    expect(output).toContain("1 failed | 13 passed");
+    expect(output).toContain("1 failed | 11 passed");
     expect(output).not.toContain("first-file");
   } finally {
     await fs.rm(root, { recursive: true, force: true });

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -4,8 +4,6 @@ import { TestRunner, type RunnerTask, type RunnerTestFile, vi } from "vitest";
 import { resetAgentEventsForTest } from "../src/infra/agent-events.js";
 import { loggingState } from "../src/logging/state.js";
 import { clearNamedPluginRuntimeStoresForTest } from "../src/plugin-sdk/runtime-store-registry.js";
-import { clearCurrentPluginMetadataSnapshot } from "../src/plugins/current-plugin-metadata-state.js";
-import { registerPluginMetadataSnapshotReaders } from "../src/plugins/plugin-metadata-snapshot.runtime.js";
 import {
   type CustomElementTracking,
   dropRepoOwnedCustomElements,
@@ -334,31 +332,6 @@ function resetOpenClawSessionSuspensionState(): void {
   api?.resetSessionSuspensionStateForTest?.();
 }
 
-function resetOpenClawPluginMetadataState(modules: EvaluatedModules): void {
-  let clearLifecycle: (() => void) | undefined;
-  for (const [modulePath, module] of modules.idToModuleMap) {
-    if (
-      modulePath.startsWith("mock:") ||
-      !/\/src\/plugins\/plugin-metadata-lifecycle\.(?:ts|js)(?:\?.*)?$/u.test(modulePath) ||
-      !module.exports ||
-      typeof module.exports !== "object"
-    ) {
-      continue;
-    }
-    const clear = Reflect.get(module.exports, "clearPluginMetadataLifecycleCaches");
-    if (typeof clear === "function") {
-      clearLifecycle = clear;
-    }
-  }
-  (clearLifecycle ?? clearCurrentPluginMetadataSnapshot)();
-
-  // Existing lightweight bridges retain the slot, so reset reader closures in place.
-  registerPluginMetadataSnapshotReaders({
-    getCurrentPluginMetadataSnapshot: undefined,
-    resolvePluginMetadataSnapshot: undefined,
-  });
-}
-
 const SERIALIZED_RESOLVE_MOCKS = Symbol.for("openclaw.serializedResolveMocks");
 
 type SerializedResolveMocksState = {
@@ -500,12 +473,10 @@ export default class OpenClawNonIsolatedRunner extends TestRunner {
     // Named plugin runtimes intentionally survive duplicate module evaluation in production.
     // Clear their shared slots here so one test file cannot lend a partial runtime to the next.
     clearNamedPluginRuntimeStoresForTest();
-    const evaluatedModules = internals.workerState.evaluatedModules as EvaluatedModules;
-    resetOpenClawPluginMetadataState(evaluatedModules);
     dropTrackedRepoOwnedCustomElements();
     resetSharedDocumentBody();
     vi.resetModules();
     internals.moduleRunner?.mocker?.reset?.();
-    resetEvaluatedModules(evaluatedModules, true);
+    resetEvaluatedModules(internals.workerState.evaluatedModules as EvaluatedModules, true);
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where otherwise unrelated CLI update and Gateway test suites intermittently fail after another test file has published plugin metadata in a shared Vitest worker. The regression was introduced by the shared-runner cleanup included in #129502.

## Why This Change Was Made

Keep process-owned plugin metadata snapshots and their registered reader closures alive across non-isolated test files. Remove the newly introduced runner cleanup and the fixture that incorrectly required those process-stable readers to disappear; preserve all existing module, mock, environment, timer, and other shared-state cleanup.

## User Impact

No production or user-facing behavior changes. Maintainers regain reliable shared-worker CLI and Gateway validation without changing plugin configuration, runtime behavior, or public contracts.

## Evidence

- Authentic baseline owner-boundary RED: the actual production metadata reader returned undefined immediately after the shared runner cleanup, despite a published snapshot.
- Identical candidate owner-boundary GREEN: the actual production reader retains and returns the same published snapshot across the repaired cleanup boundary.
- Focused owner and affected CLI suites: 254 tests passed across three scoped Vitest shards, including 247 update CLI tests.
- Independent complete Gateway sibling proof: 199 test files and 3,687 tests passed.
- During the first Gateway run, one performance test reported a missing mock bookkeeping label even though its real SQLite transaction and all 30 archived sessions succeeded; the focused performance tests passed 2/2, and the same complete Gateway command then passed 199/199 files and 3,687/3,687 tests.
- Fresh authenticated structured review and independent owner review both reported no actionable findings.
- Production LOC: +0/-0. Test support: +1/-30. Tests: +1/-60.
- Original repair author and preserved Git commit author: Dallin Romney <dallinromney@gmail.com>.
