### PR TITLE
docs(memory): document shipped turn-taint propagation for network tool output

### DIFF
--- a/docs/concepts/memory-architecture.md
+++ b/docs/concepts/memory-architecture.md
@@ -105,11 +105,15 @@ classified from the sender, while a memory flush records the least-trusted
 class for the whole file; trusted lines in a downgraded file intentionally lose
 promotion eligibility so untrusted content cannot ride a trusted file hash.
 
-The current runtime does not propagate content origin within an owner turn.
-Assistant text derived from tool or web output therefore inherits the turn's
-sender class. A follow-up should carry content-origin metadata through tool-result
-assembly into assistant output and flush writes; that cross-cutting taint model
-is not part of this memory integration.
+Content origin also propagates within a turn. When a tool result declares
+network-sourced content (web fetches, browser reads, search results), the rest
+of that turn is marked tainted: every assistant message produced after that
+result carries the taint, and memory classification treats it as `untrusted`
+even inside an owner turn. The taint clears on the next user message. The
+remaining gap is declaration coverage: only tools that declare their results
+as network-sourced participate, so output from tools that do not — local file
+reads, for example — does not taint the turn, and assistant text derived from
+it keeps the turn's sender class.
 
 ## The write path
 

--- a/docs/concepts/memory-architecture.md
+++ b/docs/concepts/memory-architecture.md
@@ -113,7 +113,7 @@ even inside an owner turn. The taint clears on the next user message. The
 remaining gap is declaration coverage: only tools that declare their results
 as network-sourced participate, so output from tools that do not — local file
 reads, for example — does not taint the turn, and assistant text derived from
-it keeps the turn's sender class.
+it keeps its normal turn-derived provenance (`agent` in an owner turn).
 
 ## The write path
 


### PR DESCRIPTION
## What Problem This Solves

`docs/concepts/memory-architecture.md` ("Trust boundaries and limits") still claimed the runtime "does not propagate content origin within an owner turn" and that assistant text derived from tool or web output inherits the turn's sender class, framing a cross-cutting taint model as future work. That taint model has since shipped, so the page understated a real security property of the memory system.

## Why This Change Was Made

The docs must describe shipped behavior. The runtime now propagates a turn-taint bit for network-sourced tool output:

- `packages/agent-core/src/agent-loop.ts`: a tool result declaring `resultContentSource: "network"` taints the turn (`turnTainted ||= toolResults.some(toolResultTaintsTurn)`); `withAssistantTurnTaint` stamps every later assistant message in the turn; taint resets only on a new user message (`isActiveTurnTainted` walks back to the last user message).
- `packages/memory-host-sdk/src/host/session-provenance.ts`: tainted assistant messages classify `untrusted` for memory regardless of the owner turn.
- Mirrored by the Codex (`extensions/codex/src/app-server/event-projector-snapshot.ts`) and Copilot (`extensions/copilot/src/attempt-transcript-journal.ts`) runtimes.

The rewritten paragraph states that behavior and names the remaining honest gap: only tools that declare a network content source participate (browser, canvas, firecrawl, feishu, Codex webSearch, ...), so undeclared tool output (e.g. local file reads) does not taint the turn.

## User Impact

Docs-only. Readers of the memory architecture page now get an accurate picture of the within-turn provenance boundary instead of a stale "not implemented" caveat.

## Evidence

- Claims verified against the cited code in this checkout before writing (files/lines above).
- Repo-wide grep confirmed no sibling page repeats the stale caveat ("does not propagate" / "inherits the turn's sender class" only matched this page).
- `pnpm docs:check-mdx` (780 files), `pnpm docs:check-links` (6,569 internal links, 0 broken), `pnpm format:docs:check` (764 files clean), `git diff --check` all pass.
