### PR TITLE
chore(qa): make OpenAI native web search primary coverage

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.openai-live.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.openai-live.test.ts
@@ -45,6 +45,10 @@ describe("qa scenario catalog", () => {
       | undefined;
 
     expect(scenario.sourcePath).toBe("qa/scenarios/models/openai-native-web-search-live.yaml");
+    expect(scenario.coverage).toEqual({
+      primary: ["web-search.web-search-exposure-openai"],
+      secondary: ["web-search.web-search-exposure", "openai.canonical-openai-model-routing-openai"],
+    });
     expect(scenario.gatewayConfigPatch?.tools).toEqual({
       web: {
         search: {

--- a/qa/scenarios/models/openai-native-web-search-live.yaml
+++ b/qa/scenarios/models/openai-native-web-search-live.yaml
@@ -5,8 +5,9 @@ scenario:
   surface: model-provider
   coverage:
     primary:
-      - web-search.web-search-exposure
+      - web-search.web-search-exposure-openai
     secondary:
+      - web-search.web-search-exposure
       - openai.canonical-openai-model-routing-openai
   objective: Verify a live OpenAI GPT model can use OpenAI native web_search when OpenClaw web search is enabled in auto mode.
   successCriteria:


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The live OpenAI native web-search journey was only secondary coverage for the broad generic web-search behavior. Smoke/profile selection can therefore omit the exact OpenAI semantic contract even though the scenario exercises a real OpenAI model, native search enablement, and an official-source lookup.

## Why This Change Was Made

Make `web-search.web-search-exposure-openai` the scenario's primary coverage owner while retaining the generic exposure behavior as secondary coverage. A catalog assertion pins that exact ownership so future metadata changes cannot silently demote the provider-specific live contract.

## User Impact

No product behavior changes. The live QA profile now treats OpenAI native web search as required provider-specific coverage, making onboarding/release verification less likely to miss an OpenAI regression.

## Evidence

Exact head `2ed5261fc8a604195aaa8ca54218b5d089e98e8a` on current `origin/main`:

- Real OpenAI GPT-5.6 Luna run: 1/1 scenario passed in 27.989 s.
- The live model reported native web search enabled, returned `WEB-SEARCH-OK`, and selected `https://openai.com/news/company-announcements/`.
- `scenario-catalog.openai-live.test.ts` + `profile-selection.test.ts`: 10 tests passed.
- `pnpm check:changed`: passed before the conflict-free exact-head rebase.
- Fresh exact-head branch autoreview: clean, patch correct at 0.99 confidence.
- TruffleHog 3.97.0 scan: clean.
