### PR TITLE
fix(tui): preserve run and session ownership across async events

### DIFF
--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -77,7 +77,8 @@ vi.mock("../gateway/call.js", async () => ({
   isGatewayCredentialsRequiredError: gatewayMocks.isGatewayCredentialsRequiredError,
 }));
 
-vi.mock("../infra/fs-safe.js", () => ({
+vi.mock("../infra/fs-safe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/fs-safe.js")>()),
   movePathToTrash: fsSafeMocks.movePathToTrash,
 }));
 

--- a/src/commands/agents.delete.workspace.test.ts
+++ b/src/commands/agents.delete.workspace.test.ts
@@ -65,7 +65,8 @@ vi.mock("../gateway/call.js", async () => ({
   isGatewayCredentialsRequiredError: gatewayMocks.isGatewayCredentialsRequiredError,
 }));
 
-vi.mock("../infra/fs-safe.js", () => ({
+vi.mock("../infra/fs-safe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/fs-safe.js")>()),
   movePathToTrash: fsSafeMocks.movePathToTrash,
 }));
 

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -918,14 +918,12 @@ describe("openclaw.chat", () => {
     } finally {
       releaseApproval.resolve();
     }
-    await vi.waitFor(() => {
-      expect(resolveOperatorApproval).toHaveBeenCalledWith("allow-once", proposalHash);
-      expect(runGatewayRestart).toHaveBeenCalledOnce();
-      expect(systemAgentLane().activeCount).toBe(0);
-    });
+    expect(resolveOperatorApproval).toHaveBeenCalledWith("allow-once", proposalHash);
+    expect(runGatewayRestart).toHaveBeenCalledOnce();
     await expect(resolveOperatorApproval.mock.results[0]?.value).resolves.toMatchObject({
       text: expect.stringContaining("[openclaw] done: gateway.restart"),
     });
+    await vi.waitFor(() => expect(systemAgentLane().activeCount).toBe(0));
     expect(readLastSystemAgentAuditEntry()).toMatchObject({
       operation: "gateway.restart",
       summary: "Scheduled Gateway restart",

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -1401,6 +1401,42 @@ describe("tui command handlers", () => {
     expect(loadHistory).toHaveBeenCalledTimes(1);
   });
 
+  it.each(["error", "timeout", "ok"])(
+    "ignores a terminal %s ACK after its history reload switches sessions",
+    async (status) => {
+      const history = createDeferred();
+      const harness = createHarness({
+        currentAgentId: "research",
+        currentSessionKey: "agent:research:private",
+        currentSessionId: "private-session",
+        sendChat: vi.fn(async ({ runId }: { runId: string }) => ({ runId, status })),
+        loadHistory: vi.fn(() => history.promise) as LoadHistoryMock,
+      });
+      const pending = harness.handleCommand("private provider request");
+      await vi.waitFor(() => expect(harness.loadHistory).toHaveBeenCalledTimes(1));
+      harness.addSystem.mockClear();
+      harness.setActivityStatus.mockClear();
+      harness.requestRender.mockClear();
+      harness.state.currentAgentId = "ops";
+      harness.state.currentSessionKey = "agent:ops:public";
+      harness.state.currentSessionId = "public-session";
+      harness.state.activeChatRunId = "public-run";
+      harness.state.pendingSubmit = {
+        phase: "accepted",
+        runId: "public-run",
+        draftText: null,
+      };
+
+      history.resolve();
+      await pending;
+
+      expect(harness.addSystem).not.toHaveBeenCalled();
+      expect(harness.setActivityStatus).not.toHaveBeenCalled();
+      expect(harness.state.activeChatRunId).toBe("public-run");
+      expect(harness.state.pendingSubmit?.runId).toBe("public-run");
+    },
+  );
+
   it("removes the accepted canonical pending turn after a re-keyed terminal failure", async () => {
     const sendChat = vi.fn().mockResolvedValue({
       runId: "accepted-failed-run",
@@ -2211,6 +2247,86 @@ describe("tui command handlers", () => {
     expect(harness.clearTools).not.toHaveBeenCalled();
     expect(harness.addSystem).not.toHaveBeenCalled();
   });
+
+  it.each(["/model openai/gpt-5.6-luna", "/usage reset"])(
+    "does not apply a stale %s result after a nested patch handoff",
+    async (command) => {
+      const appliedAgents: string[] = [];
+      const displayedAgents: string[] = [];
+      const patchSession = vi.fn(() => {
+        queueMicrotask(() => {
+          queueMicrotask(() => {
+            harness.state.currentAgentId = "ops";
+            harness.state.currentSessionKey = "agent:ops:public";
+            harness.state.currentSessionId = "public-session";
+            harness.state.sessionGeneration += 1;
+            harness.state.sessionInfo = {
+              responseUsage: "tokens",
+              effectiveResponseUsage: "tokens",
+            };
+          });
+        });
+        return Promise.resolve({
+          ok: true as const,
+          path: "/sessions/patch",
+          key: "agent:research:private",
+          entry: { model: "private-sensitive-model" },
+        });
+      });
+      const harness = createHarness({
+        currentAgentId: "research",
+        currentSessionKey: "agent:research:private",
+        currentSessionId: "private-session",
+        sessionGeneration: 2,
+        sessionInfo: { responseUsage: "tokens", effectiveResponseUsage: "tokens" },
+        patchSession,
+        applySessionInfoFromPatch: vi.fn(() => appliedAgents.push(harness.state.currentAgentId)),
+      });
+      harness.addSystem.mockImplementation(() =>
+        displayedAgents.push(harness.state.currentAgentId),
+      );
+
+      await harness.handleCommand(command);
+
+      expect(harness.state.currentAgentId).toBe("ops");
+      expect(harness.state.sessionInfo.responseUsage).toBe("tokens");
+      expect(appliedAgents).toEqual(["research"]);
+      expect(displayedAgents).toEqual(["research"]);
+    },
+  );
+
+  it.each([
+    { command: "/model openai/gpt-5.6-luna", hook: "refresh" },
+    { command: "/think high", hook: "refresh" },
+    { command: "/verbose full", hook: "history" },
+    { command: "/usage reset", hook: "refresh" },
+  ])(
+    "hides a stale $command failure after its post-patch $hook rejects",
+    async ({ command, hook }) => {
+      const followup = createDeferred();
+      const harness = createHarness({
+        currentAgentId: "research",
+        currentSessionKey: "agent:research:private",
+        currentSessionId: "private-session",
+        ...(hook === "history"
+          ? { loadHistory: vi.fn(() => followup.promise) as LoadHistoryMock }
+          : { refreshSessionInfo: vi.fn(() => followup.promise) }),
+      });
+      const pending = harness.handleCommand(command);
+      const followupCall = hook === "history" ? harness.loadHistory : harness.refreshSessionInfo;
+      await vi.waitFor(() => expect(followupCall).toHaveBeenCalledTimes(1));
+      harness.addSystem.mockClear();
+      harness.state.currentAgentId = "ops";
+      harness.state.currentSessionKey = "agent:ops:public";
+      harness.state.currentSessionId = "public-session";
+
+      followup.reject(new Error("private provider account rejected research tenant"));
+      await pending;
+
+      expect(harness.addSystem).not.toHaveBeenCalled();
+      expect(harness.state.currentAgentId).toBe("ops");
+    },
+  );
 
   it.each(["/model openai/gpt-5.6-luna", "/usage reset"])(
     "ignores a stale global-agent %s result",

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -281,9 +281,12 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     };
   };
 
-  const patchCurrentSession = async (
+  const applySessionSetting = async (
     patch: Omit<Parameters<TuiBackend["patchSession"]>[0], "key" | "agentId">,
-  ): Promise<SessionsPatchResult | null> => {
+    success: string | ((result: SessionsPatchResult) => string),
+    failure: string,
+    after?: (result: SessionsPatchResult) => void | Promise<void>,
+  ) => {
     const { selection, isCurrent } = captureSessionIncarnation();
     try {
       const result = await client.patchSession({
@@ -291,24 +294,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         ...(!parseAgentSessionKey(selection.sessionKey) ? { agentId: selection.agentId } : {}),
         ...patch,
       });
-      return isCurrent() ? result : null;
-    } catch (err) {
       if (!isCurrent()) {
-        return null;
-      }
-      throw err;
-    }
-  };
-
-  const applySessionSetting = async (
-    patch: Omit<Parameters<TuiBackend["patchSession"]>[0], "key" | "agentId">,
-    success: string | ((result: SessionsPatchResult) => string),
-    failure: string,
-    after?: (result: SessionsPatchResult) => void | Promise<void>,
-  ) => {
-    try {
-      const result = await patchCurrentSession(patch);
-      if (!result) {
         return;
       }
       chatLog.addSystem(typeof success === "function" ? success(result) : success);
@@ -319,7 +305,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         await refreshSessionInfo();
       }
     } catch (err) {
-      chatLog.addSystem(`${failure}: ${formatTuiErrorMessage(err)}`);
+      if (isCurrent()) {
+        chatLog.addSystem(`${failure}: ${formatTuiErrorMessage(err)}`);
+      }
     }
   };
 
@@ -1034,6 +1022,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             state.activeChatRunId = null;
           }
           await loadHistory();
+          if (!isCurrentSendViewport()) {
+            return;
+          }
           if (terminalAckFailure) {
             chatLog.addSystem(`send failed: ${TERMINAL_CHAT_SEND_FAILURE_MESSAGE}`);
             setActivityStatus("error");

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -2723,6 +2723,73 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.addSystem).toHaveBeenCalledWith(`run error: ${backendError}`);
   });
 
+  it.each(["error", "final"] as const)(
+    "accepts an owned local %s event before its submit is acknowledged",
+    (terminalState) => {
+      const { state, chatLog, handleAgentEvent, handleChatEvent, noteLocalRunId } =
+        createHandlersHarness({
+          localMode: true,
+          state: { activeChatRunId: null, sessionInfo: { modelProvider: "xai" } },
+        });
+
+      handleAgentEvent({
+        runId: "completed-run",
+        sessionKey: state.currentSessionKey,
+        data: { phase: "start" },
+      });
+      handleChatEvent(makeFinalChatEvent(state, "completed-run"));
+      state.pendingSubmit = sendingSubmit("next-local-run");
+      noteLocalRunId("next-local-run");
+
+      handleChatEvent({
+        runId: "next-local-run",
+        state: terminalState,
+        ...(terminalState === "error"
+          ? { errorMessage: "monthly spending limit" }
+          : { message: { content: [{ type: "text", text: "early local reply" }] } }),
+      });
+
+      expect(state.pendingSubmit).toBeNull();
+      if (terminalState === "error") {
+        expect(chatLog.addSystem).toHaveBeenCalledWith("run error: monthly spending limit");
+      } else {
+        expect(chatLog.finalizeAssistant).toHaveBeenCalledWith(
+          "early local reply",
+          "next-local-run",
+        );
+      }
+    },
+  );
+
+  it.each([
+    { label: "unowned local", localMode: true, owned: false, sessionKey: "agent:main:main" },
+    { label: "remote", localMode: false, owned: true, sessionKey: "agent:main:main" },
+    { label: "foreign session", localMode: true, owned: true, sessionKey: "agent:main:other" },
+  ])("rejects an unsequenced $label provisional event", ({ localMode, owned, sessionKey }) => {
+    const { state, chatLog, handleAgentEvent, handleChatEvent, noteLocalRunId } =
+      createHandlersHarness({ localMode, state: { activeChatRunId: null } });
+    handleAgentEvent({
+      runId: "completed-run",
+      sessionKey: state.currentSessionKey,
+      data: { phase: "start" },
+    });
+    handleChatEvent(makeFinalChatEvent(state, "completed-run"));
+    state.pendingSubmit = sendingSubmit("untrusted-run");
+    if (owned) {
+      noteLocalRunId("untrusted-run");
+    }
+
+    handleChatEvent({
+      runId: "untrusted-run",
+      sessionKey,
+      state: "error",
+      errorMessage: "foreign private diagnostic",
+    });
+
+    expect(state.pendingSubmit).toEqual(sendingSubmit("untrusted-run"));
+    expect(chatLog.addSystem).not.toHaveBeenCalledWith("run error: foreign private diagnostic");
+  });
+
   it("surfaces a late provider error without replaying a completed assistant reply", () => {
     const { state, chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-source-reply" },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -180,9 +180,12 @@ export function createEventHandlers(context: EventHandlerContext) {
       return;
     }
     const isSequencedGatewayEvent = Number.isSafeInteger(evt.seq) && (evt.seq ?? -1) >= 0;
+    const isOwnedLocalPendingRun =
+      localMode && state.pendingSubmit?.runId === evt.runId && isLocalRunId?.(evt.runId) === true;
     if (
       runCoordinator.isRetiredOrphanRun(evt.runId) &&
       !isSequencedGatewayEvent &&
+      !isOwnedLocalPendingRun &&
       evt.runId !== getPendingSubmitAcceptedRunId(state)
     ) {
       return;
@@ -247,10 +250,10 @@ export function createEventHandlers(context: EventHandlerContext) {
         }
       }
     }
-    // Gateway chat envelopes require a non-negative sequence, even when a
-    // legacy peer omits agent lifecycle starts; orphan deltas have none.
+    // Gateway events are sequenced; early embedded events are trustworthy only
+    // when their exact provisional run belongs to the selected local viewport.
     acknowledgeChatRun(evt.runId, {
-      protectStream: isSequencedGatewayEvent,
+      protectStream: isSequencedGatewayEvent || isOwnedLocalPendingRun,
     });
     const isPendingChatRun = getPendingSubmitAcceptedRunId(state) === evt.runId;
     const isLocalChatRun = isLocalRunId?.(evt.runId) ?? false;


### PR DESCRIPTION
## What Problem This Solves

The TUI could silently discard an embedded provider failure or final response that arrived before its submit acknowledgement after a previous run had completed. That left the editor stuck in `sending` and hid actionable provider diagnostics such as xAI account spending limits.

Two related asynchronous ownership gaps also allowed an old session to affect a newly selected session: an unnecessary nested session-patch await could apply private model/settings metadata after an agent switch, and a terminal send acknowledgement could overwrite the new session's status or display the previous session's error after history finished loading.

## Why This Change Was Made

An embedded backend legitimately emits chat events without the Gateway's per-run payload sequence. The TUI orphan-event fence only recognized acknowledged submissions, overlooking its already-authoritative ownership of the exact provisional local run. Recognize that run only when local mode, pending phase, exact run ID, local ownership, and existing session/agent checks all agree, then preserve that ownership through stream registration.

Move session patching into its single actual owner so one captured session incarnation covers the RPC, immediate setting application, post-patch refresh, and error handling. Revalidate that same incarnation after terminal-ack history loading. This continues the ownership work from #129681 and #129810 while removing the nested helper that created the cross-agent microtask race.

The first hosted run also exposed two existing shard-sensitive CI failures unrelated to the TUI: agent-deletion tests replaced the whole filesystem-safety module while mocking only trash movement, and a Gateway restart test polled lane drainage before the actual delegated approval promise had settled. Preserve the original filesystem exports in both test mocks, and await authoritative approval completion before checking that its lane drains. Both are test-only fixes for the exact failed shards; production behavior is unchanged.

## User Impact

- Embedded provider failures and early final responses remain visible, and the prompt becomes usable again instead of getting stuck in `sending`.
- Switching agents or sessions cannot leak another session's private provider/model diagnostic, apply its model/settings metadata, or overwrite the new session's activity state after asynchronous work resumes.
- Remote unsequenced events, unowned local events, and events from another session remain rejected.
- Production LOC: +17/-23 (net -6); tests: +190/-7.

## Evidence

Red-first owner regressions reproduced all three failure families before the repair: unacknowledged embedded errors/finals remained invisible with a stuck pending submit; terminal `error`, `timeout`, and `ok` acknowledgements mutated a replacement session after history awaited; nested settings patches and delayed refresh failures leaked across agents. Existing xAI real-terminal coverage also failed on unmodified current `main`.

After the fix:

```
node scripts/run-vitest.mjs src/tui/tui-command-handlers.test.ts src/tui/tui-event-handlers.test.ts
# 2 files passed; 404 tests passed

node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts
# 4 files passed; 76 real PTY tests passed
# Includes: preserves xAI account limit errors in terminal output
# Includes: ignores delayed aborts and streamed events from the previously selected session

node scripts/run-vitest.mjs src/commands/agents.delete.test.ts src/commands/agents.delete.workspace.test.ts
# 2 files passed; 27 tests passed

node scripts/run-vitest.mjs src/gateway/server-methods/system-agent.test.ts
# 1 file passed; 26 tests passed

env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs
# full changed-file gate passed

.agents/skills/autoreview/scripts/autoreview --mode uncommitted
# clean; no accepted/actionable findings
```

Direct production-module replay changed from `{"phase":"sending","visible":false,"pending":"sending"}` to `{"phase":"sending","visible":true,"message":"run error: monthly spending limit","pending":null}`. Negative owner regressions separately prove unrelated local runs, remote unsequenced events, and foreign-session events stay fenced.

The affected interface is a terminal, so the running-surface proof is the authenticated real PTY suite and its rendered spending-limit assertion rather than a graphical screenshot.
