### PR TITLE
fix(openshell): remote workspace is never seeded when the gateway restarts before first exec

### DIFF
--- a/docs/gateway/openshell.md
+++ b/docs/gateway/openshell.md
@@ -138,8 +138,10 @@ Tradeoff: upload + download cost on every exec turn.
 
 `mode: "remote"` makes the **OpenShell workspace canonical**:
 
-- On first sandbox creation, OpenClaw seeds the remote workspace from local
-  once.
+- On first use after sandbox creation, OpenClaw seeds the remote workspace
+  from local once. If the Gateway restarts before that first use, the next use
+  detects the still-empty remote workspace and seeds it; a workspace that
+  already holds content is never re-seeded.
 - After that, `exec`, `read`, `write`, `edit`, and `apply_patch` operate
   directly on the remote workspace. OpenClaw does **not** sync remote changes
   back to local.
@@ -509,8 +511,8 @@ openclaw logs --follow
 3. Core writes the SSH config to a temp file and opens an SSH session through
    the same remote filesystem bridge as the generic SSH backend.
 4. In `mirror` mode: sync local to remote before exec, run, sync back after.
-5. In `remote` mode: seed once on create, then operate directly on the remote
-   workspace.
+5. In `remote` mode: seed once on first use, then operate directly on the
+   remote workspace.
 
 ## Related
 

--- a/extensions/openshell/src/backend.remote-seed.test.ts
+++ b/extensions/openshell/src/backend.remote-seed.test.ts
@@ -1,0 +1,152 @@
+// Covers the remote-mode seed obligation across a gateway restart: adopting an
+// existing sandbox must probe the managed roots instead of trusting process
+// memory, and must never re-seed roots that already hold content.
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { CreateSandboxBackendParams } from "openclaw/plugin-sdk/sandbox";
+import {
+  resolvePreferredOpenClawTmpDir,
+  tempWorkspace,
+  type TempWorkspace,
+} from "openclaw/plugin-sdk/temp-path";
+import {
+  createSandboxBrowserConfig,
+  createSandboxPruneConfig,
+  createSandboxSshConfig,
+} from "openclaw/plugin-sdk/test-fixtures";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createOpenShellSandboxBackendFactory } from "./backend.js";
+import { resolveOpenShellPluginConfig } from "./config.js";
+
+const sdkMocks = vi.hoisted(() => ({
+  runSshSandboxCommand: vi.fn(),
+  disposeSshSandboxSession: vi.fn(),
+}));
+
+const cliMocks = vi.hoisted(() => ({
+  runOpenShellCli: vi.fn(),
+  createOpenShellSshSession: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/sandbox", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/sandbox")>();
+  return {
+    ...actual,
+    runSshSandboxCommand: sdkMocks.runSshSandboxCommand,
+    disposeSshSandboxSession: sdkMocks.disposeSshSandboxSession,
+  };
+});
+
+vi.mock("./cli.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./cli.js")>();
+  return {
+    ...actual,
+    runOpenShellCli: cliMocks.runOpenShellCli,
+    createOpenShellSshSession: cliMocks.createOpenShellSshSession,
+  };
+});
+
+const tempWorkspaces: TempWorkspace[] = [];
+
+function createOpenShellBackendSandboxConfig(): CreateSandboxBackendParams["cfg"] {
+  return {
+    mode: "all",
+    backend: "openshell",
+    scope: "session",
+    workspaceAccess: "rw",
+    workspaceRoot: "/tmp/openclaw-sandboxes",
+    dockerTmpfsSource: "configured",
+    docker: {
+      image: "openclaw-sandbox:bookworm-slim",
+      containerPrefix: "openclaw-sbx-",
+      workdir: "/workspace",
+      readOnlyRoot: false,
+      tmpfs: [],
+      network: "none",
+      capDrop: [],
+      binds: [],
+      env: {},
+    },
+    ssh: createSandboxSshConfig("/tmp/openclaw-sandboxes"),
+    browser: createSandboxBrowserConfig(),
+    tools: { allow: ["*"], deny: [] },
+    prune: createSandboxPruneConfig(),
+  };
+}
+
+async function createAdoptedRemoteBackend(params: { probeStdout: string }) {
+  const workspace = await tempWorkspace({
+    rootDir: resolvePreferredOpenClawTmpDir(),
+    prefix: "openclaw-openshell-remote-seed-",
+  });
+  tempWorkspaces.push(workspace);
+  await fs.writeFile(path.join(workspace.dir, "seed.txt"), "seed", "utf8");
+  cliMocks.createOpenShellSshSession.mockResolvedValue({
+    command: "ssh",
+    configPath: "/tmp/openclaw-openshell-test-ssh-config",
+    host: "openshell-test",
+  });
+  // `sandbox get` succeeds: the sandbox was created by a previous gateway
+  // process that died before the first exec could run the one-time seed.
+  cliMocks.runOpenShellCli.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+  sdkMocks.runSshSandboxCommand.mockImplementation(async ({ remoteCommand }) => ({
+    stdout: String(remoteCommand).includes("ls -A")
+      ? Buffer.from(params.probeStdout)
+      : Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+    code: 0,
+  }));
+  const backendFactory = createOpenShellSandboxBackendFactory({
+    pluginConfig: resolveOpenShellPluginConfig({
+      command: "openshell",
+      mode: "remote",
+    }),
+  });
+  return await backendFactory({
+    sessionKey: "agent:main:turn",
+    scopeKey: "agent:main",
+    workspaceDir: workspace.dir,
+    agentWorkspaceDir: workspace.dir,
+    cfg: createOpenShellBackendSandboxConfig(),
+  });
+}
+
+function seedUploadCalls() {
+  return cliMocks.runOpenShellCli.mock.calls.filter(
+    ([params]) => params.args[0] === "sandbox" && params.args[1] === "upload",
+  );
+}
+
+describe("openshell remote-mode seed across gateway restart", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await Promise.all(tempWorkspaces.splice(0).map((workspace) => workspace.cleanup()));
+  });
+
+  it("seeds an adopted sandbox whose managed roots are empty", async () => {
+    const backend = await createAdoptedRemoteBackend({ probeStdout: "0\n" });
+
+    await backend.buildExecSpec({ command: "pwd", env: {}, usePty: false });
+
+    const uploads = seedUploadCalls();
+    expect(uploads.length).toBeGreaterThan(0);
+    expect(uploads[0]?.[0]).toMatchObject({
+      args: expect.arrayContaining([expect.stringMatching(/\/seed\.txt$/), "/sandbox/"]),
+    });
+  });
+
+  it("never re-seeds when a managed root already holds content", async () => {
+    const backend = await createAdoptedRemoteBackend({ probeStdout: "1\n" });
+
+    await backend.buildExecSpec({ command: "pwd", env: {}, usePty: false });
+
+    expect(seedUploadCalls()).toHaveLength(0);
+    const wipeCalls = sdkMocks.runSshSandboxCommand.mock.calls.filter(([params]) =>
+      String(params.remoteCommand).includes("rm -rf"),
+    );
+    expect(wipeCalls).toHaveLength(0);
+  });
+});

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -63,6 +63,11 @@ function buildOpenShellDirectoryUploadArgs(params: {
   ];
 }
 
+// Prints "0" when every managed root is missing or empty, "1" otherwise. Any
+// content in a managed root means the remote workspace was already seeded (or
+// holds operator data) and re-seeding would destroy remote-canonical state.
+const REMOTE_MANAGED_ROOTS_EMPTY_SCRIPT =
+  'for root in "$@"; do if [ -d "$root" ] && [ -n "$(ls -A "$root")" ]; then printf "1\\n"; exit 0; fi; done; printf "0\\n"';
 const PINNED_REMOTE_PATH_MUTATION_SCRIPT = [
   "set -eu",
   'die() { echo "$1" >&2; exit 1; }',
@@ -689,6 +694,17 @@ class OpenShellSandboxBackendImpl {
           throw this.buildLegacyRuntimeUnavailableError(`OpenShell reports phase "${phase}".`);
         }
       }
+      // The seed obligation must survive a gateway restart between `sandbox
+      // create` and the first exec: process memory is gone, so adopted remote
+      // sandboxes probe the managed roots instead. Only completely empty roots
+      // arm the seed — the wipe step is then a no-op, so recovery can never
+      // destroy operator content in a remote-canonical workspace.
+      if (
+        this.params.execContext.config.mode === "remote" &&
+        (await this.remoteManagedRootsEmpty())
+      ) {
+        this.remoteSeedPending = true;
+      }
       return;
     }
     if (this.params.legacyRuntimeAdopted) {
@@ -900,6 +916,16 @@ class OpenShellSandboxBackendImpl {
         }
       },
     );
+  }
+
+  private async remoteManagedRootsEmpty(): Promise<boolean> {
+    const result = await this.runRemoteShellScriptInternal({
+      script: REMOTE_MANAGED_ROOTS_EMPTY_SCRIPT,
+      args: [this.params.remoteWorkspaceDir, this.params.remoteAgentWorkspaceDir],
+    });
+    // Anything other than an exact "0" reads as non-empty so the seed never
+    // fires on ambiguous probe output.
+    return result.stdout.toString("utf8").trim() === "0";
   }
 
   private async maybeSeedRemoteWorkspace(): Promise<boolean> {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using the OpenShell sandbox backend in `mode: "remote"` would end up with a silently empty remote-canonical workspace when the Gateway restarted (crash, deploy, host reboot) between `sandbox create` and the first exec. The one-time seed obligation lived only in process memory (`remoteSeedPending`): the next process's `sandbox get` succeeded, the flag was false, and the seed never ran — the agent then operated in an unseeded workspace with no visible failure.

## Why This Change Was Made

The seed obligation must survive restarts, so adopted remote sandboxes now probe the managed roots (`remoteWorkspaceDir`, `remoteAgentWorkspaceDir`) once per process at the ensure boundary — the same self-healing pattern the generic SSH backend uses. The probe arms the seed **only when every managed root is missing or empty**, so the wipe step of seeding is provably a no-op and recovery can never destroy operator content: the seed guard shipped in stable v2026.7.1, so legacy seeded sandboxes with no marker exist in production, and `/sandbox`/`/agent` are OpenShell-managed roots that may pre-exist — a plain existence probe or marker-absence check would risk wiping remote-canonical data. Ambiguous probe output fails toward "seeded". The probe also heals a sibling hole: a `sandbox create` that times out client-side after the sandbox actually came up was previously adopted unseeded with no restart involved.

Accepted tradeoffs (noted in code comments): an operator who deliberately empties both managed roots gets re-seeded from local after a restart (nothing is destroyed), and a mid-seed crash that left partial content is treated as seeded — the same weakness the SSH backend has. Mirror mode is untouched (it syncs every exec).

## User Impact

Remote-mode OpenShell sandboxes now reliably get their one-time workspace seed even when the Gateway restarts before the first exec, eliminating a silent-failure class. Already-seeded workspaces are never re-seeded or wiped. Docs updated to state the recovery behavior.

## Evidence

- New regression test `extensions/openshell/src/backend.remote-seed.test.ts` simulates create → process restart → first exec (fresh backend, `sandbox get` succeeds, probe reports empty roots) and asserts the seed upload runs. Verified it fails on pre-fix code for exactly that reason (no seed upload) by running it against the HEAD version of `backend.ts`.
- Sibling test locks the safety invariant: probe reports content → zero seed uploads, zero wipe (`rm -rf`) commands.
- Full openshell extension suite green: 5 files, 87 tests. `check-changed`, `tsgo:extensions`, and `tsgo:extensions:test` all pass.
- Codex autoreview (`gpt-5.6-sol`, high reasoning) on the exact diff: clean, no accepted/actionable findings.
- Live OpenShell proof not run: no OpenShell gateway credentials in this environment; the `OPENCLAW_E2E_OPENSHELL=1` e2e lane covers the real CLI path where one exists.

Production LOC: +26/-0 in `backend.ts` (~16 non-comment) | Tests: +155 | Docs: +6/-4. Growth is the new restart-surviving probe at the lifecycle owner; no existing structure could absorb it.
