### PR TITLE
fix(agents): keep active hidden model streams out of stalled recovery

### DIFF
--- a/packages/ai/src/transports/openai-completions-stream.integration.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.integration.test.ts
@@ -1,6 +1,11 @@
 import { createServer } from "node:http";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import { streamWithIdleTimeout } from "../../../../src/agents/embedded-agent-runner/run/llm-idle-timeout.js";
+import {
+  getDiagnosticSessionActivitySnapshot,
+  markDiagnosticRunProgress,
+  resetDiagnosticRunActivityForTest,
+} from "../../../../src/logging/diagnostic-run-activity.js";
 import { registerBuiltInApiProviders } from "../providers/register-builtins.js";
 import { createLlmRuntime } from "../stream.js";
 import { shouldEmitOpenAICompletionsReasoning } from "./openai-completions-stream.js";
@@ -8,6 +13,10 @@ import { createOpenAICompletionsTransportStreamFn } from "./openai-completions-t
 import { makeCompletionsChunk, makeCompletionsModel } from "./openai-completions.test-support.js";
 
 describe("openai completions stream", () => {
+  afterAll(() => {
+    resetDiagnosticRunActivityForTest();
+  });
+
   it("emits Qwen thinking streams when enabled without reasoning_effort support", async () => {
     let capturedPayload: Record<string, unknown> | undefined;
     const server = createServer((req, res) => {
@@ -219,9 +228,16 @@ describe("openai completions stream", () => {
       // a loaded runner stretches every inter-chunk gap, and one gap wider than
       // the timeout inverts the ratio into a false idle timeout.
       const idleTimeoutMs = 1_000;
+      const sessionProgressStaleMs = 750;
       const reasoningChunkDelayMs = 5;
       const hiddenReasoningDurationMs = idleTimeoutMs + 200;
+      const runId = `hidden-${reasoningField}-run`;
       let hiddenReasoningElapsedMs = 0;
+      let crossedSessionProgressThreshold = false;
+      let resolveSessionProgressThreshold!: () => void;
+      const sessionProgressThresholdReached = new Promise<void>((resolve) => {
+        resolveSessionProgressThreshold = resolve;
+      });
       const server = createServer((req, res) => {
         req.resume();
         req.on("end", () => {
@@ -237,6 +253,13 @@ describe("openai completions stream", () => {
               return;
             }
             hiddenReasoningElapsedMs = Date.now() - hiddenReasoningStartedAt;
+            if (
+              !crossedSessionProgressThreshold &&
+              hiddenReasoningElapsedMs > sessionProgressStaleMs + 100
+            ) {
+              crossedSessionProgressThreshold = true;
+              resolveSessionProgressThreshold();
+            }
             if (hiddenReasoningElapsedMs < hiddenReasoningDurationMs) {
               const reasoningChunk = {
                 id: "chatcmpl-local-reasoning",
@@ -284,10 +307,16 @@ describe("openai completions stream", () => {
           reasoning: false,
         });
         const onIdleTimeout = vi.fn();
+        markDiagnosticRunProgress({
+          runId,
+          sessionId: runId,
+          reason: "model_call:started",
+        });
         const streamFn = streamWithIdleTimeout(
           createOpenAICompletionsTransportStreamFn(),
           idleTimeoutMs,
           onIdleTimeout,
+          { runId },
         );
         const stream = streamFn(
           model,
@@ -301,14 +330,23 @@ describe("openai completions stream", () => {
 
         let text = "";
         let thinking = "";
-        for await (const event of stream as AsyncIterable<{ type: string; delta?: string }>) {
-          if (event.type === "text_delta") {
-            text += event.delta ?? "";
+        const collectStream = (async () => {
+          for await (const event of stream as AsyncIterable<{ type: string; delta?: string }>) {
+            if (event.type === "text_delta") {
+              text += event.delta ?? "";
+            }
+            if (event.type === "thinking_delta") {
+              thinking += event.delta ?? "";
+            }
           }
-          if (event.type === "thinking_delta") {
-            thinking += event.delta ?? "";
-          }
-        }
+        })();
+
+        await sessionProgressThresholdReached;
+        const activity = getDiagnosticSessionActivitySnapshot({ sessionId: runId });
+        expect(activity.lastProgressAgeMs).toBeLessThan(sessionProgressStaleMs);
+        expect(activity.lastProgressReason).toBe("model_call:stream_progress");
+
+        await collectStream;
 
         expect(text).toBe("OK");
         expect(thinking).toBe("");

--- a/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
@@ -9,7 +9,9 @@ import {
   MAX_TIMER_TIMEOUT_MS,
 } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { areDiagnosticsEnabledForProcess } from "../../../infra/diagnostic-events.js";
 import { toErrorObject } from "../../../infra/errors.js";
+import { markDiagnosticRunProgress } from "../../../logging/diagnostic-run-activity.js";
 import type { StreamFn } from "../../runtime/index.js";
 import type { MutableAssistantMessageEventStream } from "../../stream-compat.js";
 import { createStreamIteratorWrapper } from "../../stream-iterator-wrapper.js";
@@ -57,13 +59,8 @@ type IdleTimeoutProviderConfig = {
  *    classification keys on `URL.hostname` so resolution would have to happen
  *    here, and adding sync/async DNS to the watchdog hot path is disproportionate.
  */
-function isLocalProviderBaseUrl(baseUrl: string): boolean {
-  let host: string;
-  try {
-    host = new URL(baseUrl).hostname.toLowerCase();
-  } catch {
-    return false;
-  }
+function isLocalProviderHostname(hostname: string): boolean {
+  let host = hostname;
   if (host.startsWith("[") && host.endsWith("]")) {
     host = host.slice(1, -1);
   }
@@ -109,36 +106,19 @@ function isLocalProviderBaseUrl(baseUrl: string): boolean {
   );
 }
 
-function isExplicitLocalHostnameBaseUrl(baseUrl: string): boolean {
-  let host: string;
-  try {
-    host = new URL(baseUrl).hostname.toLowerCase();
-  } catch {
-    return false;
-  }
-
-  if (
-    host === "docker.orb.internal" ||
-    host === "host.docker.internal" ||
-    host === "host.orb.internal"
-  ) {
-    return true;
-  }
-  return false;
+function isExplicitLocalHostname(hostname: string): boolean {
+  return (
+    hostname === "docker.orb.internal" ||
+    hostname === "host.docker.internal" ||
+    hostname === "host.orb.internal"
+  );
 }
 
-function isBareProviderHostnameBaseUrl(baseUrl: string): boolean {
-  let host: string;
-  try {
-    host = new URL(baseUrl).hostname.toLowerCase();
-  } catch {
+function isBareProviderHostname(hostname: string): boolean {
+  if (hostname.includes(".") || hostname.includes(":")) {
     return false;
   }
-
-  if (host.includes(".") || host.includes(":")) {
-    return false;
-  }
-  return /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(host);
+  return /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(hostname);
 }
 
 function isSelfHostedProviderId(provider: string | undefined): boolean {
@@ -200,7 +180,15 @@ function resolveRuntimeModelLocality(params?: {
   model?: { baseUrl?: string; id?: string; provider?: string };
 }): RuntimeModelLocality {
   const baseUrl = params?.model?.baseUrl;
-  if (typeof baseUrl !== "string" || baseUrl.length === 0) {
+  let hostname: string | undefined;
+  if (typeof baseUrl === "string" && baseUrl.length > 0) {
+    try {
+      hostname = new URL(baseUrl).hostname.toLowerCase();
+    } catch {
+      hostname = undefined;
+    }
+  }
+  if (!hostname) {
     return {
       isLocalRuntimeModel: false,
       isExplicitLocalHostnameRuntimeModel: false,
@@ -209,10 +197,10 @@ function resolveRuntimeModelLocality(params?: {
   }
   const notCloudModel = !isCloudModelRef(params?.model?.id);
   return {
-    isLocalRuntimeModel: isLocalProviderBaseUrl(baseUrl) && notCloudModel,
-    isExplicitLocalHostnameRuntimeModel: isExplicitLocalHostnameBaseUrl(baseUrl) && notCloudModel,
+    isLocalRuntimeModel: isLocalProviderHostname(hostname) && notCloudModel,
+    isExplicitLocalHostnameRuntimeModel: isExplicitLocalHostname(hostname) && notCloudModel,
     isSelfHostedHostnameRuntimeModel:
-      isBareProviderHostnameBaseUrl(baseUrl) &&
+      isBareProviderHostname(hostname) &&
       (isSelfHostedProviderId(params?.model?.provider) ||
         hasConfiguredLocalProviderSignal({
           cfg: params?.cfg,
@@ -516,10 +504,12 @@ export function streamWithIdleTimeout(
             rejectIdleTimeout = undefined;
             clearTimer();
           };
-          const unsubscribeLlmActivity = onLlmRequestActivity(
-            streamAbortController.signal,
-            armTimer,
-          );
+          const unsubscribeLlmActivity = onLlmRequestActivity(streamAbortController.signal, () => {
+            armTimer();
+            if (runId && areDiagnosticsEnabledForProcess()) {
+              markDiagnosticRunProgress({ runId, reason: "model_call:stream_progress" });
+            }
+          });
           const unsubscribeStreamToolActivity = runId ? onToolActivity(runId, armTimer) : undefined;
           const cleanupIterator = () => {
             stopWaiting();


### PR DESCRIPTION
Related: #129377. That issue remains open because its report does not include the provider's actual SSE frames.

Supersedes #129525. Thanks to @Alix-007 for identifying the hidden-stream progress gap and contributing the loopback SSE regression; their authorship is preserved in the commit.

## What Problem This Solves

Fixes an issue where users running OpenAI-compatible local reasoning models could have an actively producing response reclaimed as stalled when the provider's reasoning chunks were intentionally hidden from the normalized response stream.

## Why This Change Was Made

The existing signal-scoped request-activity listener already keeps the model idle watchdog alive for genuine raw provider chunks. It now records the same existing, run-scoped session-progress fact when diagnostics are enabled, without emitting hidden reasoning, adding configuration, or changing cancellation ownership. The same watchdog owner now parses each provider URL once and shares its normalized hostname across the existing local/private, Docker-host, and self-hosted classifications.

Production LOC: +31/-41 (net -10). Tests: +46/-8 (net +38). No persistence, public API, provider-specific special case, or new compatibility path.

## User Impact

Operators can complete long-running model responses that continuously produce hidden reasoning without stalled-session recovery incorrectly aborting the active run. Visible output, disabled-diagnostics behavior, real idle timeouts, private-network classification, and provider-specific timeout decisions remain unchanged.

## Evidence

- Exact reviewed head: `1d744209a29e92fd4dcabd89f35a6514db958f9b`.
- Before the fix, the real localhost HTTP/SSE regression failed for both `reasoning_content` and `reasoning`: session progress aged to 853 ms despite continuous provider chunks, exceeding the 750 ms stale threshold; 2 failed and 8 passed.
- After the fix, the canonical single-worker owner/sibling run passed 525 tests across 13 suites, including real localhost SSE, the complete idle/locality classification matrix, cancellation, diagnostics-disabled behavior, session attention, and stalled-session recovery.
- The earlier hosted failure came from two unrelated, incomplete filesystem mocks already repaired on current main; rebasing onto that canonical fix preserved the exact reviewed patch, and both formerly failing command suites now pass all 27 tests.
- Hosted-equivalent scoped type-aware and type-checking lint passed for both changed files with the repository-supported `OPENCLAW_OXLINT_SKIP_PREPARE=1`; this skips unrelated package-artifact preparation only and retains the full lint policy.
- Scoped formatting and `git diff --check` passed.
- Two independent source reviews approved the full change; the final structured review reported no accepted or actionable findings.
- ClawSweeper rank-up: the optional duplicate watchdog-unit assertion was intentionally skipped because both real localhost SSE regressions already instantiate the watchdog and assert canonical, run-scoped diagnostic progress across the actual production observer boundary; the complete owner suite additionally covers disabled diagnostics, cancellation, and locality. Exact-head hosted CI passed all 147 jobs, including the required gate.
- The localhost server uses synthetic OpenAI-compatible SSE; no authenticated provider run or claim about the unobserved frames in #129377 is implied.
