### PR TITLE
fix(android): honor low camera snapshot quality

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
@@ -198,6 +198,7 @@ class CameraCaptureManager(
             initialWidth = scaled.width,
             initialHeight = scaled.height,
             startQuality = (quality * 100.0).roundToInt().coerceIn(10, 100),
+            minQuality = (quality * 100.0).roundToInt().coerceIn(10, 20),
             maxBytes = maxEncodedBytes,
             encode = { width, height, q ->
               val bitmap =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users requesting documented low camera snapshot quality from 0.10 through 0.19 would receive a larger, higher-quality JPEG encoded at quality 0.20 instead.

## Why This Change Was Made

The Android camera contract accepts quality values from 0.10 through 1.00, but its shared JPEG limiter defaults to a minimum quality of 0.20. Preserve the existing 0.20 floor for normal requests while allowing the camera owner to honor an explicitly requested lower quality. Chat attachments, photo-library behavior, default quality, permissions, and recording remain unchanged.

## User Impact

Android camera snapshots now respect the complete documented quality range. Users requesting smaller JPEG payloads at quality 0.10 or 0.15 receive their requested compression instead of having it silently raised to 0.20.

## Evidence

- Actual Android 36 Play app, foreground activity, emulated rear CameraX camera, and real JPEG snapshot pipeline.
- Independent native `Bitmap.compress` controls first established distinct JPEG quantization tables for qualities 10, 15, 20, and the default 95.
- Unchanged `main`: the actual `camera.snap` quality 0.10 snapshot used the quality-20 table; the first differing quantization entry was `40` instead of the native quality-10 value `80`. The unchanged owner regression failed with `Tests run: 1, Failures: 1`.
- Exact same Android instrumentation test against this change: actual rear-camera snapshots at qualities 0.10 and 0.15 matched their independently generated native quantization tables; explicit quality 0.20 and default quality 0.95 remained unchanged. Result: `OK (1 test)`.
- Play and third-party camera handler, camera-facing, JPEG limiter, and photo-library owner/sibling suites: **56 tests passed**.
- All four Android formatter gates passed: app, benchmark, wear, and wear-shared.
- Fresh independent structured code review: clean, confidence 0.99.
- The real CameraX owner instrumentation was intentionally disposable: existing JVM camera tests cannot bind an actual camera, and a shared-limiter-only test would already pass on unchanged `main`, so adding one as a supposed regression would provide false confidence.
- Production LOC: **+1/-0**; the single additional named argument preserves the documented camera-owner quality contract without changing shared behavior.
