### PR TITLE
fix(ui): preserve chat URL state during session draft cleanup

### DIFF
--- a/ui/src/e2e/chat-flow.messaging.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.messaging.e2e.test.ts
@@ -31,6 +31,27 @@ async function withChatPage(run: (page: Page) => Promise<void>): Promise<void> {
 }
 
 suite.define(() => {
+  it.each([
+    { draft: "Draft from a shared link", name: "a one-shot chat draft" },
+    { draft: undefined, name: "an existing session URL" },
+  ])("preserves remaining URL state while resolving $name", async ({ draft }) => {
+    await withChatPage(async (page) => {
+      await installMockGateway(page, { historyMessages: [] });
+      const sessionUrl = new URL(controlUiSessionUrl(suite.server.baseUrl, "main"));
+      if (draft !== undefined) {
+        sessionUrl.searchParams.set("draft", draft);
+      }
+      sessionUrl.searchParams.set("panel", "details");
+      sessionUrl.hash = "#pane";
+
+      await page.goto(sessionUrl.href);
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await expect.poll(() => composer.inputValue()).toBe(draft ?? "");
+      await expect.poll(() => new URL(page.url()).search).toBe("?panel=details");
+      await expect.poll(() => new URL(page.url()).hash).toBe("#pane");
+    });
+  });
+
   it("sends a chat turn through the GUI and renders the final Gateway event", async () => {
     await withChatPage(async (page) => {
       const gateway = await installMockGateway(page, {

--- a/ui/src/pages/chat/chat-canonical-location.ts
+++ b/ui/src/pages/chat/chat-canonical-location.ts
@@ -1,7 +1,7 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import { locationWithoutDraft } from "./route-draft.ts";
 
-function currentRouteLocation(): RouteLocation {
+export function currentRouteLocation(): RouteLocation {
   return {
     pathname: window.location.pathname,
     search: window.location.search,

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -413,6 +413,11 @@ describe("chat page split layout host", () => {
   });
 
   it("hands each route-provided draft to the active pane only once", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      `${sessionPath("main")}?draft=one-shot%20draft&panel=details#pane`,
+    );
     const page = new ChatPage();
     const navigation = setNavigationContext(page);
     const firstRouteData = { sessionKey: "main", draft: "one-shot draft" };
@@ -428,6 +433,8 @@ describe("chat page split layout host", () => {
     expect(navigation.replace).toHaveBeenCalledOnce();
     expect(navigation.replace).toHaveBeenCalledWith("chat", {
       pathname: sessionPath("main"),
+      search: "?panel=details",
+      hash: "#pane",
     });
     page.data = { ...firstRouteData };
     expect(getRouteDraftForActivePane(page)).toBe("one-shot draft");
@@ -554,6 +561,12 @@ describe("chat page split layout host", () => {
   });
 
   it("keeps catalog identity when consuming a route draft", async () => {
+    const catalogSearch = catalogSessionSearch(CATALOG_KEY);
+    window.history.replaceState(
+      {},
+      "",
+      `/chat/research${catalogSearch}&draft=one-shot%20catalog%20draft&panel=details#pane`,
+    );
     const page = new ChatPage();
     const navigation = setNavigationContext(page);
     page.data = {
@@ -566,10 +579,11 @@ describe("chat page split layout host", () => {
     await Promise.resolve();
     await page.updateComplete;
 
-    const expectedSearch = catalogSessionSearch(CATALOG_KEY);
+    const expectedSearch = `${catalogSearch}&panel=details`;
     expect(navigation.replace).toHaveBeenCalledWith("chat", {
       pathname: "/chat/research",
       search: expectedSearch,
+      hash: "#pane",
     });
     await expect(
       loadChatRoute(
@@ -606,6 +620,7 @@ describe("chat page split layout host", () => {
   });
 
   it("preserves a resolved long prefix through drafts and face changes", async () => {
+    window.history.replaceState({}, "", "/chat/main/1234567890?draft=ship&panel=details#pane");
     const page = new ChatPage();
     const navigation = setNavigationContext(page);
     page.data = {
@@ -621,6 +636,8 @@ describe("chat page split layout host", () => {
 
     expect(navigation.replace).toHaveBeenCalledWith("chat", {
       pathname: "/chat/main/1234567890",
+      search: "?panel=details",
+      hash: "#pane",
     });
     navigation.navigate.mockClear();
     const pane = page.querySelector<RenderedPane>("openclaw-chat-pane");

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -413,11 +413,7 @@ describe("chat page split layout host", () => {
   });
 
   it("hands each route-provided draft to the active pane only once", async () => {
-    window.history.replaceState(
-      {},
-      "",
-      `${sessionPath("main")}?draft=one-shot%20draft&panel=details#pane`,
-    );
+    window.history.replaceState({}, "", "/chat/main?draft=one-shot%20draft&panel=details#pane");
     const page = new ChatPage();
     const navigation = setNavigationContext(page);
     const firstRouteData = { sessionKey: "main", draft: "one-shot draft" };
@@ -425,12 +421,9 @@ describe("chat page split layout host", () => {
     expect(getRouteDraftForActivePane(page)).toBe("one-shot draft");
 
     document.body.append(page);
-    await page.updateComplete;
-    await Promise.resolve();
-    await page.updateComplete;
+    await vi.waitFor(() => expect(navigation.replace).toHaveBeenCalledOnce());
 
     expect(getRouteDraftForActivePane(page)).toBeUndefined();
-    expect(navigation.replace).toHaveBeenCalledOnce();
     expect(navigation.replace).toHaveBeenCalledWith("chat", {
       pathname: sessionPath("main"),
       search: "?panel=details",
@@ -561,12 +554,8 @@ describe("chat page split layout host", () => {
   });
 
   it("keeps catalog identity when consuming a route draft", async () => {
-    const catalogSearch = catalogSessionSearch(CATALOG_KEY);
-    window.history.replaceState(
-      {},
-      "",
-      `/chat/research${catalogSearch}&draft=one-shot%20catalog%20draft&panel=details#pane`,
-    );
+    const expectedSearch = catalogSessionSearch(CATALOG_KEY);
+    window.history.replaceState({}, "", `/chat/research${expectedSearch}&draft=ship`);
     const page = new ChatPage();
     const navigation = setNavigationContext(page);
     page.data = {
@@ -575,15 +564,12 @@ describe("chat page split layout host", () => {
       draft: "one-shot catalog draft",
     };
     document.body.append(page);
-    await page.updateComplete;
-    await Promise.resolve();
-    await page.updateComplete;
+    await vi.waitFor(() => expect(navigation.replace).toHaveBeenCalledOnce());
 
-    const expectedSearch = `${catalogSearch}&panel=details`;
     expect(navigation.replace).toHaveBeenCalledWith("chat", {
       pathname: "/chat/research",
       search: expectedSearch,
-      hash: "#pane",
+      hash: "",
     });
     await expect(
       loadChatRoute(
@@ -620,7 +606,7 @@ describe("chat page split layout host", () => {
   });
 
   it("preserves a resolved long prefix through drafts and face changes", async () => {
-    window.history.replaceState({}, "", "/chat/main/1234567890?draft=ship&panel=details#pane");
+    window.history.replaceState({}, "", "/chat/main/1234567890?draft=ship");
     const page = new ChatPage();
     const navigation = setNavigationContext(page);
     page.data = {
@@ -630,14 +616,12 @@ describe("chat page split layout host", () => {
       face: "chat",
     };
     document.body.append(page);
-    await page.updateComplete;
-    await Promise.resolve();
-    await page.updateComplete;
+    await vi.waitFor(() => expect(navigation.replace).toHaveBeenCalledOnce());
 
     expect(navigation.replace).toHaveBeenCalledWith("chat", {
       pathname: "/chat/main/1234567890",
-      search: "?panel=details",
-      hash: "#pane",
+      search: "",
+      hash: "",
     });
     navigation.navigate.mockClear();
     const pane = page.querySelector<RenderedPane>("openclaw-chat-pane");

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -403,13 +403,8 @@ export class ChatPage extends OpenClawLightDomElement {
 
   private updateRoute(sessionKey: string, replace = false, face = this.data.face ?? "chat") {
     const data = this.data;
-    if (
-      data &&
-      areUiSessionKeysEquivalent(data.sessionKey, sessionKey) &&
-      (data.face ?? "chat") === face &&
-      !data.draft &&
-      !data.focusComposer
-    ) {
+    const sameSession = data && areUiSessionKeysEquivalent(data.sessionKey, sessionKey);
+    if (sameSession && (data.face ?? "chat") === face && !data.draft && !data.focusComposer) {
       return;
     }
     const options = sessionNavigationTarget({
@@ -420,14 +415,11 @@ export class ChatPage extends OpenClawLightDomElement {
       shortIdLength: data?.sessionKey === sessionKey ? data.shortId?.length : undefined,
     }).options;
     if (replace) {
-      this.context.replace(
-        face,
-        data &&
-          areUiSessionKeysEquivalent(data.sessionKey, sessionKey) &&
-          (data.draft || data.focusComposer)
+      const location =
+        sameSession && (data.draft || data.focusComposer)
           ? locationWithoutDraft(currentRouteLocation(), options)
-          : options,
-      );
+          : options;
+      this.context.replace(face, location);
     } else {
       this.context.navigate(face, options);
     }

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -17,7 +17,7 @@ import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { persistSessionBoardFace } from "./chat-board-face-persistence.ts";
-import { stillOwnsCanonicalLocation } from "./chat-canonical-location.ts";
+import { currentRouteLocation, stillOwnsCanonicalLocation } from "./chat-canonical-location.ts";
 import { renderChatPagePaneCell } from "./chat-page-pane-render.ts";
 import { ChatPageRetainedSessions } from "./chat-page-retained-sessions.ts";
 import { closeStagedPane, resumeStagedPanes } from "./chat-pane-attachment-handoff.ts";
@@ -404,7 +404,8 @@ export class ChatPage extends OpenClawLightDomElement {
   private updateRoute(sessionKey: string, replace = false, face = this.data.face ?? "chat") {
     const data = this.data;
     if (
-      data?.sessionKey === sessionKey &&
+      data &&
+      areUiSessionKeysEquivalent(data.sessionKey, sessionKey) &&
       (data.face ?? "chat") === face &&
       !data.draft &&
       !data.focusComposer
@@ -419,7 +420,14 @@ export class ChatPage extends OpenClawLightDomElement {
       shortIdLength: data?.sessionKey === sessionKey ? data.shortId?.length : undefined,
     }).options;
     if (replace) {
-      this.context.replace(face, options);
+      this.context.replace(
+        face,
+        data &&
+          areUiSessionKeysEquivalent(data.sessionKey, sessionKey) &&
+          (data.draft || data.focusComposer)
+          ? locationWithoutDraft(currentRouteLocation(), options)
+          : options,
+      );
     } else {
       this.context.navigate(face, options);
     }

--- a/ui/src/pages/chat/route-draft.ts
+++ b/ui/src/pages/chat/route-draft.ts
@@ -13,12 +13,18 @@ function focusComposerFromLocation(location: RouteLocation): boolean {
   return new URLSearchParams(location.search).get(SESSION_COMPOSER_FOCUS_PARAM) === "1";
 }
 
-export function locationWithoutDraft(location: RouteLocation): RouteLocation {
+export function locationWithoutDraft(
+  location: RouteLocation,
+  destination: Partial<RouteLocation> = {},
+): RouteLocation {
   const params = new URLSearchParams(location.search);
+  for (const [name, value] of new URLSearchParams(destination.search)) {
+    params.set(name, value);
+  }
   params.delete("draft");
   params.delete(SESSION_COMPOSER_FOCUS_PARAM);
   const search = params.toString();
-  return { ...location, search: search ? `?${search}` : "" };
+  return { ...location, ...destination, search: search ? `?${search}` : "" };
 }
 
 export function draftRouteDataFromLocation(location: RouteLocation): RouteDraftHint {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Chat or Dashboard session links lost unrelated URL query parameters and fragments when a shared link supplied a one-shot composer draft or when Gateway startup normalized an equivalent session identity.

## Why This Change Was Made

Chat session navigation now recognizes equivalent session keys before deciding whether a route replacement is necessary. When a draft or composer-focus hint really must be consumed, its canonical cleanup helper removes only those one-shot hints while retaining the current URL state and the generated destination's required catalog/session identity.

## User Impact

Shared session links still prefill the composer exactly once, but existing URL context survives. Ordinary and draft-bearing sessions preserve unrelated query parameters and fragments, catalog-backed sessions retain their catalog identity, and long session references retain their resolved prefixes.

## Evidence

The existing owner regression failed before the fix because ChatPage forwarded only `/chat/main` instead of `/chat/main?panel=details#pane`. A real Chromium scenario independently failed with the same observed address-bar transition after successfully receiving its draft. Browser history tracing identified an earlier Gateway session-key normalization path that also replaced the URL when `main` and its canonical key referred to the same session.

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-page.test.ts ui/src/pages/chat/route.test.ts` — 44 owner and routing regressions passed, including ordinary drafts, catalog identity, long session prefixes, and delayed canonicalization.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.messaging.e2e.test.ts` — all 19 real Chromium chat scenarios passed, including draft-bearing and ordinary session URLs.
- `pnpm tsgo:ui` — passed.
- `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 pnpm check:changed` — passed.
- Independent structured Codex review — clean.
- Production LOC: +17/-11 (net +6); the necessary growth owns lossless URL preservation, equivalent-key identity, and canonical catalog-parameter merging. Tests: +33/-11.

Before/after screenshots are not representative here: the observable regression is the browser address bar and navigation history, which Playwright's page screenshots do not capture. The real Chromium regressions instead assert the exact before/after query string and fragment directly.
