### PR TITLE
fix(command-explainer): bound walk recursion depth to prevent stack overflow

### DIFF
--- a/src/infra/command-explainer/extract.test.ts
+++ b/src/infra/command-explainer/extract.test.ts
@@ -1,7 +1,7 @@
 // Covers rich shell-command extraction, fake parser shapes, source span mapping,
 // nested wrapper parsing, and parser error handling.
 import { describe, expect, it } from "vitest";
-import { explainShellCommand } from "./extract.js";
+import { CommandExplanationWorkLimitError, explainShellCommand } from "./extract.js";
 import { parseBashForCommandExplanation } from "./tree-sitter-runtime.js";
 
 function riskMatches(risk: unknown, fields: Record<string, unknown>): boolean {
@@ -27,6 +27,10 @@ function expectRisk(
 
 function spanText(source: string, span: { startIndex: number; endIndex: number }): string {
   return source.slice(span.startIndex, span.endIndex);
+}
+
+function nestShellSyntax(open: string, inner: string, close: string, depth: number): string {
+  return open.repeat(depth) + inner + close.repeat(depth);
 }
 
 describe("command explainer tree-sitter runtime", () => {
@@ -619,6 +623,34 @@ describe("command explainer tree-sitter runtime", () => {
     const span = syntaxError.span as { startIndex?: unknown; endIndex?: unknown } | undefined;
     expect(typeof span?.startIndex).toBe("number");
     expect(typeof span?.endIndex).toBe("number");
+  });
+
+  it.each([
+    {
+      name: "command substitutions",
+      source: nestShellSyntax("$( ", "/approve abc123 allow-once", " )", 5_000),
+      executable: "/approve",
+    },
+    {
+      name: "test expressions",
+      source: `[[ ${"! ".repeat(15_000)}x ]]`,
+      executable: "[[",
+    },
+  ])("walks deeply nested $name without overflowing", async ({ source, executable }) => {
+    const explanation = await explainShellCommand(source);
+
+    expect(explanation.ok).toBe(true);
+    expect(
+      [...explanation.topLevelCommands, ...explanation.nestedCommands].some(
+        (command) => command.executable === executable,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects syntax trees beyond the explanation work limit without returning partial data", async () => {
+    const source = nestShellSyntax("$( ", "echo hi", " )", 11_000);
+
+    await expect(explainShellCommand(source)).rejects.toThrow(CommandExplanationWorkLimitError);
   });
 
   it("parses and extracts a repeated approval-sized corpus without parser state leakage", async () => {

--- a/src/infra/command-explainer/extract.ts
+++ b/src/infra/command-explainer/extract.ts
@@ -37,6 +37,7 @@ type MutableExplanation = {
   risks: CommandRisk[];
   hasParseError: boolean;
   nextCommandIndex: number;
+  remainingNodes: number;
 };
 
 type DynamicArgument = {
@@ -66,7 +67,17 @@ type WalkState = {
   parentCommandId?: string;
 };
 
+type WalkFrame = {
+  node: TreeSitterNode;
+  context: CommandContext;
+  state: WalkState;
+};
+
 const MAX_WRAPPER_PAYLOAD_DEPTH = 2;
+// Wrapper payload reparses share this budget, so one explanation has one fixed work bound.
+const MAX_COMMAND_EXPLANATION_NODES = 50_000;
+
+export class CommandExplanationWorkLimitError extends Error {}
 
 const PARSEABLE_SHELL_WRAPPERS = new Set<string>(POSIX_PARSEABLE_SHELL_WRAPPERS);
 
@@ -440,8 +451,21 @@ function decodeAnsiCString(text: string): string {
   return decodeAnsiCStringWithOffsets(text).value;
 }
 
-function hasDynamicWordPart(node: TreeSitterNode): boolean {
-  return DYNAMIC_WORD_NODE_TYPES.has(node.type) || node.namedChildren.some(hasDynamicWordPart);
+function hasDynamicWordPart(root: TreeSitterNode): boolean {
+  const pending = [root];
+  while (pending.length > 0) {
+    const node = pending.pop();
+    if (!node) {
+      break;
+    }
+    if (DYNAMIC_WORD_NODE_TYPES.has(node.type)) {
+      return true;
+    }
+    for (const child of node.namedChildren) {
+      pending.push(child);
+    }
+  }
+  return false;
 }
 
 function shellWordValue(node: TreeSitterNode): ShellWordValue {
@@ -573,16 +597,26 @@ function argvFromDeclarationCommand(node: TreeSitterNode, state: WalkState): Com
 }
 
 function appendTestCommandArguments(
-  node: TreeSitterNode,
+  root: TreeSitterNode,
   parsed: CommandArgv,
   state: WalkState,
 ): void {
-  if (node.type === "test_operator" || COMMAND_ARGUMENT_NODE_TYPES.has(node.type)) {
-    appendCommandArgument(node, parsed, state);
-    return;
-  }
-  for (const child of node.namedChildren) {
-    appendTestCommandArguments(child, parsed, state);
+  const pending = [root];
+  while (pending.length > 0) {
+    const node = pending.pop();
+    if (!node) {
+      break;
+    }
+    if (node.type === "test_operator" || COMMAND_ARGUMENT_NODE_TYPES.has(node.type)) {
+      appendCommandArgument(node, parsed, state);
+      continue;
+    }
+    for (let index = node.namedChildren.length - 1; index >= 0; index -= 1) {
+      const child = node.namedChildren[index];
+      if (child) {
+        pending.push(child);
+      }
+    }
   }
 }
 
@@ -887,12 +921,12 @@ function recordCommandRisks(
   }
 }
 
-async function walk(
+async function visitNode(
   node: TreeSitterNode,
   output: MutableExplanation,
   context: CommandContext,
   state: WalkState,
-): Promise<void> {
+): Promise<CommandContext> {
   recordShape(node, output);
 
   const span = spanFromNode(node, state.spanBase);
@@ -1004,8 +1038,37 @@ async function walk(
       }
     }
   }
-  for (const child of node.namedChildren) {
-    await walk(child, output, childContext, state);
+  return childContext;
+}
+
+async function walk(
+  root: TreeSitterNode,
+  output: MutableExplanation,
+  rootContext: CommandContext,
+  rootState: WalkState,
+): Promise<void> {
+  if (root.descendantCount > output.remainingNodes) {
+    throw new CommandExplanationWorkLimitError(
+      "Shell command syntax is too complex to explain safely",
+    );
+  }
+  output.remainingNodes -= root.descendantCount;
+
+  // Shell syntax is model-controlled, so keep depth-first traversal off the call stack.
+  const pending: WalkFrame[] = [{ node: root, context: rootContext, state: rootState }];
+  while (pending.length > 0) {
+    const frame = pending.pop();
+    if (!frame) {
+      break;
+    }
+    const { node, context, state } = frame;
+    const childContext = await visitNode(node, output, context, state);
+    for (let index = node.namedChildren.length - 1; index >= 0; index -= 1) {
+      const child = node.namedChildren[index];
+      if (child) {
+        pending.push({ node: child, context: childContext, state });
+      }
+    }
   }
 }
 
@@ -1188,6 +1251,7 @@ export async function explainShellCommand(source: string): Promise<CommandExplan
       risks: [],
       hasParseError: tree.rootNode.hasError,
       nextCommandIndex: 0,
+      remainingNodes: MAX_COMMAND_EXPLANATION_NODES,
     };
     await walk(tree.rootNode, output, "top-level", {
       wrapperPayloadDepth: 0,

--- a/src/infra/exec-control-command-guard.test.ts
+++ b/src/infra/exec-control-command-guard.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectUnsafeExecControlShellCommand,
+  rejectUnsafeExecControlShellCommand,
+} from "./exec-control-command-guard.js";
+
+function nestedCommandSubstitution(inner: string, depth: number): string {
+  return "$( ".repeat(depth) + inner + " )".repeat(depth);
+}
+
+describe("exec control command guard", () => {
+  it("rejects a control command below deeply nested command substitutions", async () => {
+    const command = nestedCommandSubstitution("/approve abc123 allow-once", 5_000);
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
+    await expect(rejectUnsafeExecControlShellCommand(command)).rejects.toThrow(
+      /exec cannot run \/approve commands/,
+    );
+  });
+
+  it("rejects commands that exceed the explanation work limit", async () => {
+    const command = nestedCommandSubstitution("echo hi", 11_000);
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("incomplete-analysis");
+    await expect(rejectUnsafeExecControlShellCommand(command)).rejects.toThrow(
+      /exceeds the command explanation work limit/,
+    );
+  });
+});

--- a/src/infra/exec-control-command-guard.ts
+++ b/src/infra/exec-control-command-guard.ts
@@ -10,7 +10,11 @@ import {
   buildCommandPayloadArgvCandidates,
   buildCommandPayloadCandidates,
 } from "./command-analysis/risks.js";
-import { explainShellCommand } from "./command-explainer/extract.js";
+import {
+  CommandExplanationWorkLimitError,
+  explainShellCommand,
+} from "./command-explainer/extract.js";
+import type { CommandExplanation } from "./command-explainer/types.js";
 import { isPathInside } from "./path-guards.js";
 
 type ParsedExecApprovalCommand = {
@@ -18,7 +22,11 @@ type ParsedExecApprovalCommand = {
   decision: "allow-once" | "allow-always" | "deny";
 };
 
-type UnsafeExecControlShellCommandKind = "approve" | "channel-login" | "live-state-sqlite";
+type UnsafeExecControlShellCommandKind =
+  | "approve"
+  | "channel-login"
+  | "live-state-sqlite"
+  | "incomplete-analysis";
 
 type ExecControlShellCommandContext = {
   stateDir?: string;
@@ -258,18 +266,22 @@ export async function detectUnsafeExecControlShellCommand(
   context: ExecControlShellCommandContext = {},
 ): Promise<UnsafeExecControlShellCommandKind | null> {
   const rawCommand = command.trim();
-  const { controlCandidates, argvCandidates } = await (async () => {
-    try {
-      const explanation = await explainShellCommand(rawCommand);
-      if (explanation.ok) {
-        const commands = [...explanation.topLevelCommands, ...explanation.nestedCommands];
-        return {
-          controlCandidates: commands.flatMap((step) => buildCommandPayloadCandidates(step.argv)),
-          argvCandidates: commands.flatMap((step) => buildCommandPayloadArgvCandidates(step.argv)),
-        };
-      }
-    } catch {
-      // Fall back to line-local shell splitting below.
+  let explanation: CommandExplanation | null = null;
+  try {
+    explanation = await explainShellCommand(rawCommand);
+  } catch (error) {
+    if (error instanceof CommandExplanationWorkLimitError) {
+      return "incomplete-analysis";
+    }
+    // Fall back to line-local shell splitting below.
+  }
+  const { controlCandidates, argvCandidates } = (() => {
+    if (explanation?.ok) {
+      const commands = [...explanation.topLevelCommands, ...explanation.nestedCommands];
+      return {
+        controlCandidates: commands.flatMap((step) => buildCommandPayloadCandidates(step.argv)),
+        argvCandidates: commands.flatMap((step) => buildCommandPayloadArgvCandidates(step.argv)),
+      };
     }
     const fallbackArgv = normalizeStringEntries(rawCommand.split(/\r?\n/)).map((line) => {
       const argv = splitShellArgs(line);
@@ -300,8 +312,19 @@ export async function detectUnsafeExecControlShellCommand(
   return null;
 }
 
+function rejectIncompleteCommandAnalysis(
+  unsafeKind: UnsafeExecControlShellCommandKind | null,
+): void {
+  if (unsafeKind === "incomplete-analysis") {
+    throw new Error(
+      "exec cannot run a shell command that exceeds the command explanation work limit. Simplify the command so its complete syntax can be inspected before execution.",
+    );
+  }
+}
+
 export async function rejectUnsafeExecControlShellCommand(command: string): Promise<void> {
   const unsafeKind = await detectUnsafeExecControlShellCommand(command);
+  rejectIncompleteCommandAnalysis(unsafeKind);
   if (unsafeKind === "approve") {
     throw new Error(
       [
@@ -325,6 +348,7 @@ export async function rejectUnsafeExecLiveStateSqliteShellCommand(
   context: Required<ExecControlShellCommandContext>,
 ): Promise<void> {
   const unsafeKind = await detectUnsafeExecControlShellCommand(command, context);
+  rejectIncompleteCommandAnalysis(unsafeKind);
   if (unsafeKind !== "live-state-sqlite") {
     return;
   }


### PR DESCRIPTION
Closes #129827

## What Problem This Solves

The shell command explainer parsed deeply nested commands within its source and time limits, then overflowed the JavaScript call stack while walking the syntax tree. The exec control guard caught that failure, used a line-only fallback, and could miss a control command hidden inside the nested syntax.

## Root cause

The parser caps input at 128 KiB and 500 ms, but the post-parse command walk, dynamic-word scan, and test-expression scan used recursive JavaScript calls. The existing wrapper-payload depth limit did not bound syntax-tree depth.

## Fix

- Walk the syntax tree in source order with an explicit stack.
- Use iterative scans for dynamic words and test expressions.
- Share one fixed 50,000-node work budget across the main tree and wrapper payload reparses.
- Throw a named work-limit error before returning partial explanation data.
- Make the exec control guard reject that one incomplete-analysis error instead of using its normal parse-error fallback.

The public `CommandExplanation` shape, ordinary syntax-error fallback, shallow command behavior, and wrapper-payload depth limit do not change.

## Evidence

- Current main `69e1c75ea8df46cf5ae43f8bedd38422770ce0e1`: a real 1,500-level shell command hit `RangeError: Maximum call stack size exceeded`; the exec guard returned `null`, and the production exec path ran the command.
- This head `2c6b111d95821f7b3b9d025bb35d4518c77624a6`: the same valid command was fully inspected and ran with exit code 0 and output `OPENCLAW_DEEP_OK`.
- This head: a 5,000-level command containing `/approve` was fully explained and rejected through the normal `/approve` guard in 86 ms.
- This head: an 11,000-level command exceeded the fixed work budget and was rejected in 31 ms before execution, with no partial explanation.

## Validation

- `node scripts/run-vitest.mjs src/infra/command-explainer/extract.test.ts src/infra/exec-control-command-guard.test.ts src/infra/exec-authorization-plan.test.ts src/infra/command-analysis/explain.test.ts src/infra/command-analysis/explain.lazy.test.ts src/plugin-sdk/agent-harness-exec-review-runtime.test.ts` — 71 tests passed.
- Focused format, Oxlint, conflict-marker, maximum-lines, assertion-safety, coercion-helper, dead-export, import-cycle, and test-temp guards passed.
- A shallow 500-command corpus measured 33.66 ms median on main and 35.07 ms on this head.

## Change size

- Production: +115/-27, net +88.
- Tests: +62/-1, net +61.
- The production growth replaces recursive traversal for every command-node form and adds the distinct fail-closed budget contract that the ordinary parse-error fallback cannot provide.
