### PR TITLE
feat(memory-core): allow machine-only dreaming without Dream Diary prose

### DIFF
--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -28,6 +28,44 @@ and a bounded `<!-- importance: N -->` value from 1 to 10. Consolidation keeps
 existing annotated entries byte-for-byte unless it explicitly merges or
 supersedes them.
 
+## Machine-only dreaming
+
+Some deployments consume memory purely as an automation artifact and never read
+the Dream Diary. Set `dreaming.humanReadable: false` to keep consolidation
+running while suppressing every human-readable write:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "memory-core": {
+        "config": {
+          "dreaming": {
+            "enabled": true,
+            "humanReadable": false
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+| Output                                            | `humanReadable: false` |
+| ------------------------------------------------- | ---------------------- |
+| Light/REM/deep phases and their scheduling        | Runs                   |
+| `memory/.dreams/` machine state and phase signals | Written                |
+| `MEMORY.md` promotion and consolidation           | Runs                   |
+| `memory/dreaming/<phase>/YYYY-MM-DD.md` reports   | Written                |
+| Dream Diary narrative subagent                    | Skipped                |
+| Fallback diary entry when the subagent is absent  | Skipped                |
+| `## Deep Sleep` summary in `DREAMS.md`            | Skipped                |
+
+This is an output switch only. It does not disable a phase, change any ranking
+threshold, or alter what reaches `MEMORY.md` — phase reinforcement signals still
+feed deep ranking exactly as they do with the diary enabled. The narrative
+subagent is the main cost saved: machine-only mode makes no diary model call.
+
 ## Phase model
 
 Dreaming runs three cooperative phases per sweep, in order: light -> REM -> deep. These are internal implementation phases, not separate user-configured modes.
@@ -256,6 +294,9 @@ All settings live under `plugins.entries.memory-core.config.dreaming`.
 </ParamField>
 <ParamField path="frequency" type="string" default="0 3 * * *">
   Cron cadence for the full dreaming sweep.
+</ParamField>
+<ParamField path="humanReadable" type="boolean" default="true">
+  Set `false` for machine-only dreaming. See [Machine-only dreaming](#machine-only-dreaming).
 </ParamField>
 <ParamField path="model" type="string">
   Optional Dream Diary subagent model override. Use a canonical `provider/model` value when also setting a subagent `allowedModels` allowlist.

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -575,6 +575,7 @@ For conceptual behavior and slash commands, see [Dreaming](/concepts/dreaming).
 | --------------------------------------- | --------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `enabled`                               | `boolean` | `true`        | Enable or disable dreaming entirely                                                                                              |
 | `frequency`                             | `string`  | `0 3 * * *`   | Optional cron cadence for the full dreaming sweep                                                                                |
+| `humanReadable`                         | `boolean` | `true`        | Set `false` for machine-only dreaming: keeps every machine artifact and promotion, writes no `DREAMS.md` output                  |
 | `model`                                 | `string`  | default model | Optional Dream Diary subagent model override                                                                                     |
 | `phases.deep.maxPromotedSnippetTokens`  | `number`  | `160`         | Maximum estimated tokens kept from each short-term recall snippet promoted into `MEMORY.md`; provenance metadata remains visible |
 | `phases.deep.maxPriorEntryLossFraction` | `number`  | `0.25`        | Reject a consolidation rewrite that removes more than this fraction of prior entries                                             |

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -68,6 +68,9 @@
           "frequency": {
             "type": "string"
           },
+          "humanReadable": {
+            "type": "boolean"
+          },
           "model": {
             "type": "string"
           },

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -69,7 +69,8 @@
             "type": "string"
           },
           "humanReadable": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
           },
           "model": {
             "type": "string"

--- a/extensions/memory-core/src/config.test.ts
+++ b/extensions/memory-core/src/config.test.ts
@@ -110,13 +110,17 @@ describe("memory-core manifest config schema", () => {
     // The schema-driven Control UI renders an unset boolean from `schema.default`
     // and shows false when it is missing. Without this, an untouched install would
     // display machine-only mode while the gateway still writes Dream Diary prose.
-    const dreaming = manifest.configSchema?.properties?.dreaming as
-      | { properties?: Record<string, { default?: unknown }> }
-      | undefined;
-
-    expect(dreaming?.properties?.humanReadable?.default).toBe(true);
-    expect(dreaming?.properties?.humanReadable?.default).toBe(
-      dreaming?.properties?.enabled?.default,
-    );
+    // `enabled` is asserted alongside it because both must read as the same
+    // default-on surface for an untouched configuration.
+    expect(manifest.configSchema).toMatchObject({
+      properties: {
+        dreaming: {
+          properties: {
+            enabled: { default: true },
+            humanReadable: { default: true },
+          },
+        },
+      },
+    });
   });
 });

--- a/extensions/memory-core/src/config.test.ts
+++ b/extensions/memory-core/src/config.test.ts
@@ -105,4 +105,18 @@ describe("memory-core manifest config schema", () => {
 
     expect(result.ok).toBe(false);
   });
+
+  it("declares the runtime default for dreaming.humanReadable", () => {
+    // The schema-driven Control UI renders an unset boolean from `schema.default`
+    // and shows false when it is missing. Without this, an untouched install would
+    // display machine-only mode while the gateway still writes Dream Diary prose.
+    const dreaming = manifest.configSchema?.properties?.dreaming as
+      | { properties?: Record<string, { default?: unknown }> }
+      | undefined;
+
+    expect(dreaming?.properties?.humanReadable?.default).toBe(true);
+    expect(dreaming?.properties?.humanReadable?.default).toBe(
+      dreaming?.properties?.enabled?.default,
+    );
+  });
 });

--- a/extensions/memory-core/src/config.test.ts
+++ b/extensions/memory-core/src/config.test.ts
@@ -76,4 +76,33 @@ describe("memory-core manifest config schema", () => {
 
     expect(result.ok).toBe(true);
   });
+
+  it("accepts dreaming.humanReadable for machine-only deployments", () => {
+    const result = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "memory-core.manifest.dreaming-human-readable",
+      value: {
+        dreaming: {
+          enabled: true,
+          humanReadable: false,
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a non-boolean dreaming.humanReadable", () => {
+    const result = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "memory-core.manifest.dreaming-human-readable-invalid",
+      value: {
+        dreaming: {
+          humanReadable: "no",
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+  });
 });

--- a/extensions/memory-core/src/dreaming-markdown.test.ts
+++ b/extensions/memory-core/src/dreaming-markdown.test.ts
@@ -166,6 +166,31 @@ describe("dreaming markdown storage", () => {
     expect(dreamsContent).toContain("- Promoted: durable preference");
   });
 
+  it("skips the DREAMS.md summary but keeps the deep report when humanReadable is false", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
+
+    const reportPath = await writeDeepDreamingReport({
+      workspaceDir,
+      bodyLines: ["- Promoted: durable preference"],
+      humanReadable: false,
+      storage: {
+        mode: "separate",
+        separateReports: false,
+      },
+      nowMs: Date.parse("2026-04-05T10:00:00Z"),
+      timezone: "UTC",
+    });
+
+    // The machine artifact must survive machine-only mode unchanged.
+    const requiredReportPath = requireReportPath(reportPath);
+    const content = await fs.readFile(requiredReportPath, "utf-8");
+    expect(content).toContain("# Deep Sleep");
+    expect(content).toContain("- Promoted: durable preference");
+
+    // The human review surface must not be created at all.
+    await expectPathMissing(path.join(workspaceDir, "DREAMS.md"));
+  });
+
   it("writes the deep summary to DREAMS.md without a separate report in inline mode", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
 

--- a/extensions/memory-core/src/dreaming-markdown.ts
+++ b/extensions/memory-core/src/dreaming-markdown.ts
@@ -148,14 +148,21 @@ export async function writeDeepDreamingReport(params: {
   bodyLines: string[];
   nowMs?: number;
   timezone?: string;
+  /** False suppresses the DREAMS.md summary; the separate report still runs. */
+  humanReadable?: boolean;
   storage: MemoryDreamingStorageConfig;
 }): Promise<string | undefined> {
   const nowMs = resolveMemoryCoreNowMs(params.nowMs);
   const body = params.bodyLines.length > 0 ? params.bodyLines.join("\n") : "- No durable changes.";
-  const inlinePath = await updateDeepDreamsFile({
-    workspaceDir: params.workspaceDir,
-    bodyLines: params.bodyLines,
-  });
+  // DREAMS.md is the human review surface; the separate report below is the
+  // machine artifact, so machine-only mode skips only this write.
+  const inlinePath =
+    params.humanReadable === false
+      ? undefined
+      : await updateDeepDreamsFile({
+          workspaceDir: params.workspaceDir,
+          bodyLines: params.bodyLines,
+        });
   let reportPath: string | undefined;
   if (shouldWriteSeparate(params.storage)) {
     reportPath = resolveSeparateReportPath(params.workspaceDir, "deep", nowMs, params.timezone);
@@ -166,7 +173,7 @@ export async function writeDeepDreamingReport(params: {
     timestamp: resolveMemoryCoreTimestamp(nowMs),
     phase: "deep",
     outcome: "completed",
-    inlinePath,
+    ...(inlinePath ? { inlinePath } : {}),
     ...(reportPath ? { reportPath } : {}),
     lineCount: params.bodyLines.length,
     storageMode: params.storage.mode,

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -639,6 +639,89 @@ describe("memory-core dreaming phases", () => {
     expect(Object.keys(phaseSignals.entries).length).toBeGreaterThan(0);
   });
 
+  it("does not re-signal the same light entries across two machine-only sweeps", async () => {
+    // Machine-only mode suppresses the Dream Diary, which is also the input to
+    // prioritizeLightEntriesByDiaryCoverage. Re-staging is nevertheless gated by
+    // machine state (phaseSignals.lightHits / lastLightAt via
+    // filterFreshLightDreamingEntries), so a second sweep with no new recall must
+    // not bump lightHits again and must not change what deep ranking sees.
+    const workspaceDir = await createDreamingWorkspace();
+    await writeDailyNote(workspaceDir, [
+      `# ${DREAMING_TEST_DAY}`,
+      "",
+      "- Move backups to S3 Glacier.",
+      "- Keep retention at 365 days.",
+    ]);
+    const testConfig: OpenClawConfig = {
+      ...LIGHT_DREAMING_TEST_CONFIG,
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          userTimezone: "UTC",
+        },
+      },
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                timezone: "UTC",
+                humanReadable: false,
+                storage: { mode: "inline", separateReports: false },
+                phases: {
+                  light: { enabled: true, limit: 20, lookbackDays: 2 },
+                  rem: { enabled: false, limit: 0, lookbackDays: 2 },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const subagent = createMockNarrativeSubagent();
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const runSweep = async (nowIso: string): Promise<void> => {
+      await runDreamingSweepPhases({
+        agentId: "main",
+        workspaceDir,
+        cfg: testConfig,
+        pluginConfig: resolveMemoryDreamingPluginConfig(testConfig),
+        logger,
+        subagent,
+        nowMs: Date.parse(nowIso),
+      });
+    };
+
+    const firstSweepIso = "2026-04-05T10:05:00.000Z";
+    const secondSweepIso = "2026-04-05T10:35:00.000Z";
+    await runSweep(firstSweepIso);
+    const afterFirst = await shortTermTesting.readPhaseSignalStore(
+      workspaceDir,
+      new Date(firstSweepIso).toISOString(),
+    );
+    const signalledKeys = Object.keys(afterFirst.entries);
+    expect(signalledKeys.length).toBeGreaterThan(0);
+
+    await runSweep(secondSweepIso);
+    const afterSecond = await shortTermTesting.readPhaseSignalStore(
+      workspaceDir,
+      new Date(secondSweepIso).toISOString(),
+    );
+
+    // The freshness filter must keep the second sweep from re-staging: same key
+    // set, same lightHits, same lastLightAt as the first sweep recorded.
+    expect(Object.keys(afterSecond.entries).toSorted()).toEqual(signalledKeys.toSorted());
+    for (const key of signalledKeys) {
+      const before = expectDefined(afterFirst.entries[key], `first-sweep signal for ${key}`);
+      const after = expectDefined(afterSecond.entries[key], `second-sweep signal for ${key}`);
+      expect(after.lightHits, `${key} keeps its light hit count`).toBe(before.lightHits);
+      expect(after.lastLightAt, `${key} keeps its light timestamp`).toBe(before.lastLightAt);
+    }
+    // Still no diary model call in either sweep.
+    expect(subagent.run).not.toHaveBeenCalled();
+  });
+
   it("suppresses cleanup warnings during request-scoped narrative fallback", async () => {
     const workspaceDir = await createDreamingWorkspace();
     await writeDailyNote(workspaceDir, [

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -574,6 +574,71 @@ describe("memory-core dreaming phases", () => {
     expect(subagent.deleteSession).toHaveBeenNthCalledWith(2, { sessionKey: expectedSessionKey });
   });
 
+  it("runs the light phase without any narrative call when humanReadable is false", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    await writeDailyNote(workspaceDir, [
+      `# ${DREAMING_TEST_DAY}`,
+      "",
+      "- Move backups to S3 Glacier.",
+      "- Keep retention at 365 days.",
+    ]);
+    const testConfig: OpenClawConfig = {
+      ...LIGHT_DREAMING_TEST_CONFIG,
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          userTimezone: "UTC",
+        },
+      },
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                timezone: "UTC",
+                humanReadable: false,
+                storage: { mode: "inline", separateReports: false },
+                phases: {
+                  light: { enabled: true, limit: 20, lookbackDays: 2 },
+                  rem: { enabled: false, limit: 0, lookbackDays: 2 },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const subagent = createMockNarrativeSubagent();
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    await runDreamingSweepPhases({
+      agentId: "main",
+      workspaceDir,
+      cfg: testConfig,
+      pluginConfig: resolveMemoryDreamingPluginConfig(testConfig),
+      logger,
+      subagent,
+      nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
+    });
+
+    // No diary model call, and no session created that would need cleanup.
+    expect(subagent.run).not.toHaveBeenCalled();
+    expect(subagent.deleteSession).not.toHaveBeenCalled();
+
+    // The machine artifacts of the phase must still be produced.
+    const dailyNote = await fs.readFile(
+      path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+      "utf-8",
+    );
+    expect(dailyNote).toContain("## Light Sleep");
+    const phaseSignals = await shortTermTesting.readPhaseSignalStore(
+      workspaceDir,
+      new Date("2026-04-05T10:05:00.000Z").toISOString(),
+    );
+    expect(Object.keys(phaseSignals.entries).length).toBeGreaterThan(0);
+  });
+
   it("suppresses cleanup warnings during request-scoped narrative fallback", async () => {
     const workspaceDir = await createDreamingWorkspace();
     await writeDailyNote(workspaceDir, [

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -72,6 +72,8 @@ import {
 type Logger = Pick<OpenClawPluginApi["logger"], "info" | "warn" | "error">;
 type DreamingPhaseStorageConfig = {
   timezone?: string;
+  /** False suppresses every Dream Diary write; machine artifacts still run. */
+  humanReadable?: boolean;
   storage: { mode: "inline" | "separate" | "both"; separateReports: boolean };
   execution?: { model?: string };
 };
@@ -1367,8 +1369,9 @@ async function runLightDreaming(
       `memory-core: light dreaming staged ${Math.min(entries.length, params.config.limit)} candidate(s) [workspace=${params.workspaceDir}].`,
     );
   }
-  // Generate dream diary narrative from the staged entries.
-  if (params.subagent && capped.length > 0) {
+  // Generate dream diary narrative from the staged entries. Machine-only mode
+  // keeps the staged candidates and phase signals above and skips this write.
+  if (params.config.humanReadable !== false && params.subagent && capped.length > 0) {
     const themes = uniqueStrings(capped.flatMap((e) => e.conceptTags).filter(Boolean));
     const data: NarrativePhaseData = {
       phase: "light",
@@ -1446,8 +1449,9 @@ async function runRemDreaming(
       `memory-core: REM dreaming wrote reflections from ${entries.length} recent memory trace(s) [workspace=${params.workspaceDir}].`,
     );
   }
-  // Generate dream diary narrative from REM reflections.
-  if (params.subagent && entries.length > 0) {
+  // Generate dream diary narrative from REM reflections. Machine-only mode
+  // keeps the reflections and phase signals above and skips this write.
+  if (params.config.humanReadable !== false && params.subagent && entries.length > 0) {
     const snippets = preview.candidateTruths.map((t) => t.snippet).filter(Boolean);
     const themes = preview.reflections.filter(
       (r) => !r.startsWith("- No strong") && !r.startsWith("  -"),

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -418,6 +418,7 @@ describe("short-term dreaming config", () => {
       maxAgeDays: 30,
       maxPromotedSnippetTokens: constants.DEFAULT_DREAMING_MAX_PROMOTED_SNIPPET_TOKENS,
       maxPriorEntryLossFraction: constants.DEFAULT_DREAMING_MAX_PRIOR_ENTRY_LOSS_FRACTION,
+      humanReadable: true,
       verboseLogging: false,
       storage: {
         mode: "separate",
@@ -461,6 +462,7 @@ describe("short-term dreaming config", () => {
       maxAgeDays: 30,
       maxPromotedSnippetTokens: 333,
       maxPriorEntryLossFraction: constants.DEFAULT_DREAMING_MAX_PRIOR_ENTRY_LOSS_FRACTION,
+      humanReadable: true,
       verboseLogging: true,
       storage: {
         mode: "separate",
@@ -503,6 +505,7 @@ describe("short-term dreaming config", () => {
       maxAgeDays: 45,
       maxPromotedSnippetTokens: 222,
       maxPriorEntryLossFraction: constants.DEFAULT_DREAMING_MAX_PRIOR_ENTRY_LOSS_FRACTION,
+      humanReadable: true,
       verboseLogging: false,
       storage: {
         mode: "separate",
@@ -541,6 +544,7 @@ describe("short-term dreaming config", () => {
       maxAgeDays: 30,
       maxPromotedSnippetTokens: constants.DEFAULT_DREAMING_MAX_PROMOTED_SNIPPET_TOKENS,
       maxPriorEntryLossFraction: constants.DEFAULT_DREAMING_MAX_PRIOR_ENTRY_LOSS_FRACTION,
+      humanReadable: true,
       verboseLogging: false,
       storage: {
         mode: "separate",
@@ -583,6 +587,17 @@ describe("short-term dreaming config", () => {
 
     expect(enabled.verboseLogging).toBe(true);
     expect(disabled.verboseLogging).toBe(false);
+  });
+
+  it("carries humanReadable through the promotion config rebuild", () => {
+    // This resolver copies fields one by one, so a dropped flag would silently
+    // leave machine-only deployments with the Dream Diary still enabled.
+    expect(resolveShortTermPromotionDreamingConfig({ pluginConfig: {} }).humanReadable).toBe(true);
+    expect(
+      resolveShortTermPromotionDreamingConfig({
+        pluginConfig: { dreaming: { humanReadable: false } },
+      }).humanReadable,
+    ).toBe(false);
   });
 
   it("falls back to defaults when thresholds are negative", () => {

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -117,6 +117,8 @@ type ShortTermPromotionDreamingConfig = {
   maxAgeDays?: number;
   maxPromotedSnippetTokens?: number;
   maxPriorEntryLossFraction: number;
+  /** False suppresses every Dream Diary write; machine artifacts still run. */
+  humanReadable?: boolean;
   verboseLogging: boolean;
   storage?: {
     mode: "inline" | "separate" | "both";
@@ -428,6 +430,7 @@ export function resolveShortTermPromotionDreamingConfig(params: {
     maxPromotedSnippetTokens:
       resolved.maxPromotedSnippetTokens ?? DEFAULT_MEMORY_DREAMING_MAX_PROMOTED_SNIPPET_TOKENS,
     maxPriorEntryLossFraction: resolved.maxPriorEntryLossFraction,
+    humanReadable: resolved.humanReadable,
     verboseLogging: resolved.verboseLogging,
     storage: resolved.storage,
     ...(resolved.execution.model ? { execution: { model: resolved.execution.model } } : {}),
@@ -627,6 +630,9 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
   let pendingNarratives = 0;
   const pluginConfig = params.cfg ? resolveMemoryDreamingPluginConfig(params.cfg) : undefined;
   const detachNarratives = params.trigger === "cron";
+  // Machine-only mode: retain every machine artifact and promotion, write no
+  // human-readable Dream Diary output. Undefined keeps the default-on surface.
+  const humanReadable = params.config.humanReadable !== false;
   const [
     { writeDeepDreamingReport },
     { appendFallbackNarrativeEntry, runDreamNarrative },
@@ -735,14 +741,17 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
         );
       }
       await writeDeepDreamingReport({
+        humanReadable,
         workspaceDir,
         bodyLines: reportLines,
         nowMs: sweepNowMs,
         timezone: params.config.timezone,
         storage: params.config.storage ?? { mode: "separate", separateReports: false },
       });
-      // Generate dream diary narrative from promoted memories.
-      if (candidates.length > 0 || applied.applied > 0) {
+      // Generate dream diary narrative from promoted memories. Machine-only mode
+      // keeps the ranking and promotion above and skips both diary writers: the
+      // narrative subagent and the fallback entry.
+      if (humanReadable && (candidates.length > 0 || applied.applied > 0)) {
         const data: NarrativePhaseData = {
           phase: "deep",
           snippets: candidates.map((c) => c.snippet).filter(Boolean),

--- a/src/memory-host-sdk/dreaming.test.ts
+++ b/src/memory-host-sdk/dreaming.test.ts
@@ -11,6 +11,9 @@ import {
   resolveMemoryDreamingPluginId,
   resolveMemoryDreamingConfig,
   resolveMemoryDreamingWorkspaces,
+  resolveMemoryDeepDreamingConfig,
+  resolveMemoryLightDreamingConfig,
+  resolveMemoryRemDreamingConfig,
 } from "./dreaming.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -119,6 +122,49 @@ describe("memory dreaming host helpers", () => {
     expect(resolved.verboseLogging).toBe(false);
     expect(resolved.storage.separateReports).toBe(false);
     expect(resolved.phases.light.enabled).toBe(false);
+  });
+
+  it("defaults humanReadable to true and propagates it to every phase resolver", () => {
+    expect(resolveMemoryDreamingConfig({ pluginConfig: {} }).humanReadable).toBe(true);
+
+    const phaseResolvers = {
+      light: resolveMemoryLightDreamingConfig,
+      deep: resolveMemoryDeepDreamingConfig,
+      rem: resolveMemoryRemDreamingConfig,
+    };
+    for (const [phase, resolve] of Object.entries(phaseResolvers)) {
+      expect(resolve({ pluginConfig: {} }).humanReadable, `${phase} inherits the default`).toBe(
+        true,
+      );
+      expect(
+        resolve({ pluginConfig: { dreaming: { humanReadable: false } } }).humanReadable,
+        `${phase} receives the opt-out`,
+      ).toBe(false);
+    }
+  });
+
+  it("resolves humanReadable=false for machine-only dreaming", () => {
+    const resolved = resolveMemoryDreamingConfig({
+      pluginConfig: { dreaming: { humanReadable: false } },
+    });
+
+    expect(resolved.humanReadable).toBe(false);
+    // Machine-side settings must be untouched by the output-only switch.
+    expect(resolved.enabled).toBe(true);
+    expect(resolved.phases.deep.enabled).toBe(true);
+    expect(resolved.phases.light.enabled).toBe(true);
+    expect(resolved.phases.rem.enabled).toBe(true);
+  });
+
+  it("coerces a humanReadable string and falls back to the default when invalid", () => {
+    expect(
+      resolveMemoryDreamingConfig({ pluginConfig: { dreaming: { humanReadable: "false" } } })
+        .humanReadable,
+    ).toBe(false);
+    expect(
+      resolveMemoryDreamingConfig({ pluginConfig: { dreaming: { humanReadable: "invalid" } } })
+        .humanReadable,
+    ).toBe(true);
   });
 
   it("lets execution defaults and phase execution override the top-level dreaming model", () => {

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -21,6 +21,9 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 const DEFAULT_MEMORY_DREAMING_ENABLED = true;
 const DEFAULT_MEMORY_DREAMING_TIMEZONE = undefined;
+// Default true preserves the established Dream Diary review surface; opting out
+// is for deployments that treat memory output as an automation artifact.
+const DEFAULT_MEMORY_DREAMING_HUMAN_READABLE = true;
 const DEFAULT_MEMORY_DREAMING_VERBOSE_LOGGING = false;
 const DEFAULT_MEMORY_DREAMING_STORAGE_MODE = "separate";
 const DEFAULT_MEMORY_DREAMING_SEPARATE_REPORTS = false;
@@ -139,6 +142,13 @@ type MemoryDreamingConfig = {
   enabled: boolean;
   frequency: string;
   timezone?: string;
+  /**
+   * When false, dreaming keeps every machine artifact (phase reports, signal
+   * state, promotion into MEMORY.md) but writes no human-readable Dream Diary
+   * output: no narrative subagent, no fallback diary entry, no deep summary
+   * appended to DREAMS.md.
+   */
+  humanReadable: boolean;
   verboseLogging: boolean;
   storage: MemoryDreamingStorageConfig;
   execution: {
@@ -358,6 +368,10 @@ export function resolveMemoryDreamingConfig(params: {
     enabled: normalizeBoolean(dreaming?.enabled, DEFAULT_MEMORY_DREAMING_ENABLED),
     frequency,
     ...(timezone ? { timezone } : {}),
+    humanReadable: normalizeBoolean(
+      dreaming?.humanReadable,
+      DEFAULT_MEMORY_DREAMING_HUMAN_READABLE,
+    ),
     verboseLogging: normalizeBoolean(
       dreaming?.verboseLogging,
       DEFAULT_MEMORY_DREAMING_VERBOSE_LOGGING,
@@ -496,6 +510,7 @@ export function resolveMemoryDeepDreamingConfig(params: {
   cfg?: OpenClawConfig;
 }): MemoryDeepDreamingConfig & {
   timezone?: string;
+  humanReadable: boolean;
   verboseLogging: boolean;
   storage: MemoryDreamingStorageConfig;
 } {
@@ -504,6 +519,7 @@ export function resolveMemoryDeepDreamingConfig(params: {
     ...resolved.phases.deep,
     enabled: resolved.enabled && resolved.phases.deep.enabled,
     ...(resolved.timezone ? { timezone: resolved.timezone } : {}),
+    humanReadable: resolved.humanReadable,
     verboseLogging: resolved.verboseLogging,
     storage: resolved.storage,
   };
@@ -514,6 +530,7 @@ export function resolveMemoryLightDreamingConfig(params: {
   cfg?: OpenClawConfig;
 }): MemoryLightDreamingConfig & {
   timezone?: string;
+  humanReadable: boolean;
   verboseLogging: boolean;
   storage: MemoryDreamingStorageConfig;
 } {
@@ -522,6 +539,7 @@ export function resolveMemoryLightDreamingConfig(params: {
     ...resolved.phases.light,
     enabled: resolved.enabled && resolved.phases.light.enabled,
     ...(resolved.timezone ? { timezone: resolved.timezone } : {}),
+    humanReadable: resolved.humanReadable,
     verboseLogging: resolved.verboseLogging,
     storage: resolved.storage,
   };
@@ -532,6 +550,7 @@ export function resolveMemoryRemDreamingConfig(params: {
   cfg?: OpenClawConfig;
 }): MemoryRemDreamingConfig & {
   timezone?: string;
+  humanReadable: boolean;
   verboseLogging: boolean;
   storage: MemoryDreamingStorageConfig;
 } {
@@ -540,6 +559,7 @@ export function resolveMemoryRemDreamingConfig(params: {
     ...resolved.phases.rem,
     enabled: resolved.enabled && resolved.phases.rem.enabled,
     ...(resolved.timezone ? { timezone: resolved.timezone } : {}),
+    humanReadable: resolved.humanReadable,
     verboseLogging: resolved.verboseLogging,
     storage: resolved.storage,
   };


### PR DESCRIPTION
Closes #79916

## What Problem This Solves

Operators running headless or automation-first deployments use `memory-core` dreaming as infrastructure: they want the light/REM/deep phase artifacts, the phase signals, and the promotion decisions into `MEMORY.md`. They do not want generated diary prose written into the workspace.

Today those two things are welded together. `dreaming.enabled: false` removes the prose but also removes the machine artifacts and the promotion flow. Leaving dreaming on means every sweep spends a model call on narrative generation and writes prose that then has to be ignored, deleted, or filtered out of review. There is no supported way to express "run the machine pipeline, write no human journal."

## Why This Change Was Made

Adds `plugins.entries.memory-core.config.dreaming.humanReadable`, defaulting to `true` so existing installs behave exactly as before. When set to `false`, dreaming keeps every machine artifact and still promotes into `MEMORY.md`, but performs no human-readable write:

- the light and REM narrative subagent calls are skipped
- the deep narrative subagent call **and** its fallback diary entry are skipped
- the `## Deep Sleep` summary is not appended to `DREAMS.md`

Two boundaries were deliberate. First, `DREAMS.md` and the per-phase report under `memory/dreaming/<phase>/YYYY-MM-DD.md` are written by the same function, but only the former is the human review surface — the report is the machine artifact, so it is still written and only the `DREAMS.md` write is gated. Second, this is an output switch, not a phase switch: light and REM reinforcement signals feed deep ranking, so gating the phases themselves would silently change what gets promoted. Skipped narratives report `status: "skipped"`, so the sweep summary's `degraded=` and `narrativesPending=` counters stay accurate instead of reporting machine-only mode as degradation.

On naming: the issue sketched a nested `humanReadable: { enabled: false }` and explicitly invited a different shape. This uses a flat boolean because there is no second sub-option to group under it, and it reads consistently with the neighbouring `enabled` and `verboseLogging` keys. It can be widened to an object later without breaking the flat form. Happy to rename to `dreamDiary.enabled` or `narrative.enabled` if maintainers prefer a different vocabulary — the mechanism is unaffected.

## User Impact

Operators can now keep managed dreaming fully enabled while opting out of Dream Diary prose:

```json
{
  "plugins": {
    "entries": {
      "memory-core": {
        "config": {
          "dreaming": {
            "enabled": true,
            "humanReadable": false
          }
        }
      }
    }
  }
}
```

Promotion, ranking thresholds, phase scheduling, and the phase report files are unchanged. The narrative subagent is the cost saved: machine-only mode makes no diary model call at all. Existing installs are untouched — the default remains `true`, and omitting the key keeps current behavior.

Documented in `docs/concepts/dreaming.md` (a "Machine-only dreaming" section with a table of exactly what runs and what is skipped) and in the `dreaming` key table in `docs/reference/memory-config.md`.

## Evidence

Tests added across four files, covering both the config plumbing and the observable behavior:

- `src/memory-host-sdk/dreaming.test.ts` — default is `true`; the flag propagates to all three phase resolvers for both the default and the opt-out; string coercion (`"false"` → `false`, `"invalid"` → default); and `humanReadable: false` leaves `enabled` and all three `phases.*.enabled` untouched, pinning this as output-only.
- `extensions/memory-core/src/config.test.ts` — the manifest `configSchema` accepts the key (it has `additionalProperties: false`, so registration is required) and rejects a non-boolean.
- `extensions/memory-core/src/dreaming-markdown.test.ts` — with `humanReadable: false`, the deep report still contains `# Deep Sleep` and the promoted line, while `DREAMS.md` is never created.
- `extensions/memory-core/src/dreaming-phases.test.ts` — a full light-phase sweep with `humanReadable: false` asserts the narrative subagent is never invoked and no session needs cleanup, while the `## Light Sleep` inline block and the phase signal store are still produced.
- `extensions/memory-core/src/dreaming.test.ts` — a regression guard on `resolveShortTermPromotionDreamingConfig`, which rebuilds its result field by field. That rebuild dropped the flag in an earlier revision of this branch, which would have left machine-only deployments with the diary still enabled; the test fails without the fix.
- `extensions/memory-core/src/dreaming-phases.test.ts` — a two-sweep regression (`does not re-signal the same light entries across two machine-only sweeps`) pinning that machine-only mode does not re-stage entries once the diary is suppressed. It fails with `lightHits` 1 → 2 if `filterFreshLightDreamingEntries` is short-circuited.
- `extensions/memory-core/src/config.test.ts` — asserts the manifest declares `default: true` for `humanReadable` alongside `enabled`, so the schema-driven Control UI does not render an untouched install as machine-only. Fails without the manifest default.

Local verification on Node 22.22.3, on `d8565db` (rebased onto `430de50d673`):

```
pnpm build                                  → BUILD_EXIT=0
                                              startup CSS gzip 45.0 KiB vs 45.5 KiB limit
node scripts/run-oxlint.mjs <changed files> → exit 0
memory-core suites (4 files)                → 115 passed
src/memory-host-sdk/dreaming.test.ts        → 21 passed
```

`node scripts/run-tsgo.mjs` reports 84 errors, spread over 29 files that are all under `scripts/`, `tsdown.config.ts`, or unrelated `.test.ts` files. Zero of them are in any file this PR touches, so this branch adds none. (These are pre-existing on `main` itself.)

**Real-workspace behavior proof:** posted as a [paired A/B run](https://github.com/openclaw/openclaw/pull/130005#issuecomment-5424054093) of the actual sweep against a real on-disk workspace using the same SQLite-backed plugin state store the gateway wires. Every machine artifact is byte-identical between `humanReadable: true` and `false` (same 5 signalled keys, same `lightHits`, identical report file sizes); the only differences are the absent `DREAMS.md` and 4 vs 0 diary model calls.
