### PR TITLE
fix(cli): preserve populated model output on stdout in plain mode

### DIFF
--- a/src/commands/models/aliases.test.ts
+++ b/src/commands/models/aliases.test.ts
@@ -85,6 +85,28 @@ describe("modelsAliasesListCommand", () => {
     expect(runtime.logs).toEqual(lines);
   });
 
+  it("writes populated plain aliases directly to stdout instead of captured logging", async () => {
+    mocks.loadModelsConfig.mockResolvedValue({
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-sonnet-4-6": { alias: "chat" },
+          },
+        },
+      },
+    });
+    const runtime = {
+      ...makeRuntime(),
+      writeStdout: vi.fn(),
+      writeJson: vi.fn(),
+    };
+
+    await modelsAliasesListCommand({ plain: true }, runtime);
+
+    expect(runtime.writeStdout).toHaveBeenCalledExactlyOnceWith("chat anthropic/claude-sonnet-4-6");
+    expect(runtime.logs).toEqual([]);
+  });
+
   it("preserves safely named prototype aliases in deterministic JSON output", async () => {
     mocks.loadModelsConfig.mockResolvedValue({
       agents: {

--- a/src/commands/models/aliases.ts
+++ b/src/commands/models/aliases.ts
@@ -3,7 +3,7 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import { DEFAULT_MODEL_ALIASES } from "../../config/defaults.js";
 import { logConfigUpdated } from "../../config/logging.js";
 import { normalizeAgentModelMapForConfig } from "../../config/model-input.js";
-import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+import { type RuntimeEnv, writeRuntimeJson, writeRuntimeStdout } from "../../runtime.js";
 import { normalizeAlias } from "./alias-name.js";
 import { loadModelsConfig } from "./load-config.js";
 import { ensureFlagCompatibility, resolveModelTarget, updateConfig } from "./shared.js";
@@ -32,7 +32,7 @@ export async function modelsAliasesListCommand(
   }
   if (opts.plain) {
     for (const [alias, target] of aliasEntries) {
-      runtime.log(`${alias} ${target}`);
+      writeRuntimeStdout(runtime, `${alias} ${target}`);
     }
     return;
   }

--- a/src/commands/models/fallbacks-shared.test.ts
+++ b/src/commands/models/fallbacks-shared.test.ts
@@ -57,4 +57,33 @@ describe("listFallbacksCommand", () => {
       fallbacks: [testCase.model],
     });
   });
+
+  it.each([
+    { label: "Fallbacks", key: "model" as const, model: "anthropic/claude-sonnet-4-6" },
+    { label: "Image fallbacks", key: "imageModel" as const, model: "openai/gpt-image-1" },
+  ])("writes populated plain $label directly to stdout", async (testCase) => {
+    mocks.loadModelsConfig.mockResolvedValue({
+      agents: {
+        defaults: {
+          [testCase.key]: { fallbacks: [testCase.model] },
+        },
+      },
+    });
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+      writeStdout: vi.fn(),
+      writeJson: vi.fn(),
+    };
+
+    await listFallbacksCommand(
+      { label: testCase.label, key: testCase.key },
+      { plain: true },
+      runtime,
+    );
+
+    expect(runtime.writeStdout).toHaveBeenCalledExactlyOnceWith(testCase.model);
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
 });

--- a/src/commands/models/fallbacks-shared.ts
+++ b/src/commands/models/fallbacks-shared.ts
@@ -5,7 +5,7 @@ import { logConfigUpdated } from "../../config/logging.js";
 import { resolveAgentModelFallbackValues, toAgentModelListLike } from "../../config/model-input.js";
 import type { AgentModelEntryConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+import { type RuntimeEnv, writeRuntimeJson, writeRuntimeStdout } from "../../runtime.js";
 import { loadModelsConfig } from "./load-config.js";
 import {
   DEFAULT_PROVIDER,
@@ -65,7 +65,7 @@ export async function listFallbacksCommand(
   }
   if (opts.plain) {
     for (const entry of fallbacks) {
-      runtime.log(entry);
+      writeRuntimeStdout(runtime, entry);
     }
     return;
   }

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -82,7 +82,7 @@ import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snaps
 import type { ProviderSyntheticAuthResult } from "../../plugins/provider-external-auth.types.js";
 import { resolveProviderSyntheticAuthWithPlugin } from "../../plugins/provider-runtime.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../../plugins/synthetic-auth.runtime.js";
-import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+import { type RuntimeEnv, writeRuntimeJson, writeRuntimeStdout } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { resolveUserPath, shortenHomePath } from "../../utils.js";
 import {
@@ -1384,7 +1384,7 @@ export async function modelsStatusCommand(
     }
 
     if (opts.plain) {
-      runtime.log(resolvedLabel);
+      writeRuntimeStdout(runtime, resolvedLabel);
       finishModelsStatusOutput(runtime, opts.check, checkStatus);
       return;
     }

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -1959,12 +1959,18 @@ describe("modelsStatusCommand auth overview", () => {
   it("exits non-zero when auth is missing", async () => {
     const originalProfiles = { ...mocks.store.profiles };
     mocks.store.profiles = {};
-    const localRuntime = createRuntime();
+    const localRuntime = {
+      ...createRuntime(),
+      writeStdout: vi.fn(),
+      writeJson: vi.fn(),
+    };
     const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
     mocks.resolveEnvApiKey.mockImplementation(() => null);
 
     try {
       await modelsStatusCommand({ check: true, plain: true }, localRuntime as never);
+      expect(localRuntime.writeStdout).toHaveBeenCalledOnce();
+      expect(localRuntime.log).not.toHaveBeenCalled();
       expect(localRuntime.exit).toHaveBeenCalledWith(1);
     } finally {
       mocks.store.profiles = originalProfiles;

--- a/src/commands/models/list.table.test.ts
+++ b/src/commands/models/list.table.test.ts
@@ -25,6 +25,33 @@ describe("printModelTable", () => {
     expect(runtime.log).not.toHaveBeenCalled();
   });
 
+  it("writes populated plain model rows directly to stdout", () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+      writeStdout: vi.fn(),
+      writeJson: vi.fn(),
+    };
+    const rows: ModelRow[] = [
+      {
+        key: "anthropic/claude-sonnet-4-6",
+        name: "Claude Sonnet",
+        input: "text",
+        contextWindow: 200_000,
+        local: false,
+        available: true,
+        tags: [],
+        missing: false,
+      },
+    ];
+
+    printModelTable(rows, runtime, { plain: true });
+
+    expect(runtime.writeStdout).toHaveBeenCalledExactlyOnceWith("anthropic/claude-sonnet-4-6");
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
   it("prints effective and native context values when a runtime cap differs", () => {
     const runtime = { log: vi.fn(), error: vi.fn() };
     const rows: ModelRow[] = [

--- a/src/commands/models/list.table.ts
+++ b/src/commands/models/list.table.ts
@@ -1,7 +1,7 @@
 /** Terminal/JSON/plain table renderer for model-list rows. */
 import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import { colorize, theme } from "../../../packages/terminal-core/src/theme.js";
-import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+import { type RuntimeEnv, writeRuntimeJson, writeRuntimeStdout } from "../../runtime.js";
 import { formatTag, formatTokenK, isRich, padTerminalCell, truncate } from "./list.format.js";
 import type { ModelRow } from "./list.types.js";
 
@@ -39,7 +39,7 @@ export function printModelTable(
 
   if (opts.plain) {
     for (const row of rows) {
-      runtime.log(sanitizeTerminalText(row.key));
+      writeRuntimeStdout(runtime, sanitizeTerminalText(row.key));
     }
     return;
   }

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
-import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../src/agents/defaults.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "../src/state/openclaw-state-schema.js";
 
 function runBuiltCli(
@@ -706,34 +705,60 @@ describe("cli json stdout contract", () => {
       name: "aliases list",
       args: ["models", "aliases", "list", "--plain"],
       opensStateDatabase: false,
+      expectedStdout: "chat anthropic/claude-sonnet-4-6\n",
     },
     {
       name: "fallbacks list",
       args: ["models", "fallbacks", "list", "--plain"],
       opensStateDatabase: false,
+      expectedStdout: "anthropic/claude-sonnet-4-6\n",
     },
     {
       name: "image fallbacks list",
       args: ["models", "image-fallbacks", "list", "--plain"],
       opensStateDatabase: false,
+      expectedStdout: "anthropic/claude-sonnet-4-6\n",
     },
     {
       name: "list control",
       args: ["models", "list", "--plain"],
       opensStateDatabase: true,
+      expectedStdout: "anthropic/claude-sonnet-4-6\n",
     },
     {
       name: "status control",
       args: ["models", "status", "--plain"],
       opensStateDatabase: true,
-      expectedStdout: `${DEFAULT_PROVIDER}/${DEFAULT_MODEL}\n`,
+      expectedStdout: "anthropic/claude-sonnet-4-6\n",
+    },
+    {
+      name: "parent status control",
+      args: ["models", "--status-plain"],
+      opensStateDatabase: true,
+      expectedStdout: "anthropic/claude-sonnet-4-6\n",
     },
   ])("keeps $name stdout exact during a pending state migration", async (testCase) => {
     await withTempHome(
       async (tempHome) => {
         const stateDir = path.join(tempHome, "isolated-state");
+        const configPath = path.join(tempHome, "openclaw.json");
         const migrationDiagnostic = "state database schema migration pending";
         await seedPendingStateMigration(stateDir);
+        await fs.writeFile(
+          configPath,
+          JSON.stringify({
+            agents: {
+              defaults: {
+                model: {
+                  primary: "anthropic/claude-sonnet-4-6",
+                  fallbacks: ["anthropic/claude-sonnet-4-6"],
+                },
+                imageModel: { fallbacks: ["anthropic/claude-sonnet-4-6"] },
+                models: { "anthropic/claude-sonnet-4-6": { alias: "chat" } },
+              },
+            },
+          }),
+        );
 
         const result = runBuiltCli(
           tempHome,
@@ -741,14 +766,14 @@ describe("cli json stdout contract", () => {
           {
             CI: "1",
             NO_COLOR: "1",
-            OPENCLAW_CONFIG_PATH: path.join(tempHome, "missing-openclaw.json"),
+            OPENCLAW_CONFIG_PATH: configPath,
             OPENCLAW_STATE_DIR: stateDir,
           },
           { inheritEnvironment: false },
         );
 
         expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout).toBe("expectedStdout" in testCase ? testCase.expectedStdout : "");
+        expect(result.stdout).toBe(testCase.expectedStdout);
         expect(result.stdout).not.toContain(migrationDiagnostic);
         expect(result.stderr.includes(migrationDiagnostic)).toBe(testCase.opensStateDatabase);
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users piping populated model aliases or text/image fallback lists in plain mode would receive an empty stdout stream even though the command succeeded, because the actual model payload was incorrectly emitted on stderr. The same output-ownership mistake also affected the model list and status producers.

Related: #129037

## Why This Change Was Made

Plain machine-readable output must use the existing direct-stdout runtime writer while diagnostic logging remains routed to stderr. Reusing that canonical writer in all four model output owners repairs aliases, text fallbacks, image fallbacks, model lists, model status, and the parent status shortcut without changing JSON, human-readable output, model sanitization, or status-check exit behavior. Production code delta: +8/-8 (net zero).

## User Impact

Operators and scripts once again receive populated model aliases, fallback entries, model lists, and status values on stdout, while startup/state-migration diagnostics remain isolated on stderr.

## Evidence

Actual current-source CLI with a populated isolated configuration, before this change:

```text
models aliases list --plain: exit=0 stdout="" stderr="backup openai/gpt-5.6-luna\\nchat anthropic/claude-sonnet-4-6\\nvision google/gemini-2.5-flash-image\\n"
models fallbacks list --plain: exit=0 stdout="" stderr="openai/gpt-5.6-luna\\n"
models image-fallbacks list --plain: exit=0 stdout="" stderr="google/gemini-2.5-flash-image\\n"
```

Same actual current-source CLI and populated configuration after the owner repair:

```text
models aliases list --plain: exit=0 stdout="backup openai/gpt-5.6-luna\\nchat anthropic/claude-sonnet-4-6\\nvision google/gemini-2.5-flash-image\\n" stderr=""
models fallbacks list --plain: exit=0 stdout="openai/gpt-5.6-luna\\n" stderr=""
models image-fallbacks list --plain: exit=0 stdout="google/gemini-2.5-flash-image\\n" stderr=""
models aliases list --json: exit=0, existing structured stdout preserved
models aliases list: exit=0, existing human-readable stdout preserved
```

- `node scripts/run-vitest.mjs src/commands/models/aliases.test.ts src/commands/models/fallbacks-shared.test.ts src/commands/models/list.table.test.ts src/commands/models/list.status.test.ts`: **59 tests passed** across both command shards.
- New populated owner regressions cover aliases, both fallback families, sanitized model-list rows, and plain status with its existing failed-auth exit behavior; the status regression failed on unchanged production before the fix.
- The existing built-process migration E2E now uses populated model configuration and asserts exact nonempty stdout for six real command forms, while separately checking migration diagnostics stay on stderr. The isolated task worktree has no built `dist/` tree, so this built-artifact suite is delegated to fresh exact-head hosted CI; the current-source CLI processes and all owner suites were run locally.
- Independent owner-boundary review: approved; mandatory automated Codex review: clean, no actionable findings.
