### PR TITLE
fix(ui): own chat history issuance with a closed state machine

### DIFF
--- a/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
@@ -119,4 +119,54 @@ suite.define(() => {
       await suite.closeBrowserContext(context);
     }
   });
+  it("keeps cached history visible and actionable when a refresh fails", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [{ text: "Cached transcript stays visible.", type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const cachedMessage = page
+        .locator(".chat-thread")
+        .getByText("Cached transcript stays visible.");
+      await cachedMessage.waitFor({ state: "visible" });
+
+      await gateway.deferNext("chat.startup");
+      await gateway.setOnline(false);
+      await gateway.setOnline(true);
+      await gateway.waitForRequest("chat.startup", { after: 1 });
+      await gateway.rejectDeferred("chat.startup", {
+        code: "GATEWAY_ERROR",
+        message: "History refresh failed.",
+        retryable: false,
+      });
+
+      const inlineError = page.locator(".chat-history-error--inline");
+      await inlineError.waitFor({ state: "visible", timeout: 5_000 });
+      expect(await inlineError.textContent()).toContain("History refresh failed.");
+      // The stale transcript must not be displaced by the failure surface.
+      await cachedMessage.waitFor({ state: "visible" });
+      await captureHistoryIssuanceProof(page, "04-history-refresh-failed-cached");
+
+      const startupCount = (await gateway.getRequests("chat.startup")).length;
+      await inlineError.getByRole("button", { name: "Retry" }).click();
+      await gateway.waitForRequest("chat.startup", { after: startupCount });
+      await inlineError.waitFor({ state: "hidden", timeout: 5_000 });
+      await cachedMessage.waitFor({ state: "visible" });
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
 });

--- a/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
@@ -1,0 +1,122 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+
+async function captureHistoryIssuanceProof(page: Page, name: string): Promise<void> {
+  const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+  if (!artifactDir) {
+    return;
+  }
+  await mkdir(artifactDir, { recursive: true });
+  await page.screenshot({ fullPage: true, path: path.join(artifactDir, `${name}.png`) });
+}
+
+suite.define(() => {
+  it("renders a failed history load in the transcript and retries it", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["chat.startup"],
+      historyMessages: [
+        {
+          content: [{ text: "Transcript recovered after retry.", type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      await gateway.rejectDeferred("chat.startup", {
+        code: "GATEWAY_UNAVAILABLE",
+        message: "Chat history is temporarily unavailable.",
+      });
+
+      const historyError = page.locator(".chat-history-error");
+      await historyError.waitFor({ state: "visible", timeout: 5_000 });
+      expect(await historyError.textContent()).toContain(
+        "Chat history is temporarily unavailable.",
+      );
+      expect(await gateway.getRequests("chat.startup")).toHaveLength(1);
+      await captureHistoryIssuanceProof(page, "01-history-load-failed");
+
+      await gateway.deferNext("chat.startup");
+      await historyError.getByRole("button", { name: "Retry" }).click();
+      await gateway.waitForRequest("chat.startup", { after: 1 });
+      await historyError.waitFor({ state: "detached" });
+      await page.locator(".chat-thread .chat-loading-skeleton").waitFor({ state: "visible" });
+      await gateway.resolveDeferred("chat.startup");
+      await page
+        .locator(".chat-thread")
+        .getByText("Transcript recovered after retry.")
+        .waitFor({ state: "visible" });
+
+      expect(await gateway.getRequests("chat.startup")).toHaveLength(2);
+      expect(await page.locator(".chat-history-error").count()).toBe(0);
+      await captureHistoryIssuanceProof(page, "02-history-load-retried");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("automatically resumes retryable history failures once after reconnect", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["chat.startup"],
+      historyMessages: [
+        {
+          content: [{ text: "Transcript recovered after reconnect.", type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      await gateway.rejectDeferred("chat.startup", {
+        code: "GATEWAY_UNAVAILABLE",
+        message: "Chat history will recover after reconnect.",
+        retryable: true,
+      });
+
+      const historyError = page.locator(".chat-history-error");
+      await historyError.waitFor({ state: "visible", timeout: 5_000 });
+      expect(await historyError.textContent()).toContain(
+        "Chat history will recover after reconnect.",
+      );
+      expect(await gateway.getRequests("chat.startup")).toHaveLength(1);
+
+      await gateway.setOnline(false);
+      expect(await gateway.getRequests("chat.startup")).toHaveLength(1);
+      await gateway.setOnline(true);
+      await gateway.waitForRequest("chat.startup", { after: 1 });
+      await page
+        .locator(".chat-thread")
+        .getByText("Transcript recovered after reconnect.")
+        .waitFor({ state: "visible" });
+
+      expect(await gateway.getRequests("chat.startup")).toHaveLength(2);
+      expect(await page.locator(".chat-history-error").count()).toBe(0);
+      await captureHistoryIssuanceProof(page, "03-history-load-auto-resumed");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -7,7 +7,7 @@ import { createDeferred } from "../../../../test/helpers/promise.js";
 import { GatewayRequestError } from "../../api/gateway.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
 import { handleChatGatewayEvent, type ChatEventPayload } from "./chat-gateway.ts";
-import { loadChatHistory, type ChatState } from "./chat-history.ts";
+import { getChatHistoryLoadState, loadChatHistory, type ChatState } from "./chat-history.ts";
 import { buildChatItems } from "./chat-thread-build.ts";
 import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
 import { cacheChatSessionSnapshot, readChatMessagesFromCache } from "./session-message-cache.ts";
@@ -2932,8 +2932,13 @@ describe("loadChatHistory retry handling", () => {
       limit: 100,
     });
     expect(request).toHaveBeenCalledTimes(1);
-    expect(state.lastError).toContain("unknown method: chat.startup");
-    expect(state.chatError).toContain("unknown method: chat.startup");
+    expect(getChatHistoryLoadState(state)).toMatchObject({
+      phase: "failed",
+      message: expect.stringContaining("unknown method: chat.startup"),
+      retryable: false,
+    });
+    expect(state.lastError).toBeNull();
+    expect(state.chatError).toBeNull();
   });
 
   it("retries retryable startup unavailability before showing history", async () => {
@@ -3673,9 +3678,14 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatMessages).toStrictEqual([]);
     expect(state.chatThinkingLevel).toBeNull();
     expect(state.chatVerboseLevel).toBeNull();
-    expect(state.lastError).toBe(
-      "This connection is missing operator.read, so existing chat history cannot be loaded yet.",
-    );
+    expect(getChatHistoryLoadState(state)).toMatchObject({
+      phase: "failed",
+      message:
+        "This connection is missing operator.read, so existing chat history cannot be loaded yet.",
+      retryable: false,
+    });
+    expect(state.lastError).toBeNull();
+    expect(state.chatError).toBeNull();
     expect(state.chatLoading).toBe(false);
   });
 
@@ -3887,14 +3897,13 @@ describe("loadChatHistory retry handling", () => {
     state.connectionEpoch = 2;
     state.connected = true;
     state.connectionEpoch = 3;
-    // The connection owner has already prepared the new epoch. The stale
-    // finalizer must not clear its loading state.
     state.chatLoading = true;
     staleRequest.reject(new Error("stale history failure"));
     await staleLoad;
 
     expect(state.lastError).toBeNull();
     expect(state.chatError).toBeNull();
+    expect(getChatHistoryLoadState(state)).toMatchObject({ phase: "pending-connection" });
     expect(state.chatLoading).toBe(true);
   });
 

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -1,6 +1,6 @@
 import { readSessionMessageSequence } from "@openclaw/gateway-client/browser";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
   AgentsListResult,
   GatewaySessionRow,
@@ -97,13 +97,32 @@ const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const SESSION_MESSAGE_RELEASE_RETRY_MS = 250;
 const MAX_SESSION_MESSAGE_RELEASE_ATTEMPTS = 3;
 
+type ChatHistoryLoadRequest = {
+  sessionKey: string;
+  requestAgentId: string | undefined;
+  startup: boolean;
+};
+
+export type ChatHistoryLoadState =
+  | { phase: "idle" }
+  | ({ phase: "pending-connection" } & ChatHistoryLoadRequest)
+  | ({
+      phase: "in-flight";
+      client: GatewayBrowserClient;
+      connectionEpoch: number;
+      key: string;
+      promise: Promise<ChatHistoryResult | undefined>;
+    } & ChatHistoryLoadRequest)
+  | { phase: "committed"; key: string }
+  | ({ phase: "failed"; message: string; retryable: boolean } & ChatHistoryLoadRequest);
+
 type ChatHistoryPaneRequests = {
   historyVersion: number;
   branchVersion: number;
   subscriptionGeneration: number;
   subscriptionError?: string;
   pendingSubscriptionReleases: Set<SessionMessageSubscription>;
-  inFlightHistory?: InFlightChatHistoryRequest;
+  historyLoad: ChatHistoryLoadState;
 };
 
 const chatHistoryPaneRequests = new WeakMap<object, ChatHistoryPaneRequests>();
@@ -116,10 +135,47 @@ function getChatHistoryPaneRequests(owner: object): ChatHistoryPaneRequests {
       branchVersion: 0,
       subscriptionGeneration: 0,
       pendingSubscriptionReleases: new Set(),
+      historyLoad: { phase: "idle" },
     };
     chatHistoryPaneRequests.set(owner, requests);
   }
   return requests;
+}
+
+export function getChatHistoryLoadState(state: ChatState): ChatHistoryLoadState {
+  const requests = getChatHistoryPaneRequests(state);
+  const load = requests.historyLoad;
+  if (load.phase === "idle") {
+    return load;
+  }
+  const requestAgentId = isUiSelectedGlobalSessionKey(state, state.sessionKey)
+    ? resolveUiSelectedSessionAgentId(state)
+    : undefined;
+  const current =
+    load.phase === "committed"
+      ? load.key === `${state.sessionKey}\u0000${requestAgentId ?? ""}`
+      : load.sessionKey === state.sessionKey && load.requestAgentId === requestAgentId;
+  if (!current) {
+    requests.historyLoad = { phase: "idle" };
+    state.chatLoading = false;
+  } else if (
+    load.phase === "in-flight" &&
+    (!state.connected ||
+      load.client !== state.client ||
+      load.connectionEpoch !== state.connectionEpoch)
+  ) {
+    // Reconnect can finish before stale work settles, so transfer its intent
+    // before the connected transition decides whether to reissue history.
+    requests.historyLoad = {
+      phase: "pending-connection",
+      sessionKey: load.sessionKey,
+      requestAgentId: load.requestAgentId,
+      startup: load.startup,
+    };
+    state.chatLoading = true;
+    state.requestUpdate?.();
+  }
+  return requests.historyLoad;
 }
 
 export function retireChatBranchRequests(state: ChatState): void {
@@ -176,7 +232,7 @@ export function resetChatHistoryProjection(state: ChatState, agentId?: string): 
   // A destructive reset keeps the session key, so invalidate both the old
   // snapshot owner and its coalesced request before creating the next epoch.
   requests.historyVersion += 1;
-  requests.inFlightHistory = undefined;
+  requests.historyLoad = { phase: "idle" };
   state.chatLoading = false;
   const scope = readChatSessionProjectionScope(state, { agentId });
   // Destructive operations keep the public session key, so only an explicit
@@ -906,13 +962,6 @@ export async function syncSelectedSessionMessageSubscription(
   }
 }
 
-type InFlightChatHistoryRequest = {
-  client: NonNullable<ChatState["client"]>;
-  connectionEpoch: number;
-  key: string;
-  promise: Promise<ChatHistoryResult | undefined>;
-};
-
 type LoadChatHistoryOptions = {
   deferBranches?: boolean;
   startup?: boolean;
@@ -1487,14 +1536,19 @@ export async function loadChatHistory(
   state: ChatState,
   opts: LoadChatHistoryOptions = {},
 ): Promise<ChatHistoryResult | undefined> {
-  if (!state.client || !state.connected) {
-    return undefined;
-  }
   const sessionKey = state.sessionKey;
   const requestAgentId = isUiSelectedGlobalSessionKey(state, sessionKey)
     ? resolveUiSelectedSessionAgentId(state)
     : undefined;
-  const method = opts.startup === true ? "chat.startup" : "chat.history";
+  const startup = opts.startup === true;
+  const requests = getChatHistoryPaneRequests(state);
+  if (!state.client || !state.connected) {
+    requests.historyLoad = { phase: "pending-connection", sessionKey, requestAgentId, startup };
+    state.chatLoading = true;
+    state.requestUpdate?.();
+    return undefined;
+  }
+  const method = startup ? "chat.startup" : "chat.history";
   const client = state.client;
   const connectionEpoch = state.connectionEpoch;
   const deltaCursor = state.chatMessagesBySession
@@ -1505,12 +1559,12 @@ export async function loadChatHistory(
     : undefined;
   const requestModeKey = deltaCursor === undefined ? "page" : `cursor:${deltaCursor}`;
   const requestKey = `${connectionEpoch}\u0000${method}\u0000${sessionKey}\u0000${requestAgentId ?? ""}\u0000${CHAT_HISTORY_REQUEST_LIMIT}\u0000${requestModeKey}`;
-  const requests = getChatHistoryPaneRequests(state);
-  const inFlight = requests.inFlightHistory;
+  const inFlight = requests.historyLoad;
   // Live events replace the rendered array while their snapshot is pending;
   // only stable session and connection ownership may start another request.
   if (
-    inFlight?.key === requestKey &&
+    inFlight.phase === "in-flight" &&
+    inFlight.key === requestKey &&
     inFlight.client === client &&
     inFlight.connectionEpoch === connectionEpoch
   ) {
@@ -1531,18 +1585,70 @@ export async function loadChatHistory(
     requestAgentId,
     method,
     deltaCursor,
-  ).finally(() => {
-    if (requests.inFlightHistory?.promise === promise) {
-      requests.inFlightHistory = undefined;
+  ).then((result) => {
+    const current = requests.historyLoad;
+    if (current.phase === "in-flight" && current.promise === promise) {
+      if (result) {
+        requests.historyLoad = {
+          phase: "committed",
+          key: `${sessionKey}\u0000${requestAgentId ?? ""}`,
+        };
+      } else if (
+        state.sessionKey === sessionKey &&
+        (!isUiSelectedGlobalSessionKey(state, sessionKey) ||
+          resolveUiSelectedSessionAgentId(state) === requestAgentId) &&
+        (!state.connected ||
+          current.client !== state.client ||
+          current.connectionEpoch !== state.connectionEpoch)
+      ) {
+        requests.historyLoad = {
+          phase: "pending-connection",
+          sessionKey,
+          requestAgentId,
+          startup,
+        };
+        state.chatLoading = true;
+      } else {
+        requests.historyLoad = { phase: "idle" };
+        state.chatLoading = false;
+      }
+      state.requestUpdate?.();
     }
+    return result;
   });
-  requests.inFlightHistory = {
+  requests.historyLoad = {
+    phase: "in-flight",
     client,
     connectionEpoch,
     key: requestKey,
     promise,
+    sessionKey,
+    requestAgentId,
+    startup,
   };
   return promise;
+}
+
+export function resumePendingChatHistoryLoad(
+  state: ChatState,
+): Promise<ChatHistoryResult | undefined> | undefined {
+  const load = getChatHistoryLoadState(state);
+  if (load.phase === "pending-connection" || (load.phase === "failed" && load.retryable)) {
+    return loadChatHistory(state, { startup: load.startup, deferBranches: true });
+  }
+  return undefined;
+}
+
+export function retryChatHistoryLoad(
+  state: ChatState,
+): Promise<ChatHistoryResult | undefined> | undefined {
+  const load = getChatHistoryLoadState(state);
+  if (load.phase !== "failed") {
+    return undefined;
+  }
+  const retry = loadChatHistory(state, { startup: load.startup });
+  state.requestUpdate?.();
+  return retry;
 }
 
 export async function loadOlderChatHistoryPage(
@@ -1918,14 +2024,23 @@ async function loadChatHistoryUncached(
       requestAgentId,
       previousRunId,
     });
-    if (isMissingOperatorReadScopeError(err)) {
+    const missingReadScope = isMissingOperatorReadScopeError(err);
+    if (missingReadScope) {
       resetChatHistoryProjection(state, requestAgentId);
       state.chatThinkingLevel = null;
       state.chatVerboseLevel = null;
-      setChatError(state, formatMissingOperatorReadScopeMessage("existing chat history"));
-    } else {
-      setChatError(state, formatUiError(err));
     }
+    getChatHistoryPaneRequests(state).historyLoad = {
+      phase: "failed",
+      sessionKey,
+      requestAgentId,
+      startup: method === "chat.startup",
+      message: missingReadScope
+        ? formatMissingOperatorReadScopeMessage("existing chat history")
+        : formatUiError(err),
+      retryable: err instanceof GatewayRequestError && err.retryable,
+    };
+    state.requestUpdate?.();
   } finally {
     if (ownsChatHistoryRequest(state, ownership)) {
       state.chatLoading = false;

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -310,7 +310,9 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     state.hello = snapshot.hello;
     state.selfUser = snapshot.selfUser ?? null;
     state.assistantAgentId = snapshot.assistantAgentId;
-    if (!state.connected) {
+    if (wasConnected && !state.connected) {
+      // Only the connected->disconnected transition may reshape loading state;
+      // repeated disconnected snapshots must stay no-ops for pane ownership.
       state.chatLoading = getChatHistoryLoadState(state).phase === "pending-connection";
     }
     const resumedHistory =

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -21,7 +21,12 @@ import {
   uiSessionEventMatches,
 } from "../../lib/sessions/session-key.ts";
 import { invalidateChatAvatarCache } from "./chat-avatar.ts";
-import { applyChatAgentsList, syncSelectedSessionMessageSubscription } from "./chat-history.ts";
+import {
+  applyChatAgentsList,
+  getChatHistoryLoadState,
+  resumePendingChatHistoryLoad,
+  syncSelectedSessionMessageSubscription,
+} from "./chat-history.ts";
 import { ChatPaneLifecycle } from "./chat-pane-lifecycle.ts";
 import {
   applySelectedSessionProjection,
@@ -304,6 +309,12 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     state.connectionEpoch = this.connectionGeneration;
     state.hello = snapshot.hello;
     state.selfUser = snapshot.selfUser ?? null;
+    state.assistantAgentId = snapshot.assistantAgentId;
+    if (!state.connected) {
+      state.chatLoading = getChatHistoryLoadState(state).phase === "pending-connection";
+    }
+    const resumedHistory =
+      !wasConnected && state.connected ? resumePendingChatHistoryLoad(state) : undefined;
     if (sourceChanged) {
       retireSessionWorkspaceCheckout(state, this.presented);
     }
@@ -356,10 +367,10 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
         startup: true,
         awaitHistory: true,
         deferBranches: true,
+        historyLoad: resumedHistory,
       });
       this.deferSessionHydrationUntilTranscript(state.sessionKey, historyRefresh);
     }
-    state.assistantAgentId = snapshot.assistantAgentId;
     const routeSessionKey = this.sessionKey.trim();
     const catalogRouteKey = parseCatalogSessionKey(routeSessionKey);
     const canonicalRouteSessionKey =
@@ -445,6 +456,7 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
         startup: true,
         awaitHistory: true,
         deferBranches: true,
+        historyLoad: resumedHistory,
       });
       this.deferSessionHydrationUntilTranscript(startupSessionKey, historyRefresh);
       void historyRefresh.finally(() => {

--- a/ui/src/pages/chat/chat-pane-history-issuance.test.ts
+++ b/ui/src/pages/chat/chat-pane-history-issuance.test.ts
@@ -1,0 +1,130 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { getChatHistoryLoadState, loadChatHistory } from "./chat-history.ts";
+import { createTestChatPane } from "./chat-pane.test-support.ts";
+
+function createCanonicalRoutePane(request: ReturnType<typeof vi.fn>) {
+  const client = { request } as unknown as GatewayBrowserClient;
+  const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+  const hello = {
+    snapshot: {
+      sessionDefaults: {
+        defaultAgentId: "main",
+        mainKey: "main",
+        mainSessionKey: "agent:main:main",
+      },
+    },
+  } as unknown as NonNullable<ApplicationContext["gateway"]["snapshot"]["hello"]>;
+  state.hello = hello;
+  state.settings = {
+    sessionKey: state.sessionKey,
+    lastActiveSessionKey: state.sessionKey,
+  } as typeof state.settings;
+  pane.sessionKey = "main";
+  pane.connectedClient = null;
+  pane.active = true;
+  pane.presented = true;
+  const snapshot = {
+    ...pane.context.gateway.snapshot,
+    assistantAgentId: "main",
+    client,
+    hello,
+    phase: "connected" as const,
+  };
+  return { pane, state, snapshot };
+}
+
+function assistantHistory(text: string) {
+  return {
+    messages: [{ role: "assistant", content: [{ type: "text", text }] }],
+  };
+}
+
+describe("chat pane history issuance across Gateway connection transitions", () => {
+  it("issues a disconnected history request once when connection redirects the route", async () => {
+    const request = vi.fn().mockResolvedValue(assistantHistory("Recovered transcript"));
+    const { pane, state, snapshot } = createCanonicalRoutePane(request);
+    state.connected = false;
+
+    await loadChatHistory(state);
+
+    expect(request).not.toHaveBeenCalled();
+    expect(getChatHistoryLoadState(state)).toMatchObject({
+      phase: "pending-connection",
+      sessionKey: "agent:main:current",
+      startup: false,
+    });
+    expect(state.chatLoading).toBe(true);
+
+    pane.applyGatewaySnapshot(snapshot);
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    expect(request).toHaveBeenCalledWith("chat.history", {
+      sessionKey: "agent:main:current",
+      limit: 100,
+    });
+    await vi.waitFor(() =>
+      expect(state.chatMessages).toEqual([
+        { role: "assistant", content: [{ type: "text", text: "Recovered transcript" }] },
+      ]),
+    );
+    expect(getChatHistoryLoadState(state).phase).toBe("committed");
+  });
+
+  it("automatically retries a retryable history failure when the Gateway reconnects", async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new GatewayRequestError({
+          code: "GATEWAY_UNAVAILABLE",
+          message: "Gateway connection interrupted",
+          retryable: true,
+        }),
+      )
+      .mockResolvedValueOnce(assistantHistory("Recovered after reconnect"));
+    const { pane, state, snapshot } = createCanonicalRoutePane(request);
+
+    await loadChatHistory(state, { startup: true });
+
+    expect(getChatHistoryLoadState(state)).toMatchObject({
+      phase: "failed",
+      sessionKey: state.sessionKey,
+      retryable: true,
+      startup: true,
+    });
+    pane.applyGatewaySnapshot({ ...snapshot, phase: "reconnecting", hello: null });
+    pane.applyGatewaySnapshot(snapshot);
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    expect(request).toHaveBeenNthCalledWith(2, "chat.startup", {
+      sessionKey: state.sessionKey,
+      limit: 100,
+    });
+    await vi.waitFor(() =>
+      expect(state.chatMessages).toEqual([
+        { role: "assistant", content: [{ type: "text", text: "Recovered after reconnect" }] },
+      ]),
+    );
+    expect(getChatHistoryLoadState(state).phase).toBe("committed");
+  });
+
+  it("discards a disconnected history request after the selected session changes", async () => {
+    const request = vi.fn();
+    const { pane, state, snapshot } = createCanonicalRoutePane(request);
+    state.connected = false;
+
+    await loadChatHistory(state);
+
+    expect(getChatHistoryLoadState(state).phase).toBe("pending-connection");
+    state.sessionKey = "agent:main:different-session";
+    pane.applyGatewaySnapshot(snapshot);
+
+    expect(request).not.toHaveBeenCalled();
+    expect(getChatHistoryLoadState(state)).toEqual({ phase: "idle" });
+    expect(state.chatLoading).toBe(false);
+  });
+});

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -84,6 +84,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
     );
     const chat = renderChat({
       ...chatProps,
+      historyState: catalog ? undefined : state,
       header: board.face === "dashboard" ? nothing : header,
     });
     // Keep this root stable across board face changes so the guarded board runtime

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -12,7 +12,7 @@ import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { refreshChatAvatar, resolveAgentIdForSession } from "./chat-avatar.ts";
 import { applyRemoteSlashCommandsResult, refreshSlashCommands } from "./chat-commands.ts";
-import { loadChatHistory } from "./chat-history.ts";
+import { loadChatHistory, type ChatHistoryResult } from "./chat-history.ts";
 import { flushChatQueueForEvent } from "./chat-send-actions.ts";
 import {
   flushChatQueueAfterIdleSessionReconciliation,
@@ -28,6 +28,7 @@ import { scheduleChatScroll } from "./scroll.ts";
 
 type ChatRefreshOptions = {
   deferBranches?: boolean;
+  historyLoad?: Promise<ChatHistoryResult | undefined>;
   scheduleScroll?: boolean;
   awaitHistory?: boolean;
   startup?: boolean;
@@ -227,10 +228,12 @@ async function refreshChat(
   const refreshedAgentId = resolveAgentIdForSession(host);
   const requestUpdate = () => host.requestUpdate?.();
   const previousSessionsResult = host.sessionsResult;
-  const historyLoad = loadChatHistory(host, {
-    deferBranches: opts?.deferBranches === true,
-    startup: opts?.startup === true,
-  });
+  const historyLoad =
+    opts?.historyLoad ??
+    loadChatHistory(host, {
+      deferBranches: opts?.deferBranches === true,
+      startup: opts?.startup === true,
+    });
   const historyRefresh = historyLoad.finally(() => {
     if (opts?.scheduleScroll !== false) {
       scheduleChatScroll(host);

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -40,7 +40,9 @@ import {
 import type { ProviderUsageDisplayProps } from "../../lib/provider-quota-summary.ts";
 import type { SessionToolOverrides } from "../../lib/sessions/patch.ts";
 import type { UiSessionDefaultsHost } from "../../lib/sessions/session-key.ts";
+import { getChatHistoryLoadState, retryChatHistoryLoad } from "./chat-history.ts";
 import type { ChatRunStartupStatus } from "./chat-run-startup.ts";
+import type { ChatState } from "./chat-state-contract.ts";
 import {
   type ChatPlacementStartupNoticeProps,
   renderChatViewNotices,
@@ -89,6 +91,7 @@ type ChatReplyTarget = {
 export type ChatProps = ChatTaskSuggestionTrayProps &
   ChatPlacementStartupNoticeProps & {
     transcript: ChatTranscriptController;
+    historyState?: ChatState;
     paneId: string;
     sessionKey: string;
     announceTranscript?: boolean;
@@ -531,6 +534,28 @@ export function renderChat(props: ChatProps) {
         </button>
       `
     : nothing;
+  const historyState = props.historyState;
+  const historyLoadState = historyState ? getChatHistoryLoadState(historyState) : undefined;
+  const historyError =
+    historyState &&
+    historyLoadState?.phase === "failed" &&
+    historyLoadState.sessionKey === props.sessionKey &&
+    props.messages.length === 0 &&
+    props.toolMessages.length === 0 &&
+    props.streamSegments.length === 0 &&
+    !props.stream &&
+    props.queue.length === 0
+      ? html`<div class="chat-history-error" role="alert">
+          <span>${historyLoadState.message}</span>
+          <button
+            class="btn btn--sm"
+            type="button"
+            @click=${() => retryChatHistoryLoad(historyState)}
+          >
+            ${t("common.retry")}
+          </button>
+        </div>`
+      : nothing;
 
   return html`
     <section
@@ -585,7 +610,8 @@ export function renderChat(props: ChatProps) {
                 })}
                 ${renderTranscriptSearch(props.paneId, requestUpdate)}
                 <div class="chat-main__conversation">
-                  ${thread} ${earlierHistoryButton} ${scrollToBottomButton}
+                  ${historyError === nothing ? thread : historyError} ${earlierHistoryButton}
+                  ${scrollToBottomButton}
                   ${props.inlineApproval && props.onApprovalDecision
                     ? html`<div class="chat-inline-approval">
                         ${renderExecApprovalCard({

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -536,26 +536,35 @@ export function renderChat(props: ChatProps) {
     : nothing;
   const historyState = props.historyState;
   const historyLoadState = historyState ? getChatHistoryLoadState(historyState) : undefined;
-  const historyError =
-    historyState &&
+  const historyFailed =
+    historyState !== undefined &&
     historyLoadState?.phase === "failed" &&
-    historyLoadState.sessionKey === props.sessionKey &&
+    historyLoadState.sessionKey === props.sessionKey;
+  const transcriptEmpty =
     props.messages.length === 0 &&
     props.toolMessages.length === 0 &&
     props.streamSegments.length === 0 &&
     !props.stream &&
-    props.queue.length === 0
-      ? html`<div class="chat-history-error" role="alert">
-          <span>${historyLoadState.message}</span>
-          <button
-            class="btn btn--sm"
-            type="button"
-            @click=${() => retryChatHistoryLoad(historyState)}
-          >
-            ${t("common.retry")}
-          </button>
-        </div>`
-      : nothing;
+    props.queue.length === 0;
+  // A failed load with cached content must stay visible without displacing the
+  // transcript; only an empty pane may replace the thread with the error panel.
+  const renderHistoryFailure = (inline: boolean) =>
+    html`<div
+      class="chat-history-error${inline ? " chat-history-error--inline" : ""}"
+      role=${inline ? "status" : "alert"}
+    >
+      <span>${historyLoadState?.phase === "failed" ? historyLoadState.message : ""}</span>
+      <button
+        class="btn btn--sm"
+        type="button"
+        @click=${() => historyState && retryChatHistoryLoad(historyState)}
+      >
+        ${t("common.retry")}
+      </button>
+    </div>`;
+  const historyError = historyFailed && transcriptEmpty ? renderHistoryFailure(false) : nothing;
+  const historyRefreshNotice =
+    historyFailed && !transcriptEmpty ? renderHistoryFailure(true) : nothing;
 
   return html`
     <section
@@ -610,8 +619,8 @@ export function renderChat(props: ChatProps) {
                 })}
                 ${renderTranscriptSearch(props.paneId, requestUpdate)}
                 <div class="chat-main__conversation">
-                  ${historyError === nothing ? thread : historyError} ${earlierHistoryButton}
-                  ${scrollToBottomButton}
+                  ${historyRefreshNotice} ${historyError === nothing ? thread : historyError}
+                  ${earlierHistoryButton} ${scrollToBottomButton}
                   ${props.inlineApproval && props.onApprovalDecision
                     ? html`<div class="chat-inline-approval">
                         ${renderExecApprovalCard({

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -632,6 +632,17 @@ openclaw-chat-page {
   text-align: center;
 }
 
+/* Failed refresh with cached history keeps the transcript and shows a compact
+   banner instead; displacing content would hide the stale-but-useful messages. */
+.chat-history-error--inline {
+  flex: 0 0 auto;
+  flex-direction: row;
+  justify-content: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-block-end: 1px solid var(--border);
+}
+
 .chat-history-available {
   position: absolute;
   z-index: 10;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -619,6 +619,19 @@ openclaw-chat-page {
   font-size: 12px;
 }
 
+.chat-history-error {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 0;
+  padding: 24px;
+  color: var(--muted);
+  text-align: center;
+}
+
 .chat-history-available {
   position: absolute;
   z-index: 10;


### PR DESCRIPTION
Closes #128655
Supersedes #128691

## What Problem This Solves

Two related silent/dead-end failure legs in Control UI chat history loading:

1. **Never-asked leg (worst class — silent no-outcome):** `loadChatHistory` opened with `if (!state.client || !state.connected) return undefined;`. Any caller racing the connection lifecycle (observed live during onboarding's config hot-reload ws bounce; also reachable through the pane context's early-return legs) left the pane in skeletons forever: zero requests on the wire, no error, no recorded fact, nothing to retry. Reproduced live on a fresh gateway (`chat.history` never appeared in the gateway request log while the pane skeletoned across reloads).
2. **Failed leg (dead-end alert, #128655):** when the request was issued and failed, the error fed `setChatError` — a dismiss-only alert with no recovery action.

## Why This Change Was Made

History issuance now lives in one closed state machine recorded at the owner (`ChatHistoryLoadState`: `idle | pending-connection | in-flight | committed | failed`), replacing the implicit combination of `inFlightHistory`, `chatLoading`, and `connected` booleans callers had to keep in sync:

- A load requested while disconnected records `pending-connection` (the skeleton is then honest — a load is owed) and re-arms exactly once at the pane context's `connected` false→true transition; the resumed promise threads through `refreshPageChat` so startup paths cannot double-issue.
- A failure records `failed` with a `retryable` fact. With an empty transcript it renders an accessible `.chat-history-error` panel with a Retry action instead of the dismiss-only alert; retryable failures also auto-resume on reconnect. In-flight loads invalidated by reconnect transfer their intent back to `pending-connection` instead of vanishing.
- Session switches and projection resets return the machine to `idle`; the old `InFlightChatHistoryRequest` parallel state is deleted.

This supersedes #128691 by fixing the failure leg at the request owner rather than adding a panel-status presentation layer, and by also covering the never-asked leg a retry affordance cannot reach (there is no failure to retry when no request was ever made). Credit to @vyctorbrzezowski for the issue, the deterministic repro, and the retry-affordance direction.

## User Impact

Chat panes can no longer skeleton forever after connection races — they either load once connected or show an actionable error. History failures self-heal on reconnect when retryable and otherwise offer Retry in the transcript area.

## Evidence

- Pre-fix behavioral failure (this branch's tests against unpatched `main`): `chat-flow.history-issuance.e2e.test.ts` times out waiting for `.chat-history-error` (the dismiss-only alert reality), and the host regression records zero gateway requests for a disconnected-then-connected pane.
- Post-fix: `node scripts/run-vitest.mjs run ui/src/pages/chat` — 153 files, 3,154 passed / 15 skipped; e2e batch (`chat-flow.history-issuance`, `chat-flow.streaming`, `chat-flow.queue-edit`, `chat-run-lifecycle`) — 25/25 passed; `node scripts/check-changed.mjs` green.
- Mock-gateway harness e2e covers the changed path per the real-behavior-proof gate: failure → visible retryable panel → Retry recovers the transcript; retryable failure → reconnect auto-resumes exactly once.
