### PR TITLE
fix(android): preserve notification forwarding consent

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -3335,7 +3335,7 @@ private fun rememberPermissionState(
     applyToViewModel = {
       viewModel.setCameraEnabled(cameraGranted)
       viewModel.setLocationMode(requestedLocationMode)
-      viewModel.setNotificationForwardingEnabled(notificationListenerGranted)
+      viewModel.setNotificationForwardingEnabled(notificationListenerGranted && viewModel.notificationForwardingEnabled.value)
     },
   )
 }


### PR DESCRIPTION
## Problem

Android onboarding treated Notification Listener access as consent to forward notifications. If someone had explicitly disabled **Forward Notifications**, completing onboarding with listener access still granted silently re-enabled forwarding and could send notification titles and message content to the Gateway.

The Android documentation defines these as separate choices: forwarding is off by default, and listener access is a prerequisite rather than an opt-in.

## Fix

Preserve the existing forwarding preference when onboarding applies permissions, and additionally require actual notification-listener access. This keeps an explicit opt-out disabled, preserves an existing opt-in while access is granted, and disables forwarding when listener access is revoked.

The change modifies one existing production line: **+1/-1, net zero**. It adds no permissions, configuration, helper, fallback, or testing seam.

## Evidence

An Android 36 Google Play debug build exercised the real NotificationManager listener grant, the production onboarding Permissions screen, Continue action, and the persisted app preference:

- Unmodified baseline: listener granted + forwarding explicitly disabled -> completing onboarding incorrectly persisted forwarding enabled.
- Fixed: listener granted + forwarding disabled -> forwarding remains disabled.
- Fixed: listener granted + forwarding enabled -> forwarding remains enabled.
- Fixed: actual listener access revoked + forwarding previously enabled -> forwarding is disabled.

Each fixed on-device scenario passed through the real application UI and actual Android notification-listener authorization. No user notifications were read and only the task app's own listener authorization was changed.

## Validation

- Google Play flavor: `OnboardingFlowLogicTest` 63/63, `SecurePrefsNotificationForwardingTest` 7/7, and `DeviceNotificationListenerServiceTest` 8/8.
- Third-party flavor: the same 78/78 owner, preference, and listener-service tests.
- Total: **156/156 focused tests passed**.
- All four hosted Android lint modules passed: app, benchmark, Wear, and wear-shared.
- Independent authenticated code review reported no actionable findings.
