### PR TITLE
refactor(proxy-capture): remove redundant peer check

### DIFF
--- a/src/proxy-capture/store.sqlite.ts
+++ b/src/proxy-capture/store.sqlite.ts
@@ -514,11 +514,7 @@ class DebugProxyCaptureStoreImpl {
         hosts.set(host, (hosts.get(host) ?? 0) + 1);
         // Local model/provider endpoints are useful to surface separately when
         // debugging why cloud-provider labels are absent.
-        if (
-          host === "127.0.0.1:11434" ||
-          host.startsWith("127.0.0.1:") ||
-          host.startsWith("localhost:")
-        ) {
+        if (host.startsWith("127.0.0.1:") || host.startsWith("localhost:")) {
           localPeers.set(host, (localPeers.get(host) ?? 0) + 1);
         }
       }


### PR DESCRIPTION
## What Problem This Solves

The proxy-capture coverage owner carried an exact `127.0.0.1:11434` check immediately before a generic `127.0.0.1:` prefix check that already accepts the same host. The stale special case added a duplicate decision and implied provider-specific behavior where none exists.

This is a maintainer-requested, AI-assisted cleanup from the bounded M-P owner campaign.

## Why This Change Was Made

Remove only the subsumed equality and retain the canonical loopback/localhost prefix checks. For every normalized host string, `host === "127.0.0.1:11434"` implies `host.startsWith("127.0.0.1:")`, so local-peer membership, counts, map insertion order, and sorted output remain identical.

The original proxy-capture commit (#64895) introduced both terms together. No separate product, provider, persistence, security, or compatibility boundary distinguishes the exact port. Alternatives that extracted a helper or changed the local-peer policy were rejected as broader and less direct.

Production LOC: +1/-5 (net -4). Tests: +0/-0.

## User Impact

No user-visible behavior changes. Proxy-capture coverage continues to classify all `127.0.0.1:<port>` and `localhost:<port>` hosts exactly as before, with one fewer redundant predicate.

## Evidence

Exact head: `35a609d7e54f2205c92aa39ae7f221a2d996a284`

- Direct production-path assertion through `DebugProxyCaptureStore.summarizeSessionCoverage`: `127.0.0.1:11434`, `127.0.0.1:1234`, and `localhost:8080` remained in `localPeers` in the same order; `api.example.com` remained excluded.
- `node scripts/run-vitest.mjs src/proxy-capture/store.sqlite.test.ts` — 14/14 passed.
- `node scripts/check-changed.mjs -- src/proxy-capture/store.sqlite.ts` — all changed-file gates passed, including core/core-test types, dead exports, lint, cycles, and database guards.
- `node scripts/run-oxlint.mjs src/proxy-capture/store.sqlite.ts` — 0 warnings/errors.
- `git diff --check` — passed.
- Deslop — clean, no changes required.
- Structured exact-head autoreview — clean, correctness 1.00.
- Separate independent exact-head Codex review — clean, correctness 1.00.
