### PR TITLE
refactor: remove progress-card limit forwarders

### DIFF
--- a/src/agents/tools/progress-card-tool.ts
+++ b/src/agents/tools/progress-card-tool.ts
@@ -1,12 +1,12 @@
 import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { Type } from "typebox";
 import {
+  PROGRESS_CARD_MAX_STEPS,
   ProgressCardStepSchema,
   type ProgressCardPutResult,
 } from "../../../packages/gateway-protocol/src/index.js";
 import {
   normalizeProgressCardInput,
-  PROGRESS_CARD_MAX_STEPS,
   ProgressCardInputError,
 } from "../../session-cards/progress-card-input.js";
 import type { AnyAgentTool } from "./common.js";

--- a/src/gateway/server-methods/progress-card.test.ts
+++ b/src/gateway/server-methods/progress-card.test.ts
@@ -1,16 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
-import type {
-  ProgressCard,
-  ProgressCardStep,
-} from "../../../packages/gateway-protocol/src/index.js";
-import { resolveCoreOperatorGatewayMethodScope } from "../methods/core-descriptors.js";
-import type { ProgressCardStore } from "../progress-card-store.js";
 import {
-  createProgressCardHandlers,
   PROGRESS_CARD_MAX_STEP_UTF8_BYTES,
   PROGRESS_CARD_MAX_STEPS,
   PROGRESS_CARD_MAX_UTF8_BYTES,
-} from "./progress-card.js";
+  type ProgressCard,
+  type ProgressCardStep,
+} from "../../../packages/gateway-protocol/src/index.js";
+import { resolveCoreOperatorGatewayMethodScope } from "../methods/core-descriptors.js";
+import type { ProgressCardStore } from "../progress-card-store.js";
+import { createProgressCardHandlers } from "./progress-card.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 
 function createHarness() {

--- a/src/gateway/server-methods/progress-card.ts
+++ b/src/gateway/server-methods/progress-card.ts
@@ -6,9 +6,6 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import {
   normalizeProgressCardInput,
-  PROGRESS_CARD_MAX_STEP_UTF8_BYTES,
-  PROGRESS_CARD_MAX_STEPS,
-  PROGRESS_CARD_MAX_UTF8_BYTES,
   ProgressCardInputError,
 } from "../../session-cards/progress-card-input.js";
 import { progressCardStore, type ProgressCardStore } from "../progress-card-store.js";
@@ -17,8 +14,6 @@ import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { resolveSessionStoreKey } from "../session-store-key.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
-
-export { PROGRESS_CARD_MAX_STEP_UTF8_BYTES, PROGRESS_CARD_MAX_STEPS, PROGRESS_CARD_MAX_UTF8_BYTES };
 
 function resolveProgressCardSessionKey(
   sessionKey: string,

--- a/src/session-cards/progress-card-input.ts
+++ b/src/session-cards/progress-card-input.ts
@@ -7,8 +7,6 @@ import {
 } from "../../packages/gateway-protocol/src/index.js";
 import { stripInvisibleUnicode } from "../infra/unicode-visibility.js";
 
-export { PROGRESS_CARD_MAX_STEP_UTF8_BYTES, PROGRESS_CARD_MAX_STEPS, PROGRESS_CARD_MAX_UTF8_BYTES };
-
 export class ProgressCardInputError extends Error {}
 
 type NormalizedProgressCardInput = {


### PR DESCRIPTION
## What Problem This Solves

Progress-card size and count limits had one canonical owner in the Gateway protocol plus two internal forwarding exports. That extra path made ownership ambiguous and required callers to reach protocol constants through unrelated validation and handler modules.

## Why This Change Was Made

Remove both forwarding exports and import the same protocol-owned bindings directly in the progress-card tool and handler test. The protocol constants, schemas, validation order, error text, storage, and runtime control flow are unchanged.

## User Impact

No user-visible behavior changes. Progress-card limits now have one source of truth and fewer internal API hops.

AI-assisted: implemented and reviewed with Amp.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/progress-card.test.ts src/agents/tools/progress-card-tool.test.ts src/session-cards/progress-card-store.test.ts` — 23/23 passed across 3 shards.
- `git diff --check` — passed.
- `node scripts/check-changed.mjs -- <4 changed files>` — all guards, formatting, dead-export scan, and core typecheck passed; the core-test typecheck reached unrelated `ui/vite.config.ts` and exposed a stale shared install (`pako` 1.0.11 present versus 3.0.1 required, with `@types/pako` absent). Exact-head CI remains required before landing.
- Structured Codex autoreview (`--mode uncommitted --max-priority P1`) — clean, no accepted/actionable findings.
- Separate exact-head Codex review (`--mode commit --commit HEAD --max-priority P1`) — clean, no accepted/actionable findings.
- Production LOC: +1/-8 (net -7). Tests: +6/-8 (net -2).
