### PR TITLE
fix(voice-call): preserve call capacity after storage failure

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -870,6 +870,13 @@ digits.
 
 ## Troubleshooting
 
+### Call placement fails to save its initial record
+
+Voice Call saves the initial record before reserving a concurrency slot or
+contacting the carrier. If that write fails, the placement reports the storage
+error without dialing. Restore access to the state directory, then retry; the
+failed placement does not consume `maxConcurrentCalls` capacity.
+
 ### Setup fails webhook exposure
 
 Run setup from the same environment that runs the Gateway:

--- a/extensions/voice-call/src/manager/outbound.persistence.test.ts
+++ b/extensions/voice-call/src/manager/outbound.persistence.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createEventManagerHarness } from "../manager.test-harness.js";
+import type { InitiateCallResult } from "../types.js";
+import { initiateCall } from "./outbound.js";
+import { loadActiveCallsFromStore } from "./store.js";
+
+const { cleanup, createContext, createProvider, setup } = createEventManagerHarness();
+beforeEach(setup);
+afterEach(cleanup);
+
+it("keeps outbound capacity available after storage failure without dialing", async () => {
+  const placement = createDeferred<InitiateCallResult>();
+  const dial = vi.fn(() => placement.promise);
+  const ctx = createContext({
+    provider: createProvider({ initiateCall: dial }),
+    webhookUrl: "https://example.com/voice/webhook",
+  });
+  ctx.config.maxConcurrentCalls = 1;
+  const statePath = path.join(ctx.storePath, "state");
+  fs.writeFileSync(statePath, "block the database directory");
+
+  await expect(initiateCall(ctx, "+15550000001")).rejects.toMatchObject({
+    code: "PLUGIN_STATE_OPEN_FAILED",
+  });
+  expect(dial).not.toHaveBeenCalled();
+  expect(ctx.activeCalls.size).toBe(0);
+  expect(ctx.providerCallIdMap.size).toBe(0);
+
+  fs.unlinkSync(statePath);
+  const recovered = initiateCall(ctx, "+15550000001");
+  try {
+    await expect(initiateCall(ctx, "+15550000002")).resolves.toMatchObject({
+      success: false,
+      error: "Maximum concurrent calls (1) reached",
+    });
+    expect(dial).toHaveBeenCalledOnce();
+  } finally {
+    placement.resolve({ providerCallId: "provider-recovered", status: "initiated" });
+    await recovered;
+  }
+  const result = await recovered;
+  expect(result.success).toBe(true);
+  expect(ctx.activeCalls.size).toBe(1);
+  expect(ctx.providerCallIdMap.get("provider-recovered")).toBe(result.callId);
+  expect(loadActiveCallsFromStore(ctx.storePath).activeCalls.get(result.callId)).toMatchObject({
+    providerCallId: "provider-recovered",
+    state: "initiated",
+  });
+});

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -1,4 +1,3 @@
-// Voice Call plugin module implements outbound behavior.
 import crypto from "node:crypto";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
@@ -210,8 +209,9 @@ export async function initiateCall(
     },
   };
 
-  ctx.activeCalls.set(callId, callRecord);
+  // Persist before reserving capacity so storage failures cannot strand undialed calls.
   persistCallRecord(ctx.storePath, callRecord);
+  ctx.activeCalls.set(callId, callRecord);
 
   try {
     // For notify mode with a message, use inline TwiML with <Say>.


### PR DESCRIPTION
Closes #129473.

## What Problem This Solves

Fixes an issue where a transient storage failure during outbound Voice Call placement permanently consumed a concurrency slot. With the default limit of one, every later call failed until the Gateway restarted, even though the carrier had never been contacted.

## Why This Change Was Made

Save the initial record before publishing it to the active-call registry, matching inbound call admission. These operations remain synchronous before carrier I/O, so overlapping placements still respect capacity. The existing command/Gateway error adapters report storage failure; no catch-and-continue path, retry, reaper workaround, configuration, or database change is added.

This maintainer rewrite preserves the original author's credit and addresses both review findings: it prevents dialing after a failed initial save and replaces the rejected-Promise mock with a real filesystem obstruction at the SQLite-backed persistence boundary. Later post-dial/terminal persistence failures are outside this initial-admission repair.

## User Impact

A failed initial save returns a storage error without dialing or consuming call capacity. Once storage access is restored, the next placement succeeds without restarting. Existing calls and provider behavior are unchanged.

## Evidence

- Before the fix, the new regression reached `PLUGIN_STATE_OPEN_FAILED`, made zero carrier requests, and failed because active-call count was **1**, not **0**.
- After the fix, **72 tests across 6 files passed**, covering real persistence failure/recovery, overlapping placement at `maxConcurrentCalls: 1`, persisted provider identity, inbound admission, event commit/rollback, restoration, and termination.
- Separate command-service proof used the real `CallManager` and SQLite store with the shipped local mock carrier: storage error visible; zero dials and zero active calls during failure; recovery initiated one call; ending it returned active count to zero. This is local runtime proof, not an authenticated PSTN call. No carrier API contract changes in this patch.
- Targeted formatting and `git diff --check` passed. Fresh independent Codex review through P2 found no actionable findings.
- Local extension lint could not reach its changed-file checks because shared dependency declarations lack `Logger.attachTransport`/`Logger.settings` in unrelated `src/logging/logger.ts`. Clean exact-head CI is required before landing; no dependency override was made.
- Production **+2/-2 (net 0)**; regression **+52**; docs **+7**. The new lifecycle comment replaces a redundant file-header comment.

Focused command:

```sh
node scripts/run-vitest.mjs extensions/voice-call/src/manager/outbound.persistence.test.ts extensions/voice-call/src/manager/outbound.test.ts extensions/voice-call/src/manager/events.inbound.test.ts extensions/voice-call/src/manager/events.test.ts extensions/voice-call/src/manager.restore.test.ts extensions/voice-call/src/manager.lifecycle.test.ts
```

All prior rank-up requests are addressed by persistence-before-publication, synchronous fault proof, visible failure before carrier I/O, and the redacted local runtime result above. AI-assisted maintainer repair; source, tests, caller error handling, inbound/terminal siblings, and stable-tag behavior were reviewed.

### Captured runtime proof at the final head

Executed at `9d018c82f869a059cf353ffb7a0fd922510d282a`, outside Vitest. The filesystem obstruction reached the real plugin-state store and reported `PLUGIN_STATE_OPEN_FAILED` (underlying `EEXIST`). The script asserts zero dial requests and empty active status before removing the obstruction. Captured output after recovery and termination:

```text
[voice-call] Outbound call initiated: callId=792fd05c-c0e1-449f-9a93-a38043a6157e providerCallId=mock-792fd05c-c0e1-449f-9a93-a38043a6157e mode=notify preConnectDtmf=no initialMessage=no
[voice-call/lifecycle] [voice-call] Call finalized callId=792fd05c-c0e1-449f-9a93-a38043a6157e providerCallId=mock-792fd05c-c0e1-449f-9a93-a38043a6157e endReason=hangup-bot
```

```json
{
  "proof": "real command service, CallManager and SQLite store; shipped mock carrier",
  "storageError": "PLUGIN_STATE_OPEN_FAILED",
  "dialsDuringFailure": 0,
  "activeDuringFailure": 0,
  "recoveryInitiated": true,
  "totalDials": 1,
  "activeAfterEnd": 0
}
```

<details>
<summary>Reproduction script (temporary state only; shipped mock carrier, no network calls)</summary>

Run from the repository root with `node --import ./scripts/tsx.mjs /tmp/voice-reservation-live.mts`:

```ts
import assert from 'node:assert/strict';
import fs from 'node:fs';
import os from 'node:os';
import path from 'node:path';
import { pathToFileURL } from 'node:url';
const root = process.cwd();
const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'voice-reservation-proof-'));
process.env.OPENCLAW_STATE_DIR = scratch;
const from = (p: string) => import(pathToFileURL(path.join(root, p)).href);
const { VoiceCallConfigSchema } = await from('extensions/voice-call/src/config.ts');
const { CallManager } = await from('extensions/voice-call/src/manager.ts');
const { MockProvider } = await from('extensions/voice-call/src/providers/mock.ts');
const { createVoiceCallCommandService } = await from('extensions/voice-call/src/command-service.ts');
const { setVoiceCallStateRuntime } = await from('extensions/voice-call/src/runtime-state.ts');
const { createPluginStateSyncKeyedStore, resetPluginStateStoreForTests } = await from('src/plugin-state/plugin-state-store.ts');
setVoiceCallStateRuntime({ state: { openSyncKeyedStore: (options: unknown) => createPluginStateSyncKeyedStore('voice-call', options) } });
const config = VoiceCallConfigSchema.parse({enabled:true, provider:'mock', maxConcurrentCalls:1});
const manager = new CallManager(config, scratch);
const provider = new MockProvider();
let dials = 0;
const initiate = provider.initiateCall.bind(provider);
provider.initiateCall = (input: unknown) => { dials++; return initiate(input); };
await manager.initialize(provider, 'http://127.0.0.1/voice/webhook');
resetPluginStateStoreForTests();
const statePath = path.join(scratch, 'state');
fs.rmSync(statePath, {recursive:true,force:true});
fs.writeFileSync(statePath, 'intentional test-only storage obstruction');
const commands = createVoiceCallCommandService(async () => ({manager,config}));
try {
  await assert.rejects(commands.initiate({to:'+15550000001'}), {code:'PLUGIN_STATE_OPEN_FAILED'});
  assert.equal(dials,0);
  assert.deepEqual((await commands.status()).calls,[]);
  fs.unlinkSync(statePath);
  const result = await commands.initiate({to:'+15550000001'});
  assert.equal(result.initiated,true);
  assert.equal(dials,1);
  assert.equal((await commands.status()).calls.length,1);
  await commands.endCall(result.callId);
  assert.deepEqual((await commands.status()).calls,[]);
  console.log(JSON.stringify({proof:'real command service, CallManager and SQLite store; shipped mock carrier',storageError:'PLUGIN_STATE_OPEN_FAILED',dialsDuringFailure:0,activeDuringFailure:0,recoveryInitiated:true,totalDials:dials,activeAfterEnd:0}));
} finally {
  resetPluginStateStoreForTests();
  fs.rmSync(scratch,{recursive:true,force:true});
}
```

</details>

Current-main redundancy rechecked directly: at `b73faf7328488a8c31a8cce39dc705376605e492`, outbound admission still publishes `activeCalls` before `persistCallRecord`; this repair is not superseded. [Immutable main source](https://github.com/openclaw/openclaw/blob/b73faf7328488a8c31a8cce39dc705376605e492/extensions/voice-call/src/manager/outbound.ts#L213). This resolves the latest review's unavailable-main-blob evidence gap.
