### PR TITLE
fix(plugins): include required ClawHub scaffold metadata

### DIFF
--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -722,6 +722,12 @@ describe("plugin authoring commands", () => {
       },
       openclaw: {
         extensions: ["./dist/index.js"],
+        compat: {
+          pluginApi: ">=2026.5.17",
+        },
+        build: {
+          openclawVersion: VERSION,
+        },
       },
     });
     expect(

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -58,6 +58,7 @@ const SUPPORTED_PLUGIN_SCAFFOLD_TYPES = [
   "provider",
 ] as const satisfies readonly PluginScaffoldType[];
 const CLAWHUB_PACKAGE_PUBLISH_WORKFLOW_REF = "9d49df109d4ad3dc8a6ecf05d26b39f46d294721";
+const TOOL_PLUGIN_API_RANGE = ">=2026.5.17";
 
 const toolPluginEntryModuleLoaders = createPluginModuleLoaderCache();
 
@@ -449,6 +450,12 @@ function createConfigSchema() {
   };
 }
 
+const createPluginPackageMetadata = (pluginApi: string) => ({
+  extensions: ["./dist/index.js"],
+  compat: { pluginApi },
+  build: { openclawVersion: VERSION },
+});
+
 function buildScaffoldTsconfig(type: PluginScaffoldType): JsonObject {
   return {
     compilerOptions: {
@@ -493,7 +500,7 @@ function writeToolPluginScaffold(params: { rootDir: string; id: string; name: st
     },
     files: ["dist", "openclaw.plugin.json", "README.md"],
     peerDependencies: {
-      openclaw: ">=2026.5.17",
+      openclaw: TOOL_PLUGIN_API_RANGE,
     },
     dependencies: {
       typebox: "^1.1.38",
@@ -503,9 +510,7 @@ function writeToolPluginScaffold(params: { rootDir: string; id: string; name: st
       typescript: "^5.9.0",
       vitest: "^3.2.0",
     },
-    openclaw: {
-      extensions: ["./dist/index.js"],
-    },
+    openclaw: createPluginPackageMetadata(TOOL_PLUGIN_API_RANGE),
   };
   const idLiteral = jsStringLiteral(params.id);
   const nameLiteral = jsStringLiteral(params.name);
@@ -603,17 +608,11 @@ function writeProviderPluginScaffold(params: { rootDir: string; id: string; name
       vitest: "^3.2.0",
     },
     openclaw: {
-      extensions: ["./dist/index.js"],
+      ...createPluginPackageMetadata(`>=${VERSION}`),
       install: {
         clawhubSpec: `clawhub:${packageName}`,
         defaultChoice: "clawhub",
         minHostVersion: `>=${VERSION}`,
-      },
-      compat: {
-        pluginApi: `>=${VERSION}`,
-      },
-      build: {
-        openclawVersion: VERSION,
       },
       release: {
         publishToClawHub: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes newly generated tool plugins failing the documented `clawhub package publish --dry-run` workflow because their package metadata omitted required plugin API compatibility and OpenClaw build-version fields.

## Why This Change Was Made

Provider plugin scaffolds already generated the required metadata, while the default tool scaffold independently emitted only its entrypoint. Both scaffolds now reuse one canonical package-metadata producer, removing duplicated provider metadata while preserving each plugin type's existing compatibility contract.

## User Impact

Authors can generate a default tool plugin and immediately package or publish it through the documented ClawHub workflow. Tool plugins retain their existing `>=2026.5.17` compatibility floor, while provider plugins retain their existing current-version floor and installation/release metadata.

## Evidence

- The real generated tool scaffold failed the actual offline `clawhub package publish --dry-run --json` command before repair because both required metadata fields were absent.
- The same documented command now succeeds, producing the real four-file package artifact without network access.
- All 25 focused tool/provider scaffolding tests pass, including preserved compatibility floors and metadata.
- Production delta: 10 lines added, 11 removed; formatting, type-aware lint, and fresh complete-diff structured P1 autoreview all pass.
