### PR TITLE
fix(ui): preserve configured models when catalog requests fail

### DIFF
--- a/ui/src/e2e/model-provider-usage-outcomes.e2e.test.ts
+++ b/ui/src/e2e/model-provider-usage-outcomes.e2e.test.ts
@@ -115,6 +115,106 @@ suite.define(() => {
     );
   });
 
+  it("keeps configured models visible when their catalog fails, then recovers on refresh", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1_000, width: 1_440 },
+      },
+      async ({ page }) => {
+        const config = {
+          agents: { defaults: { model: "openai/gpt-5.5" } },
+          models: { providers: { openai: { apiKey: "[redacted]" } } },
+        };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            ...providerUsageResponses({ updatedAt: now, providers: [] }),
+            "config.get": {
+              config,
+              sourceConfig: config,
+              hash: "model-providers-catalog-failure",
+              issues: [],
+              raw: JSON.stringify(config),
+              valid: true,
+            },
+            "models.list": {
+              __mockError: {
+                code: "UNAVAILABLE",
+                message: "Model catalog temporarily unavailable",
+              },
+            },
+            "models.authStatus": {
+              ts: now,
+              providers: [
+                {
+                  provider: "openai",
+                  displayName: "OpenAI",
+                  status: "static",
+                  profiles: [],
+                  apiKey: { source: "config" },
+                },
+              ],
+            },
+          },
+        });
+
+        await page.goto(`${suite.server.baseUrl}settings/model-providers`);
+        const card = page.locator('[data-provider-id="openai"]');
+        await card.waitFor();
+        await expect
+          .poll(async () => (await gateway.getRequests("models.list")).length)
+          .toBeGreaterThan(0);
+
+        if (recordVisuals) {
+          await mkdir(artifactDir, { recursive: true });
+          const phase =
+            (await page.locator(".provider-usage-error").count()) === 0 ? "before" : "after";
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, `model-catalog-request-failure-${phase}.png`),
+          });
+        }
+
+        await expect
+          .poll(() => page.locator(".provider-usage-error").textContent(), { timeout: 5_000 })
+          .toContain("Model catalog temporarily unavailable");
+        expect(await page.locator('[data-model-readiness="model-required"]').count()).toBe(0);
+        const primary = page.locator(".model-providers__defaults wa-select").first();
+        await expect
+          .poll(() =>
+            primary.evaluate((element) =>
+              String((element as HTMLElement & { value?: string }).value),
+            ),
+          )
+          .toBe("openai/gpt-5.5");
+
+        await gateway.setMethodResponse("models.list", {
+          models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai", available: true }],
+        });
+        await page.getByRole("button", { name: "Refresh", exact: true }).click();
+
+        await expect.poll(() => page.locator(".provider-usage-error").count()).toBe(0);
+        await expect.poll(() => card.textContent()).toContain("API key set in config");
+        await expect
+          .poll(() =>
+            primary.evaluate((element) =>
+              String((element as HTMLElement & { value?: string }).value),
+            ),
+          )
+          .toBe("openai/gpt-5.5");
+        if (recordVisuals) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "model-catalog-request-recovered.png"),
+          });
+        }
+      },
+    );
+  });
+
   it("clears unsaved provider credentials when switching agents without saving them", async () => {
     await suite.withPage(
       {

--- a/ui/src/pages/model-providers/data.test.ts
+++ b/ui/src/pages/model-providers/data.test.ts
@@ -359,6 +359,16 @@ describe("model provider configuration data", () => {
     ]);
   });
 
+  it.each(["openai/gpt-saved", "saved-model"])(
+    "keeps saved %s available when the catalog is unknown, but not when it is empty",
+    (primary) => {
+      const selection = { primary, fallbacks: [], utilityModel: null };
+
+      expect(buildSelectableDefaultModels(null, selection)[0]).not.toHaveProperty("available");
+      expect(buildSelectableDefaultModels([], selection)[0]).toMatchObject({ available: false });
+    },
+  );
+
   it("preserves alias-valued and bare model defaults as picker options", () => {
     const selectable = buildSelectableDefaultModels(
       [catalogEntry({ provider: "anthropic", id: "claude-opus", alias: "Opus", available: true })],

--- a/ui/src/pages/model-providers/data.ts
+++ b/ui/src/pages/model-providers/data.ts
@@ -369,6 +369,8 @@ export function buildSelectableDefaultModels(
     (model) => model.available !== false || selected.has(modelCatalogRef(model)),
   );
   const seen = new Set(selectable.map(modelCatalogRef));
+  // An unavailable catalog cannot establish that a saved model is unavailable.
+  const availability = models === null ? {} : { available: false as const };
   for (const ref of selected) {
     if (seen.has(ref)) {
       continue;
@@ -381,7 +383,7 @@ export function buildSelectableDefaultModels(
           model.alias?.trim().toLowerCase() === normalized || model.id.trim() === ref.trim(),
       );
       selectable.push({
-        ...(match ?? { provider: "", id: ref, name: ref, available: false }),
+        ...(match ?? { provider: "", id: ref, name: ref, ...availability }),
         selectionRef: ref,
       });
       continue;
@@ -390,7 +392,7 @@ export function buildSelectableDefaultModels(
       provider: ref.slice(0, slash),
       id: ref.slice(slash + 1),
       name: ref,
-      available: false,
+      ...availability,
     });
   }
   return selectable;

--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -78,6 +78,48 @@ describe("loadModelProvidersData", () => {
     expect(sessionUsageCall?.[1]).toHaveProperty("agentScope", "all");
   });
 
+  it.each([
+    { label: "the initial prepared catalog", refresh: false },
+    { label: "the configured catalog after discovery", refresh: true },
+  ])("surfaces a failure loading $label without discarding provider data", async ({ refresh }) => {
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      switch (method) {
+        case "models.authStatus":
+          return {
+            ts: 1,
+            providers: [{ provider: "openai", displayName: "OpenAI", status: "ok", profiles: [] }],
+          };
+        case "models.list":
+          if ((params as { view?: string } | undefined)?.view === "all") {
+            return { providerOutcomes: [] };
+          }
+          throw new Error("configured catalog unavailable: OPENAI_API_KEY=sk-1234567890abcdef");
+        case "config.get":
+          return {
+            config: { agents: { defaults: { model: "openai/gpt-5.5" } } },
+            hash: "hash",
+          };
+        case "usage.status":
+          return { updatedAt: 1, providers: [] };
+        case "sessions.usage":
+          return { aggregates: { byProvider: [] } };
+        default:
+          return {};
+      }
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+
+    const result = await loadModelProvidersData(client, { agentId: "main", refresh });
+
+    expect(result.models).toBeNull();
+    expect(result.catalogError).toBe(
+      "configured catalog unavailable: OPENAI_API_KEY=sk-123...cdef",
+    );
+    expect(result.authStatus?.providers).toHaveLength(1);
+    expect(result.config).toEqual({ agents: { defaults: { model: "openai/gpt-5.5" } } });
+    expect(result.error).toBeNull();
+  });
+
   it("degrades an invalid auth-status response without discarding other provider data", async () => {
     const request = vi.fn(async (method: string) => {
       switch (method) {

--- a/ui/src/pages/model-providers/load.ts
+++ b/ui/src/pages/model-providers/load.ts
@@ -86,17 +86,16 @@ export async function loadModelProvidersData(
         .then((result) => ({ ok: true as const, result: result ?? null }))
         .catch((error: unknown) => ({ ok: false as const, error }))
     : Promise.resolve({ ok: true as const, result: null });
-  const modelsLoad = opts?.refresh
-    ? catalogRefresh.then((catalogResult) =>
-        loadModels(client, {
-          agentId: opts.agentId,
-          ...(catalogResult.ok ? { refresh: true } : { preparedOnly: true }),
-        }),
-      )
-    : loadModels(client, {
-        agentId: opts.agentId,
-        preparedOnly: true,
-      }).catch(() => null);
+  const modelsLoad = catalogRefresh.then((catalogResult) =>
+    loadModels(client, {
+      agentId: opts.agentId,
+      ...(opts.refresh && catalogResult.ok ? { refresh: true } : { preparedOnly: true }),
+      rejectOnFailure: true,
+    }).then(
+      (result) => ({ ok: true as const, result }),
+      (error: unknown) => ({ ok: false as const, error }),
+    ),
+  );
   const [authStatus, models, catalogResult, config, providerUsageFetch, costByProvider] =
     await Promise.all([
       loadModelAuthStatus(client, opts).then(
@@ -121,9 +120,13 @@ export async function loadModelProvidersData(
   return {
     authStatus:
       authStatus.ok && Array.isArray(authStatus.result?.providers) ? authStatus.result : null,
-    models,
+    models: models.ok ? models.result : null,
     providerOutcomes: catalogResult.ok ? (catalogResult.result?.providerOutcomes ?? []) : [],
-    catalogError: catalogResult.ok ? null : errorMessage(catalogResult.error),
+    catalogError: !catalogResult.ok
+      ? errorMessage(catalogResult.error)
+      : !models.ok
+        ? errorMessage(models.error)
+        : null,
     config,
     providerUsage: providerUsageFetch,
     costByProvider,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Settings → Models would be told to connect an AI model and lose their configured default-model controls when the Gateway temporarily fails to load the model catalog, even though their existing provider credentials and saved default model are healthy.

## Why This Change Was Made

The Models page now keeps a failed catalog request distinct from a successful empty catalog, surfaces its sanitized error without dropping independent provider/configuration data, and preserves the existing distinction between an unknown saved model and a genuinely unavailable model. The normal refresh path still retains cached models when discovery fails; verified empty catalogs and retired models continue to show the existing setup prompt.

## User Impact

Operators can see their configured primary, utility, and fallback model controls while a temporary catalog outage is visible and recoverable with Refresh. Existing healthy provider credentials remain visible, and a real missing or retired model still correctly requires setup.

## Evidence

Four owner regressions failed against the previous implementation: initial and post-refresh configured catalog failures were incorrectly reduced to an empty list, and both qualified and alias-valued saved models were incorrectly marked unavailable when their catalog was unknown. After the repair, all 63 focused loader, model projection, and existing readiness/view tests pass, including the existing retired-model negative control; the complete real-Chromium mocked-Gateway suite also passes all four scenarios.

The new browser scenario failed against the existing code before the repair, then passed by exercising a real Chromium page, mocked Gateway WebSocket failure, preserved configured model controls, healthy provider credentials, and a successful Refresh recovery. The fixtures contain only synthetic data and literal redacted configuration values. Independent source review and fresh automated review both reported no findings.

**Before: a temporary catalog error silently claims no model is configured.**

![Before: configured provider exists but Models incorrectly demands model setup](https://github.com/user-attachments/assets/7d3e48e0-f980-45a8-b2e3-05f3e2f5bf54)

**After: the saved model controls remain available and the real catalog error is visible.**

![After: saved model controls remain visible alongside the real catalog error](https://github.com/user-attachments/assets/5ae92c71-45f1-468b-9d55-80db4a576629)

**After Refresh: discovery recovers and the warning clears.**

![After refresh: model discovery recovers and the transient warning disappears](https://github.com/user-attachments/assets/f8d84d9b-20b4-402f-9d5d-cfafe02fc717)
