### PR TITLE
test(telegram): drop obsolete timeout dead-letter scenario

### DIFF
--- a/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
+++ b/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
@@ -115,25 +115,6 @@ function photoUpdate(params: { updateId: number; messageId: number; caption?: st
   };
 }
 
-function singletonPhotoUpdate(params: { updateId: number; messageId: number }) {
-  const update = photoUpdate(params);
-  const { media_group_id: _mediaGroupId, ...message } = update.message;
-  return { ...update, message };
-}
-
-function textUpdate(params: { updateId: number; messageId: number; text: string }) {
-  return {
-    update_id: params.updateId,
-    message: {
-      message_id: params.messageId,
-      date: 1_736_380_800 + params.messageId,
-      chat: { id: 111, type: "private" as const, first_name: "Ada" },
-      from: { id: 111, is_bot: false, first_name: "Ada" },
-      text: params.text,
-    },
-  };
-}
-
 function forwardedTextUpdate(params: { updateId: number; messageId: number; text: string }) {
   return {
     update_id: params.updateId,
@@ -153,15 +134,12 @@ function forwardedTextUpdate(params: { updateId: number; messageId: number; text
   };
 }
 
-function createBotApiTransport(params: { onGetFile?: (call: number) => Response } = {}) {
+function createBotApiTransport() {
   let getFileCall = 0;
   const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
     const url = input instanceof Request ? input.url : input instanceof URL ? input.href : input;
     if (url.includes("/getFile")) {
       getFileCall += 1;
-      if (params.onGetFile) {
-        return params.onGetFile(getFileCall);
-      }
       return new Response(
         JSON.stringify({
           ok: true,
@@ -342,84 +320,6 @@ describe("Telegram durable ingress coalescing", () => {
     activeResources.push(resources);
     return resources;
   }
-
-  it.each([
-    {
-      label: "current-message",
-      update: singletonPhotoUpdate({ updateId: 601, messageId: 1 }),
-      expectBufferedFailure: false,
-    },
-    {
-      label: "buffered media-group",
-      update: photoUpdate({ updateId: 602, messageId: 2 }),
-      expectBufferedFailure: true,
-    },
-  ])(
-    "cancels $label hydration at the claim watchdog and releases the same-chat lane",
-    async ({ update, expectBufferedFailure }) => {
-      const getFile = vi.fn(
-        () =>
-          new Response(
-            JSON.stringify({
-              ok: false,
-              error_code: 429,
-              description: "Too Many Requests: retry after 60",
-              parameters: { retry_after: 60 },
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          ),
-      );
-      const runtimeError = vi.fn();
-      const telegramTransport = createBotApiTransport({ onGetFile: getFile });
-      const { monitor } = await createMonitor({
-        telegramTransport,
-        adoptionStallTimeoutMs: 120,
-        onRuntimeError: runtimeError,
-      });
-      const nextUpdateId = update.update_id + 10;
-      const next = textUpdate({
-        updateId: nextUpdateId,
-        messageId: update.message.message_id + 10,
-        text: "next message after stalled media",
-      });
-      monitor.start();
-
-      await monitor.admit(update);
-      await vi.waitFor(() => expect(getFile).toHaveBeenCalledOnce(), {
-        timeout: 1_000,
-        interval: 5,
-      });
-      const nextAdmittedAt = Date.now();
-      await monitor.admit(next);
-      const turn = await awaitSingleDownstreamTurn();
-
-      expect(Date.now() - nextAdmittedAt).toBeLessThan(1_000);
-      expect(turn.Body).toContain("next message after stalled media");
-      expect(turn.Body).not.toContain("<media:image>");
-      const queue = openTelegramIngressQueue(spoolDir);
-      await vi.waitFor(async () => {
-        expect(await queue.listFailed?.({ limit: "all" })).toEqual([
-          expect.objectContaining({
-            id: telegramQueueEventId(update.update_id),
-            reason: "handler-timeout",
-          }),
-        ]);
-      });
-      await expect(
-        queue.enqueue(telegramQueueEventId(nextUpdateId), {} as never),
-      ).resolves.toMatchObject({ kind: "completed" });
-      if (expectBufferedFailure) {
-        await vi.waitFor(() => expect(runtimeError).toHaveBeenCalledOnce());
-      } else {
-        expect(runtimeError).not.toHaveBeenCalled();
-      }
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 50);
-      });
-      expect(getFile).toHaveBeenCalledOnce();
-      expect(downstreamTurns).toHaveBeenCalledOnce();
-    },
-  );
 
   it("coalesces album members admitted a few milliseconds apart", async () => {
     const { monitor, telegramTransport } = await createMonitor();


### PR DESCRIPTION
## Summary

Remove the Telegram coalescing scenario that still requires watchdog timeouts to dead-letter immediately and let a later same-lane message overtake them. Merged #127090 intentionally replaced that behavior with retry-in-lane-order, with coverage at the shared drain owner plus Telegram polling/webhook paths.

This is stacked on #129778 only because that PR restores the fixture mock needed to load this file; retarget to `main` after #129778 merges.

## Root cause

The scenario landed in #120706 under the old `handler-timeout` terminal-failure contract. #127090 changed the owner invariant: a claim-to-adoption timeout is guillotined, released through the shared retry disposition, and retried before its same-lane successor. The stale table therefore asserts both outcomes that are now forbidden: a `handler-timeout` dead letter and same-lane overtaking.

## Test audit

Deletion is preferable to rewriting this as duplicate implementation coverage. The current contract is already covered by `src/channels/message/ingress-drain.watchdog.test.ts`, with Telegram polling/webhook owner-boundary regressions added by #127090. The remaining coalescing suite continues to cover album/forward buffering and durable restart behavior.

## Verification

- Before: exact original-order suite loaded after #129778, 6 passed / 2 failed.
- After: `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts` — 6 passed.
- `pnpm exec oxfmt --check extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts`
- `git diff --check`
- structured autoreview: clean, patch correct (0.99).

## Diff shape

Production: 0. Tests/test support: +1/-88 (the +1 is simplification of a helper signature). No runtime behavior change.