### PR TITLE
fix(huggingface): honor available provider capabilities

### DIFF
--- a/extensions/huggingface/models.test.ts
+++ b/extensions/huggingface/models.test.ts
@@ -37,6 +37,111 @@ describe("huggingface models", () => {
     const models = await discoverHuggingfaceModels("");
     expect(models).toHaveLength(HUGGINGFACE_MODEL_CATALOG.length);
     expect(models.map((m) => m.id)).toEqual(HUGGINGFACE_MODEL_CATALOG.map((m) => m.id));
+    expect(models[0]?.contextWindow).toBe(131072);
+    expect(models[0]?.compat).toBeUndefined();
+  });
+
+  it("uses the live route context for bundled models while preserving their catalog metadata", async () => {
+    const bundledModel = HUGGINGFACE_MODEL_CATALOG[0]!;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          data: [
+            {
+              id: bundledModel.id,
+              name: "Upstream name must not replace bundled metadata",
+              architecture: { input_modalities: ["text", "image"] },
+              providers: [{ context_length: 64000, supports_tools: true }],
+            },
+          ],
+        }),
+      ),
+    );
+
+    const models = await discoverHuggingfaceModels("hf_test_token");
+
+    expect(models).toEqual([{ ...bundledModel, contextWindow: 64000 }]);
+  });
+
+  it("disables tools only when every available route explicitly rejects them", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          data: [
+            {
+              id: "test/no-tools-vision",
+              architecture: { input_modalities: ["text", "image"] },
+              providers: [
+                { context_length: 96000, supports_tools: false },
+                { context_length: 64000, supports_tools: false },
+              ],
+            },
+            {
+              id: "test/mixed-routes",
+              providers: [{ supports_tools: false }, { supports_tools: true }],
+            },
+            {
+              id: "test/unknown-route",
+              providers: [{ supports_tools: false }, { context_length: 48000 }],
+            },
+            {
+              id: "test/errored-route",
+              providers: [
+                { status: "error", context_length: 262144, supports_tools: true },
+                { status: "live", context_length: 32000, supports_tools: false },
+              ],
+            },
+            { id: "test/no-routes" },
+            { id: "test/tools", providers: [{ supports_tools: true }] },
+          ],
+        }),
+      ),
+    );
+
+    const models = await discoverHuggingfaceModels("hf_test_token");
+
+    expect(
+      models.map(({ id, input, contextWindow, compat }) => ({ id, input, contextWindow, compat })),
+    ).toEqual([
+      {
+        id: "test/no-tools-vision",
+        input: ["text", "image"],
+        contextWindow: 96000,
+        compat: { supportsTools: false },
+      },
+      {
+        id: "test/mixed-routes",
+        input: ["text"],
+        contextWindow: 131072,
+        compat: undefined,
+      },
+      {
+        id: "test/unknown-route",
+        input: ["text"],
+        contextWindow: 48000,
+        compat: undefined,
+      },
+      {
+        id: "test/errored-route",
+        input: ["text"],
+        contextWindow: 32000,
+        compat: { supportsTools: false },
+      },
+      {
+        id: "test/no-routes",
+        input: ["text"],
+        contextWindow: 131072,
+        compat: undefined,
+      },
+      {
+        id: "test/tools",
+        input: ["text"],
+        contextWindow: 131072,
+        compat: undefined,
+      },
+    ]);
   });
 
   it("uses the default discovery timeout for live Hugging Face fetches", async () => {

--- a/extensions/huggingface/models.test.ts
+++ b/extensions/huggingface/models.test.ts
@@ -64,6 +64,44 @@ describe("huggingface models", () => {
     expect(models).toEqual([{ ...bundledModel, contextWindow: 64000 }]);
   });
 
+  it("limits discovered models to every available route regardless of provider order", async () => {
+    const bundledModel = HUGGINGFACE_MODEL_CATALOG[0]!;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          data: [
+            {
+              id: "Qwen/Qwen3.8-2.4T-A95B",
+              providers: [{ context_length: 1010000 }, { context_length: 262144 }],
+            },
+            {
+              id: "test/reversed-provider-order",
+              providers: [{ context_length: 262144 }, { context_length: 1010000 }],
+            },
+            {
+              id: bundledModel.id,
+              providers: [
+                { status: "error", context_length: 16000 },
+                { context_length: 96000 },
+                { context_length: 0 },
+                { context_length: 64000 },
+              ],
+            },
+          ],
+        }),
+      ),
+    );
+
+    const models = await discoverHuggingfaceModels("hf_test_token");
+
+    expect(models.map(({ id, contextWindow }) => ({ id, contextWindow }))).toEqual([
+      { id: "Qwen/Qwen3.8-2.4T-A95B", contextWindow: 262144 },
+      { id: "test/reversed-provider-order", contextWindow: 262144 },
+      { id: bundledModel.id, contextWindow: 64000 },
+    ]);
+  });
+
   it("disables tools only when every available route explicitly rejects them", async () => {
     vi.stubGlobal(
       "fetch",
@@ -108,7 +146,7 @@ describe("huggingface models", () => {
       {
         id: "test/no-tools-vision",
         input: ["text", "image"],
-        contextWindow: 96000,
+        contextWindow: 64000,
         compat: { supportsTools: false },
       },
       {

--- a/extensions/huggingface/models.test.ts
+++ b/extensions/huggingface/models.test.ts
@@ -102,7 +102,7 @@ describe("huggingface models", () => {
     ]);
   });
 
-  it("disables tools only when every available route explicitly rejects them", async () => {
+  it("disables tools whenever an available route explicitly rejects them", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
@@ -121,6 +121,10 @@ describe("huggingface models", () => {
               providers: [{ supports_tools: false }, { supports_tools: true }],
             },
             {
+              id: "test/reversed-mixed-routes",
+              providers: [{ supports_tools: true }, { supports_tools: false }],
+            },
+            {
               id: "test/unknown-route",
               providers: [{ supports_tools: false }, { context_length: 48000 }],
             },
@@ -131,7 +135,15 @@ describe("huggingface models", () => {
                 { status: "live", context_length: 32000, supports_tools: false },
               ],
             },
+            {
+              id: "test/errored-unsupported-route",
+              providers: [
+                { status: "error", supports_tools: false },
+                { status: "live", supports_tools: true },
+              ],
+            },
             { id: "test/no-routes" },
+            { id: "test/unknown-only", providers: [{}] },
             { id: "test/tools", providers: [{ supports_tools: true }] },
           ],
         }),
@@ -153,13 +165,19 @@ describe("huggingface models", () => {
         id: "test/mixed-routes",
         input: ["text"],
         contextWindow: 131072,
-        compat: undefined,
+        compat: { supportsTools: false },
+      },
+      {
+        id: "test/reversed-mixed-routes",
+        input: ["text"],
+        contextWindow: 131072,
+        compat: { supportsTools: false },
       },
       {
         id: "test/unknown-route",
         input: ["text"],
         contextWindow: 48000,
-        compat: undefined,
+        compat: { supportsTools: false },
       },
       {
         id: "test/errored-route",
@@ -168,7 +186,19 @@ describe("huggingface models", () => {
         compat: { supportsTools: false },
       },
       {
+        id: "test/errored-unsupported-route",
+        input: ["text"],
+        contextWindow: 131072,
+        compat: undefined,
+      },
+      {
         id: "test/no-routes",
+        input: ["text"],
+        contextWindow: 131072,
+        compat: undefined,
+      },
+      {
+        id: "test/unknown-only",
         input: ["text"],
         contextWindow: 131072,
         compat: undefined,

--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -132,18 +132,16 @@ function projectHuggingfaceModels(rows: readonly unknown[]): ModelDefinitionConf
     const providerWithContext = providers.find(
       (provider) => typeof provider?.context_length === "number" && provider.context_length > 0,
     );
-    const model =
-      catalogById.get(id) ??
-      ({
-        id,
-        name: displayNameFromApiEntry(entry),
-        reasoning: isReasoningModelHeuristic(id),
-        input:
-          Array.isArray(modalities) && modalities.includes("image") ? ["text", "image"] : ["text"],
-        cost: HUGGINGFACE_DEFAULT_COST,
-        contextWindow: HUGGINGFACE_DEFAULT_CONTEXT_WINDOW,
-        maxTokens: HUGGINGFACE_DEFAULT_MAX_TOKENS,
-      } satisfies ModelDefinitionConfig);
+    const model: ModelDefinitionConfig = catalogById.get(id) ?? {
+      id,
+      name: displayNameFromApiEntry(entry),
+      reasoning: isReasoningModelHeuristic(id),
+      input:
+        Array.isArray(modalities) && modalities.includes("image") ? ["text", "image"] : ["text"],
+      cost: HUGGINGFACE_DEFAULT_COST,
+      contextWindow: HUGGINGFACE_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: HUGGINGFACE_DEFAULT_MAX_TOKENS,
+    };
     models.push({
       ...model,
       contextWindow: providerWithContext?.context_length ?? model.contextWindow,

--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -33,7 +33,9 @@ type HFModelEntry = {
     input_modalities?: string[];
   };
   providers?: Array<{
+    status?: string;
     context_length?: number;
+    supports_tools?: boolean;
   }>;
 };
 
@@ -88,14 +90,7 @@ function isReasoningModelHeuristic(modelId: string): boolean {
   );
 }
 
-function inferredMetaFromModelId(id: string): { name: string; reasoning: boolean } {
-  const base = id.split("/").pop() ?? id;
-  const reasoning = isReasoningModelHeuristic(id);
-  const name = base.replace(/-/g, " ").replace(/\b(\w)/g, (c) => c.toUpperCase());
-  return { name, reasoning };
-}
-
-function displayNameFromApiEntry(entry: HFModelEntry, inferredName: string): string {
+function displayNameFromApiEntry(entry: HFModelEntry): string {
   const fromApi =
     (typeof entry.name === "string" && entry.name.trim()) ||
     (typeof entry.title === "string" && entry.title.trim()) ||
@@ -103,11 +98,11 @@ function displayNameFromApiEntry(entry: HFModelEntry, inferredName: string): str
   if (fromApi) {
     return fromApi;
   }
+  const base = entry.id.split("/").pop() ?? entry.id;
   if (typeof entry.owned_by === "string" && entry.owned_by.trim()) {
-    const base = entry.id.split("/").pop() ?? entry.id;
     return `${entry.owned_by.trim()}/${base}`;
   }
-  return inferredName;
+  return base.replace(/-/g, " ").replace(/\b(\w)/g, (c) => c.toUpperCase());
 }
 
 function readHuggingfaceModelRows(body: unknown): readonly unknown[] {
@@ -130,27 +125,31 @@ function projectHuggingfaceModels(rows: readonly unknown[]): ModelDefinitionConf
     }
     seen.add(id);
 
-    const catalogEntry = catalogById.get(id);
-    if (catalogEntry) {
-      models.push(Object.assign({}, catalogEntry));
-      continue;
-    }
-
-    const inferred = inferredMetaFromModelId(id);
     const modalities = entry?.architecture?.input_modalities;
-    const providers = Array.isArray(entry?.providers) ? entry.providers : [];
+    const providers = Array.isArray(entry?.providers)
+      ? entry.providers.filter((provider) => provider?.status !== "error")
+      : [];
     const providerWithContext = providers.find(
       (provider) => typeof provider?.context_length === "number" && provider.context_length > 0,
     );
+    const model =
+      catalogById.get(id) ??
+      ({
+        id,
+        name: displayNameFromApiEntry(entry),
+        reasoning: isReasoningModelHeuristic(id),
+        input:
+          Array.isArray(modalities) && modalities.includes("image") ? ["text", "image"] : ["text"],
+        cost: HUGGINGFACE_DEFAULT_COST,
+        contextWindow: HUGGINGFACE_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: HUGGINGFACE_DEFAULT_MAX_TOKENS,
+      } satisfies ModelDefinitionConfig);
     models.push({
-      id,
-      name: displayNameFromApiEntry(entry, inferred.name),
-      reasoning: inferred.reasoning,
-      input:
-        Array.isArray(modalities) && modalities.includes("image") ? ["text", "image"] : ["text"],
-      cost: HUGGINGFACE_DEFAULT_COST,
-      contextWindow: providerWithContext?.context_length ?? HUGGINGFACE_DEFAULT_CONTEXT_WINDOW,
-      maxTokens: HUGGINGFACE_DEFAULT_MAX_TOKENS,
+      ...model,
+      contextWindow: providerWithContext?.context_length ?? model.contextWindow,
+      ...(providers.length > 0 && providers.every((provider) => provider?.supports_tools === false)
+        ? { compat: { ...model.compat, supportsTools: false } }
+        : {}),
     });
   }
   return models;

--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -129,9 +129,9 @@ function projectHuggingfaceModels(rows: readonly unknown[]): ModelDefinitionConf
     const providers = Array.isArray(entry?.providers)
       ? entry.providers.filter((provider) => provider?.status !== "error")
       : [];
-    const providerWithContext = providers.find(
-      (provider) => typeof provider?.context_length === "number" && provider.context_length > 0,
-    );
+    const providerContexts = providers
+      .map((provider) => provider?.context_length)
+      .filter((context): context is number => typeof context === "number" && context > 0);
     const model: ModelDefinitionConfig = catalogById.get(id) ?? {
       id,
       name: displayNameFromApiEntry(entry),
@@ -144,7 +144,8 @@ function projectHuggingfaceModels(rows: readonly unknown[]): ModelDefinitionConf
     };
     models.push({
       ...model,
-      contextWindow: providerWithContext?.context_length ?? model.contextWindow,
+      contextWindow:
+        providerContexts.length > 0 ? Math.min(...providerContexts) : model.contextWindow,
       ...(providers.length > 0 && providers.every((provider) => provider?.supports_tools === false)
         ? { compat: { ...model.compat, supportsTools: false } }
         : {}),

--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -146,7 +146,7 @@ function projectHuggingfaceModels(rows: readonly unknown[]): ModelDefinitionConf
       ...model,
       contextWindow:
         providerContexts.length > 0 ? Math.min(...providerContexts) : model.contextWindow,
-      ...(providers.length > 0 && providers.every((provider) => provider?.supports_tools === false)
+      ...(providers.some((provider) => provider?.supports_tools === false)
         ? { compat: { ...model.compat, supportsTools: false } }
         : {}),
     });


### PR DESCRIPTION
## Summary

Hugging Face's inference-router catalog exposes context limits and tool support per backend, while its OpenAI-compatible endpoint chooses the fastest available backend by default and can select alternatives through routing policies or failover. Existing discovery copied the first backend's context limit and advertised tools even when an eligible backend explicitly rejected them.

Project the safe capability intersection at the owning Hugging Face discovery boundary:

- Use the smallest positive context limit across every available, non-error backend.
- Disable tools whenever any available backend explicitly reports `supports_tools: false`.
- Preserve bundled model metadata, single tool-capable routes, unknown-only capabilities, errored-route exclusion, and existing static/default fallbacks.

Production delta: +23/-25 (net -2). Focused regression coverage: +173 lines.

## Upstream contract

Hugging Face documents that its OpenAI-compatible router selects the **fastest available provider by default**, with explicit provider/policy selection and failover; it does not guarantee capability-aware routing for tool-bearing requests:

- [Hugging Face provider selection and OpenAI-compatible routing](https://huggingface.co/docs/inference-providers/index#provider-selection)
- [Hugging Face function calling and explicit provider selection](https://huggingface.co/docs/inference-providers/main/guides/function-calling#provider-selection)
- [Hugging Face router model metadata and provider-specific supports_tools](https://huggingface.co/docs/inference-providers/en/hub-api#list-openai-compatible-models)

The live public catalog confirms why a union is unsafe: `meta-llama/Llama-3.1-8B-Instruct` advertises Novita at approximately 168 tokens/second with `supports_tools: false`, while its tool-capable DeepInfra backend reaches approximately 30 tokens/second. The documented default therefore selects the explicitly incompatible backend unless a capable provider is pinned.

## Verification

- Queried the live unauthenticated public router catalog and passed its response through the actual production discovery owner: **134 models**, including **31** with at least one available route explicitly rejecting tools and **five** mixing tool-capable and tool-incapable routes.
- Passed discovered live models through the real OpenAI-completions request builder: mixed-route Llama and GPT-OSS requests omit unsupported tool payloads; the single tool-capable DeepSeek R1 route retains its tools.
- Verified real context corrections: Qwen `1,010,000 -> 262,144`; Gemma `262,144 -> 131,072`; DeepSeek V4 `1,048,576 -> 512,000`; bundled default DeepSeek R1 remains `64,000`.
- Captured fail-first owner regressions for both mixed-route orders and false-plus-unknown routes, then proved reversed route order, errored negative routes, unknown-only routes, positive-only routes, no-route/static fallback, bundled metadata, and existing policy/provider suffix behavior.
- Ran six discovery, provider, transport, and agent suites: **86 tests passed**.
- Targeted type-aware lint, formatting, `git diff --check`, and fresh independent local plus complete-branch P1 reviews passed.
- No authenticated account, user token, paid request, external mutation, or local user service was used.

## Risk

Low: existing plugin-owned model projection only; no configuration, authentication, request-schema, storage, migration, or model-default changes. The conservative intersection resolves both ClawSweeper concerns without assuming an undocumented upstream router capability.
