### PR TITLE
test(ui): trim duplicate routing coverage and stabilize cron E2E

### DIFF
--- a/ui/src/app/browser-link-routing.test.ts
+++ b/ui/src/app/browser-link-routing.test.ts
@@ -108,15 +108,6 @@ describe("Control UI browser link routing", () => {
     expect(urls).toEqual([]);
   });
 
-  it("preserves host behavior when the browser panel is unavailable", () => {
-    startBrowserLinkRouting(false);
-    const event = mouseEvent("click");
-
-    appendLink("https://example.com/report").dispatchEvent(event);
-
-    expect(event.defaultPrevented).toBe(false);
-  });
-
   it("falls through to existing app routing when the Control UI panel is unavailable", () => {
     const postMessage = vi.fn();
     Object.defineProperty(window, "webkit", {

--- a/ui/src/e2e/cron-trigger-authoring.e2e.test.ts
+++ b/ui/src/e2e/cron-trigger-authoring.e2e.test.ts
@@ -223,25 +223,34 @@ suite.define(() => {
         await expect.poll(() => triggerToggle.count()).toBe(1);
         await captureTriggerCapabilityProof(page, "05-unsaved-disable-keeps-active-trigger");
 
-        const saveResult = await page.evaluate(async () => {
+        await page.evaluate(() => {
           const config = (document.querySelector("openclaw-app") as CronTriggerTestApp).runtime
             ?.context.runtimeConfig;
           if (!config) {
             throw new Error("Runtime config capability is unavailable");
           }
           config.setWritesSuspended(false);
-          const saved = await config.save();
-          return {
-            dirty: config.state.configFormDirty,
-            needsApply: config.state.configNeedsApply,
-            saved,
-          };
+          // Observe this long-lived save through Gateway/state boundaries; returning its
+          // promise through CDP lets Chromium collect it under full-shard memory pressure.
+          void config.save();
         });
-        expect(saveResult).toEqual({ dirty: false, needsApply: true, saved: true });
         const savedRequest = await gateway.waitForRequest("config.set");
         expect(JSON.parse(String((savedRequest.params as { raw?: string }).raw))).toEqual({
           cron: { triggers: { enabled: false } },
         });
+        await expect
+          .poll(() =>
+            page.evaluate(() => {
+              const config = (document.querySelector("openclaw-app") as CronTriggerTestApp).runtime
+                ?.context.runtimeConfig;
+              return {
+                dirty: config?.state.configFormDirty,
+                needsApply: config?.state.configNeedsApply,
+                saving: config?.state.configSaving,
+              };
+            }),
+          )
+          .toEqual({ dirty: false, needsApply: true, saving: false });
         expect(await gateway.getRequests("config.apply")).toHaveLength(0);
         await expect.poll(() => triggerToggle.count()).toBe(1);
         await captureTriggerCapabilityProof(page, "06-saved-unapplied-keeps-active-trigger");


### PR DESCRIPTION
## What Problem This Solves

The Control UI browser-link suite contained two byte-identical browser-panel-unavailable cases. While landing that cleanup, exact-head CI also exposed a deterministic full-shard failure in `cron-trigger-authoring.e2e.test.ts`: both attempts failed when Chromium garbage-collected a long-lived promise returned through `page.evaluate` while `runtimeConfig.save()` waited for the mock Gateway response.

## Why This Change Was Made

- remove only the second copy of the browser fallback test; retain the identical default-browser proof and the distinct WebKit fallback case
- start the Cron config save inside the page without returning its long-lived promise through CDP
- preserve the stronger boundary assertions by observing the exact `config.set` request and polling the resulting dirty/apply state

No production code or runtime behavior changes.

## User Impact

None at runtime. Test coverage is less redundant, and the Cron authoring E2E remains behavior-focused without depending on Chromium retaining a remote promise under full-shard memory pressure.

## Evidence

- `node scripts/run-vitest.mjs ui/src/app/browser-link-routing.test.ts` (baseline: 6 passed; post-change: 5 passed)
- `node scripts/run-vitest.mjs ui/src/app/browser-link-routing.test.ts ui/src/e2e/cron-trigger-authoring.e2e.test.ts` (2 files; 8 tests passed after rebase)
- `OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner --shard 1/3` (93 files; 339 tests passed)
- `node scripts/check-changed.mjs -- ui/src/app/browser-link-routing.test.ts ui/src/e2e/cron-trigger-authoring.e2e.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean for each focused change)
- exact-head CI run `32941465676`, attempts 1 and 2, reproduced the pre-fix `page.evaluate: Resulting promise was garbage collected` failure at `cron-trigger-authoring.e2e.test.ts:226`; the focused suite passed locally before the fix, isolating the defect to full-shard promise lifetime
