### PR TITLE
feat(msteams): native Adaptive Card approve/deny for exec and plugin approvals

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -872,7 +872,6 @@ extensions/msteams/src/reply-dispatcher.ts	4
 extensions/msteams/src/reply-stream-controller.ts	1
 extensions/msteams/src/sdk-proactive.ts	7
 extensions/msteams/src/sdk.ts	10
-extensions/msteams/src/send.ts	1
 extensions/msteams/src/setup-surface.ts	7
 extensions/msteams/src/sqlite-state.ts	1
 extensions/msteams/src/sso-token-store.ts	2

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -5,7 +5,7 @@ read_when:
 title: "Microsoft Teams"
 ---
 
-Status: text + DM attachments are supported; channel/group file sending requires `sharePointSiteId` + Graph permissions (see [Sending files in group chats](#sending-files-in-group-chats)). Polls are sent via Adaptive Cards. Message actions expose explicit `upload-file` for file-first sends.
+Status: text + DM attachments are supported; channel/group file sending requires `sharePointSiteId` + Graph permissions (see [Sending files in group chats](#sending-files-in-group-chats)). Polls and approval prompts are sent via Adaptive Cards. Message actions expose explicit `upload-file` for file-first sends.
 
 ## Bundled plugin
 
@@ -717,7 +717,7 @@ Teams markdown is more limited than Slack or Discord:
 
 - Basic formatting works: **bold**, _italic_, `code`, links.
 - Complex markdown (tables, nested lists) may not render correctly.
-- Adaptive Cards are supported for polls and semantic presentation sends (see below).
+- Adaptive Cards are supported for approval prompts, polls, and semantic presentation sends (see below).
 
 ## Configuration
 
@@ -730,7 +730,8 @@ Key settings (see [/gateway/configuration](/gateway/configuration) for shared ch
 - `channels.msteams.webhook.port` (default `3978`).
 - `channels.msteams.webhook.path` (default `/api/messages`).
 - `channels.msteams.dmPolicy`: `pairing | allowlist | open | disabled` (default `pairing`).
-- `channels.msteams.allowFrom`: DM allowlist (AAD object IDs recommended). The wizard resolves names to IDs during setup when Graph access is available.
+- `channels.msteams.allowFrom`: DM allowlist (AAD object IDs recommended). Stable AAD object IDs also authorize approval actions. The wizard resolves names to IDs during setup when Graph access is available.
+- `channels.msteams.defaultTo`: default outbound target; a stable AAD object ID can also authorize approval actions.
 - `channels.msteams.dangerouslyAllowNameMatching`: break-glass toggle to re-enable mutable UPN/display-name matching and direct team/channel name routing.
 - `channels.msteams.textChunkLimit`: outbound text chunk size in characters (default `4000`, and hard-capped at `4000` regardless of a higher configured value).
 - `channels.msteams.streaming.chunkMode`: `length` (default) or `newline` to split on blank lines (paragraph boundaries) before length chunking.
@@ -908,6 +909,30 @@ Per-user sharing is more secure since only chat participants can access the file
 ### Files stored location
 
 Uploaded files are stored in a `/OpenClawShared/` folder in the configured SharePoint site's default document library.
+
+## Native approval cards
+
+Microsoft Teams can deliver exec and plugin approval requests as Adaptive Cards in the originating conversation. Each card describes the requested command or plugin action and provides only the decisions allowed for that request, such as **Approve once**, **Always allow**, and **Deny**. After a decision or expiration, OpenClaw updates the original card with its final status.
+
+Enable the existing top-level approval forwarding settings for each approval type you want to receive:
+
+```json5
+{
+  approvals: {
+    exec: { enabled: true, mode: "session" },
+    plugin: { enabled: true, mode: "session" },
+  },
+  channels: {
+    msteams: {
+      allowFrom: ["00000000-0000-0000-0000-000000000000"],
+    },
+  },
+}
+```
+
+`approvals.exec` and `approvals.plugin` are independent; enabling one does not enable the other. Native card delivery also requires a configured Teams bot and at least one approver resolved from `channels.msteams.allowFrom` or `channels.msteams.defaultTo`. Approvers must be stable AAD object IDs; display names, email addresses, group entries, and conversation IDs do not grant approval access. OpenClaw checks the clicking user's AAD object ID before resolving the request.
+
+No Teams-specific approval configuration is required. The existing `/approve <id> <decision>` command remains available as a text fallback when native delivery is unavailable. For forwarding modes and supported decisions, see [Approval forwarding to chat channels](/tools/exec-approvals-advanced#approval-forwarding-to-chat-channels).
 
 ## Polls (Adaptive Cards)
 

--- a/extensions/msteams/src/approval-auth.ts
+++ b/extensions/msteams/src/approval-auth.ts
@@ -18,7 +18,7 @@ function resolveMSTeamsChannelConfig(cfg: OpenClawConfig) {
   return cfg.channels?.msteams;
 }
 
-export const msTeamsApprovalAuth = createChannelApprovalAuth({
+const msTeamsApproval = createChannelApprovalAuth({
   channelLabel: "Microsoft Teams",
   resolveInputs: ({ cfg }) => {
     const channel = resolveMSTeamsChannelConfig(cfg);
@@ -32,4 +32,7 @@ export const msTeamsApprovalAuth = createChannelApprovalAuth({
     }
     return MSTEAMS_ID_RE.test(trimmed) ? trimmed : undefined;
   },
-}).approvalAuth;
+});
+
+export const getMSTeamsApprovalApprovers = msTeamsApproval.resolveApprovers;
+export const msTeamsApprovalAuth = msTeamsApproval.approvalAuth;

--- a/extensions/msteams/src/approval-card-actions.ts
+++ b/extensions/msteams/src/approval-card-actions.ts
@@ -1,0 +1,102 @@
+import crypto from "node:crypto";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
+import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
+import {
+  isRecord,
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export type MSTeamsApprovalCardBinding = {
+  token: string;
+  accountId: string;
+  approvalId: string;
+  approvalKind: ChannelApprovalKind;
+  decision: ExecApprovalDecision;
+  allowedDecisions: readonly ExecApprovalDecision[];
+  conversationId: string;
+  activityId: string;
+  expiresAtMs: number;
+};
+
+type MSTeamsApprovalCardClaim =
+  | { kind: "claimed"; binding: MSTeamsApprovalCardBinding }
+  | { kind: "missing" }
+  | { kind: "in-flight" };
+
+const approvalCardBindings = new Map<string, MSTeamsApprovalCardBinding>();
+const approvalCardResolvingTokens = new Set<string>();
+const MSTEAMS_APPROVAL_CARD_BINDING_MAX_ENTRIES = 1024;
+
+export function createMSTeamsApprovalToken(): string {
+  return crypto.randomBytes(18).toString("base64url");
+}
+
+export function readMSTeamsApprovalActionToken(value: unknown): string | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const action = isRecord(value.action) ? value.action : undefined;
+  const submitted =
+    action &&
+    normalizeOptionalLowercaseString(action.type) === "action.submit" &&
+    isRecord(action.data)
+      ? action.data
+      : value;
+  if (submitted.openclawAction !== "approval") {
+    return null;
+  }
+  return normalizeOptionalString(submitted.token) ?? null;
+}
+
+export function registerMSTeamsApprovalCardBinding(binding: MSTeamsApprovalCardBinding): boolean {
+  if (binding.expiresAtMs <= Date.now()) {
+    return false;
+  }
+  approvalCardBindings.delete(binding.token);
+  approvalCardBindings.set(binding.token, binding);
+  pruneMapToMaxSize(approvalCardBindings, MSTEAMS_APPROVAL_CARD_BINDING_MAX_ENTRIES);
+  return true;
+}
+
+export function getMSTeamsApprovalCardBinding(token: string): MSTeamsApprovalCardBinding | null {
+  const binding = approvalCardBindings.get(token);
+  if (!binding) {
+    return null;
+  }
+  if (binding.expiresAtMs <= Date.now()) {
+    approvalCardBindings.delete(token);
+    approvalCardResolvingTokens.delete(token);
+    return null;
+  }
+  return binding;
+}
+
+export function claimMSTeamsApprovalCardBinding(token: string): MSTeamsApprovalCardClaim {
+  const binding = getMSTeamsApprovalCardBinding(token);
+  if (!binding) {
+    return { kind: "missing" };
+  }
+  if (approvalCardResolvingTokens.has(token)) {
+    return { kind: "in-flight" };
+  }
+  // Keep the claim until resolution completes or fails so concurrent submits cannot resolve twice.
+  approvalCardResolvingTokens.add(token);
+  return { kind: "claimed", binding };
+}
+
+export function completeMSTeamsApprovalCardBinding(token: string): void {
+  approvalCardResolvingTokens.delete(token);
+  approvalCardBindings.delete(token);
+}
+
+export function releaseMSTeamsApprovalCardBinding(token: string): void {
+  approvalCardResolvingTokens.delete(token);
+}
+
+export function unregisterMSTeamsApprovalCardBindings(tokens: readonly string[]): void {
+  for (const token of tokens) {
+    completeMSTeamsApprovalCardBinding(token);
+  }
+}

--- a/extensions/msteams/src/approval-card-submit.test.ts
+++ b/extensions/msteams/src/approval-card-submit.test.ts
@@ -1,0 +1,337 @@
+import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
+import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getMSTeamsApprovalCardBinding,
+  registerMSTeamsApprovalCardBinding,
+  unregisterMSTeamsApprovalCardBindings,
+} from "./approval-card-actions.js";
+import { maybeHandleMSTeamsApprovalCardSubmit } from "./approval-card-submit.js";
+import { createMSTeamsMessageHandlerDeps } from "./monitor-handler.test-helpers.js";
+import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
+import type { MSTeamsTurnContext } from "./sdk-types.js";
+
+const resolveApprovalOverGateway = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
+  resolveApprovalOverGateway,
+}));
+
+const APPROVER_ID = "11111111-2222-4333-8444-555555555555";
+const UNAUTHORIZED_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const CONVERSATION_ID = "19:approval-chat";
+const ACTIVITY_ID = "card-activity";
+const testTokens = new Set<string>();
+
+function createResolution(params: {
+  approvalId: string;
+  approvalKind?: ChannelApprovalKind;
+  decision?: ExecApprovalDecision;
+  applied?: boolean;
+}): ApprovalResolveResult {
+  const decision = params.decision ?? "allow-once";
+  const common = {
+    id: params.approvalId,
+    urlPath: `/approve/${params.approvalId}`,
+    createdAtMs: 1,
+    expiresAtMs: 10_000,
+    resolvedAtMs: 2,
+    reason: "user" as const,
+    presentation:
+      params.approvalKind === "plugin"
+        ? {
+            kind: "plugin" as const,
+            title: "Plugin request",
+            description: "Allow the plugin action.",
+            severity: "info" as const,
+            allowedDecisions: ["allow-once" as const, "deny" as const],
+          }
+        : {
+            kind: "exec" as const,
+            commandText: "echo approved",
+            commandPreview: null,
+            allowedDecisions: ["allow-once" as const, "deny" as const],
+          },
+  };
+  return decision === "deny"
+    ? {
+        applied: params.applied ?? true,
+        approval: { ...common, status: "denied", decision: "deny" },
+      }
+    : {
+        applied: params.applied ?? true,
+        approval: { ...common, status: "allowed", decision },
+      };
+}
+
+function createDeps(): MSTeamsMessageHandlerDeps {
+  return createMSTeamsMessageHandlerDeps({
+    cfg: { channels: { msteams: { allowFrom: [APPROVER_ID] } } },
+  });
+}
+
+function createContext(params: {
+  token?: string;
+  senderId?: string;
+  conversationId?: string;
+  replyToId?: string;
+  nested?: boolean;
+  value?: unknown;
+}): MSTeamsTurnContext {
+  const approvalValue = {
+    openclawAction: "approval",
+    ...(params.token ? { token: params.token } : {}),
+  };
+  return {
+    activity: {
+      type: "message",
+      from: { aadObjectId: params.senderId ?? APPROVER_ID },
+      conversation: { id: params.conversationId ?? CONVERSATION_ID },
+      ...(params.replyToId ? { replyToId: params.replyToId } : {}),
+      value:
+        params.value ??
+        (params.nested
+          ? { action: { type: "Action.Submit", data: approvalValue } }
+          : approvalValue),
+    },
+    sendActivity: vi.fn(async () => undefined),
+    sendActivities: vi.fn(async () => undefined),
+    updateActivity: vi.fn(async () => ({ id: ACTIVITY_ID })),
+    deleteActivity: vi.fn(async () => undefined),
+  };
+}
+
+function registerBinding(params: {
+  token: string;
+  accountId?: string;
+  approvalKind?: ChannelApprovalKind;
+  decision?: ExecApprovalDecision;
+  allowedDecisions?: readonly ExecApprovalDecision[];
+  conversationId?: string;
+}): void {
+  testTokens.add(params.token);
+  registerMSTeamsApprovalCardBinding({
+    token: params.token,
+    accountId: params.accountId ?? "default",
+    approvalId: `approval-${params.token}`,
+    approvalKind: params.approvalKind ?? "exec",
+    decision: params.decision ?? "allow-once",
+    allowedDecisions: params.allowedDecisions ?? ["allow-once", "deny"],
+    conversationId: params.conversationId ?? CONVERSATION_ID,
+    activityId: ACTIVITY_ID,
+    expiresAtMs: Date.now() + 60_000,
+  });
+}
+
+describe("maybeHandleMSTeamsApprovalCardSubmit", () => {
+  beforeEach(() => {
+    resolveApprovalOverGateway
+      .mockReset()
+      .mockImplementation(
+        (params: {
+          approvalId: string;
+          approvalKind: ChannelApprovalKind;
+          decision: ExecApprovalDecision;
+        }) => Promise.resolve(createResolution(params)),
+      );
+  });
+
+  afterEach(() => {
+    unregisterMSTeamsApprovalCardBindings(Array.from(testTokens));
+    testTokens.clear();
+  });
+
+  it("leaves unrelated Adaptive Card submits available to normal message dispatch", async () => {
+    const context = createContext({ value: { intent: "deploy", environment: "prod" } });
+
+    await expect(
+      maybeHandleMSTeamsApprovalCardSubmit({ context, deps: createDeps() }),
+    ).resolves.toBe(false);
+
+    expect(resolveApprovalOverGateway).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "missing", token: undefined },
+    { label: "unknown", token: "unknown-token" },
+  ])("consumes approval submits with a $label token", async ({ token }) => {
+    await expect(
+      maybeHandleMSTeamsApprovalCardSubmit({
+        context: createContext({ token }),
+        deps: createDeps(),
+      }),
+    ).resolves.toBe(true);
+
+    expect(resolveApprovalOverGateway).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: "account",
+      binding: { accountId: "another-account" },
+      context: {},
+    },
+    {
+      label: "conversation",
+      binding: {},
+      context: { conversationId: "19:another-conversation" },
+    },
+    {
+      label: "activity",
+      binding: {},
+      context: { replyToId: "another-activity" },
+    },
+    {
+      label: "decision",
+      binding: { decision: "allow-always" as const },
+      context: {},
+    },
+  ])("rejects a mismatched $label without consuming the token", async (scenario) => {
+    const token = `mismatch-${scenario.label}`;
+    registerBinding({ token, ...scenario.binding });
+
+    await expect(
+      maybeHandleMSTeamsApprovalCardSubmit({
+        context: createContext({ token, ...scenario.context }),
+        deps: createDeps(),
+      }),
+    ).resolves.toBe(true);
+
+    expect(resolveApprovalOverGateway).not.toHaveBeenCalled();
+    expect(getMSTeamsApprovalCardBinding(token)).not.toBeNull();
+  });
+
+  it("requires an allowlisted AAD identity and preserves tokens for the authorized approver", async () => {
+    const token = "authorization";
+    registerBinding({ token, approvalKind: "plugin", decision: "deny" });
+    const deps = createDeps();
+
+    await expect(
+      maybeHandleMSTeamsApprovalCardSubmit({
+        context: createContext({ token, senderId: UNAUTHORIZED_ID }),
+        deps,
+      }),
+    ).resolves.toBe(true);
+    expect(resolveApprovalOverGateway).not.toHaveBeenCalled();
+
+    const authorizedContext = createContext({ token, nested: true });
+    await expect(
+      maybeHandleMSTeamsApprovalCardSubmit({ context: authorizedContext, deps }),
+    ).resolves.toBe(true);
+
+    expect(resolveApprovalOverGateway).toHaveBeenCalledWith({
+      cfg: deps.cfg,
+      approvalId: `approval-${token}`,
+      approvalKind: "plugin",
+      decision: "deny",
+      channel: "msteams",
+      accountId: "default",
+      senderId: APPROVER_ID,
+    });
+    expect(authorizedContext.updateActivity).toHaveBeenCalledWith({
+      type: "message",
+      id: ACTIVITY_ID,
+      attachments: [
+        {
+          contentType: "application/vnd.microsoft.card.adaptive",
+          content: expect.objectContaining({ type: "AdaptiveCard" }),
+        },
+      ],
+    });
+    expect(JSON.stringify(vi.mocked(authorizedContext.updateActivity).mock.calls[0])).toContain(
+      "Denied",
+    );
+    expect(getMSTeamsApprovalCardBinding(token)).toBeNull();
+  });
+
+  it("normalizes Teams conversation message suffixes before matching their card", async () => {
+    const token = "normalized-conversation";
+    registerBinding({ token });
+
+    await expect(
+      maybeHandleMSTeamsApprovalCardSubmit({
+        context: createContext({
+          token,
+          conversationId: `${CONVERSATION_ID};messageid=thread-root`,
+        }),
+        deps: createDeps(),
+      }),
+    ).resolves.toBe(true);
+
+    expect(resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows only one gateway resolution while simultaneous clicks are in flight", async () => {
+    const token = "in-flight";
+    registerBinding({ token });
+    const deferred = createDeferred<ApprovalResolveResult>();
+    resolveApprovalOverGateway.mockReturnValueOnce(deferred.promise);
+    const deps = createDeps();
+    const first = maybeHandleMSTeamsApprovalCardSubmit({
+      context: createContext({ token }),
+      deps,
+    });
+
+    await expect(
+      maybeHandleMSTeamsApprovalCardSubmit({ context: createContext({ token }), deps }),
+    ).resolves.toBe(true);
+    expect(resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
+
+    deferred.resolve(createResolution({ approvalId: `approval-${token}` }));
+    await expect(first).resolves.toBe(true);
+  });
+
+  it("releases the token after a recoverable gateway failure", async () => {
+    const token = "gateway-retry";
+    registerBinding({ token });
+    resolveApprovalOverGateway.mockRejectedValueOnce(new Error("gateway unavailable"));
+    const deps = createDeps();
+
+    await expect(
+      maybeHandleMSTeamsApprovalCardSubmit({ context: createContext({ token }), deps }),
+    ).rejects.toThrow("gateway unavailable");
+    await expect(
+      maybeHandleMSTeamsApprovalCardSubmit({ context: createContext({ token }), deps }),
+    ).resolves.toBe(true);
+
+    expect(resolveApprovalOverGateway).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the token when the terminal card update fails", async () => {
+    const token = "update-retry";
+    registerBinding({ token });
+    const failedContext = createContext({ token });
+    vi.mocked(failedContext.updateActivity).mockRejectedValueOnce(new Error("update failed"));
+    const deps = createDeps();
+
+    await expect(
+      maybeHandleMSTeamsApprovalCardSubmit({ context: failedContext, deps }),
+    ).rejects.toThrow("update failed");
+    await expect(
+      maybeHandleMSTeamsApprovalCardSubmit({ context: createContext({ token }), deps }),
+    ).resolves.toBe(true);
+
+    expect(resolveApprovalOverGateway).toHaveBeenCalledTimes(2);
+  });
+
+  it("retires permanently missing approvals and ignores subsequent clicks", async () => {
+    const token = "not-found";
+    registerBinding({ token });
+    resolveApprovalOverGateway.mockRejectedValueOnce(
+      Object.assign(new Error("approval no longer exists"), {
+        gatewayCode: "APPROVAL_NOT_FOUND",
+      }),
+    );
+    const deps = createDeps();
+    const context = createContext({ token });
+
+    await expect(maybeHandleMSTeamsApprovalCardSubmit({ context, deps })).resolves.toBe(true);
+    expect(getMSTeamsApprovalCardBinding(token)).toBeNull();
+    expect(context.updateActivity).not.toHaveBeenCalled();
+
+    await expect(maybeHandleMSTeamsApprovalCardSubmit({ context, deps })).resolves.toBe(true);
+    expect(resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/msteams/src/approval-card-submit.ts
+++ b/extensions/msteams/src/approval-card-submit.ts
@@ -1,0 +1,138 @@
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import {
+  resolveApprovalOverGateway,
+  type ApprovalResolveResult,
+} from "openclaw/plugin-sdk/approval-gateway-runtime";
+import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { msTeamsApprovalAuth } from "./approval-auth.js";
+import {
+  claimMSTeamsApprovalCardBinding,
+  completeMSTeamsApprovalCardBinding,
+  getMSTeamsApprovalCardBinding,
+  readMSTeamsApprovalActionToken,
+  releaseMSTeamsApprovalCardBinding,
+} from "./approval-card-actions.js";
+import { buildMSTeamsCanonicalApprovalTerminalCard } from "./approval-card.js";
+import { normalizeMSTeamsConversationId } from "./inbound.js";
+import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
+import type { MSTeamsTurnContext } from "./sdk-types.js";
+
+function isMSTeamsApprovalSubmit(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (value.openclawAction === "approval") {
+    return true;
+  }
+  const action = isRecord(value.action) ? value.action : undefined;
+  const data = action?.data;
+  return isRecord(data) && data.openclawAction === "approval";
+}
+
+export async function maybeHandleMSTeamsApprovalCardSubmit(params: {
+  context: MSTeamsTurnContext;
+  deps: MSTeamsMessageHandlerDeps;
+}): Promise<boolean> {
+  const { context, deps } = params;
+  if (!isMSTeamsApprovalSubmit(context.activity.value)) {
+    return false;
+  }
+
+  const ignored = (reason: string) => deps.log.info("msteams approval ignored", { reason });
+  const token = readMSTeamsApprovalActionToken(context.activity.value);
+  if (!token) {
+    ignored("missing card token");
+    return true;
+  }
+  const binding = getMSTeamsApprovalCardBinding(token);
+  if (!binding) {
+    ignored("unknown or expired card token");
+    return true;
+  }
+  if (binding.accountId !== DEFAULT_ACCOUNT_ID) {
+    ignored("card token account mismatch");
+    return true;
+  }
+  if (
+    normalizeMSTeamsConversationId(context.activity.conversation?.id ?? "") !==
+    normalizeMSTeamsConversationId(binding.conversationId)
+  ) {
+    ignored("card token conversation mismatch");
+    return true;
+  }
+  if (context.activity.replyToId && context.activity.replyToId !== binding.activityId) {
+    ignored("card token activity mismatch");
+    return true;
+  }
+  if (!binding.allowedDecisions.includes(binding.decision)) {
+    ignored("card token decision is no longer allowed");
+    return true;
+  }
+
+  const senderId = context.activity.from?.aadObjectId;
+  const authorization = msTeamsApprovalAuth.authorizeActorAction?.({
+    cfg: deps.cfg,
+    accountId: DEFAULT_ACCOUNT_ID,
+    senderId,
+    action: "approve",
+    approvalKind: binding.approvalKind,
+  });
+  if (!authorization?.authorized) {
+    ignored(`unauthorized actor ${senderId || "unknown"}`);
+    return true;
+  }
+
+  const claim = claimMSTeamsApprovalCardBinding(token);
+  if (claim.kind !== "claimed") {
+    ignored(
+      claim.kind === "in-flight"
+        ? "card token resolve already in flight"
+        : "card token already consumed",
+    );
+    return true;
+  }
+
+  const consumed = claim.binding;
+  let result: ApprovalResolveResult;
+  try {
+    result = await resolveApprovalOverGateway({
+      cfg: deps.cfg,
+      approvalId: consumed.approvalId,
+      approvalKind: consumed.approvalKind,
+      decision: consumed.decision,
+      channel: "msteams",
+      accountId: DEFAULT_ACCOUNT_ID,
+      senderId,
+    });
+    await context.updateActivity({
+      type: "message",
+      id: consumed.activityId,
+      attachments: [
+        {
+          contentType: "application/vnd.microsoft.card.adaptive",
+          content: buildMSTeamsCanonicalApprovalTerminalCard(result),
+        },
+      ],
+    });
+  } catch (error) {
+    if (isApprovalNotFoundError(error)) {
+      // Missing approvals cannot recover; retire the card instead of rearming its token.
+      completeMSTeamsApprovalCardBinding(token);
+      ignored(`approval expired or no longer exists id=${consumed.approvalId}`);
+      return true;
+    }
+    releaseMSTeamsApprovalCardBinding(token);
+    throw error;
+  }
+
+  completeMSTeamsApprovalCardBinding(token);
+  deps.log.info("msteams approval resolved", {
+    approvalId: consumed.approvalId,
+    approvalKind: consumed.approvalKind,
+    applied: result.applied,
+    status: result.approval.status,
+    senderId,
+  });
+  return true;
+}

--- a/extensions/msteams/src/approval-card.test.ts
+++ b/extensions/msteams/src/approval-card.test.ts
@@ -1,0 +1,212 @@
+import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type {
+  ExecApprovalPendingView,
+  PluginApprovalPendingView,
+} from "openclaw/plugin-sdk/approval-handler-runtime";
+import { describe, expect, it } from "vitest";
+import {
+  buildMSTeamsCanonicalApprovalTerminalCard,
+  buildMSTeamsExpiredApprovalCard,
+  buildMSTeamsPendingApprovalCard,
+  buildMSTeamsResolvedApprovalCard,
+} from "./approval-card.js";
+
+function createExecPendingView(): ExecApprovalPendingView {
+  return {
+    approvalId: "approval-1",
+    approvalKind: "exec",
+    phase: "pending",
+    title: "Exec Approval Required",
+    metadata: [
+      { label: "Agent", value: "main" },
+      { label: "Host", value: "gateway" },
+    ],
+    commandText: "npm run deploy",
+    actions: [
+      {
+        decision: "allow-once",
+        label: "Approve once",
+        style: "success",
+        command: "/approve approval-1 allow-once",
+      },
+      {
+        decision: "deny",
+        label: "Deny",
+        style: "danger",
+        command: "/approve approval-1 deny",
+      },
+    ],
+    expiresAtMs: 61_000,
+  };
+}
+
+function createPluginPendingView(): PluginApprovalPendingView {
+  return {
+    approvalId: "plugin-1",
+    approvalKind: "plugin",
+    phase: "pending",
+    title: "Publish production changes",
+    description: "Allow the deploy plugin to update production.",
+    metadata: [{ label: "Plugin", value: "deploy" }],
+    severity: "warning",
+    actions: [
+      {
+        decision: "deny",
+        label: "Deny",
+        style: "danger",
+        command: "/approve plugin-1 deny",
+      },
+    ],
+    expiresAtMs: 31_000,
+  };
+}
+
+describe("Microsoft Teams approval Adaptive Cards", () => {
+  it("renders an exec command, ordered metadata, and only the available namespaced actions", () => {
+    const result = buildMSTeamsPendingApprovalCard({
+      view: createExecPendingView(),
+      nowMs: 1_000,
+    });
+
+    expect(result.card).toEqual({
+      type: "AdaptiveCard",
+      version: "1.5",
+      body: [
+        {
+          type: "TextBlock",
+          text: "Exec Approval Required",
+          weight: "Bolder",
+          size: "Medium",
+          wrap: true,
+        },
+        { type: "TextBlock", text: "Expires in 60s", isSubtle: true, wrap: true },
+        { type: "TextBlock", text: "Command", weight: "Bolder", wrap: true },
+        { type: "TextBlock", text: "npm run deploy", fontType: "Monospace", wrap: true },
+        {
+          type: "FactSet",
+          facts: [
+            { title: "Approval ID:", value: "approval-1" },
+            { title: "Agent:", value: "main" },
+            { title: "Host:", value: "gateway" },
+          ],
+        },
+      ],
+      actions: [
+        {
+          type: "Action.Submit",
+          title: "Approve once",
+          data: { openclawAction: "approval", token: expect.any(String) },
+        },
+        {
+          type: "Action.Submit",
+          title: "Deny",
+          data: { openclawAction: "approval", token: expect.any(String) },
+        },
+      ],
+    });
+    expect(result.allowedDecisions).toEqual(["allow-once", "deny"]);
+    expect(result.actionTokens.map(({ token }) => token)).toEqual(
+      (result.card.actions as Array<{ data: { token: string } }>).map(({ data }) => data.token),
+    );
+    expect(new Set(result.actionTokens.map(({ token }) => token)).size).toBe(2);
+  });
+
+  it("presents plugin-owned request details and never invents unavailable approval actions", () => {
+    const result = buildMSTeamsPendingApprovalCard({
+      view: createPluginPendingView(),
+      nowMs: 1_000,
+    });
+
+    expect(result.card).toMatchObject({
+      body: [
+        { text: "Plugin Approval Required" },
+        { text: "Expires in 30s" },
+        { text: "Request" },
+        { text: "Publish production changes" },
+        { text: "Allow the deploy plugin to update production." },
+        {
+          facts: [
+            { title: "Approval ID:", value: "plugin-1" },
+            { title: "Plugin:", value: "deploy" },
+          ],
+        },
+      ],
+      actions: [
+        {
+          title: "Deny",
+          data: { openclawAction: "approval", token: expect.any(String) },
+        },
+      ],
+    });
+    expect(result.allowedDecisions).toEqual(["deny"]);
+  });
+
+  it("removes approval actions from resolved and expired cards", () => {
+    const { actions: _actions, expiresAtMs: _expiresAtMs, ...view } = createExecPendingView();
+    const resolved = buildMSTeamsResolvedApprovalCard({
+      ...view,
+      phase: "resolved",
+      decision: "allow-always",
+      resolvedBy: "alice",
+    });
+    const expired = buildMSTeamsExpiredApprovalCard({ ...view, phase: "expired" });
+
+    expect(resolved.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ text: "Exec Approval: Allowed always" }),
+        expect.objectContaining({ text: "Resolved by alice" }),
+      ]),
+    );
+    expect(expired.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ text: "Exec Approval Expired" }),
+        expect.objectContaining({
+          text: "This approval request expired before it was resolved.",
+        }),
+      ]),
+    );
+    expect(resolved).not.toHaveProperty("actions");
+    expect(expired).not.toHaveProperty("actions");
+  });
+
+  it("displays the canonical winning decision when another surface resolved the approval first", () => {
+    const result: ApprovalResolveResult = {
+      applied: false,
+      approval: {
+        id: "approval-1",
+        urlPath: "/approve/approval-1",
+        createdAtMs: 1,
+        expiresAtMs: 61_000,
+        resolvedAtMs: 2,
+        status: "denied",
+        decision: "deny",
+        reason: "user",
+        presentation: {
+          kind: "exec",
+          commandText: "npm run deploy",
+          allowedDecisions: ["allow-once", "deny"],
+        },
+      },
+    };
+
+    const card = buildMSTeamsCanonicalApprovalTerminalCard(result);
+
+    expect(card).toMatchObject({
+      body: [
+        { text: "Exec Approval: Denied" },
+        { text: "Already resolved" },
+        { text: "Command" },
+        { text: "npm run deploy" },
+        {
+          facts: [
+            { title: "Approval ID:", value: "approval-1" },
+            { title: "Status:", value: "denied" },
+            { title: "Decision:", value: "deny" },
+            { title: "Reason:", value: "user" },
+          ],
+        },
+      ],
+    });
+    expect(card).not.toHaveProperty("actions");
+  });
+});

--- a/extensions/msteams/src/approval-card.ts
+++ b/extensions/msteams/src/approval-card.ts
@@ -1,0 +1,198 @@
+import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type {
+  ApprovalMetadataView,
+  ChannelApprovalKind,
+  ExpiredApprovalView,
+  PendingApprovalView,
+  ResolvedApprovalView,
+} from "openclaw/plugin-sdk/approval-handler-runtime";
+import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { createMSTeamsApprovalToken } from "./approval-card-actions.js";
+
+export type MSTeamsApprovalActionToken = {
+  token: string;
+  decision: ExecApprovalDecision;
+};
+
+export type MSTeamsPendingApprovalCard = {
+  approvalId: string;
+  approvalKind: ChannelApprovalKind;
+  expiresAtMs: number;
+  card: Record<string, unknown>;
+  actionTokens: MSTeamsApprovalActionToken[];
+  allowedDecisions: readonly ExecApprovalDecision[];
+};
+
+type MSTeamsApprovalBodyItem = Record<string, unknown>;
+
+function buildCardHeading(title: string, subtitle: string): MSTeamsApprovalBodyItem[] {
+  return [
+    { type: "TextBlock", text: title, weight: "Bolder", size: "Medium", wrap: true },
+    { type: "TextBlock", text: subtitle, isSubtle: true, wrap: true },
+  ];
+}
+
+function buildApprovalSubject(
+  view: PendingApprovalView | ResolvedApprovalView | ExpiredApprovalView,
+): MSTeamsApprovalBodyItem[] {
+  if (view.approvalKind === "exec") {
+    return [
+      { type: "TextBlock", text: "Command", weight: "Bolder", wrap: true },
+      { type: "TextBlock", text: view.commandText, fontType: "Monospace", wrap: true },
+      ...(view.commandPreview && view.commandPreview !== view.commandText
+        ? [
+            { type: "TextBlock", text: "Preview", weight: "Bolder", wrap: true },
+            { type: "TextBlock", text: view.commandPreview, fontType: "Monospace", wrap: true },
+          ]
+        : []),
+    ];
+  }
+  return [
+    { type: "TextBlock", text: "Request", weight: "Bolder", wrap: true },
+    { type: "TextBlock", text: view.title, weight: "Bolder", wrap: true },
+    ...(view.description ? [{ type: "TextBlock", text: view.description, wrap: true }] : []),
+  ];
+}
+
+function buildApprovalMetadata(
+  approvalId: string,
+  metadata: readonly ApprovalMetadataView[],
+): MSTeamsApprovalBodyItem {
+  return {
+    type: "FactSet",
+    facts: [{ title: "Approval ID:", value: approvalId }].concat(
+      metadata.map(({ label, value }) => ({ title: `${label}:`, value })),
+    ),
+  };
+}
+
+function buildAdaptiveCard(
+  body: MSTeamsApprovalBodyItem[],
+  actions?: MSTeamsApprovalBodyItem[],
+): Record<string, unknown> {
+  return {
+    type: "AdaptiveCard",
+    version: "1.5",
+    body,
+    ...(actions?.length ? { actions } : {}),
+  };
+}
+
+function formatApprovalDecision(decision: ExecApprovalDecision): string {
+  return decision === "allow-once"
+    ? "Allowed once"
+    : decision === "allow-always"
+      ? "Allowed always"
+      : "Denied";
+}
+
+export function buildMSTeamsPendingApprovalCard(params: {
+  view: PendingApprovalView;
+  nowMs: number;
+}): MSTeamsPendingApprovalCard {
+  const { view, nowMs } = params;
+  const kindLabel = view.approvalKind === "plugin" ? "Plugin" : "Exec";
+  const actionTokens: MSTeamsApprovalActionToken[] = [];
+  const actions = view.actions.map(({ decision, label }) => {
+    const token = createMSTeamsApprovalToken();
+    actionTokens.push({ token, decision });
+    return {
+      type: "Action.Submit",
+      title: label,
+      data: { openclawAction: "approval", token },
+    };
+  });
+  const remainingSeconds = Math.max(0, Math.ceil((view.expiresAtMs - nowMs) / 1000));
+  const body = [
+    ...buildCardHeading(`${kindLabel} Approval Required`, `Expires in ${remainingSeconds}s`),
+    ...buildApprovalSubject(view),
+    buildApprovalMetadata(view.approvalId, view.metadata),
+  ];
+  return {
+    approvalId: view.approvalId,
+    approvalKind: view.approvalKind,
+    expiresAtMs: view.expiresAtMs,
+    card: buildAdaptiveCard(body, actions),
+    actionTokens,
+    allowedDecisions: view.actions.map(({ decision }) => decision),
+  };
+}
+
+export function buildMSTeamsResolvedApprovalCard(
+  view: ResolvedApprovalView,
+): Record<string, unknown> {
+  const kindLabel = view.approvalKind === "plugin" ? "Plugin" : "Exec";
+  const resolvedBy = normalizeOptionalString(view.resolvedBy);
+  return buildAdaptiveCard([
+    ...buildCardHeading(
+      `${kindLabel} Approval: ${formatApprovalDecision(view.decision)}`,
+      resolvedBy ? `Resolved by ${resolvedBy}` : "Resolved",
+    ),
+    ...buildApprovalSubject(view),
+    buildApprovalMetadata(view.approvalId, view.metadata),
+  ]);
+}
+
+export function buildMSTeamsExpiredApprovalCard(
+  view: ExpiredApprovalView,
+): Record<string, unknown> {
+  const kindLabel = view.approvalKind === "plugin" ? "Plugin" : "Exec";
+  return buildAdaptiveCard([
+    ...buildCardHeading(
+      `${kindLabel} Approval Expired`,
+      "This approval request expired before it was resolved.",
+    ),
+    ...buildApprovalSubject(view),
+    buildApprovalMetadata(view.approvalId, view.metadata),
+  ]);
+}
+
+export function buildMSTeamsCanonicalApprovalTerminalCard(
+  result: ApprovalResolveResult,
+): Record<string, unknown> {
+  const { approval } = result;
+  const { presentation } = approval;
+  const kindLabel =
+    presentation.kind === "exec"
+      ? "Exec"
+      : presentation.kind === "plugin"
+        ? "Plugin"
+        : "System Agent";
+  const outcome =
+    approval.status === "allowed"
+      ? formatApprovalDecision(approval.decision)
+      : approval.status === "denied"
+        ? "Denied"
+        : approval.status === "expired"
+          ? "Expired"
+          : "Cancelled";
+  const subject: MSTeamsApprovalBodyItem[] =
+    presentation.kind === "exec"
+      ? [
+          { type: "TextBlock", text: "Command", weight: "Bolder", wrap: true },
+          {
+            type: "TextBlock",
+            text: presentation.commandPreview ?? presentation.commandText,
+            fontType: "Monospace",
+            wrap: true,
+          },
+        ]
+      : [
+          { type: "TextBlock", text: presentation.title, weight: "Bolder", wrap: true },
+          { type: "TextBlock", text: presentation.description, wrap: true },
+        ];
+  const metadata = [
+    { label: "Status", value: approval.status },
+    ...("decision" in approval ? [{ label: "Decision", value: approval.decision }] : []),
+    { label: "Reason", value: approval.reason },
+  ];
+  return buildAdaptiveCard([
+    ...buildCardHeading(
+      `${kindLabel} Approval: ${outcome}`,
+      result.applied ? "Resolved by this action" : "Already resolved",
+    ),
+    ...subject,
+    buildApprovalMetadata(approval.id, metadata),
+  ]);
+}

--- a/extensions/msteams/src/approval-handler.runtime.test.ts
+++ b/extensions/msteams/src/approval-handler.runtime.test.ts
@@ -1,0 +1,426 @@
+import type {
+  ExecApprovalPendingView,
+  ExpiredApprovalView,
+  PendingApprovalView,
+  PluginApprovalPendingView,
+  ResolvedApprovalView,
+} from "openclaw/plugin-sdk/approval-handler-runtime";
+import type {
+  ExecApprovalRequest,
+  PluginApprovalRequest,
+} from "openclaw/plugin-sdk/approval-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getMSTeamsApprovalCardBinding,
+  unregisterMSTeamsApprovalCardBindings,
+} from "./approval-card-actions.js";
+
+const sendAdaptiveCardMSTeams = vi.hoisted(() => vi.fn());
+const editAdaptiveCardMSTeams = vi.hoisted(() => vi.fn());
+
+vi.mock("./send.js", async () => ({
+  ...(await vi.importActual<typeof import("./send.js")>("./send.js")),
+  sendAdaptiveCardMSTeams,
+  editAdaptiveCardMSTeams,
+}));
+
+const { msTeamsApprovalNativeRuntime } = await import("./approval-handler.runtime.js");
+
+const cfg: OpenClawConfig = {
+  channels: {
+    msteams: {
+      enabled: true,
+      appId: "teams-app",
+      appPassword: "test-password",
+      tenantId: "teams-tenant",
+      allowFrom: ["00000000-0000-4000-8000-000000000001"],
+    },
+  },
+};
+
+function createExecPendingView(): ExecApprovalPendingView {
+  return {
+    approvalId: "exec-approval-1",
+    approvalKind: "exec",
+    phase: "pending",
+    title: "Exec Approval Required",
+    description: "A command needs your approval.",
+    metadata: [
+      { label: "Agent", value: "operations" },
+      { label: "Host", value: "gateway" },
+    ],
+    commandText: "deploy --production",
+    cwd: "/srv/service",
+    actions: [
+      {
+        decision: "allow-once",
+        label: "Approve once",
+        style: "success",
+        command: "/approve exec-approval-1 allow-once",
+      },
+      {
+        decision: "deny",
+        label: "Deny",
+        style: "danger",
+        command: "/approve exec-approval-1 deny",
+      },
+    ],
+    expiresAtMs: Date.now() + 60_000,
+  };
+}
+
+function createPluginPendingView(): PluginApprovalPendingView {
+  return {
+    approvalId: "plugin-approval-1",
+    approvalKind: "plugin",
+    phase: "pending",
+    title: "Deploy production service",
+    description: "The deployment plugin requests access.",
+    metadata: [
+      { label: "Plugin", value: "deployments" },
+      { label: "Tool", value: "deploy_service" },
+    ],
+    pluginId: "deployments",
+    toolName: "deploy_service",
+    severity: "critical",
+    actions: [
+      {
+        decision: "allow-once",
+        label: "Approve once",
+        style: "success",
+        command: "/approve plugin-approval-1 allow-once",
+      },
+    ],
+    expiresAtMs: Date.now() + 60_000,
+  };
+}
+
+function createRequest(view: PendingApprovalView): ExecApprovalRequest | PluginApprovalRequest {
+  return view.approvalKind === "plugin"
+    ? {
+        id: view.approvalId,
+        request: {
+          title: view.title,
+          description: view.description ?? "",
+          severity: view.severity,
+          pluginId: view.pluginId ?? undefined,
+          toolName: view.toolName ?? undefined,
+        },
+        createdAtMs: Date.now(),
+        expiresAtMs: view.expiresAtMs,
+      }
+    : {
+        id: view.approvalId,
+        request: { command: view.commandText },
+        createdAtMs: Date.now(),
+        expiresAtMs: view.expiresAtMs,
+      };
+}
+
+async function createPendingScenario(view: PendingApprovalView = createExecPendingView()) {
+  const request = createRequest(view);
+  const pendingPayload = await msTeamsApprovalNativeRuntime.presentation.buildPendingPayload({
+    cfg,
+    accountId: "default",
+    request,
+    approvalKind: view.approvalKind,
+    nowMs: Date.now(),
+    view,
+  });
+  const plannedTarget = {
+    surface: "origin" as const,
+    target: { to: "msteams:conversation:19:channel@thread.tacv2", threadId: "thread-root" },
+    reason: "preferred" as const,
+  };
+  const prepared = await msTeamsApprovalNativeRuntime.transport.prepareTarget({
+    cfg,
+    accountId: "default",
+    plannedTarget,
+    request,
+    approvalKind: view.approvalKind,
+    view,
+    pendingPayload,
+  });
+  if (!prepared) {
+    throw new Error("Expected prepared Microsoft Teams approval target");
+  }
+  return { view, request, pendingPayload, plannedTarget, prepared };
+}
+
+describe("msTeamsApprovalNativeRuntime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sendAdaptiveCardMSTeams.mockResolvedValue({
+      messageId: "approval-activity-1",
+      conversationId: "19:channel@thread.tacv2",
+    });
+    editAdaptiveCardMSTeams.mockResolvedValue({ conversationId: "19:channel@thread.tacv2" });
+  });
+
+  it.each([
+    {
+      name: "exec command and scope",
+      createView: createExecPendingView,
+      expectedContent: ["Exec Approval Required", "deploy --production", "operations", "gateway"],
+      expectedDecisions: ["allow-once", "deny"],
+    },
+    {
+      name: "plugin action and scope",
+      createView: createPluginPendingView,
+      expectedContent: [
+        "Plugin Approval Required",
+        "Deploy production service",
+        "deployments",
+        "deploy_service",
+      ],
+      expectedDecisions: ["allow-once"],
+    },
+  ])("renders the pending $name with only its authorized actions", async (testCase) => {
+    const { pendingPayload } = await createPendingScenario(testCase.createView());
+    const serializedCard = JSON.stringify(pendingPayload.card);
+    for (const expectedText of testCase.expectedContent) {
+      expect(serializedCard).toContain(expectedText);
+    }
+    expect(pendingPayload.allowedDecisions).toEqual(testCase.expectedDecisions);
+    expect(pendingPayload.card.actions).toEqual(
+      pendingPayload.actionTokens.map(({ token }, index) => ({
+        type: "Action.Submit",
+        title: testCase.createView().actions[index]?.label,
+        data: { openclawAction: "approval", token },
+      })),
+    );
+    expect(serializedCard).not.toContain("/approve");
+  });
+
+  it("normalizes destinations and preserves thread roots only for channel conversations", async () => {
+    const { view, request, pendingPayload } = await createPendingScenario();
+    for (const testCase of [
+      {
+        to: "msteams:conversation:19:channel@thread.tacv2",
+        expected: "conversation:19:channel@thread.tacv2;messageid=thread-root",
+      },
+      {
+        to: "conversation:19:channel@thread.tacv2;messageid=existing-root",
+        expected: "conversation:19:channel@thread.tacv2;messageid=existing-root",
+      },
+      { to: "conversation:19:group@thread.v2", expected: "conversation:19:group@thread.v2" },
+      {
+        to: "user:00000000-0000-4000-8000-000000000001",
+        expected: "user:00000000-0000-4000-8000-000000000001",
+      },
+    ]) {
+      const prepared = await msTeamsApprovalNativeRuntime.transport.prepareTarget({
+        cfg,
+        accountId: "default",
+        plannedTarget: {
+          surface: "origin",
+          target: { to: testCase.to, threadId: "thread-root" },
+          reason: "preferred",
+        },
+        request,
+        approvalKind: "exec",
+        view,
+        pendingPayload,
+      });
+      expect(prepared?.target.to).toBe(testCase.expected);
+    }
+  });
+
+  it("delivers and binds pending cards, then replaces resolved cards without actions", async () => {
+    const { view, request, pendingPayload, plannedTarget, prepared } =
+      await createPendingScenario();
+    const entry = await msTeamsApprovalNativeRuntime.transport.deliverPending({
+      cfg,
+      accountId: "default",
+      plannedTarget,
+      preparedTarget: prepared.target,
+      request,
+      approvalKind: "exec",
+      view,
+      pendingPayload,
+    });
+    if (!entry) {
+      throw new Error("Expected delivered Microsoft Teams approval card");
+    }
+    expect(sendAdaptiveCardMSTeams).toHaveBeenCalledWith({
+      cfg,
+      to: "conversation:19:channel@thread.tacv2;messageid=thread-root",
+      card: pendingPayload.card,
+    });
+
+    const binding = await msTeamsApprovalNativeRuntime.interactions?.bindPending?.({
+      cfg,
+      accountId: "default",
+      entry,
+      request,
+      approvalKind: "exec",
+      view,
+      pendingPayload,
+    });
+    if (!binding) {
+      throw new Error("Expected native approval action bindings");
+    }
+    expect(binding).toHaveLength(2);
+    for (const [index, token] of binding.entries()) {
+      expect(getMSTeamsApprovalCardBinding(token)).toEqual({
+        token,
+        accountId: "default",
+        approvalId: "exec-approval-1",
+        approvalKind: "exec",
+        decision: pendingPayload.actionTokens[index]?.decision,
+        allowedDecisions: ["allow-once", "deny"],
+        conversationId: "19:channel@thread.tacv2",
+        activityId: "approval-activity-1",
+        expiresAtMs: view.expiresAtMs,
+      });
+    }
+
+    const resolvedView: ResolvedApprovalView = {
+      ...view,
+      phase: "resolved",
+      decision: "allow-once",
+      resolvedBy: "00000000-0000-4000-8000-000000000001",
+    };
+    const final = await msTeamsApprovalNativeRuntime.presentation.buildResolvedResult({
+      cfg,
+      accountId: "default",
+      request,
+      resolved: {
+        id: request.id,
+        decision: "allow-once",
+        resolvedBy: "00000000-0000-4000-8000-000000000001",
+        ts: Date.now(),
+      },
+      view: resolvedView,
+      entry,
+    });
+    if (final.kind !== "update") {
+      throw new Error("Expected resolved Microsoft Teams approval card update");
+    }
+    await msTeamsApprovalNativeRuntime.transport.updateEntry?.({
+      cfg,
+      accountId: "default",
+      entry,
+      payload: final.payload,
+      phase: "resolved",
+    });
+    expect(editAdaptiveCardMSTeams).toHaveBeenCalledWith({
+      cfg,
+      to: "19:channel@thread.tacv2",
+      activityId: "approval-activity-1",
+      card: final.payload,
+    });
+    expect(JSON.stringify(final.payload)).toContain("Allowed once");
+    expect(final.payload).not.toHaveProperty("actions");
+
+    await msTeamsApprovalNativeRuntime.interactions?.unbindPending?.({
+      cfg,
+      accountId: "default",
+      entry,
+      binding,
+      request,
+      approvalKind: "exec",
+    });
+    for (const token of binding) {
+      expect(getMSTeamsApprovalCardBinding(token)).toBeNull();
+    }
+  });
+
+  it.each(["unknown", ""])(
+    "rejects an unaddressable approval activity id: %s",
+    async (messageId) => {
+      sendAdaptiveCardMSTeams.mockResolvedValue({
+        messageId,
+        conversationId: "19:channel@thread.tacv2",
+      });
+      const { view, request, pendingPayload, plannedTarget, prepared } =
+        await createPendingScenario();
+
+      await expect(
+        msTeamsApprovalNativeRuntime.transport.deliverPending({
+          cfg,
+          accountId: "default",
+          plannedTarget,
+          preparedTarget: prepared.target,
+          request,
+          approvalKind: "exec",
+          view,
+          pendingPayload,
+        }),
+      ).resolves.toBeNull();
+      for (const { token } of pendingPayload.actionTokens) {
+        expect(getMSTeamsApprovalCardBinding(token)).toBeNull();
+      }
+    },
+  );
+
+  it("replaces expired approvals without actions and releases canceled deliveries", async () => {
+    const { view, request, pendingPayload, plannedTarget, prepared } =
+      await createPendingScenario(createPluginPendingView());
+    const entry = await msTeamsApprovalNativeRuntime.transport.deliverPending({
+      cfg,
+      accountId: "default",
+      plannedTarget,
+      preparedTarget: prepared.target,
+      request,
+      approvalKind: "plugin",
+      view,
+      pendingPayload,
+    });
+    if (!entry) {
+      throw new Error("Expected delivered plugin approval card");
+    }
+    const binding = await msTeamsApprovalNativeRuntime.interactions?.bindPending?.({
+      cfg,
+      accountId: "default",
+      entry,
+      request,
+      approvalKind: "plugin",
+      view,
+      pendingPayload,
+    });
+    if (!binding) {
+      throw new Error("Expected plugin approval action bindings");
+    }
+
+    const expiredView: ExpiredApprovalView = { ...view, phase: "expired" };
+    const final = await msTeamsApprovalNativeRuntime.presentation.buildExpiredResult({
+      cfg,
+      accountId: "default",
+      request,
+      view: expiredView,
+      entry,
+    });
+    if (final.kind !== "update") {
+      throw new Error("Expected expired Microsoft Teams approval card update");
+    }
+    await msTeamsApprovalNativeRuntime.transport.updateEntry?.({
+      cfg,
+      accountId: "default",
+      entry,
+      payload: final.payload,
+      phase: "expired",
+    });
+    expect(editAdaptiveCardMSTeams).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activityId: "approval-activity-1",
+        card: final.payload,
+      }),
+    );
+    expect(JSON.stringify(final.payload)).toContain("Plugin Approval Expired");
+    expect(final.payload).not.toHaveProperty("actions");
+
+    await msTeamsApprovalNativeRuntime.interactions?.cancelDelivered?.({
+      cfg,
+      accountId: "default",
+      entry,
+      request,
+      approvalKind: "plugin",
+    });
+    for (const token of binding) {
+      expect(getMSTeamsApprovalCardBinding(token)).toBeNull();
+    }
+    unregisterMSTeamsApprovalCardBindings(binding);
+  });
+});

--- a/extensions/msteams/src/approval-handler.runtime.test.ts
+++ b/extensions/msteams/src/approval-handler.runtime.test.ts
@@ -18,11 +18,13 @@ import {
 
 const sendAdaptiveCardMSTeams = vi.hoisted(() => vi.fn());
 const editAdaptiveCardMSTeams = vi.hoisted(() => vi.fn());
+const sendMessageMSTeams = vi.hoisted(() => vi.fn());
 
 vi.mock("./send.js", async () => ({
   ...(await vi.importActual<typeof import("./send.js")>("./send.js")),
   sendAdaptiveCardMSTeams,
   editAdaptiveCardMSTeams,
+  sendMessageMSTeams,
 }));
 
 const { msTeamsApprovalNativeRuntime } = await import("./approval-handler.runtime.js");
@@ -225,6 +227,30 @@ describe("msTeamsApprovalNativeRuntime", () => {
       });
       expect(prepared?.target.to).toBe(testCase.expected);
     }
+  });
+
+  it("sends a visible text fallback when card delivery fails", async () => {
+    const { view, request, pendingPayload, plannedTarget } = await createPendingScenario();
+    sendMessageMSTeams.mockResolvedValue({
+      messageId: "fallback-1",
+      conversationId: "19:channel@thread.tacv2",
+    });
+
+    msTeamsApprovalNativeRuntime.observe?.onDeliveryError?.({
+      cfg,
+      accountId: "default",
+      error: new Error("card send failed"),
+      plannedTarget,
+      request,
+      approvalKind: "exec",
+      view,
+      pendingPayload,
+    });
+
+    await vi.waitFor(() => expect(sendMessageMSTeams).toHaveBeenCalledTimes(1));
+    const fallback = sendMessageMSTeams.mock.calls[0]?.[0];
+    expect(fallback?.to).toBe("msteams:conversation:19:channel@thread.tacv2");
+    expect(fallback?.text).toContain("/approve exec-approval-1 <allow-once|deny>");
   });
 
   it("delivers and binds pending cards, then replaces resolved cards without actions", async () => {

--- a/extensions/msteams/src/approval-handler.runtime.ts
+++ b/extensions/msteams/src/approval-handler.runtime.ts
@@ -1,0 +1,136 @@
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import { createChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
+import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import {
+  registerMSTeamsApprovalCardBinding,
+  unregisterMSTeamsApprovalCardBindings,
+} from "./approval-card-actions.js";
+import {
+  buildMSTeamsExpiredApprovalCard,
+  buildMSTeamsPendingApprovalCard,
+  buildMSTeamsResolvedApprovalCard,
+  type MSTeamsApprovalActionToken,
+} from "./approval-card.js";
+import {
+  isMSTeamsNativeApprovalClientEnabled,
+  shouldHandleMSTeamsNativeApprovalRequest,
+} from "./approval-native.js";
+import { extractMSTeamsConversationMessageId } from "./inbound.js";
+import { normalizeMSTeamsMessagingTarget } from "./resolve-allowlist.js";
+import { editAdaptiveCardMSTeams, sendAdaptiveCardMSTeams } from "./send.js";
+import { inferMSTeamsTargetChatType } from "./session-route.js";
+
+const log = createSubsystemLogger("msteams/approvals");
+
+type MSTeamsPendingDelivery = ReturnType<typeof buildMSTeamsPendingApprovalCard>;
+
+type MSTeamsPendingEntry = {
+  accountId: string;
+  conversationId: string;
+  activityId: string;
+  actionTokens: readonly MSTeamsApprovalActionToken[];
+};
+
+export const msTeamsApprovalNativeRuntime = createChannelApprovalNativeRuntimeAdapter<
+  MSTeamsPendingDelivery,
+  { to: string },
+  MSTeamsPendingEntry,
+  readonly string[],
+  Record<string, unknown>
+>({
+  eventKinds: ["exec", "plugin"],
+  availability: {
+    isConfigured: ({ cfg, accountId }) => isMSTeamsNativeApprovalClientEnabled({ cfg, accountId }),
+    shouldHandle: ({ cfg, accountId, approvalKind, request }) =>
+      shouldHandleMSTeamsNativeApprovalRequest({ cfg, accountId, approvalKind, request }),
+  },
+  presentation: {
+    buildPendingPayload: ({ view, nowMs }) => buildMSTeamsPendingApprovalCard({ view, nowMs }),
+    buildResolvedResult: ({ view }) => ({
+      kind: "update",
+      payload: buildMSTeamsResolvedApprovalCard(view),
+    }),
+    buildExpiredResult: ({ view }) => ({
+      kind: "update",
+      payload: buildMSTeamsExpiredApprovalCard(view),
+    }),
+  },
+  transport: {
+    prepareTarget: ({ plannedTarget }) => {
+      const normalizedTarget = normalizeMSTeamsMessagingTarget(plannedTarget.target.to);
+      if (!normalizedTarget) {
+        throw new Error("Microsoft Teams approval delivery target is missing");
+      }
+      const threadId = plannedTarget.target.threadId;
+      const to =
+        threadId != null &&
+        inferMSTeamsTargetChatType(normalizedTarget) === "channel" &&
+        !extractMSTeamsConversationMessageId(normalizedTarget)
+          ? `${normalizedTarget};messageid=${threadId}`
+          : normalizedTarget;
+      return {
+        dedupeKey: buildChannelApprovalNativeTargetKey({
+          ...plannedTarget.target,
+          to: normalizedTarget,
+        }),
+        target: { to },
+      };
+    },
+    deliverPending: async ({ cfg, accountId, preparedTarget, pendingPayload }) => {
+      const sent = await sendAdaptiveCardMSTeams({
+        cfg,
+        to: preparedTarget.to,
+        card: pendingPayload.card,
+      });
+      if (!sent.messageId || sent.messageId === "unknown" || !sent.conversationId) {
+        return null;
+      }
+      return {
+        accountId: accountId ?? DEFAULT_ACCOUNT_ID,
+        conversationId: sent.conversationId,
+        activityId: sent.messageId,
+        actionTokens: pendingPayload.actionTokens,
+      };
+    },
+    updateEntry: async ({ cfg, entry, payload }) => {
+      await editAdaptiveCardMSTeams({
+        cfg,
+        to: entry.conversationId,
+        activityId: entry.activityId,
+        card: payload,
+      });
+    },
+  },
+  interactions: {
+    bindPending: ({ entry, request, approvalKind, view, pendingPayload }) => {
+      const tokens: string[] = [];
+      for (const actionToken of entry.actionTokens) {
+        if (
+          registerMSTeamsApprovalCardBinding({
+            token: actionToken.token,
+            accountId: entry.accountId,
+            approvalId: request.id,
+            approvalKind,
+            decision: actionToken.decision,
+            allowedDecisions: pendingPayload.allowedDecisions,
+            conversationId: entry.conversationId,
+            activityId: entry.activityId,
+            expiresAtMs: view.expiresAtMs,
+          })
+        ) {
+          tokens.push(actionToken.token);
+        }
+      }
+      return tokens.length > 0 ? tokens : null;
+    },
+    unbindPending: ({ binding }) => unregisterMSTeamsApprovalCardBindings(binding),
+    cancelDelivered: ({ entry }) =>
+      unregisterMSTeamsApprovalCardBindings(entry.actionTokens.map(({ token }) => token)),
+  },
+  observe: {
+    onDeliveryError: ({ error, request }) => {
+      log.error(`msteams approvals: failed to deliver request ${request.id}: ${String(error)}`);
+    },
+  },
+});

--- a/extensions/msteams/src/approval-handler.runtime.ts
+++ b/extensions/msteams/src/approval-handler.runtime.ts
@@ -18,7 +18,7 @@ import {
 } from "./approval-native.js";
 import { extractMSTeamsConversationMessageId } from "./inbound.js";
 import { normalizeMSTeamsMessagingTarget } from "./resolve-allowlist.js";
-import { editAdaptiveCardMSTeams, sendAdaptiveCardMSTeams } from "./send.js";
+import { editAdaptiveCardMSTeams, sendAdaptiveCardMSTeams, sendMessageMSTeams } from "./send.js";
 import { inferMSTeamsTargetChatType } from "./session-route.js";
 
 const log = createSubsystemLogger("msteams/approvals");
@@ -129,8 +129,21 @@ export const msTeamsApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
       unregisterMSTeamsApprovalCardBindings(entry.actionTokens.map(({ token }) => token)),
   },
   observe: {
-    onDeliveryError: ({ error, request }) => {
+    onDeliveryError: ({ cfg, error, plannedTarget, request, approvalKind, pendingPayload }) => {
       log.error(`msteams approvals: failed to deliver request ${request.id}: ${String(error)}`);
+      // The active native route suppressed the local text prompt, so a failed
+      // card send must still surface a visible approval path (#130040 tracks
+      // the shared-boundary fix); losing both prompts is a silent failure.
+      const decisions = pendingPayload.allowedDecisions.join("|");
+      void sendMessageMSTeams({
+        cfg,
+        to: plannedTarget.target.to,
+        text: `⚠️ Could not deliver the ${approvalKind} approval card for ${request.id}. Reply "/approve ${request.id} <${decisions}>" to resolve it.`,
+      }).catch((fallbackError: unknown) => {
+        log.error(
+          `msteams approvals: fallback prompt for ${request.id} also failed: ${String(fallbackError)}`,
+        );
+      });
     },
   },
 });

--- a/extensions/msteams/src/approval-native.test.ts
+++ b/extensions/msteams/src/approval-native.test.ts
@@ -1,0 +1,304 @@
+import { isImplicitSameChatApprovalAuthorization } from "openclaw/plugin-sdk/approval-auth-runtime";
+import type { ExecApprovalRequest } from "openclaw/plugin-sdk/approval-runtime";
+import type { ChannelOutboundPayloadHint } from "openclaw/plugin-sdk/channel-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { describe, expect, it } from "vitest";
+import {
+  isMSTeamsNativeApprovalClientEnabled,
+  msTeamsApprovalCapability,
+  shouldHandleMSTeamsNativeApprovalRequest,
+  shouldSuppressLocalMSTeamsExecApprovalPrompt,
+} from "./approval-native.js";
+
+const APPROVER_ID = "40a1a0ed-4ff2-4164-a219-55518990c197";
+const OTHER_USER_ID = "b2d381f1-36dd-4120-b6fb-8dd37388ff11";
+const CONVERSATION_ID = "19:channel@thread.tacv2";
+
+function createConfig(
+  overrides: {
+    approvals?: OpenClawConfig["approvals"];
+    teams?: Partial<NonNullable<NonNullable<OpenClawConfig["channels"]>["msteams"]>>;
+  } = {},
+): OpenClawConfig {
+  return {
+    approvals: overrides.approvals ?? { exec: { enabled: true } },
+    channels: {
+      msteams: {
+        appId: "app-id",
+        appPassword: "app-password",
+        tenantId: "tenant-id",
+        allowFrom: [APPROVER_ID],
+        ...overrides.teams,
+      },
+    },
+  };
+}
+
+function createExecRequest(
+  overrides: Partial<ExecApprovalRequest["request"]> = {},
+): ExecApprovalRequest {
+  return {
+    id: "approval-1",
+    request: {
+      command: "echo hello",
+      turnSourceChannel: "msteams",
+      turnSourceTo: `conversation:${CONVERSATION_ID}`,
+      turnSourceAccountId: "default",
+      ...overrides,
+    },
+    createdAtMs: 0,
+    expiresAtMs: 60_000,
+  };
+}
+
+const pendingExecPayload: ReplyPayload = {
+  text: "Approval required.",
+  channelData: {
+    execApproval: {
+      approvalId: "12345678-1234-1234-1234-123456789012",
+      approvalSlug: "12345678",
+      approvalKind: "exec",
+      agentId: "main",
+      sessionKey: "agent:main:msteams:channel:example",
+    },
+  },
+};
+
+const activeExecApprovalHint: ChannelOutboundPayloadHint = {
+  kind: "approval-pending",
+  approvalKind: "exec",
+  nativeRouteActive: true,
+};
+
+describe("Microsoft Teams native approval capability", () => {
+  it("subscribes to exec and plugin approvals for a configured bot and approver", () => {
+    const runtime = msTeamsApprovalCapability.nativeRuntime;
+
+    expect(runtime?.eventKinds).toEqual(["exec", "plugin"]);
+    expect(runtime?.availability.isConfigured({ cfg: createConfig() })).toBe(true);
+    expect(
+      runtime?.availability.isConfigured({
+        cfg: createConfig({ approvals: { plugin: { enabled: true } } }),
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    {
+      name: "approval forwarding is absent",
+      cfg: { channels: createConfig().channels } satisfies OpenClawConfig,
+    },
+    {
+      name: "exec forwarding is disabled",
+      cfg: createConfig({ approvals: { exec: { enabled: false } } }),
+    },
+    {
+      name: "forwarding only targets another channel",
+      cfg: createConfig({
+        approvals: {
+          exec: {
+            enabled: true,
+            mode: "targets",
+            targets: [{ channel: "slack", to: "channel:C123" }],
+          },
+        },
+      }),
+    },
+    {
+      name: "the Teams account is disabled",
+      cfg: createConfig({ teams: { enabled: false } }),
+    },
+    {
+      name: "the bot credentials are incomplete",
+      cfg: createConfig({ teams: { appPassword: undefined } }),
+    },
+    {
+      name: "no approvers are configured",
+      cfg: createConfig({ teams: { allowFrom: undefined } }),
+    },
+    {
+      name: "allowlist entries are not stable Entra object IDs",
+      cfg: createConfig({ teams: { allowFrom: ["someone@example.com", "*"] } }),
+    },
+  ])("does not enable native approvals when $name", ({ cfg }) => {
+    expect(isMSTeamsNativeApprovalClientEnabled({ cfg })).toBe(false);
+  });
+
+  it("accepts a valid default destination as the configured approver", () => {
+    const cfg = createConfig({
+      teams: { allowFrom: undefined, defaultTo: `user:${APPROVER_ID.toUpperCase()}` },
+    });
+
+    expect(isMSTeamsNativeApprovalClientEnabled({ cfg })).toBe(true);
+    expect(
+      msTeamsApprovalCapability.authorizeActorAction?.({
+        cfg,
+        senderId: APPROVER_ID,
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toEqual({ authorized: true });
+  });
+
+  it("keeps authorization available when native forwarding is disabled", () => {
+    const cfg = createConfig({ approvals: { exec: { enabled: false } } });
+
+    expect(
+      msTeamsApprovalCapability.getActionAvailabilityState?.({
+        cfg,
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toEqual({ kind: "enabled" });
+    expect(
+      msTeamsApprovalCapability.authorizeActorAction?.({
+        cfg,
+        senderId: APPROVER_ID.toUpperCase(),
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toEqual({ authorized: true });
+  });
+
+  it("rejects unlisted actors for both approval kinds", () => {
+    for (const approvalKind of ["exec", "plugin"] as const) {
+      expect(
+        msTeamsApprovalCapability.authorizeActorAction?.({
+          cfg: createConfig(),
+          senderId: OTHER_USER_ID,
+          action: "approve",
+          approvalKind,
+        }),
+      ).toEqual({
+        authorized: false,
+        reason: `❌ You are not authorized to approve ${approvalKind} requests on Microsoft Teams.`,
+      });
+    }
+  });
+
+  it("preserves implicit same-chat authorization when no approvers are configured", () => {
+    const authorization = msTeamsApprovalCapability.authorizeActorAction?.({
+      cfg: createConfig({ teams: { allowFrom: undefined } }),
+      senderId: OTHER_USER_ID,
+      action: "approve",
+      approvalKind: "exec",
+    });
+
+    expect(authorization).toEqual({ authorized: true });
+    expect(isImplicitSameChatApprovalAuthorization(authorization)).toBe(true);
+  });
+
+  it("restricts routing to the single Teams account and originating channel", () => {
+    const cfg = createConfig();
+    const request = createExecRequest();
+
+    expect(
+      shouldHandleMSTeamsNativeApprovalRequest({
+        cfg,
+        accountId: "default",
+        approvalKind: "exec",
+        request,
+      }),
+    ).toBe(true);
+    expect(
+      shouldHandleMSTeamsNativeApprovalRequest({
+        cfg,
+        accountId: "other",
+        approvalKind: "exec",
+        request,
+      }),
+    ).toBe(false);
+    expect(
+      shouldHandleMSTeamsNativeApprovalRequest({
+        cfg,
+        approvalKind: "exec",
+        request: createExecRequest({ turnSourceChannel: "slack" }),
+      }),
+    ).toBe(false);
+    expect(
+      shouldHandleMSTeamsNativeApprovalRequest({
+        cfg,
+        approvalKind: "exec",
+        request: createExecRequest({ turnSourceTo: "  " }),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not handle exec approvals when only plugin forwarding is enabled", () => {
+    expect(
+      shouldHandleMSTeamsNativeApprovalRequest({
+        cfg: createConfig({ approvals: { plugin: { enabled: true } } }),
+        approvalKind: "exec",
+        request: createExecRequest(),
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves the normalized conversation and source thread for native delivery", () => {
+    const request = createExecRequest({
+      turnSourceTo: `teams:conversation:${CONVERSATION_ID}`,
+      turnSourceThreadId: "thread-root-123",
+    });
+
+    expect(
+      msTeamsApprovalCapability.native?.resolveOriginTarget?.({
+        cfg: createConfig(),
+        accountId: "default",
+        approvalKind: "exec",
+        request,
+      }),
+    ).toEqual({
+      to: `conversation:${CONVERSATION_ID}`,
+      accountId: "default",
+      threadId: "thread-root-123",
+    });
+  });
+
+  it("maps stable allowlisted approvers to user-prefixed Teams DM targets", () => {
+    expect(
+      msTeamsApprovalCapability.native?.resolveApproverDmTargets?.({
+        cfg: createConfig(),
+        accountId: "default",
+        approvalKind: "exec",
+        request: createExecRequest(),
+      }),
+    ).toEqual([{ to: `user:${APPROVER_ID}`, accountId: "default" }]);
+  });
+
+  it("suppresses the duplicate text prompt only while native exec delivery owns it", () => {
+    expect(
+      shouldSuppressLocalMSTeamsExecApprovalPrompt({
+        cfg: createConfig(),
+        payload: pendingExecPayload,
+        hint: activeExecApprovalHint,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSuppressLocalMSTeamsExecApprovalPrompt({
+        cfg: createConfig(),
+        payload: pendingExecPayload,
+        hint: { ...activeExecApprovalHint, nativeRouteActive: false },
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSuppressLocalMSTeamsExecApprovalPrompt({
+        cfg: createConfig({ approvals: { exec: { enabled: false } } }),
+        payload: pendingExecPayload,
+        hint: activeExecApprovalHint,
+      }),
+    ).toBe(false);
+  });
+
+  it("describes the existing Teams allowlist and default destination setup", () => {
+    const guidance = msTeamsApprovalCapability.describeExecApprovalSetup?.({
+      channel: "msteams",
+      channelLabel: "Microsoft Teams",
+    });
+
+    expect(guidance).toContain("`channels.msteams.allowFrom`");
+    expect(guidance).toContain("`channels.msteams.defaultTo`");
+  });
+});

--- a/extensions/msteams/src/approval-native.ts
+++ b/extensions/msteams/src/approval-native.ts
@@ -1,0 +1,176 @@
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { createApproverRestrictedNativeApprovalCapability } from "openclaw/plugin-sdk/approval-delivery-runtime";
+import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
+import type {
+  ChannelApprovalKind,
+  ChannelApprovalNativeRuntimeAdapter,
+} from "openclaw/plugin-sdk/approval-handler-runtime";
+import {
+  createChannelApproverDmTargetResolver,
+  createChannelNativeOriginTargetResolver,
+  createNativeApprovalChannelRouteGates,
+  createNativeApprovalMessagingTargetResolvers,
+  shouldSuppressLocalNativeExecApprovalPrompt,
+} from "openclaw/plugin-sdk/approval-native-runtime";
+import type {
+  ExecApprovalRequest,
+  PluginApprovalRequest,
+} from "openclaw/plugin-sdk/approval-runtime";
+import type {
+  ChannelApprovalCapability,
+  ChannelOutboundPayloadHint,
+} from "openclaw/plugin-sdk/channel-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { getMSTeamsApprovalApprovers, msTeamsApprovalAuth } from "./approval-auth.js";
+import { msteamsConfigAdapter, resolveMSTeamsAccount } from "./channel-config.js";
+import { normalizeMSTeamsMessagingTarget } from "./resolve-allowlist.js";
+
+type MSTeamsApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+
+function isMSTeamsApprovalTransportEnabled(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): boolean {
+  if (params.accountId && normalizeAccountId(params.accountId) !== DEFAULT_ACCOUNT_ID) {
+    return false;
+  }
+  const account = resolveMSTeamsAccount(params.cfg);
+  return account.enabled && account.configured && account.tokenStatus === "available";
+}
+
+const msTeamsMessagingTargetResolvers = createNativeApprovalMessagingTargetResolvers({
+  channel: "msteams",
+  normalizeTo: normalizeMSTeamsMessagingTarget,
+});
+
+const msTeamsApprovalTargetResolvers = {
+  ...msTeamsMessagingTargetResolvers,
+  resolveTurnSourceTarget: (request: MSTeamsApprovalRequest) => {
+    const target = msTeamsMessagingTargetResolvers.resolveTurnSourceTarget(request);
+    return target ? { ...target, threadId: request.request.turnSourceThreadId ?? null } : null;
+  },
+  resolveSessionTarget: (
+    sessionTarget: Parameters<typeof msTeamsMessagingTargetResolvers.resolveSessionTarget>[0],
+  ) => {
+    const target = msTeamsMessagingTargetResolvers.resolveSessionTarget(sessionTarget);
+    return target ? { ...target, threadId: sessionTarget.threadId ?? null } : null;
+  },
+};
+
+const msTeamsApprovalRouteGates = createNativeApprovalChannelRouteGates({
+  channel: "msteams",
+  defaultForwardingMode: "session",
+  isTransportEnabled: isMSTeamsApprovalTransportEnabled,
+  listAccountIds: msteamsConfigAdapter.listAccountIds,
+  resolveDefaultAccountId: () => DEFAULT_ACCOUNT_ID,
+  normalizeForwardTarget: msTeamsApprovalTargetResolvers.normalizeForwardTarget,
+  resolveTurnSourceTarget: msTeamsApprovalTargetResolvers.resolveTurnSourceTarget,
+});
+
+export function isMSTeamsNativeApprovalClientEnabled(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): boolean {
+  return (
+    msTeamsApprovalRouteGates.canAnyApprovalPotentiallyRouteToChannel({
+      ...params,
+      nativeSessionOnly: true,
+    }) && getMSTeamsApprovalApprovers(params).length > 0
+  );
+}
+
+export function shouldHandleMSTeamsNativeApprovalRequest(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  approvalKind?: ChannelApprovalKind;
+  request: MSTeamsApprovalRequest;
+}): boolean {
+  return (
+    msTeamsApprovalRouteGates.shouldHandleApprovalRequest(params) &&
+    getMSTeamsApprovalApprovers(params).length > 0 &&
+    Boolean(msTeamsApprovalTargetResolvers.resolveTurnSourceTarget(params.request))
+  );
+}
+
+export function shouldSuppressLocalMSTeamsExecApprovalPrompt(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  payload: ReplyPayload;
+  hint?: ChannelOutboundPayloadHint;
+}): boolean {
+  return shouldSuppressLocalNativeExecApprovalPrompt({
+    ...params,
+    isNativeDeliveryEnabled: isMSTeamsNativeApprovalClientEnabled,
+  });
+}
+
+const resolveMSTeamsOriginTarget = createChannelNativeOriginTargetResolver({
+  channel: "msteams",
+  shouldHandleRequest: shouldHandleMSTeamsNativeApprovalRequest,
+  resolveTurnSourceTarget: msTeamsApprovalTargetResolvers.resolveTurnSourceTarget,
+  resolveSessionTarget: msTeamsApprovalTargetResolvers.resolveSessionTarget,
+  normalizeTarget: msTeamsApprovalTargetResolvers.normalizeTarget,
+});
+
+const msTeamsLazyApprovalNativeRuntime = createLazyChannelApprovalNativeRuntimeAdapter({
+  eventKinds: ["exec", "plugin"],
+  isConfigured: ({ cfg, accountId }) => isMSTeamsNativeApprovalClientEnabled({ cfg, accountId }),
+  shouldHandle: ({ cfg, accountId, approvalKind, request }) =>
+    shouldHandleMSTeamsNativeApprovalRequest({ cfg, accountId, approvalKind, request }),
+  load: async () => {
+    const { msTeamsApprovalNativeRuntime } = await import("./approval-handler.runtime.js");
+    // SAFETY: Core only returns payloads and entries produced by this same typed runtime.
+    return msTeamsApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter;
+  },
+});
+
+const resolveMSTeamsApproverDmTargets = createChannelApproverDmTargetResolver({
+  shouldHandleRequest: shouldHandleMSTeamsNativeApprovalRequest,
+  resolveApprovers: getMSTeamsApprovalApprovers,
+  mapApprover: (approver, params) => ({
+    to: `user:${approver}`,
+    accountId: normalizeOptionalString(params.accountId),
+  }),
+});
+
+const msTeamsNativeApprovalCapability = createApproverRestrictedNativeApprovalCapability({
+  channel: "msteams",
+  channelLabel: "Microsoft Teams",
+  describeExecApprovalSetup: () =>
+    "Approve it from the Web UI or terminal UI for now. Microsoft Teams supports native approvals when the bot is configured. Configure `channels.msteams.allowFrom` or `channels.msteams.defaultTo` with Microsoft Entra object ID approvers.",
+  listAccountIds: msteamsConfigAdapter.listAccountIds,
+  hasApprovers: ({ cfg, accountId }) => getMSTeamsApprovalApprovers({ cfg, accountId }).length > 0,
+  isExecAuthorizedSender: ({ cfg, accountId, senderId }) =>
+    msTeamsApprovalAuth.authorizeActorAction?.({
+      cfg,
+      accountId,
+      senderId,
+      action: "approve",
+      approvalKind: "exec",
+    })?.authorized ?? false,
+  isPluginAuthorizedSender: ({ cfg, accountId, senderId }) =>
+    msTeamsApprovalAuth.authorizeActorAction?.({
+      cfg,
+      accountId,
+      senderId,
+      action: "approve",
+      approvalKind: "plugin",
+    })?.authorized ?? false,
+  isNativeDeliveryEnabled: isMSTeamsNativeApprovalClientEnabled,
+  resolveNativeDeliveryMode: () => "channel",
+  requireMatchingTurnSourceChannel: true,
+  resolveSuppressionAccountId: ({ target, request }) =>
+    normalizeOptionalString(target.accountId) ??
+    normalizeOptionalString(request.request.turnSourceAccountId),
+  resolveOriginTarget: resolveMSTeamsOriginTarget,
+  resolveApproverDmTargets: resolveMSTeamsApproverDmTargets,
+  nativeRuntime: msTeamsLazyApprovalNativeRuntime,
+});
+
+export const msTeamsApprovalCapability: ChannelApprovalCapability = {
+  ...msTeamsNativeApprovalCapability,
+  // Preserve implicit same-chat authorization when no explicit approvers exist.
+  authorizeActorAction: (params) => msTeamsApprovalAuth.authorizeActorAction?.(params),
+};

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -1,12 +1,14 @@
 // Msteams tests cover channel plugin behavior.
 import fs from "node:fs";
 import path from "node:path";
+import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MSTeamsConfigSchema } from "../config-api.js";
 import { msteamsDirectoryContractPlugin } from "../directory-contract-api.js";
 import { msTeamsApprovalAuth } from "./approval-auth.js";
+import { msTeamsApprovalCapability } from "./approval-native.js";
 import { msteamsPlugin } from "./channel.js";
 import { msteamsSetupPlugin } from "./channel.setup.js";
 
@@ -241,8 +243,19 @@ describe("msteamsPlugin", () => {
     },
   );
 
-  it("exposes approval auth through approvalCapability", () => {
-    expect(msteamsPlugin.approvalCapability).toBe(msTeamsApprovalAuth);
+  it("exposes native approval delivery without replacing existing approval authorization", () => {
+    const authorization = {
+      cfg: createConfiguredMSTeamsCfg(),
+      senderId: "40a1a0ed-4ff2-4164-a219-55518990c197",
+      action: "approve",
+      approvalKind: "exec",
+    } as const;
+
+    expect(msteamsPlugin.approvalCapability).toBe(msTeamsApprovalCapability);
+    expect(msteamsPlugin.approvalCapability?.authorizeActorAction?.(authorization)).toEqual(
+      msTeamsApprovalAuth.authorizeActorAction?.(authorization),
+    );
+    expect(msteamsPlugin.approvalCapability?.nativeRuntime?.eventKinds).toEqual(["exec", "plugin"]);
   });
 
   it("advertises legacy and group-management message-tool actions together", () => {
@@ -269,6 +282,66 @@ describe("msteamsPlugin", () => {
       "removeParticipant",
       "renameGroup",
     ]);
+  });
+
+  it("registers the approval runtime before monitor startup only when native delivery is enabled", async () => {
+    const monitorModule = await import("./index.js");
+    const monitor = vi.spyOn(monitorModule, "monitorMSTeamsProvider").mockResolvedValue({
+      app: null,
+      shutdown: async () => {},
+    });
+    const register = vi.fn(() => ({ dispose: vi.fn() }));
+    const controller = new AbortController();
+    const cfg: OpenClawConfig = {
+      ...createConfiguredMSTeamsCfg(),
+      approvals: { exec: { enabled: true } },
+      channels: {
+        msteams: {
+          ...createConfiguredMSTeamsCfg().channels?.msteams,
+          allowFrom: ["40a1a0ed-4ff2-4164-a219-55518990c197"],
+        },
+      },
+    };
+    const startAccount = async (config: OpenClawConfig) =>
+      await msteamsPlugin.gateway?.startAccount?.({
+        cfg: config,
+        accountId: "default",
+        account: msteamsPlugin.config.resolveAccount(config, "default"),
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        abortSignal: controller.signal,
+        getStatus: () => ({ accountId: "default" }),
+        setStatus: vi.fn(),
+        channelRuntime: {
+          runtimeContexts: {
+            register,
+            get: () => undefined,
+            watch: () => () => {},
+          },
+        },
+      });
+
+    try {
+      await startAccount(cfg);
+
+      expect(register).toHaveBeenCalledWith({
+        channelId: "msteams",
+        accountId: "default",
+        capability: CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
+        context: {},
+        abortSignal: controller.signal,
+      });
+      expect(register.mock.invocationCallOrder[0]).toBeLessThan(
+        monitor.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+      );
+
+      await startAccount({ ...cfg, approvals: { exec: { enabled: false } } });
+
+      expect(register).toHaveBeenCalledOnce();
+      expect(monitor).toHaveBeenCalledTimes(2);
+    } finally {
+      controller.abort();
+      monitor.mockRestore();
+    }
   });
 
   it("reuses the shared Teams target-id matcher for explicit targets", () => {

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -1,4 +1,5 @@
 // Msteams plugin module implements channel behavior.
+import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
 import type {
   ChannelMessageActionAdapter,
   ChannelMessageToolDiscovery,
@@ -14,6 +15,7 @@ import {
   createAllowlistProviderGroupPolicyWarningCollector,
   createConditionalWarningCollector,
 } from "openclaw/plugin-sdk/channel-policy";
+import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
 import {
   createChannelDirectoryAdapter,
   createRuntimeDirectoryLiveAdapter,
@@ -45,7 +47,11 @@ import {
   msteamsContextTargetsMatch,
   resolveMSTeamsAutoThreadId,
 } from "./action-threading.js";
-import { msTeamsApprovalAuth } from "./approval-auth.js";
+import {
+  isMSTeamsNativeApprovalClientEnabled,
+  msTeamsApprovalCapability,
+  shouldSuppressLocalMSTeamsExecApprovalPrompt,
+} from "./approval-native.js";
 import { resolveMSTeamsAccount, type ResolvedMSTeamsAccount } from "./channel-config.js";
 import { msteamsSetupPlugin } from "./channel.setup.js";
 import { collectMSTeamsMutableAllowlistWarnings } from "./doctor.js";
@@ -371,6 +377,8 @@ const msteamsChannelOutbound: ChannelOutboundAdapter = {
   resolveEffectiveTextChunkLimit: ({ fallbackLimit }) =>
     typeof fallbackLimit === "number" && fallbackLimit > 0 ? Math.min(fallbackLimit, 4000) : 4000,
   pollMaxOptions: 12,
+  shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload, hint }) =>
+    shouldSuppressLocalMSTeamsExecApprovalPrompt({ cfg, accountId, payload, hint }),
   deliveryCapabilities: {
     durableFinal: {
       text: true,
@@ -426,7 +434,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
       groups: {
         resolveToolPolicy: resolveMSTeamsGroupToolPolicy,
       },
-      approvalCapability: msTeamsApprovalAuth,
+      approvalCapability: msTeamsApprovalCapability,
       doctor: {
         dmAllowFromMode: "topOnly",
         groupModel: "hybrid",
@@ -1068,6 +1076,16 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
           });
           statusSink({ port });
           ctx.log?.info(`starting provider (port ${port})`);
+          if (isMSTeamsNativeApprovalClientEnabled({ cfg: ctx.cfg, accountId: ctx.accountId })) {
+            registerChannelRuntimeContext({
+              channelRuntime: ctx.channelRuntime,
+              channelId: "msteams",
+              accountId: ctx.accountId,
+              capability: CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
+              context: {},
+              abortSignal: ctx.abortSignal,
+            });
+          }
           return monitorMSTeamsProvider({
             cfg: ctx.cfg,
             runtime: ctx.runtime,

--- a/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
+++ b/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
@@ -282,6 +282,39 @@ describe("msteams adaptive card action invoke", () => {
     expect(ctxPayload.CommandBody).toBe(JSON.stringify(payload));
   });
 
+  it.each([
+    { activity: "invoke", token: "unknown-token" },
+    { activity: "invoke", token: "" },
+    { activity: "message", token: "unknown-token" },
+    { activity: "message", token: undefined },
+  ])(
+    "does not dispatch a rejected approval submit from a $activity activity",
+    async ({ activity, token }) => {
+      const deps = createDeps();
+      const data = {
+        openclawAction: "approval",
+        ...(token !== undefined ? { token } : {}),
+      };
+
+      if (activity === "invoke") {
+        const handler = createActivityHandler();
+        const registered = registerMSTeamsHandlers(handler, deps) as MSTeamsActivityHandler & {
+          run: NonNullable<MSTeamsActivityHandler["run"]>;
+        };
+        await runAdaptiveCardInvoke(registered, {
+          action: { type: "Action.Submit", data },
+        });
+      } else {
+        await runMessageActivity({ value: data, deps });
+      }
+
+      expect(runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+      expect(deps.log.info).toHaveBeenCalledWith("msteams approval ignored", {
+        reason: token ? "unknown or expired card token" : "missing card token",
+      });
+    },
+  );
+
   it("routes message activities with submitted card values as message text", async () => {
     const data = { value: "button-submit-value", label: "Submit action" };
 

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -1,6 +1,7 @@
 // Msteams plugin module implements monitor handler behavior.
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { serializeMSTeamsAdaptiveCardActionValue } from "./adaptive-card-submit.js";
+import { maybeHandleMSTeamsApprovalCardSubmit } from "./approval-card-submit.js";
 import { formatUnknownError } from "./errors.js";
 import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
 import { resolveMSTeamsSenderAccess } from "./monitor-handler/access.js";
@@ -153,6 +154,9 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
       // agent can react. Poll votes are intercepted in monitor.ts's
       // app.on("card.action") handler which returns the InvokeResponse to Teams.
       if (ctx.activity?.type === "invoke" && ctx.activity?.name === "adaptiveCard/action") {
+        if (await maybeHandleMSTeamsApprovalCardSubmit({ context: ctx, deps })) {
+          return;
+        }
         const text = serializeMSTeamsAdaptiveCardActionValue(ctx.activity?.value);
         if (text) {
           return await handleTeamsMessage(
@@ -181,7 +185,12 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
       await next();
     };
     try {
-      const result = await handleTeamsMessage(context as MSTeamsTurnContext, turnAdoptionLifecycle);
+      const ctx = context as MSTeamsTurnContext;
+      if (await maybeHandleMSTeamsApprovalCardSubmit({ context: ctx, deps })) {
+        await runNext();
+        return undefined;
+      }
+      const result = await handleTeamsMessage(ctx, turnAdoptionLifecycle);
       await runNext();
       return result;
     } catch (err) {

--- a/extensions/msteams/src/send.test.ts
+++ b/extensions/msteams/src/send.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
-import { deleteMessageMSTeams, editMessageMSTeams, sendMessageMSTeams } from "./send.js";
+import {
+  deleteMessageMSTeams,
+  editAdaptiveCardMSTeams,
+  editMessageMSTeams,
+  sendMessageMSTeams,
+} from "./send.js";
 
 const mockState = vi.hoisted(() => ({
   loadOutboundMediaFromUrl: vi.fn(),
@@ -612,6 +617,38 @@ describe("editMessageMSTeams", () => {
         text: "Updated text",
       }),
     ).rejects.toThrow("msteams edit failed");
+  });
+
+  it("updates an existing activity with a replacement Adaptive Card", async () => {
+    const mockApp = createMockApp();
+    mockState.resolveMSTeamsSendContext.mockResolvedValue({
+      app: mockApp,
+      conversationId: "19:conversation@thread.tacv2",
+      ref: { conversation: { id: "19:conversation@thread.tacv2" } },
+      log: { debug: vi.fn(), info: vi.fn() },
+      sdkCloudOptions: { cloud: "Public" },
+    });
+    const card = { type: "AdaptiveCard", version: "1.5", body: [] };
+
+    const result = await editAdaptiveCardMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: "conversation:19:conversation@thread.tacv2",
+      activityId: "approval-activity",
+      card,
+    });
+
+    expect(result.conversationId).toBe("19:conversation@thread.tacv2");
+    expect(mockState.updateMSTeamsActivityWithReference).toHaveBeenCalledWith(
+      mockApp,
+      expect.objectContaining({ conversation: { id: "19:conversation@thread.tacv2" } }),
+      "approval-activity",
+      {
+        type: "message",
+        id: "approval-activity",
+        attachments: [{ contentType: "application/vnd.microsoft.card.adaptive", content: card }],
+      },
+      { serviceUrlBoundary: { cloud: "Public" } },
+    );
   });
 });
 

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -558,27 +558,50 @@ type MSTeamsMessageMutationResult = {
 export async function editMessageMSTeams(
   params: MSTeamsMessageMutationParams & { text: string },
 ): Promise<MSTeamsMessageMutationResult> {
-  const { cfg, to, activityId, text } = params;
+  return updateMSTeamsMessageActivity({
+    ...params,
+    activity: {
+      type: "message",
+      id: params.activityId,
+      text: params.text,
+    },
+  });
+}
+
+export async function editAdaptiveCardMSTeams(
+  params: MSTeamsMessageMutationParams & { card: Record<string, unknown> },
+): Promise<MSTeamsMessageMutationResult> {
+  return updateMSTeamsMessageActivity({
+    ...params,
+    activity: {
+      type: "message",
+      id: params.activityId,
+      attachments: [
+        {
+          contentType: "application/vnd.microsoft.card.adaptive",
+          content: params.card,
+        },
+      ],
+    },
+  });
+}
+
+async function updateMSTeamsMessageActivity(
+  params: MSTeamsMessageMutationParams & { activity: Record<string, unknown> },
+): Promise<MSTeamsMessageMutationResult> {
+  const { cfg, to, activityId, activity } = params;
   const { app, conversationId, ref, log, sdkCloudOptions } = await resolveMSTeamsSendContext({
     cfg,
     to,
   });
 
-  log.debug?.("editing proactive message", { conversationId, activityId, textLength: text.length });
+  log.debug?.("editing proactive message", { conversationId, activityId });
 
   try {
     const baseRef = buildConversationReference(ref);
-    await updateMSTeamsActivityWithReference(
-      app,
-      baseRef,
-      activityId,
-      {
-        type: "message",
-        id: activityId,
-        text,
-      } as Record<string, unknown>,
-      { serviceUrlBoundary: sdkCloudOptions },
-    );
+    await updateMSTeamsActivityWithReference(app, baseRef, activityId, activity, {
+      serviceUrlBoundary: sdkCloudOptions,
+    });
   } catch (err) {
     throw createMSTeamsSendError("msteams edit", err);
   }

--- a/scripts/lib/type-assertion-guard-scope.mjs
+++ b/scripts/lib/type-assertion-guard-scope.mjs
@@ -72,6 +72,7 @@ export const CHAINED_ASSERTION_EXCLUDED_ROOTS = [
   "extensions/matrix/src/approval-native.ts", // approval runtime dynamically implements the public channel adapter seam
   "extensions/matrix/src/matrix/client/logging.ts", // Matrix SDK logger singleton has an undeclared loglevel capability
   "extensions/matrix/src/test-runtime.ts", // test support
+  "extensions/msteams/src/approval-native.ts", // approval runtime dynamically implements the public channel adapter seam
   "extensions/msteams/src/attachments/shared.ts", // Vitest mock metadata is intentionally probed in production test support
   "extensions/msteams/src/sdk-proactive.ts", // proactive sends require private Teams app transport internals
   "extensions/msteams/src/sdk.ts", // Teams SDK public and deep-import types disagree across package boundaries


### PR DESCRIPTION
## What Problem This Solves

Microsoft Teams was the only major bundled chat channel without native approval UI. When an exec approval or a gateway plugin approval originated from a Teams conversation, operators got the text-only `/approve <id> <decision>` fallback, while Slack, Discord, Telegram, and Google Chat users get interactive approve/deny controls. Approving from Teams meant hand-typing approval IDs or switching to the Web UI.

## Why This Change Was Made

Teams now delivers exec and plugin approvals as Adaptive Cards, following the Google Chat card-channel pattern (token-bound actions, one-shot claim, gateway resolution) and the shared SDK approval-native helpers. The pending card names the approval kind, the command (or plugin action title/description), metadata including the approval ID and expiry, and one `Action.Submit` button per decision the request actually allows. Card submits are intercepted in the monitor before they could be serialized into agent-visible message text, authorized against stable AAD object IDs from `channels.msteams.allowFrom`/`defaultTo` via the existing `msTeamsApprovalAuth`, claimed once (concurrent clicks and replays are rejected), resolved over the gateway, and the card is updated in place to its terminal state. Native delivery gates on the existing top-level `approvals.exec`/`approvals.plugin` forwarding config — no new Teams-specific config surface. The `/approve` text fallback and its implicit same-chat authorization are preserved unchanged.

## User Impact

Teams operators can approve or deny exec/plugin approvals with one click on a card in the originating conversation (including channel threads), gated to configured AAD-object-ID approvers. The card records the outcome and who resolved it. No configuration migration; the feature activates when approval forwarding is enabled and approvers resolve.

## Evidence

- `node scripts/run-vitest.mjs extensions/msteams` — 96 files / 1511 tests passed, including new suites: `approval-native.test.ts`, `approval-card.test.ts`, `approval-card-submit.test.ts`, `approval-handler.runtime.test.ts` (gating, origin-target resolution, unauthorized/unknown-token/conversation-mismatch/double-click rejection, gateway resolution + terminal card update, expiry).
- `node scripts/run-vitest.mjs extensions/googlechat extensions/slack` — 137 files / 2538 tests passed (sibling non-regression).
- `node scripts/check-changed.mjs` — all lanes green after rebase onto latest `main`.
- Autoreview (Codex, gpt-5.6-sol, high): clean, no accepted/actionable findings.
- Docs: `docs/channels/msteams.md` gains a "Native approval cards" section with config example.

Live Teams proof was not captured in this environment (no Teams tenant/bot credentials available to this session); the flow is covered at the boundary by the monitor-ingress card-submit tests and the runtime adapter transport tests.

## Included maintenance (flagged for maintainer eyes)

- **Chained-assertion ledger entry** for `extensions/msteams/src/approval-native.ts` — the lazy native-runtime adapter uses the same `as unknown as ChannelApprovalNativeRuntimeAdapter` seam as all 8 existing channel `approval-native.ts` files, each carrying the identical ledger entry ("approval runtime dynamically implements the public channel adapter seam"). A follow-up worth considering: type the SDK lazy-adapter seam so all 9 entries can be deleted.
