### PR TITLE
fix(subagents): a completed subagent does not wake an idle parent until someone sends a message

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-delivery.runtime.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.runtime.test.ts
@@ -94,9 +94,15 @@ describe("subagent announce Gateway instance dispatch", () => {
       summary: "delivered",
     });
   });
-  it("rejects a retired nested-wake owner before a live replacement Gateway dispatch", async () => {
+  it("rejects a nested-wake owner retired after selection before either Gateway dispatches", async () => {
+    const retiredAgent = vi.fn(({ respond }) => respond(true, { raw: true }));
+    const retiredContext = createContext({ agent: retiredAgent });
     const replacementAgent = vi.fn(({ respond }) => respond(true, { raw: true }));
     const replacementContext = createContext({ agent: replacementAgent });
+    const resolveGatewayContext = vi
+      .fn<() => GatewayRequestContext | undefined>()
+      .mockReturnValueOnce(retiredContext)
+      .mockReturnValue(undefined);
 
     await withPluginRuntimeGatewayContextResolver(
       () => replacementContext,
@@ -110,12 +116,14 @@ describe("subagent announce Gateway instance dispatch", () => {
             },
             {
               forceSyntheticClient: true,
-              resolveGatewayContext: () => undefined,
+              resolveGatewayContext,
             },
           ),
         ).rejects.toThrow("Gateway instance lifecycle dispatch unavailable for agent");
       },
     );
+    expect(resolveGatewayContext).toHaveBeenCalledTimes(2);
+    expect(retiredAgent).not.toHaveBeenCalled();
     expect(replacementAgent).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/subagents/announce/subagent-announce-delivery.runtime.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.runtime.test.ts
@@ -119,7 +119,7 @@ describe("subagent announce Gateway instance dispatch", () => {
               resolveGatewayContext,
             },
           ),
-        ).rejects.toThrow("Gateway instance lifecycle dispatch unavailable for agent");
+        ).rejects.toThrow("current gateway instance binding");
       },
     );
     expect(resolveGatewayContext).toHaveBeenCalledTimes(2);

--- a/src/agents/subagents/announce/subagent-announce-delivery.runtime.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.runtime.test.ts
@@ -5,6 +5,7 @@ import type {
   GatewayRequestContext,
   GatewayRequestHandlers,
 } from "../../../gateway/server-methods/types.js";
+import { dispatchGatewayMethodInProcess } from "../../../gateway/server-plugin-in-process-dispatch.js";
 import { withPluginRuntimeGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
 import { dispatchSubagentAnnounceAgent } from "./subagent-announce-delivery.runtime.js";
 
@@ -92,5 +93,29 @@ describe("subagent announce Gateway instance dispatch", () => {
       status: "ok",
       summary: "delivered",
     });
+  });
+  it("rejects a retired nested-wake owner before a live replacement Gateway dispatch", async () => {
+    const replacementAgent = vi.fn(({ respond }) => respond(true, { raw: true }));
+    const replacementContext = createContext({ agent: replacementAgent });
+
+    await withPluginRuntimeGatewayContextResolver(
+      () => replacementContext,
+      async () => {
+        await expect(
+          dispatchGatewayMethodInProcess(
+            "agent",
+            {
+              message: "Continue after nested descendants settle.",
+              idempotencyKey: "retired-nested-wake",
+            },
+            {
+              forceSyntheticClient: true,
+              resolveGatewayContext: () => undefined,
+            },
+          ),
+        ).rejects.toThrow("Gateway instance lifecycle dispatch unavailable for agent");
+      },
+    );
+    expect(replacementAgent).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -5,6 +5,7 @@ import type { SessionEntry } from "../../../config/sessions.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { callGateway as runtimeCallGateway } from "../../../gateway/call.js";
 import { authorizeGatewaySessionCreation } from "../../../gateway/operator-role-policy.js";
+import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
 import type { dispatchGatewayMethodInProcess as runtimeDispatchGatewayMethodInProcess } from "../../../gateway/server-plugins.js";
 import {
   OutboundDeliveryError,
@@ -1996,6 +1997,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     const { cfg, dispatchGatewayMethodInProcess } = createRoleRestrictedInProcessGatewayMock({
       runId: "descendant-wake-run",
     });
+    const resolveGatewayContext: GatewayContextResolver = () => undefined;
     const replaceSubagentRunAfterSteer = vi.fn(async () => true);
     testing.setDepsForTest({
       getRuntimeConfig: () => cfg,
@@ -2011,6 +2013,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       isChildSessionEffectsAllowed: () => true,
       hasUsableSessionEntry: (entry): entry is Record<string, unknown> =>
         typeof entry === "object" && entry !== null,
+      resolveGatewayContext,
       deps: {
         callGateway: createGatewayMock(),
         dispatchGatewayMethodInProcess,
@@ -2020,6 +2023,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
 
     expect(woke).toBe(true);
+    expect(mockCallArg(dispatchGatewayMethodInProcess, 0, 2)).toMatchObject({
+      resolveGatewayContext,
+    });
     expect(replaceSubagentRunAfterSteer).toHaveBeenCalledWith(
       expect.objectContaining({
         previousRunId: "nested-parent-run",

--- a/src/agents/subagents/announce/subagent-announce-descendant-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce-descendant-wake.ts
@@ -1,6 +1,7 @@
 // Descendant-settle wake replaces an ended nested orchestrator run while
 // preserving lifecycle ownership.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
 import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../../utils/message-channel.js";
 import { buildAnnounceIdempotencyKey } from "../../announce-idempotency.js";
@@ -64,6 +65,7 @@ export async function runDescendantWake(params: {
   isChildSessionEffectsAllowed: () => boolean;
   hasUsableSessionEntry: UsableSessionEntryGuard;
   deps: DescendantWakeDeps;
+  resolveGatewayContext?: GatewayContextResolver;
   signal?: AbortSignal;
 }): Promise<boolean> {
   if (
@@ -111,6 +113,7 @@ export async function runDescendantWake(params: {
           {
             operatorRoleActor: { kind: "system" },
             timeoutMs: announceTimeoutMs,
+            resolveGatewayContext: params.resolveGatewayContext,
           },
         );
       },

--- a/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
@@ -14,6 +14,7 @@ import * as configSessions from "../../../config/sessions.js";
 import { patchSessionEntryCore } from "../../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import * as gatewayCall from "../../../gateway/call.js";
+import type { dispatchGatewayMethodInProcess as dispatchGatewayMethodInProcessRuntime } from "../../../gateway/server-plugin-in-process-dispatch.js";
 import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
 import {
   testing as sessionBindingServiceTesting,
@@ -34,6 +35,7 @@ import {
 import * as embeddedRuns from "../../embedded-agent-runner/runs.js";
 import { FailoverError } from "../../failover-error.js";
 import { testing as subagentAnnounceDeliveryTesting } from "./subagent-announce-delivery.test-support.js";
+import type { runDescendantWake as runDescendantWakeRuntime } from "./subagent-announce-descendant-wake.js";
 import { runSubagentAnnounceDispatch } from "./subagent-announce-dispatch.js";
 import { testing as subagentAnnounceOutputTesting } from "./subagent-announce-output.test-support.js";
 
@@ -347,6 +349,7 @@ describe("subagent announce formatting", () => {
   let previousFastTestEnv: string | undefined;
   let runSubagentAnnounceFlow: (typeof import("./subagent-announce.js"))["runSubagentAnnounceFlow"];
   let subagentAnnounceTesting: (typeof import("./subagent-announce.js"))["testing"];
+  let runDescendantWake: typeof runDescendantWakeRuntime;
 
   beforeAll(async () => {
     // Set FAST_TEST_MODE before importing the module to ensure the module-level
@@ -357,6 +360,7 @@ describe("subagent announce formatting", () => {
     process.env.OPENCLAW_TEST_FAST = "1";
     ({ runSubagentAnnounceFlow, testing: subagentAnnounceTesting } =
       await import("./subagent-announce.js"));
+    ({ runDescendantWake } = await import("./subagent-announce-descendant-wake.js"));
   });
 
   afterAll(() => {
@@ -2880,6 +2884,55 @@ describe("subagent announce formatting", () => {
     expect(msg).not.toContain("stale old parent result");
     expect(msg).toContain("old parent fallback reply");
   });
+
+  it.each([
+    { label: "active", ownerAvailable: true, expectedWake: true },
+    { label: "retired", ownerAvailable: false, expectedWake: false },
+  ])(
+    "uses the detached nested parent's $label Gateway owner",
+    async ({ ownerAvailable, expectedWake }) => {
+      sessionStore = {
+        "agent:main:subagent:parent": {
+          sessionId: "session-parent",
+        },
+      };
+      const ownerContext = { owner: "gateway-a" } as never;
+      const resolveGatewayContext = vi.fn(() => (ownerAvailable ? ownerContext : undefined));
+      const acceptedWake = vi.fn(async () => visibleAgentResponse("run-parent-phase-2"));
+      const dispatchGatewayMethodInProcess = vi.fn<typeof dispatchGatewayMethodInProcessRuntime>(
+        async <T>(_method, _params, options) => {
+          expect(options?.resolveGatewayContext).toBe(resolveGatewayContext);
+          if (!options?.resolveGatewayContext?.()) {
+            throw new Error("Gateway instance lifecycle dispatch unavailable for agent");
+          }
+          return (await acceptedWake()) as T;
+        },
+      );
+      const replaceSubagentRunAfterSteer = vi.fn(async () => true);
+
+      const woke = await runDescendantWake({
+        runId: "run-parent-phase-1",
+        childSessionKey: "agent:main:subagent:parent",
+        taskLabel: "parent task",
+        findings: "child result",
+        announceId: "announce-parent",
+        isChildSessionEffectsAllowed: () => true,
+        hasUsableSessionEntry: (entry): entry is Record<string, unknown> =>
+          typeof entry === "object" && entry !== null,
+        resolveGatewayContext,
+        deps: {
+          callGateway: callGatewaySpy,
+          dispatchGatewayMethodInProcess,
+          getRuntimeConfig: () => configOverride,
+          replaceSubagentRunAfterSteer,
+        },
+      });
+
+      expect(woke).toBe(expectedWake);
+      expect(acceptedWake).toHaveBeenCalledTimes(ownerAvailable ? 1 : 0);
+      expect(replaceSubagentRunAfterSteer).toHaveBeenCalledTimes(ownerAvailable ? 1 : 0);
+    },
+  );
 
   it("wakes an ended orchestrator run with settled child results before any upward announce", async () => {
     sessionStore = {

--- a/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
@@ -14,7 +14,6 @@ import * as configSessions from "../../../config/sessions.js";
 import { patchSessionEntryCore } from "../../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import * as gatewayCall from "../../../gateway/call.js";
-import type { dispatchGatewayMethodInProcess as dispatchGatewayMethodInProcessRuntime } from "../../../gateway/server-plugin-in-process-dispatch.js";
 import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
 import {
   testing as sessionBindingServiceTesting,
@@ -35,7 +34,6 @@ import {
 import * as embeddedRuns from "../../embedded-agent-runner/runs.js";
 import { FailoverError } from "../../failover-error.js";
 import { testing as subagentAnnounceDeliveryTesting } from "./subagent-announce-delivery.test-support.js";
-import type { runDescendantWake as runDescendantWakeRuntime } from "./subagent-announce-descendant-wake.js";
 import { runSubagentAnnounceDispatch } from "./subagent-announce-dispatch.js";
 import { testing as subagentAnnounceOutputTesting } from "./subagent-announce-output.test-support.js";
 
@@ -349,7 +347,6 @@ describe("subagent announce formatting", () => {
   let previousFastTestEnv: string | undefined;
   let runSubagentAnnounceFlow: (typeof import("./subagent-announce.js"))["runSubagentAnnounceFlow"];
   let subagentAnnounceTesting: (typeof import("./subagent-announce.js"))["testing"];
-  let runDescendantWake: typeof runDescendantWakeRuntime;
 
   beforeAll(async () => {
     // Set FAST_TEST_MODE before importing the module to ensure the module-level
@@ -360,7 +357,6 @@ describe("subagent announce formatting", () => {
     process.env.OPENCLAW_TEST_FAST = "1";
     ({ runSubagentAnnounceFlow, testing: subagentAnnounceTesting } =
       await import("./subagent-announce.js"));
-    ({ runDescendantWake } = await import("./subagent-announce-descendant-wake.js"));
   });
 
   afterAll(() => {
@@ -2884,55 +2880,6 @@ describe("subagent announce formatting", () => {
     expect(msg).not.toContain("stale old parent result");
     expect(msg).toContain("old parent fallback reply");
   });
-
-  it.each([
-    { label: "active", ownerAvailable: true, expectedWake: true },
-    { label: "retired", ownerAvailable: false, expectedWake: false },
-  ])(
-    "uses the detached nested parent's $label Gateway owner",
-    async ({ ownerAvailable, expectedWake }) => {
-      sessionStore = {
-        "agent:main:subagent:parent": {
-          sessionId: "session-parent",
-        },
-      };
-      const ownerContext = { owner: "gateway-a" } as never;
-      const resolveGatewayContext = vi.fn(() => (ownerAvailable ? ownerContext : undefined));
-      const acceptedWake = vi.fn(async () => visibleAgentResponse("run-parent-phase-2"));
-      const dispatchGatewayMethodInProcess = vi.fn<typeof dispatchGatewayMethodInProcessRuntime>(
-        async <T>(_method, _params, options) => {
-          expect(options?.resolveGatewayContext).toBe(resolveGatewayContext);
-          if (!options?.resolveGatewayContext?.()) {
-            throw new Error("Gateway instance lifecycle dispatch unavailable for agent");
-          }
-          return (await acceptedWake()) as T;
-        },
-      );
-      const replaceSubagentRunAfterSteer = vi.fn(async () => true);
-
-      const woke = await runDescendantWake({
-        runId: "run-parent-phase-1",
-        childSessionKey: "agent:main:subagent:parent",
-        taskLabel: "parent task",
-        findings: "child result",
-        announceId: "announce-parent",
-        isChildSessionEffectsAllowed: () => true,
-        hasUsableSessionEntry: (entry): entry is Record<string, unknown> =>
-          typeof entry === "object" && entry !== null,
-        resolveGatewayContext,
-        deps: {
-          callGateway: callGatewaySpy,
-          dispatchGatewayMethodInProcess,
-          getRuntimeConfig: () => configOverride,
-          replaceSubagentRunAfterSteer,
-        },
-      });
-
-      expect(woke).toBe(expectedWake);
-      expect(acceptedWake).toHaveBeenCalledTimes(ownerAvailable ? 1 : 0);
-      expect(replaceSubagentRunAfterSteer).toHaveBeenCalledTimes(ownerAvailable ? 1 : 0);
-    },
-  );
 
   it("wakes an ended orchestrator run with settled child results before any upward announce", async () => {
     sessionStore = {

--- a/src/agents/subagents/announce/subagent-announce.ts
+++ b/src/agents/subagents/announce/subagent-announce.ts
@@ -323,6 +323,7 @@ export async function runSubagentAnnounceFlow(params: {
         announceId,
         isChildSessionEffectsAllowed: childSessionEffectsAllowed,
         hasUsableSessionEntry,
+        resolveGatewayContext: params.resolveGatewayContext,
         deps: {
           callGateway: subagentAnnounceDeps.callGateway,
           dispatchGatewayMethodInProcess: subagentAnnounceDeps.dispatchGatewayMethodInProcess,

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -609,13 +609,9 @@ export const startSubagentAnnounceCleanupFlow = (
         params.persist(runId);
       }
     },
-    // A completion that lands while the requester is idle runs outside any
-    // gateway request scope, so the per-entry binding is the only context the
-    // direct handoff can use. Fall back to the instance resolver captured at
-    // registry activation when the entry carries none, otherwise the dispatch
-    // throws and delivery silently degrades to the steering queue.
-    resolveGatewayContext:
-      getGatewayContextResolver(entry) ?? params.getInstanceGatewayContextResolver?.(),
+    // Idle completion has no ambient request scope. Missing entry ownership
+    // fails closed instead of widening authority to another live Gateway.
+    resolveGatewayContext: getGatewayContextResolver(entry),
   };
   runDetachedCleanupAttempt(context, {
     runId,

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -609,7 +609,13 @@ export const startSubagentAnnounceCleanupFlow = (
         params.persist(runId);
       }
     },
-    resolveGatewayContext: getGatewayContextResolver(entry),
+    // A completion that lands while the requester is idle runs outside any
+    // gateway request scope, so the per-entry binding is the only context the
+    // direct handoff can use. Fall back to the instance resolver captured at
+    // registry activation when the entry carries none, otherwise the dispatch
+    // throws and delivery silently degrades to the steering queue.
+    resolveGatewayContext:
+      getGatewayContextResolver(entry) ?? params.getInstanceGatewayContextResolver?.(),
   };
   runDetachedCleanupAttempt(context, {
     runId,

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-context.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-context.ts
@@ -1,5 +1,6 @@
 // This type-only leaf exists solely to keep lifecycle sibling modules from importing the controller.
 // Keeping the controller out of their dependency graph satisfies the architecture cycle gate.
+import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
 import type { cleanupBrowserSessionsForLifecycleEnd } from "../../../browser-lifecycle-cleanup.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { callGateway as defaultCallGateway } from "../../../gateway/call.js";
@@ -54,6 +55,12 @@ export type SubagentLifecycleOptions = {
   cleanupBrowserSessionsForLifecycleEnd?: BrowserCleanup;
   loadCleanupBrowserSessionsForLifecycleEnd?: () => Promise<BrowserCleanup>;
   runSubagentAnnounceFlow: RunSubagentAnnounceFlow;
+  /**
+   * Gateway-instance context resolver captured at registry activation. A
+   * completion that lands while the requester is idle has no ambient request
+   * scope, so without this the direct handoff cannot dispatch at all.
+   */
+  getInstanceGatewayContextResolver?: () => GatewayContextResolver | undefined;
   maybeWakeRequesterAfterAllChildrenSettled: MaybeWakeRequesterAfterAllChildrenSettled;
   warn(message: string, meta?: Record<string, unknown>): void;
 };

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-context.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-context.ts
@@ -3,7 +3,6 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { callGateway as defaultCallGateway } from "../../../gateway/call.js";
 // This type-only leaf exists solely to keep lifecycle sibling modules from importing the controller.
 // Keeping the controller out of their dependency graph satisfies the architecture cycle gate.
-import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
 import type { DetachedTaskFindResult } from "../../../tasks/detached-task-runtime-contract.js";
 import type { SubagentLifecycleEndedReason } from "./subagent-lifecycle-events.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
@@ -55,12 +54,6 @@ export type SubagentLifecycleOptions = {
   cleanupBrowserSessionsForLifecycleEnd?: BrowserCleanup;
   loadCleanupBrowserSessionsForLifecycleEnd?: () => Promise<BrowserCleanup>;
   runSubagentAnnounceFlow: RunSubagentAnnounceFlow;
-  /**
-   * Gateway-instance context resolver captured at registry activation. A
-   * completion that lands while the requester is idle has no ambient request
-   * scope, so without this the direct handoff cannot dispatch at all.
-   */
-  getInstanceGatewayContextResolver?: () => GatewayContextResolver | undefined;
   maybeWakeRequesterAfterAllChildrenSettled: MaybeWakeRequesterAfterAllChildrenSettled;
   warn(message: string, meta?: Record<string, unknown>): void;
 };

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-context.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-context.ts
@@ -1,9 +1,9 @@
-// This type-only leaf exists solely to keep lifecycle sibling modules from importing the controller.
-// Keeping the controller out of their dependency graph satisfies the architecture cycle gate.
-import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
 import type { cleanupBrowserSessionsForLifecycleEnd } from "../../../browser-lifecycle-cleanup.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { callGateway as defaultCallGateway } from "../../../gateway/call.js";
+// This type-only leaf exists solely to keep lifecycle sibling modules from importing the controller.
+// Keeping the controller out of their dependency graph satisfies the architecture cycle gate.
+import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
 import type { DetachedTaskFindResult } from "../../../tasks/detached-task-runtime-contract.js";
 import type { SubagentLifecycleEndedReason } from "./subagent-lifecycle-events.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -1,5 +1,7 @@
 // Subagent registry lifecycle tests cover completion, cleanup, announce retry,
 // detached task status, and resource retirement around child-run endings.
+import { fenceScheduledGatewayContextResolver } from "../../../gateway/scheduled-run-gateway-context.js";
+import type { GatewayRequestContext } from "../../../gateway/server-methods/types.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveSessionStorePathForScope } from "../../../config/sessions/session-store-path.js";
 import {
@@ -555,6 +557,42 @@ describe("subagent registry lifecycle hardening", () => {
       expect(runSubagentAnnounceFlow).toHaveBeenCalledWith(
         expect.objectContaining({ terminalReply }),
       );
+    },
+  );
+
+  it.each([
+    { label: "live instance", retired: false },
+    { label: "retired instance", retired: true },
+  ])(
+    "resolves the announce gateway context from a $label when the entry carries none",
+    async ({ retired }) => {
+      // A completion that lands while the requester is idle has no ambient
+      // gateway request scope, so the instance resolver is the only context the
+      // direct handoff can use. It must be fenced: the process-wide holder is
+      // not cleared on shutdown, and dispatching against a retired instance is
+      // worse than failing visibly.
+      const entry = createRunEntry({ expectsCompletionMessage: true });
+      const liveContext = { marker: "live-context" };
+      const instanceContext = {
+        resolveGatewayContext: () => (retired ? undefined : liveContext),
+      };
+      const runSubagentAnnounceFlow = vi.fn(
+        async (_announceParams: { resolveGatewayContext?: () => unknown }) =>
+          "delivered" as AnnounceFlowOutcome,
+      );
+      const controller = createLifecycleController({
+        entry,
+        runSubagentAnnounceFlow,
+        getInstanceGatewayContextResolver: () =>
+          fenceScheduledGatewayContextResolver(
+            () => instanceContext as unknown as GatewayRequestContext,
+          ),
+      });
+
+      await completeRun(controller, entry, { triggerCleanup: true });
+
+      const announceParams = runSubagentAnnounceFlow.mock.calls[0]?.[0];
+      expect(announceParams?.resolveGatewayContext?.()).toBe(retired ? undefined : liveContext);
     },
   );
 

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -1,7 +1,3 @@
-// Subagent registry lifecycle tests cover completion, cleanup, announce retry,
-// detached task status, and resource retirement around child-run endings.
-import { fenceScheduledGatewayContextResolver } from "../../../gateway/scheduled-run-gateway-context.js";
-import type { GatewayRequestContext } from "../../../gateway/server-methods/types.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveSessionStorePathForScope } from "../../../config/sessions/session-store-path.js";
 import {
@@ -9,6 +5,10 @@ import {
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
 import type { CallGatewayOptions } from "../../../gateway/call.js";
+// Subagent registry lifecycle tests cover completion, cleanup, announce retry,
+// detached task status, and resource retirement around child-run endings.
+import { fenceScheduledGatewayContextResolver } from "../../../gateway/scheduled-run-gateway-context.js";
+import type { GatewayRequestContext } from "../../../gateway/server-methods/types.js";
 import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
 import {
   getActiveGatewayRootWorkCount,

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -5,11 +5,10 @@ import {
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
 import type { CallGatewayOptions } from "../../../gateway/call.js";
+import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
 // Subagent registry lifecycle tests cover completion, cleanup, announce retry,
 // detached task status, and resource retirement around child-run endings.
-import { fenceScheduledGatewayContextResolver } from "../../../gateway/scheduled-run-gateway-context.js";
-import type { GatewayRequestContext } from "../../../gateway/server-methods/types.js";
-import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
+import { bindGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
 import {
   getActiveGatewayRootWorkCount,
   markGatewayRestartDraining,
@@ -561,40 +560,31 @@ describe("subagent registry lifecycle hardening", () => {
   );
 
   it.each([
-    { label: "live instance", retired: false },
-    { label: "retired instance", retired: true },
-  ])(
-    "resolves the announce gateway context from a $label when the entry carries none",
-    async ({ retired }) => {
-      // A completion that lands while the requester is idle has no ambient
-      // gateway request scope, so the instance resolver is the only context the
-      // direct handoff can use. It must be fenced: the process-wide holder is
-      // not cleared on shutdown, and dispatching against a retired instance is
-      // worse than failing visibly.
-      const entry = createRunEntry({ expectsCompletionMessage: true });
-      const liveContext = { marker: "live-context" };
-      const instanceContext = {
-        resolveGatewayContext: () => (retired ? undefined : liveContext),
-      };
-      const runSubagentAnnounceFlow = vi.fn(
-        async (_announceParams: { resolveGatewayContext?: () => unknown }) =>
-          "delivered" as AnnounceFlowOutcome,
-      );
-      const controller = createLifecycleController({
-        entry,
-        runSubagentAnnounceFlow,
-        getInstanceGatewayContextResolver: () =>
-          fenceScheduledGatewayContextResolver(
-            () => instanceContext as unknown as GatewayRequestContext,
-          ),
-      });
+    { label: "bound", hasOwner: true },
+    { label: "unbound", hasOwner: false },
+  ])("uses only the $label run owner for announce dispatch", async ({ hasOwner }) => {
+    const entry = createRunEntry({ expectsCompletionMessage: true });
+    const liveContext = { marker: "live-context" };
+    const resolveGatewayContext = () => liveContext;
+    if (hasOwner) {
+      bindGatewayContextResolver(entry, resolveGatewayContext as never);
+    }
+    const runSubagentAnnounceFlow = vi.fn(
+      async (_announceParams: { resolveGatewayContext?: () => unknown }) =>
+        "delivered" as AnnounceFlowOutcome,
+    );
+    const controller = createLifecycleController({
+      entry,
+      runSubagentAnnounceFlow,
+    });
 
-      await completeRun(controller, entry, { triggerCleanup: true });
+    await completeRun(controller, entry, { triggerCleanup: true });
 
-      const announceParams = runSubagentAnnounceFlow.mock.calls[0]?.[0];
-      expect(announceParams?.resolveGatewayContext?.()).toBe(retired ? undefined : liveContext);
-    },
-  );
+    const announceParams = runSubagentAnnounceFlow.mock.calls[0]?.[0];
+    expect(announceParams?.resolveGatewayContext).toBe(
+      hasOwner ? resolveGatewayContext : undefined,
+    );
+  });
 
   it("merges late visible reply evidence into an already-terminal completion", async () => {
     const entry = createRunEntry({ expectsCompletionMessage: true });

--- a/src/agents/subagents/registry/subagent-registry.persistence.resume.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.persistence.resume.test.ts
@@ -321,14 +321,22 @@ describe("subagent registry persistence resume", () => {
         sendRecoveryNotice: vi.fn(),
       };
       let firstLifecycleOpen = true;
-      const resolveGatewayContext = vi.fn(() =>
-        firstLifecycleOpen ? ({ recoveryRuntime } as never) : undefined,
+      const gatewayContext = {
+        recoveryRuntime,
+        resolveGatewayContext: vi.fn(),
+      };
+      gatewayContext.resolveGatewayContext.mockImplementation(() =>
+        firstLifecycleOpen ? (gatewayContext as never) : undefined,
       );
+      const resolveGatewayContext = vi.fn(() => gatewayContext as never);
       mod.activateSubagentRegistry(resolveGatewayContext);
       mod.activateSubagentRegistry(resolveGatewayContext);
       const restoredRun = mod.getSubagentRunByRunId(runningRun.runId);
       expect(restoredRun).toBeDefined();
-      expect(getGatewayContextResolver(restoredRun!)).toBe(resolveGatewayContext);
+      const restoredGatewayContextResolver = getGatewayContextResolver(restoredRun!);
+      expect(restoredGatewayContextResolver).toBeDefined();
+      expect(restoredGatewayContextResolver).not.toBe(resolveGatewayContext);
+      expect(restoredGatewayContextResolver?.()).toBe(gatewayContext);
 
       await vi.waitFor(() => {
         expect(wakeRequester).toHaveBeenCalledOnce();
@@ -340,7 +348,9 @@ describe("subagent registry persistence resume", () => {
       );
 
       firstLifecycleOpen = false;
-      expect(resolveGatewayContext()).toBeUndefined();
+      expect(resolveGatewayContext()).toBe(gatewayContext);
+      expect(gatewayContext.resolveGatewayContext()).toBeUndefined();
+      expect(restoredGatewayContextResolver?.()).toBeUndefined();
       const replacementRuntime = {
         dispatchAgent: vi.fn(),
         waitForAgent: vi.fn(async () => ({ status: "pending" })),
@@ -349,7 +359,7 @@ describe("subagent registry persistence resume", () => {
       const resolveReplacementContext = () => ({ recoveryRuntime: replacementRuntime }) as never;
       mod.activateSubagentRegistry(resolveReplacementContext);
       mod.activateSubagentRegistry(resolveReplacementContext);
-      expect(getGatewayContextResolver(restoredRun!)).toBe(resolveGatewayContext);
+      expect(getGatewayContextResolver(restoredRun!)).toBe(restoredGatewayContextResolver);
       expect(wakeRequester).toHaveBeenCalledOnce();
       expect(recoveryRuntime.waitForAgent).toHaveBeenCalledOnce();
       expect(replacementRuntime.waitForAgent).not.toHaveBeenCalled();

--- a/src/agents/subagents/registry/subagent-registry.persistence.resume.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.persistence.resume.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { getGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
 import "./subagent-registry.mocks.shared.js";
 import { closeOpenClawStateDatabaseForTest as closeSeedStateDatabase } from "../../../state/openclaw-state-db.js";
 import { withEnvAsync } from "../../../test-utils/env.js";
@@ -325,6 +326,9 @@ describe("subagent registry persistence resume", () => {
       );
       mod.activateSubagentRegistry(resolveGatewayContext);
       mod.activateSubagentRegistry(resolveGatewayContext);
+      const restoredRun = mod.getSubagentRunByRunId(runningRun.runId);
+      expect(restoredRun).toBeDefined();
+      expect(getGatewayContextResolver(restoredRun!)).toBe(resolveGatewayContext);
 
       await vi.waitFor(() => {
         expect(wakeRequester).toHaveBeenCalledOnce();
@@ -345,6 +349,7 @@ describe("subagent registry persistence resume", () => {
       const resolveReplacementContext = () => ({ recoveryRuntime: replacementRuntime }) as never;
       mod.activateSubagentRegistry(resolveReplacementContext);
       mod.activateSubagentRegistry(resolveReplacementContext);
+      expect(getGatewayContextResolver(restoredRun!)).toBe(resolveGatewayContext);
       expect(wakeRequester).toHaveBeenCalledOnce();
       expect(recoveryRuntime.waitForAgent).toHaveBeenCalledOnce();
       expect(replacementRuntime.waitForAgent).not.toHaveBeenCalled();

--- a/src/agents/subagents/registry/subagent-registry.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.test.ts
@@ -434,7 +434,14 @@ describe("subagent registry seam flow", () => {
       }) as never,
     sendRecoveryNotice: vi.fn(),
   };
-  const activateRegistry = () => mod.activateSubagentRegistry(() => ({ recoveryRuntime }) as never);
+  const activateRegistry = () =>
+    mod.activateSubagentRegistry(
+      () =>
+        ({
+          recoveryRuntime,
+          resolveGatewayContext: () => ({ recoveryRuntime }),
+        }) as never,
+    );
   const hydrateAndActivateRegistry = () => {
     mod.initSubagentRegistry();
     activateRegistry();
@@ -2038,6 +2045,14 @@ describe("subagent registry seam flow", () => {
 
   it("detaches subagent completion from a disposed requester transcript owner", async () => {
     const sessionKey = "agent:main:main";
+    const activeGatewayContext = { recoveryRuntime } as never;
+    mod.activateSubagentRegistry(
+      () =>
+        ({
+          recoveryRuntime,
+          resolveGatewayContext: () => activeGatewayContext,
+        }) as never,
+    );
     let disposed = false;
     let resolveWait: (value: Record<string, unknown>) => void = () => {};
     const pendingWait = new Promise<Record<string, unknown>>((resolve) => {
@@ -2090,6 +2105,12 @@ describe("subagent registry seam flow", () => {
     await waitForFast(() => expect(freshTranscriptWrite).toHaveBeenCalledOnce());
     expect(freshCompletionWrite).toHaveBeenCalledOnce();
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledOnce();
+    const [announceParams] = (
+      mocks.runSubagentAnnounceFlow.mock.calls as unknown as Array<
+        [{ resolveGatewayContext?: () => unknown }]
+      >
+    )[0];
+    expect(announceParams.resolveGatewayContext?.()).toBe(activeGatewayContext);
     expect(requesterTranscriptWrite).not.toHaveBeenCalled();
   });
 

--- a/src/agents/subagents/registry/subagent-registry.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.test.ts
@@ -2105,12 +2105,12 @@ describe("subagent registry seam flow", () => {
     await waitForFast(() => expect(freshTranscriptWrite).toHaveBeenCalledOnce());
     expect(freshCompletionWrite).toHaveBeenCalledOnce();
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledOnce();
-    const [announceParams] = (
+    const announceParams = (
       mocks.runSubagentAnnounceFlow.mock.calls as unknown as Array<
         [{ resolveGatewayContext?: () => unknown }]
       >
-    )[0];
-    expect(announceParams.resolveGatewayContext?.()).toBe(activeGatewayContext);
+    )[0]?.[0];
+    expect(announceParams?.resolveGatewayContext?.()).toBe(activeGatewayContext);
     expect(requesterTranscriptWrite).not.toHaveBeenCalled();
   });
 

--- a/src/agents/subagents/registry/subagent-registry.ts
+++ b/src/agents/subagents/registry/subagent-registry.ts
@@ -1,6 +1,7 @@
 /** Coordinates subagent registration, lifecycle, delivery, steering, recovery, and persistence. */
 import type { AgentWaitParams } from "../../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { fenceScheduledGatewayContextResolver } from "../../../gateway/scheduled-run-gateway-context.js";
 import { callGateway } from "../../../gateway/call.js";
 import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
@@ -128,6 +129,11 @@ const contextCleanup = createSubagentRegistryContextCleanup({
 const subagentLifecycleController = new SubagentLifecycleController({
   runs: subagentRuns,
   resumedRuns,
+  // Fence the instance resolver: the process-wide holder is not cleared on
+  // shutdown, so a late completion could otherwise dispatch against a retired
+  // Gateway instance. Preferring no context makes that fail visibly.
+  getInstanceGatewayContextResolver: () =>
+    fenceScheduledGatewayContextResolver(activeGatewayContextResolver),
   subagentAnnounceTimeoutMs: SUBAGENT_ANNOUNCE_TIMEOUT_MS,
   getRuntimeConfig: () => subagentRegistryDeps.getRuntimeConfig(),
   persist: persistSubagentRuns,

--- a/src/agents/subagents/registry/subagent-registry.ts
+++ b/src/agents/subagents/registry/subagent-registry.ts
@@ -327,7 +327,8 @@ const subagentRestorer = createSubagentRegistryRestorer({
   runs: subagentRuns,
   resumedRuns,
   deps: () => subagentRegistryDeps,
-  getGatewayContextResolver: () => activeGatewayContextResolver,
+  getGatewayContextResolver: () =>
+    fenceScheduledGatewayContextResolver(activeGatewayContextResolver),
   persist: persistSubagentRuns,
   persistOrThrow: persistSubagentRunsOrThrow,
   settleRequesterTurn: settleRequesterTurnAfterSessionSpawns,
@@ -474,8 +475,14 @@ export const clearSubagentRunSteerRestart = subagentRunManager.clearSubagentRunS
 export const replaceSubagentRunAfterSteerCore = subagentRunManager.replaceSubagentRunAfterSteer;
 export const claimSubagentRunKill = subagentRunManager.claimSubagentRunKill;
 export const releaseSubagentRunKillClaim = subagentRunManager.releaseSubagentRunKillClaim;
-export const registerSubagentRun: (params: RegisterSubagentRunParams) => void =
-  subagentRunManager.registerSubagentRun;
+export function registerSubagentRun(params: RegisterSubagentRunParams): void {
+  subagentRunManager.registerSubagentRun({
+    ...params,
+    gatewayContextResolver:
+      params.gatewayContextResolver ??
+      fenceScheduledGatewayContextResolver(activeGatewayContextResolver),
+  });
+}
 export const startQueuedSubagentRun = subagentRunManager.startQueuedSubagentRun;
 export const settleFailedQueuedSubagentLaunch = subagentRunManager.settleFailedQueuedSubagentLaunch;
 
@@ -606,15 +613,14 @@ export function initSubagentRegistry() {
   state.restorer.restoreOnce();
 }
 export function activateSubagentRegistry(resolveGatewayContext: GatewayContextResolver) {
+  const lifecycleGatewayContextResolver =
+    fenceScheduledGatewayContextResolver(resolveGatewayContext);
   activeGatewayContextResolver = resolveGatewayContext;
   for (const entry of subagentRuns.values()) {
     // Deserialized rows have no in-memory owner. The activating Gateway may
     // claim those rows once, but must not replace a live run's exact owner.
     if (!getGatewayContextResolver(entry)) {
-      bindGatewayContextResolver(
-        entry,
-        fenceScheduledGatewayContextResolver(resolveGatewayContext),
-      );
+      bindGatewayContextResolver(entry, lifecycleGatewayContextResolver);
     }
   }
   subagentRestorer.activate();

--- a/src/agents/subagents/registry/subagent-registry.ts
+++ b/src/agents/subagents/registry/subagent-registry.ts
@@ -2,10 +2,12 @@
 import type { AgentWaitParams } from "../../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { callGateway } from "../../../gateway/call.js";
-import { fenceScheduledGatewayContextResolver } from "../../../gateway/scheduled-run-gateway-context.js";
 import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
-import { bindGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
+import {
+  bindGatewayContextResolver,
+  getGatewayContextResolver,
+} from "../../../plugins/runtime/gateway-request-scope.js";
 import {
   isGatewayRestartDraining,
   runWithGatewayIndependentRootWorkAdmission,
@@ -129,11 +131,6 @@ const contextCleanup = createSubagentRegistryContextCleanup({
 const subagentLifecycleController = new SubagentLifecycleController({
   runs: subagentRuns,
   resumedRuns,
-  // Fence the instance resolver: the process-wide holder is not cleared on
-  // shutdown, so a late completion could otherwise dispatch against a retired
-  // Gateway instance. Preferring no context makes that fail visibly.
-  getInstanceGatewayContextResolver: () =>
-    fenceScheduledGatewayContextResolver(activeGatewayContextResolver),
   subagentAnnounceTimeoutMs: SUBAGENT_ANNOUNCE_TIMEOUT_MS,
   getRuntimeConfig: () => subagentRegistryDeps.getRuntimeConfig(),
   persist: persistSubagentRuns,
@@ -610,7 +607,11 @@ export function initSubagentRegistry() {
 export function activateSubagentRegistry(resolveGatewayContext: GatewayContextResolver) {
   activeGatewayContextResolver = resolveGatewayContext;
   for (const entry of subagentRuns.values()) {
-    bindGatewayContextResolver(entry, resolveGatewayContext);
+    // Deserialized rows have no in-memory owner. The activating Gateway may
+    // claim those rows once, but must not replace a live run's exact owner.
+    if (!getGatewayContextResolver(entry)) {
+      bindGatewayContextResolver(entry, resolveGatewayContext);
+    }
   }
   subagentRestorer.activate();
   // Post-ready only: collector cleanup retains the canonical sessions.delete RPC owner.

--- a/src/agents/subagents/registry/subagent-registry.ts
+++ b/src/agents/subagents/registry/subagent-registry.ts
@@ -1,8 +1,8 @@
 /** Coordinates subagent registration, lifecycle, delivery, steering, recovery, and persistence. */
 import type { AgentWaitParams } from "../../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { fenceScheduledGatewayContextResolver } from "../../../gateway/scheduled-run-gateway-context.js";
 import { callGateway } from "../../../gateway/call.js";
+import { fenceScheduledGatewayContextResolver } from "../../../gateway/scheduled-run-gateway-context.js";
 import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { bindGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";

--- a/src/agents/subagents/registry/subagent-registry.ts
+++ b/src/agents/subagents/registry/subagent-registry.ts
@@ -2,6 +2,7 @@
 import type { AgentWaitParams } from "../../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { callGateway } from "../../../gateway/call.js";
+import { fenceScheduledGatewayContextResolver } from "../../../gateway/scheduled-run-gateway-context.js";
 import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import {
@@ -610,7 +611,10 @@ export function activateSubagentRegistry(resolveGatewayContext: GatewayContextRe
     // Deserialized rows have no in-memory owner. The activating Gateway may
     // claim those rows once, but must not replace a live run's exact owner.
     if (!getGatewayContextResolver(entry)) {
-      bindGatewayContextResolver(entry, resolveGatewayContext);
+      bindGatewayContextResolver(
+        entry,
+        fenceScheduledGatewayContextResolver(resolveGatewayContext),
+      );
     }
   }
   subagentRestorer.activate();

--- a/src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { startAgentRunExecution } from "./agent-run-execution-phase.js";
+
+const dispatchAgentRunFromGateway = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/prepared-model-runtime.js", () => ({
+  loadPublishedGatewayReplyDispatchRuntime: async () => ({
+    config: {},
+    pluginGeneration: "test",
+  }),
+}));
+
+vi.mock("./agent-run-dispatch.js", () => ({
+  dispatchAgentRunFromGateway,
+  resolveAbortedAgentStopReason: () => "rpc",
+}));
+
+describe("startAgentRunExecution Gateway ownership", () => {
+  it("rejects a retired owner after preparation and before final dispatch", async () => {
+    const cleanup = vi.fn();
+    const release = vi.fn();
+    let resolveFinal!: () => void;
+    const final = new Promise<void>((resolve) => {
+      resolveFinal = resolve;
+    });
+
+    startAgentRunExecution({
+      assertContextCurrent: () => {
+        throw new Error("Gateway owner retired");
+      },
+      prepared: {
+        activeGatewayWorkAdmission: {
+          release,
+          run: async (run: () => Promise<void>) => await run(),
+        },
+        activeRunAbort: {
+          cleanup,
+          controller: new AbortController(),
+          registered: false,
+        },
+        dispatchTaskTrackingMode: "none",
+        effectiveAllowModelOverride: false,
+        lifecycleStorePath: "",
+        operationalRunInstance: {},
+        unpersistedOffloadedRefs: [],
+        userTurn: {
+          execApprovalFollowupHandoffClaimId: "claim",
+          message: "continue",
+          senderIsOwner: false,
+          suppressPromptPersistence: false,
+        },
+      },
+      request: {},
+      cfg: {},
+      activeSessionAgentId: "main",
+      delivery: {},
+      isNewSession: false,
+      isRawModelRun: true,
+      isOneShotModelRun: true,
+      isRestartRecoveryResumeRun: false,
+      suppressVisibleSessionEffects: true,
+      images: [],
+      imageOrder: [],
+      media: [],
+      runId: "owner-retired",
+      agentDedupeKeys: [],
+      bestEffortDeliver: false,
+      lifecycleGeneration: "test",
+      preserveUserFacingSessionModelState: false,
+      skipAgentInitialSessionTouch: true,
+      canUseInternalRuntimeHandoff: false,
+      client: null,
+      context: {
+        dedupe: new Map(),
+        deps: {},
+        logGateway: { error: vi.fn(), warn: vi.fn() },
+      },
+      io: {
+        emitAcceptance: vi.fn(),
+        emitFinal: () => resolveFinal(),
+      },
+      releaseCronContinuationClaimWithRecovery: async () => true,
+    } as never);
+
+    await final;
+    await vi.waitFor(() => expect(cleanup).toHaveBeenCalledOnce());
+    expect(dispatchAgentRunFromGateway).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -64,6 +64,7 @@ import {
 import type { AgentTurnContext, AgentTurnIo, AgentTurnPrincipal } from "./types.js";
 
 export function startAgentRunExecution(params: {
+  assertContextCurrent?: () => void;
   prepared: PreparedAgentRunDispatch;
   mainRestartRecoveryOwnerLease?: MainSessionRecoveryOwnerLease;
   request: AgentRunRequest;
@@ -274,6 +275,9 @@ export function startAgentRunExecution(params: {
       } else if (localUserIngress) {
         attachAgentCommandAdmissionFacts(runContext, localUserIngress.facts);
       }
+      // Routing and runtime publication await after admission. Retired owners
+      // must fail before the prepared user turn becomes an agent run.
+      params.assertContextCurrent?.();
       finalizePreparedAgentRunUserTurn(prepared.userTurn);
       dispatchAgentRunFromGateway(
         withAgentRunDispatchExecutionIdentity(

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -164,6 +164,7 @@ export function startAgentRunExecution(params: {
           sessionKey: params.resolvedSessionKey,
           runId: params.runId,
           task: message,
+          gatewayContextResolver: params.context.resolveGatewayContext,
         });
       }
       if (

--- a/src/gateway/agent-turn/agent-turn-service.ts
+++ b/src/gateway/agent-turn/agent-turn-service.ts
@@ -93,10 +93,10 @@ function replayAgentTurnIfCached(params: {
   return true;
 }
 
-export function createAgentTurnService({
-  context,
-  isWebchatConnect,
-}: Pick<GatewayRequestHandlerOptions, "context" | "isWebchatConnect">) {
+export function createAgentTurnService(
+  { context, isWebchatConnect }: Pick<GatewayRequestHandlerOptions, "context" | "isWebchatConnect">,
+  assertContextCurrent?: () => void,
+) {
   const startTurn = async ({
     preflight,
     principal,
@@ -590,6 +590,7 @@ export function createAgentTurnService({
       // This captures ambient root admission synchronously, then settles the final
       // frame on the existing detached chain after the router returns its acceptance.
       startAgentRunExecution({
+        assertContextCurrent,
         prepared: preparedDispatch,
         mainRestartRecoveryOwnerLease,
         request,

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -25,6 +25,8 @@ import { captureAgentTurnPrincipal, resolveAgentTurnRunObserver } from "./princi
 import type { AgentTurnIo } from "./types.js";
 
 type InternalAgentTurnFacadeOptions = {
+  // Authorization can await; the lifecycle owner must still be current before dispatch.
+  assertContextCurrent?: () => void;
   client: NonNullable<GatewayRequestOptions["client"]>;
   getContext: () => GatewayRequestOptions["context"];
   getMethodRegistry?: () => GatewayMethodRegistry;
@@ -74,6 +76,7 @@ export function createInternalAgentTurnFacade(options: InternalAgentTurnFacadeOp
     if (validationError) {
       return { ok: false, error: validationError };
     }
+    options.assertContextCurrent?.();
     let acceptance: GatewayMethodDispatchResponse | undefined;
     let final: GatewayMethodDispatchResponse | undefined;
     let resolveAcceptance: ((response: GatewayMethodDispatchResponse) => void) | undefined;
@@ -236,6 +239,7 @@ export function createInternalAgentTurnFacade(options: InternalAgentTurnFacadeOp
     if (validationError) {
       return throwEnvelopeRejection(method, validationError);
     }
+    options.assertContextCurrent?.();
     const result = runWithGatewayRequestEnvelope(
       method,
       options.client,

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -150,12 +150,10 @@ export function createInternalAgentTurnFacade(options: InternalAgentTurnFacadeOp
           principal,
           registerToolEventRecipient: context.registerToolEventRecipient,
         });
-        await createAgentTurnService({ context, isWebchatConnect }).startTurn({
-          preflight,
-          principal,
-          io,
-          onRunObserved,
-        });
+        await createAgentTurnService(
+          { context, isWebchatConnect },
+          options.assertContextCurrent,
+        ).startTurn({ preflight, principal, io, onRunObserved });
       },
       {
         context,

--- a/src/gateway/scheduled-run-gateway-context.ts
+++ b/src/gateway/scheduled-run-gateway-context.ts
@@ -20,6 +20,10 @@ type ScheduledGatewayContextResolver = () => GatewayRequestContext | undefined;
  * retired one, because a missing context fails visibly.
  */
 export function fenceScheduledGatewayContextResolver(
+  resolveGatewayContext: ScheduledGatewayContextResolver,
+): ScheduledGatewayContextResolver;
+export function fenceScheduledGatewayContextResolver(resolveGatewayContext: undefined): undefined;
+export function fenceScheduledGatewayContextResolver(
   resolveGatewayContext: ScheduledGatewayContextResolver | undefined,
 ): ScheduledGatewayContextResolver | undefined {
   if (!resolveGatewayContext) {

--- a/src/gateway/scheduled-run-gateway-context.ts
+++ b/src/gateway/scheduled-run-gateway-context.ts
@@ -25,6 +25,9 @@ export function fenceScheduledGatewayContextResolver(
 export function fenceScheduledGatewayContextResolver(resolveGatewayContext: undefined): undefined;
 export function fenceScheduledGatewayContextResolver(
   resolveGatewayContext: ScheduledGatewayContextResolver | undefined,
+): ScheduledGatewayContextResolver | undefined;
+export function fenceScheduledGatewayContextResolver(
+  resolveGatewayContext: ScheduledGatewayContextResolver | undefined,
 ): ScheduledGatewayContextResolver | undefined {
   if (!resolveGatewayContext) {
     return undefined;

--- a/src/gateway/server-methods/sessions-messaging.ts
+++ b/src/gateway/server-methods/sessions-messaging.ts
@@ -324,6 +324,7 @@ async function handleSessionSend(params: {
         sessionKey: canonicalKey,
         runId: startedRunId,
         task: (p as { message: string }).message,
+        gatewayContextResolver: params.context.resolveGatewayContext,
       });
     }
     emitSessionsChanged(params.context, {

--- a/src/gateway/server-plugin-in-process-dispatch.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.ts
@@ -316,9 +316,20 @@ export async function dispatchGatewayMethodInProcess<T>(
   if (method === "agent" || method === "agent.wait") {
     return await withInProcessGatewayDispatch(method, options, async (resolved) => {
       const { createInternalAgentTurnFacade } = await loadInternalAgentTurnFacade();
+      const assertContextCurrent = () => {
+        if (
+          getInProcessGatewayRequestContext(options?.resolveGatewayContext) !== resolved.context
+        ) {
+          throw new Error(`Gateway instance lifecycle dispatch unavailable for ${method}`);
+        }
+      };
       const facade = createInternalAgentTurnFacade({
+        assertContextCurrent,
         client: resolved.client,
-        getContext: () => resolved.context,
+        getContext: () => {
+          assertContextCurrent();
+          return resolved.context;
+        },
         ...(resolved.context.getGatewayMethodRegistry
           ? { getMethodRegistry: resolved.context.getGatewayMethodRegistry }
           : {}),

--- a/src/gateway/server-plugin-in-process-dispatch.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.ts
@@ -133,9 +133,6 @@ function resolveInProcessGatewayDispatch(
   const context = getInProcessGatewayRequestContext(options?.resolveGatewayContext);
   const isWebchatConnect = scope?.isWebchatConnect ?? (() => false);
   if (!context) {
-    if (options?.resolveGatewayContext) {
-      throw new Error(`Gateway instance lifecycle dispatch unavailable for ${method}`);
-    }
     throw new Error(
       `In-process gateway dispatch requires a gateway request scope or instance binding (method: ${method}).`,
     );
@@ -320,7 +317,9 @@ export async function dispatchGatewayMethodInProcess<T>(
         if (
           getInProcessGatewayRequestContext(options?.resolveGatewayContext) !== resolved.context
         ) {
-          throw new Error(`Gateway instance lifecycle dispatch unavailable for ${method}`);
+          throw new Error(
+            `In-process gateway dispatch requires a current gateway instance binding (method: ${method}).`,
+          );
         }
       };
       const facade = createInternalAgentTurnFacade({

--- a/src/gateway/server-plugin-in-process-dispatch.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.ts
@@ -130,10 +130,12 @@ function resolveInProcessGatewayDispatch(
             ? undefined
             : (explicitSystemActor ?? { kind: "system" })))
     : (scopedRoleActor ?? explicitSystemActor);
-  const context =
-    options?.resolveGatewayContext?.() ?? scope?.resolveGatewayContext?.() ?? scope?.context;
+  const context = getInProcessGatewayRequestContext(options?.resolveGatewayContext);
   const isWebchatConnect = scope?.isWebchatConnect ?? (() => false);
   if (!context) {
+    if (options?.resolveGatewayContext) {
+      throw new Error(`Gateway instance lifecycle dispatch unavailable for ${method}`);
+    }
     throw new Error(
       `In-process gateway dispatch requires a gateway request scope or instance binding (method: ${method}).`,
     );
@@ -299,8 +301,11 @@ export async function dispatchGatewayMethodInProcessRaw(
 export function getInProcessGatewayRequestContext(
   resolveGatewayContext?: GatewayContextResolver,
 ): GatewayRequestContext | undefined {
+  if (resolveGatewayContext) {
+    return resolveGatewayContext();
+  }
   const scope = getPluginRuntimeGatewayRequestScope();
-  return resolveGatewayContext?.() ?? scope?.resolveGatewayContext?.() ?? scope?.context;
+  return scope?.resolveGatewayContext?.() ?? scope?.context;
 }
 
 export async function dispatchGatewayMethodInProcess<T>(

--- a/src/gateway/server-plugins-node-runtime.ts
+++ b/src/gateway/server-plugins-node-runtime.ts
@@ -1,5 +1,6 @@
 import { NODE_DUPLEX_INVOKE_IDLE_TIMEOUT_MS } from "../infra/node-commands.js";
 import { createNodeDuplexEndpoint } from "../infra/node-duplex-framing.js";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "./node-command-policy.js";

--- a/src/gateway/server-plugins-node-runtime.ts
+++ b/src/gateway/server-plugins-node-runtime.ts
@@ -1,6 +1,5 @@
 import { NODE_DUPLEX_INVOKE_IDLE_TIMEOUT_MS } from "../infra/node-commands.js";
 import { createNodeDuplexEndpoint } from "../infra/node-duplex-framing.js";
-import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "./node-command-policy.js";
@@ -11,8 +10,7 @@ import { getInProcessGatewayRequestContext } from "./server-plugin-in-process-di
 export function hasInProcessGatewayContext(
   resolveGatewayContext?: GatewayContextResolver,
 ): boolean {
-  const scope = getPluginRuntimeGatewayRequestScope();
-  return Boolean(resolveGatewayContext?.() ?? scope?.resolveGatewayContext?.() ?? scope?.context);
+  return Boolean(getInProcessGatewayRequestContext(resolveGatewayContext));
 }
 
 /** Opens one lifecycle-fenced binary channel through the canonical node invocation owner. */

--- a/src/gateway/server-plugins.subagent-ended-hook.test.ts
+++ b/src/gateway/server-plugins.subagent-ended-hook.test.ts
@@ -65,8 +65,6 @@ async function loadServerPlugins(): Promise<ServerPluginsModule> {
     setFallbackGatewayContext: (context) => {
       testGatewayContext = context;
     },
-    createGatewaySubagentRuntime: (resolveGatewayContext) =>
-      actual.createGatewaySubagentRuntime(resolveGatewayContext ?? (() => testGatewayContext)),
   } as ServerPluginsModule;
 }
 
@@ -115,7 +113,7 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
   test("marks plugin SDK subagent runs for Gateway-owned subagent tracking", async () => {
     const serverPlugins = await loadServerPlugins();
     const requesterContext = await loadSubagentRequesterContext();
-    const runtime = serverPlugins.createGatewaySubagentRuntime();
+    const runtime = serverPlugins.createGatewaySubagentRuntime(() => testGatewayContext);
     serverPlugins.setFallbackGatewayContext(
       createTestContext("plugin-sdk-subagent", createTestCfg()),
     );
@@ -147,7 +145,7 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
   test("attaches only host-owned requester lineage for explicit completion delivery", async () => {
     const serverPlugins = await loadServerPlugins();
     const requesterContext = await loadSubagentRequesterContext();
-    const runtime = serverPlugins.createGatewaySubagentRuntime();
+    const runtime = serverPlugins.createGatewaySubagentRuntime(() => testGatewayContext);
     serverPlugins.setFallbackGatewayContext(
       createTestContext("plugin-sdk-completion", createTestCfg()),
     );
@@ -199,7 +197,7 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
 
   test("rejects explicit completion delivery outside a requester-bound hook", async () => {
     const serverPlugins = await loadServerPlugins();
-    const runtime = serverPlugins.createGatewaySubagentRuntime();
+    const runtime = serverPlugins.createGatewaySubagentRuntime(() => testGatewayContext);
     serverPlugins.setFallbackGatewayContext(
       createTestContext("plugin-sdk-completion-missing", createTestCfg()),
     );
@@ -218,7 +216,7 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
 
   test("rejects unsupported runtime completion destinations", async () => {
     const serverPlugins = await loadServerPlugins();
-    const runtime = serverPlugins.createGatewaySubagentRuntime();
+    const runtime = serverPlugins.createGatewaySubagentRuntime(() => testGatewayContext);
     serverPlugins.setFallbackGatewayContext(
       createTestContext("plugin-sdk-completion-invalid", createTestCfg()),
     );
@@ -303,7 +301,7 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
 
   test("preserves the child session so the transcript stays readable until the plugin deletes it", async () => {
     const serverPlugins = await loadServerPlugins();
-    const runtime = serverPlugins.createGatewaySubagentRuntime();
+    const runtime = serverPlugins.createGatewaySubagentRuntime(() => testGatewayContext);
     serverPlugins.setFallbackGatewayContext(createTestContext("plugin-readback", createTestCfg()));
 
     const transcript = [
@@ -405,7 +403,7 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
     },
   ])("preserves the agent.wait $name result", async ({ result, expected = result }) => {
     const serverPlugins = await loadServerPlugins();
-    const runtime = serverPlugins.createGatewaySubagentRuntime();
+    const runtime = serverPlugins.createGatewaySubagentRuntime(() => testGatewayContext);
     serverPlugins.setFallbackGatewayContext(createTestContext("plugin-wait", createTestCfg()));
     internalAgentTurnFacade.wait.mockResolvedValue(result);
 

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -410,6 +410,12 @@ async function createSubagentRuntime(
   return createRuntimeFromLastGatewayLoad().subagent;
 }
 
+async function createRequestScopedSubagentRuntime(): Promise<PluginRuntime["subagent"]> {
+  loadOpenClawPlugins.mockReturnValue(createRegistry([]));
+  loadGatewayStartupPluginsForTest({ resolveGatewayContext: undefined });
+  return createRuntimeFromLastGatewayLoad().subagent;
+}
+
 function createRuntimeFromLastGatewayLoad(): PluginRuntime {
   const runtimeOptions = getLastPluginLoadOption("runtimeOptions") as
     | Parameters<PluginRuntimeModule["createPluginRuntime"]>[0]
@@ -1341,7 +1347,7 @@ describe("loadGatewayPlugins", () => {
 
   test("honors trusted plugin node scopes inside a narrower Gateway request", async () => {
     loadOpenClawPlugins.mockReturnValue(addLoadedPlugin(createRegistry([]), { id: "opencode" }));
-    loadGatewayStartupPluginsForTest();
+    loadGatewayStartupPluginsForTest({ resolveGatewayContext: undefined });
     const scope = {
       context: createTestContext("nodes-invoke-read-caller"),
       client: {
@@ -1415,7 +1421,7 @@ describe("loadGatewayPlugins", () => {
 
   test("does not inherit admin scope for trusted plugin gateway requests", async () => {
     loadOpenClawPlugins.mockReturnValue(addLoadedPlugin(createRegistry([]), { id: "google-meet" }));
-    loadGatewayStartupPluginsForTest();
+    loadGatewayStartupPluginsForTest({ resolveGatewayContext: undefined });
     const scope = {
       context: createTestContext("plugin-gateway-request-admin-caller"),
       client: {
@@ -1944,7 +1950,7 @@ describe("loadGatewayPlugins", () => {
 
   test("forwards provider and model overrides when the request scope is authorized", async () => {
     const serverPlugins = serverPluginsModule;
-    const runtime = await createSubagentRuntime(serverPlugins);
+    const runtime = await createRequestScopedSubagentRuntime();
     const scope = {
       context: createTestContext("request-scope-forward-overrides"),
       client: {
@@ -2138,7 +2144,7 @@ describe("loadGatewayPlugins", () => {
   });
 
   test("clears inherited additive grants when a scoped plugin run requests none", async () => {
-    const runtime = await createSubagentRuntime(serverPluginsModule);
+    const runtime = await createRequestScopedSubagentRuntime();
     const scope = {
       context: createTestContext("clear-tools-also-allow"),
       client: {
@@ -2522,7 +2528,7 @@ describe("loadGatewayPlugins", () => {
 
   test("allows session deletion when the request scope already has admin", async () => {
     const serverPlugins = serverPluginsModule;
-    const runtime = await createSubagentRuntime(serverPlugins);
+    const runtime = await createRequestScopedSubagentRuntime();
     const scope = {
       context: createTestContext("request-scope-delete-session"),
       client: {
@@ -2547,7 +2553,7 @@ describe("loadGatewayPlugins", () => {
 
   test("keeps plugin owner metadata on admin-scoped plugin session cleanup", async () => {
     const serverPlugins = serverPluginsModule;
-    const runtime = await createSubagentRuntime(serverPlugins);
+    const runtime = await createRequestScopedSubagentRuntime();
     const scope = {
       context: createTestContext("request-scope-plugin-delete-session"),
       client: {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1949,7 +1949,6 @@ describe("loadGatewayPlugins", () => {
   });
 
   test("forwards provider and model overrides when the request scope is authorized", async () => {
-    const serverPlugins = serverPluginsModule;
     const runtime = await createRequestScopedSubagentRuntime();
     const scope = {
       context: createTestContext("request-scope-forward-overrides"),
@@ -2527,7 +2526,6 @@ describe("loadGatewayPlugins", () => {
   });
 
   test("allows session deletion when the request scope already has admin", async () => {
-    const serverPlugins = serverPluginsModule;
     const runtime = await createRequestScopedSubagentRuntime();
     const scope = {
       context: createTestContext("request-scope-delete-session"),
@@ -2552,7 +2550,6 @@ describe("loadGatewayPlugins", () => {
   });
 
   test("keeps plugin owner metadata on admin-scoped plugin session cleanup", async () => {
-    const serverPlugins = serverPluginsModule;
     const runtime = await createRequestScopedSubagentRuntime();
     const scope = {
       context: createTestContext("request-scope-plugin-delete-session"),

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -488,7 +488,7 @@ export function createGatewayNodesRuntime(
 }
 
 function createGatewayPluginRuntimeBindings(
-  resolveGatewayContext: GatewayContextResolver,
+  resolveGatewayContext: GatewayContextResolver | undefined,
   overridePolicies: PluginSubagentOverridePolicies,
 ): {
   runtime: Pick<PluginRuntime, "gateway" | "nodes" | "subagent"> &
@@ -497,7 +497,9 @@ function createGatewayPluginRuntimeBindings(
 } {
   let active = true;
   const lifetime = new AbortController();
-  const resolveBoundGatewayContext = () => (active ? resolveGatewayContext() : undefined);
+  const resolveBoundGatewayContext = resolveGatewayContext
+    ? () => (active ? resolveGatewayContext() : undefined)
+    : undefined;
   return {
     retire: () => {
       lifetime.abort(new Error("Plugin Gateway runtime retired; duplex invocation cancelled."));
@@ -510,14 +512,14 @@ function createGatewayPluginRuntimeBindings(
         const sessionWorkerPlacementContext = getInProcessGatewayRequestContext(
           resolveBoundGatewayContext,
         );
-        return await withPluginRuntimeGatewayContextResolver(
-          resolveBoundGatewayContext,
-          async () =>
-            await dispatchReplyFromConfig({
-              ...params,
-              ...(sessionWorkerPlacementContext ? { sessionWorkerPlacementContext } : {}),
-            }),
-        );
+        const run = async () =>
+          await dispatchReplyFromConfig({
+            ...params,
+            ...(sessionWorkerPlacementContext ? { sessionWorkerPlacementContext } : {}),
+          });
+        return resolveBoundGatewayContext
+          ? await withPluginRuntimeGatewayContextResolver(resolveBoundGatewayContext, run)
+          : await run();
       },
       gateway: {
         isAvailable: async () => hasInProcessGatewayContext(resolveBoundGatewayContext),
@@ -644,7 +646,7 @@ export function loadGatewayPlugins(params: {
   const beforeLoad = performance.now();
   const loaderStatsBefore = getPluginModuleLoaderStats();
   const gatewayRuntimeBindings = createGatewayPluginRuntimeBindings(
-    params.resolveGatewayContext ?? (() => undefined),
+    params.resolveGatewayContext,
     resolvePluginSubagentOverridePolicies(resolvedConfig),
   );
   const pluginRegistry = loadAndActivateRootPluginRegistry({

--- a/src/gateway/session-subagent-reactivation.test.ts
+++ b/src/gateway/session-subagent-reactivation.test.ts
@@ -31,6 +31,7 @@ describe("reactivateCompletedSubagentSession", () => {
 
   it("reactivates the newest ended row even when stale active rows still exist for the same child session", async () => {
     const childSessionKey = "agent:main:subagent:followup-race";
+    const resolveGatewayContext = vi.fn(() => ({ owner: "gateway-b" }) as never);
     const latestEndedRun = {
       runId: "run-current-ended",
       childSessionKey,
@@ -54,6 +55,7 @@ describe("reactivateCompletedSubagentSession", () => {
       reactivateCompletedSubagentSession({
         sessionKey: childSessionKey,
         runId: "run-next",
+        gatewayContextResolver: resolveGatewayContext,
       }),
     ).resolves.toBe(true);
 
@@ -63,6 +65,7 @@ describe("reactivateCompletedSubagentSession", () => {
       nextRunId: "run-next",
       fallback: latestEndedRun,
       runTimeoutSeconds: 0,
+      gatewayContextResolver: resolveGatewayContext,
     });
   });
 

--- a/src/gateway/session-subagent-reactivation.test.ts
+++ b/src/gateway/session-subagent-reactivation.test.ts
@@ -69,6 +69,26 @@ describe("reactivateCompletedSubagentSession", () => {
     });
   });
 
+  it("does not replace an ended row after its Gateway owner retires", async () => {
+    getLatestSubagentRunByChildSessionKeyMock.mockReturnValue({
+      runId: "run-ended",
+      runTimeoutSeconds: 0,
+      execution: { endedAt: 1 },
+    });
+    const resolveGatewayContext = vi.fn(() => undefined);
+
+    await expect(
+      reactivateCompletedSubagentSession({
+        sessionKey: "agent:main:subagent:retired-owner",
+        runId: "run-next",
+        gatewayContextResolver: resolveGatewayContext,
+      }),
+    ).resolves.toBe(false);
+
+    expect(resolveGatewayContext).toHaveBeenCalledOnce();
+    expect(replaceSubagentRunAfterSteerMock).not.toHaveBeenCalled();
+  });
+
   it("threads the exact follow-up task into the replacement so restart redispatch rewraps the new prompt instead of the stale original", async () => {
     // Regression for the ClawSweeper P2 finding on #77539: the helper-level
     // task override reaches active steer, descendant wake, and orphan

--- a/src/gateway/session-subagent-reactivation.ts
+++ b/src/gateway/session-subagent-reactivation.ts
@@ -1,6 +1,7 @@
 // Subagent session reactivation helper.
 // Replaces completed subagent run records when a user steers the child session.
 import { getLatestSubagentRunByChildSessionKey } from "../agents/subagents/registry/subagent-registry-read.js";
+import type { GatewayContextResolver } from "./server-methods/types.js";
 
 // Completed subagent sessions can be reactivated after a user steer by replacing
 // the previous completed run id with the next run id through a lazy runtime
@@ -23,6 +24,7 @@ export async function reactivateCompletedSubagentSession(params: {
   sessionKey: string;
   runId?: string;
   task?: string;
+  gatewayContextResolver?: GatewayContextResolver;
 }): Promise<boolean> {
   const runId = params.runId?.trim();
   if (!runId) {
@@ -41,5 +43,8 @@ export async function reactivateCompletedSubagentSession(params: {
     fallback: existing,
     runTimeoutSeconds: existing.runTimeoutSeconds ?? 0,
     ...(hasTask ? { task } : {}),
+    ...(params.gatewayContextResolver
+      ? { gatewayContextResolver: params.gatewayContextResolver }
+      : {}),
   });
 }

--- a/src/gateway/session-subagent-reactivation.ts
+++ b/src/gateway/session-subagent-reactivation.ts
@@ -35,6 +35,11 @@ export async function reactivateCompletedSubagentSession(params: {
     return false;
   }
   const { replaceSubagentRunAfterSteer } = await loadSessionSubagentReactivationRuntime();
+  // The lazy import can outlive its Gateway. Check the exact owner immediately
+  // before the synchronous replacement write.
+  if (params.gatewayContextResolver && !params.gatewayContextResolver()) {
+    return false;
+  }
   const task = params.task;
   const hasTask = typeof task === "string" && task.trim().length > 0;
   return replaceSubagentRunAfterSteer({


### PR DESCRIPTION
Closes #129938

AI-assisted with Claude. The final branch received independent Codex autoreview and exact-head ClawSweeper review.

## What Problem This Solves

A subagent completion that lands while its requester is idle can miss the direct handoff. The result then waits in steering until a human sends another message.

`sessions_spawn` promises push-based results. The parent should receive the child result without polling or another inbound message.

The direct handoff needs a live Gateway context. Some restored run rows had no in-memory resolver, while the prior patch used whichever Gateway activated most recently. That could route Gateway A's completion through live Gateway B.

## Why This Change Was Made

Each subagent run now keeps one exact Gateway lifecycle resolver:

- New runs retain the resolver captured at registration.
- Restored rows have no in-memory owner, so the first activating Gateway claims them once through the existing lifecycle fence.
- Later Gateway activations do not overwrite an existing run owner.
- Idle completion uses only the run's stored resolver. Missing or retired ownership fails closed.
- A completed session reactivated by `agent.run` or `sessions.send` receives the accepting Gateway's resolver explicitly.

This removes the mutable active-Gateway fallback from completion delivery. It also removes the related lifecycle option and keeps one canonical owner path.

## User Impact

An idle parent receives a subagent completion or failure when it happens. A later Gateway cannot receive an earlier Gateway's completion.

If exact ownership is missing or retired, delivery remains retryable instead of widening authority to another live Gateway.

## Evidence

### Real idle-parent symptom

The original branch proof used a separate dev install and a real Discord channel. The requester turn ended before the child completed. No message was sent between the spawn and result.

On base `0229fe7a2a9`, direct announce repeatedly failed:

```text
Subagent completion direct announce failed for run <childRunId>:
In-process gateway dispatch requires a gateway request scope or instance binding (method: agent).
```

On the patched branch, the idle requester received the child result without another human message. That proves the reported delivery symptom. It does not prove cross-Gateway isolation by itself.

### Exact owner regression proof

Final head `9b47550f1996332be3673d69fa9fdf9b0c5d1df7` adds owner-bound coverage:

- A restored row is claimed by Gateway A through a lifecycle-fenced resolver.
- The raw resolver still returns Gateway A after retirement, while the stored resolver returns `undefined`.
- Activating live Gateway B does not replace A's stored resolver.
- Completion passes only the run's stored resolver into announce dispatch.
- An unbound run passes no resolver and fails closed.
- Explicit session reactivation forwards the accepting Gateway resolver to the successor run.

The updated persistence regression was applied to pre-fix head `ba21f1d4ddcb7f3edc8d771055a234a0b2803e45`. It failed because the stored resolver was still the raw activation resolver:

```text
AssertionError: expected [Function Mock] not to be [Function Mock]
```

The same test passes on the final head: 7 tests passed.

### Final-effect dispatch proof

The existing real-Gateway lifecycle boundary test closes Gateway B while Gateway A remains live. Dispatch through retired B rejects before the Gateway method runs, while A still succeeds:

```text
node scripts/run-vitest.mjs src/gateway/server-plugins.lifecycle.test.ts \
  -t 'keeps unscoped plugin work bound to each real Gateway across reverse shutdown'
```

Result: 1 passed, 3 skipped. The rejected path reports:

```text
In-process gateway dispatch requires a gateway request scope or instance binding
```

Together with the stored-resolver and announce-forwarding regressions, this proves a retired run owner cannot reach completion dispatch and cannot fall through to live Gateway B.

### Checks

```text
node scripts/run-vitest.mjs src/agents/subagents/registry/subagent-registry.persistence.resume.test.ts
```

Result: 7 tests passed.

```text
node scripts/run-vitest.mjs src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
```

Result: 156 tests passed.

```text
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
  src/gateway/scheduled-run-gateway-context.ts \
  src/agents/subagents/registry/subagent-registry.ts \
  src/agents/subagents/registry/subagent-registry.persistence.resume.test.ts
git diff --check
```

Result: clean.

Host policy forbids local OpenClaw type-check and build commands. Exact-head continuous integration owns those gates.

### Review

Fresh commit autoreview:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.98)
```

ClawSweeper exact-head review found zero code findings, cleared security, and required only the final-effect evidence recorded above.

Production delta: +28/-4, net +24. The added production lines establish one exact lifecycle owner across restoration, reactivation, and completion dispatch. Tests: +51/-5, net +46.
