### PR TITLE
refactor(lmstudio): unify configured auth resolution

### DIFF
--- a/extensions/lmstudio/src/embedding-provider.ts
+++ b/extensions/lmstudio/src/embedding-provider.ts
@@ -19,6 +19,7 @@ import {
   resolveLmstudioInferenceBase,
   resolveLmstudioServerBase,
 } from "./models.js";
+import { hasLmstudioAuthorizationHeader } from "./provider-auth.js";
 import {
   buildLmstudioAuthHeaders,
   resolveLmstudioConfiguredApiKeyForProvider,
@@ -55,16 +56,6 @@ function normalizeLmstudioModel(model: string, providerId?: string): string {
     defaultModel: DEFAULT_LMSTUDIO_EMBEDDING_MODEL,
     prefixes: [`${providerId?.trim() || LMSTUDIO_PROVIDER_ID}/`, `${LMSTUDIO_PROVIDER_ID}/`],
   });
-}
-
-function hasAuthorizationHeader(headers: Record<string, string> | undefined): boolean {
-  if (!headers) {
-    return false;
-  }
-  return Object.entries(headers).some(
-    ([headerName, value]) =>
-      headerName.trim().toLowerCase() === "authorization" && value.trim().length > 0,
-  );
 }
 
 /** Resolves API key (real or synthetic placeholder) from runtime/provider auth config. */
@@ -217,7 +208,7 @@ export async function createLmstudioEmbeddingProvider(
     providerHeaders,
     !isFallbackActivation ? sanitizeLmstudioStringHeaders(options.remote?.headers) : undefined,
   );
-  const apiKey = hasAuthorizationHeader(headerOverrides)
+  const apiKey = hasLmstudioAuthorizationHeader(headerOverrides)
     ? undefined
     : !isFallbackActivation
       ? remoteApiKey?.trim() ||

--- a/extensions/lmstudio/src/runtime.test.ts
+++ b/extensions/lmstudio/src/runtime.test.ts
@@ -267,6 +267,34 @@ describe("lmstudio-runtime", () => {
     });
   });
 
+  it.each([
+    {
+      name: "a configured env marker resolves its concrete credential",
+      apiKey: "GOOGLE_API_KEY",
+      env: { GOOGLE_API_KEY: "direct-env-key" },
+      expected: "direct-env-key",
+    },
+    {
+      name: "a SecretRef resolving to an env marker is not dereferenced again",
+      apiKey: { source: "env", provider: "default", id: "LM_API_TOKEN" },
+      env: { LM_API_TOKEN: "GOOGLE_API_KEY", GOOGLE_API_KEY: "nested-env-key" },
+      expected: undefined,
+    },
+    {
+      name: "a configured synthetic auth marker is suppressed",
+      apiKey: CUSTOM_LOCAL_AUTH_MARKER,
+      env: {},
+      expected: undefined,
+    },
+  ])("preserves configured auth semantics when $name", async ({ apiKey, env, expected }) => {
+    await expect(
+      resolveLmstudioConfiguredApiKey({
+        config: buildLmstudioConfig({ apiKey }),
+        env,
+      }),
+    ).resolves.toBe(expected);
+  });
+
   it("resolves env-template api keys from config", async () => {
     await expect(
       resolveLmstudioConfiguredApiKey({
@@ -293,15 +321,24 @@ describe("lmstudio-runtime", () => {
     ).resolves.toBe("custom-template-lmstudio-key");
   });
 
-  it("throws a path-specific error when an env-template api key cannot be resolved", async () => {
+  it.each([
+    { name: "env template", apiKey: "${LMSTUDIO_API_KEY}" },
+    {
+      name: "SecretRef",
+      apiKey: { source: "env", provider: "default", id: "LMSTUDIO_API_KEY" },
+    },
+  ])("fails closed for an unresolved $name unless explicitly allowed", async ({ apiKey }) => {
+    const options = {
+      config: buildLmstudioConfig({ apiKey }),
+      env: {},
+    };
+
+    await expect(resolveLmstudioConfiguredApiKey(options)).rejects.toThrow(
+      /models\.providers\.lmstudio\.apiKey/i,
+    );
     await expect(
-      resolveLmstudioConfiguredApiKey({
-        config: buildLmstudioConfig({
-          apiKey: "${LMSTUDIO_API_KEY}",
-        }),
-        env: {},
-      }),
-    ).rejects.toThrow(/models\.providers\.lmstudio\.apiKey/i);
+      resolveLmstudioConfiguredApiKey({ ...options, allowUnresolved: true }),
+    ).resolves.toBeUndefined();
   });
 
   it("throws a path-specific error when a SecretRef header cannot be resolved", async () => {

--- a/extensions/lmstudio/src/runtime.ts
+++ b/extensions/lmstudio/src/runtime.ts
@@ -80,50 +80,20 @@ export async function resolveLmstudioConfiguredApiKeyForProvider(params: {
   path?: string;
   allowUnresolved?: boolean;
 }): Promise<string | undefined> {
-  const providerConfig = params.config?.models?.providers?.[params.providerId];
+  const config = params.config;
+  const providerConfig = config?.models?.providers?.[params.providerId];
   const apiKeyInput = providerConfig?.apiKey;
-  if (apiKeyInput === undefined || apiKeyInput === null) {
+  if (apiKeyInput === undefined || apiKeyInput === null || !config) {
     return undefined;
   }
 
   const path = params.path ?? `models.providers.${params.providerId}.apiKey`;
   const env = params.env ?? process.env;
   const directApiKey = normalizeOptionalSecretInput(apiKeyInput);
-  if (directApiKey !== undefined) {
-    const resolved = params.config
-      ? await resolveConfiguredSecretInputString({
-          config: params.config,
-          env,
-          value: directApiKey,
-          path,
-          unresolvedReasonStyle: "detailed",
-        })
-      : { value: directApiKey };
-    if (resolved.unresolvedRefReason) {
-      if (params.allowUnresolved) {
-        return undefined;
-      }
-      throw new Error(`${path}: ${resolved.unresolvedRefReason}`);
-    }
-    const resolvedValue = normalizeOptionalSecretInput(resolved.value);
-    const trimmed = resolvedValue ? normalizeApiKeyConfig(resolvedValue).trim() : "";
-    if (!trimmed) {
-      return undefined;
-    }
-    if (isKnownEnvApiKeyMarker(trimmed)) {
-      const envValue = normalizeOptionalSecretInput(env[trimmed]);
-      return envValue;
-    }
-    return isNonSecretApiKeyMarker(trimmed) ? undefined : trimmed;
-  }
-
-  if (!params.config) {
-    return undefined;
-  }
   const resolved = await resolveConfiguredSecretInputString({
-    config: params.config,
+    config,
     env,
-    value: apiKeyInput,
+    value: directApiKey ?? apiKeyInput,
     path,
     unresolvedReasonStyle: "detailed",
   });
@@ -134,14 +104,14 @@ export async function resolveLmstudioConfiguredApiKeyForProvider(params: {
     throw new Error(`${path}: ${resolved.unresolvedRefReason}`);
   }
   const resolvedValue = normalizeOptionalSecretInput(resolved.value);
-  const trimmedResolvedValue = resolvedValue ? normalizeApiKeyConfig(resolvedValue).trim() : "";
-  if (!trimmedResolvedValue) {
+  const trimmed = resolvedValue ? normalizeApiKeyConfig(resolvedValue).trim() : "";
+  if (!trimmed) {
     return undefined;
   }
-  if (isNonSecretApiKeyMarker(trimmedResolvedValue)) {
-    return undefined;
+  if (directApiKey !== undefined && isKnownEnvApiKeyMarker(trimmed)) {
+    return normalizeOptionalSecretInput(env[trimmed]);
   }
-  return trimmedResolvedValue;
+  return isNonSecretApiKeyMarker(trimmed) ? undefined : trimmed;
 }
 
 export async function resolveLmstudioConfiguredApiKey(params: {


### PR DESCRIPTION
## What Problem This Solves

LM Studio maintains duplicate configured-credential resolution paths for literal API keys and SecretRefs, and its embedding provider separately reimplements the plugin's existing Authorization-header detection. Keeping those authentication decisions in multiple places makes an established, security-sensitive provider contract harder to maintain consistently.

## Why This Change Was Made

Resolve configured credentials through one canonical LM Studio provider-owned flow and reuse the plugin's established Authorization-header detector for embeddings. Preserve the shipped distinction between a directly configured environment-marker, which resolves its concrete environment credential, and a SecretRef yielding the same marker, which remains suppressed and is never recursively dereferenced.

## User Impact

No intended user-visible behavior change. Existing API-key and SecretRef resolution, header-based authentication, synthetic local credentials, provider aliases, unresolved-secret handling, and model setup and embedding behavior remain unchanged.

## Evidence

- Production: +12/-51 lines, net -39; tests: +45/-8 lines, net +37.
- Tests-first parity against unchanged production: 21/21 LM Studio runtime tests passed, including direct-marker versus SecretRef-marker behavior, synthetic credentials, and strict versus explicitly allowed unresolved templates and SecretRefs.
- Final complete LM Studio plugin suite: 211/211 tests across all 10 files passed using the canonical provider Vitest configuration and a single worker.
- All three changed files passed formatting and the canonical extension lint wrapper with both `--type-aware` and `--type-check`; the repository-supported `OPENCLAW_OXLINT_SKIP_PREPARE=1` skipped only unrelated whole-repository SDK declaration regeneration, which currently encounters existing Google, Markdown, and TUI dependency-type drift. No lint rules or type checks were disabled.
- Read-only live LM Studio discovery confirmed the running local service remained reachable with 14 installed models and no loaded models; no models or services were started or modified.
- Two independent owner/security reviews approved the final change; the mandatory full-diff automated review reported no actionable findings.
- Verified head: `ec634073aa35eb73a592462031cce5d60fb8755d`.
