### PR TITLE
fix(packaging): point provider discovery metadata at built modules

### DIFF
--- a/scripts/lib/plugin-npm-package-manifest.mts
+++ b/scripts/lib/plugin-npm-package-manifest.mts
@@ -12,10 +12,7 @@ import {
 } from "../generate-npm-package-lock.mts";
 import { resolveNpmRunner } from "../npm-runner.mts";
 import type { NpmRunnerParams } from "../npm-runner.mts";
-import {
-  listPluginNpmRuntimeBuildOutputs,
-  resolvePluginNpmRuntimeBuildPlan,
-} from "./plugin-npm-runtime-build.mts";
+import { resolvePluginNpmRuntimeBuildPlan } from "./plugin-npm-runtime-build.mts";
 import type { PluginNpmRuntimeBuildPlan, PluginPackageJson } from "./plugin-npm-runtime-build.mts";
 import { isRecord } from "./record-shared.mjs";
 
@@ -56,18 +53,6 @@ function readJsonFile(filePath: string): PluginPackageJson {
 
 function writeJsonFile(filePath: string, value: unknown) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-}
-
-function resolvePackageDir(repoRoot: string, packageDir: string) {
-  return path.isAbsolute(packageDir) ? packageDir : path.resolve(repoRoot, packageDir);
-}
-
-function resolvePackageJsonPath(packageDir: string) {
-  return path.join(packageDir, "package.json");
-}
-
-function packageRelativePathExists(packageDir: string, relativePath: string) {
-  return fs.existsSync(path.join(packageDir, relativePath));
 }
 
 function normalizePackPath(value: string) {
@@ -121,7 +106,7 @@ function assertPackageFilesDoNotExcludeRequiredRuntimeArtifacts(plan: PluginNpmR
     return;
   }
 
-  for (const requiredPath of listPluginNpmRuntimeBuildOutputs(plan)) {
+  for (const requiredPath of plan.runtimeBuildOutputs) {
     for (const exclusion of exclusions) {
       if (packFilePatternMatchesPath(exclusion, requiredPath)) {
         throw new Error(
@@ -133,8 +118,8 @@ function assertPackageFilesDoNotExcludeRequiredRuntimeArtifacts(plan: PluginNpmR
 }
 
 function assertPluginNpmRuntimeBuildExists(plan: PluginNpmRuntimeBuildPlan) {
-  const missing = listPluginNpmRuntimeBuildOutputs(plan).filter(
-    (runtimePath) => !packageRelativePathExists(plan.packageDir, runtimePath.replace(/^\.\//u, "")),
+  const missing = plan.runtimeBuildOutputs.filter(
+    (runtimePath) => !fs.existsSync(path.join(plan.packageDir, runtimePath.replace(/^\.\//u, ""))),
   );
   if (missing.length > 0) {
     const packageName =
@@ -149,21 +134,20 @@ function assertPluginNpmRuntimeBuildExists(plan: PluginNpmRuntimeBuildPlan) {
   assertPackageFilesDoNotExcludeRequiredRuntimeArtifacts(plan);
 }
 
-function resolvePackagedChannelStateMetadata(
+function resolvePackagedRuntimeMetadata(
   metadata: unknown,
   metadataKey: string,
   plan: PluginNpmRuntimeBuildPlan,
 ) {
-  if (
-    !metadata ||
-    !isRecord(metadata) ||
-    typeof metadata.specifier !== "string" ||
-    !metadata.specifier.trim()
-  ) {
+  if (!isRecord(metadata) && typeof metadata !== "string") {
+    return metadata;
+  }
+  const specifier = typeof metadata === "string" ? metadata : metadata.specifier;
+  if (typeof specifier !== "string" || !specifier.trim()) {
     return metadata;
   }
 
-  const normalizedSpecifier = normalizePackPath(metadata.specifier);
+  const normalizedSpecifier = normalizePackPath(specifier);
   const sourceEntry = normalizedSpecifier.replace(/\.(?:[cm]?[jt]s)$/u, "");
   const runtimeSpecifier = plan.runtimeBuildOutputs.find((runtimePath) => {
     const normalizedRuntimePath = normalizePackPath(runtimePath);
@@ -174,16 +158,14 @@ function resolvePackagedChannelStateMetadata(
   });
   if (!runtimeSpecifier) {
     throw new Error(
-      `channel ${metadataKey} specifier '${metadata.specifier}' has no package-local runtime output for ${plan.pluginDir}`,
+      `${metadataKey} '${specifier}' has no package-local runtime output for ${plan.pluginDir}`,
     );
   }
 
-  // Published plugins omit source files; installed channel probes must load
-  // the exact ESM or CommonJS sidecar emitted by the package runtime build.
-  return {
-    ...metadata,
-    specifier: runtimeSpecifier,
-  };
+  // Published plugins omit source files, so metadata must target the emitted sidecar.
+  return typeof metadata === "string"
+    ? runtimeSpecifier
+    : { ...metadata, specifier: runtimeSpecifier };
 }
 
 function resolvePackagedChannelMetadata(plan: PluginNpmRuntimeBuildPlan) {
@@ -195,9 +177,9 @@ function resolvePackagedChannelMetadata(plan: PluginNpmRuntimeBuildPlan) {
   const packagedChannel: JsonRecord = { ...channel };
   for (const metadataKey of ["configuredState", "persistedAuthState"]) {
     if (Object.hasOwn(channel, metadataKey)) {
-      packagedChannel[metadataKey] = resolvePackagedChannelStateMetadata(
+      packagedChannel[metadataKey] = resolvePackagedRuntimeMetadata(
         channel[metadataKey],
-        metadataKey,
+        `channel ${metadataKey} specifier`,
         plan,
       );
     }
@@ -539,7 +521,7 @@ function installPackageLocalBundledDependencies(params: PluginPackageContext) {
   }
 
   console.error(`[plugin-npm-publish] installing bundled dependencies for ${params.pluginDir}`);
-  const packageJsonPath = resolvePackageJsonPath(params.packageDir);
+  const packageJsonPath = path.join(params.packageDir, "package.json");
   const packedPackageJsonText = fs.readFileSync(packageJsonPath, "utf8");
   const installPackageJsonBase = {
     ...params.packageJson,
@@ -610,8 +592,8 @@ function installPackageLocalBundledDependencies(params: PluginPackageContext) {
  */
 export function resolveAugmentedPluginNpmPackageJson(params: PluginPackageParams) {
   const repoRoot = path.resolve(params.repoRoot ?? ".");
-  const packageDir = resolvePackageDir(repoRoot, params.packageDir);
-  const packageJsonPath = resolvePackageJsonPath(packageDir);
+  const packageDir = path.resolve(repoRoot, params.packageDir);
+  const packageJsonPath = path.join(packageDir, "package.json");
   if (!fs.existsSync(packageJsonPath)) {
     return {
       packageJsonPath,
@@ -777,7 +759,7 @@ export function mergeGeneratedChannelConfigs(
  */
 export function resolveAugmentedPluginNpmManifest(params: PluginPackageParams) {
   const repoRoot = path.resolve(params.repoRoot ?? ".");
-  const packageDir = resolvePackageDir(repoRoot, params.packageDir);
+  const packageDir = path.resolve(repoRoot, params.packageDir);
   const manifestPath = path.join(packageDir, "openclaw.plugin.json");
   if (!fs.existsSync(manifestPath)) {
     return {
@@ -793,14 +775,24 @@ export function resolveAugmentedPluginNpmManifest(params: PluginPackageParams) {
   const pluginId =
     typeof manifest.id === "string" && manifest.id ? manifest.id : path.basename(packageDir);
   const generatedChannelConfigs = readGeneratedBundledChannelConfigs(repoRoot).get(pluginId);
-  const augmentedManifest = mergeGeneratedChannelConfigs(manifest, generatedChannelConfigs);
+  const augmentedManifest = { ...mergeGeneratedChannelConfigs(manifest, generatedChannelConfigs) };
+  if (typeof manifest.providerCatalogEntry === "string") {
+    const plan = resolvePluginNpmRuntimeBuildPlan({ repoRoot, packageDir });
+    if (plan) {
+      augmentedManifest.providerCatalogEntry = resolvePackagedRuntimeMetadata(
+        manifest.providerCatalogEntry,
+        "providerCatalogEntry",
+        plan,
+      );
+    }
+  }
   const changed = JSON.stringify(augmentedManifest) !== JSON.stringify(manifest);
   return {
     manifestPath,
     pluginId,
     changed,
     manifest: augmentedManifest,
-    reason: changed ? "generated-channel-configs" : "unchanged",
+    reason: changed ? "generated-manifest-metadata" : "unchanged",
   };
 }
 
@@ -820,8 +812,8 @@ export function withAugmentedPluginNpmManifestForPackage<T>(
   callback: (context: ManifestOverlayContext) => T,
 ): T {
   const repoRoot = path.resolve(params.repoRoot ?? ".");
-  const packageDir = resolvePackageDir(repoRoot, params.packageDir);
-  const packageJsonPath = resolvePackageJsonPath(packageDir);
+  const packageDir = path.resolve(repoRoot, params.packageDir);
+  const packageJsonPath = path.join(packageDir, "package.json");
   const packageJsonForBundlePolicy = fs.existsSync(packageJsonPath)
     ? readJsonFile(packageJsonPath)
     : undefined;
@@ -862,7 +854,7 @@ export function withAugmentedPluginNpmManifestForPackage<T>(
       : undefined;
   if (resolvedManifest.changed && resolvedManifest.manifest) {
     console.error(
-      `[plugin-npm-publish] overlaying generated channel config metadata for ${resolvedManifest.pluginId}`,
+      `[plugin-npm-publish] overlaying generated manifest metadata for ${resolvedManifest.pluginId}`,
     );
     writeJsonFile(resolvedManifest.manifestPath, resolvedManifest.manifest);
   }

--- a/test/plugin-npm-package-manifest.test.ts
+++ b/test/plugin-npm-package-manifest.test.ts
@@ -409,6 +409,11 @@ describe("plugin npm package manifest staging", () => {
   it("overlays package-local runtime metadata while packing and restores source package json", () => {
     const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-package-runtime-");
     const packageDir = writePublishablePluginPackage(repoDir);
+    writeJsonFile(join(packageDir, "openclaw.plugin.json"), {
+      id: "diffs",
+      providers: ["diffs"],
+      providerCatalogEntry: "./provider-discovery.ts",
+    });
     const sourcePackageJson = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
     sourcePackageJson.openclaw.channel = {
       id: "diffs",
@@ -422,8 +427,10 @@ describe("plugin npm package manifest staging", () => {
       join(packageDir, "configured-state.ts"),
       "export function hasConfiguredChannelState() {}\n",
     );
+    writeFileText(join(packageDir, "provider-discovery.ts"), "export default {};\n");
     writeFileText(join(packageDir, "dist", "index.js"), "export {};\n");
     writeFileText(join(packageDir, "dist", "setup-entry.js"), "export {};\n");
+    writeFileText(join(packageDir, "dist", "provider-discovery.js"), "export default {};\n");
     writeFileText(
       join(packageDir, "dist", "configured-state.js"),
       "export function hasConfiguredChannelState() { return true; }\n",
@@ -471,6 +478,7 @@ describe("plugin npm package manifest staging", () => {
     });
 
     const originalText = readFileSync(join(packageDir, "package.json"), "utf8");
+    const originalManifest = readFileSync(join(packageDir, "openclaw.plugin.json"), "utf8");
     withAugmentedPluginNpmManifestForPackage(
       { repoRoot: repoDir, packageDir, bundleDependencies: true },
       () => {
@@ -491,14 +499,25 @@ describe("plugin npm package manifest staging", () => {
         expect(stagedPackageJson.files).toContain("skills/**");
         expect(stagedPackageJson.peerDependencies.openclaw).toBe(">=2026.4.30");
         expect(stagedPackageJson.peerDependenciesMeta.openclaw.optional).toBe(true);
+        expect(
+          JSON.parse(readFileSync(join(packageDir, "openclaw.plugin.json"), "utf8"))
+            .providerCatalogEntry,
+        ).toBe("./dist/provider-discovery.js");
       },
     );
     expect(readFileSync(join(packageDir, "package.json"), "utf8")).toBe(originalText);
+    expect(readFileSync(join(packageDir, "openclaw.plugin.json"), "utf8")).toBe(originalManifest);
   });
 
-  it("packs and loads both mapped channel-state probes from one package artifact", () => {
+  it("packs and loads mapped provider and channel entries from one package artifact", () => {
     const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-package-state-runtime-");
     const packageDir = writePublishablePluginPackage(repoDir);
+    writeJsonFile(join(packageDir, "openclaw.plugin.json"), {
+      id: "diffs",
+      providers: ["diffs"],
+      providerCatalogEntry: "./provider-discovery.ts",
+      configSchema: { type: "object" },
+    });
     const sourcePackageJson = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
     sourcePackageJson.openclaw.build = { runtimeFormat: "cjs" };
     sourcePackageJson.openclaw.channel = {
@@ -521,6 +540,7 @@ describe("plugin npm package manifest staging", () => {
       join(packageDir, "auth-presence.ts"),
       "export function hasPersistedChannelAuth() {}\n",
     );
+    writeFileText(join(packageDir, "provider-discovery.ts"), "export default { id: 'diffs' };\n");
     writeFileText(join(packageDir, "dist", "index.cjs"), "module.exports = {};\n");
     writeFileText(join(packageDir, "dist", "setup-entry.cjs"), "module.exports = {};\n");
     writeFileText(
@@ -531,8 +551,13 @@ describe("plugin npm package manifest staging", () => {
       join(packageDir, "dist", "auth-presence.cjs"),
       "exports.hasPersistedChannelAuth = () => true;\n",
     );
+    writeFileText(
+      join(packageDir, "dist", "provider-discovery.cjs"),
+      "module.exports = { id: 'diffs', auth: [], catalog: { run: () => ({ models: [] }) } };\n",
+    );
 
     const originalText = readFileSync(join(packageDir, "package.json"), "utf8");
+    const originalManifest = readFileSync(join(packageDir, "openclaw.plugin.json"), "utf8");
     withAugmentedPluginNpmManifestForPackage({ repoRoot: repoDir, packageDir }, () => {
       const stagedPackageJson = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
       expect(stagedPackageJson.openclaw.channel.configuredState).toEqual({
@@ -570,8 +595,10 @@ describe("plugin npm package manifest staging", () => {
       const packedFiles = packedPackage.files.map((file) => file.path);
       expect(packedFiles).toContain("dist/configured-state.cjs");
       expect(packedFiles).toContain("dist/auth-presence.cjs");
+      expect(packedFiles).toContain("dist/provider-discovery.cjs");
       expect(packedFiles).not.toContain("configured-state.ts");
       expect(packedFiles).not.toContain("auth-presence.ts");
+      expect(packedFiles).not.toContain("provider-discovery.ts");
 
       const extract = spawnSync(
         "tar",
@@ -587,13 +614,36 @@ describe("plugin npm package manifest staging", () => {
       const load = spawnSync(
         process.execPath,
         [
+          "--import",
+          tsxImport,
           "--input-type=module",
           "--eval",
           `
 import fs from "node:fs";
 import { pathToFileURL } from "node:url";
+import { loadPluginManifestRegistryCore } from ${JSON.stringify(new URL("../src/plugins/manifest-registry.ts", import.meta.url).href)};
+import { resolvePluginDiscoveryProvidersRuntime } from ${JSON.stringify(new URL("../src/plugins/provider-discovery.runtime.ts", import.meta.url).href)};
 const root = ${JSON.stringify(packageRoot)};
 const pkg = JSON.parse(fs.readFileSync(root + "/package.json", "utf8"));
+const manifest = JSON.parse(fs.readFileSync(root + "/openclaw.plugin.json", "utf8"));
+const provider = await import(new URL(manifest.providerCatalogEntry, pathToFileURL(root + "/")));
+if (provider.default?.id !== "diffs") throw new Error("packed provider discovery failed");
+const config = { plugins: { entries: { diffs: { enabled: true } } } };
+const registry = loadPluginManifestRegistryCore({
+  config,
+  installRecords: {},
+  candidates: [{ idHint: "diffs", source: root + "/dist/index.cjs", rootDir: root, origin: "global" }],
+});
+const index = { plugins: [{ pluginId: "diffs", rootDir: root, origin: "global", enabled: true }], installRecords: {} };
+const discovered = resolvePluginDiscoveryProvidersRuntime({
+  config,
+  env: {},
+  discoveryEntriesOnly: true,
+  pluginMetadataSnapshot: { index, manifestRegistry: registry },
+});
+if (discovered.length !== 1 || discovered[0].id !== "diffs") {
+  throw new Error("packed provider discovery registry failed");
+}
 for (const key of ["configuredState", "persistedAuthState"]) {
   const state = pkg.openclaw.channel[key];
   const loaded = await import(new URL(state.specifier, pathToFileURL(root + "/")));
@@ -605,6 +655,7 @@ process.stdout.write("PACKED_PLUGIN_CHANNEL_STATE_OK\\n");
         {
           cwd: packageRoot,
           encoding: "utf8",
+          env: { ...process.env, TSX_TSCONFIG_PATH: join(process.cwd(), "tsconfig.json") },
           stdio: ["ignore", "pipe", "pipe"],
         },
       );
@@ -612,6 +663,7 @@ process.stdout.write("PACKED_PLUGIN_CHANNEL_STATE_OK\\n");
       expect(load.stdout).toBe("PACKED_PLUGIN_CHANNEL_STATE_OK\n");
     });
     expect(readFileSync(join(packageDir, "package.json"), "utf8")).toBe(originalText);
+    expect(readFileSync(join(packageDir, "openclaw.plugin.json"), "utf8")).toBe(originalManifest);
   });
 
   it("stages portable bundled dependencies without polluting pack output", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes nine installed provider plugins silently losing lightweight provider discovery because their published package manifests reference nonexistent `provider-discovery.ts` files even though the tarball contains compiled discovery modules under `dist/`.

## Why This Change Was Made

The existing packaging overlay rewrote compiled channel sidecars but never rewrote provider discovery entrypoints. One canonical runtime-sidecar mapper now serves both channel and provider metadata, pointing generated package manifests at the actual ESM or CommonJS build output while leaving source manifests untouched.

## User Impact

Installed Anthropic Vertex, BytePlus, DeepInfra, DeepSeek, Moonshot, OpenCode, OpenCode Go, Tencent, and Volcengine plugins correctly expose provider metadata during lightweight discovery, implicit configuration, and model catalog loading.

## Evidence

- An authentic extracted npm tarball failed before repair with `ERR_MODULE_NOT_FOUND` for the nonexistent packaged `provider-discovery.ts` path.
- Actual DeepInfra source build, packaging overlay, offline npm pack, tarball extraction, production manifest registry, and real discovery module import now succeed; the original source manifest is restored unchanged.
- CommonJS packaging is separately verified through the real production registry and entries-only provider discovery, preserving both existing channel sidecars.
- All 176 focused packaging, runtime build, manifest registry, provider discovery, and DeepInfra tests pass across five suites.
- Production delta: 37 lines added and 45 removed; type-aware lint, formatting, and fresh complete-diff structured P1 autoreview pass.
