### PR TITLE
refactor(ui): tidy the roster refresh owner and session test harnesses

### DIFF
--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -237,6 +237,36 @@ describe("sidebar attention refresh ownership", () => {
     vi.unstubAllGlobals();
   });
 
+  it("keeps the plain attention panel inside its top-layer menu surface", async () => {
+    const provider = createApplicationContextProvider({
+      gateway: {
+        snapshot: { phase: "connected", client: null, hello: null },
+        connection: { gatewayUrl: "" },
+        subscribe: () => () => undefined,
+        subscribeEvents: () => () => undefined,
+      },
+      overlays: {
+        snapshot: { approvalQueue: [] },
+        subscribe: () => () => undefined,
+      },
+      scopeUpgrade: hiddenScopeUpgradeCapability,
+    } as unknown as ApplicationContext);
+    const element = document.createElement("openclaw-sidebar-attention") as SidebarAttentionElement;
+    provider.append(element);
+    document.body.append(provider);
+
+    await waitForFast(() =>
+      expect(element.querySelector<HTMLButtonElement>(".sidebar-issues-button")).not.toBeNull(),
+    );
+    element.querySelector<HTMLButtonElement>(".sidebar-issues-button")!.click();
+
+    await waitForFast(() => {
+      const panel = element.querySelector(".sidebar-issues-panel");
+      expect(panel).not.toBeNull();
+      expect(panel?.closest("openclaw-menu-surface")).not.toBeNull();
+    });
+  });
+
   it("keeps the latest refresh when an older load on the same client finishes last", async () => {
     const firstCron = deferred<unknown>();
     const firstAuth = deferred<unknown>();

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -249,6 +249,10 @@ describe("sidebar attention refresh ownership", () => {
         snapshot: { approvalQueue: [] },
         subscribe: () => () => undefined,
       },
+      agentSelection: {
+        state: { selectedId: null, scopeId: null },
+        subscribe: () => () => undefined,
+      },
       scopeUpgrade: hiddenScopeUpgradeCapability,
     } as unknown as ApplicationContext);
     const element = document.createElement("openclaw-sidebar-attention") as SidebarAttentionElement;

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -2,23 +2,15 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
-import { createSessionCapability } from "./index.ts";
+import {
+  createSessionCapabilityHarness,
+  sessionChangedEvent,
+  sessionsResult,
+} from "./session-capability.test-support.ts";
+import type { SessionCapability } from "./session-capability.ts";
 
 const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 200;
 const SESSION_EVENT_REFRESH_MAX_WAIT_MS = 1_000;
-
-function sessionsResult(
-  ts: number,
-  sessions: SessionsListResult["sessions"] = [],
-): SessionsListResult {
-  return {
-    ts,
-    path: "",
-    count: sessions.length,
-    defaults: { modelProvider: null, model: null, contextTokens: null },
-    sessions,
-  };
-}
 
 function deferred<T>() {
   let resolve: (value: T) => void = () => undefined;
@@ -26,37 +18,6 @@ function deferred<T>() {
     resolve = next;
   });
   return { promise, resolve };
-}
-
-function sessionChangedEvent(key: string): GatewayEventFrame {
-  return {
-    type: "event",
-    event: "sessions.changed",
-    payload: { sessionKey: key, reason: "create", key, kind: "direct", updatedAt: 1 },
-  };
-}
-
-function createHarness(request: GatewayBrowserClient["request"], ownerId?: string) {
-  const client = { request } as GatewayBrowserClient;
-  let eventListener: ((event: GatewayEventFrame) => void) | undefined;
-  const sessions = createSessionCapability({
-    snapshot: {
-      client,
-      phase: "connected",
-      sessionKey: "agent:main:main",
-      assistantAgentId: "main",
-      hello: null,
-      selfUser: ownerId ? { id: ownerId } : null,
-    },
-    subscribe: () => () => undefined,
-    subscribeEvents(listener) {
-      eventListener = listener;
-      return () => {
-        eventListener = undefined;
-      };
-    },
-  });
-  return { sessions, emitEvent: (event: GatewayEventFrame) => eventListener?.(event) };
 }
 
 function installPageLifecycle() {
@@ -98,9 +59,9 @@ describe("event-driven session list refresh", () => {
         updatedAt: 1,
         owner: { actor: { type: "human" as const, id: "profile-self" } },
       };
-      return sessionsResult(1, [visible]);
+      return sessionsResult([visible], 1);
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
 
@@ -159,7 +120,7 @@ describe("event-driven session list refresh", () => {
           throw new Error(`Unexpected request: ${method}`);
         }
         if (params?.boardFace !== "dashboard") {
-          return sessionsResult(1);
+          return sessionsResult([], 1);
         }
         const rows = params.agentId
           ? [{ ...dashboardRows[0]!, key: `agent:${params.agentId}:dashboard` }]
@@ -167,14 +128,14 @@ describe("event-driven session list refresh", () => {
         const offset = params.offset ?? 0;
         const page = rows.slice(offset, offset + (params.limit ?? 50));
         return {
-          ...sessionsResult(1, page),
+          ...sessionsResult(page, 1),
           totalCount: rows.length,
           hasMore: offset + page.length < rows.length,
           nextOffset: offset + page.length < rows.length ? offset + page.length : null,
         };
       },
     );
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
     const allAgentsQuery = {
@@ -255,18 +216,21 @@ describe("event-driven session list refresh", () => {
         calls[lane] += 1;
         const done = lane !== "research" && calls[lane] > 1;
         const rowKey = lane === "research" ? "agent:research:other" : key;
-        return sessionsResult(calls[lane], [
-          {
-            key: rowKey,
-            kind: "direct",
-            updatedAt: calls[lane],
-            hasActiveRun: !done,
-            status: done ? "done" : "running",
-          },
-        ]);
+        return sessionsResult(
+          [
+            {
+              key: rowKey,
+              kind: "direct",
+              updatedAt: calls[lane],
+              hasActiveRun: !done,
+              status: done ? "done" : "running",
+            },
+          ],
+          calls[lane],
+        );
       },
     );
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
     const mainQuery = {
@@ -341,9 +305,9 @@ describe("event-driven session list refresh", () => {
       if (method !== "sessions.list") {
         throw new Error(`Unexpected request: ${method}`);
       }
-      return sessionsResult(1, [mainRow]);
+      return sessionsResult([mainRow], 1);
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
 
@@ -398,9 +362,9 @@ describe("event-driven session list refresh", () => {
         throw new Error(`Unexpected request: ${method}`);
       }
       listCalls += 1;
-      return sessionsResult(listCalls, listCalls === 1 ? [mainRow] : [fallbackRow]);
+      return sessionsResult(listCalls === 1 ? [mainRow] : [fallbackRow], listCalls);
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
 
@@ -454,19 +418,17 @@ describe("event-driven session list refresh", () => {
     {
       filter: "ownerId",
       query: { ownerId: "profile-ada" },
-      applyFilter: (sessions: ReturnType<typeof createSessionCapability>) =>
-        sessions.setOwnerFilter("profile-ada"),
+      applyFilter: (sessions: SessionCapability) => sessions.setOwnerFilter("profile-ada"),
     },
     {
       filter: "involvingMe",
       query: { involvingMe: true },
-      applyFilter: (sessions: ReturnType<typeof createSessionCapability>) =>
-        sessions.setInvolvingMeFilter(true),
+      applyFilter: (sessions: SessionCapability) => sessions.setInvolvingMeFilter(true),
     },
     {
       filter: "search",
       query: { search: "Ada" },
-      applyFilter: (sessions: ReturnType<typeof createSessionCapability>) =>
+      applyFilter: (sessions: SessionCapability) =>
         sessions.refresh({ agentId: "main", search: "Ada", force: true }),
     },
   ])(
@@ -494,12 +456,12 @@ describe("event-driven session list refresh", () => {
           }
           const filtered = Boolean(params?.ownerId || params?.involvingMe || params?.search);
           return sessionsResult(
-            matchesFilteredRoster ? 1 : 2,
             filtered && !matchesFilteredRoster ? [] : [row],
+            matchesFilteredRoster ? 1 : 2,
           );
         },
       );
-      const { sessions, emitEvent } = createHarness(
+      const { sessions, emitEvent } = createSessionCapabilityHarness(
         request as unknown as GatewayBrowserClient["request"],
       );
 
@@ -556,13 +518,13 @@ describe("event-driven session list refresh", () => {
       const page = rows.slice(offset, offset + limit);
       const hasMore = offset + page.length < rows.length;
       return {
-        ...sessionsResult(offset + 1, page),
+        ...sessionsResult(page, offset + 1),
         totalCount: rows.length,
         nextOffset: hasMore ? offset + page.length : null,
         hasMore,
       };
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
 
@@ -590,9 +552,9 @@ describe("event-driven session list refresh", () => {
       if (method !== "sessions.list") {
         throw new Error(`Unexpected request: ${method}`);
       }
-      return sessionsResult(1);
+      return sessionsResult([], 1);
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
 
@@ -625,9 +587,9 @@ describe("event-driven session list refresh", () => {
       if (method !== "sessions.list") {
         throw new Error(`Unexpected request: ${method}`);
       }
-      return sessionsResult(1);
+      return sessionsResult([], 1);
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
 
@@ -654,9 +616,9 @@ describe("event-driven session list refresh", () => {
       if (method !== "sessions.list") {
         throw new Error(`Unexpected request: ${method}`);
       }
-      return sessionsResult(1);
+      return sessionsResult([], 1);
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
 
@@ -685,9 +647,9 @@ describe("event-driven session list refresh", () => {
       if (method !== "sessions.list") {
         throw new Error(`Unexpected request: ${method}`);
       }
-      return sessionsResult(1);
+      return sessionsResult([], 1);
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
 
@@ -728,9 +690,9 @@ describe("event-driven session list refresh", () => {
           secondListStarted.resolve();
           return await secondList.promise;
         }
-        return sessionsResult(listCalls);
+        return sessionsResult([], listCalls);
       });
-      const { sessions, emitEvent } = createHarness(
+      const { sessions, emitEvent } = createSessionCapabilityHarness(
         request as unknown as GatewayBrowserClient["request"],
       );
 
@@ -752,7 +714,7 @@ describe("event-driven session list refresh", () => {
           expect(request).toHaveBeenCalledTimes(1);
         }
 
-        firstList.resolve(sessionsResult(1));
+        firstList.resolve(sessionsResult([], 1));
         await secondListStarted.promise;
         if (!fireBeforeInitialCompletion) {
           await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
@@ -770,12 +732,12 @@ describe("event-driven session list refresh", () => {
         });
         expect(sessions.state.loading).toBe(false);
 
-        secondList.resolve(sessionsResult(2));
+        secondList.resolve(sessionsResult([], 2));
         await Promise.all([initialRefresh, explicitRefresh]);
         expect(request).toHaveBeenCalledTimes(2);
       } finally {
-        firstList.resolve(sessionsResult(1));
-        secondList.resolve(sessionsResult(2));
+        firstList.resolve(sessionsResult([], 1));
+        secondList.resolve(sessionsResult([], 2));
         sessions.dispose();
         vi.useRealTimers();
       }
@@ -816,9 +778,9 @@ describe("event-driven session list refresh", () => {
         secondListStarted.resolve();
         return await secondList.promise;
       }
-      return sessionsResult(listCalls);
+      return sessionsResult([], listCalls);
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
 
@@ -842,7 +804,7 @@ describe("event-driven session list refresh", () => {
       }
       await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
 
-      firstList.resolve(sessionsResult(1));
+      firstList.resolve(sessionsResult([], 1));
       await secondListStarted.promise;
       expect(request.mock.calls[1]?.[1]).toMatchObject({
         agentId: "main",
@@ -850,7 +812,7 @@ describe("event-driven session list refresh", () => {
         offset: 25,
       });
 
-      secondList.resolve(sessionsResult(2));
+      secondList.resolve(sessionsResult([], 2));
       await Promise.all([initialRefresh, appendRefresh]);
       expect(request).toHaveBeenCalledTimes(3);
       expect(request.mock.calls[2]?.[1]).toMatchObject({
@@ -859,8 +821,8 @@ describe("event-driven session list refresh", () => {
       });
       expect(request.mock.calls[2]?.[1]).not.toHaveProperty("offset");
     } finally {
-      firstList.resolve(sessionsResult(1));
-      secondList.resolve(sessionsResult(2));
+      firstList.resolve(sessionsResult([], 1));
+      secondList.resolve(sessionsResult([], 2));
       sessions.dispose();
       vi.useRealTimers();
     }
@@ -882,9 +844,9 @@ describe("event-driven session list refresh", () => {
       if (listCalls === 3) {
         thirdListStarted.resolve();
       }
-      return sessionsResult(listCalls);
+      return sessionsResult([], listCalls);
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
 
@@ -898,7 +860,7 @@ describe("event-driven session list refresh", () => {
       await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
       expect(request).toHaveBeenCalledTimes(2);
 
-      secondList.resolve(sessionsResult(2));
+      secondList.resolve(sessionsResult([], 2));
       await thirdListStarted.promise;
       expect(request).toHaveBeenCalledTimes(3);
     } finally {
@@ -917,12 +879,12 @@ describe("event-driven session list refresh", () => {
         throw new Error(`Unexpected request: ${method}`);
       }
       if (params?.archived !== "all") {
-        return sessionsResult(0);
+        return sessionsResult([], 0);
       }
       filteredCalls += 1;
-      return filteredCalls === 2 ? await activeRefresh.promise : sessionsResult(filteredCalls);
+      return filteredCalls === 2 ? await activeRefresh.promise : sessionsResult([], filteredCalls);
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
     const unsubscribe = sessions.subscribeList({ agentId: "main", archivedFilter: "all" }, vi.fn());
@@ -936,7 +898,7 @@ describe("event-driven session list refresh", () => {
       emitEvent(sessionChangedEvent("agent:main:queued"));
       await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
       page.setVisibility("hidden");
-      activeRefresh.resolve(sessionsResult(2));
+      activeRefresh.resolve(sessionsResult([], 2));
       await vi.advanceTimersByTimeAsync(0);
       expect(filteredCalls).toBe(2);
 
@@ -944,7 +906,7 @@ describe("event-driven session list refresh", () => {
       await vi.advanceTimersByTimeAsync(0);
       expect(filteredCalls).toBe(3);
     } finally {
-      activeRefresh.resolve(sessionsResult(2));
+      activeRefresh.resolve(sessionsResult([], 2));
       unsubscribe();
       sessions.dispose();
       vi.useRealTimers();
@@ -959,9 +921,9 @@ describe("event-driven session list refresh", () => {
       if (method !== "sessions.list") {
         throw new Error(`Unexpected request: ${method}`);
       }
-      return sessionsResult(1, [{ key: "agent:main:pending", kind: "direct", updatedAt: 0 }]);
+      return sessionsResult([{ key: "agent:main:pending", kind: "direct", updatedAt: 0 }], 1);
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
     );
     const unsubscribe = sessions.subscribeList({ agentId: "main", archivedFilter: "all" }, vi.fn());

--- a/ui/src/lib/sessions/owner-first-roster.test.ts
+++ b/ui/src/lib/sessions/owner-first-roster.test.ts
@@ -1,54 +1,13 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
-import type { SessionsListResult } from "../../api/types.ts";
-import { createSessionCapability } from "./index.ts";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import {
+  createSessionCapabilityHarness,
+  sessionChangedEvent,
+  sessionsResult,
+} from "./session-capability.test-support.ts";
 
 const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 200;
-
-function sessionsResult(
-  ts: number,
-  sessions: SessionsListResult["sessions"] = [],
-): SessionsListResult {
-  return {
-    ts,
-    path: "",
-    count: sessions.length,
-    defaults: { modelProvider: null, model: null, contextTokens: null },
-    sessions,
-  };
-}
-
-function sessionChangedEvent(key: string): GatewayEventFrame {
-  return {
-    type: "event",
-    event: "sessions.changed",
-    payload: { sessionKey: key, reason: "create", key, kind: "direct", updatedAt: 1 },
-  };
-}
-
-function createHarness(request: GatewayBrowserClient["request"], ownerId: string) {
-  const client = { request } as GatewayBrowserClient;
-  let eventListener: ((event: GatewayEventFrame) => void) | undefined;
-  const sessions = createSessionCapability({
-    snapshot: {
-      client,
-      phase: "connected",
-      sessionKey: "agent:main:main",
-      assistantAgentId: "main",
-      hello: null,
-      selfUser: { id: ownerId },
-    },
-    subscribe: () => () => undefined,
-    subscribeEvents(listener) {
-      eventListener = listener;
-      return () => {
-        eventListener = undefined;
-      };
-    },
-  });
-  return { sessions, emitEvent: (event: GatewayEventFrame) => eventListener?.(event) };
-}
 
 describe("owner-first session roster plan", () => {
   it("retains owner and appended shared pages when an event replaces the list", async () => {
@@ -81,15 +40,15 @@ describe("owner-first session roster plan", () => {
           throw new Error(`Unexpected request: ${method}`);
         }
         if (params?.ownerId === ownerId) {
-          return sessionsResult(1, [ownerHead, ownerTail]);
+          return sessionsResult([ownerHead, ownerTail], 1);
         }
         const offset = params?.offset ?? 0;
-        return sessionsResult(2, sharedRows.slice(offset, offset + (params?.limit ?? 50)));
+        return sessionsResult(sharedRows.slice(offset, offset + (params?.limit ?? 50)), 2);
       },
     );
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
-      ownerId,
+      { ownerId },
     );
 
     try {
@@ -136,12 +95,12 @@ describe("owner-first session roster plan", () => {
         throw new Error(`Unexpected request: ${method}`);
       }
       return params?.ownerId === ownerId
-        ? sessionsResult(1, [ownRow])
-        : sessionsResult(2, [ownRow, foreignRow]);
+        ? sessionsResult([ownRow], 1)
+        : sessionsResult([ownRow, foreignRow], 2);
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
-      ownerId,
+      { ownerId },
     );
 
     try {
@@ -191,16 +150,16 @@ describe("owner-first session roster plan", () => {
         throw new Error(`Unexpected request: ${method}`);
       }
       if (params?.ownerId === ownerId) {
-        return sessionsResult(1, [ownRow]);
+        return sessionsResult([ownRow], 1);
       }
       if (failShared) {
         throw new Error("shared roster unavailable");
       }
-      return sessionsResult(2, [ownRow, foreignRow]);
+      return sessionsResult([ownRow, foreignRow], 2);
     });
-    const { sessions, emitEvent } = createHarness(
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
-      ownerId,
+      { ownerId },
     );
 
     try {

--- a/ui/src/lib/sessions/session-capability.test-support.ts
+++ b/ui/src/lib/sessions/session-capability.test-support.ts
@@ -1,5 +1,6 @@
 import type { GatewayBrowserClient, GatewayEventFrame, GatewayHelloOk } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
+import { createSessionCapability } from "./index.ts";
 
 export function sessionsResult(
   sessions: SessionsListResult["sessions"],
@@ -14,13 +15,18 @@ export function sessionsResult(
   };
 }
 
-export function createGatewayHarness(client: GatewayBrowserClient, featureMethods?: string[]) {
+export function createGatewayHarness(
+  client: GatewayBrowserClient,
+  featureMethods?: string[],
+  options?: { selfUser?: { readonly id: string } | null },
+) {
   let snapshot: {
     client: GatewayBrowserClient | null;
     phase: "connected" | "reconnecting";
     sessionKey: string;
     assistantAgentId: string | null;
     hello: GatewayHelloOk | null;
+    selfUser: { readonly id: string } | null;
   } = {
     client,
     phase: "connected" as const,
@@ -30,6 +36,7 @@ export function createGatewayHarness(client: GatewayBrowserClient, featureMethod
       featureMethods === undefined
         ? null
         : ({ features: { methods: featureMethods } } as GatewayHelloOk),
+    selfUser: options?.selfUser ?? null,
   };
   const listeners = new Set<(next: typeof snapshot) => void>();
   const eventListeners = new Set<(event: GatewayEventFrame) => void>();
@@ -63,4 +70,26 @@ export function createGatewayHarness(client: GatewayBrowserClient, featureMethod
       }
     },
   };
+}
+
+export function sessionChangedEvent(key: string): GatewayEventFrame {
+  return {
+    type: "event",
+    event: "sessions.changed",
+    payload: { sessionKey: key, reason: "create", key, kind: "direct", updatedAt: 1 },
+  };
+}
+
+export function createSessionCapabilityHarness(
+  request: GatewayBrowserClient["request"],
+  options?: { ownerId?: string },
+) {
+  const { gateway, emitEvent } = createGatewayHarness(
+    { request } as GatewayBrowserClient,
+    undefined,
+    {
+      selfUser: options?.ownerId ? { id: options.ownerId } : null,
+    },
+  );
+  return { sessions: createSessionCapability(gateway), emitEvent };
 }

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -93,13 +93,69 @@ function isPrimarySessionListQuery(options: SessionListScope): boolean {
   );
 }
 
+function preserveCurrentSessionRow(
+  result: SessionsListResult,
+  state: SessionState,
+  snapshot: SessionGateway["snapshot"],
+  backgroundHydrate: boolean,
+): SessionsListResult {
+  const currentKey = snapshot.sessionKey?.trim();
+  if (!currentKey) {
+    return result;
+  }
+  const currentAgentId = normalizeAgentId(
+    parseAgentSessionKey(currentKey)?.agentId ?? resolveUiSelectedGlobalAgentId(snapshot),
+  );
+  const exactPreviousCurrentRow = state.result?.sessions.find((row) =>
+    areUiSessionKeysEquivalent(row.key, currentKey),
+  );
+  const previousCurrentRow =
+    exactPreviousCurrentRow ??
+    (state.agentId === currentAgentId
+      ? state.result?.sessions.find((row) =>
+          uiSessionRowMatchesSelectedChat(snapshot, row.key, currentKey),
+        )
+      : undefined);
+  const nextContainsCurrentRow = exactPreviousCurrentRow
+    ? result.sessions.some((row) => areUiSessionKeysEquivalent(row.key, currentKey))
+    : result.sessions.some((row) => uiSessionRowMatchesSelectedChat(snapshot, row.key, currentKey));
+  if (
+    previousCurrentRow &&
+    (backgroundHydrate || previousCurrentRow.archived === true) &&
+    !nextContainsCurrentRow
+  ) {
+    const sessions = [...result.sessions, previousCurrentRow];
+    return { ...result, count: sessions.length, sessions };
+  }
+  return result;
+}
+
+function retainSessionPaginationWindow(
+  options: SessionListOptions,
+  offset: number | undefined,
+  result: SessionsListResult | null,
+  nextResult: SessionsListResult,
+  snapshot: SessionGateway["snapshot"],
+): SessionListOptions {
+  const ownerFirstPage =
+    Boolean(snapshot.selfUser?.id.trim()) && isPrimarySessionListQuery(options);
+  const retainedListLimit =
+    ownerFirstPage && result && typeof offset === "number"
+      ? offset + result.sessions.length
+      : nextResult.sessions.length;
+  // Retain the shared pagination window, excluding owner rows merged ahead of it.
+  return {
+    ...options,
+    limit: Math.max(options.limit ?? DEFAULT_SESSION_LIST_QUERY.limit, retainedListLimit),
+  };
+}
+
 export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   let inFlight: Promise<void> | null = null;
   let queuedExplicitRefresh: SessionRefreshOptions | null = null;
   let eventRefreshQueued = false;
   let lastListOptions: SessionListOptions = {};
-  let hasForegroundListOptions = false;
-  let hasSeededListOptions = false;
+  let listOptionsSource: "none" | "seeded" | "foreground" = "none";
   const observesPageLifecycle =
     typeof document !== "undefined" && typeof globalThis.addEventListener === "function";
   let pageActive = !observesPageLifecycle || document.visibilityState !== "hidden";
@@ -253,10 +309,10 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     delete durableListOptions.offset;
     if (!backgroundHydrate && !provisional) {
       lastListOptions = durableListOptions;
-      hasForegroundListOptions = true;
-    } else if (!provisional && !hasForegroundListOptions && !hasSeededListOptions) {
+      listOptionsSource = "foreground";
+    } else if (!provisional && listOptionsSource === "none") {
       lastListOptions = durableListOptions;
-      hasSeededListOptions = true;
+      listOptionsSource = "seeded";
     }
     // A provisional owner window may only paint an empty sidebar faster; once a
     // roster is on screen it stays silent so foreign-owned rows never blink out.
@@ -286,53 +342,21 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
           ? appendSessionResults(currentState.result, merged)
           : reconcileRosterPresentationMetadata(merged, currentState.result);
       if (append && nextResult && !backgroundHydrate) {
-        const ownerFirstPage =
-          Boolean(host.snapshot().selfUser?.id.trim()) &&
-          isPrimarySessionListQuery(durableListOptions);
-        const retainedListLimit =
-          ownerFirstPage && result && typeof requestOptions.offset === "number"
-            ? requestOptions.offset + result.sessions.length
-            : nextResult.sessions.length;
-        // Retain the shared pagination window, excluding owner rows merged ahead of it.
-        lastListOptions = {
-          ...durableListOptions,
-          limit: Math.max(
-            durableListOptions.limit ?? DEFAULT_SESSION_LIST_QUERY.limit,
-            retainedListLimit,
-          ),
-        };
+        lastListOptions = retainSessionPaginationWindow(
+          durableListOptions,
+          requestOptions.offset,
+          result,
+          nextResult,
+          host.snapshot(),
+        );
       }
       if (nextResult) {
-        const snapshot = host.snapshot();
-        const currentKey = snapshot.sessionKey?.trim();
-        if (currentKey) {
-          const currentAgentId = normalizeAgentId(
-            parseAgentSessionKey(currentKey)?.agentId ?? resolveUiSelectedGlobalAgentId(snapshot),
-          );
-          const exactPreviousCurrentRow = currentState.result?.sessions.find((row) =>
-            areUiSessionKeysEquivalent(row.key, currentKey),
-          );
-          const previousCurrentRow =
-            exactPreviousCurrentRow ??
-            (currentState.agentId === currentAgentId
-              ? currentState.result?.sessions.find((row) =>
-                  uiSessionRowMatchesSelectedChat(snapshot, row.key, currentKey),
-                )
-              : undefined);
-          const nextContainsCurrentRow = exactPreviousCurrentRow
-            ? nextResult.sessions.some((row) => areUiSessionKeysEquivalent(row.key, currentKey))
-            : nextResult.sessions.some((row) =>
-                uiSessionRowMatchesSelectedChat(snapshot, row.key, currentKey),
-              );
-          if (
-            previousCurrentRow &&
-            (backgroundHydrate || previousCurrentRow.archived === true) &&
-            !nextContainsCurrentRow
-          ) {
-            const sessions = [...nextResult.sessions, previousCurrentRow];
-            nextResult = { ...nextResult, count: sessions.length, sessions };
-          }
-        }
+        nextResult = preserveCurrentSessionRow(
+          nextResult,
+          currentState,
+          host.snapshot(),
+          backgroundHydrate,
+        );
       }
       nextResult = host.decorate(nextResult);
       if (!provisional) {

--- a/ui/src/test-helpers/app-sidebar-cases/transient-menus.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/transient-menus.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createGateway, createSessions, mountSidebar } from "../app-sidebar.ts";
-import { waitForFast } from "../wait-for.ts";
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar transient menus", () => {
@@ -22,25 +21,6 @@ describe("AppSidebar transient menus", () => {
     const menu = sidebar.querySelector(".sidebar-session-sort-menu");
     expect(menu).not.toBeNull();
     expect(menu?.closest("openclaw-menu-surface")).toBeNull();
-  });
-
-  it("keeps the plain attention panel inside its top-layer menu surface", async () => {
-    const gateway = createGateway({} as GatewayBrowserClient);
-    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
-    const attention = sidebar.querySelector<HTMLElement & { updateComplete: Promise<boolean> }>(
-      "openclaw-sidebar-attention",
-    );
-    await attention?.updateComplete;
-    const trigger = attention?.querySelector<HTMLButtonElement>(".sidebar-issues-button");
-    expect(trigger).not.toBeNull();
-
-    trigger?.click();
-
-    await waitForFast(() => {
-      const panel = attention?.querySelector(".sidebar-issues-panel");
-      expect(panel).not.toBeNull();
-      expect(panel?.closest("openclaw-menu-surface")).not.toBeNull();
-    });
   });
 
   it("ignores a stale sort-menu hide after opening its replacement", async () => {

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -39,6 +39,8 @@ import { createStorageMock } from "./storage.ts";
 
 // The attention widget owns independent health RPC tests. Keep those requests
 // out of sidebar client call-order assertions.
+// Sidebar attention is inert in this harness; cover attention rendering in
+// sidebar-attention.test.ts, not app-sidebar cases.
 vi.mock("../components/sidebar-attention.ts", () => ({}));
 
 export type SessionGroupMutationResult = Awaited<ReturnType<SessionCapability["groupsRename"]>>;


### PR DESCRIPTION
Related: #129558
Related: #129517

## What Problem This Solves

Follow-up cleanup to the sidebar-flicker landings. `load()` in the roster refresh had grown to ~140 lines with two dense inline decision blocks; two parallel booleans tracked one three-state fact; two test suites hand-rolled copies of harness helpers that `session-capability.test-support.ts` already owns; and one app-sidebar case asserted the real attention panel renders under a harness that mocks the attention module away — import-order dependent, deterministically failing in local single-file runs on clean main while CI's worker mix passes.

## Why This Change Was Made

Behavior-neutral: `preserveCurrentSessionRow` and `retainSessionPaginationWindow` are named extractions of `load()`'s decision blocks (its spine now reads normalize → loading publish → request+owner merge → provisional return → decide → publish); `hasForegroundListOptions`/`hasSeededListOptions` collapse into one closed `listOptionsSource` mode per house style. The test-support module gains `selfUser` support, `sessionChangedEvent`, and `createSessionCapabilityHarness`, and the duplicated local copies die. The attention-panel invariant (panel opens inside `openclaw-menu-surface`) moves to `sidebar-attention.test.ts` against the real component, and the harness mock now documents where attention rendering coverage belongs.

## User Impact

None at runtime. Developers get a readable roster owner, one canonical session-capability test harness, and local `app-sidebar.test.ts` runs that match CI instead of failing by construction.

## Evidence

- Full session-lib + sidebar + attention sweep: 712 files / 10,358 tests green; both owner-first e2e specs green; `pnpm check:changed` exit 0.
- Previously flaky-local invocation now green: `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts --run -t "transient menus"`.
- Production delta +24/−50 in the refactor commit is signature/plumbing cost of the two named extractions against a 140→85 line `load()`; tests net −50 from harness dedup; the moved attention test keeps its exact assertion set.
- Codex autoreview (gpt-5.6-sol, high) on the branch diff: clean, no findings.
