### PR TITLE
fix(ui): side chat composer controls are misaligned

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -4460,6 +4460,57 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("keeps the embedded side-chat composer trailing and flush with the tab strip", async () => {
+    const page = await openBrowserPage(1024, 768);
+    try {
+      await page.setContent(`<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+        <section class="chat-session-rail chat-session-rail--expanded chat-session-rail--embedded">
+          <div class="chat-session-rail__thread">Side chat</div>
+          <form class="agent-chat__input chat-session-rail__composer">
+            <div class="agent-chat__composer-input-row">
+              <label class="agent-chat__composer-combobox chat-session-rail__prompt">
+                <input class="chat-session-rail__input" type="text" placeholder="Ask a question" />
+              </label>
+            </div>
+            <div class="agent-chat__composer-footer">
+              <div class="agent-chat__composer-trail">
+                <div class="agent-chat__composer-actions">
+                  <button class="chat-send-btn">${iconSvg()}</button>
+                </div>
+              </div>
+            </div>
+          </form>
+        </section>
+      </body></html>`);
+
+      const geometry = await page.evaluate(() => {
+        const rect = (selector: string) => {
+          const element = document.querySelector<HTMLElement>(selector)!;
+          const box = element.getBoundingClientRect();
+          return { left: box.left, right: box.right, width: box.width };
+        };
+        const thread = document.querySelector<HTMLElement>(".chat-session-rail__thread")!;
+        const threadStyle = getComputedStyle(thread);
+        return {
+          composer: rect(".chat-session-rail__composer"),
+          footer: rect(".chat-session-rail__composer .agent-chat__composer-footer"),
+          input: rect(".chat-session-rail__input"),
+          send: rect(".chat-session-rail__composer .chat-send-btn"),
+          threadBorderTopWidth: threadStyle.borderTopWidth,
+          threadMarginTop: threadStyle.marginTop,
+        };
+      });
+
+      expect(geometry.input.width).toBeGreaterThan(geometry.composer.width * 0.8);
+      expect(geometry.footer.width).toBeGreaterThan(geometry.composer.width * 0.8);
+      expect(Math.abs(geometry.composer.right - geometry.send.right)).toBeLessThanOrEqual(10);
+      expect(geometry.threadBorderTopWidth).toBe("0px");
+      expect(geometry.threadMarginTop).toBe("0px");
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it.each([
     [1024, 768],
     [1366, 900],

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2012,9 +2012,10 @@ openclaw-chat-session-rail {
   overscroll-behavior-y: contain;
 }
 
-/* No digest means no digest block, so the thread would otherwise stack its own
-   border directly under the header's and open with a hanging 12px gap. */
-.chat-session-rail__header + .chat-session-rail__thread {
+/* No digest or embedded header means the thread would otherwise open with a
+   hanging divider and 12px gap. */
+.chat-session-rail__header + .chat-session-rail__thread,
+.chat-session-rail--embedded > .chat-session-rail__thread {
   margin-top: 0;
   border-top: 0;
 }
@@ -2121,16 +2122,6 @@ openclaw-chat-session-rail {
   50% {
     opacity: 0.45;
   }
-}
-
-.chat-session-rail__composer {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex: 0 0 auto;
-  padding: 10px 10px 11px 14px;
-  border-top: 1px solid var(--border);
-  background: color-mix(in srgb, var(--secondary) 40%, transparent);
 }
 
 .chat-session-rail__prompt {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Side Chat composer placed its send button in the middle of the input surface and showed a horizontal divider below the tab strip.

## Why This Change Was Made

The embedded Side Chat now inherits the canonical main-composer layout instead of overriding it with the retired rail flex alignment. Its embedded thread also starts flush below the tab strip without the standalone rail separator.

Dictation is feasible because the microphone and hold-to-dictate infrastructure already exists on `main`. It is intentionally not included here: clean Side Chat reuse still needs Gateway client plumbing and controller, picker, error, and lifecycle handling, while #127823 is actively changing those shared dictation contracts. Track it as a follow-up after #127823 merges; no code was copied from that PR.

## User Impact

Side Chat now matches the main composer: the send button sits at the trailing edge, the input uses the available width, and the panel content meets the tab strip without an extra divider.

## Evidence

https://github.com/user-attachments/assets/84312d64-df66-4c7f-8712-4c07e0c75595

- Before (first 3 seconds) → after (last 3 seconds): send alignment and top-divider removal in the live Control UI mock.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t "keeps the embedded side-chat composer trailing and flush with the tab strip"`
- `./node_modules/.bin/oxfmt --check ui/src/pages/chat/chat-responsive.browser.test.ts ui/src/styles/components.css`
