### PR TITLE
refactor(gateway): reuse cron stream owner callback contract

### DIFF
--- a/src/gateway/cron-stream-watchers.ts
+++ b/src/gateway/cron-stream-watchers.ts
@@ -1,7 +1,6 @@
 import { resolveCronTriggerMinIntervalMs } from "../config/cron-limits.js";
 import type { CronJob, CronJobState } from "../cron/types.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
-import type { ProcessSupervisor } from "../process/supervisor/index.js";
 import {
   CronStreamJobOwner,
   isCronStreamJob,
@@ -9,17 +8,12 @@ import {
   type CronStreamOwnerSnapshot,
   type CronStreamStopReason,
 } from "./cron-stream-job-owner.js";
-import type { CronStreamFireDisposition, CronStreamJob } from "./cron-stream-output.js";
+import type { CronStreamJob } from "./cron-stream-output.js";
 
 export type { CronStreamFireDisposition } from "./cron-stream-output.js";
 
 const MAX_RETIRED_COUNTER_SEEDS = 1_024;
 const MAX_MUTATION_EPOCHS = 1_024;
-
-type Logger = {
-  info: (obj: unknown, msg?: string) => void;
-  warn: (obj: unknown, msg?: string) => void;
-};
 
 type CronStreamWatchers = {
   reconcile: (jobs: CronJob[], enabled: boolean, triggersEnabled?: boolean) => Promise<void>;
@@ -51,42 +45,13 @@ export function resolveStreamStopReason(input: {
 }
 
 /** Supervise line-producing cron sources through one serialized owner per job. */
-export function createCronStreamWatchers(params: {
-  getProcessSupervisor: () => ProcessSupervisor;
-  /** Test seams; production uses the built-in cadence and retry schedules. */
-  minIntervalMs?: number;
-  retryBackoffMs?: number[];
-  updateState: (
-    jobId: string,
-    patch: Partial<CronJobState>,
-    streamScheduleKey: string,
-    streamSourceIdentity: string,
-  ) => Promise<boolean | void>;
-  retireSource: (
-    jobId: string,
-    streamScheduleKey: string,
-    streamSourceIdentity: string,
-  ) => Promise<string | undefined>;
-  updateCounters?: (
-    jobId: string,
-    counters: Pick<CronJobState, "streamDroppedBatches" | "streamCoalescedBatches">,
-  ) => Promise<void>;
-  recordFailure: (
-    jobId: string,
-    error: string,
-    patch: Partial<CronJobState>,
-    streamScheduleKey: string,
-    streamSourceIdentity: string,
-  ) => Promise<void>;
-  fireBatch: (
-    job: CronJob,
-    batch: string,
-    streamScheduleKey: string,
-    streamSourceIdentity: string,
-  ) => Promise<CronStreamFireDisposition>;
-  logger: Logger;
-  nowMs?: () => number;
-}): CronStreamWatchers {
+export function createCronStreamWatchers(
+  params: Omit<CronStreamOwnerParams, "minIntervalMs" | "nowMs"> & {
+    /** Test seams; production uses the built-in cadence and retry schedules. */
+    minIntervalMs?: number;
+    nowMs?: () => number;
+  },
+): CronStreamWatchers {
   const owners = new Map<string, CronStreamJobOwner>();
   const retiredCounterSeeds = new Map<
     string,


### PR DESCRIPTION
## What Problem This Solves

Cron stream watcher and job-owner maintenance previously duplicated the same process, lifecycle callback, logging, and scheduling option contracts, allowing those internal boundaries to drift independently.

## Why This Change Was Made

Derive watcher options directly from the existing job-owner contract while retaining the two intentionally optional watcher overrides. Remove the redundant local logger shape and type-only imports.

## User Impact

None. This is an internal type-only cleanup; process supervision, lifecycle ordering, callbacks, scheduling defaults, and generated runtime JavaScript stay unchanged.

## Evidence

- One production file: 8 lines added, 43 removed, for 35 fewer lines; no tests or public contracts changed.
- Before/after generated JavaScript is byte-for-byte identical.
- Focused gateway owner, output, interleaving, real subprocess, and shutdown coverage: 10 files and 191 tests passed.
- Previously broken QA-lab inherited-baseline fixtures: 2 files and 13 tests passed on repaired main.
- Full unrestricted changed gate passed, including all dead-code scans, core and core-test typechecks, lint, ownership, lifecycle, and import-cycle guards.
- Fresh exact-commit review and separate independent read-only review both approved.