### PR TITLE
fix(qa): reject blocked sender replies in allowlist scenarios

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
+import { createQaBusState } from "./bus-state.js";
 import {
   readQaScenarioById,
   readQaScenarioExecutionConfig,
   readQaScenarioPack,
   validateQaScenarioExecutionConfig,
 } from "./scenario-catalog.js";
+import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+import { recentOutboundSummary } from "./suite-runtime-transport.js";
 
 type CatalogScenario = ReturnType<typeof readQaScenarioById>;
 type FlowCatalogScenario = CatalogScenario & {
@@ -265,6 +268,79 @@ describe("qa scenario catalog channel contracts", () => {
     const scenario = requireFlowScenario(readQaScenarioById("channel-canary"));
 
     expect(scenario.execution.channels).toEqual(["qa-channel", "telegram", "buzz", "msteams"]);
+  });
+
+  it.each([
+    {
+      label: "accepts only the authorized driver reply",
+      observerReplies: false,
+      driverReplies: true,
+      expectedFailure: null,
+    },
+    {
+      label: "rejects an observer reply when the authorized driver never replies",
+      observerReplies: true,
+      driverReplies: false,
+      expectedFailure: "waiting for outbound marker",
+    },
+    {
+      label: "rejects a late observer reply even when the authorized driver replies",
+      observerReplies: true,
+      driverReplies: true,
+      expectedFailure: "blocked sender replied",
+    },
+  ])("$label", async ({ observerReplies, driverReplies, expectedFailure }) => {
+    const state = createQaBusState();
+    const result = runLoadedScenarioFlow("channel-sender-allowlist", {
+      state,
+      api: { recentOutboundSummary },
+      onWaitForOutboundMessage: ({ state: currentState }) => {
+        for (const [senderId, replies] of [
+          ["observer", observerReplies],
+          ["driver", driverReplies],
+        ] as const) {
+          if (!replies) {
+            continue;
+          }
+          const inbound = currentState
+            .getSnapshot()
+            .messages.find(
+              (message) => message.direction === "inbound" && message.senderId === senderId,
+            );
+          if (!inbound) {
+            throw new Error(`missing ${senderId} inbound message`);
+          }
+          const marker = inbound.text.split("reply exactly: ")[1];
+          if (!marker) {
+            throw new Error(`missing ${senderId} requested reply marker`);
+          }
+          currentState.addOutboundMessage({
+            accountId: "qa-channel",
+            to: "group:qa-routing-allowlist",
+            replyToId: inbound.id,
+            text: marker,
+          });
+        }
+      },
+    });
+
+    if (expectedFailure) {
+      await expect(result).rejects.toThrow(expectedFailure);
+    } else {
+      await expect(result).resolves.toMatchObject({ status: "pass" });
+    }
+
+    const snapshot = state.getSnapshot();
+    const senderIdsByInboundId = new Map(
+      snapshot.messages
+        .filter((message) => message.direction === "inbound")
+        .map((message) => [message.id, message.senderId]),
+    );
+    expect(
+      snapshot.messages
+        .filter((message) => message.direction === "outbound")
+        .map((message) => senderIdsByInboundId.get(message.replyToId ?? "")),
+    ).toEqual([...(observerReplies ? ["observer"] : []), ...(driverReplies ? ["driver"] : [])]);
   });
 
   it("keeps transcript-role delivery on the Crabline driver", () => {

--- a/qa/scenarios/channels/channel-sender-allowlist.yaml
+++ b/qa/scenarios/channels/channel-sender-allowlist.yaml
@@ -27,6 +27,7 @@ scenario:
         - driver
     config:
       conversationId: qa-routing-allowlist
+      blockedMarker: QA-BLOCKED-SENDER-SHOULD-NOT-REPLY
       expectedMarker: QA-ALLOWLIST-OVERRIDE-OK
 
 flow:
@@ -38,9 +39,6 @@ flow:
         - call: waitForTransportReady
           args: [{ ref: env }, 60000]
         - resetTransport: true
-        - set: outboundStartIndex
-          value:
-            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
         - sendInbound:
             conversation:
               id: { ref: config.conversationId }
@@ -48,10 +46,9 @@ flow:
             senderId: observer
             senderName: QA Observer
             text:
-              expr: "`@openclaw reply exactly: ${config.expectedMarker}`"
+              expr: "`@openclaw reply exactly: ${config.blockedMarker}`"
         - waitForNoOutbound:
             quietMs: 1500
-            sinceIndex: { ref: outboundStartIndex }
         - sendInbound:
             conversation:
               id: { ref: config.conversationId }
@@ -68,4 +65,7 @@ flow:
             timeoutMs:
               expr: liveTurnTimeoutMs(env, 60000)
           saveAs: outbound
+        - assert:
+            expr: "!state.getSnapshot().messages.some((message) => message.direction === 'outbound' && String(message.text ?? '').includes(config.blockedMarker))"
+            message: { expr: "`blocked sender replied: ${recentOutboundSummary(state)}`" }
       detailsExpr: outbound.text


### PR DESCRIPTION
## Summary

The release/all channel sender-allowlist QA scenario reused the same reply marker for blocked and authorized senders and discarded its original outbound boundary. A blocked sender's reply could therefore satisfy the authorized sender's expected response, falsely reporting a successful allowlist check.

Give the blocked sender its own marker and assert across the complete actual scenario execution that the blocked marker never appears. The authorized driver still has to produce its own expected reply, so both blocked-only responses and mixed blocked-plus-authorized responses now fail.

Scenario production YAML: +5/-5 (net 0). Tests: +76/-0.

## Verification

- Drove the actual registered release/all scenario through the canonical in-process bus and flow runner, capturing the blocked-only and blocked-plus-authorized false successes before the fix.
- Confirmed blocked-only and mixed replies now fail for the correct observable reasons, while authorized-only delivery succeeds.
- Ran relevant scenario/catalog/runtime coverage: **223 tests passed**.
- Formatting, focused checks, and fresh independent P1 review passed.
- No live channels, providers, user gateway, account state, or network were used.

## Risk

Low: scenario-only correctness, no shipped runtime behavior or public configuration changes.
