### PR TITLE
fix(cli): preserve structured core send failures

### DIFF
--- a/src/infra/outbound/message-action-send.core.test.ts
+++ b/src/infra/outbound/message-action-send.core.test.ts
@@ -1,10 +1,15 @@
 // Covers core message-action send fallback, TTS application, and durable send
 // policy after plugin preparation is absent.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../../packages/gateway-protocol/src/client-info.js";
 import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { OutboundDeliveryError } from "./deliver-types.js";
 import { runMessageAction } from "./message-action-runner.js";
 
 const ttsMocks = vi.hoisted(() => ({
@@ -77,6 +82,104 @@ describe("runMessageAction core send routing", () => {
       .mockReset()
       .mockImplementation(async (params: { payload: unknown }) => params.payload);
   });
+
+  it.each([
+    {
+      label: "failed",
+      error: new Error("provider rejected the message"),
+      expectedStatus: "failed" as const,
+      expectedMessageId: undefined,
+    },
+    {
+      label: "partial_failed",
+      error: new OutboundDeliveryError("second send failed", {
+        cause: new Error("provider rejected the attachment"),
+        results: [{ channel: "testchat", messageId: "first-send-1" }],
+        stage: "platform_send",
+      }),
+      expectedStatus: "partial_failed" as const,
+      expectedMessageId: "first-send-1",
+    },
+  ])(
+    "returns structured $label core delivery outcomes to CLI callers",
+    async ({ error, expectedStatus, expectedMessageId }) => {
+      const sendText = vi.fn().mockRejectedValue(error);
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "testchat",
+            source: "test",
+            plugin: createOutboundTestPlugin({
+              id: "testchat",
+              outbound: { deliveryMode: "direct", sendText },
+            }),
+          },
+        ]),
+      );
+
+      const result = await runMessageAction({
+        cfg: {
+          channels: { testchat: { enabled: true } },
+        } as OpenClawConfig,
+        action: "send",
+        params: {
+          channel: "testchat",
+          target: "channel:abc",
+          message: "hello",
+        },
+        gateway: {
+          clientName: GATEWAY_CLIENT_NAMES.CLI,
+          mode: GATEWAY_CLIENT_MODES.CLI,
+        },
+        conversationReadOrigin: "direct-operator",
+        dryRun: false,
+      });
+
+      expect(result).toMatchObject({
+        kind: "send",
+        handledBy: "core",
+        sendResult: {
+          deliveryStatus: expectedStatus,
+          error: expect.any(String),
+          ...(expectedMessageId ? { result: { messageId: expectedMessageId } } : {}),
+        },
+      });
+      expect(sendText).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("keeps throwing core delivery failures for non-CLI callers", async () => {
+    const sendText = vi.fn().mockRejectedValue(new Error("provider rejected the message"));
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "testchat",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "testchat",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    await expect(
+      runMessageAction({
+        cfg: {
+          channels: { testchat: { enabled: true } },
+        } as OpenClawConfig,
+        action: "send",
+        params: {
+          channel: "testchat",
+          target: "channel:abc",
+          message: "hello",
+        },
+        dryRun: false,
+      }),
+    ).rejects.toThrow("provider rejected the message");
+    expect(sendText).toHaveBeenCalledOnce();
+  });
+
   it("does not misclassify send as poll when zero-valued poll params are present", async () => {
     const sendMedia = vi.fn().mockResolvedValue({
       channel: "testchat",

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -18,6 +18,7 @@ import type { OutboundMediaAccess } from "../../media/load-options.js";
 import type { PollInput } from "../../polls.js";
 import { normalizePollInput } from "../../polls.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
+import { GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import type { DeliveryQueueCompletionRetention } from "../delivery-queue-sqlite.js";
 import { formatErrorMessage } from "../errors.js";
 import { resolveMessageChannelSelection } from "./channel-selection.js";
@@ -476,7 +477,9 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
           }
         : undefined,
     });
-    if (!params.bestEffort && (send.status === "failed" || send.status === "partial_failed")) {
+    const shouldThrowFailure =
+      !params.bestEffort && params.gateway?.clientName !== GATEWAY_CLIENT_NAMES.CLI;
+    if (shouldThrowFailure && (send.status === "failed" || send.status === "partial_failed")) {
       throw send.error;
     }
     const results = send.status === "sent" || send.status === "partial_failed" ? send.results : [];


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #129202.

The CLI lost durable `failed` and `partial_failed` core-send results because the sender threw before JSON formatting could read them. Operators saw only a generic error and lost the delivery status, partial-send marker, and successful message ID.

## Why This Change Was Made

The durable sender remains the terminal outcome owner. It returns structured terminal failures only when the explicit caller identity is the CLI. Non-CLI callers keep the existing throwing contract. Queue, retry, recovery, batch-stop, and best-effort policies do not change.

## User Impact

`openclaw message send --json` now exits 1 and returns the structured delivery failure. A partial send also reports `sentBeforeError: true` and the successful message ID.

## Evidence

- Exact current-main RED (`8d51e415d6a`): a real Discord CLI send with a synthetic invalid token reached Discord and received 401. The CLI exited 1 without structured JSON.
- Exact current-main RED (`8d51e415d6a`): a real Discord CLI media send posted its randomized caption, then rejected a blocked video URL. The CLI exited 1 without `partial_failed`, `sentBeforeError`, or the successful message ID.
- Patch-identical live GREEN (`456838db637`), retained for final head `64e00b7f1fa`: the same cases exited 1 with structured `failed` and `partial_failed` JSON. The partial result included `sentBeforeError: true` and the successful message ID.
- Anti-cheat and cleanup: the partial case found the randomized caption through Discord after the media failure and deleted it after each run.
- Regression proof: the two new CLI cases fail on current main and pass on the repaired head. The non-CLI throw case passes on both.
- Focused validation: 88 owner/caller tests and 121 queue, retry, recovery, and sibling-policy tests passed. Formatting, focused lint, production type-check, build, and diff checks passed.
- Exact-head gates: CI run `33153895617` passed after one infrastructure-only package-boundary timeout retry. Local ClawSweeper passed on `64e00b7f1fa` with no findings, security concerns, maintainer decisions, or rank-up moves.
- Production delta: +4/-1. The repair uses the existing explicit CLI identity at the durable-result owner and removes the incoming cross-layer policy flag.
