### PR TITLE
fix(codex): keep progress cards out of chat history

### DIFF
--- a/extensions/codex/src/app-server/event-projector-reasoning.ts
+++ b/extensions/codex/src/app-server/event-projector-reasoning.ts
@@ -103,8 +103,7 @@ export class CodexReasoningProjection {
       .filter((part): part is string => Boolean(part))
       .join("\n");
     if (planText) {
-      // Structured turn updates are the canonical latest plan. Retain the last
-      // non-empty update so the terminal transcript proves planning occurred.
+      // Structured turn updates are the canonical latest plan for terminal classification.
       this.turnPlanText = planText;
     }
     if (source === "codex-app-server" && plan) {

--- a/extensions/codex/src/app-server/event-projector-result.ts
+++ b/extensions/codex/src/app-server/event-projector-result.ts
@@ -154,7 +154,6 @@ export function buildCodexAttemptResult(
     turnId: input.turnId,
     upstreamUserText: input.upstreamUserText,
     reasoningText,
-    planText,
     asyncMessages,
     commentaryMessages,
     toolMessages: input.toolTranscriptProjection.transcriptMessages,

--- a/extensions/codex/src/app-server/event-projector-snapshot.test.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.test.ts
@@ -16,7 +16,6 @@ function buildSnapshot(trigger: EmbeddedRunAttemptParams["trigger"]): AgentMessa
     turnId: "turn-1",
     upstreamUserText: undefined,
     reasoningText: "checking memory",
-    planText: undefined,
     asyncMessages: [],
     commentaryMessages: [],
     toolMessages: [

--- a/extensions/codex/src/app-server/event-projector-snapshot.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.ts
@@ -38,7 +38,6 @@ export function buildCodexMessagesSnapshot(params: {
   turnId: string;
   upstreamUserText: string | undefined;
   reasoningText: string | undefined;
-  planText: string | undefined;
   asyncMessages: ReadonlyArray<{ itemId: string; message: AssistantMessage }>;
   commentaryMessages: ReadonlyArray<{ itemId: string; message: AssistantMessage }>;
   toolMessages: readonly AgentMessage[];
@@ -52,14 +51,6 @@ export function buildCodexMessagesSnapshot(params: {
       attachCodexMirrorIdentity(
         params.createAssistantMirrorMessage("Codex reasoning", params.reasoningText),
         `${params.turnId}:reasoning`,
-      ),
-    );
-  }
-  if (params.planText) {
-    messages.push(
-      attachCodexMirrorIdentity(
-        params.createAssistantMirrorMessage("Codex plan", params.planText),
-        `${params.turnId}:plan`,
       ),
     );
   }
@@ -120,7 +111,6 @@ export function buildCodexSteeringMessagesSnapshot(params: {
     turnId: params.turnId,
     upstreamUserText: params.upstreamUserText,
     reasoningText: undefined,
-    planText: undefined,
     asyncMessages,
     commentaryMessages,
     toolMessages: params.toolMessages,

--- a/extensions/codex/src/app-server/event-projector.reasoning.test.ts
+++ b/extensions/codex/src/app-server/event-projector.reasoning.test.ts
@@ -531,15 +531,9 @@ describe("CodexAppServerEventProjector reasoning and guardian projection", () =>
       },
     );
     expect(result.toolMetas).toEqual([{ toolName: "sessions_send", isError: false }]);
-    expect(result.messagesSnapshot.map((message) => message.role)).toEqual([
-      "user",
-      "assistant",
-      "assistant",
-    ]);
+    expect(result.messagesSnapshot.map((message) => message.role)).toEqual(["user", "assistant"]);
     expect(JSON.stringify(result.messagesSnapshot[1])).toContain("Codex reasoning");
-    expect(JSON.stringify(result.messagesSnapshot[2])).toContain("Codex plan");
-    expect(JSON.stringify(result.messagesSnapshot[2])).toContain("next");
-    expect(JSON.stringify(result.messagesSnapshot[2])).toContain("[in_progress] patch");
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("Codex plan:");
     expect(result.compactionCount).toBe(1);
     expect(requireRecord(result.itemLifecycle, "item lifecycle")).not.toHaveProperty(
       "compactionCount",

--- a/extensions/codex/src/app-server/event-projector.verbose-hooks.test.ts
+++ b/extensions/codex/src/app-server/event-projector.verbose-hooks.test.ts
@@ -337,7 +337,7 @@ describe("CodexAppServerEventProjector verbose output and hook projection", () =
       { step: "step two", status: "pending" },
     ]);
     expect(result.assistantTexts).toEqual(["final answer"]);
-    expect(JSON.stringify(result.messagesSnapshot)).toContain("Codex plan");
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("Codex plan:");
   });
 
   it("fires before_compaction and after_compaction hooks for codex compaction items", async () => {

--- a/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
@@ -233,41 +233,8 @@ describe("Outcome/fallback runtime contract - Codex app-server adapter", () => {
     expect(result.assistantTexts).toStrictEqual([]);
     expect(result.lastAssistant).toBeUndefined();
     expect(readAttemptTerminal(result).promptError).toBeNull();
-    expect(result.messagesSnapshot.map((message) => message.role)).toStrictEqual([
-      "user",
-      "assistant",
-    ]);
-    const planMessage = result.messagesSnapshot[1];
-    if (planMessage?.role !== "assistant") {
-      throw new Error("expected Codex plan mirror assistant message");
-    }
-    expect(readMirrorIdentity(planMessage)).toBe(`${TURN_ID}:plan`);
-    expect(planMessage.content).toStrictEqual([
-      {
-        type: "text",
-        text: `Codex plan:\n${OUTCOME_FALLBACK_RUNTIME_CONTRACT.planningOnlyText}`,
-      },
-    ]);
-    expect(planMessage.api).toBe("openai-chatgpt-responses");
-    expect(planMessage.provider).toBe("codex");
-    expect(planMessage.model).toBe(OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel);
-    expect(planMessage.usage).toStrictEqual({
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        total: 0,
-      },
-    });
-    expect(planMessage.stopReason).toBe("stop");
-    expect(typeof planMessage.timestamp).toBe("number");
-    expect(planMessage.timestamp).toBeGreaterThan(0);
+    expect(result.messagesSnapshot.map((message) => message.role)).toStrictEqual(["user"]);
+    expect(result.agentHarnessResultClassification).toBe("planning-only");
   });
 
   it("preserves tool side-effect telemetry so fallback can stay disabled", async () => {
@@ -349,6 +316,25 @@ describe("Outcome/fallback runtime contract - Codex app-server adapter", () => {
                 },
               ],
             },
+          }),
+        );
+        return projector.buildResult(buildToolTelemetry());
+      },
+    },
+    {
+      name: "structured planning-only",
+      classification: "planning-only",
+      expectedCode: "planning_only_result",
+      build: async () => {
+        const projector = await createProjector();
+        await projector.handleNotification(
+          forCurrentTurn("turn/plan/updated", {
+            plan: [{ step: OUTCOME_FALLBACK_RUNTIME_CONTRACT.planningOnlyText, status: "pending" }],
+          }),
+        );
+        await projector.handleNotification(
+          forCurrentTurn("turn/completed", {
+            turn: { id: TURN_ID, status: "completed", items: [] },
           }),
         );
         return projector.buildResult(buildToolTelemetry());

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2613,7 +2613,24 @@ describe("runCodexAppServerAttempt", () => {
     ).toHaveLength(2);
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await run;
+    const result = await run;
+    expect(persistedProgressCardInputs[0]).toEqual({ markdown: "Plan restored", plan });
+    expect(result.messagesSnapshot).toContainEqual(
+      expect.objectContaining({
+        role: "toolResult",
+        toolName: "progress_card",
+        isError: false,
+      }),
+    );
+    expect(
+      result.messagesSnapshot.some(
+        (message) =>
+          message.role === "assistant" &&
+          (message as { __openclaw?: { mirrorIdentity?: string } }).__openclaw?.mirrorIdentity ===
+            "turn-1:plan",
+      ),
+    ).toBe(false);
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("Codex plan:");
   });
 
   it("does not inject plan state after compaction when the turn has no plan", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -76,6 +76,7 @@ import {
 } from "./protocol.js";
 import { itemNotification, rawItemCompleted, turnCompleted } from "./protocol.test-helpers.js";
 import { resolveCodexDynamicToolDirectNames } from "./run-attempt-tools.js";
+import { readMirrorIdentity } from "./upstream-prompt-provenance.js";
 import * as userInputBridge from "./user-input-bridge.js";
 
 type CodexAppServerToolTelemetry = Parameters<CodexAppServerEventProjector["buildResult"]>[0];
@@ -2623,12 +2624,7 @@ describe("runCodexAppServerAttempt", () => {
       }),
     );
     expect(
-      result.messagesSnapshot.some(
-        (message) =>
-          message.role === "assistant" &&
-          (message as { __openclaw?: { mirrorIdentity?: string } }).__openclaw?.mirrorIdentity ===
-            "turn-1:plan",
-      ),
+      result.messagesSnapshot.some((message) => readMirrorIdentity(message) === "turn-1:plan"),
     ).toBe(false);
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("Codex plan:");
   });

--- a/extensions/qa-lab/src/scenario-flow-runner.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test.ts
@@ -242,7 +242,6 @@ function createPlanningEvidenceFixture(
 function runPlanningEvidenceFixture(
   fixture: PlanningEvidenceFixture,
   currentSummary = fixture.currentSummary,
-  gatewayEvidence?: { cardStep?: string; visibleAssistantText?: string },
 ) {
   const state = createQaBusState();
   const readOptions: unknown[] = [];
@@ -255,6 +254,7 @@ function runPlanningEvidenceFixture(
     currentSummary,
   ];
   let readIndex = 0;
+  const cardStep = fixture.scenario.execution.config?.internalMarker;
   const result = runLoadedScenarioFlow(fixture.scenario.id, {
     flow: readPlanningEvidenceFlow(fixture.scenario),
     state,
@@ -272,26 +272,8 @@ function runPlanningEvidenceFixture(
         gateway: {
           call: async (method: string) =>
             method === "progressCard.get"
-              ? {
-                  card: {
-                    revision: 1,
-                    steps: [
-                      {
-                        step:
-                          gatewayEvidence?.cardStep ??
-                          fixture.scenario.execution.config?.internalMarker,
-                      },
-                    ],
-                  },
-                }
-              : {
-                  messages: [
-                    {
-                      role: "assistant",
-                      content: gatewayEvidence?.visibleAssistantText ?? fixture.outboundText,
-                    },
-                  ],
-                },
+              ? { card: { revision: 1, steps: [{ step: cardStep }] } }
+              : { messages: [{ role: "assistant", content: fixture.outboundText }] },
         },
       },
       readSessionTranscriptSummary: async (...args: unknown[]) => {
@@ -701,36 +683,6 @@ describe("scenario-flow-runner", () => {
 
       await expect(result).rejects.toThrow(fixture.failureMessage);
       expect(readOptions).toEqual([{ allowEmpty: true }, { afterEventCursor: 7 }]);
-    },
-  );
-
-  it.each([
-    {
-      name: "the durable progress card omits the requested marker",
-      gatewayEvidence: { cardStep: "different step" },
-      failureMessage: "missing marked durable progress_card evidence",
-    },
-    {
-      name: "Gateway history exposes a synthetic Codex plan assistant message",
-      gatewayEvidence: { visibleAssistantText: "Codex plan:\nQA_INTERNAL_PLAN_DO_NOT_SEND" },
-      failureMessage: "Codex plan leaked into visible Gateway history",
-    },
-  ])(
-    "rejects Codex no-meta-leak evidence when $name",
-    async ({ gatewayEvidence, failureMessage }) => {
-      const scenario = readQaScenarioById("codex-harness-no-meta-leak");
-      if (scenario.execution.kind !== "flow") {
-        throw new Error("Codex no-meta-leak scenario has no flow");
-      }
-      const fixture = createPlanningEvidenceFixture(scenario as PlanningEvidenceScenario);
-
-      const { result } = runPlanningEvidenceFixture(
-        fixture,
-        fixture.currentSummary,
-        gatewayEvidence,
-      );
-
-      await expect(result).rejects.toThrow(failureMessage);
     },
   );
 

--- a/extensions/qa-lab/src/scenario-flow-runner.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test.ts
@@ -129,7 +129,11 @@ function readCurrentRunProviderPromptEvidenceFlow(trajectoryEvents: unknown[]): 
   };
 }
 
-const planningEvidenceCoverageIds = new Set(["runtime.no-meta-leak", "workspace.planning"]);
+const planningEvidenceCoverageIds = new Set([
+  "agent-runtime.external-harness-selection-planning",
+  "openai.codex-harness-no-meta-leak",
+  "openai.codex-harness-planning",
+]);
 
 type PlanningEvidenceScenario = QaSeedScenarioWithSource & {
   execution: Extract<QaScenarioExecution, { kind: "flow" }> & { flow?: QaScenarioFlow };
@@ -200,14 +204,11 @@ function createPlanningEvidenceFixture(
     return {
       scenario,
       outboundText: expectedReply,
-      failureMessage: "missing marked Codex internal plan/reasoning mirror evidence",
+      failureMessage: "missing successful current-attempt progress_card update",
       currentSummary: {
         eventCursor: 9,
-        assistantMirrors: [
-          { identity: "current-turn:plan", text: `Codex plan:\n${internalMarker}` },
-          { identity: "current-turn:assistant", text: expectedReply },
-        ],
-        successfulToolCallCounts: {},
+        assistantMirrors: [{ identity: "current-turn:assistant", text: expectedReply }],
+        successfulToolCallCounts: { progress_card: 1 },
       },
     };
   }
@@ -216,14 +217,11 @@ function createPlanningEvidenceFixture(
     return {
       scenario,
       outboundText,
-      failureMessage: "missing Codex App Server plan signal",
+      failureMessage: "missing Codex harness progress_card signal",
       currentSummary: {
         eventCursor: 9,
-        assistantMirrors: [
-          { identity: "current-turn:plan", text: "Codex plan:\n- build the game" },
-          { identity: "current-turn:assistant", text: outboundText },
-        ],
-        successfulToolCallCounts: {},
+        assistantMirrors: [{ identity: "current-turn:assistant", text: outboundText }],
+        successfulToolCallCounts: { progress_card: 1 },
       },
     };
   }
@@ -244,16 +242,14 @@ function createPlanningEvidenceFixture(
 function runPlanningEvidenceFixture(
   fixture: PlanningEvidenceFixture,
   currentSummary = fixture.currentSummary,
+  gatewayEvidence?: { cardStep?: string; visibleAssistantText?: string },
 ) {
   const state = createQaBusState();
   const readOptions: unknown[] = [];
   const summaries = [
     {
       eventCursor: 7,
-      assistantMirrors: [
-        { identity: "old-turn:plan", text: "Codex plan:\nQA_INTERNAL_PLAN_DO_NOT_SEND" },
-        { identity: "old-turn:assistant", text: fixture.outboundText },
-      ],
+      assistantMirrors: [{ identity: "old-turn:assistant", text: fixture.outboundText }],
       successfulToolCallCounts: { progress_card: 1 },
     },
     currentSummary,
@@ -273,6 +269,30 @@ function runPlanningEvidenceFixture(
       env: {
         providerMode: "live-frontier",
         primaryModel: "openai/gpt-5.6-luna",
+        gateway: {
+          call: async (method: string) =>
+            method === "progressCard.get"
+              ? {
+                  card: {
+                    revision: 1,
+                    steps: [
+                      {
+                        step:
+                          gatewayEvidence?.cardStep ??
+                          fixture.scenario.execution.config?.internalMarker,
+                      },
+                    ],
+                  },
+                }
+              : {
+                  messages: [
+                    {
+                      role: "assistant",
+                      content: gatewayEvidence?.visibleAssistantText ?? fixture.outboundText,
+                    },
+                  ],
+                },
+        },
       },
       readSessionTranscriptSummary: async (...args: unknown[]) => {
         readOptions.push(args[2]);
@@ -681,6 +701,36 @@ describe("scenario-flow-runner", () => {
 
       await expect(result).rejects.toThrow(fixture.failureMessage);
       expect(readOptions).toEqual([{ allowEmpty: true }, { afterEventCursor: 7 }]);
+    },
+  );
+
+  it.each([
+    {
+      name: "the durable progress card omits the requested marker",
+      gatewayEvidence: { cardStep: "different step" },
+      failureMessage: "missing marked durable progress_card evidence",
+    },
+    {
+      name: "Gateway history exposes a synthetic Codex plan assistant message",
+      gatewayEvidence: { visibleAssistantText: "Codex plan:\nQA_INTERNAL_PLAN_DO_NOT_SEND" },
+      failureMessage: "Codex plan leaked into visible Gateway history",
+    },
+  ])(
+    "rejects Codex no-meta-leak evidence when $name",
+    async ({ gatewayEvidence, failureMessage }) => {
+      const scenario = readQaScenarioById("codex-harness-no-meta-leak");
+      if (scenario.execution.kind !== "flow") {
+        throw new Error("Codex no-meta-leak scenario has no flow");
+      }
+      const fixture = createPlanningEvidenceFixture(scenario as PlanningEvidenceScenario);
+
+      const { result } = runPlanningEvidenceFixture(
+        fixture,
+        fixture.currentSummary,
+        gatewayEvidence,
+      );
+
+      await expect(result).rejects.toThrow(failureMessage);
     },
   );
 

--- a/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
@@ -479,8 +479,8 @@ describe("qa suite runtime agent session helpers", () => {
       sessionId: "session-mirrors",
       message: {
         role: "assistant",
-        content: "Codex plan:\n- inspect\n- build",
-        __openclaw: { mirrorIdentity: "turn-123:plan" },
+        content: "Checking the workspace.",
+        __openclaw: { mirrorIdentity: "turn-123:commentary:message-1" },
       },
     });
 
@@ -494,8 +494,8 @@ describe("qa suite runtime agent session helpers", () => {
     ).resolves.toMatchObject({
       assistantMirrors: [
         {
-          identity: "turn-123:plan",
-          text: "Codex plan:\n- inspect\n- build",
+          identity: "turn-123:commentary:message-1",
+          text: "Checking the workspace.",
         },
       ],
     });
@@ -512,8 +512,8 @@ describe("qa suite runtime agent session helpers", () => {
       message: {
         role: "assistant",
         content: [
-          { type: "toolCall", id: "plan-ok", name: "update_plan", arguments: {} },
-          { type: "toolCall", id: "plan-error", name: "update_plan", arguments: {} },
+          { type: "toolCall", id: "plan-ok", name: "progress_card", arguments: {} },
+          { type: "toolCall", id: "plan-error", name: "progress_card", arguments: {} },
           { type: "toolCall", id: "write-mismatch", name: "write", arguments: {} },
         ],
       },
@@ -522,15 +522,15 @@ describe("qa suite runtime agent session helpers", () => {
       {
         role: "toolResult",
         toolCallId: "plan-ok",
-        toolName: "update_plan",
-        content: [{ type: "text", text: "Plan updated" }],
+        toolName: "progress_card",
+        content: [{ type: "text", text: "Progress card updated" }],
         isError: false,
         timestamp: 100,
       },
       {
         role: "toolResult",
         toolCallId: "plan-ok",
-        toolName: "update_plan",
+        toolName: "progress_card",
         content: [{ type: "text", text: "duplicate" }],
         isError: false,
         timestamp: 200,
@@ -538,7 +538,7 @@ describe("qa suite runtime agent session helpers", () => {
       {
         role: "toolResult",
         toolCallId: "plan-error",
-        toolName: "update_plan",
+        toolName: "progress_card",
         content: [{ type: "text", text: "failed" }],
         isError: true,
         timestamp: 300,
@@ -568,10 +568,10 @@ describe("qa suite runtime agent session helpers", () => {
         sessionKey,
       ),
     ).resolves.toMatchObject({
-      assistantToolCallCounts: { update_plan: 2, write: 1 },
-      completedToolCallCounts: { update_plan: 2 },
-      successfulToolCallCounts: { update_plan: 1 },
-      successfulToolCallEvents: [{ name: "update_plan", timestamp: 100, toolCallId: "plan-ok" }],
+      assistantToolCallCounts: { progress_card: 2, write: 1 },
+      completedToolCallCounts: { progress_card: 2 },
+      successfulToolCallCounts: { progress_card: 1 },
+      successfulToolCallEvents: [{ name: "progress_card", timestamp: 100, toolCallId: "plan-ok" }],
     });
   });
 
@@ -807,13 +807,13 @@ describe("qa suite runtime agent session helpers", () => {
     for (const message of [
       {
         role: "assistant",
-        content: [{ type: "toolCall", id: "old-plan", name: "update_plan", arguments: {} }],
+        content: [{ type: "toolCall", id: "old-plan", name: "progress_card", arguments: {} }],
       },
       {
         role: "toolResult",
         toolCallId: "old-plan",
-        toolName: "update_plan",
-        content: [{ type: "text", text: "Plan updated" }],
+        toolName: "progress_card",
+        content: [{ type: "text", text: "Progress card updated" }],
         isError: false,
         timestamp: 100,
       },
@@ -830,7 +830,7 @@ describe("qa suite runtime agent session helpers", () => {
       sessionKey,
     );
     expect(checkpoint.successfulToolCallEvents).toEqual([
-      { name: "update_plan", timestamp: 100, toolCallId: "old-plan" },
+      { name: "progress_card", timestamp: 100, toolCallId: "old-plan" },
     ]);
     await appendQaTranscriptMessage({
       tempRoot,

--- a/qa/scenarios/models/codex-harness-no-meta-leak.yaml
+++ b/qa/scenarios/models/codex-harness-no-meta-leak.yaml
@@ -36,8 +36,8 @@ scenario:
       expectedReply: QA_LEAK_OK
       internalMarker: QA_INTERNAL_PLAN_DO_NOT_SEND
       prompt: |-
-        First call update_plan with one pending step whose text is exactly QA_INTERNAL_PLAN_DO_NOT_SEND.
-        Keep that plan and any reasoning or coordination text internal.
+        First call progress_card with one pending step whose text is exactly QA_INTERNAL_PLAN_DO_NOT_SEND.
+        Keep that plan and any reasoning or coordination text out of your visible reply.
 
         Reply with exactly one line:
         QA_LEAK_OK
@@ -115,12 +115,24 @@ flow:
         - set: appServerTurn
           value:
             expr: "assistantMirror.identity.slice(0, -':assistant'.length)"
+        - assert:
+            expr: "(transcript.successfulToolCallCounts.progress_card ?? 0) > 0"
+            message: missing successful current-attempt progress_card update
+        - set: progressCard
+          value:
+            expr: "(await env.gateway.call('progressCard.get', { sessionKey: 'agent:qa:codex-meta-leak' })).card"
+        - assert:
+            expr: "progressCard?.steps?.some((step) => step.step === config.internalMarker)"
+            message: missing marked durable progress_card evidence
         - set: internalMirrors
           value:
-            expr: "(transcript.assistantMirrors ?? []).filter((mirror) => mirror.identity.startsWith(appServerTurn + ':') && (mirror.identity.endsWith(':reasoning') || mirror.identity.endsWith(':plan')))"
+            expr: "(transcript.assistantMirrors ?? []).filter((mirror) => mirror.identity === appServerTurn + ':reasoning')"
+        - set: visibleHistory
+          value:
+            expr: "(await env.gateway.call('chat.history', { sessionKey: 'agent:qa:codex-meta-leak', limit: 100 })).messages ?? []"
         - assert:
-            expr: "internalMirrors.some((mirror) => mirror.text.includes(config.internalMarker))"
-            message: missing marked Codex internal plan/reasoning mirror evidence
+            expr: "!visibleHistory.some((message) => message.role === 'assistant' && (typeof message.content === 'string' ? message.content : (message.content ?? []).filter((part) => part.type === 'text').map((part) => part.text).join('\\n')).startsWith('Codex plan:\\n'))"
+            message: Codex plan leaked into visible Gateway history
         - set: outboundLower
           value:
             expr: normalizeLowercaseStringOrEmpty(outbound.text)
@@ -150,4 +162,4 @@ flow:
                   expr: "!outboundLower.includes(normalizeLowercaseStringOrEmpty(forbidden))"
                   message:
                     expr: "`visible reply leaked internal meta text (${forbidden}): ${outbound.text}`"
-      detailsExpr: "`provider=${selected?.provider} model=${selected?.model} runtime=${config.harnessRuntime} agentRun=${turn.started.runId} appServerTurn=${appServerTurn} internalMirrors=${internalMirrors.map((mirror) => mirror.identity).join(',')} planSignal=${internalMirrors.find((mirror) => mirror.identity.endsWith(':plan'))?.identity ?? 'n/a'} artifact=n/a visibleReply=${JSON.stringify(outbound.text)}`"
+      detailsExpr: "`provider=${selected?.provider} model=${selected?.model} runtime=${config.harnessRuntime} agentRun=${turn.started.runId} appServerTurn=${appServerTurn} internalMirrors=${internalMirrors.map((mirror) => mirror.identity).join(',')} planSignal=progress_card:revision:${progressCard.revision} artifact=n/a visibleReply=${JSON.stringify(outbound.text)}`"

--- a/qa/scenarios/workspace/medium-game-plan-codex-harness.yaml
+++ b/qa/scenarios/workspace/medium-game-plan-codex-harness.yaml
@@ -14,7 +14,7 @@ scenario:
   successCriteria:
     - A live-frontier run fails fast unless the selected primary model is openai/gpt-5.6-luna with the Codex harness forced.
     - The scenario forces the Codex embedded harness.
-    - The Codex App Server emits a turn-scoped plan signal before the artifact assertion passes.
+    - The Codex harness records a successful `progress_card` tool call before the artifact assertion passes.
     - The agent writes a self-contained HTML game with a canvas loop, controls, scoring, waves, pause, and restart.
   docsRefs:
     - docs/plugins/sdk-agent-harness.md
@@ -37,7 +37,7 @@ scenario:
       gameTitle: Star Garden Defenders
       minBytes: 5000
       buildPrompt: |-
-        Call update_plan with a short implementation plan before editing.
+        Call progress_card with a short implementation plan before editing.
 
         Then build a medium-complex, self-contained browser game at ./star-garden-defenders-codex.html.
 
@@ -118,12 +118,9 @@ flow:
         - set: appServerTurn
           value:
             expr: "assistantMirror.identity.slice(0, -':assistant'.length)"
-        - set: planMirror
-          value:
-            expr: "transcript.assistantMirrors?.find((mirror) => mirror.identity === appServerTurn + ':plan' && mirror.text.startsWith('Codex plan:\\n'))"
         - assert:
-            expr: "planMirror?.identity"
-            message: missing Codex App Server plan signal
+            expr: "(transcript.successfulToolCallCounts.progress_card ?? 0) > 0"
+            message: missing Codex harness progress_card signal
         - set: artifactPath
           value:
             expr: "path.join(env.gateway.workspaceDir, config.artifactFile)"
@@ -164,4 +161,4 @@ flow:
             expr: "outbound.text.includes(config.artifactFile)"
             message:
               expr: "`final reply did not mention ${config.artifactFile}: ${outbound.text}`"
-      detailsExpr: "`provider=${selected?.provider} model=${selected?.model} runtime=${config.harnessRuntime} agentRun=${turn.started.runId} appServerTurn=${appServerTurn} planSignal=${planMirror.identity} artifact=${artifactPath} bytes=${artifact.length} visibleReply=${JSON.stringify(outbound.text)}`"
+      detailsExpr: "`provider=${selected?.provider} model=${selected?.model} runtime=${config.harnessRuntime} agentRun=${turn.started.runId} appServerTurn=${appServerTurn} planSignal=progress_card:success:${transcript.successfulToolCallCounts.progress_card ?? 0} artifact=${artifactPath} bytes=${artifact.length} visibleReply=${JSON.stringify(outbound.text)}`"


### PR DESCRIPTION
Related: #125125

## What Problem This Solves

Fixes an issue where Codex-backed sessions could show an internal `Codex plan:` assistant message in chat history after the agent updated its progress card, especially when a gateway restart interrupted the turn before a final answer.

## Why This Change Was Made

`progress_card` is the canonical durable status owner. The Codex adapter still needs structured plan state for terminal classification and native compatibility events, but it no longer converts that state into a second assistant transcript message. QA evidence now verifies the successful `progress_card` call and durable card directly instead of depending on the obsolete plan mirror.

The native Codex checklist remains disabled per thread. Straggling native plan events still normalize into the OpenClaw progress card, preserving the compatibility ingress without restoring a duplicate transcript owner.

## User Impact

Codex sessions keep their durable progress card and planning-only fallback behavior, while chat history no longer exposes a synthetic `Codex plan:` message. Interrupted/recovered turns therefore show the real work stream and recovery boundary without leaking the internal checklist as an assistant reply.

## Evidence

- Live frontier QA on patch-equivalent pre-refresh head `1214ae533f97d07fc3f548bc7de675c7cfba91af`: `codex-harness-no-meta-leak` passed in 64.3 seconds. The run recorded `progress_card` revision 1, returned exactly `QA_LEAK_OK`, and found no internal plan mirror in visible history.
- Current exact head `629a4a343a96848c817e100d14991533baa22053`: required CI green, including build artifacts, typecheck, lint, extension shards, QA smoke, security, and `openclaw/ci-gate`.
- Focused Vitest after rebase: 299 tests passed across the Codex projector/attempt and QA scenario owners.
- Follow-up focused lint proof: affected Codex and QA test files clean; 174 tests passed.
- `pnpm build`: passed.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `check:changed`: all pre-lint gates passed, including typecheck and dead-export scans. Its two task-owned lint findings were fixed and re-proven with targeted lint/tests.
- Codex autoreview: clean on the implementation and on the follow-up lint/test cleanup.
- Production LOC: +1/-13 (net -12). Tests and QA evidence: +98/-98 (net 0).

### Upstream Codex contract

Direct inspection used the exact installed package version, `@openai/codex` 0.149.1, at public source tag [`rust-v0.149.1`](https://github.com/openai/codex/tree/rust-v0.149.1):

- [`UpdatePlanArgs`](https://github.com/openai/codex/blob/rust-v0.149.1/codex-rs/protocol/src/plan_tool.rs#L24-L28) defines the native surface as a TODO/checklist tool, not plan mode.
- The [tool handler](https://github.com/openai/codex/blob/rust-v0.149.1/codex-rs/core/src/tools/handlers/plan.rs#L84-L95) emits `EventMsg::PlanUpdate`; its model-visible result is only [`Plan updated`](https://github.com/openai/codex/blob/rust-v0.149.1/codex-rs/core/src/tools/handlers/plan.rs#L22-L40).
- App Server maps that event to the structured [`TurnPlanUpdatedNotification`](https://github.com/openai/codex/blob/rust-v0.149.1/codex-rs/app-server/src/bespoke_event_handling.rs#L1264-L1283).
- Protocol v2 keeps [`AgentMessage` and `Plan` as distinct thread items](https://github.com/openai/codex/blob/rust-v0.149.1/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L247-L263), with plan streaming carried by a separate [`PlanDeltaNotification`](https://github.com/openai/codex/blob/rust-v0.149.1/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1360-L1367).

This repair therefore preserves the upstream structured plan contract and removes only OpenClaw's duplicate conversion of that state into an assistant chat message.

The original screenshot contains private session content and is intentionally not uploaded publicly. The live QA scenario exercises the real Codex harness, durable card RPC, visible reply, and Gateway history projection with synthetic markers instead.

AI-assisted: yes; implementation and review were independently checked before publication.
