### PR TITLE
fix(android): preserve omitted image-only chat messages

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -1746,9 +1746,8 @@ internal fun ChatBubble(
       when (part.type) {
         "text" -> !part.text.isNullOrBlank()
         "image" -> {
-          val displayable = !part.base64.isNullOrBlank() || !part.artifactId.isNullOrBlank()
-          val visible = displayable && visibleImageCount < 4
-          if (displayable) visibleImageCount += 1
+          val visible = visibleImageCount < 4
+          visibleImageCount += 1
           visible
         }
         "canvas" -> normalizedRole == "assistant" && part.widget != null
@@ -1838,20 +1837,15 @@ internal fun ChatBubble(
                   loadMedia = loadMediaArtifact,
                 )
               part.isAudioAttachment() || part.isVideoAttachment() -> ChatMediaAttachmentLabel(content = part)
-              part.type == "image" ->
-                if (!part.base64.isNullOrBlank()) {
-                  ChatBase64Image(
-                    base64 = part.base64,
-                    mimeType = part.mimeType,
-                  )
-                } else {
-                  ChatManagedImage(
-                    artifactId = checkNotNull(part.artifactId),
-                    label = part.alt?.takeIf(String::isNotBlank) ?: part.fileName ?: nativeString("Image"),
-                    resolverReady = inlineWidgetResolverReady,
-                    loadImage = loadImageArtifact,
-                  )
-                }
+              part.type == "image" && !part.base64.isNullOrBlank() ->
+                ChatBase64Image(base64 = part.base64, mimeType = part.mimeType)
+              part.type == "image" && !part.artifactId.isNullOrBlank() ->
+                ChatManagedImage(
+                  artifactId = part.artifactId,
+                  label = part.alt?.takeIf(String::isNotBlank) ?: part.fileName ?: nativeString("Image"),
+                  resolverReady = inlineWidgetResolverReady,
+                  loadImage = loadImageArtifact,
+                )
               part.type == "canvas" && normalizedRole == "assistant" ->
                 ChatInlineWidget(
                   preview = checkNotNull(part.widget),

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMessageViewsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMessageViewsTest.kt
@@ -3,6 +3,7 @@ package ai.openclaw.app.ui.chat
 import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatOutboxStatus
+import ai.openclaw.app.chat.parseChatMessageContent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertCountEquals
@@ -16,6 +17,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performSemanticsAction
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -210,6 +212,63 @@ class ChatMessageViewsTest {
     composeRule
       .onNode(hasContentDescription("OpenClaw") and hasText("quarterly-report.pdf"))
       .assertIsDisplayed()
+    assertEquals(0, artifactRequests)
+  }
+
+  @Test
+  fun omittedImageOnlyTurnsRemainVisibleWithoutLoadingBeyondTheImageCap() {
+    val omittedImage =
+      requireNotNull(
+        parseChatMessageContent(
+          Json.parseToJsonElement(
+            """{"type":"image","mimeType":"image/png","omitted":true,"bytes":5}""",
+          ),
+        ),
+      )
+    var artifactRequests = 0
+
+    composeRule.setContent {
+      Column {
+        listOf(
+          listOf(omittedImage),
+          (1..5).map { index -> omittedImage.copy(fileName = "redacted-$index.png") },
+        ).forEachIndexed { index, images ->
+          ChatBubble(
+            messageId = "omitted-images-$index",
+            entryId = null,
+            role = "assistant",
+            live = false,
+            content = images,
+            timestampMs = null,
+            onReplyMessage = {},
+            sessionActionsEnabled = false,
+            onRewindMessage = {},
+            onForkMessage = {},
+            speechState = null,
+            onToggleListen = { _, _ -> },
+            inlineMediaPlaybackBlocked = false,
+            inlineWidgetResolverReady = true,
+            resolveInlineWidgetResource = { _, _ ->
+              artifactRequests += 1
+              null
+            },
+            loadImageArtifact = {
+              artifactRequests += 1
+              null
+            },
+            loadMediaArtifact = { _, _, _ ->
+              artifactRequests += 1
+              null
+            },
+          )
+        }
+      }
+    }
+
+    composeRule.onNode(hasContentDescription("OpenClaw") and hasText("Attachment")).assertIsDisplayed()
+    (1..4).forEach { index -> composeRule.onNodeWithText("redacted-$index.png").assertIsDisplayed() }
+    composeRule.onAllNodesWithText("redacted-5.png").assertCountEquals(0)
+    composeRule.onNodeWithText("Additional images hidden: 1").assertIsDisplayed()
     assertEquals(0, artifactRequests)
   }
 


### PR DESCRIPTION
## What Problem This Solves

When the Gateway safely removes inline image bytes from chat history, it deliberately keeps an opaque image marker so an image-only assistant reply remains visible. Android instead discarded that marker and silently removed the entire assistant message from the conversation.

The Gateway and Apple chat client already agree that these redacted image blocks represent displayable attachments. The Android chat bubble filtered them out before its existing safe, localized attachment placeholder could render them.

## Why This Change Was Made

Opaque image markers are intentionally retained by Gateway sanitization and already displayed safely by Apple clients. Android's chat-bubble owner incorrectly rejected them before its existing passive attachment fallback could render the reply.

## What Changed

- Preserve redacted image blocks through the existing chat-bubble image filter and existing four-image cap.
- Keep inline images and managed artifacts on their existing rendering paths; route images without bytes or artifacts to the already-existing passive `Attachment` text fallback.
- Preserve Gateway redaction completely: no recovered bytes, synthesized artifact authority, URL opening, downloads, network requests, or image/media/widget resolver access.
- Simplify the image-owner branch: **six fewer production lines** in one existing file, with no dependencies, permissions, configuration, protocol, or localization changes.

## User Impact

Android users once again see assistant responses containing only an intentionally redacted image as a safe localized `Attachment` placeholder instead of having the entire reply silently disappear. Existing images and managed artifacts behave normally; omitted image bytes remain private, and no attachment is opened, fetched, or downloaded.

## Evidence

- Unchanged frozen production fail-first: **six actual Compose owner tests, one genuine failure** proving that a real sanitized Gateway image-only response erased the entire assistant turn; five existing controls passed.
- Reviewed repair: **45/45 tests pass**: six Compose message-view cases, 24 chat-content parser cases, and 15 chat-screen sibling cases.
- The new production-Compose regression verifies the safe `Attachment` placeholder, the existing four-image cap and hidden-image count, and exactly **zero** image, media, or widget resolver requests.
- Existing managed images still load their real artifacts; sender labels, document attachments, audio/video, canvas, chat actions, and parser behavior remain covered.
- All four hosted-equivalent Android lint suites pass: app, benchmark, wear, and wear-shared.
- Independent authenticated automated review: clean, with no actionable findings.
- Real Android 36 proof feeds the exact Gateway-redacted image marker through the actual production parser and production chat bubble inside a resumed app activity. Unchanged production shows no assistant reply; the repair visibly displays the safe `Attachment` placeholder and honors the first-four image cap. Both runs have no inline bytes, artifact ID, URL, or resolver requests, and readable screenshot pixels are verified.

### Before

![Before: the redacted image-only assistant reply is entirely invisible](https://github.com/user-attachments/assets/c2711154-af3e-41ba-b8d4-03451228817b)

### After

![After: the safe Attachment placeholder preserves the assistant reply without exposing image contents](https://github.com/user-attachments/assets/e8813961-8169-415f-858f-dfe1ece62bdf)
