### PR TITLE
fix(gateway): pin git config for session-diff and worker workspace paths

### DIFF
--- a/src/agents/worktrees/git.ts
+++ b/src/agents/worktrees/git.ts
@@ -21,9 +21,14 @@ type WorktreeListEntry = {
   lockedReason?: string;
 };
 
-function gitEnvironment(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  // Gateway-run Git must never execute repository hooks or filesystem monitors;
-  // the admin-gated setup script is the sole intentional repository-code path.
+/**
+ * Gateway-run Git must never execute repository hooks or filesystem monitors;
+ * the admin-gated setup script is the sole intentional repository-code path.
+ * Exported so other Gateway-owned callers that must bypass the `runGit`/
+ * `requireGit*` wrappers (e.g. a buffered, non-throwing invocation with a
+ * custom timeout) still pin the same invariant instead of reimplementing it.
+ */
+export function gitEnvironment(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return {
     ...(env ?? process.env),
     GIT_CONFIG_COUNT: "2",

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -77,7 +77,8 @@ vi.mock("../gateway/call.js", async () => ({
   isGatewayCredentialsRequiredError: gatewayMocks.isGatewayCredentialsRequiredError,
 }));
 
-vi.mock("../infra/fs-safe.js", () => ({
+vi.mock("../infra/fs-safe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/fs-safe.js")>()),
   movePathToTrash: fsSafeMocks.movePathToTrash,
 }));
 

--- a/src/commands/agents.delete.workspace.test.ts
+++ b/src/commands/agents.delete.workspace.test.ts
@@ -65,7 +65,8 @@ vi.mock("../gateway/call.js", async () => ({
   isGatewayCredentialsRequiredError: gatewayMocks.isGatewayCredentialsRequiredError,
 }));
 
-vi.mock("../infra/fs-safe.js", () => ({
+vi.mock("../infra/fs-safe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/fs-safe.js")>()),
   movePathToTrash: fsSafeMocks.movePathToTrash,
 }));
 

--- a/src/commands/status.agent-local.test.ts
+++ b/src/commands/status.agent-local.test.ts
@@ -18,7 +18,10 @@ vi.mock("../config/sessions/paths.js", () => ({
 vi.mock("../config/sessions/session-accessor.js", () => ({
   listSessionEntriesReadOnly: () => [],
 }));
-vi.mock("../infra/fs-safe.js", () => ({ pathExists: async () => false }));
+vi.mock("../infra/fs-safe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/fs-safe.js")>()),
+  pathExists: async () => false,
+}));
 
 describe("getAgentLocalStatuses", () => {
   beforeEach(() => {

--- a/src/gateway/server-methods/sessions-diff.test.ts
+++ b/src/gateway/server-methods/sessions-diff.test.ts
@@ -138,6 +138,42 @@ describe("loadSessionDiff", () => {
     expect(result.unavailableReason).toBe("not_git");
   });
 
+  // Diff and baseline reads run inside the Gateway process against user
+  // checkouts, so a checkout-configured core.fsmonitor command (or hook) must
+  // never execute — same invariant as the publication git transport.
+  it.skipIf(process.platform === "win32")(
+    "never executes a checkout-configured core.fsmonitor command",
+    async () => {
+      initRepo(repoRoot);
+      fs.writeFileSync(path.join(repoRoot, "a.txt"), "one\n");
+      git(repoRoot, "add", "a.txt");
+      git(repoRoot, "commit", "-qm", "init");
+      fs.writeFileSync(path.join(repoRoot, "a.txt"), "two\n");
+      // Script and sentinel live outside the checkout so they never show up
+      // as untracked entries in the diffs under test.
+      const outside = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-fsmonitor-"));
+      try {
+        const sentinel = path.join(outside, "sentinel");
+        const hook = path.join(outside, "fsmonitor.sh");
+        fs.writeFileSync(hook, `#!/bin/sh\n: > "${sentinel}"\nexit 1\n`, { mode: 0o755 });
+        git(repoRoot, "config", "core.fsmonitor", hook);
+        // Sanity: unpinned git in this checkout does run the command.
+        git(repoRoot, "status", "--porcelain");
+        expect(fs.existsSync(sentinel)).toBe(true);
+        fs.rmSync(sentinel);
+
+        mockSession(repoRoot);
+        const diff = await loadSessionDiff({ sessionKey: "agent:main:s1" });
+        expect(diff.files.map((file) => file.path)).toEqual(["a.txt"]);
+        const baseline = await captureSessionDiffBaseline({ cwd: repoRoot, sessionId: "s1" });
+        expect(baseline?.files.map((file) => file.path)).toEqual(["a.txt"]);
+        expect(fs.existsSync(sentinel)).toBe(false);
+      } finally {
+        fs.rmSync(outside, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("shows the full diff without mutating a pending baseline claim", async () => {
     initRepo(repoRoot);
     fs.writeFileSync(path.join(repoRoot, "pending.txt"), "pending first turn\n");

--- a/src/gateway/worker-environments/node-worker-workspace-fallback.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-fallback.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { runCommandWithTimeout, type SpawnResult } from "../../process/exec.js";
@@ -61,8 +62,20 @@ export function recordNodeSyncPath(
 }
 
 async function localGit(root: string, args: string[]): Promise<string> {
+  // Inspection runs inside the Gateway process against a user checkout, so
+  // checkout-configured hook/fsmonitor commands must never execute here.
   const result = await runCommandWithTimeout(
-    ["git", ...GIT_NONINTERACTIVE_ARGS, "-C", root, ...args],
+    [
+      "git",
+      "-c",
+      `core.hooksPath=${os.devNull}`,
+      "-c",
+      "core.fsmonitor=false",
+      ...GIT_NONINTERACTIVE_ARGS,
+      "-C",
+      root,
+      ...args,
+    ],
     {
       timeoutMs: GIT_TIMEOUT_MS,
       maxOutputBytes: 256 * 1024,

--- a/src/gateway/worker-environments/workspace-result-staging.ts
+++ b/src/gateway/worker-environments/workspace-result-staging.ts
@@ -45,7 +45,16 @@ const workspaceLog = createSubsystemLogger("gateway/worker-workspace");
 const DISABLED_GIT_HOOKS_PATH = os.devNull;
 
 function gitCommand(cwd: string, args: string[]): string[] {
-  return ["git", "-c", `core.hooksPath=${DISABLED_GIT_HOOKS_PATH}`, "-C", cwd, ...args];
+  return [
+    "git",
+    "-c",
+    `core.hooksPath=${DISABLED_GIT_HOOKS_PATH}`,
+    "-c",
+    "core.fsmonitor=false",
+    "-C",
+    cwd,
+    ...args,
+  ];
 }
 
 export function workerWorkspaceTransferPaths(

--- a/src/sessions/session-diff.ts
+++ b/src/sessions/session-diff.ts
@@ -8,7 +8,7 @@ import type {
   SessionDiffFile,
   SessionsDiffResult,
 } from "../../packages/gateway-protocol/src/index.js";
-import { runGit } from "../agents/worktrees/git.js";
+import { gitEnvironment, runGit } from "../agents/worktrees/git.js";
 import type { SessionDiffBaseline } from "../config/sessions/types.js";
 import { runCommandBuffered } from "../process/exec.js";
 import {
@@ -587,6 +587,7 @@ async function gitOutForBaseline(cwd: string, args: string[]): Promise<string | 
     ["git", "-C", cwd, "-c", "core.quotePath=false", ...args],
     {
       timeoutMs: 30_000,
+      env: gitEnvironment(),
       maxOutputBytes: {
         stdout: MAX_BASELINE_GIT_OUTPUT_BYTES,
         stderr: 32 * 1024,


### PR DESCRIPTION
## What Problem This Solves

Gateway-owned code running git against user checkouts could execute a repo-configured `core.fsmonitor` command or `core.hooksPath` hook from inside the Gateway process. #129968 fixed this for the managed worktrees service by pinning `core.hooksPath=/dev/null` and `core.fsmonitor=false` via `GIT_CONFIG_*` env in `src/agents/worktrees/git.ts`, but three other call sites still bypassed the pin: `session-diff.ts`'s baseline-capture helper (raw `runCommandBuffered`), the worker workspace fallback's local repo inspection (`status`/`rev-parse`), and worker workspace result staging (pinned hooks but not fsmonitor).

## Why This Change Was Made

Route `session-diff.ts`'s `gitOutForBaseline` through the worktrees git seam's now-exported `gitEnvironment()` helper instead of a bare `runCommandBuffered` call, and pin the same two config keys directly in the two worker-workspace files that spawn git outside that seam. This closes the same invariant gap for every remaining Gateway-process git invocation against a user checkout.

## User Impact

Session diff/baseline reads and worker workspace sync no longer execute a checkout-configured `core.fsmonitor` command or hook from inside the Gateway process.

## Evidence

- Regression test (`src/gateway/server-methods/sessions-diff.test.ts`): plants a `core.fsmonitor` script that writes a sentinel outside the repo, confirms unpinned git executes it, then asserts `loadSessionDiff` and `captureSessionDiffBaseline` never trigger it. Fails pre-fix at the baseline-capture assertion; passes post-fix.
- `pnpm test` green: sessions-diff, worktrees (129 tests), session-diff-baseline, worker workspace fallback/reconcile/recovery/sync suites.
- `pnpm tsgo`, oxlint, and oxfmt clean on touched files.
- Live probe against a real git 2.54 repo confirmed the pinned seam suppresses both a `core.fsmonitor` script and a `core.hooksPath` hook, while `allowRepositoryHooks`-style explicit opt-outs (unaffected by this change) still run intentionally.
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.
