### PR TITLE
test(oc-path): remove duplicate scenario coverage

### DIFF
--- a/extensions/oc-path/src/oc-path/tests/scenarios/oc-path-parse-edges.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/scenarios/oc-path-parse-edges.test.ts
@@ -13,22 +13,6 @@ function expectErr(fn: () => unknown, code: string): void {
 }
 
 describe("oc-path-parse-edges", () => {
-  it("file + section", () => {
-    expect(parseOcPath("oc://SOUL.md/Boundaries").section).toBe("Boundaries");
-  });
-
-  it("file + section + item", () => {
-    expect(parseOcPath("oc://SOUL.md/Boundaries/deny-rule-1").item).toBe("deny-rule-1");
-  });
-
-  it("file + section + item + field", () => {
-    expect(parseOcPath("oc://SOUL.md/B/deny-1/risk").field).toBe("risk");
-  });
-
-  it("session query parameter", () => {
-    expect(parseOcPath("oc://X.md?session=daily").session).toBe("daily");
-  });
-
   it("session with full path", () => {
     const p = parseOcPath("oc://X.md/sec/item/field?session=cron");
     expect(p).toEqual({
@@ -55,28 +39,8 @@ describe("oc-path-parse-edges", () => {
     expect(p.session).toBeUndefined();
   });
 
-  it("missing scheme throws", () => {
-    expectErr(() => parseOcPath("SOUL.md"), "OC_PATH_MISSING_SCHEME");
-  });
-
   it("wrong scheme throws", () => {
     expectErr(() => parseOcPath("https://x.com"), "OC_PATH_MISSING_SCHEME");
-  });
-
-  it("empty after scheme throws", () => {
-    expectErr(() => parseOcPath("oc://"), "OC_PATH_EMPTY");
-  });
-
-  it("empty segment throws", () => {
-    expectErr(() => parseOcPath("oc://X.md//item"), "OC_PATH_EMPTY_SEGMENT");
-  });
-
-  it("too-deep nesting throws", () => {
-    expectErr(() => parseOcPath("oc://X.md/a/b/c/d/e"), "OC_PATH_TOO_DEEP");
-  });
-
-  it("non-string throws", () => {
-    expectErr(() => parseOcPath(42 as unknown as string), "OC_PATH_NOT_STRING");
   });
 
   it("round-trip canonical forms", () => {
@@ -110,14 +74,6 @@ describe("oc-path-parse-edges", () => {
     const p = parseOcPath("oc://X.md/[frontmatter]/name");
     expect(p.section).toBe("[frontmatter]");
     expect(p.item).toBe("name");
-  });
-
-  it("formatOcPath rejects empty file", () => {
-    expectErr(() => formatOcPath({ file: "" }), "OC_PATH_FILE_REQUIRED");
-  });
-
-  it("formatOcPath rejects item without section", () => {
-    expectErr(() => formatOcPath({ file: "X.md", item: "i" }), "OC_PATH_NESTING");
   });
 
   it("formatOcPath quotes raw slot values containing special chars", () => {

--- a/extensions/oc-path/src/oc-path/tests/sentinel.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/sentinel.test.ts
@@ -3,22 +3,6 @@ import { describe, expect, it } from "vitest";
 import { OcEmitSentinelError, REDACTED_SENTINEL, guardSentinel } from "../sentinel.js";
 
 describe("guardSentinel", () => {
-  it("passes through normal strings", () => {
-    expect(() => guardSentinel("normal value", "oc://SOUL.md")).not.toThrow();
-  });
-
-  it("passes through non-string values", () => {
-    expect(() => guardSentinel(42, "oc://SOUL.md")).not.toThrow();
-    expect(() => guardSentinel(null, "oc://SOUL.md")).not.toThrow();
-    expect(() => guardSentinel(undefined, "oc://SOUL.md")).not.toThrow();
-  });
-
-  it("throws on the sentinel literal", () => {
-    expect(() => guardSentinel(REDACTED_SENTINEL, "oc://SOUL.md/[fm]/token")).toThrow(
-      OcEmitSentinelError,
-    );
-  });
-
   it("attaches the OcPath in the error", () => {
     try {
       guardSentinel(REDACTED_SENTINEL, "oc://config/plugins.entries.foo.token");


### PR DESCRIPTION
## What Problem This Solves

The OC Path test tree reasserted 14 parser/formatter/sentinel cases in weaker scenario tests even though focused owner suites already prove the same contracts with stronger assertions.

## Why This Change Was Made

- remove 11 strict-subset parser and formatter cases from `oc-path-parse-edges.test.ts`; retain every unique query, quoting, round-trip, nesting, and wildcard edge
- remove 3 duplicate sentinel pass/throw cases from `sentinel.test.ts`; retain its unique error path/code proof and the stronger scenario sentinel suite
- keep production code and runtime behavior unchanged

## User Impact

None at runtime. The same OC Path behavior remains covered with less duplicate test execution and clearer ownership.

## Evidence

- baseline focused suite: 4 files, 70 tests passed
- post-change focused suite: 4 files, 56 tests passed
- `node scripts/check-changed.mjs --dry-run -- extensions/oc-path/src/oc-path/tests/scenarios/oc-path-parse-edges.test.ts extensions/oc-path/src/oc-path/tests/sentinel.test.ts`
- `node scripts/check-changed.mjs -- extensions/oc-path/src/oc-path/tests/scenarios/oc-path-parse-edges.test.ts extensions/oc-path/src/oc-path/tests/sentinel.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean; no accepted/actionable findings)
- `git diff --check`
