### PR TITLE
fix(gateway): rank project picker GitHub search by relevance

### DIFF
--- a/src/gateway/project-github-search.test.ts
+++ b/src/gateway/project-github-search.test.ts
@@ -15,6 +15,10 @@ function repository(fullName: string, updatedAt: string, description?: string) {
   };
 }
 
+function requestUrl(input: Parameters<typeof fetch>[0] | undefined): string {
+  return typeof input === "string" ? input : input instanceof URL ? input.href : (input?.url ?? "");
+}
+
 function json(value: unknown, status = 200): Response {
   return new Response(JSON.stringify(value), {
     status,
@@ -87,6 +91,72 @@ describe("project GitHub search", () => {
       "Authorization",
       "Bearer test-github-token",
     );
+  });
+
+  it("preserves GitHub best-match order for global results instead of re-sorting by recency", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      json({
+        items: [
+          repository("openclaw/best-match", "2020-01-01T00:00:00Z"),
+          repository("someone/recently-pushed-fork", "2026-08-25T00:00:00Z"),
+        ],
+      }),
+    );
+
+    const result = await searchRemoteProjects("best-match", { env: {}, fetchImpl, now: 300 });
+
+    expect(result.projects.map((project) => project.fullName)).toEqual([
+      "openclaw/best-match",
+      "someone/recently-pushed-fork",
+    ]);
+    const searchUrl = requestUrl(fetchImpl.mock.calls[0]?.[0]);
+    expect(searchUrl).not.toContain("sort=");
+  });
+
+  it("resolves exact owner/name queries directly and ranks the repository first", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      if (requestUrl(input).includes("/repos/openclaw/openclaw")) {
+        return json(repository("openclaw/openclaw", "2026-08-20T00:00:00Z"));
+      }
+      return json({
+        items: [
+          repository("someone/openclaw-tutorial", "2026-08-25T00:00:00Z"),
+          repository("openclaw/openclaw", "2026-08-20T00:00:00Z"),
+        ],
+      });
+    });
+
+    const result = await searchRemoteProjects("openclaw/openclaw", {
+      env: {},
+      fetchImpl,
+      now: 400,
+    });
+
+    expect(result.projects.map((project) => project.fullName)).toEqual([
+      "openclaw/openclaw",
+      "someone/openclaw-tutorial",
+    ]);
+    expect(fetchImpl.mock.calls.map((call) => requestUrl(call[0]))).toEqual([
+      expect.stringContaining("/repos/openclaw/openclaw"),
+      expect.stringContaining("/search/repositories?"),
+    ]);
+  });
+
+  it("degrades to search results when the exact owner/name lookup misses", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      if (requestUrl(input).includes("/repos/")) {
+        return json({ message: "Not Found" }, 404);
+      }
+      return json({ items: [repository("acme/missing-exact", "2026-08-10T00:00:00Z")] });
+    });
+
+    const result = await searchRemoteProjects("acme/missing-exact-repo", {
+      env: {},
+      fetchImpl,
+      now: 500,
+    });
+
+    expect(result.projects.map((project) => project.fullName)).toEqual(["acme/missing-exact"]);
   });
 
   it("caches normalized queries for 60 seconds and refetches after expiry", async () => {

--- a/src/gateway/project-github-search.test.ts
+++ b/src/gateway/project-github-search.test.ts
@@ -159,6 +159,24 @@ describe("project GitHub search", () => {
     expect(result.projects.map((project) => project.fullName)).toEqual(["acme/missing-exact"]);
   });
 
+  it("degrades optional lanes to global results when their requests reject in transport", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const url = requestUrl(input);
+      if (url.includes("/repos/") || url.includes("/user/repos")) {
+        throw new TypeError("fetch failed");
+      }
+      return json({ items: [repository("acme/still-works", "2026-08-10T00:00:00Z")] });
+    });
+
+    const result = await searchRemoteProjects("acme/still-works", {
+      env: { GH_TOKEN: "test-github-token" },
+      fetchImpl,
+      now: 600,
+    });
+
+    expect(result.projects.map((project) => project.fullName)).toEqual(["acme/still-works"]);
+  });
+
   it("caches normalized queries for 60 seconds and refetches after expiry", async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()

--- a/src/gateway/project-github-search.ts
+++ b/src/gateway/project-github-search.ts
@@ -20,12 +20,9 @@ const SEARCH_CACHE_MS = 60_000;
 const SEARCH_CACHE_LIMIT = 100;
 const SEARCH_RESULT_LIMIT = 10;
 const AFFILIATED_RESULT_LIMIT = 10;
-
-type SearchCandidate = {
-  project: RemoteProject;
-  affiliated: boolean;
-  updatedAt: string;
-};
+// GitHub owner/repo shapes; an exact match resolves directly instead of relying
+// on search ranking (search tokenizes the slash and matches thousands of repos).
+const EXACT_REPO_QUERY = /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\/[A-Za-z0-9._-]+$/;
 
 type SearchCacheEntry = {
   expiresAt: number;
@@ -39,7 +36,7 @@ function boundedString(value: string | undefined, maxLength: number): string | u
   return trimmed ? trimmed.slice(0, maxLength) : undefined;
 }
 
-function parseRepository(value: unknown, affiliated: boolean): SearchCandidate | null {
+function parseRepository(value: unknown): RemoteProject | null {
   if (!isRecord(value)) {
     return null;
   }
@@ -56,58 +53,57 @@ function parseRepository(value: unknown, affiliated: boolean): SearchCandidate |
   if (!clone || !webUrl) {
     return null;
   }
+  const description = boundedString(readOptionalGitHubString(value, "description"), 500);
   return {
-    affiliated,
-    updatedAt: readOptionalGitHubString(value, "updated_at") ?? "",
-    project: {
-      name: name.slice(0, 100),
-      fullName: fullName.slice(0, 200),
-      cloneUrl: clone.url,
-      webUrl,
-      private: value.private === true,
-      ...(boundedString(readOptionalGitHubString(value, "description"), 500)
-        ? { description: boundedString(readOptionalGitHubString(value, "description"), 500) }
-        : {}),
-    },
+    name: name.slice(0, 100),
+    fullName: fullName.slice(0, 200),
+    cloneUrl: clone.url,
+    webUrl,
+    private: value.private === true,
+    ...(description ? { description } : {}),
   };
 }
 
-function candidateSort(left: SearchCandidate, right: SearchCandidate): number {
-  if (left.affiliated !== right.affiliated) {
-    return left.affiliated ? -1 : 1;
-  }
-  if (left.updatedAt !== right.updatedAt) {
-    return left.updatedAt > right.updatedAt ? -1 : 1;
-  }
-  const leftName = left.project.fullName.toLowerCase();
-  const rightName = right.project.fullName.toLowerCase();
-  return leftName < rightName ? -1 : leftName > rightName ? 1 : 0;
-}
-
-function repositoryArray(value: unknown, affiliated: boolean): SearchCandidate[] {
+function repositoryArray(value: unknown): RemoteProject[] {
   const items = Array.isArray(value)
     ? value
     : isRecord(value) && Array.isArray(value.items)
       ? value.items
       : [];
   return items.flatMap((item) => {
-    const parsed = parseRepository(item, affiliated);
+    const parsed = parseRepository(item);
     return parsed ? [parsed] : [];
   });
 }
 
-function matchesAffiliatedQuery(candidate: SearchCandidate, query: string): boolean {
+function matchesAffiliatedQuery(project: RemoteProject, query: string): boolean {
   const needle = query.toLowerCase();
-  return [candidate.project.name, candidate.project.fullName, candidate.project.description ?? ""]
+  return [project.name, project.fullName, project.description ?? ""]
     .join("\n")
     .toLowerCase()
     .includes(needle);
 }
 
+async function loadExactRepository(
+  query: string,
+  fetchImpl: typeof fetch,
+  token: string | undefined,
+): Promise<RemoteProject | null> {
+  const url = new URL(`/repos/${query}`, GITHUB_API_ORIGIN);
+  try {
+    return parseRepository(await fetchGitHubJson(url.href, fetchImpl, token));
+  } catch (error) {
+    if (error instanceof ControlUiGitHubError) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 async function loadAffiliatedRepositories(
   fetchImpl: typeof fetch,
   token: string,
-): Promise<SearchCandidate[]> {
+): Promise<RemoteProject[]> {
   const url = new URL("/user/repos", GITHUB_API_ORIGIN);
   url.searchParams.set("affiliation", "owner,collaborator,organization_member");
   url.searchParams.set("sort", "updated");
@@ -115,7 +111,7 @@ async function loadAffiliatedRepositories(
   url.searchParams.set("per_page", String(AFFILIATED_RESULT_LIMIT));
   try {
     const response = await fetchGitHubApi(url.href, fetchImpl, token);
-    return repositoryArray(await readGitHubJsonResponse(response), true);
+    return repositoryArray(await readGitHubJsonResponse(response));
   } catch (error) {
     if (error instanceof ControlUiGitHubError) {
       return [];
@@ -128,13 +124,11 @@ async function loadRepositorySearch(
   query: string,
   fetchImpl: typeof fetch,
   token: string | undefined,
-): Promise<SearchCandidate[]> {
+): Promise<RemoteProject[]> {
   const url = new URL("/search/repositories", GITHUB_API_ORIGIN);
   url.searchParams.set("q", `${query} in:name,description`);
-  url.searchParams.set("sort", "updated");
-  url.searchParams.set("order", "desc");
   url.searchParams.set("per_page", String(SEARCH_RESULT_LIMIT));
-  return repositoryArray(await fetchGitHubJson(url.href, fetchImpl, token), false);
+  return repositoryArray(await fetchGitHubJson(url.href, fetchImpl, token));
 }
 
 async function searchProjectsUncached(params: {
@@ -142,25 +136,30 @@ async function searchProjectsUncached(params: {
   fetchImpl: typeof fetch;
   token?: string;
 }): Promise<ProjectsSearchRemoteResult> {
-  const affiliated = params.token
-    ? (await loadAffiliatedRepositories(params.fetchImpl, params.token)).filter((candidate) =>
-        matchesAffiliatedQuery(candidate, params.query),
-      )
-    : [];
-  const global = await loadRepositorySearch(params.query, params.fetchImpl, params.token);
-  const deduped = new Map<string, SearchCandidate>();
-  for (const candidate of [...affiliated, ...global].toSorted(candidateSort)) {
-    const key = candidate.project.fullName.toLowerCase();
+  const [exact, affiliated, global] = await Promise.all([
+    EXACT_REPO_QUERY.test(params.query)
+      ? loadExactRepository(params.query, params.fetchImpl, params.token)
+      : null,
+    params.token ? loadAffiliatedRepositories(params.fetchImpl, params.token) : [],
+    loadRepositorySearch(params.query, params.fetchImpl, params.token),
+  ]);
+  // Order is the ranking: exact owner/name hit, then affiliated repositories
+  // (API-sorted by recency), then global search in GitHub best-match order.
+  const ranked = [
+    ...(exact ? [exact] : []),
+    ...affiliated.filter((project) => matchesAffiliatedQuery(project, params.query)),
+    ...global,
+  ];
+  const deduped = new Map<string, RemoteProject>();
+  for (const project of ranked) {
+    const key = project.fullName.toLowerCase();
     if (!deduped.has(key)) {
-      deduped.set(key, candidate);
+      deduped.set(key, project);
     }
   }
   return {
     credential: params.token ? "configured" : "missing",
-    projects: [...deduped.values()]
-      .toSorted(candidateSort)
-      .slice(0, SEARCH_RESULT_LIMIT)
-      .map((candidate) => candidate.project),
+    projects: [...deduped.values()].slice(0, SEARCH_RESULT_LIMIT),
   };
 }
 

--- a/src/gateway/project-github-search.ts
+++ b/src/gateway/project-github-search.ts
@@ -5,7 +5,6 @@ import type {
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { parseProjectGitUrl } from "../projects/project-git-url.js";
 import {
-  ControlUiGitHubError,
   fetchGitHubApi,
   fetchGitHubJson,
   GITHUB_API_ORIGIN,
@@ -90,13 +89,12 @@ async function loadExactRepository(
   token: string | undefined,
 ): Promise<RemoteProject | null> {
   const url = new URL(`/repos/${query}`, GITHUB_API_ORIGIN);
+  // Optional enrichment lane: a miss, API error, or transport rejection must
+  // degrade to search-only results, never sink the whole picker query.
   try {
     return parseRepository(await fetchGitHubJson(url.href, fetchImpl, token));
-  } catch (error) {
-    if (error instanceof ControlUiGitHubError) {
-      return null;
-    }
-    throw error;
+  } catch {
+    return null;
   }
 }
 
@@ -109,14 +107,13 @@ async function loadAffiliatedRepositories(
   url.searchParams.set("sort", "updated");
   url.searchParams.set("direction", "desc");
   url.searchParams.set("per_page", String(AFFILIATED_RESULT_LIMIT));
+  // Optional enrichment lane: see loadExactRepository — failures degrade to
+  // global-search-only results instead of failing the picker query.
   try {
     const response = await fetchGitHubApi(url.href, fetchImpl, token);
     return repositoryArray(await readGitHubJsonResponse(response));
-  } catch (error) {
-    if (error instanceof ControlUiGitHubError) {
-      return [];
-    }
-    throw error;
+  } catch {
+    return [];
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

The Control UI project picker's GitHub search returned essentially random repositories. Typing the exact `openclaw/openclaw` surfaced recently-pushed forks, tutorial repos, and mirrors instead of the canonical repository — on any gateway without a configured Control UI GitHub credential (e.g. a fresh install), the picker was unusable for finding a specific repo.

Root cause, verified live against `api.github.com`: `searchRemoteProjects` requested `/search/repositories` with `sort=updated&order=desc`, discarding GitHub's best-match relevance ranking. A query like `openclaw/openclaw` matches ~68k repositories (search tokenizes the slash), so "most recently pushed match" is effectively random. Replaying the exact query: with `sort=updated` the top hit is `luborliu/openclaw-pico-learnings`; with default best-match ordering it is `openclaw/openclaw`. A local `candidateSort` then re-sorted by `updated_at` a second time, so fixing the API parameter alone would not have been enough.

## Why This Change Was Made

- Global search now uses GitHub's default best-match ordering (no `sort`/`order` params) and results keep API order instead of being re-sorted by recency.
- Exact `owner/name` queries additionally resolve directly via `GET /repos/{owner}/{name}` and rank first; a miss (404/network) degrades silently to search results. This also makes private-but-accessible repos findable by exact name when a token is configured.
- Ranking is now positional (exact hit → affiliated matches, API recency order → global best-match order), which deletes `candidateSort`, the `SearchCandidate` wrapper, and the `updatedAt`/`affiliated` bookkeeping.

Production LOC is net +1 (56/−55): the deleted sorting machinery pays for the new exact-lookup lane.

## User Impact

Typing a repo name — or the exact `owner/name` — in the project picker now returns the intended repository first, both with and without a configured Control UI GitHub credential.

## Evidence

- Live API replay (2026-08-25): identical query with `sort=updated` → `luborliu/openclaw-pico-learnings` first; with best-match → `openclaw/openclaw` first.
- New regression tests fail on pre-fix code for the intended reasons: `preserves GitHub best-match order…` and `resolves exact owner/name queries…` (verified by running the new tests against `HEAD`'s implementation: 2 failed, 5 passed).
- `node scripts/run-vitest.mjs src/gateway/project-github-search.test.ts` → 7/7 green; `check:changed` lanes green (format, typecheck core + tests, lint, ratchets).
- Live gateway proof on stable.openclaw.ai after deploy: see PR comment.

## Red-main heal (second commit)

`main` was red on `check-lint` and `check-test-types` when this PR first ran CI; commit 637da87a5da landed the equivalent heal on main first, so this branch rebased onto it and the temporary heal commit was dropped as empty. The PR is now the search fix only.
