### PR TITLE
fix(agents): add denial guidance to plugin approval rejections

### DIFF
--- a/src/agents/agent-tools.before-tool-call.approval.ts
+++ b/src/agents/agent-tools.before-tool-call.approval.ts
@@ -42,18 +42,16 @@ const log = createSubsystemLogger("agents/tools");
 /**
  * Terminal denial feedback for plugin approvals. Mirrors the exec-approval
  * denied follow-up semantics (bash-tools.exec-approval-followup.ts) so the
- * agent treats a user denial as final: the command did not run, the approval
- * request is closed and cannot be re-approved via /approve (the agent must not
- * mention approval commands), the command must not be re-run, and the user
- * must not be asked to approve it again. Gives the agent one compliant exit:
- * a fresh command invocation triggers a new approval request.
+ * agent treats a user denial as final: the tool call did not run, the approval
+ * request is closed and cannot be re-approved (the agent must not mention
+ * approval commands), and the call must not be retried. If the user still
+ * wants the action, a new tool call triggers a fresh approval request.
  */
 const PLUGIN_APPROVAL_DENIED_REASON = [
-  "Denied by user. The command was not run.",
-  "This denial is final: the approval request is closed, and /approve cannot re-approve this command. Do not mention /approve or any other approval command to the user.",
-  "Do not run the command again and do not ask the user to approve it again.",
-  "If the user still wants to execute the command, tell them to start over: a new command invocation will trigger a fresh approval request.",
-  "Explain to the user that the command did not run because approval was denied.",
+  "Denied by user. The tool call did not run.",
+  "This denial is final: the approval request is closed. Do not mention /approve or any other approval command to the user.",
+  "Do not run the tool call again or ask the user to approve it again.",
+  "If the user still wants the action, explain that a new tool call will trigger a fresh approval request.",
 ].join("\n");
 
 function resolvePluginToolApprovalTimeoutMs(approval: PluginApprovalRequest): number {

--- a/src/agents/agent-tools.before-tool-call.approval.ts
+++ b/src/agents/agent-tools.before-tool-call.approval.ts
@@ -39,6 +39,23 @@ import { callGatewayTool } from "./tools/gateway.js";
 type PluginApprovalRequest = NonNullable<PluginHookBeforeToolCallResult["requireApproval"]>;
 const log = createSubsystemLogger("agents/tools");
 
+/**
+ * Terminal denial feedback for plugin approvals. Mirrors the exec-approval
+ * denied follow-up semantics (bash-tools.exec-approval-followup.ts) so the
+ * agent treats a user denial as final: the command did not run, the approval
+ * request is closed and cannot be re-approved via /approve (the agent must not
+ * mention approval commands), the command must not be re-run, and the user
+ * must not be asked to approve it again. Gives the agent one compliant exit:
+ * a fresh command invocation triggers a new approval request.
+ */
+const PLUGIN_APPROVAL_DENIED_REASON = [
+  "Denied by user. The command was not run.",
+  "This denial is final: the approval request is closed, and /approve cannot re-approve this command. Do not mention /approve or any other approval command to the user.",
+  "Do not run the command again and do not ask the user to approve it again.",
+  "If the user still wants to execute the command, tell them to start over: a new command invocation will trigger a fresh approval request.",
+  "Explain to the user that the command did not run because approval was denied.",
+].join("\n");
+
 function resolvePluginToolApprovalTimeoutMs(approval: PluginApprovalRequest): number {
   if (
     typeof approval.timeoutMs !== "number" ||
@@ -236,7 +253,7 @@ async function requestPluginToolApproval(params: {
           kind: "failure",
           disposition: "blocked",
           deniedReason: "plugin-approval",
-          reason: "Denied by user",
+          reason: PLUGIN_APPROVAL_DENIED_REASON,
           params: params.baseParams,
         };
       }
@@ -399,7 +416,7 @@ async function requestPluginToolApproval(params: {
         kind: "failure",
         disposition: "blocked",
         deniedReason: "plugin-approval",
-        reason: "Denied by user",
+        reason: PLUGIN_APPROVAL_DENIED_REASON,
         params: params.baseParams,
       };
     }

--- a/src/agents/agent-tools.before-tool-call.approval.ts
+++ b/src/agents/agent-tools.before-tool-call.approval.ts
@@ -39,20 +39,21 @@ import { callGatewayTool } from "./tools/gateway.js";
 type PluginApprovalRequest = NonNullable<PluginHookBeforeToolCallResult["requireApproval"]>;
 const log = createSubsystemLogger("agents/tools");
 
-/**
- * Terminal denial feedback for plugin approvals. Mirrors the exec-approval
- * denied follow-up semantics (bash-tools.exec-approval-followup.ts) so the
- * agent treats a user denial as final: the tool call did not run, the approval
- * request is closed and cannot be re-approved (the agent must not mention
- * approval commands), and the call must not be retried. If the user still
- * wants the action, a new tool call triggers a fresh approval request.
- */
-const PLUGIN_APPROVAL_DENIED_REASON = [
-  "Denied by user. The tool call did not run.",
-  "This denial is final: the approval request is closed. Do not mention /approve or any other approval command to the user.",
-  "Do not run the tool call again or ask the user to approve it again.",
-  "If the user still wants the action, explain that a new tool call will trigger a fresh approval request.",
-].join("\n");
+function pluginApprovalDeniedOutcome(baseParams: unknown): HookOutcome {
+  return {
+    blocked: true,
+    kind: "failure",
+    disposition: "blocked",
+    deniedReason: "plugin-approval",
+    reason: [
+      "Denied by user. The tool call did not run.",
+      "This denial is final: the approval request is closed. Do not mention /approve or any other approval command to the user.",
+      "Do not run the tool call again or ask the user to approve it again.",
+      "If the user still wants the action, explain that a new tool call will trigger a fresh approval request.",
+    ].join("\n"),
+    params: baseParams,
+  };
+}
 
 function resolvePluginToolApprovalTimeoutMs(approval: PluginApprovalRequest): number {
   if (
@@ -246,14 +247,7 @@ async function requestPluginToolApproval(params: {
         };
       }
       if (resolution === PluginApprovalResolutions.DENY) {
-        return {
-          blocked: true,
-          kind: "failure",
-          disposition: "blocked",
-          deniedReason: "plugin-approval",
-          reason: PLUGIN_APPROVAL_DENIED_REASON,
-          params: params.baseParams,
-        };
+        return pluginApprovalDeniedOutcome(params.baseParams);
       }
       // Veto carries the plugin-supplied reason; plain timeouts record a
       // timed_out failure disposition for the audit ledger.
@@ -409,14 +403,7 @@ async function requestPluginToolApproval(params: {
       };
     }
     if (resolution === PluginApprovalResolutions.DENY) {
-      return {
-        blocked: true,
-        kind: "failure",
-        disposition: "blocked",
-        deniedReason: "plugin-approval",
-        reason: PLUGIN_APPROVAL_DENIED_REASON,
-        params: params.baseParams,
-      };
+      return pluginApprovalDeniedOutcome(params.baseParams);
     }
     const fallbackTimeoutReason = approval.timeoutReason ?? "Approval timed out";
     const timeoutReason =

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -2719,7 +2719,7 @@ describe("before_tool_call requireApproval handling", () => {
     );
   });
 
-  it("blocks on deny decision", async () => {
+  it("uses tool-neutral guidance for a denied plugin tool call", async () => {
     hookRunner.runBeforeToolCall.mockResolvedValue({
       requireApproval: {
         title: "Dangerous",
@@ -2731,8 +2731,8 @@ describe("before_tool_call requireApproval handling", () => {
     mockCallGateway.mockResolvedValueOnce({ id: "server-id-2", decision: "deny" });
 
     const result = await runBeforeToolCallHook({
-      toolName: "bash",
-      params: {},
+      toolName: "web_search",
+      params: { query: "OpenClaw" },
       ctx: { agentId: "main", sessionKey: "main" },
     });
 
@@ -2741,11 +2741,10 @@ describe("before_tool_call requireApproval handling", () => {
     expect(result).toHaveProperty(
       "reason",
       [
-        "Denied by user. The command was not run.",
-        "This denial is final: the approval request is closed, and /approve cannot re-approve this command. Do not mention /approve or any other approval command to the user.",
-        "Do not run the command again and do not ask the user to approve it again.",
-        "If the user still wants to execute the command, tell them to start over: a new command invocation will trigger a fresh approval request.",
-        "Explain to the user that the command did not run because approval was denied.",
+        "Denied by user. The tool call did not run.",
+        "This denial is final: the approval request is closed. Do not mention /approve or any other approval command to the user.",
+        "Do not run the tool call again or ask the user to approve it again.",
+        "If the user still wants the action, explain that a new tool call will trigger a fresh approval request.",
       ].join("\n"),
     );
   });

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -2738,7 +2738,16 @@ describe("before_tool_call requireApproval handling", () => {
 
     expect(result.blocked).toBe(true);
     expect(result).toHaveProperty("disposition", "blocked");
-    expect(result).toHaveProperty("reason", "Denied by user");
+    expect(result).toHaveProperty(
+      "reason",
+      [
+        "Denied by user. The command was not run.",
+        "This denial is final: the approval request is closed, and /approve cannot re-approve this command. Do not mention /approve or any other approval command to the user.",
+        "Do not run the command again and do not ask the user to approve it again.",
+        "If the user still wants to execute the command, tell them to start over: a new command invocation will trigger a fresh approval request.",
+        "Explain to the user that the command did not run because approval was denied.",
+      ].join("\n"),
+    );
   });
 
   it("keeps the generic plugin approval timeout reason unchanged", async () => {

--- a/test/e2e/qa-lab/runtime/agent-tool-safety-approvals.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/agent-tool-safety-approvals.e2e.test.ts
@@ -146,7 +146,12 @@ describe("agent tool safety approvals", () => {
 
       expect(denied).toMatchObject({
         name: "BeforeToolCallFailureError",
-        message: "Denied by user",
+        message: [
+          "Denied by user. The tool call did not run.",
+          "This denial is final: the approval request is closed. Do not mention /approve or any other approval command to the user.",
+          "Do not run the tool call again or ask the user to approve it again.",
+          "If the user still wants the action, explain that a new tool call will trigger a fresh approval request.",
+        ].join("\n"),
       });
       expect(getBeforeToolCallFailureDisposition(denied)).toBe("blocked");
       expect(execute).not.toHaveBeenCalled();


### PR DESCRIPTION
## What Problem This Solves

A denied plugin tool approval reached the agent as only `Denied by user`.

That text did not say the tool never ran, the approval request was closed, or the same call must not be retried. The agent could retry the call or tell the user to approve a request that no longer existed.

## Why This Change Was Made

The plugin approval owner now returns one canonical denial outcome for embedded and Gateway approvals. The outcome says the tool did not run, the denial is final, the old request cannot be approved again, and a fresh tool call is required if the user still wants the action.

This replay preserves the typed approval-scope support that landed on `main` after the contributor branch started.

## User Impact

After a user rejects a plugin approval, the agent explains the final result and does not retry the denied call or point to an obsolete approval command.

## Evidence

- Exact-main red: `6ddd598683fa4db3186378034513bba47a6ae30b` returned only `Denied by user` through a real Gateway approval request, wait, separate reviewer denial, and wrapped tool-result path.
- Exact-head green: `1778d6f44b7b8fb18e10178c53f58300803592c8` returned the full final guidance through the same path.
- Anti-cheat control: the denied call executed zero times, the resolved approval inventory was empty, and a changed-input `allow-once` call executed exactly once.
- Focused tests: 106 passed across the Gateway owner test, embedded approval test, and real Gateway proof.
- Local gates: 28 permitted format, lint, dependency, architecture, and repository ratchets passed. Hosted CI owns type checks.
- Production delta: `+18/-16`, net `+2`; one shared denial outcome replaces the two prior duplicate objects.

Related: #69573

AI-assisted: repaired and verified with Codex.
