### PR TITLE
refactor(shared): reuse listener notification helper

### DIFF
--- a/src/shared/tool-activity-heartbeat.ts
+++ b/src/shared/tool-activity-heartbeat.ts
@@ -1,4 +1,5 @@
 import { resolveGlobalSingleton } from "./global-singleton.js";
+import { notifyListeners } from "./listeners.js";
 
 const { runListeners, runLastActivityMs } = resolveGlobalSingleton(
   Symbol.for("openclaw.toolActivityHeartbeat"),
@@ -8,13 +9,7 @@ const { runListeners, runLastActivityMs } = resolveGlobalSingleton(
   }),
   (state) => {
     for (const listeners of state.runListeners.values()) {
-      for (const listener of listeners) {
-        try {
-          listener();
-        } catch {
-          // Shutdown wakeups are best-effort; one observer cannot strand the rest.
-        }
-      }
+      notifyListeners(listeners, undefined);
     }
     state.runListeners.clear();
     state.runLastActivityMs.clear();


### PR DESCRIPTION
## What Problem This Solves

The tool-activity heartbeat lifecycle reset carried its own seven-line best-effort listener notification loop even though `src/shared/listeners.ts` already owns the same ordered, failure-isolated notification behavior. Keeping both private paths made shutdown semantics easier to drift.

## Why This Change Was Made

Reuse the existing `notifyListeners` helper for shutdown wakeups, preserving Set iteration order, per-listener exception isolation, subsequent-listener delivery, map cleanup order, and all ordinary `notifyToolActivity` behavior. The ordinary notification path intentionally remains direct because its thrown-listener behavior is distinct.

Production LOC: +2/-7 (net -5) | Tests: +0/-0. No new helper, dependency, config, public API, or compatibility behavior.

## User Impact

No user-visible behavior changes. Tool-activity shutdown now uses the same private listener notification owner as other core event surfaces.

## Evidence

Exact reviewed head: `7a2106a134b00e4ed1471cd1924721c9754421db`

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/tool-activity-heartbeat.test.ts src/shared/global-singleton.test.ts` — 25/25 tests passed.
- `node scripts/check-changed.mjs -- src/shared/tool-activity-heartbeat.ts` — passed the full changed-file gate, including formatting, dead-export scan, core/core-test typechecks, lint, import cycles, and safeguard checks.
- Diff-scoped deslop: clean; no changes required.
- Structured autoreview: clean, no accepted/actionable findings.
- Separate exact-head read-only Codex review: clean, no actionable findings after full owner-path/helper/caller/adjacent-test inspection.
- Test audit: no new test added because this is a behavior-preserving substitution by the already canonical helper; a refactor-coupled test would duplicate helper semantics and would not distinguish the old implementation.

