### PR TITLE
test(memory): consolidate session archive fixtures

### DIFF
--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -296,28 +296,17 @@ describe("listSessionTranscriptCorpusEntriesForAgent", () => {
         updateMode: "none",
       },
     );
-    const archivePath = path.join(
-      sessionsDir,
-      `${sessionId}.jsonl.deleted.2026-06-25T12-01-00.000Z`,
-    );
-    fsSync.writeFileSync(
-      archivePath,
-      JSON.stringify({
-        type: "message",
-        message: { role: "user", content: "Archived JSONL transcript text" },
-      }),
-    );
-    const resetArchivePath = path.join(
-      sessionsDir,
-      `${sessionId}.jsonl.reset.2026-06-25T12-02-00.000Z`,
-    );
-    fsSync.writeFileSync(
-      resetArchivePath,
-      JSON.stringify({
-        type: "message",
-        message: { role: "user", content: "Retained pre-reset conversation fact" },
-      }),
-    );
+    const [archivePath, resetArchivePath] = [
+      ["deleted.2026-06-25T12-01-00.000Z", "Archived JSONL transcript text"],
+      ["reset.2026-06-25T12-02-00.000Z", "Retained pre-reset conversation fact"],
+    ].map(([suffix, content]) => {
+      const filePath = path.join(sessionsDir, `${sessionId}.jsonl.${suffix}`);
+      fsSync.writeFileSync(
+        filePath,
+        JSON.stringify({ type: "message", message: { role: "user", content } }),
+      );
+      return filePath;
+    });
 
     expect(fsSync.existsSync(path.join(sessionsDir, `${sessionId}.jsonl`))).toBe(false);
     const entries = await listSessionTranscriptCorpusEntriesForAgent("main");
@@ -348,22 +337,15 @@ describe("listSessionTranscriptCorpusEntriesForAgent", () => {
       ]),
     );
 
-    const liveEntry = requireSessionEntry(
-      await buildSessionEntry(sessionKey, {
-        agentId: "main",
-        sessionId,
-        sessionKey,
-        storePath,
-        updatedAtMs: updatedAt,
-      }),
-    );
-    const liveState = statSessionEntrySync(sessionKey, {
+    const liveIdentity = {
       agentId: "main",
       sessionId,
       sessionKey,
       storePath,
       updatedAtMs: updatedAt,
-    });
+    };
+    const liveEntry = requireSessionEntry(await buildSessionEntry(sessionKey, liveIdentity));
+    const liveState = statSessionEntrySync(sessionKey, liveIdentity);
     const archiveEntry = requireSessionEntry(await buildSessionEntry(archivePath));
     const resetArchiveEntry = requireSessionEntry(await buildSessionEntry(resetArchivePath));
 

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -296,17 +296,22 @@ describe("listSessionTranscriptCorpusEntriesForAgent", () => {
         updateMode: "none",
       },
     );
-    const [archivePath, resetArchivePath] = [
-      ["deleted.2026-06-25T12-01-00.000Z", "Archived JSONL transcript text"],
-      ["reset.2026-06-25T12-02-00.000Z", "Retained pre-reset conversation fact"],
-    ].map(([suffix, content]) => {
+    const createArchive = (suffix: string, content: string): string => {
       const filePath = path.join(sessionsDir, `${sessionId}.jsonl.${suffix}`);
       fsSync.writeFileSync(
         filePath,
         JSON.stringify({ type: "message", message: { role: "user", content } }),
       );
       return filePath;
-    });
+    };
+    const archivePath = createArchive(
+      "deleted.2026-06-25T12-01-00.000Z",
+      "Archived JSONL transcript text",
+    );
+    const resetArchivePath = createArchive(
+      "reset.2026-06-25T12-02-00.000Z",
+      "Retained pre-reset conversation fact",
+    );
 
     expect(fsSync.existsSync(path.join(sessionsDir, `${sessionId}.jsonl`))).toBe(false);
     const entries = await listSessionTranscriptCorpusEntriesForAgent("main");


### PR DESCRIPTION
## What Problem This Solves

Current main fails its required check-lint job because the memory-host session-file owner test grew to 1,008 counted source lines, exceeding the unchanged 1,000-line ESLint maximum after valuable retained-session recall coverage was added.

## Why This Change Was Made

Keep both deleted and reset transcript archive fixtures, every assertion, and every existing test. Build the two equivalent archive records from one small fixture table and reuse the identical session identity already passed to both owner operations.

## User Impact

None. This change touches one test file only. No production code, session behavior, persistence, migrations, security boundaries, lint thresholds, or configuration changes.

## Evidence

- Reproduced current main failure exactly: `eslint(max-lines): File has too many lines (1008); Maximum allowed is 1000`.
- Actual configured type-aware owner check now passes: `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json packages/memory-host-sdk/src/host/session-files.test.ts`.
- All 40 real session owner tests passed before and after the cleanup.
- Two independent source audits proved all five suites, all 39 test declarations, and all 80 assertion expressions remain identical.
- Conflict-marker, max-lines-ratchet, assertion-safety-ratchet, formatting, and exact type-aware owner lint checks passed.
- The source diff is test-only: +15/-33, or 18 fewer test lines; production source is unchanged.
- Structured authenticated precommit review reported no actionable findings.
- The full delegated changed-file check could not start because Testbox targeted and fallback checkout synchronization timed out before executing any check. Exact-head hosted CI with a fresh checkout is the authoritative full-environment validation.
