### PR TITLE
fix(ui): keep progress in main chat when side chat opens

### DIFF
--- a/docs/tools/progress-card.md
+++ b/docs/tools/progress-card.md
@@ -85,8 +85,7 @@ An empty plan plus empty or whitespace-only Markdown also clears it. A successfu
 
 The current chat keeps exactly one live card in the main conversation:
 
-- When the chat is wide enough that the centered composer leaves a free gutter, the card docks in that space beside the composer with its full checklist expanded.
-- At narrower widths the card appears in the collapsible surface inside the composer.
+- The card appears in the collapsible surface inside the composer at every width.
 
 Opening a side panel does not move the card out of the conversation. The placements are mutually exclusive. Hover a session row in the sidebar or a session-reference link in chat to see the same card for that session. All card placements read the same Gateway-backed state and refresh after `progressCard.changed` notifications.
 Each placement shows the local time of the last progress update, including seconds.

--- a/docs/tools/progress-card.md
+++ b/docs/tools/progress-card.md
@@ -83,13 +83,12 @@ An empty plan plus empty or whitespace-only Markdown also clears it. A successfu
 
 ## Where the card appears
 
-The current chat shows exactly one live card:
+The current chat keeps exactly one live card in the main conversation:
 
-- When the session rail is visible, the card appears in the rail.
-- Otherwise, when the chat is wide enough that the centered composer leaves a free gutter, the card docks in that space beside the composer with its full checklist expanded.
+- When the chat is wide enough that the centered composer leaves a free gutter, the card docks in that space beside the composer with its full checklist expanded.
 - At narrower widths the card appears in the collapsible surface inside the composer.
 
-The placements are mutually exclusive. Hover a session row in the sidebar or a session-reference link in chat to see the same card for that session. All card placements read the same Gateway-backed state and refresh after `progressCard.changed` notifications.
+Opening a side panel does not move the card out of the conversation. The placements are mutually exclusive. Hover a session row in the sidebar or a session-reference link in chat to see the same card for that session. All card placements read the same Gateway-backed state and refresh after `progressCard.changed` notifications.
 Each placement shows the local time of the last progress update, including seconds.
 
 ## Pin the card to the dashboard

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -18,7 +18,7 @@ const progressCard: ProgressCard = {
 };
 
 describe("renderSessionProgressCard", () => {
-  it.each(["board", "composer", "hovercard", "rail"] as const)(
+  it.each(["board", "composer", "hovercard"] as const)(
     "shows the last activity time for %s cards with and without checklist steps",
     (placement) => {
       const container = document.createElement("div");
@@ -46,7 +46,7 @@ describe("renderSessionProgressCard", () => {
 
   it("renders sanitized markdown and one accessible typed checklist", () => {
     const container = document.createElement("div");
-    render(renderSessionProgressCard(progressCard, "rail"), container);
+    render(renderSessionProgressCard(progressCard, "hovercard"), container);
 
     const card = container.querySelector(".session-progress-card");
     expect(card?.getAttribute("aria-label")).toMatch(/^1 of 3 completed\. Last activity: /);

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -7,7 +7,7 @@ import { formatTimeMs } from "../lib/format.ts";
 import { icons } from "./icons.ts";
 import { toSanitizedMarkdownHtml } from "./markdown.ts";
 
-type SessionProgressCardPlacement = "board" | "composer" | "hovercard" | "rail";
+type SessionProgressCardPlacement = "board" | "composer" | "hovercard";
 
 const STATUS_LABEL_KEYS: Record<ProgressCardStep["status"], Parameters<typeof t>[0]> = {
   completed: "sessionProgressCard.status.completed",

--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -100,7 +100,7 @@ suite.define(() => {
         await expect.poll(() => gateway.getRequests("progressCard.get")).toHaveLength(1);
 
         const visiblePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible");
-        const expectVisibleLastActivity = async (placement: "composer" | "rail") => {
+        const expectVisibleLastActivity = async (placement: "composer") => {
           const card = visiblePane.locator(`[data-progress-card-placement="${placement}"]`);
           const timestamp = card.locator("time");
           await expect
@@ -132,10 +132,10 @@ suite.define(() => {
         await page.setViewportSize({ height: 900, width: 1280 });
         await openChatSidePanelType(page, "Side chat");
         await expect
-          .poll(() => visiblePane.locator('[data-progress-card-placement="rail"]').count())
+          .poll(() => visiblePane.locator('[data-progress-card-placement="composer"]').count())
           .toBe(1);
         await expect
-          .poll(() => visiblePane.locator('[data-progress-card-placement="composer"]').count())
+          .poll(() => visiblePane.locator('[data-progress-card-placement="rail"]').count())
           .toBe(0);
         await expect.poll(() => visiblePane.locator(".session-progress-card").count()).toBe(1);
 
@@ -147,8 +147,18 @@ suite.define(() => {
         await expect
           .poll(() => visiblePane.locator(".chat-thread").textContent())
           .not.toContain("Implementation is moving.");
-        await expectVisibleLastActivity("rail");
-        await captureProof(page, "rail-visible.png");
+        await expectVisibleLastActivity("composer");
+        await captureProof(page, "composer-with-side-chat.png");
+
+        const sidePanel = visiblePane.locator(".sidebar-region__right-runtime .side-panel");
+        await sidePanel.locator(".side-panel__expand").click();
+        await expect
+          .poll(() => visiblePane.locator('[data-progress-card-placement="composer"]').count())
+          .toBe(1);
+        await expect
+          .poll(() => visiblePane.locator('[data-progress-card-placement="rail"]').count())
+          .toBe(0);
+        await sidePanel.locator(".side-panel__expand").click();
 
         await page.setViewportSize({ height: 900, width: 560 });
         await expect
@@ -157,7 +167,6 @@ suite.define(() => {
         await expect
           .poll(() => visiblePane.locator('[data-progress-card-placement="rail"]').count())
           .toBe(0);
-        const sidePanel = visiblePane.locator(".sidebar-region__right-runtime .side-panel");
         await sidePanel.locator(".side-panel__minimize").click();
         await sidePanel.waitFor({ state: "hidden" });
         await expect.poll(() => visiblePane.locator(".session-progress-card").count()).toBe(1);

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -1,5 +1,4 @@
 import { html, nothing, type TemplateResult } from "lit";
-import type { ProgressCard } from "../../../../packages/gateway-protocol/src/schema/progress-card.js";
 import type { SessionObserverDigest } from "../../../../packages/gateway-protocol/src/schema/sessions.js";
 import type { ControlUiSessionPullRequest } from "../../../../src/gateway/control-ui-contract.js";
 import { desktopFocusPath } from "../../components/desktop/desktop-focus-window.ts";
@@ -40,8 +39,6 @@ type SidebarPanelDefinitionParams = {
   startedAt: number | undefined;
   lastReadAt: number | undefined;
   pullRequests: ControlUiSessionPullRequest[];
-  progressCard: ProgressCard | null;
-  onDismissProgressCard?: (card: ProgressCard) => void;
   companion: ChatSessionCompanionThread;
   onCompanionSubmit: (question: string) => void;
   onCompanionDraftChange: (draft: string) => void;
@@ -125,8 +122,6 @@ export function sidebarPanelDefinitions(
         .activeRunId=${params.activeRunId}
         .startedAt=${params.startedAt}
         .lastReadAt=${params.lastReadAt}
-        .progressCard=${params.progressCard}
-        .onDismissProgressCard=${params.onDismissProgressCard}
         .pullRequests=${params.pullRequests}
         .companion=${params.companion}
         .connected=${state?.connected === true}

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -1,8 +1,5 @@
 import { html, nothing } from "lit";
-import type {
-  ProgressCard,
-  SessionObserverDigest,
-} from "../../../../packages/gateway-protocol/src/index.js";
+import type { SessionObserverDigest } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { isDesktopPanelAvailable } from "../../app/app-shell-chrome.ts";
 import { ChatPaneBrowserAnnotationRender } from "./chat-pane-browser-annotation-render.ts";
@@ -12,7 +9,6 @@ import {
   sidebarPanelDefinitions,
   sidebarPanelTemplates,
 } from "./chat-pane-embedded-panels.ts";
-import type { ChatProgressCardPlacement } from "./chat-pane-rails.ts";
 import type { ResolvedBoardView } from "./chat-pane-shared.ts";
 import { renderSidebarRegion, sidebarRegionCallbacks } from "./chat-pane-sidebar-layout.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
@@ -38,8 +34,6 @@ type ChatPaneLayoutRenderParams = {
   currentAgentId: string;
   board: ResolvedBoardView;
   sidebarLayout: SidebarLayout;
-  progressCardPlacement: ChatProgressCardPlacement;
-  onDismissProgressCard?: (card: ProgressCard) => void;
   sessionWorkspace: SessionWorkspaceProps;
   backgroundTasks: BackgroundTasksProps;
   chatProps: ChatProps;
@@ -60,8 +54,6 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       currentAgentId,
       board,
       sidebarLayout,
-      progressCardPlacement,
-      onDismissProgressCard,
       sessionWorkspace,
       backgroundTasks,
       chatProps,
@@ -127,8 +119,6 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       startedAt: selectedSession?.startedAt ?? state.chatStreamStartedAt ?? undefined,
       lastReadAt: selectedSession?.lastReadAt,
       pullRequests: this.sessionPullRequests,
-      progressCard: progressCardPlacement === "rail" ? this.progressCard.card : null,
-      onDismissProgressCard,
       companion: companionThread,
       onCompanionSubmit: (question) => void this.submitSessionCompanionQuestion(question),
       onCompanionDraftChange: (draft) =>

--- a/ui/src/pages/chat/chat-pane-rails.ts
+++ b/ui/src/pages/chat/chat-pane-rails.ts
@@ -8,8 +8,6 @@ import { closeSlot, isSidebarSlotVisible, openSlot, type SidebarSlotId } from ".
 type ChatPaneSidebarLayout = Parameters<typeof isSidebarSlotVisible>[0];
 type ChatPaneGatewaySnapshot = Parameters<typeof isDesktopPanelAvailable>[0];
 
-export type ChatProgressCardPlacement = "composer";
-
 export function releaseAttachmentWorkspaceOwner(state: ChatPageHost, slot: SidebarSlotId): void {
   // Attachment views temporarily own Files content. Release that owner
   // with the slot so reopening Files restores the session workspace.
@@ -74,12 +72,10 @@ export function createChatPaneRails(params: {
     narrowLayout: false,
     onToggleCollapsed: () => togglePanelSlot("tasks"),
   };
-  const progressCardPlacement: ChatProgressCardPlacement = "composer";
   return {
     backgroundTasks,
     closePanelSlot,
     openPanelSlot,
-    progressCardPlacement,
     sessionWorkspace,
   };
 }

--- a/ui/src/pages/chat/chat-pane-rails.ts
+++ b/ui/src/pages/chat/chat-pane-rails.ts
@@ -3,28 +3,12 @@ import type { ChatPageHost } from "./chat-state-host.ts";
 import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
 import { openTaskDetailId } from "./components/chat-detail-slot.ts";
 import { createSessionWorkspaceProps } from "./components/chat-session-workspace.ts";
-import {
-  SIDEBAR_NARROW_BREAKPOINT_PX,
-  closeSlot,
-  isSidebarSlotVisible,
-  openSlot,
-  type SidebarSlotId,
-} from "./sidebar-layout.ts";
+import { closeSlot, isSidebarSlotVisible, openSlot, type SidebarSlotId } from "./sidebar-layout.ts";
 
 type ChatPaneSidebarLayout = Parameters<typeof isSidebarSlotVisible>[0];
 type ChatPaneGatewaySnapshot = Parameters<typeof isDesktopPanelAvailable>[0];
 
-export type ChatProgressCardPlacement = "composer" | "rail";
-
-/** Picks the single live progress-card placement for one chat pane. */
-function chatProgressCardPlacement(params: {
-  companionRailVisible: boolean;
-}): ChatProgressCardPlacement {
-  if (params.companionRailVisible) {
-    return "rail";
-  }
-  return "composer";
-}
+export type ChatProgressCardPlacement = "composer";
 
 export function releaseAttachmentWorkspaceOwner(state: ChatPageHost, slot: SidebarSlotId): void {
   // Attachment views temporarily own Files content. Release that owner
@@ -38,7 +22,6 @@ export function releaseAttachmentWorkspaceOwner(state: ChatPageHost, slot: Sideb
 export function createChatPaneRails(params: {
   state: ChatPageHost;
   sidebarLayout: ChatPaneSidebarLayout;
-  paneWidth: number;
   presentationId: string;
   presented: boolean;
   gatewaySnapshot: ChatPaneGatewaySnapshot;
@@ -91,11 +74,7 @@ export function createChatPaneRails(params: {
     narrowLayout: false,
     onToggleCollapsed: () => togglePanelSlot("tasks"),
   };
-  const progressCardPlacement = chatProgressCardPlacement({
-    companionRailVisible:
-      params.paneWidth >= SIDEBAR_NARROW_BREAKPOINT_PX &&
-      isSidebarSlotVisible(sidebarLayout, "companion"),
-  });
+  const progressCardPlacement: ChatProgressCardPlacement = "composer";
   return {
     backgroundTasks,
     closePanelSlot,

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -234,7 +234,6 @@ export class ChatPane extends ChatPaneLayoutRender {
     } = createChatPaneRails({
       state,
       sidebarLayout,
-      paneWidth: this.paneWidth,
       presentationId: this.presentationId,
       presented: this.presented,
       gatewaySnapshot,
@@ -320,8 +319,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       waitingApproval: state.waitingApprovalStatuses.size > 0,
       compactionStatus: state.compactionStatus,
       fallbackStatus: state.fallbackStatus,
-      progressCard:
-        progressCardPlacement === "rail" || !this.progressCard.card ? null : this.progressCard.card,
+      progressCard: this.progressCard.card,
       onDismissProgressCard,
       gatewayQuestionPrompts: catalogKey || sessionParticipationBlocked ? [] : this.questionPrompts,
       onGatewayQuestionChange: () => {
@@ -650,8 +648,6 @@ export class ChatPane extends ChatPaneLayoutRender {
       currentAgentId,
       board,
       sidebarLayout,
-      progressCardPlacement,
-      onDismissProgressCard,
       sessionWorkspace,
       backgroundTasks,
       chatProps: props,

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -225,20 +225,15 @@ export class ChatPane extends ChatPaneLayoutRender {
           ? t("chat.catalog.remoteViewOnly")
           : t("chat.catalog.unsupportedViewOnly")
         : null;
-    const {
-      backgroundTasks,
-      closePanelSlot,
-      openPanelSlot,
-      progressCardPlacement,
-      sessionWorkspace,
-    } = createChatPaneRails({
-      state,
-      sidebarLayout,
-      presentationId: this.presentationId,
-      presented: this.presented,
-      gatewaySnapshot,
-      setObserverVisibility: this.setSessionObserverVisibility,
-    });
+    const { backgroundTasks, closePanelSlot, openPanelSlot, sessionWorkspace } =
+      createChatPaneRails({
+        state,
+        sidebarLayout,
+        presentationId: this.presentationId,
+        presented: this.presented,
+        gatewaySnapshot,
+        setObserverVisibility: this.setSessionObserverVisibility,
+      });
     const selfUser = resolveCurrentSelfUser({
       snapshotUser: gatewaySnapshot.selfUser,
       presenceEntries: readPresenceEntries(gatewaySnapshot.hello?.snapshot),

--- a/ui/src/pages/chat/components/chat-session-rail.ts
+++ b/ui/src/pages/chat/components/chat-session-rail.ts
@@ -1,4 +1,3 @@
-import type { ProgressCard } from "@openclaw/gateway-protocol";
 import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
 import { ref } from "lit/directives/ref.js";
@@ -8,7 +7,6 @@ import type { ControlUiSessionPullRequest } from "../../../../../src/gateway/con
 import { icons } from "../../../components/icons.ts";
 import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
 import { renderPanelEmptyState } from "../../../components/panel-empty-state.ts";
-import { renderSessionProgressCard } from "../../../components/session-progress-card.ts";
 import "../../../components/tooltip.ts";
 import "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
@@ -219,8 +217,6 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
   @property({ attribute: false }) activeRunId: string | null = null;
   @property({ attribute: false }) startedAt?: number;
   @property({ attribute: false }) lastReadAt?: number;
-  @property({ attribute: false }) progressCard: ProgressCard | null = null;
-  @property({ attribute: false }) onDismissProgressCard?: (card: ProgressCard) => void;
   @property({ attribute: false }) pullRequests: ControlUiSessionPullRequest[] = [];
   @property({ attribute: false }) companion: ChatSessionCompanionThread = {
     exchanges: [],
@@ -627,7 +623,6 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
         ${digest
           ? html`<div class="chat-session-rail__digest">${this.renderDigestDetails(digest)}</div>`
           : nothing}
-        ${renderSessionProgressCard(this.progressCard, "rail", this.onDismissProgressCard)}
         ${this.renderThread()}
         ${this.companion.exchanges.length === 0 && !this.companion.pendingQuestion
           ? this.renderStarters()

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -417,13 +417,6 @@
   animation: fade-in 0.2s var(--ease-out);
 }
 
-.session-progress-card--rail {
-  flex: 0 0 auto;
-  margin: 10px 14px 0;
-  padding-top: 10px;
-  border-top: 1px solid var(--border);
-}
-
 .session-progress-card--board {
   padding: var(--space-3);
 }


### PR DESCRIPTION
Closes #130107

## What Problem This Solves

Fixes an issue where users opening Side chat during an active run would see the progress card move out of the main chat and into the side panel.

## Why This Change Was Made

In this PR, the canonical progress-placement owner chooses only the main conversation's dock or composer placement. The obsolete Side chat rail delivery, props, and styling are removed; dashboard widgets and session hovercards keep their independent Gateway-backed progress access.

## User Impact

Opening Side chat now leaves the active progress card with the primary conversation, so the run status remains visible where the work is happening.

## Evidence

- Real-main repro: the task worktree was created cleanly from `origin/main@1e6844b71aa2299c082d23cf66dce38ff00b2211`. Before any production edit, only the existing E2E expectation was inverted; `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-progress-live-placement.e2e.test.ts` failed because the main-chat composer had `0` progress cards after Side chat opened instead of `1`.
- Main-path visual repro: `node --import tsx scripts/control-ui-mock-dev.ts --host 127.0.0.1 --port 5209 --fixture workboard` served the unmodified production UI from that `origin/main` checkout. The fixture supplies deterministic Gateway data only; the first video segment exercises the real Control UI placement path and shows PROGRESS move into Side chat.
- Final rebased head: `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs ui/src/components/session-progress-card.test.ts ui/src/pages/chat/chat-session-rail.test.ts ui/src/pages/chat/chat-pane.test.ts` — 54/54 and 42/42 passed.
- Final rebased head: the focused E2E command above — 4/4 passed.
- Targeted Oxfmt, Stylelint, and `git diff --check origin/main...HEAD` passed.
- Production LOC: +8/−55 (net −47). Tests: +5/−5. Docs: +3/−4.
- Codex autoreview on the final branch was clean with no accepted/actionable findings.
- AI-assisted: yes; the owner path, pre-fix failure, mock flow, final MP4, focused tests, and final diff were inspected directly.

The 9.9-second H.264 MP4 was inspected at 1280×800. The first segment, recorded before the production edit on real `origin/main`, shows PROGRESS moving into Side chat. After the black divider, the same flow on the fix keeps PROGRESS in the main chat.

https://github.com/user-attachments/assets/79d0c251-5e81-4945-9565-af758f7bdae3
