### PR TITLE
fix(matrix): preserve approval reactions after Gateway failures

### DIFF
--- a/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
@@ -372,6 +372,52 @@ describe("matrix approval reactions", () => {
     ).toBeNull();
   });
 
+  it("retains approval anchors and propagates transient Gateway failures for replay", async () => {
+    const core = buildCore();
+    const cfg = buildConfig();
+    registerMatrixApprovalReactionTarget({
+      roomId: "!ops:example.org",
+      eventId: "$approval-msg",
+      approvalId: "req-123",
+      approvalKind: "exec",
+      allowedDecisions: ["allow-once"],
+    });
+    const client = createReactionClient();
+    resolveMatrixApproval.mockRejectedValueOnce(new Error("gateway 503"));
+
+    await expect(handleReaction({ client, core, cfg })).rejects.toThrow("gateway 503");
+    expect(
+      await resolveMatrixApprovalReactionTargetWithPersistence({
+        accountId: "default",
+        roomId: "!ops:example.org",
+        eventId: "$approval-msg",
+        reactionKey: "✅",
+      }),
+    ).not.toBeNull();
+
+    await handleReaction({ client, core, cfg });
+
+    expect(
+      await resolveMatrixApprovalReactionTargetWithPersistence({
+        accountId: "default",
+        roomId: "!ops:example.org",
+        eventId: "$approval-msg",
+        reactionKey: "✅",
+      }),
+    ).toBeNull();
+    expect(resolveMatrixApproval).toHaveBeenCalledTimes(2);
+    expect(resolveMatrixApproval).toHaveBeenLastCalledWith({
+      cfg,
+      approvalId: "req-123",
+      approvalKind: "exec",
+      decision: "allow-once",
+      channel: "matrix",
+      accountId: "default",
+      senderId: "@owner:example.org",
+    });
+    expect(core.system.enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
   it("terminalizes every sibling prompt when this surface wins", async () => {
     const core = buildCore();
     const cfg = buildConfig();

--- a/extensions/matrix/src/matrix/monitor/reaction-events.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.ts
@@ -166,7 +166,7 @@ async function maybeResolveMatrixApprovalReaction(params: {
     params.logVerboseMessage(
       `matrix: approval reaction failed id=${params.target.approvalId} sender=${params.senderId}: ${String(err)}`,
     );
-    return true;
+    throw err;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix users approving an execution or plugin request with a reaction would see no outcome when the Gateway temporarily failed, and the same approval reaction could not be replayed after recovery.

## Why This Change Was Made

The Matrix approval reaction owner treated non-terminal Gateway errors as successfully consumed reactions. That caused the inbound owner to commit its durable replay claim even though the approval never resolved. Propagating the original error lets the existing inbound owner report it and release the uncommitted claim, while retaining the original approval anchor for an authorized replay. Sender authorization, reviewer identity, approval authority, terminal cleanup, and expired-approval behavior remain unchanged. Production delta: +1/-1 (net zero).

## User Impact

Operators can recover a Matrix approval reaction after a temporary Gateway outage instead of losing the action silently and waiting for the approval to expire.

## Evidence

- Tests-first owner regression: before the fix, the authorized Matrix reaction incorrectly resolved successfully instead of rejecting the injected `gateway 503` error; after the fix, the error propagates, the exact account/room/event approval anchor remains registered, and replay resolves the same approval and retires its anchor.
- Matrix owner, inbound handler, durable replay deduplication, approval-reaction authorization, approval anchors, and execution-approval suites: **218 tests passed across 6 suites**.
- iMessage approval sibling suite: **35 tests passed**. Total: **253 tests passed**.
- Strict production TypeScript project: 10,837 source files, zero diagnostics; strict test TypeScript project: 10,887 source files, zero diagnostics.
- Canonical formatting, targeted oxlint, assertion-safety ratchet, maximum-lines ratchet, and `git diff --check` all passed.
- Independent owner/security-boundary review and authenticated Codex review: no findings.
- Live authenticated Matrix proof was not available because this task has no isolated configured Matrix homeserver or account; the authentic reaction-handler, Gateway-failure, replay-anchor, and full inbound-owner regressions exercise the changed channel boundary instead.
