### PR TITLE
fix(config): bound nesting depth before Zod strict validation to prevent heap OOM

### DIFF
--- a/src/config/validation-core.ts
+++ b/src/config/validation-core.ts
@@ -44,6 +44,7 @@ import {
   mergeUnsupportedMutableSecretRefIssues,
   withConfigIssuePath,
 } from "./validation-issues.js";
+import { checkConfigNestingDepth } from "./validation-nesting-guard.js";
 import { isBuiltInModelProviderOverlayId } from "./zod-schema.core.js";
 import { OpenClawSchema } from "./zod-schema.js";
 import { McpServerNameSchema, NodeHostMcpServerNameSchema } from "./zod-schema.root-support.js";
@@ -354,6 +355,22 @@ export function validateConfigObjectRaw(
     (issue) => !normalizedMcpServerNameIssueKeys.has(JSON.stringify([issue.path, issue.message])),
   );
   const policyIssues = collectUnsupportedSecretRefPolicyIssues(normalizedRaw);
+  // Guard against pathological nesting before Zod safeParse: strictObject emits
+  // one issue per unknown key at each level, so a deeply-nested input makes Zod
+  // allocate O(n²) path elements and exhausts the heap before error reporting.
+  const nestingCheck = checkConfigNestingDepth(normalizedRaw, "Config");
+  if (!nestingCheck.ok) {
+    return {
+      ok: false,
+      issues: mergeUnsupportedMutableSecretRefIssues(
+        policyIssues,
+        nestingCheck.issues.map((issue) => ({
+          path: issue.path,
+          message: issue.message,
+        })) satisfies ConfigValidationIssue[],
+      ),
+    };
+  }
   const validated = OpenClawSchema.safeParse(normalizedRaw);
   if (!validated.success || mcpServerNameIssues.length > 0) {
     const schemaIssues = validated.success

--- a/src/config/validation-nesting-guard.test.ts
+++ b/src/config/validation-nesting-guard.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_VALIDATION_NESTING_DEPTH,
+  measureConfigNestingDepth,
+  checkConfigNestingDepth,
+} from "./validation-nesting-guard.js";
+import { validateConfigObjectRaw } from "./validation.js";
+
+describe("measureConfigNestingDepth", () => {
+  it("returns 0 for primitives", () => {
+    expect(measureConfigNestingDepth(null)).toBe(0);
+    expect(measureConfigNestingDepth(undefined)).toBe(0);
+    expect(measureConfigNestingDepth("string")).toBe(0);
+    expect(measureConfigNestingDepth(42)).toBe(0);
+  });
+
+  it("returns 1 for a shallow object", () => {
+    expect(measureConfigNestingDepth({})).toBe(1);
+    expect(measureConfigNestingDepth({ a: 1 })).toBe(1);
+  });
+
+  it("returns 1 for a shallow array", () => {
+    expect(measureConfigNestingDepth([])).toBe(1);
+    expect(measureConfigNestingDepth([1, 2, 3])).toBe(1);
+  });
+
+  it("measures nested object depth", () => {
+    expect(measureConfigNestingDepth({ a: { b: { c: 1 } } })).toBe(3);
+  });
+
+  it("measures nested array depth", () => {
+    expect(measureConfigNestingDepth([[[1]]])).toBe(3);
+  });
+
+  it("measures the deepest branch", () => {
+    const value = { shallow: 1, deep: { a: { b: { c: 1 } } } };
+    expect(measureConfigNestingDepth(value)).toBe(4);
+  });
+
+  it("handles deeply-nested input without stack overflow", () => {
+    // 10 000 levels — must not throw RangeError (iterative, not recursive).
+    let value: unknown = 1;
+    for (let i = 0; i < 10_000; i += 1) {
+      value = { a: value };
+    }
+    expect(() => measureConfigNestingDepth(value)).not.toThrow();
+    expect(measureConfigNestingDepth(value)).toBe(10_000);
+  });
+});
+
+describe("checkConfigNestingDepth", () => {
+  it("passes shallow config values", () => {
+    expect(checkConfigNestingDepth({ agents: { entries: {} } }, "Config")).toEqual({ ok: true });
+  });
+
+  it("passes values at the maximum supported depth", () => {
+    let value: unknown = 1;
+    for (let i = 0; i < MAX_VALIDATION_NESTING_DEPTH - 1; i += 1) {
+      value = { a: value };
+    }
+    expect(checkConfigNestingDepth(value, "Config")).toEqual({ ok: true });
+  });
+
+  it("rejects values exceeding the maximum depth", () => {
+    let value: unknown = 1;
+    for (let i = 0; i < MAX_VALIDATION_NESTING_DEPTH + 1; i += 1) {
+      value = { a: value };
+    }
+    const result = checkConfigNestingDepth(value, "Config");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0].message).toContain("maximum supported nesting depth");
+      expect(result.issues[0].message).toContain(String(MAX_VALIDATION_NESTING_DEPTH));
+    }
+  });
+});
+
+describe("validateConfigObjectRaw nesting guard", () => {
+  it("returns a clean validation error for deeply-nested input instead of crashing", () => {
+    // Mirrors the issue #129734 reproduction: a 20 000-level nested object.
+    // Without the guard, Zod strictObject allocates O(n²) issue paths and
+    // exhausts the V8 heap before the error wrapper can run.
+    let value: unknown = 1;
+    for (let i = 0; i < 20_000; i += 1) {
+      value = { a: value };
+    }
+    const result = validateConfigObjectRaw(value);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues.length).toBeGreaterThanOrEqual(1);
+      expect(result.issues[0].message).toContain("maximum supported nesting depth");
+    }
+  });
+
+  it("does not affect normal shallow config validation", () => {
+    const result = validateConfigObjectRaw({ agents: { entries: { main: {} } } });
+    // Shallow configs pass the nesting guard and proceed to normal schema validation.
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/config/validation-nesting-guard.ts
+++ b/src/config/validation-nesting-guard.ts
@@ -1,0 +1,89 @@
+/**
+ * Depth guard for config schema validation.
+ *
+ * `OpenClawSchema` is a Zod `strictObject`, so every unrecognized key at every
+ * nesting level produces a validation issue whose path spans from the root to
+ * that key. A pathologically deep object (e.g. 20 000 levels of `{"a":{…}}`)
+ * makes Zod allocate O(n²) path elements inside `safeParse`, exhausting the V8
+ * heap before the error wrapper can run.
+ *
+ * This guard measures structural depth iteratively (explicit stack, no
+ * recursion) and rejects inputs above `MAX_VALIDATION_NESTING_DEPTH` before
+ * `safeParse` runs. It protects every caller of `validateConfigObjectRaw`,
+ * including paths that receive an already-parsed object and never cross a
+ * raw-text parsing boundary.
+ */
+import { isRecord } from "../utils.js";
+
+/**
+ * Maximum structural nesting depth a config value may have when reaching schema
+ * validation. Real configs rarely exceed 5–6 levels; 64 leaves ample headroom
+ * while keeping Zod issue paths bounded.
+ */
+export const MAX_VALIDATION_NESTING_DEPTH = 64;
+
+/** Error thrown when a config value exceeds the supported nesting depth. */
+export class ConfigValidationNestingError extends Error {
+  constructor(
+    readonly measuredDepth: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ConfigValidationNestingError";
+  }
+}
+
+/**
+ * Measures the maximum structural nesting depth of a parsed value.
+ *
+ * Iterative (explicit stack) so the measurement itself can never recurse or
+ * overflow the stack on pathological input. Primitives have depth 0; a shallow
+ * object or array has depth 1.
+ */
+export function measureConfigNestingDepth(value: unknown): number {
+  let maxDepth = 0;
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 1 }];
+  while (stack.length > 0) {
+    const entry = stack.pop();
+    if (!entry) {
+      continue;
+    }
+    const current = entry.value;
+    if (Array.isArray(current)) {
+      if (entry.depth > maxDepth) {
+        maxDepth = entry.depth;
+      }
+      for (const item of current) {
+        stack.push({ value: item, depth: entry.depth + 1 });
+      }
+    } else if (isRecord(current)) {
+      if (entry.depth > maxDepth) {
+        maxDepth = entry.depth;
+      }
+      for (const child of Object.values(current)) {
+        stack.push({ value: child, depth: entry.depth + 1 });
+      }
+    }
+  }
+  return maxDepth;
+}
+
+/**
+ * Asserts a parsed config value stays within the supported nesting depth.
+ * Returns a typed issue array on violation so callers can fold it into their
+ * existing validation-issue reporting instead of catching an exception.
+ */
+export function checkConfigNestingDepth(
+  value: unknown,
+  label: string,
+): { ok: true } | { ok: false; issues: { path: string; message: string }[] } {
+  const depth = measureConfigNestingDepth(value);
+  if (depth <= MAX_VALIDATION_NESTING_DEPTH) {
+    return { ok: true };
+  }
+  const message = `${label} exceeds the maximum supported nesting depth of ${MAX_VALIDATION_NESTING_DEPTH} (measured ${depth} levels)`;
+  return {
+    ok: false,
+    issues: [{ path: "", message }],
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

A deeply nested object supplied to `config patch --file <file> --dry-run` crashes the process with **JavaScript heap out of memory** (`FATAL ERROR: Reached heap limit Allocation failed`, exit `134` / `SIGABRT`) instead of returning the documented `Unrecognized key` validation error.

`OpenClawSchema` is a Zod `strictObject`, so every unrecognized key at every nesting level produces a validation issue whose path spans from root to that key. A pathologically deep object (e.g. 20 000 levels of `{"a":{…}}`) makes Zod allocate O(n²) path elements inside `safeParse`, exhausting the V8 heap (~2 GB) before the error wrapper can run.

## Why This Change Was Made

The fix adds an iterative depth guard (`measureConfigNestingDepth`) that runs **before** `OpenClawSchema.safeParse` in `validateConfigObjectRaw`. Inputs exceeding `MAX_VALIDATION_NESTING_DEPTH = 64` get a clean `Config exceeds the maximum supported nesting depth` validation error instead of crashing the process.

The guard is iterative (explicit stack, no recursion) so measuring pathological input can never itself overflow the stack. Real configs rarely exceed 5–6 levels; 64 leaves ample headroom while keeping Zod issue paths bounded.

This complements #129324 (which guards the raw-text parsing boundary with `parseJsonWithNestingGuard`) by protecting the **shared schema-validation boundary** in `validateConfigObjectRaw`. All callers of `validateConfigObjectRaw` are covered, including paths that receive an already-parsed object and never cross a raw-text parse site (e.g. `doctor` automatic-upgrade-config-repair, gateway config RPC validation, config write validation).

## User Impact

Before: `openclaw config patch --file deep.json --dry-run` with a deeply-nested input crashes with `SIGABRT` (exit `134`) and no error message.

After: the same input returns a clean, wrapped validation error:

```
Config exceeds the maximum supported nesting depth of 64 (measured 20000 levels)
```

The process stays alive and exits with a normal non-zero code. Normal shallow configs are unaffected.

## Evidence

**Unit tests (12/12 passed):**
```
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

**Regression tests (91/91 passed — schema + validation policy + nesting guard):**
```
 Test Files  3 passed (3)
      Tests  91 passed (91)
```

**Lint + format check:**
```
$ oxlint src/config/validation-nesting-guard.ts src/config/validation-nesting-guard.test.ts src/config/validation-core.ts
(exit 0, no issues)

$ oxfmt --check src/config/validation-nesting-guard.ts src/config/validation-nesting-guard.test.ts src/config/validation-core.ts
All matched files use the correct format.
```

**Real behavior proof:**
```
$ node --import tsx /tmp/proof-129734.ts
=== Issue #129734 proof ===
Input: 20000-level nested {a:{a:...}} object
MAX_VALIDATION_NESTING_DEPTH = 64

[After fix] Calling validateConfigObjectRaw on deeply-nested input...
Result: ok=false
Issues: 1
First issue: path="" message="Config exceeds the maximum supported nesting depth of 64 (measured 20000 levels)"
Heap delta: 2.7 MB (bounded — no OOM)

[Regression check] Normal shallow config still validates...
Result: ok=true

=== Proof complete: no heap OOM, clean validation error returned ===
```

## Review
- Manually reviewed and verified
- AI-assisted: Yes
- Fixes #129734
