### PR TITLE
fix(ui): remove unused startup styles to restore css budget

### DIFF
--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -534,13 +534,6 @@
   white-space: nowrap;
 }
 
-.session-progress-card__count {
-  color: var(--muted);
-  font-family: var(--mono);
-  font-size: var(--control-ui-text-xs);
-  font-variant-numeric: tabular-nums;
-}
-
 .session-progress-card__dismiss {
   width: 22px;
   min-width: 22px;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2564,12 +2564,6 @@ openclaw-chat-session-rail {
   background: var(--warn-subtle);
 }
 
-.chip-danger {
-  color: var(--danger);
-  border-color: color-mix(in srgb, var(--danger) 30%, transparent);
-  background: var(--danger-subtle);
-}
-
 /* ===========================================
    Data Table
    =========================================== */


### PR DESCRIPTION
## What Problem This Solves

Current main fails its production Control UI build because startup CSS compresses to 46,092 bytes, exceeding the existing 45 KiB limit by 12 bytes. The identical failure affects both main builds and unrelated pull-request jobs.

## Why This Change Was Made

Remove two obsolete selectors from startup-loaded stylesheets. The last danger-chip producer was removed previously, and the session progress-card count element was replaced by a differently named summary element; an existing owner test explicitly asserts that the old count selector matches no rendered elements.

## User Impact

No rendered UI, accessibility, interaction, theme, or security behavior changes. The existing startup stylesheet and all CSS performance budgets remain unchanged; users receive a smaller startup stylesheet.

## Evidence

- Separate main and pull-request hosted jobs independently fail the unchanged startup CSS budget at exactly 46,092 versus 46,080 bytes.
- Whole-repository source and history searches show both removed selectors have no production producer; the retained progress-card owner test asserts the removed class has zero rendered matches.
- Real LightningCSS minification across all seven startup-owned stylesheets, followed by the exact pinned pako 3.0.1 production codec with level 9 and legacyHash enabled, saves 25 compressed bytes (38,900 to 38,875); the observed hosted 46,092-byte baseline therefore projects to 46,067 bytes, below the unchanged 46,080-byte limit.
- The exact pinned codec was loaded read-only from its existing content-addressed package-store entry without installing or modifying worktree dependencies. Fresh-install exact-head hosted production build remains the authoritative complete-bundle proof.
- The changed-file runner passes its first 13 safety, package, formatting, and UI i18n guards; its unrelated global core-test typecheck encounters existing stale shared dependency typings outside both changed stylesheets. Fresh-install hosted CI validates that full repository stage.
- Five unchanged UI/performance owner suites pass all 37 tests; the full UI stylesheet lint, dead-CSS audit, formatting, and independent owner source review pass.
- Production stylesheet delta: +0/-13 lines. No tests, budgets, baselines, build policy, or approval-boot styles are changed.
