### PR TITLE
fix(ci): restore release types and QA driver fixtures

### DIFF
--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -242,10 +242,10 @@ describe("isolated QA suite transport cleanup", () => {
   it("keeps Crabline workers concurrent while publishing readiness only from the final aggregate", async () => {
     const lab = createCleanupTestLab();
     const selection = {
-      capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+      capabilityMatrixPath: "crabline-channel-driver-capabilities.json",
       channel: "telegram",
       channelDriver: "crabline",
-      smokeArtifactPath: "crabline-fake-provider-smoke.json",
+      providerReadinessArtifactPath: "crabline-provider-readiness.json",
     } as const;
     let activeWorkers = 0;
     let maxActiveWorkers = 0;

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
@@ -284,10 +284,10 @@ describe("runtime parity suite transport cleanup", () => {
     mocks.writeQaSuiteArtifacts.mockClear();
     const scenario = makeQaSuiteTestScenario("runtime-cleanup");
     const selection = {
-      capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+      capabilityMatrixPath: "crabline-channel-driver-capabilities.json",
       channel: "telegram",
       channelDriver: "crabline",
-      smokeArtifactPath: "crabline-fake-provider-smoke.json",
+      providerReadinessArtifactPath: "crabline-provider-readiness.json",
     } as const;
     const parentLab = createCleanupTestLab();
     const openClawLab = createCleanupTestLab();

--- a/scripts/github/release-validation-campaign.d.mts
+++ b/scripts/github/release-validation-campaign.d.mts
@@ -27,8 +27,23 @@ export function validateReleaseValidationCampaignArtifact(
   },
 ): ReleaseValidationCampaignArtifact;
 
+type ReleaseValidationGitHubMethod = (...args: never[]) => Promise<unknown>;
+
 export function runReleaseValidationCampaignPublish(params: {
-  github: any;
+  github: {
+    paginate: (...args: never[]) => Promise<unknown[]>;
+    rest: {
+      issues: {
+        create: ReleaseValidationGitHubMethod;
+        createComment: ReleaseValidationGitHubMethod;
+        createLabel: ReleaseValidationGitHubMethod;
+        get: ReleaseValidationGitHubMethod;
+        getLabel: ReleaseValidationGitHubMethod;
+        listForRepo: ReleaseValidationGitHubMethod;
+        update: ReleaseValidationGitHubMethod;
+      };
+    };
+  };
   context: { repo: { owner: string; repo: string } };
   core: { info(message: string): void; setOutput?(name: string, value: string): void };
   artifact: unknown;


### PR DESCRIPTION
## Summary

- Replace the explicit-any release campaign client declaration with the exact seven asynchronous GitHub issue methods and paginator used by the publisher.
- Update both QA cleanup fixtures to the exact Crabline 0.1.17 driver selection contract, removing retired smoke fields and outdated capability filenames.
- Repair two independent deterministic current-main static CI failures introduced by #129726 and #124189 without changing runtime behavior.

## Validation

- Original release declaration lint failure reproduced and corrected; focused oxlint now passes.
- Strict standalone TypeScript checking of the existing release campaign owner tests passes, including their narrowly typed GitHub fakes.
- Release campaign owner tests: 8 passed.
- Both affected QA cleanup suites: 13 passed.
- Exact Crabline 0.1.17 tagged source and producer inspected directly.
- Independent review and configured structured Codex review: clean.
- Full local extension typechecking is unavailable because shared dependencies contain Crabline 0.1.11 while current main pins 0.1.17; hosted check-test-types validates the exact current dependency graph.