### PR TITLE
fix(bedrock): reject invalid UTF-8 model discovery

### DIFF
--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -632,6 +632,25 @@ describe("bedrock mantle discovery", () => {
     expect(json).not.toHaveBeenCalled();
   });
 
+  it("rejects invalid UTF-8 model discovery responses", async () => {
+    const prefix = new TextEncoder().encode('{"data":[{"id":"anthropic.');
+    const suffix = new TextEncoder().encode('.model","object":"model"}]}');
+    const invalidBody = new Uint8Array([...prefix, 0xff, ...suffix]);
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(invalidBody, { headers: { "content-type": "application/json" } }),
+      );
+
+    const models = await discoverMantleModels({
+      region: "us-east-1",
+      bearerToken: "test-token",
+      fetchFn: mockFetch as unknown as typeof fetch,
+    });
+
+    expect(models).toStrictEqual([]);
+  });
+
   // ---------------------------------------------------------------------------
   // Discovery caching
   // ---------------------------------------------------------------------------

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -636,16 +636,14 @@ describe("bedrock mantle discovery", () => {
     const prefix = new TextEncoder().encode('{"data":[{"id":"anthropic.');
     const suffix = new TextEncoder().encode('.model","object":"model"}]}');
     const invalidBody = new Uint8Array([...prefix, 0xff, ...suffix]);
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(invalidBody, { headers: { "content-type": "application/json" } }),
-      );
+    const mockFetch = vi.fn<typeof fetch>(
+      async () => new Response(invalidBody, { headers: { "content-type": "application/json" } }),
+    );
 
     const models = await discoverMantleModels({
-      region: "us-east-1",
+      region: testRegion,
       bearerToken: "test-token",
-      fetchFn: mockFetch as unknown as typeof fetch,
+      fetchFn: mockFetch,
     });
 
     expect(models).toStrictEqual([]);

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -8,11 +8,11 @@ import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -278,18 +278,14 @@ function inferReasoningSupport(modelId: string): boolean {
 }
 
 async function readMantleModelDiscoveryJson(response: Response): Promise<OpenAIModelsResponse> {
-  const bytes = await readResponseWithLimit(response, MANTLE_DISCOVERY_RESPONSE_MAX_BYTES, {
+  const body = await readProviderJsonResponse<unknown>(response, "Mantle model discovery", {
+    maxBytes: MANTLE_DISCOVERY_RESPONSE_MAX_BYTES,
     chunkTimeoutMs: MANTLE_DISCOVERY_TIMEOUT_MS,
-    onOverflow: ({ size, maxBytes }) =>
-      new Error(
-        `Mantle model discovery response exceeded ${maxBytes} bytes (${size} bytes received)`,
-      ),
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(
         `Mantle model discovery response stalled: no data received for ${chunkTimeoutMs}ms`,
       ),
   });
-  const body = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)) as unknown;
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     return {};
   }

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -289,7 +289,7 @@ async function readMantleModelDiscoveryJson(response: Response): Promise<OpenAIM
         `Mantle model discovery response stalled: no data received for ${chunkTimeoutMs}ms`,
       ),
   });
-  const body = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+  const body = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)) as unknown;
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     return {};
   }


### PR DESCRIPTION
## What Problem This Solves

Bedrock Mantle model discovery accepted malformed UTF-8 response bytes. The decoder replaced invalid bytes with `�`, so an otherwise valid JSON response could publish and cache a corrupted model ID.

## Why This Change Was Made

The Mantle catalog reader bounded the response size, but it decoded the bytes with the default replacement behavior instead of the shared provider JSON reader's fatal UTF-8 validation.

The fix routes the bounded Mantle catalog through the plugin SDK provider JSON reader. This gives provider JSON one canonical decoding path while preserving Mantle's response cap, idle timeout, cache, and stale-result behavior.

The regression test uses the existing production discovery entrypoint, a typed fetch boundary, and a unique region so module-level cache state cannot affect later tests.

## User Impact

Malformed provider responses no longer expose or cache replacement-character model IDs. Valid catalogs continue to return their models.

## Evidence

- Exact current main `873e1c85fa5a45751c3d66dc8da4dea70ed8fef5`: the production discovery entrypoint returned `["anthropic.�.model"]` for an otherwise valid catalog containing byte `0xff`.
- Exact head `e05b9c376ff329280024631e633102c42be92618`: the identical response returned no discovered models.
- The same production-boundary harness accepted a valid near-limit catalog and rejected an oversized catalog on both revisions.
- The regression test failed on current main for the intended corrupted-ID assertion and passed all 59 Mantle plugin tests on exact head.
- A real AWS Bedrock Mantle `/v1/models` request on exact head returned 55 valid models and zero IDs containing replacement characters.
- AWS controls the real catalog response bytes and exposes no request option that can induce malformed UTF-8. The deterministic malformed-byte production-boundary A/B is authoritative for that failure mode; the live AWS request confirms valid catalog behavior.
