### PR TITLE
fix(android): skip scoped IPv6 discovery addresses

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
@@ -307,7 +307,7 @@ class GatewayDiscovery(
 
   private fun resolvedHostAddress(resolved: NsdServiceInfo): String? {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-      return resolved.hostAddresses.firstOrNull()?.hostAddress
+      return resolved.hostAddresses.firstOrNull { it.hostAddress?.contains('%') == false }?.hostAddress
     }
     return legacyHostAddress(resolved)
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayDiscoveryTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayDiscoveryTest.kt
@@ -1,10 +1,75 @@
 package ai.openclaw.app.gateway
 
+import android.net.nsd.NsdServiceInfo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 import org.xbill.DNS.Rcode
+import java.net.Inet6Address
+import java.net.InetAddress
 
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
 class GatewayDiscoveryTest {
+  private val scope = CoroutineScope(SupervisorJob())
+
+  @After
+  fun tearDown() {
+    scope.cancel()
+  }
+
+  @Test
+  fun discoveredGatewaySkipsScopedIpv6WhenIpv4IsAvailable() {
+    val discovery = discoverGateway(scopedIpv6(), InetAddress.getByName("127.0.0.1"))
+
+    assertEquals("127.0.0.1", discovery.discoveredHost())
+  }
+
+  @Test
+  fun discoveredGatewayOmitsUndialableScopedIpv6OnlyAddress() {
+    val discovery = discoverGateway(scopedIpv6())
+
+    assertTrue(discovery.gateways.value.isEmpty())
+  }
+
+  @Test
+  fun discoveredGatewayPreservesFirstUnscopedIpv6Address() {
+    val ipv6 = InetAddress.getByName("2001:db8::1")
+    val discovery = discoverGateway(ipv6, InetAddress.getByName("127.0.0.1"))
+
+    assertEquals(ipv6.hostAddress, discovery.discoveredHost())
+  }
+
+  @Test
+  fun discoveredGatewayPreservesIpv4BeforeScopedIpv6() {
+    val discovery = discoverGateway(InetAddress.getByName("127.0.0.1"), scopedIpv6())
+
+    assertEquals("127.0.0.1", discovery.discoveredHost())
+  }
+
+  @Test
+  @Config(sdk = [33])
+  fun discoveredGatewayPreservesLegacyAndroidHost() {
+    val service =
+      NsdServiceInfo().apply {
+        serviceName = "Gateway"
+        serviceType = "_openclaw-gw._tcp."
+        port = 18789
+        @Suppress("DEPRECATION")
+        host = InetAddress.getByName("127.0.0.1")
+      }
+
+    assertEquals("127.0.0.1", discoverGateway(service).discoveredHost())
+  }
+
   @Test
   fun statusTextFormatsLocalAndWideAreaDiscoveryStates() {
     val cases =
@@ -58,6 +123,37 @@ class GatewayDiscoveryTest {
       )
     }
   }
+
+  private fun discoverGateway(vararg addresses: InetAddress): GatewayDiscovery =
+    discoverGateway(
+      NsdServiceInfo().apply {
+        serviceName = "Gateway"
+        serviceType = "_openclaw-gw._tcp."
+        port = 18789
+        hostAddresses = addresses.toList()
+      },
+    )
+
+  private fun discoverGateway(service: NsdServiceInfo): GatewayDiscovery {
+    val discovery = GatewayDiscovery(RuntimeEnvironment.getApplication(), scope)
+    GatewayDiscovery::class.java.getDeclaredMethod("upsertResolvedService", NsdServiceInfo::class.java).apply {
+      isAccessible = true
+      invoke(discovery, service)
+    }
+    return discovery
+  }
+
+  private fun GatewayDiscovery.discoveredHost(): String {
+    val endpoints = gateways.value
+    return endpoints.single().host
+  }
+
+  private fun scopedIpv6(): Inet6Address =
+    Inet6Address.getByAddress(
+      null,
+      byteArrayOf(0xfe.toByte(), 0x80.toByte(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1),
+      3,
+    )
 }
 
 private data class StatusCase(


### PR DESCRIPTION
## Summary

Android 14+ network-service discovery returns every resolved gateway address in resolver order. A link-local IPv6 address can appear first with an interface scope, such as `fe80::1%ifb0`, followed by a reachable IPv4 address. Android was publishing the scoped address as the discovered gateway even though the pinned OkHttp 5.5.0 URL parser rejects scoped IPv6 literals before opening a WebSocket. Manual gateway entry already rejects these addresses, but discovery bypassed that validation.

Choose the first non-null, unscoped resolved address at the existing `GatewayDiscovery` owner. This preserves resolver ordering for reachable IPv4 and unscoped IPv6 addresses, omits scoped-only gateways, and leaves Android 13 and older discovery, TLS, certificate pinning, and transport headers unchanged.

Production delta: **+1 / -1 (net zero)**. Regression coverage: **+96 test lines**.

## Verification

- Fail-first owner regression: real Android `NsdServiceInfo` published scoped `fe80:0:0:0:0:0:0:1%3` instead of available `127.0.0.1`; a scoped-only gateway was also incorrectly published. Both failures pass after the one-line owner repair.
- Real Android 36 before/after proof: an actual `NsdServiceInfo` containing scoped `fe80::1%ifb0` followed by `127.0.0.1` passed through the production resolved-service callback and public gateway list. The unchanged app selected the undialable scoped host; the fixed app selected IPv4 and its real `GatewaySession` completed a genuine loopback RFC 6455 challenge/connect/hello WebSocket handshake. The same instrumentation also checks scoped-only omission, usable IPv6, IPv4, and absence of cleartext credential/custom-header reads.
- Existing legacy Android 13 discovery and unscoped IPv6 address ordering remain covered.
- Pinned OkHttp 5.5.0 contract verified directly against its [official source artifact](https://repo.maven.apache.org/maven2/com/squareup/okhttp3/okhttp-android/5.5.0/okhttp-android-5.5.0-sources.jar).
- Both Play and third-party app distributions: **34 gateway suites / 272 tests passed**.
- All four Android modules passed Kotlin lint.
- Independent review: no actionable findings.

```sh
./gradlew \
  :app:testPlayDebugUnitTest --tests 'ai.openclaw.app.gateway.*' \
  :app:testThirdPartyDebugUnitTest --tests 'ai.openclaw.app.gateway.*' \
  :app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck \
  --no-parallel --console=plain
```

An existing unrelated gateway RPC-response-versus-close timing test failed once during an initial broad run, passed an unchanged focused rerun, and passed in the complete final two-distribution run; no unrelated production code or tests were changed.
