### PR TITLE
fix(llama-cpp): stop recommending failed models during setup

### DIFF
--- a/extensions/llama-cpp/src/external-server/setup.test.ts
+++ b/extensions/llama-cpp/src/external-server/setup.test.ts
@@ -248,6 +248,11 @@ describe("llama-server setup", () => {
       expected: "llama-cpp/meta-llama/Llama-3.3-8B",
     },
     {
+      name: "does not recommend a server when every model has failed",
+      models: [{ id: "google/gemma-4-27b", status: "unloaded", failed: true }],
+      expected: null,
+    },
+    {
       name: "returns no candidate for an empty model catalog",
       models: [],
       expected: null,
@@ -850,5 +855,22 @@ describe("llama-server setup", () => {
       "llama-server model missing was not found. Available models: qwen/model:Q4_K_M",
     );
     expect(ctx.runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("rejects failed-only implicit setup while preserving an explicitly selected model", async () => {
+    const discovery = successfulDiscovery();
+    discovery.models = discovery.models.map((model) => ({ ...model, failed: true }));
+    discoverMock.mockResolvedValue(discovery);
+
+    const implicit = nonInteractiveContext();
+    await expect(validateLlamaServerNonInteractive(implicit)).resolves.toBe(false);
+    expect(implicit.runtime.error).toHaveBeenCalledWith(
+      "No llama-server text models were found at http://localhost:8080.",
+    );
+    expect(removeProviderAuthProfilesWithLockMock).not.toHaveBeenCalled();
+    expect(upsertAuthProfileWithLockMock).not.toHaveBeenCalled();
+
+    const explicit = nonInteractiveContext({ customModelId: "qwen/model:Q4_K_M" });
+    await expect(validateLlamaServerNonInteractive(explicit)).resolves.toBe(true);
   });
 });

--- a/extensions/llama-cpp/src/external-server/setup.ts
+++ b/extensions/llama-cpp/src/external-server/setup.ts
@@ -38,8 +38,7 @@ import { resolveLlamaServerEndpoint } from "./endpoint.js";
 import { buildLlamaServerProviderConfig } from "./models.js";
 
 function selectSetupModelId(discovery: Extract<LlamaServerDiscoveryResult, { kind: "success" }>) {
-  const healthy = discovery.models.filter((model) => !model.failed);
-  const candidates = healthy.length > 0 ? healthy : discovery.models;
+  const candidates = discovery.models.filter((model) => !model.failed);
   const ready = candidates.filter(
     (model) => model.status === "loaded" || model.status === "sleeping",
   );
@@ -224,28 +223,33 @@ async function removeDefaultAuthProfile(agentDir?: string): Promise<void> {
   }
 }
 
-async function discoverForSetup(params: {
-  config: OpenClawConfig;
-  baseUrl: string;
-  env?: NodeJS.ProcessEnv;
-  signal?: AbortSignal;
-}): Promise<LlamaServerDiscoveryResult> {
-  const providerConfig = params.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
-  const headers = await resolveLlamaServerProviderHeaders({
-    config: params.config,
-    env: params.env,
-    headers: providerConfig?.headers,
-  });
-  const resolvedApiKey = !hasLlamaServerAuthorizationHeader(headers)
-    ? await resolveLlamaServerRuntimeApiKey({ config: params.config })
-    : undefined;
-  return await discoverLlamaServer({
-    baseUrl: params.baseUrl,
-    apiKey: resolvedApiKey,
-    headers,
-    signal: params.signal,
-    cacheTtlMs: 0,
-  });
+async function discoverForSetup(
+  ctx: ProviderAppGuidedSetupContext,
+): Promise<Extract<LlamaServerDiscoveryResult, { kind: "success" }> | null> {
+  const provider = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+  if (provider?.localService) {
+    return null;
+  }
+  try {
+    const headers = await resolveLlamaServerProviderHeaders({
+      config: ctx.config,
+      env: ctx.env,
+      headers: provider?.headers,
+    });
+    const apiKey = !hasLlamaServerAuthorizationHeader(headers)
+      ? await resolveLlamaServerRuntimeApiKey({ config: ctx.config })
+      : undefined;
+    const discovery = await discoverLlamaServer({
+      baseUrl: provider?.baseUrl ?? LLAMA_SERVER_DEFAULT_ORIGIN,
+      apiKey,
+      headers,
+      signal: ctx.signal,
+      cacheTtlMs: 0,
+    });
+    return discovery.kind === "success" ? discovery : null;
+  } catch {
+    return null;
+  }
 }
 
 async function discoverWithAccess(params: {
@@ -267,23 +271,8 @@ async function discoverWithAccess(params: {
 export async function detectLlamaServerSetup(
   ctx: ProviderAppGuidedSetupContext,
 ): Promise<{ modelRef: string; detail?: string } | null> {
-  const provider = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
-  if (provider?.localService) {
-    return null;
-  }
-  const baseUrl = provider?.baseUrl ?? LLAMA_SERVER_DEFAULT_ORIGIN;
-  let discovery: LlamaServerDiscoveryResult;
-  try {
-    discovery = await discoverForSetup({
-      config: ctx.config,
-      baseUrl,
-      env: ctx.env,
-      signal: ctx.signal,
-    });
-  } catch {
-    return null;
-  }
-  if (discovery.kind !== "success") {
+  const discovery = await discoverForSetup(ctx);
+  if (!discovery) {
     return null;
   }
   const modelId = selectSetupModelId(discovery);
@@ -300,22 +289,8 @@ export async function detectLlamaServerSetup(
 export async function prepareLlamaServerSetup(
   ctx: ProviderAppGuidedSetupContext & { modelRef: string },
 ): Promise<ProviderAuthResult | null> {
-  const provider = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
-  if (provider?.localService) {
-    return null;
-  }
-  let discovery: LlamaServerDiscoveryResult;
-  try {
-    discovery = await discoverForSetup({
-      config: ctx.config,
-      baseUrl: provider?.baseUrl ?? LLAMA_SERVER_DEFAULT_ORIGIN,
-      env: ctx.env,
-      signal: ctx.signal,
-    });
-  } catch {
-    return null;
-  }
-  if (discovery.kind !== "success") {
+  const discovery = await discoverForSetup(ctx);
+  if (!discovery) {
     return null;
   }
   const prefix = `${LLAMA_CPP_PROVIDER_ID}/`;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users connecting an existing llama.cpp server through guided or noninteractive setup could be offered a model that has already failed to start when every advertised model is failed.

## Why This Change Was Made

The upstream llama.cpp router marks a model as failed when it is unloaded and its last process exited unsuccessfully. OpenClaw's implicit selector filtered failed models but then fell back to those same failed models when none were healthy. Keep failed models out of automatic selection, while preserving an operator's explicitly requested model. Consolidate duplicated read-only guided discovery, managed-server exclusion, credential resolution, cancellation, and failure handling into their existing provider owner.

## User Impact

Guided setup no longer recommends a broken existing-server model, and implicit noninteractive setup fails before changing authentication profiles. Operators who explicitly request a model retain their existing selection behavior. Managed llama.cpp setup, configured authorization headers, API keys, cancellation, discovery request counts, and existing diagnostic messages are unchanged.

## Evidence

- The upstream router defines failure as `status == UNLOADED && exit_code != 0` and exposes it as `status.failed` in the model catalog.
- Before the fix, the existing provider setup suite reproduced both failures: **2 failed, 27 passed**. Guided setup returned a failed model instead of no candidate, and implicit noninteractive validation incorrectly succeeded.
- After the fix, provider setup, discovery, model mapping, and authentication suites passed: **53 tests across four files**. The real generic system-agent setup inference ingress passed another **9 tests**: **62 tests passed across five files**.
- Scoped formatting and type-aware plugin lint passed. Two independent reviews and a fresh structured autoreview reported no actionable findings.
- Production delta: **25 lines removed**; regression coverage: **22 lines added**. No configuration, persistence, schema, plugin API, dependency, or changelog changes.
