### PR TITLE
refactor: remove redundant proxy resolver layer

### DIFF
--- a/src/llm/utils/node-http-proxy.ts
+++ b/src/llm/utils/node-http-proxy.ts
@@ -12,16 +12,11 @@ interface NodeHttpProxyAgents {
   httpsAgent: HttpsAgent;
 }
 
-/** Resolves the environment proxy URL that applies to a target URL. */
-function resolveHttpProxyUrlForTarget(targetUrl: string | URL): URL | undefined {
-  return resolveEnvNodeProxyUrlForTarget(targetUrl);
-}
-
 /** Builds fixed HTTP and HTTPS proxy agents for a target URL, when env proxy config applies. */
 export function createHttpProxyAgentsForTarget(
   targetUrl: string | URL,
 ): NodeHttpProxyAgents | undefined {
-  const proxyUrl = resolveHttpProxyUrlForTarget(targetUrl);
+  const proxyUrl = resolveEnvNodeProxyUrlForTarget(targetUrl);
   if (!proxyUrl) {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

The LLM Node proxy adapter retained a private resolver name whose implementation only forwarded its argument to the canonical `src/infra/net` proxy resolver. That leftover layer made proxy ownership look split even though all policy had already moved to the infrastructure owner.

## Why This Change Was Made

Inline the canonical resolver call at the adapter's sole call site and delete the private identity wrapper. This completes the earlier proxyline consolidation without changing the exported `createHttpProxyAgentsForTarget` function, its return type, the Plugin SDK forwarding surface, environment lookup, `NO_PROXY` handling, protocol validation, or agent construction.

Alternatives considered:

- Keep the private wrapper: rejected because it owns no behavior or type adaptation and preserves a second concept for the same canonical operation.
- Move or change the exported adapter: rejected because the Plugin SDK surface and Bedrock integration are shipped contracts outside this cleanup.

AI-assisted: yes.

## User Impact

No user-visible behavior changes. Maintainers have one fewer proxy-resolution path to trace.

Production LOC: +1/-6 (net -5) | Tests: +0/-0

Exact head: `7423b4b0965e52f2fecea8344e582303a95eedb9`

## Evidence

- `node scripts/run-vitest.mjs src/llm/utils/node-http-proxy.test.ts src/infra/net/node-proxy-agent.test.ts` — 2 files, 8 tests passed.
- `node scripts/check-changed.mjs -- src/llm/utils/node-http-proxy.ts` — passed with the current frozen lockfile, including formatting, dead-export scans, core/core-test typechecks, lint, import cycles, and repository guards.
- `git diff --check HEAD^ HEAD` — passed.
- Deslop review — no behavior-neutral cleanup findings beyond the intended deletion.
- Structured autoreview — clean; no accepted/actionable findings.
- Separate exact-head Codex source review — clean; no P0/P1 findings after inspecting the resolver, Bedrock caller, Plugin SDK forward, and owner/callee tests.
- Live overlap scan covered all 2,239 open PR file stacks; none touches `src/llm/utils/node-http-proxy.ts`. Open issue/PR searches for the file and symbols also returned no overlap.

CI and exact-head ClawSweeper review will be recorded before landing.
