### PR TITLE
fix(sandbox): restore reliable OpenShell execution and workspace integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **OpenShell sandbox reliability:** preserve sandbox creation on current and older OpenShell releases, serialize shared mirror execution through workspace publication, preserve backend registration ownership across plugin reloads, resolve attachments against each backend's actual workspace, and activate only configured sandbox plugins for CLI status and recreation. Fixes #127441, #127438, #98446. Thanks @DaveFan-NCHC and @harjothkhara.
-- **File-tool destination integrity:** preserve existing literal `@`-prefixed workspace paths across reads, writes, edits, patches, policy metadata, and memory flushing while retaining safe file-completion shorthand. Fixes #119270. Thanks @yetval and @harjothkhara.
-- **Plugin registry refresh:** restore installed plugin projections after policy-only refreshes, preserve legitimate orphan records, and compare equivalent install-owner maps independently of insertion order. Fixes #89606. Thanks @cjagwani and @qingminglong.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **OpenShell sandbox reliability:** preserve sandbox creation on current and older OpenShell releases, serialize shared mirror execution through workspace publication, preserve backend registration ownership across plugin reloads, resolve attachments against each backend's actual workspace, and activate only configured sandbox plugins for CLI status and recreation. Fixes #127441, #127438, #98446. Thanks @DaveFan-NCHC and @harjothkhara.
+- **File-tool destination integrity:** preserve existing literal `@`-prefixed workspace paths across reads, writes, edits, patches, policy metadata, and memory flushing while retaining safe file-completion shorthand. Fixes #119270. Thanks @yetval and @harjothkhara.
+- **Plugin registry refresh:** restore installed plugin projections after policy-only refreshes, preserve legitimate orphan records, and compare equivalent install-owner maps independently of insertion order. Fixes #89606. Thanks @cjagwani and @qingminglong.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -15,6 +15,10 @@ Manage sandbox runtimes for isolated agent execution: Docker/Podman containers, 
 
 List sandbox runtimes with status, backend, config match, age, idle time, and associated session/agent.
 
+For configured plugin-provided backends such as OpenShell, the CLI loads the
+owning backend plugin before checking live runtime status. Browser-only
+operations do not require backend plugin activation.
+
 ```bash
 openclaw sandbox list
 openclaw sandbox list --browser  # browser containers only

--- a/docs/gateway/openshell.md
+++ b/docs/gateway/openshell.md
@@ -126,6 +126,8 @@ canonical**:
 
 - Before `exec`, OpenClaw syncs the local workspace into the sandbox.
 - After `exec`, OpenClaw syncs the remote workspace back to local.
+- Concurrent operations sharing the same workspace wait for the current
+  upload, command, and download to finish before starting their own sync.
 - File tools go through the sandbox bridge, but local stays source of truth
   between turns.
 
@@ -147,6 +149,8 @@ Tradeoff: upload + download cost on every exec turn.
   back to local.
 - Prompt-time media reads still work (file/media tools read through the
   sandbox bridge).
+- Outbound images and other attachments can use paths under the configured
+  remote workspace, such as `/sandbox/chart.png`.
 
 Best for long-running agents and CI: lower per-turn overhead, and host-local
 edits cannot silently clobber remote state.
@@ -224,6 +228,12 @@ and restart the Gateway.
 Sandbox-level settings (`mode`, `scope`, `workspaceAccess`) live under
 `agents.defaults.sandbox` like any backend. See
 [Sandboxing](/gateway/sandboxing) for the full matrix.
+
+To pass non-secret environment values into sandboxed commands, use the existing
+`agents.defaults.sandbox.docker.env` setting; the OpenShell backend also
+applies those values during command execution. OpenShell does not currently
+inject them into sandbox creation or background services. Keep credentials in
+OpenShell providers or another dedicated secret-delivery mechanism.
 
 ## Examples
 
@@ -344,6 +354,11 @@ remote workspace for that scope, and the next use seeds a fresh one from
 local. For `mirror` mode, recreate mainly resets the remote execution
 environment since local stays canonical.
 
+Sandbox CLI commands activate the configured backend's owning plugin before
+looking up runtime status or deleting a sandbox. Unrelated plugins are not
+loaded for these operations, and browser-only commands remain independent of
+the OpenShell backend.
+
 OpenClaw keeps a registered sandbox's shipped legacy runtime name after an
 upgrade so its remote workspace remains addressable. Recreating that scope
 deletes the legacy runtime; the next use creates the current 19-character
@@ -397,6 +412,7 @@ settings to this backend.
 Custom images used with the OpenClaw filesystem bridge must provide:
 
 - `/bin/sh`
+- `sleep` for the persistent sandbox main process on current OpenShell releases
 - `python3` or `python` for pinned write, edit, rename, and remove operations
 - GNU-compatible `stat` and `find`
 - standard `mkdir`, `mv`, `rm`, and `rmdir` utilities
@@ -492,6 +508,9 @@ openclaw logs --follow
   remote files are canonical and are not synchronized back to the host. Use
   `mirror` mode when host-visible changes are required. Recreating a remote
   sandbox destroys its remote-only files.
+- **An image or attachment cannot be sent:** Use a path under the configured
+  `remoteWorkspaceDir`, such as `/sandbox/report.png`, rather than assuming
+  every backend uses Docker's `/workspace` directory.
 - **Recreate or prune cannot delete a sandbox:** Restore access to the original
   OpenShell gateway and workspace, confirm the sandbox still exists with
   `openshell --workspace <workspace-name> sandbox get <sandbox-name>`, and retry

--- a/extensions/openshell/README.md
+++ b/extensions/openshell/README.md
@@ -6,6 +6,10 @@ This plugin lets OpenClaw use OpenShell-managed local or remote sandboxes with
 SSH command execution. Choose `mirror` mode for a synchronized local workspace
 or `remote` mode for a remote-canonical workspace.
 
+Mirror operations sharing a workspace run sequentially so concurrent agent
+turns cannot overwrite one another. Outbound attachments resolve against the
+configured remote workspace, which defaults to `/sandbox`.
+
 Configuring an OpenShell workspace requires OpenShell `v0.0.88` or newer. The
 plugin supports OpenShell control-plane workspaces through
 `plugins.entries.openshell.config.workspace`; this is separate from OpenClaw's

--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -521,7 +521,6 @@ describe("openshell sandbox backend e2e", () => {
       const scopeSuffix = `${process.pid}-${Date.now()}`;
       const scopeKey = `session:openshell-e2e-deny:${scopeSuffix}`;
       const testRunId = `${process.pid.toString(36)}${Date.now().toString(36)}`;
-      const allowSandboxName = `oc-a-${testRunId.slice(-14)}`;
       const openShellWorkspace = `oc-w-${testRunId.slice(-14)}`;
       let hostPolicyServer: HostPolicyServer | null | undefined;
       let workspaceCreated = false;
@@ -582,6 +581,15 @@ describe("openshell sandbox backend e2e", () => {
         scopeKey: `session:openshell-e2e-mirror:${scopeSuffix}`,
         workspaceDir: mirrorWorkspaceDir,
         agentWorkspaceDir: mirrorWorkspaceDir,
+        cfg: sandboxCfg,
+      });
+      const allowBackend = await createOpenShellSandboxBackendFactory({
+        pluginConfig: { ...pluginConfig, policy: allowPolicyPath },
+      })({
+        sessionKey: `session:openshell-e2e-allow:${scopeSuffix}`,
+        scopeKey: `session:openshell-e2e-allow:${scopeSuffix}`,
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
         cfg: sandboxCfg,
       });
 
@@ -771,37 +779,19 @@ describe("openshell sandbox backend e2e", () => {
           runBackendExec({ backend: mirrorBackend, command: "cat nested/mirror-note.txt" }),
         ).resolves.toMatchObject({ code: 0, stdout: "mirror-write\n" });
 
-        const allowedGetResult = await runCommand({
-          command: OPENCLAW_OPENSHELL_COMMAND,
-          args: [
-            "--workspace",
-            openShellWorkspace,
-            "sandbox",
-            "create",
-            "--name",
-            allowSandboxName,
-            "--from",
-            dockerfilePath,
-            "--policy",
-            allowPolicyPath,
-            "--no-auto-providers",
-            "--no-keep",
-            "--",
-            "curl",
-            "--fail",
-            "--silent",
-            "--show-error",
-            "--max-time",
-            "15",
-            `http://host.openshell.internal:${hostPolicyServer.port}/policy-test`,
-          ],
-          env,
+        const allowedGetResult = await runBackendExec({
+          backend: allowBackend,
+          command: `curl --fail --silent --show-error --max-time 15 "http://host.openshell.internal:${hostPolicyServer.port}/policy-test"`,
           timeoutMs: 60_000,
         });
         expect(allowedGetResult.code).toBe(0);
         expect(allowedGetResult.stdout).toContain('"message":"hello-from-host"');
       } finally {
-        for (const sandboxName of [backend.runtimeId, mirrorBackend.runtimeId, allowSandboxName]) {
+        for (const sandboxName of [
+          backend.runtimeId,
+          mirrorBackend.runtimeId,
+          allowBackend.runtimeId,
+        ]) {
           await runCommand({
             command: OPENCLAW_OPENSHELL_COMMAND,
             args: ["--workspace", openShellWorkspace, "sandbox", "delete", sandboxName],

--- a/extensions/openshell/src/backend.exec-workdir.test.ts
+++ b/extensions/openshell/src/backend.exec-workdir.test.ts
@@ -1,6 +1,7 @@
 // Openshell tests cover backend-owned exec workdir validation behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import type { CreateSandboxBackendParams } from "openclaw/plugin-sdk/sandbox";
 import {
   resolvePreferredOpenClawTmpDir,
@@ -73,6 +74,26 @@ function createOpenShellBackendSandboxConfig(): CreateSandboxBackendParams["cfg"
     tools: { allow: ["*"], deny: [] },
     prune: createSandboxPruneConfig(),
   };
+}
+
+async function createOpenShellBackendFixture(params: {
+  workspaceDir: string;
+  scopeKey: string;
+  command?: string;
+}) {
+  const factory = createOpenShellSandboxBackendFactory({
+    pluginConfig: resolveOpenShellPluginConfig({
+      command: params.command ?? "openshell",
+      mode: "mirror",
+    }),
+  });
+  return await factory({
+    sessionKey: `${params.scopeKey}:turn`,
+    scopeKey: params.scopeKey,
+    workspaceDir: params.workspaceDir,
+    agentWorkspaceDir: params.workspaceDir,
+    cfg: createOpenShellBackendSandboxConfig(),
+  });
 }
 
 describe("openshell backend exec workdir validation", () => {
@@ -168,6 +189,12 @@ describe("openshell backend exec workdir validation", () => {
       ],
       cwd: workspaceDir,
     });
+    await backend.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: execSpec.finalizeToken,
+    });
     const nestedFile = path.join(workspaceDir, "nested", "note.txt");
     const bridge = backend.createFsBridge?.({
       sandbox: createSandboxTestContext({
@@ -230,7 +257,7 @@ describe("openshell backend exec workdir validation", () => {
 
     await expect(backend.validateWorkdir?.("/workspace")).resolves.toBe("/workspace");
     backend.discardPreparedWorkdir?.("/workspace");
-    await backend.buildExecSpec({
+    const execSpec = await backend.buildExecSpec({
       command: "pwd",
       workdir: "/workspace",
       env: {},
@@ -241,5 +268,171 @@ describe("openshell backend exec workdir validation", () => {
       ([params]) => params.args[0] === "sandbox" && params.args[1] === "upload",
     );
     expect(uploadCalls).toHaveLength(2);
+    await backend.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: execSpec.finalizeToken,
+    });
+  });
+
+  it.each([
+    {
+      label: "legacy trailing exec",
+      help: "Usage: openshell sandbox create [OPTIONS]\n      --no-tty\n",
+      expectedEnding: ["--", "true"],
+    },
+    {
+      label: "persistent canonical main",
+      help: "Usage: openshell sandbox create [OPTIONS]\n      --detach  Start without attaching\n",
+      expectedEnding: ["--detach", "--", "sleep", "infinity"],
+    },
+  ])("creates compatible persistent sandboxes for $label CLIs", async (scenario) => {
+    const workspace = await tempWorkspace({
+      rootDir: resolvePreferredOpenClawTmpDir(),
+      prefix: "openclaw-openshell-create-",
+    });
+    tempWorkspaces.push(workspace);
+    cliMocks.runOpenShellCli.mockImplementation(async ({ args }: { args: string[] }) => {
+      if (args[1] === "get") {
+        return { code: 1, stdout: "", stderr: "sandbox not found" };
+      }
+      if (args[1] === "create" && args[2] === "--help") {
+        return { code: 0, stdout: scenario.help, stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    for (const scopeKey of ["agent:create:first", "agent:create:second"]) {
+      const backend = await createOpenShellBackendFixture({
+        workspaceDir: workspace.dir,
+        scopeKey,
+        command: `openshell-${scenario.label.replaceAll(" ", "-")}`,
+      });
+      const execSpec = await backend.buildExecSpec({ command: "pwd", env: {}, usePty: false });
+      await backend.finalizeExec?.({
+        status: "completed",
+        exitCode: 0,
+        timedOut: false,
+        token: execSpec.finalizeToken,
+      });
+    }
+
+    const helpCalls = cliMocks.runOpenShellCli.mock.calls.filter(
+      ([params]) => params.args[1] === "create" && params.args[2] === "--help",
+    );
+    expect(helpCalls).toHaveLength(1);
+    const createCalls = cliMocks.runOpenShellCli.mock.calls.filter(
+      ([params]) => params.args[1] === "create" && params.args[2] !== "--help",
+    );
+    expect(createCalls).toHaveLength(2);
+    for (const [params] of createCalls) {
+      expect(params.args.slice(-scenario.expectedEnding.length)).toEqual(scenario.expectedEnding);
+    }
+  });
+
+  it.each([
+    { label: "a host workspace", sharedHost: true, sharedRuntime: false },
+    { label: "a remote runtime", sharedHost: false, sharedRuntime: true },
+  ])("holds $label until command execution and publication finish", async (scenario) => {
+    const workspaces = await Promise.all(
+      ["first", "second"].map(async (label) =>
+        tempWorkspace({
+          rootDir: resolvePreferredOpenClawTmpDir(),
+          prefix: `openclaw-openshell-${label}-`,
+        }),
+      ),
+    );
+    tempWorkspaces.push(...workspaces);
+    const firstWorkspace = expectDefined(workspaces[0], "first OpenShell workspace");
+    const secondWorkspace = expectDefined(workspaces[1], "second OpenShell workspace");
+    const first = await createOpenShellBackendFixture({
+      workspaceDir: firstWorkspace.dir,
+      scopeKey: "agent:workspace:first",
+    });
+    const second = await createOpenShellBackendFixture({
+      workspaceDir: (scenario.sharedHost ? firstWorkspace : secondWorkspace).dir,
+      scopeKey: scenario.sharedRuntime ? "agent:workspace:first" : "agent:workspace:second",
+    });
+
+    const firstExec = await first.buildExecSpec({ command: "first", env: {}, usePty: false });
+    const secondPreparation = second.buildExecSpec({ command: "second", env: {}, usePty: false });
+
+    try {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(cliMocks.runOpenShellCli.mock.calls.map(([params]) => params.args[1])).toEqual([
+        "get",
+      ]);
+    } finally {
+      await first.finalizeExec?.({
+        status: "completed",
+        exitCode: 0,
+        timedOut: false,
+        token: firstExec.finalizeToken,
+      });
+    }
+
+    const secondExec = await secondPreparation;
+    expect(cliMocks.runOpenShellCli.mock.calls.map(([params]) => params.args[1])).toEqual([
+      "get",
+      "download",
+      "get",
+    ]);
+    await second.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: secondExec.finalizeToken,
+    });
+  });
+
+  it("keeps operations against different workspaces parallel", async () => {
+    const workspaces = await Promise.all(
+      ["first", "second"].map(async (label) =>
+        tempWorkspace({
+          rootDir: resolvePreferredOpenClawTmpDir(),
+          prefix: `openclaw-openshell-${label}-`,
+        }),
+      ),
+    );
+    tempWorkspaces.push(...workspaces);
+    const backends = await Promise.all(
+      workspaces.map(async (workspace, index) =>
+        createOpenShellBackendFixture({
+          workspaceDir: workspace.dir,
+          scopeKey: `agent:workspace:${index}`,
+        }),
+      ),
+    );
+    const first = expectDefined(backends[0], "first OpenShell backend");
+    const second = expectDefined(backends[1], "second OpenShell backend");
+    const firstExec = await first.buildExecSpec({ command: "first", env: {}, usePty: false });
+    const secondPreparation = second.buildExecSpec({ command: "second", env: {}, usePty: false });
+    let secondExec: Awaited<typeof secondPreparation> | undefined;
+    try {
+      await vi.waitFor(() => {
+        const startedRuntimeIds = cliMocks.runOpenShellCli.mock.calls
+          .filter(([params]) => params.args[1] === "get")
+          .map(([params]) => params.args[2]);
+        expect(startedRuntimeIds).toEqual([first.runtimeId, second.runtimeId]);
+      });
+      secondExec = await secondPreparation;
+    } finally {
+      await first.finalizeExec?.({
+        status: "completed",
+        exitCode: 0,
+        timedOut: false,
+        token: firstExec.finalizeToken,
+      });
+      secondExec ??= await secondPreparation;
+      await second.finalizeExec?.({
+        status: "completed",
+        exitCode: 0,
+        timedOut: false,
+        token: secondExec.finalizeToken,
+      });
+    }
   });
 });

--- a/extensions/openshell/src/backend.remote-seed.test.ts
+++ b/extensions/openshell/src/backend.remote-seed.test.ts
@@ -135,24 +135,36 @@ describe("openshell remote-mode seed across gateway restart", () => {
   it("seeds an adopted sandbox whose managed roots are empty", async () => {
     const backend = await createAdoptedRemoteBackend({ probeStdout: "0\n" });
 
-    await backend.buildExecSpec({ command: "pwd", env: {}, usePty: false });
+    const execSpec = await backend.buildExecSpec({ command: "pwd", env: {}, usePty: false });
 
     const uploads = seedUploadCalls();
     expect(uploads.length).toBeGreaterThan(0);
     expect(uploads[0]?.[0]).toMatchObject({
       args: expect.arrayContaining([expect.stringMatching(/\/seed\.txt$/), "/sandbox/"]),
     });
+    await backend.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: execSpec.finalizeToken,
+    });
   });
 
   it("never re-seeds when a managed root already holds content", async () => {
     const backend = await createAdoptedRemoteBackend({ probeStdout: "1\n" });
 
-    await backend.buildExecSpec({ command: "pwd", env: {}, usePty: false });
+    const execSpec = await backend.buildExecSpec({ command: "pwd", env: {}, usePty: false });
 
     expect(seedUploadCalls()).toHaveLength(0);
     const wipeCalls = sdkMocks.runSshSandboxCommand.mock.calls.filter(([params]) =>
       String(params.remoteCommand).includes("rm -rf"),
     );
     expect(wipeCalls).toHaveLength(0);
+    await backend.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: execSpec.finalizeToken,
+    });
   });
 });

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -2,6 +2,8 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import type {
   CreateSandboxBackendParams,
   OpenClawConfig,
@@ -47,8 +49,16 @@ type CreateOpenShellSandboxBackendFactoryParams = {
 type PendingExec = {
   sshSession: SshSandboxSession;
   cleanup: () => Promise<void>;
+  workspaceLease: OpenShellWorkspaceLease;
 };
 
+type OpenShellWorkspaceLease = {
+  release: () => void;
+};
+
+// A command owns both its remote runtime and host mirror until final publication finishes.
+const openShellWorkspaceOperations = new KeyedAsyncQueue();
+let openShellDetachedCreateSupport: { key: string; promise: Promise<boolean> } | undefined;
 const MATERIALIZED_SKILLS_REMOTE_PARTS = [".openclaw", "sandbox-skills"] as const;
 function buildOpenShellDirectoryUploadArgs(params: {
   sandboxName: string;
@@ -296,6 +306,7 @@ class OpenShellSandboxBackendImpl {
   private preparedRemoteWorkspaceForNextExec: {
     workdir: string;
     promise: Promise<void>;
+    lease: OpenShellWorkspaceLease;
   } | null = null;
   private remoteSeedPending = false;
 
@@ -340,7 +351,8 @@ class OpenShellSandboxBackendImpl {
       finalizeExec: async ({ token }) => {
         await this.finalizeExec(token as PendingExec | undefined);
       },
-      runShellCommand: async (command) => await this.runRemoteShellScript(command),
+      runShellCommand: async (command) =>
+        await this.runWorkspaceOperation(async () => await this.runRemoteShellScript(command)),
       createFsBridge: ({ sandbox }) =>
         this.params.execContext.config.mode === "remote"
           ? createRemoteShellSandboxFsBridge({
@@ -351,18 +363,79 @@ class OpenShellSandboxBackendImpl {
               sandbox,
               backend: handle,
             }),
-      runRemoteShellScript: async (command) => await this.runRemoteShellScript(command),
+      runRemoteShellScript: async (command) =>
+        await this.runWorkspaceOperation(async () => await this.runRemoteShellScript(command)),
       mkdirpRemotePath: async (remotePath, signal) =>
-        await this.mkdirpRemotePath(remotePath, signal),
+        await this.runWorkspaceOperation(
+          async () => await this.mkdirpRemotePath(remotePath, signal),
+        ),
       removeRemotePath: async (remotePath, removeParams) =>
-        await this.removeRemotePath(remotePath, removeParams),
+        await this.runWorkspaceOperation(
+          async () => await this.removeRemotePath(remotePath, removeParams),
+        ),
       renameRemotePath: async (fromRemotePath, toRemotePath, signal) =>
-        await this.renameRemotePath(fromRemotePath, toRemotePath, signal),
+        await this.runWorkspaceOperation(
+          async () => await this.renameRemotePath(fromRemotePath, toRemotePath, signal),
+        ),
       syncLocalPathToRemote: async (localPath, remotePath) =>
-        await this.syncLocalPathToRemote(localPath, remotePath),
+        await this.runWorkspaceOperation(
+          async () => await this.syncLocalPathToRemote(localPath, remotePath),
+        ),
     };
     this.handle = handle;
     return handle;
+  }
+
+  private async runWorkspaceOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const lease = await this.acquireWorkspaceLease();
+    try {
+      return await operation();
+    } finally {
+      lease.release();
+    }
+  }
+
+  private async acquireWorkspaceLease(): Promise<OpenShellWorkspaceLease> {
+    const { config, sandboxName } = this.params.execContext;
+    const keys = [
+      `host:${path.resolve(this.params.createParams.workspaceDir)}`,
+      `runtime:${JSON.stringify([
+        config.gatewayEndpoint ?? "",
+        config.gateway ?? "",
+        config.workspace ?? process.env.OPENSHELL_WORKSPACE ?? "",
+        sandboxName,
+      ])}`,
+    ].toSorted();
+    const releases: Array<() => void> = [];
+    try {
+      for (const key of keys) {
+        const acquired = createDeferred<void>();
+        const released = createDeferred<void>();
+        void openShellWorkspaceOperations.enqueue(key, async () => {
+          acquired.resolve();
+          await released.promise;
+        });
+        await acquired.promise;
+        releases.push(released.resolve);
+      }
+    } catch (error) {
+      for (const release of releases.toReversed()) {
+        release();
+      }
+      throw error;
+    }
+    let active = true;
+    return {
+      release: () => {
+        if (!active) {
+          return;
+        }
+        active = false;
+        for (const release of releases.toReversed()) {
+          release();
+        }
+      },
+    };
   }
 
   async prepareExec(params: {
@@ -372,36 +445,44 @@ class OpenShellSandboxBackendImpl {
     usePty: boolean;
   }): Promise<{ argv: string[]; token: PendingExec }> {
     const remoteWorkdir = params.workdir ?? this.params.remoteWorkspaceDir;
-    const preparedWorkspace = this.consumePreparedRemoteWorkspaceForNextExec(remoteWorkdir);
     const remoteCommand = buildValidatedExecRemoteCommand({
       command: params.command,
       workdir: remoteWorkdir,
       env: {},
     });
-    await (preparedWorkspace ?? this.prepareRemoteWorkspaceForExec());
-    const sshSession = await createOpenShellSshSession({
-      context: this.params.execContext,
-    });
+    const preparedWorkspace = this.consumePreparedRemoteWorkspaceForNextExec(remoteWorkdir);
+    const workspaceLease = preparedWorkspace?.lease ?? (await this.acquireWorkspaceLease());
     try {
-      const prepared = await prepareSshSandboxExec({
-        session: sshSession,
-        remoteCommand,
-        env: params.env,
-        tty: params.usePty,
+      await (preparedWorkspace?.promise ?? this.prepareRemoteWorkspaceForExec());
+      const sshSession = await createOpenShellSshSession({
+        context: this.params.execContext,
       });
-      return {
-        argv: prepared.argv,
-        token: { sshSession, cleanup: prepared.cleanup },
-      };
+      try {
+        const prepared = await prepareSshSandboxExec({
+          session: sshSession,
+          remoteCommand,
+          env: params.env,
+          tty: params.usePty,
+        });
+        return {
+          argv: prepared.argv,
+          token: { sshSession, cleanup: prepared.cleanup, workspaceLease },
+        };
+      } catch (error) {
+        await disposeSshSandboxSession(sshSession);
+        throw error;
+      }
     } catch (error) {
-      await disposeSshSandboxSession(sshSession);
+      workspaceLease.release();
       throw error;
     }
   }
 
   async validateWorkdir(workdir: string): Promise<string | null> {
+    this.discardPreparedRemoteWorkspace();
+    const lease = await this.acquireWorkspaceLease();
     const preparedWorkspace = this.prepareRemoteWorkspaceForExec();
-    const reusablePreparation = { workdir, promise: preparedWorkspace };
+    const reusablePreparation = { workdir, promise: preparedWorkspace, lease };
     this.preparedRemoteWorkspaceForNextExec = reusablePreparation;
     try {
       await preparedWorkspace;
@@ -420,17 +501,23 @@ class OpenShellSandboxBackendImpl {
         const resolvedWorkdir = result.code === 0 ? result.stdout.toString("utf8").trim() : "";
         if (this.preparedRemoteWorkspaceForNextExec === reusablePreparation) {
           this.preparedRemoteWorkspaceForNextExec = resolvedWorkdir
-            ? { workdir: resolvedWorkdir, promise: preparedWorkspace }
+            ? { workdir: resolvedWorkdir, promise: preparedWorkspace, lease }
             : null;
+          if (!resolvedWorkdir) {
+            lease.release();
+          }
+        } else {
+          lease.release();
         }
         return resolvedWorkdir || null;
       } finally {
         await disposeSshSandboxSession(sshSession);
       }
     } catch (error) {
-      if (this.preparedRemoteWorkspaceForNextExec === reusablePreparation) {
+      if (this.preparedRemoteWorkspaceForNextExec?.lease === lease) {
         this.preparedRemoteWorkspaceForNextExec = null;
       }
+      lease.release();
       throw error;
     }
   }
@@ -450,20 +537,35 @@ class OpenShellSandboxBackendImpl {
     }
   }
 
-  private consumePreparedRemoteWorkspaceForNextExec(workdir: string): Promise<void> | null {
+  private consumePreparedRemoteWorkspaceForNextExec(workdir: string): {
+    promise: Promise<void>;
+    lease: OpenShellWorkspaceLease;
+  } | null {
     const preparedWorkspace = this.preparedRemoteWorkspaceForNextExec;
     if (!preparedWorkspace || preparedWorkspace.workdir !== workdir) {
-      this.preparedRemoteWorkspaceForNextExec = null;
+      this.discardPreparedRemoteWorkspace();
       return null;
     }
     this.preparedRemoteWorkspaceForNextExec = null;
-    return preparedWorkspace.promise;
+    return preparedWorkspace;
   }
 
   discardPreparedWorkdir(workdir: string): void {
     if (this.preparedRemoteWorkspaceForNextExec?.workdir === workdir) {
-      this.preparedRemoteWorkspaceForNextExec = null;
+      this.discardPreparedRemoteWorkspace();
     }
+  }
+
+  private discardPreparedRemoteWorkspace(): void {
+    const preparedWorkspace = this.preparedRemoteWorkspaceForNextExec;
+    if (!preparedWorkspace) {
+      return;
+    }
+    this.preparedRemoteWorkspaceForNextExec = null;
+    void preparedWorkspace.promise.then(
+      () => preparedWorkspace.lease.release(),
+      () => preparedWorkspace.lease.release(),
+    );
   }
 
   private async prepareRemoteWorkspaceForExec(): Promise<void> {
@@ -478,18 +580,23 @@ class OpenShellSandboxBackendImpl {
     }
   }
 
-  async finalizeExec(token: PendingExec | undefined): Promise<void> {
+  async finalizeExec(token?: PendingExec): Promise<void> {
+    const workspaceLease = token?.workspaceLease ?? (await this.acquireWorkspaceLease());
     try {
       if (this.params.execContext.config.mode === "mirror") {
         await this.syncWorkspaceFromRemote();
       }
     } finally {
-      if (token?.sshSession) {
-        try {
-          await token.cleanup();
-        } finally {
-          await disposeSshSandboxSession(token.sshSession);
+      try {
+        if (token?.sshSession) {
+          try {
+            await token.cleanup();
+          } finally {
+            await disposeSshSandboxSession(token.sshSession);
+          }
         }
+      } finally {
+        workspaceLease.release();
       }
     }
   }
@@ -721,6 +828,7 @@ class OpenShellSandboxBackendImpl {
     if (!/\bsandbox not found\b/iu.test(getResult.stderr)) {
       throw new Error(getResult.stderr.trim() || "openshell sandbox get failed");
     }
+    const detachedCreateSupported = await this.supportsDetachedSandboxCreation();
     const createArgs = [
       "sandbox",
       "create",
@@ -736,8 +844,7 @@ class OpenShellSandboxBackendImpl {
         ? ["--auto-providers"]
         : ["--no-auto-providers"]),
       ...this.params.execContext.config.providers.flatMap((provider) => ["--provider", provider]),
-      "--",
-      "true",
+      ...(detachedCreateSupported ? ["--detach", "--", "sleep", "infinity"] : ["--", "true"]),
     ];
     const createResult = await runOpenShellCli({
       context: this.params.execContext,
@@ -749,6 +856,45 @@ class OpenShellSandboxBackendImpl {
       throw new Error(createResult.stderr.trim() || "openshell sandbox create failed");
     }
     this.remoteSeedPending = true;
+  }
+
+  private async supportsDetachedSandboxCreation(): Promise<boolean> {
+    const { config } = this.params.execContext;
+    const cliIdentity = JSON.stringify([
+      config.command,
+      config.gatewayEndpoint ?? "",
+      config.gateway ?? "",
+      config.workspace ?? process.env.OPENSHELL_WORKSPACE ?? "",
+    ]);
+    let support =
+      openShellDetachedCreateSupport?.key === cliIdentity
+        ? openShellDetachedCreateSupport.promise
+        : undefined;
+    if (!support) {
+      support = (async () => {
+        const result = await runOpenShellCli({
+          context: this.params.execContext,
+          args: ["sandbox", "create", "--help"],
+          cwd: this.params.createParams.workspaceDir,
+        });
+        if (result.code !== 0) {
+          throw new Error(
+            result.stderr.trim() || "openshell sandbox create capability check failed",
+          );
+        }
+        // Older supported CLIs run and await trailing commands; newer ones require a live main.
+        return /^\s*--detach(?:\s|$)/mu.test(result.stdout);
+      })();
+      openShellDetachedCreateSupport = { key: cliIdentity, promise: support };
+    }
+    try {
+      return await support;
+    } catch (error) {
+      if (openShellDetachedCreateSupport?.promise === support) {
+        openShellDetachedCreateSupport = undefined;
+      }
+      throw error;
+    }
   }
 
   private async resolveLegacyRuntimePhase(): Promise<string | undefined> {

--- a/src/agents/agent-tools.at-prefixed-host-paths.test.ts
+++ b/src/agents/agent-tools.at-prefixed-host-paths.test.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import "./test-helpers/fast-coding-tools.js";
+import "./test-helpers/fast-openclaw-tools.js";
+import { createOpenClawCodingTools } from "./agent-tools.js";
+import { createApplyPatchTool } from "./apply-patch.js";
+import { expectReadWriteEditTools, getTextContent } from "./test-helpers/agent-tools-fs-helpers.js";
+import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+async function withWorkspace(run: (workspaceDir: string) => Promise<void>): Promise<void> {
+  await run(tempDirs.make("openclaw-at-host-"));
+}
+
+describe("leading-@ host and mounted sandbox paths", () => {
+  it.each([false, true])(
+    "preserves literal files, new descendants, and file-reference shorthand with workspaceOnly=%s",
+    async (workspaceOnly) => {
+      await withWorkspace(async (workspaceDir) => {
+        const literalPath = path.join(workspaceDir, "@existing.md");
+        const siblingPath = path.join(workspaceDir, "existing.md");
+        const literalParent = path.join(workspaceDir, "@notes");
+        const siblingParent = path.join(workspaceDir, "notes");
+        await fs.mkdir(literalParent);
+        await fs.mkdir(siblingParent);
+        await fs.writeFile(literalPath, "literal original", "utf8");
+        await fs.writeFile(siblingPath, "sibling original", "utf8");
+        await fs.writeFile(path.join(siblingParent, "new.md"), "sibling child", "utf8");
+        await fs.writeFile(path.join(workspaceDir, "reference.md"), "reference", "utf8");
+        const { readTool, writeTool, editTool } = expectReadWriteEditTools(
+          createOpenClawCodingTools({
+            workspaceDir,
+            config: { tools: { fs: { workspaceOnly } } },
+          }),
+        );
+
+        expect(
+          getTextContent(await readTool.execute("at-existing-read", { path: "@existing.md" })),
+        ).toContain("literal original");
+        expect(
+          getTextContent(await readTool.execute("at-reference-read", { path: "@reference.md" })),
+        ).toContain("reference");
+        await writeTool.execute("at-existing-write", {
+          path: "@existing.md",
+          content: "literal updated",
+        });
+        await editTool.execute("at-existing-edit", {
+          path: "@existing.md",
+          edits: [{ oldText: "updated", newText: "edited" }],
+        });
+        await writeTool.execute("at-parent-write", {
+          path: "@notes/nested/../new.md",
+          content: "literal child",
+        });
+
+        await expect(fs.readFile(literalPath, "utf8")).resolves.toBe("literal edited");
+        await expect(fs.readFile(siblingPath, "utf8")).resolves.toBe("sibling original");
+        await expect(fs.readFile(path.join(literalParent, "new.md"), "utf8")).resolves.toBe(
+          "literal child",
+        );
+        await expect(fs.readFile(path.join(siblingParent, "new.md"), "utf8")).resolves.toBe(
+          "sibling child",
+        );
+      });
+    },
+  );
+
+  it.each([
+    { name: "workspace-confined host", workspaceOnly: true, mounted: false },
+    { name: "unconfined host", workspaceOnly: false, mounted: false },
+    { name: "mounted sandbox", workspaceOnly: true, mounted: true },
+  ])("adds, updates, and deletes literal paths through the $name owner", async (runtime) => {
+    await withWorkspace(async (workspaceDir) => {
+      const literalParent = path.join(workspaceDir, "@notes");
+      const siblingParent = path.join(workspaceDir, "notes");
+      await fs.mkdir(literalParent);
+      await fs.mkdir(siblingParent);
+      await fs.writeFile(path.join(siblingParent, "new.md"), "sibling before\n", "utf8");
+      const patchTool = createApplyPatchTool({
+        cwd: workspaceDir,
+        workspaceOnly: runtime.workspaceOnly,
+        ...(runtime.mounted
+          ? { sandbox: { root: workspaceDir, bridge: createHostSandboxFsBridge(workspaceDir) } }
+          : {}),
+      });
+      const runPatch = (callId: string, lines: string[]) =>
+        patchTool.execute(callId, { input: lines.join("\n") });
+
+      await runPatch("at-patch-add", [
+        "*** Begin Patch",
+        "*** Add File: @notes/new.md",
+        "+literal before",
+        "*** End Patch",
+      ]);
+      await expect(fs.readFile(path.join(literalParent, "new.md"), "utf8")).resolves.toBe(
+        "literal before\n",
+      );
+
+      await runPatch("at-patch-update", [
+        "*** Begin Patch",
+        "*** Update File: @notes/new.md",
+        "@@",
+        "-literal before",
+        "+literal after",
+        "*** End Patch",
+      ]);
+      await expect(fs.readFile(path.join(literalParent, "new.md"), "utf8")).resolves.toBe(
+        "literal after\n",
+      );
+
+      await runPatch("at-patch-delete", [
+        "*** Begin Patch",
+        "*** Delete File: @notes/new.md",
+        "*** End Patch",
+      ]);
+      await expect(fs.stat(path.join(literalParent, "new.md"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(fs.readFile(path.join(siblingParent, "new.md"), "utf8")).resolves.toBe(
+        "sibling before\n",
+      );
+    });
+  });
+});

--- a/src/agents/agent-tools.at-prefixed-remote-paths.test.ts
+++ b/src/agents/agent-tools.at-prefixed-remote-paths.test.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  createSandboxedEditTool,
+  createSandboxedReadTool,
+  createSandboxedWriteTool,
+  wrapToolMemoryFlushAppendOnlyWrite,
+  wrapToolWorkspaceRootGuardWithOptions,
+} from "./agent-tools.read.js";
+import { createApplyPatchTool } from "./apply-patch.js";
+import { createRemoteShellSandboxFsBridge } from "./sandbox/remote-fs-bridge.js";
+import { createLocalRemoteShellScriptRunner } from "./sandbox/remote-fs-bridge.test-helpers.js";
+import { createSandboxTestContext } from "./sandbox/test-fixtures.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("leading-@ paths on a real remote sandbox filesystem bridge", () => {
+  it.runIf(process.platform !== "win32")(
+    "preserves remote-only literal files, shorthand, journal authority, and patch targets",
+    async () => {
+      const stateDir = tempDirs.make("openclaw-at-remote-");
+      const hostRoot = path.join(stateDir, "host");
+      const remoteRoot = path.join(stateDir, "remote");
+      await fs.mkdir(hostRoot);
+      await fs.mkdir(remoteRoot);
+      await fs.writeFile(path.join(remoteRoot, "@notes.md"), "literal original", "utf8");
+      await fs.writeFile(path.join(remoteRoot, "notes.md"), "sibling original", "utf8");
+      await fs.writeFile(path.join(remoteRoot, "reference.md"), "reference", "utf8");
+      await fs.mkdir(path.join(remoteRoot, "@projects"));
+      await fs.mkdir(path.join(remoteRoot, "projects"));
+      await fs.writeFile(path.join(remoteRoot, "projects", "new.md"), "sibling child", "utf8");
+
+      const sandbox = createSandboxTestContext({
+        overrides: {
+          workspaceDir: hostRoot,
+          agentWorkspaceDir: hostRoot,
+          containerWorkdir: remoteRoot,
+          workspaceAccess: "rw",
+        },
+      });
+      const bridge = createRemoteShellSandboxFsBridge({
+        sandbox,
+        runtime: {
+          remoteWorkspaceDir: remoteRoot,
+          remoteAgentWorkspaceDir: remoteRoot,
+          runRemoteShellScript: createLocalRemoteShellScriptRunner(),
+        },
+      });
+      const guard = (tool: ReturnType<typeof createSandboxedReadTool>) =>
+        wrapToolWorkspaceRootGuardWithOptions(tool, hostRoot, {
+          containerWorkdir: remoteRoot,
+          bridge,
+        });
+      const readTool = guard(createSandboxedReadTool({ root: hostRoot, bridge }));
+      const writeTool = guard(createSandboxedWriteTool({ root: hostRoot, bridge }));
+      const editTool = guard(createSandboxedEditTool({ root: hostRoot, bridge }));
+
+      await expect(readTool.execute("remote-at-read", { path: "@notes.md" })).resolves.toEqual(
+        expect.objectContaining({
+          content: expect.arrayContaining([
+            expect.objectContaining({ type: "text", text: "literal original" }),
+          ]),
+        }),
+      );
+      await expect(
+        readTool.execute("remote-at-reference", { path: "@reference.md" }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          content: expect.arrayContaining([
+            expect.objectContaining({ type: "text", text: "reference" }),
+          ]),
+        }),
+      );
+      await writeTool.execute("remote-at-write", {
+        path: "@notes.md",
+        content: "literal updated",
+      });
+      await editTool.execute("remote-at-edit", {
+        path: "@notes.md",
+        edits: [{ oldText: "updated", newText: "edited" }],
+      });
+      await expect(fs.readFile(path.join(remoteRoot, "@notes.md"), "utf8")).resolves.toBe(
+        "literal edited",
+      );
+      await expect(fs.readFile(path.join(remoteRoot, "notes.md"), "utf8")).resolves.toBe(
+        "sibling original",
+      );
+      await writeTool.execute("remote-at-parent-write", {
+        path: "@projects/new.md",
+        content: "literal child",
+      });
+      await expect(fs.readFile(path.join(remoteRoot, "@projects", "new.md"), "utf8")).resolves.toBe(
+        "literal child",
+      );
+      await expect(fs.readFile(path.join(remoteRoot, "projects", "new.md"), "utf8")).resolves.toBe(
+        "sibling child",
+      );
+
+      const journal = "memory/2026-08-25.md";
+      for (const parent of ["memory", "@memory"]) {
+        await fs.mkdir(path.join(remoteRoot, parent));
+      }
+      await fs.writeFile(path.join(remoteRoot, journal), "allowed", "utf8");
+      await fs.writeFile(path.join(remoteRoot, `@${journal}`), "literal", "utf8");
+      const memoryWriteTool = wrapToolMemoryFlushAppendOnlyWrite(writeTool, {
+        root: hostRoot,
+        relativePath: journal,
+        sandbox: { root: hostRoot, bridge },
+      });
+      await expect(
+        memoryWriteTool.execute("remote-at-memory", {
+          path: `@${journal}`,
+          content: "wrong journal",
+        }),
+      ).rejects.toThrow(/Memory flush writes are restricted/);
+      await expect(fs.readFile(path.join(remoteRoot, journal), "utf8")).resolves.toBe("allowed");
+
+      await createApplyPatchTool({ cwd: hostRoot, sandbox: { root: hostRoot, bridge } }).execute(
+        "remote-at-patch",
+        {
+          input: ["*** Begin Patch", "*** Delete File: @notes.md", "*** End Patch"].join("\n"),
+        },
+      );
+      await expect(fs.stat(path.join(remoteRoot, "@notes.md"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(fs.readFile(path.join(remoteRoot, "notes.md"), "utf8")).resolves.toBe(
+        "sibling original",
+      );
+      await expect(fs.stat(path.join(hostRoot, "@notes.md"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
+});

--- a/src/agents/agent-tools.memory-flush-append-write.test.ts
+++ b/src/agents/agent-tools.memory-flush-append-write.test.ts
@@ -80,6 +80,35 @@ describe("wrapToolMemoryFlushAppendOnlyWrite output contract", () => {
     expect(await fs.readFile(absolute, "utf-8")).toBe("seed\nhello");
   });
 
+  it.each([true, false])(
+    "rejects @memory paths instead of appending to their allowed sibling (literal exists: %s)",
+    async (literalExists) => {
+      const allowedPath = path.join(root, RELATIVE_PATH);
+      const literalPath = path.join(root, `@${RELATIVE_PATH}`);
+      await fs.mkdir(path.dirname(allowedPath), { recursive: true });
+      await fs.mkdir(path.dirname(literalPath), { recursive: true });
+      await fs.writeFile(allowedPath, "allowed", "utf8");
+      if (literalExists) {
+        await fs.writeFile(literalPath, "literal", "utf8");
+      }
+      const wrapped = wrapToolMemoryFlushAppendOnlyWrite(baseWriteTool(), {
+        root,
+        relativePath: RELATIVE_PATH,
+      });
+
+      await expect(
+        wrapped.execute("at-memory-flush", {
+          path: `@${RELATIVE_PATH}`,
+          content: "wrong journal",
+        }),
+      ).rejects.toThrow(/Memory flush writes are restricted/);
+      await expect(fs.readFile(allowedPath, "utf8")).resolves.toBe("allowed");
+      if (literalExists) {
+        await expect(fs.readFile(literalPath, "utf8")).resolves.toBe("literal");
+      }
+    },
+  );
+
   it("documents the pre-fix regression: append-only metadata violates the declared schema", () => {
     const validation = validateAgainstDeclaredSchema({ path: RELATIVE_PATH, appendOnly: true });
     expect(validation.ok).toBe(false);

--- a/src/agents/agent-tools.memory-flush-append-write.test.ts
+++ b/src/agents/agent-tools.memory-flush-append-write.test.ts
@@ -80,15 +80,17 @@ describe("wrapToolMemoryFlushAppendOnlyWrite output contract", () => {
     expect(await fs.readFile(absolute, "utf-8")).toBe("seed\nhello");
   });
 
-  it.each([true, false])(
-    "rejects @memory paths instead of appending to their allowed sibling (literal exists: %s)",
-    async (literalExists) => {
+  it.each(["file", "ancestor", "absent"] as const)(
+    "rejects @memory paths instead of appending to their allowed sibling (literal: %s)",
+    async (literalState) => {
       const allowedPath = path.join(root, RELATIVE_PATH);
       const literalPath = path.join(root, `@${RELATIVE_PATH}`);
       await fs.mkdir(path.dirname(allowedPath), { recursive: true });
-      await fs.mkdir(path.dirname(literalPath), { recursive: true });
       await fs.writeFile(allowedPath, "allowed", "utf8");
-      if (literalExists) {
+      if (literalState !== "absent") {
+        await fs.mkdir(path.dirname(literalPath), { recursive: true });
+      }
+      if (literalState === "file") {
         await fs.writeFile(literalPath, "literal", "utf8");
       }
       const wrapped = wrapToolMemoryFlushAppendOnlyWrite(baseWriteTool(), {
@@ -103,7 +105,7 @@ describe("wrapToolMemoryFlushAppendOnlyWrite output contract", () => {
         }),
       ).rejects.toThrow(/Memory flush writes are restricted/);
       await expect(fs.readFile(allowedPath, "utf8")).resolves.toBe("allowed");
-      if (literalExists) {
+      if (literalState === "file") {
         await expect(fs.readFile(literalPath, "utf8")).resolves.toBe("literal");
       }
     },

--- a/src/agents/agent-tools.params.ts
+++ b/src/agents/agent-tools.params.ts
@@ -5,6 +5,8 @@
  */
 import { asOptionalObjectRecord as getToolParamsRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AnyAgentTool } from "./agent-tools.types.js";
+import { preserveAtPrefixedRelativePath } from "./path-policy.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.types.js";
 
 /** Return a record view of model-supplied tool params when possible. */
 export { getToolParamsRecord };
@@ -123,8 +125,19 @@ function normalizeHallucinatedOfficePathExtension(value: string): string {
 }
 
 /** Normalize model-supplied file-tool path params without touching payload text. */
-export function normalizeFileToolPathParam(value: string): string {
-  return normalizeHallucinatedOfficePathExtension(stripMalformedXmlArgValueSuffix(value));
+export function normalizeFileToolPathParam(value: string): string;
+export function normalizeFileToolPathParam(
+  value: string,
+  cwd: string,
+  bridge?: SandboxFsBridge,
+): Promise<string>;
+export function normalizeFileToolPathParam(
+  value: string,
+  cwd?: string,
+  bridge?: SandboxFsBridge,
+): string | Promise<string> {
+  const repaired = normalizeHallucinatedOfficePathExtension(stripMalformedXmlArgValueSuffix(value));
+  return cwd ? Promise.resolve(preserveAtPrefixedRelativePath(repaired, cwd, bridge)) : repaired;
 }
 
 /** Strip malformed XML suffixes from selected string fields without mutating input. */
@@ -148,17 +161,21 @@ export function stripMalformedXmlArgValueSuffixFromKeys<T extends Record<string,
 }
 
 /** Normalize selected file-tool path fields without mutating input. */
-export function normalizeFileToolPathParamsFromKeys<T extends Record<string, unknown>>(
+export async function normalizeFileToolPathParamsFromKeys<T extends Record<string, unknown>>(
   record: T,
   keys: readonly string[],
-): T {
+  cwd?: string,
+  bridge?: SandboxFsBridge,
+): Promise<T> {
   let normalized: T | undefined;
   for (const key of keys) {
     const value = record[key];
     if (typeof value !== "string") {
       continue;
     }
-    const normalizedValue = normalizeFileToolPathParam(value);
+    const normalizedValue = cwd
+      ? await normalizeFileToolPathParam(value, cwd, bridge)
+      : normalizeFileToolPathParam(value);
     if (normalizedValue !== value) {
       normalized ??= { ...record };
       normalized[key as keyof T] = normalizedValue as T[keyof T];
@@ -225,6 +242,8 @@ export function assertRequiredParams(
 export function wrapToolParamValidation(
   tool: AnyAgentTool,
   requiredParamGroups?: readonly RequiredParamGroup[],
+  cwd?: string,
+  bridge?: SandboxFsBridge,
 ): AnyAgentTool {
   return {
     ...tool,
@@ -233,7 +252,7 @@ export function wrapToolParamValidation(
       const pathKeys = resolveFileToolPathParamKeys(requiredParamGroups);
       const normalizedParams =
         record && pathKeys.length > 0
-          ? normalizeFileToolPathParamsFromKeys(record, pathKeys)
+          ? await normalizeFileToolPathParamsFromKeys(record, pathKeys, cwd, bridge)
           : params;
       if (requiredParamGroups?.length) {
         assertRequiredParams(getToolParamsRecord(normalizedParams), requiredParamGroups, tool.name);

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -76,6 +76,8 @@ const ENV_FILE_PATH_RE = /(?:^|[/\\])(?:\.env(?:\.[^/\\]+)?|[^/\\]+\.env)$/i;
 type OpenClawReadToolOptions = {
   modelContextWindowTokens?: number;
   imageSanitization?: ImageSanitizationLimits;
+  cwd?: string;
+  bridge?: SandboxFsBridge;
 };
 
 type SkillReadContent = {
@@ -737,7 +739,12 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
     execute: async (toolCallId, args, signal, onUpdate) => {
       const record = getToolParamsRecord(args);
       const normalizedRecord = record
-        ? normalizeFileToolPathParamsFromKeys(record, ["path"])
+        ? await normalizeFileToolPathParamsFromKeys(
+            record,
+            ["path"],
+            options.root,
+            options.sandbox?.bridge,
+          )
         : undefined;
       assertRequiredParams(normalizedRecord, REQUIRED_PARAM_GROUPS.write, tool.name);
       const filePath =
@@ -863,6 +870,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
     pathParamKeys?: readonly string[];
     normalizeGuardedPathParams?: boolean;
     resolutionCwd?: string;
+    bridge?: SandboxFsBridge;
   },
 ): AnyAgentTool {
   const pathParamKeys =
@@ -877,7 +885,11 @@ export function wrapToolWorkspaceRootGuardWithOptions(
         if (typeof rawFilePath !== "string" || !rawFilePath.trim()) {
           continue;
         }
-        const filePath = normalizeFileToolPathParam(rawFilePath);
+        const filePath = await normalizeFileToolPathParam(
+          rawFilePath,
+          options?.resolutionCwd ?? root,
+          options?.bridge,
+        );
         if (!filePath.trim()) {
           throw malformedXmlArgValuePathError(key);
         }
@@ -958,6 +970,8 @@ export function createSandboxedReadTool(
   return createOpenClawReadTool(base, {
     modelContextWindowTokens: params.modelContextWindowTokens,
     imageSanitization: params.imageSanitization,
+    cwd: params.root,
+    bridge: params.bridge,
   });
 }
 
@@ -970,7 +984,7 @@ export function createSandboxedWriteTool(
       operations: createSandboxWriteOperations(params),
     }),
   );
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
+  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write, params.root, params.bridge);
 }
 
 /** Create a sandbox-backed edit tool with required-parameter validation. */
@@ -982,7 +996,7 @@ export function createSandboxedEditTool(
       operations: createSandboxEditOperations(params),
     }),
   );
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit);
+  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit, params.root, params.bridge);
 }
 
 /** Create a host workspace write tool using guarded filesystem operations. */
@@ -1000,7 +1014,7 @@ export function createHostWorkspaceWriteTool(
       operations: createHostWriteOperations(options?.containmentRoot ?? root, options),
     }),
   );
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
+  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write, root);
 }
 
 /** Create a host workspace edit tool using guarded filesystem operations. */
@@ -1018,7 +1032,7 @@ export function createHostWorkspaceEditTool(
       operations: createHostEditOperations(options?.containmentRoot ?? root, options),
     }),
   );
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit);
+  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit, root);
 }
 
 /** Wrap the base read tool with OpenClaw paging, MIME, and image handling. */
@@ -1031,7 +1045,7 @@ export function createOpenClawReadTool(
     execute: async (toolCallId, params, signal) => {
       const record = getToolParamsRecord(params);
       const normalizedRecord = record
-        ? normalizeFileToolPathParamsFromKeys(record, ["path"])
+        ? await normalizeFileToolPathParamsFromKeys(record, ["path"], options?.cwd, options?.bridge)
         : undefined;
       assertRequiredParams(normalizedRecord, REQUIRED_PARAM_GROUPS.read, base.name);
       const filePath =

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -761,7 +761,7 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
         root: options.root,
         containerWorkdir: options.containerWorkdir,
       });
-      if (resolvedPath !== allowedAbsolutePath) {
+      if (filePath.startsWith("@") || resolvedPath !== allowedAbsolutePath) {
         throw new Error(
           `Memory flush writes are restricted to ${options.relativePath}; use that path only.`,
         );

--- a/src/agents/apply-patch-paths.test.ts
+++ b/src/agents/apply-patch-paths.test.ts
@@ -3,10 +3,12 @@
  * Ensures pre-execution policy checks see add/update/delete/move paths in
  * host and sandbox forms without requiring full parser success.
  */
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { extractApplyPatchTargetPaths } from "./apply-patch-paths.js";
+import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge.js";
 
 const defaultCwd = process.cwd();
 const cwdPath = (...segments: string[]) => path.join(defaultCwd, ...segments);
@@ -223,6 +225,40 @@ describe("extractApplyPatchTargetPaths", () => {
       path.join("/tmp", "openclaw-target.ts"),
     ]);
   });
+
+  it.each(["host", "mounted sandbox"])(
+    "derives literal @ files and new descendants through the %s path owner",
+    async (runtime) => {
+      const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-patch-at-path-"));
+      try {
+        const literalParent = path.join(cwd, "@notes");
+        const siblingParent = path.join(cwd, "notes");
+        await fs.mkdir(literalParent);
+        await fs.mkdir(siblingParent);
+        await fs.writeFile(path.join(literalParent, "existing.md"), "literal");
+        await fs.writeFile(path.join(siblingParent, "existing.md"), "sibling");
+        await fs.writeFile(path.join(siblingParent, "new.md"), "sibling");
+        const patch = [
+          "*** Begin Patch",
+          "*** Delete File: @notes/existing.md",
+          "*** Add File: @notes/new.md",
+          "+literal",
+          "*** End Patch",
+        ].join("\n");
+        const options =
+          runtime === "mounted sandbox"
+            ? { cwd, sandbox: { root: cwd, bridge: createHostSandboxFsBridge(cwd) } }
+            : { cwd };
+
+        expect(extractApplyPatchTargetPaths(patch, options)).toEqual([
+          path.join(literalParent, "existing.md"),
+          path.join(literalParent, "new.md"),
+        ]);
+      } finally {
+        await fs.rm(cwd, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("defaults missing cwd to apply_patch process cwd semantics", () => {
     const patch = [

--- a/src/agents/apply-patch-paths.ts
+++ b/src/agents/apply-patch-paths.ts
@@ -5,6 +5,7 @@
  */
 import path from "node:path";
 import { extractApplyPatchTargets } from "./apply-patch-targets.js";
+import { preserveAtPrefixedRelativePath } from "./path-policy.js";
 import { resolveSandboxInputPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
@@ -52,14 +53,17 @@ function normalizePatchPath(
   }
   const cwd = options.cwd ?? options.sandbox?.root ?? process.cwd();
   try {
+    const filePath = preserveAtPrefixedRelativePath(raw, cwd);
     const resolved = options.sandbox
       ? options.sandbox.bridge.resolvePath({
-          filePath: raw,
+          filePath,
           cwd,
         })
       : undefined;
     const normalized = path.normalize(
-      resolved ? (resolved.hostPath ?? resolved.containerPath) : resolveSandboxInputPath(raw, cwd),
+      resolved
+        ? (resolved.hostPath ?? resolved.containerPath)
+        : resolveSandboxInputPath(filePath, cwd),
     );
     return normalized && normalized !== "." ? normalized : undefined;
   } catch {

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -17,7 +17,7 @@ import {
 } from "./apply-patch-file-ops.js";
 import { applyUpdateHunk } from "./apply-patch-update.js";
 import type { MemoryWriteProvenanceObserver } from "./memory-write-provenance.js";
-import { resolvePathFromInput } from "./path-policy.js";
+import { preserveAtPrefixedRelativePath, resolvePathFromInput } from "./path-policy.js";
 import type { AgentTool } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import {
@@ -309,10 +309,11 @@ async function ensureDir(filePath: string, ops: PatchFileOps) {
   await ops.mkdirp(parent);
 }
 
-async function assertPatchParentPath(filePath: string, options: ApplyPatchOptions) {
+async function assertPatchParentPath(rawFilePath: string, options: ApplyPatchOptions) {
   if (options.workspaceOnly === false || options.sandbox) {
     return;
   }
+  const filePath = preserveAtPrefixedRelativePath(rawFilePath, options.cwd);
   const parent = path.dirname(filePath);
   if (!parent || parent === ".") {
     return;
@@ -358,11 +359,16 @@ async function assertNoExistingParentAliases(params: { parentPath: string; rootP
 }
 
 async function resolvePatchPath(
-  filePath: string,
+  rawFilePath: string,
   options: ApplyPatchOptions,
   aliasPolicy: PathAliasPolicy = PATH_ALIAS_POLICIES.strict,
 ): Promise<{ resolved: string; display: string }> {
   if (options.sandbox) {
+    const filePath = await preserveAtPrefixedRelativePath(
+      rawFilePath,
+      options.cwd,
+      options.sandbox.bridge,
+    );
     const resolved = options.sandbox.bridge.resolvePath({
       filePath,
       cwd: options.cwd,
@@ -382,6 +388,7 @@ async function resolvePatchPath(
     };
   }
 
+  const filePath = preserveAtPrefixedRelativePath(rawFilePath, options.cwd);
   const workspaceOnly = options.workspaceOnly !== false;
   const resolved = workspaceOnly
     ? (

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -153,6 +153,7 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
             {
               modelContextWindowTokens: options.modelContextWindowTokens,
               imageSanitization: options.imageSanitization,
+              cwd: options.codingRoot,
             },
           );
       const guarded = options.workspaceOnly
@@ -166,6 +167,7 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
                     readOnlyWorkspaceSkillMounts,
                   ),
                   containerWorkdir: sandbox.containerWorkdir,
+                  bridge: sandboxFsBridge,
                 }
               : { additionalRoots: skillReadRoots, resolutionCwd: options.codingRoot },
           )
@@ -218,11 +220,13 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
       options.workspaceOnly
         ? wrapToolWorkspaceRootGuardWithOptions(edit, sandboxRoot, {
             containerWorkdir: sandbox.containerWorkdir,
+            bridge: sandboxFsBridge,
           })
         : edit,
       options.workspaceOnly
         ? wrapToolWorkspaceRootGuardWithOptions(write, sandboxRoot, {
             containerWorkdir: sandbox.containerWorkdir,
+            bridge: sandboxFsBridge,
           })
         : write,
     );

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -253,6 +253,7 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
         hasRepliedRef: options?.hasRepliedRef,
         sameChannelThreadRequired: options?.sameChannelThreadRequired,
         sandboxRoot: options?.sandboxRoot,
+        sandboxContainerWorkdir: options?.sandboxContainerWorkdir,
         requireExplicitTarget: options?.requireExplicitMessageTarget,
         sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
         sourceReplyOnly: options?.sourceReplyOnly,

--- a/src/agents/path-policy.ts
+++ b/src/agents/path-policy.ts
@@ -4,8 +4,10 @@
  * Converts validated absolute or relative inputs into root-relative paths without allowing boundary escapes.
  */
 import path from "node:path";
+import { pathExistsSync } from "../infra/fs-safe.js";
 import { normalizeWindowsPathPreservingCase } from "../infra/path-guards.js";
 import { resolveSandboxInputPath } from "./sandbox-paths.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.types.js";
 
 // Shared path boundary helpers for workspace and sandbox-facing agent inputs.
 // Callers get normalized relative paths only after the candidate proves it stays
@@ -161,4 +163,64 @@ export function toRelativeSandboxPath(
 /** Resolve a user-supplied path against `cwd` using the sandbox input rules. */
 export function resolvePathFromInput(filePath: string, cwd: string): string {
   return path.normalize(resolveSandboxInputPath(filePath, cwd));
+}
+
+/** Disambiguate an existing literal relative filename from `@` file-reference shorthand. */
+export function preserveAtPrefixedRelativePath(filePath: string, cwd: string): string;
+export function preserveAtPrefixedRelativePath(
+  filePath: string,
+  cwd: string,
+  bridge: SandboxFsBridge | undefined,
+): string | Promise<string>;
+export function preserveAtPrefixedRelativePath(
+  filePath: string,
+  cwd: string,
+  bridge?: SandboxFsBridge,
+): string | Promise<string> {
+  if (!filePath.startsWith("@")) {
+    return filePath;
+  }
+  const stripped = filePath.slice(1);
+  if (
+    !stripped ||
+    stripped === "~" ||
+    stripped.startsWith("~/") ||
+    stripped.startsWith("~\\") ||
+    /^file:\/\//i.test(stripped) ||
+    path.posix.isAbsolute(stripped) ||
+    path.win32.isAbsolute(stripped)
+  ) {
+    // Absolute/home/URL mentions must reach existing workspace guards unchanged.
+    return filePath;
+  }
+  // `./` preserves literal @ through legacy resolvers without breaking TUI mentions.
+  const literalPath = `./${filePath}`;
+  let literalAncestor = filePath;
+  while (true) {
+    const parent = path.dirname(literalAncestor);
+    if (parent === "." || parent === literalAncestor) {
+      break;
+    }
+    literalAncestor = parent;
+  }
+  const ancestorPath = literalAncestor === filePath ? undefined : `./${literalAncestor}`;
+  const mountedHostPath = bridge?.resolvePath({ filePath: literalPath, cwd }).hostPath;
+  if (!bridge || mountedHostPath) {
+    const hostPath = mountedHostPath ?? path.resolve(cwd, literalPath);
+    const ancestorHostPath = ancestorPath
+      ? bridge
+        ? bridge.resolvePath({ filePath: ancestorPath, cwd }).hostPath
+        : path.resolve(cwd, ancestorPath)
+      : undefined;
+    return pathExistsSync(hostPath) || (ancestorHostPath && pathExistsSync(ancestorHostPath))
+      ? literalPath
+      : filePath;
+  }
+  return bridge
+    .stat({ filePath: literalPath, cwd })
+    .then(async (stat) =>
+      stat || (ancestorPath && (await bridge.stat({ filePath: ancestorPath, cwd })))
+        ? literalPath
+        : filePath,
+    );
 }

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -354,6 +354,59 @@ describe("resolveSandboxedMediaSource", () => {
     },
   );
 
+  it.each([
+    {
+      name: "OpenShell absolute path",
+      containerWorkdir: "/sandbox",
+      media: "/sandbox/media/pic.png",
+    },
+    {
+      name: "OpenShell file URL",
+      containerWorkdir: "/sandbox",
+      media: "file:///sandbox/media/pic.png",
+    },
+    {
+      name: "custom backend workdir with trailing slash",
+      containerWorkdir: "/remote/agent/",
+      media: "/remote/agent/media/pic.png",
+    },
+    {
+      name: "custom backend file URL",
+      containerWorkdir: "/remote/agent",
+      media: "FILE:/remote/agent/media/pic.png",
+    },
+  ])(
+    "maps $name through the authoritative backend workdir",
+    async ({ containerWorkdir, media }) => {
+      await withSandboxRoot(async (sandboxDir) => {
+        await expect(
+          resolveSandboxedMediaSource({
+            media,
+            sandboxRoot: sandboxDir,
+            containerWorkdir,
+          }),
+        ).resolves.toBe(path.join(sandboxDir, "media", "pic.png"));
+      });
+    },
+  );
+
+  it.each([
+    "/sandbox-other/secret.png",
+    "/workspace/secret.png",
+    "/sandbox/../secret.png",
+    "file:///sandbox-other/secret.png",
+  ])("rejects %s outside the authoritative backend workdir", async (media) => {
+    await withSandboxRoot(async (sandboxDir) => {
+      await expect(
+        resolveSandboxedMediaSource({
+          media,
+          sandboxRoot: sandboxDir,
+          containerWorkdir: "/sandbox",
+        }),
+      ).rejects.toThrow(/sandbox/i);
+    });
+  });
+
   it("preserves remote mxc:// media sources", async () => {
     await withSandboxRoot(async (sandboxDir) => {
       const result = await resolveSandboxedMediaSource({

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -229,6 +229,7 @@ export async function resolveAllowedManagedMediaPath(
 export async function resolveSandboxedMediaSource(params: {
   media: string;
   sandboxRoot: string;
+  containerWorkdir?: string;
 }): Promise<string> {
   const raw = params.media.trim();
   if (!raw) {
@@ -237,11 +238,16 @@ export async function resolveSandboxedMediaSource(params: {
   if (isPassThroughRemoteMediaSource(raw)) {
     return raw;
   }
+  const normalizedContainerWorkdir = path.posix.normalize(
+    (params.containerWorkdir ?? SANDBOX_CONTAINER_WORKDIR).replace(/\\/g, "/"),
+  );
+  const containerWorkdir = normalizedContainerWorkdir.replace(/\/+$/, "") || "/";
   let candidate = raw;
   if (/^file:/i.test(candidate)) {
     const workspaceMappedFromUrl = mapContainerWorkspaceFileUrl({
       fileUrl: candidate,
       sandboxRoot: params.sandboxRoot,
+      containerWorkdir,
     });
     if (workspaceMappedFromUrl) {
       candidate = workspaceMappedFromUrl;
@@ -258,6 +264,7 @@ export async function resolveSandboxedMediaSource(params: {
   const containerWorkspaceMapped = mapContainerWorkspacePath({
     candidate,
     sandboxRoot: params.sandboxRoot,
+    containerWorkdir,
   });
   if (containerWorkspaceMapped) {
     candidate = containerWorkspaceMapped;
@@ -296,6 +303,7 @@ async function assertNoManagedMediaAliasEscape(params: {
 function mapContainerWorkspaceFileUrl(params: {
   fileUrl: string;
   sandboxRoot: string;
+  containerWorkdir: string;
 }): string | undefined {
   let parsed: URL;
   try {
@@ -313,35 +321,31 @@ function mapContainerWorkspaceFileUrl(params: {
   if (hasEncodedFileUrlSeparator(parsed.pathname)) {
     return undefined;
   }
-  // Sandbox paths are Linux-style (/workspace/*). Parse the URL path directly so
-  // Windows hosts can still accept file:///workspace/... media references.
+  // Backend workdirs are container paths; parse the URL directly so Windows hosts
+  // can still map Linux-style file URLs to their actual sandbox workspace.
   let normalizedPathname: string;
   try {
     normalizedPathname = decodeURIComponent(parsed.pathname).replace(/\\/g, "/");
   } catch {
     return undefined;
   }
-  if (
-    normalizedPathname !== SANDBOX_CONTAINER_WORKDIR &&
-    !normalizedPathname.startsWith(`${SANDBOX_CONTAINER_WORKDIR}/`)
-  ) {
-    return undefined;
-  }
   return mapContainerWorkspacePath({
     candidate: normalizedPathname,
     sandboxRoot: params.sandboxRoot,
+    containerWorkdir: params.containerWorkdir,
   });
 }
 
 function mapContainerWorkspacePath(params: {
   candidate: string;
   sandboxRoot: string;
+  containerWorkdir: string;
 }): string | undefined {
   const normalized = params.candidate.replace(/\\/g, "/");
-  if (normalized === SANDBOX_CONTAINER_WORKDIR) {
+  if (normalized === params.containerWorkdir) {
     return path.resolve(params.sandboxRoot);
   }
-  const prefix = `${SANDBOX_CONTAINER_WORKDIR}/`;
+  const prefix = params.containerWorkdir === "/" ? "/" : `${params.containerWorkdir}/`;
   if (!normalized.startsWith(prefix)) {
     return undefined;
   }

--- a/src/agents/sandbox/backend.test.ts
+++ b/src/agents/sandbox/backend.test.ts
@@ -8,6 +8,19 @@ import {
   registerSandboxBackend,
 } from "./backend.js";
 
+function createGenerationRegistration(label: string) {
+  return {
+    factory: async () => {
+      throw new Error(`unused sandbox backend ${label}`);
+    },
+    manager: {
+      describeRuntime: async () => ({ running: true, configLabelMatch: true }),
+      removeRuntime: async () => {},
+    },
+    resolveWorkdir: () => `/runtime/${label}`,
+  };
+}
+
 describe("sandbox backend registry", () => {
   it("registers Podman as a built-in backend", () => {
     expect(getSandboxBackendFactory("podman")).not.toBeNull();
@@ -61,4 +74,84 @@ describe("sandbox backend registry", () => {
     restore();
     expect(getSandboxBackendWorkdirResolver("test-workdir")).toBeNull();
   });
+
+  it.each([
+    {
+      scenario: "older registration retires first",
+      generations: ["A", "B"],
+      disposalOrder: [
+        ["A", "B"],
+        ["B", null],
+      ],
+    },
+    {
+      scenario: "active registration restores its live predecessor",
+      generations: ["A", "B"],
+      disposalOrder: [
+        ["B", "A"],
+        ["A", null],
+      ],
+    },
+    {
+      scenario: "active registration skips every retired predecessor",
+      generations: ["A", "B", "C"],
+      disposalOrder: [
+        ["B", "C"],
+        ["A", "C"],
+        ["C", null],
+      ],
+    },
+    {
+      scenario: "active registration restores the newest unretired predecessor",
+      generations: ["A", "B", "C"],
+      disposalOrder: [
+        ["B", "C"],
+        ["C", "A"],
+        ["A", null],
+      ],
+    },
+    {
+      scenario: "repeated stale disposal never restores retired authority",
+      generations: ["A", "B"],
+      disposalOrder: [
+        ["B", "A"],
+        ["A", null],
+        ["B", null],
+      ],
+    },
+  ] as const)(
+    "preserves all backend authority when $scenario",
+    ({ generations, disposalOrder }) => {
+      const backendId = "test-generation-ownership";
+      const registrations = new Map<string, ReturnType<typeof createGenerationRegistration>>();
+      const disposers = new Map<string, () => void>();
+
+      try {
+        for (const label of generations) {
+          const registration = createGenerationRegistration(label);
+          registrations.set(label, registration);
+          disposers.set(label, registerSandboxBackend(backendId, registration));
+        }
+
+        for (const [disposedLabel, expectedLabel] of disposalOrder) {
+          const dispose = disposers.get(disposedLabel);
+          if (!dispose) {
+            throw new Error(`missing sandbox registration disposer ${disposedLabel}`);
+          }
+          dispose();
+
+          const expected = expectedLabel ? registrations.get(expectedLabel) : undefined;
+          expect(getSandboxBackendFactory(backendId)).toBe(expected?.factory ?? null);
+          expect(getSandboxBackendManager(backendId)).toBe(expected?.manager ?? null);
+          expect(getSandboxBackendWorkdirResolver(backendId)).toBe(
+            expected?.resolveWorkdir ?? null,
+          );
+        }
+      } finally {
+        for (const dispose of Array.from(disposers.values()).toReversed()) {
+          dispose();
+        }
+      }
+    },
+  );
 });

--- a/src/agents/sandbox/backend.ts
+++ b/src/agents/sandbox/backend.ts
@@ -45,11 +45,20 @@ export type {
 
 const SANDBOX_BACKEND_FACTORIES_STATE_KEY = Symbol.for("openclaw.sandboxBackendFactories");
 
+type SandboxBackendRegistrationGeneration = {
+  registration: RegisteredSandboxBackend;
+  previous: SandboxBackendRegistrationGeneration | undefined;
+  retired: boolean;
+};
+
 // Process-wide sandbox backend registry. Tests and plugins can install temporary
 // factories while core still auto-registers the bundled container and SSH backends.
-function getSandboxBackendFactories(): Map<SandboxBackendId, RegisteredSandboxBackend> {
+function getSandboxBackendFactories(): Map<SandboxBackendId, SandboxBackendRegistrationGeneration> {
   const globalStore = globalThis as typeof globalThis & {
-    [SANDBOX_BACKEND_FACTORIES_STATE_KEY]?: Map<SandboxBackendId, RegisteredSandboxBackend>;
+    [SANDBOX_BACKEND_FACTORIES_STATE_KEY]?: Map<
+      SandboxBackendId,
+      SandboxBackendRegistrationGeneration
+    >;
   };
   globalStore[SANDBOX_BACKEND_FACTORIES_STATE_KEY] ??= new Map();
   return globalStore[SANDBOX_BACKEND_FACTORIES_STATE_KEY];
@@ -71,31 +80,54 @@ export function registerSandboxBackend(
   const normalizedId = normalizeSandboxBackendId(id);
   const resolved = typeof registration === "function" ? { factory: registration } : registration;
   const factories = getSandboxBackendFactories();
-  const previous = factories.get(normalizedId);
-  factories.set(normalizedId, resolved);
+  const generation: SandboxBackendRegistrationGeneration = {
+    registration: resolved,
+    previous: factories.get(normalizedId),
+    retired: false,
+  };
+  factories.set(normalizedId, generation);
   return () => {
-    const currentFactories = getSandboxBackendFactories();
-    if (previous) {
-      currentFactories.set(normalizedId, previous);
+    if (generation.retired) {
       return;
     }
-    currentFactories.delete(normalizedId);
+    generation.retired = true;
+    if (factories.get(normalizedId) !== generation) {
+      return;
+    }
+    // Older disposers can run before newer plugin generations retire. Skip
+    // every retired predecessor so stale sandbox authority never returns.
+    let previous = generation.previous;
+    while (previous?.retired) {
+      previous = previous.previous;
+    }
+    if (previous) {
+      factories.set(normalizedId, previous);
+      return;
+    }
+    factories.delete(normalizedId);
   };
 }
 
 /** Look up a sandbox backend factory by normalized backend id. */
 export function getSandboxBackendFactory(id: string): SandboxBackendFactory | null {
-  return getSandboxBackendFactories().get(normalizeSandboxBackendId(id))?.factory ?? null;
+  return (
+    getSandboxBackendFactories().get(normalizeSandboxBackendId(id))?.registration.factory ?? null
+  );
 }
 
 /** Look up optional lifecycle management hooks for a registered backend. */
 export function getSandboxBackendManager(id: string): SandboxBackendManager | null {
-  return getSandboxBackendFactories().get(normalizeSandboxBackendId(id))?.manager ?? null;
+  return (
+    getSandboxBackendFactories().get(normalizeSandboxBackendId(id))?.registration.manager ?? null
+  );
 }
 
 /** Look up optional backend workdir resolution that does not start the runtime. */
 export function getSandboxBackendWorkdirResolver(id: string): SandboxBackendWorkdirResolver | null {
-  return getSandboxBackendFactories().get(normalizeSandboxBackendId(id))?.resolveWorkdir ?? null;
+  return (
+    getSandboxBackendFactories().get(normalizeSandboxBackendId(id))?.registration.resolveWorkdir ??
+    null
+  );
 }
 
 /** Resolve a backend factory or throw the user-facing configuration error. */

--- a/src/agents/tools/message-tool-execution.ts
+++ b/src/agents/tools/message-tool-execution.ts
@@ -228,6 +228,7 @@ type MessageToolOptions = {
   hasRepliedRef?: { value: boolean };
   sameChannelThreadRequired?: boolean;
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
   requireExplicitTarget?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   /** Process-local completion authority: send only to the current source route. */
@@ -666,6 +667,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           executionIdentityToken,
           agentId: resolvedAgentId,
           sandboxRoot: options?.sandboxRoot,
+          sandboxContainerWorkdir: options?.sandboxContainerWorkdir,
           sourceReplyDeliveryMode: sourceReplySinkDeliveryMode,
           // Only an admitted channel source can arm terminal restart reconciliation.
           // Source-less scheduled and ambient sends remain ordinary message actions.

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -154,31 +154,57 @@ describe("createReplyMediaPathNormalizer", () => {
     });
   });
 
-  it("maps sandbox-relative media back to the host sandbox workspace before staging", async () => {
-    ensureSandboxWorkspaceForSession.mockResolvedValue({
-      workspaceDir: "/tmp/sandboxes/session-1",
-      containerWorkdir: "/workspace",
+  it.each([
+    { name: "Docker", containerWorkdir: "/workspace" },
+    { name: "OpenShell", containerWorkdir: "/sandbox" },
+    { name: "custom remote backend", containerWorkdir: "/remote/agent" },
+  ])(
+    "maps $name media to the host sandbox workspace before staging",
+    async ({ containerWorkdir }) => {
+      ensureSandboxWorkspaceForSession.mockResolvedValue({
+        workspaceDir: "/tmp/sandboxes/session-1",
+        containerWorkdir,
+      });
+      const normalize = createTestReplyMediaNormalizer();
+
+      const result = await normalize({
+        mediaUrls: ["./out/photo.png", `file://${containerWorkdir}/screens/final.png`],
+      });
+
+      expectMedia(result, "/tmp/outbound-media/photo.png", [
+        "/tmp/outbound-media/photo.png",
+        "/tmp/outbound-media/final.png",
+      ]);
+      expectOutboundAttachmentCall(
+        0,
+        path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
+        5 * 1024 * 1024,
+      );
+      expectOutboundAttachmentCall(
+        1,
+        path.join("/tmp/sandboxes/session-1", "screens", "final.png"),
+        5 * 1024 * 1024,
+      );
+    },
+  );
+
+  it("maps explicitly supplied backend workdirs without rediscovering the sandbox", async () => {
+    const normalize = createTestReplyMediaNormalizer({
+      sandboxRoot: "/tmp/sandboxes/session-1",
+      sandboxContainerWorkdir: "/sandbox",
     });
-    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
-      mediaUrls: ["./out/photo.png", "file:///workspace/screens/final.png"],
+      mediaUrls: ["/sandbox/screens/final.png"],
     });
 
-    expectMedia(result, "/tmp/outbound-media/photo.png", [
-      "/tmp/outbound-media/photo.png",
-      "/tmp/outbound-media/final.png",
-    ]);
+    expectMedia(result, "/tmp/outbound-media/final.png", ["/tmp/outbound-media/final.png"]);
     expectOutboundAttachmentCall(
       0,
-      path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
-      5 * 1024 * 1024,
-    );
-    expectOutboundAttachmentCall(
-      1,
       path.join("/tmp/sandboxes/session-1", "screens", "final.png"),
       5 * 1024 * 1024,
     );
+    expect(ensureSandboxWorkspaceForSession).not.toHaveBeenCalled();
   });
 
   it("drops sandbox-mapped media when staging fails instead of retrying the workspace fallback", async () => {

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -56,6 +56,7 @@ export function createReplyMediaPathNormalizer(params: {
   requesterSenderUsername?: string;
   requesterSenderE164?: string;
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
 }): (payload: ReplyPayload) => Promise<ReplyPayload> {
   // Prefer an explicit agentId so callers without a resolved sessionKey (e.g.
   // `openclaw agent --deliver` with `--reply-channel/--reply-to`) still get
@@ -71,20 +72,29 @@ export function createReplyMediaPathNormalizer(params: {
     accountId: params.accountId,
   });
   const explicitSandboxRoot = params.sandboxRoot?.trim();
-  let sandboxRootPromise: Promise<string | undefined> | undefined = explicitSandboxRoot
-    ? Promise.resolve(explicitSandboxRoot)
+  let sandboxWorkspacePromise:
+    | Promise<{ root: string; containerWorkdir?: string } | undefined>
+    | undefined = explicitSandboxRoot
+    ? Promise.resolve({
+        root: explicitSandboxRoot,
+        containerWorkdir: params.sandboxContainerWorkdir,
+      })
     : undefined;
   const persistedMediaBySource = new Map<string, Promise<string>>();
 
-  const resolveSandboxRoot = async (): Promise<string | undefined> => {
-    if (!sandboxRootPromise) {
-      sandboxRootPromise = ensureSandboxWorkspaceForSession({
+  const resolveSandboxWorkspace = async () => {
+    if (!sandboxWorkspacePromise) {
+      sandboxWorkspacePromise = ensureSandboxWorkspaceForSession({
         config: params.cfg,
         sessionKey: params.sessionKey,
         workspaceDir: params.workspaceDir,
-      }).then((sandbox) => sandbox?.workspaceDir);
+      }).then((sandbox) =>
+        sandbox
+          ? { root: sandbox.workspaceDir, containerWorkdir: sandbox.containerWorkdir }
+          : undefined,
+      );
     }
-    return await sandboxRootPromise;
+    return await sandboxWorkspacePromise;
   };
 
   const resolveMediaAccessForSource = (media: string) =>
@@ -166,13 +176,14 @@ export function createReplyMediaPathNormalizer(params: {
       !media.startsWith("~") &&
       !path.isAbsolute(media) &&
       !WINDOWS_DRIVE_RE.test(media);
-    const sandboxRoot = await resolveSandboxRoot();
-    if (sandboxRoot) {
+    const sandboxWorkspace = await resolveSandboxWorkspace();
+    if (sandboxWorkspace) {
       let sandboxResolvedMedia: string;
       try {
         sandboxResolvedMedia = await resolveSandboxedMediaSource({
           media,
-          sandboxRoot,
+          sandboxRoot: sandboxWorkspace.root,
+          containerWorkdir: sandboxWorkspace.containerWorkdir,
         });
       } catch (err) {
         if (FILE_URL_RE.test(media)) {

--- a/src/cli/command-bootstrap.test.ts
+++ b/src/cli/command-bootstrap.test.ts
@@ -139,6 +139,19 @@ describe("ensureCliCommandBootstrap", () => {
     });
   });
 
+  it("limits sandbox runtime commands to configured backend owner plugins", async () => {
+    await ensureCliCommandBootstrap({
+      runtime: {} as never,
+      commandPath: ["sandbox", "list"],
+      loadPlugins: true,
+    });
+
+    expect(ensureCliPluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "sandbox-backends",
+      routeLogsToStderr: undefined,
+    });
+  });
+
   it("does not evaluate config or plugin runtimes for a gateway-backed agent turn", async () => {
     await ensureCliCommandBootstrap({
       runtime: {} as never,

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -10,7 +10,12 @@ type CliConfigGuardMode = "run" | "skip" | "validate" | "when-suppressed";
 type CliConfigGuardPolicy =
   | CliConfigGuardMode
   | ((ctx: { argv: string[]; commandPath: string[] }) => CliConfigGuardMode);
-export type CliPluginRegistryScope = "all" | "channels" | "configured-channels" | "memory";
+export type CliPluginRegistryScope =
+  | "all"
+  | "channels"
+  | "configured-channels"
+  | "memory"
+  | "sandbox-backends";
 export type CliPluginRegistryPolicy = {
   scope: CliPluginRegistryScope;
 };
@@ -127,6 +132,17 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     },
   },
   { commandPath: ["directory"], policy: { loadPlugins: "always" } },
+  {
+    commandPath: ["sandbox"],
+    policy: {
+      loadPlugins: ({ argv, commandPath }) =>
+        !(
+          (commandPath[1] === "list" || commandPath[1] === "recreate") &&
+          hasFlag(argv, "--browser")
+        ),
+      pluginRegistry: { scope: "sandbox-backends" },
+    },
+  },
   { commandPath: ["agents"], policy: { loadPlugins: "always", networkProxy: "bypass" } },
   {
     commandPath: ["agents"],

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -305,6 +305,46 @@ describe("command-path-policy", () => {
     });
   });
 
+  it("loads only sandbox backend owner plugins for runtime commands", () => {
+    const sandboxPolicy = resolveCliCommandPathPolicy(["sandbox"]);
+    expectLoadPluginsResolver(sandboxPolicy);
+    expect(sandboxPolicy.pluginRegistry).toEqual({ scope: "sandbox-backends" });
+
+    for (const commandPath of [
+      ["sandbox", "list"],
+      ["sandbox", "recreate"],
+      ["sandbox", "explain"],
+    ]) {
+      expect(resolveCliCommandPathPolicy(commandPath).pluginRegistry).toEqual({
+        scope: "sandbox-backends",
+      });
+      expect(
+        sandboxPolicy.loadPlugins({
+          argv: ["node", "openclaw", ...commandPath],
+          commandPath,
+          jsonOutputMode: false,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it.each([
+    ["list", ["--browser"]],
+    ["recreate", ["--browser", "--all"]],
+    ["recreate", ["--all", "--browser"]],
+  ])("keeps browser-only sandbox %s independent of plugin activation", (subcommand, flags) => {
+    const policy = resolveCliCommandPathPolicy(["sandbox", subcommand]);
+    expectLoadPluginsResolver(policy);
+
+    expect(
+      policy.loadPlugins({
+        argv: ["node", "openclaw", "sandbox", subcommand, ...flags],
+        commandPath: ["sandbox", subcommand],
+        jsonOutputMode: false,
+      }),
+    ).toBe(false);
+  });
+
   it("resolves mixed startup-only rules", () => {
     expectResolvedPolicy(["qa", "suite"], {
       configGuard: "skip",

--- a/src/infra/outbound/message-action-contracts.ts
+++ b/src/infra/outbound/message-action-contracts.ts
@@ -110,6 +110,7 @@ export type MessageActionInput = {
     receiptDiscriminator: string,
   ) => void;
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
   dryRun?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   sourceReplyFinal?: boolean;

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -98,6 +98,16 @@ describe("message action media helpers", () => {
     });
     expect(
       resolveAttachmentMediaPolicy({
+        sandboxRoot: "/tmp/workspace",
+        sandboxContainerWorkdir: "/sandbox",
+      }),
+    ).toEqual({
+      mode: "sandbox",
+      sandboxRoot: "/tmp/workspace",
+      containerWorkdir: "/sandbox",
+    });
+    expect(
+      resolveAttachmentMediaPolicy({
         sandboxRoot: "   ",
         mediaLocalRoots: ["/tmp/a"],
       }),
@@ -127,39 +137,49 @@ describe("message action media helpers", () => {
     });
   });
 
-  maybeIt("normalizes sandbox media lists and dedupes resolved workspace paths", async () => {
-    const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-list-"));
-    try {
-      await expect(
-        normalizeSandboxMediaList({
-          values: [" data:text/plain;base64,QQ== "],
-        }),
-      ).rejects.toThrow(/data:/i);
-      await expect(
-        normalizeSandboxMediaList({
-          values: [
-            " file:///workspace/assets/photo.png ",
-            "/workspace/assets/photo.png",
-            "buffer://message-send/attachment",
-            " ",
-          ],
-          sandboxRoot: ` ${sandboxRoot} `,
-        }),
-      ).resolves.toEqual([
-        path.join(sandboxRoot, "assets", "photo.png"),
-        "buffer://message-send/attachment",
-      ]);
-    } finally {
-      await fs.rm(sandboxRoot, { recursive: true, force: true });
-    }
-  });
+  maybeIt.each([
+    { name: "Docker", containerWorkdir: "/workspace" },
+    { name: "OpenShell", containerWorkdir: "/sandbox" },
+  ])(
+    "normalizes $name media lists and dedupes resolved workspace paths",
+    async ({ containerWorkdir }) => {
+      const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-list-"));
+      try {
+        await expect(
+          normalizeSandboxMediaList({
+            values: [" data:text/plain;base64,QQ== "],
+          }),
+        ).rejects.toThrow(/data:/i);
+        await expect(
+          normalizeSandboxMediaList({
+            values: [
+              ` file://${containerWorkdir}/assets/photo.png `,
+              `${containerWorkdir}/assets/photo.png`,
+              "buffer://message-send/attachment",
+              " ",
+            ],
+            sandboxRoot: ` ${sandboxRoot} `,
+            sandboxContainerWorkdir: containerWorkdir,
+          }),
+        ).resolves.toEqual([
+          path.join(sandboxRoot, "assets", "photo.png"),
+          "buffer://message-send/attachment",
+        ]);
+      } finally {
+        await fs.rm(sandboxRoot, { recursive: true, force: true });
+      }
+    },
+  );
 
-  maybeIt("normalizes mediaUrl and fileUrl sandbox media params", async () => {
+  maybeIt.each([
+    { name: "Docker", containerWorkdir: "/workspace" },
+    { name: "OpenShell", containerWorkdir: "/sandbox" },
+  ])("normalizes $name mediaUrl and fileUrl sandbox media params", async ({ containerWorkdir }) => {
     const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-alias-"));
     try {
       const args: Record<string, unknown> = {
-        mediaUrl: " file:///workspace/assets/photo.png ",
-        fileUrl: "/workspace/docs/report.pdf",
+        mediaUrl: ` file://${containerWorkdir}/assets/photo.png `,
+        fileUrl: `${containerWorkdir}/docs/report.pdf`,
       };
 
       await normalizeSandboxMediaParams({
@@ -167,6 +187,7 @@ describe("message action media helpers", () => {
         mediaPolicy: {
           mode: "sandbox",
           sandboxRoot: ` ${sandboxRoot} `,
+          containerWorkdir,
         },
       });
 
@@ -222,11 +243,14 @@ describe("message action media helpers", () => {
     }
   });
 
-  maybeIt("normalizes the selected structured attachment sandbox source", async () => {
+  maybeIt.each([
+    { name: "Docker", containerWorkdir: "/workspace" },
+    { name: "OpenShell", containerWorkdir: "/sandbox" },
+  ])("normalizes the selected $name structured attachment source", async ({ containerWorkdir }) => {
     const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-attachment-"));
     try {
       const attachment: Record<string, unknown> = {
-        path: "/workspace/replies/photo.png",
+        path: `${containerWorkdir}/replies/photo.png`,
         mimeType: "image/png",
         name: "photo.png",
       };
@@ -239,6 +263,7 @@ describe("message action media helpers", () => {
         mediaPolicy: {
           mode: "sandbox",
           sandboxRoot,
+          containerWorkdir,
         },
       });
 

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -397,6 +397,7 @@ type AttachmentMediaPolicy =
   | {
       mode: "sandbox";
       sandboxRoot: string;
+      containerWorkdir?: string;
     }
   | {
       mode: "host";
@@ -408,6 +409,7 @@ type AttachmentMediaPolicy =
 /** Chooses sandbox or host media loading policy for attachment hydration. */
 export function resolveAttachmentMediaPolicy(params: {
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
   mediaAccess?: OutboundMediaAccess;
   mediaLocalRoots?: readonly string[] | "any";
   mediaReadFile?: OutboundMediaReadFile;
@@ -417,6 +419,9 @@ export function resolveAttachmentMediaPolicy(params: {
     return {
       mode: "sandbox",
       sandboxRoot,
+      ...(params.sandboxContainerWorkdir
+        ? { containerWorkdir: params.sandboxContainerWorkdir }
+        : {}),
     };
   }
   const explicitLocalRoots = resolveOutboundMediaLocalRoots(params.mediaLocalRoots);
@@ -545,18 +550,23 @@ export async function normalizeSandboxMediaParams(params: {
   extraParamKeys?: readonly string[];
   structuredAttachments?: StructuredAttachmentMode;
 }): Promise<void> {
-  const sandboxRoot =
-    params.mediaPolicy.mode === "sandbox" ? params.mediaPolicy.sandboxRoot.trim() : undefined;
+  const sandbox =
+    params.mediaPolicy.mode === "sandbox"
+      ? {
+          sandboxRoot: params.mediaPolicy.sandboxRoot.trim(),
+          containerWorkdir: params.mediaPolicy.containerWorkdir,
+        }
+      : undefined;
   for (const key of buildActionMediaSourceParamKeys(params.extraParamKeys)) {
     const entry = resolveMediaParamEntry(params.args, key);
     if (!entry) {
       continue;
     }
     assertMediaNotDataUrl(entry.value);
-    if (!sandboxRoot) {
+    if (!sandbox?.sandboxRoot) {
       continue;
     }
-    const normalized = await resolveSandboxedMediaSource({ media: entry.value, sandboxRoot });
+    const normalized = await resolveSandboxedMediaSource({ media: entry.value, ...sandbox });
     if (normalized !== entry.value) {
       params.args[entry.key] = normalized;
     }
@@ -572,12 +582,12 @@ export async function normalizeSandboxMediaParams(params: {
   }
   for (const attachmentSource of attachmentSources) {
     assertMediaNotDataUrl(attachmentSource.value);
-    if (!sandboxRoot) {
+    if (!sandbox?.sandboxRoot) {
       continue;
     }
     const normalized = await resolveSandboxedMediaSource({
       media: attachmentSource.value,
-      sandboxRoot,
+      ...sandbox,
     });
     if (normalized !== attachmentSource.value) {
       attachmentSource.attachment[attachmentSource.key] = normalized;
@@ -589,6 +599,7 @@ export async function normalizeSandboxMediaParams(params: {
 export async function normalizeSandboxMediaList(params: {
   values: string[];
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
 }): Promise<string[]> {
   const sandboxRoot = params.sandboxRoot?.trim();
   const normalized: string[] = [];
@@ -600,7 +611,11 @@ export async function normalizeSandboxMediaList(params: {
     }
     assertMediaNotDataUrl(raw);
     const resolved = sandboxRoot
-      ? await resolveSandboxedMediaSource({ media: raw, sandboxRoot })
+      ? await resolveSandboxedMediaSource({
+          media: raw,
+          sandboxRoot,
+          containerWorkdir: params.sandboxContainerWorkdir,
+        })
       : raw;
     if (seen.has(resolved)) {
       continue;
@@ -734,18 +749,5 @@ export function parseJsonMessageParam(params: Record<string, unknown>, key: stri
 
 /** Parses the interactive message action param as JSON when provided as a string. */
 export function parseInteractiveParam(params: Record<string, unknown>): void {
-  const raw = params.interactive;
-  if (typeof raw !== "string") {
-    return;
-  }
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    delete params.interactive;
-    return;
-  }
-  try {
-    params.interactive = JSON.parse(trimmed) as unknown;
-  } catch {
-    throw new Error("--interactive must be valid JSON");
-  }
+  parseJsonMessageParam(params, "interactive");
 }

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -228,6 +228,7 @@ async function handleInternalSourceReplySendAction(
     dryRun,
     mediaPolicy: resolveAttachmentMediaPolicy({
       sandboxRoot: input.sandboxRoot,
+      sandboxContainerWorkdir: input.sandboxContainerWorkdir,
       mediaAccess: input.mediaAccess,
       mediaLocalRoots: getAgentScopedMediaLocalRoots(input.cfg, agentId),
     }),
@@ -262,6 +263,7 @@ async function handleInternalSourceReplySendAction(
       requesterSenderUsername: input.requesterSenderUsername ?? undefined,
       requesterSenderE164: input.requesterSenderE164 ?? undefined,
       sandboxRoot: input.sandboxRoot,
+      sandboxContainerWorkdir: input.sandboxContainerWorkdir,
     })(sourceReplyPayload);
     if (
       resolveSendableOutboundReplyParts(sourceReplyPayload).mediaUrls.length !== requestedMediaCount
@@ -423,6 +425,7 @@ export async function runMessageAction(input: MessageActionInput): Promise<Messa
 
   const normalizationPolicy = resolveAttachmentMediaPolicy({
     sandboxRoot: input.sandboxRoot,
+    sandboxContainerWorkdir: input.sandboxContainerWorkdir,
     mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, resolvedAgentId),
   });
   const extraActionMediaSourceParamKeys = resolveExtraActionMediaSourceParamKeys({
@@ -464,6 +467,7 @@ export async function runMessageAction(input: MessageActionInput): Promise<Messa
     });
   const mediaPolicy = resolveAttachmentMediaPolicy({
     sandboxRoot: input.sandboxRoot,
+    sandboxContainerWorkdir: input.sandboxContainerWorkdir,
     mediaAccess,
   });
   const gateway = input.gateway;

--- a/src/infra/outbound/message-action-send.media.test.ts
+++ b/src/infra/outbound/message-action-send.media.test.ts
@@ -58,6 +58,7 @@ const runDrySend = (params: {
   cfg: OpenClawConfig;
   actionParams: Record<string, unknown>;
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
 }) =>
   runMessageAction({
     cfg: params.cfg,
@@ -65,6 +66,7 @@ const runDrySend = (params: {
     params: params.actionParams as never,
     dryRun: true,
     sandboxRoot: params.sandboxRoot,
+    sandboxContainerWorkdir: params.sandboxContainerWorkdir,
   });
 
 const requireRecord = createRequireRecord("record", "expected-non-array-record");
@@ -250,7 +252,10 @@ describe("runMessageAction media behavior", () => {
     });
   });
 
-  it("sends structured attachments as media urls", async () => {
+  it.each([
+    { name: "Docker", containerWorkdir: "/workspace" },
+    { name: "OpenShell", containerWorkdir: "/sandbox" },
+  ])("sends structured $name sandbox attachments as media urls", async ({ containerWorkdir }) => {
     setTestPlugin(workspacePlugin, "workspace");
 
     await withSandbox(async (sandboxDir) => {
@@ -260,9 +265,13 @@ describe("runMessageAction media behavior", () => {
           channel: "workspace",
           target: "12345678",
           message: "track ready",
-          attachments: [{ path: "./song.mp3" }, { filePath: "/workspace/cover.png" }],
+          attachments: [
+            { path: "./song.mp3" },
+            { filePath: `file://${containerWorkdir}/cover.png` },
+          ],
         },
         sandboxRoot: sandboxDir,
+        sandboxContainerWorkdir: containerWorkdir,
       });
 
       expect(result.kind).toBe("send");

--- a/src/infra/outbound/message-action-send.ts
+++ b/src/infra/outbound/message-action-send.ts
@@ -210,6 +210,7 @@ export async function buildMessagePayload(params: {
   const normalizedMediaUrls = await normalizeSandboxMediaList({
     values: mergedMediaUrls,
     sandboxRoot: input.sandboxRoot,
+    sandboxContainerWorkdir: input.sandboxContainerWorkdir,
   });
   mergedMediaUrls.length = 0;
   mergedMediaUrls.push(...normalizedMediaUrls);

--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -12,6 +12,7 @@ import {
   OPENCLAW_STATE_SCHEMA_VERSION,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
+import { recordPluginCandidateInstallOwner } from "./candidate-install-owner.js";
 import type { PluginCandidate } from "./discovery.js";
 import {
   readPersistedInstalledPluginIndexInstallRecords,
@@ -781,7 +782,11 @@ describe("installed plugin index persistence", () => {
     const stateDir = makeTempDir();
     const pluginDir = path.join(stateDir, "plugins", "demo");
     fs.mkdirSync(pluginDir, { recursive: true });
-    const candidate = createCandidate(pluginDir);
+    const candidate = recordPluginCandidateInstallOwner(createCandidate(pluginDir), "package");
+    const installRecords = {
+      package: { source: "git", installPath: pluginDir },
+      orphaned: { source: "path", installPath: path.join(stateDir, "missing") },
+    } satisfies InstalledPluginIndex["installRecords"];
     const env = {
       OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
       OPENCLAW_VERSION: "2026.4.25",
@@ -791,8 +796,14 @@ describe("installed plugin index persistence", () => {
       reason: "manual",
       stateDir,
       candidates: [candidate],
+      installRecords,
       env,
     });
+    expect(
+      Object.keys(
+        requirePersisted(await readPersistedInstalledPluginIndex({ stateDir })).installRecords,
+      ),
+    ).toEqual(["orphaned", "package"]);
     fs.writeFileSync(
       path.join(pluginDir, "openclaw.plugin.json"),
       JSON.stringify({
@@ -808,6 +819,7 @@ describe("installed plugin index persistence", () => {
       reason: "policy-changed",
       stateDir,
       candidates: [candidate],
+      installRecords,
       env,
       config: {
         plugins: {
@@ -828,6 +840,19 @@ describe("installed plugin index persistence", () => {
       manifestHash: initial.plugins[0]?.manifestHash,
     });
     expect(refreshed.policyHash).not.toBe(initial.policyHash);
+
+    const changedInstallRecords = {
+      ...installRecords,
+      package: { ...installRecords.package, source: "npm" },
+    } satisfies InstalledPluginIndex["installRecords"];
+    const rebuilt = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      candidates: [candidate],
+      installRecords: changedInstallRecords,
+      env,
+    });
+    expect(rebuilt.plugins[0]?.manifestHash).not.toBe(initial.plugins[0]?.manifestHash);
   });
 
   it("falls back to a source rebuild when a policy refresh target is missing", async () => {
@@ -869,6 +894,43 @@ describe("installed plugin index persistence", () => {
 
     expect(refreshed.plugins.map((plugin) => plugin.pluginId)).toContain("next-demo");
   });
+
+  it.each(["path", "npm", "archive", "git", "clawhub", "marketplace"] as const)(
+    "restores an installed %s plugin missing from a policy refresh projection",
+    async (source) => {
+      const stateDir = makeTempDir();
+      const pluginDir = path.join(stateDir, "plugins", "demo");
+      fs.mkdirSync(pluginDir, { recursive: true });
+      const candidate = createCandidate(pluginDir);
+      const installRecords = {
+        demo: { source, installPath: pluginDir },
+      } satisfies InstalledPluginIndex["installRecords"];
+      const env = {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+        OPENCLAW_VERSION: "2026.4.25",
+        VITEST: "true",
+      };
+      const initial = await refreshPersistedInstalledPluginIndex({
+        reason: "manual",
+        stateDir,
+        candidates: [candidate],
+        installRecords,
+        env,
+      });
+      await writePersistedInstalledPluginIndex({ ...initial, plugins: [] }, { stateDir });
+
+      const refreshed = await refreshPersistedInstalledPluginIndex({
+        reason: "policy-changed",
+        stateDir,
+        candidates: [candidate],
+        installRecords,
+        env,
+      });
+
+      expectPluginIds(refreshed, ["demo"]);
+      await expectPersistedIndex(stateDir, { pluginIds: ["demo"] });
+    },
+  );
 
   it("preserves existing install records when refreshing the manifest cache", async () => {
     const stateDir = makeTempDir();

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -13,6 +13,7 @@ import {
   setPluginInstallRecordMapEntry,
 } from "../config/plugin-install-record-map.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { resolveUserPath } from "../infra/home-dir.js";
 import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
@@ -20,7 +21,7 @@ import { safeParseWithSchema } from "../utils/zod-parse.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
-import { hashJson } from "./installed-plugin-index-hash.js";
+import { hashStableJson } from "./installed-plugin-index-hash.js";
 import {
   isInstalledPluginIndexInstallOwnerAmbiguous,
   recordInstalledPluginIndexInstallOwner,
@@ -485,15 +486,24 @@ export function writePersistedInstalledPluginIndexWithLeaseSync(
   return filePath;
 }
 
-function hasPolicyRefreshTargets(
+function hasCompletePolicyRefreshProjection(
   persisted: InstalledPluginIndex,
   policyPluginIds: readonly string[] | undefined,
+  env: NodeJS.ProcessEnv,
 ): boolean {
-  if (!policyPluginIds || policyPluginIds.length === 0) {
-    return true;
-  }
   const pluginIds = new Set(persisted.plugins.map((plugin) => plugin.pluginId));
-  return policyPluginIds.every((pluginId) => pluginIds.has(pluginId));
+  if (policyPluginIds?.some((pluginId) => !pluginIds.has(pluginId))) {
+    return false;
+  }
+  const installOwners = new Set(persisted.plugins.map(resolveInstalledPluginIndexInstallOwner));
+  return Object.entries(persisted.installRecords).every(([installOwner, record]) => {
+    if (installOwners.has(installOwner)) {
+      return true;
+    }
+    const installedPath = record.installPath?.trim() || record.sourcePath?.trim();
+    // Missing package bytes are orphaned owner records, not rediscoverable plugins.
+    return !installedPath || !existsSync(resolveUserPath(installedPath, env));
+  });
 }
 
 function canRefreshPersistedPolicyState(
@@ -523,11 +533,11 @@ function canRefreshPersistedPolicyState(
   }
   if (
     params.installRecords &&
-    hashJson(params.installRecords) !== hashJson(persisted.installRecords ?? {})
+    hashStableJson(params.installRecords) !== hashStableJson(persisted.installRecords ?? {})
   ) {
     return false;
   }
-  return hasPolicyRefreshTargets(persisted, params.policyPluginIds);
+  return hasCompletePolicyRefreshProjection(persisted, params.policyPluginIds, env);
 }
 
 function refreshPersistedPolicyState(

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -200,6 +200,91 @@ describe("ensurePluginRegistryLoaded", () => {
     );
   });
 
+  it("loads only matching configured sandbox backend owners, never unrelated broken plugins", () => {
+    const config = {
+      agents: {
+        defaults: { sandbox: { backend: "sandbox-owner" } },
+        entries: { research: { sandbox: { backend: "research-owner" } } },
+      },
+      plugins: {
+        entries: {
+          "sandbox-owner": { enabled: true },
+          "research-owner": { enabled: true },
+          "broken-plugin": { enabled: true },
+        },
+      },
+    };
+    mocks.resolvePluginMetadataSnapshot.mockReturnValue({
+      index: {
+        installRecords: {},
+        plugins: ["sandbox-owner", "research-owner", "broken-plugin"].map((pluginId) => ({
+          pluginId,
+          startup: { sidecar: false, memory: false, agentHarnesses: [] },
+        })),
+      },
+      manifestRegistry: { plugins: [], diagnostics: [] },
+    } as never);
+    mocks.loadOpenClawPlugins.mockImplementationOnce((options) => {
+      if (options?.onlyPluginIds?.includes("broken-plugin")) {
+        throw new Error("unrelated plugin failed to initialize");
+      }
+      return undefined as never;
+    });
+
+    expect(() => ensurePluginRegistryLoaded({ scope: "sandbox-backends", config })).not.toThrow();
+    expect(requireLoadOptions().onlyPluginIds).toEqual(["research-owner", "sandbox-owner"]);
+    expect(mocks.resolveEffectivePluginIds).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, "docker", "podman", "ssh"])(
+    "does not activate plugins for the built-in sandbox backend %s",
+    (backend) => {
+      mocks.resolvePluginMetadataSnapshot.mockReturnValue({
+        index: {
+          installRecords: {},
+          plugins: ["docker", "podman", "ssh"].map((pluginId) => ({
+            pluginId,
+            startup: { sidecar: false, memory: false, agentHarnesses: [] },
+          })),
+        },
+        manifestRegistry: { plugins: [], diagnostics: [] },
+      } as never);
+
+      ensurePluginRegistryLoaded({
+        scope: "sandbox-backends",
+        config: { agents: { defaults: { sandbox: { backend } } } },
+      });
+
+      expect(requireLoadOptions().onlyPluginIds).toEqual([]);
+      expect(mocks.resolveEffectivePluginIds).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not guess a differently named sandbox backend owner", () => {
+    mocks.resolvePluginMetadataSnapshot.mockReturnValue({
+      index: {
+        installRecords: {},
+        plugins: [
+          {
+            pluginId: "actual-owner",
+            startup: { sidecar: false, memory: false, agentHarnesses: [] },
+          },
+        ],
+      },
+      manifestRegistry: { plugins: [], diagnostics: [] },
+    } as never);
+
+    ensurePluginRegistryLoaded({
+      scope: "sandbox-backends",
+      config: {
+        agents: { defaults: { sandbox: { backend: "different-backend" } } },
+        plugins: { entries: { "actual-owner": { enabled: true } } },
+      },
+    });
+
+    expect(requireLoadOptions().onlyPluginIds).toEqual([]);
+  });
+
   it("loads only the selected memory backend and embedding provider owners", () => {
     const config = {
       memory: { search: { provider: "openai" } },

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -1,4 +1,5 @@
 // Runtime registry loader assembles process-root plugin runtimes from config metadata.
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withActivatedPluginIds } from "../activation-context.js";
 import {
@@ -16,7 +17,15 @@ import {
   resolvePluginRuntimeLoadContext,
 } from "./load-context.js";
 
-export type PluginRegistryScope = "configured-channels" | "channels" | "memory" | "all";
+export type PluginRegistryScope =
+  | "configured-channels"
+  | "channels"
+  | "memory"
+  | "sandbox-backends"
+  | "all";
+
+// Core-owned backends must keep their registry ownership if a plugin reuses an id.
+const CORE_SANDBOX_BACKEND_IDS = new Set(["docker", "podman", "ssh"]);
 
 function resolveMemoryPluginIds(
   context: ReturnType<typeof resolvePluginRuntimeLoadContext>,
@@ -37,6 +46,35 @@ function resolveMemoryPluginIds(
   const memoryPluginId = normalizePluginsConfig(context.config.plugins).slots.memory?.trim();
   if (memoryPluginId) {
     pluginIds.add(memoryPluginId);
+  }
+  return [...pluginIds].toSorted();
+}
+
+function resolveSandboxBackendPluginIds(
+  context: ReturnType<typeof resolvePluginRuntimeLoadContext>,
+): string[] {
+  if (!context.metadataSnapshot) {
+    return [];
+  }
+  const agents = context.activationSourceConfig.agents;
+  const configuredBackendIds = [
+    agents?.defaults?.sandbox?.backend,
+    ...Object.values(agents?.entries ?? {}).map((agent) => agent.sandbox?.backend),
+    ...(agents?.list ?? []).map((agent) => agent.sandbox?.backend),
+  ];
+  const lookup = createInstalledPluginIndexScopeLookup(context.metadataSnapshot.index);
+  const pluginIds = new Set<string>();
+  for (const backendId of configuredBackendIds) {
+    const normalizedBackendId = normalizeOptionalLowercaseString(backendId);
+    if (
+      !normalizedBackendId ||
+      CORE_SANDBOX_BACKEND_IDS.has(normalizedBackendId) ||
+      !lookup.hasInstalledPluginIds([normalizedBackendId])
+    ) {
+      continue;
+    }
+    // Backend ids have no manifest ownership contract; only an exact installed plugin id is safe.
+    pluginIds.add(lookup.normalizePluginId(normalizedBackendId));
   }
   return [...pluginIds].toSorted();
 }
@@ -64,6 +102,9 @@ function resolveScopePluginIds(params: {
     // Memory CLI commands must use the same backend and embedding adapters as
     // Gateway, without activating unrelated explicitly enabled plugins.
     return resolveMemoryPluginIds(params.context);
+  }
+  if (params.scope === "sandbox-backends") {
+    return resolveSandboxBackendPluginIds(params.context);
   }
   return resolveEffectivePluginIds({
     config: params.context.rawConfig,
@@ -99,6 +140,7 @@ export function ensurePluginRegistryLoaded(options?: {
         throwOnLoadError: true,
         ...(scope === "configured-channels" ||
         scope === "memory" ||
+        scope === "sandbox-backends" ||
         scope === "all" ||
         hasNonEmptyPluginIdScope(pluginIds)
           ? { onlyPluginIds: pluginIds }


### PR DESCRIPTION
Closes #127441
Closes #127438
Closes #98446
Closes #119270
Closes #89606

Related contributor work: #119834, #120005, #124701.

## What Problem This Solves

Fixes an issue where OpenShell operators could lose mirrored workspace changes during concurrent agent turns, see a running sandbox reported as stopped, lose installed plugins after a policy refresh, fail to send images from `/sandbox`, or have a file tool silently overwrite or delete an unprefixed sibling when the requested destination starts with `@`.

Live validation also found that OpenShell 0.0.113 changed sandbox creation: the requested command is now the sandbox's canonical main process. The previous `-- true` command therefore immediately terminated every newly created sandbox on current OpenShell releases.

## Why This Change Was Made

Keep ownership at the producer and lifecycle boundary:

- Mirror commands retain deterministic host-workspace and remote-runtime leases across preparation, actual process execution, publication, cancellation, and cleanup.
- Sandbox backend registrations track their own generation, so disposing old plugins cannot delete current registrations or resurrect retired authority.
- Current OpenShell CLIs receive a persistent detached main process, while supported older CLIs retain their existing creation contract through a bounded CLI capability check.
- Outbound messages, structured attachments, file URLs, and ordinary replies consistently use the backend's authoritative container workspace rather than assuming Docker's `/workspace`.
- Sandbox CLI commands activate only plugins that own configured backend IDs; browser-only operations and unrelated enabled plugins remain isolated.
- Policy-only plugin registry refreshes rediscover missing installed-package projections without disturbing orphan records, and semantically equivalent install maps no longer depend on property insertion order.
- File tools, memory flushes, patches, mounted sandbox bridges, remote bridges, and synchronous plugin policy metadata preserve existing literal `@` files and directories while maintaining file-completion shorthand and absolute-path safety.

The OpenShell execution owner also preserves the newly landed secure environment staging contract: workspace leases remain held while staged SSH execution is prepared, cleaned up, and published.

## User Impact

OpenShell sandboxes work with current and previously supported CLI releases, concurrent mirrored commands cannot overwrite each other's work, running plugin-backed sandboxes report real status, plugin installations survive policy updates, and outbound media works from the real sandbox workspace. Ordinary coding and memory tools no longer operate on a different file than the path shown to the user.

Existing Docker, Podman, SSH, browser-only sandbox commands, file-reference shorthand, and workspace containment behavior remain supported. The OpenShell and sandbox CLI documentation now explains concurrency, backend activation, remote attachments, current image requirements, and the existing shared sandbox environment setting.

## Evidence

- Real isolated NVIDIA OpenShell 0.0.113 gateway with Docker-backed sandboxes, gateway-issued signing credentials, non-default control-plane workspace, real SSH execution, mirrored and remote workspaces, protected host metadata, and deny/allow network policies: `extensions/openshell/src/backend.e2e.test.ts` — **4 passed**.
- OpenShell owner and cross-version CLI contract regressions: **74 passed** across backend execution, legacy/current creation, remote seeding, filesystem mirroring, and deterministic same-runtime/same-host concurrency.
- Rebased OpenShell, secure SSH environment staging, backend lifecycle, and literal-path owner coverage: **113 passed** across eight focused files.
- Sandbox registration, media ownership, literal-path handling, mounted bridges, remote bridges, memory flushing, and patch policy parity: **182 passed, 1 intentionally skipped**.
- CLI activation, plugin projection refresh, outbound attachment hydration, and reply normalization: **185 passed**.
- Memory migration and dreaming sibling coverage: **166 passed**, plus both dependency-light doctor contract guards.
- Full OpenClaw distribution build completed during the live end-to-end run.
- Structured independent review completed without actionable findings.

Contributor credit is preserved for the related plugin activation, literal-path, and registry-refresh proposals from @harjothkhara and @qingminglong.
