### PR TITLE
perf(ui): replace warm refresh sleeps with owner signals

### DIFF
--- a/ui/src/e2e/session-owner-warm-refresh.e2e.test.ts
+++ b/ui/src/e2e/session-owner-warm-refresh.e2e.test.ts
@@ -2,6 +2,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
+import type { ApplicationContext } from "../app/context.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -81,9 +82,8 @@ suite.define(() => {
       await bob.waitFor();
       await captureSidebar(page, "warm-before-event.png");
 
-      // Hold the warm refresh open at its vulnerable point: the owner-scoped
-      // request resolves instantly (mocked response), the shared request stays
-      // deferred. Pre-#129558 the owner-only publish blanks Bob's row here.
+      // Hold the warm refresh open at its vulnerable point: release the
+      // owner-scoped response while the shared response remains deferred.
       const before = (await gateway.getRequests("sessions.list")).length;
       await gateway.deferNext("sessions.list", { ownerId: "profile-ada" });
       await gateway.deferNext("sessions.list");
@@ -95,21 +95,107 @@ suite.define(() => {
         updatedAt: 3,
       });
       await gateway.waitForRequest("sessions.list", { after: before + 1 });
+      const ownerProbe = await page.evaluateHandle(() => {
+        const app = document.querySelector<
+          HTMLElement & { runtime?: { context: ApplicationContext } }
+        >("openclaw-app");
+        const sidebar = document.querySelector<HTMLElement & { updateComplete: Promise<boolean> }>(
+          "openclaw-app-sidebar",
+        );
+        const sessions = app?.runtime?.context.sessions;
+        const row = sidebar?.querySelector('[data-session-key="agent:main:bob"]');
+        const scope = sessions?.captureConnectionScope();
+        if (!sidebar || !sessions || !row || !scope) {
+          throw new Error("The warm session owner or sidebar is unavailable");
+        }
+        let removed = false;
+        const observer = new MutationObserver((records) => {
+          removed ||= records.some(({ removedNodes }) =>
+            Array.from(removedNodes).some((node) => node === row || node.contains(row)),
+          );
+        });
+        observer.observe(sidebar, { childList: true, subtree: true });
+        return {
+          observer,
+          revision: sessions.canonicalListRevision,
+          row,
+          scope,
+          sessions,
+          sidebar,
+          wasRemoved: () => removed,
+        };
+      });
       await gateway.resolveDeferred("sessions.list", ownerRoster);
 
-      // The shared phase is still pending; the roster on screen must not shrink
-      // to the owner window. Sample repeatedly so a transient blank fails loud.
+      const ownerPhase = await ownerProbe.evaluate(async (probe) => {
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        });
+        await probe.sidebar.updateComplete;
+        return {
+          connected: probe.sessions.isConnectionScopeCurrent(probe.scope),
+          loading: probe.sessions.state.loading,
+          revisionAdvanced: probe.sessions.canonicalListRevision !== probe.revision,
+          rowConnected: probe.row.isConnected,
+          rowRemoved: probe.wasRemoved(),
+        };
+      });
+      expect(ownerPhase).toEqual({
+        connected: true,
+        loading: true,
+        revisionAdvanced: false,
+        rowConnected: true,
+        rowRemoved: false,
+      });
+      expect(
+        (await gateway.getRequests("sessions.list"))
+          .slice(before)
+          .map((request) => (request.params as { ownerId?: string }).ownerId ?? null),
+      ).toEqual(["profile-ada", null]);
+
       for (let sample = 0; sample < 6; sample += 1) {
-        await page.waitForTimeout(100);
         expect(await bob.count()).toBe(1);
         expect(await ada.count()).toBe(1);
       }
       await captureSidebar(page, "warm-shared-deferred.png");
 
       await gateway.resolveDeferred("sessions.list", sharedRoster);
+      const sharedPhase = await ownerProbe.evaluate(async (probe) => {
+        if (probe.sessions.canonicalListRevision === probe.revision) {
+          await new Promise<void>((resolve) => {
+            const unsubscribe = probe.sessions.subscribe(() => {
+              if (probe.sessions.canonicalListRevision > probe.revision) {
+                unsubscribe();
+                resolve();
+              }
+            });
+            if (probe.sessions.canonicalListRevision > probe.revision) {
+              unsubscribe();
+              resolve();
+            }
+          });
+        }
+        await probe.sidebar.updateComplete;
+        probe.observer.disconnect();
+        return {
+          connected: probe.sessions.isConnectionScopeCurrent(probe.scope),
+          loading: probe.sessions.state.loading,
+          revisionAdvanced: probe.sessions.canonicalListRevision > probe.revision,
+          rowConnected: probe.row.isConnected,
+          rowRemoved: probe.wasRemoved(),
+        };
+      });
+      expect(sharedPhase).toEqual({
+        connected: true,
+        loading: false,
+        revisionAdvanced: true,
+        rowConnected: true,
+        rowRemoved: false,
+      });
       await expect.poll(() => bob.count()).toBe(1);
       expect(await ada.count()).toBe(1);
       await captureSidebar(page, "warm-after-merge.png");
+      await ownerProbe.dispose();
     } finally {
       await context.close();
     }


### PR DESCRIPTION
## What Problem This Solves

The Control UI warm owner-first refresh regression spent at least 600 ms in six fixed sleeps on every CI run while checking that another person's session never disappears during the deferred shared-roster phase.

## Why This Change Was Made

Replace fixed-delay sampling with a continuous browser MutationObserver, the real browser-render/Lit update boundary, and the session owner's authoritative connection generation and canonical roster revision. Preserve every original Ada/Bob row assertion, prove the two requests are owner-first then shared, and verify the shared response is the only canonical publish.

## User Impact

No production behavior changes. Control UI ownership regression coverage is stronger and the existing browser test finishes faster.

## Evidence

- One task-owned Blacksmith Testbox, immutable main parent 0036788055b5631f95d5eaeff9a1ba684fd78bb3, exact baseline/candidate blobs verified before every run, one excluded warmup, one worker, distinct filesystem-module caches, import diagnostics, and eight order-balanced samples.
- Scoped wall mean: 10.625 s baseline -> 9.253 s candidate; -1.373 s (-12.9%). Browser test-body mean: 1,586 ms -> 972 ms; -615 ms. Vitest mean: 10.128 s -> 8.758 s. Import mean: 220 ms -> 218 ms. Peak-RSS means: 1,567,451 KiB -> 1,676,828 KiB (runner noise; no production/import change). CPU user/system means: 10.21/3.22 s -> 9.65/3.26 s. Every sample ran the same one passing test.
- Reversible production fault: invert the provisional-owner guard in ui/src/lib/sessions/session-roster-refresh.ts; the optimized browser test fails at its retained ownership assertion with loading=false, Bob rowConnected=false, and rowRemoved=true. Restore and hash-verify the production file immediately.
- Test audit: protects continuous foreign-owner visibility, stable connection ownership, owner/shared request ordering, and canonical publish ownership; catches the historical provisional owner-only publish; preserves the existing browser-only DOM/transport integration absent from unit coverage; adds no production seam.
- Owner unit regressions: 3 passed. Capture-off owner and sibling Chromium E2Es: 4 files / 17 tests passed, covering warm refresh, cold owner-first startup, owner assignment, and broader sharing/ownership behavior.
- Explicit capture mode passed and produced three inspected screenshots plus a browser video; both Ada and Bob remain visible before, during, and after the deferred shared phase.
- Final exact-file Chromium E2E passed. Complete explicit-path changed gate passed all formatting, guard, dead-code, Control UI i18n, core-test typecheck, and changed-file lint lanes. Fresh independent autoreview clean.
- Production LOC: +0/-0. Tests: +92/-6. No protocol, dependency, snapshot, baseline, production, or changelog change.

AI-assisted.
