### PR TITLE
perf(agents): avoid unused extension contexts during streaming

### DIFF
--- a/src/agents/sessions/extensions/runner.test.ts
+++ b/src/agents/sessions/extensions/runner.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { ModelRegistry } from "../model-registry.js";
 import type { SessionManager } from "../session-manager.js";
+import { createExtensionRuntime } from "./loader.js";
 import { ExtensionRunner } from "./runner.js";
-import type { Extension, ExtensionRuntime } from "./types.js";
+import type {
+  Extension,
+  ExtensionActions,
+  ExtensionContext,
+  ExtensionContextActions,
+} from "./types.js";
 
 type TestHandler = (...args: unknown[]) => Promise<unknown>;
 type TestHandlers = Record<string, TestHandler[]>;
@@ -29,7 +35,7 @@ function buildExtension(handlers?: TestHandlers, path = "/tmp/test-extension.ts"
 function buildRunner(extensions: Extension[]): ExtensionRunner {
   return new ExtensionRunner(
     extensions,
-    {} as ExtensionRuntime,
+    createExtensionRuntime(),
     "/tmp",
     {} as SessionManager,
     {} as ModelRegistry,
@@ -225,5 +231,153 @@ describe("ExtensionRunner handler dispatch", () => {
       }),
     ).rejects.toBe(failure);
     expect(laterHandler).not.toHaveBeenCalled();
+  });
+});
+
+describe("ExtensionRunner context construction", () => {
+  function messageUpdateEvent() {
+    return {
+      type: "message_update",
+      message: buildMessages()[1],
+      assistantMessageEvent: { type: "text_delta", delta: "hi", contentIndex: 0 },
+    } as Parameters<ExtensionRunner["emit"]>[0];
+  }
+
+  it.each([
+    { name: "no extensions", extensions: [] },
+    {
+      name: "unrelated handlers",
+      extensions: [buildExtension({ user_bash: [async () => undefined] })],
+    },
+  ])("skips streaming contexts with $name", async ({ extensions }) => {
+    const runner = buildRunner(extensions);
+    const createContext = vi.spyOn(runner, "createContext");
+
+    await runner.emit(messageUpdateEvent());
+    await runner.emit({
+      type: "tool_execution_update",
+      toolCallId: "call-1",
+      toolName: "custom",
+      args: {},
+      partialResult: {},
+    });
+
+    expect(createContext).not.toHaveBeenCalled();
+  });
+
+  it("shares one context across matching streaming handlers", async () => {
+    const contexts: unknown[] = [];
+    const record: TestHandler = async (_event, context) => void contexts.push(context);
+    const runner = buildRunner([
+      buildExtension({ message_update: [record] }, "/tmp/first.ts"),
+      buildExtension({ message_update: [record] }, "/tmp/second.ts"),
+    ]);
+    const createContext = vi.spyOn(runner, "createContext");
+
+    await runner.emit(messageUpdateEvent());
+
+    expect(createContext).toHaveBeenCalledOnce();
+    expect(contexts).toHaveLength(2);
+    expect(contexts[0]).toBe(contexts[1]);
+  });
+
+  it("propagates context construction failures outside extension handler isolation", async () => {
+    const failure = new Error("context construction failed");
+    const runner = buildRunner([buildExtension({ message_update: [async () => undefined] })]);
+    vi.spyOn(runner, "createContext").mockImplementation(() => {
+      throw failure;
+    });
+    const errors: unknown[] = [];
+    runner.onError((error) => errors.push(error));
+
+    await expect(runner.emit(messageUpdateEvent())).rejects.toBe(failure);
+    expect(errors).toEqual([]);
+  });
+
+  it("skips tool-call context construction without a matching handler", async () => {
+    const runner = buildRunner([buildExtension({ user_bash: [async () => undefined] })]);
+    const createContext = vi.spyOn(runner, "createContext");
+
+    await runner.emitToolCall({
+      type: "tool_call",
+      toolName: "custom",
+      toolCallId: "call-1",
+      input: {},
+    });
+
+    expect(createContext).not.toHaveBeenCalled();
+  });
+
+  it("preserves supplied context identity and its evolving system prompt", async () => {
+    const contexts: ExtensionContext[] = [];
+    const prompts: string[] = [];
+    const runner = buildRunner([
+      buildExtension({
+        before_agent_start: [
+          async (_event, value) => {
+            const context = value as ExtensionContext;
+            contexts.push(context);
+            prompts.push(context.getSystemPrompt());
+            return { systemPrompt: "updated" };
+          },
+          async (_event, value) => {
+            const context = value as ExtensionContext;
+            contexts.push(context);
+            prompts.push(context.getSystemPrompt());
+          },
+        ],
+      }),
+    ]);
+    const createContext = vi.spyOn(runner, "createContext");
+
+    await expect(
+      runner.emitBeforeAgentStart("hello", undefined, "original", { cwd: "/tmp" }),
+    ).resolves.toMatchObject({ systemPrompt: "updated" });
+
+    expect(createContext).toHaveBeenCalledOnce();
+    expect(contexts[0]).toBe(contexts[1]);
+    expect(prompts).toEqual(["original", "updated"]);
+  });
+
+  it("keeps lazy live context guards while retaining its captured model getter", () => {
+    const runner = buildRunner([]);
+    const firstGetModel = vi.fn(() => undefined);
+    const secondGetModel = vi.fn(() => undefined);
+    const buildActions = (
+      getModel: ExtensionContextActions["getModel"],
+      idle: boolean,
+    ): ExtensionContextActions => ({
+      getModel,
+      isIdle: () => idle,
+      getSignal: () => undefined,
+      abort: () => {},
+      hasPendingMessages: () => false,
+      shutdown: () => {},
+      getContextUsage: () => undefined,
+      compact: () => {},
+      getSystemPrompt: () => "system",
+    });
+
+    runner.bindCore({} as ExtensionActions, buildActions(firstGetModel, true));
+    const context = runner.createContext();
+    const commandContext = runner.createCommandContext();
+    expect(typeof Object.getOwnPropertyDescriptor(context, "ui")?.get).toBe("function");
+    expect(typeof Object.getOwnPropertyDescriptor(commandContext, "ui")?.get).toBe("function");
+
+    const updatedUi = { ...runner.getUIContext() };
+    runner.setUIContext(updatedUi);
+    runner.bindCore({} as ExtensionActions, buildActions(secondGetModel, false));
+
+    expect(context.ui).toBe(updatedUi);
+    expect(context.hasUI).toBe(true);
+    expect(context.isIdle()).toBe(false);
+    expect(context.model).toBeUndefined();
+    expect(firstGetModel).toHaveBeenCalledOnce();
+    expect(secondGetModel).not.toHaveBeenCalled();
+
+    runner.invalidate("session replaced");
+    expect(() => context.ui).toThrow("session replaced");
+    expect(() => context.isIdle()).toThrow("session replaced");
+    expect(() => commandContext.cwd).toThrow("session replaced");
   });
 });

--- a/src/agents/sessions/extensions/runner.ts
+++ b/src/agents/sessions/extensions/runner.ts
@@ -595,78 +595,42 @@ export class ExtensionRunner {
    * Context values are resolved at call time, so changes via bindCore/bindUI are reflected.
    */
   createContext(): ExtensionContext {
-    const assertActive = () => this.assertActive();
+    const requireActiveRunner = () => {
+      this.assertActive();
+      return this;
+    };
+    // Model selection snapshots its getter; all other context values stay live.
     const getModel = this.getModel;
-    const getUiContext = () => this.uiContext;
-    const hasUiContext = () => this.hasUI();
-    const getCwd = () => this.cwd;
-    const getSessionManager = () => this.sessionManager;
-    const getModelRegistry = () => this.modelRegistry;
-    const isIdle = () => this.isIdleFn();
-    const getSignal = () => this.getSignalFn();
-    const abort = () => this.abortFn();
-    const hasPendingMessages = () => this.hasPendingMessagesFn();
-    const shutdown = () => this.shutdownHandler();
-    const getContextUsage = () => this.getContextUsageFn();
-    const compact = (options?: CompactOptions) => this.compactFn(options);
-    const getSystemPrompt = () => this.getSystemPromptFn();
     return {
       get ui() {
-        assertActive();
-        return getUiContext();
+        return requireActiveRunner().uiContext;
       },
       get hasUI() {
-        assertActive();
-        return hasUiContext();
+        return requireActiveRunner().hasUI();
       },
       get cwd() {
-        assertActive();
-        return getCwd();
+        return requireActiveRunner().cwd;
       },
       get sessionManager() {
-        assertActive();
-        return getSessionManager();
+        return requireActiveRunner().sessionManager;
       },
       get modelRegistry() {
-        assertActive();
-        return getModelRegistry();
+        return requireActiveRunner().modelRegistry;
       },
       get model() {
-        assertActive();
+        requireActiveRunner();
         return getModel();
       },
-      isIdle: () => {
-        assertActive();
-        return isIdle();
-      },
+      isIdle: () => requireActiveRunner().isIdleFn(),
       get signal() {
-        assertActive();
-        return getSignal();
+        return requireActiveRunner().getSignalFn();
       },
-      abort: () => {
-        assertActive();
-        abort();
-      },
-      hasPendingMessages: () => {
-        assertActive();
-        return hasPendingMessages();
-      },
-      shutdown: () => {
-        assertActive();
-        shutdown();
-      },
-      getContextUsage: () => {
-        assertActive();
-        return getContextUsage();
-      },
-      compact: (options) => {
-        assertActive();
-        compact(options);
-      },
-      getSystemPrompt: () => {
-        assertActive();
-        return getSystemPrompt();
-      },
+      abort: () => requireActiveRunner().abortFn(),
+      hasPendingMessages: () => requireActiveRunner().hasPendingMessagesFn(),
+      shutdown: () => requireActiveRunner().shutdownHandler(),
+      getContextUsage: () => requireActiveRunner().getContextUsageFn(),
+      compact: (options) => requireActiveRunner().compactFn(options),
+      getSystemPrompt: () => requireActiveRunner().getSystemPromptFn(),
     };
   }
 
@@ -721,12 +685,15 @@ export class ExtensionRunner {
       ctx: ExtensionContext,
       extensionPath: string,
     ) => Promise<TResult | undefined>,
-    ctx = this.createContext(),
+    ctx?: ExtensionContext,
   ): Promise<TResult | undefined> {
+    let handlerContext = ctx;
     for (const ext of this.extensions) {
       for (const handler of ext.handlers.get(eventType) ?? []) {
+        // Context construction is a runner fault, not an isolated handler failure.
+        handlerContext ??= this.createContext();
         try {
-          const result = await invoke(handler, ctx, ext.path);
+          const result = await invoke(handler, handlerContext, ext.path);
           if (result !== undefined) {
             return result;
           }
@@ -816,7 +783,7 @@ export class ExtensionRunner {
   }
 
   async emitToolCall(event: ToolCallEvent): Promise<ToolCallEventResult | undefined> {
-    const ctx = this.createContext();
+    let ctx: ExtensionContext | undefined;
     let result: ToolCallEventResult | undefined;
 
     for (const ext of this.extensions) {
@@ -826,6 +793,7 @@ export class ExtensionRunner {
       }
 
       for (const handler of handlers) {
+        ctx ??= this.createContext();
         const handlerResult = await handler(event, ctx);
 
         if (handlerResult) {


### PR DESCRIPTION
## Summary

Streaming replies dispatched `message_update` and `tool_execution_update` events through a default parameter that eagerly built an extension context even when no plugin handled the event. `tool_call` repeated the same ownership mistake. The default no-plugin path consequently allocated and immediately discarded a context for every streamed update.

Defer context construction until the first matching handler in both dispatch owners, keep one shared context per dispatch, and preserve explicitly supplied contexts. Simplify the existing public `ExtensionRunner.createContext()` implementation around one active-runner lifecycle fence, replacing fourteen redundant closure captures while preserving lazy property descriptors, live UI and action rebinding, invalidation checks, and the separately captured model getter.

This follows and improves the original diagnosis and proposed repair from @quangtran88 in #129365. Thank you, Tran Quang, for identifying and proving the streaming hot-path problem.

Production code: **26 additions, 58 deletions (net -32 lines)**. Regression tests: **156 additions, 2 deletions**. No plugin API, configuration, persistence, or security-boundary changes.

## Verification

- Tests-first baseline on unchanged production: **3 failed, 17 passed**. The failures independently reproduce unnecessary context allocation for `message_update`, `tool_execution_update`, and `tool_call`.
- An unrelated existing command-test mock failure appeared in the first hosted CI run; after its canonical repair landed independently in #130149, this unchanged runner patch was rebased onto repaired `main` and the exact previously failing command suites passed **27 tests**.
- Final owner, extension-loader, and agent-session SDK coverage: **5 files, 63 tests passed**.
- Regression coverage also preserves one shared context for multiple handlers, explicitly supplied before-agent-start contexts and evolving prompts, construction failures outside handler isolation, lazy public context descriptors, live rebinding, captured model getters, and invalidated runner contexts.
- Full type-aware and type-checking lint passed for both changed production and test files.
- Scoped formatting, two independent architecture/security reviews, and a fresh full-diff automated review passed.

Related: #129359
