### PR TITLE
refactor(agents): share session token normalization

### DIFF
--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -46,6 +46,7 @@ import type { PreparedModelRuntimePluginGeneration } from "../prepared-model-run
 import { SessionManager } from "../sessions/session-manager.js";
 import {
   clearCliSessionInStore as clearCliSessionInStoreImpl,
+  normalizeSessionTokenCount,
   recordCliCompactionInStore as recordCliCompactionInStoreImpl,
 } from "./session-store.js";
 
@@ -169,15 +170,8 @@ export function resetCliCompactionTestDeps(): void {
   });
 }
 
-function resolvePositiveInteger(value: number | undefined): number | undefined {
-  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
-    return undefined;
-  }
-  return Math.floor(value);
-}
-
 function resolveSessionTokenSnapshot(sessionEntry: SessionEntry | undefined): number | undefined {
-  return resolvePositiveInteger(resolveFreshSessionTotalTokens(sessionEntry));
+  return normalizeSessionTokenCount(resolveFreshSessionTotalTokens(sessionEntry));
 }
 
 function isNativeHarnessCompactionSession(
@@ -593,7 +587,7 @@ export async function runCliTurnCompactionLifecycle(params: {
   extraSystemPrompt?: string;
   pluginGeneration?: PreparedModelRuntimePluginGeneration;
 }): Promise<SessionEntry | undefined> {
-  const contextTokenBudget = resolvePositiveInteger(params.sessionEntry?.contextTokens);
+  const contextTokenBudget = normalizeSessionTokenCount(params.sessionEntry?.contextTokens);
   if (!params.storePath || !contextTokenBudget) {
     return params.sessionEntry;
   }

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -39,7 +39,7 @@ async function getContextModule() {
   return await contextModuleLoader.load();
 }
 
-function resolvePositiveInteger(value: number | undefined): number | undefined {
+export function normalizeSessionTokenCount(value: number | undefined): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return undefined;
   }
@@ -105,7 +105,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const modelUsed = result.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
   const providerUsed = result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider;
   const agentHarnessId = normalizeOptionalString(result.meta.agentMeta?.agentHarnessId);
-  const runtimeContextTokens = resolvePositiveInteger(result.meta.agentMeta?.contextTokens);
+  const runtimeContextTokens = normalizeSessionTokenCount(result.meta.agentMeta?.contextTokens);
   const contextBudgetStatus = result.meta.agentMeta?.contextBudgetStatus;
   const contextTokens =
     runtimeContextTokens !== undefined


### PR DESCRIPTION
## Summary

- reuse the session-store token-count normalizer in CLI compaction
- remove the duplicate finite, non-negative integer coercion
- keep session persistence and compaction behavior unchanged

## Architecture

`src/agents/command/session-store.ts` already owns normalization of persisted
session token counts. CLI compaction now calls that owner instead of maintaining
an identical local helper. No config, persistence shape, protocol, dependency,
or SDK surface changes.

Production delta: `+5/-11` (net `-6`). Tests unchanged.

## Verification

- `src/agents/command/session-store.test.ts`: 59 passed
- `src/agents/command/cli-compaction.test.ts`: 31 passed
- `pnpm check:changed`
- runtime import-cycle check: 0 cycles
- `git diff --check`
- branch autoreview: no actionable findings
- Blacksmith Testbox `tbx_01m0xn4gbnydnknfqvhyam1da4`: passed

Testbox run: https://github.com/openclaw/openclaw/actions/runs/32912316401

## Changelog

Not required for an internal behavior-preserving refactor.
