### PR TITLE
test(release): keep workflow regressions in changed runs

### DIFF
--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -2277,7 +2277,10 @@ const SEMANTIC_TOOLING_TARGET_PATTERNS: Array<[RegExp, string[]]> = [
     /^\.github\/workflows\/openclaw-release-checks\.yml$/u,
     [packageAcceptance, crossOsReleaseChecks, pluginPrerelease, installDocker],
   ],
-  [/^\.github\/workflows\/docker-release\.yml$/u, ["src/dockerfile.test.ts"]],
+  [
+    /^\.github\/workflows\/docker-release\.yml$/u,
+    ["src/dockerfile.test.ts", "docker-channel-promote", "vercel-container-registry-publish"],
+  ],
   [/^\.github\/workflows\/install-smoke\.yml$/u, ["install-smoke-no-push-workflow", installDocker]],
   [/^\.github\/workflows\/openclaw-performance\.yml$/u, ["openclaw-performance-workflow"]],
   [/^\.github\/workflows\/plugin-prerelease\.yml$/u, [pluginPrerelease]],
@@ -2287,8 +2290,13 @@ const SEMANTIC_TOOLING_TARGET_PATTERNS: Array<[RegExp, string[]]> = [
     [crossOsReleaseChecks, "openclaw-cross-os-release-workflow", packageAcceptance],
   ],
   [
-    /^\.github\/workflows\/(?:openclaw-release-publish|package-acceptance)\.yml$/u,
-    [packageAcceptance],
+    /^\.github\/workflows\/openclaw-release-publish\.yml$/u,
+    [packageAcceptance, "vercel-container-registry-publish"],
+  ],
+  [/^\.github\/workflows\/package-acceptance\.yml$/u, [packageAcceptance]],
+  [
+    /^\.github\/workflows\/vercel-container-registry-publish\.yml$/u,
+    ["docker-channel-promote", "release-plan-producer", "vercel-container-registry-publish"],
   ],
   [
     /^\.github\/workflows\/plugin-clawhub-new\.yml$/u,

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -499,6 +499,40 @@ describe("scripts/test-projects changed-target routing", () => {
     );
   });
 
+  it.each([
+    {
+      workflowPath: ".github/workflows/docker-release.yml",
+      targets: [
+        "src/dockerfile.test.ts",
+        "test/scripts/docker-channel-promote.test.ts",
+        "test/scripts/vercel-container-registry-publish.test.ts",
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
+    },
+    {
+      workflowPath: ".github/workflows/openclaw-release-publish.yml",
+      targets: [
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/vercel-container-registry-publish.test.ts",
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
+    },
+    {
+      workflowPath: ".github/workflows/vercel-container-registry-publish.yml",
+      targets: [
+        "test/scripts/docker-channel-promote.test.ts",
+        "test/scripts/release-plan-producer.test.ts",
+        "test/scripts/vercel-container-registry-publish.test.ts",
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
+    },
+  ])(
+    "routes release workflow edits through their owning regression tests for $workflowPath",
+    ({ workflowPath, targets }) => {
+      expectChangedTargets([workflowPath], targets);
+    },
+  );
+
   it("keeps generated locale publisher and inventory edits on workflow guards", () => {
     for (const actionPath of [
       ".github/actions/create-generated-pr-tokens/action.yml",


### PR DESCRIPTION
Follow-up to #129467.

## What Problem This Solves

Resolves a problem where edits to the Docker and Vercel release workflows could skip the regression tests that directly parse and assert those workflows when `pnpm test:changed` selected a precise target plan.

This follow-up was deliberately kept out of #129467 because changing the shared test-project resolver during the active broad-suite timeout incident would have forced metadata-complete compact CI for that repair.

## Why This Change Was Made

The changed-test resolver now maps each release workflow to the exact owner tests that consume it, while preserving the workflows' existing Dockerfile, package-acceptance, release-plan, and workflow-guard coverage. A table-driven resolver regression locks the complete target set for all three workflow paths.

The implementation was AI-assisted and reviewed by the maintainer.

## User Impact

There is no product runtime change. Maintainers get precise, fast regression coverage when changing Docker release publication, OpenClaw release orchestration, or Vercel Container Registry publication workflows.

## Evidence

- Pre-fix focused resolver regression: 2 failed, 1 passed because the Docker and release-publish workflow routes omitted their owning release tests.
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts` — 282 passed.
- `node scripts/check-changed.mjs -- scripts/test-projects.test-support.mts test/scripts/test-projects.test.ts` — passed for `scripts`, `testRoot`, and `tooling` lanes.
- `git diff --check` — passed.
- Fresh structured autoreview — no accepted/actionable findings.

Tooling/test-support delta: +11/-3. Tests: +34/-0. Production runtime: 0.
