### PR TITLE
fix(ollama): preserve namespaced embedding query instructions

### DIFF
--- a/extensions/ollama/src/embedding-provider.runtime.ts
+++ b/extensions/ollama/src/embedding-provider.runtime.ts
@@ -150,7 +150,7 @@ function normalizeEmbeddingModel(model: string, providerId?: string): string {
 }
 
 function applyQueryInstructionTemplate(model: string, queryText: string): string {
-  const normalizedModel = model.trim().toLowerCase();
+  const normalizedModel = model.trim().toLowerCase().replace(/^.*\//, "");
   const match = QUERY_INSTRUCTION_TEMPLATES.find(({ prefix }) =>
     normalizedModel.startsWith(prefix),
   );

--- a/extensions/ollama/src/embedding-provider.test.ts
+++ b/extensions/ollama/src/embedding-provider.test.ts
@@ -128,12 +128,6 @@ function readEmbeddingRequestBody(init: RequestInit | undefined): { input?: unkn
   return JSON.parse(init.body) as { input?: unknown };
 }
 
-function readFirstEmbeddingInput(fetchMock: ReturnType<typeof mockEmbeddingFetch>): unknown {
-  const init = firstFetchInit(fetchMock);
-  const body = readEmbeddingRequestBody(init);
-  return body.input;
-}
-
 function firstGuardedFetchCall(): Record<string, unknown> {
   const call = fetchConfiguredLocalOriginWithSsrFGuardMock.mock.calls[0]?.[0];
   if (!call || typeof call !== "object") {
@@ -508,39 +502,77 @@ describe("ollama embedding provider", () => {
     );
   });
 
-  it("uses a retrieval query prefix for qwen3 embedding queries", async () => {
-    const { fetchMock } = await embedTestQuery({ model: "qwen3-embedding:0.6b" }, "怀孕");
+  it.each([
+    {
+      name: "bare qwen",
+      model: "qwen3-embedding:0.6b",
+      query: "怀孕",
+      expected:
+        "Instruct: Given a user query, retrieve relevant memory notes and documents\nQuery:怀孕",
+    },
+    {
+      name: "namespaced qwen",
+      model: "library/qwen3-embedding:0.6b",
+      query: "怀孕",
+      expected:
+        "Instruct: Given a user query, retrieve relevant memory notes and documents\nQuery:怀孕",
+    },
+    {
+      name: "registry-qualified qwen",
+      model: "registry.ollama.ai/library/qwen3-embedding:0.6b",
+      query: "怀孕",
+      expected:
+        "Instruct: Given a user query, retrieve relevant memory notes and documents\nQuery:怀孕",
+    },
+    {
+      name: "bare nomic",
+      model: "nomic-embed-text",
+      query: "What does $& mean?",
+      expected: "search_query: What does $& mean?",
+    },
+    {
+      name: "namespaced nomic",
+      model: "library/nomic-embed-text:latest",
+      query: "What does $& mean?",
+      expected: "search_query: What does $& mean?",
+    },
+    {
+      name: "bare mixedbread",
+      model: "mxbai-embed-large:latest",
+      query: "capital of Australia",
+      expected: "Represent this sentence for searching relevant passages: capital of Australia",
+    },
+    {
+      name: "namespaced mixedbread",
+      model: "mixedbread/mxbai-embed-large:latest",
+      query: "capital of Australia",
+      expected: "Represent this sentence for searching relevant passages: capital of Australia",
+    },
+    {
+      name: "unknown namespaced model",
+      model: "custom/unknown-embedder:latest",
+      query: "unmodified query",
+      expected: "unmodified query",
+    },
+  ])("uses the correct retrieval query for $name", async ({ model, query, expected }) => {
+    const { fetchMock } = await embedTestQuery({ model }, query);
 
-    expect(readFirstEmbeddingInput(fetchMock)).toBe(
-      "Instruct: Given a user query, retrieve relevant memory notes and documents\nQuery:怀孕",
-    );
+    expectEmbeddingFetch(fetchMock, "http://127.0.0.1:11434/api/embed", {
+      model,
+      input: expected,
+    });
   });
 
-  it("uses the nomic search_query prefix for query embeddings", async () => {
-    const { fetchMock } = await embedTestQuery({}, "What does $& mean?");
+  it.each(["qwen3-embedding:0.6b", "library/qwen3-embedding:0.6b"])(
+    "keeps document batch embeddings raw for %s",
+    async (model) => {
+      const { inputs } = mockBatchEmbeddingFetch(2);
+      const { provider } = await createEmbeddingProvider({ model });
 
-    expect(readFirstEmbeddingInput(fetchMock)).toBe("search_query: What does $& mean?");
-  });
-
-  it("uses the mixedbread retrieval prompt for query embeddings", async () => {
-    const { fetchMock } = await embedTestQuery(
-      { model: "mxbai-embed-large:latest" },
-      "capital of Australia",
-    );
-
-    expect(readFirstEmbeddingInput(fetchMock)).toBe(
-      "Represent this sentence for searching relevant passages: capital of Australia",
-    );
-  });
-
-  it("keeps document batch embeddings raw", async () => {
-    const { inputs } = mockBatchEmbeddingFetch(2);
-
-    const { provider } = await createEmbeddingProvider({ model: "qwen3-embedding:0.6b" });
-
-    await expect(provider.embedBatch(["doc one", "doc two"])).resolves.toHaveLength(2);
-    expect(inputs).toEqual([["doc one", "doc two"]]);
-  });
+      await expect(provider.embedBatch(["doc one", "doc two"])).resolves.toHaveLength(2);
+      expect(inputs).toEqual([["doc one", "doc two"]]);
+    },
+  );
 
   it("uses custom Ollama provider config and strips that provider prefix", async () => {
     const release = vi.fn();


### PR DESCRIPTION
## What Problem This Solves

Fixes Ollama memory retrieval silently dropping the required model-specific search instructions when an embedding model uses a valid namespace or registry-qualified identifier.

## Why This Change Was Made

The Ollama embedding owner matched instruction templates against the entire model identifier, so valid references such as `library/qwen3-embedding:0.6b`, `library/nomic-embed-text:latest`, and `mixedbread/mxbai-embed-large:latest` never matched their model families. The owner now matches the final model-name component while preserving the exact original identifier sent to Ollama.

## User Impact

Qwen, Nomic, and Mixedbread embedding models consistently receive their documented retrieval-query instructions whether configured with a bare name, namespace, or full registry path. Document batches and unknown embedding models retain their existing behavior.

## Evidence

- Direct Ollama upstream model-name source and documentation confirm namespaces and registry-qualified model references are valid.
- Four authentic `/api/embed` request regressions failed before repair while six bare-name, unknown-model, and document-batch controls continued to pass.
- All 205 focused Ollama provider tests pass across five suites.
- Production delta is one line added and one removed; formatting, type-aware lint, and a fresh complete-diff structured P1 autoreview all pass.
- No model identifier, endpoint, authentication, reasoning content, persistence, configuration, or public contract is changed.
