### PR TITLE
fix(macos): cancelled Talk sessions can spin at full CPU

### DIFF
--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -479,8 +479,7 @@ actor TalkModeRuntime {
     }
 
     private func silenceLoop() async {
-        while self.isEnabled {
-            try? await Task.sleep(nanoseconds: 200_000_000)
+        while self.isEnabled, (try? await Task.sleep(nanoseconds: 200_000_000)) != nil {
             await self.checkSilence()
         }
     }

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -479,7 +479,7 @@ actor TalkModeRuntime {
     }
 
     private func silenceLoop() async {
-        while self.isEnabled, (try? await Task.sleep(nanoseconds: 200_000_000)) != nil {
+        while self.isEnabled, await SimpleTaskSupport.waitForNextOperation(interval: 0.2) {
             await self.checkSilence()
         }
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS Talk users resuming voice input, replacing a silence monitor, or reconfiguring an active session could experience a pegged CPU and an unresponsive Talk runtime.

## Why This Change Was Made

The macOS silence-monitor lifecycle cancels its previous task before starting a replacement while Talk remains enabled. Its previous loop discarded the cancellation thrown by Swift `Task.sleep`, immediately repeated without waiting, and continued invoking silence checks indefinitely. The monitor now reuses the application's existing `SimpleTaskSupport.waitForNextOperation` cancellation owner, already used by presence reporting and channel polling, to exit before a stale check while preserving its existing 200 ms cadence. Production delta: +1/-2, net -1; no new API, configuration, dependency, actor seam, or UI surface.

## User Impact

Replacing, pausing, or reconfiguring an active macOS Talk session no longer leaves an orphaned monitor spinning at full CPU or competing with the active voice session. Normal silence detection behavior remains unchanged.

## Evidence

Actual Swift 6.4 executable cancellation proof, using the same task/sleep lifecycle as the production owner:

```json
{"verdict":"FAIL","cancelledSilenceChecks":5000,"elapsedMs":0.789584,"expectedCancelledChecks":0}
{"verdict":"PASS","cancelledSilenceChecks":0,"elapsedMs":0.043167,"expectedCancelledChecks":0}
{"normalCadenceVerdict":"PASS","normalSilenceChecks":1}
```

- The exact changed production file passes `xcrun swiftc -parse apps/macos/Sources/OpenClaw/TalkModeRuntime.swift`.
- Existing `SimpleTaskSupportTests` already cover cancellation during sleep, cancellation after sleep, and replacing a superseded task. The same canonical helper is already used by presence reporting and channel polling; the iOS Talk silence owner likewise returns immediately when its sleep is cancelled.
- The exact macOS CI formatter succeeds across all 338 application files and 26 additional native sources: `./scripts/format-swift.sh macos`. SwiftLint on the changed owner reports zero violations.
- Fresh independent structured Codex autoreview: clean, with no accepted/actionable findings.
- A new in-process regression test is intentionally not added: the unfixed actor enters an unbounded busy loop and can permanently wedge the shared serialized macOS test runner; exposing its private task solely for a test would add an unnecessary production seam. The bounded executable before/after cancellation proof directly covers the violated Swift concurrency contract, and hosted macOS CI validates the real application build and existing native tests.
