### PR TITLE
fix(active-memory): recall from Codex Dashboard sessions

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -1176,6 +1176,44 @@ describe("active-memory plugin", () => {
     });
   });
 
+  it("runs product recall for an opted-in Dashboard session from the canonical channel", async () => {
+    syncRuntimePluginConfig({ agents: [], logging: true });
+    configFile = {
+      ...configFile,
+      agents: {
+        list: [
+          {
+            id: "personal",
+            workspace: "/tmp/live-personal-workspace",
+            agentDir: "/tmp/live-personal-agent",
+            model: { primary: "openai/gpt-5.5" },
+            memory: { search: { rememberAcrossConversations: true } },
+          },
+        ],
+      },
+    };
+    const sessionKey = "agent:personal:dashboard:12345";
+    hoisted.sessionStore[sessionKey] = { sessionId: "s-dashboard", updatedAt: 0 };
+
+    await runPromptBuild(
+      { prompt: "what do I usually order?" },
+      {
+        agentId: "personal",
+        sessionKey,
+        messageProvider: undefined,
+        channel: "webchat",
+        channelId: "webchat",
+      },
+    );
+
+    expect(lastEmbeddedRunParams().conversationRecall).toEqual({
+      anchorSessionKey: sessionKey,
+      scope: "same-agent-private",
+      corpus: "sessions",
+    });
+    expect(lastEmbeddedRunParams().toolsAllow).toEqual(["memory_search"]);
+  });
+
   it("keeps product recall available when Lossless Claw owns the context-engine slot", async () => {
     syncRuntimePluginConfig({ agents: [], logging: true });
     configFile = {

--- a/extensions/active-memory/session-policy.ts
+++ b/extensions/active-memory/session-policy.ts
@@ -220,6 +220,7 @@ function isEligibleInteractiveSession(ctx: {
   trigger?: string;
   sessionKey?: string;
   sessionId?: string;
+  channel?: string;
   messageProvider?: string;
   channelId?: string;
 }): boolean {
@@ -242,7 +243,7 @@ function isEligibleInteractiveSession(ctx: {
   if (!ctx.sessionKey && !ctx.sessionId) {
     return false;
   }
-  const provider = (ctx.messageProvider ?? "").trim().toLowerCase();
+  const provider = (ctx.channel ?? ctx.messageProvider ?? "").trim().toLowerCase();
   if (provider === "webchat") {
     return true;
   }
@@ -251,6 +252,7 @@ function isEligibleInteractiveSession(ctx: {
 
 function resolveChatType(ctx: {
   sessionKey?: string;
+  channel?: string;
   messageProvider?: string;
   channelId?: string;
   mainKey?: string;
@@ -278,14 +280,14 @@ function resolveChatType(ctx: {
       agentSessionParts[0] === "agent" &&
       (agentSessionParts[2] === mainKey || agentSessionParts[2] === "main")
     ) {
-      const provider = (ctx.messageProvider ?? "").trim().toLowerCase();
+      const provider = (ctx.channel ?? ctx.messageProvider ?? "").trim().toLowerCase();
       const channelId = (ctx.channelId ?? "").trim();
       if (provider && provider !== "webchat" && channelId) {
         return "direct";
       }
     }
   }
-  const provider = (ctx.messageProvider ?? "").trim().toLowerCase();
+  const provider = (ctx.channel ?? ctx.messageProvider ?? "").trim().toLowerCase();
   if (provider === "webchat") {
     return "direct";
   }
@@ -296,6 +298,7 @@ function isAllowedChatType(
   config: ResolvedActiveRecallPluginConfig,
   ctx: {
     sessionKey?: string;
+    channel?: string;
     messageProvider?: string;
     channelId?: string;
     mainKey?: string;
@@ -310,6 +313,7 @@ function isAllowedChatType(
 
 function isPrivateRecallDestination(ctx: {
   sessionKey?: string;
+  channel?: string;
   messageProvider?: string;
   channelId?: string;
   mainKey?: string;

--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -1,5 +1,6 @@
 import {
   bootstrapHarnessContextEngine,
+  buildAgentHookContextChannelFields,
   buildHarnessContextEngineRuntimeContext,
   CODEX_APP_SERVER_CONTEXT_ENGINE_HOST,
   embeddedAgentLog,
@@ -103,6 +104,13 @@ export async function prepareCodexAttemptContext(
     sessionKey: sandboxSessionKey,
     sessionId: params.sessionId,
     workspaceDir: params.workspaceDir,
+    channel: buildAgentHookContextChannelFields({
+      sessionKey: sandboxSessionKey,
+      messageChannel: params.messageChannel,
+      messageProvider: params.messageProvider,
+      currentChannelId: params.currentChannelId,
+      messageTo: params.messageTo,
+    }).channel,
     messageProvider: params.messageProvider ?? undefined,
     trigger: params.trigger,
     channelId: hookChannelId,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2908,7 +2908,10 @@ describe("runCodexAppServerAttempt", () => {
     const sessionManager = openRunSession(sessionFile);
     sessionManager.appendMessage(assistantMessage("previous turn", Date.now()));
     const harness = createStartedThreadHarness();
-    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    const params = createParams(sessionFile, workspaceDir);
+    params.messageChannel = "webchat";
+    params.messageProvider = undefined;
+    const run = runCodexAppServerAttempt(params);
     await harness.waitForMethod("turn/start");
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
@@ -2921,7 +2924,7 @@ describe("runCodexAppServerAttempt", () => {
         messages?: Array<{ content?: Array<{ text?: string; type?: string }>; role?: string }>;
         prompt?: string;
       },
-      { runId?: string; sessionId?: string },
+      { channel?: string; messageProvider?: string; runId?: string; sessionId?: string },
     ];
     expect(hookInput.prompt).toBe("hello");
     expect(hookInput.messages).toEqual([
@@ -2932,6 +2935,8 @@ describe("runCodexAppServerAttempt", () => {
     ]);
     expect(hookContext.runId).toBe("run-1");
     expect(hookContext.sessionId).toBe("session-1");
+    expect(hookContext.channel).toBe("webchat");
+    expect(hookContext.messageProvider).toBeUndefined();
     const threadStart = harness.requests.find((request) => request.method === "thread/start");
     const threadStartParams = threadStart?.params as { developerInstructions?: string } | undefined;
     const wrappedPluginSystemContext = (text: string) =>


### PR DESCRIPTION
## What Problem This Solves

Active Memory can be enabled for an opted-in Dashboard session and still skip recall when that session runs through the Codex app-server harness. The Codex attempt context retained `messageProvider`, but did not propagate OpenClaw's canonical `channel`, so a normal `webchat` turn could reach the Active Memory policy with neither field populated.

Closes #130051.

## Why This Change Was Made

The existing OpenClaw hook-context helper already defines the canonical channel contract used by sibling runtimes. This change reuses that helper in the Codex attempt context and lets Active Memory consume `channel` with the existing `messageProvider` as compatibility fallback. It does not add a new routing or memory mechanism.

## User Impact

Users who explicitly enable cross-conversation recall can use it from Codex-backed Dashboard sessions. Existing DM/group policy, allowlists, and disabled-recall behavior remain unchanged.

## Evidence

- Failed first on current `main`: the Active Memory policy test reported no embedded recall run, and the Codex hook-context test received `channel: undefined` instead of `webchat`.
- Passed after the fix on exact head `fbc37607bef41e0acc4756060d3a8cd7bff9a876`:
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-active-memory.config.ts --maxWorkers=1 --no-file-parallelism extensions/active-memory/index.test.ts -t "runs product recall for an opted-in Dashboard session from the canonical channel"`
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-attempt.config.ts --maxWorkers=1 --no-file-parallelism extensions/codex/src/app-server/run-attempt.test.ts -t "applies before_prompt_build to Codex developer instructions and turn input"`
- `oxfmt --check` passed for all four changed files.
- `git diff --check upstream/main...HEAD` passed.

Local full-file Vitest runs were attempted but the shared SQLite fixture failed to open before behavioral assertions (`unable to open database file`) across both files on Windows. The focused regression paths above are green; repository CI remains the full-suite authority.
