### PR TITLE
fix(ios): stale Watch operations overwrite current prompts and commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4015,16 +4015,33 @@ jobs:
               process.stdout.write(simulator.udid);
             '
           )"
+          derived_data_path="$RUNNER_TEMP/openclaw-watch-lifecycle"
           xcodebuild \
             -project apps/ios/OpenClaw.xcodeproj \
             -scheme OpenClawWatchApp \
             -configuration Debug \
             -destination "platform=watchOS Simulator,id=${simulator_id}" \
+            -derivedDataPath "$derived_data_path" \
+            -parallel-testing-enabled NO \
+            -only-testing:OpenClawWatchTests/WatchInboxStoreOperationTests \
+            CODE_SIGNING_ALLOWED=NO \
+            build-for-testing
+          xcrun simctl boot "$simulator_id" 2>/dev/null || true
+          xcrun simctl bootstatus "$simulator_id" -b
+          xcrun simctl install \
+            "$simulator_id" \
+            "$derived_data_path/Build/Products/Debug-watchsimulator/OpenClawWatchApp.app"
+          xcodebuild \
+            -project apps/ios/OpenClaw.xcodeproj \
+            -scheme OpenClawWatchApp \
+            -configuration Debug \
+            -destination "platform=watchOS Simulator,id=${simulator_id}" \
+            -derivedDataPath "$derived_data_path" \
             -resultBundlePath apps/ios/build/LifecycleTestResults/OpenClawWatchOperationTests.xcresult \
             -parallel-testing-enabled NO \
             -only-testing:OpenClawWatchTests/WatchInboxStoreOperationTests \
             CODE_SIGNING_ALLOWED=NO \
-            test
+            test-without-building
 
       - name: Upload iOS lifecycle simulator evidence
         if: ${{ always() && steps.ios_lifecycle_tests.outcome != '' && steps.ios_lifecycle_tests.outcome != 'skipped' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3996,6 +3996,36 @@ jobs:
             -only-testing:OpenClawTests/TraceHeadingVisualProofTests \
             test
 
+      - name: Run focused Apple Watch operation simulator tests
+        if: env.HISTORICAL_TARGET != 'true'
+        run: |
+          set -euo pipefail
+          simulator_id="$(
+            xcrun simctl list devices available --json | node --input-type=module -e '
+              const chunks = [];
+              for await (const chunk of process.stdin) chunks.push(chunk);
+              const runtimes = JSON.parse(Buffer.concat(chunks).toString("utf8")).devices;
+              const simulator = Object.values(runtimes)
+                .flat()
+                .find((device) => device.isAvailable && device.name.startsWith("Apple Watch"));
+              if (!simulator) {
+                console.error("No available Apple Watch simulator for operation lifecycle tests");
+                process.exit(1);
+              }
+              process.stdout.write(simulator.udid);
+            '
+          )"
+          xcodebuild \
+            -project apps/ios/OpenClaw.xcodeproj \
+            -scheme OpenClawWatchApp \
+            -configuration Debug \
+            -destination "platform=watchOS Simulator,id=${simulator_id}" \
+            -resultBundlePath apps/ios/build/LifecycleTestResults/OpenClawWatchOperationTests.xcresult \
+            -parallel-testing-enabled NO \
+            -only-testing:OpenClawWatchTests/WatchInboxStoreOperationTests \
+            CODE_SIGNING_ALLOWED=NO \
+            test
+
       - name: Upload iOS lifecycle simulator evidence
         if: ${{ always() && steps.ios_lifecycle_tests.outcome != '' && steps.ios_lifecycle_tests.outcome != 'skipped' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -1090,8 +1090,13 @@ extension RootTabsSourceGuardTests {
         let messagesSource = try String(
             contentsOf: Self.watchInboxMessagesSourceURL(),
             encoding: .utf8)
+        let tombstoneSource = try String(
+            contentsOf: Self.watchInboxStoreSourceURL()
+                .deletingLastPathComponent()
+                .appendingPathComponent("WatchExecApprovalTerminalTombstone.swift"),
+            encoding: .utf8)
         #expect(messagesSource.contains("var sourceSentAtMs: Int64?"))
-        #expect(source.contains("var outcomeIsAuthoritative: Bool?"))
+        #expect(tombstoneSource.contains("var outcomeIsAuthoritative: Bool?"))
         #expect(source.contains("guard let recordSentAtMs = record.sourceSentAtMs else { return true }"))
         #expect(restore.contains("state.execApprovalTerminalTombstones ?? []"))
         #expect(restore.contains("self.isExecApprovalTerminal("))

--- a/apps/ios/WatchApp/Sources/OpenClawWatchApp.swift
+++ b/apps/ios/WatchApp/Sources/OpenClawWatchApp.swift
@@ -43,10 +43,10 @@ struct OpenClawWatchApp: App {
                 onAction: { action in
                     guard let receiver = self.receiver else { return }
                     let draft = self.inboxStore.makeReplyDraft(action: action)
-                    self.inboxStore.markReplySending(actionLabel: action.label)
+                    guard let attemptID = self.inboxStore.markReplySending(actionLabel: action.label) else { return }
                     Task { @MainActor in
                         let result = await receiver.sendReply(draft)
-                        self.inboxStore.markReplyResult(result, actionLabel: action.label)
+                        self.inboxStore.markReplyResult(result, actionLabel: action.label, attemptID: attemptID)
                     }
                 },
                 onExecApprovalDecision: { approvalId, gatewayStableID, decision in
@@ -126,20 +126,20 @@ struct OpenClawWatchApp: App {
 
     private func refreshAppSnapshot() {
         guard let receiver else { return }
-        self.inboxStore.markAppSnapshotRequestStarted()
+        let attemptID = self.inboxStore.markAppSnapshotRequestStarted()
         Task { @MainActor in
             let result = await receiver.requestAppSnapshot()
-            self.inboxStore.markAppSnapshotRequestResult(result)
+            self.inboxStore.markAppSnapshotRequestResult(result, attemptID: attemptID)
         }
     }
 
     private func sendAppCommand(_ command: WatchAppCommand) {
         guard let receiver else { return }
         let message = self.inboxStore.makeAppCommand(command)
-        self.inboxStore.markAppCommandSending(command)
+        let attemptID = self.inboxStore.markAppCommandSending(command)
         Task { @MainActor in
             let result = await receiver.sendAppCommand(message)
-            self.inboxStore.markAppCommandResult(result, command: command)
+            self.inboxStore.markAppCommandResult(result, command: command, attemptID: attemptID)
         }
     }
 
@@ -155,11 +155,15 @@ struct OpenClawWatchApp: App {
             return nil
         }
         let message = self.inboxStore.makeAppCommand(.sendChat, text: trimmed)
-        self.inboxStore.markAppCommandSending(.sendChat)
+        let attemptID = self.inboxStore.markAppCommandSending(.sendChat)
         Task { @MainActor in
             let result = await receiver.sendAppCommand(message)
-            self.inboxStore.markAppCommandResult(result, command: .sendChat)
+            guard self.inboxStore.markAppCommandResult(result, command: .sendChat, attemptID: attemptID) else {
+                return
+            }
             try? await Task.sleep(nanoseconds: 900_000_000)
+            guard self.inboxStore.isCurrentAppCommandAttempt(attemptID, gatewayStableID: message.gatewayStableID)
+            else { return }
             self.refreshAppSnapshot()
         }
         return message.commandId

--- a/apps/ios/WatchApp/Sources/WatchExecApprovalTerminalTombstone.swift
+++ b/apps/ios/WatchApp/Sources/WatchExecApprovalTerminalTombstone.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+struct ExecApprovalTerminalTombstone: Codable, Equatable {
+    var approvalId: String
+    var gatewayStableID: String
+    var outcome: WatchExecApprovalOutcome
+    var outcomeIsAuthoritative: Bool?
+    var recordedAt: Date
+
+    private enum CodingKeys: String, CodingKey {
+        case approvalId
+        case gatewayStableID
+        case outcome
+        case outcomeText
+        case outcomeIsAuthoritative
+        case recordedAt
+    }
+
+    init(
+        approvalId: String,
+        gatewayStableID: String,
+        outcome: WatchExecApprovalOutcome,
+        outcomeIsAuthoritative: Bool?,
+        recordedAt: Date)
+    {
+        self.approvalId = approvalId
+        self.gatewayStableID = gatewayStableID
+        self.outcome = outcome
+        self.outcomeIsAuthoritative = outcomeIsAuthoritative
+        self.recordedAt = recordedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.approvalId = try container.decode(String.self, forKey: .approvalId)
+        self.gatewayStableID = try container.decode(String.self, forKey: .gatewayStableID)
+        self.outcome = try container.decodeIfPresent(
+            WatchExecApprovalOutcome.self,
+            forKey: .outcome) ?? Self.decodeLegacyOutcome(
+            container.decodeIfPresent(String.self, forKey: .outcomeText))
+        self.outcomeIsAuthoritative = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .outcomeIsAuthoritative)
+        self.recordedAt = try container.decode(Date.self, forKey: .recordedAt)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.approvalId, forKey: .approvalId)
+        try container.encode(self.gatewayStableID, forKey: .gatewayStableID)
+        try container.encode(self.outcome, forKey: .outcome)
+        try container.encodeIfPresent(
+            self.outcomeIsAuthoritative,
+            forKey: .outcomeIsAuthoritative)
+        try container.encode(self.recordedAt, forKey: .recordedAt)
+    }
+
+    private static func decodeLegacyOutcome(_ text: String?) -> WatchExecApprovalOutcome {
+        text.flatMap(WatchExecApprovalOutcome.decodeLegacyLocalizedText)
+            ?? WatchExecApprovalOutcome(code: .unavailable)
+    }
+}

--- a/apps/ios/WatchApp/Sources/WatchInboxStore.swift
+++ b/apps/ios/WatchApp/Sources/WatchInboxStore.swift
@@ -192,6 +192,19 @@ import WatchKit
     {
         self.defaults = defaults
         self.restorePersistedState()
+        if [self.replyStatus?.code, self.appSnapshotStatus?.code, self.appCommandStatus?.code].contains(.sending) {
+            // Attempt ownership never survives app restoration, so interrupted sends must be retryable.
+            if self.replyStatus?.code == .sending {
+                self.replyStatus?.code = .failed
+            }
+            if self.appSnapshotStatus?.code == .sending {
+                self.appSnapshotStatus?.code = .failed
+            }
+            if self.appCommandStatus?.code == .sending {
+                self.appCommandStatus?.code = .failed
+            }
+            self.persistState()
+        }
         self.pruneExecApprovalTerminalTombstones(now: Date())
         self.pruneExpiredExecApprovals(nowMs: Self.nowMs())
         if requestNotificationAuthorization {

--- a/apps/ios/WatchApp/Sources/WatchInboxStore.swift
+++ b/apps/ios/WatchApp/Sources/WatchInboxStore.swift
@@ -6,67 +6,6 @@ import WatchKit
 @MainActor @Observable final class WatchInboxStore {
     private typealias ExecApprovalOwnerKey = WatchExecApprovalIdentityKey
 
-    private struct ExecApprovalTerminalTombstone: Codable, Equatable {
-        var approvalId: String
-        var gatewayStableID: String
-        var outcome: WatchExecApprovalOutcome
-        var outcomeIsAuthoritative: Bool?
-        var recordedAt: Date
-
-        private enum CodingKeys: String, CodingKey {
-            case approvalId
-            case gatewayStableID
-            case outcome
-            case outcomeText
-            case outcomeIsAuthoritative
-            case recordedAt
-        }
-
-        init(
-            approvalId: String,
-            gatewayStableID: String,
-            outcome: WatchExecApprovalOutcome,
-            outcomeIsAuthoritative: Bool?,
-            recordedAt: Date)
-        {
-            self.approvalId = approvalId
-            self.gatewayStableID = gatewayStableID
-            self.outcome = outcome
-            self.outcomeIsAuthoritative = outcomeIsAuthoritative
-            self.recordedAt = recordedAt
-        }
-
-        init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.approvalId = try container.decode(String.self, forKey: .approvalId)
-            self.gatewayStableID = try container.decode(String.self, forKey: .gatewayStableID)
-            self.outcome = try container.decodeIfPresent(
-                WatchExecApprovalOutcome.self,
-                forKey: .outcome) ?? Self.decodeLegacyOutcome(
-                container.decodeIfPresent(String.self, forKey: .outcomeText))
-            self.outcomeIsAuthoritative = try container.decodeIfPresent(
-                Bool.self,
-                forKey: .outcomeIsAuthoritative)
-            self.recordedAt = try container.decode(Date.self, forKey: .recordedAt)
-        }
-
-        func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(self.approvalId, forKey: .approvalId)
-            try container.encode(self.gatewayStableID, forKey: .gatewayStableID)
-            try container.encode(self.outcome, forKey: .outcome)
-            try container.encodeIfPresent(
-                self.outcomeIsAuthoritative,
-                forKey: .outcomeIsAuthoritative)
-            try container.encode(self.recordedAt, forKey: .recordedAt)
-        }
-
-        private static func decodeLegacyOutcome(_ text: String?) -> WatchExecApprovalOutcome {
-            text.flatMap(WatchExecApprovalOutcome.decodeLegacyLocalizedText)
-                ?? WatchExecApprovalOutcome(code: .unavailable)
-        }
-    }
-
     private enum DeferredGatewayPayload: Codable {
         case notification(message: WatchNotifyMessage, transport: String)
         case execApprovalPrompt(message: WatchExecApprovalPromptMessage, transport: String)
@@ -212,6 +151,11 @@ import WatchKit
     private var lastExecApprovalSnapshotSentAtMs: Int64?
     private var hasCompletedExecApprovalSnapshotRefreshInSession = false
     private var lastDeliveryKey: String?
+    // Transport completions can outlive their prompt, snapshot, or gateway owner.
+    // Keep attempt identities volatile so stale results never replace persisted state.
+    private var activeReplyAttemptID: UUID?
+    private var activeAppSnapshotAttemptID: UUID?
+    private var activeAppCommandAttemptID: UUID?
     var voiceTurnState = WatchVoiceTurnState()
     /// WatchConnectivity does not order application-context updates against user-info
     /// transfers. Persist a bounded handoff queue so a new route's alert is not lost
@@ -392,6 +336,7 @@ import WatchKit
         self.risk = message.risk
         self.actions = message.actions
         self.lastDeliveryKey = deliveryKey
+        self.activeReplyAttemptID = nil
         self.replyStatus = nil
         self.replyStatusAt = nil
         self.isReplySending = false
@@ -647,8 +592,13 @@ import WatchKit
         }
         self.appSnapshot = merged
         self.appSnapshotUpdatedAt = Date()
+        self.activeAppSnapshotAttemptID = nil
         self.appSnapshotStatus = nil
         if !hasExistingAppSnapshot || !Self.gatewayIDsMatch(previousGatewayID, nextGatewayID) {
+            if hasExistingAppSnapshot {
+                self.activeAppCommandAttemptID = nil
+                self.appCommandStatus = nil
+            }
             self.hasCompletedExecApprovalSnapshotRefreshInSession = false
             if !Self.gatewayIDsMatch(self.gatewayStableID, nextGatewayID) {
                 self.clearMessagePrompt()
@@ -669,12 +619,18 @@ import WatchKit
         self.persistState()
     }
 
-    func markAppSnapshotRequestStarted() {
+    func markAppSnapshotRequestStarted() -> UUID {
+        let attemptID = UUID()
+        self.activeAppSnapshotAttemptID = attemptID
         self.appSnapshotStatus = WatchAppCommandStatus(command: .refresh, code: .sending)
         self.persistState()
+        return attemptID
     }
 
-    func markAppSnapshotRequestResult(_ result: WatchReplySendResult) {
+    @discardableResult
+    func markAppSnapshotRequestResult(_ result: WatchReplySendResult, attemptID: UUID) -> Bool {
+        guard self.activeAppSnapshotAttemptID == attemptID else { return false }
+        self.activeAppSnapshotAttemptID = nil
         if let errorMessage = result.errorMessage, !errorMessage.isEmpty {
             self.appSnapshotStatus = WatchAppCommandStatus(
                 command: .refresh,
@@ -688,6 +644,7 @@ import WatchKit
             self.appSnapshotStatus = nil
         }
         self.persistState()
+        return true
     }
 
     func makeAppCommand(_ command: WatchAppCommand, text: String? = nil) -> WatchAppCommandMessage {
@@ -705,12 +662,16 @@ import WatchKit
         WatchGatewayID.exact(self.appSnapshot?.gatewayStableID) != nil
     }
 
-    func markAppCommandSending(_ command: WatchAppCommand) {
+    func markAppCommandSending(_ command: WatchAppCommand) -> UUID {
+        let attemptID = UUID()
+        self.activeAppCommandAttemptID = attemptID
         self.appCommandStatus = WatchAppCommandStatus(command: command, code: .sending)
         self.persistState()
+        return attemptID
     }
 
     func markAppCommandBlocked(_ command: WatchAppCommand, reason: String) {
+        self.activeAppCommandAttemptID = nil
         self.appCommandStatus = WatchAppCommandStatus(
             command: command,
             code: .blocked,
@@ -718,7 +679,9 @@ import WatchKit
         self.persistState()
     }
 
-    func markAppCommandResult(_ result: WatchReplySendResult, command: WatchAppCommand) {
+    @discardableResult
+    func markAppCommandResult(_ result: WatchReplySendResult, command: WatchAppCommand, attemptID: UUID) -> Bool {
+        guard self.activeAppCommandAttemptID == attemptID else { return false }
         if let errorMessage = result.errorMessage, !errorMessage.isEmpty {
             self.appCommandStatus = WatchAppCommandStatus(
                 command: command,
@@ -732,6 +695,12 @@ import WatchKit
             self.appCommandStatus = WatchAppCommandStatus(command: command, code: .sent)
         }
         self.persistState()
+        return true
+    }
+
+    func isCurrentAppCommandAttempt(_ attemptID: UUID, gatewayStableID: String?) -> Bool {
+        self.activeAppCommandAttemptID == attemptID
+            && WatchGatewayID.key(self.appSnapshot?.gatewayStableID) == WatchGatewayID.key(gatewayStableID)
     }
 }
 
@@ -1180,6 +1149,7 @@ extension WatchInboxStore {
         self.expiresAtMs = nil
         self.risk = nil
         self.actions = []
+        self.activeReplyAttemptID = nil
         self.replyStatus = nil
         self.replyStatusAt = nil
         self.isReplySending = false
@@ -1557,7 +1527,10 @@ extension WatchInboxStore {
             sentAtMs: Self.nowMs())
     }
 
-    func markReplySending(actionLabel: String) {
+    func markReplySending(actionLabel: String) -> UUID? {
+        guard !self.isReplySending else { return nil }
+        let attemptID = UUID()
+        self.activeReplyAttemptID = attemptID
         self.isReplySending = true
         self.replyStatus = WatchReplyStatus(
             code: .sending,
@@ -1565,9 +1538,13 @@ extension WatchInboxStore {
             detail: nil)
         self.replyStatusAt = Date()
         self.persistState()
+        return attemptID
     }
 
-    func markReplyResult(_ result: WatchReplySendResult, actionLabel: String) {
+    @discardableResult
+    func markReplyResult(_ result: WatchReplySendResult, actionLabel: String, attemptID: UUID) -> Bool {
+        guard self.activeReplyAttemptID == attemptID else { return false }
+        self.activeReplyAttemptID = nil
         self.isReplySending = false
         if let errorMessage = result.errorMessage, !errorMessage.isEmpty {
             self.replyStatus = WatchReplyStatus(
@@ -1592,6 +1569,7 @@ extension WatchInboxStore {
         }
         self.replyStatusAt = Date()
         self.persistState()
+        return true
     }
 
     private func postLocalNotification(

--- a/apps/ios/WatchTests/WatchInboxStoreOperationTests.swift
+++ b/apps/ios/WatchTests/WatchInboxStoreOperationTests.swift
@@ -29,8 +29,9 @@ struct WatchInboxStoreOperationTests {
 
             let restoredStore = WatchInboxStore(defaults: defaults, requestNotificationAuthorization: false)
             #expect(restoredStore.promptId == "replacement-prompt")
-            #expect(restoredStore.replyStatus?.code == .sending)
+            #expect(restoredStore.replyStatus?.code == .failed)
             #expect(restoredStore.replyStatus?.actionLabel == replacementAction.label)
+            #expect(!restoredStore.isReplySending)
 
             #expect(store.markReplyResult(
                 Self.result(.delivered),
@@ -52,6 +53,29 @@ struct WatchInboxStoreOperationTests {
             #expect(store.replyStatus?.actionLabel == action.label)
             #expect(store.markReplyResult(Self.result(.delivered), actionLabel: action.label, attemptID: attempt))
             #expect(store.markReplySending(actionLabel: action.label) != nil)
+        }
+    }
+
+    @Test func `restored interrupted operations become recoverable before actions reopen`() throws {
+        try Self.withStore { store, defaults in
+            let action = WatchPromptAction(id: "approve", label: "Approve")
+            store.consume(message: Self.prompt(id: "current-prompt", action: action), transport: "sendMessage")
+            store.consume(appSnapshot: Self.snapshot(id: "current-snapshot"))
+            _ = try #require(store.markReplySending(actionLabel: action.label))
+            _ = store.markAppSnapshotRequestStarted()
+            _ = store.markAppCommandSending(.sendChat)
+
+            let restored = WatchInboxStore(defaults: defaults, requestNotificationAuthorization: false)
+            #expect(restored.replyStatus?.code == .failed)
+            #expect(restored.appSnapshotStatus?.code == .failed)
+            #expect(restored.appCommandStatus?.code == .failed)
+            #expect(!restored.isReplySending)
+
+            let reopened = WatchInboxStore(defaults: defaults, requestNotificationAuthorization: false)
+            #expect(reopened.replyStatus?.code == .failed)
+            #expect(reopened.appSnapshotStatus?.code == .failed)
+            #expect(reopened.appCommandStatus?.code == .failed)
+            #expect(reopened.markReplySending(actionLabel: action.label) != nil)
         }
     }
 

--- a/apps/ios/WatchTests/WatchInboxStoreOperationTests.swift
+++ b/apps/ios/WatchTests/WatchInboxStoreOperationTests.swift
@@ -1,0 +1,290 @@
+import Foundation
+import Testing
+@testable import OpenClawWatchApp
+
+@MainActor
+struct WatchInboxStoreOperationTests {
+    @Test func `reply completion cannot overwrite a replacement prompt`() throws {
+        try Self.withStore { store, defaults in
+            let originalAction = WatchPromptAction(id: "original-action", label: "Approve original")
+            store.consume(
+                message: Self.prompt(id: "original-prompt", action: originalAction),
+                transport: "sendMessage")
+            let originalAttempt = try #require(store.markReplySending(actionLabel: originalAction.label))
+
+            let replacementAction = WatchPromptAction(id: "replacement-action", label: "Approve replacement")
+            store.consume(
+                message: Self.prompt(id: "replacement-prompt", action: replacementAction),
+                transport: "sendMessage")
+            let replacementAttempt = try #require(store.markReplySending(actionLabel: replacementAction.label))
+
+            #expect(!store.markReplyResult(
+                Self.result(.delivered),
+                actionLabel: originalAction.label,
+                attemptID: originalAttempt))
+            #expect(store.promptId == "replacement-prompt")
+            #expect(store.isReplySending)
+            #expect(store.replyStatus?.code == .sending)
+            #expect(store.replyStatus?.actionLabel == replacementAction.label)
+
+            let restoredStore = WatchInboxStore(defaults: defaults, requestNotificationAuthorization: false)
+            #expect(restoredStore.promptId == "replacement-prompt")
+            #expect(restoredStore.replyStatus?.code == .sending)
+            #expect(restoredStore.replyStatus?.actionLabel == replacementAction.label)
+
+            #expect(store.markReplyResult(
+                Self.result(.delivered),
+                actionLabel: replacementAction.label,
+                attemptID: replacementAttempt))
+            #expect(store.replyStatus?.code == .sent)
+            #expect(!store.isReplySending)
+        }
+    }
+
+    @Test func `current prompt rejects duplicate reply submissions`() throws {
+        try Self.withStore { store, _ in
+            let action = WatchPromptAction(id: "approve", label: "Approve")
+            store.consume(message: Self.prompt(id: "current-prompt", action: action), transport: "sendMessage")
+            let attempt = try #require(store.markReplySending(actionLabel: action.label))
+
+            #expect(store.markReplySending(actionLabel: "Duplicate") == nil)
+            #expect(store.isReplySending)
+            #expect(store.replyStatus?.actionLabel == action.label)
+            #expect(store.markReplyResult(Self.result(.delivered), actionLabel: action.label, attemptID: attempt))
+            #expect(store.markReplySending(actionLabel: action.label) != nil)
+        }
+    }
+
+    @Test func `reply accepts current delivered queued and failed outcomes`() throws {
+        try Self.withStore { store, _ in
+            let outcomes: [(WatchReplySendResult, WatchDeliveryStatusCode)] = [
+                (Self.result(.delivered), .sent),
+                (Self.result(.queued), .queued),
+                (Self.result(.notSent, errorMessage: "Offline"), .failed),
+            ]
+
+            for (index, outcome) in outcomes.enumerated() {
+                let action = WatchPromptAction(id: "reply-\(index)", label: "Reply \(index)")
+                store.consume(
+                    message: Self.prompt(id: "reply-prompt-\(index)", action: action),
+                    transport: "sendMessage")
+                let attempt = try #require(store.markReplySending(actionLabel: action.label))
+
+                #expect(store.markReplyResult(outcome.0, actionLabel: action.label, attemptID: attempt))
+                #expect(store.replyStatus?.code == outcome.1)
+                #expect(!store.isReplySending)
+            }
+        }
+    }
+
+    @Test func `older snapshot request cannot overwrite the current request`() throws {
+        try Self.withStore { store, defaults in
+            let originalAttempt = store.markAppSnapshotRequestStarted()
+            let replacementAttempt = store.markAppSnapshotRequestStarted()
+
+            #expect(!store.markAppSnapshotRequestResult(
+                Self.result(.notSent, errorMessage: "Old request failed"),
+                attemptID: originalAttempt))
+            #expect(store.appSnapshotStatus?.code == .sending)
+            #expect(store.markAppSnapshotRequestResult(Self.result(.queued), attemptID: replacementAttempt))
+            #expect(store.appSnapshotStatus?.code == .queued)
+
+            let restoredStore = WatchInboxStore(defaults: defaults, requestNotificationAuthorization: false)
+            #expect(restoredStore.appSnapshotStatus?.code == .queued)
+        }
+    }
+
+    @Test func `accepted snapshot retires its pending request`() throws {
+        try Self.withStore { store, defaults in
+            let attempt = store.markAppSnapshotRequestStarted()
+            store.consume(appSnapshot: Self.snapshot(id: "received-snapshot"))
+
+            #expect(store.appSnapshotStatus == nil)
+            #expect(!store.markAppSnapshotRequestResult(Self.result(.delivered), attemptID: attempt))
+            #expect(store.appSnapshotStatus == nil)
+
+            let restoredStore = WatchInboxStore(defaults: defaults, requestNotificationAuthorization: false)
+            #expect(restoredStore.appSnapshotStatus == nil)
+        }
+    }
+
+    @Test func `rejected older snapshot does not retire the current request`() throws {
+        try Self.withStore { store, _ in
+            store.consume(appSnapshot: Self.snapshot(id: "current-snapshot", sentAtMs: 200))
+            let attempt = store.markAppSnapshotRequestStarted()
+            store.consume(appSnapshot: Self.snapshot(id: "old-snapshot", sentAtMs: 100))
+
+            #expect(store.appSnapshot?.snapshotId == "current-snapshot")
+            #expect(store.appSnapshotStatus?.code == .sending)
+            #expect(store.markAppSnapshotRequestResult(Self.result(.delivered), attemptID: attempt))
+            #expect(store.appSnapshotStatus?.code == .sent)
+        }
+    }
+
+    @Test func `older command completion cannot overwrite the current command`() throws {
+        try Self.withStore { store, defaults in
+            store.consume(appSnapshot: Self.snapshot(id: "owner-snapshot"))
+            let originalAttempt = store.markAppCommandSending(.startTalk)
+            let replacementAttempt = store.markAppCommandSending(.stopTalk)
+
+            #expect(!store.markAppCommandResult(
+                Self.result(.notSent, errorMessage: "Old command failed"),
+                command: .startTalk,
+                attemptID: originalAttempt))
+            #expect(store.appCommandStatus?.command == .stopTalk)
+            #expect(store.appCommandStatus?.code == .sending)
+            #expect(store.markAppCommandResult(
+                Self.result(.queued),
+                command: .stopTalk,
+                attemptID: replacementAttempt))
+            #expect(store.appCommandStatus?.code == .queued)
+
+            let restoredStore = WatchInboxStore(defaults: defaults, requestNotificationAuthorization: false)
+            #expect(restoredStore.appCommandStatus?.command == .stopTalk)
+            #expect(restoredStore.appCommandStatus?.code == .queued)
+        }
+    }
+
+    @Test func `same gateway snapshots preserve an in-flight command`() throws {
+        try Self.withStore { store, _ in
+            store.consume(appSnapshot: Self.snapshot(id: "initial-snapshot", sentAtMs: 100))
+            let attempt = store.markAppCommandSending(.sendChat)
+            store.consume(appSnapshot: Self.snapshot(id: "refreshed-snapshot", sentAtMs: 200))
+
+            #expect(store.appCommandStatus?.code == .sending)
+            #expect(store.isCurrentAppCommandAttempt(attempt, gatewayStableID: "watch-test-gateway"))
+            #expect(store.markAppCommandResult(Self.result(.delivered), command: .sendChat, attemptID: attempt))
+            #expect(store.appCommandStatus?.code == .sent)
+        }
+    }
+
+    @Test func `exact Unicode gateway replacement retires and clears the old command`() throws {
+        try Self.withStore { store, defaults in
+            let originalGateway = "gateway-caf\u{00E9}"
+            let replacementGateway = "gateway-cafe\u{0301}"
+            #expect(originalGateway == replacementGateway)
+
+            store.consume(appSnapshot: Self.snapshot(id: "original-owner", gatewayStableID: originalGateway))
+            let attempt = store.markAppCommandSending(.sendChat)
+            store.consume(appSnapshot: Self.snapshot(id: "replacement-owner", gatewayStableID: replacementGateway))
+
+            #expect(store.appCommandStatus == nil)
+            #expect(!store.isCurrentAppCommandAttempt(attempt, gatewayStableID: originalGateway))
+            #expect(!store.markAppCommandResult(Self.result(.delivered), command: .sendChat, attemptID: attempt))
+
+            let restoredStore = WatchInboxStore(defaults: defaults, requestNotificationAuthorization: false)
+            #expect(restoredStore.appCommandStatus == nil)
+            #expect(restoredStore.appSnapshot?.gatewayStableID?.utf8.elementsEqual(replacementGateway.utf8) == true)
+        }
+    }
+
+    @Test func `blocked command retires older completions and persists its reason`() throws {
+        try Self.withStore { store, defaults in
+            store.consume(appSnapshot: Self.snapshot(id: "owner-snapshot"))
+            let attempt = store.markAppCommandSending(.sendChat)
+            store.markAppCommandBlocked(.sendChat, reason: "Refreshing iPhone state")
+
+            #expect(!store.markAppCommandResult(Self.result(.delivered), command: .sendChat, attemptID: attempt))
+            #expect(store.appCommandStatus?.code == .blocked)
+            #expect(store.appCommandStatus?.detail == "Refreshing iPhone state")
+
+            let restoredStore = WatchInboxStore(defaults: defaults, requestNotificationAuthorization: false)
+            #expect(restoredStore.appCommandStatus?.code == .blocked)
+            #expect(restoredStore.appCommandStatus?.detail == "Refreshing iPhone state")
+        }
+    }
+
+    @Test func `current command accepts delivered queued and failed outcomes`() throws {
+        try Self.withStore { store, _ in
+            store.consume(appSnapshot: Self.snapshot(id: "owner-snapshot"))
+            let outcomes: [(WatchReplySendResult, WatchDeliveryStatusCode)] = [
+                (Self.result(.delivered), .sent),
+                (Self.result(.queued), .queued),
+                (Self.result(.notSent, errorMessage: "Offline"), .failed),
+            ]
+
+            for outcome in outcomes {
+                let attempt = store.markAppCommandSending(.startTalk)
+                #expect(store.markAppCommandResult(outcome.0, command: .startTalk, attemptID: attempt))
+                #expect(store.appCommandStatus?.code == outcome.1)
+            }
+        }
+    }
+
+    @Test func `newer command retires an older delayed refresh owner`() throws {
+        try Self.withStore { store, _ in
+            store.consume(appSnapshot: Self.snapshot(id: "owner-snapshot"))
+            let originalAttempt = store.markAppCommandSending(.sendChat)
+            #expect(store.markAppCommandResult(
+                Self.result(.delivered),
+                command: .sendChat,
+                attemptID: originalAttempt))
+            #expect(store.isCurrentAppCommandAttempt(originalAttempt, gatewayStableID: "watch-test-gateway"))
+
+            let replacementAttempt = store.markAppCommandSending(.startTalk)
+            #expect(!store.isCurrentAppCommandAttempt(originalAttempt, gatewayStableID: "watch-test-gateway"))
+            #expect(store.isCurrentAppCommandAttempt(replacementAttempt, gatewayStableID: "watch-test-gateway"))
+            #expect(!store.isCurrentAppCommandAttempt(replacementAttempt, gatewayStableID: "different-gateway"))
+        }
+    }
+
+    private static func withStore(
+        _ body: (WatchInboxStore, UserDefaults) throws -> Void) throws
+    {
+        let suiteName = "WatchInboxStoreOperationTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        try body(WatchInboxStore(defaults: defaults, requestNotificationAuthorization: false), defaults)
+    }
+
+    private static func result(
+        _ delivery: WatchReplyDeliveryState,
+        errorMessage: String? = nil) -> WatchReplySendResult
+    {
+        WatchReplySendResult(
+            delivery: delivery,
+            transport: "sendMessage",
+            errorMessage: errorMessage,
+            requiresCanonicalReadback: false)
+    }
+
+    private static func snapshot(
+        id: String,
+        gatewayStableID: String = "watch-test-gateway",
+        sentAtMs: Int64? = nil) -> WatchAppSnapshotMessage
+    {
+        WatchAppSnapshotMessage(
+            gatewayStatus: .init(code: .gatewayConnected),
+            gatewayConnected: true,
+            agentName: "Test agent",
+            agentAvatarURL: nil,
+            agentAvatarText: nil,
+            sessionKey: "main",
+            gatewayStableID: gatewayStableID,
+            talkStatus: .init(code: .talkReady),
+            talkEnabled: false,
+            talkListening: false,
+            talkSpeaking: false,
+            pendingApprovalCount: 0,
+            chatItems: nil,
+            chatStatus: nil,
+            sentAtMs: sentAtMs,
+            snapshotId: id)
+    }
+
+    private static func prompt(id: String, action: WatchPromptAction) -> WatchNotifyMessage {
+        WatchNotifyMessage(
+            id: id,
+            title: "Approval requested",
+            body: action.label,
+            sentAtMs: nil,
+            promptId: id,
+            sessionKey: "main",
+            gatewayStableID: "watch-test-gateway",
+            kind: nil,
+            details: nil,
+            expiresAtMs: nil,
+            risk: nil,
+            actions: [action])
+    }
+}

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -50,6 +50,9 @@ schemes:
     build:
       targets:
         OpenClawWatchApp: all
+    test:
+      targets:
+        - OpenClawWatchTests
 
 targets:
   OpenClaw:
@@ -503,5 +506,38 @@ targets:
       path: UITests/Info.plist
       properties:
         CFBundleDisplayName: OpenClawUITests
+        CFBundleShortVersionString: "$(OPENCLAW_MARKETING_VERSION)"
+        CFBundleVersion: "$(OPENCLAW_BUILD_VERSION)"
+
+  OpenClawWatchTests:
+    type: bundle.unit-test
+    platform: watchOS
+    deploymentTarget: "11.0"
+    configFiles:
+      Debug: Config/Signing.xcconfig
+      Release: Config/Signing.xcconfig
+    sources:
+      - path: WatchTests
+    dependencies:
+      - target: OpenClawWatchApp
+    settings:
+      base:
+        CODE_SIGN_IDENTITY: "$(OPENCLAW_CODE_SIGN_IDENTITY)"
+        CODE_SIGN_STYLE: "$(OPENCLAW_CODE_SIGN_STYLE)"
+        DEVELOPMENT_TEAM: "$(OPENCLAW_DEVELOPMENT_TEAM)"
+        PRODUCT_BUNDLE_IDENTIFIER: "$(OPENCLAW_WATCH_APP_BUNDLE_ID).tests"
+        ENABLE_APP_INTENTS_METADATA_GENERATION: NO
+        SWIFT_VERSION: "6.0"
+        SWIFT_STRICT_CONCURRENCY: complete
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/OpenClawWatchApp.app/OpenClawWatchApp"
+        BUNDLE_LOADER: "$(TEST_HOST)"
+      configs:
+        Debug:
+          CODE_SIGN_STYLE: Automatic
+          PRODUCT_BUNDLE_IDENTIFIER: "$(OPENCLAW_DEBUG_WATCH_APP_BUNDLE_ID).tests"
+    info:
+      path: Tests/Info.plist
+      properties:
+        CFBundleDisplayName: "$(PRODUCT_NAME)"
         CFBundleShortVersionString: "$(OPENCLAW_MARKETING_VERSION)"
         CFBundleVersion: "$(OPENCLAW_BUILD_VERSION)"


### PR DESCRIPTION
Closes #127520

## What Problem This Solves

Fixes an issue where Apple Watch users responding to a prompt, refreshing iPhone state, or sending a command could see an older operation overwrite the newer operation's status. A delayed prompt completion could also re-enable an action while its replacement was still sending, and switching Gateways could leave the previous Gateway's command status visible and persisted.

## Why This Change Was Made

The Watch inbox owns three independent, ephemeral operation attempts and accepts a completion only while its attempt still owns the relevant prompt, snapshot request, or Gateway command. Prompt replacement, accepted snapshots, blocked commands, newer attempts, and exact Gateway-owner changes invalidate the appropriate attempt before stale state can be displayed or persisted. Because operation ownership cannot survive process restoration, persisted interrupted reply, refresh, and command attempts are immediately recovered as retryable failures instead of displaying an orphaned sending status while actions have already reopened. Existing queued and uncertain WatchConnectivity delivery semantics remain unchanged.

The existing approval tombstone persistence model moves into its own Watch source file so the inbox remains below the established SwiftLint file-length limit without suppressing any checks. A dedicated hosted watchOS test target exercises the actual Watch application module directly, and the existing iOS CI job now builds that target, boots an available Apple Watch simulator, installs the Watch application, runs its tests, and uploads the result bundle alongside iOS lifecycle evidence. Explicit installation is required on fresh hosted Watch simulators and matches the existing Watch screenshot lifecycle.

## User Impact

Watch replies stay disabled until the current operation finishes, prompt and command status always belongs to the currently displayed operation and Gateway, and interrupted operations reopen as visible, retryable failures instead of falsely claiming that they are still sending.

## Evidence

- Confirmed the new real-watchOS regression fails before the production repair: the older reply clears the replacement prompt's in-flight flag, overwrites its action/status, and persists the wrong result across reload.
- Independently reproduced the ClawSweeper restoration finding against the real Watch application target before repairing it: 12 existing tests passed and the new interrupted-operation restoration regression failed. After repairing the persistence owner, all 13 tests pass and reply, refresh, and command statuses reopen as persisted retryable failures.
- All 13 real Apple Watch Series 11 / watchOS 27 simulator regressions pass after the repair, covering reversed reply/snapshot/command completions, duplicate action admission, accepted versus rejected snapshots, same-owner refreshes, byte-distinct Unicode Gateway replacements, persisted reloads, interrupted-operation restoration, blocked commands, delivered/queued/failed outcomes, and delayed chat-refresh ownership.
- Existing iOS Watch-ownership source guards and branded-typography regressions are exercised against the full iOS app and its real embedded Watch companion.
- The exact new CI Watch simulator build, boot, install, and test-without-building lifecycle passes all 13 operation regressions locally and produces an `OpenClawWatchOperationTests.xcresult` bundle; workflow/security lint passes.
- `node scripts/check-changed.mjs -- apps/ios/WatchApp/Sources/OpenClawWatchApp.swift apps/ios/WatchApp/Sources/WatchExecApprovalTerminalTombstone.swift apps/ios/WatchApp/Sources/WatchInboxStore.swift apps/ios/Tests/RootTabsSourceGuardTests.swift apps/ios/WatchTests/WatchInboxStoreOperationTests.swift apps/ios/project.yml` passes, including strict Swift lint with zero violations.
- Independent structured code review: no actionable findings.
