### PR TITLE
fix(e2e): include Codex thread project id

### DIFF
--- a/scripts/e2e/lib/codex-app-server-fixture.mjs
+++ b/scripts/e2e/lib/codex-app-server-fixture.mjs
@@ -24,6 +24,7 @@ export function createFakeThreadStartResponse({ params, sessionId, threadId, ver
       forkedFromId: null,
       preview: "",
       ephemeral: false,
+      projectId: params?.projectId ?? null,
       modelProvider: "openai",
       createdAt: now,
       updatedAt: now,

--- a/test/scripts/codex-app-server-fixture.test.ts
+++ b/test/scripts/codex-app-server-fixture.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { createFakeThreadStartResponse } from "../../scripts/e2e/lib/codex-app-server-fixture.mjs";
+
+describe("createFakeThreadStartResponse", () => {
+  it.each([
+    { expected: null, params: {} },
+    { expected: "project-1", params: { projectId: "project-1" } },
+  ])("returns the protocol-required projectId as $expected", ({ expected, params }) => {
+    const response = createFakeThreadStartResponse({
+      params,
+      sessionId: "session-1",
+      threadId: "thread-1",
+      version: "0.149.1",
+    });
+
+    expect(response.thread.projectId).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- return the protocol-required nullable `projectId` from the shared fake Codex `thread/start` response
- preserve a requested project assignment and otherwise emit explicit `null`
- cover both mappings at the fixture owner boundary

## Root cause

Codex app-server 0.149.1 made `Thread.projectId` a required nullable response field. OpenClaw's generated schema was refreshed in b68c136, but `scripts/e2e/lib/codex-app-server-fixture.mjs` kept emitting the prior fake `Thread` shape. Runtime validation therefore rejected the fake `thread/start` response before repo-E2E Codex auth and approval scenarios could reach `turn/start`.

Upstream contract inspected directly:

- `../codex/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs:196` defines the `Thread`; its `project_id` uses a required nullable schema.
- `../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:59` defines optional `ThreadStartParams.project_id`, so the response must preserve a supplied value or explicitly return `null`.

The sibling fake app servers all consume this shared builder; no duplicate `Thread` response builder required a parallel repair.

## Proof

Pre-fix validator reproduction:

```text
Error: Invalid Codex app-server thread/start response: /thread must have required properties projectId
```

Passing:

```text
node scripts/run-vitest.mjs --config test/vitest/vitest.tooling.config.ts test/scripts/codex-app-server-fixture.test.ts
Test Files  1 passed (1)
Tests  2 passed (2)
```

`check-changed` passed all focused formatting, dependency, conflict-marker, coercion, and script guards before reaching the existing checkout-wide type drift in unrelated Matrix, QA Lab, Google provider, Markdown, TUI, and UI dependencies.

Autoreview: clean, no accepted/actionable findings.

## Test audit

The new test protects the independently generated app-server response contract and fails on the exact pre-fix omission. Existing protocol-validator tests build their own canonical response and therefore could not catch drift in this shared repo-E2E fixture. The test needs no production-only seam and covers both nullable and supplied project assignments in one table.

## Scope / LOC

- tooling production: +1 / -0
- tests: +18 / -0
- no protocol, generated schema, timeout, retry, model, or mock-boundary changes
