### PR TITLE
fix: dashboard changes succeed after Gateway authority is retired

### DIFF
--- a/src/gateway/server-methods/board.runtime-boundaries.test.ts
+++ b/src/gateway/server-methods/board.runtime-boundaries.test.ts
@@ -5,6 +5,14 @@ import { resetBoardEventNoticeStateForTest } from "../../boards/board-notices.js
 import { SqliteBoardStore } from "../../boards/sqlite-board-store.js";
 import { replaceSessionEntrySync } from "../../config/sessions/session-accessor.entry.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import {
+  markPluginRegistryActive,
+  markPluginRegistryRetired,
+} from "../../plugins/registry-lifecycle.js";
+import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
+import { resetGatewayWorkAdmission } from "../../process/gateway-work-admission.js";
+import { runWithGatewayRootWorkAdmissionForTest } from "../../process/gateway-work-admission.test-helpers.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -14,6 +22,11 @@ import { createBoardHarness as createHarness } from "./board.test-support.js";
 import { sessionMutationHandlers } from "./sessions-mutations.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 
+const reviewWidgetApproval = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/exec-auto-reviewer.js", () => ({
+  createModelExecAutoReviewer: vi.fn(() => reviewWidgetApproval),
+}));
 vi.mock("./sessions.runtime.js", () => ({
   performGatewaySessionReset: vi.fn(async ({ key, reason }: { key: string; reason: string }) => ({
     ok: true,
@@ -28,11 +41,14 @@ describe("board gateway runtime boundaries", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
   beforeEach(() => {
+    resetGatewayWorkAdmission();
     resetBoardEventNoticeStateForTest();
     resetSystemEventsForTest();
+    reviewWidgetApproval.mockReset();
   });
 
   afterEach(() => {
+    resetGatewayWorkAdmission();
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
   });
@@ -81,6 +97,152 @@ describe("board gateway runtime boundaries", () => {
       { limit: 2 },
       expect.objectContaining({ params: expect.any(Object) }),
     );
+  });
+
+  it.each([
+    {
+      name: "layout update before applyOps",
+      run: async () => {
+        const harness = createHarness();
+        const response = await runWithGatewayRootWorkAdmissionForTest(async () => {
+          resetGatewayWorkAdmission();
+          return await harness.invoke("board.update", {
+            sessionKey: "session",
+            ops: [{ kind: "tab_create", tabId: "ops", title: "Ops" }],
+          });
+        });
+        return {
+          response,
+          verify: () => expect(harness.store.getSnapshot("session").tabs).toEqual([]),
+        };
+      },
+    },
+    {
+      name: "Canvas widget after document materialization",
+      run: async () => {
+        const harness = createHarness(async () => {
+          resetGatewayWorkAdmission();
+          return { html: "<p>canvas</p>", cspSandbox: "scripts" };
+        });
+        const response = await runWithGatewayRootWorkAdmissionForTest(() =>
+          harness.invoke("board.widget.put", {
+            sessionKey: "session",
+            name: "canvas",
+            content: { kind: "canvas-doc", docId: "canvas-doc" },
+          }),
+        );
+        return {
+          response,
+          verify: () => expect(harness.store.getSnapshot("session").widgets).toEqual([]),
+        };
+      },
+    },
+    {
+      name: "automatic widget approval before grant",
+      run: async () => {
+        const pluginRegistry = createEmptyPluginRegistry();
+        markPluginRegistryActive(pluginRegistry);
+        reviewWidgetApproval.mockImplementationOnce(async () => {
+          markPluginRegistryRetired(pluginRegistry);
+          markPluginRegistryActive(pluginRegistry);
+          return {
+            decision: "allow-once",
+            risk: "low",
+            rationale: "approved before plugin reload",
+          };
+        });
+        const harness = createHarness(undefined, undefined, undefined, {
+          getRuntimeConfig: () => ({
+            agents: { list: [{ id: "main" }] },
+            tools: { exec: { mode: "auto" } },
+          }),
+        });
+        const response = await withPluginRuntimeGatewayRequestScope(
+          { isWebchatConnect: () => false, pluginRegistry },
+          () =>
+            runWithGatewayRootWorkAdmissionForTest(() =>
+              harness.invoke("board.widget.put", {
+                sessionKey: "session",
+                name: "approval",
+                content: { kind: "html", html: "approval" },
+                declared: { netOrigins: ["https://example.com"] },
+              }),
+            ),
+        );
+        return {
+          response,
+          verify: () =>
+            expect(harness.store.getSnapshot("session").widgets).toMatchObject([
+              { name: "approval", grantState: "pending" },
+            ]),
+        };
+      },
+    },
+    {
+      name: "explicit widget grant before store grant",
+      run: async () => {
+        const harness = createHarness();
+        const put = await harness.invoke("board.widget.put", {
+          sessionKey: "session",
+          name: "grant",
+          content: { kind: "html", html: "grant" },
+          declared: { netOrigins: ["https://example.com"] },
+        });
+        const snapshot = put.mock.calls[0]?.[1] as BoardSnapshot | undefined;
+        const widget = snapshot?.widgets[0];
+        if (!widget) {
+          throw new Error("board.widget.put did not return a widget");
+        }
+        harness.broadcast.mockClear();
+        const response = await runWithGatewayRootWorkAdmissionForTest(async () => {
+          resetGatewayWorkAdmission();
+          return await harness.invoke("board.widget.grant", {
+            sessionKey: "session",
+            name: widget.name,
+            decision: "granted",
+            revision: widget.revision,
+            instanceId: widget.instanceId,
+          });
+        });
+        return {
+          response,
+          verify: () =>
+            expect(harness.store.getSnapshot("session").widgets).toMatchObject([
+              { name: "grant", grantState: "pending" },
+            ]),
+        };
+      },
+    },
+    {
+      name: "widget event before notice append",
+      run: async () => {
+        const harness = createHarness();
+        await harness.invoke("board.widget.put", {
+          sessionKey: "session",
+          name: "counter",
+          content: { kind: "html", html: "counter" },
+        });
+        harness.broadcast.mockClear();
+        const response = await runWithGatewayRootWorkAdmissionForTest(async () => {
+          resetGatewayWorkAdmission();
+          return await harness.invoke("board.event", {
+            sessionKey: "session",
+            widget: "counter",
+            payload: { count: 1 },
+          });
+        });
+        return {
+          response,
+          verify: () => expect(peekSystemEvents("agent:main:session")).toEqual([]),
+        };
+      },
+    },
+  ])("fences $name to its request and plugin authority", async ({ run }) => {
+    const { response, verify } = await run();
+
+    expect(response.mock.calls[0]?.[0]).toBe(false);
+    expect(response.mock.calls[0]?.[2]).toMatchObject({ code: "UNAVAILABLE" });
+    verify();
   });
 
   it("rejects unknown data bindings inside the gateway allowlist boundary", async () => {

--- a/src/gateway/server-methods/board.runtime-boundaries.test.ts
+++ b/src/gateway/server-methods/board.runtime-boundaries.test.ts
@@ -1,5 +1,12 @@
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { BoardSnapshot } from "../../../packages/gateway-protocol/src/index.js";
+import { WebSocketServer } from "ws";
+import { GatewayClient } from "../../../packages/gateway-client/src/index.js";
+import {
+  PROTOCOL_VERSION,
+  type BoardSnapshot,
+} from "../../../packages/gateway-protocol/src/index.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { resetBoardEventNoticeStateForTest } from "../../boards/board-notices.js";
 import { SqliteBoardStore } from "../../boards/sqlite-board-store.js";
@@ -18,6 +25,13 @@ import {
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  createCoreGatewayMethodDescriptors,
+  createGatewayMethodRegistry,
+} from "../methods/registry.js";
+import { createGatewayBroadcaster } from "../server-broadcast.js";
+import { handleGatewayRequest } from "../server-methods.js";
+import type { GatewayWsClient } from "../server/ws-types.js";
 import { createBoardHarness as createHarness } from "./board.test-support.js";
 import { sessionMutationHandlers } from "./sessions-mutations.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
@@ -99,6 +113,163 @@ describe("board gateway runtime boundaries", () => {
     );
   });
 
+  it("fences awaited board mutation through Gateway dispatch when its root retires", async () => {
+    const documentStarted = createDeferred();
+    const releaseDocument = createDeferred<{ html: string; cspSandbox: "scripts" }>();
+    const harness = createHarness(async () => {
+      documentStarted.resolve();
+      return await releaseDocument.promise;
+    });
+    const handler = harness.handlers["board.widget.put"];
+    if (!handler) {
+      throw new Error("board.widget.put handler missing");
+    }
+    const methodRegistry = createGatewayMethodRegistry(
+      createCoreGatewayMethodDescriptors({ "board.widget.put": handler }),
+    );
+    const events: string[] = [];
+    const connected = createDeferred();
+    const gatewayClients = new Set<GatewayWsClient>();
+    const { broadcast } = createGatewayBroadcaster({ clients: gatewayClients });
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    server.on("connection", (socket) => {
+      socket.send(
+        JSON.stringify({
+          type: "event",
+          event: "connect.challenge",
+          payload: { nonce: "board-authority-proof", ts: Date.now() },
+        }),
+      );
+      socket.on("message", (data) => {
+        const request = JSON.parse(rawDataToString(data)) as {
+          id: string;
+          method: string;
+          params?: unknown;
+          type: "req";
+        };
+        if (request.method === "connect") {
+          gatewayClients.add({
+            socket,
+            connect: {
+              role: "operator",
+              scopes: ["operator.admin"],
+            } as GatewayWsClient["connect"],
+            connId: "board-authority-proof",
+            usesSharedGatewayAuth: false,
+          });
+          socket.send(
+            JSON.stringify({
+              type: "res",
+              id: request.id,
+              ok: true,
+              payload: {
+                type: "hello-ok",
+                protocol: PROTOCOL_VERSION,
+                server: { version: "board-authority-proof", connId: "board-authority-proof" },
+                features: { methods: ["board.widget.put"], events: ["board.changed"] },
+                snapshot: {
+                  presence: [],
+                  health: {},
+                  stateVersion: { presence: 1, health: 1 },
+                  uptimeMs: 1,
+                },
+                auth: { role: "operator", scopes: ["operator.admin"] },
+                policy: {
+                  maxPayload: 512 * 1024,
+                  maxBufferedBytes: 1024 * 1024,
+                  tickIntervalMs: 60_000,
+                },
+              },
+            }),
+          );
+          return;
+        }
+        void handleGatewayRequest({
+          req: request,
+          respond: (ok, payload, error) => {
+            socket.send(
+              JSON.stringify({
+                type: "res",
+                id: request.id,
+                ok,
+                ...(payload === undefined ? {} : { payload }),
+                ...(error === undefined ? {} : { error }),
+              }),
+            );
+          },
+          client: null,
+          isWebchatConnect: () => false,
+          context: {
+            broadcast,
+            getRuntimeConfig: () => ({
+              agents: { list: [{ id: "main" }] },
+              tools: { exec: { mode: "ask" } },
+            }),
+            logGateway: { warn: vi.fn() },
+          } as unknown as GatewayRequestContext,
+          methodRegistry,
+        });
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.once("listening", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("board authority proof server did not get a TCP address");
+    }
+    const client = new GatewayClient({
+      url: `ws://127.0.0.1:${address.port}`,
+      onEvent: (event) => events.push(event.event ?? ""),
+      onHelloOk: () => connected.resolve(),
+      onConnectError: (error) => connected.reject(error),
+    });
+    try {
+      client.start();
+      await connected.promise;
+      const request = client.request(
+        "board.widget.put",
+        {
+          sessionKey: "session",
+          name: "canvas",
+          content: { kind: "canvas-doc", docId: "canvas-doc" },
+        },
+        { timeoutMs: null },
+      );
+      const requestOutcome = request.then(
+        () => ({ error: undefined }),
+        (error: unknown) => ({ error }),
+      );
+      await documentStarted.promise;
+
+      resetGatewayWorkAdmission();
+      releaseDocument.resolve({ html: "<p>canvas</p>", cspSandbox: "scripts" });
+
+      const { error } = await requestOutcome;
+      expect(error).toBeInstanceOf(Error);
+      expect(String(error)).toContain("board request authority is no longer active");
+      expect(harness.store.getSnapshot("session").widgets).toEqual([]);
+      expect(events).not.toContain("board.changed");
+
+      await client.request("board.widget.put", {
+        sessionKey: "session",
+        name: "live",
+        content: { kind: "canvas-doc", docId: "live-canvas-doc" },
+      });
+      expect(harness.store.getSnapshot("session").widgets).toMatchObject([{ name: "live" }]);
+      expect(events).toContain("board.changed");
+    } finally {
+      client.stop();
+      gatewayClients.clear();
+      for (const socket of server.clients) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
   it.each([
     {
       name: "layout update before applyOps",
@@ -114,26 +285,6 @@ describe("board gateway runtime boundaries", () => {
         return {
           response,
           verify: () => expect(harness.store.getSnapshot("session").tabs).toEqual([]),
-        };
-      },
-    },
-    {
-      name: "Canvas widget after document materialization",
-      run: async () => {
-        const harness = createHarness(async () => {
-          resetGatewayWorkAdmission();
-          return { html: "<p>canvas</p>", cspSandbox: "scripts" };
-        });
-        const response = await runWithGatewayRootWorkAdmissionForTest(() =>
-          harness.invoke("board.widget.put", {
-            sessionKey: "session",
-            name: "canvas",
-            content: { kind: "canvas-doc", docId: "canvas-doc" },
-          }),
-        );
-        return {
-          response,
-          verify: () => expect(harness.store.getSnapshot("session").widgets).toEqual([]),
         };
       },
     },

--- a/src/gateway/server-methods/board.test-support.ts
+++ b/src/gateway/server-methods/board.test-support.ts
@@ -105,5 +105,5 @@ export function createBoardHarness(
     });
     return respond;
   };
-  return { store, broadcast, invoke, mcpApp };
+  return { store, broadcast, handlers, invoke, mcpApp };
 }

--- a/src/gateway/server-methods/board.ts
+++ b/src/gateway/server-methods/board.ts
@@ -33,7 +33,13 @@ import {
   resolveBoardWidgetContentKindByPluginKind,
   resolveBoardWidgetContentKindResourceUrls,
 } from "../../plugins/board-widget-content-kinds.js";
+import {
+  capturePluginRegistryLifecycleEpoch,
+  isPluginRegistryLifecycleEpochActive,
+} from "../../plugins/registry-lifecycle.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import { getPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
+import { isGatewaySubordinateWorkAdmissionClosed } from "../../process/gateway-work-admission.js";
 import {
   readBoardDataBinding,
   runBoardActionVerb,
@@ -90,6 +96,27 @@ function respondBoardError(
     return;
   }
   respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(error)));
+}
+
+function captureBoardRequestAuthority() {
+  const scopedPluginRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+  const pluginRegistryEpoch =
+    scopedPluginRegistry && capturePluginRegistryLifecycleEpoch(scopedPluginRegistry);
+  const assertActive = () => {
+    if (
+      isGatewaySubordinateWorkAdmissionClosed() ||
+      (scopedPluginRegistry &&
+        (!pluginRegistryEpoch ||
+          !isPluginRegistryLifecycleEpochActive(scopedPluginRegistry, pluginRegistryEpoch)))
+    ) {
+      throw new Error("board request authority is no longer active");
+    }
+  };
+  assertActive();
+  return {
+    assertActive,
+    pluginRegistry: scopedPluginRegistry ?? getActivePluginRegistry() ?? undefined,
+  };
 }
 
 function resolveBoardSessionKey(
@@ -275,10 +302,12 @@ export function createBoardHandlers(
       validateBoardUpdateParams,
       ({ params: boardParams, respond, context }) => {
         try {
+          const authority = captureBoardRequestAuthority();
           const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
           if (!boardSessionKey) {
             return;
           }
+          authority.assertActive();
           const snapshot = store.applyOps(boardSessionKey, boardParams.ops);
           if (boardParams.ops.length > 0) {
             context.broadcast("board.changed", {
@@ -297,6 +326,7 @@ export function createBoardHandlers(
       validateBoardWidgetPutParams,
       async ({ params: requestParams, respond, context }) => {
         try {
+          const authority = captureBoardRequestAuthority();
           const requestedBoardSessionKey = resolveBoardSessionKey(requestParams, context, respond);
           if (!requestedBoardSessionKey) {
             return;
@@ -311,6 +341,7 @@ export function createBoardHandlers(
           let declared = requestDeclared;
           if (requestParams.content.kind === "canvas-doc") {
             const document = await readCanvasDocument(requestParams.content.docId);
+            authority.assertActive();
             if (document.cspSandbox !== "scripts") {
               throw new BoardValidationError(
                 "invalid_operation",
@@ -324,6 +355,7 @@ export function createBoardHandlers(
               viewId: requestParams.content.viewId,
               cfg: context.getRuntimeConfig(),
             });
+            authority.assertActive();
             const { view } = active;
             if (!view.toolCallId) {
               throw new BoardValidationError(
@@ -338,13 +370,16 @@ export function createBoardHandlers(
             } catch {
               // Reconstructed or revoked source leases may be pinned only as read-only content.
             }
+            authority.assertActive();
             const allowedTools = interactive ? await mcpApp.resolveAllowedToolNames(active) : [];
+            authority.assertActive();
             if (interactive) {
               try {
                 await requireMcpAppInteraction(view);
               } catch {
                 interactive = false;
               }
+              authority.assertActive();
             }
             content = {
               kind: "mcp-app",
@@ -359,7 +394,7 @@ export function createBoardHandlers(
             declared = interactive && allowedTools.length > 0 ? { tools: allowedTools } : undefined;
           } else if (requestParams.content.kind === "registered") {
             const registration = resolveBoardWidgetContentKind(
-              getActivePluginRegistry(),
+              authority.pluginRegistry,
               requestParams.content.contentKind,
             );
             if (!registration) {
@@ -427,6 +462,7 @@ export function createBoardHandlers(
             content: materializedContent,
             ...(declared ? { declared } : {}),
           };
+          authority.assertActive();
           let snapshot = store.putWidget(boardParams);
           const widget = snapshot.widgets.find(
             (candidate) => candidate.name === snapshot.resolvedWidgetName,
@@ -438,6 +474,7 @@ export function createBoardHandlers(
               name: snapshot.resolvedWidgetName,
               declared: declared ?? {},
             });
+            authority.assertActive();
             if (decision) {
               snapshot = {
                 ...store.grant(
@@ -467,10 +504,12 @@ export function createBoardHandlers(
       validateBoardWidgetGrantParams,
       ({ params: boardParams, respond, context }) => {
         try {
+          const authority = captureBoardRequestAuthority();
           const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
           if (!boardSessionKey) {
             return;
           }
+          authority.assertActive();
           const snapshot = store.grant(
             boardSessionKey,
             boardParams.name,
@@ -551,6 +590,7 @@ export function createBoardHandlers(
       validateBoardEventParams,
       ({ params: boardParams, respond, context }) => {
         try {
+          const authority = captureBoardRequestAuthority();
           const identity =
             "ticket" in boardParams
               ? resolveAuthorizedBoardWidgetView(store, boardParams.ticket)
@@ -574,6 +614,7 @@ export function createBoardHandlers(
           if (!identity) {
             return;
           }
+          authority.assertActive();
           const appended = appendNotice({
             sessionKey: identity.sessionKey,
             widget: identity.name,

--- a/src/plugins/registry-lifecycle.ts
+++ b/src/plugins/registry-lifecycle.ts
@@ -6,6 +6,7 @@ const activatedRegistries = new WeakSet<PluginRegistry>();
 const registryEpochs = new WeakMap<PluginRegistry, object>();
 const recordEpochs = new WeakMap<PluginRegistry, WeakMap<PluginRecord, object>>();
 
+export type PluginRegistryLifecycleEpoch = object;
 type PluginRecordLifecycleEpoch = object;
 
 /** Marks a registry retired so late runtime calls can reject stale plugin state. */
@@ -25,6 +26,21 @@ export function markPluginRegistryActive(registry: PluginRegistry | null | undef
     // regain authority merely because the same registry object becomes active.
     registryEpochs.set(registry, Object.freeze({}));
   }
+}
+
+/** Capture the exact activation generation currently owned by a registry. */
+export function capturePluginRegistryLifecycleEpoch(
+  registry: PluginRegistry,
+): PluginRegistryLifecycleEpoch | undefined {
+  return retiredRegistries.has(registry) ? undefined : registryEpochs.get(registry);
+}
+
+/** True only while the exact captured registry activation remains current. */
+export function isPluginRegistryLifecycleEpochActive(
+  registry: PluginRegistry,
+  epoch: PluginRegistryLifecycleEpoch,
+): boolean {
+  return !retiredRegistries.has(registry) && registryEpochs.get(registry) === epoch;
 }
 
 /** Mint the exact record generation used by one registered native channel runtime. */

--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -50,7 +50,10 @@ import unitFastRootConfig from "./vitest/vitest.unit-fast-root.config.ts";
 import { createUnitFastVitestConfig } from "./vitest/vitest.unit-fast.config.ts";
 
 const patternFiles = createPatternFileHelper("openclaw-vitest-projects-config-");
-const scopedGatewayMethodsIsolatedTestFiles = ["server-methods/agent.test.ts"];
+const scopedGatewayMethodsIsolatedTestFiles = [
+  "server-methods/agent.test.ts",
+  "server-methods/board.runtime-boundaries.test.ts",
+];
 
 function requireTestConfig<T extends { test?: unknown }>(config: T): NonNullable<T["test"]> {
   if (!config.test) {
@@ -108,7 +111,9 @@ describe("projects vitest config", () => {
     expect(serverIsolatedConfig.runner).toBeUndefined();
     expect(serverIsolatedConfig.include).toEqual(gatewayServerIsolatedTestFiles);
     expect(methodsConfig.exclude).toContain("server-methods/agent.test.ts");
+    expect(methodsConfig.exclude).toContain("server-methods/board.runtime-boundaries.test.ts");
     expect(gatewayFallback.exclude).toContain("server-methods/agent.test.ts");
+    expect(gatewayFallback.exclude).toContain("server-methods/board.runtime-boundaries.test.ts");
     expect(gatewayFallback.exclude).toContain("server.sessions.compaction-read-errors.test.ts");
   });
 

--- a/test/vitest/vitest.gateway-server-paths.mjs
+++ b/test/vitest/vitest.gateway-server-paths.mjs
@@ -9,7 +9,10 @@ export const gatewayServerBackedHttpTestFiles = [
 
 // Gateway method tests whose deep module mocks can be defeated by a neighbour's
 // shared cache. These keep the shared methods runner but use a fresh module graph.
-export const gatewayMethodsIsolatedTestFiles = ["src/gateway/server-methods/agent.test.ts"];
+export const gatewayMethodsIsolatedTestFiles = [
+  "src/gateway/server-methods/agent.test.ts",
+  "src/gateway/server-methods/board.runtime-boundaries.test.ts",
+];
 
 // Gateway server tests that replace a module the Gateway reaches only through
 // re-exports. These need both a fresh graph and the plain Vitest runner.


### PR DESCRIPTION
Related: #129183

## What Problem This Solves

Fixes an issue where an in-flight dashboard board request could continue after the request or plugin generation that admitted it had been retired.

The stale handler could still mutate board state, grant a widget, append an event notice, or broadcast a successful result after Gateway suspension, request retirement, or plugin reload.

## Why This Change Was Made

Each affected board handler now captures its request authority at entry. That authority binds the handler to:

- the admitted Gateway root-work lifetime; and
- the exact activation generation of the request-scoped plugin registry.

The handler revalidates that authority after asynchronous materialization or approval work and immediately before the state-changing operation. Registered widget kinds are also resolved from the captured request registry instead of a later ambient registry.

This PR is limited to board layout updates, widget creation, widget grants, and widget event notices. Agent dashboard routing, durable board tickets, board HTTP/action redemption, MCP App reconstruction, and Control UI app-view rendering remain separate changes.

## User Impact

Dashboard changes now fail closed when their owning request or plugin generation has been retired. A stale request can no longer complete against a replacement Gateway or plugin generation.

Normal same-request operations continue to use the existing board store and broadcast paths.

## Evidence

Current `origin/main` with the five focused authority scenarios applied:

```text
Test Files  1 failed (1)
Tests       5 failed | 5 passed (10)

All five stale-authority scenarios returned success:
- layout update before applyOps
- Canvas widget after document materialization
- automatic widget approval before grant
- explicit widget grant before store grant
- widget event before notice append
```

Candidate:

```text
Test Files  1 passed (1)
Tests       10 passed (10)
Oxlint      0 warnings, 0 errors
```

- Baseline Blacksmith Testbox: `tbx_01m0z3szapkd330h44haj2yq6b`
- Baseline Actions run: https://github.com/openclaw/openclaw/actions/runs/32973869618
- Candidate Blacksmith Testbox: `tbx_01m0z10d9xs2d095snf5netfze`
- Exact candidate: `4af5df9cee15f6044ae6487d1f10b8ab93600667`
- Patch surface: 47 additions and 11 deletions in production code; 162 focused test additions.
- Rebase verification: the stable patch ID remained `955daec7b66ef56411ab0621298c034377acfbe1`, and `git range-diff` reported the original and rebased commits as identical.
- Visual proof omitted because this PR changes backend request ownership and stale side-effect rejection without changing rendered UI.
