### PR TITLE
refactor(android): consolidate motion JSON parsing

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -378,12 +377,7 @@ class MotionHandler private constructor(
     if (paramsJson.isNullOrBlank()) {
       return MotionActivityRequest(startISO = null, endISO = null, limit = 200)
     }
-    val params =
-      try {
-        Json.parseToJsonElement(paramsJson).asObjectOrNull()
-      } catch (_: Throwable) {
-        null
-      } ?: return null
+    val params = parseJsonParamsObject(paramsJson) ?: return null
     // Keep the accepted gateway parameter even though Android can only return
     // one live classification sample for now.
     val limit = ((params["limit"] as? JsonPrimitive)?.content?.toIntOrNull() ?: 200).coerceIn(1, 1000)
@@ -398,12 +392,7 @@ class MotionHandler private constructor(
     if (paramsJson.isNullOrBlank()) {
       return MotionPedometerRequest(startISO = null, endISO = null)
     }
-    val params =
-      try {
-        Json.parseToJsonElement(paramsJson).asObjectOrNull()
-      } catch (_: Throwable) {
-        null
-      } ?: return null
+    val params = parseJsonParamsObject(paramsJson) ?: return null
     return MotionPedometerRequest(
       startISO = parseJsonString(params, "startISO")?.trim()?.ifEmpty { null },
       endISO = parseJsonString(params, "endISO")?.trim()?.ifEmpty { null },


### PR DESCRIPTION
## What Problem This Solves

No user-visible behavior changes. This is an internal cleanup of Android node motion request parsing.

Motion support added two identical JSON-object parsing/catch blocks before reuse of the canonical `NodeUtils` parser was established in sibling handlers (#120456). This change routes both motion request parsers through `parseJsonParamsObject` and deletes the duplicate implementation.

## Why This Change Was Made

The simplification preserves the existing invariants:

- the shared helper has the same parse/catch/object-cast semantics as both removed blocks;
- the motion parsers still own their pre-helper absent/blank defaults;
- malformed and non-object JSON remain invalid;
- JSON null handling, literal string handling, range fields, and activity limit parsing/bounds are unchanged.

Alternatives rejected:

- Keep the duplicate blocks: preserves unnecessary parallel ownership and future drift risk.
- Add a motion-local wrapper: adds indirection without a distinct motion contract.
- Broaden this into a field-helper refactor: larger than needed and would mix parser consolidation with handler-specific policy.

## User Impact

None intended. Android node behavior and protocol responses are unchanged.

## Evidence

Exact head: `47624964c65b37ddb8802643d2cb2a9805a5eb0e`

- Local changed gate: passed on the frozen head.
- `git diff --check`: passed.
- No local Android/Gradle pass: `JAVA_HOME`/`java` were unavailable in the local environment.
- Existing `MotionHandlerTest` behavior tests cover invalid non-object JSON, absent params, JSON null ranges, literal `"null"` strings, range propagation, and activity limit bounds. No implementation-coupled test was added for a source-equivalent helper substitution.
- Independent exact-head verifier: **PUBLISH**, conditional on hosted Android validation.
- Structured autoreview: clean.
- Separate exact-head read-only Codex review: **CLEAN**.
- Hosted Android exact-head compile, unit tests, lint, and ktlint are mandatory before landing.
- No live-device proof is claimed or needed for this parser-owner-only cleanup.

Production LOC: +2/-13 (net -11). Tests: +0/-0.

## Overlap and Remaining Uncertainty

Immediately before publication, live open issue/PR searches found no `MotionHandler`, `MotionHandlerTest`, or `NodeUtils` overlap, no remote `codex/android-motion-parser-cleanup` branch, and no existing PR for that head branch. Current `origin/main` had no changes to those three files relative to base `0229fe7a2a90341b73aa21c895b98e650b4bd4de`. The related sibling-handler consolidation #120456 is merged and does not touch this file stack.

The only remaining uncertainty is hosted Android toolchain validation because the local environment had no Java runtime. CI must close that gap on this exact head.

## Test Audit

No test changes. Existing behavior-level coverage exercises the relevant invariants; adding a test that asserts which equivalent parser function is called would couple tests to implementation rather than behavior.

AI-assisted: yes.
