### PR TITLE
fix(heartbeat): deliver manual wakes when recurring cadence is disabled

### DIFF
--- a/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
+++ b/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
@@ -4,7 +4,8 @@
 // max-lines budget.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetConfigRuntimeState, type OpenClawConfig } from "../config/config.js";
-import { startHeartbeatRunner } from "./heartbeat-runner.js";
+import { wake as wakeCronService } from "../cron/service/wake.js";
+import { setHeartbeatsEnabled, startHeartbeatRunner } from "./heartbeat-runner.js";
 import { requestHeartbeat } from "./heartbeat-wake.js";
 
 describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
@@ -63,9 +64,124 @@ describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
   }
 
   afterEach(() => {
+    setHeartbeatsEnabled(true);
     resetConfigRuntimeState();
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it.each(["now", "next-heartbeat"] as const)(
+    "runs a targeted manual %s wake when recurring heartbeats are disabled",
+    async (mode) => {
+      useFakeHeartbeatTime();
+      const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+      const runner = startHeartbeatRunner({
+        cfg: {
+          agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
+        } as OpenClawConfig,
+        runOnce: runSpy,
+        stableSchedulerSeed: TEST_SCHEDULER_SEED,
+      });
+      const enqueueSystemEvent = vi.fn();
+      const state = {
+        deps: {
+          enqueueSystemEvent,
+          requestHeartbeat: (wake: Parameters<typeof requestHeartbeat>[0]) =>
+            requestHeartbeat({ ...wake, coalesceMs: 0 }),
+        },
+      } as unknown as Parameters<typeof wakeCronService>[0];
+
+      expect(
+        wakeCronService(state, {
+          mode,
+          text: "Operator requested a session update.",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+        }),
+      ).toEqual({ ok: true });
+      expect(enqueueSystemEvent).toHaveBeenCalledWith("Operator requested a session update.", {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+      });
+
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(runSpy).toHaveBeenCalledOnce();
+      expectRunCallFields(runSpy, 0, {
+        agentId: "main",
+        source: "manual",
+        intent: "immediate",
+        reason: "wake",
+        sessionKey: "agent:main:main",
+      });
+      runner.stop();
+    },
+  );
+
+  it.each([
+    {
+      name: "without a session target",
+      wake: { agentId: "main", sessionKey: undefined },
+    },
+    {
+      name: "for an unconfigured agent",
+      wake: { agentId: "unknown", sessionKey: "agent:unknown:main" },
+    },
+    {
+      name: "with event intent",
+      wake: { agentId: "main", sessionKey: "agent:main:main", intent: "event" as const },
+    },
+    {
+      name: "with a non-manual reason",
+      wake: { agentId: "main", sessionKey: "agent:main:main", reason: "manual" },
+    },
+  ])("rejects an unscheduled manual wake $name", async ({ wake }) => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    requestHeartbeat({
+      source: "manual",
+      intent: "immediate",
+      reason: "wake",
+      ...wake,
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).not.toHaveBeenCalled();
+    runner.stop();
+  });
+
+  it("keeps targeted manual wakes disabled when heartbeats are globally disabled", async () => {
+    useFakeHeartbeatTime();
+    setHeartbeatsEnabled(false);
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    requestHeartbeat({
+      source: "manual",
+      intent: "immediate",
+      reason: "wake",
+      sessionKey: "agent:main:main",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).not.toHaveBeenCalled();
+    runner.stop();
   });
 
   it.each([

--- a/src/infra/heartbeat-wake-policy.ts
+++ b/src/infra/heartbeat-wake-policy.ts
@@ -61,8 +61,7 @@ type TargetedUnscheduledWakeParams = {
 
 export function isTargetedUnscheduledWake(params: TargetedUnscheduledWakeParams): boolean {
   const hasSessionTarget = normalizeOptionalString(params.sessionKey) !== undefined;
-  const hasTarget = hasSessionTarget || normalizeOptionalString(params.agentId) !== undefined;
-  if (!hasTarget) {
+  if (!hasSessionTarget && normalizeOptionalString(params.agentId) === undefined) {
     return false;
   }
 
@@ -72,6 +71,7 @@ export function isTargetedUnscheduledWake(params: TargetedUnscheduledWakeParams)
   // they cannot broaden the immediate-wake exception.
   const reason = params.reason?.trim();
   switch (params.source) {
+    case "manual":
     case "notifications-event":
       return params.intent === "immediate" && hasSessionTarget && reason === "wake";
     case "hook":


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw system event --mode now` or requesting a session-targeted wake through the automations tool would receive `{ "ok": true }` while their event never reached the model when recurring heartbeats were disabled with `heartbeat.every: "0m"`. Session-targeted `next-heartbeat` requests were silently lost in the same way, even though they are documented to run immediately.

## Why This Change Was Made

Recognize the existing, narrowly scoped manual wake shape at the shared heartbeat admission owner: a configured agent, a real session target, `intent: "immediate"`, and `reason: "wake"`. Reuse the exact existing notification-wake rule while preserving manual source identity, configured-system-agent routing, global heartbeat disable, agent/session ownership checks, and the distinct behavior of ordinary automation wakes. Production change: +2/-2 lines.

## User Impact

Explicit operator and agent-requested session wakes now deliver their queued event immediately even when recurring heartbeat cadence is disabled. Turning heartbeats off globally still blocks these wakes, and malformed wake shapes, requests without a canonical session target, and unknown-agent requests remain rejected.

## Evidence

The new regression first failed against unmodified main for both real producer paths:

```text
FAIL runs a targeted manual now wake when recurring heartbeats are disabled
FAIL runs a targeted manual next-heartbeat wake when recurring heartbeats are disabled
AssertionError: expected vi.fn() to be called once, but got 0 times
Tests: 2 failed | 11 passed
```

After the owner repair, the actual production cron wake producer, heartbeat bus and scheduler, system-event queue, and auto-reply prompt formatter produce:

```json
{"mode":"now","cadence":"0m","apiResult":{"ok":true},"turnCount":1,"turn":{"source":"manual","intent":"immediate","sessionKey":"agent:main:main","prompt":"System: [timestamp] Operator requested visible manual wake: now"},"pendingEvents":[]}
{"mode":"next-heartbeat","cadence":"0m","apiResult":{"ok":true},"turnCount":2,"turn":{"source":"manual","intent":"immediate","sessionKey":"agent:main:main","prompt":"System: [timestamp] Operator requested visible manual wake: next-heartbeat"},"pendingEvents":[]}
```

Focused validation:

```text
heartbeat runner + scheduler + wake suites: 86 passed
cron wake + origin routing + delivery-context suites: 16 passed
changed-file formatting, focused typed lint, and git diff --check: passed
independent structured review: clean
```

The full local changed gate passed all conflict, max-lines, assertion, dependency, formatting, plugin-boundary, and complete production/full-tree/script dead-export checks. Its core typecheck cannot complete against the shared checkout's stale borrowed dependencies: main requires `@google/genai 2.17.1`, `markdown-it 15.0.0`, and `@earendil-works/pi-tui 0.84.2`, while the available install contains `2.13.0`, `14.3.0`, and `0.82.1`. The resulting errors are confined to unchanged Google provider, Markdown, and TUI files. Exact-head hosted CI with the current lockfile is required before landing.

AI-assisted: Yes.
