### PR TITLE
refactor(gateway): speed up GitHub publication security tests

### DIFF
--- a/src/gateway/github-publication-coordinator-methods.ts
+++ b/src/gateway/github-publication-coordinator-methods.ts
@@ -12,10 +12,8 @@ import {
   prepareCurrentGitHubPublicationIdentity,
   resolveGitHubPublicationWorktreeOwner,
 } from "./github-publication-availability.js";
-import {
-  captureGitHubPublicationWorkspaceSnapshot,
-  matchesGitHubPublicationIdentityRow,
-} from "./github-publication-executor.js";
+import { matchesGitHubPublicationIdentityRow } from "./github-publication-executor.js";
+import { captureGitHubPublicationWorkspaceSnapshot } from "./github-publication-git-transport.js";
 import {
   deferGitHubPublicationRequests as deferRequests,
   digestGitHubPublicationRequest as digestRequest,

--- a/src/gateway/github-publication-executor.ts
+++ b/src/gateway/github-publication-executor.ts
@@ -1,6 +1,4 @@
-import fs from "node:fs/promises";
 import os from "node:os";
-import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import type { SessionGitHubPublicationResult } from "../../packages/gateway-protocol/src/schema/session-github-publication.js";
@@ -8,7 +6,6 @@ import { resolveGitCoauthorAttribution } from "../agents/git-coauthor-attributio
 import type { PreparedGitHubPublicationIdentity } from "../agents/github-tool-identity.js";
 import { managedWorktrees } from "../agents/worktrees/service.js";
 import { resolveControlUiSessionUrl } from "../config/control-ui-link-base.js";
-import { runCommandBuffered } from "../process/exec.js";
 import type { DB as StateDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   currentGitHubPublicationConfig,
@@ -32,12 +29,14 @@ import {
 } from "./github-publication-git-index.js";
 import {
   appendGitHubPublicationMessage,
-  assertGitHubPublicationTreeHasNoFilters,
   assertSafeGitPublicationWorkspace,
   assertGitHubPublicationBranchRef,
+  captureGitHubPublicationWorkspaceSnapshot,
   githubPublicationPushArgs,
   githubPublicationRemoteHeadArgs,
   githubPublicationUpdateRefArgs,
+  requirePublicationCommand as requireCommand,
+  runPublicationCommand as runCommand,
 } from "./github-publication-git-transport.js";
 import {
   githubPublicationCreatePullRequestArgs,
@@ -68,37 +67,6 @@ export function matchesGitHubPublicationIdentityRow(
   );
 }
 
-async function runCommand(
-  argv: string[],
-  options: { cwd?: string; env?: NodeJS.ProcessEnv; input?: string } = {},
-) {
-  return await runCommandBuffered(argv, {
-    ...(options.cwd ? { cwd: options.cwd } : {}),
-    env: {
-      ...(options.env ?? process.env),
-      GIT_NO_REPLACE_OBJECTS: "1",
-      // Pin every command against repository hooks; explicit hook-disabling -c flags stay stronger.
-      GIT_CONFIG_COUNT: "1",
-      GIT_CONFIG_KEY_0: "core.hooksPath",
-      GIT_CONFIG_VALUE_0: os.devNull,
-    },
-    ...(options.input !== undefined ? { input: options.input } : {}),
-    timeoutMs: 60_000,
-    maxOutputBytes: 256 * 1024,
-  });
-}
-
-async function requireCommand(
-  argv: string[],
-  options: { cwd?: string; env?: NodeJS.ProcessEnv; input?: string } = {},
-): Promise<string> {
-  const result = await runCommand(argv, options);
-  if (result.code !== 0) {
-    throw new Error(`${argv[0]} command failed`);
-  }
-  return result.stdout.toString("utf8").trim();
-}
-
 function parseJsonObject(value: string, label: string): Record<string, unknown> {
   let parsed: unknown;
   try {
@@ -110,85 +78,6 @@ function parseJsonObject(value: string, label: string): Record<string, unknown> 
     throw new Error(`${label} returned an invalid response`);
   }
   return parsed;
-}
-
-export async function captureGitHubPublicationWorkspaceSnapshot(params: {
-  cwd: string;
-  assertCurrent?: () => void;
-}): Promise<{ sourceHeadCommit: string; sourceIndexTree: string; workspaceTree: string }> {
-  const step = async <T>(operation: () => Promise<T>): Promise<T> => {
-    params.assertCurrent?.();
-    const result = await operation();
-    params.assertCurrent?.();
-    return result;
-  };
-  await step(async () => await assertSafeGitPublicationWorkspace(params.cwd, runCommand));
-  const sourceHeadCommit = await step(
-    async () =>
-      await requireCommand(["git", "rev-parse", "--verify", "HEAD^{commit}"], {
-        cwd: params.cwd,
-      }),
-  );
-  const sourceIndexTree = await step(
-    async () =>
-      await requireCommand(
-        ["git", "-c", `core.hooksPath=${os.devNull}`, "-c", "core.fsmonitor=false", "write-tree"],
-        { cwd: params.cwd },
-      ),
-  );
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-github-snapshot-"));
-  try {
-    const env: NodeJS.ProcessEnv = {
-      GIT_ATTR_NOSYSTEM: "1",
-      GIT_CONFIG_GLOBAL: os.devNull,
-      GIT_CONFIG_SYSTEM: os.devNull,
-      GIT_INDEX_FILE: path.join(tempDir, "index"),
-    };
-    await step(async () => {
-      await requireCommand(
-        [
-          "git",
-          "-c",
-          `core.hooksPath=${os.devNull}`,
-          "-c",
-          "core.fsmonitor=false",
-          "read-tree",
-          sourceHeadCommit,
-        ],
-        { cwd: params.cwd, env },
-      );
-    });
-    await step(async () => {
-      await requireCommand(
-        [
-          "git",
-          "-c",
-          `core.attributesFile=${os.devNull}`,
-          "-c",
-          `core.hooksPath=${os.devNull}`,
-          "-c",
-          "core.fsmonitor=false",
-          "add",
-          "-A",
-        ],
-        { cwd: params.cwd, env },
-      );
-    });
-    const workspaceTree = await step(
-      async () =>
-        await requireCommand(
-          ["git", "-c", `core.hooksPath=${os.devNull}`, "-c", "core.fsmonitor=false", "write-tree"],
-          { cwd: params.cwd, env },
-        ),
-    );
-    await step(
-      async () =>
-        await assertGitHubPublicationTreeHasNoFilters(params.cwd, workspaceTree, runCommand),
-    );
-    return { sourceHeadCommit, sourceIndexTree, workspaceTree };
-  } finally {
-    await fs.rm(tempDir, { recursive: true, force: true });
-  }
 }
 
 export async function executeGitHubPublication(params: {

--- a/src/gateway/github-publication-git-index.test.ts
+++ b/src/gateway/github-publication-git-index.test.ts
@@ -13,8 +13,8 @@ import {
   updateGitHubPublicationBranchAndIndex,
 } from "./github-publication-git-index.js";
 import {
-  assertGitHubPublicationTreeHasNoFilters,
   assertSafeGitPublicationWorkspace,
+  captureGitHubPublicationWorkspaceSnapshot,
   githubPublicationPushArgs,
   githubPublicationUpdateRefArgs,
 } from "./github-publication-git-transport.js";
@@ -24,7 +24,10 @@ let directoryIndex = 0;
 const REQUEST_ID = "11111111-1111-4111-8111-111111111111";
 
 beforeEach(async () => {
-  testState = await createOpenClawTestState({ prefix: "openclaw-publication-index-" });
+  testState = await createOpenClawTestState({
+    prefix: "openclaw-publication-index-",
+    env: { XDG_CONFIG_HOME: undefined },
+  });
   directoryIndex = 0;
 });
 
@@ -204,28 +207,14 @@ describe("GitHub publication index update", () => {
   });
 
   it("rejects a filter from Git's default global attributes file", async () => {
-    const cwd = await makeDirectory("attributes");
-    const globalAttributes = path.join(cwd, "global-attributes");
+    const { cwd } = await createFixture();
+    const globalAttributes = path.join(testState.home, ".config", "git", "attributes");
+    await fs.mkdir(path.dirname(globalAttributes), { recursive: true });
     await fs.writeFile(globalAttributes, "*.secret filter=redact\n");
 
-    await expect(
-      assertGitHubPublicationTreeHasNoFilters(cwd, "a".repeat(40), async (argv) => {
-        const command = argv.join(" ");
-        if (command === "git var GIT_ATTR_GLOBAL") {
-          return { code: 0, stdout: Buffer.from(globalAttributes) };
-        }
-        if (command === "git var GIT_ATTR_SYSTEM") {
-          return { code: 0, stdout: Buffer.from(path.join(cwd, "missing-system-attributes")) };
-        }
-        if (argv.includes("ls-tree")) {
-          return { code: 0, stdout: Buffer.alloc(0) };
-        }
-        if (command === "git rev-parse --git-path info/attributes") {
-          return { code: 0, stdout: Buffer.from(path.join(cwd, "missing-info-attributes")) };
-        }
-        throw new Error(`unexpected command: ${command}`);
-      }),
-    ).rejects.toThrow("unsupported Git clean filter");
+    await expect(captureGitHubPublicationWorkspaceSnapshot({ cwd })).rejects.toThrow(
+      "unsupported Git clean filter",
+    );
   });
 
   it("moves the branch and index together without changing accepted worktree content", async () => {

--- a/src/gateway/github-publication-git-transport.ts
+++ b/src/gateway/github-publication-git-transport.ts
@@ -1,10 +1,39 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { runCommandBuffered } from "../process/exec.js";
 import { githubPublicationUnsafeConfigArgs } from "./github-publication-base.js";
 
 type GitCommandOptions = { cwd?: string; env?: NodeJS.ProcessEnv; input?: string };
 type GitCommandResult = { code: number | null; stdout: Buffer };
+
+export async function runPublicationCommand(argv: string[], options: GitCommandOptions = {}) {
+  return await runCommandBuffered(argv, {
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+    env: {
+      ...(options.env ?? process.env),
+      GIT_NO_REPLACE_OBJECTS: "1",
+      // Pin every command against repository hooks; explicit hook-disabling -c flags stay stronger.
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "core.hooksPath",
+      GIT_CONFIG_VALUE_0: os.devNull,
+    },
+    ...(options.input !== undefined ? { input: options.input } : {}),
+    timeoutMs: 60_000,
+    maxOutputBytes: 256 * 1024,
+  });
+}
+
+export async function requirePublicationCommand(
+  argv: string[],
+  options: GitCommandOptions = {},
+): Promise<string> {
+  const result = await runPublicationCommand(argv, options);
+  if (result.code !== 0) {
+    throw new Error(`${argv[0]} command failed`);
+  }
+  return result.stdout.toString("utf8").trim();
+}
 
 export async function assertSafeGitPublicationWorkspace(
   cwd: string,
@@ -76,7 +105,7 @@ async function readOptionalAttributeFile(file: string): Promise<Buffer | undefin
   }
 }
 
-export async function assertGitHubPublicationTreeHasNoFilters(
+async function assertGitHubPublicationTreeHasNoFilters(
   cwd: string,
   workspaceTree: string,
   run: (argv: string[], options?: GitCommandOptions) => Promise<GitCommandResult>,
@@ -136,6 +165,84 @@ export async function assertGitHubPublicationTreeHasNoFilters(
     if (contents) {
       assertNoGitFilterAttributes(contents);
     }
+  }
+}
+
+export async function captureGitHubPublicationWorkspaceSnapshot(params: {
+  cwd: string;
+  assertCurrent?: () => void;
+}): Promise<{ sourceHeadCommit: string; sourceIndexTree: string; workspaceTree: string }> {
+  const step = async <T>(operation: () => Promise<T>): Promise<T> => {
+    params.assertCurrent?.();
+    const result = await operation();
+    params.assertCurrent?.();
+    return result;
+  };
+  await step(() => assertSafeGitPublicationWorkspace(params.cwd, runPublicationCommand));
+  const sourceHeadCommit = await step(
+    async () =>
+      await requirePublicationCommand(["git", "rev-parse", "--verify", "HEAD^{commit}"], {
+        cwd: params.cwd,
+      }),
+  );
+  const sourceIndexTree = await step(
+    async () =>
+      await requirePublicationCommand(
+        ["git", "-c", `core.hooksPath=${os.devNull}`, "-c", "core.fsmonitor=false", "write-tree"],
+        { cwd: params.cwd },
+      ),
+  );
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-github-snapshot-"));
+  try {
+    const env: NodeJS.ProcessEnv = {
+      GIT_ATTR_NOSYSTEM: "1",
+      GIT_CONFIG_GLOBAL: os.devNull,
+      GIT_CONFIG_SYSTEM: os.devNull,
+      GIT_INDEX_FILE: path.join(tempDir, "index"),
+    };
+    await step(async () => {
+      await requirePublicationCommand(
+        [
+          "git",
+          "-c",
+          `core.hooksPath=${os.devNull}`,
+          "-c",
+          "core.fsmonitor=false",
+          "read-tree",
+          sourceHeadCommit,
+        ],
+        { cwd: params.cwd, env },
+      );
+    });
+    await step(async () => {
+      await requirePublicationCommand(
+        [
+          "git",
+          "-c",
+          `core.attributesFile=${os.devNull}`,
+          "-c",
+          `core.hooksPath=${os.devNull}`,
+          "-c",
+          "core.fsmonitor=false",
+          "add",
+          "-A",
+        ],
+        { cwd: params.cwd, env },
+      );
+    });
+    const workspaceTree = await step(
+      async () =>
+        await requirePublicationCommand(
+          ["git", "-c", `core.hooksPath=${os.devNull}`, "-c", "core.fsmonitor=false", "write-tree"],
+          { cwd: params.cwd, env },
+        ),
+    );
+    await step(() =>
+      assertGitHubPublicationTreeHasNoFilters(params.cwd, workspaceTree, runPublicationCommand),
+    );
+    return { sourceHeadCommit, sourceIndexTree, workspaceTree };
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
   }
 }
 

--- a/src/gateway/github-publication-hooks.test.ts
+++ b/src/gateway/github-publication-hooks.test.ts
@@ -3,8 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runCommandBuffered } from "../process/exec.js";
-import { captureGitHubPublicationWorkspaceSnapshot } from "./github-publication-executor.js";
-import { assertSafeGitPublicationWorkspace } from "./github-publication-git-transport.js";
+import {
+  assertSafeGitPublicationWorkspace,
+  captureGitHubPublicationWorkspaceSnapshot,
+} from "./github-publication-git-transport.js";
 
 let root: string;
 
@@ -48,7 +50,7 @@ describe("GitHub publication Git hooks", () => {
     const hooks = path.join(root, "git-hooks");
     const sentinel = path.join(root, ".hook-ran");
     await fs.mkdir(hooks);
-    for (const hook of ["reference-transaction", "pre-push"]) {
+    for (const hook of ["reference-transaction", "pre-push", "post-index-change"]) {
       await fs.writeFile(path.join(hooks, hook), `#!/bin/sh\nprintf hook > '${sentinel}'\n`, {
         mode: 0o755,
       });

--- a/src/gateway/github-publication.ts
+++ b/src/gateway/github-publication.ts
@@ -11,10 +11,10 @@ import {
 } from "./github-publication-availability.js";
 import { createGitHubPublicationCoordinatorMethods } from "./github-publication-coordinator-methods.js";
 import {
-  captureGitHubPublicationWorkspaceSnapshot,
   executeGitHubPublication,
   matchesGitHubPublicationIdentityRow,
 } from "./github-publication-executor.js";
+import { captureGitHubPublicationWorkspaceSnapshot } from "./github-publication-git-transport.js";
 import {
   claimGitHubPublicationExecution as claimExecution,
   deferGitHubPublicationRequests as deferRequests,


### PR DESCRIPTION
## What Problem This Solves

The Gateway's newly added GitHub-publication security regression suite loaded the entire publication executor, session persistence graph, and attribution machinery just to capture an isolated Git workspace snapshot. That made three real-Git security cases significantly slower and more memory-intensive than their actual work required.

## Why This Change Was Made

Move hardened publication command execution and workspace snapshot capture into the existing Git transport owner, and have the executor and both coordinators consume that canonical owner directly. Preserve claim revalidation, hook suppression, replacement/filter rejection, isolated indexes, and cleanup; watch `post-index-change`, the hook snapshotting can actually invoke, and prove global-attribute rejection through a real Git snapshot instead of a mocked private helper.

## User Impact

No user-visible behavior changes. Maintainers get faster, lower-memory Gateway security tests with stronger protection against accidentally running repository-authored Git hooks.

## Evidence

- One owned Blacksmith Testbox, excluded warmup, eight baseline and eight final one-worker samples, distinct filesystem-module-cache paths, import diagnostics, and `/usr/bin/time -v`.
- Median scoped wall time: **9.445s -> 4.280s (-5.165s, -54.7%)**.
- Median Vitest imports: **5.115s -> 0.100s (-98.1%)**; median peak RSS: **1,041,632 KiB -> 595,796 KiB (-42.8%)**.
- Six GitHub-publication owner/sibling suites: **74/74 passing**, covering real hooks, replacement metadata, Git index recovery, claim/session authority, deferred publication, attribution, and durable transcript reporting.
- Reversible fault proof: deliberately point the snapshot's `read-tree` at repository hooks; the new `post-index-change` sentinel runs and the security test fails, then passes after restoring hook suppression.
- Production LOC **-6**; test LOC **-9**. Fresh independent autoreview reported no actionable findings.
- Full `pnpm check:changed --base b5fcae34fe13fb46ab79c0f405a34dd080c03c20`: passed on Blacksmith, including production/core-test typechecks, all dead-export scans, lint, import cycles, and security guards.
