### PR TITLE
fix(qa): reject token confidence lanes without executed evidence

### DIFF
--- a/extensions/qa-lab/src/confidence-report.test.ts
+++ b/extensions/qa-lab/src/confidence-report.test.ts
@@ -449,39 +449,55 @@ describe("qa confidence report", () => {
     }
   });
 
-  it("rejects skipped token reports when a live usage source is required", async () => {
-    await writeJson("live-token/qa-runtime-token-efficiency-summary.json", {
-      status: "skipped",
-      pass: true,
-      rows: [],
-    });
+  it.each([
+    ["skipped", "skipped", [], undefined, false, "token summary has no usage rows"],
+    ["empty", "estimated", [], undefined, false, "token summary has no usage rows"],
+    ["missing", "estimated", undefined, undefined, false, "token summary missing rows"],
+    [
+      "executed",
+      "estimated",
+      [{ usageSource: "mock-estimate" }],
+      undefined,
+      true,
+      "summary pass=true",
+    ],
+    ["live", "skipped", [], "live-usage", false, "token summary has no live-usage rows"],
+  ] as const)(
+    "evaluates %s token evidence",
+    async (_name, status, rows, expectedSource, passed, details) => {
+      await writeJson("live-token/qa-runtime-token-efficiency-summary.json", {
+        status,
+        pass: true,
+        ...(rows ? { rows } : {}),
+      });
 
-    const report = await buildQaConfidenceReport({
-      manifest: {
-        version: 1,
-        profile: "codex-100",
-        lanes: [
-          {
-            id: "live-token-efficiency",
-            title: "Live token efficiency",
-            kind: "token-efficiency-summary",
-            artifact: "live-token/qa-runtime-token-efficiency-summary.json",
-            required: true,
-            expectedTokenUsageSource: "live-usage",
-          },
-        ],
-      },
-      artifactRoot: tempRoot,
-      strictZeroUnknowns: true,
-      generatedAt: "2026-05-12T00:00:00.000Z",
-    });
+      const report = await buildQaConfidenceReport({
+        manifest: {
+          version: 1,
+          profile: "codex-100",
+          lanes: [
+            {
+              id: "live-token-efficiency",
+              title: "Live token efficiency",
+              kind: "token-efficiency-summary",
+              artifact: "live-token/qa-runtime-token-efficiency-summary.json",
+              required: true,
+              ...(expectedSource ? { expectedTokenUsageSource: expectedSource } : {}),
+            },
+          ],
+        },
+        artifactRoot: tempRoot,
+        strictGlobalPass: true,
+      });
 
-    expect(report.pass).toBe(false);
-    expect(report.lanes[0]).toMatchObject({
-      status: "unknown",
-      details: "token summary has no live-usage rows",
-    });
-  });
+      expect(report.pass).toBe(passed);
+      expect(report.globalPass).toBe(passed);
+      expect(report.lanes[0]).toMatchObject({
+        status: passed ? "pass" : "unknown",
+        details,
+      });
+    },
+  );
 
   it("preserves partial zero-unknown mode for classified failing lanes", async () => {
     await writeJson("classified/qa-suite-summary.json", {

--- a/extensions/qa-lab/src/confidence-report.ts
+++ b/extensions/qa-lab/src/confidence-report.ts
@@ -549,22 +549,22 @@ function evaluateTokenEfficiencySummary(
   expectedTokenUsageSource: QaConfidenceManifestLane["expectedTokenUsageSource"],
 ): QaConfidenceLaneEvaluation {
   const base = evaluatePassSummary(payload);
-  if (!base.passed || !expectedTokenUsageSource) {
+  if (!base.passed || !isRecord(payload)) {
     return base;
   }
-  if (!isRecord(payload) || !Array.isArray(payload.rows)) {
+  const rows = Array.isArray(payload.rows) ? payload.rows : undefined;
+  if (!rows || rows.length === 0 || readString(payload.status) === "skipped") {
     return {
       passed: false,
-      details: `token summary missing rows for expected usageSource=${expectedTokenUsageSource}`,
+      details: !rows
+        ? `token summary missing rows${expectedTokenUsageSource ? ` for expected usageSource=${expectedTokenUsageSource}` : ""}`
+        : `token summary has no ${expectedTokenUsageSource ?? "usage"} rows`,
     };
   }
-  if (readString(payload.status) === "skipped" || payload.rows.length === 0) {
-    return {
-      passed: false,
-      details: `token summary has no ${expectedTokenUsageSource} rows`,
-    };
+  if (!expectedTokenUsageSource) {
+    return base;
   }
-  const mismatched = payload.rows.filter(
+  const mismatched = rows.filter(
     (row) => !isRecord(row) || row.usageSource !== expectedTokenUsageSource,
   );
   return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA operators using a required token-efficiency confidence lane without an expected usage-source filter would receive a successful strict confidence verdict even when the lane was skipped, contained no usage rows, or omitted its evidence entirely.

## Why This Change Was Made

Validate the actual token-evidence rows before applying the optional usage-source filter. Keep the token-report producer's intentional standalone skip semantics, existing source-specific diagnostics, and all configured confidence profiles unchanged.

## User Impact

Required token-efficiency lanes can no longer silently turn zero executed scenarios into a green confidence report. Valid unfiltered evidence and existing live/mock usage-source checks continue to behave as before.

## Evidence

- RED: the real QA confidence suite failed three new owner-boundary cases before the fix because skipped, empty, and missing evidence all incorrectly returned `pass: true`.
- GREEN: the confidence-report and token-efficiency-report owner/sibling suites pass all 62 tests, including an unfiltered executed-evidence control and the existing live-usage failure contract.
- Strict production TypeScript project: 10,500 source files, zero diagnostics.
- Strict test TypeScript project: 10,550 source files, zero diagnostics.
- Focused oxlint, canonical formatting checks, and staged whitespace checks pass; the existing 1,000-line test-file limit remains satisfied without suppressions.
- Independent review and fresh authenticated Codex review both report no findings.
- Production code: +9/-9, net zero. Tests: +47/-31, net +16.
