### PR TITLE
fix(reply): keep fast abort off provider runtime

### DIFF
--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -39,11 +39,13 @@ vi.mock("./model-catalog.runtime.js", () => ({
 }));
 
 let createModelSelectionStateForTest: typeof import("../auto-reply/reply/model-selection.js").createModelSelectionState;
+let resolveSessionModelRef: typeof import("./session-model-ref.js").resolveSessionModelRef;
 
 describe("model-selection plugin runtime normalization", () => {
   beforeAll(async () => {
     ({ createModelSelectionState: createModelSelectionStateForTest } =
       await import("../auto-reply/reply/model-selection.js"));
+    ({ resolveSessionModelRef } = await import("./session-model-ref.js"));
   });
 
   beforeEach(() => {
@@ -243,6 +245,50 @@ describe("model-selection plugin runtime normalization", () => {
     expect(state.provider).toBe("custom-provider");
     expect(state.model).toBe("custom-modern-model");
     expect(state.resetModelOverride).toBe(false);
+  });
+
+  it("keeps resolved persisted overrides off plugin runtime hooks", () => {
+    normalizeProviderModelIdWithPluginMock.mockReturnValue("incorrectly-renormalized-model");
+
+    expect(
+      resolveSessionModelRef(
+        {},
+        {
+          providerOverride: "custom-provider",
+          modelOverride: "custom-modern-model",
+          modelOverrideRouteResolution: "resolved",
+        },
+        "main",
+      ),
+    ).toEqual({
+      provider: "custom-provider",
+      model: "custom-modern-model",
+    });
+    expect(normalizeProviderModelIdWithPluginMock).not.toHaveBeenCalled();
+  });
+
+  it("normalizes raw persisted overrides through plugin runtime hooks", () => {
+    normalizeProviderModelIdWithPluginMock.mockImplementation(({ provider, context }) =>
+      provider === "custom-provider" &&
+      (context as { modelId?: string }).modelId === "custom-legacy-model"
+        ? "custom-modern-model"
+        : undefined,
+    );
+
+    expect(
+      resolveSessionModelRef(
+        {},
+        {
+          providerOverride: "custom-provider",
+          modelOverride: "custom-legacy-model",
+        },
+        "main",
+      ),
+    ).toEqual({
+      provider: "custom-provider",
+      model: "custom-modern-model",
+    });
+    expect(normalizeProviderModelIdWithPluginMock).toHaveBeenCalledOnce();
   });
 
   it("reuses one lifecycle metadata snapshot across auto-reply model normalization", async () => {

--- a/src/agents/session-model-ref.ts
+++ b/src/agents/session-model-ref.ts
@@ -14,7 +14,14 @@ import {
 
 type SessionModelEntry =
   | SessionEntry
-  | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">;
+  | Pick<
+      SessionEntry,
+      | "model"
+      | "modelProvider"
+      | "modelOverride"
+      | "providerOverride"
+      | "modelOverrideRouteResolution"
+    >;
 
 export function resolveSessionModelRef(
   cfg: OpenClawConfig,
@@ -27,11 +34,17 @@ export function resolveSessionModelRef(
     modelOverride: entry?.modelOverride,
   });
   if (normalizedOverride.providerOverride && normalizedOverride.modelOverride) {
+    // Resolved overrides were canonicalized by their producer. Re-running plugin hooks here
+    // can cold-load provider runtime and transform the same persisted identity twice.
+    const allowPluginNormalization =
+      entry?.modelOverrideRouteResolution === "resolved"
+        ? false
+        : options?.allowPluginNormalization;
     return resolvePersistedSelectedModelRef({
       defaultProvider: normalizedOverride.providerOverride,
       overrideProvider: normalizedOverride.providerOverride,
       overrideModel: normalizedOverride.modelOverride,
-      allowPluginNormalization: options?.allowPluginNormalization,
+      allowPluginNormalization,
     })!;
   }
   const runtimeProvider = normalizeOptionalString(entry?.modelProvider);

--- a/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
@@ -429,6 +429,13 @@ describe("dispatchReplyFromConfig", () => {
     });
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "should not run" }) as ReplyPayload);
+    sessionStoreMocks.currentEntry = {
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-6-20260205",
+      modelOverrideRouteResolution: "resolved",
+      thinkingLevel: "high",
+    };
+    const onModelSelected = vi.fn();
     const ctx = buildTestCtx({
       Provider: "imessage",
       Surface: "imessage",
@@ -447,7 +454,13 @@ describe("dispatchReplyFromConfig", () => {
       SessionKey: "agent:main:imessage:direct:peer",
     });
 
-    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { onModelSelected },
+    });
 
     expect(mocks.tryFastApproveFromMessage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -458,6 +471,11 @@ describe("dispatchReplyFromConfig", () => {
     expect(replyResolver).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({
       text: "✅ Approval allow-once submitted.",
+    });
+    expect(onModelSelected).toHaveBeenCalledWith({
+      provider: "anthropic",
+      model: "claude-opus-4-6-20260205",
+      thinkLevel: "high",
     });
   });
 
@@ -515,6 +533,7 @@ describe("dispatchReplyFromConfig", () => {
     sessionStoreMocks.currentEntry = {
       providerOverride: "anthropic",
       modelOverride: "claude-opus-4-6-20260205",
+      modelOverrideRouteResolution: "resolved",
       thinkingLevel: "high",
     };
     const onModelSelected = vi.fn();
@@ -545,6 +564,7 @@ describe("dispatchReplyFromConfig", () => {
     sessionStoreMocks.currentEntry = {
       providerOverride: "anthropic",
       modelOverride: "claude-opus-4-6-20260205",
+      modelOverrideRouteResolution: "resolved",
       thinkingLevel: "high",
     };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a fast `/stop` reply could wake the provider plugin runtime while building its response prefix, adding cold startup work after the agent run was already aborted.

Related: #45315
Related: #113154

## Why This Change Was Made

Session model persistence already records whether an override was resolved to its canonical provider/model identity. The session-model resolver now trusts that producer-owned provenance: complete overrides marked `resolved` skip plugin normalization, while raw or unmarked persisted overrides keep the existing provider-runtime normalization path.

The regression originated when #45315 (`35fa1f9613c`) added selected-model prefix context and was carried into the split dispatch pipeline by #113154 (`127b78142b6e`).

## User Impact

Fast abort acknowledgements no longer load provider runtime code just to render an already-canonical selected model in a response prefix. Older raw persisted model IDs still run provider normalization and retain mapped-ID compatibility.

## Evidence

- Red proof with the owner repair temporarily reverted: the resolved-override regression failed with `incorrectly-renormalized-model`; the raw mapped-ID countercase passed
- `node scripts/run-vitest.mjs src/agents/model-selection.plugin-runtime.test.ts`: 13 passed; 2.70s real; 552,779,776-byte max RSS
- `node scripts/run-vitest.mjs src/agents/session-model-ref.test.ts`: 12 passed; 8.07s real; 761,348,096-byte max RSS
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts`: 392 passed; 54.98s real; 1,477,378,048-byte max RSS
- Direct, routed, and handled `/approve` fast-prefix fixtures now carry resolved provenance and assert selected model/prefix behavior
- Clean-machine Blacksmith Testbox `pnpm build`: passed on `tbx_01m10hctengy7ej5dq3p5ympjs` ([run](https://github.com/openclaw/openclaw/actions/runs/33033963440))
- `git diff --check`: passed
- `oxfmt --check` on all changed files: passed
- `node scripts/check-changed.mjs -- <changed files>`: guards, formatting, boundaries, and dead-export scan passed; local core typecheck reached unrelated stale shared dependency errors, so hosted CI is authoritative for the owning shard

Production delta: `src/agents/session-model-ref.ts` +15/-2. The net growth moves the invariant to the persistence provenance owner and preserves raw compatibility without a fast-path consumer workaround. Tests and test support: +67/-1.

AI-assisted: yes. The change and evidence were reviewed directly.
