### PR TITLE
refactor(lmstudio): share guided setup connection discovery

### DIFF
--- a/extensions/lmstudio/src/setup.ts
+++ b/extensions/lmstudio/src/setup.ts
@@ -430,38 +430,49 @@ async function discoverLmstudioSetupModels(params: {
   };
 }
 
-/** Read-only local discovery plus a success-gated config proposal for guided setup. */
-export async function prepareAppGuidedLmstudioSetup(
-  ctx: ProviderAppGuidedSetupContext & { modelRef?: string },
-): Promise<ProviderAuthResult | null> {
+async function resolveAppGuidedLmstudioConnection(ctx: ProviderAppGuidedSetupContext) {
   const existingProvider = ctx.config.models?.providers?.[PROVIDER_ID];
   const baseUrl = resolveLmstudioInferenceBase(
     existingProvider?.baseUrl ?? resolveLmstudioSetupDefaultInferenceBaseUrl(ctx.env),
   );
-  let headers: Record<string, string> | undefined;
-  let configuredValue: string | undefined;
   try {
-    headers = await resolveLmstudioProviderHeaders({
+    const headers = await resolveLmstudioProviderHeaders({
       config: ctx.config,
       env: ctx.env,
       headers: existingProvider?.headers,
     });
-    configuredValue = await resolveLmstudioConfiguredApiKey({
+    const configuredValue = await resolveLmstudioConfiguredApiKey({
       config: ctx.config,
       env: ctx.env,
       allowUnresolved: true,
     });
+    const accessValue = configuredValue ?? ctx.env[LMSTUDIO_DEFAULT_API_KEY_ENV_VAR]?.trim();
+    return {
+      existingProvider,
+      accessValue,
+      discoveryRequest: {
+        baseUrl,
+        apiKey: accessValue ?? LMSTUDIO_LOCAL_API_KEY_PLACEHOLDER,
+        ...(headers ? { headers } : {}),
+        timeoutMs: 5000,
+      },
+    };
   } catch {
     return null;
   }
-  const environmentValue = ctx.env[LMSTUDIO_DEFAULT_API_KEY_ENV_VAR]?.trim();
-  const accessValue = configuredValue ?? environmentValue;
-  const setupDiscovery = await discoverLmstudioSetupModels({
-    baseUrl,
-    apiKey: accessValue ?? LMSTUDIO_LOCAL_API_KEY_PLACEHOLDER,
-    ...(headers ? { headers } : {}),
-    timeoutMs: 5000,
-  });
+}
+
+/** Read-only local discovery plus a success-gated config proposal for guided setup. */
+export async function prepareAppGuidedLmstudioSetup(
+  ctx: ProviderAppGuidedSetupContext & { modelRef?: string },
+): Promise<ProviderAuthResult | null> {
+  const connection = await resolveAppGuidedLmstudioConnection(ctx);
+  if (!connection) {
+    return null;
+  }
+  const { existingProvider, accessValue, discoveryRequest } = connection;
+  const { baseUrl, headers } = discoveryRequest;
+  const setupDiscovery = await discoverLmstudioSetupModels(discoveryRequest);
   if ("failure" in setupDiscovery) {
     return null;
   }
@@ -491,14 +502,6 @@ export async function prepareAppGuidedLmstudioSetup(
         })
       ? LMSTUDIO_LOCAL_API_KEY_PLACEHOLDER
       : undefined;
-  const providerAccess = { apiKey: persistedAccess };
-  const providerSetup = {
-    ...providerAccess,
-    existingProvider,
-    baseUrl,
-    headers: existingProvider?.headers,
-    models: setupDiscovery.value.models,
-  };
   return {
     profiles: [],
     defaultModel: `${PROVIDER_ID}/${selectedModelId}`,
@@ -506,7 +509,13 @@ export async function prepareAppGuidedLmstudioSetup(
       models: {
         mode: ctx.config.models?.mode ?? "merge",
         providers: {
-          [PROVIDER_ID]: buildLmstudioSetupProviderConfig(providerSetup),
+          [PROVIDER_ID]: buildLmstudioSetupProviderConfig({
+            existingProvider,
+            baseUrl,
+            apiKey: persistedAccess,
+            headers: existingProvider?.headers,
+            models: setupDiscovery.value.models,
+          }),
         },
       },
     },
@@ -517,35 +526,11 @@ export async function prepareAppGuidedLmstudioSetup(
 export async function detectAppGuidedLmstudioAvailability(
   ctx: ProviderAppGuidedSetupContext,
 ): Promise<boolean> {
-  const existingProvider = ctx.config.models?.providers?.[PROVIDER_ID];
-  const baseUrl = resolveLmstudioInferenceBase(
-    existingProvider?.baseUrl ?? resolveLmstudioSetupDefaultInferenceBaseUrl(ctx.env),
-  );
-  let headers: Record<string, string> | undefined;
-  let configuredValue: string | undefined;
-  try {
-    headers = await resolveLmstudioProviderHeaders({
-      config: ctx.config,
-      env: ctx.env,
-      headers: existingProvider?.headers,
-    });
-    configuredValue = await resolveLmstudioConfiguredApiKey({
-      config: ctx.config,
-      env: ctx.env,
-      allowUnresolved: true,
-    });
-  } catch {
+  const connection = await resolveAppGuidedLmstudioConnection(ctx);
+  if (!connection) {
     return false;
   }
-  const environmentValue = ctx.env[LMSTUDIO_DEFAULT_API_KEY_ENV_VAR]?.trim();
-  const accessValue = configuredValue ?? environmentValue;
-  const discovery = await fetchLmstudioModels({
-    baseUrl,
-    apiKey: accessValue ?? LMSTUDIO_LOCAL_API_KEY_PLACEHOLDER,
-    ...(headers ? { headers } : {}),
-    timeoutMs: 5000,
-  });
-  return discovery.reachable;
+  return (await fetchLmstudioModels(connection.discoveryRequest)).reachable;
 }
 
 /** Interactive LM Studio setup with connectivity and model-availability checks. */


### PR DESCRIPTION
## What Problem This Solves

LM Studio guided setup and its lightweight availability probe independently repeated the same provider endpoint, configured headers, SecretRef, environment-key, local-placeholder, and discovery-request preparation. Keeping those two copies in sync made a deliberately different pair of discovery policies harder to maintain.

## Why This Change Was Made

Share one private, provider-owned guided connection resolver and the exact request it prepares. Keep the two callers responsible for their distinct decisions: availability checks only whether the server is reachable, while guided setup still requires an eligible loaded, tool-capable model with sufficient context before proposing configuration. Remove two pre-existing one-use configuration wrappers in the same owner.

## User Impact

No user-visible behavior changes. Configured and environment-backed authentication, header resolution and failure handling, Docker/default/custom endpoints, persisted configuration, model eligibility, and the number of discovery requests remain unchanged. Production code decreases by 15 lines (+37/-52); no tests, public APIs, configuration, or plugin boundaries change.

## Evidence

- Trusted Linux owner tests: LM Studio setup and registered provider, 2 files and 78 tests passing.
- Trusted Linux full LM Studio plugin suite: 10 files and 207 tests passing.
- Linux scoped formatter and direct linter: clean, zero warnings and zero errors.
- Existing live LM Studio native endpoint returned 14 catalog models and zero loaded LLMs, confirming the real state where availability must remain true while guided setup must not select a model. The observation was read-only; no model was loaded and no server settings were changed.
- Two independent reviews approved the exact final change; mandatory structured autoreview passed with no actionable findings.
- Remote proof: https://github.com/openclaw/openclaw/actions/runs/32937118034
- Exact reviewed head: ac666ac7732181f6f4f1747d1eac36614487b2de.
