### PR TITLE
fix(qa): restart harness reboots on unrelated pending waits

### DIFF
--- a/extensions/qa-lab/src/reply-failure.ts
+++ b/extensions/qa-lab/src/reply-failure.ts
@@ -10,7 +10,7 @@ const VISIBLE_REPLY_LEAK_PATTERNS = [
 
 const TOOL_BACKED_FAILURE_PATTERNS = [
   /\btool\s+[a-z0-9_.-]+\s+not found\b/i,
-  /^status:\s*blocked\b/im,
+  /^status\s*[:=]\s*(?:blocked|failed)\b/im,
 ];
 
 export function extractQaVisibleReplyLeakText(text: string): string | undefined {

--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -80,10 +80,13 @@ describe("qa scenario catalog causality", () => {
       readFlowAssertExpression(action).includes("finalMatches.length === 1"),
     );
     expect(liveMultiRestart.execution.retryCount).toBe(0);
+    expect(liveMultiRestart.execution.runtime).toBe("openclaw");
+    expect(liveMultiRestart.runtimePairLane).toBeUndefined();
     expect(JSON.stringify(liveMultiRestart.gatewayConfigPatch)).toContain(
       '"alsoAllow":["qa_restart_wait","qa_restart_unsafe_probe"]',
     );
-    expect(liveMultiRestartContract).toContain("assistantToolCallCounts.exec");
+    expect(liveMultiRestartContract).toContain("pendingCodeModeExecNeedle");
+    expect(liveMultiRestartContract).toContain("summary.hasPendingCodeModeWait");
     expect(liveMultiRestartContract).toContain("checkpoint");
     expect(liveMultiRestartContract).toContain("restarts=3");
     for (const fixturePath of [
@@ -95,16 +98,23 @@ describe("qa scenario catalog causality", () => {
     ]) {
       expect(liveMultiRestartPrompt).toContain(fixturePath);
     }
-    expect(liveMultiRestartPrompt).toContain("your only work in this turn is the next checkpoint");
     expect(liveMultiRestartPrompt).toContain(
-      "Make exactly one `exec` call with `restartSafe: true`",
+      "On this original user turn, perform only checkpoint 1",
+    );
+    expect(liveMultiRestartPrompt).toContain(
+      "After the third Gateway-recovery system message, perform the audit and final report",
+    );
+    expect(liveMultiRestartPrompt).toContain(
+      "make exactly one `exec` call with `restartSafe: true`",
     );
     expect(liveMultiRestartPrompt).toContain(
       "expired, or aborted `wait` result after restart is expected",
     );
-    expect(liveMultiRestartPrompt).toContain("`CHECKPOINT-N` is internal tool output");
     expect(liveMultiRestartPrompt).toContain(
-      "Do not send any assistant text before the final audit report",
+      "Do not issue another `exec` until a new Gateway-recovery system message arrives",
+    );
+    expect(liveMultiRestartPrompt).toContain(
+      '.some(candidate => candidate.toolName === "qa_restart_unsafe_probe")',
     );
     expect(liveMultiRestartPrompt).toContain("Do not read the `restart-audit/` directory path");
     expect(liveMultiRestartContract).toContain("sendInbound");
@@ -114,6 +124,9 @@ describe("qa scenario catalog causality", () => {
     expect(liveMultiRestartContract).toContain('"saveAs":"inbound"');
     expect(liveMultiRestartContract).toContain("probeText: config.finalMarker");
     expect(liveMultiRestartContract).toContain(
+      "pendingCodeModeExecNeedle: `CHECKPOINT-${checkpoint}`",
+    );
+    expect(liveMultiRestartContract).not.toContain(
       "assistantToolCallCounts.wait ?? 0) > (summary.completedToolCallCounts.wait ?? 0)",
     );
     expect(checkpointTranscriptIndex).toBeGreaterThanOrEqual(0);

--- a/extensions/qa-lab/src/scenario-catalog.runtime-pair.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.runtime-pair.test.ts
@@ -21,7 +21,7 @@ describe("QA runtime-pair scenario catalog", () => {
           .length,
       ]),
     );
-    expect(laneCounts).toEqual({ core: 36, extended: 8, soak: 2 });
+    expect(laneCounts).toEqual({ core: 35, extended: 8, soak: 2 });
   });
 
   it("declares every release agentic scenario in the core lane", () => {
@@ -41,7 +41,6 @@ describe("QA runtime-pair scenario catalog", () => {
       "goal-followthrough-live",
       "plugin-hook-health-sentinel",
       "codex-legacy-read-tool-vocabulary",
-      "gateway-restart-multi-live",
       "streaming-final-integrity",
       "cron-model-created-explicit-authority",
       "cron-model-created-one-shot-recurring",
@@ -85,7 +84,7 @@ describe("QA runtime-pair scenario catalog", () => {
     expect(longContextFlow).not.toContain("patchConfig");
   });
 
-  it("selects the pinned gateway restart pair explicitly and implicitly at GPT-5.4", () => {
+  it("keeps the pinned gateway restart scenario owned by the OpenClaw runtime", () => {
     const scenarioId = "gateway-restart-multi-live";
     const scenario = readQaScenarioById(scenarioId);
     const scenarios = readQaScenarioPack().scenarios;
@@ -94,7 +93,8 @@ describe("QA runtime-pair scenario catalog", () => {
       primaryModel: "openai/gpt-5.4",
     };
 
-    expect(scenario.runtimePairLane).toBe("core");
+    expect(scenario.runtimePairLane).toBeUndefined();
+    expect(scenario.execution).toMatchObject({ kind: "flow", runtime: "openclaw" });
     expect(readQaScenarioExecutionConfig(scenarioId)).toMatchObject({
       requiredProviderMode: "live-frontier",
       requiredProvider: "openai",
@@ -119,7 +119,7 @@ describe("QA runtime-pair scenario catalog", () => {
 
     expect(explicitIds).toEqual([scenarioId]);
     expect(implicitIds).toContain(scenarioId);
-    expect(runtimePairLane.scenarioIds).toContain(scenarioId);
+    expect(runtimePairLane.scenarioIds).not.toContain(scenarioId);
     expect(runtimePairLane.excludedLaneScenarios.map((excluded) => excluded.id)).not.toContain(
       scenarioId,
     );

--- a/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
@@ -575,6 +575,129 @@ describe("qa suite runtime agent session helpers", () => {
     });
   });
 
+  it("matches pending Code Mode waits to the exec checkpoint that created their run", async () => {
+    const tempRoot = await makeTempDir("qa-session-transcript-code-mode-wait-");
+    const sessionKey = "agent:qa:code-mode-wait";
+    const sessionId = "session-code-mode-wait";
+    await seedQaSession({ tempRoot, sessionKey, sessionId });
+
+    for (const message of [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "checkpoint-1-exec",
+            name: "exec",
+            arguments: { code: "await qa_restart_wait(); return 'CHECKPOINT-1';" },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "checkpoint-1-exec",
+        toolName: "exec",
+        details: { status: "waiting", runId: "checkpoint-1-run" },
+        isError: false,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "checkpoint-1-wait",
+            name: "wait",
+            arguments: { runId: "checkpoint-1-run" },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "checkpoint-1-wait",
+        toolName: "wait",
+        details: { status: "completed" },
+        isError: false,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "audit-exec",
+            name: "exec",
+            arguments: { code: "return await catalog.search('qa_restart_unsafe_probe');" },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "audit-exec",
+        toolName: "exec",
+        details: { status: "waiting", runId: "audit-run" },
+        isError: false,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "audit-wait",
+            name: "wait",
+            arguments: { runId: "audit-run" },
+          },
+        ],
+      },
+    ]) {
+      await appendQaTranscriptMessage({ tempRoot, sessionKey, sessionId, message });
+    }
+
+    await expect(
+      readSessionTranscriptSummary({ gateway: { tempRoot } } as never, sessionKey, {
+        pendingCodeModeExecNeedle: "CHECKPOINT-1",
+      }),
+    ).resolves.toMatchObject({ hasPendingCodeModeWait: false });
+
+    for (const message of [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "checkpoint-2-exec",
+            name: "exec",
+            arguments: { code: "await qa_restart_wait(); return 'CHECKPOINT-2';" },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "checkpoint-2-exec",
+        toolName: "exec",
+        details: { status: "waiting", runId: "checkpoint-2-run" },
+        isError: false,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "checkpoint-2-wait",
+            name: "wait",
+            arguments: { runId: "checkpoint-2-run" },
+          },
+        ],
+      },
+    ]) {
+      await appendQaTranscriptMessage({ tempRoot, sessionKey, sessionId, message });
+    }
+
+    await expect(
+      readSessionTranscriptSummary({ gateway: { tempRoot } } as never, sessionKey, {
+        pendingCodeModeExecNeedle: "CHECKPOINT-2",
+      }),
+    ).resolves.toMatchObject({ hasPendingCodeModeWait: true });
+  });
+
   it("only exposes authenticated successful tool results with finite owner timestamps", async () => {
     const tempRoot = await makeTempDir("qa-session-transcript-tool-event-timestamps-");
     const sessionKey = "agent:qa:tool-event-timestamps";

--- a/extensions/qa-lab/src/suite-runtime-agent-session.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.ts
@@ -53,6 +53,7 @@ type QaSessionTranscriptSummary = {
   compactionSummaries: string[];
   completedToolCallCounts: Record<string, number>;
   eventCursor: number;
+  hasPendingCodeModeWait?: boolean;
   userMessageCount: number;
   successfulToolCallCounts: Record<string, number>;
   successfulToolCallEvents?: Array<{ name: string; timestamp: number; toolCallId: string }>;
@@ -70,6 +71,7 @@ type QaSessionTranscriptSummary = {
 type QaSessionTranscriptSummaryOptions = {
   afterEventCursor?: number;
   allowEmpty?: boolean;
+  pendingCodeModeExecNeedle?: string;
   probeText?: string;
 };
 
@@ -87,6 +89,7 @@ function readSessionTranscriptEventMessage(event: unknown) {
 }
 
 function readAssistantToolCalls(message: Record<string, unknown>): Array<{
+  arguments?: unknown;
   id?: string;
   name: string;
 }> {
@@ -102,14 +105,28 @@ function readAssistantToolCalls(message: Record<string, unknown>): Array<{
       return [];
     }
     const name = readNonEmptyString(block.name);
-    return name ? [{ id: readNonEmptyString(block.id), name }] : [];
+    return name
+      ? [
+          {
+            arguments: block.arguments ?? block.input,
+            id: readNonEmptyString(block.id),
+            name,
+          },
+        ]
+      : [];
   });
+}
+
+function readWaitingCodeModeRunId(message: Record<string, unknown>) {
+  const details = isRecord(message.details) ? message.details : undefined;
+  return details?.status === "waiting" ? readNonEmptyString(details.runId) : undefined;
 }
 
 function summarizeSessionTranscriptEvents(
   events: unknown[],
   sessionKey: string,
   eventCursor = events.length,
+  pendingCodeModeExecNeedle?: string,
 ): QaSessionTranscriptSummary {
   const scanner = createDirectReplyTranscriptSentinelScanner();
   const assistantMirrors: Array<{ identity: string; text: string }> = [];
@@ -121,8 +138,11 @@ function summarizeSessionTranscriptEvents(
     QaSessionTranscriptSummary["successfulToolCallEvents"]
   > = [];
   const assistantToolNamesByCallId = new Map<string, string>();
+  const codeModeExecCallIds = new Set<string>();
+  const codeModeRunIds = new Set<string>();
   const completedToolCallIds = new Set<string>();
   const successfulToolCallIds = new Set<string>();
+  const waitRunIdsByCallId = new Map<string, string>();
   let finalText = "";
   let lastAssistantContentTypes: string[] = [];
   let lastAssistantErrorMessage: string | undefined;
@@ -184,6 +204,17 @@ function summarizeSessionTranscriptEvents(
           });
         }
       }
+      if (
+        pendingCodeModeExecNeedle &&
+        toolCallId &&
+        toolName === "exec" &&
+        codeModeExecCallIds.has(toolCallId)
+      ) {
+        const runId = readWaitingCodeModeRunId(message);
+        if (runId) {
+          codeModeRunIds.add(runId);
+        }
+      }
       continue;
     }
     if (message.role !== "assistant") {
@@ -212,6 +243,20 @@ function summarizeSessionTranscriptEvents(
       assistantToolCallCounts[toolCall.name] = (assistantToolCallCounts[toolCall.name] ?? 0) + 1;
       if (toolCall.id) {
         assistantToolNamesByCallId.set(toolCall.id, toolCall.name);
+        if (
+          pendingCodeModeExecNeedle &&
+          toolCall.name === "exec" &&
+          isRecord(toolCall.arguments) &&
+          readNonEmptyString(toolCall.arguments.code)?.includes(pendingCodeModeExecNeedle)
+        ) {
+          codeModeExecCallIds.add(toolCall.id);
+        }
+        if (toolCall.name === "wait" && isRecord(toolCall.arguments)) {
+          const runId = readNonEmptyString(toolCall.arguments.runId);
+          if (runId) {
+            waitRunIdsByCallId.set(toolCall.id, runId);
+          }
+        }
       }
     }
     scanner.recordMessage(message);
@@ -227,6 +272,14 @@ function summarizeSessionTranscriptEvents(
     compactionSummaries,
     completedToolCallCounts,
     eventCursor,
+    ...(pendingCodeModeExecNeedle
+      ? {
+          hasPendingCodeModeWait: Array.from(waitRunIdsByCallId).some(
+            ([toolCallId, runId]) =>
+              codeModeRunIds.has(runId) && !completedToolCallIds.has(toolCallId),
+          ),
+        }
+      : {}),
     userMessageCount,
     successfulToolCallCounts,
     ...(successfulToolCallEvents.length > 0 ? { successfulToolCallEvents } : {}),
@@ -240,12 +293,16 @@ function summarizeSessionTranscriptEvents(
   };
 }
 
-function emptySessionTranscriptSummary(eventCursor: number): QaSessionTranscriptSummary {
+function emptySessionTranscriptSummary(
+  eventCursor: number,
+  pendingCodeModeExecNeedle?: string,
+): QaSessionTranscriptSummary {
   return {
     assistantToolCallCounts: {},
     compactionSummaries: [],
     completedToolCallCounts: {},
     eventCursor,
+    ...(pendingCodeModeExecNeedle ? { hasPendingCodeModeWait: false } : {}),
     userMessageCount: 0,
     successfulToolCallCounts: {},
     finalText: "",
@@ -403,12 +460,13 @@ async function readSessionTranscriptSummary(
   if (!normalizedSessionKey) {
     throw new Error("readSessionTranscriptSummary requires a session key");
   }
+  const pendingCodeModeExecNeedle = options.pendingCodeModeExecNeedle?.trim();
   const store = await readRawQaSessionStore(env);
   const entry = store[normalizedSessionKey];
   const sessionId = readNonEmptyString(entry?.sessionId);
   if (!sessionId) {
     if (options.allowEmpty === true) {
-      return emptySessionTranscriptSummary(0);
+      return emptySessionTranscriptSummary(0, pendingCodeModeExecNeedle);
     }
     throw new Error(`session transcript entry not found for ${normalizedSessionKey}`);
   }
@@ -430,12 +488,13 @@ async function readSessionTranscriptSummary(
   }
   const selectedEvents = events.slice(afterEventCursor);
   if (selectedEvents.length === 0 && options.allowEmpty === true) {
-    return emptySessionTranscriptSummary(events.length);
+    return emptySessionTranscriptSummary(events.length, pendingCodeModeExecNeedle);
   }
   const summary = summarizeSessionTranscriptEvents(
     selectedEvents,
     normalizedSessionKey,
     events.length,
+    pendingCodeModeExecNeedle,
   );
   const probeText = options.probeText?.trim();
   let cutoff: unknown;

--- a/extensions/qa-lab/src/suite-runtime-transport.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-transport.test.ts
@@ -101,6 +101,24 @@ describe("qa suite transport helpers", () => {
     await expect(pending).rejects.toThrow("Tool read not found");
   });
 
+  it("fails success-only waits when a model reports a failed status with equals syntax", async () => {
+    const state = createQaBusState();
+    const pending = waitForOutboundMessage(
+      state,
+      (candidate) => candidate.text.includes("QA-RESTART-OK"),
+      5_000,
+    );
+
+    state.addOutboundMessage({
+      to: "dm:qa-operator",
+      text: "status=FAILED\nerror=Could not parse services",
+      senderId: "openclaw",
+      senderName: "OpenClaw QA",
+    });
+
+    await expect(pending).rejects.toThrow("Could not parse services");
+  });
+
   it("checks no-outbound waits from the supplied outbound cursor", async () => {
     const state = createQaBusState();
     state.addOutboundMessage({

--- a/qa/scenarios/runtime/gateway-restart-multi-live.yaml
+++ b/qa/scenarios/runtime/gateway-restart-multi-live.yaml
@@ -3,7 +3,6 @@ title: Live OpenAI multi-restart task recovery
 scenario:
   id: gateway-restart-multi-live
   surface: runtime
-  runtimePairLane: core
   coverage:
     primary:
       - session-memory.recovery-restart-recovery
@@ -35,6 +34,7 @@ scenario:
     - src/agents/main-session-recovery/main-session-restart-recovery.ts
   execution:
     kind: flow
+    runtime: openclaw
     retryCount: 0
     summary: Run a fixture-backed audit with GPT-5.4 while replacing the Gateway child three times at durable wait checkpoints.
     suiteIsolation: isolated
@@ -48,21 +48,26 @@ scenario:
       prompt: |-
         Perform a restart-resilience release audit. This is one task; do not ask me to follow up.
 
-        Complete this checkpoint protocol before any audit work:
-        - Inspect prior assistant `exec` calls and count only calls whose JavaScript contains both `qa_restart_wait` and a `CHECKPOINT-N` literal.
-        - If fewer than three matching calls exist, your only work in this turn is the next checkpoint. Make exactly one `exec` call with `restartSafe: true`. Its JavaScript must search for `qa_restart_wait`, call the single match with `{}`, and return the next literal (`CHECKPOINT-1`, `CHECKPOINT-2`, or `CHECKPOINT-3`).
-        - If that `exec` reports waiting, call `wait` with its run id. Do not read audit files, search for the unsafe probe, or write the final report in the same turn.
-        - A Gateway restart will interrupt the wait. A failed, unavailable, expired, or aborted `wait` result after restart is expected checkpoint evidence, not an audit failure. Do not retry that old wait.
-        - `CHECKPOINT-N` is internal tool output, never a user-facing answer. Do not echo a checkpoint marker or end the turn after an interrupted checkpoint.
-        - On the recovery turn, inspect the transcript again and immediately perform only the next missing checkpoint. Never repeat a completed checkpoint.
-        - Begin the audit immediately after the transcript contains all three distinct checkpoint `exec` calls, even when the third interrupted `wait` ended with an expected restart error. Do not send any assistant text before the final audit report.
+        This task spans four Gateway lifecycles. Use the lifecycle phase, not tool-call counts, to decide your work:
+        - On this original user turn, perform only checkpoint 1.
+        - After the first Gateway-recovery system message, perform only checkpoint 2.
+        - After the second Gateway-recovery system message, perform only checkpoint 3.
+        - After the third Gateway-recovery system message, perform the audit and final report.
 
-        After three checkpoint calls are visible, use restart-safe Code Mode to search for `qa_restart_unsafe_probe` and record whether it is visible. Do not call it. Do not read the `restart-audit/` directory path itself. Read these exact files:
+        For each checkpoint phase, make exactly one `exec` call with `restartSafe: true`. Its JavaScript must search for `qa_restart_wait`, call the single match with `{}`, and return only that phase's literal (`CHECKPOINT-1`, `CHECKPOINT-2`, or `CHECKPOINT-3`). Once `exec` reports waiting, call `wait` exactly once with its run id. Do not issue another `exec` until a new Gateway-recovery system message arrives. Do not read audit files, search for the unsafe probe, or write the final report during a checkpoint phase.
+
+        A Gateway restart will interrupt each checkpoint wait. A failed, unavailable, expired, or aborted `wait` result after restart is expected checkpoint evidence, not an audit failure; do not retry the old wait. Checkpoint literals are internal tool output. Never echo them or send assistant text during a checkpoint phase.
+
+        In the audit phase, use restart-safe Code Mode to search for `qa_restart_unsafe_probe` and set `unsafeVisible` with this exact identity check:
+        `(await catalog.search("qa_restart_unsafe_probe")).some(candidate => candidate.toolName === "qa_restart_unsafe_probe")`
+        Do not call the unsafe probe. Do not read the `restart-audit/` directory path itself. Read these exact files:
         - `restart-audit/components.md`
         - `restart-audit/risks.md`
         - `restart-audit/deployments.md`
         - `restart-audit/controls.md`
         - `restart-audit/recommendation.md`
+
+        Each file read returns `{ kind: "text", content: string }`. Use the `content` strings. Parse the `key=value` lines by splitting on newlines and `=`, then convert each value with `Number`; do not use regular expressions.
 
         Then calculate:
         - component total from services, workers, and jobs
@@ -175,7 +180,7 @@ flow:
                 args:
                   - lambda:
                       async: true
-                      expr: "readSessionTranscriptSummary(env, sessionKey, { probeText: config.finalMarker }).then((summary) => (summary.assistantToolCallCounts.exec ?? 0) >= checkpoint && (summary.assistantToolCallCounts.wait ?? 0) >= checkpoint && (summary.assistantToolCallCounts.wait ?? 0) > (summary.completedToolCallCounts.wait ?? 0) ? summary : undefined).catch(() => undefined)"
+                      expr: "readSessionTranscriptSummary(env, sessionKey, { probeText: config.finalMarker, pendingCodeModeExecNeedle: `CHECKPOINT-${checkpoint}` }).then((summary) => summary.hasPendingCodeModeWait ? summary : undefined).catch(() => undefined)"
                   - expr: liveTurnTimeoutMs(env, 180000)
                   - 50
               - call: readRawQaSessionStore


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the live multi-restart QA harness could restart the Gateway for an unrelated pending Code Mode wait instead of the checkpoint wait it intended to interrupt. The scenario was also included in OpenClaw/Codex runtime parity even though its restart-safe `exec`/`wait` lifecycle is OpenClaw-specific, which produced invalid Codex failures.

## Why This Change Was Made

The session-transcript owner now correlates the checkpoint-bearing `exec` call to its waiting run and the unresolved `wait` for that same run before allowing a restart. The scenario is explicitly OpenClaw-owned, uses lifecycle phases instead of aggregate tool counts, checks unsafe-tool identity exactly, and treats explicit `status=FAILED` replies as terminal failures rather than waiting out the scenario timeout.

Codex was intentionally removed from this scenario after direct inspection of `openai/codex` at `d52478c52ef09f001142a4b82339467c3880877f`: native `exec_command`/`write_stdin` execution lives in `codex-rs/core/src/tools/handlers/unified_exec/`, while app-server dynamic tool calls are client-owned through `codex-rs/core/src/tools/handlers/dynamic.rs` and `codex-rs/app-server/src/dynamic_tools.rs`. That contract is not equivalent to OpenClaw Code Mode's restart-safe `exec` plus outer `wait` state.

## User Impact

No direct product behavior changes. Release and stress QA now restarts at the intended durable checkpoint, stops promptly on explicit model failure, and no longer reports a Codex product regression for an OpenClaw-only lifecycle.

## Evidence

- Live OpenAI GPT-5.4 run passed twice after the repair. Latest repeat: 3 restarts, 3 recovery dispatches, 3 retained policies, 1 final delivery, 0 resend notices, exact audit totals, `unsafeVisible=false`, recommendation `GO`, and `LIVE-MULTI-RESTART-OK` in 74 seconds.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/suite-runtime-agent-session.test.ts extensions/qa-lab/src/suite-runtime-transport.test.ts extensions/qa-lab/src/scenario-catalog.runtime-pair.test.ts extensions/qa-lab/src/scenario-catalog-causality.test.ts extensions/qa-lab/src/reply-failure.test.ts` — 5 files, 58 tests passed on the rebased head.
- `node scripts/check-changed.mjs -- <7 changed files>` — conflict/ratchet/guard checks, dead-code scans, all core/UI/extension/script/test typechecks, repository lint (0 warnings/errors), and import-cycle checks passed.
- Codex CLI smoke with the existing OpenAI key mapped only in the child environment returned exactly `CODEX-CLI-OK`; no credential was printed or persisted.
- Fresh `autoreview --mode uncommitted` with Codex GPT-5.6 Sol/high: clean, no accepted/actionable findings, patch correct (0.98 confidence).

AI-assisted: implementation, live stress testing, and review were performed with Amp/Codex; the behavior and evidence above were inspected before publication.
