### PR TITLE
refactor(routing): share account ID canonical cache

### DIFF
--- a/src/routing/account-id.ts
+++ b/src/routing/account-id.ts
@@ -13,8 +13,7 @@ const LEADING_DASH_RE = /^-+/;
 const TRAILING_DASH_RE = /-+$/;
 const ACCOUNT_ID_CACHE_MAX = 512;
 
-const normalizeAccountIdCache = new Map<string, string>();
-const normalizeOptionalAccountIdCache = new Map<string, string | undefined>();
+const normalizedAccountIdCache = new Map<string, string | undefined>();
 
 function canonicalizeAccountId(value: string): string {
   const normalized = normalizeLowercaseStringOrEmpty(value);
@@ -36,18 +35,24 @@ function normalizeCanonicalAccountId(value: string): string | undefined {
   return canonical;
 }
 
+function resolveCachedCanonicalAccountId(value: string): string | undefined {
+  if (normalizedAccountIdCache.has(value)) {
+    return normalizedAccountIdCache.get(value);
+  }
+  const normalized = normalizeCanonicalAccountId(value);
+  normalizedAccountIdCache.set(value, normalized);
+  // Bounded FIFO-ish cache avoids unbounded growth from user/channel input
+  // while keeping hot account ids cheap during routing.
+  pruneMapToMaxSize(normalizedAccountIdCache, ACCOUNT_ID_CACHE_MAX);
+  return normalized;
+}
+
 export function normalizeAccountId(value: string | undefined | null): string {
   const trimmed = (value ?? "").trim();
   if (!trimmed) {
     return DEFAULT_ACCOUNT_ID;
   }
-  const cached = normalizeAccountIdCache.get(trimmed);
-  if (cached) {
-    return cached;
-  }
-  const normalized = normalizeCanonicalAccountId(trimmed) || DEFAULT_ACCOUNT_ID;
-  setNormalizeCache(normalizeAccountIdCache, trimmed, normalized);
-  return normalized;
+  return resolveCachedCanonicalAccountId(trimmed) ?? DEFAULT_ACCOUNT_ID;
 }
 
 // Optional variant for config fields where absence is meaningful. Invalid ids
@@ -57,17 +62,5 @@ export function normalizeOptionalAccountId(value: string | undefined | null): st
   if (!trimmed) {
     return undefined;
   }
-  if (normalizeOptionalAccountIdCache.has(trimmed)) {
-    return normalizeOptionalAccountIdCache.get(trimmed);
-  }
-  const normalized = normalizeCanonicalAccountId(trimmed) || undefined;
-  setNormalizeCache(normalizeOptionalAccountIdCache, trimmed, normalized);
-  return normalized;
-}
-
-function setNormalizeCache<T>(cache: Map<string, T>, key: string, value: T): void {
-  cache.set(key, value);
-  // Bounded FIFO-ish cache avoids unbounded growth from user/channel input
-  // while keeping hot account ids cheap during routing.
-  pruneMapToMaxSize(cache, ACCOUNT_ID_CACHE_MAX);
+  return resolveCachedCanonicalAccountId(trimmed);
 }


### PR DESCRIPTION
## What Problem This Solves

Account ID normalization kept two independent bounded caches for the same canonical account-ID fact. That duplicated cache state, lookup branches, and writes on a routing hot path.

## Why This Change Was Made

Cache the shared canonical result once, then let the existing required and optional APIs apply their unchanged `"default"` versus `undefined` fallbacks. This preserves all account identifiers and routing behavior while removing one cache and the generic cache-write path.

Alternatives considered: keeping API-specific caches preserves duplicate state; caching only final API results retains the original ownership split. The canonicalizer is the narrow existing owner of the shared fact.

Production LOC: +15/-22 (net -7) | Tests: +0/-0

Exact reviewed head: `9c1a39bdcbf2c629833989c0a9a61b1a931cef90`

## User Impact

No user-visible behavior change. Account routing keeps the same normalization, invalid-ID handling, defaults, identifiers, and fallback semantics with one fewer internal cache.

## Evidence

- `node scripts/run-vitest.mjs src/routing/account-id.test.ts` — 15 tests passed.
- `node scripts/check-changed.mjs -- src/routing/account-id.ts` — core/coreTests changed-file plan passed, including formatting, lint, typechecks, dead exports, import cycles, and repository guards.
- Structured autoreview — clean, no accepted/actionable findings.
- Separate exact-head read-only Codex review — `CLEAN`.
- `git diff --check` — passed.
