### PR TITLE
fix(android): recover dropped gateway events

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -950,6 +950,7 @@ class GatewaySession(
     private var socket: WebSocket? = null
     private val loggerTag = "OpenClawGateway"
     private val incomingMessages = Channel<String>(Channel.UNLIMITED)
+    private var lastEventSequence: Long? = null
 
     // RPC waiters belong to this socket generation. Closing it must not touch a replacement connection.
     private val pending = ConcurrentHashMap<String, CompletableDeferred<RpcResponse>>()
@@ -1707,6 +1708,15 @@ class GatewaySession(
       }
       // Retired sockets can still drain queued frames after reconnect. Never let them mutate current state.
       if (currentConnection !== this) return
+      gatewayEvent.seq?.let { sequence ->
+        val previous = lastEventSequence
+        if (previous != null && sequence > previous + 1) {
+          onEvent("seqGap", null)
+          // Recovery can retire this socket before its triggering event is delivered.
+          if (currentConnection !== this || !isReady()) return
+        }
+        lastEventSequence = sequence
+      }
       if (event == GatewayEvent.NodeInvokeRequest.rawValue && payloadJson != null && onInvoke != null) {
         handleInvokeEvent(payloadJson)
         return

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -156,6 +156,192 @@ private data class ReconnectServer(
 @Config(sdk = [34])
 class GatewaySessionReconnectTest {
   @Test
+  fun sequenceGapSignalsRecoveryBeforeAdmittingTheNextEvent() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val connected = CompletableDeferred<Unit>()
+      val finalEvent = CompletableDeferred<Unit>()
+      val received = ConcurrentLinkedQueue<String>()
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") webSocket.send(connectResponseFrame(id))
+        }
+      val harness =
+        createReconnectHarness(
+          onConnected = { connected.complete(Unit) },
+          onEvent = { event, payload ->
+            val marker =
+              payload?.let { value ->
+                json
+                  .parseToJsonElement(value)
+                  .jsonObject["marker"]
+                  ?.jsonPrimitive
+                  ?.content
+              }
+            received += marker ?: event
+            if (marker == "after-gap") finalEvent.complete(Unit)
+          },
+        )
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connected.await() }
+        val socket = checkNotNull(server.sockets.peek())
+        socket.send("""{"type":"event","event":"health","payload":{"marker":"first"},"seq":41}""")
+        socket.send("""{"type":"event","event":"health","payload":{"marker":"unsequenced"}}""")
+        socket.send("""{"type":"event","event":"health","payload":{"marker":"contiguous"},"seq":42}""")
+        socket.send("""{"type":"event","event":"health","payload":{"marker":"duplicate"},"seq":42}""")
+        socket.send("""{"type":"event","event":"health","payload":{"marker":"older"},"seq":41}""")
+        socket.send("""{"type":"event","event":"health","payload":{"marker":"after-older"},"seq":42}""")
+        socket.send("""{"type":"event","event":"chat","payload":{"marker":"after-gap"},"seq":44}""")
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { finalEvent.await() }
+
+        assertEquals(
+          listOf("first", "unsequenced", "contiguous", "duplicate", "older", "after-older", "seqGap", "after-gap"),
+          received.toList(),
+        )
+      } finally {
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun sequenceGapSignalsRecoveryBeforeInvokingTheNextCommand() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val connected = CompletableDeferred<Unit>()
+      val invoked = CompletableDeferred<Unit>()
+      val received = ConcurrentLinkedQueue<String>()
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") webSocket.send(connectResponseFrame(id))
+        }
+      val harness =
+        createReconnectHarness(
+          onConnected = { connected.complete(Unit) },
+          onEvent = { event, _ -> received += event },
+          onInvoke = {
+            received += "invoke"
+            invoked.complete(Unit)
+            GatewaySession.InvokeResult.ok("{}")
+          },
+        )
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connected.await() }
+        val socket = checkNotNull(server.sockets.peek())
+        socket.send("""{"type":"event","event":"health","payload":{},"seq":1}""")
+        socket.send(
+          """{"type":"event","event":"node.invoke.request","payload":{"id":"gap-invoke","nodeId":"node-1","command":"calendar.events"},"seq":3}""",
+        )
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { invoked.await() }
+
+        assertEquals(listOf("health", "seqGap", "invoke"), received.toList())
+      } finally {
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun sequenceGapCallbackCannotAdmitAnEventAfterDisconnect() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val connected = CompletableDeferred<Unit>()
+      val disconnected = CompletableDeferred<Unit>()
+      val decision = CompletableDeferred<String>()
+      val received = ConcurrentLinkedQueue<String>()
+      var currentSession: GatewaySession? = null
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") webSocket.send(connectResponseFrame(id))
+        }
+      val harness =
+        createReconnectHarness(
+          onConnected = { connected.complete(Unit) },
+          onDisconnected = { disconnected.complete(Unit) },
+          onEvent = { event, _ ->
+            received += event
+            if (event == "seqGap") {
+              checkNotNull(currentSession).disconnect()
+              decision.complete(event)
+            } else if (event == "chat") {
+              decision.complete(event)
+            }
+          },
+        )
+      currentSession = harness.session
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connected.await() }
+        val socket = checkNotNull(server.sockets.peek())
+        socket.send("""{"type":"event","event":"health","payload":{},"seq":1}""")
+        socket.send("""{"type":"event","event":"chat","payload":{},"seq":3}""")
+
+        assertEquals("seqGap", withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { decision.await() })
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { disconnected.await() }
+        assertEquals(listOf("health", "seqGap"), received.toList())
+      } finally {
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun sequenceTrackingStartsFreshAfterReconnect() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val firstConnected = CompletableDeferred<Unit>()
+      val secondConnected = CompletableDeferred<Unit>()
+      val firstSocketEvent = CompletableDeferred<Unit>()
+      val finalEvent = CompletableDeferred<Unit>()
+      val connections = AtomicInteger()
+      val received = ConcurrentLinkedQueue<String>()
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") webSocket.send(connectResponseFrame(id))
+        }
+      val harness =
+        createReconnectHarness(
+          onConnected = {
+            if (connections.incrementAndGet() == 1) firstConnected.complete(Unit) else secondConnected.complete(Unit)
+          },
+          onEvent = { event, payload ->
+            val marker =
+              payload?.let { value ->
+                json
+                  .parseToJsonElement(value)
+                  .jsonObject["marker"]
+                  ?.jsonPrimitive
+                  ?.content
+              }
+            received += marker ?: event
+            if (marker == "first-socket") firstSocketEvent.complete(Unit)
+            if (marker == "second-after-gap") finalEvent.complete(Unit)
+          },
+        )
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { firstConnected.await() }
+        checkNotNull(server.sockets.peek())
+          .send("""{"type":"event","event":"health","payload":{"marker":"first-socket"},"seq":1}""")
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { firstSocketEvent.await() }
+
+        harness.session.reconnect()
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { secondConnected.await() }
+        val secondSocket = checkNotNull(server.sockets.lastOrNull())
+        secondSocket.send("""{"type":"event","event":"health","payload":{"marker":"second-first"},"seq":100}""")
+        secondSocket.send("""{"type":"event","event":"chat","payload":{"marker":"second-after-gap"},"seq":102}""")
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { finalEvent.await() }
+
+        assertEquals(listOf("first-socket", "second-first", "seqGap", "second-after-gap"), received.toList())
+      } finally {
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
   fun capturedRequestLeaseRejectsReplacementSocketBeforeEnqueue() =
     runBlocking {
       val json = Json { ignoreUnknownKeys = true }


### PR DESCRIPTION
## What Problem This Solves

Android silently kept stale assistant replies, run state, usage, and subagent progress after the gateway dropped a slow-client event. The existing ChatController recovery path already refreshes authoritative history on a sequence gap, but Android GatewaySession never emitted that signal.

## Why This Change Was Made

Gateway broadcast sequences are per connection, advance only after scope and subscription filters, and intentionally skip a number when a slow client drops an eligible event. Track that sequence in the existing Connection owner and mirror the Apple client: emit seqGap before the next normal event or node invocation, reset naturally on reconnect, and recheck the current connection plus READY state after the recovery callback. Challenge frames, first events, missing sequences, duplicates, and older events retain their existing semantics. The production change adds ten lines and does not change protocol, configuration, authentication, or gateway permissions.

## User Impact

A missed gateway event now refreshes Android chat history and clears stale live-run, usage, and subagent presentation before the next event is delivered. Existing connections and device commands remain unchanged when their event sequences are contiguous.

## Evidence

- Unchanged real WebSocket regression baseline: 28 owner tests, exactly four new failures proving absent recovery before normal events and node invocation, stale-event admission after callback disconnect, and missing recovery after reconnect; all 24 existing controls passed.
- Final focused validation: 90 passing tests covering GatewaySession (28), ChatController history/run recovery (44), subagent state (9), and usage streaming (9).
- All four Android lint modules pass: app, benchmark, wear, and wear-shared.
- Independent P1 code review reports no actionable findings.
- Real Android API 36 uses an in-process loopback WebSocket that validates a synthetic token, operator role, challenge nonce, and the production Ed25519 device identity before connecting the actual GatewaySession and ChatController.
- Unchanged Android runner passes while proving one chat.history request, legal node.presence and update.available events with sequence numbers 1 and 3, and a visible production ChatBubble showing STALE CHAT MESSAGE.
- Fixed Android runner passes with the same device, app signer, and scenario: two chat.history requests, seqGap delivered before update.available, and the production ChatBubble visibly showing RECOVERED GATEWAY MESSAGE. Screenshot glyph pixels are validated before capture.

Before:

![Actual Android production chat before dropped-event recovery: STALE CHAT MESSAGE](https://github.com/user-attachments/assets/93c11fd6-64ae-4844-9457-e1a2114d11c1)

After:

![Actual Android production chat after dropped-event recovery: RECOVERED GATEWAY MESSAGE](https://github.com/user-attachments/assets/c12a5686-0fb8-4103-a2d4-828735ce76ed)
