### PR TITLE
refactor(memory): reuse canonical embedding input size estimators

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -40,6 +40,36 @@ describe("memory embedding policy", () => {
     expect(batches[0]).toHaveLength(4);
   });
 
+  it("budgets multibyte text and structured inline data by their actual UTF-8 bytes", () => {
+    const textChunks = [chunk("é"), chunk("😀"), chunk("a")];
+    expect(buildMemoryEmbeddingBatches(textChunks, 5).map((batch) => batch.length)).toEqual([1, 2]);
+
+    const structuredChunks = [
+      {
+        ...chunk("this longer fallback text is ignored when parts are present"),
+        embeddingInput: {
+          text: "this fallback is also ignored",
+          parts: [
+            { type: "text" as const, text: "é" },
+            { type: "inline-data" as const, mimeType: "a/b", data: "😀" },
+          ],
+        },
+      },
+      {
+        ...chunk("the second fallback is ignored too"),
+        embeddingInput: {
+          text: "unused fallback",
+          parts: [{ type: "text" as const, text: "é" }],
+        },
+      },
+    ];
+
+    expect(buildMemoryEmbeddingBatches(structuredChunks, 10).map((batch) => batch.length)).toEqual([
+      1, 1,
+    ]);
+    expect(buildMemoryEmbeddingBatches(structuredChunks, 11)).toEqual([structuredChunks]);
+  });
+
   it("filters empty chunks before embedding", () => {
     const chunks = filterNonEmptyMemoryChunks([chunk("\n\n"), chunk("hello"), chunk("   ")]);
 

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -1,50 +1,16 @@
 // Memory Core plugin module implements manager embedding policy behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import {
+  estimateStructuredEmbeddingInputBytes,
+  estimateUtf8Bytes,
+  type EmbeddingInput,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
-
-type MemoryEmbeddingTextPart = {
-  type: "text";
-  text: string;
-};
-
-type MemoryEmbeddingInlineDataPart = {
-  type: "inline-data";
-  mimeType: string;
-  data: string;
-};
-
-type MemoryEmbeddingInput = {
-  text: string;
-  parts?: Array<MemoryEmbeddingTextPart | MemoryEmbeddingInlineDataPart>;
-};
 
 type MemoryEmbeddingChunk = {
   text: string;
-  embeddingInput?: MemoryEmbeddingInput;
+  embeddingInput?: EmbeddingInput;
 };
-
-function estimateUtf8Bytes(text: string): number {
-  if (!text) {
-    return 0;
-  }
-  return Buffer.byteLength(text, "utf8");
-}
-
-function estimateStructuredEmbeddingInputBytes(input: MemoryEmbeddingInput): number {
-  if (!input.parts?.length) {
-    return estimateUtf8Bytes(input.text);
-  }
-  let total = 0;
-  for (const part of input.parts) {
-    if (part.type === "text") {
-      total += estimateUtf8Bytes(part.text);
-    } else {
-      total += estimateUtf8Bytes(part.mimeType);
-      total += estimateUtf8Bytes(part.data);
-    }
-  }
-  return total;
-}
 
 export function filterNonEmptyMemoryChunks<T extends MemoryEmbeddingChunk>(chunks: T[]): T[] {
   return chunks.filter((chunk) => chunk.text.trim().length > 0);
@@ -169,6 +135,6 @@ export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(par
   }
 }
 
-export function buildTextEmbeddingInputs(chunks: MemoryEmbeddingChunk[]): MemoryEmbeddingInput[] {
+export function buildTextEmbeddingInputs(chunks: MemoryEmbeddingChunk[]): EmbeddingInput[] {
   return chunks.map((chunk) => chunk.embeddingInput ?? { text: chunk.text });
 }


### PR DESCRIPTION
## What Problem This Solves

Memory Core maintained its own copies of the embedding input type and UTF-8 size-estimation functions even though its existing public plugin SDK already exposes the same canonical types and behavior. Keeping two implementations makes future multimodal input-size policy changes vulnerable to drift.

## Why This Change Was Made

The Memory Core batching owner now imports `EmbeddingInput`, `estimateUtf8Bytes`, and `estimateStructuredEmbeddingInputBytes` from its existing, stable `openclaw/plugin-sdk/memory-core-host-engine-embeddings` contract. This deletes three duplicate private types and two duplicate functions without introducing a new SDK export, dependency, configuration option, compatibility path, or provider-specific behavior.

Production code changes by +7/-41, removing 34 lines overall.

## User Impact

None. This is a behavior-preserving internal architecture cleanup. Plain-text, multibyte UTF-8, surrogate-pair, and structured inline-data batching retain their existing size accounting and request boundaries.

## Evidence

- Tests were written first, while production remained unchanged: the existing Memory Core owner suite passed all 17 tests before the duplicate implementations were deleted.
- The new owner-boundary case checks multibyte text, emoji/surrogate-pair text, structured text parts, inline-data MIME and payload bytes, exact batch-size thresholds, and structured parts taking precedence over fallback text.
- After switching to the canonical SDK implementation, all 65 tests across seven policy, retry, generic-provider, broad-SDK-mock, cache, batch-state, and reindex suites passed:
  `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts --configLoader runner extensions/memory-core/src/memory/manager-embedding-policy.test.ts extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts extensions/memory-core/src/memory/embeddings.test.ts extensions/memory-core/src/memory/generic-embedding-provider.integration.test.ts extensions/memory-core/src/memory/manager-batch-state.test.ts extensions/memory-core/src/memory/manager-embedding-cache.test.ts extensions/memory-core/src/memory/manager-reindex-state.test.ts`
- Scoped formatter and lint checks passed for both changed files.
- Two independent reviews plus a fresh structured autoreview reported no actionable findings.
- Production: +7/-41 (net -34). Tests: +30/-0.
