### PR TITLE
fix: older chat history loads slowly in tool-heavy conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI chat history:** load older pages from sparse, tool-heavy conversations without repeatedly reprocessing the accumulated transcript, while preserving complete pages and existing pagination boundaries.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI chat history:** load older pages from sparse, tool-heavy conversations without repeatedly reprocessing the accumulated transcript, while preserving complete pages and existing pagination boundaries.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -50,6 +50,7 @@ import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import * as chatDisplayProjection from "./chat-display-projection.js";
 import { assertPluginMetadataSnapshotConsistency } from "./plugin-metadata.test-helpers.js";
 import {
   createDirectChatContext,
@@ -6888,6 +6889,47 @@ describe("gateway server chat", () => {
       expect(JSON.stringify(olderPage.payload?.messages)).not.toContain("NO_REPLY");
       expect(olderPage.payload?.hasMore).toBe(false);
       expect(olderPage.payload?.nextOffset).toBeUndefined();
+    });
+  });
+
+  test("chat.history fills sparse pages without repeatedly projecting scanned transcript rows", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await prepareMainHistoryHarness({ ws, createSessionDir });
+      const startedAt = Date.now();
+      const events = Array.from({ length: 1_500 }, (_, index) =>
+        createTextTranscriptEvent(
+          index % 50 === 0 ? "user" : "assistant",
+          index % 50 === 0 ? `visible ${index / 50}` : "NO_REPLY",
+          { timestamp: startedAt + index },
+        ),
+      );
+      await writeMainSessionTranscript(events);
+
+      let projectedRows = 0;
+      const project = chatDisplayProjection.projectChatDisplayMessagesWithState;
+      const projectionSpy = vi
+        .spyOn(chatDisplayProjection, "projectChatDisplayMessagesWithState")
+        .mockImplementation((messages, options) => {
+          projectedRows += messages.length;
+          return project(messages, options);
+        });
+
+      try {
+        const page = await rpcReq<{
+          messages?: Array<{ __openclaw?: { seq?: number } }>;
+          nextOffset?: number;
+          hasMore?: boolean;
+        }>(ws, "chat.history", makeMainSessionParams({ limit: 25, offset: 0 }));
+        expect(page.ok).toBe(true);
+        expect(page.payload?.messages?.map(readOpenClawSeq)).toEqual(
+          Array.from({ length: 25 }, (_, index) => (index + 5) * 50 + 1),
+        );
+        expect(page.payload).toMatchObject({ hasMore: true, nextOffset: 1_250 });
+        expect(projectedRows).toBeGreaterThan(0);
+        expect(projectedRows).toBeLessThanOrEqual(events.length * 2);
+      } finally {
+        projectionSpy.mockRestore();
+      }
     });
   });
 

--- a/src/gateway/session-history-tail.ts
+++ b/src/gateway/session-history-tail.ts
@@ -103,24 +103,26 @@ export async function readIncrementalChatHistoryTail(params: {
     readPage.messages,
     overreadContextMessage,
   );
-  const project = () => {
+  const project = (
+    messages = rawMessages,
+    contextMessage = overreadContextMessage,
+    resolveProfileDisplay = true,
+  ) => {
     const filteredRawMessages =
       sessionStartedAt === undefined
-        ? rawMessages
+        ? messages
         : dropChatHistoryOverreadContextMessage(
             dropPreSessionStartAnnouncePairs(
-              overreadContextMessage === undefined
-                ? rawMessages
-                : [overreadContextMessage, ...rawMessages],
+              contextMessage === undefined ? messages : [contextMessage, ...messages],
               sessionStartedAt,
             ),
-            overreadContextMessage,
+            contextMessage,
           );
     const projection = projectChatDisplayMessagesWithState(filteredRawMessages, {
       includeCommentaryFallbacks: true,
       maxChars: params.effectiveMaxChars,
-      resolveCurrentUserProfileDisplay,
-      turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(overreadContextMessage),
+      ...(resolveProfileDisplay ? { resolveCurrentUserProfileDisplay } : {}),
+      turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(contextMessage),
     });
     const projected =
       offset === 0
@@ -131,10 +133,17 @@ export async function readIncrementalChatHistoryTail(params: {
     return { filteredRawMessages, projected, projection };
   };
   let result = project();
+  let estimatedVisibleMessages = result.projected.length;
+  let projectionDirty = false;
   let scanLimit = rawHistoryWindowMessages;
   let scannedBytes = 0;
   let nextChunkMessages = SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES;
   while (offset + rawPageMessages < readPage.totalMessages) {
+    if (projectionDirty && estimatedVisibleMessages >= params.max) {
+      result = project();
+      projectionDirty = false;
+      estimatedVisibleMessages = result.projected.length;
+    }
     if (result.projected.length >= params.max) {
       break;
     }
@@ -155,13 +164,14 @@ export async function readIncrementalChatHistoryTail(params: {
     }
     // One older context row preserves stale-pair and heartbeat boundaries across chunks.
     const contextMessage = page.messages.length > chunkMessages ? page.messages[0] : undefined;
-    rawPageMessages += page.messages.length - (contextMessage === undefined ? 0 : 1);
-    rawMessages = dropChatHistoryOverreadContextMessage(
-      [...page.messages, ...rawMessages],
-      contextMessage,
-    );
+    const chunkRawMessages = dropChatHistoryOverreadContextMessage(page.messages, contextMessage);
+    rawPageMessages += chunkRawMessages.length;
+    rawMessages = chunkRawMessages.concat(rawMessages);
     overreadContextMessage = contextMessage;
-    result = project();
+    // Count fresh rows once; the authoritative whole-window projection preserves cross-chunk facts.
+    estimatedVisibleMessages += project(chunkRawMessages, contextMessage, false).projection.messages
+      .length;
+    projectionDirty = true;
     scannedBytes += Buffer.byteLength(JSON.stringify(page.messages), "utf8");
     if (rawPageMessages > rawHistoryWindowMessages && scannedBytes >= params.maxBytes) {
       break;
@@ -171,6 +181,9 @@ export async function readIncrementalChatHistoryTail(params: {
       nextChunkMessages * 2,
       SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_CHUNK_MESSAGES,
     );
+  }
+  if (projectionDirty) {
+    result = project();
   }
   return {
     overreadContextMessage,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users loading older chat history could wait more than 30 seconds when a conversation contained many hidden tool, commentary, or silent transcript entries between visible messages.

## Why This Change Was Made

The shared Gateway history reader previously reprojected the entire accumulated transcript every time it scanned another older chunk. Count each newly scanned chunk once, then run the authoritative full-window projection only when the page may be complete or scanning finishes. This retains complete pages, cursor offsets, cross-chunk turn boundaries, profile enrichment, and the existing shared WebSocket, REST, and SSE behavior.

## User Impact

Older pages from long, tool-heavy conversations load substantially faster without dropping visible messages or changing pagination.

## Evidence

- Added a real Gateway RPC regression with 1,500 transcript rows and only one visible message per 50 rows. Before the fix it fails after reprocessing 3,385 rows; the exact current head passes while enforcing a linear projection-work bound and checking exact visible rows plus the pagination cursor: 1 passed, 115 skipped.
- Passed 14 focused Gateway WebSocket, REST, and SSE integration scenarios across both affected history suites.
- Passed targeted formatting, lint, and diff-whitespace checks.
- Production delta: +27/-14 (net +13); regression coverage: +42 lines. The production growth preserves cross-chunk projection correctness while replacing repeated whole-window work with bounded incremental accounting. The release-owned changelog remains unchanged.
