### PR TITLE
fix(memory-core): route provider API-key SecretRefs through canonical SDK seam

### DIFF
--- a/extensions/memory-core/src/cli-runtime-common.ts
+++ b/extensions/memory-core/src/cli-runtime-common.ts
@@ -11,6 +11,7 @@ import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   defaultRuntime,
   formatErrorMessage,
+  getMemoryEmbeddingCommandSecretTargetIds,
   getMemorySearchManager,
   getRuntimeConfig,
   resolveCommandSecretRefsViaGateway,
@@ -27,9 +28,6 @@ export type MemoryManager = NonNullable<
   Awaited<ReturnType<typeof getMemorySearchManager>>["manager"]
 >;
 type MemoryManagerPurpose = Parameters<typeof getMemorySearchManager>[0]["purpose"];
-function getMemoryCommandSecretTargetIds(): Set<string> {
-  return new Set(["memory.search.remote.apiKey", "agents.entries.*.memory.search.remote.apiKey"]);
-}
 function isMemorySecretOwnerFailure(error: unknown, message: string): boolean {
   const candidate = error && typeof error === "object" ? (error as Record<string, unknown>) : {};
   if (
@@ -60,7 +58,7 @@ async function loadMemoryCommandConfig(
     const { resolvedConfig, diagnostics } = await resolveCommandSecretRefsViaGateway({
       config,
       commandName,
-      targetIds: getMemoryCommandSecretTargetIds(),
+      targetIds: getMemoryEmbeddingCommandSecretTargetIds(),
       ...(mode ? { mode } : {}),
     });
     return { config: resolvedConfig, diagnostics };

--- a/extensions/memory-core/src/cli.host.runtime.ts
+++ b/extensions/memory-core/src/cli.host.runtime.ts
@@ -3,6 +3,7 @@ export {
   defaultRuntime,
   formatErrorMessage,
   resolveCommandSecretRefsViaGateway,
+  getMemoryEmbeddingCommandSecretTargetIds,
   setVerbose,
   shortenHomeInString,
   shortenHomePath,

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { getMemoryEmbeddingCommandSecretTargetIds as canonicalMemoryTargetIds } from "openclaw/plugin-sdk/memory-core-host-runtime-cli";
 import { resolveSessionTranscriptsDirForAgent as resolveTestSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
@@ -80,6 +81,7 @@ vi.mock("./cli.host.runtime.js", async () => {
     {
       defaultRuntime,
       formatErrorMessage,
+      getMemoryEmbeddingCommandSecretTargetIds,
       setVerbose,
       shortenHomeInString,
       shortenHomePath,
@@ -98,6 +100,7 @@ vi.mock("./cli.host.runtime.js", async () => {
   return {
     defaultRuntime,
     formatErrorMessage,
+    getMemoryEmbeddingCommandSecretTargetIds,
     getMemorySearchManager,
     listMemoryFiles,
     getRuntimeConfig,
@@ -857,9 +860,7 @@ describe("memory cli", () => {
     ) as { config?: unknown; commandName?: unknown; targetIds?: unknown; mode?: unknown };
     expect(secretRefsCall.config).toBe(config);
     expect(secretRefsCall.commandName).toBe("memory status");
-    expect(secretRefsCall.targetIds).toStrictEqual(
-      new Set(["memory.search.remote.apiKey", "agents.entries.*.memory.search.remote.apiKey"]),
-    );
+    expect(secretRefsCall.targetIds).toStrictEqual(canonicalMemoryTargetIds());
     expect(secretRefsCall.mode).toBe("read_only_status");
   });
 

--- a/src/plugin-sdk/memory-core-host-runtime-cli.ts
+++ b/src/plugin-sdk/memory-core-host-runtime-cli.ts
@@ -4,6 +4,7 @@
 
 export { formatErrorMessage, withManager } from "../cli/cli-utils.js";
 export { resolveCommandSecretRefsViaGateway } from "../cli/command-secret-gateway.js";
+export { getMemoryEmbeddingCommandSecretTargetIds } from "../cli/command-secret-targets.js";
 export { formatHelpExamples } from "../cli/help-format.js";
 export { withProgress, withProgressTotals } from "../cli/progress.js";
 export { isVerbose, setVerbose } from "../globals.js";


### PR DESCRIPTION
## What Problem This Solves

A memory command (`memory status`, `memory index`, etc.) resolves its SecretRefs via `resolveCommandSecretRefsViaGateway`, passing a set of target IDs that the Gateway resolver expands. The memory-core plugin maintained a **private 2-entry set** in `cli-runtime-common.ts`:

```ts
function getMemoryCommandSecretTargetIds(): Set<string> {
  return new Set(["memory.search.remote.apiKey", "agents.entries.*.memory.search.remote.apiKey"]);
}
```

This omitted every `models.providers.*.apiKey` target. A user who configured a provider API key as a SecretRef under `models.providers.<id>.apiKey` (a documented path for vector-search-capable providers, `docs/concepts/memory-builtin.md`) hit an unresolved SecretRef: the Gateway resolver only resolves the target IDs submitted to it, the missing provider key stayed unresolved, the memory manager failed to connect, and the failure surfaced misattributed to the `memory.search.remote.apiKey` path. Silent failure + misattribution.

The canonical policy already lived in core (`src/cli/command-secret-targets.ts`): `getMemoryEmbeddingCommandSecretTargetIds()` returns the full superset — all `STATIC_MODEL_TARGET_IDS` (13 provider targets including `models.providers.*.apiKey`) plus the two memory keys. Core's own `capability-cli/embedding.ts` already called it. The plugin had diverged into a private copy that lost the provider half.

Fixes #129749

## Why This Change Was Made

Owner-boundary repair: the plugin should not maintain a duplicate of a canonical core policy — it rots exactly as it did here (core added provider targets, the private copy didn't track them). The canonical function is reused through the **existing** `memory-core-host-runtime-cli` SDK subpath, not a new one, so this is a narrow additive seam: the subpath was already registered (`package.json`, `scripts/lib/plugin-sdk-entrypoints.json`) and already re-exported `resolveCommandSecretRefsViaGateway`. Adding one more canonical re-export matches that established seam.

- `src/plugin-sdk/memory-core-host-runtime-cli.ts`: re-export `getMemoryEmbeddingCommandSecretTargetIds`.
- `extensions/memory-core/src/cli.host.runtime.ts`: forward it through the host facade barrel (alongside `resolveCommandSecretRefsViaGateway`).
- `extensions/memory-core/src/cli-runtime-common.ts`: delete the private `getMemoryCommandSecretTargetIds`; pass the canonical set to `resolveCommandSecretRefsViaGateway`.
- `extensions/memory-core/src/cli.test.ts`: the assertion that encoded the bug (`toStrictEqual(new Set([2 entries]))`) now asserts `toStrictEqual(canonicalMemoryTargetIds())` — the submitted target IDs must equal the canonical superset.

No fallback, no consumer-side guard. The producer (canonical policy) now feeds the consumer (plugin CLI) directly through the SDK seam.

## User Impact

- A provider API key configured as a SecretRef under `models.providers.<id>.apiKey` is now resolved for memory commands; the memory manager connects instead of failing silently.
- The failure, when a provider key *is* misconfigured, now surfaces against the correct path (`models.providers.*`) rather than being misattributed to `memory.search.remote.apiKey`.
- Users without a provider SecretRef are unaffected — the resolver finds no match for the added targets and skips them (no behavior change for healthy non-provider configs).

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-core/src/cli.test.ts`: **98/98**. The updated test asserts `resolveCommandSecretRefsViaGateway` is called with `targetIds` equal to `canonicalMemoryTargetIds()` (the real canonical superset imported from the SDK subpath), proving the plugin now submits the full canonical set including provider targets.
- `node scripts/run-vitest.mjs src/cli/command-secret-targets.test.ts src/cli/command-secret-resolution.coverage.test.ts`: **36/36** — the canonical function and secret resolution are unaffected.
- `node --import tsx scripts/check-extension-plugin-sdk-boundary.mts --mode=src-outside-plugin-sdk`: **no boundary violations** — the plugin reaches core only through the SDK subpath.
- `node --import tsx scripts/plugin-sdk-surface-report.mts --check`: **pass** (189 entrypoints, 2961 exports) — the additive re-export does not drift the SDK surface.
- `oxfmt --check` + `oxlint`: clean on all four changed files.
- Production LOC delta: **−1 net** (delete the 3-line private function + its 2-entry body; add 1 re-export line + 1 barrel line; the call site is a 1:1 rename). Bug-fix default net ≤0.

### Real-behavior proof

The fix is provable by construction: the plugin's `getMemoryCommandSecretTargetIds` is deleted, so the only source of the submitted target IDs is the canonical `getMemoryEmbeddingCommandSecretTargetIds` re-exported through the SDK seam. The test asserts the submitted IDs equal that canonical set, so the provider targets are present by construction — there is no second copy that could diverge again. A live memory-command run with a configured provider SecretRef would strengthen this; this Linux dev environment has no configured provider, so the unit-level assertion (which directly compares the submitted set to the canonical set) is the strongest local proof. Live proof is the one gap.

## Before merge

- tsgo: local `run-tsgo.mjs` is blocked by a stale `@google/genai` (local `2.13.0` vs lockfile `2.17.1`, `pnpm install` could not refresh). Deferred to CI, which uses the correct lockfile. The change is a 1-line re-export + a function deletion + a call-site rename + a test-assertion update — low type risk; `oxlint` (which carries type-aware rules) is clean.
- `plugin-sdk:api:diff` runs in CI against the PR head; the additive re-export is expected to appear as a new callable export on an existing subpath.
