### PR TITLE
fix(config): structure noninteractive preflight warnings

### DIFF
--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -8,6 +8,8 @@ import { writeConfigHealthStateToStore } from "../config/io.health-state.js";
 import { createConfigHealthFingerprint } from "../config/io.observe-state.js";
 import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import { resetLogger, setLoggerOverride } from "../logging/logger.js";
+import { loggingState } from "../logging/state.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -76,10 +78,16 @@ async function seedLastKnownGood(
 describe("runDoctorConfigPreflight", () => {
   afterEach(() => {
     closeOpenClawStateDatabaseForTest();
+    resetLogger();
     noteMock.mockClear();
+    vi.restoreAllMocks();
   });
 
-  it("renders legacy context-budget notices with their config paths", async () => {
+  it("logs config warnings as structured records when stdout is non-interactive", async () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "warn", consoleStyle: "json" });
+    const consoleSink = loggingState.rawConsole ?? console;
+    const warnSpy = vi.spyOn(consoleSink, "warn").mockImplementation(() => undefined);
+
     await withTempHome(async (home) => {
       await writeOpenClawConfig(home, {
         models: { providers: { openai: { contextTokens: 64_000 } } },
@@ -90,11 +98,48 @@ describe("runDoctorConfigPreflight", () => {
         migrateLegacyConfig: false,
         invalidConfigNote: false,
       });
-
-      const output = noteMock.mock.calls.map(([message]) => message).join("\n");
-      expect(output).toContain("- models.providers.openai.contextTokens:");
-      expect(output).not.toContain("- : ");
     });
+
+    const records = warnSpy.mock.calls
+      .map(([value]) => String(value).trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        subsystem: "config",
+        message: expect.stringContaining("models.providers.openai.contextTokens"),
+      }),
+    );
+    expect(noteMock).not.toHaveBeenCalledWith(expect.anything(), "Config warnings");
+  });
+
+  it("renders legacy context-budget notices with their config paths", async () => {
+    const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+    try {
+      await withTempHome(async (home) => {
+        await writeOpenClawConfig(home, {
+          models: { providers: { openai: { contextTokens: 64_000 } } },
+        });
+
+        await runDoctorConfigPreflight({
+          migrateState: false,
+          migrateLegacyConfig: false,
+          invalidConfigNote: false,
+        });
+
+        const output = noteMock.mock.calls.map(([message]) => message).join("\n");
+        expect(output).toContain("- models.providers.openai.contextTokens:");
+        expect(output).not.toContain("- : ");
+      });
+    } finally {
+      if (originalIsTTY) {
+        Object.defineProperty(process.stdout, "isTTY", originalIsTTY);
+      } else {
+        Reflect.deleteProperty(process.stdout, "isTTY");
+      }
+    }
   });
 
   it("supports non-observing config reads", async () => {

--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -24,6 +24,20 @@ const noteMock = vi.hoisted(() => vi.fn<(message: string, title?: string) => voi
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({ note: noteMock }));
 
+async function withStdoutIsTTY<T>(isTTY: boolean, run: () => Promise<T>): Promise<T> {
+  const original = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+  Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: isTTY });
+  try {
+    return await run();
+  } finally {
+    if (original) {
+      Object.defineProperty(process.stdout, "isTTY", original);
+    } else {
+      Reflect.deleteProperty(process.stdout, "isTTY");
+    }
+  }
+}
+
 type ConfigHealthDatabase = Pick<OpenClawStateKyselyDatabase, "config_health_entries">;
 
 function readConfigHealthRow(env: NodeJS.ProcessEnv, configPath: string) {
@@ -84,40 +98,40 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("logs config warnings as structured records when stdout is non-interactive", async () => {
-    setLoggerOverride({ level: "silent", consoleLevel: "warn", consoleStyle: "json" });
-    const consoleSink = loggingState.rawConsole ?? console;
-    const warnSpy = vi.spyOn(consoleSink, "warn").mockImplementation(() => undefined);
+    await withStdoutIsTTY(false, async () => {
+      setLoggerOverride({ level: "silent", consoleLevel: "warn", consoleStyle: "json" });
+      const consoleSink = loggingState.rawConsole ?? console;
+      const warnSpy = vi.spyOn(consoleSink, "warn").mockImplementation(() => undefined);
 
-    await withTempHome(async (home) => {
-      await writeOpenClawConfig(home, {
-        models: { providers: { openai: { contextTokens: 64_000 } } },
+      await withTempHome(async (home) => {
+        await writeOpenClawConfig(home, {
+          models: { providers: { openai: { contextTokens: 64_000 } } },
+        });
+
+        await runDoctorConfigPreflight({
+          migrateState: false,
+          migrateLegacyConfig: false,
+          invalidConfigNote: false,
+        });
       });
 
-      await runDoctorConfigPreflight({
-        migrateState: false,
-        migrateLegacyConfig: false,
-        invalidConfigNote: false,
-      });
+      const records = warnSpy.mock.calls
+        .map(([value]) => String(value).trim())
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+      expect(records).toContainEqual(
+        expect.objectContaining({
+          level: "warn",
+          subsystem: "config",
+          message: expect.stringContaining("models.providers.openai.contextTokens"),
+        }),
+      );
+      expect(noteMock).not.toHaveBeenCalledWith(expect.anything(), "Config warnings");
     });
-
-    const records = warnSpy.mock.calls
-      .map(([value]) => String(value).trim())
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as Record<string, unknown>);
-    expect(records).toContainEqual(
-      expect.objectContaining({
-        level: "warn",
-        subsystem: "config",
-        message: expect.stringContaining("models.providers.openai.contextTokens"),
-      }),
-    );
-    expect(noteMock).not.toHaveBeenCalledWith(expect.anything(), "Config warnings");
   });
 
   it("renders legacy context-budget notices with their config paths", async () => {
-    const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
-    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
-    try {
+    await withStdoutIsTTY(true, async () => {
       await withTempHome(async (home) => {
         await writeOpenClawConfig(home, {
           models: { providers: { openai: { contextTokens: 64_000 } } },
@@ -133,13 +147,7 @@ describe("runDoctorConfigPreflight", () => {
         expect(output).toContain("- models.providers.openai.contextTokens:");
         expect(output).not.toContain("- : ");
       });
-    } finally {
-      if (originalIsTTY) {
-        Object.defineProperty(process.stdout, "isTTY", originalIsTTY);
-      } else {
-        Reflect.deleteProperty(process.stdout, "isTTY");
-      }
-    }
+    });
   });
 
   it("supports non-observing config reads", async () => {

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -9,6 +9,7 @@ import {
   recoverConfigFromLastKnownGood,
 } from "../config/io.js";
 import type { ConfigSnapshotReadMeasure } from "../config/io.js";
+import { logConfigWarningsOnce } from "../config/io.warnings.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import type { ConfigFileSnapshot } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -17,6 +18,7 @@ import type {
   MigrationCheckpointIdentity,
   StartupMigrationLease,
 } from "../infra/startup-migration-checkpoint.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
@@ -53,6 +55,8 @@ const loadDoctorStateMigrations = createLazyRuntimeModule(
 const loadLegacyCronRepair = createLazyRuntimeModule(
   () => import("./doctor/cron/legacy-repair.js"),
 );
+
+const configLog = createSubsystemLogger("config");
 
 export type DoctorConfigPreflightResult = {
   snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
@@ -418,7 +422,12 @@ export async function runDoctorConfigPreflight(
 
     const warnings = snapshot.warnings ?? [];
     if (warnings.length > 0) {
-      note(formatConfigIssueLines(warnings, "-").join("\n"), "Config warnings");
+      // Non-interactive Gateway stdout is a log stream; preserve its structured logging contract.
+      if (process.stdout.isTTY) {
+        note(formatConfigIssueLines(warnings, "-").join("\n"), "Config warnings");
+      } else {
+        logConfigWarningsOnce({ configPath: snapshot.path, warnings, logger: configLog });
+      }
     }
 
     const baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};

--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -214,7 +214,7 @@ describe("config io paths", () => {
       load();
       expect(logger.warn).toHaveBeenCalledTimes(1);
       expect(logger.warn).toHaveBeenCalledWith(
-        "Config warnings:\n- plugins.entries.google-antigravity-auth: plugin removed: google-antigravity-auth (stale config entry ignored; remove it from plugins config)",
+        "Config warnings: plugins.entries.google-antigravity-auth: plugin removed: google-antigravity-auth (stale config entry ignored; remove it from plugins config)",
       );
 
       createConfigIO({

--- a/src/config/io.state.test.ts
+++ b/src/config/io.state.test.ts
@@ -92,4 +92,20 @@ describe("config IO state caches", () => {
     expect(loggedConfigWarningFingerprints.size).toBe(CACHE_MAX_SIZE);
     expect(warnSpy).toHaveBeenCalledTimes(CACHE_MAX_SIZE + 2);
   });
+
+  it("emits each config warning record on one physical line", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    logConfigWarningsOnce({
+      configPath: "/config.json",
+      warnings: [
+        { path: "root", message: "first line\ncontinuation" },
+        { path: "nested.value", message: "second warning" },
+      ],
+      logger: console,
+    });
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(String(warnSpy.mock.calls[0]?.[0])).not.toContain("\n");
+  });
 });

--- a/src/config/io.warnings.ts
+++ b/src/config/io.warnings.ts
@@ -9,10 +9,6 @@ import {
 import type { OpenClawConfig } from "./types.js";
 import { shouldWarnOnTouchedVersion } from "./version.js";
 
-function sanitizeConfigWarningSegment(value: string): string {
-  return sanitizeTerminalText(value).replace(/\s*(?:\r\n|[\r\n])+\s*/gu, " ");
-}
-
 export function warnOnConfigMiskeys(raw: unknown, logger: Pick<typeof console, "warn">): void {
   if (!raw || typeof raw !== "object") {
     return;
@@ -40,7 +36,7 @@ export function logConfigWarningsOnce(params: {
   const details = params.warnings
     .map(
       (warning) =>
-        `${sanitizeConfigWarningSegment(warning.path || "<root>")}: ${sanitizeConfigWarningSegment(warning.message)}`,
+        `${sanitizeTerminalText(warning.path || "<root>")}: ${sanitizeTerminalText(warning.message)}`,
     )
     .join("; ");
   const fingerprint = hashConfigRaw(details);

--- a/src/config/io.warnings.ts
+++ b/src/config/io.warnings.ts
@@ -9,6 +9,10 @@ import {
 import type { OpenClawConfig } from "./types.js";
 import { shouldWarnOnTouchedVersion } from "./version.js";
 
+function sanitizeConfigWarningSegment(value: string): string {
+  return sanitizeTerminalText(value).replace(/\s*(?:\r\n|[\r\n])+\s*/gu, " ");
+}
+
 export function warnOnConfigMiskeys(raw: unknown, logger: Pick<typeof console, "warn">): void {
   if (!raw || typeof raw !== "object") {
     return;
@@ -36,16 +40,16 @@ export function logConfigWarningsOnce(params: {
   const details = params.warnings
     .map(
       (warning) =>
-        `- ${sanitizeTerminalText(warning.path || "<root>")}: ${sanitizeTerminalText(warning.message)}`,
+        `${sanitizeConfigWarningSegment(warning.path || "<root>")}: ${sanitizeConfigWarningSegment(warning.message)}`,
     )
-    .join("\n");
+    .join("; ");
   const fingerprint = hashConfigRaw(details);
   if (loggedConfigWarningFingerprints.get(params.configPath) === fingerprint) {
     setBoundedConfigIoWarningEntry(loggedConfigWarningFingerprints, params.configPath, fingerprint);
     return;
   }
   setBoundedConfigIoWarningEntry(loggedConfigWarningFingerprints, params.configPath, fingerprint);
-  params.logger.warn(`Config warnings:\n${details}`);
+  params.logger.warn(`Config warnings: ${details}`);
 }
 
 export function warnIfConfigFromFuture(


### PR DESCRIPTION
## What Problem This Solves

Gateway config preflight rendered warnings with a Clack note even when stdout was non-interactive. That put untagged box-drawing lines into daemon log streams and bypassed `logging.consoleStyle: "json"`.

Closes #129842.

## Why This Change Was Made

`runDoctorConfigPreflight` owns this presentation boundary:

- Interactive stdout keeps the existing grouped Clack note.
- Non-interactive stdout routes the same warnings through `logConfigWarningsOnce` and the `config` subsystem logger.
- The existing sanitizer, fingerprint dedupe, file logging, level, subsystem, and JSON console style remain in one canonical path.

No config key, schema, protocol, storage, authentication, or migration contract changes.

## User Impact

Gateway operators using line-oriented or JSON log ingestion now receive one attributable warning record instead of a raw multi-line terminal box. Interactive terminal users retain the existing note UI.

Risk is limited to the intentional non-interactive warning presentation change. Warning text and validation outcomes are unchanged.

Production delta: +13/-4, net +9. Test delta: +82/-13, net +69.

## Evidence

### Built Gateway red/green proof

Exact current main: `b05213c066d55ece2754f1efb6b977df8db1cdd7`.

Exact fixed head: `c1f6a2219e159fc20ec663794b0451eae838e18e`.

Four isolated built Gateway runs used the same JSON logging config and a unique missing-plugin warning. Each process used disposable state and a separate port.

Current main, non-interactive stdout:

```text
│
◇  Config warnings ──────────────────────────────────────────────────╮
│  - plugins.entries.missing-pr129954-c1f6a221-b05213c0: plugin not  │
│    found: missing-pr129954-c1f6a221-b05213c0                       │
```

Fixed head, non-interactive output:

```json
{"level":"warn","subsystem":"config","message":"Config warnings: plugins.entries.missing-pr129954-c1f6a221-b05213c0: plugin not found: missing-pr129954-c1f6a221-b05213c0 (stale config entry ignored; remove it from plugins config)"}
```

Assertions:

```text
main-nontty: raw_box_stdout=true structured_warnings=0
main-tty: raw_box=true structured_warnings=0
head-nontty: raw_box=false structured_warnings=1
head-tty: raw_box=true structured_warnings=0
```

The unique plugin ID proves each run consumed the test config. Exactly one fixed-head warning record proves the shared dedupe still suppresses duplicate emission. Both pseudo-terminal runs retained the interactive note.

### Regression and focused checks

```text
Current-main owner-boundary regression:
  1 expected failure: non-TTY preflight produced no structured record

Current-main serializer regression:
  1 expected failure: the warning record contained physical newlines

Fixed head:
  136 focused tests passed across preflight, config I/O, process, config guard,
  console capture, and startup policy.

Formatting, focused Oxlint, git diff --check, and every permitted non-type-check
changed-scope ratchet passed. Hosted CI owns the full type-check and build gates.
```

All isolated Gateway processes exited, their ports were released, and disposable state was removed after the raw outputs and hashes were retained.

## Disclosure

AI-assisted contribution. The fix was reproduced on current main, verified through exact built Gateway red/green runs, and checked with focused regression coverage.
