### PR TITLE
fix(release): approved VCR mirror recovery never starts

### DIFF
--- a/.github/workflows/vercel-container-registry-publish.yml
+++ b/.github/workflows/vercel-container-registry-publish.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     # Release mirroring is advisory; approved recovery must fail visibly.
-    continue-on-error: ${{ inputs.advisory }}
+    continue-on-error: ${{ inputs.advisory == true }}
     permissions:
       contents: read
     steps:

--- a/test/scripts/vercel-container-registry-publish.test.ts
+++ b/test/scripts/vercel-container-registry-publish.test.ts
@@ -486,6 +486,17 @@ describe("Vercel Container Registry publishing", () => {
     expect(copyStep?.run).toContain("${alias}=${SOURCE_IMAGE}@${digest}");
   });
 
+  it("keeps direct VCR recovery blocking without exposing an advisory dispatch input", () => {
+    const reusable = readWorkflow(".github/workflows/vercel-container-registry-publish.yml");
+    const releaseWorkflow = readWorkflow(".github/workflows/openclaw-release-publish.yml");
+
+    expect(reusable.on?.workflow_dispatch?.inputs).not.toHaveProperty("advisory");
+    expect(requireJob(reusable, "publish")["continue-on-error"]).toBe(
+      "${{ inputs.advisory == true }}",
+    );
+    expect(requireJob(releaseWorkflow, "publish_vcr").with?.advisory).toBe(true);
+  });
+
   it("isolates best-effort VCR publication from Docker and GitHub release finalization", () => {
     const reusable = readWorkflow(".github/workflows/vercel-container-registry-publish.yml");
     const dockerRelease = readWorkflow(".github/workflows/docker-release.yml");
@@ -542,7 +553,6 @@ describe("Vercel Container Registry publishing", () => {
     expect(reusablePublish.if).toBe(
       "${{ always() && (inputs.advisory || (needs.validate_recovery.result == 'success' && needs.approve_recovery.result == 'success')) }}",
     );
-    expect(reusablePublish["continue-on-error"]).toBe("${{ inputs.advisory }}");
     expect(reusablePublish.permissions).toEqual({ contents: "read" });
     expect(reusablePublish["timeout-minutes"]).toBe(30);
 
@@ -576,7 +586,6 @@ describe("Vercel Container Registry publishing", () => {
       required: true,
       type: "boolean",
     });
-    expect(reusable.on?.workflow_dispatch?.inputs).not.toHaveProperty("advisory");
     expect(reusable.on?.workflow_dispatch?.inputs).toEqual({
       include_browser: reusable.on?.workflow_call?.inputs?.include_browser,
       source_digests: reusable.on?.workflow_call?.inputs?.source_digests,


### PR DESCRIPTION
Related: #129467, #129466

## What Problem This Solves

Fixes an issue where release operators starting an approved mirror-only Vercel Container Registry recovery would see the workflow fail after approval because GitHub Actions never created the publishing job.

Observed failure: https://github.com/openclaw/openclaw/actions/runs/32926021420

That direct recovery run completed `validate_recovery` and `approve_recovery` successfully, but no `publish` job was materialized. **No VCR I/O occurred in the failed run:** there was no registry authentication, image inspection/copy, Sandbox operation, or registry write.

## Why This Change Was Made

The direct `workflow_dispatch` contract intentionally omits the caller-only `advisory` input, so its missing value resolves to an empty string. Passing that value directly to the boolean job-level `continue-on-error` field prevents GitHub Actions from creating the job.

Compare the input explicitly with `true` so automated reusable-workflow calls remain advisory while approved direct recovery receives a real `false` and remains blocking. The dispatch schema, main-only validation, protected `docker-release` approval, immutable-source attestation/version checks, and registry write ordering are unchanged. This implementation was AI-assisted and reviewed by the maintainer.

## User Impact

Release operators can retry an already-published Docker image's protected, mirror-only VCR recovery and receive a visible failure if publishing fails. Automated release mirroring remains best-effort, and operators cannot set an advisory recovery mode.

## Evidence

- Failed-run metadata proves both recovery-gate jobs succeeded, the publish job never existed, and no VCR I/O occurred: https://github.com/openclaw/openclaw/actions/runs/32926021420
- The new focused regression was first run against the unmodified workflow and failed with `expected '${{ inputs.advisory }}' to be '${{ inputs.advisory == true }}'`.
- `node scripts/run-vitest.mjs test/scripts/vercel-container-registry-publish.test.ts test/scripts/docker-channel-promote.test.ts`: 43 tests passed.
- `node --import tsx scripts/check-workflows.mts`: workflow validation and `zizmor` passed.
- `node scripts/check-changed.mjs -- .github/workflows/vercel-container-registry-publish.yml test/scripts/vercel-container-registry-publish.test.ts`: formatting, root-test typechecking, script lint, and all selected guards passed.
- Initial PR CI exposed the independently fixed Control UI gzip-budget regression; rebased onto merged #129824 and verified `node scripts/ui.js build` passes at 340,907 B against the refreshed 340,901 B baseline plus its unchanged 512 B tolerance.
- `git diff --check` passed.
- Fresh structured Codex autoreview through P1: no accepted/actionable findings.
- The structural regression proves direct dispatch has no `advisory` input, the publish job's error policy is an explicit boolean comparison, and the automated release caller still passes `advisory: true`.
- Production/workflow delta: +1/-1 (net 0). Tests: +11/-2 (net +9).
- No recovery workflow has been dispatched as part of this repair. Live post-merge VCR recovery is intentionally reserved for the parent/operator; this PR does not claim live publication proof.
