### PR TITLE
refactor(channels): simplify attachment alias resolution

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -133,9 +133,7 @@ function resolveFeishuSendAttachmentMedia(params: Record<string, unknown>): stri
   };
 
   const inspect = (record: Record<string, unknown>, nested = false): void => {
-    const keys = nested
-      ? [...sourceKeys.slice(0, sourceKeys.length - 1), "url", "image"]
-      : sourceKeys;
+    const keys = nested ? [...sourceKeys.slice(0, -1), "url", "image"] : sourceKeys;
     for (const key of keys) {
       const value = read(record, key);
       if (value === undefined) {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -114,274 +114,102 @@ import { feishuSetupWizard, runFeishuLogin } from "./setup-surface.js";
 import { looksLikeFeishuId, normalizeFeishuTarget, resolveReceiveIdType } from "./targets.js";
 import type { FeishuConfig, FeishuProbeResult, ResolvedFeishuAccount } from "./types.js";
 
-// Path-shaped attachment param aliases the message-tool schema declares. A
-// direct Gateway `message.action send` may arrive with any of these instead of
-// the canonical `media` field the Feishu handler reads; collect them so an
-// attachment intent is promoted to a single canonical mediaUrl instead of being
-// silently dropped on the text-only success branch (issue #112244).
-const FEISHU_SEND_MEDIA_SOURCE_PARAM_KEYS = [
-  "media",
-  "mediaUrl",
-  "path",
-  "filePath",
-  "fileUrl",
-  "image",
-] as const;
+function resolveFeishuSendAttachmentMedia(params: Record<string, unknown>): string | undefined {
+  const sourceKeys = ["media", "mediaUrl", "path", "filePath", "fileUrl", "image"];
+  const candidates: string[] = [];
+  let unsupportedPayload = false;
+  let unsupportedFile = false;
+  let malformed = false;
 
-const FEISHU_ATTACHMENT_MEDIA_SOURCE_PARAM_KEYS = [
-  "media",
-  "mediaUrl",
-  "path",
-  "filePath",
-  "fileUrl",
-  "url",
-  "image",
-] as const;
-
-// Converts a camelCase param key to its snake_case spelling (e.g. filePath ->
-// file_path, mediaUrl -> media_url). The Gateway action contract resolves both
-// spellings before a message action reaches a channel, so a Feishu send may
-// arrive with either; the resolver honors both to avoid silently dropping an
-// attachment alias that uses the snake_case spelling (issue #112244).
-function toFeishuSnakeCaseKey(key: string): string {
-  return key
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
-    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
-    .toLowerCase();
-}
-
-// Reads a raw param value, preferring the canonical (camelCase) key and
-// falling back to its snake_case spelling when the canonical key is absent.
-function readFeishuParam(params: Record<string, unknown>, key: string): unknown {
-  if (Object.hasOwn(params, key)) {
-    return params[key];
-  }
-  const snakeKey = toFeishuSnakeCaseKey(key);
-  return snakeKey === key || !Object.hasOwn(params, snakeKey) ? undefined : params[snakeKey];
-}
-
-function readFeishuStringParam(params: Record<string, unknown>, key: string): string | undefined {
-  const raw = readFeishuParam(params, key);
-  const value = typeof raw === "string" ? normalizeOptionalString(raw) : undefined;
-  return value ?? undefined;
-}
-
-function readFeishuStringArrayParam(params: Record<string, unknown>, key: string): string[] {
-  const raw = readFeishuParam(params, key);
-  // A single string is accepted in place of an array so a caller that wrote
-  // `mediaUrls: "/tmp/a.png"` instead of `["/tmp/a.png"]` is not silently
-  // dropped on the text-only success branch.
-  if (Array.isArray(raw)) {
-    const normalized: string[] = [];
-    for (const entry of raw) {
-      const trimmed = typeof entry === "string" ? normalizeOptionalString(entry) : undefined;
-      if (trimmed) {
-        normalized.push(trimmed);
-      }
+  const read = (record: Record<string, unknown>, key: string): unknown => {
+    if (Object.hasOwn(record, key)) {
+      return record[key];
     }
-    return normalized;
-  }
-  const single = typeof raw === "string" ? normalizeOptionalString(raw) : undefined;
-  return single ? [single] : [];
-}
+    const snakeKey = key
+      .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+      .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+      .toLowerCase();
+    return snakeKey !== key && Object.hasOwn(record, snakeKey) ? record[snakeKey] : undefined;
+  };
 
-// Detects a declared media source field whose value is present but malformed
-// (not a string for scalar sources; not a string or array for `mediaUrls`; or
-// an array containing a non-string entry). A present malformed value expresses
-// attachment intent the Feishu send path cannot represent, so it must fail
-// visibly instead of being treated as absent and falling through to a
-// text-only success branch that recreates the silent-drop bug of #112244.
-// A blank string ("", "  ") is a string and therefore not malformed.
-function readFeishuParamPresence(
-  params: Record<string, unknown>,
-  key: string,
-  kind: "scalar" | "stringOrArray",
-): "absent" | "present" | "malformed" {
-  const raw = readFeishuParam(params, key);
-  if (raw === undefined) {
-    return "absent";
-  }
-  if (kind === "stringOrArray") {
-    if (Array.isArray(raw)) {
-      return raw.some((entry) => typeof entry !== "string") ? "malformed" : "present";
-    }
-    return typeof raw === "string" ? "present" : "malformed";
-  }
-  return typeof raw === "string" ? "present" : "malformed";
-}
-
-// Detects an unsupported attachment-intent key (`file`/`buffer`/`base64`) whose
-// value is present. A non-blank string is the original unsupported-intent
-// signal; a present NON-string value (e.g. `file: {}`, `buffer: 42`) is a
-// malformed intent the resolver cannot promote either. The non-string case used
-// to be silently skipped — `readFeishuStringParam` returns undefined for
-// objects, so `Boolean(...)` was false, leaving no candidate and falling through
-// to a text-only `ok:true`, recreating the silent-drop this PR removes (issue
-// #112244, ClawSweeper P1). A blank string ("", "  ") stays ignored, preserving
-// the blank-alias ignore behavior.
-function hasFeishuUnsupportedIntentValue(params: Record<string, unknown>, key: string): boolean {
-  const raw = readFeishuParam(params, key);
-  if (raw === undefined) {
-    return false;
-  }
-  if (typeof raw === "string") {
-    return Boolean(normalizeOptionalString(raw));
-  }
-  return true;
-}
-
-type FeishuSendAttachmentMedia = {
-  mediaUrl: string | undefined;
-  /** Collected non-blank media source values across all aliases. */
-  mediaUrls: string[];
-  /** A buffer/base64 payload (top-level or nested in attachments[]) that the
-   * Feishu send path cannot represent; rejected instead of silent text fallback. */
-  hasUnsupportedAttachmentPayload: boolean;
-  /** An attachment-intent key (e.g. `file`) the Feishu send path does not map
-   * to a media source string; a non-blank value is rejected instead of silent
-   * text fallback (issue #112244). */
-  hasUnsupportedAttachmentIntent: boolean;
-  /** A declared media source field whose value is present but malformed (e.g.
-   * `media: {}` or `mediaUrls: [{}]`); rejected instead of being treated as
-   * absent and falling through to a text-only success branch (issue #112244). */
-  hasMalformedAttachmentIntent: boolean;
-};
-
-function collectFeishuSendAttachmentMedia(
-  params: Record<string, unknown>,
-): FeishuSendAttachmentMedia {
-  const candidates: Array<string | undefined> = FEISHU_SEND_MEDIA_SOURCE_PARAM_KEYS.map((key) =>
-    readFeishuStringParam(params, key),
-  );
-  candidates.push(...readFeishuStringArrayParam(params, "mediaUrls"));
-  // A blank buffer/base64 ("", "  ") is not an unsupported payload intent and
-  // must not trigger rejection; only a non-blank value counts. A present
-  // non-string value (e.g. `buffer: {}`) is a malformed payload intent that
-  // must also be rejected instead of silently skipped (issue #112244, ClawSweeper P1).
-  let hasUnsupportedAttachmentPayload =
-    hasFeishuUnsupportedIntentValue(params, "buffer") ||
-    hasFeishuUnsupportedIntentValue(params, "base64");
-  // A non-blank `file` is the linked issue's reproduction input; it is not a
-  // media source the Feishu send path maps, so it is treated as an unsupported
-  // attachment intent rather than dropped on the text-only success branch. A
-  // present non-string value (e.g. `file: {}`) is the same class of malformed
-  // intent and is rejected too (issue #112244, ClawSweeper P1).
-  let hasUnsupportedAttachmentIntent = hasFeishuUnsupportedIntentValue(params, "file");
-  // A declared media source whose value is present but malformed (non-string
-  // for scalar sources; non-string/non-array or array-with-non-string-entry for
-  // `mediaUrls`) is an attachment-intent signal the Feishu send path cannot
-  // satisfy, so it is rejected rather than silently treated as absent and
-  // dropped on the text-only success branch (issue #112244). A blank string is
-  // a string and therefore not malformed, preserving the blank-alias ignore.
-  let hasMalformedAttachmentIntent = false;
-  for (const key of FEISHU_SEND_MEDIA_SOURCE_PARAM_KEYS) {
-    if (readFeishuParamPresence(params, key, "scalar") === "malformed") {
-      hasMalformedAttachmentIntent = true;
-    }
-  }
-  if (readFeishuParamPresence(params, "mediaUrls", "stringOrArray") === "malformed") {
-    hasMalformedAttachmentIntent = true;
-  }
-  // A declared `attachments` field that is not an array (e.g. an object
-  // container like `{ media: "/tmp/a" }`) expresses attachment intent the
-  // Feishu send path cannot promote — the nested media source is not a
-  // top-level alias and the array resolver below never runs. Treating it as
-  // absent recreates the silent text-only `ok:true` success this PR removes,
-  // so it is rejected before the text branch (issue #112244, ClawSweeper P1).
-  if (params.attachments !== undefined && !Array.isArray(params.attachments)) {
-    hasMalformedAttachmentIntent = true;
-  }
-  if (Array.isArray(params.attachments)) {
-    for (const attachment of params.attachments) {
-      // A non-record array entry (e.g. `null`, a number, or a string) is a
-      // declared attachment intent the resolver cannot promote to a media
-      // source; skipping it silently would leave no candidate and fall through
-      // to a text-only `ok:true` — the exact drop this PR removes. Reject it
-      // before the text branch instead (issue #112244, ClawSweeper P1).
-      if (!isRecord(attachment)) {
-        hasMalformedAttachmentIntent = true;
+  const inspect = (record: Record<string, unknown>, nested = false): void => {
+    const keys = nested
+      ? [...sourceKeys.slice(0, sourceKeys.length - 1), "url", "image"]
+      : sourceKeys;
+    for (const key of keys) {
+      const value = read(record, key);
+      if (value === undefined) {
         continue;
       }
-      for (const key of FEISHU_ATTACHMENT_MEDIA_SOURCE_PARAM_KEYS) {
-        candidates.push(readFeishuStringParam(attachment, key));
+      if (typeof value !== "string") {
+        malformed = true;
+        continue;
       }
-      // Collect valid nested `mediaUrls` entries too, mirroring the top-level
-      // handling: without this, `{ attachments: [{ mediaUrls: ["/tmp/a.png"] }] }`
-      // would pass the malformed check but produce no candidate and silently
-      // fall through to a text-only `ok:true` — the exact drop this PR removes
-      // (issue #112244, ClawSweeper P1).
-      candidates.push(...readFeishuStringArrayParam(attachment, "mediaUrls"));
-      // Each structured attachment is scanned for unsupported payloads too, so
-      // `attachments: [{ buffer: ... }]` fails visibly instead of producing no
-      // media candidate and silently falling through to a text-only send. A
-      // present non-string value (e.g. `attachments: [{ file: {} }]`) is a
-      // malformed intent rejected the same way (issue #112244, ClawSweeper P1).
-      hasUnsupportedAttachmentPayload ||=
-        hasFeishuUnsupportedIntentValue(attachment, "buffer") ||
-        hasFeishuUnsupportedIntentValue(attachment, "base64");
-      hasUnsupportedAttachmentIntent ||= hasFeishuUnsupportedIntentValue(attachment, "file");
-      for (const key of FEISHU_ATTACHMENT_MEDIA_SOURCE_PARAM_KEYS) {
-        if (readFeishuParamPresence(attachment, key, "scalar") === "malformed") {
-          hasMalformedAttachmentIntent = true;
+      const normalized = normalizeOptionalString(value);
+      if (normalized) {
+        candidates.push(normalized);
+      }
+    }
+
+    const multiple = read(record, "mediaUrls");
+    if (multiple !== undefined) {
+      for (const value of Array.isArray(multiple) ? multiple : [multiple]) {
+        if (typeof value !== "string") {
+          malformed = true;
+          continue;
+        }
+        const normalized = normalizeOptionalString(value);
+        if (normalized) {
+          candidates.push(normalized);
         }
       }
-      if (readFeishuParamPresence(attachment, "mediaUrls", "stringOrArray") === "malformed") {
-        hasMalformedAttachmentIntent = true;
+    }
+
+    for (const key of ["buffer", "base64"]) {
+      const value = read(record, key);
+      unsupportedPayload ||=
+        value !== undefined &&
+        (typeof value !== "string" || Boolean(normalizeOptionalString(value)));
+    }
+    const file = read(record, "file");
+    unsupportedFile ||=
+      file !== undefined && (typeof file !== "string" || Boolean(normalizeOptionalString(file)));
+  };
+
+  inspect(params);
+  const attachments = params.attachments;
+  if (attachments !== undefined && !Array.isArray(attachments)) {
+    malformed = true;
+  } else if (Array.isArray(attachments)) {
+    for (const attachment of attachments) {
+      if (!isRecord(attachment)) {
+        malformed = true;
+      } else {
+        inspect(attachment, true);
       }
     }
   }
-  const seen = new Set<string>();
-  const mediaUrls: string[] = [];
-  for (const candidate of candidates) {
-    if (!candidate || seen.has(candidate)) {
-      continue;
-    }
-    seen.add(candidate);
-    mediaUrls.push(candidate);
-  }
-  return {
-    mediaUrl: mediaUrls[0],
-    mediaUrls,
-    hasUnsupportedAttachmentPayload,
-    hasUnsupportedAttachmentIntent,
-    hasMalformedAttachmentIntent,
-  };
-}
 
-// Feishu delivers one media item per message. A send declaring more than one
-// attachment is rejected rather than silently delivering only the first, and
-// buffer/base64 payloads (top-level or nested in attachments[]) are rejected
-// because the Feishu send path loads media from a media source string
-// (path/URL) via the outbound adapter, not from an in-memory buffer. A
-// non-blank `file` attachment-intent key is rejected the same way because the
-// shared action contract deliberately excludes `file` from supported media
-// sources; a present malformed media source value (e.g. `media: {}` or
-// `mediaUrls: [{}]`) is rejected because the resolver cannot promote it to a
-// mediaUrl and treating it as absent would recreate the silent text-only
-// success branch. Failing visibly here matches the issue's expected behavior
-// instead of returning ok:true on a text-only send. Mirrors the Mattermost
-// send-attachment resolver shape.
-function resolveFeishuSendAttachmentMedia(params: Record<string, unknown>): string | undefined {
-  const attachmentMedia = collectFeishuSendAttachmentMedia(params);
-  if (attachmentMedia.hasUnsupportedAttachmentPayload) {
+  if (unsupportedPayload) {
     throw new Error(
       "Feishu send supports media attachments through media, mediaUrl, path, filePath, fileUrl, image, mediaUrls, or attachments[] with one of those fields; buffer/base64 payloads are not supported.",
     );
   }
-  if (attachmentMedia.hasMalformedAttachmentIntent) {
+  if (malformed) {
     throw new Error(
       "Feishu send supports media attachments through media, mediaUrl, path, filePath, fileUrl, image, mediaUrls, or attachments[] with one of those fields; a present malformed media source value is not supported — use a string path/URL (or a string array for mediaUrls) instead.",
     );
   }
-  if (attachmentMedia.hasUnsupportedAttachmentIntent) {
+  if (unsupportedFile) {
     throw new Error(
       "Feishu send supports media attachments through media, mediaUrl, path, filePath, fileUrl, image, mediaUrls, or attachments[] with one of those fields; the `file` attachment-intent parameter is not supported — use one of the supported media sources instead.",
     );
   }
-  if (attachmentMedia.mediaUrls.length > 1) {
+  const urls = [...new Set(candidates)];
+  if (urls.length > 1) {
     throw new Error("Feishu send supports a single media attachment.");
   }
-  return attachmentMedia.mediaUrl;
+  return urls[0];
 }
 
 function readBooleanParam(params: Record<string, unknown>, keys: string[]): boolean | undefined {

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -2,6 +2,7 @@
 import {
   jsonResult,
   readPositiveIntegerParam,
+  readStringArrayParam,
   readStringParam,
   withNormalizedTimestamp,
 } from "openclaw/plugin-sdk/channel-actions";
@@ -617,74 +618,13 @@ function parseMattermostReactActionParams(params: Record<string, unknown>): {
   };
 }
 
-function collectNonBlankStrings(values: Array<string | undefined>): string[] {
-  const collected: string[] = [];
-  const seen = new Set<string>();
-  for (const value of values) {
-    const trimmed = value?.trim();
-    if (trimmed && !seen.has(trimmed)) {
-      seen.add(trimmed);
-      collected.push(trimmed);
-    }
-  }
-  return collected;
-}
-
-function toSnakeCaseKey(key: string): string {
-  return key
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
-    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
-    .toLowerCase();
-}
-
-function readMattermostParam(params: Record<string, unknown>, key: string): unknown {
-  if (Object.hasOwn(params, key)) {
-    return params[key];
-  }
-  const snakeKey = toSnakeCaseKey(key);
-  return snakeKey === key || !Object.hasOwn(params, snakeKey) ? undefined : params[snakeKey];
-}
-
-function readMattermostStringParam(
-  params: Record<string, unknown>,
-  key: string,
-): string | undefined {
-  const raw = readMattermostParam(params, key);
-  return typeof raw === "string" ? normalizeOptionalString(raw) : undefined;
-}
-
-function readMattermostStringArrayParam(params: Record<string, unknown>, key: string): string[] {
-  const raw = readMattermostParam(params, key);
-  if (Array.isArray(raw)) {
-    return raw
-      .filter((entry): entry is string => typeof entry === "string")
-      .flatMap((entry) => {
-        const normalized = normalizeOptionalString(entry);
-        return normalized ? [normalized] : [];
-      });
-  }
-  if (typeof raw === "string") {
-    const normalized = normalizeOptionalString(raw);
-    return normalized ? [normalized] : [];
-  }
-  return [];
-}
-
-function collectMattermostAttachmentMedia(params: Record<string, unknown>): {
-  mediaUrls: string[];
-  hasUnsupportedAttachmentPayload: boolean;
-} {
-  const mediaUrlCandidates: Array<string | undefined> = [
-    readMattermostStringParam(params, "media"),
-    readMattermostStringParam(params, "mediaUrl"),
-    readMattermostStringParam(params, "path"),
-    readMattermostStringParam(params, "filePath"),
-    readMattermostStringParam(params, "fileUrl"),
-  ];
-  mediaUrlCandidates.push(...readMattermostStringArrayParam(params, "mediaUrls"));
+function resolveMattermostSendAttachmentMedia(params: Record<string, unknown>): string | undefined {
+  const sourceKeys = ["media", "mediaUrl", "path", "filePath", "fileUrl"];
+  const candidates = sourceKeys.map((key) => readStringParam(params, key));
+  candidates.push(...(readStringArrayParam(params, "mediaUrls") ?? []));
 
   let hasUnsupportedAttachmentPayload = Boolean(
-    readMattermostStringParam(params, "buffer") ?? readMattermostStringParam(params, "base64"),
+    readStringParam(params, "buffer") ?? readStringParam(params, "base64"),
   );
   if (Array.isArray(params.attachments)) {
     for (const attachment of params.attachments) {
@@ -692,39 +632,26 @@ function collectMattermostAttachmentMedia(params: Record<string, unknown>): {
         continue;
       }
       const record = attachment as Record<string, unknown>;
-      mediaUrlCandidates.push(
-        readMattermostStringParam(record, "media"),
-        readMattermostStringParam(record, "mediaUrl"),
-        readMattermostStringParam(record, "path"),
-        readMattermostStringParam(record, "filePath"),
-        readMattermostStringParam(record, "fileUrl"),
-        readMattermostStringParam(record, "url"),
-      );
+      candidates.push(...sourceKeys.map((key) => readStringParam(record, key)));
+      candidates.push(readStringParam(record, "url"));
       hasUnsupportedAttachmentPayload ||= Boolean(
-        readMattermostStringParam(record, "buffer") ?? readMattermostStringParam(record, "base64"),
+        readStringParam(record, "buffer") ?? readStringParam(record, "base64"),
       );
     }
   }
 
-  return {
-    mediaUrls: collectNonBlankStrings(mediaUrlCandidates),
-    hasUnsupportedAttachmentPayload,
-  };
-}
-
-function resolveMattermostSendAttachmentMedia(params: Record<string, unknown>): string | undefined {
-  const attachmentMedia = collectMattermostAttachmentMedia(params);
-  if (attachmentMedia.hasUnsupportedAttachmentPayload) {
+  if (hasUnsupportedAttachmentPayload) {
     throw new Error(
       "Mattermost send attachments require media, mediaUrl, path, filePath, fileUrl, mediaUrls, or attachments[] with one of those fields; buffer/base64 payloads are not supported.",
     );
   }
-  if (attachmentMedia.mediaUrls.length > 1) {
+  const mediaUrls = [...new Set(candidates.filter((candidate) => Boolean(candidate)))];
+  if (mediaUrls.length > 1) {
     throw new Error(
       "Mattermost send supports one attachment per message; split multiple mediaUrls or attachments[] entries into separate sends.",
     );
   }
-  return attachmentMedia.mediaUrls[0];
+  return mediaUrls[0];
 }
 
 type MattermostOutboundContext = Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0];


### PR DESCRIPTION
## What Problem This Solves

Feishu and Mattermost each accumulated layers of private attachment-alias readers, intermediate result shapes, and repeated collection passes around their message-action owners. The Feishu owner recently became shared by ordinary sends and thread replies, making it especially important to keep one clear, behavior-equivalent attachment boundary.

## Why This Change Was Made

Replace the Feishu reader stack with one owner-local inspection pass that preserves canonical-over-snake-case precedence, nested aliases, ordered deduplication, malformed-input rejection, and the existing exact error priority. Simplify Mattermost through the already-imported canonical channel-actions SDK string readers, which existed before its minimum supported host version.

Each plugin retains its own deliberately different input policy: Feishu visibly rejects malformed sources and unsupported file intent, while Mattermost continues ignoring malformed optional aliases and rejects only unsupported string payloads or multiple attachments.

## User Impact

No user-visible behavior, attachment URL, thread reply, error message, upload-failure handling, media authorization, account isolation, or public plugin API changes. Both current Feishu send and thread-reply actions retain all attachment aliases and their distinct outbound upload semantics. No tests, manifests, dependency versions, SDK exports, or security policies are changed.

## Evidence

- Only two production files change: Feishu +70/-242 and Mattermost +13/-86, for a genuine combined reduction of **245 production lines**; zero test lines changed.
- Fresh differential execution against the actual final dirty source checked 120,000 Feishu send/thread-reply outcomes and 60,000 Mattermost outcomes; every returned attachment URL, thrown error string, ordering rule, and precedence decision matched current main.
- All six unchanged Feishu/Mattermost owner suites passed all 415 assertions before and after the refactor, including the newly landed thread-reply attachment-alias regressions.
- Two independent full-source reviews verified nested url/image/mediaUrls handling, malformed inputs, buffer/base64/file error priority, media roots, upload-failure markers, and owner authorization boundaries.
- Mattermost reuses an existing channel-actions module; both canonical readers were already shipped in stable v2026.5.28, earlier than the plugin's minimum host version of 2026.6.9.
- Production, full-tree, and scripts dead-export scans each returned zero entries; authenticated structured precommit review completed clean with 0.98 confidence.
- The full changed-file gate passed its first 16 security, boundary, formatting, ratchet, owner-contract, dependency, and dead-export stages. Its global extension typecheck then reproduced the previously diagnosed shared-checkout dependency drift in unrelated acpx, cua, maxmind, markdown, QA, and TUI owners; neither changed Feishu/Mattermost file has a diagnostic. Isolated worktrees must not reinstall shared dependencies, so exact-head hosted CI with freshly installed pinned dependencies is the authoritative whole-tree typecheck.
