### PR TITLE
fix(macos): show recovery steps when the Gateway service fails

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -302,11 +302,6 @@ extension GatewayLaunchAgentManager {
         let message: String?
     }
 
-    private struct ParsedDaemonJson {
-        let text: String
-        let object: [String: Any]
-    }
-
     private static func runDaemonCommand(
         _ args: [String],
         timeout: Double = Self.startupMigrationTolerance,
@@ -335,12 +330,13 @@ extension GatewayLaunchAgentManager {
                     self.testingDaemonStatusPayloads.removeFirst()
                 }
             } else {
-                "{\"ok\":true}"
+                self.testingDaemonStatusPayload ?? "{\"ok\":true}"
             }
+            let parsed = JSONObjectExtractionSupport.extract(from: payload)
             return CommandResult(
-                success: true,
+                success: (parsed?.object["ok"] as? Bool) ?? true,
                 payload: Data(payload.utf8),
-                message: nil)
+                message: parsed?.message)
         }
         if ProcessInfo.processInfo.isRunningTests {
             return CommandResult(
@@ -357,9 +353,10 @@ extension GatewayLaunchAgentManager {
         var env = ProcessInfo.processInfo.environment
         env["PATH"] = CommandResolver.preferredPaths().joined(separator: ":")
         let response = await ShellExecutor.runDetailed(command: command, cwd: nil, env: env, timeout: timeout)
-        let parsed = self.parseDaemonJson(from: response.stdout) ?? self.parseDaemonJson(from: response.stderr)
+        let parsed = JSONObjectExtractionSupport.extract(from: response.stdout)
+            ?? JSONObjectExtractionSupport.extract(from: response.stderr)
         let ok = parsed?.object["ok"] as? Bool
-        let message = (parsed?.object["error"] as? String) ?? (parsed?.object["message"] as? String)
+        let message = parsed?.message
         let payload = parsed?.text.data(using: .utf8)
             ?? (response.stdout.isEmpty ? response.stderr : response.stdout).data(using: .utf8)
         let success = response.success && (ok ?? true)
@@ -382,11 +379,6 @@ extension GatewayLaunchAgentManager {
     private static func withJsonFlag(_ args: [String]) -> [String] {
         if args.contains("--json") { return args }
         return args + ["--json"]
-    }
-
-    private static func parseDaemonJson(from raw: String) -> ParsedDaemonJson? {
-        guard let parsed = JSONObjectExtractionSupport.extract(from: raw) else { return nil }
-        return ParsedDaemonJson(text: parsed.text, object: parsed.object)
     }
 
     private static func summarize(_ text: String) -> String? {

--- a/apps/macos/Sources/OpenClaw/JSONObjectExtractionSupport.swift
+++ b/apps/macos/Sources/OpenClaw/JSONObjectExtractionSupport.swift
@@ -1,7 +1,18 @@
 import Foundation
 
 enum JSONObjectExtractionSupport {
-    static func extract(from raw: String) -> (text: String, object: [String: Any])? {
+    struct ExtractedObject {
+        let text: String
+        let object: [String: Any]
+
+        var message: String? {
+            JSONObjectExtractionSupport.mergeHints(
+                message: (self.object["error"] as? String) ?? (self.object["message"] as? String),
+                hints: (self.object["hints"] as? [String]) ?? [])
+        }
+    }
+
+    static func extract(from raw: String) -> ExtractedObject? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let start = trimmed.firstIndex(of: "{"),
               let end = trimmed.lastIndex(of: "}")
@@ -11,6 +22,17 @@ enum JSONObjectExtractionSupport {
         let jsonText = String(trimmed[start...end])
         guard let data = jsonText.data(using: .utf8) else { return nil }
         guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
-        return (jsonText, object)
+        return ExtractedObject(text: jsonText, object: object)
+    }
+
+    static func mergeHints(message: String?, hints: [String]) -> String? {
+        let trimmed = message?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let nonEmpty = trimmed?.isEmpty == false ? trimmed : nil
+        guard !hints.isEmpty else { return nonEmpty }
+        let hintText = hints.prefix(2).joined(separator: " · ")
+        if let nonEmpty {
+            return "\(nonEmpty) (\(hintText))"
+        }
+        return hintText
     }
 }

--- a/apps/macos/Sources/OpenClaw/NodeServiceManager.swift
+++ b/apps/macos/Sources/OpenClaw/NodeServiceManager.swift
@@ -149,13 +149,13 @@ extension NodeServiceManager {
     private static func errorMessage(from result: CommandResult, treatNotLoadedAsError: Bool) -> String? {
         if !result.success {
             return result.parsed.flatMap {
-                self.mergeHints(message: $0.error ?? $0.message, hints: $0.hints)
+                JSONObjectExtractionSupport.mergeHints(message: $0.error ?? $0.message, hints: $0.hints)
             } ?? result.message ?? "Node service command failed"
         }
         guard let parsed = result.parsed else { return nil }
         if treatNotLoadedAsError, parsed.result == "not-loaded" {
             let base = parsed.message ?? "Node service not loaded."
-            return self.mergeHints(message: base, hints: parsed.hints)
+            return JSONObjectExtractionSupport.mergeHints(message: base, hints: parsed.hints)
         }
         return nil
     }
@@ -182,17 +182,6 @@ extension NodeServiceManager {
             message: message,
             error: error,
             hints: hints)
-    }
-
-    private static func mergeHints(message: String?, hints: [String]) -> String? {
-        let trimmed = message?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let nonEmpty = trimmed?.isEmpty == false ? trimmed : nil
-        guard !hints.isEmpty else { return nonEmpty }
-        let hintText = hints.prefix(2).joined(separator: " · ")
-        if let nonEmpty {
-            return "\(nonEmpty) (\(hintText))"
-        }
-        return hintText
     }
 
     private static func launchdProgramArguments(

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -224,6 +224,46 @@ struct GatewayLaunchAgentManagerTests {
         }
     }
 
+    @Test(arguments: ["failure-with-hints", "failure-hints-only", "failure-without-hints", "success"])
+    func `gateway daemon failures preserve actionable recovery hints`(_ scenario: String) async {
+        await TestIsolation.withIsolatedState {
+            let marker = FileManager.default.temporaryDirectory
+                .appendingPathComponent("openclaw-no-disable-marker-\(UUID().uuidString)")
+            defer {
+                GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(nil)
+                GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+                GatewayLaunchAgentManager.setTestingDaemonStatusPayload(nil)
+            }
+
+            let payload = switch scenario {
+            case "failure-with-hints":
+                """
+                {"ok":false,"error":"Gateway service not installed.",
+                "hints":["openclaw gateway install","openclaw gateway start","third hint"]}
+                """
+            case "failure-hints-only":
+                #"{"ok":false,"hints":["openclaw gateway install","openclaw gateway start"]}"#
+            case "failure-without-hints":
+                #"{"ok":false,"error":"Gateway service not installed."}"#
+            default:
+                #"{"ok":true,"message":"Gateway already started."}"#
+            }
+            let expected: String? = switch scenario {
+            case "failure-with-hints":
+                "Gateway service not installed. (openclaw gateway install · openclaw gateway start)"
+            case "failure-hints-only": "openclaw gateway install · openclaw gateway start"
+            case "failure-without-hints": "Gateway service not installed."
+            default: nil
+            }
+
+            GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(marker)
+            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
+            GatewayLaunchAgentManager.setTestingDaemonStatusPayload(payload)
+
+            #expect(await GatewayLaunchAgentManager.kickstart() == expected)
+        }
+    }
+
     @Test func `launch agent plist snapshot parses args and env`() throws {
         let url = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-launchd-\(UUID().uuidString).plist")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users starting or repairing a local Gateway would see a generic service failure without the actionable install and start commands that the Gateway CLI had already provided.

## Why This Change Was Made

Gateway and node service failures now share the same bounded recovery-hint formatting at their existing native JSON owner. This removes the redundant Gateway parser and duplicate node formatter while preserving process-exit precedence, existing service interception, and fail-closed tests.

The existing post-update local activation path independently discards its failure reason; that separate downstream issue is not claimed as fixed here.

## User Impact

Failed Gateway startup and managed Gateway restart now explain how to recover, for example: `Gateway service not installed. (openclaw gateway install · openclaw gateway start)`. Hint-only failures also remain actionable, while successful operations and generic failures retain their existing behavior.

## Evidence

- Authentic pre-fix regression through `GatewayLaunchAgentManager.kickstart()`: both CLI error-with-hints and hint-only cases failed; generic-failure and success controls passed.
- After the repair, 144 native tests across seven Gateway, node, installer, onboarding, connection-mode, and update suites passed:

  ```sh
  DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path apps/macos --filter 'OpenClawIPCTests\.(GatewayLaunchAgentManagerTests|NodeServiceManagerTests|GatewayProcessManagerTests|CLIInstallerTests|UpdateOrchestrationTests|OnboardingViewSmokeTests|ConnectionModeCoordinatorTests)' --no-parallel -j 4
  ```

- Strict SwiftLint: zero violations; SwiftFormat lint: clean; native-app i18n verification: clean.
- Independent owner-boundary review and configured structured Codex review both found no actionable issues.
- Production delta: +33/-30 (net +3), justified by one shared normalized service-result owner; regression coverage: +40 lines.
- Live installed-app screenshots are unavailable because reproducing this state would mutate the operator-owned Gateway LaunchAgent or launch the installed app; the actual native service boundary is exercised through its existing explicitly intercepted fixture without touching live services.
