### PR TITLE
docs: declared local browser profiles must set cdpPort or cdpUrl

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -507,9 +507,10 @@ See [Plugins](/tools/plugin).
   snapshot/ref-driven actions instead of CSS-selector targeting, one-file upload
   hooks, no dialog timeout overrides, no `wait --load networkidle`, and no
   `responsebody`, PDF export, download interception, or batch actions.
-- Local managed `openclaw` profiles auto-assign `cdpPort` and `cdpUrl`; set
-  `cdpUrl` explicitly only for remote CDP profiles or existing-session endpoint
-  attach.
+- Local managed `openclaw` profiles get a `cdpPort` allocated from the managed
+  range when OpenClaw creates the profile. A profile you declare by hand must
+  set `cdpPort` itself, or `cdpUrl` for a remote CDP endpoint; the schema
+  rejects an `openclaw` or `clawd` profile that sets neither.
 - Local managed profiles can set `executablePath` to override the global
   `browser.executablePath` for that profile. Use this to run one profile in
   Chrome and another in Brave.

--- a/docs/tools/browser-linux-troubleshooting.md
+++ b/docs/tools/browser-linux-troubleshooting.md
@@ -149,8 +149,9 @@ Notes:
   limits: ref-driven actions only, one file per upload, no dialog `timeoutMs`
   overrides, no `wait --load networkidle`, and no `responsebody`, PDF export,
   download interception, or batch actions.
-- Local `openclaw`-driver profiles auto-assign `cdpPort`/`cdpUrl`; only set
-  those manually for remote CDP.
+- Local `openclaw`-driver profiles get a `cdpPort` allocated when OpenClaw
+  creates them; a profile you declare by hand must set `cdpPort` itself, or
+  `cdpUrl` for remote CDP.
 - Remote CDP profiles accept `http://`, `https://`, `ws://`, and `wss://`.
   Use HTTP(S) for `/json/version` discovery, or WS(S) when your browser
   service gives you a direct DevTools socket URL.

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -298,9 +298,14 @@ main model can read the screenshot directly.
 <Accordion title="Ports and reachability">
 
 - Control service binds to loopback on a port derived from `gateway.port` (default `18791` = gateway + 2). `OPENCLAW_GATEWAY_PORT` takes priority over `gateway.port`; either shifts the derived ports in the same family.
-- Local `openclaw` profiles auto-assign `cdpPort`/`cdpUrl` from a range starting 9 ports above the control port (default `18800`-`18899`); set those only for
-  remote CDP profiles or existing-session endpoint attach. `cdpUrl` defaults to
-  the managed local CDP port when unset.
+- Local `openclaw` profiles use a CDP port range starting 9 ports above the control port (default `18800`-`18899`). OpenClaw allocates from that range for
+  the implicit default profile and for profiles created with
+  `openclaw browser create-profile`, writing the chosen `cdpPort` into the
+  config. A profile you declare by hand must set `cdpPort` itself, or `cdpUrl`
+  for a remote endpoint: the schema rejects an `openclaw` or `clawd` profile
+  that sets neither with `Profile must set cdpPort or cdpUrl`.
+  `existing-session` profiles take the endpoint from `cdpUrl` and ignore
+  `cdpPort`; `extension` profiles own their relay port and reject `cdpUrl`.
 - Remote and `attachOnly` CDP reachability, WebSocket handshakes, and local
   managed-Chrome startup use built-in deadlines.
 - Repeated managed Chrome launch/readiness failures are circuit-broken per


### PR DESCRIPTION
Closes #119335

[AI-assisted]

## What Problem This Solves

Fixes an issue where operators following the browser docs would hand-declare a local `openclaw` profile with neither `cdpPort` nor `cdpUrl`, expecting those fields to auto-assign, then hit `Profile must set cdpPort or cdpUrl` on config validate.

The same stale sentence was on the browser topic page, Linux browser troubleshooting, and the configuration reference.

## Why This Change Was Made

Docs-only repair of an already-correct schema and `resolveProfile` contract. Allocation happens when OpenClaw creates the implicit default profile or when you run `openclaw browser create-profile`. A profile declared by hand must set `cdpPort` or `cdpUrl`.

Wording is the already-reviewed copy from #119336 (@abacha). That PR was the same three-file fix; it was closed after 15 days at ready-for-maintainer-look because of rebase cost, not because the doc is correct. This commit does not restore the later-removed claim that top-level `browser.cdpUrl` defaults to the managed local port.

No schema, runtime, example, generated-doc, or changelog change.

## User Impact

Operators who copy a local `openclaw` / `clawd` profile into config now see that they must set `cdpPort` themselves (or `cdpUrl` for a remote endpoint). `create-profile` and the implicit default still get a port from the managed range (`18800`–`18899` by default). `existing-session` and `extension` exceptions stay as they already behave.

## Evidence

Exact diff: `git diff 0285926bf90a...f4af016b77d6` (three files, +15 / −8).

- Current `main` still has the auto-assign sentence on those three pages; no leftover `auto-assign` under `docs/` after this commit.
- Schema (`src/config/zod-schema.root-shape.ts`) still rejects a declared `openclaw` or `clawd` profile that sets neither, with `Profile must set cdpPort or cdpUrl`. `existing-session` may omit both; `extension` rejects `cdpUrl`.
- Existing test `rejects openclaw profiles without cdpPort or cdpUrl` still passes.
- Live `OpenClawSchema.safeParse` A/B: missing both → reject; `cdpPort: 18800` → accept; `existing-session` with neither → accept; `extension` + `cdpUrl` → reject.
- `git diff --check` clean; `oxfmt` on the three files.
- `$autoreview --engine claude --mode uncommitted` (pre-commit): clean, no accepted/actionable findings.

Skipped full `pnpm build && pnpm check && pnpm test` and `openclaw config validate` CLI: docs-only, and the dist-backed CLI wrapper rebuilds stale `dist` on an unrelated `TuiMainScreen` export miss.