### PR TITLE
improve(ui): simplify chat image preview overlay

### DIFF
--- a/ui/src/components/image-lightbox.test.ts
+++ b/ui/src/components/image-lightbox.test.ts
@@ -28,7 +28,7 @@ async function renderLightbox() {
   render(
     html`<openclaw-image-lightbox
       src="data:image/png;base64,cG5n"
-      title="Generated lobster"
+      .imageTitle=${"Generated lobster"}
     ></openclaw-image-lightbox>`,
     container,
   );
@@ -84,11 +84,12 @@ describe("openclaw-image-lightbox", () => {
 
     expect(root?.querySelector<HTMLImageElement>("img")?.alt).toBe("Generated lobster");
     expect(root?.querySelector<HTMLImageElement>("img")?.src).toBe("data:image/png;base64,cG5n");
+    expect(modal.hasAttribute("title")).toBe(false);
     await vi.waitFor(() =>
       expect(root?.querySelector<HTMLAnchorElement>("a")?.href).toBe("blob:lightbox-original"),
     );
     expect(fetchImage).toHaveBeenCalledTimes(1);
-    expect(root?.querySelector<HTMLButtonElement>("button")?.hasAttribute("autofocus")).toBe(true);
+    expect(root?.querySelector<HTMLButtonElement>(".close")?.hasAttribute("autofocus")).toBe(false);
   });
 
   it("accepts parameters on safe raster MIME types", async () => {
@@ -98,7 +99,7 @@ describe("openclaw-image-lightbox", () => {
     render(
       html`<openclaw-image-lightbox
         src="data:image/png;charset=utf-8;base64,cG5n"
-        title="Generated lobster"
+        .imageTitle=${"Generated lobster"}
       ></openclaw-image-lightbox>`,
       container,
     );
@@ -131,7 +132,7 @@ describe("openclaw-image-lightbox", () => {
     render(
       html`<openclaw-image-lightbox
         src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'></svg>"
-        title="Untrusted SVG"
+        .imageTitle=${"Untrusted SVG"}
       ></openclaw-image-lightbox>`,
       container,
     );
@@ -153,7 +154,7 @@ describe("openclaw-image-lightbox", () => {
     render(
       html`<openclaw-image-lightbox
         src="blob:untrusted-svg"
-        title="Untrusted SVG"
+        .imageTitle=${"Untrusted SVG"}
       ></openclaw-image-lightbox>`,
       container,
     );
@@ -172,7 +173,7 @@ describe("openclaw-image-lightbox", () => {
     render(
       html`<openclaw-image-lightbox
         src="blob:safe-png"
-        title="Safe PNG"
+        .imageTitle=${"Safe PNG"}
       ></openclaw-image-lightbox>`,
       container,
     );

--- a/ui/src/components/image-lightbox.test.ts
+++ b/ui/src/components/image-lightbox.test.ts
@@ -89,7 +89,7 @@ describe("openclaw-image-lightbox", () => {
       expect(root?.querySelector<HTMLAnchorElement>("a")?.href).toBe("blob:lightbox-original"),
     );
     expect(fetchImage).toHaveBeenCalledTimes(1);
-    expect(root?.querySelector<HTMLButtonElement>(".close")?.hasAttribute("autofocus")).toBe(false);
+    expect(root?.querySelector<HTMLButtonElement>(".close")?.hasAttribute("autofocus")).toBe(true);
   });
 
   it("accepts parameters on safe raster MIME types", async () => {
@@ -248,5 +248,71 @@ describe("openclaw-image-lightbox", () => {
 
     dialogAdapter.dispatchEvent(new CustomEvent("modal-cancel", { bubbles: true }));
     expect(closes).toBe(2);
+  });
+
+  it("dismisses only a pointer gesture that starts and ends on the backdrop", async () => {
+    const { modal } = await renderLightbox();
+    const stage = modal.shadowRoot?.querySelector<HTMLElement>(".stage");
+    const image = modal.shadowRoot?.querySelector<HTMLImageElement>(".image");
+    Object.defineProperty(modal.shadowRoot!, "elementFromPoint", {
+      configurable: true,
+      value: vi.fn(() => stage ?? null),
+    });
+    let closes = 0;
+    modal.addEventListener("image-lightbox-close", () => {
+      closes += 1;
+    });
+
+    image?.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, button: 0, isPrimary: true, pointerId: 1 }),
+    );
+    stage?.dispatchEvent(
+      new PointerEvent("pointerup", { bubbles: true, button: 0, isPrimary: true, pointerId: 1 }),
+    );
+    expect(closes).toBe(0);
+
+    stage?.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+        isPrimary: true,
+        pointerId: 2,
+      }),
+    );
+    stage?.dispatchEvent(
+      new PointerEvent("pointerup", {
+        bubbles: true,
+        button: 0,
+        clientX: 30,
+        clientY: 30,
+        isPrimary: true,
+        pointerId: 2,
+      }),
+    );
+    expect(closes).toBe(0);
+
+    stage?.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+        isPrimary: true,
+        pointerId: 3,
+      }),
+    );
+    stage?.dispatchEvent(
+      new PointerEvent("pointerup", {
+        bubbles: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+        isPrimary: true,
+        pointerId: 3,
+      }),
+    );
+    expect(closes).toBe(1);
   });
 });

--- a/ui/src/components/image-lightbox.ts
+++ b/ui/src/components/image-lightbox.ts
@@ -308,7 +308,7 @@ class OpenClawImageLightbox extends OpenClawLitElement {
     const canZoom = this.imageReady && this.panzoom !== undefined;
     return html`
       <openclaw-modal-dialog
-        class="mobile-edge-to-edge"
+        class="mobile-edge-to-edge viewport-edge-to-edge"
         label=${t("chat.imageLightbox.label", { title })}
         @modal-cancel=${this.emitClose}
         @keydown=${this.handleKeydown}

--- a/ui/src/components/image-lightbox.ts
+++ b/ui/src/components/image-lightbox.ts
@@ -47,6 +47,8 @@ class OpenClawImageLightbox extends OpenClawLitElement {
   private panzoom?: PanzoomObject;
   private panzoomImage?: HTMLImageElement;
   private panzoomStage?: HTMLDivElement;
+  private backdropPointer: { pointerId: number; clientX: number; clientY: number } | undefined;
+  private motionQuery?: MediaQueryList;
 
   static override styles = css`
     :host {
@@ -255,10 +257,23 @@ class OpenClawImageLightbox extends OpenClawLitElement {
         min-height: 44px;
       }
     }
+
+    @media (prefers-reduced-motion: reduce) {
+      openclaw-modal-dialog {
+        --show-duration: 0ms;
+        --hide-duration: 0ms;
+      }
+
+      .actions .action {
+        transition: none;
+      }
+    }
   `;
 
   override connectedCallback() {
     super.connectedCallback();
+    this.motionQuery = globalThis.matchMedia?.("(prefers-reduced-motion: reduce)");
+    this.motionQuery?.addEventListener("change", this.handleMotionPreferenceChange);
     if (this.hasUpdated) {
       void this.resolveOriginalUrl();
       void this.updateComplete.then(() => {
@@ -272,6 +287,8 @@ class OpenClawImageLightbox extends OpenClawLitElement {
 
   override disconnectedCallback() {
     this.originalUrlRequest += 1;
+    this.motionQuery?.removeEventListener("change", this.handleMotionPreferenceChange);
+    this.motionQuery = undefined;
     this.destroyPanzoom();
     this.revokeOriginalBlobUrl();
     super.disconnectedCallback();
@@ -307,6 +324,7 @@ class OpenClawImageLightbox extends OpenClawLitElement {
                       href=${this.openOriginalUrl}
                       target="_blank"
                       rel="noreferrer"
+                      aria-label=${t("chat.imageLightbox.openOriginal")}
                     >
                       <span class="open-original-label">
                         ${t("chat.imageLightbox.openOriginal")}
@@ -320,6 +338,7 @@ class OpenClawImageLightbox extends OpenClawLitElement {
               <button
                 class="action close"
                 type="button"
+                autofocus
                 aria-label=${t("chat.imageLightbox.close")}
                 @click=${this.emitClose}
               >
@@ -327,7 +346,13 @@ class OpenClawImageLightbox extends OpenClawLitElement {
               </button>
             </div>
           </header>
-          <div class="stage" @click=${this.handleStageClick} @dblclick=${this.handleDoubleClick}>
+          <div
+            class="stage"
+            @pointerdown=${this.handleStagePointerDown}
+            @pointerup=${this.handleStagePointerUp}
+            @pointercancel=${this.resetBackdropPointer}
+            @dblclick=${this.handleDoubleClick}
+          >
             <img
               class=${this.scale > 1 ? "image zoomed" : "image"}
               src=${this.src}
@@ -396,6 +421,7 @@ class OpenClawImageLightbox extends OpenClawLitElement {
     this.panzoomImage = image;
     this.panzoomStage = stage;
     this.panzoom = Panzoom(image, {
+      duration: this.motionQuery?.matches ? 0 : 200,
       maxScale: MAX_SCALE,
       minScale: 1,
       panOnlyWhenZoomed: true,
@@ -455,10 +481,47 @@ class OpenClawImageLightbox extends OpenClawLitElement {
     this.panzoom?.zoomToPoint(DOUBLE_TAP_SCALE, event);
   };
 
-  private handleStageClick = (event: MouseEvent) => {
-    if (event.target === event.currentTarget) {
+  private handleStagePointerDown = (event: PointerEvent) => {
+    const stage = event.currentTarget;
+    if (
+      event.button !== 0 ||
+      !event.isPrimary ||
+      event.target !== stage ||
+      !(stage instanceof HTMLElement)
+    ) {
+      this.backdropPointer = undefined;
+      return;
+    }
+    this.backdropPointer = {
+      pointerId: event.pointerId,
+      clientX: event.clientX,
+      clientY: event.clientY,
+    };
+    stage.setPointerCapture?.(event.pointerId);
+  };
+
+  private handleStagePointerUp = (event: PointerEvent) => {
+    const pointer = this.backdropPointer;
+    this.backdropPointer = undefined;
+    const stage = event.currentTarget;
+    const releaseTarget = this.shadowRoot?.elementFromPoint?.(event.clientX, event.clientY);
+    const shouldClose =
+      event.button === 0 &&
+      event.isPrimary &&
+      pointer?.pointerId === event.pointerId &&
+      releaseTarget === stage &&
+      Math.hypot(event.clientX - pointer.clientX, event.clientY - pointer.clientY) <= 4;
+    if (shouldClose) {
       this.emitClose();
     }
+  };
+
+  private resetBackdropPointer = () => {
+    this.backdropPointer = undefined;
+  };
+
+  private handleMotionPreferenceChange = (event: MediaQueryListEvent) => {
+    this.panzoom?.setOptions({ duration: event.matches ? 0 : 200 });
   };
 
   private zoomIn = () => this.panzoom?.zoomIn();

--- a/ui/src/components/image-lightbox.ts
+++ b/ui/src/components/image-lightbox.ts
@@ -54,56 +54,27 @@ class OpenClawImageLightbox extends OpenClawLitElement {
     }
 
     openclaw-modal-dialog {
-      --openclaw-modal-width: min(1280px, calc(100vw - 40px));
-      --openclaw-modal-max-width: calc(100vw - 40px);
-      --openclaw-modal-max-height: calc(100dvh - 40px);
+      --openclaw-modal-width: 100vw;
+      --openclaw-modal-max-width: 100vw;
+      --openclaw-modal-max-height: 100dvh;
+      --openclaw-modal-backdrop-filter: none;
     }
 
     .lightbox {
-      width: min(1280px, calc(100vw - 40px));
-      height: min(900px, calc(100dvh - 40px));
+      width: 100vw;
+      height: 100dvh;
       display: grid;
-      grid-template-rows: auto minmax(0, 1fr) auto;
+      grid-template-rows: minmax(0, 1fr);
       overflow: hidden;
-      border: 1px solid color-mix(in srgb, var(--border-strong) 80%, transparent);
-      border-radius: var(--radius-lg);
-      /* Deliberately darker than any theme surface: the lightbox is a
-         photo-viewer chrome that stays near-black in light mode too, so the
-         white text and white-alpha borders below assume this literal. */
-      background: #07090f;
-      box-shadow: 0 28px 90px rgba(0, 0, 0, 0.6);
     }
 
-    .header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 16px;
-      min-height: 54px;
-      padding: 10px 12px 10px 18px;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-      background: rgba(255, 255, 255, 0.04);
-      color: #fff;
+    .header,
+    .actions {
+      display: contents;
     }
 
     .title {
-      min-width: 0;
-      overflow: hidden;
-      font-size: 13px;
-      font-weight: 650;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .actions,
-    .zoom-controls {
-      display: inline-flex;
-      align-items: center;
-    }
-
-    .actions {
-      gap: 8px;
-      flex: 0 0 auto;
+      display: none;
     }
 
     .action {
@@ -112,19 +83,19 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       align-items: center;
       justify-content: center;
       padding: 0 12px;
-      border: 1px solid rgba(255, 255, 255, 0.1);
+      border: 0;
       border-radius: var(--radius-md);
-      background: rgba(255, 255, 255, 0.08);
+      background: transparent;
       color: #fff;
       font: inherit;
       font-size: 12px;
       font-weight: 650;
       text-decoration: none;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.85);
     }
 
     .action:hover {
-      border-color: rgba(255, 255, 255, 0.2);
-      background: rgba(255, 255, 255, 0.14);
+      background: rgba(255, 255, 255, 0.1);
     }
 
     .action:focus-visible {
@@ -132,8 +103,21 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       outline-offset: 2px;
     }
 
+    .open-original,
     .close {
-      width: 36px;
+      position: fixed;
+      z-index: 1;
+      top: max(16px, calc(12px + var(--safe-area-top, 0px)));
+    }
+
+    .open-original {
+      right: max(68px, calc(64px + var(--safe-area-right, 0px)));
+    }
+
+    .close {
+      right: max(16px, calc(12px + var(--safe-area-right, 0px)));
+      width: 44px;
+      height: 44px;
       padding: 0;
       color: rgba(255, 255, 255, 0.82);
     }
@@ -157,7 +141,7 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       display: grid;
       place-items: center;
       box-sizing: border-box;
-      padding: 20px;
+      padding: 20px 20px 72px;
       overflow: hidden;
     }
 
@@ -169,8 +153,6 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       max-height: 100%;
       width: auto;
       height: auto;
-      border-radius: var(--radius-md);
-      background: rgba(255, 255, 255, 0.04);
       object-fit: contain;
       cursor: zoom-in;
       -webkit-user-drag: none;
@@ -181,15 +163,14 @@ class OpenClawImageLightbox extends OpenClawLitElement {
     }
 
     .zoom-controls {
-      justify-self: center;
+      position: fixed;
+      z-index: 1;
+      bottom: max(14px, calc(10px + var(--safe-area-bottom, 0px)));
+      left: 50%;
+      display: inline-flex;
+      align-items: center;
       gap: 4px;
-      margin-bottom: 14px;
-      padding: 4px;
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      border-radius: var(--radius-lg);
-      background: rgba(7, 9, 15, 0.82);
-      box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
-      backdrop-filter: blur(12px);
+      transform: translateX(-50%);
     }
 
     .zoom-control {
@@ -221,29 +202,16 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       .lightbox {
         width: 100vw;
         height: 100dvh;
-        border: 0;
-        border-radius: 0;
-      }
-
-      .header {
-        padding-top: calc(10px + var(--safe-area-top, 0px));
-        padding-right: calc(12px + var(--safe-area-right, 0px));
-        padding-left: calc(16px + var(--safe-area-left, 0px));
       }
 
       .stage {
-        padding: 0 calc(12px + var(--safe-area-right, 0px)) 0
-          calc(12px + var(--safe-area-left, 0px));
+        padding: 0 calc(12px + var(--safe-area-right, 0px))
+          calc(64px + var(--safe-area-bottom, 0px)) calc(12px + var(--safe-area-left, 0px));
       }
 
-      .close,
       .zoom-control {
         min-width: 44px;
         min-height: 44px;
-      }
-
-      .zoom-controls {
-        margin-bottom: calc(12px + var(--safe-area-bottom, 0px));
       }
     }
   `;

--- a/ui/src/components/image-lightbox.ts
+++ b/ui/src/components/image-lightbox.ts
@@ -34,7 +34,7 @@ function dataUrlMimeType(source: string): string | undefined {
 
 class OpenClawImageLightbox extends OpenClawLitElement {
   @property() src = "";
-  @property() override title = "";
+  @property({ attribute: false }) imageTitle = "";
   @query(".stage") private stage?: HTMLDivElement;
   @query(".image") private image?: HTMLImageElement;
   @queryAll(".action") private actions!: NodeListOf<HTMLElement>;
@@ -68,9 +68,30 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       overflow: hidden;
     }
 
-    .header,
-    .actions {
+    .header {
       display: contents;
+    }
+
+    .actions {
+      position: fixed;
+      z-index: 1;
+      top: max(16px, calc(12px + var(--safe-area-top, 0px)));
+      right: max(16px, calc(12px + var(--safe-area-right, 0px)));
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .actions .action {
+      border-radius: 999px;
+      background-color: color-mix(in srgb, var(--text) 10%, transparent);
+      -webkit-backdrop-filter: blur(12px);
+      backdrop-filter: blur(12px);
+      transition: background-color 180ms ease;
+    }
+
+    .actions .action:hover {
+      background-color: color-mix(in srgb, var(--text) 16%, transparent);
     }
 
     .title {
@@ -95,7 +116,7 @@ class OpenClawImageLightbox extends OpenClawLitElement {
     }
 
     .action:hover {
-      background: rgba(255, 255, 255, 0.1);
+      background: color-mix(in srgb, var(--text) 10%, transparent);
     }
 
     .action:focus-visible {
@@ -103,19 +124,19 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       outline-offset: 2px;
     }
 
-    .open-original,
-    .close {
-      position: fixed;
-      z-index: 1;
-      top: max(16px, calc(12px + var(--safe-area-top, 0px)));
+    .action:focus:not(:focus-visible) {
+      outline: none;
     }
 
     .open-original {
-      right: max(68px, calc(64px + var(--safe-area-right, 0px)));
+      min-height: 44px;
+    }
+
+    .open-original-icon {
+      display: none;
     }
 
     .close {
-      right: max(16px, calc(12px + var(--safe-area-right, 0px)));
       width: 44px;
       height: 44px;
       padding: 0;
@@ -178,7 +199,9 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       min-height: 40px;
       padding: 0 10px;
       border: 0;
-      background: transparent;
+      background: color-mix(in srgb, var(--text) 10%, transparent);
+      -webkit-backdrop-filter: blur(12px);
+      backdrop-filter: blur(12px);
       font-size: 15px;
     }
 
@@ -205,8 +228,26 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       }
 
       .stage {
-        padding: 0 calc(12px + var(--safe-area-right, 0px))
+        padding: calc(68px + var(--safe-area-top, 0px)) calc(12px + var(--safe-area-right, 0px))
           calc(64px + var(--safe-area-bottom, 0px)) calc(12px + var(--safe-area-left, 0px));
+      }
+
+      .open-original {
+        width: 44px;
+        padding: 0;
+      }
+
+      .open-original-label {
+        display: none;
+      }
+
+      .open-original-icon {
+        display: inline-flex;
+      }
+
+      .open-original-icon svg {
+        width: 17px;
+        height: 17px;
       }
 
       .zoom-control {
@@ -246,7 +287,7 @@ class OpenClawImageLightbox extends OpenClawLitElement {
   }
 
   override render() {
-    const title = this.title.trim() || t("chat.imageLightbox.untitled");
+    const title = this.imageTitle.trim() || t("chat.imageLightbox.untitled");
     const canZoom = this.imageReady && this.panzoom !== undefined;
     return html`
       <openclaw-modal-dialog
@@ -267,14 +308,18 @@ class OpenClawImageLightbox extends OpenClawLitElement {
                       target="_blank"
                       rel="noreferrer"
                     >
-                      ${t("chat.imageLightbox.openOriginal")}
+                      <span class="open-original-label">
+                        ${t("chat.imageLightbox.openOriginal")}
+                      </span>
+                      <span class="open-original-icon" aria-hidden="true">
+                        ${icons.externalLink}
+                      </span>
                     </a>
                   `
                 : nothing}
               <button
                 class="action close"
                 type="button"
-                autofocus
                 aria-label=${t("chat.imageLightbox.close")}
                 @click=${this.emitClose}
               >
@@ -282,7 +327,7 @@ class OpenClawImageLightbox extends OpenClawLitElement {
               </button>
             </div>
           </header>
-          <div class="stage" @dblclick=${this.handleDoubleClick}>
+          <div class="stage" @click=${this.handleStageClick} @dblclick=${this.handleDoubleClick}>
             <img
               class=${this.scale > 1 ? "image zoomed" : "image"}
               src=${this.src}
@@ -408,6 +453,12 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       return;
     }
     this.panzoom?.zoomToPoint(DOUBLE_TAP_SCALE, event);
+  };
+
+  private handleStageClick = (event: MouseEvent) => {
+    if (event.target === event.currentTarget) {
+      this.emitClose();
+    }
   };
 
   private zoomIn = () => this.panzoom?.zoomIn();

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -35,7 +35,7 @@ export class OpenClawModalDialog extends OpenClawLitElement {
     wa-dialog {
       --width: min(var(--openclaw-modal-width, 540px), calc(100vw - 48px));
       --spacing: 0;
-      --backdrop-filter: blur(4px);
+      --backdrop-filter: var(--openclaw-modal-backdrop-filter, blur(4px));
     }
 
     wa-dialog::part(dialog) {

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -62,6 +62,23 @@ export class OpenClawModalDialog extends OpenClawLitElement {
       max-height: calc(100dvh - 20px);
     }
 
+    :host(.viewport-edge-to-edge) wa-dialog {
+      --width: 100vw;
+    }
+
+    :host(.viewport-edge-to-edge) wa-dialog::part(dialog) {
+      width: 100vw;
+      height: 100dvh;
+      max-width: none;
+      max-height: none;
+      margin: 0;
+      border-radius: 0;
+    }
+
+    :host(.viewport-edge-to-edge) wa-dialog::part(body) {
+      height: 100%;
+    }
+
     :host(.palette) wa-dialog::part(dialog) {
       margin-block-start: min(20dvh, 160px);
       margin-block-end: auto;

--- a/ui/src/e2e/chat-image-lightbox.e2e.test.ts
+++ b/ui/src/e2e/chat-image-lightbox.e2e.test.ts
@@ -167,8 +167,11 @@ describeControlUiE2e("Control UI image lightbox", () => {
         .toBeGreaterThan(0);
       await waitForLightboxAnimations(page);
       const desktopBox = await page.locator("openclaw-image-lightbox .lightbox").boundingBox();
-      expect(desktopBox?.width ?? 0).toBeGreaterThan(1000);
-      expect(desktopBox?.height ?? 0).toBeGreaterThan(700);
+      const viewport = page.viewportSize();
+      expect(desktopBox?.x).toBe(0);
+      expect(desktopBox?.y).toBe(0);
+      expect(desktopBox?.width).toBe(viewport?.width);
+      expect(desktopBox?.height).toBe(viewport?.height);
       const originalPopup = page.waitForEvent("popup");
       await openOriginal.click();
       const originalPage = await originalPopup;

--- a/ui/src/e2e/chat-image-lightbox.e2e.test.ts
+++ b/ui/src/e2e/chat-image-lightbox.e2e.test.ts
@@ -135,7 +135,7 @@ describeControlUiE2e("Control UI image lightbox", () => {
       const dialog = page.getByRole("dialog", { name: "Image preview: OpenClaw banner" });
       await dialog.waitFor({ state: "visible" });
       const closeButton = page.getByRole("button", { name: "Close image preview" });
-      const openOriginal = page.getByRole("link", { name: "Open original" });
+      const openOriginal = page.getByRole("link", { name: "Open in new tab" });
       await openOriginal.waitFor({ state: "visible" });
       await expect.poll(() => openOriginal.getAttribute("href")).toMatch(/^blob:/);
       const focusIsInsideLightbox = () =>

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -279,7 +279,8 @@ suite.define(() => {
       const lightbox = page.locator("openclaw-image-lightbox");
       const dialog = page.getByRole("dialog", { name: "Image preview: favicon-32.png" });
       await dialog.waitFor({ state: "visible" });
-      await expect(lightbox.getAttribute("title")).resolves.toBe("favicon-32.png");
+      await expect(lightbox.getAttribute("title")).resolves.toBeNull();
+      await page.getByAltText("favicon-32.png").last().waitFor({ state: "visible" });
       await captureUiProof(page, "new-session-picked-image-lightbox.png");
       await page.keyboard.press("Escape");
       await lightbox.waitFor({ state: "detached" });
@@ -309,7 +310,7 @@ suite.define(() => {
       await expect.poll(() => previewButton.locator("img").getAttribute("src")).toMatch(/^blob:/u);
       await previewButton.click();
       await page.getByRole("dialog", { name: "Image preview: untrusted.svg" }).waitFor();
-      await expect(page.getByRole("link", { name: "Open original" }).count()).resolves.toBe(0);
+      await expect(page.getByRole("link", { name: "Open in new tab" }).count()).resolves.toBe(0);
       await captureUiProof(page, "new-session-svg-lightbox.png");
     });
   });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5717,7 +5717,7 @@ export const en: TranslationMap = {
     imageLightbox: {
       label: "Image preview: {title}",
       open: "Open image {title}",
-      openOriginal: "Open original",
+      openOriginal: "Open in new tab",
       copy: "Copy image",
       download: "Download image",
       copyFailed: "Could not copy this image. Check clipboard access and try again.",

--- a/ui/src/pages/chat/components/chat-image-lightbox.ts
+++ b/ui/src/pages/chat/components/chat-image-lightbox.ts
@@ -56,7 +56,7 @@ export function renderChatImageLightbox(
   return html`
     <openclaw-image-lightbox
       src=${item.src}
-      title=${item.title}
+      .imageTitle=${item.title}
       @image-lightbox-close=${onClose}
     ></openclaw-image-lightbox>
   `;

--- a/ui/src/pages/chat/components/chat-message-images.ts
+++ b/ui/src/pages/chat/components/chat-message-images.ts
@@ -211,7 +211,10 @@ export function renderMessageImages(images: RenderableImageBlock[], opts?: Image
           type="button"
           class="chat-message-image-button"
           aria-label=${t("chat.imageLightbox.open", { title })}
-          @click=${() => openImage(img, previewUrl)}
+          @click=${(event: MouseEvent) => {
+            event.stopPropagation();
+            openImage(img, previewUrl);
+          }}
         >
           <img
             src=${previewUrl}

--- a/ui/src/pages/chat/components/chat-message-images.ts
+++ b/ui/src/pages/chat/components/chat-message-images.ts
@@ -531,7 +531,7 @@ function renderManagedImageActions(
       <button
         type="button"
         class="chat-image-action"
-        title=${t("chat.imageLightbox.openOriginal")}
+        title=${t("chat.imageLightbox.open", { title })}
         aria-label=${t("chat.imageLightbox.open", { title })}
         @click=${onOpen}
       >


### PR DESCRIPTION
Closes #129989

## What Problem This Solves

Opening an image from chat currently puts the media inside a large viewer card. The header, frame, and toolbar compete with the image and make the preview feel heavier than the action warrants, especially on narrow screens.

## Why This Change Was Made

This PR keeps the existing lightbox and Panzoom implementation intact while simplifying only its presentation:

- removes the card frame, title bar, border, and toolbar chrome;
- uses a dark backdrop without blur so the image remains the clear focal point;
- keeps the original-image action and close control aligned at the top-right;
- uses theme-aware design tokens for the translucent control surfaces, with a short background transition;
- keeps zoom controls centered at the bottom;
- reserves top space on narrow screens and collapses “Open in new tab” to an accessible external-link icon.

The existing zoom, pan, wheel/pinch, double-click, keyboard, original-image safety, and focus/modal behavior stay on the existing implementation rather than being rewritten.

## User Impact

Chat images open directly against a calm full-viewport overlay. The image remains fully visible, the X stays in the top-right, and zoom remains available through the existing controls and keyboard shortcuts. Clicking outside the image closes the preview; clicking the image itself does not. Accessible names remain available through `alt` and `aria-label` without leaking native `title` tooltips.

## Evidence

All frames use the same fully loaded “Tall portrait” image. The image reached its final rendered state (`naturalWidth: 471`, `opacity: 1`) before capture, and every PNG below was opened and inspected after capture.

### Desktop — dark

<table>
  <tr>
    <th>Before — current main</th>
    <th>After — this PR head</th>
  </tr>
  <tr>
    <td><img width="720" alt="Current main dark image lightbox with large card chrome" src="https://github.com/user-attachments/assets/c72468cf-0a31-4a56-a2f7-eee23f349bd3" /></td>
    <td><img width="720" alt="This PR dark image lightbox with clean image and floating controls" src="https://github.com/user-attachments/assets/d95bde90-dbf4-4b1d-9b36-b7f536590766" /></td>
  </tr>
</table>

### Desktop — light

<table>
  <tr>
    <th>Before — current main</th>
    <th>After — this PR head</th>
  </tr>
  <tr>
    <td><img width="720" alt="Current main light image lightbox with large card chrome" src="https://github.com/user-attachments/assets/4f95181a-18ea-4d62-898b-514f44de5f38" /></td>
    <td><img width="720" alt="This PR light image lightbox with clean image and theme-aware controls" src="https://github.com/user-attachments/assets/15737334-f5b3-4704-ba31-c259095b983f" /></td>
  </tr>
</table>

### Mobile — dark, 390 × 844

<table>
  <tr>
    <th>Before — current main</th>
    <th>After — this PR head</th>
  </tr>
  <tr>
    <td><img width="390" alt="Current main narrow image lightbox with card header" src="https://github.com/user-attachments/assets/5331bc2a-0355-4753-94b4-910a55052eee" /></td>
    <td><img width="390" alt="This PR narrow image lightbox with reserved top space and icon-only external action" src="https://github.com/user-attachments/assets/8cbbb9e7-a658-4019-95cf-7c179769a490" /></td>
  </tr>
</table>

- Before: `origin/main` at `ee2f5f2084d4bdf314ba8a258b5457410098b148`
- After: PR head at `9ee39e5a5a6e2a27ab088612970b4564c4a34e09`
- Local test/CI gates were intentionally not run for this closeout; the external lander owns the required gates.
