### PR TITLE
refactor(worker): centralize terminal error subscriptions

### DIFF
--- a/src/worker/worker-connection.test.ts
+++ b/src/worker/worker-connection.test.ts
@@ -439,6 +439,24 @@ describe("WorkerConnection state listener isolation", () => {
     expect(listeners.observed).toEqual(["fenced"]);
     expect(terminalErrors).toEqual([new WorkerFencedError("owner-epoch-mismatch")]);
   });
+
+  it("keeps terminal errors bound to their emitted state during nested transitions", () => {
+    const connection = createIdleConnection();
+    const terminalErrors: Error[] = [];
+    connection.onStateChange((state) => {
+      if (state.kind === "fenced") {
+        void connection.stop();
+      }
+    });
+    connection.onTerminalError((error) => terminalErrors.push(error));
+
+    connection.fence("owner-epoch-mismatch");
+
+    expect(terminalErrors).toEqual([
+      new WorkerConnectionStoppedError(),
+      new WorkerFencedError("owner-epoch-mismatch"),
+    ]);
+  });
 });
 
 describe("WorkerConnection inference listener isolation", () => {

--- a/src/worker/worker-connection.test.ts
+++ b/src/worker/worker-connection.test.ts
@@ -22,6 +22,7 @@ import {
   toWorkerConnectionError,
   WorkerAdmissionDeadlineExceededError,
   WorkerConnectionStoppedError,
+  WorkerFencedError,
 } from "./worker-connection-contract.js";
 import { WorkerConnectionEndpointError } from "./worker-connection-endpoint.js";
 import { WorkerConnectionFrameDispatcher } from "./worker-connection-frames.js";
@@ -154,9 +155,12 @@ describe("worker connection endpoint failures", () => {
       admissionDeadlineMs: 60_000,
       reconnectBackoff: { initialMs: 30_000, maxMs: 30_000, factor: 1, jitter: 0 },
     });
+    const terminalErrors: Error[] = [];
+    connection.onTerminalError((error) => terminalErrors.push(error));
 
     await expect(connection.start()).rejects.toBeInstanceOf(WorkerConnectionEndpointError);
-    expect(connection.state).toMatchObject({ kind: "failed" });
+    expect(terminalErrors).toHaveLength(1);
+    expect(connection.state).toEqual({ kind: "failed", error: terminalErrors[0] });
     expect(createSocket).not.toHaveBeenCalled();
   });
 
@@ -404,6 +408,8 @@ describe("WorkerConnection state listener isolation", () => {
   it("settles stop and reaches later listeners when an earlier listener throws", async () => {
     const connection = createIdleConnection();
     const listeners = installThrowingThenHealthyListeners(connection);
+    const terminalErrors: Error[] = [];
+    connection.onTerminalError((error) => terminalErrors.push(error));
     const exit = connection.waitForExit();
 
     await expect(connection.stop()).resolves.toBeUndefined();
@@ -413,11 +419,14 @@ describe("WorkerConnection state listener isolation", () => {
     expect(connection.state).toEqual({ kind: "stopped" });
     expect(listeners.throwingCalls()).toBe(1);
     expect(listeners.observed).toEqual(["stopped"]);
+    expect(terminalErrors).toEqual([new WorkerConnectionStoppedError()]);
   });
 
   it("settles fencing and reaches later listeners when an earlier listener throws", async () => {
     const connection = createIdleConnection();
     const listeners = installThrowingThenHealthyListeners(connection);
+    const terminalErrors: Error[] = [];
+    connection.onTerminalError((error) => terminalErrors.push(error));
 
     expect(() => connection.fence("owner-epoch-mismatch")).not.toThrow();
     await expect(connection.waitForExit()).resolves.toEqual({
@@ -428,6 +437,7 @@ describe("WorkerConnection state listener isolation", () => {
     expect(connection.state).toEqual({ kind: "fenced", reason: "owner-epoch-mismatch" });
     expect(listeners.throwingCalls()).toBe(1);
     expect(listeners.observed).toEqual(["fenced"]);
+    expect(terminalErrors).toEqual([new WorkerFencedError("owner-epoch-mismatch")]);
   });
 });
 

--- a/src/worker/worker-connection.ts
+++ b/src/worker/worker-connection.ts
@@ -47,11 +47,7 @@ import {
 import { WorkerConnectionEndpointError } from "./worker-connection-endpoint.js";
 import { WorkerConnectionFrameDispatcher } from "./worker-connection-frames.js";
 
-export {
-  WorkerConnectionInterruptedError,
-  WorkerConnectionStoppedError,
-  WorkerFencedError,
-} from "./worker-connection-contract.js";
+export { WorkerConnectionInterruptedError } from "./worker-connection-contract.js";
 export type { WorkerConnectionState } from "./worker-connection-contract.js";
 
 const DEFAULT_RECONNECT_BACKOFF: BackoffPolicy = {
@@ -160,6 +156,14 @@ export class WorkerConnection {
   onStateChange(listener: (state: WorkerConnectionState) => void): () => void {
     this.stateListeners.add(listener);
     return () => this.stateListeners.delete(listener);
+  }
+
+  onTerminalError(listener: (error: Error) => void): () => void {
+    return this.onStateChange(() => {
+      if (this.isTerminal()) {
+        listener(this.terminalError());
+      }
+    });
   }
 
   onInferenceEvent(listener: (frame: WorkerInferenceEventFrame) => void): () => void {

--- a/src/worker/worker-connection.ts
+++ b/src/worker/worker-connection.ts
@@ -159,9 +159,9 @@ export class WorkerConnection {
   }
 
   onTerminalError(listener: (error: Error) => void): () => void {
-    return this.onStateChange(() => {
-      if (this.isTerminal()) {
-        listener(this.terminalError());
+    return this.onStateChange((state) => {
+      if (this.isTerminal(state)) {
+        listener(this.terminalError(state));
       }
     });
   }
@@ -511,22 +511,18 @@ export class WorkerConnection {
     return error;
   }
 
-  private isTerminal(): boolean {
-    return (
-      this.stateValue.kind === "failed" ||
-      this.stateValue.kind === "fenced" ||
-      this.stateValue.kind === "stopped"
-    );
+  private isTerminal(state: WorkerConnectionState = this.stateValue): boolean {
+    return state.kind === "failed" || state.kind === "fenced" || state.kind === "stopped";
   }
 
-  private terminalError(): Error {
-    if (this.stateValue.kind === "failed") {
-      return this.stateValue.error;
+  private terminalError(state: WorkerConnectionState = this.stateValue): Error {
+    if (state.kind === "failed") {
+      return state.error;
     }
-    if (this.stateValue.kind === "fenced") {
-      return new WorkerFencedError(this.stateValue.reason);
+    if (state.kind === "fenced") {
+      return new WorkerFencedError(state.reason);
     }
-    if (this.stateValue.kind === "stopped") {
+    if (state.kind === "stopped") {
       return new WorkerConnectionStoppedError();
     }
     return new WorkerConnectionInterruptedError("worker connection terminated");

--- a/src/worker/worker-rpc-clients.test.ts
+++ b/src/worker/worker-rpc-clients.test.ts
@@ -11,12 +11,9 @@ import type {
   WorkerInferenceTerminalOutcome,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { WorkerConnectionStoppedError, WorkerFencedError } from "./worker-connection-contract.js";
 import type { WorkerConnection, WorkerConnectionState } from "./worker-connection.js";
-import {
-  WorkerConnectionInterruptedError,
-  WorkerConnectionStoppedError,
-  WorkerFencedError,
-} from "./worker-connection.js";
+import { WorkerConnectionInterruptedError } from "./worker-connection.js";
 import {
   WorkerInferenceProxyClient,
   WorkerLiveEventClient,
@@ -37,7 +34,7 @@ const HELLO: WorkerHelloOk = {
 function connectionHarness() {
   let state: WorkerConnectionState = { kind: "ready", hello: HELLO };
   const readyListeners = new Set<Parameters<WorkerConnection["onReady"]>[0]>();
-  const stateListeners = new Set<Parameters<WorkerConnection["onStateChange"]>[0]>();
+  const terminalErrorListeners = new Set<Parameters<WorkerConnection["onTerminalError"]>[0]>();
   const inferenceEventListeners = new Set<Parameters<WorkerConnection["onInferenceEvent"]>[0]>();
   const inferenceTerminalListeners = new Set<
     Parameters<WorkerConnection["onInferenceTerminal"]>[0]
@@ -62,10 +59,10 @@ function connectionHarness() {
         readyListeners.delete(listener);
       };
     },
-    onStateChange: (listener: Parameters<WorkerConnection["onStateChange"]>[0]) => {
-      stateListeners.add(listener);
+    onTerminalError: (listener: Parameters<WorkerConnection["onTerminalError"]>[0]) => {
+      terminalErrorListeners.add(listener);
       return () => {
-        stateListeners.delete(listener);
+        terminalErrorListeners.delete(listener);
       };
     },
     onInferenceEvent: (listener: Parameters<WorkerConnection["onInferenceEvent"]>[0]) => {
@@ -93,10 +90,10 @@ function connectionHarness() {
         listener(HELLO);
       }
     },
-    emitState: (nextState: WorkerConnectionState) => {
+    emitTerminalError: (nextState: WorkerConnectionState, error: Error) => {
       state = nextState;
-      for (const listener of stateListeners) {
-        listener(nextState);
+      for (const listener of terminalErrorListeners) {
+        listener(error);
       }
     },
     emitInferenceEvent: (frame: WorkerInferenceEventFrame) => {
@@ -731,7 +728,7 @@ describe("worker live-event client", () => {
   it("drops previews and rejects terminal delivery after stop without rescheduling", async () => {
     const harness = connectionHarness();
     harness.waitForReady.mockRejectedValue(new WorkerConnectionStoppedError());
-    harness.emitState({ kind: "stopped" });
+    harness.emitTerminalError({ kind: "stopped" }, new WorkerConnectionStoppedError());
     const client = new WorkerLiveEventClient(harness.connection, { runEpoch: 3 });
 
     client.enqueuePreview("run-1", LIVE_EVENT);
@@ -751,7 +748,10 @@ describe("worker live-event client", () => {
     client.enqueuePreview("run-1", LIVE_EVENT);
     const terminal = client.emitTerminal("run-1", TERMINAL_EVENT);
     await vi.waitFor(() => expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2));
-    harness.emitState({ kind: "fenced", reason: "owner-epoch-mismatch" });
+    harness.emitTerminalError(
+      { kind: "fenced", reason: "owner-epoch-mismatch" },
+      new WorkerFencedError("owner-epoch-mismatch"),
+    );
 
     await expect(terminal).rejects.toEqual(new WorkerFencedError("owner-epoch-mismatch"));
     client.dispose();

--- a/src/worker/worker-rpc-inference-client.ts
+++ b/src/worker/worker-rpc-inference-client.ts
@@ -6,12 +6,7 @@ import type {
   WorkerInferenceTerminalOutcome,
   WorkerInferenceTerminalParams,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
-import {
-  type WorkerConnection,
-  WorkerConnectionInterruptedError,
-  WorkerConnectionStoppedError,
-  WorkerFencedError,
-} from "./worker-connection.js";
+import { type WorkerConnection, WorkerConnectionInterruptedError } from "./worker-connection.js";
 import type { InferenceResponseError } from "./worker-rpc-client-shared.js";
 import { fenceForOwnershipError } from "./worker-rpc-client-shared.js";
 
@@ -66,15 +61,7 @@ export class WorkerInferenceProxyClient {
   constructor(private readonly connection: WorkerConnection) {
     this.unsubscribers = [
       connection.onReady(() => this.resume()),
-      connection.onStateChange((state) => {
-        if (state.kind === "fenced") {
-          this.rejectAllOperations(new WorkerFencedError(state.reason));
-        } else if (state.kind === "failed") {
-          this.rejectAllOperations(state.error);
-        } else if (state.kind === "stopped") {
-          this.rejectAllOperations(new WorkerConnectionStoppedError());
-        }
-      }),
+      connection.onTerminalError((error) => this.rejectAllOperations(error)),
       connection.onInferenceEvent((frame) => this.handleEvent(frame.payload)),
       connection.onInferenceTerminal((frame) => this.handleTerminal(frame.payload)),
     ];

--- a/src/worker/worker-rpc-live-event-client.ts
+++ b/src/worker/worker-rpc-live-event-client.ts
@@ -1,11 +1,6 @@
 import type { WorkerLiveEvent } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { createDeferredCore, type Deferred } from "../shared/deferred.js";
-import {
-  type WorkerConnection,
-  WorkerConnectionInterruptedError,
-  WorkerConnectionStoppedError,
-  WorkerFencedError,
-} from "./worker-connection.js";
+import { type WorkerConnection, WorkerConnectionInterruptedError } from "./worker-connection.js";
 import { fenceForOwnershipError, isTerminalConnection } from "./worker-rpc-client-shared.js";
 
 type WorkerLiveEventClientOptions = {
@@ -53,15 +48,7 @@ export class WorkerLiveEventClient {
     this.maxSentSeqValue = this.ackedSeqValue;
     this.unsubscribers = [
       connection.onReady(() => this.pump()),
-      connection.onStateChange((state) => {
-        if (state.kind === "fenced") {
-          this.rejectAll(new WorkerFencedError(state.reason));
-        } else if (state.kind === "failed") {
-          this.rejectAll(state.error);
-        } else if (state.kind === "stopped") {
-          this.rejectAll(new WorkerConnectionStoppedError());
-        }
-      }),
+      connection.onTerminalError((error) => this.rejectAll(error)),
     ];
   }
 

--- a/src/worker/worker.fault-injection.test.ts
+++ b/src/worker/worker.fault-injection.test.ts
@@ -14,8 +14,10 @@ import {
   clearAgentRunContext,
   getAgentRunContext,
 } from "../infra/agent-run-registry.js";
-import { WorkerAdmissionError } from "./worker-connection-contract.js";
-import { WorkerConnectionStoppedError } from "./worker-connection.js";
+import {
+  WorkerAdmissionError,
+  WorkerConnectionStoppedError,
+} from "./worker-connection-contract.js";
 import {
   ComposedGatewayHarness,
   ENVIRONMENT_ID,

--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -48,12 +48,11 @@ import { listRunningSessions } from "../agents/bash-process-registry.js";
 import { saveExecApprovals, type ExecApprovalsFile } from "../infra/exec-approvals.js";
 import { buildWorkerConnectParams, type WorkerLaunchDescriptor } from "./launch-descriptor.js";
 import { WORKER_PROVIDER_REPLAY_LOCAL_RETRY_MESSAGE } from "./transcript-message.js";
-import { WorkerAdmissionDeadlineExceededError } from "./worker-connection-contract.js";
 import {
-  createWorkerConnection,
+  WorkerAdmissionDeadlineExceededError,
   WorkerConnectionStoppedError,
-  type WorkerConnectionState,
-} from "./worker-connection.js";
+} from "./worker-connection-contract.js";
+import { createWorkerConnection, type WorkerConnectionState } from "./worker-connection.js";
 import {
   WorkerInferenceProxyClient,
   WorkerLiveEventClient,


### PR DESCRIPTION
## What Problem This Solves

Worker terminal-failure behavior was maintained in multiple internal paths, so later connection changes could make live-event and inference RPC clients settle pending work differently. The same duplication also kept two error re-exports alive only for tests.

This is a maintainer-requested, AI-assisted cleanup lane; no user-visible behavior change is intended.

## Why This Change Was Made

`WorkerConnection` now owns terminal-error subscriptions as well as the existing failed/fenced/stopped error mapping. Both RPC clients subscribe to that owner instead of re-deriving the mapping, and the callback maps the emitted state snapshot so nested transitions preserve event identity. Test-only consumers import error classes from their defining contract, allowing the stale connection-barrel re-exports to be deleted.

A standalone mapping helper was rejected because it added more production code and left subscription policy duplicated. A client-shared listener helper was rejected because `WorkerConnection` already owns terminal state and error semantics.

Production LOC: +21/-47 (net -26) | Tests: +50/-21

## User Impact

No user-visible change is intended. Worker live-event and inference operations continue to reject with the same failed error object, fenced reason, or stopped error at the same terminal transitions, with fewer independent control paths to keep aligned.

## Evidence

Exact reviewed head: `a1343b386c77246124abe961b5af9734352b41b2`

- Focused worker proof: 82/82 tests passed across `worker-connection`, RPC clients, runtime, and fault-injection suites.
- Reentrancy regression: failed on the prior reviewed head with `Stopped, Stopped` instead of `Stopped, Fenced`; passes on this head.
- `node scripts/check-changed.mjs`: passed all selected core/core-test typechecks, lint, dead-export, import-cycle, formatting, and repository guards.
- Deslop: clean.
- Structured autoreview: clean, no accepted/actionable findings.
- Independent exact-head Codex follow-up: `NO FINDINGS`.
- Fresh overlap check: 439 open PRs updated on 2026-08-26 scanned; zero touched any candidate file.

