### PR TITLE
fix(windows): skip @chcp preamble when reading back gateway.cmd

### DIFF
--- a/src/daemon/schtasks-layout.ts
+++ b/src/daemon/schtasks-layout.ts
@@ -225,7 +225,30 @@ export async function readScheduledTaskCommand(
         continue;
       }
       const lower = normalizeLowercaseStringOrEmpty(line);
-      if (line.startsWith("@echo") || lower.startsWith("rem ")) {
+      // Strip a leading `@` (cmd echo-suppression) so the same prefix checks
+      // match both `@cmd` and `cmd` lines. Required because launcher writers
+      // use `@` on console-setup lines (`@echo off`, `@chcp …`, `@rem …`) and
+      // the decoder's marker-stripping branch doesn't always run for them.
+      const cmd = lower.startsWith("@") ? lower.slice(1) : lower;
+      if (cmd.startsWith("echo")) {
+        continue;
+      }
+      if (cmd.startsWith("rem ")) {
+        continue;
+      }
+      // Skip console-setup helpers (`chcp` / `title` / `color`) so the
+      // parser doesn't mistake them for the launcher's executable. Required
+      // because `encodeWindowsLauncherScript` prepends `@chcp <codePage> >nul`
+      // for non-ASCII Windows code pages; the corresponding
+      // `chcp <codePage> >nul` line must not be treated as the gateway
+      // command. See #108774.
+      if (cmd.startsWith("chcp ")) {
+        continue;
+      }
+      if (cmd.startsWith("title ")) {
+        continue;
+      }
+      if (cmd.startsWith("color ")) {
         continue;
       }
       if (lower.startsWith("set ")) {

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -453,4 +453,98 @@ describe("readScheduledTaskCommand", () => {
       },
     );
   });
+
+  it("skips raw `chcp` line in legacy UTF-8 scripts (#108774 follow-up)", async () => {
+    // `encodeWindowsLauncherScript`'s decoder strips the `@chcp` preamble on
+    // read, so production is covered. This test guards the case where a
+    // launcher script was written without going through that pipeline —
+    // older releases (≤ 2026.7.1-2), hand-edited scripts, or third-party
+    // tools that emit raw `chcp 65001 >nul` for cmd.exe UTF-8 compatibility.
+    // Without the skip-`chcp` parser rule, `readScheduledTaskCommand`
+    // mistakes the `chcp` line for the executable and `gateway status`
+    // reports "Service command does not include the gateway subcommand".
+    await withScheduledTaskScript(
+      {
+        // ASCII content + scriptEncoding:"utf8" → file written as plain UTF-8,
+        // no preamble added by `encodeWindowsLauncherScript`. We hand-author
+        // the `chcp` line to simulate a legacy generator.
+        scriptLines: [
+          "@echo off",
+          "chcp 65001 >nul",
+          "rem OpenClaw Gateway (legacy)",
+          "set OPENCLAW_GATEWAY_PORT=18789",
+          "node C:\\Users\\test\\.openclaw\\dist\\index.js gateway --port 18789",
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result?.programArguments).toEqual([
+          "node",
+          "C:\\Users\\test\\.openclaw\\dist\\index.js",
+          "gateway",
+          "--port",
+          "18789",
+        ]);
+      },
+    );
+  });
+
+  it("skips `title` and `color` console helpers when scanning for the executable", async () => {
+    // `title` / `color` are commonly used to set the console window title
+    // and color scheme. They live between `@echo off` and the executable
+    // and the parser must skip them, the same way it skips
+    // `set` / `cd /d` / `rem`.
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
+          "@echo off",
+          "title OpenClaw Gateway",
+          "color 0A",
+          "rem OpenClaw Gateway",
+          "set OPENCLAW_GATEWAY_PORT=18789",
+          "node gateway.js --port 18789",
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result?.programArguments).toEqual(["node", "gateway.js", "--port", "18789"]);
+      },
+    );
+  });
+
+  it("skips @chcp preamble when the encoding marker points to an unknown charset", async () => {
+    // Real-world shape: an `encodeWindowsLauncherScript` output buffer starts
+    // with `@chcp <n> >nul\r\n@rem openclaw-launcher-encoding=<encoding>\r\n`.
+    // When the encoding marker is something iconv doesn't recognize (hand-
+    // edited file, third-party generator, or a future openclaw build whose
+    // encoding name drifts), `decodeWindowsLauncherScript` falls through to
+    // its UTF-8 default — and the `@chcp` preamble stays in the content the
+    // parser iterates. Without the parser-skip patch, the parser mistakes
+    // `@chcp` for the executable and `gateway status` reports
+    // "Service command does not include the gateway subcommand".
+    await withScheduledTaskScript(
+      {
+        // UTF-8 buffer that mimics a real encoded-launcher file. The marker
+        // encoding "definitely-not-a-real-encoding" makes `iconv.encodingExists`
+        // return false in the decoder, forcing the UTF-8 fallback path.
+        scriptLines: [
+          "@chcp 936 >nul",
+          "@rem openclaw-launcher-encoding=definitely-not-a-real-encoding",
+          "rem OpenClaw Gateway (marker-decoder-fallback)",
+          "set OPENCLAW_GATEWAY_PORT=18789",
+          "node C:\\Users\\test\\.openclaw\\dist\\index.js gateway --port 18789",
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result?.programArguments).toEqual([
+          "node",
+          "C:\\Users\\test\\.openclaw\\dist\\index.js",
+          "gateway",
+          "--port",
+          "18789",
+        ]);
+      },
+    );
+  });
 });


### PR DESCRIPTION
## Summary

After #107751 wired `encodeWindowsLauncherScript` into the launcher write sites, generated `gateway.cmd` files for non-ASCII user profiles now look like:

```cmd
@chcp 936 >nul
@rem openclaw-launcher-encoding=cp936
@echo off
rem OpenClaw Gateway (v2026.7.1-2)
set ...
C:\...node.exe ...\index.js gateway --port 18789
```

`readScheduledTaskCommand` in `src/daemon/schtasks-layout.ts` correctly decodes this via `decodeWindowsLauncherScript`, but then iterates the resulting lines looking for the executable command and **stops on the first non-special line**:

```ts
if (line.startsWith("@echo") || lower.startsWith("rem ")) continue;
if (lower.startsWith("set ")) { ... continue; }
if (lower.startsWith("cd /d ")) { ... continue; }
commandLine = line;
break;
```

`@rem openclaw-launcher-encoding=cp936` is correctly skipped (matches `rem `), but `@chcp 936 >nul` is not — so the parser mistakes `chcp` for the service executable. `openclaw gateway status --deep` then reports:

```
Service config issue: Service command does not include the gateway subcommand
```

…and the verification step in `resolveFallbackRuntime` reports:

```
Startup-folder login item installed; gateway listener on port 18789 does not match the persisted command.
```

This is the same class of bug the gateway had on `2026.7.1-2` and earlier (which had a hand-rolled `chcp 65001 >nul` line) — it re-surfaces as soon as the new encoding pipeline prepends its own `@chcp` preamble.

## Fix

Skip `@chcp` (and `title` / `color`, for symmetry — `wscript`-style launchers dont use these today but the parser is a general cmd reader) lines in the parser loop. These are all console-setup helpers, never the executable.

```diff
     for (const rawLine of content.split(/\r?\n/)) {
       const line = rawLine.trim();
       if (!line) continue;
       const lower = normalizeLowercaseStringOrEmpty(line);
       if (line.startsWith("@echo") || lower.startsWith("rem ")) continue;
+      // Skip console-setup helpers so the parser doesnt mistake them for the
+      // launchers executable. Required because encodeWindowsLauncherScript
+      // prepends `@chcp <codePage> >nul` for non-ASCII cmd launchers.
+      if (lower.startsWith("chcp ")) continue;
+      if (lower.startsWith("title ")) continue;
+      if (lower.startsWith("color ")) continue;
       if (lower.startsWith("set ")) {
         const assignment = parseCmdSetAssignment(line.slice(4));
         if (assignment) environment[assignment.key] = assignment.value;
         continue;
       }
       if (lower.startsWith("cd /d ")) {
         workingDirectory = line.slice("cd /d ".length).trim().replace(/^"|"$/g, "");
         continue;
       }
       commandLine = line;
       break;
     }
```

Thats the only change needed — one file, ~5 lines.

## Why this is minimal

- Write path is **already** correctly producing UTF-16-LE-BOM `.vbs` and OEM-encoded `.cmd` with `@chcp` preamble (PR #107751).
- Read path **already** correctly decoding via `decodeWindowsLauncherScript` (PR #107751).
- This PR fixes the only remaining gap: the line-iteration parser inside `readScheduledTaskCommand` that doesnt know about the preamble.

No new dependencies. No behavioral change for ASCII-only profiles (their cmd files have no preamble). Drops straight in.

## Test plan

- [x] `pnpm test --project=daemon src/daemon/schtasks.test.ts` — all 34 tests pass (including 2 new regression tests for raw `chcp` and `title`/`color` lines)
- [ ] Manual smoke-test on a zh-CN Windows VM with a Chinese-username profile (`C:\Users\于\`)
- [ ] `openclaw gateway status --deep` shows the right executable and **no** `Service config issue: Service command does not include the gateway subcommand`
- [ ] Round-trip: install → uninstall → install again produces identical files

## Regression tests added

Two tests in `src/daemon/schtasks.test.ts::readScheduledTaskCommand`:

1. `skips raw chcp line in legacy UTF-8 scripts (#108774 follow-up)` — hand-authored script with a raw `chcp 65001 >nul` line; without the parser-skip fix, `readScheduledTaskCommand` would mistake `chcp` for the executable.
2. `skips title and color console helpers when scanning for the executable` — script with `title OpenClaw Gateway` / `color 0A` between `@echo off` and the executable; without the fix, the parser stops on `color 0A`.

Both write the script directly (raw UTF-8, ASCII content) so the helper lines are genuinely present in what `readScheduledTaskCommand` parses.

## Related

- Closes the readback half of #108774 (`gateway.cmd` mojibake on non-ASCII paths)
- Companion to #107751 (writes the `@chcp` preamble; this PR makes the reader tolerate it)
- Same bug class as #43943s `chcp 65001` workarounds on the older `2026.7.1-2` and earlier