### PR TITLE
fix(ui): cloud worker profile edits corrupt other providers

### DIFF
--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -399,7 +399,7 @@ suite.define(() => {
     }
   });
 
-  it("deletes a profile and its project defaults only after confirmation", async () => {
+  it("preserves provider-owned editors and deletes profiles plus their project defaults", async () => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();
     const pending = configuredCloudWorkerProfile();
@@ -416,9 +416,28 @@ suite.define(() => {
       },
     };
     const gateway = await installMockGateway(page, {
-      featureMethods: ["config.patch", "environments.list"],
+      featureMethods: ["config.patch", "config.schema", "environments.list"],
       methodResponses: {
         "config.get": configResponse(initialConfig, "cloud-workers-delete-1"),
+        "config.schema": {
+          version: "e2e",
+          generatedAt: "2026-08-25T00:00:00.000Z",
+          uiHints: {},
+          schema: {
+            type: "object",
+            properties: {
+              cloudWorkers: {
+                type: "object",
+                properties: {
+                  profiles: {
+                    type: "object",
+                    additionalProperties: { type: "object" },
+                  },
+                },
+              },
+            },
+          },
+        },
         "config.patch": {
           ok: true,
           hash: "cloud-workers-delete-2",
@@ -435,6 +454,57 @@ suite.define(() => {
       const pendingRow = page.locator(".settings-row").filter({
         has: page.locator("code", { hasText: /^pending$/ }),
       });
+      await pendingRow.getByRole("button", { name: "Edit" }).click();
+      const editor = page.locator(".settings-section", {
+        has: page.getByRole("heading", { name: "Edit profile", exact: true }),
+      });
+      await expect.poll(() => page.getByLabel("Crabbox backend").inputValue()).toBe("aws");
+
+      const replacement = {
+        provider: "static-ssh",
+        install: "bundle",
+        settings: {
+          host: "worker.example.test",
+          user: "openclaw",
+          keyRef: { source: "env", provider: "default", id: "QA_PRIVATE_KEY" },
+        },
+      };
+      const replacedConfig = {
+        cloudWorkers: {
+          profiles: { pending: replacement, retained },
+          projectProfiles: initialConfig.cloudWorkers.projectProfiles,
+        },
+      };
+      const configGetCount = (await gateway.getRequests("config.get")).length;
+      await gateway.setMethodResponse(
+        "config.get",
+        configResponse(replacedConfig, "cloud-workers-provider-replaced"),
+      );
+      await gateway.emitGatewayEvent("config.changed", {
+        path: "/tmp/openclaw.json",
+        hash: "cloud-workers-provider-replaced",
+        ts: Date.now(),
+      });
+      await gateway.waitForRequest("config.get", { after: configGetCount });
+      await pendingRow.getByText("Provider: static-ssh", { exact: true }).waitFor();
+      const saveButton = editor.getByRole("button", { name: "Save" });
+      await expect.poll(() => saveButton.isEnabled()).toBe(true);
+      await saveButton.click();
+      await expect
+        .poll(() => editor.getByRole("alert").textContent())
+        .toBe("This profile changed or was removed. Reload the page and try again.");
+      expect(await gateway.getRequests("config.patch")).toHaveLength(0);
+      await editor.getByRole("button", { name: "Cancel" }).click();
+
+      await pendingRow.getByRole("button", { name: "Edit" }).click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/advanced");
+      await expect.poll(() => new URL(page.url()).searchParams.get("section")).toBe("cloudWorkers");
+      await gateway.waitForRequest("config.schema");
+      await page.locator(".page-title").getByText("Advanced", { exact: true }).waitFor();
+      expect(await gateway.getRequests("config.patch")).toHaveLength(0);
+      await page.goBack();
+      await pendingRow.getByText("Provider: static-ssh", { exact: true }).waitFor();
+
       await pendingRow.getByRole("button", { name: "Delete" }).click();
       const confirmation = await waitForConfirmModal(page);
       await expect.poll(() => confirmation.textContent()).toContain("Delete profile pending?");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2584,7 +2584,7 @@ export const en: TranslationMap = {
     intro: "Run agent sessions on ephemeral cloud machines instead of this gateway.",
     documentation: "Cloud worker documentation",
     sectionTitle: "Profiles",
-    sectionDescription: "Each profile defines how Crabbox provisions and retires a worker.",
+    sectionDescription: "Each profile defines how its provider provisions and retires a worker.",
     empty: "No cloud worker profiles are configured.",
     addProfile: "Add profile",
     editProfile: "Edit profile",

--- a/ui/src/pages/cloud-workers/cloud-worker-config.test.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-config.test.ts
@@ -18,6 +18,7 @@ const configuredProfile = {
     ttl: "24h",
     idleTimeout: "60m",
     setup: "install-node",
+    setupEnv: ["OPENCLAW_WORKER_ARTIFACT_TOKEN"],
     desktop: true,
     binary: "/opt/crabbox",
     region: "eu-west-1",
@@ -91,6 +92,7 @@ describe("cloud worker settings state", () => {
                 ttl: "8h",
                 idleTimeout: "45m",
                 setup: null,
+                setupEnv: null,
                 desktop: null,
                 binary: null,
                 region: "eu-west-1",
@@ -99,6 +101,79 @@ describe("cloud worker settings state", () => {
           },
         },
       },
+    });
+  });
+
+  it("preserves forwarded setup environment while its setup command remains configured", () => {
+    const config = { cloudWorkers: { profiles: { production: configuredProfile } } };
+    const draft = createCloudWorkerDraft(readCloudWorkerProfiles(config)[0]);
+
+    expect(buildCloudWorkerUpsertPatch(config, draft, "production")).toMatchObject({
+      patch: {
+        cloudWorkers: {
+          profiles: {
+            production: {
+              settings: {
+                setup: "install-node",
+                setupEnv: ["OPENCLAW_WORKER_ARTIFACT_TOKEN"],
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it.each([undefined, []])("keeps empty setup environment unchanged (%j)", (setupEnv) => {
+    const existingSettings = Object.fromEntries(
+      Object.entries(configuredProfile.settings).filter(
+        ([key]) => key !== "setupEnv" || setupEnv !== undefined,
+      ),
+    );
+    if (setupEnv) {
+      existingSettings.setupEnv = setupEnv;
+    }
+    const profile = { ...configuredProfile, settings: existingSettings };
+    const config = { cloudWorkers: { profiles: { production: profile } } };
+    const draft = { ...createCloudWorkerDraft(readCloudWorkerProfiles(config)[0]), setup: "" };
+
+    expect(buildCloudWorkerUpsertPatch(config, draft, "production")).toEqual({
+      patch: {
+        cloudWorkers: {
+          profiles: {
+            production: { ...profile, settings: { ...existingSettings, setup: null } },
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects an edit after its authoritative profile changes provider", () => {
+    const config = {
+      cloudWorkers: {
+        profiles: {
+          production: {
+            provider: "static-ssh",
+            settings: { host: "worker.example.test", user: "openclaw" },
+          },
+        },
+      },
+    };
+    const draft = createCloudWorkerDraft({
+      id: "production",
+      providerId: "crabbox",
+      install: "bundle",
+      backend: "aws",
+      machineClass: "standard",
+      ttl: "8h",
+      idleTimeout: "45m",
+      setup: "",
+      desktop: false,
+      binary: "",
+    });
+
+    expect(buildCloudWorkerUpsertPatch(config, draft, "production")).toEqual({
+      error: "profileMissing",
     });
   });
 

--- a/ui/src/pages/cloud-workers/cloud-worker-config.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-config.ts
@@ -153,6 +153,9 @@ export function buildCloudWorkerUpsertPatch(
   }
   const id = editingId ?? draft.id;
   const existing = isRecord(profiles[id]) ? profiles[id] : {};
+  if (editingId && normalizeOptionalString(existing.provider) !== "crabbox") {
+    return { error: "profileMissing" };
+  }
   const existingSettings = profileSettings(existing);
   const settings = {
     ...existingSettings,
@@ -161,6 +164,11 @@ export function buildCloudWorkerUpsertPatch(
     ttl: draft.ttl.trim(),
     idleTimeout: draft.idleTimeout.trim(),
     setup: draft.setup.trim() || null,
+    ...(draft.setup.trim() ||
+    !Array.isArray(existingSettings.setupEnv) ||
+    existingSettings.setupEnv.length === 0
+      ? {}
+      : { setupEnv: null }),
     desktop: draft.desktop ? true : null,
     binary: draft.binary.trim() || null,
   };

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -163,6 +163,10 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     if (!this.canManage()) {
       return;
     }
+    if (profile.providerId !== "crabbox") {
+      this.context.navigate("advanced", { search: "?section=cloudWorkers" });
+      return;
+    }
     this.editor = { kind: "edit", profileId: profile.id };
     this.draft = createCloudWorkerDraft(profile);
     this.formError = null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users editing cloud worker profiles could corrupt a non-Crabbox provider's configuration, save a stale Crabbox form after the profile changed providers, or leave an unusable Crabbox profile after removing its setup command.

## Why This Change Was Made

The curated cloud-worker settings page treated every worker provider as Crabbox, and its patch builder did not recheck authoritative provider ownership after `config.changed`. Clearing setup also preserved dependent `setupEnv` values, producing a profile the Crabbox provider rejects with `Crabbox profile setupEnv requires setup`.

The repair keeps provider selection at the existing settings/navigation boundary and validates the authoritative provider again in the canonical patch owner. It conditionally tombstones only a nonempty setup environment list when its setup command is removed; no provider fallback, timeout expansion, additional config surface, or new editor is introduced.

## User Impact

Operators can edit third-party cloud profiles safely through the existing Advanced configuration editor, see a clear warning instead of corrupting a profile that changed providers, and remove Crabbox setup commands without leaving behind invalid forwarded-environment settings. Existing provider deletion and project-default cleanup continue working, and the Settings copy accurately describes mixed-provider configurations.

## Evidence

Before: a profile replaced with `static-ssh` still exposes the stale Crabbox editor.

![Before: a replaced third-party profile remains underneath a stale Crabbox-only editor](https://github.com/user-attachments/assets/2414c06e-92c7-4ef4-8ea5-7e15dcd957ba)

After: the stale edit fails visibly without a configuration write.

![After: stale provider replacement is rejected with a visible warning and no config write](https://github.com/user-attachments/assets/d5d99c15-402f-4ca0-9f91-8215e1efa3c0)

After: editing the third-party profile opens the existing provider-owned Advanced configuration section.

![After: third-party profiles open the existing Advanced cloud worker configuration editor](https://github.com/user-attachments/assets/41dadf03-3980-4ea9-a05a-01e051ac1ba3)

All screenshots use synthetic mocked Gateway data only.

- Captured fail-first owner regressions: clearing setup left a nonempty `setupEnv`, and replacing a profile provider produced a corrupt third-party patch.
- Captured fail-first real Chromium flow: a stale Crabbox edit after `config.changed` failed to display the required rejection.
- `node scripts/run-vitest.mjs ui/src/pages/cloud-workers/cloud-worker-config.test.ts` — 16 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/cloud-workers-settings.e2e.test.ts` — seven real Chromium scenarios passed, including visible fail-closed state, zero unsafe writes, the fully rendered Advanced editor, and generic profile deletion.
- `pnpm ui:i18n:verify` — passed without generated locale changes.
- `pnpm check:changed -- ui/src/pages/cloud-workers/cloud-worker-config.ts ui/src/pages/cloud-workers/cloud-worker-config.test.ts ui/src/pages/cloud-workers/cloud-workers-page.ts ui/src/e2e/cloud-workers-settings.e2e.test.ts ui/src/i18n/locales/en.ts` — passed all formatting, i18n, type-checking, lint, and full unused-export checks.
- Fresh structured Codex autoreview returned no actionable findings.
