### PR TITLE
fix(setup): emit JSON failure for invalid baseline config

### DIFF
--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -465,32 +465,50 @@ describe("setupCommand", () => {
     });
   });
 
-  it("preserves malformed config and stops before setup mutations", async () => {
-    await withTempHome(async (home) => {
-      const runtime = {
-        log: vi.fn(),
-        error: vi.fn(),
-        exit: vi.fn(),
-      };
-      const configDir = path.join(home, ".openclaw");
-      const configPath = path.join(configDir, "openclaw.json");
-      const deps = createSetupDeps(home);
-      const original = Buffer.from('{ "gateway": ', "utf-8");
+  it.each([false, true])(
+    "preserves malformed config and reports failure (json: %s)",
+    async (json) => {
+      await withTempHome(async (home) => {
+        const runtime = {
+          log: vi.fn(),
+          error: vi.fn(),
+          exit: vi.fn(),
+        };
+        const configDir = path.join(home, ".openclaw");
+        const configPath = path.join(configDir, "openclaw.json");
+        const deps = createSetupDeps(home);
+        const original = Buffer.from('{ "gateway": ', "utf-8");
 
-      await fs.mkdir(configDir, { recursive: true });
-      await fs.writeFile(configPath, original);
+        await fs.mkdir(configDir, { recursive: true });
+        await fs.writeFile(configPath, original);
 
-      await setupCommand(undefined, runtime, deps);
+        await setupCommand(json ? { json: true } : undefined, runtime, deps);
 
-      expect(runtime.exit).toHaveBeenCalledWith(1);
-      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("openclaw doctor"));
-      expect(await fs.readFile(configPath)).toStrictEqual(original);
-      expect(deps.replaceConfigFile).not.toHaveBeenCalled();
-      expect(deps.ensureAgentWorkspace).not.toHaveBeenCalled();
-      expect(deps.resolveSessionTranscriptsDir).not.toHaveBeenCalled();
-      expect(deps.mkdir).not.toHaveBeenCalled();
-    });
-  });
+        expect(runtime.exit).toHaveBeenCalledWith(1);
+        expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("openclaw doctor"));
+        if (json) {
+          expect(runtime.log).toHaveBeenCalledOnce();
+          expect(JSON.parse(String(runtime.log.mock.calls[0]?.[0]))).toEqual({
+            ok: false,
+            error: {
+              type: "cli_error",
+              message: "OpenClaw config is invalid: ~/.openclaw/openclaw.json",
+            },
+            issues: expect.arrayContaining([
+              expect.objectContaining({ path: "<root>", message: expect.any(String) }),
+            ]),
+          });
+        } else {
+          expect(runtime.log).not.toHaveBeenCalled();
+        }
+        expect(await fs.readFile(configPath)).toStrictEqual(original);
+        expect(deps.replaceConfigFile).not.toHaveBeenCalled();
+        expect(deps.ensureAgentWorkspace).not.toHaveBeenCalled();
+        expect(deps.resolveSessionTranscriptsDir).not.toHaveBeenCalled();
+        expect(deps.mkdir).not.toHaveBeenCalled();
+      });
+    },
+  );
 
   it.each([
     ["string", '"not-an-object"'],

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -150,6 +150,16 @@ export async function setupCommand(
   const prepared = await io.readConfigFileSnapshotForWrite();
   const snapshot = prepared.snapshot;
   if (snapshot.exists && !snapshot.valid) {
+    if (opts?.json) {
+      const [{ formatCliJsonFailure }, { normalizeConfigIssues }] = await Promise.all([
+        import("../cli/failure-output.js"),
+        import("../config/issue-format.js"),
+      ]);
+      writeRuntimeJson(runtime, {
+        ...formatCliJsonFailure(`OpenClaw config is invalid: ${shortenHomePath(configPath)}`),
+        issues: normalizeConfigIssues(snapshot.issues),
+      });
+    }
     const formatConfigFilePath = deps.formatConfigFilePath ?? formatDefaultConfigPath;
     runtime.error(
       `Config invalid at ${await formatConfigFilePath(configPath)}. Run \`${formatCliCommand("openclaw doctor")}\` to repair it, then re-run setup.`,


### PR DESCRIPTION
## Summary

- Keep baseline setup machine-readable when an existing configuration is invalid: emit the same canonical CLI error envelope and normalized validation issues as onboarding and config validation.
- Preserve the existing doctor guidance on stderr, exit status, malformed config bytes, and zero config, workspace, or session mutations.
- Load JSON failure formatting only on the invalid-config JSON branch so normal baseline setup keeps its existing cold startup path.

## Root cause

Baseline setup intentionally validates its own config snapshot instead of using the normal global config guard. Its failure branch wrote only human stderr and exited, so callers explicitly requesting JSON received an empty stdout even though normal onboarding already returned structured invalid-config failures.

## Validation

- Authentic owner regression reproduced the empty JSON output before the repair.
- Setup owner, setup command registration, and onboarding sibling suites: 149 tests passed.
- Real source CLI baseline command with invalid config: exit 1, exactly one parseable canonical JSON failure with validation issues, and existing doctor guidance on stderr.
- Real human baseline command with the same config: unchanged empty stdout, doctor guidance, and exit 1.
- Focused lint, formatting, independent review, and configured structured Codex review all passed.