### PR TITLE
refactor(cli): dedupe screen artifact writers

### DIFF
--- a/src/cli/nodes-screen.ts
+++ b/src/cli/nodes-screen.ts
@@ -5,8 +5,12 @@ import {
   parseScreenSnapshotResult,
   type ScreenSnapshotResult,
 } from "../plugins/computer-use-contract.js";
-import { writeBase64ToFile } from "./nodes-camera.js";
 import { asRecord, readStringValue, resolveTempPathParts } from "./nodes-media-utils.js";
+
+export {
+  writeBase64ToFile as writeScreenRecordToFile,
+  writeBase64ToFile as writeScreenSnapshotToFile,
+} from "./nodes-camera.js";
 
 /** Validated payload returned by `nodes screen record` RPC calls. */
 type ScreenRecordPayload = {
@@ -42,15 +46,6 @@ export function screenRecordTempPath(opts: { ext: string; tmpDir?: string; id?: 
   return path.join(tmpDir, `openclaw-screen-record-${id}${ext}`);
 }
 
-/** Decode and write a screen recording payload to disk. */
-export async function writeScreenRecordToFile(
-  filePath: string,
-  base64: string,
-  opts?: { maxBytes?: number },
-) {
-  return writeBase64ToFile(filePath, base64, opts);
-}
-
 /** Validated payload returned by `nodes screen snapshot` RPC calls. */
 /** Validate and normalize an unknown screen-snapshot payload. */
 export function parseScreenSnapshotPayload(value: unknown): ScreenSnapshotResult {
@@ -79,13 +74,4 @@ export function screenSnapshotTempPath(opts: { ext: string; tmpDir?: string; id?
   // is how a JPEG snapshot ends up named `.png`.
   const { tmpDir, id, ext } = resolveTempPathParts(opts);
   return path.join(tmpDir, `openclaw-screen-snapshot-${id}${ext}`);
-}
-
-/** Decode and write a screen snapshot payload to disk. */
-export async function writeScreenSnapshotToFile(
-  filePath: string,
-  base64: string,
-  opts?: { maxBytes?: number },
-) {
-  return writeBase64ToFile(filePath, base64, opts);
 }


### PR DESCRIPTION
## What Problem This Solves

The node-screen helper surface independently owned two byte-identical async forwarding implementations for recording and snapshot artifact writes, even though both always delegated to the same bounded, validating base64 writer. Those speculative adapters added duplicate implementation paths with no screen-specific behavior.

## Why This Change Was Made

Preserve the existing internal screen-writer export names as direct ESM aliases of the canonical `writeBase64ToFile` implementation and delete both forwarding bodies. Production callers, accepted inputs, output/error bytes, return values, write ordering, and side effects remain unchanged.

## User Impact

No user-visible behavior changes. Node screen recordings and snapshots are validated, bounded, and written exactly as before through one canonical implementation.

## Evidence

- Focused exact-head proof: 62/62 tests passed (`nodes-camera.test.ts` 48/48; `program.nodes-media.e2e.test.ts` 14/14), including both preserved writer names, size limits, invalid-base64 errors, file writes, and CLI media flow.
- Exact-head formatting, oxlint, dead-export scan, production core typecheck, plugin/import boundaries, dependency pins, wrapper-shadowing, and architecture guards passed.
- The broader local core-test declaration pass reaches the same unrelated stale shared-install `pako` declaration gap in `ui/vite.config.ts`; exact-head hosted CI remains authoritative.
- Both import-cycle analyzers report zero cycles.
- Test audit: existing behavior-level writer and CLI coverage directly protects the preserved contract; no implementation-identity test was added.
- Deslop: clean; no additional edits.
- Structured exact-head autoreview: clean, patch correctness 0.99.
- Separate exact-head Codex review: clean, no actionable findings; verified ESM alias semantics, callers, history, cycles, test sufficiency, and no Codex runtime/protocol involvement.
- Production LOC: +5/-19 (net -14); tests unchanged.

AI-assisted cleanup; the implementation and validation evidence were reviewed before submission.
