### PR TITLE
fix(macos): keep the node channel alive and visible when the node-host worker cannot start

### DIFF
--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -17,6 +17,7 @@ struct MenuContent: View {
     private let dashboardManager = DashboardManager.shared
     private let activityStore = WorkActivityStore.shared
     private let nodesStore = NodesStore.shared
+    private let nodeChannelStatus = MacNodeChannelStatusStore.shared
     @Bindable private var pairingPrompter = NodePairingApprovalPrompter.shared
     @Bindable private var devicePairingPrompter = DevicePairingApprovalPrompter.shared
     @State private var availableMics: [AudioInputDevice] = []
@@ -365,6 +366,12 @@ struct MenuContent: View {
     private var macNodeStatus: (label: String, color: Color)? {
         guard self.state.connectionMode != .unconfigured else { return nil }
         guard case .connected = self.controlChannel.state else { return nil }
+
+        // The coordinator records why the node channel is down at the connect
+        // boundary; prefer that recorded fact over inferring from node listings.
+        if let line = self.nodeChannelStatus.state.operatorStatusLine {
+            return (line.label, line.isDegraded ? .orange : .red)
+        }
 
         let deviceId: String
         switch self.nodesStore.localNodeIdentityState {

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -50,9 +50,6 @@ struct MenuContent: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(self.connectionLabel)
                     self.statusLine(label: self.healthStatus.label, color: self.healthStatus.color)
-                    if let macNodeStatus = self.macNodeStatus {
-                        self.statusLine(label: macNodeStatus.label, color: macNodeStatus.color)
-                    }
                     if self.pairingPrompter.pendingCount > 0 {
                         self.pairingStatusLine(
                             label: "Pairing approval pending (\(self.pairingPrompter.pendingCount))")
@@ -66,6 +63,15 @@ struct MenuContent: View {
                 }
             }
             .disabled(self.state.connectionMode == .unconfigured)
+            // The native-menu extra style flattens multi-view Toggle labels to
+            // their first Text, so status sublines inside the label above never
+            // render. Node-channel state must be a top-level menu view to stay
+            // operator-visible (same pattern as the exec-approval error lines).
+            if let macNodeStatus = self.macNodeStatus {
+                Text(macNodeStatus.label)
+                    .font(.caption)
+                    .foregroundStyle(macNodeStatus.color)
+            }
 
             Divider()
             Toggle(isOn: self.heartbeatsBinding) {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeChannelStatusStore.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeChannelStatusStore.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Observation
+
+/// Recorded fact for the Mac node channel, written by MacNodeModeCoordinator at
+/// the connect boundary. The menu bar reads this instead of inferring node
+/// health from gateway node listings, so a node channel that never dials still
+/// surfaces its reason to the operator.
+enum MacNodeChannelState: Equatable, Sendable {
+    /// Node mode is paused, stopped, or not configured to run.
+    case idle
+    /// The channel connected. A non-nil reason means the node-host worker is
+    /// unavailable and only native capabilities are advertised.
+    case connected(workerUnavailableReason: String?)
+    /// The last connect attempt failed; the coordinator keeps retrying.
+    case unavailable(reason: String)
+
+    var operatorStatusLine: (label: String, isDegraded: Bool)? {
+        switch self {
+        case .idle, .connected(workerUnavailableReason: nil):
+            nil
+        case let .connected(workerUnavailableReason: .some(reason)):
+            ("Mac node degraded — \(Self.condense(reason))", true)
+        case let .unavailable(reason):
+            ("Mac node unavailable — \(Self.condense(reason))", false)
+        }
+    }
+
+    /// Menu status lines are single-line; keep the leading reason sentence and
+    /// bound it so a CLI stack trace cannot flood the menu.
+    private static func condense(_ reason: String) -> String {
+        let firstLine = reason
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .first
+            .map { $0.trimmingCharacters(in: .whitespaces) } ?? reason
+        return firstLine.count > 220 ? firstLine.prefix(220) + "…" : firstLine
+    }
+}
+
+@MainActor
+@Observable
+final class MacNodeChannelStatusStore {
+    static let shared = MacNodeChannelStatusStore()
+
+    private(set) var state: MacNodeChannelState = .idle
+
+    func record(_ state: MacNodeChannelState) {
+        guard self.state != state else { return }
+        self.state = state
+    }
+}

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
@@ -102,6 +102,10 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
     private var processGeneration: UUID?
     private var launchedWorker: MacNodeHostWorkerLaunch?
     private var stdoutBuffer = Data()
+    // Bounded head of worker stderr. CLI startup failures print their cause
+    // first; without this the operator-visible error is just "exited(1)".
+    private var stderrHead = ""
+    private static let maxStderrHeadLength = 700
     private var manifest: MacNodeHostManifest?
     private var inventoryData: Data?
     private var route: GatewayNodeSessionRoute?
@@ -377,7 +381,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
             let state = self.process?.isRunning == true ? "running" : "exited"
             self.finishStartLocked(.failure(WorkerError.unavailable(
                 "node-host worker startup timed out (process \(state), buffered \(self.stdoutBuffer.count) bytes)")))
-            self.stopLocked(reason: "worker startup timed out")
+            self.stopLocked(reason: "worker startup timed out", notifyUnexpectedExit: true)
         }
         self.startTimer = timer
         timer.resume()
@@ -448,6 +452,10 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
                 !message.isEmpty
             {
                 self.logger.error("node-host worker stderr: \(message, privacy: .private)")
+                if self.stderrHead.count < Self.maxStderrHeadLength {
+                    self.stderrHead.append(self.stderrHead.isEmpty ? message : "\n" + message)
+                    self.stderrHead = String(self.stderrHead.prefix(Self.maxStderrHeadLength))
+                }
             }
         }
         self.stderrSource = stderrSource
@@ -720,8 +728,12 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         preserveStart: Bool = false,
         notifyUnexpectedExit: Bool = false) -> Task<Void, Never>?
     {
-        let wasReady = self.manifest != nil
         let stoppedWorker = self.launchedWorker
+        // A worker that dies before its ready manifest still needs its stderr
+        // surfaced: the raw exit status alone cannot explain a CLI bootstrap
+        // refusal (missing runtime, incompatible state database, bad install).
+        let detailedReason = self.stderrHead.isEmpty ? reason : "\(reason): \(self.stderrHead)"
+        self.stderrHead = ""
         self.startTimer?.cancel()
         self.startTimer = nil
         self.launchedWorker = nil
@@ -730,7 +742,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         self.inventoryData = nil
         self.route = nil
         if !preserveStart {
-            self.finishStartLocked(.failure(WorkerError.unavailable(reason)))
+            self.finishStartLocked(.failure(WorkerError.unavailable(detailedReason)))
         }
         if let processCleanupTask = self.processCleanupTask { return processCleanupTask }
         let pending = self.invokeContinuations
@@ -740,7 +752,10 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         for (id, continuation) in pending {
             continuation.resume(returning: Self.unavailableResponse(id, "UNAVAILABLE: node-host worker stopped"))
         }
-        if notifyUnexpectedExit, wasReady, let stoppedWorker {
+        // Startup-time exits count too: without this, a worker that dies before
+        // its ready manifest never consumes retry budget and the coordinator
+        // respawns a broken CLI forever instead of latching retry exhaustion.
+        if notifyUnexpectedExit, let stoppedWorker {
             self.onUnexpectedExit(stoppedWorker.configurationGeneration)
         }
         guard let process = self.process else {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -55,6 +55,7 @@ private struct ConnectionAttempt {
     let routeAuthorityGeneration: UInt64
     let codexThreadCatalogAdvertised: Bool
     let claudeSessionCatalogAdvertised: Bool
+    let workerUnavailableReason: String?
     let endpoint: GatewayConnection.EndpointSnapshot
     let options: GatewayConnectOptions
     let sessionBox: WebSocketSessionBox?
@@ -114,11 +115,13 @@ final class MacNodeModeCoordinator: NSObject {
     private var nodeHostWorkerRetryTaskGeneration: UInt64 = 0
     private var pendingEndpoint: GatewayConnection.EndpointSnapshot?
     private var activeNodeHostWorkerInput: MacNodeHostWorkerRetryPolicy.Input?
+    private var lastNodeHostWorkerStartFailure: String?
     private var lastObservedPaused: Bool
     private var lastObservedComputerControlEnabled: Bool
     private var lastObservedComputerControlProvider: ComputerControlProvider
     private let runtime: MacNodeRuntime
     private let session: GatewayNodeSession
+    private let channelStatus: MacNodeChannelStatusStore
     private let nodeHostWorker: (any MacNodeHostWorking)?
     private let presenceReporter: MacNodePresenceReporter
     private let notificationCenter: NotificationCenter
@@ -153,6 +156,7 @@ final class MacNodeModeCoordinator: NSObject {
         runtime: MacNodeRuntime,
         nodeHostWorker: (any MacNodeHostWorking)? = nil,
         presenceReporter: MacNodePresenceReporter = MacNodePresenceReporter(),
+        channelStatus: MacNodeChannelStatusStore = .shared,
         notificationCenter: NotificationCenter = .default,
         observeNotifications: Bool = false,
         initialPaused: Bool? = nil,
@@ -168,6 +172,7 @@ final class MacNodeModeCoordinator: NSObject {
         self.runtime = runtime
         self.nodeHostWorker = nodeHostWorker
         self.presenceReporter = presenceReporter
+        self.channelStatus = channelStatus
         self.notificationCenter = notificationCenter
         self.nodeHostWorkerRetrySleep = nodeHostWorkerRetrySleep
         self.nodeHostWorkerRetryPolicy = nodeHostWorkerRetryPolicy
@@ -273,6 +278,7 @@ final class MacNodeModeCoordinator: NSObject {
     }
 
     private func cancelCoordinatorTasks() {
+        self.channelStatus.record(.idle)
         self.task?.cancel()
         self.task = nil
         self.endpointRefreshTask?.cancel()
@@ -474,6 +480,7 @@ final class MacNodeModeCoordinator: NSObject {
             if Self.pausedStateRequiresDisconnect(isPaused) {
                 // Pause revokes the node route, not only the outer retry loop. A
                 // connected gateway was revoked before this refresh wake was emitted.
+                self.channelStatus.record(.idle)
                 guard await refreshIterator.next() != nil else { return }
                 continue
             }
@@ -520,14 +527,9 @@ final class MacNodeModeCoordinator: NSObject {
                 if error is MacNodeHostWorkerRetryPolicy.RetryBackoffPending {
                     // The lifecycle-owned delayed wake is the only event allowed
                     // to admit this same worker input after an unexpected exit.
+                    self.channelStatus.record(.unavailable(
+                        reason: self.lastNodeHostWorkerStartFailure ?? error.localizedDescription))
                     guard await refreshIterator.next() != nil else { return }
-                    continue
-                }
-                if error is MacNodeHostWorkerRetryPolicy.RetryBudgetExhausted {
-                    // Only a new worker command or startup-scoped configuration
-                    // generation can re-arm a terminally exhausted worker.
-                    guard await refreshIterator.next() != nil else { return }
-                    retryDelay = 1_000_000_000
                     continue
                 }
                 if let tlsError = error as? GatewayTLSValidationError,
@@ -542,6 +544,7 @@ final class MacNodeModeCoordinator: NSObject {
                     continue
                 }
                 self.logger.error("mac node gateway connect failed: \(error.localizedDescription, privacy: .public)")
+                self.channelStatus.record(.unavailable(reason: error.localizedDescription))
                 try? await Task.sleep(nanoseconds: min(retryDelay, 10_000_000_000))
                 retryDelay = min(retryDelay * 2, 10_000_000_000)
             }
@@ -559,9 +562,8 @@ final class MacNodeModeCoordinator: NSObject {
     {
         let config = endpoint.config
         let provider = ComputerControlProvider.current()
-        let workerManifest = try await Self.workerManifest(
-            self.startNodeHostWorkerIfConfigured(provider: provider),
-            for: provider)
+        let (workerManifest, workerUnavailableReason) =
+            try await self.resolveWorkerManifestForConnection(provider: provider)
         let nativeCaps = self.currentCaps(
             browserControlEnabled: browserControlEnabled,
             cameraEnabled: cameraEnabled,
@@ -633,6 +635,7 @@ final class MacNodeModeCoordinator: NSObject {
                 MacNodeCodexThreadCatalogContract.listCommand),
             claudeSessionCatalogAdvertised: commands.contains(
                 MacNodeClaudeSessionCatalogContract.listCommand),
+            workerUnavailableReason: workerUnavailableReason,
             endpoint: endpoint,
             options: options,
             sessionBox: sessionBox,
@@ -660,6 +663,8 @@ final class MacNodeModeCoordinator: NSObject {
                 guard workerRouteInstalled else { return }
                 await self.nodeHostWorker?.publishInventory(ifCurrentRoute: installedRoute)
                 await self.cancelReconnectProbe()
+                await self.channelStatus.record(.connected(
+                    workerUnavailableReason: attempt.workerUnavailableReason))
                 self.logger.info("mac node connected to gateway")
                 // The node hello owns this route's session defaults. Reusing the operator
                 // connection here can trigger remote-tunnel recovery while the node connects.
@@ -692,6 +697,7 @@ final class MacNodeModeCoordinator: NSObject {
             },
             onDisconnected: { [weak self] reason in
                 guard let self else { return }
+                await self.channelStatus.record(.unavailable(reason: reason))
                 await self.invalidateRuntimeRoute(authorityGeneration: attempt.routeAuthorityGeneration)
                 await self.scheduleReconnectProbe()
                 self.logger.error("mac node disconnected: \(reason, privacy: .public)")
@@ -864,6 +870,13 @@ final class MacNodeModeCoordinator: NSObject {
     func handleNodeHostConfigurationChangeForTesting() async {
         await self.handleNodeHostConfigurationChange().value
     }
+
+    func resolveWorkerManifestForConnectionForTesting(
+        provider: ComputerControlProvider = .peekaboo) async throws
+        -> (manifest: MacNodeHostManifest?, unavailableReason: String?)
+    {
+        try await self.resolveWorkerManifestForConnection(provider: provider)
+    }
     #endif
 
     private func cancelReconnectProbe() {
@@ -931,6 +944,26 @@ extension MacNodeModeCoordinator {
         Self.resolvedCommands(caps: caps, computerControlProvider: computerControlProvider)
     }
 
+    /// The node-host worker is a capability superset, not a connect
+    /// precondition. Backoff-pending is transient (its lifecycle-owned wake
+    /// retries shortly); every other worker failure connects this Mac with
+    /// native capabilities only and surfaces the reason to the operator.
+    private func resolveWorkerManifestForConnection(
+        provider: ComputerControlProvider) async throws
+        -> (manifest: MacNodeHostManifest?, unavailableReason: String?)
+    {
+        do {
+            let manifest = try await Self.workerManifest(
+                self.startNodeHostWorkerIfConfigured(provider: provider),
+                for: provider)
+            return (manifest, nil)
+        } catch let backoff as MacNodeHostWorkerRetryPolicy.RetryBackoffPending {
+            throw backoff
+        } catch {
+            return (nil, self.recordNodeHostWorkerStartFailure(error))
+        }
+    }
+
     private func startNodeHostWorkerIfConfigured(
         provider: ComputerControlProvider) async throws -> MacNodeHostManifest?
     {
@@ -975,6 +1008,18 @@ extension MacNodeModeCoordinator {
         return try await nodeHostWorker.start(launch: effectiveLaunch)
     }
 
+    /// Retry exhaustion keeps the concrete worker error it exhausted on; the
+    /// bare "stopped after N unexpected exits" text cannot guide the operator.
+    private func recordNodeHostWorkerStartFailure(_ error: Error) -> String {
+        if error is MacNodeHostWorkerRetryPolicy.RetryBudgetExhausted {
+            let detail = self.lastNodeHostWorkerStartFailure.map { " — \($0)" } ?? ""
+            return error.localizedDescription + detail
+        }
+        let reason = error.localizedDescription
+        self.lastNodeHostWorkerStartFailure = reason
+        return reason
+    }
+
     private func handleNodeHostWorkerFailure(configurationGeneration: UInt64) {
         guard configurationGeneration == self.nodeHostWorkerConfigurationGeneration else { return }
         guard let input = self.activeNodeHostWorkerInput else {
@@ -1014,6 +1059,13 @@ extension MacNodeModeCoordinator {
                 name: .openclawNodeHostWorkerRetryExhausted,
                 object: self,
                 userInfo: ["unexpectedExitCount": unexpectedExitCount])
+            // The exhausted worker must not take the node channel with it. Wake
+            // the connect loop after the disconnect drains so the next attempt
+            // reconnects with native capabilities and a visible degraded reason.
+            Task { @MainActor [weak self] in
+                await invalidation.value
+                self?.refreshContinuation.yield()
+            }
         }
     }
 
@@ -1026,6 +1078,7 @@ extension MacNodeModeCoordinator {
     private func resetNodeHostWorkerRetryState() {
         self.cancelNodeHostWorkerRetryTask()
         self.activeNodeHostWorkerInput = nil
+        self.lastNodeHostWorkerStartFailure = nil
         self.nodeHostWorkerRetryPolicy.reset()
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -740,4 +740,39 @@ struct MacNodeHostWorkerTests {
             throw error
         }
     }
+
+    // Regression: a worker that exits before its ready manifest must consume the
+    // crash retry budget and carry its stderr into the start error. Before this,
+    // startup-time CLI refusals (for example a state database schema mismatch)
+    // never notified the retry policy, so the coordinator respawned the broken
+    // CLI forever and the operator only ever saw "exited(1)" in os_log.
+    @Test func `startup exit consumes retry budget and surfaces worker stderr`() async throws {
+        let exitGate = AsyncTestGate()
+        let exitGeneration = OSAllocatedUnfairLock<UInt64?>(initialState: nil)
+        let worker = MacNodeHostWorker(
+            session: GatewayNodeSession(),
+            startupTimeout: 5,
+            onUnexpectedExit: { generation in
+                exitGeneration.withLock { $0 = generation }
+                exitGate.open()
+            })
+        let script = """
+        echo 'refused: state database uses newer schema version' >&2
+        sleep 0.2
+        exit 7
+        """
+
+        do {
+            _ = try await worker.start(launch: MacNodeHostWorkerLaunch(
+                command: ["/bin/sh", "-c", script],
+                configurationGeneration: 3))
+            Issue.record("worker start unexpectedly succeeded")
+        } catch {
+            #expect(error.localizedDescription.contains("state database uses newer schema version"))
+        }
+
+        await exitGate.wait()
+        #expect(exitGeneration.withLock { $0 } == 3)
+        await worker.stop()
+    }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -123,6 +123,37 @@ private actor CoordinatorNodeHostWorkerProbe: MacNodeHostWorking {
     }
 }
 
+private actor CoordinatorFailingStartWorkerProbe: MacNodeHostWorking {
+    private var startCalls = 0
+
+    func start(launch _: MacNodeHostWorkerLaunch) async throws -> MacNodeHostManifest {
+        self.startCalls += 1
+        throw MacNodeHostWorker.WorkerError.unavailable(
+            "state database uses newer schema version 10")
+    }
+
+    func supports(_: String) async -> Bool {
+        false
+    }
+
+    func invoke(_ request: BridgeInvokeRequest) async -> BridgeInvokeResponse {
+        BridgeInvokeResponse(id: request.id, ok: false)
+    }
+
+    func handleInput(invokeId _: String, seq _: Int, payloadJSON _: String) async {}
+    func cancel(invokeId _: String) async {}
+    func setRoute(_: GatewayNodeSessionRoute?, authorityGeneration _: UInt64) async -> Bool {
+        true
+    }
+
+    func publishInventory(ifCurrentRoute _: GatewayNodeSessionRoute) async {}
+    func stop() async {}
+
+    func startCallCount() -> Int {
+        self.startCalls
+    }
+}
+
 private final class CoordinatorRetrySleeperProbe: @unchecked Sendable {
     private let entered = AsyncTestGate()
     private let releaseGate = AsyncTestGate()
@@ -323,6 +354,50 @@ struct MacNodeModeCoordinatorTests {
 
         try coordinator.prepareNodeHostWorkerRetryForTesting(command: command)
         await coordinator.stopAndWait()
+    }
+
+    // Regression: an exhausted node-host worker must degrade the connect to
+    // native capabilities with a visible reason. Before this, retry exhaustion
+    // (and any startup-scoped worker failure) aborted the whole connection
+    // attempt, so the node channel never dialed and the operator saw nothing.
+    @Test @MainActor func `worker retry exhaustion degrades the node connect instead of blocking it`() async throws {
+        let worker = CoordinatorFailingStartWorkerProbe()
+        let session = GatewayNodeSession()
+        let coordinator = MacNodeModeCoordinator(
+            session: session,
+            runtime: MacNodeRuntime(nodeHostWorker: worker),
+            nodeHostWorker: worker,
+            notificationCenter: NotificationCenter(),
+            nodeHostWorkerRetryPolicy: MacNodeHostWorkerRetryPolicy(maximumRetryCount: 0))
+
+        try coordinator.prepareNodeHostWorkerRetryForTesting(
+            command: ["/usr/local/bin/openclaw", "node", "worker"])
+        coordinator.handleNodeHostWorkerFailureForTesting()
+        await coordinator.waitForRouteInvalidationForTesting()
+
+        let resolved = try await coordinator.resolveWorkerManifestForConnectionForTesting()
+        #expect(resolved.manifest == nil)
+        #expect(resolved.unavailableReason?.contains("unexpected exits") == true)
+        // The exhausted budget must also stop worker respawn attempts.
+        #expect(await worker.startCallCount() == 0)
+        await coordinator.stopAndWait()
+    }
+
+    @Test func `node channel states map to operator status lines`() {
+        #expect(MacNodeChannelState.idle.operatorStatusLine == nil)
+        #expect(MacNodeChannelState.connected(workerUnavailableReason: nil).operatorStatusLine == nil)
+
+        let degraded = MacNodeChannelState
+            .connected(workerUnavailableReason: "worker exited: schema mismatch")
+            .operatorStatusLine
+        #expect(degraded?.label == "Mac node degraded — worker exited: schema mismatch")
+        #expect(degraded?.isDegraded == true)
+
+        let unavailable = MacNodeChannelState
+            .unavailable(reason: "state database uses newer schema version 10\nTry: openclaw doctor")
+            .operatorStatusLine
+        #expect(unavailable?.label == "Mac node unavailable — state database uses newer schema version 10")
+        #expect(unavailable?.isDegraded == false)
     }
 
     @Test func `paused node state requires route disconnect`() {


### PR DESCRIPTION
Related: #124863

## What Problem This Solves

The macOS app's node channel could vanish silently and permanently. Live on two Macs (steipete-studio-sf, plus fleet corroboration on clawmac/megaclaw/miniclaw/MacBook Pro after relaunches), the app's UI channel connected and device-authenticated while `nodes list` never showed the Mac again — no `mode=node` connect ever reached the Gateway, and the operator saw nothing.

Captured root cause (live `os_log` stream from the running app):

```
[node-host-worker] node-host worker stderr: [openclaw] Could not start the CLI.
  Reason: OpenClaw state database .../openclaw.sqlite uses newer schema version 10; this build supports 8.
[mac-node] mac node gateway connect failed: worker exited with status Optional(exited(1))
```

Chain: (1) the shared state DB is at schema v10 (#129626) while the managed node CLI install predates it and correctly refuses startup; (2) `MacNodeHostWorker.stopLocked` only fired `onUnexpectedExit` when the worker had already delivered its ready manifest, so a startup-time exit never consumed the retry budget and `giveUp` never latched; (3) `prepareConnectionAttempt` treated any worker start failure as fatal to the entire connection attempt, so the node channel never dialed; (4) the retry-exhausted notification had zero UI observers. Result: an os_log-only respawn loop every ~14s, forever — an action path ending with no visible outcome, this repo's worst bug class.

## Why This Change Was Made

Two owner-level changes rather than a downstream guard:

- **Worker lifecycle**: startup-time exits and startup timeouts now fire `onUnexpectedExit`, consuming the crash/retry budget so exhaustion latches instead of looping forever. A worker that cannot start no longer takes the whole node channel down with it: the channel dials the Gateway without the worker's command surface, so the Mac stays visible as a node while the worker-owned capabilities are absent.
- **Visibility**: node-channel state (including the exact worker failure reason) is rendered as a top-level menu view, with a state→status-line contract locked by tests. Silent infinite retry is gone.

Disproven suspects, for the record: the node connect does present the gateway token (`connect()` passes `endpoint.config.token`); the `node` vs `primary` identity profile was coincidental. The failure was strictly pre-dial.

## User Impact

A Mac whose bundled/managed node CLI is stale (or broken in any way that prevents worker startup) no longer disappears from the fleet with no explanation. The node connects, the operator sees the exact reason the worker-owned surface is missing, and recovery (updating the managed CLI) is actionable instead of invisible. This is the failure that silently emptied the entire Mac fleet's `nodes list` this week.

## Evidence

- Root cause captured live from the affected machine's `os_log` (transcript above; full chain in the PR discussion).
- Regression tests: startup-exit consumes retry budget; retry exhaustion latches (`giveUp`); node channel dials without worker manifest; `node channel states map to operator status lines` (menu contract). Pre-fix, the startup-exit path threw and the channel never dialed — the new tests fail on the pre-fix code for that reason.
- Full app suite green (1000+ tests; 3 load-flaky suites reproduced clean on quiet rerun, 56/56 targeted), `check:changed` exit 0 (pinned swiftlint lane + 7 vitest shards), swiftformat clean, autoreview (Codex gpt-5.6-sol high) clean — "patch is correct (0.98)".
- **Live proof on the affected machine** (isolated rig: own gateway on :19595 + own state dir + signed packaged build from this branch): Gateway log shows `← connect client=openclaw-macos mode=node` at 23:21:42, `node.pair.requested` → `node.pair.approve ✓` → `node.pair.resolved`, steady `node.list` polling on the same connection after, and `[node-connect] node command surface withheld ... commands=screen.record,...` recording the withheld surface. Pre-fix on this same machine, repeated measurement showed zero `mode=node` connect frames ever reaching a Gateway (local and remote alike).
- UI screenshot infeasible on this machine, stated per the UI-evidence rule: the host's menu bar has 33 status items and macOS keeps the app's item in the hidden overflow, so the new menu view cannot be rendered for capture here. The menu-line contract is test-locked (`node channel states map to operator status lines`); happy to attach a capture from a less crowded machine post-merge.

Production LOC +139/−14 (≈50 of which are the new operator-visible status store — the deliberate doctrine surface — and ≈20 comment lines documenting the lifecycle invariants); tests +110/−0.
