### PR TITLE
fix(llama-cpp): restore tools for fallback-capable chat templates

### DIFF
--- a/extensions/llama-cpp/src/external-server/models.test.ts
+++ b/extensions/llama-cpp/src/external-server/models.test.ts
@@ -66,6 +66,48 @@ describe("llama-server model mapping", () => {
     ).toEqual(["text", "image"]);
   });
 
+  it.each([
+    {
+      name: "native tool descriptions and calls",
+      caps: { supports_tools: true, supports_tool_calls: true },
+      supported: true,
+    },
+    {
+      name: "fallback tool descriptions",
+      caps: { supports_tools: false, supports_tool_calls: true },
+      supported: true,
+    },
+    {
+      name: "tool calls without description metadata",
+      caps: { supports_tool_calls: true },
+      supported: true,
+    },
+    {
+      name: "tool descriptions without calls",
+      caps: { supports_tools: true, supports_tool_calls: false },
+      supported: false,
+    },
+    {
+      name: "unsupported tool descriptions and calls",
+      caps: { supports_tools: false, supports_tool_calls: false },
+      supported: false,
+    },
+    { name: "missing tool-call capability", caps: { supports_tools: true }, supported: false },
+    {
+      name: "malformed tool-call capability",
+      caps: { supports_tools: true, supports_tool_calls: "true" },
+      supported: false,
+    },
+    { name: "missing template capabilities", caps: undefined, supported: false },
+  ])("uses the tool-call capability for $name", ({ caps, supported }) => {
+    expect(
+      mapLlamaServerModel(
+        { id: "community/fallback-model", object: "model" },
+        { chat_template_caps: caps },
+      )?.config.compat?.supportsTools,
+    ).toBe(supported);
+  });
+
   it("defaults unknown capabilities conservatively", () => {
     expect(mapLlamaServerModel({ id: "model", object: "model" })?.config.compat).toMatchObject({
       supportsTools: false,

--- a/extensions/llama-cpp/src/external-server/models.ts
+++ b/extensions/llama-cpp/src/external-server/models.ts
@@ -93,8 +93,7 @@ function buildCompat(
   props: LlamaServerPropsWire | undefined,
 ): NonNullable<ModelDefinitionConfig["compat"]> {
   const caps = props?.chat_template_caps;
-  const supportsTools =
-    asBoolean(caps?.supports_tools) === true && asBoolean(caps?.supports_tool_calls) === true;
+  const supportsTools = asBoolean(caps?.supports_tool_calls) === true;
   const supportsTypedContent = asBoolean(caps?.supports_typed_content) === true;
   return {
     supportsStore: false,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users connecting an existing llama-server would lose access to agent tools when their chat template supports tool calls but relies on llama.cpp's fallback for describing the available tools.

## Why This Change Was Made

llama.cpp treats tool-call parsing and native tool-description rendering as independent capabilities. Its upstream implementation explicitly supports the fallback combination and gates tool parsing only on `supports_tool_calls`; OpenClaw now follows that same provider-owned contract when discovering existing servers.

## User Impact

Existing llama-server models that can call tools through llama.cpp's supported fallback now keep their OpenClaw agent tools. Models with absent, disabled, or malformed tool-call capability remain conservatively tool-disabled.

## Evidence

- Upstream llama.cpp commit `dd1ea524333b1e697489067d7a4c39c60d32beee` explicitly handles templates with tool calls but no native tool descriptions: https://github.com/ggml-org/llama.cpp/blob/dd1ea524333b1e697489067d7a4c39c60d32beee/common/chat.cpp#L3445-L3448
- The upstream parser gates tool handling on `supports_tool_calls` alone: https://github.com/ggml-org/llama.cpp/blob/dd1ea524333b1e697489067d7a4c39c60d32beee/common/chat-auto-parser-generator.cpp#L146-L148
- Actual local HTTP discovery exercised `/health`, `/models`, and `/props?model=community%2Ffallback-template.gguf&autoload=false` without loading or modifying a model. With `supports_tools: false` and `supports_tool_calls: true`, the discovered model changed from `supportsTools: false` before the fix to `supportsTools: true` afterward.
- The owner-level regression failed on both supported fallback cases before the fix; its capability matrix also covers native support, missing description metadata, disabled calls, missing calls, malformed calls, and absent capabilities.
- All seven existing-server discovery, setup, provider, endpoint, streaming, authentication, and model suites passed: **72 tests**.
- Formatting, scoped lint, two independent source reviews, and automated review passed. Production code is net **-1 line**.
