### PR TITLE
fix(ci): publish maturity scorecards when main advances

### DIFF
--- a/.github/actions/publish-generated-pr/action.yml
+++ b/.github/actions/publish-generated-pr/action.yml
@@ -34,7 +34,8 @@ inputs:
     required: true
   invalidation-paths:
     description: Newline-delimited generator input paths that make an older run stale.
-    required: true
+    required: false
+    default: ""
   working-directory:
     description: Repository root containing the generated files.
     required: false
@@ -123,10 +124,6 @@ runs:
             invalidation_paths+=("${invalidation_path}")
           fi
         done <<< "${INVALIDATION_PATHS}"
-        if [[ "${#invalidation_paths[@]}" -eq 0 ]]; then
-          echo "Generated PR publication requires at least one invalidation path." >&2
-          exit 1
-        fi
 
         find_open_pr() {
           timeout --signal=TERM --kill-after=10s 60s \
@@ -143,7 +140,8 @@ runs:
             echo "::error::Resolved workflow source is not an ancestor of latest ${BASE_BRANCH}."
             return 1
           fi
-          if ! git diff --quiet "${source_commit}" "${base_ref}" -- "${invalidation_paths[@]}"; then
+          if [[ "${#invalidation_paths[@]}" -gt 0 ]] &&
+            ! git diff --quiet "${source_commit}" "${base_ref}" -- "${invalidation_paths[@]}"; then
             neutralize_outcome=stale-input
           elif find_owned_path_overlap; then
             neutralize_outcome=overlap
@@ -274,7 +272,8 @@ runs:
 
           # A completed older run must never publish output after a newer base changed generator
           # inputs. The caller chooses whether a guaranteed successor can own reconciliation.
-          if ! git diff --quiet "${source_commit}" "${base_ref}" -- "${invalidation_paths[@]}"; then
+          if [[ "${#invalidation_paths[@]}" -gt 0 ]] &&
+            ! git diff --quiet "${source_commit}" "${base_ref}" -- "${invalidation_paths[@]}"; then
             echo "::notice::Stale generated output detected because generator inputs changed on ${BASE_BRANCH}."
             prepare_outcome=stale-input
             return 0

--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -242,13 +242,23 @@ jobs:
             echo "expected_sha must be a full 40-character SHA; got: ${EXPECTED_SHA}" >&2
             exit 1
           fi
-          if [[ -n "${expected_sha// }" && "$selected_revision" != "$expected_sha" ]]; then
-            echo "Ref '${INPUT_REF}' resolved to ${selected_revision}, expected ${EXPECTED_SHA}." >&2
+          if [[ ! "$SUCCESSOR_ATTEMPT" =~ ^[0-2]$ ]]; then
+            echo "successor_attempt must be 0, 1, or 2." >&2
             exit 1
           fi
 
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          if [[ -z "${expected_sha// }" && "$branch_candidate" == "$DEFAULT_BRANCH" ]]; then
+          if [[ -n "${expected_sha// }" && "$selected_revision" != "$expected_sha" ]]; then
+            if [[ "$SUCCESSOR_ATTEMPT" == "0" || "$branch_candidate" != "$DEFAULT_BRANCH" ]] ||
+              ! git merge-base --is-ancestor "$expected_sha" refs/remotes/origin/main; then
+              echo "Ref '${INPUT_REF}' resolved to ${selected_revision}, expected ${EXPECTED_SHA}." >&2
+              exit 1
+            fi
+            # A queued successor may start after main advances. Refreeze only a forward-moving
+            # main descendant here; arbitrary mismatches and the initial dispatch still fail.
+            floating_default_branch=true
+            selected_revision="$(git rev-parse refs/remotes/origin/main)"
+          elif [[ -z "${expected_sha// }" && "$branch_candidate" == "$DEFAULT_BRANCH" ]]; then
             # A direct main dispatch may wait while checkout fetches full history. Freeze the
             # latest fetched main here so later reusable jobs never receive a moving branch.
             floating_default_branch=true
@@ -275,10 +285,6 @@ jobs:
 
           if [[ ! "$EVIDENCE_RUN_ID" =~ ^[0-9]+$ ]]; then
             echo "qa_evidence_run_id must be a numeric GitHub Actions run id." >&2
-            exit 1
-          fi
-          if [[ ! "$SUCCESSOR_ATTEMPT" =~ ^[0-2]$ ]]; then
-            echo "successor_attempt must be 0, 1, or 2." >&2
             exit 1
           fi
           publication_base="${DEFAULT_BRANCH}"

--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -27,6 +27,11 @@ on:
         required: false
         default: true
         type: boolean
+      successor_attempt:
+        description: Internal bounded retry count for stale generated output
+        required: false
+        default: "0"
+        type: string
   workflow_call:
     inputs:
       qa_evidence_run_id:
@@ -48,6 +53,11 @@ on:
         required: false
         default: false
         type: boolean
+      successor_attempt:
+        description: Internal bounded retry count for stale generated output
+        required: false
+        default: "0"
+        type: string
     secrets:
       OPENAI_API_KEY:
         description: OpenAI API key used by live QA profile scenarios
@@ -217,6 +227,7 @@ jobs:
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           INPUT_REF: ${{ inputs.ref }}
           PUBLISH_PULL_REQUEST: ${{ inputs.publish_pull_request }}
+          SUCCESSOR_ATTEMPT: ${{ inputs.successor_attempt }}
         shell: bash
         run: |
           set -euo pipefail
@@ -264,6 +275,10 @@ jobs:
 
           if [[ ! "$EVIDENCE_RUN_ID" =~ ^[0-9]+$ ]]; then
             echo "qa_evidence_run_id must be a numeric GitHub Actions run id." >&2
+            exit 1
+          fi
+          if [[ ! "$SUCCESSOR_ATTEMPT" =~ ^[0-2]$ ]]; then
+            echo "successor_attempt must be 0, 1, or 2." >&2
             exit 1
           fi
           publication_base="${DEFAULT_BRANCH}"
@@ -694,7 +709,7 @@ jobs:
         needs.validate_selected_ref.outputs.workflow_repository == 'openclaw/openclaw' }}
     runs-on: ubuntu-24.04
     permissions:
-      actions: read
+      actions: write
       contents: read
     steps:
       - name: Checkout trusted workflow source
@@ -811,7 +826,9 @@ jobs:
             :(exclude)qa/maturity-scores.yaml
             :(exclude)docs/maturity/scorecard.md
             :(exclude)docs/maturity/taxonomy.md
-          overlap-policy: fail
+          # A stale run hands off to the bounded successor step below. Keep all repository
+          # inputs invalidating so the successor always scores one immutable current snapshot.
+          overlap-policy: defer
           pr-body: |
             ## What Problem This Solves
 
@@ -831,3 +848,46 @@ jobs:
             - Source SHA: `${{ needs.validate_selected_ref.outputs.selected_revision }}`
             - QA evidence run: `${{ inputs.qa_evidence_run_id || github.run_id }}`
             - Strict score validation and maturity docs rendering passed.
+
+      - name: Dispatch latest-base successor
+        env:
+          ALLOW_FAILURES: ${{ inputs.allow_failures }}
+          BASE_BRANCH: ${{ needs.validate_selected_ref.outputs.publication_base }}
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.validate_selected_ref.outputs.selected_revision }}
+          SUCCESSOR_ATTEMPT: ${{ inputs.successor_attempt }}
+        working-directory: selected
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "+refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
+          latest_sha="$(git rev-parse "refs/remotes/origin/${BASE_BRANCH}")"
+          if [[ "$latest_sha" == "$SOURCE_SHA" ]]; then
+            exit 0
+          fi
+
+          max_successor_attempts=2
+          if (( SUCCESSOR_ATTEMPT >= max_successor_attempts )); then
+            echo "::error::Maturity scorecard remained stale after ${SUCCESSOR_ATTEMPT} successor attempts."
+            exit 1
+          fi
+
+          next_attempt="$((SUCCESSOR_ATTEMPT + 1))"
+          successor_url="$(
+            gh workflow run maturity-scorecard.yml \
+              --repo "$GITHUB_REPOSITORY" \
+              --ref main \
+              -f ref="$BASE_BRANCH" \
+              -f expected_sha="$latest_sha" \
+              -f publish_pull_request=true \
+              -f allow_failures="$ALLOW_FAILURES" \
+              -f successor_attempt="$next_attempt"
+          )"
+          {
+            echo "### Stale maturity scorecard handoff"
+            echo
+            echo "- Stale source: \`$SOURCE_SHA\`"
+            echo "- Latest base: \`$latest_sha\`"
+            echo "- Successor attempt: \`$next_attempt/$max_successor_attempts\`"
+            echo "- Successor run: $successor_url"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -27,11 +27,6 @@ on:
         required: false
         default: true
         type: boolean
-      successor_attempt:
-        description: Internal bounded retry count for stale generated output
-        required: false
-        default: "0"
-        type: string
   workflow_call:
     inputs:
       qa_evidence_run_id:
@@ -53,11 +48,6 @@ on:
         required: false
         default: false
         type: boolean
-      successor_attempt:
-        description: Internal bounded retry count for stale generated output
-        required: false
-        default: "0"
-        type: string
     secrets:
       OPENAI_API_KEY:
         description: OpenAI API key used by live QA profile scenarios
@@ -227,7 +217,6 @@ jobs:
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           INPUT_REF: ${{ inputs.ref }}
           PUBLISH_PULL_REQUEST: ${{ inputs.publish_pull_request }}
-          SUCCESSOR_ATTEMPT: ${{ inputs.successor_attempt }}
         shell: bash
         run: |
           set -euo pipefail
@@ -242,23 +231,13 @@ jobs:
             echo "expected_sha must be a full 40-character SHA; got: ${EXPECTED_SHA}" >&2
             exit 1
           fi
-          if [[ ! "$SUCCESSOR_ATTEMPT" =~ ^[0-2]$ ]]; then
-            echo "successor_attempt must be 0, 1, or 2." >&2
+          if [[ -n "${expected_sha// }" && "$selected_revision" != "$expected_sha" ]]; then
+            echo "Ref '${INPUT_REF}' resolved to ${selected_revision}, expected ${EXPECTED_SHA}." >&2
             exit 1
           fi
 
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          if [[ -n "${expected_sha// }" && "$selected_revision" != "$expected_sha" ]]; then
-            if [[ "$SUCCESSOR_ATTEMPT" == "0" || "$branch_candidate" != "$DEFAULT_BRANCH" ]] ||
-              ! git merge-base --is-ancestor "$expected_sha" refs/remotes/origin/main; then
-              echo "Ref '${INPUT_REF}' resolved to ${selected_revision}, expected ${EXPECTED_SHA}." >&2
-              exit 1
-            fi
-            # A queued successor may start after main advances. Refreeze only a forward-moving
-            # main descendant here; arbitrary mismatches and the initial dispatch still fail.
-            floating_default_branch=true
-            selected_revision="$(git rev-parse refs/remotes/origin/main)"
-          elif [[ -z "${expected_sha// }" && "$branch_candidate" == "$DEFAULT_BRANCH" ]]; then
+          if [[ -z "${expected_sha// }" && "$branch_candidate" == "$DEFAULT_BRANCH" ]]; then
             # A direct main dispatch may wait while checkout fetches full history. Freeze the
             # latest fetched main here so later reusable jobs never receive a moving branch.
             floating_default_branch=true
@@ -715,7 +694,7 @@ jobs:
         needs.validate_selected_ref.outputs.workflow_repository == 'openclaw/openclaw' }}
     runs-on: ubuntu-24.04
     permissions:
-      actions: write
+      actions: read
       contents: read
     steps:
       - name: Checkout trusted workflow source
@@ -827,14 +806,8 @@ jobs:
             qa/maturity-scores.yaml
             docs/maturity/scorecard.md
             docs/maturity/taxonomy.md
-          invalidation-paths: |
-            .
-            :(exclude)qa/maturity-scores.yaml
-            :(exclude)docs/maturity/scorecard.md
-            :(exclude)docs/maturity/taxonomy.md
-          # A stale run hands off to the bounded successor step below. Keep all repository
-          # inputs invalidating so the successor always scores one immutable current snapshot.
-          overlap-policy: defer
+          invalidation-paths: ""
+          overlap-policy: fail
           pr-body: |
             ## What Problem This Solves
 
@@ -854,46 +827,3 @@ jobs:
             - Source SHA: `${{ needs.validate_selected_ref.outputs.selected_revision }}`
             - QA evidence run: `${{ inputs.qa_evidence_run_id || github.run_id }}`
             - Strict score validation and maturity docs rendering passed.
-
-      - name: Dispatch latest-base successor
-        env:
-          ALLOW_FAILURES: ${{ inputs.allow_failures }}
-          BASE_BRANCH: ${{ needs.validate_selected_ref.outputs.publication_base }}
-          GH_TOKEN: ${{ github.token }}
-          SOURCE_SHA: ${{ needs.validate_selected_ref.outputs.selected_revision }}
-          SUCCESSOR_ATTEMPT: ${{ inputs.successor_attempt }}
-        working-directory: selected
-        run: |
-          set -euo pipefail
-          git fetch --no-tags origin \
-            "+refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
-          latest_sha="$(git rev-parse "refs/remotes/origin/${BASE_BRANCH}")"
-          if [[ "$latest_sha" == "$SOURCE_SHA" ]]; then
-            exit 0
-          fi
-
-          max_successor_attempts=2
-          if (( SUCCESSOR_ATTEMPT >= max_successor_attempts )); then
-            echo "::error::Maturity scorecard remained stale after ${SUCCESSOR_ATTEMPT} successor attempts."
-            exit 1
-          fi
-
-          next_attempt="$((SUCCESSOR_ATTEMPT + 1))"
-          successor_url="$(
-            gh workflow run maturity-scorecard.yml \
-              --repo "$GITHUB_REPOSITORY" \
-              --ref main \
-              -f ref="$BASE_BRANCH" \
-              -f expected_sha="$latest_sha" \
-              -f publish_pull_request=true \
-              -f allow_failures="$ALLOW_FAILURES" \
-              -f successor_attempt="$next_attempt"
-          )"
-          {
-            echo "### Stale maturity scorecard handoff"
-            echo
-            echo "- Stale source: \`$SOURCE_SHA\`"
-            echo "- Latest base: \`$latest_sha\`"
-            echo "- Successor attempt: \`$next_attempt/$max_successor_attempts\`"
-            echo "- Successor run: $successor_url"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1124,39 +1124,6 @@ function runQaSelectedRefValidation(
   return { ...result, outputs: readWorkflowOutputs(githubOutput) };
 }
 
-function runMaturitySelectedRefValidation(params: {
-  topology: ReturnType<typeof createQaProtocolTopology>;
-  expectedSha: string;
-  revision: string;
-  successorAttempt: string;
-}) {
-  runGit(params.topology.checkout, ["checkout", "-q", "--detach", params.revision]);
-  const githubOutput = path.join(params.topology.checkout, "github-output");
-  rmSync(githubOutput, { force: true });
-  const validateStep = expectDefined(
-    readMaturityScorecardWorkflow().jobs.validate_selected_ref.steps.find(
-      (step: WorkflowStep) => step.name === "Validate selected ref",
-    ),
-    "maturity selected-ref validation step",
-  );
-  const result = runWorkflowShellScript(expectDefined(validateStep.run, "validation script"), {
-    cwd: params.topology.checkout,
-    env: {
-      ...process.env,
-      DEFAULT_BRANCH: "main",
-      EVIDENCE_RUN_ID: "42",
-      EXPECTED_SHA: params.expectedSha,
-      GITHUB_OUTPUT: githubOutput,
-      GITHUB_STEP_SUMMARY: path.join(params.topology.checkout, "github-summary"),
-      INPUT_REF: "main",
-      PATH: `${params.topology.fakeBin}:${process.env.PATH ?? ""}`,
-      PUBLISH_PULL_REQUEST: "false",
-      SUCCESSOR_ATTEMPT: params.successorAttempt,
-    },
-  });
-  return { ...result, outputs: readWorkflowOutputs(githubOutput) };
-}
-
 function runProtocolSinceFixture(checkout: string, baseSha: string) {
   for (const scriptPath of [
     "packages/normalization-core/src/record-coerce.ts",
@@ -1361,6 +1328,7 @@ function runGeneratedPublisherScenario(
     existingPr?: boolean;
     expectFailure?: boolean;
     failGeneratedPush?: boolean;
+    invalidationPaths?: string;
     mergeGeneratedPush?: boolean;
     noGeneratedChange?: boolean;
     overlapPolicy?: string;
@@ -1528,7 +1496,7 @@ ${actionRun}`;
         FAKE_STALE_HEAD_ONCE: stalePrHeadOnce,
         FAKE_STALE_PR_VIEW_HEAD_ONCE: stalePrViewHeadOnce,
         GENERATED_PATHS: "generated",
-        INVALIDATION_PATHS: "source",
+        INVALIDATION_PATHS: options.invalidationPaths ?? "source",
         OVERLAP_POLICY: options.overlapPolicy ?? "defer",
         CONTENTS_TOKEN: "contents-token",
         GH_TOKEN: "test-token",
@@ -2427,6 +2395,11 @@ NODE
     expect(actionPublishStep.env.CONTENTS_TOKEN).toBe("${{ steps.tokens.outputs.contents-token }}");
     expect(actionPublishStep.env.GH_TOKEN).toBe("${{ steps.tokens.outputs.pull-request-token }}");
     expect(actionPublishStep.env.INVALIDATION_PATHS).toBe("${{ inputs.invalidation-paths }}");
+    expect(publishAction.inputs["invalidation-paths"]).toEqual({
+      description: "Newline-delimited generator input paths that make an older run stale.",
+      required: false,
+      default: "",
+    });
     expect(publishAction.inputs["working-directory"]).toEqual({
       description: "Repository root containing the generated files.",
       required: false,
@@ -2614,37 +2587,6 @@ NODE
     }
   });
 
-  it("refreezes a queued maturity successor only across a forward main advance", () => {
-    const topology = createQaProtocolTopology();
-    const currentMain = runGit(topology.origin, ["rev-parse", "main"]);
-    const successor = runMaturitySelectedRefValidation({
-      topology,
-      expectedSha: topology.mainBase,
-      revision: currentMain,
-      successorAttempt: "1",
-    });
-    expect(successor.status, successor.stderr).toBe(0);
-    expect(successor.outputs.selected_revision).toBe(currentMain);
-
-    const initial = runMaturitySelectedRefValidation({
-      topology,
-      expectedSha: topology.mainBase,
-      revision: currentMain,
-      successorAttempt: "0",
-    });
-    expect(initial.status).not.toBe(0);
-    expect(initial.stderr).toContain(`expected ${topology.mainBase}`);
-
-    const divergent = runMaturitySelectedRefValidation({
-      topology,
-      expectedSha: topology.featureHead,
-      revision: currentMain,
-      successorAttempt: "1",
-    });
-    expect(divergent.status).not.toBe(0);
-    expect(divergent.stderr).toContain(`expected ${topology.featureHead}`);
-  });
-
   it.skipIf(process.platform === "win32")(
     "enables auto-merge for the exact generated pull request head",
     () => {
@@ -2802,6 +2744,21 @@ NODE
         "Deferred stale generated output because generator inputs changed on main.",
       );
       expect(result.summary).toContain("Neutralized stale generated pull request");
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "publishes after unrelated source changes when input invalidation is disabled",
+    () => {
+      const result = runGeneratedPublisherScenario(null, {
+        invalidationPaths: "",
+        overlapPolicy: "fail",
+        updateSource: true,
+      });
+
+      expect(result.branchExists).toBe(true);
+      expect(result.generatedA).toBe("desired-a");
+      expect(result.publishOutput).not.toContain("Refusing stale generated output");
     },
   );
 
@@ -9092,21 +9049,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
 
     expect(publishPrJob.needs).toEqual(["validate_selected_ref", "publisher_preflight", "publish"]);
     expect(publishPrJob["runs-on"]).toBe("ubuntu-24.04");
-    expect(publishPrJob.permissions).toEqual({ actions: "write", contents: "read" });
-    expect(maturityWorkflow.on.workflow_dispatch.inputs.successor_attempt).toEqual({
-      description: "Internal bounded retry count for stale generated output",
-      required: false,
-      default: "0",
-      type: "string",
-    });
-    expect(maturityWorkflow.on.workflow_call.inputs.successor_attempt).toEqual(
-      maturityWorkflow.on.workflow_dispatch.inputs.successor_attempt,
-    );
-    const validateSelectedRefStep = maturityWorkflow.jobs.validate_selected_ref.steps.find(
-      (step: WorkflowStep) => step.name === "Validate selected ref",
-    );
-    expect(validateSelectedRefStep.env.SUCCESSOR_ATTEMPT).toBe("${{ inputs.successor_attempt }}");
-    expect(validateSelectedRefStep.run).toContain('[[ ! "$SUCCESSOR_ATTEMPT" =~ ^[0-2]$ ]]');
+    expect(publishPrJob.permissions).toEqual({ actions: "read", contents: "read" });
     for (const fragment of [
       "needs.publisher_preflight.result == 'success'",
       "needs.publish.result == 'success'",
@@ -9163,17 +9106,12 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "working-directory": "selected",
       "commit-message": "docs: update maturity scorecard",
       "pr-title": "docs: update maturity scorecard",
-      "overlap-policy": "defer",
+      "invalidation-paths": "",
+      "overlap-policy": "fail",
     });
     expect(openDocsPrStep.with["generated-paths"].trim().split("\n")).toEqual(
       MATURITY_GENERATED_PR_PATHS,
     );
-    expect(openDocsPrStep.with["invalidation-paths"].trim().split("\n")).toEqual([
-      ".",
-      ":(exclude)qa/maturity-scores.yaml",
-      ":(exclude)docs/maturity/scorecard.md",
-      ":(exclude)docs/maturity/taxonomy.md",
-    ]);
     for (const heading of [
       "## What Problem This Solves",
       "## Why This Change Was Made",
@@ -9182,24 +9120,6 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     ]) {
       expect(openDocsPrStep.with["pr-body"]).toContain(heading);
     }
-    const successorStep = publishPrJob.steps.find(
-      (step: WorkflowStep) => step.name === "Dispatch latest-base successor",
-    );
-    expect(successorStep).toMatchObject({
-      env: {
-        ALLOW_FAILURES: "${{ inputs.allow_failures }}",
-        BASE_BRANCH: "${{ needs.validate_selected_ref.outputs.publication_base }}",
-        GH_TOKEN: "${{ github.token }}",
-        SOURCE_SHA: "${{ needs.validate_selected_ref.outputs.selected_revision }}",
-        SUCCESSOR_ATTEMPT: "${{ inputs.successor_attempt }}",
-      },
-      "working-directory": "selected",
-    });
-    expect(successorStep.run).toContain("max_successor_attempts=2");
-    expect(successorStep.run).toContain("gh workflow run maturity-scorecard.yml");
-    expect(successorStep.run).toContain('-f expected_sha="$latest_sha"');
-    expect(successorStep.run).toContain('-f successor_attempt="$next_attempt"');
-    expect(successorStep.run).toContain("remained stale after");
     expect(publishPrJob.steps).not.toContainEqual(
       expect.objectContaining({ name: "Create generated docs PR app token" }),
     );

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1124,6 +1124,39 @@ function runQaSelectedRefValidation(
   return { ...result, outputs: readWorkflowOutputs(githubOutput) };
 }
 
+function runMaturitySelectedRefValidation(params: {
+  topology: ReturnType<typeof createQaProtocolTopology>;
+  expectedSha: string;
+  revision: string;
+  successorAttempt: string;
+}) {
+  runGit(params.topology.checkout, ["checkout", "-q", "--detach", params.revision]);
+  const githubOutput = path.join(params.topology.checkout, "github-output");
+  rmSync(githubOutput, { force: true });
+  const validateStep = expectDefined(
+    readMaturityScorecardWorkflow().jobs.validate_selected_ref.steps.find(
+      (step: WorkflowStep) => step.name === "Validate selected ref",
+    ),
+    "maturity selected-ref validation step",
+  );
+  const result = runWorkflowShellScript(expectDefined(validateStep.run, "validation script"), {
+    cwd: params.topology.checkout,
+    env: {
+      ...process.env,
+      DEFAULT_BRANCH: "main",
+      EVIDENCE_RUN_ID: "42",
+      EXPECTED_SHA: params.expectedSha,
+      GITHUB_OUTPUT: githubOutput,
+      GITHUB_STEP_SUMMARY: path.join(params.topology.checkout, "github-summary"),
+      INPUT_REF: "main",
+      PATH: `${params.topology.fakeBin}:${process.env.PATH ?? ""}`,
+      PUBLISH_PULL_REQUEST: "false",
+      SUCCESSOR_ATTEMPT: params.successorAttempt,
+    },
+  });
+  return { ...result, outputs: readWorkflowOutputs(githubOutput) };
+}
+
 function runProtocolSinceFixture(checkout: string, baseSha: string) {
   for (const scriptPath of [
     "packages/normalization-core/src/record-coerce.ts",
@@ -2579,6 +2612,37 @@ NODE
       expect(publishStep.with["pr-body"]).toContain("${{ needs.resolve-base.outputs.sha }}");
       expect(publishStep.with["pr-body"]).not.toContain("${{ github.sha }}");
     }
+  });
+
+  it("refreezes a queued maturity successor only across a forward main advance", () => {
+    const topology = createQaProtocolTopology();
+    const currentMain = runGit(topology.origin, ["rev-parse", "main"]);
+    const successor = runMaturitySelectedRefValidation({
+      topology,
+      expectedSha: topology.mainBase,
+      revision: currentMain,
+      successorAttempt: "1",
+    });
+    expect(successor.status, successor.stderr).toBe(0);
+    expect(successor.outputs.selected_revision).toBe(currentMain);
+
+    const initial = runMaturitySelectedRefValidation({
+      topology,
+      expectedSha: topology.mainBase,
+      revision: currentMain,
+      successorAttempt: "0",
+    });
+    expect(initial.status).not.toBe(0);
+    expect(initial.stderr).toContain(`expected ${topology.mainBase}`);
+
+    const divergent = runMaturitySelectedRefValidation({
+      topology,
+      expectedSha: topology.featureHead,
+      revision: currentMain,
+      successorAttempt: "1",
+    });
+    expect(divergent.status).not.toBe(0);
+    expect(divergent.stderr).toContain(`expected ${topology.featureHead}`);
   });
 
   it.skipIf(process.platform === "win32")(

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -9028,6 +9028,21 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
 
     expect(publishPrJob.needs).toEqual(["validate_selected_ref", "publisher_preflight", "publish"]);
     expect(publishPrJob["runs-on"]).toBe("ubuntu-24.04");
+    expect(publishPrJob.permissions).toEqual({ actions: "write", contents: "read" });
+    expect(maturityWorkflow.on.workflow_dispatch.inputs.successor_attempt).toEqual({
+      description: "Internal bounded retry count for stale generated output",
+      required: false,
+      default: "0",
+      type: "string",
+    });
+    expect(maturityWorkflow.on.workflow_call.inputs.successor_attempt).toEqual(
+      maturityWorkflow.on.workflow_dispatch.inputs.successor_attempt,
+    );
+    const validateSelectedRefStep = maturityWorkflow.jobs.validate_selected_ref.steps.find(
+      (step: WorkflowStep) => step.name === "Validate selected ref",
+    );
+    expect(validateSelectedRefStep.env.SUCCESSOR_ATTEMPT).toBe("${{ inputs.successor_attempt }}");
+    expect(validateSelectedRefStep.run).toContain('[[ ! "$SUCCESSOR_ATTEMPT" =~ ^[0-2]$ ]]');
     for (const fragment of [
       "needs.publisher_preflight.result == 'success'",
       "needs.publish.result == 'success'",
@@ -9084,7 +9099,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "working-directory": "selected",
       "commit-message": "docs: update maturity scorecard",
       "pr-title": "docs: update maturity scorecard",
-      "overlap-policy": "fail",
+      "overlap-policy": "defer",
     });
     expect(openDocsPrStep.with["generated-paths"].trim().split("\n")).toEqual(
       MATURITY_GENERATED_PR_PATHS,
@@ -9103,6 +9118,24 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     ]) {
       expect(openDocsPrStep.with["pr-body"]).toContain(heading);
     }
+    const successorStep = publishPrJob.steps.find(
+      (step: WorkflowStep) => step.name === "Dispatch latest-base successor",
+    );
+    expect(successorStep).toMatchObject({
+      env: {
+        ALLOW_FAILURES: "${{ inputs.allow_failures }}",
+        BASE_BRANCH: "${{ needs.validate_selected_ref.outputs.publication_base }}",
+        GH_TOKEN: "${{ github.token }}",
+        SOURCE_SHA: "${{ needs.validate_selected_ref.outputs.selected_revision }}",
+        SUCCESSOR_ATTEMPT: "${{ inputs.successor_attempt }}",
+      },
+      "working-directory": "selected",
+    });
+    expect(successorStep.run).toContain("max_successor_attempts=2");
+    expect(successorStep.run).toContain("gh workflow run maturity-scorecard.yml");
+    expect(successorStep.run).toContain('-f expected_sha="$latest_sha"');
+    expect(successorStep.run).toContain('-f successor_attempt="$next_attempt"');
+    expect(successorStep.run).toContain("remained stale after");
     expect(publishPrJob.steps).not.toContainEqual(
       expect.objectContaining({ name: "Create generated docs PR app token" }),
     );


### PR DESCRIPTION
## What Problem This Solves

The maturity scorecard run takes long enough that `main` normally advances before publication. The publisher treated any intervening repository change as stale input and discarded otherwise valid generated results, so successful scorecard work ended as a failed run.

## How This PR Solves It

- Makes input invalidation optional in the shared generated-PR publisher.
- Disables input invalidation for the maturity scorecard workflow, whose report is intentionally tied to the immutable source SHA it audited.
- Keeps generated-path overlap detection fail-closed, so publication still refuses to overwrite concurrent edits to the scorecard artifacts.
- Leaves every other generated-PR caller invalidation policy unchanged.
- Removes the earlier retry/successor approach; normal `main` churn is accepted rather than retried.

## User Impact

Maturity scorecard updates can publish after `main` advances instead of repeatedly becoming obsolete at the publication step.

## Validation

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 130 passed, 2 skipped.
- `node scripts/check-changed.mjs -- .github/actions/publish-generated-pr/action.yml .github/workflows/maturity-scorecard.yml test/scripts/ci-workflow-guards.test.ts` — passed.
- `git diff --check` — passed.
- Local `pnpm check:workflows` preflight was blocked because the configured package index does not provide pinned `pre-commit==4.6.2`; exact-head CI remains authoritative.

Production/tooling delta: +7/-12. Tests: +24/-7.

## Related Run

- Failed maturity scorecard run: https://github.com/openclaw/openclaw/actions/runs/32918319838