### PR TITLE
fix(android): preserve disabled location consent during onboarding

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -3104,25 +3104,25 @@ internal fun canFinishOnboarding(
 private val requiredContactPermissions = listOf(Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS)
 private val requiredCalendarPermissions = listOf(Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR)
 
-internal fun initialCameraCapabilityEnabled(
+internal fun initialDeviceCapabilityEnabled(
   savedCapabilityEnabled: Boolean,
-  androidCameraPermissionGranted: Boolean,
-): Boolean = savedCapabilityEnabled && androidCameraPermissionGranted
+  androidPermissionGranted: Boolean,
+): Boolean = savedCapabilityEnabled && androidPermissionGranted
 
-internal fun cameraPermissionRowStatusText(
+internal fun deviceCapabilityRowStatusText(
   capabilityEnabled: Boolean,
-  androidCameraPermissionGranted: Boolean,
+  androidPermissionGranted: Boolean,
 ): NativeText =
   when {
     capabilityEnabled -> nativeText("Enabled")
-    androidCameraPermissionGranted -> nativeText("Off")
+    androidPermissionGranted -> nativeText("Off")
     else -> nativeText("Not allowed")
   }
 
-internal fun cameraCapabilityAfterRowTap(
+internal fun deviceCapabilityAfterRowTap(
   currentCapabilityEnabled: Boolean,
-  androidCameraPermissionGranted: Boolean,
-): Boolean? = if (androidCameraPermissionGranted) !currentCapabilityEnabled else null
+  androidPermissionGranted: Boolean,
+): Boolean? = if (androidPermissionGranted) !currentCapabilityEnabled else null
 
 private fun permissionRowStatusText(granted: Boolean): NativeText = if (granted) nativeText("Granted") else nativeText("Not granted")
 
@@ -3148,9 +3148,15 @@ private fun rememberPermissionState(
   val currentLocationMode by viewModel.locationMode.collectAsState()
   var microphoneGranted by rememberSaveable { mutableStateOf(hasPermission(context, Manifest.permission.RECORD_AUDIO)) }
   val cameraPermissionGranted = hasPermission(context, Manifest.permission.CAMERA)
-  var cameraGranted by rememberSaveable { mutableStateOf(initialCameraCapabilityEnabled(currentCameraEnabled, cameraPermissionGranted)) }
+  var cameraGranted by rememberSaveable { mutableStateOf(initialDeviceCapabilityEnabled(currentCameraEnabled, cameraPermissionGranted)) }
+
+  fun hasLocationPermission(): Boolean =
+    hasPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ||
+      hasPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
+
+  val locationPermissionGranted = hasLocationPermission()
   var locationGranted by rememberSaveable {
-    mutableStateOf(hasPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) || hasPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION))
+    mutableStateOf(initialDeviceCapabilityEnabled(currentLocationMode != LocationMode.Off, locationPermissionGranted))
   }
   val photosPermissions = photoReadPermissionsForRequest()
   var photosGranted by rememberSaveable { mutableStateOf(hasPhotoReadPermission(context)) }
@@ -3238,9 +3244,9 @@ private fun rememberPermissionState(
 
   fun requestCameraCapability() {
     val nextCapabilityEnabled =
-      cameraCapabilityAfterRowTap(
+      deviceCapabilityAfterRowTap(
         currentCapabilityEnabled = cameraGranted,
-        androidCameraPermissionGranted = hasPermission(context, Manifest.permission.CAMERA),
+        androidPermissionGranted = hasPermission(context, Manifest.permission.CAMERA),
       )
     if (nextCapabilityEnabled != null) {
       cameraGranted = nextCapabilityEnabled
@@ -3260,14 +3266,26 @@ private fun rememberPermissionState(
         nativeText("Capture photos and clips from this phone"),
         Icons.Default.CameraAlt,
         cameraGranted,
-        cameraPermissionRowStatusText(
+        deviceCapabilityRowStatusText(
           capabilityEnabled = cameraGranted,
-          androidCameraPermissionGranted = hasPermission(context, Manifest.permission.CAMERA),
+          androidPermissionGranted = cameraPermissionGranted,
         ),
         ::requestCameraCapability,
       ),
-      PermissionRowModel(PermissionRowId.Location, nativeText("Location"), nativeText("Read this phone's location"), Icons.Default.LocationOn, locationGranted) {
-        request(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
+      PermissionRowModel(
+        PermissionRowId.Location,
+        nativeText("Location"),
+        nativeText("Read this phone's location"),
+        Icons.Default.LocationOn,
+        locationGranted,
+        deviceCapabilityRowStatusText(locationGranted, locationPermissionGranted),
+      ) {
+        val nextCapabilityEnabled = deviceCapabilityAfterRowTap(locationGranted, hasLocationPermission())
+        if (nextCapabilityEnabled != null) {
+          locationGranted = nextCapabilityEnabled
+        } else {
+          request(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
+        }
       },
       if (photosAvailable) {
         PermissionRowModel(PermissionRowId.Photos, nativeText("Photos"), nativeText("Read recent photos and media"), Icons.Default.Image, photosGranted) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -180,21 +180,42 @@ class OnboardingFlowLogicTest {
   }
 
   @Test
-  fun cameraCapabilityStartsOffEvenWhenScannerPermissionWasGranted() {
+  fun deviceCapabilityStartsOffEvenWhenAndroidPermissionWasGranted() {
     assertBooleanCases(
-      false to initialCameraCapabilityEnabled(savedCapabilityEnabled = false, androidCameraPermissionGranted = false),
-      false to initialCameraCapabilityEnabled(savedCapabilityEnabled = false, androidCameraPermissionGranted = true),
-      false to initialCameraCapabilityEnabled(savedCapabilityEnabled = true, androidCameraPermissionGranted = false),
-      true to initialCameraCapabilityEnabled(savedCapabilityEnabled = true, androidCameraPermissionGranted = true),
+      false to initialDeviceCapabilityEnabled(savedCapabilityEnabled = false, androidPermissionGranted = false),
+      false to initialDeviceCapabilityEnabled(savedCapabilityEnabled = false, androidPermissionGranted = true),
+      false to initialDeviceCapabilityEnabled(savedCapabilityEnabled = true, androidPermissionGranted = false),
+      true to initialDeviceCapabilityEnabled(savedCapabilityEnabled = true, androidPermissionGranted = true),
     )
   }
 
   @Test
-  fun cameraPermissionRowDistinguishesAndroidPermissionFromCapabilityOptIn() {
+  fun locationCapabilityRequiresBothTheSavedModeAndAndroidPermission() {
+    listOf(
+      Triple(LocationMode.Off, false, false),
+      Triple(LocationMode.Off, true, false),
+      Triple(LocationMode.WhileUsing, false, false),
+      Triple(LocationMode.WhileUsing, true, true),
+      Triple(LocationMode.Always, false, false),
+      Triple(LocationMode.Always, true, true),
+    ).forEach { (savedMode, androidPermissionGranted, expected) ->
+      assertEquals(
+        "savedMode=$savedMode androidPermissionGranted=$androidPermissionGranted",
+        expected,
+        initialDeviceCapabilityEnabled(
+          savedCapabilityEnabled = savedMode != LocationMode.Off,
+          androidPermissionGranted = androidPermissionGranted,
+        ),
+      )
+    }
+  }
+
+  @Test
+  fun deviceCapabilityRowDistinguishesAndroidPermissionFromCapabilityOptIn() {
     assertEqualsCases(
-      "Not allowed" to cameraPermissionRowStatusText(capabilityEnabled = false, androidCameraPermissionGranted = false).resolveNativeText(),
-      "Off" to cameraPermissionRowStatusText(capabilityEnabled = false, androidCameraPermissionGranted = true).resolveNativeText(),
-      "Enabled" to cameraPermissionRowStatusText(capabilityEnabled = true, androidCameraPermissionGranted = true).resolveNativeText(),
+      "Not allowed" to deviceCapabilityRowStatusText(capabilityEnabled = false, androidPermissionGranted = false).resolveNativeText(),
+      "Off" to deviceCapabilityRowStatusText(capabilityEnabled = false, androidPermissionGranted = true).resolveNativeText(),
+      "Enabled" to deviceCapabilityRowStatusText(capabilityEnabled = true, androidPermissionGranted = true).resolveNativeText(),
     )
   }
 
@@ -207,10 +228,10 @@ class OnboardingFlowLogicTest {
   }
 
   @Test
-  fun cameraPermissionRowTogglesCapabilityWhenAndroidPermissionAlreadyGranted() {
-    assertNull(cameraCapabilityAfterRowTap(currentCapabilityEnabled = false, androidCameraPermissionGranted = false))
-    assertTrue(cameraCapabilityAfterRowTap(currentCapabilityEnabled = false, androidCameraPermissionGranted = true)!!)
-    assertFalse(cameraCapabilityAfterRowTap(currentCapabilityEnabled = true, androidCameraPermissionGranted = true)!!)
+  fun deviceCapabilityRowTogglesOnlyWhenAndroidPermissionAlreadyGranted() {
+    assertNull(deviceCapabilityAfterRowTap(currentCapabilityEnabled = false, androidPermissionGranted = false))
+    assertTrue(deviceCapabilityAfterRowTap(currentCapabilityEnabled = false, androidPermissionGranted = true)!!)
+    assertFalse(deviceCapabilityAfterRowTap(currentCapabilityEnabled = true, androidPermissionGranted = true)!!)
   }
 
   @Test


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users who had explicitly disabled location sharing would silently have it re-enabled when they completed onboarding while Android still granted foreground location access. The previously approved node then unnecessarily returned to the approval screen even though the user never selected Location.

## Why This Change Was Made

Android permission and the user's separate in-app capability consent are different authorities. Generalize onboarding's existing camera capability-selection, status, and tap policy for location so a saved Off choice remains Off until the user explicitly enables it. Recheck the live Android permission when the user taps the row, preserving safe behavior if permission was revoked while onboarding remained open. Existing While Using and authorized Always modes retain their current resolution.

Production delta: +35/-17, net +18 lines; the additional production lines implement explicit location consent, truthful capability status, safe fresh-permission rechecks, and the required formatter layout while reusing the existing camera ownership policy. Tests: +34/-13.

## User Impact

Onboarding no longer silently enables location sharing or needlessly requests renewed node approval. Users can still explicitly enable location from the same onboarding row; doing so correctly refreshes node approval. Android Play and third-party builds preserve their existing foreground/background location contracts.

## Evidence

Validated against the reviewed head `89a1749506e061f5ae30c8f66d59cc4217db83cd` with the real Android 36 Play app, real foreground location permissions, the production onboarding UI, persisted preferences, and an approved Gateway fixture. A disposable debug-only entry hook selected the Permissions screen; the permission-selection, Continue, persistence, and approval paths remained the actual production owners.

Before: Android foreground location was granted, the user's saved location mode was Off, and the user did not tap Location. The real Permissions screen incorrectly displayed an enabled location capability, and Continue persisted While Using and opened an unsolicited approval screen.

![Before: location incorrectly appears enabled despite the user's saved Off choice](https://github.com/user-attachments/assets/5d156f43-b446-433c-8e84-e76d52e02695)

![Before: onboarding incorrectly requests renewed node approval](https://github.com/user-attachments/assets/c191d75d-94bd-45c7-9f89-141f04e78670)

After: the same real Android permission and saved Off state display location as disabled, preserve Off, complete onboarding, and open the actual Chat screen.

![After: location remains disabled until the user explicitly enables it](https://github.com/user-attachments/assets/b65ecbbd-361a-4e8b-8325-1571f60a273a)

![After: unchanged location authority completes onboarding and opens Chat](https://github.com/user-attachments/assets/11f15b0b-0a47-4ec9-bd15-22c403a8a4eb)

An additional real-device control explicitly tapped Location with the existing Android grant; location then became While Using and correctly returned to node approval.

![Explicitly enabling Location correctly requests node approval](https://github.com/user-attachments/assets/e50c27f7-de0c-4725-a0ee-72e1708bdae2)

Observed platform evidence:

```text
Before: tapLocation=false actualMode=WhileUsing onboardingCompleted=false
After:  tapLocation=false actualMode=Off        onboardingCompleted=true
Opt in: tapLocation=true  actualMode=WhileUsing onboardingCompleted=false
```

Focused Play and third-party suites each passed all 64 onboarding tests, with every Android formatter module passing in the same run:

```text
./gradlew --no-daemon \
  :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest \
  :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest \
  :app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck

BUILD SUCCESSFUL
Play: 64 tests, 0 failures
Third-party: 64 tests, 0 failures
```

Independent source and real-device visual review both accepted the final change; fresh structured review returned no actionable findings.
