### PR TITLE
fix(agents): scope fall-through plugin registry loads to the active runtime registry

### DIFF
--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -48,10 +48,12 @@ vi.mock("./harness/runtime-plugin-load-plan.js", () => ({
   resolveAgentRuntimePluginSelections: hoisted.resolveAgentRuntimePluginSelections,
 }));
 
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   getPluginRuntimeGatewayRequestScope,
   withPluginRuntimeRegistryScope,
 } from "../plugins/runtime/gateway-request-scope.js";
+import { createPluginRecord } from "../plugins/status.test-helpers.js";
 import {
   createPreparedInboundRegistryLoader,
   prepareWorkspacePluginRegistries,
@@ -103,7 +105,7 @@ describe("agent runtime plugin registries", () => {
   });
 
   it("adopts full-only runtime capabilities from the active composition-root registry", () => {
-    const activeRegistry = { active: true };
+    const activeRegistry = createEmptyPluginRegistry();
     const contextEnginesAdopted = { handle: "context-engines" };
     const presentersAdopted = { handle: "presenters" };
     hoisted.getActivePluginRegistry.mockReturnValue(activeRegistry);
@@ -121,6 +123,49 @@ describe("agent runtime plugin registries", () => {
       contextEnginesAdopted,
       activeRegistry,
     );
+    expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledWith(
+      expect.not.objectContaining({ onlyPluginIds: expect.anything() }),
+    );
+  });
+
+  it("bounds unscoped agent loads to active runtime plugins and selected owners", async () => {
+    const runtime =
+      await vi.importActual<typeof import("../plugins/runtime.js")>("../plugins/runtime.js");
+    const previousRegistry = runtime.captureActivePluginRegistrySnapshot();
+    const activeRegistry = createEmptyPluginRegistry();
+    activeRegistry.plugins.push(
+      createPluginRecord({ id: "startup-channel" }),
+      createPluginRecord({ id: "startup-provider" }),
+      createPluginRecord({ id: "deferred-plugin", format: "openclaw", imported: false }),
+    );
+    hoisted.resolveAgentRuntimePluginLoadPlan.mockImplementation(({ config, basePluginIds }) => ({
+      config,
+      pluginIds: [...(basePluginIds ?? []), "selected-provider"],
+    }));
+
+    try {
+      runtime.setActivePluginRegistry(activeRegistry);
+      hoisted.getActivePluginRegistry.mockImplementation(runtime.getActivePluginRegistry);
+
+      loadAgentRuntimePluginRegistryHandle({
+        config: {} as never,
+        workspaceDir: "/tmp/workspace",
+        selections: [{ provider: "selected", modelId: "model" }],
+      });
+
+      expect(hoisted.resolveAgentRuntimePluginLoadPlan).toHaveBeenCalledWith(
+        expect.objectContaining({ basePluginIds: ["startup-channel", "startup-provider"] }),
+      );
+      expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onlyPluginIds: ["startup-channel", "startup-provider", "selected-provider"],
+        }),
+      );
+    } finally {
+      activeRegistry.plugins.length = 0;
+      runtime.restoreActivePluginRegistrySnapshot(previousRegistry);
+      hoisted.getActivePluginRegistry.mockReset().mockReturnValue(undefined);
+    }
   });
 
   it("reuses the current Gateway generation and loads only the imported-plugin delta", () => {
@@ -302,6 +347,9 @@ describe("agent runtime plugin registries", () => {
   it("keeps an explicit metadata generation source-default without Gateway selection", () => {
     const config = {} as never;
     const metadataSnapshot = createMetadataSnapshot();
+    hoisted.getActivePluginRegistry.mockReturnValue({
+      plugins: [{ id: "broader-process-owner", status: "loaded" }],
+    });
 
     loadAgentRuntimePluginRegistryHandle({
       config,

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -1,6 +1,9 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { adoptRuntimeContextEngineRegistrations } from "../context-engine/registry.js";
-import { listRuntimePluginIdsFromRegistry } from "../plugins/active-runtime-registry.js";
+import {
+  listLoadedRuntimePluginIds,
+  listRuntimePluginIdsFromRegistry,
+} from "../plugins/active-runtime-registry.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../plugins/installed-plugin-index-install-records.js";
 import { loadPluginRegistryHandle } from "../plugins/loader.js";
@@ -68,6 +71,9 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
     ...(workspaceDir ? { workspaceDir } : {}),
   };
   const requestPluginRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+  // Gateway-hosted fall-through must not cold-load every plugin (30-45s event-loop convoy);
+  // startup runtime plugin ids plus selected run owners bound the registry scope.
+  const activePluginIds = listLoadedRuntimePluginIds();
   const startupPluginIds =
     params.basePluginIds !== undefined
       ? [...params.basePluginIds]
@@ -75,7 +81,9 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
         ? listRuntimePluginIdsFromRegistry(requestPluginRegistry)
         : metadataSnapshot.pluginIds
           ? [...metadataSnapshot.pluginIds]
-          : undefined;
+          : activePluginIds.length > 0
+            ? activePluginIds
+            : undefined;
   const planParams = {
     config: params.config,
     workspaceDir: workspaceDir ?? process.cwd(),


### PR DESCRIPTION
# fix(agents): scope fall-through plugin registry loads to the active runtime registry

## What Problem This Solves

First hook/cron isolated-run dispatch in a gateway process blocks the Node event loop for 30-45s, making the gateway HTTP server completely unresponsive (hook POSTs time out past gog's 10s client deadline; the fan-out handler's own 8s response-deadline timer cannot fire). During the gmail hook fan-out live test (PR #130002 follow-up), a 13-message burst pushed every embedded run's `attempt-workspace` stage to 14-15.4s with all stages ending at the same wall-clock instant — classic event-loop starvation.

Root cause (proven by CPU profile of a live dev-gateway repro): `prepareCronRunContext` (`src/cron/isolated-agent/run-prepare.ts:641`) builds its plugin registry via `loadAgentRuntimePluginRegistryHandle` with only run selections. In `resolveAgentRuntimePluginRegistryLoad`, the startup-scope fallback chain (explicit base → request-scope registry → snapshot pluginIds) resolves empty on the hook/cron path, and with no base the loader drops `onlyPluginIds` entirely — cold-loading **every discovered plugin** (~70 bundled providers). In a dev checkout each uninstalled provider plugin loads from TypeScript source through jiti's synchronous babel transform: one contiguous 42.6s block, of which 36.2s is extension module loading (amazon-bedrock 16.8s, opencode 13.1s), plus ~4s GC from AST churn. The gateway process already owns an active startup plugin registry; the fall-through simply never consulted it. PR #125596 fixed this class for the channel path (which carries its admitted plugin generation); hooks/cron never got the same treatment.

## Why This Change Was Made

Owner-level repair: the "what to load" policy lives in `resolveAgentRuntimePluginRegistryLoad`, and every fall-through caller (hook dispatch, cron scheduler, trigger scripts, subagent registry) benefits from fixing it there. The fallback chain gains one step: when no explicit base, request scope, or snapshot scope exists, use the active process registry's runtime plugin ids as the startup base. `resolveAgentRuntimePluginLoadPlan` then adds the run's selected provider/harness/memory/context-engine owners on top, preserving the invariant that every selected provider joins the immutable run generation. Hosts with no active registry (pure library use) keep full discovery unchanged.

## User Impact

- Gateway stays responsive during cold hook/cron bursts; the 8s fan-out response deadline actually fires, so gog's rewind/redeliver convergence works instead of livelocking (the failure mode recorded in #130002).
- First isolated hook/cron run in a process no longer pays a ~30-45s (dev) / multi-second (packaged) full-plugin cold load.

## Evidence

BEFORE (cold 13-message POST to /hooks/gmail, dev gateway, fresh process):
- Hook POST timed out at 30s (client abort); the 8s deadline timer never fired.
- Independent HTTP probe: gateway unresponsive 06:12:26 → 06:12:57 (~31.5s, two 15s client timeouts + one 11.6s response).
- CDP CPU profile: single 42.6s non-idle block starting the moment the POST arrived; 36.2s attributed to extension module loading under `prepareCronRunContext → loadAgentRuntimePluginRegistryHandle → loadOpenClawPlugins`, dominated by jiti/babel TS transpile (18.3s babel.cjs + 5.5s jiti.cjs self time) and jiti cache fs (2.5s readFileUtf8, 2.1s writeFileUtf8).

AFTER (same rig, fresh state dir + fresh process, fix applied):
- Cold 13-message POST answered in **8.03s with the designed 503 partial fan-out response** ("8/13 dispatched, 0 failed, 5 pending" — the 8s response deadline fired; pending items dispatch in background and redelivery replays converge).
- HTTP probe (500ms cadence, 60s): max latency **4.56s** (single cold spike at burst arrival), next-worst 440ms, everything else ≤330ms. No outage.
- CDP CPU profile: longest non-idle block **5.5s** (was 42.6s), composed of first-dispatch lazy module loads for startup-registry plugins only (teams-meetings 3.4s + zoom-meetings 0.8s jiti source loads + embedded-runner chunk eval). No non-startup provider plugin (amazon-bedrock, opencode, etc.) loads at all.

Regression test: `bounds unscoped agent loads to active runtime plugins and selected owners` in `src/agents/runtime-plugins.test.ts` — fails pre-fix (no `onlyPluginIds`), passes post-fix.

Production LOC delta: +8 (helper import, invariant comment, one fallback branch). Tests +49/-1.

## Follow-ups (recorded, out of scope here)

- Hook/cron path still rebuilds plugin metadata snapshots per run (installed-plugin-index `safeHashFile`, doctor-contract path resolution, realpath walks — measured ~5-6s aggregate across a 13-run warm burst). Canonical fix is carrying the gateway's admitted plugin generation into hook/cron dispatch, completing #125596 for this ingress.
- `prepareCronRunContext` runs before the HookDispatch lane bounds anything, so N preparations run unbounded on burst admission.
- First dispatch still cold-evaluates the embedded-runner dist chunk graph (~4-6s once per process); a post-ready background warmup would hide it.
