### PR TITLE
refactor(meeting-bot): inline audio fallback guard

### DIFF
--- a/src/meeting-bot/realtime-audio-format.ts
+++ b/src/meeting-bot/realtime-audio-format.ts
@@ -82,10 +82,7 @@ function decodeMeetingTelephonyTtsAudio(
     case "alaw":
       return alawToPcm(audio);
   }
-  return unsupportedMeetingTelephonyTtsFormat(sourceFormat);
-}
-
-function unsupportedMeetingTelephonyTtsFormat(_format: never): never {
+  sourceFormat satisfies never;
   throw new Error("Unsupported telephony TTS output format for meeting platform");
 }
 


### PR DESCRIPTION
## What Problem This Solves

Meeting-bot telephony audio decoding delegated its compile-time-exhaustive unsupported-format fallback to a one-use `never` helper. The helper added indirection even though the owning parser is the sole producer of the closed `"pcm" | "mulaw" | "alaw"` union.

## Why This Change Was Made

Inline the `never` exhaustiveness assertion and the identical fallback error after the existing switch, then delete the one-use helper. This preserves both current runtime behavior and the compile-time requirement that every future union member receive an explicit decoder branch.

Production LOC: +1/-4 (net -3) | Tests: +0/-0

Exact head: `8ecb311eb1b5cd11e7e7ab688a192637c6547b1f`

AI-assisted: yes.

## User Impact

No user-visible change. PCM, mu-law, and A-law bytes follow the same conversion branches; unsupported internal values retain the same fallback error; unsupported external output formats remain rejected by the unchanged parser.

## Evidence

- `node scripts/run-vitest.mjs extensions/google-meet/index.test.ts`: 168/168 passed on the exact final patch, including mu-law pass-through/decoding and unsupported `mp3` rejection.
- `node scripts/check-changed.mjs -- src/meeting-bot/realtime-audio-format.ts`: passed all guards, formatting, dead-export scan, production/core-test typechecks, focused oxlint, and boundary checks on the exact final patch.
- `node scripts/run-oxlint.mjs src/meeting-bot/realtime-audio-format.ts`: zero warnings/errors on the exact final patch.
- `git diff --check`: passed.
- Deslop inspection: clean; no edits needed.
- Final-head structured autoreview: clean, no actionable P0/P1 findings, correctness 0.99.
- Separate exact-head Codex review: clean, no actionable P0/P1 findings, correctness 0.98.
- Live overlap check: open PR #111466 does not touch this file or audio-format stack; no matching open PR was found for `src/meeting-bot/realtime-audio-format.ts`.

ClawSweeper's exact review of the prior head correctly identified that terminal A-law narrowing lost future exhaustiveness. This final patch applies its rank-up move by restoring an explicit `satisfies never` assertion without restoring the one-use helper. All head-sensitive proof and reviews above were rerun after that change.


