### PR TITLE
fix(gateway): keep loaded conversations responsive under heavy load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway heavy-load responsiveness:** prevent transcript prefetch churn, unrelated subscription stalls, unnecessary observer model calls and media cleanup, full-session-cache copies, and prolonged slow-client WebSocket retention under concurrent use.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway heavy-load responsiveness:** prevent transcript prefetch churn, unrelated subscription stalls, unnecessary observer model calls and media cleanup, full-session-cache copies, and prolonged slow-client WebSocket retention under concurrent use.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/package.json
+++ b/package.json
@@ -1817,7 +1817,6 @@
     "test:docker:doctor-switch": "bash scripts/e2e/doctor-install-switch-docker.sh",
     "test:docker:compose-setup": "bash scripts/e2e/compose-setup.sh",
     "test:docker:e2e-build": "bash scripts/e2e/build-image.sh",
-    "test:docker:gateway-concurrency": "bash scripts/e2e/gateway-concurrency-docker.sh",
     "test:docker:gateway-network": "bash scripts/e2e/gateway-network-docker.sh",
     "test:docker:kitchen-sink-plugin": "bash scripts/e2e/kitchen-sink-plugin-docker.sh",
     "test:docker:kitchen-sink-rpc": "bash scripts/e2e/kitchen-sink-rpc-docker.sh",

--- a/package.json
+++ b/package.json
@@ -1817,6 +1817,7 @@
     "test:docker:doctor-switch": "bash scripts/e2e/doctor-install-switch-docker.sh",
     "test:docker:compose-setup": "bash scripts/e2e/compose-setup.sh",
     "test:docker:e2e-build": "bash scripts/e2e/build-image.sh",
+    "test:docker:gateway-concurrency": "bash scripts/e2e/gateway-concurrency-docker.sh",
     "test:docker:gateway-network": "bash scripts/e2e/gateway-network-docker.sh",
     "test:docker:kitchen-sink-plugin": "bash scripts/e2e/kitchen-sink-plugin-docker.sh",
     "test:docker:kitchen-sink-rpc": "bash scripts/e2e/kitchen-sink-rpc-docker.sh",

--- a/packages/gateway-client/src/session-subscriptions.test.ts
+++ b/packages/gateway-client/src/session-subscriptions.test.ts
@@ -165,36 +165,47 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
     });
   });
 
-  it("coalesces distinct requested aliases before the first canonical acknowledgment", async () => {
-    const acknowledgement = deferred<unknown>();
-    const { client, request } = createClient(async (method) =>
-      method === "sessions.messages.subscribe" ? await acknowledgement.promise : {},
-    );
-    const coordinator = new GatewaySessionMessageSubscriptionCoordinator(client);
+  it.each([
+    { name: "default main", requestedKey: "main", canonicalKey: "agent:main:main" },
+    {
+      name: "configured main",
+      requestedKey: "agent:ops:main",
+      canonicalKey: "agent:ops:work",
+    },
+    { name: "global main", requestedKey: "agent:ops:main", canonicalKey: "global" },
+  ])(
+    "coalesces $name aliases before the first canonical acknowledgment",
+    async ({ requestedKey, canonicalKey }) => {
+      const acknowledgement = deferred<unknown>();
+      const { client, request } = createClient(async (method) =>
+        method === "sessions.messages.subscribe" ? await acknowledgement.promise : {},
+      );
+      const coordinator = new GatewaySessionMessageSubscriptionCoordinator(client);
 
-    const requested = coordinator.acquire("main");
-    const canonical = coordinator.acquire("agent:main:main");
+      const requested = coordinator.acquire(requestedKey);
+      const canonical = coordinator.acquire(canonicalKey);
 
-    expect(request).toHaveBeenCalledExactlyOnceWith("sessions.messages.subscribe", {
-      key: "main",
-    });
+      expect(request).toHaveBeenCalledExactlyOnceWith("sessions.messages.subscribe", {
+        key: requestedKey,
+      });
 
-    acknowledgement.resolve({ key: "agent:main:main" });
-    const [first, second] = await Promise.all([requested, canonical]);
+      acknowledgement.resolve({ key: canonicalKey });
+      const [first, second] = await Promise.all([requested, canonical]);
 
-    expect(first).not.toBe(second);
-    expect(first).toEqual({ key: "agent:main:main", agentId: null });
-    expect(second).toEqual({ key: "agent:main:main", agentId: null });
-    expect(request).toHaveBeenCalledOnce();
+      expect(first).not.toBe(second);
+      expect(first).toEqual({ key: canonicalKey, agentId: null });
+      expect(second).toEqual({ key: canonicalKey, agentId: null });
+      expect(request).toHaveBeenCalledOnce();
 
-    await coordinator.release(first);
-    expect(request).toHaveBeenCalledOnce();
-    await coordinator.release(second);
-    expect(request).toHaveBeenCalledTimes(2);
-    expect(request).toHaveBeenLastCalledWith("sessions.messages.unsubscribe", {
-      key: "agent:main:main",
-    });
-  });
+      await coordinator.release(first);
+      expect(request).toHaveBeenCalledOnce();
+      await coordinator.release(second);
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(request).toHaveBeenLastCalledWith("sessions.messages.unsubscribe", {
+        key: canonicalKey,
+      });
+    },
+  );
 
   it("upgrades a provisional canonical alias without creating a competing plain observer", async () => {
     const acknowledgement = deferred<unknown>();
@@ -254,7 +265,7 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
     await expect(main).resolves.toEqual({ key: "global", agentId: "main" });
   });
 
-  it("releases another session after its agent's first subscription times out", async () => {
+  it("subscribes another session before its agent's stalled subscription times out", async () => {
     vi.useFakeTimers();
     const { client, request } = createStalledRequestClient(
       "sessions.messages.subscribe",
@@ -267,15 +278,22 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
       failure = error;
     });
     const recovered = coordinator.acquire("healthy");
-    expect(request).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "sessions.messages.subscribe",
+      { key: "healthy" },
+      { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
+    );
+    await expect(recovered).resolves.toEqual({ key: "healthy", agentId: null });
+    expect(failure).toBeUndefined();
 
     await vi.advanceTimersByTimeAsync(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS);
 
     expect(failure).toBeInstanceOf(GatewayProtocolRequestTimeoutError);
-    await expect(recovered).resolves.toEqual({ key: "healthy", agentId: null });
     expect(request).toHaveBeenCalledTimes(3);
     expect(request).toHaveBeenNthCalledWith(
-      2,
+      3,
       "sessions.messages.unsubscribe",
       { key: "stalled" },
       { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },

--- a/packages/gateway-client/src/session-subscriptions.ts
+++ b/packages/gateway-client/src/session-subscriptions.ts
@@ -115,11 +115,14 @@ export class GatewaySessionMessageSubscriptionCoordinator {
       );
       if (!existing) {
         const provisional = [...this.#entries].find(
-          (candidate) => candidate.agentId === agentId && !candidate.canonicalSettled,
+          (candidate) =>
+            candidate.agentId === agentId &&
+            !candidate.canonicalSettled &&
+            this.#couldShareCanonicalIdentity(candidate.key, normalizedKey),
         );
         if (provisional) {
-          // Requested aliases cannot be compared safely until their first
-          // Gateway acknowledgment supplies the canonical wire identity.
+          // Only potentially aliased sessions need the first Gateway acknowledgment;
+          // unrelated bodies must not inherit another observer's request deadline.
           await (provisional.plainFallback ?? provisional.ready).catch(() => undefined);
           continue;
         }
@@ -386,6 +389,20 @@ export class GatewaySessionMessageSubscriptionCoordinator {
 
   #areKeysEquivalent(left: string, right: string): boolean {
     return left === right || this.#keysEquivalent?.(left, right) === true;
+  }
+
+  #couldShareCanonicalIdentity(left: string, right: string): boolean {
+    const leftBody = left.replace(/^agent:[^:]+:/i, "").toLowerCase();
+    const rightBody = right.replace(/^agent:[^:]+:/i, "").toLowerCase();
+    // Main/global routing can replace its body with a configured alias. Folding
+    // opaque peer IDs only over-serializes; it never merges distinct observers.
+    return (
+      leftBody === rightBody ||
+      leftBody === "main" ||
+      rightBody === "main" ||
+      leftBody === "global" ||
+      rightBody === "global"
+    );
   }
 }
 

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -31,28 +31,9 @@ import {
   type SessionFileEntry,
 } from "./session-files.js";
 
-function captureStateDirEnv() {
-  const stateDir = process.env.OPENCLAW_STATE_DIR;
-  const configPath = process.env.OPENCLAW_CONFIG_PATH;
-  return {
-    restore() {
-      if (stateDir === undefined) {
-        Reflect.deleteProperty(process.env, "OPENCLAW_STATE_DIR");
-      } else {
-        Reflect.set(process.env, "OPENCLAW_STATE_DIR", stateDir);
-      }
-      if (configPath === undefined) {
-        Reflect.deleteProperty(process.env, "OPENCLAW_CONFIG_PATH");
-      } else {
-        Reflect.set(process.env, "OPENCLAW_CONFIG_PATH", configPath);
-      }
-    },
-  };
-}
-
 let fixtureRoot: string;
 let tmpDir: string;
-let envSnapshot: ReturnType<typeof captureStateDirEnv> | undefined;
+let envSnapshot: Record<string, string | undefined> | undefined;
 let fixtureId = 0;
 
 beforeAll(() => {
@@ -66,7 +47,10 @@ afterAll(() => {
 beforeEach(() => {
   tmpDir = path.join(fixtureRoot, `case-${fixtureId++}`);
   fsSync.mkdirSync(tmpDir, { recursive: true });
-  envSnapshot = captureStateDirEnv();
+  envSnapshot = {
+    OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
+    OPENCLAW_CONFIG_PATH: process.env.OPENCLAW_CONFIG_PATH,
+  };
   Reflect.set(process.env, "OPENCLAW_STATE_DIR", tmpDir);
   clearRuntimeConfigSnapshot();
   clearConfigCache();
@@ -77,7 +61,13 @@ afterEach(() => {
   // env is active, then close shared state before removing the Windows-owned directory.
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
-  envSnapshot?.restore();
+  for (const [key, value] of Object.entries(envSnapshot ?? {})) {
+    if (value === undefined) {
+      Reflect.deleteProperty(process.env, key);
+    } else {
+      Reflect.set(process.env, key, value);
+    }
+  }
   envSnapshot = undefined;
   clearRuntimeConfigSnapshot();
   clearConfigCache();

--- a/scripts/bench-gateway-concurrency.ts
+++ b/scripts/bench-gateway-concurrency.ts
@@ -1,18 +1,25 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 // Bench Gateway Concurrency script measures gateway probes during synthetic streaming turns.
 import { randomUUID } from "node:crypto";
-import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { request } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { pathToFileURL } from "node:url";
-import { PROTOCOL_VERSION } from "../packages/gateway-protocol/src/version.ts";
 import { asFiniteNumber } from "../packages/normalization-core/src/number-coercion.ts";
 import { sliceUtf16Safe } from "../packages/normalization-core/src/utf16-slice.ts";
 import { applyMockOpenAiModelConfig } from "./e2e/lib/fixtures/mock-openai-config.mjs";
 import { delay, stopChild } from "./lib/gateway-bench-child.ts";
-import { getFreePort } from "./lib/gateway-bench-probes.ts";
+import { getFreePort, readProcessRssMb } from "./lib/gateway-bench-probes.ts";
 import {
   BASE_GATEWAY_BENCH_CONFIG,
   buildGatewayBenchChildArgs,
@@ -79,17 +86,32 @@ type FreshConnectionProbe = {
 
 type GatewayRpc = <T>(method: string, params: unknown, timeoutMs?: number) => Promise<T>;
 
+type GatewayMemorySample = {
+  atMs: number;
+  heapTotalMb: number;
+  heapUsedMb: number;
+  rssMb: number;
+};
+
 type BenchmarkRun = {
   controlUi: ControlUiProbe[];
   durationMs: number;
   freshConnection: FreshConnectionProbe;
+  history: TimedProbe[];
+  memory: { after: GatewayMemorySample; before: GatewayMemorySample; peakRssMb: number };
+  messageSubscriptions: TimedProbe[];
+  messageSubscriptionsDuringLoad: TimedProbe[];
+  modelRequestCount: number;
   probeWarmup: {
     durationMs: number;
     samples: GatewaySample[];
   };
   pluginMetadataScans: ReturnType<typeof summarizePluginMetadataScans>;
   readyz: ReadyProbe[];
+  sessionSeedDurationMs: number;
   sessionsList: TimedProbe[];
+  sessionUpdates: TimedProbe[];
+  setupDurationMs: number;
   turnCount: number;
   turnsDurationMs: number;
 };
@@ -98,15 +120,24 @@ type CliOptions = {
   cadenceMs: number;
   concurrency: number;
   cpuProfDir?: string;
+  diagnosticsTimeline: boolean;
   entry: string;
+  historyBurst: number;
+  historyClients: number;
   json: boolean;
   maxControlMs?: number;
   maxHandshakeMs?: number;
   output?: string;
   pluginCount: number;
   runs: number;
+  sessionCount: number;
+  sessionUpdateClients: number;
+  sessionUpdates: number;
+  streamChunkDelayMs: number;
+  subscribers: number;
   timeoutMs: number;
   toolEvents: boolean;
+  visibleObserver: boolean;
   warmup: number;
   workspaceFanout: boolean;
 };
@@ -120,6 +151,9 @@ const DEFAULT_WARMUP = 0;
 const MOCK_RESPONSE_CHUNK_DELAY_MS = 1_000;
 const MAX_CONCURRENCY = 64;
 const MAX_PLUGIN_COUNT = 100;
+const MAX_SESSION_COUNT = 10_000;
+const MAX_SESSION_UPDATES = 100_000;
+const MAX_SESSION_SEED_CONCURRENCY = 16;
 const MAX_RUNS = 20;
 const MAX_WARMUP = 10;
 const MAX_SAMPLES_PER_RUN = 2_048;
@@ -130,17 +164,32 @@ const PROBE_WARMUP_TARGET_MS = 1_000;
 const PROBE_WARMUP_RETRY_DELAY_MS = 100;
 const GATEWAY_STDERR_TAIL_LINES = 20;
 const AGENT_WAIT_RPC_GRACE_MS = 5_000;
-const BOOLEAN_FLAGS = new Set(["--help", "-h", "--json", "--tool-events", "--workspace-fanout"]);
+const BOOLEAN_FLAGS = new Set([
+  "--help",
+  "-h",
+  "--json",
+  "--no-diagnostics-timeline",
+  "--tool-events",
+  "--visible-observer",
+  "--workspace-fanout",
+]);
 const VALUE_FLAGS = new Set([
   "--cadence-ms",
   "--concurrency",
   "--cpu-prof-dir",
   "--entry",
+  "--history-burst",
+  "--history-clients",
   "--max-control-ms",
   "--max-handshake-ms",
   "--output",
   "--plugin-count",
   "--runs",
+  "--session-count",
+  "--session-update-clients",
+  "--session-updates",
+  "--stream-chunk-delay-ms",
+  "--subscribers",
   "--timeout-ms",
   "--warmup",
 ]);
@@ -187,7 +236,20 @@ function parseOptions(argv: string[] = process.argv.slice(2)): CliOptions {
       MAX_CONCURRENCY,
     ),
     cpuProfDir: resolveOutputPath(parseFlagValue(argv, "--cpu-prof-dir")),
+    diagnosticsTimeline: !hasFlag(argv, "--no-diagnostics-timeline"),
     entry: resolveEntry(parseFlagValue(argv, "--entry"), DEFAULT_ENTRY),
+    historyBurst: parseBoundedPositiveInt(
+      parseFlagValue(argv, "--history-burst"),
+      5,
+      "--history-burst",
+      32,
+    ),
+    historyClients: parseBoundedNonNegativeInt(
+      parseFlagValue(argv, "--history-clients"),
+      0,
+      "--history-clients",
+      MAX_CONCURRENCY,
+    ),
     json: hasFlag(argv, "--json"),
     maxControlMs: parseFlagValue(argv, "--max-control-ms")
       ? parseBoundedPositiveInt(
@@ -213,6 +275,36 @@ function parseOptions(argv: string[] = process.argv.slice(2)): CliOptions {
       MAX_PLUGIN_COUNT,
     ),
     runs: parseBoundedPositiveInt(parseFlagValue(argv, "--runs"), DEFAULT_RUNS, "--runs", MAX_RUNS),
+    sessionCount: parseBoundedNonNegativeInt(
+      parseFlagValue(argv, "--session-count"),
+      0,
+      "--session-count",
+      MAX_SESSION_COUNT,
+    ),
+    sessionUpdateClients: parseBoundedPositiveInt(
+      parseFlagValue(argv, "--session-update-clients"),
+      4,
+      "--session-update-clients",
+      MAX_CONCURRENCY,
+    ),
+    sessionUpdates: parseBoundedNonNegativeInt(
+      parseFlagValue(argv, "--session-updates"),
+      0,
+      "--session-updates",
+      MAX_SESSION_UPDATES,
+    ),
+    streamChunkDelayMs: parseBoundedPositiveInt(
+      parseFlagValue(argv, "--stream-chunk-delay-ms"),
+      MOCK_RESPONSE_CHUNK_DELAY_MS,
+      "--stream-chunk-delay-ms",
+      30_000,
+    ),
+    subscribers: parseBoundedNonNegativeInt(
+      parseFlagValue(argv, "--subscribers"),
+      0,
+      "--subscribers",
+      MAX_CONCURRENCY,
+    ),
     timeoutMs: parseBoundedPositiveInt(
       parseFlagValue(argv, "--timeout-ms"),
       DEFAULT_TIMEOUT_MS,
@@ -220,6 +312,7 @@ function parseOptions(argv: string[] = process.argv.slice(2)): CliOptions {
       10 * 60_000,
     ),
     toolEvents: hasFlag(argv, "--tool-events"),
+    visibleObserver: hasFlag(argv, "--visible-observer"),
     warmup: parseBoundedNonNegativeInt(
       parseFlagValue(argv, "--warmup"),
       DEFAULT_WARMUP,
@@ -245,6 +338,15 @@ Options:
   --cadence-ms <ms>  Probe cadence (default: ${DEFAULT_CADENCE_MS})
   --timeout-ms <ms>  Per-run cap, excluding probe warmup (default: ${DEFAULT_TIMEOUT_MS})
   --entry <path>     Gateway CLI entry file (default: ${DEFAULT_ENTRY})
+  --session-count <n> Seed up to ${MAX_SESSION_COUNT} distinct sessions before load
+  --session-updates <n> Bounded public sessions.patch mutations during load
+  --session-update-clients <n> Concurrent session mutation clients (default: 4)
+  --history-clients <n> Concurrent dedicated history-prefetch WebSocket clients
+  --history-burst <n> Parallel history requests per prefetch client (default: 5)
+  --subscribers <n> Dedicated session-message subscription clients
+  --stream-chunk-delay-ms <n> Mock-provider delay between stream chunks (default: ${MOCK_RESPONSE_CHUNK_DELAY_MS})
+  --visible-observer Mark subscribed clients visible to exercise session observation
+  --no-diagnostics-timeline Disable synchronous diagnostics timeline file writes
   --plugin-count <n> Configure synthetic plugins through plugins.load.paths (default: 0)
   --tool-events      Make every synthetic turn execute a tool before replying
   --workspace-fanout Bind each turn to a distinct workspace
@@ -509,8 +611,11 @@ function buildConfig(
 ): string {
   const controlUiRoot = path.join(root, "control-ui");
   mkdirSync(controlUiRoot, { recursive: true });
+  const checkoutIndex = path.join(process.cwd(), "ui", "index.html");
   copyFileSync(
-    path.join(process.cwd(), "ui", "index.html"),
+    existsSync(checkoutIndex)
+      ? checkoutIndex
+      : path.join(process.cwd(), "dist", "control-ui", "index.html"),
     path.join(controlUiRoot, "index.html"),
   );
 
@@ -524,13 +629,38 @@ function buildConfig(
   agents.defaults = {
     ...(agents.defaults as Record<string, unknown>),
     maxConcurrent: concurrency,
+    utilityModel: "openai/gpt-5.6-luna",
   };
   const pluginFixtures =
     pluginCount > 0 ? writePluginFixtures(root, { count: pluginCount }) : undefined;
   return writeGatewayBenchConfig(root, config, { pluginFixtures });
 }
 
-async function connectGateway(port: number, deadlineAt: number, subscribeSessions = true) {
+async function readGatewayProtocolVersion(entry: string): Promise<number> {
+  const protocolPath = path.join(
+    path.dirname(path.resolve(entry)),
+    "gateway",
+    "protocol",
+    "index.js",
+  );
+  const protocol: unknown = await import(pathToFileURL(protocolPath).href);
+  if (
+    typeof protocol !== "object" ||
+    protocol === null ||
+    !("PROTOCOL_VERSION" in protocol) ||
+    typeof protocol.PROTOCOL_VERSION !== "number"
+  ) {
+    throw new Error(`Gateway protocol module is missing PROTOCOL_VERSION: ${protocolPath}`);
+  }
+  return protocol.PROTOCOL_VERSION;
+}
+
+async function connectGateway(
+  port: number,
+  deadlineAt: number,
+  protocolVersion: number,
+  subscribeSessions = true,
+) {
   let requestDeadlineAt = deadlineAt;
   const client = createGatewayWsClient({
     handshakeTimeoutMs: Math.min(8_000, requireRemainingMs(deadlineAt, "connecting WebSocket")),
@@ -566,8 +696,8 @@ async function connectGateway(port: number, deadlineAt: number, subscribeSession
   };
 
   await requestRpc("connect", {
-    minProtocol: PROTOCOL_VERSION,
-    maxProtocol: PROTOCOL_VERSION,
+    minProtocol: protocolVersion,
+    maxProtocol: protocolVersion,
     client: {
       id: "gateway-client",
       displayName: "gateway-concurrency-benchmark",
@@ -589,6 +719,71 @@ async function connectGateway(port: number, deadlineAt: number, subscribeSession
       requestDeadlineAt = value;
     },
   };
+}
+
+async function readGatewayMemory(
+  rpc: GatewayRpc,
+  runStartedAt: number,
+): Promise<GatewayMemorySample> {
+  const result = await rpc<{
+    processMemory?: { heapTotalBytes?: number; heapUsedBytes?: number; rssBytes?: number };
+  }>("status", { includeChannelSummary: false });
+  const memory = result.processMemory;
+  const heapTotalBytes = asFiniteNumber(memory?.heapTotalBytes);
+  const heapUsedBytes = asFiniteNumber(memory?.heapUsedBytes);
+  const rssBytes = asFiniteNumber(memory?.rssBytes);
+  if (heapTotalBytes === undefined || heapUsedBytes === undefined || rssBytes === undefined) {
+    throw new Error("Gateway status did not report process memory");
+  }
+  const toMb = (bytes: number) => bytes / 1024 / 1024;
+  return {
+    atMs: performance.now() - runStartedAt,
+    heapTotalMb: toMb(heapTotalBytes),
+    heapUsedMb: toMb(heapUsedBytes),
+    rssMb: toMb(rssBytes),
+  };
+}
+
+function readGatewayProcessRssMb(pid: number | undefined): number | null {
+  if (!pid) {
+    return null;
+  }
+  if (process.platform !== "linux") {
+    return readProcessRssMb(pid);
+  }
+  try {
+    const status = readFileSync(`/proc/${pid}/status`, "utf8");
+    const match = /^VmRSS:\s+(\d+)\s+kB$/mu.exec(status);
+    const rssKb = match ? Number(match[1]) : Number.NaN;
+    return Number.isFinite(rssKb) && rssKb > 0 ? rssKb / 1024 : null;
+  } catch {
+    return null;
+  }
+}
+
+async function timeRpcProbe(
+  rpc: GatewayRpc,
+  method: string,
+  params: unknown,
+  runStartedAt: number,
+): Promise<TimedProbe> {
+  const startedAt = performance.now();
+  try {
+    await rpc(method, params);
+    return {
+      atMs: startedAt - runStartedAt,
+      error: null,
+      latencyMs: performance.now() - startedAt,
+      ok: true,
+    };
+  } catch (error) {
+    return {
+      atMs: startedAt - runStartedAt,
+      error: describeProbeError(error),
+      latencyMs: performance.now() - startedAt,
+      ok: false,
+    };
+  }
 }
 
 async function runTurn(
@@ -770,19 +965,32 @@ async function runGatewaySample(options: {
   cadenceMs: number;
   concurrency: number;
   deadlineAt: number;
+  diagnosticsTimeline: boolean;
   entry: string;
   cpuProfDir?: string;
+  historyBurst: number;
+  historyClients: number;
   pluginCount: number;
+  sessionCount: number;
+  sessionUpdateClients: number;
+  sessionUpdates: number;
+  streamChunkDelayMs: number;
+  subscribers: number;
+  timeoutMs: number;
   toolEvents: boolean;
+  visibleObserver: boolean;
   workspaceFanout: boolean;
 }): Promise<BenchmarkRun> {
   const root = mkdtempSync(path.join(tmpdir(), "openclaw-gateway-concurrency-"));
   const [port, mockPort] = await Promise.all([getFreePort(), getFreePort()]);
   const runStartedAt = performance.now();
   const timelinePath = path.join(root, "diagnostics-timeline.jsonl");
+  const requestLogPath = path.join(root, "mock-provider-requests.jsonl");
+  const protocolVersion = await readGatewayProtocolVersion(options.entry);
   let gateway: ChildProcessWithoutNullStreams | undefined;
   let mockProvider: ChildProcessWithoutNullStreams | undefined;
   let client: Awaited<ReturnType<typeof connectGateway>> | undefined;
+  const auxiliaryClients: Array<Awaited<ReturnType<typeof connectGateway>>> = [];
   let gatewayOutput = { readOutput: () => "", readStderrTail: () => "" };
   let mockOutput = { readOutput: () => "", readStderrTail: () => "" };
 
@@ -795,7 +1003,8 @@ async function runGatewaySample(options: {
         LANG: process.env.LANG ?? "en_US.UTF-8",
         PATH: process.env.PATH,
         MOCK_PORT: String(mockPort),
-        MOCK_RESPONSE_CHUNK_DELAY_MS: String(MOCK_RESPONSE_CHUNK_DELAY_MS),
+        MOCK_REQUEST_LOG: requestLogPath,
+        MOCK_RESPONSE_CHUNK_DELAY_MS: String(options.streamChunkDelayMs),
         SUCCESS_MARKER: "OpenClaw gateway concurrency benchmark streaming response.",
       },
     });
@@ -817,8 +1026,12 @@ async function runGatewaySample(options: {
         env: {
           ...createGatewayBenchEnv(root, configPath, {
             caseEnv: {
-              OPENCLAW_DIAGNOSTICS: "timeline",
-              OPENCLAW_DIAGNOSTICS_TIMELINE_PATH: timelinePath,
+              ...(options.diagnosticsTimeline
+                ? {
+                    OPENCLAW_DIAGNOSTICS: "timeline",
+                    OPENCLAW_DIAGNOSTICS_TIMELINE_PATH: timelinePath,
+                  }
+                : {}),
               OPENCLAW_SKIP_CHANNELS: "1",
             },
           }),
@@ -838,8 +1051,11 @@ async function runGatewaySample(options: {
       throw new Error(`gateway did not become ready\n${gatewayOutput.readOutput()}`);
     }
     await waitForGatewayDispatchReady(gatewayOutput.readOutput, options.deadlineAt);
-    client = await connectGateway(port, options.deadlineAt);
+    client = await connectGateway(port, options.deadlineAt, protocolVersion);
     const rpc = client.request;
+    if (options.visibleObserver) {
+      await rpc("sessions.observer.visibility", { visible: true });
+    }
     // The first authenticated RPC lazily imports the server-method graph. It measured 6.9s
     // on an idle M4 Pro (previously 18.4s) and crossed 20s on Linux; hot probes took 15-40ms.
     // Keep that cold work out of the load-phase deadline and latency distributions.
@@ -855,30 +1071,121 @@ async function runGatewaySample(options: {
           runStartedAt,
         }),
     });
-    const loadDeadlineAt = options.deadlineAt + probeWarmup.durationMs;
-    client.setDeadlineAt(loadDeadlineAt);
-    const workspaceSessionKeys = options.workspaceFanout
-      ? await Promise.all(
-          Array.from({ length: options.concurrency }, async (_, index) => {
-            const workspaceDir = path.join(root, `workspace-${index + 1}`);
-            mkdirSync(workspaceDir, { recursive: true });
-            const sessionKey = `agent:main:gateway-concurrency-${index + 1}`;
+    const setupDeadlineAt = performance.now() + options.timeoutMs;
+    const setupStartedAt = performance.now();
+    client.setDeadlineAt(setupDeadlineAt);
+    const sessionCount = Math.max(options.concurrency, options.sessionCount);
+    const prepareSessions =
+      options.workspaceFanout ||
+      options.sessionCount > 0 ||
+      options.historyClients > 0 ||
+      options.sessionUpdates > 0 ||
+      options.subscribers > 0;
+    const sessionKeys = Array.from(
+      { length: sessionCount },
+      (_, index) => `agent:main:gateway-concurrency-${index + 1}`,
+    );
+    const sessionSeedStartedAt = performance.now();
+    if (prepareSessions) {
+      let nextSessionIndex = 0;
+      let seededSessionCount = 0;
+      await Promise.all(
+        Array.from({ length: Math.min(MAX_SESSION_SEED_CONCURRENCY, sessionCount) }, async () => {
+          for (;;) {
+            const index = nextSessionIndex++;
+            const sessionKey = sessionKeys[index];
+            if (!sessionKey) {
+              return;
+            }
+            const workspaceDir = options.workspaceFanout
+              ? path.join(root, `workspace-${index + 1}`)
+              : undefined;
+            if (workspaceDir) {
+              mkdirSync(workspaceDir, { recursive: true });
+            }
             await rpc("sessions.create", {
               key: sessionKey,
               agentId: "main",
-              cwd: workspaceDir,
+              ...(workspaceDir ? { cwd: workspaceDir } : {}),
             });
-            return sessionKey;
-          }),
-        )
-      : [];
+            seededSessionCount += 1;
+            if (sessionCount >= 250 && seededSessionCount % 250 === 0) {
+              console.error(
+                `[bench-gateway-concurrency] seeded ${seededSessionCount}/${sessionCount} sessions`,
+              );
+            }
+          }
+        }),
+      );
+    }
+    const sessionSeedDurationMs = performance.now() - sessionSeedStartedAt;
+    const messageSubscriptions: TimedProbe[] = [];
+    for (let index = 0; index < options.subscribers; index += 1) {
+      const subscriber = await connectGateway(port, setupDeadlineAt, protocolVersion, false);
+      auxiliaryClients.push(subscriber);
+      if (options.visibleObserver) {
+        await subscriber.request("sessions.observer.visibility", { visible: true });
+      }
+      const subscription = await timeRpcProbe(
+        subscriber.request,
+        "sessions.messages.subscribe",
+        { key: sessionKeys[index % sessionKeys.length] },
+        runStartedAt,
+      );
+      messageSubscriptions.push(subscription);
+      if (!subscription.ok) {
+        throw new Error(`session message subscription failed: ${subscription.error}`);
+      }
+    }
+    const historyClients = await Promise.all(
+      Array.from({ length: options.historyClients }, async () => {
+        const historyClient = await connectGateway(port, setupDeadlineAt, protocolVersion, false);
+        auxiliaryClients.push(historyClient);
+        return historyClient;
+      }),
+    );
+    const sessionUpdateClients = await Promise.all(
+      Array.from(
+        { length: options.sessionUpdates > 0 ? options.sessionUpdateClients : 0 },
+        async () => {
+          const updateClient = await connectGateway(port, setupDeadlineAt, protocolVersion, false);
+          auxiliaryClients.push(updateClient);
+          return updateClient;
+        },
+      ),
+    );
+    const subscriptionProbeClient =
+      options.subscribers > 0
+        ? await connectGateway(port, setupDeadlineAt, protocolVersion, false)
+        : undefined;
+    if (subscriptionProbeClient) {
+      auxiliaryClients.push(subscriptionProbeClient);
+    }
+    const memoryBefore = await readGatewayMemory(rpc, runStartedAt);
+    const setupDurationMs = performance.now() - setupStartedAt;
+    // Large session fixtures are setup, not benchmarked load. Every measured
+    // run therefore gets its complete timeout after all clients are ready.
+    const loadDeadlineAt = performance.now() + options.timeoutMs;
+    client.setDeadlineAt(loadDeadlineAt);
+    for (const auxiliaryClient of auxiliaryClients) {
+      auxiliaryClient.setDeadlineAt(loadDeadlineAt);
+    }
     // The benchmark compares runtime event work, so discard startup and lazy-import spans.
-    writeFileSync(timelinePath, "");
+    if (options.diagnosticsTimeline) {
+      writeFileSync(timelinePath, "");
+    }
 
     const controlUi: ControlUiProbe[] = [];
+    const history: TimedProbe[] = [];
+    const messageSubscriptionsDuringLoad: TimedProbe[] = [];
     const readyz: ReadyProbe[] = [];
     const sessionsList: TimedProbe[] = [];
+    const sessionUpdates: TimedProbe[] = [];
+    let peakRssMb = memoryBefore.rssMb;
+    let lastRssSampleAt = performance.now();
     let turnsDone = false;
+    let updatesDone = options.sessionUpdates === 0;
+    const workloadDone = () => turnsDone && updatesDone;
     let startedTurnCount = 0;
     let resolveAllTurnsStarted!: () => void;
     const allTurnsStarted = new Promise<void>((resolve) => {
@@ -894,7 +1201,7 @@ async function runGatewaySample(options: {
               resolveAllTurnsStarted();
             }
           },
-          ...(workspaceSessionKeys[index] ? { sessionKey: workspaceSessionKeys[index] } : {}),
+          ...(sessionKeys[index] ? { sessionKey: sessionKeys[index] } : {}),
         }),
       ),
     ).finally(() => {
@@ -904,7 +1211,7 @@ async function runGatewaySample(options: {
     const freshConnection = allTurnsStarted.then(async (): Promise<FreshConnectionProbe> => {
       const startedAt = performance.now();
       try {
-        const freshClient = await connectGateway(port, loadDeadlineAt, false);
+        const freshClient = await connectGateway(port, loadDeadlineAt, protocolVersion, false);
         freshClient.close();
         return { error: null, latencyMs: performance.now() - startedAt, ok: true };
       } catch (error) {
@@ -918,16 +1225,41 @@ async function runGatewaySample(options: {
     const sampler = (async () => {
       for (;;) {
         const sampleStartedAt = performance.now();
-        const sample = await sampleGateway({
-          deadlineAt: loadDeadlineAt,
-          port,
-          rpc,
-          runStartedAt,
-        });
+        const subscriptionKey = sessionKeys[readyz.length % sessionKeys.length];
+        const [sample, subscription] = await Promise.all([
+          sampleGateway({
+            deadlineAt: loadDeadlineAt,
+            port,
+            rpc,
+            runStartedAt,
+          }),
+          subscriptionProbeClient && subscriptionKey
+            ? timeRpcProbe(
+                subscriptionProbeClient.request,
+                "sessions.messages.subscribe",
+                { key: subscriptionKey },
+                runStartedAt,
+              )
+            : Promise.resolve(undefined),
+        ]);
+        if (subscription) {
+          messageSubscriptionsDuringLoad.push(subscription);
+          if (subscription.ok) {
+            await subscriptionProbeClient?.request("sessions.messages.unsubscribe", {
+              key: subscriptionKey,
+            });
+          }
+        }
         readyz.push(sample.readyz);
         sessionsList.push(sample.sessionsList);
         controlUi.push(sample.controlUi);
-        if (turnsDone || readyz.length >= MAX_SAMPLES_PER_RUN) {
+        if (performance.now() - lastRssSampleAt >= 1_000) {
+          // Linux reads procfs without spawning a process. Non-Linux hosts use
+          // the shared ps fallback at most once per second to bound perturbation.
+          peakRssMb = Math.max(peakRssMb, readGatewayProcessRssMb(gateway?.pid) ?? 0);
+          lastRssSampleAt = performance.now();
+        }
+        if (workloadDone() || readyz.length >= MAX_SAMPLES_PER_RUN) {
           break;
         }
         await delay(
@@ -938,18 +1270,83 @@ async function runGatewaySample(options: {
         );
       }
     })();
-    await Promise.all([turns, sampler]);
+    const historyLoad = Promise.all(
+      historyClients.map(async (historyClient, clientIndex) => {
+        let offset = clientIndex * options.historyBurst;
+        while (!workloadDone() && history.length < MAX_SAMPLES_PER_RUN) {
+          const probes = await Promise.all(
+            Array.from({ length: options.historyBurst }, (_, index) =>
+              timeRpcProbe(
+                historyClient.request,
+                "chat.history",
+                { sessionKey: sessionKeys[(offset + index) % sessionKeys.length] },
+                runStartedAt,
+              ),
+            ),
+          );
+          history.push(...probes);
+          offset += options.historyBurst;
+          if (!workloadDone()) {
+            await delay(Math.min(options.cadenceMs, remainingMs(loadDeadlineAt)));
+          }
+        }
+      }),
+    );
+    let nextUpdateIndex = 0;
+    const sessionUpdateLoad = Promise.all(
+      sessionUpdateClients.map(async (updateClient) => {
+        for (;;) {
+          const index = nextUpdateIndex++;
+          if (index >= options.sessionUpdates) {
+            return;
+          }
+          const sessionKey = sessionKeys[index % sessionKeys.length];
+          const update = await timeRpcProbe(
+            updateClient.request,
+            "sessions.patch",
+            { key: sessionKey, label: `Benchmark update ${index + 1}` },
+            runStartedAt,
+          );
+          sessionUpdates.push(update);
+          if (!update.ok) {
+            throw new Error(`sessions.patch load probe failed: ${update.error}`);
+          }
+        }
+      }),
+    ).finally(() => {
+      updatesDone = true;
+    });
+    await Promise.all([turns, sampler, historyLoad, sessionUpdateLoad]);
+    if (options.historyClients > 0 && !history.some((sample) => sample.ok)) {
+      const failure = history[0]?.error ?? "no requests completed before turns finished";
+      throw new Error(`all configured chat.history load probes failed: ${failure}`);
+    }
     const freshConnectionResult = await freshConnection;
     const turnsDurationMs = performance.now() - turnsStartedAt;
+    const memoryAfter = await readGatewayMemory(rpc, runStartedAt);
+    peakRssMb = Math.max(peakRssMb, memoryAfter.rssMb);
+    const modelRequestCount = existsSync(requestLogPath)
+      ? readFileSync(requestLogPath, "utf8").split(/\r?\n/u).filter(Boolean).length
+      : 0;
 
     return {
       controlUi,
       durationMs: performance.now() - runStartedAt,
       freshConnection: freshConnectionResult,
+      history,
+      memory: { after: memoryAfter, before: memoryBefore, peakRssMb },
+      messageSubscriptions,
+      messageSubscriptionsDuringLoad,
+      modelRequestCount,
       probeWarmup,
-      pluginMetadataScans: summarizePluginMetadataScans(readDiagnosticsTimelineSpans(timelinePath)),
+      pluginMetadataScans: summarizePluginMetadataScans(
+        options.diagnosticsTimeline ? readDiagnosticsTimelineSpans(timelinePath) : [],
+      ),
       readyz,
+      sessionSeedDurationMs,
       sessionsList,
+      sessionUpdates,
+      setupDurationMs,
       turnCount: options.concurrency,
       turnsDurationMs,
     };
@@ -957,6 +1354,9 @@ async function runGatewaySample(options: {
     const detail = formatRunFailure(error, gatewayOutput, mockOutput);
     throw new Error(detail, { cause: error });
   } finally {
+    for (const auxiliaryClient of auxiliaryClients) {
+      auxiliaryClient.close();
+    }
     client?.close();
     if (gateway) {
       if (options.cpuProfDir && gateway.exitCode === null && gateway.signalCode === null) {
@@ -980,6 +1380,10 @@ async function runGatewaySample(options: {
 
 function summarizeRuns(runs: readonly BenchmarkRun[]) {
   const readyz = runs.flatMap((run) => run.readyz);
+  const history = runs.flatMap((run) => run.history);
+  const subscriptions = runs.flatMap((run) => run.messageSubscriptions);
+  const subscriptionsDuringLoad = runs.flatMap((run) => run.messageSubscriptionsDuringLoad);
+  const sessionUpdates = runs.flatMap((run) => run.sessionUpdates);
   return {
     controlUiFailedSamples: runs.flatMap((run) => run.controlUi).filter((sample) => !sample.ok)
       .length,
@@ -998,6 +1402,25 @@ function summarizeRuns(runs: readonly BenchmarkRun[]) {
     ),
     freshConnectionFailedRuns: runs.filter((run) => !run.freshConnection.ok).length,
     freshConnectionLatencyMs: summarizeNumbers(runs.map((run) => run.freshConnection.latencyMs)),
+    gatewayHeapGrowthMb: summarizeNumbers(
+      runs.map((run) => run.memory.after.heapUsedMb - run.memory.before.heapUsedMb),
+    ),
+    gatewayHeapUsedMb: summarizeNumbers(runs.map((run) => run.memory.after.heapUsedMb)),
+    gatewayPeakRssMb: summarizeNumbers(runs.map((run) => run.memory.peakRssMb)),
+    gatewayRssGrowthMb: summarizeNumbers(
+      runs.map((run) => run.memory.after.rssMb - run.memory.before.rssMb),
+    ),
+    historyFailedSamples: history.filter((sample) => !sample.ok).length,
+    historyLatencyMs: summarizeNumbers(history.map((sample) => sample.latencyMs)),
+    historySampleCount: history.length,
+    messageSubscriptionFailedSamples: subscriptions.filter((sample) => !sample.ok).length,
+    messageSubscriptionLatencyMs: summarizeNumbers(subscriptions.map((sample) => sample.latencyMs)),
+    messageSubscriptionLoadFailedSamples: subscriptionsDuringLoad.filter((sample) => !sample.ok)
+      .length,
+    messageSubscriptionLoadLatencyMs: summarizeNumbers(
+      subscriptionsDuringLoad.map((sample) => sample.latencyMs),
+    ),
+    modelRequestCount: runs.reduce((count, run) => count + run.modelRequestCount, 0),
     pluginMetadataScanCount: runs.reduce((sum, run) => sum + run.pluginMetadataScans.count, 0),
     pluginMetadataScanTotalDurationMs: runs.reduce(
       (sum, run) => sum + run.pluginMetadataScans.totalDurationMs,
@@ -1006,12 +1429,17 @@ function summarizeRuns(runs: readonly BenchmarkRun[]) {
     readyzLatencyMs: summarizeNumbers(readyz.map((sample) => sample.latencyMs)),
     readyzFailedSamples: readyz.filter((sample) => !sample.ok).length,
     sampleCount: readyz.length,
+    sessionSeedDurationMs: summarizeNumbers(runs.map((run) => run.sessionSeedDurationMs)),
     sessionsListLatencyMs: summarizeNumbers(
       runs.flatMap((run) => run.sessionsList.map((sample) => sample.latencyMs)),
     ),
     sessionsListFailedSamples: runs
       .flatMap((run) => run.sessionsList)
       .filter((sample) => !sample.ok).length,
+    sessionUpdateFailedSamples: sessionUpdates.filter((sample) => !sample.ok).length,
+    sessionUpdateLatencyMs: summarizeNumbers(sessionUpdates.map((sample) => sample.latencyMs)),
+    sessionUpdateSampleCount: sessionUpdates.length,
+    setupDurationMs: summarizeNumbers(runs.map((run) => run.setupDurationMs)),
     turnsDurationMs: summarizeNumbers(runs.map((run) => run.turnsDurationMs)),
   };
 }
@@ -1056,13 +1484,22 @@ async function main(): Promise<void> {
   const payload = {
     cadenceMs: options.cadenceMs,
     concurrency: options.concurrency,
+    diagnosticsTimeline: options.diagnosticsTimeline,
     entry: options.entry,
     generatedAt: new Date().toISOString(),
+    historyBurst: options.historyBurst,
+    historyClients: options.historyClients,
     mode: "mock-streaming-agent",
     pluginCount: options.pluginCount,
     runs,
+    sessionCount: Math.max(options.sessionCount, options.concurrency),
+    sessionUpdateClients: options.sessionUpdates > 0 ? options.sessionUpdateClients : 0,
+    sessionUpdates: options.sessionUpdates,
+    streamChunkDelayMs: options.streamChunkDelayMs,
+    subscribers: options.subscribers,
     summary: summarizeRuns(runs),
     toolEvents: options.toolEvents,
+    visibleObserver: options.visibleObserver,
     workspaceFanout: options.workspaceFanout,
   };
   if (options.output) {

--- a/scripts/e2e/gateway-concurrency-docker.sh
+++ b/scripts/e2e/gateway-concurrency-docker.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+
+IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-gateway-concurrency-e2e" OPENCLAW_GATEWAY_CONCURRENCY_E2E_IMAGE)"
+ARTIFACT_DIR="${OPENCLAW_GATEWAY_CONCURRENCY_ARTIFACT_DIR:-$ROOT_DIR/.artifacts/gateway-concurrency}"
+mkdir -p "$ARTIFACT_DIR"
+
+docker_e2e_build_or_reuse "$IMAGE_NAME" gateway-concurrency "$ROOT_DIR/scripts/e2e/Dockerfile" "$ROOT_DIR"
+
+BENCH_ARGS=(
+  --entry /app/dist/entry.js
+  --concurrency "${OPENCLAW_GATEWAY_CONCURRENCY:-12}"
+  --session-count "${OPENCLAW_GATEWAY_CONCURRENCY_SESSIONS:-48}"
+  --history-clients "${OPENCLAW_GATEWAY_CONCURRENCY_HISTORY_CLIENTS:-3}"
+  --history-burst "${OPENCLAW_GATEWAY_CONCURRENCY_HISTORY_BURST:-5}"
+  --session-updates "${OPENCLAW_GATEWAY_CONCURRENCY_SESSION_UPDATES:-0}"
+  --session-update-clients "${OPENCLAW_GATEWAY_CONCURRENCY_SESSION_UPDATE_CLIENTS:-4}"
+  --subscribers "${OPENCLAW_GATEWAY_CONCURRENCY_SUBSCRIBERS:-6}"
+  --stream-chunk-delay-ms "${OPENCLAW_GATEWAY_CONCURRENCY_STREAM_DELAY_MS:-1000}"
+  --timeout-ms "${OPENCLAW_GATEWAY_CONCURRENCY_TIMEOUT_MS:-180000}"
+  --output /artifacts/gateway-concurrency.json
+  --json
+)
+if [[ "${OPENCLAW_GATEWAY_CONCURRENCY_VISIBLE_OBSERVER:-1}" == "1" ]]; then
+  BENCH_ARGS+=(--visible-observer)
+fi
+if [[ "${OPENCLAW_GATEWAY_CONCURRENCY_TOOL_EVENTS:-0}" == "1" ]]; then
+  BENCH_ARGS+=(--tool-events)
+fi
+if [[ "${OPENCLAW_GATEWAY_CONCURRENCY_DIAGNOSTICS_TIMELINE:-1}" == "0" ]]; then
+  BENCH_ARGS+=(--no-diagnostics-timeline)
+fi
+
+# Only test-owned harness files cross into the container; the Gateway itself
+# always executes the exact packaged /app/dist entrypoint from the image.
+docker_e2e_run_with_harness \
+  -v "$ROOT_DIR/scripts/bench-gateway-concurrency.ts:/app/scripts/bench-gateway-concurrency.ts:ro" \
+  -v "$ARTIFACT_DIR:/artifacts" \
+  "$IMAGE_NAME" \
+  node scripts/bench-gateway-concurrency.ts "${BENCH_ARGS[@]}"
+
+echo "Gateway concurrency artifact: $ARTIFACT_DIR/gateway-concurrency.json"

--- a/scripts/lib/docker-e2e-scenarios.mts
+++ b/scripts/lib/docker-e2e-scenarios.mts
@@ -534,7 +534,7 @@ export const mainLanes: DockerE2eLane[] = [
   ),
   serviceLane(
     "gateway-concurrency",
-    "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:gateway-concurrency",
+    "OPENCLAW_SKIP_DOCKER_BUILD=1 bash scripts/e2e/gateway-concurrency-docker.sh",
     { timeoutMs: 10 * 60 * 1000, weight: 3 },
   ),
   serviceLane("gateway-network", "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:gateway-network"),

--- a/scripts/lib/docker-e2e-scenarios.mts
+++ b/scripts/lib/docker-e2e-scenarios.mts
@@ -532,6 +532,11 @@ export const mainLanes: DockerE2eLane[] = [
       weight: 3,
     },
   ),
+  serviceLane(
+    "gateway-concurrency",
+    "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:gateway-concurrency",
+    { timeoutMs: 10 * 60 * 1000, weight: 3 },
+  ),
   serviceLane("gateway-network", "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:gateway-network"),
   serviceLane("browser-cdp-snapshot", "pnpm test:docker:browser-cdp-snapshot", {
     stateScenario: "empty",

--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -547,6 +547,10 @@ describe("SQLite session entry cache", () => {
     });
     const before = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
     const siblingBefore = before.find((row) => row.sessionKey === siblingScope.sessionKey)?.entry;
+    const database = openOpenClawAgentDatabase(scope);
+    const cachedBefore = readSessionEntryCache(database, { cache: true });
+    const changedEntryBefore = cachedBefore.entries.get(scope.sessionKey);
+    const siblingEntryBefore = cachedBefore.entries.get(siblingScope.sessionKey);
 
     parseSessionEntryCalls.mockClear();
     listProjectionCalls.mockClear();
@@ -564,6 +568,14 @@ describe("SQLite session entry cache", () => {
     expect(parseSessionEntryCalls).not.toHaveBeenCalled();
     expect(listProjectionCalls).toHaveBeenCalledOnce();
     expect(sessionNodeVersionScans.rowCounts).toEqual([]);
+
+    const cachedAfter = readSessionEntryCache(database, { cache: true });
+    expect(cachedAfter.entries).toBe(cachedBefore.entries);
+    expect(cachedAfter.listEntries).toBe(cachedBefore.listEntries);
+    expect(cachedAfter.keys).toBe(cachedBefore.keys);
+    expect(cachedAfter.entries.get(scope.sessionKey)).not.toBe(changedEntryBefore);
+    expect(cachedAfter.entries.get(siblingScope.sessionKey)).toBe(siblingEntryBefore);
+    expect(cachedAfter.listEntries.get(siblingScope.sessionKey)).toBe(siblingBefore);
   });
 
   it("adds a tracked upsert to a warm snapshot without reparsing siblings", async () => {
@@ -575,6 +587,9 @@ describe("SQLite session entry cache", () => {
     });
     const existing = listSessionEntriesCore({ ...scope, clone: false, projection: "list" })[0]
       ?.entry;
+    const database = openOpenClawAgentDatabase(scope);
+    const cachedBefore = readSessionEntryCache(database, { cache: true });
+    const existingEntry = cachedBefore.entries.get(scope.sessionKey);
     const insertedScope = { ...scope, sessionKey: "agent:main:write-through-inserted" };
 
     parseSessionEntryCalls.mockClear();
@@ -594,6 +609,13 @@ describe("SQLite session entry cache", () => {
     expect(after.find((row) => row.sessionKey === scope.sessionKey)?.entry).toBe(existing);
     expect(parseSessionEntryCalls).not.toHaveBeenCalled();
     expect(listProjectionCalls).toHaveBeenCalledOnce();
+
+    const cachedAfter = readSessionEntryCache(database, { cache: true });
+    expect(cachedAfter.entries).toBe(cachedBefore.entries);
+    expect(cachedAfter.listEntries).toBe(cachedBefore.listEntries);
+    expect(cachedAfter.keys).toEqual([scope.sessionKey, insertedScope.sessionKey].toSorted());
+    expect(cachedAfter.entries.get(scope.sessionKey)).toBe(existingEntry);
+    expect(cachedAfter.listEntries.get(scope.sessionKey)).toBe(existing);
   });
 
   it("does not let a tracked write mask an earlier raw connection write", async () => {

--- a/src/config/sessions/session-accessor.sqlite-entry-cache.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-cache.ts
@@ -404,28 +404,23 @@ function publishSqliteSessionEntryCacheUpsert(
     }
     const generationIsContinuous =
       cached.validityToken.sessionNodesGeneration === writeGeneration.before;
-    const entries = new Map(cached.entries);
-    entries.set(row.session_key, entry);
-    const listProjections = new Map(cached.listProjections);
-    listProjections.delete(row.session_key);
-    const updatedAtByKey = new Map(cached.updatedAtByKey);
-    const knownKey = updatedAtByKey.has(row.session_key);
-    updatedAtByKey.set(row.session_key, row.updated_at);
+    // Borrowed cache views are synchronous, so the commit owner can update one
+    // row in place without cloning every session map on each active-run write.
+    cached.entries.set(row.session_key, entry);
+    cached.listProjections.delete(row.session_key);
+    const knownKey = cached.updatedAtByKey.has(row.session_key);
+    cached.updatedAtByKey.set(row.session_key, row.updated_at);
+    if (!knownKey) {
+      cached.keys = [...cached.keys, row.session_key].toSorted();
+    }
     // Advance only across the bracketed row write. A raw write before/after this bracket leaves
     // a generation gap, while the retained data_version still exposes external commits.
-    sessionEntryCaches.set(database.db, {
-      entries,
-      keys: knownKey ? cached.keys : [...cached.keys, row.session_key].toSorted(),
-      listEntries: createLazyListProjections(entries, listProjections),
-      listProjections,
-      updatedAtByKey,
-      validityToken: generationIsContinuous
-        ? {
-            ...cached.validityToken,
-            sessionNodesGeneration: writeGeneration.after,
-          }
-        : cached.validityToken,
-    });
+    if (generationIsContinuous) {
+      cached.validityToken = {
+        ...cached.validityToken,
+        sessionNodesGeneration: writeGeneration.after,
+      };
+    }
   });
 }
 

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -277,6 +277,7 @@ type TestSocket = {
   bufferedAmount: number;
   send: (payload: string) => void;
   close: (code: number, reason: string) => void;
+  terminate: () => void;
 };
 
 type EventFrame = {
@@ -299,6 +300,7 @@ function makeRecordingSocket(): RecordingSocket {
       sent.push(JSON.parse(payload) as EventFrame);
     }),
     close: vi.fn(),
+    terminate: vi.fn(),
     sent,
   };
 }
@@ -435,6 +437,7 @@ describe("gateway broadcaster", () => {
     broadcastToConnIds("session.message", payload, new Set(["slow-session", "healthy-session"]));
 
     expect(slowSocket.close).toHaveBeenCalledWith(1008, "slow consumer");
+    expect(slowSocket.terminate).toHaveBeenCalledOnce();
     expect(slowSocket.send).not.toHaveBeenCalled();
     expect(healthySocket.sent).toEqual([
       { type: "event", event: "session.message", payload, seq: 1 },
@@ -453,6 +456,8 @@ describe("gateway broadcaster", () => {
     // number: the next delivered frame exposes the loss to gap detection.
     socket.bufferedAmount = MAX_BUFFERED_BYTES + 1;
     broadcastToConnIds("tick", { ts: 3 }, new Set(["c-seq"]), { dropIfSlow: true });
+    expect(socket.close).not.toHaveBeenCalled();
+    expect(socket.terminate).not.toHaveBeenCalled();
     socket.bufferedAmount = 0;
     broadcastToConnIds("tick", { ts: 4 }, new Set(["c-seq"]));
 

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -77,7 +77,7 @@ import {
 const OUTGOING_IMAGE_ROUTE_PREFIX = "/api/chat/media/outgoing";
 const DEFAULT_TRANSIENT_OUTGOING_IMAGE_TTL_MS = 15 * 60 * 1000;
 const MANAGED_OUTGOING_IMAGE_TICKET_SCOPE = "managed-outgoing-image";
-export const MANAGED_OUTGOING_IMAGE_TICKET_TTL_MS = 5 * 60 * 1000;
+const MANAGED_OUTGOING_IMAGE_TICKET_TTL_MS = 5 * 60 * 1000;
 export const MANAGED_OUTGOING_IMAGE_ARTIFACT_ID_PREFIX = "artifact_managed_image_";
 export const MANAGED_OUTGOING_MEDIA_ARTIFACT_ID_PREFIX = "artifact_managed_media_";
 const MANAGED_IMAGE_THUMBNAIL_MAX_SIDE = 300;

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -3229,6 +3229,7 @@ describe("gateway/node-registry", () => {
       bufferedAmount: MAX_BUFFERED_BYTES + 1,
       send: vi.fn(),
       close: vi.fn(),
+      terminate: vi.fn(),
     };
     registerTestNodeSocket(registry, socket);
     const payload = serializeEventPayload({ foo: "bar" });
@@ -3237,6 +3238,10 @@ describe("gateway/node-registry", () => {
       expect(registry.sendEventRaw("node-1", "chat", payload)).toBe(false);
       expect(socket.send).not.toHaveBeenCalled();
       expect(socket.close).toHaveBeenCalledWith(1008, "slow consumer");
+      expect(socket.terminate).toHaveBeenCalledOnce();
+      expect(socket.close.mock.invocationCallOrder[0]).toBeLessThan(
+        socket.terminate.mock.invocationCallOrder[0]!,
+      );
       expect(diagnosticEvents).toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -1508,6 +1508,7 @@ export class NodeRegistry {
     } catch {
       /* ignore */
     }
+    node.client.socket.terminate();
     return true;
   }
 }

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -365,6 +365,7 @@ export function createGatewayBroadcaster(params: {
         } catch {
           /* ignore */
         }
+        c.socket.terminate();
         continue;
       }
       // Build the frame before consuming the seq: a serialization failure

--- a/src/gateway/server-methods/chat-assistant-content.ts
+++ b/src/gateway/server-methods/chat-assistant-content.ts
@@ -9,17 +9,10 @@ import { renderQrPngDataUrl } from "../../media/qr-image.js";
 import { renderQrTerminal } from "../../media/qr-terminal.js";
 import { stripInlineDirectiveTagsForDelivery } from "../../utils/directive-tags.js";
 import { stripEnvelopeFromMessage } from "../chat-sanitize.js";
-import {
-  cleanupManagedOutgoingMediaRecords,
-  createManagedOutgoingMediaBlocks,
-} from "../managed-image-attachments.js";
-import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-agent.js";
+import { createManagedOutgoingMediaBlocks } from "../managed-image-attachments.js";
 import { formatForLog } from "../ws-log.js";
-import { hasRegisteredChatRunForSessionKey } from "./session-active-runs.js";
-import type { GatewayRequestContext } from "./types.js";
 
 const MANAGED_OUTGOING_MEDIA_PATH_PREFIX = "/api/chat/media/outgoing/";
-const chatHistoryManagedMediaCleanupState = new Map<string, Promise<void>>();
 
 export type AssistantDisplayContentBlock = Record<string, unknown>;
 
@@ -433,41 +426,4 @@ export function hasManagedOutgoingAssistantContent(
         (isManagedOutgoingMediaUrl(block.url) || isManagedOutgoingMediaUrl(block.openUrl)),
     ),
   );
-}
-
-export function scheduleChatHistoryManagedMediaCleanup(params: {
-  sessionKey: string;
-  agentId?: string;
-  cfg: import("../../config/types.openclaw.js").OpenClawConfig;
-  context: Pick<GatewayRequestContext, "chatAbortControllers" | "logGateway">;
-}) {
-  const cleanupKey = params.agentId
-    ? `agent:${params.agentId}:${params.sessionKey}`
-    : params.sessionKey;
-  if (chatHistoryManagedMediaCleanupState.has(cleanupKey)) {
-    return;
-  }
-  const pending = cleanupManagedOutgoingMediaRecords({
-    sessionKey: params.sessionKey,
-    ...(params.agentId ? { agentId: params.agentId } : {}),
-    hasActiveSessionRun: (sessionKey, agentId) =>
-      hasRegisteredChatRunForSessionKey({
-        context: params.context,
-        sessionKey,
-        agentId,
-        defaultAgentId: tryResolveSessionCompatibilityOwnerAgentId(params.cfg, sessionKey),
-      }),
-  })
-    .then(() => undefined)
-    .catch((error: unknown) => {
-      params.context.logGateway.debug(
-        `chat.history managed media cleanup skipped sessionKey=${JSON.stringify(params.sessionKey)} error=${formatForLog(error)}`,
-      );
-    })
-    .finally(() => {
-      if (chatHistoryManagedMediaCleanupState.get(cleanupKey) === pending) {
-        chatHistoryManagedMediaCleanupState.delete(cleanupKey);
-      }
-    });
-  chatHistoryManagedMediaCleanupState.set(cleanupKey, pending);
 }

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -36,7 +36,6 @@ import {
 } from "../session-utils.js";
 import { prepareSessionWorkspaceIcon } from "../workspace-icon-http.js";
 import { resolveAgentIdOrRespondError } from "./agent-id-shared.js";
-import { scheduleChatHistoryManagedMediaCleanup } from "./chat-assistant-content.js";
 import {
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
   createChatHistoryByteCounter,
@@ -335,12 +334,6 @@ async function handleChatHistoryRequest({
     byteCounter,
     messages: normalized,
     maxSingleMessageBytes: perMessageHardCap,
-  });
-  scheduleChatHistoryManagedMediaCleanup({
-    sessionKey,
-    ...(selectedAgent.agentId ? { agentId: selectedAgent.agentId } : {}),
-    cfg,
-    context,
   });
   const capped = messageId
     ? (capChatHistoryAroundMessage({

--- a/src/gateway/server.chat-history-cursor.test.ts
+++ b/src/gateway/server.chat-history-cursor.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { createSessionProjection, reduceSessionProjection } from "@openclaw/gateway-client/browser";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
 import { clearConfigCache } from "../config/config.js";
@@ -19,6 +19,7 @@ import {
 import { waitForSessionTranscriptIndexReconcile } from "../config/sessions/session-transcript-reconcile.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
+import * as managedOutgoingMedia from "./managed-image-attachments.js";
 import { createDirectChatContext } from "./server-chat.agent-events.test-helpers.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
 import { installGatewayTestHooks, testState, writeSessionStore } from "./test-helpers.js";
@@ -128,6 +129,25 @@ afterEach(() => {
 });
 
 describe("chat.history cursor catch-up", () => {
+  test.each(["chat.history", "chat.startup"] as const)(
+    "%s does not launch managed outgoing media garbage collection",
+    async (method) => {
+      const { context } = await createCursorSession();
+      const cleanup = vi
+        .spyOn(managedOutgoingMedia, "cleanupManagedOutgoingMediaRecords")
+        .mockResolvedValue({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 0 });
+
+      try {
+        const result = await callChat(context, method);
+
+        expect(result.ok).toBe(true);
+        expect(cleanup).not.toHaveBeenCalled();
+      } finally {
+        cleanup.mockRestore();
+      }
+    },
+  );
+
   test("returns an empty delta at the cached head", async () => {
     const { context } = await createCursorSession();
     const page = await callChat<{ deltaCursor?: string; messages?: unknown[] }>(

--- a/src/gateway/server/ws-connection.test-helpers.ts
+++ b/src/gateway/server/ws-connection.test-helpers.ts
@@ -22,6 +22,7 @@ export type GatewayWsTestSocket = EventEmitter & {
   send: ReturnType<typeof vi.fn>;
   ping?: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
+  terminate: ReturnType<typeof vi.fn>;
 };
 
 export function createGatewayWsTestLogger() {
@@ -79,6 +80,7 @@ export function createGatewayWsTestSocket(
         socket.emit("close", code ?? 1000, Buffer.from(reason ?? ""));
       }
     }),
+    terminate: vi.fn(),
   });
   return socket;
 }

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -411,6 +411,10 @@ describe("attachGatewayWsConnectionHandler", () => {
 
     expect(socket.send).not.toHaveBeenCalled();
     expect(socket.close).toHaveBeenCalledWith(1008, "slow consumer");
+    expect(socket.terminate).toHaveBeenCalledOnce();
+    expect(socket.close.mock.invocationCallOrder[0]).toBeLessThan(
+      socket.terminate.mock.invocationCallOrder[0]!,
+    );
   });
 
   it.each([

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -358,6 +358,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
           limitBytes: MAX_BUFFERED_BYTES,
         });
         close(1008, connectionKind === "worker" ? "slow-consumer" : "slow consumer");
+        socket.terminate();
         return { kind: "unavailable" } as const;
       }
       let encoded: string;
@@ -388,14 +389,14 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
 
     socket.once("error", (err) => {
       if (isWsPayloadLimitError(err)) {
-        const workerPayload = connectionKind === "worker";
         logRejectedLargePayload({
           surface: client ? "gateway.ws.frame" : "gateway.ws.preauth",
-          limitBytes: workerPayload
-            ? WORKER_PROTOCOL_MAX_PAYLOAD_BYTES
-            : client
-              ? MAX_PAYLOAD_BYTES
-              : MAX_PREAUTH_PAYLOAD_BYTES,
+          limitBytes:
+            connectionKind === "worker"
+              ? WORKER_PROTOCOL_MAX_PAYLOAD_BYTES
+              : client
+                ? MAX_PAYLOAD_BYTES
+                : MAX_PREAUTH_PAYLOAD_BYTES,
           reason: client ? "ws_frame_limit" : "preauth_frame_limit",
         });
       }
@@ -455,10 +456,9 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         ...closeMeta,
       };
       if (!client) {
-        const isExpectedStartupRetryClose = closeCause === GATEWAY_STARTUP_PENDING_CLOSE_CAUSE;
         const logFn =
           isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr) ||
-          isExpectedStartupRetryClose ||
+          closeCause === GATEWAY_STARTUP_PENDING_CLOSE_CAUSE ||
           isExpectedLocalAppStartupAbort(code)
             ? logWsControl.debug
             : logWsControl.warn;

--- a/src/gateway/session-observer-audience.test.ts
+++ b/src/gateway/session-observer-audience.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createHarness,
+  event,
+  flushObserver,
+  resetSessionObserverEventSequence,
+  startAndAddToolNotes,
+} from "./session-observer.test-utils.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  resetSessionObserverEventSequence();
+});
+
+describe("session observer audience", () => {
+  it("reserves utility-model digests for directly watched sessions", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const sessionListOnly = createHarness({ subscribe: false, broadSubscribe: true });
+    const directlyWatched = createHarness({ broadSubscribe: true });
+
+    startAndAddToolNotes(sessionListOnly.observer);
+    startAndAddToolNotes(directlyWatched.observer);
+    sessionListOnly.observer.handleEvent(
+      event({
+        stream: "item",
+        data: {
+          kind: "preamble",
+          phase: "update",
+          progressText: "Preparing the next session",
+        },
+      }),
+    );
+
+    expect(sessionListOnly.broadcastToConnIds).toHaveBeenCalledWith(
+      "session.observer",
+      expect.objectContaining({ headline: "Preparing the next session" }),
+      new Set(["conn-1"]),
+      expect.objectContaining({ dropIfSlow: true }),
+    );
+
+    await vi.advanceTimersByTimeAsync(12_000);
+    await flushObserver();
+
+    expect(sessionListOnly.prepareModel).not.toHaveBeenCalled();
+    expect(sessionListOnly.completeModel).not.toHaveBeenCalled();
+    expect(directlyWatched.prepareModel).toHaveBeenCalledOnce();
+    expect(directlyWatched.completeModel).toHaveBeenCalledOnce();
+
+    sessionListOnly.observer.dispose();
+    directlyWatched.observer.dispose();
+  });
+
+  it("stops model work when only the broad session-list audience remains", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const harness = createHarness({ broadSubscribe: true });
+    startAndAddToolNotes(harness.observer);
+
+    harness.subscribers.unsubscribe("conn-1", "agent:main:session-1");
+    await vi.advanceTimersByTimeAsync(12_000);
+
+    expect(harness.prepareModel).not.toHaveBeenCalled();
+    expect(harness.completeModel).not.toHaveBeenCalled();
+
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Still visible in the list" },
+      }),
+    );
+
+    expect(harness.broadcastToConnIds).toHaveBeenCalledWith(
+      "session.observer",
+      expect.objectContaining({ headline: "Still visible in the list" }),
+      new Set(["conn-1"]),
+      expect.objectContaining({ dropIfSlow: true }),
+    );
+    harness.observer.dispose();
+  });
+});

--- a/src/gateway/session-observer-audience.ts
+++ b/src/gateway/session-observer-audience.ts
@@ -5,6 +5,7 @@ import type {
   SessionEventSubscriberRegistry,
   SessionMessageSubscriberRegistry,
 } from "./server-chat-state.js";
+import type { SessionObserverState } from "./session-observer-model.js";
 import { resolveSessionSubscriptionKeys } from "./session-subscription-keys.js";
 
 export function createSessionObserverAudience(params: {
@@ -14,6 +15,10 @@ export function createSessionObserverAudience(params: {
   getConfig: () => OpenClawConfig;
 }) {
   const messageSubscriberKeys = (sessionKey: string, agentId: string): string[] => {
+    const canonicalKeys = resolveSessionSubscriptionKeys(sessionKey, agentId);
+    if (canonicalKeys[0] === sessionKey) {
+      return canonicalKeys;
+    }
     const config = params.getConfig();
     const persistedOwner = resolvePersistedSessionStoreOwnerForKey(config, sessionKey);
     const compatibilityAgentId =
@@ -33,7 +38,25 @@ export function createSessionObserverAudience(params: {
     return recipients;
   };
 
+  const classify = (sessionKey: string, agentId: string): "direct" | "broad" | "none" => {
+    for (const key of messageSubscriberKeys(sessionKey, agentId)) {
+      for (const connId of params.subscribers.get(key)) {
+        if (params.isVisible(connId)) {
+          return "direct";
+        }
+      }
+    }
+    for (const connId of params.sessionEventSubscribers?.getAll() ?? []) {
+      if (params.isVisible(connId)) {
+        return "broad";
+      }
+    }
+    return "none";
+  };
+
   return {
+    classify,
+
     deliveryOptions(sessionKey: string, agentId: string) {
       return {
         agentId,
@@ -41,20 +64,6 @@ export function createSessionObserverAudience(params: {
         sessionKeys: messageSubscriberKeys(sessionKey, agentId),
         sessionSubscriptionVerified: true,
       };
-    },
-
-    has(sessionKey: string, agentId: string): boolean {
-      for (const connId of messageRecipients(sessionKey, agentId)) {
-        if (params.isVisible(connId)) {
-          return true;
-        }
-      }
-      for (const connId of params.sessionEventSubscribers?.getAll() ?? []) {
-        if (params.isVisible(connId)) {
-          return true;
-        }
-      }
-      return false;
     },
 
     recipients(sessionKey: string, agentId: string): ReadonlySet<string> {
@@ -77,4 +86,60 @@ export function createSessionObserverAudience(params: {
       return recipients;
     },
   };
+}
+
+export function createSessionObserverAudienceLifecycle(params: {
+  audience: Pick<ReturnType<typeof createSessionObserverAudience>, "classify">;
+  states: Map<string, SessionObserverState>;
+  subscribers: SessionMessageSubscriberRegistry;
+  isCurrent: (state: SessionObserverState) => boolean;
+  resolveUtilityModelRef: (agentId: string) => string | undefined;
+  suspend: (state: SessionObserverState) => void;
+  demote: (state: SessionObserverState) => void;
+}) {
+  type ObservedAudience = ReturnType<typeof params.audience.classify>;
+
+  const reconcileState = (state: SessionObserverState): void => {
+    const audience = params.audience.classify(state.sessionKey, state.agentId);
+    if (audience === "none") {
+      params.suspend(state);
+    } else if (state.utilityModelRef && audience !== "direct") {
+      params.demote(state);
+    }
+  };
+
+  const reconcileAll = (): void => {
+    // Suspension deletes the current entry; Map iteration keeps later states reachable.
+    for (const state of params.states.values()) {
+      reconcileState(state);
+    }
+  };
+
+  const unsubscribe = params.subscribers.onChange((sessionKey) => {
+    const state = params.states.get(sessionKey);
+    if (state) {
+      reconcileState(state);
+    } else if (sessionKey.toLowerCase() === "global") {
+      // Only the legacy bare alias can affect an agent-qualified state indirectly.
+      reconcileAll();
+    }
+  });
+
+  const stateIsCurrent = (
+    state: SessionObserverState,
+    observedAudience?: ObservedAudience,
+  ): boolean =>
+    params.isCurrent(state) &&
+    (observedAudience ?? params.audience.classify(state.sessionKey, state.agentId)) !== "none";
+
+  const modelStateIsCurrent = (
+    state: SessionObserverState,
+    observedAudience?: ObservedAudience,
+  ): boolean =>
+    Boolean(state.utilityModelRef) &&
+    (observedAudience ?? params.audience.classify(state.sessionKey, state.agentId)) === "direct" &&
+    params.isCurrent(state) &&
+    params.resolveUtilityModelRef(state.agentId) === state.utilityModelRef;
+
+  return { stateIsCurrent, modelStateIsCurrent, reconcileAll, unsubscribe };
 }

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -13,7 +13,10 @@ import {
 import { resolveUtilityModelRefForAgent } from "../agents/utility-model.js";
 import { getAgentRunContext } from "../infra/agent-run-registry.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { createSessionObserverAudience } from "./session-observer-audience.js";
+import {
+  createSessionObserverAudience,
+  createSessionObserverAudienceLifecycle,
+} from "./session-observer-audience.js";
 import { createSessionObserverCompanionSnapshotReader } from "./session-observer-companion.js";
 import { createSessionObserverCompletion } from "./session-observer-completion.js";
 import type { SessionObserverEvent, SessionObserverService } from "./session-observer-contract.js";
@@ -86,6 +89,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     isVisible: (connId) => visibleConnections.has(connId),
     getConfig: deps.getConfig,
   });
+  type ObservedAudience = ReturnType<typeof audience.classify>;
   // Narrow run-identity guard shared by persist paths: a digest may still land
   // while its session is unwatched, but never after a newer run replaces it.
   const runStillCurrent = (runId: string, sessionKey: string, agentId: string) => () =>
@@ -113,7 +117,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     now,
     setTimeoutFn,
     clearTimeoutFn,
-    isCurrent: stateIsCurrent,
+    isCurrent: (state) => audienceLifecycle.stateIsCurrent(state),
     publish: (state, digest) => {
       deps.broadcastToConnIds(
         "session.observer",
@@ -237,34 +241,20 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     demoteUtilityModel(state);
   };
 
-  const suspendStatesWithoutAudience = () => {
-    // Map iteration tolerates suspendState deleting the current entry.
-    for (const state of states.values()) {
-      if (!audience.has(state.sessionKey, state.agentId)) {
-        suspendState(state);
-      }
-    }
-  };
-
-  const unsubscribeChanges = deps.subscribers.onChange(() => suspendStatesWithoutAudience());
-
-  function stateIsCurrent(state: SessionObserverState): boolean {
-    return (
+  const audienceLifecycle = createSessionObserverAudienceLifecycle({
+    audience,
+    states,
+    subscribers: deps.subscribers,
+    isCurrent: (state) =>
       !disposed &&
       stateIsTracked(state) &&
-      audience.has(state.sessionKey, state.agentId) &&
-      deps.getConfig().gateway?.controlUi?.sessionObserver !== false
-    );
-  }
+      deps.getConfig().gateway?.controlUi?.sessionObserver !== false,
+    resolveUtilityModelRef: (agentId) => resolveUtilityModelRef({ cfg: deps.getConfig(), agentId }),
+    suspend: suspendState,
+    demote: demoteUtilityModel,
+  });
 
-  function modelStateIsCurrent(state: SessionObserverState): boolean {
-    return (
-      stateIsCurrent(state) &&
-      Boolean(state.utilityModelRef) &&
-      resolveUtilityModelRef({ cfg: deps.getConfig(), agentId: state.agentId }) ===
-        state.utilityModelRef
-    );
-  }
+  const { modelStateIsCurrent } = audienceLifecycle;
 
   const requestModelDigest = createSessionObserverCompletion({
     getConfig: deps.getConfig,
@@ -282,13 +272,15 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
   const schedule = (
     state: SessionObserverState,
     run: (state: SessionObserverState, final: boolean) => void,
+    observedAudience?: ObservedAudience,
   ) => {
-    if (!stateIsCurrent(state)) {
+    const currentAudience = observedAudience ?? audience.classify(state.sessionKey, state.agentId);
+    if (!audienceLifecycle.stateIsCurrent(state, currentAudience)) {
       retireInactiveState(state);
       return;
     }
     if (
-      !modelStateIsCurrent(state) ||
+      !modelStateIsCurrent(state, currentAudience) ||
       state.inFlight ||
       state.timer ||
       state.terminalHealth ||
@@ -309,11 +301,12 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
   };
 
   const runDigest = (state: SessionObserverState, final: boolean) => {
-    if (!stateIsCurrent(state)) {
+    const currentAudience = audience.classify(state.sessionKey, state.agentId);
+    if (!audienceLifecycle.stateIsCurrent(state, currentAudience)) {
       retireInactiveState(state);
       return;
     }
-    if (!modelStateIsCurrent(state)) {
+    if (!modelStateIsCurrent(state, currentAudience)) {
       if (final) {
         retireTerminalState(state);
       }
@@ -455,9 +448,10 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     event: SessionObserverEvent,
     allowPreambleOnly: boolean,
     sessionKey: string,
-    agentId: string | undefined,
+    agentId: string,
+    observedAudience: ObservedAudience,
   ): SessionObserverState | undefined => {
-    if (!agentId || !audience.has(sessionKey, agentId)) {
+    if (observedAudience === "none") {
       return undefined;
     }
     const scopeKey = resolveSessionSubscriptionKey(sessionKey, agentId);
@@ -465,7 +459,10 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     if (cfg.gateway?.controlUi?.sessionObserver === false) {
       return undefined;
     }
-    const utilityModelRef = disabledRuns.has(event.runId) ? undefined : modelSlots.claim(agentId);
+    const utilityModelRef =
+      disabledRuns.has(event.runId) || observedAudience !== "direct"
+        ? undefined
+        : modelSlots.claim(agentId);
     if (!utilityModelRef && !allowPreambleOnly) {
       return undefined;
     }
@@ -586,6 +583,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       }
       return;
     }
+    const currentAudience = audience.classify(sessionKey, agentId);
     const scopeKey = resolveSessionSubscriptionKey(sessionKey, agentId);
     if (terminal && audience.recipients(sessionKey, agentId).size === 0) {
       void synthesizeTerminalDigest({ event, state: states.get(scopeKey) });
@@ -643,14 +641,13 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     }
     if (
       state &&
-      (!audience.has(sessionKey, agentId) ||
-        deps.getConfig().gateway?.controlUi?.sessionObserver === false)
+      (currentAudience === "none" || deps.getConfig().gateway?.controlUi?.sessionObserver === false)
     ) {
       suspendState(state);
       state = undefined;
     }
     if (!state) {
-      state = admitState(event, isPreamble, sessionKey, agentId);
+      state = admitState(event, isPreamble, sessionKey, agentId, currentAudience);
     }
     if (!state) {
       if (terminal) {
@@ -668,9 +665,10 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       state.previousDigest = revisionFloor.previousDigest;
     }
     revisionFloors.delete(scopeKey);
-    const utilityModelRef = disabledRuns.has(state.runId)
-      ? undefined
-      : modelSlots.claim(state.agentId, state);
+    const utilityModelRef =
+      disabledRuns.has(state.runId) || currentAudience !== "direct"
+        ? undefined
+        : modelSlots.claim(state.agentId, state);
     if (state.utilityModelRef !== utilityModelRef) {
       modelSlots.invalidateRequest(state);
       state.preparedPromise = undefined;
@@ -704,7 +702,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       runDigest(state, true);
       return;
     }
-    schedule(state, runDigest);
+    schedule(state, runDigest, currentAudience);
   };
 
   return {
@@ -715,11 +713,11 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         return;
       }
       visibleConnections.delete(connId);
-      suspendStatesWithoutAudience();
+      audienceLifecycle.reconcileAll();
     },
     removeConnection(connId) {
       if (visibleConnections.delete(connId)) {
-        suspendStatesWithoutAudience();
+        audienceLifecycle.reconcileAll();
       }
     },
     getCompanionSnapshot,
@@ -727,7 +725,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       disposed = true;
       pendingTerminalErrors.forEach((_timer, runId) => clearPendingTerminalError(runId));
       preamblePublisher.dispose();
-      unsubscribeChanges();
+      audienceLifecycle.unsubscribe();
       for (const state of states.values()) {
         dropState(state);
       }

--- a/src/gateway/talk-transcription-relay.test.ts
+++ b/src/gateway/talk-transcription-relay.test.ts
@@ -560,12 +560,22 @@ describe("talk transcription gateway relay", () => {
   });
 
   it("closes a backpressured owner for final transcripts while healthy owners still receive them", async () => {
-    const createSocket = () => ({
-      readyState: WebSocket.OPEN,
-      bufferedAmount: 0,
-      send: vi.fn<(payload: string) => void>(),
-      close: vi.fn<(code: number, reason: string) => void>(),
-    });
+    const createSocket = () => {
+      const socket = {
+        readyState: WebSocket.OPEN as number,
+        bufferedAmount: 0,
+        send: vi.fn<(payload: string) => void>(),
+        close: vi.fn<(code: number, reason: string) => void>(),
+        terminate: vi.fn<() => void>(),
+      };
+      socket.close.mockImplementation(() => {
+        socket.readyState = WebSocket.CLOSING;
+      });
+      socket.terminate.mockImplementation(() => {
+        socket.readyState = WebSocket.CLOSING;
+      });
+      return socket;
+    };
     const slowSocket = createSocket();
     const healthySocket = createSocket();
     const createClient = (
@@ -614,11 +624,13 @@ describe("talk transcription gateway relay", () => {
 
       expect(slowSocket.send).toHaveBeenCalledTimes(slowFramesBeforePartial);
       expect(slowSocket.close).not.toHaveBeenCalled();
+      expect(slowSocket.terminate).not.toHaveBeenCalled();
 
       slowRequest.onTranscript?.("slow final");
       healthyRequest.onTranscript?.("healthy final");
 
       expect(slowSocket.close).toHaveBeenCalledWith(1008, "slow consumer");
+      expect(slowSocket.terminate).toHaveBeenCalledOnce();
       const healthyFrames = healthySocket.send.mock.calls.map(
         ([frame]) => JSON.parse(frame) as { event: string; payload: unknown },
       );

--- a/test/scripts/bench-gateway-concurrency.test.ts
+++ b/test/scripts/bench-gateway-concurrency.test.ts
@@ -24,11 +24,27 @@ describe("gateway concurrency benchmark script", () => {
         "/tmp/gateway-cpu-profiles",
         "--plugin-count",
         "50",
+        "--session-count",
+        "120",
+        "--history-clients",
+        "6",
+        "--history-burst",
+        "5",
+        "--session-updates",
+        "500",
+        "--session-update-clients",
+        "8",
+        "--subscribers",
+        "4",
+        "--stream-chunk-delay-ms",
+        "2000",
         "--max-control-ms",
         "2000",
         "--max-handshake-ms",
         "2000",
         "--tool-events",
+        "--no-diagnostics-timeline",
+        "--visible-observer",
         "--workspace-fanout",
         "--output",
         "concurrency.json",
@@ -38,14 +54,23 @@ describe("gateway concurrency benchmark script", () => {
       cadenceMs: 50,
       concurrency: 12,
       cpuProfDir: "/tmp/gateway-cpu-profiles",
+      diagnosticsTimeline: false,
       json: true,
+      historyBurst: 5,
+      historyClients: 6,
       maxControlMs: 2_000,
       maxHandshakeMs: 2_000,
       output: "concurrency.json",
       pluginCount: 50,
       runs: 2,
+      sessionCount: 120,
+      sessionUpdateClients: 8,
+      sessionUpdates: 500,
+      streamChunkDelayMs: 2_000,
+      subscribers: 4,
       timeoutMs: 90_000,
       toolEvents: true,
+      visibleObserver: true,
       warmup: 0,
       workspaceFanout: true,
     });
@@ -59,6 +84,17 @@ describe("gateway concurrency benchmark script", () => {
     expect(() => testing.parseOptions(["--plugin-count", "101"])).toThrow(
       "--plugin-count must be at most 100",
     );
+    expect(testing.parseOptions(["--session-count", "10000"]).sessionCount).toBe(10_000);
+    expect(() => testing.parseOptions(["--session-count", "10001"])).toThrow(
+      "--session-count must be at most 10000",
+    );
+    expect(() => testing.parseOptions(["--history-burst", "33"])).toThrow(
+      "--history-burst must be at most 32",
+    );
+    expect(() => testing.parseOptions(["--session-updates", "100001"])).toThrow(
+      "--session-updates must be at most 100000",
+    );
+    expect(testing.parseOptions([]).diagnosticsTimeline).toBe(true);
   });
 
   it("summarizes plugin metadata scans captured after startup warmup", () => {
@@ -80,6 +116,15 @@ describe("gateway concurrency benchmark script", () => {
       controlUi: [],
       durationMs: 10,
       freshConnection: { error: null, latencyMs: 25, ok: true },
+      history: [],
+      memory: {
+        after: { atMs: 10, heapTotalMb: 120, heapUsedMb: 80, rssMb: 200 },
+        before: { atMs: 0, heapTotalMb: 100, heapUsedMb: 60, rssMb: 180 },
+        peakRssMb: 210,
+      },
+      messageSubscriptions: [],
+      messageSubscriptionsDuringLoad: [],
+      modelRequestCount: 1,
       probeWarmup: { durationMs: 2, samples: [] },
       pluginMetadataScans: {
         count,
@@ -87,12 +132,19 @@ describe("gateway concurrency benchmark script", () => {
         totalDurationMs: durations.reduce((sum, value) => sum + value, 0),
       },
       readyz: [],
+      sessionSeedDurationMs: 2,
       sessionsList: [],
+      sessionUpdates: [],
+      setupDurationMs: 3,
       turnCount: 1,
       turnsDurationMs: 5,
     });
 
     expect(testing.summarizeRuns([createRun(2, [10, 20]), createRun(1, [30])])).toMatchObject({
+      gatewayHeapGrowthMb: { count: 2, max: 20, p50: 20, p95: 20, p99: 20 },
+      gatewayPeakRssMb: { count: 2, max: 210, p50: 210, p95: 210, p99: 210 },
+      gatewayRssGrowthMb: { count: 2, max: 20, p50: 20, p95: 20, p99: 20 },
+      modelRequestCount: 2,
       pluginMetadataScanCount: 3,
       pluginMetadataScanTotalDurationMs: 60,
     });
@@ -138,10 +190,22 @@ describe("gateway concurrency benchmark script", () => {
       controlUi: [],
       durationMs: 10,
       freshConnection: { error: null, latencyMs: 25, ok: true },
+      history: [],
+      memory: {
+        after: { atMs: 10, heapTotalMb: 120, heapUsedMb: 80, rssMb: 200 },
+        before: { atMs: 0, heapTotalMb: 100, heapUsedMb: 60, rssMb: 180 },
+        peakRssMb: 210,
+      },
+      messageSubscriptions: [],
+      messageSubscriptionsDuringLoad: [],
+      modelRequestCount: 1,
       pluginMetadataScans: { count: 0, durationMs: null, totalDurationMs: 0 },
       probeWarmup: { durationMs: 2, samples: [] },
       readyz: [],
+      sessionSeedDurationMs: 2,
       sessionsList: [],
+      sessionUpdates: [],
+      setupDurationMs: 3,
       turnCount: 8,
       turnsDurationMs: 5,
     };

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -447,6 +447,24 @@ describe("scripts/lib/docker-e2e-plan", () => {
     expect(plan.lanes.map((lane) => lane.name)).not.toContain("live-mcp-code-mode-gateway");
   });
 
+  it("selects isolated packaged Gateway concurrency proof without widening release-core coverage", () => {
+    const targeted = planFor({ selectedLaneNames: ["gateway-concurrency"] });
+    const core = planFor({ profile: RELEASE_PATH_PROFILE, releaseChunk: "core" });
+
+    expect(targeted.lanes.map(summarizeLane)).toEqual([
+      {
+        command: "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:gateway-concurrency",
+        imageKind: "functional",
+        live: false,
+        name: "gateway-concurrency",
+        resources: ["docker", "service"],
+        timeoutMs: 600_000,
+        weight: 3,
+      },
+    ]);
+    expect(core.lanes.map((lane) => lane.name)).not.toContain("gateway-concurrency");
+  });
+
   it("plans Open WebUI only when release-path coverage requests it", () => {
     const withoutOpenWebUI = planFor({
       includeOpenWebUI: false,

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -453,7 +453,7 @@ describe("scripts/lib/docker-e2e-plan", () => {
 
     expect(targeted.lanes.map(summarizeLane)).toEqual([
       {
-        command: "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:gateway-concurrency",
+        command: "OPENCLAW_SKIP_DOCKER_BUILD=1 bash scripts/e2e/gateway-concurrency-docker.sh",
         imageKind: "functional",
         live: false,
         name: "gateway-concurrency",

--- a/ui/src/pages/chat/session-prefetch.test.ts
+++ b/ui/src/pages/chat/session-prefetch.test.ts
@@ -280,6 +280,72 @@ describe("recent session prefetch", () => {
     expect(open).not.toHaveBeenCalled();
   });
 
+  it("keeps repeated roster refreshes within the bounded recent-session snapshot window", async () => {
+    const request = vi.fn(async (_method: string, params: unknown) =>
+      historyResult((params as { sessionKey: string }).sessionKey),
+    );
+    const client = { request } as unknown as GatewayBrowserClient;
+    const rows = Array.from({ length: 25 }, (_, index) =>
+      row(`agent:main:recent-${index}`, NOW - index - 1),
+    );
+
+    for (let listRevision = 1; listRevision <= 5; listRevision += 1) {
+      updatePrefetch({ client, listRevision, openSessionKeys: [], rows });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await settlePromises();
+      await store.flush();
+    }
+
+    expect(request.mock.calls.map(sessionKeyFromCall)).toEqual(
+      rows.slice(0, 20).map(({ key }) => key),
+    );
+    expect(store.readSavedAt("agent:main:recent-0")).not.toBeNull();
+    expect(store.readSavedAt("agent:main:recent-19")).not.toBeNull();
+
+    updatePrefetch({ client, listRevision: 6, openSessionKeys: [], rows });
+    await vi.advanceTimersByTimeAsync(31_000);
+    await settlePromises();
+    await store.flush();
+
+    expect(request).toHaveBeenCalledTimes(20);
+    expect(store.readSavedAt("agent:main:recent-0")).not.toBeNull();
+  });
+
+  it("reserves snapshot capacity for presented panes while warming recent background sessions", async () => {
+    const presentedSessionKey = "agent:main:presented";
+    cacheChatSessionSnapshot(
+      cache,
+      snapshotHost,
+      { sessionKey: presentedSessionKey },
+      historySnapshot("presented"),
+    );
+    await store.flush();
+
+    const request = vi.fn(async (_method: string, params: unknown) =>
+      historyResult((params as { sessionKey: string }).sessionKey),
+    );
+    const client = { request } as unknown as GatewayBrowserClient;
+    const backgroundRows = Array.from({ length: 25 }, (_, index) =>
+      row(`agent:main:background-${index}`, NOW - index - 1),
+    );
+    const rows = [row(presentedSessionKey, NOW), ...backgroundRows];
+
+    for (let listRevision = 1; listRevision <= 5; listRevision += 1) {
+      updatePrefetch({ client, listRevision, openSessionKeys: [presentedSessionKey], rows });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await settlePromises();
+      await store.flush();
+    }
+
+    expect(request.mock.calls.map(sessionKeyFromCall)).toEqual(
+      backgroundRows.slice(0, 19).map(({ key }) => key),
+    );
+    expect(
+      readChatSessionSnapshot(cache, snapshotHost, { sessionKey: presentedSessionKey }),
+    ).toEqual(historySnapshot("presented"));
+    expect(store.readSavedAt(presentedSessionKey)).not.toBeNull();
+  });
+
   it("coalesces a newer list revision until the per-session cooldown expires", async () => {
     const request = vi.fn(async (_method: string, params: unknown) =>
       historyResult((params as { sessionKey: string }).sessionKey),

--- a/ui/src/pages/chat/session-prefetch.test.ts
+++ b/ui/src/pages/chat/session-prefetch.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { MAX_CACHED_CHAT_SESSIONS } from "./session-cache.ts";
 import {
   appendChatMessageToCache,
   cacheChatSessionSnapshot,
@@ -319,6 +320,14 @@ describe("recent session prefetch", () => {
       { sessionKey: presentedSessionKey },
       historySnapshot("presented"),
     );
+    for (let index = 1; index < MAX_CACHED_CHAT_SESSIONS; index += 1) {
+      cacheChatSessionSnapshot(
+        cache,
+        snapshotHost,
+        { sessionKey: `agent:main:stale-${index}` },
+        historySnapshot(`stale-${index}`),
+      );
+    }
     await store.flush();
 
     const request = vi.fn(async (_method: string, params: unknown) =>

--- a/ui/src/pages/chat/session-prefetch.ts
+++ b/ui/src/pages/chat/session-prefetch.ts
@@ -181,6 +181,17 @@ class SessionPrefetcher {
     if (!this.isCurrent(snapshot)) {
       return;
     }
+    // Refresh presented snapshots through their LRU owner before background writes
+    // so a full cache evicts stale entries instead of visible conversation panes.
+    for (const sessionKey of snapshot.openSessionKeys) {
+      const presented = readChatSessionSnapshot(this.cache, snapshot.snapshotHost, { sessionKey });
+      if (presented && this.cache.size === MAX_CACHED_CHAT_SESSIONS) {
+        this.snapshotStore.write(
+          resolveChatSnapshotKey(snapshot.snapshotHost, { sessionKey }),
+          presented,
+        );
+      }
+    }
     const selection = this.selectCandidates(snapshot);
     if (selection.deferMs !== null) {
       this.schedule(selection.deferMs);

--- a/ui/src/pages/chat/session-prefetch.ts
+++ b/ui/src/pages/chat/session-prefetch.ts
@@ -5,6 +5,7 @@ import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import { requestChatSessionSnapshot } from "./chat-history.ts";
+import { MAX_CACHED_CHAT_SESSIONS } from "./session-cache.ts";
 import {
   appendChatMessageToCache,
   cacheChatSessionSnapshot,
@@ -300,6 +301,7 @@ class SessionPrefetcher {
         resolveChatSnapshotKey(snapshot.snapshotHost, { sessionKey }),
       ),
     );
+    const maxPrefetchedSessions = Math.max(0, MAX_CACHED_CHAT_SESSIONS - openKeys.size);
     const rows = (snapshot.rows ?? []).toSorted(
       (left, right) => sessionActivityAt(right) - sessionActivityAt(left),
     );
@@ -320,6 +322,10 @@ class SessionPrefetcher {
         continue;
       }
       seen.add(snapshotKey);
+      // Warming older rows must never evict hotter or presented snapshots.
+      if (seen.size > maxPrefetchedSessions) {
+        break;
+      }
       const activityAt = sessionActivityAt(row);
       const savedAt = this.snapshotStore.readSavedAt(snapshotKey);
       if (savedAt !== null && savedAt >= activityAt) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening or switching conversations on a busy Gateway could wait tens of seconds for transcript text, encounter session-message subscription timeouts, or see Gateway memory grow rapidly while other sessions were active.

## Why This Change Was Made

Keep expensive work with its lifecycle owner: scheduled maintenance alone performs managed-media garbage collection; tracked session writes update their existing synchronous borrowed cache instead of cloning every session index; the observer classifies each event audience once and reserves utility-model work for directly watched sessions; unrelated subscriptions no longer inherit another session's request deadline; chat prefetch stays within its actual snapshot-cache capacity; and saturated WebSocket transports release their buffered data immediately after preserving the existing close reason.

While validating the latest main-branch merge, independently reproduce a shared channel-ingress abandonment retry regression across Teams, Signal, and WhatsApp. That owner-boundary repair subsequently landed separately in #130077, so this PR is rebased onto it and contains no duplicate channel-ingress changes.

Extend the existing Gateway concurrency benchmark with bounded session populations, public session-update bursts, concurrent transcript and subscription pressure, process-memory and event-loop measurements, optional diagnostics-free measurement, and a package-backed Docker E2E lane.

## User Impact

Busy shared Gateways remain more responsive while loading conversations, recover unrelated subscriptions immediately, waste less background model work, and retain less memory under concurrent sessions and slow clients.

## Evidence

- 431 focused Gateway, WebSocket, observer, subscription, session-cache, Control UI, benchmark, and Docker-planner tests pass across six Vitest shards; new regression cases were observed failing against the original source first.
- The new packaged `gateway-concurrency` Docker lane passes against the built candidate with 165 transcript requests, 13 live subscription probes, 32 public session updates, eight concurrent turns, and zero failures.
- Alternating baseline/candidate Docker runs on the same original commit, frozen benchmark, four CPUs, and 4 GiB with 256 sessions and 128 concurrent public session updates: mean transcript p95 improved 23.5%, subscription p95 improved 23.7%, event-loop p95 improved 18.8%, and peak RSS dropped 42.7 MiB.
- The heavier 1,000-session/256-update Docker run reduced peak RSS by 46.5 MiB, RSS growth by 60.1 MiB (12.8%), event-loop p95 by 33.2%, transcript p99 by 9.2%, and total runtime by 6.6%. Individual update p95 varied across runs; median and p99 improved in the heavier run.
- Direct observer-boundary probes reduced subscriber lookups by 66.7%, broad-only event processing by approximately 24x, and subscription-churn processing by approximately 40x; directly watched sessions retain their utility-model behavior.
- Real paused WebSocket peers previously retained approximately 54 MiB each behind a 30-second graceful-close timer; saturated transports now terminate immediately while droppable events retain their existing drop-only behavior.
- Structured independent review completed with no actionable findings.
- The complete repository changed-check gate passes, including full-tree lint, core/UI/plugin/scripts typechecks, dead-code checks, storage guards, and runtime import-cycle checks. A small existing session-test fixture cleanup also keeps the latest main-branch merge under its enforced file-size limit without changing test behavior.
- A full-cache regression now proves the oldest currently presented conversation survives background warming in both the in-memory LRU and persisted snapshot store; focused shared-ingress and Telegram regressions also pass on the rebased main baseline that already includes #130077.
