### PR TITLE
chore(telegram): remove duplicate durable target test

### DIFF
--- a/extensions/telegram/src/targets.test.ts
+++ b/extensions/telegram/src/targets.test.ts
@@ -138,10 +138,6 @@ describe("telegram numeric target normalization", () => {
 });
 
 describe("normalizeTelegramOutboundTarget", () => {
-  it("normalizes legacy durable group retry targets for Telegram sends", () => {
-    expect(normalizeTelegramOutboundTarget("group:-1001234567890")).toBe("-1001234567890");
-  });
-
   it("normalizes legacy durable group retry targets with topic suffixes", () => {
     expect(normalizeTelegramOutboundTarget("group:-1001234567890:topic:77")).toBe(
       "-1001234567890:topic:77",


### PR DESCRIPTION
## What Problem This Solves

Removes a direct helper assertion that strictly repeats the legacy durable-group target behavior already covered through Telegram's outbound delivery boundary. Both tests were introduced together for the same retry-target regression, so the helper-level replay added maintenance without detecting another failure.

## Why This Change Was Made

`outbound-adapter.test.ts` retains the identical `group:-1001234567890` input and verifies that the normalized numeric chat reaches the send transport. The helper suite keeps distinct topic, shorthand-topic, direct-topic, valid numeric, invalid group, and username cases. No production code or Telegram behavior changes.

## User Impact

No user-visible impact. Durable retry normalization remains protected at the real outbound send boundary, with unique helper edge cases retained.

## Evidence

- Baseline: `targets.test.ts` + `outbound-adapter.test.ts` — 80/80 passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/targets.test.ts extensions/telegram/src/outbound-adapter.test.ts` — 79/79 remaining tests passed.
- `node scripts/check-changed.mjs -- extensions/telegram/src/targets.test.ts` — passed, including extension test types and targeted oxlint.
- Targeted oxfmt and `git diff --check` — passed.
- Fresh autoreview against the final diff — no accepted/actionable findings; patch correct 0.99.

Production LOC: `+0/-0`

Tests: `+0/-4`

AI-assisted test audit. No changelog entry: test-only strict-subset deletion with no behavior change.
