### PR TITLE
fix(ios): prioritize active gateway errors over connection names

### DIFF
--- a/apps/ios/Sources/Status/GatewayStatusBuilder.swift
+++ b/apps/ios/Sources/Status/GatewayStatusBuilder.swift
@@ -22,8 +22,8 @@ enum GatewayStatusBuilder {
         lastGatewayProblem: GatewayConnectionProblem?,
         gatewayStatusText: String) -> GatewayDisplayState
     {
-        if gatewayServerName != nil { return .connected }
         if lastGatewayProblem != nil { return .error }
+        if gatewayServerName != nil { return .connected }
 
         let text = gatewayStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
         if text.localizedCaseInsensitiveContains("connecting") ||

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -552,12 +552,14 @@ private func waitUntil(
         #expect(appModel.lastGatewayProblem == problem)
         #expect(appModel.gatewayPairingPaused)
         #expect(appModel.gatewayPairingRequestId == "req-admin")
+        #expect(GatewayStatusBuilder.build(appModel: appModel) == .error)
 
         appModel.clearGatewayConnectionProblem()
 
         #expect(appModel.lastGatewayProblem == problem)
         #expect(appModel.gatewayPairingPaused)
         #expect(appModel.gatewayPairingRequestId == "req-admin")
+        #expect(GatewayStatusBuilder.build(appModel: appModel) == .error)
 
         appModel.clearOperatorGatewayConnectionProblemIfCurrent()
 
@@ -567,6 +569,7 @@ private func waitUntil(
         #expect(!appModel.gatewayPairingPaused)
         #expect(appModel.gatewayPairingRequestId == nil)
         #expect(appModel.gatewayStatusText == "Connected")
+        #expect(GatewayStatusBuilder.build(appModel: appModel) == .connected)
     }
 
     @Test @MainActor func `retained gateway problem clears only when explicit target changes`() throws {

--- a/apps/ios/Tests/GatewayStatusBuilderTests.swift
+++ b/apps/ios/Tests/GatewayStatusBuilderTests.swift
@@ -3,9 +3,10 @@ import Testing
 @testable import OpenClaw
 
 struct GatewayStatusBuilderTests {
-    @Test func `paused problem keeps error status`() {
+    @Test(arguments: [nil, "gateway.example.com"] as [String?])
+    func `paused problem keeps error status`(_ gatewayServerName: String?) {
         let state = GatewayStatusBuilder.build(
-            gatewayServerName: nil,
+            gatewayServerName: gatewayServerName,
             lastGatewayProblem: GatewayConnectionProblem(
                 kind: .pairingRequired,
                 owner: .gateway,
@@ -19,9 +20,10 @@ struct GatewayStatusBuilderTests {
         #expect(state == .error)
     }
 
-    @Test func `transient problem keeps error status while reconnecting`() {
+    @Test(arguments: [nil, "gateway.example.com"] as [String?])
+    func `transient problem keeps error status while reconnecting`(_ gatewayServerName: String?) {
         let state = GatewayStatusBuilder.build(
-            gatewayServerName: nil,
+            gatewayServerName: gatewayServerName,
             lastGatewayProblem: GatewayConnectionProblem(
                 kind: .timeout,
                 owner: .network,


### PR DESCRIPTION
## What Problem This Solves

Fixes the iOS app incorrectly displaying Online or Connected while an active operator pairing failure or connection timeout exists alongside a still-connected Gateway node.

## Why This Change Was Made

The shared iOS Gateway status owner checked the retained server name before the authoritative structured operator error. Reordering those two existing checks makes every shared status surface report the actual failure while preserving successful reconnection, which already clears the error at its lifecycle owner.

## User Impact

The iOS sidebar, chat, settings, and other shared Gateway indicators correctly display Attention instead of a misleading healthy connection during active operator pairing or connection failures.

## Evidence

- The actual existing operator pairing lifecycle regression failed against unchanged production code and passed after the two-line precedence swap.
- A native nine-case production status matrix verifies pairing failures, timeouts, retained connections, successful recovery, reconnecting, legacy textual errors, and offline states.
- Full iOS SwiftLint, Swift syntax, targeted formatting, native localization verification, and fresh complete-diff structured P1 autoreview pass.
- Production delta: one line added and one removed.
- A simulator screenshot/full hosted XCTest cannot run safely in this environment: the only booted simulator is user-owned, the test host would install/launch its app, and the existing generated project has an unrelated unresolved package baseline. Actual production Swift source and the real existing lifecycle test body were executed directly instead.
