### PR TITLE
fix(gateway): keep session events within their owning agent

### DIFF
--- a/src/gateway/server-broadcast.board.test.ts
+++ b/src/gateway/server-broadcast.board.test.ts
@@ -4,7 +4,12 @@ import {
   GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_IDS,
 } from "../../packages/gateway-protocol/src/client-info.js";
+import {
+  deleteSessionEntryLifecycle,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
 import {
   createSessionEventSubscriberRegistry,
@@ -12,6 +17,11 @@ import {
 } from "./server-chat-state.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { createSessionObserverAudience } from "./session-observer-audience.js";
+import {
+  canReceiveSessionEvent as canReceiveSessionEventForClient,
+  invalidateSessionSharingSnapshot,
+  resolveSessionSharingTarget,
+} from "./session-sharing.js";
 import { resolveSessionSubscriptionKeys } from "./session-subscription-keys.js";
 
 type RecordingSocket = {
@@ -141,6 +151,111 @@ describe("board event scope guards", () => {
 });
 
 describe("collaboration event scope guards", () => {
+  it("revalidates an authoritative session-generation creator replacement before socket I/O", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = "agent:main:draft-owner-filter";
+      const ownerActor = { type: "human" as const, id: "profile-owner" };
+      const successorActor = { type: "human" as const, id: "profile-successor" };
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey },
+        {
+          sessionId: "session-draft-owner-filter",
+          updatedAt: 1,
+          visibility: "draft",
+          createdActor: ownerActor,
+        },
+      );
+      const owner = makeClient("owner", "operator", ["operator.read"]);
+      const successor = makeClient("successor", "operator", ["operator.read"]);
+      for (const [entry, actor] of [
+        [owner, ownerActor],
+        [successor, successorActor],
+      ] as const) {
+        entry.client.authenticatedUserId = actor.id;
+        entry.client.authenticatedUserProfile = {
+          profileId: actor.id,
+          displayName: null,
+          hasAvatar: false,
+          updatedAt: 1,
+        };
+      }
+      const cfg: OpenClawConfig = {};
+      const filter = vi.fn(
+        (
+          client: GatewayWsClient,
+          sessionKeys: readonly string[],
+          agentId?: string,
+          event?: string,
+          payload?: unknown,
+        ) => canReceiveSessionEventForClient({ cfg, client, sessionKeys, agentId, event, payload }),
+      );
+      const { broadcastToConnIds } = createGatewayBroadcaster({
+        clients: new Set([owner.client, successor.client]),
+        canReceiveSessionEvent: filter,
+      });
+      const broadcast = () =>
+        broadcastToConnIds(
+          "sessions.changed",
+          { sessionKey, agentId: "main", reason: "updated" },
+          new Set([owner.client.connId, successor.client.connId]),
+          { agentId: "main", sessionKeys: [sessionKey] },
+        );
+
+      broadcast();
+
+      expect(owner.socket.send).toHaveBeenCalledOnce();
+      expect(successor.socket.send).not.toHaveBeenCalled();
+      expect(filter.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER).toBeLessThan(
+        owner.socket.send.mock.invocationCallOrder[0] ?? -1,
+      );
+      expect(JSON.parse(String(owner.socket.send.mock.calls[0]?.[0]))).toMatchObject({
+        event: "sessions.changed",
+        payload: { sessionKey, agentId: "main", reason: "updated" },
+      });
+
+      const target = resolveSessionSharingTarget({ cfg, sessionKey, agentId: "main" });
+      if (!target) {
+        throw new Error("expected the persisted draft session target");
+      }
+      await expect(
+        deleteSessionEntryLifecycle({
+          agentId: target.agentId,
+          archiveTranscript: false,
+          expectedSessionId: "session-draft-owner-filter",
+          storePath: target.storePath,
+          target: { canonicalKey: target.canonicalKey, storeKeys: target.storeKeys },
+        }),
+      ).resolves.toMatchObject({ deleted: true });
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey },
+        {
+          sessionId: "session-draft-successor-filter",
+          updatedAt: 2,
+          visibility: "draft",
+          createdActor: successorActor,
+        },
+      );
+      invalidateSessionSharingSnapshot(sessionKey);
+      owner.socket.send.mockClear();
+      successor.socket.send.mockClear();
+      owner.socket.events.length = 0;
+      successor.socket.events.length = 0;
+      filter.mockClear();
+
+      broadcast();
+
+      expect(owner.socket.send).not.toHaveBeenCalled();
+      expect(successor.socket.send).toHaveBeenCalledOnce();
+      expect(filter.mock.invocationCallOrder.at(-1) ?? Number.MAX_SAFE_INTEGER).toBeLessThan(
+        successor.socket.send.mock.invocationCallOrder[0] ?? -1,
+      );
+      expect(JSON.parse(String(successor.socket.send.mock.calls[0]?.[0]))).toMatchObject({
+        event: "sessions.changed",
+        payload: { sessionKey, agentId: "main", reason: "updated" },
+      });
+    });
+  });
+
   it("uses the payload session scope for observer subscription filtering", () => {
     const subscribed = makeClient("subscribed", "operator", ["operator.read"]);
     const otherSession = makeClient("other-session", "operator", ["operator.read"]);

--- a/src/gateway/server-broadcast.board.test.ts
+++ b/src/gateway/server-broadcast.board.test.ts
@@ -176,6 +176,7 @@ describe("collaboration event scope guards", () => {
           profileId: actor.id,
           displayName: null,
           hasAvatar: false,
+          avatarRevision: "1",
           updatedAt: 1,
         };
       }

--- a/src/gateway/server-methods/session-change-event.test.ts
+++ b/src/gateway/server-methods/session-change-event.test.ts
@@ -204,16 +204,18 @@ describe("sessions.changed coalescing", () => {
     expect(context.broadcastToConnIds).toHaveBeenCalledWith(
       "sessions.changed",
       expect.objectContaining({
-        agentId: "ops",
         activeRunIds: ["ops-global-run"],
         hasActiveRun: true,
       }),
       expect.anything(),
       expect.objectContaining({
         agentId: "ops",
-        sessionKeys: ["agent:ops:global", "global"],
+        sessionKeys: ["global"],
       }),
     );
+    const payload = vi.mocked(context.broadcastToConnIds).mock.calls[0]?.[1];
+    expect(payload).not.toHaveProperty("agentId");
+    expect(payload).not.toHaveProperty("goal");
   });
 
   it("keeps a retired fixed-store owner private after the mutation commits", () => {

--- a/src/gateway/server-methods/session-change-event.test.ts
+++ b/src/gateway/server-methods/session-change-event.test.ts
@@ -204,12 +204,55 @@ describe("sessions.changed coalescing", () => {
     expect(context.broadcastToConnIds).toHaveBeenCalledWith(
       "sessions.changed",
       expect.objectContaining({
+        agentId: "ops",
         activeRunIds: ["ops-global-run"],
         hasActiveRun: true,
       }),
       expect.anything(),
-      expect.anything(),
+      expect.objectContaining({
+        agentId: "ops",
+        sessionKeys: ["agent:ops:global", "global"],
+      }),
     );
+  });
+
+  it("keeps a retired fixed-store owner private after the mutation commits", () => {
+    const config = {
+      session: { scope: "global", store: "/stores/shared.sqlite" },
+      agents: {
+        ownership: "explicit",
+        defaults: { sessionStore: { agentId: "ops" } },
+        entries: { research: {} },
+      },
+    } satisfies OpenClawConfig;
+    const context = createContext(new Set(["conn-1"]), config);
+
+    emitSessionsChanged(context, { reason: "update", sessionKey: "global" });
+
+    expect(mocks.loadRow).not.toHaveBeenCalled();
+    expect(context.broadcastToConnIds).toHaveBeenCalledWith(
+      "sessions.changed",
+      expect.objectContaining({ sessionKey: "global", reason: "update" }),
+      new Set(["conn-1"]),
+      {
+        agentId: "ops",
+        dropIfSlow: true,
+        sessionKeys: ["agent:ops:global"],
+      },
+    );
+    const payload = vi.mocked(context.broadcastToConnIds).mock.calls[0]?.[1];
+    for (const field of [
+      "agentId",
+      "key",
+      "label",
+      "session",
+      "goal",
+      "status",
+      "hasActiveRun",
+      "activeRunIds",
+    ]) {
+      expect(payload, field).not.toHaveProperty(field);
+    }
   });
 
   it("tombstones exact run ids when lifecycle projection takes ownership", () => {

--- a/src/gateway/server-methods/session-change-event.ts
+++ b/src/gateway/server-methods/session-change-event.ts
@@ -1,8 +1,12 @@
 // Shared sessions.changed broadcaster for gateway RPC and chat-command mutations.
-import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { hasSessionChangeReceivers } from "../session-change-receivers.js";
 import { buildGatewaySessionSnapshot } from "../session-event-payload.js";
-import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-agent.js";
+import {
+  resolveSessionEventBroadcastScope,
+  resolveSessionEventAgentScope,
+  type SessionEventAgentScope,
+} from "../session-request-agent.js";
 import { invalidateSessionSharingSnapshot } from "../session-sharing.js";
 import { loadGatewaySessionRow } from "../session-utils.js";
 import { resolveVisibleActiveSessionRunState } from "./session-active-runs.js";
@@ -29,6 +33,7 @@ type PendingSessionChange = {
   firstDeferredAt?: number;
   key: string;
   payload: SessionChangedPayload;
+  scope: SessionEventAgentScope | null;
   timer: ReturnType<typeof setTimeout> | null;
 };
 
@@ -42,60 +47,62 @@ export function readSessionsMutationVersion(context: object): number {
   return sessionsMutationVersions.get(context) ?? 0;
 }
 
-function sessionChangeKey(payload: SessionChangedPayload): string {
-  return `${payload.agentId ?? ""}\0${payload.sessionKey ?? ""}`;
+function sessionChangeKey(payload: SessionChangedPayload, scope: SessionEventAgentScope | null) {
+  return `${scope?.[1] ?? payload.agentId ?? ""}\0${payload.sessionKey ?? ""}`;
 }
 
 function broadcastSessionsChanged(
   context: SessionChangeContext,
   payload: SessionChangedPayload,
+  scope: SessionEventAgentScope | null,
 ): void {
   const connIds = context.getSessionEventSubscriberConnIds();
   if (!hasSessionChangeReceivers(connIds)) {
     return;
   }
-  const cfg = context.getRuntimeConfig();
-  const unscopedOwnerAgentId = payload.sessionKey
-    ? tryResolveSessionCompatibilityOwnerAgentId(cfg, payload.sessionKey)
-    : undefined;
-  const effectiveAgentId = payload.agentId ?? unscopedOwnerAgentId;
-  const sessionRow = payload.sessionKey
-    ? loadGatewaySessionRow(
-        payload.sessionKey,
-        effectiveAgentId ? { agentId: effectiveAgentId } : undefined,
-      )
-    : null;
-  let rowAgentId: string | undefined;
-  if (sessionRow) {
-    try {
-      rowAgentId = resolveAgentIdFromSessionKey(sessionRow.key, effectiveAgentId);
-    } catch {
-      rowAgentId = undefined;
-    }
+  if (scope === null) {
+    return;
   }
+  const [eventAgentId, routingAgentId, compatibilityOwnerAgentId] = scope;
+  const privateBroadcastScope = resolveSessionEventBroadcastScope(payload.sessionKey, scope);
+  const broadcastOptions = {
+    ...privateBroadcastScope,
+    dropIfSlow: true,
+  };
+  const eventPayload = {
+    ...payload,
+    ...(eventAgentId ? { agentId: eventAgentId } : {}),
+    ts: Date.now(),
+  };
+  if (
+    !payload.sessionKey ||
+    !routingAgentId ||
+    (!eventAgentId && !parseAgentSessionKey(payload.sessionKey))
+  ) {
+    context.broadcastToConnIds("sessions.changed", eventPayload, connIds, broadcastOptions);
+    return;
+  }
+  const sessionRow = loadGatewaySessionRow(payload.sessionKey, { agentId: routingAgentId });
   const activeRunState =
-    sessionRow &&
-    (sessionRow.key !== "global" || rowAgentId !== undefined || unscopedOwnerAgentId !== undefined)
+    sessionRow && (sessionRow.key !== "global" || routingAgentId !== undefined)
       ? resolveVisibleActiveSessionRunState({
           context,
           requestedKey: payload.sessionKey ?? sessionRow.key,
           canonicalKey: sessionRow.key,
           sessionId: sessionRow.sessionId,
-          agentId: rowAgentId,
-          defaultAgentId: unscopedOwnerAgentId,
+          agentId: routingAgentId,
+          defaultAgentId: compatibilityOwnerAgentId,
         })
       : null;
   context.broadcastToConnIds(
     "sessions.changed",
     {
-      ...payload,
-      ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
-      ts: Date.now(),
+      ...eventPayload,
       ...(sessionRow
         ? {
             ...buildGatewaySessionSnapshot({
               sessionRow,
-              agentId: effectiveAgentId,
+              agentId: eventAgentId,
               activeRunState,
               status: activeRunState?.active ? (activeRunState.status ?? "running") : undefined,
             }),
@@ -103,13 +110,7 @@ function broadcastSessionsChanged(
         : {}),
     },
     connIds,
-    {
-      ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
-      dropIfSlow: true,
-      // Scope only to a concrete key; a `[undefined]` scope filters no connection
-      // correctly and would strip draft gating, so fall back to an unscoped send.
-      ...(sessionRow?.key ? { sessionKeys: [sessionRow.key] } : {}),
-    },
+    broadcastOptions,
   );
 }
 
@@ -124,7 +125,7 @@ function finishPendingSessionChange(pending: PendingSessionChange): void {
     byKey.delete(pending.key);
   }
   if (pending.dirty) {
-    broadcastSessionsChanged(pending.context, pending.payload);
+    broadcastSessionsChanged(pending.context, pending.payload, pending.scope);
   }
 }
 
@@ -147,12 +148,16 @@ export function emitSessionsChanged(context: SessionChangeContext, payload: Sess
   if (!hasSessionChangeReceivers(connIds)) {
     return;
   }
-  const key = sessionChangeKey(payload);
+  const scope: SessionEventAgentScope | null = payload.sessionKey
+    ? resolveSessionEventAgentScope(context.getRuntimeConfig(), payload.sessionKey, payload.agentId)
+    : [payload.agentId, payload.agentId, undefined];
+  const key = sessionChangeKey(payload, scope);
   const byKey = pendingChangesByContext.get(context) ?? new Map<string, PendingSessionChange>();
   pendingChangesByContext.set(context, byKey);
   const pending = byKey.get(key);
   if (pending) {
     pending.payload = payload;
+    pending.scope = scope;
     pending.dirty = true;
     pending.firstDeferredAt ??= Date.now();
     if (pending.timer) {
@@ -176,13 +181,14 @@ export function emitSessionsChanged(context: SessionChangeContext, payload: Sess
     dirty: false,
     key,
     payload,
+    scope,
     timer: null,
   };
   next.timer = setTimeout(() => finishPendingSessionChange(next), SESSIONS_CHANGED_DEBOUNCE_MS);
   next.timer.unref?.();
   byKey.set(key, next);
   pendingSessionChanges.add(next);
-  broadcastSessionsChanged(context, payload);
+  broadcastSessionsChanged(context, payload, scope);
 }
 
 export function emitSessionArchived(

--- a/src/gateway/server-methods/session-change-event.ts
+++ b/src/gateway/server-methods/session-change-event.ts
@@ -3,7 +3,7 @@ import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { hasSessionChangeReceivers } from "../session-change-receivers.js";
 import { buildGatewaySessionSnapshot } from "../session-event-payload.js";
 import {
-  resolveSessionEventBroadcastScope,
+  resolvePrivateSessionEventBroadcastScope,
   resolveSessionEventAgentScope,
   type SessionEventAgentScope,
 } from "../session-request-agent.js";
@@ -64,8 +64,10 @@ function broadcastSessionsChanged(
     return;
   }
   const [eventAgentId, routingAgentId, compatibilityOwnerAgentId] = scope;
-  const privateBroadcastScope = resolveSessionEventBroadcastScope(payload.sessionKey, scope);
+  const privateBroadcastScope = resolvePrivateSessionEventBroadcastScope(payload.sessionKey, scope);
+  const broadcastAgentId = routingAgentId;
   const broadcastOptions = {
+    ...(broadcastAgentId ? { agentId: broadcastAgentId } : {}),
     ...privateBroadcastScope,
     dropIfSlow: true,
   };
@@ -77,7 +79,7 @@ function broadcastSessionsChanged(
   if (
     !payload.sessionKey ||
     !routingAgentId ||
-    (!eventAgentId && !parseAgentSessionKey(payload.sessionKey))
+    (!eventAgentId && !compatibilityOwnerAgentId && !parseAgentSessionKey(payload.sessionKey))
   ) {
     context.broadcastToConnIds("sessions.changed", eventPayload, connIds, broadcastOptions);
     return;
@@ -110,7 +112,10 @@ function broadcastSessionsChanged(
         : {}),
     },
     connIds,
-    broadcastOptions,
+    {
+      ...broadcastOptions,
+      ...(sessionRow?.key ? { sessionKeys: [sessionRow.key] } : {}),
+    },
   );
 }
 

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -172,7 +172,6 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         messageSeq: 1,
       }),
       expect.any(Set),
-      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:main"] }),
     );
   });
 
@@ -221,7 +220,6 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         phase: "message",
       }),
       new Set(["conn-broad", "conn-shared", "conn-targeted"]),
-      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:main"] }),
     );
     const payload = broadcastToConnIds.mock.calls[0]?.[1];
     expect(payload).not.toHaveProperty("message");
@@ -259,7 +257,6 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       "sessions.changed",
       expect.objectContaining({ sessionKey: "agent:main:current" }),
       new Set(["conn-1", "conn-current"]),
-      { agentId: "main", sessionKeys: ["agent:main:current"] },
     );
   });
 
@@ -419,7 +416,6 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         messageSeq: 1,
       }),
       expect.any(Set),
-      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:main"] }),
     );
     const payload = broadcastToConnIds.mock.calls[0]?.[1];
     expect(payload).not.toHaveProperty("lifecycleRevision");
@@ -456,7 +452,6 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         messageSeq: 1,
       }),
       expect.any(Set),
-      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:main"] }),
     );
   });
 
@@ -484,7 +479,6 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         messageSeq: 3,
       }),
       expect.any(Set),
-      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:main"] }),
     );
   });
 
@@ -519,7 +513,6 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         }),
       }),
       expect.any(Set),
-      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:main"] }),
     );
   });
 
@@ -587,7 +580,7 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
   });
 
   it.each([
-    { name: "publishes the configured persisted owner's identity and goal" },
+    { name: "routes the configured persisted owner without publishing its goal" },
     { name: "publishes the explicit owner's identity and goal", agentId: "ops" },
   ])("$name", async ({ agentId }) => {
     runtimeConfigState.value = fixedStoreRuntimeConfig("ops", ["ops", "research"]);
@@ -637,13 +630,15 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       "session.message",
       expect.objectContaining({ sessionKey: "global" }),
       new Set(["conn-scoped", "conn-global"]),
-      {
-        agentId: "ops",
-        sessionKeys: ["agent:ops:global", "global"],
-      },
     );
     const payload = broadcastToConnIds.mock.calls[0]?.[1];
-    expect(payload).toMatchObject({ agentId: "ops", goal, session: { goal } });
+    if (agentId) {
+      expect(payload).toMatchObject({ agentId: "ops", goal, session: { goal } });
+    } else {
+      expect(payload).not.toHaveProperty("agentId");
+      expect(payload).not.toHaveProperty("goal");
+      expect(payload).not.toHaveProperty("session.goal");
+    }
   });
 
   it("keeps a retired fixed-store owner private instead of routing through another agent", async () => {
@@ -968,11 +963,7 @@ describe("createLifecycleEventBroadcastHandler", () => {
         text: "Research",
       }),
       new Set(["conn-1"]),
-      {
-        agentId: "main",
-        dropIfSlow: true,
-        sessionKeys: ["agent:main:main"],
-      },
+      { dropIfSlow: true },
     );
   });
 
@@ -1005,7 +996,7 @@ describe("createLifecycleEventBroadcastHandler", () => {
   });
 
   it.each([
-    { name: "publishes active state and goal for the configured persisted owner" },
+    { name: "projects configured persisted state without publishing its goal" },
     { name: "publishes active state and goal for the explicit owner", agentId: "ops" },
   ])("$name", ({ agentId }) => {
     runtimeConfigState.value = fixedStoreRuntimeConfig("ops", ["ops", "research"]);
@@ -1045,14 +1036,16 @@ describe("createLifecycleEventBroadcastHandler", () => {
         activeRunIds: ["run-before-finalize"],
       }),
       new Set(["conn-1"]),
-      {
-        agentId: "ops",
-        dropIfSlow: true,
-        sessionKeys: ["agent:ops:global", "global"],
-      },
+      { dropIfSlow: true },
     );
     const payload = broadcastToConnIds.mock.calls[0]?.[1];
-    expect(payload).toMatchObject({ agentId: "ops", goal });
+    if (agentId) {
+      expect(payload).toMatchObject({ agentId: "ops", goal });
+    } else {
+      expect(payload).not.toHaveProperty("agentId");
+      expect(payload).not.toHaveProperty("goal");
+      expect(payload).not.toHaveProperty("session.goal");
+    }
   });
 
   it("publishes only a private invalidation for a retired fixed-store lifecycle owner", () => {

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
+import type { SessionMessageSubscriberRegistry } from "./server-chat-state.js";
 
 const sessionRow = vi.hoisted(() => ({
   key: "agent:main:main",
@@ -94,7 +95,7 @@ function fixedStoreRuntimeConfig(ownerAgentId: string, configuredAgentIds: strin
 function createHandler(
   projectSessionActive: boolean,
   executionStarted = true,
-  getSessionMessageSubscribers: SessionMessageSubscribers["get"] = () => new Set<string>(),
+  getSessionMessageSubscribers: SessionMessageSubscriberRegistry["get"] = () => new Set<string>(),
 ) {
   const broadcastToConnIds = vi.fn();
   const handler = createTranscriptUpdateBroadcastHandler({

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -80,17 +80,43 @@ function createActiveRun(
   };
 }
 
-function createHandler(projectSessionActive: boolean, executionStarted = true) {
+function fixedStoreRuntimeConfig(ownerAgentId: string, configuredAgentIds: string[]) {
+  return {
+    session: { store: "/tmp/shared.sqlite" },
+    agents: {
+      ownership: "explicit",
+      defaults: { sessionStore: { agentId: ownerAgentId } },
+      entries: Object.fromEntries(configuredAgentIds.map((agentId) => [agentId, {}])),
+    },
+  };
+}
+
+function createHandler(
+  projectSessionActive: boolean,
+  executionStarted = true,
+  getSessionMessageSubscribers: SessionMessageSubscribers["get"] = () => new Set<string>(),
+) {
   const broadcastToConnIds = vi.fn();
   const handler = createTranscriptUpdateBroadcastHandler({
     broadcastToConnIds,
     sessionEventSubscribers: { getAll: () => new Set(["conn-1"]) },
-    sessionMessageSubscribers: { get: () => new Set<string>() },
+    sessionMessageSubscribers: { get: getSessionMessageSubscribers },
     chatAbortControllers: new Map([
       ["run-before-finalize", createActiveRun(projectSessionActive, executionStarted)],
     ]),
   });
   return { broadcastToConnIds, handler };
+}
+
+const PRIVATE_SESSION_FIELDS =
+  "agentId session message owner goal status hasActiveRun activeRunIds model responseUsage".split(
+    " ",
+  );
+
+function expectPrivateSessionInvalidation(payload: unknown) {
+  for (const field of PRIVATE_SESSION_FIELDS) {
+    expect(payload, field).not.toHaveProperty(field);
+  }
 }
 
 async function emitAssistantTranscriptUpdate(
@@ -146,6 +172,7 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         messageSeq: 1,
       }),
       expect.any(Set),
+      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:main"] }),
     );
   });
 
@@ -194,6 +221,7 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         phase: "message",
       }),
       new Set(["conn-broad", "conn-shared", "conn-targeted"]),
+      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:main"] }),
     );
     const payload = broadcastToConnIds.mock.calls[0]?.[1];
     expect(payload).not.toHaveProperty("message");
@@ -203,6 +231,36 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
     expect(payload).not.toHaveProperty("storePath");
     expect(payload).not.toHaveProperty("target.storePath");
     expect(readSessionMessageCountAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("scopes a queued marker update to its final transcript key", async () => {
+    resolveTranscriptSessionKeyBySessionIdMock
+      .mockReturnValueOnce("agent:main:queued")
+      .mockReturnValue("agent:main:current");
+    listAccessorSessionEntriesReadOnlyMock.mockReturnValue([
+      { key: "agent:main:current", entry: { sessionId: "sess-main" } },
+    ]);
+    const getSessionMessageSubscribers = vi.fn((sessionKey: string) =>
+      sessionKey === "agent:main:current" ? new Set(["conn-current"]) : new Set(["conn-stale"]),
+    );
+    const { broadcastToConnIds, handler } = createHandler(
+      false,
+      true,
+      getSessionMessageSubscribers,
+    );
+
+    await handler({
+      sessionFile: "sqlite:main:sess-main:/tmp/explicit-sessions.json",
+    });
+
+    expect(getSessionMessageSubscribers).toHaveBeenCalledWith("agent:main:current");
+    expect(getSessionMessageSubscribers).not.toHaveBeenCalledWith("agent:main:queued");
+    expect(broadcastToConnIds).toHaveBeenCalledWith(
+      "sessions.changed",
+      expect.objectContaining({ sessionKey: "agent:main:current" }),
+      new Set(["conn-1", "conn-current"]),
+      { agentId: "main", sessionKeys: ["agent:main:current"] },
+    );
   });
 
   it("rejects an identity-only invalidation when its custom-store owner was deleted", async () => {
@@ -361,6 +419,7 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         messageSeq: 1,
       }),
       expect.any(Set),
+      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:main"] }),
     );
     const payload = broadcastToConnIds.mock.calls[0]?.[1];
     expect(payload).not.toHaveProperty("lifecycleRevision");
@@ -397,6 +456,7 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         messageSeq: 1,
       }),
       expect.any(Set),
+      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:main"] }),
     );
   });
 
@@ -424,6 +484,7 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         messageSeq: 3,
       }),
       expect.any(Set),
+      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:main"] }),
     );
   });
 
@@ -458,6 +519,7 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         }),
       }),
       expect.any(Set),
+      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:main"] }),
     );
   });
 
@@ -525,17 +587,10 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
   });
 
   it.each([
-    { name: "routes a bare event without disclosing the persisted owner's goal" },
-    { name: "publishes the qualified owner's goal", agentId: "ops" },
+    { name: "publishes the configured persisted owner's identity and goal" },
+    { name: "publishes the explicit owner's identity and goal", agentId: "ops" },
   ])("$name", async ({ agentId }) => {
-    runtimeConfigState.value = {
-      session: { store: "/tmp/owned-shared.sqlite" },
-      agents: {
-        ownership: "explicit",
-        defaults: { sessionStore: { agentId: "ops" } },
-        entries: { ops: {}, research: {} },
-      },
-    };
+    runtimeConfigState.value = fixedStoreRuntimeConfig("ops", ["ops", "research"]);
     sessionRow.key = "global";
     const goal = {
       schemaVersion: 1 as const,
@@ -582,15 +637,52 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       "session.message",
       expect.objectContaining({ sessionKey: "global" }),
       new Set(["conn-scoped", "conn-global"]),
+      {
+        agentId: "ops",
+        sessionKeys: ["agent:ops:global", "global"],
+      },
     );
     const payload = broadcastToConnIds.mock.calls[0]?.[1];
-    if (agentId) {
-      expect(payload).toMatchObject({ agentId: "ops", goal, session: { goal } });
-    } else {
-      expect(payload).not.toHaveProperty("agentId");
-      expect(payload).not.toHaveProperty("goal");
-      expect(payload).not.toHaveProperty("session.goal");
-    }
+    expect(payload).toMatchObject({ agentId: "ops", goal, session: { goal } });
+  });
+
+  it("keeps a retired fixed-store owner private instead of routing through another agent", async () => {
+    runtimeConfigState.value = fixedStoreRuntimeConfig("ops", ["research"]);
+    const getSessionMessageSubscribers = vi.fn((sessionKey: string) =>
+      sessionKey === "agent:ops:global"
+        ? new Set(["conn-ops"])
+        : sessionKey === "agent:research:global"
+          ? new Set(["conn-research"])
+          : new Set<string>(),
+    );
+    const { broadcastToConnIds, handler } = createHandler(
+      false,
+      true,
+      getSessionMessageSubscribers,
+    );
+
+    await handler({
+      sessionKey: "global",
+      message: { role: "assistant", content: [{ type: "text", text: "private owner" }] },
+      messageId: "message-retired-owner",
+      messageSeq: 1,
+    });
+
+    expect(getSessionMessageSubscribers).toHaveBeenCalledWith("agent:ops:global");
+    expect(getSessionMessageSubscribers).not.toHaveBeenCalledWith("agent:research:global");
+    expect(loadGatewaySessionRowMock).not.toHaveBeenCalled();
+    expect(broadcastToConnIds).toHaveBeenCalledOnce();
+    expect(broadcastToConnIds).toHaveBeenCalledWith(
+      "sessions.changed",
+      expect.objectContaining({ sessionKey: "global", phase: "message" }),
+      new Set(["conn-1", "conn-ops"]),
+      {
+        agentId: "ops",
+        dropIfSlow: true,
+        sessionKeys: ["agent:ops:global"],
+      },
+    );
+    expectPrivateSessionInvalidation(broadcastToConnIds.mock.calls[0]?.[1]);
   });
 
   it("broadcasts user idempotency keys in session.message metadata", async () => {
@@ -876,7 +968,11 @@ describe("createLifecycleEventBroadcastHandler", () => {
         text: "Research",
       }),
       new Set(["conn-1"]),
-      { dropIfSlow: true },
+      {
+        agentId: "main",
+        dropIfSlow: true,
+        sessionKeys: ["agent:main:main"],
+      },
     );
   });
 
@@ -909,17 +1005,10 @@ describe("createLifecycleEventBroadcastHandler", () => {
   });
 
   it.each([
-    { name: "projects bare active state without disclosing the persisted owner's goal" },
-    { name: "publishes active state and goal for the qualified owner", agentId: "ops" },
+    { name: "publishes active state and goal for the configured persisted owner" },
+    { name: "publishes active state and goal for the explicit owner", agentId: "ops" },
   ])("$name", ({ agentId }) => {
-    runtimeConfigState.value = {
-      session: { store: "/tmp/owned-shared.sqlite" },
-      agents: {
-        ownership: "explicit",
-        defaults: { sessionStore: { agentId: "ops" } },
-        entries: { ops: {}, research: {} },
-      },
-    };
+    runtimeConfigState.value = fixedStoreRuntimeConfig("ops", ["ops", "research"]);
     sessionRow.key = "global";
     const goal = {
       schemaVersion: 1 as const,
@@ -956,15 +1045,38 @@ describe("createLifecycleEventBroadcastHandler", () => {
         activeRunIds: ["run-before-finalize"],
       }),
       new Set(["conn-1"]),
-      { dropIfSlow: true },
+      {
+        agentId: "ops",
+        dropIfSlow: true,
+        sessionKeys: ["agent:ops:global", "global"],
+      },
     );
     const payload = broadcastToConnIds.mock.calls[0]?.[1];
-    if (agentId) {
-      expect(payload).toMatchObject({ agentId: "ops", goal });
-    } else {
-      expect(payload).not.toHaveProperty("agentId");
-      expect(payload).not.toHaveProperty("goal");
-      expect(payload).not.toHaveProperty("session.goal");
-    }
+    expect(payload).toMatchObject({ agentId: "ops", goal });
+  });
+
+  it("publishes only a private invalidation for a retired fixed-store lifecycle owner", () => {
+    runtimeConfigState.value = fixedStoreRuntimeConfig("ops", ["research"]);
+    const broadcastToConnIds = vi.fn();
+    const handler = createLifecycleEventBroadcastHandler({
+      broadcastToConnIds,
+      sessionEventSubscribers: { getAll: () => new Set(["conn-events"]) },
+      chatAbortControllers: new Map(),
+    });
+
+    handler({ sessionKey: "global", reason: "updated" });
+
+    expect(loadGatewaySessionRowMock).not.toHaveBeenCalled();
+    expect(broadcastToConnIds).toHaveBeenCalledWith(
+      "sessions.changed",
+      expect.objectContaining({ sessionKey: "global", reason: "updated" }),
+      new Set(["conn-events"]),
+      {
+        agentId: "ops",
+        dropIfSlow: true,
+        sessionKeys: ["agent:ops:global"],
+      },
+    );
+    expectPrivateSessionInvalidation(broadcastToConnIds.mock.calls[0]?.[1]);
   });
 });

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -4,14 +4,12 @@ import path from "node:path";
 import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { getRuntimeConfig } from "../config/io.js";
-import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import {
   listSessionEntriesReadOnly as listAccessorSessionEntriesReadOnly,
   loadSessionEntryReadOnly as loadAccessorSessionEntryReadOnly,
   resolveTranscriptSessionKeyBySessionId,
 } from "../config/sessions/session-accessor.js";
-import { resolvePersistedSessionStoreOwnerForKey } from "../config/sessions/session-store-owner.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import type { SessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import type { InternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
@@ -26,19 +24,17 @@ import { resolveVisibleActiveSessionRunState } from "./server-methods/session-ac
 import { hasSessionChangeReceivers } from "./session-change-receivers.js";
 import { buildGatewaySessionSnapshot } from "./session-event-payload.js";
 import {
-  resolveSessionSubscriptionKey,
-  resolveSessionSubscriptionKeys,
-} from "./session-subscription-keys.js";
+  resolveSessionEventBroadcastScope,
+  resolveSessionEventAgentScope,
+  type SessionEventAgentScope,
+} from "./session-request-agent.js";
+import { resolveSessionSubscriptionKey } from "./session-subscription-keys.js";
 import { projectSessionMessagePayload } from "./session-transcript-message.js";
 import { readSessionMessageCountAsync } from "./session-transcript-readers.js";
 import { loadGatewaySessionRow, loadGatewaySessionEntryReadOnly } from "./session-utils.js";
 
 type SessionEventSubscribers = Pick<SessionEventSubscriberRegistry, "getAll">;
 type SessionMessageSubscribers = Pick<SessionMessageSubscriberRegistry, "get">;
-
-function tryResolveCompatibilityDefaultAgentId(): string | undefined {
-  return tryResolveLegacyCompatibilityAgentId(getRuntimeConfig());
-}
 
 function readTranscriptUpdateLifecycleOwner(
   update: InternalSessionTranscriptUpdate,
@@ -95,27 +91,25 @@ export function createTranscriptUpdateBroadcastHandler(params: {
       normalizeOptionalString(update.target?.sessionKey) ??
       normalizeOptionalString(update.sessionKey) ??
       (legacyMarker ? resolveTranscriptSessionKeyBySessionId(legacyMarker) : undefined);
-    let agentId =
+    const agentId =
       normalizeOptionalString(update.target?.agentId) ??
       normalizeOptionalString(update.agentId) ??
       legacyMarker?.agentId;
-    if (!agentId && sessionKey?.toLowerCase() === "global") {
-      const config = getRuntimeConfig();
-      const persistedOwner = resolvePersistedSessionStoreOwnerForKey(config, sessionKey);
-      agentId =
-        persistedOwner.kind === "configured"
-          ? persistedOwner.agentId
-          : tryResolveLegacyCompatibilityAgentId(config);
+    const agentScope = sessionKey
+      ? resolveSessionEventAgentScope(getRuntimeConfig(), sessionKey, agentId)
+      : undefined;
+    if (agentScope === null) {
+      return Promise.resolve();
     }
     // Raw global is per-agent storage identity; its qualified aliases must share a lane.
     const laneKey =
-      sessionKey && agentId
-        ? resolveSessionSubscriptionKey(sessionKey, agentId)
+      sessionKey && agentScope?.[1]
+        ? resolveSessionSubscriptionKey(sessionKey, agentScope[1])
         : (sessionKey ?? normalizeOptionalString(update.sessionFile) ?? "");
     // Preserve transcript update order within the lane even when counting
     // messages requires an async read from the session file.
     const tail = broadcastQueues.get(laneKey) ?? Promise.resolve();
-    const task = tail.then(() => handleTranscriptUpdateBroadcast(params, queuedUpdate));
+    const task = tail.then(() => handleTranscriptUpdateBroadcast(params, queuedUpdate, agentScope));
     const settled = task.then(
       () => undefined,
       () => undefined,
@@ -139,6 +133,7 @@ async function handleTranscriptUpdateBroadcast(
     chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   },
   update: InternalSessionTranscriptUpdate,
+  capturedAgentScope: SessionEventAgentScope | undefined,
 ): Promise<void> {
   const legacyMarker = parseSqliteSessionFileMarker(update.sessionFile);
   const targetAgentId = normalizeOptionalString(update.target?.agentId);
@@ -198,28 +193,23 @@ async function handleTranscriptUpdateBroadcast(
   if (!sessionKey) {
     return;
   }
-  const effectiveAgentId = compatibleLegacyMarker?.agentId ?? targetAgentId ?? update.agentId;
-  const compatibilityDefaultAgentId = tryResolveCompatibilityDefaultAgentId();
-  const persistedOwner = resolvePersistedSessionStoreOwnerForKey(getRuntimeConfig(), sessionKey);
-  const stableCompatibilityAgentId =
-    persistedOwner.kind === "configured" ? persistedOwner.agentId : compatibilityDefaultAgentId;
-  const stableUnscopedOwner =
-    !parseAgentSessionKey(sessionKey) && !effectiveAgentId ? stableCompatibilityAgentId : undefined;
-  const storageAgentId = effectiveAgentId ?? stableUnscopedOwner;
-  const visibleAgentId = effectiveAgentId;
-  const routingAgentId = effectiveAgentId ?? stableUnscopedOwner;
+  const agentScope =
+    capturedAgentScope ??
+    resolveSessionEventAgentScope(
+      getRuntimeConfig(),
+      sessionKey,
+      compatibleLegacyMarker?.agentId ?? targetAgentId ?? update.agentId,
+    );
+  if (!agentScope) {
+    return;
+  }
+  const [eventAgentId, routingAgentId, compatibilityOwnerAgentId] = agentScope;
+  const privateBroadcastScope = resolveSessionEventBroadcastScope(sessionKey, agentScope);
   const connIds = new Set<string>();
   for (const connId of params.sessionEventSubscribers.getAll()) {
     connIds.add(connId);
   }
-  let broadcastKeys = [sessionKey];
-  if (sessionKey === "global" && routingAgentId) {
-    broadcastKeys = resolveSessionSubscriptionKeys(
-      sessionKey,
-      routingAgentId,
-      stableCompatibilityAgentId,
-    );
-  }
+  const broadcastKeys = privateBroadcastScope?.sessionKeys ?? [sessionKey];
   for (const broadcastKey of broadcastKeys) {
     for (const connId of params.sessionMessageSubscribers.get(broadcastKey)) {
       connIds.add(connId);
@@ -233,6 +223,29 @@ async function handleTranscriptUpdateBroadcast(
       return;
     }
   }
+  const lifecycleRevision = normalizeOptionalString(update.lifecycleRevision);
+  if (!eventAgentId && !parseAgentSessionKey(sessionKey)) {
+    if (lifecycleRevision) {
+      const currentLifecycleOwner = readTranscriptUpdateLifecycleOwner(update);
+      if (
+        !currentLifecycleOwner ||
+        (currentLifecycleOwner.lifecycleRevision &&
+          currentLifecycleOwner.lifecycleRevision !== lifecycleRevision)
+      ) {
+        return;
+      }
+    }
+    params.broadcastToConnIds(
+      "sessions.changed",
+      { sessionKey, phase: "message", ts: Date.now() },
+      connIds,
+      {
+        ...privateBroadcastScope,
+        dropIfSlow: true,
+      },
+    );
+    return;
+  }
   let messageSeq = asPositiveSafeInteger(update.messageSeq);
   if (update.message !== undefined && messageSeq === undefined) {
     // Updates from raw transcript events may not carry seq; fall back to the
@@ -241,7 +254,7 @@ async function handleTranscriptUpdateBroadcast(
     const fallbackTarget = updateStorePath
       ? {
           entry: loadAccessorSessionEntryReadOnly({
-            agentId: storageAgentId ?? routingAgentId,
+            agentId: routingAgentId,
             sessionKey,
             storePath: updateStorePath,
           }),
@@ -257,7 +270,7 @@ async function handleTranscriptUpdateBroadcast(
     messageSeq = messageSessionId
       ? asPositiveSafeInteger(
           await readSessionMessageCountAsync({
-            agentId: update.target?.agentId ?? storageAgentId ?? routingAgentId,
+            agentId: update.target?.agentId ?? routingAgentId,
             sessionEntry: entry,
             sessionId: messageSessionId,
             sessionKey,
@@ -266,7 +279,6 @@ async function handleTranscriptUpdateBroadcast(
         )
       : undefined;
   }
-  const lifecycleRevision = normalizeOptionalString(update.lifecycleRevision);
   if (lifecycleRevision) {
     // A reset can retain sessionId, so validate the captured owner after every
     // awaited transcript read before projecting the current session snapshot.
@@ -287,19 +299,19 @@ async function handleTranscriptUpdateBroadcast(
   });
   const activeRunState =
     sessionRow &&
-    (sessionRow.key !== "global" || routingAgentId !== undefined || compatibilityDefaultAgentId)
+    (sessionRow.key !== "global" || routingAgentId !== undefined || compatibilityOwnerAgentId)
       ? resolveVisibleActiveSessionRunState({
           context: params,
           requestedKey: sessionKey,
           canonicalKey: sessionRow.key,
           sessionId: sessionRow.sessionId,
           ...(routingAgentId ? { agentId: routingAgentId } : {}),
-          defaultAgentId: stableUnscopedOwner,
+          defaultAgentId: compatibilityOwnerAgentId,
         })
       : null;
   const sessionSnapshot = buildGatewaySessionSnapshot({
     sessionRow,
-    agentId: visibleAgentId,
+    agentId: eventAgentId,
     includeSession: true,
     activeRunState,
     status: activeRunState?.active ? (activeRunState.status ?? "running") : undefined,
@@ -311,18 +323,19 @@ async function handleTranscriptUpdateBroadcast(
       "sessions.changed",
       {
         sessionKey,
-        ...(visibleAgentId ? { agentId: visibleAgentId } : {}),
+        ...(eventAgentId ? { agentId: eventAgentId } : {}),
         phase: "message",
         ts: Date.now(),
         ...sessionSnapshot,
       },
       connIds,
+      privateBroadcastScope,
     );
     return;
   }
   const projected = projectSessionMessagePayload({
     sessionKey,
-    ...(visibleAgentId ? { agentId: visibleAgentId } : {}),
+    ...(eventAgentId ? { agentId: eventAgentId } : {}),
     message: update.message,
     ...(typeof update.messageId === "string" ? { messageId: update.messageId } : {}),
     ...(messageSeq !== undefined ? { messageSeq } : {}),
@@ -330,7 +343,7 @@ async function handleTranscriptUpdateBroadcast(
     sessionSnapshot,
   });
   if (projected.payload) {
-    params.broadcastToConnIds("session.message", projected.payload, connIds);
+    params.broadcastToConnIds("session.message", projected.payload, connIds, privateBroadcastScope);
     return;
   }
 
@@ -344,7 +357,7 @@ async function handleTranscriptUpdateBroadcast(
     "sessions.changed",
     {
       sessionKey,
-      ...(visibleAgentId ? { agentId: visibleAgentId } : {}),
+      ...(eventAgentId ? { agentId: eventAgentId } : {}),
       phase: "message",
       ts: Date.now(),
       ...(typeof update.messageId === "string" ? { messageId: update.messageId } : {}),
@@ -352,7 +365,7 @@ async function handleTranscriptUpdateBroadcast(
       ...sessionSnapshot,
     },
     sessionEventConnIds,
-    { dropIfSlow: true },
+    { ...privateBroadcastScope, dropIfSlow: true },
   );
 }
 
@@ -372,36 +385,44 @@ export function createLifecycleEventBroadcastHandler(params: {
     if (!hasSessionChangeReceivers(connIds)) {
       return;
     }
-    const compatibilityDefaultAgentId = tryResolveCompatibilityDefaultAgentId();
-    const eventAgentId =
-      normalizeOptionalString(event.agentId) ?? parseAgentSessionKey(event.sessionKey)?.agentId;
-    const persistedOwner = resolvePersistedSessionStoreOwnerForKey(
+    const agentScope = resolveSessionEventAgentScope(
       getRuntimeConfig(),
       event.sessionKey,
+      normalizeOptionalString(event.agentId),
+      true,
     );
-    const stableOwnerAgentId =
-      (persistedOwner.kind === "configured" ? persistedOwner.agentId : undefined) ??
-      compatibilityDefaultAgentId;
-    const rowAgentId = eventAgentId ?? stableOwnerAgentId;
-    const sessionRow = rowAgentId
-      ? loadGatewaySessionRow(event.sessionKey, { agentId: rowAgentId })
-      : undefined;
+    if (!agentScope) {
+      return;
+    }
+    const [eventAgentId, routingAgentId, compatibilityOwnerAgentId] = agentScope;
+    const privateBroadcastScope = resolveSessionEventBroadcastScope(event.sessionKey, agentScope);
+    const broadcastOptions = { ...privateBroadcastScope, dropIfSlow: true };
+    if (!eventAgentId || !routingAgentId) {
+      params.broadcastToConnIds(
+        "sessions.changed",
+        { sessionKey: event.sessionKey, reason: event.reason, ts: Date.now() },
+        connIds,
+        broadcastOptions,
+      );
+      return;
+    }
+    const sessionRow = loadGatewaySessionRow(event.sessionKey, { agentId: routingAgentId });
     const activeRunState =
-      sessionRow && (sessionRow.key !== "global" || rowAgentId)
+      sessionRow && (sessionRow.key !== "global" || routingAgentId)
         ? resolveVisibleActiveSessionRunState({
             context: params,
             requestedKey: event.sessionKey,
             canonicalKey: sessionRow.key,
             sessionId: sessionRow.sessionId,
-            ...(rowAgentId ? { agentId: rowAgentId } : {}),
-            defaultAgentId: stableOwnerAgentId,
+            ...(routingAgentId ? { agentId: routingAgentId } : {}),
+            defaultAgentId: compatibilityOwnerAgentId,
           })
         : null;
     params.broadcastToConnIds(
       "sessions.changed",
       {
         sessionKey: event.sessionKey,
-        ...(eventAgentId ? { agentId: eventAgentId } : {}),
+        agentId: eventAgentId,
         reason: event.reason,
         parentSessionKey: event.parentSessionKey,
         label: event.label,
@@ -424,7 +445,7 @@ export function createLifecycleEventBroadcastHandler(params: {
           : {}),
       },
       connIds,
-      { dropIfSlow: true },
+      broadcastOptions,
     );
   };
 }

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -24,11 +24,14 @@ import { resolveVisibleActiveSessionRunState } from "./server-methods/session-ac
 import { hasSessionChangeReceivers } from "./session-change-receivers.js";
 import { buildGatewaySessionSnapshot } from "./session-event-payload.js";
 import {
-  resolveSessionEventBroadcastScope,
+  resolvePrivateSessionEventBroadcastScope,
   resolveSessionEventAgentScope,
   type SessionEventAgentScope,
 } from "./session-request-agent.js";
-import { resolveSessionSubscriptionKey } from "./session-subscription-keys.js";
+import {
+  resolveSessionSubscriptionKey,
+  resolveSessionSubscriptionKeys,
+} from "./session-subscription-keys.js";
 import { projectSessionMessagePayload } from "./session-transcript-message.js";
 import { readSessionMessageCountAsync } from "./session-transcript-readers.js";
 import { loadGatewaySessionRow, loadGatewaySessionEntryReadOnly } from "./session-utils.js";
@@ -204,12 +207,14 @@ async function handleTranscriptUpdateBroadcast(
     return;
   }
   const [eventAgentId, routingAgentId, compatibilityOwnerAgentId] = agentScope;
-  const privateBroadcastScope = resolveSessionEventBroadcastScope(sessionKey, agentScope);
+  const privateBroadcastScope = resolvePrivateSessionEventBroadcastScope(sessionKey, agentScope);
   const connIds = new Set<string>();
   for (const connId of params.sessionEventSubscribers.getAll()) {
     connIds.add(connId);
   }
-  const broadcastKeys = privateBroadcastScope?.sessionKeys ?? [sessionKey];
+  const broadcastKeys = routingAgentId
+    ? resolveSessionSubscriptionKeys(sessionKey, routingAgentId, compatibilityOwnerAgentId)
+    : [sessionKey];
   for (const broadcastKey of broadcastKeys) {
     for (const connId of params.sessionMessageSubscribers.get(broadcastKey)) {
       connIds.add(connId);
@@ -224,7 +229,7 @@ async function handleTranscriptUpdateBroadcast(
     }
   }
   const lifecycleRevision = normalizeOptionalString(update.lifecycleRevision);
-  if (!eventAgentId && !parseAgentSessionKey(sessionKey)) {
+  if (!eventAgentId && !compatibilityOwnerAgentId && !parseAgentSessionKey(sessionKey)) {
     if (lifecycleRevision) {
       const currentLifecycleOwner = readTranscriptUpdateLifecycleOwner(update);
       if (
@@ -329,7 +334,6 @@ async function handleTranscriptUpdateBroadcast(
         ...sessionSnapshot,
       },
       connIds,
-      privateBroadcastScope,
     );
     return;
   }
@@ -343,7 +347,7 @@ async function handleTranscriptUpdateBroadcast(
     sessionSnapshot,
   });
   if (projected.payload) {
-    params.broadcastToConnIds("session.message", projected.payload, connIds, privateBroadcastScope);
+    params.broadcastToConnIds("session.message", projected.payload, connIds);
     return;
   }
 
@@ -365,7 +369,7 @@ async function handleTranscriptUpdateBroadcast(
       ...sessionSnapshot,
     },
     sessionEventConnIds,
-    { ...privateBroadcastScope, dropIfSlow: true },
+    { dropIfSlow: true },
   );
 }
 
@@ -395,9 +399,12 @@ export function createLifecycleEventBroadcastHandler(params: {
       return;
     }
     const [eventAgentId, routingAgentId, compatibilityOwnerAgentId] = agentScope;
-    const privateBroadcastScope = resolveSessionEventBroadcastScope(event.sessionKey, agentScope);
+    const privateBroadcastScope = resolvePrivateSessionEventBroadcastScope(
+      event.sessionKey,
+      agentScope,
+    );
     const broadcastOptions = { ...privateBroadcastScope, dropIfSlow: true };
-    if (!eventAgentId || !routingAgentId) {
+    if (!routingAgentId || (!eventAgentId && !compatibilityOwnerAgentId)) {
       params.broadcastToConnIds(
         "sessions.changed",
         { sessionKey: event.sessionKey, reason: event.reason, ts: Date.now() },
@@ -422,7 +429,7 @@ export function createLifecycleEventBroadcastHandler(params: {
       "sessions.changed",
       {
         sessionKey: event.sessionKey,
-        agentId: eventAgentId,
+        ...(eventAgentId ? { agentId: eventAgentId } : {}),
         reason: event.reason,
         parentSessionKey: event.parentSessionKey,
         label: event.label,
@@ -445,7 +452,7 @@ export function createLifecycleEventBroadcastHandler(params: {
           : {}),
       },
       connIds,
-      broadcastOptions,
+      { dropIfSlow: true },
     );
   };
 }

--- a/src/gateway/session-request-agent.test.ts
+++ b/src/gateway/session-request-agent.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  resolveSessionEventAgentScope,
   resolveRequestedSessionAgentId,
   tryResolveSessionCompatibilityOwnerAgentId,
 } from "./session-request-agent.js";
@@ -107,5 +108,50 @@ describe("requested session agent ownership", () => {
         "agent:retired:main",
       ),
     ).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
+  });
+});
+
+describe("session event agent scope", () => {
+  it("separates configured, retired, legacy, and explicit event ownership", () => {
+    expect(resolveSessionEventAgentScope(fixedStoreConfig("ops"), "global")).toEqual([
+      "ops",
+      "ops",
+      "ops",
+    ]);
+    expect(resolveSessionEventAgentScope(fixedStoreConfig("retired"), "global")).toEqual([
+      undefined,
+      "retired",
+      undefined,
+    ]);
+    expect(
+      resolveSessionEventAgentScope({ agents: { entries: { main: { default: true } } } }, "global"),
+    ).toEqual(["main", "main", "main"]);
+    expect(resolveSessionEventAgentScope(fixedStoreConfig("ops"), "global", "research")).toEqual([
+      "research",
+      "research",
+      "ops",
+    ]);
+  });
+
+  it("rejects conflicting qualified event identity without consulting fallbacks", () => {
+    expect(
+      resolveSessionEventAgentScope(fixedStoreConfig("ops"), "agent:research:main", "ops"),
+    ).toBeNull();
+    expect(resolveSessionEventAgentScope(fixedStoreConfig("ops"), "agent:research:main")).toEqual([
+      undefined,
+      "research",
+      undefined,
+    ]);
+    expect(
+      resolveSessionEventAgentScope(
+        fixedStoreConfig("ops"),
+        "agent:research:main",
+        undefined,
+        true,
+      ),
+    ).toEqual(["research", "research", undefined]);
+    expect(
+      resolveSessionEventAgentScope(fixedStoreConfig("ops"), "agent:retired:main", undefined, true),
+    ).toEqual([undefined, "retired", undefined]);
   });
 });

--- a/src/gateway/session-request-agent.test.ts
+++ b/src/gateway/session-request-agent.test.ts
@@ -114,7 +114,7 @@ describe("requested session agent ownership", () => {
 describe("session event agent scope", () => {
   it("separates configured, retired, legacy, and explicit event ownership", () => {
     expect(resolveSessionEventAgentScope(fixedStoreConfig("ops"), "global")).toEqual([
-      "ops",
+      undefined,
       "ops",
       "ops",
     ]);
@@ -125,7 +125,7 @@ describe("session event agent scope", () => {
     ]);
     expect(
       resolveSessionEventAgentScope({ agents: { entries: { main: { default: true } } } }, "global"),
-    ).toEqual(["main", "main", "main"]);
+    ).toEqual([undefined, "main", "main"]);
     expect(resolveSessionEventAgentScope(fixedStoreConfig("ops"), "global", "research")).toEqual([
       "research",
       "research",

--- a/src/gateway/session-request-agent.ts
+++ b/src/gateway/session-request-agent.ts
@@ -13,10 +13,67 @@ import {
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
+import { resolveSessionSubscriptionKeys } from "./session-subscription-keys.js";
 
 type RequestedSessionAgentIdResolution =
   | { ok: true; agentId: string }
   | { ok: false; error: ErrorShape };
+
+/** Public identity, private routing identity, then raw-global compatibility owner. */
+export type SessionEventAgentScope = readonly [
+  eventAgentId: string | undefined,
+  routingAgentId: string | undefined,
+  compatibilityOwnerAgentId: string | undefined,
+];
+
+/** Resolves public event identity separately from private session routing ownership. */
+export function resolveSessionEventAgentScope(
+  cfg: OpenClawConfig,
+  key: string,
+  explicitAgentId?: string,
+  publishQualifiedAgent = false,
+): SessionEventAgentScope | null {
+  const parsed = parseAgentSessionKey(key.trim());
+  const keyAgentId = parsed?.agentId ? normalizeAgentId(parsed.agentId) : undefined;
+  const explicit = explicitAgentId === undefined ? null : normalizeAgentIdStrict(explicitAgentId);
+  if (explicit !== null && !explicit.ok) {
+    return null;
+  }
+  if (explicit?.value && keyAgentId && explicit.value !== keyAgentId) {
+    return null;
+  }
+  const persistedOwner = resolvePersistedSessionStoreOwnerForKey(cfg, key);
+  const compatibilityOwnerAgentId = keyAgentId
+    ? undefined
+    : tryResolveSessionCompatibilityOwnerAgentId(cfg, key);
+  const eventAgentId =
+    explicit?.value ??
+    (publishQualifiedAgent && keyAgentId && listAgentIds(cfg).includes(keyAgentId)
+      ? keyAgentId
+      : undefined) ??
+    compatibilityOwnerAgentId;
+  const routingAgentId =
+    explicit?.value ??
+    keyAgentId ??
+    eventAgentId ??
+    (persistedOwner.kind === "retired" ? persistedOwner.agentId : undefined);
+  return [eventAgentId, routingAgentId, compatibilityOwnerAgentId];
+}
+
+/** Binds private broadcast authorization to the final canonical session key. */
+export function resolveSessionEventBroadcastScope(
+  key: string | undefined,
+  [, routingAgentId, compatibilityOwnerAgentId]: SessionEventAgentScope,
+) {
+  return routingAgentId
+    ? {
+        agentId: routingAgentId,
+        sessionKeys: key
+          ? resolveSessionSubscriptionKeys(key, routingAgentId, compatibilityOwnerAgentId)
+          : undefined,
+      }
+    : undefined;
+}
 
 /** Resolves only stable implicit ownership for unscoped session rows and active runs. */
 export function tryResolveSessionCompatibilityOwnerAgentId(

--- a/src/gateway/session-request-agent.ts
+++ b/src/gateway/session-request-agent.ts
@@ -50,27 +50,28 @@ export function resolveSessionEventAgentScope(
     explicit?.value ??
     (publishQualifiedAgent && keyAgentId && listAgentIds(cfg).includes(keyAgentId)
       ? keyAgentId
-      : undefined) ??
-    compatibilityOwnerAgentId;
+      : undefined);
   const routingAgentId =
     explicit?.value ??
     keyAgentId ??
-    eventAgentId ??
+    compatibilityOwnerAgentId ??
     (persistedOwner.kind === "retired" ? persistedOwner.agentId : undefined);
   return [eventAgentId, routingAgentId, compatibilityOwnerAgentId];
 }
 
-/** Binds private broadcast authorization to the final canonical session key. */
-export function resolveSessionEventBroadcastScope(
+/** Binds a retired unqualified owner to its private sharing scope. */
+export function resolvePrivateSessionEventBroadcastScope(
   key: string | undefined,
-  [, routingAgentId, compatibilityOwnerAgentId]: SessionEventAgentScope,
+  [eventAgentId, routingAgentId, compatibilityOwnerAgentId]: SessionEventAgentScope,
 ) {
-  return routingAgentId
+  return key &&
+    !parseAgentSessionKey(key) &&
+    !eventAgentId &&
+    routingAgentId &&
+    !compatibilityOwnerAgentId
     ? {
         agentId: routingAgentId,
-        sessionKeys: key
-          ? resolveSessionSubscriptionKeys(key, routingAgentId, compatibilityOwnerAgentId)
-          : undefined,
+        sessionKeys: resolveSessionSubscriptionKeys(key, routingAgentId),
       }
     : undefined;
 }

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -46,6 +46,59 @@ function installPageLifecycle() {
 }
 
 describe("event-driven session list refresh", () => {
+  it("refreshes the canonical roster without merging an ownerless raw-global snapshot", async () => {
+    vi.useFakeTimers();
+    const researchRow = {
+      key: "global",
+      kind: "global" as const,
+      updatedAt: 1,
+      owner: { actor: { type: "agent" as const, id: "research", label: "Research" } },
+      model: "research-model",
+      status: "done" as const,
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      return sessionsResult([researchRow], 1);
+    });
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      await sessions.refresh({ agentId: "main", force: true });
+      const before = sessions.state.result;
+      request.mockClear();
+
+      emitEvent({
+        type: "event",
+        event: "sessions.changed",
+        payload: {
+          sessionKey: "global",
+          reason: "updated",
+          updatedAt: 2,
+          owner: { actor: { type: "agent", id: "ops", label: "Ops" } },
+          model: "ops-model",
+          status: "running",
+          hasActiveRun: true,
+          activeRunIds: ["ops-run"],
+        },
+      });
+
+      expect(sessions.state.result).toBe(before);
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+      expect(request).toHaveBeenCalledExactlyOnceWith(
+        "sessions.list",
+        expect.objectContaining({ agentId: "main" }),
+      );
+      expect(sessions.state.result?.sessions).toEqual([researchRow]);
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("does not admit an active message for a session absent from the canonical roster", async () => {
     const visibleKey = "agent:main:visible";
     const unrelatedKey = "agent:main:unrelated";

--- a/ui/src/lib/sessions/list-options.test.ts
+++ b/ui/src/lib/sessions/list-options.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { SessionsListResult } from "../../api/types.ts";
+import type { SessionGoal, SessionsListResult } from "../../api/types.ts";
 import { createSessionCapability } from "./index.ts";
 
 function sessionsResult(sessions: SessionsListResult["sessions"], ts: number): SessionsListResult {
@@ -415,6 +415,17 @@ describe("session list replacement options", () => {
   });
 
   it("does not preserve another agent's raw-global row through background hydration", async () => {
+    const opsGoal: SessionGoal = {
+      schemaVersion: 1,
+      id: "goal-ops",
+      objective: "Ops only",
+      status: "active",
+      createdAt: 1,
+      updatedAt: 1,
+      tokenStart: 0,
+      tokensUsed: 0,
+      continuationTurns: 0,
+    };
     let listCallCount = 0;
     const request = vi.fn(async (method: string) => {
       if (method !== "sessions.list") {
@@ -429,7 +440,7 @@ describe("session list replacement options", () => {
                 kind: "global",
                 updatedAt: 1,
                 owner: { actor: { type: "agent", id: "ops", label: "Ops" } },
-                goal: "Ops only",
+                goal: opsGoal,
                 status: "running",
               },
             ]
@@ -454,7 +465,7 @@ describe("session list replacement options", () => {
     await sessions.refresh({ agentId: "ops", force: true });
     expect(sessions.state.result?.sessions[0]).toMatchObject({
       key: "global",
-      goal: "Ops only",
+      goal: opsGoal,
     });
 
     snapshot.assistantAgentId = "research";

--- a/ui/src/lib/sessions/list-options.test.ts
+++ b/ui/src/lib/sessions/list-options.test.ts
@@ -414,6 +414,57 @@ describe("session list replacement options", () => {
     sessions.dispose();
   });
 
+  it("does not preserve another agent's raw-global row through background hydration", async () => {
+    let listCallCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      listCallCount += 1;
+      return sessionsResult(
+        listCallCount === 1
+          ? [
+              {
+                key: "global",
+                kind: "global",
+                updatedAt: 1,
+                owner: { actor: { type: "agent", id: "ops", label: "Ops" } },
+                goal: "Ops only",
+                status: "running",
+              },
+            ]
+          : [],
+        listCallCount,
+      );
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const snapshot = {
+      client,
+      phase: "connected" as const,
+      sessionKey: "global",
+      assistantAgentId: "ops",
+      hello: null,
+    };
+    const sessions = createSessionCapability({
+      snapshot,
+      subscribe: () => () => undefined,
+      subscribeEvents: () => () => undefined,
+    });
+
+    await sessions.refresh({ agentId: "ops", force: true });
+    expect(sessions.state.result?.sessions[0]).toMatchObject({
+      key: "global",
+      goal: "Ops only",
+    });
+
+    snapshot.assistantAgentId = "research";
+    await sessions.refresh({ agentId: "research", backgroundHydrate: true, force: true });
+
+    expect(sessions.state.agentId).toBe("research");
+    expect(sessions.state.result?.sessions).toEqual([]);
+    sessions.dispose();
+  });
+
   it("does not preserve a derived title across a session reset", async () => {
     const key = "agent:main:dashboard:session";
     let listCallCount = 0;

--- a/ui/src/lib/sessions/reconcile.test.ts
+++ b/ui/src/lib/sessions/reconcile.test.ts
@@ -343,6 +343,35 @@ test("ownerless raw-global events invalidate without contaminating the selected 
   expect(invalidated.result).toBe(result);
   expect(invalidated.row).toBeUndefined();
 
+  const mainResult = buildResult([{ key: "main", kind: "direct", updatedAt: 1, status: "done" }]);
+  const invalidatedMain = reconcileSessionChanged(
+    mainResult,
+    { sessionKey: "main", reason: "delete", ts: 2 },
+    { resultAgentId: "main", selectedGlobalAgentId: "main" },
+  );
+  expect(invalidatedMain.applied).toBe(false);
+  expect(invalidatedMain.result).toBe(mainResult);
+
+  const ownerlessMain = reconcileSessionChanged(
+    mainResult,
+    {
+      sessionKey: "main",
+      activeRunIds: ["main-run"],
+      hasActiveRun: true,
+      status: "running",
+      updatedAt: 2,
+    },
+    { resultAgentId: "main", selectedGlobalAgentId: "main" },
+  );
+  expect(ownerlessMain.applied).toBe(true);
+  expect(ownerlessMain.row).toMatchObject({
+    key: "main",
+    activeRunIds: ["main-run"],
+    hasActiveRun: true,
+    status: "running",
+  });
+  expect(ownerlessMain.row).not.toHaveProperty("agentId");
+
   const explicit = reconcileSessionChanged(
     result,
     { ...payload, agentId: "research" },

--- a/ui/src/lib/sessions/reconcile.test.ts
+++ b/ui/src/lib/sessions/reconcile.test.ts
@@ -308,6 +308,58 @@ test("sessions.changed applies reassignment and invalidates the complete owner f
   expect(reconciled.result?.owners).toBeUndefined();
 });
 
+test("ownerless raw-global events invalidate without contaminating the selected agent row", () => {
+  const researchOwner = { type: "agent" as const, id: "research", label: "Research" };
+  const result = buildResult([
+    {
+      key: "global",
+      kind: "global",
+      updatedAt: 1,
+      owner: { actor: researchOwner },
+      model: "research-model",
+      status: "done",
+      hasActiveRun: false,
+      activeRunIds: [],
+    },
+  ]);
+  const payload = {
+    sessionKey: "global",
+    reason: "updated",
+    updatedAt: 2,
+    owner: { actor: { type: "agent", id: "ops", label: "Ops" } },
+    model: "ops-model",
+    status: "running",
+    hasActiveRun: true,
+    activeRunIds: ["ops-run"],
+    inputTokens: 42,
+  };
+
+  const invalidated = reconcileSessionChanged(result, payload, {
+    resultAgentId: "research",
+    selectedGlobalAgentId: "research",
+  });
+
+  expect(invalidated.applied).toBe(false);
+  expect(invalidated.result).toBe(result);
+  expect(invalidated.row).toBeUndefined();
+
+  const explicit = reconcileSessionChanged(
+    result,
+    { ...payload, agentId: "research" },
+    {
+      resultAgentId: "research",
+      selectedGlobalAgentId: "research",
+    },
+  );
+  expect(explicit.applied).toBe(true);
+  expect(explicit.row).toMatchObject({
+    owner: { actor: { id: "ops" } },
+    model: "ops-model",
+    status: "running",
+    activeRunIds: ["ops-run"],
+  });
+});
+
 describe("reconcileSessionChanged", () => {
   it("drops a cleared category from the merged row", () => {
     const key = "agent:main:discord:channel:1";

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -371,6 +371,12 @@ export function reconcileSessionChanged(
     return { applied: false, result };
   }
   const { event, source, key, reason } = parsed;
+  // Unqualified rows need an outer agent identity. Without it, the payload can
+  // only invalidate the canonical roster; optimistically merging would assign
+  // a private fallback owner's state to whichever global agent is selected.
+  if (!parsed.agentId && !parseAgentSessionKey(key)) {
+    return { applied: false, key, agentId: null, result };
+  }
   if (reason === "delete" && !result) {
     return {
       applied: true,

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -371,10 +371,26 @@ export function reconcileSessionChanged(
     return { applied: false, result };
   }
   const { event, source, key, reason } = parsed;
-  // Unqualified rows need an outer agent identity. Without it, the payload can
-  // only invalidate the canonical roster; optimistically merging would assign
-  // a private fallback owner's state to whichever global agent is selected.
-  if (!parsed.agentId && !parseAgentSessionKey(key)) {
+  const {
+    agentId: _agentId,
+    clientRunId: _clientRunId,
+    compacted: _compacted,
+    key: _key,
+    phase: _phase,
+    reason: _reason,
+    runId: _runId,
+    session: _session,
+    sessionKey: _sessionKey,
+    ts: _ts,
+    ...rowFields
+  } = source;
+  // Ownerless raw global and projection-free legacy aliases only invalidate the
+  // canonical roster; optimistic merging could apply a retired private owner's
+  // lifecycle event to whichever agent is currently selected.
+  if (
+    !parsed.agentId &&
+    (isUiGlobalSessionKey(key) || (!parseAgentSessionKey(key) && !Object.keys(rowFields).length))
+  ) {
     return { applied: false, key, agentId: null, result };
   }
   if (reason === "delete" && !result) {
@@ -415,19 +431,6 @@ export function reconcileSessionChanged(
       deletedKey: existing.key,
     };
   }
-  const {
-    agentId: _agentId,
-    clientRunId: _clientRunId,
-    compacted: _compacted,
-    key: _key,
-    phase: _phase,
-    reason: _reason,
-    runId: _runId,
-    session: _session,
-    sessionKey: _sessionKey,
-    ts: _ts,
-    ...rowFields
-  } = source;
   // The gateway wire folds cron/spawn-child into "direct" before projection
   // (session-utils-row.ts, #115299); cron detection is isCronSessionKey.
   const kind =

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -12,7 +12,6 @@ import type {
   SessionState,
 } from "./session-capability.ts";
 import {
-  areUiSessionKeysEquivalent,
   normalizeAgentId,
   parseAgentSessionKey,
   resolveUiSelectedGlobalAgentId,
@@ -103,26 +102,20 @@ function preserveCurrentSessionRow(
   if (!currentKey) {
     return result;
   }
+  const parsedAgentId = parseAgentSessionKey(currentKey)?.agentId;
   const currentAgentId = normalizeAgentId(
-    parseAgentSessionKey(currentKey)?.agentId ?? resolveUiSelectedGlobalAgentId(snapshot),
+    parsedAgentId ?? resolveUiSelectedGlobalAgentId(snapshot),
   );
-  const exactPreviousCurrentRow = state.result?.sessions.find((row) =>
-    areUiSessionKeysEquivalent(row.key, currentKey),
-  );
-  const previousCurrentRow =
-    exactPreviousCurrentRow ??
-    (state.agentId === currentAgentId
-      ? state.result?.sessions.find((row) =>
-          uiSessionRowMatchesSelectedChat(snapshot, row.key, currentKey),
-        )
-      : undefined);
-  const nextContainsCurrentRow = exactPreviousCurrentRow
-    ? result.sessions.some((row) => areUiSessionKeysEquivalent(row.key, currentKey))
-    : result.sessions.some((row) => uiSessionRowMatchesSelectedChat(snapshot, row.key, currentKey));
+  if (!parsedAgentId && normalizeAgentId(state.agentId ?? "") !== currentAgentId) {
+    return result;
+  }
+  const matchesCurrent = (row: GatewaySessionRow) =>
+    uiSessionRowMatchesSelectedChat(snapshot, row.key, currentKey);
+  const previousCurrentRow = state.result?.sessions.find(matchesCurrent);
   if (
     previousCurrentRow &&
     (backgroundHydrate || previousCurrentRow.archived === true) &&
-    !nextContainsCurrentRow
+    !result.sessions.some(matchesCurrent)
   ) {
     const sessions = [...result.sessions, previousCurrentRow];
     return { ...result, count: sessions.length, sessions };


### PR DESCRIPTION
## What Problem This Solves

Fixes a P1 session-privacy issue where queued or delayed Gateway session events could lose their authoritative agent owner. An unqualified session key could then be resolved against a newer compatibility owner after the event was admitted, allowing a retired owner's update or queued marker to refresh another agent's roster or message surface.

## Why This Change Was Made

Session events now capture one authoritative event, routing, and compatibility-owner scope before entering debounce or asynchronous transcript work. That same scope owns row lookup, active-run projection, subscription keys, and the final broadcast; unresolved or stale owner state is dropped instead of being widened. The Control UI also preserves owner-qualified reconciliation so sparse refreshes cannot replace another agent's session.

The production increase is intentional: the owner tuple and its validation must cross both the Gateway's queued-event boundary and the UI's reconciliation boundary. Keeping those facts explicit avoids re-deriving authority from a session key after an await or owner transition.

## User Impact

Operators with multiple agents no longer risk seeing one agent's retired or delayed session update refresh another agent's roster or message view. Legitimate global compatibility sessions continue to route through their captured owner, while ambiguous events fail closed. No configuration or migration is required; existing session keys and storage remain unchanged.

## Evidence

- Pre-fix reproductions cover a retired owner and a queued marker crossing an owner transition.
- Gateway/session owner suites: 125 passing.
- Broader session lifecycle and UI reconciliation suites: 97 passing.
- Independent security verification plus maintainer pre-commit and committed-branch reviews: clean; secret scan found no findings.
- Production delta: +83 lines across the Gateway and UI owner boundary; regression and sibling coverage are included in the 11-file change.

A standalone browser build could not provide additional local proof because the current baseline checkout is missing `@panzoom/panzoom`, before this patch's code is reached. The focused Gateway/UI owner suites are green, and fresh exact-head CI is the authoritative full-build gate.
