### PR TITLE
fix(parallels): avoid host networking for macOS upgrades

### DIFF
--- a/scripts/e2e/parallels/macos-smoke.ts
+++ b/scripts/e2e/parallels/macos-smoke.ts
@@ -254,12 +254,6 @@ class MacosSmoke {
         : resolveSnapshot(this.options.vmName, this.options.snapshotHint);
       this.latestVersion = resolveLatestVersion(this.options.latestVersion);
       this.installVersion = this.options.installVersion || this.latestVersion;
-      this.hostIp = resolveHostIp(this.options.hostIp);
-      this.hostPort = await resolveHostPort(
-        this.options.hostPort,
-        this.options.hostPortExplicit,
-        defaultOptions().hostPort,
-      );
 
       say(`VM: ${this.options.vmName}`);
       say(`Snapshot hint: ${this.options.snapshotHint}`);
@@ -274,6 +268,12 @@ class MacosSmoke {
       say(`Run logs: ${this.runDir}`);
 
       if (this.needsHostTgz()) {
+        this.hostIp = resolveHostIp(this.options.hostIp);
+        this.hostPort = await resolveHostPort(
+          this.options.hostPort,
+          this.options.hostPortExplicit,
+          defaultOptions().hostPort,
+        );
         this.artifact = await packOpenClaw({
           destination: this.tgzDir,
           packageSpec: this.options.targetPackageSpec,

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -622,7 +622,7 @@ describe("Parallels smoke model selection", () => {
     ).toBe(false);
   });
 
-  it("starts the default macOS upgrade without building or packaging the host checkout", () => {
+  it("starts the default macOS upgrade without host networking or packaging the checkout", () => {
     const tempDir = makeTempDir(tempDirs, "openclaw-macos-upgrade-no-pack-");
     writeNodeFakePrlctl(
       tempDir,
@@ -652,8 +652,6 @@ describe("Parallels smoke model selection", () => {
         TS_PATHS.macos,
         "--mode",
         "upgrade",
-        "--host-ip",
-        "127.0.0.1",
         "--latest-version",
         "2026.8.25",
         "--api-key-env",
@@ -666,6 +664,7 @@ describe("Parallels smoke model selection", () => {
         env: {
           ...process.env,
           ...fakePrlctlEnv(tempDir),
+          "BASH_FUNC_ifconfig%%": "() { return 1; }",
           OPENCLAW_PARALLELS_ARTIFACT_ROOT: join(tempDir, "artifacts"),
           OPENCLAW_PARALLELS_SKIP_SNAPSHOT_RESTORE: "1",
           OPENCLAW_PARALLELS_TEST_API_KEY: "fixture-not-a-real-credential",
@@ -1106,8 +1105,6 @@ if (commandArgs[0] === "list") {
           "2026.1.1",
           "--target-package-spec",
           "openclaw@2026.1.1",
-          "--host-ip",
-          "127.0.0.1",
           "--api-key-env",
           "OPENCLAW_PARALLELS_TEST_KEY",
           "--json",
@@ -1118,6 +1115,7 @@ if (commandArgs[0] === "list") {
           env: {
             ...process.env,
             ...fakeEnv,
+            "BASH_FUNC_ifconfig%%": "() { return 1; }",
             NODE_OPTIONS: `${fakeEnv.NODE_OPTIONS} --import=${pathToFileURL(npmBootstrapPath).href}`,
             OPENCLAW_PARALLELS_ARTIFACT_ROOT: tempDir,
             OPENCLAW_PARALLELS_TEST_KEY: "fixture",


### PR DESCRIPTION
## Summary

- Resolve the Parallels host IP and reserve a host HTTP port only when the macOS smoke harness actually needs to serve a packaged artifact.
- Let the default release-to-dev upgrade and direct npm-package installs run without a Parallels host-only network adapter or an unused listening port.
- Strengthen the existing real-entrypoint fake-Parallels regressions for the default upgrade and both snapshot states by making host-interface discovery fail deterministically.

The previous upgrade cleanup correctly stopped building and serving an unnecessary host package, but the lifecycle owner still performed host IP discovery and port binding before deciding whether a host server was needed. Hosts without the expected 10.211.x Parallels interface therefore failed immediately with `failed to detect Parallels host IP; pass --host-ip`, before restoring a snapshot or reaching onboarding. Moving the existing preflight into the existing package-server branch fixes the ownership boundary without adding a fallback, changing an option, or affecting fresh/tarball lanes.

## Test plan

- Captured three authentic failures through the real macOS smoke entrypoint and fake Parallels CLI: default upgrade, powered-on direct-package snapshot, and powered-off direct-package snapshot.
- `node scripts/run-vitest.mjs test/scripts/parallels-smoke-model.test.ts -t 'starts the default macOS upgrade without host networking|restores a .* macOS snapshot without discarding its saved desktop session' --maxWorkers=1` — all three pass after the fix.
- `node scripts/run-vitest.mjs test/scripts/parallels-smoke-model.test.ts test/scripts/parallels-npm-update-smoke.test.ts --maxWorkers=1` — 144 macOS, Windows, Linux, and npm-update tests pass.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/e2e/parallels/macos-smoke.ts test/scripts/parallels-smoke-model.test.ts`.
- `pnpm exec oxfmt --check scripts/e2e/parallels/macos-smoke.ts test/scripts/parallels-smoke-model.test.ts`.

Production: +6/-6 (net zero); existing regression tests: +3/-5 (net negative).
