### PR TITLE
fix(ollama): allow setup reset with any installed local model

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -30,8 +30,8 @@ const promptAndConfigureOllamaMock = vi.hoisted(() =>
   })),
 );
 const ensureOllamaModelPulledMock = vi.hoisted(() => vi.fn(async () => {}));
-const checkOllamaCloudAuthMock = vi.hoisted(() => vi.fn());
 const configureOllamaNonInteractiveMock = vi.hoisted(() => vi.fn());
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
 const fetchOllamaModelsMock = vi.hoisted(() => vi.fn());
 const fetchLoadedOllamaModelNamesMock = vi.hoisted(() => vi.fn());
 const buildOllamaProviderMock = vi.hoisted(() => vi.fn());
@@ -79,9 +79,13 @@ vi.mock("openclaw/plugin-sdk/secret-input-runtime", async (importOriginal) => {
   };
 });
 
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
 vi.mock("./src/setup.runtime.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./src/setup.runtime.js")>()),
-  checkOllamaCloudAuth: checkOllamaCloudAuthMock,
   configureOllamaNonInteractive: configureOllamaNonInteractiveMock,
   ensureOllamaModelPulled: ensureOllamaModelPulledMock,
   promptAndConfigureOllama: promptAndConfigureOllamaMock,
@@ -95,8 +99,11 @@ beforeEach(() => {
   clearLiveCatalogCacheForTests();
   promptAndConfigureOllamaMock.mockClear();
   ensureOllamaModelPulledMock.mockClear();
-  checkOllamaCloudAuthMock.mockReset();
-  checkOllamaCloudAuthMock.mockResolvedValue({ signedIn: true });
+  fetchWithSsrFGuardMock.mockReset();
+  fetchWithSsrFGuardMock.mockResolvedValue({
+    response: new Response(null, { status: 200 }),
+    release: vi.fn(async () => {}),
+  });
   configureOllamaNonInteractiveMock.mockReset();
   fetchOllamaModelsMock.mockReset();
   fetchLoadedOllamaModelNamesMock.mockReset();
@@ -338,10 +345,8 @@ describe("ollama plugin", () => {
       models: ["gemma4:latest"],
     },
     {
-      name: "rejects an unavailable default Ollama model before destructive reset",
+      name: "accepts an installed Ollama model when the suggested default is unavailable",
       models: ["qwen2.5-coder:7b"],
-      error:
-        "Ollama model gemma4 was not found at http://ollama-host:11434.\nAvailable models: qwen2.5-coder:7b",
     },
     {
       name: "refuses to pull an unavailable local model during destructive-reset preflight",
@@ -399,9 +404,11 @@ describe("ollama plugin", () => {
       models: models.map((name) => ({ name })),
     });
     if (cloud === "unauthenticated") {
-      checkOllamaCloudAuthMock.mockResolvedValue({
-        signedIn: false,
-        signinUrl: "https://ollama.com/signin",
+      fetchWithSsrFGuardMock.mockResolvedValue({
+        response: new Response(JSON.stringify({ signin_url: "https://ollama.com/signin" }), {
+          status: 401,
+        }),
+        release: vi.fn(async () => {}),
       });
     }
     if (cloud === "unconfirmed") {
@@ -420,7 +427,9 @@ describe("ollama plugin", () => {
       expect(fetchOllamaModelsMock).toHaveBeenCalledWith("http://ollama-host:11434");
     }
     if (cloud === "confirmed") {
-      expect(checkOllamaCloudAuthMock).toHaveBeenCalledWith("http://ollama-host:11434");
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({ url: "http://ollama-host:11434/api/me" }),
+      );
       expect(queryOllamaModelShowInfoMock).toHaveBeenCalledWith(
         "http://ollama-host:11434",
         "kimi-k2.5:cloud",

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -14,7 +14,6 @@ import {
   type OpenClawPluginApi,
   type ProviderAppGuidedSetupContext,
   type ProviderAuthContext,
-  type ProviderAuthMethod,
   type ProviderAuthMethodNonInteractiveContext,
   type ProviderAuthResult,
   type ProviderAugmentModelCatalogContext,
@@ -43,7 +42,6 @@ import {
   OLLAMA_CLOUD_DEFAULT_MODELS,
   OLLAMA_CLOUD_PROVIDER_ID,
   OLLAMA_DEFAULT_BASE_URL,
-  OLLAMA_DEFAULT_MODEL,
   OLLAMA_GLM52_CLOUD_MODEL_ID,
   resolveOllamaSetupDefaultBaseUrl,
 } from "./src/defaults.js";
@@ -164,88 +162,6 @@ function classifyOllamaFailoverReason(errorMessage: string): "server_error" | un
 const OLLAMA_CLOUD_DEFAULT_MODEL_REF = `${OLLAMA_CLOUD_PROVIDER_ID}/${OLLAMA_CLOUD_DEFAULT_MODELS[0].id}`;
 const OLLAMA_CONFIGURED_SHOW_CONCURRENCY = 4;
 const OLLAMA_CONFIGURED_SHOW_MAX_MODELS = 8;
-
-type OllamaNonInteractiveValidationContext = Parameters<
-  NonNullable<ProviderAuthMethod["validateNonInteractive"]>
->[0];
-
-async function validateOllamaNonInteractive(
-  ctx: OllamaNonInteractiveValidationContext,
-): Promise<boolean> {
-  const configuredBaseUrl =
-    typeof ctx.opts.customBaseUrl === "string" ? ctx.opts.customBaseUrl.trim() : undefined;
-  const baseUrl = resolveOllamaApiBase(configuredBaseUrl || resolveOllamaSetupDefaultBaseUrl());
-  // Reset must only inspect existing models: pulling or storing credentials
-  // here could mutate a healthy installation before its reset is approved.
-  const discovery = await fetchOllamaModels(baseUrl);
-  if (!discovery.reachable) {
-    ctx.runtime.error(
-      `Ollama could not be reached at ${baseUrl}.\nDownload it at https://ollama.com/download`,
-    );
-    ctx.runtime.exit(1);
-    return false;
-  }
-
-  const requestedModel =
-    typeof ctx.opts.customModelId === "string"
-      ? ctx.opts.customModelId.trim().replace(/^ollama\//i, "")
-      : undefined;
-  const selectedModel = requestedModel || OLLAMA_DEFAULT_MODEL;
-  const availableModelNames = discovery.models.map((model) => model.name);
-  const normalizeAvailableModelName = (modelName: string) =>
-    modelName
-      .trim()
-      .toLowerCase()
-      .replace(/:latest$/, "");
-  const selectedModelIsAvailable = availableModelNames.some(
-    (modelName) =>
-      normalizeAvailableModelName(modelName) === normalizeAvailableModelName(selectedModel),
-  );
-
-  if (requestedModel && isOllamaCloudModel(requestedModel)) {
-    const { checkOllamaCloudAuth } = await loadOllamaSetup();
-    const cloudAuth = await checkOllamaCloudAuth(baseUrl);
-    if (!cloudAuth.signedIn) {
-      ctx.runtime.error(
-        `Cloud models on this Ollama host need \`ollama signin\`.\n${
-          cloudAuth.signinUrl ?? "Run `ollama signin` on the configured Ollama host."
-        }`,
-      );
-      ctx.runtime.exit(1);
-      return false;
-    }
-    // Catalog rows can be stale; /api/show confirms every cloud model without
-    // downloading or loading it before the destructive reset is approved.
-    const showInfo = await queryOllamaModelShowInfo(baseUrl, requestedModel);
-    if (typeof showInfo.contextWindow !== "number" && (showInfo.capabilities?.length ?? 0) === 0) {
-      ctx.runtime.error(
-        `Ollama model ${requestedModel} was not found at ${baseUrl}.\nAvailable models: ${
-          availableModelNames.join(", ") || "(none)"
-        }`,
-      );
-      ctx.runtime.exit(1);
-      return false;
-    }
-    return true;
-  }
-
-  if (availableModelNames.length === 0) {
-    ctx.runtime.error(
-      `No Ollama models are available at ${baseUrl}.\nPull a model first, then re-run setup.`,
-    );
-    ctx.runtime.exit(1);
-    return false;
-  }
-  if (!selectedModelIsAvailable) {
-    ctx.runtime.error(
-      `Ollama model ${selectedModel} was not found at ${baseUrl}.\nAvailable models: ${availableModelNames.join(", ")}`,
-    );
-    ctx.runtime.exit(1);
-    return false;
-  }
-
-  return true;
-}
 
 async function buildLocalOllamaProvider(
   configuredBaseUrl?: string,
@@ -1046,7 +962,8 @@ export default definePluginEntry({
               ...(result.defaultModel ? { defaultModel: result.defaultModel } : {}),
             };
           },
-          validateNonInteractive: validateOllamaNonInteractive,
+          validateNonInteractive: async (ctx) =>
+            await (await loadOllamaSetup()).validateOllamaNonInteractive(ctx),
           runNonInteractive: async (ctx: ProviderAuthMethodNonInteractiveContext) => {
             const { configureOllamaNonInteractive } = await loadOllamaSetup();
             return await configureOllamaNonInteractive({

--- a/extensions/ollama/src/setup.runtime.ts
+++ b/extensions/ollama/src/setup.runtime.ts
@@ -1,5 +1,6 @@
 // Ollama setup runtime handles plugin onboarding behavior.
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import type { ProviderAuthMethod } from "openclaw/plugin-sdk/plugin-entry";
 import type {
   OpenClawConfig,
   SecretInput,
@@ -32,6 +33,7 @@ import {
   enrichOllamaModelsWithContext,
   fetchOllamaModels,
   isOllamaCloudModel,
+  queryOllamaModelShowInfo,
   resolveOllamaApiBase,
   type OllamaModelWithContext,
 } from "./provider-models.js";
@@ -445,6 +447,62 @@ export async function promptAndConfigureOllama(params: {
     env: params.env,
     ...(params.signal ? { signal: params.signal } : {}),
   });
+}
+
+/** Checks existing host models without pulling or mutating state before reset. */
+export async function validateOllamaNonInteractive(
+  ctx: Parameters<NonNullable<ProviderAuthMethod["validateNonInteractive"]>>[0],
+): Promise<boolean> {
+  const configuredBaseUrl =
+    typeof ctx.opts.customBaseUrl === "string" ? ctx.opts.customBaseUrl.trim() : undefined;
+  const baseUrl = resolveOllamaApiBase(configuredBaseUrl || resolveOllamaSetupDefaultBaseUrl());
+  const discovery = await fetchOllamaModels(baseUrl);
+  const fail = (message: string) => {
+    ctx.runtime.error(message);
+    ctx.runtime.exit(1);
+    return false;
+  };
+  if (!discovery.reachable) {
+    return fail(
+      `Ollama could not be reached at ${baseUrl}.\nDownload it at https://ollama.com/download`,
+    );
+  }
+
+  const requestedModel = normalizeOllamaModelName(
+    typeof ctx.opts.customModelId === "string" ? ctx.opts.customModelId : undefined,
+  );
+  const availableModelNames = discovery.models.map((model) => model.name);
+  if (requestedModel && isOllamaCloudModel(requestedModel)) {
+    const cloudAuth = await checkOllamaCloudAuth(baseUrl);
+    if (!cloudAuth.signedIn) {
+      return fail(
+        `Cloud models on this Ollama host need \`ollama signin\`.\n${
+          cloudAuth.signinUrl ?? "Run `ollama signin` on the configured Ollama host."
+        }`,
+      );
+    }
+    // A catalog row alone does not prove a cloud model still exists.
+    const showInfo = await queryOllamaModelShowInfo(baseUrl, requestedModel);
+    if (typeof showInfo.contextWindow !== "number" && (showInfo.capabilities?.length ?? 0) === 0) {
+      return fail(
+        `Ollama model ${requestedModel} was not found at ${baseUrl}.\nAvailable models: ${
+          availableModelNames.join(", ") || "(none)"
+        }`,
+      );
+    }
+    return true;
+  }
+  if (availableModelNames.length === 0) {
+    return fail(
+      `No Ollama models are available at ${baseUrl}.\nPull a model first, then re-run setup.`,
+    );
+  }
+  if (requestedModel && !findAvailableOllamaModelName(requestedModel, availableModelNames)) {
+    return fail(
+      `Ollama model ${requestedModel} was not found at ${baseUrl}.\nAvailable models: ${availableModelNames.join(", ")}`,
+    );
+  }
+  return true;
 }
 
 export async function configureOllamaNonInteractive(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users resetting non-interactive Ollama onboarding would see `Ollama model gemma4 was not found` even though another usable model was already installed and no particular model was requested. Normal onboarding already selects an installed model; its separate reset preflight incorrectly required the suggested `gemma4` default before allowing the reset.

## Why This Change Was Made

Move destructive-reset validation into Ollama's existing lazily loaded setup owner, reuse its canonical model-name matching, and accept any installed model when the operator did not explicitly request one. Explicit missing models still fail before reset, and cloud models still require both the guarded host sign-in check and authoritative model inspection. Preflight remains read-only: it never pulls models, writes credentials, or changes configuration.

This deletes the duplicate eager validation path and reduces production code by 25 lines: provider entrypoint +2/-85, existing setup owner +58/-0. Tests are +20/-11 because the existing registration-boundary table now exercises the real cloud-auth owner through its guarded HTTP boundary.

## User Impact

Operators can safely run non-interactive Ollama setup with reset when their host has a valid installed model other than the suggested default. Explicit model selection, unavailable-host guidance, cloud sign-in requirements, cloud model verification, model-name normalization, and reset ordering remain unchanged.

## Evidence

- Exact candidate: `80ca07cd6662bb39033990a0c1e7938f4cf61329`.
- A real pre-fix Linux run of the changed existing registration-boundary test failed for the intended reason: **1 failed, 105 passed**; the Qwen-only reset preflight returned `false` instead of `true`.
- The same Linux runner and same owner suite pass after the fix: **106/106**.
- Five adjacent Ollama setup suites pass: **71/71**.
- The actual onboarding/reset ingress suite passes: **89/89**.
- Total focused proof: **266/266 tests across seven files**.
- Provider owner command: `node scripts/run-vitest.mjs --config test/vitest/vitest.extension-providers.config.ts --configLoader runner extensions/ollama/index.test.ts`.
- Sibling suites: `extensions/ollama/src/setup.test.ts`, `extensions/ollama/src/setup.non-interactive-auth.test.ts`, `extensions/ollama/src/setup-model-selection.test.ts`, `extensions/ollama/src/setup-body-release.test.ts`, and `extensions/ollama/src/setup.cancellation.test.ts`.
- Actual reset ingress: `src/commands/onboard.test.ts`.
- Targeted formatting is clean; direct scoped lint reports **0 errors and 0 warnings**.
- Two independent reviews found no issues, and the final structured review was clean.
- Required hosted CI will run on the exact published head.
