### PR TITLE
fix: proxied model streams drop all events when the server omits the space after data:

### DIFF
--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -182,6 +182,50 @@ describe("streamProxy", () => {
     });
   });
 
+  it("accepts data lines without a space after the colon", async () => {
+    // The SSE spec makes the space optional; proxies emitting `data:{...}`
+    // must not have their events silently dropped.
+    const proxyEvents = [
+      { type: "text_start", contentIndex: 0, contentSignature: "sig" },
+      { type: "text_delta", contentIndex: 0, delta: "Working..." },
+      { type: "text_end", contentIndex: 0 },
+      { type: "done", reason: "stop", usage },
+    ];
+    const body = [
+      `data:${JSON.stringify(proxyEvents[0])}`,
+      "",
+      `data: ${JSON.stringify(proxyEvents[1])}`,
+      "",
+      `data:${JSON.stringify(proxyEvents[2])}`,
+      "",
+      `data:${JSON.stringify(proxyEvents[3])}`,
+      "",
+    ].join("\n");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responseFromText(body)),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+    });
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    expect(events.map((event) => event.type)).toEqual([
+      "text_start",
+      "text_delta",
+      "text_end",
+      "done",
+    ]);
+    await expect(stream.result()).resolves.toMatchObject({
+      content: [{ type: "text", text: "Working..." }],
+    });
+  });
+
   it("delays tool argument previews while preserving exact terminal arguments", async () => {
     const initialContent = "a".repeat(128);
     const checkpointContent = "b".repeat(400);

--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -356,10 +356,12 @@ export function streamProxy(
       const toolArgumentPreviewSchedules = new Map<number, ToolArgumentPreviewSchedule>();
 
       const processSseLine = (line: string) => {
-        if (!line.startsWith("data: ")) {
+        // The SSE spec makes the space after "data:" optional; accept both
+        // `data:{...}` and `data: {...}`, mirroring provider-transport-fetch.
+        if (!line.startsWith("data:")) {
           return;
         }
-        const data = line.slice(6).trim();
+        const data = line.slice("data:".length).trim();
         if (!data) {
           return;
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users routing agents through a custom proxy (`streamFn` = `streamProxy` with a user-supplied `proxyUrl`) would get an empty or truncated model response when that proxy emits SSE `data:` lines without the optional trailing space. Every such line was skipped by `processSseLine`, so the whole stream was silently dropped.

## Why This Change Was Made

The SSE spec makes the single space after `data:` optional ([MDN — event stream format](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format)), and spec-compliant proxies/gateways do emit `data:{...}`. The runtime proxy required the literal prefix `data: ` and discarded everything else. The main provider transport already accepts both forms (`hasReadableSseData` in `src/agents/provider-transport-fetch.ts`); this change aligns the proxy path with that behavior: accept `data:` with or without the space and trim the payload.

## User Impact

Users behind proxies or gateways that omit the space now get complete streamed output instead of a silently empty response. Proxies that already send `data: ` are unaffected.

## Evidence

- New focused test `accepts data lines without a space after the colon` in `src/agents/runtime/proxy.test.ts` streams mixed space/no-space frames through `streamProxy` and asserts the full event sequence plus the final text content.
- Red/green verified locally: on unpatched `main` the new test fails in both project contexts; with the fix `pnpm exec vitest run src/agents/runtime/proxy.test.ts` passes — 38/38 tests (19 in each of agents-core and agents-support).

### Live end-to-end run (real HTTP, no mocks)

A real local HTTP server (Node `http`) acting as the proxy was pointed at by the real `streamProxy`, emitting SSE with **no space** after `data:` on every frame.

**Before (unpatched `main`)** — the whole stream is dropped and the client ends with an error event:

```
[proxy] POST /api/stream -> 200 text/event-stream (no-space data frames)
[client] events received: ["error"]
[client] final text content: null
[verdict] DROPPED — stream lost
```

**After (this branch)** — same server, same frames:

```
[proxy] POST /api/stream -> 200 text/event-stream (no-space data frames)
[client] events received: ["text_start","text_delta","text_end","done"]
[client] final text content: "streamed over real HTTP"
[verdict] OK — stream parsed
```
