### PR TITLE
fix(line): preserve quick replies after rejected rich messages

### DIFF
--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -371,6 +371,10 @@ export async function deliverLineAutoReply(params: {
     if (canRetryTextOnly) {
       // HTTPFetchError 400 is an actual LINE response: that request was rejected
       // atomically. Retry its text/actions plus the tail that was never attempted.
+      const lastRetryMessage = retryMessages.at(-1);
+      if (quickRepliesNeedCarrier && lastRetryMessage && !lastRetryMessage.quickReply) {
+        lastRetryMessage.quickReply = deps.createQuickReplyItems(lineData.quickReplies!);
+      }
       try {
         await sendLineMessages(retryMessages, false);
       } catch {

--- a/extensions/line/src/row-overflow-delivery.loopback.test.ts
+++ b/extensions/line/src/row-overflow-delivery.loopback.test.ts
@@ -2,8 +2,12 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { chunkMarkdownText } from "openclaw/plugin-sdk/reply-runtime";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginRuntime } from "../api.js";
+import { deliverLineAutoReply } from "./auto-reply-delivery.js";
+import { baseDeliveryParams, createDeps } from "./auto-reply-delivery.test-helpers.js";
+import { processLineMessage } from "./markdown-to-line.js";
 import { lineOutboundAdapter } from "./outbound.js";
 import { setLineRuntime } from "./runtime.js";
+import { createQuickReplyItems, pushMessagesLine } from "./send.js";
 
 type WireMessage = { type: string; text?: string; altText?: string };
 
@@ -164,6 +168,16 @@ describe("Row-overflow table delivery through production outbound adapter over l
         body,
       };
       requests.push(record);
+
+      if (
+        url.pathname === "/v2/bot/message/push" &&
+        body.to === "UtestAutoReplyRecovery" &&
+        body.messages.some((message) => message.type === "flex")
+      ) {
+        response.writeHead(400, { "content-type": "application/json" });
+        response.end(JSON.stringify({ message: "invalid rich message" }));
+        return;
+      }
 
       if (url.pathname === "/v2/bot/message/push" || url.pathname === "/v2/bot/message/reply") {
         response.writeHead(200, { "content-type": "application/json" });
@@ -374,6 +388,57 @@ describe("Row-overflow table delivery through production outbound adapter over l
         quickReply: { items: [{ action: { label: "Continue", text: "Continue" } }] },
       },
     ]);
+  });
+
+  it("preserves quick replies when LINE rejects the final Markdown card", async () => {
+    const { deps } = createDeps({
+      processLineMessage,
+      chunkMarkdownText,
+      pushMessagesLine,
+      createQuickReplyItems,
+    });
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      cfg: LINE_TEST_CFG,
+      accountId: "default",
+      to: "line:user:UtestAutoReplyRecovery",
+      replyToken: undefined,
+      payload: { text: "Choose one\n\n```js\nfirst()\n```" },
+      lineData: { quickReplies: ["Continue"] },
+      deps,
+    });
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0]).toMatchObject({
+      path: "/v2/bot/message/push",
+      body: {
+        to: "UtestAutoReplyRecovery",
+        messages: [
+          { type: "text", text: "Choose one" },
+          {
+            type: "flex",
+            altText: "Code",
+            quickReply: { items: [{ action: { label: "Continue", text: "Continue" } }] },
+          },
+        ],
+      },
+    });
+    expect(requests[1]).toMatchObject({
+      path: "/v2/bot/message/push",
+      body: {
+        to: "UtestAutoReplyRecovery",
+        messages: [
+          {
+            type: "text",
+            text: "Choose one",
+            quickReply: { items: [{ action: { label: "Continue", text: "Continue" } }] },
+          },
+        ],
+      },
+    });
+    expect(recordChannelActivityMock).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({ status: "partial", visibleReplySent: true });
   });
 
   it("carries a valid Bearer token and recipient through the production outbound adapter", async () => {


### PR DESCRIPTION
## Summary

Preserve LINE quick-reply actions when a definitively rejected rich automatic reply is recovered as text. The rejected Flex card previously owned the actions; filtering the card silently dropped them even though LINE accepted the recovered message.

Closes #130075

## Root cause

The existing LINE automatic-reply recovery owner correctly retries only after an authoritative provider HTTP 400, but it selects surviving text without transferring quick replies from the rejected final Flex message. The accepted retry therefore contains readable text but no user actions.

## What changed

- Move the original quick replies onto the final surviving text only inside the existing definitive-HTTP-400 recovery gate, and preserve any quick replies already present.
- Add a real localhost LINE transport regression: the provider physically rejects the mixed push with HTTP 400, accepts the text-only retry with HTTP 200, and records exactly one successful delivery.
- Keep ambiguous transport failures, HTTP 408/429/503, partial delivery, existing source ordering, reply-token behavior, and five-message batching unchanged.
- Production delta: +4 lines in the existing recovery owner; test delta: +65 lines.

## Verification

- Pre-fix real HTTP regression: first rejected request contains text plus a Flex card with quick replies; the second accepted text-only request loses those actions.
- Post-fix: the accepted text carries the same quick replies, and exactly one provider delivery is recorded.
- Five LINE owner and recovery suites: 141 tests passed.
- Independent real-HTTP and non-replay verification: 38 tests passed.
- Extension test typechecking and project lint passed.
- Independent full-branch and frozen source-only reviews passed.
