### PR TITLE
fix(onboard): scope hatch timeout to initial turn

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -24,7 +24,7 @@ import {
   type TuiPendingSubmit,
 } from "./tui-submit-state.js";
 import { createEditorSubmitHandler, createSubmitBurstCoalescer } from "./tui-submit.js";
-import type { SessionInfo } from "./tui-types.js";
+import type { SessionInfo, TuiOptions } from "./tui-types.js";
 
 type LoadHistoryMock = ReturnType<typeof vi.fn> & (() => Promise<void>);
 type RunAuthFlow = NonNullable<Parameters<typeof createCommandHandlers>[0]["runAuthFlow"]>;
@@ -115,7 +115,7 @@ function createHarness(params?: {
   activeChatRunId?: string | null;
   pendingSubmit?: TuiPendingSubmit | null;
   activityStatus?: string;
-  opts?: { local?: boolean };
+  opts?: Pick<TuiOptions, "local" | "timeoutMs">;
   currentSessionId?: string | null;
   sessionGeneration?: number;
   currentAgentId?: string;
@@ -563,6 +563,23 @@ describe("tui command handlers", () => {
       message: "/unregistered-command",
     });
     expect(requestRender).toHaveBeenCalled();
+  });
+
+  it("scopes an explicit timeout override to one message", async () => {
+    const { handleCommand, sendMessage, sendChat, state } = createHarness();
+
+    await sendMessage("automatic hatch", 300_000);
+    state.pendingSubmit = null;
+    await handleCommand("later interactive turn");
+
+    expect(sendChat).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ message: "automatic hatch", timeoutMs: 300_000 }),
+    );
+    expect(sendChat).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ message: "later interactive turn", timeoutMs: undefined }),
+    );
   });
 
   it("projects the canonical pending user before chat.send is acknowledged", async () => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -881,7 +881,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     tui.requestRender();
   };
 
-  const sendMessage = async (text: string) => {
+  const sendMessage = async (text: string, timeoutMs = opts.timeoutMs) => {
     const admission = resolveMessageAdmission(text);
     if (admission.status === "blocked") {
       reportBlockedMessageSubmit(text, admission);
@@ -937,7 +937,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         message: text,
         thinking: opts.thinking,
         deliver: deliverDefault,
-        timeoutMs: opts.timeoutMs,
+        timeoutMs,
         runId,
       });
       const acceptedRunId = sendResult.runId || runId;

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -17,6 +17,8 @@ export type TuiOptions = {
   timeoutMs?: number;
   historyLimit?: number;
   message?: string;
+  /** Overrides timeoutMs only for the message sent automatically at startup. */
+  initialMessageTimeoutMs?: number;
   /**
    * Internal CLI guard: after the standalone TUI returns, force the child
    * process out if imported runtime handles keep the event loop alive.

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1858,7 +1858,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
       scheduleDynamicSlashCommandsRefresh();
       if (!state.autoMessageSent && autoMessage) {
         state.autoMessageSent = true;
-        await sendMessage(autoMessage);
+        await sendMessage(autoMessage, opts.initialMessageTimeoutMs);
         if (!ownsConnection()) {
           return;
         }

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -604,7 +604,7 @@ describe("finalizeSetupWizard", () => {
       local: true,
       deliver: false,
       message: undefined,
-      timeoutMs: 300_000,
+      initialMessageTimeoutMs: 300_000,
     });
   });
 
@@ -669,6 +669,8 @@ describe("finalizeSetupWizard", () => {
     const tuiOptions = runTui.mock.calls.at(-1)?.[0] as Record<string, unknown>;
     expect(tuiOptions).not.toHaveProperty("url");
     expect(tuiOptions).not.toHaveProperty("token");
+    expect(tuiOptions).toMatchObject({ initialMessageTimeoutMs: 300_000 });
+    expect(tuiOptions).not.toHaveProperty("timeoutMs");
   });
 
   it.each([
@@ -867,7 +869,7 @@ describe("finalizeSetupWizard", () => {
       local: true,
       deliver: false,
       message: "Wake up, my friend!",
-      timeoutMs: 300_000,
+      initialMessageTimeoutMs: 300_000,
     });
   });
 
@@ -1026,7 +1028,7 @@ describe("finalizeSetupWizard", () => {
       local: true,
       deliver: false,
       message: undefined,
-      timeoutMs: 300_000,
+      initialMessageTimeoutMs: 300_000,
     });
   });
 
@@ -1073,7 +1075,7 @@ describe("finalizeSetupWizard", () => {
         local: true,
         deliver: false,
         message: "醒醒，我的朋友！",
-        timeoutMs: 300_000,
+        initialMessageTimeoutMs: 300_000,
       });
     } finally {
       if (previousLocale === undefined) {
@@ -2013,9 +2015,10 @@ describe("finalizeSetupWizard", () => {
           },
           deliver: false,
           message: undefined,
-          timeoutMs: 300_000,
+          initialMessageTimeoutMs: 300_000,
         }),
       );
+      expect(runTui.mock.calls.at(-1)?.[0]).not.toHaveProperty("timeoutMs");
       expect(sessionGateway.close).toHaveBeenCalledWith({ reason: "onboarding tui exited" });
       expect(cancelProcessExitAfterTuiReturn).toHaveBeenCalledWith(setupCleanupExitTimer);
       expect(scheduleProcessExitAfterTuiReturn).toHaveBeenCalledTimes(2);

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -1038,7 +1038,7 @@ export async function finalizeSetupWizard(
           message: shouldSeedBootstrapHatch
             ? t("wizard.finalize.bootstrapHatchMessage")
             : undefined,
-          timeoutMs: HATCH_TUI_TIMEOUT_MS,
+          initialMessageTimeoutMs: HATCH_TUI_TIMEOUT_MS,
         });
       } finally {
         restoreTerminalState("post-setup tui", { resumeStdinIfPaused: false });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Classic onboarding passes a five-minute hatch timeout into the post-setup TUI. The TUI forwards its configured timeout to every submitted turn, so the bootstrap safety cap incorrectly remained active for every later interactive message.

## Why This Change Was Made

Preserve the shipped five-minute watchdog for the automatic bootstrap hatch message, but scope it to that one startup submission. Later user-entered turns use the normal TUI timeout setting, which classic onboarding leaves unset.

The TUI now accepts an internal `initialMessageTimeoutMs` option for its automatic startup message. This keeps explicit standalone `--timeout-ms` behavior unchanged while separating the onboarding bootstrap bound from the rest of the session.

## User Impact

A stalled first provider call still times out after five minutes, while users can continue chatting in the TUI opened by classic onboarding without every later turn inheriting the bootstrap cap.

## Evidence

Exact head `a3915d764bba757c796f7fa9acaf5f275b9e57c2` rebased onto current `origin/main`:

- `pnpm exec vitest run src/tui/tui-command-handlers.test.ts src/wizard/setup.finalize.test.ts`: 257 tests passed.
- Regression proof sends a bounded automatic hatch turn, then verifies a later interactive turn has no timeout.
- `pnpm check:changed`: passed before the conflict-free exact patch rebase.
- Fresh branch autoreview: clean, patch correct at 0.99 confidence.
- TruffleHog 3.97.0 scan: clean.