### PR TITLE
fix(qa): enforce complete channel route isolation evidence

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channel-routing-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channel-routing-proof.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+import { formatTransportTranscript, recentOutboundSummary } from "./suite-runtime-transport.js";
+
+type ScenarioRoute = {
+  target: string;
+  marker: string;
+  leakedTarget: string;
+};
+
+type ChannelRoutingScenario = {
+  scenarioId: string;
+  routes: readonly ScenarioRoute[];
+  expectedFailure: string;
+};
+
+type RouteLeak = "none" | "conversation" | "conversation-kind" | "account";
+
+const routingScenarios = [
+  {
+    scenarioId: "channel-secondary-conversation-isolation",
+    expectedFailure: "secondary conversation leaked into primary route",
+    routes: [
+      {
+        target: "group:primary",
+        marker: "QA-PRIMARY-CONVERSATION-OK",
+        leakedTarget: "group:secondary",
+      },
+      {
+        target: "group:secondary",
+        marker: "QA-SECONDARY-CONVERSATION-OK",
+        leakedTarget: "group:primary",
+      },
+    ],
+  },
+  {
+    scenarioId: "channel-dm-group-routing",
+    expectedFailure: "DM/group routes crossed",
+    routes: [
+      {
+        target: "dm:qa-routing-dm",
+        marker: "QA-DM-ROUTING-OK",
+        leakedTarget: "group:qa-routing-group",
+      },
+      {
+        target: "group:qa-routing-group",
+        marker: "QA-GROUP-ROUTING-OK",
+        leakedTarget: "dm:qa-routing-dm",
+      },
+    ],
+  },
+  {
+    scenarioId: "channel-canary",
+    expectedFailure: "expected one canary reply, saw 2",
+    routes: [
+      {
+        target: "group:qa-routing-primary",
+        marker: "QA-CHANNEL-CANARY-OK",
+        leakedTarget: "group:foreign",
+      },
+    ],
+  },
+  {
+    scenarioId: "dm-chat-baseline",
+    expectedFailure: "expected exactly one DM baseline marker reply, saw 2",
+    routes: [
+      {
+        target: "dm:alice",
+        marker: "QA-DM-BASELINE-OK",
+        leakedTarget: "dm:mallory",
+      },
+    ],
+  },
+  {
+    scenarioId: "channel-chat-baseline",
+    expectedFailure: "expected exactly one channel baseline marker reply, saw 2",
+    routes: [
+      {
+        target: "channel:qa-room",
+        marker: "QA-CHANNEL-BASELINE-OK",
+        leakedTarget: "dm:mallory",
+      },
+    ],
+  },
+] as const satisfies readonly ChannelRoutingScenario[];
+
+function runRoutingScenario(scenario: ChannelRoutingScenario, leak: RouteLeak) {
+  return runLoadedScenarioFlow(scenario.scenarioId, {
+    state: createQaBusState(),
+    api: { formatTransportTranscript, recentOutboundSummary },
+    onWaitForOutboundMessage: ({ waitCount, state }) => {
+      const route = scenario.routes[waitCount - 1];
+      if (!route) {
+        throw new Error(`unexpected outbound wait ${waitCount}`);
+      }
+      state.addOutboundMessage({
+        accountId: "qa-channel",
+        to: route.target,
+        text: route.marker,
+      });
+      if (leak !== "none") {
+        const leakedTarget =
+          leak === "conversation"
+            ? route.leakedTarget
+            : leak === "conversation-kind"
+              ? `${route.target.startsWith("dm:") ? "group" : "dm"}:${route.target.split(":")[1]}`
+              : route.target;
+        state.addOutboundMessage({
+          accountId: leak === "account" ? "foreign-account" : "qa-channel",
+          to: leakedTarget,
+          text: route.marker,
+        });
+      }
+    },
+  });
+}
+
+describe("channel scenario route isolation", () => {
+  it.each(routingScenarios)(
+    "accepts replies delivered only to their originating conversation in $scenarioId",
+    async (scenario) => {
+      await expect(runRoutingScenario(scenario, "none")).resolves.toMatchObject({ status: "pass" });
+    },
+  );
+
+  it.each(routingScenarios)(
+    "rejects and identifies replies leaked into another conversation in $scenarioId",
+    async (scenario) => {
+      const result = runRoutingScenario(scenario, "conversation");
+
+      await expect(result).rejects.toThrow(scenario.expectedFailure);
+      for (const route of scenario.routes) {
+        await expect(result).rejects.toThrow(route.leakedTarget.split(":")[1]);
+      }
+    },
+  );
+
+  it.each(
+    routingScenarios
+      .slice(0, 2)
+      .flatMap((scenario) =>
+        (["conversation-kind", "account"] as const).map((leak) => ({ scenario, leak })),
+      ),
+  )(
+    "rejects a same-ID $leak route collision in $scenario.scenarioId",
+    async ({ scenario, leak }) => {
+      await expect(runRoutingScenario(scenario, leak)).rejects.toThrow(scenario.expectedFailure);
+    },
+  );
+
+  it("reports the blocked actor reply instead of crashing while formatting its transcript", async () => {
+    const result = runLoadedScenarioFlow("channel-multi-actor-ordering", {
+      state: createQaBusState(),
+      api: { formatTransportTranscript, recentOutboundSummary },
+      onWaitForOutboundMessage: ({ state }) => {
+        state.addOutboundMessage({
+          accountId: "qa-channel",
+          to: "group:qa-routing-ordering",
+          text: "QA-MULTI-ACTOR-ORDERING-OK",
+        });
+        state.addOutboundMessage({
+          accountId: "qa-channel",
+          to: "group:qa-routing-ordering",
+          text: "QA-BLOCKED-ACTOR-SHOULD-NOT-REPLY",
+        });
+      },
+    });
+
+    await expect(result).rejects.toThrow("blocked actor produced a reply");
+    await expect(result).rejects.toThrow("QA-BLOCKED-ACTOR-SHOULD-NOT-REPLY");
+  });
+});

--- a/extensions/qa-lab/src/scenario-catalog-channel-routing-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channel-routing-proof.test.ts
@@ -145,7 +145,21 @@ describe("channel scenario route isolation", () => {
   )(
     "rejects a same-ID $leak route collision in $scenario.scenarioId",
     async ({ scenario, leak }) => {
-      await expect(runRoutingScenario(scenario, leak)).rejects.toThrow(scenario.expectedFailure);
+      const result = runRoutingScenario(scenario, leak);
+      const firstRoute = scenario.routes[0];
+      const conversationId = firstRoute.target.split(":")[1];
+      const expectedKind = firstRoute.target.startsWith("dm:") ? "direct" : "group";
+      const leakedKind =
+        leak === "conversation-kind"
+          ? expectedKind === "direct"
+            ? "group"
+            : "direct"
+          : expectedKind;
+      const leakedAccount = leak === "account" ? "foreign-account" : "qa-channel";
+
+      await expect(result).rejects.toThrow(scenario.expectedFailure);
+      await expect(result).rejects.toThrow(`qa-channel:${expectedKind}:${conversationId}:`);
+      await expect(result).rejects.toThrow(`${leakedAccount}:${leakedKind}:${conversationId}:`);
     },
   );
 

--- a/extensions/qa-lab/src/suite-runtime-transport.ts
+++ b/extensions/qa-lab/src/suite-runtime-transport.ts
@@ -78,7 +78,7 @@ function recentOutboundSummary(state: QaTransportState, limit = 5) {
     .getSnapshot()
     .messages.filter((message: QaBusMessage) => message.direction === "outbound")
     .slice(-limit)
-    .map((message: QaBusMessage) => `${message.conversation.id}:${message.text}`)
+    .map(({ accountId, conversation: { kind, id }, text }) => `${accountId}:${kind}:${id}:${text}`)
     .join(" | ");
 }
 

--- a/qa/scenarios/channels/channel-canary.yaml
+++ b/qa/scenarios/channels/channel-canary.yaml
@@ -60,9 +60,9 @@ flow:
           saveAs: outbound
         - set: matchingOutbound
           value:
-            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId && String(message.text ?? '').includes(config.expectedMarker))"
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && String(message.text ?? '').includes(config.expectedMarker))"
         - assert:
             expr: matchingOutbound.length === 1
             message:
-              expr: "`expected one canary reply, saw ${matchingOutbound.length}; transcript=${formatTransportTranscript(state, { conversationId: config.conversationId })}`"
+              expr: "`expected one canary reply, saw ${matchingOutbound.length}; transcript=${recentOutboundSummary(state)}`"
       detailsExpr: outbound.text

--- a/qa/scenarios/channels/channel-chat-baseline.yaml
+++ b/qa/scenarios/channels/channel-chat-baseline.yaml
@@ -90,9 +90,9 @@ flow:
             - expr: liveTurnTimeoutMs(env, 180000)
         - set: matchingOutbound
           value:
-            expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-room' && candidate.conversation.kind === 'channel' && String(candidate.text ?? '').includes(config.expectedMarker))"
+            expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound' && String(candidate.text ?? '').includes(config.expectedMarker))"
         - assert:
             expr: matchingOutbound.length === 1
             message:
-              expr: "`expected exactly one channel baseline marker reply, saw ${matchingOutbound.length}; transcript=${formatTransportTranscript(state, { conversationId: 'qa-room' })}`"
+              expr: "`expected exactly one channel baseline marker reply, saw ${matchingOutbound.length}; transcript=${recentOutboundSummary(state)}`"
       detailsExpr: message.text

--- a/qa/scenarios/channels/channel-dm-group-routing.yaml
+++ b/qa/scenarios/channels/channel-dm-group-routing.yaml
@@ -72,7 +72,7 @@ flow:
               expr: liveTurnTimeoutMs(env, 60000)
           saveAs: groupOutbound
         - assert:
-            expr: "dmOutbound.conversation.id !== groupOutbound.conversation.id && !String(dmOutbound.text ?? '').includes(config.groupMarker) && !String(groupOutbound.text ?? '').includes(config.dmMarker)"
+            expr: "!state.getSnapshot().messages.some((message) => message.direction === 'outbound' && ((String(message.text ?? '').includes(config.dmMarker) && (message.accountId !== dmOutbound.accountId || message.conversation.kind !== dmOutbound.conversation.kind || message.conversation.id !== dmOutbound.conversation.id)) || (String(message.text ?? '').includes(config.groupMarker) && (message.accountId !== groupOutbound.accountId || message.conversation.kind !== groupOutbound.conversation.kind || message.conversation.id !== groupOutbound.conversation.id))))"
             message:
-              expr: "`DM/group routes crossed; transcript=${formatTransportTranscript(state)}`"
+              expr: "`DM/group routes crossed; transcript=${recentOutboundSummary(state)}`"
       detailsExpr: "`${dmOutbound.conversation.kind}:${dmOutbound.text} | ${groupOutbound.conversation.kind}:${groupOutbound.text}`"

--- a/qa/scenarios/channels/channel-multi-actor-ordering.yaml
+++ b/qa/scenarios/channels/channel-multi-actor-ordering.yaml
@@ -71,5 +71,5 @@ flow:
         - assert:
             expr: "!state.getSnapshot().messages.some((message) => message.direction === 'outbound' && String(message.text ?? '').includes(config.blockedMarker))"
             message:
-              expr: "`blocked actor produced a reply; transcript=${formatTransportTranscript(state)}`"
+              expr: "`blocked actor produced a reply; transcript=${recentOutboundSummary(state)}`"
       detailsExpr: outbound.text

--- a/qa/scenarios/channels/channel-secondary-conversation-isolation.yaml
+++ b/qa/scenarios/channels/channel-secondary-conversation-isolation.yaml
@@ -69,7 +69,7 @@ flow:
               expr: liveTurnTimeoutMs(env, 60000)
           saveAs: secondaryOutbound
         - assert:
-            expr: "!String(primaryOutbound.text ?? '').includes(config.secondaryMarker) && !String(secondaryOutbound.text ?? '').includes(config.primaryMarker)"
+            expr: "!state.getSnapshot().messages.some((message) => message.direction === 'outbound' && ((String(message.text ?? '').includes(config.primaryMarker) && (message.accountId !== primaryOutbound.accountId || message.conversation.kind !== primaryOutbound.conversation.kind || message.conversation.id !== primaryOutbound.conversation.id)) || (String(message.text ?? '').includes(config.secondaryMarker) && (message.accountId !== secondaryOutbound.accountId || message.conversation.kind !== secondaryOutbound.conversation.kind || message.conversation.id !== secondaryOutbound.conversation.id))))"
             message:
-              expr: "`secondary conversation leaked into primary route; transcript=${formatTransportTranscript(state)}`"
+              expr: "`secondary conversation leaked into primary route; transcript=${recentOutboundSummary(state)}`"
       detailsExpr: "`${primaryOutbound.conversation.id} -> ${secondaryOutbound.conversation.id}`"

--- a/qa/scenarios/channels/dm-chat-baseline.yaml
+++ b/qa/scenarios/channels/dm-chat-baseline.yaml
@@ -51,9 +51,9 @@ flow:
           saveAs: outbound
         - set: matchingOutbound
           value:
-            expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'alice' && candidate.conversation.kind === 'direct' && String(candidate.text ?? '').includes(config.expectedMarker))"
+            expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound' && String(candidate.text ?? '').includes(config.expectedMarker))"
         - assert:
             expr: matchingOutbound.length === 1
             message:
-              expr: "`expected exactly one DM baseline marker reply, saw ${matchingOutbound.length}; transcript=${formatTransportTranscript(state, { conversationId: 'alice' })}`"
+              expr: "`expected exactly one DM baseline marker reply, saw ${matchingOutbound.length}; transcript=${recentOutboundSummary(state)}`"
       detailsExpr: outbound.text


### PR DESCRIPTION
## What Problem This Solves

Fixes five release-profile QA channel scenarios falsely passing even when replies leak into the wrong conversation, account, or conversation type. Six related scenarios also produced missing or incomplete diagnostics that concealed the leaked route.

## Why This Change Was Made

The affected scenarios selected an expected reply before checking isolation, so additional replies delivered to a different route were never considered. They now inspect all relevant messages and compare the canonical complete route identity: account, conversation type, and conversation ID. Existing shared outbound summaries replace invalid or overly narrow transcript calls.

## User Impact

Release and full QA runs now detect real cross-conversation, DM/group, and cross-account routing leaks and report both the expected and unexpected routes when failures occur.

## Evidence

- Real loaded-catalog scenarios and the production scenario runner falsely passed five authentic cross-route leaks before repair.
- Independent structured review additionally exposed same-conversation-ID collisions across account and conversation type; four authentic regressions reproduced and now reject those cases.
- A subsequent ClawSweeper review correctly identified that failure summaries still hid account/type collisions; the canonical bounded transport summary now includes account, conversation type, conversation ID, and message text, with all four collision diagnostics independently verified.
- All 135 scenario owner/sibling tests, 80 CLI/provider-selection tests, and three actual release/all CLI runtime cases pass.
- Six scenario YAML changes are production-line neutral; type-aware lint, formatting, and fresh final complete-diff structured P1 autoreview all pass.
