### PR TITLE
fix(ci): prevent update scenarios from poisoning later CLI checks

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1517,7 +1517,7 @@ describe("update-cli", () => {
       delete process.env[key];
     }
     restartHealthTestControl.snapshot = undefined;
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     serviceEnabled.mockResolvedValue(true);
     readPersistedInstalledPluginIndex.mockResolvedValue(null);
     restorePersistedInstalledPluginIndex.mockResolvedValue(undefined);


### PR DESCRIPTION
Related: #129971

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where the hosted CLI CI shard can report dozens of unrelated update-command failures after an earlier scenario leaves a one-shot mock implementation unused. The observed compact-small-6 failure first expected a SIGTERM rejection but completed successfully; the immediately following scenario then received that stale SIGTERM, followed by incorrect service mocks and an obsolete update entrypoint.

## Why This Change Was Made

Reset all mock implementations at the update suite's existing per-scenario lifecycle boundary before its existing setup restores the required defaults. Direct inspection of the installed Vitest spy implementation confirms that clearing mocks preserves queued one-shot implementations, while resetting them discards those queues and preserves factory-provided defaults. Deliberate mid-scenario mock clears, every existing assertion, production behavior, and global runner configuration remain unchanged.

## User Impact

No production or user-visible behavior changes. Contributors and maintainers get deterministic isolation between update-command scenarios, preventing inherited false-red CI cascades from blocking unrelated changes.

## Evidence

- Hosted failing sequence on #129971: an unconsumed one-shot SIGTERM moves from its intended update scenario into the immediately following scenario, followed by stale entrypoint and managed-service failures.
- Before: an executable owner-boundary probe using the actual update-suite setup and installed Vitest implementation fails because the next scenario receives `stale-SIGTERM` instead of `fresh-success`.
- After: the identical probe passes; separate installed-dependency proof confirms that factory-provided mock defaults survive reset.
- Full affected update-command suite: **247 passed**.
- Entire original hosted `agentic-cli` shard: **231 files passed, 1 skipped; 5,549 tests passed, 41 skipped**.
- Independent owner/dependency review and authenticated committed review both clean.
- Production LOC: **+0/-0**. Existing tests: **+1/-1**; no test added, weakened, skipped, or removed.
