### PR TITLE
fix(cron): prevent run waits from failing after clock changes

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -620,9 +620,19 @@ describe("cron cli", () => {
     },
   );
 
-  it("reduces each history RPC timeout as the cron run wait budget elapses", async () => {
+  it.each([
+    { name: "without a system clock jump", clockJumpMs: 0 },
+    { name: "after the system clock jumps forward", clockJumpMs: 3_600_000 },
+    { name: "after the system clock jumps backward", clockJumpMs: -3_600_000 },
+  ])("reduces each history RPC timeout $name", async ({ clockJumpMs }) => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-27T12:00:00.000Z"));
+    const monotonicNow = performance.now.bind(performance);
+    let monotonicSample = 0;
+    vi.spyOn(performance, "now").mockImplementation(
+      () => monotonicNow() + ++monotonicSample / 1_000,
+    );
+    const startedAt = new Date("2026-07-27T12:00:00.000Z");
+    vi.setSystemTime(startedAt);
 
     const pendingRun = runCronRunAndCaptureExit({
       enqueued: true,
@@ -644,6 +654,7 @@ describe("cron cli", () => {
     expect(callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.runs")).toHaveLength(
       1,
     );
+    vi.setSystemTime(new Date(startedAt.getTime() + clockJumpMs));
     await vi.advanceTimersByTimeAsync(25);
 
     const { calls, exitSpy, runOpts } = await pendingRun;
@@ -654,6 +665,7 @@ describe("cron cli", () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
     expect(runOpts.timeout).toBe("600000");
     expect(pollTimeouts).toHaveLength(2);
+    expect(pollTimeouts.every(Number.isSafeInteger)).toBe(true);
     expect(pollTimeouts[0]).toBeLessThanOrEqual(100);
     expect(pollTimeouts[1]).toBeLessThanOrEqual(75);
     expect(pollTimeouts[1]).toBeLessThan(pollTimeouts[0] ?? 0);

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -67,10 +67,10 @@ async function waitForCronRunCompletion(params: {
   pollIntervalMs: number;
 }): Promise<CronRunLogEntryResult> {
   // Poll the task ledger rather than cron.run because completion state is written asynchronously.
-  const startedAt = Date.now();
+  const startedAt = performance.now();
   let hasPolled = false;
   for (;;) {
-    const elapsedBeforePollMs = Date.now() - startedAt;
+    const elapsedBeforePollMs = Math.floor(performance.now() - startedAt);
     if (hasPolled && elapsedBeforePollMs >= params.timeoutMs) {
       throw new Error(`timed out waiting for cron run ${params.runId}`);
     }
@@ -91,7 +91,7 @@ async function waitForCronRunCompletion(params: {
     if (entry?.status === "ok" || entry?.status === "error" || entry?.status === "skipped") {
       return entry;
     }
-    const elapsedMs = Date.now() - startedAt;
+    const elapsedMs = Math.floor(performance.now() - startedAt);
     if (elapsedMs >= params.timeoutMs) {
       throw new Error(`timed out waiting for cron run ${params.runId}`);
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw cron run --wait` could receive an immediate false timeout after the system clock moved forward, or wait far beyond their requested deadline after the clock moved backward.

## Why This Change Was Made

Measure the existing CLI wait deadline with the monotonic clock instead of wall time. Round elapsed milliseconds down before deriving each Gateway RPC timeout so fractional monotonic readings preserve the existing positive safe-integer timeout contract, including the initial poll for a zero-duration wait.

## User Impact

Manual cron runs remain observable and respect their requested wait deadline across NTP corrections and manual system-clock changes. Explicit shorter RPC timeouts and zero-duration waits retain their existing behavior.

## Evidence

- Before: the existing real Commander cron CLI test exits with code `1` after a one-hour forward jump; a one-hour backward jump inflates a remaining `75ms` deadline into a `600000ms` Gateway timeout.
- Before: a naive monotonic conversion without integer rounding fails all three unchanged/forward/backward regression cases by producing fractional Gateway timeouts.
- After: the same table-driven CLI regression passes unchanged, forward-jump, and backward-jump scenarios with injected fractional monotonic readings and safe-integer timeout assertions.
- Full affected suites: `219 passed` across `src/cli/cron-cli.test.ts` and `src/cli/cron-cli/register.cron-simple.test.ts`.
- Targeted formatting and strict lint pass; independent owner-boundary review and fresh automated review are clean.
- The complete local changed-file gate passes 16 guards before unrelated existing dependency/type mismatches in Google finish reasons, `markdown-it`, and `@earendil-works/pi-tui`; exact-head hosted CI must validate the fresh dependency graph.
- Production delta: `+3/-3`; regression tests: `+14/-2`.
