### PR TITLE
fix(models): avoid retired automatic auth-probe models

### DIFF
--- a/src/commands/models/list.probe.models.ts
+++ b/src/commands/models/list.probe.models.ts
@@ -1,5 +1,5 @@
 /** Model candidate normalization and catalog selection for auth probes. */
-import { expectDefined } from "@openclaw/normalization-core";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { normalizeProviderId, parseModelRef } from "../../agents/model-selection.js";
 import { DEFAULT_PROVIDER } from "./shared.js";
 
@@ -20,7 +20,7 @@ export function buildProbeCandidateMap(modelCandidates: string[]): Map<string, s
   return map;
 }
 
-function catalogProbePriority(provider: string, modelId: string): number {
+function probePriority(provider: string, modelId: string): number {
   const id = modelId.trim().toLowerCase();
   if (provider !== "anthropic") {
     return 50;
@@ -50,21 +50,20 @@ function catalogProbePriority(provider: string, modelId: string): number {
 export function selectProbeModel(params: {
   provider: string;
   candidates: Map<string, string[]>;
-  catalog: Array<{ provider: string; id: string }>;
+  catalog: Array<Pick<ModelCatalogEntry, "provider" | "id" | "status">>;
 }): { provider: string; model: string } | null {
   const { provider, candidates, catalog } = params;
-  const direct = candidates.get(provider);
-  if (direct && direct.length > 0) {
-    return { provider, model: expectDefined(direct[0], "direct entry at 0") };
+  const direct = candidates.get(provider)?.[0];
+  if (direct) {
+    return { provider, model: direct };
   }
   const fromCatalog = catalog
-    .map((entry, index) => ({ entry, index }))
-    .filter(({ entry }) => normalizeProviderId(entry.provider) === provider)
-    .toSorted((left, right) => {
-      const priority =
-        catalogProbePriority(provider, left.entry.id) -
-        catalogProbePriority(provider, right.entry.id);
-      return priority || left.index - right.index;
-    })[0]?.entry;
+    .filter(
+      (entry) =>
+        normalizeProviderId(entry.provider) === provider &&
+        entry.status !== "deprecated" &&
+        entry.status !== "disabled",
+    )
+    .toSorted((a, b) => probePriority(provider, a.id) - probePriority(provider, b.id))[0];
   return fromCatalog ? { provider, model: fromCatalog.id } : null;
 }

--- a/src/commands/models/list.probe.ollama.test.ts
+++ b/src/commands/models/list.probe.ollama.test.ts
@@ -1,11 +1,15 @@
 // Ollama probe planning tests cover keyless runtime auth and provider-scoped catalog reads.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { buildProbeCandidateMap, selectProbeModel } from "./list.probe.models.js";
 
-const loadPreparedModelCatalog = vi.fn(async () => [
-  { provider: "ollama", id: "llama3.2:latest" },
-  { provider: "ollama", id: "gemma4:latest" },
-]);
+const loadPreparedModelCatalog = vi.fn(
+  async (): Promise<Array<Pick<ModelCatalogEntry, "provider" | "id" | "status">>> => [
+    { provider: "ollama", id: "llama3.2:latest" },
+    { provider: "ollama", id: "gemma4:latest" },
+  ],
+);
 
 vi.mock("../../agents/prepared-model-catalog.js", () => ({ loadPreparedModelCatalog }));
 vi.mock("../../agents/auth-profiles.js", () => ({
@@ -141,5 +145,144 @@ describe("Ollama probe targets", () => {
         useRuntimeAuth: true,
       }),
     ]);
+  });
+
+  it("builds an automatic Ollama probe with the first non-retired catalog model", async () => {
+    loadPreparedModelCatalog.mockResolvedValueOnce([
+      { provider: "ollama", id: "kimi-k2.5", status: "deprecated" },
+      { provider: "ollama", id: "kimi-k2.6" },
+    ]);
+
+    const plan = await buildProbeTargets({
+      cfg: {
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "http://127.0.0.1:11434",
+              api: "ollama",
+              models: [],
+            },
+          },
+        },
+      },
+      providers: ["ollama"],
+      modelCandidates: [],
+      options,
+    });
+
+    expect(plan.results).toEqual([]);
+    expect(plan.targets).toEqual([
+      expect.objectContaining({
+        provider: "ollama",
+        model: { provider: "ollama", model: "kimi-k2.6" },
+      }),
+    ]);
+  });
+});
+
+type ProbeModelScenario = {
+  name: string;
+  provider: string;
+  catalog: Array<Pick<ModelCatalogEntry, "provider" | "id" | "status">>;
+  requestedModels?: string[];
+  expectedModel: string | null;
+};
+
+const probeModelScenarios: ProbeModelScenario[] = [
+  {
+    name: "skips the retired Ollama Cloud catalog model",
+    provider: "ollama-cloud",
+    catalog: [
+      { provider: "ollama-cloud", id: "kimi-k2.5", status: "deprecated" },
+      { provider: "ollama-cloud", id: "kimi-k2.6" },
+    ],
+    expectedModel: "kimi-k2.6",
+  },
+  {
+    name: "skips the retired Tencent preview in favor of its replacement",
+    provider: "tencent-tokenhub",
+    catalog: [
+      { provider: "tencent-tokenhub", id: "hy3-preview", status: "deprecated" },
+      { provider: "tencent-tokenhub", id: "hy3" },
+    ],
+    expectedModel: "hy3",
+  },
+  {
+    name: "skips disabled automatic catalog candidates",
+    provider: "ollama",
+    catalog: [
+      { provider: "ollama", id: "disabled-model", status: "disabled" },
+      { provider: "ollama", id: "available-model", status: "available" },
+    ],
+    expectedModel: "available-model",
+  },
+  {
+    name: "keeps available preview models eligible",
+    provider: "ollama",
+    catalog: [
+      { provider: "ollama", id: "preview-model", status: "preview" },
+      { provider: "ollama", id: "available-model", status: "available" },
+    ],
+    expectedModel: "preview-model",
+  },
+  {
+    name: "reports no model when every automatic candidate is retired",
+    provider: "ollama",
+    catalog: [
+      { provider: "ollama", id: "deprecated-model", status: "deprecated" },
+      { provider: "ollama", id: "disabled-model", status: "disabled" },
+    ],
+    expectedModel: null,
+  },
+  {
+    name: "preserves an explicitly selected retired model",
+    provider: "ollama-cloud",
+    requestedModels: ["ollama-cloud/kimi-k2.5"],
+    catalog: [
+      { provider: "ollama-cloud", id: "kimi-k2.5", status: "deprecated" },
+      { provider: "ollama-cloud", id: "kimi-k2.6" },
+    ],
+    expectedModel: "kimi-k2.5",
+  },
+  {
+    name: "does not prioritize a retired Anthropic Haiku over a live Sonnet",
+    provider: "anthropic",
+    catalog: [
+      { provider: "anthropic", id: "claude-haiku-4-5-20251001", status: "deprecated" },
+      { provider: "anthropic", id: "claude-sonnet-4-6", status: "available" },
+    ],
+    expectedModel: "claude-sonnet-4-6",
+  },
+  {
+    name: "preserves the Anthropic Haiku probe priority among eligible models",
+    provider: "anthropic",
+    catalog: [
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      { provider: "anthropic", id: "claude-haiku-4-5" },
+      { provider: "anthropic", id: "claude-haiku-4-5-20251001" },
+    ],
+    expectedModel: "claude-haiku-4-5-20251001",
+  },
+  {
+    name: "preserves catalog order for equally prioritized eligible models",
+    provider: "ollama",
+    catalog: [
+      { provider: "ollama", id: "retired-model", status: "deprecated" },
+      { provider: "ollama", id: "first-live-model" },
+      { provider: "ollama", id: "second-live-model" },
+    ],
+    expectedModel: "first-live-model",
+  },
+];
+
+describe("automatic probe model lifecycle", () => {
+  it.each(probeModelScenarios)("$name", ({ provider, catalog, requestedModels, expectedModel }) => {
+    expect(
+      selectProbeModel({
+        provider,
+        candidates: buildProbeCandidateMap(requestedModels ?? []),
+        catalog,
+      }),
+    ).toEqual(expectedModel === null ? null : { provider, model: expectedModel });
   });
 });


### PR DESCRIPTION
Supersedes #128116 with full credit to @Finn763. Related: #124689; that broader report also contains an independent model-picker issue and must remain open.

## What Problem This Solves

Fixes an issue where users running provider authentication probes would see a valid Ollama Cloud or Tencent credential reported unhealthy when the provider's first catalog model had already been retired. The real Ollama Cloud catalog lists deprecated `kimi-k2.5` before available `kimi-k2.6`; Tencent TokenHub similarly lists deprecated `hy3-preview` before available `hy3`.

## Why This Change Was Made

The shared automatic auth-probe selector was discarding model lifecycle metadata before selecting the first provider catalog row. Retain that existing metadata and skip only `deprecated` or `disabled` rows for automatic selection, matching the established model-catalog visibility owner. Explicitly selected retired models remain available, preview models remain eligible, Anthropic's existing probe priorities are preserved, and stable sorting keeps provider-declared catalog order. Removing the redundant indexed sorting wrappers reduces production code by one line.

This credited replacement reconstructs @Finn763's reviewed change directly on trusted current `main`: the original external-fork branch was more than 200 commits behind and its exact-head CI failed on unrelated, already-repaired skill-prompt tests. No contributor-controlled code was executed locally.

## User Impact

Ollama Cloud auth probes choose live `kimi-k2.6` instead of retired `kimi-k2.5`; Tencent TokenHub probes choose live `hy3` instead of retired `hy3-preview`. Explicit operator-selected models, including historically shipped retired models, are unchanged. Other providers inherit the same lifecycle-safe automatic selection without a new setting, API, or provider-specific branch.

## Evidence

- Trusted current-main regression before the owner fix: **7 failed, 38 passed** across the real probe-target caller and shared selector; failures cover actual Ollama and Tencent manifest ordering, disabled rows, all-retired catalogs, retired Anthropic priority, and same-priority catalog order.
- Exact same focused suites after the owner fix: **45 passed** (`src/commands/models/list.probe.ollama.test.ts` and `src/commands/models/list.probe.targets.test.ts`).
- The contributor's existing real, authenticated Ollama before/after proof used the same provider configuration and credential: before, `ollama-cloud/kimi-k2.5` returned model-not-found; after, `ollama-cloud/kimi-k2.6` completed with status `ok`. Credentials were redacted; this replacement does not claim to have repeated that authenticated run.
- Existing public compatibility is covered: explicit retired selections still win, `preview` and unspecified statuses remain eligible, the all-retired case returns `no_model`, Anthropic priority remains unchanged, and stable ties preserve manifest order.
- Formatter, scoped lint, diff checks, and independent source reviews passed. Production: **+13/-14 (net -1)**; tests: **+147/-4**.

Original diagnosis and contribution: @Finn763.
