### PR TITLE
fix(onboarding): missing ESM package errors omit the repair hint

### DIFF
--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -112,6 +112,21 @@ describe("logNonInteractiveOnboardingFailure", () => {
         commands: ["doctor --fix"],
       },
       {
+        detail: "Cannot find package 'typebox' imported from /app/plugin.mjs",
+        commands: ["doctor --fix"],
+      },
+      {
+        detail: "ERR_MODULE_NOT_FOUND",
+        commands: ["doctor --fix"],
+      },
+      {
+        detail: "connect ECONNREFUSED",
+        diagnostics: {
+          lastGatewayError: "Cannot find package '@openclaw/example' imported from /app/plugin.mjs",
+        },
+        commands: ["doctor --fix"],
+      },
+      {
         detail: "connect ECONNREFUSED",
         diagnostics: {
           service: {

--- a/src/commands/onboard-non-interactive/local/output.ts
+++ b/src/commands/onboard-non-interactive/local/output.ts
@@ -119,7 +119,7 @@ export function classifyGatewayHealthFailure(params: {
     return "auth-mismatch";
   }
   if (
-    /\b(?:runtime[- ]deps?|runtime dependencies|cannot find module|sqlite-vec|loadextension)\b/i.test(
+    /\b(?:runtime[- ]deps?|runtime dependencies|cannot find (?:module|package)|(?:err_)?module_not_found|sqlite-vec|loadextension)\b/i.test(
       combined,
     )
   ) {


### PR DESCRIPTION
Closes #130155

## What Problem This Solves

Fixes an issue where users running noninteractive onboarding would receive no useful repair hint, or an unrelated Gateway-status hint, when a required ES-module package was missing. Supported Node versions report this failure as `Cannot find package ...` or `ERR_MODULE_NOT_FOUND`, which onboarding previously failed to recognize.

## Why This Change Was Made

Extend the existing canonical runtime-dependency classifier to recognize Node's ESM missing-package wording and module-not-found error codes alongside the already supported CommonJS wording. Preserve the existing authentication precedence, profile/container selection, daemon diagnostics, and human/JSON output without adding another recovery path.

## User Impact

Operators now receive the existing, correctly scoped `openclaw doctor --fix` recovery command when onboarding fails because a required ES-module package cannot be loaded.

## Evidence

- The new existing-table regression failed on unmodified production for both profile and container onboarding contexts before the classifier fix.
- All 28 onboarding Gateway-diagnostics tests pass after the change.
- Actual Node 24 and Node 26 ESM and CommonJS errors passed 72 real owner-level cases spanning direct failures, daemon last errors, profile/container/default contexts, and human/JSON output.
- Existing authentication mismatch precedence and CommonJS recovery behavior remain intact.
- Targeted lint, formatting, an independent source review, and Codex autoreview pass without findings.
- Production change: +1/-1 line, net zero. Regression tests extend the existing table by 15 lines.

AI-assisted and independently verified against Node's actual supported runtime errors.
