### PR TITLE
fix(ci): restore Control UI startup CSS ceiling

### DIFF
--- a/scripts/check-control-ui-performance.mts
+++ b/scripts/check-control-ui-performance.mts
@@ -29,9 +29,9 @@ const controlUiPerformanceBudgets = {
   // 350 KiB maintainer-approved by Vyctor 2026-08-11 for #121686;
   // #121734 left main 6 B below the prior 319 KiB hard ceiling.
   startupJsGzipBytes: 350 * KIB,
-  // The Absolutely theme and Inbox update styling landed concurrently within
-  // 45 KiB alone, but their merged main tree is 46,092 B. Keep 500 B headroom.
-  startupCssGzipBytes: 45 * KIB + 512,
+  // 45 KiB CSS ceilings maintainer-approved 2026-07 alongside the interleaved
+  // sidebar zone styling; headroom over the ~36.5 KiB post-diet baseline.
+  startupCssGzipBytes: 45 * KIB,
   largestJsGzipBytes: 215 * KIB,
   // Composer multiline surface (stack #124301) legitimately grew boot CSS;
   // operator decision 2026-08-25 rejected boot splitting due to precedence risk.


### PR DESCRIPTION
Related: #130015, #130027, #130032

## What Problem This Solves

Resolves a problem where the Control UI startup CSS hard gate remained temporarily relaxed to 46,592 B after behavior-preserving source cleanups had already brought the production bundle back below its original 46,080-B ceiling.

## Why This Change Was Made

Restores the existing 45 KiB startup CSS ceiling and its original ownership comment after #130027 and #130032 removed stale startup selectors. It does not raise or rebaseline a budget, alter compression, or change Control UI behavior.

Tooling LOC: +3/-3 (net 0) | Tests: +0/-0

## User Impact

Contributors regain the original deterministic growth guard for startup CSS. There is no rendered UI, accessibility, interaction, theme, or security behavior change.

## Evidence

- Before source cleanup, exact base `1605dbd3efef1c10da95c4a9bbb51a19a9d07865` built 46,092 B of startup CSS against the 46,080-B ceiling and failed both `build-artifacts` and `checks-node-compact-small-18`.
- #130027 landed the first behavior-preserving stale-selector cleanup as `9b3445de4d1858285464ecdf0bae936afbf044e4`; #130032 landed the remaining stale approval selector cleanup as `33a24b6d8ea200be0bd2fbcecdd6b80443b57171`.
- Exact head `c56e1d83e820c53e58bbf00304c2320401324548`, Node 24.19: `pnpm ui:build` passes with startup CSS **46,058 B / 46,080 B**, 22 B headroom, and no violations.
- `pnpm test test/scripts/control-ui-performance.test.ts`: 13/13 passed on Node 24.19.
- `node scripts/check-changed.mjs -- scripts/check-control-ui-performance.mts`: all selected tooling, format, typecheck, lint, dependency, and guard lanes passed.
- Test audit: no test added. A literal assertion of the configured ceiling would duplicate the source contract; the production build plus existing evaluator boundary tests provide stronger proof.
- Deslop: clean; this is the exact inverse of #130015's temporary comment/constant exemption.
- Structured Codex autoreview: clean, 0.99.
- Separate exact-head read-only Codex review: `CLEAN`; it verified 46,080 B passes, 46,081 B fails, and the canonical UI build invokes this validator.
- DOM/a11y/E2E: not applicable because this final diff changes no UI source or runtime behavior.
