### PR TITLE
refactor(cli): reuse node connection reminder

### DIFF
--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -35,6 +35,7 @@ import {
 } from "../shared/device-pairing-access.js";
 import { formatCliCommand } from "./command-format.js";
 import { callGatewayFromCliWithTransport } from "./gateway-rpc.js";
+import { formatConnectionFlagReminder } from "./nodes-cli/cli-utils.js";
 import { quoteCliArg } from "./quote-cli-arg.js";
 
 type DevicesRpcOpts = {
@@ -144,16 +145,6 @@ function buildNodeApproveCommand(opts: DevicesRpcOpts, requestId: string): strin
   return formatCliCommand(args.map(quoteCliArg).join(" "));
 }
 
-function formatNodeConnectionFlagReminder(opts: DevicesRpcOpts): string | null {
-  const flags = [
-    normalizeOptionalString(opts.url) ? "--url" : null,
-    normalizeOptionalString(opts.token) ? "--token" : null,
-  ].filter((flag) => flag !== null);
-  return flags.length > 0
-    ? `Reuse the same connection option${flags.length === 1 ? "" : "s"} when rerunning: ${flags.join(", ")}.`
-    : null;
-}
-
 function stringsMatch(left: unknown, right: unknown): boolean {
   const normalizedLeft = normalizeOptionalString(left);
   const normalizedRight = normalizeOptionalString(right);
@@ -186,7 +177,7 @@ function buildPendingNodeApprovalNotice(
       normalizeOptionalString(device.displayName) ??
       device.deviceId,
     command: buildNodeApproveCommand(opts, requestId),
-    connectionReminder: formatNodeConnectionFlagReminder(opts),
+    connectionReminder: formatConnectionFlagReminder(opts),
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

The devices and nodes CLI paths independently owned identical wording and connection-flag selection for node-approval rerun guidance. That duplicated policy could drift even though both surfaces intentionally emit the same reminder.

## Why This Change Was Made

Reuse the existing nodes CLI formatter from the devices runtime and remove the later private copy. The canonical helper predates the duplicate and accepts the same `url`/`token` option shape; command registration, flags, output bytes and order, exits, side effects, and lazy runtime loading remain unchanged.

## User Impact

No user-visible behavior changes. Operators receive the same reminder text in the same location, and credentials remain redacted.

## Evidence

- Focused CLI proof: 103/103 tests passed (`devices-cli.test.ts`, `nodes-cli.coverage.test.ts`), including exact reminder bytes and secret redaction.
- Exact-head formatting and oxlint: clean.
- Changed-file guards: conflict markers, formatting, dead exports, production core typecheck, plugin/import boundaries, dependency pins, and architecture guards passed. The broader core-test declaration pass reaches the same unrelated current-main `pako` declaration gap in `ui/vite.config.ts`; exact-head CI remains authoritative.
- Import-cycle check: zero runtime value cycles.
- Structured autoreview: clean, patch correctness 0.99.
- Separate exact-head Codex review: clean, no actionable findings.
- Test audit: existing boundary coverage directly protects the preserved behavior, so no duplicative test was added.
- Production LOC: +2/−11 (net −9); tests unchanged.