### PR TITLE
fix(ui): preserve focused settings edits during config polling

### DIFF
--- a/ui/src/e2e/config-form-integrity.e2e.test.ts
+++ b/ui/src/e2e/config-form-integrity.e2e.test.ts
@@ -296,4 +296,59 @@ suite.define(() => {
       },
     );
   });
+
+  it("keeps a focused scalar edit alive while applied config polling is pending", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: configFormIntegrityMocks(),
+      });
+      await page.goto(`${suite.server.baseUrl}settings/advanced?section=laboratory`);
+
+      const endpoint = page.getByRole("textbox", { name: "Endpoint slug" });
+      const retryBudget = page.getByRole("spinbutton", { name: "Retry budget" });
+      await expect.poll(() => endpoint.inputValue()).toBe("local-api");
+
+      await gateway.deferNext("config.set");
+      const initialSetCount = (await gateway.getRequests("config.set")).length;
+      await retryBudget.fill("6");
+      await gateway.waitForRequest("config.set", { after: initialSetCount });
+      const firstSetCount = (await gateway.getRequests("config.set")).length;
+
+      const endpointHandle = await endpoint.elementHandle();
+      expect(endpointHandle).not.toBeNull();
+      await endpointHandle!.evaluate((element) => {
+        element.focus();
+        (element as HTMLInputElement).value = "poll-safe-api";
+      });
+      const configGetCount = (await gateway.getRequests("config.get")).length;
+      await gateway.deferNext("config.get");
+      await gateway.resolveDeferred("config.set");
+      await gateway.waitForRequest("config.get", { after: configGetCount });
+
+      expect(
+        await endpointHandle!.evaluate((element) => [
+          element.isConnected,
+          !(element as HTMLInputElement).disabled,
+          document.activeElement === element,
+          (element as HTMLInputElement).value,
+        ]),
+      ).toEqual([true, true, true, "poll-safe-api"]);
+
+      await gateway.deferNext("config.set");
+      await endpointHandle!.evaluate((element) => {
+        element.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+      });
+      await gateway.resolveDeferred("config.get", {
+        ...configFormIntegrityMocks()["config.get"],
+        appliedConfigHash: "mock-config-hash-1",
+        configRevisionHash: "mock-config-hash-1",
+        hash: "mock-config-hash-1",
+      });
+      const request = await gateway.waitForRequest("config.set", { after: firstSetCount });
+      expect(JSON.parse(String((request.params as { raw?: string }).raw))).toMatchObject({
+        laboratory: { endpoint: "poll-safe-api", retryBudget: 6 },
+      });
+      await gateway.resolveDeferred("config.set");
+    });
+  });
 });

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -226,6 +226,7 @@ export async function loadConfig(
   state: RuntimeConfigState,
   options: LoadConfigOptions = {},
   isCurrentLoad: () => boolean = () => true,
+  execution: { presentation?: "background" | "foreground" } = {},
 ): Promise<boolean> {
   const client = state.client;
   if (!client || !state.connected) {
@@ -233,7 +234,10 @@ export async function loadConfig(
   }
   const connectionEpoch = currentConfigConnectionEpoch(state);
   const version = nextRequestVersion(state, "config");
-  state.configLoading = true;
+  const foreground = execution.presentation !== "background";
+  if (foreground) {
+    state.configLoading = true;
+  }
   state.lastError = null;
   state.chatError = null;
   try {
@@ -249,7 +253,7 @@ export async function loadConfig(
     }
     return false;
   } finally {
-    if (isCurrentRequest(state, "config", version, client, connectionEpoch)) {
+    if (foreground && isCurrentRequest(state, "config", version, client, connectionEpoch)) {
       state.configLoading = false;
     }
   }

--- a/ui/src/lib/config/runtime-config-capability.applied-refresh.test.ts
+++ b/ui/src/lib/config/runtime-config-capability.applied-refresh.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment node
+import { expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ConfigSnapshot } from "../../api/types.ts";
+import { createConfigCapabilityHarness, deferred } from "./config-test-harness.ts";
+
+it("keeps applied-hash polling in the background while converging", async () => {
+  vi.useFakeTimers();
+  const refresh = deferred<ConfigSnapshot>();
+  let getCount = 0;
+  const snapshot = {
+    config: { count: 2 },
+    raw: '{"count":2}',
+    hash: "raw-hash-2",
+    configRevisionHash: "revision-2",
+    appliedConfigHash: "revision-1",
+    valid: true,
+    issues: [],
+  } satisfies ConfigSnapshot;
+  const request = vi.fn((method: string) => {
+    if (method !== "config.get") {
+      return Promise.resolve({});
+    }
+    getCount += 1;
+    return getCount === 1 ? Promise.resolve(snapshot) : refresh.promise;
+  });
+  const { runtimeConfig } = createConfigCapabilityHarness(
+    request as GatewayBrowserClient["request"],
+  );
+  await runtimeConfig.ensureLoaded();
+  const loadingPublications: boolean[] = [];
+  runtimeConfig.subscribe((state) => loadingPublications.push(state.configLoading));
+
+  await vi.advanceTimersByTimeAsync(250);
+
+  expect(getCount).toBe(2);
+  expect(loadingPublications).not.toContain(true);
+  refresh.resolve({ ...snapshot, appliedConfigHash: "revision-2" });
+  await vi.advanceTimersByTimeAsync(0);
+  expect(runtimeConfig.state.configNeedsApply).toBe(false);
+  runtimeConfig.dispose();
+});

--- a/ui/src/lib/config/runtime-config-capability.ts
+++ b/ui/src/lib/config/runtime-config-capability.ts
@@ -142,7 +142,8 @@ export function createRuntimeConfigCapability(
       state.connected &&
       state.configNeedsApply &&
       state.configSnapshot?.appliedConfigHash !== undefined,
-    refresh: (isCurrent) => loadOnce("config", () => loadConfig(state, {}, isCurrent)),
+    refresh: (isCurrent) =>
+      loadOnce("config", () => loadConfig(state, {}, isCurrent, { presentation: "background" })),
   });
   const refreshConnectionState = () => {
     const config = run(() => loadConfig(state));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users editing a focused Settings field could have the control disabled and unfocused before its input event committed when applied-config polling started.

## Why This Change Was Made

Applied-hash polling now loads the authoritative snapshot with background presentation, so it preserves request versioning, error handling, snapshot adoption, and stale-response guards without toggling the foreground `configLoading` state. Normal loads remain foreground by default.

The repair stays at the config loader owner. It does not change applied-refresh cadence/cancellation, draft modeling, scalar controls, or Settings rendering.

## User Impact

Focused Settings inputs remain connected, enabled, focused, and editable while the Gateway checks whether a saved config revision has become active. The committed value continues through autosave instead of silently disappearing.

## Evidence

- CI symptom: run https://github.com/openclaw/openclaw/actions/runs/32965503096, job https://github.com/openclaw/openclaw/actions/runs/32965503096/job/98167314837 timed out waiting for the post-edit `config.set`. A later passing rerun (https://github.com/openclaw/openclaw/actions/runs/32966510035/job/98170487225) does not remove the race; runner timing only changed whether polling interrupted the editor.
- Parent unit regression failed with `loadingPublications = [true]` during the deferred applied-hash poll.
- Parent Chrome E2E failed with the same input still connected and retaining its DOM value, but `disabled: true` and `focused: false`.
- `node scripts/run-vitest.mjs run ui/src/lib/config/runtime-config-capability.applied-refresh.test.ts ui/src/lib/config/runtime-config-capability.test.ts ui/src/lib/config/config-gateway-operations.test.ts` — 49 passed.
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=... node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/config-form-integrity.e2e.test.ts` — 3 passed in real Chrome; the second `config.set` contained `laboratory.endpoint = "poll-safe-api"`.
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=... node scripts/run-vitest.mjs run ui/src/components/config-form-scalar-integrity.browser.test.ts` — 20 passed.
- Changed-file format, oxlint, stylelint, diff checks, i18n verification, policy ratchets, dependency guards, dead-export scan, and test-temp report passed.
- `pnpm tsgo:core:test` and `pnpm tsgo:ui` reach only the pre-existing linked-install error for missing `pako` declarations in `ui/vite.config.ts`; no changed-file type errors remain.
- Deslop: clean. Structured Claude autoreview raised one shared-version ordering concern; source tracing rejected it because foreground loads synchronously register in `configLoad` and polling joins them through `loadOnce`, while write/reconnect paths cancel polling before direct loads.
- Production LOC: +8/-3 (net +5). Test LOC: +97. No docs or changelog changes.
