### PR TITLE
fix(memory): stop suggesting unavailable scheduling tools

### DIFF
--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -346,11 +346,14 @@ describe("memory-core plugin runtime registration", () => {
 
     const ownerTool = intentFactory({ config: {}, senderIsOwner: true }) as {
       name?: string;
+      description?: string;
       parameters?: {
         properties?: Record<string, { default?: string }>;
       };
     };
     expect(ownerTool).toMatchObject({ name: "intent" });
+    expect(ownerTool.description).toContain("Use scheduled tasks for time-based reminders");
+    expect(ownerTool.description).not.toMatch(/\b(?:cron|automations)\b/u);
     expect(ownerTool.parameters?.properties?.scope?.default).toBe("channel");
     expect(ownerTool.parameters?.properties?.senderScope?.default).toBe("sender");
     expect(warn).toHaveBeenCalledTimes(1);

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -131,7 +131,7 @@ function createLazyStandingIntentTool(
     label: "Standing Intent",
     name: "intent",
     description:
-      "Create, list, or explicitly cancel event-conditioned standing intents. A created intent is armed; the system injects the reminder automatically when it triggers. Do not deliver it early or cancel it unless the user asks. Use cron or scheduled tasks for time-based reminders.",
+      "Create, list, or explicitly cancel event-conditioned standing intents. A created intent is armed; the system injects the reminder automatically when it triggers. Do not deliver it early or cancel it unless the user asks. Use scheduled tasks for time-based reminders.",
     parameters: {
       type: "object",
       properties: {

--- a/extensions/memory-core/src/standing-intents-tool.ts
+++ b/extensions/memory-core/src/standing-intents-tool.ts
@@ -148,7 +148,7 @@ export function createStandingIntentTool(options: {
   return {
     label: "Standing Intent",
     name: "intent",
-    description: `Create, list, or explicitly cancel event-conditioned standing intents. Creating an intent arms it immediately. ${STANDING_INTENT_AUTOMATION_GUIDANCE} ${STANDING_INTENT_SCOPE_GUIDANCE} Use cron or scheduled tasks for time-based reminders; use this tool only for events expressed by trigger keywords.`,
+    description: `Create, list, or explicitly cancel event-conditioned standing intents. Creating an intent arms it immediately. ${STANDING_INTENT_AUTOMATION_GUIDANCE} ${STANDING_INTENT_SCOPE_GUIDANCE} Use scheduled tasks for time-based reminders; use this tool only for events expressed by trigger keywords.`,
     parameters: {
       type: "object",
       properties: {

--- a/extensions/memory-core/src/standing-intents.test.ts
+++ b/extensions/memory-core/src/standing-intents.test.ts
@@ -109,6 +109,8 @@ describe("standing intents", () => {
       "Intent is armed for this channel. The system injects the reminder automatically when it triggers. Do not deliver it early or cancel it unless the user asks.",
     );
     expect(tool.description).toContain("system injects the reminder automatically");
+    expect(tool.description).toContain("Use scheduled tasks for time-based reminders");
+    expect(tool.description).not.toMatch(/\b(?:cron|automations)\b/u);
     expect(tool.description).toContain(
       'Use "channel" (the default) for any "whenever I mention X" request.',
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users asking their agent to remember an event-conditioned standing intent could see the model try to call a nonexistent `cron` tool, or suggest a scheduling tool unavailable to the current turn.

## Why This Change Was Made

Both the bundled memory plugin's actual lazily registered standing-intent tool and its loaded execution owner now describe time-based reminders by capability: use scheduled tasks. This preserves the distinction between event-conditioned standing intents and scheduled reminders without statically advertising another tool.

## User Impact

Agents receive the same actionable scheduling guidance without hallucinating an old tool name or a capability excluded by their current policy. Owner-only intent authorization, scope, persistence, plugin contracts, and scheduler aliases are unchanged.

## Evidence

- Test-first proof on current main: the existing real owner-only plugin registration test and the existing standing-intent create/list/cancel test both failed on the stale `Use cron or scheduled tasks for time-based reminders` description; 38 neighboring tests passed.
- Replacing only the two model-visible descriptions made the same existing owner suites pass: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/memory-core/index.test.ts extensions/memory-core/src/standing-intents.test.ts` — 2 files, 40 passing tests.
- Existing non-owner and missing-config authorization cases remain in the passing plugin owner suite; both lazy and loaded descriptions are asserted to contain scheduled-task guidance and no static `cron` or `automations` reference.
- Targeted formatting and `git diff --check` pass. The optional local plugin lint wrapper additionally invokes repository-wide Plugin SDK declaration preparation, which is blocked in this linked checkout by unrelated preexisting borrowed-dependency type mismatches; exact-head hosted CI remains the full verification gate.
- Independent architecture review, a complete structured code review, and a separate read-only review found no actionable issues.
- Production delta: **+2/-2, net zero**; five regression-test lines were added to existing owner tests.
