### PR TITLE
fix(cron): report when tool caps suppress configured MCP tools

### DIFF
--- a/extensions/codex/src/app-server/attempt-terminal.ts
+++ b/extensions/codex/src/app-server/attempt-terminal.ts
@@ -13,3 +13,21 @@ export type AttemptFailureSource = Extract<
   { kind: "failed" }
 >["source"];
 export const attemptTerminal = agentHarnessAttemptTerminal;
+
+export function withMcpToolMaterialization(
+  error: unknown,
+  materialization: EmbeddedRunAttemptResult["mcpToolMaterialization"],
+): unknown {
+  if (!materialization) {
+    return error;
+  }
+  const carrier =
+    error && typeof error === "object" && Object.isExtensible(error)
+      ? error
+      : new Error(String(error), { cause: error });
+  Object.defineProperty(carrier, "mcpToolMaterialization", {
+    configurable: true,
+    value: materialization,
+  });
+  return carrier;
+}

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -1389,20 +1389,6 @@ describe("createCodexDynamicToolBridge", () => {
       source: "registered" as const,
       diagnosticTool: "a".repeat(129),
     },
-    {
-      label: "reserved mcp name",
-      name: "mcp",
-      placement: "direct" as const,
-      source: "both" as const,
-      diagnosticTool: "mcp",
-    },
-    {
-      label: "reserved mcp namespace prefix",
-      name: "mcp__read",
-      placement: "searchable" as const,
-      source: "both" as const,
-      diagnosticTool: "mcp__read",
-    },
   ])("quarantines Codex-invalid dynamic tool names: $label", async (testCase) => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const execute = vi.fn(async () => textToolResult("healthy sibling executed"));
@@ -1500,14 +1486,14 @@ describe("createCodexDynamicToolBridge", () => {
   it("reports an empty final surface when all dynamic tool names are invalid", () => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const bridge = createCodexDynamicToolBridge({
-      tools: [createTool({ name: "bad.name" }), createTool({ name: "mcp" })],
+      tools: [createTool({ name: "bad.name" })],
       signal: new AbortController().signal,
     });
 
     expect(bridge.availableTools).toEqual([]);
     expect(bridge.availableSpecs).toEqual([]);
     expect(bridge.specs).toEqual([]);
-    expect(bridge.telemetry.quarantinedTools.map((tool) => tool.tool)).toEqual(["bad.name", "mcp"]);
+    expect(bridge.telemetry.quarantinedTools.map((tool) => tool.tool)).toEqual(["bad.name"]);
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("retained 0 available and 0 registered tools"),
       expect.objectContaining({
@@ -1515,6 +1501,53 @@ describe("createCodexDynamicToolBridge", () => {
         registeredToolCount: 0,
       }),
     );
+  });
+
+  it("remaps only exact lowercase Codex MCP namespace hazards", async () => {
+    const execute = vi.fn(async () => textToolResult("mcp tool executed"));
+    const sourceNames = ["mcp", "mcp_", "mcp__read", "MCP", "MCP__read"];
+    const tools = sourceNames.map((name) => createTool({ name, execute }));
+    const bridge = createCodexDynamicToolBridge({
+      tools,
+      signal: new AbortController().signal,
+      loading: "direct",
+      directToolNames: sourceNames,
+    });
+
+    expect(bridge.availableTools.map((tool) => tool.name)).toEqual(sourceNames);
+    expect(specNames(bridge.availableSpecs)).toEqual([
+      "openclaw_mcp",
+      "mcp_",
+      "openclaw_mcp__read",
+      "MCP",
+      "MCP__read",
+    ]);
+    expect(bridge.telemetry.quarantinedTools).toEqual([]);
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-mcp",
+      namespace: null,
+      tool: "openclaw_mcp__read",
+      arguments: {},
+    });
+    expect(result.success).toBe(true);
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it("uses one collision allocator for available and registered Codex projections", () => {
+    const safeCollision = createTool({ name: "openclaw_mcp" });
+    const reserved = createTool({ name: "mcp" });
+    const bridge = createCodexDynamicToolBridge({
+      tools: [safeCollision, reserved],
+      registeredTools: [reserved, safeCollision],
+      signal: new AbortController().signal,
+      loading: "direct",
+    });
+
+    expect(specNames(bridge.availableSpecs)).toEqual(["openclaw_mcp", "openclaw_mcp_2"]);
+    expect(specNames(bridge.specs)).toEqual(["openclaw_mcp_2", "openclaw_mcp"]);
   });
 
   it("uses the bridge's executable projection for authority snapshots", () => {

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -107,6 +107,7 @@ type CodexToolResultHookContext = Omit<CodexDynamicToolHookContext, "config">;
 
 type ProjectedCodexDynamicTool = {
   tool: AnyAgentTool;
+  sourceName: string;
   name: string;
   description: string;
   inputSchema: JsonSchemaObject & JsonValue;
@@ -460,6 +461,54 @@ const CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE = "openclaw";
 const CODEX_DYNAMIC_TOOL_NAME_MAX_CHARS = 128;
 const CODEX_DYNAMIC_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/u;
 
+function needsCodexDynamicToolNameAlias(name: string): boolean {
+  return name === "mcp" || name.startsWith("mcp__");
+}
+
+function createCodexDynamicToolNameProjection(
+  toolSets: ReadonlyArray<readonly AnyAgentTool[]>,
+): (sourceName: string) => string {
+  const usedNames = new Set<string>();
+  for (const tools of toolSets) {
+    for (const index of tools.keys()) {
+      try {
+        const name = tools[index]?.name;
+        if (
+          typeof name === "string" &&
+          name.length <= CODEX_DYNAMIC_TOOL_NAME_MAX_CHARS &&
+          CODEX_DYNAMIC_TOOL_NAME_PATTERN.test(name) &&
+          !needsCodexDynamicToolNameAlias(name)
+        ) {
+          usedNames.add(name);
+        }
+      } catch {
+        // Descriptor projection below records unreadable entries for diagnostics.
+      }
+    }
+  }
+  const projectedNames = new Map<string, string>();
+  return (sourceName) => {
+    if (!needsCodexDynamicToolNameAlias(sourceName)) {
+      return sourceName;
+    }
+    const existing = projectedNames.get(sourceName);
+    if (existing) {
+      return existing;
+    }
+    const base = `openclaw_${sourceName}`;
+    let ordinal = 1;
+    let projected = base.slice(0, CODEX_DYNAMIC_TOOL_NAME_MAX_CHARS);
+    while (usedNames.has(projected)) {
+      ordinal += 1;
+      const suffix = `_${ordinal}`;
+      projected = `${base.slice(0, CODEX_DYNAMIC_TOOL_NAME_MAX_CHARS - suffix.length)}${suffix}`;
+    }
+    usedNames.add(projected);
+    projectedNames.set(sourceName, projected);
+    return projected;
+  };
+}
+
 // Keep OpenClaw control-path tools directly callable even when Codex tool_search
 // is unavailable or resolves a connector-only universe. Developer instructions
 // still steer normal Codex subagents to native spawn_agent.
@@ -527,16 +576,21 @@ export function createCodexDynamicToolBridge(params: {
     contextWindowTokens > 0
       ? Math.max(1, resolveLiveToolResultMaxChars({ contextWindowTokens }))
       : DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
+  const projectToolName = createCodexDynamicToolNameProjection([
+    params.tools,
+    params.registeredTools ?? [],
+  ]);
   const availableProjection = projectCodexExecutableDynamicToolSurface(
     params.tools,
     params.hookContext,
+    projectToolName,
   );
   const registeredProjection = params.registeredTools
-    ? projectCodexDynamicTools(params.registeredTools)
+    ? projectCodexDynamicTools(params.registeredTools, projectToolName)
     : availableProjection;
   const availableTools = availableProjection.tools;
   const quarantinedAvailableToolNames = new Set(
-    availableProjection.quarantinedTools.map((tool) => tool.tool),
+    availableProjection.quarantinedTools.map((tool) => projectToolName(tool.tool)),
   );
   const registeredSpecTools = (
     params.registeredTools ? registeredProjection.tools : availableTools
@@ -588,10 +642,11 @@ export function createCodexDynamicToolBridge(params: {
     snapshot?: ExecutionSnapshot;
   };
   const executionSnapshotStates = new Map<string, ExecutionSnapshotState>();
-  const directToolNames = new Set([
-    ...ALWAYS_DIRECT_DYNAMIC_TOOL_NAMES,
-    ...(params.directToolNames ?? []),
-  ]);
+  const directToolNames = new Set(
+    [...ALWAYS_DIRECT_DYNAMIC_TOOL_NAMES, ...(params.directToolNames ?? [])].map((name) =>
+      projectToolName(name),
+    ),
+  );
   let readRemoteWorkspaceFile: CodexRemoteWorkspaceFileReader | undefined;
   return {
     availableTools: availableTools.map((entry) => entry.tool),
@@ -649,7 +704,7 @@ export function createCodexDynamicToolBridge(params: {
           executionStarted: false,
         });
       }
-      const { tool, name: toolName } = toolEntry;
+      const { tool, sourceName: toolName } = toolEntry;
       const rawArguments = call.arguments;
       const args = asNonArrayRecord(rawArguments);
       const startedAt = Date.now();
@@ -1002,11 +1057,12 @@ export function createCodexDynamicToolBridge(params: {
 function projectCodexExecutableDynamicToolSurface(
   tools: readonly AnyAgentTool[],
   hookContext: CodexDynamicToolHookContext | undefined,
+  projectToolName: (sourceName: string) => string,
 ): {
   tools: ProjectedCodexDynamicTool[];
   quarantinedTools: CodexDynamicToolSchemaQuarantine[];
 } {
-  const projected = projectCodexDynamicTools(tools);
+  const projected = projectCodexDynamicTools(tools, projectToolName);
   const wrapped = wrapProjectedCodexDynamicTools(projected.tools, hookContext);
   return {
     tools: wrapped.tools,
@@ -1025,7 +1081,11 @@ export function projectCodexExecutableDynamicTools(params: {
   availableTools: AnyAgentTool[];
   quarantinedTools: CodexDynamicToolSchemaQuarantine[];
 } {
-  const projected = projectCodexExecutableDynamicToolSurface(params.tools, params.hookContext);
+  const projected = projectCodexExecutableDynamicToolSurface(
+    params.tools,
+    params.hookContext,
+    createCodexDynamicToolNameProjection([params.tools]),
+  );
   return {
     availableTools: projected.tools.map((entry) => entry.tool),
     quarantinedTools: projected.quarantinedTools,
@@ -1155,7 +1215,10 @@ function createCodexDynamicToolFunctionSpec(params: {
   };
 }
 
-function projectCodexDynamicTools(tools: readonly AnyAgentTool[]): {
+function projectCodexDynamicTools(
+  tools: readonly AnyAgentTool[],
+  projectToolName: (sourceName: string) => string,
+): {
   tools: ProjectedCodexDynamicTool[];
   quarantinedTools: CodexDynamicToolSchemaQuarantine[];
 } {
@@ -1209,7 +1272,8 @@ function projectCodexDynamicTools(tools: readonly AnyAgentTool[]): {
     }
     projectedTools.push({
       tool,
-      name: descriptor.name,
+      sourceName: descriptor.name,
+      name: projectToolName(descriptor.name),
       description: descriptor.description,
       inputSchema: projection.schema,
     });
@@ -1256,8 +1320,6 @@ function readCodexDynamicToolDescriptor(
       nameViolation = `${rawName}.name must match ^[a-zA-Z0-9_-]+$`;
     } else if (rawName.length > CODEX_DYNAMIC_TOOL_NAME_MAX_CHARS) {
       nameViolation = `${rawName}.name must be at most ${CODEX_DYNAMIC_TOOL_NAME_MAX_CHARS} characters`;
-    } else if (rawName === "mcp" || rawName.startsWith("mcp__")) {
-      nameViolation = `${rawName}.name is reserved by Codex app-server`;
     }
     if (nameViolation) {
       return {

--- a/extensions/codex/src/app-server/mcp-materialization.real-binary.live.test.ts
+++ b/extensions/codex/src/app-server/mcp-materialization.real-binary.live.test.ts
@@ -1,0 +1,165 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { materializeStaticMcpToolsForScheduledHarnessRun } from "openclaw/plugin-sdk/codex-mcp-projection";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
+import {
+  flattenCodexDynamicToolFunctions,
+  type CodexDynamicToolFunctionSpec,
+  type CodexModelListResponse,
+} from "./protocol.js";
+import { createIsolatedCodexAppServerClient } from "./shared-client.js";
+
+const LIVE =
+  process.env.OPENCLAW_LIVE_TEST === "1" &&
+  process.env.OPENCLAW_LIVE_CODEX_MCP_MATERIALIZATION === "1";
+const describeLive = LIVE ? describe : describe.skip;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describeLive("Codex MCP materialization real-binary bridge", () => {
+  it("keeps the generic MCP name while a real Codex app-server accepts its provider alias", async () => {
+    await withTempDir("openclaw-codex-mcp-materialization-", async (root) => {
+      const workspace = path.join(root, "workspace");
+      const agentDir = path.join(root, "agent");
+      await fs.mkdir(workspace, { recursive: true });
+      vi.stubEnv("OPENCLAW_STATE_DIR", path.join(root, "state"));
+
+      const materialized = await materializeStaticMcpToolsForScheduledHarnessRun({
+        sessionId: "codex-mcp-materialization-live",
+        provider: "openai",
+        model: "codex-live-control",
+        workspaceDir: workspace,
+        agentDir,
+        cfg: {
+          mcp: {
+            servers: {
+              mcp: {
+                transport: "stdio",
+                command: process.execPath,
+                args: [path.resolve("scripts/e2e/mcp-app-conformance-server.mjs")],
+                codex: { defaultToolsApprovalMode: "approve" },
+              },
+            },
+          },
+        },
+        toolsAllow: ["mcp__show"],
+        autoApproveCodexAppServerApprovals: true,
+        retireSessionRuntimeAfterDispose: true,
+      });
+      try {
+        expect(materialized.mcpToolMaterialization).toEqual({
+          provider: "openai",
+          model: "codex-live-control",
+          materializedToolCount: 3,
+          toolsAllowMatchedToolCount: 1,
+        });
+        expect(materialized.tools.map((tool) => tool.name)).toEqual(["mcp__show"]);
+
+        // Non-Codex control: execute the unprojected generic tool against the
+        // same live MCP transport before applying any provider-specific name.
+        const genericResult = await materialized.tools[0]!.execute("generic-control", {});
+        expect(JSON.stringify(genericResult)).toContain("initial-result");
+
+        const materializedTool = materialized.tools[0];
+        if (!materializedTool) {
+          throw new Error("expected the real stdio transport to materialize mcp__show");
+        }
+        const projectedTools = ["mcp", "mcp_", "mcp__show"].map((name) =>
+          Object.assign({}, materializedTool, { name }),
+        );
+
+        const bridge = createCodexDynamicToolBridge({
+          tools: projectedTools,
+          registeredTools: projectedTools,
+          signal: new AbortController().signal,
+          loading: "direct",
+        });
+        expect(bridge.availableTools.map((tool) => tool.name)).toEqual([
+          "mcp",
+          "mcp_",
+          "mcp__show",
+        ]);
+        const projectedSpecs = flattenCodexDynamicToolFunctions(bridge.availableSpecs);
+        expect(projectedSpecs.map((tool) => tool.name)).toEqual([
+          "openclaw_mcp",
+          "mcp_",
+          "openclaw_mcp__show",
+        ]);
+
+        const runtime = resolveCodexAppServerRuntimeOptions({
+          pluginConfig: { appServer: { homeScope: "user" } },
+          env: {},
+        });
+        const client = await createIsolatedCodexAppServerClient({
+          startOptions: {
+            ...runtime.start,
+            env: { CODEX_HOME: path.join(root, "codex-home") },
+            clearEnv: ["CODEX_API_KEY", "OPENAI_API_KEY"],
+          },
+          agentDir,
+          authProfileId: null,
+          timeoutMs: 60_000,
+        });
+        try {
+          const listed = await client.request<CodexModelListResponse>(
+            "model/list",
+            { limit: 100, cursor: null, includeHidden: false },
+            { timeoutMs: 60_000 },
+          );
+          const modelId =
+            listed.data.find((model) => model.isDefault)?.model ?? listed.data[0]?.model;
+          if (!modelId) {
+            throw new Error("Codex model/list returned no models");
+          }
+          const started = await client.request(
+            "thread/start",
+            {
+              cwd: workspace,
+              model: modelId,
+              approvalPolicy: "never",
+              sandbox: "danger-full-access",
+              dynamicTools: projectedSpecs,
+              ephemeral: true,
+            },
+            { timeoutMs: 60_000 },
+          );
+          expect(started.thread.id).toEqual(expect.any(String));
+
+          const mcpUnderscoreSpec = projectedSpecs.find((spec) => spec.name === "mcp_");
+          if (!mcpUnderscoreSpec) {
+            throw new Error("expected Codex projection to preserve mcp_ unchanged");
+          }
+          const reservedSpec = (name: "mcp" | "mcp__show"): CodexDynamicToolFunctionSpec => ({
+            ...mcpUnderscoreSpec,
+            name,
+          });
+          for (const reservedName of ["mcp", "mcp__show"] as const) {
+            await expect(
+              client.request(
+                "thread/start",
+                {
+                  cwd: workspace,
+                  model: modelId,
+                  approvalPolicy: "never",
+                  sandbox: "danger-full-access",
+                  dynamicTools: [reservedSpec(reservedName)],
+                  ephemeral: true,
+                },
+                { timeoutMs: 60_000 },
+              ),
+            ).rejects.toThrow(`dynamic tool name is reserved: ${reservedName}`);
+          }
+        } finally {
+          await client.closeAndWait();
+        }
+      } finally {
+        await materialized.dispose();
+      }
+    });
+  }, 120_000);
+});

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -499,6 +499,12 @@ export async function finalizeCodexAttempt(
   );
   const finalizedResult: EmbeddedRunAttemptResult = {
     ...result,
+    ...(prompt.context.attemptTools.scheduledConfiguredMcp?.mcpToolMaterialization
+      ? {
+          mcpToolMaterialization:
+            prompt.context.attemptTools.scheduledConfiguredMcp.mcpToolMaterialization,
+        }
+      : {}),
     ...(toolState.yieldAcknowledgment
       ? { yieldAcknowledgment: toolState.yieldAcknowledgment }
       : {}),

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -9,6 +9,7 @@ import {
   captureFinalCodexCronCreatorToolAllowlist,
   materializeStaticMcpToolsForScheduledHarnessRun,
 } from "openclaw/plugin-sdk/codex-mcp-projection";
+import { withMcpToolMaterialization } from "./attempt-terminal.js";
 import { resolveCodexPluginsPolicy, shouldAutoApproveCodexAppServerApprovals } from "./config.js";
 import {
   buildDynamicTools,
@@ -324,6 +325,8 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     ? await materializeStaticMcpToolsForScheduledHarnessRun({
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
+        provider: params.provider,
+        model: params.modelId,
         workspaceDir: effectiveWorkspace,
         agentDir: policyContext.agentDir,
         cfg: params.config,
@@ -491,6 +494,8 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
         try {
           materialized = await materializeStaticMcpToolsForScheduledHarnessRun({
             sessionId: authorityRuntimeId,
+            provider: params.provider,
+            model: params.modelId,
             workspaceDir: effectiveWorkspace,
             agentDir: policyContext.agentDir,
             cfg: params.config,
@@ -566,9 +571,17 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
   } catch (error) {
     // Materialized runtimes are attempt-owned only after this function returns.
     // Dispose here when filtering, schema projection, or bridge setup fails first.
-    await scopedMcpTools?.dispose();
-    await scheduledConfiguredMcp?.dispose();
-    throw error;
+    try {
+      await scopedMcpTools?.dispose();
+    } catch {
+      // Preserve the tool-setup error; cleanup is best-effort.
+    }
+    try {
+      await scheduledConfiguredMcp?.dispose();
+    } catch {
+      // Preserve the tool-setup error; cleanup is best-effort.
+    }
+    throw withMcpToolMaterialization(error, scheduledConfiguredMcp?.mcpToolMaterialization);
   }
 }
 

--- a/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
@@ -26,6 +26,7 @@ const mcpMocks = vi.hoisted(() => ({
   staticDiagnosticNotice: undefined as string | undefined,
   staticFailure: undefined as Error | undefined,
   staticFailureGate: undefined as Promise<void> | undefined,
+  staticMatchedToolCount: undefined as number | undefined,
   staticCalls: [] as Array<Record<string, unknown>>,
   staticToolExecutes: [] as ReturnType<typeof vi.fn>[],
   threadConfigCalls: [] as Array<Record<string, unknown>>,
@@ -95,16 +96,24 @@ vi.mock("openclaw/plugin-sdk/codex-mcp-projection", async (importOriginal) => {
       }));
       mcpMocks.staticToolExecutes.push(execute);
       return {
-        tools: mcpMocks.staticDiagnosticNotice
-          ? []
-          : [
-              {
-                name: "fake__show",
-                description: "Show the configured MCP fixture result.",
-                parameters: { type: "object", properties: {} },
-                execute,
-              },
-            ],
+        tools:
+          mcpMocks.staticDiagnosticNotice || mcpMocks.staticMatchedToolCount === 0
+            ? []
+            : [
+                {
+                  name: "fake__show",
+                  description: "Show the configured MCP fixture result.",
+                  parameters: { type: "object", properties: {} },
+                  execute,
+                },
+              ],
+        mcpToolMaterialization: {
+          provider: String(params.provider),
+          model: String(params.model),
+          materializedToolCount: 1,
+          toolsAllowMatchedToolCount:
+            mcpMocks.staticMatchedToolCount ?? (mcpMocks.staticDiagnosticNotice ? 0 : 1),
+        },
         appTools: [
           {
             name: "fake__app_only",
@@ -178,6 +187,7 @@ beforeEach(() => {
   mcpMocks.staticDiagnosticNotice = undefined;
   mcpMocks.staticFailure = undefined;
   mcpMocks.staticFailureGate = undefined;
+  mcpMocks.staticMatchedToolCount = undefined;
   mcpMocks.dispose.mockClear();
   mcpMocks.captureFacade.mockClear();
   mcpMocks.staticFacade.mockClear();
@@ -281,6 +291,8 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
     expect(JSON.stringify(threadStart?.dynamicTools ?? [])).toContain("fake__show");
     expect(mcpMocks.staticCalls[0]).not.toHaveProperty("requesterSenderId");
     expect(mcpMocks.staticCalls[0]).toMatchObject({
+      provider: params.provider,
+      model: params.modelId,
       toolsAllow: ["*"],
       manifestRegistry: params.preparedModelRuntime?.metadataSnapshot.manifestRegistry,
       autoApproveCodexAppServerApprovals: true,
@@ -304,7 +316,14 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
     expect(mcpMocks.staticToolExecutes[0]).toHaveBeenCalledOnce();
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await run;
+    const result = await run;
+
+    expect(result.mcpToolMaterialization).toEqual({
+      provider: params.provider,
+      model: params.modelId,
+      materializedToolCount: 1,
+      toolsAllowMatchedToolCount: 1,
+    });
 
     expect(mcpMocks.captureCalls).toHaveLength(1);
     expect(mcpMocks.captureCalls[0]).toMatchObject({
@@ -319,6 +338,70 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
     expect(binding).toMatchObject({ configuredMcpOwnershipVersion: 1 });
     expect(binding).not.toHaveProperty("mcpServersFingerprint");
     expect(binding).not.toHaveProperty("userMcpServersFingerprint");
+  });
+
+  it("carries exact-selector materialization through a post-setup turn failure", async () => {
+    const sessionFile = path.join(tempDir, "session-scheduled-static-mcp-turn-failure.jsonl");
+    const params = createParams(
+      sessionFile,
+      path.join(tempDir, "workspace-scheduled-static-mcp-turn-failure"),
+    );
+    configureFakeMcp(params);
+    params.trigger = "cron";
+    params.toolsAllow = ["fake__missing"];
+    params.scheduledToolPolicy = { version: 1, mode: "trusted" };
+    mcpMocks.staticMatchedToolCount = 0;
+
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "turn/start") {
+        throw new Error("turn start failed after MCP materialization");
+      }
+      return undefined;
+    });
+
+    await expect(runCodexAppServerAttempt(params)).rejects.toMatchObject({
+      message: "turn start failed after MCP materialization",
+      mcpToolMaterialization: {
+        provider: params.provider,
+        model: params.modelId,
+        materializedToolCount: 1,
+        toolsAllowMatchedToolCount: 0,
+      },
+    });
+    const threadStart = harness.requests.find((request) => request.method === "thread/start")
+      ?.params as { dynamicTools?: Array<{ name?: string }> } | undefined;
+    expect(threadStart?.dynamicTools?.map((tool) => tool.name)).not.toContain("fake__show");
+  });
+
+  it("carries exact-selector materialization through tool projection setup failure", async () => {
+    const sessionFile = path.join(tempDir, "session-scheduled-static-mcp-projection-failure.jsonl");
+    const params = createParams(
+      sessionFile,
+      path.join(tempDir, "workspace-scheduled-static-mcp-projection-failure"),
+    );
+    const setupError = new Error("dynamic tool projection failed after MCP materialization");
+    configureFakeMcp(params);
+    params.trigger = "cron";
+    params.toolsAllow = ["fake__missing"];
+    params.scheduledToolPolicy = { version: 1, mode: "trusted" };
+    mcpMocks.staticMatchedToolCount = 0;
+    mcpMocks.captureFacade.mockImplementationOnce(() => {
+      throw setupError;
+    });
+    mcpMocks.dispose.mockRejectedValueOnce(new Error("configured MCP disposal failed"));
+
+    const error = await runCodexAppServerAttempt(params).catch((caught: unknown) => caught);
+
+    expect(error).toBe(setupError);
+    expect(error).toMatchObject({
+      mcpToolMaterialization: {
+        provider: params.provider,
+        model: params.modelId,
+        materializedToolCount: 1,
+        toolsAllowMatchedToolCount: 0,
+      },
+    });
+    expect(mcpMocks.dispose).toHaveBeenCalledOnce();
   });
 
   it("preserves bounded canonical continuity when scheduled MCP replaces ordinary ownership", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1,6 +1,6 @@
 // Codex plugin module implements run attempt behavior.
 import type { EmbeddedRunAttemptParamsV2 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import { type EmbeddedRunAttemptResult, withMcpToolMaterialization } from "./attempt-terminal.js";
 import { activateCodexAttemptTurn } from "./run-attempt-active-turn.js";
 import { cleanupCodexAttempt } from "./run-attempt-cleanup.js";
 import { prepareCodexAttemptConnection } from "./run-attempt-connection.js";
@@ -27,65 +27,81 @@ export async function runCodexAppServerAttempt(
   const connection = await prepareCodexAttemptConnection({ params, options });
   const runtime = await prepareCodexAttemptRuntime(connection);
   const attemptTools = await prepareCodexAttemptTools(runtime);
-  const attemptContext = await prepareCodexAttemptContext(runtime, attemptTools);
-  const attemptPrompt = await prepareCodexAttemptPrompt(attemptContext);
-  const resources = prepareCodexAttemptResources(attemptPrompt);
-  attemptTools.runtimeYieldCompletionClaim.current = () =>
-    resources.state.nativeHookRelay?.hasClaimedDirectChild() ?? false;
-  await startCodexAttemptRuntime(resources);
-
-  const turnRuntime = createCodexAttemptTurnState(resources);
-  const lifecycle = createCodexAttemptLifecycleController(resources, turnRuntime);
-  const notifications = createCodexAttemptNotificationController(resources, turnRuntime, lifecycle);
-  const serverRequests = createCodexAttemptServerRequestController(
-    resources,
-    turnRuntime,
-    lifecycle,
-  );
-  const { ensureCurrentThreadRoute } = await prepareCodexAttemptRoute(
-    resources,
-    turnRuntime,
-    notifications,
-    serverRequests.handleServerRequest,
-  );
-  const turnRequest = await prepareCodexAttemptTurnRequest(
-    resources,
-    turnRuntime,
-    ensureCurrentThreadRoute,
-    notifications.waitForActiveNativeTurnCompletion,
-  );
-  const turnStart = await startCodexAttemptTurn(resources, turnRuntime, notifications, turnRequest);
-  if ("result" in turnStart) {
-    return turnStart.result;
-  }
-  const activeTurn = await activateCodexAttemptTurn(
-    resources,
-    turnRuntime,
-    lifecycle,
-    notifications,
-    turnStart.turn,
-  );
-
-  let finalizedResult: EmbeddedRunAttemptResult;
+  const mcpToolMaterialization = attemptTools.scheduledConfiguredMcp?.mcpToolMaterialization;
   try {
-    finalizedResult = await finalizeCodexAttempt(
+    const attemptContext = await prepareCodexAttemptContext(runtime, attemptTools);
+    const attemptPrompt = await prepareCodexAttemptPrompt(attemptContext);
+    const resources = prepareCodexAttemptResources(attemptPrompt);
+    attemptTools.runtimeYieldCompletionClaim.current = () =>
+      resources.state.nativeHookRelay?.hasClaimedDirectChild() ?? false;
+    await startCodexAttemptRuntime(resources);
+
+    const turnRuntime = createCodexAttemptTurnState(resources);
+    const lifecycle = createCodexAttemptLifecycleController(resources, turnRuntime);
+    const notifications = createCodexAttemptNotificationController(
+      resources,
+      turnRuntime,
+      lifecycle,
+    );
+    const serverRequests = createCodexAttemptServerRequestController(
+      resources,
+      turnRuntime,
+      lifecycle,
+    );
+    const { ensureCurrentThreadRoute } = await prepareCodexAttemptRoute(
+      resources,
+      turnRuntime,
+      notifications,
+      serverRequests.handleServerRequest,
+    );
+    const turnRequest = await prepareCodexAttemptTurnRequest(
+      resources,
+      turnRuntime,
+      ensureCurrentThreadRoute,
+      notifications.waitForActiveNativeTurnCompletion,
+    );
+    const turnStart = await startCodexAttemptTurn(
+      resources,
+      turnRuntime,
+      notifications,
+      turnRequest,
+    );
+    if ("result" in turnStart) {
+      return mcpToolMaterialization
+        ? { ...turnStart.result, mcpToolMaterialization }
+        : turnStart.result;
+    }
+    const activeTurn = await activateCodexAttemptTurn(
       resources,
       turnRuntime,
       lifecycle,
       notifications,
-      turnRequest,
-      activeTurn,
+      turnStart.turn,
     );
-  } finally {
-    await cleanupCodexAttempt(resources, turnRuntime, lifecycle, turnRequest, activeTurn);
+
+    let finalizedResult: EmbeddedRunAttemptResult;
+    try {
+      finalizedResult = await finalizeCodexAttempt(
+        resources,
+        turnRuntime,
+        lifecycle,
+        notifications,
+        turnRequest,
+        activeTurn,
+      );
+    } finally {
+      await cleanupCodexAttempt(resources, turnRuntime, lifecycle, turnRequest, activeTurn);
+    }
+    // Cleanup retires the execution lease; only then can device loss no longer
+    // race the final result captured during asynchronous terminal processing.
+    if (
+      resources.state.executionDisconnectError &&
+      !connection.terminalState.explicitCancellationObserved
+    ) {
+      throw resources.state.executionDisconnectError;
+    }
+    return finalizedResult;
+  } catch (error) {
+    throw withMcpToolMaterialization(error, mcpToolMaterialization);
   }
-  // Cleanup retires the execution lease; only then can device loss no longer
-  // race the final result captured during asynchronous terminal processing.
-  if (
-    resources.state.executionDisconnectError &&
-    !connection.terminalState.explicitCancellationObserved
-  ) {
-    throw resources.state.executionDisconnectError;
-  }
-  return finalizedResult;
 }

--- a/src/agents/agent-bundle-mcp-harness.test.ts
+++ b/src/agents/agent-bundle-mcp-harness.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { executeMcpAppOperation } from "../gateway/mcp-app-operations.js";
 import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
+import { findMcpToolMaterialization } from "./failover-error.js";
 import { getMcpAppViewLease } from "./mcp-ui-resource.js";
 import { testing as mcpUiResourceTesting } from "./mcp-ui-resource.test-support.js";
 
@@ -205,6 +206,8 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
       sessionId: "scheduled",
+      provider: "openai",
+      model: "gpt-5.4-codex",
       workspaceDir: "/workspace",
       toolsAllow: ["user-mail__inbox"],
     });
@@ -217,6 +220,12 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
       }),
     );
     expect(result?.tools.map((tool) => tool.name)).toEqual(["user-mail__inbox"]);
+    expect(result.mcpToolMaterialization).toEqual({
+      provider: "openai",
+      model: "gpt-5.4-codex",
+      materializedToolCount: 1,
+      toolsAllowMatchedToolCount: 1,
+    });
     await result?.dispose();
   });
 
@@ -227,12 +236,88 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
       sessionId: "scheduled-denied",
+      provider: "openai",
+      model: "gpt-5.4-codex",
       workspaceDir: "/workspace",
       toolsAllow: ["read"],
     });
 
     expect(result?.tools).toEqual([]);
     await result?.dispose();
+  });
+
+  it("captures explicit-cap matches before conversation policy and Codex approval", async () => {
+    const runtime = makeRuntime({ sessionId: "scheduled-policy", requesterSenderId: "unused" });
+    delete runtime.requesterScope;
+    runtime.peekCatalog()!.servers["user-mail"]!.codexApprovalMode = "approve";
+    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+
+    const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
+      sessionId: "scheduled-policy",
+      provider: "openai",
+      model: "gpt-5.4-codex",
+      workspaceDir: "/workspace",
+      toolsAllow: ["user-mail__inbox"],
+      policyContext: {
+        conversationToolPolicy: { deny: ["user-mail__inbox"] },
+      },
+    });
+
+    expect(result.tools).toEqual([]);
+    expect(result.mcpToolMaterialization).toMatchObject({
+      materializedToolCount: 1,
+      toolsAllowMatchedToolCount: 1,
+    });
+    await result.dispose();
+  });
+
+  it("carries post-cap materialization when scheduled app policy setup fails", async () => {
+    const runtime = makeRuntime({
+      sessionId: "scheduled-approval-failure",
+      requesterSenderId: "unused",
+    });
+    const releaseLease = vi.fn();
+    const setupError = new Error("scheduled app policy setup failed");
+    delete runtime.requesterScope;
+    runtime.acquireLease = vi.fn(() => releaseLease);
+    const catalog = runtime.peekCatalog()!;
+    catalog.servers["user-mail"]!.toolCount = 2;
+    catalog.tools.push({
+      serverName: "user-mail",
+      safeServerName: "user-mail",
+      toolName: "app-only",
+      description: "app-only",
+      inputSchema: { type: "object", properties: {} },
+      fallbackDescription: "app-only",
+      uiVisibility: ["app"],
+    });
+    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    const params = {
+      sessionId: "scheduled-approval-failure",
+      provider: "openai",
+      model: "gpt-5.4-codex",
+      workspaceDir: "/workspace",
+      toolsAllow: ["user-mail__app-only"],
+      policyContext: {
+        config: { tools: { allow: ["missing-policy-entry"] } },
+      },
+      warn: () => {
+        throw setupError;
+      },
+    } as Parameters<typeof materializeStaticMcpToolsForScheduledHarnessRunCore>[0];
+
+    const error = await materializeStaticMcpToolsForScheduledHarnessRunCore(params).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBe(setupError);
+    expect(findMcpToolMaterialization(error)).toEqual({
+      provider: "openai",
+      model: "gpt-5.4-codex",
+      materializedToolCount: 1,
+      toolsAllowMatchedToolCount: 0,
+    });
+    expect(releaseLease).toHaveBeenCalledOnce();
   });
 
   it("binds persistent app views to the same finite scheduled cap", async () => {
@@ -275,6 +360,8 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
       sessionId: "scheduled-app",
+      provider: "openai",
+      model: "gpt-5.4-codex",
       sessionKey: "agent:main:main",
       agentId: "main",
       workspaceDir: "/workspace",
@@ -349,6 +436,8 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
       sessionId: "scheduled-app-approval",
+      provider: "openai",
+      model: "gpt-5.4-codex",
       sessionKey: "agent:main:main",
       agentId: "main",
       workspaceDir: "/workspace",
@@ -416,6 +505,8 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
       sessionId: "scheduled-app-yolo",
+      provider: "openai",
+      model: "gpt-5.4-codex",
       sessionKey: "agent:main:main",
       agentId: "main",
       workspaceDir: "/workspace",
@@ -441,6 +532,8 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
       sessionId: "scheduled-empty",
+      provider: "openai",
+      model: "gpt-5.4-codex",
       workspaceDir: "/workspace",
       toolsAllow: ["*"],
     });
@@ -472,6 +565,8 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
       sessionId: "scheduled-diagnostic",
+      provider: "openai",
+      model: "gpt-5.4-codex",
       workspaceDir: "/workspace",
       toolsAllow: ["*"],
     });
@@ -491,6 +586,8 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
       sessionId: "scheduled-prompt",
+      provider: "openai",
+      model: "gpt-5.4-codex",
       workspaceDir: "/workspace",
       toolsAllow: ["user-mail__inbox"],
     });
@@ -511,6 +608,8 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
       sessionId: "scheduled-yolo",
+      provider: "openai",
+      model: "gpt-5.4-codex",
       workspaceDir: "/workspace",
       toolsAllow: ["user-mail__inbox"],
       autoApproveCodexAppServerApprovals: true,
@@ -537,6 +636,8 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
       sessionId: `scheduled-${mode}`,
+      provider: "openai",
+      model: "gpt-5.4-codex",
       workspaceDir: "/workspace",
       toolsAllow: ["user-mail__inbox"],
     });
@@ -554,6 +655,8 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
       sessionId: "scheduled-unknown",
+      provider: "openai",
+      model: "gpt-5.4-codex",
       workspaceDir: "/workspace",
       toolsAllow: ["user-mail__inbox"],
     });

--- a/src/agents/agent-bundle-mcp-harness.ts
+++ b/src/agents/agent-bundle-mcp-harness.ts
@@ -23,6 +23,8 @@ import {
 } from "./conversation-capability-profile.js";
 import { applyFinalEffectiveToolPolicy } from "./embedded-agent-runner/effective-tool-policy.js";
 import { applyEmbeddedAttemptToolsAllow } from "./embedded-agent-runner/run/attempt-tool-construction-plan.js";
+import type { McpToolMaterializationFact } from "./embedded-agent-runner/types.js";
+import { withMcpToolMaterialization } from "./failover-error.js";
 import { requiresMcpCodexToolApproval } from "./mcp-codex-tool-approval.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -40,6 +42,8 @@ type RequesterScopedHarnessMcpTools = {
 type ScheduledStaticHarnessMcpTools = {
   /** Final executable static MCP tools for this scheduled turn. */
   tools: AnyAgentTool[];
+  /** Exact MCP surface observed after this attempt's explicit tool cap. */
+  mcpToolMaterialization: McpToolMaterializationFact;
   /** Bounded model/operator warning when configured servers or final policy were incomplete. */
   diagnosticNotice?: string;
   dispose: () => Promise<void>;
@@ -129,6 +133,13 @@ function applyHarnessToolPolicy(
   const allowed = applyEmbeddedAttemptToolsAllow(tools, params.toolsAllow, {
     toolMeta: (tool) => getPluginToolMeta(tool),
   });
+  return applyHarnessConversationPolicy(allowed, params);
+}
+
+function applyHarnessConversationPolicy(
+  tools: AnyAgentTool[],
+  params: MaterializeRequesterScopedMcpToolsForHarnessRunParams,
+): AnyAgentTool[] {
   const profile =
     params.conversationCapabilityProfile ??
     (params.policyContext
@@ -138,10 +149,10 @@ function applyHarnessToolPolicy(
         })
       : undefined);
   if (!profile) {
-    return allowed;
+    return tools;
   }
   return applyFinalEffectiveToolPolicy({
-    bundledTools: allowed,
+    bundledTools: tools,
     config: params.policyContext?.config ?? params.cfg,
     conversationCapabilityProfile: profile,
     warn: params.warn ?? (() => undefined),
@@ -174,6 +185,8 @@ export async function materializeStaticMcpToolsForScheduledHarnessRunCore(
     MaterializeRequesterScopedMcpToolsForHarnessRunParams,
     "requesterSenderId" | "agentAccountId" | "messageChannel"
   > & {
+    provider: string;
+    model: string;
     toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
     /** Exact established Codex yolo predicate; no other profile bypasses approval metadata. */
     autoApproveCodexAppServerApprovals?: boolean;
@@ -210,6 +223,7 @@ export async function materializeStaticMcpToolsForScheduledHarnessRunCore(
     await retireSnapshotRuntime?.();
     throw error;
   }
+  let mcpToolMaterialization: McpToolMaterializationFact | undefined;
   try {
     const policyWarnings: string[] = [];
     const policyParams = {
@@ -219,8 +233,19 @@ export async function materializeStaticMcpToolsForScheduledHarnessRunCore(
         params.warn?.(message);
       },
     };
+    const explicitlyAllowedTools = applyEmbeddedAttemptToolsAllow(
+      liveRuntime.tools,
+      params.toolsAllow,
+      { toolMeta: (tool) => getPluginToolMeta(tool) },
+    );
+    mcpToolMaterialization = {
+      provider: params.provider,
+      model: params.model,
+      materializedToolCount: liveRuntime.tools.length,
+      toolsAllowMatchedToolCount: explicitlyAllowedTools.length,
+    };
     const allowed = filterScheduledCodexApproval(
-      applyHarnessToolPolicy(liveRuntime.tools, policyParams),
+      applyHarnessConversationPolicy(explicitlyAllowedTools, policyParams),
       params.autoApproveCodexAppServerApprovals === true,
       (message) => policyWarnings.push(message),
     );
@@ -228,7 +253,14 @@ export async function materializeStaticMcpToolsForScheduledHarnessRunCore(
     // same complete catalog and final policy before any model tool can mint one.
     liveRuntime.restrictAppTools?.(
       filterScheduledCodexApproval(
-        applyHarnessToolPolicy(liveRuntime.appTools ?? liveRuntime.tools, policyParams),
+        applyHarnessConversationPolicy(
+          applyEmbeddedAttemptToolsAllow(
+            liveRuntime.appTools ?? liveRuntime.tools,
+            params.toolsAllow,
+            { toolMeta: (tool) => getPluginToolMeta(tool) },
+          ),
+          policyParams,
+        ),
         params.autoApproveCodexAppServerApprovals === true,
         (message) => policyWarnings.push(message),
       ),
@@ -242,6 +274,7 @@ export async function materializeStaticMcpToolsForScheduledHarnessRunCore(
     let disposed = false;
     return {
       tools: allowed,
+      mcpToolMaterialization,
       ...(diagnosticNotice ? { diagnosticNotice } : {}),
       dispose: async () => {
         if (disposed) {
@@ -252,8 +285,12 @@ export async function materializeStaticMcpToolsForScheduledHarnessRunCore(
       },
     };
   } catch (error) {
-    await liveRuntime.dispose();
-    throw error;
+    try {
+      await liveRuntime.dispose();
+    } catch {
+      // Preserve the post-materialization setup error; cleanup is best-effort.
+    }
+    throw withMcpToolMaterialization(error, mcpToolMaterialization);
   }
 }
 

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -22,6 +22,14 @@ export type BundleMcpToolRuntime = {
   dispose: () => Promise<void>;
 };
 
+/** Exact MCP surface observed after the run's explicit tool cap was applied. */
+export type McpToolMaterializationFact = {
+  provider: string;
+  model: string;
+  materializedToolCount: number;
+  toolsAllowMatchedToolCount: number;
+};
+
 /** Catalog metadata for one configured MCP server. */
 export type McpServerCatalog = {
   serverName: string;

--- a/src/agents/embedded-agent-runner/run.terminal-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run.terminal-timeout.test.ts
@@ -69,6 +69,20 @@ describe("resolveEmbeddedRunTerminalTimeout", () => {
     ]);
   });
 
+  it("preserves MCP materialization evidence in timeout replacement results", () => {
+    const materialization = {
+      provider: "openai",
+      model: "gpt-5.4",
+      materializedToolCount: 1,
+      toolsAllowMatchedToolCount: 0,
+    };
+    const result = resolveEmbeddedRunTerminalTimeout(
+      makeTimeoutInput(makeTimedOutAttempt({ mcpToolMaterialization: materialization })),
+    );
+
+    expect(result?.mcpToolMaterialization).toEqual(materialization);
+  });
+
   it("preserves an accepted child spawn while surfacing the parent timeout", () => {
     const acceptedSessionSpawns = [
       { runId: "run-child", childSessionKey: "agent:claude:subagent:child" },

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setPluginToolMeta } from "../../../plugins/tools.js";
+import { findMcpToolMaterialization } from "../../failover-error.js";
 import { attachToolAllowlistIntersection } from "../../tool-policy.js";
 
 const mocks = vi.hoisted(() => ({
@@ -217,6 +218,77 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
     expect(inheritedToolAllowlist).not.toContain("server__delete");
   });
 
+  it.each([
+    { cap: "notes__missing", materializedName: "notes__search" },
+    { cap: "notes__search", materializedName: "notes__search-2" },
+  ])(
+    "records zero post-materialization matches for cap $cap against $materializedName",
+    async ({ cap, materializedName }) => {
+      mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+      mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
+        tools: [{ name: materializedName }],
+      });
+      const input = createInput([], []);
+      input.attempt.toolsAllow = [cap];
+      input.preparedToolBase.effectiveToolsAllow = [cap];
+
+      const result = await prepareEmbeddedAttemptBundleTools(input);
+
+      expect(result.mcpToolMaterialization).toEqual({
+        provider: "provider",
+        model: "model",
+        materializedToolCount: 1,
+        toolsAllowMatchedToolCount: 0,
+      });
+    },
+  );
+
+  it("records explicit-cap matches before conversation policy removes the tool", async () => {
+    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
+      tools: [{ name: "notes__search" }],
+    });
+    mocks.applyFinalEffectiveToolPolicy.mockReturnValue([]);
+    const input = createInput([], []);
+    input.attempt.toolsAllow = ["notes__search"];
+    input.preparedToolBase.effectiveToolsAllow = ["notes__search"];
+
+    const result = await prepareEmbeddedAttemptBundleTools(input);
+
+    expect(result.mcpToolMaterialization).toEqual({
+      provider: "provider",
+      model: "model",
+      materializedToolCount: 1,
+      toolsAllowMatchedToolCount: 1,
+    });
+    expect(result.tools).toEqual([]);
+  });
+
+  it("carries post-cap materialization when later LSP setup fails", async () => {
+    const disposeMcp = vi.fn(async () => {});
+    const setupError = new Error("LSP setup failed after MCP materialization");
+    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
+      tools: [{ name: "notes__search" }],
+      dispose: disposeMcp,
+    });
+    mocks.createBundleLspToolRuntime.mockRejectedValue(setupError);
+    const input = createInput([], []);
+    input.attempt.toolsAllow = ["notes__missing", "lsp_probe"];
+    input.preparedToolBase.effectiveToolsAllow = input.attempt.toolsAllow;
+
+    const error = await prepareEmbeddedAttemptBundleTools(input).catch((caught: unknown) => caught);
+
+    expect(error).toBe(setupError);
+    expect(findMcpToolMaterialization(error)).toEqual({
+      provider: "provider",
+      model: "model",
+      materializedToolCount: 1,
+      toolsAllowMatchedToolCount: 0,
+    });
+    expect(disposeMcp).toHaveBeenCalledOnce();
+  });
+
   it("captures the post-quarantine creator cap with plugin ownership", async () => {
     const coreTool = { name: "automations" };
     const allowedMcpTool = { name: "mail__read" };
@@ -250,20 +322,16 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
     });
   });
 
-  it("disposes prepared bundle runtimes when later policy setup fails", async () => {
+  it("carries post-cap materialization when later schema projection fails", async () => {
     const disposeMcp = vi.fn(async () => {});
-    const disposeLsp = vi.fn(async () => {});
+    const setupError = new Error("bundle policy failed");
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
     mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
-      tools: [],
+      tools: [{ name: "notes__search" }],
       dispose: disposeMcp,
     });
-    mocks.createBundleLspToolRuntime.mockResolvedValue({
-      tools: [],
-      dispose: disposeLsp,
-    });
-    mocks.applyFinalEffectiveToolPolicy.mockImplementation(() => {
-      throw new Error("bundle policy failed");
+    mocks.filterRuntimeCompatibleTools.mockImplementation(() => {
+      throw setupError;
     });
 
     const input = {
@@ -276,6 +344,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
         runId: "run",
         runtimePlan: {},
         sessionId: "session",
+        toolsAllow: ["notes__missing"],
       },
       effectiveWorkspace: "/tmp/workspace",
       getCurrentAttemptPluginMetadataSnapshot: () => undefined,
@@ -283,7 +352,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
       isRawModelRun: false,
       preparedToolBase: {
         cronCreatorToolAllowlist: [],
-        effectiveToolsAllow: undefined,
+        effectiveToolsAllow: ["notes__missing"],
         localModelLeanPreserveToolNames: [],
         runtimeCapabilityProfile: undefined,
         toolsEnabled: true,
@@ -292,11 +361,16 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
       sessionAgentId: "main",
     } as unknown as Parameters<typeof prepareEmbeddedAttemptBundleTools>[0];
 
-    await expect(prepareEmbeddedAttemptBundleTools(input)).rejects.toThrow("bundle policy failed");
-    expect(mocks.applyFinalEffectiveToolPolicy).toHaveBeenCalledWith(
-      expect.objectContaining({ workspaceDir: "/tmp/workspace" }),
-    );
+    const error = await prepareEmbeddedAttemptBundleTools(input).catch((caught: unknown) => caught);
+
+    expect(error).toBe(setupError);
+    expect(findMcpToolMaterialization(error)).toEqual({
+      provider: "provider",
+      model: "model",
+      materializedToolCount: 1,
+      toolsAllowMatchedToolCount: 0,
+    });
+    expect(mocks.filterRuntimeCompatibleTools).toHaveBeenCalledOnce();
     expect(disposeMcp).toHaveBeenCalledOnce();
-    expect(disposeLsp).toHaveBeenCalledOnce();
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -4,6 +4,8 @@ import {
   getOrCreateSessionMcpRuntime,
   materializeBundleMcpToolsForRun,
 } from "../../agent-bundle-mcp-tools.js";
+import type { McpToolMaterializationFact } from "../../agent-bundle-mcp-types.js";
+import { withMcpToolMaterialization } from "../../failover-error.js";
 import { filterLocalModelLeanTools } from "../../local-model-lean.js";
 import { normalizeAgentRuntimeTools } from "../../runtime-plan/tools.js";
 import { isRuntimeToolAllowed } from "../../tool-policy-match.js";
@@ -124,7 +126,21 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
       })
     : undefined;
   let bundleLspRuntime: Awaited<ReturnType<typeof createBundleLspToolRuntime>> | undefined;
+  let mcpToolMaterialization: McpToolMaterializationFact | undefined;
   try {
+    const allowedBundleMcpTools = applyEmbeddedAttemptToolsAllow(
+      bundleMcpRuntime?.tools ?? [],
+      effectiveToolsAllow,
+      { toolMeta: (tool) => getPluginToolMeta(tool) },
+    );
+    mcpToolMaterialization = bundleMcpRuntime
+      ? {
+          provider: params.attempt.provider,
+          model: params.attempt.modelId,
+          materializedToolCount: bundleMcpRuntime.tools.length,
+          toolsAllowMatchedToolCount: allowedBundleMcpTools.length,
+        }
+      : undefined;
     const bundleLspEnabled =
       !params.attempt.forceRestartSafeTools &&
       !params.attempt.forceCodeModeReconciliationTools &&
@@ -145,11 +161,6 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
           ],
         })
       : undefined;
-    const allowedBundleMcpTools = applyEmbeddedAttemptToolsAllow(
-      bundleMcpRuntime?.tools ?? [],
-      effectiveToolsAllow,
-      { toolMeta: (tool) => getPluginToolMeta(tool) },
-    );
     const allowedBundleLspTools = applyEmbeddedAttemptToolsAllow(
       bundleLspRuntime?.tools ?? [],
       effectiveToolsAllow,
@@ -239,6 +250,7 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
       bundleLspRuntime,
       bundleMcpRuntime,
       clientTools,
+      mcpToolMaterialization,
       tools,
       uncompactedEffectiveTools: [...schemaProjection.tools],
     };
@@ -253,6 +265,6 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
     } catch {
       // Preserve the preparation error; cleanup is best-effort.
     }
-    throw error;
+    throw withMcpToolMaterialization(error, mcpToolMaterialization);
   }
 }

--- a/src/agents/embedded-agent-runner/run/attempt-result.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.test.ts
@@ -253,6 +253,25 @@ describe("attempt result projection", () => {
     expect(latest.latestMcpConnectAction.authorizationUrl).toBe("https://auth.example/latest");
   });
 
+  it("carries MCP materialization evidence across an internal retry", () => {
+    const carryover = createMcpAttemptCarryover();
+    const materialization = {
+      provider: "openai",
+      model: "gpt-5.4",
+      materializedToolCount: 2,
+      toolsAllowMatchedToolCount: 0,
+    };
+    const first: Parameters<typeof carryover.apply>[0] = {
+      mcpToolMaterialization: materialization,
+    };
+    const retry: Parameters<typeof carryover.apply>[0] = {};
+
+    carryover.apply(first);
+    carryover.apply(retry);
+
+    expect(retry.mcpToolMaterialization).toEqual(materialization);
+  });
+
   it("keeps completed client tool calls in reserved source order", () => {
     expect(
       completeResult({

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -38,14 +38,20 @@ type HookRunner = ReturnType<typeof getGlobalHookRunner>;
 export function createMcpAttemptCarryover() {
   let latestMcpAppChannelView: EmbeddedRunAttemptResult["latestMcpAppChannelView"];
   let latestMcpConnectAction: EmbeddedRunAttemptResult["latestMcpConnectAction"];
+  let mcpToolMaterialization: EmbeddedRunAttemptResult["mcpToolMaterialization"];
   return {
     apply(
-      attempt: Pick<EmbeddedRunAttemptResult, "latestMcpAppChannelView" | "latestMcpConnectAction">,
+      attempt: Pick<
+        EmbeddedRunAttemptResult,
+        "latestMcpAppChannelView" | "latestMcpConnectAction" | "mcpToolMaterialization"
+      >,
     ): void {
       latestMcpAppChannelView = attempt.latestMcpAppChannelView ?? latestMcpAppChannelView;
       attempt.latestMcpAppChannelView = latestMcpAppChannelView;
       latestMcpConnectAction = attempt.latestMcpConnectAction ?? latestMcpConnectAction;
       attempt.latestMcpConnectAction = latestMcpConnectAction;
+      mcpToolMaterialization = attempt.mcpToolMaterialization ?? mcpToolMaterialization;
+      attempt.mcpToolMaterialization = mcpToolMaterialization;
     },
   };
 }

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -6,6 +6,7 @@ import {
 import { resolveContextEngineOwnerPluginId } from "../../../context-engine/registry.js";
 import { createBundleLspToolRuntime } from "../../agent-bundle-lsp-runtime.js";
 import { materializeBundleMcpToolsForRun } from "../../agent-bundle-mcp-tools.js";
+import type { McpToolMaterializationFact } from "../../agent-bundle-mcp-types.js";
 import { AgentRunTerminalOutcomeError } from "../../agent-run-terminal-error.js";
 import {
   buildAgentRunTerminalOutcomeFromAttempt,
@@ -14,6 +15,7 @@ import {
   type AgentRunAttemptTerminal,
 } from "../../agent-run-terminal-outcome.js";
 import { resolveAgentDir } from "../../agent-scope.js";
+import { withMcpToolMaterialization } from "../../failover-error.js";
 import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import type { AgentSession } from "../../sessions/index.js";
 import {
@@ -96,6 +98,7 @@ export async function runEmbeddedAttempt(
   };
   let emitDiagnosticRunCompleted: EmitDiagnosticRunCompleted | undefined;
   let bundleMcpRuntime: Awaited<ReturnType<typeof materializeBundleMcpToolsForRun>> | undefined;
+  let mcpToolMaterialization: McpToolMaterializationFact | undefined;
   let bundleLspRuntime: Awaited<ReturnType<typeof createBundleLspToolRuntime>> | undefined;
   let toolSearchCatalogRef: ToolSearchCatalogRef | undefined;
   let toolSearchCatalogApplied = false;
@@ -280,6 +283,7 @@ export async function runEmbeddedAttempt(
       { config: params.config },
     );
     bundleMcpRuntime = preparedBundleTools.bundleMcpRuntime;
+    mcpToolMaterialization = preparedBundleTools.mcpToolMaterialization;
     bundleLspRuntime = preparedBundleTools.bundleLspRuntime;
     const { clientTools, uncompactedEffectiveTools } = preparedBundleTools;
     // Catalog preparation registers global run state before tool projection and
@@ -503,6 +507,7 @@ export async function runEmbeddedAttempt(
       return {
         ...executionResult,
         codeModeEngaged: codeModeControlsEnabledForRun,
+        ...(mcpToolMaterialization ? { mcpToolMaterialization } : {}),
         ...(catalogSession
           ? {
               bridgeCalls: {
@@ -538,14 +543,15 @@ export async function runEmbeddedAttempt(
       });
     }
   } catch (error) {
+    const terminalError = withMcpToolMaterialization(error, mcpToolMaterialization);
     const terminalOutcome = buildAgentRunTerminalOutcomeFromAttempt({
       terminal: executionState.terminal,
       abortSignal: params.abortSignal,
     });
     if (terminalOutcome.status === "timeout") {
-      throw new AgentRunTerminalOutcomeError(error, terminalOutcome);
+      throw new AgentRunTerminalOutcomeError(terminalError, terminalOutcome);
     }
-    throw error;
+    throw terminalError;
   } finally {
     const cleanupTerminal = projectAgentRunAttemptTerminal(executionState.terminal);
     const cleanupReason =

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
@@ -212,6 +212,32 @@ describe("terminal resolution", () => {
     ).toEqual({ viewId: "view-latest" });
   });
 
+  it("preserves MCP materialization evidence through terminal cancellation", async () => {
+    const materialization = {
+      provider: "openai",
+      model: "gpt-5.4",
+      materializedToolCount: 1,
+      toolsAllowMatchedToolCount: 0,
+    };
+    const assistant = emptyAssistant({ stopReason: "aborted" });
+    const attempt = makeEmbeddedRunnerAttempt({
+      terminal: { kind: "aborted", source: "external" },
+      lastAssistant: assistant,
+      currentAttemptAssistant: assistant,
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    });
+    attempt.mcpToolMaterialization = materialization;
+
+    const resolved = await resolveEmbeddedRunTerminal(
+      makeTerminalInput({ attempt, attemptAssistant: assistant }),
+    );
+
+    expect(resolved.action).toBe("complete");
+    if (resolved.action === "complete") {
+      expect(resolved.result.mcpToolMaterialization).toEqual(materialization);
+    }
+  });
+
   it("retries a required empty reply even when deliberate silence is enabled", async () => {
     const activateInternalPrompt = vi.fn();
     const input = makeTerminalInput({

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -397,14 +397,13 @@ export async function resolveEmbeddedRunTerminal(input: {
   retryState.compactionContinuationInstruction = null;
 
   if (reasoningOnlyRetriesExhausted && !input.finalAssistantVisibleText) {
-    const incompletePayloadText = "⚠️ Agent couldn't generate a response. Please try again.";
     log.warn(
       `reasoning-only retries exhausted: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
         `provider=${input.activeErrorContext.provider}/${input.activeErrorContext.model} attempts=${retryState.reasoningOnlyAttempts}/${input.maxReasoningOnlyRetryAttempts} — surfacing incomplete-turn error`,
     );
     return surfaceIncompleteTurn({
       ...input,
-      text: incompletePayloadText,
+      text: "⚠️ Agent couldn't generate a response. Please try again.",
       payloadCount: 0,
       incompleteTurnFallbackSafe,
       terminalToolPresentation,
@@ -716,6 +715,7 @@ export function copyAttemptDeliveryState(attempt: EmbeddedRunAttemptResult) {
   return {
     latestMcpAppChannelView: attempt.latestMcpAppChannelView,
     latestMcpConnectAction: attempt.latestMcpConnectAction,
+    mcpToolMaterialization: attempt.mcpToolMaterialization,
     didSendViaMessagingTool: attempt.didSendViaMessagingTool,
     didDeliverSourceReplyViaMessageTool: attempt.didDeliverSourceReplyViaMessageTool === true,
     didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -32,7 +32,7 @@ import type { AuthStorage, ModelRegistry } from "../../sessions/index.js";
 import type { ToolErrorSummary } from "../../tool-error-summary.js";
 import type { NormalizedUsage } from "../../usage.js";
 import type { EmbeddedRunReplayMetadata, EmbeddedRunReplayState } from "../replay-state.js";
-import type { EmbeddedRunLivenessState } from "../types.js";
+import type { EmbeddedRunLivenessState, McpToolMaterializationFact } from "../types.js";
 import type { RunEmbeddedAgentParams } from "./params.js";
 import type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js";
 
@@ -187,6 +187,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
 
 export type EmbeddedRunAttemptResult = {
   terminal: AgentRunAttemptTerminal;
+  /** Exact MCP surface observed after this attempt's explicit tool cap. */
+  mcpToolMaterialization?: McpToolMaterializationFact;
   /** True when the runtime made the authoritative final-assistant transcript decision. */
   assistantTranscriptOwned?: boolean;
   /** Exact idempotency key for the runtime-owned final-assistant transcript row. */

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../config/sessions/types.js";
 import type { DiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import type { AcceptedSessionSpawn } from "../accepted-session-spawn.js";
+import type { McpToolMaterializationFact } from "../agent-bundle-mcp-types.js";
 import type { AgentRunTerminalReceipt } from "../agent-run-terminal-receipt.js";
 import type { AgentRunTerminalReplySnapshot } from "../agent-run-terminal-reply.js";
 import type {
@@ -20,6 +21,8 @@ import type { McpAppChannelView } from "../mcp-ui-resource.js";
 import type { FallbackAttempt } from "../model-fallback.types.js";
 import type { AgentRunTimeoutPhase } from "../run-timeout-attribution.js";
 import type { NormalizedUsage } from "../usage.js";
+
+export type { McpToolMaterializationFact };
 
 export type BlockReplyFlushContext =
   | {
@@ -235,6 +238,7 @@ export type EmbeddedAgentRunMeta = {
 export type EmbeddedAgentRunResult = {
   latestMcpAppChannelView?: McpAppChannelView;
   latestMcpConnectAction?: McpConnectAction;
+  mcpToolMaterialization?: McpToolMaterializationFact;
   payloads?: Array<{
     text?: string;
     mediaUrl?: string;

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { createAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
+import { AgentRunTerminalOutcomeError } from "./agent-run-terminal-error.js";
 import {
   buildFailoverRemediationHint,
   buildProviderReauthCommand,
@@ -11,12 +12,14 @@ import {
   describeFailoverError,
   FailoverError,
   findCliTimeoutError,
+  findMcpToolMaterialization,
   isNonProviderRuntimeCoordinationError,
   isSignalTimeoutReason,
   isTimeoutError,
   resolveFailoverReasonFromError,
   resolveFailoverStatus,
   resolveModelFallbackError,
+  withMcpToolMaterialization,
 } from "./failover-error.js";
 
 // OpenAI 429 example shape: https://help.openai.com/en/articles/5955604-how-can-i-solve-429-too-many-requests-errors
@@ -42,6 +45,42 @@ const OPENAI_SERVER_ERROR_PAYLOAD =
   'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}';
 
 describe("failover-error", () => {
+  it("preserves MCP materialization through timeout and auth wrappers", () => {
+    const materialization = {
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      materializedToolCount: 2,
+      toolsAllowMatchedToolCount: 0,
+    };
+    const enrichedRawError = withMcpToolMaterialization(
+      new Error("HTTP 503: provider unavailable"),
+      materialization,
+    );
+    const nestedFailover = new FailoverError("terminal candidate failed", {
+      reason: "timeout",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      cause: enrichedRawError,
+    });
+    const terminal = new AgentRunTerminalOutcomeError(enrichedRawError, {
+      reason: "hard_timeout",
+      status: "timeout",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+
+    expect(findMcpToolMaterialization(terminal)).toEqual(materialization);
+    expect(
+      coerceToFailoverError(terminal, {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      })?.mcpToolMaterialization,
+    ).toEqual(materialization);
+    expect(
+      coerceToFailoverError(nestedFailover, { authMode: "oauth" })?.mcpToolMaterialization,
+    ).toEqual(materialization);
+  });
+
   it("finds structured CLI timeout context through aggregate wrappers", () => {
     const timeout = new FailoverError("CLI exceeded timeout", {
       reason: "timeout",

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -7,6 +7,7 @@ import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/numb
 import { formatCliCommand } from "../cli/command-format.js";
 import { isAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
 import { collectErrorGraphCandidates, readErrorName } from "../infra/errors.js";
+import type { McpToolMaterializationFact } from "./agent-bundle-mcp-types.js";
 import {
   classifyFailoverSignal,
   extractFailoverSignalDetails,
@@ -58,6 +59,7 @@ export class FailoverError extends Error {
   readonly cliTimeout?: CliTimeoutContext;
   readonly attempts?: readonly FallbackAttemptRecord[];
   readonly soonestCooldownExpiry?: number | null;
+  readonly mcpToolMaterialization?: McpToolMaterializationFact;
 
   constructor(
     message: string,
@@ -78,6 +80,7 @@ export class FailoverError extends Error {
       cliTimeout?: CliTimeoutContext;
       attempts?: readonly FallbackAttemptRecord[];
       soonestCooldownExpiry?: number | null;
+      mcpToolMaterialization?: McpToolMaterializationFact;
     },
   ) {
     super(message, { cause: params.cause });
@@ -97,6 +100,7 @@ export class FailoverError extends Error {
     this.cliTimeout = params.cliTimeout;
     this.attempts = params.attempts;
     this.soonestCooldownExpiry = params.soonestCooldownExpiry;
+    this.mcpToolMaterialization = params.mcpToolMaterialization;
   }
 }
 
@@ -238,6 +242,35 @@ function findErrorProperty<T>(
     findErrorProperty(candidate.error, reader, seen) ??
     findErrorProperty(candidate.cause, reader, seen)
   );
+}
+
+export function findMcpToolMaterialization(err: unknown): McpToolMaterializationFact | undefined {
+  return findErrorProperty(err, (candidate) => {
+    if (!candidate || typeof candidate !== "object") {
+      return undefined;
+    }
+    // SAFETY: only withMcpToolMaterialization and FailoverError construct this internal fact.
+    return (candidate as { mcpToolMaterialization?: McpToolMaterializationFact })
+      .mcpToolMaterialization;
+  });
+}
+
+export function withMcpToolMaterialization(
+  err: unknown,
+  materialization: McpToolMaterializationFact | undefined,
+): unknown {
+  if (!materialization) {
+    return err;
+  }
+  const carrier =
+    err && typeof err === "object" && Object.isExtensible(err)
+      ? err
+      : new Error(String(err), { cause: err });
+  Object.defineProperty(carrier, "mcpToolMaterialization", {
+    configurable: true,
+    value: materialization,
+  });
+  return carrier;
 }
 
 function readDirectStatusCode(err: unknown): number | undefined {
@@ -851,6 +884,7 @@ export function coerceToFailoverError(
         cliTimeout: sourceError.cliTimeout,
         attempts: sourceError.attempts,
         soonestCooldownExpiry: sourceError.soonestCooldownExpiry,
+        mcpToolMaterialization: findMcpToolMaterialization(sourceError),
       });
     }
     return sourceError;
@@ -882,6 +916,7 @@ export function coerceToFailoverError(
     rawError: message,
     cause: err instanceof Error ? err : undefined,
     suspend: shouldSuspend,
+    mcpToolMaterialization: findMcpToolMaterialization(sourceError),
   });
 }
 

--- a/src/agents/model-fallback-attempt.ts
+++ b/src/agents/model-fallback-attempt.ts
@@ -14,6 +14,7 @@ import {
   FailoverError,
   buildFailoverRemediationHint,
   describeFailoverError,
+  findMcpToolMaterialization,
   isFailoverError,
   isNonProviderRuntimeCoordinationError,
   resolveModelFallbackError,
@@ -648,6 +649,7 @@ export function throwFallbackFailureSummary(params: {
     lane: params.attribution?.lane,
     attempts,
     soonestCooldownExpiry: params.soonestCooldownExpiry ?? null,
+    mcpToolMaterialization: findMcpToolMaterialization(params.lastError),
   });
 }
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -22,7 +22,7 @@ import { testing as cliBackendsTesting } from "./cli-backends.test-support.js";
 import { classifyEmbeddedAgentRunResultForModelFallback } from "./embedded-agent-runner/result-fallback-classifier.js";
 import { abortable } from "./embedded-agent-runner/run/abortable.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent-runner/types.js";
-import { FailoverError } from "./failover-error.js";
+import { FailoverError, withMcpToolMaterialization } from "./failover-error.js";
 import { resetFallbackSkipCacheForTest } from "./fallback-skip-cache.test-support.js";
 import {
   AgentHarnessPreflightError,
@@ -2896,6 +2896,55 @@ describe("runWithModelFallback", () => {
       }),
     ).rejects.toThrow("something weird");
     expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the terminal candidate MCP materialization carrier in the all-failed summary", async () => {
+    const terminalMaterialization = {
+      provider: "anthropic",
+      model: "claude-haiku-3-5",
+      materializedToolCount: 2,
+      toolsAllowMatchedToolCount: 0,
+    };
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new FailoverError("primary failed", {
+          reason: "overloaded",
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          mcpToolMaterialization: {
+            provider: "openai",
+            model: "gpt-4.1-mini",
+            materializedToolCount: 1,
+            toolsAllowMatchedToolCount: 1,
+          },
+        }),
+      )
+      .mockRejectedValueOnce(
+        withMcpToolMaterialization(
+          new FailoverError("fallback failed", {
+            reason: "auth",
+            provider: "anthropic",
+            model: "claude-haiku-3-5",
+          }),
+          terminalMaterialization,
+        ),
+      );
+
+    const error = await runWithModelFallback({
+      cfg: makeCfg(),
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(FailoverError);
+    expect(error).toMatchObject({
+      provider: "anthropic",
+      model: "claude-haiku-3-5",
+      mcpToolMaterialization: terminalMaterialization,
+    });
+    expect(run).toHaveBeenCalledTimes(2);
   });
 
   it("treats LiveSessionModelSwitchError as failover on last candidate (#58496 family)", async () => {

--- a/src/cron/isolated-agent/run-delivery-trace.tools-allow.test.ts
+++ b/src/cron/isolated-agent/run-delivery-trace.tools-allow.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { createCronToolsAllowPreflightDiagnostics } from "./run-delivery-trace.js";
+import {
+  createCronMcpToolsAllowDiagnostics,
+  createCronToolsAllowPreflightDiagnostics,
+} from "./run-delivery-trace.js";
 
 const cfg = {
   mcp: {
@@ -86,6 +89,131 @@ describe("configured MCP inherited-cap diagnostics", () => {
     ).resolves.toBeUndefined();
     await expect(
       createCronToolsAllowPreflightDiagnostics({ ...base, agentId: "research" }),
+    ).resolves.toMatchObject({ entries: [expect.objectContaining({ severity: "warn" })] });
+  });
+});
+
+describe("configured MCP explicit-cap diagnostics", () => {
+  const base = {
+    cfg,
+    jobId: "job-explicit-cap",
+    provider: "openai",
+    model: "gpt-5.4",
+    workspaceDir: "/workspace",
+    agentRuntime: "openclaw",
+  };
+
+  it.each([
+    { toolsAllow: ["notes__missing"], materializedName: "nonexistent selector" },
+    { toolsAllow: ["notes__search"], materializedName: "collision-renamed selector" },
+  ])("warns when a $materializedName matched no exposed MCP tool", async ({ toolsAllow }) => {
+    const diagnostics = await createCronMcpToolsAllowDiagnostics({
+      ...base,
+      agentPayload: { kind: "agentTurn", message: "run", toolsAllow },
+      materialization: {
+        provider: "openai",
+        model: "gpt-5.4",
+        materializedToolCount: 1,
+        toolsAllowMatchedToolCount: 0,
+      },
+    });
+
+    expect(diagnostics?.summary).toContain("suppressed every configured MCP tool");
+  });
+
+  it("does not infer selector success without matching terminal materialization evidence", async () => {
+    await expect(
+      createCronMcpToolsAllowDiagnostics({
+        ...base,
+        agentPayload: {
+          kind: "agentTurn",
+          message: "run",
+          toolsAllow: ["notes__missing"],
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not warn when the explicit cap matched before later conversation filtering", async () => {
+    await expect(
+      createCronMcpToolsAllowDiagnostics({
+        ...base,
+        agentPayload: {
+          kind: "agentTurn",
+          message: "run",
+          toolsAllow: ["notes__search"],
+        },
+        materialization: {
+          provider: "openai",
+          model: "gpt-5.4",
+          materializedToolCount: 1,
+          toolsAllowMatchedToolCount: 1,
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("uses static inspection only for an obvious finite cap that cannot start MCP", async () => {
+    const diagnostics = await createCronMcpToolsAllowDiagnostics({
+      ...base,
+      agentPayload: { kind: "agentTurn", message: "run", toolsAllow: ["read"] },
+    });
+
+    expect(diagnostics?.summary).toContain("suppressed every configured MCP tool");
+  });
+
+  it("does not warn for an intentional deny-all cap", async () => {
+    await expect(
+      createCronMcpToolsAllowDiagnostics({
+        ...base,
+        agentPayload: { kind: "agentTurn", message: "run", toolsAllow: [] },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("ignores materialization evidence from a different fallback candidate", async () => {
+    await expect(
+      createCronMcpToolsAllowDiagnostics({
+        ...base,
+        agentPayload: {
+          kind: "agentTurn",
+          message: "run",
+          toolsAllow: ["notes__missing"],
+        },
+        materialization: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          materializedToolCount: 1,
+          toolsAllowMatchedToolCount: 0,
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("applies Codex agent scoping only to the terminal runtime projection", async () => {
+    const agentScopedCfg = {
+      mcp: {
+        servers: {
+          notes: {
+            transport: "stdio",
+            command: "notes-mcp",
+            codex: { agents: ["research"] },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const params = {
+      ...base,
+      cfg: agentScopedCfg,
+      agentRuntime: "codex",
+      agentPayload: { kind: "agentTurn" as const, message: "run", toolsAllow: ["read"] },
+    };
+
+    await expect(
+      createCronMcpToolsAllowDiagnostics({ ...params, agentId: "support" }),
+    ).resolves.toBeUndefined();
+    await expect(
+      createCronMcpToolsAllowDiagnostics({ ...params, agentId: "research" }),
     ).resolves.toMatchObject({ entries: [expect.objectContaining({ severity: "warn" })] });
   });
 });

--- a/src/cron/isolated-agent/run-delivery-trace.ts
+++ b/src/cron/isolated-agent/run-delivery-trace.ts
@@ -1,6 +1,8 @@
 import { resolveStaticSessionMcpServerNames } from "../../agents/agent-bundle-mcp-runtime-config.js";
 import { resolveCodexMcpToolOverridesForAgent } from "../../agents/cli-runner/bundle-mcp-codex.js";
 /** Delivery planning, prompt policy, and delivery trace construction for cron runs. */
+import { shouldCreateBundleMcpRuntimeForAttempt } from "../../agents/embedded-agent-runner/run/attempt-tool-construction-plan.js";
+import type { McpToolMaterializationFact } from "../../agents/embedded-agent-runner/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
   SourceDeliveryOutcome,
@@ -147,6 +149,76 @@ export function buildCronDeliveryTrace(params: {
     fallbackUsed: params.fallbackUsed,
     delivered: params.delivered,
   };
+}
+
+const MCP_TOOLS_ALLOW_SUPPRESSION_WARNING =
+  "This automation's explicit toolsAllow suppressed every configured MCP tool, so no configured MCP tools were exposed. Add bundle-mcp, group:plugins, an exact post-materialization <server>__<tool> selector, or * to the automation's tool cap.";
+
+export async function createCronMcpToolsAllowDiagnostics(params: {
+  cfg: OpenClawConfig;
+  jobId: string;
+  provider: string;
+  model: string;
+  agentId?: string;
+  workspaceDir: string;
+  agentPayload: Extract<CronJob["payload"], { kind: "agentTurn" }> | null;
+  agentRuntime: string;
+  materialization?: McpToolMaterializationFact;
+}): Promise<CronRunDiagnostics | undefined> {
+  const toolsAllow = params.agentPayload?.toolsAllow;
+  if (
+    toolsAllow === undefined ||
+    toolsAllow.length === 0 ||
+    params.agentPayload?.toolsAllowIsDefault === true ||
+    toolsAllow.includes("*")
+  ) {
+    return undefined;
+  }
+  const materialization = params.materialization;
+  if (materialization?.provider === params.provider && materialization.model === params.model) {
+    return materialization.materializedToolCount > 0 &&
+      materialization.toolsAllowMatchedToolCount === 0
+      ? createCronRunDiagnosticsFromError("cron-preflight", MCP_TOOLS_ALLOW_SUPPRESSION_WARNING, {
+          severity: "warn",
+        })
+      : undefined;
+  }
+  if (
+    shouldCreateBundleMcpRuntimeForAttempt({
+      toolsEnabled: true,
+      disableTools: false,
+      toolsAllow,
+    })
+  ) {
+    // Exact/group selectors require the post-materialization fact above. Never
+    // synthesize tool IDs from config to guess whether a selector matched.
+    return undefined;
+  }
+  try {
+    const toolOverrides =
+      params.agentRuntime === "codex"
+        ? resolveCodexMcpToolOverridesForAgent(params.cfg, {
+            agentId: params.agentId,
+            toolOverrides: undefined,
+          })
+        : undefined;
+    const hasEnabledStaticMcp =
+      resolveStaticSessionMcpServerNames({
+        workspaceDir: params.workspaceDir,
+        cfg: params.cfg,
+        toolOverrides,
+      }).length > 0;
+    return hasEnabledStaticMcp
+      ? createCronRunDiagnosticsFromError("cron-preflight", MCP_TOOLS_ALLOW_SUPPRESSION_WARNING, {
+          severity: "warn",
+        })
+      : undefined;
+  } catch (error) {
+    logWarn(
+      `[cron:${params.jobId}] Failed to inspect configured MCP for toolsAllow diagnostics: ${String(error)}`,
+    );
+    return undefined;
+  }
 }
 
 export async function createCronToolsAllowPreflightDiagnostics(params: {

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -34,7 +34,11 @@ import {
 import type { CronDeliveryTrace, CronRunTelemetry } from "../types.js";
 import { resolveCronChannelOutputPolicy } from "./channel-output-policy.js";
 import { resolveCronPayloadOutcome } from "./helpers.js";
-import { buildCronDeliveryTrace, loadCronDeliveryRuntime } from "./run-delivery-trace.js";
+import {
+  buildCronDeliveryTrace,
+  createCronMcpToolsAllowDiagnostics,
+  loadCronDeliveryRuntime,
+} from "./run-delivery-trace.js";
 import type { PreparedCronRunContext } from "./run-prepare.js";
 import {
   adoptCronRunSessionMetadata,
@@ -46,6 +50,7 @@ import {
   deriveSessionTotalTokens,
   hasNonzeroUsage,
   isCliProvider,
+  resolveEffectiveAgentRuntime,
 } from "./run.runtime.js";
 import type { RunCronAgentTurnResult } from "./run.types.js";
 import { cleanupCronRunSessionAfterRun } from "./session-cleanup.js";
@@ -104,6 +109,30 @@ export async function finalizeCronRun(params: {
     finalRunResult.meta?.agentMeta?.provider ??
     execution.fallbackProvider ??
     execution.liveSelection.provider;
+  const terminalProvider = execution.fallbackProvider ?? execution.liveSelection.provider;
+  const terminalModel = execution.fallbackModel ?? execution.liveSelection.model;
+  const terminalMcpDiagnostics = await createCronMcpToolsAllowDiagnostics({
+    cfg: prepared.cfgWithAgentDefaults,
+    jobId: prepared.input.job.id,
+    provider: terminalProvider,
+    model: terminalModel,
+    agentId: prepared.agentId,
+    workspaceDir: prepared.workspaceDir,
+    agentPayload: prepared.agentPayload,
+    agentRuntime: resolveEffectiveAgentRuntime({
+      cfg: prepared.cfgWithAgentDefaults,
+      provider: terminalProvider,
+      modelId: terminalModel,
+      agentId: prepared.agentId,
+      sessionKey: prepared.runSessionKey,
+      sessionEntry: prepared.cronSession.sessionEntry,
+    }),
+    materialization: finalRunResult.mcpToolMaterialization,
+  });
+  const preflightAndMcpDiagnostics = mergeCronRunDiagnostics(
+    prepared.preflightDiagnostics,
+    terminalMcpDiagnostics,
+  );
   const runtimeContextTokens = resolvePositiveContextTokens(
     finalRunResult.meta?.agentMeta?.contextTokens,
   );
@@ -298,6 +327,11 @@ export async function finalizeCronRun(params: {
   } else {
     telemetry = { model: modelUsed, provider: providerUsed };
   }
+  const terminalTelemetry: CronRunTelemetry = {
+    ...telemetry,
+    model: terminalModel,
+    provider: terminalProvider,
+  };
   await prepared.persistSessionEntry();
   await prepared.runContinuationSession?.seal({ basePersisted: true });
 
@@ -306,11 +340,11 @@ export async function finalizeCronRun(params: {
       status: "error",
       error: params.abortReason(),
       diagnostics: mergeCronRunDiagnostics(
-        prepared.preflightDiagnostics,
+        preflightAndMcpDiagnostics,
         createCronRunDiagnosticsFromAgentResult(finalRunResult, { finalStatus: "error" }),
         createCronRunDiagnosticsFromError("cron-setup", params.abortReason()),
       ),
-      ...telemetry,
+      ...terminalTelemetry,
     });
   }
   const cronPayloadOutcome = resolveCronPayloadOutcome({
@@ -332,11 +366,11 @@ export async function finalizeCronRun(params: {
       status: "error",
       error,
       diagnostics: mergeCronRunDiagnostics(
-        prepared.preflightDiagnostics,
+        preflightAndMcpDiagnostics,
         createCronRunDiagnosticsFromAgentResult(finalRunResult, { finalStatus: "error" }),
         createCronRunDiagnosticsFromError("agent-run", error),
       ),
-      ...telemetry,
+      ...terminalTelemetry,
     });
   }
   const {
@@ -361,7 +395,7 @@ export async function finalizeCronRun(params: {
   const agentDiagnostics = createCronRunDiagnosticsFromAgentResult(finalRunResult, {
     finalStatus: hasFatalErrorPayload ? "error" : "ok",
   });
-  const runDiagnostics = mergeCronRunDiagnostics(prepared.preflightDiagnostics, agentDiagnostics);
+  const runDiagnostics = mergeCronRunDiagnostics(preflightAndMcpDiagnostics, agentDiagnostics);
   const resolveRunOutcome = (result?: {
     delivered?: boolean;
     deliveryAttempted?: boolean;
@@ -391,7 +425,7 @@ export async function finalizeCronRun(params: {
           ? createCronRunDiagnosticsFromError("delivery", result.deliveryError)
           : undefined,
       ),
-      ...telemetry,
+      ...terminalTelemetry,
     });
   const failPendingPresentationWarningUnlessDelivered = (delivered?: boolean) => {
     if (pendingPresentationWarningError && delivered !== true) {
@@ -471,7 +505,7 @@ export async function finalizeCronRun(params: {
         runDiagnostics,
         createCronRunDiagnosticsFromError("agent-run", error),
       ),
-      ...telemetry,
+      ...terminalTelemetry,
     });
   }
   if (hasFatalStructuredErrorPayload && prepared.deliveryRequested) {
@@ -522,7 +556,7 @@ export async function finalizeCronRun(params: {
     ttsAuto: prepared.cronSession.sessionEntry.ttsAuto,
     summary,
     outputText,
-    telemetry,
+    telemetry: terminalTelemetry,
     abortSignal: prepared.input.abortSignal ?? prepared.input.signal,
     isAborted: params.isAborted,
     abortReason: params.abortReason,

--- a/src/cron/isolated-agent/run.tools-allow.test.ts
+++ b/src/cron/isolated-agent/run.tools-allow.test.ts
@@ -1,7 +1,10 @@
 // Tool allowlist tests cover tool availability for isolated cron runs.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "../../agents/test-helpers/fast-coding-tools.js";
+import { FailoverError, withMcpToolMaterialization } from "../../agents/failover-error.js";
+import { throwFallbackFailureSummary } from "../../agents/model-fallback-attempt.js";
 import {
+  runFallbackModelAttempt,
   runInitialModelFallbackAttempt,
   type TestModelFallbackRunnerParams,
 } from "../../agents/test-helpers/model-fallback-runner.test-support.js";
@@ -400,6 +403,98 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
         MISSING_WEB_SEARCH_PROVIDER_DIAGNOSTIC_MESSAGE,
         "cron isolated agent run aborted",
       ]);
+    },
+  );
+
+  it(
+    "uses the terminal fallback candidate when agent metadata reports a CLI alias",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      runEmbeddedAgentMock.mockImplementation(async (request) => ({
+        payloads: [{ text: "fallback ok" }],
+        meta: {
+          agentMeta: {
+            provider: request.model === "gpt-5" ? "openai-cli" : request.provider,
+            model: request.model,
+          },
+        },
+        mcpToolMaterialization: {
+          provider: request.provider,
+          model: request.model,
+          materializedToolCount: 1,
+          toolsAllowMatchedToolCount: request.model === "gpt-5" ? 0 : 1,
+        },
+      }));
+      runWithModelFallbackMock.mockImplementation(async (params: TestModelFallbackRunnerParams) => {
+        await runInitialModelFallbackAttempt(params);
+        const result = await runFallbackModelAttempt(params, "openai", "gpt-5", "unknown");
+        return { result, provider: "openai", model: "gpt-5", attempts: [] };
+      });
+
+      const result = await runCronIsolatedAgentTurn(makeParamsWithToolsAllow(["notes__missing"]));
+
+      expect(result.status).toBe("ok");
+      expect(result.provider).toBe("openai");
+      expect(result.model).toBe("gpt-5");
+      expect(result.diagnostics?.summary).toContain("suppressed every configured MCP tool");
+    },
+  );
+
+  it(
+    "persists one exact-selector MCP warning when all fallback candidates fail",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      const terminalError = withMcpToolMaterialization(
+        new FailoverError("post-materialization setup failed", {
+          reason: "auth",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+        }),
+        {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          materializedToolCount: 2,
+          toolsAllowMatchedToolCount: 0,
+        },
+      );
+      runWithModelFallbackMock.mockImplementation(async () =>
+        throwFallbackFailureSummary({
+          attempts: [
+            {
+              reason: "overloaded",
+              provider: "openai",
+              model: "gpt-5.4",
+              error: "primary candidate failed",
+            },
+            {
+              reason: "auth",
+              provider: "anthropic",
+              model: "claude-sonnet-4-6",
+              error: "terminal candidate failed",
+            },
+          ],
+          candidates: [
+            { provider: "openai", model: "gpt-5.4" },
+            { provider: "anthropic", model: "claude-sonnet-4-6" },
+          ],
+          lastError: terminalError,
+          label: "models",
+          formatAttempt: (attempt) => `${attempt.provider}/${attempt.model}: ${attempt.error}`,
+        }),
+      );
+
+      const result = await runCronIsolatedAgentTurn(makeParamsWithToolsAllow(["notes__missing"]));
+
+      expect(result).toMatchObject({
+        status: "error",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      });
+      expect(
+        result.diagnostics?.entries.filter((entry) =>
+          entry.message.includes("suppressed every configured MCP tool"),
+        ),
+      ).toHaveLength(1);
     },
   );
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,4 +1,5 @@
 import { retireSessionMcpRuntime } from "../../agents/agent-bundle-mcp-tools.js";
+import { findMcpToolMaterialization, isFailoverError } from "../../agents/failover-error.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import { cleanupBrowserSessionsForLifecycleEnd } from "../../browser-lifecycle-cleanup.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
@@ -32,10 +33,11 @@ import type {
   CronAgentExecutionStarted,
   CronStoredJob,
 } from "../types.js";
+import { createCronMcpToolsAllowDiagnostics } from "./run-delivery-trace.js";
 import { finalizeCronRun } from "./run-finalize.js";
 import { prepareCronRunContext } from "./run-prepare.js";
 import { CronSessionLifecycleClaimError, type MutableCronSession } from "./run-session-state.js";
-import { logWarn } from "./run.runtime.js";
+import { logWarn, resolveEffectiveAgentRuntime } from "./run.runtime.js";
 import type { RunCronAgentTurnResult } from "./run.types.js";
 import { cleanupCronRunSessionAfterRun } from "./session-cleanup.js";
 
@@ -292,6 +294,32 @@ export async function runCronIsolatedAgentTurn(params: {
     const error = isCronLaneTimeout ? abortReason() : normalizeCronRunErrorText(err);
     outcome = "error";
     outcomeError = error;
+    const terminalProvider =
+      (isFailoverError(err) ? err.provider : undefined) ??
+      prepared.context.cronSession.sessionEntry.modelProvider ??
+      prepared.context.liveSelection.provider;
+    const terminalModel =
+      (isFailoverError(err) ? err.model : undefined) ??
+      prepared.context.cronSession.sessionEntry.model ??
+      prepared.context.liveSelection.model;
+    const terminalMcpDiagnostics = await createCronMcpToolsAllowDiagnostics({
+      cfg: prepared.context.cfgWithAgentDefaults,
+      jobId: params.job.id,
+      provider: terminalProvider,
+      model: terminalModel,
+      agentId: prepared.context.agentId,
+      workspaceDir: prepared.context.workspaceDir,
+      agentPayload: prepared.context.agentPayload,
+      agentRuntime: resolveEffectiveAgentRuntime({
+        cfg: prepared.context.cfgWithAgentDefaults,
+        provider: terminalProvider,
+        modelId: terminalModel,
+        agentId: prepared.context.agentId,
+        sessionKey: prepared.context.runSessionKey,
+        sessionEntry: prepared.context.cronSession.sessionEntry,
+      }),
+      materialization: findMcpToolMaterialization(err),
+    });
     return prepared.context.withRunSession({
       status: "error",
       error,
@@ -308,10 +336,11 @@ export async function runCronIsolatedAgentTurn(params: {
       // Task-run history keeps provider/model attribution instead of looking like
       // an un-attributed cron timeout. finalizeCronRun does the same via
       // telemetry on the aborted path; this catch never reaches it.
-      provider: prepared.context.liveSelection.provider,
-      model: prepared.context.liveSelection.model,
+      provider: terminalProvider,
+      model: terminalModel,
       diagnostics: mergeCronRunDiagnostics(
         prepared.context.preflightDiagnostics,
+        terminalMcpDiagnostics,
         createCronRunDiagnosticsFromError(
           isCronLaneTimeout ? "cron-setup" : "agent-run",
           isCronLaneTimeout ? error : err,


### PR DESCRIPTION
Supersedes #121797.

Credit: @Grynn identified the missing cron diagnostic and authored the original PR. This replacement preserves Grynn's co-author attribution while replacing the blocked synthetic-selector design.

## What Problem This Solves

An explicit automation `toolsAllow` cap could suppress every configured MCP tool without producing a warning. The old design inferred selector success from synthetic/static tool IDs, so nonexistent exact selectors and collision-renamed IDs could suppress the warning even when zero MCP tools reached the model.

## Design

The run now captures one bounded fact immediately after the explicit tool cap and before LSP setup, conversation policy, provider/schema projection, or Codex approval filtering: terminal provider/model, total materialized MCP tools, and matched MCP tools. Each post-materialization setup owner attaches the fact to its original terminal error after best-effort one-shot cleanup. The fact then follows terminal results/errors through internal retries, timeout/cancellation replacement, fallback candidates, all-failed `FailoverError` summaries, and CLI aliases. Cron diagnostics consume it only when its provider/model match the terminal candidate. Static preflight remains only for obvious finite caps that cannot start MCP; exact/group selectors never use fabricated IDs.

Codex naming is a separate provider projection. Codex 0.149.1 reserves exactly the case-sensitive lowercase names `mcp` and `mcp__*`. Those names receive collision-safe protocol aliases. Valid `mcp_`, `MCP`, `MCP__read`, generic names, and all non-Codex tool identities remain unchanged. Available/model and registered/app projections share one allocator, while execution resolves back to the original source name.

## Frozen Patch

- Head: `15b8d730f47aa88e5891dd7cf4356d724d55a8b5`
- Patch parent / reviewed base: `8c1c1f8c8f5024756fc0d1a7170e1f05695db1c4`
- Tree: `c1bdb52911955e3cd16ea7e95e120aee6547cf5e`
- Diff: 30 files; production +462/-100; tests/live proof +872/-44
- Current-main integration check: `d4be12917ca40b0e5dc34d1ddc651ad8fefd3e74` has zero changed-path overlap and a conflict-free merge tree; the reviewed base was retained instead of rebasing solely for behind status.

## Evidence

- Focused owner/regression suite: 521/521 passed across Codex projection and attempt failures, MCP materialization, post-materialization generic/LSP/Codex setup errors, embedded retry/timeout/cancellation, fallback summaries, CLI alias attribution, and cron persistence.
- Exact-head `pnpm check:changed`: passed (format, typecheck, lint, boundaries, dead exports, import cycles, database and repository guards).
- Exact-head `pnpm build`: passed; only existing dependency `eval` and ineffective dynamic-import warnings.
- Secretless real Codex proof: `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_CODEX_MCP_MATERIALIZATION=1 pnpm exec vitest run extensions/codex/src/app-server/mcp-materialization.real-binary.live.test.ts --config test/vitest/vitest.live.config.ts` — 1/1 passed. A real stdio MCP server materializes three tools; the generic non-Codex control executes successfully; real `codex-cli 0.149.1` accepts `mcp_` unchanged and projected aliases, while raw `mcp` and `mcp__show` are rejected as reserved.
- Authoritative Codex source: sibling checkout tag `rust-v0.149.1`, peeled `ff29a44391deccde0aba0f8390337d7f3c319ea4`, `codex-rs/app-server/src/request_processors/thread_processor.rs`; both exact checks are `name == "mcp" || name.starts_with("mcp__")`.
- Fresh exact-head autoreview: clean, no accepted/actionable P0-P2 findings (overall correctness 0.91). Its prior in-scope P2 found the LSP-initialization gap; the final head moves the bounded fact before LSP setup and adds an owner regression.
- Fresh test audit: each regression protects an observable owner/fallback/cron contract and a credible pre-fix failure; no test-only production seam or weaker duplicate replacement coverage was added.
- Own exact-head source/diff review: no remaining actionable finding; `git diff --check` passed and the worktree is clean.

Regression coverage includes nonexistent selectors, collision-renamed exact selectors, intentional deny-all caps, lowercase reserved names, `mcp_` and uppercase compatibility, explicit-cap timing, post-materialization generic/LSP/Codex setup errors, fallback/CLI attribution, and timeout/cancellation preservation.

AI-assisted development disclosure: implementation, tests, and review were produced with Amp/Codex assistance under maintainer direction and verified with the commands above.
