### PR TITLE
fix(ollama): retain advertised context and tools when model inspection is unavailable

### DIFF
--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -197,7 +197,7 @@ describe("ollama provider models", () => {
   it.each([
     {
       description: "retains authoritative list metadata when model inspection fails",
-      showResponse: () => jsonResponse({ error: "inspection unavailable" }, { status: 503 }),
+      showResponse: () => jsonResponse({ error: "inspection unavailable" }, 503),
       contextWindow: 32_768,
       supportsTools: true,
     },

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -194,6 +194,81 @@ describe("ollama provider models", () => {
     ).toBe(true);
   });
 
+  it.each([
+    {
+      description: "retains authoritative list metadata when model inspection fails",
+      showResponse: () => jsonResponse({ error: "inspection unavailable" }, { status: 503 }),
+      contextWindow: 32_768,
+      supportsTools: true,
+    },
+    {
+      description: "retains list metadata omitted from a successful model inspection",
+      showResponse: () => jsonResponse({}),
+      contextWindow: 32_768,
+      supportsTools: true,
+    },
+    {
+      description: "prefers explicit model-inspection metadata over the model list",
+      showResponse: () =>
+        jsonResponse({
+          model_info: { "gemma.context_length": 65_536 },
+          capabilities: ["completion"],
+        }),
+      contextWindow: 65_536,
+      supportsTools: false,
+    },
+  ])("$description", async ({ showResponse, contextWindow, supportsTools }) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) =>
+        requestUrl(input).endsWith("/api/tags")
+          ? jsonResponse({
+              models: [
+                {
+                  name: "gemma4:e2b",
+                  details: { context_length: 32_768 },
+                  capabilities: ["completion", "tools"],
+                },
+              ],
+            })
+          : showResponse(),
+      ),
+    );
+
+    const provider = await buildOllamaProvider("http://127.0.0.1:11434");
+
+    expect(provider.models).toEqual([
+      expect.objectContaining({
+        id: "gemma4:e2b",
+        contextWindow,
+        compat: expect.objectContaining({ supportsTools }),
+      }),
+    ]);
+  });
+
+  it("keeps an explicit empty model-inspection capability list authoritative", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) =>
+        requestUrl(input).endsWith("/api/tags")
+          ? jsonResponse({
+              models: [
+                {
+                  name: "gemma4:e2b",
+                  details: { context_length: 32_768 },
+                  capabilities: ["completion", "tools"],
+                },
+              ],
+            })
+          : jsonResponse({ capabilities: [] }),
+      ),
+    );
+
+    await expect(buildOllamaProvider("http://127.0.0.1:11434")).resolves.toMatchObject({
+      models: [],
+    });
+  });
+
   it("forwards remote auth to model listing and show probes", async () => {
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer cloud-key");
@@ -787,13 +862,29 @@ describe("ollama provider models", () => {
     }
   });
 
-  it("keeps tools off after a live /api/show failure", async () => {
+  it.each([
+    {
+      description: "keeps tools off after a live inspection failure without list metadata",
+      listed: { name: "deepseek-r1:14b", digest: "sha256:show-failure" },
+      expected: { contextWindow: OLLAMA_DEFAULT_CONTEXT_WINDOW, supportsTools: false },
+    },
+    {
+      description: "preserves authoritative list metadata after a live inspection failure",
+      listed: {
+        name: "gemma4:e2b",
+        digest: "sha256:list-metadata",
+        details: { context_length: 32_768 },
+        capabilities: ["completion", "tools"],
+      },
+      expected: { contextWindow: 32_768, supportsTools: true },
+    },
+  ])("$description", async ({ listed, expected }) => {
     const server = createServer((request, response) => {
       response.setHeader("Content-Type", "application/json");
       if (request.url === "/api/tags") {
         response.end(
           JSON.stringify({
-            models: [{ name: "deepseek-r1:14b", digest: "sha256:show-failure" }],
+            models: [listed],
           }),
         );
         return;
@@ -819,9 +910,10 @@ describe("ollama provider models", () => {
       const provider = await buildOllamaProvider(`http://127.0.0.1:${address.port}`);
       const model = expectDefined(provider.models?.[0], "show-failed Ollama model");
 
-      expect(model.id).toBe("deepseek-r1:14b");
-      expect(model.compat?.supportsTools).toBe(false);
-      expect(model.reasoning).toBe(true);
+      expect(model.id).toBe(listed.name);
+      expect(model.contextWindow).toBe(expected.contextWindow);
+      expect(model.compat?.supportsTools).toBe(expected.supportsTools);
+      expect(model.reasoning).toBe(listed.name.startsWith("deepseek-r1"));
     } finally {
       if (server.listening) {
         await new Promise<void>((resolve, reject) => {

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -25,7 +25,9 @@ export type OllamaTagModel = {
   size?: number;
   digest?: string;
   remote_host?: string;
+  capabilities?: string[];
   details?: {
+    context_length?: number;
     family?: string;
     parameter_size?: string;
     quantization_level?: string;
@@ -43,11 +45,7 @@ type OllamaRunningModel = {
 
 type OllamaModelRow = OllamaTagModel | OllamaRunningModel;
 
-export type OllamaModelWithContext = OllamaTagModel & {
-  contextWindow?: number;
-  capabilities?: string[];
-  showInspectionFailed?: boolean;
-};
+export type OllamaModelWithContext = OllamaTagModel & OllamaModelShowInfo;
 
 const OLLAMA_SHOW_CONCURRENCY = 8;
 const OLLAMA_CONTEXT_ENRICH_LIMIT = 200;
@@ -94,6 +92,16 @@ export type OllamaModelShowInfo = {
   /** Distinguishes a failed request from a successful response that omitted capabilities. */
   showInspectionFailed?: boolean;
 };
+
+export const mergeOllamaModelShowInfo = (
+  model: OllamaModelWithContext,
+  info: OllamaModelShowInfo,
+): OllamaModelWithContext => ({
+  ...model,
+  ...info,
+  contextWindow: info.contextWindow ?? model.contextWindow ?? model.details?.context_length,
+  capabilities: info.capabilities ?? model.capabilities,
+});
 
 const OLLAMA_FAILED_SHOW_INFO: OllamaModelShowInfo = Object.freeze({
   showInspectionFailed: true,
@@ -297,7 +305,7 @@ export async function enrichOllamaModelsWithContext(
     const batchResults = await Promise.all(
       batch.map(async (model) => {
         const showInfo = await queryOllamaModelShowInfoCached(apiBase, model, opts);
-        return Object.assign({}, model, showInfo);
+        return mergeOllamaModelShowInfo(model, showInfo);
       }),
     );
     enriched.push(...batchResults);
@@ -371,8 +379,7 @@ export function buildOllamaModelDefinition(
       ? isReasoningModelHeuristic(modelId)
       : capabilities.includes("thinking"));
   const compat = {
-    supportsTools:
-      opts?.showInspectionFailed === true ? false : (capabilities?.includes("tools") ?? true),
+    supportsTools: capabilities?.includes("tools") ?? opts?.showInspectionFailed !== true,
     supportsUsageInStreaming: true,
     supportsJsonSchemaResponseFormat: !isOllamaCloudModel(modelId),
   };
@@ -479,12 +486,7 @@ export async function fetchOllamaModels(
   opts?: OllamaModelRequestOptions,
   deps?: OllamaModelsFetchDeps,
 ): Promise<{ reachable: boolean; models: OllamaTagModel[] }> {
-  const result = await fetchOllamaModelRows({
-    baseUrl,
-    endpoint: "tags",
-    opts,
-    deps,
-  });
+  const result = await fetchOllamaModelRows({ baseUrl, endpoint: "tags", opts, deps });
   return {
     reachable: result.reachable,
     models: result.models.filter(
@@ -498,12 +500,7 @@ export async function fetchLoadedOllamaModelNames(
   opts?: OllamaModelRequestOptions,
   deps?: OllamaModelsFetchDeps,
 ): Promise<{ reachable: boolean; models: string[] }> {
-  const result = await fetchOllamaModelRows({
-    baseUrl,
-    endpoint: "ps",
-    opts,
-    deps,
-  });
+  const result = await fetchOllamaModelRows({ baseUrl, endpoint: "ps", opts, deps });
   return {
     reachable: result.reachable,
     models: result.models

--- a/extensions/ollama/src/setup-model-selection.test.ts
+++ b/extensions/ollama/src/setup-model-selection.test.ts
@@ -156,6 +156,56 @@ describe("Ollama onboarding model selection", () => {
     expect(result.defaultModel).toBe("ollama/deepseek-r1:1b");
   });
 
+  it.each([
+    {
+      description: "model inspection fails",
+      showResponse: () => Response.json({ error: "inspection unavailable" }, { status: 503 }),
+    },
+    {
+      description: "model inspection omits metadata",
+      showResponse: () => Response.json({}),
+    },
+  ])(
+    "selects and configures list-advertised models when $description",
+    async ({ showResponse }) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | URL | Request) =>
+          requestUrl(input).endsWith("/api/tags")
+            ? Response.json({
+                models: [
+                  {
+                    name: "gemma4:e2b",
+                    size: 2_000_000_000,
+                    details: { context_length: 32_768 },
+                    capabilities: ["completion", "tools"],
+                  },
+                ],
+              })
+            : showResponse(),
+        ),
+      );
+      const prompter = {
+        select: vi.fn().mockResolvedValueOnce("local-only"),
+        text: vi.fn().mockResolvedValueOnce("http://127.0.0.1:11434"),
+        note: vi.fn(async () => undefined),
+        confirm: vi.fn().mockResolvedValue(false),
+      } as unknown as WizardPrompter;
+
+      const result = await promptAndConfigureOllama({ cfg: {}, prompter });
+
+      expect(result.defaultModel).toBe("ollama/gemma4:e2b");
+      expect(result.config.models?.providers?.ollama?.models).toContainEqual(
+        expect.objectContaining({
+          id: "gemma4:e2b",
+          contextWindow: 32_768,
+          compat: expect.objectContaining({ supportsTools: true }),
+        }),
+      );
+      expect(prompter.confirm).not.toHaveBeenCalled();
+    },
+  );
+
   it("aborts pending model discovery with the setup signal", async () => {
     const controller = new AbortController();
     vi.stubGlobal(

--- a/extensions/ollama/src/setup-model-selection.ts
+++ b/extensions/ollama/src/setup-model-selection.ts
@@ -7,6 +7,7 @@ import {
   enrichOllamaModelsWithContext,
   fetchOllamaModels,
   isReasoningModelHeuristic,
+  mergeOllamaModelShowInfo,
   readOllamaModelShowInfo,
   resolveOllamaApiBase,
   type OllamaModelWithContext,
@@ -164,7 +165,7 @@ export async function inspectOllamaModelsForSetup(
             signal,
             auditContext: "ollama-setup.tools-scan",
           });
-          return Object.assign({}, model, showInfo);
+          return mergeOllamaModelShowInfo(model, showInfo);
         } catch (error) {
           signal?.throwIfAborted();
           // A failed inspection must not inherit the optimistic tools default
@@ -172,7 +173,7 @@ export async function inspectOllamaModelsForSetup(
           // distinct from authoritative empty capabilities so name-based
           // reasoning detection still applies.
           inspectionFailures.push(`${model.name}: ${formatErrorMessage(error)}`);
-          return Object.assign({}, model, { showInspectionFailed: true as const });
+          return mergeOllamaModelShowInfo(model, { showInspectionFailed: true });
         }
       }),
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users configuring a tools-capable local Ollama model would receive no recommended default, an incorrect 128,000-token context window, or disabled tools when Ollama already advertised the correct capabilities and context in `/api/tags` but `/api/show` failed or omitted those fields.

## Why This Change Was Made

Ollama's upstream list response already contains both [`capabilities`](https://github.com/ollama/ollama/blob/43f4eda80887877ad0106574d8f3f4b7d69c9cf9/api/types.go#L821-L831) and [`details.context_length`](https://github.com/ollama/ollama/blob/43f4eda80887877ad0106574d8f3f4b7d69c9cf9/api/types.go#L932-L941); its [actual list producer](https://github.com/ollama/ollama/blob/43f4eda80887877ad0106574d8f3f4b7d69c9cf9/server/model_list_cache.go#L834-L855) and [upstream regression test](https://github.com/ollama/ollama/blob/43f4eda80887877ad0106574d8f3f4b7d69c9cf9/server/model_list_cache_test.go#L22-L69) independently confirm both facts.

Merge those authoritative list facts once in the Ollama plugin's model-metadata owner and reuse that owner for provider discovery and interactive setup. Explicit `/api/show` metadata remains higher authority, including an explicit empty capability array; failed inspection without advertised capabilities remains conservative, and the existing public list-response shape, authentication behavior, config surface, and storage stay unchanged. Production code shrinks by two lines (+20/-22).

## User Impact

Operators can complete Ollama setup with the correct installed default, accurate native context window, and working tools even when optional per-model inspection is temporarily unavailable or incomplete. Existing older Ollama responses and explicit unsupported-model capability lists retain their previous behavior.

## Evidence

- Fail-first against unchanged production: three owner-boundary regressions failed; a model advertising `details.context_length: 32768` and `capabilities: ["completion", "tools"]` instead configured `contextWindow: 128000`, disabled tools after failed inspection, and left interactive setup without a default model.
- Fixed behavior is covered through the real interactive setup entry point and a genuine ephemeral TCP HTTP server exercising OpenClaw's real guarded `/api/tags` and failing `/api/show` requests; sibling cases cover missing show fields, stronger show metadata, explicit empty capabilities, and legacy responses.
- `node scripts/run-vitest.mjs extensions/ollama/src/provider-models.test.ts extensions/ollama/src/provider-models.ssrf.test.ts extensions/ollama/src/provider-models.preflight-timeout.test.ts extensions/ollama/src/setup-model-selection.test.ts extensions/ollama/src/setup.test.ts extensions/ollama/src/setup.cancellation.test.ts extensions/ollama/src/setup-pull.test.ts extensions/ollama/src/setup-body-release.test.ts extensions/ollama/src/discovery-shared.test.ts extensions/ollama/src/provider-base-url.test.ts extensions/ollama/provider-discovery.test.ts extensions/ollama/provider-discovery.import-guard.test.ts extensions/ollama/provider-policy-api.test.ts extensions/ollama/index.test.ts` — **14 files, 355 tests passed**.
- Focused changed-file oxlint, formatting, and integrated P1 autoreview all passed.
- Hosted CI on the first head also caught a test-fixture typing mistake (`jsonResponse` requires its HTTP status as a number); that fixture is corrected on the current head, and the complete 355-test suite, focused lint, and whole-branch P1 review were rerun successfully.
- The previous hosted `build-artifacts` failure was an unrelated Control UI startup CSS budget overflow (`46,092 B` versus `46,080 B`) inherited from the moving `main` merge-ref. The canonical fix landed separately in #130027; this branch was mechanically rebased onto that repaired commit, with `git range-diff` confirming both Ollama commits remained patch-identical, followed by a fresh 355-test run, focused lint, and clean whole-branch P1 review.
- Local whole-repository extension typechecking also encounters unrelated existing dependency/type mismatches in other plugins; hosted CI isolated the Ollama fixture mismatch and it was corrected as described above. Running Ollama's own server test offline was unavailable because its Go dependencies are not cached; the exact upstream source, producer, and test are linked above. No authenticated live Ollama service was used.
