### PR TITLE
fix(telegram): scheduled reactions target the wrong message

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -21,6 +21,7 @@ import {
   buildOutboundMediaLoadOptions,
   probeVideoDimensions,
 } from "openclaw/plugin-sdk/media-runtime";
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import type { ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
@@ -81,6 +82,7 @@ type TelegramReplyChannelData = {
   pin?: boolean;
   reaction?: {
     emoji?: unknown;
+    replyToId?: unknown;
   };
 };
 
@@ -805,7 +807,8 @@ export async function deliverReplies(params: {
       typeof telegramData?.reaction?.emoji === "string" ? telegramData.reaction.emoji : undefined;
     const replyToId =
       params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
-    if (reactionEmoji && typeof replyToId !== "number") {
+    const targetId = parseStrictPositiveInteger(telegramData?.reaction?.replyToId ?? replyToId);
+    if (reactionEmoji && typeof targetId !== "number") {
       params.runtime.error?.(danger("Telegram reaction requires a reply target"));
       continue;
     }
@@ -878,9 +881,9 @@ export async function deliverReplies(params: {
         }),
       );
       let firstDeliveredMessageId: number | undefined;
-      if (reactionEmoji && typeof replyToId === "number") {
+      if (reactionEmoji && typeof targetId === "number") {
         await params.onPlatformSendDispatch?.();
-        const reactionResult = await reactMessageTelegram(params.chatId, replyToId, reactionEmoji, {
+        const reactionResult = await reactMessageTelegram(params.chatId, targetId, reactionEmoji, {
           cfg: params.cfg ?? { channels: { telegram: { botToken: params.token } } },
           token: params.token,
           accountId: params.accountId,

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -420,6 +420,100 @@ describe("deliverReplies", () => {
     expect(setMessageReaction).toHaveBeenCalledWith("123", 456, [{ type: "emoji", emoji: "🔥" }]);
   });
 
+  it.each([
+    {
+      name: "a nested reaction target with default reply threading disabled",
+      nestedReplyToId: "456",
+      replyToMode: "off" as const,
+    },
+    {
+      name: "a numeric nested reaction target",
+      nestedReplyToId: 456,
+      replyToMode: "off" as const,
+    },
+    {
+      name: "a nested reaction target instead of a different outer reply",
+      nestedReplyToId: "456",
+      outerReplyToId: "789",
+      replyToMode: "all" as const,
+    },
+    {
+      name: "a nested reaction target without enabling native text replies",
+      nestedReplyToId: "456",
+      outerReplyToId: "789",
+      replyToMode: "off" as const,
+      text: "Done",
+    },
+    {
+      name: "a nested reaction target while preserving a different native text reply",
+      nestedReplyToId: "456",
+      outerReplyToId: "789",
+      replyToMode: "all" as const,
+      text: "Done",
+    },
+  ])("honors $name", async ({ nestedReplyToId, outerReplyToId, replyToMode, text }) => {
+    const runtime = createRuntime(false);
+    const setMessageReaction = vi.fn().mockResolvedValue(true);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 901, chat: { id: "123" } });
+    const bot = createBot({ sendMessage, setMessageReaction });
+
+    const result = await deliverWith({
+      replies: [
+        {
+          ...(text ? { text } : {}),
+          ...(outerReplyToId ? { replyToId: outerReplyToId } : {}),
+          channelData: { telegram: { reaction: { emoji: "🔥", replyToId: nestedReplyToId } } },
+        },
+      ],
+      replyToMode,
+      runtime,
+      bot,
+    });
+
+    expect(result).toEqual({ delivered: true });
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(setMessageReaction).toHaveBeenCalledWith("123", 456, [{ type: "emoji", emoji: "🔥" }]);
+    if (text) {
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      if (replyToMode === "off") {
+        expect(mockCallArg(sendMessage, 0, 2)).not.toHaveProperty("reply_to_message_id");
+      } else {
+        expect(mockCallArg(sendMessage, 0, 2)).toMatchObject({ reply_to_message_id: 789 });
+      }
+    } else {
+      expect(sendMessage).not.toHaveBeenCalled();
+    }
+  });
+
+  it.each(["0", "-1", "12.5", "9007199254740992", "invalid"])(
+    "rejects invalid explicit nested reaction target %s without using the outer reply",
+    async (nestedReplyToId) => {
+      const runtime = createRuntime(false);
+      const setMessageReaction = vi.fn().mockResolvedValue(true);
+      const sendMessage = vi.fn().mockResolvedValue({ message_id: 901, chat: { id: "123" } });
+
+      const result = await deliverWith({
+        replies: [
+          {
+            text: "Done",
+            replyToId: "789",
+            channelData: { telegram: { reaction: { emoji: "🔥", replyToId: nestedReplyToId } } },
+          },
+        ],
+        replyToMode: "all",
+        runtime,
+        bot: createBot({ sendMessage, setMessageReaction }),
+      });
+
+      expect(result).toEqual({ delivered: false });
+      expect(runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("requires a reply target"),
+      );
+      expect(setMessageReaction).not.toHaveBeenCalled();
+      expect(sendMessage).not.toHaveBeenCalled();
+    },
+  );
+
   it("does not mark rejected reaction-only replies as delivered", async () => {
     const runtime = createRuntime(false);
     const setMessageReaction = vi.fn().mockRejectedValue(new Error("REACTION_INVALID"));

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -351,6 +351,88 @@ describe("telegramOutbound", () => {
     });
   });
 
+  it.each([
+    { name: "a nested reaction target", nestedReplyToId: "777" },
+    { name: "a numeric nested reaction target", nestedReplyToId: 777 },
+    {
+      name: "a nested reaction target instead of a different outer reply",
+      nestedReplyToId: "777",
+      outerReplyToId: "888",
+    },
+    {
+      name: "a nested reaction target without turning accompanying text into a reply",
+      nestedReplyToId: "777",
+      text: "Done",
+    },
+    {
+      name: "a nested reaction target while preserving a different text reply",
+      nestedReplyToId: "777",
+      outerReplyToId: "888",
+      text: "Done",
+    },
+  ])("honors $name", async ({ nestedReplyToId, outerReplyToId, text }) => {
+    reactMessageTelegramMock.mockResolvedValueOnce({ ok: true });
+    if (text) {
+      sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-text", chatId: "12345" });
+    }
+
+    const result = await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      ...(outerReplyToId ? { replyToId: outerReplyToId } : {}),
+      payload: {
+        ...(text ? { text } : {}),
+        channelData: {
+          telegram: {
+            reaction: { emoji: "🔥", replyToId: nestedReplyToId },
+          },
+        },
+      },
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(reactMessageTelegramMock).toHaveBeenCalledWith("12345", 777, "🔥", expect.any(Object));
+    if (text) {
+      expect(sendMessageTelegramMock).toHaveBeenCalledWith(
+        "12345",
+        text,
+        expect.objectContaining({
+          replyToMessageId: outerReplyToId ? Number(outerReplyToId) : undefined,
+        }),
+      );
+      expect(result.messageId).toBe("tg-text");
+    } else {
+      expect(sendMessageTelegramMock).not.toHaveBeenCalled();
+      expect(result.messageId).toBe("777");
+    }
+  });
+
+  it.each(["0", "-1", "12.5", "9007199254740992", "invalid"])(
+    "rejects invalid explicit nested reaction target %s without using the outer reply",
+    async (nestedReplyToId) => {
+      reactMessageTelegramMock.mockResolvedValueOnce({ ok: true });
+      sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-text", chatId: "12345" });
+
+      await expect(
+        telegramOutbound.sendPayload!({
+          cfg: {} as never,
+          to: "12345",
+          text: "",
+          replyToId: "888",
+          payload: {
+            text: "Done",
+            channelData: { telegram: { reaction: { emoji: "🔥", replyToId: nestedReplyToId } } },
+          },
+          deps: { sendTelegram: sendMessageTelegramMock },
+        }),
+      ).rejects.toThrow("Telegram reaction requires a reply target");
+
+      expect(reactMessageTelegramMock).not.toHaveBeenCalled();
+      expect(sendMessageTelegramMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("applies reaction payloads before sending visible text", async () => {
     reactMessageTelegramMock.mockResolvedValueOnce({ ok: true });
     sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-text", chatId: "12345" });

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -10,6 +10,7 @@ import {
   createAttachedChannelResultAdapter,
   type ChannelOutboundAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
 import {
   resolveSendableOutboundReplyParts,
@@ -333,7 +334,9 @@ export async function sendTelegramPayloadMessages(params: {
     presentation: payload.presentation,
     interactive: payload.interactive,
   });
-  const replyToMessageId = params.baseOpts.replyToMessageId;
+  const replyToMessageId = parseStrictPositiveInteger(
+    telegramData?.reaction?.replyToId ?? params.baseOpts.replyToMessageId,
+  );
   const promptContextSource = resolveTelegramPromptContextSource(params.payload);
   const projectionCursor = promptContextSource
     ? createTelegramPromptContextProjectionCursor(promptContextSource)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users scheduling Telegram reactions would see no reaction, lose an accompanying reply, or react to the wrong message when the reaction carried its own target message ID. Streaming reactions were also silently dropped under Telegram's default disabled reply threading, even when their explicit reaction target was valid.

## Why This Change Was Made

Both Telegram-owned delivery paths now honor the reaction's explicit target before any outer reply target and validate it with the existing strict positive, safe-integer parser. Invalid explicit targets are rejected instead of falling back to a different message; ordinary text reply threading and the existing outer-target fallback remain independent and unchanged.

The change stays inside the existing Telegram transport owners and their tests. It does not modify authentication, security policy, configuration, public schemas, or core delivery contracts.

## User Impact

Scheduled and streamed Telegram reactions reliably reach the intended message, including when normal reply threading is disabled. Replies accompanying a reaction keep their original reply behavior, and malformed message identifiers cannot redirect a reaction to another message.

## Evidence

- Before the production change, all 20 new owner-boundary regression cases failed: nested-only reaction targets produced no request, conflicting targets selected the wrong message, default-off streaming reported no delivery, and malformed explicit targets incorrectly fell back to the outer message.
- After the change, 207 owner and sibling tests pass:

  `node scripts/run-vitest.mjs extensions/telegram/src/outbound-adapter.test.ts extensions/telegram/src/outbound-adapter.normalize-payload.test.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/bot-native-command-plugins.test.ts`

- Independent verification passed 224 Telegram owner and native-command tests plus 19 actual production-to-grammY HTTP serialization scenarios, covering valid string and numeric IDs, nested-target precedence, existing outer-target fallback, default-off streaming, independent text replies, and malformed IDs with zero outbound requests.
- HTTP requests were intercepted locally through grammY's custom fetch implementation; no authenticated live Telegram provider delivery was attempted.
- Changed-file oxlint, formatting, TruffleHog, independent review, and fresh authenticated committed-diff review are clean.
