### PR TITLE
fix(ai): report interrupted local-model streams instead of empty success

### DIFF
--- a/packages/ai/src/transports/openai-completions-stream.tool-calls.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.tool-calls.test.ts
@@ -244,7 +244,41 @@ describe("openai completions stream", () => {
     }
   });
 
-  it("keeps tool calls fail-closed through fetch wrapper when stream ends without [DONE] and without finish_reason", async () => {
+  it.each([
+    { name: "an empty response", delta: undefined, done: false, finishReason: undefined },
+    {
+      name: "a partial visible response",
+      delta: { content: "A partial answer" },
+      done: false,
+      finishReason: undefined,
+    },
+    {
+      name: "an unfinished native tool call",
+      delta: {
+        tool_calls: [
+          {
+            index: 0,
+            id: "call_loopback_nodone",
+            function: { name: "bash", arguments: '{"cmd":"echo no done"}' },
+          },
+        ],
+      },
+      done: false,
+      finishReason: undefined,
+    },
+    {
+      name: "a clean SSE terminal without finish_reason",
+      delta: { content: "A complete answer" },
+      done: true,
+      finishReason: undefined,
+    },
+    {
+      name: "an explicit finish_reason without an SSE terminal",
+      delta: { content: "A complete answer" },
+      done: false,
+      finishReason: "stop" as const,
+    },
+  ])("preserves an honest terminal outcome for $name", async ({ delta, done, finishReason }) => {
     const server = createServer((req, res) => {
       let body = "";
       req.setEncoding("utf8");
@@ -258,21 +292,12 @@ describe("openai completions stream", () => {
           "cache-control": "no-cache",
           connection: "keep-alive",
         });
-        // Emit delta.tool_calls chunk with no finish_reason
-        res.write(
-          `data: ${JSON.stringify(
-            makeCompletionsChunk({
-              tool_calls: [
-                {
-                  index: 0,
-                  id: "call_loopback_nodone",
-                  function: { name: "bash", arguments: '{"cmd":"echo no done"}' },
-                },
-              ],
-            }),
-          )}\n\n`,
-        );
-        // Close WITHOUT data: [DONE] — simulates connection drop / truncated stream
+        if (delta) {
+          res.write(`data: ${JSON.stringify(makeCompletionsChunk(delta, finishReason))}\n\n`);
+        }
+        if (done) {
+          res.write("data: [DONE]\n\n");
+        }
         res.end();
       });
     });
@@ -303,26 +328,23 @@ describe("openai completions stream", () => {
         { apiKey: "test-key" } as never,
       );
 
-      let doneReason: string | undefined;
-      const doneMessage: { content?: Array<{ type?: string }> } = {};
+      let terminalEvent: string | undefined;
       for await (const event of stream as AsyncIterable<{
         type: string;
-        reason?: string;
-        message?: { content?: Array<{ type?: string }> };
       }>) {
-        if (event.type === "done") {
-          doneReason = event.reason;
-          if (event.message) {
-            Object.assign(doneMessage, event.message);
-          }
+        if (event.type === "done" || event.type === "error") {
+          terminalEvent = event.type;
         }
       }
 
-      // EOF without [DONE] → sawStreamDONE stays false → fail-closed
-      expect(doneReason).toBe("stop");
-      const toolCallBlocks =
-        doneMessage.content?.filter((block) => block.type === "toolCall") ?? [];
-      expect(toolCallBlocks).toStrictEqual([]);
+      const result = await stream.result();
+      const cleanTerminal = done || Boolean(finishReason);
+      expect(terminalEvent).toBe(cleanTerminal ? "done" : "error");
+      expect(result.stopReason).toBe(cleanTerminal ? "stop" : "error");
+      if (!cleanTerminal) {
+        expect(result.errorMessage).toContain("Stream ended without finish_reason");
+      }
+      expect(result.content.filter((block) => block.type === "toolCall")).toStrictEqual([]);
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));

--- a/packages/ai/src/transports/openai-completions-stream.tool-calls.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.tool-calls.test.ts
@@ -337,7 +337,7 @@ describe("openai completions stream", () => {
         }
       }
 
-      const result = await stream.result();
+      const result = await (await stream).result();
       const cleanTerminal = done || Boolean(finishReason);
       expect(terminalEvent).toBe(cleanTerminal ? "done" : "error");
       expect(result.stopReason).toBe(cleanTerminal ? "stop" : "error");

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -124,7 +124,7 @@ export async function processCompletionsStream(
   const toolCallBlockIndices = new WeakMap<ToolCallBlock, number>();
   let explicitVisibleTextBlocks: Set<TextBlock> | undefined;
   const normalizeToolCallDeltas = createOpenAICompletionsToolCallDeltaNormalizer();
-  let sawStopFinishReason = false;
+  let finishReason: string | undefined;
   let sawNativeToolCallDelta = false;
   const blockIndex = () => output.content.length - 1;
   const measureUtf8Bytes = (text: string) => Buffer.byteLength(text, "utf8");
@@ -442,9 +442,7 @@ export async function processCompletionsStream(
         allowSingularToolCall: true,
       });
       output.stopReason = finishReasonResult.stopReason;
-      if (finishReasonResult.stopReason === "stop") {
-        sawStopFinishReason = true;
-      }
+      finishReason = finishReasonResult.stopReason;
       if (finishReasonResult.errorMessage) {
         output.errorMessage = finishReasonResult.errorMessage;
       }
@@ -567,22 +565,18 @@ export async function processCompletionsStream(
     emitReasoningUsageActivity(hasReasoningUsageActivity);
     await cooperativeScheduler.afterEvent();
   }
+  if (!finishReason && options?.sawStreamDONE?.() === false) {
+    throw new Error("Stream ended without finish_reason");
+  }
   flushReasoningTagTextPartitioner();
   flushDeepSeekToolCallRecovererAtEnd();
   flushDeepSeekTextFilterAtEnd();
   currentBlock = null;
   flushPendingPostToolCallDeltas();
-  // Promote complete silent tool-call-only responses when the stream finished
-  // cleanly (reached post-loop). Two paths:
-  //   sawStopFinishReason: explicit provider terminal (legacy DSML / #88791)
-  //   sawNativeToolCallDelta + sawStreamDONE: structured delta.tool_calls with
-  //     a clean SSE [DONE] terminal but no finish_reason (e.g. Evolink
-  //     DeepSeek V4). [DONE] tracking distinguishes clean termination from
-  //     connection drops (EOF without [DONE] remains fail-closed).
-  // Truncated streams throw before reaching this code.
+  // Only an explicit stop or observed SSE terminal may authorize silent tool calls.
   finalizeOpenAICompletionsToolCalls(output, {
     allowSilentToolCallPromotion:
-      sawStopFinishReason || (sawNativeToolCallDelta && (options?.sawStreamDONE?.() ?? false)),
+      finishReason === "stop" || (sawNativeToolCallDelta && (options?.sawStreamDONE?.() ?? false)),
     onConfirmedToolCall(block, contentIndex) {
       if (block.type !== "toolCall") {
         return;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running OpenAI-compatible local models through the managed Gateway could receive an empty successful answer, a silently truncated answer, or a dropped tool call when the provider disconnected before completing its response.

## Why This Change Was Made

The OpenAI SDK treats both a real SSE `[DONE]` marker and an ordinary connection EOF as the end of its iterator. The managed transport already observes the raw SSE terminal, but its stream owner only used that fact when deciding whether a tool call was executable. Consequently, interrupted empty, text, and tool responses were finalized as successful `stop` outcomes.

Record the provider finish reason in the existing canonical stream owner and require either that explicit finish reason or the existing observed `[DONE]` marker before completing a managed response. The correction removes six production lines overall. Direct package streams, internal parser callers without terminal observers, malformed-tool safeguards, cancellation, request policy, and existing provider-specific behavior retain their contracts.

## User Impact

Interrupted local-model responses now fail visibly instead of pretending that an empty, partial, or abandoned tool response succeeded. Compatible providers that omit `[DONE]` after an explicit finish reason still work, and providers that emit `[DONE]` without a finish reason still work.

## Evidence

The existing real-localhost streaming regression originally accepted a dropped tool stream as a successful empty answer. Replacing it with a table covering real HTTP/SSE streams produced three failing regressions before the fix:

```
empty response without finish_reason or [DONE]       done -> error
partial text without finish_reason or [DONE]         done -> error
unfinished tool call without finish_reason or [DONE] done -> error
clean [DONE] without finish_reason                  done -> done
explicit finish_reason without [DONE]               done -> done
```

After the owner repair, all five cases pass. A separate real-localhost replay confirmed that each interrupted response ends with `Stream ended without finish_reason` and exposes no executable tool call, while both valid terminal formats remain successful.

Focused validation passed **413 tests across 21 suites**, covering standalone and managed stream parity, encrypted and Google thought signatures, reasoning and usage contracts, DeepSeek recovery, legacy and modern tool calls, malformed arguments, provider response hooks, cancellation, request timeouts, and local HTTP streaming. Scoped formatting and lint checks passed; the final independent structured review reported no actionable findings.

Production: **+7/-13 (net -6)**. Regression tests: **+52/-30**.
