### PR TITLE
fix(matrix): preserve encrypted attachments with blank media URLs

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -690,7 +690,6 @@ extensions/matrix/src/matrix/monitor/context-summary.ts	2
 extensions/matrix/src/matrix/monitor/events.ts	3
 extensions/matrix/src/matrix/monitor/handler-context.ts	1
 extensions/matrix/src/matrix/monitor/handler-helpers.ts	3
-extensions/matrix/src/matrix/monitor/handler-ingress-content.ts	2
 extensions/matrix/src/matrix/monitor/handler-ingress-prefix.ts	3
 extensions/matrix/src/matrix/monitor/handler-state.ts	1
 extensions/matrix/src/matrix/monitor/handler.ts	2

--- a/extensions/matrix/src/matrix/monitor/handler-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-helpers.ts
@@ -1,4 +1,5 @@
 import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { CoreConfig } from "../../types.js";
 import {
@@ -157,6 +158,24 @@ export function resolveMatrixPendingHistoryText(params: {
   return formatMatrixMessageText({ body, filename, msgtype }) ?? "";
 }
 
+export function resolveMatrixInboundMediaContent(content: RoomMessageEventContent) {
+  const file = content.file && typeof content.file === "object" ? content.file : undefined;
+  const info =
+    content.info && typeof content.info === "object"
+      ? (content.info as { mimetype?: string; size?: number })
+      : undefined;
+  const body = normalizeOptionalString(content.body);
+
+  return {
+    url: normalizeOptionalString(content.url) ?? normalizeOptionalString(file?.url),
+    file,
+    body: body ?? "",
+    contentType: info?.mimetype,
+    sizeBytes: typeof info?.size === "number" ? info.size : undefined,
+    originalFilename: normalizeOptionalString(content.filename) ?? body,
+  };
+}
+
 export function isMatrixAudioMediaEnabled(cfg: CoreConfig): boolean {
   const tools = cfg.tools as
     | {
@@ -177,22 +196,12 @@ export function shouldDeferMatrixAudioPreflightForRoomIngress(params: {
   if (!isMatrixAudioMediaEnabled(params.cfg)) {
     return false;
   }
-  const content = params.content;
-  const contentUrl = "url" in content && typeof content.url === "string" ? content.url : undefined;
-  const contentFile =
-    "file" in content && content.file && typeof content.file === "object"
-      ? content.file
-      : undefined;
-  const mediaUrl = contentUrl ?? contentFile?.url;
-  const contentInfo =
-    "info" in content && content.info && typeof content.info === "object"
-      ? (content.info as { mimetype?: string })
-      : undefined;
+  const mediaContent = resolveMatrixInboundMediaContent(params.content);
   return (
-    mediaUrl?.startsWith("mxc://") === true &&
+    mediaContent.url?.startsWith("mxc://") === true &&
     isMatrixAudioContent({
-      msgtype: typeof content.msgtype === "string" ? content.msgtype : undefined,
-      mimetype: contentInfo?.mimetype,
+      msgtype: typeof params.content.msgtype === "string" ? params.content.msgtype : undefined,
+      mimetype: mediaContent.contentType,
     })
   );
 }

--- a/extensions/matrix/src/matrix/monitor/handler-ingress-content.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-ingress-content.ts
@@ -9,6 +9,7 @@ import { resolveMatrixMonitorCommandAccess } from "./access-state.js";
 import {
   isMatrixAudioMediaEnabled,
   resolveMatrixInboundBodyText,
+  resolveMatrixInboundMediaContent,
   resolveMatrixMentionPrecheckText,
   resolveMatrixPendingHistoryText,
 } from "./handler-helpers.js";
@@ -116,22 +117,8 @@ export async function resolveMatrixIngressContent(config: {
     content,
     locationText: locationPayload?.text,
   });
-  const contentUrl = "url" in content && typeof content.url === "string" ? content.url : undefined;
-  const contentFile =
-    "file" in content && content.file && typeof content.file === "object"
-      ? content.file
-      : undefined;
-  const mediaUrl = contentUrl ?? contentFile?.url;
-  const earlyContentInfo =
-    "info" in content && content.info && typeof content.info === "object"
-      ? (content.info as { mimetype?: string; size?: number })
-      : undefined;
-  const earlyContentType = earlyContentInfo?.mimetype;
-  const earlyContentSize =
-    typeof earlyContentInfo?.size === "number" ? earlyContentInfo.size : undefined;
-  const earlyContentBody = typeof content.body === "string" ? content.body.trim() : "";
-  const earlyContentFilename = typeof content.filename === "string" ? content.filename.trim() : "";
-  const earlyOriginalFilename = earlyContentFilename || earlyContentBody || undefined;
+  let mediaContent = resolveMatrixInboundMediaContent(content);
+  const mediaUrl = mediaContent.url;
   const pendingHistoryText = resolveMatrixPendingHistoryText({
     mentionPrecheckText,
     content,
@@ -173,7 +160,7 @@ export async function resolveMatrixIngressContent(config: {
   const shouldRunMatrixAudioPreflight =
     isMatrixAudioContent({
       msgtype: typeof content.msgtype === "string" ? content.msgtype : undefined,
-      mimetype: earlyContentType,
+      mimetype: mediaContent.contentType,
     }) &&
     isMatrixAudioMediaEnabled(cfg) &&
     preflightAudioMediaUrl !== undefined;
@@ -208,11 +195,11 @@ export async function resolveMatrixIngressContent(config: {
       preflightMedia = await downloadMatrixMedia({
         client,
         mxcUrl: preflightAudioMediaUrl,
-        contentType: earlyContentType,
-        sizeBytes: earlyContentSize,
+        contentType: mediaContent.contentType,
+        sizeBytes: mediaContent.sizeBytes,
         maxBytes: mediaMaxBytes,
-        file: contentFile,
-        originalFilename: earlyOriginalFilename,
+        file: mediaContent.file,
+        originalFilename: mediaContent.originalFilename,
       });
     } catch (err) {
       preflightMediaDownloadFailed = true;
@@ -227,7 +214,7 @@ export async function resolveMatrixIngressContent(config: {
         roomId,
         eventId: event.event_id,
         msgtype: content.msgtype,
-        encrypted: Boolean(contentFile),
+        encrypted: Boolean(mediaContent.file),
         error: errorText,
       });
     }
@@ -373,6 +360,7 @@ export async function resolveMatrixIngressContent(config: {
       msgtype: "m.text",
       body: pollSnapshot.text,
     };
+    mediaContent = resolveMatrixInboundMediaContent(content);
   }
 
   let media: {
@@ -382,32 +370,17 @@ export async function resolveMatrixIngressContent(config: {
   } | null = preflightMedia;
   let mediaDownloadFailed = preflightMediaDownloadFailed;
   let mediaSizeLimitExceeded = preflightMediaSizeLimitExceeded;
-  const finalContentUrl =
-    "url" in content && typeof content.url === "string" ? content.url : undefined;
-  const finalContentFile =
-    "file" in content && content.file && typeof content.file === "object"
-      ? content.file
-      : undefined;
-  const finalMediaUrl = finalContentUrl ?? finalContentFile?.url;
-  const contentBody = typeof content.body === "string" ? content.body.trim() : "";
-  const contentFilename = typeof content.filename === "string" ? content.filename.trim() : "";
-  const originalFilename = contentFilename || contentBody || undefined;
-  const contentInfo =
-    "info" in content && content.info && typeof content.info === "object"
-      ? (content.info as { mimetype?: string; size?: number })
-      : undefined;
-  const contentType = contentInfo?.mimetype;
-  const contentSize = typeof contentInfo?.size === "number" ? contentInfo.size : undefined;
+  const finalMediaUrl = mediaContent.url;
   if (!media && !mediaDownloadFailed && finalMediaUrl?.startsWith("mxc://")) {
     try {
       media = await downloadMatrixMedia({
         client,
         mxcUrl: finalMediaUrl,
-        contentType,
-        sizeBytes: contentSize,
+        contentType: mediaContent.contentType,
+        sizeBytes: mediaContent.sizeBytes,
         maxBytes: mediaMaxBytes,
-        file: finalContentFile,
-        originalFilename,
+        file: mediaContent.file,
+        originalFilename: mediaContent.originalFilename,
       });
     } catch (err) {
       mediaDownloadFailed = true;
@@ -422,13 +395,13 @@ export async function resolveMatrixIngressContent(config: {
         roomId,
         eventId: event.event_id,
         msgtype: content.msgtype,
-        encrypted: Boolean(finalContentFile),
+        encrypted: Boolean(mediaContent.file),
         error: errorText,
       });
     }
   }
 
-  const rawBody = locationPayload?.text ?? contentBody;
+  const rawBody = locationPayload?.text ?? mediaContent.body;
   let bodyText = resolveMatrixInboundBodyText({
     rawBody,
     filename: typeof content.filename === "string" ? content.filename : undefined,

--- a/extensions/matrix/src/matrix/monitor/handler.audio-preflight.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.audio-preflight.test.ts
@@ -170,6 +170,51 @@ describe("createMatrixRoomMessageHandler audio preflight", () => {
     });
   });
 
+  it("transcribes encrypted room audio when a blank top-level URL masks its file URL", async () => {
+    downloadMatrixMediaMock.mockResolvedValue({
+      path: "/tmp/inbound/encrypted-voice.ogg",
+      contentType: "audio/ogg",
+      placeholder: "[matrix audio attachment]",
+    });
+    transcribeFirstAudioMock.mockResolvedValue("bot can you hear this encrypted voice note");
+    const { handler, recordInboundSession } = createAudioPreflightHarness({
+      isDirectMessage: false,
+      historyLimit: 5,
+      mentionRegexes: [/\bbot\b/i],
+      roomsConfig: {
+        "!room:example.org": { requireMention: true } as never,
+      },
+    });
+    const file = {
+      url: "mxc://example/encrypted-voice",
+      key: { kty: "oct", key_ops: ["encrypt"], alg: "A256CTR", k: "secret", ext: true },
+      iv: "iv",
+      hashes: { sha256: "hash" },
+      v: "v2",
+    };
+
+    await handler(
+      "!room:example.org",
+      createAudioEvent({
+        msgtype: "m.audio",
+        body: " \t ",
+        url: " ",
+        file,
+        info: { mimetype: "audio/ogg", size: 12345 },
+      }),
+    );
+
+    expect(downloadMatrixMediaMock).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ mxcUrl: "mxc://example/encrypted-voice", file }),
+    );
+    expect(transcribeFirstAudioMock).toHaveBeenCalledOnce();
+    expect(expectLatestInboundContext(recordInboundSession)).toMatchObject({
+      BodyForAgent: expect.stringContaining("bot can you hear this encrypted voice note"),
+      MediaPath: "/tmp/inbound/encrypted-voice.ogg",
+      WasMentioned: true,
+    });
+  });
+
   it("keeps non-filename audio fallback text while still surfacing the transcript", async () => {
     downloadMatrixMediaMock.mockResolvedValue({
       path: "/tmp/inbound/voice.ogg",

--- a/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
@@ -434,6 +434,42 @@ describe("matrix group chat history — scenario 1: basic accumulation", () => {
     );
   });
 
+  it("preserves encrypted media-only history when a blank top-level URL masks its file URL", async () => {
+    const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+    const { handler } = createGroupHistoryHandler(finalizeInboundContext);
+
+    await handler(
+      DEFAULT_ROOM,
+      createMatrixRoomMessageEvent({
+        eventId: "$encrypted-media-a",
+        originServerTs: 1000,
+        content: {
+          msgtype: "m.image",
+          body: " \t ",
+          url: "",
+          file: {
+            url: "mxc://example.org/encrypted-media-a",
+            key: { kty: "oct", key_ops: ["encrypt"], alg: "A256CTR", k: "secret", ext: true },
+            iv: "iv",
+            hashes: { sha256: "hash" },
+            v: "v2",
+          },
+        },
+      }),
+    );
+    expect(finalizeInboundContext).not.toHaveBeenCalled();
+
+    await handler(
+      DEFAULT_ROOM,
+      makeRoomTriggerEvent({ eventId: "$trigger-encrypted-media", body: "trigger", ts: 2000 }),
+    );
+
+    expectSomeBodyContaining(
+      inboundHistoryBodies(finalizeInboundContext, 0),
+      "[matrix image attachment]",
+    );
+  });
+
   it("includes skipped poll updates in next trigger history", async () => {
     const getEvent = vi.fn(async () => ({
       event_id: "$poll",

--- a/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
@@ -154,6 +154,48 @@ describe("createMatrixRoomMessageHandler media failures", () => {
     );
   });
 
+  it.each(["", " \t "])(
+    "downloads encrypted image attachments when the top-level URL is blank (%j)",
+    async (url) => {
+      downloadMatrixMediaMock.mockResolvedValue({
+        path: "/tmp/inbound/encrypted-image.png",
+        contentType: "image/png",
+        placeholder: "[matrix image attachment]",
+      });
+      const { handler, recordInboundSession } = createMediaFailureHarness();
+      const file = {
+        url: "mxc://example/encrypted-image",
+        key: { kty: "oct", key_ops: ["encrypt"], alg: "A256CTR", k: "secret", ext: true },
+        iv: "iv",
+        hashes: { sha256: "hash" },
+        v: "v2",
+      };
+
+      await handler(
+        "!room:example.org",
+        createImageEvent({
+          msgtype: "m.image",
+          body: " \t ",
+          filename: " encrypted-image.png ",
+          url,
+          file,
+          info: { mimetype: "image/png", size: 123 },
+        }),
+      );
+
+      expect(downloadMatrixMediaMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mxcUrl: "mxc://example/encrypted-image",
+          file,
+          originalFilename: "encrypted-image.png",
+        }),
+      );
+      expect(firstInboundContext(recordInboundSession).MediaPath).toBe(
+        "/tmp/inbound/encrypted-image.png",
+      );
+    },
+  );
+
   it("replaces bare image filenames with an unavailable marker when unencrypted download fails", async () => {
     downloadMatrixMediaMock.mockRejectedValue(new Error("download failed"));
     const { handler, recordInboundSession, logger, runtime } = createMediaFailureHarness();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix users sending encrypted images or voice notes would have their attachments silently discarded when a client included an empty or whitespace-only top-level media URL alongside the valid encrypted file URL. Unmentioned image attachments also disappeared from later room history, and encrypted voice notes could not be transcribed or satisfy mention-required room admission.

## Why This Change Was Made

Matrix inbound media metadata was interpreted separately by room audio admission, early message/history processing, and final attachment download, and all three paths treated a blank top-level URL as authoritative. One plugin-owned normalized media record now selects the first nonblank URL, preserves the original encrypted file and byte-limit metadata, and feeds all three existing paths. Poll replacement, captions, authorization, mention policy, and one-download semantics remain unchanged.

## User Impact

Encrypted Matrix images reach the agent, image-only room messages remain visible in later context, and encrypted voice notes are transcribed and admitted when their transcript mentions the bot. Valid unencrypted attachments and existing failure/size-limit behavior are unchanged.

## Evidence

- Before the fix, four real Matrix ingress regressions failed: empty and whitespace top-level image URLs both produced zero downloads, encrypted room audio produced zero downloads/transcriptions, and encrypted image-only room history lost its attachment marker.
- After the fix, the canonical Matrix Vitest extension project passes **309 tests across nine suites**, including media failures, audio preflight, group history, media decryption, the complete room-message handler, thread roots, reply/thread context, and events.
- All five changed TypeScript production/test files pass their real strict extension project configuration with zero diagnostics; each check loads more than 10,000 project/dependency source files.
- Targeted formatter and linter checks pass; max-lines, environment-count, and assertion-safety ratchets pass. The assertion baseline shrinks by the two obsolete casts removed from the ingress owner.
- Independent review and authenticated Codex autoreview found no actionable issues.
- Production delta: **+40/-58 (net -18 lines)**; regression tests: +123 lines; stale assertion baseline: -1 line.
- Reviewed head: `1109323ef7d0359c43692e4db31eb099718b0881`.
- A live authenticated Matrix homeserver/account is unavailable in this checkout; proof uses the actual Matrix room-message handler with existing channel/runtime fixtures, real encrypted payload shapes, and provider-boundary regression coverage.
