### PR TITLE
fix(qa): count only visible Telegram streaming finals

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -22,6 +22,52 @@ function requireFlowScenario(scenario: CatalogScenario): FlowCatalogScenario {
   return scenario as FlowCatalogScenario;
 }
 
+const telegramStreamingFinalScenarios = [
+  {
+    scenarioId: "telegram-stream-final-single-message",
+    finalTexts: ["QA-TELEGRAM-STREAM-SINGLE-OK"],
+  },
+  {
+    scenarioId: "telegram-long-final-reuses-preview",
+    finalTexts: ["TELEGRAM-LONG-FINAL-BEGIN first", "second TELEGRAM-LONG-FINAL-END"],
+  },
+  {
+    scenarioId: "telegram-long-final-three-chunks",
+    finalTexts: [
+      "TELEGRAM-LONG-FINAL-3CHUNK-BEGIN first",
+      "second final chunk",
+      "third TELEGRAM-LONG-FINAL-3CHUNK-END",
+    ],
+  },
+] as const;
+
+function runTelegramStreamingFinalScenario(params: {
+  scenarioId: string;
+  finalTexts: readonly string[];
+  deletedPreview: boolean;
+}) {
+  return runLoadedScenarioFlow(params.scenarioId, {
+    state: createQaBusState(),
+    onWaitForOutboundMessage: ({ state }) => {
+      if (params.deletedPreview) {
+        const preview = state.addOutboundMessage({
+          accountId: "qa-channel",
+          to: "channel:telegram-stream-room",
+          text: "deleted streaming preview",
+        });
+        state.deleteMessage({ accountId: "qa-channel", messageId: preview.id });
+      }
+      for (const text of params.finalTexts) {
+        state.addOutboundMessage({
+          accountId: "qa-channel",
+          to: "channel:telegram-stream-room",
+          text,
+        });
+      }
+    },
+  });
+}
+
 describe("qa scenario catalog channel contracts", () => {
   const agentRuntime = "agent-runtime";
 
@@ -262,6 +308,33 @@ describe("qa scenario catalog channel contracts", () => {
       channels: { telegram: { streaming: { mode: "partial" } } },
     });
     expect(scenario.gatewayConfigPatch).not.toHaveProperty("channels.telegram.groups");
+  });
+
+  it.each(
+    telegramStreamingFinalScenarios.flatMap((scenario) => [
+      { ...scenario, deletedPreview: false },
+      { ...scenario, deletedPreview: true },
+    ]),
+  )(
+    "counts only visible Telegram finals for $scenarioId (deleted preview: $deletedPreview)",
+    async (scenario) => {
+      await expect(runTelegramStreamingFinalScenario(scenario)).resolves.toMatchObject({
+        status: "pass",
+      });
+    },
+  );
+
+  it("rejects a deleted Telegram preview standing in for a missing final chunk", async () => {
+    await expect(
+      runTelegramStreamingFinalScenario({
+        scenarioId: "telegram-long-final-three-chunks",
+        finalTexts: [
+          "TELEGRAM-LONG-FINAL-3CHUNK-BEGIN first",
+          "second TELEGRAM-LONG-FINAL-3CHUNK-END",
+        ],
+        deletedPreview: true,
+      }),
+    ).rejects.toThrow("expected three complete final chunks; saw 2");
   });
 
   it("keeps the shared channel canary eligible for its supported channels", () => {

--- a/qa/scenarios/channels/telegram-long-final-reuses-preview.yaml
+++ b/qa/scenarios/channels/telegram-long-final-reuses-preview.yaml
@@ -45,7 +45,7 @@ flow:
           args: [4000]
         - set: finalMessages
           value:
-            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex)"
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex).filter((message) => !message.deleted)"
         - set: joinedFinal
           value:
             expr: "finalMessages.map((message) => message.text).join('')"

--- a/qa/scenarios/channels/telegram-long-final-three-chunks.yaml
+++ b/qa/scenarios/channels/telegram-long-final-three-chunks.yaml
@@ -45,7 +45,7 @@ flow:
           args: [4000]
         - set: finalMessages
           value:
-            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex)"
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex).filter((message) => !message.deleted)"
         - set: joinedFinal
           value:
             expr: "finalMessages.map((message) => message.text).join('')"

--- a/qa/scenarios/channels/telegram-stream-final-single-message.yaml
+++ b/qa/scenarios/channels/telegram-stream-final-single-message.yaml
@@ -47,7 +47,7 @@ flow:
           args: [4000]
         - set: finalMessages
           value:
-            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex)"
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex).filter((message) => !message.deleted)"
         - assert:
             expr: "finalMessages.length === 1 && finalMessages[0].text.includes(config.marker)"
             message:


### PR DESCRIPTION
## What Problem This Solves

Three registered Telegram streaming QA scenarios counted deleted preview messages as visible final replies. A normal deleted preview made the single-message, reused-preview, and three-chunk scenarios reject otherwise correct delivery; worse, two actual final chunks plus one deleted preview incorrectly satisfied the three-chunk release scenario.

## Why This Change Was Made

QA bus snapshots intentionally preserve deleted messages as tombstones. The three scenario-owned final-message projections now exclude deleted outbound messages after applying their existing outbound start boundary, matching the established visibility contract already used by the voice-preview scenario.

This is separate from the sender-allowlist repair in #129840. The branch contains that landed change and preserves its full regression coverage in the shared scenario-catalog test.

## User Impact

Telegram release QA now judges the messages users can still see: valid streamed finals no longer fail because a preview was deleted, and missing final chunks can no longer pass by counting a tombstone.

## Evidence

- Executed all three actual registered YAML scenarios through the production scenario catalog, flow runner, and QA bus.
- Before the repair: four authentic regressions failed, including the false-success case where two visible final chunks and a deleted preview were reported as three complete chunks.
- After the repair: each scenario passes both with and without a deleted preview, and a missing visible final chunk fails for the correct reason.
- Combined owner/sibling verification, including the already-landed sender-allowlist coverage: **5 suites, 133 tests passed**.
- Targeted formatting and whitespace checks pass; fresh independent complete-diff P1 review returned no actionable findings.
- Historical sibling precedent: `12d0d84262a0` already excluded deleted voice-preview tombstones from visible reply counts.
- Production scenario YAML: +3/-3, net 0. Regression tests: +73/-0.
- Proof uses the real registered scenario execution boundary with the deterministic in-process QA bus; it does not claim authenticated live Telegram delivery and does not touch user services, accounts, or credentials.
