### PR TITLE
fix(workboard): persist failureCount reset to zero after a successful attempt

### DIFF
--- a/extensions/workboard/src/store-normalizers.ts
+++ b/extensions/workboard/src/store-normalizers.ts
@@ -1334,14 +1334,12 @@ export function removeUndefinedMetadataFields(metadata: WorkboardMetadata): Work
     "archivedAt",
     "stale",
     "lifecycleStatusSourceUpdatedAt",
-    "failureCount",
   ] as const) {
     const value = next[key];
-    if (
-      value === undefined ||
-      (Array.isArray(value) && value.length === 0) ||
-      (typeof value === "number" && value === 0 && key === "failureCount")
-    ) {
+    // failureCount must not be stripped when it is a literal 0: a successful
+    // attempt resets the counter, and consumers fall back to recounting stale
+    // attempts history whenever the field is absent.
+    if (value === undefined || (Array.isArray(value) && value.length === 0)) {
       delete next[key];
     }
   }

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1536,6 +1536,15 @@ describe("WorkboardStore", () => {
       },
     });
     expect(blockedAgain.metadata?.failureCount).toBe(2);
+
+    const succeeded = await store.update(card.id, {
+      execution: {
+        ...retrying.execution!,
+        status: "succeeded",
+        updatedAt: 50,
+      },
+    });
+    expect(succeeded.metadata?.failureCount).toBe(0);
   });
 
   it("adds comments, links, proof, and archive metadata", async () => {


### PR DESCRIPTION
## What Problem This Solves

A successful workboard attempt resets `failureCount` to `0` in memory, but `removeUndefinedMetadataFields` treats a literal zero as "absent" and deletes the field before the card is persisted. Consumers then cannot distinguish "never failed" from "failures recovered to zero":

- `syncExecutionAttemptMetadata` sets `failureCount = 0` on a succeeded attempt (`extensions/workboard/src/store-card-helpers.ts:105-112`) and immediately passes metadata through `removeUndefinedMetadataFields`, which strips it via the explicit `(typeof value === "number" && value === 0 && key === "failureCount")` condition (`extensions/workboard/src/store-normalizers.ts:1340-1346`).
- The Control UI's `countCardFailedAttempts` trusts the stored count only when the field is defined and otherwise recounts stale attempts history (`ui/src/lib/workboard/derived.ts`), so a card that failed twice and then succeeded keeps displaying 2 failed attempts even though the authoritative counter was reset to 0.

Tracked in #129474.

## Why This Change Was Made

Repair at the producer boundary: the reset-to-zero is real state produced by the store's own lifecycle code; the normalizer should not erase it. Every runtime reader already coalesces missing values with `?? 0`, so persisting the literal zero changes no logic — it only stops the UI fallback from contradicting persisted state.

## User Impact

Workboard cards show accurate failure recovery: after a successful retry, the displayed failed-attempt count reflects the reset (0) instead of recounting historical attempts as if the card were still failing.

## Evidence

- New assertion in `extensions/workboard/src/store.test.ts`: after the existing blocked → retry → blocked streak (failureCount 1 → 1 → 2), a succeeding update now asserts `metadata.failureCount === 0` persists through normalization. On current main this fails because the field is stripped.
- Diff scope: production change is the removal of one strip-list entry plus its special-case condition (net -3/+4 including an explanatory comment); the rest is test coverage.
