### PR TITLE
fix(browser): honor canonical action execution deadlines

### DIFF
--- a/extensions/browser/src/browser/act-policy.test.ts
+++ b/extensions/browser/src/browser/act-policy.test.ts
@@ -1,15 +1,12 @@
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it } from "vitest";
-import {
-  resolveBrowserActExecutionBudgetMs,
-  resolveBrowserActRequestTimeoutMs,
-} from "./act-policy.js";
+import { resolveBrowserActRequestTimeoutMs } from "./act-policy.js";
 import type { BrowserActRequest } from "./client-actions.types.js";
 
-describe("browser action execution budgets", () => {
+describe("browser action request deadlines", () => {
   it("sums the delay and every sequential wait condition", () => {
     expect(
-      resolveBrowserActExecutionBudgetMs({
+      resolveBrowserActRequestTimeoutMs({
         kind: "wait",
         timeMs: 10_000,
         text: "ready",
@@ -20,7 +17,7 @@ describe("browser action execution budgets", () => {
         fn: "() => true",
         timeoutMs: 20_000,
       }),
-    ).toBe(130_000);
+    ).toBe(135_000);
   });
 
   it("normalizes each condition timeout before multiplication", () => {
@@ -34,15 +31,15 @@ describe("browser action execution budgets", () => {
       fn: "() => true",
     } as const;
 
-    expect(resolveBrowserActExecutionBudgetMs({ ...wait, timeoutMs: 1 })).toBe(3_000);
-    expect(resolveBrowserActExecutionBudgetMs({ ...wait, timeoutMs: Number.MAX_VALUE })).toBe(
-      720_000,
+    expect(resolveBrowserActRequestTimeoutMs({ ...wait, timeoutMs: 1 })).toBe(8_000);
+    expect(resolveBrowserActRequestTimeoutMs({ ...wait, timeoutMs: Number.MAX_VALUE })).toBe(
+      725_000,
     );
   });
 
   it("matches runtime normalization for whitespace-only wait conditions", () => {
     expect(
-      resolveBrowserActExecutionBudgetMs({
+      resolveBrowserActRequestTimeoutMs({
         kind: "wait",
         timeMs: 0,
         text: " ",
@@ -51,13 +48,13 @@ describe("browser action execution budgets", () => {
         url: " ",
         fn: " ",
       }),
-    ).toBe(40_000);
+    ).toBe(45_000);
     expect(resolveBrowserActRequestTimeoutMs({ kind: "wait", timeMs: 0 })).toBe(5_000);
   });
 
   it("recursively sums nested batch children in execution order", () => {
     expect(
-      resolveBrowserActExecutionBudgetMs({
+      resolveBrowserActRequestTimeoutMs({
         kind: "batch",
         actions: [
           { kind: "wait", timeMs: 30_000 },
@@ -70,11 +67,11 @@ describe("browser action execution budgets", () => {
           },
         ],
       }),
-    ).toBe(90_000);
+    ).toBe(95_000);
   });
 
   it("keeps leaf defaults and adds outer slack once", () => {
-    expect(resolveBrowserActExecutionBudgetMs({ kind: "click", ref: "1" })).toBe(60_000);
+    expect(resolveBrowserActRequestTimeoutMs({ kind: "click", ref: "1" })).toBe(65_000);
     expect(resolveBrowserActRequestTimeoutMs({ kind: "click", ref: "1", timeoutMs: 45_000 })).toBe(
       50_250,
     );
@@ -82,7 +79,7 @@ describe("browser action execution budgets", () => {
 
   it("budgets sequential leaf phases and bounded delays", () => {
     expect(
-      resolveBrowserActExecutionBudgetMs({
+      resolveBrowserActRequestTimeoutMs({
         kind: "fill",
         fields: [
           { ref: "first", type: "text" },
@@ -90,9 +87,9 @@ describe("browser action execution budgets", () => {
         ],
         timeoutMs: 20_000,
       }),
-    ).toBe(40_500);
+    ).toBe(45_500);
     expect(
-      resolveBrowserActExecutionBudgetMs({
+      resolveBrowserActRequestTimeoutMs({
         kind: "type",
         ref: "field",
         text: "value",
@@ -100,17 +97,17 @@ describe("browser action execution budgets", () => {
         submit: true,
         timeoutMs: 20_000,
       }),
-    ).toBe(60_250);
+    ).toBe(65_250);
     expect(
-      resolveBrowserActExecutionBudgetMs({
+      resolveBrowserActRequestTimeoutMs({
         kind: "click",
         ref: "button",
         delayMs: 5_000,
         timeoutMs: 20_000,
       }),
-    ).toBe(45_250);
+    ).toBe(50_250);
     expect(
-      resolveBrowserActExecutionBudgetMs({
+      resolveBrowserActRequestTimeoutMs({
         kind: "clickCoords",
         x: 10,
         y: 20,
@@ -118,12 +115,12 @@ describe("browser action execution budgets", () => {
         delayMs: 5_000,
         timeoutMs: 20_000,
       }),
-    ).toBe(35_250);
+    ).toBe(40_250);
   });
 
   it("preserves the prior whole-request floor for batches", () => {
     expect(
-      resolveBrowserActExecutionBudgetMs({
+      resolveBrowserActRequestTimeoutMs({
         kind: "batch",
         actions: [
           {
@@ -136,36 +133,36 @@ describe("browser action execution budgets", () => {
           },
         ],
       }),
-    ).toBe(60_000);
+    ).toBe(65_000);
   });
 
   it("budgets the wider scrollIntoView locator timeout", () => {
     expect(
-      resolveBrowserActExecutionBudgetMs({
+      resolveBrowserActRequestTimeoutMs({
         kind: "batch",
         actions: Array.from({ length: 4 }, () => ({
           kind: "scrollIntoView" as const,
           ref: "result",
         })),
       }),
-    ).toBe(81_000);
+    ).toBe(86_000);
     expect(
-      resolveBrowserActExecutionBudgetMs({
+      resolveBrowserActRequestTimeoutMs({
         kind: "scrollIntoView",
         ref: "result",
         timeoutMs: 120_000,
       }),
-    ).toBe(120_250);
+    ).toBe(125_250);
   });
 
   it("leaves malformed model batch validation to the browser route", () => {
     expect(
-      resolveBrowserActExecutionBudgetMs({
+      resolveBrowserActRequestTimeoutMs({
         kind: "batch",
         requests: [],
         actions: [{ kind: "wait", selector: 1 }, { kind: "unknown" }, null],
       } as unknown as BrowserActRequest),
-    ).toBe(60_000);
+    ).toBe(65_000);
   });
 
   it("saturates aggregate and slack arithmetic at the timer limit", () => {
@@ -181,7 +178,6 @@ describe("browser action execution budgets", () => {
     }));
     const batch = { kind: "batch", actions } as const;
 
-    expect(resolveBrowserActExecutionBudgetMs(batch)).toBe(MAX_TIMER_TIMEOUT_MS);
     expect(resolveBrowserActRequestTimeoutMs(batch)).toBe(MAX_TIMER_TIMEOUT_MS);
   });
 });

--- a/extensions/browser/src/browser/act-policy.ts
+++ b/extensions/browser/src/browser/act-policy.ts
@@ -206,7 +206,7 @@ function resolveExecutionBudgetMs(request: BrowserActRequest): number {
  * Resolve the runtime budget before an outer transport watchdog is armed.
  * Wait phases and batch children execute serially, so maxima would abort valid work midway.
  */
-export function resolveBrowserActExecutionBudgetMs(request: BrowserActRequest): number {
+function resolveBrowserActExecutionBudgetMs(request: BrowserActRequest): number {
   const executionBudgetMs = resolveExecutionBudgetMs(request);
   if (request.kind === "wait") {
     return executionBudgetMs;

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.batch.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.batch.test.ts
@@ -70,6 +70,7 @@ describe("browser action input batch command", () => {
       actions: SAMPLE_ACTIONS,
       targetId: "tab-1",
     });
+    expect(mocks.callBrowserRequest.mock.calls.at(-1)?.[2]).toEqual({ timeoutMs: 65_000 });
   });
 
   it("omits stopOnError by default so the route applies its fail-fast default", async () => {

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.batch.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.batch.ts
@@ -3,7 +3,6 @@
  */
 import type { Command } from "commander";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveBrowserActExecutionBudgetMs } from "../../browser/act-policy.js";
 import type { BrowserActRequest } from "../../browser/client-actions.types.js";
 import { BROWSER_TAB_REFERENCE_HELP, type BrowserParentOpts } from "../browser-cli-shared.js";
 import { danger, defaultRuntime } from "../core-api.js";
@@ -74,8 +73,7 @@ export function registerBrowserBatchCommands(
         }>({
           parent,
           profile,
-          body,
-          timeoutMs: resolveBrowserActExecutionBudgetMs(request),
+          body: request,
         });
       } catch (err) {
         defaultRuntime.error(danger(String(err)));

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
@@ -52,6 +52,8 @@ describe("browser element commands", () => {
       name: "click",
       argv: [
         "browser",
+        "--browser-profile",
+        "user",
         "click",
         " ref-1 ",
         "--target-id",
@@ -149,6 +151,7 @@ describe("browser element commands", () => {
     await program.parseAsync(argv, { from: "user" });
 
     expect(getLastActionBody()).toMatchObject(expectedBody);
+    expect(mocks.callBrowserRequest.mock.calls.at(-1)?.[2]).toEqual({ timeoutMs: 65_000 });
   });
 
   it("rejects a blank required ref before dispatch", async () => {
@@ -210,6 +213,6 @@ describe("browser element commands", () => {
     const timeoutRequest = timeoutCall?.[1] as { body?: { timeoutMs?: number } } | undefined;
     const timeoutOptions = timeoutCall?.[2] as { timeoutMs?: number } | undefined;
     expect(timeoutRequest?.body?.timeoutMs).toBe(20_000);
-    expect(timeoutOptions?.timeoutMs).toBeGreaterThan(20_000);
+    expect(timeoutOptions?.timeoutMs).toBe(25_250);
   });
 });

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.element.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.element.ts
@@ -4,6 +4,7 @@
  */
 import type { Command } from "commander";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { BrowserActRequest } from "../../browser/client-actions.types.js";
 import {
   BROWSER_TAB_REFERENCE_HELP,
   parseBrowserNonNegativeIntegerOption,
@@ -44,9 +45,8 @@ export function registerBrowserElementCommands(
 
   const runElementAction = async (params: {
     cmd: Command;
-    body: Record<string, unknown>;
+    body: BrowserActRequest;
     successMessage: string | ((result: unknown) => string);
-    timeoutMs?: number;
   }): Promise<void> => {
     const { parent, profile } = resolveBrowserActionContext(params.cmd, parentOpts);
     try {
@@ -54,7 +54,6 @@ export function registerBrowserElementCommands(
         parent,
         profile,
         body: params.body,
-        timeoutMs: params.timeoutMs,
       });
       const successMessage =
         typeof params.successMessage === "function"
@@ -215,7 +214,6 @@ export function registerBrowserElementCommands(
           targetId: normalizeOptionalString(opts.targetId),
           timeoutMs,
         },
-        timeoutMs,
         successMessage: `scrolled into view: ${refValue}`,
       });
     });

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
@@ -70,6 +70,7 @@ describe("browser action input fill command", () => {
       ],
       targetId: "tab-1",
     });
+    expect(mocks.callBrowserRequest.mock.calls.at(-1)?.[2]).toEqual({ timeoutMs: 65_000 });
   });
 
   it("reports malformed fields without sending a browser request", async () => {
@@ -220,25 +221,32 @@ describe("browser action input evaluate command", () => {
       ref: "button-1",
       targetId: "tab-2",
     });
+    expect(mocks.callBrowserRequest.mock.calls.at(-1)?.[2]).toEqual({ timeoutMs: 65_000 });
   });
 
-  it("passes timeout-ms through to the evaluate action and outer request", async () => {
-    const program = createActionInputProgram();
+  it.each([
+    { rawTimeout: "+030000", actionTimeoutMs: 30_000, requestTimeoutMs: 35_250 },
+    { rawTimeout: "1", actionTimeoutMs: 1, requestTimeoutMs: 5_750 },
+  ])(
+    "preserves the $rawTimeout evaluate timeout and canonical outer deadline",
+    async ({ rawTimeout, actionTimeoutMs, requestTimeoutMs }) => {
+      const program = createActionInputProgram();
 
-    await program.parseAsync(
-      ["browser", "evaluate", "--fn", "() => true", "--timeout-ms", "+030000"],
-      { from: "user" },
-    );
+      await program.parseAsync(
+        ["browser", "evaluate", "--fn", "() => true", "--timeout-ms", rawTimeout],
+        { from: "user" },
+      );
 
-    const request = mocks.callBrowserRequest.mock.calls.at(-1)?.[1] as
-      | { body?: { timeoutMs?: number } }
-      | undefined;
-    const options = mocks.callBrowserRequest.mock.calls.at(-1)?.[2] as
-      | { timeoutMs?: number }
-      | undefined;
-    expect(request?.body?.timeoutMs).toBe(30000);
-    expect(options?.timeoutMs).toBeGreaterThan(30000);
-  });
+      const request = mocks.callBrowserRequest.mock.calls.at(-1)?.[1] as
+        | { body?: { timeoutMs?: number } }
+        | undefined;
+      const options = mocks.callBrowserRequest.mock.calls.at(-1)?.[2] as
+        | { timeoutMs?: number }
+        | undefined;
+      expect(request?.body?.timeoutMs).toBe(actionTimeoutMs);
+      expect(options?.timeoutMs).toBe(requestTimeoutMs);
+    },
+  );
 
   it("rejects non-decimal evaluate timeouts before dispatch", async () => {
     const program = createActionInputProgram();

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
@@ -3,7 +3,6 @@
  */
 import type { Command } from "commander";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveBrowserActExecutionBudgetMs } from "../../browser/act-policy.js";
 import type { BrowserActRequest } from "../../browser/client-actions.types.js";
 import {
   BROWSER_TAB_REFERENCE_HELP,
@@ -114,7 +113,6 @@ export function registerBrowserFormWaitEvalCommands(
           parent,
           profile,
           body: request,
-          timeoutMs: resolveBrowserActExecutionBudgetMs(request),
         });
         logBrowserActionResult(parent, result, "wait complete");
       } catch (err) {
@@ -156,7 +154,6 @@ export function registerBrowserFormWaitEvalCommands(
             targetId: normalizeOptionalString(opts.targetId),
             timeoutMs,
           },
-          timeoutMs,
         });
         if (parent?.json) {
           defaultRuntime.writeJson(result);

--- a/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
@@ -4,11 +4,9 @@
 import fs from "node:fs/promises";
 import type { Command } from "commander";
 import { FsSafeError, readRegularFile } from "openclaw/plugin-sdk/security-runtime";
-import {
-  callBrowserRequest,
-  withBrowserActionTimeoutSlack,
-  type BrowserParentOpts,
-} from "../browser-cli-shared.js";
+import { resolveBrowserActRequestTimeoutMs } from "../../browser/act-policy.js";
+import type { BrowserActRequest } from "../../browser/client-actions.types.js";
+import { callBrowserRequest, type BrowserParentOpts } from "../browser-cli-shared.js";
 import {
   danger,
   defaultRuntime,
@@ -36,8 +34,7 @@ export function resolveBrowserActionContext(
 export async function callBrowserAct<T = unknown>(params: {
   parent: BrowserParentOpts;
   profile?: string;
-  body: Record<string, unknown>;
-  timeoutMs?: number;
+  body: BrowserActRequest;
 }): Promise<T> {
   return await callBrowserRequest<T>(
     params.parent,
@@ -47,7 +44,7 @@ export async function callBrowserAct<T = unknown>(params: {
       query: params.profile ? { profile: params.profile } : undefined,
       body: params.body,
     },
-    { timeoutMs: withBrowserActionTimeoutSlack(params.timeoutMs) },
+    { timeoutMs: resolveBrowserActRequestTimeoutMs(params.body) },
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Browser CLI action commands armed their outer Gateway watchdog for 25 seconds even though the documented existing-session action owner allows 60 seconds. A valid `openclaw browser --browser-profile user click ...`, form fill, hover, drag, selection, or JavaScript evaluation could therefore be cancelled early with a generic transport timeout. Explicit evaluation and scroll deadlines also omitted the owner's 250 ms navigation grace and 500 ms minimum action clamp.

## Why This Change Was Made

The Browser action owner already exposes a canonical `resolveBrowserActRequestTimeoutMs` policy, and the programmatic browser client already uses it. Route every CLI `/act` request through that same owner, strengthen the shared action body to the existing `BrowserActRequest` type, and delete duplicate timeout calculations and argument plumbing from element, wait, batch, and evaluation callers. Keep the intermediate execution-budget helper private and exercise deadline arithmetic through its actual public request-policy boundary. Preserve batch's existing raw-input boundary and route-owned validation; response-body, upload, and download timeout policies remain unchanged.

## User Impact

All eight Browser element commands, form fills, and evaluations now receive the existing canonical 65-second transport deadline when no operation timeout is provided. Explicit 20-second scroll and 30-second evaluation actions receive 25,250 ms and 35,250 ms respectively; a 1 ms evaluation correctly receives 5,750 ms after the existing minimum-action and navigation-grace policies. Sequential wait and batch deadlines remain unchanged. No CLI flags, configuration, authorization, persistence, protocols, or external dependencies change.

## Evidence

- Captured **13 failing real-Commander regressions** against unchanged production: eight element leaves and default fill/evaluate received 25,000 ms instead of 65,000 ms; explicit scroll/evaluation missed canonical navigation grace and minimum clamping. Existing raw-invalid batch input and sequential wait paths stayed green as controls.
- After the owner refactor, **141 tests across 13 suites pass**, covering every changed CLI command, batch boundary, wait sequencing, existing response-body/upload/download siblings, lazy registration, canonical action policy, programmatic browser client, Gateway timeout behavior, and the latest upstream batch-file size/FIFO/symlink security regressions.
- The same 13 regressions were also reproduced against all four exact current-main production Git objects after rebasing onto the concurrent batch-file hardening change; its security implementation and tests remain byte-for-byte intact.
- All five changed production files pass the actual strict plugin TypeScript project, loading more than 10,690 real transitive source files with zero diagnostics; all four changed tests pass the actual strict plugin-test project, loading more than 10,780 source files with zero diagnostics.
- The existing pinned Knip 6.32.2 production dependency/export guard passes after removing the obsolete intermediate execution-budget export; owner tests cover minimum clamping, single transport grace, nested batches, and timer-limit saturation through the real public request boundary.
- Exact-file formatting, plugin oxlint, max-lines and assertion-safety ratchets, and changed-lane classification pass. Independent source-blind architectural review and fresh authenticated Codex review report no actionable findings.
- Production LOC: **+9/-19 (net -10)**. Tests: **+57/-49**. Real Commander parser and owner/Gateway behavior were exercised without touching the operator's running managed browser or Gateway.
