### PR TITLE
fix(ui): reset /model default through server directive

### DIFF
--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -46,14 +46,14 @@ type DefineChatCommandInput = {
 };
 
 /**
- * Keep simple model selections on fast client-side patch paths. Multi-token
- * forms can carry runtime selectors or a prompt, so the server directive parser
- * must own the full atomic transaction.
+ * Keep simple model selections on fast client-side patch paths. Semantic reset
+ * and multi-token forms require the server directive parser to own the full
+ * atomic transaction.
  */
 export function shouldForwardModelCommandToServer(rawArgs: string): boolean {
   const args = rawArgs.trim();
   const normalized = args.toLowerCase();
-  return normalized === "list" || normalized === "status" || /\s/u.test(args);
+  return ["default", "list", "status"].includes(normalized) || /\s/u.test(args);
 }
 
 /** Defines one command with normalized aliases, scope, and argument parsing defaults. */

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -2381,13 +2381,10 @@ describe("tui command handlers", () => {
   it.each([
     { mode: "gateway", local: false, command: "/think default", field: "thinkingLevel" },
     { mode: "gateway", local: false, command: "/fast default", field: "fastMode" },
-    { mode: "gateway", local: false, command: "/model default", field: "model" },
     { mode: "embedded", local: true, command: "/think default", field: "thinkingLevel" },
     { mode: "embedded", local: true, command: "/fast default", field: "fastMode" },
-    { mode: "embedded", local: true, command: "/model default", field: "model" },
     { mode: "gateway", local: false, command: "/think inherit", field: "thinkingLevel" },
     { mode: "embedded", local: true, command: "/fast reset", field: "fastMode" },
-    { mode: "gateway", local: false, command: "/model DEFAULT", field: "model" },
   ])(
     "clears the $field session override for $command in $mode mode",
     async ({ local, command, field }) => {
@@ -2994,13 +2991,24 @@ describe("tui command handlers", () => {
     expect(closeOverlay).toHaveBeenCalledTimes(1);
   });
 
-  it.each(["codex", "openclaw"])(
-    "forwards model/runtime transactions through the server directive path for %s",
-    async (runtime) => {
+  it.each([
+    { local: false, command: "/model default" },
+    { local: true, command: "/model default" },
+    { local: false, command: "/model DEFAULT" },
+    {
+      local: false,
+      command: "/model openai/gpt-5.6-luna --runtime codex continue with this model",
+    },
+    {
+      local: false,
+      command: "/model openai/gpt-5.6-luna --runtime openclaw continue with this model",
+    },
+  ])(
+    "forwards $command through the server directive path (local: $local)",
+    async ({ command, local }) => {
       const sendChat = vi.fn().mockResolvedValue({ status: "ok" });
       const patchSession = vi.fn();
-      const command = `/model openai/gpt-5.6-luna --runtime ${runtime} continue with this model`;
-      const { handleCommand } = createHarness({ sendChat, patchSession });
+      const { handleCommand } = createHarness({ sendChat, patchSession, opts: { local } });
 
       await handleCommand(command);
 

--- a/ui/src/e2e/chat-continue-in-terminal.e2e.test.ts
+++ b/ui/src/e2e/chat-continue-in-terminal.e2e.test.ts
@@ -173,7 +173,10 @@ suite.define(() => {
         });
         await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
         const activePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--active");
-        await activePane.getByText("Mobile session menu proof.", { exact: true }).waitFor();
+        await activePane
+          .getByRole("paragraph")
+          .filter({ hasText: /^Mobile session menu proof\.$/ })
+          .waitFor();
 
         const menuTrigger = activePane.getByRole("button", {
           name: "Actions for Terminal continuation",

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -3428,6 +3428,28 @@ describe("handleSendChat", () => {
     expect(refreshCurrentSessionTools).toHaveBeenCalledTimes(1);
   });
 
+  it.each(["/model default", "/model DEFAULT"])(
+    "forwards semantic model reset commands through chat.send: %s",
+    async (command) => {
+      const host = makeChatHost({
+        requestHandlers: {
+          "chat.send": { status: "started" },
+          "sessions.patch": createResolvedModelPatch("default", "openai"),
+        },
+        sessionKey: "main",
+        chatMessage: command,
+      });
+
+      await handleSendChat(host);
+
+      expect(host.request).toHaveBeenCalledWith(
+        "chat.send",
+        expect.objectContaining({ message: command, sessionKey: "main" }),
+      );
+      expect(host.request).not.toHaveBeenCalledWith("sessions.patch", expect.anything());
+    },
+  );
+
   it("queues local slash commands while the gateway client is unavailable", async () => {
     const host = makeChatHost({
       client: null,


### PR DESCRIPTION
Closes #129889

## What Problem This Solves

Fixes an issue where Control UI users entering `/model default` would send a literal `model: "default"` session patch instead of resetting the session to its configured default. The command could leave the session on the wrong route or create an invalid provider/default selection.

## Why This Change Was Made

The shared model-command router now sends the reserved `default` reset token through the existing server directive path, which already owns default resolution, auth compatibility, model-switch state, and persistence. Simple concrete model selections remain on the fast client-side patch path; Control UI and TUI no longer maintain separate reset semantics.

Production LOC: +4/-4 (net 0). Tests: +42/-9 (net +33).

AI-assisted: yes.

## User Impact

`/model default` now reliably returns an existing session to its configured model in Control UI and TUI, with the same behavior as other channel command surfaces.

## Evidence

- Pre-fix focused regression: the new Control UI cases failed because `/model default` called `sessions.patch` with `model: "default"` instead of `chat.send`.
- Focused tests: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts src/tui/tui-command-handlers.test.ts src/auto-reply/model.test.ts` — 540 tests passed across 3 shards on the rebased head.
- Initial exact-head CI exposed a pre-existing strict-locator failure in the newly added mobile session-menu E2E: hidden accessibility announcement text duplicated the visible transcript text. The assertion now targets the anchored visible paragraph; its focused real-browser file passes 2/2, and a fresh autoreview of that repair was clean.
- Changed gate: `node scripts/check-changed.mjs -- src/auto-reply/commands-registry.shared.ts src/tui/tui-command-handlers.test.ts ui/src/pages/chat/chat-send.test.ts` — passed formatting, typechecks, lint, import-cycle, i18n, database/state, plugin-boundary, and repository guards.
- Build: `pnpm build` and a final `pnpm ui:build` passed.
- Fresh structured autoreview: clean, no accepted/actionable findings.
- Real isolated flow: built Control UI + ephemeral Gateway + local mock provider. Before, WebSocket traffic contained `sessions.patch { model: "default" }` and the alternate session model remained selected. After, traffic contains `chat.send { message: "/model default" }`, the UI reports `Session model reset to configured default`, and `sessions.list` changes the effective session model from the alternate fixture model to the configured default.

The attached before/after screenshots and short recording were inspected after capture and contain only the isolated QA fixture.

![Before: the Control UI keeps the command on the literal sessions.patch path](https://github.com/user-attachments/assets/95e62445-959e-4aaf-8177-b9ab1153d21b)

![After: the server directive confirms the configured-default reset and updates the active model](https://github.com/user-attachments/assets/178c0132-7e14-4a3e-b41e-7b9c7d5bdb36)

https://github.com/user-attachments/assets/2c8d17e6-2a19-4619-b558-48b6fc7b9b91
