### PR TITLE
fix(worktrees): never execute repository git hooks during provisioning

### DIFF
--- a/src/agents/worktrees/git.ts
+++ b/src/agents/worktrees/git.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import {
   createGitCommandError,
@@ -20,14 +21,25 @@ type WorktreeListEntry = {
   lockedReason?: string;
 };
 
-// Preserve the worktree-facing dependency contract while generic Git execution
-// remains owned by infra/git-exec.
+function gitEnvironment(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  // Gateway-run Git must never execute repository hooks or filesystem monitors;
+  // the admin-gated setup script is the sole intentional repository-code path.
+  return {
+    ...(env ?? process.env),
+    GIT_CONFIG_COUNT: "2",
+    GIT_CONFIG_KEY_0: "core.hooksPath",
+    GIT_CONFIG_VALUE_0: os.devNull,
+    GIT_CONFIG_KEY_1: "core.fsmonitor",
+    GIT_CONFIG_VALUE_1: "false",
+  };
+}
+
 export async function runGit(
   cwd: string,
   args: string[],
   options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array } = {},
 ): Promise<GitResult> {
-  return await executeGitCommand(cwd, args, options);
+  return await executeGitCommand(cwd, args, { ...options, env: gitEnvironment(options.env) });
 }
 
 export function commandError(command: string, result: GitResult): Error {
@@ -39,11 +51,11 @@ export async function requireGit(
   args: string[],
   options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array } = {},
 ): Promise<string> {
-  return await requireGitCommand(cwd, args, options);
+  return await requireGitCommand(cwd, args, { ...options, env: gitEnvironment(options.env) });
 }
 
 export async function requireGitRaw(cwd: string, args: string[]): Promise<string> {
-  return await requireGitCommandRaw(cwd, args);
+  return await requireGitCommandRaw(cwd, args, { env: gitEnvironment() });
 }
 
 export async function requireGitBuffer(
@@ -51,7 +63,7 @@ export async function requireGitBuffer(
   args: string[],
   options: { env?: NodeJS.ProcessEnv; input?: Uint8Array } = {},
 ): Promise<Buffer> {
-  return await requireGitCommandBuffer(cwd, args, options);
+  return await requireGitCommandBuffer(cwd, args, { ...options, env: gitEnvironment(options.env) });
 }
 
 function parseWorktreeList(output: string): WorktreeListEntry[] {

--- a/src/agents/worktrees/service.hooks.test.ts
+++ b/src/agents/worktrees/service.hooks.test.ts
@@ -1,0 +1,112 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { ManagedWorktreeService } from "./service.js";
+import { initializeManagedWorktreeTestRepository } from "./service.test-support.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("ManagedWorktreeService repository code isolation", () => {
+  let root: string;
+  let repo: string;
+  let sentinel: string;
+  let service: ManagedWorktreeService;
+
+  beforeEach(async () => {
+    root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-worktree-hooks-")));
+    repo = await initializeManagedWorktreeTestRepository(root);
+    sentinel = path.join(repo, ".hook-ran");
+    const hooks = path.join(repo, "git-hooks");
+    await fs.mkdir(hooks);
+    for (const hook of ["reference-transaction", "post-checkout"]) {
+      await fs.writeFile(path.join(hooks, hook), `#!/bin/sh\nprintf hook >> '${sentinel}'\n`, {
+        mode: 0o755,
+      });
+    }
+    await execFileAsync("git", ["-C", repo, "config", "core.hooksPath", "git-hooks"]);
+    service = new ManagedWorktreeService({
+      env: { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") },
+    });
+  });
+
+  afterEach(async () => {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("never executes repository hooks when creating a worktree with setup enabled", async () => {
+    const created = await service.create({ repoRoot: repo, name: "default", baseRef: "HEAD" });
+
+    await expect(fs.stat(created.path)).resolves.toBeDefined();
+    await expect(fs.access(sentinel)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("never executes repository hooks when creating a worktree with setup disabled", async () => {
+    await service.create({
+      repoRoot: repo,
+      name: "without-setup",
+      baseRef: "HEAD",
+      runSetupScript: false,
+    });
+
+    await expect(fs.access(sentinel)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("never executes repository hooks when snapshotting and removing a worktree", async () => {
+    const created = await service.create({ repoRoot: repo, name: "remove", baseRef: "HEAD" });
+    await fs.rm(sentinel, { force: true });
+
+    await expect(service.remove({ id: created.id, reason: "test" })).resolves.toMatchObject({
+      removed: true,
+      snapshotRef: expect.any(String),
+    });
+    await expect(fs.access(sentinel)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("never executes repository hooks when restoring a removed worktree", async () => {
+    const created = await service.create({ repoRoot: repo, name: "restore", baseRef: "HEAD" });
+    await service.remove({ id: created.id, reason: "test" });
+    await fs.rm(sentinel, { force: true });
+
+    await expect(service.restore({ id: created.id })).resolves.toMatchObject({ id: created.id });
+    await expect(fs.access(sentinel)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("never executes a repository filesystem monitor during lossless removal", async () => {
+    const created = await service.create({ repoRoot: repo, name: "fsmonitor", baseRef: "HEAD" });
+    await fs.rm(sentinel, { force: true });
+    const monitor = path.join(repo, "fsmonitor.sh");
+    await fs.writeFile(
+      monitor,
+      `#!/bin/sh\nprintf fsmonitor >> '${sentinel}'\nprintf 'token\\0'\n`,
+      {
+        mode: 0o755,
+      },
+    );
+    await execFileAsync("git", ["-C", repo, "config", "core.fsmonitor", monitor]);
+
+    await expect(service.removeIfLossless(created.id)).resolves.toBe(true);
+    await expect(fs.access(sentinel)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("still executes the explicitly enabled worktree setup script", async () => {
+    const setup = path.join(repo, ".openclaw");
+    await fs.mkdir(setup);
+    await fs.writeFile(
+      path.join(setup, "worktree-setup.sh"),
+      "#!/bin/sh\nprintf setup > setup-ran.txt\n",
+      { mode: 0o755 },
+    );
+
+    const created = await service.create({ repoRoot: repo, name: "setup", baseRef: "HEAD" });
+
+    await expect(fs.readFile(path.join(created.path, "setup-ran.txt"), "utf8")).resolves.toBe(
+      "setup",
+    );
+    await expect(fs.access(sentinel)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -6,11 +6,6 @@ import path from "node:path";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveStateDir } from "../../config/paths.js";
 import { isMissingPathError, formatErrorMessage } from "../../infra/errors.js";
-import {
-  executeGitCommand as runGit,
-  requireGitCommand as requireGit,
-  requireGitCommandBuffer as requireGitBuffer,
-} from "../../infra/git-exec.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { withOpenClawStateLease } from "../../state/openclaw-state-lease.js";
@@ -23,6 +18,9 @@ import {
   listGitWorktrees,
   worktreePathExists,
   removeEmptyParents,
+  requireGit,
+  requireGitBuffer,
+  runGit,
   type GitResult,
 } from "./git.js";
 import { worktreeNameAllocationFamily } from "./name.js";
@@ -483,19 +481,13 @@ async function snapshotWorktree(
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-worktree-index-"));
   const indexPath = path.join(tempDir, "index");
   const snapshotRef = `${SNAPSHOT_REF_PREFIX}/${record.id}`;
+  const filemodeArgs = process.platform === "win32" ? [] : ["-c", "core.filemode=true"];
   const env: NodeJS.ProcessEnv = {
     GIT_INDEX_FILE: indexPath,
     GIT_AUTHOR_NAME: "OpenClaw",
     GIT_AUTHOR_EMAIL: "openclaw@localhost",
     GIT_COMMITTER_NAME: "OpenClaw",
     GIT_COMMITTER_EMAIL: "openclaw@localhost",
-    ...(process.platform === "win32"
-      ? {}
-      : {
-          GIT_CONFIG_COUNT: "1",
-          GIT_CONFIG_KEY_0: "core.filemode",
-          GIT_CONFIG_VALUE_0: "true",
-        }),
   };
   try {
     const provisioned = new Set(provisionedPaths.map((entry) => gitPathKey(Buffer.from(entry))));
@@ -555,17 +547,23 @@ async function snapshotWorktree(
     if (await containsSnapshotGitMarker(record.path, snapshotPaths.values())) {
       throw new Error("nested git repositories cannot be snapshotted losslessly");
     }
-    await requireGit(record.path, ["read-tree", "HEAD"], { env });
+    await requireGit(record.path, [...filemodeArgs, "read-tree", "HEAD"], { env });
     // This index came from a tree, so it has no checkout-local skip-worktree
     // bits and update-index is independent of the source worktree's sparse cone.
-    await requireGit(record.path, ["update-index", "--add", "--remove", "-z", "--stdin"], {
-      env,
-      input:
-        snapshotPaths.size > 0
-          ? Buffer.concat([...snapshotPaths.values()].flatMap((entry) => [entry, Buffer.from([0])]))
-          : Buffer.alloc(0),
-    });
-    const tree = await requireGit(record.path, ["write-tree"], { env });
+    await requireGit(
+      record.path,
+      [...filemodeArgs, "update-index", "--add", "--remove", "-z", "--stdin"],
+      {
+        env,
+        input:
+          snapshotPaths.size > 0
+            ? Buffer.concat(
+                [...snapshotPaths.values()].flatMap((entry) => [entry, Buffer.from([0])]),
+              )
+            : Buffer.alloc(0),
+      },
+    );
+    const tree = await requireGit(record.path, [...filemodeArgs, "write-tree"], { env });
     for (const provisionedPath of provisionedPaths) {
       const overlap = await requireGit(record.path, [
         "--literal-pathspecs",
@@ -588,7 +586,15 @@ async function snapshotWorktree(
     const parent = await requireGit(record.path, ["rev-parse", "HEAD"]);
     const commit = await requireGit(
       record.path,
-      ["commit-tree", tree, "-p", parent, "-m", `OpenClaw worktree snapshot: ${reason}`],
+      [
+        ...filemodeArgs,
+        "commit-tree",
+        tree,
+        "-p",
+        parent,
+        "-m",
+        `OpenClaw worktree snapshot: ${reason}`,
+      ],
       { env },
     );
     await requireGit(record.repoRoot, ["update-ref", snapshotRef, commit]);
@@ -732,16 +738,7 @@ export class ManagedWorktreeService {
     let gitBase = base.gitOperand;
     let recordBase = base.recordRef;
     const runRepositorySetup = params.runSetupScript !== false;
-    const worktreeAddArgs = () => [
-      ...(runRepositorySetup ? [] : ["-c", `core.hooksPath=${os.devNull}`]),
-      "worktree",
-      "add",
-      "-b",
-      branch,
-      "--",
-      worktreePath,
-      gitBase,
-    ];
+    const worktreeAddArgs = () => ["worktree", "add", "-b", branch, "--", worktreePath, gitBase];
     let added = await runGit(repository.repoRoot, worktreeAddArgs());
     if (added.code !== 0 && base.remote) {
       if (!(await canResetFailedWorktreeAdd(repository.repoRoot, worktreePath, branch, added))) {

--- a/src/agents/worktrees/types.ts
+++ b/src/agents/worktrees/types.ts
@@ -45,8 +45,7 @@ export type CreateManagedWorktreeParams = {
   baseRef?: string;
   ownerKind?: ManagedWorktreeOwnerKind;
   ownerId?: string;
-  // Repository checkout hooks and .openclaw/worktree-setup.sh execute repo-local code, so
-  // callers reachable from less-privileged surfaces opt out; admin paths keep them on.
+  // Repository Git hooks are always disabled; only the setup script runs repo-local code.
   runSetupScript?: boolean;
   /** Synchronous caller-authority guard checked at allocation commit boundaries. */
   commitGuard?: () => void;

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -425,8 +425,8 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
                 explicitSessionLabel ?? generatedTitle ?? worktreeTitle?.source ?? "",
               ),
               baseRef: requestedWorktreeBaseRef,
-              // Checkout hooks and .openclaw/worktree-setup.sh run repo code; keep them
-              // admin-only so this write-scoped path cannot execute gated repo scripts.
+              // Worktree Git always disables checkout/ref hooks; only the setup
+              // script executes repository code and therefore requires admin scope.
               runSetupScript: scopes.includes(ADMIN_SCOPE),
               ...(commitGuard ? { commitGuard } : {}),
             });

--- a/src/infra/git-exec.ts
+++ b/src/infra/git-exec.ts
@@ -37,8 +37,12 @@ export async function requireGitCommand(
   return result.stdout.trim();
 }
 
-export async function requireGitCommandRaw(cwd: string, args: string[]): Promise<string> {
-  const result = await executeGitCommand(cwd, args);
+export async function requireGitCommandRaw(
+  cwd: string,
+  args: string[],
+  options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array } = {},
+): Promise<string> {
+  const result = await executeGitCommand(cwd, args, options);
   if (result.code !== 0) {
     throw createGitCommandError(`git ${args.join(" ")}`, result);
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway-managed worktree creation, removal, restoration, and garbage collection could execute repository-configured Git hooks or filesystem monitors while operating in user repositories. A repository reference-transaction hook fired during a Gateway GitHub-publication live test.

## Why This Change Was Made

Every Git command owned by the managed worktrees service now pins `core.hooksPath=/dev/null` and `core.fsmonitor=false` through `GIT_CONFIG_*` environment overrides, matching the publication executor. The explicitly admin-gated `.openclaw/worktree-setup.sh` remains the only intentional repository-code execution path.

## User Impact

Operators can create, remove, restore, and garbage-collect managed worktrees without silently running repository-configured Git hooks or filesystem monitors. Administrators can still explicitly enable the repository worktree setup script.

## Evidence

- Pre-fix regression proof: 5 of the 6 new repository-code-isolation tests failed because repository hooks executed.
- Post-fix managed-worktrees suite: 129 tests passed.
- Post-fix Gateway `sessions.create` suite: 116 tests passed.
- Changed-file validation: `check-changed` passed.
- Standalone Git 2.54 probe: unpinned `git branch` executed a repository `reference-transaction` hook, while the `GIT_CONFIG_*` pin suppressed it.
- Codex autoreview: clean, with no accepted or actionable findings.
