### PR TITLE
docs: define external package ownership contract

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1084,6 +1084,7 @@
                 "pages": [
                   "install/index",
                   "install/installer",
+                  "install/external-packages",
                   "install/node"
                 ]
               },

--- a/docs/install/external-packages.md
+++ b/docs/install/external-packages.md
@@ -1,0 +1,67 @@
+---
+summary: "Contract for OS packages and external supervisors that own OpenClaw updates and Gateway lifecycle"
+read_when:
+  - You package OpenClaw in an OS-native installer or application bundle
+  - Another process manager owns Gateway updates and restarts
+title: "External package ownership"
+---
+
+OS packages and application bundles can own the OpenClaw runtime without
+letting the bundled CLI replace package-managed files or create a second host
+service.
+
+Launch every bundled OpenClaw process with:
+
+```text
+OPENCLAW_SUPERVISOR_MODE=external
+OPENCLAW_NO_AUTO_UPDATE=1
+```
+
+These variables have separate responsibilities:
+
+- `OPENCLAW_SUPERVISOR_MODE=external` declares that another process manager
+  owns the Gateway lifecycle. Native service install, start, stop, and
+  uninstall operations are refused. Manual self-update is also refused so the
+  package manager can stop the Gateway, replace the runtime, and restart it as
+  one operation.
+- `OPENCLAW_NO_AUTO_UPDATE=1` disables automatic update checks, notices, and
+  applies. It does not replace the external-supervisor lifecycle contract.
+
+## Package responsibilities
+
+The package owner must:
+
+1. Run the Gateway in the foreground with `openclaw gateway run`.
+2. Stop the running Gateway before replacing packaged runtime files.
+3. Update the OpenClaw package and its Node.js runtime together.
+4. Restart the Gateway only after the new runtime is fully installed.
+5. Preserve the user's normal OpenClaw state unless the user explicitly
+   requests removal.
+6. Document whether the package replaces or coexists with another `openclaw`
+   executable on the same host.
+
+Do not invoke `openclaw gateway install` from a package-owned runtime. That
+would create a second lifecycle owner outside the package manager.
+
+## Update and rollback flow
+
+Use this order for upgrades and rollbacks:
+
+1. Block new launches.
+2. Stop the package-owned Gateway.
+3. Stage and verify the complete replacement runtime.
+4. Atomically activate the replacement when the platform supports it.
+5. Start `openclaw gateway run` with both ownership variables.
+6. Verify the Gateway version and health.
+7. Retain or remove the previous runtime according to the package rollback
+   policy.
+
+For shared-state compatibility checks across releases, follow the
+[database preflight guidance](/reference/database-schemas).
+
+## Related behavior
+
+- [Gateway external supervisors](/cli/gateway#external-supervisors)
+- [Update controls](/install/updating#update-campaigns)
+- [Environment variables](/help/environment)
+

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -159,6 +159,13 @@ openclaw onboard --install-daemon
 
 Or skip the link and use `pnpm openclaw ...` from inside the repo. See [Setup](/start/setup) for full development workflows.
 
+### OS packages and application bundles
+
+Distributors that bundle OpenClaw and own its updates should follow the
+[external package ownership contract](/install/external-packages). It defines
+the required environment, foreground Gateway lifecycle, update ordering, and
+state-preservation boundary.
+
 ### Install from the GitHub main checkout
 
 ```bash


### PR DESCRIPTION
## What Problem This Solves

External package managers and supervisors need a stable, public contract for owning the OpenClaw Gateway lifecycle without conflicting with OpenClaw's native service and update behavior.

## Why This Change Was Made

The monorepo already implements `OPENCLAW_SUPERVISOR_MODE=external` and `OPENCLAW_NO_AUTO_UPDATE=1`, but package authors had to infer the complete ownership, update, rollback, state, and command-coexistence rules from implementation details and scattered documentation.

This change documents that existing supported contract and links it from the installation documentation. It intentionally adds no new runtime behavior.

## User Impact

Distributors get a single contract for externally supervised installations. Existing users and native installations are unchanged.

## Evidence

- `pnpm docs:list`
- `git diff --check`

## PR Series

This is PR 1 of 3. Continue with #129692, then #129693. GitHub stacked PRs are currently disabled for this repository, so the dependency order is recorded explicitly in each draft.