### PR TITLE
fix(workers): preserve configured Git authors on cloud workers

### DIFF
--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -162,6 +163,126 @@ function workspaceTransfer(): NodeWorkspaceTransferService {
 }
 
 describe("node worker tunnel manager", () => {
+  it.each([
+    ["gateway-push", true],
+    ["published-origin", false],
+  ])("preserves the Gateway Git author through %s workspaces", async (_, dirty) => {
+    const localPath = tempDirs.make("node-worker-git-author-gateway-");
+    const remoteWorkspaceDir = path.join(tempDirs.make("node-worker-git-author-remote-"), "worker");
+    const gitEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: process.platform === "win32" ? "NUL" : "/dev/null",
+      GIT_CONFIG_NOSYSTEM: "1",
+    };
+    delete gitEnv.GIT_AUTHOR_NAME;
+    delete gitEnv.GIT_AUTHOR_EMAIL;
+    delete gitEnv.GIT_COMMITTER_NAME;
+    delete gitEnv.GIT_COMMITTER_EMAIL;
+    const localGit = (args: string[]) =>
+      execFileSync("git", ["-C", localPath, ...args], { encoding: "utf8", env: gitEnv }).trim();
+    localGit(["init", "--quiet"]);
+    localGit(["config", "user.name", "Gateway Repository Author"]);
+    localGit(["config", "user.email", "gateway-author@example.invalid"]);
+    await fs.writeFile(path.join(localPath, "tracked.txt"), "base\n");
+    localGit(["add", "tracked.txt"]);
+    localGit(["commit", "--quiet", "-m", "base"]);
+    localGit(["remote", "add", "origin", "https://example.invalid/repository.git"]);
+    if (dirty) {
+      await fs.writeFile(path.join(localPath, "tracked.txt"), "gateway change\n");
+    }
+    const baseCommit = localGit(["rev-parse", "HEAD"]);
+    const manifest = { version: 1 as const, baseCommit, entries: [] };
+    const rawManifest = serializeWorkerWorkspaceManifest(manifest);
+    const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
+    const nodeTransport = transport();
+    nodeTransport.invoke = vi.fn(async ({ params }) => {
+      const input = params as NodeWorkerWorkspaceExecInput;
+      let stdout = "";
+      let stderr = "";
+      let code = 0;
+      if (input.transfer || input.argv.includes("clone")) {
+        const clone = ["clone", "--quiet", "--no-checkout", localPath, remoteWorkspaceDir];
+        execFileSync("git", clone, { env: gitEnv });
+        if (input.transfer) {
+          execFileSync("git", ["-C", remoteWorkspaceDir, "checkout", "--quiet", baseCommit], {
+            env: gitEnv,
+          });
+          stdout = `${manifestRef}\n`;
+        }
+      } else if (input.argv[0] === "git") {
+        const result = spawnSync("git", ["-C", remoteWorkspaceDir, ...input.argv.slice(1)], {
+          encoding: "utf8",
+          env: gitEnv,
+        });
+        stdout = result.stdout;
+        stderr = result.stderr;
+        code = result.status ?? 1;
+      } else {
+        stdout = `${manifestRef}\n`;
+      }
+      return {
+        ok: true,
+        payloadJSON: JSON.stringify({
+          workspaceDir: remoteWorkspaceDir,
+          stdout,
+          stderr,
+          code,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        }),
+      };
+    });
+    const transfer = {
+      prepareSync: vi.fn(async () => ({
+        snapshot: { manifest, manifestRef, rawManifest, root: localPath },
+        token: "download-token",
+      })),
+      close: vi.fn(async () => {}),
+      revoke: vi.fn(),
+    } as unknown as NodeWorkspaceTransferService;
+    const handle = await createNodeWorkerTunnelManager({
+      gatewayDeviceId: "gateway-device-1",
+      getEnvironment: environment,
+      getTransport: () => nodeTransport,
+      launchNodeWorker: vi.fn(),
+      validateWorkerTurn: () => true,
+      workspaceTransfer: transfer,
+    }).start(startRequest());
+
+    await expect(
+      handle.syncWorkspace({
+        localPath,
+        sessionId: "session-1",
+        generation: 1,
+        gitAuthor: { name: "Configured Gateway Author" },
+      }),
+    ).resolves.toEqual({ mode: "git", remoteWorkspaceDir, manifestRef });
+
+    const commitArgs = [
+      "-c",
+      "user.useConfigOnly=true",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "worker result",
+    ];
+    const commit = spawnSync("git", ["-C", remoteWorkspaceDir, ...commitArgs], {
+      encoding: "utf8",
+      env: gitEnv,
+    });
+    expect(commit.stderr).not.toContain("Author identity unknown");
+    expect(commit.status).toBe(0);
+    expect(
+      execFileSync("git", ["-C", remoteWorkspaceDir, "show", "-s", "--format=%an <%ae>"], {
+        encoding: "utf8",
+        env: gitEnv,
+      }).trim(),
+    ).toBe("Configured Gateway Author <gateway-author@example.invalid>");
+
+    await handle.stop();
+  });
+
   it("revalidates the exact claim when a same-run replacement launches", async () => {
     const record = environment();
     let currentClaim = turnClaim();

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -572,7 +572,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
             const origin = await workspace.trySyncWorkspace(request, prepared.snapshot.manifestRef);
             recordNodeSyncPath(entry.environmentId, entry.sessionId, origin, originStartedAt);
             if (origin.kind === "synced") {
-              return origin.result;
+              return await workspace.finalizeSync(request, origin.result);
             }
             const transferred = await exec({
               argv: ["openclaw-internal-workspace-transfer"],
@@ -591,11 +591,11 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
             ) {
               throw new Error("Node workspace transfer failed");
             }
-            return {
+            return await workspace.finalizeSync(request, {
               mode: prepared.snapshot.manifest.baseCommit ? ("git" as const) : ("plain" as const),
               remoteWorkspaceDir: transferred.workspaceDir,
               manifestRef: prepared.snapshot.manifestRef,
-            };
+            });
           } finally {
             options.workspaceTransfer.revoke(entry.environmentId, prepared.token);
           }

--- a/src/gateway/worker-environments/node-worker-workspace-fallback.test.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-fallback.test.ts
@@ -37,6 +37,10 @@ function cleanWorkspace(): string {
         return spawnResult(COMMIT);
       case "remote get-url origin":
         return spawnResult(ORIGIN);
+      case "config --get user.name":
+        return spawnResult("Gateway Repository Author");
+      case "config --get user.email":
+        return spawnResult("gateway-author@example.invalid");
       case `ls-remote --heads --tags -- ${ORIGIN}`:
         return spawnResult(`${ADVERTISED_TIP}\trefs/heads/main\n`);
       default:
@@ -92,5 +96,91 @@ describe("node worker workspace origin fallback", () => {
       ),
     ).resolves.toEqual({ kind: "fallback", reason });
     expect(exec).toHaveBeenCalledTimes(commandCount);
+  });
+
+  it.each([
+    {
+      label: "fully inherited identity",
+      gitAuthor: undefined,
+      expected: ["Gateway Repository Author", "gateway-author@example.invalid"],
+    },
+    {
+      label: "configured name with inherited email",
+      gitAuthor: { name: "Configured Author" },
+      expected: ["Configured Author", "gateway-author@example.invalid"],
+    },
+    {
+      label: "inherited name with configured email",
+      gitAuthor: { email: "configured@example.invalid" },
+      expected: ["Gateway Repository Author", "configured@example.invalid"],
+    },
+  ])("projects $label into a materialized Git workspace", async ({ gitAuthor, expected }) => {
+    const localPath = cleanWorkspace();
+    const exec = vi.fn<WorkspaceExec>(async () => ({
+      ...spawnResult(),
+      workspaceDir: REMOTE_WORKSPACE,
+    }));
+    const result = {
+      mode: "git" as const,
+      remoteWorkspaceDir: REMOTE_WORKSPACE,
+      manifestRef: MANIFEST_REF,
+    };
+
+    await expect(
+      createNodeWorkerWorkspaceFallback(exec).finalizeSync(
+        { localPath, sessionId: "session-1", generation: 1, ...(gitAuthor ? { gitAuthor } : {}) },
+        result,
+      ),
+    ).resolves.toEqual(result);
+    expect(exec.mock.calls.map(([command]) => command.argv.slice(-2))).toEqual([
+      ["user.name", expected[0]],
+      ["user.email", expected[1]],
+    ]);
+  });
+
+  it("fails closed when a node rejects its Gateway Git author", async () => {
+    const localPath = cleanWorkspace();
+    const exec = vi.fn<WorkspaceExec>(async () => ({
+      ...spawnResult("", 1),
+      stderr: "node Git config rejected the author",
+      workspaceDir: REMOTE_WORKSPACE,
+    }));
+
+    await expect(
+      createNodeWorkerWorkspaceFallback(exec).finalizeSync(
+        { localPath, sessionId: "session-1", generation: 1 },
+        { mode: "git", remoteWorkspaceDir: REMOTE_WORKSPACE, manifestRef: MANIFEST_REF },
+      ),
+    ).rejects.toThrow("Worker workspace sync failed: node Git config rejected the author");
+  });
+
+  it("does not apply Git author configuration to a plain workspace", async () => {
+    const localPath = cleanWorkspace();
+    const exec = vi.fn<WorkspaceExec>();
+    const result = {
+      mode: "plain" as const,
+      remoteWorkspaceDir: REMOTE_WORKSPACE,
+      manifestRef: MANIFEST_REF,
+    };
+
+    await expect(
+      createNodeWorkerWorkspaceFallback(exec).finalizeSync(
+        { localPath, sessionId: "session-1", generation: 1, gitAuthor: { name: "Configured" } },
+        result,
+      ),
+    ).resolves.toEqual(result);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed Git authors before inspecting a node workspace", async () => {
+    const localPath = cleanWorkspace();
+
+    await expect(
+      createNodeWorkerWorkspaceFallback(vi.fn<WorkspaceExec>()).trySyncWorkspace(
+        { localPath, sessionId: "session-1", generation: 1, gitAuthor: { name: "invalid\nname" } },
+        MANIFEST_REF,
+      ),
+    ).rejects.toThrow("Worker workspace Git author metadata is invalid");
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/worker-environments/node-worker-workspace-fallback.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-fallback.ts
@@ -3,6 +3,11 @@ import path from "node:path";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { runCommandWithTimeout, type SpawnResult } from "../../process/exec.js";
 import type { WorkerWorkspaceSyncRequest, WorkerWorkspaceSyncResult } from "./tunnel-contract.js";
+import {
+  resolveWorkerWorkspaceGitAuthor,
+  validateWorkspaceSyncRequest,
+  workspaceSyncError,
+} from "./workspace-sync-helpers.js";
 import { REMOTE_WORKSPACE_MANIFEST_JS } from "./workspace-sync-scripts.js";
 
 const GIT_TIMEOUT_MS = 60_000;
@@ -160,6 +165,7 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
       request: WorkerWorkspaceSyncRequest,
       expectedManifestRef: string,
     ): Promise<OriginSyncOutcome> {
+      validateWorkspaceSyncRequest(request);
       const inspection = await inspectEligibleOrigin(request.localPath);
       if (inspection.kind === "fallback") {
         return inspection;
@@ -223,6 +229,31 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
         kind: "synced",
         result: { mode: "git", remoteWorkspaceDir: checkedOut.workspaceDir, manifestRef },
       };
+    },
+    async finalizeSync(
+      request: WorkerWorkspaceSyncRequest,
+      result: WorkerWorkspaceSyncResult,
+    ): Promise<WorkerWorkspaceSyncResult> {
+      if (result.mode === "plain") {
+        return result;
+      }
+      const author = await resolveWorkerWorkspaceGitAuthor(request, async (argv) =>
+        runCommandWithTimeout(argv, { timeoutMs: GIT_TIMEOUT_MS, maxOutputBytes: 1024 }),
+      );
+      const git = ["git", "-C", result.remoteWorkspaceDir, "config", "--local"];
+      for (const [key, value] of Object.entries(author)) {
+        if (!value) {
+          continue;
+        }
+        const configured = await exec({
+          argv: [...git, `user.${key}`, value],
+          transportRetry: "never",
+        });
+        if (!succeeded(configured)) {
+          throw workspaceSyncError(configured);
+        }
+      }
+      return result;
     },
   };
 }

--- a/src/gateway/worker-environments/workspace-sync-helpers.ts
+++ b/src/gateway/worker-environments/workspace-sync-helpers.ts
@@ -323,6 +323,19 @@ export async function probeWorkspaceGitMode(params: {
   throw workspaceSyncError(gitBaseResult);
 }
 
+export async function resolveWorkerWorkspaceGitAuthor(
+  request: Pick<WorkerWorkspaceSyncRequest, "localPath" | "gitAuthor">,
+  runTask: (argv: string[]) => Promise<SpawnResult>,
+): Promise<{ name: string; email: string }> {
+  const git = ["git", "-C", request.localPath, "config", "--get"];
+  const read = async (key: "name" | "email") => {
+    const result = await runTask([...git, `user.${key}`]);
+    return workerWorkspaceCommandSucceeded(result) ? result.stdout.trim() : "";
+  };
+  const [name, email] = await Promise.all([read("name"), read("email")]);
+  return { name: request.gitAuthor?.name ?? name, email: request.gitAuthor?.email ?? email };
+}
+
 export function stableWorkerPathComponent(value: string, length: number): string {
   return createHash("sha256").update(value).digest("hex").slice(0, length);
 }

--- a/src/gateway/worker-environments/workspace-sync.ts
+++ b/src/gateway/worker-environments/workspace-sync.ts
@@ -51,6 +51,7 @@ import {
   parseRemoteWorkspaceSetup,
   probeWorkspaceGitMode,
   readTransferredManifest,
+  resolveWorkerWorkspaceGitAuthor,
   resolveRemoteWorkspaceManifest,
   stableWorkerPathComponent,
   validateWorkspaceSyncRequest,
@@ -298,20 +299,15 @@ export function createWorkerWorkspaceActions(
         if (!success(packTransfer)) {
           throw workspaceSyncError(packTransfer);
         }
-        const [detectedAuthorName, detectedAuthorEmail] = await Promise.all(
-          ["user.name", "user.email"].map(async (key) => {
-            const result = await runTask(
-              ["git", "-C", gitRoot, "config", "--get", key],
-              workerSshCommandOptions({
-                timeoutMs: REMOTE_SETUP_TIMEOUT_MS,
-                signal: options.ownerSignal,
-              }),
-            );
-            return success(result) ? result.stdout.trim() : "";
-          }),
+        const author = await resolveWorkerWorkspaceGitAuthor(request, async (argv) =>
+          runTask(
+            argv,
+            workerSshCommandOptions({
+              timeoutMs: REMOTE_SETUP_TIMEOUT_MS,
+              signal: options.ownerSignal,
+            }),
+          ),
         );
-        const authorName = request.gitAuthor?.name ?? detectedAuthorName;
-        const authorEmail = request.gitAuthor?.email ?? detectedAuthorEmail;
         const seeded = await runWorkspaceCommand({
           transportRetry: "never",
           argv: [
@@ -321,8 +317,8 @@ export function createWorkerWorkspaceActions(
             remoteWorkspaceDir,
             path.posix.join(remoteWorkspaceDir, REMOTE_GIT_PACK_NAME),
             baseCommit,
-            authorName ?? "",
-            authorEmail ?? "",
+            author.name,
+            author.email,
           ],
           input: REMOTE_GIT_WORKSPACE_SETUP_SCRIPT,
         });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running coding sessions on cloud workers or paired devices could create commits under the device account instead of the configured Gateway Git identity. Devices requiring an explicitly configured Git author rejected those commits with `Author identity unknown`.

## Why This Change Was Made

Node-backed workspace synchronization materialized a fresh Git checkout but discarded the effective author identity that SSH-backed workers already preserve. Resolve configured and repository-inherited author fields through one shared Gateway-owned policy, then project the resulting identity into the worker checkout through the existing authenticated workspace command after either published-origin cloning or Gateway transfer. Plain workspaces remain unchanged, malformed author data and failed configuration reject the dispatch, and the node protocol, credential boundaries, persistence, and schemas do not change.

## User Impact

Cloud-worker and paired-device Git commits now retain the configured author and committer identity, including partial per-agent overrides that inherit the other field from the Gateway repository. Strict Git installations can create commits without receiving GitHub credentials or modifying global Git configuration.

## Evidence

- Fail-first production-owner regressions reproduced `Author identity unknown` and exit 128 through both published-origin cloning and Gateway workspace transfer.
- The fixed regressions perform real Git clones and strict `user.useConfigOnly=true` commits, then verify the exact resulting author on both synchronization paths.
- Additional owner coverage verifies fully inherited identity, independently overridden name and email, plain-workspace exclusion, malformed author rejection, and fail-closed worker Git configuration.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/node-worker-tunnel.test.ts src/gateway/worker-environments/node-worker-workspace-fallback.test.ts` — 27 tests passed.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/workspace-sync-tunnel.test.ts -t 'syncs a dirty workspace over pinned rsync'` — existing SSH author propagation passed.
- Full changed-source validation passed, including production and all core-test typechecks, targeted lint, repository architecture/security guards, and seven macOS CI Vitest shards covering 488 tests. The identical full-tree dead-export scan also passed separately.
- Production delta: +40 lines for authenticated per-workspace Git-author projection and the shared SSH/node identity contract; tests: +211 lines.
