### PR TITLE
fix(release): bind prerelease plugins into package Telegram QA

### DIFF
--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -410,11 +410,6 @@ jobs:
               echo "Prerelease plugin registry requires an artifact-backed Telegram package candidate." >&2
               exit 1
             fi
-            if [[ "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ID" != "$PACKAGE_ARTIFACT_RUN_ID" ||
-                  "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ATTEMPT" != "$PACKAGE_ARTIFACT_RUN_ATTEMPT" ]]; then
-              echo "Prerelease plugin registry and package artifact must come from the same producer run attempt." >&2
-              exit 1
-            fi
           fi
           case "${PROVIDER_MODE}" in
             mock-openai | live-frontier) ;;

--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -60,6 +60,36 @@ on:
         required: false
         default: ""
         type: string
+      prepublish_plugin_registry_artifact_name:
+        description: Prerelease plugin registry artifact name
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_artifact_id:
+        description: Immutable prerelease plugin registry artifact id
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_artifact_digest:
+        description: GitHub artifact service SHA-256 digest for the prerelease plugin registry
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_artifact_run_id:
+        description: Producer run id containing the prerelease plugin registry artifact
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_artifact_run_attempt:
+        description: Producer run attempt containing the prerelease plugin registry artifact
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_manifest_sha256:
+        description: Expected SHA-256 of prepublish-plugin-registry.json
+        required: false
+        default: ""
+        type: string
       harness_ref:
         description: Source ref for the private QA harness; defaults to the dispatched workflow ref
         required: false
@@ -150,6 +180,36 @@ on:
         type: string
       package_version:
         description: Exact OpenClaw package version
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_artifact_name:
+        description: Prerelease plugin registry artifact name
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_artifact_id:
+        description: Immutable prerelease plugin registry artifact id
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_artifact_digest:
+        description: GitHub artifact service SHA-256 digest for the prerelease plugin registry
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_artifact_run_id:
+        description: Producer run id containing the prerelease plugin registry artifact
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_artifact_run_attempt:
+        description: Producer run attempt containing the prerelease plugin registry artifact
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_manifest_sha256:
+        description: Expected SHA-256 of prepublish-plugin-registry.json
         required: false
         default: ""
         type: string
@@ -274,6 +334,12 @@ jobs:
           PACKAGE_SHA256: ${{ inputs.package_sha256 || '' }}
           PACKAGE_SOURCE_SHA: ${{ inputs.package_source_sha || '' }}
           PACKAGE_VERSION: ${{ inputs.package_version || '' }}
+          PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_DIGEST: ${{ inputs.prepublish_plugin_registry_artifact_digest || '' }}
+          PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_ID: ${{ inputs.prepublish_plugin_registry_artifact_id || '' }}
+          PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_NAME: ${{ inputs.prepublish_plugin_registry_artifact_name || '' }}
+          PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ATTEMPT: ${{ inputs.prepublish_plugin_registry_artifact_run_attempt || '' }}
+          PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ID: ${{ inputs.prepublish_plugin_registry_artifact_run_id || '' }}
+          PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256: ${{ inputs.prepublish_plugin_registry_manifest_sha256 || '' }}
           PROVIDER_MODE: ${{ inputs.provider_mode }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
@@ -317,6 +383,39 @@ jobs:
             echo "Artifact-backed Telegram E2E requires the complete immutable artifact and package identity tuple." >&2
             exit 1
           fi
+          registry_tuple_present=0
+          for value in \
+            "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_DIGEST" \
+            "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_ID" \
+            "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_NAME" \
+            "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ATTEMPT" \
+            "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ID" \
+            "$PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256"; do
+            if [[ -n "${value// }" ]]; then
+              registry_tuple_present=1
+            fi
+          done
+          if [[ "$registry_tuple_present" == "1" ]] &&
+            [[ -z "${PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_NAME// }" ||
+              ! "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ||
+              ! "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_ID" =~ ^[1-9][0-9]*$ ||
+              ! "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ||
+              ! "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ||
+              ! "$PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "Prerelease plugin registry requires the complete immutable artifact and manifest identity tuple." >&2
+            exit 1
+          fi
+          if [[ "$registry_tuple_present" == "1" ]]; then
+            if [[ -z "${PACKAGE_ARTIFACT_NAME// }" ]]; then
+              echo "Prerelease plugin registry requires an artifact-backed Telegram package candidate." >&2
+              exit 1
+            fi
+            if [[ "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ID" != "$PACKAGE_ARTIFACT_RUN_ID" ||
+                  "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ATTEMPT" != "$PACKAGE_ARTIFACT_RUN_ATTEMPT" ]]; then
+              echo "Prerelease plugin registry and package artifact must come from the same producer run attempt." >&2
+              exit 1
+            fi
+          fi
           case "${PROVIDER_MODE}" in
             mock-openai | live-frontier) ;;
             *)
@@ -338,6 +437,51 @@ jobs:
           if [[ "${PROVIDER_MODE}" == "live-frontier" ]]; then
             require_var OPENAI_API_KEY
           fi
+
+      - name: Validate prerelease plugin registry artifact identity
+        if: inputs.prepublish_plugin_registry_artifact_name != ''
+        env:
+          ARTIFACT_DIGEST: ${{ inputs.prepublish_plugin_registry_artifact_digest }}
+          ARTIFACT_ID: ${{ inputs.prepublish_plugin_registry_artifact_id }}
+          ARTIFACT_NAME: ${{ inputs.prepublish_plugin_registry_artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ inputs.prepublish_plugin_registry_artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ inputs.prepublish_plugin_registry_artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}")"
+          jq -e \
+            --arg digest "sha256:${ARTIFACT_DIGEST}" \
+            --arg id "$ARTIFACT_ID" \
+            --arg name "$ARTIFACT_NAME" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '
+              (.id | tostring) == $id and
+              .name == $name and
+              .expired == false and
+              .digest == $digest and
+              (.workflow_run.id | tostring) == $run_id
+            ' <<< "$artifact_json" >/dev/null || {
+            echo "Prerelease plugin registry artifact identity does not match the requested immutable tuple." >&2
+            exit 1
+          }
+          attempt_json="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}"
+          )"
+          jq -e \
+            --arg attempt "$ARTIFACT_RUN_ATTEMPT" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '(.id | tostring) == $run_id and (.run_attempt | tostring) == $attempt' \
+            <<< "$attempt_json" >/dev/null || {
+            echo "Prerelease plugin registry producer run attempt does not match the requested tuple." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_NAME" == *"-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}" ]] || {
+            echo "Prerelease plugin registry artifact name does not bind the declared producer run attempt." >&2
+            exit 1
+          }
 
       - name: Validate package artifact identity
         if: inputs.package_artifact_name != ''
@@ -423,6 +567,42 @@ jobs:
           run-id: ${{ inputs.package_artifact_run_id }}
           github-token: ${{ github.token }}
 
+      - name: Download current-run prerelease plugin registry artifact
+        if: inputs.prepublish_plugin_registry_artifact_name != '' && inputs.prepublish_plugin_registry_artifact_run_id == github.run_id
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ inputs.prepublish_plugin_registry_artifact_id }}
+          path: .artifacts/telegram-prepublish-plugin-registry
+          run-id: ${{ inputs.prepublish_plugin_registry_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Download release-run prerelease plugin registry artifact
+        if: inputs.prepublish_plugin_registry_artifact_name != '' && inputs.prepublish_plugin_registry_artifact_run_id != github.run_id
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ inputs.prepublish_plugin_registry_artifact_id }}
+          path: .artifacts/telegram-prepublish-plugin-registry
+          run-id: ${{ inputs.prepublish_plugin_registry_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate prerelease plugin registry manifest
+        if: inputs.prepublish_plugin_registry_artifact_name != ''
+        env:
+          EXPECTED_MANIFEST_SHA256: ${{ inputs.prepublish_plugin_registry_manifest_sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          manifest=".artifacts/telegram-prepublish-plugin-registry/prepublish-plugin-registry.json"
+          [[ -f "$manifest" ]] || {
+            echo "Prerelease plugin registry artifact is missing prepublish-plugin-registry.json." >&2
+            exit 1
+          }
+          actual_sha256="$(sha256sum "$manifest" | awk '{print $1}')"
+          [[ "$actual_sha256" == "$EXPECTED_MANIFEST_SHA256" ]] || {
+            echo "Prerelease plugin registry manifest SHA-256 differs from the declared identity." >&2
+            exit 1
+          }
+
       - name: Run package Telegram E2E
         id: run_lane
         shell: bash
@@ -448,6 +628,7 @@ jobs:
           PACKAGE_SHA256: ${{ inputs.package_sha256 || '' }}
           PACKAGE_SOURCE_SHA: ${{ inputs.package_source_sha || '' }}
           PACKAGE_VERSION: ${{ inputs.package_version || '' }}
+          PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_NAME: ${{ inputs.prepublish_plugin_registry_artifact_name || '' }}
         run: |
           set -euo pipefail
 
@@ -622,6 +803,9 @@ jobs:
             fi
           elif [[ -z "${OPENCLAW_NPM_TELEGRAM_PACKAGE_LABEL// }" ]]; then
             export OPENCLAW_NPM_TELEGRAM_PACKAGE_LABEL="${OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC}"
+          fi
+          if [[ -n "${PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_NAME// }" ]]; then
+            export OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR=".artifacts/telegram-prepublish-plugin-registry"
           fi
 
           if [[ -n "${INPUT_SCENARIO// }" ]]; then

--- a/.github/workflows/package-acceptance.yml
+++ b/.github/workflows/package-acceptance.yml
@@ -1023,6 +1023,12 @@ jobs:
       package_sha256: ${{ needs.resolve_package.outputs.package_sha256 }}
       package_source_sha: ${{ needs.resolve_package.outputs.package_source_sha }}
       package_version: ${{ needs.resolve_package.outputs.package_version }}
+      prepublish_plugin_registry_artifact_name: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}
+      prepublish_plugin_registry_artifact_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
+      prepublish_plugin_registry_artifact_digest: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
+      prepublish_plugin_registry_artifact_run_attempt: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
+      prepublish_plugin_registry_artifact_run_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
+      prepublish_plugin_registry_manifest_sha256: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
       package_label: openclaw@${{ needs.resolve_package.outputs.package_version }}
       harness_ref: ${{ inputs.workflow_ref }}
       provider_mode: ${{ needs.resolve_package.outputs.telegram_mode }}

--- a/scripts/e2e/codex-on-demand-docker.sh
+++ b/scripts/e2e/codex-on-demand-docker.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+source "$ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-codex-on-demand-e2e" OPENCLAW_CODEX_ON_DEMAND_E2E_IMAGE)"
 DOCKER_TARGET="${OPENCLAW_CODEX_ON_DEMAND_DOCKER_TARGET:-bare}"
@@ -21,17 +22,7 @@ run_log=""
 export OPENCLAW_E2E_NPM_INSTALL_TIMEOUT="${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-1200s}"
 
 configure_prepublish_plugin_registry() {
-  local registry_dir="$1"
-  local resolved_registry_dir
-  resolved_registry_dir="$(cd "$registry_dir" && pwd)"
-  if [ ! -f "$resolved_registry_dir/prepublish-plugin-registry.json" ]; then
-    echo "Prepublish plugin registry manifest is missing." >&2
-    exit 1
-  fi
-  PREPUBLISH_PLUGIN_REGISTRY_ARGS=(
-    -e OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR=/tmp/openclaw-prepublish-plugin-registry
-    -v "$resolved_registry_dir:/tmp/openclaw-prepublish-plugin-registry:ro"
-  )
+  prepublish_plugin_registry_mount_args "$1" PREPUBLISH_PLUGIN_REGISTRY_ARGS
 }
 if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
   configure_prepublish_plugin_registry "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR"
@@ -94,6 +85,7 @@ if ! docker_e2e_run_with_harness \
 set -euo pipefail
 
 source scripts/lib/openclaw-e2e-instance.sh
+source scripts/e2e/lib/prepublish-plugin-registry.sh
 openclaw_e2e_eval_test_state_from_b64 "${OPENCLAW_TEST_STATE_SCRIPT_B64:?missing OPENCLAW_TEST_STATE_SCRIPT_B64}"
 export NPM_CONFIG_PREFIX="$HOME/.npm-global"
 export npm_config_prefix="$NPM_CONFIG_PREFIX"
@@ -125,52 +117,14 @@ configure_plugin_registry() {
   [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ] || return 0
   local registry_root="/tmp/openclaw-codex-registry"
   local manifest="$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR/prepublish-plugin-registry.json"
-  local package_name package_version package_tarball
-  IFS=$'\t' read -r package_name package_version package_tarball < <(
-    PREPUBLISH_PLUGIN_REGISTRY_MANIFEST="$manifest" node <<'NODE'
-const fs = require("node:fs");
-const path = require("node:path");
-const manifestPath = process.env.PREPUBLISH_PLUGIN_REGISTRY_MANIFEST;
-const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-const matches = Array.isArray(manifest.packages)
-  ? manifest.packages.filter((entry) => entry?.name === "@openclaw/codex")
-  : [];
-if (matches.length !== 1) {
-  throw new Error("prepublish plugin registry must contain exactly one @openclaw/codex package");
-}
-const entry = matches[0];
-if (
-  typeof entry.version !== "string" ||
-  typeof entry.tarball !== "string" ||
-  path.basename(entry.tarball) !== entry.tarball
-) {
-  throw new Error("invalid @openclaw/codex prepublish plugin registry entry");
-}
-process.stdout.write(
-  `${entry.name}\t${entry.version}\t${path.join(path.dirname(manifestPath), entry.tarball)}\n`,
-);
-NODE
-  )
-  mkdir -p "$registry_root"
-  OPENCLAW_NPM_REGISTRY_DIST_TAGS="latest=0.0.0,beta=$package_version" \
-  OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org \
-    node scripts/e2e/lib/plugins/npm-registry-server.mjs \
-    "$registry_root/port" \
-    "$package_name" "$package_version" "$package_tarball" \
-    >"$registry_root/server.log" 2>&1 &
-  plugin_registry_pid="$!"
-  for _ in $(seq 1 100); do
-    [ -s "$registry_root/port" ] && break
-    openclaw_e2e_process_alive "$plugin_registry_pid" || break
-    sleep 0.1
-  done
-  if [ ! -s "$registry_root/port" ]; then
-    openclaw_e2e_print_log "$registry_root/server.log" >&2
-    echo "Timed out waiting for Codex npm registry." >&2
-    return 1
-  fi
-  export NPM_CONFIG_REGISTRY="http://127.0.0.1:$(cat "$registry_root/port")"
-  export npm_config_registry="$NPM_CONFIG_REGISTRY"
+  local registry_args=()
+  prepublish_plugin_registry_append_manifest_args "$manifest" registry_args "@openclaw/codex"
+  prepublish_plugin_registry_start_npm_server \
+    "$registry_root" \
+    "Codex npm registry" \
+    plugin_registry_pid \
+    "latest=0.0.0,beta=${registry_args[1]}" \
+    "${registry_args[@]}"
 }
 
 mkdir -p "$NPM_CONFIG_PREFIX" "$XDG_CACHE_HOME" "$NPM_CONFIG_CACHE"

--- a/scripts/e2e/lib/prepublish-plugin-registry.sh
+++ b/scripts/e2e/lib/prepublish-plugin-registry.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+prepublish_plugin_registry_mount_args() {
+  local registry_dir="$1"
+  local output_array_name="$2"
+  local container_dir="${3:-/tmp/openclaw-prepublish-plugin-registry}"
+  local resolved_registry_dir
+  resolved_registry_dir="$(cd "$registry_dir" && pwd)"
+  if [ ! -f "$resolved_registry_dir/prepublish-plugin-registry.json" ]; then
+    echo "Prepublish plugin registry manifest is missing." >&2
+    exit 1
+  fi
+
+  local -n output_args="$output_array_name"
+  output_args=(
+    -e "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR=$container_dir"
+    -v "$resolved_registry_dir:$container_dir:ro"
+  )
+}
+
+prepublish_plugin_registry_append_manifest_args() {
+  local manifest="$1"
+  local output_array_name="$2"
+  local required_package="${3:-}"
+  local registry_rows
+  registry_rows="$(
+    PREPUBLISH_PLUGIN_REGISTRY_MANIFEST="$manifest" \
+      PREPUBLISH_PLUGIN_REGISTRY_REQUIRED_PACKAGE="$required_package" \
+      node <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+const manifestPath = process.env.PREPUBLISH_PLUGIN_REGISTRY_MANIFEST;
+const requiredPackage = process.env.PREPUBLISH_PLUGIN_REGISTRY_REQUIRED_PACKAGE || "";
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+let packages = Array.isArray(manifest.packages) ? manifest.packages : [];
+if (requiredPackage) {
+  packages = packages.filter((entry) => entry?.name === requiredPackage);
+  if (packages.length !== 1) {
+    throw new Error(`prepublish plugin registry must contain exactly one ${requiredPackage} package`);
+  }
+}
+if (packages.length === 0) {
+  throw new Error("prepublish plugin registry manifest must contain packages");
+}
+for (const entry of packages) {
+  if (
+    typeof entry.name !== "string" ||
+    typeof entry.version !== "string" ||
+    typeof entry.tarball !== "string" ||
+    path.basename(entry.tarball) !== entry.tarball
+  ) {
+    throw new Error("invalid prepublish plugin registry package entry");
+  }
+  process.stdout.write(
+    `${entry.name}\t${entry.version}\t${path.join(path.dirname(manifestPath), entry.tarball)}\n`,
+  );
+}
+NODE
+  )"
+
+  local -n output_args="$output_array_name"
+  local plugin_package_name plugin_package_version plugin_package_tarball
+  while IFS=$'\t' read -r plugin_package_name plugin_package_version plugin_package_tarball; do
+    output_args+=("$plugin_package_name" "$plugin_package_version" "$plugin_package_tarball")
+  done <<<"$registry_rows"
+}
+
+prepublish_plugin_registry_start_npm_server() {
+  local registry_root="$1"
+  local log_label="$2"
+  local pid_var_name="$3"
+  local dist_tags="$4"
+  shift 4
+
+  if [ "$#" -eq 0 ]; then
+    return 0
+  fi
+
+  local port_file="$registry_root/port"
+  local log_file="$registry_root/server.log"
+  mkdir -p "$registry_root" && rm -f "$port_file"
+  OPENCLAW_NPM_REGISTRY_DIST_TAGS="$dist_tags" \
+  OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org \
+    node scripts/e2e/lib/plugins/npm-registry-server.mjs \
+    "$port_file" \
+    "$@" >"$log_file" 2>&1 &
+
+  local -n pid_var="$pid_var_name"
+  pid_var="$!"
+  for _ in $(seq 1 100); do
+    [ -s "$port_file" ] && break
+    openclaw_e2e_process_alive "$pid_var" || break
+    sleep 0.1
+  done
+  if [ ! -s "$port_file" ]; then
+    openclaw_e2e_print_log "$log_file" >&2
+    echo "Timed out waiting for $log_label." >&2
+    return 1
+  fi
+  export NPM_CONFIG_REGISTRY="http://127.0.0.1:$(cat "$port_file")"
+  export npm_config_registry="$NPM_CONFIG_REGISTRY"
+}

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -5,6 +5,7 @@ set -Eeuo pipefail
 exec 3>&1
 
 source scripts/lib/openclaw-e2e-instance.sh
+source scripts/e2e/lib/prepublish-plugin-registry.sh
 
 SCENARIO="${OPENCLAW_UPGRADE_SURVIVOR_SCENARIO:-base}"
 
@@ -488,40 +489,11 @@ configure_plugin_registry() {
   local fixture_root="$ARTIFACT_ROOT/plugin-registry"
   local package_dir="$fixture_root/package"
   local tarball="$fixture_root/openclaw-brave-plugin-${candidate_version}.tgz"
-  local port_file="$fixture_root/npm-registry-port"
-  local log_file="$fixture_root/npm-registry.log"
   local registry_args=()
 
   if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
     local manifest="$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR/prepublish-plugin-registry.json"
-    local registry_rows
-    registry_rows="$(
-      PREPUBLISH_PLUGIN_REGISTRY_MANIFEST="$manifest" node <<'NODE'
-const fs = require("node:fs");
-const path = require("node:path");
-const manifestPath = process.env.PREPUBLISH_PLUGIN_REGISTRY_MANIFEST;
-const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-if (!Array.isArray(manifest.packages) || manifest.packages.length === 0) {
-  throw new Error("prepublish plugin registry manifest must contain packages");
-}
-for (const entry of manifest.packages) {
-  if (
-    typeof entry.name !== "string" ||
-    typeof entry.version !== "string" ||
-    typeof entry.tarball !== "string" ||
-    path.basename(entry.tarball) !== entry.tarball
-  ) {
-    throw new Error("invalid prepublish plugin registry package entry");
-  }
-  process.stdout.write(
-    `${entry.name}\t${entry.version}\t${path.join(path.dirname(manifestPath), entry.tarball)}\n`,
-  );
-}
-NODE
-    )"
-    while IFS=$'\t' read -r plugin_package_name plugin_package_version plugin_package_tarball; do
-      registry_args+=("$plugin_package_name" "$plugin_package_version" "$plugin_package_tarball")
-    done <<<"$registry_rows"
+    prepublish_plugin_registry_append_manifest_args "$manifest" registry_args
   fi
 
   if configured_plugin_installs_enabled; then
@@ -588,18 +560,12 @@ NODE
     return 0
   fi
 
-  mkdir -p "$fixture_root" && rm -f "$port_file"
-  OPENCLAW_NPM_REGISTRY_DIST_TAGS="beta=$candidate_version" \
-  OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org \
-    node scripts/e2e/lib/plugins/npm-registry-server.mjs \
-    "$port_file" \
-    "${registry_args[@]}" \
-    >"$log_file" 2>&1 &
-  plugin_registry_pid="$!"
-
-  wait_for_fixture_port "$plugin_registry_pid" "$port_file" "$log_file" "npm registry"
-  export NPM_CONFIG_REGISTRY="http://127.0.0.1:$(cat "$port_file")"
-  export npm_config_registry="$NPM_CONFIG_REGISTRY"
+  prepublish_plugin_registry_start_npm_server \
+    "$fixture_root" \
+    "upgrade survivor npm registry" \
+    plugin_registry_pid \
+    "beta=$candidate_version" \
+    "${registry_args[@]}"
 }
 
 legacy_plugin_dependency_probe_paths() {

--- a/scripts/e2e/npm-telegram-live-docker.sh
+++ b/scripts/e2e/npm-telegram-live-docker.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+source "$ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-npm-telegram-live-e2e" OPENCLAW_NPM_TELEGRAM_LIVE_E2E_IMAGE)"
 DOCKER_TARGET="${OPENCLAW_NPM_TELEGRAM_DOCKER_TARGET:-build}"
@@ -108,6 +109,7 @@ process.stdin.on("end", () => {
 
 package_mount_args=()
 registry_helper_mount_args=()
+prepublish_plugin_registry_args=()
 package_install_source="$PACKAGE_SPEC"
 package_source_kind="npm-package"
 resolved_package_tgz="$(resolve_package_tgz "$PACKAGE_TGZ")"
@@ -137,6 +139,11 @@ elif [ -n "$resolved_package_tgz" ]; then
   package_mount_args=(-v "$resolved_package_tgz:$package_install_source:ro")
 else
   validate_openclaw_package_spec "$PACKAGE_SPEC"
+fi
+if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
+  prepublish_plugin_registry_mount_args \
+    "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR" \
+    prepublish_plugin_registry_args
 fi
 if [ -z "$PACKAGE_LABEL" ]; then
   if [ -n "$resolved_package_tgz" ]; then
@@ -418,6 +425,7 @@ EOF
 # package candidate. The candidate remains the absolute CLI/runtime SUT.
 run_logged_print_heartbeat "npm-telegram-live-suite" 60 docker_e2e_run_with_harness \
   "${docker_env[@]}" \
+  ${prepublish_plugin_registry_args[@]+"${prepublish_plugin_registry_args[@]}"} \
   -v "$ROOT_DIR/.artifacts:/app/.artifacts" \
   -v "$OUTPUT_DIR_HOST:$OUTPUT_DIR_CONTAINER" \
   -v "$harness_package_json:/app/package.json:ro" \
@@ -432,6 +440,7 @@ run_logged_print_heartbeat "npm-telegram-live-suite" 60 docker_e2e_run_with_harn
   -i "$IMAGE_NAME" bash -s <<'EOF'
 set -euo pipefail
 source scripts/lib/openclaw-e2e-instance.sh
+source scripts/e2e/lib/prepublish-plugin-registry.sh
 
 runtime_home="$(mktemp -d "/tmp/openclaw-npm-telegram-runtime.XXXXXX")"
 export HOME="$runtime_home"
@@ -440,6 +449,7 @@ export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
 export OPENCLAW_NPM_TELEGRAM_REPO_ROOT="/app"
 export OPENCLAW_NPM_TELEGRAM_PACKAGE_VERSION="$(node -e 'const pkg = require("/npm-global/lib/node_modules/openclaw/package.json"); process.stdout.write(pkg.version)')"
 sut_command="/npm-global/bin/openclaw"
+plugin_registry_pid=""
 
 dump_hotpath_logs() {
   local status="$1"
@@ -456,6 +466,25 @@ dump_hotpath_logs() {
   done
 }
 trap 'status=$?; dump_hotpath_logs "$status"; exit "$status"' ERR
+
+cleanup_runtime() {
+  openclaw_e2e_stop_process "${plugin_registry_pid:-}"
+}
+trap cleanup_runtime EXIT
+
+configure_plugin_registry() {
+  [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ] || return 0
+  local registry_args=()
+  prepublish_plugin_registry_append_manifest_args \
+    "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR/prepublish-plugin-registry.json" \
+    registry_args
+  prepublish_plugin_registry_start_npm_server \
+    /tmp/openclaw-npm-telegram-plugin-registry \
+    "package Telegram prerelease plugin registry" \
+    plugin_registry_pid \
+    "latest=0.0.0,beta=$OPENCLAW_NPM_TELEGRAM_PACKAGE_VERSION" \
+    "${registry_args[@]}"
+}
 
 test -x "$sut_command"
 openclaw_e2e_run_command "$sut_command" --version
@@ -503,6 +532,8 @@ for workspace_dir in /app/packages/* /app/extensions/*; do
   link_harness_dependency "$workspace_dir" "$workspace_name"
 done
 link_harness_dependency /app openclaw
+
+configure_plugin_registry
 
 if [ "${OPENCLAW_NPM_TELEGRAM_SKIP_HOTPATH:-0}" != "1" ]; then
   hotpath_home="$(mktemp -d "/tmp/openclaw-npm-telegram-hotpath.XXXXXX")"

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -10,6 +10,7 @@ DOCKER_E2E_HARNESS_ROOT_DIR="$HARNESS_ROOT_DIR"
 source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-package.sh"
 source "$HARNESS_ROOT_DIR/scripts/lib/openclaw-e2e-instance.sh"
+source "$HARNESS_ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-upgrade-survivor-e2e" OPENCLAW_UPGRADE_SURVIVOR_E2E_IMAGE)"
 SKIP_BUILD="${OPENCLAW_UPGRADE_SURVIVOR_E2E_SKIP_BUILD:-0}"
@@ -109,18 +110,7 @@ if [ -n "${OPENCLAW_UPGRADE_SURVIVOR_READYZ_ALLOW_DEGRADED:-}" ]; then
   )
 fi
 configure_prepublish_plugin_registry() {
-  local registry_dir="$1"
-  PREPUBLISH_PLUGIN_REGISTRY_DIR="$(
-    cd "$registry_dir" && pwd
-  )"
-  if [ ! -f "$PREPUBLISH_PLUGIN_REGISTRY_DIR/prepublish-plugin-registry.json" ]; then
-    echo "Prepublish plugin registry manifest is missing." >&2
-    exit 1
-  fi
-  PREPUBLISH_PLUGIN_REGISTRY_ARGS=(
-    -e OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR=/tmp/openclaw-prepublish-plugin-registry
-    -v "$PREPUBLISH_PLUGIN_REGISTRY_DIR:/tmp/openclaw-prepublish-plugin-registry:ro"
-  )
+  prepublish_plugin_registry_mount_args "$1" PREPUBLISH_PLUGIN_REGISTRY_ARGS
 }
 if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
   configure_prepublish_plugin_registry "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR"
@@ -291,6 +281,7 @@ docker_e2e_run_with_harness \
   "$IMAGE_NAME" \
   timeout --kill-after=30s "$DOCKER_RUN_TIMEOUT" bash -lc 'set -euo pipefail
 source scripts/lib/openclaw-e2e-instance.sh
+source scripts/e2e/lib/prepublish-plugin-registry.sh
 
 export npm_config_loglevel=error
 export npm_config_fund=false
@@ -387,40 +378,11 @@ configure_plugin_registry() {
   local fixture_root="$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT/plugin-registry"
   local package_dir="$fixture_root/package"
   local tarball="$fixture_root/openclaw-brave-plugin-2026.5.2.tgz"
-  local port_file="$fixture_root/npm-registry-port"
-  local log_file="$fixture_root/npm-registry.log"
   local registry_args=()
 
   if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
     local manifest="$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR/prepublish-plugin-registry.json"
-    local registry_rows
-    registry_rows="$(
-      PREPUBLISH_PLUGIN_REGISTRY_MANIFEST="$manifest" node <<'"'"'NODE'"'"'
-const fs = require("node:fs");
-const path = require("node:path");
-const manifestPath = process.env.PREPUBLISH_PLUGIN_REGISTRY_MANIFEST;
-const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-if (!Array.isArray(manifest.packages) || manifest.packages.length === 0) {
-  throw new Error("prepublish plugin registry manifest must contain packages");
-}
-for (const entry of manifest.packages) {
-  if (
-    typeof entry.name !== "string" ||
-    typeof entry.version !== "string" ||
-    typeof entry.tarball !== "string" ||
-    path.basename(entry.tarball) !== entry.tarball
-  ) {
-    throw new Error("invalid prepublish plugin registry package entry");
-  }
-  process.stdout.write(
-    `${entry.name}\t${entry.version}\t${path.join(path.dirname(manifestPath), entry.tarball)}\n`,
-  );
-}
-NODE
-    )"
-    while IFS=$'"'"'\t'"'"' read -r plugin_package_name plugin_package_version plugin_package_tarball; do
-      registry_args+=("$plugin_package_name" "$plugin_package_version" "$plugin_package_tarball")
-    done <<<"$registry_rows"
+    prepublish_plugin_registry_append_manifest_args "$manifest" registry_args
   fi
 
   if [ "${OPENCLAW_UPGRADE_SURVIVOR_SCENARIO:-base}" = "configured-plugin-installs" ]; then
@@ -483,18 +445,12 @@ NODE
     return 0
   fi
 
-  mkdir -p "$fixture_root"
-  OPENCLAW_NPM_REGISTRY_DIST_TAGS="beta=$package_version" \
-  OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org \
-    node scripts/e2e/lib/plugins/npm-registry-server.mjs \
-    "$port_file" \
-    "${registry_args[@]}" \
-    >"$log_file" 2>&1 &
-  plugin_registry_pid="$!"
-
-  wait_for_fixture_port "$plugin_registry_pid" "$port_file" "$log_file" "npm registry"
-  export NPM_CONFIG_REGISTRY="http://127.0.0.1:$(cat "$port_file")"
-  export npm_config_registry="$NPM_CONFIG_REGISTRY"
+  prepublish_plugin_registry_start_npm_server \
+    "$fixture_root" \
+    "upgrade survivor npm registry" \
+    plugin_registry_pid \
+    "beta=$package_version" \
+    "${registry_args[@]}"
 }
 
 openclaw_e2e_eval_test_state_from_b64 "${OPENCLAW_TEST_STATE_SCRIPT_B64:?missing OPENCLAW_TEST_STATE_SCRIPT_B64}"

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -75,6 +75,7 @@ const PLUGINS_DOCKER_MARKETPLACE_PATH = "scripts/e2e/lib/plugins/marketplace.sh"
 const PLUGINS_DOCKER_CLAWHUB_PATH = "scripts/e2e/lib/plugins/clawhub.sh";
 const PLUGINS_DOCKER_ASSERTIONS_PATH = "scripts/e2e/lib/plugins/assertions.mjs";
 const PLUGINS_DOCKER_NPM_REGISTRY_PATH = "scripts/e2e/lib/plugins/npm-registry-server.mjs";
+const PREPUBLISH_PLUGIN_REGISTRY_HELPER_PATH = "scripts/e2e/lib/prepublish-plugin-registry.sh";
 const PLUGIN_UPDATE_DOCKER_E2E_PATH = "scripts/e2e/plugin-update-unchanged-docker.sh";
 const PLUGIN_UPDATE_SCENARIO_PATH = "scripts/e2e/lib/plugin-update/unchanged-scenario.sh";
 const PLUGIN_UPDATE_CORRUPT_SCENARIO_PATH =
@@ -2501,17 +2502,25 @@ docker_e2e_docker_run_cmd run demo
   it("lets upgrade survivor fixture registries resolve transitive public packages", () => {
     const runner = readFileSync(UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "utf8");
     const publishedRunner = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
+    const registryHelper = readFileSync(PREPUBLISH_PLUGIN_REGISTRY_HELPER_PATH, "utf8");
 
+    expect(registryHelper).toContain("OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org");
+    expect(registryHelper).toContain("node scripts/e2e/lib/plugins/npm-registry-server.mjs");
     for (const script of [runner, publishedRunner]) {
-      expect(script).toContain("OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org");
-      expect(script).toContain("node scripts/e2e/lib/plugins/npm-registry-server.mjs");
-      expect(script).toContain(
-        "read -r plugin_package_name plugin_package_version plugin_package_tarball",
-      );
+      expect(script).toContain("source scripts/e2e/lib/prepublish-plugin-registry.sh");
+      expect(script).toContain("prepublish_plugin_registry_append_manifest_args");
+      expect(script).toContain("prepublish_plugin_registry_start_npm_server");
+    }
+    expect(registryHelper).toContain(
+      "read -r plugin_package_name plugin_package_version plugin_package_tarball",
+    );
+    for (const script of [runner, publishedRunner]) {
+      expect(script).toContain('registry_args+=("@openclaw/brave-plugin"');
       expect(script).not.toContain("read -r package_name package_version package_tarball");
     }
-    expect(runner).toContain('OPENCLAW_NPM_REGISTRY_DIST_TAGS="beta=$package_version"');
-    expect(publishedRunner).toContain('OPENCLAW_NPM_REGISTRY_DIST_TAGS="beta=$candidate_version"');
+    expect(registryHelper).toContain('OPENCLAW_NPM_REGISTRY_DIST_TAGS="$dist_tags"');
+    expect(runner).toContain('"beta=$package_version"');
+    expect(publishedRunner).toContain('"beta=$candidate_version"');
   });
 
   it("starts the upgrade survivor plugin registry before updates with scenario-owned config", () => {
@@ -2608,18 +2617,13 @@ docker_e2e_docker_run_cmd run demo
       expect(script).not.toContain("/__fixture__/requests");
       expect(script).not.toContain("https://clawhub.ai");
       const emptyRegistryGuardIndex = script.indexOf('if [ "${#registry_args[@]}" -eq 0 ]; then');
-      const fixtureDirectoryIndex = script.indexOf(
-        'mkdir -p "$fixture_root"',
+      const registryStartIndex = script.indexOf(
+        "prepublish_plugin_registry_start_npm_server",
         emptyRegistryGuardIndex,
       );
-      const registryServerIndex = script.indexOf(
-        "OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org",
-      );
       expect(emptyRegistryGuardIndex).toBeGreaterThanOrEqual(0);
-      expect(fixtureDirectoryIndex).toBeGreaterThanOrEqual(0);
-      expect(registryServerIndex).toBeGreaterThanOrEqual(0);
-      expect(emptyRegistryGuardIndex).toBeLessThan(fixtureDirectoryIndex);
-      expect(fixtureDirectoryIndex).toBeLessThan(registryServerIndex);
+      expect(registryStartIndex).toBeGreaterThanOrEqual(0);
+      expect(emptyRegistryGuardIndex).toBeLessThan(registryStartIndex);
       expect(script).not.toContain('\nexport FEISHU_APP_SECRET="upgrade-survivor-feishu-secret"\n');
     }
     expectTextToIncludeAll(publishedRunner, [
@@ -3880,12 +3884,18 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
 
   it("serves the version-matched Codex candidate during package onboarding", () => {
     const runner = readFileSync(CODEX_ON_DEMAND_DOCKER_E2E_PATH, "utf8");
+    const registryHelper = readFileSync(PREPUBLISH_PLUGIN_REGISTRY_HELPER_PATH, "utf8");
 
     expectTextToIncludeAll(runner, [
       "OPENCLAW_DOCKER_ALL_LANES=codex-on-demand",
-      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR=/tmp/openclaw-prepublish-plugin-registry",
+      "prepublish_plugin_registry_mount_args",
+      "prepublish_plugin_registry_append_manifest_args",
+      "prepublish_plugin_registry_start_npm_server",
+      '"latest=0.0.0,beta=${registry_args[1]}"',
+    ]);
+    expectTextToIncludeAll(registryHelper, [
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR=$container_dir",
       "node scripts/e2e/lib/plugins/npm-registry-server.mjs",
-      'OPENCLAW_NPM_REGISTRY_DIST_TAGS="latest=0.0.0,beta=$package_version"',
       "OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org",
     ]);
     expect(runner.indexOf("openclaw_e2e_install_package")).toBeLessThan(

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -100,10 +100,21 @@ describe("package Telegram live Docker E2E", () => {
     const runtimeRun = script.slice(runtimeRunStart);
 
     expect(runtimeRunStart).toBeGreaterThanOrEqual(0);
+    expect(script).toContain('source "$ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"');
+    expect(script).toContain("prepublish_plugin_registry_mount_args");
+    expect(runtimeRun).toContain(
+      '${prepublish_plugin_registry_args[@]+"${prepublish_plugin_registry_args[@]}"}',
+    );
     expect(script).toContain(
       '-e OPENCLAW_E2E_COMMAND_TIMEOUT="${OPENCLAW_E2E_COMMAND_TIMEOUT:-300s}"',
     );
     expect(runtimeRun).toContain("source scripts/lib/openclaw-e2e-instance.sh");
+    expect(runtimeRun).toContain("source scripts/e2e/lib/prepublish-plugin-registry.sh");
+    expect(runtimeRun).toContain("prepublish_plugin_registry_append_manifest_args");
+    expect(runtimeRun).toContain("prepublish_plugin_registry_start_npm_server");
+    expect(runtimeRun.indexOf("\nconfigure_plugin_registry\n")).toBeLessThan(
+      runtimeRun.indexOf('\nif [ "${OPENCLAW_NPM_TELEGRAM_SKIP_HOTPATH:-0}" != "1" ]; then'),
+    );
     expect(runtimeRun).toContain('sut_command="/npm-global/bin/openclaw"');
     expect(runtimeRun).toContain('openclaw_e2e_run_command "$sut_command" --version');
     expect(runtimeRun).toContain('openclaw_e2e_run_command "$sut_command" onboard');

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2672,6 +2672,12 @@ describe("package acceptance workflow", () => {
     expect(workflow).toContain(
       "prepublish_plugin_registry_manifest_sha256: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}",
     );
+    expect(packageTelegram.with?.prepublish_plugin_registry_artifact_run_id).toBe(
+      "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}",
+    );
+    expect(packageTelegram.with?.prepublish_plugin_registry_artifact_run_id).not.toBe(
+      packageTelegram.with?.package_artifact_run_id,
+    );
     expect(workflow).toContain("telegram_scenarios:");
     expect(packageTelegram.with?.scenario).toBe(
       "${{ needs.resolve_package.outputs.telegram_scenarios }}",
@@ -5720,9 +5726,14 @@ describe("package artifact reuse", () => {
       "Artifact-backed Telegram E2E requires the complete immutable artifact and package identity tuple.",
       "Prerelease plugin registry requires the complete immutable artifact and manifest identity tuple.",
       "Prerelease plugin registry requires an artifact-backed Telegram package candidate.",
-      "Prerelease plugin registry and package artifact must come from the same producer run attempt.",
       "PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256",
     ]);
+    expect(validateStep.run).not.toContain(
+      "Prerelease plugin registry and package artifact must come from the same producer run attempt.",
+    );
+    expect(validateStep.run).not.toContain(
+      'PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ID" != "$PACKAGE_ARTIFACT_RUN_ID',
+    );
     expect(identityStep.env).toMatchObject({
       ARTIFACT_DIGEST: "${{ inputs.package_artifact_digest }}",
       ARTIFACT_ID: "${{ inputs.package_artifact_id }}",
@@ -5884,6 +5895,28 @@ describe("package artifact reuse", () => {
     expect(result.stderr).toContain(
       "Artifact-backed Telegram E2E requires all artifact identity fields or none.",
     );
+  });
+
+  it("accepts upstream prerelease registry provenance with a downstream package re-upload", () => {
+    const result = runNpmTelegramInputValidation({
+      PACKAGE_ARTIFACT_DIGEST: "a".repeat(64),
+      PACKAGE_ARTIFACT_ID: "4567",
+      PACKAGE_ARTIFACT_NAME: "package-under-test-456-2",
+      PACKAGE_ARTIFACT_RUN_ATTEMPT: "2",
+      PACKAGE_ARTIFACT_RUN_ID: "456",
+      PACKAGE_FILE_NAME: "openclaw-2026.8.26-1.tgz",
+      PACKAGE_SHA256: "b".repeat(64),
+      PACKAGE_SOURCE_SHA: "c".repeat(40),
+      PACKAGE_VERSION: "2026.8.26-1",
+      PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_DIGEST: "d".repeat(64),
+      PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_ID: "1234",
+      PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_NAME: "prepublish-plugin-registry-123-1",
+      PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ATTEMPT: "1",
+      PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ID: "123",
+      PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256: "e".repeat(64),
+    });
+
+    expect(result.status, result.stderr).toBe(0);
   });
 
   it("uses bounded Convex lease waits instead of GitHub concurrency for CI Telegram consumers", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2654,6 +2654,24 @@ describe("package acceptance workflow", () => {
     expect(workflow).toContain(
       "package_version: ${{ needs.resolve_package.outputs.package_version }}",
     );
+    expect(workflow).toContain(
+      "prepublish_plugin_registry_artifact_name: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}",
+    );
+    expect(workflow).toContain(
+      "prepublish_plugin_registry_artifact_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}",
+    );
+    expect(workflow).toContain(
+      "prepublish_plugin_registry_artifact_digest: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}",
+    );
+    expect(workflow).toContain(
+      "prepublish_plugin_registry_artifact_run_attempt: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}",
+    );
+    expect(workflow).toContain(
+      "prepublish_plugin_registry_artifact_run_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}",
+    );
+    expect(workflow).toContain(
+      "prepublish_plugin_registry_manifest_sha256: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}",
+    );
     expect(workflow).toContain("telegram_scenarios:");
     expect(packageTelegram.with?.scenario).toBe(
       "${{ needs.resolve_package.outputs.telegram_scenarios }}",
@@ -5656,8 +5674,21 @@ describe("package artifact reuse", () => {
       job,
       "Download package-under-test artifact from release run",
     );
+    const currentRunRegistryDownload = workflowStep(
+      job,
+      "Download current-run prerelease plugin registry artifact",
+    );
+    const releaseRunRegistryDownload = workflowStep(
+      job,
+      "Download release-run prerelease plugin registry artifact",
+    );
     const validateStep = workflowStep(job, "Validate inputs and secrets");
     const identityStep = workflowStep(job, "Validate package artifact identity");
+    const registryIdentityStep = workflowStep(
+      job,
+      "Validate prerelease plugin registry artifact identity",
+    );
+    const registryManifestStep = workflowStep(job, "Validate prerelease plugin registry manifest");
     const runStep = workflowStep(job, "Run package Telegram E2E");
 
     expect(currentRunDownload).toEqual({
@@ -5687,6 +5718,10 @@ describe("package artifact reuse", () => {
       "Artifact-backed Telegram E2E requires all artifact identity fields or none.",
       "package_spec must be openclaw@alpha",
       "Artifact-backed Telegram E2E requires the complete immutable artifact and package identity tuple.",
+      "Prerelease plugin registry requires the complete immutable artifact and manifest identity tuple.",
+      "Prerelease plugin registry requires an artifact-backed Telegram package candidate.",
+      "Prerelease plugin registry and package artifact must come from the same producer run attempt.",
+      "PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256",
     ]);
     expect(identityStep.env).toMatchObject({
       ARTIFACT_DIGEST: "${{ inputs.package_artifact_digest }}",
@@ -5710,11 +5745,57 @@ describe("package artifact reuse", () => {
       "Package Telegram artifact creation time is outside the declared producer run attempt.",
       "Package Telegram artifact producer run attempt does not match the requested tuple.",
     ]);
+    expect(registryIdentityStep.if).toBe("inputs.prepublish_plugin_registry_artifact_name != ''");
+    expect(registryIdentityStep.env).toMatchObject({
+      ARTIFACT_DIGEST: "${{ inputs.prepublish_plugin_registry_artifact_digest }}",
+      ARTIFACT_ID: "${{ inputs.prepublish_plugin_registry_artifact_id }}",
+      ARTIFACT_NAME: "${{ inputs.prepublish_plugin_registry_artifact_name }}",
+      ARTIFACT_RUN_ATTEMPT: "${{ inputs.prepublish_plugin_registry_artifact_run_attempt }}",
+      ARTIFACT_RUN_ID: "${{ inputs.prepublish_plugin_registry_artifact_run_id }}",
+    });
+    expectTextToIncludeAll(registryIdentityStep.run, [
+      "actions/artifacts/${ARTIFACT_ID}",
+      '--arg digest "sha256:${ARTIFACT_DIGEST}"',
+      "actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}",
+      "Prerelease plugin registry producer run attempt does not match the requested tuple.",
+      '[[ "$ARTIFACT_NAME" == *"-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}" ]]',
+    ]);
+    expect(currentRunRegistryDownload).toMatchObject({
+      if: "inputs.prepublish_plugin_registry_artifact_name != '' && inputs.prepublish_plugin_registry_artifact_run_id == github.run_id",
+      name: "Download current-run prerelease plugin registry artifact",
+      uses: DOWNLOAD_ARTIFACT_V8,
+      with: {
+        "artifact-ids": "${{ inputs.prepublish_plugin_registry_artifact_id }}",
+        "github-token": "${{ github.token }}",
+        path: ".artifacts/telegram-prepublish-plugin-registry",
+        "run-id": "${{ inputs.prepublish_plugin_registry_artifact_run_id }}",
+      },
+    });
+    expect(releaseRunRegistryDownload).toMatchObject({
+      if: "inputs.prepublish_plugin_registry_artifact_name != '' && inputs.prepublish_plugin_registry_artifact_run_id != github.run_id",
+      name: "Download release-run prerelease plugin registry artifact",
+      uses: DOWNLOAD_ARTIFACT_V8,
+      with: {
+        "artifact-ids": "${{ inputs.prepublish_plugin_registry_artifact_id }}",
+        "github-token": "${{ github.token }}",
+        path: ".artifacts/telegram-prepublish-plugin-registry",
+        "run-id": "${{ inputs.prepublish_plugin_registry_artifact_run_id }}",
+      },
+    });
+    expect(registryManifestStep.env?.EXPECTED_MANIFEST_SHA256).toBe(
+      "${{ inputs.prepublish_plugin_registry_manifest_sha256 }}",
+    );
+    expectTextToIncludeAll(registryManifestStep.run, [
+      ".artifacts/telegram-prepublish-plugin-registry/prepublish-plugin-registry.json",
+      "Prerelease plugin registry manifest SHA-256 differs from the declared identity.",
+    ]);
     expect(runStep.env).toMatchObject({
       PACKAGE_FILE_NAME: "${{ inputs.package_file_name || '' }}",
       PACKAGE_SHA256: "${{ inputs.package_sha256 || '' }}",
       PACKAGE_SOURCE_SHA: "${{ inputs.package_source_sha || '' }}",
       PACKAGE_VERSION: "${{ inputs.package_version || '' }}",
+      PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_NAME:
+        "${{ inputs.prepublish_plugin_registry_artifact_name || '' }}",
     });
     expectTextToIncludeAll(runStep.run, [
       'declared_package_tgz="${package_dir}/${PACKAGE_FILE_NAME}"',
@@ -5732,6 +5813,7 @@ describe("package artifact reuse", () => {
       "Package Telegram artifact source SHA/version differs from the declared identity.",
       'export OPENCLAW_NPM_TELEGRAM_PACKAGE_DIR="${package_dir}"',
       'export OPENCLAW_NPM_TELEGRAM_PACKAGE_TGZ="${package_tgz}"',
+      'export OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR=".artifacts/telegram-prepublish-plugin-registry"',
     ]);
   });
 

--- a/test/scripts/prepublish-plugin-registry-shell.test.ts
+++ b/test/scripts/prepublish-plugin-registry-shell.test.ts
@@ -1,0 +1,52 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const HELPER = "scripts/e2e/lib/prepublish-plugin-registry.sh";
+
+describe("prepublish plugin registry shell helper", () => {
+  it("builds Docker mount args and package registry args from the manifest", () => {
+    const registryDir = tempDirs.make("openclaw-prepublish-registry-");
+    mkdirSync(registryDir, { recursive: true });
+    writeFileSync(
+      join(registryDir, "prepublish-plugin-registry.json"),
+      JSON.stringify({
+        packages: [
+          { name: "@openclaw/codex", version: "2026.7.2", tarball: "codex.tgz" },
+          { name: "@openclaw/telegram", version: "2026.7.2", tarball: "telegram.tgz" },
+        ],
+      }),
+    );
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `
+set -euo pipefail
+source "${HELPER}"
+mount_args=()
+registry_args=()
+prepublish_plugin_registry_mount_args "$1" mount_args
+prepublish_plugin_registry_append_manifest_args "$1/prepublish-plugin-registry.json" registry_args "@openclaw/codex"
+printf 'mount=%s\\n' "\${mount_args[*]}"
+printf 'registry=%s\\n' "\${registry_args[*]}"
+`,
+        "helper-test",
+        registryDir,
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR=/tmp/openclaw-prepublish-plugin-registry",
+    );
+    expect(result.stdout).toContain(`${registryDir}:/tmp/openclaw-prepublish-plugin-registry:ro`);
+    expect(result.stdout).toContain(`registry=@openclaw/codex 2026.7.2 ${registryDir}/codex.tgz`);
+    expect(result.stdout).not.toContain("@openclaw/telegram");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Replaces the uneditable Clownfish automerge source branch from #129784 while preserving @vincentkoc's implementation credit. Package Telegram QA should verify the prerelease OpenClaw package and managed plugins come from the same release run instead of resolving managed plugins from public npm.

Source PR: https://github.com/openclaw/openclaw/pull/129784
Related prior release-harness fix: https://github.com/openclaw/openclaw/pull/120107

## Repair Plan

- Recreate the narrow #129784 release-harness change on current `main`.
- Forward the immutable prerelease plugin registry tuple from Package Acceptance into Package Telegram QA.
- Keep direct Package Acceptance valid without registry provenance, while requiring the complete tuple when any registry field is supplied.
- Centralize verified local npm registry startup in `scripts/e2e/lib/prepublish-plugin-registry.sh` and keep the existing verifier/registry server contract.
- Preserve the source PR attribution in the squash message or co-author trailer as appropriate.

## Validation

- `pnpm check:changed`
- Fresh ClawSweeper review and exact-head CI/merge gate after the replacement PR is opened.

Clownfish 🐠 replacement reef notes:
- Cluster: automerge-openclaw-openclaw-129784
- Source PRs: https://github.com/openclaw/openclaw/pull/129784
- Credit: Credit @vincentkoc as the author of the source implementation in https://github.com/openclaw/openclaw/pull/129784.; Carry #129784 in the replacement PR body as the source PR and preserve attribution for the prerelease plugin-registry Package Telegram QA binding.; Do not close or supersede #129784 in this worker result; closure and merge are blocked by the job frontmatter.
- Validation: pnpm check:changed

fish notes: model gpt-5.5, reasoning medium; reviewed against e634ba6a9be8.
