### PR TITLE
fix(providers): recover conversations after encrypted reasoning stream rejection

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -963,6 +963,21 @@ describe("processResponsesStream", () => {
       status: 500,
       expected: false,
     },
+    {
+      message: "Could not decrypt the provided encrypted_content.",
+      status: 400,
+      expected: true,
+    },
+    {
+      message: "Could not decrypt the provided encrypted_content.",
+      status: 500,
+      expected: false,
+    },
+    {
+      message: "Could not decrypt encrypted_content metadata for the OAuth sidecar.",
+      status: 400,
+      expected: false,
+    },
     { message: "400 The certificate could not be verified.", status: undefined, expected: false },
     { message: "400 The upload could not be decrypted.", status: undefined, expected: false },
   ])(

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -10,6 +10,7 @@ import {
   buildOpenAIResponsesReasoningReplayMetadata,
   captureOpenAIResponsesCompaction,
 } from "../transports/openai-responses-compaction-replay.js";
+import { isInvalidEncryptedContentError } from "../transports/openai-responses-replay-internal.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
 import type { AssistantMessage, AssistantMessageEvent, Context, Model, Tool } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
@@ -946,6 +947,31 @@ describe("convertResponsesMessages", () => {
 });
 
 describe("processResponsesStream", () => {
+  it.each([
+    {
+      message: "400 The encrypted content could not be verified.",
+      status: undefined,
+      expected: true,
+    },
+    {
+      message: "The encrypted content could not be decrypted or parsed.",
+      status: 400,
+      expected: true,
+    },
+    {
+      message: "400 The encrypted content could not be verified.",
+      status: 500,
+      expected: false,
+    },
+    { message: "400 The certificate could not be verified.", status: undefined, expected: false },
+    { message: "400 The upload could not be decrypted.", status: undefined, expected: false },
+  ])(
+    "classifies encrypted replay rejection $expected: $message",
+    ({ message, status, expected }) => {
+      expect(isInvalidEncryptedContentError({ message, status })).toBe(expected);
+    },
+  );
+
   it("aborts the Responses request signal when the first SSE event never arrives", async () => {
     vi.useFakeTimers();
     try {
@@ -1051,6 +1077,231 @@ describe("processResponsesStream", () => {
 
     expect(requestMaxRetries).toBe(expected);
     expect(output.stopReason).toBe("stop");
+  });
+
+  it.each([
+    "create",
+    "iterator",
+    "response.failed",
+    "response.failed-status",
+    "error",
+    "nested-error",
+  ] as const)(
+    "recovers code-less encrypted reasoning rejected during %s stream drain",
+    async (failureShape) => {
+      const failureMessage =
+        "400 The encrypted content [REDACTED] could not be verified. " +
+        "Reason: Encrypted content could not be decrypted or parsed.";
+      const requests: ResponseCreateParamsStreaming[] = [];
+      const output = createAssistantOutput();
+      const { stream, events } = createCapturedAssistantMessageEventStream();
+
+      await runResponsesStreamLifecycle({
+        stream,
+        model: nativeOpenAIModel,
+        output,
+        createClient: () => ({
+          responses: {
+            create: (request) => {
+              requests.push(structuredClone(request));
+              const attempt = requests.length;
+              return {
+                withResponse: async () => {
+                  if (attempt === 1 && failureShape === "create") {
+                    throw Object.assign(new Error(failureMessage), { status: 400 });
+                  }
+                  return {
+                    data: (async function* () {
+                      if (attempt === 1) {
+                        yield {
+                          type: "response.created",
+                          sequence_number: 0,
+                          response: { id: "resp_rejected" },
+                        } as ResponseStreamEvent;
+                        if (failureShape === "iterator") {
+                          throw new Error(failureMessage);
+                        }
+                        yield (
+                          failureShape === "response.failed" ||
+                          failureShape === "response.failed-status"
+                            ? {
+                                type: "response.failed",
+                                sequence_number: 1,
+                                response: {
+                                  id: "resp_rejected",
+                                  status: "failed",
+                                  error:
+                                    failureShape === "response.failed-status"
+                                      ? {
+                                          code: null,
+                                          status: 400,
+                                          message: "The encrypted content could not be verified.",
+                                        }
+                                      : { code: null, message: failureMessage },
+                                },
+                              }
+                            : failureShape === "nested-error"
+                              ? {
+                                  type: "error",
+                                  sequence_number: 1,
+                                  error: { code: null, message: failureMessage },
+                                }
+                              : {
+                                  type: "error",
+                                  sequence_number: 1,
+                                  code: null,
+                                  message: failureMessage,
+                                  param: null,
+                                }
+                        ) as ResponseStreamEvent;
+                        return;
+                      }
+                      yield {
+                        type: "response.completed",
+                        sequence_number: 1,
+                        response: { id: "resp_recovered", status: "completed" },
+                      } as ResponseStreamEvent;
+                    })(),
+                    response: new Response(null, { status: 200 }),
+                  };
+                },
+              };
+            },
+          },
+        }),
+        buildParams: () => ({
+          model: nativeOpenAIModel.id,
+          stream: true,
+          input: [
+            {
+              type: "reasoning",
+              id: "rs_replay",
+              encrypted_content: "stale-reasoning",
+              summary: [],
+            },
+            { type: "compaction", id: "cmp_keep", encrypted_content: "valid-compaction" },
+          ],
+        }),
+      });
+
+      expect(requests).toHaveLength(2);
+      expect(requests[0]?.input).toEqual(
+        expect.arrayContaining([expect.objectContaining({ encrypted_content: "stale-reasoning" })]),
+      );
+      expect(requests[1]?.input).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "reasoning", id: "rs_replay" }),
+          expect.objectContaining({ type: "compaction", encrypted_content: "valid-compaction" }),
+        ]),
+      );
+      expect(JSON.stringify(requests[1]?.input)).not.toContain("stale-reasoning");
+      expect(events.map((event) => event.type)).toEqual(["start", "done"]);
+      expect(output.stopReason).toBe("stop");
+      expect(output.responseId).toBe("resp_recovered");
+    },
+  );
+
+  it("never retries an encrypted-looking response hook rejection", async () => {
+    let requests = 0;
+    const output = createAssistantOutput();
+    const onResponse = vi.fn(() => {
+      throw new Error("400 The encrypted content could not be verified.");
+    });
+
+    await runResponsesStreamLifecycle({
+      stream: new AssistantMessageEventStream(),
+      model: nativeOpenAIModel,
+      output,
+      options: { onResponse },
+      createClient: () => ({
+        responses: {
+          create: () => {
+            requests += 1;
+            return {
+              withResponse: async () => ({
+                data: streamResponsesEvents([]),
+                response: new Response(null, { status: 200 }),
+              }),
+            };
+          },
+        },
+      }),
+      buildParams: () => ({
+        model: nativeOpenAIModel.id,
+        stream: true,
+        input: [{ type: "reasoning", id: "rs_replay", encrypted_content: "stale", summary: [] }],
+      }),
+    });
+
+    expect(requests).toBe(1);
+    expect(onResponse).toHaveBeenCalledOnce();
+    expect(output.errorMessage).toBe("400 The encrypted content could not be verified.");
+  });
+
+  it.each([
+    { name: "thinking", item: { type: "reasoning", id: "rs_started", summary: [] } },
+    {
+      name: "text",
+      item: {
+        type: "message",
+        id: "msg_started",
+        role: "assistant",
+        status: "in_progress",
+        content: [],
+      },
+    },
+    {
+      name: "tool",
+      item: {
+        type: "function_call",
+        id: "fc_started",
+        call_id: "call_started",
+        name: "lookup",
+        arguments: "",
+      },
+    },
+  ])("never retries encrypted replay after $name output starts", async ({ item }) => {
+    const requests: ResponseCreateParamsStreaming[] = [];
+    const output = createAssistantOutput();
+    const { stream, events } = createCapturedAssistantMessageEventStream();
+
+    await runResponsesStreamLifecycle({
+      stream,
+      model: nativeOpenAIModel,
+      output,
+      createClient: () => ({
+        responses: {
+          create: (request) => {
+            requests.push(request);
+            return {
+              withResponse: async () => ({
+                data: (async function* () {
+                  yield {
+                    type: "response.output_item.added",
+                    output_index: 0,
+                    sequence_number: 0,
+                    item,
+                  } as ResponseStreamEvent;
+                  throw new Error("400 The encrypted content could not be verified.");
+                })(),
+                response: new Response(null, { status: 200 }),
+              }),
+            };
+          },
+        },
+      }),
+      buildParams: () => ({
+        model: nativeOpenAIModel.id,
+        stream: true,
+        input: [{ type: "reasoning", id: "rs_replay", encrypted_content: "stale", summary: [] }],
+      }),
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(output.content).toHaveLength(1);
+    expect(output.stopReason).toBe("error");
+    expect(events[0]?.type).toBe("start");
+    expect(events.at(-1)?.type).toBe("error");
   });
 
   it("suppresses rejected persisted compaction state on the following turn", async () => {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -277,27 +277,34 @@ export async function runResponsesStreamLifecycle<TApi extends Api>(params: {
     };
     const requestParams = await buildRequest("checkpoint");
 
-    firstEventAbort = createFirstStreamEventAbortController(options?.signal);
-    const { stream: openaiStream, response } = await createResponsesStreamWithEncryptedContentRetry(
-      {
-        client: client as never,
-        request: requestParams as never,
-        requestOptions: {
-          ...buildResponsesRequestOptions(options),
-          signal: firstEventAbort.signal,
-        },
-        model,
-        buildFullHistoryRequest: () => buildRequest("full-history"),
-        onCompactionRejected: (checkpoint) =>
-          suppressOpenAIResponsesCompaction(output, model, options, checkpoint),
+    const firstEvent = createFirstStreamEventAbortController(options?.signal);
+    firstEventAbort = firstEvent;
+    let started = false;
+    const { stream: hookedOpenAIStream } = await createResponsesStreamWithEncryptedContentRetry({
+      client: client as never,
+      request: requestParams as never,
+      requestOptions: {
+        ...buildResponsesRequestOptions(options),
+        signal: firstEvent.signal,
       },
-    );
-    const hookedOpenAIStream = withProviderResponseHook({
-      stream: openaiStream,
-      signal: firstEventAbort.signal,
-      abort: firstEventAbort.abort,
-      hook: createOpenAIProviderAcceptanceHook(options, response, model),
-      onReady: () => stream.push({ type: "start", partial: output }),
+      model,
+      buildFullHistoryRequest: () => buildRequest("full-history"),
+      onCompactionRejected: (checkpoint) =>
+        suppressOpenAIResponsesCompaction(output, model, options, checkpoint),
+      canRetryStream: () => output.content.length === 0,
+      wrapStream: ({ stream: openaiStream, response }) =>
+        withProviderResponseHook({
+          stream: openaiStream,
+          signal: firstEvent.signal,
+          abort: firstEvent.abort,
+          hook: createOpenAIProviderAcceptanceHook(options, response, model),
+          onReady: () => {
+            if (!started) {
+              started = true;
+              stream.push({ type: "start", partial: output });
+            }
+          },
+        }),
     });
 
     const firstEventTimeoutMs = getFirstStreamEventTimeoutMs(options);

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -424,11 +424,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           initialAttemptKind: NonNullable<ResponsesStreamParams["initialAttemptKind"]> = "initial",
           initialRejectedCompaction?: ResponsesStreamParams["initialRejectedCompaction"],
         ): Promise<AsyncIterable<unknown>> => {
-          const {
-            stream: rawResponseStream,
-            response,
-            attempt,
-          } = await config.createResponseStream({
+          const { stream: responseStream } = await config.createResponseStream({
             client,
             request: initialRequest,
             requestOptions,
@@ -439,26 +435,30 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             buildFullHistoryRequest: () => buildRequest("full-history"),
             onCompactionRejected: (checkpoint) =>
               suppressOpenAIResponsesCompaction(output, model, responsesOptions, checkpoint),
-          });
-          if (continuationClaim) {
-            continuationBaseline = attempt.request.previous_response_id
-              ? (params as ResponsesContinuationRequest)
-              : (attempt.request as ResponsesContinuationRequest);
-          }
-          return withProviderResponseHook({
-            stream: observeResponsesStream(rawResponseStream, model, requestStartedAt),
-            signal: firstEvent.signal,
-            abort: firstEvent.abort,
-            hook: createOpenAIProviderAcceptanceHook(options, response, model),
-            onReady: () => {
-              emitModelTransportDebug(
-                log,
-                `[responses] headers provider=${model.provider} api=${model.api} model=${model.id} ` +
-                  `transport=sse elapsedMs=${Date.now() - requestStartedAt}`,
-              );
-              startStream();
+            canRetryStream: () => output.content.length === 0,
+            wrapStream: ({ stream: rawResponseStream, response, attempt }) => {
+              if (continuationClaim) {
+                continuationBaseline = attempt.request.previous_response_id
+                  ? (params as ResponsesContinuationRequest)
+                  : (attempt.request as ResponsesContinuationRequest);
+              }
+              return withProviderResponseHook({
+                stream: observeResponsesStream(rawResponseStream, model, requestStartedAt),
+                signal: firstEvent.signal,
+                abort: firstEvent.abort,
+                hook: createOpenAIProviderAcceptanceHook(options, response, model),
+                onReady: () => {
+                  emitModelTransportDebug(
+                    log,
+                    `[responses] headers provider=${model.provider} api=${model.api} model=${model.id} ` +
+                      `transport=sse elapsedMs=${Date.now() - requestStartedAt}`,
+                  );
+                  startStream();
+                },
+              });
             },
           });
+          return responseStream;
         };
 
         let responseStream: AsyncIterable<unknown>;

--- a/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
+++ b/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
@@ -458,6 +458,72 @@ describe("OpenAI Responses provider prompt observer", () => {
     expect(onCompactionRejected).toHaveBeenCalledOnce();
   });
 
+  it.each(["iterator", "response.failed"] as const)(
+    "retries encrypted reasoning rejected by the SDK %s drain without dropping compaction",
+    async (failureShape) => {
+      const identity = { sessionId: "sdk-drain-session", authProfileId: "sdk-drain-profile" };
+      const model = createModel();
+      const context = createCompactionContext(model, identity, true);
+      const onResponse = vi.fn();
+      const options = { apiKey: "test-key", ...identity, onResponse };
+      const observations: ResponsesPromptObservation[] = [];
+      responsesPromptObserver.set(options, (observation) => observations.push(observation));
+      const failureMessage =
+        "400 The encrypted content [REDACTED] could not be verified. " +
+        "Reason: Encrypted content could not be decrypted or parsed.";
+      const failedResponse: SdkResponse = {
+        data: (async function* () {
+          yield { type: "response.created", response: { id: "resp_rejected" } };
+          if (failureShape === "iterator") {
+            throw new Error(failureMessage);
+          }
+          yield {
+            type: "response.failed",
+            response: {
+              id: "resp_rejected",
+              status: "failed",
+              error: { code: null, message: failureMessage },
+            },
+          };
+        })(),
+        response: new Response(null, {
+          status: 200,
+          headers: { "x-request-id": "req_rejected" },
+        }),
+      };
+      const recoveredResponse = completedSdkResponse("resp_recovered");
+      recoveredResponse.response = new Response(null, {
+        status: 200,
+        headers: { "x-request-id": "req_recovered" },
+      });
+      sdkState.outcomes = [failedResponse, recoveredResponse];
+
+      const stream = await Promise.resolve(
+        createOpenAIResponsesTransportStreamFn()(model, context, options as never),
+      );
+      const eventTypes: string[] = [];
+      for await (const event of stream) {
+        eventTypes.push(event.type);
+      }
+      expect(await stream.result()).toMatchObject({ stopReason: "stop" });
+
+      expect(sdkState.requests).toHaveLength(2);
+      expect(requestHasCompaction(sdkState.requests[0])).toBe(true);
+      expect(requestHasCompaction(sdkState.requests[1])).toBe(true);
+      expect(JSON.stringify(sdkState.requests[0]?.input)).toContain(SDK_REASONING_CIPHERTEXT);
+      expect(JSON.stringify(sdkState.requests[1]?.input)).not.toContain(SDK_REASONING_CIPHERTEXT);
+      expect(observations.map((observation) => observation.payloadVariant)).toEqual([
+        "initial",
+        "reasoning-stripped",
+      ]);
+      expect(onResponse.mock.calls.map(([response]) => response.headers["x-request-id"])).toEqual([
+        "req_rejected",
+        "req_recovered",
+      ]);
+      expect(eventTypes).toEqual(["start", "done"]);
+    },
+  );
+
   it("does not invoke the provider or retry when prompt observation throws", async () => {
     const options = { apiKey: "test-key" };
     responsesPromptObserver.set(options, () => {

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -34,10 +34,10 @@ export function isInvalidEncryptedContentError(error: unknown): boolean {
     message.includes("thinking_signature_invalid") ||
     ((record.status === 400 ||
       (record.status == null && /(?:^|[\s(])400(?:[\s):]|$)/.test(message))) &&
-      (message.includes("encrypted content") || message.includes("encrypted_content")) &&
-      (message.includes("could not be verified") ||
-        message.includes("could not be decrypted") ||
-        message.includes("could not decrypt")))
+      (message.includes("could not decrypt the provided encrypted_content") ||
+        (message.includes("encrypted content") &&
+          (message.includes("could not be verified") ||
+            message.includes("could not be decrypted or parsed")))))
   );
 }
 

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -1,4 +1,5 @@
 import type { Model } from "@openclaw/llm-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ResponseInput } from "openai/resources/responses/responses.js";
 import type { OpenAIResponsesCompactionRejection } from "../provider-options.js";
 import type { createOpenAIResponsesClient } from "./openai-responses-client.js";
@@ -27,13 +28,16 @@ export function isInvalidEncryptedContentError(error: unknown): boolean {
   if (record.code === "invalid_encrypted_content" || record.code === "thinking_signature_invalid") {
     return true;
   }
-  const message = typeof record.message === "string" ? record.message : "";
+  const message = typeof record.message === "string" ? record.message.toLowerCase() : "";
   return (
     message.includes("invalid_encrypted_content") ||
     message.includes("thinking_signature_invalid") ||
-    // xAI reports this exact prose contract without an error code.
-    (record.status === 400 &&
-      message.toLowerCase().includes("could not decrypt the provided encrypted_content"))
+    ((record.status === 400 ||
+      (record.status == null && /(?:^|[\s(])400(?:[\s):]|$)/.test(message))) &&
+      (message.includes("encrypted content") || message.includes("encrypted_content")) &&
+      (message.includes("could not be verified") ||
+        message.includes("could not be decrypted") ||
+        message.includes("could not decrypt")))
   );
 }
 
@@ -166,12 +170,18 @@ export async function resolveNextResponsesEncryptedContentAttempt<
 export async function createResponsesStreamWithEncryptedContentRetry(params: {
   client: ResponsesClientLike;
   request: OpenAIResponsesRequestParams;
-  requestOptions: unknown;
+  requestOptions: { signal?: AbortSignal } | undefined;
   model: Model;
   observePrompt?: NonNullable<ReturnType<typeof createResponsesPromptEgressObserver>>;
   initialAttemptKind?: ResponsesEncryptedContentAttemptKind;
   initialRejectedCompaction?: OpenAIResponsesCompactionRejection;
   onCompactionRejected?: (checkpoint: OpenAIResponsesCompactionRejection) => void;
+  canRetryStream?: () => boolean;
+  wrapStream?: (result: {
+    stream: AsyncIterable<unknown>;
+    response: Response;
+    attempt: ResponsesEncryptedContentAttempt<OpenAIResponsesRequestParams>;
+  }) => AsyncIterable<unknown>;
   buildFullHistoryRequest?: () =>
     | OpenAIResponsesRequestParams
     | Promise<OpenAIResponsesRequestParams>;
@@ -210,7 +220,67 @@ export async function createResponsesStreamWithEncryptedContentRetry(params: {
       payloadVariant: attempt.kind,
     });
     try {
-      return await sendAttempt(attempt);
+      const result = await sendAttempt(attempt);
+      return {
+        ...result,
+        stream: {
+          async *[Symbol.asyncIterator]() {
+            let rejectedEvent: unknown;
+            try {
+              for await (const event of params.wrapStream?.(result) ?? result.stream) {
+                if (isRecord(event)) {
+                  const failure =
+                    event.type === "response.failed" && isRecord(event.response)
+                      ? event.response.error
+                      : event.type === "error"
+                        ? (event.error ?? event)
+                        : undefined;
+                  if (
+                    isRecord(failure) &&
+                    params.canRetryStream?.() === true &&
+                    isInvalidEncryptedContentError(failure)
+                  ) {
+                    rejectedEvent = event;
+                    const message = typeof failure.message === "string" ? failure.message : "";
+                    throw Object.assign(new Error(message), {
+                      code: failure.code,
+                      status: failure.status,
+                    });
+                  }
+                }
+                yield event;
+              }
+            } catch (error) {
+              // Response hooks can abort the request before any output exists; retrying their
+              // failures would reissue an already-canceled request as provider recovery.
+              const nextAttempt =
+                params.canRetryStream?.() === true && !params.requestOptions?.signal?.aborted
+                  ? await resolveNextResponsesEncryptedContentAttempt(result.attempt, error, {
+                      buildFullHistoryRequest: params.buildFullHistoryRequest,
+                    })
+                  : undefined;
+              if (!nextAttempt) {
+                if (rejectedEvent !== undefined) {
+                  yield rejectedEvent;
+                  return;
+                }
+                throw error;
+              }
+              log.warn(
+                `[responses] retrying streamed encrypted content provider=${params.model.provider} ` +
+                  `api=${params.model.api} model=${params.model.id}`,
+              );
+              const recovered = await createResponsesStreamWithEncryptedContentRetry({
+                ...params,
+                request: nextAttempt.request,
+                initialAttemptKind: nextAttempt.kind,
+                initialRejectedCompaction: nextAttempt.rejectedCompaction,
+              });
+              yield* recovered.stream;
+            }
+          },
+        },
+      };
     } catch (error) {
       let nextAttempt = await resolveNextResponsesEncryptedContentAttempt(attempt, error, {
         buildFullHistoryRequest: params.buildFullHistoryRequest,


### PR DESCRIPTION
Fixes #124465
Related: #95493, #95587, #97926

## What Problem This Solves

Fixes an issue where users chatting with GitHub Copilot could permanently lose a conversation after replayed encrypted reasoning was rejected: the assistant repeatedly failed with `LLM request failed` until the session was reset. The same failure could affect another Responses-compatible provider when its rejection arrived after streaming had already started.

## Why This Change Was Made

The OpenAI SDK can defer a provider error until the Responses stream is iterated, and those streamed SDK errors do not necessarily retain their HTTP status or structured error code. OpenClaw's existing encrypted-replay recovery wrapped only initial stream creation, so both the deferred SDK exception and normal `response.failed` / `error` stream events escaped recovery.

Move recovery ownership across the complete SDK create-and-drain lifecycle used by both Responses transport callers. Recognize narrowly bounded encrypted-content verification/decryption failures, retry only before thinking, text, or tool output has been committed, preserve the existing reasoning-then-compaction recovery stages, re-run the correct response hook for replacement HTTP responses, and keep one visible assistant lifecycle. Aborted requests and failed response hooks never retry.

The existing Copilot plugin remains responsible for proactively stripping connection-bound reasoning before dispatch. Its producer-side mitigation and this shared transport-side recovery are complementary; this change does not recursively remove valid encrypted compaction state or change provider configuration.

Production delta: +126/-49 (net +77). The additional production code is necessary to own deferred single-consumption stream failures, provider response/continuation lifecycles, and the pre-output/abort safety boundary; the existing creation-only retry cannot express that capability. Regression tests: +332/-0.

## User Impact

Copilot and other Responses-compatible conversations recover automatically from a rejected stale reasoning item instead of repeatedly resending poisoned history. Valid compaction remains available, existing streamed output is never duplicated, and operators do not need to reset the conversation.

## Evidence

- Before the fix, the real shared lifecycle regression failed for iterator-thrown errors, `response.failed`, and `error` events: each sent only one poisoned request instead of the required sanitized recovery request.
- Direct dependency proof: installed OpenAI SDK 7.5.0 `node_modules/openai/src/core/streaming.ts:58-87` consumes SSE only during async iteration and constructs `new APIError(undefined, data.error, undefined, response.headers)` at lines 83-85. A real SDK `Stream` over a real `Response` containing an SSE error yielded `APIError` with absent status and code, confirming the deferred shape independently of mocks.
- Additional independent review reproduced two real edge cases before repair: a nested status-only `response.failed` did not recover, and an encrypted-looking response-hook failure incorrectly attempted a second request.
- After the fix, seven focused Responses transport and agent-side replay suites pass **261 tests**, including immediate HTTP 400, deferred SDK errors without status/code, flat/nested error events, unrelated OAuth-sidecar/HTTP-500 negative cases, the existing xAI rejection contract, exactly one start/done lifecycle, no retry after thinking/text/tool output, aborted hooks, retained encrypted compaction, prompt observation, replacement-response headers, continuation state, and WebSocket siblings:

  ```bash
  node scripts/run-vitest.mjs \
    src/agents/openai-transport-stream.replay-and-tools.test.ts \
    packages/ai/src/providers/openai-responses-shared.test.ts \
    packages/ai/src/transports/openai-responses-prompt-observer.test.ts \
    packages/ai/src/transports/openai-responses-websocket-client.test.ts \
    packages/ai/src/transports/openai-responses-compaction-replay.test.ts \
    packages/ai/src/transports/openai-responses-transport.response-hook.test.ts \
    packages/ai/src/transports/openai-responses-client.continuation.test.ts
  ```

- A genuine authenticated GitHub Copilot request from the patched checkout completed through the documented disposable CLI flow using `github-copilot/gpt-5.4`; the real `/responses` endpoint returned HTTP 200 and the requested assistant response.
- A deliberate live 400-to-200 recovery cannot be safely forced through the normal disposable CLI: the shipped Copilot plugin removes stale reasoning ciphertext before dispatch, the disposable command supports only one turn, and inducing the original state would require bypassing the production sanitizer, altering an operator-owned session, or invalidating credentials. The maintainer accepts this concrete live-fault-proof limitation; genuine authenticated Copilot success, direct SDK source/real-SSE fault proof, and real exported production-boundary recovery regressions are the strongest safe evidence. No live fault recovery is claimed.
- The separate handwritten ChatGPT SSE transport does not serve Copilot and remains a named sibling follow-up; its WebSocket path already owns complete-stream semantic recovery.
- Structured Codex autoreview: no accepted/actionable findings. Independently source-reviewed across the SDK contract, both production caller paths, response hooks, continuation state, compaction, and cancellation.

Reported by @shanselman. AI-assisted implementation; no prior contributor code was copied.
