### PR TITLE
fix(signal): replay approval reactions after transient Gateway failures

### DIFF
--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -600,7 +600,7 @@ export async function maybeResolveSignalApprovalReaction(params: {
     params.logVerboseMessage?.(
       `signal: approval reaction failed id=${target.approvalId} sender=${actorId}: ${String(error)}`,
     );
-    return true;
+    throw error;
   }
 }
 

--- a/extensions/signal/src/signal-ingress.approval-reaction-replay.test.ts
+++ b/extensions/signal/src/signal-ingress.approval-reaction-replay.test.ts
@@ -1,0 +1,183 @@
+// Signal durable-ingress replay proof: a transient Gateway failure during
+// approval-reaction resolution must release the real SQLite claim so the real
+// drain redelivers the operator's reaction once the Gateway recovers.
+// Everything here is real (SQLite queue, monitor, drain, event handler,
+// approval-reaction resolution) except the one true external boundary: the
+// Gateway approval-resolution call.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSignalApprovalReactionTargetsForTest,
+  registerSignalApprovalReactionTarget,
+} from "./approval-reactions.js";
+import { startSignalIngressMonitor } from "./signal-ingress.js";
+
+const resolverMocks = vi.hoisted(() => ({
+  resolveSignalApproval: vi.fn(),
+  isApprovalNotFoundError: vi.fn(() => false),
+}));
+
+vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
+  resolveApprovalOverGateway: resolverMocks.resolveSignalApproval,
+}));
+vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
+  isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
+}));
+
+vi.useRealTimers();
+let createBaseSignalEventHandlerDeps: typeof import("./monitor/event-handler.test-harness.js").createBaseSignalEventHandlerDeps;
+let createSignalReceiveEvent: typeof import("./monitor/event-handler.test-harness.js").createSignalReceiveEvent;
+let createSignalEventHandler: typeof import("./monitor/event-handler.js").createSignalEventHandler;
+
+type SignalIngressQueue = NonNullable<Parameters<typeof startSignalIngressMonitor>[0]["queue"]>;
+type SignalIngressPayload = Parameters<SignalIngressQueue["enqueue"]>[1];
+
+beforeAll(async () => {
+  const harness = await import("./monitor/event-handler.test-harness.js");
+  createBaseSignalEventHandlerDeps = harness.createBaseSignalEventHandlerDeps;
+  createSignalReceiveEvent = harness.createSignalReceiveEvent;
+  ({ createSignalEventHandler } = await import("./monitor/event-handler.js"));
+});
+
+beforeEach(() => {
+  clearSignalApprovalReactionTargetsForTest();
+  resolverMocks.resolveSignalApproval.mockReset();
+  resolverMocks.isApprovalNotFoundError.mockReset();
+  resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
+});
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+});
+
+async function withQueue<T>(fn: (queue: SignalIngressQueue) => Promise<T>): Promise<T> {
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-signal-ingress-replay-"));
+  const stateDir = await fs.realpath(created);
+  const queue = createChannelIngressQueueForTests<SignalIngressPayload>({
+    channelId: "signal",
+    accountId: "default",
+    stateDir,
+  });
+  try {
+    return await fn(queue);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+describe("Signal approval reaction durable replay", () => {
+  it(
+    "releases the claim and replays a reaction after a transient Gateway failure",
+    { timeout: 30_000 },
+    async () => {
+      await withQueue(async (queue) => {
+        // First resolution attempt fails like a transient Gateway 503; the
+        // redelivered attempt resolves the approval.
+        resolverMocks.resolveSignalApproval
+          .mockRejectedValueOnce(new Error("gateway 503"))
+          .mockResolvedValue({
+            applied: true,
+            approval: { status: "allowed", decision: "allow-once" },
+          });
+        registerSignalApprovalReactionTarget({
+          accountId: "default",
+          // normalizeE164 preserves '+', matching the conversationKey the handler
+          // derives from the sender (signal:+15550001111).
+          conversationKey: "+15550001111",
+          messageId: "1700000000123",
+          approvalId: "approval-abc-123",
+          approvalKind: "exec",
+          allowedDecisions: ["allow-once"],
+          targetAuthorKeys: ["+15550001111"],
+          route: { deliveryMode: "session" },
+          routeAllowed: true,
+        });
+
+        const handler = createSignalEventHandler(
+          createBaseSignalEventHandlerDeps({
+            cfg: {
+              channels: { signal: { allowFrom: ["+15550001111"] } },
+              approvals: { exec: { enabled: true, mode: "session" } },
+            },
+            isSignalReactionMessage: (reaction) => reaction != null,
+          }),
+        );
+        const monitor = await startSignalIngressMonitor({
+          accountId: "default",
+          queue,
+          dispatch: handler,
+          runtime: { error: vi.fn(), log: vi.fn() },
+        });
+        const reactionEvent = createSignalReceiveEvent({
+          sourceNumber: "+15550001111",
+          reactionMessage: {
+            emoji: "👍",
+            targetAuthor: "+15550001111",
+            targetSentTimestamp: 1700000000123,
+          },
+        });
+
+        try {
+          await monitor.receive(reactionEvent);
+          // First attempt: the handler's throw escapes into the real drain.
+          await vi.waitFor(
+            () => expect(resolverMocks.resolveSignalApproval).toHaveBeenCalledTimes(1),
+            { timeout: 5_000 },
+          );
+          await monitor.waitForIdle();
+
+          // The drain released the claim instead of completing it: the durable
+          // row is pending again with the recorded attempt and error. The retry
+          // backoff (>=1s from the release) keeps the lane unclaimed here, so
+          // this is a produced-state read, never a race against redelivery.
+          expect(await queue.listClaims()).toHaveLength(0);
+          const pendingAfterFailure = await queue.listPending({ limit: "all" });
+          expect(pendingAfterFailure).toHaveLength(1);
+          expect(pendingAfterFailure[0]?.attempts).toBe(1);
+          expect(pendingAfterFailure[0]?.lastError).toContain("gateway 503");
+
+          // The real drain reclaims and redelivers the same reaction event.
+          await vi.waitFor(
+            () => expect(resolverMocks.resolveSignalApproval).toHaveBeenCalledTimes(2),
+            { timeout: 15_000 },
+          );
+          await monitor.waitForIdle();
+
+          // Redelivery carried the identical resolution request.
+          expect(resolverMocks.resolveSignalApproval.mock.calls[1]?.[0]).toEqual(
+            resolverMocks.resolveSignalApproval.mock.calls[0]?.[0],
+          );
+          expect(resolverMocks.resolveSignalApproval.mock.calls[1]?.[0]).toEqual(
+            expect.objectContaining({
+              approvalId: "approval-abc-123",
+              approvalKind: "exec",
+              decision: "allow-once",
+              channel: "signal",
+              accountId: "default",
+            }),
+          );
+
+          // The replayed attempt resolved the approval and completed the row.
+          expect(await queue.listPending({ limit: "all" })).toHaveLength(0);
+          expect(await queue.listClaims()).toHaveLength(0);
+
+          // The completion tombstone is durable: the same reaction can never
+          // dispatch a third time.
+          await monitor.receive(reactionEvent);
+          await monitor.waitForIdle();
+          expect(resolverMocks.resolveSignalApproval).toHaveBeenCalledTimes(2);
+        } finally {
+          await monitor.stop();
+        }
+      });
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Signal approval reactions treated every non-expired Gateway failure as handled. A transient Gateway failure therefore completed the durable ingress claim and silently dropped the operator's approval click.

Fixes #130133.

## Why This Change Was Made

The Signal durable ingress queue already owns retry. The approval resolver must preserve expired-approval cleanup, but it must rethrow every other Gateway failure so the queue releases and replays the claim.

Matrix uses the same owner boundary after #129879. WhatsApp is intentionally separate because its approval reaction runs before durable admission, so a bare rethrow there would still drop the reaction.

## User Impact

A transient Gateway failure no longer loses a Signal approval reaction. Signal retries the same durable event after the Gateway recovers, then records completion so it cannot dispatch again.

## Evidence

Current main `be8b6ff3c4697c045d9277356018846e777fbcdc` with only the authoritative replay test added:

```text
$ node scripts/run-vitest.mjs extensions/signal/src/signal-ingress.approval-reaction-replay.test.ts
FAIL: expected pendingAfterFailure to have length 1, received 0
```

Exact PR head `3b756de46803554d0afb7cd7cc72cb6558bc6f0a`:

```text
$ node scripts/run-vitest.mjs extensions/signal/src/signal-ingress.approval-reaction-replay.test.ts
Test Files  1 passed (1)
Tests       1 passed (1)
```

Exact GitHub merge result `8dc3a96d0e7598b77b33b9dcff43d95546349f8d` against current main `d36d90ba62d28fb412ef7e922bb3fed93c563b91` passed the same focused test. Exact-head `openclaw/ci-gate` also passed in run `33044232460`.

The test uses the real SQLite queue, Signal monitor, generic ingress drain, and Signal event handler. It mocks only the external Gateway approval call. It proves claim release, identical redelivery, completion, and tombstone deduplication.

Production logic is one changed line: `return true` becomes `throw error`. Test audit removed the two earlier unit-level tests because the SQLite owner-boundary test supersedes them.

The final canonical Telegram userbot DM smoke recorded one user message, two typing events, and one SUT reply containing `OPENCLAW_E2E_OK`. The mock provider recorded one `POST /v1/responses`; the fresh Gateway recorded ready and clean shutdown with zero errors. This is collateral regression proof only because the Signal approval-reaction change is not Telegram-visible.
