### PR TITLE
refactor(elevenlabs): consolidate voice-setting directive parsing

### DIFF
--- a/extensions/elevenlabs/speech-provider.test.ts
+++ b/extensions/elevenlabs/speech-provider.test.ts
@@ -45,6 +45,17 @@ const OUTPUT_FORMAT_CASES = [
   { outputFormat: "future_123", fileExtension: ".bin", voiceCompatible: false },
 ] as const;
 
+const DIRECTIVE_POLICY = {
+  enabled: true,
+  allowText: true,
+  allowProvider: true,
+  allowVoice: true,
+  allowModelId: true,
+  allowVoiceSettings: true,
+  allowNormalization: true,
+  allowSeed: true,
+};
+
 describe("elevenlabs speech provider", () => {
   const originalFetch = globalThis.fetch;
 
@@ -72,6 +83,49 @@ describe("elevenlabs speech provider", () => {
       "eleven_monolingual_v1",
     ]);
   });
+
+  it.each([
+    ["stability", "0", { stability: 0 }],
+    ["similarity", "1", { similarityBoost: 1 }],
+    ["similarityboost", "0.25", { similarityBoost: 0.25 }],
+    ["similarity_boost", "5e-1", { similarityBoost: 0.5 }],
+    ["style", "1", { style: 1 }],
+    ["speed", ".5", { speed: 0.5 }],
+    ["speed", "2", { speed: 2 }],
+    ["stability", "-0.1", "stability must be between 0 and 1"],
+    ["similarity", "Infinity", "invalid similarityBoost value"],
+    ["similarity_boost", "1.1", "similarityBoost must be between 0 and 1"],
+    ["style", "0x1", "invalid style value"],
+    ["speed", ".49", "speed must be between 0.5 and 2"],
+    ["speed", "2.01", "speed must be between 0.5 and 2"],
+    ["speed", "invalid", undefined, false],
+  ] as const)(
+    "preserves the %s=%s voice-setting directive",
+    (key, value, expected, allowed?: boolean) => {
+      const currentOverrides = { voiceId: "existing-voice", voiceSettings: { style: 0.25 } };
+      const allowVoiceSettings = allowed ?? true;
+      const parsed = buildElevenLabsSpeechProvider().parseDirectiveToken?.({
+        key,
+        value,
+        policy: { ...DIRECTIVE_POLICY, allowVoiceSettings },
+        currentOverrides,
+      });
+
+      expect(parsed).toEqual(
+        !allowVoiceSettings
+          ? { handled: true }
+          : typeof expected === "string"
+            ? { handled: true, warnings: [expected] }
+            : {
+                handled: true,
+                overrides: {
+                  ...currentOverrides,
+                  voiceSettings: { ...currentOverrides.voiceSettings, ...expected },
+                },
+              },
+      );
+    },
+  );
 
   it("forwards the core-resolved voice-list timeout", async () => {
     globalThis.fetch = vi.fn(async () => Response.json({ voices: [] })) as unknown as typeof fetch;

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -269,54 +269,25 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext) {
           handled: true,
           overrides: { ...ctx.currentOverrides, modelId: normalizeElevenLabsTtsModelId(ctx.value) },
         };
-      case "stability": {
-        if (!ctx.policy.allowVoiceSettings) {
-          return { handled: true };
-        }
-        const value = parseNumberValue(ctx.value);
-        if (value == null) {
-          return { handled: true, warnings: ["invalid stability value"] };
-        }
-        requireInRange(value, 0, 1, "stability");
-        return { handled: true, overrides: mergeVoiceSettingsOverride(ctx, { stability: value }) };
-      }
+      case "stability":
       case "similarity":
       case "similarityboost":
-      case "similarity_boost": {
-        if (!ctx.policy.allowVoiceSettings) {
-          return { handled: true };
-        }
-        const value = parseNumberValue(ctx.value);
-        if (value == null) {
-          return { handled: true, warnings: ["invalid similarityBoost value"] };
-        }
-        requireInRange(value, 0, 1, "similarityBoost");
-        return {
-          handled: true,
-          overrides: mergeVoiceSettingsOverride(ctx, { similarityBoost: value }),
-        };
-      }
-      case "style": {
-        if (!ctx.policy.allowVoiceSettings) {
-          return { handled: true };
-        }
-        const value = parseNumberValue(ctx.value);
-        if (value == null) {
-          return { handled: true, warnings: ["invalid style value"] };
-        }
-        requireInRange(value, 0, 1, "style");
-        return { handled: true, overrides: mergeVoiceSettingsOverride(ctx, { style: value }) };
-      }
+      case "similarity_boost":
+      case "style":
       case "speed": {
         if (!ctx.policy.allowVoiceSettings) {
           return { handled: true };
         }
+        const setting = ctx.key.startsWith("similarity") ? "similarityBoost" : ctx.key;
         const value = parseNumberValue(ctx.value);
         if (value == null) {
-          return { handled: true, warnings: ["invalid speed value"] };
+          return { handled: true, warnings: [`invalid ${setting} value`] };
         }
-        requireInRange(value, 0.5, 2, "speed");
-        return { handled: true, overrides: mergeVoiceSettingsOverride(ctx, { speed: value }) };
+        requireInRange(value, setting === "speed" ? 0.5 : 0, setting === "speed" ? 2 : 1, setting);
+        return {
+          handled: true,
+          overrides: mergeVoiceSettingsOverride(ctx, { [setting]: value }),
+        };
       }
       case "speakerboost":
       case "speaker_boost":


### PR DESCRIPTION
## What Problem This Solves

ElevenLabs voice-setting directives repeated the same policy, numeric validation, range checking, warning, and nested-override behavior across four separate branches. Maintaining these paths independently made it easier for supported aliases or validation behavior to drift.

## Why This Change Was Made

Route stability, similarity, style, and speed directives through one provider-owned parsing path while retaining every supported alias, exact malformed and out-of-range warning, existing numeric bounds, disabled-policy behavior, and nested voice-setting merge. The generic speech helper cannot be reused without changing warning and override contracts.

Production: +8/-37 lines (net -29). Tests: +54 lines.

## User Impact

No user-visible behavior changes. Existing ElevenLabs voice-setting directives, provider configuration, authentication, model catalog, and public interfaces retain their current behavior.

## Evidence

- Characterized aliases, inclusive boundaries, scientific notation, malformed tokens, exact warning messages, disabled overrides, and existing nested settings before refactoring.
- All six ElevenLabs owner and sibling test files passed: 85 tests.
- Shared speech-directive caller and numeric-helper suites passed: 28 tests.
- Full unrestricted changed-file validation passed, including dead-export scans, provider-owner guards, production and test typechecks, plugin boundaries, changed-file lint, and runtime import cycles:

```
node scripts/check-changed.mjs -- extensions/elevenlabs/speech-provider.ts extensions/elevenlabs/speech-provider.test.ts
```

- Independent source and read-only exact-commit reviews passed.
