### PR TITLE
fix(gateway): tools.invoke must carry the caller's host-minted role authority

### DIFF
--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -362,7 +362,15 @@ if (args[0] === "--pure" && args[1] === "db" && args.includes("--format") && arg
   process.exitCode = 2;
 }
 `;
-  await fs.writeFile(executable, script);
+  // Flush and close the executable before exec: a still-open write handle makes
+  // the immediately following spawn fail with ETXTBSY under parallel CI shards.
+  const executableHandle = await fs.open(executable, "w");
+  try {
+    await executableHandle.writeFile(script);
+    await executableHandle.sync();
+  } finally {
+    await executableHandle.close();
+  }
   if (process.platform === "win32") {
     await fs.writeFile(path.join(directory, "opencode.js"), script);
     // This exact direct-forwarder shape is parsed into a Node entrypoint;

--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -242,10 +242,10 @@ describe("isolated QA suite transport cleanup", () => {
   it("keeps Crabline workers concurrent while publishing readiness only from the final aggregate", async () => {
     const lab = createCleanupTestLab();
     const selection = {
-      capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+      capabilityMatrixPath: "crabline-channel-driver-capabilities.json",
       channel: "telegram",
       channelDriver: "crabline",
-      smokeArtifactPath: "crabline-fake-provider-smoke.json",
+      providerReadinessArtifactPath: "crabline-provider-readiness.json",
     } as const;
     let activeWorkers = 0;
     let maxActiveWorkers = 0;

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
@@ -284,10 +284,10 @@ describe("runtime parity suite transport cleanup", () => {
     mocks.writeQaSuiteArtifacts.mockClear();
     const scenario = makeQaSuiteTestScenario("runtime-cleanup");
     const selection = {
-      capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+      capabilityMatrixPath: "crabline-channel-driver-capabilities.json",
       channel: "telegram",
       channelDriver: "crabline",
-      smokeArtifactPath: "crabline-fake-provider-smoke.json",
+      providerReadinessArtifactPath: "crabline-provider-readiness.json",
     } as const;
     const parentLab = createCleanupTestLab();
     const openClawLab = createCleanupTestLab();

--- a/scripts/github/release-validation-campaign.d.mts
+++ b/scripts/github/release-validation-campaign.d.mts
@@ -27,8 +27,27 @@ export function validateReleaseValidationCampaignArtifact(
   },
 ): ReleaseValidationCampaignArtifact;
 
+/**
+ * Structural subset of the Actions-provided Octokit client this publisher uses.
+ * Declared locally so the script keeps a real contract without depending on
+ * Octokit's generated types from a plain-Node script surface.
+ */
+export type ReleaseValidationCampaignGitHubClient = {
+  rest: {
+    issues: {
+      get(params: Record<string, unknown>): Promise<{ data: unknown }>;
+      getLabel(params: Record<string, unknown>): Promise<unknown>;
+      createLabel(params: Record<string, unknown>): Promise<unknown>;
+      createComment(params: Record<string, unknown>): Promise<unknown>;
+      update(params: Record<string, unknown>): Promise<{ data: unknown }>;
+      listForRepo: unknown;
+    };
+  };
+  paginate(route: unknown, params: Record<string, unknown>): Promise<unknown[]>;
+};
+
 export function runReleaseValidationCampaignPublish(params: {
-  github: any;
+  github: ReleaseValidationCampaignGitHubClient;
   context: { repo: { owner: string; repo: string } };
   core: { info(message: string): void; setOutput?(name: string, value: string): void };
   artifact: unknown;

--- a/src/gateway/server-methods/tools-invoke.ts
+++ b/src/gateway/server-methods/tools-invoke.ts
@@ -55,6 +55,7 @@ export const toolsInvokeHandlers: GatewayRequestHandlers = {
       cfg: context.getRuntimeConfig(),
       input: params,
       authenticatedUserProfile: client?.authenticatedUserProfile,
+      operatorRoleActor: client?.internal?.operatorRoleActor,
       operatorScopes: client?.connect.scopes,
       senderIsOwner: client?.connect?.scopes?.includes("operator.admin"),
       clientCaps: client?.connect?.caps,

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -473,6 +473,7 @@ const invokeToolsRpc = async (
     hasAvatar: boolean;
     updatedAt: number;
   },
+  internal?: { operatorRoleActor?: { kind: "system" } | { kind: "operator"; profileId: string } },
 ) => {
   const respond = vi.fn();
   await expectDefined(
@@ -484,6 +485,7 @@ const invokeToolsRpc = async (
     context: { getRuntimeConfig: () => cfg } as never,
     client: {
       ...(authenticatedUserProfile ? { authenticatedUserProfile } : {}),
+      ...(internal ? { internal } : {}),
       connect: {
         role: "operator",
         scopes,
@@ -569,6 +571,50 @@ describe("POST /tools/invoke", () => {
         },
       });
       expect(hookMocks.runBeforeToolCallHook).not.toHaveBeenCalled();
+    });
+  });
+
+  it("preserves host-minted system authority for a shared-secret caller under roles", async () => {
+    await withOpenClawTestState({ label: "tools-invoke-system-authority" }, async () => {
+      const owner = ensureProfileForEmail("sysauth-owner@example.test");
+      const sessionKey = "agent:main:sysauth-primary";
+      const entry = {
+        sessionId: "sysauth-primary-session",
+        updatedAt: 1,
+        visibility: "shared" as const,
+        createdActor: { type: "human" as const, id: owner.id },
+      };
+      await upsertSessionEntryCore({ agentId: "main", sessionKey }, entry);
+      sessionEntries.set(sessionKey, entry);
+      cfg = {
+        agents: { list: [{ id: "main", default: true, tools: { allow: ["agents_list"] } }] },
+        gateway: {
+          roles: {
+            default: "guest",
+            definitions: {
+              guest: {
+                sessions: { others: "view" },
+                agents: ["guest-agent"],
+                scopes: ["operator.write"],
+              },
+            },
+          },
+        },
+      };
+
+      // Shared-secret operator owners have no durable profile; connect mints system
+      // authority on the connection. Dispatch must carry that fact forward instead of
+      // re-deriving ownership from scopes, or the caller is denied its own agent.
+      const call = await invokeToolsRpc(
+        { name: "agents_list", args: {}, sessionKey },
+        ["operator.write"],
+        undefined,
+        undefined,
+        undefined,
+        { operatorRoleActor: { kind: "system" } },
+      );
+
+      expect(call?.[1]).toMatchObject({ ok: true, toolName: "agents_list" });
     });
   });
 

--- a/src/gateway/tools-invoke-shared.ts
+++ b/src/gateway/tools-invoke-shared.ts
@@ -177,6 +177,8 @@ type InvokeGatewayToolParams = {
   agentTo?: string;
   agentThreadId?: string;
   authenticatedUserProfile?: GatewayClient["authenticatedUserProfile"];
+  /** Host-minted authority from the calling connection; never derived from wire params. */
+  operatorRoleActor?: NonNullable<GatewayClient["internal"]>["operatorRoleActor"];
   operatorScopes?: readonly string[];
   senderIsOwner?: boolean;
   clientCaps?: string[];
@@ -248,11 +250,15 @@ async function invokeGatewayToolWithSignal(
   const authenticatedUserProfile = params.cfg.gateway?.roles
     ? params.authenticatedUserProfile
     : undefined;
+  // The calling connection already resolved its authority at connect (shared-secret
+  // owners mint system authority there). Carry that exact fact forward instead of
+  // re-deriving it from scopes, or role boundaries deny the caller's own dispatch.
+  const operatorRoleActor =
+    params.operatorRoleActor ??
+    (params.senderIsOwner && !authenticatedUserProfile ? { kind: "system" as const } : undefined);
   const client = createSyntheticPluginRuntimeClient({
     ...(authenticatedUserProfile ? { authenticatedUserProfile } : {}),
-    ...(params.senderIsOwner && !authenticatedUserProfile
-      ? { operatorRoleActor: { kind: "system" as const } }
-      : {}),
+    ...(operatorRoleActor ? { operatorRoleActor } : {}),
     scopes: params.senderIsOwner ? [ADMIN_SCOPE] : [...(params.operatorScopes ?? [])],
   });
   const primarySessionAuthorizationError = authorizeResolvedSessionMutation({


### PR DESCRIPTION
## What Problem This Solves

On a Gateway with `gateway.roles` configured, a shared-secret operator owner (`auth.mode=token`/`password`, e.g. the local CLI and host automation) could not dispatch tools against its own agents:

```
tools.invoke exec --agentId roboclaw
=> forbidden: Your operator role cannot create sessions for agent "roboclaw";
   choose an allowed agent or ask a gateway administrator to update your role.
```

The same connection could still mutate sessions directly (`sessions.patch` on that agent succeeds), so the boundary was inconsistent: identical authority, two different answers depending on which entry point was used.

Observed on `team.openclaw.ai` after enabling `gateway.roles`.

## Why This Change Was Made

The connect handshake already resolves each connection's authority exactly once and stores it server-side: `connect-session.ts` mints `internal.operatorRoleActor = { kind: "system" }` for shared-secret operator owners, which `authorizeGatewaySessionCreation` treats as exempt.

`tools.invoke` discarded that host-minted fact and re-derived ownership from `connect.scopes` (`senderIsOwner`). A shared-secret caller has no durable profile, so the synthetic dispatch client carried neither a profile nor an actor and resolved to the deny-by-default role (`agents: []`) — refusing the caller's own dispatch.

The fix carries the prepared fact forward instead of rediscovering it, per the repo rule that hot paths reuse prepared authority rather than re-deriving it. The scope-derived path is preserved as a fallback for callers that have no connection actor (the HTTP `/tools/invoke` surface), so that behavior is unchanged.

This is a follow-up to #128548, which introduced the role boundary.

## User Impact

- Restores tool dispatch for shared-secret operator owners (local CLI, host automation, scripted `tools.invoke`) on Gateways with `gateway.roles` enabled.
- No change for deployments without `gateway.roles`: no policy is resolved and the actor is unused.
- No widening: authority still comes only from the host-minted connection actor, which is set server-side at connect and is never accepted from wire params. Profile-identified operators are unaffected and remain subject to the agent allowlist.

## Evidence

- Regression test `preserves host-minted system authority for a shared-secret caller under roles` (`src/gateway/tools-invoke-http.test.ts`) models the production shape: an existing session owned by another profile, a role whose `agents` allowlist excludes the target, and a caller with only `operator.write` plus the connection's system actor.
  - Pre-fix: fails with `expected { ok: false, … } to match object { ok: true, toolName: 'agents_list' }` (the FORBIDDEN allowlist error).
  - Post-fix: passes.
- `pnpm test src/gateway/tools-invoke-http.test.ts src/gateway/tools-invoke-http.abort.test.ts src/gateway/tools-invoke-http.cron-regression.test.ts src/gateway/session-sharing.test.ts src/gateway/operator-role-policy.test.ts` → 84 passed.
- `CI=true pnpm check:changed` → exit 0 (typecheck core + tests, lint, ratchets, import cycles).
- Production LOC: +9/-2 (net +7) in two files; the remainder is the regression test.

## Bundled CI repairs (unrelated to the fix, disclosed)

Exact-head CI was red on gates this branch does not touch. Per the repo rule that a red gate gets fixed in the landing PR rather than waited out, two repairs ride along. Both were reproduced on clean `origin/main` before any local edit:

- **`check-test-types` (red on main).** `extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts` and `suite-runtime-parity-runner.cleanup.test.ts` still built `OpenClawCrablineChannelDriverSelection` with the retired `smokeArtifactPath` and a stale `capabilityMatrixPath` after the readiness-artifact change (#124189). Both fixtures now match the current type and its pinned constants. Proof: `pnpm check:test-types` fails on clean `origin/main` (`5af41d881e0`) with the same two `TS2741` errors and exits 0 here.
- **`check-lint` (red on main).** `scripts/github/release-validation-campaign.d.mts` declared the Actions Octokit client as `any` (#129726), tripping `no-explicit-any`. Replaced with the structural subset the publisher actually calls, rather than suppressing the rule.

Also fixed one flaky-by-construction shard hit on this branch: `extensions/opencode/session-catalog.test.ts` wrote the fake `opencode` executable and spawned it immediately, so a still-open write handle failed the launch with `ETXTBSY` under parallel shards. The fake CLI is now written through an explicit file handle with an `fsync` before close; suite run 4x locally, 18 passed each time.
