### PR TITLE
fix(node-host): drain all workers before shutdown failures

### DIFF
--- a/src/node-host/node-worker-supervisor.container.test.ts
+++ b/src/node-host/node-worker-supervisor.container.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import type { WorkerConnectionEndpoint } from "../worker/worker-connection-endpoint.js";
+import { NodeWorkerContainerLifecycle } from "./node-worker-container-lifecycle.js";
 import { NodeWorkerLaunchStore } from "./node-worker-launch-store.js";
 import { requireNodeWorkerProcessIdentity } from "./node-worker-process-identity.js";
 import { createNodeWorkerSupervisor } from "./node-worker-supervisor.js";
@@ -836,6 +837,73 @@ describe("node worker supervisor container isolation", () => {
       if (fs.existsSync(failureMarker)) {
         fs.unlinkSync(failureMarker);
       }
+      await fixture.supervisor.close();
+    }
+  });
+
+  it("waits for healthy container shutdown before reporting a sibling removal failure", async () => {
+    const fixture = containerFixture({ capacity: 2 });
+    const first = testWorkerLaunchInput(fixture.workspaceDir, "container-close-failed", "wait");
+    const sibling = testWorkerLaunchInput(fixture.workspaceDir, "container-close-sibling", "wait");
+    const removalMarker = path.join(fixture.engineRoot, "hold-removal");
+    const store = new NodeWorkerLaunchStore({ env: fixture.env });
+    const removalFailure = new Error("injected first container removal failure");
+    const originalRemove = Reflect.get(
+      NodeWorkerContainerLifecycle.prototype,
+      "remove",
+    ) as NodeWorkerContainerLifecycle["remove"];
+    const remove = vi
+      .spyOn(NodeWorkerContainerLifecycle.prototype, "remove")
+      .mockImplementation(async function (this: NodeWorkerContainerLifecycle, container, owner) {
+        if (owner.launchId === first.launchId) {
+          throw removalFailure;
+        }
+        await originalRemove.call(this, container, owner);
+      });
+
+    try {
+      const failedWorker = await fixture.supervisor.launch(first, endpoint);
+      const siblingWorker = await fixture.supervisor.launch(sibling, endpoint);
+      await vi.waitFor(
+        () => expect(fixture.events().filter((event) => event.argv[0] === "start")).toHaveLength(2),
+        { timeout: 5_000 },
+      );
+      fs.writeFileSync(removalMarker, "hold");
+
+      const closing = fixture.supervisor.close();
+      const settled = vi.fn();
+      void closing.then(settled, settled);
+      await vi.waitFor(
+        () =>
+          expect(
+            fixture
+              .events()
+              .some(
+                (event) =>
+                  event.argv[0] === "rm" &&
+                  event.argv.at(-1) === siblingWorker.container!.containerId,
+              ),
+          ).toBe(true),
+        { timeout: 5_000 },
+      );
+
+      expect(settled).not.toHaveBeenCalled();
+      expect(fixture.exists(siblingWorker.container!.containerId)).toBe(true);
+
+      fs.unlinkSync(removalMarker);
+      await expect(closing).rejects.toBe(removalFailure);
+      expect(fixture.exists(siblingWorker.container!.containerId)).toBe(false);
+      expect(store.get(sibling.launchId)).toMatchObject({ state: "interrupted" });
+      expect(fixture.exists(failedWorker.container!.containerId)).toBe(true);
+      expect(store.get(first.launchId)).toMatchObject({
+        state: "running",
+        container: failedWorker.container,
+      });
+    } finally {
+      if (fs.existsSync(removalMarker)) {
+        fs.unlinkSync(removalMarker);
+      }
+      remove.mockRestore();
       await fixture.supervisor.close();
     }
   });

--- a/src/node-host/node-worker-supervisor.ts
+++ b/src/node-host/node-worker-supervisor.ts
@@ -412,11 +412,12 @@ class NodeWorkerSupervisor {
         }
       }
       await Promise.allSettled(this.starting.values());
-      await Promise.all(
+      const stopped = await Promise.allSettled(
         [...this.active.values()]
           .filter((active): active is NodeWorkerRunningChild => active.state === "running")
-          .map(async (active) => await this.stopChild(active, "interrupted")),
+          .map((active) => this.stopChild(active, "interrupted")),
       );
+      errors.push(...stopped.flatMap((r) => (r.status === "rejected" ? [r.reason] : [])));
       for (const active of this.active.values()) {
         if (active.state !== "observed") {
           continue;
@@ -427,11 +428,10 @@ class NodeWorkerSupervisor {
           errors.push(error);
         }
       }
-      if (errors.length === 1) {
-        throw errors[0];
-      }
-      if (errors.length > 1) {
-        throw new AggregateError(errors, "node worker terminal reconciliation failed");
+      if (errors.length > 0) {
+        throw errors.length === 1
+          ? errors[0]
+          : new AggregateError(errors, "node worker terminal reconciliation failed");
       }
     })();
     const closePromise = operation.finally(() => {


### PR DESCRIPTION
## Summary

- wait for every active remote node worker to finish container/process teardown before surfacing shutdown failures
- preserve the existing exact single-error versus aggregate-error contract and reconcile healthy sibling ownership before the host can exit
- cover a failed first Docker removal plus a healthy sibling whose actual fake-engine removal remains blocked; production delta is exactly zero lines

## Root cause

`NodeWorkerSupervisor.close()` used fail-fast `Promise.all` across independent worker stops. If one Docker container removal rejected while another removal was still in flight, supervisor shutdown rejected immediately. The terminal Gateway reconnect handler calls `activeRuntime.close().finally(() => process.exit(code))`, so that premature rejection could forcibly exit the node host and orphan the still-running healthy container.

The supervisor now joins every stop with `Promise.allSettled`, collects failures in its existing owner-local error accumulator, completes terminal reconciliation, and preserves the original single-error/`AggregateError` behavior. This matches the existing parent runtime shutdown contract without adding production lines, configuration, compatibility paths, or test-only seams.

## Verification

- Failing-before owner proof: the new two-container regression observed supervisor shutdown reject with the first injected removal error while the healthy sibling's existing fake Docker `rm` was deliberately held.
- Passing-after exact-tree proof: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/node-host/node-worker-supervisor.container.test.ts src/node-host/node-worker-supervisor.test.ts src/node-host/runtime.test.ts src/node-host/runner.test.ts --reporter=dot` — four files, **111 tests passed**, including real runner terminal reconnect/exit behavior.
- The new regression verifies the healthy Docker container remains present while removal is blocked, shutdown stays pending despite its sibling's failure, the healthy container is then removed and durably marked interrupted, and the failed container remains authoritatively running until retry cleanup.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --timed -- src/node-host/node-worker-supervisor.ts src/node-host/node-worker-supervisor.container.test.ts` — **all 28 changed-file, typecheck, lint, boundary, and security stages passed**.
- Fresh structured independent autoreview: clean.
- `git diff --numstat`: production `+7/-7` (**net zero**); regression test `+68`.

Related remote-node live Docker/Gateway/Chromium proof and Full Access approval repair: #129674.
