### PR TITLE
fix(ui): show agent config errors and hydrated identity avatars

### DIFF
--- a/ui/src/e2e/agent-config-save.e2e.test.ts
+++ b/ui/src/e2e/agent-config-save.e2e.test.ts
@@ -18,6 +18,79 @@ const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "agent
 const requireRecord = createRequireRecord("record", "expected-object-value");
 
 suite.define(() => {
+  it("shows rejected initial configuration loads and recovers when reloaded", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { height: 900, width: 1280 } },
+      async ({ page }) => {
+        const config = { agents: { entries: { main: { default: true } } } };
+        const gateway = await installMockGateway(page, {
+          assistantName: "Main agent",
+          defaultAgentId: "main",
+          methodResponses: {
+            "agents.list": {
+              agents: [{ id: "main", name: "Main agent" }],
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
+            },
+            "config.get": {
+              __mockError: {
+                code: "INTERNAL_ERROR",
+                message: "Agent configuration unavailable; retry Reload Config",
+                retryable: true,
+              },
+            },
+          },
+        });
+
+        expect(
+          (await page.goto(`${suite.server.baseUrl}settings/agents/main/overview`))?.status(),
+        ).toBe(200);
+        await gateway.waitForRequest("agents.list");
+        await gateway.waitForRequest("config.get");
+        const agentsPage = page.locator("openclaw-agents-page");
+        const reload = agentsPage.getByRole("button", { name: "Reload Config" });
+        await reload.waitFor();
+        if (captureUiProof) {
+          await mkdir(proofDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(
+              proofDir,
+              `agent-config-load-${process.env.OPENCLAW_UI_PROOF_LABEL ?? "failed"}.png`,
+            ),
+          });
+        }
+
+        const error = agentsPage
+          .getByRole("alert")
+          .filter({ hasText: "Agent configuration unavailable" });
+        await expect.poll(() => error.isVisible()).toBe(true);
+        await expect
+          .poll(() => agentsPage.locator(".model-picker__select").getAttribute("disabled"))
+          .not.toBeNull();
+
+        await gateway.setMethodResponse("config.get", {
+          config,
+          sourceConfig: config,
+          runtimeConfig: config,
+          hash: "recovered-agent-config",
+          issues: [],
+          raw: JSON.stringify(config),
+          valid: true,
+        });
+        const readsBefore = (await gateway.getRequests("config.get")).length;
+        await reload.click();
+        await gateway.waitForRequest("config.get", { after: readsBefore });
+        await expect.poll(() => error.count()).toBe(0);
+        await expect
+          .poll(() => agentsPage.locator(".model-picker__select").getAttribute("disabled"))
+          .toBeNull();
+      },
+    );
+  });
+
   it("submits keyed entries and surfaces Gateway validation failures", async () => {
     await suite.withPage(
       {

--- a/ui/src/e2e/avatar-initial-emoji.e2e.test.ts
+++ b/ui/src/e2e/avatar-initial-emoji.e2e.test.ts
@@ -164,11 +164,26 @@ suite.define(() => {
       },
       async ({ page }) => {
         const config = { agents: { list: [{ id: "main" }, { id: "emoji" }] } };
+        const hydratedEmojiAgent = { id: "emoji", identity: { name: "Rocket" }, name: "Rocket" };
         const gateway = await installMockGateway(page, {
           defaultAgentId: "main",
           methodResponses: {
-            "agent.identity.get": agentIdentities,
-            "agents.list": agentsList,
+            "agent.identity.get": {
+              cases: [
+                {
+                  match: { agentId: "emoji" },
+                  response: {
+                    agentId: "emoji",
+                    avatar: "",
+                    avatarStatus: "none",
+                    emoji: emojiGrapheme,
+                    name: "Rocket",
+                  },
+                },
+                agentIdentities.cases[1],
+              ],
+            },
+            "agents.list": { ...agentsList, agents: [asciiAgent, hydratedEmojiAgent] },
             "config.get": {
               config,
               sourceConfig: config,
@@ -186,16 +201,22 @@ suite.define(() => {
         await gateway.waitForRequest("config.get");
         const agentSelect = page.locator("openclaw-agents-page openclaw-agent-select");
         await agentSelect.locator(".agent-select__trigger").click();
-        await agentSelect.getByRole("menuitemradio", { name: "🚀Rocket", exact: true }).click();
+        await agentSelect.getByRole("menuitemradio", { name: "Rocket", exact: true }).click();
         await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/emoji/tools");
         await page.getByRole("tab", { name: "Overview", exact: true }).click();
         await expect
           .poll(() => new URL(page.url()).pathname)
           .toBe("/settings/agents/emoji/overview");
         await expect
+          .poll(() => page.locator(".agent-identity-editor__emoji input").inputValue())
+          .toBe(emojiGrapheme);
+        await screenshot(
+          page,
+          `03-agents-overview-${process.env.OPENCLAW_UI_PROOF_LABEL ?? "emoji"}.png`,
+        );
+        await expect
           .poll(() => page.locator(".agent-identity-editor__avatar-text").textContent())
           .toBe(emojiGrapheme);
-        await screenshot(page, "03-agents-overview-emoji.png");
       },
     );
   });

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -952,11 +952,7 @@ class AgentsPage
             loading: configState.configLoading,
             saving: configState.configSaving,
             dirty: configState.configFormDirty,
-            error:
-              configState.configAutoSaveStatus === "error" ||
-              configState.configAutoSaveStatus === "conflict"
-                ? configState.lastError
-                : null,
+            error: configState.lastError,
           },
           channels: {
             snapshot: this.context.channels.state.channelsSnapshot,

--- a/ui/src/pages/agents/panels-overview.ts
+++ b/ui/src/pages/agents/panels-overview.ts
@@ -107,7 +107,8 @@ export function renderAgentOverview(params: {
   const identityAvatarUrl =
     identityDraft.avatar ?? resolveAgentAvatarUrl(agent, params.agentIdentity);
   const identityAvatarText =
-    resolveAgentTextAvatar(agent) ?? (deriveAvatarInitial(identityName || agent.id) || "?");
+    resolveAgentTextAvatar(agent, params.agentIdentity) ??
+    (deriveAvatarInitial(identityName || agent.id) || "?");
   const identityDirty =
     identityDraft.name !== null || identityDraft.emoji !== null || identityDraft.avatar !== null;
   const identityInvalid =

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -109,7 +109,7 @@ describe("renderAgents", () => {
       renderAgents(
         createProps({
           agentIdentityById: {
-            beta: { agentId: "beta", name: "Fetched Beta", avatar: "" },
+            beta: { agentId: "beta", name: "Fetched Beta", avatar: "", emoji: "🦊" },
           },
         }),
       ),
@@ -119,6 +119,7 @@ describe("renderAgents", () => {
     expect(
       container.querySelector<HTMLInputElement>(".agent-identity-editor__fields input")?.value,
     ).toBe("Fetched Beta");
+    expect(container.querySelector(".agent-identity-editor__avatar-text")?.textContent).toBe("🦊");
   });
 
   it("shows a model-catalog failure and lets the operator retry", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes two issues on the Agents Overview page: operators saw disabled configuration controls with no explanation when the initial configuration request failed, and agents with a hydrated identity emoji displayed a letter avatar even though the emoji editor and other agent surfaces already showed the correct emoji.

## Why This Change Was Made

The Agents page incorrectly filtered the shared configuration owner's authoritative error by autosave status, dropping legitimate initial-load and reload failures. Its identity preview also called the canonical text-avatar resolver without the hydrated identity that sibling surfaces already supply. Forwarding the existing error directly and passing the existing hydrated identity fixes both owner-boundary mistakes while deleting three net production lines.

## User Impact

Configuration failures now appear immediately as an accessible alert, with the existing Reload Config control recovering normally and re-enabling the model picker. Agent avatar previews now match the hydrated emoji shown in the identity editor, sidebar, and agent selector.

## Evidence

Before: the configuration request failed, but no error appeared:

![Before: Agents configuration fails silently while controls remain disabled](https://github.com/user-attachments/assets/c96fa948-900f-47aa-9eda-662df383e343)

After: the existing Agents alert explains the failure and points to Reload Config:

![After: Agents shows the configuration error and recovery action](https://github.com/user-attachments/assets/ebd39868-334c-406f-93af-3b4942fe9300)

Before: the hydrated emoji is present in the editor, but the avatar incorrectly shows the name initial:

![Before: hydrated rocket emoji appears in the editor but avatar shows R](https://github.com/user-attachments/assets/9a2aed04-91cf-4e71-bad0-0448616c1621)

After: the Overview avatar uses the same hydrated emoji as sibling agent surfaces:

![After: hydrated rocket emoji appears consistently in the Overview avatar](https://github.com/user-attachments/assets/20043e2b-c5fe-4563-afc9-911bcb4e1eee)

- Red-before: the existing owner test rendered `F` instead of `🦊`; real Chromium independently rendered `R` instead of `🚀` and omitted the initial configuration-failure alert.
- `node scripts/run-vitest.mjs ui/src/pages/agents/view.test.ts ui/src/pages/agents/agents-page.test.ts` — 51 passed.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/avatar-initial-emoji.e2e.test.ts` — three real Chromium scenarios passed, including sidebar and selector siblings.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/agent-config-save.e2e.test.ts` — three real Chromium scenarios passed, including rejected initial load, visible error, successful Reload Config, and existing config-save flows.
- `pnpm tsgo:ui` — passed.
- `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 pnpm check:changed` — comprehensive changed-file gate passed.
- Independent structured Codex full-diff review: clean.
- Production delta: +3/-6, net -3; test coverage added separately.
