### PR TITLE
fix(agents): interactive process prompts stall during timed polls

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -319,7 +319,6 @@ src/agents/bash-tools.exec-host-gateway.ts
 src/agents/bash-tools.exec-host-node.test.ts
 src/agents/bash-tools.exec-runtime.ts
 src/agents/bash-tools.exec.approval-id.test.ts
-src/agents/bash-tools.process.ts
 src/agents/btw.test.ts
 src/agents/btw.ts
 src/agents/cli-runner.reliability.test.ts

--- a/src/agents/bash-tools.process.e2e.test.ts
+++ b/src/agents/bash-tools.process.e2e.test.ts
@@ -111,7 +111,19 @@ test.skipIf(process.platform === "win32").each([
 
     const outcome = await run.promise;
     const notification = peekSystemEventEntries(scopeKey)[0]?.text;
-    const poll = await pendingPoll;
+    let poll = await pendingPoll;
+    if ((poll.details as { status?: string }).status === "running") {
+      expect(poll.details).toMatchObject({
+        status: "running",
+        sessionId: run.session.id,
+        aggregated: "REAL_CHILD_OUTPUT",
+      });
+      expect(textContent(poll)).toContain("REAL_CHILD_OUTPUT");
+      poll = await processTool.execute(`process-terminal-final-poll-${name}`, {
+        action: "poll",
+        sessionId: run.session.id,
+      });
+    }
     const details = poll.details as { status?: string; exitCode?: number };
 
     expect(outcome.status).toBe(expectedStatus);
@@ -317,11 +329,11 @@ test.skipIf(process.platform === "win32")(
         )
         .toContain("READY");
 
-      const readyPoll = await processTool.execute("process-control-ready-poll", {
-        action: "poll",
-        sessionId,
-        timeout: 1_000,
-      });
+      const readyPoll = await processTool.execute(
+        "process-control-ready-poll",
+        { action: "poll", sessionId, timeout: 30_000 },
+        AbortSignal.timeout(1_000),
+      );
       expect(readyPoll.details).toMatchObject({
         status: "running",
         sessionId,

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -112,6 +112,81 @@ test("process poll waits for completion when timeout is provided", async () => {
   });
 });
 
+test.each([
+  { name: "buffered stdout", stream: "stdout", arrivesDuringWait: false, dropped: false },
+  { name: "buffered stderr", stream: "stderr", arrivesDuringWait: false, dropped: false },
+  { name: "new stdout", stream: "stdout", arrivesDuringWait: true, dropped: false },
+  { name: "new stderr", stream: "stderr", arrivesDuringWait: true, dropped: false },
+  { name: "buffered capped output", stream: "stdout", arrivesDuringWait: false, dropped: true },
+] as const)(
+  "process poll returns $name before the requested wait expires",
+  async ({ name, stream, arrivesDuringWait, dropped }) => {
+    vi.useFakeTimers();
+    const sessionId = `sess-prompt-${name.replaceAll(" ", "-")}`;
+    const { processTool, session } = createProcessSessionHarness(sessionId);
+    const controller = new AbortController();
+    const appendPendingOutput = () => {
+      if (dropped) {
+        appendOversizedPendingOutput(session);
+      } else {
+        appendOutput(session, stream, "interactive prompt\n");
+      }
+    };
+    if (arrivesDuringWait) {
+      setTimeout(appendPendingOutput, 10);
+    } else {
+      appendPendingOutput();
+    }
+
+    let settled = false;
+    const observedPoll = pollSession(
+      processTool,
+      "toolcall-prompt",
+      sessionId,
+      30_000,
+      controller.signal,
+    ).then(
+      (result) => {
+        settled = true;
+        return result;
+      },
+      () => undefined,
+    );
+
+    try {
+      await vi.advanceTimersByTimeAsync(arrivesDuringWait ? 250 : 0);
+      expect(settled).toBe(true);
+
+      const poll = await observedPoll;
+      expect(poll?.details).toMatchObject({ status: "running", sessionId });
+      expect(poll?.content[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining(
+          dropped ? "earlier output is omitted from this poll" : "interactive prompt",
+        ),
+      });
+      expect(session.pendingOutput).toHaveLength(0);
+    } finally {
+      controller.abort();
+      await observedPoll;
+      vi.useRealTimers();
+    }
+  },
+);
+
+test("process poll rejects an already-aborted signal without consuming buffered output", async () => {
+  const sessionId = "sess-prompt-already-aborted";
+  const { processTool, session } = createProcessSessionHarness(sessionId);
+  appendOutput(session, "stdout", "interactive prompt\n");
+  const controller = new AbortController();
+  controller.abort();
+
+  await expect(
+    pollSession(processTool, "toolcall-prompt-aborted", sessionId, 30_000, controller.signal),
+  ).rejects.toMatchObject({ name: "AbortError" });
+  expect(session.pendingOutput).toEqual([{ stream: "stdout", text: "interactive prompt\n" }]);
+});
+
 test("waiting poll returns only output appended since the previous poll", async () => {
   vi.useFakeTimers();
   try {

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -380,10 +380,7 @@ export function createProcessTool(
       }
 
       if (!params.sessionId) {
-        return {
-          content: [{ type: "text", text: "sessionId is required for this action." }],
-          details: { status: "failed" },
-        };
+        return failText("sessionId is required for this action.");
       }
 
       const session = getSession(params.sessionId);
@@ -391,35 +388,30 @@ export function createProcessTool(
       const scopedSession = isInScope(session) ? session : undefined;
       const scopedFinished = isInScope(finished) ? finished : undefined;
 
-      const failedResult = (text: string): AgentToolResult<unknown> => ({
-        content: [{ type: "text", text }],
-        details: { status: "failed" },
-      });
-
       const resolveBackgroundedWritableStdin = () => {
         if (!scopedSession) {
           return {
             ok: false as const,
-            result: failedResult(`No active session found for ${params.sessionId}`),
+            result: failText(`No active session found for ${params.sessionId}`),
           };
         }
         if (!scopedSession.backgrounded) {
           return {
             ok: false as const,
-            result: failedResult(`Session ${params.sessionId} is not backgrounded.`),
+            result: failText(`Session ${params.sessionId} is not backgrounded.`),
           };
         }
         if (scopedSession.finalizing) {
           return {
             ok: false as const,
-            result: failedResult(`Session ${params.sessionId} is finalizing.`),
+            result: failText(`Session ${params.sessionId} is finalizing.`),
           };
         }
         const stdin = resolveSessionStdin(scopedSession);
         if (!isWritableStdin(stdin)) {
           return {
             ok: false as const,
-            result: failedResult(`Session ${params.sessionId} stdin is not writable.`),
+            result: failText(`Session ${params.sessionId} stdin is not writable.`),
           };
         }
         return { ok: true as const, session: scopedSession, stdin };
@@ -451,8 +443,17 @@ export function createProcessTool(
           }
           const pollWaitMs = resolvePollWaitMs(params.timeout);
           if (pollWaitMs > 0 && !scopedSession.exited) {
+            if (signal?.aborted) {
+              throw createAbortError(signal.reason);
+            }
             const deadline = Date.now() + pollWaitMs;
-            while (!scopedSession.exited && Date.now() < deadline) {
+            // Interactive children cannot progress until their pending prompt reaches the model.
+            while (
+              !scopedSession.exited &&
+              scopedSession.pendingOutput.length === 0 &&
+              !scopedSession.pendingOutputDropped &&
+              Date.now() < deadline
+            ) {
               await sleepPollInterval(Math.max(0, Math.min(250, deadline - Date.now())), signal);
             }
           }
@@ -501,15 +502,7 @@ export function createProcessTool(
         case "log": {
           if (scopedSession) {
             if (!scopedSession.backgrounded) {
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: `Session ${params.sessionId} is not backgrounded.`,
-                  },
-                ],
-                details: { status: "failed" },
-              };
+              return failText(`Session ${params.sessionId} is not backgrounded.`);
             }
             const window = resolveLogSliceWindow(params.offset, params.limit);
             const { slice, totalLines, totalChars } = sliceLogLines(
@@ -570,15 +563,7 @@ export function createProcessTool(
               },
             };
           }
-          return {
-            content: [
-              {
-                type: "text",
-                text: `No session found for ${params.sessionId}`,
-              },
-            ],
-            details: { status: "failed" },
-          };
+          return failText(`No session found for ${params.sessionId}`);
         }
 
         case "write": {
@@ -632,15 +617,7 @@ export function createProcessTool(
           }
           const payload = encodePaste(params.text ?? "", params.bracketed !== false);
           if (!payload) {
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: "No paste text provided.",
-                },
-              ],
-              details: { status: "failed" },
-            };
+            return failText("No paste text provided.");
           }
           await writeProcessStdin(resolved.stdin, payload);
           return runningSessionResult(
@@ -690,15 +667,7 @@ export function createProcessTool(
               details: { status: "completed" },
             };
           }
-          return {
-            content: [
-              {
-                type: "text",
-                text: `No finished session found for ${params.sessionId}`,
-              },
-            ],
-            details: { status: "failed" },
-          };
+          return failText(`No finished session found for ${params.sessionId}`);
         }
 
         case "remove": {
@@ -741,22 +710,11 @@ export function createProcessTool(
               details: { status: "completed" },
             };
           }
-          return {
-            content: [
-              {
-                type: "text",
-                text: `No session found for ${params.sessionId}`,
-              },
-            ],
-            details: { status: "failed" },
-          };
+          return failText(`No session found for ${params.sessionId}`);
         }
       }
 
-      return {
-        content: [{ type: "text", text: `Unknown action ${params.action as string}` }],
-        details: { status: "failed" },
-      };
+      return failText(`Unknown action ${params.action as string}`);
     },
   };
 }

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -721,4 +721,3 @@ export function createProcessTool(
 
 /** Shared process-control tool instance used by the default Bash tool barrel. */
 export const processTool = createProcessTool();
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running interactive background commands would not see an already-available prompt until the requested process poll timed out, leaving the command unable to receive the input it was waiting for.

## Why This Change Was Made

The process lifecycle already records unread output at its authoritative registry boundary, but timed polling only stopped when the command exited or its deadline elapsed. Polling now wakes for unread stdout, stderr, or an output-omission notice while preserving cancellation, terminal-outcome precedence, notification ownership, and the existing 30-second wait cap. Equivalent failure responses now share the owner's existing renderer, removing enough code to retire its grandfathered max-lines exemption and shrink the matching ratchet baseline.

## User Impact

Interactive CLI prompts and progress output become visible as soon as they are available, so an agent can provide input without waiting up to 30 seconds. Quiet commands still wait normally, and completed or canceled commands retain their existing status, output, and notification behavior.

## Evidence

- Before: the existing real PTY child emitted `READY`, a non-consuming log confirmed the prompt, and a 30-second poll still failed a one-second cancellation guard. After: the same real interactive child returns `READY` immediately and completes the existing input, key handling, cancellation, and terminal-result round trip.
- Five focused regressions cover already-buffered and newly arriving stdout/stderr plus retained-output omission; an already-aborted poll still rejects without consuming buffered output.
- Ten process, registry, supervisor, input, send-keys, retention, real-child, exec-runtime, and memory-host suites pass: **147 tests**. A cross-channel sanity sweep confirms current `main` also passes **74 shared-ingress, Telegram, Signal, Microsoft Teams, and WhatsApp tests**.
- Canonical strict production, owner-test, and real-PTY-test TypeScript project graphs each pass with zero diagnostics across more than 10,000 transitive source files.
- Repository-configured Rust AST lint, changed-file formatting, assertion-safety ratchet, and max-lines ratchet pass; the max-lines baseline shrinks from 894 exemptions to 893.
- Independent owner-boundary review and an authenticated Codex review reported no actionable findings.
- Production owner: **21 additions / 64 deletions (net -43)**; the matching baseline removes one obsolete entry.

AI-assisted: Codex.
