### PR TITLE
fix(qa): recognize Code Mode recovery in OTel proof

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -8199,6 +8199,22 @@ Update and merge these partial structured summaries.`,
     expect(outputText(recovered)).toBe(
       "The requested file could not be read: ENOENT. QA-FAILED-TOOL-FINALIZED-OK",
     );
+
+    const reconciled = await expectNonStreamingResponsesJson<{
+      output?: Array<{ content?: Array<{ text?: string }> }>;
+    }>(server, {
+      model: "gpt-5.6-luna",
+      input: [
+        makeUserInput(prompt),
+        makeUserInput(
+          "The previous Code Mode mutation may have partially applied. Do not repeat or finish any mutation. Use only the available read-only inspection tools to determine the authoritative current state, then report exactly what applied, what did not, what remains unknown, and what work is still required.",
+        ),
+        failedToolOutput,
+      ],
+    });
+    expect(outputText(reconciled)).toBe(
+      "The requested file could not be read: ENOENT. QA-FAILED-TOOL-FINALIZED-OK",
+    );
   });
 });
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -293,6 +293,9 @@ const QA_CODE_MODE_TARGET_MARKER = "qa-code-mode-target:";
 const QA_RESTART_CHECKPOINT_COUNT = 3;
 const QA_RESTART_FINAL_TEXT = "unsafeVisible=false\nRESTART-CODE-MODE-WAIT-OK";
 const QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE = /failed tool terminal recovery qa check/i;
+// Code Mode uses this read-only continuation after an uncertain tool effect.
+const QA_CODE_MODE_RECONCILIATION_PROMPT_RE =
+  /the previous Code Mode mutation may have partially applied/i;
 const QA_TELEGRAM_VISIBLE_PARTIAL_FAILURE_PROMPT_RE = /telegram visible partial failure qa check/i;
 const QA_TELEGRAM_UNSENT_FAILURE_PROMPT_RE = /telegram unsent failure qa check/i;
 const QA_TELEGRAM_VISIBLE_PARTIAL_FAILURE_MARKER = "TELEGRAM-VISIBLE-PARTIAL-BEFORE-FAILURE";
@@ -1040,9 +1043,10 @@ async function buildResponsesPayload(
     QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT_RE.test(prompt) ||
     (prompt.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE) &&
       QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT_RE.test(allInputText));
+  const isCodeModeReconciliation = QA_CODE_MODE_RECONCILIATION_PROMPT_RE.test(prompt);
   const isActiveFailedToolTerminalRecovery =
     QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE.test(prompt) ||
-    (prompt.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE) &&
+    ((prompt.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE) || isCodeModeReconciliation) &&
       QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE.test(allInputText));
   const hasCallableCodeMode = hasCodeModeExecSurface(toolDeclarationBody);
   const canCallSessionsSpawn =
@@ -1373,8 +1377,14 @@ async function buildResponsesPayload(
     return buildAssistantEvents("");
   }
   if (isActiveFailedToolTerminalRecovery) {
-    if (allInputText.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE)) {
-      if (!allInputText.includes("If a tool failed, say so; never claim completion or success.")) {
+    if (
+      allInputText.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE) ||
+      isCodeModeReconciliation
+    ) {
+      if (
+        !isCodeModeReconciliation &&
+        !allInputText.includes("If a tool failed, say so; never claim completion or success.")
+      ) {
         return buildAssistantEvents("FAILED-TOOL-HONESTY-INSTRUCTION-MISSING");
       }
       const marker = exactMarkerDirective ?? exactReplyDirective ?? "QA-FAILED-TOOL-FINALIZED-OK";

--- a/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
@@ -9,6 +9,9 @@ import {
 } from "../../../../extensions/qa-lab/api.js";
 import { type CapturedSpan, startLocalOtlpReceiver } from "./otel-test-support.js";
 
+const CODE_MODE_RECONCILIATION_NEEDLE =
+  "The previous Code Mode mutation may have partially applied.";
+
 async function startOtlpReceiver(disallowedBodyNeedles: string[] = []) {
   const receiver = startLocalOtlpReceiver(disallowedBodyNeedles);
   const port = await receiver.listen();
@@ -183,41 +186,21 @@ describe("diagnostics-otel gateway runtime", () => {
         `${mock.baseUrl}/debug/requests?after=${requestCursor.cursor}`,
       ).then((response) => response.json())) as Array<{
         allInputText?: string;
-        body?: { input?: Array<Record<string, unknown>>; tools?: unknown[] };
         plannedToolName?: string;
         plannedWireToolName?: string;
-        toolOutputCallId?: string;
       }>;
       const readPlans = scenarioRequests.filter((request) => request.plannedToolName === "read");
       const finalizations = scenarioRequests.filter((request) =>
-        (request.allInputText ?? "").includes(
+        [
           "The previous assistant turn completed its tool calls but did not produce a user-visible answer.",
-        ),
+          CODE_MODE_RECONCILIATION_NEEDLE,
+        ].some((needle) => (request.allInputText ?? "").includes(needle)),
       );
       expect(readPlans).toHaveLength(1);
       expect(readPlans[0]?.plannedWireToolName).toBe("exec");
       expect(finalizations).toHaveLength(1);
-      expect(finalizations[0]?.body?.tools ?? []).toHaveLength(0);
-      expect(finalizations[0]?.allInputText).toContain(
-        "If a tool failed, say so; never claim completion or success.",
-      );
-      const finalizationInput = finalizations[0]?.body?.input ?? [];
-      const failedExecCalls = finalizationInput.filter(
-        (item) =>
-          item.type === "function_call" &&
-          item.name === "exec" &&
-          JSON.stringify(item.arguments ?? "").includes("qa-failed-terminal-missing-file.txt"),
-      );
-      const failedExecOutputs = finalizationInput.filter(
-        (item) =>
-          item.type === "function_call_output" &&
-          item.call_id === failedExecCalls[0]?.call_id &&
-          /ENOENT|no such file/iu.test(JSON.stringify(item.output ?? "")),
-      );
-      expect(failedExecCalls).toHaveLength(1);
-      expect(failedExecOutputs).toHaveLength(1);
-      expect(finalizations[0]?.toolOutputCallId).toBe(failedExecCalls[0]?.call_id);
-
+      expect(finalizations[0]?.allInputText).toContain(CODE_MODE_RECONCILIATION_NEEDLE);
+      expect(finalizations[0]?.allInputText).toContain("report exactly what applied");
       const failureEvidence = await waitFor(
         () => {
           const toolError = activeReceiver.capturedSpans.find(

--- a/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
@@ -186,8 +186,11 @@ describe("diagnostics-otel gateway runtime", () => {
         `${mock.baseUrl}/debug/requests?after=${requestCursor.cursor}`,
       ).then((response) => response.json())) as Array<{
         allInputText?: string;
+        body?: { input?: Array<Record<string, unknown>>; tools?: Array<{ name?: string }> };
+        plannedToolCallId?: string;
         plannedToolName?: string;
         plannedWireToolName?: string;
+        toolOutputCallId?: string;
       }>;
       const readPlans = scenarioRequests.filter((request) => request.plannedToolName === "read");
       const finalizations = scenarioRequests.filter((request) =>
@@ -197,10 +200,24 @@ describe("diagnostics-otel gateway runtime", () => {
         ].some((needle) => (request.allInputText ?? "").includes(needle)),
       );
       expect(readPlans).toHaveLength(1);
+      expect(readPlans[0]?.plannedToolCallId).toBeTruthy();
       expect(readPlans[0]?.plannedWireToolName).toBe("exec");
       expect(finalizations).toHaveLength(1);
       expect(finalizations[0]?.allInputText).toContain(CODE_MODE_RECONCILIATION_NEEDLE);
       expect(finalizations[0]?.allInputText).toContain("report exactly what applied");
+      expect(finalizations[0]?.body?.tools?.map((tool) => tool.name)).toEqual(["read"]);
+      const finalizationInput = finalizations[0]?.body?.input ?? [];
+      // The failed exec belongs to the host-owned Code Mode surface, so it must not be replayed
+      // into the model transcript; the following OTel assertion carries its failure evidence.
+      expect(
+        finalizationInput.filter(
+          (item) => item.type === "function_call" || item.type === "function_call_output",
+        ),
+      ).toEqual([]);
+      expect(finalizations[0]?.toolOutputCallId).toBeUndefined();
+      expect(scenarioRequests.indexOf(finalizations[0]!)).toBe(
+        scenarioRequests.indexOf(readPlans[0]!) + 1,
+      );
       const failureEvidence = await waitFor(
         () => {
           const toolError = activeReceiver.capturedSpans.find(


### PR DESCRIPTION
## Summary

- recognize the canonical Code Mode read-only reconciliation prompt in the QA mock's failed-tool scenario
- keep failure-honest finalization behavior across both settled-tool and Code Mode continuation dialects
- update the real Gateway/OTel proof to assert the current reconciliation contract while retaining linked span, error, and terminal-delivery evidence

## Root cause

`#128071` replaced the generic settled-tool finalization prompt with a Code Mode-specific read-only reconciliation prompt after a failed bridged tool call. The QA mock only recognized the retired prompt, so it fell through to its generic exact-marker response. The real OTel proof then received `QA-FAILED-TOOL-FINALIZED-OK` without the failure report and stopped before evaluating the captured telemetry.

Owner: the qa-lab mock provider's scenario classifier and its real Gateway OTel proof. Product runtime behavior is unchanged.

## Verification

- pre-fix reproduction at validation SHA `0036788055b5631f95d5eaeff9a1ba684fd78bb3`: `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts --reporter=verbose` failed with the marker-only response
- post-fix current-main proof: same command passed, including linked run/harness/model/tool/terminal span assertions
- `pnpm exec vitest run extensions/qa-lab/src/providers/mock-openai/server.test.ts --reporter=dot` — 272 passed
- `node scripts/check-changed.mjs -- extensions/qa-lab/src/providers/mock-openai/server.ts extensions/qa-lab/src/providers/mock-openai/server.test.ts test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts` — passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no actionable findings

## Scope and LOC

- QA mock/test-support production: +13/-3
- tests: +24/-25
- no product production, config, protocol, schema, dependency, or timeout changes

Fixes the OTel recovery assertion failure in Release Checks run 32917859227, job 98025911272.
