### PR TITLE
fix(ci): restore release validation gates

### DIFF
--- a/scripts/github/release-validation-campaign.d.mts
+++ b/scripts/github/release-validation-campaign.d.mts
@@ -18,6 +18,88 @@ export type ReleaseValidationCampaignArtifact =
       releaseUrl: string;
     };
 
+type CampaignRepoRequest = {
+  owner: string;
+  repo: string;
+};
+
+type CampaignIssue = {
+  number: number;
+  state: string;
+  title: string;
+  body?: string | null;
+  html_url: string;
+  labels: Array<string | { name?: string }>;
+  pull_request?: { url: string | null };
+};
+
+type CampaignListIssuesRequest = CampaignRepoRequest & {
+  state: "open";
+  labels: string;
+  per_page: number;
+};
+
+type CampaignIssueNumberRequest = CampaignRepoRequest & {
+  issue_number: number;
+};
+
+type CampaignGetLabelRequest = CampaignRepoRequest & {
+  name: string;
+};
+
+type CampaignCreateLabelRequest = CampaignRepoRequest & {
+  name: string;
+  color: string;
+  description: string;
+};
+
+type CampaignCreateCommentRequest = CampaignIssueNumberRequest & {
+  body: string;
+};
+
+type CampaignCreateIssueRequest = CampaignRepoRequest & {
+  title: string;
+  body: string;
+  labels: string[];
+};
+
+type CampaignUpdateIssueRequest =
+  | (CampaignIssueNumberRequest & {
+      title: string;
+      body: string;
+      state: "open";
+      labels: string[];
+    })
+  | (CampaignIssueNumberRequest & {
+      state: "closed";
+      state_reason: "completed";
+      labels: string[];
+    });
+
+type CampaignIssueResponse = Promise<{ data: CampaignIssue }>;
+
+type CampaignListIssuesMethod = (
+  parameters: CampaignListIssuesRequest,
+) => Promise<{ data: CampaignIssue[] }>;
+
+type CampaignGitHub = {
+  paginate(
+    method: CampaignListIssuesMethod,
+    parameters: CampaignListIssuesRequest,
+  ): Promise<CampaignIssue[]>;
+  rest: {
+    issues: {
+      listForRepo: CampaignListIssuesMethod;
+      getLabel(parameters: CampaignGetLabelRequest): Promise<unknown>;
+      createLabel(parameters: CampaignCreateLabelRequest): Promise<unknown>;
+      createComment(parameters: CampaignCreateCommentRequest): Promise<unknown>;
+      create(parameters: CampaignCreateIssueRequest): CampaignIssueResponse;
+      update(parameters: CampaignUpdateIssueRequest): CampaignIssueResponse;
+      get(parameters: CampaignIssueNumberRequest): CampaignIssueResponse;
+    };
+  };
+};
+
 export function validateReleaseValidationCampaignArtifact(
   artifact: unknown,
   options?: {
@@ -27,27 +109,8 @@ export function validateReleaseValidationCampaignArtifact(
   },
 ): ReleaseValidationCampaignArtifact;
 
-/**
- * Structural subset of the Actions-provided Octokit client this publisher uses.
- * Declared locally so the script keeps a real contract without depending on
- * Octokit's generated types from a plain-Node script surface.
- */
-export type ReleaseValidationCampaignGitHubClient = {
-  rest: {
-    issues: {
-      get(params: Record<string, unknown>): Promise<{ data: unknown }>;
-      getLabel(params: Record<string, unknown>): Promise<unknown>;
-      createLabel(params: Record<string, unknown>): Promise<unknown>;
-      createComment(params: Record<string, unknown>): Promise<unknown>;
-      update(params: Record<string, unknown>): Promise<{ data: unknown }>;
-      listForRepo: unknown;
-    };
-  };
-  paginate(route: unknown, params: Record<string, unknown>): Promise<unknown[]>;
-};
-
 export function runReleaseValidationCampaignPublish(params: {
-  github: ReleaseValidationCampaignGitHubClient;
+  github: CampaignGitHub;
   context: { repo: { owner: string; repo: string } };
   core: { info(message: string): void; setOutput?(name: string, value: string): void };
   artifact: unknown;

--- a/test/scripts/release-validation-campaign.test.ts
+++ b/test/scripts/release-validation-campaign.test.ts
@@ -126,9 +126,13 @@ function harness(initialIssues: ReturnType<typeof issue>[]) {
           }
           return { data: current };
         },
-        get: async ({ issue_number }: { issue_number: number }) => ({
-          data: issues.get(issue_number),
-        }),
+        get: async ({ issue_number }: { issue_number: number }) => {
+          const current = issues.get(issue_number);
+          if (!current) {
+            throw new Error("missing issue");
+          }
+          return { data: current };
+        },
       },
     },
   };


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/129743

Supersedes: https://github.com/openclaw/openclaw/pull/129733

## What Problem This Solves

Fixes the remaining release-validation declaration weakness exposed by two current-main CI regressions that formed a hard exact-head dependency cycle:

- The release-validation campaign declaration failed `check-lint` because its GitHub client parameter used explicit `any`.
- Two QA Lab cleanup fixtures failed `check-test-types` because they still used Crabline's retired smoke-artifact shape.

The prior lint-only head failed on the QA fixtures in https://github.com/openclaw/openclaw/actions/runs/32920876010/job/98034237450. Conversely, #129743's exact head fixed those fixtures but failed on current-main's release-validation lint error in https://github.com/openclaw/openclaw/actions/runs/32919562454/job/98030450577. Neither isolated PR could produce a green merge-ref CI result.

## Why This Change Was Made

The first amended head combined both independently reviewed canonical repairs. During the required rebase, `main` commit `637da87a5da10cf079224fcd102725bce1c5ee57` landed the byte-identical #129743 QA fixture repair and a broader declaration based on `Record<string, unknown>` and untyped pagination.

This PR now keeps only the remaining strict delta:

- Model the exact issue operations, request payloads, pagination contract, and consumed response shape used by the publisher.
- Make the test harness follow Octokit's success-or-throw issue lookup contract instead of returning an impossible successful `undefined` response.

The QA fixtures from #129743 are already present in the current base, so they are not duplicated as no-op changes. This supersedes #129733 because that uneditable branch mixed the broader declaration shape with overlapping QA commits.

## User Impact

No product behavior changes. Maintainers retain green release-validation lint and QA Lab typecheck gates with a closed GitHub API contract rather than a type-laundering boundary.

## Evidence

- Baseline lint reproduction: `release-validation-campaign.d.mts:31:11 no-explicit-any`.
- Prior exact-head QA type failures: missing `providerReadinessArtifactPath` in both cleanup fixtures.
- Focused script oxlint: passed.
- `pnpm tsgo:scripts`: passed.
- `pnpm tsgo:test:root`: passed.
- Release-validation campaign Vitest: 8/8 passed.
- `pnpm tsgo:extensions:test`: passed on the rebased current-main QA repair.
- `pnpm test:extension qa-lab -- extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts`: 2 files, 13/13 passed.
- `node scripts/check-changed.mjs -- scripts/github/release-validation-campaign.d.mts test/scripts/release-validation-campaign.test.ts`: passed.
- Test audit: clean; the existing harness now matches the dependency contract and adds no test-only production seam.
- Codex/Sol autoreview: no accepted/actionable findings.
- Production LOC: `+0/-0`; tooling declarations: `+83/-20`; tests: `+7/-3`.

Co-authored contribution preserved from Dallin Romney's public commit in #129733.

AI-assisted; implementation and final diff were reviewed locally.
