### PR TITLE
fix(test): refresh embedded provider runtime mock

### DIFF
--- a/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
+++ b/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
@@ -367,6 +367,7 @@ export function installEmbeddedRunnerFastRunE2eMocks(
     prepareProviderRuntimeAuth: options.prepareProviderRuntimeAuth ?? vi.fn(async () => undefined),
     resolveProviderAuthProfileId: vi.fn(() => undefined),
     resolveProviderCapabilitiesWithPlugin: vi.fn(() => undefined),
+    resolveProviderDeprecatedAuthProfileIds: vi.fn(() => []),
     resolveExternalAuthProfilesWithPlugins: vi.fn(() => []),
     resolveProviderSyntheticAuthWithPlugin: vi.fn(() => undefined),
     runProviderDynamicModel: vi.fn(() => undefined),


### PR DESCRIPTION
## Summary

- refresh the shared fast embedded-runner E2E provider-runtime mock
- represent the provider-owned retired-profile resolver with the neutral empty-policy result
- restore auth rotation and cross-provider fallback suites without activating real plugin runtime

## Root cause

Full Release Validation run [32917859227](https://github.com/openclaw/openclaw/actions/runs/32917859227), job [98025911272](https://github.com/openclaw/openclaw/actions/runs/32917859227/job/98025911272), failed dozens of embedded auth/fallback cases with Vitest's missing-export error for `resolveProviderDeprecatedAuthProfileIds`.

#129052 added that production resolver to exclude provider-retired credentials from generic auth selection. The shared fast E2E mock remained a complete explicit mock of `provider-runtime.js` but did not implement the new dependency, so Vitest failed before the tests reached their auth and fallback behavior.

The mock owner now returns `[]`, the correct neutral policy for these provider-generic fixtures. This keeps the suites isolated and deterministic without bypassing the production call path or loading provider plugins.

## Test audit

- Observable invariant: shared embedded-runner fixtures can execute generic auth selection with no provider-retired profiles.
- Credible regression: adding a required provider-runtime call without updating the explicit shared mock fails every consuming E2E suite before behavior assertions.
- Existing coverage: five E2E files share this one mock owner; the change fixes the shared seam instead of duplicating per-file mocks.
- Production seam: none; this is test support only.

## Validation

- pre-fix reproduction: exact release job repeatedly reported missing `resolveProviderDeprecatedAuthProfileIds` from the shared mock
- `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts` (31 passed)
- `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/agents/model-fallback.run-embedded.e2e.test.ts src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts` (24 passed)
- `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/agents/cli-runner.fault-sequences.e2e.test.ts src/agents/embedded-agent-runner.e2e.test.ts` (28 passed)
- `node scripts/check-changed.mjs -- src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts` (all pre-typecheck gates passed; the shared local dependency tree has unrelated Google SDK, markdown-it, and pi-tui type drift, so exact-head CI is authoritative for typecheck)
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean, no actionable findings)
- `git diff --check`

Production LOC: +0/-0. Test support: +1/-0.
