### PR TITLE
fix(plugins): memory plugin discovery loads SQLite during doctor startup

### DIFF
--- a/src/agents/workspace-legacy-state.ts
+++ b/src/agents/workspace-legacy-state.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { resolveLegacyStateDirs, resolveStateDir } from "../config/paths.js";
 import { root } from "../infra/fs-safe.js";
 import { resolveUserPath } from "../utils.js";
-import { resolveWorkspaceStateIdentity } from "./workspace-state-store.js";
+import { resolveWorkspaceStateIdentity } from "./workspace-state-identity.js";
 
 export const LEGACY_WORKSPACE_STATE_DIRNAME = ".openclaw";
 const LEGACY_WORKSPACE_STATE_FILENAME = "workspace-state.json";

--- a/src/agents/workspace-state-identity.ts
+++ b/src/agents/workspace-state-identity.ts
@@ -1,0 +1,87 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveUserPath } from "../infra/home-dir.js";
+
+export type WorkspaceStateIdentity = {
+  workspaceKey: string;
+  workspacePath: string;
+};
+
+const MAX_WORKSPACE_IDENTITY_SYMLINKS = 40;
+
+function normalizeWorkspaceIdentityPath(value: string): string {
+  const normalized = path.normalize(value).normalize("NFC");
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function canonicalizeWorkspaceIdentityPath(workspaceDir: string): string {
+  const fallback = normalizeWorkspaceIdentityPath(path.resolve(resolveUserPath(workspaceDir)));
+  let candidate = fallback;
+  const followedSymlinks = new Set<string>();
+
+  for (let redirectCount = 0; redirectCount < MAX_WORKSPACE_IDENTITY_SYMLINKS; redirectCount += 1) {
+    const missingSegments: string[] = [];
+    let current = candidate;
+    while (true) {
+      try {
+        return normalizeWorkspaceIdentityPath(
+          path.join(fs.realpathSync.native(current), ...missingSegments.toReversed()),
+        );
+      } catch {
+        // A dangling symlink still carries the stable target identity. Resolve
+        // it lexically so vanished-workspace protection cannot be bypassed.
+      }
+      try {
+        if (fs.lstatSync(current).isSymbolicLink()) {
+          const normalizedLink = normalizeWorkspaceIdentityPath(current);
+          if (followedSymlinks.has(normalizedLink)) {
+            return fallback;
+          }
+          followedSymlinks.add(normalizedLink);
+          candidate = path.resolve(
+            path.dirname(current),
+            fs.readlinkSync(current),
+            ...missingSegments.toReversed(),
+          );
+          break;
+        }
+      } catch {
+        // Keep walking to a real existing ancestor.
+      }
+      const parent = path.dirname(current);
+      if (parent === current) {
+        return fallback;
+      }
+      missingSegments.push(path.basename(current));
+      current = parent;
+    }
+  }
+  return fallback;
+}
+
+export function createWorkspaceStateIdentity(workspacePath: string): WorkspaceStateIdentity {
+  return {
+    workspacePath,
+    workspaceKey: createHash("sha256").update(workspacePath).digest("hex"),
+  };
+}
+
+export function resolveWorkspaceStateAliases(workspaceDir: string): WorkspaceStateIdentity[] {
+  const lexicalPath = normalizeWorkspaceIdentityPath(path.resolve(resolveUserPath(workspaceDir)));
+  const canonicalPath = canonicalizeWorkspaceIdentityPath(workspaceDir);
+  return [...new Set([lexicalPath, canonicalPath])].map(createWorkspaceStateIdentity);
+}
+
+export function workspacePathEntryExists(workspaceDir: string): boolean {
+  try {
+    fs.lstatSync(path.resolve(resolveUserPath(workspaceDir)));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveWorkspaceStateIdentity(workspaceDir: string): WorkspaceStateIdentity {
+  return createWorkspaceStateIdentity(canonicalizeWorkspaceIdentityPath(workspaceDir));
+}

--- a/src/agents/workspace-state-store.ts
+++ b/src/agents/workspace-state-store.ts
@@ -1,6 +1,4 @@
-import { createHash } from "node:crypto";
-import fs, { existsSync } from "node:fs";
-import path from "node:path";
+import { existsSync } from "node:fs";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -15,7 +13,15 @@ import {
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
-import { resolveUserPath } from "../utils.js";
+import {
+  createWorkspaceStateIdentity,
+  resolveWorkspaceStateAliases,
+  resolveWorkspaceStateIdentity,
+  workspacePathEntryExists,
+  type WorkspaceStateIdentity,
+} from "./workspace-state-identity.js";
+
+export { resolveWorkspaceStateIdentity };
 
 export const WORKSPACE_SETUP_STATE_VERSION = 1 as const;
 export const WORKSPACE_ATTESTATION_RECENT_MS = 24 * 60 * 60 * 1000;
@@ -76,11 +82,6 @@ export type WorkspaceStateSnapshot = {
   attestation?: WorkspaceAttestation;
 };
 
-type WorkspaceStateIdentity = {
-  workspaceKey: string;
-  workspacePath: string;
-};
-
 type WorkspaceStateDeletionPlan = {
   lexicalAlias: WorkspaceStateIdentity;
   currentCanonicalIdentity: WorkspaceStateIdentity;
@@ -99,89 +100,11 @@ type WorkspaceStateDatabase = Pick<
 
 type WorkspaceStateDatabaseHandle = Pick<ReturnType<typeof openOpenClawStateDatabase>, "db">;
 
-const MAX_WORKSPACE_IDENTITY_SYMLINKS = 40;
-
 type WorkspaceIdentityResolution = {
   identity: WorkspaceStateIdentity;
   aliases: WorkspaceStateIdentity[];
   missingAliasKeys: string[];
 };
-
-function normalizeWorkspaceIdentityPath(value: string): string {
-  const normalized = path.normalize(value).normalize("NFC");
-  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
-}
-
-function canonicalizeWorkspaceIdentityPath(workspaceDir: string): string {
-  const fallback = normalizeWorkspaceIdentityPath(path.resolve(resolveUserPath(workspaceDir)));
-  let candidate = fallback;
-  const followedSymlinks = new Set<string>();
-
-  for (let redirectCount = 0; redirectCount < MAX_WORKSPACE_IDENTITY_SYMLINKS; redirectCount += 1) {
-    const missingSegments: string[] = [];
-    let current = candidate;
-    while (true) {
-      try {
-        return normalizeWorkspaceIdentityPath(
-          path.join(fs.realpathSync.native(current), ...missingSegments.toReversed()),
-        );
-      } catch {
-        // A dangling symlink still carries the stable target identity. Resolve
-        // it lexically so vanished-workspace protection cannot be bypassed.
-      }
-      try {
-        if (fs.lstatSync(current).isSymbolicLink()) {
-          const normalizedLink = normalizeWorkspaceIdentityPath(current);
-          if (followedSymlinks.has(normalizedLink)) {
-            return fallback;
-          }
-          followedSymlinks.add(normalizedLink);
-          candidate = path.resolve(
-            path.dirname(current),
-            fs.readlinkSync(current),
-            ...missingSegments.toReversed(),
-          );
-          break;
-        }
-      } catch {
-        // Keep walking to a real existing ancestor.
-      }
-      const parent = path.dirname(current);
-      if (parent === current) {
-        return fallback;
-      }
-      missingSegments.push(path.basename(current));
-      current = parent;
-    }
-  }
-  return fallback;
-}
-
-function createWorkspaceStateIdentity(workspacePath: string): WorkspaceStateIdentity {
-  return {
-    workspacePath,
-    workspaceKey: createHash("sha256").update(workspacePath).digest("hex"),
-  };
-}
-
-function resolveWorkspaceStateAliases(workspaceDir: string): WorkspaceStateIdentity[] {
-  const lexicalPath = normalizeWorkspaceIdentityPath(path.resolve(resolveUserPath(workspaceDir)));
-  const canonicalPath = canonicalizeWorkspaceIdentityPath(workspaceDir);
-  return [...new Set([lexicalPath, canonicalPath])].map(createWorkspaceStateIdentity);
-}
-
-function workspacePathEntryExists(workspaceDir: string): boolean {
-  try {
-    fs.lstatSync(path.resolve(resolveUserPath(workspaceDir)));
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-export function resolveWorkspaceStateIdentity(workspaceDir: string): WorkspaceStateIdentity {
-  return createWorkspaceStateIdentity(canonicalizeWorkspaceIdentityPath(workspaceDir));
-}
 
 function resolveWorkspaceIdentityFromDatabase(params: {
   workspaceDir: string;

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -16,7 +16,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
-import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-store.js";
+import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 const DEFAULT_MEMORY_DREAMING_ENABLED = true;

--- a/src/memory-host-sdk/event-store.ts
+++ b/src/memory-host-sdk/event-store.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { z } from "zod";
-import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-store.js";
+import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
 import {
   pluginStateEntriesInKeyRange,
   registerPluginStateSyncSequencedJournalEntry,


### PR DESCRIPTION
Related: #116650, #118015

## What Problem This Solves

Resolves a problem where discovering the bundled memory plugin or enumerating its doctor contract eagerly loaded the SQLite query runtime. The resulting forbidden import chain breaks the existing plugin doctor closure guard on main and blocks otherwise unrelated pull requests.

## Why This Change Was Made

Workspace identity resolution only needs filesystem, path, hashing, and home-directory helpers, but it lived inside the SQLite-backed workspace state store. Move the unchanged identity and alias helpers into their own lightweight owner and reuse that owner from workspace state, legacy migration, memory dreaming, and memory-event storage. Preserve the state store's existing resolver export, symlink and dangling-alias handling, Unicode and Windows normalization, persistence behavior, and public plugin SDK surface.

## User Impact

Plugin discovery and doctor enumeration stay lightweight again, and unrelated pull requests can pass the existing doctor dependency-closure check. Workspace identities, memory dreaming, memory-event ownership, and stored state retain their existing behavior; no schema, migration, storage format, configuration, or public API changes are introduced.

## Evidence

Frozen main baseline: `9b77c06bbde9bd9cf3d280ef1d515d8a824a1582`.
Reviewed repair commit: `2e0ec2fc172df449c57bb7eefaabbd01b62d37b6`.
Source change: #116650 (`cb6c508fe3392438bb6b8cb14e3626f9a3f8f407`); repair authored by @steipete.

Before the change, the existing regression command failed with one broken test because `memory-core -> memory-host-sdk/dreaming -> workspace-state-store -> kysely` was statically reachable:

```text
node scripts/run-vitest.mjs src/plugins/doctor-contract-closure-guard.test.ts
Test Files  1 failed (1)
Tests       1 failed | 3 passed (4)
```

After the owner-boundary extraction, the same command passed all four tests. The complete focused owner and sibling proof also passed seven files and 78 tests:

```text
node scripts/run-vitest.mjs \
  src/plugins/doctor-contract-closure-guard.test.ts \
  src/plugins/doctor-contract-declarations.test.ts \
  src/agents/workspace-state-store.test.ts \
  src/agents/workspace-legacy-state.test.ts \
  src/agents/workspace-sqlite-safety.test.ts \
  src/memory-host-sdk/dreaming.test.ts \
  extensions/memory-core/src/memory-events.test.ts
```

Targeted formatting, targeted core lint, and `git diff --check` all passed. The structured pre-commit review and a separate read-only exact-commit Codex review each reported zero actionable findings.

Production delta: +10 lines, reflecting a pure 87-line identity-owner move and its necessary imports; no test-only production seams or duplicate regression tests were added because the existing architectural guard already proves the failure before the fix.
