### PR TITLE
fix(discord): preserve explicit replies on thread-bound sessions

### DIFF
--- a/extensions/discord/src/channel.message-adapter.test.ts
+++ b/extensions/discord/src/channel.message-adapter.test.ts
@@ -8,8 +8,11 @@ import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   createDiscordOutboundHoisted,
   installDiscordOutboundModuleSpies,
+  mockDiscordBoundThreadManager,
   resetDiscordOutboundMocks,
 } from "./outbound-adapter.test-harness.js";
+import { sendMessageDiscord } from "./send.outbound.js";
+import { makeDiscordRest, requestBody } from "./send.test-harness.js";
 
 const hoisted = createDiscordOutboundHoisted();
 await installDiscordOutboundModuleSpies(hoisted);
@@ -74,6 +77,38 @@ function requirePollSender(
 describe("discord channel message adapter", () => {
   beforeEach(() => {
     resetDiscordOutboundMocks(hoisted);
+  });
+
+  it("delivers explicit replies through Discord's native message endpoint on bound threads", async () => {
+    mockDiscordBoundThreadManager(hoisted);
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValue({ id: "thread-1", type: 0 });
+    postMock.mockResolvedValue({ id: "native-reply-1", channel_id: "thread-1" });
+    const cfg = { channels: { discord: { token: "fixture-token" } } };
+
+    const result = await requireTextSender(requireDiscordMessageAdapter())({
+      cfg,
+      to: "channel:parent-1",
+      text: "native reply",
+      accountId: "default",
+      threadId: "thread-1",
+      replyToId: "parent-message-1",
+      replyToIdSource: "explicit",
+      replyToMode: "off",
+      deps: {
+        discord: async (to, text, options) =>
+          await sendMessageDiscord(to, text, { ...options, cfg, rest, token: "fixture-token" }),
+      },
+    });
+
+    expect(hoisted.sendWebhookMessageDiscordMock).not.toHaveBeenCalled();
+    expect(postMock).toHaveBeenCalledOnce();
+    expect(requestBody(postMock)).toMatchObject({
+      content: "native reply",
+      message_reference: { message_id: "parent-message-1", fail_if_not_exists: false },
+    });
+    expect(result.receipt.replyToId).toBe("parent-message-1");
+    expect(result.receipt.parts[0]?.replyToId).toBe("parent-message-1");
   });
 
   it("backs declared durable-final capabilities with outbound send proofs", async () => {

--- a/extensions/discord/src/channel.message-adapter.test.ts
+++ b/extensions/discord/src/channel.message-adapter.test.ts
@@ -96,7 +96,7 @@ describe("discord channel message adapter", () => {
       replyToIdSource: "explicit",
       replyToMode: "off",
       deps: {
-        discord: async (to, text, options) =>
+        discord: async (...[to, text, options]: Parameters<typeof sendMessageDiscord>) =>
           await sendMessageDiscord(to, text, { ...options, cfg, rest, token: "fixture-token" }),
       },
     });

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -190,7 +190,7 @@ describe("discordOutbound", () => {
     },
   );
 
-  it("uses webhook persona delivery for bound thread text replies", async () => {
+  it("uses webhook persona delivery for bound thread messages without native replies", async () => {
     mockDiscordBoundThreadManager(hoisted);
     const cfg = {
       channels: {
@@ -206,7 +206,6 @@ describe("discordOutbound", () => {
       text: "hello from persona",
       accountId: "default",
       threadId: "thread-1",
-      replyToId: "reply-1",
       identity: {
         name: "Codex",
         avatarUrl: "https://example.com/avatar.png",
@@ -225,7 +224,6 @@ describe("discordOutbound", () => {
     expect(options.webhookToken).toBe("tok-1");
     expect(options.accountId).toBe("default");
     expect(options.threadId).toBe("thread-1");
-    expect(options.replyTo).toBe("reply-1");
     expect(options.username).toBe("Codex");
     expect(options.avatarUrl).toBe("https://example.com/avatar.png");
     expect(options.cfg).toBe(cfg);
@@ -236,6 +234,53 @@ describe("discordOutbound", () => {
       target: { kind: "channel", id: "thread-1" },
     });
   });
+
+  it("keeps webhook persona delivery when an implicit off-mode reply was suppressed", async () => {
+    mockDiscordBoundThreadManager(hoisted);
+
+    await discordOutbound.sendText?.({
+      cfg: {},
+      to: "channel:parent-1",
+      text: "hello from persona",
+      accountId: "default",
+      threadId: "thread-1",
+      replyToIdSource: "implicit",
+      replyToMode: "off",
+    });
+
+    expect(hoisted.sendWebhookMessageDiscordMock).toHaveBeenCalledOnce();
+    expect(hoisted.sendMessageDiscordMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "explicit default-off", replyToIdSource: "explicit", replyToMode: "off", scope: "all" },
+    { name: "implicit first", replyToIdSource: "implicit", replyToMode: "first", scope: "first" },
+    { name: "source-omitted", replyToIdSource: undefined, replyToMode: undefined, scope: "all" },
+  ] as const)(
+    "preserves $name native replies in webhook-bound threads",
+    async ({ replyToIdSource, replyToMode, scope }) => {
+      mockDiscordBoundThreadManager(hoisted);
+
+      const result = await discordOutbound.sendText?.({
+        cfg: {},
+        to: "channel:parent-1",
+        text: "native reply",
+        accountId: "default",
+        threadId: "thread-1",
+        replyToId: "reply-1",
+        replyToIdSource,
+        replyToMode,
+      });
+
+      expect(hoisted.sendWebhookMessageDiscordMock).not.toHaveBeenCalled();
+      expectDiscordThreadBotSend({
+        hoisted,
+        text: "native reply",
+        result,
+        options: { reply: { messageId: "reply-1", scope } },
+      });
+    },
+  );
 
   it("keeps webhook persona usernames on a UTF-16 boundary", async () => {
     mockDiscordBoundThreadManager(hoisted);

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -73,7 +73,6 @@ async function maybeSendDiscordWebhookText(params: {
   threadId?: string | number | null;
   accountId?: string | null;
   identity?: OutboundIdentity;
-  replyToId?: string | null;
   onPlatformSendDispatch?: () => Promise<void>;
 }): Promise<{ messageId: string; channelId: string } | null> {
   if (params.threadId == null) {
@@ -103,7 +102,6 @@ async function maybeSendDiscordWebhookText(params: {
     accountId: binding.accountId,
     threadId: binding.threadId,
     cfg: params.cfg,
-    replyTo: params.replyToId ?? undefined,
     username: persona.username,
     avatarUrl: persona.avatarUrl,
     onPlatformSendDispatch: params.onPlatformSendDispatch,
@@ -186,7 +184,8 @@ export const discordOutbound: ChannelOutboundAdapter = {
   ...createAttachedChannelResultAdapter({
     channel: "discord",
     sendText: async (ctx) => {
-      if (!ctx.silent) {
+      // Execute Webhook cannot create native replies; those require the bot message endpoint.
+      if (!ctx.silent && !ctx.replyToId) {
         let webhookSelected = false;
         try {
           const webhookResult = await maybeSendDiscordWebhookText({
@@ -195,7 +194,6 @@ export const discordOutbound: ChannelOutboundAdapter = {
             threadId: ctx.threadId,
             accountId: ctx.accountId,
             identity: ctx.identity,
-            replyToId: ctx.replyToId,
             onPlatformSendDispatch: ctx.onPlatformSendDispatch
               ? async () => {
                   webhookSelected = true;

--- a/extensions/discord/src/send.webhook.ts
+++ b/extensions/discord/src/send.webhook.ts
@@ -36,7 +36,6 @@ type DiscordWebhookSendOpts = {
   webhookToken: string;
   accountId?: string;
   threadId?: string | number;
-  replyTo?: string;
   username?: string;
   avatarUrl?: string;
   wait?: boolean;
@@ -116,8 +115,6 @@ export async function sendWebhookMessageDiscord(
     throw new Error("Discord webhook id/token are required");
   }
 
-  const replyTo = normalizeOptionalString(opts.replyTo) ?? "";
-  const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
   const { account, proxyFetch } = resolveDiscordClientAccountContext({
     cfg: opts.cfg,
     accountId: opts.accountId,
@@ -166,7 +163,6 @@ export async function sendWebhookMessageDiscord(
             username: normalizeOptionalString(opts.username),
             avatar_url: normalizeOptionalString(opts.avatarUrl),
             ...(flags ? { flags } : {}),
-            ...(messageReference ? { message_reference: messageReference } : {}),
           }),
           signal: deadline.signal,
         });
@@ -208,7 +204,6 @@ export async function sendWebhookMessageDiscord(
       fallbackChannelId: opts.threadId ? String(opts.threadId) : "",
       kind: "text",
       ...(opts.threadId != null ? { threadId: opts.threadId } : {}),
-      ...(replyTo ? { replyToId: replyTo } : {}),
     });
     const resultConversationId = result.channelId.trim();
     if (result.messageId !== "unknown" && resultConversationId) {


### PR DESCRIPTION
## What Problem This Solves

Fixes explicit Discord replies silently disappearing in thread-bound sessions because OpenClaw attempted to send unsupported native reply fields through Discord's Execute Webhook API.

## Why This Change Was Made

Discord's installed API contract supports native message references only on the normal bot message endpoint, not the webhook endpoint. The channel delivery owner now routes surviving explicit or otherwise effective replies through the existing bot sender and deletes the obsolete unsupported webhook reply plumbing.

## User Impact

Explicit reply tags and first-reply behavior correctly create native Discord replies in bound threads. Ordinary messages and suppressed implicit replies still retain their existing webhook persona behavior.

## Evidence

- Direct installed Discord API types independently confirm that webhook payloads do not accept native message references while bot message payloads do.
- Four authentic pre-fix owner and actual SDK-to-provider request regressions failed across explicit default-off replies, implicit first replies, source-omitted replies, and the real message adapter.
- All 105 focused Discord delivery, SDK, webhook, native reply, and thread-binding tests pass across seven suites.
- Production delta: two lines added and nine removed; formatting, focused type-aware lint, and fresh complete-diff structured P1 autoreview pass.
- Existing webhook personas, thread bindings, authorization, and reply-policy filtering remain unchanged.
