### PR TITLE
fix(gateway): bound the publication attribute scan by listing size, not the command cap

### DIFF
--- a/src/gateway/github-publication-git-transport.ts
+++ b/src/gateway/github-publication-git-transport.ts
@@ -4,7 +4,12 @@ import path from "node:path";
 import { runCommandBuffered } from "../process/exec.js";
 import { githubPublicationUnsafeConfigArgs } from "./github-publication-base.js";
 
-type GitCommandOptions = { cwd?: string; env?: NodeJS.ProcessEnv; input?: string };
+type GitCommandOptions = {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  input?: string;
+  maxOutputBytes?: number;
+};
 type GitCommandResult = { code: number | null; stdout: Buffer };
 
 export async function runPublicationCommand(argv: string[], options: GitCommandOptions = {}) {
@@ -20,7 +25,7 @@ export async function runPublicationCommand(argv: string[], options: GitCommandO
     },
     ...(options.input !== undefined ? { input: options.input } : {}),
     timeoutMs: 60_000,
-    maxOutputBytes: 256 * 1024,
+    maxOutputBytes: options.maxOutputBytes ?? 256 * 1024,
   });
 }
 
@@ -34,6 +39,12 @@ export async function requirePublicationCommand(
   }
   return result.stdout.toString("utf8").trim();
 }
+
+// A recursive tree listing scales with repository size (openclaw itself is
+// ~3.3MB), far past the default per-command cap above. Without this explicit
+// bound the attribute scan dies as an output-limit "verification" failure on
+// any real repository.
+const TREE_LISTING_MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
 
 export async function assertSafeGitPublicationWorkspace(
   cwd: string,
@@ -110,7 +121,10 @@ async function assertGitHubPublicationTreeHasNoFilters(
   workspaceTree: string,
   run: (argv: string[], options?: GitCommandOptions) => Promise<GitCommandResult>,
 ): Promise<void> {
-  const listing = await run(["git", "ls-tree", "-r", "-z", "--full-tree", workspaceTree], { cwd });
+  const listing = await run(["git", "ls-tree", "-r", "-z", "--full-tree", workspaceTree], {
+    cwd,
+    maxOutputBytes: TREE_LISTING_MAX_OUTPUT_BYTES,
+  });
   if (listing.code !== 0) {
     throw new Error("GitHub publication workspace attributes could not be verified.");
   }

--- a/src/gateway/github-publication-hooks.test.ts
+++ b/src/gateway/github-publication-hooks.test.ts
@@ -67,6 +67,28 @@ describe("GitHub publication Git hooks", () => {
     await expect(fs.access(sentinel)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("captures a repository whose recursive tree listing exceeds the default output cap", async () => {
+    // ~2000 long-pathed files push `git ls-tree -r` past the executor's 256KB
+    // default; the attribute scan must use its own listing bound (regression:
+    // real repositories failed capture as "attributes could not be verified").
+    const segment = "a".repeat(60);
+    for (let dir = 0; dir < 40; dir += 1) {
+      const dirPath = path.join(root, `${segment}-${dir}`);
+      await fs.mkdir(dirPath);
+      await Promise.all(
+        Array.from({ length: 50 }, (_, file) =>
+          fs.writeFile(path.join(dirPath, `${segment}-${file}.txt`), "x\n"),
+        ),
+      );
+    }
+    await git("add", "-A");
+    await git("commit", "-q", "-m", "large tree");
+
+    await expect(captureGitHubPublicationWorkspaceSnapshot({ cwd: root })).resolves.toMatchObject({
+      workspaceTree: expect.stringMatching(/^[a-f0-9]{40}$/u),
+    });
+  });
+
   it.each(["replace refs", "grafts"])("rejects Git replacement metadata from %s", async (kind) => {
     const head = await git("rev-parse", "HEAD");
     if (kind === "replace refs") {


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #129772, found during its live production verification on the team gateway. With the hooksPath blocker fixed, publication now reaches the workspace-attribute scan — and fails on every real repository with "GitHub publication workspace attributes could not be verified."

Root cause: `assertGitHubPublicationTreeHasNoFilters` runs `git ls-tree -r -z --full-tree <tree>`, whose output scales with repository size (3.3MB for openclaw itself), against the executor's fixed 256KB per-command output cap. The listing terminates as `output-limit`, the nonzero code is misreported as an attribute-verification failure, and publication fails terminally. This was latent and unreachable before #129772 because the hooksPath assertion always failed first on real checkouts; the tiny scratch repo in the original live proof stayed under the cap.

## Why This Change Was Made

The tree listing is the only repo-size-scaled command in the publication path (verified by audit; `reflog show` and the attribute-blob reads are bounded in practice). The executor's `runCommand` now honors a per-call `maxOutputBytes` override, and the attribute scan passes an explicit 64MB listing bound with a comment stating the invariant. `git ls-tree` rejects `:(glob)` pathspec magic, so server-side filtering to just `.gitattributes` entries is not available; an explicit bound on the one scan that needs the full listing is the smallest correct fix. All other commands keep the 256KB default.

## User Impact

Gateway GitHub publication works on real-sized repositories, not just toy ones. Combined with #129772 this makes the stuck roboclaw publications on the team gateway actually publishable.

## Evidence

Live root cause: replayed on the production team gateway — `git ls-tree -r -z --full-tree HEAD | wc -c` in the stuck roboclaw worktree returns 3,319,144 bytes; the production `sessions.github.publish` call failed with exactly "workspace attributes could not be verified" on the post-#129772 deployed build (`d38ffa39e600`).

Regression test: new case in `github-publication-hooks.test.ts` builds a repo whose recursive listing exceeds 256KB and drives the real `captureGitHubPublicationWorkspaceSnapshot` path — fails pre-fix with the exact production error (verified by stashing only the two production files), passes post-fix.

Suites: 6 publication test files green; `node scripts/check-changed.mjs` green; fresh Codex autoreview clean.

Production LOC delta: +12/−3 (cap plumbing + bound constant); tests +21/−1.

Post-land: production verification on the team gateway (rerun of the stuck session's publish after the hourly deploy) is the completion proof for the whole repair; result will be posted on #129772.
