### PR TITLE
fix(ui): restore startup CSS budget

### DIFF
--- a/ui/src/pages/approval/approval-page.test.ts
+++ b/ui/src/pages/approval/approval-page.test.ts
@@ -136,7 +136,6 @@ function createPage(params: {
   connected?: boolean;
   hello?: ApplicationGatewaySnapshot["hello"];
   id?: string;
-  withBootFallback?: boolean;
 }) {
   const source = createGateway(params.client, params.connected, params.hello);
   const page = document.createElement(APPROVAL_PAGE_ELEMENT_NAME) as TestApprovalPage;
@@ -145,11 +144,6 @@ function createPage(params: {
     gateway: source.gateway,
   } as unknown as ApplicationContext);
   page.approvalId = params.id ?? "exec:approval-1";
-  if (params.withBootFallback) {
-    const fallback = document.createElement("main");
-    fallback.className = "approval-page approval-page--booting";
-    page.append(fallback);
-  }
   provider.append(page);
   document.body.append(provider);
   return { page, source };
@@ -399,19 +393,6 @@ describe("ApprovalPage", () => {
     expect(request).toHaveBeenCalledTimes(2);
     expect(page.querySelector("h1")?.textContent).toBe("Approved");
     expect(page.querySelectorAll("[data-decision]")).toHaveLength(0);
-  });
-
-  it("replaces the host boot fallback instead of duplicating the page", async () => {
-    const request = vi.fn(async () => ({ approval: pendingApproval() }));
-    const { page } = createPage({
-      client: { request } as unknown as GatewayBrowserClient,
-      withBootFallback: true,
-    });
-
-    await settle(page);
-
-    expect(page.querySelectorAll(".approval-page")).toHaveLength(1);
-    expect(page.querySelector(".approval-page--booting")).toBeNull();
   });
 
   it("loads a durable approval and sends a kind-bound resolution", async () => {

--- a/ui/src/styles/approval-boot.css
+++ b/ui/src/styles/approval-boot.css
@@ -40,10 +40,5 @@ openclaw-approval-page {
   }
 }
 
-.approval-page--booting {
-  align-content: center;
-  color: var(--muted);
-}
-
-/* Only the shell's pre-hydration booting state lives here; the full approval
- * page styles load with the lazy page chunk (see approval-page.ts). */
+/* Only the shared page frame lives here; detailed approval styles load with
+ * the lazy page chunk (see approval-page.ts). */

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2564,12 +2564,6 @@ openclaw-chat-session-rail {
   background: var(--warn-subtle);
 }
 
-.chip-danger {
-  color: var(--danger);
-  border-color: color-mix(in srgb, var(--danger) 30%, transparent);
-  background: var(--danger-subtle);
-}
-
 /* ===========================================
    Data Table
    =========================================== */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where unrelated pull requests could not pass the Control UI build because current `main` produced 46,092 B of startup CSS against the unchanged 46,080 B limit.

## Why This Change Was Made

Removes two orphaned entry-stylesheet selector families instead of raising or baselining the performance budget: a pre-hydration approval fallback retired by #126409, and a task danger chip retired by #128853. The associated approval test-only fallback scaffold is removed with its dead selector. No production markup still emits either class.

Rejected alternatives: raising the budget would hide the regression; removing either selector family alone leaves current main at 46,081 B and still failing.

Production LOC: +2/-13 (net -11) | Tests: +0/-19
Exact head: `077e817c5c39bb5024179a29fc6a9b5162dd49ff`

## User Impact

No product behavior changes. Contributors regain a green deterministic Control UI build gate, and the startup stylesheet remains under its existing size budget.

## Evidence

- Before, fresh current-main build on CI's Node 24.19: `startup CSS gzip: 46,092 B vs 46,080 B` (failure).
- After, same command/toolchain: `control-ui-core-*.css.gz 46067`; `pnpm ui:build` passes all unchanged budgets.
- `pnpm test ui/src/pages/approval/approval-page.test.ts`: 28/28 passed.
- `node scripts/check-changed.mjs -- ui/src/pages/approval/approval-page.test.ts ui/src/styles/approval-boot.css ui/src/styles/components.css`: passed all selected typecheck, lint, formatting, i18n, dead-export, and guard lanes.
- `node --import tsx scripts/audit-control-ui-dead-css.mts`: removed selectors absent; only unrelated existing `.workboard-toggle` findings remain.
- Test audit: the removed approval case only constructed a production-retired fallback and therefore asserted a test-only seam; remaining approval behavior coverage is 28/28 green.
- Deslop: clean; deletion-only behavior change apart from updating the now-accurate stylesheet ownership comment.
- Structured autoreview: clean, 0.99.
- Separate exact-head read-only Codex review: `CLEAN`.

This is an autonomous broken-main repair; the linked agent transcript is omitted.
