### PR TITLE
fix(ci): restore release-validation and Crabline checks

### DIFF
--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -242,10 +242,10 @@ describe("isolated QA suite transport cleanup", () => {
   it("keeps Crabline workers concurrent while publishing readiness only from the final aggregate", async () => {
     const lab = createCleanupTestLab();
     const selection = {
-      capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+      capabilityMatrixPath: "crabline-channel-driver-capabilities.json",
       channel: "telegram",
       channelDriver: "crabline",
-      smokeArtifactPath: "crabline-fake-provider-smoke.json",
+      providerReadinessArtifactPath: "crabline-provider-readiness.json",
     } as const;
     let activeWorkers = 0;
     let maxActiveWorkers = 0;

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
@@ -284,10 +284,10 @@ describe("runtime parity suite transport cleanup", () => {
     mocks.writeQaSuiteArtifacts.mockClear();
     const scenario = makeQaSuiteTestScenario("runtime-cleanup");
     const selection = {
-      capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+      capabilityMatrixPath: "crabline-channel-driver-capabilities.json",
       channel: "telegram",
       channelDriver: "crabline",
-      smokeArtifactPath: "crabline-fake-provider-smoke.json",
+      providerReadinessArtifactPath: "crabline-provider-readiness.json",
     } as const;
     const parentLab = createCleanupTestLab();
     const openClawLab = createCleanupTestLab();

--- a/scripts/github/release-validation-campaign.d.mts
+++ b/scripts/github/release-validation-campaign.d.mts
@@ -28,7 +28,7 @@ export function validateReleaseValidationCampaignArtifact(
 ): ReleaseValidationCampaignArtifact;
 
 export function runReleaseValidationCampaignPublish(params: {
-  github: any;
+  github: unknown;
   context: { repo: { owner: string; repo: string } };
   core: { info(message: string): void; setOutput?(name: string, value: string): void };
   artifact: unknown;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where pull requests across the repository cannot pass CI because the release-validation lint lane rejects an explicit `any` and two QA-Lab cleanup fixtures no longer satisfy the current Crabline artifact contract.

## Why This Change Was Made

Keep the injected GitHub Actions client opaque at its existing declaration boundary and update both existing cleanup fixtures to use the canonical Crabline capability and provider-readiness artifact names. This restores both independent gates without introducing a duplicate GitHub client hierarchy or changing runtime behavior; production and test line counts are both net zero.

Related: #129733, #129743.

## User Impact

Contributors and maintainers can validate and land unrelated fixes again. There is no product, configuration, authentication, or runtime behavior change.

## Evidence

- Reproduced the two hosted CI failures: `typescript(no-explicit-any)` in the release-validation declaration and `TS2741` for the two stale Crabline cleanup fixtures.
- Both genuine QA-Lab cleanup suites pass: **13 tests across 2 suites**, resolving the authentic pinned `@openclaw/crabline@0.1.17` source.
- Both strict owning extension-test project checks pass with **12,959 real source files** and **11 authentic pinned Crabline resolutions** each; the strict scripts declaration project also passes.
- Changed-file oxlint, canonical formatting, assertion-safety ratchet, max-lines ratchet, and environment-count guard all pass.
- Two independent reviews and an authenticated Codex review reported no findings.
- Exact delta: release declaration **+1/-1**; existing tests **+4/-4**.
