### PR TITLE
fix(reply): preserve final answers after reasoning and commentary updates

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -336,8 +336,22 @@ export async function buildReplyPayloads(params: {
       directlySentTextFragmentsByAssistantMessage.set(assistantMessageIndex, [sentText]);
     }
   }
-  const isDirectlySentBlockPayload = (payload: ReplyPayload) =>
-    Boolean(params.directlySentBlockKeys?.has(createBlockReplyContentKey(payload)));
+  const isDirectlySentBlockPayload = (payload: ReplyPayload) => {
+    const contentKey = createBlockReplyContentKey(payload);
+    if (!params.directlySentBlockKeys?.has(contentKey)) {
+      return false;
+    }
+    const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
+    return (
+      assistantMessageIndex === undefined ||
+      !params.directlySentBlockPayloads?.length ||
+      params.directlySentBlockPayloads.some(
+        (sentPayload) =>
+          getReplyPayloadMetadata(sentPayload)?.assistantMessageIndex === assistantMessageIndex &&
+          createBlockReplyContentKey(sentPayload) === contentKey,
+      )
+    );
+  };
   const hasDirectlySentText = (payload: ReplyPayload): boolean => {
     if (isDirectlySentBlockPayload(payload)) {
       return true;

--- a/src/auto-reply/reply/block-reply-pipeline.multi-message.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.multi-message.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { setReplyPayloadMetadata } from "../reply-payload.js";
+import { buildReplyPayloads } from "./agent-runner-payloads.js";
 import { createBlockReplyPipeline } from "./block-reply-pipeline.js";
 
 function blockFor(text: string, assistantMessageIndex: number) {
@@ -45,6 +46,59 @@ describe("block reply pipeline multi-assistant-message suppression", () => {
       false,
     );
   });
+
+  it("delivers matching text from separate assistant messages", async () => {
+    for (const coalescing of [
+      undefined,
+      { minChars: 100, maxChars: 200, idleMs: 0, joiner: " " },
+    ]) {
+      const sent: string[] = [];
+      const pipeline = createBlockReplyPipeline({
+        onBlockReply: async (payload) => {
+          if (payload.text) {
+            sent.push(payload.text);
+          }
+        },
+        timeoutMs: 5000,
+        ...(coalescing ? { coalescing } : {}),
+      });
+
+      pipeline.enqueue(blockFor("Same answer", 0));
+      pipeline.enqueue(blockFor("Same answer", 1));
+      await pipeline.flush({ force: true });
+
+      expect(sent).toEqual(["Same answer", "Same answer"]);
+    }
+  });
+
+  it.each([false, true])(
+    "keeps a matching final answer from a different assistant message (coalescing=%s)",
+    async (coalescingEnabled) => {
+      const pipeline = createBlockReplyPipeline({
+        onBlockReply: async () => {},
+        timeoutMs: 5000,
+        ...(coalescingEnabled
+          ? { coalescing: { minChars: 100, maxChars: 200, idleMs: 0, joiner: " " } }
+          : {}),
+      });
+
+      pipeline.enqueue(blockFor("Same answer", 0));
+      await pipeline.flush({ force: true });
+      const finalPayload = blockFor("Same answer", 1);
+      const { replyPayloads } = await buildReplyPayloads({
+        payloads: [finalPayload],
+        isHeartbeat: false,
+        didLogHeartbeatStrip: false,
+        blockStreamingEnabled: true,
+        blockReplyPipeline: pipeline,
+        replyToMode: "off",
+      });
+
+      expect(pipeline.hasSentExactPayload?.(finalPayload)).toBe(false);
+      expect(pipeline.hasSentPayload(finalPayload)).toBe(false);
+      expect(replyPayloads).toEqual([expect.objectContaining({ text: "Same answer" })]);
+    },
+  );
 
   it("suppresses a single message split into multiple blocks", async () => {
     const pipeline = createBlockReplyPipeline({

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -99,6 +99,32 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     expect(pipeline.didStreamTerminalReply?.()).toBe(true);
   });
 
+  it.each([
+    { lane: "reasoning", payload: { text: "Same answer", isReasoning: true } },
+    { lane: "commentary", payload: { text: "Same answer", isCommentary: true } },
+  ])("keeps $lane separate from a matching visible answer", async ({ payload }) => {
+    for (const coalescing of [
+      undefined,
+      { minChars: 100, maxChars: 200, idleMs: 0, joiner: " " },
+    ]) {
+      const sent: ReplyPayload[] = [];
+      const pipeline = createBlockReplyPipeline({
+        onBlockReply: async (reply) => {
+          sent.push(reply);
+        },
+        timeoutMs: 5000,
+        ...(coalescing ? { coalescing } : {}),
+      });
+
+      pipeline.enqueue(payload);
+      pipeline.enqueue({ text: "Same answer" });
+      await pipeline.flush({ force: true });
+
+      expect(sent).toEqual([payload, { text: "Same answer" }]);
+      expect(pipeline.didStreamTerminalReply?.()).toBe(true);
+    }
+  });
+
   it("keeps separate deliveries for same text with different replyToId", async () => {
     const sent: Array<{ text?: string; replyToId?: string }> = [];
     const pipeline = createBlockReplyPipeline({
@@ -541,6 +567,24 @@ describe("createBlockReplyPipeline content coverage dedup", () => {
 
     expect(pipeline.didStream()).toBe(false);
     expect(pipeline.hasSentPayload({ text: "1. Inspect\n2. Patch" })).toBe(false);
+  });
+
+  it.each([
+    { lane: "reasoning", payload: { text: "Same answer", isReasoning: true } },
+    { lane: "commentary", payload: { text: "Same answer", isCommentary: true } },
+  ])("keeps $lane out of visible final-content accounting", async ({ payload }) => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue(payload);
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.didStream()).toBe(true);
+    expect(pipeline.didStreamTerminalReply?.()).toBe(false);
+    expect(pipeline.hasSentPayload({ text: "Same answer" })).toBe(false);
+    expect(pipeline.hasSentExactPayload?.({ text: "Same answer" })).toBe(false);
   });
 
   it("does not let a status notice de-dupe later matching assistant content", async () => {

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -72,6 +72,9 @@ function createBlockReplyPayloadKey(payload: ReplyPayload): string {
   return JSON.stringify({
     ...createBlockReplyContentIdentity(payload),
     statusNotice: isReplyPayloadStatusNotice(payload),
+    reasoning: payload.isReasoning === true,
+    commentary: payload.isCommentary === true,
+    assistantMessageIndex: getReplyPayloadMetadata(payload)?.assistantMessageIndex ?? null,
     replyToId: payload.replyToId ?? null,
   });
 }
@@ -82,6 +85,14 @@ export function createBlockReplyContentKey(payload: ReplyPayload): string {
   // This intentionally ignores replyToId so a streamed threaded payload and the
   // later final payload still collapse when they carry the same content.
   return JSON.stringify(createBlockReplyContentIdentity(payload));
+}
+
+function createIndexedBlockReplyContentKey(payload: ReplyPayload): string {
+  const contentKey = createBlockReplyContentKey(payload);
+  const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
+  return assistantMessageIndex === undefined
+    ? contentKey
+    : `${assistantMessageIndex}:${contentKey}`;
 }
 
 function resolveBlockReplyTimeoutMs(timeoutMs: number): number {
@@ -168,14 +179,16 @@ export function createBlockReplyPipeline(params: {
         }
         sentKeys.add(payloadKey);
         const isStatusNotice = isReplyPayloadStatusNotice(payload);
-        if (!isStatusNotice) {
+        const isTerminalContent = isReplyPayloadTerminalContent(payload);
+        if (isTerminalContent) {
           sentContentKeys.add(contentKey);
+          sentContentKeys.add(createIndexedBlockReplyContentKey(payload));
         }
         const reply = resolveSendableOutboundReplyParts(payload);
         for (const mediaUrl of reply.mediaUrls) {
           sentMediaUrls.add(mediaUrl);
         }
-        if (!isStatusNotice && reply.trimmedText) {
+        if (isTerminalContent && reply.trimmedText) {
           const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
           const fragments = streamedTextFragmentsByMessage.get(assistantMessageIndex) ?? [];
           fragments.push(reply.trimmedText);
@@ -183,10 +196,7 @@ export function createBlockReplyPipeline(params: {
         }
         if (!isStatusNotice) {
           didStream = true;
-          if (
-            isReplyPayloadTerminalContent(payload) &&
-            hasOutboundReplyContent(payload, { trimText: true })
-          ) {
+          if (isTerminalContent && hasOutboundReplyContent(payload, { trimText: true })) {
             didStreamTerminalReply = true;
           }
         }
@@ -324,9 +334,10 @@ export function createBlockReplyPipeline(params: {
     didStream: () => didStream,
     didStreamTerminalReply: () => didStreamTerminalReply,
     isAborted: () => aborted,
-    hasSentExactPayload: (payload) => sentContentKeys.has(createBlockReplyContentKey(payload)),
+    hasSentExactPayload: (payload) =>
+      sentContentKeys.has(createIndexedBlockReplyContentKey(payload)),
     hasSentPayload: (payload) => {
-      const payloadKey = createBlockReplyContentKey(payload);
+      const payloadKey = createIndexedBlockReplyContentKey(payload);
       if (sentContentKeys.has(payloadKey)) {
         return true;
       }
@@ -339,7 +350,12 @@ export function createBlockReplyPipeline(params: {
       }
       const normalize = (text: string) => text.replace(/\s+/g, "");
       const target = normalize(reply.trimmedText);
-      for (const fragments of streamedTextFragmentsByMessage.values()) {
+      const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
+      const streamedFragments =
+        assistantMessageIndex === undefined
+          ? streamedTextFragmentsByMessage.values()
+          : [streamedTextFragmentsByMessage.get(assistantMessageIndex) ?? []];
+      for (const fragments of streamedFragments) {
         if (fragments.length > 0 && normalize(fragments.join("")) === target) {
           return true;
         }

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
+import { buildReplyPayloads } from "./agent-runner-payloads.js";
 import { createBlockReplyContentKey } from "./block-reply-pipeline.js";
 import {
   createBlockReplyDeliveryHandler,
@@ -43,6 +44,92 @@ describe("createBlockReplyDeliveryHandler", () => {
 
     await createBlockReplyDeliveryHandler({ ...baseParams, [enabledFlag]: true })(payload);
     expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { lane: "reasoning", flag: "isReasoning", blockStreamingEnabled: false },
+    { lane: "commentary", flag: "isCommentary", blockStreamingEnabled: false },
+    { lane: "reasoning", flag: "isReasoning", blockStreamingEnabled: true },
+    { lane: "commentary", flag: "isCommentary", blockStreamingEnabled: true },
+    { lane: "status notice", flag: "isStatusNotice", blockStreamingEnabled: true },
+  ] as const)(
+    "preserves the final answer after directly sending $lane (streaming=$blockStreamingEnabled)",
+    async ({ flag, blockStreamingEnabled }) => {
+      const delivered: ReplyPayload[] = [];
+      const directlySentBlockKeys = new Set<string>();
+      const directlySentBlockPayloads: Array<ReplyPayload | undefined> = [];
+      const handler = createBlockReplyDeliveryHandler({
+        onBlockReply: async (payload) => {
+          delivered.push(payload);
+        },
+        normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+        applyReplyToMode: (payload) => payload,
+        typingSignals: {
+          signalTextDelta: vi.fn(async () => {}),
+        } as unknown as TypingSignaler,
+        reasoningPayloadsEnabled: true,
+        commentaryPayloadsEnabled: true,
+        blockStreamingEnabled,
+        blockReplyPipeline: null,
+        directlySentBlockKeys,
+        directlySentBlockPayloads,
+      });
+
+      await handler({ text: "Same answer", [flag]: true });
+      const { replyPayloads } = await buildReplyPayloads({
+        payloads: [{ text: "Same answer" }],
+        isHeartbeat: false,
+        didLogHeartbeatStrip: false,
+        blockStreamingEnabled,
+        blockReplyPipeline: null,
+        directlySentBlockKeys,
+        directlySentBlockPayloads: directlySentBlockPayloads.filter(
+          (payload): payload is ReplyPayload => payload !== undefined,
+        ),
+        replyToMode: "off",
+      });
+
+      expect(delivered).toHaveLength(1);
+      expect(directlySentBlockKeys.size).toBe(0);
+      expect(replyPayloads).toEqual([expect.objectContaining({ text: "Same answer" })]);
+    },
+  );
+
+  it("keeps a matching final answer from a different directly sent assistant message", async () => {
+    const directlySentBlockKeys = new Set<string>();
+    const directlySentBlockPayloads: Array<ReplyPayload | undefined> = [];
+    const handler = createBlockReplyDeliveryHandler({
+      onBlockReply: async () => {},
+      normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+      applyReplyToMode: (payload) => payload,
+      typingSignals: {
+        signalTextDelta: vi.fn(async () => {}),
+      } as unknown as TypingSignaler,
+      blockStreamingEnabled: true,
+      blockReplyPipeline: null,
+      directlySentBlockKeys,
+      directlySentBlockPayloads,
+    });
+
+    await handler(setReplyPayloadMetadata({ text: "Same answer" }, { assistantMessageIndex: 0 }));
+    const finalPayload = setReplyPayloadMetadata(
+      { text: "Same answer" },
+      { assistantMessageIndex: 1 },
+    );
+    const { replyPayloads } = await buildReplyPayloads({
+      payloads: [finalPayload],
+      isHeartbeat: false,
+      didLogHeartbeatStrip: false,
+      blockStreamingEnabled: true,
+      blockReplyPipeline: null,
+      directlySentBlockKeys,
+      directlySentBlockPayloads: directlySentBlockPayloads.filter(
+        (payload): payload is ReplyPayload => payload !== undefined,
+      ),
+      replyToMode: "off",
+    });
+
+    expect(replyPayloads).toEqual([expect.objectContaining({ text: "Same answer" })]);
   });
 
   it("sends captioned media-bearing block replies when block streaming is disabled", async () => {

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -1,7 +1,7 @@
 /** Normalizes reply directives and delivers block replies through streaming or direct paths. */
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "../../globals.js";
-import { copyReplyPayloadMetadata, isReplyPayloadStatusNotice } from "../reply-payload.js";
+import { copyReplyPayloadMetadata, isReplyPayloadTerminalContent } from "../reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { BlockReplyContext, ReplyPayload, ReplyThreadingPolicy } from "../types.js";
 import type { BlockReplyPipeline } from "./block-reply-pipeline.js";
@@ -76,8 +76,8 @@ async function sendDirectBlockReply(params: {
   const deliveryIndex = params.directlySentBlockPayloads.length;
   params.directlySentBlockPayloads.push(undefined);
   await params.onBlockReply(params.payload);
-  params.directlySentBlockKeys.add(createBlockReplyContentKey(params.trackingPayload));
-  if (!isReplyPayloadStatusNotice(params.trackingPayload)) {
+  if (isReplyPayloadTerminalContent(params.trackingPayload)) {
+    params.directlySentBlockKeys.add(createBlockReplyContentKey(params.trackingPayload));
     params.directlySentBlockPayloads[deliveryIndex] = params.trackingPayload;
   }
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users would receive no final answer when an enabled reasoning, commentary, or status message happened to contain the same text. This affected both the default non-streaming delivery path and streamed replies. Separate assistant messages containing identical text could also incorrectly suppress each other.

## Why This Change Was Made

The streaming pipeline and direct delivery route now distinguish supplemental display lanes from terminal answer content before recording delivery evidence. Final-answer suppression also respects the authoritative assistant-message index in both delivery paths while preserving the existing content-only public key, thread-independent deduplication, ordering, and legacy unindexed behavior. The 30 net production lines are required to maintain that shared invariant across the pipeline owner, direct-delivery owner, and final payload owner.

## User Impact

Users reliably receive their actual answer after reasoning, commentary, and status updates, including with default non-streaming settings. Multiple assistant messages with matching text remain distinct instead of silently disappearing.

## Evidence

- Captured 13 failing owner-boundary regressions before the fixes, including actual direct delivery and streaming pipeline calls followed by the real final-reply builder.
- Verified 680 passing tests across 10 owner, final-payload, agent, dispatch, and Discord transport test files.
- Independently exercised 180 real end-to-end combinations covering reasoning, commentary, status, visible replies, streaming and coalescing on/off, indexed and unindexed messages, and direct or pipelined delivery.
- Focused type-aware lint, formatting, independent review, and authenticated code review all pass.
