### PR TITLE
chore(whatsapp): remove duplicate setup replays

### DIFF
--- a/extensions/whatsapp/src/channel.setup.test.ts
+++ b/extensions/whatsapp/src/channel.setup.test.ts
@@ -14,13 +14,9 @@ import {
   createWhatsAppLinkingHarness,
   createWhatsAppOwnerAllowlistHarness,
   createWhatsAppPersonalPhoneHarness,
-  createWhatsAppRootAllowFromConfig,
   expectNoWhatsAppLoginFollowup,
   expectWhatsAppAllowlistModeSetup,
   expectWhatsAppLoginFollowup,
-  expectWhatsAppOpenPolicySetup,
-  expectWhatsAppOwnerAllowlistSetup,
-  expectWhatsAppPersonalPhoneSetup,
   expectWhatsAppSeparatePhoneDisabledSetup,
 } from "./setup-test-helpers.js";
 
@@ -178,19 +174,6 @@ describe("whatsapp setup wizard", () => {
     hoisted.resolveWhatsAppAuthDir.mockReturnValue({ authDir: "/tmp/openclaw-whatsapp-test" });
   });
 
-  it("applies owner allowlist when forceAllowFrom is enabled", async () => {
-    const harness = createWhatsAppOwnerAllowlistHarness(createQueuedWizardPrompter);
-
-    const result = await runConfigureWithHarness({
-      harness,
-      forceAllowFrom: true,
-    });
-
-    expect(result.accountId).toBe(DEFAULT_ACCOUNT_ID);
-    expect(hoisted.loginWeb).not.toHaveBeenCalled();
-    expectWhatsAppOwnerAllowlistSetup(result.cfg, harness);
-  });
-
   it("rejects invalid owner numbers during prompt validation", async () => {
     const harness = createWhatsAppOwnerAllowlistHarness(createQueuedWizardPrompter);
 
@@ -257,17 +240,6 @@ describe("whatsapp setup wizard", () => {
     ).rejects.toThrow("Invalid WhatsApp allowFrom list");
   });
 
-  it("enables allowlist self-chat mode for personal-phone setup", async () => {
-    hoisted.hasWebCredsSync.mockReturnValue(true);
-    const harness = createWhatsAppPersonalPhoneHarness(createQueuedWizardPrompter);
-
-    const result = await runConfigureWithHarness({
-      harness,
-    });
-
-    expectWhatsAppPersonalPhoneSetup(result.cfg);
-  });
-
   it("throws a user-facing error instead of crashing when personal-phone input is undefined", async () => {
     hoisted.hasWebCredsSync.mockReturnValue(true);
     const harness = createWhatsAppPersonalPhoneHarness(createQueuedWizardPrompter);
@@ -278,20 +250,6 @@ describe("whatsapp setup wizard", () => {
         harness,
       }),
     ).rejects.toThrow("Invalid WhatsApp owner number");
-  });
-
-  it("forces wildcard allowFrom for open policy without allowFrom follow-up prompts", async () => {
-    hoisted.hasWebCredsSync.mockReturnValue(true);
-    const harness = createSeparatePhoneHarness({
-      selectValues: ["separate", "open"],
-    });
-
-    const result = await runConfigureWithHarness({
-      harness,
-      cfg: createWhatsAppRootAllowFromConfig() as OpenClawConfig,
-    });
-
-    expectWhatsAppOpenPolicySetup(result.cfg, harness);
   });
 
   it("surfaces accounts.default group warning paths for named accounts", () => {


### PR DESCRIPTION
## What Problem This Solves

Three WhatsApp happy-path setup tests replayed the same configuration branches already covered through the exported setup-wizard owner boundary, adding duplicate maintenance and mock-boundary cost without protecting another contract.

## Why This Change Was Made

Remove the direct `finalizeWhatsAppSetup` replays for forced owner allowlisting, personal-phone self-chat, and open-policy wildcard setup. Identically named tests remain in `setup-surface.test.ts`; they use the same shared harness and assertion helpers while exercising `whatsappSetupWizard.finalize` through `runSetupWizardFinalize`.

Unique validator, malformed-input, deferred-linking, named-account, security-warning, auth-state, login, and persistence-guard coverage remains unchanged.

## User Impact

No user-visible behavior changes. The WhatsApp setup suite is smaller while retaining the stronger owner-boundary proof.

Production LOC: +0/-0 | Tests: +0/-42

## Evidence

- Baseline: `node scripts/run-vitest.mjs extensions/whatsapp/src/setup-surface.test.ts extensions/whatsapp/src/channel.setup.test.ts` — 34/34 passed.
- Current head: same command — 31/31 remaining tests passed.
- `node scripts/check-changed.mjs --dry-run -- extensions/whatsapp/src/channel.setup.test.ts` — classified the `extensionTests` lane.
- `node scripts/check-changed.mjs -- extensions/whatsapp/src/channel.setup.test.ts` — passed.
- Fresh autoreview: clean; no accepted/actionable findings.
- `git diff --check origin/main...HEAD` — passed.
