### PR TITLE
fix(android): preserve disconnected node gateway status

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -2160,7 +2160,7 @@ internal fun gatewaySummary(
   isConnected: Boolean,
   gatewayConnectionProblem: GatewayConnectionProblem? = null,
 ): String {
-  if (isConnected) return nativeString("Online and ready")
+  if (isConnected) return if (statusText == "Connected (node offline)") gatewayStatusForDisplay(statusText) else nativeString("Online and ready")
   val status = statusText.trim().lowercase()
   return when {
     status.contains("connecting") || status.contains("reconnecting") -> nativeString("Connecting...")

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -13,6 +13,7 @@ import ai.openclaw.app.GatewayPendingDeviceSummary
 import ai.openclaw.app.GatewaySkillWorkshopProposal
 import ai.openclaw.app.GatewaySkillWorkshopSummary
 import ai.openclaw.app.chat.ChatSessionEntry
+import ai.openclaw.app.gatewayConnectionDisplay
 import ai.openclaw.app.i18n.resolveNativeText
 import ai.openclaw.app.i18n.verbatimText
 import ai.openclaw.app.normalizeOperatorScopes
@@ -840,6 +841,21 @@ class ShellScreenLogicTest {
   fun gatewaySummaryFallsBackToGenericAuthLabelWithoutAKnownReason() {
     assertEquals("Authentication needed", gatewaySummary("auth failed", isConnected = false, gatewayConnectionProblem = null))
     assertEquals("Authentication needed", gatewaySummary("auth failed", isConnected = false, gatewayConnectionProblem = authProblem("SOME_UNMAPPED_CODE")))
+  }
+
+  @Test
+  fun gatewaySummaryPreservesNodeFailureWhileOperatorStaysConnected() {
+    val display =
+      gatewayConnectionDisplay(
+        operatorConnected = true,
+        nodeConnected = false,
+        operatorStatusText = "Connected",
+        nodeStatusText = "Gateway error: pairing required",
+        operatorProblem = null,
+        nodeProblem = authProblem("PAIRING_REQUIRED"),
+      )
+
+    assertEquals("Connected (node offline)", gatewaySummary(display))
   }
 
   @Test


### PR DESCRIPTION
## Summary

When the Android operator connection stayed connected while its node disconnected, the canonical runtime correctly produced `Connected (node offline)`, but the Shell summary erased that authoritative state and displayed `Online and ready`. Preserve the runtime-owned, localized offline-node status in the existing summary projection instead of claiming the disconnected node is available.

Production: +1/-1 (net 0). Tests: +16/-0.

## Verification

- Captured an authentic failing regression through the actual `gatewayConnectionDisplay` producer and Android Shell summary before changing production.
- Ran the relevant real Android runtime/UI suites: **80 tests passed**.
- Full Android ktlint and native localization verification passed.
- Independently reviewed at P1 with no actionable findings.
- No personal device, installed app, user gateway, signing identity, or network connection was touched; Android JVM/Robolectric production-boundary proof was used because launching or screenshotting a user's device was not appropriate.

## Risk

Low: preserves the existing translated status produced by the canonical native runtime without changing connectivity, pairing, authentication, or configuration.
