### PR TITLE
fix(ui): show workspace copy-path outcomes

### DIFF
--- a/ui/src/pages/chat/components/chat-session-workspace-rail.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace-rail.test.ts
@@ -1,0 +1,92 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderSessionWorkspaceRail } from "./chat-session-workspace-rail.ts";
+import type { SessionWorkspaceProps } from "./chat-session-workspace-types.ts";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+});
+
+describe("session workspace path actions", () => {
+  it.each(
+    [
+      {
+        surface: "session Files",
+        selector: ".chat-workspace-rail__list:not(.chat-workspace-rail__list--browser)",
+        path: "src/edited.ts",
+        origin: "session" as const,
+      },
+      {
+        surface: "project browser",
+        selector: ".chat-workspace-rail__list--browser",
+        path: "src/browser.ts",
+        origin: "workspace" as const,
+      },
+    ].flatMap((surface) =>
+      [false, true].map((failed) => ({
+        surface: surface.surface,
+        selector: surface.selector,
+        path: surface.path,
+        origin: surface.origin,
+        failed,
+        feedback: failed ? "Copy failed" : "Copied!",
+      })),
+    ),
+  )("shows $feedback when copying a $surface path", async (testCase) => {
+    const writeText = testCase.failed
+      ? vi.fn().mockRejectedValue(new DOMException("Clipboard access denied", "NotAllowedError"))
+      : vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const onOpenFile = vi.fn();
+    const workspace = {
+      collapsed: false,
+      sessionKey: "agent:main:workspace",
+      list: {
+        sessionKey: "agent:main:workspace",
+        root: "/synthetic/project",
+        files: [{ kind: "modified" as const, name: "edited.ts", path: "src/edited.ts" }],
+        browser: {
+          path: "",
+          entries: [{ kind: "file" as const, name: "browser.ts", path: "src/browser.ts" }],
+        },
+      },
+      loading: false,
+      error: null,
+      activeId: null,
+      dock: "right" as const,
+      narrowLayout: false,
+      onToggleCollapsed: vi.fn(),
+      onSetDock: vi.fn(),
+      onRefresh: vi.fn(),
+      onBrowsePath: vi.fn(),
+      onOpenFile,
+      onSearch: vi.fn(),
+      onOpenArtifact: vi.fn(),
+    } satisfies SessionWorkspaceProps;
+    const mount = document.body.appendChild(document.createElement("div"));
+    render(renderSessionWorkspaceRail(workspace), mount);
+
+    const row = mount.querySelector<HTMLElement>(`${testCase.selector} .chat-workspace-rail__file`);
+    expect(row).toBeInstanceOf(HTMLElement);
+    const rowClick = vi.fn();
+    row!.addEventListener("click", rowClick);
+    const copy = row!.querySelector<HTMLButtonElement>('button[aria-label="Copy path"]');
+    expect(copy).toBeInstanceOf(HTMLButtonElement);
+
+    copy!.click();
+    await vi.waitFor(() => expect(copy!.getAttribute("aria-label")).toBe(testCase.feedback));
+
+    expect(writeText).toHaveBeenCalledWith(testCase.path);
+    expect(copy!.dataset[testCase.failed ? "error" : "copied"]).toBe("1");
+    expect(rowClick).not.toHaveBeenCalled();
+    expect(onOpenFile).not.toHaveBeenCalled();
+
+    const preview = row!.querySelector<HTMLButtonElement>('button[aria-label="Preview"]');
+    expect(preview).toBeInstanceOf(HTMLButtonElement);
+    preview!.click();
+    expect(onOpenFile).toHaveBeenCalledWith(testCase.path, testCase.origin);
+  });
+});

--- a/ui/src/pages/chat/components/chat-session-workspace-rail.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace-rail.test.ts
@@ -47,7 +47,9 @@ describe("session workspace path actions", () => {
       list: {
         sessionKey: "agent:main:workspace",
         root: "/synthetic/project",
-        files: [{ kind: "modified" as const, name: "edited.ts", path: "src/edited.ts" }],
+        files: [
+          { kind: "modified" as const, name: "edited.ts", path: "src/edited.ts", missing: false },
+        ],
         browser: {
           path: "",
           entries: [{ kind: "file" as const, name: "browser.ts", path: "src/browser.ts" }],

--- a/ui/src/pages/chat/components/chat-session-workspace-rail.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace-rail.ts
@@ -1,4 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
+import { renderCopyButton } from "../../../components/copy-button.ts";
 import { icons } from "../../../components/icons.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
@@ -136,19 +137,9 @@ export function renderSessionWorkspaceRail(
           ${icons.eye}
         </button>
       </openclaw-tooltip>
-      <openclaw-tooltip .content=${t("chat.workspaceFiles.copyPath")}>
-        <button
-          class="chat-workspace-rail__row-action"
-          type="button"
-          aria-label=${t("chat.workspaceFiles.copyPath")}
-          @click=${(event: Event) => {
-            event.stopPropagation();
-            sessionWorkspace.onCopyPath(path);
-          }}
-        >
-          ${icons.copy}
-        </button>
-      </openclaw-tooltip>
+      <span @click=${(event: Event) => event.stopPropagation()}>
+        ${renderCopyButton(path, t("chat.workspaceFiles.copyPath"))}
+      </span>
     </span>
   `;
   const renderSessionSummary = (): TemplateResult | typeof nothing => {

--- a/ui/src/pages/chat/components/chat-session-workspace-types.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace-types.ts
@@ -19,7 +19,6 @@ export type SessionWorkspaceProps = {
   onSetDock: (dock: ChatWorkspaceDock) => void;
   onRefresh: () => void;
   onBrowsePath: (path: string) => void;
-  onCopyPath: (path: string) => void;
   onOpenFile: (path: string, origin: "session" | "workspace") => void;
   onSearch: (search: string) => void;
   onOpenArtifact: (artifactId: string) => void;

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -4,7 +4,6 @@ import type { ArtifactDownloadResult, SessionWorkspaceGetResult } from "../../..
 import { hasOperatorAdminAccess } from "../../../app/operator-access.ts";
 import { patchSettings, type ChatWorkspaceDock } from "../../../app/settings.ts";
 import { t } from "../../../i18n/index.ts";
-import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { formatUiError } from "../../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../../lib/gateway-methods.ts";
 import {
@@ -478,9 +477,6 @@ export function createSessionWorkspaceProps(
       workspace.browserPath = path;
       workspace.browserSearch = "";
       loadSessionWorkspace(state, workspace, true);
-    },
-    onCopyPath: (path) => {
-      void copyToClipboard(path);
     },
     onOpenFile: (path, origin) => {
       // Session paths are cwd-relative; browser rows are workspace-root-relative.

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -975,7 +975,8 @@ openclaw-chat-sidebar-region,
   opacity: 1;
 }
 
-.chat-workspace-rail__row-action {
+.chat-workspace-rail__row-action,
+.chat-workspace-rail__row-actions :where(.chat-copy-btn) {
   display: inline-grid;
   width: 24px;
   height: 24px;
@@ -987,13 +988,15 @@ openclaw-chat-sidebar-region,
 }
 
 .chat-workspace-rail__row-action:hover,
-.chat-workspace-rail__row-action:focus-visible {
+.chat-workspace-rail__row-action:focus-visible,
+.chat-workspace-rail__row-actions :where(.chat-copy-btn:hover, .chat-copy-btn:focus-visible) {
   border-color: color-mix(in srgb, var(--border-strong) 72%, transparent);
   background: color-mix(in srgb, var(--bg-elevated) 82%, transparent);
   color: var(--text);
 }
 
-.chat-workspace-rail__row-action svg {
+.chat-workspace-rail__row-action svg,
+.chat-workspace-rail__row-actions :where(.chat-copy-btn svg) {
   width: 14px;
   height: 14px;
   fill: none;


### PR DESCRIPTION
## What Problem This Solves

Fixes chat workspace Files and project-browser Copy Path actions silently ignoring both successful clipboard writes and denied clipboard failures.

## Why This Change Was Made

Workspace rows implemented a bespoke copy button and discarded its asynchronous outcome instead of using the existing canonical UI copy-button owner. The repair reuses that owner and removes the redundant callback, type, and import, reducing production code by 11 lines while preserving row layout and click behavior.

## User Impact

Both chat Files and project-browser rows visibly and accessibly report copied paths or clipboard failures. Buttons retain their existing 24px geometry, and copying never accidentally opens the selected file.

## Before

![Workspace copy buttons silently hide their outcome](https://github.com/user-attachments/assets/4c333811-964a-4ea3-8d23-27fa29bd04bf)

## After

![Workspace copy buttons show successful and failed clipboard outcomes](https://github.com/user-attachments/assets/85a808be-837a-430b-80e1-7729e47638e5)

## Evidence

- Four actual rendered owner regressions failed before repair across session/project rows and successful/denied clipboard writes.
- An isolated real Chromium browser verifies visible green/red feedback, accessible labels, unchanged icon geometry, and no accidental file opening.
- All 63 focused UI owner/sibling tests pass.
- Production delta is minus 11 lines; formatting, UI lint/style checks, localization verification, and fresh complete-diff structured P1 autoreview pass.
- Full-repository UI typechecking has only existing unrelated baseline dependency errors; no touched file produces a type diagnostic.
