### PR TITLE
fix(gateway): report failed chat streams as errors

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2628,8 +2628,8 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       name: "internal agent error without a provider terminal",
       fail: true,
       providerTerminal: false,
-      expected: "Error: internal error",
-      protocolError: false,
+      expected: "internal error",
+      protocolError: true,
     },
     {
       name: "internal agent error with a provider terminal",
@@ -3143,16 +3143,16 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         const choices = errorChunks.flatMap(
           (chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [],
         );
-        const errorContentChoice = choices.find(
-          (choice) =>
-            (choice.delta as Record<string, unknown> | undefined)?.content ===
-            "Error: internal error",
-        );
-        expect(errorContentChoice?.finish_reason).toBeNull();
-        const stopChoices = choices.filter((choice) => choice.finish_reason === "stop");
-        expect(stopChoices).toHaveLength(1);
-        expect(stopChoices[0]?.delta).toEqual({});
-        expect(choices.at(-1)).toEqual(stopChoices[0]);
+        expect(errorChunks.filter((chunk) => "error" in chunk)).toEqual([
+          { error: { message: "internal error", type: "api_error" } },
+        ]);
+        expect(
+          choices.some((choice) =>
+            Boolean((choice.delta as Record<string, unknown> | undefined)?.content),
+          ),
+        ).toBe(false);
+        expect(choices.some((choice) => choice.finish_reason === "stop")).toBe(false);
+        expect(errorText).not.toContain("boom");
       }
     } finally {
       // shared server

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1527,19 +1527,7 @@ export async function handleOpenAiHttpRequest(
         finishStreamWithError(terminalStreamError);
         return;
       }
-      // Runs without a producer-owned terminal retain the visible-error fallback.
-      const content = "Error: internal error";
-      writeAssistantContentChunk(res, {
-        runId,
-        model,
-        content,
-      });
-      finalUsage = {
-        prompt_tokens: 0,
-        completion_tokens: 0,
-        total_tokens: 0,
-      };
-      requestFinalize();
+      finishStreamWithError({ message: "internal error", type: "api_error" });
     } finally {
       releaseAgentRootWork?.();
       // The provider owns observed terminals; a second end would erase a failed session.


### PR DESCRIPTION
Closes #127246

## What Problem This Solves

Fixes an issue where OpenAI-compatible Chat Completions clients received a successful assistant response when an agent failed with an unclassified internal exception before emitting its own terminal event. Official OpenAI SDK clients accepted `Error: internal error` as ordinary model output, observed `finish_reason: "stop"`, and never entered their error-handling path.

## Why This Change Was Made

The Chat streaming owner already has a canonical bounded protocol-error finalizer for provider failures, invalid tool configuration, and failed agent results. Its generic exception catch retained a second terminal policy that fabricated assistant content, invented zero-token usage, and finalized the failed run successfully. Remove that duplicate success fallback and route unclassified exceptions through the existing error finalizer, matching non-streaming Chat and Responses behavior while preserving mapped-error precedence, lifecycle ownership, root-work cleanup, disconnect handling, and redaction.

Existing broader PR #123053 does not repair this specific catch path and also changes unrelated replay and ownership surfaces; this focused repair avoids those protected decisions.

## User Impact

Streaming OpenAI-compatible clients now receive one sanitized `api_error` event followed by `[DONE]` when the agent unexpectedly fails, so the official SDK rejects the failed request instead of silently presenting an internal failure as a successful assistant answer. Successful streams and provider-owned terminal errors keep their existing behavior.

## Evidence

- Frozen main baseline: `12dff762355502a9e4ddbd8b14cec1bbed6257ba`.
- Reviewed candidate head: `6a02d2fd62a383571bf822e1105e18ee63522003`.
- Failing before the owner repair: the real Gateway HTTP stream emitted no top-level error frame, and the official OpenAI SDK resolved the failed stream successfully: **2 failed, 3 passed**.
- Passing after the same focused reproduction: **5 passed**; the official SDK rejects with `{ error: { message: "internal error", type: "api_error" } }`, and the raw HTTP SSE response contains exactly one sanitized error frame and `[DONE]`, no assistant error text, no successful stop, and no private exception detail.
- Full Chat, Responses, and cross-endpoint parity regression coverage: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/gateway/openresponses-parity.test.ts` — **3 files, 140 tests passed**.
- Targeted formatting and `git diff --check` passed; production **+1/-13 (net -12 lines)**; tests **+12/-12 (net 0 lines)**.
- Fresh structured autoreview: clean, no accepted/actionable findings. Separate independent owner-boundary and frozen-head review completed before publication.
- Exact-head hosted CI must pass before native maintainer landing.

### ClawSweeper rank-up disposition

ClawSweeper reviewed the exact candidate head and reported no actionable code findings. Its request to rebase and confirm focused regression and exact-head CI before marking the PR ready is stale: the PR is already ready, the focused official-SDK/Gateway reproduction passes, all 140 owner/sibling tests pass, and exact-head CI run `32923776442` completed successfully across 147 jobs with a successful required `openclaw/ci-gate`. A rebase is intentionally skipped because neither touched file changed between the frozen base and current `main`, there is no demonstrated source conflict, and repository policy prohibits refreshing a verified green head merely because `main` advanced.
