### PR TITLE
fix(msteams): deliver adaptive cards in normal agent replies

### DIFF
--- a/extensions/msteams/src/messenger.presentation.test.ts
+++ b/extensions/msteams/src/messenger.presentation.test.ts
@@ -1,0 +1,85 @@
+import { expect, it, vi } from "vitest";
+import { renderReplyPayloadsToMessages, sendMSTeamsMessages } from "./messenger.js";
+
+it.each([
+  { name: "presentation-only", text: undefined },
+  { name: "text and presentation", text: "Choose a deployment" },
+])("delivers $name normal replies as native Adaptive Cards", async ({ text }) => {
+  const presentation = {
+    title: "Deployment",
+    blocks: [
+      { type: "text" as const, text: "Choose an environment" },
+      {
+        type: "buttons" as const,
+        buttons: [
+          { label: "Deploy", action: { type: "command" as const, command: "/deploy" } },
+          {
+            label: "Details",
+            action: { type: "url" as const, url: "https://example.test/deploy" },
+          },
+          { label: "Acknowledge", value: "acknowledge" },
+        ],
+      },
+      {
+        type: "select" as const,
+        placeholder: "Environment",
+        options: [
+          {
+            label: "Production",
+            action: { type: "command" as const, command: "/deploy production" },
+          },
+        ],
+      },
+    ],
+  };
+  const sendActivity = vi.fn(async (_activity: unknown) => ({ id: "adaptive-card" }));
+  const messages = renderReplyPayloadsToMessages([{ text, presentation }], {
+    textChunkLimit: 4000,
+    tableMode: "code",
+    chunkText: false,
+  });
+
+  const ids = await sendMSTeamsMessages({
+    replyStyle: "thread",
+    app: {} as never,
+    appId: "app123",
+    conversationRef: { conversation: { id: "conversation-1", conversationType: "personal" } },
+    context: { sendActivity },
+    messages,
+  });
+
+  expect(ids).toEqual(["adaptive-card"]);
+  expect(sendActivity).toHaveBeenCalledTimes(1);
+  const activity = sendActivity.mock.calls[0]?.[0] as {
+    text?: string;
+    attachments: Array<{ contentType: string; content: Record<string, unknown> }>;
+  };
+  expect(activity.text).toBeUndefined();
+  expect(activity.attachments).toEqual([
+    {
+      contentType: "application/vnd.microsoft.card.adaptive",
+      content: expect.objectContaining({
+        type: "AdaptiveCard",
+        body: expect.arrayContaining([
+          expect.objectContaining({ text: "Deployment" }),
+          expect.objectContaining({ text: "Choose an environment" }),
+          expect.objectContaining({ text: "Environment:\n- Production: `/deploy production`" }),
+          ...(text ? [expect.objectContaining({ text })] : []),
+        ]),
+        actions: [
+          { type: "Action.Submit", title: "Deploy", data: "/deploy" },
+          {
+            type: "Action.OpenUrl",
+            title: "Details",
+            url: "https://example.test/deploy",
+          },
+          {
+            type: "Action.Submit",
+            title: "Acknowledge",
+            data: { value: "acknowledge", label: "Acknowledge" },
+          },
+        ],
+      }),
+    },
+  ]);
+});

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -30,6 +30,7 @@ import {
 import { extractFilename, extractMessageId, getMimeType, isLocalPath } from "./media-helpers.js";
 import { parseMentions } from "./mentions.js";
 import { setPendingUploadActivityId } from "./pending-uploads.js";
+import { buildMSTeamsAdaptiveCardActivity, buildMSTeamsPresentationCard } from "./presentation.js";
 import { withRevokedProxyFallback } from "./revoked-context.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 import { sendMSTeamsActivityWithReference } from "./sdk-proactive.js";
@@ -85,6 +86,7 @@ type MSTeamsReplyRenderOptions = {
 export type MSTeamsRenderedMessage = {
   text?: string;
   mediaUrl?: string;
+  adaptiveCard?: Record<string, unknown>;
 };
 
 type MSTeamsSendRetryOptions = {
@@ -233,12 +235,21 @@ export function renderReplyPayloadsToMessages(
       text: formatMSTeamsMarkdown(payload.text ?? "", tableMode),
     });
 
+    if (payload.presentation) {
+      out.push({
+        adaptiveCard: buildMSTeamsPresentationCard({
+          presentation: payload.presentation,
+          text: reply.text,
+        }),
+      });
+    }
     if (!reply.hasContent) {
       continue;
     }
 
+    const text = payload.presentation ? "" : reply.text;
     if (!reply.hasMedia) {
-      pushTextMessages(out, reply.text, { chunkText, chunkLimit, chunkMode });
+      pushTextMessages(out, text, { chunkText, chunkLimit, chunkMode });
       continue;
     }
 
@@ -246,7 +257,7 @@ export function renderReplyPayloadsToMessages(
       // For inline mode, combine text with first media as attachment
       const firstMedia = reply.mediaUrls[0];
       if (firstMedia) {
-        out.push({ text: reply.text || undefined, mediaUrl: firstMedia });
+        out.push({ text: text || undefined, mediaUrl: firstMedia });
         // Additional media URLs as separate messages
         for (let i = 1; i < reply.mediaUrls.length; i++) {
           if (reply.mediaUrls[i]) {
@@ -254,13 +265,13 @@ export function renderReplyPayloadsToMessages(
           }
         }
       } else {
-        pushTextMessages(out, reply.text, { chunkText, chunkLimit, chunkMode });
+        pushTextMessages(out, text, { chunkText, chunkLimit, chunkMode });
       }
       continue;
     }
 
     // mediaMode === "split"
-    pushTextMessages(out, reply.text, { chunkText, chunkLimit, chunkMode });
+    pushTextMessages(out, text, { chunkText, chunkLimit, chunkMode });
     for (const mediaUrl of reply.mediaUrls) {
       if (!mediaUrl) {
         continue;
@@ -280,7 +291,9 @@ async function buildActivity(
   mediaMaxBytes?: number,
   options?: { feedbackLoopEnabled?: boolean },
 ): Promise<Record<string, unknown>> {
-  const activity: Record<string, unknown> = { type: "message" };
+  const activity: Record<string, unknown> = msg.adaptiveCard
+    ? buildMSTeamsAdaptiveCardActivity(msg.adaptiveCard)
+    : { type: "message" };
 
   // Mark as AI-generated so Teams renders the "AI generated" badge.
   activity.channelData = {
@@ -409,7 +422,7 @@ export async function sendMSTeamsMessages(params: {
   serviceUrlBoundary?: MSTeamsSdkCloudOptions;
 }): Promise<string[]> {
   const messages = params.messages.filter(
-    (m) => (m.text && m.text.trim().length > 0) || m.mediaUrl,
+    (message) => message.text?.trim() || message.mediaUrl || message.adaptiveCard,
   );
   if (messages.length === 0) {
     return [];

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -7,6 +7,7 @@ import { resolveMSTeamsSenderAccess } from "./monitor-handler/access.js";
 import { createMSTeamsMessageHandler } from "./monitor-handler/message-handler.js";
 import { createMSTeamsReactionHandler } from "./monitor-handler/reaction-handler.js";
 import type { MSTeamsIngressDispatchResult, MSTeamsIngressLifecycle } from "./msteams-ingress.js";
+import { buildMSTeamsAdaptiveCardActivity } from "./presentation.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 import { buildGroupWelcomeText, buildWelcomeCard } from "./welcome-card.js";
 
@@ -217,15 +218,7 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
             promptStarters: msteamsCfg?.promptStarters,
           });
           try {
-            await ctx.sendActivity({
-              type: "message",
-              attachments: [
-                {
-                  contentType: "application/vnd.microsoft.card.adaptive",
-                  content: card,
-                },
-              ],
-            });
+            await ctx.sendActivity(buildMSTeamsAdaptiveCardActivity(card));
             deps.log.info("sent welcome card");
           } catch (err) {
             deps.log.debug?.("failed to send welcome card", { error: formatUnknownError(err) });

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -24,6 +24,18 @@ export const MSTEAMS_PRESENTATION_CAPABILITIES = {
   },
 } satisfies ChannelOutboundAdapter["presentationCapabilities"];
 
+export function buildMSTeamsAdaptiveCardActivity(card: Record<string, unknown>) {
+  return {
+    type: "message" as const,
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: card,
+      },
+    ],
+  };
+}
+
 export function buildMSTeamsPresentationCard(params: {
   presentation: MessagePresentation;
   text?: string | null;

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -290,13 +290,16 @@ describe("createTeamsReplyStreamController", () => {
   it("holds payloads around replacement text until native settlement", async () => {
     const stream = makeAcknowledgedStream();
     const ctrl = makeController({ stream });
+    const presentation = {
+      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open", value: "open" }] }],
+    };
 
     ctrl.onPartialReply({ text: "abcde" });
     stream.acknowledge("abcde");
     ctrl.onPartialReply({ text: "provider replacement" });
 
     expect(ctrl.preparePayload({ mediaUrl: "https://example.test/before.png" })).toBeUndefined();
-    expect(ctrl.preparePayload({ text: "provider replacement" })).toBeUndefined();
+    expect(ctrl.preparePayload({ text: "provider replacement", presentation })).toBeUndefined();
     expect(
       ctrl.preparePayload({
         text: "second payload",
@@ -311,6 +314,7 @@ describe("createTeamsReplyStreamController", () => {
       logicalContent: "provider replacement\nsecond payload",
       postNativePayloads: [
         { mediaUrl: "https://example.test/before.png" },
+        { text: undefined, presentation },
         { text: "second payload", mediaUrl: "https://example.test/after.png" },
       ],
     });
@@ -386,6 +390,32 @@ describe("createTeamsReplyStreamController", () => {
     });
   });
 
+  it.each(["partial", "progress"] as const)(
+    "preserves a presentation after %s streaming owns the reply text",
+    (mode) => {
+      const stream = makeStream();
+      const ctrl = createTeamsReplyStreamController({
+        allowProviderPreview: true,
+        conversationType: "personal",
+        context: makeContext(stream),
+        feedbackLoopEnabled: false,
+        msteamsConfig: { streaming: { mode } } as never,
+      });
+      const presentation = {
+        title: "Choose",
+        blocks: [{ type: "buttons" as const, buttons: [{ label: "Open", value: "open" }] }],
+      };
+      if (mode === "partial") {
+        ctrl.onPartialReply({ text: "streamed" });
+      }
+
+      expect(ctrl.preparePayload({ text: "streamed", presentation })).toEqual({
+        text: undefined,
+        presentation,
+      });
+    },
+  );
+
   it("allows fallback delivery for second text segment after tool calls", () => {
     const stream = makeStream();
     const ctrl = makeController({ stream });
@@ -452,15 +482,22 @@ describe("createTeamsReplyStreamController", () => {
     expect(ctrl.preparePayload({ text: "partial complete" })).toBeUndefined();
   });
 
-  it("drops the payload even when it carries media after cancel", () => {
-    // Cancel honored consistently — no leftover media bubble lands either.
+  it.each([
+    { name: "media", content: { mediaUrl: "https://x/y.png" } },
+    {
+      name: "presentation",
+      content: {
+        presentation: {
+          blocks: [{ type: "buttons" as const, buttons: [{ label: "Open", value: "open" }] }],
+        },
+      },
+    },
+  ])("drops the payload even when it carries $name after cancel", ({ content }) => {
     const stream = makeStream();
     const ctrl = makeController({ stream });
     ctrl.onPartialReply({ text: "partial" });
     stream.canceled = true;
-    expect(
-      ctrl.preparePayload({ text: "partial complete", mediaUrl: "https://x/y.png" }),
-    ).toBeUndefined();
+    expect(ctrl.preparePayload({ text: "partial complete", ...content })).toBeUndefined();
   });
 
   it("falls back to block delivery when no tokens were streamed", () => {

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -55,6 +55,10 @@ function isStreamCancelledError(err: unknown): boolean {
   return err instanceof Error && err.name === "StreamCancelledError";
 }
 
+function hasMSTeamsUnstreamedContent(payload: ReplyPayload): boolean {
+  return Boolean(payload.presentation || payload.mediaUrl || payload.mediaUrls?.length);
+}
+
 /**
  * Bridges openclaw's reply pipeline callbacks to the SDK's `ctx.stream`.
  * Streaming is enabled for personal (DM) conversations only; group/channel
@@ -193,16 +197,16 @@ export function createTeamsReplyStreamController(params: {
       return payload;
     }
     const remainingText = payload.text.slice(acknowledgedText.length);
-    const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
-    if (!remainingText && !hasMedia) {
+    if (!remainingText && !hasMSTeamsUnstreamedContent(payload)) {
       return undefined;
     }
     return { ...payload, text: remainingText || undefined };
   };
 
   const fallbackPayloadForSuppressedFinal = (payload: ReplyPayload): ReplyPayload => {
-    const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
-    return hasMedia ? { ...payload, mediaUrl: undefined, mediaUrls: undefined } : payload;
+    return hasMSTeamsUnstreamedContent(payload)
+      ? { ...payload, mediaUrl: undefined, mediaUrls: undefined, presentation: undefined }
+      : payload;
   };
 
   const finalStreamActivity = (text?: string) => ({
@@ -235,9 +239,8 @@ export function createTeamsReplyStreamController(params: {
       if (entry.kind === "payload") {
         return [entry.payload];
       }
-      const hasMedia = Boolean(entry.payload.mediaUrl || entry.payload.mediaUrls?.length);
       const text = replacementFallback?.text;
-      if (!text && !hasMedia) {
+      if (!text && !hasMSTeamsUnstreamedContent(entry.payload)) {
         return [];
       }
       return [{ ...entry.payload, text: text || undefined }];
@@ -512,11 +515,10 @@ export function createTeamsReplyStreamController(params: {
       // latched mid-flight, deliver only a provider-acknowledged remainder;
       // preserve the full reply when delivery was not acknowledged.
       if (tokensEmitted && !streamFailed) {
-        const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
         pendingFinalPayload = fallbackPayloadForSuppressedFinal(payload);
         streamFinalizationPending = true;
         tokensEmitted = false;
-        return hasMedia ? { ...payload, text: undefined } : undefined;
+        return hasMSTeamsUnstreamedContent(payload) ? { ...payload, text: undefined } : undefined;
       }
       if (streamFailed) {
         // Trim the provider-acknowledged prefix only from the failed segment.
@@ -539,8 +541,7 @@ export function createTeamsReplyStreamController(params: {
           nativeDispatchStarted = true;
           pendingFinalPayload = fallbackPayloadForSuppressedFinal(payload);
           streamFinalizationPending = true;
-          const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
-          return hasMedia ? { ...payload, text: undefined } : undefined;
+          return hasMSTeamsUnstreamedContent(payload) ? { ...payload, text: undefined } : undefined;
         } catch (err) {
           if (isStreamCancelledError(err)) {
             canceledLocally = true;

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -26,6 +26,7 @@ import { buildConversationReference, sendMSTeamsMessages } from "./messenger.js"
 import { setPendingUploadActivityIdFs } from "./pending-uploads-fs.js";
 import { setPendingUploadActivityId } from "./pending-uploads.js";
 import { buildMSTeamsPollCard } from "./polls.js";
+import { buildMSTeamsAdaptiveCardActivity } from "./presentation.js";
 import {
   deleteMSTeamsActivityWithReference,
   sendMSTeamsActivityWithReference,
@@ -474,20 +475,10 @@ export async function sendPollMSTeams(
     optionCount: pollCard.options.length,
   });
 
-  const activity = {
-    type: "message",
-    attachments: [
-      {
-        contentType: "application/vnd.microsoft.card.adaptive",
-        content: pollCard.card,
-      },
-    ],
-  };
-
   // Send poll via proactive conversation (Adaptive Cards require direct activity send)
   const messageId = await sendProactiveActivity({
     ctx,
-    activity,
+    activity: buildMSTeamsAdaptiveCardActivity(pollCard.card),
     errorPrefix: "msteams poll send",
   });
 
@@ -519,20 +510,10 @@ export async function sendAdaptiveCardMSTeams(
     cardVersion: card.version,
   });
 
-  const activity = {
-    type: "message",
-    attachments: [
-      {
-        contentType: "application/vnd.microsoft.card.adaptive",
-        content: card,
-      },
-    ],
-  };
-
   // Send card via proactive conversation
   const messageId = await sendProactiveActivity({
     ctx,
-    activity,
+    activity: buildMSTeamsAdaptiveCardActivity(card),
     errorPrefix: "msteams card send",
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes Microsoft Teams silently discarding documented Adaptive Card presentations from normal agent replies, including card-only replies and both default partial and progress streaming modes.

## Why This Change Was Made

The normal Teams reply owner and streaming lifecycle bypassed the existing plugin-owned Adaptive Card renderer even though outbound, poll, and welcome paths already used equivalent card activities. The repair consolidates those duplicate activity builders into one canonical Teams presentation owner and preserves structured cards throughout normal and streaming delivery.

## User Impact

Teams users receive their expected cards, buttons, URL actions, callback actions, and selection fallbacks in ordinary replies and streamed responses. Existing incoming conversation context, tenant/thread ownership, approvals, authorization, cancellation, and provider transport behavior remain unchanged.

## Evidence

- Four authentic production-owner/provider and streaming regressions failed before repair: presentation-only replies, text-plus-card replies, partial streaming, and progress streaming.
- The complete Microsoft Teams plugin suite passes: 1,457 tests across 92 suites, covering cards, auth, invocations, approvals, polling, welcome messages, thread delivery, cancellation, and provider streaming.
- Production delta is exactly neutral: 47 lines added and 47 removed by consolidating the existing card builders.
- Formatting, focused type-aware lint, maximum-lines validation, and fresh final complete-diff structured P1 autoreview pass.
- No public API, configuration, authentication, authorization, persistent state, or channel policy changes.
