### PR TITLE
fix(memory): cap embedding batch item count

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -37,6 +37,7 @@ import { createMemoryEmbeddingOperationError } from "./manager-embedding-errors.
 import {
   buildMemoryEmbeddingBatches,
   buildTextEmbeddingInputs,
+  DEFAULT_MEMORY_EMBEDDING_BATCH_MAX_ITEMS,
   filterNonEmptyMemoryChunks,
   isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingTransportError,
@@ -57,6 +58,19 @@ const VECTOR_TABLE = MEMORY_INDEX_VECTOR_TABLE;
 const FTS_TABLE = MEMORY_INDEX_FTS_TABLE;
 const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const EMBEDDING_BATCH_MAX_TOKENS = 8000;
+
+function resolveEmbeddingBatchMaxItems(): number {
+  const raw = process.env.OPENCLAW_MEMORY_EMBEDDING_BATCH_MAX_ITEMS;
+  if (raw != null && raw.trim() !== "") {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_MEMORY_EMBEDDING_BATCH_MAX_ITEMS;
+}
+
+const EMBEDDING_BATCH_MAX_ITEMS = resolveEmbeddingBatchMaxItems();
 const EMBEDDING_INDEX_CONCURRENCY = 4;
 const EMBEDDING_RETRY_MAX_ATTEMPTS = 3;
 const EMBEDDING_RETRY_BASE_DELAY_MS = 500;
@@ -261,7 +275,11 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
 
     const missingChunks = missing.map((m) => m.chunk);
-    const batches = buildMemoryEmbeddingBatches(missingChunks, EMBEDDING_BATCH_MAX_TOKENS);
+    const batches = buildMemoryEmbeddingBatches(
+      missingChunks,
+      EMBEDDING_BATCH_MAX_TOKENS,
+      EMBEDDING_BATCH_MAX_ITEMS,
+    );
     const provider = this.provider;
     if (!provider) {
       throw new Error("Cannot embed batch in FTS-only mode (no embedding provider)");

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -41,6 +41,50 @@ describe("memory embedding policy", () => {
     expect(batches[0]).toHaveLength(4);
   });
 
+  it("caps the number of chunks per batch even when the byte budget is not exhausted", () => {
+    // Short (e.g. Chinese) chunks stay far below the byte budget, but some
+    // providers reject more than a fixed number of items per request.
+    const chunks = Array.from({ length: 25 }, (_, index) => chunk(`\u6761\u76ee${index}`));
+
+    const batches = buildMemoryEmbeddingBatches(chunks, 8000);
+
+    expect(batches).toHaveLength(3);
+    expect(batches.map((batch) => batch.length)).toEqual([10, 10, 5]);
+    expect(batches.flat()).toEqual(chunks);
+  });
+
+  it("honors a custom per-batch item limit", () => {
+    const chunks = Array.from({ length: 7 }, (_, index) => chunk(`item-${index}`));
+
+    const batches = buildMemoryEmbeddingBatches(chunks, 8000, 3);
+
+    expect(batches).toHaveLength(3);
+    expect(batches.map((batch) => batch.length)).toEqual([3, 3, 1]);
+  });
+
+  it("splits on whichever limit is hit first: byte budget or item count", () => {
+    const small = "s".repeat(100);
+    const large = "l".repeat(4000);
+    const chunks = [
+      chunk(small),
+      chunk(small),
+      chunk(large),
+      chunk(large),
+      chunk(small),
+      chunk(small),
+    ];
+
+    const batches = buildMemoryEmbeddingBatches(chunks, 8000, 3);
+
+    // No batch exceeds either 3 items or 8000 bytes, and order is preserved.
+    for (const batch of batches) {
+      expect(batch.length).toBeLessThanOrEqual(3);
+      const bytes = batch.reduce((sum, item) => sum + Buffer.byteLength(item.text, "utf8"), 0);
+      expect(bytes).toBeLessThanOrEqual(8000);
+    }
+    expect(batches.flat()).toEqual(chunks);
+  });
+
   it("filters empty chunks before embedding", () => {
     const chunks = filterNonEmptyMemoryChunks([chunk("\n\n"), chunk("hello"), chunk("   ")]);
 
@@ -279,6 +323,19 @@ describe("memory embedding policy", () => {
       ),
     ).toBe(true);
     expect(isStructuredInputTooLargeMemoryEmbeddingError("connection reset by peer")).toBe(false);
+  });
+
+  it("treats provider item-count and 413 errors as splittable", () => {
+    const splittableMessages = [
+      "Embeddings API input limit exceeded: max 10, got 58.",
+      "BadRequest: too many inputs in embeddings request",
+      "HTTP 413 Payload Too Large",
+      "request entity too large (413)",
+    ];
+
+    for (const message of splittableMessages) {
+      expect(isSplittableMemoryEmbeddingTransportError(message)).toBe(true);
+    }
   });
 
   it("caps retry jittered delays", () => {

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -49,19 +49,36 @@ export function filterNonEmptyMemoryChunks<T extends MemoryEmbeddingChunk>(chunk
   return chunks.filter((chunk) => chunk.text.trim().length > 0);
 }
 
+/**
+ * Default maximum number of chunks per embedding request.
+ *
+ * Some embedding providers (notably the Volcengine Ark / Doubao `/embeddings`
+ * gateway) enforce a hard server-side cap on the number of items in a single
+ * `input` array and reject larger batches with HTTP 400
+ * (`Embeddings API input limit exceeded: max 10, got N`), regardless of the
+ * total payload byte size. The byte budget alone cannot protect against this
+ * because short (e.g. Chinese) chunks pack dozens of items well under the byte
+ * limit. Ten is a safe default for those providers and only costs a few extra
+ * round trips for providers without an item cap.
+ */
+export const DEFAULT_MEMORY_EMBEDDING_BATCH_MAX_ITEMS = 10;
+
 export function buildMemoryEmbeddingBatches<T extends MemoryEmbeddingChunk>(
   chunks: T[],
   maxTokens: number,
+  maxItems: number = DEFAULT_MEMORY_EMBEDDING_BATCH_MAX_ITEMS,
 ): T[][] {
   const batches: T[][] = [];
   let current: T[] = [];
   let currentTokens = 0;
+  const itemLimit = Math.max(1, Math.floor(maxItems));
 
   for (const chunk of chunks) {
     const estimate = chunk.embeddingInput
       ? estimateStructuredEmbeddingInputBytes(chunk.embeddingInput)
       : estimateUtf8Bytes(chunk.text);
-    const wouldExceed = current.length > 0 && currentTokens + estimate > maxTokens;
+    const wouldExceed =
+      current.length > 0 && (currentTokens + estimate > maxTokens || current.length >= itemLimit);
     if (wouldExceed) {
       batches.push(current);
       current = [];
@@ -88,7 +105,7 @@ const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
   /(fetch failed|other side closed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|UND_ERR_|socket hang up|socket terminated|network error|read ECONN|timed out|connection (?:reset|refused|aborted|timed out)|EHOSTUNREACH|ENETUNREACH|ECONNABORTED|EAI_AGAIN)/i;
 
 const SPLITTABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
-  /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted))/i;
+  /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted)|input limit exceeded|too many inputs|embeddings api input limit|max \d+ items|413|payload too large|request too large)/i;
 
 export function isRetryableMemoryEmbeddingTransportError(message: string): boolean {
   return RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message);


### PR DESCRIPTION
## Problem

Memory indexing batches chunks using only an 8000-byte budget, with no limit on the number of items per request. Providers that enforce a server-side cap on the `input` array length reject these requests.

The Volcengine Ark / Doubao `/embeddings` gateway allows **at most 10 items per request, regardless of payload size**. Short chunks — Chinese text in particular — pack dozens of items well under the byte budget, so indexing fails:

```
embeddings failed: HTTP 400: {"error":{"code":"InvalidParameter",
"message":"The parameter `input` specified in the request are not valid:
Embeddings API input limit exceeded: max 10, got 58.",
"param":"input","type":"BadRequest"}}
```

In the case that prompted this patch, 58 chunks totalled only 3876 bytes — less than half the byte budget — so they were packed into a single request and rejected. Verified against both `api/coding/v3` and `api/plan/v3` with several `doubao-embedding` models: `n=10` always succeeds, `n=11` always returns 400. The cap is enforced at the gateway, so no model or endpoint choice avoids it.

This is not a one-time migration issue. The embedding cache means steady-state edits re-embed only a few chunks, but any batch of more than 10 dirty chunks trips the limit — adding a new memory file, a bulk edit, `--force` reindex, or the first index of a new agent workspace.

## Fix

Add a per-batch item limit next to the existing byte budget, defaulting to `10` and overridable via `OPENCLAW_MEMORY_EMBEDDING_BATCH_MAX_ITEMS`. Batches now split on whichever limit is reached first.

Also add provider item-count and `413` errors to `SPLITTABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE`, so the existing `runMemoryEmbeddingBatchRetryWithSplit` bisecting retry can recover from item caps on providers we don't know about yet. This is purely defensive.

### Why 10 as the default

It is the known-safe value for Ark, and it is harmless elsewhere: providers without an item cap simply see a few more round trips. Batching is a transport optimization — one request with N inputs is semantically identical to N single-input requests, since each input maps to its own independent vector. Correctness is unaffected either way.

I considered exposing this through `memory.search.remote.batch` instead. That config path is currently `enabled`-only and threading a new option through the settings chain touched noticeably more surface than the bug warranted, so this patch keeps the change local with an env override. Happy to convert it to a first-class config key if you'd prefer that shape.

## Compatibility

**No reindex required.** Vector dimensions and embedding cache identity are untouched; only the number of chunks carried per HTTP request changes. Existing indexes stay valid.

One deployment note for anyone hitting this: smaller batches mean proportionally more requests, which can surface account-level rate limits (HTTP 429) that the old single-large-request behaviour masked. Not addressed here, as it is orthogonal to the correctness bug — but worth knowing if you index many agents at once.

## Tests

Four cases added to `manager-embedding-policy.test.ts`:

- many short chunks split by item count while far below the byte budget
- a custom item limit is honoured
- whichever limit is hit first triggers the split, and chunk order is preserved
- provider item-count and 413 messages are classified as splittable

```
✓ extensions/memory-core/src/memory/manager-embedding-policy.test.ts (18 tests)
  Test Files  1 passed (1)
       Tests  18 passed (18)
```

`oxlint` and `oxfmt --check` clean on all three changed files.
