### PR TITLE
fix(ui): show session diff path copy feedback

### DIFF
--- a/ui/src/pages/chat/components/session-diff-menus.ts
+++ b/ui/src/pages/chat/components/session-diff-menus.ts
@@ -55,7 +55,6 @@ export type SessionDiffMenuDraft = WithoutMenuAnchor<SessionDiffMenuData>;
 
 export type SessionDiffMenuAction =
   | { kind: "collapse-all" }
-  | { kind: "copy-path"; path: string }
   | { kind: "expand-all" }
   | { kind: "open-editor"; editor: EditorId; path: string }
   | { kind: "open-file"; path: string }
@@ -99,10 +98,6 @@ class SessionDiffMenu extends OpenClawLightDomElement {
       "scope:uncommitted": { kind: "scope", value: { scope: "uncommitted" } },
     };
     const fileMenu = this.menu?.kind === "file" ? this.menu : null;
-    if (fileMenu && value === "copy-path") {
-      this.run({ kind: "copy-path", path: fileMenu.path });
-      return;
-    }
     if (fileMenu && value === "open-file") {
       this.run({ kind: "open-file", path: fileMenu.path });
       return;
@@ -142,10 +137,7 @@ class SessionDiffMenu extends OpenClawLightDomElement {
 
   private renderFileMenu(menu: Extract<SessionDiffMenuData, { kind: "file" }>) {
     return html`
-      <wa-dropdown-item class="session-menu__item" value="copy-path">
-        <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.copy}</span>
-        <span class="session-menu__text">${t("chat.sessionDiff.copyPath")}</span>
-      </wa-dropdown-item>
+      ${this.renderCopyRow(menu.path, t("chat.sessionDiff.copyPath"))}
       <wa-dropdown-item class="session-menu__item" value="open-file" ?disabled=${!menu.canOpenFile}>
         <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.fileText}</span>
         <span class="session-menu__text">${t("chat.sessionDiff.openFile")}</span>

--- a/ui/src/pages/chat/components/session-diff-panel.test.ts
+++ b/ui/src/pages/chat/components/session-diff-panel.test.ts
@@ -76,9 +76,51 @@ afterEach(() => {
   document.body.replaceChildren();
   clearNativeGatewayTestState();
   vi.restoreAllMocks();
+  Reflect.deleteProperty(navigator, "clipboard");
 });
 
 describe("SessionDiffPanel", () => {
+  it.each([
+    { surface: "file", failed: false, feedback: "Copied!" },
+    { surface: "file", failed: true, feedback: "Copy failed" },
+    { surface: "sync", failed: false, feedback: "Copied!" },
+    { surface: "sync", failed: true, feedback: "Copy failed" },
+  ])(
+    "keeps $surface path copy feedback visible: $feedback",
+    async ({ surface, failed, feedback }) => {
+      const writeText = failed
+        ? vi.fn().mockRejectedValue(new DOMException("Clipboard access denied", "NotAllowedError"))
+        : vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: { writeText },
+      });
+      setNativeGatewayTestState(null);
+      const panel = document.createElement("openclaw-session-diff") as SessionDiffElement;
+      panel.loader = vi.fn(async () => ({ ...fileResult(SNAPSHOT_PATCH), root: "/workspace" }));
+      document.body.append(panel);
+
+      const triggerSelector =
+        surface === "file" ? ".session-diff__file-menu" : ".session-diff__toolbar-button";
+      await vi.waitFor(() => expect(panel.querySelector(triggerSelector)).not.toBeNull());
+      panel.querySelector<HTMLButtonElement>(triggerSelector)?.click();
+      await panel.updateComplete;
+
+      const menu = panel.querySelector("openclaw-session-diff-menu");
+      expect(menu).not.toBeNull();
+      const label = surface === "file" ? "Copy Path" : "Checkout path";
+      const button = menu?.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+      expect(button).toBeInstanceOf(HTMLButtonElement);
+
+      button?.click();
+      await vi.waitFor(() => expect(button?.getAttribute("aria-label")).toBe(feedback));
+
+      expect(writeText).toHaveBeenCalledWith(surface === "file" ? "example.txt" : "/workspace");
+      expect(button?.dataset[failed ? "error" : "copied"]).toBe("1");
+      expect(panel.querySelector("openclaw-session-diff-menu")).toBe(menu);
+    },
+  );
+
   it.each([
     { name: "plain browser", nativeGateway: null, offered: false },
     { name: "native local gateway", nativeGateway: "local", offered: true },

--- a/ui/src/pages/chat/components/session-diff-panel.ts
+++ b/ui/src/pages/chat/components/session-diff-panel.ts
@@ -25,7 +25,6 @@ import {
 } from "../../../lib/chat/session-diff-split.ts";
 import { parseSessionDiffPatch, type ParsedFilePatch } from "../../../lib/chat/session-diff.ts";
 import type { DiffLine } from "../../../lib/chat/tool-call-diff.ts";
-import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { openEditor } from "../../../lib/editor-links.ts";
 import { formatUiError } from "../../../lib/format-error.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
@@ -262,9 +261,6 @@ class SessionDiffPanel extends OpenClawLightDomElement {
         return;
       case "scope":
         this.scope = action.value;
-        return;
-      case "copy-path":
-        void copyToClipboard(action.path);
         return;
       case "open-file":
         this.openFile?.(action.path);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users copying a file path from the session-diff menu received no visible confirmation when the clipboard write succeeded and no visible error when access was denied.

## Why This Change Was Made

The file-action menu now uses the existing inline copy control already used by the neighboring sync menu. Its shared clipboard owner keeps the menu visible and reports both successful and failed copies through the existing visual and accessible feedback, removing the obsolete fire-and-forget action path.

## User Impact

Copying a changed file path now shows a green confirmation on success or a red error when clipboard permission is denied. Existing sync-menu copy behavior stays unchanged.

## Evidence

- A real headless Chromium run mounted the production session-diff component and production styles against a private, synthetic-only local fixture. It exercised both a successful clipboard write and an explicitly denied Clipboard API plus failed legacy copy fallback.
- The real browser confirmed the attempted value was `example.txt`, the file-action menu remained open, and the failed action exposed the accessible `Copy failed` label.
- Focused component and clipboard suites pass: **24 tests across three suites**.
- Regression cases cover file and sync menus for both success and failure.
- Fresh structured P1 code review reported no actionable findings.
- Production change: **1 line added, 13 removed (net -12)**; tests: **42 lines added**.
- All screenshots use visibly synthetic `/workspace`, `example.txt`, and fixture-only branch names; they contain no user data, personal workspace, credentials, or live service state.

### Before copying

![Synthetic session-diff file menu before copying](https://github.com/user-attachments/assets/84afded5-79c3-4247-81d1-175e1b8beb2a)

### Successful copy

![Synthetic session-diff file menu after a successful copy](https://github.com/user-attachments/assets/db4be209-e9d1-47d8-b485-821af619db31)

### Denied clipboard access

![Synthetic session-diff file menu after clipboard access is denied](https://github.com/user-attachments/assets/cbb728d5-5809-42d8-ad71-4eb698a9c93d)
