### PR TITLE
fix(voice-call): fold late provider callbacks into finalized records

### DIFF
--- a/extensions/voice-call/src/manager.restore.test.ts
+++ b/extensions/voice-call/src/manager.restore.test.ts
@@ -422,7 +422,11 @@ describe("CallManager verification on restore", () => {
 
     expect(manager.getActiveCalls()).toHaveLength(0);
 
-    manager.processEvent({
+    // The dropped (out-of-window) dedupe key is no longer restored, so the
+    // replayed webhook is not ignored by the dedupe gate. But the call is
+    // already terminal — the event must fold into the existing record instead
+    // of birthing a phantom zero-duration record under the default agent.
+    const result = manager.processEvent({
       id: replayKeys[0] as string,
       type: "call.initiated",
       callId: String(persisted.providerCallId),
@@ -433,6 +437,7 @@ describe("CallManager verification on restore", () => {
       to: "+15550000001",
     });
 
-    expect(manager.getActiveCalls()).toHaveLength(1);
+    expect(result.kind).toBe("processed");
+    expect(manager.getActiveCalls()).toHaveLength(0);
   });
 });

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -8,8 +8,10 @@ import {
 import type { VoiceCallProvider } from "../providers/base.js";
 import type { CallRecord, HangupCallInput, NormalizedEvent } from "../types.js";
 import { processEvent } from "./events.js";
+import { finalizeCall } from "./lifecycle.js";
 import { speakInitialMessage } from "./outbound.js";
 import { MAX_CALL_REPLAY_KEYS } from "./replay-keys.js";
+import { findCallMatchesInStore, getCallHistoryFromStore } from "./store.js";
 
 const logSpy = vi.hoisted(() => {
   const logEntries: string[] = [];
@@ -510,6 +512,67 @@ describe("processEvent (functional)", () => {
       waiterResolved: false,
     });
     expect(replayResult).toEqual({ kind: "ignored" });
+  });
+
+  it("does not birth a phantom record for a late status callback on a finalized call", async () => {
+    // Reproduces #130059: after finalizeCall removes a record from the active
+    // maps, a late provider "completed" status callback arrives with a fresh
+    // dedupe key (the local end never records one for the provider's eventual
+    // status callback). findCall misses the now-removed record, so the
+    // auto-register branch must consult the persistent store instead of
+    // fabricating a phantom zero-duration record under the default agent.
+    const now = Date.now();
+    const ctx = createContext();
+    const providerCallId = "CA-late-callback";
+    const realCall: CallRecord = {
+      callId: "call-real-agent",
+      providerCallId,
+      provider: "twilio",
+      direction: "outbound",
+      state: "answered",
+      from: "+15550000000",
+      to: "+15550000001",
+      agentId: "agent-sales",
+      startedAt: now - 30_000,
+      answeredAt: now - 25_000,
+      transcript: [],
+      processedEventIds: [],
+    };
+    ctx.activeCalls.set(realCall.callId, realCall);
+    ctx.providerCallIdMap.set(providerCallId, realCall.callId);
+
+    // The realtime/bot end closes the lifecycle: finalizeCall transitions to a
+    // terminal state, persists the terminal snapshot, and removes the record
+    // from the active maps (it remains only in the persistent store).
+    finalizeCall({ ctx, call: realCall, endReason: "hangup-bot" });
+    expect(ctx.activeCalls.size).toBe(0);
+    expect(ctx.providerCallIdMap.has(providerCallId)).toBe(false);
+
+    // The provider's eventual "completed" status callback arrives late, with a
+    // fresh dedupe key the local end never recorded.
+    const result = processEvent(ctx, {
+      id: "evt-late-completed",
+      type: "call.ended",
+      callId: providerCallId,
+      providerCallId,
+      timestamp: now,
+      direction: "outbound",
+      reason: "completed",
+      from: "+15550000000",
+      to: "+15550000001",
+    });
+    expect(result.kind).toBe("processed");
+
+    // No phantom: the store owns only snapshots of the original real call —
+    // retaining its agent — not a freshly-minted default-agent zero-duration
+    // phantom with a new callId.
+    const matches = await findCallMatchesInStore(ctx.storePath, providerCallId);
+    const owner = matches.byProviderCallId;
+    expect(owner).toBeDefined();
+    expect(owner!.callId).toBe("call-real-agent");
+    expect(owner!.agentId).toBe("agent-sales");
+    const history = await getCallHistoryFromStore(ctx.storePath, 50);
+    expect(history.every((call) => call.callId === "call-real-agent")).toBe(true);
   });
 
   it.each([

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -11,7 +11,7 @@ import { processEvent } from "./events.js";
 import { finalizeCall } from "./lifecycle.js";
 import { speakInitialMessage } from "./outbound.js";
 import { MAX_CALL_REPLAY_KEYS } from "./replay-keys.js";
-import { findCallMatchesInStore, getCallHistoryFromStore } from "./store.js";
+import { findCallMatchesInStore, getCallHistoryFromStore, persistCallRecord } from "./store.js";
 
 const logSpy = vi.hoisted(() => {
   const logEntries: string[] = [];
@@ -639,6 +639,85 @@ describe("processEvent (functional)", () => {
     expect(owner).toBeDefined();
     expect(owner!.callId).toBe("call-real-inbound");
     expect(owner!.agentId).toBe("agent-sales");
+  });
+
+  it("folds a late alias callback into the terminal snapshot instead of the stale pre-terminal one", async () => {
+    // Sibling coverage for #130145 Finding 2: Plivo transitions a call's
+    // providerCallId from request_uuid to CallUUID across its lifecycle, and
+    // the store appends a snapshot per event rather than upserting. After a
+    // restart clears the in-memory maps, a late status callback still carrying
+    // the old request_uuid must resolve to the terminal snapshot (and absorb) —
+    // not the stale pre-terminal snapshot it directly matches, which would
+    // re-run call.initiated side effects (answerCall) on an already-ended call.
+    const now = Date.now();
+    const answerCalls: AnswerCallInput[] = [];
+    const provider = createProvider({
+      answerCall: async (input: AnswerCallInput): Promise<void> => {
+        answerCalls.push(input);
+      },
+    });
+    const ctx = createContext({
+      config: VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "plivo",
+        fromNumber: "+15550000000",
+        inboundPolicy: "open",
+      }),
+      provider,
+    });
+    const callId = "call-plivo-alias";
+    // R1: the snapshot persisted under the original request_uuid (pre-terminal).
+    const requestUuidSnapshot: CallRecord = {
+      callId,
+      providerCallId: "request-uuid",
+      provider: "plivo",
+      direction: "inbound",
+      state: "initiated",
+      from: "+15550001234",
+      to: "+15550000000",
+      agentId: "agent-sales",
+      startedAt: now - 30_000,
+      transcript: [],
+      processedEventIds: [],
+    };
+    persistCallRecord(ctx.storePath, requestUuidSnapshot);
+    // R3: the terminal snapshot a later CallUUID callback finalized under.
+    persistCallRecord(ctx.storePath, {
+      ...requestUuidSnapshot,
+      providerCallId: "CallUUID",
+      state: "completed",
+      answeredAt: now - 25_000,
+      endedAt: now - 5_000,
+      endReason: "completed",
+    });
+
+    // In-memory maps are empty (post-restart); the late callback still carries
+    // the old request_uuid alias and must consult the store.
+    const result = processEvent(ctx, {
+      id: "evt-late-alias",
+      type: "call.initiated",
+      callId: "request-uuid",
+      providerCallId: "request-uuid",
+      timestamp: now,
+      direction: "inbound",
+      from: "+15550001234",
+      to: "+15550000000",
+    });
+
+    expect(result.kind).toBe("processed");
+    // Pre-fix: the old alias resolves to the stale initiated snapshot, which is
+    // non-terminal, so the switch re-runs and queues answerCall (1). Post-fix:
+    // the alias resolves to the terminal snapshot and absorbs (0).
+    expect(answerCalls).toHaveLength(0);
+
+    // The folded record keeps the canonical CallUUID, and the store still owns
+    // only the real call's snapshots (no phantom, no canonical-id downgrade).
+    const matches = await findCallMatchesInStore(ctx.storePath, "request-uuid");
+    const owner = matches.byProviderCallId;
+    expect(owner).toBeDefined();
+    expect(owner!.callId).toBe(callId);
+    expect(owner!.state).toBe("completed");
+    expect(owner!.providerCallId).toBe("CallUUID");
   });
 
   it.each([

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -6,7 +6,7 @@ import {
   EVENT_MANAGER_REPLAY_KEY_LIMIT,
 } from "../manager.test-harness.js";
 import type { VoiceCallProvider } from "../providers/base.js";
-import type { CallRecord, HangupCallInput, NormalizedEvent } from "../types.js";
+import type { AnswerCallInput, CallRecord, HangupCallInput, NormalizedEvent } from "../types.js";
 import { processEvent } from "./events.js";
 import { finalizeCall } from "./lifecycle.js";
 import { speakInitialMessage } from "./outbound.js";
@@ -573,6 +573,72 @@ describe("processEvent (functional)", () => {
     expect(owner!.agentId).toBe("agent-sales");
     const history = await getCallHistoryFromStore(ctx.storePath, 50);
     expect(history.every((call) => call.callId === "call-real-agent")).toBe(true);
+  });
+
+  it("does not answer a late inbound call.initiated on a finalized call", async () => {
+    // Sibling coverage for #130059: a late provider callback that folds into a
+    // terminal record must not re-run live side effects. The call.initiated
+    // handler queues answerCall for inbound calls; on an already-ended call
+    // that would send an answer action to the carrier for a dead call.
+    const now = Date.now();
+    const answerCalls: AnswerCallInput[] = [];
+    const provider = createProvider({
+      answerCall: async (input: AnswerCallInput): Promise<void> => {
+        answerCalls.push(input);
+      },
+    });
+    const ctx = createContext({
+      config: VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "plivo",
+        fromNumber: "+15550000000",
+        inboundPolicy: "open",
+      }),
+      provider,
+    });
+    const providerCallId = "CA-late-inbound";
+    const realCall: CallRecord = {
+      callId: "call-real-inbound",
+      providerCallId,
+      provider: "plivo",
+      direction: "inbound",
+      state: "answered",
+      from: "+15550001234",
+      to: "+15550000000",
+      agentId: "agent-sales",
+      startedAt: now - 30_000,
+      answeredAt: now - 25_000,
+      transcript: [],
+      processedEventIds: [],
+    };
+    ctx.activeCalls.set(realCall.callId, realCall);
+    ctx.providerCallIdMap.set(providerCallId, realCall.callId);
+
+    finalizeCall({ ctx, call: realCall, endReason: "completed" });
+    expect(ctx.activeCalls.size).toBe(0);
+    expect(ctx.providerCallIdMap.has(providerCallId)).toBe(false);
+
+    // The provider's late "initiated" status echo arrives after finalization.
+    const result = processEvent(ctx, {
+      id: "evt-late-initiated",
+      type: "call.initiated",
+      callId: providerCallId,
+      providerCallId,
+      timestamp: now,
+      direction: "inbound",
+      from: "+15550001234",
+      to: "+15550000000",
+    });
+    expect(result.kind).toBe("processed");
+    // No answer request to the carrier for an already-ended call.
+    expect(answerCalls).toHaveLength(0);
+
+    // No phantom: the store owns only snapshots of the original real call.
+    const matches = await findCallMatchesInStore(ctx.storePath, providerCallId);
+    const owner = matches.byProviderCallId;
+    expect(owner).toBeDefined();
+    expect(owner!.callId).toBe("call-real-inbound");
+    expect(owner!.agentId).toBe("agent-sales");
   });
 
   it.each([

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -284,7 +284,15 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
   };
 
   try {
-    if (event.providerCallId && event.providerCallId !== activeCall.providerCallId) {
+    // Update the record when a callback reveals the canonical provider id
+    // (e.g. a Plivo CallUUID arriving on a record still keyed by request_uuid).
+    // Skip the mutation for a folded terminal echo: that record already carries
+    // its newest canonical id, and a stale-alias callback must not downgrade it.
+    if (
+      event.providerCallId &&
+      event.providerCallId !== activeCall.providerCallId &&
+      !foldedTerminalRecord
+    ) {
       activeCall.providerCallId = event.providerCallId;
     }
     if (shouldCommitReplayKey) {

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -6,7 +6,7 @@ import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { isAllowlistedCaller, normalizePhoneNumber } from "../allowlist.js";
 import { resolveVoiceCallEffectiveConfig, resolveVoiceCallSessionKey } from "../config.js";
-import type { CallRecord, NormalizedEvent } from "../types.js";
+import { TerminalStates, type CallRecord, type NormalizedEvent } from "../types.js";
 import type { CallManagerContext } from "./context.js";
 import { finalizeCall } from "./lifecycle.js";
 import { findCall } from "./lookup.js";
@@ -168,6 +168,9 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
     providerCallIdMap: ctx.providerCallIdMap,
     callIdOrProviderCallId: event.callId,
   });
+  // Set when a late provider callback folds into a persisted terminal record;
+  // such an echo must not re-run live event side effects (see try block).
+  let foldedTerminalRecord = false;
 
   const providerCallId = event.providerCallId;
   const eventDirection =
@@ -220,6 +223,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
     const persisted = findCallByProviderCallIdInStore(ctx.storePath, providerCallId);
     if (persisted) {
       call = persisted;
+      foldedTerminalRecord = TerminalStates.has(persisted.state);
     } else {
       call = createWebhookCall({
         ctx,
@@ -285,6 +289,17 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
     }
     if (shouldCommitReplayKey) {
       appendCallReplayKey(activeCall.processedEventIds, dedupeKey);
+    }
+
+    // A late provider callback folded into a terminal record is a stale status
+    // echo. Absorb it (persist + dedupe) without re-running live side effects —
+    // answerCall, duration timers, onCallAnswered — on an already-ended call.
+    if (foldedTerminalRecord) {
+      persistCallRecord(ctx.storePath, activeCall);
+      if (shouldCommitReplayKey) {
+        rememberManagerReplayKey(ctx.processedEventIds, dedupeKey);
+      }
+      return { kind: "processed" };
     }
 
     switch (event.type) {

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -18,7 +18,7 @@ import {
   reserveRejectedProviderCall,
 } from "./replay-keys.js";
 import { addTranscriptEntry, transitionState } from "./state.js";
-import { persistCallRecord } from "./store.js";
+import { findCallByProviderCallIdInStore, persistCallRecord } from "./store.js";
 import { resolveTranscriptWaiter, startMaxDurationTimer } from "./timers.js";
 
 const log = createSubsystemLogger("voice-call/events");
@@ -212,13 +212,23 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
       return { kind: "processed" };
     }
 
-    call = createWebhookCall({
-      ctx,
-      providerCallId,
-      direction: eventDirection === "outbound" ? "outbound" : "inbound",
-      from: event.from || "unknown",
-      to: event.to || ctx.config.fromNumber || "unknown",
-    });
+    // A late provider status callback can arrive after finalizeCall removed the
+    // record from the active maps; the local end records no dedupe key for the
+    // provider's eventual terminal callback, so findCall misses. Consult the
+    // store before fabricating — otherwise a phantom zero-duration call is
+    // birthed under the default agent. Fold into an existing owner instead.
+    const persisted = findCallByProviderCallIdInStore(ctx.storePath, providerCallId);
+    if (persisted) {
+      call = persisted;
+    } else {
+      call = createWebhookCall({
+        ctx,
+        providerCallId,
+        direction: eventDirection === "outbound" ? "outbound" : "inbound",
+        from: event.from || "unknown",
+        to: event.to || ctx.config.fromNumber || "unknown",
+      });
+    }
 
     // Normalize event to internal ID for downstream consumers.
     event.callId = call.callId;

--- a/extensions/voice-call/src/manager/store.test.ts
+++ b/extensions/voice-call/src/manager/store.test.ts
@@ -16,6 +16,7 @@ import { setVoiceCallStateRuntime } from "../runtime-state.js";
 import { CallRecordSchema } from "../types.js";
 import { MAX_CALL_REPLAY_KEYS } from "./replay-keys.js";
 import {
+  findCallByProviderCallIdInStore,
   findCallMatchesInStore,
   getCallHistoryFromStore,
   loadActiveCallsFromStore,
@@ -272,5 +273,50 @@ describe("voice-call call record store", () => {
       callId: "call-target",
       state: "completed",
     });
+  });
+
+  it("resolves a provider alias to the newest snapshot for the logical call", async () => {
+    const storePath = createTestStorePath();
+    // Plivo lifecycle: outbound created with request_uuid, later callbacks carry
+    // CallUUID. The store appends per event, so the logical call is retained under
+    // both ids across a non-terminal -> terminal transition.
+    persistCallRecord(
+      storePath,
+      CallRecordSchema.parse(
+        makePersistedCall({
+          callId: "call-alias",
+          providerCallId: "request-uuid",
+          state: "initiated",
+        }),
+      ),
+    );
+    persistCallRecord(
+      storePath,
+      CallRecordSchema.parse(
+        makePersistedCall({
+          callId: "call-alias",
+          providerCallId: "CallUUID",
+          state: "completed",
+        }),
+      ),
+    );
+
+    // Sync helper (webhook fold path): the old alias must resolve to the terminal
+    // snapshot, not the stale pre-terminal one it directly matches.
+    const resolved = findCallByProviderCallIdInStore(storePath, "request-uuid");
+    expect(resolved?.state).toBe("completed");
+    expect(resolved?.providerCallId).toBe("CallUUID");
+
+    // Async sibling (inspect path): same invariant.
+    const matches = await findCallMatchesInStore(storePath, "request-uuid");
+    expect(matches.byProviderCallId).toMatchObject({
+      callId: "call-alias",
+      state: "completed",
+      providerCallId: "CallUUID",
+    });
+
+    // The canonical id resolves directly to the terminal snapshot too.
+    const canonical = findCallByProviderCallIdInStore(storePath, "CallUUID");
+    expect(canonical?.state).toBe("completed");
   });
 });

--- a/extensions/voice-call/src/manager/store.ts
+++ b/extensions/voice-call/src/manager/store.ts
@@ -397,6 +397,23 @@ function readCallHistoryFromStore(storePath: string): CallRecord[] {
   return [];
 }
 
+// Plivo transitions a call's providerCallId from request_uuid to CallUUID across
+// its lifecycle (plivo.ts), and the store appends a snapshot per event, so one
+// logical call is retained under both ids. Resolve a lookup by the old alias to
+// the newest snapshot for that call (the terminal one a late callback folds
+// into), not the stale pre-terminal alias match (#130145). A no-op for
+// telnyx/twilio, which use one stable id.
+function resolveNewestByProviderCallId(
+  calls: readonly CallRecord[],
+  providerCallId: string,
+): CallRecord | undefined {
+  const aliasMatch = calls.findLast((call) => call.providerCallId === providerCallId);
+  if (!aliasMatch) {
+    return undefined;
+  }
+  return calls.findLast((call) => call.callId === aliasMatch.callId);
+}
+
 /** Find the newest retained snapshots matching each call identifier namespace. */
 export async function findCallMatchesInStore(
   storePath: string,
@@ -405,7 +422,7 @@ export async function findCallMatchesInStore(
   const calls = readCallHistoryFromStore(storePath);
   return {
     byCallId: calls.findLast((call) => call.callId === callId),
-    byProviderCallId: calls.findLast((call) => call.providerCallId === callId),
+    byProviderCallId: resolveNewestByProviderCallId(calls, callId),
   };
 }
 
@@ -414,9 +431,7 @@ export function findCallByProviderCallIdInStore(
   storePath: string,
   providerCallId: string,
 ): CallRecord | undefined {
-  return readCallHistoryFromStore(storePath).findLast(
-    (call) => call.providerCallId === providerCallId,
-  );
+  return resolveNewestByProviderCallId(readCallHistoryFromStore(storePath), providerCallId);
 }
 
 /** Return the newest persisted call history rows up to the requested limit. */

--- a/extensions/voice-call/src/manager/store.ts
+++ b/extensions/voice-call/src/manager/store.ts
@@ -409,6 +409,16 @@ export async function findCallMatchesInStore(
   };
 }
 
+/** Find the newest retained snapshot owning a provider call id. Sync (the webhook event path cannot await); mirrors the scan in {@link findCallMatchesInStore}. */
+export function findCallByProviderCallIdInStore(
+  storePath: string,
+  providerCallId: string,
+): CallRecord | undefined {
+  return readCallHistoryFromStore(storePath).findLast(
+    (call) => call.providerCallId === providerCallId,
+  );
+}
+
 /** Return the newest persisted call history rows up to the requested limit. */
 export async function getCallHistoryFromStore(
   storePath: string,


### PR DESCRIPTION
## What Problem This Solves

Fixes #130059 — a late provider status callback (e.g. a delayed "completed"/"initiated" webhook) arriving after `finalizeCall` removed the call from the active maps births a **phantom zero-duration call record under the default agent** (`main`), and (per ClawSweeper P1 review) a late inbound `call.initiated` on such a record would also queue `answerCall` for an already-ended call.

Root cause: `findCall` (`extensions/voice-call/src/manager/lookup.ts`) only consults the in-memory active maps. `finalizeCall` (`lifecycle.ts:65-66`) removes the record from `activeCalls` and `providerCallIdMap`, and records no dedupe key for the provider's eventual terminal callback (`rememberManagerReplayKey` is only called for `call.ended`/`call.error` in `processEvent`). So when the provider's late terminal callback arrives:

1. Its dedupe key is fresh → passes the dedupe gate.
2. `findCall` misses (the record is gone from the active maps).
3. The auto-register branch (`events.ts:182`) fabricates a fresh record via `createWebhookCall` — new callId, `agentId="main"` (default), `ringing`→`completed`, zero duration.

Result: wrong agent attribution (the real owner, e.g. `agent-sales`, is replaced by `main`) and duplicate call-history entries.

## Why This Change Was Made

Producer-first repair at the birth site, in three parts:

**Part A — consult the store before fabricating.** Before fabricating, consult the persistent store by `providerCallId`; if a record already owns this id, fold the event into it instead of birthing a phantom.

- `store.ts`: add `findCallByProviderCallIdInStore` — a sync helper reusing `readCallHistoryFromStore`'s scan (the webhook event path is sync and cannot await the existing async `findCallMatchesInStore`).
- `events.ts` auto-register branch: query the store before `createWebhookCall`; fold into an existing owner when found.

**Part B — fence terminal records from live side effects (ClawSweeper P1).** Folding a terminal record is not enough: the event then fell through to the normal `switch (event.type)`, so a late inbound `call.initiated` on an ended call queued `answerCall` (an answer action to the carrier for a dead call), and `call.answered` would arm a duration timer + fire `onCallAnswered`. When the fold resolves a **terminal** record, absorb the echo instead — persist + record the dedupe key and return without running live side effects. `transitionState` is already a no-op on terminal records, so the only behavioral change is suppressing the provider/timer/callback effects that should never run on an ended call.

**Part C — resolve a Plivo provider alias to the newest snapshot (ClawSweeper P1 finding 2).** Plivo transitions a call's `providerCallId` from `request_uuid` (at outbound creation, `plivo.ts:392`) to `CallUUID` (on later callbacks, `plivo.ts:284`), and the store appends a snapshot per event rather than upserting — so one logical call is retained under both ids. `findCallByProviderCallIdInStore`/`findCallMatchesInStore` matched only the **stale pre-terminal snapshot** when a late status callback carried the old `request_uuid` alias, so the fold resolved a non-terminal record and the late callback re-ran live side effects on a dead call. `resolveNewestByProviderCallId` (shared by the sync webhook helper and the async inspect helper) resolves the alias match to the newest snapshot for the logical call. A no-op for telnyx/twilio, which use one stable id. The `providerCallId` mutation in the try block is also guarded with `!foldedTerminalRecord` so a folded terminal echo does not downgrade the canonical id (`CallUUID`) back to the stale alias.

Sibling providers (telnyx/plivo) share this provider-agnostic `processEvent` path, so all parts cover them too.

Part 1 (persist `providerCallId` as early as possible) is already satisfied on `main` — the field is persisted on the live record throughout its lifecycle, so the store lookup finds it. Part 3 (an orphan marker) is optional defense-in-depth, not needed for the root cause.

## User Impact

Operators no longer see phantom zero-duration calls attributed to `main` in their call history when a provider's status callback is delayed past local finalization, and a late inbound status echo no longer triggers a spurious answer action to the carrier for an ended call. For Plivo, a late status callback carrying the original `request_uuid` no longer re-runs side effects against a stale pre-terminal snapshot. Call history and agent attribution stay accurate. No behavior change for the normal (non-late) callback path.

## Evidence

- **Reproduction test** (`events.test.ts`): a finalized call (`agent-sales`, `answered`) receives a late `call.ended` (reason `completed`, direction `outbound`). Pre-fix: a phantom UUID record is birthed under `main` — test fails (`owner.callId` is a fresh UUID, not `call-real-agent`). Post-fix: the event folds into the existing record (`owner.callId === "call-real-agent"`, `agentId === "agent-sales"`, no duplicate in history).
- **Inbound sibling regression** (`events.test.ts`): a finalized **inbound** call receives a late `call.initiated`. Pre-fix: `answerCall` is invoked on the provider spy (`answerCalls.length === 1`) — test fails. Post-fix: no answer request (`answerCalls.length === 0`) and no phantom. This is the ClawSweeper P1 gap — the original test only covered outbound.
- **Plivo alias regression** (`store.test.ts` + `events.test.ts`, Part C): persisted snapshots under `request_uuid` (pre-terminal) and `CallUUID` (terminal) for one logical call. Pre-fix: `findCallByProviderCallIdInStore("request-uuid")` returns the stale `initiated` snapshot (`expected 'initiated' to be 'completed'`), and a late `call.initiated` carrying the alias re-runs and queues `answerCall` (`answerCalls.length` 1, expected 0). Post-fix: the alias resolves to the terminal snapshot (state `completed`, `providerCallId === "CallUUID"`), the late callback absorbs, no `answerCall`, no canonical-id downgrade.
- **`restore.test.ts`**: updated the "restores dedupe keys from terminal persisted calls" assertion — a replayed webhook on a terminal record now folds (`result.kind === "processed"`, 0 active calls) instead of birthing a phantom.
- Suite: `extensions/voice-call` **723/723 pass** (63 files, 0 failures).
- CS-listed commands:
  - `node scripts/run-vitest.mjs extensions/voice-call/src/manager/events.test.ts extensions/voice-call/src/manager/events.inbound.test.ts extensions/voice-call/src/manager/restore.test.ts` → green.
  - `node scripts/check-changed.mjs -- <touched files>` → all guards pass (format, plugin boundaries, dead export, coercion, etc.); the only failure is a **pre-existing** tsgo error in `packages/ai/src/providers/google-shared.ts:744` (stale `@google/genai`), an untouched file not part of this PR — deferred to CI.
- `oxfmt` clean, `oxlint` clean (direct `./node_modules/.bin/oxlint`; the `run-oxlint.mjs` wrapper times out locally — known issue).

### Production LOC

- `store.ts` +20/-4: `resolveNewestByProviderCallId` helper (shared by the sync webhook-path lookup and the async inspect lookup) replacing the two inline `findLast`-by-`providerCallId` scans that shared the same alias-resolution invariant.
- `events.ts` +9/-1 (this commit): the `!foldedTerminalRecord` guard on the `providerCallId` mutation, preventing a folded terminal echo from downgrading the canonical id to the stale alias.
- Prior Part A/B (`events.ts` +34/-9): fold branch + terminal-record absorb.
- Net prod (this PR) ≈ **+52** across two commits. Exceeds the bug-fix net-≤0 default for three distinct safety invariants at the same birth site: (1) phantom record = wrong-agent attribution + duplicate state, (2) dead-call side effects = spurious carrier answer/timer, and (3) Plivo alias = stale-snapshot side effects on a dead call + canonical-id downgrade. All three are producer-side realities a consumer guard can only mask, not prevent — the birth site must consult the store, fence terminal records, and resolve aliases to the newest snapshot.

## ClawSweeper Review Follow-up

- **[P1] Resolve the latest record after matching a Plivo provider alias** (`store.ts:417-419`) — **addressed** by Part C (`resolveNewestByProviderCallId` + the mutation guard), with store + events regression tests that fail pre-fix for the intended reason.
- **[P1] Resolve stored owners before rejecting inbound callbacks** (`events.ts:223-227`) — **deferred for maintainer judgment.** The recommended reorder (store consult before the inbound-rejection branch) is not a contained fix here: it breaks `retries rejected inbound hangup after a transient provider failure` (`manager.inbound-allowlist.test.ts:103`), which relies on a re-reject to retry the carrier hangup after a transient failure. Root cause: `persistRejectedInboundCall` writes a terminal `hangup-bot` record **before** the async `hangupCall` resolves, so a stored terminal record cannot distinguish "hangup succeeded → fold on a late callback" from "hangup failed → retry on the next callback." Moving the persist into the hangup success path (`.then`) would distinguish them, but it also breaks `does not publish rejected inbound calls before SQLite persistence succeeds` (`events.inbound.test.ts:45`), which encodes a persist-before-ack durability invariant. Satisfying all three (fold-after-restart, retry-on-failure, persist-before-ack) appears to require a persisted `hangupConfirmed` field updated on carrier confirmation — a record-shape/persistence-semantics change that needs maintainer discussion. Leaving this finding open for that decision rather than landing a fix that silently drops the retry path.
