### PR TITLE
fix(compaction): share model-aware memory maintenance budgets

### DIFF
--- a/extensions/memory-core/src/flush-plan.test.ts
+++ b/extensions/memory-core/src/flush-plan.test.ts
@@ -16,4 +16,21 @@ describe("buildMemoryFlushPlan", () => {
 
     expect(plan?.relativePath).toBe("memory/2026-05-30.md");
   });
+
+  it.each([
+    [8_000, 4_000, 2_000],
+    [16_000, 8_000, 4_000],
+    [24_000, 16_000, 4_000],
+    [32_000, 20_000, 4_000],
+    [128_000, 20_000, 4_000],
+    [200_000, 20_000, 4_000],
+  ])(
+    "sizes its reserve and maintenance headroom to a %i-token context window",
+    (contextWindowTokens, reserveTokensFloor, softThresholdTokens) => {
+      expect(buildMemoryFlushPlan({ contextWindowTokens })).toMatchObject({
+        reserveTokensFloor,
+        softThresholdTokens,
+      });
+    },
+  );
 });

--- a/extensions/memory-core/src/flush-plan.ts
+++ b/extensions/memory-core/src/flush-plan.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR,
   parseNonNegativeByteSize,
   resolveCronStyleNow,
+  resolveEffectiveCompactionReserveTokens,
   SILENT_REPLY_TOKEN,
   type MemoryFlushPlan,
   type OpenClawConfig,
@@ -98,6 +99,7 @@ export function buildMemoryFlushPlan(
   params: {
     cfg?: OpenClawConfig;
     nowMs?: number;
+    contextWindowTokens?: number;
   } = {},
 ): MemoryFlushPlan | null {
   const resolved = params;
@@ -108,12 +110,23 @@ export function buildMemoryFlushPlan(
     return null;
   }
 
-  const softThresholdTokens =
+  let softThresholdTokens =
     normalizeNonNegativeInt(defaults?.softThresholdTokens) ?? DEFAULT_MEMORY_FLUSH_SOFT_TOKENS;
   const forceFlushTranscriptBytes =
     parseNonNegativeByteSize(defaults?.forceFlushTranscriptBytes) ??
     DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES;
-  const reserveTokensFloor = DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR;
+  let reserveTokensFloor = DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR;
+  const contextWindowTokens = normalizeNonNegativeInt(params.contextWindowTokens);
+  if (contextWindowTokens !== null && contextWindowTokens > 0) {
+    reserveTokensFloor = resolveEffectiveCompactionReserveTokens({
+      contextTokenBudget: contextWindowTokens,
+      reserveTokens: reserveTokensFloor,
+    });
+    softThresholdTokens = Math.min(
+      softThresholdTokens,
+      Math.floor((contextWindowTokens - reserveTokensFloor) / 2),
+    );
+  }
 
   const { timeLine, userTimezone } = resolveCronStyleNow(cfg ?? {}, nowMs);
   const dateStamp = formatDateStampInTimezone(nowMs, userTimezone);

--- a/src/agents/agent-compaction-constants.ts
+++ b/src/agents/agent-compaction-constants.ts
@@ -3,13 +3,13 @@
  * large enough that `contextTokenBudget * MIN_PROMPT_BUDGET_RATIO` exceeds
  * this value, this absolute floor takes precedence.
  */
-export const MIN_PROMPT_BUDGET_TOKENS = 8_000;
+const MIN_PROMPT_BUDGET_TOKENS = 8_000;
 
 /**
  * Minimum share of the context window that must remain available for prompt
  * content after reserve tokens are subtracted.
  */
-export const MIN_PROMPT_BUDGET_RATIO = 0.5;
+const MIN_PROMPT_BUDGET_RATIO = 0.5;
 
 /** Caps compaction headroom so every model retains its minimum usable prompt budget. */
 export function resolveEffectiveCompactionReserveTokens(params: {

--- a/src/agents/agent-compaction-constants.ts
+++ b/src/agents/agent-compaction-constants.ts
@@ -11,4 +11,20 @@ export const MIN_PROMPT_BUDGET_TOKENS = 8_000;
  */
 export const MIN_PROMPT_BUDGET_RATIO = 0.5;
 
+/** Caps compaction headroom so every model retains its minimum usable prompt budget. */
+export function resolveEffectiveCompactionReserveTokens(params: {
+  contextTokenBudget: number;
+  reserveTokens: number;
+}): number {
+  const contextTokenBudget = Math.max(1, Math.floor(params.contextTokenBudget));
+  const minPromptBudget = Math.min(
+    MIN_PROMPT_BUDGET_TOKENS,
+    Math.max(1, Math.floor(contextTokenBudget * MIN_PROMPT_BUDGET_RATIO)),
+  );
+  return Math.min(
+    Math.max(0, Math.floor(params.reserveTokens)),
+    Math.max(0, contextTokenBudget - minPromptBudget),
+  );
+}
+
 export const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;

--- a/src/agents/agent-settings.test.ts
+++ b/src/agents/agent-settings.test.ts
@@ -224,6 +224,21 @@ describe("applyAgentCompactionSettingsFromConfig", () => {
     expect(shouldCompact(1, 16_384, { enabled: true, ...result.compaction })).toBe(false);
   });
 
+  it.each([
+    [8_000, 4_000],
+    [16_000, 8_000],
+    [24_000, 16_000],
+    [32_000, 20_000],
+    [128_000, 20_000],
+    [200_000, 20_000],
+  ])("keeps model window %i on its effective %i-token reserve", (contextTokenBudget, reserve) => {
+    const settingsManager = SettingsManager.inMemory();
+    const result = applyAgentCompactionSettingsFromConfig({ settingsManager, contextTokenBudget });
+
+    expect(result.compaction.reserveTokens).toBe(reserve);
+    expect(settingsManager.getCompactionReserveTokens()).toBe(reserve);
+  });
+
   it("applies capped floor when current reserve is below it on small-context models", () => {
     // Simulate an embedded runner default of 4 096 with a 16 384 context window.
     // minPromptBudget = min(8_000, floor(16_384 * 0.5)) = 8_000.

--- a/src/agents/agent-settings.ts
+++ b/src/agents/agent-settings.ts
@@ -3,7 +3,7 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { AgentCompactionMode } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ContextEngineInfo } from "../context-engine/types.js";
-import { MIN_PROMPT_BUDGET_RATIO, MIN_PROMPT_BUDGET_TOKENS } from "./agent-compaction-constants.js";
+import { resolveEffectiveCompactionReserveTokens } from "./agent-compaction-constants.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 
 export const DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR = 20_000;
@@ -46,30 +46,19 @@ export function applyAgentCompactionSettingsFromConfig(params: {
   const configuredEnabled = compactionCfg?.enabled;
 
   const configuredKeepRecentTokens = toPositiveInt(compactionCfg?.keepRecentTokens);
-  let reserveTokensFloor = DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR;
-  let maxReserveTokens: number | undefined;
-
-  // Cap the floor to a safe fraction of the context window so that
-  // small-context models (e.g. Ollama with 16 K tokens) are not starved of
-  // prompt budget.  Without this cap the default floor of 20 000 can exceed
-  // the entire context window, causing every prompt to be classified as an
-  // overflow and triggering an infinite compaction loop.
   const contextTokenBudget = toPositiveInt(params.contextTokenBudget);
-  if (contextTokenBudget !== undefined) {
-    const minPromptBudget = Math.min(
-      MIN_PROMPT_BUDGET_TOKENS,
-      Math.max(1, Math.floor(contextTokenBudget * MIN_PROMPT_BUDGET_RATIO)),
-    );
-    maxReserveTokens = Math.max(0, contextTokenBudget - minPromptBudget);
-    reserveTokensFloor = Math.min(reserveTokensFloor, maxReserveTokens);
-  }
-
-  let targetReserveTokens = Math.max(currentReserveTokens, reserveTokensFloor);
-  if (maxReserveTokens !== undefined) {
-    // Cap the effective value too: the harness default or explicit config can otherwise
-    // undo the floor cap and make shouldCompact() true from the first token.
-    targetReserveTokens = Math.min(targetReserveTokens, maxReserveTokens);
-  }
+  const requestedReserveTokens = Math.max(
+    currentReserveTokens,
+    DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR,
+  );
+  // Cap the final effective reserve, not only its floor; otherwise small models compact at token one.
+  const targetReserveTokens =
+    contextTokenBudget === undefined
+      ? requestedReserveTokens
+      : resolveEffectiveCompactionReserveTokens({
+          contextTokenBudget,
+          reserveTokens: requestedReserveTokens,
+        });
   const targetKeepRecentTokens = configuredKeepRecentTokens ?? currentKeepRecentTokens;
 
   const overrides: { reserveTokens?: number; keepRecentTokens?: number } = {};

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -4,10 +4,7 @@
 import { estimateStringChars } from "@openclaw/normalization-core/cjk-chars";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { SessionContextBudgetStatus } from "../../../config/sessions.js";
-import {
-  MIN_PROMPT_BUDGET_RATIO,
-  MIN_PROMPT_BUDGET_TOKENS,
-} from "../../agent-compaction-constants.js";
+import { resolveEffectiveCompactionReserveTokens } from "../../agent-compaction-constants.js";
 import { SAFETY_MARGIN } from "../../compaction.js";
 import type { AgentMessage, BashExecutionMessage } from "../../runtime/index.js";
 import {
@@ -368,16 +365,10 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
     }
   }
   const contextTokenBudget = Math.max(1, Math.floor(params.contextTokenBudget));
-  const requestedReserveTokens = Math.max(0, Math.floor(params.reserveTokens));
-  const minPromptBudget = Math.min(
-    MIN_PROMPT_BUDGET_TOKENS,
-    Math.max(1, Math.floor(contextTokenBudget * MIN_PROMPT_BUDGET_RATIO)),
-  );
-  // Keep a minimum prompt budget even when reserveTokens asks for most of the context window.
-  const effectiveReserveTokens = Math.min(
-    requestedReserveTokens,
-    Math.max(0, contextTokenBudget - minPromptBudget),
-  );
+  const effectiveReserveTokens = resolveEffectiveCompactionReserveTokens({
+    contextTokenBudget,
+    reserveTokens: params.reserveTokens,
+  });
   const promptBudgetBeforeReserve = Math.max(1, contextTokenBudget - effectiveReserveTokens);
   const overflowTokens = Math.max(0, estimatedPromptTokens - promptBudgetBeforeReserve);
   const toolResultPotential = estimateToolResultReductionPotential({

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -522,6 +522,21 @@ describe("runMemoryFlushIfNeeded", () => {
     await fs.rm(rootDir, { recursive: true, force: true });
   });
 
+  it("preserves an external memory provider's disabled maintenance thresholds", async () => {
+    const resolver = vi.fn<MemoryFlushPlanResolver>(() =>
+      createModifiedMemoryFlushPlan({ reserveTokensFloor: 50_000 }),
+    );
+    registerMemoryCapability("third-party-memory", { flushPlanResolver: resolver });
+    const sessionEntry = createFlushSessionEntry({ totalTokens: 8_000 });
+
+    const result = await runDefaultMemoryFlush(sessionEntry, { modelContextTokens: 32_000 });
+    await runDefaultPreflight(sessionEntry, { modelContextTokens: 32_000 });
+
+    expect(result.outcome).toBe("skipped");
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+    expect(resolver).toHaveBeenCalledWith(expect.objectContaining({ contextWindowTokens: 32_000 }));
+  });
+
   it("runs exactly one auto-reply memory flush turn, rotates, and persists metadata", async () => {
     const followupRun = createTestFollowupRun({
       authProfileId: "anthropic:work",

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -8,6 +8,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { prepareSystemAgentRunAdmission } from "../../agents/admitted-run-context.js";
+import { resolveEffectiveCompactionReserveTokens } from "../../agents/agent-compaction-constants.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { resolveCliBackendConfig } from "../../agents/cli-backends.js";
@@ -783,9 +784,16 @@ export async function runPreflightCompactionIfNeeded(params: {
     }),
     modelId: params.followupRun.run.model ?? params.defaultModel,
   });
-  const memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
-  const reserveTokensFloor = memoryFlushPlan?.reserveTokensFloor ?? 20_000;
-  const softThresholdTokens = memoryFlushPlan?.softThresholdTokens ?? 4_000;
+  const memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg, contextWindowTokens });
+  const reserveTokensFloor =
+    memoryFlushPlan?.reserveTokensFloor ??
+    resolveEffectiveCompactionReserveTokens({
+      contextTokenBudget: contextWindowTokens,
+      reserveTokens: 20_000,
+    });
+  const softThresholdTokens =
+    memoryFlushPlan?.softThresholdTokens ??
+    Math.min(4_000, Math.floor((contextWindowTokens - reserveTokensFloor) / 2));
   const freshPersistedTokens = resolveFreshSessionTotalTokens(entry);
   const promptTokenEstimate = estimatePromptTokensForMemoryFlush(
     params.promptForEstimate ?? params.followupRun.prompt,
@@ -1142,16 +1150,6 @@ export async function runMemoryFlushIfNeeded(params: {
   const activeSessionStore = params.sessionStore;
   const recordFailure = (error: unknown) =>
     recordMemoryFlushFailure(error, params, activeSessionEntry);
-  let memoryFlushPlan: MemoryFlushPlan | null;
-  try {
-    memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
-  } catch (error) {
-    return await recordFailure(error);
-  }
-  if (!memoryFlushPlan) {
-    return { sessionEntry: activeSessionEntry, outcome: "skipped" };
-  }
-
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
     cfg: params.cfg,
     provider: resolveFollowupContextConfigProvider({
@@ -1163,6 +1161,15 @@ export async function runMemoryFlushIfNeeded(params: {
     }),
     modelId: params.followupRun.run.model ?? params.defaultModel,
   });
+  let memoryFlushPlan: MemoryFlushPlan | null;
+  try {
+    memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg, contextWindowTokens });
+  } catch (error) {
+    return await recordFailure(error);
+  }
+  if (!memoryFlushPlan) {
+    return { sessionEntry: activeSessionEntry, outcome: "skipped" };
+  }
 
   const promptTokenEstimate = estimatePromptTokensForMemoryFlush(
     params.promptForEstimate ?? params.followupRun.prompt,
@@ -1336,7 +1343,11 @@ export async function runMemoryFlushIfNeeded(params: {
       (params.sessionKey ? activeSessionStore?.[params.sessionKey]?.systemPromptReport : undefined),
   );
   const prepareMemoryFlushAttempt = async () => {
-    const plan = resolveMemoryFlushPlan({ cfg: params.cfg, nowMs: memoryDeps.now() });
+    const plan = resolveMemoryFlushPlan({
+      cfg: params.cfg,
+      nowMs: memoryDeps.now(),
+      contextWindowTokens,
+    });
     if (!plan) {
       return null;
     }

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -71,6 +71,7 @@ import {
   hasAlreadyFlushedForCurrentCompaction,
   resolveMaxActiveTranscriptBytes,
   resolveMemoryFlushContextWindowTokens,
+  resolveMemoryFlushThreshold,
   resolveResponsesServerCompactionThreshold,
   shouldRunMemoryFlush,
   shouldRunPreflightCompaction,
@@ -794,10 +795,12 @@ export async function runPreflightCompactionIfNeeded(params: {
     provider: params.followupRun.run.provider,
     modelId: params.followupRun.run.model ?? params.defaultModel,
   });
-  const threshold = Math.max(
-    contextWindowTokens - reserveTokensFloor - softThresholdTokens,
-    responsesServerCompactionThreshold ?? 0,
-  );
+  const threshold = resolveMemoryFlushThreshold({
+    contextWindowTokens,
+    reserveTokensFloor,
+    softThresholdTokens,
+    minimumThresholdTokens: responsesServerCompactionThreshold,
+  });
   const freshNeedsOutputRead =
     typeof freshPersistedTokens === "number" &&
     typeof promptTokenEstimate === "number" &&
@@ -1173,8 +1176,11 @@ export async function runMemoryFlushIfNeeded(params: {
       : undefined;
   const hasFreshPersistedPromptTokens = resolveFreshSessionTotalTokens(entry) !== undefined;
 
-  const flushThreshold =
-    contextWindowTokens - memoryFlushPlan.reserveTokensFloor - memoryFlushPlan.softThresholdTokens;
+  const flushThreshold = resolveMemoryFlushThreshold({
+    contextWindowTokens,
+    reserveTokensFloor: memoryFlushPlan.reserveTokensFloor,
+    softThresholdTokens: memoryFlushPlan.softThresholdTokens,
+  });
 
   // When totals are stale/unknown, derive prompt + last output from transcript so memory
   // flush can still be evaluated against projected next-input size.

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,6 +1,7 @@
 // Builds memory flush prompts when conversation context exceeds model budget.
 import { resolveAnthropicServerCompactionPlan } from "@openclaw/ai/internal/anthropic";
 import { resolveOpenAIResponsesServerCompactionPlan } from "@openclaw/ai/internal/openai-responses-payload-policy";
+import { resolveEffectiveCompactionReserveTokens } from "../../agents/agent-compaction-constants.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelExtraParamSources } from "../../agents/model-extra-params.js";
@@ -40,6 +41,27 @@ function resolvePositiveTokenCount(value: number | undefined): number | undefine
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? Math.floor(value)
     : undefined;
+}
+
+/** Resolves one model-aware maintenance threshold for memory flush and preflight compaction. */
+export function resolveMemoryFlushThreshold(params: {
+  contextWindowTokens: number;
+  reserveTokensFloor: number;
+  softThresholdTokens: number;
+  minimumThresholdTokens?: number;
+}): number {
+  const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
+  const reserveTokens = resolveEffectiveCompactionReserveTokens({
+    contextTokenBudget: contextWindow,
+    reserveTokens: params.reserveTokensFloor,
+  });
+  const promptBudget = contextWindow - reserveTokens;
+  // Maintenance headroom must not consume the usable prompt budget on small-context models.
+  const softThreshold = Math.min(
+    Math.max(0, Math.floor(params.softThresholdTokens)),
+    Math.floor(promptBudget / 2),
+  );
+  return Math.max(promptBudget - softThreshold, Math.floor(params.minimumThresholdTokens ?? 0));
 }
 
 export function resolveResponsesServerCompactionThreshold(params: {
@@ -122,19 +144,7 @@ function resolveMemoryFlushGateState<
     return null;
   }
 
-  const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
-  const reserveTokens = Math.max(0, Math.floor(params.reserveTokensFloor));
-  const softThreshold = Math.max(0, Math.floor(params.softThresholdTokens));
-  const threshold = Math.max(
-    0,
-    contextWindow - reserveTokens - softThreshold,
-    Math.floor(params.minimumThresholdTokens ?? 0),
-  );
-  if (threshold <= 0) {
-    return null;
-  }
-
-  return { entry: params.entry, totalTokens, threshold };
+  return { entry: params.entry, totalTokens, threshold: resolveMemoryFlushThreshold(params) };
 }
 
 export function shouldRunMemoryFlush(params: {

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,7 +1,6 @@
 // Builds memory flush prompts when conversation context exceeds model budget.
 import { resolveAnthropicServerCompactionPlan } from "@openclaw/ai/internal/anthropic";
 import { resolveOpenAIResponsesServerCompactionPlan } from "@openclaw/ai/internal/openai-responses-payload-policy";
-import { resolveEffectiveCompactionReserveTokens } from "../../agents/agent-compaction-constants.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelExtraParamSources } from "../../agents/model-extra-params.js";
@@ -43,7 +42,7 @@ function resolvePositiveTokenCount(value: number | undefined): number | undefine
     : undefined;
 }
 
-/** Resolves one model-aware maintenance threshold for memory flush and preflight compaction. */
+/** Resolves the maintenance threshold owned by the selected memory provider. */
 export function resolveMemoryFlushThreshold(params: {
   contextWindowTokens: number;
   reserveTokensFloor: number;
@@ -51,17 +50,13 @@ export function resolveMemoryFlushThreshold(params: {
   minimumThresholdTokens?: number;
 }): number {
   const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
-  const reserveTokens = resolveEffectiveCompactionReserveTokens({
-    contextTokenBudget: contextWindow,
-    reserveTokens: params.reserveTokensFloor,
-  });
-  const promptBudget = contextWindow - reserveTokens;
-  // Maintenance headroom must not consume the usable prompt budget on small-context models.
-  const softThreshold = Math.min(
-    Math.max(0, Math.floor(params.softThresholdTokens)),
-    Math.floor(promptBudget / 2),
+  const reserveTokens = Math.max(0, Math.floor(params.reserveTokensFloor));
+  const softThreshold = Math.max(0, Math.floor(params.softThresholdTokens));
+  return Math.max(
+    0,
+    contextWindow - reserveTokens - softThreshold,
+    Math.floor(params.minimumThresholdTokens ?? 0),
   );
-  return Math.max(promptBudget - softThreshold, Math.floor(params.minimumThresholdTokens ?? 0));
 }
 
 export function resolveResponsesServerCompactionThreshold(params: {
@@ -144,7 +139,8 @@ function resolveMemoryFlushGateState<
     return null;
   }
 
-  return { entry: params.entry, totalTokens, threshold: resolveMemoryFlushThreshold(params) };
+  const threshold = resolveMemoryFlushThreshold(params);
+  return threshold > 0 ? { entry: params.entry, totalTokens, threshold } : null;
 }
 
 export function shouldRunMemoryFlush(params: {

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -289,20 +289,39 @@ describe("shouldRunMemoryFlush", () => {
     ).toBe(false);
   });
 
+  it("preserves thresholds supplied by external memory providers", () => {
+    expect(
+      resolveMemoryFlushThreshold({
+        contextWindowTokens: 100,
+        reserveTokensFloor: 10,
+        softThresholdTokens: 80,
+      }),
+    ).toBe(10);
+
+    const disabled = {
+      entry: { totalTokens: 8_000, totalTokensFresh: true, totalTokensVersion: 1 as const },
+      contextWindowTokens: 32_000,
+      reserveTokensFloor: 50_000,
+      softThresholdTokens: 4_000,
+    };
+    expect(shouldRunMemoryFlush(disabled)).toBe(false);
+    expect(shouldRunPreflightCompaction(disabled)).toBe(false);
+  });
+
   it.each([
-    [8_000, 2_000],
-    [16_000, 4_000],
-    [24_000, 4_000],
-    [32_000, 8_000],
-    [128_000, 104_000],
-    [200_000, 176_000],
+    [8_000, 4_000, 2_000, 2_000],
+    [16_000, 8_000, 4_000, 4_000],
+    [24_000, 16_000, 4_000, 4_000],
+    [32_000, 20_000, 4_000, 8_000],
+    [128_000, 20_000, 4_000, 104_000],
+    [200_000, 20_000, 4_000, 176_000],
   ])(
-    "preserves a usable %i-token model window with a %i-token maintenance threshold",
-    (contextWindowTokens, threshold) => {
+    "preserves a usable %i-token model window with provider-owned maintenance budgets",
+    (contextWindowTokens, reserveTokensFloor, softThresholdTokens, threshold) => {
       const params = {
         contextWindowTokens,
-        reserveTokensFloor: 20_000,
-        softThresholdTokens: 4_000,
+        reserveTokensFloor,
+        softThresholdTokens,
       };
 
       expect(resolveMemoryFlushThreshold(params)).toBe(threshold);

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -25,6 +25,7 @@ import {
 import {
   hasAlreadyFlushedForCurrentCompaction,
   resolveMemoryFlushContextWindowTokens,
+  resolveMemoryFlushThreshold,
   shouldRunMemoryFlush,
   shouldRunPreflightCompaction,
 } from "./memory-flush.js";
@@ -287,6 +288,44 @@ describe("shouldRunMemoryFlush", () => {
       }),
     ).toBe(false);
   });
+
+  it.each([
+    [8_000, 2_000],
+    [16_000, 4_000],
+    [24_000, 4_000],
+    [32_000, 8_000],
+    [128_000, 104_000],
+    [200_000, 176_000],
+  ])(
+    "preserves a usable %i-token model window with a %i-token maintenance threshold",
+    (contextWindowTokens, threshold) => {
+      const params = {
+        contextWindowTokens,
+        reserveTokensFloor: 20_000,
+        softThresholdTokens: 4_000,
+      };
+
+      expect(resolveMemoryFlushThreshold(params)).toBe(threshold);
+      expect(
+        shouldRunMemoryFlush({
+          ...params,
+          entry: { totalTokens: threshold, totalTokensFresh: true, totalTokensVersion: 1 },
+        }),
+      ).toBe(true);
+      expect(
+        shouldRunPreflightCompaction({
+          ...params,
+          entry: { totalTokens: threshold - 1, totalTokensFresh: true, totalTokensVersion: 1 },
+        }),
+      ).toBe(false);
+      expect(
+        shouldRunPreflightCompaction({
+          ...params,
+          entry: { totalTokens: threshold, totalTokensFresh: true, totalTokensVersion: 1 },
+        }),
+      ).toBe(true);
+    },
+  );
 
   it("skips when under threshold", () => {
     expect(

--- a/src/plugin-sdk/memory-core-host-runtime-core.ts
+++ b/src/plugin-sdk/memory-core-host-runtime-core.ts
@@ -1,6 +1,7 @@
 // Memory core host runtime exports bridge memory host runtime-core APIs into the SDK.
 export { SILENT_REPLY_TOKEN } from "../../packages/memory-host-sdk/src/runtime-core.js";
 export { resolveRememberAcrossConversations } from "../../packages/memory-host-sdk/src/host/config-utils.js";
+export { resolveEffectiveCompactionReserveTokens } from "../agents/agent-compaction-constants.js";
 export { DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR } from "../agents/agent-settings.js";
 export {
   asToolParamsRecord,

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -253,6 +253,7 @@ export function listMemoryPromptPreparations(): MemoryPromptPreparationRegistrat
 export function resolveMemoryFlushPlan(params: {
   cfg?: OpenClawConfig;
   nowMs?: number;
+  contextWindowTokens?: number;
 }): MemoryFlushPlan | null {
   return getMemoryCapability()?.capability.flushPlanResolver?.(params) ?? null;
 }

--- a/src/plugins/registry-contribution-types.ts
+++ b/src/plugins/registry-contribution-types.ts
@@ -242,6 +242,7 @@ export type MemoryFlushPlan = {
 export type MemoryFlushPlanResolver = (params: {
   cfg?: OpenClawConfig;
   nowMs?: number;
+  contextWindowTokens?: number;
 }) => MemoryFlushPlan | null;
 
 export type RegisteredMemorySearchManager = Omit<MemorySearchManager, "readFile"> & {


### PR DESCRIPTION
Related: #124911.

## What Problem This Solves

Fixes an issue where users of 8k, 16k, and 24k context-window models could silently miss memory flushing and preflight compaction because those paths subtracted a fixed 20k reserve even though the actual agent runner correctly capped that reserve for the selected model.

## Why This Change Was Made

Consolidate the effective compaction-reserve calculation at its architectural owner and reuse it in embedded agent settings, preemptive compaction, memory-flush gating, preflight compaction, and threshold diagnostics. Bound soft maintenance headroom against the remaining usable prompt budget while preserving established reserve behavior for large-context models. No retired compaction configuration is restored.

## User Impact

Small-context models preserve important history before overflow, compaction and memory flushing agree on the same thresholds, and existing large-model behavior remains unchanged.

## Evidence

- 228 focused compaction, embedded-agent, auto-reply, and reset-session corpus regression tests passed across four Vitest shards on the final head; the earlier combined reliability sweep passed 432 tests.
- Behavioral regression tables cover 8k, 16k, 24k, 32k, 128k, and 200k context windows for both memory maintenance gates.
- Existing embedded-agent, auto-reply, and preemptive-compaction sibling regressions remain green.
- Production code grows by only 12 lines while replacing duplicate reserve and threshold calculations.
- Independent structured review reported no accepted/actionable findings.
- Full-repository oxlint, all three Knip unused-export scans, and the 30,272-file formatting gate pass; the adjacent reset-archive fixture was consolidated to preserve its coverage below the existing file-length limit.
