### PR TITLE
refactor(transcription): remove duplicate connection state

### DIFF
--- a/src/realtime-transcription/websocket-session.ts
+++ b/src/realtime-transcription/websocket-session.ts
@@ -74,7 +74,6 @@ function defaultParseMessage(payload: Buffer): unknown {
 class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscriptionSession {
   private closeTimer: ReturnType<typeof setTimeout> | undefined;
   private closed = false;
-  private connected = false;
   private currentUrl = "";
   private queuedAudio: Array<Buffer | undefined> = [];
   private queuedAudioHead = 0;
@@ -134,7 +133,6 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
     }
     this.closed = true;
     this.cancelConnecting?.();
-    this.connected = false;
     this.ready = false;
     this.readySinceMs = undefined;
     this.reconnectSupervisor.cancel();
@@ -158,7 +156,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
   }
 
   isConnected(): boolean {
-    return this.connected && this.ready;
+    return this.ready;
   }
 
   private get closeTimeoutMs(): number {
@@ -331,7 +329,6 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
             return;
           }
           opened = true;
-          this.connected = true;
           this.captureLocalOpen();
           try {
             this.options.onOpen?.(transport);
@@ -380,7 +377,6 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
           clearConnectTimeout();
           this.captureClose(code, reasonBuffer);
           const readyForMs = this.readySinceMs === undefined ? 0 : Date.now() - this.readySinceMs;
-          this.connected = false;
           this.ready = false;
           this.readySinceMs = undefined;
           if (readyForMs >= RECONNECT_STABLE_RESET_MS) {
@@ -547,7 +543,6 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
       clearTimeout(this.closeTimer);
       this.closeTimer = undefined;
     }
-    this.connected = false;
     this.ready = false;
     this.readySinceMs = undefined;
     this.ws = null;


### PR DESCRIPTION
## What Problem This Solves

The realtime transcription WebSocket session kept a private `connected` flag that duplicated provider readiness and had to be updated across every close path. This left two mutable projections for the single externally observable connected state.

## Why This Change Was Made

Remove the redundant private projection and derive `isConnected()` directly from the canonical provider-ready state. Socket ownership and readiness checks still gate sends and transport operations; transcript/audio bytes and ordering, provider calls, timing, lifecycle, errors, and public types are unchanged.

## User Impact

No user-visible behavior changes. The session lifecycle has one fewer mutable concept and five fewer production lines net.

## Evidence

- Production LOC: +1/-6 (net -5); tests: +0/-0.
- `node scripts/run-vitest.mjs src/realtime-transcription/websocket-session.test.ts` — 29 passed.
- `node scripts/check-changed.mjs -- src/realtime-transcription/websocket-session.ts` — passed, including format, core/core-test types, lint, import cycles, and repository guards.
- Test audit: existing lifecycle coverage already checks pre-ready, ready, close, reconnect, timeout, and flap transitions through `isConnected()`; no implementation-coupled replacement test added.
- Structured Codex autoreview of the uncommitted diff and separate exact commit `c1535d0f48b` — clean, no findings (0.99 confidence).
- Live overlap recheck immediately before commit: no open issue/PR for `realtime transcription`, `websocket-session`, or `realtime-transcription`; current main `1e6844b71aa2299c082d23cf66dce38ff00b2211` has no `src/realtime-transcription/**` or `src/talk/**` changes from the frozen base.
