### PR TITLE
fix(feishu): include thread_id in debounce key when root_id is absent (#130028)

### DIFF
--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -282,7 +282,8 @@ export function createFeishuMessageReceiveHandler({
           return null;
         }
         const rootId = event.message.root_id?.trim();
-        const threadKey = rootId ? `thread:${rootId}` : "chat";
+        const threadId = event.message.thread_id?.trim();
+        const threadKey = rootId ? `thread:${rootId}` : (threadId ? `topic:${threadId}` : "chat");
         return `feishu:${accountId}:${chatId}:${threadKey}:${senderId}`;
       },
       shouldDebounce: ({ event }) => {


### PR DESCRIPTION
When Feishu delivers topic messages, `root_id` may be absent while `thread_id` is present. The debounce key builder only checked `root_id`, causing consecutive messages in the same topic to share a debounce key and be incorrectly merged.

## Changes

- In `monitor.message-handler.ts`, the debounce key now falls back to `thread_id` when `root_id` is absent.
- This ensures topic-level debouncing works correctly for both threaded and topic-style conversations.

Fixes #130028