### PR TITLE
refactor(bootstrap): inline Node CA certificate policy

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2263,7 +2263,6 @@ src/auto-reply/usage-bar/translator.ts	4
 src/boards/board-store.ts	1
 src/boards/sqlite-board-codec.ts	7
 src/boards/sqlite-board-store.ts	3
-src/bootstrap/node-extra-ca-certs.ts	2
 src/bootstrap/node-startup-env.ts	1
 src/canvas/documents.ts	2
 src/canvas/serve.runtime.ts	1

--- a/src/bootstrap/node-extra-ca-certs.ts
+++ b/src/bootstrap/node-extra-ca-certs.ts
@@ -10,29 +10,6 @@ const LINUX_CA_BUNDLE_PATHS = [
 export type EnvMap = Record<string, string | undefined>;
 type AccessSyncFn = (path: string, mode?: number) => void;
 
-function resolveLinuxSystemCaBundle(
-  params: {
-    platform?: NodeJS.Platform;
-    accessSync?: AccessSyncFn;
-  } = {},
-): string | undefined {
-  const platform = params.platform ?? process.platform;
-  if (platform !== "linux") {
-    return undefined;
-  }
-
-  const accessSync = params.accessSync ?? fs.accessSync.bind(fs);
-  for (const candidate of LINUX_CA_BUNDLE_PATHS) {
-    try {
-      accessSync(candidate, fs.constants.R_OK);
-      return candidate;
-    } catch {
-      continue;
-    }
-  }
-  return undefined;
-}
-
 /**
  * Version manager path markers (Linux subset), mirroring VERSION_MANAGER_MARKERS
  * in src/daemon/runtime-paths.ts. Not imported directly because bootstrap code
@@ -54,16 +31,6 @@ const VERSION_MANAGER_PATH_MARKERS: readonly string[] = [
   "/.nvs/",
 ];
 
-function isNodeVersionManagerRuntime(
-  env: EnvMap = process.env as EnvMap,
-  execPath: string = process.execPath,
-): boolean {
-  if (env.NVM_DIR?.trim()) {
-    return true;
-  }
-  return VERSION_MANAGER_PATH_MARKERS.some((marker) => execPath.includes(marker));
-}
-
 export function resolveAutoNodeExtraCaCerts(
   params: {
     env?: EnvMap;
@@ -72,19 +39,32 @@ export function resolveAutoNodeExtraCaCerts(
     accessSync?: AccessSyncFn;
   } = {},
 ): string | undefined {
-  const env = params.env ?? (process.env as EnvMap);
+  const env = params.env ?? process.env;
   if (env.NODE_EXTRA_CA_CERTS?.trim()) {
     return undefined;
   }
 
   const platform = params.platform ?? process.platform;
   const execPath = params.execPath ?? process.execPath;
-  if (platform !== "linux" || !isNodeVersionManagerRuntime(env, execPath)) {
+  if (platform !== "linux") {
     return undefined;
   }
 
-  return resolveLinuxSystemCaBundle({
-    platform,
-    accessSync: params.accessSync,
-  });
+  const isVersionManagerRuntime =
+    Boolean(env.NVM_DIR?.trim()) ||
+    VERSION_MANAGER_PATH_MARKERS.some((marker) => execPath.includes(marker));
+  if (!isVersionManagerRuntime) {
+    return undefined;
+  }
+
+  const accessSync = params.accessSync ?? fs.accessSync.bind(fs);
+  for (const candidate of LINUX_CA_BUNDLE_PATHS) {
+    try {
+      accessSync(candidate, fs.constants.R_OK);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
## What Problem This Solves

The bootstrap TLS resolver carried two private helpers used only once, leaving one Node startup decision split across three policy paths and retaining redundant type assertions.

## Why This Change Was Made

This consolidates Linux version-manager detection and CA bundle probing into the sole exported resolver. It preserves explicit environment precedence, platform gating, all runtime markers, candidate order, and file-access behavior while pruning the now-empty assertion-safety baseline entry.

## User Impact

No user-visible behavior changes. Maintainers now have one canonical bootstrap path for automatic `NODE_EXTRA_CA_CERTS` resolution.

## Evidence

- `node scripts/run-vitest.mjs src/bootstrap/node-extra-ca-certs.test.ts src/bootstrap/node-startup-env.test.ts src/entry.respawn.test.ts src/daemon/service-env.test.ts` — 125/125 passed across owner and direct-caller suites.
- `node scripts/check-changed.mjs -- config/assertion-safety-baseline.txt src/bootstrap/node-extra-ca-certs.ts` — green, including assertion-safety ratchet, dead-export scan, core/core-test typechecks, formatting, and lint.
- Structured exact-head autoreview — clean, no accepted/actionable findings.
- Separate read-only exact-head Codex review — no actionable regressions identified.
- Production LOC: +19/-39 (net -20). Tests: +0/-0. Tooling baseline: +0/-1.
