### PR TITLE
fix(venice): preserve authoritative model pricing

### DIFF
--- a/docs/providers/venice.md
+++ b/docs/providers/venice.md
@@ -164,6 +164,18 @@ Venice uses a credit-based system. Anonymized models cost roughly the same as
 direct API pricing plus a small Venice fee. See
 [venice.ai/pricing](https://venice.ai/pricing) for current rates.
 
+OpenClaw uses the Venice plugin manifest's prices for bundled models, including
+when those models appear in live discovery. Newly discovered models outside the
+manifest keep zero estimates until pricing is configured; zero does not mean the
+model is free.
+
+Existing explicit model prices take precedence, including zero. Onboarding
+preserves existing model entries rather than replacing their prices. If an older
+configuration contains obsolete zero rates, back up your configuration and update
+only the affected `models.providers.venice.models[].cost` fields to current rates.
+Keep intentional custom prices. See [Token use and costs](/reference/token-use)
+for pricing units and usage reporting.
+
 ## Usage examples
 
 ```bash
@@ -188,11 +200,11 @@ openclaw agent --model venice/qwen3-coder-480b-a35b-instruct-turbo --message "Re
 <AccordionGroup>
   <Accordion title="API key not recognized">
     ```bash
-    echo $VENICE_API_KEY
-    openclaw models list | grep venice
+    openclaw models list --provider venice
     ```
 
-    Confirm the key starts with `vapi_`.
+    Confirm the API key is configured and starts with `vapi_`; do not print or
+    share its value.
 
   </Accordion>
 

--- a/extensions/venice/models.test.ts
+++ b/extensions/venice/models.test.ts
@@ -184,6 +184,49 @@ describe("venice-models", () => {
     }
   });
 
+  it("preserves authoritative manifest pricing in every bundled Venice model", () => {
+    expect(
+      VENICE_MODEL_CATALOG.map(({ id, cost, compat }) => ({
+        id,
+        cost,
+        supportsUsageInStreaming: compat?.supportsUsageInStreaming,
+      })),
+    ).toEqual(
+      manifest.modelCatalog.providers.venice.models.map(({ id, cost }) => ({
+        id,
+        cost,
+        supportsUsageInStreaming: false,
+      })),
+    );
+  });
+
+  it("retains bundled prices for known live models without pricing unknown models", async () => {
+    stubVeniceModelsFetch([
+      { id: "zai-org-glm-4.7" },
+      { id: "claude-opus-5" },
+      { id: "stealth-ox-alpha" },
+      { id: "gemini-3-6-flash" },
+    ]);
+    const manifestCosts = new Map(
+      manifest.modelCatalog.providers.venice.models.map(({ id, cost }) => [id, cost]),
+    );
+
+    const models = await runWithDiscoveryEnabled(() => discoverVeniceModels());
+
+    expect(models.map(({ id, cost }) => ({ id, cost }))).toEqual([
+      { id: "zai-org-glm-4.7", cost: manifestCosts.get("zai-org-glm-4.7") },
+      { id: "claude-opus-5", cost: manifestCosts.get("claude-opus-5") },
+      {
+        id: "stealth-ox-alpha",
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+      {
+        id: "gemini-3-6-flash",
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+    ]);
+  });
+
   it("uses the shared fallback after a transient fetch failure", async () => {
     let attempts = 0;
     const fetchMock = vi.fn(async () => {

--- a/extensions/venice/models.test.ts
+++ b/extensions/venice/models.test.ts
@@ -204,8 +204,7 @@ describe("venice-models", () => {
     stubVeniceModelsFetch([
       { id: "zai-org-glm-4.7" },
       { id: "claude-opus-5" },
-      { id: "stealth-ox-alpha" },
-      { id: "gemini-3-6-flash" },
+      { id: "unknown-model-without-pricing" },
     ]);
     const manifestCosts = new Map(
       manifest.modelCatalog.providers.venice.models.map(({ id, cost }) => [id, cost]),
@@ -217,11 +216,7 @@ describe("venice-models", () => {
       { id: "zai-org-glm-4.7", cost: manifestCosts.get("zai-org-glm-4.7") },
       { id: "claude-opus-5", cost: manifestCosts.get("claude-opus-5") },
       {
-        id: "stealth-ox-alpha",
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      },
-      {
-        id: "gemini-3-6-flash",
+        id: "unknown-model-without-pricing",
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       },
     ]);

--- a/extensions/venice/models.ts
+++ b/extensions/venice/models.ts
@@ -30,7 +30,6 @@ const VENICE_DISCOVERY_CACHE_TTL_MS = 60_000;
 function decorateVeniceModelDefinition(entry: ModelDefinitionConfig): ModelDefinitionConfig {
   return {
     ...entry,
-    input: [...entry.input],
     compat: {
       supportsUsageInStreaming: false,
       ...entry.compat,

--- a/extensions/venice/models.ts
+++ b/extensions/venice/models.ts
@@ -29,13 +29,8 @@ const VENICE_DISCOVERY_CACHE_TTL_MS = 60_000;
 
 function decorateVeniceModelDefinition(entry: ModelDefinitionConfig): ModelDefinitionConfig {
   return {
-    id: entry.id,
-    name: entry.name,
-    reasoning: entry.reasoning,
+    ...entry,
     input: [...entry.input],
-    cost: VENICE_DEFAULT_COST,
-    contextWindow: entry.contextWindow,
-    maxTokens: entry.maxTokens,
     compat: {
       supportsUsageInStreaming: false,
       ...entry.compat,

--- a/extensions/venice/onboard.test.ts
+++ b/extensions/venice/onboard.test.ts
@@ -8,8 +8,8 @@ describe("Venice onboarding", () => {
   it("applies the manifest catalog, default, and alias", () => {
     const config = applyVeniceConfig({});
 
-    expect(config.models?.providers?.venice?.models.map((model) => model.id)).toEqual(
-      manifest.modelCatalog.providers.venice.models.map((model) => model.id),
+    expect(config.models?.providers?.venice?.models.map(({ id, cost }) => ({ id, cost }))).toEqual(
+      manifest.modelCatalog.providers.venice.models.map(({ id, cost }) => ({ id, cost })),
     );
     expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
       VENICE_DEFAULT_MODEL_REF,
@@ -18,5 +18,20 @@ describe("Venice onboarding", () => {
     expect(config.agents?.defaults?.models).toEqual({
       [VENICE_DEFAULT_MODEL_REF]: { alias: "GLM 4.7" },
     });
+  });
+
+  it.each([
+    { label: "zero", cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
+    { label: "custom", cost: { input: 1, output: 2, cacheRead: 0.25, cacheWrite: 0.5 } },
+  ])("preserves existing $label pricing when onboarding again", ({ cost }) => {
+    const config = applyVeniceConfig({});
+    const model = config.models!.providers!.venice!.models[0]!;
+    model.cost = { ...cost };
+
+    const reapplied = applyVeniceConfig(config);
+
+    expect(
+      reapplied.models?.providers?.venice?.models.find(({ id }) => id === model.id)?.cost,
+    ).toEqual(cost);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Venice's model decorator replaced the plugin manifest's known model prices with zeroes. Fresh provider configuration and known models returned by live discovery therefore lost their input, output, and cache prices, producing zero-dollar usage estimates despite correct upstream catalog data.

## Why This Change Was Made

Preserve the normalized manifest row and apply only Venice's streaming compatibility decoration. The shared manifest builder already clones costs, input modalities, and supported metadata, so the decorator no longer reconstructs a partial row or copies the input array again. The current batch manifest builder stays in place. No manifest, core, configuration, or fallback changes are needed.

## User Impact

Fresh/generated Venice catalogs retain known prices. Unknown discovered models still have zero estimates; that does not prove the models are free. Existing explicit zero/custom prices remain authoritative, and onboarding does not overwrite existing entries. The provider docs explain how to back up configuration and correct only obsolete cost fields, and remove a nearby API-key-printing troubleshooting instruction.

Release-note context: preserve manifest pricing for known Venice models in generated configuration and live discovery, preventing zero-dollar estimates caused by lost catalog metadata; retain intentional operator pricing overrides.

## Evidence

- Baseline: the final pricing tests against the pinned main implementation failed in the intended three places (static catalog, known live discovery, and fresh onboarding); 13 other cases passed.
- Candidate: `node scripts/run-vitest.mjs extensions/venice extensions/together/onboard.test.ts src/plugin-sdk/provider-catalog-shared.test.ts src/plugin-sdk/provider-catalog-live-projection.test.ts src/utils/usage-format.test.ts` passed 90 tests across 9 files and 3 shards.
- Real unauthenticated source-runtime discovery: 111 rows, including 19 known and 92 unknown. Before/after known-price matches are 0/19 -> 19/19 for static catalog, fresh onboarding, and live discovery. Unknown prices remain zero. For one million input, output, and cache-read tokens each on the default model, the estimate changes from $0.0000 to $3.31. An explicit zero override remains unchanged. This is metadata/runtime proof, not inference or billing verification.
- Fresh isolated Codex autoreview covered the complete staged candidate against main base `e8406570015f70e0a98e39d4408503668c12e115`. Default P0 scope: scoped-clean, no findings, no retained lower-priority findings.
- Independent public-price check: all 19 bundled rows match Venice's current base USD input, output, cached-input, and cache-write rates from `GET https://api.venice.ai/api/v1/models`; the published model catalog also retains those 19 correct base-price rows.
- Independent candidate rerun: the parent verified the same 19/19 static, onboarding, and live-price matches against unchanged production-source hashes. A real discovery timeout also preserved the corrected fallback prices; the unchanged-limit retry returned all 111 live rows.
- Scope limit / separate follow-up: this repairs preservation of existing manifest prices, not missing extended-context tier data. Two bundled models expose additional extended-context rates that the current manifest does not encode. Those tier/threshold semantics require separate verification; no complete billing-tier coverage is claimed.
- Production LOC: +1/-7 (net -6). Tests: +55/-2. Docs: +15/-3.

Local validation also passed `pnpm build`, `node scripts/check-changed.mjs -- extensions/venice/models.ts extensions/venice/models.test.ts extensions/venice/onboard.test.ts docs/providers/venice.md` (including extension source/test typechecks, lint, and all final guards), `pnpm docs:list`, and the staged-content guard. The final onboarding-test rerun passed all 3 cases after expectation refinements. The build had no ineffective-dynamic-import warnings; dependency eval and plugin-timing warnings were nonfatal.

Candidate: `1adf37728b82b32d7597ca092aa81b3aa9ab8e43`, whose tree exactly matches the final local review/test freeze. Hosted CI and native preparation must still pass for the published head before landing; local proof is not a claim that those gates have completed.
