### PR TITLE
refactor(context-engine): remove inert legacy lifecycle hooks

### DIFF
--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -1875,11 +1875,6 @@ describe("LegacyContextEngine parity", () => {
     expect(result.estimatedTokens).toBe(0);
     expect(result.systemPromptAddition).toBeUndefined();
   });
-
-  it("dispose() completes without error", async () => {
-    const engine = new LegacyContextEngine();
-    await expect(engine.dispose()).resolves.toBeUndefined();
-  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/context-engine/legacy.ts
+++ b/src/context-engine/legacy.ts
@@ -34,15 +34,7 @@ export class LegacyContextEngine implements ContextEngine {
     };
   }
 
-  async afterTurn(_params: Parameters<NonNullable<ContextEngine["afterTurn"]>>[0]): Promise<void> {
-    // No-op: legacy flow persists context directly in SessionManager.
-  }
-
   compact(params: Parameters<ContextEngine["compact"]>[0]) {
     return delegateCompactionToRuntime(params);
-  }
-
-  async dispose(): Promise<void> {
-    // Nothing to clean up for legacy engine
   }
 }


### PR DESCRIPTION
## What Problem This Solves

The built-in legacy context engine advertised optional `afterTurn` and `dispose` lifecycle hooks even though both had always been empty. That made the engine appear to own lifecycle work it deliberately leaves to SessionManager and retained a test that only asserted an empty optional method resolved.

## Why This Change Was Made

Remove the two inert methods so the internal engine exposes only lifecycle work it performs. The existing runtime contracts already cover absence: disposal uses optional calls, and post-turn dispatch falls back to the required legacy `ingest` method, which intentionally returns `{ ingested: false }` because SessionManager owns persistence.

No `ContextEngine` interface, plugin SDK, host capability, runtime dispatch, config, protocol, or persistence contract changes. Changing those shared seams was rejected as unnecessary scope.

## User Impact

No user-visible behavior changes. The legacy engine has fewer misleading lifecycle concepts and one implementation-coupled test is removed.

## Evidence

Exact reviewed head: `6752236a89e84fca3c90cfca913613691622323a`

- `node scripts/run-vitest.mjs src/context-engine/context-engine.test.ts src/context-engine/host-param-projection.test.ts src/agents/harness/context-engine-lifecycle.test.ts` — 94 tests passed across 3 shards.
- `node scripts/check-changed.mjs -- src/context-engine/legacy.ts src/context-engine/context-engine.test.ts` — complete core/coreTests changed-file gate passed, including format, dead exports, core + core-test typechecks, targeted lint, boundaries, cycles, and guardrails.
- `git diff --check HEAD^..HEAD` — passed.
- Deslop review — clean; no edits required.
- Structured autoreview — clean, no accepted/actionable findings.
- Separate exact-head read-only Codex review — CLEAN, no actionable findings.
- Live overlap check — no open PR touches either changed file.
- LOC: production `+0/-8`; tests `+0/-5`; total net `-13`.

AI-assisted: yes. The maintainer-directed cleanup and exact code paths were manually inspected, tested, and reviewed.
