### PR TITLE
fix(e2e): suppress update checks inside Docker E2E containers

### DIFF
--- a/scripts/lib/docker-e2e-container.sh
+++ b/scripts/lib/docker-e2e-container.sh
@@ -241,6 +241,7 @@ docker_e2e_resolve_pids_limit() {
 
 docker_e2e_docker_run_resource_args() {
   DOCKER_E2E_RUN_RESOURCE_ARGS=()
+  docker_e2e_append_update_check_suppression "$@"
   if docker_e2e_resource_limits_disabled; then
     return 0
   fi
@@ -260,6 +261,45 @@ docker_e2e_docker_run_resource_args() {
     pids_limit="$(docker_e2e_resolve_pids_limit "$pids_limit")" || return $?
     DOCKER_E2E_RUN_RESOURCE_ARGS+=(--pids-limit "$pids_limit")
   fi
+
+}
+
+docker_e2e_run_env_present() {
+  local name="$1"
+  shift
+  local arg
+  local expect_value=0
+  for arg in "$@"; do
+    if [ "$expect_value" = 1 ]; then
+      expect_value=0
+      case "$arg" in
+        "$name" | "$name"=*)
+          return 0
+          ;;
+      esac
+      continue
+    fi
+    case "$arg" in
+      -e | --env)
+        expect_value=1
+        ;;
+      -e"$name" | -e"$name"=* | --env="$name" | --env="$name"=*)
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+# CI containers are not installations. The runner's own CI variable does not
+# cross into `docker run`, so without this every E2E container reports a daily
+# update check and drowns real operators in the telemetry aggregates. Callers
+# that exercise update behavior pass their own value and keep it.
+docker_e2e_append_update_check_suppression() {
+  if docker_e2e_run_env_present OPENCLAW_NO_AUTO_UPDATE "$@"; then
+    return 0
+  fi
+  DOCKER_E2E_RUN_RESOURCE_ARGS+=(-e OPENCLAW_NO_AUTO_UPDATE=1)
 }
 
 docker_e2e_container_running() {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2131,7 +2131,7 @@ set -e
 stderr="$(<"$TMPDIR/stderr")"
 [[ "$status" = "13" ]]
 [[ "$stderr" = *"timeout command not found; using Node watchdog for Docker command timeout 7s"* ]]
-[[ "$(<"$TMPDIR/docker-seen")" = "run --memory 8g --cpus 16 --pids-limit 2048 -i demo|payload" ]]
+[[ "$(<"$TMPDIR/docker-seen")" = "run -e OPENCLAW_NO_AUTO_UPDATE=1 --memory 8g --cpus 16 --pids-limit 2048 -i demo|payload" ]]
 `;
 
     execFileSync("bash", ["-lc", script], { encoding: "utf8" });
@@ -2169,11 +2169,11 @@ OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8 OPENCLAW_DOCKER_E2E_MEMORY=12g OPENCLAW_DOC
 docker_e2e_docker_cmd run --memory 2g --cpus 3 --pids-limit 99 demo
 OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1 docker_e2e_docker_cmd run demo
 
-[[ "$(sed -n '1p' "$TMPDIR/docker-seen")" = "run --memory 8g --cpus 16 --pids-limit 2048 demo" ]]
-[[ "$(sed -n '2p' "$TMPDIR/docker-seen")" = "run --memory 12g --cpus 4 --pids-limit 512 demo" ]]
-[[ "$(sed -n '3p' "$TMPDIR/docker-seen")" = "run --memory 12g --cpus 8 --pids-limit 512 demo" ]]
-[[ "$(sed -n '4p' "$TMPDIR/docker-seen")" = "run --memory 2g --cpus 3 --pids-limit 99 demo" ]]
-[[ "$(sed -n '5p' "$TMPDIR/docker-seen")" = "run demo" ]]
+[[ "$(sed -n '1p' "$TMPDIR/docker-seen")" = "run -e OPENCLAW_NO_AUTO_UPDATE=1 --memory 8g --cpus 16 --pids-limit 2048 demo" ]]
+[[ "$(sed -n '2p' "$TMPDIR/docker-seen")" = "run -e OPENCLAW_NO_AUTO_UPDATE=1 --memory 12g --cpus 4 --pids-limit 512 demo" ]]
+[[ "$(sed -n '3p' "$TMPDIR/docker-seen")" = "run -e OPENCLAW_NO_AUTO_UPDATE=1 --memory 12g --cpus 8 --pids-limit 512 demo" ]]
+[[ "$(sed -n '4p' "$TMPDIR/docker-seen")" = "run -e OPENCLAW_NO_AUTO_UPDATE=1 --memory 2g --cpus 3 --pids-limit 99 demo" ]]
+[[ "$(sed -n '5p' "$TMPDIR/docker-seen")" = "run -e OPENCLAW_NO_AUTO_UPDATE=1 demo" ]]
 `;
 
     execFileSync("bash", ["-lc", script], { encoding: "utf8" });
@@ -2328,8 +2328,8 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
 
 docker_e2e_docker_run_cmd run demo
 
-[[ "$(<"$TMPDIR/timeout-seen")" = "gtimeout:--kill-after=30s 13s|docker run --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
-[[ "$(<"$TMPDIR/docker-seen")" = "run --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
+[[ "$(<"$TMPDIR/timeout-seen")" = "gtimeout:--kill-after=30s 13s|docker run -e OPENCLAW_NO_AUTO_UPDATE=1 --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
+[[ "$(<"$TMPDIR/docker-seen")" = "run -e OPENCLAW_NO_AUTO_UPDATE=1 --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
 `;
 
     execFileSync("bash", ["-lc", script], { encoding: "utf8" });
@@ -2401,8 +2401,8 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
 
 docker_e2e_docker_run_cmd run demo
 
-[[ "$(<"$TMPDIR/timeout-seen")" = "gtimeout:--kill-after=30s 15s|docker run --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
-[[ "$(<"$TMPDIR/docker-seen")" = "run --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
+[[ "$(<"$TMPDIR/timeout-seen")" = "gtimeout:--kill-after=30s 15s|docker run -e OPENCLAW_NO_AUTO_UPDATE=1 --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
+[[ "$(<"$TMPDIR/docker-seen")" = "run -e OPENCLAW_NO_AUTO_UPDATE=1 --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
 `;
 
     execFileSync("bash", ["-lc", script], { encoding: "utf8" });

--- a/test/scripts/docker-e2e-update-suppression.test.ts
+++ b/test/scripts/docker-e2e-update-suppression.test.ts
@@ -1,0 +1,56 @@
+// Covers the Docker E2E guard that keeps continuous-integration containers out
+// of the public telemetry aggregates.
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const CONTAINER_HELPER_PATH = "scripts/lib/docker-e2e-container.sh";
+
+/** Returns the docker run arguments the helper injects for the given caller args. */
+function injectedRunArgs(callerArgs: string[], env: Record<string, string> = {}): string[] {
+  const script = `
+set -euo pipefail
+source ${CONTAINER_HELPER_PATH}
+docker_e2e_docker_run_resource_args ${callerArgs.map((arg) => `'${arg}'`).join(" ")}
+printf '%s\\n' "\${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}"
+`;
+  return execFileSync("bash", ["-lc", script], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  })
+    .split("\n")
+    .filter(Boolean);
+}
+
+describe("docker e2e update-check suppression", () => {
+  it("suppresses automatic update checks inside every container", () => {
+    const args = injectedRunArgs(["-d", "--name", "openclaw-e2e", "openclaw:test"]);
+
+    expect(args).toContain("-e");
+    expect(args).toContain("OPENCLAW_NO_AUTO_UPDATE=1");
+  });
+
+  it("still suppresses when resource limits are disabled", () => {
+    const args = injectedRunArgs(["-d", "openclaw:test"], {
+      OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS: "1",
+    });
+
+    expect(args).toEqual(["-e", "OPENCLAW_NO_AUTO_UPDATE=1"]);
+  });
+
+  it("keeps a caller-provided value so update lanes stay in control", () => {
+    for (const callerArgs of [
+      ["-e", "OPENCLAW_NO_AUTO_UPDATE=0", "openclaw:test"],
+      ["-eOPENCLAW_NO_AUTO_UPDATE=0", "openclaw:test"],
+      ["--env", "OPENCLAW_NO_AUTO_UPDATE", "openclaw:test"],
+      ["--env=OPENCLAW_NO_AUTO_UPDATE=0", "openclaw:test"],
+    ]) {
+      expect(injectedRunArgs(callerArgs)).not.toContain("OPENCLAW_NO_AUTO_UPDATE=1");
+    }
+  });
+
+  it("does not mistake an image or unrelated flag value for the suppression variable", () => {
+    const args = injectedRunArgs(["-e", "SOMETHING_ELSE=1", "OPENCLAW_NO_AUTO_UPDATE", "-d"]);
+
+    expect(args).toContain("OPENCLAW_NO_AUTO_UPDATE=1");
+  });
+});

--- a/test/vitest/vitest.tooling-docker.config.ts
+++ b/test/vitest/vitest.tooling-docker.config.ts
@@ -1,7 +1,10 @@
 // Vitest tooling Docker config isolates the slow Docker helper contract tests.
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-export const toolingDockerTestFiles = ["test/scripts/docker-build-helper.test.ts"];
+export const toolingDockerTestFiles = [
+  "test/scripts/docker-build-helper.test.ts",
+  "test/scripts/docker-e2e-update-suppression.test.ts",
+];
 
 export function createToolingDockerVitestConfig(env?: Record<string, string | undefined>) {
   return createScopedVitestConfig(toolingDockerTestFiles, {


### PR DESCRIPTION
Follow-up to #129155, which did not actually work.

## What Problem This Solves

#129155 suppressed telemetry when `CI` is set. GitHub Actions sets that on the **runner**, but our E2E lanes run the CLI and gateway **inside Docker containers**, and `docker run` passes only the environment variables you name explicitly. Of roughly 35 `-e` passes across `scripts/e2e/*.sh`, exactly three set `CI=true`; the rest pass `COREPACK_*` and `OPENCLAW_SKIP_*`. Inside every other container `CI` is unset, so the guard never fires.

The live aggregates confirm it: Linux pings went from 27,984 to 37,440 in about a day after that PR landed, while macOS moved 187 → 391 and Windows 39 → 106. CI is still reporting and still dwarfing the real operators we actually want to measure.

## Why This Change Was Made

The suppression now happens where the containers are created, in the shared `docker_e2e_docker_run_resource_args` path that every E2E `docker run` already flows through. One edit covers all call sites and future lanes inherit it, instead of each script having to remember an `-e` flag.

`OPENCLAW_NO_AUTO_UPDATE=1` is the injected switch rather than `CI=true`. It is the existing documented control, it is scoped precisely to "no background update check", and it avoids perturbing unrelated CI-keyed behavior (prompts, colors, timeouts) inside test containers.

Two details worth reviewer attention:

- The injection runs **before** the resource-limits early return. Placed after it, any lane running with `OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1` would silently skip suppression — the same "guard never fires" failure this PR exists to fix. There is a test for that path.
- Callers that pass their own value keep it, in all four `docker run` spellings (`-e VAR=…`, `-eVAR=…`, `--env VAR`, `--env=VAR=…`), so lanes exercising update behavior stay in control.

The three update-focused lanes (`multi-node-update`, `upgrade-survivor`, `update-channel-switch`) are unaffected: they drive updates through explicit `openclaw update`, `openclaw update --channel`, and `openclaw update status` commands, and `OPENCLAW_NO_AUTO_UPDATE` is read only by the startup/background path (`src/infra/update-startup.ts:850`), never by those commands.

## User Impact

None for operators. CI containers stop making update-check requests, which is marginally faster for them and keeps the public telemetry aggregates representative of real installs.

## Evidence

New `test/scripts/docker-e2e-update-suppression.test.ts` covers: suppression injected for a normal run; suppression still injected when resource limits are disabled; caller-provided values preserved across all four env spellings; and an image name or unrelated flag value not being mistaken for the variable.

The test is registered in `test/vitest/vitest.tooling-docker.config.ts`. That file lists its test files explicitly, so an unregistered `test/scripts/*` file is silently selected by nothing and reports "No test files found, exiting with code 0" — it would have passed PR CI while never running.

Green locally: `pnpm check:changed` (including the Docker E2E package boundary guard), and the new suite via the tooling-docker project. Codex autoreview: clean, no actionable findings.

**LOC delta:** production +38/-1 (shell helper), tests +57/-1.

**Verification after merge:** the Linux ping count on `https://telemetry.openclaw.ai/api/stats` should stop growing; existing rows age out with the 7-day window.
