### PR TITLE
fix(ci): narrow release validation GitHub contract

### DIFF
--- a/scripts/github/release-validation-campaign.d.mts
+++ b/scripts/github/release-validation-campaign.d.mts
@@ -18,6 +18,47 @@ export type ReleaseValidationCampaignArtifact =
       releaseUrl: string;
     };
 
+type CampaignIssue = {
+  number: number;
+  state: string;
+  title: string;
+  body?: string | null;
+  html_url: string;
+  labels?: Array<string | { name?: string | null }>;
+  pull_request?: object;
+};
+
+type RepositoryParams = { owner: string; repo: string };
+
+type CampaignIssueResponse = Promise<{ data: CampaignIssue }>;
+
+type CampaignIssuesApi = {
+  listForRepo(
+    params: RepositoryParams & { state: "open"; labels: string; per_page: number },
+  ): Promise<unknown>;
+  getLabel(params: RepositoryParams & { name: string }): Promise<unknown>;
+  createLabel(
+    params: RepositoryParams & { name: string; color: string; description: string },
+  ): Promise<unknown>;
+  createComment(
+    params: RepositoryParams & { issue_number: number; body: string },
+  ): Promise<unknown>;
+  create(
+    params: RepositoryParams & { title: string; body: string; labels: string[] },
+  ): CampaignIssueResponse;
+  update(
+    params: RepositoryParams & {
+      issue_number: number;
+      title?: string;
+      body?: string;
+      state?: "open" | "closed";
+      state_reason?: "completed";
+      labels?: string[];
+    },
+  ): CampaignIssueResponse;
+  get(params: RepositoryParams & { issue_number: number }): CampaignIssueResponse;
+};
+
 export function validateReleaseValidationCampaignArtifact(
   artifact: unknown,
   options?: {
@@ -33,17 +74,11 @@ export function validateReleaseValidationCampaignArtifact(
  * Octokit's generated types from a plain-Node script surface.
  */
 export type ReleaseValidationCampaignGitHubClient = {
-  rest: {
-    issues: {
-      get(params: Record<string, unknown>): Promise<{ data: unknown }>;
-      getLabel(params: Record<string, unknown>): Promise<unknown>;
-      createLabel(params: Record<string, unknown>): Promise<unknown>;
-      createComment(params: Record<string, unknown>): Promise<unknown>;
-      update(params: Record<string, unknown>): Promise<{ data: unknown }>;
-      listForRepo: unknown;
-    };
-  };
-  paginate(route: unknown, params: Record<string, unknown>): Promise<unknown[]>;
+  paginate(
+    method: CampaignIssuesApi["listForRepo"],
+    params: Parameters<CampaignIssuesApi["listForRepo"]>[0],
+  ): Promise<CampaignIssue[]>;
+  rest: { issues: CampaignIssuesApi };
 };
 
 export function runReleaseValidationCampaignPublish(params: {

--- a/test/scripts/release-validation-campaign.test.ts
+++ b/test/scripts/release-validation-campaign.test.ts
@@ -126,9 +126,13 @@ function harness(initialIssues: ReturnType<typeof issue>[]) {
           }
           return { data: current };
         },
-        get: async ({ issue_number }: { issue_number: number }) => ({
-          data: issues.get(issue_number),
-        }),
+        get: async ({ issue_number }: { issue_number: number }) => {
+          const current = issues.get(issue_number);
+          if (!current) {
+            throw new Error("missing issue");
+          }
+          return { data: current };
+        },
       },
     },
   };


### PR DESCRIPTION
Supersedes #129733.

## What Problem This Solves

Fixes a static-analysis ownership issue where the release-validation publisher's injected GitHub client is declared with `Record<string, unknown>` request bags and unknown responses. That makes lint green but discards the exact API contract at the boundary.

## Why This Change Was Made

Defines only the GitHub Issues methods the publisher calls, with exact request and response shapes for list, get, label, comment, create, update, and pagination. The test harness now rejects an impossible missing `issues.get` response rather than returning undefined under a non-optional contract.

This is the focused replacement requested by ClawSweeper after current `main` absorbed the separate QA fixture repair. It preserves Dallin Romney's original contribution through the commit trailer.

This PR is AI-assisted and manually reviewed.

## User Impact

No user-visible runtime behavior changes. CI and future maintenance now get a real typed GitHub boundary instead of a checker-only broad type that permits invalid request shapes to compile.

## Evidence

- Current `main` directly inspected: `ReleaseValidationCampaignGitHubClient` uses broad `Record<string, unknown>` request types and unknown responses.
- `node scripts/run-vitest.mjs test/scripts/release-validation-campaign.test.ts` — 8/8 passed.
- `node scripts/check-changed.mjs -- scripts/github/release-validation-campaign.d.mts test/scripts/release-validation-campaign.test.ts` — passed formatting, script/test typechecks, lint, and policy guards.
- `git diff --check` — passed.
- Final branch autoreview — no accepted/actionable P0/P1 findings.
- Production runtime LOC: 0. Tooling declaration: +46/-11. Tests: +7/-3.

No QA Lab fixture edits remain in this branch; those are already on `main`.