### PR TITLE
fix(i18n): include concatenated Apple UI strings

### DIFF
--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -25,16 +25,6 @@ const IOS_SOURCE_PREFIXES = [
   SHARED_CHAT_UI_SOURCE_PREFIX,
   "apps/shared/OpenClawKit/Sources/OpenClawKit/",
 ] as const;
-const APPLE_CATALOG_KINDS = new Set([
-  "conditional-branch",
-  "ui-call",
-  "ui-call-multiline",
-  "ui-localized-call",
-  "ui-localized-call-multiline",
-  "ui-modifier",
-  "ui-named-argument",
-  "ui-named-argument-multiline",
-]);
 const IOS_CATALOG_EXCLUSIONS = new Set([
   // Product names and preview-only single-character fixtures are intentionally verbatim.
   "OpenClaw",
@@ -574,13 +564,17 @@ async function readOptionalFile(filePath: string): Promise<string | null> {
   }
 }
 
+function isAppleCatalogKind(kind: string): boolean {
+  return kind === "conditional-branch" || kind.startsWith("ui-");
+}
+
 function isIosCatalogEntry(entry: NativeSourceEntry): boolean {
   return (
     entry.surface === "apple" &&
     entry.sites.some(
       (site) =>
         IOS_SOURCE_PREFIXES.some((prefix) => site.path.startsWith(prefix)) &&
-        APPLE_CATALOG_KINDS.has(site.kind),
+        isAppleCatalogKind(site.kind),
     ) &&
     (!entry.source.includes("\\(") || isInflectedCountSource(entry.source)) &&
     !IOS_CATALOG_EXCLUSIONS.has(entry.source)
@@ -593,7 +587,7 @@ function isMacosCatalogEntry(entry: NativeSourceEntry): boolean {
     entry.sites.some(
       (site) =>
         MACOS_SOURCE_PREFIXES.some((prefix) => site.path.startsWith(prefix)) &&
-        APPLE_CATALOG_KINDS.has(site.kind),
+        isAppleCatalogKind(site.kind),
     ) &&
     !entry.source.includes("\\(") &&
     !MACOS_CATALOG_EXCLUSIONS.has(entry.source)

--- a/test/scripts/apple-app-i18n.test.ts
+++ b/test/scripts/apple-app-i18n.test.ts
@@ -222,6 +222,21 @@ describe("Apple app i18n catalogs", () => {
   });
 
   it("routes merged sites by coupled path and kind while preserving shipped translations", () => {
+    const concatenatedMacosEntries = [
+      { kind: "ui-call-concatenated", source: "Call concatenated" },
+      {
+        kind: "ui-localized-call-concatenated",
+        source:
+          "Older generated approvals are inactive because they were not tied to a working directory. Manual rules are unchanged.",
+      },
+      { kind: "ui-modifier-concatenated", source: "Modifier concatenated" },
+      { kind: "ui-named-argument-concatenated", source: "Named argument concatenated" },
+    ].map(({ kind, source }, index) => ({
+      id: `native.apple.concatenated.${index}`,
+      source,
+      surface: "apple",
+      sites: [{ kind, path: "apps/macos/Sources/OpenClaw/Example.swift" }],
+    }));
     const inventory = {
       version: 2,
       entries: [
@@ -243,6 +258,7 @@ describe("Apple app i18n catalogs", () => {
             { kind: "ui-call", path: "outside/Example.swift" },
           ],
         },
+        ...concatenatedMacosEntries,
       ],
     };
     const existing = {
@@ -278,6 +294,10 @@ describe("Apple app i18n catalogs", () => {
     });
     expect(ios.catalog.strings?.["Do not catalog"]).toBeUndefined();
     expect(macos.catalog.strings?.["Connect now"]).toBeDefined();
+    expect(Object.keys(macos.catalog.strings ?? {})).toEqual(
+      expect.arrayContaining(concatenatedMacosEntries.map((entry) => entry.source)),
+    );
+    expect(macos.catalog.strings?.["Do not catalog"]).toBeUndefined();
     expect(ios.contradictions).toEqual([]);
   });
 

--- a/test/scripts/apple-app-i18n.test.ts
+++ b/test/scripts/apple-app-i18n.test.ts
@@ -222,7 +222,7 @@ describe("Apple app i18n catalogs", () => {
   });
 
   it("routes merged sites by coupled path and kind while preserving shipped translations", () => {
-    const concatenatedMacosEntries = [
+    const coveredMacosEntries = [
       { kind: "ui-call-concatenated", source: "Call concatenated" },
       {
         kind: "ui-localized-call-concatenated",
@@ -230,6 +230,7 @@ describe("Apple app i18n catalogs", () => {
           "Older generated approvals are inactive because they were not tied to a working directory. Manual rules are unchanged.",
       },
       { kind: "ui-modifier-concatenated", source: "Modifier concatenated" },
+      { kind: "ui-modifier-multiline", source: "Modifier multiline" },
       { kind: "ui-named-argument-concatenated", source: "Named argument concatenated" },
     ].map(({ kind, source }, index) => ({
       id: `native.apple.concatenated.${index}`,
@@ -258,7 +259,7 @@ describe("Apple app i18n catalogs", () => {
             { kind: "ui-call", path: "outside/Example.swift" },
           ],
         },
-        ...concatenatedMacosEntries,
+        ...coveredMacosEntries,
       ],
     };
     const existing = {
@@ -295,7 +296,7 @@ describe("Apple app i18n catalogs", () => {
     expect(ios.catalog.strings?.["Do not catalog"]).toBeUndefined();
     expect(macos.catalog.strings?.["Connect now"]).toBeDefined();
     expect(Object.keys(macos.catalog.strings ?? {})).toEqual(
-      expect.arrayContaining(concatenatedMacosEntries.map((entry) => entry.source)),
+      expect.arrayContaining(coveredMacosEntries.map((entry) => entry.source)),
     );
     expect(macos.catalog.strings?.["Do not catalog"]).toBeUndefined();
     expect(ios.contradictions).toEqual([]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where compile-time concatenated Apple UI strings were present in the native source inventory but omitted from derived iOS and macOS string catalogs. The affected macOS approval explanation was therefore missing from the generated localization catalog.

## Why This Change Was Made

The native extractor already treats every `ui-*` kind as direct UI text, but the Apple catalog consumer duplicated that policy as a finite allowlist. This change removes the stale enumeration and uses one predicate that accepts `conditional-branch` or any `ui-*` kind for both Apple catalog filters.

The regression extends the existing path-and-kind routing test across all four currently emitted concatenated families plus the producer-valid `ui-modifier-multiline` kind, while preserving plist and outside-path exclusions. Generated catalogs and locale artifacts are intentionally left to the post-merge refresh workflow.

## User Impact

Concatenated Swift UI copy now reaches Apple localization catalogs consistently, including:

`Older generated approvals are inactive because they were not tied to a working directory. Manual rules are unchanged.`

## Evidence

Pre-fix `buildMacosCatalog()` reproduction:

```json
{
  "exactPresent": false,
  "kinds": [
    { "kind": "ui-call-concatenated", "present": false },
    { "kind": "ui-localized-call-concatenated", "present": false },
    { "kind": "ui-modifier-concatenated", "present": false },
    { "kind": "ui-named-argument-concatenated", "present": false }
  ],
  "keys": []
}
```

Post-fix reproduction reports `exactPresent: true` and `present: true` for all four families.
The owner-boundary regression also covers `ui-modifier-multiline`, which is emitted by the native Apple extractor and intentionally accepted by the canonical `ui-*` predicate.

Validation:

- `pnpm test test/scripts/apple-app-i18n.test.ts` - 16 passed
- `pnpm native:i18n:verify` - 4,245 entries, unchanged inventory; 1,300 macOS source keys
- `pnpm tsgo:scripts`
- `pnpm tsgo:test:root`
- targeted Oxc lint for `scripts/apple-app-i18n.ts`
- changed-file format, conflict, dependency, erasability, Docker boundary, raw HTTP/2, and diff checks
- production/tooling LOC: `+6/-12` (net `-6`)
- tests: `+21/-0`

Independent review judged the fix ship-worthy and identified one P3 adjacent test gap for `ui-modifier-multiline`; the current head addresses it. A fresh ClawSweeper review is requested on this exact head.

AI-assisted: yes. The implementation and verification above were reviewed directly.
