### PR TITLE
chore(terminal): remove duplicate display-string table test

### DIFF
--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -85,24 +85,6 @@ describe("renderTable", () => {
     expect(segment).not.toHaveBeenCalled();
   });
 
-  it.each(["$&", "$`", "$'", "$$"])(
-    "displays a literal %s home path in terminal tables",
-    (pattern) => {
-      const home = path.resolve("test-home", `${pattern}user`);
-      vi.stubEnv("HOME", home);
-      vi.stubEnv("USERPROFILE", "");
-      vi.stubEnv("OPENCLAW_HOME", "~/state");
-
-      expect(
-        renderTable({
-          columns: [{ key: "location", header: "Location" }],
-          rows: [{ location: `${home}/state/project` }],
-          border: "none",
-        }),
-      ).toBe("Location\n$OPENCLAW_HOME/project\n");
-    },
-  );
-
   it("prefers shrinking flex columns to avoid wrapping non-flex labels", () => {
     const out = renderTable({
       width: 40,


### PR DESCRIPTION
## What Problem This Solves

The terminal table suite repeated the same four JavaScript replacement-token cases already covered directly by the display-string owner, adding maintenance and CI work without protecting a distinct behavior.

## Why This Change Was Made

Remove the table-level replay of `$&`, ``$` ``, `$'`, and `$$`. The canonical `displayString` regression retains all four cases, while `table.test.ts` still verifies that table cells apply home-path display shortening for exact, child, sibling-prefix, and embedded paths.

## User Impact

No user-visible behavior changes. This only removes four duplicate test cases.

## Evidence

- Baseline `display-string.test.ts` + `table.test.ts`: 65 cases total; 64 passed, 1 Windows-only skipped.
- Current suites: 61 cases total; 60 passed, 1 Windows-only skipped.
- `node scripts/check-changed.mjs -- packages/terminal-core/src/table.test.ts` passed, including all core test type shards, formatting, and targeted oxlint.
- `git diff --check` passed.
- Fresh autoreview found no actionable findings (patch-correct confidence 0.99).
