### PR TITLE
fix(test): keep CLI hook context out of history assertion

### DIFF
--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -745,7 +745,9 @@ describeLive("gateway live (cli backend)", () => {
               sessionId?: string;
             }>("chat.history", { sessionKey });
             const cliSessionId = resolveImportedClaudeCliSessionId(nativeHistory.messages ?? []);
-            expect(JSON.stringify(nativeHistory.messages ?? [])).toContain(memoryToken);
+            // Hook-only runtime context belongs to the provider session, not the operator-visible
+            // transcript. The resumed reply below proves that the live provider retained it.
+            expect(JSON.stringify(nativeHistory.messages ?? [])).not.toContain(memoryToken);
             expect(cliSessionId).toBeTruthy();
             const continuitySessionId = nativeHistory.sessionId;
             expect(continuitySessionId).toBeTruthy();


### PR DESCRIPTION
## Summary

- align the Claude CLI continuity live probe with the canonical transcript boundary
- require hook-only runtime context to stay out of operator-visible `chat.history`
- keep the stronger resume assertion: the next provider turn must still return the hidden token from live-session memory

## Root cause

Full Release Validation run [32917859227](https://github.com/openclaw/openclaw/actions/runs/32917859227), job [98027493849](https://github.com/openclaw/openclaw/actions/runs/32917859227/job/98027493849), failed twice before sending its resume turn. The probe injected a private token through `before_prompt_build`, then incorrectly required that runtime-only context to appear in the OpenClaw transcript.

The official Agent SDK migration in #128131 made the intended ownership visible: the provider session retains injected runtime context, while the gateway transcript records the original operator prompt. `src/agents/cli-runner/prepare.test.ts` already independently proves that hook context changes the provider prompt without changing `transcriptPrompt` or the context-engine turn.

The corrected live probe now asserts both halves of the contract at their real boundaries: the hidden token is absent from `chat.history`, then the resumed provider reply must contain it and retain the same live-session generation.

## Test audit

- Observable invariant: runtime hook context reaches provider continuity without contaminating the operator transcript.
- Credible regression: persisting the prepared provider prompt would expose hidden hook context; dropping provider continuity would fail the later resume reply.
- Existing coverage: prepare-unit coverage owns prompt/transcript separation; this live test owns real Agent SDK session continuity. Neither duplicates the other.
- Production seam: none.

## Validation

- failing reproduction: release job failed the old assertion on two independent attempts, each showing only the original user prompt in `chat.history`
- `node scripts/run-vitest.mjs src/gateway/gateway-cli-backend.live-helpers.test.ts src/agents/cli-runner/prepare.test.ts` (127 tests passed)
- `node scripts/check-changed.mjs -- src/gateway/gateway-cli-backend.live.test.ts` (all non-typecheck gates passed; local shared dependencies produced pre-existing package/TUI type mismatches, so exact-head CI is authoritative for typecheck)
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean, no actionable findings)
- `git diff --check`

Production LOC: +0/-0. Tests: +3/-1.
