### PR TITLE
fix(ui): fill collapsed progress-card selection to the composer edge

### DIFF
--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -225,7 +225,12 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .session-progress-card__summary:hover {
+  /* Collapsed, the visible card extends past the summary (underlap arcs beside
+     the composer's rounded corners), so the highlight lives on the container to
+     fill the whole shape; a summary-only fill leaves slivers of the resting
+     background at those corners. */
+  .session-progress-card--composer:not([open]):hover,
+  .session-progress-card--composer[open] .session-progress-card__summary:hover {
     background: color-mix(
       in srgb,
       var(--text-strong) 5%,


### PR DESCRIPTION
## What Problem This Solves

When the composer progress card is collapsed and hovered/selected, the highlight painted only the `<summary>` band. The visible card shape extends slightly past the summary — the underlap strip and the arcs beside the composer's rounded top corners — so those areas kept the resting background, showing as little gaps of old background around the selection.

## Why This Change Was Made

The collapsed card's visible region is the full rounded container, not just the summary row. The selection fill now lives on the `.session-progress-card--composer:not([open]):hover` container (clipped to the full rounded shape and extending under the composer), so it fills the whole card. The expanded state keeps the summary-scoped hover fill, where highlighting only the header row is the intended behavior.

## User Impact

Hovering the collapsed progress card above the composer now highlights the entire card shape with no background slivers at the composer junction. No behavior change for the expanded card, touch devices, or light mode beyond the same fill correction.

## Evidence

Captured on the mocked Control UI E2E rig (dark mode, 430px viewport, collapsed card hovered); screenshots attached below: full-card before/after and a brightened corner zoom showing the gap arcs filled.

- `node scripts/check-changed.mjs` — pass (stylelint UI style lane, i18n verify, tsgo UI)
- Codex autoreview (`--mode local`, gpt-5.6-sol high): clean, no findings

![before-after](https://github.com/user-attachments/assets/4cd86f20-574e-4219-b5c6-f04ce96f7dbe)

![corner-zoom](https://github.com/user-attachments/assets/ac269c03-b44f-4edd-ac5a-5bcce44ab224)