### PR TITLE
refactor(video): unify capability overlay merging

### DIFF
--- a/src/video-generation/capability-overlays.ts
+++ b/src/video-generation/capability-overlays.ts
@@ -91,6 +91,31 @@ export function buildVideoGenerationCapabilityFailure(params: {
   return undefined;
 }
 
+function mergeVideoGenerationCapabilities<T extends VideoGenerationModeCapabilities>(
+  base: T,
+  overlay: T,
+): T {
+  const overlayOptions = overlay.providerOptions;
+  // Explicit empty providerOptions means "clear inherited options"; undefined
+  // means "inherit base declaration".
+  const mergedProviderOptions =
+    Object.hasOwn(overlay, "providerOptions") &&
+    overlayOptions &&
+    Object.keys(overlayOptions).length === 0
+      ? overlayOptions
+      : base.providerOptions || overlayOptions
+        ? {
+            ...base.providerOptions,
+            ...overlayOptions,
+          }
+        : undefined;
+  return {
+    ...base,
+    ...overlay,
+    ...(mergedProviderOptions ? { providerOptions: mergedProviderOptions } : {}),
+  } as T;
+}
+
 function mergeVideoGenerationModeCapabilities<
   T extends VideoGenerationModeCapabilities | VideoGenerationTransformCapabilities | undefined,
 >(base: T, overlay: T): T {
@@ -100,47 +125,15 @@ function mergeVideoGenerationModeCapabilities<
   if (!base) {
     return overlay;
   }
-  const overlayOptions = overlay.providerOptions;
-  const hasOverlayOptions = Object.hasOwn(overlay, "providerOptions");
-  // Explicit empty providerOptions means "clear inherited options"; undefined
-  // means "inherit base declaration".
-  const mergedProviderOptions =
-    hasOverlayOptions && overlayOptions && Object.keys(overlayOptions).length === 0
-      ? overlayOptions
-      : base.providerOptions || overlayOptions
-        ? {
-            ...base.providerOptions,
-            ...overlayOptions,
-          }
-        : undefined;
-
-  return {
-    ...base,
-    ...overlay,
-    ...(mergedProviderOptions ? { providerOptions: mergedProviderOptions } : {}),
-  } as T;
+  return mergeVideoGenerationCapabilities(base, overlay);
 }
 
 function mergeVideoGenerationProviderCapabilities(
   base: VideoGenerationProviderCapabilities,
   overlay: VideoGenerationProviderCapabilities,
 ): VideoGenerationProviderCapabilities {
-  const overlayOptions = overlay.providerOptions;
-  const hasOverlayOptions = Object.hasOwn(overlay, "providerOptions");
-  const mergedProviderOptions =
-    hasOverlayOptions && overlayOptions && Object.keys(overlayOptions).length === 0
-      ? overlayOptions
-      : base.providerOptions || overlayOptions
-        ? {
-            ...base.providerOptions,
-            ...overlayOptions,
-          }
-        : undefined;
-
   return {
-    ...base,
-    ...overlay,
-    ...(mergedProviderOptions ? { providerOptions: mergedProviderOptions } : {}),
+    ...mergeVideoGenerationCapabilities(base, overlay),
     generate: mergeVideoGenerationModeCapabilities(base.generate, overlay.generate),
     imageToVideo: mergeVideoGenerationModeCapabilities(base.imageToVideo, overlay.imageToVideo),
     videoToVideo: mergeVideoGenerationModeCapabilities(base.videoToVideo, overlay.videoToVideo),


### PR DESCRIPTION
## What Problem This Solves

The video-generation capability overlay path maintained the same shallow merge and `providerOptions` clear-vs-inherit policy in two private functions. That duplication made provider-level and mode-level overlays separate policy owners even though they must behave identically.

## Why This Change Was Made

Move the shared merge policy into one private helper and have provider and mode overlays delegate to it. Nested mode blocks still use their existing optional-block merge path, and explicit empty `providerOptions` objects still clear inherited declarations.

Alternatives rejected: exporting a shared utility would widen API surface; adding a generic cross-module merge abstraction would be speculative; leaving the duplication preserves two policy owners.

Production LOC: +20/-27 (net -7) | Tests: +0/-0

## User Impact

No user-visible behavior change. This removes one duplicated internal policy while preserving current video provider/model capability resolution.

## Evidence

Exact reviewed head: `f5e349d96b07618d3b6206e348496f59bddd7c54`

- `node scripts/run-vitest.mjs src/video-generation/capability-overlays.test.ts src/video-generation/runtime.test.ts` — 43/43 passed across 2 shards.
- `node scripts/check-changed.mjs -- src/video-generation/capability-overlays.ts` — passed, including core/core-test typechecks, lint, dead-export, import-cycle, formatting, boundary, and policy guards.
- Existing focused tests cover top-level and nested inheritance, explicit false/zero overlays, and explicit-empty `providerOptions` clearing; no duplicate test was added.
- Deslop: clean, no changes requested.
- Structured autoreview: clean, no accepted/actionable findings.
- Separate read-only exact-head Codex review: `NO FINDINGS`.
- Initial full open-PR file-stack scan plus a pre-publication incremental scan found no overlap on `src/video-generation/capability-overlays.ts`.

AI-assisted: Amp implementation and verification; Codex reviews.
