### PR TITLE
fix(browser): preserve response-body timeout diagnostics

### DIFF
--- a/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
@@ -93,7 +93,7 @@ describe("browser action input file/download commands", () => {
         timeoutMs: 45000,
       },
     });
-    expect(getLastRequestOptions()?.timeoutMs).toBeGreaterThan(45000);
+    expect(getLastRequestOptions()?.timeoutMs).toBe(50000);
   });
 
   it("keeps the outer waitfordownload request open for the advertised default wait", async () => {
@@ -101,7 +101,7 @@ describe("browser action input file/download commands", () => {
 
     await program.parseAsync(["browser", "waitfordownload"], { from: "user" });
 
-    expect(getLastRequestOptions()?.timeoutMs).toBeGreaterThan(120000);
+    expect(getLastRequestOptions()?.timeoutMs).toBe(125000);
   });
 
   it("accepts signed and zero-padded download timeouts", async () => {
@@ -111,7 +111,7 @@ describe("browser action input file/download commands", () => {
       from: "user",
     });
 
-    expect(getLastRequestOptions()?.timeoutMs).toBeGreaterThan(25_000);
+    expect(getLastRequestOptions()?.timeoutMs).toBe(30000);
   });
 
   it("uses custom download timeouts as the inner wait plus outer slack", async () => {
@@ -124,7 +124,7 @@ describe("browser action input file/download commands", () => {
       },
     );
 
-    expect(getLastRequestOptions()?.timeoutMs).toBeGreaterThan(25000);
+    expect(getLastRequestOptions()?.timeoutMs).toBe(30000);
   });
 
   it("rejects non-decimal file and download timeouts before dispatch", async () => {

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.ts
@@ -7,6 +7,7 @@ import {
   BROWSER_TAB_REFERENCE_HELP,
   callBrowserRequest,
   parseBrowserPositiveIntegerOption,
+  withBrowserActionTimeoutSlack,
   type BrowserParentOpts,
 } from "../browser-cli-shared.js";
 import {
@@ -15,7 +16,7 @@ import {
   resolveExistingUploadPaths,
   shortenHomePath,
 } from "../core-api.js";
-import { resolveBrowserActionContext, withBrowserActionTimeoutSlack } from "./shared.js";
+import { resolveBrowserActionContext } from "./shared.js";
 
 const DEFAULT_BROWSER_HOOK_TIMEOUT_MS = 120000;
 

--- a/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
@@ -3,9 +3,11 @@
  */
 import fs from "node:fs/promises";
 import type { Command } from "commander";
-import { addTimerTimeoutGraceMs } from "openclaw/plugin-sdk/number-runtime";
-import { BROWSER_ACTION_TRANSPORT_SLACK_MS } from "../../browser/act-policy.js";
-import { callBrowserRequest, type BrowserParentOpts } from "../browser-cli-shared.js";
+import {
+  callBrowserRequest,
+  withBrowserActionTimeoutSlack,
+  type BrowserParentOpts,
+} from "../browser-cli-shared.js";
 import {
   danger,
   defaultRuntime,
@@ -18,18 +20,6 @@ type BrowserActionContext = {
   parent: BrowserParentOpts;
   profile: string | undefined;
 };
-
-const DEFAULT_BROWSER_ACTION_TIMEOUT_MS = 20000;
-
-/** Adds gateway slack to a Browser action timeout so route work can finish cleanly. */
-export function withBrowserActionTimeoutSlack(timeoutMs: number | undefined): number {
-  return (
-    addTimerTimeoutGraceMs(
-      timeoutMs ?? DEFAULT_BROWSER_ACTION_TIMEOUT_MS,
-      BROWSER_ACTION_TRANSPORT_SLACK_MS,
-    ) ?? 1
-  );
-}
 
 /** Resolves inherited Browser action context from a commander command. */
 export function resolveBrowserActionContext(

--- a/extensions/browser/src/cli/browser-cli-actions-observe.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-observe.test.ts
@@ -85,22 +85,40 @@ describe("browser action observe commands", () => {
     expect(mocks.callBrowserRequest).not.toHaveBeenCalled();
   });
 
-  it("passes responsebody limits through to the request and outer timeout", async () => {
-    const program = createActionObserveProgram();
+  it.each([
+    {
+      label: "default",
+      timeout: undefined,
+      operationTimeoutMs: undefined,
+      requestTimeoutMs: 25000,
+    },
+    { label: "minimum explicit", timeout: "1", operationTimeoutMs: 1, requestTimeoutMs: 5001 },
+    {
+      label: "signed explicit",
+      timeout: "+030000",
+      operationTimeoutMs: 30000,
+      requestTimeoutMs: 35000,
+    },
+  ])(
+    "keeps the $label responsebody request open past its operation deadline",
+    async ({ timeout, operationTimeoutMs, requestTimeoutMs }) => {
+      const program = createActionObserveProgram();
+      const args = ["browser", "responsebody", "**/api", "--max-chars", "0100"];
+      if (timeout !== undefined) {
+        args.push("--timeout-ms", timeout);
+      }
 
-    await program.parseAsync(
-      ["browser", "responsebody", "**/api", "--timeout-ms", "+030000", "--max-chars", "0100"],
-      { from: "user" },
-    );
+      await program.parseAsync(args, { from: "user" });
 
-    const request = mocks.callBrowserRequest.mock.calls.at(-1)?.[1] as
-      | { body?: { timeoutMs?: number; maxChars?: number } }
-      | undefined;
-    const options = mocks.callBrowserRequest.mock.calls.at(-1)?.[2] as
-      | { timeoutMs?: number }
-      | undefined;
-    expect(request?.body?.timeoutMs).toBe(30000);
-    expect(request?.body?.maxChars).toBe(100);
-    expect(options?.timeoutMs).toBe(30000);
-  });
+      const request = mocks.callBrowserRequest.mock.calls.at(-1)?.[1] as
+        | { body?: { timeoutMs?: number; maxChars?: number } }
+        | undefined;
+      const options = mocks.callBrowserRequest.mock.calls.at(-1)?.[2] as
+        | { timeoutMs?: number }
+        | undefined;
+      expect(request?.body?.timeoutMs).toBe(operationTimeoutMs);
+      expect(request?.body?.maxChars).toBe(100);
+      expect(options?.timeoutMs).toBe(requestTimeoutMs);
+    },
+  );
 });

--- a/extensions/browser/src/cli/browser-cli-actions-observe.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-observe.ts
@@ -9,6 +9,7 @@ import {
   parseBrowserPositiveIntegerOption,
   printBrowserJsonResult,
   runBrowserCliCommand as runBrowserObserve,
+  withBrowserActionTimeoutSlack,
   type BrowserParentOpts,
 } from "./browser-cli-shared.js";
 import { defaultRuntime, shortenHomePath } from "./core-api.js";
@@ -112,7 +113,7 @@ export function registerBrowserActionObserveCommands(
               maxChars,
             },
           },
-          { timeoutMs: timeoutMs ?? 20000 },
+          { timeoutMs: withBrowserActionTimeoutSlack(timeoutMs) },
         );
         if (printBrowserJsonResult(parent, result)) {
           return;

--- a/extensions/browser/src/cli/browser-cli-shared.ts
+++ b/extensions/browser/src/cli/browser-cli-shared.ts
@@ -2,6 +2,7 @@
  * Shared Browser CLI option parsing and gateway request helpers.
  */
 import {
+  addTimerTimeoutGraceMs,
   parseStrictNonNegativeInteger,
   parseStrictPositiveInteger,
 } from "openclaw/plugin-sdk/number-runtime";
@@ -9,6 +10,7 @@ import {
   BROWSER_REQUEST_GATEWAY_METHOD,
   BROWSER_REQUEST_GATEWAY_SCOPES,
 } from "../browser-gateway-contract.js";
+import { BROWSER_ACTION_TRANSPORT_SLACK_MS } from "../browser/act-policy.js";
 import { normalizeBrowserTimerDelayMs } from "../browser/timer-delay.js";
 import { danger, defaultRuntime, runCommandWithRuntime } from "../core-api.js";
 import { callGatewayFromCli, type GatewayRpcOpts } from "./core-api.js";
@@ -29,6 +31,11 @@ type BrowserRequestParams = {
   query?: Record<string, string | number | boolean | undefined>;
   body?: unknown;
 };
+
+/** Adds gateway slack to a Browser action timeout so route work can finish cleanly. */
+export function withBrowserActionTimeoutSlack(timeoutMs: number | undefined): number {
+  return addTimerTimeoutGraceMs(timeoutMs ?? 20_000, BROWSER_ACTION_TRANSPORT_SLACK_MS) ?? 1;
+}
 
 /** Runs a Browser CLI command with the standard runtime error handling. */
 export function runBrowserCliCommand(action: () => Promise<void>) {


### PR DESCRIPTION
## What Problem This Solves

`openclaw browser responsebody` gave the outer Gateway watchdog exactly the same deadline as the browser operation. A missing response could therefore produce a generic transport timeout instead of the actionable browser-owned message explaining how to inspect recent network requests. `--timeout-ms 1` was particularly deterministic: the Gateway expired after 1 ms even though Playwright normalizes the operation to a minimum of 500 ms.

## Why This Change Was Made

The existing, saturating five-second browser transport-grace policy already handled input actions and downloads, but lived inside the input-only helper. Move that existing policy into the generic Browser CLI request owner, migrate its existing input/download callers, and use it for response-body observation. This preserves independently lazy observation and input command groups, keeps the original operation timeout unchanged, and avoids adding a second timeout policy or fallback.

## User Impact

Response-body waits now retain their useful browser-owned failure diagnostics without changing CLI flags, operation deadlines, configuration, authentication, or Gateway protocol. Omitted, 1 ms, and 30,000 ms operation timeouts respectively receive 25,000 ms, 5,001 ms, and 35,000 ms outer transport budgets. Existing uploads and downloads retain exactly one five-second grace period. Production code shrinks by one line.

## Evidence

- Captured three failing real-Commander regressions against unchanged production: outer defaults were 20,000 instead of 25,000; 1 instead of 5,001; and 30,000 instead of 35,000. All three pass after the owner-boundary refactor while preserving the original inner values.
- Eleven focused Browser CLI, input/download sibling, lazy-loading, Gateway timeout, and Playwright suites pass: **114 tests**.
- Existing upload/download coverage now asserts the exact one-time grace for explicit, signed/zero-padded, and default deadlines.
- Each changed production and test file passes its actual strict extension TypeScript project with `strict` and `noImplicitReturns`, loading more than 10,000 genuine transitive source files; formatting, extension oxlint, max-lines and assertion-safety ratchets, and changed-lane classification pass.
- Independent owner/sibling review reports no findings; fresh authenticated structured Codex review is clean. Production LOC: **+16/-17 (net -1)**; tests: **+38/-20**.
- Real Commander parsing and the Browser/Gateway/Playwright owner suites provide deterministic local boundary proof; the operator's running managed Gateway and browser were deliberately left untouched.
