### PR TITLE
fix(ui): display resolved agent workspace and effective model consistently

### DIFF
--- a/ui/src/e2e/agent-model-fallback-ownership.e2e.test.ts
+++ b/ui/src/e2e/agent-model-fallback-ownership.e2e.test.ts
@@ -1,4 +1,6 @@
 // Real browser proof that agent model fallbacks follow the Gateway's ownership contract.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -11,6 +13,9 @@ const suite = createControlUiE2eSuite({
 
 const primaryModel = "openai/gpt-5.4";
 const inheritedFallback = "anthropic/claude-sonnet-4-6";
+const writerWorkspace = "/tmp/agents/writer";
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.resolve(".artifacts/control-ui-e2e/agent-context-ownership");
 
 suite.define(() => {
   it.each([
@@ -39,6 +44,11 @@ suite.define(() => {
       model: { primary: primaryModel, fallbacks: ["google/gemini-3-pro"] },
       expectedFallbacks: ["google/gemini-3-pro"],
     },
+    {
+      name: "combines an inherited primary with agent-only fallback configuration",
+      model: { fallbacks: ["google/gemini-3-pro"] },
+      expectedFallbacks: ["google/gemini-3-pro"],
+    },
   ])("$name", async ({ model, expectedFallbacks }) => {
     await suite.withPage(
       {
@@ -49,7 +59,10 @@ suite.define(() => {
       async ({ page }) => {
         const config = {
           agents: {
-            defaults: { model: { primary: primaryModel, fallbacks: [inheritedFallback] } },
+            defaults: {
+              workspace: "/tmp/agents",
+              model: { primary: primaryModel, fallbacks: [inheritedFallback] },
+            },
             entries: {
               main: { default: true },
               writer: model === undefined ? {} : { model },
@@ -64,7 +77,13 @@ suite.define(() => {
               scope: "agent",
               agents: [
                 { id: "main", identity: { name: "Main" }, name: "Main" },
-                { id: "writer", identity: { name: "Writer" }, name: "Writer" },
+                {
+                  id: "writer",
+                  identity: { name: "Writer" },
+                  name: "Writer",
+                  workspace: writerWorkspace,
+                  model: { primary: primaryModel, fallbacks: expectedFallbacks },
+                },
               ],
             },
             "config.get": {
@@ -99,6 +118,30 @@ suite.define(() => {
         await expect
           .poll(() => new URL(page.url()).pathname)
           .toBe("/settings/agents/writer/overview");
+
+        if (captureUiProof && model && !("primary" in Object(model))) {
+          await mkdir(proofDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(
+              proofDir,
+              `${process.env.OPENCLAW_UI_PROOF_LABEL ?? "agent-context"}.png`,
+            ),
+          });
+        }
+
+        await expect
+          .poll(() => page.locator(".workspace-link").textContent())
+          .toContain(writerWorkspace);
+        const modelDescription = page
+          .locator(".settings-kv dt")
+          .filter({ hasText: "Primary Model" })
+          .locator("xpath=following-sibling::dd[1]");
+        const displayedModel = expectedFallbacks.length
+          ? `${primaryModel} (+${expectedFallbacks.length} fallback)`
+          : primaryModel;
+        await expect.poll(() => modelDescription.textContent()).toContain(displayedModel);
 
         const fallbackInput = page.locator(".agent-chip-input");
         await fallbackInput.waitFor({ timeout: 10_000 });

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -364,14 +364,17 @@ export function buildAgentContext(
   const workspace =
     workspaceFromFiles ||
     config.entry?.workspace ||
-    config.defaults?.workspace ||
     agent.workspace ||
+    config.defaults?.workspace ||
     "default";
-  const modelLabel = config.entry?.model
-    ? resolveModelLabel(config.entry?.model)
-    : config.defaults?.model
-      ? resolveModelLabel(config.defaults?.model)
-      : resolveModelLabel(agent.model);
+  const primary =
+    resolveModelPrimary(config.entry?.model) ??
+    resolveModelPrimary(config.defaults?.model) ??
+    resolveModelPrimary(agent.model);
+  const fallbacks =
+    resolveEffectiveModelFallbacks(config.entry?.model, config.defaults?.model) ??
+    (configForm ? null : resolveModelFallbacks(agent.model));
+  const modelLabel = primary ? resolveModelLabel({ primary, fallbacks }) : "-";
   const runtime = resolveAgentRuntimeLabel(agent.agentRuntime);
   const identityName =
     normalizeOptionalString(agent.identity?.name) ||

--- a/ui/src/pages/agents/panels-overview.test.ts
+++ b/ui/src/pages/agents/panels-overview.test.ts
@@ -1,8 +1,101 @@
 // Control UI tests cover the agents overview context display.
 import { render } from "lit";
 import { expect, it } from "vitest";
+import { buildAgentContext } from "../../lib/agents/display.ts";
 import { createAgentViewTestProps as createProps } from "./agents-view.test-helpers.ts";
 import { renderAgents } from "./view.ts";
+
+const inheritedAgentModel = "openai/gpt-5.4";
+const resolvedAgentWorkspace = "/tmp/agents/beta";
+
+it.each([
+  {
+    name: "inherits a primary while preserving agent-owned fallbacks",
+    model: { fallbacks: ["google/gemini-3-pro"] },
+    expectedModel: `${inheritedAgentModel} (+1 fallback)`,
+  },
+  {
+    name: "preserves explicitly disabled agent fallbacks",
+    model: { fallbacks: [] },
+    expectedModel: inheritedAgentModel,
+  },
+  {
+    name: "prefers a dirty agent primary over stale roster and global models",
+    model: { primary: "anthropic/claude-sonnet-4-6" },
+    expectedModel: "anthropic/claude-sonnet-4-6",
+  },
+])("buildAgentContext $name", ({ model, expectedModel }) => {
+  const context = buildAgentContext(
+    {
+      id: "beta",
+      workspace: resolvedAgentWorkspace,
+      model: { primary: "openai/stale-roster-model", fallbacks: ["openai/stale-fallback"] },
+    },
+    {
+      agents: {
+        defaults: {
+          workspace: "/tmp/agents",
+          model: { primary: inheritedAgentModel, fallbacks: ["openai/global-fallback"] },
+        },
+        entries: { beta: { model } },
+      },
+    },
+    null,
+    "alpha",
+  );
+
+  expect(context.workspace).toBe(resolvedAgentWorkspace);
+  expect(context.model).toBe(expectedModel);
+});
+
+it.each(["overview", "channels", "cron"] as const)(
+  "shows authoritative agent workspace and effective model on the %s panel",
+  (activePanel) => {
+    const container = document.createElement("div");
+    const props = createProps();
+    render(
+      renderAgents({
+        ...props,
+        activePanel,
+        agentsList: {
+          defaultId: "alpha",
+          mainKey: "main",
+          scope: "per-sender",
+          agents: [
+            { id: "alpha", name: "Alpha" },
+            {
+              id: "beta",
+              name: "Beta",
+              workspace: resolvedAgentWorkspace,
+              model: { primary: inheritedAgentModel },
+            },
+          ],
+        },
+        config: {
+          ...props.config,
+          form: {
+            agents: {
+              defaults: {
+                workspace: "/tmp/agents",
+                model: { primary: inheritedAgentModel, fallbacks: ["openai/global-fallback"] },
+              },
+              entries: { beta: { model: { fallbacks: ["google/gemini-3-pro"] } } },
+            },
+          },
+        },
+      }),
+      container,
+    );
+
+    const contextValue = (label: string) =>
+      Array.from(container.querySelectorAll("dt"))
+        .find((term) => term.textContent?.trim() === label)
+        ?.nextElementSibling?.textContent?.trim();
+
+    expect(contextValue("Workspace")).toBe(resolvedAgentWorkspace);
+    expect(contextValue("Primary Model")).toBe(`${inheritedAgentModel} (+1 fallback)`);
+  },
+);
 
 it.each([
   { label: "a read-only editor", canUpdateIdentity: false, identitySaving: false, text: "Save" },

--- a/ui/src/pages/agents/panels-overview.ts
+++ b/ui/src/pages/agents/panels-overview.ts
@@ -13,11 +13,10 @@ import { renderSettingsRow, renderSettingsSection } from "../../components/setti
 import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
 import {
+  buildAgentContext,
   buildModelOptions,
   normalizeModelValue,
   resolveAgentConfig,
-  resolveAgentSkillsFilter,
-  resolveAgentRuntimeLabel,
   resolveAgentTextAvatar,
   resolveEffectiveModelFallbacks,
   resolveModelFallbacks,
@@ -75,23 +74,16 @@ export function renderAgentOverview(params: {
     onModelFallbacksChange,
     onSelectPanel,
   } = params;
-  const isDefault = Boolean(params.defaultId && agent.id === params.defaultId);
+  const context = buildAgentContext(
+    agent,
+    configForm,
+    agentFilesList,
+    params.defaultId,
+    params.agentIdentity,
+  );
+  const isDefault = context.isDefault;
   const config = resolveAgentConfig(configForm, agent.id);
   const agentModel = agent.model;
-  const workspaceFromFiles =
-    agentFilesList && agentFilesList.agentId === agent.id ? agentFilesList.workspace : null;
-  const workspace =
-    workspaceFromFiles ||
-    config.entry?.workspace ||
-    config.defaults?.workspace ||
-    agent.workspace ||
-    "default";
-  const model = config.entry?.model
-    ? resolveModelLabel(config.entry?.model)
-    : config.defaults?.model
-      ? resolveModelLabel(config.defaults?.model)
-      : resolveModelLabel(agentModel);
-  const runtime = resolveAgentRuntimeLabel(agent.agentRuntime);
   const defaultModel = resolveModelLabel(config.defaults?.model ?? agentModel);
   const entryPrimary = resolveModelPrimary(config.entry?.model);
   const defaultPrimary =
@@ -104,8 +96,6 @@ export function renderAgentOverview(params: {
     resolveEffectiveModelFallbacks(config.entry?.model, config.defaults?.model) ??
     (configForm ? null : resolveModelFallbacks(agentModel));
   const fallbackChips = modelFallbacks ?? [];
-  const skillFilter = resolveAgentSkillsFilter(configForm, agent.id);
-  const skillCount = skillFilter?.length ?? null;
   const disabled = !params.canUpdateConfig || !configForm || configLoading || configSaving;
   const thinkingDefault = agent.thinkingDefault ?? "-";
 
@@ -237,22 +227,18 @@ export function renderAgentOverview(params: {
                 @click=${() => onSelectPanel("files")}
                 aria-label=${t("agents.context.openFilesTab")}
               >
-                ${workspace}
+                ${context.workspace}
               </button>
             </openclaw-tooltip>
           </dd>
           <dt>${t("agents.context.primaryModel")}</dt>
-          <dd><code>${model}</code></dd>
+          <dd><code>${context.model}</code></dd>
           <dt>${t("agents.context.runtime")}</dt>
-          <dd><code>${runtime}</code></dd>
+          <dd><code>${context.runtime}</code></dd>
           <dt>${t("agents.context.thinkingDefault")}</dt>
           <dd><code>${thinkingDefault}</code></dd>
           <dt>${t("agents.context.skillsFilter")}</dt>
-          <dd>
-            ${skillFilter
-              ? t("agents.overview.selectedSkills", { count: String(skillCount) })
-              : t("agents.overview.allSkills")}
-          </dd>
+          <dd>${context.skillsLabel}</dd>
         </dl>
       `,
     )}


### PR DESCRIPTION
## Summary

- Restore each agent's actual resolved workspace in Overview, Channels, and Automation instead of incorrectly displaying its global workspace default.
- Combine inherited primary models with agent-owned fallback lists, including explicit empty fallbacks, so fallback-only agent overrides no longer display a missing primary model.
- Remove the duplicate Overview projection and use the same canonical agent-context owner as its sibling panels. Production code: +22/-33 (net -11).

## Root cause

The Gateway already returns each agent's authoritative resolved workspace and effective model. Both the shared Control UI context builder and a second independent Overview projection instead prioritized the global configured workspace over that resolved roster value. They also rendered an agent model override as a complete model even when the override contained only a fallback list, discarding the inherited primary and displaying `-`.

The repair restores producer ownership: explicit unsaved agent workspace edits still win; the resolved roster workspace comes next; and global defaults are used only when no agent-specific value exists. The shared owner resolves primary and fallback ownership independently, preserving explicit empty fallback arrays and dirty per-agent model edits. Overview now consumes that same canonical projection as Channels and Automation.

## Before

The selected Writer agent incorrectly displayed `/tmp/agents` and no primary model despite its resolved `/tmp/agents/writer` workspace and inherited model:

![Before: wrong inherited workspace and missing primary model](https://github.com/user-attachments/assets/a953e4bd-4ef0-4293-82df-f668999a5c3e)

## After

The same real Chromium flow now shows the correct agent-owned workspace and inherited primary with its agent-owned fallback:

![After: authoritative agent workspace and effective primary model](https://github.com/user-attachments/assets/018b044e-9d01-45a5-b53a-80e605e3e9c2)

## Verification

- Pre-fix: six owner/sibling regressions fail across Overview, Channels, and Automation; actual Chromium independently fails because the wrong workspace is rendered.
- `node scripts/run-vitest.mjs ui/src/pages/agents/panels-overview.test.ts ui/src/lib/agents/display.test.ts` — 46 tests pass.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/agent-model-fallback-ownership.e2e.test.ts` — six real Chromium scenarios pass, covering inherited fallbacks, strict explicit primaries, explicitly disabled fallbacks, agent-owned fallbacks, and fallback-only overrides.
- `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 pnpm check:changed` — complete core-test/UI typechecking, formatting, lint, i18n, and architecture gates pass; the unchanged dead-export scan had already passed in the preceding full run.
- Fresh independent Codex review: clean.

## Risk

Low: presentation-only ownership correction; no persistence, protocol, configuration shape, security policy, or Gateway runtime changes. Existing draft precedence, explicit empty fallback arrays, file-owned workspace values, and agent-specific model primaries remain covered.
