### PR TITLE
fix(feishu): deliver presentations in document comments

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -31,12 +31,7 @@ import {
   createRuntimeDirectoryLiveAdapter,
 } from "openclaw/plugin-sdk/directory-runtime";
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
-import {
-  legacyInteractiveReplyToPresentation,
-  normalizeLegacyInteractiveReply,
-  normalizeMessagePresentation,
-  resolveLegacyInteractiveTextFallback,
-} from "openclaw/plugin-sdk/interactive-runtime";
+import { resolveLegacyInteractiveTextFallback } from "openclaw/plugin-sdk/interactive-runtime";
 import { createLazyRuntimeNamedExport } from "openclaw/plugin-sdk/lazy-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { createComputedAccountStatusAdapter } from "openclaw/plugin-sdk/status-helpers";
@@ -98,6 +93,7 @@ import {
   assertFeishuCardWithinEnvelope,
   buildFeishuPresentationCard,
   isFeishuCardWithinEnvelope,
+  resolveFeishuRichReply,
 } from "./presentation-card.js";
 import {
   assertFeishuChatReadAllowed,
@@ -1356,10 +1352,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             const textCard = readNativeFeishuCardJson(text, {
               responsePrefix: resolveFeishuMessageActionResponsePrefix(ctx),
             });
-            const interactive = normalizeLegacyInteractiveReply(ctx.params.interactive);
-            const presentation =
-              normalizeMessagePresentation(ctx.params.presentation) ??
-              (interactive ? legacyInteractiveReplyToPresentation(interactive) : undefined);
+            const { interactive, presentation } = resolveFeishuRichReply(ctx.params);
             // send promotes every attachment alias (path/filePath/mediaUrl/fileUrl/
             // image/mediaUrls/attachments[]) to a canonical mediaUrl and rejects
             // unsupported buffer/base64 payloads or multiple attachments instead

--- a/extensions/feishu/src/comment-dispatcher.test.ts
+++ b/extensions/feishu/src/comment-dispatcher.test.ts
@@ -209,6 +209,105 @@ describe("createFeishuCommentReplyDispatcher", () => {
       { mediaUrls: [" "], mediaUrl: "https://example.com/fallback.png" },
       "https://example.com/fallback.png",
     ],
+    [
+      "presentation-only actionable command",
+      {
+        presentation: {
+          title: "Deployment",
+          blocks: [
+            {
+              type: "buttons" as const,
+              buttons: [
+                {
+                  label: "Approve",
+                  action: { type: "command" as const, command: "/approve req_1" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      "Deployment\n\n- Approve: `/approve req_1`\n\n> Interactive buttons are unavailable in Feishu document comments. You can type the command shown above manually.",
+    ],
+    [
+      "caption, actionable presentation, and safe attachment",
+      {
+        text: "Review this",
+        mediaUrl: "https://example.com/attachment.png",
+        presentation: {
+          blocks: [
+            {
+              type: "buttons" as const,
+              buttons: [
+                {
+                  label: "Approve",
+                  action: { type: "command" as const, command: "/approve req_1" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      "Review this\n\n- Approve: `/approve req_1`\n\n> Interactive buttons are unavailable in Feishu document comments. You can type the command shown above manually.\n\nhttps://example.com/attachment.png",
+    ],
+    [
+      "legacy interactive command",
+      {
+        interactive: {
+          blocks: [
+            {
+              type: "buttons" as const,
+              buttons: [
+                {
+                  label: "Approve",
+                  action: { type: "command" as const, command: "/approve req_1" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      "- Approve: `/approve req_1`\n\n> Interactive buttons are unavailable in Feishu document comments. You can type the command shown above manually.",
+    ],
+    [
+      "disabled command without actionable guidance",
+      {
+        presentation: {
+          blocks: [
+            {
+              type: "buttons" as const,
+              buttons: [
+                {
+                  label: "Disabled",
+                  disabled: true,
+                  action: { type: "command" as const, command: "/approve req_1" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      "- Disabled",
+    ],
+    [
+      "URL-only button without actionable guidance",
+      {
+        presentation: {
+          blocks: [
+            {
+              type: "buttons" as const,
+              buttons: [
+                {
+                  label: "Open",
+                  action: { type: "url" as const, url: "https://example.com/action" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      "- Open: https://example.com/action",
+    ],
   ])("delivers %s as safe plain-text comment links", async (_label, payload, expected) => {
     const created = createTestCommentReplyDispatcher();
 

--- a/extensions/feishu/src/comment-dispatcher.test.ts
+++ b/extensions/feishu/src/comment-dispatcher.test.ts
@@ -270,6 +270,45 @@ describe("createFeishuCommentReplyDispatcher", () => {
       "- Approve: `/approve req_1`\n\n> Interactive buttons are unavailable in Feishu document comments. You can type the command shown above manually.",
     ],
     [
+      "select option with an actionable command",
+      {
+        presentation: {
+          blocks: [
+            {
+              type: "select" as const,
+              placeholder: "Choose deployment",
+              options: [
+                {
+                  label: "Deploy",
+                  action: { type: "command" as const, command: "/deploy staging" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      "Choose deployment:\n- Deploy: `/deploy staging`\n\n> Interactive buttons are unavailable in Feishu document comments. You can type the command shown above manually.",
+    ],
+    [
+      "select callback without actionable guidance",
+      {
+        presentation: {
+          blocks: [
+            {
+              type: "select" as const,
+              options: [
+                {
+                  label: "Choose",
+                  action: { type: "callback" as const, value: "private_choice" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      "Options:\n- Choose",
+    ],
+    [
       "disabled command without actionable guidance",
       {
         presentation: {

--- a/extensions/feishu/src/comment-dispatcher.ts
+++ b/extensions/feishu/src/comment-dispatcher.ts
@@ -15,6 +15,10 @@ import type { CommentFileType } from "./comment-target.js";
 import { deliverCommentThreadText } from "./drive.js";
 import { buildFeishuMediaFallbackText } from "./media-fallback.js";
 import {
+  buildFeishuCommentPresentationFallback,
+  resolveFeishuRichReply,
+} from "./presentation-card.js";
+import {
   createFeishuPartialReplyDeliveryError,
   createFeishuReplyDeliveryResult,
   noVisibleFeishuReplyDelivery,
@@ -82,7 +86,8 @@ export function createFeishuCommentReplyDispatcher(
         return noVisibleFeishuReplyDelivery;
       }
       const reply = resolveSendableOutboundReplyParts(payload);
-      let text = reply.text;
+      const { presentation } = resolveFeishuRichReply(payload);
+      let { text } = buildFeishuCommentPresentationFallback({ text: reply.text, presentation });
       for (const mediaUrl of reply.mediaUrls) {
         text = await buildFeishuMediaFallbackText({ text, mediaUrl, mediaLinkStyle: "plain" });
       }

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -14,7 +14,7 @@ import {
   type MessagePresentationAction,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ClawdbotConfig } from "../runtime-api.js";
+import type { ClawdbotConfig, ReplyPayload } from "../runtime-api.js";
 import {
   FEISHU_SELECTED_SECRET_ENV,
   FEISHU_SIBLING_SECRET_ENV,
@@ -2011,6 +2011,59 @@ describe("feishuOutbound.sendPayload native cards", () => {
     );
     expectFeishuResult(result, "reply_msg");
   });
+
+  it.each(["direct", "core-rendered"] as const)(
+    "preserves select command guidance for %s document-comment delivery",
+    async (deliveryPath) => {
+      const presentation: MessagePresentation = {
+        blocks: [
+          {
+            type: "select",
+            placeholder: "Choose deployment",
+            options: [
+              {
+                label: "Deploy",
+                action: { type: "command", command: "/deploy staging" },
+              },
+            ],
+          },
+        ],
+      };
+      const originalPayload = { presentation };
+      let payload: ReplyPayload = originalPayload;
+      if (deliveryPath === "core-rendered") {
+        const rendered = await feishuOutbound.renderPresentation?.({
+          payload: originalPayload,
+          presentation,
+          ctx: {
+            cfg: emptyConfig,
+            to: "comment:docx:doxcn123:7623358762119646411",
+            text: "",
+            accountId: "main",
+            payload: originalPayload,
+          },
+        });
+        if (!rendered) {
+          throw new Error("expected Feishu-rendered select presentation");
+        }
+        const { presentation: _presentation, ...coreRenderedPayload } = rendered;
+        payload = coreRenderedPayload;
+      }
+
+      const result = await feishuOutbound.sendPayload?.({
+        cfg: emptyConfig,
+        to: "comment:docx:doxcn123:7623358762119646411",
+        text: "",
+        accountId: "main",
+        payload,
+      });
+
+      expect(commentThreadParams()?.content).toBe(
+        "Choose deployment:\n- Deploy: `/deploy staging`\n\n> Interactive buttons are unavailable in Feishu document comments. You can type the command shown above manually.",
+      );
+      expectFeishuResult(result, "reply_msg");
+    },
+  );
 
   it("keeps TTS supplements on the document-comment delivery path", async () => {
     await feishuOutbound.sendPayload?.({

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -9,11 +9,7 @@ import {
   attachChannelToResult,
   createAttachedChannelResultAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
-import type { MessagePresentationBlock } from "openclaw/plugin-sdk/interactive-runtime";
 import {
-  legacyInteractiveReplyToPresentation,
-  normalizeLegacyInteractiveReply,
-  normalizeMessagePresentation,
   renderMessagePresentationFallbackText,
   resolveLegacyInteractiveTextFallback,
 } from "openclaw/plugin-sdk/interactive-runtime";
@@ -57,8 +53,10 @@ import {
 import type { ChannelOutboundAdapter } from "./outbound-runtime-api.js";
 import {
   assertFeishuCardWithinEnvelope,
+  buildFeishuCommentPresentationFallback,
   buildFeishuPresentationCardElements,
   isFeishuCardWithinEnvelope,
+  resolveFeishuRichReply,
 } from "./presentation-card.js";
 import {
   sendCardFeishu,
@@ -259,10 +257,7 @@ function buildFeishuPayloadCard(params: {
 
   const rawText = params.text ?? params.payload.text;
   const textCard = readNativeFeishuCardJson(rawText);
-  const interactive = normalizeLegacyInteractiveReply(params.payload.interactive);
-  const presentation =
-    normalizeMessagePresentation(params.payload.presentation) ??
-    (interactive ? legacyInteractiveReplyToPresentation(interactive) : undefined);
+  const { interactive, presentation } = resolveFeishuRichReply(params.payload);
   if (!presentation && !interactive) {
     if (!textCard) {
       return undefined;
@@ -314,34 +309,13 @@ function buildFeishuPayloadCard(params: {
   return isFeishuCardWithinEnvelope(card) ? card : undefined;
 }
 
-// Keep this aligned with the shared fallback renderer: guidance is valid only
-// when the fallback text exposes a command the user can copy.
-function hasVisibleFallbackCommand(
-  blocks: readonly MessagePresentationBlock[] | undefined,
-): boolean {
-  return (
-    blocks?.some(
-      (block) =>
-        block.type === "buttons" &&
-        block.buttons.some(
-          (button) =>
-            !button.disabled &&
-            button.action?.type === "command" &&
-            !button.url &&
-            !button.webApp?.url &&
-            !button.web_app?.url,
-        ),
-    ) ?? false
-  );
-}
-
 function renderFeishuPresentationPayload({
   payload,
   presentation,
   ctx,
 }: Parameters<NonNullable<ChannelOutboundAdapter["renderPresentation"]>>[0]) {
   const textCard = readNativeFeishuCardJson(payload.text);
-  const fallbackText = renderMessagePresentationFallbackText({
+  const { fallbackText, fallbackHasCommand } = buildFeishuCommentPresentationFallback({
     text: textCard ? undefined : payload.text,
     presentation,
   });
@@ -353,7 +327,6 @@ function renderFeishuPresentationPayload({
   const existingFeishuData = isRecord(payload.channelData?.feishu)
     ? payload.channelData.feishu
     : undefined;
-  const fallbackHasCommand = hasVisibleFallbackCommand(presentation?.blocks);
   if (!card) {
     // The marker keeps core on sendPayload after it strips presentation; that path
     // consumes it and fans out text instead of using the whole fallback as a caption.
@@ -697,21 +670,21 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const { payload, presentationFallback } = consumeFeishuPresentationFallbackMarker(ctx.payload);
     const ttsSupplement = getReplyPayloadTtsSupplement(payload);
     if (parseFeishuCommentTarget(ctx.to)) {
-      const interactive = normalizeLegacyInteractiveReply(payload.interactive);
-      const normalizedPresentation =
-        normalizeMessagePresentation(payload.presentation) ??
-        (interactive ? legacyInteractiveReplyToPresentation(interactive) : undefined);
+      const { presentation } = resolveFeishuRichReply(payload);
       // Document comments cannot render cards. Resolve the text path before
       // validating card limits so unused native card data cannot block delivery.
       const textCard = readNativeFeishuCardJson(payload.text);
       const fallbackSourceText = textCard ? undefined : payload.text;
-      const presentationFallbackText = renderMessagePresentationFallbackText({
+      const { text, fallbackText } = buildFeishuCommentPresentationFallback({
         text: fallbackSourceText,
-        presentation: normalizedPresentation,
+        presentation,
+        fallbackHasCommand:
+          isRecord(payload.channelData?.feishu) &&
+          payload.channelData.feishu.fallbackHasCommand === true,
       });
       const hasFallbackMedia = normalizeStringEntries(resolvePayloadMediaUrls(payload)).length > 0;
       if (
-        !presentationFallbackText.trim() &&
+        !fallbackText.trim() &&
         !hasFallbackMedia &&
         (textCard || readNativeFeishuCard(payload))
       ) {
@@ -719,14 +692,6 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           "Feishu native cards cannot be sent to document comments without a text or media fallback.",
         );
       }
-      // Direct delivery retains blocks; core-rendered delivery carries the fact.
-      const fallbackHasCommand =
-        hasVisibleFallbackCommand(normalizedPresentation?.blocks) ||
-        (isRecord(payload.channelData?.feishu) &&
-          payload.channelData.feishu.fallbackHasCommand === true);
-      const text = fallbackHasCommand
-        ? `${presentationFallbackText}\n\n> Interactive buttons are unavailable in Feishu document comments. You can type the command shown above manually.`
-        : presentationFallbackText;
       const fallbackPayload = {
         ...payload,
         text,
@@ -754,10 +719,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       if (ttsSupplement) {
         return await sendFeishuTtsSupplementPayload({ ctx, payload, supplement: ttsSupplement });
       }
-      const interactive = normalizeLegacyInteractiveReply(payload.interactive);
-      const presentation =
-        normalizeMessagePresentation(payload.presentation) ??
-        (interactive ? legacyInteractiveReplyToPresentation(interactive) : undefined);
+      const { presentation } = resolveFeishuRichReply(payload);
       const fallbackPayload = presentation
         ? {
             ...payload,

--- a/extensions/feishu/src/presentation-card.ts
+++ b/extensions/feishu/src/presentation-card.ts
@@ -35,13 +35,14 @@ export function buildFeishuCommentPresentationFallback(params: {
   // Only warn when the rendered fallback exposes a command the user can copy.
   const fallbackHasCommand =
     params.fallbackHasCommand === true ||
-    params.presentation?.blocks.some(
-      (block) =>
-        block.type === "buttons" &&
-        block.buttons.some(
-          ({ action, disabled, url, webApp, web_app }) =>
-            !disabled && action?.type === "command" && !url && !webApp?.url && !web_app?.url,
-        ),
+    params.presentation?.blocks.some((block) =>
+      block.type === "select"
+        ? block.options.some(({ action }) => action?.type === "command")
+        : block.type === "buttons" &&
+          block.buttons.some(
+            ({ action, disabled, url, webApp, web_app }) =>
+              !disabled && action?.type === "command" && !url && !webApp?.url && !web_app?.url,
+          ),
     ) === true;
   return {
     fallbackText,

--- a/extensions/feishu/src/presentation-card.ts
+++ b/extensions/feishu/src/presentation-card.ts
@@ -1,5 +1,7 @@
 // Feishu plugin module implements presentation card behavior.
 import {
+  legacyInteractiveReplyToPresentation,
+  normalizeLegacyInteractiveReply,
   normalizeMessagePresentation,
   renderMessagePresentationChartFallbackText,
   renderMessagePresentationFallbackText,
@@ -13,6 +15,42 @@ type NormalizedMessagePresentation = NonNullable<ReturnType<typeof normalizeMess
 
 const FEISHU_CARD_MAX_BYTES = 30 * 1024;
 const FEISHU_CARD_MAX_ELEMENTS = 200;
+
+export function resolveFeishuRichReply(payload: { interactive?: unknown; presentation?: unknown }) {
+  const interactive = normalizeLegacyInteractiveReply(payload.interactive);
+  return {
+    interactive,
+    presentation:
+      normalizeMessagePresentation(payload.presentation) ??
+      (interactive ? legacyInteractiveReplyToPresentation(interactive) : undefined),
+  };
+}
+
+export function buildFeishuCommentPresentationFallback(params: {
+  text?: string;
+  presentation?: NormalizedMessagePresentation;
+  fallbackHasCommand?: boolean;
+}) {
+  const fallbackText = renderMessagePresentationFallbackText(params);
+  // Only warn when the rendered fallback exposes a command the user can copy.
+  const fallbackHasCommand =
+    params.fallbackHasCommand === true ||
+    params.presentation?.blocks.some(
+      (block) =>
+        block.type === "buttons" &&
+        block.buttons.some(
+          ({ action, disabled, url, webApp, web_app }) =>
+            !disabled && action?.type === "command" && !url && !webApp?.url && !web_app?.url,
+        ),
+    ) === true;
+  return {
+    fallbackText,
+    fallbackHasCommand,
+    text: fallbackHasCommand
+      ? `${fallbackText}\n\n> Interactive buttons are unavailable in Feishu document comments. You can type the command shown above manually.`
+      : fallbackText,
+  };
+}
 
 function countFeishuCardElements(value: unknown, ancestors = new Set<object>()): number {
   if (Array.isArray(value)) {


### PR DESCRIPTION
## Summary

Feishu document-comment replies ignored structured presentations and legacy interactive controls. Presentation-only replies silently vanished, while text-plus-actions lost copyable commands. The initial repair also detected commands only in button blocks, missing command-bearing select options.

Consolidate rich-reply normalization and document-comment fallback into the canonical Feishu presentation owner. All normal comment dispatch, direct outbound, core-rendered outbound, card, and channel-action paths now preserve actionable button **and select** commands, while disabled buttons, callback-only controls, URL buttons, native-card rejection, media links, and fallback metadata retain their existing semantics.

Full production delta: +60/-61 (net -1). Tests: +192/-1.

## Verification

- Captured authentic fail-first provider-boundary delivery for presentation-only and caption-plus-action replies.
- Captured three additional fail-first select-command regressions across normal comment dispatch, direct outbound, and core-rendered outbound; preserved disabled, URL, and callback controls.
- Exercised the actual Feishu SDK provider boundary: presentation-only and caption-plus-actions each deliver exactly one visible reply with command guidance.
- Ran the complete Feishu plugin: **96 suites and 1,640 tests passed**.
- Targeted type-aware lint, changed-file type checking, formatting, `git diff --check`, and a fresh integrated complete-branch independent P1 review passed.
- No live Feishu account, external service, or user credentials were touched.

## Risk

Low: plugin-owned presentation/delivery consolidation, less production code, no provider API change, no public configuration, and no persistent-state change. Addresses ClawSweeper's command-bearing-select finding directly.
