### PR TITLE
fix(reply): stop advertising unavailable media messaging tools

### DIFF
--- a/src/agents/sessions/exec.real.test.ts
+++ b/src/agents/sessions/exec.real.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
@@ -62,14 +62,14 @@ describe("execCommand process-tree cleanup", () => {
     const resultPromise = execCommand(process.execPath, ["-e", parentScript], process.cwd(), {
       timeout: 1_000,
     });
-    await vi.waitFor(() => expect(existsSync(readyPath)).toBe(true), {
-      timeout: 3_000,
-      interval: 25,
-    });
-    const { parentPid, childPid } = JSON.parse(readFileSync(readyPath, "utf8")) as {
-      parentPid: number;
-      childPid: number;
-    };
+    const { parentPid, childPid } = await vi.waitFor(
+      () =>
+        JSON.parse(readFileSync(readyPath, "utf8")) as {
+          parentPid: number;
+          childPid: number;
+        },
+      { timeout: 3_000, interval: 25 },
+    );
     cleanupPids.add(parentPid);
     cleanupPids.add(childPid);
 

--- a/src/auto-reply/reply.media-note.test.ts
+++ b/src/auto-reply/reply.media-note.test.ts
@@ -22,6 +22,7 @@ describe("getReplyFromConfig media note plumbing", () => {
       isBareSessionReset: false,
       startupAction: "new",
       prefixedBody: sessionCtx.BodyForAgent,
+      sourceReplyDeliveryMode: "automatic",
     });
     const prompt = envelope.prefixedCommandBody;
 
@@ -30,11 +31,11 @@ describe("getReplyFromConfig media note plumbing", () => {
       "[media attached 1/2: /tmp/a.png (application/octet-stream)]",
       "[media attached 2/2: /tmp/b.png (application/octet-stream)]",
     ].join("\n");
-    const replyHint =
-      "To send an image back, use the message tool with structured media fields such as media, mediaUrl, path, or filePath. Keep caption in the text body.";
-    expect(prompt).toBe(`${mediaNote}\n${replyHint}\nhello`);
-    expect(envelope.queuedBody).toBe(`${mediaNote}\n${replyHint}\nhello`);
+    expect(prompt).toBe(`${mediaNote}\nhello`);
+    expect(envelope.queuedBody).toBe(`${mediaNote}\nhello`);
     expect(envelope.transcriptCommandBody).toBe(`${mediaNote}\nhello`);
+    expect(prompt).not.toContain("message tool");
+    expect(envelope.queuedBody).not.toContain("message tool");
     expect(envelope.media?.map(({ path }) => path)).toEqual(["/tmp/a.png", "/tmp/b.png"]);
     const idxA = prompt.indexOf("[media attached 1/2: /tmp/a.png");
     const idxB = prompt.indexOf("[media attached 2/2: /tmp/b.png");

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -12,8 +12,6 @@ import { buildInboundMediaNoteProjection } from "../media-note.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import { appendChannelPromptContext } from "./channel-prompt-context.js";
 
-const REPLY_MEDIA_HINT =
-  "To send an image back, use the message tool with structured media fields such as media, mediaUrl, path, or filePath. Keep caption in the text body.";
 const ROOM_EVENT_PROMPT = "[OpenClaw room event]";
 const RESUMABLE_ROOM_CONTEXT_OMITTED_PREFIXES = [
   "Conversation context (chronological, selected for current message):",
@@ -34,7 +32,6 @@ function buildReplyPromptBodies(params: {
   media?: readonly MediaFact[];
 }): {
   mediaNote?: string;
-  mediaReplyHint?: string;
   media?: MediaFact[];
   prefixedCommandBody: string;
   queuedBody: string;
@@ -56,12 +53,11 @@ function buildReplyPromptBodies(params: {
   const generatedMedia = buildInboundMediaNoteProjection(params.ctx);
   const mediaNote = generatedMedia.text;
   const media = [...generatedMedia.media, ...normalizeMediaFacts(params.media)];
-  const mediaReplyHint = mediaNote ? REPLY_MEDIA_HINT : undefined;
   const queuedBodyRaw = mediaNote
-    ? [mediaNote, mediaReplyHint, queueBodyBase].filter(Boolean).join("\n").trim()
+    ? [mediaNote, queueBodyBase].filter(Boolean).join("\n").trim()
     : queueBodyBase;
   const prefixedCommandBodyRaw = mediaNote
-    ? [mediaNote, mediaReplyHint, prefixedBody].filter(Boolean).join("\n").trim()
+    ? [mediaNote, prefixedBody].filter(Boolean).join("\n").trim()
     : prefixedBody;
   const transcriptBody = params.transcriptBody ?? params.effectiveBaseBody;
   const includeMediaTranscript = mediaNote && params.inboundEventKind !== "room_event";
@@ -74,7 +70,6 @@ function buildReplyPromptBodies(params: {
       : "";
   return {
     mediaNote,
-    mediaReplyHint,
     ...(media.length > 0 ? { media } : {}),
     prefixedCommandBody: annotateInterSessionPromptText(
       prefixedCommandBodyRaw,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending an image or other attachment could receive no useful response because the model was instructed to use a message tool that was not available. Even when that tool was enabled, the same obsolete instruction suggested attachment parameter names that the actual tool schema does not accept.

## Why This Change Was Made

The inbound-reply envelope unconditionally duplicated outdated delivery instructions in both active and queued prompts. Removing that redundant hint lets the existing canonical system prompt provide the correct guidance from the final available tool set and selected delivery mode: automatic replies use their normal media directive, while message-tool-only replies receive their existing structured attachment instructions. Attachment facts, queued prompts, transcripts, room events, and legitimate delivery-mode directives remain unchanged.

## User Impact

Models no longer attempt unavailable messaging tools or unsupported attachment fields merely because an inbound message contains media. Image and attachment replies follow the existing supported delivery path without losing the original attachment note or media metadata.

## Evidence

Actual composed production behavior before the fix, with only the read tool available:

```json
{"systemGuidesAutomaticMedia":true,"systemExposesMessageTool":false,"activePromptMentionsDeniedMessageTool":true,"queuedPromptMentionsDeniedMessageTool":true}
```

The same actual inbound-context, reply-envelope, and system-prompt composition after the fix:

```json
{"systemGuidesAutomaticMedia":true,"systemExposesMessageTool":false,"activePromptMentionsDeniedMessageTool":false,"queuedPromptMentionsDeniedMessageTool":false,"activeMediaFactPreserved":true,"queuedMediaFactPreserved":true,"transcriptMediaFactPreserved":true}
```

The updated existing owner regression fails against the original code and passes after the deletion. Relevant reply-envelope, group-context, and automatic/message-tool-only system-prompt siblings all pass:

```text
$ node scripts/run-vitest.mjs src/agents/sessions/exec.real.test.ts src/auto-reply/reply.media-note.test.ts src/auto-reply/reply/prompt-prelude.test.ts src/auto-reply/reply/groups.test.ts src/agents/system-prompt.test.ts
Test Files  5 passed (5)
Tests       147 passed (147)
```

Exact core lint also passes. Production change: +2/-7 lines (net -5); existing owner regression: +5/-4 lines.

Hosted CI also exposed an existing race in the real process-tree cleanup test: waiting only for the readiness file to exist can observe the file after creation but before its JSON contents have been written. The test now waits for a successfully parsed readiness payload using its existing timeout and interval, preserving every process-liveness assertion without adding sleeps or weakening coverage. Its actual process-tree test also passed two additional independent focused runs.

Follow-up: review the separate automatic group-context attachment instruction at its own group-context owner; this change intentionally stays scoped to the shared inbound-reply envelope.
