### PR TITLE
fix(onboarding): --skip-bootstrap still creates identity files

### DIFF
--- a/src/agents/agent-create.test.ts
+++ b/src/agents/agent-create.test.ts
@@ -565,16 +565,26 @@ describe("createAgent", () => {
     expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
   });
 
-  it("respects skipBootstrap from the current config", async () => {
+  it.each([
+    { label: "configured", configured: true, override: undefined, ensureBootstrapFiles: false },
+    { label: "explicitly enabled", configured: false, override: true, ensureBootstrapFiles: false },
+    { label: "explicitly disabled", configured: true, override: false, ensureBootstrapFiles: true },
+  ])("respects $label bootstrap skipping for workspace and identity", async (policy) => {
     mocks.config = {
-      agents: { defaults: { skipBootstrap: true }, list: [{ id: "main" }] },
+      agents: { defaults: { skipBootstrap: policy.configured }, list: [{ id: "main" }] },
     };
+    mocks.ensureAgentWorkspace.mockResolvedValue({ dir: "/tmp/work", bootstrapPending: false });
 
-    await createAgent({ name: "researcher", workspace: "/tmp/work" });
+    await createAgent({
+      name: "researcher",
+      workspace: "/tmp/work",
+      ...(policy.override === undefined ? {} : { skipBootstrap: policy.override }),
+    });
 
     expect(mocks.ensureAgentWorkspace).toHaveBeenCalledWith(
-      expect.objectContaining({ ensureBootstrapFiles: false }),
+      expect.objectContaining({ ensureBootstrapFiles: policy.ensureBootstrapFiles }),
     );
+    expect(mocks.rootWrite).toHaveBeenCalledTimes(policy.ensureBootstrapFiles ? 1 : 0);
   });
 
   it("persists the authoritative workspace returned by setup", async () => {

--- a/src/agents/agent-create.ts
+++ b/src/agents/agent-create.ts
@@ -410,12 +410,10 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
 
           // The outer lock makes this result-bearing transform single-attempt: setup
           // finishes before the final entry becomes visible to readers or delete flows.
+          const skipBootstrap = params.skipBootstrap ?? nextConfig.agents?.defaults?.skipBootstrap;
           const workspace = await ensureAgentWorkspace({
             dir: workspaceDir,
-            ensureBootstrapFiles:
-              params.skipBootstrap === undefined
-                ? !nextConfig.agents?.defaults?.skipBootstrap
-                : !params.skipBootstrap,
+            ensureBootstrapFiles: !skipBootstrap,
             skipOptionalBootstrapFiles:
               params.skipOptionalBootstrapFiles ??
               nextConfig.agents?.defaults?.skipOptionalBootstrapFiles,
@@ -440,7 +438,7 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
           await fs.mkdir(resolveSessionTranscriptsDirForAgent(agentId), { recursive: true });
           // A creation-time name is config, not proof that the fresh workspace hatched.
           // Keep IDENTITY.md templated until BOOTSTRAP completes its first-turn ceremony.
-          if (!workspace.bootstrapPending) {
+          if (!workspace.bootstrapPending && !skipBootstrap) {
             await writeIdentityFile({ workspaceDir: workspace.dir, identity });
           }
           // The receipt owns compensation until the config transform publishes this result.


### PR DESCRIPTION
Closes #130132

## What Problem This Solves

Fixes an issue where users onboarding their first agent with `--skip-bootstrap` would still find an unwanted `IDENTITY.md` in the new workspace, even though the documented option explicitly promises to skip that file along with the other bootstrap templates.

## Why This Change Was Made

The agent-creation owner correctly suppressed workspace bootstrap templates but separately treated "no bootstrap pending" as permission to create the identity file. Resolve the effective bootstrap policy once and apply it consistently to both operations while preserving explicit per-call overrides and ordinary identity creation.

## User Impact

Operators can create genuinely bootstrap-free agent workspaces. Standard onboarding still creates all normal bootstrap files, and an explicit `skipBootstrap: false` continues to override a configured default.

## Evidence

- Before the production change, the new owner-boundary regression failed for both inherited and explicitly enabled bootstrap suppression, while the explicit `false` override passed.
- After the change, all 46 existing and new agent-creation tests pass.
- Real isolated SQLite-backed `applySystemAgentSetup` and first-agent creation changed from `bootstrapFiles: ["IDENTITY.md"]` to `bootstrapFiles: []` for suppressed onboarding.
- The real normal-onboarding control still creates `AGENTS.md`, `BOOTSTRAP.md`, `IDENTITY.md`, `SOUL.md`, and `USER.md`.
- Formatting and an independent Codex autoreview both passed without findings.
- Production change: +3/-5 lines, net -2. Regression tests: +14/-4 lines.

AI-assisted, independently reviewed against the actual onboarding owner and filesystem behavior.
