### PR TITLE
fix(github-copilot): configured account order is ignored

### DIFF
--- a/extensions/github-copilot/auth.test.ts
+++ b/extensions/github-copilot/auth.test.ts
@@ -180,7 +180,11 @@ describe("resolveFirstGithubToken", () => {
     {
       label: "a public GitHub OAuth account",
       enterpriseUrl: undefined,
-      expected: { githubToken: "durable-github-token", hasProfile: true },
+      expected: {
+        githubToken: "durable-github-token",
+        githubDomain: "github.com",
+        hasProfile: true,
+      },
     },
     {
       label: "an enterprise GitHub OAuth account",
@@ -200,6 +204,18 @@ describe("resolveFirstGithubToken", () => {
     {
       label: "an OAuth account with a whitespace-only durable credential",
       enterpriseUrl: undefined,
+      refresh: "   ",
+      expected: { githubToken: "", hasProfile: true },
+    },
+    {
+      label: "an enterprise OAuth account without a durable credential",
+      enterpriseUrl: "acme.ghe.com",
+      refresh: "",
+      expected: { githubToken: "", hasProfile: true },
+    },
+    {
+      label: "an enterprise OAuth account with a whitespace-only durable credential",
+      enterpriseUrl: "acme.ghe.com",
       refresh: "   ",
       expected: { githubToken: "", hasProfile: true },
     },
@@ -235,29 +251,32 @@ describe("resolveFirstGithubToken", () => {
     ).resolves.toEqual(testCase.expected);
   });
 
-  it("rejects an explicitly ordered OAuth account with an unsupported enterprise domain", async () => {
-    ensureAuthProfileStoreMock.mockReturnValue({
-      version: 1,
-      profiles: {
-        "github-copilot:preferred": {
-          type: "oauth",
-          provider: "github-copilot",
-          access: "short-lived-copilot-token",
-          refresh: "durable-github-token",
-          expires: Date.now() + 60_000,
-          enterpriseUrl: "attacker.example",
+  it.each(["durable-github-token", "", "   "])(
+    "rejects an explicitly ordered OAuth account with an unsupported enterprise domain (refresh: %j)",
+    async (refresh) => {
+      ensureAuthProfileStoreMock.mockReturnValue({
+        version: 1,
+        profiles: {
+          "github-copilot:preferred": {
+            type: "oauth",
+            provider: "github-copilot",
+            access: "short-lived-copilot-token",
+            refresh,
+            expires: Date.now() + 60_000,
+            enterpriseUrl: "attacker.example",
+          },
         },
-      },
-    });
-    listProfilesForProviderMock.mockReturnValue(["github-copilot:preferred"]);
+      });
+      listProfilesForProviderMock.mockReturnValue(["github-copilot:preferred"]);
 
-    await expect(
-      resolveFirstGithubToken({
-        config: { auth: { order: { "github-copilot": ["github-copilot:preferred"] } } },
-        env: {},
-      }),
-    ).rejects.toThrow(/attacker\.example/);
-  });
+      await expect(
+        resolveFirstGithubToken({
+          config: { auth: { order: { "github-copilot": ["github-copilot:preferred"] } } },
+          env: {},
+        }),
+      ).rejects.toThrow(/attacker\.example/);
+    },
+  );
 
   it("keeps the first stored account without an explicit order or cooldown mutation", async () => {
     const expiredCooldown = Date.now() - 60_000;

--- a/extensions/github-copilot/auth.test.ts
+++ b/extensions/github-copilot/auth.test.ts
@@ -176,6 +176,89 @@ describe("resolveFirstGithubToken", () => {
     ).resolves.toEqual({ githubToken: testCase.expectedToken, hasProfile: true });
   });
 
+  it.each([
+    {
+      label: "a public GitHub OAuth account",
+      enterpriseUrl: undefined,
+      expected: { githubToken: "durable-github-token", hasProfile: true },
+    },
+    {
+      label: "an enterprise GitHub OAuth account",
+      enterpriseUrl: "acme.ghe.com",
+      expected: {
+        githubToken: "durable-github-token",
+        githubDomain: "acme.ghe.com",
+        hasProfile: true,
+      },
+    },
+    {
+      label: "an OAuth account without a durable credential",
+      enterpriseUrl: undefined,
+      refresh: "",
+      expected: { githubToken: "", hasProfile: true },
+    },
+    {
+      label: "an OAuth account with a whitespace-only durable credential",
+      enterpriseUrl: undefined,
+      refresh: "   ",
+      expected: { githubToken: "", hasProfile: true },
+    },
+  ])("uses the durable credential when explicit order selects $label", async (testCase) => {
+    ensureAuthProfileStoreMock.mockReturnValue({
+      version: 1,
+      profiles: {
+        "github-copilot:first": {
+          type: "token",
+          provider: "github-copilot",
+          token: "first-token",
+        },
+        "github-copilot:preferred": {
+          type: "oauth",
+          provider: "github-copilot",
+          access: "short-lived-copilot-token",
+          refresh: testCase.refresh ?? " durable-github-token ",
+          expires: Date.now() + 60_000,
+          ...(testCase.enterpriseUrl ? { enterpriseUrl: testCase.enterpriseUrl } : {}),
+        },
+      },
+    });
+    listProfilesForProviderMock.mockReturnValue([
+      "github-copilot:first",
+      "github-copilot:preferred",
+    ]);
+
+    await expect(
+      resolveFirstGithubToken({
+        config: { auth: { order: { "github-copilot": ["github-copilot:preferred"] } } },
+        env: {},
+      }),
+    ).resolves.toEqual(testCase.expected);
+  });
+
+  it("rejects an explicitly ordered OAuth account with an unsupported enterprise domain", async () => {
+    ensureAuthProfileStoreMock.mockReturnValue({
+      version: 1,
+      profiles: {
+        "github-copilot:preferred": {
+          type: "oauth",
+          provider: "github-copilot",
+          access: "short-lived-copilot-token",
+          refresh: "durable-github-token",
+          expires: Date.now() + 60_000,
+          enterpriseUrl: "attacker.example",
+        },
+      },
+    });
+    listProfilesForProviderMock.mockReturnValue(["github-copilot:preferred"]);
+
+    await expect(
+      resolveFirstGithubToken({
+        config: { auth: { order: { "github-copilot": ["github-copilot:preferred"] } } },
+        env: {},
+      }),
+    ).rejects.toThrow(/attacker\.example/);
+  });
+
   it("keeps the first stored account without an explicit order or cooldown mutation", async () => {
     const expiredCooldown = Date.now() - 60_000;
     const store = {

--- a/extensions/github-copilot/auth.test.ts
+++ b/extensions/github-copilot/auth.test.ts
@@ -102,6 +102,143 @@ describe("resolveFirstGithubToken", () => {
     });
   });
 
+  it.each([
+    {
+      label: "configured order selects the second stored account",
+      configuredOrder: ["github-copilot:preferred"],
+      expectedToken: "preferred-token",
+    },
+    {
+      label: "stored account order overrides configured order",
+      configuredOrder: ["github-copilot:first"],
+      storedOrder: ["github-copilot:preferred"],
+      expectedToken: "preferred-token",
+    },
+    {
+      label: "provider keys are matched case-insensitively",
+      providerKey: " GITHUB-COPILOT ",
+      configuredOrder: ["github-copilot:preferred"],
+      expectedToken: "preferred-token",
+    },
+    {
+      label: "an explicit empty order does not fall back to another account",
+      configuredOrder: [],
+      expectedToken: "",
+    },
+    {
+      label: "a missing configured account does not fall back to another account",
+      configuredOrder: ["github-copilot:missing"],
+      expectedToken: "",
+    },
+    {
+      label: "a cooled-down explicitly ordered account moves behind an available account",
+      configuredOrder: ["github-copilot:first", "github-copilot:preferred"],
+      firstAccountInCooldown: true,
+      expectedToken: "preferred-token",
+    },
+  ])("honors auth profile order when $label", async (testCase) => {
+    const providerKey = testCase.providerKey ?? "github-copilot";
+    ensureAuthProfileStoreMock.mockReturnValue({
+      version: 1,
+      profiles: {
+        "github-copilot:first": {
+          type: "token",
+          provider: "github-copilot",
+          token: "first-token",
+        },
+        "github-copilot:preferred": {
+          type: "token",
+          provider: "github-copilot",
+          token: "preferred-token",
+        },
+      },
+      ...(testCase.storedOrder ? { order: { [providerKey]: testCase.storedOrder } } : {}),
+      ...(testCase.firstAccountInCooldown
+        ? {
+            usageStats: {
+              "github-copilot:first": { cooldownUntil: Date.now() + 60_000 },
+            },
+          }
+        : {}),
+    });
+    listProfilesForProviderMock.mockReturnValue([
+      "github-copilot:first",
+      "github-copilot:preferred",
+    ]);
+
+    await expect(
+      resolveFirstGithubToken({
+        config: {
+          auth: { order: { [providerKey]: testCase.configuredOrder } },
+        },
+        env: {},
+      }),
+    ).resolves.toEqual({ githubToken: testCase.expectedToken, hasProfile: true });
+  });
+
+  it("keeps the first stored account without an explicit order or cooldown mutation", async () => {
+    const expiredCooldown = Date.now() - 60_000;
+    const store = {
+      version: 1,
+      profiles: {
+        "github-copilot:first": {
+          type: "token",
+          provider: "github-copilot",
+          token: "first-token",
+        },
+        "github-copilot:preferred": {
+          type: "token",
+          provider: "github-copilot",
+          token: "preferred-token",
+        },
+      },
+      usageStats: {
+        "github-copilot:first": { cooldownUntil: expiredCooldown },
+      },
+    };
+    ensureAuthProfileStoreMock.mockReturnValue(store);
+    listProfilesForProviderMock.mockReturnValue([
+      "github-copilot:first",
+      "github-copilot:preferred",
+    ]);
+
+    await expect(resolveFirstGithubToken({ config: {}, env: {} })).resolves.toEqual({
+      githubToken: "first-token",
+      hasProfile: true,
+    });
+    expect(store.usageStats["github-copilot:first"].cooldownUntil).toBe(expiredCooldown);
+  });
+
+  it("preserves explicitly requested profiles even when account order excludes them", async () => {
+    ensureAuthProfileStoreMock.mockReturnValue({
+      version: 1,
+      profiles: {
+        "github-copilot:first": {
+          type: "token",
+          provider: "github-copilot",
+          token: "first-token",
+        },
+        "github-copilot:preferred": {
+          type: "token",
+          provider: "github-copilot",
+          token: "preferred-token",
+        },
+      },
+    });
+    listProfilesForProviderMock.mockReturnValue([
+      "github-copilot:first",
+      "github-copilot:preferred",
+    ]);
+
+    await expect(
+      resolveFirstGithubToken({
+        config: { auth: { order: { "github-copilot": ["github-copilot:first"] } } },
+        env: {},
+        profileId: "github-copilot:preferred",
+      }),
+    ).resolves.toEqual({ githubToken: "preferred-token", hasProfile: true });
+  });
+
   it("uses environment direct auth without falling back to config or the first profile", async () => {
     const config = {
       models: {

--- a/extensions/github-copilot/auth.ts
+++ b/extensions/github-copilot/auth.ts
@@ -15,6 +15,7 @@ import {
   resolveConfiguredSecretInputWithFallback,
   resolveRequiredConfiguredSecretRefInputString,
 } from "openclaw/plugin-sdk/secret-input-runtime";
+import { PUBLIC_GITHUB_COPILOT_DOMAIN } from "./domain.js";
 import { PROVIDER_ID } from "./models.js";
 import { formatGithubCopilotApiKey, parseGithubCopilotApiKey } from "./oauth.js";
 
@@ -95,8 +96,14 @@ export async function resolveFirstGithubToken(params: {
         })[0];
   const profile = profileId ? authStore.profiles[profileId] : undefined;
   if (profile?.type === "oauth") {
+    const formatted = formatGithubCopilotApiKey(profile);
+    if (!normalizeOptionalSecretInput(profile.refresh)) {
+      return { githubToken: "", hasProfile };
+    }
+    const parsed = parseGithubCopilotApiKey(formatted);
     return {
-      ...parseGithubCopilotApiKey(formatGithubCopilotApiKey(profile)),
+      ...parsed,
+      githubDomain: parsed.githubDomain ?? PUBLIC_GITHUB_COPILOT_DOMAIN,
       hasProfile,
     };
   }

--- a/extensions/github-copilot/auth.ts
+++ b/extensions/github-copilot/auth.ts
@@ -1,4 +1,8 @@
 // Github Copilot plugin module implements auth behavior.
+import {
+  findNormalizedProviderValue,
+  resolveAuthProfileOrder,
+} from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ProviderPrepareDynamicModelContext } from "openclaw/plugin-sdk/plugin-entry";
 import {
@@ -73,9 +77,20 @@ export async function resolveFirstGithubToken(params: {
     return { githubToken: resolved.value?.trim() || githubToken, hasProfile: false };
   }
 
+  const explicitProfileOrder =
+    findNormalizedProviderValue(authStore.order, PROVIDER_ID) ??
+    findNormalizedProviderValue(params.config?.auth?.order, PROVIDER_ID);
+  // Preserve discovery's existing first-profile default; authored order alone
+  // delegates eligibility and cooldown handling to the canonical auth owner.
   const profileId = requestedProfileId
     ? profileIds.find((candidate) => candidate === requestedProfileId)
-    : profileIds[0];
+    : explicitProfileOrder === undefined
+      ? profileIds[0]
+      : resolveAuthProfileOrder({
+          cfg: params.config,
+          store: authStore,
+          provider: PROVIDER_ID,
+        })[0];
   const profile = profileId ? authStore.profiles[profileId] : undefined;
   if (profile?.type !== "token") {
     return { githubToken: "", hasProfile };

--- a/extensions/github-copilot/auth.ts
+++ b/extensions/github-copilot/auth.ts
@@ -16,6 +16,7 @@ import {
   resolveRequiredConfiguredSecretRefInputString,
 } from "openclaw/plugin-sdk/secret-input-runtime";
 import { PROVIDER_ID } from "./models.js";
+import { formatGithubCopilotApiKey, parseGithubCopilotApiKey } from "./oauth.js";
 
 export async function resolveFirstGithubToken(params: {
   agentDir?: string;
@@ -25,6 +26,7 @@ export async function resolveFirstGithubToken(params: {
   authProfileMode?: ProviderPrepareDynamicModelContext["authProfileMode"];
 }): Promise<{
   githubToken: string;
+  githubDomain?: string;
   hasProfile: boolean;
 }> {
   const authStore = ensureAuthProfileStore(params.agentDir, {
@@ -92,6 +94,12 @@ export async function resolveFirstGithubToken(params: {
           provider: PROVIDER_ID,
         })[0];
   const profile = profileId ? authStore.profiles[profileId] : undefined;
+  if (profile?.type === "oauth") {
+    return {
+      ...parseGithubCopilotApiKey(formatGithubCopilotApiKey(profile)),
+      hasProfile,
+    };
+  }
   if (profile?.type !== "token") {
     return { githubToken: "", hasProfile };
   }

--- a/extensions/github-copilot/dynamic-models.ts
+++ b/extensions/github-copilot/dynamic-models.ts
@@ -54,7 +54,7 @@ export function createGithubCopilotDynamicModelHooks(params: {
     }
     const { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotRuntimeAuth } =
       await loadGithubCopilotRuntime();
-    const { githubToken, hasProfile } = await resolveFirstGithubToken({
+    const { githubToken, githubDomain, hasProfile } = await resolveFirstGithubToken({
       agentDir: ctx.agentDir,
       env: ctx.env,
       ...(ctx.config ? { config: ctx.config } : {}),
@@ -71,7 +71,11 @@ export function createGithubCopilotDynamicModelHooks(params: {
         const auth = await resolveCopilotRuntimeAuth({
           githubToken,
           env: ctx.env,
-          githubDomain: resolveGithubCopilotDomain({ env: ctx.env, config: ctx.config }),
+          githubDomain: resolveGithubCopilotDomain({
+            env: ctx.env,
+            explicit: githubDomain,
+            config: ctx.config,
+          }),
         });
         baseUrl = auth.baseUrl;
         copilotApiToken = auth.apiKey;

--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -171,39 +171,45 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
     expect(firstCopilotRuntimeAuthRequest().githubToken).toBe("test-token-placeholder");
   });
 
-  it("preserves the selected OAuth account's enterprise domain for embedding auth", async () => {
-    resolveFirstGithubTokenMock.mockResolvedValueOnce({
-      githubToken: "durable-github-token",
-      githubDomain: "acme.ghe.com",
-      hasProfile: true,
-    });
-    mockDiscoveryResponse({
-      ok: true,
-      json: buildModelsResponse([
-        { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
-      ]),
-    });
+  it.each([
+    { label: "enterprise", profileDomain: "acme.ghe.com" },
+    { label: "public", profileDomain: "github.com" },
+  ])(
+    "preserves the selected $label OAuth account's domain for embedding auth",
+    async (testCase) => {
+      resolveFirstGithubTokenMock.mockResolvedValueOnce({
+        githubToken: "durable-github-token",
+        githubDomain: testCase.profileDomain,
+        hasProfile: true,
+      });
+      mockDiscoveryResponse({
+        ok: true,
+        json: buildModelsResponse([
+          { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+        ]),
+      });
 
-    await githubCopilotMemoryEmbeddingProviderAdapter.create({
-      ...defaultCreateOptions(),
-      config: {
-        models: {
-          providers: {
-            "github-copilot": {
-              baseUrl: "https://api.githubcopilot.com",
-              models: [],
-              params: { githubDomain: "other.ghe.com" },
+      await githubCopilotMemoryEmbeddingProviderAdapter.create({
+        ...defaultCreateOptions(),
+        config: {
+          models: {
+            providers: {
+              "github-copilot": {
+                baseUrl: "https://api.githubcopilot.com",
+                models: [],
+                params: { githubDomain: "other.ghe.com" },
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    expect(firstCopilotRuntimeAuthRequest()).toMatchObject({
-      githubToken: "durable-github-token",
-      githubDomain: "acme.ghe.com",
-    });
-  });
+      expect(firstCopilotRuntimeAuthRequest()).toMatchObject({
+        githubToken: "durable-github-token",
+        githubDomain: testCase.profileDomain,
+      });
+    },
+  );
 
   it("matches embedding-capable models when supported_endpoints is missing or malformed", async () => {
     mockDiscoveryResponse({

--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -171,6 +171,40 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
     expect(firstCopilotRuntimeAuthRequest().githubToken).toBe("test-token-placeholder");
   });
 
+  it("preserves the selected OAuth account's enterprise domain for embedding auth", async () => {
+    resolveFirstGithubTokenMock.mockResolvedValueOnce({
+      githubToken: "durable-github-token",
+      githubDomain: "acme.ghe.com",
+      hasProfile: true,
+    });
+    mockDiscoveryResponse({
+      ok: true,
+      json: buildModelsResponse([
+        { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+      ]),
+    });
+
+    await githubCopilotMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      config: {
+        models: {
+          providers: {
+            "github-copilot": {
+              baseUrl: "https://api.githubcopilot.com",
+              models: [],
+              params: { githubDomain: "other.ghe.com" },
+            },
+          },
+        },
+      },
+    });
+
+    expect(firstCopilotRuntimeAuthRequest()).toMatchObject({
+      githubToken: "durable-github-token",
+      githubDomain: "acme.ghe.com",
+    });
+  });
+
   it("matches embedding-capable models when supported_endpoints is missing or malformed", async () => {
     mockDiscoveryResponse({
       ok: true,

--- a/extensions/github-copilot/embeddings.ts
+++ b/extensions/github-copilot/embeddings.ts
@@ -312,21 +312,21 @@ export const githubCopilotMemoryEmbeddingProviderAdapter: MemoryEmbeddingProvide
           return { apiKey: explicitValue, baseUrl: customBaseUrl };
         })()
       : undefined;
-    const value = explicitValue
-      ? explicitValue
-      : (
-          await resolveFirstGithubToken({
-            agentDir: options.agentDir,
-            config: options.config,
-            env: process.env,
-          })
-        ).githubToken;
+    const profileAuth = explicitValue
+      ? undefined
+      : await resolveFirstGithubToken({
+          agentDir: options.agentDir,
+          config: options.config,
+          env: process.env,
+        });
+    const value = explicitValue ?? profileAuth?.githubToken;
     if (!value) {
       throw new Error("No GitHub token available for Copilot embedding provider");
     }
 
     const githubDomain = resolveGithubCopilotDomain({
       env: process.env,
+      explicit: profileAuth?.githubDomain,
       config: options.config,
     });
     // A custom endpoint owns its own explicit credential. Never resolve a

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -411,7 +411,47 @@ describe("github-copilot plugin", () => {
     expect(adapter.id).toBe("github-copilot");
   });
 
-  it("uses the configured account when discovering its live Copilot model catalog", async () => {
+  it.each([
+    {
+      label: "a stored token account",
+      profile: {
+        type: "token" as const,
+        provider: "github-copilot",
+        token: "preferred-token",
+      },
+      expectedToken: "preferred-token",
+      expectedDomain: "github.com",
+    },
+    {
+      label: "an enterprise OAuth account",
+      profile: {
+        type: "oauth" as const,
+        provider: "github-copilot",
+        access: "short-lived-copilot-token",
+        refresh: "durable-github-token",
+        expires: Date.now() + 60_000,
+        enterpriseUrl: "acme.ghe.com",
+      },
+      expectedToken: "durable-github-token",
+      expectedDomain: "acme.ghe.com",
+      configuredDomain: "other.ghe.com",
+    },
+    {
+      label: "an enterprise OAuth account with an explicit environment domain",
+      profile: {
+        type: "oauth" as const,
+        provider: "github-copilot",
+        access: "short-lived-copilot-token",
+        refresh: "durable-github-token",
+        expires: Date.now() + 60_000,
+        enterpriseUrl: "acme.ghe.com",
+      },
+      expectedToken: "durable-github-token",
+      expectedDomain: "override.ghe.com",
+      configuredDomain: "other.ghe.com",
+      envDomain: "override.ghe.com",
+    },
+  ])("uses $label when discovering its live Copilot model catalog", async (testCase) => {
     const agentDir = await createAgentDir();
     saveAuthProfileStore(
       {
@@ -422,11 +462,7 @@ describe("github-copilot plugin", () => {
             provider: "github-copilot",
             token: "first-token",
           },
-          "github-copilot:preferred": {
-            type: "token",
-            provider: "github-copilot",
-            token: "preferred-token",
-          },
+          "github-copilot:preferred": testCase.profile,
         },
       },
       agentDir,
@@ -462,18 +498,32 @@ describe("github-copilot plugin", () => {
     );
     const provider = registerProviderWithPluginConfig({});
 
+    const env = testCase.envDomain ? { COPILOT_GITHUB_DOMAIN: testCase.envDomain } : {};
     const result = await provider.catalog.run({
       config: {
         auth: { order: { "github-copilot": ["github-copilot:preferred"] } },
+        ...(testCase.configuredDomain
+          ? {
+              models: {
+                providers: {
+                  "github-copilot": {
+                    baseUrl: "https://api.githubcopilot.com",
+                    models: [],
+                    params: { githubDomain: testCase.configuredDomain },
+                  },
+                },
+              },
+            }
+          : {}),
       },
       agentDir,
-      env: {},
+      env,
     });
 
     expect(mocks.resolveCopilotRuntimeAuth).toHaveBeenCalledWith({
-      githubToken: "preferred-token",
-      env: {},
-      githubDomain: "github.com",
+      githubToken: testCase.expectedToken,
+      env,
+      githubDomain: testCase.expectedDomain,
     });
     expect(
       result && "provider" in result ? result.provider.models.map((model) => model.id) : [],

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -411,6 +411,75 @@ describe("github-copilot plugin", () => {
     expect(adapter.id).toBe("github-copilot");
   });
 
+  it("uses the configured account when discovering its live Copilot model catalog", async () => {
+    const agentDir = await createAgentDir();
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "github-copilot:first": {
+            type: "token",
+            provider: "github-copilot",
+            token: "first-token",
+          },
+          "github-copilot:preferred": {
+            type: "token",
+            provider: "github-copilot",
+            token: "preferred-token",
+          },
+        },
+      },
+      agentDir,
+      { filterExternalAuthProfiles: false, syncExternalCli: false },
+    );
+    mocks.resolveCopilotRuntimeAuth.mockResolvedValueOnce({
+      apiKey: "preferred-copilot-token",
+      baseUrl: "https://api.githubcopilot.preferred",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              data: [
+                {
+                  id: "gpt-5.4",
+                  name: "GPT-5.4",
+                  model_picker_enabled: true,
+                  policy: { state: "enabled" },
+                  capabilities: {
+                    type: "chat",
+                    limits: { max_context_window_tokens: 200_000, max_output_tokens: 64_000 },
+                    supports: { streaming: true, tool_calls: true },
+                  },
+                },
+              ],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      ),
+    );
+    const provider = registerProviderWithPluginConfig({});
+
+    const result = await provider.catalog.run({
+      config: {
+        auth: { order: { "github-copilot": ["github-copilot:preferred"] } },
+      },
+      agentDir,
+      env: {},
+    });
+
+    expect(mocks.resolveCopilotRuntimeAuth).toHaveBeenCalledWith({
+      githubToken: "preferred-token",
+      env: {},
+      githubDomain: "github.com",
+    });
+    expect(
+      result && "provider" in result ? result.provider.models.map((model) => model.id) : [],
+    ).toEqual(["gpt-5.4"]);
+  });
+
   it("skips catalog discovery when plugin discovery is disabled", async () => {
     const provider = registerProviderWithPluginConfig({ discovery: { enabled: false } });
 

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -423,6 +423,19 @@ describe("github-copilot plugin", () => {
       expectedDomain: "github.com",
     },
     {
+      label: "a public OAuth account with stale enterprise configuration",
+      profile: {
+        type: "oauth" as const,
+        provider: "github-copilot",
+        access: "short-lived-copilot-token",
+        refresh: "durable-github-token",
+        expires: Date.now() + 60_000,
+      },
+      expectedToken: "durable-github-token",
+      expectedDomain: "github.com",
+      configuredDomain: "other.ghe.com",
+    },
+    {
       label: "an enterprise OAuth account",
       profile: {
         type: "oauth" as const,

--- a/src/plugin-sdk/test-helpers/provider-discovery-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-discovery-contract.ts
@@ -138,8 +138,10 @@ function providerModelIds(provider: Record<string, unknown>): Array<unknown> {
 function installDiscoveryHooks(state: DiscoveryState, options: DiscoveryContractOptions) {
   beforeAll(async () => {
     vi.resetModules();
-    vi.doMock("openclaw/plugin-sdk/agent-runtime", () => {
+    vi.doMock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../agent-runtime.js")>();
       return {
+        ...actual,
         ensureAuthProfileStore: ensureAuthProfileStoreMock,
         listProfilesForProvider: listProfilesForProviderMock,
       };


### PR DESCRIPTION
Closes #46031

## What Problem This Solves

Fixes an issue where users with multiple GitHub Copilot accounts could not select their preferred account through `auth.order`: model discovery, account-specific entitlements, context limits, embeddings, and other provider-owned authentication flows instead silently used the first stored account.

## Why This Change Was Made

GitHub Copilot now applies the existing canonical auth-profile ordering and eligibility resolver to its already-loaded auth store only when a provider order is explicitly configured. This keeps account selection inside the provider-owned authentication boundary while preserving the shipped first-account default, direct environment/configured-secret precedence, explicitly requested profiles, cooldown behavior, and fail-closed handling for empty or unavailable configured accounts.

Follow-up: the generic model-discovery auth resolvers independently ignore configured account order and can prefer a later API-key profile over an explicitly ordered OAuth profile; that cross-provider owner should be repaired separately without broadening this GitHub Copilot fix.

## User Impact

GitHub Copilot users can reliably select the intended account and its available models, quotas, and context limits by configuring `auth.order`, including an agent-specific stored order. Existing single-account, direct-token, and explicitly pinned-account behavior remains unchanged.

## Evidence

- Before the fix, the new provider-owner and real registered-catalog regressions produced **7 failures and 57 passes**: every ordered-account scenario and the Copilot token exchange incorrectly selected `first-token`.
- After the fix, `node scripts/run-vitest.mjs extensions/github-copilot/auth.test.ts extensions/github-copilot/index.test.ts` passes **64/64** tests, covering configured order, stored-order precedence, normalized provider keys, account cooldowns, empty/missing configured accounts, unchanged default selection, explicit profile pins, and the actual registered provider catalog boundary.
- A fresh isolated candidate CLI completed a genuine authenticated `github-copilot/gpt-5.4` request against the Copilot Responses API with **HTTP 200 SSE** and a successful model reply; no operator configuration or state was modified.
- Extension production typechecking, extension test typechecking, changed-file extension lint, formatting, and the independent structured security/code review all pass.
- The full changed-file guard also exposed an unrelated existing `memory-core` doctor-contract closure into `kysely` at `src/plugins/doctor-contract-closure-guard.test.ts:520`; all eight files in that failing import chain are byte-identical to current `main`. No unrelated memory or persistence code is changed here.
