### PR TITLE
fix(agents): allow requester continuation after settle

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -931,6 +931,8 @@ describe("createCodexDynamicToolBridge", () => {
         status: "accepted",
         runId: "run_5f3a9c",
         childSessionKey: "child-7b21",
+        expectsCompletionMessage: true,
+        inlineDelivery: false,
         mode: "run",
       }),
     );
@@ -957,7 +959,12 @@ describe("createCodexDynamicToolBridge", () => {
       expect.objectContaining({ toolName: "sessions_spawn", isError: false }),
     );
     expect(bridge.telemetry.acceptedSessionSpawns).toEqual([
-      { runId: "run_5f3a9c", childSessionKey: "child-7b21" },
+      {
+        runId: "run_5f3a9c",
+        childSessionKey: "child-7b21",
+        expectsCompletionMessage: true,
+        inlineDelivery: false,
+      },
     ]);
   });
 
@@ -985,6 +992,8 @@ describe("createCodexDynamicToolBridge", () => {
         status: "accepted",
         runId: "run_compacted",
         childSessionKey: "child-compacted",
+        expectsCompletionMessage: false,
+        inlineDelivery: true,
       }),
     );
 
@@ -999,7 +1008,12 @@ describe("createCodexDynamicToolBridge", () => {
 
     expect(result).toEqual(expectInputText("Child launch recorded."));
     expect(bridge.telemetry.acceptedSessionSpawns).toEqual([
-      { runId: "run_compacted", childSessionKey: "child-compacted" },
+      {
+        runId: "run_compacted",
+        childSessionKey: "child-compacted",
+        expectsCompletionMessage: false,
+        inlineDelivery: true,
+      },
     ]);
   });
 
@@ -1983,6 +1997,8 @@ describe("createCodexDynamicToolBridge", () => {
                   status: "accepted",
                   runId: "child-run",
                   childSessionKey: "child-session",
+                  expectsCompletionMessage: true,
+                  inlineDelivery: false,
                 });
       const outer = new AbortController();
       const bridge = createCodexDynamicToolBridge({
@@ -2033,7 +2049,12 @@ describe("createCodexDynamicToolBridge", () => {
           expect(bridge.telemetry.successfulCronAdds).toBe(1);
         } else {
           expect(bridge.telemetry.acceptedSessionSpawns).toEqual([
-            { runId: "child-run", childSessionKey: "child-session" },
+            {
+              runId: "child-run",
+              childSessionKey: "child-session",
+              expectsCompletionMessage: true,
+              inlineDelivery: false,
+            },
           ]);
         }
       } finally {

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -439,7 +439,12 @@ export type CodexDynamicToolBridge = {
     coreTtsToolResults: object[];
     toolAudioAsVoice: boolean;
     successfulCronAdds?: number;
-    acceptedSessionSpawns: Array<{ runId: string; childSessionKey: string }>;
+    acceptedSessionSpawns: Array<{
+      runId: string;
+      childSessionKey: string;
+      expectsCompletionMessage: boolean;
+      inlineDelivery: boolean;
+    }>;
     quarantinedTools: CodexDynamicToolSchemaQuarantine[];
   };
 };
@@ -447,6 +452,8 @@ export type CodexDynamicToolBridge = {
 function normalizeAcceptedSessionSpawn(result: unknown): {
   runId: string;
   childSessionKey: string;
+  expectsCompletionMessage: boolean;
+  inlineDelivery: boolean;
 } | null {
   const details = asOptionalRecord(asOptionalRecord(result)?.details);
   if (!details || details.status !== "accepted") {
@@ -454,7 +461,14 @@ function normalizeAcceptedSessionSpawn(result: unknown): {
   }
   const runId = normalizeOptionalString(details.runId);
   const childSessionKey = normalizeOptionalString(details.childSessionKey);
-  return runId && childSessionKey ? { runId, childSessionKey } : null;
+  return runId && childSessionKey
+    ? {
+        runId,
+        childSessionKey,
+        expectsCompletionMessage: details.expectsCompletionMessage === true,
+        inlineDelivery: details.inlineDelivery === true,
+      }
+    : null;
 }
 
 const EXPLICIT_MESSAGE_PROVIDER_KEYS = ["channel", "provider"];

--- a/extensions/codex/src/app-server/event-projector.commentary.test.ts
+++ b/extensions/codex/src/app-server/event-projector.commentary.test.ts
@@ -705,7 +705,12 @@ describe("CodexAppServerEventProjector commentary projection", () => {
       {
         ...buildEmptyToolTelemetry(),
         acceptedSessionSpawns: [
-          { runId: "child-run", childSessionKey: "agent:main:subagent:child" },
+          {
+            runId: "child-run",
+            childSessionKey: "agent:main:subagent:child",
+            expectsCompletionMessage: true,
+            inlineDelivery: false,
+          },
         ],
       },
       { yieldDetected: true },
@@ -713,7 +718,12 @@ describe("CodexAppServerEventProjector commentary projection", () => {
 
     expect(result.yieldDetected).toBe(true);
     expect(result.acceptedSessionSpawns).toEqual([
-      { runId: "child-run", childSessionKey: "agent:main:subagent:child" },
+      {
+        runId: "child-run",
+        childSessionKey: "agent:main:subagent:child",
+        expectsCompletionMessage: true,
+        inlineDelivery: false,
+      },
     ]);
     expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
   });

--- a/extensions/copilot/src/attempt-execution.ts
+++ b/extensions/copilot/src/attempt-execution.ts
@@ -298,6 +298,7 @@ export async function runCopilotExecution(context: {
                 childSessionKey,
                 expectsCompletionMessage:
                   acceptedSessionSpawnDetails.expectsCompletionMessage === true,
+                inlineDelivery: acceptedSessionSpawnDetails.inlineDelivery === true,
               });
             }
             await runAgentHarnessAfterToolCallHook({

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -1949,6 +1949,7 @@ describe("runCopilotAttempt", () => {
               runId: "run-copilot-child",
               childSessionKey: "agent:main:subagent:copilot-child",
               expectsCompletionMessage: true,
+              inlineDelivery: false,
             },
           },
           startedAt: Date.now(),
@@ -1977,6 +1978,7 @@ describe("runCopilotAttempt", () => {
         runId: "run-copilot-child",
         childSessionKey: "agent:main:subagent:copilot-child",
         expectsCompletionMessage: true,
+        inlineDelivery: false,
       },
     ]);
   });

--- a/extensions/qa-lab/src/plugin-requester-settle-sequential-waves.e2e.test.ts
+++ b/extensions/qa-lab/src/plugin-requester-settle-sequential-waves.e2e.test.ts
@@ -1,0 +1,105 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startQaBusServer } from "./bus-server.js";
+import { createQaBusState } from "./bus-state.js";
+import { createQaGatewayChild } from "./gateway-child.js";
+import {
+  QA_REQUESTER_SETTLE_FINAL_MARKER,
+  QA_REQUESTER_SETTLE_WAVE_ONE_MARKER,
+  QA_REQUESTER_SETTLE_WAVE_TWO_MARKER,
+} from "./providers/mock-openai/mock-openai-contracts.js";
+import { startQaMockOpenAiServer } from "./providers/mock-openai/server.js";
+import { createQaChannelTransport } from "./qa-channel-transport.js";
+
+const TRIGGER =
+  "Requester settle sequential waves QA check. Complete both waves before the final answer.";
+const REQUESTER_CONVERSATION = { id: "requester-user", kind: "direct" as const };
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+
+describe("requester-settle sequential waves", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.splice(0).toReversed()) {
+      await cleanup();
+    }
+  });
+
+  it("spawns Wave 2 after Wave 1 settles and emits one final reply", async () => {
+    const state = createQaBusState();
+    const transport = createQaChannelTransport(state);
+    const bus = await startQaBusServer({ state });
+    cleanups.push(() => bus.stop());
+
+    const mock = await startQaMockOpenAiServer();
+    cleanups.push(() => mock.stop());
+
+    const gatewayOwner = createQaGatewayChild();
+    cleanups.push(async () => {
+      expect((await gatewayOwner.stop()).errors).toEqual([]);
+    });
+    const gateway = await gatewayOwner.start({
+      repoRoot: REPO_ROOT,
+      useRepoCli: true,
+      providerBaseUrl: `${mock.baseUrl}/v1`,
+      providerMode: "mock-openai",
+      transport,
+      transportBaseUrl: bus.baseUrl,
+      controlUiEnabled: false,
+    });
+    await transport.waitReady({ gateway });
+
+    const outboundStartIndex = state
+      .getSnapshot()
+      .messages.filter((message) => message.direction === "outbound").length;
+    await transport.sendInbound({
+      accountId: "default",
+      conversation: REQUESTER_CONVERSATION,
+      senderId: REQUESTER_CONVERSATION.id,
+      text: TRIGGER,
+    });
+
+    try {
+      const completion = await transport.waitForOutbound({
+        conversation: REQUESTER_CONVERSATION,
+        sinceIndex: outboundStartIndex,
+        timeoutMs: 45_000,
+      });
+      expect(completion.text).toContain(QA_REQUESTER_SETTLE_FINAL_MARKER);
+    } catch (error) {
+      throw new Error(
+        [
+          error instanceof Error ? error.message : String(error),
+          `bus=${JSON.stringify(state.getSnapshot())}`,
+          `gateway=${gateway.logs()}`,
+        ].join("\n"),
+        { cause: error },
+      );
+    }
+
+    const response = await fetch(`${mock.baseUrl}/debug/requests`);
+    expect(response.status).toBe(200);
+    const requests = (await response.json()) as Array<{
+      plannedToolArgs?: { label?: string };
+      plannedToolName?: string;
+    }>;
+    const spawnLabels = requests
+      .filter((request) => request.plannedToolName === "sessions_spawn")
+      .map((request) => request.plannedToolArgs?.label);
+    expect(spawnLabels).toContain("qa-requester-settle-wave-one");
+    expect(spawnLabels).toContain("qa-requester-settle-wave-two");
+
+    const outbound = state
+      .getSnapshot()
+      .messages.filter((message) => message.direction === "outbound");
+    expect(
+      outbound.filter((message) => message.text.includes(QA_REQUESTER_SETTLE_FINAL_MARKER)),
+    ).toHaveLength(1);
+    expect(
+      outbound.some((message) => message.text.includes(QA_REQUESTER_SETTLE_WAVE_ONE_MARKER)),
+    ).toBe(false);
+    expect(
+      outbound.some((message) => message.text.includes(QA_REQUESTER_SETTLE_WAVE_TWO_MARKER)),
+    ).toBe(false);
+  }, 180_000);
+});

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -379,6 +379,16 @@ export function isStrandedFinalRetryFailureRequest(allInputText: string): boolea
 }
 export const QA_SUBAGENT_DIRECT_FALLBACK_MARKER = "QA-SUBAGENT-DIRECT-FALLBACK-OK";
 export const QA_SUBAGENT_SELF_YIELD_MARKER = "QA-SUBAGENT-SELF-YIELD-FOLLOW-UP-OK";
+export const QA_REQUESTER_SETTLE_SEQUENTIAL_PROMPT_RE =
+  /requester settle sequential waves qa check/i;
+export const QA_REQUESTER_SETTLE_WAVE_ONE_WORKER_RE =
+  /requester settle sequential wave one worker/i;
+export const QA_REQUESTER_SETTLE_WAVE_TWO_WORKER_RE =
+  /requester settle sequential wave two worker/i;
+export const QA_REQUESTER_SETTLE_WAVE_ONE_MARKER = "QA-REQUESTER-SETTLE-WAVE-ONE-OK";
+export const QA_REQUESTER_SETTLE_WAVE_TWO_MARKER = "QA-REQUESTER-SETTLE-WAVE-TWO-OK";
+export const QA_REQUESTER_SETTLE_FINAL_MARKER = "QA-REQUESTER-SETTLE-FINAL-OK";
+export const QA_REQUESTER_SETTLE_PREMATURE_FINAL_MARKER = "QA-REQUESTER-SETTLE-PREMATURE-FINAL";
 export const QA_SUBAGENT_TERMINAL_MARKERS = {
   visible: "QA-SUBAGENT-TERMINAL-VISIBLE-OK",
   silent: "QA-SUBAGENT-TERMINAL-SILENT-REPRESENTED",
@@ -428,6 +438,7 @@ export type MockScenarioState = {
   subagentFanoutPhase: number;
   subagentHandoffSpawned: boolean;
   repeatedRequestRecoveryAttempts: number;
+  requesterSettleSequentialWave: 0 | 1 | 2;
   toolLoopReadAttempts: number;
 };
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -92,6 +92,13 @@ import {
   isStrandedFinalRetryFailureRequest,
   QA_SUBAGENT_DIRECT_FALLBACK_MARKER,
   QA_SUBAGENT_SELF_YIELD_MARKER,
+  QA_REQUESTER_SETTLE_FINAL_MARKER,
+  QA_REQUESTER_SETTLE_PREMATURE_FINAL_MARKER,
+  QA_REQUESTER_SETTLE_SEQUENTIAL_PROMPT_RE,
+  QA_REQUESTER_SETTLE_WAVE_ONE_MARKER,
+  QA_REQUESTER_SETTLE_WAVE_ONE_WORKER_RE,
+  QA_REQUESTER_SETTLE_WAVE_TWO_MARKER,
+  QA_REQUESTER_SETTLE_WAVE_TWO_WORKER_RE,
   QA_SUBAGENT_TERMINAL_MARKERS,
   QA_SUBAGENT_TERMINAL_METADATA_SENTINEL,
   QA_NATIVE_STOP_DELAY_PROMPT_RE,
@@ -1384,6 +1391,66 @@ async function buildResponsesPayload(
     return buildToolCallEventsWithArgs("sessions_yield", {
       message: "Waiting for the remote job to report back.",
     });
+  }
+  if (QA_REQUESTER_SETTLE_WAVE_ONE_WORKER_RE.test(prompt)) {
+    return buildAssistantEvents(QA_REQUESTER_SETTLE_WAVE_ONE_MARKER);
+  }
+  if (QA_REQUESTER_SETTLE_WAVE_TWO_WORKER_RE.test(prompt)) {
+    return buildAssistantEvents(QA_REQUESTER_SETTLE_WAVE_TWO_MARKER);
+  }
+  if (QA_REQUESTER_SETTLE_SEQUENTIAL_PROMPT_RE.test(allInputText)) {
+    const isSettleWake = /Every subagent spawned from this session has now settled/i.test(prompt);
+    if (isSettleWake && prompt.includes(QA_REQUESTER_SETTLE_WAVE_TWO_MARKER)) {
+      return buildAssistantEvents(QA_REQUESTER_SETTLE_FINAL_MARKER);
+    }
+    if (isSettleWake && prompt.includes(QA_REQUESTER_SETTLE_WAVE_ONE_MARKER)) {
+      if (/send your consolidated final answer to the user now/i.test(prompt)) {
+        return buildAssistantEvents(QA_REQUESTER_SETTLE_PREMATURE_FINAL_MARKER);
+      }
+      if (
+        /If additional action is required, continue the task/i.test(prompt) &&
+        scenarioState.requesterSettleSequentialWave === 1 &&
+        canCallSessionsSpawn
+      ) {
+        scenarioState.requesterSettleSequentialWave = 2;
+        return buildToolCallEventsWithArgs("sessions_spawn", {
+          task: `Requester settle sequential wave two worker: reply exactly ${QA_REQUESTER_SETTLE_WAVE_TWO_MARKER}.`,
+          label: "qa-requester-settle-wave-two",
+          thread: false,
+          mode: "run",
+        });
+      }
+      if (
+        scenarioState.requesterSettleSequentialWave === 2 &&
+        hasCompletedToolOutput &&
+        canCallSessionsYield &&
+        !/\byielded\b/i.test(toolOutput)
+      ) {
+        return buildToolCallEventsWithArgs("sessions_yield", {
+          message: `Waiting for ${QA_REQUESTER_SETTLE_WAVE_TWO_MARKER}.`,
+        });
+      }
+      return buildAssistantEvents("NO_REPLY");
+    }
+    if (scenarioState.requesterSettleSequentialWave === 0 && canCallSessionsSpawn) {
+      scenarioState.requesterSettleSequentialWave = 1;
+      return buildToolCallEventsWithArgs("sessions_spawn", {
+        task: `Requester settle sequential wave one worker: reply exactly ${QA_REQUESTER_SETTLE_WAVE_ONE_MARKER}.`,
+        label: "qa-requester-settle-wave-one",
+        thread: false,
+        mode: "run",
+      });
+    }
+    if (
+      scenarioState.requesterSettleSequentialWave === 1 &&
+      hasCompletedToolOutput &&
+      canCallSessionsYield &&
+      !/\byielded\b/i.test(toolOutput)
+    ) {
+      return buildToolCallEventsWithArgs("sessions_yield", {
+        message: `Waiting for ${QA_REQUESTER_SETTLE_WAVE_ONE_MARKER}.`,
+      });
+    }
   }
   const terminalCompletionCase = extractLastMatchingUserTurn(
     input,
@@ -2706,6 +2773,7 @@ export async function startQaMockOpenAiServer(params?: {
       subagentFanoutPhase: 0,
       subagentHandoffSpawned: false,
       repeatedRequestRecoveryAttempts: 0,
+      requesterSettleSequentialWave: 0,
       toolLoopReadAttempts: 0,
     };
     scenarioStates.set(key, state);

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1408,7 +1408,7 @@ async function buildResponsesPayload(
         return buildAssistantEvents(QA_REQUESTER_SETTLE_PREMATURE_FINAL_MARKER);
       }
       if (
-        /If additional action is required, continue the task/i.test(prompt) &&
+        /If additional action is required, continue any remaining in-scope work/i.test(prompt) &&
         scenarioState.requesterSettleSequentialWave === 1 &&
         canCallSessionsSpawn
       ) {

--- a/src/agents/accepted-session-spawn.ts
+++ b/src/agents/accepted-session-spawn.ts
@@ -44,14 +44,3 @@ export function hasCompletionMessageSessionSpawn(
 ): boolean {
   return acceptedSessionSpawns?.some((spawn) => spawn.expectsCompletionMessage === true) === true;
 }
-
-/** Return true when an accepted child owns completion or direct channel delivery. */
-export function hasContinuationSessionSpawn(
-  acceptedSessionSpawns?: readonly AcceptedSessionSpawn[],
-): boolean {
-  return (
-    acceptedSessionSpawns?.some(
-      (spawn) => spawn.expectsCompletionMessage === true || spawn.inlineDelivery === true,
-    ) === true
-  );
-}

--- a/src/agents/accepted-session-spawn.ts
+++ b/src/agents/accepted-session-spawn.ts
@@ -8,6 +8,8 @@ export type AcceptedSessionSpawn = {
   childSessionKey: string;
   /** True only when this child owns a terminal completion for its requester. */
   expectsCompletionMessage?: boolean;
+  /** True when the child delivers directly to its bound channel instead. */
+  inlineDelivery?: boolean;
 };
 
 /** Normalize a tool result that accepted a child session spawn. */
@@ -25,6 +27,7 @@ export function normalizeAcceptedSessionSpawnResult(result: unknown): AcceptedSe
     runId,
     childSessionKey,
     expectsCompletionMessage: details.expectsCompletionMessage === true,
+    inlineDelivery: details.inlineDelivery === true,
   };
 }
 
@@ -40,4 +43,15 @@ export function hasCompletionMessageSessionSpawn(
   acceptedSessionSpawns?: readonly AcceptedSessionSpawn[],
 ): boolean {
   return acceptedSessionSpawns?.some((spawn) => spawn.expectsCompletionMessage === true) === true;
+}
+
+/** Return true when an accepted child owns completion or direct channel delivery. */
+export function hasContinuationSessionSpawn(
+  acceptedSessionSpawns?: readonly AcceptedSessionSpawn[],
+): boolean {
+  return (
+    acceptedSessionSpawns?.some(
+      (spawn) => spawn.expectsCompletionMessage === true || spawn.inlineDelivery === true,
+    ) === true
+  );
 }

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -495,13 +495,11 @@ describe("deliverAgentCommandResult payload normalization", () => {
   });
 
   it("normalizes reply-media paths before outbound delivery", async () => {
-    const normalizerFn = vi.fn(
-      async (payload: ReplyPayload): Promise<ReplyPayload> => ({
-        ...payload,
-        mediaUrl: "/tmp/agent-workspace/out/photo.png",
-        mediaUrls: ["/tmp/agent-workspace/out/photo.png"],
-      }),
-    );
+    const normalizerFn = vi.fn(async (payload: ReplyPayload): Promise<ReplyPayload> => ({
+      ...payload,
+      mediaUrl: "/tmp/agent-workspace/out/photo.png",
+      mediaUrls: ["/tmp/agent-workspace/out/photo.png"],
+    }));
     createReplyMediaPathNormalizerMock.mockReturnValue(normalizerFn);
     deliverOutboundPayloadsMock.mockResolvedValue([]);
 

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -495,11 +495,13 @@ describe("deliverAgentCommandResult payload normalization", () => {
   });
 
   it("normalizes reply-media paths before outbound delivery", async () => {
-    const normalizerFn = vi.fn(async (payload: ReplyPayload): Promise<ReplyPayload> => ({
-      ...payload,
-      mediaUrl: "/tmp/agent-workspace/out/photo.png",
-      mediaUrls: ["/tmp/agent-workspace/out/photo.png"],
-    }));
+    const normalizerFn = vi.fn(
+      async (payload: ReplyPayload): Promise<ReplyPayload> => ({
+        ...payload,
+        mediaUrl: "/tmp/agent-workspace/out/photo.png",
+        mediaUrls: ["/tmp/agent-workspace/out/photo.png"],
+      }),
+    );
     createReplyMediaPathNormalizerMock.mockReturnValue(normalizerFn);
     deliverOutboundPayloadsMock.mockResolvedValue([]);
 
@@ -807,6 +809,12 @@ describe("deliverAgentCommandResult payload normalization", () => {
       },
       field: "acceptedSessionSpawns",
       expected: [{ runId: "child-run", childSessionKey: "agent:main:subagent:child" }],
+    },
+    {
+      name: "runtime-owned continuation",
+      result: { runtimeContinuationStarted: true },
+      field: "runtimeContinuationStarted",
+      expected: true,
     },
     {
       name: "successful cron add",

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -114,6 +114,7 @@ type AgentCommandDeliveryResult = {
   messagingToolSentTargets?: MessagingToolSend[];
   didSendDeterministicApprovalPrompt?: true;
   acceptedSessionSpawns?: NonNullable<RunResult["acceptedSessionSpawns"]>;
+  runtimeContinuationStarted?: true;
   successfulCronAdds?: number;
   deliverySucceeded?: boolean;
   deliveryStatus?: AgentCommandDeliveryStatus;
@@ -232,6 +233,9 @@ function buildDeliveryResult(params: {
       : {}),
     ...(hasNonEmptyArray(params.result.acceptedSessionSpawns)
       ? { acceptedSessionSpawns: params.result.acceptedSessionSpawns }
+      : {}),
+    ...(params.result.runtimeContinuationStarted === true
+      ? { runtimeContinuationStarted: true }
       : {}),
     ...(hasSuccessfulCronAdds ? { successfulCronAdds } : {}),
     ...(params.deliverySucceeded !== undefined

--- a/src/agents/embedded-agent-runner/delivery-evidence.ts
+++ b/src/agents/embedded-agent-runner/delivery-evidence.ts
@@ -115,7 +115,7 @@ function hasNonEmptyArray(value: unknown): boolean {
   return Array.isArray(value) && value.length > 0;
 }
 
-export function hasAcceptedSessionSpawnEvidence(value: unknown): boolean {
+function hasAcceptedSessionSpawnEvidence(value: unknown): boolean {
   return Array.isArray(value)
     ? value.some((entry) => {
         const spawn = asOptionalRecord(entry);

--- a/src/agents/embedded-agent-runner/delivery-evidence.ts
+++ b/src/agents/embedded-agent-runner/delivery-evidence.ts
@@ -124,6 +124,19 @@ export function hasAcceptedSessionSpawnEvidence(value: unknown): boolean {
     : false;
 }
 
+export function hasContinuationSessionSpawnEvidence(value: unknown): boolean {
+  return Array.isArray(value)
+    ? value.some((entry) => {
+        const spawn = asOptionalRecord(entry);
+        return (
+          hasNonEmptyString(spawn?.runId) &&
+          hasNonEmptyString(spawn?.childSessionKey) &&
+          (spawn?.expectsCompletionMessage === true || spawn?.inlineDelivery === true)
+        );
+      })
+    : false;
+}
+
 function collectStringValues(value: unknown, output: Set<string>) {
   if (typeof value === "string" && value.trim()) {
     output.add(value.trim());

--- a/src/agents/embedded-agent-runner/delivery-evidence.ts
+++ b/src/agents/embedded-agent-runner/delivery-evidence.ts
@@ -36,6 +36,7 @@ export type AgentDeliveryEvidence = {
   /** Durable recovery evidence sets this when its bounded target projection omitted entries. */
   messagingToolSentTargetsTruncated?: unknown;
   acceptedSessionSpawns?: unknown;
+  runtimeContinuationStarted?: unknown;
   successfulCronAdds?: unknown;
   meta?: {
     toolSummary?: {
@@ -114,7 +115,7 @@ function hasNonEmptyArray(value: unknown): boolean {
   return Array.isArray(value) && value.length > 0;
 }
 
-function hasAcceptedSessionSpawnEvidence(value: unknown): boolean {
+export function hasAcceptedSessionSpawnEvidence(value: unknown): boolean {
   return Array.isArray(value)
     ? value.some((entry) => {
         const spawn = asOptionalRecord(entry);
@@ -409,6 +410,7 @@ function hasAgentDeliveryEvidenceShape(value: object): boolean {
     "messagingToolSentMediaUrls" in value ||
     "messagingToolSentTargets" in value ||
     "acceptedSessionSpawns" in value ||
+    "runtimeContinuationStarted" in value ||
     "successfulCronAdds" in value ||
     "meta" in value
   );
@@ -549,10 +551,14 @@ export function hasVisibleOutboundDeliveryEvidence(result: AgentDeliveryEvidence
 
 /** Returns whether committed non-messaging resource effects make replay unsafe. */
 function hasCommittedNonMessagingOutboundDeliveryEvidence(
-  result: Pick<AgentDeliveryEvidence, "acceptedSessionSpawns" | "successfulCronAdds">,
+  result: Pick<
+    AgentDeliveryEvidence,
+    "acceptedSessionSpawns" | "runtimeContinuationStarted" | "successfulCronAdds"
+  >,
 ): boolean {
   return (
     hasAcceptedSessionSpawnEvidence(result.acceptedSessionSpawns) ||
+    result.runtimeContinuationStarted === true ||
     hasPositiveNumber(result.successfulCronAdds)
   );
 }

--- a/src/agents/embedded-agent-runner/run/attempt-delivery-state.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-delivery-state.ts
@@ -15,5 +15,6 @@ export function copyAttemptDeliveryState(attempt: EmbeddedRunAttemptResult) {
     heartbeatToolResponse: attempt.heartbeatToolResponse,
     successfulCronAdds: attempt.successfulCronAdds,
     acceptedSessionSpawns: attempt.acceptedSessionSpawns,
+    runtimeContinuationStarted: attempt.runtimeContinuationStarted,
   };
 }

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -278,6 +278,8 @@ export type EmbeddedAgentRunResult = {
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
   // Child sessions successfully accepted by sessions_spawn during the run.
   acceptedSessionSpawns?: AcceptedSessionSpawn[];
+  // Native harness work whose future output has a runtime-owned delivery path.
+  runtimeContinuationStarted?: boolean;
   // Structured heartbeat outcome recorded by the heartbeat response tool.
   heartbeatToolResponse?: HeartbeatToolResponse;
   // Count of successful cron.add tool calls in this run.

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -1528,6 +1528,7 @@ describe("handleToolExecutionEnd sessions_spawn terminal success tracking", () =
         runId: "run-child",
         childSessionKey: "agent:claude:subagent:child",
         expectsCompletionMessage: true,
+        inlineDelivery: false,
       },
     ]);
     expect(ctx.state.replayState).toEqual({

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -2401,6 +2401,7 @@ describe("subscribeEmbeddedAgentSession", () => {
         runId: "run-child",
         childSessionKey: "agent:claude:subagent:child",
         expectsCompletionMessage: true,
+        inlineDelivery: false,
       },
     ]);
 

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -5446,12 +5446,26 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   ];
 
   it.each(
-    requesterSettleCases.flatMap((testCase) =>
-      (testCase.routes ?? [externalRequesterSettleRoute]).map((route) => ({
-        testCase,
-        route,
-      })),
-    ),
+    requesterSettleCases
+      .flatMap((testCase) =>
+        testCase.requireVisibleReply
+          ? [
+              testCase,
+              {
+                ...testCase,
+                name: `continuation: ${testCase.name}`,
+                requireVisibleReply: false,
+                requireContinuationProgress: true,
+              },
+            ]
+          : [testCase],
+      )
+      .flatMap((testCase) =>
+        (testCase.routes ?? [externalRequesterSettleRoute]).map((route) => ({
+          testCase,
+          route,
+        })),
+      ),
   )("$route.name: $testCase.name", async ({ testCase, route }) => {
     const { response, requireVisibleReply, requireContinuationProgress, expected } = testCase;
     const callGateway = createGatewayMock(response);

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -4911,14 +4911,42 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     path: "direct",
     reason: "visible_reply_missing",
   } as const;
+  const pendingRequesterFinal = {
+    delivered: false,
+    path: "direct",
+    disposition: "agent_run_pending",
+  } as const;
 
-  const externalRequesterSettleRoute = {
+  type RequesterSettleRoute = {
+    name: string;
+    sessionKey: string;
+    origin?: { channel?: string; to?: string; accountId?: string };
+    requesterIsSubagent?: boolean;
+    agentParams: {
+      deliver: boolean;
+      channel: string | undefined;
+      accountId: string | undefined;
+      to: string | undefined;
+    };
+  };
+
+  type RequesterSettleDeliveryCase = {
+    name: string;
+    response: Record<string, unknown>;
+    routes?: readonly RequesterSettleRoute[];
+    requireVisibleReply: boolean;
+    requireContinuationProgress?: boolean;
+    recordsVisibleFinal?: boolean;
+    expected: Readonly<Record<string, unknown>>;
+  };
+
+  const externalRequesterSettleRoute: RequesterSettleRoute = {
     name: "Discord",
     sessionKey: "agent:main:discord:dm:U123",
     origin: { channel: "discord", to: "dm:U123", accountId: "acct-1" },
     agentParams: { deliver: true, channel: "discord", accountId: "acct-1", to: "dm:U123" },
   };
-  const requesterSettleRoutes = [
+  const requesterSettleRoutes: readonly RequesterSettleRoute[] = [
     externalRequesterSettleRoute,
     {
       name: "no origin",
@@ -4941,13 +4969,13 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     },
   ];
 
-  const requesterSettleCases = [
+  const requesterSettleCases: RequesterSettleDeliveryCase[] = [
     ...["accepted", "in_flight"].map((status) => ({
       name: `does not record ${status} handoff as a visible final`,
       routes: requesterSettleRoutes,
       response: { status },
       requireVisibleReply: true,
-      expected: deliveredRequesterFinal,
+      expected: pendingRequesterFinal,
     })),
     {
       name: "does not record a canceled partial answer as a visible final",
@@ -4959,7 +4987,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     {
       name: "records a non-yielded visible final without requiring a reply",
       routes: requesterSettleRoutes.slice(1),
-      response: { result: { payloads: [{ text: "The consolidated answer." }] } },
+      response: { status: "ok", result: { payloads: [{ text: "The consolidated answer." }] } },
       requireVisibleReply: false,
       recordsVisibleFinal: true,
       expected: deliveredRequesterFinal,
@@ -4980,7 +5008,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       name: "accepts a yielded requester's visible final answer",
       recordsVisibleFinal: true,
       routes: requesterSettleRoutes.slice(1),
-      response: { result: { payloads: [{ text: "The consolidated answer." }] } },
+      response: { status: "ok", result: { payloads: [{ text: "The consolidated answer." }] } },
       requireVisibleReply: true,
       expected: deliveredRequesterFinal,
     },
@@ -5189,6 +5217,46 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expected: missingRequesterFinal,
     },
     {
+      name: "accepts a follow-on subagent spawn when the settle turn may continue",
+      response: {
+        result: {
+          payloads: [],
+          acceptedSessionSpawns: [{ runId: "run-next", childSessionKey: "agent:main:next" }],
+        },
+      },
+      requireVisibleReply: false,
+      requireContinuationProgress: true,
+      expected: deliveredRequesterFinal,
+    },
+    {
+      name: "accepts a Codex native continuation owned by the runtime",
+      response: { result: { payloads: [], runtimeContinuationStarted: true } },
+      requireVisibleReply: false,
+      requireContinuationProgress: true,
+      expected: deliveredRequesterFinal,
+    },
+    ...(["accepted", "started", "in_flight"] as const).map((status) => ({
+      name: `keeps a ${status} continuation turn pending`,
+      response: { status },
+      requireVisibleReply: false,
+      requireContinuationProgress: true,
+      expected: pendingRequesterFinal,
+    })),
+    {
+      name: "rejects an empty continuation turn",
+      response: {},
+      requireVisibleReply: false,
+      requireContinuationProgress: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects a silent continuation turn",
+      response: { result: { payloads: [{ text: "NO_REPLY" }] } },
+      requireVisibleReply: false,
+      requireContinuationProgress: true,
+      expected: missingRequesterFinal,
+    },
+    {
       name: "rejects a cron side effect without a final reply",
       response: { result: { payloads: [], successfulCronAdds: 1 } },
       requireVisibleReply: true,
@@ -5342,8 +5410,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       })),
     ),
   )("$route.name: $testCase.name", async ({ testCase, route }) => {
-    const { response, requireVisibleReply, expected } = testCase;
-    const callGateway = createGatewayMock({ status: "ok", ...response });
+    const { response, requireVisibleReply, requireContinuationProgress, expected } = testCase;
+    const callGateway = createGatewayMock(response);
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
     const sendMessage = createSendMessageMock();
     const origin = route.origin;
@@ -5369,6 +5437,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       requesterIsSubagent: "requesterIsSubagent" in route && route.requesterIsSubagent === true,
       expectsCompletionMessage: false,
       requireDirectDelivery: true,
+      ...(requireContinuationProgress ? { requireContinuationProgress: true } : {}),
       ...(requireVisibleReply ? { requireVisibleReply: true } : {}),
       directIdempotencyKey: "announce-requester-settle-direct",
       sourceTool: "subagent_announce",
@@ -5386,7 +5455,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
     const agentParams = expectGatewayAgentParams(callGateway, route.agentParams);
     expect(agentParams.sourceReplyDeliveryMode).toBe(
-      requireVisibleReply && route.agentParams.deliver ? "automatic" : undefined,
+      (requireVisibleReply || requireContinuationProgress) && route.agentParams.deliver
+        ? "automatic"
+        : undefined,
     );
   });
 

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -5221,7 +5221,50 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       response: {
         result: {
           payloads: [],
-          acceptedSessionSpawns: [{ runId: "run-next", childSessionKey: "agent:main:next" }],
+          acceptedSessionSpawns: [
+            {
+              runId: "run-next",
+              childSessionKey: "agent:main:next",
+              expectsCompletionMessage: true,
+            },
+          ],
+        },
+      },
+      requireVisibleReply: false,
+      requireContinuationProgress: true,
+      expected: deliveredRequesterFinal,
+    },
+    {
+      name: "does not treat a fire-and-forget spawn as requester continuation",
+      response: {
+        result: {
+          payloads: [],
+          acceptedSessionSpawns: [
+            {
+              runId: "run-background",
+              childSessionKey: "agent:main:background",
+              expectsCompletionMessage: false,
+            },
+          ],
+        },
+      },
+      requireVisibleReply: false,
+      requireContinuationProgress: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "accepts inline ACP delivery as requester continuation",
+      response: {
+        result: {
+          payloads: [],
+          acceptedSessionSpawns: [
+            {
+              runId: "run-inline",
+              childSessionKey: "agent:main:acp:inline",
+              expectsCompletionMessage: false,
+              inlineDelivery: true,
+            },
+          ],
         },
       },
       requireVisibleReply: false,

--- a/src/agents/subagents/announce/subagent-announce-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.ts
@@ -154,6 +154,7 @@ export async function deliverSubagentAnnouncement(params: {
   requesterIsSubagent: boolean;
   expectsCompletionMessage: boolean;
   requireDirectDelivery?: boolean;
+  requireContinuationProgress?: boolean;
   requireVisibleReply?: boolean;
   bestEffortDeliver?: boolean;
   directIdempotencyKey: string;
@@ -321,6 +322,7 @@ export async function deliverSubagentAnnouncement(params: {
         requesterIsSubagent: params.requesterIsSubagent,
         expectsCompletionMessage: params.expectsCompletionMessage,
         createUserTurnTranscriptRecorder: createCompletionUserTurnTranscriptRecorder,
+        requireContinuationProgress: params.requireContinuationProgress,
         requireVisibleReply: params.requireVisibleReply,
         onDeliveryResult: params.onDeliveryResult,
         signal: params.signal,

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -520,7 +520,7 @@ export async function sendSubagentAnnounceDirectly(params: {
       hasMessagingToolDeliveryToSource(directAnnounceResult, deliveryTarget),
     );
     const requiresAutomaticFinalReceipt =
-      shouldDeliverAgentFinal && (params.expectsCompletionMessage || params.requireVisibleReply);
+      shouldDeliverAgentFinal && (params.expectsCompletionMessage || requireVisibleTurnOutcome);
     const automaticEvidence = getAutomaticDeliveryEvidence(directAnnounceResult ?? {});
     const directDeliveryFailure =
       (shouldDeliverAgentFinal || requiresMessageToolDelivery) && directAnnounceResult
@@ -651,24 +651,9 @@ export async function sendSubagentAnnounceDirectly(params: {
     }
     const requesterVisibleFinalDelivered =
       hasFinalMessagingToolDelivery || (shouldDeliverAgentFinal && automaticFinalDelivered);
-    const continuationProgressDelivered =
-      requesterVisibleFinalDelivered ||
-      (!shouldDeliverAgentFinal &&
-        !requiresMessageToolDelivery &&
-        hasVisibleNonSilentGatewayPayload) ||
-      directAnnounceResult?.runtimeContinuationStarted === true ||
-      hasContinuationSessionSpawnEvidence(directAnnounceResult?.acceptedSessionSpawns);
-    if (params.requireContinuationProgress && !continuationProgressDelivered) {
-      return {
-        delivered: false,
-        path: "direct",
-        reason: "visible_reply_missing",
-        error: "continuation turn did not start another subagent or deliver a visible final",
-      };
-    }
     const hasVisibleCompletionReply =
       requesterVisibleFinalDelivered ||
-      (!shouldDeliverAgentFinal && !params.requireVisibleReply && hasMessagingToolDelivery) ||
+      (!shouldDeliverAgentFinal && !requireVisibleTurnOutcome && hasMessagingToolDelivery) ||
       // Nested requesters and internal sessions observe the final in their transcript.
       // Unresolved external origins still require delivery evidence.
       (!requiresMessageToolDelivery &&
@@ -680,6 +665,20 @@ export async function sendSubagentAnnounceDirectly(params: {
               ? normalizeMessageChannel(origin.channel) === INTERNAL_MESSAGE_CHANNEL
               : !origin?.to,
           )));
+    // Continuations share final-delivery routing and suppression checks. Only
+    // an accepted successor that owns completion can replace the visible final.
+    const continuationProgressDelivered =
+      hasVisibleCompletionReply ||
+      directAnnounceResult?.runtimeContinuationStarted === true ||
+      hasContinuationSessionSpawnEvidence(directAnnounceResult?.acceptedSessionSpawns);
+    if (params.requireContinuationProgress && !continuationProgressDelivered) {
+      return {
+        delivered: false,
+        path: "direct",
+        reason: "visible_reply_missing",
+        error: "continuation turn did not start another subagent or deliver a visible final",
+      };
+    }
     const silentCompletionOk = hasIntentionalSilentCompletionReply && !isSubagentCompletion;
     if (
       !hasVisibleCompletionReply &&

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -23,6 +23,7 @@ import { normalizeAgentRunTerminalDeliverySnapshot } from "../../agent-run-termi
 import {
   getAgentCommandDeliveryFailure,
   getGatewayAgentResult,
+  hasAcceptedSessionSpawnEvidence,
   hasCommittedOutboundDeliveryEvidence,
   getAutomaticDeliveryEvidence,
 } from "../../embedded-agent-runner/delivery-evidence.js";
@@ -137,6 +138,7 @@ export async function sendSubagentAnnounceDirectly(params: {
   triggerMessage: string;
   internalEvents?: AgentInternalEvent[];
   expectsCompletionMessage: boolean;
+  requireContinuationProgress?: boolean;
   requireVisibleReply?: boolean;
   bestEffortDeliver?: boolean;
   directIdempotencyKey: string;
@@ -296,9 +298,11 @@ export async function sendSubagentAnnounceDirectly(params: {
         isSourceSessionEffectsAllowed: isCompletionDeliveryAllowed,
       });
     // Synthetic requester-settle turns must not inherit a tool-only mode that suppresses the final.
+    const requireVisibleTurnOutcome =
+      params.requireVisibleReply || params.requireContinuationProgress;
     const completionSourceReplyDeliveryMode = requiresMessageToolDelivery
       ? "message_tool_only"
-      : params.requireVisibleReply && deliveryTarget.deliver
+      : requireVisibleTurnOutcome && deliveryTarget.deliver
         ? "automatic"
         : undefined;
     const shouldDeliverAgentFinal = deliveryTarget.deliver && !requiresMessageToolDelivery;
@@ -490,6 +494,14 @@ export async function sendSubagentAnnounceDirectly(params: {
 
     const directAnnounceStillPending = isGatewayAgentRunPending(directAnnounceResponse);
     if (directAnnounceStillPending) {
+      if (requireVisibleTurnOutcome) {
+        return {
+          delivered: false,
+          path: "direct",
+          disposition: "agent_run_pending",
+          error: "required requester turn is still running",
+        };
+      }
       return {
         delivered: true,
         path: "direct",
@@ -639,6 +651,28 @@ export async function sendSubagentAnnounceDirectly(params: {
     }
     const requesterVisibleFinalDelivered =
       hasFinalMessagingToolDelivery || (shouldDeliverAgentFinal && automaticFinalDelivered);
+    const acceptedContinuationSpawn = Boolean(
+      directAnnounceResult &&
+      (hasAcceptedSessionSpawnEvidence(directAnnounceResult.acceptedSessionSpawns) ||
+        directAnnounceResult.runtimeContinuationStarted === true),
+    );
+    const deliveredContinuationFinal =
+      requesterVisibleFinalDelivered ||
+      (!shouldDeliverAgentFinal &&
+        !requiresMessageToolDelivery &&
+        hasVisibleNonSilentGatewayPayload);
+    if (
+      params.requireContinuationProgress &&
+      !deliveredContinuationFinal &&
+      !acceptedContinuationSpawn
+    ) {
+      return {
+        delivered: false,
+        path: "direct",
+        reason: "visible_reply_missing",
+        error: "continuation turn did not start another subagent or deliver a visible final",
+      };
+    }
     const hasVisibleCompletionReply =
       requesterVisibleFinalDelivered ||
       (!shouldDeliverAgentFinal && !params.requireVisibleReply && hasMessagingToolDelivery) ||

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -651,21 +651,14 @@ export async function sendSubagentAnnounceDirectly(params: {
     }
     const requesterVisibleFinalDelivered =
       hasFinalMessagingToolDelivery || (shouldDeliverAgentFinal && automaticFinalDelivered);
-    const acceptedContinuationSpawn = Boolean(
-      directAnnounceResult &&
-      (hasContinuationSessionSpawnEvidence(directAnnounceResult.acceptedSessionSpawns) ||
-        directAnnounceResult.runtimeContinuationStarted === true),
-    );
-    const deliveredContinuationFinal =
+    const continuationProgressDelivered =
       requesterVisibleFinalDelivered ||
       (!shouldDeliverAgentFinal &&
         !requiresMessageToolDelivery &&
-        hasVisibleNonSilentGatewayPayload);
-    if (
-      params.requireContinuationProgress &&
-      !deliveredContinuationFinal &&
-      !acceptedContinuationSpawn
-    ) {
+        hasVisibleNonSilentGatewayPayload) ||
+      directAnnounceResult?.runtimeContinuationStarted === true ||
+      hasContinuationSessionSpawnEvidence(directAnnounceResult?.acceptedSessionSpawns);
+    if (params.requireContinuationProgress && !continuationProgressDelivered) {
       return {
         delivered: false,
         path: "direct",
@@ -687,16 +680,13 @@ export async function sendSubagentAnnounceDirectly(params: {
               ? normalizeMessageChannel(origin.channel) === INTERNAL_MESSAGE_CHANNEL
               : !origin?.to,
           )));
-    const acceptsIntentionalSilentCompletion =
-      hasIntentionalSilentCompletionReply && !isSubagentCompletion;
+    const silentCompletionOk = hasIntentionalSilentCompletionReply && !isSubagentCompletion;
     if (
       !hasVisibleCompletionReply &&
       (params.requireVisibleReply ||
         (params.expectsCompletionMessage &&
           (shouldDeliverAgentFinal ||
-            (!requiresMessageToolDelivery &&
-              !hasCompletionSideEffect &&
-              !acceptsIntentionalSilentCompletion))))
+            (!requiresMessageToolDelivery && !hasCompletionSideEffect && !silentCompletionOk))))
     ) {
       return {
         delivered: false,

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -23,7 +23,7 @@ import { normalizeAgentRunTerminalDeliverySnapshot } from "../../agent-run-termi
 import {
   getAgentCommandDeliveryFailure,
   getGatewayAgentResult,
-  hasAcceptedSessionSpawnEvidence,
+  hasContinuationSessionSpawnEvidence,
   hasCommittedOutboundDeliveryEvidence,
   getAutomaticDeliveryEvidence,
 } from "../../embedded-agent-runner/delivery-evidence.js";
@@ -653,7 +653,7 @@ export async function sendSubagentAnnounceDirectly(params: {
       hasFinalMessagingToolDelivery || (shouldDeliverAgentFinal && automaticFinalDelivered);
     const acceptedContinuationSpawn = Boolean(
       directAnnounceResult &&
-      (hasAcceptedSessionSpawnEvidence(directAnnounceResult.acceptedSessionSpawns) ||
+      (hasContinuationSessionSpawnEvidence(directAnnounceResult.acceptedSessionSpawns) ||
         directAnnounceResult.runtimeContinuationStarted === true),
     );
     const deliveredContinuationFinal =

--- a/src/agents/subagents/announce/subagent-announce-dispatch.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-dispatch.test.ts
@@ -171,6 +171,29 @@ describe("runSubagentAnnounceDispatch", () => {
     ]);
   });
 
+  it("does not fallback-steer while a direct agent run is pending", async () => {
+    const steer = vi.fn(async () => ({ status: "steered" }) as const);
+    const direct = vi.fn(async () => ({
+      delivered: false,
+      path: "direct" as const,
+      disposition: "agent_run_pending" as const,
+    }));
+
+    const result = await runSubagentAnnounceDispatch({
+      expectsCompletionMessage: true,
+      steer,
+      direct,
+    });
+
+    expect(direct).toHaveBeenCalledTimes(1);
+    expect(steer).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      delivered: false,
+      path: "direct",
+      disposition: "agent_run_pending",
+    });
+  });
+
   it.each([
     {
       name: "cannot deliver",

--- a/src/agents/subagents/announce/subagent-announce-dispatch.ts
+++ b/src/agents/subagents/announce/subagent-announce-dispatch.ts
@@ -8,6 +8,7 @@ type SubagentDeliveryPath = "steered" | "direct" | "queued" | "none";
 type SubagentAnnounceDeliveryDisposition =
   | "delivered"
   | "session_queued"
+  | "agent_run_pending"
   | "intentional_non_delivery"
   | "retryable"
   | "ambiguous"
@@ -156,6 +157,7 @@ export async function runSubagentAnnounceDispatch(params: {
   if (
     primaryDirect.delivered ||
     primaryDirect.disposition === "session_queued" ||
+    primaryDirect.disposition === "agent_run_pending" ||
     primaryDirect.disposition === "intentional_non_delivery" ||
     primaryDirect.disposition === "ambiguous" ||
     primaryDirect.disposition === "permanent_failure"

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-dispatch.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-dispatch.test.ts
@@ -417,14 +417,19 @@ describe("requester settle dispatch deadline", () => {
       await vi.advanceTimersByTimeAsync(20);
       await expect(firstWake).resolves.toBe(false);
       expect(child.requesterSettleWake).toMatchObject({
-        status: "pending",
+        status: "dispatching",
         attemptCount: 1,
+        replayCount: 1,
       });
 
       await vi.advanceTimersByTimeAsync(30_000);
       const replay = wake();
       await vi.advanceTimersByTimeAsync(20);
       await expect(replay).resolves.toBe(false);
+      const firstIdempotencyKey = deliver.mock.calls[0]?.[0]?.directIdempotencyKey;
+      expect(firstIdempotencyKey).toEqual(expect.any(String));
+      expect(firstIdempotencyKey).not.toBe("");
+      expect(deliver.mock.calls[1]?.[0]?.directIdempotencyKey).toBe(firstIdempotencyKey);
 
       const deadlineCancelled = acceptedSignals.map((signal) => signal.aborted);
       releaseBlocker();

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test-support.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test-support.ts
@@ -1,0 +1,65 @@
+import { expect } from "vitest";
+import type { SubagentRunRecord } from "../registry/subagent-registry.types.js";
+
+export const REQUESTER = "agent:main:main";
+export const requesterSettleKey = (suffix: string) =>
+  `announce:requester-settle:main:${REQUESTER}:${suffix}`;
+
+type SettledChildOverrides = Omit<Partial<SubagentRunRecord>, "execution"> & {
+  startedAt?: number;
+  endedAt?: number;
+  outcome?: SubagentRunRecord["execution"]["outcome"];
+  execution?: SubagentRunRecord["execution"];
+};
+
+export function makeSettledChild(overrides: SettledChildOverrides): SubagentRunRecord {
+  const runId = overrides.runId ?? "run-child";
+  const { startedAt = 2_000, endedAt = 3_000, outcome, execution, ...recordOverrides } = overrides;
+  return {
+    runId,
+    childSessionKey: overrides.childSessionKey ?? `agent:main:subagent:${runId}`,
+    requesterSessionKey: REQUESTER,
+    requesterDisplayKey: "main",
+    task: "investigate",
+    cleanup: "keep",
+    createdAt: 1_000,
+    execution: execution ?? { status: "terminal", startedAt, endedAt, outcome },
+    expectsCompletionMessage: true,
+    delivery: { status: "delivered" },
+    requesterSettleWake: { status: "pending", attemptCount: 0 },
+    ...recordOverrides,
+  };
+}
+
+export function makeYieldedChild(
+  params: {
+    execution?: SubagentRunRecord["execution"];
+    afterRequesterYield?: boolean;
+  } = {},
+): SubagentRunRecord {
+  return makeSettledChild({
+    runId: "run-b",
+    ...(params.execution ? { execution: params.execution } : {}),
+    delivery: { status: "delivered" },
+    requesterSettleWake: {
+      status: "pending",
+      attemptCount: 0,
+      batchRunIds: ["run-b"],
+      requesterYieldBatch: true,
+      ...(params.afterRequesterYield ? { afterRequesterYield: true } : {}),
+      rearmGeneration: 1,
+    },
+  });
+}
+
+export function expectContinuationFirstWake(call: Record<string, unknown>): void {
+  expect(call.requireVisibleReply).toBeUndefined();
+  expect(call.requireContinuationProgress).toBe(true);
+  const message = String(call.triggerMessage);
+  expect(message).toContain("deciding whether the original task is done");
+  expect(message).toContain(
+    "If additional action is required, continue any remaining in-scope work",
+  );
+  expect(message).not.toContain("send your consolidated final answer to the user now");
+  expect(message).not.toContain("NO_REPLY");
+}

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -4,6 +4,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { SubagentRunRecord } from "../registry/subagent-registry.types.js";
+import type { deliverSubagentAnnouncement } from "./subagent-announce-delivery.js";
+import type { SubagentAnnounceDeliveryDeps } from "./subagent-announce-delivery.runtime.js";
 import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
 import {
   makeSettledChild,
@@ -14,7 +16,9 @@ import {
 } from "./subagent-announce.requester-settle-wake.test-support.js";
 
 const deliverSpy = vi.fn(
-  async (_params: Record<string, unknown>): Promise<SubagentAnnounceDeliveryResult> => ({
+  async (
+    _params: Parameters<typeof deliverSubagentAnnouncement>[0],
+  ): Promise<SubagentAnnounceDeliveryResult> => ({
     delivered: true,
     path: "direct",
   }),
@@ -58,7 +62,8 @@ vi.mock("./subagent-announce.runtime.js", () => ({
 }));
 
 vi.mock("./subagent-announce-delivery.js", () => ({
-  deliverSubagentAnnouncement: (params: Record<string, unknown>) => deliverSpy(params),
+  deliverSubagentAnnouncement: (params: Parameters<typeof deliverSubagentAnnouncement>[0]) =>
+    deliverSpy(params),
   loadRequesterSessionEntry: (sessionKey: string) => ({
     entry: sessionStore[sessionKey],
     canonicalKey: sessionKey,
@@ -755,81 +760,83 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     }
   });
 
-  it("does not charge pending polls to the ambiguous transport replay budget", async () => {
-    const firstChild = makeSettledChild({ runId: "run-a" });
-    const secondChild = makeSettledChild({ runId: "run-b" });
-    const children = [firstChild, secondChild];
-    const pending = {
-      delivered: false,
-      path: "direct" as const,
-      disposition: "agent_run_pending" as const,
-    };
-    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue(children);
-    deliverSpy
-      .mockResolvedValueOnce(pending)
-      .mockResolvedValueOnce(pending)
-      .mockRejectedValueOnce(new Error("connection lost after admission"));
-    const wake = () =>
-      maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: secondChild }));
-
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    try {
-      for (let poll = 0; poll < 2; poll += 1) {
-        expect(await wake()).toBe(false);
+  it.each(
+    [0, 2].flatMap((pendingPolls) =>
+      ["exception", "RPC result"].map((failureKind) => ({ pendingPolls, failureKind })),
+    ),
+  )(
+    "keeps the admitted key after $pendingPolls polls and $failureKind",
+    async ({ failureKind, pendingPolls }) => {
+      const actual = await vi.importActual<typeof import("./subagent-announce-delivery.js")>(
+        "./subagent-announce-delivery.js",
+      );
+      const { setSubagentAnnounceDeliveryDepsForTest } =
+        await import("./subagent-announce-delivery.runtime.js");
+      const child = makeYieldedChild();
+      registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([child]);
+      const keys: unknown[] = [];
+      let phase: "pending" | "disconnected" | "completed" = "pending";
+      const cfg = { session: { mainKey: "main", scope: "per-sender" as const } };
+      setSubagentAnnounceDeliveryDepsForTest({
+        getRuntimeConfig: () => cfg,
+        getRequesterSessionActivity: () => ({ isActive: false }),
+        loadRequesterSessionEntry: (canonicalKey) => ({ cfg, canonicalKey, entry: undefined }),
+        dispatchGatewayMethodInProcess: vi.fn<
+          SubagentAnnounceDeliveryDeps["dispatchGatewayMethodInProcess"]
+        >(async (_method, params) => {
+          keys.push(params?.idempotencyKey);
+          if (phase === "disconnected") {
+            throw new Error("connect ECONNRESET");
+          }
+          return phase === "pending"
+            ? { status: "accepted" }
+            : { status: "ok", result: { payloads: [{ text: "Requester work completed." }] } };
+        }),
+      });
+      deliverSpy.mockImplementation(async (params) => {
+        if (phase === "disconnected" && failureKind === "exception") {
+          throw new Error("connect ECONNRESET");
+        }
+        return await actual.deliverSubagentAnnouncement(params);
+      });
+      const wake = () =>
+        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child }));
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      try {
+        for (let poll = 0; poll < pendingPolls; poll += 1) {
+          expect(await wake()).toBe(false);
+          await expect(deliverSpy.mock.results.at(-1)?.value).resolves.toMatchObject({
+            disposition: "agent_run_pending",
+          });
+          await vi.advanceTimersByTimeAsync(30_000);
+        }
+        phase = "disconnected";
+        const failedPoll = wake();
+        await vi.advanceTimersByTimeAsync(100);
+        expect(await failedPoll).toBe(false);
+        if (failureKind === "RPC result") {
+          await expect(deliverSpy.mock.results.at(-1)?.value).resolves.toMatchObject({
+            disposition: "retryable",
+          });
+        }
+        expect(child.requesterSettleWake).toMatchObject({
+          status: "dispatching",
+          attemptCount: 1,
+          replayCount: 1,
+          lastError: "connect ECONNRESET",
+        });
         await vi.advanceTimersByTimeAsync(30_000);
+        phase = "completed";
+        expect(await wake()).toBe(true);
+        expect(new Set(keys)).toEqual(new Set([requesterSettleKey("run-b:yield-1")]));
+        expect(completeBatchSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        setSubagentAnnounceDeliveryDepsForTest();
+        vi.useRealTimers();
       }
-      expect(await wake()).toBe(false);
-      expect(firstChild.requesterSettleWake).toMatchObject({
-        status: "dispatching",
-        attemptCount: 1,
-        replayCount: 1,
-        nextAttemptAt: 90_000,
-        lastError: "connection lost after admission",
-      });
-
-      await vi.advanceTimersByTimeAsync(30_000);
-      expect(await wake()).toBe(true);
-      const keys = deliverSpy.mock.calls.map(([arg]) => arg.directIdempotencyKey);
-      expect(new Set(keys)).toEqual(new Set([requesterSettleKey("run-a,run-b")]));
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("replays an ambiguous transport failure with the same idempotency key", async () => {
-    const firstChild = makeSettledChild({ runId: "run-a" });
-    const secondChild = makeSettledChild({ runId: "run-b" });
-    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([firstChild, secondChild]);
-    deliverSpy.mockRejectedValueOnce(new Error("connection lost after admission"));
-
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    try {
-      expect(
-        await maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: secondChild })),
-      ).toBe(false);
-      expect(firstChild.requesterSettleWake).toMatchObject({
-        status: "dispatching",
-        attemptCount: 1,
-        replayCount: 1,
-        nextAttemptAt: 30_000,
-        lastError: "connection lost after admission",
-      });
-
-      await vi.advanceTimersByTimeAsync(30_000);
-      expect(
-        await maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: secondChild })),
-      ).toBe(true);
-      expect(deliverSpy).toHaveBeenCalledTimes(2);
-      expect(deliverSpy.mock.calls.map(([arg]) => arg.directIdempotencyKey)).toEqual([
-        requesterSettleKey("run-a,run-b"),
-        requesterSettleKey("run-a,run-b"),
-      ]);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+    },
+  );
 
   it("defers a retry when the requester spawned another active descendant", async () => {
     const firstChild = makeSettledChild({ runId: "run-a" });
@@ -894,21 +901,14 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       makeSettledChild({ runId: "run-a" }),
       makeSettledChild({ runId: "run-b" }),
     ]);
-    deliverSpy.mockResolvedValueOnce({
-      delivered: false,
-      path: "direct",
-      disposition: "ambiguous",
-    });
+    const failure = { delivered: false, path: "direct", disposition: "ambiguous" } as const;
+    deliverSpy.mockResolvedValueOnce(failure);
 
     const woke = await maybeWakeRequesterAfterAllChildrenSettled(wakeParams());
 
     expect(woke).toBe(false);
     expect(deliverSpy).toHaveBeenCalledTimes(1);
-    expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-a", "run-b"], undefined, {
-      delivered: false,
-      path: "direct",
-      disposition: "ambiguous",
-    });
+    expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-a", "run-b"], undefined, failure);
   });
 
   it("does not consume retry budget when aborted before dispatch", async () => {

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -193,7 +193,9 @@ function expectContinuationFirstWake(call: Record<string, unknown>): void {
   expect(call.requireContinuationProgress).toBe(true);
   const message = String(call.triggerMessage);
   expect(message).toContain("deciding whether the original task is done");
-  expect(message).toContain("If additional action is required, continue the task");
+  expect(message).toContain(
+    "If additional action is required, continue any remaining in-scope work",
+  );
   expect(message).not.toContain("send your consolidated final answer to the user now");
   expect(message).toContain("NO_REPLY");
 }

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -7,14 +7,7 @@ import type { SubagentRunRecord } from "../registry/subagent-registry.types.js";
 import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
 
 const deliverSpy = vi.fn(
-  async (
-    _params: Record<string, unknown>,
-  ): Promise<{
-    delivered: boolean;
-    path: string;
-    disposition?: "ambiguous" | "permanent_failure" | "intentional_non_delivery";
-    reason?: string;
-  }> => ({
+  async (_params: Record<string, unknown>): Promise<SubagentAnnounceDeliveryResult> => ({
     delivered: true,
     path: "direct",
   }),
@@ -110,6 +103,27 @@ function makeSettledChild(overrides: SettledChildOverrides): SubagentRunRecord {
   };
 }
 
+function makeYieldedChild(
+  params: {
+    execution?: SubagentRunRecord["execution"];
+    afterRequesterYield?: boolean;
+  } = {},
+): SubagentRunRecord {
+  return makeSettledChild({
+    runId: "run-b",
+    ...(params.execution ? { execution: params.execution } : {}),
+    delivery: { status: "delivered" },
+    requesterSettleWake: {
+      status: "pending",
+      attemptCount: 0,
+      batchRunIds: ["run-b"],
+      requesterYieldBatch: true,
+      ...(params.afterRequesterYield ? { afterRequesterYield: true } : {}),
+      rearmGeneration: 1,
+    },
+  });
+}
+
 const transitionBatchSpy = vi.fn();
 const completeBatchSpy = vi.fn();
 
@@ -172,6 +186,16 @@ function deliveredCallArg(): Record<string, unknown> {
     throw new Error("expected deliverSubagentAnnouncement call");
   }
   return call;
+}
+
+function expectContinuationFirstWake(call: Record<string, unknown>): void {
+  expect(call.requireVisibleReply).toBeUndefined();
+  expect(call.requireContinuationProgress).toBe(true);
+  const message = String(call.triggerMessage);
+  expect(message).toContain("deciding whether the original task is done");
+  expect(message).toContain("If additional action is required, continue the task");
+  expect(message).not.toContain("send your consolidated final answer to the user now");
+  expect(message).toContain("NO_REPLY");
 }
 
 describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
@@ -443,18 +467,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       afterRequesterYield: true,
     },
   ])("$name", async ({ afterRequesterYield }) => {
-    const child = makeSettledChild({
-      runId: "run-b",
-      delivery: { status: "delivered" },
-      requesterSettleWake: {
-        status: "pending",
-        attemptCount: 0,
-        batchRunIds: ["run-b"],
-        requesterYieldBatch: true,
-        rearmGeneration: 1,
-        ...(afterRequesterYield ? { afterRequesterYield } : {}),
-      },
-    });
+    const child = makeYieldedChild(afterRequesterYield ? { afterRequesterYield: true } : {});
     registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([child]);
 
     const woke = await maybeWakeRequesterAfterAllChildrenSettled(
@@ -463,10 +476,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
 
     expect(woke).toBe(true);
     expect(deliverSpy).toHaveBeenCalledOnce();
-    expect(deliveredCallArg().requireVisibleReply).toBe(true);
-    const message = String(deliveredCallArg().triggerMessage);
-    expect(message).not.toContain("NO_REPLY");
-    expect(message).toContain("continue any remaining in-scope work before replying");
+    expectContinuationFirstWake(deliveredCallArg());
     expect(deliveredCallArg().directIdempotencyKey).toBe(requesterSettleKey("run-b:yield-1"));
     expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1, {
       delivered: true,
@@ -484,18 +494,8 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
   ] as const)(
     "does not wake a yielded requester while its only frozen child %s",
     async (_description, execution) => {
-      const activeChild = makeSettledChild({
-        runId: "run-b",
-        execution,
-        delivery: { status: "pending" },
-        requesterSettleWake: {
-          status: "pending",
-          attemptCount: 0,
-          batchRunIds: ["run-b"],
-          requesterYieldBatch: true,
-          rearmGeneration: 1,
-        },
-      });
+      const activeChild = makeYieldedChild({ execution });
+      activeChild.delivery = { status: "pending" };
       registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([activeChild]);
 
       const woke = await maybeWakeRequesterAfterAllChildrenSettled(
@@ -752,53 +752,100 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     }
   });
 
-  it("retains a yielded wake after a silent final and retries its visible reply", async () => {
-    const child = makeSettledChild({
-      runId: "run-b",
-      delivery: { status: "delivered" },
-      requesterSettleWake: {
-        status: "pending",
-        attemptCount: 0,
-        batchRunIds: ["run-b"],
-        requesterYieldBatch: true,
-        rearmGeneration: 1,
-      },
-    });
+  it("replays a pending continuation before retrying its silent final", async () => {
+    const child = makeYieldedChild();
+    const wake = () =>
+      maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child }));
     registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([child]);
-    deliverSpy.mockResolvedValueOnce({
-      delivered: false,
-      path: "direct",
-      reason: "visible_reply_missing",
-    });
+    deliverSpy
+      .mockResolvedValueOnce({
+        delivered: false,
+        path: "direct",
+        disposition: "agent_run_pending",
+        error: "required requester turn is still running",
+      })
+      .mockResolvedValueOnce({
+        delivered: false,
+        path: "direct",
+        reason: "visible_reply_missing",
+      });
 
     vi.useFakeTimers();
     vi.setSystemTime(0);
     try {
-      await expect(
-        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
-      ).resolves.toBe(false);
-      expect(completeBatchSpy).not.toHaveBeenCalled();
+      await expect(wake()).resolves.toBe(false);
+      expect(child.requesterSettleWake).toMatchObject({
+        status: "dispatching",
+        attemptCount: 1,
+        nextAttemptAt: 30_000,
+        lastError: "required requester turn is still running",
+      });
+      expect(child.requesterSettleWake?.replayCount).toBeUndefined();
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(wake()).resolves.toBe(false);
+      expect(deliverSpy.mock.calls.map(([arg]) => arg.directIdempotencyKey)).toEqual([
+        requesterSettleKey("run-b:yield-1"),
+        requesterSettleKey("run-b:yield-1"),
+      ]);
       expect(child.requesterSettleWake).toMatchObject({
         status: "pending",
         attemptCount: 1,
-        nextAttemptAt: 30_000,
+        nextAttemptAt: 60_000,
         requesterYieldBatch: true,
         rearmGeneration: 1,
         lastError: "visible_reply_missing",
       });
+      expect(completeBatchSpy).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(30_000);
-      await expect(
-        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
-      ).resolves.toBe(true);
-      expect(deliverSpy.mock.calls.map(([arg]) => arg.directIdempotencyKey)).toEqual([
-        requesterSettleKey("run-b:yield-1"),
-        requesterSettleKey("run-b:yield-1:retry-1"),
-      ]);
+      await expect(wake()).resolves.toBe(true);
       expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1, {
         delivered: true,
         path: "direct",
       });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not charge pending polls to the ambiguous transport replay budget", async () => {
+    const firstChild = makeSettledChild({ runId: "run-a" });
+    const secondChild = makeSettledChild({ runId: "run-b" });
+    const children = [firstChild, secondChild];
+    const pending = {
+      delivered: false,
+      path: "direct" as const,
+      disposition: "agent_run_pending" as const,
+    };
+    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue(children);
+    deliverSpy
+      .mockResolvedValueOnce(pending)
+      .mockResolvedValueOnce(pending)
+      .mockRejectedValueOnce(new Error("connection lost after admission"));
+    const wake = () =>
+      maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: secondChild }));
+
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      for (let poll = 0; poll < 2; poll += 1) {
+        expect(await wake()).toBe(false);
+        await vi.advanceTimersByTimeAsync(30_000);
+      }
+      expect(await wake()).toBe(false);
+      expect(firstChild.requesterSettleWake).toMatchObject({
+        status: "dispatching",
+        attemptCount: 1,
+        replayCount: 1,
+        nextAttemptAt: 90_000,
+        lastError: "connection lost after admission",
+      });
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(await wake()).toBe(true);
+      const keys = deliverSpy.mock.calls.map(([arg]) => arg.directIdempotencyKey);
+      expect(new Set(keys)).toEqual(new Set([requesterSettleKey("run-a,run-b")]));
     } finally {
       vi.useRealTimers();
     }

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { SubagentRunRecord } from "../registry/subagent-registry.types.js";
 import type { deliverSubagentAnnouncement } from "./subagent-announce-delivery.js";
-import type { SubagentAnnounceDeliveryDeps } from "./subagent-announce-delivery.runtime.js";
 import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
 import {
   makeSettledChild,
@@ -781,17 +780,22 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
         getRuntimeConfig: () => cfg,
         getRequesterSessionActivity: () => ({ isActive: false }),
         loadRequesterSessionEntry: (canonicalKey) => ({ cfg, canonicalKey, entry: undefined }),
-        dispatchGatewayMethodInProcess: vi.fn<
-          SubagentAnnounceDeliveryDeps["dispatchGatewayMethodInProcess"]
-        >(async (_method, params) => {
-          keys.push(params?.idempotencyKey);
+        dispatchGatewayMethodInProcess: async <T>(
+          _method: string,
+          params: Record<string, unknown>,
+        ): Promise<T> => {
+          keys.push(params.idempotencyKey);
           if (phase === "disconnected") {
             throw new Error("connect ECONNRESET");
           }
-          return phase === "pending"
-            ? { status: "accepted" }
-            : { status: "ok", result: { payloads: [{ text: "Requester work completed." }] } };
-        }),
+          // The fixture models the concrete gateway responses; the generic dispatch contract
+          // leaves the response type to its caller, so this boundary cast is intentionally narrow.
+          return (
+            phase === "pending"
+              ? { status: "accepted" }
+              : { status: "ok", result: { payloads: [{ text: "Requester work completed." }] } }
+          ) as T;
+        },
       });
       deliverSpy.mockImplementation(async (params) => {
         if (phase === "disconnected" && failureKind === "exception") {

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -5,6 +5,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { SubagentRunRecord } from "../registry/subagent-registry.types.js";
 import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
+import {
+  makeSettledChild,
+  makeYieldedChild,
+  expectContinuationFirstWake,
+  requesterSettleKey,
+  REQUESTER,
+} from "./subagent-announce.requester-settle-wake.test-support.js";
 
 const deliverSpy = vi.fn(
   async (_params: Record<string, unknown>): Promise<SubagentAnnounceDeliveryResult> => ({
@@ -73,57 +80,6 @@ import {
   type RequesterSettleWakeBatchState,
 } from "./subagent-announce.requester-settle-wake.js";
 
-const REQUESTER = "agent:main:main";
-const requesterSettleKey = (suffix: string) =>
-  `announce:requester-settle:main:${REQUESTER}:${suffix}`;
-
-type SettledChildOverrides = Omit<Partial<SubagentRunRecord>, "execution"> & {
-  startedAt?: number;
-  endedAt?: number;
-  outcome?: SubagentRunRecord["execution"]["outcome"];
-  execution?: SubagentRunRecord["execution"];
-};
-
-function makeSettledChild(overrides: SettledChildOverrides): SubagentRunRecord {
-  const runId = overrides.runId ?? "run-child";
-  const { startedAt = 2_000, endedAt = 3_000, outcome, execution, ...recordOverrides } = overrides;
-  return {
-    runId,
-    childSessionKey: overrides.childSessionKey ?? `agent:main:subagent:${runId}`,
-    requesterSessionKey: REQUESTER,
-    requesterDisplayKey: "main",
-    task: "investigate",
-    cleanup: "keep",
-    createdAt: 1_000,
-    execution: execution ?? { status: "terminal", startedAt, endedAt, outcome },
-    expectsCompletionMessage: true,
-    delivery: { status: "delivered" },
-    requesterSettleWake: { status: "pending", attemptCount: 0 },
-    ...recordOverrides,
-  };
-}
-
-function makeYieldedChild(
-  params: {
-    execution?: SubagentRunRecord["execution"];
-    afterRequesterYield?: boolean;
-  } = {},
-): SubagentRunRecord {
-  return makeSettledChild({
-    runId: "run-b",
-    ...(params.execution ? { execution: params.execution } : {}),
-    delivery: { status: "delivered" },
-    requesterSettleWake: {
-      status: "pending",
-      attemptCount: 0,
-      batchRunIds: ["run-b"],
-      requesterYieldBatch: true,
-      ...(params.afterRequesterYield ? { afterRequesterYield: true } : {}),
-      rearmGeneration: 1,
-    },
-  });
-}
-
 const transitionBatchSpy = vi.fn();
 const completeBatchSpy = vi.fn();
 
@@ -186,18 +142,6 @@ function deliveredCallArg(): Record<string, unknown> {
     throw new Error("expected deliverSubagentAnnouncement call");
   }
   return call;
-}
-
-function expectContinuationFirstWake(call: Record<string, unknown>): void {
-  expect(call.requireVisibleReply).toBeUndefined();
-  expect(call.requireContinuationProgress).toBe(true);
-  const message = String(call.triggerMessage);
-  expect(message).toContain("deciding whether the original task is done");
-  expect(message).toContain(
-    "If additional action is required, continue any remaining in-scope work",
-  );
-  expect(message).not.toContain("send your consolidated final answer to the user now");
-  expect(message).not.toContain("NO_REPLY");
 }
 
 describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
@@ -264,7 +208,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       }),
     );
     registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue(children);
-    const deliveryGate = createDeferred<{ delivered: boolean; path: string }>();
+    const deliveryGate = createDeferred<SubagentAnnounceDeliveryResult>();
     deliverSpy.mockReturnValueOnce(deliveryGate.promise);
 
     const wakeA = maybeWakeRequesterAfterAllChildrenSettled(

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -197,7 +197,7 @@ function expectContinuationFirstWake(call: Record<string, unknown>): void {
     "If additional action is required, continue any remaining in-scope work",
   );
   expect(message).not.toContain("send your consolidated final answer to the user now");
-  expect(message).toContain("NO_REPLY");
+  expect(message).not.toContain("NO_REPLY");
 }
 
 describe("maybeWakeRequesterAfterAllChildrenSettled", () => {

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -69,16 +69,15 @@ const activeRequesterSettleWakeBatches = new Map<string, () => boolean>();
 
 function buildRequesterSettleWakeMessage(params: {
   findings?: string;
-  requireVisibleReply: boolean;
+  allowContinuation: boolean;
   modelRouteChange?: string;
   preserveModelRouteNotice: boolean;
 }): string {
   return [
     "[Subagent Context] Every subagent spawned from this session has now settled — none are still running or awaiting completion delivery.",
     "[Subagent Context] Do not keep waiting or call sessions_yield again for this batch; no further completion events will arrive.",
-    "[Subagent Context] Child settlement ends this batch, not necessarily the original user request. Review the results against the requested outcome and continue any remaining in-scope work before replying.",
-    params.requireVisibleReply
-      ? "[Subagent Context] Child completion delivery is internal; the original user request still requires your visible final answer only after the requested outcome is complete or genuinely blocked."
+    params.allowContinuation
+      ? "[Subagent Context] Child settlement ends this batch, not necessarily the original user request. Review the completion results against the requested outcome before deciding whether the original task is done. If additional action is required, continue any remaining in-scope work; otherwise send a truthful user-facing update."
       : `[Subagent Context] Reply ONLY: ${SILENT_REPLY_TOKEN} only if you already delivered the consolidated final answer for this batch.`,
     ...(params.modelRouteChange
       ? [
@@ -390,7 +389,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(
   const completionChannel = normalizeMessageChannel(directOrigin?.channel);
   const wakeMessage = buildRequesterSettleWakeMessage({
     findings,
-    requireVisibleReply: requesterYieldedAfterDelivery,
+    allowContinuation: requesterYieldedAfterDelivery,
     modelRouteChange,
     preserveModelRouteNotice: !completionChannel || !isDeliverableMessageChannel(completionChannel),
   });
@@ -480,7 +479,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(
         requesterIsSubagent: false,
         expectsCompletionMessage: false,
         requireDirectDelivery: true,
-        ...(requesterYieldedAfterDelivery ? { requireVisibleReply: true } : {}),
+        ...(requesterYieldedAfterDelivery ? { requireContinuationProgress: true } : {}),
         directIdempotencyKey: buildAnnounceIdempotencyKey(
           attemptIndex === 0 ? wakeKeyBase : `${wakeKeyBase}:retry-${attemptIndex}`,
         ),
@@ -525,6 +524,28 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(
     if (delivery.delivered) {
       completeBatch(settledBatch, state.rearmGeneration, delivery);
       return true;
+    }
+    if (delivery.disposition === "agent_run_pending") {
+      const retryDelayMs = REQUESTER_SETTLE_WAKE_RETRY_DELAYS_MS[0];
+      const lastError = delivery.error ?? "requester settle turn is still running";
+      // The admitted turn may later resolve through Gateway dedupe. Keep this
+      // batch dispatching and preserve the transport-failure replay budget.
+      state = {
+        status: "dispatching",
+        attemptCount: state.attemptCount,
+        ...(state.replayCount !== undefined ? { replayCount: state.replayCount } : {}),
+        nextAttemptAt: Date.now() + retryDelayMs,
+        batchRunIds,
+        ...(state.requesterYieldBatch === true ? { requesterYieldBatch: true } : {}),
+        ...(state.afterRequesterYield === true ? { afterRequesterYield: true } : {}),
+        ...(state.rearmGeneration !== undefined ? { rearmGeneration: state.rearmGeneration } : {}),
+        lastError,
+      };
+      params.transitionBatch(settledBatch, state);
+      logWarn(
+        `requester settle wake turn still running; same-key poll scheduled in ${Math.round(retryDelayMs / 1000)}s`,
+      );
+      return false;
     }
     if (
       delivery.disposition === "ambiguous" ||

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -487,9 +487,17 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(
         resolveGatewayContext,
       });
     } catch (error) {
-      // A transport exception can arrive after gateway admission. Replay the
-      // same persisted idempotency key; only a known no-turn result may rotate it.
-      const lastError = error instanceof Error ? error.message : String(error);
+      delivery = {
+        delivered: false,
+        path: "direct",
+        disposition: "retryable",
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+    // Direct delivery normalizes RPC failures to retryable results. Both forms
+    // can follow admission, so only a known no-turn result may rotate the key.
+    if (delivery.disposition === "retryable") {
+      const lastError = delivery.error ?? "requester settle transport failed";
       const replayCount = (state.replayCount ?? 0) + 1;
       const retryDelayMs = REQUESTER_SETTLE_WAKE_RETRY_DELAYS_MS[replayCount - 1];
       if (

--- a/src/agents/subagents/registry/subagent-registry.types.ts
+++ b/src/agents/subagents/registry/subagent-registry.types.ts
@@ -70,6 +70,7 @@ export type SubagentRestartRecoveryReceipt = {
 type SubagentDeliveryDisposition =
   | "delivered"
   | "session_queued"
+  | "agent_run_pending"
   | "intentional_non_delivery"
   | "retryable"
   | "ambiguous"

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -472,10 +472,14 @@ describe("sessions_spawn tool", () => {
           mockCallArg(hoisted.spawnAcpDirectMock, 0, 0, "spawnAcpDirect").expectsCompletionMessage,
         ).toBe(expected);
 
-        await tool.execute("visible", {
+        const visibleResult = await tool.execute("visible", {
           task: "visible child",
           visible: true,
           ...input,
+        });
+        expect(visibleResult.details).toMatchObject({
+          status: "accepted",
+          expectsCompletionMessage: expected,
         });
         expect(registerRun).toHaveBeenCalledWith(
           expect.objectContaining({ expectsCompletionMessage: expected }),

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -443,6 +443,7 @@ export async function maybeSpawnVisibleSession(params: {
       status: "accepted",
       childSessionKey,
       runId,
+      expectsCompletionMessage: params.expectsCompletionMessage,
       mode: "run",
       cleanup: "keep",
       ...(sessionUrl ? { sessionUrl } : {}),


### PR DESCRIPTION
Closes #129455.

## What Problem This Solves

A requester that yielded to subagents must be able to continue its original task after those children settle. An accepted successor or trusted native continuation is progress, but an admitted/in-flight run is not yet a completed final. Premature settlement loses work; retrying an already admitted run with a new key can duplicate it.

## Why This Change Was Made

The existing requester-settle owner now keeps nonterminal runs dispatching and polls their original idempotency key. It accepts a terminal visible final or completion-owning successor evidence. Ordinary announcement admission semantics remain unchanged.

The September 5 follow-up fixes three review findings at the existing direct-delivery and wake owners:

- Continuation finals use the canonical route and suppression predicate. Text for an unresolved external destination, suppressed output, and progress-only tool messages do not become a visible-final receipt.
- Continuation-required turns use the same automatic-delivery suppression and ambiguous-send decision as other required finals, preventing retry after intentional suppression or possible delivery.
- The wake handles both thrown transport failures and production-normalized retryable results through bounded same-key replay. Only a known completed no-progress result uses a fresh attempt key.

Existing-solutions preflight: this is an internal lifecycle invariant. External plugins or orchestration wrappers cannot repair the canonical Gateway admission/delivery receipt. The implementation reuses existing terminal evidence, successor ownership, and retry budgets; no new policy or persistent representation is introduced by this follow-up.

## User Impact

Sequential subagent workflows can continue without an early final. External-route and suppression protections remain effective, and transient poll failures do not cause a second admitted requester run. Configuration, protocol version, storage schema, and provider authentication are unchanged by the repair.

## Evidence

### September 5 Production Gateway Recovery: Partial Coverage

Product head remains `ee93ac12dbef1cf9e8474a0ee1a4fd51adbf10d1`. Independent Leon proof commit [`170165a1bce46b67d84d508ab832b29a3f91a502`](https://github.com/Leon-SK668/openclaw/commit/170165a1bce46b67d84d508ab832b29a3f91a502) is its direct child and changes only one E2E scenario file plus the runner workflow; production source and lockfile are unchanged. The runner builds and executes the proof tree, not a checkout relabeled as the PR SHA.

[Run 33974410761](https://github.com/Leon-SK668/openclaw/actions/runs/33974410761) / [job 101328472408](https://github.com/Leon-SK668/openclaw/actions/runs/33974410761/job/101328472408) succeeded on Linux / Node 24 after frozen-lock installation and a source build with private QA enabled. Two scenarios passed: 43.27 seconds Vitest duration, 53.33 seconds including wrapper preparation. [Downloadable log artifact 9972012261](https://github.com/Leon-SK668/openclaw/actions/runs/33974410761/artifacts/9972012261) contains the runner receipt. The [complete scenario](https://github.com/Leon-SK668/openclaw/blob/170165a1bce46b67d84d508ab832b29a3f91a502/test/gateway-restored-requester-settle.e2e.test.ts) defines the readback assertions.

`node scripts/run-vitest.mjs test/gateway-restored-requester-settle.e2e.test.ts --reporter=dot`

- **Admission/backpressure:** seed three durable pending wakes; the actual Gateway starts two real HTTP requests to a deterministic local model receiver, keeps the third queued, then admits it after one response is released. The observed peak stays at two, and an independent CLI agent probe can progress.
- **Seeded batch recovery/readback:** seed two terminal registry rows sharing one dispatching batch, with valid persistent requester/child session entries. Startup produces exactly one model request and one requester transcript final. Both registry rows remain present with wake state cleared. After a second Gateway restart, authenticated health RPCs keep a five-second observation window live; request count and persisted final count remain one, and both rows still exist. This demonstrates restored-batch coalescing and no replay in the measured window, not an unlimited-time guarantee.

**Still missing:** this does not inject a real pending-to-error socket fault, demonstrate retention of a previously running admitted request through that fault, or exercise intentional message-delivery suppression / ambiguous-send recovery. Duplicate replay suppression is not the same as intentional non-delivery. These outstanding parts of the durable review remain open; no complete-proof or merge-ready claim is made from this run.

**Limits and failed attempts:** the model is a deterministic loopback HTTP/SSE receiver; no external model, production channel or user message is used. The local stores are real SQLite/session readback, seeded through test helpers rather than produced by real child execution. Earlier runs 33972884766 and 33973526239 failed and are not counted as passes; the latter exposed an incomplete child-session fixture that canonical orphan cleanup removed after restart. The successful runner adds the missing persistent child sessions and retains the row-existence assertions. Production code and the PR head were not modified to obtain this result.

AI-assisted maintenance transcript (redacted): read the recovery review; build an independent runner; run the real Gateway and deterministic receiver; inspect the failed restart fixture; retain durable-row and final-count assertions; verify the successful run, unchanged production blobs and Leon author/committer; publish this bounded partial receipt. No credentials or private session records are included.


- Current head: `ee93ac12dbef1cf9e8474a0ee1a4fd51adbf10d1`; production-repair parent: `87f6b9c6a5ec81462b6aac2fe2eb1f1401855e31`; frozen rebase baseline: `c4052ca628ac0e1026b82c10d7d80a5ebd8aaff9`.
- Acceptance-red before production edits: extending the existing route/suppression matrix to continuation mode and exercising normalized retryable results produced 8 failures (397 passed). A separate below-production RPC fault case also failed because the wake changed from dispatching to pending and lost replayCount.
- Production-repair verification on `19515d47294acb35866f049dc769a5a13d6a3dae`: 4 files, 482 tests passed under Node 24.15.0 (113.82 seconds including wrapper preparation). Subsequent CI found two missed test issues, corrected below; this historical narrow run was not full-CI green.

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/agents/subagents/announce/subagent-announce-delivery.test.ts \
  src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts \
  src/agents/subagents/announce/subagent-announce-dispatch.test.ts \
  src/agents/command/delivery.test.ts --reporter=dot
```

The consolidated transport matrix uses the real deliverSubagentAnnouncement, direct delivery, retry classification, and requester wake code. It injects only the RPC boundary or a delivery exception. For both initial admission and two preceding pending polls, ECONNRESET produces one replay, preserves the original key, and completes once after recovery. This is a composed production-boundary regression, not a live provider or socket-level Gateway trace.

- Scoped oxfmt, oxlint --deny-warnings, and git diff --check passed. The stale formatting in command/delivery.test.ts is corrected.
- The earlier isolated type probe did not catch Vitest erasing the dispatcher generic in the complete test. CI did. The current fixture directly implements the generic RPC function without a `vi.fn` wrapper; full test-type CI remains authoritative.
- Fresh autoreview against the repair parent, with --max-priority P3 and owner/caller/dependency context, was scoped-clean after the final correction (no accepted/actionable findings). This certifies the repair scope, not an independent new audit of every historical PR commit.
- Repair size: 5 files, production +27/-20, tests +110/-98. Production growth is the explicit shared handling of normalized RPC failures; no generated, lockfile, schema, or config changes.
- Both author and committer on the final repair commit are Leon-SK668. It was pushed as a normal fast-forward.

### Current-Head CI Repair

- [CI run 33944517964](https://github.com/openclaw/openclaw/actions/runs/33944517964) on parent `19515d47294acb35866f049dc769a5a13d6a3dae` exposed a generic fixture type error and an outdated sibling deadline-state expectation. Both are repaired without changing production code.
- `subagent-announce.requester-settle-wake.test.ts` now injects a direct generic dispatcher function. `subagent-announce.requester-settle-dispatch.test.ts` checks dispatching state, one replay, and reuse of a nonempty idempotency key, while retaining cancellation and later-lane progress assertions.
- Final candidate verification under Node 24.15.0: **2 files, 49 tests passed**, 113.30 seconds including wrapper preparation.

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts \
  src/agents/subagents/announce/subagent-announce.requester-settle-dispatch.test.ts \
  --maxWorkers=1 --reporter=dot

node scripts/run-oxlint.mjs --tsconfig test/tsconfig/tsconfig.test.root.json \
  --deny-warnings \
  src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts \
  src/agents/subagents/announce/subagent-announce.requester-settle-dispatch.test.ts
```

- The scoped type-aware lint command above passed, as did formatter checks and `git diff --cached --check`. Fresh `autoreview --mode local --base 19515d47294acb35866f049dc769a5a13d6a3dae --max-priority P3` was scoped-clean with no accepted/actionable findings.
- Latest repair: **2 test files, +19/-10 lines; production +0/-0**. No new live Gateway/model proof or full local repository typecheck is claimed. Exact-head [CI run 33946547190](https://github.com/openclaw/openclaw/actions/runs/33946547190) passed, including check-test-types-core-1, checks-node-compact-large-11, and openclaw/ci-gate. All 215 returned check runs were completed with zero failures at verification.

### Dependency Contract

The acting agent personally inspected sibling Codex checkout `2df67054232090af8d2fa197c46b994bc2b0dda1`: `codex-rs/app-server/src/bespoke_event_handling.rs:159` and `:1305` distinguish turn start from terminal completion; `codex-rs/protocol/src/protocol.rs:4049` defines child-spawn completion with an optional child identifier. OpenClaw's `extensions/codex/src/app-server/run-attempt-resources.ts:197` records scoped native child acceptance. This repair does not change that protocol or turn acceptance into a final-answer receipt.

### Historical Real Gateway Proof

The August 30 child-Gateway receipt remains tied to `91ee2aaaaee08aa500bf914d755f07d84f5359bc`. It ran the repository CLI, a real local Gateway, qa-channel transport, and deterministic OpenAI provider fixture. Provider request readback contained both sequential sessions_spawn labels; the outbound ledger contained exactly one final reply and neither worker marker. The one-scenario run passed in 93.482 seconds.

Later canonical QA lifecycle/type repair at `187a47632d53c43c201d510dea33934d58fd8518` completed [CI run 33349566314](https://github.com/openclaw/openclaw/actions/runs/33349566314) with 198 successful jobs and no failures. These are historical receipts, not new exact-head live proof.

Known limits: the new source-built Gateway/loopback-model receipt above provides partial recovery coverage only, not external-model/channel proof. Current-head CI passed; pending-to-error and intentional/ambiguous-delivery proof remain outstanding. CI and prior ratings do not close those gaps. AI assistance was used for diagnosis, tests, implementation, and independent review.


<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session excerpt</summary>

```text
source: local Codex session
redaction: system/developer prompts, reasoning, raw tool output, local paths, credentials, emails, and unrelated contribution work omitted

[user]
Refresh the open PRs and advance the CI-failing or proof-blocked work that can still be advanced.

[assistant]
The exact-head durable review on #129729 identified a P1: nonterminal Gateway responses were treated as delivered, so the caller retired the durable requester wake without a successor spawn or visible final.

[assistant]
I added an explicit pending disposition. Ordinary announces retain their existing admission semantics, but continuation-required turns remain dispatching and replay the same idempotency key. Pending direct runs also block fallback steering.

[assistant]
Autoreview found that pending polls initially shared the ambiguous transport replay counter. I separated those budgets and added a regression with two pending polls, a transport failure, and same-key recovery. A final fresh autoreview reported no actionable findings.

[assistant]
The final Node 24 focused suite passed 250/250 tests. Scoped format, lint, diff checks, a production Gateway recovery contract test, and two verbose durable-state scenarios passed. The commit was audited for exact parent, tree, and Leon identity, then pushed normally without force.

[assistant]
The new exact-head CI exposed nine checks failing from one declaration-contract omission: the announce result could now return `agent_run_pending`, but the registry's persisted delivery union did not accept it. I added the missing union member, reran `tsgo:core` and all 250 focused tests, received a clean fresh autoreview, audited Leon author/committer identity, and pushed the one-line follow-up without force.
```

</details>
<!-- agent-transcript:end -->