### PR TITLE
fix(ollama): skip local checks for hosted web search

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -608,7 +608,7 @@ First-run Q&A - install, onboard, auth routes, subscriptions, initial failures -
     | Grok | No (xAI OAuth or key) | `XAI_API_KEY` |
     | Kimi | No | `KIMI_API_KEY` or `MOONSHOT_API_KEY` |
     | MiniMax Search | No | `MINIMAX_CODE_PLAN_KEY`, `MINIMAX_CODING_API_KEY`, or `MINIMAX_API_KEY` |
-    | Ollama Web Search | Yes (needs `ollama signin`) | - |
+    | Ollama Web Search | Local: yes (needs `ollama signin`); hosted: no | Hosted: `OLLAMA_API_KEY` |
     | Perplexity | No | `PERPLEXITY_API_KEY` or `OPENROUTER_API_KEY` |
     | SearXNG | Yes (self-hosted) | `SEARXNG_BASE_URL` |
     | Tavily | No | `TAVILY_API_KEY` |

--- a/docs/tools/ollama-search.md
+++ b/docs/tools/ollama-search.md
@@ -17,6 +17,11 @@ Ollama host plus `ollama signin`. Direct hosted search (no local Ollama) needs
 
 ## Setup
 
+If you already use Ollama for models, Ollama Web Search reuses the same
+configured host.
+
+### Local Ollama
+
 <Steps>
   <Step title="Start Ollama">
     Make sure Ollama is installed and running.
@@ -36,8 +41,15 @@ Ollama host plus `ollama signin`. Direct hosted search (no local Ollama) needs
   </Step>
 </Steps>
 
-If you already use Ollama for models, Ollama Web Search reuses the same
-configured host.
+### Hosted Ollama
+
+1. Create an [Ollama API key](https://docs.ollama.com/api/authentication#api-keys)
+   and set `OLLAMA_API_KEY` in the Gateway environment.
+2. Set `models.providers.ollama.baseUrl` to `https://ollama.com`; see
+   [Config](#config).
+3. Run `openclaw configure --section web` and select **Ollama Web Search**.
+
+Hosted search does not require a local Ollama daemon or `ollama signin`.
 
 <Note>
   OpenClaw never auto-selects Ollama Web Search over a higher-priority

--- a/docs/tools/ollama-search.md
+++ b/docs/tools/ollama-search.md
@@ -134,8 +134,9 @@ Direct hosted Ollama Web Search (no local Ollama):
   and `OLLAMA_API_KEY` is set, it retries once against
   `https://ollama.com/api/web_search` with that key — without sending it to
   the local host.
-- OpenClaw warns during setup if Ollama is unreachable or not signed in, but
-  does not block selecting the provider.
+- OpenClaw warns during setup if a local Ollama host is unreachable or not
+  signed in, or if hosted search has no API key. These warnings do not block
+  selecting the provider.
 
 ## Related
 

--- a/extensions/ollama/src/web-search-provider.runtime.ts
+++ b/extensions/ollama/src/web-search-provider.runtime.ts
@@ -346,10 +346,9 @@ export function createOllamaWebSearchProvider(): WebSearchProviderPlugin {
     setCredentialValue: () => {},
     applySelectionConfig: (config) => enablePluginInConfig(config, "ollama").config,
     runSetup: async (ctx) =>
-      await warnOllamaWebSearchPrereqs({
-        config: ctx.config,
-        prompter: ctx.prompter,
-      }),
+      isOllamaCloudBaseUrl(resolveOllamaWebSearchBaseUrl(ctx.config))
+        ? ctx.config
+        : await warnOllamaWebSearchPrereqs(ctx),
     createTool: (ctx) => ({
       description: OLLAMA_WEB_SEARCH_TOOL_DESCRIPTION,
       parameters: OLLAMA_WEB_SEARCH_TOOL_PARAMETERS,

--- a/extensions/ollama/src/web-search-provider.runtime.ts
+++ b/extensions/ollama/src/web-search-provider.runtime.ts
@@ -22,7 +22,7 @@ import {
 import { coerceSecretRef } from "openclaw/plugin-sdk/secret-input";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { OLLAMA_DEFAULT_BASE_URL } from "./defaults.js";
+import { OLLAMA_CLOUD_BASE_URL, OLLAMA_DEFAULT_BASE_URL } from "./defaults.js";
 import { readProviderBaseUrl } from "./provider-base-url.js";
 import {
   buildOllamaBaseUrlSsrFPolicy,
@@ -37,10 +37,11 @@ import {
 
 const OLLAMA_HOSTED_WEB_SEARCH_PATH = "/api/web_search";
 const OLLAMA_LOCAL_WEB_SEARCH_PROXY_PATH = "/api/experimental/web_search";
-const OLLAMA_CLOUD_BASE_URL = "https://ollama.com";
 const DEFAULT_OLLAMA_WEB_SEARCH_COUNT = 5;
 const DEFAULT_OLLAMA_WEB_SEARCH_TIMEOUT_MS = 15_000;
 const OLLAMA_WEB_SEARCH_SNIPPET_MAX_CHARS = 300;
+const OLLAMA_CLOUD_WEB_SEARCH_AUTH_ERROR =
+  "Hosted Ollama Web Search requires an API key. Set OLLAMA_API_KEY or configure models.providers.ollama.apiKey.";
 
 type OllamaWebSearchResult = {
   title?: string;
@@ -220,7 +221,11 @@ async function runOllamaWebSearch(params: {
 
     try {
       if (response.status === 401) {
-        throw new Error("Ollama web search authentication failed. Run `ollama signin`.");
+        throw new Error(
+          isOllamaCloudBaseUrl(attempt.baseUrl)
+            ? OLLAMA_CLOUD_WEB_SEARCH_AUTH_ERROR
+            : "Ollama web search authentication failed. Run `ollama signin`.",
+        );
       }
       if (response.status === 403) {
         throw new Error(
@@ -243,11 +248,7 @@ async function runOllamaWebSearch(params: {
       params.signal?.throwIfAborted();
       break;
     } catch (error) {
-      if (error instanceof Error) {
-        lastError = error;
-      } else {
-        lastError = new Error(String(error));
-      }
+      lastError = error instanceof Error ? error : new Error(String(error));
       throw lastError;
     } finally {
       // The 401/403 branches throw before the stream is touched, leaving release
@@ -301,14 +302,20 @@ async function warnOllamaWebSearchPrereqs(params: {
   };
 }): Promise<OpenClawConfig> {
   const baseUrl = resolveOllamaWebSearchBaseUrl(params.config);
+  if (isOllamaCloudBaseUrl(baseUrl)) {
+    if (
+      !resolveConfiguredOllamaWebSearchApiKey(params.config) &&
+      !resolveEnvOllamaWebSearchApiKey()
+    ) {
+      await params.prompter.note(OLLAMA_CLOUD_WEB_SEARCH_AUTH_ERROR, "Ollama Web Search");
+    }
+    return params.config;
+  }
+
   const { reachable } = await fetchOllamaModels(baseUrl);
   if (!reachable) {
     await params.prompter.note(
-      [
-        "Ollama Web Search requires Ollama to be running.",
-        `Expected host: ${baseUrl}`,
-        "Start Ollama before using this provider.",
-      ].join("\n"),
+      `Ollama Web Search requires Ollama to be running.\nExpected host: ${baseUrl}\nStart Ollama before using this provider.`,
       "Ollama Web Search",
     );
     return params.config;
@@ -318,10 +325,7 @@ async function warnOllamaWebSearchPrereqs(params: {
   const auth = await checkOllamaCloudAuth(baseUrl);
   if (!auth.signedIn) {
     await params.prompter.note(
-      [
-        "Ollama Web Search requires `ollama signin`.",
-        ...(auth.signinUrl ? [auth.signinUrl] : ["Run `ollama signin`."]),
-      ].join("\n"),
+      `Ollama Web Search requires \`ollama signin\`.\n${auth.signinUrl ?? "Run `ollama signin`."}`,
       "Ollama Web Search",
     );
   }
@@ -345,10 +349,7 @@ export function createOllamaWebSearchProvider(): WebSearchProviderPlugin {
     getCredentialValue: () => undefined,
     setCredentialValue: () => {},
     applySelectionConfig: (config) => enablePluginInConfig(config, "ollama").config,
-    runSetup: async (ctx) =>
-      isOllamaCloudBaseUrl(resolveOllamaWebSearchBaseUrl(ctx.config))
-        ? ctx.config
-        : await warnOllamaWebSearchPrereqs(ctx),
+    runSetup: async (ctx) => await warnOllamaWebSearchPrereqs(ctx),
     createTool: (ctx) => ({
       description: OLLAMA_WEB_SEARCH_TOOL_DESCRIPTION,
       parameters: OLLAMA_WEB_SEARCH_TOOL_PARAMETERS,

--- a/extensions/ollama/src/web-search-provider.test.ts
+++ b/extensions/ollama/src/web-search-provider.test.ts
@@ -5,6 +5,7 @@ import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createStreamingResponse } from "../../test-support/streaming-error-response.js";
 import { createOllamaWebSearchProvider as createContractOllamaWebSearchProvider } from "../web-search-contract-api.js";
+import { createLazyOllamaWebSearchProvider } from "./web-search-provider-registration.js";
 import { createOllamaWebSearchProvider } from "./web-search-provider.js";
 
 const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
@@ -40,8 +41,10 @@ function createOllamaConfig(provider: OllamaProviderConfigOverride = {}): OpenCl
   };
 }
 
-async function runOllamaWebSearchSetup(config: OpenClawConfig) {
-  const provider = createOllamaWebSearchProvider();
+async function runOllamaWebSearchSetup(
+  config: OpenClawConfig,
+  provider = createOllamaWebSearchProvider(),
+) {
   if (!provider.runSetup) {
     throw new Error("Expected Ollama web search setup");
   }
@@ -501,6 +504,37 @@ describe("ollama web search provider", () => {
         "Start Ollama before using this provider.",
       ].join("\n"),
     );
+  });
+
+  it.each([
+    {
+      name: "the configured model provider",
+      config: createOllamaConfig({ baseUrl: "https://ollama.com", apiKey: "hosted-test-key" }),
+    },
+    {
+      name: "the plugin's higher-priority web search override",
+      config: {
+        ...createOllamaConfig(),
+        plugins: {
+          entries: {
+            ollama: { config: { webSearch: { baseUrl: "https://ollama.com/v1" } } },
+          },
+        },
+      },
+    },
+  ])("does not require a local daemon when $name selects hosted search", async ({ config }) => {
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce(guardedResponse({ models: [] }))
+      .mockResolvedValueOnce(guardedResponse({ error: "not signed in" }, { status: 401 }));
+
+    const { next, notes } = await runOllamaWebSearchSetup(
+      config,
+      createLazyOllamaWebSearchProvider(),
+    );
+
+    expect(next).toBe(config);
+    expect(notes).toEqual([]);
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });
 
   it("resolves env var when config apiKey is a marker string", async () => {

--- a/extensions/ollama/src/web-search-provider.test.ts
+++ b/extensions/ollama/src/web-search-provider.test.ts
@@ -463,6 +463,14 @@ describe("ollama web search provider", () => {
     );
   });
 
+  it("surfaces API-key guidance for hosted Ollama 401 responses", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValue(guardedResponse("", { status: 401 }));
+
+    await expect(
+      runOllamaWebSearch(createOllamaConfig({ baseUrl: "https://ollama.com" })),
+    ).rejects.toThrow("Set OLLAMA_API_KEY or configure models.providers.ollama.apiKey");
+  });
+
   it("reports malformed Ollama web search JSON with a stable provider error", async () => {
     fetchWithSsrFGuardMock.mockResolvedValueOnce(guardedResponse("{ nope"));
 
@@ -514,7 +522,7 @@ describe("ollama web search provider", () => {
     {
       name: "the plugin's higher-priority web search override",
       config: {
-        ...createOllamaConfig(),
+        ...createOllamaConfig({ apiKey: "hosted-test-key" }),
         plugins: {
           entries: {
             ollama: { config: { webSearch: { baseUrl: "https://ollama.com/v1" } } },
@@ -535,6 +543,58 @@ describe("ollama web search provider", () => {
     expect(next).toBe(config);
     expect(notes).toEqual([]);
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "the configured model provider",
+      config: createOllamaConfig({ baseUrl: "https://ollama.com" }),
+    },
+    {
+      name: "the plugin's higher-priority web search override",
+      config: {
+        ...createOllamaConfig(),
+        plugins: {
+          entries: {
+            ollama: { config: { webSearch: { baseUrl: "https://ollama.com/v1" } } },
+          },
+        },
+      },
+    },
+  ])("warns when $name selects hosted search without an API key", async ({ config }) => {
+    await withEnvAsync({ OLLAMA_API_KEY: undefined }, async () => {
+      const { next, notes } = await runOllamaWebSearchSetup(
+        config,
+        createLazyOllamaWebSearchProvider(),
+      );
+
+      expect(next).toBe(config);
+      expect(notes).toEqual([
+        {
+          title: "Ollama Web Search",
+          message:
+            "Hosted Ollama Web Search requires an API key. Set OLLAMA_API_KEY or configure models.providers.ollama.apiKey.",
+        },
+      ]);
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("accepts the ambient API key for hosted Ollama search setup", async () => {
+    await withEnvAsync({ OLLAMA_API_KEY: "hosted-env-key" }, async () => {
+      const config = createOllamaConfig({
+        baseUrl: "https://ollama.com",
+        apiKey: "OLLAMA_API_KEY",
+      });
+      const { next, notes } = await runOllamaWebSearchSetup(
+        config,
+        createLazyOllamaWebSearchProvider(),
+      );
+
+      expect(next).toBe(config);
+      expect(notes).toEqual([]);
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    });
   });
 
   it("resolves env var when config apiKey is a marker string", async () => {


### PR DESCRIPTION
## Summary

Direct hosted Ollama Web Search uses the configured Ollama Cloud endpoint and an API key; it does not require a local Ollama daemon or `ollama signin`. Existing setup incorrectly probed local daemon/sign-in prerequisites even when both the model-provider endpoint and plugin-specific endpoint selected hosted search.

Route the existing prerequisite owner by the actual resolved endpoint. Hosted endpoints check their configured or environment API key and show actionable credential guidance when it is missing; local endpoints retain their existing daemon and sign-in warnings. Hosted HTTP 401 errors now explain the API-key requirement instead of suggesting local sign-in. The FAQ and dedicated Ollama-search guide now provide explicitly separate local and hosted setup paths.

Full branch production: +22/-22 (net 0). Tests: +96/-2.

## Verification

- Independently inspected Ollama's official [Web Search API documentation](https://docs.ollama.com/capabilities/web-search) and [authentication documentation](https://docs.ollama.com/api/authentication#api-keys). They document `POST https://ollama.com/api/web_search`, bearer API-key authentication through `OLLAMA_API_KEY`, and local `ollama signin` as a separate local-installation authentication path.
- Confirmed the actual hosted endpoint's authentication boundary with a credential-free, empty-body request that cannot execute a search:

  ```bash
  env -u OLLAMA_API_KEY -u GITHUB_TOKEN -u GH_TOKEN -u HOMEBREW_GITHUB_API_TOKEN \
    curl --disable --silent --show-error --max-time 15 \
    --header 'Authorization:' --header 'Content-Type: application/json' \
    --data '{}' --write-out '\nhttp_status=%{http_code}\n' \
    https://ollama.com/api/web_search
  ```

  Actual result: `{"error":"Unauthorized"}` and `http_status=401`. No credential, local Ollama service, account, search query, or authenticated request was used. This is live negative authentication-boundary proof, not a claim of authenticated live-search success.
- Captured three authentic failing registered-provider/runtime cases before repairing the complete owner: hosted model-provider endpoint with no key, hosted plugin-specific override with no key, and hosted 401 authentication guidance.
- Verified configured literal credentials, configured environment-marker credentials, ambient `OLLAMA_API_KEY`, endpoint precedence, unchanged local daemon/sign-in diagnostics, and both hosted selection paths.
- Ran five actual Ollama provider, transport, interactive-setup, and noninteractive-setup suites: **187 tests passed**; reran the complete changed provider suite after the documentation fix: **31 tests passed**.
- Ran targeted type-aware lint, formatting, `git diff --check`, documentation glossary validation, and `pnpm docs:check-config-examples` (**774 documentation files scanned; 1,194 configuration examples validated**).
- Fresh integrated whole-branch independent P1 review passed with no accepted/actionable findings after all three commits.
- Addresses both latest ClawSweeper rank-up moves: explicit local/hosted setup documentation and direct hosted authentication-boundary confirmation with official upstream contract evidence.

## Risk

Low: one canonical plugin-owned setup decision, no new configuration, no authentication mechanism changes, no persistent state, no change to legitimate hosted or local search requests, and unchanged production line count.
