### PR TITLE
chore: remove duplicate model-readiness assertion

### DIFF
--- a/ui/src/pages/model-providers/view.test.ts
+++ b/ui/src/pages/model-providers/view.test.ts
@@ -554,7 +554,6 @@ describe("renderModelProviders", () => {
     const readiness = container.querySelector('[data-model-readiness="model-required"]');
     expect(text(readiness)).toContain("Connect a verified AI model");
     expect(text(readiness)).toContain("Model required");
-    expect(text(readiness)).toContain("Connect a verified AI model");
     expect(container.querySelector(".model-providers__defaults")).toBeNull();
     expect(text(container.querySelector('[data-provider-id="openai"]'))).toContain(
       "Credentials configured",


### PR DESCRIPTION
## What Problem This Solves

The model-provider readiness test repeated the same unchanged-DOM text assertion twice, adding maintenance noise without detecting another regression.

## Why This Change Was Made

Remove the exact adjacent duplicate while retaining the first readiness-copy assertion and all distinct checks for the required state, hidden defaults, credential status, and recovery routing.

## User Impact

No user-visible behavior changes. This only makes the existing test more focused.

Production LOC: +0/-0 | Tests: +0/-1

## Evidence

- Baseline: `node scripts/run-vitest.mjs ui/src/pages/model-providers/view.test.ts` — 36/36 passed.
- Current exact head: `node scripts/run-vitest.mjs ui/src/pages/model-providers/view.test.ts` — 36/36 passed.
- `node scripts/check-changed.mjs -- ui/src/pages/model-providers/view.test.ts` — passed.
- Fresh autoreview: clean; no accepted/actionable findings.
- `git diff --check origin/main...HEAD` — passed.
