### PR TITLE
fix(gateway): preserve target context in suspension resume hints

### DIFF
--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -246,6 +246,26 @@ describe("gateway register option collisions", () => {
       },
     },
     {
+      name: "preserves the custom suspend port in its human-readable resume hint",
+      argv: ["gateway", "suspend", "--port", "19086"],
+      assert: () => {
+        expectLocalGatewayCall("gateway.suspend.prepare", 19086);
+        expect(defaultRuntime.log).toHaveBeenCalledWith(
+          "Resume with: openclaw gateway resume suspension-1 --port 19086",
+        );
+      },
+    },
+    {
+      name: "preserves an inherited suspend port in its human-readable resume hint",
+      argv: ["gateway", "--port", "19087", "suspend"],
+      assert: () => {
+        expectLocalGatewayCall("gateway.suspend.prepare", 19087);
+        expect(defaultRuntime.log).toHaveBeenCalledWith(
+          "Resume with: openclaw gateway resume suspension-1 --port 19087",
+        );
+      },
+    },
+    {
       name: "inherits parent --port for gateway resume",
       argv: ["gateway", "--port", "19087", "resume", "suspension-1", "--json"],
       assert: () => {

--- a/src/cli/gateway-cli/suspend-cli.test.ts
+++ b/src/cli/gateway-cli/suspend-cli.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OutputRuntimeEnv } from "../../runtime.js";
 import { runGatewayResume, runGatewaySuspend } from "./suspend-cli.js";
 
@@ -30,6 +30,7 @@ const busyResult = {
 
 describe("gateway suspend CLI", () => {
   beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.unstubAllEnvs());
 
   it("prints a ready lease with the default CLI request id", async () => {
     const callGateway = vi.fn(async () => readyResult);
@@ -50,6 +51,58 @@ describe("gateway suspend CLI", () => {
     );
     expect(runtime.log).toHaveBeenCalledWith("Resume with: openclaw gateway resume suspension-1");
   });
+
+  it.each([
+    {
+      name: "default gateway",
+      rpcOpts: {},
+      profile: "",
+      container: "",
+      command: "openclaw gateway resume suspension-1",
+    },
+    {
+      name: "custom local port",
+      rpcOpts: { localPortOverride: 18999 },
+      profile: "",
+      container: "",
+      command: "openclaw gateway resume suspension-1 --port 18999",
+    },
+    {
+      name: "named profile and custom local port",
+      rpcOpts: { localPortOverride: 18999 },
+      profile: "work",
+      container: "",
+      command: "openclaw --profile work gateway resume suspension-1 --port 18999",
+    },
+    {
+      name: "container takes precedence over profile",
+      rpcOpts: { localPortOverride: 18999 },
+      profile: "work",
+      container: "demo",
+      command: "openclaw --container demo gateway resume suspension-1 --port 18999",
+    },
+    {
+      name: "explicit URL and credentials remain private",
+      rpcOpts: { url: "wss://gateway.example:19444", token: "opaque-credential" },
+      profile: "",
+      container: "",
+      command: "openclaw gateway resume suspension-1",
+    },
+  ])(
+    "prints a correctly scoped resume hint for $name",
+    async ({ rpcOpts, profile, container, command }) => {
+      vi.stubEnv("OPENCLAW_PROFILE", profile);
+      vi.stubEnv("OPENCLAW_CONTAINER_HINT", container);
+      const runtime = createRuntime();
+
+      await runGatewaySuspend(
+        { rpcOpts },
+        { callGateway: vi.fn(async () => readyResult), runtime },
+      );
+
+      expect(runtime.log).toHaveBeenCalledWith(`Resume with: ${command}`);
+    },
+  );
 
   it("reports blockers without polling when --wait is omitted", async () => {
     const callGateway = vi.fn(async () => busyResult);

--- a/src/cli/gateway-cli/suspend-cli.ts
+++ b/src/cli/gateway-cli/suspend-cli.ts
@@ -5,6 +5,7 @@ import type {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { colorize, isRich, theme } from "../../../packages/terminal-core/src/theme.js";
 import type { OutputRuntimeEnv } from "../../runtime.js";
+import { formatCliCommand } from "../command-format.js";
 import type { callGatewayFromCliWithTransport } from "../gateway-rpc.js";
 
 type SuspendRpcOpts = Parameters<typeof callGatewayFromCliWithTransport>[1];
@@ -56,14 +57,6 @@ function formatBusyResult(
   ].join("\n");
 }
 
-function writeSuspendJson(
-  runtime: OutputRuntimeEnv,
-  result: GatewaySuspendPrepareResult,
-  requestId: string,
-): void {
-  runtime.writeJson({ ...result, requestId });
-}
-
 export async function runGatewaySuspend(
   options: {
     rpcOpts: SuspendRpcOpts;
@@ -97,7 +90,7 @@ export async function runGatewaySuspend(
     })) as GatewaySuspendPrepareResult;
     if (latest.status === "ready") {
       if (options.json) {
-        writeSuspendJson(deps.runtime, latest, requestId);
+        deps.runtime.writeJson({ ...latest, requestId });
         return;
       }
       const rich = isRich();
@@ -106,13 +99,17 @@ export async function runGatewaySuspend(
       deps.runtime.log(
         `${colorize(rich, theme.muted, "Expires:")} ${new Date(latest.expiresAtMs).toISOString()} (${latest.expiresAtMs} ms)`,
       );
-      deps.runtime.log(`Resume with: openclaw gateway resume ${latest.suspensionId}`);
+      const port = options.rpcOpts.localPortOverride;
+      const command = `openclaw gateway resume ${latest.suspensionId}`;
+      deps.runtime.log(
+        `Resume with: ${formatCliCommand(port === undefined ? command : `${command} --port ${port}`)}`,
+      );
       return;
     }
 
     if (deadlineMs === undefined) {
       if (options.json) {
-        writeSuspendJson(deps.runtime, latest, requestId);
+        deps.runtime.writeJson({ ...latest, requestId });
         deps.runtime.exit(1);
         return;
       }
@@ -131,7 +128,7 @@ export async function runGatewaySuspend(
     throw new Error("Gateway suspension polling ended without a result");
   }
   if (options.json) {
-    writeSuspendJson(deps.runtime, latest, requestId);
+    deps.runtime.writeJson({ ...latest, requestId });
     deps.runtime.exit(1);
     return;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators suspending a Gateway on a custom local port, under a named profile, or inside a container received a resume command targeting the default Gateway instead of the Gateway they had actually suspended. Copying the suggested command could therefore leave the intended Gateway suspended until its lease expired.

## Why This Change Was Made

The suspend CLI already owns both the resolved local port and the generated resume hint, so it now includes that port and passes the complete command through the existing canonical CLI formatter. That formatter preserves the active profile or container, with the existing container-over-profile precedence. Explicit remote URLs and authentication credentials are deliberately never copied into the displayed command. The now-redundant private JSON-output helper is removed without changing JSON output, polling, or resume behavior.

## User Impact

The documented `openclaw gateway suspend --port 18999` workflow now prints `openclaw gateway resume <suspensionId> --port 18999`. Profile and container workflows produce similarly copy-pasteable commands for their actual Gateway, while the default Gateway and machine-readable output remain unchanged.

## Evidence

The exact current-main hardcoded resume hint was temporarily restored before verification. Five new regressions failed for the intended reason: two executed the real Commander command registration with explicit and inherited ports, while three exercised the suspend owner with a custom port, named profile, and container-over-profile precedence. The other 36 owner and parser controls still passed. Restoring the canonical-owner fix made all four focused and sibling suites pass:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cli/gateway-cli/suspend-cli.test.ts src/cli/gateway-cli/register.option-collisions.test.ts src/cli/profile.test.ts src/cli/gateway-cli/run.option-collisions.test.ts

Test Files  4 passed (4)
Tests       196 passed (196)
```

Focused proof also covers the unchanged default hint, explicit URL and credential privacy, JSON-ready output, bounded polling, busy/timeout behavior, actual Gateway RPC option inheritance, and existing profile/container formatter behavior.

```text
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cli/gateway-cli/register.option-collisions.test.ts src/cli/gateway-cli/suspend-cli.test.ts src/cli/gateway-cli/suspend-cli.ts
git diff --check
```

Targeted typed lint, formatting, and whitespace checks pass. An independent integrated P1 code review reported no actionable findings. Production changes: +9/-12 (net -3); regression tests: +74/-1. No running operator Gateway was touched; real CLI parsing is exercised against an injected Gateway RPC transport.
