### PR TITLE
fix(gateway): report failed secondary account restart probes

### DIFF
--- a/src/cli/daemon-cli/restart-health-probe.test.ts
+++ b/src/cli/daemon-cli/restart-health-probe.test.ts
@@ -320,7 +320,16 @@ describe("restart health", () => {
     expect(sleep).not.toHaveBeenCalled();
   });
 
-  it("stops waiting once the expected-version gateway reports channel probe errors", async () => {
+  it.each([
+    ["a legacy channel snapshot", undefined, "telegram"],
+    ["an active secondary account", {}, "telegram/work"],
+    ["a disabled secondary account", { enabled: false }, undefined],
+    ["an unconfigured secondary account", { configured: false }, undefined],
+    ["an unlinked secondary account", { linked: false }, undefined],
+    ["a status-disabled secondary account", { statusState: "disabled" }, undefined],
+    ["a status-unconfigured secondary account", { statusState: "unconfigured" }, undefined],
+  ])("reports restart health for %s", async (_label, accountState, expectedAccountId) => {
+    const failedProbe = { ok: false, error: "This operation was aborted" };
     probeGateway.mockResolvedValue({
       ok: true,
       close: null,
@@ -330,7 +339,15 @@ describe("restart health", () => {
         channels: {
           telegram: {
             configured: true,
-            probe: { ok: false, error: "This operation was aborted" },
+            probe: accountState ? { ok: true } : failedProbe,
+            ...(accountState
+              ? {
+                  accounts: {
+                    default: { configured: true, probe: { ok: true } },
+                    work: { enabled: true, configured: true, ...accountState, probe: failedProbe },
+                  },
+                }
+              : {}),
           },
         },
       },
@@ -342,19 +359,27 @@ describe("restart health", () => {
       hints: [],
     });
 
-    const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
+    const { renderRestartDiagnostics, waitForGatewayHealthyRestart } =
+      await import("./restart-health.js");
     const snapshot = await waitForGatewayHealthyRestart({
       service: makeGatewayService({ status: "running", pid: 8000 }),
       port: 18789,
       expectedVersion: "2026.4.24",
     });
 
-    expect(snapshot.healthy).toBe(false);
-    expect(snapshot.waitOutcome).toBe("channel-errors");
+    expect(snapshot.healthy).toBe(!expectedAccountId);
+    expect(snapshot.waitOutcome).toBe(expectedAccountId ? "channel-errors" : "healthy");
     expect(snapshot.elapsedMs).toBe(0);
-    expect(snapshot.channelProbeErrors).toEqual([
-      { id: "telegram", error: "This operation was aborted" },
-    ]);
+    if (expectedAccountId) {
+      expect(snapshot.channelProbeErrors).toEqual([
+        { id: expectedAccountId, error: "This operation was aborted" },
+      ]);
+      expect(renderRestartDiagnostics(snapshot)).toContain(
+        `- ${expectedAccountId}: This operation was aborted`,
+      );
+    } else {
+      expect(snapshot.channelProbeErrors).toBeUndefined();
+    }
     expect(sleep).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/daemon-cli/restart-health-probe.ts
+++ b/src/cli/daemon-cli/restart-health-probe.ts
@@ -1,4 +1,5 @@
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -123,33 +124,32 @@ function readActivatedPluginErrors(health: unknown): PluginHealthErrorSummary[] 
 }
 
 function readChannelProbeErrors(health: unknown): Array<{ id: string; error: string }> {
-  if (!health || typeof health !== "object") {
-    return [];
-  }
-  const channels = (health as { channels?: unknown }).channels;
-  if (!channels || typeof channels !== "object" || Array.isArray(channels)) {
-    return [];
-  }
-  const errors: Array<{ id: string; error: string }> = [];
-  for (const [id, summary] of Object.entries(channels)) {
-    if (!summary || typeof summary !== "object") {
-      continue;
-    }
-    const probe = (summary as { probe?: unknown }).probe;
-    if (!probe || typeof probe !== "object") {
-      continue;
-    }
-    const ok = (probe as { ok?: unknown }).ok;
-    if (ok !== false) {
-      continue;
-    }
-    const error = (probe as { error?: unknown }).error;
-    errors.push({
-      id,
-      error: typeof error === "string" && error.trim() ? error : "probe failed",
+  const channels = asNullableRecord(asNullableRecord(health)?.channels);
+  return Object.entries(channels ?? {}).flatMap(([id, summary]) => {
+    const channel = asNullableRecord(summary);
+    const accounts = asNullableRecord(channel?.accounts);
+    return Object.entries(accounts ?? { [id]: channel }).flatMap(([accountId, value]) => {
+      const account = asNullableRecord(value);
+      const probe = asNullableRecord(account?.probe);
+      if (
+        probe?.ok !== false ||
+        account?.enabled === false ||
+        account?.configured === false ||
+        account?.linked === false ||
+        account?.statusState === "disabled" ||
+        account?.statusState === "unconfigured"
+      ) {
+        return [];
+      }
+      const error = probe.error;
+      return [
+        {
+          id: accounts ? `${id}/${accountId}` : id,
+          error: typeof error === "string" && error.trim() ? error : "probe failed",
+        },
+      ];
     });
-  }
-  return errors;
+  });
 }
 
 export async function confirmGatewayReachable(params: {


### PR DESCRIPTION
## Summary

Gateway restart diagnostics inspected only a channel's aggregate/default probe. An active secondary account could fail its real channel probe while the default account succeeded, causing the restart command to incorrectly report the Gateway fully healthy.

Read per-account probes at the existing restart-health ownership boundary and retain canonical channel-level snapshots when account snapshots are unavailable. Report active secondary failures using their precise `channel/account` identity while correctly ignoring disabled, unconfigured, and unlinked accounts.

Production: +26/-26 (net 0). Tests: +33/-8.

## Verification

- Captured the original failing restart-owner regression before production changes.
- Invoked the actual production `confirmGatewayReachable` owner with an isolated synchronous transport stub: a failed active account now appears as `telegram/secondary` instead of disappearing.
- Ran restart-owner, Gateway health-collector, and formatter siblings: **108 tests passed**; two pre-existing loopback-server cases were intentionally skipped to avoid touching local network services.
- Confirmed legacy aggregate snapshots, active account failures, disabled/unconfigured/unlinked accounts, and rendered restart diagnostics.
- Formatting, focused lint, architecture guards, and independent P1 review passed.
- Whole-repository type programs currently expose unrelated pre-existing Google, markdown-it, and terminal UI dependency mismatches; neither changed file produces diagnostics.

## Risk

Low: existing CLI health projection only, no service lifecycle change, no authentication/configuration change, no persistent state, and no interaction with the user's live Gateway.
