### PR TITLE
refactor(msteams): unify proactive send failure handling

### DIFF
--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -66,6 +66,16 @@ const FILE_CONSENT_THRESHOLD_BYTES = 4 * 1024 * 1024; // 4MB
  */
 const MSTEAMS_MAX_MEDIA_BYTES = 100 * 1024 * 1024;
 
+function createMSTeamsSendError(errorPrefix: string, error: unknown): Error {
+  const classification = classifyMSTeamsSendError(error);
+  const hint = formatMSTeamsSendErrorHint(classification);
+  const status = classification.statusCode ? ` (HTTP ${classification.statusCode})` : "";
+  return new Error(
+    `${errorPrefix} failed${status}: ${formatUnknownError(error)}${hint ? ` (${hint})` : ""}`,
+    { cause: error },
+  );
+}
+
 function createMSTeamsSendReceipt(params: {
   conversationId: string;
   platformMessageIds: readonly string[];
@@ -333,13 +343,7 @@ export async function sendMessageMSTeams(
         kind: "media",
       });
     } catch (err) {
-      const classification = classifyMSTeamsSendError(err);
-      const hint = formatMSTeamsSendErrorHint(classification);
-      const status = classification.statusCode ? ` (HTTP ${classification.statusCode})` : "";
-      throw new Error(
-        `msteams file send failed${status}: ${formatUnknownError(err)}${hint ? ` (${hint})` : ""}`,
-        { cause: err },
-      );
+      throw createMSTeamsSendError("msteams file send", err);
     }
   }
 
@@ -387,13 +391,7 @@ async function sendTextWithMedia(
       serviceUrlBoundary: ctx.sdkCloudOptions,
     });
   } catch (err) {
-    const classification = classifyMSTeamsSendError(err);
-    const hint = formatMSTeamsSendErrorHint(classification);
-    const status = classification.statusCode ? ` (HTTP ${classification.statusCode})` : "";
-    throw new Error(
-      `msteams send failed${status}: ${formatUnknownError(err)}${hint ? ` (${hint})` : ""}`,
-      { cause: err },
-    );
+    throw createMSTeamsSendError("msteams send", err);
   }
 
   const messageId = platformMessageIds[0] ?? "unknown";
@@ -439,13 +437,7 @@ async function sendProactiveActivity({
   try {
     return await sendProactiveActivityRaw({ ctx, activity });
   } catch (err) {
-    const classification = classifyMSTeamsSendError(err);
-    const hint = formatMSTeamsSendErrorHint(classification);
-    const status = classification.statusCode ? ` (HTTP ${classification.statusCode})` : "";
-    throw new Error(
-      `${errorPrefix} failed${status}: ${formatUnknownError(err)}${hint ? ` (${hint})` : ""}`,
-      { cause: err },
-    );
+    throw createMSTeamsSendError(errorPrefix, err);
   }
 }
 
@@ -544,31 +536,16 @@ export async function sendAdaptiveCardMSTeams(
   };
 }
 
-type EditMSTeamsMessageParams = {
+type MSTeamsMessageMutationParams = {
   /** Full config (for credentials) */
   cfg: OpenClawConfig;
   /** Conversation ID or user ID */
   to: string;
-  /** Activity ID of the message to edit */
-  activityId: string;
-  /** New message text */
-  text: string;
-};
-
-type EditMSTeamsMessageResult = {
-  conversationId: string;
-};
-
-type DeleteMSTeamsMessageParams = {
-  /** Full config (for credentials) */
-  cfg: OpenClawConfig;
-  /** Conversation ID or user ID */
-  to: string;
-  /** Activity ID of the message to delete */
+  /** Activity ID of the message to edit or delete */
   activityId: string;
 };
 
-type DeleteMSTeamsMessageResult = {
+type MSTeamsMessageMutationResult = {
   conversationId: string;
 };
 
@@ -579,8 +556,8 @@ type DeleteMSTeamsMessageResult = {
  * original turn context.
  */
 export async function editMessageMSTeams(
-  params: EditMSTeamsMessageParams,
-): Promise<EditMSTeamsMessageResult> {
+  params: MSTeamsMessageMutationParams & { text: string },
+): Promise<MSTeamsMessageMutationResult> {
   const { cfg, to, activityId, text } = params;
   const { app, conversationId, ref, log, sdkCloudOptions } = await resolveMSTeamsSendContext({
     cfg,
@@ -603,13 +580,7 @@ export async function editMessageMSTeams(
       { serviceUrlBoundary: sdkCloudOptions },
     );
   } catch (err) {
-    const classification = classifyMSTeamsSendError(err);
-    const hint = formatMSTeamsSendErrorHint(classification);
-    const status = classification.statusCode ? ` (HTTP ${classification.statusCode})` : "";
-    throw new Error(
-      `msteams edit failed${status}: ${formatUnknownError(err)}${hint ? ` (${hint})` : ""}`,
-      { cause: err },
-    );
+    throw createMSTeamsSendError("msteams edit", err);
   }
 
   log.info("edited proactive message", { conversationId, activityId });
@@ -624,8 +595,8 @@ export async function editMessageMSTeams(
  * original turn context.
  */
 export async function deleteMessageMSTeams(
-  params: DeleteMSTeamsMessageParams,
-): Promise<DeleteMSTeamsMessageResult> {
+  params: MSTeamsMessageMutationParams,
+): Promise<MSTeamsMessageMutationResult> {
   const { cfg, to, activityId } = params;
   const { app, conversationId, ref, log, sdkCloudOptions } = await resolveMSTeamsSendContext({
     cfg,
@@ -640,13 +611,7 @@ export async function deleteMessageMSTeams(
       serviceUrlBoundary: sdkCloudOptions,
     });
   } catch (err) {
-    const classification = classifyMSTeamsSendError(err);
-    const hint = formatMSTeamsSendErrorHint(classification);
-    const status = classification.statusCode ? ` (HTTP ${classification.statusCode})` : "";
-    throw new Error(
-      `msteams delete failed${status}: ${formatUnknownError(err)}${hint ? ` (${hint})` : ""}`,
-      { cause: err },
-    );
+    throw createMSTeamsSendError("msteams delete", err);
   }
 
   log.info("deleted proactive message", { conversationId, activityId });


### PR DESCRIPTION
## What Problem This Solves

Microsoft Teams message, file, card, poll, edit, and delete operations repeated the same error classification and formatting logic in five places, while edit and delete duplicated their private request and result types.

## Why This Change Was Made

Reuse one plugin-private error constructor and one shared private message-mutation shape. Keep every Teams SDK request, service URL boundary, authentication check, log event, error prefix, HTTP status, remediation hint, and original error cause unchanged.

## User Impact

No user-visible behavior changes. Microsoft Teams retains the same proactive sending, message mutation, and failure diagnostics with 35 fewer lines of plugin production code.

## Evidence

- Focused owner, classifier, channel-action, outbound, and real Teams SDK local-loopback suites: 5 files, 154 tests passing before and after the refactor.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs extensions/msteams/src/send.test.ts extensions/msteams/src/errors.test.ts extensions/msteams/src/send.threaded-attachments.test.ts extensions/msteams/src/channel.actions.test.ts extensions/msteams/src/outbound.test.ts`
- `node scripts/check-changed.mjs` passed unrestricted, including extension and extension-test typechecks, all dead-export scans, plugin boundaries, lint, formatting, and security guards.
- Fresh owner autoreview and separate independent read-only final-commit review both passed.
- Production: +22/-57 (net -35); tests unchanged.
