### PR TITLE
refactor(voyage): reuse canonical embedding batch deadlines

### DIFF
--- a/extensions/voyage/embedding-batch.test.ts
+++ b/extensions/voyage/embedding-batch.test.ts
@@ -1,10 +1,14 @@
-// Voyage batch tests cover bounded status/error response reads.
-import { describe, expect, it, vi } from "vitest";
+// Voyage batch tests cover the real HTTP boundary and bounded response reads.
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { runVoyageEmbeddingBatches } from "./embedding-batch.js";
 import type { VoyageEmbeddingClient } from "./embedding-provider.js";
 
-function jsonResponse(body: unknown): Response {
+type VoyageBatchOptions = Parameters<typeof runVoyageEmbeddingBatches>[0];
+type BatchStage = "upload" | "create" | "status" | "output" | "error";
+
+function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
+    status,
     headers: { "content-type": "application/json" },
   });
 }
@@ -12,16 +16,86 @@ function jsonResponse(body: unknown): Response {
 function buildClient(): VoyageEmbeddingClient {
   return {
     baseUrl: "https://api.voyageai.test/v1",
-    headers: { authorization: "Bearer test" },
+    headers: { authorization: "Bearer fixture-voyage" },
     model: "voyage-3",
   };
 }
 
-/**
- * A streaming JSON-ish body that proves an oversized response stops being read
- * before the whole advertised payload is buffered into memory. getReadCount
- * reports how many chunks were pulled; cancel() flips wasCanceled.
- */
+function resolveBatchStage(url: string, init?: RequestInit): BatchStage {
+  if (url.endsWith("/files") && init?.method === "POST") {
+    return "upload";
+  }
+  if (url.endsWith("/batches") && init?.method === "POST") {
+    return "create";
+  }
+  if (url.endsWith("/batches/batch-0")) {
+    return "status";
+  }
+  if (url.endsWith("/files/output-0/content")) {
+    return "output";
+  }
+  if (url.endsWith("/files/error-0/content")) {
+    return "error";
+  }
+  throw new Error(`unexpected Voyage batch request: ${url}`);
+}
+
+function defaultBatchResponse(stage: BatchStage): Response {
+  switch (stage) {
+    case "upload":
+      return jsonResponse({ id: "input-0" });
+    case "create":
+      return jsonResponse({ id: "batch-0", status: "in_progress" });
+    case "status":
+      return jsonResponse({ id: "batch-0", status: "completed", output_file_id: "output-0" });
+    case "output":
+      return new Response(
+        JSON.stringify({
+          custom_id: "req-0",
+          response: { status_code: 200, body: { data: [{ embedding: [1, 2] }] } },
+        }),
+      );
+    case "error":
+      return new Response(
+        JSON.stringify({
+          custom_id: "req-0",
+          response: { status_code: 500, message: "provider rejected request" },
+          error: null,
+        }),
+      );
+  }
+  throw new Error("unexpected Voyage batch stage");
+}
+
+function fetchInputUrl(input: RequestInfo | URL): string {
+  return typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+}
+
+function stubBatchFetch(
+  override?: (stage: BatchStage, url: string, init?: RequestInit) => Response | undefined,
+) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = fetchInputUrl(input);
+    const stage = resolveBatchStage(url, init);
+    return override?.(stage, url, init) ?? defaultBatchResponse(stage);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function runBatch(overrides: Partial<VoyageBatchOptions> = {}) {
+  return runVoyageEmbeddingBatches({
+    client: buildClient(),
+    agentId: "main",
+    requests: [{ custom_id: "req-0", body: { input: "hello" } }],
+    wait: true,
+    pollIntervalMs: 1,
+    timeoutMs: 60_000,
+    concurrency: 1,
+    ...overrides,
+  });
+}
+
 function streamingResponse(params: { chunkCount: number; chunkSize: number; status?: number }): {
   response: Response;
   getReadCount: () => number;
@@ -52,158 +126,96 @@ function streamingResponse(params: { chunkCount: number; chunkSize: number; stat
   };
 }
 
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
 describe("voyage batch bounded reads", () => {
   it("clamps polling to the remaining batch timeout", async () => {
-    const sleeps: number[] = [];
-
-    await expect(
-      runVoyageEmbeddingBatches({
-        client: buildClient(),
-        agentId: "main",
-        requests: [{ custom_id: "req-0", body: { input: "hello" } }],
-        wait: true,
-        pollIntervalMs: 2_000,
-        timeoutMs: 1_000,
-        concurrency: 1,
-        deps: {
-          now: (() => {
-            const times = [0, 500];
-            return () => times.shift() ?? 500;
-          })(),
-          sleep: async (ms) => {
-            sleeps.push(ms);
-            throw new Error("stop after first wait");
-          },
-          uploadBatchJsonlFile: async () => "input-0",
-          postJsonWithRetry: async () => ({ id: "batch-0", status: "in_progress" }),
-        },
-      }),
-    ).rejects.toThrow("stop after first wait");
-
-    expect(sleeps).toEqual([500]);
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    stubBatchFetch();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const nowSpy = vi.spyOn(Date, "now");
+    const result = runBatch({
+      pollIntervalMs: 2_000,
+      timeoutMs: 1_000,
+      debug: (message) => {
+        if (message === "memory embeddings: voyage batch created") {
+          nowSpy.mockReturnValueOnce(0).mockReturnValue(500);
+        }
+      },
+    });
+    const rejection = expect(result).rejects.toThrow("voyage batch batch-0 timed out after 1000ms");
+    for (
+      let attempt = 0;
+      attempt < 100 && !timeoutSpy.mock.calls.some(([, ms]) => ms === 500);
+      attempt++
+    ) {
+      await Promise.resolve();
+    }
+    expect(timeoutSpy.mock.calls.some(([, ms]) => ms === 500)).toBe(true);
+    nowSpy.mockReturnValue(1_000);
+    await vi.advanceTimersByTimeAsync(500);
+    await rejection;
   });
 
   it("does not poll status after the batch timeout expires", async () => {
-    let now = 0;
-    const statusFetch = vi.fn();
-
-    await expect(
-      runVoyageEmbeddingBatches({
-        client: buildClient(),
-        agentId: "main",
-        requests: [{ custom_id: "req-0", body: { input: "hello" } }],
-        wait: true,
-        pollIntervalMs: 1_000,
-        timeoutMs: 1_000,
-        concurrency: 1,
-        deps: {
-          now: () => now,
-          sleep: async (ms) => {
-            now += ms;
-          },
-          uploadBatchJsonlFile: async () => "input-0",
-          postJsonWithRetry: async () => ({ id: "batch-0", status: "in_progress" }),
-          withRemoteHttpResponse: statusFetch as never,
-        },
-      }),
-    ).rejects.toThrow("voyage batch batch-0 timed out after 1000ms");
-
-    expect(statusFetch).not.toHaveBeenCalled();
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const fetchMock = stubBatchFetch();
+    const result = runBatch({ pollIntervalMs: 1_000, timeoutMs: 1_000 });
+    const rejection = expect(result).rejects.toThrow("voyage batch batch-0 timed out after 1000ms");
+    await vi.advanceTimersByTimeAsync(1_000);
+    await rejection;
+    expect(
+      fetchMock.mock.calls.some(([url]) => fetchInputUrl(url).endsWith("/batches/batch-0")),
+    ).toBe(false);
   });
 
   it("caps an oversized batch status stream through the public runner", async () => {
     const streamed = streamingResponse({ chunkCount: 20, chunkSize: 1024 * 1024 });
+    stubBatchFetch((stage) => (stage === "status" ? streamed.response : undefined));
 
-    await expect(
-      runVoyageEmbeddingBatches({
-        client: buildClient(),
-        agentId: "main",
-        requests: [{ custom_id: "req-0", body: { input: "hello" } }],
-        wait: true,
-        pollIntervalMs: 1,
-        timeoutMs: 60_000,
-        concurrency: 1,
-        deps: {
-          now: () => 0,
-          sleep: async () => {},
-          uploadBatchJsonlFile: async () => "input-0",
-          postJsonWithRetry: async () => ({ id: "batch-0", status: "in_progress" }),
-          withRemoteHttpResponse: (async (params: {
-            onResponse: (response: Response) => Promise<unknown>;
-          }) => await params.onResponse(streamed.response)) as never,
-        },
-      }),
-    ).rejects.toThrow(/voyage-batch-status: JSON response exceeds \d+ bytes/);
-
+    await expect(runBatch()).rejects.toThrow(
+      /voyage-batch-status: JSON response exceeds \d+ bytes/,
+    );
     expect(streamed.getReadCount()).toBeLessThan(20);
     expect(streamed.wasCanceled()).toBe(true);
   });
 
   it("fail-softs an oversized error file through the public runner", async () => {
     const streamed = streamingResponse({ chunkCount: 20, chunkSize: 1024 * 1024 });
+    stubBatchFetch((stage) => {
+      if (stage === "create") {
+        return jsonResponse({
+          id: "batch-0",
+          status: "completed",
+          output_file_id: "output-0",
+          error_file_id: "error-0",
+        });
+      }
+      return stage === "error" ? streamed.response : undefined;
+    });
 
-    await expect(
-      runVoyageEmbeddingBatches({
-        client: buildClient(),
-        agentId: "main",
-        requests: [{ custom_id: "req-0", body: { input: "hello" } }],
-        wait: true,
-        pollIntervalMs: 1,
-        timeoutMs: 60_000,
-        concurrency: 1,
-        deps: {
-          uploadBatchJsonlFile: async () => "input-0",
-          postJsonWithRetry: async () => ({
-            id: "batch-0",
-            status: "completed",
-            output_file_id: "output-0",
-            error_file_id: "error-0",
-          }),
-          withRemoteHttpResponse: (async (params: {
-            url: string;
-            onResponse: (response: Response) => Promise<unknown>;
-          }) => {
-            expect(params.url).toContain("/files/error-0/content");
-            return await params.onResponse(streamed.response);
-          }) as never,
-        },
-      }),
-    ).rejects.toThrow(
+    await expect(runBatch()).rejects.toThrow(
       /voyage batch batch-0 completed: error file unavailable: voyage batch error file content exceeds \d+ bytes/,
     );
-
     expect(streamed.getReadCount()).toBeLessThan(20);
     expect(streamed.wasCanceled()).toBe(true);
   });
 
   it("normalizes and bounds a non-OK status diagnostic through the public runner", async () => {
-    const streamed = streamingResponse({
-      chunkCount: 20,
-      chunkSize: 1024 * 1024,
+    const streamed = streamingResponse({ chunkCount: 20, chunkSize: 1024 * 1024, status: 500 });
+    stubBatchFetch((stage) => (stage === "status" ? streamed.response : undefined));
+
+    await expect(runBatch()).rejects.toMatchObject({
+      name: "ProviderHttpError",
       status: 500,
+      statusCode: 500,
     });
-
-    await expect(
-      runVoyageEmbeddingBatches({
-        client: buildClient(),
-        agentId: "main",
-        requests: [{ custom_id: "req-0", body: { input: "hello" } }],
-        wait: true,
-        pollIntervalMs: 1,
-        timeoutMs: 60_000,
-        concurrency: 1,
-        deps: {
-          now: () => 0,
-          sleep: async () => {},
-          uploadBatchJsonlFile: async () => "input-0",
-          postJsonWithRetry: async () => ({ id: "batch-0", status: "in_progress" }),
-          withRemoteHttpResponse: (async (params: {
-            onResponse: (response: Response) => Promise<unknown>;
-          }) => await params.onResponse(streamed.response)) as never,
-        },
-      }),
-    ).rejects.toMatchObject({ name: "ProviderHttpError", status: 500, statusCode: 500 });
-
     expect(streamed.getReadCount()).toBeLessThan(20);
     expect(streamed.wasCanceled()).toBe(true);
   });
@@ -228,80 +240,74 @@ describe("voyage batch bounded reads", () => {
         },
       }),
     );
+    stubBatchFetch((stage) => (stage === "output" ? output : undefined));
 
-    const result = await runVoyageEmbeddingBatches({
-      client: buildClient(),
-      agentId: "main",
-      requests: [{ custom_id: "req-0", body: { input: "hello" } }],
-      wait: true,
-      pollIntervalMs: 1,
-      timeoutMs: 1_000,
-      concurrency: 1,
-      deps: {
-        uploadBatchJsonlFile: async () => "input-0",
-        postJsonWithRetry: async () => ({
-          id: "batch-0",
-          status: "completed",
-          output_file_id: "output-0",
-        }),
-        withRemoteHttpResponse: (async (params: {
-          onResponse: (response: Response) => Promise<unknown>;
-        }) => await params.onResponse(output)) as never,
-      },
-    });
-
-    expect(result).toEqual(new Map([["req-0", [1, 2]]]));
+    await expect(runBatch()).resolves.toEqual(new Map([["req-0", [1, 2]]]));
     expect(canceled).toBe(true);
   });
 
   it("reads a completed error file before downloading successful output", async () => {
-    let outputFetched = false;
-
-    await expect(
-      runVoyageEmbeddingBatches({
-        client: buildClient(),
-        agentId: "main",
-        requests: [{ custom_id: "req-0", body: { input: "hello" } }],
-        wait: true,
-        pollIntervalMs: 1,
-        timeoutMs: 1_000,
-        concurrency: 1,
-        deps: {
-          uploadBatchJsonlFile: async () => "input-0",
-          postJsonWithRetry: async () => ({
+    const fetchMock = stubBatchFetch((stage) =>
+      stage === "status"
+        ? jsonResponse({
             id: "batch-0",
-            status: "in_progress",
-          }),
-          withRemoteHttpResponse: (async (params: {
-            url: string;
-            onResponse: (response: Response) => Promise<unknown>;
-          }) => {
-            if (params.url.endsWith("/batches/batch-0")) {
-              return await params.onResponse(
-                jsonResponse({
-                  id: "batch-0",
-                  status: "completed",
-                  output_file_id: "output-0",
-                  error_file_id: "error-0",
-                }),
-              );
-            }
-            if (params.url.endsWith("/files/output-0/content")) {
-              outputFetched = true;
-            }
-            return await params.onResponse(
-              new Response(
-                JSON.stringify({
-                  custom_id: "req-0",
-                  response: { status_code: 500, message: "provider rejected request" },
-                  error: null,
-                }),
-              ),
-            );
-          }) as never,
-        },
-      }),
-    ).rejects.toThrow("voyage batch batch-0 completed: provider rejected request");
-    expect(outputFetched).toBe(false);
+            status: "completed",
+            output_file_id: "output-0",
+            error_file_id: "error-0",
+          })
+        : undefined,
+    );
+
+    await expect(runBatch()).rejects.toThrow(
+      "voyage batch batch-0 completed: provider rejected request",
+    );
+    expect(
+      fetchMock.mock.calls.some(([url]) => fetchInputUrl(url).includes("/files/output-0/")),
+    ).toBe(false);
+  });
+
+  it("preserves authentication and batch request details on the real fetch boundary", async () => {
+    const fetchMock = stubBatchFetch();
+
+    await expect(runBatch()).resolves.toEqual(new Map([["req-0", [1, 2]]]));
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer fixture-voyage");
+    }
+    const create = fetchMock.mock.calls.find(([url]) => fetchInputUrl(url).endsWith("/batches"));
+    const requestBody = create?.[1]?.body;
+    if (typeof requestBody !== "string") {
+      throw new Error("missing Voyage batch creation body");
+    }
+    expect(JSON.parse(requestBody)).toMatchObject({
+      endpoint: "/v1/embeddings",
+      request_params: { model: "voyage-3", input_type: "document" },
+    });
+    const status = fetchMock.mock.calls.find(([url]) =>
+      fetchInputUrl(url).endsWith("/batches/batch-0"),
+    );
+    expect(status?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("retries transient batch creation failures through the shared HTTP policy", async () => {
+    let attempts = 0;
+    stubBatchFetch((stage) => {
+      if (stage !== "create" || ++attempts > 1) {
+        return undefined;
+      }
+      return jsonResponse({ error: { message: "retry this request" } }, 503);
+    });
+
+    await expect(runBatch()).resolves.toEqual(new Map([["req-0", [1, 2]]]));
+    expect(attempts).toBe(2);
+  });
+
+  it("does not poll or download when waiting is disabled", async () => {
+    const fetchMock = stubBatchFetch();
+
+    await expect(runBatch({ wait: false })).rejects.toThrow(
+      "voyage batch batch-0 submitted; enable remote.batch.wait to await completion",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/voyage/embedding-batch.ts
+++ b/extensions/voyage/embedding-batch.ts
@@ -24,7 +24,10 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   assertOkOrThrowProviderError,
+  createProviderOperationDeadline,
   readProviderJsonResponse,
+  resolveProviderOperationTimeoutMs,
+  waitProviderOperationPollInterval,
 } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -51,29 +54,6 @@ const VOYAGE_BATCH_MAX_REQUESTS = 50000;
 // them at 16 MiB; non-OK diagnostics use the shared bounded provider prefix.
 const VOYAGE_BATCH_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 
-type VoyageBatchDeps = {
-  now: () => number;
-  sleep: (ms: number) => Promise<void>;
-  postJsonWithRetry: typeof postJsonWithRetry<VoyageBatchStatus>;
-  uploadBatchJsonlFile: typeof uploadBatchJsonlFile;
-  withRemoteHttpResponse: typeof withRemoteHttpResponse;
-};
-
-function resolveVoyageBatchDeps(overrides: Partial<VoyageBatchDeps> | undefined): VoyageBatchDeps {
-  return {
-    now: overrides?.now ?? Date.now,
-    sleep:
-      overrides?.sleep ??
-      (async (ms: number) =>
-        await new Promise((resolve) => {
-          setTimeout(resolve, ms);
-        })),
-    postJsonWithRetry: overrides?.postJsonWithRetry ?? postJsonWithRetry,
-    uploadBatchJsonlFile: overrides?.uploadBatchJsonlFile ?? uploadBatchJsonlFile,
-    withRemoteHttpResponse: overrides?.withRemoteHttpResponse ?? withRemoteHttpResponse,
-  };
-}
-
 function buildVoyageBatchRequest<T>(params: {
   client: VoyageEmbeddingClient;
   path: string;
@@ -96,17 +76,16 @@ async function submitVoyageBatch(params: {
   client: VoyageEmbeddingClient;
   requests: VoyageBatchRequest[];
   agentId: string;
-  deps: VoyageBatchDeps;
 }): Promise<VoyageBatchStatus> {
   const baseUrl = normalizeBatchBaseUrl(params.client);
-  const inputFileId = await params.deps.uploadBatchJsonlFile({
+  const inputFileId = await uploadBatchJsonlFile({
     client: params.client,
     requests: params.requests,
     errorPrefix: "voyage batch file upload failed",
   });
 
   // 2. Create batch job using Voyage Batches API
-  return await params.deps.postJsonWithRetry({
+  return await postJsonWithRetry<VoyageBatchStatus>({
     url: `${baseUrl}/batches`,
     headers: buildBatchHeaders(params.client, { json: true }),
     ssrfPolicy: params.client.ssrfPolicy,
@@ -130,10 +109,9 @@ async function submitVoyageBatch(params: {
 async function fetchVoyageBatchStatus(params: {
   client: VoyageEmbeddingClient;
   batchId: string;
-  deps: VoyageBatchDeps;
   signal?: AbortSignal;
 }): Promise<VoyageBatchStatus> {
-  return await params.deps.withRemoteHttpResponse(
+  return await withRemoteHttpResponse(
     buildVoyageBatchRequest({
       client: params.client,
       path: `batches/${params.batchId}`,
@@ -151,10 +129,9 @@ async function fetchVoyageBatchStatus(params: {
 async function readVoyageBatchError(params: {
   client: VoyageEmbeddingClient;
   errorFileId: string;
-  deps: VoyageBatchDeps;
 }): Promise<string | undefined> {
   try {
-    return await params.deps.withRemoteHttpResponse(
+    return await withRemoteHttpResponse(
       buildVoyageBatchRequest({
         client: params.client,
         path: `files/${params.errorFileId}/content`,
@@ -188,26 +165,27 @@ async function waitForVoyageBatch(params: {
   timeoutMs: number;
   debug?: (message: string, data?: Record<string, unknown>) => void;
   initial?: VoyageBatchStatus;
-  deps: VoyageBatchDeps;
 }): Promise<BatchCompletionResult> {
-  const start = params.deps.now();
-  const deadline = start + params.timeoutMs;
+  const deadline = createProviderOperationDeadline({
+    label: `voyage batch ${params.batchId}`,
+    timeoutMs: params.timeoutMs,
+  });
   let current: VoyageBatchStatus | undefined = params.initial;
   while (true) {
     let status: VoyageBatchStatus;
     if (current) {
       status = current;
     } else {
-      const remainingRequestMs = deadline - params.deps.now();
-      if (remainingRequestMs <= 0) {
-        throw new Error(`voyage batch ${params.batchId} timed out after ${params.timeoutMs}ms`);
-      }
-      const signal = AbortSignal.timeout(Math.max(1, remainingRequestMs));
+      const signal = AbortSignal.timeout(
+        resolveProviderOperationTimeoutMs({
+          deadline,
+          defaultTimeoutMs: params.timeoutMs,
+        }),
+      );
       try {
         status = await fetchVoyageBatchStatus({
           client: params.client,
           batchId: params.batchId,
-          deps: params.deps,
           signal,
         });
       } catch (error) {
@@ -227,7 +205,6 @@ async function waitForVoyageBatch(params: {
         await readVoyageBatchError({
           client: params.client,
           errorFileId,
-          deps: params.deps,
         }),
     });
     if (state === "completed") {
@@ -244,19 +221,21 @@ async function waitForVoyageBatch(params: {
         await readVoyageBatchError({
           client: params.client,
           errorFileId,
-          deps: params.deps,
         }),
     });
     if (!params.wait) {
       throw new Error(`voyage batch ${params.batchId} still ${state}; wait disabled`);
     }
-    const remainingMs = deadline - params.deps.now();
-    if (remainingMs <= 0) {
-      throw new Error(`voyage batch ${params.batchId} timed out after ${params.timeoutMs}ms`);
-    }
-    const waitMs = Math.min(params.pollIntervalMs, remainingMs);
+    const waitMs = Math.min(
+      params.pollIntervalMs,
+      resolveProviderOperationTimeoutMs({
+        deadline,
+        defaultTimeoutMs: params.timeoutMs,
+      }),
+    );
     params.debug?.(`voyage batch ${params.batchId} ${state}; waiting ${waitMs}ms`);
-    await params.deps.sleep(waitMs);
+    await waitProviderOperationPollInterval({ deadline, pollIntervalMs: waitMs });
+    resolveProviderOperationTimeoutMs({ deadline, defaultTimeoutMs: params.timeoutMs });
     current = undefined;
   }
 }
@@ -266,10 +245,8 @@ export async function runVoyageEmbeddingBatches(
     client: VoyageEmbeddingClient;
     agentId: string;
     requests: VoyageBatchRequest[];
-    deps?: Partial<VoyageBatchDeps>;
   } & EmbeddingBatchExecutionParams,
 ): Promise<Map<string, number[]>> {
-  const deps = resolveVoyageBatchDeps(params.deps);
   return await runEmbeddingBatchGroups({
     ...buildEmbeddingBatchGroupOptions(params, {
       maxRequests: VOYAGE_BATCH_MAX_REQUESTS,
@@ -280,7 +257,6 @@ export async function runVoyageEmbeddingBatches(
         client: params.client,
         requests: group,
         agentId: params.agentId,
-        deps,
       });
       if (!batchInfo.id) {
         throw new Error("voyage batch create failed: missing batch id");
@@ -299,7 +275,7 @@ export async function runVoyageEmbeddingBatches(
         provider: "voyage",
         status: batchInfo,
         readError: async (errorFileId) =>
-          await readVoyageBatchError({ client: params.client, errorFileId, deps }),
+          await readVoyageBatchError({ client: params.client, errorFileId }),
       });
 
       const completed = await resolveCompletedBatchResult({
@@ -315,7 +291,6 @@ export async function runVoyageEmbeddingBatches(
             timeoutMs,
             debug: params.debug,
             initial: batchInfo,
-            deps,
           }),
       });
 
@@ -323,7 +298,7 @@ export async function runVoyageEmbeddingBatches(
       const errors: string[] = [];
       const remaining = new Set(group.map((request) => request.custom_id));
 
-      await deps.withRemoteHttpResponse({
+      await withRemoteHttpResponse({
         url: `${baseUrl}/files/${completed.outputFileId}/content`,
         ssrfPolicy: params.client.ssrfPolicy,
         init: {


### PR DESCRIPTION
## Summary

- Remove Voyage's five-member, test-only production dependency-injection layer and its resolver/plumbing from embedding batch upload, creation, status polling, error handling, and output consumption.
- Reuse the existing provider operation deadline, bounded request timeout, and poll-interval helpers already used by OpenAI and Gemini, preserving Voyage's existing timeout text and total operation deadline.
- Move existing regressions to the actual guarded-fetch boundary and strengthen coverage for outbound authentication, request abort signals, transient HTTP retries, disabled waiting, bounded 16 MiB responses, stream cancellation, and error-file precedence.

Production: **-25 lines** (`+28/-53`). Tests: **+6 lines** (`+210/-204`) while expanding from seven to ten owner-boundary scenarios. No public SDK, provider configuration, model defaults, embedding-cache identities, or external API behavior changes.

## Validation

- Original untouched owner suite: **7 passing tests**.
- Rewritten real guarded-fetch regression suite passed on the previous production implementation before the refactor: **9 passing tests**.
- Final Voyage owner suite: **10 passing tests**, including synthetic authentication, abort-signal, retry, timeout, bounded-stream, and disabled-wait proofs.
- Cross-provider/shared batch suite: **120 passing tests across 13 files**, covering Voyage, OpenAI, Gemini, Mistral, DeepInfra, and shared batch upload/output/status/runner/HTTP/error owners.
- Full type-aware scoped lint, formatting, and whitespace checks pass.
- Independent maintainer reviews and fresh automated review completed; no live credentials or external network requests are used.
