### PR TITLE
feat(cron): link chat notifications to Control UI run inspection

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -346,6 +346,11 @@ Agent-turn jobs default to the creating conversation when the create request car
 | `webhook`  | POST finished event payload to a URL                                |
 | `none`     | No runner fallback delivery                                         |
 
+When `gateway.publicOrigin` is configured and the Control UI is enabled, chat
+notifications include an `Inspect` link into the Control UI. Command and script
+completion announcements open the automation run; isolated agent announcements
+open the run's session.
+
 For a `current` job using `announce` (the default), the final assistant result is a first-class session completion, not a WebChat-specific outbound message. OpenClaw waits for active turns in the creation-bound conversation, verifies that the same session generation still owns the key, and commits the result through the canonical transcript writer with cron job/run provenance and a job/run idempotency key. A retry cannot append the same result twice.
 
 WebChat receives the committed `session.message` event immediately. The same assistant result comes from `chat.history` after a refresh or reconnect; no follow-up user message is required. Delivery is successful only after that transcript/event commit succeeds.
@@ -407,7 +412,7 @@ Failure notification routes resolve in this order:
 
 A required completion-delivery failure is distinct from an execution failure: a run can record `status: "ok"` with `completionStatus: "failed"`. It does not increment the execution-failure streak or backoff. The scheduler may notify immediately only through a resolved alternate failure destination; it never retries the already-failed primary route.
 
-Chat failure notifications include the run start time in the agent's configured user timezone. Webhook message text stays stable; integrations can read the same instant from the structured `runAtMs` field.
+Chat failure notifications include the run start time in the agent's configured user timezone. When `gateway.publicOrigin` is configured and the Control UI is enabled, they also include an `Inspect` link to the automation run. Webhook message text stays stable; integrations can read the same instant from the structured `runAtMs` field and construct their own links.
 Chat notifications show normalized failure causes or allowlisted producer facts for known command and script failures. Arbitrary commands, paths, provider bodies, secrets, delivery errors, skip reasons, diagnostics, and stack/error text remain in automation history. Failure webhooks retain the structured raw error for diagnostic integrations.
 
 The scheduler also provides an unconditional safety backstop. A time-based recurring job is auto-disabled after 10 consecutive execution failures; a successful run resets that streak. On the terminal failure, the richer auto-disable notification replaces the regular threshold alert. Repeated schedule-computation failures auto-disable after 3 errors. The job records `state.autoDisabled.reason` as `consecutive-failures` or `schedule-errors`, and the owning agent receives a notification with a safe cause and recovery command. Raw errors stay in automation history. After fixing the cause, run `openclaw automations enable <jobId>`; enabling clears the recorded reason and failure streaks. Because disabled jobs are hidden by the default list, use `openclaw automations list --all` to inspect them.

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -177,6 +177,10 @@ When a task reaches a terminal state, OpenClaw notifies you. There are two deliv
 
 **Session-queued delivery** - if direct delivery fails or no origin is set, the update is queued as a system event in the requester's session and surfaces on the next heartbeat.
 
+When `gateway.publicOrigin` is configured and the Control UI is enabled,
+direct channel notifications include an `Inspect` link to the task's own
+session. Session-queued notifications do not include this link.
+
 Durable subagent completion handoffs retry for up to 30 minutes with capped
 exponential backoff. A queued handoff is not reported as delivered until the
 queue settles. If delivery reaches its deadline or fails permanently, the task

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -806,9 +806,9 @@ Gateway or node host and check `openclaw nodes pending` again.
   loopback hosts (`localhost`, `127.0.0.1`, or `[::1]`) during local development.
   Per-requester MCP OAuth requires this value and uses
   `<publicOrigin>/oauth/mcp/callback` as its callback URL.
-  Slack session-card actions and plugin-generated viewer links also use this
-  origin. Set `gateway.controlUi.basePath` separately when the Control UI is
-  served below a reverse-proxy path prefix.
+  Slack session-card actions, plugin-generated viewer links, and chat deep links
+  into the Control UI also use this origin. Set `gateway.controlUi.basePath`
+  separately when the Control UI is served below a reverse-proxy path prefix.
 - `bind`: `auto`, `loopback` (default), `lan` (`0.0.0.0`), `tailnet` (Tailscale IPv4 when available, otherwise loopback), or `custom` (one IPv4 address). A resolved `tailnet` address and any `custom` address other than `127.0.0.1` or `0.0.0.0` require `127.0.0.1` on the same port for same-host clients; startup fails if either listener cannot bind. Non-loopback exposure remains limited to the selected interface.
 - **Legacy bind aliases**: use bind mode values in `gateway.bind` (`auto`, `loopback`, `lan`, `tailnet`, `custom`), not host aliases (`0.0.0.0`, `127.0.0.1`, `localhost`, `::`, `::1`).
 - **Docker note**: the default `loopback` bind listens on `127.0.0.1` inside the container. With Docker bridge networking (`-p 18789:18789`), traffic arrives on `eth0`, so the gateway is unreachable. Use `--network host`, or set `bind: "lan"` (or `bind: "custom"` with `customBindHost: "0.0.0.0"`) to listen on all interfaces.

--- a/src/config/control-ui-link-base.test.ts
+++ b/src/config/control-ui-link-base.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveControlUiSessionLinkBase } from "./control-ui-link-base.js";
+import {
+  resolveControlUiAutomationRunUrl,
+  resolveControlUiSessionLinkBase,
+} from "./control-ui-link-base.js";
 
 describe("resolveControlUiSessionLinkBase", () => {
   it("omits session links without a public Gateway origin", () => {
@@ -55,5 +58,47 @@ describe("resolveControlUiSessionLinkBase", () => {
     const publicOrigin = `https://${"a.".repeat(91)}example.com`;
     expect(publicOrigin).toHaveLength(201);
     expect(resolveControlUiSessionLinkBase({ gateway: { publicOrigin } })).toBeUndefined();
+  });
+});
+
+describe("resolveControlUiAutomationRunUrl", () => {
+  it.each([
+    { name: "without a public Gateway origin", gateway: {} },
+    {
+      name: "when the Control UI is disabled",
+      gateway: {
+        publicOrigin: "https://gateway.example.com",
+        controlUi: { enabled: false },
+      },
+    },
+  ])("omits automation links $name", ({ gateway }) => {
+    expect(
+      resolveControlUiAutomationRunUrl({ gateway }, { jobId: "daily-report" }),
+    ).toBeUndefined();
+  });
+
+  it("joins the normalized Control UI base path and encodes job and run identifiers", () => {
+    expect(
+      resolveControlUiAutomationRunUrl(
+        {
+          gateway: {
+            publicOrigin: "https://gateway.example.com",
+            controlUi: { basePath: " /control/// " },
+          },
+        },
+        { jobId: "job /?&", runId: "cron:job /?&:123" },
+      ),
+    ).toBe(
+      "https://gateway.example.com/control/automations?job=job+%2F%3F%26&run=cron%3Ajob+%2F%3F%26%3A123",
+    );
+  });
+
+  it("omits the run query parameter when no run identifier is available", () => {
+    expect(
+      resolveControlUiAutomationRunUrl(
+        { gateway: { publicOrigin: "https://gateway.example.com" } },
+        { jobId: "daily-report" },
+      ),
+    ).toBe("https://gateway.example.com/automations?job=daily-report");
   });
 });

--- a/src/config/control-ui-link-base.ts
+++ b/src/config/control-ui-link-base.ts
@@ -36,6 +36,21 @@ export function resolveControlUiSessionLinkBase(cfg: ControlUiLinkConfig): strin
   return sessionLinkBase.length <= 200 ? sessionLinkBase : undefined;
 }
 
+export function resolveControlUiAutomationRunUrl(
+  cfg: ControlUiLinkConfig,
+  params: { jobId: string; runId?: string },
+): string | undefined {
+  const location = resolveControlUiLinkLocation(cfg);
+  if (!location) {
+    return undefined;
+  }
+  const query = new URLSearchParams({ job: params.jobId });
+  if (params.runId) {
+    query.set("run", params.runId);
+  }
+  return `${location.origin}${location.basePath}/automations?${query}`;
+}
+
 export function resolveControlUiSessionUrl(
   cfg: ControlUiLinkConfig,
   params: {

--- a/src/cron/isolated-agent.delivery-awareness.test.ts
+++ b/src/cron/isolated-agent.delivery-awareness.test.ts
@@ -97,6 +97,62 @@ describe("runCronIsolatedAgentTurn cron delivery awareness", () => {
     });
   });
 
+  it("appends the exact run-session inspection link only to the final visible delivery payload", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeDefaultAgentSessionStoreEntries({});
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "first cron update" }, { text: "final cron summary" }]);
+
+      const result = await runAnnounceTurn({
+        home,
+        storePath,
+        sessionKey: "cron:job-1",
+        deps,
+        cfgOverrides: {
+          gateway: { publicOrigin: "https://control.example", controlUi: { basePath: "/console" } },
+        },
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      });
+
+      expect(result.status).toBe("ok");
+      expect(result.delivered).toBe(true);
+      expect(result.sessionKey).toMatch(/^agent:main:cron:job-1:run:/);
+      expect(deps.sendMessageTelegram).toHaveBeenNthCalledWith(
+        1,
+        "123",
+        "first cron update",
+        expect.any(Object),
+      );
+      expect(deps.sendMessageTelegram).toHaveBeenNthCalledWith(
+        2,
+        "123",
+        `final cron summary\nInspect: https://control.example/console/chat/main/${result.sessionKey?.replace(/^agent:main:/, "").replaceAll(":", "/")}`,
+        expect.any(Object),
+      );
+    });
+  });
+
+  it("does not turn a suppressed silent reply into an inspection-link announcement", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeDefaultAgentSessionStoreEntries({});
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "NO_REPLY" }]);
+
+      const result = await runAnnounceTurn({
+        home,
+        storePath,
+        sessionKey: "cron:job-1",
+        deps,
+        cfgOverrides: { gateway: { publicOrigin: "https://control.example" } },
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      });
+
+      expect(result.status).toBe("ok");
+      expect(result.delivered).toBeFalsy();
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+    });
+  });
+
   it("uses the global main queue when session scope is global", async () => {
     await withTempCronHome(async (home) => {
       const storePath = await writeDefaultAgentSessionStoreEntries({});

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,6 +1,8 @@
 /** Dispatches isolated cron output to direct delivery, mirrors, and follow-up queues. */
+import { copyReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import type { NormalizeReplySkipReason } from "../../auto-reply/reply/normalize-reply.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { resolveControlUiSessionUrl } from "../../config/control-ui-link-base.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/inbound.runtime.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type {
@@ -277,6 +279,24 @@ export async function dispatchCronDelivery(
       ).filter((p) => hasReplyPayloadContent(p, { trimText: true }));
       if (payloadsForDelivery.length === 0) {
         return await finishSilentReplyDelivery();
+      }
+      // Add presentation only after suppression so an inspection link cannot
+      // turn a silent or empty run into a visible announcement. Replace rather
+      // than mutate: payload objects can be aliased by the caller's turn output.
+      const inspectionIndex = payloadsForDelivery.findLastIndex((payload) => payload.text?.trim());
+      if (inspectionIndex >= 0) {
+        const inspectionUrl = resolveControlUiSessionUrl(params.cfgWithAgentDefaults, {
+          sessionKey: params.runSessionKey,
+          fallbackAgentId: params.agentId,
+          exactKey: true,
+        });
+        if (inspectionUrl) {
+          const payload = payloadsForDelivery[inspectionIndex]!;
+          payloadsForDelivery[inspectionIndex] = copyReplyPayloadMetadata(payload, {
+            ...payload,
+            text: `${payload.text}\nInspect: ${inspectionUrl}`,
+          });
+        }
       }
       deliveryAttempted = true;
       const { sessionKey: deliverySessionKey, route: directCronOutboundRoute } =

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,5 +1,4 @@
 /** Dispatches isolated cron output to direct delivery, mirrors, and follow-up queues. */
-import { copyReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import type { NormalizeReplySkipReason } from "../../auto-reply/reply/normalize-reply.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { resolveControlUiSessionUrl } from "../../config/control-ui-link-base.js";
@@ -57,7 +56,10 @@ import type {
   DispatchCronDeliveryState,
   SuccessfulCronDeliveryTarget,
 } from "./delivery-dispatch-types.js";
-import { normalizeDirectCronDeliveryPayloads } from "./delivery-payload-normalization.js";
+import {
+  appendCronRunInspectionLink,
+  normalizeDirectCronDeliveryPayloads,
+} from "./delivery-payload-normalization.js";
 import { pickSummaryFromOutput } from "./helpers.js";
 import type { RunCronAgentTurnResult } from "./run.types.js";
 import {
@@ -280,24 +282,14 @@ export async function dispatchCronDelivery(
       if (payloadsForDelivery.length === 0) {
         return await finishSilentReplyDelivery();
       }
-      // Add presentation only after suppression so an inspection link cannot
-      // turn a silent or empty run into a visible announcement. Replace rather
-      // than mutate: payload objects can be aliased by the caller's turn output.
-      const inspectionIndex = payloadsForDelivery.findLastIndex((payload) => payload.text?.trim());
-      if (inspectionIndex >= 0) {
-        const inspectionUrl = resolveControlUiSessionUrl(params.cfgWithAgentDefaults, {
+      const linkedPayloadsForDelivery = appendCronRunInspectionLink(
+        payloadsForDelivery,
+        resolveControlUiSessionUrl(params.cfgWithAgentDefaults, {
           sessionKey: params.runSessionKey,
           fallbackAgentId: params.agentId,
           exactKey: true,
-        });
-        if (inspectionUrl) {
-          const payload = payloadsForDelivery[inspectionIndex]!;
-          payloadsForDelivery[inspectionIndex] = copyReplyPayloadMetadata(payload, {
-            ...payload,
-            text: `${payload.text}\nInspect: ${inspectionUrl}`,
-          });
-        }
-      }
+        }),
+      );
       deliveryAttempted = true;
       const { sessionKey: deliverySessionKey, route: directCronOutboundRoute } =
         await resolveDirectCronDeliverySessionKey({
@@ -370,7 +362,7 @@ export async function dispatchCronDelivery(
           to: delivery.to,
           accountId: delivery.accountId,
           threadId: delivery.threadId,
-          payloads: payloadsForDelivery,
+          payloads: linkedPayloadsForDelivery,
           session: deliverySession,
           identity,
           bestEffort: params.deliveryBestEffort,
@@ -494,7 +486,7 @@ export async function dispatchCronDelivery(
       const deliveryAwarenessText = resolveCronAwarenessText({
         outputText,
         synthesizedText,
-        deliveryPayloads: payloadsForDelivery,
+        deliveryPayloads: linkedPayloadsForDelivery,
         outboundPayloads: attemptedPayloadsForMirror,
       });
       const shouldQueueAwarenessForDelivery = shouldQueueCronAwareness({
@@ -526,7 +518,7 @@ export async function dispatchCronDelivery(
             ? projectDeliveredDirectCronPayloadsForMirror(attemptedPayloadsForMirror)
             : projectOutboundPayloadPlanForMirror(
                 createOutboundPayloadPlan(
-                  buildDirectCronTranscriptMirrorPayloads(payloadsForDelivery),
+                  buildDirectCronTranscriptMirrorPayloads(linkedPayloadsForDelivery),
                   {
                     cfg: params.cfgWithAgentDefaults,
                     sessionKey: deliverySessionKey,

--- a/src/cron/isolated-agent/delivery-payload-normalization.ts
+++ b/src/cron/isolated-agent/delivery-payload-normalization.ts
@@ -96,3 +96,25 @@ export function normalizeDirectCronDeliveryPayloads(params: {
 
   return { kind: "deliver", payload: payloads };
 }
+
+/**
+ * Appends the Control UI run-inspection link to the last visible payload.
+ * Callers invoke this only after silent-reply suppression so a link cannot turn
+ * a silent or empty run into a visible announcement; the payload is replaced
+ * rather than mutated because payload objects can be aliased by the caller.
+ */
+export function appendCronRunInspectionLink(
+  payloads: ReplyPayload[],
+  inspectionUrl: string | undefined,
+): ReplyPayload[] {
+  const index = payloads.findLastIndex((payload) => payload.text?.trim());
+  if (!inspectionUrl || index < 0) {
+    return payloads;
+  }
+  const payload = payloads[index]!;
+  const linked = copyReplyPayloadMetadata(payload, {
+    ...payload,
+    text: `${payload.text}\nInspect: ${inspectionUrl}`,
+  });
+  return payloads.map((entry, at) => (at === index ? linked : entry));
+}

--- a/src/gateway/server-cron-notifications.presentation.test.ts
+++ b/src/gateway/server-cron-notifications.presentation.test.ts
@@ -22,49 +22,42 @@ describe("sendGatewayCronFailureAlert presentation", () => {
     mocks.sendCronAnnouncePayloadStrict.mockResolvedValue(undefined);
   });
 
-  it("adds the run start time without dropping presentation", async () => {
-    const job = makeCronJob({
-      delivery: {
-        mode: "announce",
-        channel: "telegram",
-        to: "channel:ops",
+  it.each([
+    {
+      name: "without a public origin",
+      gateway: undefined,
+      expectedText: "cron failed\nRun started: 2026-01-15 10:30 EST",
+    },
+    {
+      name: "with a public origin",
+      gateway: {
+        publicOrigin: "https://gateway.example",
+        controlUi: { basePath: "/control" },
       },
-    });
-
-    await sendGatewayCronFailureAlert({
-      deps: {} as CliDeps,
-      logger: { warn: vi.fn() },
-      resolveCronAgent: () => ({
-        agentId: "main",
-        cfg: { agents: { defaults: { userTimezone: "America/New_York" } } },
-      }),
-      job,
-      payload: {
-        text: "cron failed",
-        presentation: {
-          blocks: [
-            {
-              type: "buttons",
-              buttons: [
-                {
-                  label: "Log in to Codex",
-                  action: { type: "command", command: "/login codex" },
-                },
-              ],
-            },
-          ],
+      expectedText:
+        "cron failed\nRun started: 2026-01-15 10:30 EST\nInspect: https://gateway.example/control/automations?job=job-1&run=cron%3Ajob-1%3A1768491000000",
+    },
+  ])(
+    "composes failure alert details $name without dropping presentation",
+    async ({ gateway, expectedText }) => {
+      const job = makeCronJob({
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "channel:ops",
         },
-      },
-      runAtMs: Date.parse("2026-01-15T15:30:00.000Z"),
-      channel: "telegram",
-      to: "channel:ops",
-      mode: "announce",
-    });
+      });
 
-    expect(mocks.sendCronAnnouncePayloadStrict).toHaveBeenCalledWith(
-      expect.objectContaining({
+      await sendGatewayCronFailureAlert({
+        deps: {} as CliDeps,
+        logger: { warn: vi.fn() },
+        resolveCronAgent: () => ({
+          agentId: "main",
+          cfg: { agents: { defaults: { userTimezone: "America/New_York" } }, gateway },
+        }),
+        job,
         payload: {
-          text: "cron failed\nRun started: 2026-01-15 10:30 EST",
+          text: "cron failed",
           presentation: {
             blocks: [
               {
@@ -79,7 +72,32 @@ describe("sendGatewayCronFailureAlert presentation", () => {
             ],
           },
         },
-      }),
-    );
-  });
+        runAtMs: Date.parse("2026-01-15T15:30:00.000Z"),
+        channel: "telegram",
+        to: "channel:ops",
+        mode: "announce",
+      });
+
+      expect(mocks.sendCronAnnouncePayloadStrict).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: {
+            text: expectedText,
+            presentation: {
+              blocks: [
+                {
+                  type: "buttons",
+                  buttons: [
+                    {
+                      label: "Log in to Codex",
+                      action: { type: "command", command: "/login codex" },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        }),
+      );
+    },
+  );
 });

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -6,10 +6,12 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveUserTimezone } from "../agents/date-time.js";
 import type { CliDeps } from "../cli/deps.types.js";
+import { resolveControlUiAutomationRunUrl } from "../config/control-ui-link-base.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { redactCronCommandSummaryForExternalDelivery } from "../cron/command-output-summary.js";
 import { resolveCronDeliveryPlan, sendCronAnnouncePayloadStrict } from "../cron/delivery.js";
 import { retryTransientDirectCronDelivery } from "../cron/isolated-agent/delivery-dispatch-policy.js";
+import { createCronExecutionId } from "../cron/run-id.js";
 import type { CronEvent, CronService } from "../cron/service.js";
 import { resolveCronDeliverySessionKey } from "../cron/session-target.js";
 import type { CronJob } from "../cron/types.js";
@@ -150,6 +152,20 @@ function appendCronRunStarted(
     timeZone: resolveUserTimezone(config.agents?.defaults?.userTimezone),
   });
   return timestamp ? `${message}\nRun started: ${timestamp}` : message;
+}
+
+function appendCronFailureAlertDetails(
+  message: string,
+  jobId: string,
+  runAtMs: number | undefined,
+  config: OpenClawConfig,
+): string {
+  const withRunStarted = appendCronRunStarted(message, runAtMs, config);
+  const inspectUrl = resolveControlUiAutomationRunUrl(config, {
+    jobId,
+    runId: runAtMs ? createCronExecutionId(jobId, runAtMs) : undefined,
+  });
+  return inspectUrl ? `${withRunStarted}\nInspect: ${inspectUrl}` : withRunStarted;
 }
 
 function buildCronFinishedWebhookPayload(evt: CronEvent) {
@@ -375,7 +391,12 @@ async function sendGatewayCronFailureAlertUnderAdmission(
       },
       payload: {
         ...params.payload,
-        text: appendCronRunStarted(params.payload.text ?? "", params.runAtMs, runtimeConfig),
+        text: appendCronFailureAlertDetails(
+          params.payload.text ?? "",
+          params.job.id,
+          params.runAtMs,
+          runtimeConfig,
+        ),
       },
       abortSignal: abortController.signal,
       onDeliveryAttempt: params.onDeliveryAttempt,

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -2080,6 +2080,7 @@ describe("buildGatewayCronService", () => {
   it("delivers isolated script notify through the cron announce path", async () => {
     const cfg = createCronConfig("server-cron-script-announce");
     cfg.cron = { ...cfg.cron, triggers: { enabled: true } };
+    cfg.gateway = { publicOrigin: "https://gateway.example", controlUi: { basePath: "/control" } };
     loadConfigMock.mockReturnValue(cfg);
     cronScriptExecutorMock.mockResolvedValueOnce({
       kind: "completed",
@@ -2112,7 +2113,9 @@ describe("buildGatewayCronService", () => {
       expect(sendCronAnnouncePayloadStrictMock).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
           jobId: job.id,
-          payload: { text: "queue changed" },
+          payload: {
+            text: `queue changed\nInspect: https://gateway.example/control/automations?job=${job.id}&run=cron%3A${job.id}%3A${state.cron.getJob(job.id)?.state.lastRunAtMs}`,
+          },
           target: expect.objectContaining({ threadId: 456 }),
         }),
       );
@@ -2421,14 +2424,15 @@ describe("buildGatewayCronService", () => {
     }
   });
 
-  it("redacts command summary secrets before announce delivery", async () => {
+  it("appends the command inspection link after redacting announce delivery secrets and URLs", async () => {
     const cfg = createCronConfig("server-cron-command-announce-redaction");
+    cfg.gateway = { publicOrigin: "https://gateway.example", controlUi: { basePath: "/control" } };
     const state = loadCronService(cfg);
     try {
       const job = await addCommandJob(
         state,
         "announce-redacted-command",
-        "process.stdout.write('Log in with token=opaque-secret-value\\n')",
+        "process.stdout.write('Visit https://private.example/device and log in with token=opaque-secret-value\\n')",
         {
           deleteAfterRun: false,
           delivery: {
@@ -2448,7 +2452,12 @@ describe("buildGatewayCronService", () => {
       const payload = requireRecord(announcePayload.payload, "cron announce reply payload");
       const message = typeof payload.text === "string" ? payload.text : "";
       expect(message).toContain("token=***");
+      expect(message).toContain("[redacted-url]");
       expect(message).not.toContain("opaque-secret-value");
+      expect(message).not.toContain("https://private.example/device");
+      expect(message).toContain(
+        `\nInspect: https://gateway.example/control/automations?job=${job.id}&run=cron%3A${job.id}%3A${state.cron.getJob(job.id)?.state.lastRunAtMs}`,
+      );
       expect(state.cron.getJob(job.id)?.state.lastRunStatus).toBe("ok");
       expect(state.cron.getJob(job.id)?.state.lastDeliveryStatus).toBe("delivered");
     } finally {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -10,6 +10,7 @@ import {
 import { abortAndDrainEmbeddedAgentRun } from "../agents/embedded-agent.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { CliDeps } from "../cli/deps.types.js";
+import { resolveControlUiAutomationRunUrl } from "../config/control-ui-link-base.js";
 import { getRuntimeConfig } from "../config/io.js";
 import {
   resolveSessionStoreCompatibilityAgentId,
@@ -40,6 +41,7 @@ import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { retryTransientDirectCronDelivery } from "../cron/isolated-agent/delivery-dispatch-policy.js";
 import { resolveCronJobBoundSessionKeys } from "../cron/job-session-bindings.js";
 import { toPublicCronJob } from "../cron/public-job.js";
+import { createCronExecutionId } from "../cron/run-id.js";
 import { resolveCronScheduledToolPolicy } from "../cron/scheduled-tool-policy.js";
 import { cronScriptFailureMetadata } from "../cron/script-failure.js";
 import { CronService, type CronEvent } from "../cron/service.js";
@@ -233,6 +235,7 @@ function sanitizeCronHeartbeatOverride(
 async function finalizeCronCompletionAnnouncement(params: {
   job: CronJob;
   text?: string;
+  runStartedAtMs?: number;
   abortSignal?: AbortSignal;
   deps: CliDeps;
   resolveCronAgent: (requested?: string | null) => { agentId: string; cfg: OpenClawConfig };
@@ -258,6 +261,15 @@ async function finalizeCronCompletionAnnouncement(params: {
   }
 
   const { agentId, cfg } = params.resolveCronAgent(params.job.agentId);
+  const inspectUrl = resolveControlUiAutomationRunUrl(cfg, {
+    jobId: params.job.id,
+    runId:
+      params.runStartedAtMs === undefined
+        ? undefined
+        : createCronExecutionId(params.job.id, params.runStartedAtMs),
+  });
+  // Command summaries are already redacted; adding the link earlier would strip its URL.
+  const text = inspectUrl ? `${params.text}\nInspect: ${inspectUrl}` : params.text;
   const abortSignal = params.abortSignal ?? new AbortController().signal;
   let deliveryMayHaveReachedRecipient = false;
   try {
@@ -279,7 +291,7 @@ async function finalizeCronCompletionAnnouncement(params: {
             accountId: plan.accountId,
             sessionKey: resolveCronDeliverySessionKey(params.job),
           },
-          payload: { text: params.text },
+          payload: { text },
           abortSignal,
           onDeliveryAttempt: (reachedRecipient) => {
             deliveryMayHaveReachedRecipient ||= reachedRecipient;
@@ -906,6 +918,7 @@ export function buildGatewayCronService(params: {
           typeof result.summary === "string" && result.summary.trim()
             ? redactCronCommandSummaryForExternalDelivery(result.summary)
             : undefined,
+        runStartedAtMs: job.state.runningAtMs,
         abortSignal,
         deps: params.deps,
         resolveCronAgent,
@@ -976,6 +989,7 @@ export function buildGatewayCronService(params: {
       const completion = await finalizeCronCompletionAnnouncement({
         job,
         text: job.sessionTarget === "main" ? undefined : notify,
+        runStartedAtMs: job.state.runningAtMs,
         abortSignal,
         deps: params.deps,
         resolveCronAgent,

--- a/src/tasks/task-registry-delivery-runtime.ts
+++ b/src/tasks/task-registry-delivery-runtime.ts
@@ -1,2 +1,12 @@
+import { resolveControlUiSessionUrl } from "../config/control-ui-link-base.js";
+import { getRuntimeConfig } from "../infra/outbound/message.config.runtime.js";
+
 // Runtime delivery seam for task terminal/state-change notifications.
 export { sendMessage } from "../infra/outbound/message.js";
+
+export function resolveTaskControlUiSessionUrl(params: {
+  sessionKey: string;
+  fallbackAgentId?: string;
+}): string | undefined {
+  return resolveControlUiSessionUrl(getRuntimeConfig(), { ...params, exactKey: true });
+}

--- a/src/tasks/task-registry-delivery.ts
+++ b/src/tasks/task-registry-delivery.ts
@@ -273,7 +273,6 @@ async function maybeDeliverTaskTerminalUpdateUnderAdmission(
     const shouldDeliverParentReviewDirect = canDeliverParentReviewTaskToThreadOrigin(latest);
     const canDeliverDirect =
       canDeliverTaskToRequesterOrigin(latest) || shouldDeliverParentReviewDirect;
-    const directEventText = formatTaskTerminalMessage(latest);
     const sessionEventText = formatTaskTerminalMessage(
       latest,
       shouldRouteParentReview ? { surface: "parent_session" } : undefined,
@@ -302,19 +301,30 @@ async function maybeDeliverTaskTerminalUpdateUnderAdmission(
       }
     }
     try {
-      const { sendMessage } = await loadTaskRegistryDeliveryRuntime();
+      const { sendMessage, resolveTaskControlUiSessionUrl } =
+        await loadTaskRegistryDeliveryRuntime();
       const beforeSend = tasks.get(taskId);
       if (!beforeSend || !shouldAutoDeliverTaskTerminalUpdate(beforeSend)) {
         return beforeSend ? cloneTaskRecord(beforeSend) : null;
       }
       const requesterAgentId = parseAgentSessionKey(ownerSessionKey)?.agentId;
+      const inspectUrl = latest.childSessionKey
+        ? resolveTaskControlUiSessionUrl?.({
+            sessionKey: latest.childSessionKey,
+            fallbackAgentId:
+              parseAgentSessionKey(latest.childSessionKey)?.agentId ?? requesterAgentId,
+          })
+        : undefined;
+      const directEventText = shouldDeliverParentReviewDirect
+        ? sessionEventText
+        : formatTaskTerminalMessage(latest);
       const idempotencyKey = resolveTaskTerminalIdempotencyKey(latest);
       const sendResult = await sendMessage({
         channel: owner.requesterOrigin?.channel,
         to: owner.requesterOrigin?.to ?? "",
         accountId: owner.requesterOrigin?.accountId,
         threadId: owner.requesterOrigin?.threadId,
-        content: shouldDeliverParentReviewDirect ? sessionEventText : directEventText,
+        content: inspectUrl ? `${directEventText}\nInspect: ${inspectUrl}` : directEventText,
         agentId: requesterAgentId,
         idempotencyKey,
         mirror: {

--- a/src/tasks/task-registry-state.ts
+++ b/src/tasks/task-registry-state.ts
@@ -37,13 +37,12 @@ type TaskRegistryRestoreState =
   | { status: "failed"; error: Error };
 let taskRegistryRestoreState: TaskRegistryRestoreState = { status: "uninitialized" };
 export const taskFlowSyncRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
-export type TaskRegistryDeliveryRuntime = Pick<
-  typeof import("./task-registry-delivery-runtime.js"),
-  "sendMessage"
-> &
-  Partial<
-    Pick<typeof import("./task-registry-delivery-runtime.js"), "resolveTaskControlUiSessionUrl">
-  >;
+export type TaskRegistryDeliveryRuntime = {
+  sendMessage: (typeof import("./task-registry-delivery-runtime.js"))["sendMessage"];
+  // Optional so existing test overrides that stub only sendMessage stay valid;
+  // delivery treats a missing resolver as "no Control UI link".
+  resolveTaskControlUiSessionUrl?: (typeof import("./task-registry-delivery-runtime.js"))["resolveTaskControlUiSessionUrl"];
+};
 export const TASK_REGISTRY_DELIVERY_RUNTIME_OVERRIDE_KEY = Symbol.for(
   "openclaw.taskRegistry.deliveryRuntimeOverride",
 );

--- a/src/tasks/task-registry-state.ts
+++ b/src/tasks/task-registry-state.ts
@@ -40,7 +40,10 @@ export const taskFlowSyncRetryTimers = new Map<string, ReturnType<typeof setTime
 export type TaskRegistryDeliveryRuntime = Pick<
   typeof import("./task-registry-delivery-runtime.js"),
   "sendMessage"
->;
+> &
+  Partial<
+    Pick<typeof import("./task-registry-delivery-runtime.js"), "resolveTaskControlUiSessionUrl">
+  >;
 export const TASK_REGISTRY_DELIVERY_RUNTIME_OVERRIDE_KEY = Symbol.for(
   "openclaw.taskRegistry.deliveryRuntimeOverride",
 );

--- a/src/tasks/task-registry.test-support.ts
+++ b/src/tasks/task-registry.test-support.ts
@@ -1,4 +1,5 @@
 import type { TaskRegistryControlRuntime } from "./task-registry-control.types.js";
+import type { TaskRegistryDeliveryRuntime } from "./task-registry-state.js";
 import { createTaskRecord as createTaskRecordOrNull } from "./task-registry.js";
 import type { TaskEventRecord, TaskRecord } from "./task-registry.types.js";
 
@@ -35,11 +36,6 @@ export function createAcpTaskRecord(
     ...params,
   });
 }
-
-type TaskRegistryDeliveryRuntime = Pick<
-  typeof import("./task-registry-delivery-runtime.js"),
-  "sendMessage"
->;
 
 type TaskRegistryTestApi = {
   maybeDeliverTaskStateChangeUpdate(

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1956,6 +1956,11 @@ describe("task-registry", () => {
   it("queues delegated ACP completion to the requester session when a delivery origin exists", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
+      const resolveTaskControlUiSessionUrl = vi.fn(() => "https://dashboard.example/chat/task");
+      setTaskRegistryDeliveryRuntimeForTests({
+        sendMessage: hoisted.sendMessageMock,
+        resolveTaskControlUiSessionUrl,
+      });
       hoisted.sendMessageMock.mockResolvedValue({
         channel: "notifychat",
         to: "notifychat:123",
@@ -1991,6 +1996,8 @@ describe("task-registry", () => {
       expect(peekSystemEvents("agent:main:main")).toEqual([
         expect.stringContaining("Background task ready for review: ACP background task"),
       ]);
+      expect(peekSystemEvents("agent:main:main")[0]).not.toContain("Inspect:");
+      expect(resolveTaskControlUiSessionUrl).not.toHaveBeenCalled();
     });
   });
 
@@ -2035,21 +2042,43 @@ describe("task-registry", () => {
     );
   });
 
-  it("delivers non-delegated ACP completion to the requester channel when a delivery origin exists", async () => {
+  it.each([
+    {
+      name: "with an inspection link when the child session is linkable",
+      childSessionKey: "agent:worker:acp:child",
+      inspectUrl: "https://dashboard.example/chat/agent%3Aworker%3Aacp%3Achild",
+    },
+    {
+      name: "without an inspection link when no public Control UI is configured",
+      childSessionKey: "agent:worker:acp:child",
+      inspectUrl: undefined,
+    },
+    {
+      name: "without an inspection link when the task has no child session",
+      childSessionKey: undefined,
+      inspectUrl: "https://dashboard.example/chat/unused",
+    },
+  ])("delivers ACP completion directly to a requester thread $name", async (testCase) => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
+      const resolveTaskControlUiSessionUrl = vi.fn(() => testCase.inspectUrl);
+      setTaskRegistryDeliveryRuntimeForTests({
+        sendMessage: hoisted.sendMessageMock,
+        resolveTaskControlUiSessionUrl,
+      });
       hoisted.sendMessageMock.mockResolvedValue({
-        channel: "notifychat",
-        to: "notifychat:123",
+        channel: "discord",
+        to: "channel:123",
         via: "direct",
       });
 
       createTaskFixture("acp", {
         requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
+          channel: "discord",
+          to: "channel:123",
           threadId: "321",
         },
+        childSessionKey: testCase.childSessionKey,
         runId: "run-direct-delivery",
         task: "Investigate issue",
         deliveryStatus: "pending",
@@ -2074,11 +2103,28 @@ describe("task-registry", () => {
       await waitForAssertion(() => expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(1));
       const message = sentMessageCall();
       expectRecordFields(message, {
-        channel: "notifychat",
-        to: "notifychat:123",
+        channel: "discord",
+        to: "channel:123",
         threadId: "321",
       });
-      expect(String(message.content)).toContain("Background task done: ACP background task");
+      expect(String(message.content)).toContain(
+        testCase.childSessionKey
+          ? "Background task ready for review: ACP background task"
+          : "Background task done: ACP background task",
+      );
+      if (testCase.childSessionKey) {
+        expect(resolveTaskControlUiSessionUrl).toHaveBeenCalledWith({
+          sessionKey: testCase.childSessionKey,
+          fallbackAgentId: "worker",
+        });
+      } else {
+        expect(resolveTaskControlUiSessionUrl).not.toHaveBeenCalled();
+      }
+      if (testCase.childSessionKey && testCase.inspectUrl) {
+        expect(String(message.content).endsWith(`\nInspect: ${testCase.inspectUrl}`)).toBe(true);
+      } else {
+        expect(String(message.content)).not.toContain("Inspect:");
+      }
       expectRecordFields(message.mirror, {
         sessionKey: "agent:main:main",
       });

--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -9,6 +9,7 @@ import "./cron-page.ts";
 
 type CronTestPage = HTMLElement & {
   context: ApplicationContext;
+  routeSearch: string;
   updateComplete: Promise<boolean>;
   requestUpdate: () => void;
   render: () => typeof nothing;
@@ -178,6 +179,76 @@ afterEach(() => {
 });
 
 describe("CronPage editor state sync", () => {
+  it("opens a linked job's history after its jobs load and highlights the linked run", async () => {
+    const job: CronJob = {
+      id: "linked-job",
+      name: "Linked automation",
+      enabled: true,
+      createdAtMs: 0,
+      updatedAtMs: 0,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "digest" },
+      state: {},
+    };
+    const jobs = createDeferred<CronJobsListResult>();
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "cron.list") {
+        return jobs.promise;
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, triggersEnabled: true };
+      }
+      if (method === "cron.runs") {
+        const entries =
+          (params as { id?: string }).id === job.id
+            ? [
+                {
+                  ts: 2,
+                  jobId: job.id,
+                  action: "finished",
+                  runId: "cron:linked-job:2",
+                  summary: "Another run",
+                },
+                {
+                  ts: 1,
+                  jobId: job.id,
+                  action: "finished",
+                  runId: "cron:linked-job:1",
+                  summary: "Linked run",
+                },
+              ]
+            : [];
+        return { entries, total: entries.length, offset: 0, hasMore: false };
+      }
+      if (method === "models.list") {
+        return { models: [] };
+      }
+      return {};
+    });
+    const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
+    const page = createPage(createContext(gateway), { render: true });
+    page.routeSearch = "?job=linked-job&run=cron%3Alinked-job%3A1";
+
+    await waitForCronPage(() => expect(page.cron.cronLoading).toBe(true));
+    expect(page.cron.cronEditingJobId).toBeNull();
+    jobs.resolve(cronListResponse([job]));
+
+    await waitForCronPage(() => {
+      expect(page.cron.cronEditingJobId).toBe(job.id);
+      expect(
+        page
+          .querySelector('[data-test-id="cron-detail-tab-history"]')
+          ?.getAttribute("aria-selected"),
+      ).toBe("true");
+      expect(page.querySelector(".cron-run-entry--highlighted")?.textContent).toContain(
+        "Linked run",
+      );
+    });
+    expect(page.querySelectorAll(".cron-run-entry--highlighted")).toHaveLength(1);
+  });
+
   it.each([
     { scenario: "an unsaved enable edit", active: false, edited: true, saved: false },
     { scenario: "an unsaved disable edit", active: true, edited: false, saved: false },

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -1,6 +1,6 @@
 import { consume } from "@lit/context";
-import { html } from "lit";
-import { state } from "lit/decorators.js";
+import { html, type PropertyValues } from "lit";
+import { property, state } from "lit/decorators.js";
 import type { AgentsListResult, CronJob } from "../../api/types.ts";
 import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
@@ -44,18 +44,23 @@ import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { buildCronSuggestions, THINKING_SUGGESTIONS } from "./form-suggestions.ts";
+import { resolveCronRouteData } from "./route-model.ts";
 import { renderCron, type CronDetailTab, type CronListTab } from "./view.ts";
 
 class CronPage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
   private context!: ApplicationContext;
 
+  @property({ attribute: false }) routeSearch = "";
   @state() private cron = createInitialCronState();
   @state() private agentsList: AgentsListResult | null = null;
   @state() private cronModelSuggestions: string[] = [];
   @state() private listTab: CronListTab = "tasks";
   @state() private detailTab: CronDetailTab = "settings";
 
+  private pendingRouteData: ReturnType<typeof resolveCronRouteData> | null = null;
+  private highlightedRunId: string | null = null;
+  private pendingRunScroll = false;
   private modelSuggestionsState: CronState | null = null;
   private readonly gateway = new GatewayPageController(this, {
     getGateway: () => this.context?.gateway,
@@ -163,6 +168,15 @@ class CronPage extends OpenClawLightDomElement {
 
   private lastPanelKey: string | null = null;
 
+  override willUpdate(changed: PropertyValues) {
+    if (changed.has("routeSearch")) {
+      const routeData = resolveCronRouteData(this.routeSearch);
+      this.pendingRouteData = routeData.jobId ? routeData : null;
+      this.highlightedRunId = null;
+      this.pendingRunScroll = false;
+    }
+  }
+
   override updated() {
     // Switching between list and detail (or between two jobs) keeps the same
     // page scroller alive, so reset scroll and the detail tab per target.
@@ -171,10 +185,26 @@ class CronPage extends OpenClawLightDomElement {
     const panelKey = `${mode}:${editingJobId ?? ""}`;
     if (panelKey !== this.lastPanelKey) {
       this.lastPanelKey = panelKey;
-      this.detailTab = "settings";
+      this.detailTab = editingJobId && this.highlightedRunId ? "history" : "settings";
       const scroller = this.closest(".content");
       if (scroller instanceof HTMLElement && typeof scroller.scrollTo === "function") {
         scroller.scrollTo({ top: 0 });
+      }
+    }
+    if (this.pendingRouteData && !this.cron.cronLoading && this.cron.cronJobsSnapshotRevision) {
+      // Consume the link only after its inventory arrives so later clicks cannot re-adopt it.
+      const routeData = this.pendingRouteData;
+      this.pendingRouteData = null;
+      const job = this.cron.cronJobs.find((entry) => entry.id === routeData.jobId);
+      if (job) {
+        this.selectJob(job, routeData.runId);
+      }
+    }
+    if (this.pendingRunScroll) {
+      const run = this.querySelector<HTMLElement>(".cron-run-entry--highlighted");
+      if (run) {
+        run.scrollIntoView?.({ block: "nearest" });
+        this.pendingRunScroll = false;
       }
     }
   }
@@ -248,7 +278,12 @@ class CronPage extends OpenClawLightDomElement {
     this.requestCronUpdate();
   }
 
-  private selectJob(job: CronJob) {
+  private selectJob(job: CronJob, runId: string | null = null) {
+    this.highlightedRunId = runId;
+    this.pendingRunScroll = Boolean(runId);
+    if (runId) {
+      this.detailTab = "history";
+    }
     this.cron.cronCreateOpen = false;
     startCronEdit(this.cron, job);
     this.requestCronUpdate();
@@ -428,6 +463,7 @@ class CronPage extends OpenClawLightDomElement {
           channelLabels: channels.channelsSnapshot?.channelLabels ?? {},
           channelMeta: channels.channelsSnapshot?.channelMeta ?? [],
           runs: this.cron.cronRuns,
+          highlightedRunId: this.highlightedRunId,
           runsTotal: this.cron.cronRunsTotal,
           runsHasMore: this.cron.cronRunsHasMore,
           runsLoadingMore: this.cron.cronRunsLoadingMore,
@@ -506,8 +542,12 @@ class CronPage extends OpenClawLightDomElement {
   }
 }
 
-export const header = true,
-  render = () => html`<openclaw-cron-page></openclaw-cron-page>`;
+export const cronPageComponent = {
+  header: true,
+  render: (search: unknown) => html`<openclaw-cron-page
+    .routeSearch=${typeof search === "string" ? search : ""}
+  ></openclaw-cron-page>`,
+};
 
 // Module re-evaluation can retain the shared registry (for example, in Vitest).
 if (!customElements.get("openclaw-cron-page")) {

--- a/ui/src/pages/cron/route-model.test.ts
+++ b/ui/src/pages/cron/route-model.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { resolveCronRouteData } from "./route-model.ts";
+
+describe("resolveCronRouteData", () => {
+  it.each([
+    { scenario: "an empty search", search: "", jobId: null, runId: null },
+    { scenario: "a job only", search: "?job=job-1", jobId: "job-1", runId: null },
+    {
+      scenario: "a job and run",
+      search: "?job=job-1&run=cron%3Ajob-1%3A123",
+      jobId: "job-1",
+      runId: "cron:job-1:123",
+    },
+    {
+      scenario: "blank and whitespace values",
+      search: "?job=%20%20&run=%20%20",
+      jobId: null,
+      runId: null,
+    },
+    {
+      scenario: "a blank run on an existing job",
+      search: "?job=%20job-1%20&run=%20%20",
+      jobId: "job-1",
+      runId: null,
+    },
+    { scenario: "a run without a job", search: "?run=run-1", jobId: null, runId: null },
+    {
+      scenario: "plus-encoded spaces",
+      search: "?job=job+one&run=run+one",
+      jobId: "job one",
+      runId: "run one",
+    },
+  ])("normalizes $scenario", ({ search, jobId, runId }) => {
+    expect(resolveCronRouteData(search)).toEqual({ jobId, runId });
+  });
+});

--- a/ui/src/pages/cron/route-model.test.ts
+++ b/ui/src/pages/cron/route-model.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { resolveCronRouteData } from "./route-model.ts";
+import { cronRunEntryMatchesLink, resolveCronRouteData } from "./route-model.ts";
 
 describe("resolveCronRouteData", () => {
   it.each([
@@ -33,5 +33,45 @@ describe("resolveCronRouteData", () => {
     },
   ])("normalizes $scenario", ({ search, jobId, runId }) => {
     expect(resolveCronRouteData(search)).toEqual({ jobId, runId });
+  });
+});
+
+describe("cronRunEntryMatchesLink", () => {
+  const entry = {
+    jobId: "job-1",
+    runId: "manual:job-1:1787732891668:1",
+    runAtMs: 1_787_732_891_692,
+  };
+
+  it.each([
+    {
+      scenario: "the exact public run id",
+      linked: "manual:job-1:1787732891668:1",
+      matches: true,
+    },
+    {
+      scenario: "the execution id via the recorded run start",
+      linked: "cron:job-1:1787732891692",
+      matches: true,
+    },
+    {
+      scenario: "an execution id for another job",
+      linked: "cron:job-2:1787732891692",
+      matches: false,
+    },
+    {
+      scenario: "an execution id with a different run start",
+      linked: "cron:job-1:1787732891693",
+      matches: false,
+    },
+    { scenario: "an unrelated id", linked: "run-1", matches: false },
+  ])("matches $scenario", ({ linked, matches }) => {
+    expect(cronRunEntryMatchesLink(linked, entry)).toBe(matches);
+  });
+
+  it("does not match an execution id when the entry has no recorded run start", () => {
+    expect(
+      cronRunEntryMatchesLink("cron:job-1:1787732891692", { jobId: "job-1", runId: "abc" }),
+    ).toBe(false);
   });
 });

--- a/ui/src/pages/cron/route-model.ts
+++ b/ui/src/pages/cron/route-model.ts
@@ -1,0 +1,8 @@
+export function resolveCronRouteData(search: string): {
+  jobId: string | null;
+  runId: string | null;
+} {
+  const params = new URLSearchParams(search);
+  const jobId = params.get("job")?.trim() || null;
+  return { jobId, runId: jobId ? params.get("run")?.trim() || null : null };
+}

--- a/ui/src/pages/cron/route-model.ts
+++ b/ui/src/pages/cron/route-model.ts
@@ -6,3 +6,21 @@ export function resolveCronRouteData(search: string): {
   const jobId = params.get("job")?.trim() || null;
   return { jobId, runId: jobId ? params.get("run")?.trim() || null : null };
 }
+
+const CRON_EXECUTION_ID_RE = /^cron:(.+):(\d+)$/u;
+
+/**
+ * Notifications link runs by execution id (`cron:<jobId>:<startedAtMs>`), while
+ * ledger entries carry public run ids (receipt UUIDs, `manual:<...>` ids) that
+ * never equal it. Match exact ids first, then the entry's recorded run start.
+ */
+export function cronRunEntryMatchesLink(
+  linkedRunId: string,
+  entry: { jobId: string; runId?: string; runAtMs?: number },
+): boolean {
+  if (entry.runId === linkedRunId) {
+    return true;
+  }
+  const match = CRON_EXECUTION_ID_RE.exec(linkedRunId);
+  return match !== null && match[1] === entry.jobId && entry.runAtMs === Number(match[2]);
+}

--- a/ui/src/pages/cron/route.ts
+++ b/ui/src/pages/cron/route.ts
@@ -3,5 +3,7 @@ import { routePageSpec } from "../../app-route-paths.ts";
 
 export const page = definePage({
   ...routePageSpec("cron"),
-  component: () => import("./cron-page.ts"),
+  loaderDeps: (_context, { search }) => search,
+  loader: (_context, { deps }) => deps,
+  component: () => import("./cron-page.ts").then((module) => module.cronPageComponent),
 });

--- a/ui/src/pages/cron/view-runs.ts
+++ b/ui/src/pages/cron/view-runs.ts
@@ -23,6 +23,7 @@ import {
 } from "../../lib/format.ts";
 import { shouldHandleNavigationClick } from "../../lib/navigation-click.ts";
 import { sessionNavigationTarget } from "../../lib/sessions/route-navigation.ts";
+import { cronRunEntryMatchesLink } from "./route-model.ts";
 
 // Leaf contract: the slice of the cron view props this module needs. Keeping
 // it local (instead of importing CronProps from view.ts) avoids a module
@@ -414,7 +415,7 @@ function renderRun(
     entry.summary || formatUiExternalText(entry.error) || t("cron.runEntry.noSummary");
   const showErrorInMeta = Boolean(entry.error) && Boolean(entry.summary);
   const facts = [delivery, entry.model, entry.provider, usageSummary].filter(Boolean);
-  const highlighted = Boolean(highlightedRunId && entry.runId === highlightedRunId);
+  const highlighted = Boolean(highlightedRunId && cronRunEntryMatchesLink(highlightedRunId, entry));
   return html`
     <div class="cron-run-entry ${highlighted ? "cron-run-entry--highlighted" : ""}">
       <div class="cron-run-entry__header">

--- a/ui/src/pages/cron/view-runs.ts
+++ b/ui/src/pages/cron/view-runs.ts
@@ -31,6 +31,7 @@ type CronRunsSectionProps = {
   basePath: string;
   agentId: string;
   runs: CronRunLogEntry[];
+  highlightedRunId?: string | null;
   runsHasMore: boolean;
   runsLoadingMore: boolean;
   runsStatuses: CronRunsStatusValue[];
@@ -328,7 +329,13 @@ export function renderRunsSection(props: CronRunsSectionProps) {
         : html`
             <div class="cron-runs__list">
               ${runs.map((entry) =>
-                renderRun(entry, props.agentId, props.basePath, props.onNavigateToChat),
+                renderRun(
+                  entry,
+                  props.agentId,
+                  props.basePath,
+                  props.highlightedRunId,
+                  props.onNavigateToChat,
+                ),
               )}
             </div>
           `}
@@ -382,6 +389,7 @@ function renderRun(
   entry: CronRunLogEntry,
   fallbackAgentId: string,
   basePath: string,
+  highlightedRunId?: string | null,
   onNavigateToChat?: (sessionKey: string) => void,
 ) {
   const chatUrl =
@@ -406,8 +414,9 @@ function renderRun(
     entry.summary || formatUiExternalText(entry.error) || t("cron.runEntry.noSummary");
   const showErrorInMeta = Boolean(entry.error) && Boolean(entry.summary);
   const facts = [delivery, entry.model, entry.provider, usageSummary].filter(Boolean);
+  const highlighted = Boolean(highlightedRunId && entry.runId === highlightedRunId);
   return html`
-    <div class="cron-run-entry">
+    <div class="cron-run-entry ${highlighted ? "cron-run-entry--highlighted" : ""}">
       <div class="cron-run-entry__header">
         <div class="cron-run-entry__main">
           <div class="cron-run-entry__title">

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -101,6 +101,7 @@ type CronProps = {
   channelLabels?: Record<string, string>;
   channelMeta?: ChannelUiMetaEntry[];
   runs: CronRunLogEntry[];
+  highlightedRunId?: string | null;
   runsTotal: number;
   runsHasMore: boolean;
   runsLoadingMore: boolean;

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -1084,6 +1084,11 @@
   border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
 }
 
+.cron-run-entry--highlighted {
+  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--accent) 75%, transparent);
+  padding-left: var(--space-3);
+}
+
 .cron-run-entry__header {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What Problem This Solves

Automation and task notifications delivered to chat channels dead-end: the operator reads "Automation X failed" or a completion summary with no way to click through to the run record, even though the Control UI has session, automations, and run-history views for exactly that. OpenTag-style products link every result to its run page; OpenClaw had no such link anywhere in the delivery path.

## Why This Change Was Made

When the operator has already told us where the Control UI lives (`gateway.publicOrigin` + `gateway.controlUi`), notifications should carry an "Inspect" deep link. No new config surface: the URL derives entirely from the existing owner in `src/config/control-ui-link-base.ts` (the same resolver the agent system prompt and Slack progress cards already use). The link is composed once at each notification's composition chokepoint and carried inside the payload — channels never rediscover it.

Append sites and targets:

- **Cron failure alerts** (announce mode) and **command/script completion announcements** link to `/automations?job=<id>&run=cron:<id>:<startedAtMs>`. The link is appended after `redactCronCommandSummaryForExternalDelivery`, whose URL-stripping would otherwise eat it; the failure-alert append composes alongside the existing `Run started:` line in `server-cron-notifications.ts`. Webhook payloads stay unchanged — structured consumers already receive `jobId`/`runAtMs` and can build their own links.
- **Isolated agent run completions** link to the run's exact session route (`/chat/<agent>/cron/<job>/run/<id>` via `resolveControlUiSessionUrl` with `exactKey`). The append happens only after silent-token/NO_REPLY suppression and replaces the payload immutably (payload objects can be aliased by the caller's turn output), so a suppressed run can never become a visible announcement.
- **Task terminal notifications** on the direct channel route link to the task's own child session; session-queued system events stay link-free. The task delivery module has no config access, so the runtime seam (`task-registry-delivery-runtime.ts`) gained a config-backed resolver reusing the same `getRuntimeConfig` the outbound sender already uses.
- **Control UI**: `/automations` now adopts `?job=<id>&run=<id>` (loader search pass-through following the Activity/Sessions pattern; one-shot adoption after jobs load; opens the History tab and highlights + scrolls to the linked run). Notifications embed the execution id (`cron:<jobId>:<startedAtMs>`) while ledger entries carry public run ids (receipt UUIDs / `manual:<...>`), so the highlight matcher resolves the execution id against the entry's recorded `runAtMs` — a mismatch found and fixed during live verification, with regression tests.

Also folded in: `task-registry.test-support.ts` had a duplicate local `TaskRegistryDeliveryRuntime` type; it now type-imports the canonical one from `task-registry-state.ts`.

## User Impact

Operators with a configured `gateway.publicOrigin` get a clickable "Inspect" link on automation failure alerts, automation completion messages, and background-task completion notifications, landing directly on the run record (automations run history or the run's session). Operators without a public origin see no change. Docs updated: automation cron-jobs and tasks delivery sections, plus the `publicOrigin` reference bullet.

## Evidence

- Unit/behavior tests: link-base URL builder cases; failure-alert append (with/without origin, presentation preserved); command announce append-after-redaction (secret + URL redaction still applied, link intact); isolated delivery (link only on final visible payload; suppressed silent runs deliver nothing); task delivery (direct route only, seam-injected resolver); UI route-model parsing + run matcher (public id and execution-id-vs-runAtMs cases); cron-page cold-load adoption test (selects job, opens History, highlights exactly one run).
- Local gates: `node scripts/check-changed.mjs` green (format, tsgo core+test shards, lint, i18n, dead-export, guards); touched suites via `node scripts/run-vitest.mjs` all green.
- Live proof on a dev gateway (isolated `OPENCLAW_STATE_DIR`, port 19345, `publicOrigin` set, qa-channel synthetic transport): a failing command automation (`exit 3`, global `failureAlert.after: 1`) produced both the completion announce and the failure alert on the channel bus, each ending with `Inspect: http://127.0.0.1:19345/automations?job=<id>&run=cron%3A<id>%3A<startedAtMs>`. Clicking that exact URL in a real browser (after token auth) landed on the job with Run history open and the linked run highlighted; served bundle hash verified freshly rebuilt. Before/after screenshots attached; captured qa-channel transcript JSON retained.
- Autoreview (Codex `gpt-5.6-sol`, high): clean, no accepted/actionable findings.

![01-before-automations-list](https://github.com/user-attachments/assets/32e827d3-71cc-4995-ab81-177589fb293a)

![02-after-deep-link-highlighted-run](https://github.com/user-attachments/assets/c647aa12-ec14-44ae-b35d-914c22e9dbcf)