### PR TITLE
fix(github-copilot): allow xhigh and max thinking levels on claude-opus-5

### DIFF
--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -455,6 +455,26 @@ describe("github-copilot plugin", () => {
     expect(profile?.levels.map((level) => level.id)).toContain("xhigh");
   });
 
+  it("exposes xhigh and max thinking for the bundled Claude Opus 5 model", () => {
+    const provider = registerProviderWithPluginConfig({});
+    const model = expectDefined(
+      manifest.modelCatalog.providers["github-copilot"].models.find(
+        (candidate) => candidate.id === "claude-opus-5",
+      ),
+      "bundled GitHub Copilot Claude Opus 5 model",
+    );
+
+    const profile = provider.resolveThinkingProfile({
+      provider: "github-copilot",
+      modelId: model.id,
+      compat: model.compat,
+    });
+
+    expect(profile?.levels.map((level) => level.id)).toEqual(
+      expect.arrayContaining(["xhigh", "max"]),
+    );
+  });
+
   it("exposes max thinking for catalog-supported Copilot reasoning efforts", () => {
     const provider = registerProviderWithPluginConfig({});
 

--- a/extensions/github-copilot/openclaw.plugin.json
+++ b/extensions/github-copilot/openclaw.plugin.json
@@ -44,7 +44,11 @@
             "contextWindow": 1000000,
             "maxTokens": 128000,
             "cost": { "input": 5, "output": 25, "cacheRead": 0.5, "cacheWrite": 6.25 },
-            "compat": { "codeMode": "capable" }
+            "compat": {
+              "codeMode": "capable",
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["low", "medium", "high", "xhigh", "max"]
+            }
           },
           {
             "id": "claude-sonnet-5",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users on the GitHub Copilot provider running `claude-opus-5` could not select thinking levels above `high`. `/think max` and `/think xhigh` were both rejected, and the model picker offered only `default, off, minimal, low, medium, high` — even with `agents.defaults.thinkingDefault: "max"` set in config.

The Copilot API advertises `low, medium, high, xhigh, max` for this model, so the two highest reasoning tiers were simply unreachable through OpenClaw.

There is no user-side workaround. A `models.providers` config overlay does not help: `resolveCopilotForwardCompatModel()` returns early when the model is already present in the bundled registry (`extensions/github-copilot/models.ts:43-46`), and that function is the only path that applies a user-supplied `thinkingLevelMap`. Setting the overlay, restarting, and re-testing produced no change.

## Why This Change Was Made

The bundled manifest entry for `claude-opus-5` declared `"compat": { "codeMode": "capable" }` with no `supportedReasoningEfforts`. `resolveCopilotThinkingLevelMap()` (`extensions/github-copilot/models.ts:245-258`) returns `undefined` unless that field is an array, so no `thinkingLevelMap` was ever attached and `clampThinkingLevel()` filtered both `xhigh` and `max` out of the supported set.

The native Claude fallback does not cover this either. `resolveClaudeNativeThinkingLevelMap()` would grant `{xhigh, max}` for Opus 5, but `model-utils.ts:41-45` only consults it for `api === "anthropic-messages"` routes, and Copilot resolves through its OpenAI-compatible transport.

This declares the effort list on the manifest entry, matching how `extensions/opencode/openclaw.plugin.json` already declares the same field for the same model id. `extensions/anthropic/openclaw.plugin.json` ships an equivalent `thinkingLevelMap` for it as well.

Scope is deliberately limited to `claude-opus-5`, the model verified end to end on a live account. `claude-fable-5` and `claude-sonnet-5` appear to have the same gap and are left for a follow-up so each can be tested rather than pattern-matched.

## User Impact

Copilot users can select `xhigh` and `max` thinking levels on `claude-opus-5`, and an existing `thinkingDefault` of `max` now resolves instead of being silently clamped to `high`.

Higher reasoning tiers consume more reasoning tokens per turn, which maps to premium-request consumption on Copilot token auth. This is opt-in: the default is unchanged, and users reach the new tiers only by explicitly selecting them or configuring a higher `thinkingDefault`.

## Evidence

Verified on a live GitHub Copilot account (token auth) against a local gateway.

**Before** — `/status` reported `think high` despite `thinkingDefault: "max"`, and `/think max` was rejected:

```
Thinking level "max" is not supported by github-copilot/claude-opus-5.
Valid: default, off, minimal, low, medium, high
```

Note that `xhigh` is absent from that list too, confirming the resolver attached no map at all rather than mapping one tier and not the other.

**After** — with this change applied and the gateway restarted, `/think max` is accepted and `/status` reports:

```
🎛️ Modes: think max · fast off · elevated
```

**Tests** — `pnpm vitest run extensions/github-copilot/models.test.ts`: 9 files, 166 tests passed.

The existing suite already covers this resolver's behavior, including `models.test.ts:117` asserting `thinkingLevelMap` becomes `{ xhigh: "xhigh", max: null }` when `supportedReasoningEfforts` includes `xhigh` but not `max`.
