### PR TITLE
fix(release): preserve beta channel in prerelease survivor

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -17,6 +17,7 @@ const SCENARIOS = new Set([
   "plugin-deps-cleanup",
   "configured-plugin-installs",
   "stale-source-plugin-shadow",
+  "prerelease-plugin-registry",
   "tilde-log-path",
   "meeting-transcripts-sqlite",
   "versioned-runtime-deps",
@@ -391,14 +392,16 @@ function seedState() {
 function assertConfigSurvived() {
   const config = getConfig();
   const coverage = getCoverage();
-  if (getScenario() === "meeting-transcripts-sqlite") {
+  const scenario = getScenario();
+  if (scenario === "meeting-transcripts-sqlite") {
     // This focused migration fixture proves state import/export across one published
     // baseline; the broad base scenario owns unrelated agent/channel config parity.
     return;
   }
 
   if (acceptsIntent(coverage, "update")) {
-    assert(config.update?.channel === "stable", "update.channel was not preserved");
+    const expectedChannel = scenario === "prerelease-plugin-registry" ? "beta" : "stable";
+    assert(config.update?.channel === expectedChannel, "update.channel was not preserved");
   }
   if (acceptsIntent(coverage, "gateway")) {
     assert(config.gateway?.auth?.mode === "token", "gateway auth mode was not preserved");
@@ -434,7 +437,7 @@ function assertConfigSurvived() {
     } else {
       assert(pluginAllow.includes("whatsapp"), "whatsapp plugin allow entry missing");
     }
-    if (getScenario() === "codex-allowlist-survival") {
+    if (scenario === "codex-allowlist-survival") {
       assert(pluginAllow.includes("codex"), "Codex plugin allow entry missing");
     }
     if (hasCoverage(coverage) && acceptsIntent(coverage, "feishu-channel")) {
@@ -507,7 +510,7 @@ function assertConfigSurvived() {
     }
   }
 
-  if (getScenario() === "channel-post-core-restore") {
+  if (scenario === "channel-post-core-restore") {
     const whatsapp = config.channels?.whatsapp;
     assert(whatsapp?.enabled === true, "post-core channel restore dropped WhatsApp");
     assert(

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
@@ -232,12 +232,7 @@ export function resolveScenarioConfigSteps(scenario: string): ConfigStep[] {
   return scenarioConfigSteps.get(scenario) ?? [];
 }
 
-const recipe: ConfigStep[] = [
-  {
-    id: "update-channel",
-    intent: "update",
-    argv: ["config", "set", "update.channel", "stable"],
-  },
+const sharedRecipe: ConfigStep[] = [
   configSetJsonFile("gateway", "gateway", "gateway", "gateway.json"),
   ...representativeConfigSteps,
   {
@@ -248,9 +243,15 @@ const recipe: ConfigStep[] = [
 ];
 
 export function resolveUpgradeSurvivorConfigSteps(scenario = "base"): ConfigStep[] {
-  const validateStep = recipe.at(-1);
+  const validateStep = sharedRecipe.at(-1);
+  const updateChannel = scenario === "prerelease-plugin-registry" ? "beta" : "stable";
   return [
-    ...recipe.slice(0, -1),
+    {
+      id: "update-channel",
+      intent: "update",
+      argv: ["config", "set", "update.channel", updateChannel],
+    },
+    ...sharedRecipe.slice(0, -1),
     ...resolveScenarioConfigSteps(scenario),
     ...(validateStep ? [validateStep] : []),
   ];

--- a/scripts/lib/docker-e2e-plan.mts
+++ b/scripts/lib/docker-e2e-plan.mts
@@ -113,6 +113,7 @@ const UPGRADE_SURVIVOR_SCENARIOS = [
   "plugin-deps-cleanup",
   "configured-plugin-installs",
   "stale-source-plugin-shadow",
+  "prerelease-plugin-registry",
   "tilde-log-path",
   "meeting-transcripts-sqlite",
   "versioned-runtime-deps",
@@ -120,12 +121,18 @@ const UPGRADE_SURVIVOR_SCENARIOS = [
   "sqlite-volume",
 ];
 
+// Prerelease registry proof requires an explicit artifact contract and must not
+// join broad survivor sweeps that do not supply one.
+const UPGRADE_SURVIVOR_AGGREGATE_SCENARIOS = UPGRADE_SURVIVOR_SCENARIOS.filter(
+  (scenario) => scenario !== "prerelease-plugin-registry",
+);
+
 const UPGRADE_SURVIVOR_SCENARIO_ALIASES = new Map([
   [
     "reported-issues",
-    UPGRADE_SURVIVOR_SCENARIOS.filter((scenario) => scenario !== "sqlite-volume"),
+    UPGRADE_SURVIVOR_AGGREGATE_SCENARIOS.filter((scenario) => scenario !== "sqlite-volume"),
   ],
-  ["far-reaching", UPGRADE_SURVIVOR_SCENARIOS],
+  ["far-reaching", UPGRADE_SURVIVOR_AGGREGATE_SCENARIOS],
 ]);
 
 // Upgrade recipes select an OpenAI model whose runtime is supplied by the
@@ -135,6 +142,10 @@ const UPGRADE_SURVIVOR_RUNTIME_COMPANION_PACKAGES = ["@openclaw/codex"];
 // Pre-protocol catalogs are content-addressed. Unknown legacy blocks fail
 // closed instead of requiring a dependency or reimplementing a JavaScript parser.
 const LEGACY_UPGRADE_SURVIVOR_SCENARIO_CATALOGS = new Map([
+  [
+    "f886fb3ca6232eb97cdfe93a9ab7fc8e8cd4a39658c5518bfb736a2242d0c949",
+    "base acpx-openclaw-tools-bridge feishu-channel bootstrap-persona channel-post-core-restore codex-allowlist-survival plugin-deps-cleanup configured-plugin-installs stale-source-plugin-shadow prerelease-plugin-registry tilde-log-path meeting-transcripts-sqlite versioned-runtime-deps cron-scheduled-authority sqlite-volume auth-profile-v2026-7-2-beta-5",
+  ],
   [
     "0c5d3ce3533c035033890923aae7e210f4fdb24e7b8af32371930cdf12a00fd5",
     "base acpx-openclaw-tools-bridge feishu-channel bootstrap-persona channel-post-core-restore codex-allowlist-survival plugin-deps-cleanup configured-plugin-installs stale-source-plugin-shadow tilde-log-path meeting-transcripts-sqlite versioned-runtime-deps cron-scheduled-authority sqlite-volume auth-profile-v2026-7-2-beta-5",

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -1003,6 +1003,29 @@ describe("scripts/lib/docker-e2e-plan", () => {
     ]);
   });
 
+  it("plans the prerelease registry survivor only when explicitly requested", () => {
+    const laneName = "published-upgrade-survivor-2026.7.1-2-prerelease-plugin-registry";
+    const explicitPlan = planFor({
+      selectedLaneNames: ["published-upgrade-survivor"],
+      upgradeSurvivorBaselines: "2026.7.1-2",
+      upgradeSurvivorScenarios: "prerelease-plugin-registry",
+    });
+
+    expect(explicitPlan.lanes.map(summarizeLane)).toEqual([
+      publishedUpgradeSurvivorLane(laneName, "openclaw@2026.7.1-2", "prerelease-plugin-registry"),
+    ]);
+
+    for (const aggregateScenario of ["reported-issues", "far-reaching"]) {
+      const aggregateLaneNames = planFor({
+        selectedLaneNames: ["published-upgrade-survivor"],
+        upgradeSurvivorBaselines: "2026.7.1-2",
+        upgradeSurvivorScenarios: aggregateScenario,
+      }).lanes.map((lane) => lane.name);
+
+      expect(aggregateLaneNames).not.toContain(laneName);
+    }
+  });
+
   it("expands reported upgrade issue scenarios", () => {
     const plan = planFor({
       selectedLaneNames: ["published-upgrade-survivor"],

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -264,6 +264,35 @@ function assertConfiguredPluginState(params: { installPath?: string } = {}): voi
   }
 }
 
+function assertConfig(params: {
+  acceptedIntents: string[];
+  config: unknown;
+  scenario: string;
+}): void {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-config-"));
+  try {
+    const configPath = join(root, "openclaw.json");
+    const coveragePath = join(root, "coverage.json");
+    writeJson(configPath, params.config);
+    writeJson(coveragePath, {
+      acceptedIntents: params.acceptedIntents,
+      skippedIntents: [],
+    });
+
+    execFileSync(process.execPath, [ASSERTIONS_PATH, "assert-config"], {
+      env: {
+        ...process.env,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_UPGRADE_SURVIVOR_CONFIG_COVERAGE_JSON: coveragePath,
+        OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: params.scenario,
+      },
+      stdio: "pipe",
+    });
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
 function createUpdateRunSelfUpgradeSummary() {
   const sourceVersion = "2026.4.26";
   const targetVersion = "2026.7.2";
@@ -367,9 +396,27 @@ describe("upgrade survivor assertions", () => {
 
     expect(scenarios).toContain("base");
     expect(scenarios).toContain("acpx-openclaw-tools-bridge");
+    expect(scenarios).toContain("prerelease-plugin-registry");
     expect(scenarios).toContain("sqlite-volume");
     expect(new Set(scenarios).size).toBe(scenarios.length);
   });
+
+  it.each([
+    ["base", "stable", "beta"],
+    ["prerelease-plugin-registry", "beta", "stable"],
+  ])(
+    "requires the %s scenario to preserve the %s update channel",
+    (scenario, expectedChannel, wrongChannel) => {
+      const run = (channel: string) =>
+        assertConfig({
+          acceptedIntents: ["update"],
+          config: { update: { channel } },
+          scenario,
+        });
+      expect(() => run(expectedChannel)).not.toThrow();
+      expect(() => run(wrongChannel)).toThrow(/update.channel/);
+    },
+  );
 
   it("seeds recent ordered legacy session timestamps", () => {
     const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-seed-"));
@@ -459,40 +506,25 @@ describe("upgrade survivor assertions", () => {
   });
 
   it("asserts the ACPX OpenClaw tools bridge config survived", () => {
-    const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-acpx-config-"));
-    try {
-      const configPath = join(root, "openclaw.json");
-      const coveragePath = join(root, "coverage.json");
-      writeJson(configPath, {
-        plugins: {
-          allow: ["acpx"],
-          entries: {
-            acpx: {
-              enabled: true,
-              config: {
-                openClawToolsMcpBridge: true,
+    expect(() =>
+      assertConfig({
+        acceptedIntents: ["acpx-openclaw-tools-bridge"],
+        config: {
+          plugins: {
+            allow: ["acpx"],
+            entries: {
+              acpx: {
+                enabled: true,
+                config: {
+                  openClawToolsMcpBridge: true,
+                },
               },
             },
           },
         },
-      });
-      writeJson(coveragePath, {
-        acceptedIntents: ["acpx-openclaw-tools-bridge"],
-        skippedIntents: [],
-      });
-
-      execFileSync(process.execPath, [ASSERTIONS_PATH, "assert-config"], {
-        env: {
-          ...process.env,
-          OPENCLAW_CONFIG_PATH: configPath,
-          OPENCLAW_UPGRADE_SURVIVOR_CONFIG_COVERAGE_JSON: coveragePath,
-          OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "acpx-openclaw-tools-bridge",
-        },
-        stdio: "pipe",
-      });
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
+        scenario: "acpx-openclaw-tools-bridge",
+      }),
+    ).not.toThrow();
   });
 
   it("accepts official ClawHub npm-pack installs for configured external plugins", () => {

--- a/test/scripts/upgrade-survivor-config-recipe.test.ts
+++ b/test/scripts/upgrade-survivor-config-recipe.test.ts
@@ -146,6 +146,17 @@ describe("upgrade survivor config recipe command resolution", () => {
     ]);
   });
 
+  it.each([
+    ["base", "stable"],
+    ["prerelease-plugin-registry", "beta"],
+  ])("keeps the %s scenario on the %s update channel", (scenario, expectedChannel) => {
+    const updateChannels = resolveUpgradeSurvivorConfigSteps(scenario)
+      .filter((step) => step.argv.slice(0, 3).join(" ") === "config set update.channel")
+      .map((step) => step.argv[3]);
+
+    expect(updateChannels.at(-1)).toBe(expectedChannel);
+  });
+
   it("inserts scenario config before final validation", () => {
     const steps = resolveUpgradeSurvivorConfigSteps("feishu-channel");
     expect(steps.find((step) => step.id === "channels-discord")).toBeDefined();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where prerelease-registry upgrade-survivor validation forced `update.channel=stable`. After the candidate core package updated, configured plugins could resolve through the deliberately poisoned `latest` dist-tag instead of the candidate served on `beta`.

Prerequisite for https://github.com/openclaw/openclaw/pull/129912.

## Why This Change Was Made

Adds the dedicated `prerelease-plugin-registry` survivor scenario. Its config recipe persists `update.channel=beta`, while every other survivor scenario retains the existing stable-channel contract. The executable survivor assertion enforces the scenario-specific channel after update.

No workflow, planner, runtime, registry server, Discord, or install-resolution behavior changes.

## User Impact

Release maintainers can validate prerelease plugin companions through the real published-upgrade survivor path without contradicting the registry's beta-only candidate contract.

## Evidence

- Pre-fix focused regression: 3 failures for the unknown scenario and inherited stable channel.
- Post-fix: `node scripts/run-vitest.mjs test/scripts/upgrade-survivor-config-recipe.test.ts test/scripts/upgrade-survivor-assertions.test.ts` (36 passed).
- Test audit: retained as executable config-recipe and assertion-boundary proof; no test-only production seam.
- Autoreview: clean, no accepted/actionable findings, confidence 0.99.
- Formatting, conflict-marker, changelog-attribution, deprecation-registry, wildcard-export, duplicate-coverage, coercion-helper, dependency-pin, package-patch, temp-creation, and script-erasability gates passed.
- `check-changed` then stopped in script typecheck on sparse-checkout-missing Control UI files and the checkout's existing `pako` declaration gap; no touched-file diagnostic.
- LOC after compression: harness `+16/-12` (net `+4`); tests `+73/-30` (net `+43`).
- Paired proof prerequisite/head/source SHA: `3937676ecd72ebd609ab6f3ce82e22f0e42b9671`.
- Producer: https://github.com/openclaw/openclaw/actions/runs/32950174812 passed. It produced package `package-under-test-32950174812-1` (artifact id `9600149711`, digest `047aa4e2dccaef0fcd07c33c781ffe2da426239dd098026d4b0c9eae6541d113`, package SHA-256 `82f6ed37b7082825c2188fa405dc8d876e8a67a700647e5ffafd318790d5c885`, version `2026.8.1`, source SHA `3937676ecd72ebd609ab6f3ce82e22f0e42b9671`).
- Producer registry: `docker-e2e-prepublish-plugin-registry-32950174812-1` (artifact id `9600345095`, digest `21f1f38d74d35184c3754d52842edd013675ea7f074bcd70288654805d3d2325`, manifest SHA-256 `de15ed2b7a801cd61e9a9578d43013b8dc487bee7feb0e5ef4b86ed8511a791f`) contains `@openclaw/codex`, `@openclaw/discord`, and `@openclaw/whatsapp`, bound to source SHA `3937676ecd72ebd609ab6f3ce82e22f0e42b9671` and candidate `2026.8.1`.
- The producer's targeted `published-upgrade-survivor` run passed with scenario `prerelease-plugin-registry` and baseline `openclaw@2026.7.1-2`.
- Consumer/reuse: https://github.com/openclaw/openclaw/actions/runs/32952564629 passed on workflow head `47a32fe2739f00987bb6021eca97755606ab8f43`. It downloaded and validated the exact producer package and registry binding/content; both the targeted Docker survivor and Telegram `mock-openai` passed.
- The consumer created exactly four artifacts: `npm-telegram-beta-e2e-32952564629-1`, `docker-e2e-published-upgrade-survivor`, `docker-e2e-shared-images-pr129912-artifact-reuse-3937676ecd72-32952564629-1`, and `package-under-test-32952564629-1`. No plugin-registry artifact was regenerated.

## ClawSweeper

Exact-head review found no patch defect. Rank-up move applied: the paired artifact-backed prerelease-registry survivor proof is complete on the exact prerequisite/source SHA, including exact registry reuse with no replacement upload, Docker survivor success, and Telegram success. The staged owner/sequencing decision is to land this isolated scenario prerequisite before the dependent Package Acceptance change.

No re-review was requested because the reviewed code/head is unchanged and the latest ClawSweeper review is under 12 hours old; these updates add only the requested proof and maintainer sequencing decision.

AI-assisted; implementation and evidence reviewed by the author.
