### PR TITLE
chore(cron): remove duplicate session override tests

### DIFF
--- a/src/cron/isolated-agent.model-formatting.test.ts
+++ b/src/cron/isolated-agent.model-formatting.test.ts
@@ -635,24 +635,6 @@ describe("cron model formatting and precedence edge cases", () => {
     });
   });
 
-  describe("stored session overrides", () => {
-    it("stored modelOverride/providerOverride are applied", async () => {
-      await expectSelectedModel(
-        {
-          sessionEntry: {
-            providerOverride: "openai",
-            modelOverride: "gpt-4.1-mini",
-          },
-        },
-        { provider: "openai", model: "gpt-4.1-mini" },
-      );
-    });
-
-    it("default remains when store has no override", async () => {
-      await expectDefaultSelectedModel({ sessionEntry: {} });
-    });
-  });
-
   describe("Gmail hook model precedence", () => {
     const gmailModel = {
       provider: "openrouter",


### PR DESCRIPTION
## What Problem This Solves

Two cron model-selection tests still claimed to cover stored-session behavior after a runtime-seam refactor had reduced them to direct calls that exactly replayed the model-precedence cases above. They added maintenance and CI work without detecting another regression.

## Why This Change Was Made

Remove the obsolete `stored session overrides` block. The retained model-precedence tests pass the same provider/model session entry and the same effective empty session entry to `resolveCronModelSelection`.

The original storage contract remains covered at its owner in `isolated-agent/session.test.ts`, including preservation of `modelOverride`/`providerOverride` from an existing session and missing-override behavior. History confirms `8727338372b4` collapsed the formerly distinct force-new/store flows into the duplicate direct calls.

## User Impact

No user-visible behavior changes. Cron model-selection coverage remains intact while the suite has two fewer duplicate tests.

Production LOC: +0/-0 | Tests: +0/-18

## Evidence

- Baseline: `node scripts/run-vitest.mjs src/cron/isolated-agent.model-formatting.test.ts` — 39/39 passed.
- Post-change and post-rebase: `node scripts/run-vitest.mjs src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent/session.test.ts` — 59/59 remaining tests passed (37 model-selection + 22 session-owner tests).
- `node scripts/check-changed.mjs --dry-run -- src/cron/isolated-agent.model-formatting.test.ts` — classified the `coreTests` lane.
- `node scripts/check-changed.mjs -- src/cron/isolated-agent.model-formatting.test.ts` — passed repository guards, format, dead-export scan, all core-test typecheck shards, and lint.
- `git diff --check origin/main...HEAD` — passed.
- Fresh autoreview — clean; no accepted/actionable findings; patch correctness 0.99.
