### PR TITLE
fix(ci): restore release-validation lint gate

### DIFF
--- a/scripts/github/release-validation-campaign.d.mts
+++ b/scripts/github/release-validation-campaign.d.mts
@@ -27,8 +27,73 @@ export function validateReleaseValidationCampaignArtifact(
   },
 ): ReleaseValidationCampaignArtifact;
 
+type ReleaseValidationCampaignRepository = { owner: string; repo: string };
+
+type ReleaseValidationCampaignIssue = {
+  number: number;
+  state: string;
+  title: string;
+  body: string | null;
+  html_url: string;
+  labels?: Array<string | { name?: string }>;
+  pull_request?: object;
+};
+
+type ReleaseValidationCampaignIssueList = (
+  params: ReleaseValidationCampaignRepository & {
+    state: "open";
+    labels: string;
+    per_page: number;
+  },
+) => Promise<{ data: ReleaseValidationCampaignIssue[] }>;
+
+type ReleaseValidationCampaignGitHub = {
+  paginate(
+    endpoint: ReleaseValidationCampaignIssueList,
+    params: Parameters<ReleaseValidationCampaignIssueList>[0],
+  ): Promise<ReleaseValidationCampaignIssue[]>;
+  rest: {
+    issues: {
+      listForRepo: ReleaseValidationCampaignIssueList;
+      get(
+        params: ReleaseValidationCampaignRepository & { issue_number: number },
+      ): Promise<{ data: ReleaseValidationCampaignIssue | undefined }>;
+      getLabel(
+        params: ReleaseValidationCampaignRepository & { name: string },
+      ): Promise<{ data: object }>;
+      createLabel(
+        params: ReleaseValidationCampaignRepository & {
+          name: string;
+          color: string;
+          description: string;
+        },
+      ): Promise<{ data: object }>;
+      create(
+        params: ReleaseValidationCampaignRepository & {
+          title: string;
+          body: string;
+          labels: string[];
+        },
+      ): Promise<{ data: ReleaseValidationCampaignIssue }>;
+      update(
+        params: ReleaseValidationCampaignRepository & {
+          issue_number: number;
+          labels: string[];
+          state: "open" | "closed";
+          state_reason?: "completed";
+          title?: string;
+          body?: string;
+        },
+      ): Promise<{ data: ReleaseValidationCampaignIssue }>;
+      createComment(
+        params: ReleaseValidationCampaignRepository & { issue_number: number; body: string },
+      ): Promise<{ data: object }>;
+    };
+  };
+};
+
 export function runReleaseValidationCampaignPublish(params: {
-  github: any;
+  github: ReleaseValidationCampaignGitHub;
   context: { repo: { owner: string; repo: string } };
   core: { info(message: string): void; setOutput?(name: string, value: string): void };
   artifact: unknown;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the repository's main CI lint gate fails on the release-validation campaign declaration because its GitHub client parameter uses an explicit `any` type.

## Why This Change Was Made

Replaces the untyped parameter with a narrow structural contract covering exactly the issue pagination, read, label, create, update, and comment operations used by the campaign publisher. Runtime behavior is unchanged; the declaration now documents the actual Actions/Octokit boundary instead of bypassing type and lint checks.

## User Impact

No product behavior changes. Maintainers regain a green lint gate, and future changes to the campaign publisher are checked against the GitHub API surface it actually requires.

## Evidence

- Current `main` reproduced the failure in [`check-lint`](https://github.com/openclaw/openclaw/actions/runs/32917896716/job/98026550798): `scripts/github/release-validation-campaign.d.mts:31:11` violated `typescript(no-explicit-any)`.
- `node scripts/run-vitest.mjs test/scripts/release-validation-campaign.test.ts` — 8 tests passed.
- `node scripts/check-changed.mjs -- scripts/github/release-validation-campaign.d.mts` — formatting, script typecheck, lint, and repository guards passed.
- `git diff --check` — passed.
- Fresh mandatory autoreview found no actionable P0/P1 issues and judged the patch correct.
- Delta: tooling declarations +66/-1; production runtime and tests unchanged.
