### PR TITLE
chore(voice-call): remove duplicate timer cap tests

### DIFF
--- a/extensions/voice-call/src/manager/timer-delays.test.ts
+++ b/extensions/voice-call/src/manager/timer-delays.test.ts
@@ -1,18 +1,10 @@
 // Voice Call tests cover timer delays plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it } from "vitest";
-import {
-  resolveVoiceCallSecondsTimerDelayMs,
-  resolveVoiceCallTimerDelayMs,
-} from "./timer-delays.js";
+import { resolveVoiceCallSecondsTimerDelayMs } from "./timer-delays.js";
 
 describe("voice-call timer delays", () => {
   it("caps second-based delays to timer-safe milliseconds", () => {
-    expect(resolveVoiceCallSecondsTimerDelayMs(Number.MAX_SAFE_INTEGER)).toBe(MAX_TIMER_TIMEOUT_MS);
     expect(resolveVoiceCallSecondsTimerDelayMs(Number.MAX_VALUE)).toBe(MAX_TIMER_TIMEOUT_MS);
-  });
-
-  it("caps millisecond delays to timer-safe values", () => {
-    expect(resolveVoiceCallTimerDelayMs(Number.MAX_SAFE_INTEGER)).toBe(MAX_TIMER_TIMEOUT_MS);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Removes two strict-subset timer-delay assertions from the voice-call helper suite. The same `Number.MAX_SAFE_INTEGER` second and millisecond cap paths are already covered through the real manager timer APIs, so the direct helper assertions added maintenance and CI work without detecting a distinct regression.

## Why This Change Was Made

The owner-level tests in `manager/timers.test.ts` exercise both max-duration seconds and transcript milliseconds through production timer scheduling. `manager/outbound.test.ts` independently exercises the second-based notify hangup path. The helper suite keeps its unique `Number.MAX_VALUE` seconds-overflow case, which the owner tests do not cover.

No production code or behavior changes.

## User Impact

No user-visible impact. Maintainers retain timer-cap and overflow regression coverage with two fewer redundant assertions.

## Evidence

- Baseline before deletion: affected voice-call suites — 28/28 passed.
- `node scripts/run-vitest.mjs extensions/voice-call/src/manager/timer-delays.test.ts extensions/voice-call/src/manager/timers.test.ts extensions/voice-call/src/manager/outbound.test.ts` — 27/27 remaining tests passed.
- `node scripts/check-changed.mjs -- extensions/voice-call/src/manager/timer-delays.test.ts` — passed, including extension test types and targeted oxlint.
- `node_modules/.bin/oxfmt --check extensions/voice-call/src/manager/timer-delays.test.ts` — passed.
- Fresh autoreview against `origin/main` — no accepted/actionable findings; patch correct 0.99.
- `git diff --check origin/main...HEAD` — passed.

Production LOC: `+0/-0`

Tests: `+1/-9`

AI-assisted test audit. No changelog entry: test-only strict-subset deletion with no behavior change.
