### PR TITLE
fix(azure): avoid unsupported prompt cache keys

### DIFF
--- a/packages/ai/src/providers/azure-openai-responses.test.ts
+++ b/packages/ai/src/providers/azure-openai-responses.test.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { describe, expect, it } from "vitest";
 import { configureAiTransportHost } from "../host.js";
 import { buildOpenAIResponsesReplayContext } from "../transports/openai-responses-compaction-replay.js";
@@ -162,6 +163,44 @@ describe("azure-openai-responses", () => {
     } finally {
       configureAiTransportHost({});
     }
+  });
+
+  it("honors the prompt-cache compatibility opt-out at the request boundary", async () => {
+    const sentParams: Array<Record<string, unknown>> = [];
+    const hostFetch: typeof fetch = async (input, init) => {
+      const body: unknown = await new Request(input, init).json();
+      if (!isRecord(body)) {
+        throw new Error("expected an object request payload");
+      }
+      sentParams.push(body);
+      return Response.json({ error: { message: "captured" } }, { status: 400 });
+    };
+
+    configureAiTransportHost({ buildModelFetch: () => hostFetch });
+    try {
+      for (const supportsPromptCacheKey of [undefined, false, true]) {
+        await streamAzureOpenAIResponses(
+          // SAFETY: Configured Azure models carry generic compat fields beyond the API-specific type.
+          {
+            ...azureResponsesModel,
+            compat: supportsPromptCacheKey === undefined ? undefined : { supportsPromptCacheKey },
+          } as never,
+          context,
+          {
+            apiKey: "test-api-key",
+            sessionId: "session-123",
+          },
+        ).result();
+      }
+    } finally {
+      configureAiTransportHost({});
+    }
+
+    expect(sentParams.map((params) => params.prompt_cache_key)).toEqual([
+      "session-123",
+      undefined,
+      "session-123",
+    ]);
   });
 
   it("fences compaction replay by the resolved Azure endpoint", async () => {

--- a/packages/ai/src/providers/azure-openai-responses.test.ts
+++ b/packages/ai/src/providers/azure-openai-responses.test.ts
@@ -165,7 +165,7 @@ describe("azure-openai-responses", () => {
     }
   });
 
-  it("honors the prompt-cache compatibility opt-out at the request boundary", async () => {
+  it("applies prompt-cache compatibility and proxy policy at the request boundary", async () => {
     const sentParams: Array<Record<string, unknown>> = [];
     const hostFetch: typeof fetch = async (input, init) => {
       const body: unknown = await new Request(input, init).json();
@@ -178,11 +178,20 @@ describe("azure-openai-responses", () => {
 
     configureAiTransportHost({ buildModelFetch: () => hostFetch });
     try {
-      for (const supportsPromptCacheKey of [undefined, false, true]) {
+      const cases = [
+        [azureResponsesModel.baseUrl, undefined],
+        [azureResponsesModel.baseUrl, false],
+        [azureResponsesModel.baseUrl, true],
+        ["https://gateway.example.com/proxy/openai/v1", undefined],
+        ["https://gateway.example.com/proxy/openai/v1", false],
+        ["https://gateway.example.com/proxy/openai/v1", true],
+      ] as const;
+      for (const [baseUrl, supportsPromptCacheKey] of cases) {
         await streamAzureOpenAIResponses(
           // SAFETY: Configured Azure models carry generic compat fields beyond the API-specific type.
           {
             ...azureResponsesModel,
+            baseUrl,
             compat: supportsPromptCacheKey === undefined ? undefined : { supportsPromptCacheKey },
           } as never,
           context,
@@ -198,6 +207,9 @@ describe("azure-openai-responses", () => {
 
     expect(sentParams.map((params) => params.prompt_cache_key)).toEqual([
       "session-123",
+      undefined,
+      "session-123",
+      undefined,
       undefined,
       "session-123",
     ]);

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -6,6 +6,10 @@ import { getAiTransportHost } from "../host.js";
 import type { BaseOpenAIStreamOptions } from "../provider-options.js";
 import type { OpenAIResponsesReplayMode } from "../transports/openai-responses-compaction-replay.js";
 import type { OpenAIResponsesRequestParams } from "../transports/openai-responses-contracts.js";
+import {
+  applyOpenAIResponsesPayloadPolicy,
+  resolveOpenAIResponsesPayloadPolicy,
+} from "../transports/openai-responses-payload-policy.js";
 import type { Context, Model, SimpleStreamOptions, StreamFunction } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { resolveAzureDeploymentNameFromMap } from "./azure-deployment-map.js";
@@ -239,6 +243,14 @@ function buildParams(
   };
 
   applyCommonResponsesParams(params, model, context, options);
+  applyOpenAIResponsesPayloadPolicy(
+    // SAFETY: OpenAI SDK request params are mutable string-keyed payload objects at egress.
+    params as unknown as Record<string, unknown>,
+    resolveOpenAIResponsesPayloadPolicy(model, {
+      storeMode: "preserve",
+      enablePromptCacheStripping: true,
+    }),
+  );
 
   return params;
 }

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -272,6 +272,7 @@ export function buildOpenAIResponsesParams(
   const isCodexResponses = isOpenAICodexResponsesModel(model);
   const payloadPolicy = resolveOpenAIResponsesPayloadPolicy(model, {
     storeMode: "disable",
+    enablePromptCacheStripping: true,
   });
   const messages = convertOpenAIResponsesMessagesForRequest(model, context, options, replayMode);
   if (isCodexResponses) {

--- a/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
+++ b/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
@@ -229,6 +229,29 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("store");
   });
 
+  it("strips Azure Responses prompt-cache keys when compat disables them", () => {
+    const options = {
+      sessionId: "session-123",
+    } as const;
+    const azureModel = makeResponsesModel<"azure-openai-responses">({
+      api: "azure-openai-responses",
+      provider: "azure-openai-responses",
+      baseUrl: "https://example.openai.azure.com/openai/v1",
+    });
+    const supported = buildOpenAIResponsesParams(azureModel, emptyContext(), options);
+    const disabled = buildOpenAIResponsesParams(
+      // SAFETY: Configured Azure models carry generic compat fields beyond the API-specific type.
+      { ...azureModel, compat: { supportsPromptCacheKey: false } } as never,
+      emptyContext(),
+      options,
+    );
+
+    expect(supported).toMatchObject({
+      prompt_cache_key: "session-123",
+    });
+    expect(disabled).not.toHaveProperty("prompt_cache_key");
+  });
+
   it("uses system role for xAI default-route responses providers without relying on baseUrl host sniffing", () => {
     const params = buildOpenAIResponsesParams(
       makeResponsesModel({

--- a/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
+++ b/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
@@ -229,7 +229,7 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("store");
   });
 
-  it("strips Azure Responses prompt-cache keys when compat disables them", () => {
+  it("applies Azure Responses prompt-cache compatibility and proxy policy", () => {
     const options = {
       sessionId: "session-123",
     } as const;
@@ -245,11 +245,39 @@ describe("openai transport stream", () => {
       emptyContext(),
       options,
     );
+    const proxyDefault = buildOpenAIResponsesParams(
+      { ...azureModel, baseUrl: "https://gateway.example.com/proxy/openai/v1" },
+      emptyContext(),
+      options,
+    );
+    const proxyDisabled = buildOpenAIResponsesParams(
+      {
+        ...azureModel,
+        baseUrl: "https://gateway.example.com/proxy/openai/v1",
+        compat: { supportsPromptCacheKey: false },
+      } as never,
+      emptyContext(),
+      options,
+    );
+    const proxySupported = buildOpenAIResponsesParams(
+      {
+        ...azureModel,
+        baseUrl: "https://gateway.example.com/proxy/openai/v1",
+        compat: { supportsPromptCacheKey: true },
+      } as never,
+      emptyContext(),
+      options,
+    );
 
     expect(supported).toMatchObject({
       prompt_cache_key: "session-123",
     });
     expect(disabled).not.toHaveProperty("prompt_cache_key");
+    expect(proxyDefault).not.toHaveProperty("prompt_cache_key");
+    expect(proxyDisabled).not.toHaveProperty("prompt_cache_key");
+    expect(proxySupported).toMatchObject({
+      prompt_cache_key: "session-123",
+    });
   });
 
   it("uses system role for xAI default-route responses providers without relying on baseUrl host sniffing", () => {


### PR DESCRIPTION
Closes #102907

## What Problem This Solves

Fixes an issue where users routing Azure OpenAI Responses requests to endpoints that reject `prompt_cache_key` could receive a 400 response even after declaring `compat.supportsPromptCacheKey: false`. Disabling caching entirely was the only workaround.

## Why This Change Was Made

Both Azure Responses request producers now apply the existing shared payload compatibility policy. The policy is deliberately tri-state:

- native Azure route + unset or `true`: preserve `prompt_cache_key`;
- any Responses route + explicit `false`: strip it;
- proxy-like route + unset: strip it by default;
- proxy-like route + explicit `true`: preserve it.

This fixes the ignored explicit opt-out while preserving OpenClaw's documented rule that compatible proxies opt in explicitly.

## User Impact

Operators can keep normal session caching behavior while opting incompatible Azure endpoints out of prompt-cache affinity fields through the documented compatibility setting. Proxy operators that support the field can continue to enable it with `compat.supportsPromptCacheKey: true`.

## Evidence

### Regression and exact-head checks

Exact head: `b4b5d2c122730bb8e6e0496ecef96947fa7a4ffa`

- Before the fix, the direct-provider regression captured `prompt_cache_key` for unset, false, and true instead of omitting it for false.
- Before the fix, the managed Azure builder regression also retained the field for explicit false.
- The request-boundary regressions now cover native Azure and proxy-like URLs across unset, false, and true. They assert the canonical results: native `keep/strip/keep`; proxy `strip/strip/keep`.
- `node scripts/run-vitest.mjs packages/ai/src/providers/azure-openai-responses.test.ts src/agents/openai-transport-stream.reasoning-and-cache.test.ts src/agents/openai-responses-payload-policy.test.ts` — 3 files, 41 tests passed.
- `node scripts/check-changed.mjs -- packages/ai/src/providers/azure-openai-responses.test.ts packages/ai/src/providers/azure-openai-responses.ts packages/ai/src/transports/openai-responses-params-internal.ts src/agents/openai-transport-stream.reasoning-and-cache.test.ts` — passed on exact head.
- The single allowed draft-PR autoreview round was clean on implementation head `c3c36252ff8d0b0212782dad51e6da4335409d90`; the follow-up commit changes tests only.

### ClawSweeper P1 follow-up: unset proxy routes

The prior finding asked this PR to preserve `prompt_cache_key` when compatibility is unset on a proxy-like route. That would invert the existing public contract and create different policy at the builder and final-egress boundaries:

- The prompt-caching reference says proxies must opt in with `compat.supportsPromptCacheKey: true`; support is never auto-detected for proxies: https://docs.openclaw.ai/reference/prompt-caching
- The canonical policy implements `true = keep`, `false = strip`, and `unset proxy = strip`: https://github.com/openclaw/openclaw/blob/b4b5d2c122730bb8e6e0496ecef96947fa7a4ffa/packages/ai/src/transports/openai-responses-payload-policy.ts#L245-L258
- The OpenAI Responses wrapper applies that policy at final egress: https://github.com/openclaw/openclaw/blob/b4b5d2c122730bb8e6e0496ecef96947fa7a4ffa/src/llm/providers/stream-wrappers/openai.ts#L350-L388
- Existing owner-boundary coverage already requires stripping on an unset proxy route: https://github.com/openclaw/openclaw/blob/b4b5d2c122730bb8e6e0496ecef96947fa7a4ffa/src/agents/openai-responses-payload-policy.test.ts#L120-L143
- The behavior originated in the stable fix for #48155 / #49877. Explicit `true` is the escape hatch for verified capable proxies.

The follow-up commit therefore keeps the shared policy intact and expands both Azure request-boundary regressions rather than changing production behavior to satisfy the inverted premise.

### Dependency and endpoint contract

- The installed OpenAI JavaScript SDK is 7.5.0. Its Responses client posts the supplied request `body` unchanged, and its Azure client only adds deployment routing before delegating to the same request builder:
  - https://github.com/openai/openai-node/blob/v7.5.0/src/resources/responses/responses.ts#L98-L117
  - https://github.com/openai/openai-node/blob/v7.5.0/src/azure.ts#L134-L165
- Microsoft's current Azure OpenAI documentation says Responses uses the OpenAI request structure and documents `prompt_cache_key` for current GPT-5.6/v1 integrations:
  - https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/prompt-caching
  - https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/responses
- The original issue does not identify the rejecting endpoint, model/deployment, or API version. An arbitrary current Azure v1 run therefore cannot reproduce the reported endpoint-specific rejection. The issue's own ClawSweeper review classified the defect as `clawsweeper:source-repro`, removed `clawsweeper:needs-live-repro`, and named these two focused tests plus the changed gate as its acceptance criteria:
  - https://github.com/openclaw/openclaw/issues/102907#issuecomment-4926506612

### Live-proof boundary

No credentialed Azure result is claimed. This checkout has no Azure key, base URL/resource, deployment mapping, Azure CLI session, or repo-native Azure credentialed workflow. A legitimate live run requires a deployed Azure model plus Azure authentication, as Microsoft's Responses guide documents. The strongest available proof is therefore the pre-fix failure/post-fix pass at both real request producers and the final SDK egress boundary, plus the dependency source above.

There is no persistent data-model or SQLite change; the only changed production behavior is request-body compatibility policy application. Test references to cache fields are wire-payload assertions, not stored schema.

Production LOC: +13/-0 (net +13) | Tests: +102/-0. Production growth is limited to invoking the existing canonical policy at the direct provider boundary and enabling its existing stripping gate at the managed builder boundary; no new policy or configuration surface was added.
