### PR TITLE
fix(line): preserve rich message source order

### DIFF
--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -22,6 +22,36 @@ describe("deliverLineAutoReply", () => {
   it.each([
     { name: "without quick replies", quickReplies: [] as string[] },
     { name: "with final quick replies", quickReplies: ["Continue"] },
+  ])("keeps ordinary Markdown blocks in source order $name", async ({ quickReplies }) => {
+    const { deps, replyMessageLine, pushMessagesLine } = createDeps({
+      processLineMessage: processOrderedLineMessage,
+      chunkMarkdownText,
+    });
+    const markdown =
+      "Before\n\n```js\nfirst()\n```\n\nBetween\n\n| Name | Value |\n|---|---|\n| Item | one |\n\nAfter";
+
+    await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: markdown },
+      lineData: quickReplies.length > 0 ? { quickReplies } : {},
+      deps,
+    });
+
+    expect(replyMessageLine).toHaveBeenCalledOnce();
+    expect(pushMessagesLine).not.toHaveBeenCalled();
+    const messages = expectDefined(replyMessageLine.mock.calls[0]?.[1], "LINE reply messages");
+    expect(
+      messages.map((message) => (message.type === "flex" ? message.altText : message.text)),
+    ).toEqual(["Before", "Code", "Between", "Table", "After"]);
+    if (quickReplies.length > 0) {
+      expect(messages.at(-1)).toMatchObject({ quickReply: { items: quickReplies } });
+      expect(messages.slice(0, -1).every((message) => !("quickReply" in message))).toBe(true);
+    }
+  });
+
+  it.each([
+    { name: "without quick replies", quickReplies: [] as string[] },
+    { name: "with final quick replies", quickReplies: ["Continue"] },
   ])("keeps oversized Markdown tables in source order $name", async ({ quickReplies }) => {
     const { deps, replyMessageLine, pushMessagesLine } = createDeps({
       processLineMessage: processOrderedLineMessage,

--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -41,12 +41,97 @@ describe("deliverLineAutoReply", () => {
     expect(pushMessagesLine).not.toHaveBeenCalled();
     const messages = expectDefined(replyMessageLine.mock.calls[0]?.[1], "LINE reply messages");
     expect(
-      messages.map((message) => (message.type === "flex" ? message.altText : message.text)),
+      messages.map((message) =>
+        message.type === "flex"
+          ? message.altText
+          : message.type === "text"
+            ? message.text
+            : message.type,
+      ),
     ).toEqual(["Before", "Code", "Between", "Table", "After"]);
     if (quickReplies.length > 0) {
       expect(messages.at(-1)).toMatchObject({ quickReply: { items: quickReplies } });
       expect(messages.slice(0, -1).every((message) => !("quickReply" in message))).toBe(true);
     }
+  });
+
+  it.each([
+    {
+      name: "a fenced code block",
+      markdown: "```js\nfirst()\n```",
+      cards: ["Code"],
+    },
+    {
+      name: "a Markdown table",
+      markdown: "| Name | Value |\n|---|---|\n| Item | one |",
+      cards: ["Table"],
+    },
+    {
+      name: "consecutive code and table cards",
+      markdown: "```js\nfirst()\n```\n\n| Name | Value |\n|---|---|\n| Item | one |",
+      cards: ["Code", "Table"],
+    },
+  ])("keeps media as the final quick-reply carrier after $name", async ({ markdown, cards }) => {
+    const lineData = { quickReplies: ["Continue"] };
+    const { deps, replyMessageLine, pushMessagesLine } = createDeps({
+      processLineMessage: processOrderedLineMessage,
+      chunkMarkdownText,
+    });
+
+    await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: markdown, mediaUrls: ["https://example.com/image.jpg"] },
+      lineData,
+      deps,
+    });
+
+    const messages = expectDefined(replyMessageLine.mock.calls[0]?.[1], "LINE reply messages");
+    expect(
+      messages.map((message) => (message.type === "flex" ? message.altText : message.type)),
+    ).toEqual([...cards, "image"]);
+    expect(messages.at(-1)).toMatchObject({
+      type: "image",
+      originalContentUrl: "https://example.com/image.jpg",
+      quickReply: { items: ["Continue"] },
+    });
+    expect(messages.slice(0, -1).every((message) => !("quickReply" in message))).toBe(true);
+    expect(pushMessagesLine).not.toHaveBeenCalled();
+  });
+
+  it("keeps quick replies on final media when ordered cards overflow the reply token", async () => {
+    const lineData = { quickReplies: ["Continue"] };
+    const { deps, replyMessageLine, pushMessagesLine } = createDeps({
+      processLineMessage: processOrderedLineMessage,
+      chunkMarkdownText,
+    });
+
+    await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: {
+        text: Array.from({ length: 6 }, (_, index) => `\`\`\`js\ncard${index}()\n\`\`\``).join(
+          "\n\n",
+        ),
+        mediaUrls: ["https://example.com/image.jpg"],
+      },
+      lineData,
+      deps,
+    });
+
+    expect(replyMessageLine.mock.calls[0]?.[1].map((message) => message.type)).toEqual([
+      "flex",
+      "flex",
+      "flex",
+      "flex",
+      "flex",
+    ]);
+    expect(pushMessagesLine.mock.calls[0]?.[1]).toMatchObject([
+      { type: "flex", altText: "Code" },
+      {
+        type: "image",
+        originalContentUrl: "https://example.com/image.jpg",
+        quickReply: { items: ["Continue"] },
+      },
+    ]);
   });
 
   it.each([

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -300,7 +300,15 @@ export async function deliverLineAutoReply(params: {
   }
 
   const textMessages: messagingApi.Message[] = chunks.map((text) => ({ type: "text", text }));
-  const richMediaMessages = [...richMessages, ...mediaMessages];
+  // Rich-only Markdown stays on the inline media path so its final media
+  // message, not an earlier Flex card, owns the visible quick replies.
+  const orderedDeliveryMessages =
+    hasQuickReplies && chunks.length === 0 ? undefined : orderedMessages;
+  const richMediaMessages = [
+    ...richMessages,
+    ...(orderedDeliveryMessages ? [] : (orderedMessages ?? [])),
+    ...mediaMessages,
+  ];
   if (hasQuickReplies && textMessages.length === 0 && richMediaMessages.length === 0) {
     textMessages.push({
       type: "text",
@@ -308,8 +316,8 @@ export async function deliverLineAutoReply(params: {
     });
   }
   if (hasQuickReplies) {
-    const targetMessages = orderedMessages?.length
-      ? orderedMessages
+    const targetMessages = orderedDeliveryMessages?.length
+      ? orderedDeliveryMessages
       : textMessages.length > 0
         ? textMessages
         : richMediaMessages;
@@ -324,8 +332,8 @@ export async function deliverLineAutoReply(params: {
   // Quick replies disappear when a newer message arrives, so rich/media parts
   // lead and the action-bearing text remains final across reply/push batches.
   const messages = hasQuickReplies
-    ? [...richMediaMessages, ...(orderedMessages ?? textMessages)]
-    : [...(orderedMessages ?? textMessages), ...richMediaMessages];
+    ? [...richMediaMessages, ...(orderedDeliveryMessages ?? textMessages)]
+    : [...(orderedDeliveryMessages ?? textMessages), ...richMediaMessages];
   try {
     // A reply token carries five messages without consuming push quota. The
     // canonical batcher owns overflow and reply failure fallback for every payload.

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -517,6 +517,38 @@ describe("line outbound sendPayload", () => {
     );
   });
 
+  it("keeps rendered-code quick replies on the final inline media message", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:U123",
+      text: "```js\nfirst()\n```",
+      payload: {
+        text: "```js\nfirst()\n```",
+        mediaUrl: "https://example.com/image.jpg",
+        channelData: { line: { quickReplies: ["Continue"] } },
+      },
+      accountId: "default",
+      cfg,
+    });
+
+    expect(mocks.pushMessagesLine).toHaveBeenCalledExactlyOnceWith(
+      "line:user:U123",
+      [
+        expect.objectContaining({ type: "flex", altText: "Code" }),
+        expect.objectContaining({
+          type: "image",
+          originalContentUrl: "https://example.com/image.jpg",
+          quickReply: { items: ["Continue"] },
+        }),
+      ],
+      { verbose: false, accountId: "default", cfg },
+    );
+    expect(mocks.pushFlexMessage).not.toHaveBeenCalled();
+  });
+
   it("sends template message without dropping text", async () => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -517,38 +517,6 @@ describe("line outbound sendPayload", () => {
     );
   });
 
-  it("keeps rendered-code quick replies on the final inline media message", async () => {
-    const { runtime, mocks } = createRuntime();
-    setLineRuntime(runtime);
-    const cfg = { channels: { line: {} } } as OpenClawConfig;
-
-    await lineOutboundAdapter.sendPayload!({
-      to: "line:user:U123",
-      text: "```js\nfirst()\n```",
-      payload: {
-        text: "```js\nfirst()\n```",
-        mediaUrl: "https://example.com/image.jpg",
-        channelData: { line: { quickReplies: ["Continue"] } },
-      },
-      accountId: "default",
-      cfg,
-    });
-
-    expect(mocks.pushMessagesLine).toHaveBeenCalledExactlyOnceWith(
-      "line:user:U123",
-      [
-        expect.objectContaining({ type: "flex", altText: "Code" }),
-        expect.objectContaining({
-          type: "image",
-          originalContentUrl: "https://example.com/image.jpg",
-          quickReply: { items: ["Continue"] },
-        }),
-      ],
-      { verbose: false, accountId: "default", cfg },
-    );
-    expect(mocks.pushFlexMessage).not.toHaveBeenCalled();
-  });
-
   it("sends template message without dropping text", async () => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);

--- a/extensions/line/src/markdown-to-line.test.ts
+++ b/extensions/line/src/markdown-to-line.test.ts
@@ -207,6 +207,19 @@ describe("processLineMessage", () => {
     expect(result.flexMessages).toHaveLength(0);
   });
 
+  it("keeps ordinary code cards, table cards, and prose in authored order", () => {
+    const result = processLineMessage(
+      "Before\n\n```js\nfirst()\n```\n\nBetween\n\n| Name | Value |\n|---|---|\n| Item | one |\n\nAfter",
+    );
+
+    expect(result.flexMessages.map((message) => message.altText)).toEqual(["Code", "Table"]);
+    expect(
+      result.segments?.map((segment) =>
+        segment.type === "flex" ? segment.message.altText : segment.text,
+      ),
+    ).toEqual(["Before", "Code", "Between", "Table", "After"]);
+  });
+
   it("processes text with code blocks", () => {
     const text = `Check this code:
 
@@ -346,7 +359,7 @@ print("done")
       Buffer.byteLength(JSON.stringify(result.flexMessages[0]?.contents), "utf8"),
     ).toBeLessThanOrEqual(30_000);
     expect(result.text).toBe("");
-    expect(result.segments).toBeUndefined();
+    expect(result.segments).toEqual([{ type: "flex", message: result.flexMessages[0] }]);
   });
 
   it("downgrades a generic table with more than 10 rows to ordered bullet text", () => {
@@ -384,7 +397,7 @@ print("done")
     const result = processLineMessage(`| Name | Price |\n|---|---|\n${rows}`);
 
     expect(result.flexMessages).toHaveLength(1);
-    expect(result.segments).toBeUndefined();
+    expect(result.segments).toEqual([{ type: "flex", message: result.flexMessages[0] }]);
   });
 
   it("keeps a generic table with exactly 10 rows as a Flex bubble", () => {
@@ -394,7 +407,7 @@ print("done")
     const result = processLineMessage(`| Name | Value | Extra |\n|---|---|---|\n${rows}`);
 
     expect(result.flexMessages).toHaveLength(1);
-    expect(result.segments).toBeUndefined();
+    expect(result.segments).toEqual([{ type: "flex", message: result.flexMessages[0] }]);
   });
 
   it("downgrades a two-column table with inline markup and more than 10 rows using the renderer's layout decision", () => {

--- a/extensions/line/src/markdown-to-line.ts
+++ b/extensions/line/src/markdown-to-line.ts
@@ -24,7 +24,7 @@ export interface ProcessedLineMessage {
   text: string;
   /** Flex messages extracted from tables/code blocks */
   flexMessages: FlexMessage[];
-  /** Source-ordered delivery parts only when a table must fall back to plain text. */
+  /** Source-ordered delivery parts whenever Markdown contains rich blocks. */
   segments?: Array<{ type: "text"; text: string } | { type: "flex"; message: FlexMessage }>;
 }
 
@@ -430,9 +430,7 @@ export function convertCodeBlockToFlexBubble(block: CodeBlock): FlexBubble {
 export function processLineMessage(text: string): ProcessedLineMessage {
   const { ir, tables } = parseLineMarkdown(text);
   const codeSpans = codeBlockSpans(ir);
-  const flexMessages: FlexMessage[] = [];
   const plainTextInsertions: PlainTextInsertion[] = [];
-  let hasOversizedTable = false;
 
   for (const table of tables) {
     // Receipt cards keep 12 plain rows; generic and styled table layouts keep only 10.
@@ -446,7 +444,6 @@ export function processLineMessage(text: string): ProcessedLineMessage {
     const bubble = rowOverflow ? undefined : convertTableToFlexBubble(toMarkdownTable(table));
     // LINE rejects the whole push/reply when any bubble exceeds its 30 KB UTF-8 JSON limit.
     if (!bubble || Buffer.byteLength(JSON.stringify(bubble), "utf8") > LINE_FLEX_BUBBLE_MAX_BYTES) {
-      hasOversizedTable = true;
       plainTextInsertions.push({
         position: table.placeholderOffset,
         text: `\n\n${formatOversizedTableAsBullets(table)}\n\n`,
@@ -454,27 +451,22 @@ export function processLineMessage(text: string): ProcessedLineMessage {
       continue;
     }
     const message = toFlexMessage("Table", bubble);
-    flexMessages.push(message);
     plainTextInsertions.push({ position: table.placeholderOffset, message });
   }
 
   for (const span of codeSpans) {
     const message = toFlexMessage("Code", convertCodeBlockToFlexBubble(toCodeBlock(ir, span)));
-    flexMessages.push(message);
     plainTextInsertions.push({ position: span.start, message });
   }
 
   const segments: LineMessageSegment[] = [];
-  const processedText = projectPlainText(
-    ir,
-    codeSpans,
-    plainTextInsertions,
-    hasOversizedTable ? (segment) => segments.push(segment) : undefined,
+  const processedText = projectPlainText(ir, codeSpans, plainTextInsertions, (segment) =>
+    segments.push(segment),
   );
   return {
     text: processedText,
-    flexMessages,
-    ...(hasOversizedTable ? { segments } : {}),
+    flexMessages: segments.flatMap((segment) => (segment.type === "flex" ? [segment.message] : [])),
+    ...(plainTextInsertions.length > 0 ? { segments } : {}),
   };
 }
 

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -244,7 +244,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       await sendMediaMessages();
     }
 
-    if (orderedMessages) {
+    if (orderedMessages && !shouldSendQuickRepliesInline) {
       for (const [index, message] of orderedMessages.entries()) {
         const isLast = index === orderedMessages.length - 1;
         if (message.type === "flex") {

--- a/extensions/line/src/row-overflow-delivery.loopback.test.ts
+++ b/extensions/line/src/row-overflow-delivery.loopback.test.ts
@@ -332,6 +332,25 @@ describe("Row-overflow table delivery through production outbound adapter over l
     }
   });
 
+  it("preserves ordinary prose, code, and table order on the actual LINE HTTP wire", async () => {
+    const markdown =
+      "Before\n\n```js\nfirst()\n```\n\nBetween\n\n| Name | Value |\n|---|---|\n| Item | one |\n\nAfter";
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:UtestOrdered",
+      text: markdown,
+      payload: { text: markdown },
+      cfg: LINE_TEST_CFG,
+    });
+
+    expect(
+      collectAllWireMessages(requests).map((message) =>
+        message.type === "flex" ? message.altText : message.text,
+      ),
+    ).toEqual(["Before", "Code", "Between", "Table", "After"]);
+    expect(requests.every((request) => request.body.messages.length <= 5)).toBe(true);
+  });
+
   it("carries a valid Bearer token and recipient through the production outbound adapter", async () => {
     const rows = Array.from({ length: 15 }, (_, i) => `| Item${i + 1} | $${i + 1}.00 |`).join("\n");
     const markdown = `| Name | Price |\n|---|---|\n${rows}`;

--- a/extensions/line/src/row-overflow-delivery.loopback.test.ts
+++ b/extensions/line/src/row-overflow-delivery.loopback.test.ts
@@ -351,6 +351,31 @@ describe("Row-overflow table delivery through production outbound adapter over l
     expect(requests.every((request) => request.body.messages.length <= 5)).toBe(true);
   });
 
+  it("keeps rendered-code quick replies on final media on the actual LINE HTTP wire", async () => {
+    const markdown = "```js\nfirst()\n```";
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:UtestRichMedia",
+      text: markdown,
+      payload: {
+        text: markdown,
+        mediaUrl: "https://example.com/image.jpg",
+        channelData: { line: { quickReplies: ["Continue"] } },
+      },
+      cfg: LINE_TEST_CFG,
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.body.messages).toMatchObject([
+      { type: "flex", altText: "Code" },
+      {
+        type: "image",
+        originalContentUrl: "https://example.com/image.jpg",
+        quickReply: { items: [{ action: { label: "Continue", text: "Continue" } }] },
+      },
+    ]);
+  });
+
   it("carries a valid Bearer token and recipient through the production outbound adapter", async () => {
     const rows = Array.from({ length: 15 }, (_, i) => `| Item${i + 1} | $${i + 1}.00 |`).join("\n");
     const markdown = `| Name | Price |\n|---|---|\n${rows}`;


### PR DESCRIPTION
Closes #129915

## What Problem This Solves

Fixes LINE messages containing interleaved prose, fenced code, and Markdown tables arriving in the wrong source order. It also fixes the original patch's automatic-reply regression: a rich-only message with attached media incorrectly became `image, Flex-with-quick-replies` instead of `Flex, image-with-quick-replies`, hiding the intended final action carrier.

## Why This Change Was Made

LINE already has a formatter-owned source-ordered presentation stream for oversized tables. Reuse that existing stream for every rich Markdown block, derive Flex cards from the same canonical stream, and keep rich-only automatic replies on the existing inline rich/media path so attached media remains last and owns the quick replies. Mixed prose continues to use the ordered text path, and the existing reply/push batcher still owns overflow, receipt, retry, and partial-delivery behavior.

The outbound final-media regression now lives in the existing real LINE Messaging API HTTP-loopback suite instead of pushing an already-large mock test file over the repository's 1,000-line limit. No configuration, authentication, storage, protocol, or public plugin API changes are involved.

## User Impact

LINE preserves authored prose, code-card, and table-card order across normal outbound sends and automatic replies. Rich-only replies keep attached images after their cards, quick replies remain exclusively on the final visible message, and overflow beyond LINE's five-message reply limit preserves the same order and action carrier in the following push.

## Evidence

The original source-order regressions failed before the formatter repair. Four additional authentic automatic-reply owner regressions then failed against the previous PR head:

- fenced code plus media arrived as `image, Code` instead of `Code, image`;
- a Markdown table plus media arrived as `image, Table` instead of `Table, image`;
- consecutive code/table cards plus media arrived as `image, Code, Table` instead of `Code, Table, image`;
- six source-ordered cards incorrectly placed the image inside the first reply-token batch instead of on the final overflow push with the quick replies.

All four pass after the delivery-owner repair. The stronger outbound regression executes the real LINE sender and records the actual localhost Messaging API JSON request, including the sole final image quick-reply action.

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/line

Test Files  36 passed (36)
Tests       546 passed (546)

oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/line
PASS

node --import tsx scripts/check-max-lines-ratchet.mts --base 12dff762355502a9e4ddbd8b14cec1bbed6257ba
max-lines ratchet OK: 896 grandfathered suppressions.

node --import tsx scripts/check-assertion-safety-ratchet.mts --base 12dff762355502a9e4ddbd8b14cec1bbed6257ba
assertion SAFETY ratchet OK: 4258 files, 13348 grandfathered assertions.
```

Focused type-aware lint passes for every follow-up file, and the previous LINE `TS2339` is removed by correctly narrowing the official SDK message union. A complete local extensions-test typecheck is currently blocked by unrelated existing dependency mismatches outside LINE; it reports no LINE diagnostic. Formatting, both repository ratchets, and independent P1 review pass. All provider traffic remained on an ephemeral local HTTP server; no live LINE account or credential was used.

Complete branch production changes: +19/-19 (net 0). Test changes: +175/-3.

Exact repaired head: `74d2b8a89699703d46b8df4ee444226d4b4f0c44`.
