### PR TITLE
improve(ui): calm the sidebar update affordance

### DIFF
--- a/ui/src/app/app-host-native-shell.test.ts
+++ b/ui/src/app/app-host-native-shell.test.ts
@@ -7,7 +7,7 @@ import { getRenderedModalDialog, installDialogPolyfill } from "../test-helpers/m
 import "./app-host.ts";
 import { resetAppHostTestGlobals, type ShellKeyboardState } from "./app-host.test-support.ts";
 import type { ApplicationContext } from "./context.ts";
-import { navigationSurfaceIsHidden, renderFloatingUpdateCard } from "./navigation-surface.ts";
+import { renderFloatingUpdateCard } from "./navigation-surface.ts";
 
 type ShellNavigationState = {
   runtime: { context: ApplicationContext };
@@ -490,12 +490,10 @@ describe("OpenClaw native shell", () => {
 });
 
 describe("OpenClaw shell update affordance", () => {
-  it("renders floating attention while keeping update actions in navigation", async () => {
+  it("renders only the stale-client refresh card outside navigation", () => {
     const container = document.createElement("div");
     document.body.append(container);
     const shared = {
-      mobileNavLayout: false,
-      onboarding: false,
       updateAvailable: {
         currentVersion: "2026.7.1",
         latestVersion: "2026.7.2",
@@ -507,22 +505,13 @@ describe("OpenClaw shell update affordance", () => {
       refreshRequired: false,
       onRefresh: vi.fn(),
     };
-    const collapsed = navigationSurfaceIsHidden({
-      onboarding: false,
-      navCollapsed: true,
-      navDrawerOpen: false,
-      mobileNavLayout: false,
-    });
-    render(renderFloatingUpdateCard({ ...shared, navigationSurfaceHidden: collapsed }), container);
-    expect(
-      container.querySelector("openclaw-sidebar-attention.sidebar-attention--floating"),
-    ).not.toBeNull();
+    render(renderFloatingUpdateCard(shared), container);
+    expect(container.querySelector("openclaw-sidebar-attention")).toBeNull();
     expect(container.querySelector("openclaw-sidebar-update-card")).toBeNull();
 
     render(
       renderFloatingUpdateCard({
         ...shared,
-        navigationSurfaceHidden: collapsed,
         updateAvailable: null,
         refreshRequired: true,
       }),
@@ -535,114 +524,19 @@ describe("OpenClaw shell update affordance", () => {
     refreshCard?.onRefresh();
     expect(shared.onRefresh).toHaveBeenCalledOnce();
     expect(shared.onUpdate).not.toHaveBeenCalled();
-
-    const visible = navigationSurfaceIsHidden({
-      onboarding: false,
-      navCollapsed: false,
-      navDrawerOpen: false,
-      mobileNavLayout: false,
-    });
-    render(
-      renderFloatingUpdateCard({
-        ...shared,
-        navigationSurfaceHidden: visible,
-        updateAvailable: null,
-        refreshRequired: true,
-      }),
-      container,
-    );
-    expect(container.querySelector("openclaw-sidebar-update-card")).not.toBeNull();
     container.remove();
   });
 
-  it("keeps attention in the closed mobile drawer while preserving stale-client refresh", async () => {
+  it("hides the stale-client refresh card in compact chrome", () => {
     const container = document.createElement("div");
-    document.body.append(container);
-    try {
-      const navigationSurfaceHidden = navigationSurfaceIsHidden({
-        onboarding: false,
-        navCollapsed: false,
-        navDrawerOpen: false,
-        mobileNavLayout: true,
-      });
-      expect(navigationSurfaceHidden).toBe(true);
-      const shared = {
-        navigationSurfaceHidden,
-        mobileNavLayout: true,
-        onboarding: false,
-        updateAvailable: {
-          currentVersion: "2026.7.1",
-          latestVersion: "2026.7.2",
-          channel: "stable" as const,
-        },
-        updateBusy: false,
-        canUpdate: true,
-        onUpdate: vi.fn(),
-        refreshRequired: false,
-        onRefresh: vi.fn(),
-      };
-
-      render(renderFloatingUpdateCard(shared), container);
-      expect(
-        container.querySelector("openclaw-sidebar-attention.sidebar-attention--floating"),
-      ).toBeNull();
-
-      render(
-        renderFloatingUpdateCard({ ...shared, updateAvailable: null, refreshRequired: true }),
-        container,
-      );
-      const refreshCard = container.querySelector<
-        HTMLElement & { updateComplete: Promise<boolean> }
-      >("openclaw-sidebar-update-card");
-      await refreshCard?.updateComplete;
-      expect(refreshCard?.querySelector(".sidebar-update-card")).not.toBeNull();
-    } finally {
-      container.remove();
-    }
-  });
-
-  it("keeps the stale-client refresh visible during onboarding", () => {
-    const container = document.createElement("div");
-    const shared = {
-      mobileNavLayout: false,
-      onboarding: true,
-      updateAvailable: null,
-      updateBusy: false,
-      onUpdate: vi.fn(),
-      refreshRequired: true,
-      onRefresh: vi.fn(),
-    };
-    expect(
-      navigationSurfaceIsHidden({
-        onboarding: true,
-        navCollapsed: false,
-        navDrawerOpen: false,
-        mobileNavLayout: false,
-      }),
-    ).toBe(true);
-
-    for (const navigationSurfaceHidden of [false, true]) {
-      render(renderFloatingUpdateCard({ ...shared, navigationSurfaceHidden }), container);
-      expect(
-        container.querySelector("openclaw-sidebar-attention.sidebar-attention--floating") !== null,
-      ).toBe(navigationSurfaceHidden);
-      const cards = container.querySelectorAll<HTMLElement & { refreshRequired: boolean }>(
-        "openclaw-sidebar-update-card",
-      );
-      expect(cards).toHaveLength(1);
-      expect(cards[0]?.refreshRequired).toBe(true);
-    }
-
     render(
       renderFloatingUpdateCard({
-        ...shared,
-        navigationSurfaceHidden: true,
-        updateAvailable: {
-          currentVersion: "2026.7.1",
-          latestVersion: "2026.7.2",
-          channel: "stable",
-        },
-        refreshRequired: false,
+        compact: true,
+        updateAvailable: null,
+        updateBusy: false,
+        onUpdate: vi.fn(),
+        refreshRequired: true,
+        onRefresh: vi.fn(),
       }),
       container,
     );

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -41,11 +41,7 @@ import {
 import { isMobileNavLayout, shouldMergeChatChrome } from "./mobile-nav-layout.ts";
 import type { NativeHistoryState } from "./native-web-chrome.ts";
 import { isNativeWebChromeHost } from "./native-web-chrome.ts";
-import {
-  floatingSidebarAttentionVisible,
-  navigationSurfaceIsHidden,
-  renderFloatingUpdateCard,
-} from "./navigation-surface.ts";
+import { navigationSurfaceIsHidden, renderFloatingUpdateCard } from "./navigation-surface.ts";
 import { readGatewayOperatorAccess } from "./operator-access.ts";
 import {
   NAV_WIDTH_MAX,
@@ -56,12 +52,6 @@ import {
 import { createUpdateProgressWatcher } from "./update-overlay-helpers.ts";
 
 const EMPTY_SESSION_HAS_DRAFT = () => false;
-const SIDEBAR_ATTENTION_ELEMENT = {
-  tagName: "openclaw-sidebar-attention",
-  label: t("attention.issues"),
-  loadModule: () => import("../components/sidebar-attention.ts"),
-} satisfies OptionalCustomElement;
-
 export interface ShellViewHost {
   readonly context: ApplicationContext<RouteId> | undefined;
   readonly runtime: ApplicationRuntime | undefined;
@@ -289,17 +279,6 @@ export function renderApplicationShell(host: ShellViewHost) {
     navDrawerOpen,
     mobileNavLayout,
   });
-  if (
-    floatingSidebarAttentionVisible({
-      navigationSurfaceHidden,
-      mobileNavLayout,
-      onboarding,
-      settingsTakeover,
-      compact: mergedChatChrome,
-    })
-  ) {
-    host.lazyCustomElements.preload(SIDEBAR_ATTENTION_ELEMENT, { reportError: true });
-  }
   const shellWidth = Math.max(globalThis.innerWidth || 0, NAV_WIDTH_MAX);
   // A route query is navigation input, not an owner record. Let it override the
   // live selection only after the roster proves that agent exists.
@@ -588,10 +567,6 @@ export function renderApplicationShell(host: ShellViewHost) {
         .tabIndex=${-1}
       >
         ${renderFloatingUpdateCard({
-          navigationSurfaceHidden,
-          mobileNavLayout,
-          onboarding,
-          settingsTakeover,
           compact: mergedChatChrome,
           updateAvailable: overlaySnapshot.updateAvailable,
           updateSchedule: overlaySnapshot.updateSchedule,
@@ -606,8 +581,6 @@ export function renderApplicationShell(host: ShellViewHost) {
           onRefresh: () => host.refreshControlUi(),
           onHoldUpdate: () => context.overlays.holdUpdate(),
           onReviewUpdate: () => host.navigate("updates"),
-          onNavigate: (routeId) => host.navigate(routeId),
-          onOpenApprovals: () => host.openApprovals(),
         })}
         ${pageActionsBlocked && gatewaySnapshot.phase !== "reload-required"
           ? html`<div class="connection-action-block" role="status" aria-live="polite">

--- a/ui/src/app/navigation-surface.browser.test.ts
+++ b/ui/src/app/navigation-surface.browser.test.ts
@@ -49,9 +49,6 @@ describe.skipIf(!hasBrowserLayout)("navigation surface browser layout", () => {
           </div>
           <main class="content">
             ${renderFloatingUpdateCard({
-              navigationSurfaceHidden: true,
-              mobileNavLayout: false,
-              onboarding: false,
               updateAvailable: null,
               updateBusy: false,
               onUpdate: () => undefined,

--- a/ui/src/app/navigation-surface.browser.test.ts
+++ b/ui/src/app/navigation-surface.browser.test.ts
@@ -25,6 +25,30 @@ function overlaps(left: DOMRect, right: DOMRect): boolean {
 }
 
 describe.skipIf(!hasBrowserLayout)("navigation surface browser layout", () => {
+  it("does not move update attention into collapsed chrome", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const params = {
+      navigationSurfaceHidden: true,
+      mobileNavLayout: false,
+      onboarding: false,
+      updateAvailable: {
+        channel: "stable" as const,
+        currentVersion: "1.0.0",
+        latestVersion: "2.0.0",
+      },
+      updateBusy: false,
+      onUpdate: () => undefined,
+      refreshRequired: false,
+      onRefresh: () => undefined,
+    };
+
+    render(renderFloatingUpdateCard(params), container);
+
+    expect(document.querySelector("openclaw-sidebar-attention")).toBeNull();
+    expect(document.querySelector("openclaw-sidebar-update-card")).toBeNull();
+  });
+
   it("keeps the floating refresh card clear of the collapsed chrome cluster", async () => {
     await useDesktopViewport();
     render(

--- a/ui/src/app/navigation-surface.ts
+++ b/ui/src/app/navigation-surface.ts
@@ -1,5 +1,4 @@
 import { html, nothing } from "lit";
-import type { NavigationRouteId } from "../app-navigation.ts";
 import type { ApplicationContext } from "./context.ts";
 import type { UpdateProgress } from "./update-confirmation.ts";
 
@@ -14,26 +13,7 @@ export function navigationSurfaceIsHidden(params: {
   );
 }
 
-export function floatingSidebarAttentionVisible(params: {
-  navigationSurfaceHidden: boolean;
-  mobileNavLayout: boolean;
-  onboarding: boolean;
-  settingsTakeover?: boolean;
-  compact?: boolean;
-}): boolean {
-  // Mobile keeps attention in its drawer except during onboarding. Settings
-  // replaces that drawer/sidebar entirely, so both need the floating copy.
-  const attentionNeedsFloating =
-    params.settingsTakeover ||
-    (params.navigationSurfaceHidden && (!params.mobileNavLayout || params.onboarding));
-  return attentionNeedsFloating && !params.compact;
-}
-
 export function renderFloatingUpdateCard(params: {
-  navigationSurfaceHidden: boolean;
-  mobileNavLayout: boolean;
-  onboarding: boolean;
-  settingsTakeover?: boolean;
   compact?: boolean;
   updateAvailable: ApplicationContext["overlays"]["snapshot"]["updateAvailable"];
   updateSchedule?: ApplicationContext["overlays"]["snapshot"]["updateSchedule"];
@@ -48,36 +28,24 @@ export function renderFloatingUpdateCard(params: {
   onRefresh: () => void;
   onHoldUpdate?: () => Promise<boolean>;
   onReviewUpdate?: () => void;
-  onNavigate?: (routeId: NavigationRouteId) => void;
-  onOpenApprovals?: () => void;
 }) {
-  const showAttention = floatingSidebarAttentionVisible(params);
-  const showUpdateCard = !params.compact && params.refreshRequired;
-  if (!showAttention && !showUpdateCard) {
+  if (params.compact || !params.refreshRequired) {
     return nothing;
   }
-  return html`${showAttention
-    ? html`<openclaw-sidebar-attention
-        class="sidebar-attention--floating"
-        .onNavigate=${params.onNavigate}
-        .onOpenApprovals=${params.onOpenApprovals}
-      ></openclaw-sidebar-attention>`
-    : nothing}${showUpdateCard
-    ? html`<openclaw-sidebar-update-card
-        class="sidebar-update-card--floating"
-        .updateAvailable=${params.updateAvailable}
-        .updateSchedule=${params.updateSchedule ?? null}
-        .heldUpdateCampaignId=${params.heldUpdateCampaignId ?? null}
-        .updateBusy=${params.updateBusy}
-        .statusBanner=${params.statusBanner ?? null}
-        .watchUpdateProgress=${params.watchUpdateProgress}
-        .canUpdate=${params.canUpdate ?? false}
-        .canHoldUpdate=${params.canHoldUpdate ?? false}
-        .onUpdate=${params.onUpdate}
-        .refreshRequired=${params.refreshRequired}
-        .onRefresh=${params.onRefresh}
-        .onHoldUpdate=${params.onHoldUpdate ?? (async () => false)}
-        .onReviewUpdate=${params.onReviewUpdate ?? (() => undefined)}
-      ></openclaw-sidebar-update-card>`
-    : nothing}`;
+  return html`<openclaw-sidebar-update-card
+    class="sidebar-update-card--floating"
+    .updateAvailable=${params.updateAvailable}
+    .updateSchedule=${params.updateSchedule ?? null}
+    .heldUpdateCampaignId=${params.heldUpdateCampaignId ?? null}
+    .updateBusy=${params.updateBusy}
+    .statusBanner=${params.statusBanner ?? null}
+    .watchUpdateProgress=${params.watchUpdateProgress}
+    .canUpdate=${params.canUpdate ?? false}
+    .canHoldUpdate=${params.canHoldUpdate ?? false}
+    .onUpdate=${params.onUpdate}
+    .refreshRequired=${params.refreshRequired}
+    .onRefresh=${params.onRefresh}
+    .onHoldUpdate=${params.onHoldUpdate ?? (async () => false)}
+    .onReviewUpdate=${params.onReviewUpdate ?? (() => undefined)}
+  ></openclaw-sidebar-update-card>`;
 }

--- a/ui/src/components/settings-sidebar.ts
+++ b/ui/src/components/settings-sidebar.ts
@@ -28,6 +28,7 @@ import { redactLoginFailureError } from "./login-gate.ts";
 import { renderOfflineSidebarStatus } from "./session-row-badges.ts";
 import type { SettingsSaveIndicatorProps } from "./settings-save-indicator.ts";
 import "./settings-save-indicator.ts";
+import "./sidebar-attention.ts";
 import "./sidebar-build-chip.ts";
 
 type SettingsSidebarProps = {
@@ -342,12 +343,21 @@ export function renderSettingsSidebar(props: SettingsSidebarProps) {
           : html`<openclaw-settings-save-indicator
               .props=${props.saveIndicator}
             ></openclaw-settings-save-indicator>`}
-        <openclaw-sidebar-build-chip
-          .basePath=${props.basePath}
-          .gatewayVersion=${props.gatewayVersion || null}
-          .variant=${"settings"}
-          .onNavigate=${() => props.onNavigate("about")}
-        ></openclaw-sidebar-build-chip>
+        <div class="settings-sidebar__footer-row">
+          <openclaw-sidebar-build-chip
+            .basePath=${props.basePath}
+            .gatewayVersion=${props.gatewayVersion || null}
+            .variant=${"settings"}
+            .onNavigate=${() => props.onNavigate("about")}
+          ></openclaw-sidebar-build-chip>
+          <span class="settings-sidebar__attention">
+            <openclaw-sidebar-attention
+              .showInboxButton=${false}
+              .onNavigate=${props.onNavigate}
+              .watchUpdateProgress=${props.watchUpdateProgress}
+            ></openclaw-sidebar-attention>
+          </span>
+        </div>
       </footer>
     </aside>
   `;

--- a/ui/src/components/sidebar-attention-layout.browser.test.ts
+++ b/ui/src/components/sidebar-attention-layout.browser.test.ts
@@ -1,71 +1,15 @@
 import { afterEach, describe, expect, it } from "vitest";
 import "../test-helpers/load-styles.ts";
 import "../styles/hub-tabs.css";
-import "../styles/sidebar-footer-update.css";
 import "../styles/sidebar-issues.css";
 import "./web-awesome-tabs.ts";
-// Upgrade the real element: the floating layout once regressed because a base
-// class stamped inline `display: contents`, which only a live upgrade reveals.
-import "./sidebar-attention.ts";
 
 afterEach(() => {
   document.body.replaceChildren();
-  document.documentElement.classList.remove(
-    "openclaw-native-nav",
-    "openclaw-native-macos",
-    "openclaw-native-web-chrome",
-  );
+  document.documentElement.classList.remove("openclaw-native-nav");
 });
 
 describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
-  it("positions collapsed sidebar attention beyond chrome controls", () => {
-    const shell = document.createElement("div");
-    shell.className = "shell shell--nav-collapsed";
-    shell.innerHTML = `
-      <div class="shell-chrome-controls">
-        <button class="shell-chrome-controls__button"></button>
-        <button class="shell-chrome-controls__button"></button>
-        <button class="shell-chrome-controls__button"></button>
-        <button class="shell-chrome-controls__button shell-chrome-controls__custodian"></button>
-      </div>
-      <nav class="macos-titlebar-controls">
-        ${Array.from(
-          { length: 5 },
-          () => '<button class="topbar-icon-btn macos-titlebar-controls__button"></button>',
-        ).join("")}
-      </nav>
-      <main class="content">
-        <openclaw-sidebar-attention class="sidebar-attention--floating">
-          <button class="sidebar-issues-button"></button>
-        </openclaw-sidebar-attention>
-      </main>
-    `;
-    document.body.append(shell);
-
-    const attention = shell.querySelector<HTMLElement>("openclaw-sidebar-attention")!;
-    const chrome = shell.querySelector<HTMLElement>(".shell-chrome-controls")!;
-    const nativeChrome = shell.querySelector<HTMLElement>(".macos-titlebar-controls")!;
-    const inbox = attention.querySelector<HTMLElement>(".sidebar-issues-button")!;
-
-    expect(getComputedStyle(attention).position).toBe("fixed");
-    expect(getComputedStyle(attention).display).toBe("flex");
-    expect(attention.getBoundingClientRect().left).toBeGreaterThanOrEqual(
-      chrome.getBoundingClientRect().right + 8,
-    );
-    expect(Number.parseFloat(getComputedStyle(inbox).borderTopWidth)).toBeGreaterThan(0);
-
-    document.documentElement.classList.add("openclaw-native-nav");
-    expect(attention.getBoundingClientRect().left).toBeGreaterThanOrEqual(8);
-
-    document.documentElement.classList.add("openclaw-native-macos");
-    expect(getComputedStyle(attention).top).toBe("52px");
-
-    document.documentElement.classList.add("openclaw-native-web-chrome");
-    expect(
-      attention.getBoundingClientRect().left - nativeChrome.getBoundingClientRect().right,
-    ).toBe(4);
-  });
-
   it("keeps hub tabs compact and item rails flush with the scrollport", async () => {
     const fixture = document.createElement("section");
     fixture.className = "sidebar-issues-panel";

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -69,6 +69,7 @@ type SidebarAttentionElement = HTMLElement & {
   context: ApplicationContext;
   updateComplete: Promise<boolean>;
   cronJobs: CronJob[];
+  showInboxButton: boolean;
   startUpdate(): void;
   modelAuthStatus: ModelAuthStatusResult | null;
   loadedAtMs: number;
@@ -572,6 +573,55 @@ describe("sidebar attention refresh ownership", () => {
 });
 
 describe("update attention", () => {
+  it("can hide Inbox while keeping the footer update", async () => {
+    const context = {
+      gateway: {
+        snapshot: {
+          phase: "connected",
+          client: null,
+          hello: {
+            auth: { role: "operator", scopes: ["operator.admin"] },
+            features: { methods: ["update.run"] },
+            server: { bootId: "boot-a" },
+          },
+        },
+        connection: { gatewayUrl: "" },
+        subscribe: () => () => undefined,
+        subscribeEvents: () => () => undefined,
+      },
+      overlays: {
+        snapshot: {
+          approvalQueue: [],
+          updateAvailable: {
+            currentVersion: "2026.8.1",
+            latestVersion: "2026.8.2",
+            channel: "latest",
+          },
+          updateRunning: false,
+          updateReconciliationPending: false,
+          updateStatusBanner: null,
+        },
+        subscribe: () => () => undefined,
+      },
+      agentSelection: {
+        state: { selectedId: null, scopeId: null },
+        subscribe: () => () => undefined,
+      },
+      scopeUpgrade: hiddenScopeUpgradeCapability,
+    } as unknown as ApplicationContext;
+    const provider = createApplicationContextProvider(context);
+    const element = document.createElement("openclaw-sidebar-attention") as SidebarAttentionElement;
+    element.showInboxButton = false;
+    provider.append(element);
+    document.body.append(provider);
+
+    await element.updateComplete;
+
+    expect(element.querySelector(".sidebar-issues-button")).toBeNull();
+    expect(element.querySelector(".sidebar-footer-update")).not.toBeNull();
+    provider.remove();
+  });
+
   it("hides an unhydrated campaign only while update status can be polled", () => {
     const overlaySnapshot = {
       updateAvailable: {

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -63,9 +63,8 @@ type SidebarAttentionAgentScope = { selectedId: string | null; scopeId: string |
 const VISIBILITY_REFRESH_MIN_AGE_MS = 60_000;
 // Always-visible native windows need a slow lifecycle-owned refresh too.
 const IDLE_REFRESH_INTERVAL_MS = 10 * 60_000;
-// Display is stylesheet-owned (layout.css `display: contents` in the footer,
-// flex when floating): the LightDomContents base's inline display would defeat
-// the floating override, re-piling the collapsed-nav cluster at the origin.
+// Display is stylesheet-owned (`display: contents`) so the footer layout owns
+// the Inbox and update controls without an extra box between them.
 class SidebarAttention extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
   private context?: ApplicationContext;
@@ -86,6 +85,7 @@ class SidebarAttention extends OpenClawLightDomElement {
   @property({ attribute: false }) activeRouteId?: NavigationRouteId;
   @property({ attribute: false }) onNavigate?: (routeId: NavigationRouteId) => void;
   @property({ attribute: false }) watchUpdateProgress?: UpdateProgressWatcher;
+  @property({ attribute: false }) showInboxButton = true;
 
   private loadedClient: GatewayBrowserClient | null = null;
   private loadedGateway: ApplicationContext["gateway"] | null = null;
@@ -628,33 +628,35 @@ class SidebarAttention extends OpenClawLightDomElement {
       count: String(count),
     });
     return html`
-      <span class="sr-only" role="status" aria-live="polite">${label}</span>
-      <button
-        type="button"
-        class="sidebar-issues-button"
-        aria-expanded=${String(this.panelOpen)}
-        aria-haspopup="dialog"
-        aria-controls="sidebar-issues-panel"
-        aria-label=${label}
-        @click=${(event: MouseEvent) => {
-          const trigger = event.currentTarget;
-          if (!(trigger instanceof HTMLElement)) {
-            return;
-          }
-          if (this.panelOpen) {
-            this.closePanel(true);
-          } else {
-            void this.openPanel(trigger);
-          }
-        }}
-      >
-        <span class="sidebar-issues-button__icon" aria-hidden="true">${icons.inbox}</span>
-        ${count > 0
-          ? html`<span class="sidebar-issues-button__count" aria-hidden="true"
-              >${count > 9 ? "9+" : count}</span
-            >`
-          : nothing}
-      </button>
+      ${this.showInboxButton
+        ? html`<span class="sr-only" role="status" aria-live="polite">${label}</span>
+            <button
+              type="button"
+              class="sidebar-issues-button"
+              aria-expanded=${String(this.panelOpen)}
+              aria-haspopup="dialog"
+              aria-controls="sidebar-issues-panel"
+              aria-label=${label}
+              @click=${(event: MouseEvent) => {
+                const trigger = event.currentTarget;
+                if (!(trigger instanceof HTMLElement)) {
+                  return;
+                }
+                if (this.panelOpen) {
+                  this.closePanel(true);
+                } else {
+                  void this.openPanel(trigger);
+                }
+              }}
+            >
+              <span class="sidebar-issues-button__icon" aria-hidden="true">${icons.inbox}</span>
+              ${count > 0
+                ? html`<span class="sidebar-issues-button__count" aria-hidden="true"
+                    >${count > 9 ? "9+" : count}</span
+                  >`
+                : nothing}
+            </button>`
+        : nothing}
       ${updateEntry
         ? html`<span class="sidebar-footer-update-slot">
             <button

--- a/ui/src/e2e/chat-side-panel-clearance.e2e.test.ts
+++ b/ui/src/e2e/chat-side-panel-clearance.e2e.test.ts
@@ -161,7 +161,7 @@ async function expectPanelHeaderControlsClearShellChrome(page: Page): Promise<vo
     ].map(rect);
     const shells = [
       ...document.querySelectorAll(
-        ":is(.shell-chrome-controls, .macos-titlebar-controls, .sidebar-attention--floating) button:not([hidden])",
+        ":is(.shell-chrome-controls, .macos-titlebar-controls) button:not([hidden])",
       ),
     ]
       .map(rect)
@@ -210,7 +210,6 @@ suite.define(() => {
       deviceLess: false,
       direction: "ltr",
       expectedControl: ".shell-chrome-controls__search",
-      expectedUpdate: false,
       name: "expanded navigation",
       navCollapsed: false,
       operatorScopes: undefined,
@@ -224,7 +223,6 @@ suite.define(() => {
       deviceLess: false,
       direction: "ltr",
       expectedControl: ".shell-chrome-controls__search",
-      expectedUpdate: false,
       name: "collapsed navigation",
       navCollapsed: true,
       operatorScopes: undefined,
@@ -238,11 +236,10 @@ suite.define(() => {
       deviceLess: false,
       direction: "ltr",
       expectedControl: ".shell-chrome-controls__custodian",
-      expectedUpdate: true,
-      name: "collapsed navigation with custodian and attention",
+      name: "collapsed navigation with custodian",
       navCollapsed: true,
       operatorScopes: undefined,
-      proof: "collapsed-nav-custodian-attention",
+      proof: "collapsed-nav-custodian",
       themeMode: "dark" as const,
       updateAvailable: {
         channel: "stable",
@@ -255,12 +252,11 @@ suite.define(() => {
       custodian: false,
       deviceLess: true,
       direction: "rtl",
-      expectedControl: ".sidebar-attention--floating .sidebar-issues-button",
-      expectedUpdate: false,
-      name: "collapsed RTL limited-access status and attention",
+      expectedControl: ".shell-chrome-controls__search",
+      name: "collapsed RTL limited access",
       navCollapsed: true,
       operatorScopes: limitedScopes,
-      proof: "collapsed-rtl-limited-attention",
+      proof: "collapsed-rtl-limited",
       themeMode: "dark" as const,
       updateAvailable: undefined,
     },
@@ -294,22 +290,9 @@ suite.define(() => {
           await expect
             .poll(() => page.locator(".shell").getAttribute("class"))
             .toContain("shell--nav-collapsed");
-          await page.locator(".sidebar-attention--floating .sidebar-issues-button").waitFor();
         }
         await page.locator(testCase.expectedControl).waitFor();
-        if (testCase.expectedUpdate) {
-          const updateSlot = page.locator(
-            ".sidebar-attention--floating .sidebar-footer-update-slot",
-          );
-          await updateSlot.waitFor();
-          await updateSlot.hover();
-          await waitForShellLayout(page);
-          await expectPanelHeaderControlsClearShellChrome(page);
-          await page.mouse.move(800, 700);
-          await updateSlot.locator(".sidebar-footer-update").focus();
-          await waitForShellLayout(page);
-          await expectPanelHeaderControlsClearShellChrome(page);
-        }
+        expect(await page.locator(".sidebar-attention--floating").count()).toBe(0);
         await waitForShellLayout(page);
         await expectPanelHeaderControlsClearShellChrome(page);
         await capturePanel(page, testCase.proof);

--- a/ui/src/e2e/device-scope-upgrade.e2e.test.ts
+++ b/ui/src/e2e/device-scope-upgrade.e2e.test.ts
@@ -207,7 +207,7 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
     await availableItem.getByRole("button", { name: "Request admin" }).waitFor();
   });
 
-  it("keeps a pending admin request across Inbox presenters and Settings", async () => {
+  it("keeps a pending admin request while Inbox is hidden outside the open sidebar", async () => {
     const context = await createContext();
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -234,12 +234,10 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
       .locator(".shell-chrome-controls")
       .getByRole("button", { name: "Collapse sidebar" })
       .click();
-    const collapsedItem = await openLimitedAccessItem(await openInbox(page));
-    await waitForPendingUpgradeItem(collapsedItem);
+    expect(await page.locator(".sidebar-issues-button:visible").count()).toBe(0);
     expect(await gateway.getRequests("device.scopes.requestUpgrade")).toHaveLength(1);
     expect(await gateway.getRequests("device.scopes.waitUpgrade")).toHaveLength(1);
 
-    await closeInbox(page);
     await page.getByRole("button", { name: "Expand sidebar" }).click();
     const sidebar = page.locator("openclaw-app-sidebar");
     const identityCard = sidebar.locator(".sidebar-identity-card");
@@ -250,9 +248,7 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
       .getByRole("menuitem", { exact: true, name: "Settings" })
       .click();
     await waitForControlUiSettingsTakeover(page);
-    const settingsItem = await openLimitedAccessItem(await openInbox(page));
-    await waitForPendingUpgradeItem(settingsItem);
-    await waitForAnimations(page.locator("#sidebar-issues-panel"));
+    expect(await page.locator(".settings-sidebar__footer .sidebar-issues-button").count()).toBe(0);
     await captureProof(page, "settings-inbox-upgrade-pending.png");
     expect(await gateway.getRequests("device.scopes.requestUpgrade")).toHaveLength(1);
     expect(await gateway.getRequests("device.scopes.waitUpgrade")).toHaveLength(1);
@@ -302,7 +298,7 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
     },
   );
 
-  it("keeps Inbox reachable at the bottom left during onboarding", async () => {
+  it("does not float Inbox when onboarding hides navigation", async () => {
     const context = await createContext();
     const page = await context.newPage();
     await installMockGateway(page, {
@@ -314,10 +310,8 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
     expect(
       await page.getByText("Update the Gateway to continue setup with OpenClaw.").count(),
     ).toBe(0);
-    const inbox = page.locator(".sidebar-attention--floating .sidebar-issues-button");
-    await expect.poll(() => inbox.getAttribute("aria-label")).toBe("1 inbox item");
-    const item = await openLimitedAccessItem(await openInbox(page));
-    await item.getByRole("button", { name: "Request admin" }).waitFor();
+    expect(await page.locator(".sidebar-attention--floating").count()).toBe(0);
+    expect(await page.locator(".sidebar-issues-button:visible").count()).toBe(0);
     await captureProof(page, "onboarding-inbox-limited-access.png");
   });
 

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -392,9 +392,7 @@ suite.define(() => {
     await panel.getByRole("button", { name: "Expand side panel" }).click();
     await panel.getByRole("button", { name: "Restore side panel" }).waitFor();
 
-    const shellControls = page.locator(
-      ".macos-titlebar-controls button:visible, .sidebar-attention--floating button:visible",
-    );
+    const shellControls = page.locator(".macos-titlebar-controls button:visible");
     const panelControls = panel.locator(":scope > .side-panel__header :is(button, wa-tab):visible");
     const shellBoxes = await Promise.all(
       Array.from({ length: await shellControls.count() }, (_, index) =>
@@ -411,7 +409,7 @@ suite.define(() => {
     expect(panelLeft - shellRight).toBeGreaterThanOrEqual(4);
     expect(panelLeft - shellRight).toBeLessThanOrEqual(16);
     if (testCase.deviceLess) {
-      await page.locator(".sidebar-attention--floating .sidebar-issues-button__count").waitFor();
+      expect(await page.locator(".sidebar-attention--floating").count()).toBe(0);
       expect(await page.locator(".scope-upgrade-shell-status").count()).toBe(0);
     }
     for (let index = 0; index < (await panelControls.count()); index += 1) {

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -293,24 +293,7 @@ suite.define(() => {
       .poll(() => page.locator(".shell").getAttribute("class"))
       .toContain("shell--nav-collapsed");
     await expect.poll(() => newThread.isVisible()).toBe(true);
-    await page.locator(".sidebar-attention--floating .sidebar-footer-update").waitFor();
-    const toolbarBox = await toolbar.boundingBox();
-    const attentionBox = await page.locator(".sidebar-attention--floating").boundingBox();
-    expect(toolbarBox).not.toBeNull();
-    expect(attentionBox).not.toBeNull();
-    expect(attentionBox!.x - (toolbarBox!.x + toolbarBox!.width)).toBeGreaterThanOrEqual(4);
-    const topLeftControls = page.locator(
-      ".macos-titlebar-controls button:visible, .sidebar-attention--floating button:visible",
-    );
-    const centerlines = await topLeftControls.evaluateAll((buttons) =>
-      buttons.map((button) => {
-        const box = button.getBoundingClientRect();
-        return box.top + box.height / 2;
-      }),
-    );
-    for (const centerline of centerlines.slice(1)) {
-      expect(centerline).toBeCloseTo(centerlines[0]!, 1);
-    }
+    expect(await page.locator(".sidebar-attention--floating").count()).toBe(0);
     if (railProofDir) {
       await mkdir(railProofDir, { recursive: true });
       await page.screenshot({

--- a/ui/src/e2e/update-confirmation.e2e.test.ts
+++ b/ui/src/e2e/update-confirmation.e2e.test.ts
@@ -248,8 +248,8 @@ suite.define(() => {
           const style = getComputedStyle(button);
           return { height: Number.parseFloat(style.height), width: Number.parseFloat(style.width) };
         });
-        expect(buttonSize.width).toBeGreaterThanOrEqual(40);
-        expect(buttonSize.height).toBeGreaterThanOrEqual(40);
+        expect(buttonSize.width).toBe(32);
+        expect(buttonSize.height).toBe(32);
         expect(await page.locator(".sidebar-footer-update__label").isVisible()).toBe(false);
         expect(await page.locator(".sidebar-shell").evaluate((shell) => shell.scrollWidth)).toBe(
           await page.locator(".sidebar-shell").evaluate((shell) => shell.clientWidth),

--- a/ui/src/styles/sidebar-footer-update.css
+++ b/ui/src/styles/sidebar-footer-update.css
@@ -1,107 +1,50 @@
-/* Floating footer controls clear collapsed chrome and feed their resting width
-   back into the first-row safe edge. */
-.shell--nav-collapsed:has(openclaw-sidebar-attention.sidebar-attention--floating) {
-  --shell-attention-width: 40px;
-}
-
-.shell--nav-collapsed:has(
-  openclaw-sidebar-attention.sidebar-attention--floating .sidebar-footer-update-slot
-) {
-  --shell-attention-width: 72px;
-}
-
-openclaw-sidebar-attention.sidebar-attention--floating {
-  --sidebar-bg: var(--bg-content, var(--bg));
-
-  position: fixed;
-  top: 10px;
-  left: calc(var(--shell-chrome-controls-inset) + var(--shell-controls-width) + 8px);
-  z-index: 45;
-  display: flex;
-  align-items: center;
-  gap: var(--shell-chrome-controls-gap);
-}
-
-/* Native navigation hides the web controls. */
-html.openclaw-native-nav openclaw-sidebar-attention.sidebar-attention--floating {
-  left: calc(var(--shell-chrome-controls-inset) + 6px);
-}
-
-html.openclaw-native-macos openclaw-sidebar-attention.sidebar-attention--floating {
-  top: 52px;
-}
-
-/* Web-hosted titlebar controls occupy the native row instead of sitting below it. */
-html.openclaw-native-web-chrome openclaw-sidebar-attention.sidebar-attention--floating {
-  top: calc((var(--openclaw-native-titlebar-height, 50px) - var(--shell-chrome-control-size)) / 2);
-  left: calc(
-    var(--shell-native-titlebar-controls-inset) + var(--shell-native-titlebar-controls-width) +
-      var(--shell-chrome-controls-gap)
-  );
-}
-
-:is(.shell--onboarding, .shell--settings) openclaw-sidebar-attention.sidebar-attention--floating {
-  inset: auto auto max(12px, env(safe-area-inset-bottom)) max(12px, env(safe-area-inset-left));
-}
-
-/* A stale-client refresh card shares the collapsed overlay strip's row; drop it
-   below the fixed attention cluster instead of rendering both at the origin. */
-.sidebar-attention--floating ~ .sidebar-update-card--floating .sidebar-update-card {
-  margin-top: 50px;
-}
-
-/* Footer buttons need opaque chrome when they float over arbitrary page content. */
-:where(openclaw-sidebar-attention.sidebar-attention--floating) .sidebar-issues-button {
-  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
-  background: color-mix(in srgb, var(--panel) 92%, transparent);
-  box-shadow: var(--shadow-sm);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-}
-
 .sidebar-footer-bar:has(.sidebar-footer-update-slot) {
-  padding-inline-end: 80px;
+  padding-inline-end: 88px;
 }
 
 .sidebar-footer-update-slot {
-  --sidebar-footer-update-size: 32px;
-
   position: relative;
-  width: var(--sidebar-footer-update-size);
-  height: var(--sidebar-footer-update-size);
-  flex: 0 0 var(--sidebar-footer-update-size);
+  width: 32px;
+  height: 32px;
+  flex: 0 0 32px;
 }
 
 .sidebar-footer-update {
   display: inline-grid;
-  width: var(--sidebar-footer-update-size);
-  height: var(--sidebar-footer-update-size);
+  width: 32px;
+  height: 32px;
   place-items: center;
   padding: 0;
-  border: 1px solid color-mix(in srgb, var(--inbox-attention) 24%, var(--border));
+  border: 0;
   border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--inbox-attention) 8%, var(--sidebar-bg));
   color: color-mix(in srgb, var(--inbox-attention) 52%, var(--muted));
   cursor: var(--cursor-action);
   transition:
-    border-color var(--duration-fast) ease,
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;
 }
 
+:root[data-theme-mode="dark"] .sidebar-footer-update {
+  background: color-mix(in srgb, var(--inbox-attention) 18%, var(--sidebar-bg));
+  color: color-mix(in srgb, var(--inbox-attention) 82%, var(--muted));
+}
+
 .sidebar-footer-update:is(:hover, :focus-visible):not(:disabled) {
-  border-color: color-mix(in srgb, var(--inbox-attention) 42%, var(--border));
   background: color-mix(in srgb, var(--inbox-attention) 14%, var(--sidebar-bg));
   color: var(--inbox-attention);
 }
 
+:root[data-theme-mode="dark"] .sidebar-footer-update:is(:hover, :focus-visible):not(:disabled) {
+  background: color-mix(in srgb, var(--inbox-attention) 24%, var(--sidebar-bg));
+}
+
 .sidebar-footer-update:focus-visible {
   outline: none;
-  box-shadow: var(--focus-ring);
+  box-shadow: none;
 }
 
 .sidebar-footer-update:disabled {
-  border-color: color-mix(in srgb, var(--muted) 24%, var(--border));
   background: color-mix(in srgb, var(--muted) 8%, var(--sidebar-bg));
   color: var(--muted);
   cursor: not-allowed;
@@ -152,7 +95,6 @@ html.openclaw-native-web-chrome openclaw-sidebar-attention.sidebar-attention--fl
 
 @media (hover: none), (pointer: coarse) {
   .sidebar-footer-update:not(:disabled):active {
-    border-color: color-mix(in srgb, var(--inbox-attention) 42%, var(--border));
     background: color-mix(in srgb, var(--inbox-attention) 14%, var(--sidebar-bg));
     color: var(--inbox-attention);
   }
@@ -164,8 +106,27 @@ html.openclaw-native-web-chrome openclaw-sidebar-attention.sidebar-attention--fl
   }
 }
 
-.shell--mobile-nav .sidebar-footer-update-slot {
-  --sidebar-footer-update-size: 40px;
+.settings-sidebar__footer-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+}
+
+.settings-sidebar__footer-row .sidebar-footer-build {
+  min-width: 0;
+  margin-left: 0;
+  margin-inline-end: auto;
+}
+
+.settings-sidebar__attention {
+  --sidebar-bg: var(--bg);
+
+  display: flex;
+  height: 32px;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
 }
 
 .sidebar-footer-build__text {

--- a/ui/src/styles/sidebar-footer-update.css
+++ b/ui/src/styles/sidebar-footer-update.css
@@ -52,13 +52,13 @@
 
 .sidebar-footer-update__icon {
   display: inline-flex;
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
 }
 
 .sidebar-footer-update__icon svg {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
 }
 
 .sidebar-footer-update__dismiss {


### PR DESCRIPTION
## What Problem This Solves

The sidebar footer update action added in #129813 competed with the Inbox and became visually loud, especially in dark mode. It also moved with the Inbox into a floating top-bar cluster when navigation was hidden, while Settings exposed Inbox outside its intended sidebar context.

## Why This Change Was Made

This keeps the direction of #129813 while adjusting discovery, contrast, and positioning: the update action is a calm 32 px footer control without a border or focus ring, with a stronger dark-mode tint and glyph. Update and Inbox no longer migrate into the floating top-bar cluster when the sidebar is collapsed, that cluster and its dead code are removed, and Settings anchors only update beside the version while keeping Inbox out of Settings.

The stale-client refresh card remains available outside navigation because it is a separate required recovery action. The approved visual head was `42e492139fcfc9309d8188f352d021184c2094be`; the final rebased head is `574ef21860ca71063b1053e58765342f8bde2b89`.

## User Impact

Operators get a quieter footer with update and Inbox aligned at the same 32 px size, clearer update contrast in dark mode, and stable placement instead of a second floating action cluster. Settings keeps the update discoverable beside the installed version without presenting Inbox there.

## Evidence

Real-behavior proof was captured from the operator-approved running Control UI mock at 1440 x 900. The scenes exercise the changed surfaces with an update available: expanded sidebar, collapsed sidebar, and Settings. The collapsed scene visibly shows that neither update nor Inbox migrates into the top bar; Settings visibly shows only update beside the version.

### Desktop dark

| Evidence |
| --- |
| **Expanded sidebar**<br>![Dark mode with the sidebar open, showing the 32 px update control beside Inbox in the footer](https://github.com/user-attachments/assets/3625d66f-88c0-43f9-8d94-39168a69bbb0) |
| **Collapsed sidebar**<br>![Dark mode with the sidebar collapsed and no floating update or Inbox cluster in the top bar](https://github.com/user-attachments/assets/3dfc70a6-ae5d-417e-9f09-eed7fba1a81c) |
| **Settings**<br>![Dark Settings with only the update control anchored beside the version](https://github.com/user-attachments/assets/a4f940a9-b8a2-4c5e-96fc-17e55e82abec) |

### Validation

- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test ui/src/components/sidebar-attention.test.ts ui/src/components/settings-sidebar.test.ts ui/src/app/app-host-native-shell.test.ts` (73 passed)
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm --dir ui test --project browser src/app/navigation-surface.browser.test.ts src/components/sidebar-attention-layout.browser.test.ts` (4 passed)
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/update-confirmation.e2e.test.ts ui/src/e2e/device-scope-upgrade.e2e.test.ts ui/src/e2e/chat-side-panel-clearance.e2e.test.ts ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts` (38 passed)
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs`
- Six approved base/final scene pairs checked with `compare -metric AE`: all returned `0`.

### Regression and patch quality

- New regression tests: 2. Both fail on pre-change head `fc98837bede82fff84fe154b4e090f4e807058b7` for the intended reasons: the collapsed shell renders floating attention, and `showInboxButton=false` does not hide Inbox.
- Production: +105 / -184 lines. Tests: +106 / -231 lines. Total: +211 / -415 lines.
- Removed behavior is intentionally not retained: no floating update/Inbox presenter and no Inbox in Settings.
- Upgrade impact: none. This changes only Control UI presentation; no config, persisted state, protocol, CLI, migration, or shipped compatibility surface changes.
- Proof limit: the supplied approved gallery is desktop-only; responsive behavior is covered by the focused real-browser E2E suite.
- Review disposition: suggestions to restore Inbox on navigation-hidden surfaces or restore the prior focus ring would reverse the approved placement/visual decisions, so both are recorded as separate product follow-ups rather than applied here.
