### PR TITLE
fix(codex): keep live commentary tables and code blocks readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Codex live commentary formatting:** preserve Markdown line breaks and code indentation in streamed progress updates so tables, paragraphs, and fenced code blocks render correctly before the response finishes.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Codex live commentary formatting:** preserve Markdown line breaks and code indentation in streamed progress updates so tables, paragraphs, and fenced code blocks render correctly before the response finishes.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -514,7 +514,7 @@ export class CodexAssistantProjection {
   }
 
   private emitCommentaryProgress(params: { itemId: string; text: string }): void {
-    const progressText = params.text.replace(/\s+/g, " ").trim();
+    const progressText = params.text.trim();
     if (
       !progressText ||
       this.lastCommentaryProgressTextByItem.get(params.itemId) === progressText

--- a/extensions/codex/src/app-server/event-projector.commentary.test.ts
+++ b/extensions/codex/src/app-server/event-projector.commentary.test.ts
@@ -206,6 +206,18 @@ describe("CodexAppServerEventProjector commentary projection", () => {
   it("streams commentary agent messages as keyed progress events", async () => {
     const onAgentEvent = vi.fn();
     const onPartialReply = vi.fn();
+    const commentaryText = [
+      "Checking the app-server stream",
+      "",
+      "| Intent | Command |",
+      "| --- | --- |",
+      "| Session only | `/model opus` |",
+      "",
+      "```text",
+      "BEFORE  /model opus  → persistent",
+      "AFTER   /model opus  → session only",
+      "```",
+    ].join("\n");
     const projector = await createProjector({
       ...(await createParams()),
       onAgentEvent,
@@ -224,7 +236,7 @@ describe("CodexAppServerEventProjector commentary projection", () => {
     );
     await projector.handleNotification(agentMessageDelta("Checking", "msg-commentary"));
     await projector.handleNotification(
-      agentMessageDelta(" the app-server stream", "msg-commentary"),
+      agentMessageDelta(commentaryText.slice("Checking".length), "msg-commentary"),
     );
     await projector.handleNotification(
       turnCompleted([
@@ -232,7 +244,7 @@ describe("CodexAppServerEventProjector commentary projection", () => {
           type: "agentMessage",
           id: "msg-commentary",
           phase: "commentary",
-          text: "Checking the app-server stream",
+          text: commentaryText,
         },
         {
           type: "agentMessage",
@@ -262,7 +274,7 @@ describe("CodexAppServerEventProjector commentary projection", () => {
         kind: "preamble",
         title: "Preamble",
         phase: "update",
-        progressText: "Checking the app-server stream",
+        progressText: commentaryText,
         source: "codex-app-server",
       },
     ]);
@@ -276,9 +288,9 @@ describe("CodexAppServerEventProjector commentary projection", () => {
     );
     expect(commentary).toMatchObject({
       role: "assistant",
-      content: [{ type: "text", text: "Checking the app-server stream" }],
+      content: [{ type: "text", text: commentaryText }],
       openclawStreamFallback: {
-        replacementText: "Checking the app-server stream",
+        replacementText: commentaryText,
         source: "segment",
         itemId: "msg-commentary",
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users watching live Codex commentary would see Markdown tables, paragraph breaks, indentation, and fenced code blocks collapse into one unreadable paragraph while an agent was working. The same commentary looked correct after the response completed because persisted transcript entries retained the original Markdown.

## Why This Change Was Made

Preserve the original whitespace at the Codex commentary event producer instead of flattening every whitespace run into a space. The upstream Codex app-server protocol forwards assistant-message deltas verbatim (`codex-rs/app-server-protocol/src/protocol/event_mapping.rs:362-370`), declares each delta as an unmodified string (`codex-rs/app-server-protocol/src/protocol/v2/item.rs:1348-1356`), and assembles completed agent-message text without whitespace normalization (`codex-rs/app-server-protocol/src/protocol/v2/item.rs:826-837`). The existing Control UI Markdown renderer already correctly handles multiline streamed tables and fenced code. Outer trimming and per-item duplicate suppression remain unchanged.

## User Impact

Live Codex progress updates now keep readable Markdown tables, paragraphs, fenced code blocks, and code indentation instead of becoming a wall of literal pipes and inline code.

## Evidence

- Reproduced the reported issue against the live Control UI and recovered the exact persisted commentary: it contained 21 newline characters, a valid table, and a fenced code block; applying the existing producer's whitespace replacement reproduced the screenshot exactly.
- Extended the existing Codex commentary projector regression with a real Markdown table and fenced code block. Before the fix it failed because `progressText` flattened the complete message into one line; after the fix both owner-boundary projector suites pass: 44 tests across two files.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.commentary.test.ts extensions/codex/src/app-server/event-projector.assistant.test.ts`
- `node scripts/check-changed.mjs -- extensions/codex/src/app-server/event-projector-assistant.ts extensions/codex/src/app-server/event-projector.commentary.test.ts`
- Structured Codex autoreview: clean, with no actionable findings.
- Real Control UI proof: a deterministic mocked Gateway emits the same keyed preamble first with the old flattened producer output and then with the fixed multiline output while the run remains active. Browser assertions verify zero tables/code blocks before, then a two-row table and fenced code block afterward. The screenshots use only synthetic, public-safe fixture data.

### Before: live commentary flattened into one paragraph

![Before: live commentary renders literal Markdown pipes and an inline code fence](https://github.com/user-attachments/assets/893101de-0fe3-44fb-988b-b7a2de6df71d)

### After: live commentary preserves the table and fenced code block

![After: live commentary renders a readable Markdown table and fenced code block](https://github.com/user-attachments/assets/84276311-6931-461e-821d-4c2e763582f7)

Production LOC: +1/-1 (net 0). Tests: +17/-5.
