### PR TITLE
feat(memory): session provenance, admission policy, and openclaw memory forget

### DIFF
--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -1,15 +1,17 @@
 ---
-summary: "CLI reference for `openclaw memory` (status/index/search/promote/promote-explain/rem-harness/rem-backfill/session-backfill)"
+summary: "CLI reference for `openclaw memory` (status/index/search/forget/promote/promote-explain/rem-harness/rem-backfill/session-backfill)"
 read_when:
   - You want to index or search semantic memory
   - You're debugging memory availability or indexing
   - You want to promote recalled short-term memory into `MEMORY.md`
+  - You need to delete provenance-tracked memories derived from specific sessions or participants
 title: "Memory"
 ---
 
 # `openclaw memory`
 
-Manage semantic memory indexing, search, and promotion into `MEMORY.md`.
+Manage semantic memory indexing, search, promotion into `MEMORY.md`, and
+provenance-based deletion.
 Provided by the bundled `memory-core` plugin, available when
 `plugins.slots.memory` selects `memory-core` (the default). Other memory
 plugins expose their own CLI namespaces.
@@ -54,6 +56,13 @@ extra-path details before showing indexing progress. The completion message
 reports the indexed file count. An empty corpus is a successful no-op: the
 command reports the resolved workspace path and that nothing was indexed, and
 leaves the missing `memory/` directory for the first memory write to create.
+Internal dreaming-narrative, cron, and heartbeat session transcripts are
+excluded from indexing, including retained compressed narrative archives whose
+original sessions are no longer active. Sessions previously selected by
+`memory forget` also remain excluded. `--force` removes stale index records for
+both groups without reindexing their retained transcripts. Ordinary retained,
+reset, and deleted user-session archives remain eligible until explicitly
+targeted.
 
 ## `memory search`
 
@@ -72,6 +81,68 @@ warns that matches may be incomplete. With `--json`, the response adds
 `stale: true`, plus `warning` and `action` fields describing how to rebuild the
 index. Treat an empty `results` array as authoritative only when `stale` is
 absent.
+
+## `memory forget`
+
+Delete provenance-tracked durable memory entries derived from selected
+sessions, together with their indexed and short-term copies. Select sessions by
+ID or session key, their external-content hook source, or a participant's actor
+ID:
+
+```bash
+openclaw memory forget --session <id-or-key> [--session <id-or-key> ...]
+openclaw memory forget --hook-source gmail [--since 2026-01-01]
+openclaw memory forget --participant <actor-id> [--agent <id>] [--dry-run] [--json]
+```
+
+`--session`, `--hook-source`, and `--participant` are repeatable. At least one
+selector is required. `--agent` selects one agent and otherwise defaults to the
+default agent. `--since <date>` limits matching sessions to the selected time
+window.
+
+Run with `--dry-run` before deleting. It computes the same complete report as
+the real purge without changing memory files, SQLite indexes, plugin state, or
+durable deletion records. `--json` prints that report as machine-readable JSON.
+
+A purge removes matching pipeline-promoted entries, session-corpus lines,
+selected-session transcript index chunks, full-text and vector index records,
+embedding-cache entries, short-term recall, seen-hash scopes, dreaming rewrite
+backups, and recorded origins. It also clears stale index records for internal
+dreaming-narrative, cron, or heartbeat sessions. An entry derived from both
+selected and unselected sessions is deleted whole and reported as a
+mixed-lineage entry; dreaming can regenerate supported facts from surviving
+sessions later. Entries without recorded origins remain searchable and are not
+deleted by an unrelated selector; the report lists them as untargetable.
+
+A real purge records each selected session as forgotten in the agent's SQLite
+database. Future dreaming sweeps record that session as excluded with reason
+`forgotten`; `memory session-backfill` and transcript indexing, including
+`memory index --force`, also reject it. Repeating the purge is safe and does
+not undo this exclusion.
+
+Dream diaries and other workspace memory files can quote source-session corpus
+lines without retaining a session reference. The purge removes any whole line
+containing an exact purged corpus-line snippet from files such as
+`memory/dreaming/**/*.md` and `DREAMS.md`, as well as matching dreaming
+backups. `artifacts.memoryLines` reports the number of these additional removed
+memory-file lines. Model-paraphrased prose that does not contain the exact
+source text cannot be attributed reliably and is not removed automatically.
+
+Direct agent edits to memory files are tracked at the file level, not per
+entry. When such a write happened during a selected session, `curatedWrites`
+lists its `relativePath` and `observedAt` without modifying the file. Evidence
+comes from native write-observer records and the selected sessions' live or
+archived transcripts, including writes performed by external agent harnesses.
+Review those files separately: a freeform edit cannot be attributed to
+individual lines safely enough for automatic deletion.
+
+<Warning>
+`memory forget` removes selected-session transcript chunks from the memory
+index and permanently prevents their memory-pipeline readmission, but does not
+delete the original source session transcripts. The report identifies the
+selected sessions so you can remove transcript data separately through its
+owning session-management workflow when required.
+</Warning>
 
 ## `memory promote`
 
@@ -177,7 +248,10 @@ tracked message hashes and per-run caps as live session ingestion, so repeated
 canonical store are eligible; tool output, web or non-owner input, and turns
 without trustworthy owner provenance are excluded. Foreign archive files have
 no authenticated owner-provenance contract, so their embedded ownership fields
-remain untrusted and cannot be staged.
+remain untrusted and cannot be staged. Sessions previously purged with
+[`memory forget`](/cli/memory#memory-forget) remain durably excluded, including
+when their original transcripts still exist or their tracked hashes were
+cleared.
 
 `--apply` drains the selected history to completion in one invocation while
 keeping each bounded batch in its own transaction. Human and JSON output report
@@ -193,7 +267,8 @@ commands use the same grounded-only staging class and diary markers. Run
 `session-backfill --rollback` only when you intend to clear both commands'
 grounded backfill artifacts from that workspace. Rollback also removes the
 tracked hashes added by session backfill and rewinds the affected transcript
-cursors, so the same candidates can be previewed and applied again.
+cursors, so surviving eligible candidates can be previewed and applied again.
+Rollback does not remove forgotten-session records or readmit purged sessions.
 
 ## Dreaming
 

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -97,8 +97,16 @@ openclaw memory forget --participant <actor-id> [--agent <id>] [--dry-run] [--js
 
 `--session`, `--hook-source`, and `--participant` are repeatable. At least one
 selector is required. `--agent` selects one agent and otherwise defaults to the
-default agent. `--since <date>` limits matching sessions to the selected time
-window.
+default agent. Explicit session IDs and keys match both live sessions and
+retained archived sessions. An unknown explicit value is still treated as an
+exact session ID, purged where matching artifacts exist, and durably excluded
+from future memory ingestion. The report identifies each selected session as
+`live`, `archived`, or `unresolved`. Hook-source and participant selectors only
+match sessions whose corresponding metadata still exists; archived sessions do
+not retain those facts, so select them by ID or key instead. `--since <date>`
+filters live sessions by their creation time and archived sessions by their
+archive creation time; unresolved explicit IDs have no timestamp and remain
+selected.
 
 Run with `--dry-run` before deleting. It computes the same complete report as
 the real purge without changing memory files, SQLite indexes, plugin state, or

--- a/docs/plan/memory-provenance.md
+++ b/docs/plan/memory-provenance.md
@@ -140,7 +140,8 @@ Writers:
   `{candidateKey, action: added|merged|superseded, resultEntry, priorEntries}`.
   Code unions the parents' origin rows onto the result entry's key on `merged`,
   re-keys on `superseded`, inserts fresh rows on `added`. Origin rows for keys
-  no longer referenced by any live entry are pruned by the same pass.
+  no longer referenced by any live entry are pruned by the same pass. Shared
+  workspaces reconcile every participating agent's existing origin rows.
 
 Operator-curated `MEMORY.md`/`USER.md` edits have no origin rows. Direct agent
 edits also lack deterministic entry lineage, but their existing bounded

--- a/docs/plan/memory-provenance.md
+++ b/docs/plan/memory-provenance.md
@@ -1,0 +1,225 @@
+---
+summary: Memory provenance and selective deletion — pipeline-promoted entries record source sessions, admission policy excludes configured sources, and `memory forget` durably blocks reingestion while purging attributable artifacts and reporting agent-curated writes.
+title: Memory provenance plan
+read_when:
+  - Changing dreaming ingestion, consolidation, promotion, or memory deletion
+  - Adding session-derived data to durable memory files or the memory index
+  - Reviewing enterprise memory-policy, GDPR-deletion, or taint requirements
+---
+
+## Status
+
+Accepted (operator decision, 2026-08-25). Single-PR implementation: admission
+policy, entry origins, durable forgotten-session records, `memory forget`.
+
+## Problem
+
+Enterprise operators need two guarantees the built-in memory system cannot give
+today:
+
+1. **Admission**: content from named sources (email connectors, specific
+   channels, specific counterparties) must be excludable from the durable
+   memory pipeline by policy, deterministically — not by prompting. This does
+   not restrict an agent's direct file edits during the excluded session.
+2. **Deletion**: "purge every memory derived from X" — where X is a session, a
+   person, or a source class (e.g. all Gmail-derived sessions) — must be
+   executable and auditable after the fact. Employee-exit and GDPR erasure are
+   the driving cases.
+
+Today the session id is available at every memory write site but is never
+recorded as a queryable fact: it is encoded in chunk paths
+(`sessions/<agentId>/<sessionId>`), in session-corpus line prefixes
+(`[<agentId>/sessions/<agentId>/<sessionId>#L<n>]`), and in daily-note prose
+headers — never as a column. Consolidation (dreaming) merges entries across
+sessions, so lineage is a DAG; after one dream cycle no deterministic join from
+memory text back to source sessions exists.
+
+## Design
+
+### Invariants
+
+- Entry lineage is recorded at the producer, at write time, in the per-agent
+  SQLite DB (`agents/<agentId>/agent/openclaw-agent.sqlite`). Direct-write file
+  provenance remains in its existing bounded core-owned SQLite plugin state.
+  No prose parsing on the read path.
+- Lineage survives consolidation: a merged entry's origin set is the union of
+  its parents' origin sets, maintained deterministically in code around the
+  consolidation LLM call — the model never carries provenance.
+- Deletion is whole-entry: an entry with any origin in the purge set is
+  removed entirely. No LLM-mediated "subtract one source" rewriting.
+- A purge sweeps every derived artifact: memory files, index chunks (FTS +
+  vec + recall metadata + provenance via cascade), session-corpus lines,
+  short-term recall state, and dreaming memory backups. Verbatim copies of
+  purged corpus snippets are removed whole-line from derived memory files and
+  backups. A deletion that survives in a backup namespace is not a deletion.
+- Forgetting a session records a durable per-agent tombstone. Later dreaming
+  ingestion, explicit session backfill, and transcript indexing honor that
+  recorded fact, so clearing seen-hash scopes cannot turn purged sessions
+  back into new work.
+- Internal dreaming-narrative, cron, and heartbeat session transcripts never
+  enter the memory transcript index, including retained compressed narrative
+  archives without live session-window rows. Structured session or run
+  identity remains authoritative; quoted memory content is never used as a
+  classifier. Forced reindex and purge remove stale index records from
+  earlier runs without readmitting forgotten sessions.
+- Direct agent edits carry file-level source-session evidence from native
+  write-observer records or the selected sessions' live and archived harness
+  transcripts, not invented entry lineage. Matching files are reported as
+  `curatedWrites`, never edited automatically when affected lines cannot be
+  identified.
+- Missing provenance never blocks recall or changes retrieval behavior; it
+  only limits what `memory forget` can target (reported, not silent).
+
+### 1. Admission policy (no schema change)
+
+Config under the `memory-core` plugin entry:
+
+```jsonc
+"memoryPolicy": {
+  "excludeSessions": {
+    "hookExternalContentSources": ["gmail"],   // matches session_windows.hook_external_content_source
+    "channels": ["email"],                     // matches session_windows.channel
+    "chatTypes": []                            // direct | group | channel
+  }
+}
+```
+
+Enforcement point: session corpus building / `scanSessionIngestionSource`
+(`extensions/memory-core/src/session-ingestion.ts` already exposes
+`acceptProvenance`; extend the corpus entry with the session-window facts so
+the predicate can act on them). An excluded session is recorded as excluded in
+ingestion state (visible non-outcome), never scanned into the corpus, and
+therefore can never reach candidates, consolidation, or promotion.
+
+Forgotten sessions are also excluded regardless of policy configuration. Their
+recorded ingestion non-outcome carries `excludedReason: "forgotten"`; explicit
+session backfill and the transcript index consult the same durable fact
+before processing live sessions or retained archives.
+
+This policy governs pipeline ingestion only. An agent running in an excluded
+session can still write `MEMORY.md`, `USER.md`, or another memory file during
+its turn; native write-observer records and harness tool calls in that
+session's transcript supply evidence for report-only deletion review.
+
+### 2. Entry origins and forgotten sessions (additive schema, same version)
+
+New tables in the per-agent DB, following the retired
+`skill_workshop_proposal_origin_runs` child-table pattern:
+
+```sql
+CREATE TABLE IF NOT EXISTS memory_entry_origins (
+  entry_key TEXT NOT NULL,      -- stable claim key (claimHash / candidateKey)
+  agent_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,     -- logical session id
+  session_key TEXT,             -- when known
+  origin_class TEXT NOT NULL CHECK (origin_class IN ('owner','agent','untrusted','system')),
+  observed_at INTEGER NOT NULL,
+  PRIMARY KEY (entry_key, agent_id, session_id)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS memory_session_tombstones (
+  session_id TEXT NOT NULL PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+) STRICT;
+```
+
+Additive: new tables only, declared in the canonical schema plus a one-time
+idempotent lazy ensure on first feature use, folded into the migration path at
+the next natural bump (per `docs/reference/database-schemas.md`). Tombstones
+are written only by a real purge, use reason `forgotten`, and are idempotent;
+`--dry-run` does not initialize tombstone storage or write a deletion record.
+
+Writers:
+
+- **Ingestion → corpus**: each session-corpus line already carries its session
+  ref; when a promotion candidate is formed from session-derived lines, record
+  `(claimHash, agentId, sessionId)`.
+- **Consolidation**: the LLM returns
+  `{candidateKey, action: added|merged|superseded, resultEntry, priorEntries}`.
+  Code unions the parents' origin rows onto the result entry's key on `merged`,
+  re-keys on `superseded`, inserts fresh rows on `added`. Origin rows for keys
+  no longer referenced by any live entry are pruned by the same pass.
+
+Operator-curated `MEMORY.md`/`USER.md` edits have no origin rows. Direct agent
+edits also lack deterministic entry lineage, but their existing bounded
+memory-artifact provenance record carries `sessionId` and, when known,
+`sessionKey`; `memory forget` reports matching files without rewriting them.
+
+### 3. `memory forget` (purge command)
+
+CLI surface (memory-core owns it): resolve a session set, then purge.
+
+```
+openclaw memory forget --session <id-or-key> [...]
+openclaw memory forget --hook-source gmail [--since <date>]
+openclaw memory forget --participant <actor-id>
+  [--dry-run] [--json]
+```
+
+Session-set resolution queries `session_windows` / `session_participants`.
+Purge steps, in order, reported per step:
+
+1. Session-corpus files: identify lines whose rendered prefix matches the
+   purged sessions and retain their exact text for deterministic cleanup;
+   rewrite corpus files without those lines.
+2. Origin join → entry keys → remove matching entries from memory files
+   (promotion-written blocks are hash-addressable; daily-note session sections
+   carry session ids in headers). Remove any other whole memory-file line that
+   contains an exact purged corpus snippet, including dream diaries and
+   `DREAMS.md`; report those lines as `artifacts.memoryLines`.
+3. Index: delete chunks for removed content and the selected sessions' own
+   transcripts (cascades take recall metadata, provenance, FTS, vec); clear
+   stale internal narrative/cron/heartbeat transcript debris, including
+   metadata-less retained narrative archives; drop `memory_index_sources`
+   rows for fully removed files; bump revision.
+4. Plugin state: purge `short-term-recall` snippets and seen-hash scopes for
+   the sessions; purge matching entries and exact snippets inside
+   `dreaming-memory-backups`.
+5. Origins and tombstones: delete origin rows for the purged sessions; report
+   entries whose origin set became empty vs. mixed-lineage entries that were
+   removed whole. Record each selected session with reason `forgotten` so
+   later ingestion, session backfill, indexing, and forced reindex cannot
+   resurrect its content.
+6. Curated writes: report `{ relativePath, observedAt }` for agent-written
+   memory files recorded by the write observer or matching mutation tool calls
+   in the selected sessions' live and archived transcripts. Deduplicate files
+   across both sources and leave their contents unchanged because file-level
+   provenance cannot identify affected entries.
+
+`--dry-run` prints the full report without writing. Mixed-lineage entries are
+deleted whole and listed, so the operator can re-run dreaming to regenerate
+what clean sessions still support; forgotten sessions remain excluded from
+that sweep. Repeating a purge is idempotent. A future legal-hold flag can
+refuse purges with a named reason; out of scope for this PR beyond leaving the
+report shaped to carry refusals.
+
+## Non-goals
+
+- Purging session transcripts themselves (session store owns that; `forget`
+  removes their memory-index copies and reports the source sessions so the
+  operator can act on retained transcripts separately).
+- Automatically redacting direct agent-written memory files without
+  deterministic entry-level lineage (`curatedWrites` is report-only).
+- Removing LLM-paraphrased diary prose that no longer contains an exact
+  purged corpus snippet.
+- Sub-entry source subtraction or model-mediated rewriting; attributable
+  promoted entries are removed whole and exact corpus quotes whole-line.
+- Legal-hold enforcement (report shape only).
+- Cross-agent purge orchestration (per-agent DB; callers iterate agents).
+
+## Proof
+
+Live test with a real OpenAI-backed agent in an isolated `OPENCLAW_STATE_DIR`:
+seed synthetic sessions (some flagged as email-derived), run dreaming, verify
+origin rows exist and admission excluded the tainted session; run
+`memory forget --dry-run` then real purge; verify memory files, FTS, vec,
+embedding cache, session-corpus, short-term state, and backups no longer
+contain the purged facts; verify internal narrative transcripts remain
+unindexed even when only retained compressed archives remain, exact diary
+quotes are removed, matching direct agent writes are reported without
+modification, and recall still works for surviving entries. Run another
+dreaming sweep and forced reindex to verify tombstoned sessions remain
+excluded and their transcript chunks are not recreated; verify explicit session
+backfill also refuses to regenerate their candidates.

--- a/docs/plan/memory-provenance.md
+++ b/docs/plan/memory-provenance.md
@@ -158,7 +158,15 @@ openclaw memory forget --participant <actor-id>
   [--dry-run] [--json]
 ```
 
-Session-set resolution queries `session_windows` / `session_participants`.
+Explicit session IDs and keys resolve against live `session_windows` and
+retained `session_transcript_archives`; an unmatched explicit value remains an
+exact-ID purge target rather than silently disappearing. The report identifies
+each target as `live`, `archived`, or `unresolved`. Hook-source and participant
+selectors only match facts recorded in `session_windows` /
+`session_participants`; archived sessions no longer retain that metadata and
+must be selected explicitly. `--since` compares live-session creation times or
+archive creation times; unresolved explicit IDs remain eligible.
+
 Purge steps, in order, reported per step:
 
 1. Session-corpus files: identify lines whose rendered prefix matches the

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -6,6 +6,7 @@ read_when:
   - You want to configure memory search providers or embedding models
   - You want to understand hybrid search, MMR, or temporal-decay defaults
   - You want to enable multimodal memory indexing
+  - You need to exclude specific session sources from memory-pipeline ingestion
 ---
 
 This page lists every configuration knob for OpenClaw memory search. For conceptual overviews, see:
@@ -477,6 +478,16 @@ Index session transcripts and surface them via `memory_search`:
 Session indexing is opt-in and runs asynchronously. Results can be slightly stale. Active transcripts live in the agent's SQLite database, while retained transcript artifacts can live on disk. Treat access to both as part of the same trust boundary.
 </Warning>
 
+Internal dreaming-narrative, cron, and heartbeat session transcripts are not
+indexed, including retained compressed narrative archives whose live session
+metadata is gone. They may quote fragments from user conversations but are not
+searchable memory sources. Sessions purged with
+[`openclaw memory forget`](/cli/memory#memory-forget) are also durably excluded,
+even though their source transcripts remain in the session store. A forced
+reindex removes stale transcript records without readmitting either group.
+Ordinary user-session transcripts, including retained, reset, and
+deleted-session archives, remain eligible until explicitly targeted.
+
 <Note>
 The [session-memory hook](/automation/hooks#session-memory) saves conversation
 excerpts to `<workspace>/memory/`, which the `memory` source already indexes.
@@ -558,6 +569,64 @@ Built-in memory indexes live in each agent's OpenClaw SQLite database at
 | `auto` (default) | Include `Source: <path#line>` when useful              |
 | `on`             | Always include the source footer                       |
 | `off`            | Omit the footer; the path remains available internally |
+
+---
+
+## Memory admission policy
+
+Configure deterministic session exclusions under
+`plugins.entries.memory-core.config.memoryPolicy.excludeSessions`. Excluded
+sessions never enter the dreaming corpus, so the memory pipeline cannot turn
+them into promotion candidates or consolidated entries.
+
+| Key                          | Type       | Default | Matches                                   |
+| ---------------------------- | ---------- | ------- | ----------------------------------------- |
+| `hookExternalContentSources` | `string[]` | `[]`    | External-content hook sources, like Gmail |
+| `channels`                   | `string[]` | `[]`    | Session channel identifiers               |
+| `chatTypes`                  | `string[]` | `[]`    | `"direct"`, `"group"`, or `"channel"`     |
+
+Every setting is optional. Empty or omitted arrays preserve the existing
+admission behavior. A session matching any configured exclusion is recorded as
+excluded rather than silently ignored. Sessions previously purged by
+[`openclaw memory forget`](/cli/memory#memory-forget) are also excluded
+regardless of these settings; their recorded exclusion reason is `forgotten`.
+This durable per-agent exclusion prevents later dreaming sweeps, session
+backfills, and transcript reindexing from restoring the purged memory.
+
+<Warning>
+This is an ingestion boundary, not a file-write restriction. An agent running
+inside an excluded session can still edit `MEMORY.md`, `USER.md`, or another
+memory file directly during its turn. Such freeform edits do not gain
+entry-level lineage and are not removed automatically by `memory forget`;
+matching observed file writes appear in its `curatedWrites` report instead.
+</Warning>
+
+```json5
+{
+  plugins: {
+    entries: {
+      "memory-core": {
+        config: {
+          memoryPolicy: {
+            excludeSessions: {
+              hookExternalContentSources: ["gmail"],
+              channels: ["email"],
+              chatTypes: ["group"],
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+The policy alone prevents future ingestion; it does not erase memories already
+derived from those sources. To preview and remove existing entries and their
+derived artifacts while durably excluding the selected sessions from future
+memory ingestion, session backfill, and transcript indexing, use
+[`openclaw memory forget`](/cli/memory#memory-forget). The source session
+transcripts themselves remain in the session store.
 
 ---
 

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -57,6 +57,30 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+      "memoryPolicy": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "excludeSessions": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "hookExternalContentSources": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "channels": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "chatTypes": {
+                "type": "array",
+                "items": { "type": "string", "enum": ["direct", "group", "channel"] }
+              }
+            }
+          }
+        }
+      },
       "dreaming": {
         "type": "object",
         "additionalProperties": false,

--- a/extensions/memory-core/src/cli-index-search.runtime.ts
+++ b/extensions/memory-core/src/cli-index-search.runtime.ts
@@ -311,6 +311,9 @@ export async function runMemoryForget(opts: MemoryForgetCommandOptions) {
     if (report.sessionIds.length > 0) {
       lines.push(`${muted("Session IDs:")} ${report.sessionIds.join(", ")}`);
     }
+    for (const session of report.sessionResolutions) {
+      lines.push(`${muted("Session resolution:")} ${session.sessionId} (${session.source})`);
+    }
     if (report.mixedLineageEntryKeys.length > 0) {
       lines.push(
         `${muted("Mixed-lineage entry keys:")} ${report.mixedLineageEntryKeys.join(", ")}`,

--- a/extensions/memory-core/src/cli-index-search.runtime.ts
+++ b/extensions/memory-core/src/cli-index-search.runtime.ts
@@ -6,6 +6,7 @@ import {
   formatAuditCounts,
   formatExtraPaths,
   formatMemoryIndexOutcome,
+  resolveMemoryAgent,
   resolveMemoryPluginConfig,
   scanMemoryManagerSources,
   withMemoryCommand,
@@ -13,6 +14,7 @@ import {
 import {
   defaultRuntime,
   formatErrorMessage,
+  getRuntimeConfig,
   setVerbose,
   shortenHomeInString,
   shortenHomePath,
@@ -21,11 +23,13 @@ import {
 } from "./cli.host.runtime.js";
 import type {
   MemoryCommandOptions,
+  MemoryForgetCommandOptions,
   MemoryPromoteCommandOptions,
   MemoryPromoteExplainOptions,
   MemorySearchCommandOptions,
 } from "./cli.types.js";
 import { resolveShortTermPromotionDreamingConfig } from "./dreaming.js";
+import { forgetMemoryEntries } from "./memory-forget.js";
 import { formatMemoryVectorDegradedWriteReason } from "./memory/manager-vector-warning.js";
 import type { MemoryCoreRuntimeHost } from "./memory/runtime-host.js";
 import {
@@ -265,6 +269,74 @@ export async function runMemorySearch(
     },
   });
 }
+
+export async function runMemoryForget(opts: MemoryForgetCommandOptions) {
+  if (!opts.session?.length && !opts.hookSource?.length && !opts.participant?.length) {
+    defaultRuntime.error(
+      "Memory forget requires --session <id-or-key>, --hook-source <source>, or --participant <actor-id>.",
+    );
+    process.exitCode = 1;
+    return;
+  }
+  try {
+    const cfg = getRuntimeConfig({ skipPluginValidation: true });
+    const agentId = resolveMemoryAgent(cfg, opts.agent);
+    const report = await forgetMemoryEntries({
+      cfg,
+      agentId,
+      sessionIds: opts.session,
+      hookSources: opts.hookSource,
+      participants: opts.participant,
+      since: opts.since,
+      dryRun: Boolean(opts.dryRun),
+    });
+    if (opts.json) {
+      defaultRuntime.writeJson(report);
+      return;
+    }
+    const lines = [
+      `${heading(report.dryRun ? "Memory Deletion Preview" : "Memory Deletion")} ${muted(`(${agentId})`)}`,
+      `${muted("Source sessions:")} ${report.sessionIds.length}`,
+      `${muted("Source transcripts retained:")} ${report.sessionIds.length}`,
+      `${muted("Deleted entries:")} ${report.entryKeys.length}`,
+      `${muted("Mixed-lineage entries deleted whole:")} ${report.mixedLineageEntryKeys.length}`,
+      `${muted("Entries without targetable provenance:")} ${report.untargetableEntryKeys.length}`,
+      `${muted("Curated writes retained:")} ${report.curatedWrites.length}`,
+      `${muted("Memory artifacts:")} ${report.artifacts.memoryFiles} files, ${report.artifacts.memoryEntries} entries, ${report.artifacts.memoryLines} quoted lines`,
+      `${muted("Session corpus:")} ${report.artifacts.sessionCorpusFiles} files, ${report.artifacts.sessionCorpusLines} lines`,
+      `${muted("Index artifacts:")} ${report.artifacts.indexChunks} chunks, ${report.artifacts.indexSources} sources, ${report.artifacts.ftsRows} full-text rows, ${report.artifacts.vectorRows} vector rows, ${report.artifacts.embeddingCacheRows} cached embeddings`,
+      `${muted("Plugin state:")} ${report.artifacts.shortTermEntries} short-term entries, ${report.artifacts.seenHashScopes} seen-hash scopes, ${report.artifacts.backups} backups`,
+      `${muted("Origin rows:")} ${report.artifacts.originRows}`,
+    ];
+    if (report.sessionIds.length > 0) {
+      lines.push(`${muted("Session IDs:")} ${report.sessionIds.join(", ")}`);
+    }
+    if (report.mixedLineageEntryKeys.length > 0) {
+      lines.push(
+        `${muted("Mixed-lineage entry keys:")} ${report.mixedLineageEntryKeys.join(", ")}`,
+      );
+    }
+    if (report.untargetableEntryKeys.length > 0) {
+      lines.push(`${muted("Untargetable entry keys:")} ${report.untargetableEntryKeys.join(", ")}`);
+    }
+    for (const curatedWrite of report.curatedWrites) {
+      lines.push(
+        `${muted("Curated write retained:")} ${curatedWrite.relativePath} (${new Date(curatedWrite.observedAt).toISOString()})`,
+      );
+    }
+    for (const refusal of report.refusals) {
+      lines.push(warn(`Refused: ${refusal}`));
+    }
+    if (report.dryRun) {
+      lines.push(muted("Dry run: no memory files, index rows, or plugin state were changed."));
+    }
+    defaultRuntime.log(lines.join("\n"));
+  } catch (error) {
+    defaultRuntime.error(`Memory forget failed: ${formatErrorMessage(error)}`);
+    process.exitCode = 1;
+  }
+}
+
 function matchesPromotionSelector(
   candidate: {
     key: string;
@@ -330,6 +402,7 @@ export async function runMemoryPromote(
       if (opts.apply) {
         try {
           applyResult = await applyShortTermPromotions({
+            agentId,
             workspaceDir,
             candidates,
             limit: opts.limit,

--- a/extensions/memory-core/src/cli-index-search.runtime.ts
+++ b/extensions/memory-core/src/cli-index-search.runtime.ts
@@ -1,6 +1,9 @@
 import path from "node:path";
 import { resolveMemorySearchStaleness } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
-import { resolveMemoryDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
+import {
+  resolveMemoryDreamingConfig,
+  resolveMemoryDreamingWorkspaces,
+} from "openclaw/plugin-sdk/memory-core-host-status";
 import {
   buildCliMemorySearchSessionKey,
   formatAuditCounts,
@@ -406,6 +409,9 @@ export async function runMemoryPromote(
         try {
           applyResult = await applyShortTermPromotions({
             agentId,
+            workspaceAgentIds: resolveMemoryDreamingWorkspaces(cfg).find(
+              (workspace) => path.resolve(workspace.workspaceDir) === path.resolve(workspaceDir),
+            )?.agentIds,
             workspaceDir,
             candidates,
             limit: opts.limit,

--- a/extensions/memory-core/src/cli-runtime-common.ts
+++ b/extensions/memory-core/src/cli-runtime-common.ts
@@ -128,7 +128,7 @@ export function formatAuditCounts(audit: ShortTermAuditSummary): string {
   const suffix = scriptCoverage ? ` · scripts=${scriptCoverage}` : "";
   return `${audit.entryCount} entries · ${audit.promotedCount} promoted · ${audit.conceptTaggedEntryCount} concept-tagged · ${audit.spacedEntryCount} spaced${suffix}`;
 }
-function resolveAgent(cfg: OpenClawConfig, agent?: string) {
+export function resolveMemoryAgent(cfg: OpenClawConfig, agent?: string) {
   const trimmed = agent?.trim();
   if (agent !== undefined && !trimmed) {
     throw new Error("--agent must not be blank");
@@ -213,7 +213,7 @@ export async function withMemoryCommand(params: {
   emitMemorySecretResolveDiagnostics(diagnostics, { json: params.diagnosticsToStderr });
   const agentIds = params.allAgents
     ? resolveAgentIds(cfg, params.agent)
-    : [resolveAgent(cfg, params.agent)];
+    : [resolveMemoryAgent(cfg, params.agent)];
   for (const agentId of agentIds) {
     await withMemoryManagerForAgent({
       commandName: params.commandName,

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -1,4 +1,5 @@
 export {
+  runMemoryForget,
   runMemoryIndex,
   runMemoryPromote,
   runMemoryPromoteExplain,

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -331,6 +331,10 @@ describe("memory cli", () => {
       agentId: "ops",
       dryRun: true,
       sessionIds: ["session-one", "session-two"],
+      sessionResolutions: [
+        { sessionId: "session-one", sessionKey: "agent:ops:one", source: "live" },
+        { sessionId: "session-two", source: "unresolved" },
+      ],
       entryKeys: ["mixed-entry"],
       mixedLineageEntryKeys: ["mixed-entry"],
       untargetableEntryKeys: ["curated-entry"],
@@ -396,6 +400,8 @@ describe("memory cli", () => {
     await runMemoryCli(["forget", "--session", "session-one", "--agent", "ops", "--dry-run"]);
     const output = firstMockCallArg(logs, "memory forget output");
     expect(output).toContain("Source transcripts retained: 2");
+    expect(output).toContain("Session resolution: session-one (live)");
+    expect(output).toContain("Session resolution: session-two (unresolved)");
     expect(output).toContain("Memory artifacts: 1 files, 1 entries, 2 quoted lines");
     expect(output).toContain("Curated write retained: MEMORY.md (2026-08-25T12:00:00.000Z)");
     expect(getMemorySearchManager).not.toHaveBeenCalled();

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -30,6 +30,7 @@ import {
 } from "./test-helpers.js";
 
 const getMemorySearchManager = vi.hoisted(() => vi.fn());
+const forgetMemoryEntries = vi.hoisted(() => vi.fn());
 const getRuntimeConfig = vi.hoisted(() => vi.fn(() => ({})));
 const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "main"));
 const resolveCommandSecretRefsViaGateway = vi.hoisted(() =>
@@ -74,6 +75,8 @@ async function seedCliBackfillTranscript(sessionId: string, days: string[]): Pro
   }
   await upsertSessionEntry({ agentId, sessionKey, storePath, entry });
 }
+
+vi.mock("./memory-forget.js", () => ({ forgetMemoryEntries }));
 
 vi.mock("./cli.host.runtime.js", async () => {
   const [
@@ -142,6 +145,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   getMemorySearchManager.mockReset();
+  forgetMemoryEntries.mockReset();
   getRuntimeConfig.mockReset().mockReturnValue({});
   resolveDefaultAgentId.mockReset().mockReturnValue("main");
   resolveCommandSecretRefsViaGateway.mockReset().mockImplementation(async ({ config }) => ({
@@ -320,6 +324,83 @@ describe("memory cli", () => {
       },
     }));
   }
+
+  it("forwards repeated forget selectors and reports quoted lines and curated writes in both output formats", async () => {
+    getRuntimeConfig.mockReturnValue(configuredAgents);
+    const report = {
+      agentId: "ops",
+      dryRun: true,
+      sessionIds: ["session-one", "session-two"],
+      entryKeys: ["mixed-entry"],
+      mixedLineageEntryKeys: ["mixed-entry"],
+      untargetableEntryKeys: ["curated-entry"],
+      curatedWrites: [
+        { relativePath: "MEMORY.md", observedAt: Date.parse("2026-08-25T12:00:00Z") },
+      ],
+      artifacts: {
+        memoryFiles: 1,
+        memoryEntries: 1,
+        memoryLines: 2,
+        sessionCorpusFiles: 1,
+        sessionCorpusLines: 2,
+        indexChunks: 1,
+        indexSources: 0,
+        ftsRows: 1,
+        vectorRows: 1,
+        embeddingCacheRows: 1,
+        shortTermEntries: 1,
+        seenHashScopes: 2,
+        backups: 1,
+        originRows: 2,
+      },
+      refusals: [],
+    };
+    forgetMemoryEntries.mockResolvedValueOnce(report);
+    const json = spyRuntimeJson(defaultRuntime);
+
+    await runMemoryCli([
+      "forget",
+      "--session",
+      "session-one",
+      "--session",
+      "session-two",
+      "--hook-source",
+      "gmail",
+      "--hook-source",
+      "email",
+      "--participant",
+      "person-one",
+      "--participant",
+      "person-two",
+      "--since",
+      "2026-01-01",
+      "--agent",
+      "ops",
+      "--dry-run",
+      "--json",
+    ]);
+
+    expect(forgetMemoryEntries).toHaveBeenCalledWith({
+      cfg: configuredAgents,
+      agentId: "ops",
+      sessionIds: ["session-one", "session-two"],
+      hookSources: ["gmail", "email"],
+      participants: ["person-one", "person-two"],
+      since: "2026-01-01",
+      dryRun: true,
+    });
+    expect(firstWrittenJsonArg(json)).toEqual(report);
+
+    forgetMemoryEntries.mockResolvedValueOnce(report);
+    const logs = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["forget", "--session", "session-one", "--agent", "ops", "--dry-run"]);
+    const output = firstMockCallArg(logs, "memory forget output");
+    expect(output).toContain("Source transcripts retained: 2");
+    expect(output).toContain("Memory artifacts: 1 files, 1 entries, 2 quoted lines");
+    expect(output).toContain("Curated write retained: MEMORY.md (2026-08-25T12:00:00.000Z)");
+    expect(getMemorySearchManager).not.toHaveBeenCalled();
+    expect(resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
+  });
 
   it.each([
     ["status", ["status", "--agent", "nope-zzz"]],

--- a/extensions/memory-core/src/cli.ts
+++ b/extensions/memory-core/src/cli.ts
@@ -12,6 +12,7 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import type {
   MemoryCommandOptions,
+  MemoryForgetCommandOptions,
   MemoryPromoteCommandOptions,
   MemoryPromoteExplainOptions,
   MemoryRemBackfillOptions,
@@ -49,6 +50,11 @@ async function runMemorySearch(
 ) {
   const runtime = await loadMemoryCliRuntime();
   await runtime.runMemorySearch(queryArg, opts, hostOptions);
+}
+
+async function runMemoryForget(opts: MemoryForgetCommandOptions) {
+  const runtime = await loadMemoryCliRuntime();
+  await runtime.runMemoryForget(opts);
 }
 
 async function runMemoryPromote(
@@ -126,6 +132,10 @@ function parseMemoryCliNonNegativeIntegerOption(value: string, flag: string): nu
   return parsed;
 }
 
+function collectMemoryCliValues(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
 export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRuntimeHost) {
   if (hostOptions?.openKeyedStore) {
     configureMemoryCoreDreamingState(hostOptions.openKeyedStore);
@@ -148,6 +158,10 @@ export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRunt
           [
             'openclaw memory search --query "deployment" --max-results 20',
             "Limit results for focused troubleshooting.",
+          ],
+          [
+            "openclaw memory forget --hook-source gmail --dry-run",
+            "Preview deletion of memories derived from matching sessions.",
           ],
           [
             `openclaw memory promote --limit 10 --min-score ${DEFAULT_PROMOTION_MIN_SCORE}`,
@@ -219,6 +233,35 @@ export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRunt
     .option("--json", "Print JSON")
     .action(async (queryArg: string | undefined, opts: MemorySearchCommandOptions) => {
       await runMemorySearch(queryArg, opts, hostOptions);
+    });
+
+  memory
+    .command("forget")
+    .description("Delete memories and derived artifacts from selected sessions")
+    .option("--agent <id>", "Agent id (default: default agent)")
+    .option(
+      "--session <id-or-key>",
+      "Source session ID or key (repeatable)",
+      collectMemoryCliValues,
+      [],
+    )
+    .option(
+      "--hook-source <source>",
+      "External-content hook source (repeatable)",
+      collectMemoryCliValues,
+      [],
+    )
+    .option(
+      "--participant <actor-id>",
+      "Session participant actor ID (repeatable)",
+      collectMemoryCliValues,
+      [],
+    )
+    .option("--since <date>", "Only include sessions observed on or after this date")
+    .option("--dry-run", "Report everything that would be deleted without writing", false)
+    .option("--json", "Print the complete machine-readable deletion report")
+    .action(async (opts: MemoryForgetCommandOptions) => {
+      await runMemoryForget(opts);
     });
 
   memory

--- a/extensions/memory-core/src/cli.types.ts
+++ b/extensions/memory-core/src/cli.types.ts
@@ -15,6 +15,14 @@ export type MemorySearchCommandOptions = MemoryCommandOptions & {
   minScore?: number;
 };
 
+export type MemoryForgetCommandOptions = MemoryCommandOptions & {
+  session?: string[];
+  hookSource?: string[];
+  participant?: string[];
+  since?: string;
+  dryRun?: boolean;
+};
+
 export type MemoryPromoteCommandOptions = MemoryCommandOptions & {
   limit?: number;
   minScore?: number;

--- a/extensions/memory-core/src/config.test.ts
+++ b/extensions/memory-core/src/config.test.ts
@@ -38,6 +38,13 @@ describe("memory-core manifest config schema", () => {
       schema: manifest.configSchema,
       cacheKey: "memory-core.manifest.dreaming-phase-thresholds",
       value: {
+        memoryPolicy: {
+          excludeSessions: {
+            hookExternalContentSources: ["gmail"],
+            channels: ["email"],
+            chatTypes: ["group"],
+          },
+        },
         dreaming: {
           enabled: true,
           timezone: "Europe/London",
@@ -75,5 +82,15 @@ describe("memory-core manifest config schema", () => {
     });
 
     expect(result.ok).toBe(true);
+  });
+
+  it("rejects unsupported session admission chat types", () => {
+    const result = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "memory-core.manifest.session-admission-chat-types",
+      value: { memoryPolicy: { excludeSessions: { chatTypes: ["broadcast"] } } },
+    });
+
+    expect(result.ok).toBe(false);
   });
 });

--- a/extensions/memory-core/src/dreaming-consolidation.ts
+++ b/extensions/memory-core/src/dreaming-consolidation.ts
@@ -11,6 +11,7 @@ import { filterConsolidationCandidates } from "./dreaming-consolidation-candidat
 import type { SubagentSurface } from "./dreaming-narrative.js";
 import { extractAssistantText } from "./dreaming-shared.js";
 import { DEFAULT_MEMORY_FILE_MAX_CHARS } from "./memory-budget.js";
+import { buildPromotionMarker } from "./short-term-promotion-memory-write.js";
 import {
   buildPromotionRecallAnnotations,
   groupPromotionCandidatesByProjectKey,
@@ -21,7 +22,6 @@ import type { PromotionCandidate } from "./short-term-promotion-types.js";
 
 const CONSOLIDATION_TIMEOUT_MS = 60_000;
 const CONSOLIDATION_MESSAGE_LIMIT = 5;
-const PROMOTION_MARKER_PREFIX = "openclaw-memory-promotion:";
 const PROMOTED_SNIPPET_CHARS_PER_TOKEN_ESTIMATE = 4;
 const CONSOLIDATION_SYSTEM_PROMPT = [
   "Revise the supplied MEMORY.md using only the supplied candidates as new evidence.",
@@ -412,11 +412,7 @@ export function applyMemoryConsolidationPlan(params: {
   }
   const lines = params.existingMemory.replace(/\r\n/gu, "\n").split("\n");
   for (const operation of params.plan.operations) {
-    if (
-      lines.some((line) =>
-        line.includes(`<!-- ${PROMOTION_MARKER_PREFIX}${operation.candidateKey} -->`),
-      )
-    ) {
+    if (lines.some((line) => line.includes(buildPromotionMarker(operation.candidateKey)))) {
       return null;
     }
     const latestEntries = extractMemoryEntries(lines.join("\n"));
@@ -474,7 +470,7 @@ export function applyMemoryConsolidationPlan(params: {
     if (operation.lineageKey) {
       additions.push(`<!-- openclaw-memory-lineage:${operation.lineageKey} -->`);
     }
-    additions.push(`<!-- ${PROMOTION_MARKER_PREFIX}${operation.candidateKey} -->`);
+    additions.push(buildPromotionMarker(operation.candidateKey));
     if (!appendedEntries.has(operation.resultEntry)) {
       additions.push(operation.resultEntry);
       appendedEntries.add(operation.resultEntry);

--- a/extensions/memory-core/src/dreaming-ingestion-state.ts
+++ b/extensions/memory-core/src/dreaming-ingestion-state.ts
@@ -25,6 +25,7 @@ export type SessionIngestionFileState = {
   contentHash: string;
   lineCount: number;
   lastContentLine: number;
+  excludedReason?: string;
 };
 
 export type SessionIngestionState = {
@@ -97,6 +98,9 @@ export function normalizeSessionIngestionState(raw: unknown): SessionIngestionSt
         contentHash: typeof file.contentHash === "string" ? file.contentHash.trim() : "",
         lineCount,
         lastContentLine: Math.min(lineCount, lastContentLine),
+        ...(typeof file.excludedReason === "string" && file.excludedReason.trim()
+          ? { excludedReason: file.excludedReason.trim() }
+          : {}),
       };
     }
   }

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -20,6 +20,7 @@ import {
   runDreamingSweepPhases,
   seedHistoricalDailyMemorySignals,
 } from "./dreaming-phases.js";
+import { forgetMemoryEntries } from "./memory-forget.js";
 import { previewRemHarness } from "./rem-harness.js";
 import { writeSessionIngestionState } from "./session-ingestion.js";
 import {
@@ -174,6 +175,7 @@ async function seedDreamingSessionTranscript(params: {
   sessionId: string;
   sessionKey?: string;
   spawnedBy?: string;
+  hookExternalContentSource?: "gmail" | "webhook";
 }): Promise<void> {
   const agentId = params.agentId ?? "main";
   const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
@@ -196,6 +198,9 @@ async function seedDreamingSessionTranscript(params: {
       sessionId: params.sessionId,
       updatedAt,
       ...(params.spawnedBy ? { spawnedBy: params.spawnedBy } : {}),
+      ...(params.hookExternalContentSource
+        ? { hookExternalContentSource: params.hookExternalContentSource }
+        : {}),
     },
   });
   for (const message of params.messages) {
@@ -220,6 +225,9 @@ async function seedDreamingSessionTranscript(params: {
       sessionId: params.sessionId,
       updatedAt,
       ...(params.spawnedBy ? { spawnedBy: params.spawnedBy } : {}),
+      ...(params.hookExternalContentSource
+        ? { hookExternalContentSource: params.hookExternalContentSource }
+        : {}),
     },
   });
 }
@@ -1293,6 +1301,117 @@ describe("memory-core dreaming phases", () => {
     const snippets = ranked.map((candidate) => candidate.snippet);
     expectIncludesSubstring(snippets, "Move backups to S3 Glacier.");
     expectIncludesSubstring(snippets, "Set retention to 365 days.");
+  });
+
+  it("records policy exclusions and keeps forgotten sessions excluded after policy removal and resweeps", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    setDreamingTestEnv(path.join(workspaceDir, ".state"));
+    await seedDreamingSessionTranscript({
+      sessionId: "gmail-session",
+      hookExternalContentSource: "gmail",
+      messages: [
+        {
+          role: "user",
+          timestamp: "2026-04-05T18:01:00.000Z",
+          content: "Never retain this imported Gmail claim.",
+        },
+      ],
+    });
+    await seedDreamingSessionTranscript({
+      sessionId: "trusted-session",
+      messages: [
+        {
+          role: "user",
+          timestamp: "2026-04-05T18:02:00.000Z",
+          content: "Keep this trusted interactive claim.",
+        },
+      ],
+    });
+
+    const excludedConfig: OpenClawConfig = {
+      agents: { list: [{ id: "main", workspace: workspaceDir }] },
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              memoryPolicy: { excludeSessions: { hookExternalContentSources: ["gmail"] } },
+              dreaming: {
+                enabled: true,
+                phases: { light: { enabled: true, limit: 20, lookbackDays: 7 } },
+              },
+            },
+          },
+        },
+      },
+    };
+    const excludedHarness = createHarness(excludedConfig, workspaceDir);
+    const corpusPath = path.join(
+      workspaceDir,
+      "memory",
+      ".dreams",
+      "session-corpus",
+      "2026-04-05.txt",
+    );
+
+    try {
+      await withDreamingTestClock(async () => {
+        await triggerLightDreaming(excludedHarness.beforeAgentReply, workspaceDir, 5);
+      });
+      const excludedState = await dreamingTestState.readSessionIngestionState(workspaceDir);
+      expect(excludedState.files["main:sessions/main/gmail-session"]).toMatchObject({
+        contentHash: "",
+        lineCount: 0,
+        excludedReason: "hookExternalContentSource:gmail",
+      });
+      expect(excludedState.seenMessages).not.toHaveProperty("main:sessions/main/gmail-session");
+      expect(await fs.readFile(corpusPath, "utf-8")).toContain(
+        "Keep this trusted interactive claim.",
+      );
+      expect(await fs.readFile(corpusPath, "utf-8")).not.toContain(
+        "Never retain this imported Gmail claim.",
+      );
+
+      const admittedHarness = createDefaultStorageLightDreamingHarness(workspaceDir, {
+        includeMainAgent: true,
+      });
+      await withDreamingTestClock(async () => {
+        await triggerLightDreaming(admittedHarness.beforeAgentReply, workspaceDir, 6);
+      });
+      const admittedState = await dreamingTestState.readSessionIngestionState(workspaceDir);
+      expect(admittedState.files["main:sessions/main/gmail-session"]).not.toHaveProperty(
+        "excludedReason",
+      );
+      expect(await fs.readFile(corpusPath, "utf-8")).toContain(
+        "Never retain this imported Gmail claim.",
+      );
+
+      await forgetMemoryEntries({
+        cfg: excludedConfig,
+        agentId: "main",
+        sessionIds: ["gmail-session"],
+      });
+      expect(await fs.readFile(corpusPath, "utf-8")).not.toContain(
+        "Never retain this imported Gmail claim.",
+      );
+      await withDreamingTestClock(async () => {
+        await triggerLightDreaming(admittedHarness.beforeAgentReply, workspaceDir, 7);
+      });
+      const forgottenState = await dreamingTestState.readSessionIngestionState(workspaceDir);
+      expect(forgottenState.files["main:sessions/main/gmail-session"]).toMatchObject({
+        contentHash: "",
+        lineCount: 0,
+        excludedReason: "forgotten",
+      });
+      expect(forgottenState.seenMessages).not.toHaveProperty("main:sessions/main/gmail-session");
+      expect(await fs.readFile(corpusPath, "utf-8")).not.toContain(
+        "Never retain this imported Gmail claim.",
+      );
+      expect(await fs.readFile(corpusPath, "utf-8")).toContain(
+        "Keep this trusted interactive claim.",
+      );
+    } finally {
+      restoreDreamingTestEnv();
+    }
   });
 
   it("redacts sensitive session content before writing session corpus", async () => {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -40,12 +40,15 @@ import {
   readMemoryCoreWorkspaceEntries,
   writeMemoryCoreWorkspaceEntries,
 } from "./dreaming-state.js";
+import { listMemorySessionTombstones } from "./memory-entry-origins.js";
 import { textSimilarity as snippetSimilarity } from "./memory/tokenize.js";
 import {
   appendSessionCorpusLines,
   mergeTrackedMessageHashes,
   readSessionIngestionState,
+  resolveAdmissionPolicy,
   scanSessionIngestionSource,
+  sessionExclusionReason,
   sessionIngestionSourceFromCorpus,
   sessionIngestionStateKeyFromCorpus,
   SESSION_INGESTION_MAX_MESSAGES_PER_FILE,
@@ -53,6 +56,8 @@ import {
   SESSION_INGESTION_MIN_MESSAGES_PER_FILE,
   trimTrackedSessionScopes,
   writeSessionIngestionState,
+  type SessionAdmissionPolicy,
+  type SessionEntryOrigin,
   type SessionIngestionMessage,
   type SessionIngestionSource,
   type SessionIngestionState,
@@ -97,6 +102,7 @@ type DreamingPhaseRunParams<TConfig extends LightDreamingConfig | RemDreamingCon
   subagent?: DreamNarrativeRequest["subagent"];
   detachNarratives?: boolean;
   nowMs?: number;
+  admissionPolicy?: SessionAdmissionPolicy;
 };
 const DAILY_MEMORY_FILENAME_RE = /^(\d{4}-\d{2}-\d{2})(?:-[^/]+)?\.md$/i;
 const DAILY_INGESTION_SCORE = 0.62;
@@ -503,7 +509,9 @@ export function filterRecallEntriesWithinLookback(params: {
 
 type DailyIngestionBatch = {
   day: string;
-  results: Array<MemorySearchResult & { identitySnippet?: string }>;
+  results: Array<
+    MemorySearchResult & { identitySnippet?: string; sessionOrigin?: SessionEntryOrigin }
+  >;
 };
 
 type DailyMemoryFile = {
@@ -597,6 +605,7 @@ async function collectSessionIngestionBatches(params: {
   nowMs: number;
   timezone?: string;
   state: SessionIngestionState;
+  admissionPolicy?: SessionAdmissionPolicy;
 }) {
   if (!params.cfg) {
     const nextState = { version: 3 as const, files: {}, seenMessages: {} };
@@ -620,6 +629,9 @@ async function collectSessionIngestionBatches(params: {
   const sources: SessionIngestionSource[] = [];
   for (const agentId of agentIds) {
     const knownStateKeys = new Set<string>();
+    const forgottenSessionIds = new Set(
+      listMemorySessionTombstones({ agentId }).map((tombstone) => tombstone.sessionId),
+    );
     for (const entry of await listSessionTranscriptCorpusEntriesForAgent(agentId, {
       includeRetainedSqlite: true,
     })) {
@@ -634,6 +646,24 @@ async function collectSessionIngestionBatches(params: {
         entry.artifactKind !== "active-session" ||
         isCheckpointSessionTranscriptPath(entry.sessionFile)
       ) {
+        continue;
+      }
+      const excludedReason = sessionExclusionReason(
+        source,
+        params.admissionPolicy,
+        forgottenSessionIds,
+      );
+      if (excludedReason) {
+        // Record exclusion before reading transcript content; the empty
+        // fingerprint makes removing the policy re-admit this session.
+        nextFiles[source.stateKey] = {
+          mtimeMs: entry.updatedAtMs ?? 0,
+          size: 0,
+          contentHash: "",
+          lineCount: 0,
+          lastContentLine: 0,
+          excludedReason,
+        };
         continue;
       }
       sources.push(source);
@@ -731,6 +761,7 @@ async function ingestSessionTranscriptSignals(params: {
   lookbackDays: number;
   nowMs: number;
   timezone?: string;
+  admissionPolicy?: SessionAdmissionPolicy;
 }): Promise<void> {
   const state = await readSessionIngestionState(params.workspaceDir);
   const collected = await collectSessionIngestionBatches({
@@ -741,6 +772,7 @@ async function ingestSessionTranscriptSignals(params: {
     nowMs: params.nowMs,
     timezone: params.timezone,
     state,
+    admissionPolicy: params.admissionPolicy,
   });
   const ingestionDayBucket = formatMemoryDreamingDay(params.nowMs, params.timezone);
   for (const batch of collected.batches) {
@@ -1309,6 +1341,7 @@ async function ingestDreamingPhaseSignals(
     lookbackDays: params.config.lookbackDays,
     nowMs,
     timezone: params.config.timezone,
+    admissionPolicy: params.admissionPolicy,
   });
   return nowMs;
 }
@@ -1501,6 +1534,7 @@ export async function runDreamingSweepPhases(params: {
   // Normalize nowMs once so all phase timestamps and narrative session keys are consistent.
   const sweepNowMs =
     typeof params.nowMs === "number" && Number.isFinite(params.nowMs) ? params.nowMs : Date.now();
+  const admissionPolicy = resolveAdmissionPolicy(params.pluginConfig);
   let degradedPhases = 0;
   let pendingNarratives = 0;
   const recordNarrativeOutcome = (outcome: DreamNarrativeOutcome): void => {
@@ -1527,6 +1561,7 @@ export async function runDreamingSweepPhases(params: {
           subagent: params.subagent,
           nowMs: sweepNowMs,
           detachNarratives: params.detachNarratives,
+          admissionPolicy,
         }),
       );
     } catch (err) {
@@ -1558,6 +1593,7 @@ export async function runDreamingSweepPhases(params: {
           subagent: params.subagent,
           nowMs: sweepNowMs,
           detachNarratives: params.detachNarratives,
+          admissionPolicy,
         }),
       );
     } catch (err) {

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -701,6 +701,7 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
         );
       }
       const applied = await applyShortTermPromotions({
+        agentId,
         workspaceDir,
         candidates,
         limit: params.config.limit,

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -574,13 +574,18 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
   // carries its owning agent. The triggering agent owns whatever the roster cannot attribute.
   const triggerAgentId = normalizeLowercaseStringOrEmpty(params.agentId);
   const seenWorkspaces = new Set<string>();
-  const workspaces: Array<{ agentId?: string; workspaceDir: string }> = [];
-  const addWorkspace = (workspaceDir: string, agentId: string): void => {
+  const workspaces: Array<{ agentId?: string; agentIds: readonly string[]; workspaceDir: string }> =
+    [];
+  const addWorkspace = (
+    workspaceDir: string,
+    agentId: string,
+    agentIds: readonly string[] = [agentId],
+  ): void => {
     if (!workspaceDir || seenWorkspaces.has(workspaceDir)) {
       return;
     }
     seenWorkspaces.add(workspaceDir);
-    workspaces.push({ ...(agentId ? { agentId } : {}), workspaceDir });
+    workspaces.push({ ...(agentId ? { agentId } : {}), agentIds, workspaceDir });
   };
   // The triggering agent wins its own workspace; otherwise sort so a workspace shared by
   // several agents always resolves the same owner across sweeps.
@@ -597,7 +602,11 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
       // the host falls back to the roster default agent when the turn has no id.
       ...(triggerAgentId ? { primaryAgentId: triggerAgentId } : {}),
     })) {
-      addWorkspace(entry.workspaceDir, resolveWorkspaceOwnerAgentId(entry.agentIds));
+      addWorkspace(
+        entry.workspaceDir,
+        resolveWorkspaceOwnerAgentId(entry.agentIds),
+        entry.agentIds,
+      );
     }
   }
   if (workspaces.length === 0 && fallbackWorkspaceDir) {
@@ -642,7 +651,7 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
     import("./dreaming-phases.js"),
     import("./short-term-promotion.js"),
   ]);
-  for (const { agentId, workspaceDir } of workspaces) {
+  for (const { agentId, agentIds, workspaceDir } of workspaces) {
     const sweepNowMs = Date.now();
     try {
       const phaseResult = await runDreamingSweepPhases({
@@ -702,6 +711,7 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
       }
       const applied = await applyShortTermPromotions({
         agentId,
+        workspaceAgentIds: agentIds,
         workspaceDir,
         candidates,
         limit: params.config.limit,

--- a/extensions/memory-core/src/memory-entry-origins.test.ts
+++ b/extensions/memory-core/src/memory-entry-origins.test.ts
@@ -1,0 +1,216 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
+} from "openclaw/plugin-sdk/sqlite-runtime";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  closeOpenClawStateDatabaseForTest,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  deleteMemoryEntryOrigins,
+  listMemoryEntryOrigins,
+  listMemorySessionTombstones,
+  reconcileMemoryEntryOrigins,
+  recordMemoryEntryOrigins,
+  recordMemorySessionTombstones,
+  type MemoryEntryOrigin,
+} from "./memory-entry-origins.js";
+import { recordShortTermRecalls } from "./short-term-promotion-record.js";
+import {
+  configureMemoryCoreDreamingStateForTests,
+  resetMemoryCoreDreamingStateForTests,
+} from "./test-helpers.js";
+
+describe("memory entry origins", () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-origin-")),
+    );
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    await configureMemoryCoreDreamingStateForTests();
+    await fs.mkdir(path.dirname(resolveOpenClawAgentSqlitePath({ agentId: "main" })), {
+      recursive: true,
+    });
+  });
+
+  afterEach(async () => {
+    resetMemoryCoreDreamingStateForTests();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    vi.unstubAllEnvs();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  function origin(entryKey: string, sessionId: string): MemoryEntryOrigin {
+    return {
+      entryKey,
+      agentId: "main",
+      sessionId,
+      sessionKey: `agent:main:${sessionId}`,
+      originClass: "owner",
+      observedAt: 1_000,
+    };
+  }
+
+  it("lazily restores the additive origins table without changing the agent schema version", () => {
+    const db = openOpenClawAgentDatabase({ agentId: "main" }).db;
+    const version = db.prepare("PRAGMA user_version").get();
+    db.exec("DROP TABLE IF EXISTS memory_entry_origins");
+
+    expect(listMemoryEntryOrigins({ agentId: "main" })).toEqual([]);
+    expect(
+      db.prepare("SELECT name FROM sqlite_schema WHERE name = 'memory_entry_origins'").get(),
+    ).toBeUndefined();
+    recordMemoryEntryOrigins({ agentId: "main", origins: [origin("candidate", "session-1")] });
+    recordMemoryEntryOrigins({ agentId: "main", origins: [origin("candidate", "session-1")] });
+
+    expect(listMemoryEntryOrigins({ agentId: "main" })).toEqual([origin("candidate", "session-1")]);
+    expect(db.prepare("PRAGMA user_version").get()).toEqual(version);
+  });
+
+  it("lazily persists forgotten sessions without recreating tombstones on reads or repeat writes", () => {
+    const db = openOpenClawAgentDatabase({ agentId: "main" }).db;
+    const version = db.prepare("PRAGMA user_version").get();
+    db.exec("DROP TABLE IF EXISTS memory_session_tombstones");
+
+    expect(listMemorySessionTombstones({ agentId: "main" })).toEqual([]);
+    expect(listMemorySessionTombstones({ agentId: "main", sessionIds: [] })).toEqual([]);
+    expect(
+      db.prepare("SELECT name FROM sqlite_schema WHERE name = 'memory_session_tombstones'").get(),
+    ).toBeUndefined();
+    recordMemoryEntryOrigins({ agentId: "main", origins: [origin("candidate", "session-1")] });
+    expect(
+      db.prepare("SELECT name FROM sqlite_schema WHERE name = 'memory_session_tombstones'").get(),
+    ).toBeUndefined();
+
+    expect(
+      recordMemorySessionTombstones({
+        agentId: "main",
+        sessionIds: ["session-2", "session-1", "session-1"],
+        createdAt: 1_000,
+      }),
+    ).toBe(2);
+    expect(
+      recordMemorySessionTombstones({
+        agentId: "main",
+        sessionIds: ["session-1"],
+        reason: "replacement",
+        createdAt: 2_000,
+      }),
+    ).toBe(0);
+    expect(listMemorySessionTombstones({ agentId: "main" })).toEqual([
+      { sessionId: "session-1", agentId: "main", reason: "forgotten", createdAt: 1_000 },
+      { sessionId: "session-2", agentId: "main", reason: "forgotten", createdAt: 1_000 },
+    ]);
+    expect(listMemorySessionTombstones({ agentId: "main", sessionIds: ["session-2"] })).toEqual([
+      { sessionId: "session-2", agentId: "main", reason: "forgotten", createdAt: 1_000 },
+    ]);
+    expect(db.prepare("PRAGMA user_version").get()).toEqual(version);
+  });
+
+  it("unions every parent session onto a merged entry and removes its retired parent key", () => {
+    recordMemoryEntryOrigins({
+      agentId: "main",
+      origins: [origin("prior", "session-1"), origin("candidate", "session-2")],
+    });
+    const priorEntry = "- The deployment target is staging.";
+    const previousMemory = `# Memory\n<!-- openclaw-memory-promotion:prior -->\n${priorEntry}\n`;
+    const currentMemory = `# Memory\n<!-- openclaw-memory-promotion:candidate -->\n- The deployment target is staging. Source: memory/a.md#L1-L1\n`;
+
+    reconcileMemoryEntryOrigins({
+      agentId: "main",
+      previousMemory,
+      currentMemory,
+      operations: [
+        {
+          candidateKey: "candidate",
+          action: "merged",
+          priorEntries: [priorEntry],
+        },
+      ],
+    });
+
+    expect(listMemoryEntryOrigins({ agentId: "main" })).toEqual([
+      origin("candidate", "session-1"),
+      origin("candidate", "session-2"),
+    ]);
+    expect(listMemoryEntryOrigins({ agentId: "main", entryKeys: ["prior"] })).toEqual([]);
+  });
+
+  it("re-keys superseded session lineage while preserving unrelated live memory", () => {
+    recordMemoryEntryOrigins({
+      agentId: "main",
+      origins: [origin("stale", "session-1"), origin("surviving", "session-3")],
+    });
+    const priorEntry = "- The deployment target is staging.";
+    const previousMemory = `<!-- openclaw-memory-lineage:target -->\n<!-- openclaw-memory-promotion:stale -->\n${priorEntry}\n<!-- openclaw-memory-promotion:surviving -->\n- Keep this independent memory.\n`;
+    const currentMemory = `<!-- openclaw-memory-promotion:surviving -->\n- Keep this independent memory.\n<!-- openclaw-memory-lineage:target -->\n<!-- openclaw-memory-promotion:replacement -->\n- The deployment target is production.\n`;
+
+    reconcileMemoryEntryOrigins({
+      agentId: "main",
+      previousMemory,
+      currentMemory,
+      operations: [
+        {
+          candidateKey: "replacement",
+          action: "superseded",
+          priorEntries: [priorEntry],
+        },
+      ],
+    });
+
+    expect(listMemoryEntryOrigins({ agentId: "main" })).toEqual([
+      origin("replacement", "session-1"),
+      origin("surviving", "session-3"),
+    ]);
+    expect(deleteMemoryEntryOrigins({ agentId: "main", entryKeys: ["replacement"] })).toBe(1);
+    expect(listMemoryEntryOrigins({ agentId: "main" })).toEqual([origin("surviving", "session-3")]);
+  });
+
+  it("records exact session identity when a transcript recall candidate is first produced", async () => {
+    const workspaceDir = path.join(stateDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "deployment target",
+      results: [
+        {
+          path: "memory/.dreams/session-corpus/2026-08-25.txt",
+          startLine: 1,
+          endLine: 1,
+          score: 0.8,
+          snippet: "The deployment target is staging.",
+          source: "memory",
+          provenance: {
+            originClass: "owner",
+            sessionKind: "interactive",
+            observedAt: 1_000,
+          },
+          sessionOrigin: {
+            agentId: "main",
+            sessionId: "session-1",
+            sessionKey: "agent:main:session-1",
+          },
+        },
+      ],
+      nowMs: 1_000,
+    });
+
+    expect(listMemoryEntryOrigins({ agentId: "main", sessionIds: ["session-1"] })).toEqual([
+      expect.objectContaining({
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        originClass: "owner",
+        observedAt: 1_000,
+      }),
+    ]);
+  });
+});

--- a/extensions/memory-core/src/memory-entry-origins.test.ts
+++ b/extensions/memory-core/src/memory-entry-origins.test.ts
@@ -124,7 +124,7 @@ describe("memory entry origins", () => {
     const currentMemory = `# Memory\n<!-- openclaw-memory-promotion:candidate -->\n- The deployment target is staging. Source: memory/a.md#L1-L1\n`;
 
     reconcileMemoryEntryOrigins({
-      agentId: "main",
+      agentIds: ["main"],
       previousMemory,
       currentMemory,
       operations: [
@@ -153,7 +153,7 @@ describe("memory entry origins", () => {
     const currentMemory = `<!-- openclaw-memory-promotion:surviving -->\n- Keep this independent memory.\n<!-- openclaw-memory-lineage:target -->\n<!-- openclaw-memory-promotion:replacement -->\n- The deployment target is production.\n`;
 
     reconcileMemoryEntryOrigins({
-      agentId: "main",
+      agentIds: ["main"],
       previousMemory,
       currentMemory,
       operations: [

--- a/extensions/memory-core/src/memory-entry-origins.ts
+++ b/extensions/memory-core/src/memory-entry-origins.ts
@@ -1,0 +1,332 @@
+import type { DatabaseSync } from "node:sqlite";
+import {
+  executeSqliteQuerySync,
+  getNodeSqliteKysely,
+  openOpenClawAgentDatabase,
+  runSqliteImmediateTransactionSync,
+  withOpenClawAgentDatabaseReadOnly,
+} from "openclaw/plugin-sdk/sqlite-runtime";
+
+type MemoryOriginClass = "owner" | "agent" | "untrusted" | "system";
+
+export type MemoryEntryOrigin = {
+  entryKey: string;
+  agentId: string;
+  sessionId: string;
+  sessionKey: string | null;
+  originClass: MemoryOriginClass;
+  observedAt: number;
+};
+
+type MemorySessionTombstone = {
+  sessionId: string;
+  agentId: string;
+  reason: string;
+  createdAt: number;
+};
+
+type MemoryEntryOriginRow = {
+  entry_key: string;
+  agent_id: string;
+  session_id: string;
+  session_key: string | null;
+  origin_class: MemoryOriginClass;
+  observed_at: number;
+};
+
+type MemorySessionTombstoneRow = {
+  session_id: string;
+  agent_id: string;
+  reason: string;
+  created_at: number;
+};
+
+type MemoryOriginDatabase = {
+  memory_entry_origins: MemoryEntryOriginRow;
+  memory_session_tombstones: MemorySessionTombstoneRow;
+};
+type SqliteSchemaDatabase = { sqlite_schema: { type: string; name: string } };
+const ensuredDatabases = new WeakSet<DatabaseSync>();
+const ensuredTombstoneDatabases = new WeakSet<DatabaseSync>();
+
+function openMemoryOriginDatabase(agentId: string): DatabaseSync {
+  const db = openOpenClawAgentDatabase({ agentId }).db;
+  if (!ensuredDatabases.has(db)) {
+    db.exec(`CREATE TABLE IF NOT EXISTS memory_entry_origins (
+      entry_key TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      session_key TEXT,
+      origin_class TEXT NOT NULL CHECK (origin_class IN ('owner', 'agent', 'untrusted', 'system')),
+      observed_at INTEGER NOT NULL,
+      PRIMARY KEY (entry_key, agent_id, session_id)
+    ) STRICT`);
+    ensuredDatabases.add(db);
+  }
+  return db;
+}
+
+function hasMemoryTable(db: DatabaseSync, tableName: string): boolean {
+  const schema = getNodeSqliteKysely<SqliteSchemaDatabase>(db);
+  return (
+    executeSqliteQuerySync(
+      db,
+      schema
+        .selectFrom("sqlite_schema")
+        .select("name")
+        .where("type", "=", "table")
+        .where("name", "=", tableName),
+    ).rows.length > 0
+  );
+}
+
+function originRow(origin: MemoryEntryOrigin): MemoryEntryOriginRow {
+  return {
+    entry_key: origin.entryKey,
+    agent_id: origin.agentId,
+    session_id: origin.sessionId,
+    session_key: origin.sessionKey,
+    origin_class: origin.originClass,
+    observed_at: origin.observedAt,
+  };
+}
+
+function readOrigin(row: MemoryEntryOriginRow): MemoryEntryOrigin {
+  return {
+    entryKey: row.entry_key,
+    agentId: row.agent_id,
+    sessionId: row.session_id,
+    sessionKey: row.session_key,
+    originClass: row.origin_class,
+    observedAt: row.observed_at,
+  };
+}
+
+export function listMemoryEntryOrigins(params: {
+  agentId: string;
+  sessionIds?: readonly string[];
+  entryKeys?: readonly string[];
+}): MemoryEntryOrigin[] {
+  if (params.sessionIds?.length === 0 || params.entryKeys?.length === 0) {
+    return [];
+  }
+  const result = withOpenClawAgentDatabaseReadOnly(({ db }) => {
+    if (!ensuredDatabases.has(db) && !hasMemoryTable(db, "memory_entry_origins")) {
+      return [];
+    }
+    const kysely = getNodeSqliteKysely<MemoryOriginDatabase>(db);
+    let query = kysely
+      .selectFrom("memory_entry_origins")
+      .selectAll()
+      .where("agent_id", "=", params.agentId);
+    if (params.sessionIds) {
+      query = query.where("session_id", "in", params.sessionIds);
+    }
+    if (params.entryKeys) {
+      query = query.where("entry_key", "in", params.entryKeys);
+    }
+    return executeSqliteQuerySync(
+      db,
+      query.orderBy("entry_key", "asc").orderBy("session_id", "asc"),
+    ).rows.map(readOrigin);
+  }, params);
+  return result.found ? result.value : [];
+}
+
+export function listMemorySessionTombstones(params: {
+  agentId: string;
+  sessionIds?: readonly string[];
+}): MemorySessionTombstone[] {
+  if (params.sessionIds?.length === 0) {
+    return [];
+  }
+  const result = withOpenClawAgentDatabaseReadOnly(({ db }) => {
+    if (!ensuredTombstoneDatabases.has(db) && !hasMemoryTable(db, "memory_session_tombstones")) {
+      return [];
+    }
+    const kysely = getNodeSqliteKysely<MemoryOriginDatabase>(db);
+    let query = kysely
+      .selectFrom("memory_session_tombstones")
+      .selectAll()
+      .where("agent_id", "=", params.agentId);
+    if (params.sessionIds) {
+      query = query.where("session_id", "in", params.sessionIds);
+    }
+    return executeSqliteQuerySync(db, query.orderBy("session_id", "asc")).rows.map((row) => ({
+      sessionId: row.session_id,
+      agentId: row.agent_id,
+      reason: row.reason,
+      createdAt: row.created_at,
+    }));
+  }, params);
+  return result.found ? result.value : [];
+}
+
+export function recordMemorySessionTombstones(params: {
+  agentId: string;
+  sessionIds: readonly string[];
+  reason?: string;
+  createdAt?: number;
+}): number {
+  const sessionIds = [...new Set(params.sessionIds)];
+  if (sessionIds.length === 0) {
+    return 0;
+  }
+  const db = openOpenClawAgentDatabase({ agentId: params.agentId }).db;
+  if (!ensuredTombstoneDatabases.has(db)) {
+    db.exec(`CREATE TABLE IF NOT EXISTS memory_session_tombstones (
+      session_id TEXT NOT NULL PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    ) STRICT`);
+    ensuredTombstoneDatabases.add(db);
+  }
+  const reason = params.reason ?? "forgotten";
+  const createdAt = params.createdAt ?? Date.now();
+  return runSqliteImmediateTransactionSync(db, () => {
+    const kysely = getNodeSqliteKysely<MemoryOriginDatabase>(db);
+    let recorded = 0;
+    for (const sessionId of sessionIds) {
+      const result = executeSqliteQuerySync(
+        db,
+        kysely
+          .insertInto("memory_session_tombstones")
+          .values({
+            session_id: sessionId,
+            agent_id: params.agentId,
+            reason,
+            created_at: createdAt,
+          })
+          .onConflict((conflict) => conflict.column("session_id").doNothing()),
+      );
+      recorded += Number(result.numAffectedRows ?? 0n);
+    }
+    return recorded;
+  });
+}
+
+export function recordMemoryEntryOrigins(params: {
+  agentId: string;
+  origins: readonly MemoryEntryOrigin[];
+}): void {
+  if (params.origins.length === 0) {
+    return;
+  }
+  const db = openMemoryOriginDatabase(params.agentId);
+  runSqliteImmediateTransactionSync(db, () => {
+    const kysely = getNodeSqliteKysely<MemoryOriginDatabase>(db);
+    for (const origin of params.origins) {
+      if (origin.agentId !== params.agentId) {
+        throw new Error("memory entry origin belongs to another agent");
+      }
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .insertInto("memory_entry_origins")
+          .values(originRow(origin))
+          .onConflict((conflict) =>
+            conflict.columns(["entry_key", "agent_id", "session_id"]).doNothing(),
+          ),
+      );
+    }
+  });
+}
+
+export function deleteMemoryEntryOrigins(params: {
+  agentId: string;
+  entryKeys: readonly string[];
+}): number {
+  if (params.entryKeys.length === 0) {
+    return 0;
+  }
+  const db = openMemoryOriginDatabase(params.agentId);
+  return runSqliteImmediateTransactionSync(db, () => {
+    const kysely = getNodeSqliteKysely<MemoryOriginDatabase>(db);
+    const result = executeSqliteQuerySync(
+      db,
+      kysely
+        .deleteFrom("memory_entry_origins")
+        .where("agent_id", "=", params.agentId)
+        .where("entry_key", "in", params.entryKeys),
+    );
+    return Number(result.numAffectedRows ?? 0n);
+  });
+}
+
+export function reconcileMemoryEntryOrigins(params: {
+  agentId: string;
+  previousMemory: string;
+  currentMemory: string;
+  operations: readonly {
+    candidateKey: string;
+    action: "added" | "merged" | "superseded";
+    priorEntries: readonly string[];
+  }[];
+}): void {
+  if (params.operations.length === 0) {
+    return;
+  }
+  const previousLines = params.previousMemory.replace(/\r\n/gu, "\n").split("\n");
+  const promotionKeys = (content: string) =>
+    [...content.matchAll(/<!--\s*openclaw-memory-promotion:([^\n]*?)\s*-->/giu)]
+      .map((match) => match[1]?.trim())
+      .filter((key): key is string => Boolean(key));
+  const liveKeys = new Set(promotionKeys(params.currentMemory));
+  const db = openMemoryOriginDatabase(params.agentId);
+  runSqliteImmediateTransactionSync(db, () => {
+    const kysely = getNodeSqliteKysely<MemoryOriginDatabase>(db);
+    for (const operation of params.operations) {
+      const parentKeys = new Set([operation.candidateKey]);
+      for (const entry of operation.priorEntries) {
+        const entryIndex = previousLines.findIndex((line) => line.trim() === entry);
+        const marker = previousLines[entryIndex - 1]?.trim();
+        const parentKey = /^<!--\s*openclaw-memory-promotion:([^\n]*?)\s*-->$/u
+          .exec(marker ?? "")?.[1]
+          ?.trim();
+        if (parentKey) {
+          parentKeys.add(parentKey);
+        }
+      }
+      const rows = executeSqliteQuerySync(
+        db,
+        kysely
+          .selectFrom("memory_entry_origins")
+          .selectAll()
+          .where("agent_id", "=", params.agentId)
+          .where("entry_key", "in", [...parentKeys]),
+      ).rows;
+      for (const row of rows) {
+        executeSqliteQuerySync(
+          db,
+          kysely
+            .insertInto("memory_entry_origins")
+            .values({ ...row, entry_key: operation.candidateKey })
+            .onConflict((conflict) =>
+              conflict.columns(["entry_key", "agent_id", "session_id"]).doNothing(),
+            ),
+        );
+      }
+      const retiredKeys = [...parentKeys].filter((key) => !liveKeys.has(key));
+      if (retiredKeys.length > 0) {
+        executeSqliteQuerySync(
+          db,
+          kysely
+            .deleteFrom("memory_entry_origins")
+            .where("agent_id", "=", params.agentId)
+            .where("entry_key", "in", retiredKeys),
+        );
+      }
+    }
+    const retiredKeys = promotionKeys(params.previousMemory).filter((key) => !liveKeys.has(key));
+    if (retiredKeys.length > 0) {
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .deleteFrom("memory_entry_origins")
+          .where("agent_id", "=", params.agentId)
+          .where("entry_key", "in", retiredKeys),
+      );
+    }
+  });
+}

--- a/extensions/memory-core/src/memory-entry-origins.ts
+++ b/extensions/memory-core/src/memory-entry-origins.ts
@@ -255,7 +255,7 @@ export function deleteMemoryEntryOrigins(params: {
 }
 
 export function reconcileMemoryEntryOrigins(params: {
-  agentId: string;
+  agentIds: readonly string[];
   previousMemory: string;
   currentMemory: string;
   operations: readonly {
@@ -273,60 +273,61 @@ export function reconcileMemoryEntryOrigins(params: {
       .map((match) => match[1]?.trim())
       .filter((key): key is string => Boolean(key));
   const liveKeys = new Set(promotionKeys(params.currentMemory));
-  const db = openMemoryOriginDatabase(params.agentId);
-  runSqliteImmediateTransactionSync(db, () => {
-    const kysely = getNodeSqliteKysely<MemoryOriginDatabase>(db);
-    for (const operation of params.operations) {
-      const parentKeys = new Set([operation.candidateKey]);
-      for (const entry of operation.priorEntries) {
-        const entryIndex = previousLines.findIndex((line) => line.trim() === entry);
-        const marker = previousLines[entryIndex - 1]?.trim();
-        const parentKey = /^<!--\s*openclaw-memory-promotion:([^\n]*?)\s*-->$/u
-          .exec(marker ?? "")?.[1]
-          ?.trim();
-        if (parentKey) {
-          parentKeys.add(parentKey);
-        }
+  const operationParents = params.operations.map((operation) => {
+    const parentKeys = new Set([operation.candidateKey]);
+    for (const entry of operation.priorEntries) {
+      const entryIndex = previousLines.findIndex((line) => line.trim() === entry);
+      const marker = previousLines[entryIndex - 1]?.trim();
+      const parentKey = /^<!--\s*openclaw-memory-promotion:([^\n]*?)\s*-->$/u
+        .exec(marker ?? "")?.[1]
+        ?.trim();
+      if (parentKey) {
+        parentKeys.add(parentKey);
       }
-      const rows = executeSqliteQuerySync(
-        db,
-        kysely
-          .selectFrom("memory_entry_origins")
-          .selectAll()
-          .where("agent_id", "=", params.agentId)
-          .where("entry_key", "in", [...parentKeys]),
-      ).rows;
-      for (const row of rows) {
-        executeSqliteQuerySync(
+    }
+    return { operation, parentKeys: [...parentKeys] };
+  });
+  const retiredKeys = promotionKeys(params.previousMemory).filter((key) => !liveKeys.has(key));
+  const affectedKeys = [
+    ...new Set([...retiredKeys, ...operationParents.flatMap(({ parentKeys }) => parentKeys)]),
+  ];
+  for (const agentId of [...new Set(params.agentIds)].toSorted()) {
+    if (listMemoryEntryOrigins({ agentId, entryKeys: affectedKeys }).length === 0) {
+      continue;
+    }
+    const db = openMemoryOriginDatabase(agentId);
+    runSqliteImmediateTransactionSync(db, () => {
+      const kysely = getNodeSqliteKysely<MemoryOriginDatabase>(db);
+      for (const { operation, parentKeys } of operationParents) {
+        const rows = executeSqliteQuerySync(
           db,
           kysely
-            .insertInto("memory_entry_origins")
-            .values({ ...row, entry_key: operation.candidateKey })
-            .onConflict((conflict) =>
-              conflict.columns(["entry_key", "agent_id", "session_id"]).doNothing(),
-            ),
-        );
+            .selectFrom("memory_entry_origins")
+            .selectAll()
+            .where("agent_id", "=", agentId)
+            .where("entry_key", "in", parentKeys),
+        ).rows;
+        for (const row of rows) {
+          executeSqliteQuerySync(
+            db,
+            kysely
+              .insertInto("memory_entry_origins")
+              .values({ ...row, entry_key: operation.candidateKey })
+              .onConflict((conflict) =>
+                conflict.columns(["entry_key", "agent_id", "session_id"]).doNothing(),
+              ),
+          );
+        }
       }
-      const retiredKeys = [...parentKeys].filter((key) => !liveKeys.has(key));
       if (retiredKeys.length > 0) {
         executeSqliteQuerySync(
           db,
           kysely
             .deleteFrom("memory_entry_origins")
-            .where("agent_id", "=", params.agentId)
+            .where("agent_id", "=", agentId)
             .where("entry_key", "in", retiredKeys),
         );
       }
-    }
-    const retiredKeys = promotionKeys(params.previousMemory).filter((key) => !liveKeys.has(key));
-    if (retiredKeys.length > 0) {
-      executeSqliteQuerySync(
-        db,
-        kysely
-          .deleteFrom("memory_entry_origins")
-          .where("agent_id", "=", params.agentId)
-          .where("entry_key", "in", retiredKeys),
-      );
-    }
-  });
+    });
+  }
 }

--- a/extensions/memory-core/src/memory-forget-curated-writes.ts
+++ b/extensions/memory-core/src/memory-forget-curated-writes.ts
@@ -1,0 +1,77 @@
+import path from "node:path";
+import { isPathInside } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export function collectTranscriptWrites(params: {
+  message: unknown;
+  observedAt: number;
+  workspaceDir: string;
+  writes: Map<string, { relativePath: string; observedAt: number }>;
+}): void {
+  const message = asNullableRecord(params.message);
+  if (message?.role !== "assistant" || !Array.isArray(message.content)) {
+    return;
+  }
+  for (const item of message.content) {
+    const call = asNullableRecord(item);
+    if (
+      !call ||
+      (call.type !== "toolCall" && call.type !== "tool_call" && call.type !== "tool_use") ||
+      (call.name !== "apply_patch" && call.name !== "write" && call.name !== "edit")
+    ) {
+      continue;
+    }
+    let rawArguments = call.arguments ?? call.input;
+    if (typeof rawArguments === "string") {
+      try {
+        rawArguments = JSON.parse(rawArguments) as unknown;
+      } catch {
+        rawArguments = call.name === "apply_patch" ? { input: rawArguments } : undefined;
+      }
+    }
+    const args = asNullableRecord(rawArguments);
+    if (!args) {
+      continue;
+    }
+    const candidates = [args.path, args.file_path, args.filePath];
+    if (call.name === "apply_patch") {
+      const input = typeof args.input === "string" ? args.input : args.patch;
+      if (typeof input === "string") {
+        for (const match of input.matchAll(
+          /^\*\*\* (?:(?:Add|Update|Delete) File|Move to): (.+)$/gmu,
+        )) {
+          candidates.push(match[1]);
+        }
+      }
+      if (Array.isArray(args.changes)) {
+        for (const change of args.changes) {
+          const entry = asNullableRecord(change);
+          if (entry) {
+            candidates.push(entry.path, asNullableRecord(entry.kind)?.move_path);
+          }
+        }
+      } else {
+        candidates.push(...Object.keys(asNullableRecord(args.changes) ?? {}));
+      }
+    }
+    const cwd = typeof args.cwd === "string" ? args.cwd : params.workspaceDir;
+    for (const candidate of candidates) {
+      if (typeof candidate !== "string" || !candidate.trim()) {
+        continue;
+      }
+      const absolutePath = path.resolve(params.workspaceDir, cwd, candidate);
+      if (!isPathInside(params.workspaceDir, absolutePath)) {
+        continue;
+      }
+      const relativePath = path.relative(params.workspaceDir, absolutePath).replaceAll("\\", "/");
+      if (
+        (relativePath === "MEMORY.md" ||
+          relativePath === "USER.md" ||
+          relativePath.startsWith("memory/")) &&
+        !params.writes.has(relativePath)
+      ) {
+        params.writes.set(relativePath, { relativePath, observedAt: params.observedAt });
+      }
+    }
+  }
+}

--- a/extensions/memory-core/src/memory-forget.test.ts
+++ b/extensions/memory-core/src/memory-forget.test.ts
@@ -32,6 +32,7 @@ import {
 import { forgetMemoryEntries } from "./memory-forget.js";
 import { closeMemoryDatabase, openMemoryDatabaseAtPath } from "./memory/manager-db.js";
 import { readSessionIngestionState, writeSessionIngestionState } from "./session-ingestion.js";
+import { buildPromotionRecallAnnotations } from "./short-term-promotion-metadata.js";
 import {
   applyShortTermPromotions,
   rankShortTermPromotionCandidates,
@@ -236,6 +237,143 @@ describe("memory forget", () => {
     }
     expect(listMemorySessionTombstones({ agentId: "main" })).toEqual([]);
   });
+
+  it.each(["merged", "superseded"] as const)(
+    "preserves another workspace agent's deletion lineage when an entry is %s",
+    async (action) => {
+      cfg = {
+        agents: {
+          defaults: { workspace: workspaceDir },
+          list: [
+            { id: "alpha", default: true, workspace: workspaceDir },
+            { id: "gamma", workspace: workspaceDir },
+            { id: "vacant", workspace: workspaceDir },
+          ],
+        },
+      } as OpenClawConfig;
+      await upsertSessionEntry({
+        agentId: "gamma",
+        sessionKey: "agent:gamma:private-session",
+        entry: { sessionId: "private-session", updatedAt: 1_000 },
+      });
+      const priorEntry = "- The launch code is violet.";
+      const snippet =
+        action === "merged" ? "The launch code is violet." : "The launch code is cobalt.";
+      const memoryPath = path.join(workspaceDir, "MEMORY.md");
+      await fs.writeFile(
+        memoryPath,
+        [
+          "# Long-Term Memory",
+          ...(action === "superseded" ? ["<!-- openclaw-memory-lineage:launch-code -->"] : []),
+          "<!-- openclaw-memory-promotion:retired-entry -->",
+          priorEntry,
+          "",
+        ].join("\n"),
+      );
+      const notePath = path.join(workspaceDir, "memory", "2026-08-26.md");
+      await fs.mkdir(path.dirname(notePath), { recursive: true });
+      await fs.writeFile(notePath, `${snippet}\n`);
+      recordMemoryEntryOrigins({
+        agentId: "gamma",
+        origins: [
+          {
+            entryKey: "retired-entry",
+            agentId: "gamma",
+            sessionId: "private-session",
+            sessionKey: "agent:gamma:private-session",
+            originClass: "owner",
+            observedAt: 1_000,
+          },
+        ],
+      });
+      const vacantDb = openOpenClawAgentDatabase({ agentId: "vacant" }).db;
+      vacantDb.exec("DROP TABLE IF EXISTS memory_entry_origins");
+      const nowMs = Date.parse("2026-08-26T12:00:00.000Z");
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "launch code",
+        signalType: "daily",
+        nowMs,
+        results: [
+          {
+            path: "memory/2026-08-26.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.9,
+            snippet,
+            source: "memory",
+            provenance: {
+              originClass: "owner",
+              sessionKind: "interactive",
+              observedAt: nowMs,
+              ...(action === "superseded" ? { supersedesKey: "launch-code" } : {}),
+            },
+            sessionOrigin: {
+              agentId: "alpha",
+              sessionId: "alpha-session",
+              sessionKey: "agent:alpha:alpha-session",
+            },
+          },
+        ],
+      });
+      const thresholds = { minScore: 0, minRecallCount: 0, minUniqueQueries: 0 };
+      const candidates = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        nowMs,
+        ...thresholds,
+      });
+      const promoted = candidates[0];
+      expect(promoted).toBeDefined();
+      const resultEntry = `- ${promoted!.snippet} Source: ${promoted!.path}#L1-L1 ${buildPromotionRecallAnnotations(promoted!)}`;
+      const output = JSON.stringify({
+        memory: `# Long-Term Memory\n${resultEntry}\n`,
+        operations: [
+          { candidateKey: promoted!.key, action, resultEntry, priorEntries: [priorEntry] },
+        ],
+      });
+      const subagent = {
+        run: vi.fn(async () => ({ runId: "shared-consolidation" })),
+        waitForRun: vi.fn(async () => ({ status: "ok" })),
+        getSessionMessages: vi.fn(async () => ({
+          messages: [{ role: "assistant", content: output }],
+        })),
+        deleteSession: vi.fn(async () => undefined),
+      };
+
+      const applied = await applyShortTermPromotions({
+        agentId: "alpha",
+        workspaceAgentIds: ["vacant", "gamma", "alpha", "gamma"],
+        workspaceDir,
+        candidates,
+        consolidation: { subagent, logger: { info: vi.fn(), warn: vi.fn() } },
+        maxPriorEntryLossFraction: 1,
+        nowMs,
+        ...thresholds,
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(listMemoryEntryOrigins({ agentId: "gamma" })).toMatchObject([
+        { entryKey: promoted!.key, sessionId: "private-session" },
+      ]);
+      expect(
+        vacantDb
+          .prepare("SELECT name FROM sqlite_schema WHERE name = 'memory_entry_origins'")
+          .get(),
+      ).toBeUndefined();
+
+      const report = await forgetMemoryEntries({
+        cfg,
+        agentId: "gamma",
+        sessionIds: ["private-session"],
+      });
+      expect(report).toMatchObject({
+        entryKeys: [promoted!.key],
+        artifacts: { memoryEntries: 1, originRows: 1 },
+      });
+      expect(await fs.readFile(memoryPath, "utf8")).not.toContain(snippet);
+      expect(listMemoryEntryOrigins({ agentId: "gamma" })).toEqual([]);
+    },
+  );
 
   it("removes a marker-addressable plain-append promotion after budget compaction", async () => {
     await seedSession("target");

--- a/extensions/memory-core/src/memory-forget.test.ts
+++ b/extensions/memory-core/src/memory-forget.test.ts
@@ -10,7 +10,7 @@ import { listSessionTranscriptCorpusEntriesForAgent } from "openclaw/plugin-sdk/
 import { loadSqliteVecExtension } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { listMemoryArtifactProvenance } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { deleteSessionEntry, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { openOpenClawAgentDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
 import {
@@ -85,6 +85,157 @@ describe("memory forget", () => {
         .run(hookSource, sessionId);
     }
   }
+
+  it.each([
+    { label: "session ID", selector: "archived" },
+    { label: "session key", selector: "agent:main:archived" },
+  ])("purges an archived-only session selected by its $label", async ({ selector }) => {
+    await seedSession("archived");
+    recordMemoryEntryOrigins({
+      agentId: "main",
+      origins: [
+        {
+          entryKey: "archived-entry",
+          agentId: "main",
+          sessionId: "archived",
+          sessionKey: "agent:main:archived",
+          originClass: "owner",
+          observedAt: 1_000,
+        },
+      ],
+    });
+    await fs.writeFile(
+      path.join(workspaceDir, "MEMORY.md"),
+      "# Long-Term Memory\n<!-- openclaw-memory-promotion:archived-entry -->\n- Archived secret.\n",
+    );
+    await fs.writeFile(path.join(workspaceDir, "USER.md"), "# User\nKeep curated profile.\n");
+    const corpusDir = path.join(workspaceDir, "memory", ".dreams", "session-corpus");
+    await fs.mkdir(corpusDir, { recursive: true });
+    await fs.writeFile(
+      path.join(corpusDir, "archived.txt"),
+      "[main/sessions/main/archived#L1] User: An archived private fact.\n",
+    );
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: "main",
+      sessionId: "archived",
+      sessionKey: "agent:main:archived",
+      message: {
+        role: "assistant",
+        timestamp: 2_000,
+        content: [
+          { type: "toolCall", id: "curated", name: "write", arguments: { path: "USER.md" } },
+        ],
+      },
+    });
+    await expect(
+      deleteSessionEntry({
+        agentId: "main",
+        sessionKey: "agent:main:archived",
+        expectedSessionId: "archived",
+        archiveTranscript: true,
+      }),
+    ).resolves.toBe(true);
+    const db = openOpenClawAgentDatabase({ agentId: "main" }).db;
+    expect(
+      db.prepare("SELECT session_id FROM session_windows WHERE session_id = ?").get("archived"),
+    ).toBeUndefined();
+    expect(
+      db
+        .prepare(
+          "SELECT session_id, session_key FROM session_transcript_archives WHERE session_id = ?",
+        )
+        .get("archived"),
+    ).toEqual({ session_id: "archived", session_key: "agent:main:archived" });
+
+    const preview = await forgetMemoryEntries({
+      cfg,
+      agentId: "main",
+      sessionIds: [selector],
+      dryRun: true,
+    });
+    expect(preview).toMatchObject({
+      sessionIds: ["archived"],
+      sessionResolutions: [
+        { sessionId: "archived", sessionKey: "agent:main:archived", source: "archived" },
+      ],
+      entryKeys: ["archived-entry"],
+      curatedWrites: [{ relativePath: "USER.md", observedAt: expect.any(Number) }],
+      artifacts: { memoryEntries: 1, sessionCorpusLines: 1, originRows: 1 },
+    });
+    expect(listMemorySessionTombstones({ agentId: "main" })).toEqual([]);
+
+    const report = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: [selector] });
+    expect(report).toEqual({ ...preview, dryRun: false });
+    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).not.toContain(
+      "Archived secret",
+    );
+    expect(await fs.readFile(path.join(workspaceDir, "USER.md"), "utf8")).toContain(
+      "Keep curated profile",
+    );
+    expect(listMemoryEntryOrigins({ agentId: "main" })).toEqual([]);
+    expect(listMemorySessionTombstones({ agentId: "main" })).toMatchObject([
+      { sessionId: "archived", reason: "forgotten" },
+    ]);
+  });
+
+  it("durably tombstones an unresolved explicit session without inventing artifacts", async () => {
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# Long-Term Memory\nKeep this.\n");
+
+    const preview = await forgetMemoryEntries({
+      cfg,
+      agentId: "main",
+      sessionIds: ["unknown-session"],
+      dryRun: true,
+    });
+    expect(preview).toMatchObject({
+      sessionIds: ["unknown-session"],
+      sessionResolutions: [{ sessionId: "unknown-session", source: "unresolved" }],
+    });
+    expect(Object.values(preview.artifacts).every((count) => count === 0)).toBe(true);
+    expect(listMemorySessionTombstones({ agentId: "main" })).toEqual([]);
+
+    const report = await forgetMemoryEntries({
+      cfg,
+      agentId: "main",
+      sessionIds: ["unknown-session"],
+    });
+    expect(report).toEqual({ ...preview, dryRun: false });
+    const tombstones = listMemorySessionTombstones({ agentId: "main" });
+    expect(tombstones).toMatchObject([{ sessionId: "unknown-session", reason: "forgotten" }]);
+    expect(
+      await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["unknown-session"] }),
+    ).toEqual(report);
+    expect(listMemorySessionTombstones({ agentId: "main" })).toEqual(tombstones);
+  });
+
+  it("does not infer hook or participant facts for an archived-only session", async () => {
+    await seedSession("archived", "gmail");
+    const db = openOpenClawAgentDatabase({ agentId: "main" }).db;
+    db.prepare(
+      `INSERT INTO session_participants
+         (session_key, actor_type, actor_id, first_prompted_at, last_prompted_at)
+       VALUES (?, 'user', 'participant', 1, 1)`,
+    ).run("agent:main:archived");
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: "main",
+      sessionId: "archived",
+      sessionKey: "agent:main:archived",
+      message: { role: "user", content: "Archive this session." },
+    });
+    await deleteSessionEntry({
+      agentId: "main",
+      sessionKey: "agent:main:archived",
+      expectedSessionId: "archived",
+      archiveTranscript: true,
+    });
+
+    for (const selectors of [{ hookSources: ["gmail"] }, { participants: ["participant"] }]) {
+      const report = await forgetMemoryEntries({ cfg, agentId: "main", ...selectors });
+      expect(report.sessionIds).toEqual([]);
+      expect(report.sessionResolutions).toEqual([]);
+    }
+    expect(listMemorySessionTombstones({ agentId: "main" })).toEqual([]);
+  });
 
   it("removes a marker-addressable plain-append promotion after budget compaction", async () => {
     await seedSession("target");

--- a/extensions/memory-core/src/memory-forget.test.ts
+++ b/extensions/memory-core/src/memory-forget.test.ts
@@ -1,0 +1,735 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { zstdCompressSync } from "node:zlib";
+import { createOpenClawCodingTools } from "openclaw/plugin-sdk/agent-harness";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { listSessionTranscriptCorpusEntriesForAgent } from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
+import { loadSqliteVecExtension } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { listMemoryArtifactProvenance } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { openOpenClawAgentDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  closeOpenClawStateDatabaseForTest,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DREAMING_MEMORY_BACKUP_NAMESPACE,
+  SHORT_TERM_RECALL_NAMESPACE,
+  readMemoryCoreWorkspaceEntries,
+  writeMemoryCoreWorkspaceEntries,
+} from "./dreaming-state.js";
+import {
+  listMemoryEntryOrigins,
+  listMemorySessionTombstones,
+  recordMemoryEntryOrigins,
+} from "./memory-entry-origins.js";
+import { forgetMemoryEntries } from "./memory-forget.js";
+import { closeMemoryDatabase, openMemoryDatabaseAtPath } from "./memory/manager-db.js";
+import { readSessionIngestionState, writeSessionIngestionState } from "./session-ingestion.js";
+import {
+  applyShortTermPromotions,
+  rankShortTermPromotionCandidates,
+  recordShortTermRecalls,
+} from "./short-term-promotion.js";
+import { configureMemoryCoreDreamingStateForTests } from "./test-helpers.js";
+
+describe("memory forget", () => {
+  let stateDir: string;
+  let workspaceDir: string;
+  let cfg: OpenClawConfig;
+  let vectorDatabase: DatabaseSync | undefined;
+
+  beforeEach(async () => {
+    stateDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-forget-")),
+    );
+    workspaceDir = path.join(stateDir, "workspace");
+    await fs.mkdir(workspaceDir);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    await configureMemoryCoreDreamingStateForTests();
+    cfg = {
+      agents: { defaults: { workspace: workspaceDir }, list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+  });
+
+  afterEach(async () => {
+    if (vectorDatabase) {
+      closeMemoryDatabase(vectorDatabase);
+      vectorDatabase = undefined;
+    }
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    resetPluginStateStoreForTests();
+    vi.unstubAllEnvs();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  async function seedSession(sessionId: string, hookSource?: "gmail" | "webhook"): Promise<void> {
+    const sessionKey = `agent:main:${sessionId}`;
+    await upsertSessionEntry({
+      agentId: "main",
+      sessionKey,
+      entry: { sessionId, updatedAt: 1_000 },
+    });
+    if (hookSource) {
+      openOpenClawAgentDatabase({ agentId: "main" })
+        .db.prepare(
+          "UPDATE session_windows SET hook_external_content_source = ? WHERE session_id = ?",
+        )
+        .run(hookSource, sessionId);
+    }
+  }
+
+  it("removes a marker-addressable plain-append promotion after budget compaction", async () => {
+    await seedSession("target");
+    const nowMs = Date.parse("2026-08-25T12:00:00.000Z");
+    const snippet = "The undisclosed launch code is cobalt.";
+    const sourcePath = "memory/2026-08-25.md";
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, sourcePath), `${snippet}\n`);
+    await fs.writeFile(
+      path.join(workspaceDir, "MEMORY.md"),
+      [
+        "# Long-Term Memory",
+        "Curated operator fact.",
+        "",
+        "## Promoted From Short-Term Memory (2026-08-24)",
+        "<!-- openclaw-memory-promotion:older-entry -->",
+        `- ${"x".repeat(500)}`,
+        "",
+      ].join("\n"),
+    );
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "launch code",
+      signalType: "daily",
+      nowMs,
+      results: [
+        {
+          path: sourcePath,
+          startLine: 1,
+          endLine: 1,
+          score: 0.9,
+          snippet,
+          source: "memory",
+          provenance: { originClass: "owner", sessionKind: "interactive", observedAt: nowMs },
+          sessionOrigin: {
+            agentId: "main",
+            sessionId: "target",
+            sessionKey: "agent:main:target",
+          },
+        },
+      ],
+    });
+    const thresholds = { minScore: 0, minRecallCount: 0, minUniqueQueries: 0 };
+    const candidates = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      nowMs,
+      ...thresholds,
+    });
+    const candidateKey = candidates[0]?.key;
+    expect(candidateKey).toMatch(/^memory:claim:/);
+
+    const promoted = await applyShortTermPromotions({
+      agentId: "main",
+      workspaceDir,
+      candidates,
+      nowMs,
+      memoryFileMaxChars: 450,
+      ...thresholds,
+    });
+    expect(promoted.appended).toBe(1);
+    expect(promoted.compactedDates).toEqual(["2026-08-24"]);
+    const promotedMemory = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8");
+    expect(promotedMemory).toContain(`<!-- openclaw-memory-promotion:${candidateKey} -->`);
+    expect(promotedMemory).toContain(snippet);
+
+    const report = await forgetMemoryEntries({
+      cfg,
+      agentId: "main",
+      sessionIds: ["target"],
+    });
+
+    expect(report).toMatchObject({
+      entryKeys: [candidateKey],
+      artifacts: { memoryFiles: 1, memoryEntries: 1, shortTermEntries: 1, originRows: 1 },
+    });
+    const survivingMemory = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8");
+    expect(survivingMemory).toContain("Curated operator fact.");
+    expect(survivingMemory).not.toContain(snippet);
+    expect(survivingMemory).not.toContain(candidateKey);
+  });
+
+  it("durably purges every derived owner, archived narrative, and verbatim dream quote", async () => {
+    await seedSession("survivor");
+    await seedSession("target", "gmail");
+    recordMemoryEntryOrigins({
+      agentId: "main",
+      origins: [
+        {
+          entryKey: "mixed-entry",
+          agentId: "main",
+          sessionId: "target",
+          sessionKey: "agent:main:target",
+          originClass: "owner",
+          observedAt: 1_000,
+        },
+        {
+          entryKey: "mixed-entry",
+          agentId: "main",
+          sessionId: "survivor",
+          sessionKey: "agent:main:survivor",
+          originClass: "owner",
+          observedAt: 1_000,
+        },
+        {
+          entryKey: "clean-entry",
+          agentId: "main",
+          sessionId: "survivor",
+          sessionKey: "agent:main:survivor",
+          originClass: "owner",
+          observedAt: 1_000,
+        },
+      ],
+    });
+    const memoryContent = [
+      "# Long-Term Memory",
+      "Curated operator fact.",
+      "<!-- openclaw-memory-lineage:old-lineage -->",
+      "<!-- openclaw-memory-promotion:mixed-entry -->",
+      "- Erase the mixed secret.",
+      "<!-- openclaw-memory-promotion:clean-entry -->",
+      "- Keep the clean fact.",
+      "<!-- openclaw-memory-promotion:legacy-entry -->",
+      "- Preserve an untargetable legacy fact.",
+      "",
+    ].join("\n");
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memoryContent);
+    await fs.writeFile(path.join(workspaceDir, "USER.md"), "# User\nCurated private profile.\n");
+    const sourceSnippet = "User: Please remember violet-mongoose-42.";
+    const assistantSnippet = "Assistant: The launch code is violet-mongoose-42.";
+    const lightDiaryPath = path.join(workspaceDir, "memory", "dreaming", "light", "2026-08-26.md");
+    const rootDiaryPath = path.join(workspaceDir, "DREAMS.md");
+    await fs.mkdir(path.dirname(lightDiaryPath), { recursive: true });
+    await fs.writeFile(
+      lightDiaryPath,
+      `# Light Dream\n- Candidate: ${sourceSnippet}\n- Candidate: Keep an unrelated memory.\n`,
+    );
+    await fs.writeFile(rootDiaryPath, `# Dream Diary\n- Candidate: ${assistantSnippet}\n`);
+    const corpusDir = path.join(workspaceDir, "memory", ".dreams", "session-corpus");
+    await fs.mkdir(corpusDir, { recursive: true });
+    const mixedCorpusPath = path.join(corpusDir, "2026-08-25.txt");
+    const removedCorpusPath = path.join(corpusDir, "2026-08-26.txt");
+    await fs.writeFile(
+      mixedCorpusPath,
+      `[main/sessions/main/target#L1] ${sourceSnippet}\n[main/sessions/main/survivor#L1] keep\n`,
+    );
+    await fs.writeFile(removedCorpusPath, `[main/sessions/main/target#L2] ${assistantSnippet}\n`);
+    await writeMemoryCoreWorkspaceEntries({
+      namespace: SHORT_TERM_RECALL_NAMESPACE,
+      workspaceDir,
+      entries: [
+        {
+          key: "mixed-entry",
+          value: { key: "mixed-entry", path: "memory/source.md", snippet: "erase" },
+        },
+        {
+          key: "clean-entry",
+          value: { key: "clean-entry", path: "memory/source.md", snippet: "keep" },
+        },
+      ],
+    });
+    await writeSessionIngestionState(workspaceDir, {
+      version: 3,
+      files: {
+        "main:sessions/main/target": {
+          mtimeMs: 1,
+          size: 1,
+          contentHash: "hash",
+          lineCount: 1,
+          lastContentLine: 1,
+        },
+      },
+      seenMessages: {
+        "main:sessions/main/target": ["target-hash"],
+        "main:sessions/main/survivor": ["survivor-hash"],
+      },
+    });
+    await writeMemoryCoreWorkspaceEntries({
+      namespace: DREAMING_MEMORY_BACKUP_NAMESPACE,
+      workspaceDir,
+      entries: [
+        {
+          key: "backup",
+          value: {
+            createdAt: "2026-08-25T00:00:00.000Z",
+            content: `${memoryContent}- Candidate: ${sourceSnippet}\n`,
+            contentHash: createHash("sha256")
+              .update(`${memoryContent}- Candidate: ${sourceSnippet}\n`)
+              .digest("hex"),
+          },
+        },
+      ],
+    });
+
+    const agentDatabase = openOpenClawAgentDatabase({ agentId: "main" });
+    const db = openMemoryDatabaseAtPath(agentDatabase.path, true, "main");
+    vectorDatabase = db;
+    const loaded = await loadSqliteVecExtension({ db });
+    expect(loaded.ok).toBe(true);
+    db.exec(`
+      CREATE VIRTUAL TABLE memory_index_chunks_fts USING fts5(
+        text, id UNINDEXED, path UNINDEXED, source UNINDEXED,
+        model UNINDEXED, start_line UNINDEXED, end_line UNINDEXED
+      );
+      CREATE VIRTUAL TABLE memory_index_chunks_vec USING vec0(
+        id TEXT PRIMARY KEY, embedding FLOAT[2]
+      );
+    `);
+    const transcriptPath = path.join(stateDir, "agents", "main", "sessions", "target.jsonl");
+    await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+    await fs.writeFile(transcriptPath, "source transcript survives deletion\n");
+    const narrativeSessionId = "3cb3f634-6821-4123-8123-abcdef123456";
+    const narrativeArchiveName = `${narrativeSessionId}.jsonl.deleted.2026-08-26T10-00-00.000Z.zst`;
+    const narrativeArchivePath = path.join(path.dirname(transcriptPath), narrativeArchiveName);
+    const narrativeTranscript = [
+      {
+        type: "message",
+        message: { role: "user", content: `Write a dream diary entry: ${sourceSnippet}` },
+      },
+      {
+        type: "session",
+        sessionKey: "agent:main:dreaming-narrative-memory-core-v2-light-orphan",
+      },
+    ];
+    await fs.writeFile(
+      narrativeArchivePath,
+      zstdCompressSync(
+        `${narrativeTranscript.map((record) => JSON.stringify(record)).join("\n")}\n`,
+      ),
+    );
+    expect(
+      db
+        .prepare("SELECT session_id FROM session_windows WHERE session_id = ?")
+        .get(narrativeSessionId),
+    ).toBeUndefined();
+    const indexedFiles = [
+      { path: "MEMORY.md", source: "memory", originClass: "owner" },
+      {
+        path: "memory/.dreams/session-corpus/2026-08-26.txt",
+        source: "memory",
+        originClass: "owner",
+      },
+      { path: "sessions/main/target", source: "sessions", originClass: "owner" },
+      {
+        path: `sessions/main/${narrativeArchiveName}`,
+        source: "sessions",
+        originClass: "owner",
+        sessionKind: "unknown",
+        text: "violet",
+      },
+      {
+        path: "sessions/main/survivor.jsonl.deleted-2026-08-25.zst",
+        source: "sessions",
+        originClass: "owner",
+      },
+    ];
+    for (const [index, file] of indexedFiles.entries()) {
+      const chunkId = `chunk-${index}`;
+      const hash = `hash-${index}`;
+      const text = file.text ?? "erase";
+      db.prepare(
+        `INSERT INTO memory_index_chunks (
+          id, path, source, start_line, end_line, hash, model, text, embedding, updated_at
+        ) VALUES (?, ?, ?, 1, 1, ?, 'test', ?, '[1,0]', 1)`,
+      ).run(chunkId, file.path, file.source, hash, text);
+      db.prepare(
+        "INSERT INTO memory_index_sources (path, source, hash, mtime, size) VALUES (?, ?, ?, 1, 1)",
+      ).run(file.path, file.source, hash);
+      db.prepare(
+        `INSERT INTO memory_index_chunks_fts
+          (text, id, path, source, model, start_line, end_line)
+         VALUES (?, ?, ?, ?, 'test', 1, 1)`,
+      ).run(text, chunkId, file.path, file.source);
+      db.prepare("INSERT INTO memory_index_chunks_vec (id, embedding) VALUES (?, ?)").run(
+        chunkId,
+        new Float32Array([1, 0]),
+      );
+      db.prepare(
+        `INSERT INTO memory_embedding_cache
+          (provider, model, provider_key, hash, embedding, dims, updated_at)
+         VALUES ('test', 'test', 'test', ?, '[1,0]', 2, 1)`,
+      ).run(hash);
+      db.prepare(
+        `INSERT INTO memory_index_chunk_provenance
+          (chunk_id, origin_class, session_kind, observed_at)
+         VALUES (?, ?, ?, 1)`,
+      ).run(chunkId, file.originClass, file.sessionKind ?? "interactive");
+    }
+    db.exec("DROP TABLE IF EXISTS memory_session_tombstones");
+    const revisionBefore = (
+      db.prepare("SELECT revision FROM memory_index_state WHERE id = 1").get() as {
+        revision: number;
+      }
+    ).revision;
+
+    const preview = await forgetMemoryEntries({
+      cfg,
+      agentId: "main",
+      hookSources: ["gmail"],
+      dryRun: true,
+    });
+    expect(preview).toMatchObject({
+      dryRun: true,
+      sessionIds: ["target"],
+      entryKeys: ["mixed-entry"],
+      mixedLineageEntryKeys: ["mixed-entry"],
+      untargetableEntryKeys: ["legacy-entry"],
+      artifacts: {
+        memoryFiles: 3,
+        memoryEntries: 1,
+        memoryLines: 2,
+        sessionCorpusFiles: 2,
+        sessionCorpusLines: 2,
+        indexChunks: 4,
+        indexSources: 3,
+        ftsRows: 4,
+        vectorRows: 4,
+        embeddingCacheRows: 4,
+        shortTermEntries: 1,
+        seenHashScopes: 1,
+        backups: 1,
+        originRows: 2,
+      },
+    });
+    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(memoryContent);
+    expect(
+      db
+        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
+        .get("memory_session_tombstones"),
+    ).toBeUndefined();
+    expect(
+      (
+        db.prepare("SELECT revision FROM memory_index_state WHERE id = 1").get() as {
+          revision: number;
+        }
+      ).revision,
+    ).toBe(revisionBefore);
+
+    const report = await forgetMemoryEntries({ cfg, agentId: "main", hookSources: ["gmail"] });
+    expect(report).toEqual({ ...preview, dryRun: false });
+    const survivingMemory = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8");
+    expect(survivingMemory).toContain("Curated operator fact.");
+    expect(survivingMemory).toContain("Keep the clean fact.");
+    expect(survivingMemory).toContain("Preserve an untargetable legacy fact.");
+    expect(survivingMemory).not.toContain("mixed secret");
+    expect(survivingMemory).not.toContain("old-lineage");
+    expect(await fs.readFile(lightDiaryPath, "utf8")).toBe(
+      "# Light Dream\n- Candidate: Keep an unrelated memory.\n",
+    );
+    expect(await fs.readFile(rootDiaryPath, "utf8")).toBe("# Dream Diary\n");
+    expect(await fs.readFile(path.join(workspaceDir, "USER.md"), "utf8")).toContain("Curated");
+    expect(await fs.readFile(mixedCorpusPath, "utf8")).toBe(
+      "[main/sessions/main/survivor#L1] keep\n",
+    );
+    await expect(fs.stat(removedCorpusPath)).rejects.toMatchObject({ code: "ENOENT" });
+    for (const table of [
+      "memory_index_chunks",
+      "memory_index_chunks_fts",
+      "memory_index_chunks_vec",
+      "memory_index_chunk_provenance",
+      "memory_embedding_cache",
+    ]) {
+      expect(
+        (db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as { count: number }).count,
+      ).toBe(1);
+    }
+    expect(
+      (db.prepare("SELECT path FROM memory_index_sources").all() as Array<{ path: string }>).map(
+        (row) => row.path,
+      ),
+    ).toEqual(["MEMORY.md", "sessions/main/survivor.jsonl.deleted-2026-08-25.zst"]);
+    expect(
+      db
+        .prepare("SELECT id FROM memory_index_chunks_fts WHERE memory_index_chunks_fts MATCH ?")
+        .all("violet"),
+    ).toEqual([]);
+    expect(await fs.readFile(transcriptPath, "utf8")).toBe("source transcript survives deletion\n");
+    expect(
+      (
+        db.prepare("SELECT revision FROM memory_index_state WHERE id = 1").get() as {
+          revision: number;
+        }
+      ).revision,
+    ).toBeGreaterThan(revisionBefore);
+    expect(
+      (
+        await readMemoryCoreWorkspaceEntries({
+          namespace: SHORT_TERM_RECALL_NAMESPACE,
+          workspaceDir,
+        })
+      ).map((entry) => entry.key),
+    ).toEqual(["clean-entry"]);
+    expect((await readSessionIngestionState(workspaceDir)).seenMessages).toEqual({
+      "main:sessions/main/survivor": ["survivor-hash"],
+    });
+    const backups = await readMemoryCoreWorkspaceEntries<{
+      content: string;
+      contentHash: string;
+    }>({ namespace: DREAMING_MEMORY_BACKUP_NAMESPACE, workspaceDir });
+    expect(backups[0]?.value.content).not.toContain("mixed secret");
+    expect(backups[0]?.value.content).not.toContain(sourceSnippet);
+    expect(backups[0]?.value.contentHash).toBe(
+      createHash("sha256").update(backups[0]!.value.content).digest("hex"),
+    );
+    expect(listMemoryEntryOrigins({ agentId: "main" }).map((origin) => origin.entryKey)).toEqual([
+      "clean-entry",
+    ]);
+    const tombstones = listMemorySessionTombstones({ agentId: "main" });
+    expect(tombstones).toEqual([
+      {
+        agentId: "main",
+        sessionId: "target",
+        reason: "forgotten",
+        createdAt: expect.any(Number),
+      },
+    ]);
+
+    const repeated = await forgetMemoryEntries({ cfg, agentId: "main", hookSources: ["gmail"] });
+    expect(repeated.sessionIds).toEqual(["target"]);
+    expect(Object.values(repeated.artifacts).every((count) => count === 0)).toBe(true);
+    expect(listMemorySessionTombstones({ agentId: "main" })).toEqual(tombstones);
+  });
+
+  it("reports session-authored curated memory without deleting unattributable file content", async () => {
+    await seedSession("target");
+    const curatedContent = "# Long-Term Memory\nThe launch code is violet.\n";
+    const writeTool = createOpenClawCodingTools({
+      workspaceDir,
+      config: cfg,
+      sessionId: "target",
+      sessionKey: "agent:main:target",
+      senderIsOwner: true,
+    }).find((tool) => tool.name === "write");
+    expect(writeTool).toBeDefined();
+    await writeTool!.execute("write-curated-memory", {
+      path: "MEMORY.md",
+      content: curatedContent,
+    });
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: "main",
+      sessionId: "target",
+      sessionKey: "agent:main:target",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "observed-write",
+            name: "write",
+            arguments: { path: "MEMORY.md" },
+          },
+        ],
+      },
+    });
+
+    const preview = await forgetMemoryEntries({
+      cfg,
+      agentId: "main",
+      sessionIds: ["target"],
+      dryRun: true,
+    });
+    expect(preview.curatedWrites).toEqual([
+      { relativePath: "MEMORY.md", observedAt: expect.any(Number) },
+    ]);
+    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(curatedContent);
+
+    const report = await forgetMemoryEntries({
+      cfg,
+      agentId: "main",
+      sessionIds: ["target"],
+    });
+    expect(report).toEqual({ ...preview, dryRun: false });
+    expect(report.artifacts.memoryFiles).toBe(0);
+    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(curatedContent);
+  });
+
+  it("reports harness memory writes from selected live and archived transcripts without observer state", async () => {
+    await seedSession("survivor");
+    await seedSession("target");
+    const observedAt = Date.parse("2026-08-26T12:34:56.000Z");
+    const memoryContent = "# Long-Term Memory\nA harness-authored private fact.\n";
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memoryContent);
+    await fs.writeFile(path.join(workspaceDir, "USER.md"), "# User\n");
+    await fs.writeFile(path.join(workspaceDir, "memory", "profile.md"), "# Profile\n");
+    const patchInput = [
+      "*** Begin Patch",
+      "*** Update File: MEMORY.md",
+      "@@",
+      "+A harness-authored private fact.",
+      "*** Update File: README.md",
+      "@@",
+      "+Not a memory file.",
+      "*** End Patch",
+    ].join("\n");
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: "main",
+      sessionId: "target",
+      sessionKey: "agent:main:target",
+      message: {
+        role: "assistant",
+        timestamp: observedAt,
+        content: [
+          { type: "toolCall", id: "patch", name: "apply_patch", arguments: { input: patchInput } },
+          { type: "toolCall", id: "profile", name: "write", arguments: { path: "USER.md" } },
+          {
+            type: "toolCall",
+            id: "nested",
+            name: "edit",
+            input: { file_path: path.join(workspaceDir, "memory", "profile.md") },
+          },
+          {
+            type: "toolCall",
+            id: "structured",
+            name: "apply_patch",
+            arguments: { changes: [{ path: "memory/structured.md" }, { path: "README.md" }] },
+          },
+          { type: "toolCall", id: "ordinary", name: "write", arguments: { path: "README.md" } },
+          { type: "toolCall", id: "escaping", name: "edit", arguments: { path: "../MEMORY.md" } },
+          { type: "toolCall", id: "malformed", name: "apply_patch", arguments: { input: 42 } },
+          { type: "toolCall", id: "read-only", name: "read", arguments: { path: "MEMORY.md" } },
+          { type: "toolCall", id: "missing", name: "write", arguments: null },
+          null,
+        ],
+      },
+    });
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: "main",
+      sessionId: "survivor",
+      sessionKey: "agent:main:survivor",
+      message: {
+        role: "assistant",
+        timestamp: observedAt + 1,
+        content: [
+          {
+            type: "toolCall",
+            id: "unselected",
+            name: "write",
+            arguments: { path: "memory/keep.md" },
+          },
+        ],
+      },
+    });
+    const archiveDir = path.join(stateDir, "agents", "main", "sessions");
+    await fs.mkdir(archiveDir, { recursive: true });
+    const archivedMessage = {
+      type: "message",
+      timestamp: new Date(observedAt + 1).toISOString(),
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "archived",
+            name: "edit",
+            input: { filePath: "memory/archive.md" },
+          },
+        ],
+      },
+    };
+    await fs.writeFile(
+      path.join(archiveDir, "target.jsonl.deleted.2026-08-26T12-35-00.000Z.zst"),
+      zstdCompressSync(`${JSON.stringify(archivedMessage)}\n`),
+    );
+    expect(await listSessionTranscriptCorpusEntriesForAgent("main")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sessionId: "target", artifactKind: "active-session" }),
+        expect.objectContaining({ sessionId: "target", artifactKind: "archive-artifact" }),
+      ]),
+    );
+    expect(await listMemoryArtifactProvenance({ workspaceDir })).toEqual([]);
+
+    const preview = await forgetMemoryEntries({
+      cfg,
+      agentId: "main",
+      sessionIds: ["target"],
+      dryRun: true,
+    });
+
+    expect(preview.curatedWrites).toEqual([
+      { relativePath: "MEMORY.md", observedAt },
+      { relativePath: "memory/archive.md", observedAt: observedAt + 1 },
+      { relativePath: "memory/profile.md", observedAt },
+      { relativePath: "memory/structured.md", observedAt },
+      { relativePath: "USER.md", observedAt },
+    ]);
+    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(memoryContent);
+
+    const report = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["target"] });
+    expect(report).toEqual({ ...preview, dryRun: false });
+    expect(report.artifacts.memoryFiles).toBe(0);
+    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(memoryContent);
+  });
+
+  it("keeps missing provenance untargetable without creating its table during dry-run", async () => {
+    await seedSession("target");
+    const db = openOpenClawAgentDatabase({ agentId: "main" }).db;
+    db.exec("DROP TABLE IF EXISTS memory_entry_origins");
+    db.exec("DROP TABLE IF EXISTS memory_session_tombstones");
+    const memoryContent =
+      "# Long-Term Memory\n<!-- openclaw-memory-promotion:legacy-entry -->\n- Keep old memory.\n";
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memoryContent);
+    const revision = (
+      db.prepare("SELECT revision FROM memory_index_state WHERE id = 1").get() as {
+        revision: number;
+      }
+    ).revision;
+
+    const report = await forgetMemoryEntries({
+      cfg,
+      agentId: "main",
+      sessionIds: ["target"],
+      dryRun: true,
+    });
+
+    expect(report.entryKeys).toEqual([]);
+    expect(report.untargetableEntryKeys).toEqual(["legacy-entry"]);
+    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(memoryContent);
+    expect(
+      db
+        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
+        .get("memory_entry_origins"),
+    ).toBeUndefined();
+    expect(
+      db
+        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
+        .get("memory_session_tombstones"),
+    ).toBeUndefined();
+    expect(
+      (
+        db.prepare("SELECT revision FROM memory_index_state WHERE id = 1").get() as {
+          revision: number;
+        }
+      ).revision,
+    ).toBe(revision);
+
+    const deleted = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["target"] });
+    expect(deleted.artifacts.memoryFiles).toBe(0);
+    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(memoryContent);
+    expect(listMemorySessionTombstones({ agentId: "main" })).toMatchObject([
+      { agentId: "main", sessionId: "target", reason: "forgotten" },
+    ]);
+    expect(
+      db
+        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
+        .get("memory_entry_origins"),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/memory-core/src/memory-forget.ts
+++ b/extensions/memory-core/src/memory-forget.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import {
   resolveAgentWorkspaceDir,
   type OpenClawConfig,
@@ -20,6 +19,7 @@ import { listMemoryArtifactProvenance } from "openclaw/plugin-sdk/memory-core-ho
 import {
   executeSqliteQuerySync,
   getNodeSqliteKysely,
+  openNodeSqliteDatabase,
   openOpenClawAgentDatabase,
   runSqliteImmediateTransactionSync,
   withOpenClawAgentDatabaseReadOnly,
@@ -280,7 +280,7 @@ async function planMemoryIndex(params: {
   }
   let vectorRows = 0;
   if (result.value.hasVectorTable && result.value.chunks.length > 0) {
-    const probe = new DatabaseSync(":memory:", { allowExtension: true });
+    const probe = openNodeSqliteDatabase(":memory:", { allowExtension: true });
     let extensionPath: string;
     try {
       const loaded = await loadSqliteVecExtension({ db: probe });

--- a/extensions/memory-core/src/memory-forget.ts
+++ b/extensions/memory-core/src/memory-forget.ts
@@ -1,0 +1,680 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import {
+  resolveAgentWorkspaceDir,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import {
+  buildSessionEntry,
+  listSessionTranscriptCorpusEntriesForAgent,
+  resolveMemorySessionTargets,
+} from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
+import {
+  isFileMissingError,
+  listMemoryFiles,
+  loadSqliteVecExtension,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { listMemoryArtifactProvenance } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import {
+  executeSqliteQuerySync,
+  getNodeSqliteKysely,
+  openOpenClawAgentDatabase,
+  runSqliteImmediateTransactionSync,
+  withOpenClawAgentDatabaseReadOnly,
+} from "openclaw/plugin-sdk/sqlite-runtime";
+import {
+  DREAMING_MEMORY_BACKUP_NAMESPACE,
+  SHORT_TERM_RECALL_NAMESPACE,
+  readMemoryCoreWorkspaceEntries,
+  writeMemoryCoreWorkspaceEntries,
+} from "./dreaming-state.js";
+import {
+  deleteMemoryEntryOrigins,
+  listMemoryEntryOrigins,
+  recordMemorySessionTombstones,
+} from "./memory-entry-origins.js";
+import { collectTranscriptWrites } from "./memory-forget-curated-writes.js";
+import { closeMemoryDatabase, openMemoryDatabaseAtPath } from "./memory/manager-db.js";
+import { isMemorySessionIndexable } from "./memory/manager-session-sync-state.js";
+import {
+  readSessionIngestionState,
+  SESSION_CORPUS_RELATIVE_DIR,
+  writeSessionIngestionState,
+} from "./session-ingestion.js";
+import type { ShortTermRecallEntry } from "./short-term-promotion-types.js";
+
+type ForgetDatabase = {
+  sqlite_master: { type: string; name: string };
+  memory_index_chunks: {
+    id: string;
+    path: string;
+    source: string;
+    hash: string;
+  };
+  memory_index_sources: { path: string; source: string };
+  memory_index_chunk_provenance: {
+    chunk_id: string;
+    origin_class: "owner" | "agent" | "untrusted" | "system";
+    session_kind: "interactive" | "cron" | "heartbeat" | "subagent" | "unknown";
+  };
+  memory_index_chunks_fts: { id: string; path: string; source: string };
+  memory_index_chunks_vec: { id: string };
+  memory_embedding_cache: { hash: string };
+};
+
+type MemoryBackup = { createdAt: string; content: string; contentHash: string };
+type MemoryRewrite = {
+  absolutePath: string;
+  relativePath: string;
+  content: string;
+  remove: boolean;
+};
+type ForgetIndexPlan = {
+  chunks: Array<ForgetDatabase["memory_index_chunks"]>;
+  sources: Array<ForgetDatabase["memory_index_sources"]>;
+  ftsRows: number;
+  vectorRows: number;
+  embeddingCacheRows: number;
+  hasVectorTable: boolean;
+};
+
+export type MemoryForgetReport = {
+  agentId: string;
+  dryRun: boolean;
+  sessionIds: string[];
+  entryKeys: string[];
+  mixedLineageEntryKeys: string[];
+  untargetableEntryKeys: string[];
+  curatedWrites: Array<{ relativePath: string; observedAt: number }>;
+  artifacts: {
+    memoryFiles: number;
+    memoryEntries: number;
+    memoryLines: number;
+    sessionCorpusFiles: number;
+    sessionCorpusLines: number;
+    indexChunks: number;
+    indexSources: number;
+    ftsRows: number;
+    vectorRows: number;
+    embeddingCacheRows: number;
+    shortTermEntries: number;
+    seenHashScopes: number;
+    backups: number;
+    originRows: number;
+  };
+  refusals: string[];
+};
+
+const PROMOTION_MARKER = /^\s*<!--\s*openclaw-memory-promotion:([^\n]*?)\s*-->\s*$/u;
+const LINEAGE_MARKER = /^\s*<!--\s*openclaw-memory-lineage:[^\n]*?-->\s*$/u;
+
+function referencesSession(
+  value: string,
+  agentId: string,
+  sessionIds: ReadonlySet<string>,
+): boolean {
+  return [...sessionIds].some(
+    (sessionId) =>
+      value.includes(`sessions/${agentId}/${sessionId}`) ||
+      value.includes(`${agentId}:${sessionId}`) ||
+      new RegExp(`\\bSession ID:\\s*${escapePattern(sessionId)}(?:[;\\s]|$)`, "iu").test(value),
+  );
+}
+
+function escapePattern(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function scrubMemoryContent(params: {
+  content: string;
+  entryKeys: ReadonlySet<string>;
+  sessionIds: ReadonlySet<string>;
+  corpusSnippets: ReadonlySet<string>;
+  agentId: string;
+}): { content: string; removedEntries: number; removedLines: number } {
+  const lines = params.content.split(/\r?\n/u);
+  const corpusSnippets = [...params.corpusSnippets];
+  let removedEntries = 0;
+  let removedLines = 0;
+  for (let index = 0; index < lines.length; index += 1) {
+    const markerKey = PROMOTION_MARKER.exec(lines[index] ?? "")?.[1]?.trim();
+    if (markerKey && params.entryKeys.has(markerKey)) {
+      const start = index > 0 && LINEAGE_MARKER.test(lines[index - 1] ?? "") ? index - 1 : index;
+      let end = index + 1;
+      if (end < lines.length && !PROMOTION_MARKER.test(lines[end] ?? "")) {
+        end += 1;
+        while (end < lines.length && /^\s+\S/u.test(lines[end] ?? "")) {
+          end += 1;
+        }
+      }
+      lines.splice(start, end - start);
+      removedEntries += 1;
+      index = start - 1;
+      continue;
+    }
+    if (corpusSnippets.some((snippet) => lines[index]?.includes(snippet))) {
+      lines.splice(index, 1);
+      removedLines += 1;
+      index -= 1;
+      continue;
+    }
+    if (!referencesSession(lines[index] ?? "", params.agentId, params.sessionIds)) {
+      continue;
+    }
+    const heading = /^(#{1,6})\s/u.exec(lines[index] ?? "");
+    if (!heading && !/\bSession ID:/iu.test(lines[index] ?? "")) {
+      continue;
+    }
+    let end = index + 1;
+    while (end < lines.length) {
+      const nextHeading = /^(#{1,6})\s/u.exec(lines[end] ?? "");
+      if (
+        (nextHeading && (!heading || nextHeading[1]!.length <= heading[1]!.length)) ||
+        /\bSession ID:/iu.test(lines[end] ?? "")
+      ) {
+        break;
+      }
+      end += 1;
+    }
+    lines.splice(index, end - index);
+    removedEntries += 1;
+    index -= 1;
+  }
+  return { content: lines.join("\n"), removedEntries, removedLines };
+}
+
+function tableNames(db: ReturnType<typeof openOpenClawAgentDatabase>["db"]): Set<string> {
+  const kysely = getNodeSqliteKysely<ForgetDatabase>(db);
+  return new Set(
+    executeSqliteQuerySync(
+      db,
+      kysely.selectFrom("sqlite_master").select("name").where("type", "=", "table"),
+    ).rows.map((row) => row.name),
+  );
+}
+
+async function planMemoryIndex(params: {
+  agentId: string;
+  changedPaths: ReadonlySet<string>;
+  removedPaths: ReadonlySet<string>;
+  sessionIds: ReadonlySet<string>;
+  excludedSessionIds: ReadonlySet<string>;
+}): Promise<ForgetIndexPlan> {
+  const result = withOpenClawAgentDatabaseReadOnly(
+    ({ db, path: databasePath }) => {
+      const kysely = getNodeSqliteKysely<ForgetDatabase>(db);
+      const chunks = executeSqliteQuerySync(
+        db,
+        kysely
+          .selectFrom("memory_index_chunks")
+          .leftJoin(
+            "memory_index_chunk_provenance",
+            "memory_index_chunk_provenance.chunk_id",
+            "memory_index_chunks.id",
+          )
+          .select([
+            "memory_index_chunks.id as id",
+            "memory_index_chunks.path as path",
+            "memory_index_chunks.source as source",
+            "memory_index_chunks.hash as hash",
+            "memory_index_chunk_provenance.origin_class as originClass",
+            "memory_index_chunk_provenance.session_kind as sessionKind",
+          ]),
+      ).rows.filter(
+        (chunk) =>
+          params.changedPaths.has(chunk.path) ||
+          referencesSession(chunk.path, params.agentId, params.sessionIds) ||
+          (params.sessionIds.size > 0 &&
+            chunk.source === "sessions" &&
+            (chunk.originClass === "system" ||
+              !isMemorySessionIndexable({ sessionKind: chunk.sessionKind ?? "unknown" }) ||
+              referencesSession(chunk.path, params.agentId, params.excludedSessionIds))),
+      );
+      const removedSessionPaths = new Set(
+        chunks.filter((chunk) => chunk.source === "sessions").map((chunk) => chunk.path),
+      );
+      const sources = executeSqliteQuerySync(
+        db,
+        kysely.selectFrom("memory_index_sources").select(["path", "source"]),
+      ).rows.filter(
+        (source) =>
+          params.removedPaths.has(source.path) ||
+          (source.source === "sessions" && removedSessionPaths.has(source.path)),
+      );
+      const chunkIds = chunks.map((chunk) => chunk.id);
+      const chunkHashes = [...new Set(chunks.map((chunk) => chunk.hash))];
+      const tables = tableNames(db);
+      const ftsRows =
+        chunkIds.length > 0 && tables.has("memory_index_chunks_fts")
+          ? executeSqliteQuerySync(
+              db,
+              kysely.selectFrom("memory_index_chunks_fts").select("id").where("id", "in", chunkIds),
+            ).rows.length
+          : 0;
+      const hasVectorTable = tables.has("memory_index_chunks_vec");
+      const embeddingCacheRows =
+        chunkHashes.length > 0 && tables.has("memory_embedding_cache")
+          ? executeSqliteQuerySync(
+              db,
+              kysely
+                .selectFrom("memory_embedding_cache")
+                .select("hash")
+                .where("hash", "in", chunkHashes),
+            ).rows.length
+          : 0;
+      return { chunks, sources, ftsRows, embeddingCacheRows, hasVectorTable, databasePath };
+    },
+    { agentId: params.agentId },
+  );
+  if (!result.found) {
+    return {
+      chunks: [],
+      sources: [],
+      ftsRows: 0,
+      vectorRows: 0,
+      embeddingCacheRows: 0,
+      hasVectorTable: false,
+    };
+  }
+  let vectorRows = 0;
+  if (result.value.hasVectorTable && result.value.chunks.length > 0) {
+    const probe = new DatabaseSync(":memory:", { allowExtension: true });
+    let extensionPath: string;
+    try {
+      const loaded = await loadSqliteVecExtension({ db: probe });
+      if (!loaded.ok || !loaded.extensionPath) {
+        throw new Error(
+          `memory forget cannot inspect vector index: ${loaded.error ?? "load failed"}`,
+        );
+      }
+      extensionPath = loaded.extensionPath;
+    } finally {
+      probe.close();
+    }
+    // Ordinary owner handles cannot enable extensions after construction.
+    // This fresh owner-validated handle stays read-only while exposing vec0.
+    const vectorResult = withOpenClawAgentDatabaseReadOnly(
+      ({ db }) => {
+        db.enableLoadExtension(true);
+        db.loadExtension(extensionPath);
+        const vectorKysely = getNodeSqliteKysely<ForgetDatabase>(db);
+        return executeSqliteQuerySync(
+          db,
+          vectorKysely
+            .selectFrom("memory_index_chunks_vec")
+            .select("id")
+            .where(
+              "id",
+              "in",
+              result.value.chunks.map((chunk) => chunk.id),
+            ),
+        ).rows.length;
+      },
+      { agentId: params.agentId },
+      { allowExtension: true },
+    );
+    vectorRows = vectorResult.found ? vectorResult.value : 0;
+  }
+  return { ...result.value, vectorRows };
+}
+
+export async function forgetMemoryEntries(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionIds?: string[];
+  hookSources?: string[];
+  participants?: string[];
+  since?: string;
+  dryRun?: boolean;
+}): Promise<MemoryForgetReport> {
+  if (!params.sessionIds?.length && !params.hookSources?.length && !params.participants?.length) {
+    throw new Error("memory forget requires a session, hook source, or participant selector");
+  }
+  const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+  const targets = resolveMemorySessionTargets({
+    agentId: params.agentId,
+    sessionIds: params.sessionIds,
+    hookSources: params.hookSources,
+    participants: params.participants,
+    since: params.since,
+  });
+  const sessionIds = new Set(targets.map((target) => target.sessionId));
+  const allOrigins = listMemoryEntryOrigins({ agentId: params.agentId });
+  const entryKeys = new Set(
+    allOrigins
+      .filter((origin) => sessionIds.has(origin.sessionId))
+      .map((origin) => origin.entryKey),
+  );
+  const allOriginKeys = new Set(allOrigins.map((origin) => origin.entryKey));
+  const mixedLineageEntryKeys = new Set(
+    allOrigins
+      .filter((origin) => entryKeys.has(origin.entryKey) && !sessionIds.has(origin.sessionId))
+      .map((origin) => origin.entryKey),
+  );
+  const untargetableEntryKeys = new Set<string>();
+  const corpusDir = path.join(workspaceDir, SESSION_CORPUS_RELATIVE_DIR);
+  const corpusFiles = await fs
+    .readdir(corpusDir, { withFileTypes: true })
+    .catch((error: unknown) => {
+      if (isFileMissingError(error)) {
+        return [];
+      }
+      throw error;
+    });
+  const corpusRewrites: MemoryRewrite[] = [];
+  const corpusSnippets = new Set<string>();
+  let removedCorpusLines = 0;
+  for (const file of corpusFiles) {
+    if (!file.isFile() || !/\.(?:txt|md)$/iu.test(file.name)) {
+      continue;
+    }
+    const absolutePath = path.join(corpusDir, file.name);
+    const content = await fs.readFile(absolutePath, "utf8");
+    const lines = content.split(/\r?\n/u);
+    const retained = lines.filter((line) => {
+      if (!referencesSession(line, params.agentId, sessionIds)) {
+        return true;
+      }
+      const snippet = /^\[[^\]]+#L\d+\]\s*(.+)$/u.exec(line)?.[1]?.trim();
+      // Ingestion only admits snippets of at least 12 characters; shorter
+      // malformed corpus rows must never trigger broad substring deletion.
+      if (snippet && snippet.length >= 12) {
+        corpusSnippets.add(snippet);
+      }
+      return false;
+    });
+    if (retained.length !== lines.length) {
+      removedCorpusLines += lines.length - retained.length;
+      const rewritten = retained.join("\n");
+      corpusRewrites.push({
+        absolutePath,
+        relativePath: path.relative(workspaceDir, absolutePath).replaceAll("\\", "/"),
+        content: rewritten,
+        remove: rewritten.trim().length === 0,
+      });
+    }
+  }
+
+  const memoryRewrites: MemoryRewrite[] = [];
+  let removedMemoryEntries = 0;
+  let removedMemoryLines = 0;
+  const memoryFiles = await listMemoryFiles(workspaceDir, [
+    path.join(workspaceDir, "DREAMS.md"),
+    path.join(workspaceDir, "dreams.md"),
+  ]);
+  for (const absolutePath of memoryFiles) {
+    const content = await fs.readFile(absolutePath, "utf8");
+    for (const line of content.split(/\r?\n/u)) {
+      const key = PROMOTION_MARKER.exec(line)?.[1]?.trim();
+      if (key && !allOriginKeys.has(key)) {
+        untargetableEntryKeys.add(key);
+      }
+    }
+    const scrubbed = scrubMemoryContent({
+      content,
+      entryKeys,
+      sessionIds,
+      corpusSnippets,
+      agentId: params.agentId,
+    });
+    if (scrubbed.content !== content) {
+      memoryRewrites.push({
+        absolutePath,
+        relativePath: path.relative(workspaceDir, absolutePath).replaceAll("\\", "/"),
+        content: scrubbed.content,
+        remove: false,
+      });
+      removedMemoryEntries += scrubbed.removedEntries;
+      removedMemoryLines += scrubbed.removedLines;
+    }
+  }
+
+  const [shortTermEntries, ingestionState, backups, artifactProvenance, sessionCorpusEntries] =
+    await Promise.all([
+      readMemoryCoreWorkspaceEntries<ShortTermRecallEntry>({
+        namespace: SHORT_TERM_RECALL_NAMESPACE,
+        workspaceDir,
+      }),
+      readSessionIngestionState(workspaceDir),
+      readMemoryCoreWorkspaceEntries<MemoryBackup>({
+        namespace: DREAMING_MEMORY_BACKUP_NAMESPACE,
+        workspaceDir,
+      }),
+      listMemoryArtifactProvenance({ workspaceDir }),
+      listSessionTranscriptCorpusEntriesForAgent(params.agentId),
+    ]);
+  const sessionKeys = new Set(targets.map((target) => target.sessionKey));
+  const curatedWrites = new Map(
+    artifactProvenance
+      .filter(({ provenance }) =>
+        provenance.sessionId
+          ? sessionIds.has(provenance.sessionId)
+          : Boolean(provenance.sessionKey && sessionKeys.has(provenance.sessionKey)),
+      )
+      .map(({ relativePath, provenance }) => [
+        relativePath,
+        { relativePath, observedAt: provenance.observedAt },
+      ]),
+  );
+  const retainedShortTerm = shortTermEntries.filter(
+    ({ key, value }) =>
+      !entryKeys.has(key) &&
+      !entryKeys.has(value.key) &&
+      !referencesSession(`${value.path}\n${value.snippet}`, params.agentId, sessionIds),
+  );
+  const removedSeenScopes = Object.keys(ingestionState.seenMessages).filter((scope) =>
+    referencesSession(scope, params.agentId, sessionIds),
+  );
+  const retainedFileStates = Object.fromEntries(
+    Object.entries(ingestionState.files).filter(
+      ([key]) => !referencesSession(key, params.agentId, sessionIds),
+    ),
+  );
+  let rewrittenBackups = 0;
+  const nextBackups = backups.map(({ key, value }) => {
+    const scrubbed = scrubMemoryContent({
+      content: value.content,
+      entryKeys,
+      sessionIds,
+      corpusSnippets,
+      agentId: params.agentId,
+    });
+    if (scrubbed.content === value.content) {
+      return { key, value };
+    }
+    rewrittenBackups += 1;
+    return {
+      key,
+      value: {
+        ...value,
+        content: scrubbed.content,
+        contentHash: createHash("sha256").update(scrubbed.content).digest("hex"),
+      },
+    };
+  });
+
+  const excludedSessionIds = new Set<string>();
+  for (const entry of sessionCorpusEntries) {
+    const selectedSession = sessionIds.has(entry.sessionId);
+    if (!isMemorySessionIndexable(entry)) {
+      excludedSessionIds.add(entry.sessionId);
+      if (!selectedSession) {
+        continue;
+      }
+    }
+    if (
+      selectedSession ||
+      (entry.artifactKind === "archive-artifact" &&
+        (!entry.sessionKind || entry.sessionKind === "unknown"))
+    ) {
+      const parsed = await buildSessionEntry(entry.sessionFile, {
+        ...(entry.transcriptSource === "sqlite"
+          ? { agentId: entry.agentId, sessionId: entry.sessionId, storePath: entry.storePath }
+          : {}),
+        ...(entry.sessionKey ? { sessionKey: entry.sessionKey } : {}),
+        ...(entry.sessionKind ? { sessionKind: entry.sessionKind } : {}),
+        ...(selectedSession
+          ? {
+              onTranscriptMessage: (message: unknown, observedAt: number) =>
+                collectTranscriptWrites({
+                  message,
+                  observedAt,
+                  workspaceDir,
+                  writes: curatedWrites,
+                }),
+            }
+          : {}),
+      });
+      if (parsed && !isMemorySessionIndexable(parsed)) {
+        excludedSessionIds.add(entry.sessionId);
+      }
+    }
+  }
+
+  const changedPaths = new Set(
+    [...memoryRewrites, ...corpusRewrites].map((rewrite) => rewrite.relativePath),
+  );
+  const indexPlan = await planMemoryIndex({
+    agentId: params.agentId,
+    changedPaths,
+    removedPaths: new Set(
+      corpusRewrites.filter((rewrite) => rewrite.remove).map((rewrite) => rewrite.relativePath),
+    ),
+    sessionIds,
+    excludedSessionIds,
+  });
+  const report: MemoryForgetReport = {
+    agentId: params.agentId,
+    dryRun: params.dryRun === true,
+    sessionIds: [...sessionIds].toSorted(),
+    entryKeys: [...entryKeys].toSorted(),
+    mixedLineageEntryKeys: [...mixedLineageEntryKeys].toSorted(),
+    untargetableEntryKeys: [...untargetableEntryKeys].toSorted(),
+    curatedWrites: [...curatedWrites.values()].toSorted((left, right) =>
+      left.relativePath.localeCompare(right.relativePath),
+    ),
+    artifacts: {
+      memoryFiles: memoryRewrites.length,
+      memoryEntries: removedMemoryEntries,
+      memoryLines: removedMemoryLines,
+      sessionCorpusFiles: corpusRewrites.length,
+      sessionCorpusLines: removedCorpusLines,
+      indexChunks: indexPlan.chunks.length,
+      indexSources: indexPlan.sources.length,
+      ftsRows: indexPlan.ftsRows,
+      vectorRows: indexPlan.vectorRows,
+      embeddingCacheRows: indexPlan.embeddingCacheRows,
+      shortTermEntries: shortTermEntries.length - retainedShortTerm.length,
+      seenHashScopes: removedSeenScopes.length,
+      backups: rewrittenBackups,
+      originRows: allOrigins.filter((origin) => entryKeys.has(origin.entryKey)).length,
+    },
+    refusals: [],
+  };
+  if (params.dryRun || sessionIds.size === 0) {
+    return report;
+  }
+
+  const database = openOpenClawAgentDatabase({ agentId: params.agentId });
+  const vectorDb =
+    indexPlan.chunks.length > 0 && indexPlan.hasVectorTable
+      ? openMemoryDatabaseAtPath(database.path, true, params.agentId)
+      : undefined;
+  const db = vectorDb ?? database.db;
+  const kysely = getNodeSqliteKysely<ForgetDatabase>(db);
+  const chunkIds = indexPlan.chunks.map((chunk) => chunk.id);
+  const chunkHashes = [...new Set(indexPlan.chunks.map((chunk) => chunk.hash))];
+  try {
+    if (vectorDb) {
+      const loaded = await loadSqliteVecExtension({ db });
+      if (!loaded.ok) {
+        throw new Error(
+          `memory forget cannot purge vector index: ${loaded.error ?? "load failed"}`,
+        );
+      }
+    }
+
+    // Forget is durable admission policy: persist it before removing the
+    // checkpoints that would otherwise make this session look newly eligible.
+    recordMemorySessionTombstones({ agentId: params.agentId, sessionIds: [...sessionIds] });
+
+    for (const rewrite of [...memoryRewrites, ...corpusRewrites]) {
+      if (rewrite.remove) {
+        await fs.unlink(rewrite.absolutePath);
+      } else {
+        await fs.writeFile(rewrite.absolutePath, rewrite.content, "utf8");
+      }
+    }
+    if (retainedShortTerm.length !== shortTermEntries.length) {
+      await writeMemoryCoreWorkspaceEntries({
+        namespace: SHORT_TERM_RECALL_NAMESPACE,
+        workspaceDir,
+        entries: retainedShortTerm,
+      });
+    }
+    if (
+      removedSeenScopes.length > 0 ||
+      Object.keys(retainedFileStates).length !== Object.keys(ingestionState.files).length
+    ) {
+      await writeSessionIngestionState(workspaceDir, {
+        ...ingestionState,
+        files: retainedFileStates,
+        seenMessages: Object.fromEntries(
+          Object.entries(ingestionState.seenMessages).filter(
+            ([scope]) => !referencesSession(scope, params.agentId, sessionIds),
+          ),
+        ),
+      });
+    }
+    if (rewrittenBackups > 0) {
+      await writeMemoryCoreWorkspaceEntries({
+        namespace: DREAMING_MEMORY_BACKUP_NAMESPACE,
+        workspaceDir,
+        entries: nextBackups,
+      });
+    }
+    runSqliteImmediateTransactionSync(db, () => {
+      if (chunkIds.length > 0) {
+        if (indexPlan.ftsRows > 0) {
+          executeSqliteQuerySync(
+            db,
+            kysely.deleteFrom("memory_index_chunks_fts").where("id", "in", chunkIds),
+          );
+        }
+        if (indexPlan.hasVectorTable) {
+          executeSqliteQuerySync(
+            db,
+            kysely.deleteFrom("memory_index_chunks_vec").where("id", "in", chunkIds),
+          );
+        }
+        executeSqliteQuerySync(
+          db,
+          kysely.deleteFrom("memory_index_chunks").where("id", "in", chunkIds),
+        );
+      }
+      for (const source of indexPlan.sources) {
+        executeSqliteQuerySync(
+          db,
+          kysely
+            .deleteFrom("memory_index_sources")
+            .where("path", "=", source.path)
+            .where("source", "=", source.source),
+        );
+      }
+      if (indexPlan.embeddingCacheRows > 0) {
+        executeSqliteQuerySync(
+          db,
+          kysely.deleteFrom("memory_embedding_cache").where("hash", "in", chunkHashes),
+        );
+      }
+    });
+    deleteMemoryEntryOrigins({ agentId: params.agentId, entryKeys: [...entryKeys] });
+    return report;
+  } finally {
+    if (vectorDb) {
+      closeMemoryDatabase(vectorDb);
+    }
+  }
+}

--- a/extensions/memory-core/src/memory-forget.ts
+++ b/extensions/memory-core/src/memory-forget.ts
@@ -84,6 +84,11 @@ export type MemoryForgetReport = {
   agentId: string;
   dryRun: boolean;
   sessionIds: string[];
+  sessionResolutions: Array<{
+    sessionId: string;
+    sessionKey?: string;
+    source: "live" | "archived" | "unresolved";
+  }>;
   entryKeys: string[];
   mixedLineageEntryKeys: string[];
   untargetableEntryKeys: string[];
@@ -549,6 +554,13 @@ export async function forgetMemoryEntries(params: {
     agentId: params.agentId,
     dryRun: params.dryRun === true,
     sessionIds: [...sessionIds].toSorted(),
+    sessionResolutions: targets
+      .map(({ sessionId, sessionKey, resolution }) =>
+        sessionKey
+          ? { sessionId, sessionKey, source: resolution }
+          : { sessionId, source: resolution },
+      )
+      .toSorted((left, right) => left.sessionId.localeCompare(right.sessionId)),
     entryKeys: [...entryKeys].toSorted(),
     mixedLineageEntryKeys: [...mixedLineageEntryKeys].toSorted(),
     untargetableEntryKeys: [...untargetableEntryKeys].toSorted(),

--- a/extensions/memory-core/src/memory/manager-session-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-ops.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   listSessionTranscriptCorpusEntriesForAgent,
+  loadArchivedSessions,
   sessionPathForFile,
   sessionPathForSessionIdentity,
   statSessionEntrySync,
@@ -19,8 +20,10 @@ import {
   type MemorySyncParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+import { listMemorySessionTombstones } from "../memory-entry-origins.js";
 import { shouldSyncSessionsForReindex } from "./manager-session-reindex.js";
 import {
+  isMemorySessionIndexable,
   resolveMemorySessionStartupState,
   type MemorySessionStartupFileState,
 } from "./manager-session-sync-state.js";
@@ -68,8 +71,31 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
     }
   }
 
-  protected listSessionCorpusEntries(): Promise<SessionTranscriptCorpusEntry[]> {
-    return listSessionTranscriptCorpusEntriesForAgent(this.agentId);
+  protected async listSessionCorpusEntries(): Promise<SessionTranscriptCorpusEntry[]> {
+    const entries = await listSessionTranscriptCorpusEntriesForAgent(this.agentId);
+    const archivedSessions = new Map(
+      loadArchivedSessions({
+        agentId: this.agentId,
+        sessionIds: entries
+          .filter((entry) => entry.artifactKind === "archive-artifact")
+          .map((entry) => entry.sessionId),
+      }).map((archive) => [archive.archiveName, archive]),
+    );
+    const forgottenSessions = new Set(
+      listMemorySessionTombstones({
+        agentId: this.agentId,
+        sessionIds: entries.map((entry) => entry.sessionId),
+      }).map((entry) => entry.sessionId),
+    );
+    return entries.filter((entry) => {
+      const archive = archivedSessions.get(path.basename(entry.sessionFile));
+      const archivedSessionKey =
+        archive?.sessionId === entry.sessionId ? archive.sessionKey : undefined;
+      return (
+        !forgottenSessions.has(entry.sessionId) &&
+        isMemorySessionIndexable(entry, archivedSessionKey)
+      );
+    });
   }
 
   protected sessionPathForCorpusEntry(entry: SessionTranscriptCorpusEntry): string {

--- a/extensions/memory-core/src/memory/manager-session-sync-state.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-state.ts
@@ -1,4 +1,10 @@
 // Memory Core plugin module implements manager session sync state behavior.
+import {
+  isCronRunSessionKey,
+  isDreamingNarrativeSessionStoreKey,
+  type SessionFileEntry,
+  type SessionTranscriptCorpusEntry,
+} from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
 import type { MemorySourceFileStateRow } from "./manager-source-state.js";
 
 export type MemorySessionStartupFileState = {
@@ -7,6 +13,29 @@ export type MemorySessionStartupFileState = {
   mtimeMs: number;
   size: number;
 };
+
+export function isMemorySessionIndexable(
+  entry: Pick<
+    SessionTranscriptCorpusEntry,
+    "generatedByDreamingNarrative" | "generatedByCronRun" | "sessionKind"
+  > &
+    Partial<Pick<SessionFileEntry, "lineProvenance">>,
+  archivedSessionKey?: string,
+): boolean {
+  return !(
+    entry.generatedByDreamingNarrative ||
+    entry.generatedByCronRun ||
+    entry.sessionKind === "cron" ||
+    entry.sessionKind === "heartbeat" ||
+    (archivedSessionKey !== undefined &&
+      (isDreamingNarrativeSessionStoreKey(archivedSessionKey) ||
+        isCronRunSessionKey(archivedSessionKey) ||
+        archivedSessionKey.endsWith(":heartbeat"))) ||
+    (entry.lineProvenance !== undefined &&
+      entry.lineProvenance.length > 0 &&
+      entry.lineProvenance.every((line) => line.originClass === "system"))
+  );
+}
 
 export function resolveMemorySessionStartupState(params: {
   files: MemorySessionStartupFileState[];

--- a/extensions/memory-core/src/memory/manager-session-update-race.test.ts
+++ b/extensions/memory-core/src/memory/manager-session-update-race.test.ts
@@ -1,8 +1,14 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { listSessionTranscriptCorpusEntriesForAgent } from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
 import type { MemorySessionSyncTarget } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { deleteSessionEntry, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
 import { describe, expect, it, vi } from "vitest";
+import { recordMemorySessionTombstones } from "../memory-entry-origins.js";
 import { createManagerIndexFixture } from "./manager-index.test-support.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
@@ -13,6 +19,49 @@ describe("memory session update sync", () => {
     closeAllMemorySearchManagers,
   });
   const { createConfig, getFreshManager, seedSessionTranscript } = fixture;
+
+  function seedIndexedSession(database: DatabaseSync, sessionPath: string, text: string): void {
+    database
+      .prepare(
+        "INSERT INTO memory_index_sources (path, source, hash, mtime, size) VALUES (?, 'sessions', ?, ?, ?)",
+      )
+      .run(sessionPath, "stale-session", 10, 20);
+    database
+      .prepare(
+        "INSERT INTO memory_index_chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, 'sessions', 1, 1, ?, ?, ?, ?, ?)",
+      )
+      .run(sessionPath, sessionPath, "stale-chunk", "fts-only", text, "[]", 10);
+    database
+      .prepare(
+        "INSERT INTO memory_index_chunks_fts (text, id, path, source, model, start_line, end_line) VALUES (?, ?, ?, 'sessions', ?, 1, 1)",
+      )
+      .run(text, sessionPath, sessionPath, "fts-only");
+    database
+      .prepare(
+        "INSERT INTO memory_index_chunk_provenance (chunk_id, origin_class, session_kind, observed_at) VALUES (?, 'system', 'subagent', ?)",
+      )
+      .run(sessionPath, 10);
+  }
+
+  function expectSessionIndexRemoved(database: DatabaseSync, sessionPath: string): void {
+    expect(
+      database
+        .prepare("SELECT path FROM memory_index_sources WHERE path = ? AND source = 'sessions'")
+        .get(sessionPath),
+    ).toBeUndefined();
+    expect(
+      database
+        .prepare("SELECT path FROM memory_index_chunks WHERE path = ? AND source = 'sessions'")
+        .get(sessionPath),
+    ).toBeUndefined();
+    expect(
+      database
+        .prepare(
+          "SELECT path FROM memory_index_chunks_fts WHERE memory_index_chunks_fts MATCH ? AND path = ?",
+        )
+        .all("violet", sessionPath),
+    ).toEqual([]);
+  }
 
   it("indexes an update that arrives before an active sync clears dirty state", async () => {
     fixture.setStateDir(path.join(fixture.paths.workspace, ".state-session-update-during-sync"));
@@ -95,5 +144,277 @@ describe("memory session update sync", () => {
       await manager.close?.();
       fixture.restoreStateDir();
     }
+  });
+
+  it.each(["startup catch-up", "forced reindex"] as const)(
+    "removes previously indexed dreaming narratives during %s",
+    async (mode) => {
+      const sessionId = "narrative-thread";
+      await seedSessionTranscript({
+        sessionId,
+        sessionKey: "agent:main:dreaming-narrative-run-1",
+        messages: [
+          {
+            role: "user",
+            timestamp: Date.now(),
+            content: "Internal narrative violet fragment that must never remain indexed.",
+          },
+        ],
+      });
+      const manager = await getFreshManager(
+        createConfig({ provider: "none", sources: ["sessions"], sessionMemory: true }),
+        "cli",
+      );
+      const database = Reflect.get(manager, "db") as DatabaseSync;
+      const sessionPath = `sessions/main/${sessionId}.jsonl`;
+      seedIndexedSession(database, sessionPath, "Internal narrative violet fragment");
+
+      if (mode === "startup catch-up") {
+        await (
+          manager as unknown as { runSessionStartupCatchup: () => Promise<string[]> }
+        ).runSessionStartupCatchup();
+        await manager.sync({ reason: "await-startup-catchup" });
+      } else {
+        await manager.sync({ reason: "forced-reindex", force: true });
+      }
+
+      expectSessionIndexRemoved(database, sessionPath);
+    },
+  );
+
+  it.each([
+    {
+      description: "narrative archive through CLI forced indexing",
+      sessionKey: "agent:main:dreaming-narrative-memory-core-v2-light-real",
+      runId: "dreaming-narrative-main-light-real",
+      force: true,
+    },
+    {
+      description: "unchanged narrative archive through regular reconciliation",
+      sessionKey: "agent:main:dreaming-narrative-memory-core-v2-light-real",
+      runId: "dreaming-narrative-main-light-real",
+      force: false,
+    },
+    {
+      description: "cron archive through CLI forced indexing",
+      sessionKey: "agent:main:cron:job-1:run:run-1",
+      runId: "internal-cron-run-1",
+      force: true,
+    },
+    {
+      description: "heartbeat archive through CLI forced indexing",
+      sessionKey: "agent:main:chat:base:heartbeat",
+      runId: "internal-heartbeat-run-1",
+      force: true,
+    },
+  ])("prunes a real compressed $description", async (scenario) => {
+    const sessionId = "3cb3f634-6821-4123-8123-abcdef123456";
+    const sessionKey = scenario.sessionKey;
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    const storePath = path.join(sessionsDir, "sessions.json");
+    await seedSessionTranscript({
+      sessionId,
+      sessionKey,
+      messages: [
+        {
+          role: "user",
+          timestamp: Date.now(),
+          content: "Previously retained violet fragment.",
+        },
+      ],
+    });
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: "main",
+      sessionId,
+      sessionKey,
+      storePath,
+      message: {
+        role: "assistant",
+        timestamp: Date.now(),
+        content: [{ type: "text", text: "A narrative derived from that violet fragment." }],
+        __openclaw: { runId: scenario.runId },
+      },
+    });
+    await expect(
+      deleteSessionEntry({
+        agentId: "main",
+        archiveTranscript: true,
+        expectedSessionId: sessionId,
+        sessionKey,
+        storePath,
+      }),
+    ).resolves.toBe(true);
+    const archiveName = (await fs.readdir(sessionsDir)).find(
+      (name) => name.startsWith(`${sessionId}.jsonl.deleted.`) && name.endsWith(".zst"),
+    );
+    expect(archiveName).toBeDefined();
+    const manager = await getFreshManager(
+      createConfig({ provider: "none", sources: ["sessions"], sessionMemory: true }),
+      "cli",
+      true,
+    );
+    expect(manager.status().sourceCounts?.find((source) => source.source === "sessions")).toEqual(
+      expect.objectContaining({ eligible: 0 }),
+    );
+    const database = Reflect.get(manager, "db") as DatabaseSync;
+    const sessionPath = `sessions/main/${archiveName}`;
+    expect(
+      database
+        .prepare("SELECT session_id FROM session_windows WHERE session_id = ?")
+        .get(sessionId),
+    ).toBeUndefined();
+    expect(
+      (await listSessionTranscriptCorpusEntriesForAgent("main")).find(
+        (entry) => entry.sessionId === sessionId,
+      ),
+    ).toMatchObject({ artifactKind: "archive-artifact", sessionKind: "unknown" });
+    seedIndexedSession(database, sessionPath, "Previously retained violet fragment");
+    database
+      .prepare(
+        "UPDATE memory_index_chunk_provenance SET origin_class = 'owner', session_kind = 'unknown' WHERE chunk_id = ?",
+      )
+      .run(sessionPath);
+    const archiveStat = await fs.stat(path.join(sessionsDir, archiveName!));
+    database
+      .prepare("UPDATE memory_index_sources SET mtime = ?, size = ? WHERE path = ?")
+      .run(archiveStat.mtimeMs, archiveStat.size, sessionPath);
+
+    if (scenario.force) {
+      await manager.sync({ reason: "cli", force: true });
+    } else {
+      await (
+        manager as unknown as { runSessionStartupCatchup: () => Promise<string[]> }
+      ).runSessionStartupCatchup();
+      await manager.sync({ reason: "await-startup-catchup" });
+    }
+
+    expectSessionIndexRemoved(database, sessionPath);
+  });
+
+  it("never reindexes a tombstoned session while preserving its source transcript", async () => {
+    const sessionId = "forgotten-transcript";
+    const sessionKey = `agent:main:chat:${sessionId}`;
+    await seedSessionTranscript({
+      sessionId,
+      sessionKey,
+      messages: [
+        { role: "user", timestamp: Date.now(), content: "Previously indexed violet fragment." },
+      ],
+    });
+    const manager = await getFreshManager(
+      createConfig({ provider: "none", sources: ["sessions"], sessionMemory: true }),
+      "cli",
+    );
+    const database = Reflect.get(manager, "db") as DatabaseSync;
+    const sessionPath = `sessions/main/${sessionId}.jsonl`;
+    await manager.sync({ reason: "index-before-forget", force: true });
+    expect(
+      database.prepare("SELECT path FROM memory_index_chunks WHERE path = ?").get(sessionPath),
+    ).toEqual({ path: sessionPath });
+
+    recordMemorySessionTombstones({ agentId: "main", sessionIds: [sessionId] });
+    await manager.sync({ reason: "forced-reindex-after-forget", force: true });
+
+    expectSessionIndexRemoved(database, sessionPath);
+    expect(
+      database
+        .prepare("SELECT session_id FROM session_windows WHERE session_id = ?")
+        .get(sessionId),
+    ).toEqual({ session_id: sessionId });
+    await manager.sync({
+      reason: "targeted-update-after-forget",
+      sessions: [{ agentId: "main", sessionId, sessionKey }],
+    });
+    expectSessionIndexRemoved(database, sessionPath);
+  });
+
+  it.each([
+    { description: "system-only", includeUserTurn: false, indexable: false },
+    { description: "mixed user/system", includeUserTurn: true, indexable: true },
+  ])("indexes only eligible $description archived transcripts", async (scenario) => {
+    const archiveName = "internal-turn.jsonl.deleted.2026-08-26T11-00-00.000Z";
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const records = [
+      {
+        type: "message",
+        message: {
+          role: "user",
+          content: "Internal system-generated fragment",
+          provenance: { kind: "internal_system", sourceTool: "internal-maintenance" },
+        },
+      },
+      ...(scenario.includeUserTurn
+        ? [
+            {
+              type: "message",
+              message: {
+                role: "user",
+                content: "Real user conversation about agent:main:dreaming-narrative-run-1",
+              },
+            },
+          ]
+        : []),
+    ];
+    await fs.writeFile(
+      path.join(sessionsDir, archiveName),
+      `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    );
+    const manager = await getFreshManager(
+      createConfig({ provider: "none", sources: ["sessions"], sessionMemory: true }),
+      "cli",
+    );
+
+    await manager.sync({ reason: "forced-reindex", force: true });
+
+    const database = Reflect.get(manager, "db") as DatabaseSync;
+    expect(
+      database
+        .prepare("SELECT DISTINCT path FROM memory_index_chunks WHERE source = 'sessions'")
+        .all(),
+    ).toEqual(scenario.indexable ? [{ path: `sessions/main/${archiveName}` }] : []);
+  });
+
+  it.each([
+    { kind: "cron", sessionKey: "agent:main:cron:job-1:run:run-1" },
+    { kind: "dreaming narrative", sessionKey: "agent:main:dreaming-narrative-run-1" },
+    {
+      kind: "heartbeat",
+      sessionKey: "agent:main:heartbeat:run-1",
+      heartbeatIsolatedBaseSessionKey: "agent:main:chat:base",
+    },
+  ])("excludes $kind transcripts from targeted memory indexing", async (systemSession) => {
+    const sessionId = "system-thread";
+    await seedSessionTranscript({
+      sessionId,
+      sessionKey: systemSession.sessionKey,
+      messages: [{ role: "assistant", timestamp: Date.now(), content: "Internal system output." }],
+    });
+    if (systemSession.heartbeatIsolatedBaseSessionKey) {
+      await upsertSessionEntry({
+        agentId: "main",
+        sessionKey: systemSession.sessionKey,
+        storePath: path.join(resolveSessionTranscriptsDirForAgent("main"), "sessions.json"),
+        entry: {
+          sessionId,
+          updatedAt: Date.now(),
+          heartbeatIsolatedBaseSessionKey: systemSession.heartbeatIsolatedBaseSessionKey,
+        },
+      });
+    }
+    const manager = await getFreshManager(
+      createConfig({ provider: "none", sources: ["sessions"], sessionMemory: true }),
+      "cli",
+    );
+
+    await manager.sync({
+      reason: "targeted-generated-session",
+      sessions: [{ agentId: "main", sessionId, sessionKey: systemSession.sessionKey }],
+    });
+
+    const database = Reflect.get(manager, "db") as DatabaseSync;
+    expect(
+      database.prepare("SELECT path FROM memory_index_chunks WHERE source = 'sessions'").all(),
+    ).toEqual([]);
   });
 });

--- a/extensions/memory-core/src/memory/manager-source-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-source-sync-ops.ts
@@ -10,7 +10,10 @@ import {
   runWithConcurrency,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { MemoryManagerSessionSyncOps } from "./manager-session-sync-ops.js";
-import { resolveMemorySessionSyncPlan } from "./manager-session-sync-state.js";
+import {
+  isMemorySessionIndexable,
+  resolveMemorySessionSyncPlan,
+} from "./manager-session-sync-state.js";
 import {
   loadMemorySourceFileState,
   resolveMemorySourceFileEntries,
@@ -290,6 +293,13 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
         this.buildSessionEntryOptions(corpusEntryForPath(absPath)),
       );
       if (!entry) {
+        this.advanceSyncProgress(params.progress);
+        return null;
+      }
+      if (!isMemorySessionIndexable(entry)) {
+        // Archived runs may reveal their internal origin only while parsing.
+        // Remove earlier index artifacts before excluding that transcript.
+        deleteIndexedSessionPath(entry.path);
         this.advanceSyncProgress(params.progress);
         return null;
       }

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -925,7 +925,7 @@ describe("session startup catch-up", () => {
     expect(harness.indexedContents[0]).not.toContain("replacement store target");
   });
 
-  it("preserves generated-session classification during targeted custom-store indexing", async () => {
+  it("excludes generated cron transcripts from targeted custom-store indexing", async () => {
     const storePath = path.join(stateDir, "custom-sessions", "sessions.json");
     const session = await writeSqliteSession({
       storePath,
@@ -947,8 +947,8 @@ describe("session startup catch-up", () => {
       ],
     });
 
-    expect(harness.indexedPaths).toEqual([session.corpusPath]);
-    expect(harness.indexedContents).toEqual([""]);
+    expect(harness.indexedPaths).toEqual([]);
+    expect(harness.indexedContents).toEqual([]);
   });
 
   it("queues transcript update identity without requiring a session file", async () => {

--- a/extensions/memory-core/src/migration/doctor-dreaming-state.ts
+++ b/extensions/memory-core/src/migration/doctor-dreaming-state.ts
@@ -34,6 +34,8 @@ type LegacySource = {
   filePath: string;
 };
 
+const LEGACY_DREAMING_STATE_DIR = path.join("memory", ".dreams");
+
 async function readJsonFile(filePath: string): Promise<unknown> {
   return JSON.parse(await fs.readFile(filePath, "utf8"));
 }
@@ -51,7 +53,7 @@ async function collectLegacySources(
       { label: "phase signals", fileName: "phase-signals.json" },
     ];
     for (const candidate of candidates) {
-      const filePath = path.join(workspaceDir, "memory", ".dreams", candidate.fileName);
+      const filePath = path.join(workspaceDir, LEGACY_DREAMING_STATE_DIR, candidate.fileName);
       if (await legacyStateFileExists(filePath)) {
         sources.push({ workspaceDir, label: candidate.label, filePath });
       }

--- a/extensions/memory-core/src/session-backfill.test.ts
+++ b/extensions/memory-core/src/session-backfill.test.ts
@@ -14,6 +14,7 @@ import {
   clearMemoryCoreWorkspaceNamespace,
   SESSION_BACKFILL_REWIND_NAMESPACE,
 } from "./dreaming-state.js";
+import { recordMemorySessionTombstones } from "./memory-entry-origins.js";
 import {
   markSessionBackfillRewindBaseline,
   resetSessionBackfillIngestionState,
@@ -129,6 +130,39 @@ describe("runSessionBackfill", () => {
         apply: true,
       }),
     ).rejects.toThrow("Memory session-backfill --rem cannot be combined with --apply.");
+  });
+
+  it("never resurrects forgotten canonical sessions through session backfill apply", async () => {
+    const workspaceDir = await createIsolatedWorkspace("forgotten-");
+    await seedCanonicalTranscript("forgotten", [
+      {
+        role: "user",
+        content: "Forgotten owner claim must never return.",
+        timestamp: "2026-01-02T12:00:00.000Z",
+        owner: true,
+      },
+    ]);
+    await seedCanonicalTranscript("retained", [
+      {
+        role: "user",
+        content: "Retained owner claim remains eligible.",
+        timestamp: "2026-01-02T12:01:00.000Z",
+        owner: true,
+      },
+    ]);
+    recordMemorySessionTombstones({ agentId: "main", sessionIds: ["forgotten"] });
+
+    const result = await runSessionBackfill({
+      agentId: "main",
+      workspaceDir,
+      apply: true,
+      timezone: "UTC",
+    });
+
+    expect(result.candidateCount).toBe(1);
+    expect(result.days[0]?.topCandidates).toEqual(["User: Retained owner claim remains eligible."]);
+    const ingestion = await dreamingTestState.readSessionIngestionState(workspaceDir);
+    expect(ingestion.files).not.toHaveProperty("main:sessions/main/forgotten");
   });
 
   it("buckets messages in the configured timezone and processes days oldest first", async () => {

--- a/extensions/memory-core/src/session-backfill.ts
+++ b/extensions/memory-core/src/session-backfill.ts
@@ -5,6 +5,7 @@ import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-ru
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import type { SessionIngestionFileState } from "./dreaming-ingestion-state.js";
 import { removeBackfillDiaryEntries, writeBackfillDiaryEntries } from "./dreaming-narrative.js";
+import { listMemorySessionTombstones } from "./memory-entry-origins.js";
 import { previewGroundedRemMarkdown } from "./rem-evidence.js";
 import type {
   SessionBackfillDay,
@@ -30,6 +31,7 @@ import {
   mergeTrackedMessageHashes,
   readSessionIngestionState,
   scanSessionIngestionSource,
+  sessionExclusionReason,
   sessionIngestionSourceFromCorpus,
   trimTrackedSessionScopes,
   writeSessionIngestionState,
@@ -92,13 +94,17 @@ async function listSessionBackfillSources(params: {
   const corpus = await listSessionTranscriptCorpusEntriesForAgent(params.agentId, {
     includeRetainedSqlite: true,
   });
+  const forgottenSessionIds = new Set(
+    listMemorySessionTombstones({ agentId: params.agentId }).map((entry) => entry.sessionId),
+  );
   const sources = corpus
     .map(sessionIngestionSourceFromCorpus)
     .filter(
       (entry): entry is SessionIngestionSource =>
         entry !== null &&
         !entry.buildOptions.generatedByDreamingNarrative &&
-        !entry.buildOptions.generatedByCronRun,
+        !entry.buildOptions.generatedByCronRun &&
+        !sessionExclusionReason(entry, undefined, forgottenSessionIds),
     );
   const canonicalPaths = new Set(sources.map((entry) => path.resolve(entry.absolutePath)));
   for (const archiveFile of params.archiveFiles) {

--- a/extensions/memory-core/src/session-ingestion.test.ts
+++ b/extensions/memory-core/src/session-ingestion.test.ts
@@ -25,6 +25,7 @@ describe("session ingestion", () => {
     });
 
     expect(source?.scope).toBe("main:foo.jsonl");
+    expect(source?.sessionOrigin).toEqual({ agentId: "main", sessionId: "foo.jsonl" });
   });
 
   it("verifies backfill content despite an unchanged size and mtime", async () => {

--- a/extensions/memory-core/src/session-ingestion.ts
+++ b/extensions/memory-core/src/session-ingestion.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   buildSessionEntry,
+  loadMemorySessionMetadata,
   parseUsageCountedSessionIdFromFileName,
   sessionPathForFile,
   statSessionEntrySync,
@@ -12,6 +13,10 @@ import {
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import { formatMemoryDreamingDay } from "openclaw/plugin-sdk/memory-core-host-status";
 import { appendRegularFile } from "openclaw/plugin-sdk/security-runtime";
+import {
+  asNullableRecord,
+  normalizeStringEntries,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   normalizeSessionIngestionState,
   SESSION_INGESTION_MAX_TRACKED_MESSAGES_PER_SESSION,
@@ -25,6 +30,7 @@ import {
   SESSION_SEEN_HASHES_PER_CHUNK,
   writeMemoryCoreWorkspaceEntries,
 } from "./dreaming-state.js";
+import { listMemorySessionTombstones } from "./memory-entry-origins.js";
 
 export type { SessionIngestionState } from "./dreaming-ingestion-state.js";
 
@@ -38,11 +44,24 @@ const SESSION_INGESTION_MAX_SNIPPET_CHARS = 280;
 const SESSION_INGESTION_MAX_TRACKED_SCOPES = 2048;
 type BuildSessionEntryOptions = NonNullable<Parameters<typeof buildSessionEntry>[1]>;
 
+export type SessionEntryOrigin = {
+  agentId: string;
+  sessionId: string;
+  sessionKey?: string;
+};
+
+export type SessionAdmissionPolicy = {
+  hookExternalContentSources: string[];
+  channels: string[];
+  chatTypes: string[];
+};
+
 export type SessionIngestionMessage = {
   day: string;
   snippet: string;
   rendered: string;
   provenance: NonNullable<MemorySearchResult["provenance"]>;
+  sessionOrigin?: SessionEntryOrigin;
 };
 
 export type SessionIngestionSource = {
@@ -54,6 +73,7 @@ export type SessionIngestionSource = {
   scope: string;
   legacyScope?: string;
   buildOptions: BuildSessionEntryOptions;
+  sessionOrigin?: SessionEntryOrigin;
 };
 
 export type SessionIngestionCandidate = SessionIngestionMessage & {
@@ -106,6 +126,11 @@ export function sessionIngestionSourceFromCorpus(
     sessionPath,
     stateKey: `${entry.agentId}:${sessionPath}`,
     scope,
+    sessionOrigin: {
+      agentId: entry.agentId,
+      sessionId: entry.sessionId,
+      ...(entry.sessionKey ? { sessionKey: entry.sessionKey } : {}),
+    },
     ...(entry.transcriptSource === "sqlite"
       ? {
           legacyScope: buildSessionScope(entry.agentId, entry.sessionId),
@@ -123,6 +148,65 @@ export function sessionIngestionSourceFromCorpus(
       ...(entry.generatedByCronRun ? { generatedByCronRun: true } : {}),
     },
   };
+}
+
+export function resolveAdmissionPolicy(
+  pluginConfig?: Record<string, unknown>,
+): SessionAdmissionPolicy | undefined {
+  const exclusions = asNullableRecord(
+    asNullableRecord(pluginConfig?.memoryPolicy)?.excludeSessions,
+  );
+  if (!exclusions) {
+    return undefined;
+  }
+  const values = (key: keyof SessionAdmissionPolicy): string[] =>
+    Array.isArray(exclusions[key])
+      ? normalizeStringEntries(
+          exclusions[key].filter((value): value is string => typeof value === "string"),
+        )
+      : [];
+  const policy = {
+    hookExternalContentSources: values("hookExternalContentSources"),
+    channels: values("channels"),
+    chatTypes: values("chatTypes"),
+  };
+  return Object.values(policy).some((entries) => entries.length > 0) ? policy : undefined;
+}
+
+export function sessionExclusionReason(
+  source: SessionIngestionSource,
+  policy?: SessionAdmissionPolicy,
+  forgottenSessionIds?: ReadonlySet<string>,
+): string | undefined {
+  if (!source.sessionOrigin) {
+    return undefined;
+  }
+  const { agentId, sessionId } = source.sessionOrigin;
+  const forgotten = forgottenSessionIds
+    ? forgottenSessionIds.has(sessionId)
+    : listMemorySessionTombstones({ agentId, sessionIds: [sessionId] }).length > 0;
+  if (forgotten) {
+    return "forgotten";
+  }
+  if (!policy) {
+    return undefined;
+  }
+  const metadata = loadMemorySessionMetadata(source.sessionOrigin);
+  if (!metadata) {
+    return undefined;
+  }
+  if (
+    metadata.hookExternalContentSource &&
+    policy.hookExternalContentSources.includes(metadata.hookExternalContentSource)
+  ) {
+    return `hookExternalContentSource:${metadata.hookExternalContentSource}`;
+  }
+  if (metadata.channel && policy.channels.includes(metadata.channel)) {
+    return `channel:${metadata.channel}`;
+  }
+  return metadata.chatType && policy.chatTypes.includes(metadata.chatType)
+    ? `chatType:${metadata.chatType}`
+    : undefined;
 }
 
 export function sessionIngestionStateKeyFromCorpus(entry: SessionTranscriptCorpusEntry): string {
@@ -305,6 +389,7 @@ export async function scanSessionIngestionSource(params: {
       scope: params.source.scope,
       stateKey: params.source.stateKey,
       snippet,
+      ...(params.source.sessionOrigin ? { sessionOrigin: params.source.sessionOrigin } : {}),
     });
     seen.add(hash);
   }
@@ -394,7 +479,7 @@ export async function appendSessionCorpusLines(params: {
   workspaceDir: string;
   day: string;
   lines: SessionIngestionMessage[];
-}): Promise<MemorySearchResult[]> {
+}): Promise<Array<MemorySearchResult & { sessionOrigin?: SessionEntryOrigin }>> {
   if (params.lines.length === 0) {
     return [];
   }
@@ -428,5 +513,6 @@ export async function appendSessionCorpusLines(params: {
     snippet: entry.snippet,
     source: "memory",
     provenance: entry.provenance,
+    ...(entry.sessionOrigin ? { sessionOrigin: entry.sessionOrigin } : {}),
   }));
 }

--- a/extensions/memory-core/src/short-term-promotion-apply.ts
+++ b/extensions/memory-core/src/short-term-promotion-apply.ts
@@ -21,7 +21,9 @@ import {
 } from "./dreaming-consolidation-candidates.js";
 import { applyMemoryConsolidationPlan, consolidateMemory } from "./dreaming-consolidation.js";
 import { compactMemoryForBudget, DEFAULT_MEMORY_FILE_MAX_CHARS } from "./memory-budget.js";
+import { reconcileMemoryEntryOrigins } from "./memory-entry-origins.js";
 import {
+  buildPromotionMarker,
   hashMemoryContent,
   isAtomicReplacePermissionError,
   MemoryWriteConflictError,
@@ -53,7 +55,6 @@ import {
 } from "./short-term-promotion-utils.js";
 import { resolveMemoryCoreNowMs, resolveMemoryCoreTimestamp } from "./time.js";
 
-const PROMOTION_MARKER_PREFIX = "openclaw-memory-promotion:";
 const PROMOTED_SNIPPET_CHARS_PER_TOKEN_ESTIMATE = 4;
 const MEMORY_WRITE_LOCK_OPTIONS = {
   retries: { retries: 100, factor: 1.2, minTimeout: 25, maxTimeout: 250 },
@@ -78,7 +79,7 @@ function buildPromotionSection(
     for (const candidate of groupCandidates) {
       const source = `${candidate.path}:${candidate.startLine}-${candidate.endLine}`;
       const metadata = `[score=${candidate.score.toFixed(3)} signals=${candidate.signalCount} recalls=${candidate.recallCount} avg=${candidate.avgScore.toFixed(3)} source=${source}]`;
-      lines.push(`<!-- ${PROMOTION_MARKER_PREFIX}${candidate.key} -->`);
+      lines.push(buildPromotionMarker(candidate.key));
       // Cap only the visible MEMORY.md text. The recall store keeps the full
       // rehydrated snippet so ranking, provenance, and dream narratives remain
       // tied to the source entry instead of this presentation budget.
@@ -412,6 +413,7 @@ export async function applyShortTermPromotions(
       : null;
   let consolidationResult: Awaited<ReturnType<typeof applyMemoryConsolidationPlan>> = null;
   let committedCandidates: PromotionCandidate[] = [];
+  let committedMemoryContent: string | undefined;
   let appendedCandidates = 0;
   let rewriteSkippedReason: string | undefined;
   const promotionLockTarget = await resolveMemoryPromotionLockTarget(workspaceDir);
@@ -519,6 +521,7 @@ export async function applyShortTermPromotions(
             expectedHash: consolidationBaseMemoryHash,
             content: consolidationResult.content,
           });
+          committedMemoryContent = consolidationResult.content;
           for (const candidate of toAppend) {
             successfulCandidates.set(candidate.key, candidate);
           }
@@ -583,6 +586,7 @@ export async function applyShortTermPromotions(
             allowInPlaceFallback: true,
             content,
           });
+          committedMemoryContent = content;
           for (const candidate of toAppend) {
             successfulCandidates.set(candidate.key, candidate);
           }
@@ -610,6 +614,21 @@ export async function applyShortTermPromotions(
         Math.max(nowMs, Number.isFinite(latestUpdatedAtMs) ? latestUpdatedAtMs : 0),
       );
       await writeStore(workspaceDir, latestStore);
+      if (options.agentId && committedMemoryContent) {
+        reconcileMemoryEntryOrigins({
+          agentId: options.agentId,
+          previousMemory: existingMemory,
+          currentMemory: committedMemoryContent,
+          operations:
+            consolidationResult && consolidationPlan
+              ? consolidationPlan.operations
+              : toAppend.map((candidate) => ({
+                  candidateKey: candidate.key,
+                  action: "added" as const,
+                  priorEntries: [],
+                })),
+        });
+      }
       committedCandidates = [...successfulCandidates.values()];
     });
   });

--- a/extensions/memory-core/src/short-term-promotion-apply.ts
+++ b/extensions/memory-core/src/short-term-promotion-apply.ts
@@ -616,7 +616,7 @@ export async function applyShortTermPromotions(
       await writeStore(workspaceDir, latestStore);
       if (options.agentId && committedMemoryContent) {
         reconcileMemoryEntryOrigins({
-          agentId: options.agentId,
+          agentIds: [options.agentId, ...(options.workspaceAgentIds ?? [])],
           previousMemory: existingMemory,
           currentMemory: committedMemoryContent,
           operations:

--- a/extensions/memory-core/src/short-term-promotion-memory-write.ts
+++ b/extensions/memory-core/src/short-term-promotion-memory-write.ts
@@ -3,6 +3,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 
+export function buildPromotionMarker(candidateKey: string): string {
+  return `<!-- openclaw-memory-promotion:${candidateKey} -->`;
+}
+
 export class MemoryWriteConflictError extends Error {
   constructor() {
     super("MEMORY.md changed before the dreaming write could commit");

--- a/extensions/memory-core/src/short-term-promotion-record.ts
+++ b/extensions/memory-core/src/short-term-promotion-record.ts
@@ -8,6 +8,7 @@ import { formatMemoryDreamingDay } from "openclaw/plugin-sdk/memory-core-host-st
 import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
 import pLimit from "p-limit";
 import { deriveConceptTags } from "./concept-vocabulary.js";
+import { recordMemoryEntryOrigins, type MemoryEntryOrigin } from "./memory-entry-origins.js";
 import { readStore, withShortTermLock, writeStore } from "./short-term-promotion-store.js";
 import type { ShortTermRecallEntry, ShortTermRecallStore } from "./short-term-promotion-types.js";
 import {
@@ -151,7 +152,12 @@ async function updateShortTermRecallStore(
 export async function recordShortTermRecalls(params: {
   workspaceDir?: string;
   query: string;
-  results: Array<MemorySearchResult & { identitySnippet?: string }>;
+  results: Array<
+    MemorySearchResult & {
+      identitySnippet?: string;
+      sessionOrigin?: { agentId: string; sessionId: string; sessionKey?: string };
+    }
+  >;
   signalType?: "recall" | "daily";
   dedupeByQueryPerDay?: boolean;
   dayBucket?: string;
@@ -189,6 +195,7 @@ export async function recordShortTermRecalls(params: {
   }
   const signalType = params.signalType ?? "recall";
   const queryHash = hashQuery(query);
+  const origins: MemoryEntryOrigin[] = [];
   const todayBucket =
     normalizeIsoDay(params.dayBucket ?? "") ?? formatMemoryDreamingDay(nowMs, params.timezone);
   await updateShortTermRecallStore(
@@ -311,9 +318,25 @@ export async function recordShortTermRecalls(params: {
           ...(projectKey ? { projectKey } : {}),
           ...(existing?.promotedAt ? { promotedAt: existing.promotedAt } : {}),
         };
+        if (result.sessionOrigin) {
+          origins.push({
+            entryKey: key,
+            agentId: result.sessionOrigin.agentId,
+            sessionId: result.sessionOrigin.sessionId,
+            sessionKey: result.sessionOrigin.sessionKey ?? null,
+            originClass: provenance.originClass,
+            observedAt: provenance.observedAt,
+          });
+        }
       }
     },
     async () => {
+      for (const agentId of new Set(origins.map((origin) => origin.agentId))) {
+        recordMemoryEntryOrigins({
+          agentId,
+          origins: origins.filter((origin) => origin.agentId === agentId),
+        });
+      }
       await appendMemoryHostEvent(workspaceDir, {
         type: "memory.recall.recorded",
         timestamp: nowIso,

--- a/extensions/memory-core/src/short-term-promotion-types.ts
+++ b/extensions/memory-core/src/short-term-promotion-types.ts
@@ -160,6 +160,7 @@ export type RankShortTermPromotionOptions = {
 
 export type ApplyShortTermPromotionsOptions = {
   agentId?: string;
+  workspaceAgentIds?: readonly string[];
   workspaceDir: string;
   candidates: PromotionCandidate[];
   limit?: number;

--- a/extensions/memory-core/src/short-term-promotion-types.ts
+++ b/extensions/memory-core/src/short-term-promotion-types.ts
@@ -159,6 +159,7 @@ export type RankShortTermPromotionOptions = {
 };
 
 export type ApplyShortTermPromotionsOptions = {
+  agentId?: string;
   workspaceDir: string;
   candidates: PromotionCandidate[];
   limit?: number;

--- a/packages/memory-host-sdk/src/engine-sessions.ts
+++ b/packages/memory-host-sdk/src/engine-sessions.ts
@@ -24,6 +24,8 @@ export {
   type SessionTranscriptCorpusOptions,
 } from "./host/session-files.js";
 export {
+  isCronRunSessionKey,
+  isDreamingNarrativeSessionStoreKey,
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
   parseSqliteSessionFileMarker,

--- a/packages/memory-host-sdk/src/host/session-files.provenance.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.provenance.test.ts
@@ -22,6 +22,47 @@ async function writeTranscript(name: string, records: unknown[]): Promise<string
 }
 
 describe("session transcript provenance", () => {
+  it.each(["assistant", "toolResult"])(
+    "discards earlier archive lines after an authoritative %s event identifies a dreaming run",
+    async (role) => {
+      const filePath = await writeTranscript("narrative.jsonl.deleted.2026-08-26T10-00-00.000Z", [
+        { type: "message", message: { role: "user", content: "Private fragment from dreaming." } },
+        {
+          type: "message",
+          message: {
+            role,
+            content: "Internal narrative output.",
+            __openclaw: { runId: "dreaming-narrative-main-light-real" },
+          },
+        },
+      ]);
+
+      const entry = await buildSessionEntry(filePath, { sessionKind: "unknown" });
+
+      expect(entry?.generatedByDreamingNarrative).toBe(true);
+      expect(entry?.content).toBe("");
+      expect(entry?.lineProvenance).toEqual([]);
+    },
+  );
+
+  it("does not treat run identity on user-authored transcript messages as authoritative", async () => {
+    const filePath = await writeTranscript("interactive.jsonl", [
+      {
+        type: "message",
+        message: {
+          role: "user",
+          content: "Keep this genuine user conversation.",
+          __openclaw: { runId: "dreaming-narrative-main-light-spoofed" },
+        },
+      },
+    ]);
+
+    const entry = await buildSessionEntry(filePath, { sessionKind: "interactive" });
+
+    expect(entry?.generatedByDreamingNarrative).toBeUndefined();
+    expect(entry?.content).toBe("User: Keep this genuine user conversation.");
+  });
+
   it("classifies owner input and its agent-derived response", async () => {
     const filePath = await writeTranscript("owner.jsonl", [
       {

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -1,6 +1,7 @@
 // Memory Host SDK module implements session files behavior.
 import fsSync from "node:fs";
 import path from "node:path";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeAgentId } from "./config-utils.js";
 import { readRegularFile, statRegularFile } from "./fs-utils.js";
 import { hashText } from "./hash.js";
@@ -98,6 +99,8 @@ export type BuildSessionEntryOptions = {
   updatedAtMs?: number;
   /** Override for tests or specialized callers that need a tighter parse yield cadence. */
   parseYieldEveryLines?: number;
+  /** Observe persisted messages before memory indexing drops tool-only content. */
+  onTranscriptMessage?: (message: unknown, observedAt: number) => void;
 };
 
 export type SessionTranscriptClassification = {
@@ -174,8 +177,8 @@ function isDreamingNarrativeBootstrapRecord(record: unknown): boolean {
   return typeof runId === "string" && runId.startsWith(DREAMING_NARRATIVE_RUN_PREFIX);
 }
 
-function hasDreamingNarrativeRunId(value: unknown): boolean {
-  return typeof value === "string" && value.startsWith(DREAMING_NARRATIVE_RUN_PREFIX);
+function hasDreamingNarrativeIdentity(value: unknown): boolean {
+  return typeof value === "string" && isDreamingNarrativeSessionStoreKey(value);
 }
 
 function isDreamingNarrativeGeneratedRecord(record: unknown): boolean {
@@ -186,15 +189,27 @@ function isDreamingNarrativeGeneratedRecord(record: unknown): boolean {
     return false;
   }
   const candidate = record as {
+    type?: unknown;
     runId?: unknown;
     sessionKey?: unknown;
     data?: unknown;
+    message?: unknown;
   };
   if (
-    hasDreamingNarrativeRunId(candidate.runId) ||
-    hasDreamingNarrativeRunId(candidate.sessionKey)
+    hasDreamingNarrativeIdentity(candidate.runId) ||
+    hasDreamingNarrativeIdentity(candidate.sessionKey)
   ) {
     return true;
+  }
+  const message = candidate.type === "message" ? asOptionalRecord(candidate.message) : undefined;
+  if (message) {
+    const metadata = asOptionalRecord(message["__openclaw"]);
+    if (
+      (message.role === "assistant" || message.role === "toolResult") &&
+      hasDreamingNarrativeIdentity(metadata?.runId)
+    ) {
+      return true;
+    }
   }
   if (!candidate.data || typeof candidate.data !== "object" || Array.isArray(candidate.data)) {
     return false;
@@ -203,7 +218,9 @@ function isDreamingNarrativeGeneratedRecord(record: unknown): boolean {
     runId?: unknown;
     sessionKey?: unknown;
   };
-  return hasDreamingNarrativeRunId(nested.runId) || hasDreamingNarrativeRunId(nested.sessionKey);
+  return (
+    hasDreamingNarrativeIdentity(nested.runId) || hasDreamingNarrativeIdentity(nested.sessionKey)
+  );
 }
 
 function hasCronRunSessionKey(value: unknown): boolean {
@@ -857,15 +874,15 @@ export async function buildSessionEntry(
       } catch {
         continue;
       }
-      if (!generatedByDreamingNarrative && isDreamingNarrativeGeneratedRecord(record)) {
-        generatedByDreamingNarrative = true;
-      }
-      if (
+      const identifiesDreamingNarrative =
+        !generatedByDreamingNarrative && isDreamingNarrativeGeneratedRecord(record);
+      const identifiesCronRun =
         !generatedByCronRun &&
         allowArchiveRecordCronClassification &&
-        isCronRunGeneratedRecord(record)
-      ) {
-        generatedByCronRun = true;
+        isCronRunGeneratedRecord(record);
+      if (identifiesDreamingNarrative || identifiesCronRun) {
+        generatedByDreamingNarrative ||= identifiesDreamingNarrative;
+        generatedByCronRun ||= identifiesCronRun;
         collected.length = 0;
         lineMap.length = 0;
         messageTimestampsMs.length = 0;
@@ -887,6 +904,11 @@ export async function buildSessionEntry(
       if (message.role !== "user" && message.role !== "assistant") {
         continue;
       }
+      const timestampMs = parseSessionTimestampMs(
+        record as { timestamp?: unknown },
+        message as { timestamp?: unknown },
+      );
+      opts.onTranscriptMessage?.(message, Math.max(0, Math.floor(timestampMs || mtimeMs)));
       const inputProvenance = message.provenance as
         | { kind?: unknown; sourceTool?: unknown }
         | undefined;
@@ -922,10 +944,6 @@ export async function buildSessionEntry(
       const safe = redactSensitiveText(text, { mode: "tools" });
       const label = message.role === "user" ? "User" : "Assistant";
       const renderedLines = renderSessionExportLines(label, safe);
-      const timestampMs = parseSessionTimestampMs(
-        record as { timestamp?: unknown },
-        message as { timestamp?: unknown },
-      );
       const memoryProvenance: MemoryEntryProvenance = {
         originClass: classifySessionMessageOrigin(message, turnOrigin),
         sessionKind,

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -2479,13 +2479,16 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
-  it("records ordinary write, edit, and apply_patch memory provenance from turn taint", async () => {
+  it("records turn taint and source-session lineage for memory writes, edits, and patches", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-write-taint-"));
     let tainted = false;
     try {
       const tools = createOpenClawCodingTools({
         workspaceDir,
         config: { tools: { fs: { workspaceOnly: true } } },
+        sessionId: "source-session",
+        sessionKey: "agent:main:policy-session",
+        runSessionKey: "agent:main:durable-session",
         senderIsOwner: true,
         isTurnTainted: () => tainted,
       });
@@ -2518,8 +2521,16 @@ describe("createOpenClawCodingTools", () => {
           ),
         ),
       ).resolves.toEqual([
-        expect.objectContaining({ originClass: "untrusted" }),
-        expect.objectContaining({ originClass: "untrusted" }),
+        expect.objectContaining({
+          originClass: "untrusted",
+          sessionId: "source-session",
+          sessionKey: "agent:main:durable-session",
+        }),
+        expect.objectContaining({
+          originClass: "untrusted",
+          sessionId: "source-session",
+          sessionKey: "agent:main:durable-session",
+        }),
       ]);
       await expect(
         applyPatch("patch-existing-memory", {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -525,6 +525,8 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       options?.senderIsOwner === false || options?.isTurnTainted?.() === true
         ? "untrusted"
         : "agent",
+    sessionId: options?.sessionId,
+    sessionKey: options?.runSessionKey ?? options?.sessionKey,
   });
   const includeCoreTools = options?.includeCoreTools !== false;
   const toolConstructionPlan = options?.toolConstructionPlan ?? {

--- a/src/agents/memory-write-provenance.ts
+++ b/src/agents/memory-write-provenance.ts
@@ -102,6 +102,8 @@ export function createMemoryWriteProvenanceObserver(params: {
   mutationRoot: string;
   workspaceDir: string;
   resolveOriginClass: () => "agent" | "untrusted";
+  sessionId?: string;
+  sessionKey?: string;
   now?: () => number;
 }): MemoryWriteProvenanceObserver {
   const now = params.now ?? Date.now;
@@ -121,6 +123,8 @@ export function createMemoryWriteProvenanceObserver(params: {
         contentAfter,
         originClass: params.resolveOriginClass(),
         observedAt: now(),
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
       });
       try {
         await commit();

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -391,6 +391,8 @@ async function saveSessionMemoryNow(
       workspaceDir,
       resolveOriginClass: () =>
         transcript.status === "available" ? transcript.originClass : "agent",
+      sessionId: currentSessionId,
+      sessionKey: event.sessionKey,
       now: () => now.getTime(),
     });
     const commit = () => memoryRoot.write(filename, entry, { encoding: "utf-8" });

--- a/src/memory/memory-artifact-provenance.ts
+++ b/src/memory/memory-artifact-provenance.ts
@@ -14,6 +14,8 @@ export type MemoryArtifactProvenance = {
   fileHash: string;
   originClass: MemoryArtifactOriginClass;
   observedAt: number;
+  sessionId?: string;
+  sessionKey?: string;
 };
 
 type StoredMemoryArtifactProvenance = MemoryArtifactProvenance & {
@@ -119,6 +121,8 @@ function toPublicProvenance(stored: StoredMemoryArtifactProvenance): MemoryArtif
     fileHash: stored.fileHash,
     originClass: stored.originClass,
     observedAt: stored.observedAt,
+    ...(stored.sessionId ? { sessionId: stored.sessionId } : {}),
+    ...(stored.sessionKey ? { sessionKey: stored.sessionKey } : {}),
   };
 }
 
@@ -129,6 +133,8 @@ export async function recordMemoryArtifactWriteProvenance(params: {
   contentAfter: string;
   originClass: MemoryArtifactOriginClass;
   observedAt: number;
+  sessionId?: string;
+  sessionKey?: string;
 }): Promise<(() => Promise<void>) | undefined> {
   const address = resolveAddress(params);
   if (!address) {
@@ -155,6 +161,8 @@ export async function recordMemoryArtifactWriteProvenance(params: {
       fileHash: sha256(params.contentAfter),
       originClass,
       observedAt: params.observedAt,
+      ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
       reservationId,
     };
   });

--- a/src/plugin-sdk/memory-core-host-engine-sessions.ts
+++ b/src/plugin-sdk/memory-core-host-engine-sessions.ts
@@ -1,7 +1,14 @@
 /** Private-local SDK subpath for memory session transcript helpers. */
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
+import type { DB as OpenClawAgentDatabase } from "../state/openclaw-agent-db.generated.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+
 export {
   buildSessionEntry,
   extractKeywords,
+  isCronRunSessionKey,
+  isDreamingNarrativeSessionStoreKey,
   isQueryStopWordToken,
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
@@ -29,3 +36,195 @@ export type {
   SessionTranscriptCorpusEntry,
   SessionTranscriptCorpusOptions,
 } from "../../packages/memory-host-sdk/src/engine-sessions.js";
+
+export type MemorySessionTarget = {
+  agentId: string;
+  sessionId: string;
+  sessionKey: string;
+  hookExternalContentSource: string | null;
+  channel: string | null;
+  accountId: string | null;
+  chatType: string | null;
+  createdAt: number;
+  participantIds: string[];
+};
+
+export type MemorySessionSelectors = {
+  agentId: string;
+  sessionIds?: readonly string[];
+  hookSources?: readonly string[];
+  participants?: readonly string[];
+  since?: string | number;
+};
+
+type SessionMetadataDatabase = Pick<
+  OpenClawAgentDatabase,
+  "session_windows" | "session_participants" | "session_transcript_archives"
+>;
+
+const SESSION_METADATA_COLUMNS = [
+  "session_windows.session_id",
+  "session_windows.session_key",
+  "session_windows.hook_external_content_source",
+  "session_windows.channel",
+  "session_windows.account_id",
+  "session_windows.chat_type",
+  "session_windows.created_at",
+] as const;
+
+function projectSessionMetadata(
+  agentId: string,
+  row: {
+    session_id: string;
+    session_key: string;
+    hook_external_content_source: string | null;
+    channel: string | null;
+    account_id: string | null;
+    chat_type: string | null;
+    created_at: number;
+  },
+  participantIds: string[] = [],
+): MemorySessionTarget {
+  return {
+    agentId,
+    sessionId: row.session_id,
+    sessionKey: row.session_key,
+    hookExternalContentSource: row.hook_external_content_source,
+    channel: row.channel,
+    accountId: row.account_id,
+    chatType: row.chat_type,
+    createdAt: row.created_at,
+    participantIds,
+  };
+}
+
+/** Read authoritative admission facts without creating a missing agent database. */
+export function loadMemorySessionMetadata(params: {
+  agentId: string;
+  sessionId: string;
+  sessionKey?: string;
+}): MemorySessionTarget | undefined {
+  const result = withOpenClawAgentDatabaseReadOnly(({ db }) => {
+    let query = getNodeSqliteKysely<SessionMetadataDatabase>(db)
+      .selectFrom("session_windows")
+      .select(SESSION_METADATA_COLUMNS)
+      .where("session_id", "=", params.sessionId);
+    if (params.sessionKey) {
+      query = query.where("session_key", "=", params.sessionKey);
+    }
+    const row = executeSqliteQuerySync(db, query).rows[0];
+    return row ? projectSessionMetadata(params.agentId, row) : undefined;
+  }, params);
+  return result.found ? result.value : undefined;
+}
+
+/** Resolve retained archive identities after their live session rows disappear. */
+export function loadArchivedSessions(params: {
+  agentId: string;
+  sessionIds: readonly string[];
+}): Array<{ archiveName: string; sessionId: string; sessionKey: string }> {
+  const sessionIds = [...new Set(params.sessionIds)];
+  if (sessionIds.length === 0) {
+    return [];
+  }
+  const result = withOpenClawAgentDatabaseReadOnly(({ db }) => {
+    if (!tableExists(db, "session_transcript_archives")) {
+      return [];
+    }
+    return executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<SessionMetadataDatabase>(db)
+        .selectFrom("session_transcript_archives")
+        .select(["archive_name", "session_id", "session_key"])
+        .where("session_id", "in", sessionIds),
+    ).rows.map((archive) => ({
+      archiveName: archive.archive_name,
+      sessionId: archive.session_id,
+      sessionKey: archive.session_key,
+    }));
+  }, params);
+  return result.found ? result.value : [];
+}
+
+/** Resolve explicit memory-forget selectors against authoritative session owners. */
+export function resolveMemorySessionTargets(params: MemorySessionSelectors): MemorySessionTarget[] {
+  const sessionIds = [...new Set(params.sessionIds ?? [])];
+  const hookSources = [...new Set(params.hookSources ?? [])];
+  const participants = [...new Set(params.participants ?? [])];
+  if (sessionIds.length === 0 && hookSources.length === 0 && participants.length === 0) {
+    return [];
+  }
+  const since = typeof params.since === "string" ? Date.parse(params.since) : params.since;
+  if (since !== undefined && !Number.isFinite(since)) {
+    throw new Error(`Invalid memory session date: ${params.since}`);
+  }
+  const result = withOpenClawAgentDatabaseReadOnly(({ db }) => {
+    const sessionDb = getNodeSqliteKysely<SessionMetadataDatabase>(db);
+    const hasParticipants = tableExists(db, "session_participants");
+    if (!hasParticipants && sessionIds.length === 0 && hookSources.length === 0) {
+      return [];
+    }
+    let query = sessionDb
+      .selectFrom("session_windows")
+      .select(SESSION_METADATA_COLUMNS)
+      .where((expression) =>
+        expression.or([
+          ...(sessionIds.length > 0
+            ? [
+                expression("session_windows.session_id", "in", sessionIds),
+                expression("session_windows.session_key", "in", sessionIds),
+              ]
+            : []),
+          ...(hookSources.length > 0
+            ? [expression("session_windows.hook_external_content_source", "in", hookSources)]
+            : []),
+          ...(participants.length > 0 && hasParticipants
+            ? [
+                expression.exists(
+                  expression
+                    .selectFrom("session_participants")
+                    .select("session_key")
+                    .whereRef(
+                      "session_participants.session_key",
+                      "=",
+                      "session_windows.session_key",
+                    )
+                    .where("actor_id", "in", participants),
+                ),
+              ]
+            : []),
+        ]),
+      );
+    if (since !== undefined) {
+      query = query.where("session_windows.created_at", ">=", since);
+    }
+    const rows = executeSqliteQuerySync(
+      db,
+      query.orderBy("session_windows.created_at").orderBy("session_windows.session_id"),
+    ).rows;
+    const participantIds = new Map<string, string[]>();
+    if (rows.length > 0 && hasParticipants) {
+      const keys = [...new Set(rows.map((row) => row.session_key))];
+      const participantRows = executeSqliteQuerySync(
+        db,
+        sessionDb
+          .selectFrom("session_participants")
+          .select(["session_key", "actor_id"])
+          .where("session_key", "in", keys)
+          .orderBy("session_key")
+          .orderBy("actor_id"),
+      ).rows;
+      for (const participant of participantRows) {
+        const ids = participantIds.get(participant.session_key) ?? [];
+        if (!ids.includes(participant.actor_id)) {
+          ids.push(participant.actor_id);
+        }
+        participantIds.set(participant.session_key, ids);
+      }
+    }
+    return rows.map((row) =>
+      projectSessionMetadata(params.agentId, row, participantIds.get(row.session_key)),
+    );
+  }, params);
+  return result.found ? result.value : [];
+}

--- a/src/plugin-sdk/memory-core-host-engine-sessions.ts
+++ b/src/plugin-sdk/memory-core-host-engine-sessions.ts
@@ -1,4 +1,5 @@
 /** Private-local SDK subpath for memory session transcript helpers. */
+import type { DatabaseSync } from "node:sqlite";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentDatabase } from "../state/openclaw-agent-db.generated.js";
@@ -40,12 +41,13 @@ export type {
 export type MemorySessionTarget = {
   agentId: string;
   sessionId: string;
-  sessionKey: string;
+  sessionKey?: string;
+  resolution: "live" | "archived" | "unresolved";
   hookExternalContentSource: string | null;
   channel: string | null;
   accountId: string | null;
   chatType: string | null;
-  createdAt: number;
+  createdAt?: number;
   participantIds: string[];
 };
 
@@ -89,6 +91,7 @@ function projectSessionMetadata(
     agentId,
     sessionId: row.session_id,
     sessionKey: row.session_key,
+    resolution: "live",
     hookExternalContentSource: row.hook_external_content_source,
     channel: row.channel,
     accountId: row.account_id,
@@ -118,31 +121,44 @@ export function loadMemorySessionMetadata(params: {
   return result.found ? result.value : undefined;
 }
 
+function readSessionArchives(db: DatabaseSync, selectors: readonly string[]) {
+  if (selectors.length === 0 || !tableExists(db, "session_transcript_archives")) {
+    return [];
+  }
+  return executeSqliteQuerySync(
+    db,
+    getNodeSqliteKysely<SessionMetadataDatabase>(db)
+      .selectFrom("session_transcript_archives")
+      .select(["archive_name", "session_id", "session_key", "created_at"])
+      .where((expression) =>
+        expression.or([
+          expression("session_id", "in", selectors),
+          expression("session_key", "in", selectors),
+        ]),
+      )
+      .orderBy("created_at")
+      .orderBy("session_id"),
+  ).rows.map((archive) => ({
+    archiveName: archive.archive_name,
+    sessionId: archive.session_id,
+    sessionKey: archive.session_key,
+    createdAt: archive.created_at,
+  }));
+}
+
 /** Resolve retained archive identities after their live session rows disappear. */
 export function loadArchivedSessions(params: {
   agentId: string;
   sessionIds: readonly string[];
-}): Array<{ archiveName: string; sessionId: string; sessionKey: string }> {
+}): Array<{ archiveName: string; sessionId: string; sessionKey: string; createdAt: number }> {
   const sessionIds = [...new Set(params.sessionIds)];
   if (sessionIds.length === 0) {
     return [];
   }
-  const result = withOpenClawAgentDatabaseReadOnly(({ db }) => {
-    if (!tableExists(db, "session_transcript_archives")) {
-      return [];
-    }
-    return executeSqliteQuerySync(
-      db,
-      getNodeSqliteKysely<SessionMetadataDatabase>(db)
-        .selectFrom("session_transcript_archives")
-        .select(["archive_name", "session_id", "session_key"])
-        .where("session_id", "in", sessionIds),
-    ).rows.map((archive) => ({
-      archiveName: archive.archive_name,
-      sessionId: archive.session_id,
-      sessionKey: archive.session_key,
-    }));
-  }, params);
+  const result = withOpenClawAgentDatabaseReadOnly(
+    ({ db }) => readSessionArchives(db, sessionIds),
+    params,
+  );
   return result.found ? result.value : [];
 }
 
@@ -158,6 +174,7 @@ export function resolveMemorySessionTargets(params: MemorySessionSelectors): Mem
   if (since !== undefined && !Number.isFinite(since)) {
     throw new Error(`Invalid memory session date: ${params.since}`);
   }
+  const resolvedSelectors = new Set<string>();
   const result = withOpenClawAgentDatabaseReadOnly(({ db }) => {
     const sessionDb = getNodeSqliteKysely<SessionMetadataDatabase>(db);
     const hasParticipants = tableExists(db, "session_participants");
@@ -202,6 +219,25 @@ export function resolveMemorySessionTargets(params: MemorySessionSelectors): Mem
       db,
       query.orderBy("session_windows.created_at").orderBy("session_windows.session_id"),
     ).rows;
+    const knownRows =
+      since === undefined || sessionIds.length === 0
+        ? rows
+        : executeSqliteQuerySync(
+            db,
+            sessionDb
+              .selectFrom("session_windows")
+              .select(["session_id", "session_key"])
+              .where((expression) =>
+                expression.or([
+                  expression("session_id", "in", sessionIds),
+                  expression("session_key", "in", sessionIds),
+                ]),
+              ),
+          ).rows;
+    for (const row of knownRows) {
+      resolvedSelectors.add(row.session_id);
+      resolvedSelectors.add(row.session_key);
+    }
     const participantIds = new Map<string, string[]>();
     if (rows.length > 0 && hasParticipants) {
       const keys = [...new Set(rows.map((row) => row.session_key))];
@@ -222,9 +258,47 @@ export function resolveMemorySessionTargets(params: MemorySessionSelectors): Mem
         participantIds.set(participant.session_key, ids);
       }
     }
-    return rows.map((row) =>
-      projectSessionMetadata(params.agentId, row, participantIds.get(row.session_key)),
+    const targets = new Map(
+      rows.map((row) => [
+        row.session_id,
+        projectSessionMetadata(params.agentId, row, participantIds.get(row.session_key)),
+      ]),
     );
+    for (const archive of readSessionArchives(db, sessionIds)) {
+      resolvedSelectors.add(archive.sessionId);
+      resolvedSelectors.add(archive.sessionKey);
+      if (targets.has(archive.sessionId) || (since !== undefined && archive.createdAt < since)) {
+        continue;
+      }
+      targets.set(archive.sessionId, {
+        agentId: params.agentId,
+        sessionId: archive.sessionId,
+        sessionKey: archive.sessionKey,
+        resolution: "archived",
+        hookExternalContentSource: null,
+        channel: null,
+        accountId: null,
+        chatType: null,
+        createdAt: archive.createdAt,
+        participantIds: [],
+      });
+    }
+    return [...targets.values()];
   }, params);
-  return result.found ? result.value : [];
+  const targets = result.found ? result.value : [];
+  for (const sessionId of sessionIds) {
+    if (!resolvedSelectors.has(sessionId)) {
+      targets.push({
+        agentId: params.agentId,
+        sessionId,
+        resolution: "unresolved",
+        hookExternalContentSource: null,
+        channel: null,
+        accountId: null,
+        chatType: null,
+        participantIds: [],
+      });
+    }
+  }
+  return targets;
 }

--- a/src/plugin-sdk/sqlite-runtime.ts
+++ b/src/plugin-sdk/sqlite-runtime.ts
@@ -5,6 +5,7 @@ export {
   openOpenClawAgentDatabase,
   resolveOpenClawAgentSqlitePath,
 } from "../state/openclaw-agent-db.js";
+export { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
 export { ensureOpenClawAgentStandingIntentsSchema } from "../state/openclaw-agent-standing-intents-schema.js";
 export {
   executeSqliteQuerySync,

--- a/src/state/openclaw-agent-db-readonly.ts
+++ b/src/state/openclaw-agent-db-readonly.ts
@@ -18,7 +18,7 @@ import {
   isIncognitoOpenClawAgentSqlitePath,
   resolveOpenClawAgentSqlitePath,
 } from "./openclaw-agent-db.paths.js";
-import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db.js";
+import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db-contract.js";
 
 type OpenClawAgentReadOnlyDatabase = {
   agentId: string;
@@ -59,7 +59,7 @@ function findOpenAgentDatabase(
 export function withOpenClawAgentDatabaseReadOnly<T>(
   operation: (database: OpenClawAgentReadOnlyDatabase) => T,
   options: OpenClawAgentDatabaseOptions,
-  behavior: { throwOnMissingTable?: boolean } = {},
+  behavior: { throwOnMissingTable?: boolean; allowExtension?: boolean } = {},
 ): OpenClawAgentDatabaseReadOnlyResult<T> {
   const agentId = normalizeAgentId(options.agentId);
   const pathname = resolveOpenClawAgentSqlitePath({ ...options, agentId });
@@ -67,6 +67,9 @@ export function withOpenClawAgentDatabaseReadOnly<T>(
     // Read-only misses must not create process-lifetime handles; only creation and
     // write paths may materialize the process-held incognito database.
     const database = getOpenClawAgentDatabaseIfOpen({ ...options, agentId });
+    if (database && behavior.allowExtension) {
+      throw new Error("Extension-capable read-only access is unavailable for incognito databases.");
+    }
     return database
       ? { found: true, value: operation(database) }
       : { found: false, reason: "database-missing" };
@@ -75,7 +78,9 @@ export function withOpenClawAgentDatabaseReadOnly<T>(
   // opening and closing a connection per call made reads scale with row count.
   // An in-flight transaction is skipped so callers never observe uncommitted
   // rows that a fresh read-only connection could not have seen.
-  const opened = findOpenAgentDatabase({ ...options, agentId });
+  const opened = behavior.allowExtension
+    ? undefined
+    : findOpenAgentDatabase({ ...options, agentId });
   if (opened && !opened.db.isTransaction) {
     // A newer build can migrate this file while the handle stays open, so the
     // forward-compatibility gate still runs before any reused read.
@@ -92,7 +97,10 @@ export function withOpenClawAgentDatabaseReadOnly<T>(
   if (!fs.existsSync(pathname)) {
     return { found: false, reason: "database-missing" };
   }
-  const db = openNodeSqliteDatabase(pathname, { readOnly: true });
+  const db = openNodeSqliteDatabase(pathname, {
+    readOnly: true,
+    ...(behavior.allowExtension ? { allowExtension: true } : {}),
+  });
   try {
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
     assertSupportedAgentSchemaVersion(db, pathname);

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -59,6 +59,8 @@ type ExistingAgentSchemaMeta = {
 const AGENT_SCHEMA_COMPATIBILITY = {
   allowCompatibleAdditiveColumns: true,
   allowedMissingTables: [
+    "memory_entry_origins",
+    "memory_session_tombstones",
     MEMORY_INDEX_CHUNK_PROVENANCE_TABLE,
     MEMORY_INDEX_CHUNK_RECALL_METADATA_TABLE,
     CONTEXT_ENGINE_TURN_OUTBOX_TABLE,

--- a/src/state/openclaw-agent-db.generated.d.ts
+++ b/src/state/openclaw-agent-db.generated.d.ts
@@ -147,6 +147,15 @@ export interface MemoryEmbeddingCache {
   updated_at: number;
 }
 
+export interface MemoryEntryOrigins {
+  agent_id: string;
+  entry_key: string;
+  observed_at: number;
+  origin_class: string;
+  session_id: string;
+  session_key: string | null;
+}
+
 export interface MemoryIndexChunkProvenance {
   chunk_id: string;
   observed_at: number;
@@ -192,6 +201,13 @@ export interface MemoryIndexSources {
 export interface MemoryIndexState {
   id: Generated<number>;
   revision: number;
+}
+
+export interface MemorySessionTombstones {
+  agent_id: string;
+  created_at: number;
+  reason: string;
+  session_id: string;
 }
 
 export interface MessageToolRunOutcomes {
@@ -490,12 +506,14 @@ export interface DB {
   conversations: Conversations;
   heartbeat_outcomes: HeartbeatOutcomes;
   memory_embedding_cache: MemoryEmbeddingCache;
+  memory_entry_origins: MemoryEntryOrigins;
   memory_index_chunk_provenance: MemoryIndexChunkProvenance;
   memory_index_chunk_recall_metadata: MemoryIndexChunkRecallMetadata;
   memory_index_chunks: MemoryIndexChunks;
   memory_index_meta: MemoryIndexMeta;
   memory_index_sources: MemoryIndexSources;
   memory_index_state: MemoryIndexState;
+  memory_session_tombstones: MemorySessionTombstones;
   message_tool_run_outcomes: MessageToolRunOutcomes;
   schema_meta: SchemaMeta;
   session_conversations: SessionConversations;

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -51,6 +51,7 @@ import {
   resolveOpenClawAgentSqlitePath,
   runOpenClawAgentWriteTransaction,
 } from "./openclaw-agent-db.js";
+import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
 import {
   closeOpenClawStateDatabaseForTest,
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
@@ -1026,6 +1027,28 @@ describe("openclaw agent database", () => {
       reason: "database-missing",
     });
     expect(fs.existsSync(databasePath)).toBe(false);
+  });
+
+  it("opens extension-capable reads separately from the owner without enabling writes", () => {
+    const stateDir = createTempStateDir();
+    const options = {
+      agentId: "worker-1",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    };
+    const owner = openOpenClawAgentDatabase(options);
+
+    const result = withOpenClawAgentDatabaseReadOnly(
+      ({ db }) => {
+        expect(db).not.toBe(owner.db);
+        expect(() => db.enableLoadExtension(true)).not.toThrow();
+        expect(() => db.prepare("DELETE FROM auth_profile_store").run()).toThrow(/readonly/iu);
+        return db.prepare("SELECT agent_id FROM schema_meta WHERE meta_key = 'primary'").get();
+      },
+      options,
+      { allowExtension: true },
+    );
+
+    expect(result).toEqual({ found: true, value: { agent_id: "worker-1" } });
   });
 
   it("refuses a newer schema from the read-only database helper", () => {
@@ -3585,6 +3608,48 @@ describe("openclaw agent database", () => {
     } finally {
       repaired.close();
     }
+  });
+
+  it("keeps memory provenance tables independently lazy and accepts their same-version installation", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const olderShape = new DatabaseSync(databasePath);
+    olderShape.exec("DROP TABLE memory_entry_origins; DROP TABLE memory_session_tombstones;");
+    olderShape.close();
+
+    const opened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const findMemoryTable = (name: string) =>
+      opened.db.prepare("SELECT strict FROM pragma_table_list WHERE name = ?").get(name);
+    expect(findMemoryTable("memory_entry_origins")).toBeUndefined();
+    expect(findMemoryTable("memory_session_tombstones")).toBeUndefined();
+    expect(readSqliteNumberPragma(opened.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+
+    for (const name of ["memory_entry_origins", "memory_session_tombstones"]) {
+      const canonicalSchema = OPENCLAW_AGENT_SCHEMA_SQL.match(
+        new RegExp(`CREATE TABLE IF NOT EXISTS ${name} \\([\\s\\S]*?\\) STRICT;`, "u"),
+      )?.[0];
+      if (!canonicalSchema) {
+        throw new Error(`Canonical ${name} schema is missing.`);
+      }
+      opened.db.exec(canonicalSchema);
+      opened.db.exec(canonicalSchema);
+      expect(findMemoryTable(name)).toEqual({ strict: 1 });
+      if (name === "memory_entry_origins") {
+        expect(findMemoryTable("memory_session_tombstones")).toBeUndefined();
+      }
+    }
+    expect(readSqliteNumberPragma(opened.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+
+    closeOpenClawAgentDatabaseByPath(databasePath);
+    const reopened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    for (const name of ["memory_entry_origins", "memory_session_tombstones"]) {
+      expect(
+        reopened.db.prepare("SELECT strict FROM pragma_table_list WHERE name = ?").get(name),
+      ).toEqual({ strict: 1 });
+    }
+    expect(readSqliteNumberPragma(reopened.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
   });
 
   it("rejects a missing current-schema table instead of recreating it empty", () => {

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -558,6 +558,23 @@ CREATE TABLE IF NOT EXISTS memory_index_chunk_provenance (
   FOREIGN KEY (chunk_id) REFERENCES memory_index_chunks(id) ON DELETE CASCADE
 ) STRICT;
 
+CREATE TABLE IF NOT EXISTS memory_entry_origins (
+  entry_key TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  session_key TEXT,
+  origin_class TEXT NOT NULL CHECK (origin_class IN ('owner', 'agent', 'untrusted', 'system')),
+  observed_at INTEGER NOT NULL,
+  PRIMARY KEY (entry_key, agent_id, session_id)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS memory_session_tombstones (
+  session_id TEXT NOT NULL PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS memory_embedding_cache (
   provider TEXT NOT NULL,
   model TEXT NOT NULL,

--- a/src/state/openclaw-database-verify.worker.ts
+++ b/src/state/openclaw-database-verify.worker.ts
@@ -1,10 +1,4 @@
-import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
-import {
-  assertSqliteIntegrity,
-  isTerminalSqliteIntegrityError,
-} from "../infra/sqlite-integrity.js";
-import { prepareSqliteReadOnlyLocationInProcess } from "../infra/sqlite-readonly-location.js";
-import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db.js";
+import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db-contract.js";
 
 const DATABASE_VERIFY_CHILD_ARG = "--openclaw-database-verify-child";
 
@@ -40,20 +34,25 @@ function formatVerifyError(error: unknown): string {
 async function verifyOpenClawDatabase(
   target: OpenClawDatabaseVerifyTarget,
 ): Promise<OpenClawDatabaseVerifyResult> {
+  const [sqlite, integrity, location] = await Promise.all([
+    import("../infra/node-sqlite.js"),
+    import("../infra/sqlite-integrity.js"),
+    import("../infra/sqlite-readonly-location.js"),
+  ]);
   let cleanup: (() => boolean) | undefined;
   let database: import("node:sqlite").DatabaseSync | undefined;
   let result = await (async (): Promise<OpenClawDatabaseVerifyResult> => {
     try {
-      const prepared = await prepareSqliteReadOnlyLocationInProcess(target.path);
+      const prepared = await location.prepareSqliteReadOnlyLocationInProcess(target.path);
       cleanup = prepared.cleanup;
-      database = openNodeSqliteDatabase(prepared.location, {
+      database = sqlite.openNodeSqliteDatabase(prepared.location, {
         readOnly: true,
       });
       database.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-      assertSqliteIntegrity(database, target.label);
+      integrity.assertSqliteIntegrity(database, target.label);
       return { path: target.path, ok: true };
     } catch (error) {
-      const terminal = error instanceof Error && isTerminalSqliteIntegrityError(error);
+      const terminal = error instanceof Error && integrity.isTerminalSqliteIntegrityError(error);
       return {
         path: target.path,
         ok: false,


### PR DESCRIPTION
## What Problem This Solves

Enterprise operators need two guarantees the built-in memory system could not give: **admission** (content from named sources — email connectors, specific channels — must be excludable from durable memory by policy, deterministically) and **deletion** ("purge every memory derived from session X / person Y / all Gmail-derived sessions" must be executable and auditable — employee exit and GDPR erasure are the driving cases). Until now the source session id was available at every memory write site but never recorded as a queryable fact, and dreaming consolidation merges entries across sessions, so no deterministic join from a memory back to its source sessions existed.

Accepted design: `docs/plan/memory-provenance.md` (in this PR).

## Why This Change Was Made

Direct maintainer request (operator-accepted design, 2026-08-25) following enterprise discussions where the blocking questions were "can email stay out of memory?" and "how do we prune a departed person out of an agent's memory?".

Three coordinated parts, all owned where the facts are produced:

1. **Admission policy** — `plugins.entries.memory-core.config.memoryPolicy.excludeSessions` (`hookExternalContentSources`, `channels`, `chatTypes`). Matching sessions never enter the dreaming corpus; the exclusion is recorded in ingestion state as a visible non-outcome (removing the policy re-admits). Pipeline-only by design: an agent in an excluded session can still edit memory files directly during its turn; that boundary is documented and those writes are surfaced by `forget` (below).
2. **Entry origins** — new additive per-agent table `memory_entry_origins` (entry_key, agent_id, session_id, session_key, origin_class, observed_at). Recorded when session-derived candidates are formed; maintained deterministically through consolidation (origin sets union on merge, re-key on supersede) — the LLM never carries provenance. Every durable promotion write now emits the canonical `<!-- openclaw-memory-promotion:KEY -->` marker so entries stay hash-addressable in memory files.
3. **`openclaw memory forget`** — resolves a session set (`--session` id-or-key, `--hook-source`, `--participant`, `--since`; repeatable) from the authoritative session tables and purges whole entries plus every derived artifact: memory-file entries by marker, verbatim quoted lines in dream diaries/DREAMS.md, session-corpus lines, index chunks (FTS + vec + recall metadata + provenance via cascade), sources, embedding-cache rows, short-term recall state, seen-hash scopes, and dreaming memory backups. `--dry-run` produces the identical report without writing; `--json` emits the typed report.

Live testing surfaced and fixed five defects that unit tests alone missed:

- **Purge resurrection**: forget cleared seen-hash state, so the next dreaming sweep re-ingested the purged session (verified live: corpus, diary quote, and origins all came back). Fix: forget writes durable `memory_session_tombstones` rows; dreaming ingestion, session backfill, and transcript indexing all treat tombstoned sessions as excluded (`excludedReason: "forgotten"`), and forget is idempotent.
- **Narrative transcript index leak**: dreaming-narrative subagent transcripts (including retained `.zst` archives) were indexed into the memory index quoting raw corpus fragments — hidden from search results by visibility filtering but present in FTS/vec. Real archives carry narrative identity only on `message.__openclaw.runId` (verified against the codex protocol source in `../codex`); classification now uses that authoritative identity plus `session_transcript_archives`, exclusion runs before enumeration, and sync/reindex prunes pre-existing debris.
- **Unmarked plain-append promotions**: the non-consolidation promotion path wrote MEMORY.md entries without markers, making them unforgettable; markers are now emitted by one shared builder on every durable promotion write.
- **Verbatim diary quotes**: dream-diary lines quoting purged corpus snippets survived; forget now scrubs lines containing purged snippets across workspace memory files (LLM-paraphrased prose remains a documented boundary).
- **Harness-blind curated writes**: with the default codex harness, "remember X" edits MEMORY.md via `apply_patch`, invisible to the native memory-write observer. The write observer now records session identity (native tools + session-memory hook), and forget additionally derives `curatedWrites` from the purged sessions' transcripts (live + archived, all harness dialects, defensive parsing) — reported with path + timestamp, never auto-edited.

**Schema note (review checkpoint per `docs/reference/database-schemas.md`)**: two additive tables in the per-agent DB at the current schema version — `memory_entry_origins` and `memory_session_tombstones` — declared canonically in `openclaw-agent-schema.sql` plus one-time idempotent lazy ensure on first feature use; registered in the additive compatibility allowlist so older readers stay safe. Design and acceptance recorded in `docs/plan/memory-provenance.md`.

## User Impact

- Operators can keep named sources (e.g. Gmail-derived sessions) out of durable memory with three config keys, and see excluded sessions recorded rather than silently skipped.
- `openclaw memory forget` gives a deterministic, auditable purge with dry-run preview, typed JSON report, mixed-lineage and untargetable entries called out, `curatedWrites` surfacing agent-authored file edits from the purged sessions, and retained source transcripts reported (session store owns those).
- Purged sessions can never re-enter memory: tombstones fence dreaming ingestion, backfill, and transcript indexing permanently.
- Internal dreaming/cron/heartbeat transcripts no longer pollute the memory index.
- Docs: `docs.openclaw.ai/cli/memory` (forget) and `docs.openclaw.ai/reference/memory-config` (admission policy) updated; design note `docs/plan/memory-provenance.md`.

## Evidence

Live E2E on an isolated dev gateway (own `OPENCLAW_STATE_DIR`, port 19801, real OpenAI provider `gpt-5.6-luna`, real dreaming cron sweeps, real embeddings). Synthetic sessions with distinctive random facts; one session tainted `hook_external_content_source='gmail'`:

- Admission: tainted session never reached the corpus; checkpoint records `excludedReason: hookExternalContentSource:gmail`; clean facts ingested (corpus grep proof).
- Origins: per-session rows with correct origin classes; none for the excluded session.
- Purge: `forget --session <id>` removed corpus lines, diary quote lines, index chunk, FTS row, vec row, embedding-cache row, short-term entries, seen-hash scope, and origin rows (dry-run report identical to real run).
- Anti-resurrection: forced dreaming sweep after purge re-ingested nothing (`excludedReason: "forgotten"` recorded, corpus clean, zero origins); forced reindex did not resurrect the purged session's transcript chunks.
- Narrative debris: after the fix, `memory index --force` dropped the indexed file set from 16 to 9, zero `.zst` narrative sources/chunks remain, and FTS matches for both purged facts are zero.
- Curated writes: a codex-harness session that edited MEMORY.md via `apply_patch` (verified in transcript) is reported in `curatedWrites` with path and timestamp.
- Selector proof: `--hook-source gmail` resolved the tainted session from its recorded session-window fact, purged its transcript-index rows, and tombstoned it.
- Survivors: unrelated memories remain recallable via `memory search` after all purges.

Validation (all green on the final tree): `pnpm check:changed`; `pnpm test extensions/memory-core` (1,188 passed / 3 skipped); `pnpm test src/state` (542 passed / 7 skipped); `pnpm build` (no new `[INEFFECTIVE_DYNAMIC_IMPORT]`); `node scripts/generate-kysely-types.mts --verify`; `node scripts/check-docs-config-examples.mjs` (1,195 examples); `git diff --check`. Regression tests for each live-found defect fail on pre-fix code (verified during development). Codex protocol contracts for `apply_patch` shapes verified directly against `../codex/codex-rs/protocol/src/models.rs`, `items.rs`, and `core/src/tools/handlers/apply_patch.rs`.

Production LOC: +1,804 / −84 across core + memory-core + memory-host-sdk; tests +1,647; docs +373; generated typings +18. The growth is the new capability surface (provenance store, tombstones, purge engine, admission policy, CLI command) named above.
