### PR TITLE
fix(tui): make provider-specific thinking labels selectable

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -2473,6 +2473,93 @@ describe("tui command handlers", () => {
   });
 
   it.each([
+    {
+      name: "provider-specific binary on",
+      local: false,
+      levels: [
+        { id: "off", label: "off" },
+        { id: "high", label: "on" },
+      ],
+      input: "on",
+      expected: "high",
+    },
+    {
+      name: "case-insensitive binary on in embedded mode",
+      local: true,
+      levels: [{ id: "high", label: "on" }],
+      input: "ON",
+      expected: "high",
+    },
+    {
+      name: "always-on high profile",
+      local: false,
+      levels: [{ id: "high", label: "always on" }],
+      input: "always on",
+      expected: "high",
+    },
+    {
+      name: "always-on off profile",
+      local: false,
+      levels: [{ id: "off", label: "always on" }],
+      input: "always on",
+      expected: "off",
+    },
+    {
+      name: "Moonshot binary on",
+      local: false,
+      levels: [{ id: "low", label: "on" }],
+      input: "on",
+      expected: "low",
+    },
+    {
+      name: "canonical id ahead of another option's label",
+      local: false,
+      levels: [
+        { id: "low", label: "high" },
+        { id: "high", label: "turbo" },
+      ],
+      input: "high",
+      expected: "high",
+    },
+  ])(
+    "resolves $name to its canonical thinking level",
+    async ({ local, levels, input, expected }) => {
+      const { handleCommand, patchSession, addSystem } = createHarness({
+        opts: { local },
+        sessionInfo: { thinkingLevels: levels },
+      });
+
+      await handleCommand(`/think ${input}`);
+
+      expect(patchSession).toHaveBeenCalledWith({
+        key: "agent:main:main",
+        thinkingLevel: expected,
+      });
+      expect(addSystem).toHaveBeenCalledWith(`thinking set to ${input}`);
+    },
+  );
+
+  it.each([undefined, []])(
+    "resolves thinking labels from the provider policy when session levels are %j",
+    async (thinkingLevels) => {
+      const { handleCommand, patchSession } = createHarness({
+        sessionInfo: {
+          modelProvider: "opencode-go",
+          model: "minimax-m3",
+          thinkingLevels,
+        },
+      });
+
+      await handleCommand("/think on");
+
+      expect(patchSession).toHaveBeenCalledWith({
+        key: "agent:main:main",
+        thinkingLevel: "high",
+      });
+    },
+  );
+
+  it.each([
     { command: "verbose", usage: "usage: /verbose <on|off|full>" },
     { command: "reasoning", usage: "usage: /reasoning <on|off|stream>" },
   ])("shows the complete canonical no-argument /$command usage", async ({ command, usage }) => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -8,8 +8,8 @@ import { modelKey } from "../agents/model-ref-shared.js";
 import { shouldForwardModelCommandToServer } from "../auto-reply/commands-registry.shared.js";
 import { normalizeGroupActivation } from "../auto-reply/group-activation.js";
 import {
-  formatThinkingLevels,
   isSessionDefaultDirectiveValue,
+  listThinkingLevelOptions,
   normalizeUsageDisplay,
   resolveResponseUsageMode,
 } from "../auto-reply/thinking.js";
@@ -632,20 +632,20 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     },
     models: async () => await openModelSelector(),
     think: async (args) => {
+      const { thinkingLevels, modelProvider, model, agentRuntime } = state.sessionInfo;
+      const levels = thinkingLevels?.length
+        ? thinkingLevels
+        : listThinkingLevelOptions(modelProvider, model, undefined, agentRuntime?.id);
       if (!args) {
-        const levels =
-          state.sessionInfo.thinkingLevels?.map((level) => level.label).join("|") ||
-          formatThinkingLevels(
-            state.sessionInfo.modelProvider,
-            state.sessionInfo.model,
-            "|",
-            undefined,
-            state.sessionInfo.agentRuntime?.id,
-          );
-        chatLog.addSystem(`usage: /think <${levels}|default>`);
+        chatLog.addSystem(`usage: /think <${levels.map(({ label }) => label).join("|")}|default>`);
         return;
       }
-      const thinkingLevel = isSessionDefaultDirectiveValue(args) ? null : args;
+      const normalized = args.toLowerCase();
+      const thinkingLevel = isSessionDefaultDirectiveValue(args)
+        ? null
+        : (levels.find(({ id }) => id.toLowerCase() === normalized)?.id ??
+          levels.find(({ label }) => label.toLowerCase() === normalized)?.id ??
+          args);
       await applySessionSetting({ thinkingLevel }, `thinking set to ${args}`, "think failed");
     },
     verbose: async (args) => {

--- a/src/tui/tui-session-identity-pty.e2e.test.ts
+++ b/src/tui/tui-session-identity-pty.e2e.test.ts
@@ -74,6 +74,39 @@ afterEach(async () => {
   await disposeActiveTuiFixtures();
 });
 
+it("submits provider-specific thinking labels with one Enter", async () => {
+  const fixture = await startTuiFixture({
+    env: {
+      OPENCLAW_TUI_PTY_THINKING_LABEL: "on",
+      OPENCLAW_TUI_PTY_SAFE_THINKING_LABEL: "always on",
+    },
+  });
+
+  try {
+    await fixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+
+    for (const [index, { label, id }] of [
+      { label: "on", id: "fixture-thinking" },
+      { label: "always on", id: "fixture-thinking-safe" },
+    ].entries()) {
+      await fixture.run.write(`/think ${label}`, { delay: false });
+      await fixture.run.waitForOutput(`→ ${label}`, STARTUP_TIMEOUT_MS);
+      await fixture.run.write("\r", { delay: false });
+      const entries = await waitForLogCount({
+        logPath: fixture.logPath,
+        predicate: (entry) => entry.method === "patchSession",
+        count: index + 1,
+      });
+      expect(entries.findLast((entry) => entry.method === "patchSession")?.payload).toMatchObject({
+        thinkingLevel: id,
+      });
+      await fixture.run.waitForOutput(`thinking set to ${label}`, STARTUP_TIMEOUT_MS);
+    }
+  } finally {
+    await fixture.cleanup();
+  }
+}, 65_000);
+
 it("clears the previous display name when the selected session is unnamed", async () => {
   const fixture = await startTuiFixture();
   try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting `/think on` or `/think always on` in the terminal UI would receive an unsupported-thinking-level error when their provider uses a different canonical effort identifier for the displayed label. OpenCode Go MiniMax M3 advertises `on` for `high`, Moonshot advertises `on` for `low`, and always-on profiles can resolve to either `high` or `off`.

## Why This Change Was Made

Resolve the active provider's displayed thinking labels at the TUI command owner before updating the session. Prefer an explicitly entered canonical ID over a colliding label, reuse the provider's existing thinking policy when session options are absent, and preserve provider-owned display labels, existing completions, single-Enter submission, case-insensitive input, and default/inherit reset behavior.

Production LOC: +12/-12 (net 0). Tests: +120/-0.

## User Impact

Users can choose the exact thinking labels shown by `/help`, `/think`, and terminal completion across OpenCode Go, Moonshot, and other provider-defined profiles. Both Gateway and embedded TUI modes store the provider's intended canonical setting without changing the visible command experience.

## Evidence

- Before the fix, seven owner-boundary regression cases failed because `on`, `ON`, and `always on` were sent verbatim instead of their active provider's canonical ID; the new exact-ID collision case also guards against ambiguous provider labels.
- Before the fix, the real pseudo-terminal regression failed with `thinkingLevel: "on"` instead of `thinkingLevel: "fixture-thinking"`. After the fix, the same terminal submits both `on` and `always on` with one Enter and the fake backend receives their distinct canonical IDs. This exercises the real TUI terminal loop; it does not claim live provider or Gateway transport coverage.
- `node scripts/run-vitest.mjs src/tui/tui-command-handlers.test.ts src/tui/commands.test.ts src/tui/tui-session-actions.test.ts src/tui/tui.submit-handler.test.ts src/tui/tui-session-events.test.ts` — 392 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-session-identity-pty.e2e.test.ts -t 'submits provider-specific thinking labels'` — passed.
- `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs` — passed all formatting, lint, production/test TypeScript, dead-export, architecture, database-first, import-cycle, and authorization guards.
- Independent structured Codex review: clean, no accepted/actionable findings.
- The broader PTY stress run separately exposed an existing xAI spending-limit error-display failure; its isolated owner unit passes while the untouched PTY case fails. That unrelated event-rendering boundary remains a named follow-up, as does the analogous thinking-label resolution in the Control UI.
