### PR TITLE
fix(ci): type release validation publisher client

### DIFF
--- a/scripts/github/release-validation-campaign.d.mts
+++ b/scripts/github/release-validation-campaign.d.mts
@@ -18,6 +18,11 @@ export type ReleaseValidationCampaignArtifact =
       releaseUrl: string;
     };
 
+export type ReleaseValidationCampaignGitHub = {
+  paginate: unknown;
+  rest: { issues: Record<string, unknown> };
+};
+
 export function validateReleaseValidationCampaignArtifact(
   artifact: unknown,
   options?: {
@@ -28,7 +33,7 @@ export function validateReleaseValidationCampaignArtifact(
 ): ReleaseValidationCampaignArtifact;
 
 export function runReleaseValidationCampaignPublish(params: {
-  github: any;
+  github: ReleaseValidationCampaignGitHub;
   context: { repo: { owner: string; repo: string } };
   core: { info(message: string): void; setOutput?(name: string, value: string): void };
   artifact: unknown;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where every current-main CI run fails the script lint lane because the release-validation campaign publisher declaration uses an explicit `any`.

## Why This Change Was Made

The declaration now exposes the GitHub client boundary it actually consumes: pagination plus the issues REST group. Runtime behavior is unchanged.

## User Impact

No user-visible product behavior changes. Main and PR CI can lint the release-validation publisher again.

## Evidence

- Reproduced remotely in `check-lint`: `scripts/github/release-validation-campaign.d.mts:31:11 Unexpected any`.
- `node scripts/check-changed.mjs -- scripts/github/release-validation-campaign.d.mts`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings.
- Production LOC: +0/-0. Tooling declarations: +6/-1. Tests: +0/-0.
