### PR TITLE
fix(ios): prevent Apple Watch callbacks from crashing the app

### DIFF
--- a/apps/ios/Sources/Services/WatchConnectivityTransport.swift
+++ b/apps/ios/Sources/Services/WatchConnectivityTransport.swift
@@ -11,27 +11,6 @@ private struct WatchConnectivityTransportCallbacks {
     var appCommandHandler: (@Sendable (WatchAppCommandEvent) -> Void)?
 }
 
-private func sendReachableWatchMessage(_ payload: [String: Any], with session: WCSession) async throws {
-    // WatchConnectivity replies arrive on its own queue. Keep this continuation explicitly
-    // nonisolated so Swift 6 does not inherit a caller actor (for example MainActor) into the
-    // Objective-C callback boundary and trap on the reply callback executor check.
-    try await withCheckedThrowingContinuation(isolation: nil) { (continuation: CheckedContinuation<Void, Error>) in
-        session.sendMessage(
-            payload,
-            replyHandler: { reply in
-                do {
-                    try requireAcceptedWatchMessageReply(reply)
-                    continuation.resume(returning: ())
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            },
-            errorHandler: { error in
-                continuation.resume(throwing: error)
-            })
-    }
-}
-
 final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
     private nonisolated static let logger = Logger(subsystem: "ai.openclawfoundation.app", category: "watch.messaging")
 

--- a/apps/ios/Sources/Services/WatchSessionActivationGate.swift
+++ b/apps/ios/Sources/Services/WatchSessionActivationGate.swift
@@ -1,4 +1,5 @@
 import Foundation
+@preconcurrency import WatchConnectivity
 
 enum WatchMessageAcknowledgmentError: LocalizedError {
     case rejected(String)
@@ -20,6 +21,39 @@ func requireAcceptedWatchMessageReply(_ reply: [String: Any]) throws {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         throw WatchMessageAcknowledgmentError.rejected(
             reason.flatMap { $0.isEmpty ? nil : $0 } ?? "payload was rejected")
+    }
+}
+
+final class WatchMessageSendCompletion: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, any Error>?
+
+    init(_ continuation: CheckedContinuation<Void, any Error>) {
+        self.continuation = continuation
+    }
+
+    func complete(_ result: Result<Void, any Error>) {
+        let continuation = self.lock.withLock { () -> CheckedContinuation<Void, any Error>? in
+            defer { self.continuation = nil }
+            return self.continuation
+        }
+        continuation?.resume(with: result)
+    }
+}
+
+func sendReachableWatchMessage(_ payload: [String: Any], with session: WCSession) async throws {
+    // WatchConnectivity callbacks use their own executor and can race despite their
+    // documented exactly-once contract; only the first callback owns this continuation.
+    try await withCheckedThrowingContinuation(isolation: nil) { continuation in
+        let completion = WatchMessageSendCompletion(continuation)
+        session.sendMessage(
+            payload,
+            replyHandler: { reply in
+                completion.complete(Result { try requireAcceptedWatchMessageReply(reply) })
+            },
+            errorHandler: { error in
+                completion.complete(.failure(error))
+            })
     }
 }
 

--- a/apps/ios/Tests/WatchSessionActivationGateTests.swift
+++ b/apps/ios/Tests/WatchSessionActivationGateTests.swift
@@ -17,6 +17,55 @@ struct WatchSessionActivationGateTests {
         }
     }
 
+    @Test func `accepted watch reply ignores later transport callbacks`() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            let completion = WatchMessageSendCompletion(continuation)
+            completion.complete(.success(()))
+            completion.complete(.failure(URLError(.timedOut)))
+            completion.complete(.success(()))
+        }
+    }
+
+    @Test func `watch transport error ignores later replies and errors`() async {
+        await #expect(throws: URLError.self) {
+            try await withCheckedThrowingContinuation { continuation in
+                let completion = WatchMessageSendCompletion(continuation)
+                completion.complete(.failure(URLError(.notConnectedToInternet)))
+                completion.complete(.success(()))
+                completion.complete(.failure(WatchMessageAcknowledgmentError.rejected("late")))
+            }
+        }
+    }
+
+    @Test func `rejected watch acknowledgment ignores a later transport error`() async {
+        await #expect(throws: WatchMessageAcknowledgmentError.self) {
+            try await withCheckedThrowingContinuation { continuation in
+                let completion = WatchMessageSendCompletion(continuation)
+                completion.complete(Result {
+                    try requireAcceptedWatchMessageReply(["ok": false, "error": "unsupported_payload"])
+                })
+                completion.complete(.failure(URLError(.timedOut)))
+            }
+        }
+    }
+
+    @Test func `racing watch callbacks complete their continuation exactly once`() async {
+        do {
+            try await withCheckedThrowingContinuation { continuation in
+                let completion = WatchMessageSendCompletion(continuation)
+                DispatchQueue.concurrentPerform(iterations: 100) { index in
+                    completion.complete(index.isMultiple(of: 2)
+                        ? .success(())
+                        : .failure(URLError(.timedOut)))
+                }
+            }
+        } catch is URLError {
+            // Either terminal callback may win; racing callbacks must never resume twice.
+        } catch {
+            Issue.record("Unexpected watch message failure: \(error)")
+        }
+    }
+
     @Test func `startup event buffering is ordered and bounded`() {
         var buffer = WatchMessagingStartupBuffer<String>(maxCount: 3)
 
@@ -87,10 +136,6 @@ struct WatchSessionActivationGateTests {
             contentsOf: iosRoot.appendingPathComponent(
                 "WatchApp/Sources/WatchConnectivityReceiver.swift"),
             encoding: .utf8)
-        let transportSource = try String(
-            contentsOf: iosRoot.appendingPathComponent(
-                "Sources/Services/WatchConnectivityTransport.swift"),
-            encoding: .utf8)
         let serviceSource = try String(
             contentsOf: iosRoot.appendingPathComponent(
                 "Sources/Services/WatchMessagingService.swift"),
@@ -104,8 +149,6 @@ struct WatchSessionActivationGateTests {
         #expect(receiverSource.contains(
             "acknowledgment: WatchMessageAcknowledgment? = nil) -> Bool"))
         #expect(receiverSource.contains("guard activationState == .activated else { return }"))
-        #expect(receiverSource.contains("try requireAcceptedWatchMessageReply(reply)"))
-        #expect(transportSource.contains("try requireAcceptedWatchMessageReply(reply)"))
         let callbackRegistration = try #require(
             serviceSource.range(of: "self.transport.setAppCommandHandler"))
         let activation = try #require(serviceSource.range(of: "self.transport.activate()"))

--- a/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
+++ b/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
@@ -92,7 +92,6 @@ struct WatchExecApprovalSnapshotRequestToken: Hashable, Sendable {
 }
 
 final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
-    private typealias MessageSendContinuation = CheckedContinuation<Void, Error>
     private static let maxAcceptedExecApprovalSnapshotRequests = 32
 
     private let store: WatchInboxStore
@@ -165,7 +164,7 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
         let payload = Self.encodeSnapshotRequestPayload(request)
         if session.isReachable {
             do {
-                try await Self.sendMessage(payload, through: session)
+                try await sendReachableWatchMessage(payload, with: session)
                 return token
             } catch {
                 // Fall through to queued delivery.
@@ -261,7 +260,7 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
         var requiresCanonicalReadback = false
         if session.isReachable {
             do {
-                try await Self.sendMessage(payload, through: session)
+                try await sendReachableWatchMessage(payload, with: session)
                 return WatchReplySendResult(
                     delivery: .delivered,
                     transport: "sendMessage",
@@ -281,22 +280,6 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
             transport: "transferUserInfo",
             errorMessage: nil,
             requiresCanonicalReadback: requiresCanonicalReadback)
-    }
-
-    private static func sendMessage(_ payload: [String: Any], through session: WCSession) async throws {
-        try await withCheckedThrowingContinuation(isolation: nil) { (continuation: MessageSendContinuation) in
-            session.sendMessage(
-                payload,
-                replyHandler: { reply in
-                    do {
-                        try requireAcceptedWatchMessageReply(reply)
-                        continuation.resume(returning: ())
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
-                },
-                errorHandler: { error in continuation.resume(throwing: error) })
-        }
     }
 
     private static func unavailableResult(_ error: any Error) -> WatchReplySendResult {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where using the OpenClaw iPhone app with its Apple Watch companion could crash the iPhone app or watch app when WatchConnectivity delivered a late error after another terminal message callback had already completed.

## Why This Change Was Made

WatchConnectivity documents mutually exclusive reply and error callbacks, but an observed iOS 27 simulator crash showed its queued error callback violating that contract and resuming an already-completed Swift checked continuation. Both sides had duplicated unsafe bridges, so this change replaces them with one shared, lock-protected, first-result-wins completion owner while preserving acknowledgment validation and existing queued-delivery behavior.

## User Impact

Apple Watch notifications, replies, approval decisions, commands, and snapshot refreshes no longer terminate either app when the platform emits competing or duplicate callbacks. Delivery fallback behavior is unchanged.

## Evidence

- Reproduced crash: `CheckedContinuation.resume(throwing:)` from `WatchConnectivityTransport.swift` after WatchConnectivity invoked its message error handler on the iOS 27 simulator.
- Confirmed the installed Apple `WCSession.h` contract says exactly one reply/error handler should run; the completion owner safely contains the observed framework violation.
- Focused real iOS 27 simulator test suite passed **11/11**, including accepted-reply-then-error, error-then-reply, rejected-acknowledgment-then-error, and 100 competing concurrent callbacks:

  ```sh
  PATH="$PWD/.build/swift-tools:$PATH" xcodebuild -quiet \
    -project apps/ios/OpenClaw.xcodeproj \
    -scheme OpenClaw -configuration Debug \
    -destination 'platform=iOS Simulator,id=48F53A23-E022-4B59-ABCA-BAD7C6F59251' \
    -parallel-testing-enabled NO \
    -only-testing:OpenClawTests/WatchSessionActivationGateTests \
    CODE_SIGNING_ALLOWED=NO test
  ```

- The iPhone test build also compiled the watchOS companion. The original iOS simulator and its paired watchOS 27 simulator were booted and connected, both rebuilt apps launched successfully, and live WatchConnectivity queued transfers were observed without either process crashing.
- Shared owner independently typechecked for both iOS 18+ and watchOS 11+ simulator deployment targets.
- Structured Codex autoreview: clean; no actionable findings.
- Production LOC: `+36/-40` (**net -4**); tests: `+49/-6`.

AI-assisted; no release or App Store publication is part of this change.
