### PR TITLE
fix(github-copilot): recover sessions after encrypted reasoning stream failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **GitHub Copilot reasoning recovery:** recover rejected encrypted reasoning during streamed Responses before any visible output, preserve valid compaction history, and prevent poisoned follow-up turns. Fixes #124465.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/extensions/github-copilot/connection-bound-ids.live.test.ts
+++ b/extensions/github-copilot/connection-bound-ids.live.test.ts
@@ -106,6 +106,16 @@ function buildReplayAssistantMessage(connectionBoundId: string): AssistantMessag
     timestamp: Date.now() - 1,
     content: [
       {
+        type: "thinking",
+        thinking: "Earlier assistant reasoning.",
+        thinkingSignature: JSON.stringify({
+          type: "reasoning",
+          id: "rs_live_replay",
+          encrypted_content: "intentionally-invalid-replay-ciphertext",
+          summary: [{ type: "summary_text", text: "Earlier assistant reasoning." }],
+        }),
+      },
+      {
         type: "text",
         text: "Earlier assistant text.",
         textSignature: JSON.stringify({ v: 1, id: connectionBoundId }),
@@ -205,6 +215,7 @@ describeLive("github-copilot connection-bound Responses IDs live", () => {
       {
         apiKey: token.apiKey,
         maxTokens: 256,
+        replayResponsesItemIds: true,
         onPayload: (payload: unknown) => {
           capturedPayload = {
             ...(payload as Record<string, unknown>),
@@ -219,6 +230,12 @@ describeLive("github-copilot connection-bound Responses IDs live", () => {
     const result = (await stream.result()) as AssistantMessage;
     logProgress("tool-call Responses request completed");
     const input = Array.isArray(capturedPayload?.input) ? capturedPayload.input : [];
+    const replayedReasoning = input.find(
+      (item): item is Record<string, unknown> =>
+        Boolean(item) &&
+        typeof item === "object" &&
+        (item as Record<string, unknown>).type === "reasoning",
+    );
     const replayedAssistant = input.find(
       (item): item is Record<string, unknown> =>
         Boolean(item) &&
@@ -226,6 +243,8 @@ describeLive("github-copilot connection-bound Responses IDs live", () => {
         (item as Record<string, unknown>).type === "message",
     );
 
+    expect(replayedReasoning?.id).toBe("rs_live_replay");
+    expect(replayedReasoning).not.toHaveProperty("encrypted_content");
     expect(replayedAssistant?.id).toMatch(/^msg_[a-f0-9]{16}$/);
     expect(replayedAssistant?.id).not.toBe(staleId);
     const toolCall = result.content.find((block) => block.type === "toolCall");

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -50,6 +50,7 @@ import { createResponsesPromptEgressObserver } from "./openai-responses-prompt-o
 import {
   createOpenAIResponsesAssistantOutput,
   createResponsesStreamWithEncryptedContentRetry,
+  drainResponsesStreamWithEncryptedContentRetry,
   isInvalidEncryptedContentError,
   resolveNextResponsesEncryptedContentAttempt,
   resolveAzureOpenAIApiVersion,
@@ -58,7 +59,7 @@ import { processResponsesStream } from "./openai-responses-stream-internal.js";
 import { observeResponsesStream } from "./openai-responses-stream-observer-internal.js";
 import {
   createOpenAIResponsesWebSocketStream,
-  type OpenAIResponsesWebSocketMode,
+  resolveNativeOpenAIResponsesWebSocketMode,
   supportsNativeOpenAIResponsesEndpoint,
 } from "./openai-responses-websocket.js";
 import {
@@ -82,25 +83,6 @@ import {
   withProviderResponseHook,
 } from "./transport-stream-shared.js";
 import { redactIdentifier } from "./transport-utils.js";
-
-function resolveNativeOpenAIResponsesWebSocketMode(
-  model: Model,
-  transport: OpenAIResponsesOptions["transport"],
-): OpenAIResponsesWebSocketMode | undefined {
-  if (transport !== "websocket" && transport !== "websocket-cached" && transport !== "auto") {
-    return undefined;
-  }
-  if (getAiTransportHost().requiresManagedTransport(model)) {
-    return undefined;
-  }
-  return supportsNativeOpenAIResponsesEndpoint({
-    provider: model.provider,
-    api: model.api,
-    baseUrl: model.baseUrl,
-  })
-    ? transport
-    : undefined;
-}
 
 function combineWebSocketTimeoutSignal(
   signal: AbortSignal,
@@ -419,6 +401,9 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             `apiKey=${apiKey ? "present" : "missing"} ${summarizeResponsesPayload(params)}`,
         );
         let continuationBaseline: ResponsesContinuationRequest | undefined;
+        let responseAttempt: Awaited<
+          ReturnType<ResponsesTransportExecutorOptions["createResponseStream"]>
+        >["attempt"];
         const createSseStream = async (
           initialRequest = (continuationClaim?.request ?? params) as typeof params,
           initialAttemptKind: NonNullable<ResponsesStreamParams["initialAttemptKind"]> = "initial",
@@ -440,6 +425,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             onCompactionRejected: (checkpoint) =>
               suppressOpenAIResponsesCompaction(output, model, responsesOptions, checkpoint),
           });
+          responseAttempt = attempt;
           if (continuationClaim) {
             continuationBaseline = attempt.request.previous_response_id
               ? (params as ResponsesContinuationRequest)
@@ -489,6 +475,11 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
               degradeCooldownMs: websocketSessionPolicy?.degradeCooldownMs,
             });
             finishWebSocket = websocket.finish;
+            responseAttempt = {
+              kind: "initial",
+              // WebSocket sanitization removes `stream`; SSE recovery must restore it.
+              request: { ...websocket.request, stream: true } as typeof params,
+            };
             observePrompt?.(websocket.request, {
               egress: "responses-websocket",
               payloadVariant: "initial",
@@ -523,15 +514,9 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
                     // semantic attempt instead of treating this like an ambiguous disconnect.
                     const encryptedContentRejected = isInvalidEncryptedContentError(error);
                     const recovery = encryptedContentRejected
-                      ? await resolveNextResponsesEncryptedContentAttempt(
-                          {
-                            kind: "initial",
-                            // WebSocket sanitization removes `stream`; SSE must restore it.
-                            request: { ...websocket.request, stream: true } as typeof params,
-                          },
-                          error,
-                          { buildFullHistoryRequest: () => buildRequest("full-history") },
-                        )
+                      ? await resolveNextResponsesEncryptedContentAttempt(responseAttempt, error, {
+                          buildFullHistoryRequest: () => buildRequest("full-history"),
+                        })
                       : undefined;
                     if (encryptedContentRejected && !recovery) {
                       throw error;
@@ -566,17 +551,38 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           responseStream = await createSseStream();
         }
         try {
-          const terminal = await processResponsesStream(responseStream, output, stream, model, {
-            ...config.pricingOptions?.(responsesOptions, model),
-            firstEventTimeoutMs:
-              getFirstStreamEventTimeoutMs(options) ?? config.firstEventTimeoutMs,
-            abortFirstEventStream: firstEvent.abort,
-            onFirstEventTimeout: getFirstStreamEventTimeoutHandler(options),
+          const terminal = await drainResponsesStreamWithEncryptedContentRetry({
+            stream: responseStream,
+            attempt: responseAttempt,
+            output,
             signal: options?.signal,
-            reasoningReplayMetadata: buildOpenAIResponsesReasoningReplayMetadata(model, {
-              authProfileId: responsesOptions?.authProfileId,
-              sessionId: options?.sessionId,
-            }),
+            buildFullHistoryRequest: () => buildRequest("full-history"),
+            processStream: (candidate) =>
+              processResponsesStream(candidate, output, stream, model, {
+                ...config.pricingOptions?.(responsesOptions, model),
+                firstEventTimeoutMs:
+                  getFirstStreamEventTimeoutMs(options) ?? config.firstEventTimeoutMs,
+                abortFirstEventStream: firstEvent.abort,
+                onFirstEventTimeout: getFirstStreamEventTimeoutHandler(options),
+                signal: options?.signal,
+                reasoningReplayMetadata: buildOpenAIResponsesReasoningReplayMetadata(model, {
+                  authProfileId: responsesOptions?.authProfileId,
+                  sessionId: options?.sessionId,
+                }),
+              }),
+            createStream: async (attempt) => {
+              finishWebSocket?.({ keep: false });
+              finishWebSocket = undefined;
+              transport = "sse";
+              return {
+                stream: await createSseStream(
+                  attempt.request,
+                  attempt.kind,
+                  attempt.rejectedCompaction,
+                ),
+                attempt: responseAttempt,
+              };
+            },
           });
           finishWebSocket?.();
           if (options?.signal?.aborted) {

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -403,7 +403,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
         let continuationBaseline: ResponsesContinuationRequest | undefined;
         let responseAttempt: Awaited<
           ReturnType<ResponsesTransportExecutorOptions["createResponseStream"]>
-        >["attempt"];
+        >["attempt"] = { kind: "initial", request: params };
         const createSseStream = async (
           initialRequest = (continuationClaim?.request ?? params) as typeof params,
           initialAttemptKind: NonNullable<ResponsesStreamParams["initialAttemptKind"]> = "initial",

--- a/packages/ai/src/transports/openai-responses-debug.ts
+++ b/packages/ai/src/transports/openai-responses-debug.ts
@@ -457,6 +457,8 @@ export function normalizeResponsesFailedEvent(
 }
 
 export class ResponsesStreamFailure extends Error {
+  readonly code?: string;
+  readonly status?: number;
   readonly responseId?: string;
   readonly response: unknown;
   readonly observation: ReturnType<typeof normalizeResponsesFailedEvent>["observation"];
@@ -464,6 +466,15 @@ export class ResponsesStreamFailure extends Error {
   constructor(failure: ReturnType<typeof normalizeResponsesFailedEvent>, response: unknown) {
     super(failure.message);
     this.name = "ResponsesStreamFailure";
+    const providerError =
+      isRecord(response) && isRecord(response.error) ? response.error : undefined;
+    const code = providerError && readResponseFailedString(providerError, "code").trim();
+    if (code) {
+      this.code = code;
+    }
+    if (typeof providerError?.status === "number") {
+      this.status = providerError.status;
+    }
     this.responseId = failure.responseId;
     this.response = response;
     this.observation = failure.observation;

--- a/packages/ai/src/transports/openai-responses-prompt-observer.test-support.ts
+++ b/packages/ai/src/transports/openai-responses-prompt-observer.test-support.ts
@@ -1,0 +1,26 @@
+export function rejectedSdkStream(
+  error: { message: string; code?: string; status?: number },
+  options?: { events?: unknown[]; nestedErrorEvent?: boolean },
+): { data: AsyncIterable<unknown>; response: Response } {
+  return {
+    data: (async function* () {
+      yield* options?.events ?? [];
+      if (options?.nestedErrorEvent) {
+        yield { type: "error", error };
+        return;
+      }
+      yield {
+        type: "response.failed",
+        response: {
+          id: "resp_rejected",
+          status: "failed",
+          model: "rejected-model",
+          error,
+          output: [],
+          usage: { input_tokens: 99, output_tokens: 0, total_tokens: 99 },
+        },
+      };
+    })(),
+    response: new Response(null, { status: 200 }),
+  };
+}

--- a/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
+++ b/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
@@ -16,6 +16,7 @@ import {
   captureOpenAIResponsesCompaction,
 } from "./openai-responses-compaction-replay.js";
 import { OPENAI_RESPONSES_REASONING_REPLAY_META_KEY } from "./openai-responses-contracts.js";
+import { rejectedSdkStream } from "./openai-responses-prompt-observer.test-support.js";
 
 type SdkResponse = { data: AsyncIterable<unknown>; response: Response };
 const SDK_FULL_HISTORY_PREFIX = "full history before compaction";
@@ -456,6 +457,173 @@ describe("OpenAI Responses provider prompt observer", () => {
     expect(JSON.stringify(sdkState.requests[2]?.input)).not.toContain(SDK_REASONING_CIPHERTEXT);
     expect(onPayload).toHaveBeenCalledTimes(2);
     expect(onCompactionRejected).toHaveBeenCalledOnce();
+  });
+
+  it("recovers a code-less Copilot replay rejection while draining one assistant lifecycle", async () => {
+    const identity = { sessionId: "copilot-recovery-session", authProfileId: "copilot-profile" };
+    const model = createModel({
+      provider: "github-copilot",
+      baseUrl: "https://api.individual.githubcopilot.com",
+    });
+    const context = createCompactionContext(model, identity, true);
+    const observations: ResponsesPromptObservation[] = [];
+    const options = { apiKey: "test-key", ...identity };
+    responsesPromptObserver.set(options, (observation) => observations.push(observation));
+    sdkState.outcomes = [
+      rejectedSdkStream({
+        message:
+          "The encrypted content could not be verified. Reason: Encrypted content could not be decrypted or parsed.",
+      }),
+      completedSdkResponse("resp_copilot_recovered"),
+    ];
+
+    const stream = await Promise.resolve(
+      createOpenAIResponsesTransportStreamFn()(model, context, options as never),
+    );
+    const events: string[] = [];
+    for await (const event of stream) {
+      events.push(event.type);
+    }
+    const recovered = await stream.result();
+
+    expect(recovered).toMatchObject({ stopReason: "stop", responseId: "resp_copilot_recovered" });
+    expect(recovered.responseModel).toBeUndefined();
+    expect(recovered.usage.totalTokens).toBe(8);
+    expect(events.filter((type) => type === "start")).toHaveLength(1);
+    expect(events.filter((type) => type === "done")).toHaveLength(1);
+    expect(sdkState.requests).toHaveLength(2);
+    expect(JSON.stringify(sdkState.requests[0])).toContain(SDK_REASONING_CIPHERTEXT);
+    expect(JSON.stringify(sdkState.requests[1])).not.toContain(SDK_REASONING_CIPHERTEXT);
+    expect(requestHasCompaction(sdkState.requests[0])).toBe(true);
+    expect(requestHasCompaction(sdkState.requests[1])).toBe(true);
+    expect(observations.map(({ payloadVariant }) => payloadVariant)).toEqual([
+      "initial",
+      "reasoning-stripped",
+    ]);
+  });
+
+  it("preserves staged compaction recovery after consecutive stream-drain rejections", async () => {
+    const identity = { sessionId: "drain-stage-session", authProfileId: "drain-profile" };
+    const model = createModel();
+    const context = createCompactionContext(model, identity, true);
+    const observations: ResponsesPromptObservation[] = [];
+    const onCompactionRejected = vi.fn();
+    const options = { apiKey: "test-key", ...identity, onCompactionRejected };
+    responsesPromptObserver.set(options, (observation) => observations.push(observation));
+    sdkState.outcomes = [
+      rejectedSdkStream({ code: "invalid_encrypted_content", message: "reasoning rejected" }),
+      rejectedSdkStream({ code: "invalid_encrypted_content", message: "compaction rejected" }),
+      completedSdkResponse("resp_drain_stages_recovered"),
+    ];
+
+    const stream = await Promise.resolve(
+      createOpenAIResponsesTransportStreamFn()(model, context, options as never),
+    );
+    expect(await stream.result()).toMatchObject({
+      stopReason: "stop",
+      responseId: "resp_drain_stages_recovered",
+      providerReplay: { type: "openai-responses-compaction-suppression", data: "rejected" },
+    });
+
+    expect(sdkState.requests).toHaveLength(3);
+    expect(requestHasCompaction(sdkState.requests[0])).toBe(true);
+    expect(requestHasCompaction(sdkState.requests[1])).toBe(true);
+    expect(requestHasCompaction(sdkState.requests[2])).toBe(false);
+    expect(JSON.stringify(sdkState.requests[1])).not.toContain(SDK_REASONING_CIPHERTEXT);
+    expect(JSON.stringify(sdkState.requests[2])).toContain(SDK_FULL_HISTORY_PREFIX);
+    expect(onCompactionRejected).toHaveBeenCalledOnce();
+    expect(observations.map(({ payloadVariant }) => payloadVariant)).toEqual([
+      "initial",
+      "reasoning-stripped",
+      "compaction-stripped",
+    ]);
+  });
+
+  it("recovers a nested encrypted-content stream error without losing its provider code", async () => {
+    const identity = { sessionId: "nested-error-session", authProfileId: "nested-profile" };
+    const model = createModel();
+    sdkState.outcomes = [
+      rejectedSdkStream(
+        { code: "invalid_encrypted_content", message: "reasoning rejected", status: 400 },
+        { nestedErrorEvent: true },
+      ),
+      completedSdkResponse("resp_nested_recovered"),
+    ];
+
+    const stream = await Promise.resolve(
+      createOpenAIResponsesTransportStreamFn()(
+        model,
+        createCompactionContext(model, identity, true),
+        { apiKey: "test-key", ...identity } as never,
+      ),
+    );
+
+    expect(await stream.result()).toMatchObject({
+      stopReason: "stop",
+      responseId: "resp_nested_recovered",
+    });
+    expect(sdkState.requests).toHaveLength(2);
+    expect(JSON.stringify(sdkState.requests[1])).not.toContain(SDK_REASONING_CIPHERTEXT);
+  });
+
+  it("never retries a rejected replay after assistant output has become visible", async () => {
+    const identity = { sessionId: "visible-output-session", authProfileId: "visible-profile" };
+    const model = createModel();
+    sdkState.outcomes = [
+      rejectedSdkStream(
+        { code: "invalid_encrypted_content", message: "reasoning rejected" },
+        {
+          events: [
+            {
+              type: "response.output_item.added",
+              output_index: 0,
+              item: { type: "message", id: "msg_visible", role: "assistant", content: [] },
+            },
+            {
+              type: "response.output_text.delta",
+              output_index: 0,
+              content_index: 0,
+              delta: "Already visible",
+            },
+          ],
+        },
+      ),
+      completedSdkResponse("resp_must_not_run"),
+    ];
+
+    const stream = await Promise.resolve(
+      createOpenAIResponsesTransportStreamFn()(
+        model,
+        createCompactionContext(model, identity, true),
+        { apiKey: "test-key", ...identity } as never,
+      ),
+    );
+
+    expect(await stream.result()).toMatchObject({ stopReason: "error" });
+    expect(sdkState.requests).toHaveLength(1);
+  });
+
+  it("never retries Copilot verification prose from an explicit streamed server failure", async () => {
+    const identity = { sessionId: "server-failure-session", authProfileId: "server-profile" };
+    const model = createModel({ provider: "github-copilot" });
+    sdkState.outcomes = [
+      rejectedSdkStream({
+        message: "The encrypted content could not be verified.",
+        status: 500,
+      }),
+      completedSdkResponse("resp_must_not_run"),
+    ];
+
+    const stream = await Promise.resolve(
+      createOpenAIResponsesTransportStreamFn()(
+        model,
+        createCompactionContext(model, identity, true),
+        { apiKey: "test-key", ...identity } as never,
+      ),
+    );
+
+    expect(await stream.result()).toMatchObject({ stopReason: "error", errorCode: "500" });
+    expect(sdkState.requests).toHaveLength(1);
   });
 
   it("does not invoke the provider or retry when prompt observation throws", async () => {

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -1,4 +1,4 @@
-import type { Model } from "@openclaw/llm-core";
+import type { AssistantMessage, Model } from "@openclaw/llm-core";
 import type { ResponseInput } from "openai/resources/responses/responses.js";
 import type { OpenAIResponsesCompactionRejection } from "../provider-options.js";
 import type { createOpenAIResponsesClient } from "./openai-responses-client.js";
@@ -6,6 +6,7 @@ import {
   DEFAULT_AZURE_OPENAI_API_VERSION,
   type OpenAIResponsesRequestParams,
 } from "./openai-responses-contracts.js";
+import { ResponsesStreamFailure } from "./openai-responses-debug.js";
 import type { createResponsesPromptEgressObserver } from "./openai-responses-prompt-observer-internal.js";
 import { stripEncryptedReasoningContentFields } from "./openai-responses-replay-messages-internal.js";
 import { log } from "./openai-transport-shared.js";
@@ -28,12 +29,19 @@ export function isInvalidEncryptedContentError(error: unknown): boolean {
     return true;
   }
   const message = typeof record.message === "string" ? record.message : "";
+  const normalizedMessage = message.toLowerCase();
   return (
     message.includes("invalid_encrypted_content") ||
     message.includes("thinking_signature_invalid") ||
     // xAI reports this exact prose contract without an error code.
     (record.status === 400 &&
-      message.toLowerCase().includes("could not decrypt the provided encrypted_content"))
+      normalizedMessage.includes("could not decrypt the provided encrypted_content")) ||
+    // Copilot omits both the code and, for streamed failures, the HTTP status.
+    ((record.status === 400 ||
+      (error instanceof ResponsesStreamFailure && record.status === undefined)) &&
+      normalizedMessage.includes("encrypted content") &&
+      (normalizedMessage.includes("could not be verified") ||
+        normalizedMessage.includes("could not be decrypted or parsed")))
   );
 }
 
@@ -161,6 +169,46 @@ export async function resolveNextResponsesEncryptedContentAttempt<
     request: compactionStripped,
     rejectedCompaction: readOpenAIResponsesCompactionRejection(attempt.request),
   };
+}
+
+export async function drainResponsesStreamWithEncryptedContentRetry<T>(params: {
+  stream: AsyncIterable<unknown>;
+  attempt: ResponsesEncryptedContentAttempt<OpenAIResponsesRequestParams>;
+  output: AssistantMessage;
+  signal?: AbortSignal;
+  processStream: (stream: AsyncIterable<unknown>) => Promise<T>;
+  createStream: (
+    attempt: ResponsesEncryptedContentAttempt<OpenAIResponsesRequestParams>,
+  ) => Promise<{
+    stream: AsyncIterable<unknown>;
+    attempt: ResponsesEncryptedContentAttempt<OpenAIResponsesRequestParams>;
+  }>;
+  buildFullHistoryRequest?: () =>
+    | OpenAIResponsesRequestParams
+    | Promise<OpenAIResponsesRequestParams>;
+}): Promise<T> {
+  let { stream, attempt } = params;
+  const initialUsage = params.output.usage;
+  for (;;) {
+    try {
+      return await params.processStream(stream);
+    } catch (error) {
+      // Lazy provider streams fail after creation; replaying public output would duplicate it.
+      if (params.signal?.aborted || params.output.content.length > 0) {
+        throw error;
+      }
+      const recovery = await resolveNextResponsesEncryptedContentAttempt(attempt, error, {
+        buildFullHistoryRequest: params.buildFullHistoryRequest,
+      });
+      if (!recovery) {
+        throw error;
+      }
+      delete params.output.responseId;
+      delete params.output.responseModel;
+      params.output.usage = initialUsage;
+      ({ stream, attempt } = await params.createStream(recovery));
+    }
+  }
 }
 
 export async function createResponsesStreamWithEncryptedContentRetry(params: {

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -643,8 +643,13 @@ export async function processResponsesStream<TApi extends Api>(
         }
         break;
       } else if (event.type === "error") {
-        throw new Error(
-          event.message ? `Error Code ${event.code}: ${event.message}` : "Unknown error",
+        const nested = isRecord(event) && isRecord(event.error) ? event.error : undefined;
+        const code = typeof event.code === "string" ? event.code : nested?.code;
+        const message = typeof event.message === "string" ? event.message : nested?.message;
+        throw Object.assign(
+          new Error(message ? `Error Code ${code}: ${message}` : "Unknown error"),
+          ...(typeof code === "string" ? [{ code }] : []),
+          ...(typeof nested?.status === "number" ? [{ status: nested.status }] : []),
         );
       } else if (event.type === "response.failed") {
         const failure = normalizeResponsesFailedEvent(isRecord(event) ? event : {}, model);

--- a/packages/ai/src/transports/openai-responses-websocket.ts
+++ b/packages/ai/src/transports/openai-responses-websocket.ts
@@ -1,3 +1,4 @@
+import type { Model } from "@openclaw/llm-core";
 import type OpenAI from "openai";
 import type {
   ResponsesClientEvent,
@@ -17,6 +18,7 @@ import {
   OpenAIResponsesWebSocketPostDispatchError,
   OpenAIResponsesWebSocketPreDispatchError,
   OpenAIResponsesWebSocketSafeRetryError,
+  type OpenAIResponsesOptions,
 } from "./openai-responses-contracts.js";
 import { transportAbortError } from "./transport-stream-shared.js";
 import { sha256Hex } from "./transport-utils.js";
@@ -81,6 +83,19 @@ export function supportsNativeOpenAIResponsesEndpoint(params: {
     params.api === "openai-responses" &&
     isOfficialOpenAIResponsesBaseUrl(params.baseUrl)
   );
+}
+
+export function resolveNativeOpenAIResponsesWebSocketMode(
+  model: Model,
+  transport: OpenAIResponsesOptions["transport"],
+): OpenAIResponsesWebSocketMode | undefined {
+  if (
+    (transport !== "websocket" && transport !== "websocket-cached" && transport !== "auto") ||
+    getAiTransportHost().requiresManagedTransport(model)
+  ) {
+    return undefined;
+  }
+  return supportsNativeOpenAIResponsesEndpoint(model) ? transport : undefined;
 }
 
 function closeWebSocketSilently(socket: ResponsesWS, reason = "done"): void {

--- a/src/agents/openai-transport-stream.replay-and-tools.test.ts
+++ b/src/agents/openai-transport-stream.replay-and-tools.test.ts
@@ -716,7 +716,7 @@ describe("openai transport stream", () => {
     expect(onCompactionRejected).not.toHaveBeenCalled();
   });
 
-  it("does not retry encrypted-content failures emitted after stream creation", async () => {
+  it("leaves stream consumption failures to the managed transport recovery owner", async () => {
     const streamFailure = Object.assign(new Error("stream rejected encrypted content"), {
       code: "invalid_encrypted_content",
     });
@@ -902,6 +902,25 @@ describe("openai transport stream", () => {
       label: "rejects the xAI phrase on a 500",
       status: 500,
       message: "Could not decrypt the provided encrypted_content.",
+      expected: false,
+    },
+    {
+      label: "matches Copilot's code-less encrypted-content verification 400",
+      status: 400,
+      message:
+        "The encrypted content for item rs_prior could not be verified. Reason: Encrypted content could not be decrypted or parsed.",
+      expected: true,
+    },
+    {
+      label: "rejects Copilot's encrypted-content prose on a 500",
+      status: 500,
+      message: "The encrypted content could not be verified.",
+      expected: false,
+    },
+    {
+      label: "rejects unrelated verification failures",
+      status: 400,
+      message: "The request signature could not be verified.",
       expected: false,
     },
   ])("$label", ({ status, message, expected }) => {


### PR DESCRIPTION
Closes #124465.

## What Problem This Solves

Fixes an issue where GitHub Copilot users replaying a conversation with stale encrypted reasoning could receive a provider rejection after the Responses stream was already created, leaving the session unable to recover on later turns.

## Why This Change Was Made

The OpenAI SDK exposes a lazy stream: encrypted-content errors can occur while consuming the stream, after the existing request-creation retry boundary has returned. Move recovery to the canonical stream owner, preserve the existing reasoning-stripped then compaction-stripped progression, retain valid encrypted compaction, and never replay once assistant content has become visible. Preserve nested provider error metadata, reject explicit HTTP 500 failures, and reuse the same recovery attempt across WebSocket and SSE paths.

The existing live Copilot smoke fixture also omitted the reasoning item and replay opt-in required by its own connection-bound-ID contract; repair that fixture and verify invalid replay ciphertext is removed at real provider egress.

## User Impact

Copilot sessions recover safely from rejected stale reasoning without poisoning future turns, dropping valid compacted history, duplicating visible output, or replaying tool side effects.

## Evidence

- 432 targeted regression tests passed across seven Vitest shards spanning transport, doctor migration, memory search, compaction, auto-reply, and session persistence.
- 91 focused Copilot/WebSocket/agent transport regressions passed after the final recovery-owner refactor.
- Authenticated live GitHub Copilot provider test passed: invalid encrypted replay was stripped, a stale message ID was rewritten, and the actual streamed tool call returned its exact arguments.
- `node --import tsx scripts/check-assertion-safety-ratchet.mts --base origin/main` passed.
- Independent structured review reported no accepted/actionable findings.
