### PR TITLE
fix(cli): stop doctor JSON mode from silently filtering health checks

### DIFF
--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -397,6 +397,28 @@ describe("registerMaintenanceCommands doctor action", () => {
   });
 
   it.each(
+    [
+      { name: "severity threshold", selector: ["--severity-min", "error"] },
+      { name: "all checks", selector: ["--all"] },
+      { name: "skipped check", selector: ["--skip", "core/example"] },
+      { name: "selected check", selector: ["--only", "core/example"] },
+    ].flatMap(({ name, selector }) => [
+      { name: `${name} after JSON`, args: ["--json", ...selector] },
+      { name: `${name} before JSON`, args: [...selector, "--json"] },
+    ]),
+  )("rejects lint-only $name without explicit lint mode", async ({ args }) => {
+    const message = "doctor lint options require --lint. Use `openclaw doctor --lint ...`.";
+
+    await runMaintenanceCli(["doctor", ...args]);
+
+    expect(doctorCommand).not.toHaveBeenCalled();
+    expect(runDoctorLintCli).not.toHaveBeenCalled();
+    expect(runtime.writeJson).toHaveBeenCalledWith(jsonFailure(message));
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).toHaveBeenCalledWith(2);
+  });
+
+  it.each(
     DOCTOR_MUTATION_OPTIONS.flatMap((mutationOption) => [
       { mode: "explicit lint", args: ["--lint", mutationOption], mutationOption },
       {

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -144,6 +144,12 @@ export function registerMaintenanceCommands(program: Command) {
           opts.json === true || !process.stdout.isTTY,
         );
       }
+      if (opts.lint !== true && hasLintOnlyDoctorOptions(opts)) {
+        return exitDoctorError(
+          "doctor lint options require --lint. Use `openclaw doctor --lint ...`.",
+          opts.json === true,
+        );
+      }
       if (lintMode) {
         await runCommandWithRuntime(
           defaultRuntime,
@@ -163,12 +169,6 @@ export function registerMaintenanceCommands(program: Command) {
           (err) => exitDoctorError(formatError(err), opts.json === true || !process.stdout.isTTY),
         );
         return;
-      }
-      if (hasLintOnlyDoctorOptions(opts)) {
-        return exitDoctorError(
-          "doctor lint options require --lint. Use `openclaw doctor --lint ...`.",
-          opts.json === true,
-        );
       }
       await runCommandWithRuntime(
         defaultRuntime,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --json` could silently change or suppress health checks by adding `--severity-min`, `--all`, `--skip`, or `--only` without the required `--lint` flag. This contradicted the documented advisory JSON contract: selective checks could hide real findings, and `--all` could unexpectedly run opt-in checks while the command still exited successfully.

## Why This Change Was Made

Move Doctor's existing lint-only option validation ahead of implicit JSON lint dispatch and require an explicit `--lint` posture for those four documented selectors. This preserves the existing mutation, SQLite, and post-upgrade conflict precedence; the JSON error envelope and exit code; explicit lint behavior; and all existing public flags without adding production lines.

## User Impact

Bare `openclaw doctor --json` continues to run the default advisory health checks. Passing lint-only selectors without `--lint` now consistently returns the existing machine-readable guidance and exit code 2, while `openclaw doctor --lint --json` retains its documented filtering and threshold semantics.

## Evidence

- Before the fix, all eight real Commander owner-boundary regressions failed: each of the four selectors was accepted both before and after `--json` and incorrectly invoked the lint runner.
- After the fix, all 91 Doctor CLI owner tests pass, including the eight formerly failing argument combinations.
- Adjacent failure-output and real Doctor lint suites also pass: 134 tests across three projects in total.
- An independent review verified 13 actual Commander argument branches, and the authenticated commit review found no actionable issues.
- A real registered Doctor command now returns the documented JSON `cli_error` guidance and exit code 2 before entering lint execution.
- Production change: 6 lines added and 6 removed, for zero net production lines. Regression coverage adds 22 test lines.
