### PR TITLE
chore(heartbeat): remove duplicate event-intent test

### DIFF
--- a/src/infra/heartbeat-cooldown.test.ts
+++ b/src/infra/heartbeat-cooldown.test.ts
@@ -107,14 +107,6 @@ describe("shouldDeferWake", () => {
       ).toEqual({ defer: false });
     });
 
-    it("defers acp spawn stream wakes when they use event intent", () => {
-      expect(decide({ ...afterRun, source: "acp-spawn", reason: "acp:spawn:stream" })).toEqual({
-        defer: true,
-        reason: "not-due",
-        retryAtMs: 79_000,
-      });
-    });
-
     it("flood guard still applies to 'wake' as a backstop against unexpected loops", () => {
       const now = 1_000_000;
       const recentRunStarts = [


### PR DESCRIPTION
## What Problem This Solves

Removes a duplicate heartbeat cooldown test that exercised the exact same ACP spawn event-intent input and `not-due` result twice in one suite. The duplicate added maintenance cost without detecting a distinct regression.

## Why This Change Was Made

The earlier copy is deleted while the canonical case remains under `event-driven wakes after a prior run`, alongside the other wake-source variants that own this invariant. No production code or behavior changes.

## User Impact

No user-visible impact. Maintainers keep the same heartbeat cooldown regression coverage with one fewer redundant test.

## Evidence

- `node scripts/run-vitest.mjs src/infra/heartbeat-cooldown.test.ts` — 32/32 passed.
- `node scripts/check-changed.mjs -- src/infra/heartbeat-cooldown.test.ts` — passed, including core test type shards and targeted oxlint.
- `node_modules/.bin/oxfmt --check src/infra/heartbeat-cooldown.test.ts` — passed.
- Fresh autoreview against `origin/main` — no accepted/actionable findings; patch correct 0.99.

Production LOC: `+0/-0`

Tests: `+0/-8`

AI-assisted test audit. No changelog entry: test-only duplicate deletion with no behavior change.
