### PR TITLE
fix(daemon): prevent macOS node startup hangs from inherited compile cache

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { resolveAutoNodeExtraCaCerts } from "../bootstrap/node-extra-ca-certs.js";
 import { inspectGatewayHeapLimit } from "./gateway-heap.js";
+import { buildLaunchAgentPlist } from "./launchd-plist.js";
 import { resolveGatewayStateDir } from "./paths.js";
 import {
   buildNodeServiceEnvironment,
@@ -783,6 +784,44 @@ describe("buildNodeServiceEnvironment", () => {
 
     expect(env.OPENCLAW_LAUNCHD_LABEL).toBe("ai.openclaw.node");
   });
+
+  it("fences inherited Node compile cache in macOS node LaunchAgents", () => {
+    const environment = buildNodeServiceEnvironment({
+      env: {
+        HOME: "/Users/user",
+        NODE_COMPILE_CACHE: "/tmp/ambient-node-compile-cache",
+      },
+      platform: "darwin",
+    });
+    const plist = buildLaunchAgentPlist({
+      label: "ai.openclaw.node",
+      programArguments: ["/usr/local/bin/node", "dist/index.js", "node", "run"],
+      stdoutPath: "/tmp/openclaw-node.log",
+      stderrPath: "/tmp/openclaw-node.err.log",
+      environment,
+    });
+
+    expect(environment.NODE_DISABLE_COMPILE_CACHE).toBe("1");
+    expect(environment.NODE_COMPILE_CACHE).toBeUndefined();
+    expect(plist).toContain("<key>NODE_DISABLE_COMPILE_CACHE</key>");
+    expect(plist).not.toContain("<key>NODE_COMPILE_CACHE</key>");
+  });
+
+  it.each(["linux", "win32"] as const)(
+    "does not force Node compile cache off for %s node services",
+    (platform) => {
+      const environment = buildNodeServiceEnvironment({
+        env: {
+          HOME: platform === "win32" ? "C:\\Users\\user" : "/home/user",
+          NODE_COMPILE_CACHE: "/tmp/ambient-node-compile-cache",
+        },
+        platform,
+      });
+
+      expect(environment.NODE_DISABLE_COMPILE_CACHE).toBeUndefined();
+      expect(environment.NODE_COMPILE_CACHE).toBeUndefined();
+    },
+  );
 
   it("passes through OPENCLAW_GATEWAY_TOKEN for node services", () => {
     const env = buildNodeServiceEnvironment({

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -392,6 +392,8 @@ export function buildNodeServiceEnvironment(params: {
     CF_ACCESS_CLIENT_ID: cloudflareAccessClientId,
     CF_ACCESS_CLIENT_SECRET: cloudflareAccessClientSecret,
     OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: allowInsecurePrivateWs,
+    // launchd manager variables outlive the installer; fence node hosts from an unsuitable cache.
+    NODE_DISABLE_COMPILE_CACHE: platform === "darwin" ? "1" : undefined,
     ...resolveNodeServiceIdentityEnvironment(),
   };
 }

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -392,7 +392,8 @@ export function buildNodeServiceEnvironment(params: {
     CF_ACCESS_CLIENT_ID: cloudflareAccessClientId,
     CF_ACCESS_CLIENT_SECRET: cloudflareAccessClientSecret,
     OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: allowInsecurePrivateWs,
-    // launchd manager variables outlive the installer; fence node hosts from an unsuitable cache.
+    // launchd manager variables outlive the installer. Worker snapshots scope
+    // this host fence by the canonical managed-node service identity.
     NODE_DISABLE_COMPILE_CACHE: platform === "darwin" ? "1" : undefined,
     ...resolveNodeServiceIdentityEnvironment(),
   };

--- a/src/node-host/node-worker-bundle-installer.test.ts
+++ b/src/node-host/node-worker-bundle-installer.test.ts
@@ -180,6 +180,31 @@ describe("node worker bundle installer", () => {
     await expect(fs.readFile(prewarmMarker, "utf8")).resolves.toBe("ready");
   });
 
+  it("prewarms bundles with managed cache behind a host compile-cache fence", async () => {
+    const prewarmMarker = path.join(root, "worker-prewarmed-with-managed-cache");
+    const fixture = await bundleFixture({
+      prewarmMarker,
+      bundlePrewarm: 1,
+      compileCacheDisabled: false,
+    });
+    const served = await serve(fixture.archive, fixture.input.archive.token);
+    const installer = new NodeWorkerBundleInstaller({
+      root,
+      env: {
+        ...process.env,
+        NODE_COMPILE_CACHE: "/tmp/ambient-host-compile-cache",
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.node",
+        OPENCLAW_SERVICE_KIND: "node",
+      },
+    });
+
+    await expect(
+      installer.ensure({ input: fixture.input, gatewayUrl: served.gatewayUrl }),
+    ).resolves.toEqual(fixture.input.build);
+    await expect(fs.readFile(prewarmMarker, "utf8")).resolves.toBe("ready");
+  });
+
   it("reuses a v1 install when Windows cannot retain Unix artifact modes", async () => {
     const fixture = await bundleFixture();
     const served = await serve(fixture.archive, fixture.input.archive.token);

--- a/src/node-host/node-worker-environment.ts
+++ b/src/node-host/node-worker-environment.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { NODE_SERVICE_KIND, resolveNodeLaunchAgentLabel } from "../daemon/constants.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 
 const POSIX_WORKER_ENV_KEYS = new Set([
@@ -50,10 +51,15 @@ export function snapshotNodeWorkerEnv(source: NodeJS.ProcessEnv): NodeJS.Process
     }
     snapshot[key] = value;
   }
-  if (source.NODE_DISABLE_COMPILE_CACHE === undefined) {
+  const hostCacheFenced =
+    source.NODE_DISABLE_COMPILE_CACHE !== undefined &&
+    source.OPENCLAW_SERVICE_KIND === NODE_SERVICE_KIND &&
+    source.OPENCLAW_LAUNCHD_LABEL === resolveNodeLaunchAgentLabel();
+  const workerCacheDisabled = source.NODE_DISABLE_COMPILE_CACHE !== undefined && !hostCacheFenced;
+  if (!workerCacheDisabled) {
+    const requestedCache = hostCacheFenced ? undefined : source.NODE_COMPILE_CACHE?.trim();
     snapshot.NODE_COMPILE_CACHE =
-      source.NODE_COMPILE_CACHE?.trim() ||
-      path.join(resolvePreferredOpenClawTmpDir(), "node-worker-compile-cache");
+      requestedCache || path.join(resolvePreferredOpenClawTmpDir(), "node-worker-compile-cache");
   } else {
     snapshot.NODE_DISABLE_COMPILE_CACHE = "1";
   }

--- a/src/node-host/node-worker-supervisor.test.ts
+++ b/src/node-host/node-worker-supervisor.test.ts
@@ -445,9 +445,13 @@ describe("node worker supervisor", () => {
       HOME: path.join(root, "worker-home"),
       LANG: "en_US.UTF-8",
       LC_TIME: "de_DE.UTF-8",
+      NODE_COMPILE_CACHE: path.join(root, "host-compile-cache"),
+      NODE_DISABLE_COMPILE_CACHE: "1",
       NODE_EXTRA_CA_CERTS: path.join(root, "private-ca.pem"),
       NODE_USE_SYSTEM_CA: "1",
       OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: "1",
+      OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.node",
+      OPENCLAW_SERVICE_KIND: "node",
       OPENCLAW_SUPPLIED_SECRET: "supplied-openclaw-secret",
       NODE_OPTIONS: "--title=forbidden-worker-title",
       BASH_ENV: path.join(root, "forbidden-shell-init"),
@@ -486,8 +490,11 @@ describe("node worker supervisor", () => {
         expect(workerEnv).toMatchObject(expectedWorkerEnv);
         expect(workerEnv).not.toHaveProperty("AMBIENT_SECRET");
         expect(workerEnv).not.toHaveProperty("OPENCLAW_AMBIENT_SECRET");
+        expect(workerEnv).not.toHaveProperty("OPENCLAW_LAUNCHD_LABEL");
+        expect(workerEnv).not.toHaveProperty("OPENCLAW_SERVICE_KIND");
         expect(workerEnv).not.toHaveProperty("OPENCLAW_STATE_DIR");
         expect(workerEnv).not.toHaveProperty("OPENCLAW_SUPPLIED_SECRET");
+        expect(workerEnv).not.toHaveProperty("NODE_DISABLE_COMPILE_CACHE");
         expect(workerEnv).not.toHaveProperty("NODE_OPTIONS");
         expect(workerEnv).not.toHaveProperty("BASH_ENV");
         expect(workerEnv).not.toHaveProperty("DYLD_INSERT_LIBRARIES");


### PR DESCRIPTION
Closes #130020

Related: #130091

AI-assisted: yes (Senpi + OpenAI Codex). I reviewed the changed owner path, tests, dependency behavior, and real macOS launchd output.

## What Problem This Solves

Fixes an issue where users installing a macOS node service could get a node host that hangs before readiness when the launchd manager carries an unsuitable `NODE_COMPILE_CACHE` path.

The generated LaunchAgent previously left that manager-level cache request unfenced, so Node could activate it even though the install command itself ran with a clean environment.

## Why This Change Was Made

Darwin node-service environments now serialize `NODE_DISABLE_COMPILE_CACHE=1` at the producer named by the issue. The existing service allowlist continues to omit ambient `NODE_COMPILE_CACHE`, while Linux and Windows behavior remains unchanged.

Worker snapshots recognize the existing managed-node service identity and scope that disable value to host startup. They discard the inherited host cache path and provision their separately managed cache; unmarked explicit worker opt-outs keep their prior behavior.

This differs from #130091 by keeping the policy in `buildNodeServiceEnvironment`, covering the rendered LaunchAgent contract, and supplying real macOS before/after proof. Persisted beta-only service-definition migration is intentionally outside this fresh-install bug; the reported beta behavior is not a shipped compatibility contract.

## User Impact

Fresh macOS node LaunchAgents no longer activate a launchd-manager compile-cache path during startup. Operators can install and start the node service without clearing the manager environment manually.

Linux and Windows node services retain their current cache behavior. Worker launches, bundle prewarming, and workspace commands retain the managed worker cache instead of inheriting the host-only fence.

## Evidence

### Real macOS LaunchAgent: before -> after

Environment: macOS arm64, Node `v24.18.0`. Both runs used an isolated LaunchAgent and the same manager-simulated cache path:

```text
NODE_COMPILE_CACHE=/tmp/openclaw-130020-manager-cache
```

Current main:

```json
{"cacheDir":"/tmp/openclaw-130020-manager-cache/v24.18.0-arm64-cf738c9d-501","compileCache":"/tmp/openclaw-130020-manager-cache","disabled":null}
```

With this patch:

```json
{"cacheDir":null,"compileCache":"/tmp/openclaw-130020-manager-cache","disabled":"1"}
```

The process still received the launchd-manager variable, but Node reported no active compile-cache directory because the generated service fence won. Both isolated LaunchAgents were booted out after capture, and `launchctl print` confirmed the labels were gone.

### Failing-first regression

Before the production edit:

```text
FAIL  src/daemon/service-env.test.ts
buildNodeServiceEnvironment > fences inherited Node compile cache in macOS node LaunchAgents
AssertionError: expected undefined to be '1'

Tests  1 failed | 85 passed
```

After:

```text
Test Files  1 passed
Tests       86 passed
```

The Linux/Windows negative assertions were mutation-proven: making the fence unconditional failed both rows (`expected undefined`, received `"1"`), and restoring the Darwin-only condition passed both.

### Host fence -> managed worker cache

ClawSweeper correctly found that an unscoped host marker disabled worker caching. Failing-first coverage reproduced both affected boundaries:

```text
FAIL  node worker supervisor > spawns workers with only supplied runtime essentials
expected NODE_COMPILE_CACHE containing "node-worker-compile-cache"

FAIL  node worker bundle installer > prewarms bundles with managed cache behind a host compile-cache fence
worker bundle was not prewarmed with the requested compile-cache mode

Tests  2 failed | 44 passed
```

After scoping the fence with the existing managed-node service identity:

```text
Test Files  3 passed
Tests       132 passed
```

A minimal production-module driver then spawned a real Node child:

```json
{"snapshot":{"compileCache":"/tmp/openclaw/node-worker-compile-cache","disabled":null,"launchdLabel":null,"serviceKind":null},"child":{"cacheDir":"/tmp/openclaw/node-worker-compile-cache/v24.18.0-arm64-cf738c9d-501","compileCache":"/tmp/openclaw/node-worker-compile-cache","disabled":null,"launchdLabel":null,"serviceKind":null}}
```

The host remains fenced by the accepted LaunchAgent proof above, while the child activates the canonical managed worker cache and receives no host-only service identity.

### Validation

```text
pnpm test src/daemon/service-env.test.ts src/daemon/launchd.test.ts src/commands/node-daemon-install-helpers.test.ts -- --reporter=dot
Test Files  3 passed
Tests       254 passed
```

```text
node scripts/check-changed.mjs -- src/daemon/service-env.ts src/daemon/service-env.test.ts
exit 0 — lanes: core, coreTests
format, core typecheck, core-test typecheck, changed lint, import-cycle checks,
database-first/native-schema guards, and related repository guards passed
```

```text
node scripts/check-changed.mjs -- \
  src/daemon/service-env.ts \
  src/daemon/service-env.test.ts \
  src/node-host/node-worker-environment.ts \
  src/node-host/node-worker-supervisor.test.ts \
  src/node-host/node-worker-bundle-installer.test.ts
exit 0 — OPENCLAW_* budget 501/501; core/coreTests typecheck, lint, format,
import-cycle, database-first, schema, and related guards passed
```

```text
pnpm build
exit 0
```

```text
.agents/skills/autoreview/scripts/autoreview --mode uncommitted
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.97)
```

Patch surface: production `+12/-3`; tests `+71/-0`. The production delta adds the Darwin-only host fence plus the smallest identity-scoped worker policy needed to preserve the managed child cache.
