### PR TITLE
fix(onboard): terminal hatch connects after guided setup

### DIFF
--- a/src/commands/onboard-guided.test.ts
+++ b/src/commands/onboard-guided.test.ts
@@ -428,6 +428,23 @@ describe("runGuidedOnboarding", () => {
     expect(options).not.toHaveProperty("local");
   });
 
+  it("keeps the local terminal hatch for configured reruns", async () => {
+    localOnboarding.persisted.config = { gateway: {} };
+    const prompter = createWizardPrompter();
+    const deps: GuidedOnboardingDeps = setupDeps({ prompter });
+    delete deps.launchHatchTui;
+
+    await runGuidedOnboarding(
+      { acceptRisk: true, workspace: "/tmp/work", tui: true },
+      makeRuntime(),
+      deps,
+    );
+
+    expect(launchTuiCli).toHaveBeenCalledOnce();
+    expect(launchTuiCli).toHaveBeenCalledWith(expect.objectContaining({ local: true }));
+    expect(deps.applySetup).not.toHaveBeenCalled();
+  });
+
   it("uses --skip-ui to skip both browser and terminal handoffs", async () => {
     const prompter = createWizardPrompter();
     const deps = setupDeps({ prompter });

--- a/src/commands/onboard-guided.test.ts
+++ b/src/commands/onboard-guided.test.ts
@@ -23,8 +23,10 @@ const ensureAuthProfileStore = vi.hoisted(() =>
   vi.fn(() => ({ version: 1 as const, profiles: {} })),
 );
 const detectAvailableSetupProviderIds = vi.hoisted(() => vi.fn());
+const launchTuiCli = vi.hoisted(() => vi.fn(async (_opts: unknown) => undefined));
 
 vi.mock("../../packages/terminal-core/src/restore.js", () => ({ restoreTerminalState }));
+vi.mock("../tui/tui-launch.js", () => ({ launchTuiCli }));
 
 vi.mock("./auth-choice-prompt.js", async (importActual) => ({
   ...(await importActual<typeof import("./auth-choice-prompt.js")>()),
@@ -282,6 +284,7 @@ describe("runGuidedOnboarding", () => {
       issues: [],
       config: localOnboarding.persisted.config ?? {},
     }));
+    launchTuiCli.mockClear();
   });
 
   afterEach(() => {
@@ -406,6 +409,23 @@ describe("runGuidedOnboarding", () => {
 
     expect(runBrowserHandoff).not.toHaveBeenCalled();
     expect(deps.launchHatchTui).toHaveBeenCalledWith("/tmp/work");
+  });
+
+  it("launches the guided terminal hatch through the running Gateway", async () => {
+    const prompter = createWizardPrompter();
+    const deps: GuidedOnboardingDeps = setupDeps({ prompter });
+    delete deps.launchHatchTui;
+
+    await runGuidedOnboarding(
+      { acceptRisk: true, workspace: "/tmp/work", tui: true },
+      makeRuntime(),
+      deps,
+    );
+
+    expect(launchTuiCli).toHaveBeenCalledOnce();
+    const options = launchTuiCli.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(options).toMatchObject({ deliver: false });
+    expect(options).not.toHaveProperty("local");
   });
 
   it("uses --skip-ui to skip both browser and terminal handoffs", async () => {

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -67,11 +67,10 @@ export type GuidedOnboardingDeps = {
 
 export type GuidedAccessMode = "full" | "guarded";
 
-type GuidedOnboardingHandoff = {
-  workspace: string;
-  next: "browser" | "hatch" | "chat";
-  agentName?: string;
-};
+type GuidedOnboardingHandoff =
+  | { workspace: string; next: "browser" }
+  | { workspace: string; next: "hatch"; local: boolean }
+  | { workspace: string; next: "chat"; agentName?: string };
 
 async function openSystemAgentChat(
   deps: GuidedOnboardingDeps,
@@ -691,7 +690,7 @@ async function runGuidedOnboardingFlow(
   await prompter.outro(t("wizard.guided.hatchingNow"));
   // The TUI opens the configured default agent/workspace; on a configured
   // rerun that is the persisted default, not the --workspace probe context.
-  return { workspace: hatchWorkspace, next: "hatch" };
+  return { workspace: hatchWorkspace, next: "hatch", local: alreadyConfigured };
 }
 
 async function persistAccessMode(mode: GuidedAccessMode): Promise<void> {
@@ -706,7 +705,7 @@ async function persistAccessMode(mode: GuidedAccessMode): Promise<void> {
   });
 }
 
-async function launchHatchTui(workspace: string): Promise<void> {
+async function launchHatchTui(workspace: string, local: boolean): Promise<void> {
   const [{ launchTuiCli }, { DEFAULT_BOOTSTRAP_FILENAME }, { restoreTerminalState }, fs, path] =
     await Promise.all([
       import("../tui/tui-launch.js"),
@@ -718,10 +717,11 @@ async function launchHatchTui(workspace: string): Promise<void> {
   const hasBootstrap = fs.existsSync(path.join(workspace, DEFAULT_BOOTSTRAP_FILENAME));
   restoreTerminalState("guided hatch tui", { resumeStdinIfPaused: false });
   try {
-    // Setup already started the Gateway; local mode would contend for its state lock.
+    // Fresh setup already started the Gateway; local mode would contend for its state lock.
     // No timeoutMs: the run-level TUI timeout overrides the configured agent
     // timeout for every turn in the session, not just the hatch message.
     await launchTuiCli({
+      ...(local ? { local: true } : {}),
       deliver: false,
       // Seed the first-run hatch only when the workspace bootstrap exists;
       // re-runs against an established agent open a plain chat instead.
@@ -753,7 +753,11 @@ export async function runGuidedOnboarding(
   // Interactive surfaces start only after the wizard lifecycle restores stdin
   // so the TUI (or recovery chat) receives a clean TTY.
   if (handoff.next === "hatch") {
-    await (deps.launchHatchTui ?? launchHatchTui)(handoff.workspace);
+    if (deps.launchHatchTui) {
+      await deps.launchHatchTui(handoff.workspace);
+    } else {
+      await launchHatchTui(handoff.workspace, handoff.local);
+    }
     return;
   }
   if (handoff.next === "browser") {

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -718,10 +718,10 @@ async function launchHatchTui(workspace: string): Promise<void> {
   const hasBootstrap = fs.existsSync(path.join(workspace, DEFAULT_BOOTSTRAP_FILENAME));
   restoreTerminalState("guided hatch tui", { resumeStdinIfPaused: false });
   try {
+    // Setup already started the Gateway; local mode would contend for its state lock.
     // No timeoutMs: the run-level TUI timeout overrides the configured agent
     // timeout for every turn in the session, not just the hatch message.
     await launchTuiCli({
-      local: true,
       deliver: false,
       // Seed the first-run hatch only when the workspace bootstrap exists;
       // re-runs against an established agent open a plain chat instead.


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users completing guided local setup with the terminal handoff could see the hatch TUI fail immediately because the newly started Gateway already owned the state directory.

## Why This Change Was Made

Fresh guided setup now opens the hatch TUI through the Gateway it just installed and verified instead of starting a second embedded local runtime. Configured reruns, which deliberately do not start or verify a Gateway, retain the embedded local hatch. The first-run hatch message and non-delivery behavior stay unchanged.

## User Impact

The terminal hatch can open normally after fresh guided setup instead of refusing startup with an active-Gateway state-lock error, without making configured reruns depend on an unverified Gateway.

## Evidence

Exact head `a04841cd9de6e871bdfddfff1bd85650c1519b4e` rebased onto `origin/main` `e6ed7e30cc5ff26be72f81edfe590a0288caa4b2`:

- Fresh setup is asserted to omit `local` and use the running Gateway; configured reruns are asserted to preserve `local: true` and skip setup apply.
- Exact-head focused suite: `onboard-guided.test.ts`, 27 tests passed.
- Exact-head `pnpm check:changed`: passed, including core/test typechecks, lint, boundaries, and import-cycle checks.
- Fresh exact-head autoreview: clean, patch correct at 0.98 confidence.
- TruffleHog 3.97.0 scan: clean.
