### PR TITLE
refactor(backup): centralize outcome recording

### DIFF
--- a/src/commands/backup-git.test.ts
+++ b/src/commands/backup-git.test.ts
@@ -113,6 +113,22 @@ describe("Git backup command agent selection", () => {
     expect(mocks.createGitBackup).toHaveBeenCalledOnce();
   });
 
+  it("preserves the Git-specific warning when outcome recording fails", async () => {
+    mocks.recordBackupRunOutcome.mockImplementation(() => {
+      throw new Error("record failed");
+    });
+    const runtime = createTestRuntime();
+
+    await backupGitCreateCommand(runtime, {
+      repository: "/tmp/repository",
+      global: true,
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Warning: the Git backup outcome could not be recorded: record failed",
+    );
+  });
+
   it("resolves every current agent and its configured root for an all-scope backup", async () => {
     const mainAgentDir = path.resolve("/tmp/external-main");
     const opsAgentDir = path.resolve("/tmp/external-ops");

--- a/src/commands/backup-git.ts
+++ b/src/commands/backup-git.ts
@@ -13,10 +13,13 @@ import {
   restoreGitBackupRef,
   verifyGitBackupRef,
 } from "../snapshot/git-backup.js";
-import { recordBackupRunOutcome } from "../state/backup-run-records.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { shortenHomePath } from "../utils.js";
-import { resolveBackupAgentRoot, resolveRequiredBackupPath } from "./backup-shared.js";
+import {
+  recordBackupOutcomeBestEffort,
+  resolveBackupAgentRoot,
+  resolveRequiredBackupPath,
+} from "./backup-shared.js";
 
 type BackupGitCreateOptions = {
   repository?: string;
@@ -107,32 +110,6 @@ function resolveOneIdentity(options: BackupGitScopeOptions): GitBackupIdentity {
     : { role: "agent", agentId: normalizeAgentId(agent) };
 }
 
-function recordGitOutcomeBestEffort(
-  runtime: RuntimeEnv,
-  params: {
-    repositoryPath: string;
-    status: "ok" | "failed";
-    target?: string;
-    error?: string;
-    pushFailed?: true;
-  },
-): void {
-  try {
-    recordBackupRunOutcome({
-      kind: "git",
-      archivePath: params.repositoryPath,
-      status: params.status,
-      target: params.target,
-      error: params.error,
-      pushFailed: params.pushFailed,
-    });
-  } catch (error) {
-    runtime.error(
-      `Warning: the Git backup outcome could not be recorded: ${formatErrorMessage(error)}`,
-    );
-  }
-}
-
 export async function backupGitInitCommand(
   runtime: RuntimeEnv,
   options: { repository?: string; remote?: string; json?: boolean },
@@ -166,8 +143,9 @@ export async function backupGitCreateCommand(runtime: RuntimeEnv, options: Backu
     });
     // A completed local backup remains successful even when requested remote replication fails;
     // pushFailed records that durable degradation without discarding the recoverable local commit.
-    recordGitOutcomeBestEffort(runtime, {
-      repositoryPath,
+    recordBackupOutcomeBestEffort(runtime, {
+      kind: "git",
+      archivePath: repositoryPath,
       status: "ok",
       target: result.commit,
       error: result.pushWarning,
@@ -185,8 +163,9 @@ export async function backupGitCreateCommand(runtime: RuntimeEnv, options: Backu
     }
     return result;
   } catch (error) {
-    recordGitOutcomeBestEffort(runtime, {
-      repositoryPath,
+    recordBackupOutcomeBestEffort(runtime, {
+      kind: "git",
+      archivePath: repositoryPath,
       status: "failed",
       error: formatErrorMessage(error),
     });

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -9,10 +9,13 @@ import {
   resolveStateDir,
 } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import {
   resolveActivatedPluginBackupInventory,
   type ActivatedPluginBackupInventory,
 } from "../plugins/manifest-backup-resources.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { recordBackupRunOutcome } from "../state/backup-run-records.js";
 import { pathExists, resolveUserPath, shortenHomePath } from "../utils.js";
 import {
   createBackupResourceInventory,
@@ -26,6 +29,20 @@ import { resolveUpgradeConfigSnapshot } from "./doctor/shared/automatic-upgrade-
 // DEFLATE can legitimately encode zero-filled sparse ranges just over 1000:1.
 // Keep bounded headroom without disabling node-tar's decompression bomb guard.
 export const BACKUP_MAX_DECOMPRESSION_RATIO = 1100;
+
+export function recordBackupOutcomeBestEffort(
+  runtime: RuntimeEnv,
+  params: Parameters<typeof recordBackupRunOutcome>[0],
+): void {
+  try {
+    recordBackupRunOutcome(params);
+  } catch (error) {
+    const label = params.kind === "git" ? "Git backup" : "backup";
+    runtime.error(
+      `Warning: the ${label} outcome could not be recorded: ${formatErrorMessage(error)}`,
+    );
+  }
+}
 
 export function resolveRequiredBackupPath(
   value: string | undefined,

--- a/src/commands/backup-sqlite.ts
+++ b/src/commands/backup-sqlite.ts
@@ -12,10 +12,13 @@ import type {
   SnapshotRef,
   SnapshotSummary,
 } from "../snapshot/snapshot-provider.js";
-import { recordBackupRunOutcome } from "../state/backup-run-records.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { shortenHomePath } from "../utils.js";
-import { resolveBackupAgentRoot, resolveRequiredBackupPath } from "./backup-shared.js";
+import {
+  recordBackupOutcomeBestEffort,
+  resolveBackupAgentRoot,
+  resolveRequiredBackupPath,
+} from "./backup-shared.js";
 
 type BackupSqliteCreateOptions = {
   global?: boolean;
@@ -85,32 +88,21 @@ export async function backupSqliteCreateCommand(
       snapshotPath: result.ref.path,
       manifest: result.manifest,
     };
-    recordSqliteOutcomeBestEffort(runtime, {
+    recordBackupOutcomeBestEffort(runtime, {
+      kind: "sqlite-snapshot",
       archivePath: report.snapshotPath,
       status: "ok",
     });
     writeCreateResult(runtime, options, report);
     return report;
   } catch (error) {
-    recordSqliteOutcomeBestEffort(runtime, {
+    recordBackupOutcomeBestEffort(runtime, {
+      kind: "sqlite-snapshot",
       archivePath: repositoryPath,
       status: "failed",
       error: formatErrorMessage(error),
     });
     throw error;
-  }
-}
-
-function recordSqliteOutcomeBestEffort(
-  runtime: RuntimeEnv,
-  params: { archivePath: string; status: "ok" | "failed"; error?: string },
-): void {
-  try {
-    recordBackupRunOutcome({ kind: "sqlite-snapshot", ...params });
-  } catch (error) {
-    runtime.error(
-      `Warning: the backup outcome could not be recorded: ${formatErrorMessage(error)}`,
-    );
   }
 }
 

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -8,7 +8,7 @@ import {
 import { formatErrorMessage } from "../infra/errors.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
-import { recordBackupRunOutcome } from "../state/backup-run-records.js";
+import { recordBackupOutcomeBestEffort } from "./backup-shared.js";
 
 type BackupVerifyRuntime = typeof import("./backup-verify.js");
 
@@ -45,6 +45,7 @@ export async function backupCreateCommand(
     }
     if (!opts.dryRun) {
       recordBackupOutcomeBestEffort(runtime, {
+        kind: "archive",
         archivePath,
         status: "ok",
       });
@@ -58,24 +59,12 @@ export async function backupCreateCommand(
   } catch (error) {
     if (!opts.dryRun) {
       recordBackupOutcomeBestEffort(runtime, {
+        kind: "archive",
         archivePath,
         status: "failed",
         error: formatErrorMessage(error),
       });
     }
     throw error;
-  }
-}
-
-function recordBackupOutcomeBestEffort(
-  runtime: RuntimeEnv,
-  params: { archivePath: string; status: "ok" | "failed"; error?: string },
-): void {
-  try {
-    recordBackupRunOutcome({ kind: "archive", ...params });
-  } catch (error) {
-    runtime.error(
-      `Warning: the backup outcome could not be recorded: ${formatErrorMessage(error)}`,
-    );
   }
 }


### PR DESCRIPTION
## What Problem This Solves

The archive, Git, and SQLite backup commands each maintained a private best-effort wrapper around the same durable outcome recorder. Keeping three copies made the record fields and failure-warning policy easy to drift while preserving no independent behavior.

## Why This Change Was Made

This moves the shared error handling into the existing backup command helper owner. Each caller still passes its explicit backup kind and all existing record fields, and the helper preserves the generic archive/SQLite warning plus the Git-specific warning byte-for-byte.

## User Impact

No user-visible behavior changes. Maintainers now have one command-owned path for backup outcome recording instead of three near-identical wrappers.

Production delta: +40/−63 (net −23 LOC). Test delta: +16/−0.

## Evidence

- `node scripts/run-vitest.mjs src/commands/backup.create-verify.test.ts src/commands/backup-git.test.ts src/commands/backup-sqlite.test.ts src/commands/backup-shared.test.ts src/state/backup-run-records.test.ts` — 32 tests passed across both selected Vitest projects after rebasing onto current `origin/main`.
- `node scripts/check-changed.mjs -- src/commands/backup.ts src/commands/backup-git.ts src/commands/backup-git.test.ts src/commands/backup-sqlite.ts src/commands/backup-shared.ts` — passed all selected guards, formatting, dead-export scans, production/test typechecks, lint, and architecture checks.
- `git diff --check origin/main...HEAD` — passed.
- Structured Codex autoreview (`gpt-5.6-sol`, high) — no accepted/actionable findings; reviewer confirmed record fields and all three warning paths are preserved.

AI-assisted: yes (Amp).
