### PR TITLE
refactor(ui): centralize audio blob leases

### DIFF
--- a/ui/src/pages/chat/components/chat-audio-waveform.ts
+++ b/ui/src/pages/chat/components/chat-audio-waveform.ts
@@ -117,15 +117,10 @@ function makeRoomForChatAudioBlob(sizeBytes: number): boolean {
   return true;
 }
 
-export function retainCachedChatAudioBlob(
+function retainChatAudioBlobEntry(
   cacheKey: string,
-): { value: CachedChatAudioBlob; release: () => void } | null {
-  const entry = chatAudioBlobCache.get(cacheKey);
-  if (!entry) {
-    return null;
-  }
-  chatAudioBlobCache.delete(cacheKey);
-  chatAudioBlobCache.set(cacheKey, entry);
+  entry: ChatAudioBlobCacheEntry,
+): { value: CachedChatAudioBlob; release: () => void } {
   entry.retainCount += 1;
   let released = false;
   return {
@@ -144,6 +139,18 @@ export function retainCachedChatAudioBlob(
   };
 }
 
+export function retainCachedChatAudioBlob(
+  cacheKey: string,
+): { value: CachedChatAudioBlob; release: () => void } | null {
+  const entry = chatAudioBlobCache.get(cacheKey);
+  if (!entry) {
+    return null;
+  }
+  chatAudioBlobCache.delete(cacheKey);
+  chatAudioBlobCache.set(cacheKey, entry);
+  return retainChatAudioBlobEntry(cacheKey, entry);
+}
+
 export function cacheAndRetainChatAudioBlob(
   cacheKey: string,
   value: CachedChatAudioBlob,
@@ -159,22 +166,7 @@ export function cacheAndRetainChatAudioBlob(
     URL.revokeObjectURL(value.blobUrl);
     return null;
   }
-  const entry = { ...value, retainCount: 1 };
+  const entry = { ...value, retainCount: 0 };
   chatAudioBlobCache.set(cacheKey, entry);
-  trimChatAudioBlobCache();
-  let released = false;
-  return {
-    value: entry,
-    release: () => {
-      if (released) {
-        return;
-      }
-      released = true;
-      const current = chatAudioBlobCache.get(cacheKey);
-      if (current && current.retainCount > 0) {
-        current.retainCount -= 1;
-      }
-      trimChatAudioBlobCache();
-    },
-  };
+  return retainChatAudioBlobEntry(cacheKey, entry);
 }


### PR DESCRIPTION
## What Problem This Solves

The Control UI audio Blob cache had two private entry paths that independently implemented the same retain/release lease policy. Keeping idempotent release, retain-count decrement, and eviction trimming in two places made this lifecycle policy easy to drift.

## Why This Change Was Made

Both cached-entry and newly inserted-entry paths now delegate to one private lease owner. The new-entry path also drops a redundant post-insert trim: `makeRoomForChatAudioBlob` already proves the count and byte bounds immediately before the synchronous insertion.

A broader cache abstraction was rejected because this policy is local to the audio Blob owner and the duplicate is fully removable in place.

## User Impact

No user-visible or accessibility behavior changes. Audio playback, waveform reuse, cache bounds, and Blob URL release behavior remain the same, with one canonical private lifecycle path.

Production LOC: +17/-25 (net -8) | Tests: +0/-0

## Evidence

Exact head: `c5751ad6fae559a92cdc370268b4c2fc1003c27b`

- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-audio-waveform.test.ts ui/src/pages/chat/components/chat-audio-player.test.ts` — 2 files, 20 tests passed. This covers cache count/byte bounds, cache reuse, release lifecycle, playable controls, keyboard interaction, and play/pause `aria-label` state.
- `OPENCLAW_UI_E2E_ARTIFACT_DIR=/tmp/ui-audio-cache-e2e OPENCLAW_BEHAVIOR_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.media-files.e2e.test.ts` — real Chromium, 15 tests passed, including both assistant-audio cases and visible blocked-media states.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/pages/chat/components/chat-audio-waveform.ts` — 0 warnings, 0 errors.
- `git diff --check` — passed.
- `node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-audio-waveform.ts` — all guards through i18n passed; the shared orb install then failed unrelated core-test typechecking because it contains `pako` 1.0.11 while this head's UI manifest pins 3.0.1. The worktree did not mutate shared dependencies; exact-head clean-install CI/Testbox is the typecheck gate.
- Structured autoreview — clean, no accepted/actionable findings.
- Separate read-only exact-head review — no P0/P1 findings; a 20,000-operation differential cache model matched base behavior.
- Codex contract gate — no Codex runtime/protocol relationship. Direct sibling source inspection covered `README.md:1-8` (Codex CLI ownership) and `codex-rs/core/src/lib.rs:1-27` (core surface); a repo-wide sibling search found no OpenClaw audio/cache integration.

No screenshots are attached because no rendering path changed. The executed browser flow and DOM/accessibility assertions cover representative audio attachment states without implying a visual delta.
