### PR TITLE
fix(qa-lab): restore Crabline artifact fixtures

### DIFF
--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -242,10 +242,10 @@ describe("isolated QA suite transport cleanup", () => {
   it("keeps Crabline workers concurrent while publishing readiness only from the final aggregate", async () => {
     const lab = createCleanupTestLab();
     const selection = {
-      capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+      capabilityMatrixPath: "crabline-channel-driver-capabilities.json",
       channel: "telegram",
       channelDriver: "crabline",
-      smokeArtifactPath: "crabline-fake-provider-smoke.json",
+      providerReadinessArtifactPath: "crabline-provider-readiness.json",
     } as const;
     let activeWorkers = 0;
     let maxActiveWorkers = 0;

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
@@ -284,10 +284,10 @@ describe("runtime parity suite transport cleanup", () => {
     mocks.writeQaSuiteArtifacts.mockClear();
     const scenario = makeQaSuiteTestScenario("runtime-cleanup");
     const selection = {
-      capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+      capabilityMatrixPath: "crabline-channel-driver-capabilities.json",
       channel: "telegram",
       channelDriver: "crabline",
-      smokeArtifactPath: "crabline-fake-provider-smoke.json",
+      providerReadinessArtifactPath: "crabline-provider-readiness.json",
     } as const;
     const parentLab = createCleanupTestLab();
     const openClawLab = createCleanupTestLab();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA Lab extension typechecking failed because two cleanup fixtures still used Crabline's retired smoke artifact shape.

## Why This Change Was Made

Commit `cc1c61034fc0` added the two fixture objects after #118008 had migrated Crabline to its canonical server artifact contract. Both fixtures now use `crabline-channel-driver-capabilities.json` and `crabline-provider-readiness.json`, matching `OpenClawCrablineChannelDriverSelection`.

## User Impact

No user-visible behavior changes. Maintainers regain a green QA Lab extension typecheck without weakening the fixture or the Crabline contract.

## Evidence

Pre-fix reproduction:

```text
pnpm tsgo:extensions:test

extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts(323,9): error TS2741:
Property 'providerReadinessArtifactPath' is missing...

extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts(338,9): error TS2741:
Property 'providerReadinessArtifactPath' is missing...
```

Validation on exact base `9c30c920feec940e50e16fc6905e3489054396a2`:

- `pnpm tsgo:extensions:test`
- `pnpm test:extension qa-lab -- extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts` - 2 files, 13 tests passed
- `pnpm check:changed -- extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts`
- Autoreview: clean, no accepted/actionable findings

Production LOC: `+0/-0`

Tests: `+4/-4`

No changelog entry: this is a test-fixture contract repair with no user-visible or runtime behavior change.
