### PR TITLE
fix(sandbox): stop exposing environment values in process listings

### DIFF
--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -531,7 +531,7 @@ Paths:
       preserves workspace ownership. Rootless Podman rejects zero-valued users;
       bake packages into the image or use rootful Podman.
     - Sandbox exec does **not** inherit host `process.env`. Use `agents.defaults.sandbox.docker.env` (or a custom image) for skill API keys.
-    - Values in `agents.defaults.sandbox.docker.env` remain visible through container metadata commands such as `docker inspect` or `podman inspect`. Docker and Podman values must be single-line because engine environment files are line-delimited. Use a custom image, mounted secret file, or another secret delivery path if that metadata exposure is not acceptable.
+    - Values in `agents.defaults.sandbox.docker.env` remain visible through container metadata commands such as `docker inspect` or `podman inspect`. Docker and Podman require portable environment names and single-line, non-NUL values because secure engine environment files are line-delimited; config validation and `openclaw doctor` reject invalid entries before sandbox use. Rename invalid keys, use single-line values, or deliver multiline material through a mounted file or custom image; this requires manual remediation because `doctor --fix` cannot safely preserve the original value. SSH and OpenShell backends still support multiline values. Use a custom image, mounted secret file, or another secret delivery path if metadata exposure is not acceptable.
 
   </Accordion>
 </AccordionGroup>

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -531,7 +531,7 @@ Paths:
       preserves workspace ownership. Rootless Podman rejects zero-valued users;
       bake packages into the image or use rootful Podman.
     - Sandbox exec does **not** inherit host `process.env`. Use `agents.defaults.sandbox.docker.env` (or a custom image) for skill API keys.
-    - Values in `agents.defaults.sandbox.docker.env` are passed as explicit container environment variables. Anyone with access to the selected container engine can inspect them with metadata commands such as `docker inspect` or `podman inspect`. Use a custom image, mounted secret file, or another secret delivery path if that metadata exposure is not acceptable.
+    - Values in `agents.defaults.sandbox.docker.env` remain visible through container metadata commands such as `docker inspect` or `podman inspect`. Docker and Podman values must be single-line because engine environment files are line-delimited. Use a custom image, mounted secret file, or another secret delivery path if that metadata exposure is not acceptable.
 
   </Accordion>
 </AccordionGroup>

--- a/extensions/openshell/src/backend.exec-workdir.test.ts
+++ b/extensions/openshell/src/backend.exec-workdir.test.ts
@@ -20,6 +20,7 @@ import { resolveOpenShellPluginConfig } from "./config.js";
 const sdkMocks = vi.hoisted(() => ({
   runSshSandboxCommand: vi.fn(),
   disposeSshSandboxSession: vi.fn(),
+  prepareSshSandboxExec: vi.fn(),
 }));
 
 const cliMocks = vi.hoisted(() => ({
@@ -33,6 +34,7 @@ vi.mock("openclaw/plugin-sdk/sandbox", async (importOriginal) => {
     ...actual,
     runSshSandboxCommand: sdkMocks.runSshSandboxCommand,
     disposeSshSandboxSession: sdkMocks.disposeSshSandboxSession,
+    prepareSshSandboxExec: sdkMocks.prepareSshSandboxExec,
   };
 });
 
@@ -86,6 +88,18 @@ describe("openshell backend exec workdir validation", () => {
       stdout: "",
       stderr: "",
     });
+    sdkMocks.prepareSshSandboxExec.mockImplementation(
+      async (params: { session: { command: string; configPath: string; host: string } }) => ({
+        argv: [
+          params.session.command,
+          "-F",
+          params.session.configPath,
+          params.session.host,
+          "'/bin/sh' '/tmp/openclaw-synthetic-staging/run.sh'",
+        ],
+        cleanup: async () => {},
+      }),
+    );
     sdkMocks.runSshSandboxCommand.mockImplementation(async ({ remoteCommand }) => ({
       stdout: String(remoteCommand).includes("openclaw-validate-workdir")
         ? Buffer.from("/workspace\n")

--- a/extensions/openshell/src/backend.remote-seed.test.ts
+++ b/extensions/openshell/src/backend.remote-seed.test.ts
@@ -21,6 +21,7 @@ import { resolveOpenShellPluginConfig } from "./config.js";
 const sdkMocks = vi.hoisted(() => ({
   runSshSandboxCommand: vi.fn(),
   disposeSshSandboxSession: vi.fn(),
+  prepareSshSandboxExec: vi.fn(),
 }));
 
 const cliMocks = vi.hoisted(() => ({
@@ -34,6 +35,7 @@ vi.mock("openclaw/plugin-sdk/sandbox", async (importOriginal) => {
     ...actual,
     runSshSandboxCommand: sdkMocks.runSshSandboxCommand,
     disposeSshSandboxSession: sdkMocks.disposeSshSandboxSession,
+    prepareSshSandboxExec: sdkMocks.prepareSshSandboxExec,
   };
 });
 
@@ -89,6 +91,10 @@ async function createAdoptedRemoteBackend(params: { probeStdout: string }) {
   // `sandbox get` succeeds: the sandbox was created by a previous gateway
   // process that died before the first exec could run the one-time seed.
   cliMocks.runOpenShellCli.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+  sdkMocks.prepareSshSandboxExec.mockResolvedValue({
+    argv: ["ssh", "openshell-test"],
+    cleanup: vi.fn(),
+  });
   sdkMocks.runSshSandboxCommand.mockImplementation(async ({ remoteCommand }) => ({
     stdout: String(remoteCommand).includes("ls -A")
       ? Buffer.from(params.probeStdout)

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -46,7 +46,7 @@ type CreateOpenShellSandboxBackendFactoryParams = {
 
 type PendingExec = {
   sshSession: SshSandboxSession;
-  cleanup: (status: "completed" | "failed") => Promise<void>;
+  cleanup: () => Promise<void>;
 };
 
 const MATERIALIZED_SKILLS_REMOTE_PARTS = [".openclaw", "sandbox-skills"] as const;
@@ -337,8 +337,8 @@ class OpenShellSandboxBackendImpl {
           finalizeToken: pending.token,
         };
       },
-      finalizeExec: async ({ token, status }) => {
-        await this.finalizeExec(token as PendingExec | undefined, status);
+      finalizeExec: async ({ token }) => {
+        await this.finalizeExec(token as PendingExec | undefined);
       },
       runShellCommand: async (command) => await this.runRemoteShellScript(command),
       createFsBridge: ({ sandbox }) =>
@@ -478,10 +478,7 @@ class OpenShellSandboxBackendImpl {
     }
   }
 
-  async finalizeExec(
-    token: PendingExec | undefined,
-    status: "completed" | "failed",
-  ): Promise<void> {
+  async finalizeExec(token: PendingExec | undefined): Promise<void> {
     try {
       if (this.params.execContext.config.mode === "mirror") {
         await this.syncWorkspaceFromRemote();
@@ -489,7 +486,7 @@ class OpenShellSandboxBackendImpl {
     } finally {
       if (token?.sshSession) {
         try {
-          await token.cleanup(status);
+          await token.cleanup();
         } finally {
           await disposeSshSandboxSession(token.sshSession);
         }

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -14,6 +14,7 @@ import type {
 import {
   createRemoteShellSandboxFsBridge,
   disposeSshSandboxSession,
+  prepareSshSandboxExec,
   resolvePreferredOpenClawTmpDir,
   runSshSandboxCommand,
   sanitizeEnvVars,
@@ -45,6 +46,7 @@ type CreateOpenShellSandboxBackendFactoryParams = {
 
 type PendingExec = {
   sshSession: SshSandboxSession;
+  cleanup: (status: "completed" | "failed") => Promise<void>;
 };
 
 const MATERIALIZED_SKILLS_REMOTE_PARTS = [".openclaw", "sandbox-skills"] as const;
@@ -335,8 +337,8 @@ class OpenShellSandboxBackendImpl {
           finalizeToken: pending.token,
         };
       },
-      finalizeExec: async ({ token }) => {
-        await this.finalizeExec(token as PendingExec | undefined);
+      finalizeExec: async ({ token, status }) => {
+        await this.finalizeExec(token as PendingExec | undefined, status);
       },
       runShellCommand: async (command) => await this.runRemoteShellScript(command),
       createFsBridge: ({ sandbox }) =>
@@ -374,25 +376,27 @@ class OpenShellSandboxBackendImpl {
     const remoteCommand = buildValidatedExecRemoteCommand({
       command: params.command,
       workdir: remoteWorkdir,
-      env: params.env,
+      env: {},
     });
     await (preparedWorkspace ?? this.prepareRemoteWorkspaceForExec());
     const sshSession = await createOpenShellSshSession({
       context: this.params.execContext,
     });
-    return {
-      argv: [
-        "ssh",
-        "-F",
-        sshSession.configPath,
-        ...(params.usePty
-          ? ["-tt", "-o", "RequestTTY=force", "-o", "SetEnv=TERM=xterm-256color"]
-          : ["-T", "-o", "RequestTTY=no"]),
-        sshSession.host,
+    try {
+      const prepared = await prepareSshSandboxExec({
+        session: sshSession,
         remoteCommand,
-      ],
-      token: { sshSession },
-    };
+        env: params.env,
+        tty: params.usePty,
+      });
+      return {
+        argv: prepared.argv,
+        token: { sshSession, cleanup: prepared.cleanup },
+      };
+    } catch (error) {
+      await disposeSshSandboxSession(sshSession);
+      throw error;
+    }
   }
 
   async validateWorkdir(workdir: string): Promise<string | null> {
@@ -474,14 +478,21 @@ class OpenShellSandboxBackendImpl {
     }
   }
 
-  async finalizeExec(token?: PendingExec): Promise<void> {
+  async finalizeExec(
+    token: PendingExec | undefined,
+    status: "completed" | "failed",
+  ): Promise<void> {
     try {
       if (this.params.execContext.config.mode === "mirror") {
         await this.syncWorkspaceFromRemote();
       }
     } finally {
       if (token?.sshSession) {
-        await disposeSshSandboxSession(token.sshSession);
+        try {
+          await token.cleanup(status);
+        } finally {
+          await disposeSshSandboxSession(token.sshSession);
+        }
       }
     }
   }

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -735,6 +735,11 @@ describe("openshell backend manager", () => {
     async (status) => {
       const sentinel = "synthetic-openshell-env-value";
       cliMocks.runOpenShellCli.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+      sandboxMocks.runSshSandboxCommand.mockResolvedValueOnce({
+        stdout: Buffer.from("1\n"),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      });
       const backend = await createOpenShellBackendFixture({
         workspaceDir: "/tmp/openclaw-synthetic-workspace",
         mode: "remote",
@@ -758,6 +763,7 @@ describe("openshell backend manager", () => {
       expect(execSpec.argv.join(" ")).not.toContain("SetEnv");
       expect(execSpec.stdinMode).toBe("pipe-open");
 
+      sandboxMocks.disposeSshSandboxSession.mockClear();
       await backend.finalizeExec?.({
         status,
         exitCode: status === "completed" ? 0 : 1,
@@ -780,6 +786,11 @@ describe("openshell backend manager", () => {
 
   it("disposes the OpenShell SSH session when secure exec staging fails", async () => {
     cliMocks.runOpenShellCli.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    sandboxMocks.runSshSandboxCommand.mockResolvedValueOnce({
+      stdout: Buffer.from("1\n"),
+      stderr: Buffer.alloc(0),
+      code: 0,
+    });
     sandboxMocks.prepareSshSandboxExec.mockRejectedValueOnce(
       new Error("synthetic staging failure"),
     );
@@ -796,7 +807,7 @@ describe("openshell backend manager", () => {
       }),
     ).rejects.toThrow("synthetic staging failure");
 
-    expect(sandboxMocks.disposeSshSandboxSession).toHaveBeenCalledOnce();
+    expect(sandboxMocks.disposeSshSandboxSession).toHaveBeenCalledTimes(2);
   });
 
   it("preserves a local sandbox skills shadow when mirror sync crosses filesystems", async () => {

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -46,6 +46,8 @@ const cliMocks = vi.hoisted(() => ({
 const sandboxMocks = vi.hoisted(() => ({
   runSshSandboxCommand: vi.fn(),
   disposeSshSandboxSession: vi.fn(),
+  prepareSshSandboxExec: vi.fn(),
+  cleanupPreparedExec: vi.fn(),
   remoteRoot: "",
   remoteAgentRoot: "",
 }));
@@ -61,6 +63,7 @@ async function installOpenShellBackendMocks() {
     return {
       ...actual,
       disposeSshSandboxSession: sandboxMocks.disposeSshSandboxSession,
+      prepareSshSandboxExec: sandboxMocks.prepareSshSandboxExec,
       runSshSandboxCommand: sandboxMocks.runSshSandboxCommand,
     };
   });
@@ -89,6 +92,23 @@ function resetOpenShellBackendMocks() {
     configPath: "/tmp/openclaw-openshell-test-ssh-config",
     host: "openshell-test",
   });
+  sandboxMocks.cleanupPreparedExec.mockResolvedValue(undefined);
+  sandboxMocks.prepareSshSandboxExec.mockImplementation(
+    async (params: {
+      session: { command: string; configPath: string; host: string };
+      tty?: boolean;
+    }) => ({
+      argv: [
+        params.session.command,
+        "-F",
+        params.session.configPath,
+        ...(params.tty ? ["-tt", "-o", "RequestTTY=force"] : ["-T", "-o", "RequestTTY=no"]),
+        params.session.host,
+        "'/bin/sh' '/tmp/openclaw-synthetic-staging/run.sh'",
+      ],
+      cleanup: sandboxMocks.cleanupPreparedExec,
+    }),
+  );
   sandboxMocks.runSshSandboxCommand.mockImplementation(
     async (params: { remoteCommand: string; stdin?: Buffer | string; allowFailure?: boolean }) => {
       const remoteCommand = params.remoteCommand
@@ -135,16 +155,13 @@ describe("openshell cli helpers", () => {
     expect(shellEscape(`a'b`)).toBe(`'a'"'"'b'`);
   });
 
-  it("wraps exec commands with env and workdir", () => {
+  it("wraps exec commands with workdir when no environment is supplied", () => {
     const command = buildExecRemoteCommand({
       command: "pwd && printenv TOKEN",
       workdir: "/sandbox/project",
-      env: {
-        TOKEN: "abc 123",
-      },
+      env: {},
     });
-    expect(command).toContain(`'env'`);
-    expect(command).toContain(`'TOKEN=abc 123'`);
+    expect(command).not.toContain(`'env'`);
     expect(command).toContain(`'cd '"'"'/sandbox/project'"'"' && pwd && printenv TOKEN'`);
   });
 
@@ -711,6 +728,75 @@ describe("openshell backend manager", () => {
       }),
     ).rejects.toThrow(/unresolved placeholder token <name>/);
     expect(cliMocks.runOpenShellCli).not.toHaveBeenCalled();
+  });
+
+  it.each(["completed", "failed"] as const)(
+    "stages exec environment outside SSH argv and finalizes %s before session disposal",
+    async (status) => {
+      const sentinel = "synthetic-openshell-env-value";
+      cliMocks.runOpenShellCli.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+      const backend = await createOpenShellBackendFixture({
+        workspaceDir: "/tmp/openclaw-synthetic-workspace",
+        mode: "remote",
+      });
+
+      const execSpec = await backend.buildExecSpec({
+        command: "printenv SYNTHETIC_VALUE",
+        workdir: "/sandbox",
+        env: { SYNTHETIC_VALUE: sentinel },
+        usePty: true,
+      });
+
+      expect(sandboxMocks.prepareSshSandboxExec).toHaveBeenCalledWith({
+        session: expect.objectContaining({ host: "openshell-test" }),
+        remoteCommand: expect.stringContaining("printenv SYNTHETIC_VALUE"),
+        env: { SYNTHETIC_VALUE: sentinel },
+        tty: true,
+      });
+      expect(execSpec.argv.join(" ")).not.toContain(sentinel);
+      expect(execSpec.argv).toContain("-tt");
+      expect(execSpec.argv.join(" ")).not.toContain("SetEnv");
+      expect(execSpec.stdinMode).toBe("pipe-open");
+
+      await backend.finalizeExec?.({
+        status,
+        exitCode: status === "completed" ? 0 : 1,
+        timedOut: false,
+        token: execSpec.finalizeToken,
+      });
+
+      expect(sandboxMocks.cleanupPreparedExec).toHaveBeenCalledExactlyOnceWith(status);
+      expect(sandboxMocks.disposeSshSandboxSession).toHaveBeenCalledWith(
+        expect.objectContaining({ host: "openshell-test" }),
+      );
+      expect(sandboxMocks.cleanupPreparedExec.mock.invocationCallOrder[0]).toBeLessThan(
+        expectDefined(
+          sandboxMocks.disposeSshSandboxSession.mock.invocationCallOrder[0],
+          "OpenShell SSH session disposal invocation",
+        ),
+      );
+    },
+  );
+
+  it("disposes the OpenShell SSH session when secure exec staging fails", async () => {
+    cliMocks.runOpenShellCli.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    sandboxMocks.prepareSshSandboxExec.mockRejectedValueOnce(
+      new Error("synthetic staging failure"),
+    );
+    const backend = await createOpenShellBackendFixture({
+      workspaceDir: "/tmp/openclaw-synthetic-workspace",
+      mode: "remote",
+    });
+
+    await expect(
+      backend.buildExecSpec({
+        command: "true",
+        env: { SYNTHETIC_VALUE: "synthetic-openshell-env-value" },
+        usePty: false,
+      }),
+    ).rejects.toThrow("synthetic staging failure");
+
+    expect(sandboxMocks.disposeSshSandboxSession).toHaveBeenCalledOnce();
   });
 
   it("preserves a local sandbox skills shadow when mirror sync crosses filesystems", async () => {

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -765,7 +765,7 @@ describe("openshell backend manager", () => {
         token: execSpec.finalizeToken,
       });
 
-      expect(sandboxMocks.cleanupPreparedExec).toHaveBeenCalledExactlyOnceWith(status);
+      expect(sandboxMocks.cleanupPreparedExec).toHaveBeenCalledOnce();
       expect(sandboxMocks.disposeSshSandboxSession).toHaveBeenCalledWith(
         expect.objectContaining({ host: "openshell-test" }),
       );

--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -454,6 +454,11 @@ describe("exec foreground failures", () => {
         containerName: "sandbox-workdir-test",
         workspaceDir,
         containerWorkdir: "/workspace",
+        buildExecSpec: async ({ command, workdir }) => ({
+          argv: ["docker", "exec", "-w", workdir ?? "/workspace", "sandbox-workdir-test", command],
+          env: {},
+          stdinMode: "pipe-closed",
+        }),
       },
     });
 

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -228,6 +228,33 @@ describe("sandbox exec preparation failures", () => {
     expect(supervisorMock.spawn).not.toHaveBeenCalled();
   });
 
+  it("rejects a sandbox without a backend-owned exec specification", async () => {
+    supervisorMock.spawn.mockImplementationOnce(async (input: SpawnInput) =>
+      runtimeManagedRun(input),
+    );
+
+    await expect(
+      runExecProcess({
+        command: "sandbox-command",
+        workdir: "/tmp",
+        env: { EXAMPLE_VALUE: "synthetic-runtime-sandbox-value" },
+        sandbox: {
+          containerName: "sandbox",
+          workspaceDir: "/workspace",
+          containerWorkdir: "/workspace",
+        },
+        usePty: false,
+        warnings: [],
+        maxOutput: 1000,
+        pendingMaxOutput: 1000,
+        notifyOnExit: false,
+        timeoutSec: null,
+      }),
+    ).rejects.toThrow("sandbox backend does not provide buildExecSpec");
+
+    expect(supervisorMock.spawn).not.toHaveBeenCalled();
+  });
+
   it("settles the registered session once when buildExecSpec rejects", async () => {
     const registry = await import("./bash-process-registry.js");
     const sessionSlugs = await import("./session-slug.js");

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -52,12 +52,7 @@ import {
 } from "./bash-tools.exec-output.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
-import {
-  buildDockerExecArgs,
-  chunkString,
-  clampWithDefault,
-  readEnvInt,
-} from "./bash-tools.shared.js";
+import { chunkString, clampWithDefault, readEnvInt } from "./bash-tools.shared.js";
 import { buildCursorPositionResponse, stripDsrRequests } from "./pty-dsr.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { createSessionSlug } from "./session-slug.js";
@@ -851,32 +846,24 @@ export async function runExecProcess(opts: {
 
   const prepareSpawnSpec = async () => {
     if (opts.sandbox) {
-      const backendExecSpec = await opts.sandbox.buildExecSpec?.({
+      if (!opts.sandbox.buildExecSpec) {
+        throw new Error("sandbox backend does not provide buildExecSpec");
+      }
+      const backendExecSpec = await opts.sandbox.buildExecSpec({
         command: execCommand,
         workdir: opts.containerWorkdir ?? opts.sandbox.containerWorkdir,
         env: shellRuntimeEnv,
         usePty: opts.usePty,
       });
-      sandboxFinalizeToken = backendExecSpec?.finalizeToken;
+      sandboxFinalizeToken = backendExecSpec.finalizeToken;
       // Cleanup ownership transfers only after buildExecSpec resolves: moving this earlier can
       // double-finalize backend failures, while removing it leaks the registered exec session.
       sandboxPrepared = true;
       return {
         mode: "child" as const,
-        argv: backendExecSpec?.argv ?? [
-          "docker",
-          ...buildDockerExecArgs({
-            containerName: opts.sandbox.containerName,
-            command: execCommand,
-            workdir: opts.containerWorkdir ?? opts.sandbox.containerWorkdir,
-            env: shellRuntimeEnv,
-            tty: opts.usePty,
-          }),
-        ],
-        env: backendExecSpec?.env ?? process.env,
-        stdinMode:
-          backendExecSpec?.stdinMode ??
-          (opts.usePty ? ("pipe-open" as const) : ("pipe-closed" as const)),
+        argv: backendExecSpec.argv,
+        env: backendExecSpec.env,
+        stdinMode: backendExecSpec.stdinMode,
       };
     }
     const { shell, args: shellArgs } = getShellConfig();

--- a/src/agents/bash-tools.shared.test.ts
+++ b/src/agents/bash-tools.shared.test.ts
@@ -3,78 +3,7 @@
  * Covers strict env parsing and compact session labels.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  buildDockerExecArgs,
-  chunkString,
-  deriveSessionName,
-  readEnvInt,
-} from "./bash-tools.shared.js";
-
-describe("buildDockerExecArgs", () => {
-  it("prepends custom PATH after login shell sourcing to preserve both custom and system tools", () => {
-    const args = buildDockerExecArgs({
-      containerName: "test-container",
-      command: "echo hello",
-      env: { PATH: "/custom/bin:/usr/local/bin:/usr/bin", HOME: "/home/user" },
-      tty: false,
-    });
-
-    const commandArg = args.at(-1);
-    expect(args).toContain("OPENCLAW_PREPEND_PATH=/custom/bin:/usr/local/bin:/usr/bin");
-    expect(commandArg).toBe(
-      'export PATH="${OPENCLAW_PREPEND_PATH}:$PATH"; unset OPENCLAW_PREPEND_PATH; echo hello',
-    );
-  });
-
-  it("does not interpolate PATH into the shell command", () => {
-    const injectedPath = "$(touch /tmp/openclaw-path-injection)";
-    const args = buildDockerExecArgs({
-      containerName: "test-container",
-      command: "echo hello",
-      env: { PATH: injectedPath, HOME: "/home/user" },
-      tty: false,
-    });
-
-    expect(args).toContain(`OPENCLAW_PREPEND_PATH=${injectedPath}`);
-    expect(args.at(-1)).not.toContain(injectedPath);
-    expect(args.at(-1)).toContain("OPENCLAW_PREPEND_PATH");
-  });
-
-  it("does not add PATH export when PATH is not in env", () => {
-    const args = buildDockerExecArgs({
-      containerName: "test-container",
-      command: "echo hello",
-      env: { HOME: "/home/user" },
-      tty: false,
-    });
-
-    expect(args.at(-1)).toBe("echo hello");
-    expect(args.at(-1)).not.toContain("export PATH");
-  });
-
-  it.each([
-    {
-      name: "includes workdir flags",
-      input: { command: "pwd", workdir: "/workspace", tty: false },
-      expected: ["-w", "/workspace"],
-    },
-    {
-      name: "uses a login shell",
-      input: { command: "echo test", tty: false },
-      expected: ["/bin/sh", "-lc"],
-    },
-    { name: "includes the tty flag", input: { command: "bash", tty: true }, expected: ["-t"] },
-  ])("$name", ({ input, expected }) => {
-    const args = buildDockerExecArgs({
-      containerName: "test-container",
-      env: { HOME: "/home/user" },
-      ...input,
-    });
-    for (const value of expected) {
-      expect(args).toContain(value);
-    }
-  });
-});
+import { chunkString, deriveSessionName, readEnvInt } from "./bash-tools.shared.js";
 
 describe("readEnvInt", () => {
   afterEach(() => {

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -1,7 +1,6 @@
 /**
  * Shared helpers for bash exec/process tools.
- * Owns Docker exec argument construction, output slicing, environment
- * coercion, and compact session labels.
+ * Owns output slicing, environment coercion, and compact session labels.
  */
 import { parseStrictInteger } from "@openclaw/normalization-core/number-coercion";
 import { sliceUtf16Safe } from "../utils.js";
@@ -76,47 +75,6 @@ export function coerceEnv(env?: NodeJS.ProcessEnv | Record<string, string>) {
     }
   }
   return record;
-}
-
-/** Builds `docker exec` arguments while preserving container PATH behavior. */
-export function buildDockerExecArgs(params: {
-  containerName: string;
-  command: string;
-  workdir?: string;
-  env: Record<string, string>;
-  tty: boolean;
-}) {
-  const args = ["exec", "-i"];
-  if (params.tty) {
-    args.push("-t");
-  }
-  if (params.workdir) {
-    args.push("-w", params.workdir);
-  }
-  for (const [key, value] of Object.entries(params.env)) {
-    // Skip PATH — passing a host PATH (e.g. Windows paths) via -e poisons
-    // Docker's executable lookup, causing "sh: not found" on Windows hosts.
-    // PATH is handled separately via OPENCLAW_PREPEND_PATH below.
-    if (key === "PATH") {
-      continue;
-    }
-    args.push("-e", `${key}=${value}`);
-  }
-  const hasCustomPath = typeof params.env.PATH === "string" && params.env.PATH.length > 0;
-  if (hasCustomPath) {
-    // Avoid interpolating PATH into the shell command; pass it via env instead.
-    args.push("-e", `OPENCLAW_PREPEND_PATH=${params.env.PATH}`);
-  }
-  // Login shell (-l) sources /etc/profile which resets PATH to a minimal set,
-  // overriding both Docker ENV and -e PATH=... environment variables.
-  // Prepend custom PATH after profile sourcing to ensure custom tools are accessible
-  // while preserving system paths that /etc/profile may have added.
-  const pathExport = hasCustomPath
-    ? 'export PATH="${OPENCLAW_PREPEND_PATH}:$PATH"; unset OPENCLAW_PREPEND_PATH; '
-    : "";
-  // Use absolute path for sh to avoid dependency on PATH resolution during exec.
-  args.push(params.containerName, "/bin/sh", "-lc", `${pathExport}${params.command}`);
-  return args;
 }
 
 /**

--- a/src/agents/sandbox-create-args.test.ts
+++ b/src/agents/sandbox-create-args.test.ts
@@ -89,7 +89,7 @@ describe("buildSandboxCreateArgs", () => {
       extraHosts: ["internal.service:10.0.0.5"],
     };
 
-    const args = buildSandboxCreateArgs({
+    const { argv: args, env } = buildSandboxCreateArgs({
       name: "openclaw-sbx-test",
       cfg,
       scopeKey: "main",
@@ -122,7 +122,8 @@ describe("buildSandboxCreateArgs", () => {
     expectFlagValues(args, "--memory", ["512m"]);
     expectFlagValues(args, "--memory-swap", ["1024"]);
     expectFlagValues(args, "--cpus", ["1.5"]);
-    expectFlagValues(args, "--env", ["LANG=C.UTF-8", `OPENCLAW_CLI=${OPENCLAW_CLI_ENV_VALUE}`]);
+    expect(args).not.toContain("--env");
+    expect(env).toEqual({ LANG: "C.UTF-8", OPENCLAW_CLI: OPENCLAW_CLI_ENV_VALUE });
     expectFlagValues(args, "--ulimit", ["nofile=1024:2048", "nproc=128", "core=0"]);
   });
 
@@ -144,7 +145,7 @@ describe("buildSandboxCreateArgs", () => {
       },
     });
 
-    const args = buildSandboxCreateArgs({
+    const { argv: args } = buildSandboxCreateArgs({
       name: "openclaw-sbx-non-finite-limits",
       cfg,
       scopeKey: "main",
@@ -174,25 +175,18 @@ describe("buildSandboxCreateArgs", () => {
       },
     });
 
-    const args = buildSandboxCreateArgs({
+    const { argv: args, env } = buildSandboxCreateArgs({
       name: "openclaw-sbx-marker",
       cfg,
       scopeKey: "main",
       createdAtMs: 1700000000000,
     });
 
-    expectFlagValues(args, "--env", [
-      "ANTHROPIC_ADMIN_KEY=dummy-anthropic-admin-key",
-      "GEMINI_API_KEY=dummy-gemini-api-key",
-      "GOOGLE_CLIENT_ID=dummy-google-client-id",
-      "GOOGLE_CLIENT_SECRET=dummy-google-client-secret",
-      "HIMALAYA_CONFIG=dummy-himalaya-config",
-      "HIMALAYA_PASSWORD=dummy-himalaya-password",
-      "OURA_CLIENT_ID=dummy-oura-client-id",
-      "OURA_CLIENT_SECRET=dummy-oura-client-secret",
-      "RESEND_API_KEY=dummy-resend-api-key",
-      `OPENCLAW_CLI=${OPENCLAW_CLI_ENV_VALUE}`,
-    ]);
+    expect(args).not.toContain("--env");
+    expect(env).toEqual({
+      ...cfg.env,
+      OPENCLAW_CLI: OPENCLAW_CLI_ENV_VALUE,
+    });
   });
 
   it("emits Docker GPU passthrough as a separate argument", () => {
@@ -200,7 +194,7 @@ describe("buildSandboxCreateArgs", () => {
       gpus: "device=GPU-123",
     });
 
-    const args = buildSandboxCreateArgs({
+    const { argv: args } = buildSandboxCreateArgs({
       name: "openclaw-sbx-gpu",
       cfg,
       scopeKey: "main",
@@ -222,7 +216,7 @@ describe("buildSandboxCreateArgs", () => {
       binds: ["/home/user/source:/source:rw", "/var/data/myapp:/data:ro"],
     };
 
-    const args = buildSandboxCreateArgs({
+    const { argv: args } = buildSandboxCreateArgs({
       name: "openclaw-sbx-binds",
       cfg,
       scopeKey: "main",
@@ -302,7 +296,7 @@ describe("buildSandboxCreateArgs", () => {
       binds: [],
     };
 
-    const args = buildSandboxCreateArgs({
+    const { argv: args } = buildSandboxCreateArgs({
       name: "openclaw-sbx-no-binds",
       cfg,
       scopeKey: "main",
@@ -337,7 +331,7 @@ describe("buildSandboxCreateArgs", () => {
 
   it("allows bind sources outside runtime allowlist with explicit override", () => {
     const cfg = createSandboxConfig({}, ["/opt/external:/data:rw"]);
-    const args = buildSandboxCreateArgs({
+    const { argv: args } = buildSandboxCreateArgs({
       name: "openclaw-sbx-outside-roots-override",
       cfg,
       scopeKey: "main",
@@ -355,7 +349,7 @@ describe("buildSandboxCreateArgs", () => {
 
   it("allows reserved /workspace target bind mounts with explicit dangerous override", () => {
     const cfg = createSandboxConfig({}, ["/tmp/override:/workspace:rw"]);
-    const args = buildSandboxCreateArgs({
+    const { argv: args } = buildSandboxCreateArgs({
       name: "openclaw-sbx-reserved-target-override",
       cfg,
       scopeKey: "main",
@@ -370,7 +364,7 @@ describe("buildSandboxCreateArgs", () => {
       network: "container:peer",
       dangerouslyAllowContainerNamespaceJoin: true,
     });
-    const args = buildSandboxCreateArgs({
+    const { argv: args } = buildSandboxCreateArgs({
       name: "openclaw-sbx-container-network-override",
       cfg,
       scopeKey: "main",
@@ -381,7 +375,7 @@ describe("buildSandboxCreateArgs", () => {
 
   it("passes one --init flag so Docker reaps orphaned processes", () => {
     const cfg = createSandboxConfig();
-    const args = buildSandboxCreateArgs({
+    const { argv: args } = buildSandboxCreateArgs({
       name: "openclaw-sbx-init",
       cfg,
       scopeKey: "main",

--- a/src/agents/sandbox.ts
+++ b/src/agents/sandbox.ts
@@ -41,6 +41,7 @@ export {
   createSshSandboxSessionFromConfigText,
   createSshSandboxSessionFromSettings,
   disposeSshSandboxSession,
+  prepareSshSandboxExec,
   runSshSandboxCommand,
   shellEscape,
   uploadDirectoryToSshTarget,

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -22,6 +22,7 @@ import { SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
 
 let BROWSER_BRIDGES: Map<string, unknown>;
 let ensureSandboxBrowser: typeof import("./browser.js").ensureSandboxBrowser;
+let capturedDockerCreateEnvEntries: string[] | undefined;
 
 const dockerMocks = vi.hoisted(() => ({
   dockerContainerState: vi.fn(),
@@ -210,6 +211,18 @@ function requireDockerCreateArgs(): string[] {
   return createArgs;
 }
 
+function snapshotDockerCreateEnvEntries(args: string[]): string[] | undefined {
+  const envFile = collectDockerFlagValues(args, "--env-file")[0];
+  return envFile ? readFileSync(envFile, "utf8").split("\n").filter(Boolean) : undefined;
+}
+
+function requireDockerCreateEnvEntries(): string[] {
+  if (!capturedDockerCreateEnvEntries) {
+    throw new Error("expected the docker create environment file to exist during create");
+  }
+  return capturedDockerCreateEnvEntries;
+}
+
 function requireValue<T>(value: T | null | undefined, label: string): T {
   if (value === null || value === undefined) {
     throw new Error(`expected ${label}`);
@@ -247,11 +260,15 @@ describe("ensureSandboxBrowser create args", () => {
     bridgeMocks.startBrowserBridgeServer.mockClear();
     bridgeMocks.stopBrowserBridgeServer.mockClear();
     runtimeMocks.log.mockClear();
+    capturedDockerCreateEnvEntries = undefined;
 
     dockerMocks.dockerContainerState.mockResolvedValue({ exists: false, running: false });
     dockerMocks.execDocker.mockImplementation(async (args: string[]) => {
       if (args[0] === "image" && args[1] === "inspect") {
         return { stdout: `${SANDBOX_BROWSER_IMAGE_CONTRACT_EPOCH}\n`, stderr: "", code: 0 };
+      }
+      if (args[0] === "create") {
+        capturedDockerCreateEnvEntries = snapshotDockerCreateEnvEntries(args);
       }
       return { stdout: "", stderr: "", code: 0 };
     });
@@ -316,25 +333,45 @@ describe("ensureSandboxBrowser create args", () => {
     expect(label).toBe(SANDBOX_BROWSER_IMAGE_CONTRACT_EPOCH);
   });
 
-  it("publishes noVNC on loopback and injects noVNC password env", async () => {
+  it("delivers configured browser and generated CDP/noVNC environment without exposing values in Docker argv", async () => {
     // noVNC password stays in the container environment; external access uses a
     // short-lived observer token so URLs do not carry the password.
+    const configuredSentinel = "synthetic-browser-transport-value";
+    const cfg = buildConfig(true);
+    cfg.docker.env = { ...cfg.docker.env, BROWSER_TRANSPORT_SENTINEL: configuredSentinel };
     const result = await ensureTestSandboxBrowser({
       scopeKey: "session:test",
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
-      cfg: buildConfig(true),
+      cfg,
     });
 
     const createArgs = requireDockerCreateArgs();
 
+    expect(createArgs.some((arg) => arg.includes(configuredSentinel))).toBe(false);
     expect(createArgs).toContain("127.0.0.1::6080");
-    const envEntries = collectDockerFlagValues(createArgs, "-e");
+    expect(collectDockerFlagValues(createArgs, "--env-file")).toHaveLength(1);
+    expect(createArgs).not.toContain("-e");
+    expect(createArgs).not.toContain("--env");
+    const envEntries = requireDockerCreateEnvEntries();
+    expect(envEntries).toContain(`BROWSER_TRANSPORT_SENTINEL=${configuredSentinel}`);
     expect(envEntries).toContain("OPENCLAW_BROWSER_NO_SANDBOX=1");
     const passwordEntry = envEntries.find((entry) =>
       entry.startsWith("OPENCLAW_BROWSER_NOVNC_PASSWORD="),
     );
     expect(passwordEntry).toMatch(/^OPENCLAW_BROWSER_NOVNC_PASSWORD=[A-Za-z0-9]{8}$/);
+    const authEntry = envEntries.find((entry) =>
+      entry.startsWith("OPENCLAW_BROWSER_CDP_AUTH_TOKEN="),
+    );
+    expect(authEntry).toMatch(/^OPENCLAW_BROWSER_CDP_AUTH_TOKEN=[0-9a-f]{48}$/);
+    const noVncPassword = requireValue(passwordEntry, "noVNC password env").slice(
+      "OPENCLAW_BROWSER_NOVNC_PASSWORD=".length,
+    );
+    const cdpAuthToken = requireValue(authEntry, "CDP auth env").slice(
+      "OPENCLAW_BROWSER_CDP_AUTH_TOKEN=".length,
+    );
+    expect(createArgs.some((arg) => arg.includes(noVncPassword))).toBe(false);
+    expect(createArgs.some((arg) => arg.includes(cdpAuthToken))).toBe(false);
     expect(result?.noVncUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/sandbox\/novnc\?token=/);
     expect(result?.noVncUrl).not.toContain("password=");
   });
@@ -373,7 +410,11 @@ describe("ensureSandboxBrowser create args", () => {
           throw new Error("docker name conflict");
         }
         created = true;
-        cdpAuthToken = collectDockerFlagValues(args, "-e")
+        const envEntries = requireValue(
+          snapshotDockerCreateEnvEntries(args),
+          "docker create environment file",
+        );
+        cdpAuthToken = envEntries
           .find((entry) => entry.startsWith("OPENCLAW_BROWSER_CDP_AUTH_TOKEN="))
           ?.slice("OPENCLAW_BROWSER_CDP_AUTH_TOKEN=".length);
         configHash = collectDockerFlagValues(args, "--label")
@@ -494,8 +535,7 @@ describe("ensureSandboxBrowser create args", () => {
       cfg: buildConfig(false),
     });
 
-    const createArgs = findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create");
-    const envEntries = collectDockerFlagValues(createArgs ?? [], "-e");
+    const envEntries = requireDockerCreateEnvEntries();
     expect(
       envEntries.filter((entry) => entry.startsWith("OPENCLAW_BROWSER_NOVNC_PASSWORD=")),
     ).toStrictEqual([]);
@@ -564,7 +604,8 @@ describe("ensureSandboxBrowser create args", () => {
 
     const createArgs = requireDockerCreateArgs();
     expect(createArgs).toContain(`openclaw.configHash=${expectedHash}`);
-    expect(collectDockerFlagValues(createArgs, "--env")).toContain("GEMINI_API_KEY=dummy-gemini");
+    expect(requireDockerCreateEnvEntries()).toContain("GEMINI_API_KEY=dummy-gemini");
+    expect(createArgs.some((arg) => arg.includes("dummy-gemini"))).toBe(false);
   });
 
   it("fails before creating a browser container when Docker daemon is unavailable", async () => {
@@ -942,8 +983,7 @@ describe("ensureSandboxBrowser create args", () => {
       cfg: buildConfig(false),
     });
 
-    const createArgs = findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create");
-    const envEntries = collectDockerFlagValues(createArgs ?? [], "-e");
+    const envEntries = requireDockerCreateEnvEntries();
     const authEntry = envEntries.find((entry) =>
       entry.startsWith("OPENCLAW_BROWSER_CDP_AUTH_TOKEN="),
     );
@@ -972,8 +1012,7 @@ describe("ensureSandboxBrowser create args", () => {
       cfg,
     });
 
-    const createArgs = findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create");
-    const envEntries = collectDockerFlagValues(createArgs ?? [], "-e");
+    const envEntries = requireDockerCreateEnvEntries();
     expect(envEntries).toContain("OPENCLAW_BROWSER_CDP_SOURCE_RANGE=10.0.0.0/24");
   });
 

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -9,6 +9,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { deriveDefaultBrowserCdpPortRange } from "../../config/port-defaults.js";
+import { withContainerEnvFile } from "../../infra/container-env-file.js";
 import { isSameSsrFPolicy, type SsrFPolicy } from "../../infra/net/ssrf.js";
 import { startBrowserBridgeServer } from "../../plugin-sdk/browser-bridge.js";
 import {
@@ -381,7 +382,7 @@ async function ensureSandboxBrowserContainer(
       allowContainerNamespaceJoin: browserDockerCfg.dangerouslyAllowContainerNamespaceJoin === true,
     });
     await ensureSandboxBrowserImage(browserImage);
-    const args = buildSandboxCreateArgs({
+    const { argv: args, env } = buildSandboxCreateArgs({
       name: containerName,
       cfg: browserDockerCfg,
       scopeKey: params.scopeKey,
@@ -430,25 +431,26 @@ async function ensureSandboxBrowserContainer(
     if (noVncEnabled) {
       args.push("-p", `127.0.0.1::${params.cfg.browser.noVncPort}`);
     }
-    args.push("-e", `OPENCLAW_BROWSER_HEADLESS=${params.cfg.browser.headless ? "1" : "0"}`);
-    args.push("-e", `OPENCLAW_BROWSER_ENABLE_NOVNC=${params.cfg.browser.noVncEnabled ? "1" : "0"}`);
-    args.push("-e", `OPENCLAW_BROWSER_CDP_PORT=${params.cfg.browser.cdpPort}`);
-    args.push("-e", `${CDP_AUTH_TOKEN_ENV_KEY}=${cdpAuthToken}`);
-    args.push(
-      "-e",
-      `OPENCLAW_BROWSER_AUTO_START_TIMEOUT_MS=${params.cfg.browser.autoStartTimeoutMs}`,
-    );
+    Object.assign(env, {
+      OPENCLAW_BROWSER_HEADLESS: params.cfg.browser.headless ? "1" : "0",
+      OPENCLAW_BROWSER_ENABLE_NOVNC: params.cfg.browser.noVncEnabled ? "1" : "0",
+      OPENCLAW_BROWSER_CDP_PORT: String(params.cfg.browser.cdpPort),
+      [CDP_AUTH_TOKEN_ENV_KEY]: cdpAuthToken,
+      OPENCLAW_BROWSER_AUTO_START_TIMEOUT_MS: String(params.cfg.browser.autoStartTimeoutMs),
+      OPENCLAW_BROWSER_VNC_PORT: String(params.cfg.browser.vncPort),
+      OPENCLAW_BROWSER_NOVNC_PORT: String(params.cfg.browser.noVncPort),
+      OPENCLAW_BROWSER_NO_SANDBOX: "1",
+    });
     if (cdpSourceRange) {
-      args.push("-e", `${CDP_SOURCE_RANGE_ENV_KEY}=${cdpSourceRange}`);
+      env[CDP_SOURCE_RANGE_ENV_KEY] = cdpSourceRange;
     }
-    args.push("-e", `OPENCLAW_BROWSER_VNC_PORT=${params.cfg.browser.vncPort}`);
-    args.push("-e", `OPENCLAW_BROWSER_NOVNC_PORT=${params.cfg.browser.noVncPort}`);
-    args.push("-e", "OPENCLAW_BROWSER_NO_SANDBOX=1");
     if (noVncEnabled && noVncPassword) {
-      args.push("-e", `${NOVNC_PASSWORD_ENV_KEY}=${noVncPassword}`);
+      env[NOVNC_PASSWORD_ENV_KEY] = noVncPassword;
     }
-    args.push(browserImage);
-    await execDocker(args);
+    await withContainerEnvFile(env, async (envFile) => {
+      args.push("--env-file", envFile, browserImage);
+      await execDocker(args);
+    });
     await execDocker(["start", containerName]);
   } else if (!running) {
     await execDocker(["start", containerName]);

--- a/src/agents/sandbox/config-contract.ts
+++ b/src/agents/sandbox/config-contract.ts
@@ -1,0 +1,25 @@
+import type { SandboxScope } from "./types.js";
+
+export function resolveSandboxScope(params: {
+  scope?: SandboxScope;
+  perSession?: boolean;
+}): SandboxScope {
+  if (params.scope) {
+    return params.scope;
+  }
+  if (typeof params.perSession === "boolean") {
+    return params.perSession ? "session" : "shared";
+  }
+  return "agent";
+}
+
+export function resolveSandboxDockerEnv(params: {
+  scope: SandboxScope;
+  globalEnv?: Record<string, string>;
+  agentEnv?: Record<string, string>;
+}): Record<string, string> {
+  const agentEnv = params.scope === "shared" ? undefined : params.agentEnv;
+  return agentEnv
+    ? { ...(params.globalEnv ?? { LANG: "C.UTF-8" }), ...agentEnv }
+    : (params.globalEnv ?? { LANG: "C.UTF-8" });
+}

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -9,6 +9,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SandboxSshSettings } from "../../config/types.sandbox.js";
 import { normalizeSecretInputString } from "../../config/types.secrets.js";
 import { resolveAgentConfig } from "../agent-scope.js";
+import { resolveSandboxDockerEnv, resolveSandboxScope } from "./config-contract.js";
 import {
   DEFAULT_SANDBOX_BROWSER_AUTOSTART_TIMEOUT_MS,
   DEFAULT_SANDBOX_BROWSER_CDP_PORT,
@@ -77,18 +78,7 @@ export function resolveSandboxBrowserDockerCreateConfig(params: {
   return params.browser.binds !== undefined ? { ...base, binds: params.browser.binds } : base;
 }
 
-export function resolveSandboxScope(params: {
-  scope?: SandboxScope;
-  perSession?: boolean;
-}): SandboxScope {
-  if (params.scope) {
-    return params.scope;
-  }
-  if (typeof params.perSession === "boolean") {
-    return params.perSession ? "session" : "shared";
-  }
-  return "agent";
-}
+export { resolveSandboxScope } from "./config-contract.js";
 
 export function resolveSandboxDockerConfig(params: {
   scope: SandboxScope;
@@ -98,9 +88,11 @@ export function resolveSandboxDockerConfig(params: {
   const agentDocker = params.scope === "shared" ? undefined : params.agentDocker;
   const globalDocker = params.globalDocker;
 
-  const env = agentDocker?.env
-    ? { ...(globalDocker?.env ?? { LANG: "C.UTF-8" }), ...agentDocker.env }
-    : (globalDocker?.env ?? { LANG: "C.UTF-8" });
+  const env = resolveSandboxDockerEnv({
+    scope: params.scope,
+    globalEnv: globalDocker?.env,
+    agentEnv: agentDocker?.env,
+  });
 
   const ulimits = agentDocker?.ulimits
     ? { ...globalDocker?.ulimits, ...agentDocker.ulimits }

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -59,7 +59,7 @@ export const SANDBOX_BROWSER_IMAGE_CONTRACT_EPOCH = "2026-05-12-cdp-relay-auth";
 
 // Bump with shared Docker create-flag changes so existing ordinary and browser
 // sandboxes roll through the hash/recreate path instead of keeping stale flags.
-export const SANDBOX_DOCKER_CREATE_ARGS_EPOCH = "2026-07-10-init";
+export const SANDBOX_DOCKER_CREATE_ARGS_EPOCH = "2026-08-25-container-env-file";
 
 export const DEFAULT_SANDBOX_BROWSER_PREFIX = "openclaw-sbx-browser-";
 export const DEFAULT_SANDBOX_BROWSER_CDP_PORT = 9222;

--- a/src/agents/sandbox/docker-backend.test.ts
+++ b/src/agents/sandbox/docker-backend.test.ts
@@ -1,5 +1,6 @@
 // Docker backend manager tests cover runtime image matching and removal error
 // handling for sandbox and browser containers.
+import fs from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveSandboxConfigForAgent } from "./config.js";
@@ -53,6 +54,17 @@ function createConfig(): OpenClawConfig {
       list: [],
     },
   };
+}
+
+async function createDockerExecBackend() {
+  dockerMocks.ensureSandboxContainer.mockResolvedValueOnce("sandbox-container");
+  return createDockerSandboxBackend({
+    sessionKey: "agent:coder:main",
+    scopeKey: "agent:coder:main",
+    workspaceDir: "/workspace",
+    agentWorkspaceDir: "/workspace",
+    cfg: resolveSandboxConfigForAgent(createConfig()),
+  });
 }
 
 describe("docker sandbox backend manager", () => {
@@ -132,6 +144,96 @@ describe("docker sandbox backend manager", () => {
       podmanTarget,
     );
     expect(execSpec.argv.slice(0, 6)).toEqual(["podman", ...podmanTarget.globalArgs, "exec"]);
+    expect(execSpec.stdinMode).toBe("pipe-closed");
+    await backend.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: execSpec.finalizeToken,
+    });
+  });
+
+  it("delivers exec environment outside process arguments and cleans it after finalization", async () => {
+    const sentinel = "synthetic-container-exec-transport-value";
+    const requestedPath = "/synthetic/bin:/synthetic/system/bin";
+    const backend = await createDockerExecBackend();
+
+    const execSpec = await backend.buildExecSpec({
+      command: "printf ready",
+      workdir: "/workspace/project",
+      env: { CONFIGURED_VALUE: sentinel, PATH: requestedPath },
+      usePty: true,
+    });
+
+    expect(execSpec.argv.join(" ")).not.toContain(sentinel);
+    expect(execSpec.argv.join(" ")).not.toContain(requestedPath);
+    expect(execSpec.argv).not.toContain("-e");
+    expect(execSpec.argv).toContain("-t");
+    expect(execSpec.argv).toContain("-w");
+    expect(execSpec.argv).toContain("/workspace/project");
+    expect(execSpec.argv.slice(-4, -1)).toEqual(["sandbox-container", "/bin/sh", "-lc"]);
+    expect(execSpec.argv.at(-1)).toBe(
+      'export PATH="${OPENCLAW_PREPEND_PATH}:$PATH"; unset OPENCLAW_PREPEND_PATH; printf ready',
+    );
+    expect(execSpec.stdinMode).toBe("pipe-open");
+    const envFile = execSpec.argv[execSpec.argv.indexOf("--env-file") + 1];
+    expect(envFile).toBeDefined();
+    const envFileContent = fs.readFileSync(envFile!, "utf8");
+    expect(envFileContent).toContain(`CONFIGURED_VALUE=${sentinel}\n`);
+    expect(envFileContent).toContain(`OPENCLAW_PREPEND_PATH=${requestedPath}\n`);
+    expect(envFileContent).not.toMatch(/^PATH=/m);
+    expect(backend.finalizeExec).toBeDefined();
+
+    const finalization = {
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: execSpec.finalizeToken,
+    } as const;
+    await backend.finalizeExec?.(finalization);
+
+    expect(fs.existsSync(envFile!)).toBe(false);
+    await expect(backend.finalizeExec?.(finalization)).resolves.toBeUndefined();
+  });
+
+  it.each([
+    {
+      description: "never interpolates shell metacharacters from PATH into the command",
+      requestedPath: "$(touch /tmp/openclaw-path-injection)",
+      expectedCommand:
+        'export PATH="${OPENCLAW_PREPEND_PATH}:$PATH"; unset OPENCLAW_PREPEND_PATH; echo hello',
+    },
+    {
+      description: "does not add a PATH export when PATH is absent",
+      requestedPath: undefined,
+      expectedCommand: "echo hello",
+    },
+  ])("$description", async ({ requestedPath, expectedCommand }) => {
+    const backend = await createDockerExecBackend();
+    const execSpec = await backend.buildExecSpec({
+      command: "echo hello",
+      env: { HOME: "/synthetic/home", ...(requestedPath ? { PATH: requestedPath } : {}) },
+      usePty: false,
+    });
+
+    try {
+      expect(execSpec.argv.at(-1)).toBe(expectedCommand);
+      const envFile = execSpec.argv[execSpec.argv.indexOf("--env-file") + 1];
+      const envFileContent = fs.readFileSync(envFile!, "utf8");
+      if (requestedPath) {
+        expect(execSpec.argv.join(" ")).not.toContain(requestedPath);
+        expect(envFileContent).toContain(`OPENCLAW_PREPEND_PATH=${requestedPath}\n`);
+      } else {
+        expect(envFileContent).not.toContain("OPENCLAW_PREPEND_PATH=");
+      }
+    } finally {
+      await backend.finalizeExec?.({
+        status: "completed",
+        exitCode: 0,
+        timedOut: false,
+        token: execSpec.finalizeToken,
+      });
+    }
   });
 
   it("matches ordinary sandbox runtimes against sandbox.docker.image", async () => {

--- a/src/agents/sandbox/docker-backend.ts
+++ b/src/agents/sandbox/docker-backend.ts
@@ -3,7 +3,7 @@
  *
  * Creates/reuses Docker containers and exposes backend-neutral exec and shell-command handles.
  */
-import { buildDockerExecArgs } from "../bash-tools.shared.js";
+import { createContainerEnvFile } from "../../infra/container-env-file.js";
 import type { SandboxBackendCommandParams } from "./backend-handle.types.js";
 import type {
   CreateSandboxBackendParams,
@@ -25,6 +25,42 @@ import {
   validateSandboxContainerEngineTarget,
 } from "./docker.js";
 import type { SandboxRegistryEntry } from "./registry.js";
+
+type ContainerExecFinalizeToken = () => Promise<void>;
+
+function resolveContainerExecEnv(env: Record<string, string>): Record<string, string> {
+  const { PATH: requestedPath, ...containerEnv } = env;
+  if (requestedPath) {
+    containerEnv.OPENCLAW_PREPEND_PATH = requestedPath;
+  }
+  return containerEnv;
+}
+
+function buildContainerExecArgs(params: {
+  containerName: string;
+  command: string;
+  workdir?: string;
+  env: Record<string, string>;
+  envFile: string;
+  tty: boolean;
+}): string[] {
+  const args = ["exec", "-i"];
+  if (params.tty) {
+    args.push("-t");
+  }
+  if (params.workdir) {
+    args.push("-w", params.workdir);
+  }
+  args.push("--env-file", params.envFile);
+  // Apply the staged prepend only after login profile sourcing; direct PATH
+  // injection can break the container engine's initial executable lookup.
+  const pathExport = params.env.PATH
+    ? 'export PATH="${OPENCLAW_PREPEND_PATH}:$PATH"; unset OPENCLAW_PREPEND_PATH; '
+    : "";
+  // Use absolute path for sh to avoid dependency on PATH resolution during exec.
+  args.push(params.containerName, "/bin/sh", "-lc", `${pathExport}${params.command}`);
+  return args;
+}
 
 function resolveConfiguredDockerRuntimeImage(params: {
   config: CreateSandboxBackendParams["cfg"] | import("../../config/config.js").OpenClawConfig;
@@ -107,21 +143,39 @@ function createContainerSandboxBackendHandle(params: {
     },
     async buildExecSpec({ command, workdir, env, usePty }) {
       await validateSandboxContainerEngineTarget(params.engine, params.podmanTarget);
-      return {
-        argv: [
+      const envFile = await createContainerEnvFile(resolveContainerExecEnv(env));
+      try {
+        const argv = [
           params.engine.command,
           ...(params.engine.globalArgs ?? []),
-          ...buildDockerExecArgs({
+          ...buildContainerExecArgs({
             containerName: params.containerName,
             command,
             workdir: workdir ?? params.workdir,
             env,
+            envFile: envFile.path,
             tty: usePty,
           }),
-        ],
-        env: process.env,
-        stdinMode: usePty ? "pipe-open" : "pipe-closed",
-      };
+        ];
+        return {
+          argv,
+          env: process.env,
+          stdinMode: usePty ? "pipe-open" : "pipe-closed",
+          finalizeToken: envFile.cleanup satisfies ContainerExecFinalizeToken,
+        };
+      } catch (error) {
+        await envFile.cleanup();
+        throw error;
+      }
+    },
+    async finalizeExec({ token }) {
+      if (token === undefined) {
+        return;
+      }
+      if (typeof token !== "function") {
+        throw new Error("Invalid container sandbox execution cleanup token.");
+      }
+      await token();
     },
     runShellCommand(command) {
       return runContainerSandboxShellCommand({

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -18,6 +18,7 @@ type SpawnCall = {
   command: string;
   args: string[];
   globalArgs: string[];
+  envFileContents?: string;
 };
 
 const spawnState = vi.hoisted(() => ({
@@ -86,7 +87,13 @@ async function spawnDockerProcess(commandAndArgs: string[]) {
   }
   // The tests assert docker CLI arguments without requiring Docker; this mock
   // implements only the inspect/create/start/rm calls used by ensureSandboxContainer.
-  spawnState.calls.push({ command, args, globalArgs });
+  const envFileIndex = args.indexOf("--env-file");
+  const envFile = envFileIndex === -1 ? undefined : args[envFileIndex + 1];
+  const call: SpawnCall = { command, args, globalArgs };
+  if (args[0] === "create" && envFile) {
+    call.envFileContents = fs.readFileSync(envFile, "utf8");
+  }
+  spawnState.calls.push(call);
 
   let code = 0;
   let stdout = "";
@@ -323,6 +330,29 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     });
   });
 
+  it.each(["docker", "podman"] as const)(
+    "delivers configured %s create environment without exposing values in process arguments",
+    async (backend) => {
+      const sentinel = "synthetic-container-create-transport-value";
+      const cfg = createSandboxConfig([], undefined, "rw", { CONFIGURED_VALUE: sentinel });
+      cfg.backend = backend;
+      spawnState.containerExists = false;
+      registryMocks.readRegistryEntry.mockResolvedValue(null);
+
+      const createCall = await ensureSandboxCreateCallForTest({
+        cfg,
+        ...(backend === "podman" ? { engine: PODMAN_SANDBOX_ENGINE } : {}),
+      });
+
+      expect(createCall.args.join(" ")).not.toContain(sentinel);
+      expect(createCall.envFileContents).toContain(`CONFIGURED_VALUE=${sentinel}\n`);
+      expect(createCall.envFileContents).toContain("OPENCLAW_CLI=1\n");
+      const envFile = collectDockerFlagValues(createCall.args, "--env-file")[0];
+      expect(envFile).toBeDefined();
+      expect(fs.existsSync(envFile!)).toBe(false);
+    },
+  );
+
   it("recreates shared container when array-order change alters hash", async () => {
     // Docker flag order is part of the runtime contract, so order-sensitive
     // config changes must invalidate a shared container.
@@ -532,9 +562,9 @@ describe("ensureSandboxContainer config-hash recreation", () => {
 
     const createCall = await ensureSandboxCreateCallForTest({ cfg, workspaceDir });
     expect(createCall.args).toContain(`openclaw.configHash=${newHash}`);
-    expect(collectDockerFlagValues(createCall.args, "--env")).toEqual(
-      expect.arrayContaining(["LANG=C.UTF-8", "GEMINI_API_KEY=dummy-gemini"]),
-    );
+    expect(createCall.args).not.toContain("--env");
+    expect(createCall.envFileContents).toContain("LANG=C.UTF-8\n");
+    expect(createCall.envFileContents).toContain("GEMINI_API_KEY=dummy-gemini\n");
 
     const registryUpdate = registryMocks.updateRegistry.mock.calls.at(-1)?.[0];
     expect(registryUpdate?.configHash).toBe(newHash);

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -1,3 +1,4 @@
+import { withContainerEnvFile } from "../../infra/container-env-file.js";
 import { markOpenClawExecEnv } from "../../infra/openclaw-exec-env.js";
 /**
  * Low-level Docker command helpers for sandbox runtimes.
@@ -386,9 +387,7 @@ export function buildSandboxCreateArgs(params: {
       `Suspicious configured sandbox environment variables: ${envSanitization.warnings.join(", ")}`,
     );
   }
-  for (const [key, value] of Object.entries(markOpenClawExecEnv(envSanitization.allowed))) {
-    args.push("--env", `${key}=${value}`);
-  }
+  const env = markOpenClawExecEnv(envSanitization.allowed);
   for (const cap of params.cfg.capDrop) {
     args.push("--cap-drop", cap);
   }
@@ -440,7 +439,7 @@ export function buildSandboxCreateArgs(params: {
       args.push("-v", bind);
     }
   }
-  return args;
+  return { argv: args, env };
 }
 
 function appendCustomBinds(args: string[], cfg: SandboxDockerConfig): void {
@@ -482,7 +481,7 @@ async function createSandboxContainer(params: {
   const createCfg = podmanPolicy?.cfg ?? cfg;
   await ensureContainerImage(engine, cfg.image);
 
-  const args = buildSandboxCreateArgs({
+  const { argv: args, env } = buildSandboxCreateArgs({
     name,
     cfg: createCfg,
     scopeKey,
@@ -524,9 +523,10 @@ async function createSandboxContainer(params: {
     args,
     readOnlyWorkspaceSkillMounts: params.readOnlyWorkspaceSkillMounts,
   });
-  args.push(cfg.image, "sleep", "infinity");
-
-  await execContainer(engine, args);
+  await withContainerEnvFile(env, async (envFile) => {
+    args.push("--env-file", envFile, cfg.image, "sleep", "infinity");
+    await execContainer(engine, args);
+  });
   await execContainer(engine, ["start", name]);
 
   if (cfg.setupCommand?.trim()) {

--- a/src/agents/sandbox/ssh-backend.test.ts
+++ b/src/agents/sandbox/ssh-backend.test.ts
@@ -469,7 +469,10 @@ describe("ssh sandbox backend", () => {
       token: execSpec.finalizeToken,
     });
 
-    expect(sshMocks.spawnCommand).toHaveBeenCalledOnce();
+    expect(sshMocks.spawnCommand).toHaveBeenCalledTimes(2);
+    const cleanup = requirePreparedSshInvocation(1);
+    expect(cleanup.argv.at(-1)).toContain("openclaw-sandbox-exec-cleanup");
+    expect(cleanup.argv.join(" ")).not.toContain(sentinel);
     expect(sshMocks.disposeSshSandboxSession).toHaveBeenCalledOnce();
   });
 

--- a/src/agents/sandbox/ssh-backend.test.ts
+++ b/src/agents/sandbox/ssh-backend.test.ts
@@ -21,8 +21,14 @@ const sshMocks = vi.hoisted(() => ({
   disposeSshSandboxSession: vi.fn(),
   runSshSandboxCommand: vi.fn(),
   uploadDirectoryToSshTarget: vi.fn(),
-  buildSshSandboxArgv: vi.fn(),
+  spawnCommand: vi.fn(),
 }));
+
+vi.mock("../../process/exec.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../process/exec.js")>("../../process/exec.js");
+  return { ...actual, spawnCommand: sshMocks.spawnCommand };
+});
 
 vi.mock("./ssh.js", async () => {
   const actual = await vi.importActual<typeof import("./ssh.js")>("./ssh.js");
@@ -32,7 +38,6 @@ vi.mock("./ssh.js", async () => {
     disposeSshSandboxSession: sshMocks.disposeSshSandboxSession,
     runSshSandboxCommand: sshMocks.runSshSandboxCommand,
     uploadDirectoryToSshTarget: sshMocks.uploadDirectoryToSshTarget,
-    buildSshSandboxArgv: sshMocks.buildSshSandboxArgv,
   };
 });
 
@@ -88,6 +93,21 @@ function requireSshRunCommandParams(callIndex = 0) {
 
 function requireSshUploadParams(callIndex: number, label: string) {
   return requireMockRecordArg(sshMocks.uploadDirectoryToSshTarget, callIndex, label);
+}
+
+function requirePreparedSshInvocation(callIndex = 0): { argv: string[]; stdin: string } {
+  const call = sshMocks.spawnCommand.mock.calls[callIndex];
+  if (!Array.isArray(call?.[0])) {
+    throw new Error(`expected staged ssh invocation ${callIndex}`);
+  }
+  const input = requireRecord(call[1], "staged ssh command options").input;
+  if (typeof input !== "string" && !Buffer.isBuffer(input)) {
+    throw new Error(`expected staged ssh stdin for invocation ${callIndex}`);
+  }
+  return {
+    argv: call[0] as string[],
+    stdin: typeof input === "string" ? input : input.toString("utf8"),
+  };
 }
 
 function createBackendSandboxConfig(params?: { binds?: string[]; target?: string }): SandboxConfig {
@@ -162,14 +182,13 @@ describe("ssh sandbox backend", () => {
       code: 0,
     });
     sshMocks.uploadDirectoryToSshTarget.mockResolvedValue(undefined);
-    sshMocks.buildSshSandboxArgv.mockImplementation(({ session, remoteCommand, tty }) => [
-      session.command,
-      "-F",
-      session.configPath,
-      tty ? "-tt" : "-T",
-      session.host,
-      remoteCommand,
-    ]);
+    sshMocks.spawnCommand.mockResolvedValue({
+      failed: false,
+      isCanceled: false,
+      exitCode: 0,
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+    });
   });
 
   afterEach(async () => {
@@ -407,6 +426,99 @@ describe("ssh sandbox backend", () => {
     },
   );
 
+  it("uploads SSH exec environment privately without exposing values in local argv", async () => {
+    const sentinel = "synthetic-ssh-private-value";
+    const multilineValue = `${sentinel}\r\nsecond 'quoted' line=ok `;
+    const backend = await createPreprovisionedSshSandboxBackend(
+      {
+        sessionKey: "agent:worker:task",
+        scopeKey: "agent:worker",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/workspace",
+        cfg: createBackendSandboxConfig({ target: "peter@example.com:2222" }),
+      },
+      {
+        runtimeId: "remote-exec:environment-1:7:11",
+        remoteWorkspaceDir: "/srv/openclaw/workspaces/session-1",
+      },
+    );
+
+    const execSpec = await backend.buildExecSpec({
+      command: "printf '%s' \"$SYNTHETIC_VALUE\"",
+      env: { SYNTHETIC_VALUE: multilineValue },
+      usePty: true,
+    });
+
+    expect(execSpec.argv.join(" ")).not.toContain(sentinel);
+    expect(execSpec.argv).toContain("-tt");
+    expect(execSpec.stdinMode).toBe("pipe-open");
+    const upload = requirePreparedSshInvocation();
+    expect(upload.argv.join(" ")).not.toContain(sentinel);
+    expect(upload.argv).toContain("-T");
+    expect(upload.stdin).toContain(sentinel);
+    expect(upload.stdin).toContain("second '");
+    expect(upload.stdin).toMatch(/(?:^|\n)export SYNTHETIC_VALUE=/);
+    expect(upload.stdin).toMatch(/exec '\/bin\/sh' '-c'/);
+    expect(upload.stdin).toContain("export TERM='xterm-256color'");
+    expect(execSpec.argv.join(" ")).not.toContain("SetEnv");
+
+    await backend.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: execSpec.finalizeToken,
+    });
+
+    expect(sshMocks.spawnCommand).toHaveBeenCalledOnce();
+    expect(sshMocks.disposeSshSandboxSession).toHaveBeenCalledOnce();
+  });
+
+  it("disposes the SSH session when staged exec upload or final cleanup fails", async () => {
+    const backend = await createPreprovisionedSshSandboxBackend(
+      {
+        sessionKey: "agent:worker:task",
+        scopeKey: "agent:worker",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/workspace",
+        cfg: createBackendSandboxConfig({ target: "peter@example.com:2222" }),
+      },
+      {
+        runtimeId: "remote-exec:environment-1:7:11",
+        remoteWorkspaceDir: "/srv/openclaw/workspaces/session-1",
+      },
+    );
+
+    sshMocks.spawnCommand.mockRejectedValueOnce(new Error("synthetic staging transport failure"));
+    await expect(
+      backend.buildExecSpec({
+        command: "true",
+        env: { SYNTHETIC_VALUE: "synthetic-upload-value" },
+        usePty: false,
+      }),
+    ).rejects.toThrow("synthetic staging transport failure");
+    expect(sshMocks.spawnCommand).toHaveBeenCalledTimes(2);
+    expect(sshMocks.disposeSshSandboxSession).toHaveBeenCalledOnce();
+
+    const execSpec = await backend.buildExecSpec({
+      command: "true",
+      env: {},
+      usePty: false,
+    });
+    sshMocks.spawnCommand.mockRejectedValueOnce(new Error("synthetic cleanup transport failure"));
+    await expect(
+      backend.finalizeExec?.({
+        status: "failed",
+        exitCode: null,
+        timedOut: true,
+        token: execSpec.finalizeToken,
+      }),
+    ).rejects.toThrow("synthetic cleanup transport failure");
+    expect(sshMocks.disposeSshSandboxSession).toHaveBeenCalledTimes(2);
+    expect(sshMocks.spawnCommand.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      sshMocks.disposeSshSandboxSession.mock.invocationCallOrder.at(-1) ?? Number.POSITIVE_INFINITY,
+    );
+  });
+
   it("creates a remote-canonical backend that seeds once and reuses ssh exec", async () => {
     sshMocks.runSshSandboxCommand
       .mockResolvedValueOnce({
@@ -482,14 +594,11 @@ describe("ssh sandbox backend", () => {
       usePty: false,
     });
 
-    expect(execSpec.argv.slice(0, 5)).toEqual([
-      "ssh",
-      "-F",
-      createSession().configPath,
-      "-T",
-      createSession().host,
-    ]);
-    expect(execSpec.argv.at(-1)).toContain("/remote/openclaw/openclaw-ssh-agent-worker");
+    expect(execSpec.argv.slice(0, 4)).toEqual(["ssh", "-F", createSession().configPath, "-T"]);
+    expect(execSpec.argv).toContain(createSession().host);
+    expect(requirePreparedSshInvocation().stdin).toContain(
+      "/remote/openclaw/openclaw-ssh-agent-worker",
+    );
     expect(sshMocks.uploadDirectoryToSshTarget).toHaveBeenCalledTimes(3);
     const workspaceUploadParams = requireSshUploadParams(0, "workspace upload params");
     expect(workspaceUploadParams.localDir).toBe("/tmp/workspace");
@@ -544,7 +653,7 @@ describe("ssh sandbox backend", () => {
       usePty: false,
     });
 
-    expect(execSpec.argv.at(-1)).toContain(remoteWorkspaceDir);
+    expect(requirePreparedSshInvocation().stdin).toContain(remoteWorkspaceDir);
     expect(sshMocks.uploadDirectoryToSshTarget).not.toHaveBeenCalled();
     expect(sshMocks.runSshSandboxCommand).not.toHaveBeenCalled();
     await backend.runShellCommand({ script: "pwd" });
@@ -662,7 +771,7 @@ describe("ssh sandbox backend", () => {
     const skillsUploadParams = requireSshUploadParams(0, "skills upload params");
     expect(skillsUploadParams.localDir).toBe(skillsWorkspaceDir);
     expect(skillsUploadParams.remoteDir).toBe(runtimePaths.remoteSkillsWorkspaceDir);
-    expect(execSpec.argv.at(-1)).toContain(skillsWorkdir);
+    expect(requirePreparedSshInvocation().stdin).toContain(skillsWorkdir);
     await backend.finalizeExec?.({
       status: "completed",
       exitCode: 0,

--- a/src/agents/sandbox/ssh-backend.ts
+++ b/src/agents/sandbox/ssh-backend.ts
@@ -27,11 +27,11 @@ import { resolveSandboxAgentId } from "./shared.js";
 import {
   buildRemoteCommand,
   buildRemoteWorkdirValidationCommand,
-  buildSshSandboxArgv,
   buildValidatedExecRemoteCommand,
   createSshSandboxSessionFromSettings,
   disposeSshSandboxSession,
   ENSURE_REMOTE_REAL_DIRECTORY_SCRIPT,
+  prepareSshSandboxExec,
   runSshSandboxCommand,
   uploadDirectoryToSshTarget,
   type SshSandboxSession,
@@ -39,6 +39,7 @@ import {
 
 type PendingExec = {
   sshSession: SshSandboxSession;
+  cleanup: (status: "completed" | "failed") => Promise<void>;
 };
 
 type ResolvedSshRuntimePaths = {
@@ -208,7 +209,7 @@ class SshSandboxBackendImpl {
         const remoteCommand = buildValidatedExecRemoteCommand({
           command,
           workdir: remoteWorkdir,
-          env,
+          env: {},
         });
         await this.ensureRuntime();
         const sshSession = await this.createSession();
@@ -216,25 +217,31 @@ class SshSandboxBackendImpl {
           if (!this.consumeRefreshedSkillsForNextExec(remoteWorkdir)) {
             await this.refreshRemoteSkillsWorkspace(sshSession);
           }
+          const prepared = await prepareSshSandboxExec({
+            session: sshSession,
+            remoteCommand,
+            env,
+            tty: usePty,
+          });
           return {
-            argv: buildSshSandboxArgv({
-              session: sshSession,
-              remoteCommand,
-              tty: usePty,
-            }),
+            argv: prepared.argv,
             env: sanitizeEnvVars(process.env).allowed,
             stdinMode: "pipe-open",
-            finalizeToken: { sshSession } satisfies PendingExec,
+            finalizeToken: { sshSession, cleanup: prepared.cleanup } satisfies PendingExec,
           };
         } catch (error) {
           await disposeSshSandboxSession(sshSession);
           throw error;
         }
       },
-      finalizeExec: async ({ token }) => {
-        const sshSession = (token as PendingExec | undefined)?.sshSession;
-        if (sshSession) {
-          await disposeSshSandboxSession(sshSession);
+      finalizeExec: async ({ token, status }) => {
+        const pending = token as PendingExec | undefined;
+        if (pending) {
+          try {
+            await pending.cleanup(status);
+          } finally {
+            await disposeSshSandboxSession(pending.sshSession);
+          }
         }
       },
       runShellCommand: async (command) => await this.runRemoteShellScript(command),

--- a/src/agents/sandbox/ssh-backend.ts
+++ b/src/agents/sandbox/ssh-backend.ts
@@ -39,7 +39,7 @@ import {
 
 type PendingExec = {
   sshSession: SshSandboxSession;
-  cleanup: (status: "completed" | "failed") => Promise<void>;
+  cleanup: () => Promise<void>;
 };
 
 type ResolvedSshRuntimePaths = {
@@ -234,11 +234,11 @@ class SshSandboxBackendImpl {
           throw error;
         }
       },
-      finalizeExec: async ({ token, status }) => {
+      finalizeExec: async ({ token }) => {
         const pending = token as PendingExec | undefined;
         if (pending) {
           try {
-            await pending.cleanup(status);
+            await pending.cleanup();
           } finally {
             await disposeSshSandboxSession(pending.sshSession);
           }

--- a/src/agents/sandbox/ssh.spawn-env.test.ts
+++ b/src/agents/sandbox/ssh.spawn-env.test.ts
@@ -83,6 +83,7 @@ function spawnCommandOptions(): {
 }
 
 let runSshSandboxCommand: typeof import("./ssh.js").runSshSandboxCommand;
+let prepareSshSandboxExec: typeof import("./ssh.js").prepareSshSandboxExec;
 let uploadDirectoryToSshTarget: typeof import("./ssh.js").uploadDirectoryToSshTarget;
 
 describe("ssh subprocess env sanitization", () => {
@@ -100,7 +101,8 @@ describe("ssh subprocess env sanitization", () => {
       stdout: Buffer.alloc(0),
       stderr: Buffer.alloc(0),
     });
-    ({ runSshSandboxCommand, uploadDirectoryToSshTarget } = await import("./ssh.js"));
+    ({ prepareSshSandboxExec, runSshSandboxCommand, uploadDirectoryToSshTarget } =
+      await import("./ssh.js"));
   });
 
   afterEach(async () => {
@@ -130,6 +132,113 @@ describe("ssh subprocess env sanitization", () => {
     expect(baseEnv.OPENAI_API_KEY).toBeUndefined();
     expect(baseEnv.LANG).toBe("en_US.UTF-8");
     expect(options.maxBuffer).toBe(SANDBOX_COMMAND_MAX_BUFFER_BYTES);
+  });
+
+  it.each(["BAD-NAME", "1INVALID", "BAD\nNAME", " PADDED_NAME", "PADDED_NAME "])(
+    "rejects invalid SSH environment name %j without exposing its value",
+    async (name) => {
+      const sentinel = "synthetic-invalid-name-value";
+      await expect(
+        prepareSshSandboxExec({
+          session: {
+            command: "ssh",
+            configPath: "/tmp/openclaw-test-ssh-config",
+            host: "openclaw-sandbox",
+          },
+          remoteCommand: "'/bin/sh' '-c' 'true'",
+          env: { [name]: sentinel },
+        }),
+      ).rejects.toSatisfy((error: unknown) => {
+        expect(error).toBeInstanceOf(Error);
+        const message = (error as Error).message;
+        expect(message).toContain("POSIX variable name");
+        expect(message).not.toContain(sentinel);
+        return true;
+      });
+      expect(spawnCommandMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects NUL-containing SSH environment values before spawning without exposing them", async () => {
+    const sentinel = "synthetic-private-value";
+    await expect(
+      prepareSshSandboxExec({
+        session: {
+          command: "ssh",
+          configPath: "/tmp/openclaw-test-ssh-config",
+          host: "openclaw-sandbox",
+        },
+        remoteCommand: "'/bin/sh' '-c' 'true'",
+        env: { SYNTHETIC_VALUE: `${sentinel}\0suffix` },
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+      expect(message).toContain("SYNTHETIC_VALUE");
+      expect(message).toContain("NUL");
+      expect(message).not.toContain(sentinel);
+      return true;
+    });
+    expect(spawnCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves explicit TTY terminal values in staged stdin without SSH SetEnv", async () => {
+    const sentinel = "synthetic-explicit-terminal";
+    const prepared = await prepareSshSandboxExec({
+      session: {
+        command: "ssh",
+        configPath: "/tmp/openclaw-test-ssh-config",
+        host: "openclaw-sandbox",
+      },
+      remoteCommand: "'/bin/sh' '-c' 'printf %s \"$TERM\"'",
+      env: { TERM: sentinel },
+      tty: true,
+    });
+
+    const uploadArgv = spawnCommandMock.mock.calls[0]?.[0] as string[];
+    const uploadOptions = spawnCommandMock.mock.calls[0]?.[1] as { input?: string };
+    expect(uploadArgv).toContain("-T");
+    expect(uploadArgv.join(" ")).not.toContain(sentinel);
+    expect(uploadOptions.input).toContain(`export TERM='${sentinel}'`);
+    expect(prepared.argv).toContain("-tt");
+    expect(prepared.argv).toContain("RequestTTY=force");
+    expect(prepared.argv.join(" ")).not.toContain(sentinel);
+    expect(prepared.argv.join(" ")).not.toContain("SetEnv");
+
+    await prepared.cleanup("completed");
+    expect(spawnCommandMock).toHaveBeenCalledOnce();
+  });
+
+  it("removes remote SSH staging after an upload failure", async () => {
+    const sentinel = "synthetic-failed-upload-value";
+    spawnCommandMock.mockResolvedValueOnce({
+      failed: false,
+      isCanceled: false,
+      exitCode: 1,
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.from("synthetic staging failure"),
+    });
+
+    await expect(
+      prepareSshSandboxExec({
+        session: {
+          command: "ssh",
+          configPath: "/tmp/openclaw-test-ssh-config",
+          host: "openclaw-sandbox",
+        },
+        remoteCommand: "'/bin/sh' '-c' 'true'",
+        env: { SYNTHETIC_VALUE: sentinel },
+      }),
+    ).rejects.toThrow("synthetic staging failure");
+
+    expect(spawnCommandMock).toHaveBeenCalledTimes(2);
+    const uploadArgv = spawnCommandMock.mock.calls[0]?.[0] as string[];
+    const uploadOptions = spawnCommandMock.mock.calls[0]?.[1] as { input?: string };
+    const cleanupArgv = spawnCommandMock.mock.calls[1]?.[0] as string[];
+    expect(uploadArgv.join(" ")).not.toContain(sentinel);
+    expect(uploadOptions.input).toContain(sentinel);
+    expect(cleanupArgv.at(-1)).toContain("openclaw-sandbox-exec-cleanup");
+    expect(cleanupArgv.join(" ")).not.toContain(sentinel);
   });
 
   it("rejects transport failures even when ssh exits zero", async () => {

--- a/src/agents/sandbox/ssh.spawn-env.test.ts
+++ b/src/agents/sandbox/ssh.spawn-env.test.ts
@@ -205,8 +205,8 @@ describe("ssh subprocess env sanitization", () => {
     expect(prepared.argv.join(" ")).not.toContain(sentinel);
     expect(prepared.argv.join(" ")).not.toContain("SetEnv");
 
-    await prepared.cleanup("completed");
-    expect(spawnCommandMock).toHaveBeenCalledOnce();
+    await prepared.cleanup();
+    expect(spawnCommandMock).toHaveBeenCalledTimes(2);
   });
 
   it("removes remote SSH staging after an upload failure", async () => {

--- a/src/agents/sandbox/ssh.test.ts
+++ b/src/agents/sandbox/ssh.test.ts
@@ -173,27 +173,31 @@ describe("sandbox ssh helpers", () => {
     expect(config).toContain('  UserKnownHostsFile "/tmp/Application Support/lease/known_hosts"');
   });
 
-  it("wraps remote exec commands with env and workdir", () => {
-    const command = buildExecRemoteCommand({
-      command: "pwd && printenv TOKEN",
-      workdir: "/sandbox/project",
-      env: {
-        TOKEN: "abc 123",
-      },
-    });
-    expect(command).toContain(`'env'`);
-    expect(command).toContain(`'TOKEN=abc 123'`);
-    expect(command).toContain(`'cd '"'"'/sandbox/project'"'"' && pwd && printenv TOKEN'`);
+  it.each([
+    ["public", buildExecRemoteCommand],
+    ["validated", buildValidatedExecRemoteCommand],
+  ])("rejects configured environment values in the %s remote command builder", (_name, build) => {
+    const sentinel = "synthetic-ssh-command-value";
+    expect(() =>
+      build({
+        command: "pwd && printenv SYNTHETIC_VALUE",
+        workdir: "/sandbox/project",
+        env: { SYNTHETIC_VALUE: sentinel },
+      }),
+    ).toThrow(/environment.*secure|secure.*environment/i);
   });
 
   it("keeps the public exec command builder quote-only for compatibility", () => {
     const command = buildExecRemoteCommand({
       command: "workflow run <workflow-id> --ref main",
+      workdir: "/sandbox/project",
       env: {},
     });
 
     expect(command).toContain(`'/bin/sh'`);
-    expect(command).toContain(`'workflow run <workflow-id> --ref main'`);
+    expect(command).toContain(
+      `'cd '"'"'/sandbox/project'"'"' && workflow run <workflow-id> --ref main'`,
+    );
   });
 
   it.each([

--- a/src/agents/sandbox/ssh.ts
+++ b/src/agents/sandbox/ssh.ts
@@ -312,11 +312,7 @@ export function buildValidatedExecRemoteCommand(params: {
 }
 
 function createSshSandboxExecCleanup(session: SshSandboxSession, remoteDir: string) {
-  return async (status: "completed" | "failed"): Promise<void> => {
-    // The staged script removes its directory before exec, so successful runs need no cleanup SSH handshake.
-    if (status === "completed") {
-      return;
-    }
+  return async (): Promise<void> => {
     await runSshSandboxCommand({
       session,
       remoteCommand: buildRemoteCommand([
@@ -339,7 +335,7 @@ export async function prepareSshSandboxExec(params: {
   tty?: boolean;
 }): Promise<{
   argv: string[];
-  cleanup: (status: "completed" | "failed") => Promise<void>;
+  cleanup: () => Promise<void>;
 }> {
   const env =
     params.tty && params.env.TERM === undefined
@@ -381,7 +377,7 @@ export async function prepareSshSandboxExec(params: {
       stdin: script,
     });
   } catch (error) {
-    await cleanup("failed").catch(() => undefined);
+    await cleanup().catch(() => undefined);
     throw error;
   }
   return {

--- a/src/agents/sandbox/ssh.ts
+++ b/src/agents/sandbox/ssh.ts
@@ -4,12 +4,14 @@
  * Materializes temporary SSH config, validates remote shell snippets, runs commands, and uploads workspace trees.
  */
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { createAbortError } from "../../infra/abort-signal.js";
 import { resolveRootPath } from "../../infra/boundary-path.js";
 import { toErrorObject } from "../../infra/errors.js";
+import { normalizeEnvVarKey } from "../../infra/host-env-security.js";
 import { parseSshTarget } from "../../infra/ssh-tunnel.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { isPlainCommandExitFailure, spawnCommand } from "../../process/exec.js";
@@ -288,20 +290,15 @@ export function buildExecRemoteCommand(params: {
   workdir?: string;
   env: Record<string, string>;
 }): string {
+  if (Object.keys(params.env).length > 0) {
+    throw new Error(
+      "SSH sandbox environment requires secure script staging; use prepareSshSandboxExec.",
+    );
+  }
   const body = params.workdir
     ? `cd ${shellEscape(params.workdir)} && ${params.command}`
     : params.command;
-  const argv =
-    Object.keys(params.env).length > 0
-      ? [
-          "env",
-          ...Object.entries(params.env).map(([key, value]) => `${key}=${value}`),
-          "/bin/sh",
-          "-c",
-          body,
-        ]
-      : ["/bin/sh", "-c", body];
-  return buildRemoteCommand(argv);
+  return buildRemoteCommand(["/bin/sh", "-c", body]);
 }
 
 /** Validate and build a remote exec command for untrusted model input. */
@@ -312,6 +309,89 @@ export function buildValidatedExecRemoteCommand(params: {
 }): string {
   assertValidExecRemoteCommand(params.command);
   return buildExecRemoteCommand(params);
+}
+
+function createSshSandboxExecCleanup(session: SshSandboxSession, remoteDir: string) {
+  return async (status: "completed" | "failed"): Promise<void> => {
+    // The staged script removes its directory before exec, so successful runs need no cleanup SSH handshake.
+    if (status === "completed") {
+      return;
+    }
+    await runSshSandboxCommand({
+      session,
+      remoteCommand: buildRemoteCommand([
+        "/bin/sh",
+        "-c",
+        'rm -rf -- "$1"',
+        "openclaw-sandbox-exec-cleanup",
+        remoteDir,
+      ]),
+      allowFailure: true,
+    });
+  };
+}
+
+/** Stage exec environment through private SSH stdin, never local or remote argv. */
+export async function prepareSshSandboxExec(params: {
+  session: SshSandboxSession;
+  remoteCommand: string;
+  env: Record<string, string>;
+  tty?: boolean;
+}): Promise<{
+  argv: string[];
+  cleanup: (status: "completed" | "failed") => Promise<void>;
+}> {
+  const env =
+    params.tty && params.env.TERM === undefined
+      ? { TERM: "xterm-256color", ...params.env }
+      : params.env;
+  for (const [key, value] of Object.entries(env)) {
+    if (normalizeEnvVarKey(key, { portable: true }) !== key) {
+      throw new Error(
+        `Invalid SSH sandbox environment variable name ${JSON.stringify(key)}; use a POSIX variable name.`,
+      );
+    }
+    if (value.includes("\0")) {
+      throw new Error(
+        `Invalid SSH sandbox environment variable ${JSON.stringify(key)}; values must not contain NUL bytes.`,
+      );
+    }
+  }
+  const remoteDir = `/tmp/openclaw-sandbox-exec-${randomUUID()}`;
+  const remoteScript = `${remoteDir}/exec.sh`;
+  const script = [
+    "#!/bin/sh",
+    "set -e",
+    `rm -rf -- ${shellEscape(remoteDir)}`,
+    ...Object.entries(env).map(([key, value]) => `export ${key}=${shellEscape(value)}`),
+    `exec ${params.remoteCommand}`,
+    "",
+  ].join("\n");
+  const cleanup = createSshSandboxExecCleanup(params.session, remoteDir);
+  try {
+    await runSshSandboxCommand({
+      session: params.session,
+      remoteCommand: buildRemoteCommand([
+        "/bin/sh",
+        "-c",
+        'umask 077 && mkdir -- "$1" && cat > "$1/exec.sh" && chmod 700 "$1/exec.sh"',
+        "openclaw-sandbox-exec-stage",
+        remoteDir,
+      ]),
+      stdin: script,
+    });
+  } catch (error) {
+    await cleanup("failed").catch(() => undefined);
+    throw error;
+  }
+  return {
+    argv: buildSshSandboxArgv({
+      session: params.session,
+      remoteCommand: buildRemoteCommand(["/bin/sh", remoteScript]),
+      tty: params.tty,
+    }),
+    cleanup,
+  };
 }
 
 const VALIDATE_REMOTE_WORKDIR_SCRIPT = [
@@ -563,9 +643,7 @@ export function buildSshSandboxArgv(params: {
     params.session.command,
     "-F",
     params.session.configPath,
-    ...(params.tty
-      ? ["-tt", "-o", "RequestTTY=force", "-o", "SetEnv=TERM=xterm-256color"]
-      : ["-T", "-o", "RequestTTY=no"]),
+    ...(params.tty ? ["-tt", "-o", "RequestTTY=force"] : ["-T", "-o", "RequestTTY=no"]),
     params.session.host,
     params.remoteCommand,
   ];

--- a/src/config/validation-core.ts
+++ b/src/config/validation-core.ts
@@ -10,6 +10,8 @@ import {
   resolveAmbientOwnerAgentId,
   tryResolveAmbientOwnerAgentId,
 } from "../agents/agent-scope.js";
+import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
+import { getContainerEnvFileEntryIssue } from "../infra/container-env-file.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import {
   hasAvatarUriScheme,
@@ -310,6 +312,71 @@ function collectModelPolicyAllowIssues(config: OpenClawConfig): ConfigValidation
   return issues;
 }
 
+function collectSandboxContainerEnvIssues(
+  config: OpenClawConfig,
+  sourceRaw?: unknown,
+): ConfigValidationIssue[] {
+  const agents = listAgentEntriesWithSource(config);
+  if (
+    !config.agents?.defaults?.sandbox?.docker?.env &&
+    !agents.some(({ entry }) => entry.sandbox?.docker?.env)
+  ) {
+    return [];
+  }
+  const issues: ConfigValidationIssue[] = [];
+  const seen = new Set<string>();
+  const authoredAgents = isRecord(sourceRaw) ? listAgentEntriesWithSource(sourceRaw) : agents;
+  const authoredById = new Map(authoredAgents.map((agent) => [agent.entry.id, agent]));
+
+  const effectiveAgents = agents.length > 0 ? agents : [undefined];
+  for (const agent of effectiveAgents) {
+    const resolved = resolveSandboxConfigForAgent(config, agent?.entry.id);
+    if ((resolved.backend !== "docker" && resolved.backend !== "podman") || !resolved.docker.env) {
+      continue;
+    }
+    const authoredAgent = agent ? (authoredById.get(agent.entry.id) ?? agent) : undefined;
+    for (const [key, value] of Object.entries(resolved.docker.env)) {
+      const reason = getContainerEnvFileEntryIssue(key, value);
+      if (!reason) {
+        continue;
+      }
+      const agentOwnsValue =
+        resolved.scope !== "shared" &&
+        authoredAgent !== undefined &&
+        Object.hasOwn(authoredAgent.entry.sandbox?.docker?.env ?? {}, key);
+      const pathSegments =
+        agentOwnsValue && authoredAgent
+          ? authoredAgent.source.kind === "entries"
+            ? ["agents", "entries", authoredAgent.source.key, "sandbox", "docker", "env", key]
+            : ["agents", "list", authoredAgent.source.index, "sandbox", "docker", "env", key]
+          : ["agents", "defaults", "sandbox", "docker", "env", key];
+      const issuePath = pathSegments.join(".");
+      const issueIdentity = JSON.stringify([issuePath, reason]);
+      if (seen.has(issueIdentity)) {
+        continue;
+      }
+      seen.add(issueIdentity);
+      const backend = resolved.backend === "podman" ? "Podman" : "Docker";
+      const remediation =
+        reason === "invalid-name"
+          ? `Rename key ${JSON.stringify(key)} to use letters, digits, and underscores without a leading digit.`
+          : `Use a single-line, non-NUL value for key ${JSON.stringify(key)}, or deliver multiline material through a mounted file or custom image.`;
+      issues.push(
+        withConfigIssuePath(
+          {
+            path: issuePath,
+            message:
+              `${backend} sandbox backend requires portable environment names and single-line, non-NUL values because the secure env-file transport is line-delimited. ` +
+              `${remediation} SSH/OpenShell backends may keep multiline values. Run openclaw doctor to report the invalid path; manual remediation is required.`,
+          },
+          pathSegments,
+        ),
+      );
+    }
+  }
+  return issues;
+}
+
 /**
  * Validates config without applying runtime defaults.
  * Use this when you need the raw validated config (e.g., for writing back to file).
@@ -386,6 +453,13 @@ export function validateConfigObjectRaw(
   }
   if (policyIssues.length > 0) {
     return { ok: false, issues: policyIssues };
+  }
+  const sandboxContainerEnvIssues = collectSandboxContainerEnvIssues(
+    validatedConfig,
+    opts?.sourceRaw,
+  );
+  if (sandboxContainerEnvIssues.length > 0) {
+    return { ok: false, issues: sandboxContainerEnvIssues };
   }
   const duplicates = findDuplicateAgentDirs(validatedConfig);
   if (duplicates.length > 0) {

--- a/src/config/validation-core.ts
+++ b/src/config/validation-core.ts
@@ -10,7 +10,7 @@ import {
   resolveAmbientOwnerAgentId,
   tryResolveAmbientOwnerAgentId,
 } from "../agents/agent-scope.js";
-import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
+import { resolveSandboxDockerEnv, resolveSandboxScope } from "../agents/sandbox/config-contract.js";
 import { getContainerEnvFileEntryIssue } from "../infra/container-env-file.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import {
@@ -328,20 +328,28 @@ function collectSandboxContainerEnvIssues(
   const authoredAgents = isRecord(sourceRaw) ? listAgentEntriesWithSource(sourceRaw) : agents;
   const authoredById = new Map(authoredAgents.map((agent) => [agent.entry.id, agent]));
 
+  const defaultSandbox = config.agents?.defaults?.sandbox;
   const effectiveAgents = agents.length > 0 ? agents : [undefined];
   for (const agent of effectiveAgents) {
-    const resolved = resolveSandboxConfigForAgent(config, agent?.entry.id);
-    if ((resolved.backend !== "docker" && resolved.backend !== "podman") || !resolved.docker.env) {
+    const agentSandbox = agent?.entry.sandbox;
+    const scope = resolveSandboxScope({ scope: agentSandbox?.scope ?? defaultSandbox?.scope });
+    const backend = agentSandbox?.backend?.trim() || defaultSandbox?.backend?.trim() || "docker";
+    if (backend !== "docker" && backend !== "podman") {
       continue;
     }
+    const env = resolveSandboxDockerEnv({
+      scope,
+      globalEnv: defaultSandbox?.docker?.env,
+      agentEnv: agentSandbox?.docker?.env,
+    });
     const authoredAgent = agent ? (authoredById.get(agent.entry.id) ?? agent) : undefined;
-    for (const [key, value] of Object.entries(resolved.docker.env)) {
+    for (const [key, value] of Object.entries(env)) {
       const reason = getContainerEnvFileEntryIssue(key, value);
       if (!reason) {
         continue;
       }
       const agentOwnsValue =
-        resolved.scope !== "shared" &&
+        scope !== "shared" &&
         authoredAgent !== undefined &&
         Object.hasOwn(authoredAgent.entry.sandbox?.docker?.env ?? {}, key);
       const pathSegments =
@@ -356,7 +364,7 @@ function collectSandboxContainerEnvIssues(
         continue;
       }
       seen.add(issueIdentity);
-      const backend = resolved.backend === "podman" ? "Podman" : "Docker";
+      const backendName = backend === "podman" ? "Podman" : "Docker";
       const remediation =
         reason === "invalid-name"
           ? `Rename key ${JSON.stringify(key)} to use letters, digits, and underscores without a leading digit.`
@@ -366,7 +374,7 @@ function collectSandboxContainerEnvIssues(
           {
             path: issuePath,
             message:
-              `${backend} sandbox backend requires portable environment names and single-line, non-NUL values because the secure env-file transport is line-delimited. ` +
+              `${backendName} sandbox backend requires portable environment names and single-line, non-NUL values because the secure env-file transport is line-delimited. ` +
               `${remediation} SSH/OpenShell backends may keep multiline values. Run openclaw doctor to report the invalid path; manual remediation is required.`,
           },
           pathSegments,

--- a/src/config/validation.sandbox-container-env.test.ts
+++ b/src/config/validation.sandbox-container-env.test.ts
@@ -1,0 +1,243 @@
+// Sandbox config validation rejects environment values the selected container transport cannot carry.
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./validation.js";
+
+describe("sandbox container environment config validation", () => {
+  it("rejects multiline default Docker environment values before runtime", () => {
+    const result = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              env: { SYNTHETIC_MULTILINE: "synthetic-first\nsynthetic-second" },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toEqual([
+        expect.objectContaining({
+          path: "agents.defaults.sandbox.docker.env.SYNTHETIC_MULTILINE",
+          message: expect.stringContaining("single-line"),
+        }),
+      ]);
+    }
+  });
+
+  it.each([
+    {
+      description: "explicit Docker multiline values",
+      backend: "docker",
+      key: "SYNTHETIC_DOCKER_MULTILINE",
+      value: "synthetic-docker-first\nsynthetic-docker-second",
+    },
+    {
+      description: "Podman multiline values",
+      backend: "podman",
+      key: "SYNTHETIC_PODMAN_MULTILINE",
+      value: "synthetic-podman-first\r\nsynthetic-podman-second",
+    },
+    {
+      description: "nonportable environment names",
+      backend: "docker",
+      key: "SYNTHETIC-BAD-NAME",
+      value: "synthetic-private-invalid-name-value",
+    },
+    {
+      description: "NUL-containing values",
+      backend: "podman",
+      key: "SYNTHETIC_NUL",
+      value: "synthetic-private-before\0synthetic-private-after",
+    },
+  ])("rejects $description without exposing environment values", ({ backend, key, value }) => {
+    const result = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: { backend, docker: { env: { [key]: value } } },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toHaveLength(1);
+      const issue = result.issues[0]!;
+      expect(issue.path).toBe(`agents.defaults.sandbox.docker.env.${key}`);
+      expect(issue.message).toContain(key);
+      expect(issue.message).toContain(backend === "podman" ? "Podman" : "Docker");
+      expect(issue.message).toContain("portable");
+      expect(issue.message).toContain("single-line");
+      expect(issue.message).toContain("NUL");
+      expect(issue.message).toContain("line-delimited");
+      expect(issue.message).toContain("openclaw doctor");
+      expect(issue.message).toContain("manual remediation");
+      expect(issue.message).toContain("SSH/OpenShell");
+      expect(issue.message).not.toContain("doctor --fix");
+      if (key === "SYNTHETIC-BAD-NAME") {
+        expect(issue.message).toContain("Rename key");
+      } else {
+        expect(issue.message).toContain("mounted file or custom image");
+      }
+      for (const fragment of value.split(/[\r\n\0]/u).filter(Boolean)) {
+        expect(issue.message).not.toContain(fragment);
+      }
+    }
+  });
+
+  it.each(["ssh", "openshell", "synthetic-plugin-backend"])(
+    "accepts multiline environment values for the %s backend",
+    (backend) => {
+      expect(
+        validateConfigObject({
+          agents: {
+            defaults: {
+              sandbox: {
+                backend,
+                docker: { env: { SYNTHETIC_REMOTE_VALUE: "synthetic-first\nsynthetic-second" } },
+              },
+            },
+          },
+        }).ok,
+      ).toBe(true);
+    },
+  );
+
+  it("accepts unused Docker defaults when every explicit agent selects a remote backend", () => {
+    const result = validateConfigObject({
+      agents: {
+        ownership: "explicit",
+        defaults: {
+          sandbox: {
+            backend: "docker",
+            docker: { env: { SYNTHETIC_UNUSED: "synthetic-first\nsynthetic-second" } },
+          },
+        },
+        entries: {
+          synthetic_ssh: { sandbox: { backend: "ssh" } },
+          synthetic_openshell: { sandbox: { backend: "openshell" } },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("reports inherited invalid defaults once for effective agent container backends", () => {
+    const result = validateConfigObject({
+      agents: {
+        ownership: "explicit",
+        defaults: {
+          sandbox: {
+            backend: "ssh",
+            docker: { env: { SYNTHETIC_INHERITED: "synthetic-first\nsynthetic-second" } },
+          },
+        },
+        entries: {
+          synthetic_docker: { sandbox: { backend: "docker" } },
+          synthetic_podman: { sandbox: { backend: "podman" } },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0]?.path).toBe("agents.defaults.sandbox.docker.env.SYNTHETIC_INHERITED");
+    }
+  });
+
+  it.each([
+    {
+      description: "keyed agent entries",
+      roster: {
+        entries: {
+          synthetic_agent: {
+            sandbox: {
+              backend: "docker",
+              docker: { env: { SYNTHETIC_AGENT_VALUE: "synthetic-first\nsynthetic-second" } },
+            },
+          },
+        },
+      },
+      path: "agents.entries.synthetic_agent.sandbox.docker.env.SYNTHETIC_AGENT_VALUE",
+    },
+    {
+      description: "legacy agent list entries",
+      roster: {
+        list: [
+          {
+            id: "synthetic_agent",
+            sandbox: {
+              backend: "podman",
+              docker: { env: { SYNTHETIC_AGENT_VALUE: "synthetic-first\nsynthetic-second" } },
+            },
+          },
+        ],
+      },
+      path: "agents.list.0.sandbox.docker.env.SYNTHETIC_AGENT_VALUE",
+    },
+  ])("points agent-owned invalid values at $description", ({ roster, path }) => {
+    const config = {
+      agents: {
+        defaults: { sandbox: { backend: "ssh" } },
+        ...roster,
+      },
+    };
+    const result = validateConfigObject(config, { sourceRaw: config });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toEqual([expect.objectContaining({ path })]);
+    }
+  });
+
+  it("ignores agent Docker environment overrides that shared scope does not use", () => {
+    const result = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            scope: "shared",
+            docker: { env: { SYNTHETIC_SHARED: "synthetic-single-line" } },
+          },
+        },
+        entries: {
+          synthetic_agent: {
+            sandbox: {
+              docker: {
+                env: { SYNTHETIC_IGNORED: "synthetic-ignored-first\nsynthetic-ignored-second" },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it.each([undefined, "docker", "podman"])(
+    "accepts portable names and single-line values for backend %s",
+    (backend) => {
+      expect(
+        validateConfigObject({
+          agents: {
+            defaults: {
+              sandbox: {
+                ...(backend ? { backend } : {}),
+                docker: {
+                  env: {
+                    SYNTHETIC_EMPTY: "",
+                    SYNTHETIC_VALUE_1: " synthetic=value 🦞 ",
+                  },
+                },
+              },
+            },
+          },
+        }).ok,
+      ).toBe(true);
+    },
+  );
+});

--- a/src/fleet/containers.runtime.test.ts
+++ b/src/fleet/containers.runtime.test.ts
@@ -22,6 +22,7 @@ const profileMocks = vi.hoisted(() => ({
     options.environmentFile,
     "cell-image",
   ]),
+  validateCellContainerProfile: vi.fn(),
   validateFleetImage: vi.fn((image: string) => image),
 }));
 
@@ -134,14 +135,21 @@ describe("fleet container runtime", () => {
       }
       environmentFiles.push(environmentFile);
       await expect(fs.readFile(environmentFile, "utf8")).resolves.toBe(
-        "OPENCLAW_GATEWAY_TOKEN=fake-value\n",
+        "AAA_FEATURE=synthetic-first\nOPENCLAW_GATEWAY_TOKEN=fake-value\nZZZ_FEATURE=synthetic-last\n",
       );
+      expect(args.join(" ")).not.toContain("fake-value");
+      expect(args.join(" ")).not.toContain("synthetic-first");
+      expect(args.join(" ")).not.toContain("synthetic-last");
       return { stdout: "", stderr: "", code: 0 };
     });
     const runtime = createFleetContainerRuntime(executor);
     const profile = {
       runtime: "podman",
-      environment: { OPENCLAW_GATEWAY_TOKEN: "fake-value" },
+      environment: {
+        ZZZ_FEATURE: "synthetic-last",
+        OPENCLAW_GATEWAY_TOKEN: "fake-value",
+        AAA_FEATURE: "synthetic-first",
+      },
     } as unknown as CellContainerProfile;
 
     await runtime.run(profile, true);
@@ -157,14 +165,14 @@ describe("fleet container runtime", () => {
       1,
       "podman",
       ["run", "--env-file", environmentFiles[0], "cell-image"],
-      { redactValues: ["fake-value"] },
+      { redactValues: ["synthetic-last", "fake-value", "synthetic-first"] },
     );
     expect(executor).toHaveBeenNthCalledWith(
       2,
       "podman",
       ["create", "--env-file", environmentFiles[1], "cell-image"],
       {
-        redactValues: ["fake-value"],
+        redactValues: ["synthetic-last", "fake-value", "synthetic-first"],
       },
     );
     await Promise.all(
@@ -172,6 +180,21 @@ describe("fleet container runtime", () => {
         await expect(fs.stat(environmentFile)).rejects.toMatchObject({ code: "ENOENT" });
       }),
     );
+  });
+
+  it("preserves fleet profile validation errors before staging an invalid environment", async () => {
+    const executor = successfulExecutor();
+    const failure = new Error("Invalid fleet cell environment entry: BAD KEY");
+    profileMocks.validateCellContainerProfile.mockImplementationOnce(() => {
+      throw failure;
+    });
+    const profile = {
+      runtime: "docker",
+      environment: { "BAD KEY": "synthetic-invalid-value" },
+    } as unknown as CellContainerProfile;
+
+    await expect(createFleetContainerRuntime(executor).run(profile, true)).rejects.toBe(failure);
+    expect(executor).not.toHaveBeenCalled();
   });
 
   it("normalizes Docker and Podman inspect output", async () => {

--- a/src/fleet/containers.runtime.ts
+++ b/src/fleet/containers.runtime.ts
@@ -1,13 +1,12 @@
 import { spawn } from "node:child_process";
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { isRecord, isStringRecord } from "@openclaw/normalization-core/record-coerce";
+import { withContainerEnvFile } from "../infra/container-env-file.js";
 import { attachChildProcessBridge } from "../process/child-process-bridge.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import {
   buildCellCreateArgs,
   buildCellRunArgs,
+  validateCellContainerProfile,
   validateFleetImage,
   type CellContainerProfile,
   type FleetContainerRuntimeName,
@@ -709,24 +708,15 @@ export function createFleetContainerRuntime(
     },
 
     async run(profile: CellContainerProfile, start: boolean): Promise<void> {
-      const tempRoot = await fs.realpath(os.tmpdir());
-      const tempDir = await fs.mkdtemp(path.join(tempRoot, "openclaw-fleet-env-"));
-      const environmentFile = path.join(tempDir, "cell.env");
-      try {
+      validateCellContainerProfile(profile);
+      await withContainerEnvFile(profile.environment, async (environmentFile) => {
         const args = start
           ? buildCellRunArgs(profile, { environmentFile })
           : buildCellCreateArgs(profile, { environmentFile });
-        const content = Object.entries(profile.environment)
-          .toSorted(([left], [right]) => left.localeCompare(right))
-          .map(([key, value]) => `${key}=${value}\n`)
-          .join("");
-        await fs.writeFile(environmentFile, content, { encoding: "utf8", mode: 0o600 });
         await execute(profile.runtime, args, {
           redactValues: Object.values(profile.environment),
         });
-      } finally {
-        await fs.rm(tempDir, { recursive: true, force: true });
-      }
+      });
     },
 
     async pull(runtime: FleetContainerRuntimeName, image: string): Promise<void> {

--- a/src/infra/container-env-file.test.ts
+++ b/src/infra/container-env-file.test.ts
@@ -1,0 +1,112 @@
+// Container environment transport keeps values private while preserving engine env-file semantics.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createContainerEnvFile, withContainerEnvFile } from "./container-env-file.js";
+
+describe("container environment transport", () => {
+  it("preserves UTF-8, spaces, equals, empty values, and surrounding whitespace in a private env file", async () => {
+    const environment = {
+      PLAIN: "synthetic-container-value",
+      SPACES: "two synthetic words",
+      EQUALS: "synthetic=left=right",
+      EMPTY: "",
+      WHITESPACE: "  synthetic padded value  ",
+      UTF8: "synthetic-🦞-環境",
+    };
+    const staged = await createContainerEnvFile(environment);
+
+    try {
+      expect(await fs.readFile(staged.path, "utf8")).toBe(
+        Object.entries(environment)
+          .toSorted(([left], [right]) => left.localeCompare(right))
+          .map(([key, value]) => `${key}=${value}\n`)
+          .join(""),
+      );
+      expect((await fs.stat(path.dirname(staged.path))).mode & 0o777).toBe(0o700);
+      expect((await fs.stat(staged.path)).mode & 0o777).toBe(0o600);
+    } finally {
+      await staged.cleanup();
+    }
+
+    await expect(fs.access(staged.path)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(path.dirname(staged.path))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(staged.cleanup()).resolves.toBeUndefined();
+  });
+
+  it.each([
+    "",
+    "1INVALID",
+    "BAD-NAME",
+    "BAD NAME",
+    "BAD=NAME",
+    "BAD\nNAME",
+    " LEADING_SPACE",
+    "TRAILING_SPACE ",
+  ])("rejects unrepresentable environment name %j without exposing its value", async (key) => {
+    const syntheticValue = "synthetic-invalid-name-sentinel";
+    const error = await createContainerEnvFile({ [key]: syntheticValue }).catch(
+      (failure: unknown) => failure,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("environment variable name");
+    expect((error as Error).message).not.toContain(syntheticValue);
+  });
+
+  it.each([
+    ["line feed", "synthetic-before\nsynthetic-after"],
+    ["carriage return", "synthetic-before\rsynthetic-after"],
+    ["CRLF", "synthetic-before\r\nsynthetic-after"],
+  ])("rejects %s values with an actionable key-only error", async (_kind, value) => {
+    const error = await createContainerEnvFile({ SYNTHETIC_MULTILINE: value }).catch(
+      (failure: unknown) => failure,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("SYNTHETIC_MULTILINE");
+    expect((error as Error).message).toContain("single-line");
+    expect((error as Error).message).toContain("--env-file");
+    expect((error as Error).message).not.toContain("synthetic-before");
+    expect((error as Error).message).not.toContain("synthetic-after");
+  });
+
+  it("rejects NUL values without exposing the rejected value", async () => {
+    const error = await createContainerEnvFile({ SYNTHETIC_NUL: "synthetic-before\0after" }).catch(
+      (failure: unknown) => failure,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("SYNTHETIC_NUL");
+    expect((error as Error).message).not.toContain("synthetic-before");
+  });
+
+  it.each(["completed", "failed"] as const)(
+    "keeps the callback env file alive until its %s operation settles",
+    async (outcome) => {
+      let stagedPath = "";
+      const operationError = new Error("synthetic callback failure");
+      const operation = withContainerEnvFile(
+        { SYNTHETIC_CALLBACK: "synthetic-callback-value" },
+        async (envFilePath) => {
+          stagedPath = envFilePath;
+          expect(await fs.readFile(envFilePath, "utf8")).toBe(
+            "SYNTHETIC_CALLBACK=synthetic-callback-value\n",
+          );
+          if (outcome === "failed") {
+            throw operationError;
+          }
+          return "synthetic callback result";
+        },
+      );
+
+      if (outcome === "failed") {
+        await expect(operation).rejects.toBe(operationError);
+      } else {
+        await expect(operation).resolves.toBe("synthetic callback result");
+      }
+      await expect(fs.access(stagedPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(path.dirname(stagedPath))).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+});

--- a/src/infra/container-env-file.ts
+++ b/src/infra/container-env-file.ts
@@ -8,21 +8,35 @@ type ContainerEnvFile = {
   cleanup: () => Promise<void>;
 };
 
+export function getContainerEnvFileEntryIssue(
+  key: string,
+  value: string,
+): "invalid-name" | "line-break" | "nul" | undefined {
+  if (normalizeEnvVarKey(key, { portable: true }) !== key) {
+    return "invalid-name";
+  }
+  if (/[\r\n]/u.test(value)) {
+    return "line-break";
+  }
+  return value.includes("\0") ? "nul" : undefined;
+}
+
 function serializeContainerEnv(env: Readonly<Record<string, string>>): string {
   let content = "";
   const entries = Object.entries(env).toSorted(([left], [right]) => left.localeCompare(right));
   for (const [key, value] of entries) {
-    if (normalizeEnvVarKey(key, { portable: true }) !== key) {
+    const issue = getContainerEnvFileEntryIssue(key, value);
+    if (issue === "invalid-name") {
       throw new Error(
         `Invalid container environment variable name ${JSON.stringify(key)}; use letters, digits, and underscores without a leading digit.`,
       );
     }
-    if (/[\r\n]/u.test(value)) {
+    if (issue === "line-break") {
       throw new Error(
         `Container environment variable ${key} must have a single-line value because Docker and Podman --env-file entries are line-delimited.`,
       );
     }
-    if (value.includes("\0")) {
+    if (issue === "nul") {
       throw new Error(`Container environment variable ${key} must not contain NUL bytes.`);
     }
     content += `${key}=${value}\n`;

--- a/src/infra/container-env-file.ts
+++ b/src/infra/container-env-file.ts
@@ -1,0 +1,70 @@
+// Owns private, short-lived environment transport for Docker and Podman commands.
+import { normalizeEnvVarKey } from "./host-env-security.js";
+import { tempWorkspace } from "./private-temp-workspace.js";
+import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
+
+type ContainerEnvFile = {
+  path: string;
+  cleanup: () => Promise<void>;
+};
+
+function serializeContainerEnv(env: Readonly<Record<string, string>>): string {
+  let content = "";
+  const entries = Object.entries(env).toSorted(([left], [right]) => left.localeCompare(right));
+  for (const [key, value] of entries) {
+    if (normalizeEnvVarKey(key, { portable: true }) !== key) {
+      throw new Error(
+        `Invalid container environment variable name ${JSON.stringify(key)}; use letters, digits, and underscores without a leading digit.`,
+      );
+    }
+    if (/[\r\n]/u.test(value)) {
+      throw new Error(
+        `Container environment variable ${key} must have a single-line value because Docker and Podman --env-file entries are line-delimited.`,
+      );
+    }
+    if (value.includes("\0")) {
+      throw new Error(`Container environment variable ${key} must not contain NUL bytes.`);
+    }
+    content += `${key}=${value}\n`;
+  }
+  return content;
+}
+
+/** Stages engine environment values outside process arguments until the caller-owned cleanup. */
+export async function createContainerEnvFile(
+  env: Readonly<Record<string, string>>,
+): Promise<ContainerEnvFile> {
+  const content = serializeContainerEnv(env);
+  const workspace = await tempWorkspace({
+    rootDir: resolvePreferredOpenClawTmpDir(),
+    prefix: "openclaw-container-env-",
+    dirMode: 0o700,
+    mode: 0o600,
+  });
+
+  try {
+    const filePath = await workspace.write("container.env", content);
+    return {
+      path: filePath,
+      cleanup: async () => {
+        await workspace.cleanup();
+      },
+    };
+  } catch (error) {
+    await workspace.cleanup().catch(() => undefined);
+    throw error;
+  }
+}
+
+/** Keeps a private container environment file alive only while its engine operation runs. */
+export async function withContainerEnvFile<T>(
+  env: Readonly<Record<string, string>>,
+  run: (filePath: string) => Promise<T>,
+): Promise<T> {
+  const file = await createContainerEnvFile(env);
+  try {
+    return await run(file.path);
+  } finally {
+    await file.cleanup();
+  }
+}

--- a/src/plugin-sdk/sandbox.ts
+++ b/src/plugin-sdk/sandbox.ts
@@ -43,6 +43,7 @@ export {
   getSandboxBackendManager,
   getSandboxBackendWorkdirResolver,
   isToolAllowed,
+  prepareSshSandboxExec,
   registerSandboxBackend,
   requireSandboxBackendFactory,
   resolveSandboxRuntimeStatus,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where environment values configured for sandboxed agents could appear in local process listings while Docker, Podman, SSH, or OpenShell commands were being launched. Browser sandbox creation also exposed generated CDP and noVNC authorization values through Docker arguments.

## Why This Change Was Made

Container create and exec paths now pass environment values through private, short-lived env files rather than value-bearing `--env` / `-e` arguments. SSH and OpenShell stage a private self-deleting remote script through a separate stdin-only SSH invocation, so command stdin and TTY behavior remain intact while environment values stay out of local and remote argv. Finalization always makes a best-effort remote cleanup before disposing the SSH session, including transport failures that exit with a normal process record.

The container env-file owner is shared with fleet containers, the obsolete Docker exec fallback is removed, and the existing Plugin SDK SSH command builders fail closed when asked to serialize a non-empty environment. The Docker create-args epoch is bumped so existing sandboxes roll through the normal recreate path.

Docker and Podman env files are line-delimited. Effective container backends now reject nonportable names, NUL, and multiline values during config validation and `openclaw doctor`, before sandbox use. Remediation is intentionally manual: rename the key, use a single-line value, or deliver multiline material through a mounted file/custom image. `doctor --fix` cannot safely infer that transformation without changing bytes or removing capability. SSH, OpenShell, and other remote backends continue to support multiline values.

AI-assisted: yes. The implementation and evidence were independently reviewed before publication.

## User Impact

Sandboxed tools continue to receive their configured environment, but those values no longer appear in engine or SSH process arguments. Operators with container-engine access can still inspect container environment metadata, as documented.

Cold sandboxes recreate automatically under the new create-args epoch. Recently used shared sandboxes keep the existing recreate guidance. Incompatible Docker/Podman entries now fail at config validation with the exact source path and key-only guidance instead of failing at the first create, recreate, or exec. Validation follows effective defaults and agent overrides, including keyed/list rosters and shared scope, without rejecting unused Docker defaults in SSH/OpenShell-only fleets.

## Evidence

Before the repair, a source-level reproduction reported all three confirmed paths as exposed: Docker create, Docker exec, and SSH argv.

Focused validation:

- 581 transport, rebase, sandbox, fleet, browser, SSH, OpenShell, and update-CLI tests passed on the healed-main head.
- 340 config compatibility and owner-boundary tests passed, followed by focused reruns of the exact 176 CLI/Doctor/infra tests that exposed the cold-import regression.
- The validation follow-up's `check:changed` plan passed formatting, production/test typechecks, lint, dead-export scans, import-cycle checks, database/schema guards, and related repository guards.
- `pnpm plugin-sdk:surface:check`, `pnpm docs:list`, and `git diff --check` passed.
- Focused security review found no new high- or medium-confidence findings.
- Mandatory branch-wide and follow-up autoreviews report no accepted/actionable P0 or P1 findings.

Live Docker proof using a real container:

```json
{"createEnvironmentDelivered":true,"localExecArgvFree":true,"remoteExecArgvFree":true,"execEnvironmentAndStdinDelivered":true,"stderrEmpty":true}
```

Live OpenSSH proof using an ephemeral real SSH server, including a multiline value and command stdin:

```json
{"localSshArgvFree":true,"remoteExecArgvFree":true,"multilineEnvironmentAndStdinDelivered":true,"stderrFreeOfSentinel":true,"remoteStagingRemoved":true}
```

Production LOC: +433/-168 (net +265) | Tests: +999/-153 | Docs: +1/-1.

The production growth establishes one private container env-file owner, one SSH staging/cleanup boundary, and pre-runtime effective-config validation. It also deletes the duplicate Docker exec fallback and reuses the scope/env merge contract between runtime and validation rather than adding a second compatibility path.
