### PR TITLE
fix(channels): preserve durable retries after reply abandonment

### DIFF
--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -336,10 +336,10 @@ describe("createTelegramIngressMonitor", () => {
             {
               id: eventId,
               attempts: 0,
-              lastError: "turn-abandoned",
             },
           ]),
         );
+        expect((await queue.listPending({ limit: "all" }))[0]?.lastError).toBeUndefined();
         expect((await queue.enqueue(eventId, payload, { laneKey })).kind).not.toBe("completed");
       });
     },
@@ -378,9 +378,10 @@ describe("createTelegramIngressMonitor", () => {
 
       await vi.waitFor(async () =>
         expect(await queue.listPending({ limit: "all" })).toMatchObject([
-          { id: eventId, attempts: 0, lastError: "turn-abandoned" },
+          { id: eventId, attempts: 0 },
         ]),
       );
+      expect((await queue.listPending({ limit: "all" }))[0]?.lastError).toBeUndefined();
       expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
     });
   });
@@ -427,10 +428,10 @@ describe("createTelegramIngressMonitor", () => {
           {
             id: eventId,
             attempts: 0,
-            lastError: "turn-abandoned",
           },
         ]),
       );
+      expect((await queue.listPending({ limit: "all" }))[0]?.lastError).toBeUndefined();
       expect((await queue.enqueue(eventId, payload, { laneKey })).kind).not.toBe("completed");
     });
   });

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -248,8 +248,9 @@ function canReconcileTelegramLegacyLane(params: {
 
 export type TelegramIngressDrainLifecycle = Omit<
   ChannelIngressMonitorLifecycle,
-  "admission" | "onFailed"
+  "admission" | "onCancelled" | "onFailed"
 > & {
+  onCancelled: () => void | Promise<void>;
   onFailed: (error: unknown) => void | Promise<void>;
 };
 
@@ -339,8 +340,8 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
         ),
     },
     deliver: async (update, lifecycle) => {
-      // The monitor always supplies onFailed; the optional public field preserves
-      // structural compatibility for channel lifecycles that never use deferred failure.
+      // The monitor supplies both optional callbacks; public lifecycle fields
+      // stay optional for channel implementations that do not consume them.
       const telegramLifecycle = lifecycle as TelegramIngressDrainLifecycle;
       try {
         const result = await runWithTelegramSpooledReplayUpdate(
@@ -390,7 +391,7 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
               await telegramLifecycle.onFailed(error);
               return;
             }
-            await telegramLifecycle.onAbandoned();
+            await telegramLifecycle.onCancelled();
           };
           // Two-arg then: the rejection arm must observe only a participant.task
           // rejection. Chaining it as .catch would also swallow onFailed/onAdopted

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -157,13 +157,13 @@ describe("channel ingress drain", () => {
       expect(await queue.listClaims()).toHaveLength(1);
       expect(await queue.listPending()).toEqual([]);
 
-      // Abandon loses ownership before delivery; replay must not spend an attempt.
+      // Genuine pre-adoption abandonment records a retryable delivery attempt.
       await expectDefined(capturedLifecycles[0], "deferred lifecycle").onAbandoned();
       await drain.waitForIdle();
       await vi.waitFor(async () => {
         const pending = await queue.listPending();
         expect(pending).toHaveLength(1);
-        expect(pending[0]?.attempts).toBe(0);
+        expect(pending[0]?.attempts).toBe(1);
       });
       drain.dispose();
     });
@@ -461,7 +461,7 @@ describe("channel ingress drain", () => {
     });
   });
 
-  it("abandoned via turnAdoptionLifecycle releases claim without an attempt", async () => {
+  it("abandoned reply ownership releases claim with an attempt", async () => {
     await withTempState(async (stateDir) => {
       const queue = createTestIngressQueue(stateDir);
       await queue.enqueue("evt-q", { text: "x" }, { laneKey: "l1" });
@@ -481,7 +481,7 @@ describe("channel ingress drain", () => {
       await vi.waitFor(async () => {
         const pending = await queue.listPending();
         expect(pending).toHaveLength(1);
-        expect(pending[0]?.attempts).toBe(0);
+        expect(pending[0]?.attempts).toBe(1);
         expect(pending[0]?.lastError).toBe("turn-abandoned");
       });
       drain.dispose();
@@ -680,7 +680,7 @@ describe("channel ingress drain", () => {
     });
   });
 
-  it("does not spend retry attempts on repeated abandonment", async () => {
+  it("keeps retry-accounted abandonment pending beyond the failure threshold", async () => {
     await withTempState(async (stateDir) => {
       let clock = 1;
       const queue = createTestIngressQueue(stateDir, { now: () => clock });
@@ -705,7 +705,7 @@ describe("channel ingress drain", () => {
       expect(await queue.listPending()).toEqual([
         expect.objectContaining({
           id: "abandoned",
-          attempts: 0,
+          attempts: 3,
           lastError: "turn-abandoned",
         }),
       ]);

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -507,10 +507,7 @@ export function createChannelIngressDrain<
         await releaseUnadopted(state, { recordAttempt: false });
       },
       onAbandoned: async () => {
-        await releaseUnadopted(state, {
-          lastError: "turn-abandoned",
-          recordAttempt: false,
-        });
+        await releaseUnadopted(state, { lastError: "turn-abandoned" });
       },
     };
   };


### PR DESCRIPTION
Related: #122864
Unblocks: #129978

## What Problem This Solves

Fixes an issue where Signal and Microsoft Teams messages could immediately retry without durable attempt accounting or backoff after their reply ownership was abandoned. The recently merged Telegram owner-abort fix unintentionally made every channel's genuine abandonment budget-free, leaving current-main CI red and blocking unrelated pull requests.

## Why This Change Was Made

Restore the shared ingress owner's existing distinction: genuine pre-adoption abandonment records an attempt and remains pending, while explicit owner cancellation preserves all previous retry facts. Telegram now selects the existing cancellation lifecycle for aborted ownership; rollback failures still use the existing failure lifecycle. No public plugin SDK, API, configuration, persistence schema, or retry-threshold contract changes.

## User Impact

Signal and Microsoft Teams recover failed messages with their intended durable retry accounting and backoff. Telegram shutdown and owner replacement still requeue unprocessed messages without spending retry budget or inventing a failure, while previous real failures remain intact.

## Evidence

- Frozen unfixed main: Signal and Microsoft Teams both failed their existing durable retry/backoff/restart regressions with expected `attempts: 1, lastError: "turn-abandoned"` but an empty eligible queue; Telegram's existing 17 cases passed.
- Three restored generic-owner regressions independently failed before the production correction (actual attempts `0`, expected `1`, `1`, and `3`).
- After the owner-boundary repair: **133/133 tests passed** across Signal, Microsoft Teams, Telegram, generic drain, cancellation, durable queue, monitor, lifecycle, and public SDK fan-in.
- Production and test TypeScript checks passed independently for core and plugins; targeted core/plugin lint and formatting passed.
- Independent human-equivalent source review and structured autoreview found no actionable issues.
- Production delta: **+6/-8, net -2**. Test delta: **+10/-9, net +1**.

```text
node scripts/run-vitest.mjs \
  extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts \
  extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts \
  extensions/telegram/src/telegram-ingress-drain.test.ts \
  extensions/telegram/src/telegram-ingress-drain-factory.test.ts \
  src/channels/message/ingress-drain.test.ts \
  src/channels/message/ingress-drain.cancellation.test.ts \
  src/channels/message/ingress-queue.test.ts \
  src/channels/message/ingress-monitor.test.ts \
  src/channels/message/ingress-drain-lifecycle.test.ts \
  src/plugin-sdk/channel-ingress-runtime.test.ts
```
