### PR TITLE
fix(gateway): scope crash loop channel recovery hints

### DIFF
--- a/src/infra/gateway-boot-lifecycle.test.ts
+++ b/src/infra/gateway-boot-lifecycle.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   formatLegacyAgentMediaMigrationRequiredMessage,
   GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON,
@@ -35,6 +35,7 @@ const GATEWAY_BOOT_LIFECYCLE_RETENTION_MS = 24 * 60 * 60_000;
 
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
 });
 
 function createLifecycleDb() {
@@ -385,5 +386,26 @@ describe("formatGatewayCrashLoopManualChannelStartHint", () => {
     expect(
       formatGatewayCrashLoopManualChannelStartHint({ channelId: "telegram", accountId: "work" }),
     ).toContain(`--params '{"channel":"telegram","accountId":"work"}'`);
+  });
+
+  it.each([
+    { name: "default", profile: "", container: "", command: "openclaw" },
+    { name: "named profile", profile: "work", container: "", command: "openclaw --profile work" },
+    { name: "container", profile: "", container: "demo", command: "openclaw --container demo" },
+    {
+      name: "container and profile",
+      profile: "work",
+      container: "demo",
+      command: "openclaw --container demo",
+    },
+  ])("targets the active gateway for $name", ({ profile, container, command }) => {
+    vi.stubEnv("OPENCLAW_PROFILE", profile);
+    vi.stubEnv("OPENCLAW_CONTAINER_HINT", container);
+
+    expect(
+      formatGatewayCrashLoopManualChannelStartHint({ channelId: "telegram", accountId: "work" }),
+    ).toBe(
+      `Start a channel manually with: ${command} gateway call channels.start --params '{"channel":"telegram","accountId":"work"}'`,
+    );
   });
 });

--- a/src/infra/gateway-boot-lifecycle.ts
+++ b/src/infra/gateway-boot-lifecycle.ts
@@ -1,6 +1,7 @@
 // Persists gateway boot outcomes for supervisor crash-loop decisions.
 import { randomUUID } from "node:crypto";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { formatCliCommand } from "../cli/command-format.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
 import {
@@ -38,13 +39,12 @@ export function formatGatewayCrashLoopManualChannelStartHint(target?: {
   channelId: string;
   accountId?: string;
 }): string {
-  const params = target
-    ? JSON.stringify({
-        channel: target.channelId,
-        ...(target.accountId ? { accountId: target.accountId } : {}),
-      })
-    : `{"channel":"<id>"}`;
-  return `Start a channel manually with: openclaw gateway call channels.start --params '${params}'`;
+  const params = JSON.stringify({
+    channel: target?.channelId ?? "<id>",
+    ...(target?.accountId ? { accountId: target.accountId } : {}),
+  });
+  const command = formatCliCommand("openclaw gateway call channels.start");
+  return `Start a channel manually with: ${command} --params '${params}'`;
 }
 
 const gatewayLifecycleLog = createSubsystemLogger("gateway/lifecycle");


### PR DESCRIPTION
## What Problem This Solves

Fixes Gateway crash-loop channel recovery instructions targeting the wrong default Gateway when the operator uses an active named profile or container. Following the displayed command previously left the intended channel disconnected.

## Why This Change Was Made

The crash-loop diagnostic owner hard-coded an unscoped `openclaw` command even though the existing canonical CLI formatter already carries profile/container context. The repair reuses that formatter and removes a duplicated target-versus-placeholder serialization branch, keeping production code net neutral.

## User Impact

Operators can copy the displayed manual channel-start command directly; it now addresses the actual active Gateway, preserves channel/account parameters, and respects the established container-over-profile precedence.

## Evidence

- Authentic production-owner regressions failed for named profiles, active containers, and simultaneous profile/container context before repair.
- All 197 focused infra, CLI-formatting, and real Gateway channel-lifecycle tests pass across three suites.
- Exact owner command output preserves default context, placeholder/channel/account targeting, and container precedence.
- Production code is net neutral; formatting, type-aware lint, and fresh independent structured P1 autoreview pass.
