### PR TITLE
fix(delivery): rearm queue timers across clock jumps

### DIFF
--- a/src/gateway/session-delivery-clock-jump.integration.test.ts
+++ b/src/gateway/session-delivery-clock-jump.integration.test.ts
@@ -1,0 +1,214 @@
+import http from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getDeliveryQueueEntryStatus } from "../infra/delivery-queue-sqlite.js";
+import { scheduleSessionDelivery } from "../infra/session-delivery-queue-runtime.js";
+import { testing } from "../infra/session-delivery-queue-runtime.test-support.js";
+import {
+  enqueueClaimedSessionDelivery,
+  loadPendingSessionDeliveries,
+  releaseSessionDeliveryClaim,
+  SESSION_DELIVERY_QUEUE_NAME,
+} from "../infra/session-delivery-queue-storage.js";
+import {
+  createGatewayConfigPath,
+  removeGatewayTempHome,
+  resetGatewayTestState,
+  setupGatewayTempHome,
+} from "./gateway.test-support.js";
+import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
+import { buildMockOpenAiResponsesProvider } from "./test-openai-responses-model.js";
+
+async function startProofProvider(requests: string[]): Promise<http.Server> {
+  const server = http.createServer((request, response) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      requests.push(body);
+      const events = [
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "message",
+            id: "clock-jump-message",
+            role: "assistant",
+            content: [],
+            status: "in_progress",
+          },
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "clock-jump-message",
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text: "CLOCK_JUMP DELIVERED", annotations: [] }],
+          },
+        },
+        {
+          type: "response.completed",
+          response: {
+            status: "completed",
+            usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+          },
+        },
+      ];
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.end(
+        `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+      );
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return server;
+}
+
+async function closeProofProvider(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+afterEach(() => {
+  testing.reset();
+  resetGatewayTestState();
+  vi.restoreAllMocks();
+});
+
+describe("session delivery clock-jump integration", () => {
+  it(
+    "delivers and settles a released claim through a real Gateway client",
+    { timeout: 90_000 },
+    async () => {
+      const initialTime = Date.now();
+      const wallClock = vi.spyOn(Date, "now").mockReturnValue(initialTime);
+      const { envSnapshot, tempHome, workspaceDir } = await setupGatewayTempHome({
+        prefix: "openclaw-session-delivery-gateway-",
+      });
+      let gateway: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+      let providerServer: http.Server | undefined;
+      const providerRequests: string[] = [];
+
+      try {
+        providerServer = await startProofProvider(providerRequests);
+        const providerAddress = providerServer.address();
+        if (!providerAddress || typeof providerAddress === "string") {
+          throw new Error("proof provider did not bind a loopback port");
+        }
+        const provider = buildMockOpenAiResponsesProvider(
+          `http://127.0.0.1:${providerAddress.port}/v1`,
+        );
+        const token = "clock-jump-proof-token";
+        const configPath = await createGatewayConfigPath(tempHome);
+        const sessionKey = "agent:main:clock-jump-proof";
+        const chatEvents: string[] = [];
+        const cfg = {
+          agents: {
+            defaults: {
+              workspace: workspaceDir,
+              skipBootstrap: true,
+              model: { primary: provider.modelRef },
+              models: {
+                [provider.modelRef]: {
+                  params: { transport: "sse", openaiWsWarmup: false },
+                },
+              },
+            },
+            entries: { main: { default: true } },
+          },
+          models: {
+            mode: "replace",
+            providers: {
+              [provider.providerId]: {
+                ...provider.config,
+                request: { allowPrivateNetwork: true },
+              },
+            },
+          },
+          gateway: { auth: { mode: "token", token } },
+          plugins: { slots: { memory: "none" } },
+          tools: { profile: "minimal" },
+        } satisfies OpenClawConfig;
+        const { id } = await enqueueClaimedSessionDelivery(
+          {
+            kind: "agentTurn",
+            sessionKey,
+            message: "Reply with the clock-jump proof marker.",
+            messageId: "image:clock-jump:agent-loop",
+            idempotencyKey: "image:clock-jump:agent-loop",
+            route: { channel: "webchat", to: sessionKey, chatType: "direct" },
+            inputProvenance: {
+              kind: "inter_session",
+              sourceChannel: "webchat",
+              sourceTool: "image_generate",
+            },
+            sourceReplyDeliveryMode: "automatic",
+          },
+          60_000,
+        );
+
+        gateway = await startGatewayWithClient({
+          cfg,
+          configPath,
+          token,
+          scopes: ["operator.admin", "operator.read", "operator.write"],
+          onEvent: (event) => {
+            if (event.event !== "chat") {
+              return;
+            }
+            chatEvents.push(JSON.stringify(event.payload ?? {}));
+          },
+        });
+        await gateway.server.startupSettled;
+        await gateway.client.request("sessions.messages.subscribe", { key: sessionKey });
+        await expect
+          .poll(() => scheduleSessionDelivery(id), { timeout: 10_000, interval: 50 })
+          .toBe(true);
+
+        wallClock.mockReturnValue(initialTime + 24 * 60 * 60 * 1_000);
+        await releaseSessionDeliveryClaim(id);
+        await scheduleSessionDelivery(id);
+
+        await vi.waitFor(
+          async () => expect(await loadPendingSessionDeliveries()).toStrictEqual([]),
+          { timeout: 15_000, interval: 50 },
+        );
+        expect(providerRequests).toHaveLength(1);
+        expect(providerRequests[0]).toContain("clock-jump proof marker");
+        expect(chatEvents.join("\n")).toContain("CLOCK_JUMP DELIVERED");
+        expect(await loadPendingSessionDeliveries()).toStrictEqual([]);
+        expect(getDeliveryQueueEntryStatus(SESSION_DELIVERY_QUEUE_NAME, id)).toBe("completed");
+      } finally {
+        wallClock.mockRestore();
+        try {
+          if (gateway) {
+            try {
+              await disconnectGatewayClient(gateway.client);
+            } finally {
+              await gateway.server.close({ reason: "session delivery clock-jump proof complete" });
+            }
+          }
+        } finally {
+          try {
+            if (providerServer) {
+              await closeProofProvider(providerServer);
+            }
+          } finally {
+            try {
+              await removeGatewayTempHome(tempHome);
+            } finally {
+              envSnapshot.restore();
+            }
+          }
+        }
+      }
+    },
+  );
+});

--- a/src/infra/session-delivery-queue-runtime.test.ts
+++ b/src/infra/session-delivery-queue-runtime.test.ts
@@ -154,6 +154,72 @@ describe("session delivery queue runtime", () => {
     });
   });
 
+  it("recomputes a future claim timer after the wall clock jumps forward", async () => {
+    vi.useFakeTimers();
+    const initialTime = new Date("2026-07-15T00:00:00.000Z");
+    const dayMs = 24 * 60 * 60 * 1_000;
+    vi.setSystemTime(initialTime);
+    await withTestDir({ prefix: "openclaw-session-delivery-runtime-" }, async (tempDir) => {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: tempDir }, async () => {
+        const { id } = await enqueueClaimedSessionDelivery(
+          {
+            kind: "agentTurn",
+            sessionKey: "agent:main:main",
+            message: "generated image ready",
+            messageId: "image:task-future-clock-jump:agent-loop",
+            idempotencyKey: "image:task-future-clock-jump:agent-loop",
+          },
+          2 * dayMs,
+        );
+        const deliver = vi.fn(async () => {});
+        startSessionDeliveryRuntime({ deliver, log: logger });
+
+        await scheduleSessionDelivery(id);
+        vi.setSystemTime(new Date(initialTime.getTime() + dayMs));
+        await scheduleSessionDelivery(id);
+
+        await vi.advanceTimersByTimeAsync(dayMs - 1);
+        expect(deliver).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(deliver).toHaveBeenCalledTimes(1);
+        expect(await loadPendingSessionDeliveries()).toStrictEqual([]);
+      });
+    });
+  });
+
+  it("preempts a released claim after the wall clock jumps past its lease", async () => {
+    const initialTime = Date.now();
+    const wallClock = vi.spyOn(Date, "now").mockReturnValue(initialTime);
+    try {
+      await withTestDir({ prefix: "openclaw-session-delivery-runtime-" }, async (tempDir) => {
+        await withEnvAsync({ OPENCLAW_STATE_DIR: tempDir }, async () => {
+          const { id } = await enqueueClaimedSessionDelivery(
+            {
+              kind: "agentTurn",
+              sessionKey: "agent:main:main",
+              message: "generated image ready",
+              messageId: "image:task-expired-clock-jump:agent-loop",
+              idempotencyKey: "image:task-expired-clock-jump:agent-loop",
+            },
+            60_000,
+          );
+          const deliver = vi.fn(async () => {});
+          startSessionDeliveryRuntime({ deliver, log: logger });
+
+          await scheduleSessionDelivery(id);
+          wallClock.mockReturnValue(initialTime + 24 * 60 * 60 * 1_000);
+          await releaseSessionDeliveryClaim(id);
+          await scheduleSessionDelivery(id);
+
+          await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(1));
+          expect(await loadPendingSessionDeliveries()).toStrictEqual([]);
+        });
+      });
+    } finally {
+      wallClock.mockRestore();
+    }
+  });
+
   it("coalesces duplicate schedules while the same entry is draining", async () => {
     vi.useFakeTimers();
     await withTestDir({ prefix: "openclaw-session-delivery-runtime-" }, async (tempDir) => {

--- a/src/infra/session-delivery-queue-runtime.ts
+++ b/src/infra/session-delivery-queue-runtime.ts
@@ -73,7 +73,8 @@ function armSessionDeliveryId(id: string, delayMs: number, generation: number): 
   if (!runtime || generation !== runtimeGeneration) {
     return;
   }
-  const dueAt = Date.now() + delayMs;
+  // Native timers measure elapsed time, so preemption deadlines must ignore wall-clock jumps.
+  const dueAt = performance.now() + delayMs;
   const existing = scheduledEntries.get(id);
   if (existing && existing.dueAt <= dueAt) {
     return;


### PR DESCRIPTION
## What Problem This Solves

Session-delivery retries can keep an old process-local timer after the system wall clock jumps forward. A newly shorter durable lease or a released claim then remains delayed even though it is already due.

## Root cause

The queue converts durable wall-clock timestamps into an elapsed delay for `setTimeout`, but it stored the process-local preemption deadline as `Date.now() + delayMs`. A wall-clock jump changed that comparison without advancing the native timer.

## Fix

The process-local preemption deadline now uses `performance.now()`. Durable `availableAt`, retry, and subagent deadlines remain wall-clock values in SQLite.

## Evidence

- Exact current main at proof start: `6ddd598683fa4db3186378034513bba47a6ae30b`.
- Main red: both clock-jump regressions delivered zero messages at the corrected deadline.
- Real-timer red: the released-claim case overrides only `Date.now()` while native timers keep running; main timed out after 1.27 seconds with zero deliveries.
- Exact head: `e93f2b15bf89d5d44fe09c74f2f8b447a7aa4f56`.
- Exact-head green: the real-timer owner case delivered and removed its SQLite row.
- Exact-head Gateway trace: `node scripts/run-vitest.mjs src/gateway/session-delivery-clock-jump.integration.test.ts --reporter=verbose` passed in 9.12 seconds.
- The committed trace records `clock jump → queue drain → Gateway agent run → loopback provider HTTP request → Gateway WebSocket client reply → completed settlement tombstone`.
- Replacing only the monotonic comparator with main's wall-clock comparator kept the row pending and failed after the 15-second observation window.
- The provider request contains the proof prompt, the WebSocket client receives `CLOCK_JUMP DELIVERED`, the pending queue becomes empty, and the durable status becomes `completed`.
- The production SQLite scheduler, queue drain, queued-session delivery owner, real Gateway, provider HTTP client, Gateway WebSocket client, settlement owner, and row cleanup are exercised. The loopback provider is deterministic; no live external channel account is needed to prove the process-local timer boundary.
- Full owner suite: `node scripts/run-vitest.mjs src/infra/session-delivery-queue-runtime.test.ts --reporter=verbose` passed 13/13.
- `oxfmt`, `oxlint`, max-lines, assertion-safety, and `git diff --check` passed for the changed scope.
- Current main later advanced to `8cf4351e8fc17cd9084cce2bb7f5469a62bbf2e4` with no changes to the timer or queue owner files.

## Scope

- Executable production logic is net neutral: one clock read replaces one clock read.
- The extra production line is the required clock-domain invariant comment.
- Tests add two scheduler regressions and one Gateway-boundary settlement trace.
- No configuration, protocol, storage schema, or durable timestamp semantics change.
- Codex source at `28327355b861ab6cc76b01c7248663eb1be440cf` confirms completion notifications do not carry retry deadlines and elapsed runtime deadlines use monotonic `Instant` values.
