### PR TITLE
fix(webchat): document attachments disappear after refresh

### DIFF
--- a/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
+++ b/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
@@ -21,9 +21,7 @@ import { extractMessagingToolSourceReplyPayload } from "../embedded-agent-messag
 import { buildEmbeddedRunPayloads } from "../embedded-agent-runner/run/payloads.js";
 import { createMessageTool } from "./message-tool-execution.js";
 
-function createCurrentSourceMessageTool(
-  params: { workspaceDir?: string; sandboxRoot?: string } = {},
-) {
+function createCurrentSourceMessageTool(params: { workspaceDir?: string } = {}) {
   return createMessageTool({
     config: { agents: { entries: { main: { default: true } } } },
     currentChannelProvider: "webchat",
@@ -31,7 +29,6 @@ function createCurrentSourceMessageTool(
     agentSessionKey: "agent:main:webchat:dm:dashboard",
     runId: "webchat-run",
     workspaceDir: params.workspaceDir,
-    sandboxRoot: params.sandboxRoot,
     getScopedChannelsCommandSecretTargets: () => ({ targetIds: new Set<string>() }),
     resolveCommandSecretRefsViaGateway: async ({ config }) => ({
       resolvedConfig: config,
@@ -129,52 +126,6 @@ describe("WebChat message tool internal source reply", () => {
     );
   });
 
-  it("preserves structured attachment metadata after rewriting a sandbox path", async () => {
-    await withOpenClawTestState(
-      { layout: "state-only", prefix: "message-tool-source-sandbox-attachment-" },
-      async (state) => {
-        await fs.mkdir(state.workspaceDir, { recursive: true });
-        const sourcePath = path.join(state.workspaceDir, "source.csv");
-        const sourceContents = "id,label\n1,alpha\n2,beta\n";
-        await fs.writeFile(sourcePath, sourceContents, "utf8");
-        const tool = createCurrentSourceMessageTool({
-          workspaceDir: state.workspaceDir,
-          sandboxRoot: state.workspaceDir,
-        });
-
-        const toolResult = await tool.execute("message-sandbox-attachment-call", {
-          action: "send",
-          message: "Sandbox attachment.",
-          attachments: [
-            {
-              type: "file",
-              media: "/workspace/source.csv",
-              name: "declared-report.csv",
-              contentType: "text/csv",
-            },
-          ],
-        });
-
-        expect(toolResult.details).toMatchObject({
-          sourceReply: {
-            text: "Sandbox attachment.",
-            attachments: [
-              {
-                name: "declared-report.csv",
-                mimeType: "text/csv",
-              },
-            ],
-          },
-        });
-        const sourceReply = extractMessagingToolSourceReplyPayload(toolResult);
-        expect(sourceReply?.mediaUrls).toHaveLength(1);
-        const mediaPath = sourceReply?.mediaUrls?.[0];
-        expect(mediaPath).toBeTruthy();
-        await expect(fs.readFile(mediaPath as string, "utf8")).resolves.toBe(sourceContents);
-      },
-    );
-  });
-
   it("rejects disallowed local media before acknowledging the current-source send", async () => {
     await withOpenClawTestState(
       { layout: "state-only", prefix: "message-tool-source-path-" },
@@ -196,7 +147,7 @@ describe("WebChat message tool internal source reply", () => {
     );
   });
 
-  it("publishes managed images and documents with the current run owner", async () => {
+  it("publishes managed images and sandbox documents with the current run owner", async () => {
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-internal-source-reply-" },
       async (state) => {
@@ -234,6 +185,8 @@ describe("WebChat message tool internal source reply", () => {
           sessionId,
           agentId: "main",
           runId: "restart-proof-run",
+          workspaceDir,
+          sandboxRoot: workspaceDir,
           getScopedChannelsCommandSecretTargets: () => ({ targetIds: new Set<string>() }),
           resolveCommandSecretRefsViaGateway: async () => ({
             resolvedConfig: config,
@@ -246,7 +199,15 @@ describe("WebChat message tool internal source reply", () => {
         const sendParams = {
           action: "send" as const,
           message: "Durable attachment reply",
-          mediaUrls: [...imagePaths, documentPath],
+          mediaUrls: imagePaths,
+          attachments: [
+            {
+              type: "file" as const,
+              media: "/workspace/report.csv",
+              name: "declared-report.csv",
+              contentType: "text/csv",
+            },
+          ],
         };
         const updates: SessionTranscriptUpdate[] = [];
         const publishedDownloads: Array<Promise<unknown>> = [];
@@ -329,7 +290,7 @@ describe("WebChat message tool internal source reply", () => {
         expect(document).toMatchObject({
           type: "document",
           artifactId: expect.stringMatching(/^artifact_managed_media_/u),
-          fileName: "report.csv",
+          fileName: "declared-report.csv",
           mimeType: "text/csv",
         });
         expect(JSON.stringify(assistant)).not.toContain(workspaceDir);
@@ -354,7 +315,7 @@ describe("WebChat message tool internal source reply", () => {
         await expect(Promise.all(publishedDownloads)).resolves.toEqual([
           expect.objectContaining({ type: "image" }),
           expect.objectContaining({ type: "image" }),
-          expect.objectContaining({ type: "document", title: "report.csv" }),
+          expect.objectContaining({ type: "document", title: "declared-report.csv" }),
         ]);
         for (const block of content.filter(
           (entry) => entry.type === "image" || entry.type === "document",

--- a/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
+++ b/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
@@ -281,6 +281,18 @@ describe("WebChat message tool internal source reply", () => {
           sourceReplySink: "internal-ui",
           idempotencyKey: expect.any(String),
         });
+        const sourceReplyDetails = (
+          toolResult.details as {
+            sourceReply?: {
+              mediaUrls?: string[];
+              attachments?: Array<{ url?: string }>;
+            };
+          }
+        ).sourceReply;
+        expect(sourceReplyDetails?.attachments).toEqual(
+          sourceReplyDetails?.mediaUrls?.map((url) => expect.objectContaining({ url })),
+        );
+        expect(JSON.stringify(sourceReplyDetails)).not.toContain(workspaceDir);
         expect(content[0]).toEqual({ type: "text", text: "Durable attachment reply" });
         expect(image).toMatchObject({
           type: "image",

--- a/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
+++ b/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
@@ -21,7 +21,9 @@ import { extractMessagingToolSourceReplyPayload } from "../embedded-agent-messag
 import { buildEmbeddedRunPayloads } from "../embedded-agent-runner/run/payloads.js";
 import { createMessageTool } from "./message-tool-execution.js";
 
-function createCurrentSourceMessageTool(params: { workspaceDir?: string } = {}) {
+function createCurrentSourceMessageTool(
+  params: { workspaceDir?: string; sandboxRoot?: string } = {},
+) {
   return createMessageTool({
     config: { agents: { entries: { main: { default: true } } } },
     currentChannelProvider: "webchat",
@@ -29,6 +31,7 @@ function createCurrentSourceMessageTool(params: { workspaceDir?: string } = {}) 
     agentSessionKey: "agent:main:webchat:dm:dashboard",
     runId: "webchat-run",
     workspaceDir: params.workspaceDir,
+    sandboxRoot: params.sandboxRoot,
     getScopedChannelsCommandSecretTargets: () => ({ targetIds: new Set<string>() }),
     resolveCommandSecretRefsViaGateway: async ({ config }) => ({
       resolvedConfig: config,
@@ -122,6 +125,52 @@ describe("WebChat message tool internal source reply", () => {
         const mediaPath = sourceReply?.mediaUrls?.[0];
         expect(mediaPath).toBeTruthy();
         await expect(fs.readFile(mediaPath as string)).resolves.toEqual(attachment);
+      },
+    );
+  });
+
+  it("preserves structured attachment metadata after rewriting a sandbox path", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "message-tool-source-sandbox-attachment-" },
+      async (state) => {
+        await fs.mkdir(state.workspaceDir, { recursive: true });
+        const sourcePath = path.join(state.workspaceDir, "source.csv");
+        const sourceContents = "id,label\n1,alpha\n2,beta\n";
+        await fs.writeFile(sourcePath, sourceContents, "utf8");
+        const tool = createCurrentSourceMessageTool({
+          workspaceDir: state.workspaceDir,
+          sandboxRoot: state.workspaceDir,
+        });
+
+        const toolResult = await tool.execute("message-sandbox-attachment-call", {
+          action: "send",
+          message: "Sandbox attachment.",
+          attachments: [
+            {
+              type: "file",
+              media: "/workspace/source.csv",
+              name: "declared-report.csv",
+              contentType: "text/csv",
+            },
+          ],
+        });
+
+        expect(toolResult.details).toMatchObject({
+          sourceReply: {
+            text: "Sandbox attachment.",
+            attachments: [
+              {
+                name: "declared-report.csv",
+                mimeType: "text/csv",
+              },
+            ],
+          },
+        });
+        const sourceReply = extractMessagingToolSourceReplyPayload(toolResult);
+        expect(sourceReply?.mediaUrls).toHaveLength(1);
+        const mediaPath = sourceReply?.mediaUrls?.[0];
+        expect(mediaPath).toBeTruthy();
+        await expect(fs.readFile(mediaPath as string, "utf8")).resolves.toBe(sourceContents);
       },
     );
   });

--- a/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
+++ b/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
@@ -147,7 +147,7 @@ describe("WebChat message tool internal source reply", () => {
     );
   });
 
-  it("publishes managed images with the current run owner", async () => {
+  it("publishes managed images and documents with the current run owner", async () => {
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-internal-source-reply-" },
       async (state) => {
@@ -157,12 +157,14 @@ describe("WebChat message tool internal source reply", () => {
         const sessionKey = "agent:main:webchat:dm:restart-proof";
         const sessionId = "restart-proof-session";
         const imagePaths = ["first.png", "second.png"].map((name) => path.join(workspaceDir, name));
+        const documentPath = path.join(workspaceDir, "report.csv");
         await fs.mkdir(workspaceDir, { recursive: true });
         await Promise.all(
           imagePaths.map((imagePath) =>
             fs.writeFile(imagePath, Buffer.from(TINY_PNG_BASE64, "base64")),
           ),
         );
+        await fs.writeFile(documentPath, "account,balance\nprimary,42\n", "utf8");
 
         await replaceSessionEntry(
           { agentId: "main", sessionKey, storePath },
@@ -194,8 +196,8 @@ describe("WebChat message tool internal source reply", () => {
 
         const sendParams = {
           action: "send" as const,
-          message: "Durable image reply",
-          mediaUrls: imagePaths,
+          message: "Durable attachment reply",
+          mediaUrls: [...imagePaths, documentPath],
         };
         const updates: SessionTranscriptUpdate[] = [];
         const publishedDownloads: Array<Promise<unknown>> = [];
@@ -205,7 +207,9 @@ describe("WebChat message tool internal source reply", () => {
             update.message && typeof update.message === "object"
               ? (update.message as { content?: Array<Record<string, unknown>> }).content
               : undefined;
-          for (const block of content?.filter((entry) => entry.type === "image") ?? []) {
+          for (const block of content?.filter(
+            (entry) => entry.type === "image" || entry.type === "document",
+          ) ?? []) {
             publishedDownloads.push(
               resolveManagedOutgoingMediaArtifactDownload({
                 sessionKey,
@@ -262,18 +266,25 @@ describe("WebChat message tool internal source reply", () => {
           ? (assistant.content as Array<Record<string, unknown>>)
           : [];
         const image = content.find((block) => block.type === "image");
+        const document = content.find((block) => block.type === "document");
         expect(toolResult.details).toMatchObject({
           sourceReplySink: "internal-ui",
           idempotencyKey: expect.any(String),
         });
-        expect(content[0]).toEqual({ type: "text", text: "Durable image reply" });
+        expect(content[0]).toEqual({ type: "text", text: "Durable attachment reply" });
         expect(image).toMatchObject({
           type: "image",
           artifactId: expect.stringMatching(/^artifact_managed_image_/u),
         });
         expect(content.filter((block) => block.type === "image")).toHaveLength(2);
+        expect(document).toMatchObject({
+          type: "document",
+          artifactId: expect.stringMatching(/^artifact_managed_media_/u),
+          fileName: "report.csv",
+          mimeType: "text/csv",
+        });
         expect(JSON.stringify(assistant)).not.toContain(workspaceDir);
-        expect(listManagedImageRecordEntries({ stateDir, sessionKey })).toHaveLength(2);
+        expect(listManagedImageRecordEntries({ stateDir, sessionKey })).toHaveLength(3);
         const published = updates.find(
           (update) =>
             update.runId === "restart-proof-run" &&
@@ -288,12 +299,17 @@ describe("WebChat message tool internal source reply", () => {
         const publishedContent = (
           published?.message as { content?: Array<Record<string, unknown>> }
         )?.content;
-        expect(publishedContent?.filter((block) => block.type === "image")).toHaveLength(2);
+        expect(
+          publishedContent?.filter((block) => block.type === "image" || block.type === "document"),
+        ).toHaveLength(3);
         await expect(Promise.all(publishedDownloads)).resolves.toEqual([
           expect.objectContaining({ type: "image" }),
           expect.objectContaining({ type: "image" }),
+          expect.objectContaining({ type: "document", title: "report.csv" }),
         ]);
-        for (const block of content.filter((entry) => entry.type === "image")) {
+        for (const block of content.filter(
+          (entry) => entry.type === "image" || entry.type === "document",
+        )) {
           await expect(
             resolveManagedOutgoingMediaArtifactDownload({
               sessionKey,
@@ -301,7 +317,7 @@ describe("WebChat message tool internal source reply", () => {
               artifactId: String(block.artifactId),
               stateDir,
             }),
-          ).resolves.toMatchObject({ type: "image" });
+          ).resolves.toMatchObject({ type: block.type });
         }
       },
     );

--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -31,6 +31,7 @@ const fsSafeMocks = vi.hoisted(() => {
 
   return {
     FsSafeError: MockFsSafeError,
+    openLocalFileSafely: vi.fn(),
     rootCopyFrom: vi.fn(),
     root: vi.fn(),
     readLocalFileSafely: vi.fn(),

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -207,6 +207,38 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(ensureSandboxWorkspaceForSession).not.toHaveBeenCalled();
   });
 
+  it("realigns structured attachment sources after staging sandbox media", async () => {
+    const sandboxRoot = "/tmp/sandboxes/session-1";
+    const sourcePath = path.join(sandboxRoot, "reports", "report.csv");
+    const normalize = createTestReplyMediaNormalizer({
+      sandboxRoot,
+      sandboxContainerWorkdir: "/workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: [sourcePath],
+      attachments: [
+        {
+          path: sourcePath,
+          url: sourcePath,
+          mediaUrl: sourcePath,
+          filePath: sourcePath,
+          name: "declared-report.csv",
+          mimeType: "text/csv",
+        },
+      ],
+    });
+
+    expect(result.attachments).toEqual([
+      {
+        url: "/tmp/outbound-media/report.csv",
+        name: "declared-report.csv",
+        mimeType: "text/csv",
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toContain(sourcePath);
+  });
+
   it("drops sandbox-mapped media when staging fails instead of retrying the workspace fallback", async () => {
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -239,6 +239,27 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(JSON.stringify(result)).not.toContain(sourcePath);
   });
 
+  it("keeps attachment metadata aligned when blank media entries are dropped", async () => {
+    const normalize = createTestReplyMediaNormalizer();
+
+    const result = await normalize({
+      mediaUrls: ["   ", "./out/report.csv"],
+      attachments: [
+        { name: "wrong.png", mimeType: "image/png" },
+        { name: "declared-report.csv", mimeType: "text/csv" },
+      ],
+    });
+
+    expectMedia(result, "/tmp/outbound-media/report.csv", ["/tmp/outbound-media/report.csv"]);
+    expect(result.attachments).toEqual([
+      {
+        url: "/tmp/outbound-media/report.csv",
+        name: "declared-report.csv",
+        mimeType: "text/csv",
+      },
+    ]);
+  });
+
   it("drops sandbox-mapped media when staging fails instead of retrying the workspace fallback", async () => {
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -217,9 +217,10 @@ export function createReplyMediaPathNormalizer(params: {
     }
 
     const normalizedMedia: string[] = [];
+    const normalizedAttachments: NonNullable<ReplyPayload["attachments"]> = [];
     const seen = new Set<string>();
     let firstMediaDropError: unknown;
-    for (const media of mediaList) {
+    for (const [index, media] of mediaList.entries()) {
       let normalized: string;
       try {
         normalized = await normalizeMediaSource(media);
@@ -233,6 +234,13 @@ export function createReplyMediaPathNormalizer(params: {
       }
       seen.add(normalized);
       normalizedMedia.push(normalized);
+      if (payload.attachments) {
+        const attachment = { ...payload.attachments[index], url: normalized };
+        delete attachment.path;
+        delete attachment.mediaUrl;
+        delete attachment.filePath;
+        normalizedAttachments.push(attachment);
+      }
     }
 
     const text =
@@ -246,6 +254,7 @@ export function createReplyMediaPathNormalizer(params: {
         text,
         mediaUrl: undefined,
         mediaUrls: undefined,
+        ...(payload.attachments ? { attachments: undefined } : {}),
       });
     }
 
@@ -254,6 +263,7 @@ export function createReplyMediaPathNormalizer(params: {
       text,
       mediaUrl: normalizedMedia[0],
       mediaUrls: normalizedMedia,
+      ...(payload.attachments ? { attachments: normalizedAttachments } : {}),
     });
   };
 }

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -1,7 +1,7 @@
 // Resolves media paths from reply payloads into runtime attachment metadata.
 import path from "node:path";
 import { isPassThroughRemoteMediaSource } from "@openclaw/media-core/media-source-url";
-import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import { resolveOutboundMediaUrls } from "openclaw/plugin-sdk/reply-payload";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolvePathFromInput, toRelativeWorkspacePath } from "../../agents/path-policy.js";
 import {
@@ -38,7 +38,7 @@ function isLikelyLocalMediaSource(media: string): boolean {
 }
 
 function getPayloadMediaList(payload: ReplyPayload): string[] {
-  return resolveSendableOutboundReplyParts(payload).mediaUrls;
+  return resolveOutboundMediaUrls(payload);
 }
 
 export function createReplyMediaPathNormalizer(params: {

--- a/src/gateway/internal-source-reply-persistence.ts
+++ b/src/gateway/internal-source-reply-persistence.ts
@@ -101,12 +101,16 @@ export async function persistInternalSourceReply(params: {
       sessionKey: params.sessionKey,
       agentId: params.agentId,
       mediaUrls,
+      attachments: params.payload.attachments,
       messageId,
       localRoots: getAgentScopedMediaLocalRootsForSources({
         cfg: params.cfg,
         agentId: params.agentId,
         mediaSources: mediaUrls,
       }),
+      // The message action runner has already validated and staged these paths into
+      // gateway-owned storage before this persistence boundary is reached.
+      allowLocalNonImage: true,
     });
     const content: Array<Record<string, unknown>> = [
       ...(params.payload.text ? [{ type: "text", text: params.payload.text }] : []),

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -1528,6 +1528,36 @@ describe("createManagedOutgoingImageBlocks", () => {
     expect(requireBlock(blocks)).toMatchObject({ type: "audio", fileName: "theme.mp3" });
   });
 
+  it("creates managed document blocks with media artifact ids", async () => {
+    const sourcePath = path.join(stateDir, "workspace", "report.csv");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, "account,balance\nprimary,42\n", "utf8");
+
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [sourcePath],
+      stateDir,
+      localRoots: [path.join(stateDir, "workspace")],
+      allowLocalNonImage: true,
+    });
+
+    expect(blocks).toHaveLength(1);
+    const block = requireBlock(blocks);
+    expect(block).toMatchObject({
+      type: "document",
+      mimeType: "text/csv",
+      fileName: "report.csv",
+    });
+    const attachmentId = requireAttachmentIdFromUrl(block.url);
+    expect(block.artifactId).toBe(`${MANAGED_OUTGOING_MEDIA_ARTIFACT_ID_PREFIX}${attachmentId}`);
+    expect(readManagedImageRecord(attachmentId, stateDir)?.original).toMatchObject({
+      contentType: "text/csv",
+      filename: "report.csv",
+      width: null,
+      height: null,
+    });
+  });
+
   it("marks exotic managed media metadata for playback transcoding", async () => {
     const sourcePath = path.join(stateDir, "workspace", "voice.caf");
     await fs.mkdir(path.dirname(sourcePath), { recursive: true });
@@ -2046,17 +2076,18 @@ describe("createManagedOutgoingImageBlocks", () => {
     }
   });
 
-  it("drops downloaded non-image sources without leaving orphaned originals", async () => {
+  it("rejects untrusted local documents without leaving orphaned originals", async () => {
     const pdfPath = path.join(stateDir, "not-an-image.pdf");
     await fs.writeFile(pdfPath, Buffer.from("%PDF-1.4\n% test\n"));
 
-    const blocks = await createManagedOutgoingImageBlocks({
-      sessionKey: "agent:main:main",
-      mediaUrls: [pdfPath],
-      stateDir,
-      localRoots: [stateDir],
-    });
-    expect(blocks).toStrictEqual([]);
+    await expect(
+      createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: [pdfPath],
+        stateDir,
+        localRoots: [stateDir],
+      }),
+    ).rejects.toThrow(/Managed document attachment.*could not be prepared/u);
     const originalsDir = path.join(stateDir, "media", "outgoing", "originals");
     let originals: string[] | null = null;
     try {

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -2001,6 +2001,46 @@ describe("createManagedOutgoingImageBlocks", () => {
     }
   });
 
+  it("reports the detected image cap for oversized remote media", async () => {
+    const imageBuffer = Buffer.from(TINY_PNG_BASE64, "base64");
+    const server = http.createServer((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/octet-stream");
+      res.end(imageBuffer);
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address() as AddressInfo;
+    setMediaStoreNetworkDepsForTest({
+      resolvePinnedHostname: async (hostname) => ({
+        hostname,
+        addresses: ["127.0.0.1"],
+        lookup: createPinnedLookup({ hostname, addresses: ["127.0.0.1"] }),
+      }),
+    });
+
+    try {
+      await expect(
+        withEnvAsync(
+          { OPENCLAW_STATE_DIR: stateDir },
+          async () =>
+            await createManagedOutgoingImageBlocks({
+              sessionKey: "agent:main:main",
+              mediaUrls: [`http://127.0.0.1:${address.port}/download`],
+              stateDir,
+              limits: { maxBytes: 32 },
+            }),
+        ),
+      ).rejects.toThrow(/Managed image attachment .* exceeds the 32 bytes byte limit/u);
+    } finally {
+      setMediaStoreNetworkDepsForTest();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("rejects local image paths outside allowed roots", async () => {
     const outsideDir = tempDirs.make("managed-image-outside-");
     const outsidePath = path.join(outsideDir, "outside.png");
@@ -2035,6 +2075,23 @@ describe("createManagedOutgoingImageBlocks", () => {
 
     expect(blocks).toHaveLength(1);
     expect(requireBlock(blocks).type).toBe("image");
+  });
+
+  it("reports the detected image cap for oversized local media", async () => {
+    const allowedDir = path.join(stateDir, "workspace", "uploads");
+    const allowedPath = path.join(allowedDir, "inside.png");
+    await fs.mkdir(allowedDir, { recursive: true });
+    await fs.writeFile(allowedPath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+    await expect(
+      createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: [allowedPath],
+        stateDir,
+        localRoots: [path.join(stateDir, "workspace")],
+        limits: { maxBytes: 32 },
+      }),
+    ).rejects.toThrow(/Managed image attachment .* exceeds the 32 bytes byte limit/u);
   });
 
   it.each(["application/octet-stream", "binary/octet-stream"])(

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -2037,6 +2037,26 @@ describe("createManagedOutgoingImageBlocks", () => {
     expect(requireBlock(blocks).type).toBe("image");
   });
 
+  it.each(["application/octet-stream", "binary/octet-stream"])(
+    "ignores generic %s metadata when authorizing a known local image",
+    async (mimeType) => {
+      const allowedDir = path.join(stateDir, "workspace", "uploads");
+      const allowedPath = path.join(allowedDir, "inside.png");
+      await fs.mkdir(allowedDir, { recursive: true });
+      await fs.writeFile(allowedPath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+      const blocks = await createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: [allowedPath],
+        attachments: [{ type: "file", mimeType }],
+        stateDir,
+        localRoots: [path.join(stateDir, "workspace")],
+      });
+
+      expect(requireBlock(blocks)).toMatchObject({ type: "image", mimeType: "image/png" });
+    },
+  );
+
   it("keeps byte detection authoritative after hinted-kind ingestion", async () => {
     const sourcePath = path.join(stateDir, "workspace", "report.png");
     await fs.mkdir(path.dirname(sourcePath), { recursive: true });

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -2037,6 +2037,29 @@ describe("createManagedOutgoingImageBlocks", () => {
     expect(requireBlock(blocks).type).toBe("image");
   });
 
+  it("keeps byte detection authoritative after hinted-kind ingestion", async () => {
+    const sourcePath = path.join(stateDir, "workspace", "report.png");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(
+      sourcePath,
+      Buffer.concat([Buffer.from("%PDF-1.4\n% test\n"), Buffer.alloc(128)]),
+    );
+
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [sourcePath],
+      stateDir,
+      localRoots: [path.dirname(sourcePath)],
+      allowLocalNonImage: true,
+      limits: { maxBytes: 32 },
+    });
+
+    expect(requireBlock(blocks)).toMatchObject({
+      type: "document",
+      mimeType: "application/pdf",
+    });
+  });
+
   it("allows managed inbound image paths before validating explicit roots", async () => {
     const inboundPath = path.join(stateDir, "media", "inbound", "inbound.png");
     await fs.mkdir(path.dirname(inboundPath), { recursive: true });

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -2060,6 +2060,26 @@ describe("createManagedOutgoingImageBlocks", () => {
     });
   });
 
+  it("uses structured metadata to ingest an extensionless document", async () => {
+    const sourcePath = path.join(stateDir, "workspace", "opaque-upload");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, "id,label\n1,alpha\n");
+
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [sourcePath],
+      attachments: [{ type: "file", name: "report.csv", mimeType: "text/csv" }],
+      stateDir,
+      localRoots: [path.dirname(sourcePath)],
+      allowLocalNonImage: true,
+    });
+
+    const block = requireBlock(blocks);
+    expect(block).toMatchObject({ type: "document", mimeType: "text/csv" });
+    const record = readManagedImageRecord(requireAttachmentIdFromUrl(block.url), stateDir);
+    expect(record?.original.filename).toBe("report.csv");
+  });
+
   it("allows managed inbound image paths before validating explicit roots", async () => {
     const inboundPath = path.join(stateDir, "media", "inbound", "inbound.png");
     await fs.mkdir(path.dirname(inboundPath), { recursive: true });
@@ -2119,6 +2139,51 @@ describe("createManagedOutgoingImageBlocks", () => {
       expect((error as NodeJS.ErrnoException).code).toBe("ENOENT");
     }
     expect(originals ?? []).toStrictEqual([]);
+  });
+
+  it("rejects untrusted extensionless documents identified by structured metadata", async () => {
+    const sourcePath = path.join(stateDir, "opaque-document");
+    await fs.writeFile(sourcePath, "id,label\n1,alpha\n");
+
+    await expect(
+      createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: [sourcePath],
+        attachments: [{ type: "file", name: "report.csv", mimeType: "TEXT/CSV; charset=utf-8" }],
+        stateDir,
+        localRoots: [stateDir],
+      }),
+    ).rejects.toThrow(/Managed document attachment.*could not be prepared/u);
+  });
+
+  it("does not let image metadata weaken a known local document gate", async () => {
+    const sourcePath = path.join(stateDir, "known-document.csv");
+    await fs.writeFile(sourcePath, "id,label\n1,alpha\n");
+
+    await expect(
+      createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: [sourcePath],
+        attachments: [{ type: "file", name: "photo.png", mimeType: "image/png" }],
+        stateDir,
+        localRoots: [stateDir],
+      }),
+    ).rejects.toThrow(/Managed document attachment.*could not be prepared/u);
+  });
+
+  it("does not let image metadata authorize opaque local bytes", async () => {
+    const sourcePath = path.join(stateDir, "opaque-local-file");
+    await fs.writeFile(sourcePath, "private opaque content\n");
+
+    await expect(
+      createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: [sourcePath],
+        attachments: [{ type: "file", name: "photo.png", mimeType: "image/png" }],
+        stateDir,
+        localRoots: [stateDir],
+      }),
+    ).rejects.toThrow(/Managed media attachment.*could not be prepared/u);
   });
 
   it("does not apply the configured image cap to managed audio", async () => {

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -1614,6 +1614,28 @@ describe("createManagedOutgoingImageBlocks", () => {
     ).rejects.toThrow(new RegExp(`Managed ${kind} attachment.*16 MiB byte limit`));
   });
 
+  it("applies the byte-detected image cap before fully decoding generic data URLs", async () => {
+    const oversizedImage = Buffer.concat([
+      Buffer.from(TINY_PNG_BASE64, "base64"),
+      Buffer.alloc(32 * 1024),
+    ]).toString("base64");
+    const bufferFromSpy = vi.spyOn(Buffer, "from");
+
+    try {
+      await expect(
+        createManagedOutgoingImageBlocks({
+          sessionKey: "agent:main:main",
+          mediaUrls: [`data:application/octet-stream;base64,${oversizedImage}`],
+          stateDir,
+          limits: { maxBytes: 1024 },
+        }),
+      ).rejects.toThrow(/Managed image attachment .* exceeds the 1024 bytes byte limit/u);
+      expect(bufferFromSpy).not.toHaveBeenCalledWith(oversizedImage, "base64");
+    } finally {
+      bufferFromSpy.mockRestore();
+    }
+  });
+
   it("requires explicit reply trust for local audio", async () => {
     const sourcePath = path.join(stateDir, "workspace", "voice.mp3");
     await fs.mkdir(path.dirname(sourcePath), { recursive: true });

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -1,5 +1,5 @@
 // Gateway managed media attachment store.
-// Validates, stores, serves, and cleans up outgoing image/audio/video attachments.
+// Validates, stores, serves, and cleans up outgoing image/audio/video/document attachments.
 import { createHmac, randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -110,7 +110,7 @@ type ManagedImageAttachmentLimitsConfig = Partial<
   Pick<ManagedImageAttachmentLimits, "maxBytes" | "maxWidth" | "maxHeight" | "maxPixels">
 >;
 
-type ManagedMediaKind = Extract<MediaKind, "image" | "audio" | "video">;
+type ManagedMediaKind = Extract<MediaKind, "image" | "audio" | "video" | "document">;
 
 type ParsedMediaDataUrl =
   | { kind: "not-data-url" }
@@ -621,7 +621,12 @@ function parseMediaDataUrl(
   }
 
   const mediaKind = mediaKindFromMime(contentType);
-  if (mediaKind !== "image" && mediaKind !== "audio" && mediaKind !== "video") {
+  if (
+    mediaKind !== "image" &&
+    mediaKind !== "audio" &&
+    mediaKind !== "video" &&
+    mediaKind !== "document"
+  ) {
     return { kind: "unsupported-data-url" };
   }
 
@@ -818,7 +823,9 @@ function resolveManagedSessionOwnerAgentId(
 
 function resolveManagedRecordKind(record: ManagedImageRecord): ManagedMediaKind | null {
   const kind = mediaKindFromMime(record.original.contentType);
-  return kind === "image" || kind === "audio" || kind === "video" ? kind : null;
+  return kind === "image" || kind === "audio" || kind === "video" || kind === "document"
+    ? kind
+    : null;
 }
 
 function buildManagedMediaBlock(
@@ -908,7 +915,12 @@ function collectManagedOutgoingAttachmentRefs(
 ) {
   const refs = new Map<string, { attachmentId: string; sessionKey: string }>();
   for (const block of blocks ?? []) {
-    if (block?.type !== "image" && block?.type !== "audio" && block?.type !== "video") {
+    if (
+      block?.type !== "image" &&
+      block?.type !== "audio" &&
+      block?.type !== "video" &&
+      block?.type !== "document"
+    ) {
       continue;
     }
     for (const candidate of [block.url, block.openUrl]) {
@@ -1373,7 +1385,10 @@ export async function createManagedOutgoingMediaBlocks(params: {
     const hintedKind =
       dataUrlKind === "image" || dataUrlKind === "audio" || dataUrlKind === "video"
         ? dataUrlKind
-        : inferredKind === "image" || inferredKind === "audio" || inferredKind === "video"
+        : inferredKind === "image" ||
+            inferredKind === "audio" ||
+            inferredKind === "video" ||
+            inferredKind === "document"
           ? inferredKind
           : "media";
 
@@ -1385,10 +1400,10 @@ export async function createManagedOutgoingMediaBlocks(params: {
       }
       if (
         localMediaPath &&
-        (hintedKind === "audio" || hintedKind === "video") &&
+        (hintedKind === "audio" || hintedKind === "video" || hintedKind === "document") &&
         params.allowLocalNonImage !== true
       ) {
-        throw new Error("Local audio/video media requires an explicitly trusted reply payload");
+        throw new Error("Local non-image media requires an explicitly trusted reply payload");
       }
       let resizeWarning: ManagedMediaBlock | null = null;
       let savedOriginal =
@@ -1425,6 +1440,7 @@ export async function createManagedOutgoingMediaBlocks(params: {
                   limits.maxBytes,
                   maxBytesForKind("audio"),
                   maxBytesForKind("video"),
+                  maxBytesForKind("document"),
                   MEDIA_MAX_BYTES,
                 ),
               );
@@ -1437,13 +1453,18 @@ export async function createManagedOutgoingMediaBlocks(params: {
         continue;
       }
       const mediaKind = mediaKindFromMime(savedOriginalContentType);
-      if (mediaKind !== "image" && mediaKind !== "audio" && mediaKind !== "video") {
+      if (
+        mediaKind !== "image" &&
+        mediaKind !== "audio" &&
+        mediaKind !== "video" &&
+        mediaKind !== "document"
+      ) {
         await fs.rm(savedOriginal.path, { force: true }).catch(() => {});
         savedOriginalPath = null;
         continue;
       }
       if (localMediaPath && mediaKind !== "image" && params.allowLocalNonImage !== true) {
-        throw new Error("Local audio/video media requires an explicitly trusted reply payload");
+        throw new Error("Local non-image media requires an explicitly trusted reply payload");
       }
       const maxBytes = maxBytesForManagedMediaKind(mediaKind, limits);
       if (savedOriginal.size > maxBytes) {
@@ -1614,9 +1635,7 @@ function buildManagedMediaContentDisposition(value: string | null, contentType: 
   const fallback = contentType.startsWith("image/") ? "generated-image" : "generated-media";
   const base = (value ?? fallback).replace(/[\r\n"\\]/g, "_").trim();
   const filename = base || fallback;
-  return /^[\x20-\x7e]+$/u.test(filename)
-    ? `inline; filename="${filename}"`
-    : buildAssistantMediaContentDisposition(filename, contentType);
+  return buildAssistantMediaContentDisposition(filename, contentType);
 }
 
 export async function handleManagedOutgoingMediaHttpRequest(

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -28,6 +28,7 @@ import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { loadPendingSessionDeliveries } from "../infra/session-delivery-queue-storage.js";
 import { assertLocalMediaAllowed, resolveLocalMediaRoots } from "../media/local-media-access.js";
 import { resolveLocalMediaPath } from "../media/local-media-path.js";
+import { isGenericBinaryMediaContentType } from "../media/media-facts.js";
 import { probePlaybackMediaFileDescriptor } from "../media/media-probe.js";
 import {
   createImageProcessor,
@@ -1392,7 +1393,9 @@ export async function createManagedOutgoingMediaBlocks(params: {
     const localMediaPath = isDataUrl ? undefined : resolveLocalMediaPath(mediaUrl);
     const label = isDataUrl ? fallbackLabel : deriveAltText(localMediaPath ?? mediaUrl, index);
     const sourceKind = mediaKindFromMime(mimeTypeFromFilePath(localMediaPath ?? mediaUrl));
-    const metadataMimeKind = kindFromMime(attachmentMetadata?.mimeType);
+    const metadataMimeKind = isGenericBinaryMediaContentType(attachmentMetadata?.mimeType)
+      ? undefined
+      : kindFromMime(attachmentMetadata?.mimeType);
     const metadataNameKind = mediaKindFromMime(mimeTypeFromFilePath(attachmentMetadata?.name));
     const inferredKinds = [sourceKind, metadataMimeKind, metadataNameKind];
     // Declared metadata may identify an otherwise opaque document, but it must

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -5,7 +5,7 @@ import fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import { maxBytesForKind, mediaKindFromMime, type MediaKind } from "@openclaw/media-core/constants";
-import { kindFromMime, mimeTypeFromFilePath } from "@openclaw/media-core/mime";
+import { detectMime, kindFromMime, mimeTypeFromFilePath } from "@openclaw/media-core/mime";
 import { expectDefined } from "@openclaw/normalization-core";
 import {
   asDateTimestampMs,
@@ -86,6 +86,7 @@ const MANAGED_IMAGE_THUMBNAIL_MAX_SIDE = 300;
 const MANAGED_IMAGE_THUMBNAIL_CACHE_MAX_ENTRIES = 128;
 const MANAGED_IMAGE_THUMBNAIL_CACHE_MAX_BYTES = 16 * 1024 * 1024;
 const MANAGED_IMAGE_THUMBNAIL_MAX_PENDING = 128;
+const MANAGED_DATA_URL_SNIFF_BYTES = 16_384;
 const MANAGED_OUTGOING_ATTACHMENT_ID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const managedOutgoingImageTicketSecret = randomBytes(32);
@@ -615,11 +616,11 @@ function deriveAltText(source: string, index: number) {
   return localName || fallback;
 }
 
-function parseMediaDataUrl(
+async function parseMediaDataUrl(
   source: string,
   label: string,
   imageLimits: ManagedImageAttachmentLimits,
-): ParsedMediaDataUrl {
+): Promise<ParsedMediaDataUrl> {
   const trimmed = source.trim();
   if (!trimmed.startsWith("data:")) {
     return { kind: "not-data-url" };
@@ -645,16 +646,19 @@ function parseMediaDataUrl(
     throw new Error("Invalid image data URL");
   }
 
-  const mediaKind = mediaKindFromMime(contentType);
-  if (
-    mediaKind !== "image" &&
-    mediaKind !== "audio" &&
-    mediaKind !== "video" &&
-    mediaKind !== "document"
-  ) {
+  const declaredMediaKind = mediaKindFromMime(contentType);
+  if (!isManagedMediaKind(declaredMediaKind)) {
     return { kind: "unsupported-data-url" };
   }
 
+  const normalizedBase64 = base64Part.replace(/\s+/g, "");
+  const sniffBase64Length = Math.ceil(MANAGED_DATA_URL_SNIFF_BYTES / 3) * 4;
+  const detectedContentType = await detectMime({
+    buffer: Buffer.from(normalizedBase64.slice(0, sniffBase64Length), "base64"),
+    headerMime: contentType,
+  });
+  const detectedMediaKind = mediaKindFromMime(detectedContentType);
+  const mediaKind = isManagedMediaKind(detectedMediaKind) ? detectedMediaKind : declaredMediaKind;
   const maxBytes = maxBytesForManagedMediaKind(mediaKind, imageLimits);
   if (estimateBase64DecodedByteLength(base64Part) > maxBytes) {
     throw createManagedMediaByteLimitError({ kind: mediaKind, label, maxBytes });
@@ -662,8 +666,10 @@ function parseMediaDataUrl(
 
   return {
     kind: "media-data-url",
-    buffer: Buffer.from(base64Part.replace(/\s+/g, ""), "base64"),
-    contentType,
+    buffer: Buffer.from(normalizedBase64, "base64"),
+    contentType: isManagedMediaKind(detectedMediaKind)
+      ? (detectedContentType ?? contentType)
+      : contentType,
     mediaKind,
   };
 }
@@ -1424,7 +1430,7 @@ export async function createManagedOutgoingMediaBlocks(params: {
 
     let savedOriginalPath: string | null = null;
     try {
-      const parsedDataUrl = parseMediaDataUrl(mediaUrl, fallbackLabel, limits);
+      const parsedDataUrl = await parseMediaDataUrl(mediaUrl, fallbackLabel, limits);
       if (parsedDataUrl.kind === "unsupported-data-url") {
         continue;
       }

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -39,7 +39,7 @@ import {
   resolvePlaybackModeForSource,
   resolvePlaybackTranscode,
 } from "../media/playback-transcode.js";
-import { getMediaDir, MEDIA_MAX_BYTES, saveMediaBuffer, saveMediaSource } from "../media/store.js";
+import { getMediaDir, saveMediaBuffer, saveMediaSource } from "../media/store.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { buildAssistantMediaContentDisposition } from "./assistant-media-content-disposition.js";
@@ -317,6 +317,16 @@ function maxBytesForManagedMediaKind(
   imageLimits: ManagedImageAttachmentLimits,
 ): number {
   return kind === "image" ? imageLimits.maxBytes : maxBytesForKind(kind);
+}
+
+function maxBytesForManagedMime(
+  mime: string | undefined,
+  imageLimits: ManagedImageAttachmentLimits,
+): number {
+  const kind = mediaKindFromMime(mime);
+  return kind === "image" || kind === "audio" || kind === "video" || kind === "document"
+    ? maxBytesForManagedMediaKind(kind, imageLimits)
+    : Math.max(imageLimits.maxBytes, maxBytesForKind("unknown"));
 }
 
 function createManagedMediaByteLimitError(params: {
@@ -1432,17 +1442,13 @@ export async function createManagedOutgoingMediaBlocks(params: {
               // File URLs have already been normalized for display metadata and policy checks.
               // Pass that path to the store instead of treating URI syntax as a filename.
               const ingestSource = localMediaPath ?? mediaUrl;
+              const ingestMaxBytes = Math.max(limits.maxBytes, maxBytesForKind("unknown"));
               return await saveMediaSource(
                 ingestSource,
                 undefined,
                 "outgoing/originals",
-                Math.max(
-                  limits.maxBytes,
-                  maxBytesForKind("audio"),
-                  maxBytesForKind("video"),
-                  maxBytesForKind("document"),
-                  MEDIA_MAX_BYTES,
-                ),
+                ingestMaxBytes,
+                { maxBytesForMime: (mime) => maxBytesForManagedMime(mime, limits) },
               );
             })();
       savedOriginalPath = savedOriginal.path;

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -5,7 +5,7 @@ import fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import { maxBytesForKind, mediaKindFromMime, type MediaKind } from "@openclaw/media-core/constants";
-import { mimeTypeFromFilePath } from "@openclaw/media-core/mime";
+import { kindFromMime, mimeTypeFromFilePath } from "@openclaw/media-core/mime";
 import { expectDefined } from "@openclaw/normalization-core";
 import {
   asDateTimestampMs,
@@ -1391,7 +1391,17 @@ export async function createManagedOutgoingMediaBlocks(params: {
     const isDataUrl = trimmedMediaUrl.startsWith("data:");
     const localMediaPath = isDataUrl ? undefined : resolveLocalMediaPath(mediaUrl);
     const label = isDataUrl ? fallbackLabel : deriveAltText(localMediaPath ?? mediaUrl, index);
-    const inferredKind = mediaKindFromMime(mimeTypeFromFilePath(localMediaPath ?? mediaUrl));
+    const sourceKind = mediaKindFromMime(mimeTypeFromFilePath(localMediaPath ?? mediaUrl));
+    const metadataMimeKind = kindFromMime(attachmentMetadata?.mimeType);
+    const metadataNameKind = mediaKindFromMime(mimeTypeFromFilePath(attachmentMetadata?.name));
+    const inferredKinds = [sourceKind, metadataMimeKind, metadataNameKind];
+    // Declared metadata may identify an otherwise opaque document, but it must
+    // never authorize an opaque local file as an image or hide a non-image signal.
+    const inferredKind =
+      inferredKinds.find((kind) => kind && kind !== "image") ??
+      (sourceKind === "image" ? sourceKind : undefined);
+    const hasUnverifiedLocalImageHint =
+      Boolean(localMediaPath) && (metadataMimeKind === "image" || metadataNameKind === "image");
     const hintedKind =
       dataUrlKind === "image" || dataUrlKind === "audio" || dataUrlKind === "video"
         ? dataUrlKind
@@ -1448,7 +1458,17 @@ export async function createManagedOutgoingMediaBlocks(params: {
                 undefined,
                 "outgoing/originals",
                 ingestMaxBytes,
-                { maxBytesForMime: (mime) => maxBytesForManagedMime(mime, limits) },
+                {
+                  maxBytesForMime: (mime) => maxBytesForManagedMime(mime, limits),
+                  contentTypeHint:
+                    localMediaPath && metadataMimeKind === "image"
+                      ? undefined
+                      : attachmentMetadata?.mimeType,
+                  fileNameHint:
+                    localMediaPath && metadataNameKind === "image"
+                      ? undefined
+                      : attachmentMetadata?.name,
+                },
               );
             })();
       savedOriginalPath = savedOriginal.path;
@@ -1456,6 +1476,9 @@ export async function createManagedOutgoingMediaBlocks(params: {
       if (!savedOriginalContentType) {
         await fs.rm(savedOriginal.path, { force: true }).catch(() => {});
         savedOriginalPath = null;
+        if (hasUnverifiedLocalImageHint) {
+          throw new Error("Local image metadata could not be verified from the source");
+        }
         continue;
       }
       const mediaKind = mediaKindFromMime(savedOriginalContentType);

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -40,6 +40,7 @@ import {
   resolvePlaybackModeForSource,
   resolvePlaybackTranscode,
 } from "../media/playback-transcode.js";
+import { findMediaSizeLimitError } from "../media/store-ingest.js";
 import { getMediaDir, saveMediaBuffer, saveMediaSource } from "../media/store.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
@@ -111,7 +112,11 @@ type ManagedImageAttachmentLimitsConfig = Partial<
   Pick<ManagedImageAttachmentLimits, "maxBytes" | "maxWidth" | "maxHeight" | "maxPixels">
 >;
 
-type ManagedMediaKind = Extract<MediaKind, "image" | "audio" | "video" | "document">;
+export type ManagedMediaKind = Extract<MediaKind, "image" | "audio" | "video" | "document">;
+
+export function isManagedMediaKind(kind: unknown): kind is ManagedMediaKind {
+  return kind === "image" || kind === "audio" || kind === "video" || kind === "document";
+}
 
 type ParsedMediaDataUrl =
   | { kind: "not-data-url" }
@@ -296,6 +301,15 @@ function getSanitizedManagedImageAttachmentError(
   if (isManagedImageAttachmentSafeError(error)) {
     return error;
   }
+  const sizeLimitError = findMediaSizeLimitError(error);
+  if (sizeLimitError) {
+    const detectedKind = mediaKindFromMime(sizeLimitError.mime);
+    return createManagedMediaByteLimitError({
+      kind: isManagedMediaKind(detectedKind) ? detectedKind : kind,
+      label,
+      maxBytes: sizeLimitError.maxBytes,
+    });
+  }
   return createManagedImageAttachmentError(
     `Managed ${kind} attachment ${JSON.stringify(label)} could not be prepared`,
   );
@@ -325,13 +339,13 @@ function maxBytesForManagedMime(
   imageLimits: ManagedImageAttachmentLimits,
 ): number {
   const kind = mediaKindFromMime(mime);
-  return kind === "image" || kind === "audio" || kind === "video" || kind === "document"
+  return isManagedMediaKind(kind)
     ? maxBytesForManagedMediaKind(kind, imageLimits)
     : Math.max(imageLimits.maxBytes, maxBytesForKind("unknown"));
 }
 
 function createManagedMediaByteLimitError(params: {
-  kind: ManagedMediaKind;
+  kind: ManagedMediaKind | "media";
   label: string;
   maxBytes: number;
 }): Error {
@@ -834,9 +848,7 @@ function resolveManagedSessionOwnerAgentId(
 
 function resolveManagedRecordKind(record: ManagedImageRecord): ManagedMediaKind | null {
   const kind = mediaKindFromMime(record.original.contentType);
-  return kind === "image" || kind === "audio" || kind === "video" || kind === "document"
-    ? kind
-    : null;
+  return isManagedMediaKind(kind) ? kind : null;
 }
 
 function buildManagedMediaBlock(
@@ -926,12 +938,7 @@ function collectManagedOutgoingAttachmentRefs(
 ) {
   const refs = new Map<string, { attachmentId: string; sessionKey: string }>();
   for (const block of blocks ?? []) {
-    if (
-      block?.type !== "image" &&
-      block?.type !== "audio" &&
-      block?.type !== "video" &&
-      block?.type !== "document"
-    ) {
+    if (!isManagedMediaKind(block?.type)) {
       continue;
     }
     for (const candidate of [block.url, block.openUrl]) {
@@ -1485,12 +1492,7 @@ export async function createManagedOutgoingMediaBlocks(params: {
         continue;
       }
       const mediaKind = mediaKindFromMime(savedOriginalContentType);
-      if (
-        mediaKind !== "image" &&
-        mediaKind !== "audio" &&
-        mediaKind !== "video" &&
-        mediaKind !== "document"
-      ) {
+      if (!isManagedMediaKind(mediaKind)) {
         await fs.rm(savedOriginal.path, { force: true }).catch(() => {});
         savedOriginalPath = null;
         continue;

--- a/src/gateway/server-methods/artifacts.managed-lifecycle.test.ts
+++ b/src/gateway/server-methods/artifacts.managed-lifecycle.test.ts
@@ -63,6 +63,35 @@ describe("managed artifact lifecycle", () => {
     });
   });
 
+  it("normalizes managed documents to the public file artifact type", async () => {
+    const attachmentId = "22222222-2222-4222-8222-222222222222";
+    const artifactId = `artifact_managed_media_${attachmentId}`;
+    hoisted.resolveManagedArtifactDownload.mockResolvedValue({
+      artifactId,
+      sessionKey: "agent:main:main",
+      type: "document",
+      title: "report.csv",
+      mimeType: "text/csv",
+      sizeBytes: 10,
+      url: `/api/chat/media/outgoing/agent%3Amain%3Amain/${attachmentId}/full?mediaTicket=ticket`,
+      expiresAt: "2026-08-26T05:00:00.000Z",
+    });
+    const calls: Array<{ ok: boolean; payload?: unknown }> = [];
+
+    await artifactsHandlers["artifacts.download"]?.({
+      req: { type: "req", id: "download", method: "artifacts.download", params: {} },
+      params: { sessionKey: "agent:main:main", artifactId },
+      client: null,
+      isWebchatConnect: () => false,
+      respond: (ok, payload) => calls.push({ ok, payload }),
+      context: { getRuntimeConfig: () => ({}) } as never,
+    });
+
+    const result = calls[0]?.payload as { artifact?: Record<string, unknown> };
+    expect(calls[0]?.ok).toBe(true);
+    expectFields(result.artifact, { id: artifactId, type: "file", mimeType: "text/csv" });
+  });
+
   it("does not retarget a stale managed artifact id through a different block URL", async () => {
     const artifactId = "artifact_managed_image_11111111-1111-4111-8111-111111111111";
     const calls: Array<{ ok: boolean; error?: unknown }> = [];

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -516,7 +516,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
         respond(true, {
           artifact: {
             id: managed.artifactId,
-            type: managed.type,
+            type: normalizeArtifactType(managed.type),
             title: managed.title,
             ...(managed.mimeType ? { mimeType: managed.mimeType } : {}),
             ...(managed.sizeBytes !== undefined ? { sizeBytes: managed.sizeBytes } : {}),

--- a/src/gateway/server-methods/chat-assistant-content.ts
+++ b/src/gateway/server-methods/chat-assistant-content.ts
@@ -366,7 +366,12 @@ export function stripManagedOutgoingAssistantContentBlocks(
     return undefined;
   }
   const filtered = content.filter((block) => {
-    if (block?.type !== "image" && block?.type !== "audio" && block?.type !== "video") {
+    if (
+      block?.type !== "image" &&
+      block?.type !== "audio" &&
+      block?.type !== "video" &&
+      block?.type !== "document"
+    ) {
       return true;
     }
     return !(isManagedOutgoingMediaUrl(block.url) || isManagedOutgoingMediaUrl(block.openUrl));
@@ -422,7 +427,10 @@ export function hasManagedOutgoingAssistantContent(
   return Boolean(
     content?.some(
       (block) =>
-        (block?.type === "image" || block?.type === "audio" || block?.type === "video") &&
+        (block?.type === "image" ||
+          block?.type === "audio" ||
+          block?.type === "video" ||
+          block?.type === "document") &&
         (isManagedOutgoingMediaUrl(block.url) || isManagedOutgoingMediaUrl(block.openUrl)),
     ),
   );

--- a/src/gateway/server-restart-sentinel-agent-delivery.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.ts
@@ -39,6 +39,7 @@ import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import {
   attachManagedOutgoingMediaToMessage,
   createManagedOutgoingMediaBlocks,
+  isManagedMediaKind,
 } from "./managed-image-attachments.js";
 import { prepareGatewayInjectedAssistantContent } from "./server-methods/chat-transcript-inject.js";
 import type { GatewayContextResolver } from "./server-methods/types.js";
@@ -352,12 +353,7 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
                 localRoots: [getMediaDir()],
                 allowLocalNonImage: true,
               });
-              if (
-                !blocks.some(
-                  (block) =>
-                    block.type === "image" || block.type === "audio" || block.type === "video",
-                )
-              ) {
+              if (!blocks.some((block) => isManagedMediaKind(block.type))) {
                 throw new Error("queued internal generated media could not be prepared");
               }
               blocks = await mergeSessionDeliveryPreparedMediaBlocks(

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -186,7 +186,10 @@ const mocks = vi.hoisted(() => {
     ),
     createManagedOutgoingMediaBlocks: vi.fn<CreateManagedOutgoingMediaBlocksMock>(async (params) =>
       (params.mediaUrls ?? []).map((mediaUrl) => ({
-        type: params.attachments?.[0]?.type ?? "image",
+        type:
+          params.attachments?.[0]?.type === "file"
+            ? "document"
+            : (params.attachments?.[0]?.type ?? "image"),
         artifactId: `artifact:${mediaUrl}`,
         url: `/api/chat/media/outgoing/${encodeURIComponent(params.sessionKey)}/${encodeURIComponent(mediaUrl)}/full`,
         openUrl: `/api/chat/media/outgoing/${encodeURIComponent(params.sessionKey)}/${encodeURIComponent(mediaUrl)}/full`,
@@ -1586,6 +1589,32 @@ describe("scheduleRestartSentinelWake", () => {
     );
     expect(mocks.attachManagedOutgoingMediaToMessage).toHaveBeenCalledWith(
       expect.objectContaining({ messageId: "generated-media-transcript" }),
+    );
+    expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
+  });
+
+  it("persists internal generated documents as managed transcript content", async () => {
+    const mediaUrl = "/tmp/proof.csv";
+    mocks.dispatchGatewayMethodInProcess.mockResolvedValueOnce({
+      status: "ok",
+      result: { payloads: [{ text: "ready", mediaUrls: [mediaUrl] }] },
+    });
+
+    await deliverGeneratedMedia({
+      id: "session-delivery-media-internal-document",
+      messageId: "document:task-internal:agent-loop",
+      route: { channel: "webchat", to: "agent:main:main", chatType: "direct" },
+      expectedMediaUrls: [mediaUrl],
+      expectedMediaAttachments: {
+        [mediaUrl]: { type: "file", path: mediaUrl, mimeType: "text/csv" },
+      },
+    });
+
+    expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: [expect.objectContaining({ type: "document" })],
+        idempotencyKey: "document:task-internal:agent-loop:generated-media-transcript",
+      }),
     );
     expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
   });

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -1519,8 +1519,8 @@ describe("gateway server chat", () => {
     );
   });
 
-  test("chat.history carries managed images from a message-tool delivery mirror", async () => {
-    const replyText = "Two visible attachments.";
+  test("chat.history carries managed attachments from a message-tool delivery mirror", async () => {
+    const replyText = "Visible attachments.";
     const imageBlocks = ["first", "second"].map((name) => ({
       type: "image",
       artifactId: `artifact_managed_image_${name}`,
@@ -1529,13 +1529,21 @@ describe("gateway server chat", () => {
       alt: `${name}.png`,
       mimeType: "image/png",
     }));
+    const documentBlock = {
+      type: "document",
+      artifactId: "artifact_managed_media_report",
+      url: "/api/chat/media/outgoing/agent%3Amain%3Amain/report/full",
+      openUrl: "/api/chat/media/outgoing/agent%3Amain%3Amain/report/full",
+      fileName: "report.csv",
+      mimeType: "text/csv",
+    };
     const historyMessages = await loadChatHistoryWithMessages([
       createGatewayHistoryMessageToolCall(
         "call-message-images",
         {
           action: "send",
           message: replyText,
-          mediaUrls: ["/tmp/first.png", "/tmp/second.png"],
+          mediaUrls: ["/tmp/first.png", "/tmp/second.png", "/tmp/report.csv"],
         },
         1,
       ),
@@ -1543,7 +1551,7 @@ describe("gateway server chat", () => {
         role: "assistant",
         provider: "openclaw",
         model: "delivery-mirror",
-        content: [{ type: "text", text: replyText }, ...imageBlocks],
+        content: [{ type: "text", text: replyText }, ...imageBlocks, documentBlock],
         timestamp: 2,
       },
       {
@@ -1563,7 +1571,7 @@ describe("gateway server chat", () => {
     expect(historyMessages).toContainEqual(
       expect.objectContaining({
         role: "assistant",
-        content: [{ type: "text", text: replyText }, ...imageBlocks],
+        content: [{ type: "text", text: replyText }, ...imageBlocks, documentBlock],
         openclawMessageToolMirror: expect.objectContaining({
           toolCallId: "call-message-images",
           sourceReplySink: "internal-ui",

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -220,18 +220,24 @@ async function handleInternalSourceReplySendAction(
     (input.sessionKey
       ? resolveSessionAgentId({ sessionKey: input.sessionKey, config: input.cfg })
       : undefined);
+  const mediaPolicy = resolveAttachmentMediaPolicy({
+    sandboxRoot: input.sandboxRoot,
+    sandboxContainerWorkdir: input.sandboxContainerWorkdir,
+    mediaAccess: input.mediaAccess,
+    mediaLocalRoots: getAgentScopedMediaLocalRoots(input.cfg, agentId),
+  });
+  await normalizeSandboxMediaParams({
+    args: params,
+    mediaPolicy,
+    structuredAttachments: "all",
+  });
   await hydrateAttachmentParamsForAction({
     cfg: input.cfg,
     channel: INTERNAL_MESSAGE_CHANNEL,
     args: params,
     action: "send",
     dryRun,
-    mediaPolicy: resolveAttachmentMediaPolicy({
-      sandboxRoot: input.sandboxRoot,
-      sandboxContainerWorkdir: input.sandboxContainerWorkdir,
-      mediaAccess: input.mediaAccess,
-      mediaLocalRoots: getAgentScopedMediaLocalRoots(input.cfg, agentId),
-    }),
+    mediaPolicy,
   });
   const sourceReply = await buildMessagePayload({
     cfg: input.cfg,

--- a/src/infra/outbound/message-action-send.ts
+++ b/src/infra/outbound/message-action-send.ts
@@ -13,6 +13,7 @@ import { normalizeOutboundLocation } from "../../channels/location.js";
 import { normalizeConversationReadInvocationOrigin } from "../../channels/plugins/conversation-read-origin.js";
 import type { ChannelId, ChannelMessageActionName } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { basenameFromMediaSource } from "../../infra/local-file-access.js";
 import {
   hasLegacyInteractiveReplyBlocks,
   hasMessagePresentationBlocks,
@@ -316,10 +317,30 @@ export async function buildMessagePayload(params: {
       : undefined;
   const presentation = normalizeMessagePresentation(actionParams.presentation);
   const interactive = normalizeLegacyInteractiveReply(actionParams.interactive);
+  const attachmentSources = collectAttachmentSources(actionParams);
+  const attachmentMetadataByUrl = new Map(
+    attachmentSources.map((source) => [source.value.trim(), source] as const),
+  );
+  const sharedFilename = readToolStringParam(actionParams, "filename");
+  const sharedContentType =
+    readToolStringParam(actionParams, "contentType") ??
+    readToolStringParam(actionParams, "mimeType");
+  const attachments = mergedMediaUrls.map((url, index) => {
+    const source = attachmentMetadataByUrl.get(url.trim());
+    return {
+      url,
+      name:
+        source?.filename ??
+        (index === 0 ? sharedFilename : undefined) ??
+        basenameFromMediaSource(url),
+      mimeType: source?.contentType ?? (index === 0 ? sharedContentType : undefined),
+    };
+  });
   const payload: ReplyPayload = {
     text: message,
     ...(mediaUrl ? { mediaUrl } : {}),
     ...(mergedMediaUrls.length ? { mediaUrls: mergedMediaUrls } : {}),
+    ...(attachments.length ? { attachments } : {}),
     ...(asVoice ? { audioAsVoice: true } : {}),
     ...(asVideoNote ? { videoAsNote: true } : {}),
     ...(location ? { location } : {}),

--- a/src/media/fetch-content-type.ts
+++ b/src/media/fetch-content-type.ts
@@ -1,0 +1,35 @@
+// Remote media content-type helpers arbitrate response headers and caller fallbacks.
+
+export function isGenericResponseContentType(value?: string | null): boolean {
+  const normalized = value?.split(";")[0]?.trim().toLowerCase();
+  return (
+    !normalized ||
+    normalized === "application/octet-stream" ||
+    normalized === "binary/octet-stream" ||
+    normalized === "application/zip"
+  );
+}
+
+export function resolveResponseContentType(params: {
+  headerContentType?: string | null;
+  fallbackContentType?: string;
+}): string | undefined {
+  if (!params.fallbackContentType) {
+    return params.headerContentType ?? undefined;
+  }
+  if (isGenericResponseContentType(params.headerContentType)) {
+    return params.fallbackContentType;
+  }
+  const headerContentType = params.headerContentType?.split(";")[0]?.trim().toLowerCase();
+  const fallbackContentType = params.fallbackContentType.split(";")[0]?.trim().toLowerCase();
+  // Some platforms mislabel audio/video container uploads by top-level type.
+  // Preserve the caller hint when only that top-level prefix differs.
+  if (
+    headerContentType?.startsWith("video/") &&
+    fallbackContentType?.startsWith("audio/") &&
+    headerContentType.slice("video/".length) === fallbackContentType.slice("audio/".length)
+  ) {
+    return params.fallbackContentType;
+  }
+  return params.headerContentType ?? params.fallbackContentType;
+}

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:http";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
 import { hasErrnoCode } from "../infra/errors.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 
@@ -960,6 +961,31 @@ describe("readRemoteMediaBuffer", () => {
     expect(saved.path).toMatch(/[a-f0-9-]{36}\.png$/);
     expect(saved.path).not.toMatch(/photo---/);
     await expect(fs.readFile(saved.path)).resolves.toStrictEqual(Buffer.from([1, 2, 3, 4]));
+  });
+
+  it("preserves the detected MIME byte limit in streamed save errors", async () => {
+    const png = createSolidPngBuffer(1, 1, { r: 0, g: 0, b: 0 });
+    const response = new Response(makeStream([png]), {
+      status: 200,
+      headers: { "content-type": "application/octet-stream" },
+    });
+
+    const error = await saveResponseMedia(response, {
+      sourceUrl: "https://example.com/download",
+      maxBytes: 1024,
+      maxBytesForMime: (mime) => (mime === "image/png" ? 32 : 1024),
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toMatchObject({
+      name: "MediaFetchError",
+      code: "max_bytes",
+      message: expect.stringContaining("maxBytes 32"),
+      cause: {
+        name: "MediaSizeLimitError",
+        maxBytes: 32,
+        mime: "image/png",
+      },
+    });
   });
 
   it("preserves content-disposition CSV detection for streamed downloads", async () => {

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -22,6 +22,7 @@ import { retryAsync, type RetryOptions } from "../infra/retry.js";
 import { isTransientNetworkError } from "../infra/retryable-network-errors.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
+import { isGenericResponseContentType, resolveResponseContentType } from "./fetch-content-type.js";
 import { saveMediaStream, type MediaMaxBytesForMime, type SavedMedia } from "./store.js";
 
 /** Default remote media fetch cap shared by buffer reads and store writes. */
@@ -125,6 +126,8 @@ type SaveRemoteMediaOptions = FetchMediaOptions & {
   subdir?: string;
   originalFilename?: string;
   maxBytesForMime?: MediaMaxBytesForMime;
+  detectionContentTypeHint?: string;
+  detectionFilePathHint?: string;
 };
 
 type GuardedMediaResponse = {
@@ -475,40 +478,6 @@ function resolveRemoteFileName(params: {
   );
 }
 
-function isGenericResponseContentType(value?: string | null): boolean {
-  const normalized = value?.split(";")[0]?.trim().toLowerCase();
-  return (
-    !normalized ||
-    normalized === "application/octet-stream" ||
-    normalized === "binary/octet-stream" ||
-    normalized === "application/zip"
-  );
-}
-
-function resolveResponseContentType(params: {
-  headerContentType?: string | null;
-  fallbackContentType?: string;
-}): string | undefined {
-  if (!params.fallbackContentType) {
-    return params.headerContentType ?? undefined;
-  }
-  if (isGenericResponseContentType(params.headerContentType)) {
-    return params.fallbackContentType;
-  }
-  const headerContentType = params.headerContentType?.split(";")[0]?.trim().toLowerCase();
-  const fallbackContentType = params.fallbackContentType.split(";")[0]?.trim().toLowerCase();
-  // Some platforms mislabel audio/video container uploads by top-level type.
-  // Preserve the caller hint when only that top-level prefix differs.
-  if (
-    headerContentType?.startsWith("video/") &&
-    fallbackContentType?.startsWith("audio/") &&
-    headerContentType.slice("video/".length) === fallbackContentType.slice("audio/".length)
-  ) {
-    return params.fallbackContentType;
-  }
-  return params.headerContentType ?? params.fallbackContentType;
-}
-
 async function* responseBodyChunks(
   body: ReadableStream<Uint8Array>,
   readIdleTimeoutMs?: number,
@@ -554,6 +523,8 @@ async function saveOkMediaResponse(params: {
   subdir?: string;
   originalFilename?: string;
   maxBytesForMime?: MediaMaxBytesForMime;
+  detectionContentTypeHint?: string;
+  detectionFilePathHint?: string;
 }): Promise<SavedRemoteMedia> {
   assertMediaContentLength({
     res: params.res,
@@ -581,7 +552,11 @@ async function saveOkMediaResponse(params: {
       params.maxBytes,
       params.originalFilename,
       detectionFilePathHint,
-      { maxBytesForMime: params.maxBytesForMime },
+      {
+        maxBytesForMime: params.maxBytesForMime,
+        contentTypeHint: params.detectionContentTypeHint,
+        fileNameHint: params.detectionFilePathHint,
+      },
     );
     return { ...saved, ...(fileName ? { fileName } : {}) };
   } catch (err) {
@@ -694,6 +669,8 @@ async function saveRemoteMediaOnce(options: SaveRemoteMediaOptions): Promise<Sav
       subdir: options.subdir,
       originalFilename: options.originalFilename,
       maxBytesForMime: options.maxBytesForMime,
+      detectionContentTypeHint: options.detectionContentTypeHint,
+      detectionFilePathHint: options.detectionFilePathHint,
     });
   } finally {
     if (release) {

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -22,7 +22,7 @@ import { retryAsync, type RetryOptions } from "../infra/retry.js";
 import { isTransientNetworkError } from "../infra/retryable-network-errors.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
-import { saveMediaStream, type SavedMedia } from "./store.js";
+import { saveMediaStream, type MediaMaxBytesForMime, type SavedMedia } from "./store.js";
 
 /** Default remote media fetch cap shared by buffer reads and store writes. */
 const DEFAULT_FETCH_MEDIA_MAX_BYTES = MAX_DOCUMENT_BYTES;
@@ -116,6 +116,7 @@ type SaveResponseMediaOptions = {
   fallbackContentType?: string;
   subdir?: string;
   originalFilename?: string;
+  maxBytesForMime?: MediaMaxBytesForMime;
 };
 
 /** Options for guarded URL fetches that are saved directly into the media store. */
@@ -123,6 +124,7 @@ type SaveRemoteMediaOptions = FetchMediaOptions & {
   fallbackContentType?: string;
   subdir?: string;
   originalFilename?: string;
+  maxBytesForMime?: MediaMaxBytesForMime;
 };
 
 type GuardedMediaResponse = {
@@ -551,6 +553,7 @@ async function saveOkMediaResponse(params: {
   fallbackContentType?: string;
   subdir?: string;
   originalFilename?: string;
+  maxBytesForMime?: MediaMaxBytesForMime;
 }): Promise<SavedRemoteMedia> {
   assertMediaContentLength({
     res: params.res,
@@ -578,6 +581,7 @@ async function saveOkMediaResponse(params: {
       params.maxBytes,
       params.originalFilename,
       detectionFilePathHint,
+      { maxBytesForMime: params.maxBytesForMime },
     );
     return { ...saved, ...(fileName ? { fileName } : {}) };
   } catch (err) {
@@ -660,6 +664,7 @@ export async function saveResponseMedia(
     fallbackContentType: options.fallbackContentType,
     subdir: options.subdir,
     originalFilename: options.originalFilename,
+    maxBytesForMime: options.maxBytesForMime,
   });
 }
 
@@ -688,6 +693,7 @@ async function saveRemoteMediaOnce(options: SaveRemoteMediaOptions): Promise<Sav
       fallbackContentType: options.fallbackContentType,
       subdir: options.subdir,
       originalFilename: options.originalFilename,
+      maxBytesForMime: options.maxBytesForMime,
     });
   } finally {
     if (release) {

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -23,6 +23,7 @@ import { isTransientNetworkError } from "../infra/retryable-network-errors.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
 import { isGenericResponseContentType, resolveResponseContentType } from "./fetch-content-type.js";
+import { findMediaSizeLimitError } from "./store-ingest.js";
 import { saveMediaStream, type MediaMaxBytesForMime, type SavedMedia } from "./store.js";
 
 /** Default remote media fetch cap shared by buffer reads and store writes. */
@@ -563,10 +564,12 @@ async function saveOkMediaResponse(params: {
     if (err instanceof MediaFetchError) {
       throw err;
     }
-    if (isMediaLimitError(err)) {
+    const sizeLimitError = findMediaSizeLimitError(err);
+    if (sizeLimitError || isMediaLimitError(err)) {
+      const effectiveMaxBytes = sizeLimitError?.maxBytes ?? params.maxBytes;
       throw new MediaFetchError(
         "max_bytes",
-        `Failed to fetch media from ${params.sourceUrl}: payload exceeds maxBytes ${params.maxBytes}`,
+        `Failed to fetch media from ${params.sourceUrl}: payload exceeds maxBytes ${effectiveMaxBytes}`,
         { cause: err },
       );
     }

--- a/src/media/store-ingest.test.ts
+++ b/src/media/store-ingest.test.ts
@@ -1,0 +1,57 @@
+// Media-store ingestion tests cover byte-detected limits for local files and streams.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+
+describe("media store detected limits", () => {
+  let store: typeof import("./store.js");
+  let tempHome: TempHomeEnv;
+
+  beforeAll(async () => {
+    tempHome = await createTempHomeEnv("openclaw-media-ingest-test-home-");
+    store = await import("./store.js");
+  });
+
+  afterAll(async () => {
+    await tempHome.restore();
+  });
+
+  it("applies a byte-detected source limit instead of the filename hint", async () => {
+    const sourcePath = path.join(tempHome.home, "report.png");
+    const pdf = Buffer.concat([Buffer.from("%PDF-1.4\n"), Buffer.alloc(64)]);
+    await fs.writeFile(sourcePath, pdf);
+
+    const saved = await store.saveMediaSource(sourcePath, undefined, "outbound", 1024, {
+      maxBytesForMime: (mime) => (mime === "application/pdf" ? 1024 : 8),
+    });
+
+    expect(saved.contentType).toBe("application/pdf");
+    expect(saved.size).toBe(pdf.byteLength);
+  });
+
+  it("applies a byte-detected limit while streaming", async () => {
+    const oversizedPng = Buffer.concat([
+      createSolidPngBuffer(1, 1, { r: 0, g: 0, b: 0 }),
+      Buffer.alloc(16_384),
+    ]);
+
+    await expect(
+      store.saveMediaStream(
+        Readable.from([oversizedPng]),
+        undefined,
+        "detected-oversized-stream",
+        32 * 1024,
+        "photo.bin",
+        undefined,
+        { maxBytesForMime: (mime) => (mime === "image/png" ? 1024 : 32 * 1024) },
+      ),
+    ).rejects.toThrow("Media exceeds 0MB limit");
+
+    const targetDir = path.join(tempHome.home, ".openclaw", "media", "detected-oversized-stream");
+    const entries = await fs.readdir(targetDir).catch(() => []);
+    expect(entries).toStrictEqual([]);
+  });
+});

--- a/src/media/store-ingest.test.ts
+++ b/src/media/store-ingest.test.ts
@@ -32,6 +32,63 @@ describe("media store detected limits", () => {
     expect(saved.size).toBe(pdf.byteLength);
   });
 
+  it("keeps detected bytes authoritative over declared metadata", async () => {
+    const sourcePath = path.join(tempHome.home, "opaque-upload");
+    await fs.writeFile(sourcePath, createSolidPngBuffer(1, 1, { r: 0, g: 0, b: 0 }));
+
+    const saved = await store.saveMediaSource(sourcePath, undefined, "outbound", 1024, {
+      contentTypeHint: "text/csv",
+      fileNameHint: "report.csv",
+    });
+
+    expect(saved.contentType).toBe("image/png");
+    expect(saved.id).toMatch(/\.png$/u);
+  });
+
+  it("keeps a recognized source extension authoritative over declared metadata", async () => {
+    const sourcePath = path.join(tempHome.home, "report.csv");
+    await fs.writeFile(sourcePath, "id,label\n1,alpha\n");
+
+    const saved = await store.saveMediaSource(sourcePath, undefined, "outbound", 1024, {
+      contentTypeHint: "image/png",
+      fileNameHint: "photo.png",
+    });
+
+    expect(saved.contentType).toBe("text/csv");
+    expect(saved.id).toMatch(/\.csv$/u);
+  });
+
+  it.each([
+    ["MIME", { contentTypeHint: "text/csv" }],
+    ["filename", { fileNameHint: "report.csv" }],
+  ] as const)("uses a declared %s hint for opaque local bytes", async (_label, options) => {
+    const sourcePath = path.join(tempHome.home, `opaque-${_label.toLowerCase()}`);
+    await fs.writeFile(sourcePath, "id,label\n1,alpha\n");
+
+    const saved = await store.saveMediaSource(sourcePath, undefined, "outbound", 1024, options);
+
+    expect(saved.contentType).toBe("text/csv");
+    expect(saved.id).toMatch(/\.csv$/u);
+  });
+
+  it("does not let declared metadata raise the detected stream limit", async () => {
+    await expect(
+      store.saveMediaStream(
+        Readable.from(["id,label\n1,alpha\n"]),
+        undefined,
+        "hinted-stream-limit",
+        1024,
+        undefined,
+        undefined,
+        {
+          contentTypeHint: "image/png",
+          fileNameHint: "photo.png",
+          maxBytesForMime: (mime) => (mime ? 1024 : 8),
+        },
+      ),
+    ).rejects.toThrow("Media exceeds 0MB limit");
+  });
+
   it("applies a byte-detected limit while streaming", async () => {
     const oversizedPng = Buffer.concat([
       createSolidPngBuffer(1, 1, { r: 0, g: 0, b: 0 }),

--- a/src/media/store-ingest.ts
+++ b/src/media/store-ingest.ts
@@ -1,0 +1,197 @@
+// Media-store ingestion helpers apply bounded MIME-aware limits to files and streams.
+import fs from "node:fs/promises";
+import { detectMime } from "@openclaw/media-core/mime";
+import {
+  isFsSafeError,
+  openLocalFileSafely,
+  readLocalFileSafely,
+  type FsSafeLikeError,
+} from "./store.runtime.js";
+import { formatMediaLimitMb, MEDIA_FILE_MODE } from "./store.shared.js";
+
+const MEDIA_STREAM_SNIFF_BYTES = 16_384;
+
+/** Resolves a content-aware byte cap after bounded MIME detection. */
+export type MediaMaxBytesForMime = (mime: string | undefined) => number;
+
+export type SaveMediaOptions = {
+  maxBytesForMime?: MediaMaxBytesForMime;
+};
+
+export async function writeMediaStreamToFile(params: {
+  stream: AsyncIterable<unknown>;
+  tempPath: string;
+  maxBytes: number;
+  contentType?: string;
+  detectionFilePathHint?: string;
+  maxBytesForMime?: MediaMaxBytesForMime;
+}): Promise<{ sniffBuffer: Buffer; size: number }> {
+  const handle = await fs.open(params.tempPath, "wx", MEDIA_FILE_MODE);
+  const sniffChunks: Buffer[] = [];
+  let sniffLen = 0;
+  let total = 0;
+  let effectiveMaxBytes = params.maxBytes;
+  let detectedLimit = params.maxBytesForMime === undefined;
+  const resolveDetectedLimit = async () => {
+    if (detectedLimit || !params.maxBytesForMime) {
+      return;
+    }
+    const mime = await detectMime({
+      buffer: Buffer.concat(sniffChunks, sniffLen),
+      headerMime: params.contentType,
+      filePath: params.detectionFilePathHint,
+    });
+    effectiveMaxBytes = Math.min(effectiveMaxBytes, params.maxBytesForMime(mime));
+    detectedLimit = true;
+  };
+  try {
+    for await (const chunk of params.stream) {
+      const buffer = Buffer.isBuffer(chunk)
+        ? chunk
+        : typeof chunk === "string"
+          ? Buffer.from(chunk)
+          : chunk instanceof ArrayBuffer
+            ? Buffer.from(chunk)
+            : ArrayBuffer.isView(chunk)
+              ? Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+              : undefined;
+      if (!buffer) {
+        throw new TypeError(`Unsupported media stream chunk: ${typeof chunk}`);
+      }
+      if (buffer.byteLength === 0) {
+        continue;
+      }
+      total += buffer.byteLength;
+      if (total > effectiveMaxBytes) {
+        throw new Error(`Media exceeds ${formatMediaLimitMb(effectiveMaxBytes)} limit`);
+      }
+      if (sniffLen < MEDIA_STREAM_SNIFF_BYTES) {
+        const remaining = MEDIA_STREAM_SNIFF_BYTES - sniffLen;
+        sniffChunks.push(buffer.byteLength > remaining ? buffer.subarray(0, remaining) : buffer);
+        sniffLen += Math.min(buffer.byteLength, remaining);
+      }
+      if (sniffLen === MEDIA_STREAM_SNIFF_BYTES) {
+        await resolveDetectedLimit();
+        if (total > effectiveMaxBytes) {
+          throw new Error(`Media exceeds ${formatMediaLimitMb(effectiveMaxBytes)} limit`);
+        }
+      }
+      await handle.writeFile(buffer);
+    }
+    await resolveDetectedLimit();
+    if (total > effectiveMaxBytes) {
+      throw new Error(`Media exceeds ${formatMediaLimitMb(effectiveMaxBytes)} limit`);
+    }
+    return { sniffBuffer: Buffer.concat(sniffChunks, sniffLen), size: total };
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
+
+type SaveMediaSourceErrorCode =
+  | "invalid-path"
+  | "not-found"
+  | "not-file"
+  | "path-mismatch"
+  | "too-large";
+
+class SaveMediaSourceError extends Error {
+  code: SaveMediaSourceErrorCode;
+
+  constructor(code: SaveMediaSourceErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.code = code;
+    this.name = "SaveMediaSourceError";
+  }
+}
+
+function toSaveMediaSourceError(err: FsSafeLikeError, maxBytes: number): SaveMediaSourceError {
+  switch (err.code) {
+    case "symlink":
+      return new SaveMediaSourceError("invalid-path", "Media path must not be a symlink", {
+        cause: err,
+      });
+    case "not-file":
+      return new SaveMediaSourceError("not-file", "Media path is not a file", { cause: err });
+    case "path-mismatch":
+      return new SaveMediaSourceError("path-mismatch", "Media path changed during read", {
+        cause: err,
+      });
+    case "too-large":
+      return new SaveMediaSourceError(
+        "too-large",
+        `Media exceeds ${formatMediaLimitMb(maxBytes)} limit`,
+        { cause: err },
+      );
+    case "not-found":
+      return new SaveMediaSourceError("not-found", "Media path does not exist", { cause: err });
+    case "outside-workspace":
+      return new SaveMediaSourceError("invalid-path", "Media path is outside workspace root", {
+        cause: err,
+      });
+    default:
+      return new SaveMediaSourceError("invalid-path", "Media path is not safe to read", {
+        cause: err,
+      });
+  }
+}
+
+async function detectLocalMediaSourceMime(source: string): Promise<string | undefined> {
+  const opened = await openLocalFileSafely({ filePath: source });
+  try {
+    const sniffLength = Math.min(opened.stat.size, MEDIA_STREAM_SNIFF_BYTES);
+    const buffer = sniffLength > 0 ? Buffer.allocUnsafe(sniffLength) : Buffer.alloc(0);
+    let bytesRead = 0;
+    while (bytesRead < sniffLength) {
+      const result = await opened.handle.read(
+        buffer,
+        bytesRead,
+        sniffLength - bytesRead,
+        bytesRead,
+      );
+      if (result.bytesRead === 0) {
+        break;
+      }
+      bytesRead += result.bytesRead;
+    }
+    return await detectMime({ buffer: buffer.subarray(0, bytesRead), filePath: source });
+  } finally {
+    await opened.handle.close().catch(() => undefined);
+  }
+}
+
+export async function readMediaSourceSafely(params: {
+  source: string;
+  maxBytes: number;
+  maxBytesForMime?: MediaMaxBytesForMime;
+}) {
+  let effectiveMaxBytes = params.maxBytes;
+  try {
+    const detectedMime = params.maxBytesForMime
+      ? await detectLocalMediaSourceMime(params.source)
+      : undefined;
+    effectiveMaxBytes = params.maxBytesForMime
+      ? Math.min(params.maxBytes, params.maxBytesForMime(detectedMime))
+      : params.maxBytes;
+    const { buffer, stat } = await readLocalFileSafely({
+      filePath: params.source,
+      maxBytes: effectiveMaxBytes,
+    });
+    const mime = await detectMime({ buffer, filePath: params.source });
+    const finalMaxBytes = params.maxBytesForMime
+      ? Math.min(effectiveMaxBytes, params.maxBytesForMime(mime))
+      : effectiveMaxBytes;
+    if (buffer.byteLength > finalMaxBytes) {
+      throw new SaveMediaSourceError(
+        "too-large",
+        `Media exceeds ${formatMediaLimitMb(finalMaxBytes)} limit`,
+      );
+    }
+    return { buffer, stat, mime };
+  } catch (err) {
+    if (isFsSafeError(err)) {
+      throw toSaveMediaSourceError(err, effectiveMaxBytes);
+    }
+    throw err;
+  }
+}

--- a/src/media/store-ingest.ts
+++ b/src/media/store-ingest.ts
@@ -22,6 +22,30 @@ export type SaveMediaOptions = {
   fileNameHint?: string;
 };
 
+/** Structured byte-limit failure retaining the MIME classification that selected the cap. */
+export class MediaSizeLimitError extends Error {
+  readonly maxBytes: number;
+  readonly mime?: string;
+
+  constructor(maxBytes: number, mime?: string, options?: ErrorOptions) {
+    super(`Media exceeds ${formatMediaLimitMb(maxBytes)} limit`, options);
+    this.maxBytes = maxBytes;
+    this.mime = mime;
+    this.name = "MediaSizeLimitError";
+  }
+}
+
+export function findMediaSizeLimitError(error: unknown): MediaSizeLimitError | null {
+  let current = error;
+  for (let depth = 0; depth < 8 && current instanceof Error; depth += 1) {
+    if (current instanceof MediaSizeLimitError) {
+      return current;
+    }
+    current = current.cause;
+  }
+  return null;
+}
+
 export async function writeMediaStreamToFile(params: {
   stream: AsyncIterable<unknown>;
   tempPath: string;
@@ -35,17 +59,18 @@ export async function writeMediaStreamToFile(params: {
   let sniffLen = 0;
   let total = 0;
   let effectiveMaxBytes = params.maxBytes;
+  let detectedMime: string | undefined;
   let detectedLimit = params.maxBytesForMime === undefined;
   const resolveDetectedLimit = async () => {
     if (detectedLimit || !params.maxBytesForMime) {
       return;
     }
-    const mime = await detectMime({
+    detectedMime = await detectMime({
       buffer: Buffer.concat(sniffChunks, sniffLen),
       headerMime: params.contentType,
       filePath: params.detectionFilePathHint,
     });
-    effectiveMaxBytes = Math.min(effectiveMaxBytes, params.maxBytesForMime(mime));
+    effectiveMaxBytes = Math.min(effectiveMaxBytes, params.maxBytesForMime(detectedMime));
     detectedLimit = true;
   };
   try {
@@ -67,7 +92,7 @@ export async function writeMediaStreamToFile(params: {
       }
       total += buffer.byteLength;
       if (total > effectiveMaxBytes) {
-        throw new Error(`Media exceeds ${formatMediaLimitMb(effectiveMaxBytes)} limit`);
+        throw new MediaSizeLimitError(effectiveMaxBytes, detectedMime);
       }
       if (sniffLen < MEDIA_STREAM_SNIFF_BYTES) {
         const remaining = MEDIA_STREAM_SNIFF_BYTES - sniffLen;
@@ -77,14 +102,14 @@ export async function writeMediaStreamToFile(params: {
       if (sniffLen === MEDIA_STREAM_SNIFF_BYTES) {
         await resolveDetectedLimit();
         if (total > effectiveMaxBytes) {
-          throw new Error(`Media exceeds ${formatMediaLimitMb(effectiveMaxBytes)} limit`);
+          throw new MediaSizeLimitError(effectiveMaxBytes, detectedMime);
         }
       }
       await handle.writeFile(buffer);
     }
     await resolveDetectedLimit();
     if (total > effectiveMaxBytes) {
-      throw new Error(`Media exceeds ${formatMediaLimitMb(effectiveMaxBytes)} limit`);
+      throw new MediaSizeLimitError(effectiveMaxBytes, detectedMime);
     }
     return { sniffBuffer: Buffer.concat(sniffChunks, sniffLen), size: total };
   } finally {
@@ -176,8 +201,9 @@ export async function readMediaSourceSafely(params: {
   fileNameHint?: string;
 }) {
   let effectiveMaxBytes = params.maxBytes;
+  let detectedMime: string | undefined;
   try {
-    const detectedMime = params.maxBytesForMime
+    detectedMime = params.maxBytesForMime
       ? await detectLocalMediaSourceMime(params.source)
       : undefined;
     effectiveMaxBytes = params.maxBytesForMime
@@ -196,14 +222,14 @@ export async function readMediaSourceSafely(params: {
       ? Math.min(effectiveMaxBytes, params.maxBytesForMime(mime))
       : effectiveMaxBytes;
     if (buffer.byteLength > finalMaxBytes) {
-      throw new SaveMediaSourceError(
-        "too-large",
-        `Media exceeds ${formatMediaLimitMb(finalMaxBytes)} limit`,
-      );
+      throw new MediaSizeLimitError(finalMaxBytes, mime);
     }
     return { buffer, stat, mime };
   } catch (err) {
     if (isFsSafeError(err)) {
+      if (err.code === "too-large") {
+        throw new MediaSizeLimitError(effectiveMaxBytes, detectedMime, { cause: err });
+      }
       throw toSaveMediaSourceError(err, effectiveMaxBytes);
     }
     throw err;

--- a/src/media/store-ingest.ts
+++ b/src/media/store-ingest.ts
@@ -1,6 +1,6 @@
 // Media-store ingestion helpers apply bounded MIME-aware limits to files and streams.
 import fs from "node:fs/promises";
-import { detectMime } from "@openclaw/media-core/mime";
+import { detectMime, mimeTypeFromFilePath } from "@openclaw/media-core/mime";
 import {
   isFsSafeError,
   openLocalFileSafely,
@@ -16,6 +16,10 @@ export type MediaMaxBytesForMime = (mime: string | undefined) => number;
 
 export type SaveMediaOptions = {
   maxBytesForMime?: MediaMaxBytesForMime;
+  /** Non-authoritative MIME metadata used only when bytes do not identify the payload. */
+  contentTypeHint?: string;
+  /** Non-authoritative filename metadata used for extension-based MIME fallback. */
+  fileNameHint?: string;
 };
 
 export async function writeMediaStreamToFile(params: {
@@ -160,10 +164,16 @@ async function detectLocalMediaSourceMime(source: string): Promise<string | unde
   }
 }
 
+function resolveLocalDetectionFilePath(source: string, fileNameHint?: string): string {
+  return mimeTypeFromFilePath(source) ? source : (fileNameHint ?? source);
+}
+
 export async function readMediaSourceSafely(params: {
   source: string;
   maxBytes: number;
   maxBytesForMime?: MediaMaxBytesForMime;
+  contentTypeHint?: string;
+  fileNameHint?: string;
 }) {
   let effectiveMaxBytes = params.maxBytes;
   try {
@@ -177,7 +187,11 @@ export async function readMediaSourceSafely(params: {
       filePath: params.source,
       maxBytes: effectiveMaxBytes,
     });
-    const mime = await detectMime({ buffer, filePath: params.source });
+    const mime = await detectMime({
+      buffer,
+      additionalMimeHints: [params.contentTypeHint],
+      filePath: resolveLocalDetectionFilePath(params.source, params.fileNameHint),
+    });
     const finalMaxBytes = params.maxBytesForMime
       ? Math.min(effectiveMaxBytes, params.maxBytesForMime(mime))
       : effectiveMaxBytes;

--- a/src/media/store.outside-workspace.test.ts
+++ b/src/media/store.outside-workspace.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 
 const mocks = vi.hoisted(() => ({
+  openLocalFileSafely: vi.fn(),
   readLocalFileSafely: vi.fn(),
   isFsSafeError: vi.fn(
     (error: unknown) => typeof error === "object" && error !== null && "code" in error,
@@ -13,6 +14,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./store.runtime.js", () => {
   return {
+    openLocalFileSafely: mocks.openLocalFileSafely,
     readLocalFileSafely: mocks.readLocalFileSafely,
     isFsSafeError: mocks.isFsSafeError,
   };

--- a/src/media/store.redirect.test.ts
+++ b/src/media/store.redirect.test.ts
@@ -121,6 +121,101 @@ describe("media store remote sources", () => {
     await expect(fs.readFile(saved.path, "utf8")).resolves.toBe("custom");
   });
 
+  it("uses declared metadata hints for an extensionless remote source", async () => {
+    await useActualSaveRemoteMedia();
+    runtimeFetchMock.mockResolvedValueOnce(
+      new Response("id,label\n1,alpha\n", {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+
+    const saved = await saveMediaSource("https://example.com/download", undefined, "remote", 1024, {
+      contentTypeHint: "text/csv",
+      fileNameHint: "report.csv",
+    });
+
+    expect(saved.contentType).toBe("text/csv");
+    expect(saved.id).toMatch(/\.csv$/u);
+    await expect(fs.readFile(saved.path, "utf8")).resolves.toBe("id,label\n1,alpha\n");
+  });
+
+  it("uses a declared MIME hint behind a generic remote response type", async () => {
+    await useActualSaveRemoteMedia();
+    runtimeFetchMock.mockResolvedValueOnce(
+      new Response("id,label\n1,alpha\n", {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+
+    const saved = await saveMediaSource("https://example.com/download", undefined, "remote", 1024, {
+      contentTypeHint: "text/csv",
+    });
+
+    expect(saved.contentType).toBe("text/csv");
+    expect(saved.id).toMatch(/\.csv$/u);
+  });
+
+  it("keeps remote bytes authoritative over declared metadata", async () => {
+    await useActualSaveRemoteMedia();
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
+    runtimeFetchMock.mockResolvedValueOnce(
+      new Response(jpeg, {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+
+    const saved = await saveMediaSource("https://example.com/download", undefined, "remote", 1024, {
+      contentTypeHint: "text/csv",
+      fileNameHint: "report.csv",
+    });
+
+    expect(saved.contentType).toBe("image/jpeg");
+    expect(saved.id).toMatch(/\.jpg$/u);
+    await expect(fs.readFile(saved.path)).resolves.toStrictEqual(jpeg);
+  });
+
+  it("keeps a recognized remote suffix authoritative over declared metadata", async () => {
+    await useActualSaveRemoteMedia();
+    runtimeFetchMock.mockResolvedValueOnce(
+      new Response("id,label\n1,alpha\n", {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+
+    const saved = await saveMediaSource(
+      "https://example.com/download.csv",
+      undefined,
+      "remote",
+      1024,
+      { contentTypeHint: "image/png", fileNameHint: "photo.png" },
+    );
+
+    expect(saved.contentType).toBe("text/csv");
+    expect(saved.id).toMatch(/\.csv$/u);
+  });
+
+  it("keeps a concrete remote response type authoritative over a declared filename", async () => {
+    await useActualSaveRemoteMedia();
+    runtimeFetchMock.mockResolvedValueOnce(
+      new Response("id,label\n1,alpha\n", {
+        status: 200,
+        headers: { "content-type": "text/csv" },
+      }),
+    );
+
+    const saved = await saveMediaSource("https://example.com/download", undefined, "remote", 1024, {
+      contentTypeHint: "image/png",
+      fileNameHint: "photo.png",
+    });
+
+    expect(saved.contentType).toBe("text/csv");
+    expect(saved.id).toMatch(/\.csv$/u);
+  });
+
   it("cancels a never-ending error body before canonical status handling", async () => {
     await useActualSaveRemoteMedia();
     const cancel = vi.fn(() => new Promise<void>(() => {}));

--- a/src/media/store.remote.runtime.ts
+++ b/src/media/store.remote.runtime.ts
@@ -6,7 +6,7 @@ import {
 } from "../infra/net/runtime-fetch.js";
 import type { LookupFn, resolvePinnedHostname } from "../infra/net/ssrf.js";
 import { saveRemoteMedia, type FetchLike } from "./fetch.js";
-import type { SavedMedia } from "./store.js";
+import type { MediaMaxBytesForMime, SavedMedia } from "./store.js";
 
 const REMOTE_MEDIA_TIMEOUT_MS = 30_000;
 
@@ -31,6 +31,7 @@ export async function saveRemoteMediaForStore(params: {
   headers?: Record<string, string>;
   subdir: string;
   maxBytes: number;
+  maxBytesForMime?: MediaMaxBytesForMime;
   resolvePinnedHostnameForTest?: typeof resolvePinnedHostname;
 }): Promise<SavedMedia> {
   const resolvePinned = params.resolvePinnedHostnameForTest;
@@ -52,6 +53,7 @@ export async function saveRemoteMediaForStore(params: {
     // preserving the URL-suffix fallback without embedding the remote basename.
     originalFilename: `_${getFileExtension(params.source) ?? ""}`,
     maxBytes: params.maxBytes,
+    maxBytesForMime: params.maxBytesForMime,
     maxRedirects: 5,
     responseHeaderTimeoutMs: REMOTE_MEDIA_TIMEOUT_MS,
     readIdleTimeoutMs: REMOTE_MEDIA_TIMEOUT_MS,

--- a/src/media/store.remote.runtime.ts
+++ b/src/media/store.remote.runtime.ts
@@ -32,6 +32,8 @@ export async function saveRemoteMediaForStore(params: {
   subdir: string;
   maxBytes: number;
   maxBytesForMime?: MediaMaxBytesForMime;
+  contentTypeHint?: string;
+  fileNameHint?: string;
   resolvePinnedHostnameForTest?: typeof resolvePinnedHostname;
 }): Promise<SavedMedia> {
   const resolvePinned = params.resolvePinnedHostnameForTest;
@@ -54,6 +56,8 @@ export async function saveRemoteMediaForStore(params: {
     originalFilename: `_${getFileExtension(params.source) ?? ""}`,
     maxBytes: params.maxBytes,
     maxBytesForMime: params.maxBytesForMime,
+    ...(params.contentTypeHint ? { detectionContentTypeHint: params.contentTypeHint } : {}),
+    ...(params.fileNameHint ? { detectionFilePathHint: params.fileNameHint } : {}),
     maxRedirects: 5,
     responseHeaderTimeoutMs: REMOTE_MEDIA_TIMEOUT_MS,
     readIdleTimeoutMs: REMOTE_MEDIA_TIMEOUT_MS,

--- a/src/media/store.runtime.ts
+++ b/src/media/store.runtime.ts
@@ -2,6 +2,7 @@
 import "../infra/fs-safe-defaults.js";
 import {
   FsSafeError,
+  openLocalFileSafely as openLocalFileSafelyImpl,
   readLocalFileSafely as readLocalFileSafelyImpl,
   type FsSafeErrorCode,
 } from "../infra/fs-safe.js";
@@ -14,6 +15,9 @@ export type FsSafeLikeError = {
 
 /** fs-safe local file reader re-exported for media-store test/runtime injection. */
 export const readLocalFileSafely = readLocalFileSafelyImpl;
+
+/** fs-safe local file opener re-exported for bounded media MIME sniffing. */
+export const openLocalFileSafely = openLocalFileSafelyImpl;
 
 /** Narrows fs-safe failures without exposing the full infra error class to store callers. */
 export function isFsSafeError(error: unknown): error is FsSafeLikeError {

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -12,6 +12,7 @@ import {
   detectMime,
   extensionForMime,
   getFileExtension,
+  mimeTypeFromFilePath,
   normalizeMimeType,
 } from "@openclaw/media-core/mime";
 import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
@@ -23,6 +24,7 @@ import type { resolvePinnedHostname } from "../infra/net/ssrf.js";
 import { retryAsync } from "../infra/retry.js";
 import { writeSiblingTempFile } from "../infra/sibling-temp-file.js";
 import { resolveConfigDir } from "../utils.js";
+import { isGenericResponseContentType } from "./fetch-content-type.js";
 import {
   readMediaSourceSafely,
   type SaveMediaOptions,
@@ -403,6 +405,22 @@ function isImageHeaderMime(contentType?: string): boolean {
   return normalizeMimeType(contentType)?.startsWith("image/") === true;
 }
 
+function resolveStreamDetectionFilePaths(params: {
+  originalFilename?: string;
+  detectionFilePathHint?: string;
+  fileNameHint?: string;
+  allowFileNameHint: boolean;
+}): { source?: string; classified?: string } {
+  const sourceHints = [params.originalFilename, params.detectionFilePathHint];
+  const recognizedSource = sourceHints.find((candidate) => mimeTypeFromFilePath(candidate));
+  const source = recognizedSource ?? sourceHints.find(Boolean);
+  return {
+    source,
+    classified:
+      recognizedSource ?? (params.allowFileNameHint ? params.fileNameHint : undefined) ?? source,
+  };
+}
+
 function resolveSavedMediaExtension(params: {
   detectedMime?: string;
   headerExt?: string;
@@ -492,6 +510,8 @@ export async function saveMediaSource(
       subdir,
       maxBytes,
       maxBytesForMime: options.maxBytesForMime,
+      contentTypeHint: options.contentTypeHint,
+      fileNameHint: options.fileNameHint,
       resolvePinnedHostnameForTest,
     });
   }
@@ -500,6 +520,8 @@ export async function saveMediaSource(
     source,
     maxBytes,
     maxBytesForMime: options.maxBytesForMime,
+    contentTypeHint: options.contentTypeHint,
+    fileNameHint: options.fileNameHint,
   });
   const ext = extensionForMime(mime) ?? path.extname(source);
   const id = buildSavedMediaId({ baseId, ext });
@@ -554,6 +576,13 @@ export async function saveMediaStream(
   await fs.mkdir(dir, { recursive: true, mode: 0o700 });
   const baseId = crypto.randomUUID();
   const headerExt = extensionForAuthoritativeHeaderMime(contentType);
+  const genericContentType = isGenericResponseContentType(contentType);
+  const detectionFilePaths = resolveStreamDetectionFilePaths({
+    originalFilename,
+    detectionFilePathHint,
+    fileNameHint: options.fileNameHint,
+    allowFileNameHint: genericContentType,
+  });
   return await saveMediaSiblingTempFile({
     dir,
     tempPrefix: `.${baseId}`,
@@ -563,14 +592,23 @@ export async function saveMediaStream(
         tempPath,
         maxBytes,
         contentType,
-        detectionFilePathHint: originalFilename ?? detectionFilePathHint,
+        detectionFilePathHint: detectionFilePaths.source,
         maxBytesForMime: options.maxBytesForMime,
       });
       const mime = await detectMime({
         buffer: sniffBuffer,
-        headerMime: contentType,
-        filePath: originalFilename ?? detectionFilePathHint,
+        headerMime: genericContentType ? undefined : contentType,
+        additionalMimeHints: genericContentType
+          ? [options.contentTypeHint, contentType]
+          : [options.contentTypeHint],
+        filePath: detectionFilePaths.classified,
       });
+      const finalMaxBytes = options.maxBytesForMime
+        ? Math.min(maxBytes, options.maxBytesForMime(mime))
+        : maxBytes;
+      if (size > finalMaxBytes) {
+        throw new Error(`Media exceeds ${formatMediaLimitMb(finalMaxBytes)} limit`);
+      }
       const ext = resolveSavedMediaExtension({
         detectedMime: mime,
         headerExt,

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -23,8 +23,14 @@ import type { resolvePinnedHostname } from "../infra/net/ssrf.js";
 import { retryAsync } from "../infra/retry.js";
 import { writeSiblingTempFile } from "../infra/sibling-temp-file.js";
 import { resolveConfigDir } from "../utils.js";
-import { isFsSafeError, readLocalFileSafely, type FsSafeLikeError } from "./store.runtime.js";
+import {
+  readMediaSourceSafely,
+  type SaveMediaOptions,
+  writeMediaStreamToFile,
+} from "./store-ingest.js";
 import { formatMediaLimitMb, MEDIA_FILE_MODE } from "./store.shared.js";
+
+export type { MediaMaxBytesForMime } from "./store-ingest.js";
 
 const resolveMediaDir = () => path.join(resolveConfigDir(), "media");
 /** Default per-file media-store byte cap used by inbound staging and plugin SDK callers. */
@@ -468,108 +474,13 @@ async function writeSavedMediaBuffer(params: {
   );
 }
 
-async function writeMediaStreamToFile(params: {
-  stream: AsyncIterable<unknown>;
-  tempPath: string;
-  maxBytes: number;
-}): Promise<{ sniffBuffer: Buffer; size: number }> {
-  const handle = await fs.open(params.tempPath, "wx", MEDIA_FILE_MODE);
-  const sniffChunks: Buffer[] = [];
-  let sniffLen = 0;
-  let total = 0;
-  try {
-    for await (const chunk of params.stream) {
-      const buffer = Buffer.isBuffer(chunk)
-        ? chunk
-        : typeof chunk === "string"
-          ? Buffer.from(chunk)
-          : chunk instanceof ArrayBuffer
-            ? Buffer.from(chunk)
-            : ArrayBuffer.isView(chunk)
-              ? Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength)
-              : undefined;
-      if (!buffer) {
-        throw new TypeError(`Unsupported media stream chunk: ${typeof chunk}`);
-      }
-      if (buffer.byteLength === 0) {
-        continue;
-      }
-      total += buffer.byteLength;
-      if (total > params.maxBytes) {
-        throw new Error(`Media exceeds ${formatMediaLimitMb(params.maxBytes)} limit`);
-      }
-      if (sniffLen < 16384) {
-        const remaining = 16384 - sniffLen;
-        sniffChunks.push(buffer.byteLength > remaining ? buffer.subarray(0, remaining) : buffer);
-        sniffLen += Math.min(buffer.byteLength, remaining);
-      }
-      await handle.writeFile(buffer);
-    }
-    return {
-      sniffBuffer: Buffer.concat(sniffChunks, sniffLen),
-      size: total,
-    };
-  } finally {
-    await handle.close().catch(() => undefined);
-  }
-}
-
-/** Stable error categories for unsafe or failed source-file ingestion. */
-type SaveMediaSourceErrorCode =
-  | "invalid-path"
-  | "not-found"
-  | "not-file"
-  | "path-mismatch"
-  | "too-large";
-
-/** Error raised when saveMediaSource cannot safely read or persist a source path. */
-class SaveMediaSourceError extends Error {
-  code: SaveMediaSourceErrorCode;
-
-  constructor(code: SaveMediaSourceErrorCode, message: string, options?: ErrorOptions) {
-    super(message, options);
-    this.code = code;
-    this.name = "SaveMediaSourceError";
-  }
-}
-
-function toSaveMediaSourceError(err: FsSafeLikeError, maxBytes = MAX_BYTES): SaveMediaSourceError {
-  switch (err.code) {
-    case "symlink":
-      return new SaveMediaSourceError("invalid-path", "Media path must not be a symlink", {
-        cause: err,
-      });
-    case "not-file":
-      return new SaveMediaSourceError("not-file", "Media path is not a file", { cause: err });
-    case "path-mismatch":
-      return new SaveMediaSourceError("path-mismatch", "Media path changed during read", {
-        cause: err,
-      });
-    case "too-large":
-      return new SaveMediaSourceError(
-        "too-large",
-        `Media exceeds ${formatMediaLimitMb(maxBytes)} limit`,
-        { cause: err },
-      );
-    case "not-found":
-      return new SaveMediaSourceError("not-found", "Media path does not exist", { cause: err });
-    case "outside-workspace":
-      return new SaveMediaSourceError("invalid-path", "Media path is outside workspace root", {
-        cause: err,
-      });
-    default:
-      return new SaveMediaSourceError("invalid-path", "Media path is not safe to read", {
-        cause: err,
-      });
-  }
-}
-
 /** Saves a local path or HTTP(S) source into the media store after MIME/size validation. */
 export async function saveMediaSource(
   source: string,
   headers?: Record<string, string>,
   subdir = "",
   maxBytes = MAX_BYTES,
+  options: SaveMediaOptions = {},
 ): Promise<SavedMedia> {
   const dir = resolveMediaScopedDir(subdir, "saveMediaSource");
   await fs.mkdir(dir, { recursive: true, mode: 0o700 });
@@ -580,23 +491,20 @@ export async function saveMediaSource(
       headers,
       subdir,
       maxBytes,
+      maxBytesForMime: options.maxBytesForMime,
       resolvePinnedHostnameForTest,
     });
   }
   const baseId = crypto.randomUUID();
-  try {
-    const { buffer, stat } = await readLocalFileSafely({ filePath: source, maxBytes });
-    const mime = await detectMime({ buffer, filePath: source });
-    const ext = extensionForMime(mime) ?? path.extname(source);
-    const id = buildSavedMediaId({ baseId, ext });
-    await writeSavedMediaBuffer({ subdir, id, buffer });
-    return buildSavedMediaResult({ dir, id, size: stat.size, contentType: mime });
-  } catch (err) {
-    if (isFsSafeError(err)) {
-      throw toSaveMediaSourceError(err, maxBytes);
-    }
-    throw err;
-  }
+  const { buffer, stat, mime } = await readMediaSourceSafely({
+    source,
+    maxBytes,
+    maxBytesForMime: options.maxBytesForMime,
+  });
+  const ext = extensionForMime(mime) ?? path.extname(source);
+  const id = buildSavedMediaId({ baseId, ext });
+  await writeSavedMediaBuffer({ subdir, id, buffer });
+  return buildSavedMediaResult({ dir, id, size: stat.size, contentType: mime });
 }
 
 /** Saves an in-memory media buffer under a UUID-backed media ID. */
@@ -640,6 +548,7 @@ export async function saveMediaStream(
   maxBytes = MAX_BYTES,
   originalFilename?: string,
   detectionFilePathHint?: string,
+  options: SaveMediaOptions = {},
 ): Promise<SavedMedia> {
   const dir = resolveMediaScopedDir(subdir, "saveMediaStream");
   await fs.mkdir(dir, { recursive: true, mode: 0o700 });
@@ -653,6 +562,9 @@ export async function saveMediaStream(
         stream,
         tempPath,
         maxBytes,
+        contentType,
+        detectionFilePathHint: originalFilename ?? detectionFilePathHint,
+        maxBytesForMime: options.maxBytesForMime,
       });
       const mime = await detectMime({
         buffer: sniffBuffer,

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -26,6 +26,7 @@ import { writeSiblingTempFile } from "../infra/sibling-temp-file.js";
 import { resolveConfigDir } from "../utils.js";
 import { isGenericResponseContentType } from "./fetch-content-type.js";
 import {
+  MediaSizeLimitError,
   readMediaSourceSafely,
   type SaveMediaOptions,
   writeMediaStreamToFile,
@@ -607,7 +608,7 @@ export async function saveMediaStream(
         ? Math.min(maxBytes, options.maxBytesForMime(mime))
         : maxBytes;
       if (size > finalMaxBytes) {
-        throw new Error(`Media exceeds ${formatMediaLimitMb(finalMaxBytes)} limit`);
+        throw new MediaSizeLimitError(finalMaxBytes, mime);
       }
       const ext = resolveSavedMediaExtension({
         detectedMime: mime,

--- a/ui/src/e2e/managed-media-base-path.e2e.test.ts
+++ b/ui/src/e2e/managed-media-base-path.e2e.test.ts
@@ -98,4 +98,77 @@ describe("Control UI managed media under a UI base path", () => {
       await browser.close();
     }
   });
+
+  it("downloads a managed document ticket beneath the configured UI base path", async () => {
+    const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+    const browser = await chromium.launch({ executablePath });
+    const context = await browser.newContext({
+      serviceWorkers: "block",
+      viewport: { width: 1280, height: 800 },
+    });
+    const page = await context.newPage();
+    const attachmentId = "00000000-0000-4000-8000-000000000002";
+    const artifactId = `artifact_managed_media_${attachmentId}`;
+    const sourcePath = `/api/chat/media/outgoing/agent%3Amain%3Amain/${attachmentId}/full`;
+    const ticketedPath = `${sourcePath}?mediaTicket=ticket-document`;
+
+    const gateway = await installMockGateway(page, {
+      basePath: "/rosita",
+      historyMessages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "attachment",
+              attachment: {
+                artifactId,
+                kind: "document",
+                label: "managed-report.csv",
+                mimeType: "text/csv",
+                url: sourcePath,
+              },
+            },
+          ],
+          timestamp: 1,
+        },
+      ],
+      methodResponses: {
+        "artifacts.download": {
+          artifact: {
+            id: artifactId,
+            type: "file",
+            title: "managed-report.csv",
+            mimeType: "text/csv",
+            download: { mode: "url" },
+          },
+          url: ticketedPath,
+          expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}rosita/chat`);
+      await gateway.waitForRequest("artifacts.download");
+      const card = page.locator(".chat-assistant-attachment-card--compact");
+      await card.waitFor({
+        state: "visible",
+        timeout: 10_000,
+      });
+      const downloadLink = card.locator(".chat-assistant-attachment-card__download");
+      expect(await downloadLink.getAttribute("href")).toBe(`/rosita${ticketedPath}`);
+
+      const [download] = await Promise.all([
+        page.waitForEvent("download"),
+        downloadLink.evaluate((link) => (link as HTMLAnchorElement).click()),
+      ]);
+      expect(download.suggestedFilename()).toBe("managed-report.csv");
+      const requestUrl = new URL(download.url());
+      expect(requestUrl.pathname).toBe(`/rosita${sourcePath}`);
+      expect(requestUrl.searchParams.get("mediaTicket")).toBe("ticket-document");
+    } finally {
+      await context.close();
+      await browser.close();
+    }
+  });
 });

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -278,6 +278,36 @@ describe("message-normalizer", () => {
       ]);
     });
 
+    it("normalizes managed document content blocks as renderable attachments", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "document",
+            artifactId: "artifact_managed_media_report",
+            url: "/api/chat/media/outgoing/agent%3Amain%3Amain/report/full",
+            fileName: "report.csv",
+            mimeType: "text/csv",
+            sizeBytes: 28,
+          },
+        ],
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "attachment",
+          attachment: {
+            artifactId: "artifact_managed_media_report",
+            url: "/api/chat/media/outgoing/agent%3Amain%3Amain/report/full",
+            kind: "document",
+            label: "report.csv",
+            mimeType: "text/csv",
+            sizeBytes: 28,
+          },
+        },
+      ]);
+    });
+
     it("does not normalize non-assistant structured audio blocks as attachments", () => {
       const result = normalizeMessage({
         role: "user",

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -392,15 +392,16 @@ function coerceAudioContentBlock(
 function coerceManagedMediaContentBlock(
   item: RawContentBlock,
 ): Extract<MessageContentItem, { type: "attachment" }> | null {
-  if ((item.type !== "audio" && item.type !== "video") || item.url === undefined) {
+  const kind =
+    item.type === "audio" || item.type === "video" || item.type === "document" ? item.type : null;
+  if (!kind || item.url === undefined) {
     return null;
   }
   const url = item.url.trim();
   if (!url) {
     return null;
   }
-  const kind = item.type;
-  const fallbackLabel = kind === "audio" ? "Audio" : "Video";
+  const fallbackLabel = kind === "audio" ? "Audio" : kind === "video" ? "Video" : "Document";
   const label = item.fileName?.trim() || item.label?.trim() || fallbackLabel;
   return {
     type: "attachment",


### PR DESCRIPTION
Closes #129898

## What Problem This Solves

Fixes an issue where users receiving a document attachment from an agent through the WebChat `message` tool would see the attachment in the live reply, but lose it after reloading the conversation. The text remained, so CSV exports and other downloadable artifacts disappeared silently from durable history.

## Why This Change Was Made

The managed outgoing-media path already owns staging, download authorization, and transcript projection for image attachments, but it did not carry a document variant through that same canonical path. This change extends that owner to preserve structured document blocks, filenames, and MIME types through source-reply persistence and `chat.history`, then normalizes them into the Control UI's existing attachment card. Sandbox attachment paths are resolved through the existing workspace mapping before managed ingestion, so private host paths are not exposed to WebChat.

Declared filename and content type are carried end to end as non-authoritative hints. Payload bytes remain authoritative for MIME detection and media limits; generic MIME values do not override more specific filename or byte evidence. The legacy `MEDIA:` path remains independent and unchanged, and the change introduces no new configuration or protocol version.

The final diff touches 29 files. Judged production code is +524/-200 lines (net +324), including the extraction of bounded, MIME-aware ingestion from the existing media store. Tests and test support are +740/-22 lines and cover source-reply persistence, sandbox mapping, managed artifact lifecycle, MIME/limit policy, redirect handling, queued restart recovery, attachment-slot alignment, `chat.history`, Control UI normalization, and sibling image/`MEDIA:` behavior.

## User Impact

Documents sent by agents in WebChat, including CSV exports, retain their filename, MIME type, attachment card, and download link after a page reload. The same behavior works for sandbox-originated files after workspace-path translation. Existing image attachments and `MEDIA:` replies continue to work as before.

## Evidence

- The branch was rebased without conflicts onto `origin/main` at `07eb3203024e3ca2d1a3200290d0b8560c6a19b8`; exact head is `e652d1729aab0946f5bd28929d479db813631537`. `git range-diff` confirmed that the pre-review commits were mechanically unchanged by the rebase; later commits are focused review follow-ups.
- Focused final-head regression run passed 14 files, 7 Vitest shards, and 520 tests, including 2 real Chromium E2E tests:
  - `node scripts/run-vitest.mjs src/agents/tools/message-tool.internal-source-reply.integration.test.ts src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts src/auto-reply/reply/reply-media-paths.test.ts src/gateway/managed-image-attachments.test.ts src/gateway/server-methods/artifacts.managed-lifecycle.test.ts src/gateway/server-restart-sentinel.test.ts src/gateway/server.chat.gateway-server-chat.test.ts src/media-understanding/runtime.test.ts src/media/fetch.test.ts src/media/store-ingest.test.ts src/media/store.outside-workspace.test.ts src/media/store.redirect.test.ts ui/src/e2e/managed-media-base-path.e2e.test.ts ui/src/lib/chat/message-normalizer.test.ts`
- The final-head changed-surface gate passed for all 29 touched files:
  - `git diff --name-only -z origin/main...HEAD | xargs -0 node scripts/check-changed.mjs --`
- Full final-head build passed:
  - `pnpm build`
  - Only existing dependency warnings from Playwright/Web Tree-sitter direct `eval` and existing ineffective dynamic imports were emitted.
- The CI collection failures on the prior head were reproduced locally and fixed by adding the new `openLocalFileSafely` binding to the two complete `fs-safe.js` mocks. Both affected suites now pass locally (47 tests), and the wider final-head run above includes them.
- Review follow-up coverage confirms that queued restart recovery accepts document blocks through the shared managed-media kind guard, byte-detected local and remote media failures preserve the effective MIME-specific limit in their actionable error, generic data URLs are classified from a bounded prefix before a full decode, and blank media slots cannot misalign declared attachment metadata.
- Deployed WebChat E2E used two CSV files with identical deterministic content and distinct filenames. Before the fix, the structured `message` attachment disappeared after reload while the `MEDIA:` attachment remained. With the production change deployed, both `csv-e2e-message-deployed.csv` and `csv-e2e-media-deployed.csv` remained visible with working download links after reload. The final rebase changed commit identities only; the production diff is identical by `git range-diff`.

After deployment and page reload, both attachment paths render as downloadable CSV cards:

<img width="720" alt="WebChat showing structured message and MEDIA CSV attachment cards after reload" src="https://github.com/user-attachments/assets/bef0ed3e-5d99-4193-b216-eaa2b637283c" />

The screenshot uses deterministic test data only, and workspace path details are redacted.

AI-assisted: yes. The author reviewed the implementation, tests, and observed behavior and understands the change.
