### PR TITLE
feat: offer to turn a repeated job into a scheduled automation

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -173,6 +173,49 @@ openclaw automations add \
   --session isolated
 ```
 
+## Promoting a repeated job into an automation
+
+Most automations should start as work the agent already did. When you ask for
+substantially the same job several times, the agent offers to turn it into a
+schedule instead of only running it once more. Promotion is preferred over
+building a job from scratch because the proposal inherits a run you already
+read: you know what the output looks like before it starts arriving on a
+schedule.
+
+There is no repetition-detection engine and no new stored history. The agent
+recognizes the repeat from the conversation itself and checks
+`automations(action: "list")` for an existing job before proposing a new one,
+so a routine you already created is not duplicated. The prompting that drives
+this is gated on the automations tool, so agents without it never offer a
+routine they could not create.
+
+The confirmation restates the schedule and the task in plain words before
+anything is created, for example: "Every weekday at 07:00 Europe/Vienna, I
+summarize overnight updates and post them here." Confirm that sentence, not a
+cron expression.
+
+On confirmation the agent:
+
+1. Creates the job, with delivery defaulting to the channel and thread where you
+   asked.
+2. Immediately runs it once with `run` in `force` mode as a visible test,
+   delivered to that same thread, so you see real output well before the first
+   scheduled occurrence.
+3. Removes the job and tells you if that test fails.
+
+The job is created **enabled**, not disabled-pending-approval, and that is a
+deliberate safety choice. The scheduler supervises enabled jobs: a failing one
+raises a failure notification and is auto-disabled after repeated errors, with
+the reason recorded and the owner notified. Nothing supervises a disabled job.
+A job left disabled waiting for a confirmation that never arrives is invisible
+to every guard, hidden from the default `automations list`, and will never fire
+or explain itself — a silent non-outcome, which is a worse failure than a job
+that runs and visibly complains.
+
+Your confirmation still gates creation, so nothing is scheduled behind your
+back, and the test run is a real run with real delivery rather than a rendered
+preview: what you approve is exactly what the schedule will produce.
+
 ## Payloads
 
 Every job carries exactly one payload kind, chosen by flag:

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -583,6 +583,27 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain('[embed content_type="html" title="Status"]...[/embed]');
   });
 
+  it("offers routine promotion only when the automations tool is available", () => {
+    const withAutomations = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["automations"],
+    });
+    const withoutAutomations = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["read"],
+    });
+
+    expect(withAutomations).toContain("asked a 3rd time");
+    expect(withAutomations).toContain("get a yes, create it");
+    expect(withAutomations).toContain("failed test => say so and remove it");
+    // Created enabled on purpose: the scheduler alerts and auto-disables a
+    // failing enabled job, but nothing watches one left disabled.
+    expect(withAutomations).not.toContain("enabled:false");
+    // Gated: without the tool the trigger would point at a capability the
+    // model cannot reach.
+    expect(withoutAutomations).not.toContain("asked a 3rd time");
+  });
+
   it("teaches direct status answers only on the full Control UI surface", () => {
     const defaultPrompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1026,6 +1026,7 @@ export function buildAgentSystemPrompt(params: {
   const hasGateway = availableTools.has("gateway");
   const hasOpenClaw = availableTools.has("openclaw");
   const messageToolAvailable = availableTools.has("message");
+  const hasAutomations = availableTools.has(AUTOMATIONS_TOOL_NAME);
   const readToolName = resolveToolName("read");
   const waitToolHints = [
     hasExec ? `${resolveToolName("exec")} yieldMs` : "",
@@ -1251,6 +1252,18 @@ export function buildAgentSystemPrompt(params: {
               : []),
             ...(availableTools.has("screen")
               ? ["`screen` present: web/app turn may drive UI; messaging turn: don't."]
+              : []),
+            // The repeat is noticed during ordinary work, not while reading the
+            // automations schema, so this trigger cannot live in that tool's
+            // description; it is gated on the tool so it vanishes when absent.
+            // Create enabled: a failing enabled job is alerted and auto-disabled
+            // by the scheduler, while a job left disabled pending confirmation
+            // is watched by nothing and dies silently.
+            ...(hasAutomations
+              ? [
+                  `Same job asked a 3rd time: do it, then offer a routine. Check \`${resolveToolName(AUTOMATIONS_TOOL_NAME)}\` list first; never duplicate one.`,
+                  "Promote = restate schedule+task plainly, get a yes, create it (delivery defaults here), then force `run` once as a visible test; failed test => say so and remove it.",
+                ]
               : []),
           ]
         : []),

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -133,6 +133,61 @@ describe("cron tool", () => {
     expect(tool.description).toContain('tz:"Asia/Shanghai"');
   });
 
+  it("supports the promotion creation path: enabled add inherits conversation delivery, then a forced test run", async () => {
+    // Promotion flow contract (the guidance itself lives in the system prompt,
+    // since the repeat is noticed during ordinary work rather than while
+    // reading this tool's schema). The job is created enabled so the
+    // scheduler's failure alerts and auto-disable own a broken job; a job left
+    // disabled pending confirmation is watched by nothing. Delivery is
+    // inherited from the requesting conversation and the forced run is the
+    // visible test.
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:matrix:channel:!abcdef1234567890:example.org",
+      currentDeliveryContext: {
+        channel: "matrix",
+        to: "room:!AbCdEf1234567890:example.org",
+        threadId: "$RootEvent:Example.Org",
+      },
+    });
+    callGatewayMock.mockResolvedValueOnce({ id: "job-promoted" });
+    await tool.execute("call-promote-add", {
+      action: "add",
+      job: {
+        name: "morning brief",
+        schedule: { kind: "cron", expr: "0 7 * * *", tz: "Europe/Vienna" },
+        payload: { kind: "agentTurn", message: "Summarize overnight updates." },
+      },
+    });
+    const addCall = readGatewayCall(0);
+    expect(addCall.method).toBe("cron.add");
+    // Never created disabled: that is the one state no scheduler guard watches.
+    expect(addCall.params?.enabled).not.toBe(false);
+    expect(addCall.params?.delivery).toEqual({
+      mode: "announce",
+      channel: "matrix",
+      to: "room:!AbCdEf1234567890:example.org",
+      threadId: "$RootEvent:Example.Org",
+    });
+
+    await tool.execute("call-promote-test-run", {
+      action: "run",
+      jobId: "job-promoted",
+      runMode: "force",
+    });
+    const runCall = readGatewayCall(1);
+    expect(runCall.method).toBe("cron.run");
+    expect(runCall.params).toEqual({ id: "job-promoted", mode: "force" });
+
+    // Failed test is cleaned up, not left behind as a broken schedule.
+    await tool.execute("call-promote-rollback", {
+      action: "remove",
+      jobId: "job-promoted",
+    });
+    const removeCall = readGatewayCall(2);
+    expect(removeCall.method).toBe("cron.remove");
+    expect(removeCall.params).toEqual({ id: "job-promoted" });
+  });
+
   function buildReminderAgentTurnJob(overrides: Record<string, unknown> = {}): {
     name: string;
     schedule: { at: string };


### PR DESCRIPTION
## What Problem This Solves

OpenClaw has a full automations engine, an agent-facing `automations` tool, and a task ledger, but nothing ever suggests using them. If you ask for the same job every morning, you keep asking every morning: the agent does the work and stops. Turning that into a schedule requires the user to think of it, know automations exist, and describe a schedule from scratch.

## Why This Change Was Made

When someone asks for substantially the same job a third time, the agent now does the work and then offers to promote it into a routine. Promotion beats building a job from scratch because the proposal inherits a run the user has already read: they know what the output looks like before it starts arriving on a schedule. The agent restates the schedule and task in plain words, creates the job with delivery defaulting to the requesting channel/thread, and immediately force-runs it once as a visible test.

Two design decisions worth reviewer attention:

**The guidance lives in the system prompt, gated on the automations tool — not in the tool description.** The repeat is noticed during ordinary work, not while the model is reading the automations schema, so guidance buried in that schema would never fire at the moment the trigger happens. Gating on tool availability keeps it out of contexts where automations are unavailable, so it never points at a capability the agent cannot reach. It sits with the other tool-gated workflow hints above the prompt's cache boundary, and is keyed on tool presence rather than job state, so creating automations does not perturb the cached prefix. The duplicate check stays a tool call, whose result appends to the transcript instead of invalidating the prefix.

**Jobs are created enabled, not disabled-pending-approval.** The scheduler already supervises enabled jobs (failure alerts, auto-disable after repeated errors, owner notification). Nothing supervises a disabled one: `auto-disable.ts` returns early for `!job.enabled`, and the default `automations list` hides disabled jobs. A job left disabled awaiting a confirmation that never arrives is invisible to every guard and fails silently, which is the worse failure mode. Confirmation still gates creation, so nothing is scheduled behind the user's back.

No new detection engine and no new storage. Repetition comes from the conversation; duplicates are checked with the existing automations list. No SQLite schema change.

## User Impact

Recurring work you already do by hand gets offered to you as a schedule, in the channel where you asked, with real output delivered before the first scheduled occurrence. You confirm a plain-language sentence ("Every weekday at 07:00 Europe/Vienna, I summarize overnight updates and post them here"), not a cron expression. Agents without the automations tool are unaffected.

## Evidence

**A/B eval against the real assembled system prompt.** Built the actual prompt via `buildAgentSystemPrompt` with the automations tool bound, and a control identical except for the 275 bytes this PR adds (the control still lists the automations tool). Both were given the same three-request conversation and asked for the next assistant turn, 4 samples each, run through Codex:

| Arm | Offered a routine |
| --- | --- |
| With this change | 4 / 4 |
| Control (guidance removed) | 0 / 4 |

Representative treatment output: `Today: one review request (#1221) and a CI failure on main. Everything else is noise. Want me to make this a weekday morning routine?`
Representative control output: `Today: 1 review request (#1221) and a CI failure on main. Everything else is noise.`

The offer is caused by this change rather than being something the model does anyway.

**Tests.** `src/agents/system-prompt.test.ts` covers gating in both directions (present with the tool, absent without it) and pins that the flow does not create disabled jobs. `src/agents/tools/cron-tool.test.ts` covers the creation path: add inherits the conversation's delivery context, forced test run, and removal on a failed test.

- `node scripts/run-vitest.mjs src/agents/system-prompt.test.ts` - 127 passed
- `node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts` - 203 passed
- `tsgo -p tsconfig.core.json` clean; `agents-other` test shard clean; oxlint and oxfmt clean
- Codex autoreview: clean, no accepted/actionable findings

**Proof gap, stated plainly.** There is no live dev-gateway run of the full create/run/remove sequence with real tools bound. The host was saturated (load average ~150 from parallel work) and `pnpm build` could not finish, so the gateway rig was not reachable; the eval above exercises the offer step against the real prompt, and the tool-call shapes are covered by unit tests rather than a live gateway.
