### PR TITLE
fix(qa): align repeated-request proof with provider timeout

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -371,6 +371,7 @@ export type MockScenarioState = {
   subagentFanoutCompletedWorkers: Set<"alpha" | "beta">;
   subagentFanoutPhase: number;
   subagentHandoffSpawned: boolean;
+  repeatedRequestRecoveryAttempts: number;
   toolLoopReadAttempts: number;
 };
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -296,9 +296,12 @@ const QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE = /failed tool terminal recover
 const QA_TELEGRAM_VISIBLE_PARTIAL_FAILURE_PROMPT_RE = /telegram visible partial failure qa check/i;
 const QA_TELEGRAM_UNSENT_FAILURE_PROMPT_RE = /telegram unsent failure qa check/i;
 const QA_TELEGRAM_VISIBLE_PARTIAL_FAILURE_MARKER = "TELEGRAM-VISIBLE-PARTIAL-BEFORE-FAILURE";
-// Keep each real provider request active long enough for retries to span the
-// unchanged five-minute recovery bound while remaining below first-byte timeout.
-const QA_REPEATED_REQUEST_RESPONSE_PAUSE_MS = 110_000;
+// Complete ordinary retries inside their diagnostic request allowance, then
+// leave the fifth request active so recovery can honor both the cumulative
+// no-progress bound and the current request's own allowance.
+const QA_REPEATED_REQUEST_RESPONSE_PAUSE_MS = 80_000;
+const QA_REPEATED_REQUEST_STALLED_RESPONSE_PAUSE_MS = 180_000;
+const QA_REPEATED_REQUEST_STALL_ATTEMPT = 5;
 
 function isStreamingToolProgressContinuationText(text: string) {
   const trimmed = text.trim();
@@ -2509,6 +2512,7 @@ export async function startQaMockOpenAiServer(params?: {
       subagentFanoutCompletedWorkers: new Set<"alpha" | "beta">(),
       subagentFanoutPhase: 0,
       subagentHandoffSpawned: false,
+      repeatedRequestRecoveryAttempts: 0,
       toolLoopReadAttempts: 0,
     };
     scenarioStates.set(key, state);
@@ -2698,6 +2702,12 @@ export async function startQaMockOpenAiServer(params?: {
       toolOutputCallId: extractToolOutputCallId(input) || undefined,
       ...(extractToolOutputStructuredError(input) ? { toolOutputStructuredError: true } : {}),
     });
+    const repeatedRequestRecovery =
+      QA_REPEATED_REQUEST_RECOVERY_PROMPT_RE.test(allInputText) &&
+      !QA_REPEATED_REQUEST_QUEUED_REPLY_PROMPT_RE.test(prompt);
+    if (repeatedRequestRecovery) {
+      scenarioState.repeatedRequestRecoveryAttempts += 1;
+    }
     return {
       events,
       model,
@@ -2714,9 +2724,13 @@ export async function startQaMockOpenAiServer(params?: {
       ...(QA_FINAL_ONLY_MARKER_STREAMING_PROMPT_RE.test(allInputText)
         ? { previewPauseMs: finalOnlyMarkerPauseMs }
         : {}),
-      ...(QA_REPEATED_REQUEST_RECOVERY_PROMPT_RE.test(allInputText) &&
-      !QA_REPEATED_REQUEST_QUEUED_REPLY_PROMPT_RE.test(prompt)
-        ? { responsePauseMs: QA_REPEATED_REQUEST_RESPONSE_PAUSE_MS }
+      ...(repeatedRequestRecovery
+        ? {
+            responsePauseMs:
+              scenarioState.repeatedRequestRecoveryAttempts >= QA_REPEATED_REQUEST_STALL_ATTEMPT
+                ? QA_REPEATED_REQUEST_STALLED_RESPONSE_PAUSE_MS
+                : QA_REPEATED_REQUEST_RESPONSE_PAUSE_MS,
+          }
         : {}),
     };
   };

--- a/test/e2e/qa-lab/runtime/gateway-repeated-request-recovery.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-repeated-request-recovery.e2e.test.ts
@@ -11,6 +11,8 @@ type StabilityEvent = {
   reason?: unknown;
   outcome?: unknown;
   ageMs?: unknown;
+  durationMs?: unknown;
+  failureKind?: unknown;
   queueDepth?: unknown;
   source?: unknown;
 };
@@ -56,6 +58,7 @@ const QUEUED_PROMPT =
 const QUEUED_REPLY_MARKER = "GATEWAY_REPEATED_REQUEST_QUEUED_OK";
 const RECOVERY_REASON = "repeated_model_requests_without_progress";
 const PRODUCTION_RECOVERY_BOUND_MS = 360_000;
+const MODEL_REQUEST_ALLOWANCE_SECONDS = 90;
 const RECOVERY_PROGRESS_INTERVAL_MS = 60_000;
 const HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const HISTORY_RETRY_INTERVAL_MS = 250;
@@ -276,9 +279,9 @@ async function readFailureEvidence(params: {
   return JSON.stringify({ stability, requests, gatewayLogs });
 }
 
-describe("Gateway repeated-request recovery", () => {
+describe("Gateway repeated-request provider timeout", () => {
   it(
-    "aborts the real stalled owner once and releases one queued followup",
+    "lets the provider timeout terminate the stalled attempt before draining one queued followup",
     { timeout: 510_000 },
     async () => {
       harness = await startQaLiveLaneGateway({
@@ -294,7 +297,27 @@ describe("Gateway repeated-request recovery", () => {
         },
         transportBaseUrl: "http://127.0.0.1",
         controlUiEnabled: false,
-        mutateConfig: (config) => ({ ...config, diagnostics: { enabled: true } }),
+        mutateConfig: (config) => {
+          const models = config.models;
+          const provider = models?.providers?.["mock-openai"];
+          if (!models || !provider) {
+            throw new Error("mock-openai provider config unavailable");
+          }
+          return {
+            ...config,
+            diagnostics: { enabled: true },
+            models: {
+              ...models,
+              providers: {
+                ...models.providers,
+                "mock-openai": {
+                  ...provider,
+                  timeoutSeconds: MODEL_REQUEST_ALLOWANCE_SECONDS,
+                },
+              },
+            },
+          };
+        },
       });
       const { gateway } = harness;
 
@@ -338,7 +361,14 @@ describe("Gateway repeated-request recovery", () => {
       const events = await waitForStability(
         gateway,
         baselineSeq,
-        (records) => records.some((event) => event.type === "session.recovery.completed"),
+        (records) =>
+          records.some(
+            (event) =>
+              event.type === "model.call.error" &&
+              event.failureKind === "timeout" &&
+              typeof event.durationMs === "number" &&
+              event.durationMs >= MODEL_REQUEST_ALLOWANCE_SECONDS * 1_000,
+          ),
         350_000,
       );
       const stalled = events.filter(
@@ -352,15 +382,11 @@ describe("Gateway repeated-request recovery", () => {
       expect(stalled).toHaveLength(1);
       expect(stalled[0]?.ageMs).toEqual(expect.any(Number));
       expect(stalled[0]?.ageMs as number).toBeGreaterThanOrEqual(PRODUCTION_RECOVERY_BOUND_MS);
-      expect(requested).toEqual([
-        expect.objectContaining({ action: "abort", reason: RECOVERY_REASON }),
-      ]);
-      expect(completed).toEqual([
-        expect.objectContaining({ action: "abort_embedded_run", outcome: "aborted" }),
-      ]);
+      expect(requested).toEqual([]);
+      expect(completed).toEqual([]);
       expect(
         events.filter((event) => event.type === "model.call.started").length,
-      ).toBeGreaterThanOrEqual(4);
+      ).toBeGreaterThanOrEqual(5);
 
       const activeTerminal = (await gateway.call(
         "agent.wait",
@@ -368,13 +394,6 @@ describe("Gateway repeated-request recovery", () => {
         { timeoutMs: 35_000 },
       )) as GatewayChatRun;
       expect(activeTerminal.status).not.toBe("ok");
-
-      const queuedTerminal = (await gateway.call(
-        "agent.wait",
-        { runId: queued.runId, timeoutMs: 30_000 },
-        { timeoutMs: 35_000 },
-      )) as GatewayChatRun;
-      expect(queuedTerminal.status).toBe("ok");
 
       const history = await waitForQueuedReply(gateway, sessionKey).catch(
         async (error: unknown) => {
@@ -387,6 +406,12 @@ describe("Gateway repeated-request recovery", () => {
         },
       );
       expect(historyContainsQueuedReply(history)).toBe(true);
+      const queuedTerminal = (await gateway.call(
+        "agent.wait",
+        { runId: queued.runId, timeoutMs: 30_000 },
+        { timeoutMs: 35_000 },
+      )) as GatewayChatRun;
+      expect(queuedTerminal.status).toBe("ok");
       const mockBaseUrl = harness?.mock?.baseUrl;
       if (!mockBaseUrl) {
         throw new Error("mock provider request evidence unavailable");
@@ -394,7 +419,7 @@ describe("Gateway repeated-request recovery", () => {
       const requests = await readClassifiedMockRequests(mockBaseUrl);
       expect(
         requests.filter((request) => request.prompt === "recovery").length,
-      ).toBeGreaterThanOrEqual(4);
+      ).toBeGreaterThanOrEqual(5);
       expect(requests.filter((request) => request.prompt === "queued")).toEqual([
         expect.objectContaining({ outcome: "success" }),
       ]);
@@ -402,10 +427,10 @@ describe("Gateway repeated-request recovery", () => {
       const finalEvents = (await readStability(gateway, baselineSeq)).events ?? [];
       expect(
         finalEvents.filter((event) => event.type === "session.recovery.requested"),
-      ).toHaveLength(1);
+      ).toHaveLength(0);
       expect(
         finalEvents.filter((event) => event.type === "session.recovery.completed"),
-      ).toHaveLength(1);
+      ).toHaveLength(0);
     },
   );
 });


### PR DESCRIPTION
## What this fixes

Full Release Validation run [32917859227 / repo-E2E job 98025911272](https://github.com/openclaw/openclaw/actions/runs/32917859227/job/98025911272) timed out in `gateway-repeated-request-recovery.e2e.test.ts`. Four consecutive ~110s mock requests accumulated repeated-request no-progress diagnostics, but each newly active request remained inside its default 30-minute provider allowance.

## Root cause

The release proof predates #123877. That repair made the active provider request allowance authoritative: diagnostics must not abort a request before its provider timeout. The old test still expected a diagnostic recovery at the cumulative 360s floor, an impossible contract while a newer request retains a longer allowance.

The first candidate preserved that obsolete expectation with a 90s allowance. Exact-head run [32929006824 / repo-E2E job 98058029161](https://github.com/openclaw/openclaw/actions/runs/32929006824/job/98058029161) rejected it correctly: attempts 1–4 completed in ~80s, the fifth began, and its provider timeout fired at 90s before any diagnostic recovery. This revision aligns the proof with that observed production ownership instead of racing the transport timer.

## Fix

- Complete the first four repeated mock responses after 80s, inside the existing 90s provider allowance.
- Hold the fifth response open so the real provider timeout terminates that attempt.
- Prove cumulative stalled diagnostics are visible without a recovery request or completion.
- Prove the failed active run releases the real queue and the queued follow-up completes exactly once.

The sibling #123877 product proof covers “no recovery before the provider allowance, then manually release the provider.” This scenario remains distinct: it exercises repeated attempts, the actual provider-timeout terminal path, and queued-follow-up stabilization through a real Gateway.

## Evidence

- Pre-fix original-order reproduction: first release job above, exact main SHA `0036788055b5631f95d5eaeff9a1ba684fd78bb3`.
- Failed first-candidate contract audit: second repo-E2E job above; provider timeout on the fifth attempt, no diagnostic recovery.
- Final exact-head Gateway proof: [32942593540 / repo-E2E job 98097288314](https://github.com/openclaw/openclaw/actions/runs/32942593540/job/98097288314) passed this scenario in 430,705ms. It observed at least five model starts, the fifth provider timeout, cumulative stalled diagnostics, zero diagnostic recovery events, and one successful queued reply. The full repo-E2E job remained red for unrelated suites.
- Targeted Oxfmt: passed.
- Targeted type-aware Oxlint: passed.
- Structured autoreview after reframe: clean, patch correct (0.99).
- Local exact-SHA E2E remained blocked by the shared checkout's stale dependency graph; the dispatched exact-head repo-E2E is the authoritative proof.

## Scope

QA support +15 net; E2E test +26 net; product runtime 0. Production recovery bounds, provider timeout, retry behavior, and Gateway implementation are unchanged.
