### PR TITLE
fix(tlon): keep Urbit SSE streams working when data lines omit the space

### DIFF
--- a/extensions/tlon/src/urbit/sse-client.connect-fail.transport.test.ts
+++ b/extensions/tlon/src/urbit/sse-client.connect-fail.transport.test.ts
@@ -153,4 +153,53 @@ describe("UrbitSSEClient connect-fail body cleanup", () => {
       });
     }
   });
+
+  it("delivers no-space data frames across a real HTTP stream to a subscribed handler", async () => {
+    // The SSE spec makes the space after "data:" optional. Prove end-to-end
+    // that a ship emitting `data:{...}` (no space) still reaches the caller.
+    let resolveEvent: ((value: unknown) => void) | undefined;
+    const delivered = new Promise<unknown>((resolve) => {
+      resolveEvent = resolve;
+    });
+    let resolveStreamClosed: (() => void) | undefined;
+    const streamClosed = new Promise<void>((resolve) => {
+      resolveStreamClosed = resolve;
+    });
+    const server = createServer((request, response) => {
+      if (request.method === "GET") {
+        request.socket.once("close", () => resolveStreamClosed?.());
+        response.writeHead(200, { "Content-Type": "text/event-stream" });
+        response.write('id: 1\ndata:{"id":1,"json":{"message":"delivered"}}\n\n');
+        return;
+      }
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.write('{"ok":true');
+    });
+    const baseUrl = await listen(server);
+    const client = new UrbitSSEClient(baseUrl, "urbauth-~zod=proof", {
+      autoReconnect: false,
+      ship: "zod",
+      ssrfPolicy: { allowPrivateNetwork: true },
+      lookupFn: lookupLoopback,
+    });
+
+    try {
+      await client.subscribe({
+        app: "chat",
+        path: "/inbox",
+        event: (value) => resolveEvent?.(value),
+      });
+      await client.connect();
+
+      await expect(delivered).resolves.toEqual({ message: "delivered" });
+      expect(client.streamRelease).toBeTypeOf("function");
+
+      await client.close();
+      await expect(streamClosed).resolves.toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
 });

--- a/extensions/tlon/src/urbit/sse-client.connect-fail.transport.test.ts
+++ b/extensions/tlon/src/urbit/sse-client.connect-fail.transport.test.ts
@@ -103,7 +103,7 @@ describe("UrbitSSEClient connect-fail body cleanup", () => {
     }
   });
 
-  it("keeps a successful event stream live until its owner closes the client", async () => {
+  it("keeps a no-space event stream live until its owner closes the client", async () => {
     let resolveEvent: ((value: unknown) => void) | undefined;
     const delivered = new Promise<unknown>((resolve) => {
       resolveEvent = resolve;
@@ -118,7 +118,7 @@ describe("UrbitSSEClient connect-fail body cleanup", () => {
         streamSocket = request.socket;
         streamSocket.once("close", () => resolveStreamClosed?.());
         response.writeHead(200, { "Content-Type": "text/event-stream" });
-        response.write('id: 1\ndata: {"id":1,"json":{"message":"delivered"}}\n\n');
+        response.write('id:1\ndata:{"id":1,"json":{"message":"delivered"}}\n\n');
         return;
       }
       response.writeHead(200, { "Content-Type": "application/json" });
@@ -147,55 +147,6 @@ describe("UrbitSSEClient connect-fail body cleanup", () => {
       await client.close();
       await expect(streamClosed).resolves.toBeUndefined();
       expect(client.streamRelease).toBeNull();
-    } finally {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
-  });
-
-  it("delivers no-space data frames across a real HTTP stream to a subscribed handler", async () => {
-    // The SSE spec makes the space after "data:" optional. Prove end-to-end
-    // that a ship emitting `data:{...}` (no space) still reaches the caller.
-    let resolveEvent: ((value: unknown) => void) | undefined;
-    const delivered = new Promise<unknown>((resolve) => {
-      resolveEvent = resolve;
-    });
-    let resolveStreamClosed: (() => void) | undefined;
-    const streamClosed = new Promise<void>((resolve) => {
-      resolveStreamClosed = resolve;
-    });
-    const server = createServer((request, response) => {
-      if (request.method === "GET") {
-        request.socket.once("close", () => resolveStreamClosed?.());
-        response.writeHead(200, { "Content-Type": "text/event-stream" });
-        response.write('id: 1\ndata:{"id":1,"json":{"message":"delivered"}}\n\n');
-        return;
-      }
-      response.writeHead(200, { "Content-Type": "application/json" });
-      response.write('{"ok":true');
-    });
-    const baseUrl = await listen(server);
-    const client = new UrbitSSEClient(baseUrl, "urbauth-~zod=proof", {
-      autoReconnect: false,
-      ship: "zod",
-      ssrfPolicy: { allowPrivateNetwork: true },
-      lookupFn: lookupLoopback,
-    });
-
-    try {
-      await client.subscribe({
-        app: "chat",
-        path: "/inbox",
-        event: (value) => resolveEvent?.(value),
-      });
-      await client.connect();
-
-      await expect(delivered).resolves.toEqual({ message: "delivered" });
-      expect(client.streamRelease).toBeTypeOf("function");
-
-      await client.close();
-      await expect(streamClosed).resolves.toBeUndefined();
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));

--- a/extensions/tlon/src/urbit/sse-client.test.ts
+++ b/extensions/tlon/src/urbit/sse-client.test.ts
@@ -551,6 +551,26 @@ describe("UrbitSSEClient", () => {
       expect(mockUrbitFetch).not.toHaveBeenCalled();
     });
 
+    it("accepts data lines without a space after the colon", async () => {
+      // The SSE spec makes the space after "data:" optional; a server that
+      // emits `data:{...}` must not have its events silently dropped.
+      const mockUrbitFetch = vi.mocked(urbitFetch);
+      mockUrbitFetch.mockResolvedValue({
+        response: { ok: true, status: 204 } as unknown as Response,
+        finalUrl: "https://example.com",
+        release: vi.fn().mockResolvedValue(undefined),
+      });
+      const handler = vi.fn();
+      const client = new UrbitSSEClient("https://example.com", "urbauth-~zod=123");
+      client.eventHandlers.set(1, { event: handler });
+
+      await expect(
+        client.processEvent('id: 20\ndata:{"id":1,"json":{"ok":true}}'),
+      ).resolves.toBeUndefined();
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0]?.[0]).toEqual({ ok: true });
+    });
+
     it("does not advance the ack watermark when the ack request fails", async () => {
       const mockUrbitFetch = vi.mocked(urbitFetch);
       mockUrbitFetch.mockResolvedValue({

--- a/extensions/tlon/src/urbit/sse-client.test.ts
+++ b/extensions/tlon/src/urbit/sse-client.test.ts
@@ -551,9 +551,7 @@ describe("UrbitSSEClient", () => {
       expect(mockUrbitFetch).not.toHaveBeenCalled();
     });
 
-    it("accepts data lines without a space after the colon", async () => {
-      // The SSE spec makes the space after "data:" optional; a server that
-      // emits `data:{...}` must not have its events silently dropped.
+    it("accepts data and id lines without a space after the colon", async () => {
       const mockUrbitFetch = vi.mocked(urbitFetch);
       mockUrbitFetch.mockResolvedValue({
         response: { ok: true, status: 204 } as unknown as Response,
@@ -565,10 +563,15 @@ describe("UrbitSSEClient", () => {
       client.eventHandlers.set(1, { event: handler });
 
       await expect(
-        client.processEvent('id: 20\ndata:{"id":1,"json":{"ok":true}}'),
+        client.processEvent('id:20\ndata:{"id":1,"json":{"ok":true}}'),
       ).resolves.toBeUndefined();
       expect(handler).toHaveBeenCalledTimes(1);
       expect(handler.mock.calls[0]?.[0]).toEqual({ ok: true });
+      const body = mockUrbitFetch.mock.calls[0]?.[0].init?.body;
+      if (typeof body !== "string") {
+        throw new Error("Expected string ACK request body");
+      }
+      expect(JSON.parse(body)).toEqual([{ id: expect.any(Number), action: "ack", "event-id": 20 }]);
     });
 
     it("does not advance the ack watermark when the ack request fails", async () => {

--- a/extensions/tlon/src/urbit/sse-client.ts
+++ b/extensions/tlon/src/urbit/sse-client.ts
@@ -351,11 +351,10 @@ export class UrbitSSEClient {
     let eventId: number | null = null;
 
     for (const line of lines) {
-      if (line.startsWith("id: ")) {
-        eventId = parseUrbitSseEventId(line.slice(4));
+      // SSE permits both `field:value` and `field: value`; parse them identically.
+      if (line.startsWith("id:")) {
+        eventId = parseUrbitSseEventId(line.slice("id:".length).trim());
       }
-      // The SSE spec makes the space after "data:" optional; accept both
-      // `data:{...}` and `data: {...}`, mirroring the gateway proxy stream.
       if (line.startsWith("data:")) {
         data = line.slice("data:".length).trim();
       }

--- a/extensions/tlon/src/urbit/sse-client.ts
+++ b/extensions/tlon/src/urbit/sse-client.ts
@@ -354,8 +354,10 @@ export class UrbitSSEClient {
       if (line.startsWith("id: ")) {
         eventId = parseUrbitSseEventId(line.slice(4));
       }
-      if (line.startsWith("data: ")) {
-        data = line.slice(6);
+      // The SSE spec makes the space after "data:" optional; accept both
+      // `data:{...}` and `data: {...}`, mirroring the gateway proxy stream.
+      if (line.startsWith("data:")) {
+        data = line.slice("data:".length).trim();
       }
     }
 


### PR DESCRIPTION
## What Problem This Solves

The Tlon Urbit Server-Sent Events (SSE) client accepted only `data: ` and `id: ` fields with a space after the colon. The SSE standard makes that one space optional.

A legal `data:{...}` field left `data` empty, so `processEvent` returned before dispatch. Messages, reactions, notifications, and settings events could disappear without an error.

A legal `id:20` field left `eventId` empty, so the client dispatched the payload but did not advance or send its acknowledgement.

## Root Cause

`extensions/tlon/src/urbit/sse-client.ts` matched the full spaced prefixes instead of the SSE field names. The parser rejected valid no-space values before its dispatch and acknowledgement owner boundary.

## Fix

- Match `id:` and `data:` regardless of the optional space.
- Trim the parsed field value before the existing Urbit payload and event-ID parsers.
- Keep the repair inside the Tlon-owned SSE parser.
- Reuse the existing loopback stream test with legal no-space fields.

## Evidence

Exact current-main reproduction at `d36d90ba62d28fb412ef7e922bb3fed93c563b91`:

```
node scripts/run-vitest.mjs extensions/tlon/src/urbit/sse-client.test.ts -t 'accepts data and id lines without a space after the colon'

Test Files  1 failed (1)
Tests       1 failed | 31 skipped (32)
AssertionError: expected handler to be called 1 time, but got 0 times
```

The full pre-fix two-file run also failed both parser assertions and timed out after 120 seconds in the loopback transport test because the handler never received the no-space frame.

Exact repaired-head proof:

```
node scripts/run-vitest.mjs extensions/tlon/src/urbit/sse-client.test.ts extensions/tlon/src/urbit/sse-client.connect-fail.transport.test.ts

Test Files  2 passed (2)
Tests       37 passed (37)
```

The parser test sends `id:20\ndata:{...}`, observes handler delivery, and checks the outgoing ACK body for `event-id: 20`. The loopback test sends `id:1\ndata:{...}` over a real HTTP event stream, observes delivery, keeps the stream live, and verifies owner-driven close.

Production delta: +1 net line. Test delta: +23 net lines.

## Related

Fixes #130047

🤖 Generated with co-mind

## Landing Gates

- Exact-head `openclaw/ci-gate`: passed in run `33044403055`.
- Local ClawSweeper on `b913f842da1f73c4ce449c5b0f4f8811097c7b77`: patch correct, zero findings, security cleared, no maintainer decision, zero rank-up moves.
- Telegram doctor: `ok: true`.
- Canonical Telegram userbot: passed with a fresh exact-head gateway and a dedicated QA user lease.

Telegram command, broker secrets omitted:

```
node "$TELEGRAM_E2E_SKILL_DIR/scripts/run-mock-sut-user-e2e.mjs" \
  --dm --timeout-ms 25000 --gateway-port 20879 --mock-port 20882 \
  --text 'Please answer with OPENCLAW_E2E_OK only.' \
  --record <proof>/events.ndjson --output <proof>/summary.json
```

The complete TDLib timeline recorded the user message, two SUT typing events, and the `OPENCLAW_E2E_OK` SUT reply. The provider log recorded one `POST /v1/responses` request. The gateway log recorded ready state and clean shutdown.

This Telegram direct-message smoke is collateral regression proof only. The Tlon Urbit SSE parser change is not Telegram-visible, so Telegram cannot exercise the changed behavior.
