### PR TITLE
fix(agents): prevent selected-agent alias stalls

### DIFF
--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -4,6 +4,7 @@ import {
   resolvePreparedModelThinkingCompat,
 } from "../model-catalog-lookup.js";
 import type { ModelCatalogEntry } from "../model-catalog.types.js";
+import { resolveModelCandidateChain } from "../model-fallback-candidates.js";
 import { resolveInitialEmbeddedRunModel } from "./run/runtime-resolution.js";
 
 const STATIC_MODEL_ID = "claude-haiku-4-5";
@@ -14,6 +15,8 @@ const resolveHookModelSelectionMock = vi.hoisted(() =>
     modelId,
   })),
 );
+const loadManifestMetadataSnapshotMock = vi.hoisted(() => vi.fn());
+const normalizeProviderModelIdWithRuntimeMock = vi.hoisted(() => vi.fn(() => undefined));
 
 const emptyModelRegistry = {
   find: vi.fn((_provider: string, _modelId: string) => null),
@@ -69,7 +72,12 @@ vi.mock("./model.js", () => ({
 }));
 
 vi.mock("../provider-model-normalization.runtime.js", () => ({
-  normalizeProviderModelIdWithRuntime: () => undefined,
+  normalizeProviderModelIdWithRuntime: normalizeProviderModelIdWithRuntimeMock,
+}));
+
+vi.mock("../../plugins/manifest-contract-eligibility.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/manifest-contract-eligibility.js")>()),
+  loadManifestMetadataSnapshot: loadManifestMetadataSnapshotMock,
 }));
 
 vi.mock("../harness/runtime-plugin.js", () => ({
@@ -184,6 +192,8 @@ describe("embedded model resolution consistency", () => {
       provider,
       modelId,
     }));
+    loadManifestMetadataSnapshotMock.mockReset();
+    normalizeProviderModelIdWithRuntimeMock.mockReset().mockReturnValue(undefined);
   });
 
   it("resolves an explicit alias configured only on the selected agent", () => {
@@ -208,6 +218,72 @@ describe("embedded model resolution consistency", () => {
         model: "worker-haiku",
       }),
     ).toEqual({ provider: "anthropic", modelId: "claude-haiku-4-5" });
+    expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
+    expect(normalizeProviderModelIdWithRuntimeMock).not.toHaveBeenCalled();
+  });
+
+  it("defers custom-provider normalization until prepared manifest policy is available", () => {
+    const config = {
+      agents: {
+        entries: {
+          worker: {
+            model: { primary: "worker-custom" },
+            models: {
+              "custom-provider/legacy-model": { alias: "worker-custom" },
+            },
+          },
+        },
+      },
+    };
+    const initial = resolveInitialEmbeddedRunModel({
+      config,
+      agentId: "worker",
+    });
+
+    expect(initial).toEqual({
+      provider: "custom-provider",
+      modelId: "legacy-model",
+    });
+    expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
+    expect(normalizeProviderModelIdWithRuntimeMock).not.toHaveBeenCalled();
+
+    const manifestPlugins = [
+      {
+        modelIdNormalization: {
+          providers: {
+            "custom-provider": {
+              aliases: { "legacy-model": "modern-model" },
+            },
+          },
+        },
+      },
+    ];
+    expect(
+      resolveModelCandidateChain({
+        cfg: config,
+        agentId: "worker",
+        provider: initial.provider,
+        model: initial.modelId,
+        requestedRouteResolution: "resolved",
+        fallbacksOverride: [],
+        manifestPlugins,
+      }),
+    ).toEqual([
+      {
+        provider: "custom-provider",
+        model: "modern-model",
+        routeOrigin: "requested",
+        routeResolution: "resolved",
+      },
+    ]);
+    expect(normalizeProviderModelIdWithRuntimeMock).toHaveBeenCalledWith({
+      provider: "custom-provider",
+      plugins: manifestPlugins,
+      context: {
+        provider: "custom-provider",
+        modelId: "modern-model",
+      },
+    });
   });
 
   it("resolves the same undated configured model for chat and manual compaction", async () => {

--- a/src/agents/embedded-agent-runner/run/runtime-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-resolution.ts
@@ -90,9 +90,16 @@ export function resolveInitialEmbeddedRunModel(params: {
   model?: string;
 }): { provider: string; modelId: string } {
   const cfg = params.config ?? {};
+  // Preliminary route identification stays static; prepared metadata owns
+  // plugin and workspace normalization once the runtime context exists.
+  const staticPreliminaryNormalization = {
+    allowManifestNormalization: false,
+    allowPluginNormalization: false,
+  } as const;
   const configuredDefault = resolveDefaultModelForAgent({
     cfg,
     agentId: params.agentId,
+    ...staticPreliminaryNormalization,
   });
   const explicitProvider = normalizeOptionalString(params.provider);
   const explicitModel = normalizeOptionalString(params.model);
@@ -108,6 +115,7 @@ export function resolveInitialEmbeddedRunModel(params: {
       cfg,
       agentId: params.agentId,
       defaultProvider: provider,
+      ...staticPreliminaryNormalization,
     });
     const resolved = resolveModelRefFromString({
       cfg,
@@ -115,6 +123,7 @@ export function resolveInitialEmbeddedRunModel(params: {
       raw: explicitModel,
       defaultProvider: provider,
       aliasIndex,
+      ...staticPreliminaryNormalization,
     });
     return {
       provider: explicitProvider ?? resolved?.ref.provider ?? provider,

--- a/src/agents/model-selection-config.ts
+++ b/src/agents/model-selection-config.ts
@@ -9,6 +9,7 @@ export function resolveDefaultModelForAgent(
   params: {
     cfg: OpenClawConfig;
     agentId?: string;
+    allowManifestNormalization?: boolean;
     allowPluginNormalization?: boolean;
   } & ModelManifestNormalizationContext,
 ): ModelRef {
@@ -17,6 +18,7 @@ export function resolveDefaultModelForAgent(
     agentId: params.agentId,
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
+    allowManifestNormalization: params.allowManifestNormalization,
     allowPluginNormalization: params.allowPluginNormalization,
     manifestPlugins: params.manifestPlugins,
   });


### PR DESCRIPTION
Related: #126194

## What Problem This Solves

Selected-agent model aliases could synchronously discover plugin manifests and run provider normalization before the embedded runtime prepared its metadata. On a cold runner, that preliminary route lookup could stall the agents-embedded shard.

Regression provenance: #126194 by @steipete correctly made alias lookup agent-aware, but preliminary embedded route selection inherited manifest and plugin normalization.

## Why This Change Was Made

Preliminary embedded route identification now uses one static normalization policy for all three entry points: configured-default selection, alias-index construction, and explicit model parsing. Prepared model candidate resolution still applies supplied manifest and plugin policy once the runtime owns the workspace metadata.

This intentionally adds no cache, timeout, retry, provider special case, snapshot bridge, or onboarding behavior.

Production LOC: +11/-0 (net +11) | Tests: +77/-1 (net +76)

The production growth carries the owner-boundary policy through the existing configured-model helper and keeps the invariant at the preliminary route owner.

## User Impact

Operators using selected-agent aliases avoid plugin discovery before an embedded run, while custom providers still receive prepared manifest normalization before execution.

## Evidence

- Exact head: `388ea252271e52758ebe6dd64a5cd781f46320ed`.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model-resolution-consistency.test.ts` - 9/9 passed.
- `node scripts/run-vitest.mjs src/agents/model-selection-manifest-workspace.test.ts` - 21/21 passed.
- The selected-agent Anthropic alias and configured custom-provider primary both assert zero preliminary manifest-loader and runtime-normalizer calls.
- The custom-provider case then proves `resolveModelCandidateChain` applies supplied manifest policy and forwards it to runtime normalization.
- `git diff --check` and targeted `oxfmt --check` passed.
- `node scripts/check-changed.mjs -- <changed files>` passed applicable guards, formatting, core typecheck, affected test typecheck, and lint. The sparse checkout lacked the unrelated native Swift schema file; exact-head hosted CI owns the complete-workspace guard.
- Exact-head CI run `33034104554` passed with no failed or pending checks.
- The required `agentic-agents-embedded-base` group maps to `checks-node-compact-large-9`; exact-head job `98393101530` passed the full `test/vitest/vitest.agents-embedded-agent.config.ts` owner shard.
- The earlier full owning config completed 1,152 passing tests and exposed three already-classified unrelated failures outside this changed path. It was not restarted unchanged.

AI-assisted; the author understands and verified the owner boundary.
