### PR TITLE
fix: macOS onboarding retry silently rechecks a failed AI connection

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -135,6 +135,8 @@ final class OnboardingAISetupModel {
         guard self.configuredGatewayBlocker == nil else { return }
         guard !self.waitingForPendingActivationDeadline else { return }
         if self.pendingActivationVerification {
+            self.detectError = nil
+            self.phase = .detecting
             Task { await self.verifyPendingConfiguredInference() }
             return
         }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -1675,6 +1675,19 @@ struct OnboardingAISetupTests {
         #expect(model.detectError?.detail == "expired login")
         #expect(outcome == .notConnected)
         #expect(isPending(defaults))
+
+        model.retryFromScratch()
+
+        #expect(model.phase == .detecting)
+        #expect(model.detectError == nil)
+        #expect(OnboardingController.shared.busyReason == "OpenClaw is testing your AI connection.")
+
+        await settleQueuedAISetupTasks()
+
+        #expect(model.phase == .ready)
+        #expect(model.detectError?.detail == "expired login")
+        #expect(OnboardingController.shared.busyReason == nil)
+        #expect(await (harness.recorder.snapshot()).methods == ["openclaw.setup.verify", "openclaw.setup.verify"])
     }
 
     @Test func `completed activation receipt survives verification transport failure`() async throws {
@@ -1708,11 +1721,17 @@ struct OnboardingAISetupTests {
         #expect(!model.connected)
         #expect(pendingState(defaults) == .completed)
 
-        let retryOutcome = await model.verifyPendingConfiguredInference()
-        let requests = await waitForAISetupRequests(recorder, count: 2)
+        model.retryFromScratch()
 
-        #expect(retryOutcome == .connected)
+        #expect(model.phase == .detecting)
+        #expect(model.detectError == nil)
+        #expect(OnboardingController.shared.busyReason == "OpenClaw is testing your AI connection.")
+
+        let requests = await waitForAISetupRequests(recorder, count: 2)
+        await settleQueuedAISetupTasks()
+
         #expect(model.connected)
+        #expect(OnboardingController.shared.busyReason == nil)
         #expect(requests.methods == ["openclaw.setup.verify", "openclaw.setup.verify"])
     }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users clicking **Try again** after an existing AI connection failed verification during macOS onboarding saw the previous error remain visible while the retry ran silently, and could close setup without confirmation while the connection was being tested again.

## Why This Change Was Made

The retry owner already scheduled the correct existing-connection verification, but skipped the same visible lifecycle transition used by normal setup attempts. Clear the previous error and synchronously restore the existing verification phase before scheduling the unchanged retry, allowing the existing progress UI and window-close warning to work without changing Gateway activation, authentication, or resume ownership.

## User Impact

Choosing **Try again** now immediately clears the stale error, shows that OpenClaw is checking the AI connection, and protects setup from accidental closure during the check. A successful retry completes onboarding normally; a failed retry restores its actionable error and makes the window closeable again.

## Evidence

- Authentic pre-fix regression: two existing production-backed onboarding fixtures exercised the actual **Try again** owner and produced six failures: both paths retained the stale error, stayed in the ready phase, and left the close warning unset.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path apps/macos --filter 'OpenClawIPCTests.(OnboardingAISetupTests|OnboardingConfiguredGatewayProbeTests|OnboardingViewSmokeTests|CLIInstallerTests)' --no-parallel -j 4`: **165 tests passing** across real onboarding lifecycle, configured Gateway discovery, setup navigation, and installation.
- Both repeated verification failure and successful completed-activation recovery use the actual retry entry point and preserve exactly the expected verification requests.
- `pnpm native:i18n:verify`: **4,245 localization entries unchanged**; configured SwiftFormat and strict SwiftLint pass.
- Independent owner-boundary review and structured Codex review are clean.
- A live signed-app GUI session was unavailable in the headless test environment; the actual native onboarding model, SwiftUI action owner, and real Gateway request fixtures were exercised directly instead.
