### PR TITLE
test(packages): remove redundant no-throw assertions

### DIFF
--- a/packages/ai/src/utils/deferred-event-buffer.test.ts
+++ b/packages/ai/src/utils/deferred-event-buffer.test.ts
@@ -32,11 +32,6 @@ describe("createDeferredEventBuffer", () => {
     expect(onEvent).toHaveBeenCalledTimes(2);
   });
 
-  it("does not throw when onBufferedEvent is not provided", () => {
-    const buffer = createDeferredEventBuffer({ push() {} });
-    expect(() => buffer.push("a")).not.toThrow();
-  });
-
   it("allows push after flush to start a new buffer", () => {
     const sink = { push: vi.fn() };
     const buffer = createDeferredEventBuffer(sink);

--- a/packages/gateway-client/src/protocol-client.socket-factory.test.ts
+++ b/packages/gateway-client/src/protocol-client.socket-factory.test.ts
@@ -397,7 +397,7 @@ describe("GatewayClient socket factory recovery", () => {
       hostDeps: { beforeConnect },
     });
 
-    expect(() => client.start()).not.toThrow();
+    client.start();
     expect(onConnectError).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({ message: expect.stringContaining(expectedMessage) }),
     );

--- a/packages/sdk/src/event-hub.test.ts
+++ b/packages/sdk/src/event-hub.test.ts
@@ -12,7 +12,7 @@ describe("EventHub subscriber ownership", () => {
     const failedRead = failed.next();
     const healthyRead = healthy.next();
 
-    expect(() => hub.publish("first")).not.toThrow();
+    hub.publish("first");
     await expect(failedRead).rejects.toThrow("subscriber filter failed");
     await expect(healthyRead).resolves.toEqual({ done: false, value: "first" });
 


### PR DESCRIPTION
## What Problem This Solves

Three package tests carried assertion ceremony that did not own distinct behavior: one callback-absence `not.toThrow()` test was strictly subsumed by normal push/flush/discard cases, and two call-level `not.toThrow()` wrappers repeated what stronger subsequent outcome assertions already prove.

## Why This Change Was Made

- remove the standalone deferred-buffer callback-absence test; multiple retained callback-free cases already push, flush, discard, and restart buffers
- invoke `EventHub.publish()` directly before asserting the failed stream rejects, the healthy stream receives the event, and future events continue flowing
- invoke `GatewayClient.start()` directly before asserting the exact terminal error, no host connection attempt, no retry, and no timer
- keep production code and runtime behavior unchanged

## User Impact

None at runtime. Package tests retain their behavioral contracts with less assertion-only noise.

## Evidence

- baseline focused suites: 33 tests passed (AI 6, SDK 6, Gateway Client 21)
- rebased post-change focused suites: 32 tests passed (AI 5, SDK 6, Gateway Client 21)
- `node scripts/check-changed.mjs -- packages/ai/src/utils/deferred-event-buffer.test.ts packages/sdk/src/event-hub.test.ts packages/gateway-client/src/protocol-client.socket-factory.test.ts` — passed on the rebased head
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean on the rebased head; no accepted/actionable findings
- `git diff --check origin/main...HEAD` — passed
