### PR TITLE
fix(memory): keep doctor discovery free of database imports

### DIFF
--- a/extensions/memory-core/src/migration/doctor-dreaming-state.ts
+++ b/extensions/memory-core/src/migration/doctor-dreaming-state.ts
@@ -24,10 +24,6 @@ import {
 // Import from the defining modules, not the short-term-promotion barrel: the
 // barrel pulls memory-host-events/kysely, which doctor enumeration cold-loads.
 import { normalizeShortTermPhaseSignalStore } from "../short-term-promotion-store.js";
-import {
-  SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH,
-  SHORT_TERM_STORE_RELATIVE_PATH,
-} from "../short-term-promotion-types.js";
 import { normalizeShortTermRecallStore } from "../short-term-promotion-utils.js";
 import { resolveConfiguredWorkspaces } from "./doctor-workspaces.js";
 import { dreamingStateComparison } from "./dreaming-state-comparison.js";
@@ -38,17 +34,6 @@ type LegacySource = {
   filePath: string;
 };
 
-const LEGACY_DAILY_INGESTION_STATE_RELATIVE_PATH = path.join(
-  "memory",
-  ".dreams",
-  "daily-ingestion.json",
-);
-const LEGACY_SESSION_INGESTION_STATE_RELATIVE_PATH = path.join(
-  "memory",
-  ".dreams",
-  "session-ingestion.json",
-);
-
 async function readJsonFile(filePath: string): Promise<unknown> {
   return JSON.parse(await fs.readFile(filePath, "utf8"));
 }
@@ -58,15 +43,15 @@ async function collectLegacySources(
   env: NodeJS.ProcessEnv,
 ): Promise<LegacySource[]> {
   const sources: LegacySource[] = [];
-  for (const workspaceDir of resolveConfiguredWorkspaces(config, env)) {
+  for (const workspaceDir of await resolveConfiguredWorkspaces(config, env)) {
     const candidates = [
-      { label: "daily ingestion", relativePath: LEGACY_DAILY_INGESTION_STATE_RELATIVE_PATH },
-      { label: "session ingestion", relativePath: LEGACY_SESSION_INGESTION_STATE_RELATIVE_PATH },
-      { label: "short-term recall", relativePath: SHORT_TERM_STORE_RELATIVE_PATH },
-      { label: "phase signals", relativePath: SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH },
+      { label: "daily ingestion", fileName: "daily-ingestion.json" },
+      { label: "session ingestion", fileName: "session-ingestion.json" },
+      { label: "short-term recall", fileName: "short-term-recall.json" },
+      { label: "phase signals", fileName: "phase-signals.json" },
     ];
     for (const candidate of candidates) {
-      const filePath = path.join(workspaceDir, candidate.relativePath);
+      const filePath = path.join(workspaceDir, "memory", ".dreams", candidate.fileName);
       if (await legacyStateFileExists(filePath)) {
         sources.push({ workspaceDir, label: candidate.label, filePath });
       }

--- a/extensions/memory-core/src/migration/doctor-host-event-sources.ts
+++ b/extensions/memory-core/src/migration/doctor-host-event-sources.ts
@@ -49,7 +49,7 @@ export async function collectLegacyMemoryHostEventSources(
   const { resolveMemoryHostEventLogPath } = await import("openclaw/plugin-sdk/memory-host-events");
   const sources: LegacyMemoryHostEventSource[] = [];
   const seenWorkspaces = new Set<string>();
-  for (const workspaceDir of resolveConfiguredWorkspaces(config, env)) {
+  for (const workspaceDir of await resolveConfiguredWorkspaces(config, env)) {
     let canonicalWorkspaceDir = path.resolve(workspaceDir);
     let filePath = resolveMemoryHostEventLogPath(canonicalWorkspaceDir);
     try {

--- a/extensions/memory-core/src/migration/doctor-workspaces.ts
+++ b/extensions/memory-core/src/migration/doctor-workspaces.ts
@@ -1,6 +1,9 @@
-import { resolveMemoryDreamingWorkspaces } from "openclaw/plugin-sdk/memory-core-host-status";
-
-export function resolveConfiguredWorkspaces(config: unknown, env: NodeJS.ProcessEnv): string[] {
+export async function resolveConfiguredWorkspaces(
+  config: unknown,
+  env: NodeJS.ProcessEnv,
+): Promise<string[]> {
+  const { resolveMemoryDreamingWorkspaces } =
+    await import("openclaw/plugin-sdk/memory-core-host-status");
   return resolveMemoryDreamingWorkspaces(
     config as Parameters<typeof resolveMemoryDreamingWorkspaces>[0],
     { env },

--- a/extensions/memory-core/src/short-term-promotion-types.ts
+++ b/extensions/memory-core/src/short-term-promotion-types.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import type { MemoryEntryProvenance } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import {
   DEFAULT_MEMORY_DEEP_DREAMING_MIN_RECALL_COUNT,
@@ -10,17 +9,6 @@ import type { ConceptTagScriptCoverage } from "./concept-vocabulary.js";
 export const DEFAULT_PROMOTION_MIN_SCORE = DEFAULT_MEMORY_DEEP_DREAMING_MIN_SCORE;
 export const DEFAULT_PROMOTION_MIN_RECALL_COUNT = DEFAULT_MEMORY_DEEP_DREAMING_MIN_RECALL_COUNT;
 export const DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES = DEFAULT_MEMORY_DEEP_DREAMING_MIN_UNIQUE_QUERIES;
-export const SHORT_TERM_STORE_RELATIVE_PATH = path.join(
-  "memory",
-  ".dreams",
-  "short-term-recall.json",
-);
-export const SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH = path.join(
-  "memory",
-  ".dreams",
-  "phase-signals.json",
-);
-
 export type PromotionWeights = {
   frequency: number;
   relevance: number;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin doctor contract discovery failed its lightweight-import safety guard because memory migrations eagerly pulled in the SQLite query builder before any migration was actually requested.

## Why This Change Was Made

The private memory migration workspace helper now loads the existing canonical workspace resolver only inside its asynchronous migration owners, matching the lazy-loading boundary already used by neighboring migration code. Four duplicated legacy-path constants are replaced with their existing filenames at the migration owner, preserving every original migration path while removing a second static dependency on the heavyweight runtime.

## User Impact

Doctor discovery stays lightweight and repository validation passes again. Configured and default workspaces, symlink handling, migrated dreaming and host-event files, archive behavior, and existing public APIs are unchanged.

## Evidence

- The unchanged doctor static-closure guard failed against current main because the memory plugin reached the forbidden Kysely dependency through two independent eager imports; after the repair all four guard cases pass.
- Sixteen existing memory plugin doctor, dreaming, migration, and short-term promotion suites pass: 371 tests.
- Two independent full-source reviews verified both asynchronous migration callers, the canonical workspace resolver, all four exact legacy filenames, and unchanged public and security boundaries.
- Authenticated structured precommit review returned no findings and 0.99 confidence.
- Production source: +13/-37, a net reduction of 24 lines; no tests, configuration, schemas, baselines, or guardrails were changed.
- The local full changed-file gate passed its formatting, migration declarations, static-closure security, ratchets, dependency policy, and complete production/full-tree dead-export scans. Its repository-wide plugin typecheck then encountered unrelated pre-existing shared-worktree dependency drift: the checkout requires cua-driver 0.20.0 while the shared installation contains 0.19.3, and the declared maxmind dependency is absent. No diagnostic refers to the changed memory plugin files; exact-head hosted CI installs the correct locked dependencies and provides authoritative full typecheck validation.
