### PR TITLE
refactor(cli): consolidate skills requirement formatting

### DIFF
--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -96,24 +96,18 @@ function formatSkillName(skill: SkillStatusEntry): string {
   return emoji ? `${emoji} ${name}` : name;
 }
 
+const SKILL_REQUIREMENT_GROUPS = [
+  ["bins", "Binaries"],
+  ["anyBins", "Any binaries"],
+  ["env", "Environment"],
+  ["config", "Config"],
+  ["os", "OS"],
+] as const;
+
 function formatSkillMissingSummary(skill: SkillStatusEntry): string {
-  const missing: string[] = [];
-  if (skill.missing.bins.length > 0) {
-    missing.push(`bins: ${skill.missing.bins.join(", ")}`);
-  }
-  if (skill.missing.anyBins.length > 0) {
-    missing.push(`anyBins: ${skill.missing.anyBins.join(", ")}`);
-  }
-  if (skill.missing.env.length > 0) {
-    missing.push(`env: ${skill.missing.env.join(", ")}`);
-  }
-  if (skill.missing.config.length > 0) {
-    missing.push(`config: ${skill.missing.config.join(", ")}`);
-  }
-  if (skill.missing.os.length > 0) {
-    missing.push(`os: ${skill.missing.os.join(", ")}`);
-  }
-  return missing.join("; ");
+  return SKILL_REQUIREMENT_GROUPS.filter(([key]) => skill.missing[key].length > 0)
+    .map(([key]) => `${key}: ${skill.missing[key].join(", ")}`)
+    .join("; ");
 }
 
 /** Render skill discovery status as sanitized JSON or a terminal table. */
@@ -263,51 +257,23 @@ export function formatSkillInfo(
     lines.push(`${theme.muted("  Primary env:")} ${skill.primaryEnv}`);
   }
 
-  const hasRequirements =
-    skill.requirements.bins.length > 0 ||
-    skill.requirements.anyBins.length > 0 ||
-    skill.requirements.env.length > 0 ||
-    skill.requirements.config.length > 0 ||
-    skill.requirements.os.length > 0;
+  const requirementGroups = SKILL_REQUIREMENT_GROUPS.filter(
+    ([key]) => skill.requirements[key].length > 0,
+  );
 
-  if (hasRequirements) {
+  if (requirementGroups.length > 0) {
     lines.push("");
     lines.push(theme.heading("Requirements:"));
-    if (skill.requirements.bins.length > 0) {
-      const binsStatus = skill.requirements.bins.map((bin) => {
-        const missing = skill.missing.bins.includes(bin);
-        return missing ? theme.error(`✗ ${bin}`) : theme.success(`✓ ${bin}`);
+    for (const [key, label] of requirementGroups) {
+      const missingRequirements = skill.missing[key];
+      const requirementStatus = skill.requirements[key].map((requirement) => {
+        const missing =
+          key === "anyBins"
+            ? missingRequirements.length > 0
+            : missingRequirements.includes(requirement);
+        return missing ? theme.error(`✗ ${requirement}`) : theme.success(`✓ ${requirement}`);
       });
-      lines.push(`${theme.muted("  Binaries:")} ${binsStatus.join(", ")}`);
-    }
-    if (skill.requirements.anyBins.length > 0) {
-      const anyBinsMissing = skill.missing.anyBins.length > 0;
-      const anyBinsStatus = skill.requirements.anyBins.map((bin) => {
-        const missing = anyBinsMissing;
-        return missing ? theme.error(`✗ ${bin}`) : theme.success(`✓ ${bin}`);
-      });
-      lines.push(`${theme.muted("  Any binaries:")} ${anyBinsStatus.join(", ")}`);
-    }
-    if (skill.requirements.env.length > 0) {
-      const envStatus = skill.requirements.env.map((env) => {
-        const missing = skill.missing.env.includes(env);
-        return missing ? theme.error(`✗ ${env}`) : theme.success(`✓ ${env}`);
-      });
-      lines.push(`${theme.muted("  Environment:")} ${envStatus.join(", ")}`);
-    }
-    if (skill.requirements.config.length > 0) {
-      const configStatus = skill.requirements.config.map((cfg) => {
-        const missing = skill.missing.config.includes(cfg);
-        return missing ? theme.error(`✗ ${cfg}`) : theme.success(`✓ ${cfg}`);
-      });
-      lines.push(`${theme.muted("  Config:")} ${configStatus.join(", ")}`);
-    }
-    if (skill.requirements.os.length > 0) {
-      const osStatus = skill.requirements.os.map((osName) => {
-        const missing = skill.missing.os.includes(osName);
-        return missing ? theme.error(`✗ ${osName}`) : theme.success(`✓ ${osName}`);
-      });
-      lines.push(`${theme.muted("  OS:")} ${osStatus.join(", ")}`);
+      lines.push(`${theme.muted(`  ${label}:`)} ${requirementStatus.join(", ")}`);
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

The skills CLI repeated the same requirement-category order and formatting rules in its detailed view and missing-requirement summaries. Keeping five nearly identical branches synchronized made otherwise behavior-preserving maintenance harder than necessary.

## Why This Change Was Made

Keep the ordered requirement labels in their existing CLI formatting owner and use that single ordered representation for both summaries and detailed requirement rows. Preserve the special all-or-nothing semantics of alternative binary requirements without changing skill discovery, command registration, flags, JSON contracts, or shared requirement evaluation.

## User Impact

No user-visible behavior change. Skill list, info, and check output retains its exact ordering, labels, success/failure markers, empty-state behavior, ANSI treatment, and JSON representation. Production code decreases by 34 lines.

## Evidence

- Full unrestricted repository changed-file gate passed, including production/full-tree/script dead-export checks, core and core-test typechecks, formatting, lint, and architectural/security guards.
- Five existing skills formatter, real Commander command, real skill discovery, shared requirement-owner, and hooks sibling suites passed: **202 tests**.
- Independently compared **18 complete original versus refactored outputs** for skills list/info/check in human-readable and JSON modes: byte-for-byte identical for mixed requirement categories, unsatisfied alternative binaries, satisfied alternative binaries, and empty requirements.
- Fresh mandatory pre-commit and exact-commit Codex reviews completed without actionable findings; a separate independent read-only review approved the exact published commit.
