### PR TITLE
fix(android): restore rewind and fork for attachment-only messages

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt
@@ -59,7 +59,7 @@ internal fun ChatMessageActionHost(
   onToggleListen: (() -> Unit)? = null,
   content: @Composable () -> Unit,
 ) {
-  if (!enabled || text.isBlank()) {
+  if (!enabled || (text.isBlank() && !showSessionActions)) {
     Box(modifier = modifier) { content() }
     return
   }
@@ -81,27 +81,29 @@ internal fun ChatMessageActionHost(
       expanded = menuExpanded,
       onDismissRequest = { menuExpanded = false },
     ) {
-      onToggleListen?.let { toggleListen ->
-        MessageActionItem(label = if (listenActive) nativeString("Stop") else nativeString("Listen")) {
-          toggleListen()
+      if (text.isNotBlank()) {
+        onToggleListen?.let { toggleListen ->
+          MessageActionItem(label = if (listenActive) nativeString("Stop") else nativeString("Listen")) {
+            toggleListen()
+            menuExpanded = false
+          }
+        }
+        MessageActionItem(label = nativeString("Copy")) {
+          copyChatMessage(context, text)
           menuExpanded = false
         }
-      }
-      MessageActionItem(label = nativeString("Copy")) {
-        copyChatMessage(context, text)
-        menuExpanded = false
-      }
-      MessageActionItem(label = nativeString("Select text")) {
-        menuExpanded = false
-        selectText = true
-      }
-      MessageActionItem(label = nativeString("Share")) {
-        shareChatMessage(context, text)
-        menuExpanded = false
-      }
-      MessageActionItem(label = nativeString("Reply")) {
-        onReply(quoteChatMessage(text))
-        menuExpanded = false
+        MessageActionItem(label = nativeString("Select text")) {
+          menuExpanded = false
+          selectText = true
+        }
+        MessageActionItem(label = nativeString("Share")) {
+          shareChatMessage(context, text)
+          menuExpanded = false
+        }
+        MessageActionItem(label = nativeString("Reply")) {
+          onReply(quoteChatMessage(text))
+          menuExpanded = false
+        }
       }
       if (showSessionActions) {
         onRewind?.let { rewind ->

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMessageViewsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMessageViewsTest.kt
@@ -104,6 +104,77 @@ class ChatMessageViewsTest {
   }
 
   @Test
+  fun attachmentOnlyUserTurnsRetainEntryActionsWithoutEmptyTextActions() {
+    val actions = mutableListOf<String>()
+    val messages =
+      listOf(
+        Triple("user", "photo.png", "photo-entry"),
+        Triple("user", "report.pdf", "document-entry"),
+        Triple("assistant", "assistant.pdf", "assistant-entry"),
+        Triple("user", "unpersisted.pdf", null),
+        Triple("user", "disabled.pdf", "disabled-entry"),
+      )
+
+    composeRule.setContent {
+      Column {
+        messages.forEach { (role, fileName, entryId) ->
+          ChatBubble(
+            messageId = fileName,
+            entryId = entryId,
+            role = role,
+            live = false,
+            content =
+              listOf(
+                ChatMessageContent(
+                  type = if (fileName == "photo.png") "image" else "file",
+                  fileName = fileName,
+                ),
+              ),
+            timestampMs = null,
+            onReplyMessage = { actions += "reply:$it" },
+            sessionActionsEnabled = fileName != "disabled.pdf",
+            onRewindMessage = { actions += "rewind:$it" },
+            onForkMessage = { actions += "fork:$it" },
+            speechState = null,
+            onToggleListen = { _, _ -> actions += "listen" },
+            inlineMediaPlaybackBlocked = false,
+            inlineWidgetResolverReady = false,
+            resolveInlineWidgetResource = { _, _ -> null },
+            loadImageArtifact = { null },
+            loadMediaArtifact = { _, _, _ -> null },
+          )
+        }
+      }
+    }
+
+    listOf("assistant.pdf", "unpersisted.pdf", "disabled.pdf").forEach { fileName ->
+      val speaker = if (fileName == "assistant.pdf") "OpenClaw" else "You"
+      val semantics =
+        composeRule
+          .onNode(hasContentDescription(speaker) and hasText(fileName))
+          .fetchSemanticsNode()
+          .config
+      assertTrue(SemanticsActions.OnLongClick !in semantics)
+    }
+
+    listOf("photo.png" to "Rewind to here", "report.pdf" to "Fork from here").forEach { (fileName, selectedAction) ->
+      composeRule
+        .onNode(hasContentDescription("You") and hasText(fileName))
+        .performSemanticsAction(SemanticsActions.OnLongClick) { action -> action() }
+
+      listOf("Rewind to here", "Fork from here").forEach { label ->
+        composeRule.onNode(hasText(label) and hasClickAction()).assertExists()
+      }
+      listOf("Copy", "Select text", "Share", "Reply", "Listen").forEach { label ->
+        composeRule.onAllNodesWithText(label).assertCountEquals(0)
+      }
+      composeRule.onNodeWithText(selectedAction).performClick()
+    }
+
+    assertEquals(listOf("rewind:photo-entry", "fork:document-entry"), actions)
+  }
+
+  @Test
   fun outboxBubbleExposesSpeakerWithoutReplacingStatusOrActions() {
     composeRule.setContent {
       Column {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users long-pressing a persisted chat message that contains only a photo or document would not see the existing Rewind to here or Fork from here actions.

## Why This Change Was Made

Session rewind and fork operate on an authorized persisted chat entry, not its plaintext. Keep those existing entry-bound actions available when that entry contains only an attachment, while continuing to hide Copy, Select text, Share, Reply, and Listen whenever the message has no text. The existing user-role, persisted-entry, session-availability, and live-message authorization boundaries remain unchanged.

## User Impact

Android users can rewind to or fork from their own persisted attachment-only messages just as they can from text messages. Assistant messages, unpersisted entries, unavailable sessions, and live messages do not gain new actions; empty-text clipboard, reply, share, and listen actions are never displayed.

## Evidence

Actual Android 36 Play app: mounted the real production ChatBubble in a foreground MainActivity, then used genuine UiAutomator long-press gestures against both a photo and PDF. This validates the real production Android UI and callbacks; it is not presented as a full live Gateway/session-RPC round-trip.

Photo before: no session-action menu.

![Photo before: attachment-only user message has no session-action menu](https://github.com/user-attachments/assets/2b25328d-287c-4f59-abdc-3bb490232f8b)

Photo after: only the existing Rewind to here and Fork from here actions are visible.

![Photo after: attachment-only user message shows Rewind to here and Fork from here](https://github.com/user-attachments/assets/3fc634bd-25a9-44e2-a9d9-28a4acc157be)

Document before: no session-action menu.

![Document before: attachment-only user PDF message has no session-action menu](https://github.com/user-attachments/assets/82ba2d3f-e7a6-4356-a6ba-1d365e15e98d)

Document after: only the existing Rewind to here and Fork from here actions are visible.

![Document after: attachment-only user PDF message shows Rewind to here and Fork from here](https://github.com/user-attachments/assets/2ab5993d-7e9d-476f-ad0a-dfc05a161159)

The unchanged-main Compose regression fails with the actual user photo node missing its OnLongClick action. With the fix, the same regression verifies persisted photo and PDF rows, invokes the exact original rewind/fork entry callbacks, rejects assistant, unpersisted, and disabled-session rows, and asserts that all empty-text actions remain absent. The real-device run independently dispatches rewind:photo-entry and fork:document-entry and rejects an assistant attachment row.

Both Play and third-party flavors pass ChatMessageViewsTest, ChatMessageActionsTest, ChatControllerSessionActionsTest, and ChatControllerBranchCoordinationTest: 40 owner-and-sibling tests per flavor, 80 total. All four Android modules pass ktlint, and both Play APK artifacts assemble successfully:

```text
./gradlew :app:testPlayDebugUnitTest :app:testThirdPartyDebugUnitTest \
  --tests ai.openclaw.app.ui.chat.ChatMessageViewsTest \
  --tests ai.openclaw.app.ui.chat.ChatMessageActionsTest \
  --tests ai.openclaw.app.chat.ChatControllerSessionActionsTest \
  --tests ai.openclaw.app.chat.ChatControllerBranchCoordinationTest \
  :app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck \
  :app:assemblePlayDebug :app:assemblePlayDebugAndroidTest

BUILD SUCCESSFUL (182 tasks)
```

Production delta: +22/-20, net +2 lines for the necessary plaintext-only action grouping; regression coverage adds 71 test lines. Independent final structured review reported no actionable findings.
