### PR TITLE
fix(ci): run isolated gateway agent methods

### DIFF
--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -1816,7 +1816,10 @@ const SPLIT_NODE_SHARDS = new Map<string, NodeTestSplitShard[]>([
       ...createAgenticGatewayCoreSplitShards(),
       {
         shardName: "agentic-gateway-methods",
-        configs: ["test/vitest/vitest.gateway-methods.config.ts"],
+        configs: [
+          "test/vitest/vitest.gateway-methods.config.ts",
+          "test/vitest/vitest.gateway-methods-isolated.config.ts",
+        ],
         requiresDist: false,
       },
       {

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -22,6 +22,7 @@ import { createGatewayServerVitestConfig } from "../vitest/vitest.gateway-server
 import { createMediaUnderstandingVitestConfig } from "../vitest/vitest.media-understanding.config.ts";
 import { createMediaVitestConfig } from "../vitest/vitest.media.config.ts";
 import { createPluginsVitestConfig } from "../vitest/vitest.plugins.config.ts";
+import { fullSuiteVitestShards } from "../vitest/vitest.test-shards.mjs";
 import { createToolingVitestConfig } from "../vitest/vitest.tooling.config.ts";
 import { createTuiVitestConfig } from "../vitest/vitest.tui.config.ts";
 import { createUiIsolatedVitestConfig } from "../vitest/vitest.ui-isolated.config.ts";
@@ -112,9 +113,9 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
 
   it("projects cache-warm groups from the owned node test plan", () => {
     const groups = createVitestCacheWarmGroups();
-    expect(groups).toHaveLength(10);
+    expect(groups).toHaveLength(11);
     expect(groups.every((group) => group.configs.length === 1)).toBe(true);
-    expect(new Set(groups.flatMap((group) => group.configs))).toHaveProperty("size", 9);
+    expect(new Set(groups.flatMap((group) => group.configs))).toHaveProperty("size", 10);
     expect(new Set(groups.map((group) => group.shard_name))).toHaveProperty("size", groups.length);
 
     const coreStripeGroups = groups.filter(
@@ -145,9 +146,12 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     const gatewayGroups = groups.filter((group) =>
       group.shard_name.startsWith("cache-warm:agentic-gateway-methods:"),
     );
-    expect(gatewayGroups).toHaveLength(1);
-    expect(gatewayGroups[0]?.includePatterns).toBeUndefined();
-    expect(gatewayGroups[0]?.env).toBeUndefined();
+    expect(gatewayGroups.map((group) => group.configs[0]).toSorted()).toEqual([
+      "test/vitest/vitest.gateway-methods-isolated.config.ts",
+      "test/vitest/vitest.gateway-methods.config.ts",
+    ]);
+    expect(gatewayGroups.every((group) => group.includePatterns === undefined)).toBe(true);
+    expect(gatewayGroups.every((group) => group.env === undefined)).toBe(true);
 
     const autoReplyGroups = groups.filter((group) =>
       group.shard_name.startsWith("cache-warm:auto-reply-reply-commands-3:"),
@@ -825,6 +829,24 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(configs).not.toContain("test/vitest/vitest.bundled.config.ts");
     expect(configs).not.toContain("test/vitest/vitest.full-extensions.config.ts");
     expect(configs).not.toContain("test/vitest/vitest.extension-telegram.config.ts");
+  });
+
+  it("keeps compact agentic config ownership aligned with the full agentic project set", () => {
+    const fullAgenticShard = fullSuiteVitestShards.find((shard) => shard.name === "agentic");
+    const intentionallyExcludedConfigs = new Set(["test/vitest/vitest.channels.config.ts"]);
+    const expectedConfigs = (fullAgenticShard?.projects ?? [])
+      .filter((config) => !intentionallyExcludedConfigs.has(config))
+      .toSorted((left, right) => left.localeCompare(right));
+    const actualConfigs = [
+      ...new Set(
+        createNodeTestShards()
+          .filter((shard) => shard.shardName.startsWith("agentic-"))
+          .flatMap((shard) => shard.configs),
+      ),
+    ].toSorted((left, right) => left.localeCompare(right));
+
+    expect(fullAgenticShard).toBeDefined();
+    expect(actualConfigs).toEqual(expectedConfigs);
   });
 
   it("marks only dist-dependent shards for built artifact restore", () => {
@@ -1510,7 +1532,10 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(gatewayMethodsShard).toEqual({
       checkName: "checks-node-agentic-gateway-methods",
       shardName: "agentic-gateway-methods",
-      configs: ["test/vitest/vitest.gateway-methods.config.ts"],
+      configs: [
+        "test/vitest/vitest.gateway-methods.config.ts",
+        "test/vitest/vitest.gateway-methods-isolated.config.ts",
+      ],
       requiresDist: false,
       runner: DEFAULT_NODE_TEST_RUNNER,
     });


### PR DESCRIPTION
Fixes #129658

## What Problem This Solves

Fixes an issue where compact agentic CI skipped the isolated Gateway agent-method project added by #128965 because the compact planner still owned only the non-isolated Gateway-methods config.

## Why This Change Was Made

Adds the existing isolated config to the existing `agentic-gateway-methods` shard, so it also receives its own cache-warm group. No shard or timing estimate is added. A planner invariant now keeps compact agentic config ownership aligned with the full agentic project set except the intentionally excluded channels project.

## User Impact

No production or user-facing behavior changes. Maintainers get the existing isolated Gateway agent-method coverage in normal compact CI.

The existing `clawsweeper:no-new-fix-pr`, `clawsweeper:needs-info`, and `clawsweeper:needs-maintainer-review` advisory labels on #129658 are intentionally retained pending maintainer review. This draft does not change runner behavior or claim a new deterministic runner bypass.

## Evidence

- Pre-fix current-main planner regression: 3 of 24 assertions failed, each identifying the omitted isolated config or cache-warm group; wrapper time 4.68s.
- Final-base focused planner test: 24 of 24 passed; wrapper time 4.47s.
- Exact two-config composition with `OPENCLAW_TEST_PROJECTS_PARALLEL=1 OPENCLAW_VITEST_MAX_WORKERS=2`:
  - `vitest.gateway-methods.config.ts`: 198 files, 3405 tests passed in 105.09s.
  - `vitest.gateway-methods-isolated.config.ts`: 1 file, 284 tests passed in 24.45s.
  - Aggregate: 2 shards, 3689 tests passed in 131.52s.
- `git diff --check`, targeted format, script lint, Docker E2E boundary lint, and raw HTTP/2 import lint passed.
- `check:changed` passed its guards through script erasability, then both script and root-test typechecks stopped on the shared install missing declarations for the unchanged `ui/vite.config.ts` import of `pako`. No dependency install or workaround was applied in the worktree.
- Mandatory autoreview: clean, no accepted/actionable findings.
- LOC: production `+0/-0`; CI tooling `+4/-1`; tests `+31/-6`.
