### PR TITLE
refactor(gateway): consolidate pairing approval ownership

### DIFF
--- a/src/gateway/server/ws-connection/connect-device-pairing.ts
+++ b/src/gateway/server/ws-connection/connect-device-pairing.ts
@@ -42,10 +42,7 @@ import {
 import { issueGatewayConnectDeviceTokens } from "./connect-device-tokens.js";
 import { authorizeExistingGatewayDevice } from "./connect-existing-device.js";
 import { startGatewayNodePairingSshApproval } from "./connect-node-pairing-ssh.js";
-import {
-  resolvePairingApprovalPlan,
-  resolveTrustedProxyDeviceAutoApproveScopes,
-} from "./connect-pairing-approval-plan.js";
+import { resolvePairingApprovalPlan } from "./connect-pairing-approval-plan.js";
 import type {
   AuthenticatedGatewayConnect,
   DeviceAuthorizedGatewayConnect,
@@ -86,18 +83,29 @@ export async function authorizeGatewayConnectDevice(
     skipLocalBackendSelfPairing,
     controlUiPairingKind,
   } = state;
-  const roleConfiguredHumanOperator = role === "operator" && Boolean(configSnapshot.gateway?.roles);
-  const sharedSecretOwner = authMethod === "token" || authMethod === "password";
-  if (roleConfiguredHumanOperator && !sharedSecretOwner && !authResult.user?.trim()) {
-    const message = "operator role policies require a verified user identity";
+  const failPairingHandshake = (params: {
+    message: string;
+    details?: ReturnType<typeof buildPairingConnectErrorDetails>;
+    closeCause?: { cause: string; meta: Record<string, unknown> };
+    closeReason?: string;
+  }) => {
+    const { message, details, closeCause, closeReason } = params;
     setHandshakeState("failed");
+    if (closeCause) {
+      setCloseCause(closeCause.cause, closeCause.meta);
+    }
     send({
       type: "res",
       id: frame.id,
       ok: false,
-      error: errorShape(ErrorCodes.NOT_PAIRED, message),
+      error: errorShape(ErrorCodes.NOT_PAIRED, message, details ? { details } : undefined),
     });
-    close(1008, truncateCloseReason(message));
+    close(1008, truncateCloseReason(closeReason ?? message));
+  };
+  const roleConfiguredHumanOperator = role === "operator" && Boolean(configSnapshot.gateway?.roles);
+  const sharedSecretOwner = authMethod === "token" || authMethod === "password";
+  if (roleConfiguredHumanOperator && !sharedSecretOwner && !authResult.user?.trim()) {
+    failPairingHandshake({ message: "operator role policies require a verified user identity" });
     return undefined;
   }
   let hasServerApprovedDeviceTokenBaseline = false;
@@ -143,19 +151,14 @@ export async function authorizeGatewayConnectDevice(
       const pairingStateAllowsRequestedAccess = (
         pairedCandidate: Awaited<ReturnType<typeof getPairedDevice>>,
         requestedScopes = scopes,
-      ): boolean => {
-        if (!pairedCandidate || pairedCandidate.publicKey !== devicePublicKey) {
-          return false;
-        }
-        if (!hasEffectivePairedDeviceRole(pairedCandidate, role)) {
-          return false;
-        }
-        return roleScopesAllow({
+      ): boolean =>
+        pairedCandidate?.publicKey === devicePublicKey &&
+        hasEffectivePairedDeviceRole(pairedCandidate, role) &&
+        roleScopesAllow({
           role,
           requestedScopes,
           allowedScopes: resolvePairedAccessScopes(pairedCandidate),
         });
-      };
       const plan = await resolvePairingApprovalPlan({
         reason,
         existingPairedDevice,
@@ -168,25 +171,15 @@ export async function authorizeGatewayConnectDevice(
         deviceId: device.id,
         devicePublicKey,
         scopes,
+        hasRequestedScopes,
+        connectionScopeCap: (capped) =>
+          applyConnectionScopeCap({ scopes: capped, upgradeReq: context.handler.upgradeReq }),
       });
-      const trustedProxyAutoApproveConfig =
-        configSnapshot.gateway?.auth?.trustedProxy?.deviceAutoApprove;
-      const trustedProxyUser = authResult.user?.trim();
-      const trustedProxyAutoApproveScopes = plan.allowTrustedProxyDeviceAutoApproval
-        ? applyConnectionScopeCap({
-            scopes: resolveTrustedProxyDeviceAutoApproveScopes({
-              requestedScopes: scopes,
-              hasRequestedScopes,
-              configuredScopes: trustedProxyAutoApproveConfig?.scopes,
-            }),
-            upgradeReq: context.handler.upgradeReq,
-          })
-        : null;
       // Same-key reconnects reuse paired grants without pairing or false upgrade audits.
       if (
         reason === "scope-upgrade" &&
         plan.isTrustedProxySameKeyUpgrade &&
-        trustedProxyAutoApproveScopes !== null
+        plan.trustedProxyAutoApproveScopes !== null
       ) {
         // Authority is the live row, not the pre-plan snapshot: a revoke, key
         // replacement, or grant reduction landing during the plan await must
@@ -195,11 +188,11 @@ export async function authorizeGatewayConnectDevice(
         const livePaired = await getPairedDevice(device.id);
         if (
           livePaired &&
-          pairingStateAllowsRequestedAccess(livePaired, trustedProxyAutoApproveScopes)
+          pairingStateAllowsRequestedAccess(livePaired, plan.trustedProxyAutoApproveScopes)
         ) {
           const livePairedScopes = resolvePairedAccessScopes(livePaired);
           scopes = normalizeSortedUniqueTrimmedStringList(
-            [...scopes, ...trustedProxyAutoApproveScopes].filter((scope) =>
+            [...scopes, ...plan.trustedProxyAutoApproveScopes].filter((scope) =>
               roleScopesAllow({ role, requestedScopes: [scope], allowedScopes: livePairedScopes }),
             ),
           );
@@ -229,7 +222,7 @@ export async function authorizeGatewayConnectDevice(
       });
       const trustedProxyApprovalScopes =
         pairing.request.isRepair !== true || plan.isTrustedProxySameKeyUpgrade
-          ? trustedProxyAutoApproveScopes
+          ? plan.trustedProxyAutoApproveScopes
           : null;
       const requestContext = buildRequestContext();
       // A replacement request obsoletes older pending requestIds; tell approval
@@ -305,9 +298,9 @@ export async function authorizeGatewayConnectDevice(
           if (plan.bootstrapApprovalProfile) {
             handoffBootstrapProfile = plan.bootstrapApprovalProfile;
           }
-          if (trustedProxyApprovalScopes !== null && trustedProxyUser) {
+          if (trustedProxyApprovalScopes !== null && plan.trustedProxyUser) {
             logGateway.warn(
-              `security audit: trusted-proxy browser device auto-approved user=${formatForLog(trustedProxyUser)} device=${formatForLog(approved.device.deviceId.slice(0, 12))} scopes=${formatAuditList(scopes)}`,
+              `security audit: trusted-proxy browser device auto-approved user=${formatForLog(plan.trustedProxyUser)} device=${formatForLog(approved.device.deviceId.slice(0, 12))} scopes=${formatAuditList(scopes)}`,
             );
           } else {
             logGateway.info(
@@ -401,46 +394,34 @@ export async function authorizeGatewayConnectDevice(
         // pairing-required behavior pauses the client reconnect loop.
         const retryWhileDetachedApprovalPending =
           retryAfterBootstrapPairingApproval || sshVerifyStarted;
-        const pairingErrorDetails = buildPairingConnectErrorDetails({
-          reason,
-          requestId: recoveryRequestId,
-          ...(retryWhileDetachedApprovalPending
-            ? {
-                recommendedNextStep: "wait_then_retry",
-                retryable: true,
-                pauseReconnect: false,
-              }
-            : {}),
-          deviceId: device.id,
-          requestedRole: role,
-          requestedScopes: scopes,
-          ...(approvedRoles.length > 0 ? { approvedRoles } : {}),
-          ...(approvedScopes.length > 0 ? { approvedScopes } : {}),
-        });
-        const pairingErrorMessage = buildPairingConnectErrorMessage(reason);
-        setHandshakeState("failed");
-        setCloseCause("pairing-required", {
-          deviceId: device.id,
-          ...(recoveryRequestId ? { requestId: recoveryRequestId } : {}),
-          reason,
-        });
-        send({
-          type: "res",
-          id: frame.id,
-          ok: false,
-          error: errorShape(ErrorCodes.NOT_PAIRED, pairingErrorMessage, {
-            details: pairingErrorDetails,
+        failPairingHandshake({
+          message: buildPairingConnectErrorMessage(reason),
+          details: buildPairingConnectErrorDetails({
+            reason,
+            requestId: recoveryRequestId,
+            ...(retryWhileDetachedApprovalPending
+              ? {
+                  recommendedNextStep: "wait_then_retry",
+                  retryable: true,
+                  pauseReconnect: false,
+                }
+              : {}),
+            deviceId: device.id,
+            requestedRole: role,
+            requestedScopes: scopes,
+            ...(approvedRoles.length > 0 ? { approvedRoles } : {}),
+            ...(approvedScopes.length > 0 ? { approvedScopes } : {}),
           }),
-        });
-        close(
-          1008,
-          truncateCloseReason(
-            buildPairingConnectCloseReason({
+          closeCause: {
+            cause: "pairing-required",
+            meta: {
+              deviceId: device.id,
+              ...(recoveryRequestId ? { requestId: recoveryRequestId } : {}),
               reason,
-              requestId: recoveryRequestId,
-            }),
-          ),
-        );
+            },
+          },
+          closeReason: buildPairingConnectCloseReason({ reason, requestId: recoveryRequestId }),
+        });
         return false;
       }
       return true;
@@ -517,14 +498,7 @@ export async function authorizeGatewayConnectDevice(
     (!pairedBrowserOrigin || !browserCopilotOrigin || pairedBrowserOrigin !== browserCopilotOrigin);
   if (browserCopilotIdentityMismatch || browserCopilotOriginMismatch) {
     const message = "browser copilot requires a dedicated paired device identity";
-    setHandshakeState("failed");
-    send({
-      type: "res",
-      id: frame.id,
-      ok: false,
-      error: errorShape(ErrorCodes.NOT_PAIRED, message),
-    });
-    close(1008, truncateCloseReason(message));
+    failPairingHandshake({ message });
     return undefined;
   }
 

--- a/src/gateway/server/ws-connection/connect-existing-device.ts
+++ b/src/gateway/server/ws-connection/connect-existing-device.ts
@@ -131,42 +131,38 @@ export async function authorizeExistingGatewayDevice(params: {
           publicKey: devicePublicKey,
         })
       : null;
-  if (retryBootstrapHandoffProfile) {
+  if (
+    retryBootstrapHandoffProfile &&
+    isSetupCodeHandoffBootstrapClient({
+      profile: retryBootstrapHandoffProfile,
+      client: connectParams.client,
+    })
+  ) {
     const retryBootstrapOperatorScopes = resolveBootstrapProfileScopesForRole(
       "operator",
       retryBootstrapHandoffProfile.scopes,
       retryBootstrapHandoffProfile.purpose,
     );
+    const pairedAllowsHandoff =
+      pairedRoles.includes("operator") &&
+      roleScopesAllow({
+        role: "operator",
+        requestedScopes: retryBootstrapOperatorScopes,
+        allowedScopes: pairedScopes,
+      });
+    if (!pairedAllowsHandoff && !(await requirePairing("scope-upgrade", paired))) {
+      return { ok: false, handoffBootstrapProfile };
+    }
     if (
-      isSetupCodeHandoffBootstrapClient({
+      pairedDeviceAllowsBootstrapOperator({
+        device: device ? await getPairedDevice(device.id) : null,
+        devicePublicKey,
         profile: retryBootstrapHandoffProfile,
-        client: connectParams.client,
       })
     ) {
-      const pairedAllowsHandoff =
-        pairedRoles.includes("operator") &&
-        roleScopesAllow({
-          role: "operator",
-          requestedScopes: retryBootstrapOperatorScopes,
-          allowedScopes: pairedScopes,
-        });
-      if (!pairedAllowsHandoff) {
-        if (!(await requirePairing("scope-upgrade", paired))) {
-          return { ok: false, handoffBootstrapProfile };
-        }
-      }
-      const pairedAfterBootstrapUpgrade = device ? await getPairedDevice(device.id) : null;
-      if (
-        pairedDeviceAllowsBootstrapOperator({
-          device: pairedAfterBootstrapUpgrade,
-          devicePublicKey,
-          profile: retryBootstrapHandoffProfile,
-        })
-      ) {
-        // The setup code is the owner-approved upgrade artifact. Reuse the
-        // same handoff after retrying or promoting an existing mobile pairing.
-        handoffBootstrapProfile = retryBootstrapHandoffProfile;
-      }
+      // The setup code is the owner-approved upgrade artifact. Reuse the
+      // same handoff after retrying or promoting an existing mobile pairing.
+      handoffBootstrapProfile = retryBootstrapHandoffProfile;
     }
   }
 

--- a/src/gateway/server/ws-connection/connect-pairing-approval-plan.ts
+++ b/src/gateway/server/ws-connection/connect-pairing-approval-plan.ts
@@ -32,7 +32,7 @@ const DEFAULT_TRUSTED_PROXY_DEVICE_AUTO_APPROVE_SCOPES = [
   "operator.questions",
 ] as const;
 
-export function resolveTrustedProxyDeviceAutoApproveScopes(params: {
+function resolveTrustedProxyDeviceAutoApproveScopes(params: {
   requestedScopes: string[];
   hasRequestedScopes: boolean;
   configuredScopes?: string[];
@@ -60,7 +60,8 @@ export type PairingApprovalPlan = {
   /** Request is created silent and immediately self-approved by its lane. */
   silent: boolean;
   allowSilentLocalPairing: boolean;
-  allowTrustedProxyDeviceAutoApproval: boolean;
+  trustedProxyAutoApproveScopes: string[] | null;
+  trustedProxyUser: string | undefined;
   isTrustedProxySameKeyUpgrade: boolean;
   allowSetupCodeHandoffBootstrapPairing: boolean;
   allowControlUiOwnerBootstrapPairing: boolean;
@@ -87,9 +88,10 @@ export async function resolvePairingApprovalPlan(params: {
   deviceId: string;
   devicePublicKey: string;
   scopes: string[];
+  hasRequestedScopes: boolean;
+  connectionScopeCap: (scopes: string[]) => string[];
 }): Promise<PairingApprovalPlan> {
-  const { reason, existingPairedDevice, state, configSnapshot, scopes } = params;
-  const { connectParams } = params;
+  const { reason, existingPairedDevice, state, connectParams, configSnapshot, scopes } = params;
   const {
     role,
     isControlUi,
@@ -101,9 +103,8 @@ export async function resolvePairingApprovalPlan(params: {
     bootstrapTokenCandidate,
     pairingLocality,
   } = state;
-  const allowSilentExistingNonOperatorPairing = !(existingPairedDevice && role !== "operator");
   const allowSilentLocalPairing =
-    allowSilentExistingNonOperatorPairing &&
+    !(existingPairedDevice && role !== "operator") &&
     shouldAllowSilentLocalPairing({
       autoApproveLocal: configSnapshot.gateway?.nodes?.pairing?.autoApproveLocal,
       locality: pairingLocality,
@@ -135,13 +136,21 @@ export async function resolvePairingApprovalPlan(params: {
   // mismatch stays a manual owner decision (possible deviceId squat).
   const isTrustedProxySameKeyUpgrade =
     reason === "scope-upgrade" && existingPairedDevice?.publicKey === params.devicePublicKey;
-  const allowTrustedProxyDeviceAutoApproval =
+  const trustedProxyAutoApproveScopes =
     ((reason === "not-paired" && !existingPairedDevice) || isTrustedProxySameKeyUpgrade) &&
     role === "operator" &&
     (isBrowserOperatorUi || isWebchat) &&
     authMethod === "trusted-proxy" &&
     Boolean(trustedProxyUser) &&
-    trustedProxyAutoApproveConfig?.enabled === true;
+    trustedProxyAutoApproveConfig?.enabled === true
+      ? params.connectionScopeCap(
+          resolveTrustedProxyDeviceAutoApproveScopes({
+            requestedScopes: scopes,
+            hasRequestedScopes: params.hasRequestedScopes,
+            configuredScopes: trustedProxyAutoApproveConfig?.scopes,
+          }),
+        )
+      : null;
   const isSetupCodeMobileNodeConnect = isMobileNodeBootstrapConnect({
     role,
     scopes,
@@ -226,7 +235,8 @@ export async function resolvePairingApprovalPlan(params: {
       allowSetupCodeHandoffBootstrapPairing ||
       allowControlUiOperatorBootstrapPairing,
     allowSilentLocalPairing,
-    allowTrustedProxyDeviceAutoApproval,
+    trustedProxyAutoApproveScopes,
+    trustedProxyUser,
     isTrustedProxySameKeyUpgrade,
     allowSetupCodeHandoffBootstrapPairing,
     allowControlUiOwnerBootstrapPairing,


### PR DESCRIPTION
## What Problem This Solves

Follow-up cleanup to #129563. The pairing authorization surface carried three coherence debts:

1. **Split ownership of the trusted-proxy grant decision:** `resolvePairingApprovalPlan` decided auto-approval *eligibility* while `requirePairing` separately re-read the trustedProxy config, re-trimmed the verified user, and computed the capped grant — two readers of one config, and the decision "may we auto-approve, and for what" lived in two files.
2. **Three hand-rolled copies of the same handshake-failure shape** (`setHandshakeState("failed")` → optional `setCloseCause` → send NOT_PAIRED → `close(1008, …)`) inside `authorizeGatewayConnectDevice`.
3. A dead pre-computation and a condition pyramid in `connect-existing-device`'s bootstrap-retry block (operator scopes computed before the handoff-client check that gates their only use).

## Why This Change Was Made

Behavior-neutral consolidation, one owner per decision:

- The approval plan now returns `trustedProxyAutoApproveScopes` (the capped grant, `null` when ineligible) and `trustedProxyUser`; `requirePairing`'s fast path and inline-approval lane consume them. The `allowTrustedProxyDeviceAutoApproval` flag and the `resolveTrustedProxyDeviceAutoApproveScopes` export are gone — eligibility without an amount no longer exists as a concept. The connection scope cap is injected as a closure so the plan module stays free of HTTP types.
- One `failPairingHandshake` helper replaces the three failure blocks, preserving exact operation order and per-site behavior (the two simple sites still record no close cause).
- The bootstrap-retry block merges its nested guards into the flat gather→decide shape and computes scopes only where used.

No behavior change: identical grants, store writes, broadcast ordering, audit/log lines, close codes/reasons, and error details. The #129563 invariant (live paired-row reread as the last await before the fast-path decision) is preserved verbatim.

## User Impact

None — internal refactor. Production LOC −20 (+100/−120), tests unchanged.

## Evidence

- `pnpm test src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts` (13 passed, incl. the #129563 regression), `server.auth.control-ui.test.ts` (40), `server-methods/device-scope-upgrade.test.ts` (4), `server.device-pair-approve-authz.test.ts` (8).
- `node scripts/check-changed.mjs` clean (typecheck/lint/guards).
- Fresh Codex autoreview clean.
- Behavior-neutral bounded refactor: focused suites + changed gates per validation policy; no issue/live proof required.
