### PR TITLE
fix(ci): restore release validation lint

### DIFF
--- a/scripts/github/release-validation-campaign.d.mts
+++ b/scripts/github/release-validation-campaign.d.mts
@@ -18,6 +18,55 @@ export type ReleaseValidationCampaignArtifact =
       releaseUrl: string;
     };
 
+type CampaignIssue = {
+  number: number;
+  state: string;
+  title: string;
+  body?: string | null;
+  html_url: string;
+  labels?: Array<string | { name?: string | null }>;
+  pull_request?: object;
+};
+
+type RepositoryParams = { owner: string; repo: string };
+
+type CampaignIssueResponse = Promise<{ data: CampaignIssue }>;
+
+type CampaignIssuesApi = {
+  listForRepo(
+    params: RepositoryParams & { state: "open"; labels: string; per_page: number },
+  ): Promise<unknown>;
+  getLabel(params: RepositoryParams & { name: string }): Promise<unknown>;
+  createLabel(
+    params: RepositoryParams & { name: string; color: string; description: string },
+  ): Promise<unknown>;
+  createComment(
+    params: RepositoryParams & { issue_number: number; body: string },
+  ): Promise<unknown>;
+  create(
+    params: RepositoryParams & { title: string; body: string; labels: string[] },
+  ): CampaignIssueResponse;
+  update(
+    params: RepositoryParams & {
+      issue_number: number;
+      title?: string;
+      body?: string;
+      state?: "open" | "closed";
+      state_reason?: "completed";
+      labels?: string[];
+    },
+  ): CampaignIssueResponse;
+  get(params: RepositoryParams & { issue_number: number }): CampaignIssueResponse;
+};
+
+type CampaignGitHub = {
+  paginate(
+    method: CampaignIssuesApi["listForRepo"],
+    params: Parameters<CampaignIssuesApi["listForRepo"]>[0],
+  ): Promise<CampaignIssue[]>;
+  rest: { issues: CampaignIssuesApi };
+};
+
 export function validateReleaseValidationCampaignArtifact(
   artifact: unknown,
   options?: {
@@ -27,27 +76,8 @@ export function validateReleaseValidationCampaignArtifact(
   },
 ): ReleaseValidationCampaignArtifact;
 
-/**
- * Structural subset of the Actions-provided Octokit client this publisher uses.
- * Declared locally so the script keeps a real contract without depending on
- * Octokit's generated types from a plain-Node script surface.
- */
-export type ReleaseValidationCampaignGitHubClient = {
-  rest: {
-    issues: {
-      get(params: Record<string, unknown>): Promise<{ data: unknown }>;
-      getLabel(params: Record<string, unknown>): Promise<unknown>;
-      createLabel(params: Record<string, unknown>): Promise<unknown>;
-      createComment(params: Record<string, unknown>): Promise<unknown>;
-      update(params: Record<string, unknown>): Promise<{ data: unknown }>;
-      listForRepo: unknown;
-    };
-  };
-  paginate(route: unknown, params: Record<string, unknown>): Promise<unknown[]>;
-};
-
 export function runReleaseValidationCampaignPublish(params: {
-  github: ReleaseValidationCampaignGitHubClient;
+  github: CampaignGitHub;
   context: { repo: { owner: string; repo: string } };
   core: { info(message: string): void; setOutput?(name: string, value: string): void };
   artifact: unknown;

--- a/test/scripts/release-validation-campaign.test.ts
+++ b/test/scripts/release-validation-campaign.test.ts
@@ -126,9 +126,13 @@ function harness(initialIssues: ReturnType<typeof issue>[]) {
           }
           return { data: current };
         },
-        get: async ({ issue_number }: { issue_number: number }) => ({
-          data: issues.get(issue_number),
-        }),
+        get: async ({ issue_number }: { issue_number: number }) => {
+          const current = issues.get(issue_number);
+          if (!current) {
+            throw new Error("missing issue");
+          }
+          return { data: current };
+        },
       },
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes the release-validation scripts lint/type boundary, which still used an explicit `any` for the injected Actions Octokit client and blocked exact-head CI.

## Why This Change Was Made

Defines only the GitHub Issues API methods and exact request/response shapes the release-validation publisher consumes. The test double now matches successful `issues.get` behavior by rejecting a missing issue instead of returning an impossible undefined response.

The unrelated QA Lab Crabline fixture edits previously carried by this branch were removed. #129743 documented that separate failure; this PR now retains only the release-validation publisher client and its targeted tests.

## User Impact

No user-visible behavior change. Maintainers regain a typed, lint-clean release-validation publisher boundary without duplicating QA fixture ownership.

## Evidence

Exact head `cfa9844baff`:

- `node_modules/.bin/oxlint scripts/github/release-validation-campaign.d.mts test/scripts/release-validation-campaign.test.ts`
- `node_modules/.bin/tsgo --ignoreConfig --noEmit --strict --skipLibCheck --types node --module nodenext --moduleResolution nodenext --target es2023 scripts/github/release-validation-campaign.d.mts test/scripts/release-validation-campaign.test.ts`
- `node scripts/run-vitest.mjs test/scripts/release-validation-campaign.test.ts` — 8/8 passed
- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/github/release-validation-campaign.d.mts test/scripts/release-validation-campaign.test.ts`
- `git diff --check`
- `node scripts/check-changed.mjs --dry-run -- scripts/github/release-validation-campaign.d.mts test/scripts/release-validation-campaign.test.ts`
- Autoreview: clean, no accepted/actionable findings

Production runtime LOC: `+0/-0`. Tooling declaration: `+50/-20`. Tests: `+7/-3`.
