### PR TITLE
improve(ui): make session switching and transcript rendering faster

### DIFF
--- a/ui/src/app/app-host.document-title.test.ts
+++ b/ui/src/app/app-host.document-title.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AgentsListResult, GatewayAgentRow, GatewaySessionRow } from "../api/types.ts";
 import type { RouteId } from "../app-routes.ts";
 import "./app-host.ts";
@@ -72,6 +72,18 @@ describe("OpenClaw shell document title", () => {
     shell.routeState = { routeId: "usage" };
     shell.syncDocumentTitle();
     expect(document.title).toBe("Usage — OpenClaw");
+  });
+
+  it("does not read stored outboxes for a connected document title", () => {
+    const shell = createShell(createContext({}));
+    const summarizeStoredChatOutboxes = vi.fn(() => ({ total: 3 }));
+    shell.routeState = { routeId: "usage" };
+    shell.outboxStoreRuntime = { summarizeStoredChatOutboxes };
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("Usage — OpenClaw");
+    expect(summarizeStoredChatOutboxes).not.toHaveBeenCalled();
   });
 
   it("appends the configured environment to route and custodian titles", () => {

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -311,9 +311,6 @@ class OpenClawShell
     outboxScopeHost: StoredOutboxScopeHost,
   ): string {
     const sessionKey = this.activeSessionKey;
-    const row = context.sessions.state.result?.sessions.find(
-      (session) => session.key === sessionKey,
-    );
     // An agent's main chat is its identity, so use its roster label when available.
     const parsed = parseAgentSessionKey(sessionKey);
     const mainAgentId = isUiGlobalSessionKey(sessionKey)
@@ -321,10 +318,17 @@ class OpenClawShell
       : parsed?.rest === resolveUiConfiguredMainKey(outboxScopeHost)
         ? normalizeAgentId(parsed.agentId)
         : undefined;
-    const agent = context.agents.state.agentsList?.agents.find(
-      (candidate) => normalizeAgentId(candidate.id) === mainAgentId,
-    );
-    return agent ? normalizeAgentLabel(agent) : resolveSessionDisplayName(sessionKey, row);
+    const agent = mainAgentId
+      ? context.agents.state.agentsList?.agents.find(
+          (candidate) => normalizeAgentId(candidate.id) === mainAgentId,
+        )
+      : undefined;
+    return agent
+      ? normalizeAgentLabel(agent)
+      : resolveSessionDisplayName(
+          sessionKey,
+          context.sessions.state.result?.sessions.find((session) => session.key === sessionKey),
+        );
   }
 
   constructor() {
@@ -638,17 +642,18 @@ class OpenClawShell
       return;
     }
     const outboxScopeHost = this.storedOutboxScopeHost(context);
-    let primaryContext = titleForRoute(routeId);
+    let primaryContext = routeId === "custodian" ? t("nav.askOpenClaw") : titleForRoute(routeId);
     if (isSessionRouteId(routeId) && this.activeSessionKey) {
       primaryContext = this.chatTitleContext(context, outboxScopeHost) || primaryContext;
-    } else if (routeId === "custodian") {
-      primaryContext = t("nav.askOpenClaw");
     }
+    const offline = context.gateway.snapshot.phase !== "connected";
     let title = formatDocumentTitle({
       context: primaryContext,
       attentionCount: context.overlays.snapshot.approvalQueue.length,
-      offline: context.gateway.snapshot.phase !== "connected",
-      queuedCount: this.outboxStoreRuntime?.summarizeStoredChatOutboxes(outboxScopeHost).total ?? 0,
+      offline,
+      ...(offline && {
+        queuedCount: this.outboxStoreRuntime?.summarizeStoredChatOutboxes(outboxScopeHost).total,
+      }),
     });
     const environment = context.config?.current.environment;
     if (environment) {

--- a/ui/src/app/bootstrap.nav-visibility.test.ts
+++ b/ui/src/app/bootstrap.nav-visibility.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   SIDEBAR_SESSION_NAV_COLLAPSE_QUERY,
   withSidebarNavCollapseIntent,
 } from "../app-session-route-paths.ts";
 import { bootstrapApplication } from "./bootstrap.ts";
-import { loadSettings, saveSettings } from "./settings.ts";
+import { loadSettings, saveSettings, setSettingsChangeListener } from "./settings.ts";
 
 const SIDEBAR_COLLAPSE_SEARCH = new URLSearchParams({
   [SIDEBAR_SESSION_NAV_COLLAPSE_QUERY.name]: SIDEBAR_SESSION_NAV_COLLAPSE_QUERY.value,
@@ -83,6 +83,33 @@ describe("normalizeInitialApplicationLocation", () => {
     } finally {
       runtime?.stop();
       window.history.replaceState({}, "", previousUrl);
+      saveSettings(previousSettings);
+    }
+  });
+
+  it("keeps sidebar visibility in memory without rewriting persisted settings", () => {
+    const previousSettings = loadSettings();
+    let runtime: ReturnType<typeof bootstrapApplication> | undefined;
+    const onPersistedSettingsChanged = vi.fn();
+
+    try {
+      runtime = bootstrapApplication({
+        sessionPathBuilderReady: new Promise<void>(() => {}),
+      });
+      setSettingsChangeListener(onPersistedSettingsChanged);
+
+      runtime.context.navigation.update({ navCollapsed: true });
+
+      expect(runtime.context.navigation.snapshot.navCollapsed).toBe(true);
+      expect(onPersistedSettingsChanged).not.toHaveBeenCalled();
+
+      runtime.context.navigation.update({ navWidth: previousSettings.navWidth + 1 });
+
+      expect(onPersistedSettingsChanged).toHaveBeenCalledOnce();
+      expect(loadSettings().navWidth).toBe(previousSettings.navWidth + 1);
+    } finally {
+      runtime?.stop();
+      setSettingsChangeListener(null);
       saveSettings(previousSettings);
     }
   });

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -209,19 +209,20 @@ function createApplicationNavigationPreferences(
     },
     update(patch) {
       const nextSnapshot = { ...snapshot, ...patch };
-      if (
-        nextSnapshot.navCollapsed === snapshot.navCollapsed &&
-        nextSnapshot.navWidth === snapshot.navWidth &&
-        nextSnapshot.sidebarEntries === snapshot.sidebarEntries &&
-        nextSnapshot.pinnedAgentIds === snapshot.pinnedAgentIds
-      ) {
+      const persistedChanged =
+        nextSnapshot.navWidth !== snapshot.navWidth ||
+        nextSnapshot.sidebarEntries !== snapshot.sidebarEntries ||
+        nextSnapshot.pinnedAgentIds !== snapshot.pinnedAgentIds;
+      if (!persistedChanged && nextSnapshot.navCollapsed === snapshot.navCollapsed) {
         return;
       }
-      patchSettings({
-        navWidth: nextSnapshot.navWidth,
-        sidebarEntries: [...nextSnapshot.sidebarEntries],
-        pinnedAgentIds: [...nextSnapshot.pinnedAgentIds],
-      });
+      if (persistedChanged) {
+        patchSettings({
+          navWidth: nextSnapshot.navWidth,
+          sidebarEntries: [...nextSnapshot.sidebarEntries],
+          pinnedAgentIds: [...nextSnapshot.pinnedAgentIds],
+        });
+      }
       snapshot = nextSnapshot;
       for (const listener of listeners) {
         listener(snapshot);
@@ -337,7 +338,7 @@ export function bootstrapApplication(
   const releasedSessionQuery =
     (startupRouteId === "chat" || startupRouteId === "dashboard") &&
     sessionRouteNamespaceFromPath(applicationLocation.pathname, basePath) === null &&
-    new URLSearchParams(applicationLocation.search).has("session");
+    startupSearchParams.has("session");
   const deferInitialLocationUntilGateway =
     documentMode === null &&
     !releasedSessionQuery &&

--- a/ui/src/components/app-sidebar-child-session-data.ts
+++ b/ui/src/components/app-sidebar-child-session-data.ts
@@ -4,6 +4,7 @@ import type { SessionCapability } from "../lib/sessions/index.ts";
 import { preserveRosterPresentationMetadata } from "../lib/sessions/reconcile.ts";
 import {
   areUiSessionKeysEquivalent,
+  normalizeDefaultMainSessionAliasForUi,
   resolveUiSessionNavigationParentKey,
 } from "../lib/sessions/session-key.ts";
 export { fetchChildSessionRows } from "../lib/sessions/child-session-data.ts";
@@ -16,13 +17,11 @@ export function collectKnownSessionRows(
 ): Map<string, GatewaySessionRow> {
   const rows = new Map<string, GatewaySessionRow>();
   for (const row of [...Object.values(childRowsByParent).flat(), ...rootRows]) {
-    const previous = [...rows.keys()].find((key) => areUiSessionKeysEquivalent(key, row.key));
-    if (previous) {
-      rows.delete(previous);
-    }
-    rows.set(row.key, row);
+    const key = normalizeDefaultMainSessionAliasForUi(row.key) || row.key;
+    rows.delete(key);
+    rows.set(key, row);
   }
-  return rows;
+  return new Map([...rows.values()].map((row) => [row.key, row]));
 }
 
 export async function fetchSessionLineage(params: {
@@ -45,9 +44,11 @@ export async function fetchSessionLineage(params: {
     // malformed cycle cannot leave direct child routes spinning forever.
     for (let depth = 0; depth < MAX_SESSION_LINEAGE_DEPTH && !visited.has(currentKey); depth += 1) {
       visited.add(currentKey);
-      let row = [...params.knownRows.values()].find((candidate) =>
-        areUiSessionKeysEquivalent(candidate.key, currentKey),
-      );
+      let row =
+        params.knownRows.get(currentKey) ??
+        [...params.knownRows.values()].find((candidate) =>
+          areUiSessionKeysEquivalent(candidate.key, currentKey),
+        );
       if (!row) {
         const described = await params.client.request<{ session?: GatewaySessionRow | null }>(
           "sessions.describe",

--- a/ui/src/components/app-sidebar-session-narration.ts
+++ b/ui/src/components/app-sidebar-session-narration.ts
@@ -164,10 +164,9 @@ export class SidebarSessionNarrationController {
     const openSessionKey = input.openSessionKey.trim();
     const nextDesired = new Set<string>();
     let backgroundSubscriptions = 0;
-    for (const row of input.rows.toSorted((left, right) => rowRecency(right) - rowRecency(left))) {
-      if (!row.hasActiveRun) {
-        continue;
-      }
+    for (const row of input.rows
+      .filter((candidate) => candidate.hasActiveRun)
+      .toSorted((left, right) => rowRecency(right) - rowRecency(left))) {
       const open = areUiSessionKeysEquivalent(row.key, openSessionKey);
       if (!open && backgroundSubscriptions >= SIDEBAR_NARRATION_SUBSCRIPTION_LIMIT) {
         continue;

--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -286,6 +286,11 @@ describe("sidebar navigation lineage ownership", () => {
     { name: "exact", rootKey: child.key, cachedKey: child.key },
     { name: "equivalent", rootKey: child.key.toUpperCase(), cachedKey: child.key },
     { name: "main alias", rootKey: "main", cachedKey: "agent:main:main" },
+    {
+      name: "case-preserving Matrix alias",
+      rootKey: "Agent:Ops:Matrix:Channel:!Room:Example.Org",
+      cachedKey: "agent:ops:matrix:channel:!Room:Example.Org",
+    },
   ])(
     "keeps the canonical root authoritative over an $name cached child key",
     async ({ rootKey, cachedKey }) => {
@@ -332,6 +337,18 @@ describe("sidebar navigation lineage ownership", () => {
       expect(request).not.toHaveBeenCalled();
     },
   );
+
+  it("keeps case-sensitive Matrix and Signal session identifiers distinct", () => {
+    const keys = [
+      "agent:ops:matrix:channel:!Room:Example.Org",
+      "agent:ops:matrix:channel:!room:example.org",
+      "agent:ops:signal:group:AbC123=",
+      "agent:ops:signal:group:abc123=",
+    ];
+    const rows = keys.map((key) => ({ ...child, key }));
+
+    expect([...collectKnownSessionRows(rows, {}).keys()]).toEqual(keys);
+  });
 
   it("projects a known child exactly once under its explicit navigation parent", () => {
     const projected = projectSessionTree({

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -534,11 +534,12 @@ export function collectKnownSidebarSessionGroups(
   rows: readonly GatewaySessionRow[],
 ): string[] {
   const catalogSet = new Set(catalog);
-  const discovered = rows
-    .map((row) => normalizeOptionalString(row.category))
-    .filter((name): name is string => typeof name === "string" && !catalogSet.has(name))
-    .toSorted((a, b) => a.localeCompare(b));
-  return [...catalog, ...new Set(discovered)];
+  const discovered = new Set(
+    rows
+      .map((row) => normalizeOptionalString(row.category))
+      .filter((name): name is string => typeof name === "string" && !catalogSet.has(name)),
+  );
+  return [...catalog, ...[...discovered].toSorted((a, b) => a.localeCompare(b))];
 }
 
 /** Depth-first search across a projected session tree, including descendants.

--- a/ui/src/components/markdown-streaming.ts
+++ b/ui/src/components/markdown-streaming.ts
@@ -294,6 +294,9 @@ const streamingRemendOptions = { katex: false, linkMode: "text-only" } satisfies
 export function repairStreamingMarkdownTail(tail: string, repairStart = 0): string {
   const repaired =
     tail.slice(0, repairStart) + remend(tail.slice(repairStart), streamingRemendOptions);
+  if (!repaired.includes("<")) {
+    return repaired;
+  }
   const detailsStack: DetailsFrame[] = [];
   const codeSpans = findMarkdownCodeSpans(repaired);
   let openFence: FenceMarker | null = null;

--- a/ui/src/components/markdown-text.ts
+++ b/ui/src/components/markdown-text.ts
@@ -15,6 +15,9 @@ export function normalizeMarkdownLineBreaks(value: string): string {
 }
 
 export function isMarkdownBlockArtText(value: string): boolean {
+  if (!BLOCK_ART_GLYPH_RE.test(value)) {
+    return false;
+  }
   const lines = normalizeMarkdownLineBreaks(value).split("\n");
   const artLines = lines.filter((line) => line.trim().length > 0);
   if (artLines.length < 2) {

--- a/ui/src/lib/sessions/session-key.ts
+++ b/ui/src/lib/sessions/session-key.ts
@@ -333,7 +333,9 @@ export function buildAgentMainSessionKey(params: {
   return `agent:${agentId}:${mainKey}`;
 }
 
-function normalizeDefaultMainSessionAliasForUi(sessionKey: string | undefined | null): string {
+export function normalizeDefaultMainSessionAliasForUi(
+  sessionKey: string | undefined | null,
+): string {
   const normalized = normalizeSessionKeyForUiComparison(sessionKey);
   return normalized === DEFAULT_MAIN_KEY
     ? buildAgentMainSessionKey({ agentId: DEFAULT_AGENT_ID, mainKey: DEFAULT_MAIN_KEY })

--- a/ui/src/pages/chat/chat-agent-run-grouping.ts
+++ b/ui/src/pages/chat/chat-agent-run-grouping.ts
@@ -47,11 +47,9 @@ function itemRunId(item: AgentRunFramePart): string | undefined {
   if (item.kind === "stream-run") {
     return item.runId;
   }
-  const runIds = itemGroups(item).map((group) => group.runId);
-  const uniqueRunIds = new Set(runIds.filter((value) => value !== undefined));
-  return runIds.length > 0 && uniqueRunIds.size === 1 && runIds.every(Boolean)
-    ? uniqueRunIds.values().next().value
-    : undefined;
+  const groups = itemGroups(item);
+  const runId = groups[0]?.runId;
+  return runId && groups.every((group) => group.runId === runId) ? runId : undefined;
 }
 
 function messageIsInterrupted(message: unknown): boolean {

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -692,20 +692,16 @@ export class ChatPage extends OpenClawLightDomElement {
   override render() {
     const indicator = this.dropIndicator;
     const layout = this.layout ?? this.classicLayout();
-    const renderedPaneOwners = layout.columns.flatMap((column) =>
-      column.panes.map((pane) => ({ columnId: column.id, pane })),
-    );
-    const retainedSessions = this.retainedSessions.retain(
-      renderedPaneOwners.map(({ pane }) => pane),
-    );
-    const nextPaneKeys = new Set(
-      renderedPaneOwners.flatMap(({ columnId, pane }) => {
-        const ownerKey = JSON.stringify([columnId, pane.id]);
-        return (retainedSessions.get(pane.id) ?? []).map((sessionKey) =>
-          JSON.stringify([ownerKey, sessionKey]),
-        );
-      }),
-    );
+    const retainedSessions = this.retainedSessions.retain(panesOf(layout));
+    const nextPaneKeys = new Set<string>();
+    for (const column of layout.columns) {
+      for (const pane of column.panes) {
+        const ownerKey = JSON.stringify([column.id, pane.id]);
+        for (const sessionKey of retainedSessions.get(pane.id) ?? []) {
+          nextPaneKeys.add(JSON.stringify([ownerKey, sessionKey]));
+        }
+      }
+    }
     const renderValue = () => html`
       <div class="chat-split-view__drop-container">
         ${this.renderSplitLayout(layout, Boolean(this.layout), retainedSessions)}

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -73,7 +73,6 @@ type ChatTranscriptProjection = {
 type ChatRenderItem = ReturnType<typeof coalesceAgentRunFrames>[number];
 
 type LoadedReplySource = {
-  rowKey: string;
   message: unknown;
   messageId: string;
   senderLabel: string;
@@ -269,6 +268,7 @@ export function projectChatTranscript(
   >();
   const turnRecapByGroupKey = new Map<string, TurnRecap>();
   const loadedReplySources = new Map<string, LoadedReplySource>();
+  const messageRowKeysById = new Map<string, string>();
   const resolvedReplyPreviews = new Map<
     string,
     (MessageReplyTarget & { sourceMessageId: string }) | undefined
@@ -555,8 +555,8 @@ export function projectChatTranscript(
       for (const source of group.messages) {
         const sourceMessageId = persistedMessageEntryId(source.message);
         if (sourceMessageId && extractTextCached(source.message)?.trim()) {
+          messageRowKeysById.set(sourceMessageId, item.key);
           loadedReplySources.set(sourceMessageId, {
-            rowKey: item.key,
             message: source.message,
             messageId: source.key,
             senderLabel,
@@ -565,9 +565,7 @@ export function projectChatTranscript(
       }
     }
   }
-  transcript.syncMessageRows(
-    new Map([...loadedReplySources].map(([messageId, source]) => [messageId, source.rowKey])),
-  );
+  transcript.syncMessageRows(messageRowKeysById);
   let turnRecapOwnerKey: string | null = null;
   if (turnRecap !== null) {
     const lastItem = transcriptItems.at(-1);
@@ -585,17 +583,15 @@ export function projectChatTranscript(
   }
   // New row keys measure expanded work immediately; existing keys keep their
   // cached height until ResizeObserver reports the changed layout.
-  const transcriptRows = transcriptItems.flatMap((item): TranscriptRow<ChatRenderItem>[] =>
-    [{ kind: "item" as const, key: item.key, item }].concat(
-      item.kind === "work-group" && expandedToolCards.get(item.key)
-        ? item.groups.map((group) => ({
-            kind: "item" as const,
-            key: `${item.key}:${group.key}`,
-            item: group,
-          }))
-        : [],
-    ),
-  );
+  const transcriptRows: TranscriptRow<ChatRenderItem>[] = [];
+  for (const item of transcriptItems) {
+    transcriptRows.push({ kind: "item", key: item.key, item });
+    if (item.kind === "work-group" && expandedToolCards.get(item.key)) {
+      for (const group of item.groups) {
+        transcriptRows.push({ kind: "item", key: `${item.key}:${group.key}`, item: group });
+      }
+    }
+  }
   if (props.runStatus?.phase === "interrupted") {
     transcriptRows.push({
       kind: "content",

--- a/ui/src/pages/chat/split-layout.ts
+++ b/ui/src/pages/chat/split-layout.ts
@@ -69,28 +69,16 @@ export function findPane(
 ): { column: ChatSplitColumn; columnIndex: number; pane: ChatSplitPane; paneIndex: number } | null {
   for (const [columnIndex, column] of layout.columns.entries()) {
     const paneIndex = column.panes.findIndex((pane) => pane.id === paneId);
-    if (paneIndex >= 0) {
-      const selectedPane = column.panes[paneIndex];
-      if (!selectedPane) {
-        continue;
-      }
-      return {
-        column: {
-          ...column,
-          panes: column.panes.map((pane) => ({ ...pane })),
-          paneWeights: [...column.paneWeights],
-        },
-        columnIndex,
-        pane: { ...selectedPane },
-        paneIndex,
-      };
+    const pane = column.panes[paneIndex];
+    if (pane) {
+      return { column, columnIndex, pane, paneIndex };
     }
   }
   return null;
 }
 
 export function panesOf(layout: ChatSplitLayout): ChatSplitPane[] {
-  return layout.columns.flatMap((column) => column.panes.map((pane) => ({ ...pane })));
+  return layout.columns.flatMap((column) => column.panes);
 }
 
 /** Panes actually rendered at the current viewport width. */
@@ -184,7 +172,7 @@ export function setPaneSession(
   sessionKey: string,
 ): ChatSplitLayout {
   const next = cloneLayout(layout);
-  const pane = next.columns.flatMap((column) => column.panes).find((entry) => entry.id === paneId);
+  const pane = findPane(next, paneId)?.pane;
   if (pane) {
     pane.sessionKey = sessionKey;
   }
@@ -193,7 +181,7 @@ export function setPaneSession(
 
 export function setActivePane(layout: ChatSplitLayout, paneId: string): ChatSplitLayout {
   const next = cloneLayout(layout);
-  if (panesOf(layout).some((pane) => pane.id === paneId)) {
+  if (findPane(layout, paneId)) {
     next.activePaneId = paneId;
   }
   return next;


### PR DESCRIPTION
## What Problem This Solves

Session switching, sidebar interaction, and transcript rendering perform repeated work that grows unnecessarily with the session roster and message history. Collapsing the sidebar also rewrites persisted settings even though visibility is deliberately local to the current UI instance.

## Why This Change Was Made

Index session lineage by the existing canonical session-identity contract instead of repeatedly scanning every known key; preserve main-session aliases and case-sensitive Matrix/Signal identifiers. Keep split-layout reads immutable without cloning their entire column, avoid irrelevant connected-title/outbox and roster projections, persist navigation settings only when an actually persisted preference changes, and build transcript/reply rows in their existing owner passes. Ordinary Markdown now skips block-art and disclosure processing when its required glyph/tag cannot possibly be present. Narration and sidebar categories are filtered/deduplicated before sorting.

Production code: **+89/-96 (net -7 lines)**. Regression tests: **+59/-3**.

## User Impact

Sessions open and switch more responsively, particularly with larger rosters or long streaming transcripts. Sidebar collapse no longer serializes and rewrites unrelated stored preferences. Existing navigation aliases, offline queued counts, Markdown details/block art, split-pane ownership, and reply navigation remain unchanged.

## Evidence

Tested against a real isolated, loopback-only development Gateway serving the production-built Control UI, with 60 actual Gateway-backed sessions; Chromium alternated between the same session rows 18 times and discarded the first two warmup samples.

| Live browser measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| Median session switch | 88.9 ms | 79.1 ms | 11.0% faster |
| p95 session switch | 141.6 ms | 105.7 ms | 25.4% faster |
| Median browser CPU per switch | 41.55 ms | 33.02 ms | 20.5% less |
| p95 browser CPU per switch | 98.96 ms | 39.83 ms | 59.8% less |

Isolated owner microbenchmarks show why the same changes scale beyond the 60-session browser fixture: canonical lineage collection improves from 85.22 ms to 0.27 ms at 600 sessions, ordinary Markdown block-art classification from 45.46 ms to 0.28 ms across 12,000 calls, and ordinary streaming-tail repair from 312.46 ms to 3.71 ms across 300 calls. These are component measurements, not claims about end-to-end latency.

Both newly fixed ownership violations were reproduced with failing tests before the implementation: connected document-title rendering must not summarize stored outboxes, and visibility-only navigation changes must not publish persisted-settings changes. Focused owner/sibling validation: **315 passing tests**. Chromium end-to-end validation: **30 passing tests** across session stability, retained-pane hydration, sidebar toggling/presentation, and streaming runtime budgets. Production UI build also passes its startup-size and request-count gates.

Before (synthetic fixture data only):

![Control UI session switching before optimization](https://github.com/user-attachments/assets/31270315-a103-49d5-86c6-41186e31a9d7)

After (synthetic fixture data only):

![Control UI session switching after optimization](https://github.com/user-attachments/assets/12706d8e-826a-465c-b256-32271b7b4e83)

Real development Gateway session-switching recording:

https://github.com/user-attachments/assets/bc89bef8-f6c2-470c-b90d-e1a975a709c9
