### PR TITLE
fix(cron): close isolated cron run browser tabs under the run session key

### DIFF
--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -5,11 +5,12 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type { RunCronAgentTurnResult } from "../cron/isolated-agent.js";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
 
 type RunCronIsolatedAgentTurnMock = (params: {
   abortSignal?: AbortSignal;
-}) => Promise<{ status: "ok"; summary: string }>;
+}) => Promise<RunCronAgentTurnResult>;
 
 const {
   enqueueSystemEventMock,
@@ -1251,11 +1252,18 @@ describe("buildGatewayCronService", () => {
         wakeMode: "next-heartbeat",
         payload: { kind: "agentTurn", message: "hello" },
       });
+      runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+        status: "ok",
+        summary: "ok",
+        sessionKey: "agent:main:live-session-canonical",
+      });
 
       await state.cron.run(job.id, "force");
 
       const options = expectIsolatedRunFields({ sessionKey });
       expect(requireRecord(options.job, "isolated job").id).toBe(job.id);
+      // Session-targeted runs clean the stored target key only; the runner's
+      // canonical live-session key must not widen the close set.
       expectCleanupForSessionKeys([sessionKey]);
     } finally {
       state.cron.stop();
@@ -1297,7 +1305,45 @@ describe("buildGatewayCronService", () => {
           return record.sessionKey === "main";
         }),
       ).toBe(false);
-      expectCleanupForSessionKeys([`cron:${job.id}`]);
+      // No runner-reported run key here (stub result), so nothing is closed;
+      // the raw cron:<jobId> key never has tracked tabs.
+      expectCleanupForSessionKeys([]);
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("cleans up browser tabs under the runner-reported run session key", async () => {
+    const cfg = createCronConfig("server-cron-isolated-browser-cleanup");
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "isolated-browser-cleanup",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "open tabs" },
+      });
+      // Isolated runs execute (and track browser tabs) under the runner-minted
+      // per-run store key, not the job-level cron:<id> fallback key.
+      const runSessionKey = `agent:main:cron:${job.id}:run:1234`;
+      runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+        status: "ok",
+        summary: "ok",
+        sessionKey: runSessionKey,
+      });
+
+      await state.cron.run(job.id, "force");
+
+      expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1);
+      expectCleanupForSessionKeys([runSessionKey]);
     } finally {
       state.cron.stop();
     }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -392,9 +392,14 @@ export function buildGatewayCronService(params: {
       onLaneWait,
     }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
-      const sessionKey = resolveCronSessionTargetSessionKey(job.sessionTarget) ?? `cron:${job.id}`;
+      const sessionTargetKey = resolveCronSessionTargetSessionKey(job.sessionTarget);
+      const sessionKey = sessionTargetKey ?? `cron:${job.id}`;
+      // Cron-scoped runs track browser tabs under the runner-minted
+      // agent:<id>:cron:<jobId>:run:<sessionId> key, which the idle sweep skips;
+      // session-targeted runs reuse a live session whose tabs stay sweep-owned.
+      let cronRunSessionKey: string | undefined;
       try {
-        return await runCronIsolatedAgentTurn({
+        const result = await runCronIsolatedAgentTurn({
           cfg: runtimeConfig,
           deps: params.deps,
           job,
@@ -407,9 +412,15 @@ export function buildGatewayCronService(params: {
           sessionKey,
           lane: "cron",
         });
+        if (!sessionTargetKey) {
+          cronRunSessionKey = result.sessionKey;
+        }
+        return result;
       } finally {
+        const cleanupSessionKey = sessionTargetKey ?? cronRunSessionKey;
         await cleanupBrowserSessionsForLifecycleEnd({
-          sessionKeys: [sessionKey],
+          cfg: runtimeConfig,
+          sessionKeys: cleanupSessionKey ? [cleanupSessionKey] : [],
           onWarn: (msg) => cronLogger.warn({ jobId: job.id }, msg),
         });
       }


### PR DESCRIPTION
## What Problem This Solves

Browser tabs opened by isolated cron agent runs are never closed. `runIsolatedAgentJob` cleaned up with the job-level key `cron:<jobId>` (`src/gateway/server-cron.ts`), but the browser tool tracks tabs under the runner-minted per-run store key `agent:<agentId>:cron:<jobId>:run:<sessionId>` (`src/cron/isolated-agent/run.ts:634`, threaded to the tools via `src/cron/isolated-agent/run-executor.ts:319`/`:377` and, for CLI-harness runs, the loopback MCP `x-session-key` header: `src/agents/cli-runner/prepare.ts:457` → `src/gateway/mcp-http.request.ts:363` → `src/gateway/tool-resolution.ts:173`). The registry lookup is exact-match (`extensions/browser/src/browser/session-tab-registry.ts:171`), so the cleanup closed nothing — and the browser plugin's idle sweep deliberately excludes cron session keys (`extensions/browser/src/browser/session-tab-cleanup.ts:48`, `isPrimaryTrackedBrowserSessionKey`), so nothing ever reaps them. The tabs leak until the browser is restarted.

The mismatch has existed since the cleanup was introduced in 72b2e413d6 (#60104): the `:run:` suffix already existed at that commit, so the isolated-job cleanup key never matched.

Observed on a live 2026.6.34 install (macOS): a daily cron job (`sessionTarget: "isolated"`, Codex app-server harness) opened four host tabs via the browser tool; all four were still open 3+ hours after the run ended, every day.

## Why This Change Was Made

- Capture `result.sessionKey` from `runCronIsolatedAgentTurn` — the exact key the run's tools tracked tabs under; every result path (ok and error) goes through `withRunSession` — and close that key at run end for cron-scoped runs.
- Gate the captured key on the job having no `session:` target: for `sessionTarget: "session:<key>"` jobs the runner reports the canonical live-session key, and closing it would rip tabs out of a user's live session at cron-run end. Session-targeted jobs keep the shipped behavior (clean the stored target key only); a test now pins that gate.
- Drop the bare `cron:<jobId>` key from cleanup: tabs are only ever tracked under agent-scoped keys (`extensions/browser/src/browser-tool.ts:706`), so that key provably never matched anything.
- Pass `cfg` so the `browser.enabled: false` / browser-plugin-disabled opt-out short-circuits cleanup as designed (`src/browser-lifecycle-cleanup.ts:17`).

Cleanup deliberately stays in the gateway cron seam rather than `runCronIsolatedAgentTurn`'s own `finally`: gateway hooks (`src/gateway/server/hooks.ts:162`) also run isolated turns, but on the agent's **main** session key, where unconditional run-end tab closing would regress live main-session tabs (those are idle-sweep-owned).

Possible follow-up, intentionally out of scope: let the idle sweep also reap run-suffixed cron keys as an in-process backstop for a missed lifecycle close.

## User Impact

Isolated and untargeted cron jobs that use the browser tool no longer leak tabs in the managed browser profile after every run. Session-targeted cron jobs behave exactly as before. Installs with the browser disabled no longer get browser-maintenance calls from cron runs.

## Evidence

- Root-cause chain (all verified in source): tracking `extensions/browser/src/browser-tool.ts:706` ← key minted `src/cron/isolated-agent/run.ts:634` ← passed to runs `src/cron/isolated-agent/run-executor.ts:319`/`:377` ← loopback MCP header `src/gateway/mcp-http.request.ts:363` + `src/gateway/tool-resolution.ts:173`; miss at `extensions/browser/src/browser/session-tab-registry.ts:171`; sweep exclusion `extensions/browser/src/browser/session-tab-cleanup.ts:48`.
- Tests: `node scripts/run-vitest.mjs src/gateway/server-cron.test.ts` — 2 files, 50 tests passed. New regression test asserts cleanup receives the runner-reported run key for isolated jobs; the custom-session-target test now also asserts the runner-reported canonical key is **not** added for `session:` targets; the isolated model-override test asserts the dead `cron:<jobId>` key is gone.
- Formatting: oxfmt via `scripts/committer` (clean).
- Not run locally (linked worktree without a full install): tsgo lanes / broad `check:changed` — relying on CI for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
