### PR TITLE
refactor(talk-voice): use canonical base URL normalization

### DIFF
--- a/extensions/talk-voice/index.ts
+++ b/extensions/talk-voice/index.ts
@@ -103,11 +103,6 @@ function resolveCommandLabel(channel: string): string {
   return channel === "discord" ? "/talkvoice" : "/voice";
 }
 
-function asProviderBaseUrl(value: unknown): string | undefined {
-  const trimmed = asTrimmedString(value);
-  return trimmed || undefined;
-}
-
 const TALK_ADMIN_SCOPE = "operator.admin";
 
 function requiresAdminToSetVoice(params: {
@@ -153,7 +148,7 @@ export default definePluginEntry({
         const providerId = active.provider;
         const providerLabel = resolveProviderLabel(providerId);
         const apiKey = asTrimmedString(active.config.apiKey);
-        const baseUrl = asProviderBaseUrl(active.config.baseUrl);
+        const baseUrl = normalizeOptionalString(active.config.baseUrl);
 
         const currentVoiceId = asTrimmedString(active.config.voiceId);
 


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

> AI-assisted: implementation and review used AI coding assistance; the maintainer reviewed the exact change and validation evidence.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The bundled Talk Voice command kept a private one-use base-URL projection after string coercion ownership moved to the canonical Plugin SDK helper. That stale projection duplicated the canonical normalization contract and left an unnecessary second concept in the command path.

This is a maintainer-authorized Wave 1 cleanup with no product behavior change.

## Why This Change Was Made

Call the already-imported `normalizeOptionalString` owner directly and remove `asProviderBaseUrl`.

For every input, the removed code evaluated `normalizeOptionalString(value) ?? ""` and then mapped only the empty string to `undefined`. `normalizeOptionalString(value)` already returns the same non-empty trimmed string or `undefined`, so both Talk Voice `listVoices` calls receive the exact same `baseUrl` value.

Provider and channel behavior, wire arguments, auth/security checks, config/schema, retries/timeouts, and public outputs are unchanged.

## User Impact

No user-visible impact. This removes a stale private projection while preserving Talk Voice behavior exactly.

## Evidence

Exact reviewed head: `4b7ca12087e607d31d71d523a0e7474d2f2382bc`

- Baseline and final focused Talk Voice suite: 17/17 tests passed.
- Exact-head `pnpm test:changed`: 17/17 tests passed in the extension-media lane.
- `pnpm check:changed`: passed all selected extension production/test formatting, typecheck, lint, guard, dead-export, and import-cycle lanes.
- `node scripts/check-changed.mjs --dry-run -- extensions/talk-voice/index.ts`: selected only `extensions` and `extensionTests` lanes.
- Representative old/new normalization equivalence probe: 16/16 values matched; source algebra covers every `unknown` input.
- `git diff --check`: passed.
- Test audit: no test change or test-only production seam warranted; the existing `listVoices` call-boundary assertion already protects the normalized `baseUrl` output.
- Deslop: no findings or additional edits.
- Structured autoreview (`gpt-5.6-sol`, high): clean, no actionable findings, patch correct at 0.99 confidence.
- Separate read-only, ephemeral exact-head Codex review (`gpt-5.6-sol`, high): no concrete patch-caused findings; exact head is behavior-preserving and clean.
- Production diff: +1/−6 lines. Tests/tooling: unchanged.
