### PR TITLE
fix(package): prevent installs from deleting validated runtime assets

### DIFF
--- a/scripts/check-openclaw-package-tarball.mts
+++ b/scripts/check-openclaw-package-tarball.mts
@@ -11,11 +11,12 @@ import { pathToFileURL } from "node:url";
 import { gte as semverGte, valid as validSemver } from "semver";
 import { coerceErrorMessage } from "./lib/error-format.mts";
 import { LOCAL_BUILD_METADATA_DIST_PATHS } from "./lib/local-build-metadata-paths.mts";
+import { collectPackageDistImportErrors } from "./lib/package-dist-imports.mjs";
 import {
-  collectPackageDistImports,
-  collectPackageDistImportErrors,
-  expandPackageDistImportClosure,
-} from "./lib/package-dist-imports.mjs";
+  comparePackageDistInventory,
+  PACKAGE_DIST_INVENTORY_RELATIVE_PATH,
+  PACKAGE_INSTALL_GUARD_RELATIVE_PATH,
+} from "./lib/package-dist-inventory-contract.mts";
 import { WORKSPACE_TEMPLATE_PACK_PATHS } from "./lib/workspace-bootstrap-smoke.mts";
 
 type PackageManifest = Record<string, unknown> & {
@@ -368,7 +369,6 @@ const warnings: string[] = [];
 const CODE_MODE_WORKER_PATH = "dist/agents/code-mode.worker.js";
 const FIRST_CODE_MODE_WORKER_VERSION = "2026.5.14-beta.2";
 const REQUIRED_TARBALL_ENTRIES = ["dist/control-ui/index.html", ...WORKSPACE_TEMPLATE_PACK_PATHS];
-const PACKAGE_INSTALL_GUARD_RELATIVE_PATH = "dist/openclaw-install-guard";
 const REQUIRED_TARBALL_ENTRY_PREFIXES = ["dist/control-ui/assets/"];
 const LEGACY_PACKAGE_ACCEPTANCE_COMPAT_MAX = { year: 2026, month: 4, day: 25 };
 const LEGACY_LOCAL_BUILD_METADATA_COMPAT_MAX = { year: 2026, month: 4, day: 26 };
@@ -608,90 +608,60 @@ for (const forbiddenEntry of FORBIDDEN_LOCAL_BUILD_METADATA_FILES) {
     errors.push(`forbidden local build metadata tar entry ${forbiddenEntry}`);
   }
 }
-if (!entrySet.has("dist/postinstall-inventory.json")) {
-  errors.push("missing dist/postinstall-inventory.json");
+if (!entrySet.has(PACKAGE_DIST_INVENTORY_RELATIVE_PATH)) {
+  errors.push(`missing ${PACKAGE_DIST_INVENTORY_RELATIVE_PATH}`);
 }
-let packageDistImports: ReturnType<typeof collectPackageDistImports> | null = null;
-if (entrySet.has("dist/postinstall-inventory.json")) {
+if (entrySet.has(PACKAGE_DIST_INVENTORY_RELATIVE_PATH)) {
   try {
     const allowLegacyPrivateQaInventoryOmissions =
       isLegacyPackageAcceptanceCompatVersion(packageVersion);
-    const inventory = JSON.parse(readTarEntry("dist/postinstall-inventory.json"));
+    const inventory = JSON.parse(readTarEntry(PACKAGE_DIST_INVENTORY_RELATIVE_PATH));
     if (!Array.isArray(inventory) || inventory.some((entry) => typeof entry !== "string")) {
-      errors.push("invalid dist/postinstall-inventory.json");
+      errors.push(`invalid ${PACKAGE_DIST_INVENTORY_RELATIVE_PATH}`);
     } else {
       const inventoryEntries = inventory as string[];
-      const normalizedInventory = inventoryEntries.map((entry) => entry.replace(/\\/gu, "/"));
-      const normalizedInventorySet = new Set(normalizedInventory);
-      if (requiresCodeModeWorker && !normalizedInventorySet.has(CODE_MODE_WORKER_PATH)) {
-        errors.push(`postinstall inventory omits ${CODE_MODE_WORKER_PATH}`);
-      }
-      if (normalizedInventorySet.has(PACKAGE_INSTALL_GUARD_RELATIVE_PATH)) {
+      if (
+        inventoryEntries.some(
+          (entry) => entry.replace(/\\/gu, "/") === PACKAGE_INSTALL_GUARD_RELATIVE_PATH,
+        )
+      ) {
         errors.push(
           `package dist inventory must omit install guard ${PACKAGE_INSTALL_GUARD_RELATIVE_PATH}`,
         );
       }
-      if (typeof packageJson?.scripts?.postinstall === "string") {
-        // Postinstall prunes every uninventoried dist file, including dashboard
-        // assets that cannot be recovered from the JavaScript import graph.
-        const requiredControlUiInventoryEntries = new Set([
-          ...REQUIRED_TARBALL_ENTRIES.filter((entry) => entry.startsWith("dist/")),
-          ...normalized.filter(
-            (entry) =>
-              REQUIRED_TARBALL_ENTRY_PREFIXES.some((prefix) => entry.startsWith(prefix)) &&
-              fs.statSync(path.join(extractedPackageRoot, entry)).isFile(),
-          ),
-        ]);
-        for (const requiredEntry of requiredControlUiInventoryEntries) {
-          if (!normalizedInventorySet.has(requiredEntry)) {
-            errors.push(`postinstall inventory omits Control UI file ${requiredEntry}`);
-          }
-        }
-      }
-      packageDistImports = runPhase("dist import graph", () =>
-        collectPackageDistImports({
-          files: normalized,
-          readText: readTarEntry,
-        }),
-      );
-      for (const inventoryEntry of inventoryEntries) {
-        const normalizedEntry = inventoryEntry.replace(/\\/gu, "/");
-        if (!entrySet.has(normalizedEntry)) {
-          if (
-            allowLegacyPrivateQaInventoryOmissions &&
-            isLegacyOmittedPrivateQaInventoryEntry(normalizedEntry)
-          ) {
-            warnings.push(
-              `legacy inventory references omitted private QA tar entry ${normalizedEntry}`,
-            );
-            continue;
-          }
-          errors.push(`inventory references missing tar entry ${normalizedEntry}`);
-        }
-      }
-      const expandedInventory = expandPackageDistImportClosure({
-        files: normalized,
-        seedFiles: normalizedInventory,
-        readText: readTarEntry,
-        imports: packageDistImports,
+      const parity = comparePackageDistInventory({
+        files: normalized.filter(
+          (entry) =>
+            entry.startsWith("dist/") &&
+            fs.statSync(path.join(extractedPackageRoot, entry)).isFile(),
+        ),
+        inventory: inventoryEntries,
       });
-      for (const importedEntry of expandedInventory) {
-        if (!normalizedInventorySet.has(importedEntry)) {
-          errors.push(`inventory omits imported dist file ${importedEntry}`);
+      if (typeof packageJson?.scripts?.postinstall === "string") {
+        for (const missingEntry of parity.packagedFilesMissingFromInventory) {
+          errors.push(`postinstall inventory omits packaged dist file ${missingEntry}`);
         }
+      }
+      for (const missingEntry of parity.inventoryEntriesMissingFromPackage) {
+        if (
+          allowLegacyPrivateQaInventoryOmissions &&
+          isLegacyOmittedPrivateQaInventoryEntry(missingEntry)
+        ) {
+          warnings.push(`legacy inventory references omitted private QA tar entry ${missingEntry}`);
+          continue;
+        }
+        errors.push(`inventory references missing tar entry ${missingEntry}`);
       }
     }
   } catch (error) {
-    errors.push(`unreadable dist/postinstall-inventory.json: ${coerceErrorMessage(error)}`);
+    errors.push(`unreadable ${PACKAGE_DIST_INVENTORY_RELATIVE_PATH}: ${coerceErrorMessage(error)}`);
   }
 }
 
 errors.push(
-  ...collectPackageDistImportErrors({
-    files: normalized,
-    readText: readTarEntry,
-    imports: packageDistImports ?? undefined,
-  }),
+  ...runPhase("dist import graph", () =>
+    collectPackageDistImportErrors({ files: normalized, readText: readTarEntry }),
+  ),
 );
 
 if (errors.length > 0) {

--- a/scripts/lib/package-dist-inventory-contract.mts
+++ b/scripts/lib/package-dist-inventory-contract.mts
@@ -1,0 +1,31 @@
+export const PACKAGE_DIST_INVENTORY_RELATIVE_PATH = "dist/postinstall-inventory.json";
+export const PACKAGE_INSTALL_GUARD_RELATIVE_PATH = "dist/openclaw-install-guard";
+
+const UNINVENTORIED_PACKAGE_DIST_PATHS = new Set([
+  PACKAGE_DIST_INVENTORY_RELATIVE_PATH,
+  PACKAGE_INSTALL_GUARD_RELATIVE_PATH,
+]);
+
+export function comparePackageDistInventory(params: {
+  files: Iterable<string>;
+  inventory: Iterable<string>;
+}): {
+  packagedFilesMissingFromInventory: string[];
+  inventoryEntriesMissingFromPackage: string[];
+} {
+  const files = new Set(
+    [...params.files]
+      .map((entry) => entry.replace(/\\/gu, "/"))
+      .filter((entry) => entry.startsWith("dist/")),
+  );
+  const inventory = new Set([...params.inventory].map((entry) => entry.replace(/\\/gu, "/")));
+
+  return {
+    packagedFilesMissingFromInventory: [...files]
+      .filter((entry) => !UNINVENTORIED_PACKAGE_DIST_PATHS.has(entry) && !inventory.has(entry))
+      .toSorted(),
+    inventoryEntriesMissingFromPackage: [...inventory]
+      .filter((entry) => !files.has(entry))
+      .toSorted(),
+  };
+}

--- a/scripts/lib/package-dist-inventory.ts
+++ b/scripts/lib/package-dist-inventory.ts
@@ -10,7 +10,6 @@ import {
 
 export { LOCAL_BUILD_METADATA_DIST_PATHS } from "./local-build-metadata-paths.mts";
 export {
-  comparePackageDistInventory,
   PACKAGE_DIST_INVENTORY_RELATIVE_PATH,
   PACKAGE_INSTALL_GUARD_RELATIVE_PATH,
 } from "./package-dist-inventory-contract.mts";

--- a/scripts/lib/package-dist-inventory.ts
+++ b/scripts/lib/package-dist-inventory.ts
@@ -2,15 +2,18 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { writeJson } from "../../src/infra/json-files.ts";
+import { collectPackageDistInventory } from "../../src/infra/package-dist-inventory.ts";
 import {
-  collectPackageDistInventory,
   PACKAGE_DIST_INVENTORY_RELATIVE_PATH,
-} from "../../src/infra/package-dist-inventory.ts";
+  PACKAGE_INSTALL_GUARD_RELATIVE_PATH,
+} from "./package-dist-inventory-contract.mts";
 
 export { LOCAL_BUILD_METADATA_DIST_PATHS } from "./local-build-metadata-paths.mts";
-export { PACKAGE_DIST_INVENTORY_RELATIVE_PATH };
-
-export const PACKAGE_INSTALL_GUARD_RELATIVE_PATH = "dist/openclaw-install-guard";
+export {
+  comparePackageDistInventory,
+  PACKAGE_DIST_INVENTORY_RELATIVE_PATH,
+  PACKAGE_INSTALL_GUARD_RELATIVE_PATH,
+} from "./package-dist-inventory-contract.mts";
 
 const INSTALL_STAGE_DEBRIS_DIR_PATTERN = /^\.openclaw-install-stage(?:-[^/]+)?$/iu;
 

--- a/scripts/lib/plugin-sdk-entries.mts
+++ b/scripts/lib/plugin-sdk-entries.mts
@@ -159,7 +159,7 @@ export function buildPluginSdkPackageExports() {
 }
 
 /**
- * List public plugin SDK dist artifacts expected in package output.
+ * List all packaged plugin SDK dist artifacts, including production-private runtime JS.
  * @internal Shared repository-script contract.
  */
 export function listPluginSdkDistArtifacts() {

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -28,6 +28,10 @@ import { listBundledPluginPackArtifacts } from "./lib/bundled-plugin-build-entri
 import { formatErrorMessage } from "./lib/error-format.mts";
 import { runNpmVerifyCommand } from "./lib/npm-verify-exec.ts";
 import {
+  comparePackageDistInventory,
+  PACKAGE_DIST_INVENTORY_RELATIVE_PATH,
+} from "./lib/package-dist-inventory-contract.mts";
+import {
   collectRuntimeDependencySpecs,
   packageNameFromSpecifier,
 } from "./lib/plugin-package-dependencies.mts";
@@ -864,17 +868,6 @@ export function resolveInstalledBinaryCommandInvocation(
   };
 }
 
-function collectExpectedBundledExtensionPackageIds(): ReadonlySet<string> {
-  const ids = new Set<string>();
-  for (const relativePath of PACKAGED_BUNDLED_PLUGIN_ARTIFACTS) {
-    const match = /^dist\/extensions\/([^/]+)\/package\.json$/u.exec(relativePath);
-    if (match) {
-      ids.add(expectDefined(match[1], "bundled package extension id"));
-    }
-  }
-  return ids;
-}
-
 function readBundledExtensionPackageJsons(packageRoot: string): {
   manifests: InstalledBundledExtensionManifestRecord[];
   errors: string[];
@@ -882,15 +875,41 @@ function readBundledExtensionPackageJsons(packageRoot: string): {
   const extensionsDir = join(packageRoot, "dist", "extensions");
   const manifests: InstalledBundledExtensionManifestRecord[] = [];
   const errors: string[] = [];
-  const expectedPackageIds = collectExpectedBundledExtensionPackageIds();
+  const inventoryPath = join(packageRoot, PACKAGE_DIST_INVENTORY_RELATIVE_PATH);
 
-  // Scan the package contract first: absent bundled directories are invisible
-  // when verification only walks the installed extension root.
-  for (const expectedPackageId of expectedPackageIds) {
-    const packageJsonPath = join(extensionsDir, expectedPackageId, "package.json");
-    if (!existsSync(packageJsonPath)) {
-      errors.push(`installed bundled extension manifest missing: ${packageJsonPath}.`);
+  try {
+    const inventory: unknown = JSON.parse(readFileSync(inventoryPath, "utf8"));
+    if (!Array.isArray(inventory) || inventory.some((entry) => typeof entry !== "string")) {
+      throw new Error("inventory must be an array of file paths");
     }
+    const inventoryParity = comparePackageDistInventory({
+      files: PACKAGED_BUNDLED_PLUGIN_ARTIFACTS,
+      inventory: inventory as string[],
+    });
+    errors.push(
+      ...inventoryParity.packagedFilesMissingFromInventory.map(
+        (relativePath) =>
+          `installed bundled plugin artifact omitted from dist inventory: ${relativePath}.`,
+      ),
+    );
+  } catch (error) {
+    errors.push(
+      `installed package dist inventory is missing or invalid: ${PACKAGE_DIST_INVENTORY_RELATIVE_PATH}: ${formatErrorMessage(error)}.`,
+    );
+  }
+
+  const installedArtifactParity = comparePackageDistInventory({
+    files: [...PACKAGED_BUNDLED_PLUGIN_ARTIFACTS].filter((relativePath) =>
+      existsSync(join(packageRoot, relativePath)),
+    ),
+    inventory: PACKAGED_BUNDLED_PLUGIN_ARTIFACTS,
+  });
+  for (const relativePath of installedArtifactParity.inventoryEntriesMissingFromPackage) {
+    errors.push(
+      relativePath.endsWith("/package.json")
+        ? `installed bundled extension manifest missing: ${join(packageRoot, relativePath)}.`
+        : `installed bundled plugin artifact missing: ${relativePath}.`,
+    );
   }
 
   if (!existsSync(extensionsDir)) {

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -43,7 +43,6 @@ import {
 import { collectBundledPluginPackageDependencySpecs } from "./lib/plugin-package-dependencies.mts";
 import {
   listPluginSdkDistArtifacts,
-  listPackagedPrivatePluginSdkRuntimeArtifacts,
   listUnpackagedPrivatePluginSdkDistArtifacts,
 } from "./lib/plugin-sdk-entries.mts";
 import {
@@ -86,7 +85,6 @@ const requiredPathGroups = [
   ["dist/index.js", "dist/index.mjs"],
   ["dist/entry.js", "dist/entry.mjs"],
   ...listPluginSdkDistArtifacts(),
-  ...listPackagedPrivatePluginSdkRuntimeArtifacts(),
   ...listBundledPluginPackArtifacts(),
   ...listStaticExtensionAssetOutputs().filter((relativePath: string) => {
     const match = /^dist\/extensions\/([^/]+)\//u.exec(relativePath);

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -578,14 +578,17 @@ describe("collectInstalledPackageErrors", () => {
   ): void {
     const omitted = new Set(omittedIds);
     for (const relativePath of requiredBundledPluginPackPaths) {
-      const match = /^dist\/extensions\/([^/]+)\/package\.json$/u.exec(relativePath);
+      const match = /^dist\/extensions\/([^/]+)\//u.exec(relativePath);
       if (!match || omitted.has(match[1] ?? "")) {
         continue;
       }
-      const packageJsonPath = join(packageRoot, relativePath);
-      mkdirSync(dirname(packageJsonPath), { recursive: true });
-      writeFileSync(packageJsonPath, "{}\n", "utf8");
+      const artifactPath = join(packageRoot, relativePath);
+      mkdirSync(dirname(artifactPath), { recursive: true });
+      writeFileSync(artifactPath, relativePath.endsWith(".json") ? "{}\n" : "export {};\n", "utf8");
     }
+    const inventoryPath = join(packageRoot, "dist", "postinstall-inventory.json");
+    mkdirSync(dirname(inventoryPath), { recursive: true });
+    writeFileSync(inventoryPath, JSON.stringify(requiredBundledPluginPackPaths), "utf8");
   }
 
   it("flags version mismatches", () => {
@@ -643,10 +646,17 @@ describe("collectInstalledPackageErrors", () => {
           "package.json",
         );
         const expectedError = `installed bundled extension manifest missing: ${missingManifestPath}.`;
+        const missingArtifactErrors = requiredBundledPluginPackPaths
+          .filter((relativePath) => relativePath.startsWith(`dist/extensions/${providerId}/`))
+          .map((relativePath) =>
+            relativePath.endsWith("/package.json")
+              ? expectedError
+              : `installed bundled plugin artifact missing: ${relativePath}.`,
+          );
 
-        expect(collectInstalledBundledExtensionManifestErrors(packageRoot)).toStrictEqual([
-          expectedError,
-        ]);
+        expect(collectInstalledBundledExtensionManifestErrors(packageRoot)).toStrictEqual(
+          missingArtifactErrors,
+        );
         expect(
           collectInstalledPackageErrors({
             expectedVersion: "2026.3.23",
@@ -659,6 +669,46 @@ describe("collectInstalledPackageErrors", () => {
       }
     },
   );
+
+  it.each([
+    ["plugin manifest", "dist/extensions/ollama/openclaw.plugin.json"],
+    ["generated plugin artifact", "dist/extensions/ollama/provider-discovery.js"],
+  ])("rejects an installed bundled %s missing after postinstall", (_, relativePath) => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      writeExpectedBundledExtensionManifests(packageRoot);
+      rmSync(join(packageRoot, relativePath));
+
+      expect(collectInstalledBundledExtensionManifestErrors(packageRoot)).toContain(
+        `installed bundled plugin artifact missing: ${relativePath}.`,
+      );
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["plugin manifest", "dist/extensions/ollama/openclaw.plugin.json"],
+    ["generated plugin artifact", "dist/extensions/ollama/provider-discovery.js"],
+  ])("rejects an installed bundled %s omitted from its inventory", (_, relativePath) => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      writeExpectedBundledExtensionManifests(packageRoot);
+      writeFileSync(
+        join(packageRoot, "dist", "postinstall-inventory.json"),
+        JSON.stringify(requiredBundledPluginPackPaths.filter((entry) => entry !== relativePath)),
+        "utf8",
+      );
+
+      expect(collectInstalledBundledExtensionManifestErrors(packageRoot)).toContain(
+        `installed bundled plugin artifact omitted from dist inventory: ${relativePath}.`,
+      );
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
 
   it("rejects an installed package without its bundled extension root", () => {
     const packageRoot = makeInstalledPackageRoot();
@@ -700,16 +750,16 @@ describe("collectInstalledPackageErrors", () => {
       expect(filteredErrors).toStrictEqual(expectedErrors);
       expect(filteredErrors).toEqual(
         expect.arrayContaining(
-          ["ollama", "lmstudio"].map(
-            (providerId) =>
-              `installed bundled extension manifest missing: ${join(
-                packageRoot,
-                "dist",
-                "extensions",
-                providerId,
-                "package.json",
-              )}.`,
-          ),
+          ["ollama", "lmstudio"].flatMap((providerId) => [
+            `installed bundled extension manifest missing: ${join(
+              packageRoot,
+              "dist",
+              "extensions",
+              providerId,
+              "package.json",
+            )}.`,
+            `installed bundled plugin artifact missing: dist/extensions/${providerId}/openclaw.plugin.json.`,
+          ]),
         ),
       );
     } finally {
@@ -744,16 +794,16 @@ describe("collectInstalledPackageErrors", () => {
       expect(probe.status, probe.stderr).toBe(0);
       expect(JSON.parse(probe.stdout)).toEqual(
         expect.arrayContaining(
-          ["ollama", "lmstudio"].map(
-            (providerId) =>
-              `installed bundled extension manifest missing: ${join(
-                packageRoot,
-                "dist",
-                "extensions",
-                providerId,
-                "package.json",
-              )}.`,
-          ),
+          ["ollama", "lmstudio"].flatMap((providerId) => [
+            `installed bundled extension manifest missing: ${join(
+              packageRoot,
+              "dist",
+              "extensions",
+              providerId,
+              "package.json",
+            )}.`,
+            `installed bundled plugin artifact missing: dist/extensions/${providerId}/openclaw.plugin.json.`,
+          ]),
         ),
       );
     } finally {

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -784,13 +784,14 @@ describe("collectMissingPackPaths", () => {
         writeFileSync(filePath, "export {};\n");
       }
       for (const relativePath of requiredBundledPluginPackPaths) {
-        if (!/^dist\/extensions\/[^/]+\/package\.json$/u.test(relativePath)) {
-          continue;
-        }
-        const packageJsonPath = join(packageRoot, relativePath);
-        mkdirSync(dirname(packageJsonPath), { recursive: true });
-        writeFileSync(packageJsonPath, "{}\n");
+        const artifactPath = join(packageRoot, relativePath);
+        mkdirSync(dirname(artifactPath), { recursive: true });
+        writeFileSync(artifactPath, relativePath.endsWith(".json") ? "{}\n" : "export {};\n");
       }
+      writeFileSync(
+        join(packageRoot, PACKAGE_DIST_INVENTORY_RELATIVE_PATH),
+        JSON.stringify(requiredBundledPluginPackPaths),
+      );
       for (const relativePath of collectInstalledBundledRuntimeSidecarPaths(packageRoot)) {
         const sidecarPath = join(packageRoot, relativePath);
         mkdirSync(dirname(sidecarPath), { recursive: true });

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -742,7 +742,6 @@ describe("collectMissingPackPaths", () => {
         ...requiredBundledPluginPackPaths,
         ...requiredStaticExtensionAssetPaths,
         ...requiredPluginSdkPackPaths,
-        ...packagedPrivatePluginSdkRuntimePaths,
         ...WORKSPACE_TEMPLATE_PACK_PATHS,
         "scripts/prepare-git-hooks.mjs",
         "scripts/preinstall-package-manager-warning.mjs",

--- a/test/scripts/check-openclaw-package-tarball-control-ui.test.ts
+++ b/test/scripts/check-openclaw-package-tarball-control-ui.test.ts
@@ -194,7 +194,7 @@ describe("packaged Control UI postinstall inventory", () => {
       for (const relativePath of CONTROL_UI_FILES) {
         expect
           .soft(validationErrors)
-          .toContain(`postinstall inventory omits Control UI file ${relativePath}`);
+          .toContain(`postinstall inventory omits packaged dist file ${relativePath}`);
       }
     });
   });

--- a/test/scripts/check-openclaw-package-tarball.test.ts
+++ b/test/scripts/check-openclaw-package-tarball.test.ts
@@ -66,6 +66,7 @@ function withTarball(
     includeShrinkwrap?: boolean;
     includeWorkspaceTemplates?: boolean;
     packageJson?: Record<string, unknown>;
+    postinstall?: boolean;
   } = {},
 ) {
   const root = mkdtempSync(join(tmpdir(), "openclaw-package-tarball-test-"));
@@ -76,14 +77,32 @@ function withTarball(
       (validVersion !== null && semverGte(validVersion, FIRST_CODE_MODE_WORKER_VERSION));
     const includeCodeModeWorkerInInventory =
       options.includeCodeModeWorkerInInventory ?? includeCodeModeWorker;
-    const packageInventory = includeCodeModeWorkerInInventory
-      ? [...new Set([...inventory, CODE_MODE_WORKER_PATH])]
-      : inventory;
+    const controlUiFiles =
+      options.includeControlUi === false
+        ? {}
+        : {
+            "dist/control-ui/index.html": "<!doctype html><openclaw-app></openclaw-app>",
+            "dist/control-ui/assets/app.js": "console.log('ok');\n",
+          };
+    const packageInventory = [
+      ...new Set([
+        ...inventory,
+        ...(options.postinstall ? Object.keys(controlUiFiles) : []),
+        ...(includeCodeModeWorkerInInventory ? [CODE_MODE_WORKER_PATH] : []),
+      ]),
+    ];
     const packageRoot = join(root, "package");
     mkdirSync(join(packageRoot, "dist"), { recursive: true });
     writeFileSync(
       join(packageRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version, ...options.packageJson }),
+      JSON.stringify({
+        name: "openclaw",
+        version,
+        ...(options.postinstall
+          ? { scripts: { postinstall: "node scripts/postinstall-bundled-plugins.mjs" } }
+          : {}),
+        ...options.packageJson,
+      }),
     );
     writeFileSync(
       join(packageRoot, "dist", "postinstall-inventory.json"),
@@ -98,13 +117,6 @@ function withTarball(
               `# ${relativePath}\n`,
             ]),
           );
-    const controlUiFiles =
-      options.includeControlUi === false
-        ? {}
-        : {
-            "dist/control-ui/index.html": "<!doctype html><openclaw-app></openclaw-app>",
-            "dist/control-ui/assets/app.js": "console.log('ok');\n",
-          };
     const installGuardFile =
       options.includeInstallGuard === false
         ? {}
@@ -339,6 +351,29 @@ describe("check-openclaw-package-tarball", () => {
     );
   });
 
+  it.each([
+    ["bundled plugin manifest", "dist/extensions/example/openclaw.plugin.json", "{}\n"],
+    ["generated non-JavaScript sidecar", "dist/generated/example.schema.json", "{}\n"],
+  ])(
+    "rejects a packaged %s omitted from the postinstall inventory",
+    (_, relativePath, contents) => {
+      withTarball(
+        ["dist/index.js"],
+        { "dist/index.js": "export {};\n", [relativePath]: contents },
+        (tarball) => {
+          const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
+
+          expect(result.status).not.toBe(0);
+          expect(result.stderr).toContain(
+            `postinstall inventory omits packaged dist file ${relativePath}`,
+          );
+        },
+        "2026.7.2",
+        { postinstall: true },
+      );
+    },
+  );
+
   it("accepts historical packages published before the Code Mode worker existed", () => {
     withTarball(
       ["dist/index.js"],
@@ -376,10 +411,12 @@ describe("check-openclaw-package-tarball", () => {
         const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
 
         expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(`postinstall inventory omits ${CODE_MODE_WORKER_PATH}`);
+        expect(result.stderr).toContain(
+          `postinstall inventory omits packaged dist file ${CODE_MODE_WORKER_PATH}`,
+        );
       },
       FIRST_CODE_MODE_WORKER_VERSION,
-      { includeCodeModeWorkerInInventory: false },
+      { includeCodeModeWorkerInInventory: false, postinstall: true },
     );
   });
 
@@ -447,10 +484,11 @@ describe("check-openclaw-package-tarball", () => {
 
         expect(result.status).not.toBe(0);
         expect(result.stderr).toContain(
-          "inventory omits imported dist file dist/memory-state-current.js",
+          "postinstall inventory omits packaged dist file dist/memory-state-current.js",
         );
       },
       "2026.4.27",
+      { postinstall: true },
     );
   });
 
@@ -465,9 +503,12 @@ describe("check-openclaw-package-tarball", () => {
         const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
 
         expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain("inventory omits imported dist file dist/chunk.js");
+        expect(result.stderr).toContain(
+          "postinstall inventory omits packaged dist file dist/chunk.js",
+        );
       },
       "2026.4.27",
+      { postinstall: true },
     );
   });
 
@@ -482,9 +523,12 @@ describe("check-openclaw-package-tarball", () => {
         const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
 
         expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain("inventory omits imported dist file dist/chunk.cjs");
+        expect(result.stderr).toContain(
+          "postinstall inventory omits packaged dist file dist/chunk.cjs",
+        );
       },
       "2026.4.27",
+      { postinstall: true },
     );
   });
 
@@ -535,9 +579,12 @@ describe("check-openclaw-package-tarball", () => {
         const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
 
         expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain("inventory omits imported dist file dist/worker.js");
+        expect(result.stderr).toContain(
+          "postinstall inventory omits packaged dist file dist/worker.js",
+        );
       },
       "2026.4.27",
+      { postinstall: true },
     );
   });
 

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -683,6 +683,13 @@ describe("bundled plugin postinstall", () => {
   it("prunes stale private QA files without restoring compat sidecars", async () => {
     const packageRoot = await createTempDirAsync("openclaw-packaged-install-qa-compat-");
     const currentFile = path.join(packageRoot, "dist", "entry.js");
+    const currentManifest = path.join(
+      packageRoot,
+      "dist",
+      "extensions",
+      "example",
+      "openclaw.plugin.json",
+    );
     const stalePackage = path.join(packageRoot, "dist", "extensions", "qa-lab", "package.json");
     const staleManifest = path.join(
       packageRoot,
@@ -692,7 +699,9 @@ describe("bundled plugin postinstall", () => {
       "openclaw.plugin.json",
     );
     await fs.mkdir(path.dirname(stalePackage), { recursive: true });
+    await fs.mkdir(path.dirname(currentManifest), { recursive: true });
     await fs.writeFile(currentFile, "export {};\n");
+    await fs.writeFile(currentManifest, "{}\n");
     await writePackageDistInventory(packageRoot);
     await fs.writeFile(stalePackage, "{}\n");
     await fs.writeFile(staleManifest, "{}\n");
@@ -702,6 +711,7 @@ describe("bundled plugin postinstall", () => {
       log: { log: vi.fn(), warn: vi.fn() },
     });
 
+    await expectPathExists(currentManifest);
     await expectPathMissing(stalePackage);
     await expectPathMissing(staleManifest);
     await expectPathMissing(


### PR DESCRIPTION
Closes #129722

## What Problem This Solves

Fixes an issue where a package could pass tarball validation even though its pruning postinstall lifecycle would delete required bundled plugin manifests and other non-JavaScript runtime assets after installation.

## Why This Change Was Made

The package inventory is now checked as a bidirectional survivor-set contract whenever the package declares postinstall pruning. The same dependency-free parity owner is reused by tarball validation and installed-package verification, which now covers every bundled plugin pack artifact rather than only extension `package.json` files. Historical lifecycle-free package inspection keeps its existing compatibility behavior.

This PR is AI-assisted. I reviewed the implementation, rejected an initial over-broad lifecycle-free check, and reran the complete focused proof after narrowing the owner boundary.

## User Impact

Published packages can no longer validate successfully and then silently lose required runtime assets during installation. Bundled plugin discovery and other sidecar-backed runtime paths are protected before publication and after install.

## Evidence

- Pre-fix regression proof: six new cases accepted missing or uninventoried bundled manifests/generated sidecars before the owner repair.
- `node scripts/run-vitest.mjs test/scripts/check-openclaw-package-tarball.test.ts test/scripts/check-openclaw-package-tarball-control-ui.test.ts test/openclaw-npm-postpublish-verify.test.ts test/scripts/postinstall-bundled-plugins.test.ts test/release-check.test.ts` — 199/199 passed after rebase.
- Real offline `npm pack` plus lifecycle-enabled `npm install` fixture passed; an inventoried plugin manifest survived while stale private-QA artifacts were pruned.
- `node scripts/check-changed.mjs -- <9 changed paths>` passed formatting, script erasability, script/root-test typechecks, lint, package guards, and repository policy checks.
- `git diff --check` passed.
- Mandatory autoreview: clean, no accepted/actionable P0/P1 findings.
- Production runtime LOC: 0. Tooling LOC: +113/-90 (net +23). Tests: +160/-52 (net +108).

Full built-checkout package acceptance is delegated to exact-head CI/Testbox because the source checkout does not contain prepared `dist/postinstall-inventory.json` and install-guard build artifacts.