### PR TITLE
chore(ui): refresh startup gzip baseline

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 340388,
-  "reason": "rebase onto current main; startup growth landed on main since the boot-group ratchet",
-  "updatedAt": "2026-08-24"
+  "startupJsGzipBytes": 340901,
+  "reason": "refresh after cumulative current-main UI fixes exhausted the startup tolerance",
+  "updatedAt": "2026-08-26"
 }


### PR DESCRIPTION
## Summary

- refresh the Control UI startup gzip baseline after cumulative current-main UI fixes exhausted the 512-byte tolerance
- keep the 350 KiB hard cap and 512-byte tolerance unchanged

## Root-cause evidence

Three independent jobs on PR #129806 built the same current-main UI graph at 340,906 B, 340,913 B, and 340,907 B against a 340,388 B baseline plus 512 B tolerance (340,900 B limit). The focused failed-job rerun reproduced the same surface.

The baseline predates the current UI sequence. Building the commit immediately before #129747 measured 340,800 B; building latest main measured 340,901 B, and a second latest-main build measured 340,909 B. The recent modal keyboard ownership fix therefore contributes roughly 100 B, while earlier post-baseline UI work had already consumed roughly 412 B of the tolerance. This is cumulative intentional product growth, not a 6-byte OTel/QA change or a reason to weaken the cap.

## Verification

- `pnpm ui:build` on latest main before this change: failed at 340,901 B vs 340,900 B
- `pnpm ui:build` after this change: passed at 340,909 B vs refreshed baseline 340,901 B + unchanged 512 B tolerance
- `pnpm exec vitest run test/scripts/control-ui-performance.test.ts --reporter=dot` — 13 passed
- `node scripts/check-changed.mjs -- config/control-ui-startup-budget-baseline.json` — passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no actionable findings

## Scope

- baseline metadata only: +3/-3
- hard cap unchanged at 350 KiB
- tolerance unchanged at 512 B
- no product code or bundle contents changed

Observed in https://github.com/openclaw/openclaw/actions/runs/32925406420/job/98047541535.
