### PR TITLE
fix(channels): drain large ingress backlogs without binding every pending id

### DIFF
--- a/src/channels/message/ingress-drain-lanes.test.ts
+++ b/src/channels/message/ingress-drain-lanes.test.ts
@@ -32,11 +32,9 @@ describe("channel ingress drain lanes", () => {
       expect(await drain.drainOnce()).toEqual({ started: 1 });
       await vi.waitFor(() => expect(dispatches).toEqual(["active"]));
       await queue.enqueue("candidate", { text: "topic" }, { laneKey: "control" });
-      const claimNext = vi.spyOn(queue, "claimNext");
 
       await expect(drain.drainOnce()).resolves.toEqual({ started: 1 });
       await vi.waitFor(() => expect(dispatches).toEqual(["active", "candidate"]));
-      expect(claimNext).toHaveBeenCalledTimes(2);
       await expect(queue.enqueue("candidate", { text: "topic" })).resolves.toMatchObject({
         kind: "completed",
       });

--- a/src/channels/message/ingress-drain.test-helpers.ts
+++ b/src/channels/message/ingress-drain.test-helpers.ts
@@ -1,7 +1,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { Insertable } from "kysely";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
-import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
 import { createChannelIngressQueue } from "./ingress-queue.js";
 
 export type IngressDrainTestPayload = { text: string };
@@ -30,5 +36,37 @@ export async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Pr
   } finally {
     closeOpenClawStateDatabaseForTest();
     await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+export function seedPendingBacklog(stateDir: string, total: number): void {
+  const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+  const kysely = getNodeSqliteKysely<Pick<OpenClawStateKyselyDatabase, "channel_ingress_events">>(
+    database.db,
+  );
+  for (let offset = 0; offset < total; offset += 500) {
+    const rows: Array<Insertable<OpenClawStateKyselyDatabase["channel_ingress_events"]>> = [];
+    const end = Math.min(offset + 500, total);
+    for (let index = offset; index < end; index += 1) {
+      rows.push({
+        queue_name: JSON.stringify(["test", "a"]),
+        event_id: `evt-${index}`,
+        channel_id: "test",
+        account_id: "a",
+        status: "pending",
+        lane_key: null,
+        payload_json: JSON.stringify({ text: `msg-${index}` }),
+        metadata_json: null,
+        completed_metadata_json: null,
+        received_at: index,
+        updated_at: index,
+        attempts: 0,
+        claim_token: null,
+        claim_owner: null,
+        claimed_at: null,
+        completed_at: null,
+      });
+    }
+    executeSqliteQuerySync(database.db, kysely.insertInto("channel_ingress_events").values(rows));
   }
 }

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   createTestIngressQueue,
   type IngressDrainTestPayload as Payload,
+  seedPendingBacklog,
   withTempState,
 } from "./ingress-drain.test-helpers.js";
 
@@ -1120,6 +1121,32 @@ describe("channel ingress drain", () => {
       const again = await queue.enqueue("old", { text: "old" });
       expect(again.kind).toBe("completed");
       drain.dispose();
+    });
+  });
+
+  it("continues draining a backlog above SQLite's bind-variable ceiling", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir, { now: () => 1_000 });
+      seedPendingBacklog(stateDir, 33_000);
+      const dispatches: string[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => 1_000,
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          dispatches.push(event.id);
+          await lifecycle.onAdopted();
+        },
+      });
+
+      try {
+        await expect(drain.drainOnce()).resolves.toEqual({ started: 32 });
+        await drain.waitForIdle();
+        await expect(drain.drainOnce()).resolves.toEqual({ started: 32 });
+        await drain.waitForIdle();
+        expect(dispatches).toEqual(Array.from({ length: 64 }, (_, index) => `evt-${index}`));
+      } finally {
+        drain.dispose();
+      }
     });
   });
 });

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -122,7 +122,7 @@ export function createChannelIngressDrain<
   const now = options.now ?? Date.now;
   const formatError = options.formatError ?? formatErrorMessage;
   const orderBy = options.orderBy ?? "received";
-  const scanLimit = options.scanLimit ?? 100;
+  const scanLimit = Math.max(1, Math.floor(options.scanLimit ?? 100));
   const startLimit = options.startLimit ?? 32;
   const deferredLaneOccupancy = options.deferredLaneOccupancy ?? "hold";
   const activeByClaim = new Map<string, ActiveHandlerState<TPayload, TMetadata>>();
@@ -585,13 +585,13 @@ export function createChannelIngressDrain<
     );
     const retryDelayedLaneKeys = new Set<string>();
     const pendingLaneKeys = new Set<string>();
-    const candidateIds = new Set(pending.map((event) => event.id));
+    const retryDelayed = new Uint8Array(pending.length);
     // listPending and claimNext share order, so the first row per lane is its head.
     // Delayed tails leave this snapshot so a sibling cannot make them start early.
-    for (const event of pending) {
+    for (const [index, event] of pending.entries()) {
       const laneKey = resolveLaneKey(event, options.deriveLaneKey, options.reconcileStoredLaneKey);
       if (resolveIngressRetryDelayMs(event, options.retryPolicy, now()) > 0) {
-        candidateIds.delete(event.id);
+        retryDelayed[index] = 1;
         if (!pendingLaneKeys.has(laneKey)) {
           retryDelayedLaneKeys.add(laneKey);
         }
@@ -618,9 +618,42 @@ export function createChannelIngressDrain<
       }
     }
 
+    const candidateWindow = new Map<string, string>();
+    let nextCandidateIndex = 0;
+    const refillCandidateWindow = () => {
+      for (const [id, laneKey] of candidateWindow) {
+        if (blockedLaneKeys.has(laneKey)) {
+          candidateWindow.delete(id);
+        }
+      }
+      while (candidateWindow.size < scanLimit && nextCandidateIndex < pending.length) {
+        const index = nextCandidateIndex;
+        const event = pending[index]!;
+        nextCandidateIndex += 1;
+        if (retryDelayed[index] === 1) {
+          continue;
+        }
+        const laneKey = resolveLaneKey(
+          event,
+          options.deriveLaneKey,
+          options.reconcileStoredLaneKey,
+        );
+        if (!blockedLaneKeys.has(laneKey)) {
+          candidateWindow.set(event.id, laneKey);
+        }
+      }
+    };
+
     let started = 0;
     while (started < startLimit) {
       if (shouldStop()) {
+        break;
+      }
+      // Candidate membership freezes this pass to the analyzed snapshot. A
+      // scan-sized window avoids binding the full backlog, and the forward-only
+      // cursor keeps released rows to one attempt in this pass.
+      refillCandidateWindow();
+      if (candidateWindow.size === 0) {
         break;
       }
       const claimed = await queue.claimNext({
@@ -628,7 +661,7 @@ export function createChannelIngressDrain<
         blockedLaneKeys,
         orderBy,
         scanLimit,
-        candidateIds,
+        candidateIds: candidateWindow.keys(),
         deriveLaneKey: options.deriveLaneKey,
         ...(options.reconcileStoredLaneKey
           ? { reconcileStoredLaneKey: options.reconcileStoredLaneKey }
@@ -639,7 +672,7 @@ export function createChannelIngressDrain<
       }
       // One snapshot row gets one attempt per pass. A released claim remains
       // pending for the next pump instead of spinning through SQLite here.
-      candidateIds.delete(claimed.id);
+      candidateWindow.delete(claimed.id);
       if (shouldStop()) {
         await queue.release(claimed, { recordAttempt: false });
         break;


### PR DESCRIPTION
Refs #127474

## What Problem This Solves

The durable channel ingress drain copied every pending event ID into `candidateIds`. `claimNext` bound that full set into SQLite `IN (...)` predicates before applying its scan limit. On Node 24, a 33,000-row backlog crosses SQLite's 32,766-variable ceiling. Every pump then throws `too many SQL variables` before it claims one row, so delivery and restart recovery make zero progress.

## Root cause

`drainOnce` owns a frozen scheduling snapshot, but it sent the complete snapshot membership to the atomic queue owner. One list served three valid contracts: exclude rows added after the snapshot, exclude retry-delayed rows, and give a released row only one attempt per pass. The unbounded SQL transport was not required for those contracts.

## Fix

- Keep the scheduling snapshot in `drainOnce`.
- Preserve retry-delay decisions in a one-byte-per-row mask.
- Refill a candidate window up to `scanLimit` while advancing through the snapshot once.
- Remove rows whose lane becomes blocked before each claim.
- Pass only that bounded window to `claimNext`, which keeps the existing transaction-time sibling-lane fence.

This absorbs current-main delayed-head behavior from #127849. It also preserves snapshot membership, global order, supersede behavior, and one attempt per row per pass. No configuration, schema, migration, or public queue contract changes.

The separate `blockedLaneKeys NOT IN (...)` predicate remains unchanged. It depends on blocked-lane cardinality rather than pending-row cardinality and is not part of #127474.

## Evidence

Exact current main at the time of the red run: `baef6e0ed070853d1a25b35bf7b57841c3a0b294`.

```json
{"node":"v24.19.0","maxVariableOption":"MAX_VARIABLE_NUMBER=32766","seeded":33000,"rounds":[{"error":"too many SQL variables"}],"dispatchCount":0,"statusCounts":[{"status":"pending","count":33000}]}
```

Exact repaired head: `25daf7596066ca12f33832a7a6f44e6d2ec63867`.

```json
{"node":"v24.19.0","maxVariableOption":"MAX_VARIABLE_NUMBER=32766","seeded":33000,"rounds":[{"started":32},{"started":32},{"started":32}],"dispatchCount":96,"firstDispatch":"evt-00000","lastDispatch":"evt-00095","statusCounts":[{"status":"completed","count":96},{"status":"pending","count":32904}]}
```

The real SQLite status change and ordered first/last IDs prove that all three pumps performed new work.

## Tests

- New regression fails on pre-fix production with `too many SQL variables` and passes on the repair.
- 123 focused ingress tests pass.
- 39 queue and lane tests pass.
- Format, Oxlint, max-lines, assertion-safety, schema-version, and conflict guards pass.
- Hosted CI owns type checking for this worktree.

## Change size

- Production: `+39/-6`.
- Tests and test support: `+66/-3`.

The production growth replaces one unbounded ID set with the scan-sized scheduling window and compact retry mask needed to preserve current-main retry, snapshot, lane, and one-attempt contracts.

## AI assistance

This PR is AI-assisted. The contributor used Claude Code for the initial repair. A maintainer used Codex to rebase the intent onto current main, reproduce the failure, preserve current scheduling invariants, strengthen the regression, and run the proof above.
