### PR TITLE
test(whatsapp): await automatic redelivery retries

### DIFF
--- a/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
@@ -605,7 +605,7 @@ describe("web monitor inbox delivery and dedupe", () => {
     await listener.close();
   });
 
-  it("delivery coordinator retries redelivery after an explicit retryable failure", async () => {
+  it("delivery coordinator automatically retries after an explicit retryable failure", async () => {
     let attempts = 0;
     const onMessage = vi.fn(async () => {
       attempts += 1;
@@ -625,10 +625,6 @@ describe("web monitor inbox delivery and dedupe", () => {
     });
 
     sock.ev.emit("messages.upsert", upsert);
-    await waitForMessageCalls(onMessage, 1);
-    expect(sock.readMessages).not.toHaveBeenCalled();
-
-    sock.ev.emit("messages.upsert", upsert);
     await waitForMessageCalls(onMessage, 2);
     await vi.waitFor(() => {
       expect(sock.readMessages).toHaveBeenCalledTimes(1);
@@ -637,7 +633,7 @@ describe("web monitor inbox delivery and dedupe", () => {
     await listener.close();
   });
 
-  it("delivery coordinator retries redelivery after reply session conflicts", async () => {
+  it("delivery coordinator automatically retries after reply session conflicts", async () => {
     let attempts = 0;
     const onMessage = vi.fn(async () => {
       attempts += 1;
@@ -656,10 +652,6 @@ describe("web monitor inbox delivery and dedupe", () => {
       timestamp: 1_700_000_000,
       pushName: "Tester",
     });
-
-    sock.ev.emit("messages.upsert", upsert);
-    await waitForMessageCalls(onMessage, 1);
-    expect(sock.readMessages).not.toHaveBeenCalled();
 
     sock.ev.emit("messages.upsert", upsert);
     await waitForMessageCalls(onMessage, 2);


### PR DESCRIPTION
## Summary

- remove the transient one-delivery assertion from the two WhatsApp retry scenarios
- verify the durable monitor automatically redelivers after a retryable handler failure or reply-session conflict
- keep the successful retry's single read-receipt assertion

## Root cause

The shared durable ingress monitor now schedules another drain after a retryable delivery settles. These older tests emitted the same transport upsert a second time and waited for an intermediate exactly-one-call state. Under saturated extension shards, the legitimate automatic retry reached call two before that transient assertion ran. This is a test-harness race, not a retry-budget or provider behavior defect.

## Validation

- Before on current main: full WhatsApp config failed these 2 tests (2/1366), each expecting one callback and observing two
- After: focused file 17/17
- After: full WhatsApp config 98 files, 1366/1366
- max-lines ratchet OK: 894 grandfathered suppressions.
OPENCLAW_* count 501/501
assertion SAFETY ratchet OK: 4248 files, 13304 grandfathered assertions.
[doctor-deprecation-registry] OK as of 2026-08-26
No guarded extension wildcard re-exports found.
No plugin-sdk wildcard re-exports found in extension API barrels.
[dup:check] target coverage ok
Coercion helper declaration guard passed (106 allowlisted declarations).
PASS direct dependency pin guard: checked 622 directly declared dependency specs across 177 tracked package manifests; 0 violations.
Checking formatting...

All matched files use the correct format.
Finished in 58ms on 1 files using 16 threads.
deprecated API usage guard passed
Plugin Boundary Report

compat deprecated=23 eligibleForRemoval=0 removalPending=3 removalPendingDue=0
  removal-pending 2026-09-30 plugin-sdk-media-understanding-public-demotion due=false blocker=`api.registerMediaUnderstandingProvider(...)` with provider-owned request helpers and types from `openclaw/plugin-sdk/plugin-entry`; retain the public subpath through the 2026-09-30 window while official plugin consumers migrate readerRefs=44 readers=extensions/anthropic/media-understanding-provider.ts,extensions/browser/src/browser/vision.ts,extensions/browser/src/sdk-setup-tools.ts,extensions/codex/media-understanding-provider.ts,extensions/deepgram/audio.ts
  removal-pending 2026-09-30 plugin-sdk-memory-host-core-public-demotion due=false blocker=host-prepared memory prompts via `openclaw/plugin-sdk/core` and memory capability registration through the injected plugin API; retain the facade through the 2026-09-30 window and until a focused public-artifact read seam exists readerRefs=23 readers=extensions/active-memory/index.test.ts,extensions/active-memory/index.ts,extensions/codex/src/app-server/attempt-context.test.ts,extensions/memory-core/src/memory-get-corpus.test.ts,extensions/memory-core/src/public-artifacts.ts
  removal-pending 2026-12-01 plugin-sdk-plugin-config-runtime-public-demotion due=false blocker=`api.pluginConfig`, runtime tool context config, and focused `config-contracts`, `runtime-config-snapshot`, or `config-mutation` subpaths; retain the public subpath through the 2026-12-01 window while official plugin consumers migrate readerRefs=58 readers=extensions/active-memory/index.ts,extensions/active-memory/session-policy.ts,extensions/amazon-bedrock-mantle/register.sync.runtime.ts,extensions/amazon-bedrock/register.sync.runtime.ts,extensions/browser/src/sdk-config.ts
plugin-sdk entrypoints=337 supportedBundledFacade=2 publicPluginOwned=1
memory-host-sdk implementation=private-package-core-integrated private=true exports=10 sourceBridgeFiles=0 coreReferenceFiles=10
PASS package patch guard: no new pnpm patches; 2 approved patches allowlisted.
[deadcode] Knip production unused-export scan passed with 0 entries.
[deadcode] Knip full-tree unused-export scan passed with 0 entries.
[deadcode] Knip script unused-export scan passed with 0 entries.
[deadcode] Knip production and full-tree unused-export checks passed with 0 entries.
[qa-channel boundary dts] fresh; skipping
[memory-core boundary dts] fresh; skipping
[matrix boundary dts] fresh; skipping
[discord boundary dts] fresh; skipping
[slack boundary dts] fresh; skipping
[whatsapp boundary dts] fresh; skipping
[telegram boundary dts] fresh; skipping
Found 0 warnings and 0 errors.
Finished in 53.3s on 1 file with 263 rules using 1 threads.
- Codex autoreview: no findings (0.99 confidence)

No production code or retry semantics changed.