### PR TITLE
fix(state): canonically bootstrap fresh state before startup-checkpoint tables

### DIFF
--- a/src/infra/startup-migration-checkpoint.test.ts
+++ b/src/infra/startup-migration-checkpoint.test.ts
@@ -86,6 +86,134 @@ describe("startup migration checkpoint", () => {
     expect(existsSync(dbPath)).toBe(false);
   });
 
+  it("initializes the canonical schema before creating the first startup checkpoint", () => {
+    const env = {
+      OPENCLAW_STATE_DIR: startupMigrationTempDirs.make("openclaw-startup-migration-fresh-"),
+    };
+
+    expect(readStartupMigrationVersion(env)).toBeNull();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(resolveOpenClawStateSqlitePath(env), { readOnly: true });
+    try {
+      expect(database.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+      });
+      expect(
+        database
+          .prepare("SELECT role, schema_version FROM schema_meta WHERE meta_key = 'primary'")
+          .get(),
+      ).toEqual({ role: "global", schema_version: OPENCLAW_STATE_SCHEMA_VERSION });
+      expect(
+        database
+          .prepare("SELECT 1 AS present FROM sqlite_schema WHERE name = 'plugin_state_entries'")
+          .get(),
+      ).toEqual({ present: 1 });
+    } finally {
+      database.close();
+    }
+  });
+
+  it.each([false, true])(
+    "adopts native version-zero state before checkpoint access (existing checkpoint: %s)",
+    (hasExistingCheckpoint) => {
+      const env = {
+        OPENCLAW_STATE_DIR: startupMigrationTempDirs.make("openclaw-startup-migration-native-"),
+      };
+      const databasePath = resolveOpenClawStateSqlitePath(env);
+      mkdirSync(path.dirname(databasePath), { recursive: true });
+      const { DatabaseSync } = requireNodeSqlite();
+      const native = new DatabaseSync(databasePath);
+      native.exec(`
+        CREATE TABLE device_identities (
+          identity_key TEXT NOT NULL PRIMARY KEY,
+          device_id TEXT NOT NULL,
+          public_key_pem TEXT NOT NULL,
+          private_key_pem TEXT NOT NULL,
+          created_at_ms INTEGER NOT NULL,
+          updated_at_ms INTEGER NOT NULL
+        ) STRICT;
+        CREATE INDEX idx_device_identities_device
+          ON device_identities(device_id, updated_at_ms DESC);
+        INSERT INTO device_identities VALUES ('node', 'native-device', 'public', 'private', 1, 1);
+        CREATE TABLE exec_approvals_config (
+          config_key TEXT NOT NULL PRIMARY KEY,
+          raw_json TEXT NOT NULL,
+          socket_path TEXT,
+          has_socket_token INTEGER NOT NULL,
+          default_security TEXT,
+          default_ask TEXT,
+          default_ask_fallback TEXT,
+          auto_allow_skills INTEGER,
+          agent_count INTEGER NOT NULL,
+          allowlist_count INTEGER NOT NULL,
+          updated_at_ms INTEGER NOT NULL
+        ) STRICT;
+        INSERT INTO exec_approvals_config
+          VALUES ('current', '{}', NULL, 0, NULL, NULL, NULL, NULL, 0, 0, 1);
+      `);
+      if (hasExistingCheckpoint) {
+        native.exec(`
+          CREATE TABLE schema_meta (
+            meta_key TEXT NOT NULL PRIMARY KEY,
+            role TEXT NOT NULL,
+            schema_version INTEGER NOT NULL,
+            agent_id TEXT,
+            app_version TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+          );
+          CREATE TABLE state_leases (
+            scope TEXT NOT NULL,
+            lease_key TEXT NOT NULL,
+            owner TEXT NOT NULL,
+            expires_at INTEGER,
+            heartbeat_at INTEGER,
+            payload_json TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            PRIMARY KEY (scope, lease_key)
+          );
+          CREATE INDEX idx_state_leases_expiry
+            ON state_leases(expires_at, scope, lease_key)
+            WHERE expires_at IS NOT NULL;
+          CREATE INDEX idx_state_leases_owner
+            ON state_leases(owner, updated_at DESC);
+        `);
+      }
+      native.close();
+
+      const lease = acquireStartupMigrationLease({ env, owner: "native-bootstrap" });
+      try {
+        const initialized = new DatabaseSync(databasePath, { readOnly: true });
+        try {
+          expect(initialized.prepare("PRAGMA user_version").get()).toEqual({
+            user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+          });
+          expect(
+            initialized
+              .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
+              .get(),
+          ).toEqual({ schema_version: OPENCLAW_STATE_SCHEMA_VERSION });
+          expect(
+            initialized
+              .prepare("SELECT device_id FROM device_identities WHERE identity_key = 'node'")
+              .get(),
+          ).toEqual({ device_id: "native-device" });
+          expect(
+            initialized
+              .prepare("SELECT config_key FROM exec_approvals_config WHERE config_key = 'current'")
+              .get(),
+          ).toEqual({ config_key: "current" });
+        } finally {
+          initialized.close();
+        }
+      } finally {
+        lease.release();
+      }
+    },
+  );
+
   it("records the migrated OpenClaw version in shared state", () => {
     const env = {
       OPENCLAW_STATE_DIR: startupMigrationTempDirs.make("openclaw-startup-migration-"),
@@ -560,6 +688,9 @@ describe("startup migration checkpoint", () => {
 
     expect(needsStartupMigrationCheckpoint({ env, version: "2026.7.1" })).toBe(true);
     const lease = acquireStartupMigrationLease({ env, nowMs: 1000, owner: "first" });
+    const leased = new sqlite.DatabaseSync(dbPath, { readOnly: true });
+    expect(leased.prepare("PRAGMA user_version").get()).toEqual({ user_version: 0 });
+    leased.close();
     lease.release();
   });
 

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -1230,9 +1230,12 @@ describe("state migrations", () => {
     try {
       const databasePath = resolveOpenClawStateSqlitePath(env);
       const database = new DatabaseSync(databasePath, { readOnly: true });
+      expect(database.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+      });
       expect(
-        database.prepare("SELECT name FROM sqlite_schema WHERE type = 'table' ORDER BY name").all(),
-      ).toEqual([{ name: "schema_meta" }, { name: "state_leases" }]);
+        database.prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'").get(),
+      ).toEqual({ schema_version: OPENCLAW_STATE_SCHEMA_VERSION });
       database.close();
 
       const detected = await detectLegacyStateMigrations({

--- a/src/plugin-state/plugin-state-store.fresh-store.test.ts
+++ b/src/plugin-state/plugin-state-store.fresh-store.test.ts
@@ -1,8 +1,10 @@
-// Fresh-store reads: a startup-checkpoint DB created before the first plugin-state write has no
-// plugin_state_entries table; read-only paths must report empty, not error (#117249).
+// Fresh-store reads remain empty after checkpoint bootstrap; missing canonical tables stay errors.
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
-import { withOpenClawStateStartupMigrationCheckpointDatabase } from "../state/openclaw-state-db.js";
+import {
+  OPENCLAW_STATE_SCHEMA_VERSION,
+  withOpenClawStateStartupMigrationCheckpointDatabase,
+} from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
@@ -36,7 +38,7 @@ async function expectPluginStateReadFailure(
 }
 
 describe("plugin state fresh-store reads", () => {
-  it("treats an existing state database without the lazy plugin-state table as empty", async () => {
+  it("initializes an empty canonical plugin-state store before startup checkpoint reads", async () => {
     await withOpenClawTestState(
       { label: "plugin-state-read-only-table-missing", applyEnv: false },
       async (state) => {
@@ -64,11 +66,18 @@ describe("plugin state fresh-store reads", () => {
         expect(countPluginStateLiveEntries("discord", state.env)).toBe(0);
 
         const verify = new DatabaseSync(databasePath, { readOnly: true });
-        const tables = verify
-          .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' ORDER BY name")
-          .all();
-        verify.close();
-        expect(tables).toEqual([{ name: "schema_meta" }, { name: "state_leases" }]);
+        try {
+          expect(verify.prepare("PRAGMA user_version").get()).toEqual({
+            user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+          });
+          expect(
+            verify
+              .prepare("SELECT name FROM sqlite_schema WHERE name = 'plugin_state_entries'")
+              .get(),
+          ).toEqual({ name: "plugin_state_entries" });
+        } finally {
+          verify.close();
+        }
       },
     );
   });
@@ -80,13 +89,7 @@ describe("plugin state fresh-store reads", () => {
         const databasePath = resolveOpenClawStateSqlitePath(state.env);
         withOpenClawStateStartupMigrationCheckpointDatabase(() => undefined, { env: state.env });
         const database = new DatabaseSync(databasePath);
-        database.exec(`
-          CREATE TABLE config_machine_state (
-            state_key TEXT NOT NULL PRIMARY KEY,
-            value_json TEXT NOT NULL,
-            updated_at_ms INTEGER NOT NULL
-          ) STRICT
-        `);
+        database.exec("DROP TABLE plugin_state_entries");
         database.close();
 
         const store = createPluginStateKeyedStore("discord", {

--- a/src/state/openclaw-state-db-startup-checkpoint.ts
+++ b/src/state/openclaw-state-db-startup-checkpoint.ts
@@ -2,6 +2,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
+import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import { configureSqlitePreSchemaPragmas } from "../infra/sqlite-wal.js";
 import {
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
@@ -17,6 +18,57 @@ import {
   assertOpenClawStateWriteAllowed,
   runWithOpenClawStateWriteAccess,
 } from "./openclaw-state-ownership.js";
+
+// Native Swift stores may create only these canonical objects before Node owns schema bootstrap.
+const NATIVE_STARTUP_BOOTSTRAP_OBJECTS = new Set([
+  "table:device_auth_tokens",
+  "index:idx_device_auth_tokens_updated",
+  "table:device_identities",
+  "index:idx_device_identities_device",
+  "table:exec_approvals_config",
+  "table:macos_port_guardian_records",
+  "index:idx_macos_port_guardian_records_port",
+  "table:schema_meta",
+  "table:state_leases",
+  "index:idx_state_leases_expiry",
+  "index:idx_state_leases_owner",
+]);
+
+function isUninitializedNativeStartupDatabase(db: DatabaseSync): boolean {
+  if (readSqliteUserVersion(db) !== 0) {
+    return false;
+  }
+  const objects = db // sqlite-allow-raw -- Pre-bootstrap schema ownership is checked before Kysely exposure.
+    .prepare("SELECT type, name FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%'")
+    .all();
+  if (
+    objects.some(
+      ({ type, name }) =>
+        typeof type !== "string" ||
+        typeof name !== "string" ||
+        !NATIVE_STARTUP_BOOTSTRAP_OBJECTS.has(`${type}:${name}`),
+    )
+  ) {
+    return false;
+  }
+  const tableNames = new Set(
+    objects.filter(({ type }) => type === "table").map(({ name }) => name),
+  );
+  if (
+    tableNames.has("schema_meta") &&
+    db // sqlite-allow-raw -- An existing metadata row means this is not an unowned fresh bootstrap.
+      .prepare("SELECT 1 FROM schema_meta LIMIT 1")
+      .get()
+  ) {
+    return false;
+  }
+  return !(
+    tableNames.has("state_leases") &&
+    db // sqlite-allow-raw -- Never initialize across another startup's existing migration lease.
+      .prepare("SELECT 1 FROM state_leases LIMIT 1")
+      .get()
+  );
+}
 
 function ensureStartupMigrationCheckpointSchema(
   db: DatabaseSync,
@@ -65,9 +117,10 @@ function ensureStartupMigrationCheckpointSchema(
   );
 }
 
-export function withOpenClawStateStartupMigrationCheckpointDatabase<T>(
+export function withOpenClawStateStartupCheckpointConnection<T>(
   callback: (db: DatabaseSync) => T,
-  options: OpenClawStateDatabaseOptions = {},
+  options: OpenClawStateDatabaseOptions,
+  initializeCanonicalSchema: (db: DatabaseSync, pathname: string, env: NodeJS.ProcessEnv) => void,
 ): T {
   const env = options.env ?? process.env;
   const pathname = resolveDatabasePath(options);
@@ -82,6 +135,9 @@ export function withOpenClawStateStartupMigrationCheckpointDatabase<T>(
           busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
         });
         assertSqliteIntegrity(db, pathname);
+        if (isUninitializedNativeStartupDatabase(db)) {
+          initializeCanonicalSchema(db, pathname, env);
+        }
         ensureStartupMigrationCheckpointSchema(db, pathname, env);
         return callback(db);
       } finally {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -85,6 +85,7 @@ import {
   repairLegacyGatewayRestartHandoffsForStrictMigration,
 } from "./openclaw-state-db-schema-repair.js";
 import * as sessionWatchMigration from "./openclaw-state-db-session-watch-migration.js";
+import { withOpenClawStateStartupCheckpointConnection } from "./openclaw-state-db-startup-checkpoint.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import { describeAgentPathMigration, warnAgentPathMigration } from "./openclaw-state-db.paths.js";
 import {
@@ -124,7 +125,6 @@ export {
 } from "./openclaw-state-db-maintenance.js";
 export { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.js";
 export { detectOpenClawStateDatabaseSchemaMigrations } from "./openclaw-state-db-schema-repair.js";
-export { withOpenClawStateStartupMigrationCheckpointDatabase } from "./openclaw-state-db-startup-checkpoint.js";
 
 /** Reconfirm an advisory worker failure on the live owner connection. */
 export function confirmOpenClawStateDatabaseIntegrity(
@@ -491,6 +491,14 @@ function ensureSchema(
   }
 }
 
+/** Bootstrap fresh/native-only state canonically before startup checkpoint access. */
+export function withOpenClawStateStartupMigrationCheckpointDatabase<T>(
+  callback: (db: DatabaseSync) => T,
+  options: OpenClawStateDatabaseOptions = {},
+): T {
+  return withOpenClawStateStartupCheckpointConnection(callback, options, ensureSchema);
+}
+
 /** Open existing shared state without creating, migrating, chmodding, or configuring it. */
 export async function openExistingOpenClawStateDatabaseReadOnly(
   options: OpenClawStateDatabaseOptions = {},
@@ -672,14 +680,6 @@ export function runWithOpenClawStateBusyTimeout<T>(
   }
 }
 
-function acquireOpenClawStateDatabaseForTransaction(
-  options: OpenClawStateDatabaseOptions,
-): OpenClawStateDatabase {
-  return options.database
-    ? openOpenClawStateDatabase(options)
-    : (getOpenClawStateDatabaseIfOpen(options) ?? openOpenClawStateDatabase(options));
-}
-
 /** Run a synchronous immediate transaction against the shared state database. */
 export function runOpenClawStateWriteTransaction<T>(
   operation: (database: OpenClawStateDatabase) => T,
@@ -692,7 +692,9 @@ export function runOpenClawStateWriteTransaction<T>(
   let database = options.database ?? getOpenClawStateDatabaseIfOpen(options);
   let result: T;
   try {
-    const acquired = acquireOpenClawStateDatabaseForTransaction(options);
+    const acquired = options.database
+      ? openOpenClawStateDatabase(options)
+      : (database ?? openOpenClawStateDatabase(options));
     database = acquired;
     result = runSqliteImmediateTransactionSync(
       acquired.db,

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -15,7 +15,6 @@ import { sha256HexPrefixCore } from "../infra/crypto-digest.js";
 import { requireNodeSqlite, resolveImmutableSqliteFileUri } from "../infra/node-sqlite.js";
 import * as sqliteReadonlyLocation from "../infra/sqlite-readonly-location.js";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
-import { withOpenClawStateStartupMigrationCheckpointDatabase } from "./openclaw-state-db-startup-checkpoint.js";
 import {
   closeOpenClawStateDatabaseForTest,
   getOpenClawStateDatabaseIfOpen,
@@ -24,6 +23,7 @@ import {
   repairOpenClawStateDatabaseSchema,
   repairOpenClawStateDatabaseSchemaIfNeeded,
   runOpenClawStateWriteTransaction,
+  withOpenClawStateStartupMigrationCheckpointDatabase,
 } from "./openclaw-state-db.js";
 import { resolveOpenClawStateDirForDatabasePath } from "./openclaw-state-db.paths.js";
 import { claimOpenClawStateOwnership } from "./openclaw-state-ownership-operations.js";


### PR DESCRIPTION
## What Problem This Solves

A fresh macOS install that launches the companion app once — even just to the welcome page — can end up with a Gateway that refuses to start on every boot:

```
- Failed detecting Matrix inbound dedupe markers: PluginStateStoreError: Failed to read plugin state entry.
- Failed detecting Reef identity keys: PluginStateStoreError: ...
- Failed detecting Workboard .28 plugin-state KV: PluginStateStoreError: Failed to list plugin state entries.
OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.
```

Found live during a fresh-profile onboarding round on current main. The state DB at that point holds exactly `device_identities`, `exec_approvals_config`, `schema_meta`, `state_leases` at `user_version=0` with an empty `schema_meta` — steady state, reproducible.

Two producers combine:
- The macOS app's **intentional** pre-Node native bootstrap writes `device_identities`/`exec_approvals_config` at version zero ([OpenClawNativeStateSQLite.swift:195](apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift), contract-tested) — legitimate by design.
- The TypeScript **startup-checkpoint connection owner** ([openclaw-state-db-startup-checkpoint.ts](src/state/openclaw-state-db-startup-checkpoint.ts)) created `schema_meta` + `state_leases` on that database **without invoking canonical schema initialization** — and even checkpoint *reads* from ordinary command preflight enter this writer ([startup-migration-checkpoint.ts:255](src/infra/startup-migration-checkpoint.ts), [doctor-config-preflight.ts:170](src/commands/doctor-config-preflight.ts)).

The plugin-state fresh-store discriminator ([plugin-state-store.sqlite.ts:420](src/plugin-state/plugin-state-store.sqlite.ts)) tolerates a missing `plugin_state_entries` only when `schema_meta`/`state_leases` are the *only* tables, so the native tables flip every legacy detector into a hard error, and startup fails closed until `doctor --fix`.

## Why This Change Was Made

Repair the invalid state at its producer: the checkpoint entrypoint now lives behind the canonical schema owner (`ensureSchema` injected from [openclaw-state-db.ts](src/state/openclaw-state-db.ts)). Before any checkpoint DDL, a database is adopted and fully initialized — current schema v10, primary metadata row, native identity/approval rows preserved — only under a strict gate: `user_version=0`, every schema object exactly matches the allowlisted native/checkpoint objects, and `schema_meta`/`state_leases` hold no rows. Real legacy version-zero databases, unknown objects, nonempty metadata, occupied migration leases, future versions, and corruption keep their conservative refusal behavior. **No schema version or table definition changes** — this is bootstrap ordering, not a store redesign.

Rejected alternatives (details in the investigation): blanket version-zero canonicalization (bypasses legacy ordering and lease ownership), widening the plugin-state missing-table fallback (hides the producer violation), moving canonical init into Swift (Swift deliberately does not own the Node schema contract), and requiring doctor (a fresh install must reach ready without an operator recovery step).

The ownership collision predates schema v10 (checkpoint owner b81666ca6af 07-08, native bootstrap 4d27b5b67eb 07-18, discriminator 02419ed1998 08-01); #129626 (v10) merely exposed it. Poisoned profiles already in the wild adopt automatically on next start.

## User Impact

A fresh install that touched the app before its first gateway start now boots to ready instead of permanently refusing with cryptic plugin-state errors. Existing poisoned profiles self-heal on next start; `doctor --fix` recovery continues to work.

## Evidence

- Three new regression tests fail pre-fix (`expected user_version 10, received 0`).
- The byte-exact poison fixture captured from the live app run: before `{userVersion:0, tables:4, metadataRows:0, identityRows:1, approvalRows:1}` → after `{userVersion:10, tables:123, metadataRows:1, identityRows:1, approvalRows:1}`; a real `gateway run` against a fixture copy logs `[gateway] ready` with no doctor; `doctor --fix` against another copy exits 0 preserving both native rows.
- 319 tests green across seven state/infra/gateway files; full `check-changed` green; autoreview clean ("patch is correct (0.97)").
- Production delta +58 lines: the explicit cross-runtime object allowlist and the fail-closed adoptable-vs-legacy distinction; the canonical owner itself grows two net lines after absorbing a one-use wrapper.
