### PR TITLE
refactor(cli): simplify Gateway fallback and hook state ownership

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2412,7 +2412,7 @@ src/cli/gateway-cli/qa-parent-watchdog.ts	3
 src/cli/gateway-cli/register.ts	4
 src/cli/gateway-cli/run.ts	12
 src/cli/gateway-cli/suspend-cli.ts	2
-src/cli/hooks-cli.ts	2
+src/cli/hooks-cli.ts	1
 src/cli/logs-cli.ts	1
 src/cli/mcp-cli.ts	1
 src/cli/models-cli.ts	19

--- a/src/cli/gateway-rpc.ts
+++ b/src/cli/gateway-rpc.ts
@@ -4,6 +4,7 @@ import type {
   GatewayClientMode,
   GatewayClientName,
 } from "../../packages/gateway-protocol/src/client-info.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { OperatorScope } from "../gateway/operator-scopes.js";
 import type { DeviceIdentity } from "../infra/device-identity.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
@@ -53,6 +54,33 @@ export async function callGatewayFromCli(
 export async function isImplicitLocalGatewayTargetFromCli(opts: GatewayRpcOpts): Promise<boolean> {
   const runtime = await loadGatewayRpcRuntime();
   return await runtime.isImplicitLocalGatewayTargetFromCliRuntime(opts);
+}
+
+/** Local fallback is safe only for unavailable or explicitly supported older local Gateways. */
+export async function canFallbackToImplicitLocalGateway(params: {
+  config: OpenClawConfig;
+  error: unknown;
+  legacyMethod?: string;
+  legacyAgentId?: boolean;
+}): Promise<boolean> {
+  const gateway = await import("../gateway/call.js");
+  const { isGatewayRpcUnavailableError } = await import("../gateway/transport-error.js");
+  const { config, error, legacyMethod, legacyAgentId } = params;
+  const isLegacyError =
+    legacyMethod !== undefined &&
+    gateway.isGatewayClientRequestError(error) &&
+    error.gatewayCode === "INVALID_REQUEST" &&
+    (error.message === `unknown method: ${legacyMethod}` ||
+      (legacyAgentId === true &&
+        (error.message === `invalid ${legacyMethod} params: unexpected property agentId` ||
+          error.message ===
+            `invalid ${legacyMethod} params: at root: unexpected property 'agentId'`)));
+  return (
+    (gateway.isGatewayCredentialsRequiredError(error) ||
+      isGatewayRpcUnavailableError(error) ||
+      isLegacyError) &&
+    (await gateway.isImplicitLocalGatewayTarget({ config }))
+  );
 }
 
 /** Internal CLI facade for callers that need transport or auth policy overrides. */

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -14,7 +14,6 @@ import {
 } from "../agents/agent-scope.js";
 import { getRuntimeConfig, readConfigFileSnapshot, replaceConfigFile } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { isGatewayRpcUnavailableError } from "../gateway/transport-error.js";
 import {
   buildWorkspaceHookStatus,
   type HookStatusEntry,
@@ -31,6 +30,7 @@ import { summarizeStringEntries } from "../shared/string-sample.js";
 import { resolveOptionFromCommand } from "./cli-utils.js";
 import { formatCliCommand } from "./command-format.js";
 import { ExpectedCliError, rethrowExpectedCliError } from "./failure-output.js";
+import { canFallbackToImplicitLocalGateway } from "./gateway-rpc.js";
 import {
   formatHookInfo,
   formatHookMissingSummary,
@@ -111,12 +111,7 @@ function buildHooksReport(config: OpenClawConfig, target: HooksReportTarget): Ho
 async function loadHooksReport(agentId?: string): Promise<HookStatusReport> {
   const config = getRuntimeConfig({ skipPluginValidation: true });
   const target = resolveHooksReportTarget(config, agentId);
-  const {
-    callGateway,
-    isGatewayClientRequestError,
-    isGatewayCredentialsRequiredError,
-    isImplicitLocalGatewayTarget,
-  } = await import("../gateway/call.js");
+  const { callGateway } = await import("../gateway/call.js");
   try {
     return await callGateway<HookStatusReport>({
       config,
@@ -127,20 +122,13 @@ async function loadHooksReport(agentId?: string): Promise<HookStatusReport> {
       mode: GATEWAY_CLIENT_MODES.CLI,
     });
   } catch (error) {
-    const isLegacyHookReport =
-      isGatewayClientRequestError(error) &&
-      error.gatewayCode === "INVALID_REQUEST" &&
-      (error.message === "unknown method: hooks.status" ||
-        /^invalid hooks\.status params: (?:unexpected property agentId|at root: unexpected property 'agentId')$/u.test(
-          error.message,
-        ));
     if (
-      !(
-        isGatewayCredentialsRequiredError(error) ||
-        isGatewayRpcUnavailableError(error) ||
-        isLegacyHookReport
-      ) ||
-      !(await isImplicitLocalGatewayTarget({ config }))
+      !(await canFallbackToImplicitLocalGateway({
+        config,
+        error,
+        legacyMethod: "hooks.status",
+        legacyAgentId: true,
+      }))
     ) {
       throw error;
     }
@@ -196,30 +184,6 @@ function resolveHookForToggle(
   return hook;
 }
 
-function buildConfigWithHookEnabled(params: {
-  config: OpenClawConfig;
-  hookName: string;
-  enabled: boolean;
-  ensureHooksEnabled?: boolean;
-}): OpenClawConfig {
-  const entries = { ...params.config.hooks?.internal?.entries };
-  entries[params.hookName] = { ...entries[params.hookName], enabled: params.enabled };
-
-  const internal = {
-    ...params.config.hooks?.internal,
-    ...(params.ensureHooksEnabled ? { enabled: true } : {}),
-    entries,
-  };
-
-  return {
-    ...params.config,
-    hooks: {
-      ...params.config.hooks,
-      internal,
-    },
-  };
-}
-
 function writeHooksOutput(value: string, json: boolean | undefined): void {
   if (json) {
     defaultRuntime.writeStdout(value);
@@ -248,50 +212,39 @@ async function runOneShotHooksCliAction(
   // runCli finishes shared teardown and drains both output streams.
   requestExitAfterOneShotOutput(defaultRuntime, exitCode);
 }
-async function enableHook(hookName: string, agentId?: string): Promise<void> {
+async function setHookEnabled(hookName: string, enabled: boolean, agentId?: string): Promise<void> {
   const snapshot = await readConfigFileSnapshot();
   const config = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
   const hook = resolveHookForToggle(
     buildHooksReport(config, resolveHooksReportTarget(config, agentId)),
     hookName,
-    { requireEligible: true },
+    { requireEligible: enabled },
   );
-  const nextConfig = buildConfigWithHookEnabled({
-    config,
-    hookName: hook.hookKey,
-    enabled: true,
-    ensureHooksEnabled: true,
-  });
+  const entries = { ...config.hooks?.internal?.entries };
+  entries[hook.hookKey] = { ...entries[hook.hookKey], enabled };
+  const nextConfig: OpenClawConfig = {
+    ...config,
+    hooks: {
+      ...config.hooks,
+      internal: {
+        ...config.hooks?.internal,
+        ...(enabled ? { enabled: true } : {}),
+        entries,
+      },
+    },
+  };
 
   await replaceConfigFile({
     nextConfig,
     ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
   });
-  defaultRuntime.log(
-    `${theme.success("✓")} Enabled hook: ${hook.emoji ? `${hook.emoji} ${theme.command(hook.name)}` : decorativePrefix("🔗", theme.command(hook.name))}`,
-  );
-}
-
-async function disableHook(hookName: string, agentId?: string): Promise<void> {
-  const snapshot = await readConfigFileSnapshot();
-  const config = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
-  const hook = resolveHookForToggle(
-    buildHooksReport(config, resolveHooksReportTarget(config, agentId)),
-    hookName,
-  );
-  const nextConfig = buildConfigWithHookEnabled({
-    config,
-    hookName: hook.hookKey,
-    enabled: false,
-  });
-
-  await replaceConfigFile({
-    nextConfig,
-    ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
-  });
-  defaultRuntime.log(
-    `${theme.warn(decorativePrefix("⏸", "Disabled hook:"))} ${hook.emoji ? `${hook.emoji} ${theme.command(hook.name)}` : decorativePrefix("🔗", theme.command(hook.name))}`,
-  );
+  const prefix = enabled
+    ? `${theme.success("✓")} Enabled hook:`
+    : theme.warn(decorativePrefix("⏸", "Disabled hook:"));
+  const name = hook.emoji
+    ? `${hook.emoji} ${theme.command(hook.name)}`
+    : decorativePrefix("🔗", theme.command(hook.name));
+  defaultRuntime.log(`${prefix} ${name}`);
 }
 
 export function registerHooksCli(program: Command): void {
@@ -371,7 +324,7 @@ export function registerHooksCli(program: Command): void {
     .option("--agent <id>", "Agent id whose workspace to inspect")
     .action(async (name, _opts: { agent?: string }, command: Command) =>
       runOneShotHooksCliAction(async () => {
-        await enableHook(name, resolveHooksAgentOption(command));
+        await setHookEnabled(name, true, resolveHooksAgentOption(command));
       }),
     );
 
@@ -381,7 +334,7 @@ export function registerHooksCli(program: Command): void {
     .option("--agent <id>", "Agent id whose workspace to inspect")
     .action(async (name, _opts: { agent?: string }, command: Command) =>
       runOneShotHooksCliAction(async () => {
-        await disableHook(name, resolveHooksAgentOption(command));
+        await setHookEnabled(name, false, resolveHooksAgentOption(command));
       }),
     );
 

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -16,7 +16,6 @@ import {
 } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveGatewayPort } from "../config/paths.js";
-import { isGatewayRpcUnavailableError } from "../gateway/transport-error.js";
 import { CLAWHUB_TRUST_ERROR_CODE } from "../infra/clawhub-install-trust.js";
 import {
   CLAWHUB_SKILLS_SH_REF_PREFIX,
@@ -73,6 +72,7 @@ import { resolveClawHubRiskAcknowledgementCliOptions } from "./clawhub-risk-ackn
 import { resolveOptionFromCommand, runCommandWithRuntime } from "./cli-utils.js";
 import { inheritOptionFromParent } from "./command-options.js";
 import { formatCliJsonFailure } from "./failure-output.js";
+import { canFallbackToImplicitLocalGateway } from "./gateway-rpc.js";
 import { resolveInstallPolicyWarningAcknowledgementCliOptions } from "./install-policy-warning-acknowledgement.js";
 import { parseStrictPositiveIntOption } from "./program/helpers.js";
 import { setCommandJsonMode } from "./program/json-mode.js";
@@ -145,6 +145,22 @@ const GATEWAY_SKILLS_OFFLINE_LOCK_TIMEOUT_MS = 250;
 // Apply can await evaluator, proposal-change, and skill-change hook phases.
 const GATEWAY_SKILLS_APPLY_TIMEOUT_MS = 1_850_000;
 
+async function callSkillsGateway<T>(params: {
+  config: ResolvedSkillsWorkspace["config"];
+  method: string;
+  params: Record<string, unknown>;
+  timeoutMs?: number;
+  requiredMethods?: string[];
+}): Promise<T> {
+  const { callGateway } = await import("../gateway/call.js");
+  return await callGateway<T>({
+    timeoutMs: GATEWAY_SKILLS_STATUS_TIMEOUT_MS,
+    clientName: GATEWAY_CLIENT_NAMES.CLI,
+    mode: GATEWAY_CLIENT_MODES.CLI,
+    ...params,
+  });
+}
+
 function normalizeExplicitAgentId(agentId?: string): string | undefined {
   const normalizedAgentId = agentId?.trim();
   if (agentId !== undefined && !normalizedAgentId) {
@@ -188,36 +204,20 @@ async function loadSkillsStatusReport(
   options?: ResolveSkillsWorkspaceOptions,
 ): Promise<SkillStatusReport> {
   const resolved = resolveSkillsWorkspace({ ...options, skipPluginValidation: true });
-  const {
-    callGateway,
-    isGatewayClientRequestError,
-    isGatewayCredentialsRequiredError,
-    isImplicitLocalGatewayTarget,
-  } = await import("../gateway/call.js");
   try {
-    return await callGateway<SkillStatusReport>({
+    return await callSkillsGateway<SkillStatusReport>({
       config: resolved.config,
       method: "skills.status",
       params: { agentId: resolved.agentId },
-      timeoutMs: GATEWAY_SKILLS_STATUS_TIMEOUT_MS,
-      clientName: GATEWAY_CLIENT_NAMES.CLI,
-      mode: GATEWAY_CLIENT_MODES.CLI,
     });
   } catch (error) {
-    const isLegacySkillReport =
-      isGatewayClientRequestError(error) &&
-      error.gatewayCode === "INVALID_REQUEST" &&
-      (error.message === "unknown method: skills.status" ||
-        /^invalid skills\.status params: (?:unexpected property agentId|at root: unexpected property 'agentId')$/u.test(
-          error.message,
-        ));
     if (
-      !(
-        isGatewayCredentialsRequiredError(error) ||
-        isGatewayRpcUnavailableError(error) ||
-        isLegacySkillReport
-      ) ||
-      !(await isImplicitLocalGatewayTarget({ config: resolved.config }))
+      !(await canFallbackToImplicitLocalGateway({
+        config: resolved.config,
+        error,
+        legacyMethod: "skills.status",
+        legacyAgentId: true,
+      }))
     ) {
       throw error;
     }
@@ -426,17 +426,12 @@ async function withOfflineGatewayLock<T>(
   action: () => T | Promise<T>,
 ): Promise<T> {
   const { acquireGatewayLock } = await import("../infra/gateway-lock.js");
-  let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
-  try {
-    lock = await acquireGatewayLock({
-      allowInTests: true,
-      port: resolveGatewayPort(config, process.env),
-      role: "skill-workshop-apply",
-      timeoutMs: GATEWAY_SKILLS_OFFLINE_LOCK_TIMEOUT_MS,
-    });
-  } catch {
-    throw gatewayError;
-  }
+  const lock = await acquireGatewayLock({
+    allowInTests: true,
+    port: resolveGatewayPort(config, process.env),
+    role: "skill-workshop-apply",
+    timeoutMs: GATEWAY_SKILLS_OFFLINE_LOCK_TIMEOUT_MS,
+  }).catch(() => undefined);
   if (!lock) {
     throw gatewayError;
   }
@@ -454,34 +449,19 @@ async function callSkillCurator<T>(
   loadLocal: () => T,
 ): Promise<T> {
   const config = getRuntimeConfig();
-  const {
-    callGateway,
-    isGatewayClientRequestError,
-    isGatewayCredentialsRequiredError,
-    isImplicitLocalGatewayTarget,
-  } = await import("../gateway/call.js");
   try {
-    return await callGateway<T>({
+    return await callSkillsGateway<T>({
       config,
       method: `skills.curator.${method}`,
       params,
-      timeoutMs: GATEWAY_SKILLS_STATUS_TIMEOUT_MS,
-      clientName: GATEWAY_CLIENT_NAMES.CLI,
-      mode: GATEWAY_CLIENT_MODES.CLI,
     });
   } catch (error) {
-    const isLegacyCuratorStatus =
-      method === "status" &&
-      isGatewayClientRequestError(error) &&
-      error.gatewayCode === "INVALID_REQUEST" &&
-      error.message === `unknown method: skills.curator.${method}`;
     if (
-      !(
-        isGatewayCredentialsRequiredError(error) ||
-        isGatewayRpcUnavailableError(error) ||
-        isLegacyCuratorStatus
-      ) ||
-      !(await isImplicitLocalGatewayTarget({ config }))
+      !(await canFallbackToImplicitLocalGateway({
+        config,
+        error,
+        ...(method === "status" ? { legacyMethod: "skills.curator.status" } : {}),
+      }))
     ) {
       throw error;
     }
@@ -489,10 +469,6 @@ async function callSkillCurator<T>(
       ? loadLocal()
       : await withOfflineGatewayLock(config, error, loadLocal);
   }
-}
-
-async function loadSkillCuratorStatus(): Promise<SkillCuratorStatus> {
-  return await callSkillCurator("status", {}, getSkillCuratorStatus);
 }
 
 async function runSkillCuratorMutation(method: "pin" | "restore" | "unpin", skill: string) {
@@ -511,26 +487,18 @@ async function runSkillProposalApply(
   resolved: ResolvedSkillsWorkspace,
   proposalId: string,
 ): Promise<SkillProposalApplyResult> {
-  const { callGateway, isGatewayCredentialsRequiredError, isImplicitLocalGatewayTarget } =
-    await import("../gateway/call.js");
   let proposal: SkillProposalReadResult;
   try {
     // Decide offline fallback before dispatching the non-idempotent mutation.
     // Once a Gateway answers, apply failures must never be replayed locally.
-    proposal = await callGateway<SkillProposalReadResult>({
+    proposal = await callSkillsGateway<SkillProposalReadResult>({
       config: resolved.config,
       method: "skills.proposals.inspect",
       params: { agentId: resolved.agentId, proposalId },
-      timeoutMs: GATEWAY_SKILLS_STATUS_TIMEOUT_MS,
-      clientName: GATEWAY_CLIENT_NAMES.CLI,
-      mode: GATEWAY_CLIENT_MODES.CLI,
       requiredMethods: ["skills.proposals.apply"],
     });
   } catch (err) {
-    if (
-      !(isGatewayCredentialsRequiredError(err) || isGatewayRpcUnavailableError(err)) ||
-      !(await isImplicitLocalGatewayTarget({ config: resolved.config }))
-    ) {
+    if (!(await canFallbackToImplicitLocalGateway({ config: resolved.config, error: err }))) {
       throw err;
     }
 
@@ -553,7 +521,7 @@ async function runSkillProposalApply(
     });
   }
 
-  return await callGateway<SkillProposalApplyResult>({
+  return await callSkillsGateway<SkillProposalApplyResult>({
     config: resolved.config,
     method: "skills.proposals.apply",
     params: {
@@ -562,8 +530,6 @@ async function runSkillProposalApply(
       expectedRevisionHash: proposal.revisionHash,
     },
     timeoutMs: GATEWAY_SKILLS_APPLY_TIMEOUT_MS,
-    clientName: GATEWAY_CLIENT_NAMES.CLI,
-    mode: GATEWAY_CLIENT_MODES.CLI,
   });
 }
 
@@ -572,16 +538,12 @@ async function runSkillProposalEvaluate(
   proposalId: string,
   correlationId?: string,
 ): Promise<SkillProposalEvaluateResult> {
-  const { callGateway } = await import("../gateway/call.js");
-  const proposal = await callGateway<SkillProposalReadResult>({
+  const proposal = await callSkillsGateway<SkillProposalReadResult>({
     config: resolved.config,
     method: "skills.proposals.inspect",
     params: { agentId: resolved.agentId, proposalId },
-    timeoutMs: GATEWAY_SKILLS_STATUS_TIMEOUT_MS,
-    clientName: GATEWAY_CLIENT_NAMES.CLI,
-    mode: GATEWAY_CLIENT_MODES.CLI,
   });
-  return await callGateway<SkillProposalEvaluateResult>({
+  return await callSkillsGateway<SkillProposalEvaluateResult>({
     config: resolved.config,
     method: "skills.proposals.evaluate",
     params: {
@@ -591,8 +553,6 @@ async function runSkillProposalEvaluate(
       ...(correlationId ? { correlationId } : {}),
     },
     timeoutMs: GATEWAY_SKILLS_EVALUATION_TIMEOUT_MS,
-    clientName: GATEWAY_CLIENT_NAMES.CLI,
-    mode: GATEWAY_CLIENT_MODES.CLI,
   });
 }
 
@@ -1013,7 +973,7 @@ export function registerSkillsCli(program: Command) {
 
   const showCuratorStatus = async (opts: { json?: boolean }, command: Command) => {
     await runCommandWithRuntime(defaultRuntime, async () => {
-      const status = await loadSkillCuratorStatus();
+      const status = await callSkillCurator("status", {}, getSkillCuratorStatus);
       if (hasJsonOutput(opts) || inheritOptionFromParent<boolean>(command, "json")) {
         defaultRuntime.writeJson(status);
         return;


### PR DESCRIPTION
Related: #117567

## What Problem This Solves

Skills and Hooks repeatedly implement the same Gateway fallback decisions, while Hook enable and disable maintain duplicate configuration-mutation paths. The duplication makes future regressions in explicit Gateway authority, offline discovery, and ownership-safe mutation unnecessarily likely.

## Why This Change Was Made

Consolidate exact offline and older-Gateway eligibility in the existing lazy CLI Gateway facade, centralize repeated Skills RPC request envelopes, and give Hook toggling one canonical read/modify/write owner. Preserve configured and environment-selected Gateway authority, credential-free local discovery, exact legacy read compatibility, exclusive mutation locking, CLI identity, timeout behavior, and cold-start import boundaries. Production code decreases by 59 lines and the Hook assertion-safety baseline drops from two assertions to one.

## User Impact

No intentional behavior change. Skills, Hooks, curator operations, and Workshop proposals keep their current behavior while their shared ownership rules become smaller and less likely to diverge.

## Evidence

- 371 existing focused Gateway, CLI, Hook, Skills, curator, Workshop, and real-process regression tests passed without changing or deleting tests.
- Real isolated CLI/Gateway proof: credential-free discovery returned 55 Skills and five Hooks; an explicitly unreachable Gateway failed visibly; a real token-authenticated Gateway passed health and remote Skills discovery; active Gateway ownership prevented unauthenticated local Workshop mutation.
- Production and affected CLI-test typechecks, targeted lint, formatting, assertion-safety/max-lines ratchets, dead-export scans, plugin boundaries, dependency guards, and runtime import-cycle checks passed.
- The full local core-test typecheck also reaches unrelated UI code whose shared local dependency installation lacks pako declarations; exact-head hosted CI provides the clean-install check for that existing machine-local gap.
- Final independent structured code review reported no P0 or P1 findings.
