### PR TITLE
fix: dashboard tools target the wrong Gateway after admission

### DIFF
--- a/src/agents/harness/host-capability.test.ts
+++ b/src/agents/harness/host-capability.test.ts
@@ -4,11 +4,16 @@ import path from "node:path";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import type { GatewayRequestContext } from "../../gateway/server-methods/types.js";
 import {
   resetAgentRunRegistryForTest,
   rotateAgentRunRegistryLifecycleGeneration,
   validateAgentRunDelegatedAuthority,
 } from "../../infra/agent-run-registry.js";
+import {
+  bindGatewayContextResolver,
+  withPluginRuntimeGatewayRequestScope,
+} from "../../plugins/runtime/gateway-request-scope.js";
 import {
   closeAdmittedRunDelegatedAuthority,
   createOperationalRunInstanceRef,
@@ -29,6 +34,7 @@ import {
 import type { AnyAgentTool } from "../tools/common.js";
 import { getGatewayToolCallerIdentity } from "../tools/gateway-caller-context.js";
 import { callGatewayTool } from "../tools/gateway.js";
+import { getInProcessGatewayToolContext } from "../tools/in-process-gateway.js";
 import {
   createAgentHarnessHostCapabilities,
   retainBeforeToolCallForNativeHookRelay,
@@ -240,6 +246,44 @@ describe("agent harness host capability", () => {
     });
     host.close();
     expect(() => host.capabilities.preparedEnvironment?.()).toThrow("no longer active");
+  });
+
+  it("rejects retained preparation after the admitted Gateway is replaced", async () => {
+    const { attempt } = await admittedAttempt("run-prepared-gateway");
+    const admitted = {} as GatewayRequestContext;
+    const replacement = {} as GatewayRequestContext;
+    let current = admitted;
+    bindGatewayContextResolver(attempt.admittedRunContext, () => current);
+    const preparedExecute = vi.fn(async () => ({ content: [], details: {} }));
+    const tool = attachInternalToolExecutionPreparer(testTool().tool, async () => {
+      expect(getInProcessGatewayToolContext()).toBe(admitted);
+      return {
+        kind: "ready",
+        args: {},
+        execute: preparedExecute,
+        dispose: vi.fn(),
+      };
+    });
+    const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "codex" });
+    const [bound] = host.capabilities.bindToolSurface([tool]);
+    const preparer = bound ? getInternalToolExecutionPreparer(bound) : undefined;
+    if (!preparer) {
+      throw new Error("expected bound preparer");
+    }
+
+    await withPluginRuntimeGatewayRequestScope(
+      { context: replacement, isWebchatConnect: () => false },
+      async () => {
+        const prepared = await preparer({ toolCallId: "prepare", args: {} });
+        expect(prepared.kind).toBe("ready");
+        current = replacement;
+        if (prepared.kind === "ready") {
+          await expect(prepared.execute()).rejects.toThrow("no longer active");
+        }
+      },
+    );
+
+    expect(preparedExecute).not.toHaveBeenCalled();
   });
 
   it("delegates trajectory events and rejects a flush that outlives the capability", async () => {

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -168,16 +168,18 @@ export function createAgentHarnessHostCapabilities(params: {
   // Lexical closure must also fence work already past its entry guard. The
   // result guards below cover exact authority loss that does not use close().
   const capabilityAbortController = new AbortController();
-  const assertActive = () => {
+  const callerIdentity = createBoundCallerIdentity(attempt, assertActive);
+  function assertActive() {
     if (
       !active ||
       attempt.admittedRunContext.operationalRunInstance !== operationalRunInstance ||
-      getAdmittedRunDelegatedAuthority(attempt.admittedRunContext) !== delegatedAuthority
+      getAdmittedRunDelegatedAuthority(attempt.admittedRunContext) !== delegatedAuthority ||
+      (callerIdentity?.gatewayContextResolver !== undefined &&
+        callerIdentity.gatewayContextResolver() === undefined)
     ) {
       throw new Error("agent harness host capability is no longer active");
     }
-  };
-  const callerIdentity = createBoundCallerIdentity(attempt, assertActive);
+  }
   const requester = {
     ...((attempt.messageChannel ?? attempt.messageProvider)
       ? { channel: attempt.messageChannel ?? attempt.messageProvider ?? undefined }
@@ -276,7 +278,9 @@ export function createAgentHarnessHostCapabilities(params: {
     const assertRecoveryActive = () => {
       if (
         attempt.abortSignal?.aborted ||
-        attempt.admittedRunContext.operationalRunInstance !== operationalRunInstance
+        attempt.admittedRunContext.operationalRunInstance !== operationalRunInstance ||
+        (callerIdentity?.gatewayContextResolver !== undefined &&
+          callerIdentity.gatewayContextResolver() === undefined)
       ) {
         throw new Error("agent harness retained host policy is no longer active");
       }

--- a/src/agents/tools/dashboard-tool.test.ts
+++ b/src/agents/tools/dashboard-tool.test.ts
@@ -1,8 +1,17 @@
 import { Value } from "typebox/value";
 import { describe, expect, it, vi } from "vitest";
 import type { BoardCommand, BoardSnapshot } from "../../../packages/gateway-protocol/src/index.js";
+import {
+  createGatewayMethodDescriptorsFromHandlers,
+  createGatewayMethodRegistry,
+} from "../../gateway/methods/registry.js";
+import type {
+  GatewayRequestContext,
+  GatewayRequestHandlers,
+} from "../../gateway/server-methods/types.js";
 import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { createDashboardTool } from "./dashboard-tool.js";
+import { withGatewayToolCallerIdentity } from "./gateway-caller-context.js";
 import type { InProcessGatewayCaller } from "./in-process-gateway.js";
 
 const snapshot: BoardSnapshot = {
@@ -31,6 +40,32 @@ function recorder(boardSnapshot: BoardSnapshot = snapshot) {
       return 2;
     },
   };
+}
+
+function createGatewayAffinityHarness(revision: number) {
+  const calls: string[] = [];
+  const broadcastToConnIds = vi.fn();
+  const handlers: GatewayRequestHandlers = {
+    "board.get": ({ req, respond }) => {
+      calls.push(req.method);
+      respond(true, { ...snapshot, revision });
+    },
+  };
+  const methodRegistry = createGatewayMethodRegistry(
+    createGatewayMethodDescriptorsFromHandlers({
+      handlers,
+      owner: { kind: "core", area: "dashboard-affinity-test" },
+      defaultScope: "operator.read",
+    }),
+  );
+  const context = {
+    broadcastToConnIds,
+    getClientConnIds: () => new Set([`control-ui-${revision}`]),
+    getGatewayMethodRegistry: () => methodRegistry,
+    getRuntimeConfig: () => ({}),
+    resolveGatewayContext: () => context,
+  } as unknown as GatewayRequestContext;
+  return { broadcastToConnIds, calls, context };
 }
 
 describe("dashboard tool", () => {
@@ -92,6 +127,50 @@ describe("dashboard tool", () => {
       type: "text",
       text: expect.stringContaining('"revision":3'),
     });
+  });
+
+  it("keeps reads and broadcasts on the admitted Gateway and rejects its replacement", async () => {
+    const admitted = createGatewayAffinityHarness(11);
+    const replacement = createGatewayAffinityHarness(22);
+    let current = admitted.context;
+    const tool = createDashboardTool({ agentSessionKey: "agent:main:main" });
+
+    await withPluginRuntimeGatewayRequestScope(
+      {
+        context: replacement.context,
+        isWebchatConnect: () => false,
+      },
+      async () =>
+        await withGatewayToolCallerIdentity(
+          {
+            agentId: "main",
+            sessionKey: "agent:main:main",
+            gatewayContextResolver: () => current,
+          },
+          async () => {
+            const read = await tool.execute("read", { action: "read" });
+            const command = await tool.execute("focus", {
+              action: "focus_tab",
+              tabId: "main",
+            });
+            expect(read.details).toMatchObject({ revision: 11 });
+            expect(command.details).toEqual({ ok: true, delivered: 1 });
+
+            current = replacement.context;
+            await expect(tool.execute("late-read", { action: "read" })).rejects.toThrow(
+              /dashboard|Gateway|gateway|unavailable/u,
+            );
+            await expect(
+              tool.execute("late-focus", { action: "focus_tab", tabId: "main" }),
+            ).rejects.toThrow(/dashboard|Gateway|gateway|unavailable/u);
+          },
+        ),
+    );
+
+    expect(admitted.calls).toEqual(["board.get"]);
+    expect(replacement.calls).toEqual([]);
+    expect(admitted.broadcastToConnIds).toHaveBeenCalledOnce();
+    expect(replacement.broadcastToConnIds).not.toHaveBeenCalled();
   });
 
   it("returns content ownership and valid update paths in model-visible snapshot details", async () => {

--- a/src/agents/tools/dashboard-tool.test.ts
+++ b/src/agents/tools/dashboard-tool.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../gateway/methods/registry.js";
 import type {
   GatewayRequestContext,
+  GatewayRequestHandlerOptions,
   GatewayRequestHandlers,
 } from "../../gateway/server-methods/types.js";
 import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
@@ -43,11 +44,11 @@ function recorder(boardSnapshot: BoardSnapshot = snapshot) {
 }
 
 function createGatewayAffinityHarness(revision: number) {
-  const calls: string[] = [];
+  const requests: GatewayRequestHandlerOptions["req"][] = [];
   const broadcastToConnIds = vi.fn();
   const handlers: GatewayRequestHandlers = {
     "board.get": ({ req, respond }) => {
-      calls.push(req.method);
+      requests.push(req);
       respond(true, { ...snapshot, revision });
     },
   };
@@ -65,7 +66,7 @@ function createGatewayAffinityHarness(revision: number) {
     getRuntimeConfig: () => ({}),
     resolveGatewayContext: () => context,
   } as unknown as GatewayRequestContext;
-  return { broadcastToConnIds, calls, context };
+  return { broadcastToConnIds, context, requests };
 }
 
 describe("dashboard tool", () => {
@@ -129,10 +130,10 @@ describe("dashboard tool", () => {
     });
   });
 
-  it("keeps reads and broadcasts on the admitted Gateway and rejects its replacement", async () => {
+  it("dispatches through the admitted Gateway and fences replacement or retirement", async () => {
     const admitted = createGatewayAffinityHarness(11);
     const replacement = createGatewayAffinityHarness(22);
-    let current = admitted.context;
+    let current: GatewayRequestContext | undefined = admitted.context;
     const tool = createDashboardTool({ agentSessionKey: "agent:main:main" });
 
     await withPluginRuntimeGatewayRequestScope(
@@ -160,6 +161,7 @@ describe("dashboard tool", () => {
             await expect(tool.execute("late-read", { action: "read" })).rejects.toThrow(
               /dashboard|Gateway|gateway|unavailable/u,
             );
+            current = undefined;
             await expect(
               tool.execute("late-focus", { action: "focus_tab", tabId: "main" }),
             ).rejects.toThrow(/dashboard|Gateway|gateway|unavailable/u);
@@ -167,8 +169,15 @@ describe("dashboard tool", () => {
         ),
     );
 
-    expect(admitted.calls).toEqual(["board.get"]);
-    expect(replacement.calls).toEqual([]);
+    expect(admitted.requests).toEqual([
+      expect.objectContaining({
+        type: "req",
+        id: expect.stringMatching(/^plugin-subagent-/u),
+        method: "board.get",
+        params: expect.objectContaining({ sessionKey: "agent:main:main" }),
+      }),
+    ]);
+    expect(replacement.requests).toEqual([]);
     expect(admitted.broadcastToConnIds).toHaveBeenCalledOnce();
     expect(replacement.broadcastToConnIds).not.toHaveBeenCalled();
   });

--- a/src/agents/tools/dashboard-tool.ts
+++ b/src/agents/tools/dashboard-tool.ts
@@ -5,6 +5,7 @@ import type {
   BoardOp,
   BoardSnapshot,
 } from "../../../packages/gateway-protocol/src/index.js";
+import type { GatewayContextResolver } from "../../gateway/server-methods/types.js";
 import type { AnyAgentTool } from "./common.js";
 import {
   readNumberParam,
@@ -13,6 +14,7 @@ import {
   textResult,
   ToolInputError,
 } from "./common.js";
+import { getGatewayToolCallerIdentity } from "./gateway-caller-context.js";
 import {
   callInProcessGatewayTool,
   getInProcessGatewayToolContext,
@@ -88,11 +90,14 @@ const DashboardToolSchema = Type.Object(
   { additionalProperties: false },
 );
 
-type DashboardCommandEmitter = (params: {
-  sessionKey: string;
-  agentId?: string;
-  command: BoardCommand;
-}) => number;
+type DashboardCommandEmitter = (
+  params: {
+    sessionKey: string;
+    agentId?: string;
+    command: BoardCommand;
+  },
+  resolveGatewayContext?: GatewayContextResolver,
+) => number;
 
 type DashboardGatewayContext = {
   getClientConnIds?: (
@@ -229,12 +234,17 @@ function opForAction(action: string, params: Record<string, unknown>): BoardOp {
   }
 }
 
-function emitBoardCommand(params: {
-  sessionKey: string;
-  agentId?: string;
-  command: BoardCommand;
-}): number {
-  const context = getInProcessGatewayToolContext() as DashboardGatewayContext | undefined;
+function emitBoardCommand(
+  params: {
+    sessionKey: string;
+    agentId?: string;
+    command: BoardCommand;
+  },
+  resolveGatewayContext?: GatewayContextResolver,
+): number {
+  const context = getInProcessGatewayToolContext(resolveGatewayContext) as
+    | DashboardGatewayContext
+    | undefined;
   if (!context) {
     throw new ToolInputError("dashboard command unavailable outside gateway runtime");
   }
@@ -295,23 +305,32 @@ export function createDashboardTool(opts: DashboardToolOptions = {}): AnyAgentTo
       const params = rawArgs as Record<string, unknown>;
       const action = readToolStringParam(params, "action", { required: true });
       const sessionKey = requireSessionKey(opts.agentSessionKey);
+      const admittedResolver = getGatewayToolCallerIdentity()?.gatewayContextResolver;
+      const gatewayOptions = admittedResolver
+        ? { resolveGatewayContext: admittedResolver }
+        : undefined;
+      const callGateway = <T>(method: string, gatewayParams: Record<string, unknown>) =>
+        gatewayCall<T>(method, gatewayParams, gatewayOptions);
       if (action === "read") {
         return snapshotResult(
-          await gatewayCall<BoardSnapshot>("board.get", {
+          await callGateway<BoardSnapshot>("board.get", {
             sessionKey,
             agentId: opts.agentId,
           }),
         );
       }
       if (action === "focus_tab") {
-        const delivered = emitCommand({
-          sessionKey,
-          agentId: opts.agentId,
-          command: {
-            kind: "focus_tab",
-            tabId: readTabId(params),
+        const delivered = emitCommand(
+          {
+            sessionKey,
+            agentId: opts.agentId,
+            command: {
+              kind: "focus_tab",
+              tabId: readTabId(params),
+            },
           },
-        });
+          admittedResolver,
+        );
         return commandResult(delivered);
       }
       if (action === "set_chat_dock") {
@@ -319,11 +338,14 @@ export function createDashboardTool(opts: DashboardToolOptions = {}): AnyAgentTo
         if (!dock) {
           throw new ToolInputError("dock required");
         }
-        const delivered = emitCommand({
-          sessionKey,
-          agentId: opts.agentId,
-          command: { kind: "set_chat_dock", dock },
-        });
+        const delivered = emitCommand(
+          {
+            sessionKey,
+            agentId: opts.agentId,
+            command: { kind: "set_chat_dock", dock },
+          },
+          admittedResolver,
+        );
         return commandResult(delivered);
       }
       if (action === "widget_put") {
@@ -337,7 +359,7 @@ export function createDashboardTool(opts: DashboardToolOptions = {}): AnyAgentTo
         const after = readToolStringParam(params, "after");
         const props = readPluginProps(params);
         return snapshotResult(
-          await gatewayCall<BoardSnapshot>("board.widget.put", {
+          await callGateway<BoardSnapshot>("board.widget.put", {
             sessionKey,
             agentId: opts.agentId,
             name: readToolStringParam(params, "name", { required: true }),
@@ -360,7 +382,7 @@ export function createDashboardTool(opts: DashboardToolOptions = {}): AnyAgentTo
         );
       }
       return snapshotResult(
-        await gatewayCall<BoardSnapshot>("board.update", {
+        await callGateway<BoardSnapshot>("board.update", {
           sessionKey,
           agentId: opts.agentId,
           ops: [opForAction(action, params)],

--- a/src/agents/tools/gateway-caller-context.test.ts
+++ b/src/agents/tools/gateway-caller-context.test.ts
@@ -2,6 +2,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
 import { createExecutionIdentityAdmissionToken } from "../../audit/execution-identity-admission.js";
+import type { GatewayRequestContext } from "../../gateway/server-methods/types.js";
 import { getPluginToolMeta, setPluginToolMeta } from "../../plugins/tools.js";
 import {
   isToolWrappedWithBeforeToolCallHook,
@@ -89,6 +90,26 @@ describe("gateway caller context wrapper", () => {
     }
 
     expect(seen).toEqual([identity, identity]);
+  });
+
+  it("pins caller identity to the Gateway present at admission", async () => {
+    const admitted = {} as GatewayRequestContext;
+    const replacement = {} as GatewayRequestContext;
+    let current = admitted;
+
+    await withGatewayToolCallerIdentity(
+      {
+        agentId: "agent-a",
+        sessionKey: "agent-a:session",
+        gatewayContextResolver: () => current,
+      },
+      () => {
+        const resolveGatewayContext = getGatewayToolCallerIdentity()?.gatewayContextResolver;
+        expect(resolveGatewayContext?.()).toBe(admitted);
+        current = replacement;
+        expect(resolveGatewayContext?.()).toBeUndefined();
+      },
+    );
   });
 
   it("scopes nested approval ownership without replacing the native runtime owner", async () => {

--- a/src/agents/tools/gateway-caller-context.ts
+++ b/src/agents/tools/gateway-caller-context.ts
@@ -2,7 +2,10 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { ExecutionIdentityAdmissionToken } from "../../audit/execution-identity-admission.js";
 import type { CronCreatorAuthorityGrant } from "../../gateway/cron-creator-authority-grant.js";
-import type { GatewayContextResolver } from "../../gateway/server-methods/types.js";
+import type {
+  GatewayContextResolver,
+  GatewayRequestContext,
+} from "../../gateway/server-methods/types.js";
 import type { WorkerSessionTurnClaim } from "../../gateway/worker-environments/placement-record.js";
 import type { WorkerTurnExecutionIdentityCapability } from "../../gateway/worker-environments/placement-turn-claim-events.js";
 import { getGatewayContextResolver } from "../../plugins/runtime/gateway-request-scope.js";
@@ -61,6 +64,32 @@ type GatewayToolCallerSource = {
 
 const gatewayToolCallerStorage = new AsyncLocalStorage<GatewayToolCallerIdentity>();
 
+// Freeze the admitted instance: a later resolver result is a replacement,
+// which retires this caller's routing authority instead of transferring it.
+function bindGatewayToolContextResolver(
+  resolveGatewayContext: GatewayContextResolver | undefined,
+): GatewayContextResolver | undefined {
+  if (!resolveGatewayContext) {
+    return undefined;
+  }
+  let admittedContext: GatewayRequestContext | undefined;
+  try {
+    admittedContext = resolveGatewayContext();
+  } catch {
+    return () => undefined;
+  }
+  if (!admittedContext) {
+    return () => undefined;
+  }
+  return () => {
+    try {
+      return resolveGatewayContext() === admittedContext ? admittedContext : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+}
+
 type AdmittedGatewayToolCallerParams = {
   admittedRunContext: AdmittedRunContext;
   receiptAuthority?: () => boolean | void;
@@ -110,7 +139,9 @@ export function createAdmittedGatewayToolCallerIdentity(
     sessionKey,
     operationalRunInstance: params.admittedRunContext.operationalRunInstance,
     executionIdentityToken: params.admittedRunContext.executionIdentityToken,
-    gatewayContextResolver: getGatewayContextResolver(params.admittedRunContext),
+    gatewayContextResolver: bindGatewayToolContextResolver(
+      getGatewayContextResolver(params.admittedRunContext),
+    ),
     receiptAuthority: composeReceiptAuthority(
       () =>
         delegatedAuthority !== undefined &&
@@ -163,7 +194,8 @@ export async function withGatewayToolCallerIdentity<T>(
     inheritedOwner?.workerTurnExecutionIdentityCapability ??
     identity.workerTurnExecutionIdentityCapability;
   const gatewayContextResolver =
-    inheritedOwner?.gatewayContextResolver ?? identity.gatewayContextResolver;
+    inheritedOwner?.gatewayContextResolver ??
+    bindGatewayToolContextResolver(identity.gatewayContextResolver);
   const cronSelfManagementJobId =
     identity.cronSelfManagementJobId?.trim() ?? inheritedOwner?.cronSelfManagementJobId;
   const cronToolsAllowCapture =

--- a/src/agents/tools/in-process-gateway.test.ts
+++ b/src/agents/tools/in-process-gateway.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { readInProcessAgentRuntimeIdentity } from "../../gateway/in-process-agent-runtime-identity.js";
+import type { GatewayRequestContext } from "../../gateway/server-methods/types.js";
 
 const mocks = vi.hoisted(() => ({
   hasContext: true,
@@ -15,12 +16,14 @@ vi.mock("../../gateway/method-scopes.js", () => ({
 vi.mock("../../gateway/server-plugins.js", () => ({
   dispatchGatewayMethodInProcess: mocks.dispatch,
   getInProcessGatewayRequestContext: vi.fn(),
-  hasInProcessGatewayContext: () => mocks.hasContext,
+  hasInProcessGatewayContext: (resolveGatewayContext?: () => GatewayRequestContext | undefined) =>
+    Boolean(resolveGatewayContext?.() ?? mocks.hasContext),
 }));
 
 vi.mock("./gateway.js", () => ({ callGatewayTool: mocks.callGatewayTool }));
 vi.mock("../../gateway/call.js", () => ({ callGateway: mocks.callGateway }));
 
+import { withGatewayToolCallerIdentity } from "./gateway-caller-context.js";
 import { getGatewaySessionSpawnContext } from "./gateway-session-spawn-context.js";
 import {
   callAgentToolGatewayRequest,
@@ -220,6 +223,47 @@ describe("request-shaped in-process Gateway dispatch", () => {
       mocks.dispatch.mock.calls.filter(([method]) => method === "conversations.turn.cancel"),
     ).toHaveLength(1);
     expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("does not route abort cleanup through a replacement Gateway", async () => {
+    const admitted = {} as GatewayRequestContext;
+    const replacement = {} as GatewayRequestContext;
+    let current = admitted;
+    let cancelDispatches = 0;
+    mocks.dispatch.mockImplementation(
+      async (
+        method: string,
+        _params: unknown,
+        options?: { onSignalAbort?: () => Promise<void> },
+      ) => {
+        if (method === "conversations.turn.cancel") {
+          cancelDispatches += 1;
+          return { status: "ok" };
+        }
+        current = replacement;
+        await options?.onSignalAbort?.();
+        throw new Error("primary aborted");
+      },
+    );
+
+    await expect(
+      withGatewayToolCallerIdentity(
+        {
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          gatewayContextResolver: () => current,
+        },
+        async () =>
+          await callAgentToolGatewayRequest({
+            method: "conversations.turn",
+            params: { turnId: "turn-1" },
+            onSignalAbort: async (request) => {
+              await request("conversations.turn.cancel", { turnId: "turn-1" });
+            },
+          }),
+      ),
+    ).rejects.toThrow(/Gateway|gateway|unavailable/u);
+    expect(cancelDispatches).toBe(0);
   });
 
   it("falls back to the original Gateway request outside the Gateway process", async () => {

--- a/src/agents/tools/in-process-gateway.ts
+++ b/src/agents/tools/in-process-gateway.ts
@@ -6,6 +6,7 @@ import { resolveLeastPrivilegeOperatorScopesForMethod } from "../../gateway/meth
 import type { TrustedSessionCreation } from "../../gateway/server-methods/session-creation-provenance.js";
 import type {
   GatewayAgentRunTaskOwner,
+  GatewayContextResolver,
   GatewayRequestContext,
   TrustedAgentToolCaller,
 } from "../../gateway/server-methods/types.js";
@@ -14,12 +15,18 @@ import {
   getInProcessGatewayRequestContext,
   hasInProcessGatewayContext,
 } from "../../gateway/server-plugins.js";
+import { getGatewayToolCallerIdentity } from "./gateway-caller-context.js";
 import { runWithGatewaySessionSpawnContext } from "./gateway-session-spawn-context.js";
 import { callGatewayTool } from "./gateway.js";
+
+type InProcessGatewayCallOptions = {
+  resolveGatewayContext?: GatewayContextResolver;
+};
 
 export type InProcessGatewayCaller = <T = Record<string, unknown>>(
   method: string,
   params: Record<string, unknown>,
+  options?: InProcessGatewayCallOptions,
 ) => Promise<T>;
 
 type AgentToolGatewayRequest = Pick<
@@ -59,12 +66,58 @@ export type AgentToolGatewayRequestCaller = <T = Record<string, unknown>>(
 
 const DEFAULT_IN_PROCESS_GATEWAY_REQUEST_TIMEOUT_MS = 10_000;
 
-export function hasInProcessGatewayToolContext(): boolean {
-  return hasInProcessGatewayContext();
+function callerGatewayContextResolver(
+  explicit?: GatewayContextResolver,
+): GatewayContextResolver | undefined {
+  return explicit ?? getGatewayToolCallerIdentity()?.gatewayContextResolver;
 }
 
-export function getInProcessGatewayToolContext(): GatewayRequestContext | undefined {
-  return getInProcessGatewayRequestContext();
+function bindInProcessGatewayContext(
+  method: string,
+  resolveGatewayContext: GatewayContextResolver,
+): { assertCurrent: () => void; resolve: GatewayContextResolver } {
+  const admittedContext = resolveGatewayContext();
+  if (!admittedContext) {
+    throw new Error(`Gateway instance unavailable for ${method}`);
+  }
+  const assertCurrent = () => {
+    if (resolveGatewayContext() !== admittedContext) {
+      throw new Error(`Gateway instance unavailable for ${method}`);
+    }
+  };
+  return {
+    assertCurrent,
+    resolve: () => {
+      assertCurrent();
+      return admittedContext;
+    },
+  };
+}
+
+async function runBoundInProcessGatewayCall<T>(
+  boundGateway: ReturnType<typeof bindInProcessGatewayContext> | undefined,
+  run: (resolveGatewayContext?: GatewayContextResolver) => Promise<T>,
+): Promise<T> {
+  try {
+    const result = await run(boundGateway?.resolve);
+    boundGateway?.assertCurrent();
+    return result;
+  } catch (error) {
+    boundGateway?.assertCurrent();
+    throw error;
+  }
+}
+
+export function hasInProcessGatewayToolContext(): boolean {
+  const resolveGatewayContext = callerGatewayContextResolver();
+  return resolveGatewayContext ? Boolean(resolveGatewayContext()) : hasInProcessGatewayContext();
+}
+
+export function getInProcessGatewayToolContext(
+  explicitResolver?: GatewayContextResolver,
+): GatewayRequestContext | undefined {
+  const resolveGatewayContext = callerGatewayContextResolver(explicitResolver);
+  return resolveGatewayContext ? resolveGatewayContext() : getInProcessGatewayRequestContext();
 }
 
 /**
@@ -72,13 +125,20 @@ export function getInProcessGatewayToolContext(): GatewayRequestContext | undefi
  * router without opening a loopback transport. Outside a Gateway process, the
  * same request falls back to the ordinary Gateway client.
  */
-export const callAgentToolGatewayRequest: AgentToolGatewayRequestCaller = async <T>(
+async function callAgentToolGatewayRequestBound<T>(
   request: AgentToolGatewayRequest,
-): Promise<T> => {
-  const runtimeIdentity = agentToolGatewayRuntimeIdentities.get(request);
-  if (!hasInProcessGatewayContext()) {
+  resolveGatewayContext: GatewayContextResolver | undefined,
+  runtimeIdentity: AgentRuntimeIdentity | undefined,
+): Promise<T> {
+  const boundGateway = resolveGatewayContext
+    ? bindInProcessGatewayContext(request.method, resolveGatewayContext)
+    : undefined;
+  if (!hasInProcessGatewayContext(boundGateway?.resolve)) {
     if (runtimeIdentity) {
       throw new Error("trusted agent runtime identity requires in-process Gateway dispatch");
+    }
+    if (boundGateway) {
+      throw new Error(`Gateway instance unavailable for ${request.method}`);
     }
     const { callGateway } = await import("../../gateway/call.js");
     const {
@@ -105,30 +165,62 @@ export const callAgentToolGatewayRequest: AgentToolGatewayRequestCaller = async 
       ? {
           onSignalAbort: () =>
             request.onSignalAbort?.((method, params, options) =>
-              callAgentToolGatewayRequest({ method, params, ...options }),
+              callAgentToolGatewayRequestBound(
+                { method, params, ...options },
+                boundGateway?.resolve ?? resolveGatewayContext,
+                runtimeIdentity,
+              ),
             ),
         }
       : {}),
     ...(request.signal ? { signal: request.signal } : {}),
     ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    ...(boundGateway ? { resolveGatewayContext: boundGateway.resolve } : {}),
   };
-  return await dispatchGatewayMethodInProcess<T>(
-    request.method,
-    (request.params ?? {}) as Record<string, unknown>,
-    withInProcessAgentRuntimeIdentity(dispatchOptions, runtimeIdentity),
+  return await runBoundInProcessGatewayCall(
+    boundGateway,
+    async () =>
+      await dispatchGatewayMethodInProcess<T>(
+        request.method,
+        (request.params ?? {}) as Record<string, unknown>,
+        withInProcessAgentRuntimeIdentity(dispatchOptions, runtimeIdentity),
+      ),
+  );
+}
+
+export const callAgentToolGatewayRequest: AgentToolGatewayRequestCaller = async <T>(
+  request: AgentToolGatewayRequest,
+): Promise<T> => {
+  return await callAgentToolGatewayRequestBound(
+    request,
+    callerGatewayContextResolver(),
+    agentToolGatewayRuntimeIdentities.get(request),
   );
 };
 
 export const callInProcessGatewayTool: InProcessGatewayCaller = async <T>(
   method: string,
   params: Record<string, unknown>,
+  options: InProcessGatewayCallOptions = {},
 ): Promise<T> => {
   const scopes = resolveLeastPrivilegeOperatorScopesForMethod(method, params);
-  if (hasInProcessGatewayContext()) {
-    return await dispatchGatewayMethodInProcess<T>(method, params, {
-      forceSyntheticClient: true,
-      syntheticScopes: scopes,
-    });
+  const resolveGatewayContext = callerGatewayContextResolver(options.resolveGatewayContext);
+  const boundGateway = resolveGatewayContext
+    ? bindInProcessGatewayContext(method, resolveGatewayContext)
+    : undefined;
+  if (hasInProcessGatewayContext(boundGateway?.resolve)) {
+    return await runBoundInProcessGatewayCall(
+      boundGateway,
+      async (boundResolver) =>
+        await dispatchGatewayMethodInProcess<T>(method, params, {
+          forceSyntheticClient: true,
+          syntheticScopes: scopes,
+          ...(boundResolver ? { resolveGatewayContext: boundResolver } : {}),
+        }),
+    );
+  }
+  if (boundGateway) {
+    throw new Error(`Gateway instance unavailable for ${method}`);
   }
   return await callGatewayTool<T>(method, {}, params, { scopes });
 };

--- a/src/gateway/server-plugin-in-process-dispatch.authorization.test.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.authorization.test.ts
@@ -158,6 +158,40 @@ describe("typed in-process agent authorization", () => {
     });
   });
 
+  it("does not fall back to ambient scope when an explicit Gateway binding is retired", async () => {
+    const ambient = createContext();
+    ambient.getGatewayMethodRegistry = () =>
+      createGatewayMethodRegistry([
+        {
+          name: "sessions.list",
+          scope: "operator.read",
+          owner: { kind: "core", area: "sessions" },
+          handler: ({ respond }: GatewayRequestHandlerOptions) => {
+            respond(true, { sessions: [] });
+          },
+        },
+      ]);
+
+    await withPluginRuntimeGatewayRequestScope(
+      {
+        context: ambient,
+        isWebchatConnect: () => false,
+      },
+      async () =>
+        await expect(
+          dispatchGatewayMethodInProcess(
+            "sessions.list",
+            {},
+            {
+              forceSyntheticClient: true,
+              resolveGatewayContext: () => undefined,
+              syntheticScopes: ["operator.read"],
+            },
+          ),
+        ).rejects.toThrow("instance binding"),
+    );
+  });
+
   it("preserves the scoped operator identity across synthetic model-initiated session creation", async () => {
     const owner = createOperatorClient({
       profileId: "model-spawn-owner",


### PR DESCRIPTION
Related: #129183

## What Problem This Solves

Fixes an issue where users asking an agent to read or control a dashboard could affect a different Gateway when another in-process Gateway context became ambient after the run was admitted.

The same ownership loss could affect retained tool preparation and abort cleanup. A dashboard operation admitted through Gateway A could read from or broadcast commands through Gateway B instead of failing when Gateway A was no longer available.

## Why This Change Was Made

Dashboard tool execution now retains the exact Gateway resolver captured when the agent run was admitted. Dashboard RPCs, direct dashboard commands, retained preparation, and abort cleanup use that resolver and fail closed when its Gateway is retired or replaced.

This change is limited to agent-tool caller identity and in-process Gateway dispatch. It does not change board handlers, tickets, plugin lifecycle, MCP App views, or Control UI behavior.

Fencing mutations or broadcasts after a board handler has already started and awaited another owner is a separate board-request authority change. It is intentionally excluded from this PR.

That owner-side boundary is implemented and independently proven in draft PR #130131. The two PRs remain separate because this PR owns agent-tool Gateway selection, while #130131 owns effects inside an already-dispatched board handler.

## User Impact

Dashboard operations remain attached to the Gateway that owns the agent run. Users no longer risk an agent reading or changing another Gateway's dashboard or sending commands to the wrong Control UI client.

## Evidence

- Before: a run admitted through Gateway A read Gateway B's board revision and sent `board.command` to Gateway B's Control UI connection.
- After: the same flow reads and broadcasts only through Gateway A.
- After Gateway A replacement: later dashboard calls fail closed and do not fall back to Gateway B.

Before:

```json
{
  "observedRevision": 22,
  "gatewayACalls": [],
  "gatewayBCalls": ["board.get"],
  "gatewayABroadcasts": [],
  "gatewayBBroadcasts": ["board.command"]
}
```

After:

```json
{
  "observedRevision": 11,
  "gatewayACalls": ["board.get"],
  "gatewayBCalls": [],
  "gatewayABroadcasts": ["board.command"],
  "gatewayBBroadcasts": [],
  "replacementError": "Gateway instance unavailable for board.get"
}
```

Inspectable authority trace:

```text
1. Admit the agent run through Gateway A (revision 11).
2. Install Gateway B (revision 22) as the ambient request context.
3. Read the board and broadcast a focus command.
   Result: Gateway A receives board.get and board.command; Gateway B receives nothing.
4. Replace the admitted resolver so it now exposes Gateway B.
5. Attempt another board read and focus command.
   Result: both calls reject as unavailable before dispatch; Gateway B still receives nothing.
```

- Focused Blacksmith Testbox: `tbx_01m0z5r19rm64a5q165ametg1k`
- Rebased verification run: https://github.com/openclaw/openclaw/actions/runs/33007166781
- Exact candidate: `0d2ef11fc6a30bef21282f7a974512fc0562adae`
- Real-dispatch regression: the test observes the actual `type: "req"` envelope with a `plugin-subagent-*` request ID through the Gateway method registry.
- Baseline: the identical test on `8e1e566ab630b08da63d6d7684fa424ede29e2fd` fails because ambient Gateway B returns revision `22` instead of admitted Gateway A revision `11`.
- Candidate: the focused dashboard suite passes 17/17; format, core-test typecheck, and oxlint are green.
- Current-main overlap: `server-plugin-in-process-dispatch.ts` already contains the same explicit-resolver precedence through its shared helper, so the rebase retained current main and dropped the duplicate PR hunk.
- Changed-file verification: changed gate, core/test typechecks, and oxlint passed.
- Independent autoreview: clean.
- Separate final-effect proof: #130131 shows current main returning success in all five stale board-handler scenarios and its candidate rejecting all five.
- Visual proof omitted because this PR changes backend Gateway ownership without changing rendered UI; the two-Gateway runtime reproduction is the direct behavioral proof.
