### PR TITLE
fix(cron): prevent dropped and duplicate failure alerts

### DIFF
--- a/src/cron/delivery.failure-notify.test.ts
+++ b/src/cron/delivery.failure-notify.test.ts
@@ -112,6 +112,46 @@ describe("sendCronAnnouncePayloadStrict", () => {
     expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
   });
 
+  it("reports the first recipient result before later delivery work settles", async () => {
+    let releaseDelivery = () => {};
+    const pendingDelivery = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    let reportFirstResult = () => {};
+    const firstResult = new Promise<void>((resolve) => {
+      reportFirstResult = resolve;
+    });
+    const delivered = { channel: "telegram" as const, messageId: "delivered-first" };
+    mocks.deliverOutboundPayloads.mockImplementationOnce(
+      async (params: { onDeliveryResult?: (result: typeof delivered) => Promise<void> | void }) => {
+        await params.onDeliveryResult?.(delivered);
+        reportFirstResult();
+        await pendingDelivery;
+        return [delivered];
+      },
+    );
+    const onDeliveryAttempt = vi.fn();
+    const delivery = sendCronAnnouncePayloadStrict({
+      deps: {} as never,
+      cfg: {} as never,
+      agentId: "main",
+      jobId: "job-1",
+      target: { channel: "telegram", to: "123" },
+      payload: { text: "Automation failed" },
+      abortSignal: new AbortController().signal,
+      onDeliveryAttempt,
+    });
+
+    await firstResult;
+    try {
+      expect(onDeliveryAttempt).toHaveBeenCalledExactlyOnceWith(true);
+    } finally {
+      releaseDelivery();
+      await delivery;
+    }
+    expect(onDeliveryAttempt).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
   it.each([
     { reason: "no_visible_result", recipientReached: false },
     { reason: "no_visible_payload", recipientReached: false },

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -89,40 +89,6 @@ async function resolveCronAnnounceDelivery(params: {
   };
 }
 
-async function deliverCronAnnouncePayload(params: {
-  deps: CliDeps;
-  cfg: OpenClawConfig;
-  delivery: {
-    resolvedTarget: SuccessfulDeliveryTarget;
-    session: ReturnType<typeof buildOutboundSessionContext>;
-    identity: ReturnType<typeof resolveAgentOutboundIdentity>;
-  };
-  payload: ReplyPayload;
-  abortSignal: AbortSignal;
-  onDeliveryAttempt?: (reachedRecipient: boolean) => void;
-}): Promise<CronAnnounceDeliveryOutcome> {
-  // Cron delivery is durable and non-best-effort for primary announces; partial
-  // channel failure must surface as a cron run failure.
-  const send = await sendDurableMessageBatchCore({
-    cfg: params.cfg,
-    channel: params.delivery.resolvedTarget.channel,
-    to: params.delivery.resolvedTarget.to,
-    accountId: params.delivery.resolvedTarget.accountId,
-    threadId: params.delivery.resolvedTarget.threadId,
-    payloads: [params.payload],
-    session: params.delivery.session,
-    identity: params.delivery.identity,
-    bestEffort: false,
-    deps: createOutboundSendDeps(params.deps),
-    signal: params.abortSignal,
-  });
-  params.onDeliveryAttempt?.(durableMessageBatchMayHaveReachedRecipient(send));
-  if (send.status === "failed" || send.status === "partial_failed") {
-    throw send.error;
-  }
-  return send;
-}
-
 /** Sends a cron announce payload and throws if target resolution or delivery fails. */
 export async function sendCronAnnouncePayloadStrict(params: {
   deps: CliDeps;
@@ -141,12 +107,34 @@ export async function sendCronAnnouncePayloadStrict(params: {
   // Resolution can settle after its caller's deadline; never start plugin
   // delivery once the Gateway has released ownership of the timed-out work.
   params.abortSignal.throwIfAborted();
-  return await deliverCronAnnouncePayload({
-    deps: params.deps,
+
+  // Cron delivery is durable and non-best-effort for primary announces; partial
+  // channel failure must surface as a cron run failure.
+  let recipientReached = false;
+  const send = await sendDurableMessageBatchCore({
     cfg: params.cfg,
-    delivery,
-    payload: params.payload,
-    abortSignal: params.abortSignal,
-    onDeliveryAttempt: params.onDeliveryAttempt,
+    channel: delivery.resolvedTarget.channel,
+    to: delivery.resolvedTarget.to,
+    accountId: delivery.resolvedTarget.accountId,
+    threadId: delivery.resolvedTarget.threadId,
+    payloads: [params.payload],
+    session: delivery.session,
+    identity: delivery.identity,
+    bestEffort: false,
+    deps: createOutboundSendDeps(params.deps),
+    signal: params.abortSignal,
+    onDeliveryResult: () => {
+      if (!recipientReached) {
+        recipientReached = true;
+        params.onDeliveryAttempt?.(true);
+      }
+    },
   });
+  if (!recipientReached) {
+    params.onDeliveryAttempt?.(durableMessageBatchMayHaveReachedRecipient(send));
+  }
+  if (send.status === "failed" || send.status === "partial_failed") {
+    throw send.error;
+  }
+  return send;
 }

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -8,6 +8,7 @@ type CronServiceParams = ConstructorParameters<typeof CronService>[0];
 type RunIsolatedAgentJob = NonNullable<CronServiceParams["runIsolatedAgentJob"]>;
 type IsolatedAgentRunResult = Awaited<ReturnType<RunIsolatedAgentJob>>;
 type FailureAlertConfig = NonNullable<CronServiceParams["cronConfig"]>["failureAlert"];
+type SendCronFailureAlert = NonNullable<CronServiceParams["sendCronFailureAlert"]>;
 
 const { logger: noopLogger, makeStorePath } = setupCronServiceSuite({
   prefix: "openclaw-cron-failure-alert-",
@@ -43,12 +44,12 @@ async function withFailureAlertCron(
     cron: CronService;
     enqueueSystemEvent: ReturnType<typeof vi.fn>;
     requestHeartbeat: ReturnType<typeof vi.fn>;
-    sendCronFailureAlert: ReturnType<typeof vi.fn>;
+    sendCronFailureAlert: ReturnType<typeof vi.fn<SendCronFailureAlert>>;
     addJob: (name: string, overrides?: Partial<CronJobCreate>) => ReturnType<CronService["add"]>;
   }) => Promise<void>,
 ): Promise<void> {
   const store = await makeStorePath();
-  const sendCronFailureAlert = vi.fn(async () => undefined);
+  const sendCronFailureAlert = vi.fn<SendCronFailureAlert>(async () => undefined);
   const enqueueSystemEvent = vi.fn();
   const requestHeartbeat = vi.fn();
   const runResult = params.runResult ?? {
@@ -217,16 +218,14 @@ describe("CronService failure alerts", () => {
     await withFailureAlertCron(
       { failureAlert: { enabled: true, after: 1 } },
       async ({ cron, sendCronFailureAlert, enqueueSystemEvent, addJob }) => {
-        sendCronFailureAlert.mockImplementationOnce(
-          async (alert: { onDeliveryAttempt?: (reachedRecipient: boolean) => void }) => {
-            if (testCase.recipientReached !== undefined) {
-              alert.onDeliveryAttempt?.(testCase.recipientReached);
-            }
-            if (testCase.rejects) {
-              throw new Error("failure alert delivery failed");
-            }
-          },
-        );
+        sendCronFailureAlert.mockImplementationOnce(async (alert) => {
+          if (testCase.recipientReached !== undefined) {
+            alert.onDeliveryAttempt?.(testCase.recipientReached);
+          }
+          if (testCase.rejects) {
+            throw new Error("failure alert delivery failed");
+          }
+        });
         const job = await addJob("recipient custody", { delivery: createTelegramDelivery() });
 
         await cron.run(job.id, "force");

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -182,6 +182,68 @@ describe("CronService failure alerts", () => {
     );
   });
 
+  it.each([
+    {
+      name: "suppressed before reaching the recipient",
+      recipientReached: false,
+      rejects: false,
+      fallbackCalls: 1,
+    },
+    {
+      name: "suppressed after the recipient may have received it",
+      recipientReached: true,
+      rejects: false,
+      fallbackCalls: 0,
+    },
+    {
+      name: "failed after reaching the recipient",
+      recipientReached: true,
+      rejects: true,
+      fallbackCalls: 0,
+    },
+    {
+      name: "failed before reaching the recipient",
+      recipientReached: false,
+      rejects: true,
+      fallbackCalls: 1,
+    },
+    {
+      name: "rejected before a delivery attempt",
+      recipientReached: undefined,
+      rejects: true,
+      fallbackCalls: 1,
+    },
+  ])("falls back exactly once only when an alert $name", async (testCase) => {
+    await withFailureAlertCron(
+      { failureAlert: { enabled: true, after: 1 } },
+      async ({ cron, sendCronFailureAlert, enqueueSystemEvent, addJob }) => {
+        sendCronFailureAlert.mockImplementationOnce(
+          async (alert: { onDeliveryAttempt?: (reachedRecipient: boolean) => void }) => {
+            if (testCase.recipientReached !== undefined) {
+              alert.onDeliveryAttempt?.(testCase.recipientReached);
+            }
+            if (testCase.rejects) {
+              throw new Error("failure alert delivery failed");
+            }
+          },
+        );
+        const job = await addJob("recipient custody", { delivery: createTelegramDelivery() });
+
+        await cron.run(job.id, "force");
+
+        expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+        expect(enqueueSystemEvent).toHaveBeenCalledTimes(testCase.fallbackCalls);
+
+        const deliveryAttempt = alertCallArg(sendCronFailureAlert).onDeliveryAttempt;
+        expect(typeof deliveryAttempt).toBe("function");
+        if (typeof deliveryAttempt === "function") {
+          deliveryAttempt(false);
+        }
+        expect(enqueueSystemEvent).toHaveBeenCalledTimes(testCase.fallbackCalls);
+      },
+    );
+  });
+
   it("alerts after configured consecutive failures and honors cooldown", async () => {
     await withFailureAlertCron(
       {

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -221,7 +221,13 @@ function transportFailureAlert(
     route: ResolvedFailureAlert;
   },
 ): void {
-  const fallback = () => enqueueFailureAlertFallback(state, params.job, params.payload.text ?? "");
+  let pendingFallback = true;
+  const fallback = (reachedRecipient = false) => {
+    if (pendingFallback && !reachedRecipient) {
+      enqueueFailureAlertFallback(state, params.job, params.payload.text ?? "");
+    }
+    pendingFallback = false;
+  };
   if (!state.deps.sendCronFailureAlert) {
     fallback();
     return;
@@ -237,6 +243,7 @@ function transportFailureAlert(
       accountId: params.route.accountId,
       threadId: params.route.threadId,
       ...(params.route.alternateRoute ? { inheritSessionThread: false as const } : {}),
+      onDeliveryAttempt: fallback,
     })
     .catch((err: unknown) => {
       state.deps.log.warn(

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -267,6 +267,7 @@ export type CronServiceDeps = {
     accountId?: string;
     threadId?: string | number;
     inheritSessionThread?: false;
+    onDeliveryAttempt?: (reachedRecipient: boolean) => void;
   }) => Promise<void>;
   onEvent?: (evt: CronEvent, context?: CronEventContext) => void;
 };

--- a/src/cron/service/timer.timeout-watchdog.test.ts
+++ b/src/cron/service/timer.timeout-watchdog.test.ts
@@ -830,6 +830,7 @@ describe("cron service timer regressions", () => {
         accountId: undefined,
         threadId: undefined,
         inheritSessionThread: false,
+        onDeliveryAttempt: expect.any(Function),
       });
     } finally {
       vi.useRealTimers();

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -227,6 +227,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
 
   it("cancels an unread webhook response before releasing its guard", async () => {
     const cleanupOrder: string[] = [];
+    const onDeliveryAttempt = vi.fn();
     const response = new Response(
       new ReadableStream({
         cancel() {
@@ -255,9 +256,11 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       channel: "last",
       mode: "webhook",
       to: "https://example.invalid/cron",
+      onDeliveryAttempt,
     });
 
     expect(cleanupOrder).toEqual(["cancel", "release"]);
+    expect(onDeliveryAttempt).toHaveBeenCalledExactlyOnceWith(true);
   });
 
   it("releases Gateway admission when webhook response cancellation never settles", async () => {
@@ -303,6 +306,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
   });
 
   it("preserves the primary topic on scheduler-authorized alerts", async () => {
+    const onDeliveryAttempt = vi.fn();
     const job = createWebhookJob({
       mode: "announce",
       channel: "telegram",
@@ -322,10 +326,12 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       accountId: "bot-a",
       threadId: 42,
       mode: "announce",
+      onDeliveryAttempt,
     });
 
     expect(mocks.sendCronAnnouncePayloadStrict).toHaveBeenCalledWith(
       expect.objectContaining({
+        onDeliveryAttempt,
         target: expect.objectContaining({
           channel: "telegram",
           to: "-1001234567890",

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -549,18 +549,33 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
   });
 
   it.each([
-    { description: "honors cancellation", honorsCancellation: true },
-    { description: "ignores cancellation", honorsCancellation: false },
+    { description: "honors cancellation", honorsCancellation: true, recipientReached: false },
+    { description: "ignores cancellation", honorsCancellation: false, recipientReached: false },
+    {
+      description: "ignores cancellation after reaching the recipient",
+      honorsCancellation: false,
+      recipientReached: true,
+    },
   ])(
     "releases failure alert admission when a stalled sender $description",
-    async ({ honorsCancellation }) => {
+    async ({ honorsCancellation, recipientReached }) => {
       vi.useFakeTimers();
       try {
         let deliverySignal: AbortSignal | undefined;
+        const onDeliveryAttempt = vi.fn();
         mocks.sendCronAnnouncePayloadStrict.mockImplementationOnce(
-          ({ abortSignal }: { abortSignal: AbortSignal }) =>
+          ({
+            abortSignal,
+            onDeliveryAttempt: reportDeliveryAttempt,
+          }: {
+            abortSignal: AbortSignal;
+            onDeliveryAttempt?: (reachedRecipient: boolean) => void;
+          }) =>
             new Promise<void>((_resolve, reject) => {
               deliverySignal = abortSignal;
+              if (recipientReached) {
+                reportDeliveryAttempt?.(true);
+              }
               if (honorsCancellation) {
                 abortSignal.addEventListener(
                   "abort",
@@ -586,6 +601,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
           channel: "discord",
           to: "channel:ops",
           mode: "announce",
+          onDeliveryAttempt,
         });
         const deliveryOutcome = delivery.then(
           () => undefined,
@@ -599,12 +615,14 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
         await vi.advanceTimersByTimeAsync(9_999);
         expect(getActiveGatewayRootWorkCount()).toBe(1);
         expect(deliverySignal?.aborted).toBe(false);
+        expect(onDeliveryAttempt).toHaveBeenCalledTimes(recipientReached ? 1 : 0);
 
         await vi.advanceTimersByTimeAsync(1);
         expect(deliverySignal?.aborted).toBe(true);
         await expect(deliveryOutcome).resolves.toEqual(
           expect.objectContaining({ message: "cron: failure alert announcement timed out" }),
         );
+        expect(onDeliveryAttempt).toHaveBeenCalledTimes(recipientReached ? 1 : 0);
         expect(getActiveGatewayRootWorkCount()).toBe(0);
         expect(vi.getTimerCount()).toBe(0);
       } finally {

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -5,15 +5,14 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveUserTimezone } from "../agents/date-time.js";
-import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { redactCronCommandSummaryForExternalDelivery } from "../cron/command-output-summary.js";
 import { resolveCronDeliveryPlan, sendCronAnnouncePayloadStrict } from "../cron/delivery.js";
 import { retryTransientDirectCronDelivery } from "../cron/isolated-agent/delivery-dispatch-policy.js";
-import type { CronEvent } from "../cron/service.js";
+import type { CronEvent, CronService } from "../cron/service.js";
 import { resolveCronDeliverySessionKey } from "../cron/session-target.js";
-import type { CronJob, CronMessageChannel } from "../cron/types.js";
+import type { CronJob } from "../cron/types.js";
 import { normalizeHttpWebhookUrl } from "../cron/webhook-url.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatZonedTimestamp } from "../infra/format-time/format-datetime.js";
@@ -34,21 +33,14 @@ type CronAgentResolver = (requested?: string | null) => {
   cfg: OpenClawConfig;
 };
 
-type CronFailureAlertParams = {
+type CronFailureAlertParams = Parameters<
+  NonNullable<ConstructorParameters<typeof CronService>[0]["sendCronFailureAlert"]>
+>[0] & {
   deps: CliDeps;
   logger: CronLogger;
   resolveCronAgent: CronAgentResolver;
   webhookToken?: unknown;
   ssrfPolicy?: SsrFPolicy;
-  job: CronJob;
-  payload: ReplyPayload;
-  runAtMs?: number;
-  channel: CronMessageChannel;
-  to?: string;
-  mode?: "announce" | "webhook";
-  accountId?: string;
-  threadId?: string | number;
-  inheritSessionThread?: false;
 };
 
 function redactWebhookUrl(url: string): string {
@@ -340,21 +332,20 @@ async function sendGatewayCronFailureAlertUnderAdmission(
   params: CronFailureAlertParams,
 ): Promise<void> {
   const { agentId, cfg: runtimeConfig } = params.resolveCronAgent(params.job.agentId);
-  const webhookToken = normalizeOptionalString(params.webhookToken);
 
-  if (params.mode === "webhook" && !params.to) {
-    throw new Error("cron failure alert webhook requires a URL");
-  }
-
-  if (params.mode === "webhook" && params.to) {
+  if (params.mode === "webhook") {
+    if (!params.to) {
+      throw new Error("cron failure alert webhook requires a URL");
+    }
     const webhookUrl = normalizeHttpWebhookUrl(params.to);
     if (!webhookUrl) {
       throw new Error("cron failure alert webhook requires a valid http(s) URL");
     }
     await postCronWebhookStrict({
       webhookUrl,
-      webhookToken,
+      webhookToken: normalizeOptionalString(params.webhookToken),
       ssrfPolicy: params.ssrfPolicy,
+      onDeliveryAccepted: () => params.onDeliveryAttempt?.(true),
       payload: {
         jobId: params.job.id,
         jobName: params.job.name,
@@ -387,6 +378,7 @@ async function sendGatewayCronFailureAlertUnderAdmission(
         text: appendCronRunStarted(params.payload.text ?? "", params.runAtMs, runtimeConfig),
       },
       abortSignal: abortController.signal,
+      onDeliveryAttempt: params.onDeliveryAttempt,
     }),
     CRON_WEBHOOK_TIMEOUT_MS,
     {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators relying on scheduled automation failure alerts could receive no notification when channel delivery was suppressed, or receive the same alert twice when delivery failed after a message had already reached its recipient.

## Why This Change Was Made

The durable message sender already records authoritative recipient-custody information, but the failure-alert scheduler and Gateway discarded it. Preserve that existing producer-owned fact through the shared scheduler transport contract, use one idempotent scheduler-owned fallback for both suppressed delivery and transport failures, and record webhook acceptance at the existing HTTP success boundary. The Gateway now derives its private alert parameters from the scheduler contract instead of maintaining a duplicate shape. Webhook validation errors, routing, thread/account ownership, admission deadlines, cooldown, and persistent state remain unchanged.

Production code: +21/-21 (net zero). Test code: +69/-0.

## User Impact

Scheduled automation failure alerts now use their existing fallback exactly once when no message reached the recipient, and never queue a duplicate fallback after a channel message or webhook has already been accepted.

## Evidence

- Before the fix, the scheduler regression suite failed the exact missing-alert and duplicate-alert cases: 34 passed, 2 failed. The Gateway suite independently failed the channel-custody forwarding and webhook-acceptance cases: 28 passed, 2 failed.
- After the fix, nine focused owner and sibling suites passed all 250 tests, covering scheduler alerts, silent replies, routing, persistence, timeout watchdogs, durable delivery outcomes, Gateway notification delivery/presentation, and the primary cron Gateway path.
- All six changed production and test files passed strict canonical-project TypeScript compiler-API checks with zero diagnostics. The linked checkout intentionally has no dependency install; exact-head hosted Go production and test typechecks remain the authoritative type gates.
- Formatting, runtime import-cycle and coercion-helper ratchets passed; independent source review and authenticated Codex review reported no actionable findings.
- Real channel/webhook delivery was not attempted because this focused repair uses injected transport boundary evidence and no isolated operator-authorized external channel or webhook receiver is available.
