### PR TITLE
fix(workers): remote sessions preserve destination and access policy

### DIFF
--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -773,6 +773,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             allowHostBrowserControl: sandbox ? sandbox.browserAllowHostControl : true,
             agentSessionKey: options?.sessionKey,
             runId: options?.runId,
+            sessionPermissionPolicy,
             execSession: sessionPermissionPolicy
               ? { permissionMode: sessionPermissionPolicy.mode }
               : undefined,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -544,6 +544,7 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
             requesterRunId: options?.runId,
             swarmCollector: options?.swarmCollector,
             workspaceDir: spawnWorkspaceDir,
+            sessionPermissionPolicy: options?.sessionPermissionPolicy,
             inheritedToolAllowlist: options?.inheritedToolAllowlist,
             inheritedToolDenylist: options?.inheritedToolDenylist,
           }),

--- a/src/agents/spawned-context.ts
+++ b/src/agents/spawned-context.ts
@@ -7,6 +7,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveAgentWorkspaceDir } from "./agent-scope.js";
+import type { PreparedSessionPermissionPolicy } from "./tool-fs-policy.types.js";
 
 export type SpawnedRunMetadata = {
   spawnedBy?: string | null;
@@ -22,6 +23,7 @@ export type SpawnedToolContext = {
   agentGroupSpace?: string | null;
   agentMemberRoleIds?: string[];
   workspaceDir?: string;
+  sessionPermissionPolicy?: PreparedSessionPermissionPolicy;
   inheritedToolAllowlist?: string[];
   inheritedToolDenylist?: string[];
 };

--- a/src/agents/subagents/spawn/subagent-spawn-contract.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-contract.ts
@@ -1,4 +1,5 @@
 import type { FastMode } from "../../../shared/fast-mode.js";
+import type { SpawnedToolContext } from "../../spawned-context.js";
 import type {
   SpawnSubagentContextMode,
   SpawnSubagentMode,
@@ -38,7 +39,7 @@ export type SpawnSubagentParams = {
   attachMountPath?: string;
 };
 
-export type SpawnSubagentContext = {
+export type SpawnSubagentContext = SpawnedToolContext & {
   agentSessionKey?: string;
   requesterTurnRunId?: string;
   /** Separate key used only for completion routing, not sandbox policy. */
@@ -50,15 +51,7 @@ export type SpawnSubagentContext = {
   currentMessagingTarget?: string;
   currentChannelId?: string;
   currentMessageId?: string | number;
-  agentGroupId?: string | null;
-  agentGroupChannel?: string | null;
-  agentGroupSpace?: string | null;
-  agentMemberRoleIds?: string[];
   requesterAgentIdOverride?: string;
-  /** Explicit workspace directory for subagent to inherit (optional). */
-  workspaceDir?: string;
-  inheritedToolAllowlist?: string[];
-  inheritedToolDenylist?: string[];
   requesterRunId?: string;
 };
 

--- a/src/agents/subagents/spawn/subagent-spawn-session-patch.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-session-patch.ts
@@ -4,12 +4,14 @@ import { buildSessionCreationStamp } from "../../../config/sessions/session-entr
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolveIncognitoOpenClawAgentSqlitePath } from "../../../state/openclaw-agent-db.js";
+import { resolveUserPath } from "../../../utils.js";
 import {
   inheritedToolAllowPatch,
   inheritedToolDenyPatch,
   normalizeInheritedToolAllowlist,
   normalizeInheritedToolDenylist,
 } from "../../inherited-tool-deny.js";
+import type { PreparedSessionPermissionPolicy } from "../../tool-fs-policy.types.js";
 import { getSubagentSpawnDeps } from "./subagent-spawn-deps.js";
 import { splitModelRef } from "./subagent-spawn-plan.js";
 import {
@@ -114,6 +116,7 @@ export async function createInitialSubagentSession(params: {
   completionOwnerSessionKey: string;
   spawnedWorkspaceDir?: string;
   spawnedCwd?: string;
+  sessionPermissionPolicy?: PreparedSessionPermissionPolicy;
   admissionPatch?: Record<string, unknown>;
   inheritedToolAllowlist?: string[];
   inheritedToolDenylist?: string[];
@@ -165,6 +168,14 @@ export async function createInitialSubagentSession(params: {
       },
       {
         ...buildDirectChildSessionPatch(initialChildSessionPatch),
+        ...(params.sessionPermissionPolicy
+          ? {
+              permissionMode: params.sessionPermissionPolicy.mode,
+              sessionRoot: resolveUserPath(
+                params.spawnedWorkspaceDir ?? params.sessionPermissionPolicy.root,
+              ),
+            }
+          : {}),
         ...childSessionIdentity,
         ...buildSessionCreationStamp({
           via: "spawn",

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -1316,6 +1316,12 @@ describe("spawnSubagentDirect seam flow", () => {
   });
 
   it("registers the target agent id for cross-agent task attribution", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
     hoisted.configOverride = createConfigOverride({
       session: {
         scope: "global",
@@ -1348,11 +1354,16 @@ describe("spawnSubagentDirect seam flow", () => {
       {
         agentSessionKey: "global",
         requesterAgentIdOverride: "main",
+        sessionPermissionPolicy: { mode: "guarded", root: "/tmp/workspace-main" },
       },
     );
 
     expect(result.status).toBe("accepted");
     expect(result.childSessionKey).toMatch(/^agent:worker:subagent:/);
+    expect(persistedStore?.[result.childSessionKey as string]).toMatchObject({
+      permissionMode: "guarded",
+      sessionRoot: resolveUserPath("/tmp/workspace-worker"),
+    });
     const registerInput = firstRegisteredSubagentRun();
     expect(registerInput.childSessionKey).toBe(result.childSessionKey);
     expect(registerInput.agentId).toBe("worker");
@@ -1563,6 +1574,43 @@ describe("spawnSubagentDirect seam flow", () => {
       }),
     );
   });
+
+  it.each([
+    { label: "default", mode: undefined },
+    { label: "read-only", mode: "read-only" },
+    { label: "guarded", mode: "guarded" },
+    { label: "workspace", mode: "workspace" },
+    { label: "full", mode: "full" },
+  ] as const)(
+    "inherits the parent's $label permission mode in a hidden child",
+    async ({ mode }) => {
+      const sessionRoot = resolveUserPath("/tmp/workspace-main");
+      let persistedStore: Record<string, Record<string, unknown>> | undefined;
+      installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+        onStore: (store) => {
+          persistedStore = store;
+        },
+      });
+
+      const result = await spawnSubagentDirect(
+        { task: "inherit the parent permission policy" },
+        {
+          agentSessionKey: "agent:main:main",
+          workspaceDir: sessionRoot,
+          ...(mode ? { sessionPermissionPolicy: { mode, root: sessionRoot } } : {}),
+        },
+      );
+
+      expect(result.status).toBe("accepted");
+      const childEntry = persistedStore?.[result.childSessionKey as string];
+      if (mode) {
+        expect(childEntry).toMatchObject({ permissionMode: mode, sessionRoot });
+      } else {
+        expect(childEntry).not.toHaveProperty("permissionMode");
+        expect(childEntry).not.toHaveProperty("sessionRoot");
+      }
+    },
+  );
 
   it.each(inheritedSpawnPreferenceCases)(
     "$name",

--- a/src/agents/subagents/spawn/subagent-spawn.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.ts
@@ -188,6 +188,7 @@ export async function spawnSubagentDirect(
       completionOwnerSessionKey: ownership.completionRequesterSessionKey,
       spawnedWorkspaceDir,
       spawnedCwd,
+      sessionPermissionPolicy: ctx.sessionPermissionPolicy,
       admissionPatch: admission.childSessionPatch,
       inheritedToolAllowlist: ctx.inheritedToolAllowlist,
       inheritedToolDenylist: ctx.inheritedToolDenylist,

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -586,6 +586,42 @@ describe("sessions_spawn tool", () => {
     });
   });
 
+  it.each([
+    { label: "default", mode: undefined },
+    { label: "read-only", mode: "read-only" },
+    { label: "guarded", mode: "guarded" },
+    { label: "workspace", mode: "workspace" },
+    { label: "full", mode: "full" },
+  ] as const)(
+    "inherits the parent's $label permission mode in a visible child",
+    async ({ mode }) => {
+      const callGateway = vi.fn(async () => ({
+        key: "agent:main:dashboard:child",
+        runStarted: true,
+        runId: "run-visible",
+      }));
+      const tool = createSessionsSpawnTool({
+        agentSessionKey: "agent:main:main",
+        ...(mode ? { sessionPermissionPolicy: { mode, root: "/workspace/main" } } : {}),
+        config: { agents: { list: [{ id: "main" }] } },
+        callGateway: callGateway as never,
+        registerRun: vi.fn(),
+        countActiveRuns: () => 0,
+      });
+
+      await tool.execute("visible-permissions", { task: "inspect", visible: true, worktree: true });
+
+      const createParams = mockCallArg(callGateway, 0, 1, "sessions.create");
+      expect(createParams.worktree).toBe(true);
+      expect(createParams).not.toHaveProperty("sessionRoot");
+      if (mode) {
+        expect(createParams.permissionMode).toBe(mode);
+      } else {
+        expect(createParams).not.toHaveProperty("permissionMode");
+      }
+    },
+  );
+
   it.each([{ category: undefined }, { category: "" }])(
     "keeps a visible session ungrouped when category is $category",
     async ({ category }) => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -610,6 +610,7 @@ export function createSessionsSpawnTool(
             agentMemberRoleIds: opts?.agentMemberRoleIds,
             requesterAgentIdOverride: opts?.requesterAgentIdOverride,
             workspaceDir: opts?.workspaceDir,
+            sessionPermissionPolicy: opts?.sessionPermissionPolicy,
             inheritedToolAllowlist: opts?.inheritedToolAllowlist,
             inheritedToolDenylist: opts?.inheritedToolDenylist,
             requesterRunId: opts?.requesterRunId,

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -21,7 +21,7 @@ import { reserveChildAdmissionSlot } from "../child-admission.js";
 import { resolveAgentIdentity } from "../identity.js";
 import { resolveSubagentSpawnModelSelection } from "../model-selection.js";
 import { resolveSandboxRuntimeStatus } from "../sandbox/runtime-status.js";
-import { resolveSpawnedWorkspaceInheritance } from "../spawned-context.js";
+import { resolveSpawnedWorkspaceInheritance, type SpawnedToolContext } from "../spawned-context.js";
 import {
   countActiveRunsForSession,
   registerSubagentRun,
@@ -61,23 +61,22 @@ export type VisibleSessionsSpawnDeps = {
   countActiveRuns?: typeof countActiveRunsForSession;
 };
 
-type VisibleSessionsSpawnOptions = VisibleSessionsSpawnDeps & {
-  agentSessionKey?: string;
-  requesterTurnRunId?: string;
-  completionOwnerKey?: string;
-  agentChannel?: string;
-  agentAccountId?: string;
-  agentTo?: string;
-  agentThreadId?: string | number;
-  currentMessagingTarget?: string;
-  currentChannelId?: string;
-  currentThreadTs?: string;
-  sandboxed?: boolean;
-  config?: OpenClawConfig;
-  requesterAgentIdOverride?: string;
-  inheritedToolAllowlist?: string[];
-  inheritedToolDenylist?: string[];
-};
+type VisibleSessionsSpawnOptions = VisibleSessionsSpawnDeps &
+  SpawnedToolContext & {
+    agentSessionKey?: string;
+    requesterTurnRunId?: string;
+    completionOwnerKey?: string;
+    agentChannel?: string;
+    agentAccountId?: string;
+    agentTo?: string;
+    agentThreadId?: string | number;
+    currentMessagingTarget?: string;
+    currentChannelId?: string;
+    currentThreadTs?: string;
+    sandboxed?: boolean;
+    config?: OpenClawConfig;
+    requesterAgentIdOverride?: string;
+  };
 
 function summarizeSessionsSpawnError(error: unknown): string {
   return error instanceof Error ? error.message : typeof error === "string" ? error : "error";
@@ -329,6 +328,9 @@ export async function maybeSpawnVisibleSession(params: {
         // Declared spawn lineage: without it the child persists as a depth-0 root
         // and could spawn past maxSpawnDepth.
         spawnDepth: callerDepth + 1,
+        ...(params.options?.sessionPermissionPolicy
+          ? { permissionMode: params.options.sessionPermissionPolicy.mode }
+          : {}),
         ...(params.raw.context === "fork" ? { fork: true } : {}),
         ...(spawnedCwd ? { cwd: spawnedCwd } : {}),
         ...(worktree ? { worktree: true } : {}),

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -77,7 +77,8 @@ vi.mock("../gateway/call.js", async () => ({
   isGatewayCredentialsRequiredError: gatewayMocks.isGatewayCredentialsRequiredError,
 }));
 
-vi.mock("../infra/fs-safe.js", () => ({
+vi.mock("../infra/fs-safe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/fs-safe.js")>()),
   movePathToTrash: fsSafeMocks.movePathToTrash,
 }));
 

--- a/src/commands/agents.delete.workspace.test.ts
+++ b/src/commands/agents.delete.workspace.test.ts
@@ -65,7 +65,8 @@ vi.mock("../gateway/call.js", async () => ({
   isGatewayCredentialsRequiredError: gatewayMocks.isGatewayCredentialsRequiredError,
 }));
 
-vi.mock("../infra/fs-safe.js", () => ({
+vi.mock("../infra/fs-safe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/fs-safe.js")>()),
   movePathToTrash: fsSafeMocks.movePathToTrash,
 }));
 

--- a/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, Server } from "node:http";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { NODE_WORKER_WORKSPACE_EXEC_COMMAND } from "../../infra/node-commands.js";
 import { invokeNodeWorkerSupervisorCommand } from "../../node-host/node-worker-supervisor-commands.js";
@@ -475,6 +476,77 @@ describe("node workspace transfer service", () => {
     await expect(fs.readdir(temporaryRoot)).resolves.toEqual([]);
     await service.closeAll();
     await expect(fs.stat(temporaryRoot)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("drains sibling transfer contexts and removes scratch after a cleanup failure", async () => {
+    const root = tempDirs.make("node-workspace-transfer-close-siblings-");
+    const localPath = path.join(root, "workspace");
+    const temporaryRoot = path.join(root, "transfer-tmp");
+    await fs.mkdir(localPath);
+    const service = createNodeWorkspaceTransferService({
+      getOwner: (environmentId) => ({
+        credential: {
+          ownerEpoch: 1,
+          expiresAtMs: Date.now() + 60_000,
+          sessionId: `session-${environmentId}`,
+        },
+        environment: {
+          ownerEpoch: 1,
+          attachedSessionIds: [`session-${environmentId}`],
+          destroyRequestedAtMs: null,
+          state: "attached",
+        },
+      }),
+      temporaryRoot,
+    });
+    for (const environmentId of ["environment-1", "environment-2"]) {
+      await service.prepareSync({
+        environmentId,
+        ownerEpoch: 1,
+        sessionId: `session-${environmentId}`,
+        generation: 1,
+        localPath,
+        isAuthorized: () => true,
+      });
+    }
+
+    const cleanupError = new Error("first transfer context cleanup failed");
+    const siblingCleanup = createDeferred();
+    const originalRemove = fs.rm.bind(fs);
+    let contextRemovals = 0;
+    const remove = vi.spyOn(fs, "rm").mockImplementation(async (...args) => {
+      const target = args[0];
+      if (typeof target === "string" && path.dirname(target) === temporaryRoot) {
+        contextRemovals += 1;
+        if (contextRemovals === 1) {
+          throw cleanupError;
+        }
+        await siblingCleanup.promise;
+      }
+      await originalRemove(...args);
+    });
+    const stopping = service.closeAll();
+    const settled = vi.fn();
+    void stopping.then(settled, settled);
+
+    try {
+      await vi.waitFor(() => expect(contextRemovals).toBe(2));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(settled).not.toHaveBeenCalled();
+      expect(remove).not.toHaveBeenCalledWith(temporaryRoot, expect.anything());
+
+      siblingCleanup.resolve();
+      await expect(stopping).rejects.toBe(cleanupError);
+      expect(remove).toHaveBeenCalledWith(temporaryRoot, { recursive: true, force: true });
+      await expect(fs.stat(temporaryRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      siblingCleanup.resolve();
+      await stopping.catch(() => undefined);
+      remove.mockRestore();
+      await fs.rm(temporaryRoot, { recursive: true, force: true });
+    }
   });
 
   it("serializes transfer context replacement for one environment", async () => {

--- a/src/gateway/worker-environments/node-workspace-transfer-service.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.ts
@@ -719,8 +719,17 @@ export function createNodeWorkspaceTransferService(options: {
 
     async closeAll(): Promise<void> {
       await temporaryRootReady;
-      await Promise.all([...contexts.keys()].map(closeEnvironment));
-      await fsp.rm(temporaryBaseRoot, { recursive: true, force: true });
+      const closed = await Promise.allSettled([...contexts.keys()].map(closeEnvironment));
+      // Shared scratch outlives every transfer context, including failed sibling cleanup.
+      closed.push(
+        ...(await Promise.allSettled([
+          fsp.rm(temporaryBaseRoot, { recursive: true, force: true }),
+        ])),
+      );
+      const failure = closed.find((result) => result.status === "rejected");
+      if (failure) {
+        throw failure.reason;
+      }
     },
   };
 }

--- a/src/node-host/node-worker-supervisor-ownership.ts
+++ b/src/node-host/node-worker-supervisor-ownership.ts
@@ -38,7 +38,6 @@ export type NodeWorkerRunningChild = NodeWorkerActiveBase & {
 export type NodeWorkerObservedTerminal = NodeWorkerActiveBase & {
   state: "observed";
   outcome: NodeWorkerTerminalOutcome;
-  persistenceError?: unknown;
 };
 
 export type NodeWorkerActiveOwnership = NodeWorkerRunningChild | NodeWorkerObservedTerminal;

--- a/src/node-host/node-worker-supervisor.container.test.ts
+++ b/src/node-host/node-worker-supervisor.container.test.ts
@@ -617,6 +617,47 @@ describe("node worker supervisor container isolation", () => {
     }
   });
 
+  it("cancels a claimed container launch when its invocation aborts during creation", async () => {
+    const capacitySnapshots: Array<{ total: number; available: number }> = [];
+    const fixture = containerFixture({
+      capacity: 1,
+      onCapacityChanged: (capacity) => capacitySnapshots.push(capacity),
+    });
+    const input = testWorkerLaunchInput(fixture.workspaceDir, "container-creation-abort", "wait");
+    const createMarker = path.join(fixture.engineRoot, "hold-create");
+    const store = new NodeWorkerLaunchStore({ env: fixture.env });
+    const controller = new AbortController();
+    fs.writeFileSync(createMarker, "hold");
+
+    try {
+      const launch = fixture.supervisor.launch(input, endpoint, controller.signal);
+      await vi.waitFor(
+        () => expect(fixture.events().some((event) => event.argv[0] === "create")).toBe(true),
+        { timeout: 5_000 },
+      );
+      const container = fixture.events().find((event) => event.argv[0] === "create")?.container;
+      if (!container) {
+        throw new Error("expected a claimed container under creation");
+      }
+      expect(store.get(input.launchId)?.state).toBe("pending");
+      expect(capacitySnapshots.at(-1)).toEqual({ total: 1, available: 0 });
+
+      controller.abort(new Error("invoke cancelled"));
+      fs.unlinkSync(createMarker);
+      await launch.catch(() => undefined);
+
+      expect(store.get(input.launchId)).toMatchObject({ state: "cancelled" });
+      expect(fixture.exists(container.id)).toBe(false);
+      expect(fs.existsSync(path.join(fixture.workspaceDir, "worker-started"))).toBe(false);
+      expect(capacitySnapshots.at(-1)).toEqual({ total: 1, available: 1 });
+    } finally {
+      if (fs.existsSync(createMarker)) {
+        fs.unlinkSync(createMarker);
+      }
+      await fixture.supervisor.close();
+    }
+  });
+
   it.each([
     ["cancel", "cancelled"],
     ["close", "interrupted"],

--- a/src/node-host/node-worker-supervisor.ts
+++ b/src/node-host/node-worker-supervisor.ts
@@ -191,11 +191,22 @@ class NodeWorkerSupervisor {
       const startup = this.starting.get(input.launchId);
       return startup && claim.receipt.state === "pending" ? await startup : claim.receipt;
     }
-    const startup = this.startClaimed({ input, descriptor, planHash, supervisor });
+    let cancellation: Promise<NodeWorkerLaunchReceipt | undefined> | undefined;
+    const cancelClaimed = () => {
+      cancellation ??= this.cancel(claimInput);
+      void cancellation.catch(() => undefined);
+    };
+    signal?.addEventListener("abort", cancelClaimed, { once: true });
+    const startup = this.startClaimed({ input, descriptor, planHash, supervisor, signal });
     this.starting.set(input.launchId, startup);
+    if (signal?.aborted) {
+      cancelClaimed();
+    }
     try {
-      return await startup;
+      const receipt = await startup;
+      return cancellation ? ((await cancellation) ?? receipt) : receipt;
     } finally {
+      signal?.removeEventListener("abort", cancelClaimed);
       if (this.starting.get(input.launchId) === startup) {
         this.starting.delete(input.launchId);
       }
@@ -279,10 +290,7 @@ class NodeWorkerSupervisor {
   ): Promise<NodeWorkerLaunchReceipt | undefined> {
     await this.initialize();
     const receipt = this.store.getMatching(expected);
-    if (!receipt || receipt.state === "completed" || receipt.state === "failed") {
-      return receipt;
-    }
-    if (receipt.state === "interrupted" || receipt.state === "cancelled") {
+    if (!receipt || (receipt.state !== "pending" && receipt.state !== "running")) {
       return receipt;
     }
     const active = this.active.get(expected.launchId);
@@ -404,13 +412,7 @@ class NodeWorkerSupervisor {
     this.capacity.close();
     const operation = (async () => {
       const errors: unknown[] = [];
-      if (this.initializationPromise) {
-        try {
-          await this.initializationPromise;
-        } catch (error) {
-          errors.push(error);
-        }
-      }
+      await this.initializationPromise?.catch((error: unknown) => errors.push(error));
       await Promise.allSettled(this.starting.values());
       const stopped = await Promise.allSettled(
         [...this.active.values()]
@@ -444,25 +446,20 @@ class NodeWorkerSupervisor {
   }
 
   private reconcileActiveTerminal(active: NodeWorkerObservedTerminal): NodeWorkerLaunchReceipt {
-    try {
-      const receipt = this.capacity.finish({
-        launchId: active.launchId,
-        planHash: active.planHash,
-        supervisor: active.supervisor,
-        worker: active.worker,
-        ...active.outcome,
-      });
-      if (receipt.state === "pending" || receipt.state === "running") {
-        throw new Error(`node worker launch ${active.launchId} terminal state was not persisted`);
-      }
-      if (this.active.get(active.launchId) === active) {
-        this.active.delete(active.launchId);
-      }
-      return receipt;
-    } catch (error) {
-      active.persistenceError = error;
-      throw error;
+    const receipt = this.capacity.finish({
+      launchId: active.launchId,
+      planHash: active.planHash,
+      supervisor: active.supervisor,
+      worker: active.worker,
+      ...active.outcome,
+    });
+    if (receipt.state === "pending" || receipt.state === "running") {
+      throw new Error(`node worker launch ${active.launchId} terminal state was not persisted`);
     }
+    if (this.active.get(active.launchId) === active) {
+      this.active.delete(active.launchId);
+    }
+    return receipt;
   }
 
   private async recoverRunning(
@@ -483,6 +480,7 @@ class NodeWorkerSupervisor {
     descriptor: WorkerLaunchDescriptor;
     planHash: string;
     supervisor: NodeWorkerProcessIdentity;
+    signal?: AbortSignal;
   }): Promise<NodeWorkerLaunchReceipt> {
     const credential = params.descriptor.admission.credential;
     const endpoint = params.descriptor.connectionEndpoint;
@@ -628,8 +626,8 @@ class NodeWorkerSupervisor {
       }
       return running;
     }
-    if (this.closed) {
-      await this.stopChild(active, "interrupted");
+    if (this.closed || params.signal?.aborted) {
+      await this.stopChild(active, this.closed ? "interrupted" : "cancelled");
       return this.store.get(active.launchId) ?? running;
     }
     try {

--- a/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
@@ -103,6 +103,107 @@ suite.define(() => {
 
   it.each([
     {
+      name: "paired device",
+      preference: { kind: "device", id: "paired-runner" },
+      attribute: "data-device-id",
+      value: "paired-runner",
+      target: { deviceId: "paired-runner" },
+    },
+    {
+      name: "automatic device",
+      preference: { kind: "auto-device" },
+      attribute: "data-auto-device",
+      value: "true",
+      target: { autoDevice: true },
+    },
+    {
+      name: "cloud worker",
+      preference: { kind: "cloud", id: "aws" },
+      attribute: "data-cloud-profile",
+      value: "aws",
+      target: { profileId: "aws" },
+    },
+  ])(
+    "does not start locally while a remembered $name destination is being restored",
+    async ({ preference, attribute, value, target }) => {
+      const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+      const page = await context.newPage();
+      const appUrl = new URL(suite.server.baseUrl);
+      const gatewayUrl = `${appUrl.protocol === "https:" ? "wss:" : "ws:"}//${appUrl.host}`;
+      const storageKey = `openclaw.new-session.preferences.v1:${gatewayOriginScope(gatewayUrl)}`;
+      const sessionKey = "agent:main:restored-remote-destination";
+      const catalog = {
+        environments: [
+          {
+            id: "node:paired-runner",
+            type: "node",
+            label: "Paired runner",
+            status: "available",
+            sessionHost: true,
+            workerSlots: { total: 2, available: 1 },
+          },
+        ],
+        profiles: [{ id: "aws", providerId: "crabbox" }],
+      };
+      await page.addInitScript(
+        ({ key, workspace, where }) => {
+          localStorage.setItem(
+            key,
+            JSON.stringify({
+              agents: { main: { workspace, folder: workspace, where, worktree: true } },
+            }),
+          );
+        },
+        { key: storageKey, workspace: WORKSPACE, where: preference },
+      );
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["environments.list"],
+        operatorScopes: ["operator.read", "operator.write", "operator.admin"],
+        workspace: WORKSPACE,
+        workspaceGit: true,
+        methodResponses: {
+          "worktrees.branches": {
+            branches: [{ kind: "local", name: "main" }],
+            defaultBranch: "main",
+            repositoryStatus: "git",
+          },
+          "sessions.create": { key: sessionKey },
+          "sessions.list": createdSessionListResult(sessionKey),
+          "sessions.dispatch": { placement: { state: "active", generation: 1 } },
+          "sessions.send": { runId: "run-restored-remote", status: "started" },
+        },
+      });
+
+      try {
+        await page.goto(`${suite.server.baseUrl}new`);
+        await gateway.waitForRequest("environments.list");
+        await expect
+          .poll(() => page.locator("#new-session-detail-trigger").getAttribute("data-worktree"))
+          .toBe("true");
+        await page.locator(".new-session-page__message").fill("keep my chosen remote destination");
+        const start = page.getByRole("button", { name: "Start session" });
+        await expect.poll(() => start.isDisabled()).toBe(true);
+        await expect
+          .poll(() => start.locator("xpath=..").getAttribute("content"))
+          .toContain("Restoring your last session setup");
+        expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
+
+        await gateway.resolveDeferred("environments.list", catalog);
+        const where = page.locator("#new-session-where-trigger");
+        await expect.poll(() => where.getAttribute(attribute)).toBe(value);
+        await expect.poll(() => start.isEnabled()).toBe(true);
+        await start.click();
+        await expect(gateway.waitForRequest("sessions.dispatch")).resolves.toMatchObject({
+          params: { key: sessionKey, agentId: "main", ...target },
+        });
+      } finally {
+        await context.close();
+      }
+    },
+  );
+
+  it.each([
+    {
       name: "offline paired device",
       preference: { kind: "device", id: "paired-runner" },
       status: "unavailable",

--- a/ui/src/pages/new-session/draft-place-state.ts
+++ b/ui/src/pages/new-session/draft-place-state.ts
@@ -137,8 +137,8 @@ export class DraftPlaceState {
     return this.agentsHydratedValue;
   }
 
-  get worktreePreferenceReady(): boolean {
-    return this.repositoryState.preferenceReady;
+  get placementPreferenceReady(): boolean {
+    return this.repositoryState.preferenceReady && this.preferredWhereRestore === null;
   }
 
   canAdoptGroupDefaults(): boolean {

--- a/ui/src/pages/new-session/submit-gates.ts
+++ b/ui/src/pages/new-session/submit-gates.ts
@@ -98,7 +98,7 @@ export function resolveNewSessionSubmitBlock(
   if (
     gateway.preferenceLoading ||
     place.modelControl.isRestoringPreference() ||
-    !place.worktreePreferenceReady
+    !place.placementPreferenceReady
   ) {
     return { gate: "preference-restore", reason: t("newSession.restoringPreferences") };
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a session against a remembered paired node, automatic remote node, or cloud worker could briefly run it locally before their saved destination finished restoring. Fixes an issue where visible and hidden spawned agents silently discarded their parent's read-only, guarded, workspace, or Full Access policy, causing either unauthorized escalation or unexpected approval alerts. Resolves paired-node Docker workers surviving cancellation after claiming capacity, plus incomplete workspace-transfer cleanup when one sibling fails.

## Why This Change Was Made

Placement restoration, delegated session authority, node-supervisor cancellation, and workspace-transfer lifetime each have their own canonical owner. This repair carries the already-prepared trusted parent permission policy through both spawn paths, lets each child own its correct workspace root, fences new-session submission until the actual saved remote destination is restored, binds post-claim cancellation to the exact launch identity before opening the worker start gate, and drains all transfer contexts before removing shared scratch. Dead supervisor persistence bookkeeping and duplicate policy fields are removed rather than adding alternate execution paths or suppressing size guards.

## User Impact

Saved remote sessions never silently execute on the local machine while their environment catalog is loading. Every delegated child preserves its parent's chosen access level, including Full Access without spurious approval alerts, while cross-agent children remain scoped to their own workspace. Cancelling an in-flight Docker worker launch releases its actual container and capacity, and shutdown no longer strands staged workspace-transfer files after a sibling failure.

## Evidence

Failing before the repair:

- Three real Chromium scenarios proved paired-node, automatic-node, and cloud-worker preferences all enabled Start while the UI still showed Local.
- Four visible and four hidden subagent permission regressions failed for read-only, guarded, workspace, and Full Access; the cross-agent case also proved the child lost its own canonical workspace root.
- A real owner-boundary fake-Docker scenario proved an aborted claimed worker remained durably `running` with a surviving container and occupied slot.
- Two real workspace-transfer contexts proved shutdown rejected early, skipped sibling cleanup, and left the shared scratch directory behind.

Passing after the repair:

- 267 Gateway, subagent, node-host, and Docker-supervisor owner tests passed across four Vitest projects; a separate expanded node-supervisor/recovery run passed 58 tests.
- Exact-head hosted CI also exposed two pre-existing order-dependent agent-deletion mocks that replaced the entire filesystem-safety module; both now use the existing partial-mock owner pattern, and all 90 affected and sibling tests pass without any production change.
- 22 actual Chromium destination, placement, and Full Access scenarios passed.
- Focused type-aware lint, core/UI/root-test TypeScript projects, formatting, and independent structured review passed.
- A complete production build rebuilt the Gateway, remote worker, 63 plugins, and Control UI.
- The rebuilt real Gateway served Chromium, which selected a real paired remote node, created/dispatched/sent through the actual browser, ran two real Docker workers, synchronized the workspace, produced zero approval requests, and left no worker containers behind.
- Production: +84/-66 (net +18) across the four independent placement, authority, cleanup, and cancellation boundaries; the Docker-supervisor fix itself is net negative after removing dead ownership state. Tests: +302/-2.

Before selecting the actual paired node:

![Real Gateway Control UI showing the available paired worker node](https://github.com/user-attachments/assets/32b9d9ee-72cb-4c65-96e0-05a5acb0146d)

After two actual Docker-backed turns with Full Access and no approval alerts:

![Real Gateway Control UI after successful paired-node Docker execution without approval alerts](https://github.com/user-attachments/assets/e466cd0c-e07d-4d37-acbd-a14065965082)

Complete sanitized real-browser, paired-node, and Docker execution recording:

https://github.com/user-attachments/assets/af3bc868-2dc2-4a61-b466-d4de02412536
