### PR TITLE
fix(android): preserve document attachments in offline chat history

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
@@ -466,7 +466,7 @@ class RoomChatTranscriptCache internal constructor(
                     height = part.height,
                     sizeBytes = part.sizeBytes,
                   )
-                part.type == "audio" || part.type == "video" ->
+                part.type == "audio" || part.type == "video" || part.type == "file" ->
                   CachedMessageContent(
                     type = part.type,
                     mimeType = part.mimeType,

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatTranscriptCacheTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatTranscriptCacheTest.kt
@@ -99,7 +99,7 @@ class RoomChatTranscriptCacheTest {
     }
 
   @Test
-  fun transcriptRoundTripKeepsManagedAudioAndVideoMetadata() =
+  fun transcriptRoundTripKeepsManagedAudioVideoAndDocumentMetadata() =
     runTest {
       val audio =
         ChatMessageContent(
@@ -120,17 +120,64 @@ class RoomChatTranscriptCacheTest {
           width = 1920,
           height = 1080,
         )
+      val userDocument =
+        ChatMessageContent(
+          type = "file",
+          mimeType = "application/pdf",
+          fileName = "proposal.pdf",
+          artifactId = "artifact_managed_media_55555555-5555-4555-8555-555555555555",
+          url = "/api/chat/media/outgoing/main/55555555-5555-4555-8555-555555555555/full",
+          sizeBytes = 4_096,
+        )
+      val assistantDocument =
+        ChatMessageContent(
+          type = "file",
+          mimeType = "text/plain",
+          fileName = "summary.txt",
+          url = "https://files.example/summary.txt",
+          sizeBytes = 48,
+        )
+      val mixedText = ChatMessageContent(type = "text", text = "See attached.")
       saveTranscript(
         messages =
           listOf(
             ChatMessage(id = "audio", role = "assistant", content = listOf(audio), timestampMs = 10),
             ChatMessage(id = "video", role = "assistant", content = listOf(video), timestampMs = 11),
+            ChatMessage(
+              id = "user-document",
+              role = "user",
+              content = listOf(userDocument),
+              timestampMs = 12,
+              idempotencyKey = "run-document:user",
+              entryId = "live-user-entry",
+              senderLabel = "Alex (Slack)",
+            ),
+            ChatMessage(id = "assistant-document", role = "assistant", content = listOf(assistantDocument), timestampMs = 13),
+            ChatMessage(id = "user-mixed", role = "user", content = listOf(mixedText, userDocument), timestampMs = 14),
+            ChatMessage(id = "assistant-mixed", role = "assistant", content = listOf(mixedText, assistantDocument), timestampMs = 15),
           ),
       )
 
       val loaded = loadTranscript()
 
-      assertEquals(listOf(audio, video), loaded.map { it.content.single() })
+      assertEquals(
+        listOf(
+          listOf(audio),
+          listOf(video),
+          listOf(userDocument),
+          listOf(assistantDocument),
+          listOf(mixedText, userDocument),
+          listOf(mixedText, assistantDocument),
+        ),
+        loaded.map { it.content },
+      )
+      assertEquals(listOf("assistant", "assistant", "user", "assistant", "user", "assistant"), loaded.map { it.role })
+      assertEquals("Alex (Slack)", loaded[2].senderLabel)
+      assertEquals("run-document:user", loaded[2].idempotencyKey)
+      assertTrue(loaded.all { it.entryId == null && it.content.all { part -> part.base64 == null } })
+      assertTrue(loadTranscript(gatewayId = "gateway-b").isEmpty())
+      assertTrue(loadTranscript(agentId = "other").isEmpty())
+      assertTrue(loadTranscript(sessionKey = "other").isEmpty())
     }
 
   @Test


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users reopening offline chat history would lose document-only messages entirely, while messages containing both text and a document would silently lose their document attachment.

## Why This Change Was Made

Android already parses and displays PDF and text-document attachments, but its Room transcript cache admitted only audio and video into the existing metadata-only attachment persistence branch. Include the already-supported document type in that same branch. The existing cache schema, bounded storage, gateway/agent/session ownership, filename and sender metadata, and prohibition on persisting attachment bytes remain unchanged.

## User Impact

PDFs and other document attachments remain visible when Android restores cached chat history. Both user and assistant document-only messages survive, and document labels remain attached to mixed text-and-document messages. Audio and video behavior is unchanged.

## Evidence

The unchanged-production regression uses the actual existing Room transcript-cache owner, writes six messages, and observes only four restored rows: both document-only messages disappear and both mixed messages retain only their text. With the one-line repair, all six rows and every attachment survive.

Real default Play Android proof used an actual on-disk 40,960-byte Room database: production RoomChatTranscriptCache saved the transcript, the database was closed and reopened, and the restored messages were mounted in the production MainActivity and ChatBubble UI. UiAutomator verified both user and assistant document-only rows plus mixed PDF and text-document rows. This is an actual database reopen and mounted production Android UI; it does not claim a process kill or a full external Gateway round-trip.

Before: only mixed-message text and existing audio/video attachments remain; both document-only messages and all document labels are missing.

![Before: offline Android Room history loses document-only rows and document attachments](https://github.com/user-attachments/assets/6999e653-3443-4675-8b74-12a7fd16cbe9)

After: both user and assistant document-only rows, both mixed-message documents, sender identity, and existing audio/video attachments survive the same Room reopen.

![After: offline Android Room history preserves document-only rows and document attachments](https://github.com/user-attachments/assets/9841046a-e72f-498f-ba2b-939e68056821)

The regression additionally verifies persisted MIME type, filename, artifact reference, sanitized URL, size, sender label, and idempotency; no attachment bytes or live entry authority are cached, and unrelated gateway, agent, and session scopes cannot read the transcript.

Both Play and third-party variants passed all seven owner-and-sibling suites: RoomChatTranscriptCacheTest, ChatControllerTranscriptCacheTest, ChatMessageContentParsingTest, ChatControllerReconnectRestoreTest, ClientDatabasesTest, RoomChatCommandOutboxTest, and ChatMessageViewsTest. That is 177 tests per flavor, 354 passing tests total; all four Android modules also passed formatting checks:

```text
./gradlew --no-parallel \
  :app:testPlayDebugUnitTest \
    --tests ai.openclaw.app.chat.RoomChatTranscriptCacheTest \
    --tests ai.openclaw.app.chat.ChatControllerTranscriptCacheTest \
    --tests ai.openclaw.app.chat.ChatMessageContentParsingTest \
    --tests ai.openclaw.app.chat.ChatControllerReconnectRestoreTest \
    --tests ai.openclaw.app.chat.ClientDatabasesTest \
    --tests ai.openclaw.app.chat.RoomChatCommandOutboxTest \
    --tests ai.openclaw.app.ui.chat.ChatMessageViewsTest \
  :app:testThirdPartyDebugUnitTest \
    --tests ai.openclaw.app.chat.RoomChatTranscriptCacheTest \
    --tests ai.openclaw.app.chat.ChatControllerTranscriptCacheTest \
    --tests ai.openclaw.app.chat.ChatMessageContentParsingTest \
    --tests ai.openclaw.app.chat.ChatControllerReconnectRestoreTest \
    --tests ai.openclaw.app.chat.ClientDatabasesTest \
    --tests ai.openclaw.app.chat.RoomChatCommandOutboxTest \
    --tests ai.openclaw.app.ui.chat.ChatMessageViewsTest \
  :app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck

BUILD SUCCESSFUL (126 tasks; 354 tests)
```

Production delta: one existing line changed, net zero production lines. The existing actual-Room owner test was expanded by 47 net test lines. Independent structured review reported no actionable findings.
