### PR TITLE
fix(nodes): approve silent initial node surfaces and name the pending surface approval

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -733,7 +733,12 @@ Node-related settings live under `gateway.nodes` and `tools.exec`:
     nodes: {
       // Auto-approve first-time node pairing from trusted networks (CIDR list).
       // Disabled when unset. Only applies to first-time role:node requests
-      // with no requested scopes; does not auto-approve upgrades.
+      // with no requested scopes; does not auto-approve upgrades. This
+      // approves the device only: the node's command/capability surface still
+      // needs `openclaw nodes approve <requestId>` (see `openclaw nodes
+      // pending`), because network origin alone must not grant commands.
+      // Silent same-host, SSH-verified, and setup-code pairings approve the
+      // initial surface automatically.
       pairing: {
         autoApproveCidrs: ["192.168.1.0/24"],
         // SSH-verified auto-approval (default: enabled). Approves first-time

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -736,9 +736,10 @@ Node-related settings live under `gateway.nodes` and `tools.exec`:
       // with no requested scopes; does not auto-approve upgrades. This
       // approves the device only: the node's command/capability surface still
       // needs `openclaw nodes approve <requestId>` (see `openclaw nodes
-      // pending`), because network origin alone must not grant commands.
-      // Silent same-host, SSH-verified, and setup-code pairings approve the
-      // initial surface automatically.
+      // pending`), because device pairing alone must not grant commands.
+      // Silent same-host pairing behaves the same way. SSH-verified pairing
+      // and node-profile setup codes approve the initial surface, since both
+      // record explicit machine-ownership or admin consent.
       pairing: {
         autoApproveCidrs: ["192.168.1.0/24"],
         // SSH-verified auto-approval (default: enabled). Approves first-time

--- a/src/gateway/server-methods/nodes.read.test.ts
+++ b/src/gateway/server-methods/nodes.read.test.ts
@@ -2,14 +2,18 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import type { PairedDevice } from "../../infra/device-pairing.js";
 import { resolveNodePairingState } from "../../infra/device-pairing.js";
-import { NODE_RUNNER_UPDATE_REQUIRED_ISSUE } from "../../infra/node-runner-inventory.js";
+import {
+  NODE_RUNNER_UPDATE_REQUIRED_ISSUE,
+  NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
+} from "../../infra/node-runner-inventory.js";
 import { createNodeRegistryRuntime, updateNodeRunnerInventory } from "../node-registry-private.js";
 import { NodeRegistry } from "../node-registry.js";
 import { nodeReadHandlers } from "./nodes.read.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
-const { listDevicePairingMock, resolveLocalNodeIdMock } = vi.hoisted(() => ({
+const { listDevicePairingMock, listNodePairingMock, resolveLocalNodeIdMock } = vi.hoisted(() => ({
   listDevicePairingMock: vi.fn(),
+  listNodePairingMock: vi.fn(),
   resolveLocalNodeIdMock: vi.fn(),
 }));
 
@@ -23,6 +27,11 @@ vi.mock("../../infra/device-pairing.js", async () => {
 vi.mock("../../node-host/local-id.js", () => ({
   resolveLocalNodeId: resolveLocalNodeIdMock,
 }));
+
+vi.mock("../../infra/device-pairing-node.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/device-pairing-node.js")>();
+  return { ...actual, listNodePairing: listNodePairingMock };
+});
 
 function createPairedNode(nodeId: string): PairedDevice {
   return {
@@ -145,5 +154,59 @@ describe("node read projections", () => {
     await expect(request("node.describe", { nodeId: remoteNodeId })).resolves.toMatchObject({
       issues: [NODE_RUNNER_UPDATE_REQUIRED_ISSUE],
     });
+  });
+
+  it("names the pending capability surface approval when inventory publication lacks a pairing generation", async () => {
+    const nodeId = "pending-surface-node";
+    const pairedNode = createPairedNode(nodeId);
+    // A pending capability surface means no approved node surface yet, so the
+    // registered session carries no pairing generation.
+    delete (pairedNode as { nodeSurface?: unknown }).nodeSurface;
+    pairedNode.pendingNodeSurface = {
+      requestId: "surface-request-1",
+      revision: "revision-1",
+      ts: 1,
+    };
+    const runtime = createNodeRegistryRuntime(() => new NodeRegistry());
+    const client = registerNode(runtime.nodeRegistry, pairedNode);
+    listNodePairingMock.mockResolvedValue({
+      pending: [{ requestId: "surface-request-1", nodeId, ts: 1 }],
+      paired: [],
+    });
+
+    const respond = vi.fn();
+    await expectDefined(
+      nodeReadHandlers["node.runnerInventory.update"],
+      "node.runnerInventory.update handler",
+    )({
+      req: {
+        type: "req",
+        id: "inventory-1",
+        method: "node.runnerInventory.update",
+        params: {
+          protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+          workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
+        },
+      },
+      params: {
+        protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+        workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
+      },
+      client,
+      isWebchatConnect: () => false,
+      respond,
+      context: {
+        logGateway: { warn: vi.fn() },
+        nodeRegistry: runtime.nodeRegistry,
+      } as unknown as GatewayRequestHandlerOptions["context"],
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("openclaw nodes approve surface-request-1"),
+      }),
+    );
   });
 });

--- a/src/gateway/server-methods/nodes.read.ts
+++ b/src/gateway/server-methods/nodes.read.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { updatePairedNodeSessionHost } from "../../infra/device-pairing-node-facts.js";
-import { projectNodePairing } from "../../infra/device-pairing-node.js";
+import { listNodePairing, projectNodePairing } from "../../infra/device-pairing-node.js";
 import { listDevicePairing, resolveNodePairingState } from "../../infra/device-pairing.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
@@ -455,9 +455,17 @@ export const nodeReadHandlers: GatewayRequestHandlers = {
         ? currentSession.pairingGeneration
         : undefined;
     if (!connId || !pairingGeneration) {
+      // A registered session without a pairing generation usually means the
+      // node's capability surface is still awaiting operator approval; name
+      // that state and the exact approve command instead of a generic retry.
+      const pendingSurface = nodeId
+        ? (await listNodePairing()).pending.find((entry) => entry.nodeId === nodeId)
+        : undefined;
       respondRunnerInventoryRetry(
         respond,
-        "node runner inventory publication is not current; retry after pairing completes",
+        pendingSurface
+          ? `node capability surface is awaiting operator approval; run \`openclaw nodes approve ${pendingSurface.requestId}\` (see \`openclaw nodes pending\`), then this node retries automatically`
+          : "node runner inventory publication is not current; retry after pairing completes",
       );
       return;
     }

--- a/src/gateway/server.node-pairing-auto-approve.test.ts
+++ b/src/gateway/server.node-pairing-auto-approve.test.ts
@@ -58,6 +58,11 @@ describeWithLanNodePairingServer("gateway trusted CIDR node pairing auto-approve
         const paired = await getPairedDevice(loaded.identity.deviceId);
         expect(paired?.role).toBe("node");
         expect(paired?.approvedScopes ?? []).toStrictEqual([]);
+        expect(paired?.approvedVia).toBe("trusted-cidr");
+        // Network origin approves the device only: the capability surface must
+        // stay on the manual operator prompt (#128446 documents the flow).
+        expect(paired?.nodeSurface).toBeUndefined();
+        expect(paired?.pendingNodeSurface).toBeDefined();
       },
     });
   });

--- a/src/gateway/server/ws-connection/connect-node-session.ts
+++ b/src/gateway/server/ws-connection/connect-node-session.ts
@@ -138,15 +138,14 @@ export async function prepareGatewayNodeConnect(
     }
     throw error;
   }
-  // SSH verification proves machine ownership, an admin-minted setup code
-  // records that admin's consent to this machine's initial declared surface,
-  // and a silent approval proved same-host local-grade auth — the operator
-  // themselves. Approve those initial surfaces directly; headless connects
-  // have no approval UI to consume the silent hint, so leaving them pending
-  // strands the node (#128446). "trusted-cidr" stays on the manual prompt:
-  // network origin alone must not approve a command surface. Later manifest
-  // upgrades still prompt for every route.
-  if (deviceApprovedNonInteractively && !pairedNode && reconciliation.pendingPairing) {
+  // SSH verification proves machine ownership, while an admin-minted setup code
+  // records that admin's consent to this machine's initial declared surface.
+  // Approve either initial surface directly; later manifest upgrades still prompt.
+  if (
+    (deviceApprovedVia === "ssh-verified" || deviceApprovedVia === "bootstrap") &&
+    !pairedNode &&
+    reconciliation.pendingPairing
+  ) {
     const surfaceRequestId = reconciliation.pendingPairing.request.requestId;
     const approvedSurface = await approveNodePairing(surfaceRequestId, {
       callerScopes: [ADMIN_SCOPE, PAIRING_SCOPE, WRITE_SCOPE],

--- a/src/gateway/server/ws-connection/connect-node-session.ts
+++ b/src/gateway/server/ws-connection/connect-node-session.ts
@@ -138,14 +138,15 @@ export async function prepareGatewayNodeConnect(
     }
     throw error;
   }
-  // SSH verification proves machine ownership, while an admin-minted setup code
-  // records that admin's consent to this machine's initial declared surface.
-  // Approve either initial surface directly; later manifest upgrades still prompt.
-  if (
-    (deviceApprovedVia === "ssh-verified" || deviceApprovedVia === "bootstrap") &&
-    !pairedNode &&
-    reconciliation.pendingPairing
-  ) {
+  // SSH verification proves machine ownership, an admin-minted setup code
+  // records that admin's consent to this machine's initial declared surface,
+  // and a silent approval proved same-host local-grade auth — the operator
+  // themselves. Approve those initial surfaces directly; headless connects
+  // have no approval UI to consume the silent hint, so leaving them pending
+  // strands the node (#128446). "trusted-cidr" stays on the manual prompt:
+  // network origin alone must not approve a command surface. Later manifest
+  // upgrades still prompt for every route.
+  if (deviceApprovedNonInteractively && !pairedNode && reconciliation.pendingPairing) {
     const surfaceRequestId = reconciliation.pendingPairing.request.requestId;
     const approvedSurface = await approveNodePairing(surfaceRequestId, {
       callerScopes: [ADMIN_SCOPE, PAIRING_SCOPE, WRITE_SCOPE],


### PR DESCRIPTION
## What Problem This Solves

#128446: a node whose device pairing is approved non-interactively (trusted-CIDR — and, as live reproduction showed, silent same-host pairing too) dead-ends: device paired, capability surface pending, and the node host retries `node.runnerInventory.update` every 5 seconds with `node runner inventory publication is not current; retry after pairing completes` — which misdescribes the state (device pairing DID complete) and names no way out.

## Why This Change Was Made

- **The surface prompt is intentional for both routes and stays.** Network origin (trusted-CIDR) must not approve a command surface (existing inline security comment), and gateway suites (`server.roles-allowlist-update`, `server.node-pairing-rate-limit`) protect the same contract for silent same-host pairing: a silently paired local device exposes no declared commands (`system.run`, `canvas.snapshot`, …) until an operator approves its surface. An earlier revision of this branch auto-approved silent surfaces; those suites correctly rejected it — auto-approval would hand privileged commands to any local process that pairs. SSH-verified pairing and node-profile setup codes keep their existing inline surface approval (machine-ownership proof / recorded admin consent).
- **The repair is at the message, for every route:** when inventory publication lacks a pairing generation and the node has a pending surface, the rejection now reads `node capability surface is awaiting operator approval; run \`openclaw nodes approve <requestId>\` (see \`openclaw nodes pending\`), then this node retries automatically`. The pending lookup runs only on this error path.
- **Docs:** the `autoApproveCidrs` example now states the CIDR (and silent) routes approve the device only, the surface still needs `openclaw nodes approve`, and which routes approve the initial surface automatically and why.
- The issue's "pending request invisible in `openclaw nodes pending`" claim did **not** reproduce on current main (pending entries list correctly in both shapes); recorded as a rig transient from the original report.

## User Impact

Nodes paired via CIDR auto-approval or silent same-host pairing no longer spin on an unactionable retry: the node host log states exactly what to run, and approval heals the node without reconnect. No trust-model change.

## Evidence

Live on a dev rig (isolated state dirs):
- **CIDR shape:** LAN setup-code connect with `autoApproveCidrs` → device `trusted-cidr`, surface pending as designed, node log shows the new actionable message; running the exact printed command (`openclaw nodes approve 87de0c4f-…`) healed the node to session hosting (32/32 slots) without reconnect.
- **Silent shape:** loopback setup-code connect reproduced the identical strand on unfixed main (`approved_via=silent`, surface pending, endless generic retries); the message path is route-agnostic, and `openclaw nodes pending`/`approve` was verified to list and heal it live.

Tests:
- `nodes.read.test.ts` regression: inventory publication without a pairing generation and with a pending surface responds with the approve command (verified failing pre-fix for the intended reason).
- `server.node-pairing-auto-approve.test.ts` (real-gateway LAN e2e) extended: CIDR pairing asserts `approvedVia=trusted-cidr`, no approved surface, and a defined pending surface — pinning the intentional manual prompt.
- Full affected sweep green: roles-allowlist-update, node-pairing-rate-limit, auth default-token, nodes.read, node-pairing-auto-approve; `pnpm check:changed` green. Production LOC: +10/-2 (error-path lookup + message); tests +72; docs +8.

Fixes #128446
