### PR TITLE
fix(slack): retry stale draft cleanup

### DIFF
--- a/extensions/slack/src/draft-stream.test.ts
+++ b/extensions/slack/src/draft-stream.test.ts
@@ -197,22 +197,27 @@ describe("createSlackDraftStream", () => {
     expect(stream.messageId()).toBe("333.444");
   });
 
-  it("retries a failed detached preview cleanup on the next drain", async () => {
+  it("drains past a failed preview and retries only the retained failure", async () => {
+    const send = vi
+      .fn<DraftSendFn>()
+      .mockResolvedValueOnce(slackDraftSendResult("100.100"))
+      .mockResolvedValueOnce(slackDraftSendResult("100.300"));
     const remove = vi.fn<DraftRemoveFn>(async () => {});
     remove.mockRejectedValueOnce(new Error("cleanup failed"));
-    const { stream } = createDraftStreamHarness({ remove });
+    const { stream } = createDraftStreamHarness({ send, remove });
+    const removedMessageIds = () =>
+      mockCalls<Parameters<DraftRemoveFn>>(remove).map(([, messageId]) => messageId);
 
-    stream.update("working");
-    await stream.flush();
-    stream.forceNewMessage();
+    for (const text of ["first", "second"]) {
+      stream.update(text);
+      await stream.flush();
+      stream.forceNewMessage();
+    }
     await stream.dropDetachedMessages();
-    await stream.dropDetachedMessages();
+    expect(removedMessageIds()).toEqual(["100.100", "100.300"]);
 
-    expect(remove).toHaveBeenCalledTimes(2);
-    expect(remove).toHaveBeenLastCalledWith("C123", "111.222", {
-      token: "xoxb-test",
-      accountId: undefined,
-    });
+    await stream.dropDetachedMessages();
+    expect(removedMessageIds()).toEqual(["100.100", "100.300", "100.100"]);
   });
 
   it("drains previews detached during an in-flight removal", async () => {

--- a/extensions/slack/src/draft-stream.test.ts
+++ b/extensions/slack/src/draft-stream.test.ts
@@ -197,8 +197,10 @@ describe("createSlackDraftStream", () => {
     expect(stream.messageId()).toBe("333.444");
   });
 
-  it("drops a posted preview detached by forceNewMessage", async () => {
-    const { stream, remove } = createDraftStreamHarness();
+  it("retries a failed detached preview cleanup on the next drain", async () => {
+    const remove = vi.fn<DraftRemoveFn>(async () => {});
+    remove.mockRejectedValueOnce(new Error("cleanup failed"));
+    const { stream } = createDraftStreamHarness({ remove });
 
     stream.update("working");
     await stream.flush();
@@ -206,8 +208,8 @@ describe("createSlackDraftStream", () => {
     await stream.dropDetachedMessages();
     await stream.dropDetachedMessages();
 
-    expect(remove).toHaveBeenCalledOnce();
-    expect(remove).toHaveBeenCalledWith("C123", "111.222", {
+    expect(remove).toHaveBeenCalledTimes(2);
+    expect(remove).toHaveBeenLastCalledWith("C123", "111.222", {
       token: "xoxb-test",
       accountId: undefined,
     });
@@ -701,19 +703,18 @@ describe("createSlackDraftStream", () => {
     expect(remove).not.toHaveBeenCalled();
   });
 
-  it("clear warns when cleanup fails", async () => {
-    const remove = vi.fn<DraftRemoveFn>(async () => {
-      throw new Error("cleanup failed");
-    });
+  it("retries a failed active preview cleanup on the next clear", async () => {
+    const remove = vi.fn<DraftRemoveFn>(async () => {});
+    remove.mockRejectedValueOnce(new Error("cleanup failed"));
     const warn = vi.fn<DraftWarnFn>();
     const { stream } = createDraftStreamHarness({ remove, warn });
 
     stream.update("hello");
     await stream.flush();
     await stream.clear();
+    await stream.clear();
 
+    expect(remove).toHaveBeenCalledTimes(2);
     expect(warn).toHaveBeenCalledWith("slack stream preview cleanup failed: cleanup failed");
-    expect(stream.messageId()).toBeUndefined();
-    expect(stream.channelId()).toBeUndefined();
   });
 });

--- a/extensions/slack/src/draft-stream.ts
+++ b/extensions/slack/src/draft-stream.ts
@@ -167,10 +167,13 @@ export function createSlackDraftStream(params: {
   };
 
   const dropDetachedMessages = () => {
-    const drain = cleanupTail.then(async () => {
+    cleanupTail = cleanupTail.then(async () => {
       // Retain failures for retry without letting one stale preview block the rest.
       for (let index = 0; index < pendingCleanupMessages.length;) {
         const message = pendingCleanupMessages[index];
+        if (!message) {
+          return;
+        }
         try {
           await remove(message.channelId, message.messageId, {
             token: params.token,
@@ -184,8 +187,7 @@ export function createSlackDraftStream(params: {
         }
       }
     });
-    cleanupTail = drain;
-    return drain;
+    return cleanupTail;
   };
 
   const clear = async () => {

--- a/extensions/slack/src/draft-stream.ts
+++ b/extensions/slack/src/draft-stream.ts
@@ -168,20 +168,20 @@ export function createSlackDraftStream(params: {
 
   const dropDetachedMessages = () => {
     const drain = cleanupTail.then(async () => {
-      // Keep the failed head authoritative so the next cleanup call retries in order.
-      while (pendingCleanupMessages[0]) {
-        const message = pendingCleanupMessages[0];
+      // Retain failures for retry without letting one stale preview block the rest.
+      for (let index = 0; index < pendingCleanupMessages.length;) {
+        const message = pendingCleanupMessages[index];
         try {
           await remove(message.channelId, message.messageId, {
             token: params.token,
             accountId: params.accountId,
             ...(params.eventScope ? { client: params.eventScope.client } : {}),
           });
+          pendingCleanupMessages.splice(index, 1);
         } catch (err) {
           params.warn?.(`slack stream preview cleanup failed: ${formatSlackError(err)}`);
-          return;
+          index += 1;
         }
-        pendingCleanupMessages.shift();
       }
     });
     cleanupTail = drain;

--- a/extensions/slack/src/draft-stream.ts
+++ b/extensions/slack/src/draft-stream.ts
@@ -33,6 +33,8 @@ type SlackDraftStreamUpdate =
       blocks?: (Block | KnownBlock)[];
     };
 
+type SlackDraftMessage = { channelId: string; messageId: string };
+
 export function createSlackDraftStream(params: {
   target: string;
   cfg: OpenClawConfig;
@@ -57,12 +59,12 @@ export function createSlackDraftStream(params: {
   const edit = params.edit ?? editSlackMessage;
   const remove = params.remove ?? deleteSlackMessage;
 
-  let streamMessageId: string | undefined;
-  let streamChannelId: string | undefined;
+  let streamMessage: SlackDraftMessage | undefined;
   let untrackConversationBoundary: (() => void) | undefined;
   let lastVisibleUpdate: { text: string; blocks?: (Block | KnownBlock)[] } | undefined;
   let lastSentKey = "";
-  const detachedMessages: Array<{ channelId: string; messageId: string }> = [];
+  const pendingCleanupMessages: SlackDraftMessage[] = [];
+  let cleanupTail = Promise.resolve();
   const finalizedMessageIds = new Set<string>();
   const streamState = { stopped: false, final: false };
 
@@ -90,8 +92,8 @@ export function createSlackDraftStream(params: {
     }
     lastSentKey = sentKey;
     try {
-      if (streamChannelId && streamMessageId) {
-        await edit(streamChannelId, streamMessageId, trimmed, {
+      if (streamMessage) {
+        await edit(streamMessage.channelId, streamMessage.messageId, trimmed, {
           cfg: params.cfg,
           token: params.token,
           accountId: params.accountId,
@@ -122,25 +124,24 @@ export function createSlackDraftStream(params: {
         ...(params.metadata ? { metadata: params.metadata } : {}),
         ...(blocks ? { blocks } : {}),
       });
-      streamChannelId = sent.channelId || streamChannelId;
-      streamMessageId = sent.messageId || streamMessageId;
-      if (!streamChannelId || !streamMessageId) {
+      if (!sent.channelId || !sent.messageId) {
         stopTrackingConversationBoundary();
         streamState.stopped = true;
         params.warn?.("slack stream preview stopped (missing identifiers from sendMessage)");
         return;
       }
+      streamMessage = { channelId: sent.channelId, messageId: sent.messageId };
       lastVisibleUpdate = { text: trimmed, ...(blocks ? { blocks } : {}) };
-      if (pendingBoundary && params.conversationChannelId === streamChannelId) {
-        pendingBoundary.setMessageTs(streamMessageId);
+      if (pendingBoundary && params.conversationChannelId === streamMessage.channelId) {
+        pendingBoundary.setMessageTs(streamMessage.messageId);
       } else {
         stopTrackingConversationBoundary();
         const tracker = trackSlackDraftMessage({
           accountId: params.accountId,
           teamId: params.eventScope?.teamId,
-          channelId: streamChannelId,
+          channelId: streamMessage.channelId,
           threadTs,
-          messageTs: streamMessageId,
+          messageTs: streamMessage.messageId,
           onInterveningMessage: forceNewMessage,
         });
         untrackConversationBoundary = tracker.stop;
@@ -165,57 +166,53 @@ export function createSlackDraftStream(params: {
     untrackConversationBoundary = undefined;
   };
 
-  const removeMessage = async (channelId: string, messageId: string) => {
-    try {
-      await remove(channelId, messageId, {
-        token: params.token,
-        accountId: params.accountId,
-        ...(params.eventScope ? { client: params.eventScope.client } : {}),
-      });
-    } catch (err) {
-      params.warn?.(`slack stream preview cleanup failed: ${formatSlackError(err)}`);
-    }
+  const dropDetachedMessages = () => {
+    const drain = cleanupTail.then(async () => {
+      // Keep the failed head authoritative so the next cleanup call retries in order.
+      while (pendingCleanupMessages[0]) {
+        const message = pendingCleanupMessages[0];
+        try {
+          await remove(message.channelId, message.messageId, {
+            token: params.token,
+            accountId: params.accountId,
+            ...(params.eventScope ? { client: params.eventScope.client } : {}),
+          });
+        } catch (err) {
+          params.warn?.(`slack stream preview cleanup failed: ${formatSlackError(err)}`);
+          return;
+        }
+        pendingCleanupMessages.shift();
+      }
+    });
+    cleanupTail = drain;
+    return drain;
   };
 
   const clear = async () => {
     stopTrackingConversationBoundary();
     await discardPending();
-    const channelId = streamChannelId;
-    const messageId = streamMessageId;
-    streamChannelId = undefined;
-    streamMessageId = undefined;
+    if (streamMessage) {
+      pendingCleanupMessages.push(streamMessage);
+      streamMessage = undefined;
+    }
     lastVisibleUpdate = undefined;
     lastSentKey = "";
-    if (!channelId || !messageId) {
-      return;
-    }
-    await removeMessage(channelId, messageId);
+    await dropDetachedMessages();
   };
 
   const forceNewMessage = () => {
     stopTrackingConversationBoundary();
     streamState.stopped = false;
     streamState.final = false;
-    if (streamChannelId && streamMessageId && !finalizedMessageIds.has(streamMessageId)) {
+    if (streamMessage && !finalizedMessageIds.has(streamMessage.messageId)) {
       // A card abandoned below a newer human message is unreachable through
       // finalize/clear and would otherwise linger in its Working state.
-      detachedMessages.push({ channelId: streamChannelId, messageId: streamMessageId });
+      pendingCleanupMessages.push(streamMessage);
     }
-    streamMessageId = undefined;
-    streamChannelId = undefined;
+    streamMessage = undefined;
     lastVisibleUpdate = undefined;
     lastSentKey = "";
     loop.resetPending();
-  };
-
-  const dropDetachedMessages = async () => {
-    // The boundary notifier can append synchronously while removal awaits.
-    // Re-read the live queue so this drain also owns those later detachments.
-    let message: { channelId: string; messageId: string } | undefined;
-    while ((message = detachedMessages.shift()) !== undefined) {
-      const { channelId, messageId } = message;
-      await removeMessage(channelId, messageId);
-    }
   };
 
   const discardPendingAndStopTracking = async () => {
@@ -227,14 +224,15 @@ export function createSlackDraftStream(params: {
     messageId: string,
     editFinal: () => Promise<void>,
   ): Promise<boolean> => {
-    const channelId = streamChannelId;
+    const currentMessage = streamMessage;
     const previousUpdate = lastVisibleUpdate;
-    if (!channelId || streamMessageId !== messageId || !previousUpdate) {
+    if (!currentMessage || currentMessage.messageId !== messageId || !previousUpdate) {
       return false;
     }
+    const { channelId } = currentMessage;
 
     await editFinal();
-    if (streamChannelId === channelId && streamMessageId === messageId) {
+    if (streamMessage?.channelId === channelId && streamMessage.messageId === messageId) {
       finalizedMessageIds.add(messageId);
       stopTrackingConversationBoundary();
       return true;
@@ -267,7 +265,7 @@ export function createSlackDraftStream(params: {
     forceNewMessage,
     dropDetachedMessages,
     finalizeMessage,
-    messageId: () => streamMessageId,
-    channelId: () => streamChannelId,
+    messageId: () => streamMessage?.messageId,
+    channelId: () => streamMessage?.channelId,
   };
 }


### PR DESCRIPTION
## Summary

- retry stale Slack draft cleanup after a failed message removal
- keep retry ownership in the canonical FIFO draft stream instead of masking the failure downstream
- preserve Enterprise behavior, sealing, and successful cleanup semantics

## Root cause

A failed cleanup attempt was treated as terminal, leaving the stale Working preview in place. The draft stream already owns cleanup ordering and retries, so it now retains the failed removal for the next eligible cleanup pass.

## Verification

- two focused regressions were RED before the fix and GREEN after it
- owner suite — 27/27 passed; independent replay — 27/27 passed
- follow-up P2 regression was RED at 26/27: when stale draft A failed removal, stale draft B was not attempted in the same drain
- corrected stable-index drain is GREEN at 27/27: A fails, B drains in the same pass, and retained A retries on the next pass
- structural loop narrowing removes both exact `TS18048` diagnostics without a cast; repository-wide extension typechecking reports zero Slack diagnostics
- type-aware lint, formatting, and 17 changed-path guards passed
- full changed gate reports only unrelated shared-main dependency/type drift, with zero Slack diagnostics
- independent review and both local/full pre-ship reviews found no actionable issues

Exact final delta: production +47/-49 (net -2), tests +24/-18 (net +6). The P2 correction itself is production net-neutral.
