### PR TITLE
test(plugins): restore metadata lifecycle contract

### DIFF
--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -103,7 +103,7 @@ describe("manifest model id normalization", () => {
     tempDirs.cleanup();
   });
 
-  it("reflects manifest edits and state directory changes without a prepared snapshot", () => {
+  it("keeps process metadata stable until the lifecycle owner reloads it", () => {
     const stateDirA = tempDirs.make("openclaw-model-id-normalization-");
     const pluginDirA = path.join(stateDirA, "extensions", "normalizer");
     writeInstallIndex({ stateDir: stateDirA, pluginDir: pluginDirA });
@@ -117,6 +117,9 @@ describe("manifest model id normalization", () => {
     expect(normalizeDemoModel()).toBe("alpha/demo-model");
 
     writeNormalizerManifest({ pluginDir: pluginDirA, prefix: "bravo-local" });
+    expect(normalizeDemoModel()).toBe("alpha/demo-model");
+
+    clearPluginMetadataLifecycleCaches();
     expect(normalizeDemoModel()).toBe("bravo-local/demo-model");
 
     const stateDirB = tempDirs.make("openclaw-model-id-normalization-");


### PR DESCRIPTION
## Summary

- restore the plugin metadata lifecycle contract in the model-ID normalization regression test
- prove raw manifest edits remain invisible within the active metadata generation
- prove the lifecycle owner's explicit cache clear publishes the edited manifest on the next lookup

## Root cause

Commit `aa16e628a13` made cold unscoped metadata discovery adopt the snapshot as process metadata, matching the plugin boundary's process-stable metadata contract. An older test had been inverted by `77796591370d` to expect same-process filesystem freshness without a lifecycle reload, so the full plugin prerelease shard failed once cold discovery correctly reused its adopted snapshot.

The architectural owner is `clearPluginMetadataLifecycleCaches()`, which the gateway metadata-change watcher invokes before scheduling plugin reload. The test now exercises that same owner boundary instead of requiring request-time manifest rescans.

## Verification

- reproduced exact failure: `node scripts/run-vitest.mjs src/plugins/manifest-model-id-normalization.test.ts`
- focused + sibling metadata proof: `node scripts/run-vitest.mjs src/plugins/manifest-model-id-normalization.test.ts src/plugins/plugin-metadata-snapshot.test.ts src/plugins/manifest-metadata-scan.test.ts src/plugins/setup-registry.lifecycle.test.ts` (43 passed)
- `node scripts/check-changed.mjs -- src/plugins/manifest-model-id-normalization.test.ts`
- `git diff --check`
- autoreview: clean, no actionable findings

## Scope

- production LOC: `+0/-0`
- tests: `+4/-1`
- no runtime, config, protocol, or public-contract changes

Fixes the `Plugin Prerelease` failure in run 32917858665, job 98025433463.
