### PR TITLE
fix: macOS setup closes without warning while verifying an existing AI connection

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -105,7 +105,9 @@ final class OnboardingAISetupModel {
 
     private func updateBusyReason() {
         // Every connection attempt must make quitting mid-setup confirmable.
-        OnboardingController.shared.busyReason = if self.phase == .testing || self.manualTesting {
+        OnboardingController.shared.busyReason = if self.phase == .testing || self.manualTesting ||
+            self.phase == .detecting && self.pendingActivationVerification
+        {
             "OpenClaw is testing your AI connection."
         } else if self.activeAuthOption != nil {
             self.isPreparingModel

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -1497,6 +1497,7 @@ struct OnboardingAISetupTests {
         #expect(!model.connected)
         #expect(model.pendingActivationVerification)
         #expect(model.phase == .detecting)
+        #expect(OnboardingController.shared.busyReason == "OpenClaw is testing your AI connection.")
 
         await model.activate(kind: "codex-cli")
         #expect(model.pendingActivationVerification)
@@ -1507,6 +1508,7 @@ struct OnboardingAISetupTests {
         #expect(model.connected)
         #expect(!model.pendingActivationVerification)
         #expect(model.selectedKind == "existing-model")
+        #expect(OnboardingController.shared.busyReason == nil)
     }
 
     @Test func `implicit model label falls through verification to automatic setup`() async throws {
@@ -1663,10 +1665,13 @@ struct OnboardingAISetupTests {
         let model = harness.model(defaults: defaults)
 
         model.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
+        #expect(OnboardingController.shared.busyReason == "OpenClaw is testing your AI connection.")
         let outcome = await model.verifyPendingConfiguredInference()
 
         #expect(!model.connected)
         #expect(model.pendingActivationVerification)
+        #expect(model.phase == .ready)
+        #expect(OnboardingController.shared.busyReason == nil)
         #expect(model.detectError?.detail == "expired login")
         #expect(outcome == .notConnected)
         #expect(isPending(defaults))


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users connecting an already-configured Gateway during macOS onboarding could close setup without confirmation while OpenClaw was actively verifying the AI connection.

## Why This Change Was Made

The onboarding model already marked resumed verification as busy, but its window-close lifecycle owner recognized only ordinary candidate tests, manual API-key verification, and provider sign-in. Recognize the existing configured-connection verification phase in that same canonical close-warning owner, while keeping ordinary discovery and an idle failed-verification retry closeable.

## User Impact

Closing onboarding now asks for confirmation while an existing AI connection is being verified. Successful completion and verification failures clear the warning normally, and users can still close setup or retry after a failed verification.

## Evidence

- Authentic pre-fix macOS owner regressions both failed because the active verification warning was `nil`; the production-backed configured-connection success and failure fixtures now verify the warning appears during verification and clears afterward.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path apps/macos --filter 'OpenClawIPCTests.(OnboardingAISetupTests|OnboardingConfiguredGatewayProbeTests|CLIInstallerTests)' --no-parallel -j 4`: **134 tests passing** across onboarding, Gateway discovery, and installation.
- `pnpm native:i18n:verify`: **4,245 localization entries unchanged**.
- Scoped SwiftFormat and strict SwiftLint checks pass; independent review and structured Codex review are clean.
- A live signed-app GUI run was unavailable in the headless test environment; the real native onboarding owner and its actual Gateway verification fixtures were exercised directly instead.
