### PR TITLE
chore(telegram): remove duplicate unchanged reaction case

### DIFF
--- a/extensions/telegram/src/send-mutation-targets.test.ts
+++ b/extensions/telegram/src/send-mutation-targets.test.ts
@@ -98,7 +98,6 @@ describe("Telegram reaction presentation", () => {
     ["☃️", "☃"],
     ["❤️‍🔥", "❤‍🔥"],
     ["🤷‍♂️", "🤷‍♂"],
-    ["✅", "✅"],
     ["👍🏻", "👍🏻"],
   ])("sends %s using its Telegram wire representation %s", async (input, expected) => {
     botApi.setMessageReaction.mockResolvedValue(true);


### PR DESCRIPTION
## What Problem This Solves

Removes one duplicate unchanged-reaction row from the Telegram reaction-presentation matrix. The `✅` case repeated the exact plain-chat wire pass-through already covered in `send.test.ts`, adding maintenance and CI work without detecting another regression.

## Why This Change Was Made

The canonical `send.test.ts` case still asserts that `✅` reaches `setMessageReaction` unchanged. The presentation matrix retains `👍🏻` to protect the unchanged presentation/pass-through category, while its other rows continue to cover variation-selector normalization. Topic-qualified mutation coverage also continues to exercise `✅` through the same public send path.

No production code or Telegram behavior changes.

## User Impact

No user-visible impact. Maintainers retain plain-chat, topic-target, unchanged-presentation, normalization, custom-emoji, and removal coverage with one fewer duplicate test row.

## Evidence

- Baseline before deletion: `send.test.ts` + `send-mutation-targets.test.ts` — 279/279 passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/send-mutation-targets.test.ts extensions/telegram/src/send.test.ts` — 278/278 remaining tests passed.
- `node scripts/check-changed.mjs -- extensions/telegram/src/send-mutation-targets.test.ts` — passed, including extension test types and targeted oxlint.
- Targeted oxfmt and oxlint — passed.
- Fresh autoreview against `origin/main` — no accepted/actionable findings; patch correct 0.99.
- `git diff --check origin/main...HEAD` — passed.

Production LOC: `+0/-0`

Tests: `+0/-1`

AI-assisted test audit. No changelog entry: test-only duplicate deletion with no behavior change.
