### PR TITLE
docs: cover sqlite3_rsync pull replication in the backups guide

### DIFF
--- a/docs/install/backups.md
+++ b/docs/install/backups.md
@@ -202,8 +202,10 @@ storage, with periodic snapshots so restores stay fast. Only changed pages
 leave the machine, which makes it the right tool when backups must not
 re-upload whole databases.
 
-OpenClaw's databases run in WAL mode, which is Litestream's one hard
-requirement. A minimal `litestream.yml` replicating the control-plane
+Litestream's one hard requirement is WAL mode, which OpenClaw uses on local
+filesystems; on network-backed storage such as NFS or SMB, OpenClaw falls
+back to rollback journaling, so verify with `PRAGMA journal_mode;` first.
+A minimal `litestream.yml` replicating the control-plane
 database and one agent database to an S3-compatible bucket:
 
 ```yaml
@@ -237,7 +239,16 @@ between an origin and a replica database and ships only changed pages,
 typically over SSH with the same binary installed on both ends. Unlike a raw
 file copy, it takes a read transaction on the origin, so pulling from a live
 database while the Gateway runs produces a consistent replica. WAL mode is
-required on the origin, which OpenClaw's databases already use.
+required on the origin. OpenClaw uses WAL on local filesystems but
+deliberately falls back to rollback journaling on network-backed storage
+such as NFS or SMB, so check the origin before relying on this path:
+
+```bash
+sqlite3 ~/.openclaw/state/openclaw.sqlite "PRAGMA journal_mode;"
+```
+
+If this prints anything other than `wal`, use one of the file-based paths
+above instead.
 
 The tool ships in the `sqlite-tools` binary bundles on the
 [SQLite download page](https://sqlite.org/download.html) and in the full

--- a/docs/install/backups.md
+++ b/docs/install/backups.md
@@ -39,6 +39,8 @@ committed state safely.
 - Regular protection: provision the Gateway-owned backup automation.
 - Continuous, incremental, seconds of data loss: replicate the databases with
   Litestream.
+- Periodic incremental pull to another machine, no object storage:
+  `sqlite3_rsync`.
 
 ## Full archives
 
@@ -226,6 +228,41 @@ Litestream replicates database bytes only. Config, credentials files, and
 workspaces still need one of the file-based paths above, and the replicated
 data is as sensitive as the archives, so apply the same bucket access and
 encryption rules.
+
+## Pull replication with sqlite3_rsync
+
+[`sqlite3_rsync`](https://sqlite.org/rsync.html) is the SQLite project's
+official replication tool, modeled on `rsync`: it compares page hashes
+between an origin and a replica database and ships only changed pages,
+typically over SSH with the same binary installed on both ends. Unlike a raw
+file copy, it takes a read transaction on the origin, so pulling from a live
+database while the Gateway runs produces a consistent replica. WAL mode is
+required on the origin, which OpenClaw's databases already use.
+
+The tool ships in the `sqlite-tools` binary bundles on the
+[SQLite download page](https://sqlite.org/download.html) and in the full
+source tree; package-manager SQLite builds often omit it. Pull a database to
+another machine you control:
+
+```bash
+sqlite3_rsync 'user@gateway-host:~/.openclaw/state/openclaw.sqlite' ./replica/openclaw.sqlite
+```
+
+Re-running the command is incremental: an unchanged database exchanges only
+a few kilobytes of hashes, and appended data transfers at roughly its own
+size. Treat the replica as read-only and as sensitive as the origin.
+
+Two caveats. First, deltas are page-based, and OpenClaw's databases run
+incremental auto-vacuum on a periodic maintenance timer; a vacuum pass
+relocates pages, so a sync shortly after one (or after large deletions such
+as transcript-archive eviction) can transfer far more than the actual data
+change. Second, this replicates database bytes only, like Litestream:
+config, credentials files, and workspaces still need a file-based path
+above. For continuous replication with predictable upload size, prefer
+Litestream; use `sqlite3_rsync` for scheduled or ad-hoc pulls between
+machines without object storage. To recover, treat the replica like any
+restored database: copy it into place while the Gateway is stopped, then
+follow [Restore a database](#restore-a-database).
 
 ## Restore
 


### PR DESCRIPTION
## What Problem This Solves

The backups guide (`docs/install/backups.md`) covers archives, per-database snapshots, Git-backed dumps, scheduling, and Litestream, but has no path for incremental replication to another machine without object storage. `sqlite3_rsync` — SQLite's official rsync-style replication tool — was not mentioned anywhere in the repo, and operators who reach for plain `rsync` on live `.sqlite` files risk torn copies.

## Why This Change Was Made

`sqlite3_rsync` fills a real gap (scheduled or ad-hoc pulls between machines, SSH only, no S3), but it interacts badly with one OpenClaw storage decision: our databases run `auto_vacuum=INCREMENTAL` with a periodic `incremental_vacuum` maintenance pass (`src/infra/sqlite-wal.ts`), which relocates pages and inflates page-hash deltas after vacuum or large-deletion windows. The new section documents both the capability and that caveat, and keeps Litestream as the recommendation for continuous replication.

## User Impact

Operators get a documented, safe incremental pull path for live databases, with honest guidance on when its deltas degrade and when to prefer Litestream. Docs-only; no behavior change.

## Evidence

Live-tested against a real 4.7 MB state database with sqlite-tools 3.53.4 (macOS arm64, SHA3-256 verified):

| Scenario | Bytes sent |
|---|---|
| Initial pull | 4.73 MB (full copy) |
| Re-sync, quiescent DB | 4.1 KB (1125x speedup) |
| 1 MB appended rows | 1.05 MB |
| Delete + `incremental_vacuum`, zero new data | 1.07 MB (synthetic delta) |
| Full `VACUUM`, zero new data | 3.1 MB of 3.6 MB resent |

Replica passed `PRAGMA integrity_check` with all 128 tables after every sync. Confirmed `PRAGMA auto_vacuum` = 2 on the live database, matching the documented caveat. `git diff --check` clean; links follow Mintlify root-relative rules.
