### PR TITLE
fix(workers): keep remote execution on its selected node

### DIFF
--- a/src/gateway/node-registry.invoke-stream.ts
+++ b/src/gateway/node-registry.invoke-stream.ts
@@ -82,6 +82,9 @@ export class NodeInvokeStreamController {
     if (Buffer.byteLength(payloadJSON, "utf8") > MAX_INVOKE_INPUT_BYTES) {
       throw new Error("node invoke input exceeds 16 KiB");
     }
+    if (this.settleIfExpired(invokeId, pending)) {
+      throw new Error("node invoke is not pending");
+    }
     if (!this.options.isConnectionActive(pending)) {
       throw new Error("node invoke connection or pairing generation is unavailable");
     }
@@ -96,8 +99,7 @@ export class NodeInvokeStreamController {
       if (pending.connId !== connId) {
         continue;
       }
-      if (pending.deadlineAtMs !== undefined && Date.now() >= pending.deadlineAtMs) {
-        this.settleTimeout(id, pending);
+      if (this.settleIfExpired(id, pending)) {
         continue;
       }
       if (!this.takePending(id, pending)) {
@@ -117,8 +119,7 @@ export class NodeInvokeStreamController {
     ) {
       return false;
     }
-    if (pending.deadlineAtMs !== undefined && Date.now() >= pending.deadlineAtMs) {
-      this.settleTimeout(params.id, pending);
+    if (this.settleIfExpired(params.id, pending)) {
       return false;
     }
     if (!this.takePending(params.id, pending)) {
@@ -157,11 +158,7 @@ export class NodeInvokeStreamController {
     }
     if (params.signal) {
       const onAbort = () => {
-        if (
-          params.pending.deadlineAtMs !== undefined &&
-          Date.now() >= params.pending.deadlineAtMs
-        ) {
-          this.settleTimeout(params.requestId, params.pending);
+        if (this.settleIfExpired(params.requestId, params.pending)) {
           return;
         }
         if (!this.takePending(params.requestId, params.pending)) {
@@ -198,8 +195,7 @@ export class NodeInvokeStreamController {
     ) {
       return false;
     }
-    if (pending.deadlineAtMs !== undefined && Date.now() >= pending.deadlineAtMs) {
-      this.settleTimeout(params.invokeId, pending);
+    if (this.settleIfExpired(params.invokeId, pending)) {
       return false;
     }
     if (params.seq > pending.nextProgressSeq) {
@@ -223,8 +219,7 @@ export class NodeInvokeStreamController {
       if (chunk === undefined) {
         break;
       }
-      if (pending.deadlineAtMs !== undefined && Date.now() >= pending.deadlineAtMs) {
-        this.settleTimeout(params.invokeId, pending);
+      if (this.settleIfExpired(params.invokeId, pending)) {
         break;
       }
       pending.progressChunks.delete(pending.nextProgressSeq);
@@ -244,8 +239,7 @@ export class NodeInvokeStreamController {
         pending.progressChunks.clear();
         break;
       }
-      if (pending.deadlineAtMs !== undefined && Date.now() >= pending.deadlineAtMs) {
-        this.settleTimeout(params.invokeId, pending);
+      if (this.settleIfExpired(params.invokeId, pending)) {
         break;
       }
       this.resetIdleTimer(params.invokeId, pending);
@@ -289,6 +283,14 @@ export class NodeInvokeStreamController {
 
   private sendInvokeCancel(requestId: string, pending: PendingInvoke): void {
     this.options.sendCancel(requestId, pending);
+  }
+
+  private settleIfExpired(requestId: string, pending: PendingInvoke): boolean {
+    if (pending.deadlineAtMs === undefined || Date.now() < pending.deadlineAtMs) {
+      return false;
+    }
+    this.settleTimeout(requestId, pending);
+    return true;
   }
 
   private settleTimeout(requestId: string, pending: PendingInvoke): void {

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -2112,6 +2112,44 @@ describe("gateway/node-registry", () => {
     });
   });
 
+  it("rejects streamed input at the hard deadline before its timer callback runs", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const registry = createNodeRegistry();
+    try {
+      const { frames, invoke, invokeId } = startStreamingNodeInvoke(registry, {
+        timeoutMs: 100,
+        idleTimeoutMs: 1_000,
+        onProgress: () => {},
+      });
+
+      vi.setSystemTime(1_099);
+      registry.sendInvokeInput(invokeId, { kind: "data", data: "before" });
+
+      vi.setSystemTime(1_100);
+      expect(() => registry.sendInvokeInput(invokeId, { kind: "data", data: "expired" })).toThrow(
+        "node invoke is not pending",
+      );
+      await expect(invoke).resolves.toEqual({
+        ok: false,
+        error: { code: "TIMEOUT", message: "node invoke timed out" },
+      });
+      const inputFrames = frames
+        .map((frame) => JSON.parse(frame) as { event?: string; payload?: { payloadJSON?: string } })
+        .filter((frame) => frame.event === "node.invoke.input");
+      expect(inputFrames).toHaveLength(1);
+      expect(inputFrames[0]?.payload?.payloadJSON).toBe(
+        JSON.stringify({ kind: "data", data: "before" }),
+      );
+      expectSingleNodeInvokeCancellation(frames, invokeId);
+      await vi.runOnlyPendingTimersAsync();
+      expectSingleNodeInvokeCancellation(frames, invokeId);
+    } finally {
+      registry.unregister("conn-1");
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects streamed progress after the hard deadline before its timer callback runs", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);

--- a/src/gateway/worker-environments/environment-access.test.ts
+++ b/src/gateway/worker-environments/environment-access.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -13,6 +14,51 @@ type WorkerEnvironmentServiceError = support.WorkerEnvironmentServiceError;
 
 describe("worker environment service", () => {
   support.setupWorkerEnvironmentServiceSuite();
+
+  it("drains all tunnel owners before reporting an independent shutdown failure", async () => {
+    const shutdownError = new Error("SSH tunnel shutdown failed");
+    const nodeShutdown = createDeferred<void>();
+    const tunnelManager = {
+      stopAll: vi.fn().mockRejectedValueOnce(shutdownError).mockResolvedValue(undefined),
+    } as unknown as WorkerTunnelManager;
+    const nodeTunnelManager = {
+      bindWorkspaceBindingResolver: vi.fn(),
+      status: () => "stopped" as const,
+      start: vi.fn(),
+      stop: vi.fn(async () => {}),
+      stopAll: vi.fn(async () => await nodeShutdown.promise),
+    };
+    const nodeDesktopCarrier = {
+      bindRuntime: vi.fn(),
+      observe: vi.fn(),
+      launchApp: vi.fn(),
+      stop: vi.fn(async () => {}),
+      stopAll: vi.fn(async () => {}),
+    } as unknown as WorkerNodeDesktopCarrier;
+    const workerService = support.createService(support.createProvider(), {
+      tunnelManager,
+      nodeTunnelManager,
+      nodeDesktopCarrier,
+    });
+    const stopping = workerService.stop();
+    const settled = vi.fn();
+    void stopping.then(settled, settled);
+
+    try {
+      await support.waitForFast(() => expect(nodeTunnelManager.stopAll).toHaveBeenCalledOnce());
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(settled).not.toHaveBeenCalled();
+      expect(nodeDesktopCarrier.stopAll).toHaveBeenCalledOnce();
+
+      nodeShutdown.resolve();
+      await expect(stopping).rejects.toBe(shutdownError);
+    } finally {
+      nodeShutdown.resolve();
+      await stopping.catch(() => undefined);
+    }
+  });
 
   it("projects live workspace transport status and fences it before provider teardown", async () => {
     support.seedReady("worker-tunnel", undefined, true);

--- a/src/gateway/worker-environments/environment-access.test.ts
+++ b/src/gateway/worker-environments/environment-access.test.ts
@@ -17,7 +17,7 @@ describe("worker environment service", () => {
 
   it("drains all tunnel owners before reporting an independent shutdown failure", async () => {
     const shutdownError = new Error("SSH tunnel shutdown failed");
-    const nodeShutdown = createDeferred<void>();
+    const nodeShutdown = createDeferred();
     const tunnelManager = {
       stopAll: vi.fn().mockRejectedValueOnce(shutdownError).mockResolvedValue(undefined),
     } as unknown as WorkerTunnelManager;

--- a/src/gateway/worker-environments/environment-access.ts
+++ b/src/gateway/worker-environments/environment-access.ts
@@ -404,14 +404,22 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
     return { app: request.app, status: "ready" };
   };
 
+  const stopTunnelOwners = async (stops: Array<Promise<void> | undefined>): Promise<void> => {
+    const results = await Promise.allSettled(stops);
+    const failure = results.find((result) => result.status === "rejected");
+    if (failure) {
+      throw failure.reason;
+    }
+  };
+
   const stopTunnel = async (environmentId: string, ownerEpoch?: number): Promise<void> => {
-    await withLock(environmentId, async () => {
-      await Promise.all([
+    await withLock(environmentId, async () =>
+      stopTunnelOwners([
         tunnels?.stop(environmentId, ownerEpoch),
         nodeTunnels?.stop(environmentId, ownerEpoch),
         nodeDesktop?.stop(environmentId, ownerEpoch),
-      ]);
-    });
+      ]),
+    );
   };
 
   return {
@@ -424,9 +432,8 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
     observeDesktop,
     project,
     startTunnel,
-    stopAllTunnels: async () => {
-      await Promise.all([tunnels?.stopAll(), nodeTunnels?.stopAll(), nodeDesktop?.stopAll()]);
-    },
+    stopAllTunnels: () =>
+      stopTunnelOwners([tunnels?.stopAll(), nodeTunnels?.stopAll(), nodeDesktop?.stopAll()]),
     stopTunnel,
   };
 }

--- a/src/gateway/worker-environments/environment-access.ts
+++ b/src/gateway/worker-environments/environment-access.ts
@@ -405,7 +405,7 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
   };
 
   const stopTunnelOwners = async (stops: Array<Promise<void> | undefined>): Promise<void> => {
-    const results = await Promise.allSettled(stops);
+    const results = await Promise.allSettled(stops.filter((stop) => stop !== undefined));
     const failure = results.find((result) => result.status === "rejected");
     if (failure) {
       throw failure.reason;

--- a/src/gateway/worker-environments/node-worker-tunnel.test-support.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test-support.ts
@@ -1,0 +1,81 @@
+import { vi } from "vitest";
+import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../../../packages/gateway-protocol/src/client-info.js";
+import { WORKER_PROTOCOL_FEATURES } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../../infra/node-runner-inventory.js";
+import type { NodeWorkerSupervisorTransport } from "../node-registry-private.js";
+import type { NodeWorkspaceTransferService } from "./node-workspace-transfer-service.js";
+import type { WorkerEnvironmentRecord } from "./store.js";
+
+export const BUILD = {
+  bundleHash: "a".repeat(64),
+  openclawVersion: "2026.8.13",
+  protocolFeatures: [...WORKER_PROTOCOL_FEATURES],
+};
+
+export function environment(): WorkerEnvironmentRecord {
+  return {
+    environmentId: "environment-1",
+    providerId: "device",
+    profileId: "device:node-1",
+    profileSnapshot: { settings: { device: "node-1" } },
+    provisionOperationId: "provision-1",
+    nodeSetupId: null,
+    nodeDeviceId: "node-1",
+    sharedHost: true,
+    desktop: null,
+    bootstrapReceipt: { ...BUILD, installKind: "bundle" },
+    ownerEpoch: 2,
+    teardownTerminalState: null,
+    attachedSessionIds: ["session-1"],
+    lastError: null,
+    createdAtMs: 1,
+    updatedAtMs: 2,
+    stateChangedAtMs: 2,
+    idleSinceAtMs: null,
+    destroyRequestedAtMs: null,
+    state: "attached",
+    leaseId: "device-lease",
+    sshEndpoint: null,
+  };
+}
+
+export function transport(): NodeWorkerSupervisorTransport {
+  return {
+    hasCurrentRunner: () => true,
+    listCurrentNodes: async () => [
+      {
+        nodeId: "node-1",
+        connId: "conn-1",
+        pairingIdentity: "pairing-1",
+        pairingGeneration: "generation-1",
+        clientId: GATEWAY_CLIENT_IDS.NODE_HOST,
+        clientMode: GATEWAY_CLIENT_MODES.NODE,
+        protocolFeature: NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
+        workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
+        commands: ["system.run"],
+      },
+    ],
+    isCurrent: () => true,
+    invoke: async () => ({ ok: false, error: { code: "UNAVAILABLE" } }),
+  };
+}
+
+export function startRequest() {
+  return {
+    environmentId: "environment-1",
+    ownerEpoch: 2,
+    deviceId: "node-1",
+    sessionId: "session-1",
+    expectedBuild: BUILD,
+  };
+}
+
+export function workspaceTransfer(): NodeWorkspaceTransferService {
+  return {
+    close: vi.fn(async () => {}),
+    revoke: vi.fn(),
+  } as unknown as NodeWorkspaceTransferService;
+}

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -428,6 +428,60 @@ describe("node worker tunnel manager", () => {
     },
   );
 
+  it("drains sibling node tunnels before reporting a workspace cleanup failure", async () => {
+    const cleanupError = new Error("first workspace cleanup failed");
+    const siblingCleanup = createDeferred<void>();
+    const close = vi.fn(async (environmentId: string) => {
+      if (environmentId === "environment-1") {
+        throw cleanupError;
+      }
+      await siblingCleanup.promise;
+    });
+    const closeAll = vi.fn(async () => {});
+    const manager = createNodeWorkerTunnelManager({
+      gatewayDeviceId: "gateway-device-1",
+      getEnvironment: (environmentId) => ({
+        ...environment(),
+        environmentId,
+        attachedSessionIds: [environmentId === "environment-1" ? "session-1" : "session-2"],
+      }),
+      getTransport: transport,
+      launchNodeWorker: vi.fn(),
+      validateWorkerTurn: () => true,
+      workspaceTransfer: {
+        ...workspaceTransfer(),
+        close,
+        closeAll,
+      } as unknown as NodeWorkspaceTransferService,
+    });
+    await manager.start(startRequest());
+    await manager.start({
+      ...startRequest(),
+      environmentId: "environment-2",
+      sessionId: "session-2",
+    });
+
+    const stopping = manager.stopAll();
+    const settled = vi.fn();
+    void stopping.then(settled, settled);
+
+    try {
+      await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(2));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(settled).not.toHaveBeenCalled();
+      expect(closeAll).not.toHaveBeenCalled();
+
+      siblingCleanup.resolve();
+      await expect(stopping).rejects.toBe(cleanupError);
+      expect(closeAll).toHaveBeenCalledOnce();
+    } finally {
+      siblingCleanup.resolve();
+      await stopping.catch(() => undefined);
+    }
+  });
+
   it("reports a cleanup failure after workspace binding initialization fails", async () => {
     tunnelWarn.mockClear();
     const record = environment();

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -3,17 +3,9 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  GATEWAY_CLIENT_IDS,
-  GATEWAY_CLIENT_MODES,
-} from "../../../packages/gateway-protocol/src/client-info.js";
-import {
-  WORKER_PROTOCOL_FEATURES,
-  WORKER_RPC_SET_VERSION,
-} from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { WORKER_RPC_SET_VERSION } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../../infra/node-runner-inventory.js";
 import { parseWorkerLaunchPlan } from "../../worker/launch-descriptor.js";
 import type { NodeWorkerSupervisorReceipt } from "../../worker/node-supervisor-protocol.js";
 import type { NodeWorkerWorkspaceExecInput } from "../../worker/node-workspace-protocol.js";
@@ -24,9 +16,15 @@ import {
 import type { NodeWorkerSupervisorTransport } from "../node-registry-private.js";
 import type { createDeviceWorkerRuntime } from "./device-provider.js";
 import { createNodeWorkerTunnelManager } from "./node-worker-tunnel.js";
+import {
+  BUILD,
+  environment,
+  startRequest,
+  transport,
+  workspaceTransfer,
+} from "./node-worker-tunnel.test-support.js";
 import type { NodeWorkspaceTransferService } from "./node-workspace-transfer-service.js";
 import { sameWorkerSessionTurnClaim } from "./placement-record.js";
-import type { WorkerEnvironmentRecord } from "./store.js";
 import { serializeWorkerWorkspaceManifest } from "./workspace-manifest.js";
 
 const workspaceInfo = vi.hoisted(() => vi.fn());
@@ -45,44 +43,12 @@ vi.mock("../../logging/subsystem.js", async (importOriginal) => {
   };
 });
 
-const BUILD = {
-  bundleHash: "a".repeat(64),
-  openclawVersion: "2026.8.13",
-  protocolFeatures: [...WORKER_PROTOCOL_FEATURES],
-};
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 type NodeWorkerLaunch = ReturnType<typeof createDeviceWorkerRuntime>["launchNodeWorker"];
 type TerminalReceipt = Extract<
   NodeWorkerSupervisorReceipt,
   { state: "completed" | "failed" | "interrupted" | "cancelled" }
 >;
-
-function environment(): WorkerEnvironmentRecord {
-  return {
-    environmentId: "environment-1",
-    providerId: "device",
-    profileId: "device:node-1",
-    profileSnapshot: { settings: { device: "node-1" } },
-    provisionOperationId: "provision-1",
-    nodeSetupId: null,
-    nodeDeviceId: "node-1",
-    sharedHost: true,
-    desktop: null,
-    bootstrapReceipt: { ...BUILD, installKind: "bundle" },
-    ownerEpoch: 2,
-    teardownTerminalState: null,
-    attachedSessionIds: ["session-1"],
-    lastError: null,
-    createdAtMs: 1,
-    updatedAtMs: 2,
-    stateChangedAtMs: 2,
-    idleSinceAtMs: null,
-    destroyRequestedAtMs: null,
-    state: "attached",
-    leaseId: "device-lease",
-    sshEndpoint: null,
-  };
-}
 
 function plan() {
   return parseWorkerLaunchPlan({
@@ -122,44 +88,6 @@ function turnClaim() {
     placementGeneration: 4,
     owner: { kind: "worker" as const, environmentId: "environment-1", ownerEpoch: 2 },
   };
-}
-
-function transport(): NodeWorkerSupervisorTransport {
-  return {
-    hasCurrentRunner: () => true,
-    listCurrentNodes: async () => [
-      {
-        nodeId: "node-1",
-        connId: "conn-1",
-        pairingIdentity: "pairing-1",
-        pairingGeneration: "generation-1",
-        clientId: GATEWAY_CLIENT_IDS.NODE_HOST,
-        clientMode: GATEWAY_CLIENT_MODES.NODE,
-        protocolFeature: NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
-        workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
-        commands: ["system.run"],
-      },
-    ],
-    isCurrent: () => true,
-    invoke: async () => ({ ok: false, error: { code: "UNAVAILABLE" } }),
-  };
-}
-
-function startRequest() {
-  return {
-    environmentId: "environment-1",
-    ownerEpoch: 2,
-    deviceId: "node-1",
-    sessionId: "session-1",
-    expectedBuild: BUILD,
-  };
-}
-
-function workspaceTransfer(): NodeWorkspaceTransferService {
-  return {
-    close: vi.fn(async () => {}),
-    revoke: vi.fn(),
-  } as unknown as NodeWorkspaceTransferService;
 }
 
 describe("node worker tunnel manager", () => {
@@ -430,7 +358,7 @@ describe("node worker tunnel manager", () => {
 
   it("drains sibling node tunnels before reporting a workspace cleanup failure", async () => {
     const cleanupError = new Error("first workspace cleanup failed");
-    const siblingCleanup = createDeferred<void>();
+    const siblingCleanup = createDeferred();
     const close = vi.fn(async (environmentId: string) => {
       if (environmentId === "environment-1") {
         throw cleanupError;

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -713,8 +713,13 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       }
     },
     async stopAll(): Promise<void> {
-      await Promise.all([...entries.values()].map(stopEntry));
-      await options.workspaceTransfer.closeAll();
+      const stopped = await Promise.allSettled([...entries.values()].map(stopEntry));
+      // Shared transfer state outlives every tunnel, even when a sibling's cleanup fails.
+      stopped.push(...(await Promise.allSettled([options.workspaceTransfer.closeAll()])));
+      const failure = stopped.find((result) => result.status === "rejected");
+      if (failure) {
+        throw failure.reason;
+      }
     },
     status(environmentId: string): WorkerTunnelStatus {
       const entry = entries.get(environmentId);

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -62,11 +62,6 @@ const RETRYABLE_TRANSPORT_CODES = new Set([
   "UNAVAILABLE",
 ]);
 
-type TerminalNodeWorkerSupervisorReceipt = Extract<
-  NodeWorkerSupervisorReceipt,
-  { state: "completed" | "failed" | "interrupted" | "cancelled" }
->;
-
 type NodeWorkerLaunch = (request: {
   deviceId: string;
   input: {
@@ -81,7 +76,7 @@ type NodeWorkerLaunch = (request: {
   timeoutMs: number;
   signal?: AbortSignal;
   onDispatchReady?: () => void;
-}) => Promise<TerminalNodeWorkerSupervisorReceipt>;
+}) => Promise<Exclude<NodeWorkerSupervisorReceipt, { state: "pending" | "running" }>>;
 
 type NodeWorkerWorkspaceBinding = {
   localPath: string;

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -455,17 +455,21 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     credentialBroker.clear();
     options.liveEvents?.clear();
     options.stopNodeWorkerBundleTransfers?.();
-    await environmentAccess.stopAllTunnels();
-    const reconciliation = reconcileInFlight;
-    if (reconciliation) {
-      await Promise.allSettled([reconciliation]);
+    try {
+      await environmentAccess.stopAllTunnels();
+    } finally {
+      // Tunnel failures cannot release shutdown before admitted owner-bound operations drain.
+      const reconciliation = reconcileInFlight;
+      if (reconciliation) {
+        await Promise.allSettled([reconciliation]);
+      }
+      while (activeOperations.size > 0) {
+        await Promise.allSettled(activeOperations);
+      }
+      credentialBroker.clear();
+      turnRpc.clear();
+      options.liveEvents?.clear();
     }
-    while (activeOperations.size > 0) {
-      await Promise.allSettled(activeOperations);
-    }
-    credentialBroker.clear();
-    turnRpc.clear();
-    options.liveEvents?.clear();
   };
 
   const providerSupportsExecutionMode = (providerId: string, mode: WorkerExecutionMode) =>

--- a/src/gateway/worker-environments/worker-session-tool-executor.test.ts
+++ b/src/gateway/worker-environments/worker-session-tool-executor.test.ts
@@ -68,12 +68,13 @@ vi.mock("../../agents/tools/sessions-spawn-tool.js", async () => {
       agentSessionKey: string;
       callGateway: (method: string, params: Record<string, unknown>) => Promise<unknown>;
     }) => ({
-      execute: async (_toolCallId: string, args: { task: string }) => {
+      execute: async (_toolCallId: string, args: { task: string; worktree?: boolean }) => {
         spawnCallerIdentity(getGatewayToolCallerIdentity());
         spawnArgs(args);
         const details = await options.callGateway("sessions.create", {
           parentSessionKey: options.agentSessionKey,
           task: args.task,
+          ...(args.worktree ? { worktree: true } : {}),
         });
         return {
           content: [{ type: "text", text: "spawned" }],
@@ -479,6 +480,33 @@ describe("worker session tool topology", () => {
       parentSessionId: SOURCE.sessionId,
     });
     expect(replay.resultJson).toBe(first.resultJson);
+  });
+
+  it.each([
+    { label: "default", mode: undefined },
+    { label: "read-only", mode: "read-only" },
+    { label: "guarded", mode: "guarded" },
+    { label: "workspace", mode: "workspace" },
+    { label: "full", mode: "full" },
+  ] as const)("inherits the parent's $label permission mode in a cloud child", async ({ mode }) => {
+    setEntry(SOURCE.sessionKey, SOURCE.sessionId);
+    if (mode) {
+      sessionEntries.get(SOURCE.sessionKey)!.permissionMode = mode;
+    }
+
+    await execute({
+      identity,
+      toolName: "sessions_spawn",
+      request: { toolCallId: "spawn-cloud-child-with-permissions", task: "start the child" },
+    });
+
+    const createParams = gatewayCreate.mock.calls[0]?.[0]?.params;
+    expect(createParams).toMatchObject({ worktree: true });
+    if (mode) {
+      expect(createParams).toMatchObject({ permissionMode: mode });
+    } else {
+      expect(createParams).not.toHaveProperty("permissionMode");
+    }
   });
 
   it("carries the exact admitted parent identity into a worker-hosted child spawn", async () => {

--- a/src/gateway/worker-environments/worker-session-tool-executor.ts
+++ b/src/gateway/worker-environments/worker-session-tool-executor.ts
@@ -170,6 +170,9 @@ export function createWorkerSessionToolExecutor(params: {
       } else {
         const createParams: Record<string, unknown> = {
           ...requestParams,
+          ...(operation.source.entry.permissionMode
+            ? { permissionMode: operation.source.entry.permissionMode }
+            : {}),
           key: operation.childSessionKey,
         };
         delete createParams.task;

--- a/test/e2e/qa-lab/runtime/node-worker-container-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-container-wire.e2e.test.ts
@@ -29,6 +29,8 @@ const CONTAINER_IMAGE = process.env.OPENCLAW_DOCKER_NODE_WORKER_IMAGE ?? "node:2
 const CONTAINER_GATEWAY_HOST =
   process.env.OPENCLAW_DOCKER_NODE_WORKER_GATEWAY_HOST ?? "host.docker.internal";
 const SESSION_KEY = "agent:qa:node-worker-container-wire";
+const INITIAL_MARKER = "NODE_WORKER_CONTAINER_UI_START_OK";
+const INITIAL_PROMPT = `Reply with only this exact marker: ${INITIAL_MARKER}`;
 const EXEC_MARKER = "NODE_WORKER_CONTAINER_YOLO_OK";
 const EXEC_FILE = "node-worker-container-yolo.txt";
 const EXEC_COMMAND = `test -f /.dockerenv && printf ${EXEC_MARKER} > ${EXEC_FILE} && sleep 1`;
@@ -49,8 +51,18 @@ type ControlUiProof = {
   browser: Browser;
   context: BrowserContext;
   page: Page;
+  requests: Array<{
+    method: string;
+    params?: {
+      key?: string;
+      agentId?: string;
+      deviceId?: string;
+      message?: string;
+      idempotencyKey?: string;
+    };
+  }>;
   fullAccessPatch: {
-    arm(): void;
+    arm(sessionKey: string): void;
     held: Promise<void>;
     prematureChatSend: Promise<"premature-chat-send">;
     release(): void;
@@ -138,7 +150,9 @@ async function startControlUiProof(gateway: WireGateway): Promise<ControlUiProof
     { gatewayUrl: gateway.wsUrl, token: gateway.token },
   );
   let patchArmed = false;
+  let patchSessionKey: string | undefined;
   let releaseHeldPatch: (() => void) | undefined;
+  const requests: ControlUiProof["requests"] = [];
   let notifyPatchHeld: () => void;
   let notifyPrematureChatSend: () => void;
   const patchHeld = new Promise<void>((resolve) => {
@@ -152,12 +166,26 @@ async function startControlUiProof(gateway: WireGateway): Promise<ControlUiProof
     socket.onMessage((message) => {
       const request = JSON.parse(message.toString()) as {
         method?: string;
-        params?: { key?: string; permissionMode?: string };
+        params?: {
+          key?: string;
+          agentId?: string;
+          deviceId?: string;
+          message?: string;
+          idempotencyKey?: string;
+          permissionMode?: string;
+        };
       };
+      if (
+        request.method === "sessions.create" ||
+        request.method === "sessions.dispatch" ||
+        request.method === "sessions.send"
+      ) {
+        requests.push({ method: request.method, params: request.params });
+      }
       if (
         patchArmed &&
         request.method === "sessions.patch" &&
-        request.params?.key === SESSION_KEY &&
+        request.params?.key === patchSessionKey &&
         request.params.permissionMode === "full"
       ) {
         patchArmed = false;
@@ -179,8 +207,10 @@ async function startControlUiProof(gateway: WireGateway): Promise<ControlUiProof
     browser,
     context,
     page: await context.newPage(),
+    requests,
     fullAccessPatch: {
-      arm: () => {
+      arm: (sessionKey) => {
+        patchSessionKey = sessionKey;
         patchArmed = true;
       },
       held: patchHeld,
@@ -211,6 +241,8 @@ describe.runIf(CONTAINER_WIRE_ENABLED)("node worker real Docker wire", () => {
       let controlUiProof: ControlUiProof | undefined;
       let browserRunId: string | undefined;
       let launchId: string | undefined;
+      let inspectLaunchedContainer = !CONTROL_UI_PROOF_ENABLED;
+      let sessionKey = SESSION_KEY;
 
       try {
         expect(engine.id).toBe("docker");
@@ -235,7 +267,7 @@ describe.runIf(CONTAINER_WIRE_ENABLED)("node worker real Docker wire", () => {
               const payload = event.payload as
                 | { runId?: unknown; sessionKey?: unknown }
                 | undefined;
-              if (payload?.sessionKey === SESSION_KEY && typeof payload.runId === "string") {
+              if (payload?.sessionKey === sessionKey && typeof payload.runId === "string") {
                 browserRunId = payload.runId;
               }
             }
@@ -266,12 +298,13 @@ describe.runIf(CONTAINER_WIRE_ENABLED)("node worker real Docker wire", () => {
               return;
             }
             launchId = (JSON.parse(frame.paramsJSON) as { launchId?: string }).launchId;
-            if (launchId) {
+            if (launchId && inspectLaunchedContainer) {
               observedContainer = observeWorkerContainer(launchId);
             }
           },
         });
 
+        let remoteWorkspaceDir: string | undefined;
         if (CONTROL_UI_PROOF_ENABLED) {
           controlUiProof = await startControlUiProof(gateway);
           await controlUiProof.page.goto(`${gateway.baseUrl}/new`);
@@ -289,37 +322,108 @@ describe.runIf(CONTAINER_WIRE_ENABLED)("node worker real Docker wire", () => {
             .poll(() => where.getAttribute("data-device-id"))
             .toBe(workerNode.identity.deviceId);
           await captureControlUiProof(controlUiProof, "02-remote-device-selected");
+          await controlUiProof.page.locator(".new-session-page__message").fill(INITIAL_PROMPT);
+          await controlUiProof.page.getByRole("button", { name: "Start session" }).click();
+          await vi.waitFor(
+            () => {
+              expect(controlUiProof!.requests.map((request) => request.method)).toEqual([
+                "sessions.create",
+                "sessions.dispatch",
+                "sessions.send",
+              ]);
+            },
+            { timeout: PROOF_TIMEOUT_MS, interval: 100 },
+          );
+          const [created, dispatched, sent] = controlUiProof.requests;
+          expect(created?.params).toMatchObject({ agentId: "qa" });
+          expect(dispatched?.params).toMatchObject({
+            agentId: "qa",
+            deviceId: workerNode.identity.deviceId,
+          });
+          expect(dispatched?.params?.key).toMatch(/^agent:qa:/u);
+          sessionKey = dispatched!.params!.key!;
+          expect(sent?.params).toMatchObject({
+            key: sessionKey,
+            agentId: "qa",
+            message: INITIAL_PROMPT,
+          });
+          const initialRunId = sent?.params?.idempotencyKey;
+          expect(initialRunId).toBeTruthy();
+          await vi.waitFor(() => expect(launchId).toBeTruthy(), {
+            timeout: PROOF_TIMEOUT_MS,
+            interval: 100,
+          });
+          await expect(
+            operator.request<{ status?: string }>(
+              "agent.wait",
+              { runId: initialRunId, timeoutMs: PROOF_TIMEOUT_MS },
+              { timeoutMs: PROOF_TIMEOUT_MS + 5_000 },
+            ),
+          ).resolves.toMatchObject({ status: "ok" });
+          const firstLaunchId = launchId;
+          expect(firstLaunchId).toBeTruthy();
+          await workerNode.waitForWorkersIdle();
+          await expect(
+            dockerOutput([
+              "ps",
+              "--all",
+              "--filter",
+              `label=openclaw.node-worker.launch=${Buffer.from(firstLaunchId!).toString("base64url")}`,
+              "--format",
+              "{{.ID}}",
+            ]),
+          ).resolves.toBe("");
+          const initialHistory = await operator.request<{ messages?: unknown[] }>("chat.history", {
+            sessionKey,
+            limit: 20,
+          });
+          expect(
+            initialHistory.messages?.some(
+              (message) =>
+                (message as { role?: unknown }).role === "assistant" &&
+                wireMessageText(message).includes(INITIAL_MARKER),
+            ),
+          ).toBe(true);
+          const described = (await gateway.call("sessions.describe", { key: sessionKey })) as {
+            session?: { placement?: { state?: string; remoteWorkspaceDir?: string } };
+          };
+          expect(described.session?.placement).toMatchObject({ state: "active" });
+          remoteWorkspaceDir = described.session?.placement?.remoteWorkspaceDir;
+          launchId = undefined;
+          observedContainer = undefined;
+          browserRunId = undefined;
+          inspectLaunchedContainer = true;
+        } else {
+          await operator.request("sessions.create", {
+            key: sessionKey,
+            agentId: "qa",
+            worktree: true,
+            worktreeName: "node-worker-container-wire",
+            worktreeBaseRef: "main",
+            cwd: published.source,
+            permissionMode: "full",
+          });
+          const dispatched = (await gateway.call(
+            "sessions.dispatch",
+            { key: sessionKey, deviceId: workerNode.identity.deviceId },
+            { timeoutMs: PROOF_TIMEOUT_MS },
+          )) as { placement?: { state?: string; remoteWorkspaceDir?: string } };
+          expect(dispatched.placement).toMatchObject({ state: "active" });
+          remoteWorkspaceDir = dispatched.placement?.remoteWorkspaceDir;
         }
-
-        await operator.request("sessions.create", {
-          key: SESSION_KEY,
-          agentId: "qa",
-          worktree: true,
-          worktreeName: "node-worker-container-wire",
-          worktreeBaseRef: "main",
-          cwd: published.source,
-          permissionMode: controlUiProof ? "workspace" : "full",
-        });
-        const dispatched = (await gateway.call(
-          "sessions.dispatch",
-          { key: SESSION_KEY, deviceId: workerNode.identity.deviceId },
-          { timeoutMs: PROOF_TIMEOUT_MS },
-        )) as { placement?: { state?: string; remoteWorkspaceDir?: string } };
-        expect(dispatched.placement).toMatchObject({ state: "active" });
-        const remoteWorkspaceDir = dispatched.placement?.remoteWorkspaceDir;
         expect(remoteWorkspaceDir).toBeTruthy();
 
         if (controlUiProof) {
           const sessionPath = buildControlUiSessionPath({
             namespace: "chat",
-            sessionKey: SESSION_KEY,
+            sessionKey,
             fallbackAgentId: "qa",
           });
           await controlUiProof.page.goto(`${gateway.baseUrl}${sessionPath}`);
           const permission = controlUiProof.page.locator('[data-chat-permission-select="true"]');
           await permission.waitFor({ state: "visible", timeout: 60_000 });
           await controlUiProof.page.locator(".agent-chat__composer-combobox textarea").fill(PROMPT);
-          controlUiProof.fullAccessPatch.arm();
+          controlUiProof.fullAccessPatch.arm(sessionKey);
           await permission.click();
           await controlUiProof.page.locator('[data-chat-permission-option="full"]').click();
           await controlUiProof.fullAccessPatch.held;
@@ -344,7 +448,7 @@ describe.runIf(CONTAINER_WIRE_ENABLED)("node worker real Docker wire", () => {
               const history = await activeOperator.request<{ messages?: unknown[] }>(
                 "chat.history",
                 {
-                  sessionKey: SESSION_KEY,
+                  sessionKey,
                   limit: 20,
                 },
               );
@@ -383,7 +487,7 @@ describe.runIf(CONTAINER_WIRE_ENABLED)("node worker real Docker wire", () => {
           const runId = `node-worker-container-yolo-${Date.now()}`;
           await expect(
             operator.request("chat.send", {
-              sessionKey: SESSION_KEY,
+              sessionKey,
               message: PROMPT,
               deliver: false,
               idempotencyKey: runId,
@@ -421,7 +525,7 @@ describe.runIf(CONTAINER_WIRE_ENABLED)("node worker real Docker wire", () => {
           EXEC_MARKER,
         );
 
-        const described = (await gateway.call("sessions.describe", { key: SESSION_KEY })) as {
+        const described = (await gateway.call("sessions.describe", { key: sessionKey })) as {
           session?: { execCwd?: string; spawnedCwd?: string };
         };
         const gatewayWorkspaceDir = described.session?.execCwd ?? described.session?.spawnedCwd;
@@ -430,7 +534,7 @@ describe.runIf(CONTAINER_WIRE_ENABLED)("node worker real Docker wire", () => {
           EXEC_MARKER,
         );
         const history = await operator.request<{ messages?: unknown[] }>("chat.history", {
-          sessionKey: SESSION_KEY,
+          sessionKey,
           limit: 20,
         });
         expect(

--- a/test/e2e/qa-lab/runtime/node-worker-container-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-container-wire.e2e.test.ts
@@ -186,7 +186,7 @@ async function startControlUiProof(gateway: WireGateway): Promise<ControlUiProof
         patchArmed &&
         request.method === "sessions.patch" &&
         request.params?.key === patchSessionKey &&
-        request.params.permissionMode === "full"
+        request.params?.permissionMode === "full"
       ) {
         patchArmed = false;
         releaseHeldPatch = () => {

--- a/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
@@ -101,6 +101,96 @@ suite.define(() => {
     }
   });
 
+  it.each([
+    {
+      name: "offline paired device",
+      preference: { kind: "device", id: "paired-runner" },
+      status: "unavailable",
+      availableSlots: 1,
+      attribute: "data-device-id",
+      value: "paired-runner",
+      reason: "Device unavailable",
+    },
+    {
+      name: "automatic device without worker capacity",
+      preference: { kind: "auto-device" },
+      status: "available",
+      availableSlots: 0,
+      attribute: "data-auto-device",
+      value: "true",
+      reason: "No worker slots are available",
+    },
+  ])(
+    "keeps a remembered $name blocked until Local is explicitly selected",
+    async ({ preference, status, availableSlots, attribute, value, reason }) => {
+      const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+      const page = await context.newPage();
+      const appUrl = new URL(suite.server.baseUrl);
+      const gatewayUrl = `${appUrl.protocol === "https:" ? "wss:" : "ws:"}//${appUrl.host}`;
+      const storageKey = `openclaw.new-session.preferences.v1:${gatewayOriginScope(gatewayUrl)}`;
+      const sessionKey = "agent:main:explicit-local-choice";
+      await page.addInitScript(
+        ({ key, workspace, where }) => {
+          localStorage.setItem(
+            key,
+            JSON.stringify({
+              agents: { main: { workspace, folder: workspace, where, worktree: true } },
+            }),
+          );
+        },
+        { key: storageKey, workspace: WORKSPACE, where: preference },
+      );
+      const gateway = await installMockGateway(page, {
+        operatorScopes: ["operator.read", "operator.write"],
+        workspace: WORKSPACE,
+        workspaceGit: true,
+        methodResponses: {
+          "environments.list": {
+            environments: [
+              {
+                id: "node:paired-runner",
+                type: "node",
+                label: "Paired runner",
+                status,
+                sessionHost: true,
+                workerSlots: { total: 2, available: availableSlots },
+              },
+            ],
+            profiles: [],
+          },
+          "sessions.create": { key: sessionKey },
+          "sessions.list": createdSessionListResult(sessionKey),
+        },
+      });
+
+      try {
+        await page.goto(`${suite.server.baseUrl}new`);
+        await gateway.waitForRequest("environments.list");
+        const where = page.locator("#new-session-where-trigger");
+        await expect.poll(() => where.getAttribute(attribute)).toBe(value);
+
+        await page.locator(".new-session-page__message").fill("run only where I choose");
+        const start = page.getByRole("button", { name: "Start session" });
+        await expect.poll(() => start.isDisabled()).toBe(true);
+        await expect
+          .poll(() => start.locator("xpath=..").getAttribute("content"))
+          .toContain(reason);
+        expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
+
+        await where.click();
+        await page.locator('[data-value="gateway"]').click();
+        await expect.poll(() => start.isEnabled()).toBe(true);
+        await start.click();
+        await expect(gateway.waitForRequest("sessions.create")).resolves.toMatchObject({
+          params: { agentId: "main", message: "run only where I choose" },
+        });
+        expect(await gateway.getRequests("sessions.dispatch")).toHaveLength(0);
+      } finally {
+        await context.close();
+      }
+    },
+  );
+
   it("restores the selected agent's own destination instead of inheriting another agent's device", async () => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();

--- a/ui/src/pages/new-session/draft-place-state.ts
+++ b/ui/src/pages/new-session/draft-place-state.ts
@@ -633,11 +633,8 @@ export class DraftPlaceState {
       this.gateway.cloudProfilesReady
     ) {
       const automatic = preferredWhere.kind === "auto-device";
-      this.autoDeviceValue = automatic && this.devices().some((device) => device.selectable);
-      this.deviceIdValue =
-        preferredWhere.kind === "device" && this.findDevice(preferredWhere.id)?.selectable === true
-          ? preferredWhere.id
-          : "";
+      this.autoDeviceValue = automatic;
+      this.deviceIdValue = preferredWhere.kind === "device" ? preferredWhere.id : "";
       this.cloudProfileIdValue = "";
       this.repositoryState.forceWorktree(this.remotePlacement);
       this.preferredWhereRestore = null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting work on a remembered remote node could silently run the session locally when that node was offline or full. Nested remote workers could also lose the parent session's explicit permission mode, so guarded sessions became less restrictive and Full Access turns unexpectedly lost their no-approval contract. Concurrent Gateway worker shutdown could abandon healthy sibling tunnels and shared workspace resources after one failure, and expired node operations could still accept privileged input before their delayed timeout callback executed.

## Why This Change Was Made

Preserve the operator's selected paired-node destination and reuse the existing actionable disabled-state gate instead of falling back to Local. Propagate only the authoritative parent permission mode into nested worker session creation; drain all tunnel owners and admitted operations before releasing shared resources; and centralize the existing absolute-deadline decision across every invoke stream boundary. Strengthen the real Docker proof so Chromium's actual Start Session action must create, dispatch, and run on the selected paired node before a second Full Access remote turn executes without approvals.

## User Impact

Unavailable remote nodes remain visibly selected and blocked until the operator explicitly chooses Local. Read-only, guarded, workspace, and Full Access policies survive nested remote work. Gateway shutdown no longer strands sibling worker resources, and expired remote operations cannot accept additional input. Full Access remote Docker execution still produces zero approval prompts or pending alerts.

## Evidence

Before the repair, four explicit child permission modes, two independent tunnel shutdown owners, the expired invoke-input boundary, and both real Chromium remote-destination cases failed against current main. After the owner fixes:

```
node scripts/run-vitest.mjs src/gateway/node-registry.test.ts src/gateway/worker-environments/worker-session-tool-executor.test.ts src/gateway/worker-environments/node-worker-tunnel.test.ts src/gateway/worker-environments/environment-access.test.ts --reporter dot
# 4 files, 185 tests passed

node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts --reporter dot
# 2 files, 19 real Chromium scenarios passed

pnpm build
# complete packaged Gateway, worker, plugin, and Control UI build passed

OPENCLAW_E2E_USE_PREBUILT_DIST=1 OPENCLAW_DOCKER_NODE_WORKER_E2E=1 OPENCLAW_DOCKER_NODE_WORKER_UI_PROOF=1 node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/node-worker-container-wire.e2e.test.ts --reporter verbose
# real browser -> sessions.create -> sessions.dispatch(selected device) -> sessions.send
# first real Docker worker completes and is removed
# second real Docker worker waits for the Full Access patch, executes, reconciles workspace
# zero approval requests, zero pending overlays, and zero leaked worker containers
```

Before: an actual paired worker node is available in the Gateway-served session destination picker.

![Paired node available in the actual Gateway-served session picker](https://github.com/user-attachments/assets/fb86ec3c-5179-435a-8416-d84d2de0f94d)

After: the browser-created remote session completes both real Docker turns with Full Access and no approval alerts.

![Browser-created remote session completes in Docker with Full Access and no alerts](https://github.com/user-attachments/assets/9a16d3a2-dcee-4d85-ad5a-0a8860b2f390)

Actual Gateway, paired node, two Docker worker turns, and Chromium recording:

https://github.com/user-attachments/assets/aea68c10-1df3-447f-a55f-32b6818c31b1

Fresh independent structured autoreview: clean. Production delta is +18 lines across canonical permission inheritance, sibling shutdown ownership, and absolute-deadline fencing; regression and authentic browser/Docker proof account for the remaining growth. Companion remote-worker reconnect-storm repair already landed in #116279.
