### PR TITLE
chore(image-generation): remove duplicate live parser test

### DIFF
--- a/src/image-generation/live-test-helpers.test.ts
+++ b/src/image-generation/live-test-helpers.test.ts
@@ -4,7 +4,6 @@ import type { OpenClawConfig } from "../config/config.js";
 import {
   parseCaseFilter,
   parseImageProviderFilter,
-  parseProviderModelMap,
   redactLiveApiKey,
   resolveConfiguredLiveImageModels,
   resolveLiveImageAuthStore,
@@ -22,17 +21,6 @@ describe("image-generation live-test helpers", () => {
     expect(parseCaseFilter("all")).toBeNull();
     expect(parseCaseFilter(" google:flash , openai:default ")).toEqual(
       new Set(["google:flash", "openai:default"]),
-    );
-  });
-
-  it("parses provider model overrides by provider id", () => {
-    expect(
-      parseProviderModelMap("openai/gpt-image-2, google/gemini-3.1-flash-image-preview, invalid"),
-    ).toEqual(
-      new Map([
-        ["openai", "openai/gpt-image-2"],
-        ["google", "google/gemini-3.1-flash-image-preview"],
-      ]),
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

Removes an image-flavored replay of the shared live media provider/model parser test. Image and video wrappers both re-export the exact same `parseProviderModelMap` implementation, so the two identically named cases added maintenance and CI work without detecting separate regressions.

## Why This Change Was Made

The video helper suite retains the parser contract, including comma splitting, provider extraction, map construction, and malformed-entry rejection. Image live tests continue to consume the same shared parser through their wrapper. The image-specific config, provider filter, case filter, auth-store, and credential-redaction tests remain unchanged.

No production code or behavior changes.

## User Impact

No user-visible impact. Maintainers retain shared parser coverage and all image-specific helper coverage with one fewer duplicate test.

## Evidence

- Baseline: image + video live-helper suites — 20/20 passed.
- `node scripts/run-vitest.mjs src/image-generation/live-test-helpers.test.ts src/video-generation/live-test-helpers.test.ts` — 19/19 remaining tests passed.
- `node scripts/check-changed.mjs -- src/image-generation/live-test-helpers.test.ts` — passed, including all core test type shards and targeted oxlint.
- Targeted oxfmt and `git diff --check` — passed.
- Fresh autoreview against the final uncommitted diff — no accepted/actionable findings; patch correct 0.99.

Production LOC: `+0/-0`

Tests: `+0/-12`

AI-assisted test audit. No changelog entry: test-only duplicate deletion with no behavior change.
