### PR TITLE
test(memory): remove redundant reset archive coverage

### DIFF
--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -296,18 +296,17 @@ describe("listSessionTranscriptCorpusEntriesForAgent", () => {
         updateMode: "none",
       },
     );
-    const archiveMessage = (content: string) =>
-      JSON.stringify({ type: "message", message: { role: "user", content } });
     const archivePath = path.join(
       sessionsDir,
       `${sessionId}.jsonl.deleted.2026-06-25T12-01-00.000Z`,
     );
-    fsSync.writeFileSync(archivePath, archiveMessage("Archived JSONL transcript text"));
-    const resetArchivePath = path.join(
-      sessionsDir,
-      `${sessionId}.jsonl.reset.2026-06-25T12-02-00.000Z`,
+    fsSync.writeFileSync(
+      archivePath,
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "Archived JSONL transcript text" },
+      }),
     );
-    fsSync.writeFileSync(resetArchivePath, archiveMessage("Retained pre-reset conversation fact"));
 
     expect(fsSync.existsSync(path.join(sessionsDir, `${sessionId}.jsonl`))).toBe(false);
     const entries = await listSessionTranscriptCorpusEntriesForAgent("main");
@@ -331,10 +330,6 @@ describe("listSessionTranscriptCorpusEntriesForAgent", () => {
           sessionFile: archivePath,
           sessionId,
         }),
-        expect.objectContaining({
-          artifactKind: "archive-artifact",
-          sessionFile: resetArchivePath,
-        }),
       ]),
     );
 
@@ -355,7 +350,6 @@ describe("listSessionTranscriptCorpusEntriesForAgent", () => {
       updatedAtMs: updatedAt,
     });
     const archiveEntry = requireSessionEntry(await buildSessionEntry(archivePath));
-    const resetArchiveEntry = requireSessionEntry(await buildSessionEntry(resetArchivePath));
 
     expect(liveEntry.path).toBe("sessions/main/sqlite-live.jsonl");
     expect(liveEntry.content).toBe("User: Live SQLite transcript text");
@@ -369,10 +363,6 @@ describe("listSessionTranscriptCorpusEntriesForAgent", () => {
       "sessions/main/sqlite-live.jsonl.deleted.2026-06-25T12-01-00.000Z",
     );
     expect(archiveEntry.content).toBe("User: Archived JSONL transcript text");
-    expect(resetArchiveEntry.path).toBe(
-      "sessions/main/sqlite-live.jsonl.reset.2026-06-25T12-02-00.000Z",
-    );
-    expect(resetArchiveEntry.content).toBe("User: Retained pre-reset conversation fact");
   });
 
   it("exposes content revisions that change with SQLite appends and file replacement", async () => {


### PR DESCRIPTION
## What Problem This Solves

#130016 added a reset-archive fixture and assertions to a broad SQLite/archive integration case even though focused owner-boundary tests already prove the same reset/deleted listing and indexing behavior. #129577 subsequently compacted that setup while preserving the duplicate coverage.

## Why This Change Was Made

Remove the reset-archive branch from the broader integration case and restore the remaining archived-JSONL setup inline instead of retaining a one-use fixture helper. Stronger focused coverage remains:

- `includes reset and deleted transcripts in session file listing` proves both archive kinds enter the corpus listing.
- `indexes usage-counted reset/deleted archives but still skips bak and checkpoint artifacts` proves both archive kinds are materialized and indexed.

The surrounding integration case continues to prove SQLite live-row identity alongside archived JSONL artifacts.

## User Impact

No runtime behavior changes. This removes duplicate test maintenance while preserving unique reset-session recall coverage.

## Evidence

- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/session-files.test.ts` — 40/40 passed on the rebased head.
- `node scripts/check-changed.mjs -- packages/memory-host-sdk/src/host/session-files.test.ts` — changed-files gate passed on the rebased head.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
- `pnpm lint` — full core, extension, and script lint passed with 0 errors before rebase; the rebased changed-file lint gate also passed.
- `git diff --check origin/main...HEAD` — passed.
