### PR TITLE
fix(ui): keep Control UI startup stylesheet within its build budget

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -672,7 +672,6 @@
   /* Focus — crimson ring */
   --focus: rgba(229, 36, 59, 0.2);
   --focus-ring: 0 0 0 2px var(--bg), 0 0 0 3px color-mix(in srgb, var(--ring) 70%, transparent);
-  --focus-glow: 0 0 0 2px var(--bg), 0 0 0 3px var(--ring), 0 0 16px var(--accent-glow);
 
   /* Surfaces — true black canvas */
   --bg: #080808;
@@ -682,10 +681,8 @@
   --bg-muted: #1a1a1e;
 
   --card: #111113;
-  --card-foreground: #f0f0f2;
   --card-highlight: rgba(255, 255, 255, 0.03);
   --popover: #141416;
-  --popover-foreground: #f0f0f2;
 
   --panel: #080808;
   --panel-strong: #141416;
@@ -708,7 +705,6 @@
   --input: #1a1a1e;
 
   --secondary: #111113;
-  --secondary-foreground: #f0f0f2;
   --accent-2: #8b1a2b;
   --accent-2-muted: rgba(139, 26, 43, 0.7);
   --accent-2-subtle: rgba(139, 26, 43, 0.12);
@@ -738,22 +734,17 @@
   --accent-subtle: rgba(196, 30, 48, 0.08);
   --accent-glow: rgba(196, 30, 48, 0.12);
   --primary: #c41e30;
-  --primary-foreground: #ffffff;
 
   /* Surfaces — cool white with subtle warmth */
   --bg: #f9f9fb;
   --bg-accent: #f2f2f5;
-  --bg-elevated: #ffffff;
   --bg-hover: #eaeaef;
   --bg-muted: #eaeaef;
   --bg-content: #f2f2f5;
 
-  --card: #ffffff;
   --card-foreground: #18181b;
   --card-highlight: rgba(0, 0, 0, 0.02);
-  --popover: #ffffff;
   --popover-foreground: #18181b;
-  --session-hovercard-surface: var(--card);
   --session-hovercard-progress-surface: color-mix(
     in srgb,
     var(--card) 52%,
@@ -822,8 +813,6 @@
 
   /* Focus — match chocolate accent, slightly higher ring opacity for dark bg visibility */
   --focus: rgba(180, 120, 64, 0.2);
-  --focus-ring: 0 0 0 2px var(--bg), 0 0 0 3px color-mix(in srgb, var(--ring) 80%, transparent);
-  --focus-glow: 0 0 0 2px var(--bg), 0 0 0 3px var(--ring), 0 0 16px var(--accent-glow);
 
   /* Surfaces — deep cocoa tones */
   --bg: #1a1210;
@@ -887,22 +876,17 @@
   --accent-subtle: rgba(110, 72, 40, 0.12);
   --accent-glow: rgba(110, 72, 40, 0.16);
   --primary: #6e4828;
-  --primary-foreground: #ffffff;
 
   /* Surfaces — warm parchment tones */
   --bg: #f7f2ec;
   --bg-accent: #f0e8e0;
-  --bg-elevated: #ffffff;
   --bg-hover: #e8ddd2;
   --bg-muted: #e8ddd2;
   --bg-content: #f0e8e0;
 
-  --card: #ffffff;
   --card-foreground: #2c2118;
   --card-highlight: rgba(80, 50, 20, 0.02);
-  --popover: #ffffff;
   --popover-foreground: #2c2118;
-  --session-hovercard-surface: var(--card);
   --session-hovercard-progress-surface: color-mix(
     in srgb,
     var(--card) 48%,
@@ -973,7 +957,6 @@
   /* Focus — clay ring */
   --focus: rgba(217, 119, 87, 0.2);
   --focus-ring: 0 0 0 2px var(--bg), 0 0 0 3px color-mix(in srgb, var(--ring) 75%, transparent);
-  --focus-glow: 0 0 0 2px var(--bg), 0 0 0 3px var(--ring), 0 0 16px var(--accent-glow);
 
   /* Surfaces — warm graphite, a shade off true neutral */
   --bg: #262624;
@@ -1042,22 +1025,17 @@
   --accent-subtle: rgba(168, 69, 42, 0.1);
   --accent-glow: rgba(168, 69, 42, 0.14);
   --primary: #a8452a;
-  --primary-foreground: #ffffff;
 
   /* Surfaces — ivory paper with a faint warm cast */
   --bg: #faf9f5;
   --bg-accent: #f3f1e9;
-  --bg-elevated: #ffffff;
   --bg-hover: #edeae0;
   --bg-muted: #edeae0;
   --bg-content: #f3f1e9;
 
-  --card: #ffffff;
   --card-foreground: #1f1d1a;
   --card-highlight: rgba(60, 50, 30, 0.02);
-  --popover: #ffffff;
   --popover-foreground: #1f1d1a;
-  --session-hovercard-surface: var(--card);
   --session-hovercard-progress-surface: color-mix(
     in srgb,
     var(--card) 50%,

--- a/ui/src/styles/theme-contrast.test.ts
+++ b/ui/src/styles/theme-contrast.test.ts
@@ -141,13 +141,14 @@ describe("Control UI theme contrast", () => {
     expect(sessionLabelRule).toMatch(/color:\s*var\(--muted\)/);
     expect(readOpacity(sessionLabelRule)).toBe(1);
 
+    const lightTheme = readCssVarBlock(baseCss, ':root[data-theme-mode="light"]');
     for (const selector of [
       ':root[data-theme-mode="light"]',
       ':root[data-theme="openknot-light"]',
       ':root[data-theme="dash-light"]',
       ':root[data-theme="absolutely-light"]',
     ]) {
-      const theme = readCssVarBlock(baseCss, selector);
+      const theme = { ...lightTheme, ...readCssVarBlock(baseCss, selector) };
       const muted = requireCssColor(theme, "muted");
       for (const surface of ["bg", "bg-elevated", "bg-muted", "card"]) {
         expect(contrastRatio(muted, requireCssColor(theme, surface))).toBeGreaterThanOrEqual(4.5);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where unrelated pull requests fail Control UI build and real-gateway checks because the startup stylesheet has grown to **46,092 bytes gzip**, exceeding its unchanged **46,080-byte** limit.

## Why This Change Was Made

Theme families now inherit color and focus tokens that were already defined with exactly the same values by the default or light-mode theme, instead of redeclaring those values in all six OpenKnot, Dash, and Absolutely variants. The existing sidebar contrast test now resolves the same shared-light-plus-family cascade as the browser instead of requiring every inherited value to be repeated.

Production CSS: **+0/-22 lines**. Test: **+2/-1 lines**. No budget, baseline, palette, contrast, typography, or user-visible behavior changes.

## User Impact

Developers can build the Control UI and pass its existing startup performance check again. All six built-in theme variants render exactly as before.

## Evidence

Real generated startup asset using the exact lockfile-pinned gzip implementation:

```text
Before: 46,092 bytes gzip > 46,080-byte limit (FAIL)
After:  46,060 bytes gzip < 46,080-byte limit (PASS)
Saved:      32 bytes gzip / 770 minified stylesheet bytes
```

- All six themes rendered in real headless Chromium; all 60 inspected computed token values are unchanged.
- Before/after screenshots are byte-identical: SHA-256 `fc102eaa03ce128465fed79e3a92ff33813060857e1865c5af602f9e790f071a`.
- 30 focused theme, contrast, token, and appearance tests pass.
- Changed-file stylelint, oxlint, formatting, and structured P1 review pass.
- The contrast test first failed after removing duplicated declarations and passes after resolving inherited light-mode tokens.

### Before

![Six synthetic theme fixtures before inherited-token cleanup](https://github.com/user-attachments/assets/69c36c16-fb29-4218-a937-f24beb9055d1)

### After

![Six synthetic theme fixtures after inherited-token cleanup](https://github.com/user-attachments/assets/69c36c16-fb29-4218-a937-f24beb9055d1)

