### PR TITLE
fix(macos): show how to recover when the Mac node fails to start

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeServiceManager.swift
+++ b/apps/macos/Sources/OpenClaw/NodeServiceManager.swift
@@ -148,12 +148,11 @@ extension NodeServiceManager {
 
     private static func errorMessage(from result: CommandResult, treatNotLoadedAsError: Bool) -> String? {
         if !result.success {
-            return result.message ?? "Node service command failed"
+            return result.parsed.flatMap {
+                self.mergeHints(message: $0.error ?? $0.message, hints: $0.hints)
+            } ?? result.message ?? "Node service command failed"
         }
         guard let parsed = result.parsed else { return nil }
-        if parsed.ok == false {
-            return self.mergeHints(message: parsed.error ?? parsed.message, hints: parsed.hints)
-        }
         if treatNotLoadedAsError, parsed.result == "not-loaded" {
             let base = parsed.message ?? "Node service not loaded."
             return self.mergeHints(message: base, hints: parsed.hints)

--- a/apps/macos/Tests/OpenClawIPCTests/NodeServiceManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/NodeServiceManagerTests.swift
@@ -99,6 +99,8 @@ import Testing
 
     @Test(arguments: [
         "failed-start", "failed-stop", "failed-restart", "json-success", "plain-success", "json-failure",
+        "json-failure-with-hints", "json-failure-with-hints-and-exit", "json-failure-hints-only",
+        "not-loaded-start", "not-loaded-stop",
     ])
     func `node lifecycle respects process exit and optional JSON status`(_ scenario: String) async throws {
         let root = try makeTempDirForTests()
@@ -116,6 +118,18 @@ import Testing
             case "$OPENCLAW_NODE_SERVICE_TEST_CASE" in
               failed-*) printf '{"ok":true}'; printf 'cleanup failed' >&2; exit 23 ;;
               json-failure) printf '{"ok":false,"error":"reported failure"}' ;;
+              json-failure-with-hints*)
+                printf '{"ok":false,"error":"Node service not installed.",'
+                printf '"hints":["openclaw node install","openclaw node start","third hint"]}'
+                if [ "$OPENCLAW_NODE_SERVICE_TEST_CASE" = "json-failure-with-hints-and-exit" ]; then exit 1; fi
+                ;;
+              json-failure-hints-only)
+                printf '{"ok":false,"hints":["openclaw node install","openclaw node start"]}'
+                ;;
+              not-loaded-*)
+                printf '{"ok":true,"result":"not-loaded","message":"Node service not loaded.",'
+                printf '"hints":["openclaw node install","openclaw node start"]}'
+                ;;
               plain-success) printf 'service started' ;;
               *) printf '{"ok":true}' ;;
             esac
@@ -123,13 +137,18 @@ import Testing
             try script.write(to: executable, atomically: false, encoding: .utf8)
 
             let action = switch scenario {
-            case "failed-stop": "stop"
+            case "failed-stop", "not-loaded-stop": "stop"
             case "failed-restart": "restart"
             default: "start"
             }
             let expectedError: String? = switch scenario {
             case "failed-start", "failed-stop", "failed-restart": "cleanup failed"
             case "json-failure": "reported failure"
+            case "json-failure-with-hints", "json-failure-with-hints-and-exit":
+                "Node service not installed. (openclaw node install · openclaw node start)"
+            case "json-failure-hints-only": "openclaw node install · openclaw node start"
+            case "not-loaded-start":
+                "Node service not loaded. (openclaw node install · openclaw node start)"
             default: nil
             }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users connecting the macOS app to a remote Gateway would see that their Mac node could not start, but not the actual `openclaw node install` and `openclaw node start` commands needed to repair it. The same missing recovery guidance affected managed post-update failures.

## Why This Change Was Made

The CLI already returns structured recovery hints alongside unsuccessful node-service results. The native service owner returned its generic failure message before merging those hints, leaving its explicit structured-failure branch unreachable. Merge parsed failure details and bounded recovery hints in the canonical failure path, then fall back to existing raw or generic errors. This removes the dead branch and reduces production code by one line.

## User Impact

Remote Mac-node startup and update failures now explain how to install or start the missing service. Existing subprocess exit failures, fallback diagnostics, profile isolation, lifecycle ordering, successful responses, and idempotent stop behavior remain unchanged.

## Evidence

- Authentic pre-fix regression: the existing executable-backed `NodeServiceManager.start()` fixture failed three cases covering structured failures with exit zero, the real CLI failure with exit one, and recovery hints without a separate error message.
- Final owner verification passed all six native tests, including eleven lifecycle cases:

  ```sh
  DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path apps/macos --filter OpenClawIPCTests.NodeServiceManagerTests --no-parallel -j 4
  ```

- Seven affected owner, caller, installer, launch-agent, onboarding, and update suites passed 103 tests:

  ```sh
  DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path apps/macos --filter 'OpenClawIPCTests\.(NodeServiceManagerTests|GatewayLaunchAgentManagerTests|UpdateOrchestrationTests|ConnectionModeCoordinatorTests|NodesStoreTests|OnboardingViewSmokeTests|CLIInstallerTests)' --no-parallel -j 4
  ```

- `swiftlint lint --config config/swiftlint.yml apps/macos/Sources/OpenClaw/NodeServiceManager.swift apps/macos/Tests/OpenClawIPCTests/NodeServiceManagerTests.swift` completed with zero violations.
- `swiftformat --lint apps/macos/Sources/OpenClaw/NodeServiceManager.swift apps/macos/Tests/OpenClawIPCTests/NodeServiceManagerTests.swift --config config/swiftformat` passed.
- `node --import tsx scripts/native-app-i18n.ts verify` passed; no native localization strings changed.
- Independent human-boundary review and structured Codex review reported no actionable findings.
- Live UI capture was not feasible: reproducing this failure in the installed app would launch the operator's app and mutate the operator-owned node LaunchAgent, both explicitly prohibited for this task. The real subprocess-backed native fixture exercises the exact production error consumed by the macOS node menu and post-update flow.
