### PR TITLE
fix(talk): make relay playback completion idempotent

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/RealtimeTalkRelaySession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/RealtimeTalkRelaySession.swift
@@ -1048,6 +1048,9 @@ extension RealtimeTalkRelaySession {
     }
 
     private func markOutputPlaybackFinished(cancelIdleTask: Bool = true) {
+        // The idle timer and player completion can race; only the first completion owns the
+        // speaking-state transition and playback-mark acknowledgement.
+        guard self.isOutputPlaying else { return }
         if cancelIdleTask {
             self.outputIdleTask?.cancel()
             self.outputIdleTask = nil

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/RealtimeTalkRelaySessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/RealtimeTalkRelaySessionTests.swift
@@ -592,7 +592,7 @@ struct RealtimeTalkRelaySessionTests {
         #expect(audioCapture.isStarted)
     }
 
-    @Test func `output playback finish clears barge in start time`() {
+    @Test func `output playback finish is idempotent and clears barge in start time`() {
         var speakingStates: [Bool] = []
         let session = RealtimeTalkRelaySession(
             transport: unusedRealtimeRelayTransport(),
@@ -607,12 +607,18 @@ struct RealtimeTalkRelaySessionTests {
         #expect(session._test_outputStartedAtMs() == 100)
 
         session._test_markOutputPlaybackFinished()
+        session._test_markOutputPlaybackFinished()
         #expect(!session._test_isOutputPlaying())
         #expect(session._test_outputStartedAtMs() == nil)
         #expect(speakingStates == [false])
 
         session._test_markOutputAudioStarted(nowMs: 500)
+        #expect(session._test_isOutputPlaying())
         #expect(session._test_outputStartedAtMs() == 500)
+        session._test_markOutputPlaybackFinished()
+        #expect(!session._test_isOutputPlaying())
+        #expect(session._test_outputStartedAtMs() == nil)
+        #expect(speakingStates == [false, false])
     }
 
     @Test func `playback mark is acknowledged after output finishes`() async throws {


### PR DESCRIPTION
## Summary

- make relay playback terminal transitions idempotent when idle and stream completion race
- preserve the existing caller and playback contracts while recording the terminal state once
- add deterministic regression coverage for the competing completion producers

## Root cause

The idle and stream completion paths could both publish the same terminal playback transition. The relay session owns that lifecycle state, so the fix is a small owner-side idempotence guard rather than caller retries or timing changes.

## Verification

- deterministic regression: duplicate terminal transition RED before the fix, GREEN after it
- `swift test --package-path apps/shared/OpenClawKit --scratch-path .build/apple-relay-terminal-idempotence-verifier --filter RealtimeTalkRelaySessionTests` — 40/40 passed independently
- focused owner suite — 40/40 passed
- formatting and diff checks passed
- independent review and both local/full pre-ship reviews found no actionable issues

Production delta is +3 lines for the lifecycle guard and its invariant comment. No caller contract, protocol, or generated artifact changes.
