### PR TITLE
fix(discord): retry failed draft preview cleanup

### DIFF
--- a/extensions/discord/src/draft-stream.test.ts
+++ b/extensions/discord/src/draft-stream.test.ts
@@ -3,6 +3,22 @@ import { MessageFlags, Routes } from "discord-api-types/v10";
 import { describe, expect, it, vi } from "vitest";
 import { createDiscordDraftStream } from "./draft-stream.js";
 
+function createCurrentPreviewHarness(remove = vi.fn(async () => undefined)) {
+  const rest = {
+    post: vi.fn().mockResolvedValueOnce({ id: "m1" }).mockResolvedValueOnce({ id: "m2" }),
+    patch: vi.fn(async () => undefined),
+    delete: remove,
+  };
+  const warn = vi.fn();
+  const stream = createDiscordDraftStream({
+    rest: rest as never,
+    channelId: "c1",
+    throttleMs: 250,
+    warn,
+  });
+  return { rest, stream, warn };
+}
+
 describe("createDiscordDraftStream", () => {
   it("moves the visible draft to a newly adopted thread", async () => {
     const rest = {
@@ -136,16 +152,7 @@ describe("createDiscordDraftStream", () => {
   });
 
   it("deletes the current preview without stopping later draft updates", async () => {
-    const rest = {
-      post: vi.fn().mockResolvedValueOnce({ id: "m1" }).mockResolvedValueOnce({ id: "m2" }),
-      patch: vi.fn(async () => undefined),
-      delete: vi.fn(async () => undefined),
-    };
-    const stream = createDiscordDraftStream({
-      rest: rest as never,
-      channelId: "c1",
-      throttleMs: 250,
-    });
+    const { rest, stream } = createCurrentPreviewHarness();
 
     stream.update("temporary commentary");
     await stream.flush();
@@ -162,6 +169,24 @@ describe("createDiscordDraftStream", () => {
     });
     expect(rest.patch).not.toHaveBeenCalled();
     expect(stream.messageId()).toBe("m2");
+  });
+
+  it("retries failed current-preview cleanup without reusing the stale message", async () => {
+    const remove = vi.fn().mockRejectedValueOnce(new Error("transient"));
+    const { rest, stream, warn } = createCurrentPreviewHarness(remove);
+
+    stream.update("temporary commentary");
+    await stream.flush();
+    await stream.deleteCurrentMessage();
+    stream.update("tool progress");
+    await stream.flush();
+    await stream.cleanupRetargeted();
+
+    expect(rest.delete).toHaveBeenNthCalledWith(1, Routes.channelMessage("c1", "m1"));
+    expect(rest.delete).toHaveBeenNthCalledWith(2, Routes.channelMessage("c1", "m1"));
+    expect(rest.patch).not.toHaveBeenCalled();
+    expect(stream.messageId()).toBe("m2");
+    expect(warn).toHaveBeenCalledWith("discord stream preview cleanup failed: transient");
   });
 
   it("suppresses mentions in preview creates and edits", async () => {

--- a/extensions/discord/src/draft-stream.ts
+++ b/extensions/discord/src/draft-stream.ts
@@ -31,6 +31,8 @@ type DiscordDraftStream = {
   forceNewMessage: (mode?: "preserve" | "discard") => void;
 };
 
+type PendingCleanupMessage = { channelId: string; messageId: string; warnPrefix: string };
+
 export function createDiscordDraftStream(params: {
   rest: RequestClient;
   channelId: string;
@@ -60,7 +62,7 @@ export function createDiscordDraftStream(params: {
   let streamGeneration = 0;
   let activeCreateGeneration: number | undefined;
   let discardActiveCreate = false;
-  let retargetedCleanup: Array<{ channelId: string; messageId: string }> = [];
+  let pendingCleanupMessages: PendingCleanupMessage[] = [];
 
   const sendOrEditStreamMessage = async (text: string): Promise<boolean> => {
     const generation = streamGeneration;
@@ -159,10 +161,6 @@ export function createDiscordDraftStream(params: {
     streamMessageId = undefined;
   };
   const isValidStreamMessageId = (value: unknown): value is string => typeof value === "string";
-  const deleteStreamMessage = async (messageId: string) => {
-    await deleteChannelMessage(rest, channelId, messageId);
-  };
-
   const { loop, update, stop, clear, discardPending, seal } = createFinalizableDraftLifecycle({
     throttleMs,
     state: streamState,
@@ -170,7 +168,7 @@ export function createDiscordDraftStream(params: {
     readMessageId,
     clearMessageId,
     isValidMessageId: isValidStreamMessageId,
-    deleteMessage: deleteStreamMessage,
+    deleteMessage: async (messageId) => await deleteChannelMessage(rest, channelId, messageId),
     warn: params.warn,
     warnPrefix: "discord stream preview cleanup failed",
   });
@@ -190,16 +188,19 @@ export function createDiscordDraftStream(params: {
     loop.resetPending();
     loop.resetThrottleWindow();
   };
+  const deleteCleanupMessage = async (message: PendingCleanupMessage) => {
+    try {
+      await deleteChannelMessage(rest, message.channelId, message.messageId);
+    } catch (err) {
+      pendingCleanupMessages.push(message);
+      params.warn?.(`${message.warnPrefix}: ${formatErrorMessage(err)}`);
+    }
+  };
   const cleanupRetargeted = async () => {
-    const pending = retargetedCleanup;
-    retargetedCleanup = [];
-    for (const stale of pending) {
-      try {
-        await deleteChannelMessage(rest, stale.channelId, stale.messageId);
-      } catch (err) {
-        retargetedCleanup.push(stale);
-        params.warn?.(`discord stream preview retarget cleanup failed: ${formatErrorMessage(err)}`);
-      }
+    const pending = pendingCleanupMessages;
+    pendingCleanupMessages = [];
+    for (const message of pending) {
+      await deleteCleanupMessage(message);
     }
   };
   const retarget = async (nextChannelId: string) => {
@@ -227,34 +228,32 @@ export function createDiscordDraftStream(params: {
       const stale = {
         channelId: previousChannelId,
         messageId: previousMessageId,
+        warnPrefix: "discord stream preview retarget cleanup failed",
       };
       if (!streamMessageId) {
-        retargetedCleanup.push(stale);
+        pendingCleanupMessages.push(stale);
         throw new Error("discord stream preview retarget replacement failed");
       }
-      try {
-        await deleteChannelMessage(rest, previousChannelId, previousMessageId);
-      } catch (err) {
-        retargetedCleanup.push(stale);
-        params.warn?.(`discord stream preview retarget cleanup failed: ${formatErrorMessage(err)}`);
-      }
+      await deleteCleanupMessage(stale);
     }
   };
   const deleteCurrentMessage = async () => {
     loop.resetPending();
     await loop.waitForInFlight();
-    const messageId = streamMessageId;
+    const currentMessage = streamMessageId
+      ? {
+          channelId,
+          messageId: streamMessageId,
+          warnPrefix: "discord stream preview cleanup failed",
+        }
+      : undefined;
     streamMessageId = undefined;
     lastSentText = "";
     loop.resetThrottleWindow();
-    if (!isValidStreamMessageId(messageId)) {
+    if (!currentMessage) {
       return;
     }
-    try {
-      await deleteStreamMessage(messageId);
-    } catch (err) {
-      params.warn?.(`discord stream preview cleanup failed: ${formatErrorMessage(err)}`);
-    }
+    await deleteCleanupMessage(currentMessage);
   };
 
   params.log?.(`discord stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs})`);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Discord draft preview could remain visible after a transient DELETE failure. The stream forgot the failed cleanup request, so later cleanup passes could not retry it even though subsequent draft output moved to a new message.

## Why This Change Was Made

Discord now keeps every failed preview deletion in the existing cleanup queue, including deletion of the current preview as well as retargeted previews. The stream clears the active message before attempting deletion, so later output never edits the stale preview; a later cleanup pass retries the original channel/message pair and keeps the warning specific to the failed operation.

This is independent of #118377. That contributor PR owns the shared finalizable-draft `seal()` contract; this PR changes only Discord's DELETE-failure custody and does not copy or replace that work.

## User Impact

Discord users no longer keep an orphaned streaming preview indefinitely when Discord rejects one cleanup request transiently. The next cleanup pass retries the stale preview while new progress continues on a fresh message.

## Evidence

- Pre-fix regression: the first current-preview DELETE rejects, later output moves to a new preview, but cleanup never retries the stale message.
- Post-fix regression: the stale message is deleted on the next cleanup pass, new output is posted rather than patched onto it, and the operator receives the existing cleanup warning.
- Discord draft-stream owner suite: 57/57 passing.
- Typed lint, formatting, and diff hygiene: passing.
- Independent verification plus maintainer pre-commit and committed-branch reviews: clean; secret scan found no findings.
- Production delta: +28/-29 (net -1); tests: +35/-10.

A live Discord transport was not used because safely forcing a transient DELETE failure against a real room is not deterministic. The regression drives the production draft-stream owner with the real Discord route contract and a controlled failing REST deletion.
