### PR TITLE
fix(ui): show rejected WhatsApp actions without stalled refreshes

### DIFF
--- a/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
+++ b/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
@@ -137,6 +137,65 @@ suite.define(() => {
     );
   });
 
+  it("shows rejected WhatsApp login immediately without waiting for channel status", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { height: 900, width: 1280 } },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "channels.status": {
+              ts: Date.now(),
+              channelOrder: ["whatsapp"],
+              channelLabels: { whatsapp: "WhatsApp" },
+              channels: {
+                whatsapp: { configured: true, linked: true, running: true, connected: true },
+              },
+              channelAccounts: {},
+              channelDefaultAccountId: {},
+            },
+            "channels.pairing.list": {
+              accounts: [],
+              requests: [],
+              commandOwnerConfigured: true,
+              limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
+            },
+          },
+        });
+
+        expect((await page.goto(`${suite.server.baseUrl}settings/channels`))?.status()).toBe(200);
+        await page.locator(".channels-item", { hasText: "WhatsApp" }).first().click();
+        const detail = page.locator(".channels-detail");
+        const relink = detail.getByRole("button", { name: "Relink" });
+        await relink.waitFor();
+        const statusReadsBefore = (await gateway.getRequests("channels.status")).length;
+        await gateway.deferNext("channels.status", { probe: true });
+        await gateway.deferNext("web.login.start");
+
+        await relink.click();
+        await gateway.waitForRequest("web.login.start");
+        await gateway.rejectDeferred("web.login.start", {
+          code: "INVALID_REQUEST",
+          message: "WhatsApp login rejected",
+        });
+
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(
+              uiProofArtifactDir,
+              `whatsapp-mutation-${process.env.OPENCLAW_UI_PROOF_LABEL ?? "rejected"}.png`,
+            ),
+          });
+        }
+        await expect.poll(() => detail.textContent()).toContain("WhatsApp login rejected");
+        await expect.poll(() => relink.isEnabled()).toBe(true);
+        expect(await gateway.getRequests("channels.status")).toHaveLength(statusReadsBefore);
+      },
+    );
+  });
+
   it("confirms the explicit default account and preserves a no-op logout", async () => {
     await suite.withPage(
       {

--- a/ui/src/lib/channels/index.test.ts
+++ b/ui/src/lib/channels/index.test.ts
@@ -329,9 +329,64 @@ describe("channels controller WhatsApp logout", () => {
     expect(channels.state.whatsappLoginMessage).toBe("credential cleanup failed");
     expect(channels.state.whatsappLoginQrDataUrl).toBe("data:image/png;base64,current-qr");
     expect(channels.state.whatsappLoginConnected).toBe(true);
-    expect(request.mock.calls.filter(([method]) => method === "channels.status")).toHaveLength(1);
+    expect(request.mock.calls.filter(([method]) => method === "channels.status")).toHaveLength(0);
     channels.dispose();
   });
+});
+
+describe("channels controller WhatsApp mutation failures", () => {
+  it.each([
+    {
+      operation: "login",
+      method: "web.login.start",
+      invoke: (channels: ReturnType<typeof createChannelCapability>) =>
+        channels.startWhatsApp(false),
+      preservesQr: false,
+    },
+    {
+      operation: "scan wait",
+      method: "web.login.wait",
+      invoke: (channels: ReturnType<typeof createChannelCapability>) => channels.waitWhatsApp(),
+      preservesQr: true,
+    },
+    {
+      operation: "logout",
+      method: "channels.logout",
+      invoke: (channels: ReturnType<typeof createChannelCapability>) => channels.logoutWhatsApp(),
+      preservesQr: true,
+    },
+  ])(
+    "publishes a rejected $operation without probing channel status",
+    async ({ method, invoke, preservesQr }) => {
+      const request = vi.fn(async (requestedMethod: string) => {
+        if (requestedMethod === method) {
+          throw new Error("WhatsApp request rejected");
+        }
+        return createChannelsSnapshot("unexpected refresh");
+      });
+      const channels = createChannelCapability({
+        snapshot: { client: { request }, phase: "connected" },
+        subscribe: () => () => undefined,
+      } as never);
+      channels.state.whatsappLoginQrDataUrl = "data:image/png;base64,current-qr";
+      channels.state.whatsappLoginConnected = true;
+      const updates: Array<{ busy: boolean; message: string | null }> = [];
+      channels.subscribe((state) => {
+        updates.push({ busy: state.whatsappBusy, message: state.whatsappLoginMessage });
+      });
+
+      await invoke(channels);
+
+      expect(
+        request.mock.calls.filter(([requestedMethod]) => requestedMethod === "channels.status"),
+      ).toHaveLength(0);
+      expect(updates.at(-1)).toEqual({ busy: false, message: "WhatsApp request rejected" });
+      expect(channels.state.whatsappLoginQrDataUrl).toBe(
+        preservesQr ? "data:image/png;base64,current-qr" : null,
+      );
+      channels.dispose();
+    },
+  );
 });
 
 describe("channels controller DM pairing", () => {

--- a/ui/src/lib/channels/index.ts
+++ b/ui/src/lib/channels/index.ts
@@ -469,12 +469,12 @@ async function startWhatsAppLogin(
     state.whatsappLoginQrDataUrl = res.qrDataUrl ?? null;
     state.whatsappLoginConnected = typeof res.connected === "boolean" ? res.connected : null;
   } catch (err) {
-    if (!isCurrentWhatsAppOperation(state, operation)) {
-      return false;
+    if (isCurrentWhatsAppOperation(state, operation)) {
+      state.whatsappLoginMessage = formatUiError(err);
+      state.whatsappLoginQrDataUrl = null;
+      state.whatsappLoginConnected = null;
     }
-    state.whatsappLoginMessage = formatUiError(err);
-    state.whatsappLoginQrDataUrl = null;
-    state.whatsappLoginConnected = null;
+    return false;
   } finally {
     if (isCurrentWhatsAppOperation(state, operation)) {
       state.whatsappBusy = false;
@@ -510,11 +510,11 @@ async function waitWhatsAppLogin(state: ChannelsState, accountId?: string): Prom
       state.whatsappLoginQrDataUrl = null;
     }
   } catch (err) {
-    if (!isCurrentWhatsAppOperation(state, operation)) {
-      return false;
+    if (isCurrentWhatsAppOperation(state, operation)) {
+      state.whatsappLoginMessage = formatUiError(err);
+      state.whatsappLoginConnected = null;
     }
-    state.whatsappLoginMessage = formatUiError(err);
-    state.whatsappLoginConnected = null;
+    return false;
   } finally {
     if (isCurrentWhatsAppOperation(state, operation)) {
       state.whatsappBusy = false;
@@ -544,10 +544,10 @@ async function logoutWhatsApp(state: ChannelsState, accountId?: string): Promise
       state.whatsappLoginMessage = t("channels.whatsapp.logoutNotCleared");
     }
   } catch (err) {
-    if (!isCurrentWhatsAppOperation(state, operation)) {
-      return false;
+    if (isCurrentWhatsAppOperation(state, operation)) {
+      state.whatsappLoginMessage = formatUiError(err);
     }
-    state.whatsappLoginMessage = formatUiError(err);
+    return false;
   } finally {
     if (isCurrentWhatsAppOperation(state, operation)) {
       state.whatsappBusy = false;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators reconnecting WhatsApp, waiting for a QR scan, or logging out would see disabled controls and no explanation after the Gateway rejected their request when a subsequent channel-status probe stalled.

## Why This Change Was Made

All three WhatsApp operations caught Gateway rejections but incorrectly reported successful completion to their shared capability owner. That launched an unnecessary status refresh and postponed the state publication that displays the failure. Rejected operations now return failure while retaining their existing stale-operation checks, sanitized errors, QR-state behavior, and lifecycle cleanup; only successful operations refresh channel status.

## User Impact

Rejected WhatsApp login, scan-wait, and logout actions now show their error immediately and re-enable their controls without waiting for an unrelated status probe. Existing reconnection, authorization, disposal, and successful-mutation behavior remains unchanged.

## Evidence

Before the fix, the login rejection is invisible and Relink remains disabled:

![Before: rejected WhatsApp login leaves controls disabled and displays no error](https://github.com/user-attachments/assets/2d8a9af6-079f-4317-a0fb-46db2bf3c9aa)

After the fix, the rejection is visible immediately and Relink is enabled for retry:

![After: WhatsApp login rejection is visible and controls are enabled](https://github.com/user-attachments/assets/fa7f3ef6-6b5d-41d1-b6f1-bf175e92acf2)

- Red-before: four owner-boundary regressions failed for login, scan-wait, logout, and the existing stale logout expectation; real Chromium independently reproduced the invisible error while its status probe remained unresolved.
- `node scripts/run-vitest.mjs ui/src/lib/channels/index.test.ts` — 22 passed, including every affected mutation and existing stale-client/reconnect/disposal paths.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/channels-whatsapp-logout.e2e.test.ts` — five real Chromium scenarios passed.
- `pnpm tsgo:ui` — passed.
- `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 pnpm check:changed` — comprehensive changed-file gate passed.
- Independent structured Codex full-diff review: clean.
- Production delta: +12/-12, net zero; test coverage added separately.
