### PR TITLE
fix(deepinfra): preserve manifest reasoning during live discovery

### DIFF
--- a/extensions/deepinfra/provider-models.test.ts
+++ b/extensions/deepinfra/provider-models.test.ts
@@ -263,6 +263,89 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
     });
   });
 
+  it("preserves bundled reasoning and compat while keeping live model facts authoritative", async () => {
+    const rows = [
+      makeAgentModelEntry({
+        id: "deepseek-ai/DeepSeek-V4-Pro",
+        metadata: {
+          context_length: 96000,
+          max_tokens: 4096,
+          pricing: { input_tokens: 4, output_tokens: 8, cache_read_tokens: 0.4 },
+          tags: ["chat"],
+        },
+      }),
+      makeAgentModelEntry({
+        id: "stepfun-ai/Step-3.7-Flash",
+        metadata: {
+          context_length: 192000,
+          max_tokens: 16384,
+          pricing: { input_tokens: 0.2, output_tokens: 1.15 },
+          tags: ["chat", "vlm", "vision"],
+        },
+      }),
+      makeAgentModelEntry({
+        id: "deepseek-ai/DeepSeek-V3.2",
+        metadata: {
+          context_length: 64000,
+          max_tokens: 8192,
+          pricing: { input_tokens: 1, output_tokens: 2 },
+          tags: ["chat", "reasoning"],
+        },
+      }),
+      makeAgentModelEntry({
+        id: "unlisted/no-reasoning",
+        metadata: { context_length: 32000, max_tokens: 2048, pricing: {}, tags: ["chat"] },
+      }),
+      makeAgentModelEntry({
+        id: "unlisted/with-reasoning",
+        metadata: {
+          context_length: 48000,
+          max_tokens: 4096,
+          pricing: {},
+          tags: ["chat", "reasoning_effort"],
+        },
+      }),
+    ];
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse({ data: rows }));
+    DEEPINFRA_MODEL_CATALOG.push(DEEPINFRA_MODEL_CATALOG[0]!);
+
+    try {
+      await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
+        const models = await discoverDeepInfraModels();
+
+        expect(models.slice(0, rows.length)).toMatchObject([
+          {
+            id: "deepseek-ai/DeepSeek-V4-Pro",
+            reasoning: true,
+            input: ["text"],
+            contextWindow: 96000,
+            maxTokens: 4096,
+            cost: { input: 4, output: 8, cacheRead: 0.4, cacheWrite: 0 },
+            compat: {
+              codeMode: "capable",
+              supportsUsageInStreaming: true,
+              thinkingFormat: "deepseek",
+            },
+          },
+          {
+            id: "stepfun-ai/Step-3.7-Flash",
+            reasoning: true,
+            input: ["text", "image"],
+            contextWindow: 192000,
+            maxTokens: 16384,
+            cost: { input: 0.2, output: 1.15, cacheRead: 0, cacheWrite: 0 },
+          },
+          { id: "deepseek-ai/DeepSeek-V3.2", reasoning: false },
+          { id: "unlisted/no-reasoning", reasoning: false },
+          { id: "unlisted/with-reasoning", reasoning: true },
+        ]);
+        expect(new Set(models.map((model) => model.id)).size).toBe(models.length);
+      });
+    } finally {
+      DEEPINFRA_MODEL_CATALOG.pop();
+    }
+  });
+
   it("skips entries with no metadata or no surface tag, and deduplicates ids", async () => {
     const mockFetch = vi.fn().mockResolvedValue(
       jsonResponse({

--- a/extensions/deepinfra/provider-models.ts
+++ b/extensions/deepinfra/provider-models.ts
@@ -359,13 +359,15 @@ export function buildDeepInfraModelDefinition(model: ModelDefinitionConfig): Mod
 }
 
 function chatSurfaceModelToModelDefinition(model: DeepInfraSurfaceModel): ModelDefinitionConfig {
+  const manifestModel = DEEPINFRA_MODEL_CATALOG.find((entry) => entry.id === model.id);
   const input: Array<"text" | "image"> = model.tags.includes("vlm") ? ["text", "image"] : ["text"];
   const reasoning = model.tags.includes("reasoning") || model.tags.includes("reasoning_effort");
   return buildDeepInfraModelDefinition({
     id: model.id,
     name: model.name,
-    reasoning,
+    reasoning: manifestModel?.reasoning ?? reasoning,
     input,
+    ...(manifestModel?.compat ? { compat: manifestModel.compat } : {}),
     contextWindow: model.contextWindow ?? DEEPINFRA_DEFAULT_CONTEXT_WINDOW,
     maxTokens: model.maxTokens ?? DEEPINFRA_DEFAULT_MAX_TOKENS,
     cost: {
@@ -480,14 +482,10 @@ export async function discoverDeepInfraModels(options?: {
   }
   const liveModels = chatModels.map(chatSurfaceModelToModelDefinition);
   const seen = new Set(liveModels.map((model) => model.id));
-  const manifestModels = DEEPINFRA_MODEL_CATALOG.map(buildDeepInfraModelDefinition).filter(
-    (model) => {
-      if (seen.has(model.id)) {
-        return false;
-      }
-      seen.add(model.id);
-      return true;
-    },
-  );
+  const manifestModels = DEEPINFRA_MODEL_CATALOG.filter((model) => {
+    const unseen = !seen.has(model.id);
+    seen.add(model.id);
+    return unseen;
+  }).map(buildDeepInfraModelDefinition);
   return [...liveModels, ...manifestModels];
 }


### PR DESCRIPTION
## What Problem This Solves

DeepInfra's live model feed omits reasoning tags for currently available models that OpenClaw's curated provider manifest correctly declares as reasoning-capable. When live discovery replaced those manifest rows, `deepseek-ai/DeepSeek-V4-Pro` and `stepfun-ai/Step-3.7-Flash` became `reasoning: false`; DeepSeek V4 Pro additionally lost its curated `codeMode: "capable"` compatibility. The real OpenAI-compatible request builder consequently omitted the provider's supported reasoning controls.

## Why This Change Was Made

Merge the manifest-owned reasoning decision and compatibility metadata into matching live chat rows at the DeepInfra discovery owner. Keep live pricing, context windows, output limits, and modalities authoritative; derive reasoning from live tags for unknown models; honor an explicit manifest `reasoning: false`; and continue deduplicating the static fallback.

The provider manifest and its static published model rows are unchanged. Catalog publishing reads only plugin manifest JSON, so this runtime-only discovery repair requires neither a manifest edit nor a model-catalog publication.

Production delta: +8/-10, net -2 lines. Focused behavioral regressions: +83 test lines.

## User Impact

DeepSeek V4 Pro and Step 3.7 retain their advertised reasoning capability after authenticated model discovery, so ordinary OpenClaw runs can request their supported reasoning behavior. DeepSeek V4 Pro also retains its curated code-mode compatibility. Deprecated models explicitly marked non-reasoning stay non-reasoning, while live context, pricing, vision support, and new-provider model discovery continue to work as before.

## Evidence

- Queried DeepInfra's real unauthenticated public model endpoint: **189 live rows**. DeepSeek V4 Pro exposes only `chat` and `prompt_cache` tags, while Step 3.7 exposes `chat`, `vlm`, `vision`, and `prompt_cache`; neither advertises a reasoning tag despite both owning manifest rows declaring `reasoning: true`.
- Ran the real production discovery owner directly against the public provider endpoint: **106 live chat models**. DeepSeek V4 Pro and Step 3.7 now preserve `reasoning: true`; deprecated DeepSeek V3.2 preserves the manifest's explicit `reasoning: false`.
- Passed those actual discovered model definitions into the real OpenAI-compatible transport builder. Both corrected reasoning models emit `reasoning_effort: "high"`; DeepSeek V3.2 omits it. DeepSeek V4 Pro retains `codeMode: "capable"` and its DeepSeek thinking dialect.
- Captured an authentic fail-first regression against unmodified production: both current reasoning models incorrectly became non-reasoning, V4 Pro lost its code-mode compatibility, and an explicitly non-reasoning manifest model incorrectly became reasoning-capable.
- Seven focused discovery, proxy, plugin, onboarding, cross-surface, provider-contract, and reasoning-transport suites: **74 tests passed**; an additional general transport suite contributes **13 more passing tests** (**87 total**).
- Targeted owner-file lint, formatting, and `git diff --check` passed. A fresh independent whole-branch P1 review after rebasing found no actionable issues.\n- Refreshed the single provider commit onto main after the unrelated startup CSS budget regression was repaired in #130027.
- Static manifest model definitions, published catalog inputs, user credentials, authenticated APIs, paid inference, and operator services were untouched.

Provider contract: https://docs.deepinfra.com/chat/reasoning