### PR TITLE
fix: board tickets remain valid across Gateway replacement

### DIFF
--- a/src/canvas/widget-tool.test.ts
+++ b/src/canvas/widget-tool.test.ts
@@ -2,7 +2,7 @@
 import { access, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { InProcessGatewayCaller } from "../agents/tools/in-process-gateway.js";
 import { createTestBoardStore } from "../boards/board-store.test-support.js";
 import { createBoardHandlers } from "../gateway/server-methods/board.js";
@@ -22,6 +22,10 @@ const WIDGET_CODE_MAX_CHARS = 262_144;
 const PINNED_WIDGET_MAX_UTF8_BYTES = 256 * 1024;
 const WIDGET_MAX_PER_SCOPE = 32;
 const tempDirs: string[] = [];
+
+beforeEach(() => {
+  resetPluginRuntimeStateForTest();
+});
 
 afterEach(async () => {
   vi.useRealTimers();
@@ -85,6 +89,17 @@ function createBoardPutCaller() {
     params: Record<string, unknown>,
   ): Promise<T> => (await mock(method, params)) as T;
   return { mock, callGateway };
+}
+
+function createLiveBoardTestContext(
+  broadcast: ReturnType<typeof vi.fn> = vi.fn(),
+): GatewayRequestContext {
+  const context = {
+    broadcast,
+    getRuntimeConfig: () => ({ agents: { list: [{ id: "main" }] } }),
+  } as unknown as GatewayRequestContext;
+  context.resolveGatewayContext = () => context;
+  return context;
 }
 
 function resolveCanvasDocumentDir(stateDir: string, documentId: string): string {
@@ -704,10 +719,7 @@ describe("show_widget", () => {
         client: null,
         isWebchatConnect: () => false,
         respond,
-        context: {
-          broadcast,
-          getRuntimeConfig: () => ({ agents: { list: [{ id: "main" }] } }),
-        } as unknown as GatewayRequestContext,
+        context: createLiveBoardTestContext(broadcast),
       });
       if (failure) {
         throw failure;
@@ -790,10 +802,7 @@ describe("show_widget", () => {
             failure = new Error(error?.message ?? "board request failed");
           }
         },
-        context: {
-          broadcast: vi.fn(),
-          getRuntimeConfig: () => ({ agents: { list: [{ id: "main" }] } }),
-        } as unknown as GatewayRequestContext,
+        context: createLiveBoardTestContext(),
       });
       if (failure) {
         throw failure;
@@ -922,10 +931,7 @@ describe("show_widget", () => {
             failure = new Error(error?.message ?? "board request failed");
           }
         },
-        context: {
-          broadcast: vi.fn(),
-          getRuntimeConfig: () => ({ agents: { list: [{ id: "main" }] } }),
-        } as unknown as GatewayRequestContext,
+        context: createLiveBoardTestContext(),
       });
       if (failure) {
         throw failure;

--- a/src/gateway/board-host-tools.ts
+++ b/src/gateway/board-host-tools.ts
@@ -1,8 +1,24 @@
-import type { ErrorShape } from "../../packages/gateway-protocol/src/index.js";
+import {
+  ErrorCodes,
+  errorShape,
+  type ErrorShape,
+} from "../../packages/gateway-protocol/src/index.js";
 import { CORE_BOARD_DATA_BINDING_IDS } from "../boards/board-host-capability-ids.js";
 import { BoardValidationError } from "../boards/board-layout.js";
-import { getActivePluginSessionExtensionRegistry } from "../plugins/runtime.js";
+import { BoardEventPayloadError } from "../boards/board-notices.js";
+import {
+  capturePluginRegistryLifecycleEpoch,
+  isPluginRegistryLifecycleEpochActive,
+} from "../plugins/registry-lifecycle.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
+import { isGatewaySubordinateWorkAdmissionClosed } from "../process/gateway-work-admission.js";
+import {
+  BoardGatewayUnavailableError,
+  type BoardViewTicketAuthorityInput,
+} from "./board-view-ticket.js";
 import { agentsHandlers } from "./server-methods/agents.js";
 import { cronHandlers } from "./server-methods/cron.js";
 import { healthHandlers } from "./server-methods/health.js";
@@ -12,6 +28,73 @@ import { usageHandlers } from "./server-methods/usage.js";
 
 type BoardDataBindingId = (typeof CORE_BOARD_DATA_BINDING_IDS)[number];
 type GatewayHandlerInvocation = Parameters<GatewayRequestHandlers[string]>[0];
+
+export type BoardRequestAuthority = {
+  assertActive: () => void;
+  pluginRegistry?: PluginRegistry;
+  ticketAuthority: BoardViewTicketAuthorityInput;
+};
+
+export function captureBoardRequestAuthority(
+  invocation: GatewayHandlerInvocation,
+): BoardRequestAuthority {
+  const context = invocation.context;
+  const resolveGatewayContext = context.resolveGatewayContext;
+  if (!resolveGatewayContext) {
+    throw new BoardGatewayUnavailableError();
+  }
+  const methodRegistry = context.getGatewayMethodRegistry?.();
+  const pluginRegistry =
+    getPluginRuntimeGatewayRequestScope()?.pluginRegistry ?? getActivePluginRegistry() ?? undefined;
+  const pluginRegistryEpoch = pluginRegistry
+    ? capturePluginRegistryLifecycleEpoch(pluginRegistry)
+    : undefined;
+  const assertActive = () => {
+    try {
+      if (
+        isGatewaySubordinateWorkAdmissionClosed() ||
+        resolveGatewayContext() !== context ||
+        context.resolveGatewayContext !== resolveGatewayContext ||
+        (methodRegistry && context.getGatewayMethodRegistry?.() !== methodRegistry) ||
+        (pluginRegistry &&
+          (!pluginRegistryEpoch ||
+            !isPluginRegistryLifecycleEpochActive(pluginRegistry, pluginRegistryEpoch)))
+      ) {
+        throw new BoardGatewayUnavailableError();
+      }
+    } catch (error) {
+      if (error instanceof BoardGatewayUnavailableError) {
+        throw error;
+      }
+      throw new BoardGatewayUnavailableError();
+    }
+  };
+  assertActive();
+  return {
+    assertActive,
+    ...(pluginRegistry ? { pluginRegistry } : {}),
+    ticketAuthority: {
+      gatewayContext: context,
+      resolveGatewayContext,
+      ...(pluginRegistry ? { pluginRegistry } : {}),
+    },
+  };
+}
+
+export function respondBoardError(
+  error: unknown,
+  respond: GatewayHandlerInvocation["respond"],
+): void {
+  if (error instanceof BoardGatewayUnavailableError) {
+    respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, error.message));
+    return;
+  }
+  if (error instanceof BoardValidationError || error instanceof BoardEventPayloadError) {
+    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, error.message));
+    return;
+  }
+  respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(error)));
+}
 
 const BOARD_DATA_HANDLERS: Record<BoardDataBindingId, GatewayRequestHandlers[string]> = {
   "sessions.list": sessionReadHandlers["sessions.list"]!,
@@ -33,11 +116,13 @@ async function invokeGatewayHandler(
   method: string,
   params: Record<string, unknown>,
   invocation: GatewayHandlerInvocation,
+  authority: BoardRequestAuthority,
 ): Promise<unknown> {
   let didRespond = false;
   let succeeded = false;
   let payload: unknown;
   let responseError: ErrorShape | undefined;
+  authority.assertActive();
   await handler({
     ...invocation,
     req: { ...invocation.req, method, params },
@@ -55,6 +140,7 @@ async function invokeGatewayHandler(
       }
     },
   });
+  authority.assertActive();
   if (!didRespond) {
     throw new BoardValidationError("invalid_operation", `${method} did not return a result`);
   }
@@ -71,6 +157,7 @@ export async function readBoardDataBinding(
   bindingId: string,
   params: Record<string, unknown>,
   invocation: GatewayHandlerInvocation,
+  authority: BoardRequestAuthority = captureBoardRequestAuthority(invocation),
 ): Promise<unknown> {
   if (isBoardDataBindingId(bindingId)) {
     return await invokeGatewayHandler(
@@ -78,27 +165,32 @@ export async function readBoardDataBinding(
       bindingId,
       params,
       invocation,
+      authority,
     );
   }
-  // Widget grants belong to the attached gateway, not an agent-scoped runtime registry.
-  const registration =
-    getActivePluginSessionExtensionRegistry()?.dashboardDataBindings.get(bindingId);
+  const registration = authority.pluginRegistry?.dashboardDataBindings.get(bindingId);
   if (!registration) {
     throw new BoardValidationError(
       "invalid_operation",
       `board widget data binding is not allowed: ${bindingId}`,
     );
   }
-  return await invokeGatewayHandler(registration.handler, registration.method, params, invocation);
+  return await invokeGatewayHandler(
+    registration.handler,
+    registration.method,
+    params,
+    invocation,
+    authority,
+  );
 }
 
 export async function runBoardActionVerb(
   actionId: string,
   params: Record<string, unknown>,
   invocation: GatewayHandlerInvocation,
+  authority: BoardRequestAuthority = captureBoardRequestAuthority(invocation),
 ): Promise<unknown> {
-  const registration =
-    getActivePluginSessionExtensionRegistry()?.dashboardActionVerbs.get(actionId);
+  const registration = authority.pluginRegistry?.dashboardActionVerbs.get(actionId);
   if (!registration) {
     throw new BoardValidationError(
       "invalid_operation",
@@ -118,17 +210,25 @@ export async function runBoardActionVerb(
       );
     }
   }
-  return await invokeGatewayHandler(registration.handler, registration.method, params, invocation);
+  return await invokeGatewayHandler(
+    registration.handler,
+    registration.method,
+    params,
+    invocation,
+    authority,
+  );
 }
 
 export async function triggerBoardCronJob(
   jobId: string,
   invocation: GatewayHandlerInvocation,
+  authority: BoardRequestAuthority = captureBoardRequestAuthority(invocation),
 ): Promise<unknown> {
   return await invokeGatewayHandler(
     cronHandlers["cron.run"]!,
     "cron.run",
     { id: jobId, mode: "force" },
     invocation,
+    authority,
   );
 }

--- a/src/gateway/board-http.test.ts
+++ b/src/gateway/board-http.test.ts
@@ -13,13 +13,30 @@ import {
   createBoardViewTicket,
   verifyBoardViewTicket,
 } from "./board-view-ticket.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
 
 const stateDir = mkdtempSync(path.join(tmpdir(), "openclaw-board-http-"));
 const store = createTestBoardStore({ stateDir });
 const nowMs = 1_800_000_000_000;
 const statusHtml = "<!doctype html><p>Status 界</p>";
+const gatewayA = {} as GatewayRequestContext;
+const gatewayB = {} as GatewayRequestContext;
+let gatewayAActive = true;
+let requestGatewayContext: GatewayRequestContext | undefined = gatewayA;
 let server: Server;
 let baseUrl: string;
+const resolveGatewayA = () => (gatewayAActive ? gatewayA : undefined);
+const resolveGatewayB = () => gatewayB;
+gatewayA.resolveGatewayContext = resolveGatewayA;
+gatewayB.resolveGatewayContext = resolveGatewayB;
+const gatewayAAuthority = {
+  gatewayContext: gatewayA,
+  resolveGatewayContext: resolveGatewayA,
+};
+const gatewayBAuthority = {
+  gatewayContext: gatewayB,
+  resolveGatewayContext: resolveGatewayB,
+};
 
 beforeAll(async () => {
   store.putWidget({
@@ -75,6 +92,9 @@ beforeAll(async () => {
     const handled = handleBoardHttpRequest(req, res, {
       store,
       nowMs,
+      resolveGatewayContext: () => requestGatewayContext,
+    } as Parameters<typeof handleBoardHttpRequest>[2] & {
+      resolveGatewayContext: () => GatewayRequestContext | undefined;
     });
     if (!handled) {
       res.statusCode = 404;
@@ -108,13 +128,23 @@ function ticketFor(name: string, revision = 1, issuedAtMs = nowMs): string {
   if (!document) {
     throw new Error(`missing HTML widget: ${name}`);
   }
-  return createBoardViewTicket({
+  return issueTicket({
     sessionKey: "agent:main:main",
     name,
     revision,
     viewGeneration: document.viewGeneration,
     nowMs: issuedAtMs,
   }).ticket;
+}
+
+function issueTicket(
+  params: Omit<Parameters<typeof createBoardViewTicket>[0], "authority">,
+  authority: Parameters<typeof createBoardViewTicket>[0]["authority"] = gatewayAAuthority,
+): ReturnType<typeof createBoardViewTicket> {
+  return createBoardViewTicket({
+    ...params,
+    authority,
+  });
 }
 
 function request(
@@ -129,12 +159,42 @@ function request(
 }
 
 describe("board widget HTTP", () => {
+  it("serves a ticket only through its issuing live Gateway", async () => {
+    gatewayAActive = true;
+    requestGatewayContext = gatewayA;
+    const ticket = ticketFor("status");
+    expect((await request("status", { ticket })).status).toBe(200);
+
+    requestGatewayContext = gatewayB;
+    expect((await request("status", { ticket })).status).toBe(503);
+    const document = store.readWidgetHtml("agent:main:main", "status");
+    if (!document) {
+      throw new Error("missing status widget");
+    }
+    const replacementTicket = issueTicket(
+      {
+        sessionKey: "agent:main:main",
+        name: "status",
+        revision: document.revision,
+        viewGeneration: document.viewGeneration,
+        nowMs,
+      },
+      gatewayBAuthority,
+    ).ticket;
+    expect((await request("status", { ticket: replacementTicket })).status).toBe(200);
+
+    requestGatewayContext = gatewayA;
+    gatewayAActive = false;
+    expect((await request("status", { ticket })).status).toBe(503);
+    gatewayAActive = true;
+  });
+
   it("round-trips self-contained claims covered by a two-minute HMAC ticket", () => {
     const document = store.readWidgetHtml("agent:main:main", "status");
     if (!document || !("html" in document)) {
       throw new Error("missing status widget");
     }
-    const issued = createBoardViewTicket({
+    const issued = issueTicket({
       sessionKey: "agent:main:main",
       name: "status",
       revision: 1,
@@ -149,6 +209,7 @@ describe("board widget HTTP", () => {
       name: "status",
       revision: 1,
       viewGeneration: document.viewGeneration,
+      authorityGeneration: expect.stringMatching(/^[A-Za-z0-9_-]{32}$/u),
       expiresAtMs: issued.expiresAtMs,
       nonce: expect.stringMatching(/^[A-Za-z0-9_-]{32}$/u),
     });
@@ -275,7 +336,7 @@ describe("board widget HTTP", () => {
   });
 
   it("rejects a ticket with a stale view generation", async () => {
-    const ticket = createBoardViewTicket({
+    const ticket = issueTicket({
       sessionKey: "agent:main:main",
       name: "status",
       revision: 1,
@@ -300,7 +361,7 @@ describe("board widget HTTP", () => {
     if (!document || !("html" in document)) {
       throw new Error("missing slash-key widget");
     }
-    const ticket = createBoardViewTicket({
+    const ticket = issueTicket({
       sessionKey: "session/with/slash",
       name: "slash-key",
       revision: 1,
@@ -315,7 +376,7 @@ describe("board widget HTTP", () => {
   });
 
   it("returns 401 when valid claims have no matching HTML document", async () => {
-    const ticket = createBoardViewTicket({
+    const ticket = issueTicket({
       sessionKey: "agent:main:main",
       name: "missing",
       revision: 1,
@@ -323,7 +384,7 @@ describe("board widget HTTP", () => {
       nowMs,
     }).ticket;
     expect((await request("missing", { ticket })).status).toBe(401);
-    const mcpTicket = createBoardViewTicket({
+    const mcpTicket = issueTicket({
       sessionKey: "agent:main:main",
       name: "mcp",
       revision: 1,

--- a/src/gateway/board-http.ts
+++ b/src/gateway/board-http.ts
@@ -2,14 +2,16 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { BoardStore } from "../boards/board-store.js";
 import { buildBoardWidgetContentSecurityPolicy } from "./board-sandbox.js";
 import { boardStore } from "./board-store.js";
-import { BOARD_HTTP_PATH_PREFIX } from "./board-view-ticket.js";
+import { BoardGatewayUnavailableError, BOARD_HTTP_PATH_PREFIX } from "./board-view-ticket.js";
 import { resolveAuthorizedBoardWidgetView } from "./board-widget-view.js";
 import { isReadHttpMethod, respondNotFound, respondPlainText } from "./control-ui-http-utils.js";
 import { sendMethodNotAllowed } from "./http-common.js";
+import type { GatewayContextResolver } from "./server-methods/types.js";
 
 const BOARD_WIDGET_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 
 type BoardHttpOptions = {
+  resolveGatewayContext?: GatewayContextResolver;
   store?: BoardStore;
   nowMs?: number;
 };
@@ -61,9 +63,14 @@ export function handleBoardHttpRequest(
   let authorized;
   try {
     authorized = resolveAuthorizedBoardWidgetView(opts.store ?? boardStore, ticket, {
+      gatewayContext: opts.resolveGatewayContext?.(),
       nowMs: opts.nowMs,
     });
-  } catch {
+  } catch (error) {
+    if (error instanceof BoardGatewayUnavailableError) {
+      respondPlainText(res, 503, "Service Unavailable");
+      return true;
+    }
     respondPlainText(res, 401, "Unauthorized");
     return true;
   }

--- a/src/gateway/board-view-ticket.ts
+++ b/src/gateway/board-view-ticket.ts
@@ -1,5 +1,12 @@
 import { createHmac, randomBytes } from "node:crypto";
+import {
+  capturePluginRegistryLifecycleEpoch,
+  isPluginRegistryLifecycleEpochActive,
+  type PluginRegistryLifecycleEpoch,
+} from "../plugins/registry-lifecycle.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
+import type { GatewayContextResolver, GatewayRequestContext } from "./server-methods/types.js";
 
 export const BOARD_HTTP_PATH_PREFIX = "/__openclaw__/board/";
 // Bounds residual bearer access after the originating client loses its view authority.
@@ -9,18 +16,41 @@ export const BOARD_VIEW_TICKET_TTL_MS = 20 * 60_000;
 const BOARD_VIEW_TICKET_SCOPE = "board-widget-view";
 const BOARD_VIEW_TICKET_MAX_LENGTH = 2_048;
 const ticketSecret = randomBytes(32);
+// Keep one current generation per live Gateway context, never one entry per ticket.
+// Method or plugin generation changes replace the slot and invalidate older tickets.
+const ticketAuthorities = new WeakMap<GatewayRequestContext, BoardViewTicketAuthority>();
 
 type BoardViewTicket = {
   ticket: string;
   expiresAtMs: number;
 };
 
-type BoardViewTicketClaims = {
+export type BoardViewTicketAuthorityInput = {
+  gatewayContext: GatewayRequestContext;
+  pluginRegistry?: PluginRegistry;
+  resolveGatewayContext: GatewayContextResolver;
+};
+
+export type BoardViewTicketAuthority = BoardViewTicketAuthorityInput & {
+  generation: string;
+  methodRegistry?: ReturnType<NonNullable<GatewayRequestContext["getGatewayMethodRegistry"]>>;
+  pluginRegistryEpoch?: PluginRegistryLifecycleEpoch;
+};
+
+export class BoardGatewayUnavailableError extends Error {
+  constructor() {
+    super("dashboard unavailable");
+    this.name = "BoardGatewayUnavailableError";
+  }
+}
+
+export type BoardViewTicketClaims = {
   sessionKey: string;
   agentId?: string;
   name: string;
   revision: number;
   viewGeneration: string;
+  authorityGeneration: string;
   expiresAtMs: number;
   nonce: string;
   pluginFrame?: {
@@ -55,6 +85,8 @@ function isValidClaims(value: unknown): value is BoardViewTicketClaims {
     (claims.revision ?? 0) >= 1 &&
     typeof claims.viewGeneration === "string" &&
     /^[a-f0-9]{32}$/u.test(claims.viewGeneration) &&
+    typeof claims.authorityGeneration === "string" &&
+    /^[A-Za-z0-9_-]{32}$/u.test(claims.authorityGeneration) &&
     Number.isSafeInteger(claims.expiresAtMs) &&
     typeof claims.nonce === "string" &&
     /^[A-Za-z0-9_-]{32}$/u.test(claims.nonce) &&
@@ -67,6 +99,79 @@ function isValidClaims(value: unknown): value is BoardViewTicketClaims {
   );
 }
 
+function captureBoardViewTicketAuthority(
+  input: BoardViewTicketAuthorityInput,
+): BoardViewTicketAuthority {
+  let currentContext: GatewayRequestContext | undefined;
+  try {
+    currentContext = input.resolveGatewayContext();
+  } catch {
+    throw new BoardGatewayUnavailableError();
+  }
+  if (
+    currentContext !== input.gatewayContext ||
+    input.gatewayContext.resolveGatewayContext !== input.resolveGatewayContext
+  ) {
+    throw new BoardGatewayUnavailableError();
+  }
+  const methodRegistry = input.gatewayContext.getGatewayMethodRegistry?.();
+  const pluginRegistryEpoch = input.pluginRegistry
+    ? capturePluginRegistryLifecycleEpoch(input.pluginRegistry)
+    : undefined;
+  if (input.pluginRegistry && !pluginRegistryEpoch) {
+    throw new BoardGatewayUnavailableError();
+  }
+  const existing = ticketAuthorities.get(input.gatewayContext);
+  if (
+    existing?.resolveGatewayContext === input.resolveGatewayContext &&
+    existing.methodRegistry === methodRegistry &&
+    existing.pluginRegistry === input.pluginRegistry &&
+    existing.pluginRegistryEpoch === pluginRegistryEpoch
+  ) {
+    return existing;
+  }
+  const authority: BoardViewTicketAuthority = {
+    ...input,
+    generation: randomBytes(24).toString("base64url"),
+    ...(methodRegistry ? { methodRegistry } : {}),
+    ...(pluginRegistryEpoch ? { pluginRegistryEpoch } : {}),
+  };
+  ticketAuthorities.set(input.gatewayContext, authority);
+  return authority;
+}
+
+export function requireBoardViewTicketAuthority(
+  claims: BoardViewTicketClaims,
+  gatewayContext: GatewayRequestContext | undefined,
+): BoardViewTicketAuthority {
+  const authority = gatewayContext ? ticketAuthorities.get(gatewayContext) : undefined;
+  let currentContext: GatewayRequestContext | undefined;
+  try {
+    currentContext = authority?.resolveGatewayContext();
+  } catch {
+    throw new BoardGatewayUnavailableError();
+  }
+  if (
+    !gatewayContext ||
+    !authority ||
+    authority.generation !== claims.authorityGeneration ||
+    authority.gatewayContext !== gatewayContext ||
+    currentContext !== gatewayContext ||
+    gatewayContext.resolveGatewayContext !== authority.resolveGatewayContext ||
+    (authority.methodRegistry &&
+      gatewayContext.getGatewayMethodRegistry?.() !== authority.methodRegistry) ||
+    (authority.pluginRegistry &&
+      (!authority.pluginRegistryEpoch ||
+        !isPluginRegistryLifecycleEpochActive(
+          authority.pluginRegistry,
+          authority.pluginRegistryEpoch,
+        )))
+  ) {
+    throw new BoardGatewayUnavailableError();
+  }
+  return authority;
+}
+
 export function createBoardViewTicket(params: {
   sessionKey: string;
   agentId?: string;
@@ -75,14 +180,17 @@ export function createBoardViewTicket(params: {
   viewGeneration: string;
   nowMs?: number;
   pluginFrame?: BoardViewTicketClaims["pluginFrame"];
+  authority: BoardViewTicketAuthorityInput;
 }): BoardViewTicket {
   const nowMs = params.nowMs ?? Date.now();
+  const authority = captureBoardViewTicketAuthority(params.authority);
   const claims: BoardViewTicketClaims = {
     sessionKey: params.sessionKey,
     ...(params.agentId ? { agentId: params.agentId } : {}),
     name: params.name,
     revision: params.revision,
     viewGeneration: params.viewGeneration,
+    authorityGeneration: authority.generation,
     expiresAtMs: nowMs + BOARD_VIEW_TICKET_TTL_MS,
     nonce: randomBytes(24).toString("base64url"),
     ...(params.pluginFrame ? { pluginFrame: params.pluginFrame } : {}),
@@ -128,6 +236,22 @@ export function verifyBoardViewTicket(
     return undefined;
   }
   return claims;
+}
+
+export function resolveAuthorizedBoardViewTicketClaims(
+  value: string,
+  options: { gatewayContext?: GatewayRequestContext; nowMs?: number } = {},
+): BoardViewTicketClaims | undefined {
+  const claims = verifyBoardViewTicket(value, options);
+  if (!claims) {
+    return undefined;
+  }
+  try {
+    requireBoardViewTicketAuthority(claims, options.gatewayContext);
+    return claims;
+  } catch {
+    return undefined;
+  }
 }
 
 export function buildBoardWidgetFrameUrl(params: {

--- a/src/gateway/board-widget-view.ts
+++ b/src/gateway/board-widget-view.ts
@@ -5,8 +5,8 @@ import {
   resolveBoardWidgetContentKindByPluginKind,
   resolveBoardWidgetContentKindResourceUrls,
 } from "../plugins/board-widget-content-kinds.js";
-import { getActivePluginRegistry } from "../plugins/runtime.js";
-import { verifyBoardViewTicket } from "./board-view-ticket.js";
+import { requireBoardViewTicketAuthority, verifyBoardViewTicket } from "./board-view-ticket.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
 
 type AuthorizedBoardWidgetView = {
   sessionKey: string;
@@ -17,12 +17,13 @@ type AuthorizedBoardWidgetView = {
 export function resolveAuthorizedBoardWidgetView(
   store: BoardStore,
   ticket: string,
-  options: { nowMs?: number } = {},
+  options: { gatewayContext?: GatewayRequestContext; nowMs?: number } = {},
 ): AuthorizedBoardWidgetView {
   const claims = verifyBoardViewTicket(ticket, options);
   if (!claims) {
     throw new BoardValidationError("invalid_operation", "board widget view ticket is invalid");
   }
+  const authority = requireBoardViewTicketAuthority(claims, options.gatewayContext);
   const document = claims.pluginFrame
     ? store.readWidgetRegistered(claims.sessionKey, claims.name)
     : store.readWidgetHtml(claims.sessionKey, claims.name);
@@ -39,7 +40,7 @@ export function resolveAuthorizedBoardWidgetView(
       throw new BoardValidationError("invalid_operation", "board widget view ticket is stale");
     }
     const registration = resolveBoardWidgetContentKindByPluginKind(
-      getActivePluginRegistry(),
+      authority.pluginRegistry,
       document.pluginKind,
     );
     const resourceUrls = registration

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -426,7 +426,9 @@ export function createGatewayHttpServer(opts: {
         }),
       );
       addAdmittedStage(scopedRequestPath.startsWith("/__openclaw__/board/"), async () =>
-        (await getBoardHttpModule()).handleBoardHttpRequest(req, res),
+        (await getBoardHttpModule()).handleBoardHttpRequest(req, res, {
+          resolveGatewayContext: opts.getGatewayRequestContext?.()?.resolveGatewayContext,
+        }),
       );
       const userProfileAvatarRoute = parseControlUiUserAvatarPath(
         scopedRequestPath,

--- a/src/gateway/server-methods/board-generated-identity.test.ts
+++ b/src/gateway/server-methods/board-generated-identity.test.ts
@@ -3,6 +3,7 @@ import type { BoardSnapshot } from "../../../packages/gateway-protocol/src/index
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { SqliteBoardStore } from "../../boards/sqlite-board-store.js";
 import { replaceSessionEntrySync } from "../../config/sessions/session-accessor.entry.js";
+import { resetPluginRuntimeStateForTest } from "../../plugins/runtime.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -13,11 +14,13 @@ import { createBoardHarness } from "./board.test-support.js";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
+  resetPluginRuntimeStateForTest();
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
 });
 
 it("serializes in-flight generated-name collisions and reuses both names after reload", async () => {
+  resetPluginRuntimeStateForTest();
   const env = { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-board-generated-race-") };
   const sessionKey = "agent:main:generated-race";
   const database = openOpenClawAgentDatabase({ agentId: "main", env });

--- a/src/gateway/server-methods/board.content-kinds.test.ts
+++ b/src/gateway/server-methods/board.content-kinds.test.ts
@@ -56,7 +56,7 @@ describe("board registered widget content kinds", () => {
     const previous = getActivePluginRegistry();
     const { registry, validateSource, composeDocument } = registeredWidgetRegistry();
     setActivePluginRegistry(registry);
-    const { invoke, store } = createBoardHarness(
+    const { context, invoke, store } = createBoardHarness(
       undefined,
       {},
       undefined,
@@ -112,7 +112,9 @@ describe("board registered widget content kinds", () => {
         frameUrl: expect.stringContaining("/__openclaw__/board/"),
         sandboxUrl: expect.stringContaining("/mcp-app-sandbox"),
       });
-      const authorized = resolveAuthorizedBoardWidgetView(store, widget.viewTicket!);
+      const authorized = resolveAuthorizedBoardWidgetView(store, widget.viewTicket!, {
+        gatewayContext: context,
+      });
       expect(authorized.document.html).toContain("<main>diagram:second</main>");
       expect(authorized.document.html).toContain(
         "https://gateway.test/__openclaw__/cap/diagram-token/__openclaw__/diagram/app.js",
@@ -148,7 +150,7 @@ describe("board registered widget content kinds", () => {
     async (mode) => {
       const { registry, composeDocument } = registeredWidgetRegistry();
       setActivePluginRegistry(registry);
-      const { invoke, store } = createBoardHarness(
+      const { context, invoke, store } = createBoardHarness(
         undefined,
         {},
         undefined,
@@ -193,7 +195,9 @@ describe("board registered widget content kinds", () => {
       }
       const widget = (snapshot as BoardSnapshot).widgets[0]!;
 
-      resolveAuthorizedBoardWidgetView(store, widget.viewTicket!);
+      resolveAuthorizedBoardWidgetView(store, widget.viewTicket!, {
+        gatewayContext: context,
+      });
 
       expect(composeDocument).toHaveBeenCalledWith(
         expect.objectContaining({ promptGranted: true }),

--- a/src/gateway/server-methods/board.plugin-capabilities.test.ts
+++ b/src/gateway/server-methods/board.plugin-capabilities.test.ts
@@ -132,13 +132,33 @@ describe("board plugin capabilities", () => {
       expect(action.mock.calls[0]?.[1]).toEqual({ refreshed: true });
       expect(actionHandler).toHaveBeenCalledOnce();
 
+      setActivePluginRegistry(registry);
+      const staleAction = await invoke("board.action", {
+        ticket,
+        action: "workboard.dispatch",
+        params: { force: true },
+      });
+      expect(staleAction.mock.calls[0]?.[0]).toBe(false);
+      expect(staleAction.mock.calls[0]?.[2]).toMatchObject({ code: "UNAVAILABLE" });
+      expect(actionHandler).toHaveBeenCalledOnce();
+
+      const refreshedBoard = await invoke("board.get", { sessionKey: "session" });
+      const refreshedSnapshot = refreshedBoard.mock.calls[0]?.[1] as BoardSnapshot;
+      const refreshedAction = await invoke("board.action", {
+        ticket: refreshedSnapshot.widgets[0]?.viewTicket,
+        action: "workboard.dispatch",
+        params: { force: true },
+      });
+      expect(refreshedAction.mock.calls[0]?.[1]).toEqual({ refreshed: true });
+      expect(actionHandler).toHaveBeenCalledTimes(2);
+
       setActivePluginRegistry(createEmptyPluginRegistry());
       const unavailable = await invoke("board.data.read", {
         ticket,
         bindingId: "workboard.cards.list",
       });
       expect(unavailable.mock.calls[0]?.[0]).toBe(false);
-      expect(unavailable.mock.calls[0]?.[2]?.message).toContain("not allowed");
+      expect(unavailable.mock.calls[0]?.[2]?.message).toContain("dashboard unavailable");
     } finally {
       if (previousRegistry) {
         setActivePluginRegistry(previousRegistry);

--- a/src/gateway/server-methods/board.runtime-boundaries.test.ts
+++ b/src/gateway/server-methods/board.runtime-boundaries.test.ts
@@ -110,6 +110,7 @@ describe("board gateway runtime boundaries", () => {
       "sessions.list",
       { limit: 2 },
       expect.objectContaining({ params: expect.any(Object) }),
+      expect.objectContaining({ assertActive: expect.any(Function) }),
     );
   });
 
@@ -131,6 +132,16 @@ describe("board gateway runtime boundaries", () => {
     const connected = createDeferred();
     const gatewayClients = new Set<GatewayWsClient>();
     const { broadcast } = createGatewayBroadcaster({ clients: gatewayClients });
+    const gatewayContext = {
+      broadcast,
+      getGatewayMethodRegistry: () => methodRegistry,
+      getRuntimeConfig: () => ({
+        agents: { list: [{ id: "main" }] },
+        tools: { exec: { mode: "ask" } },
+      }),
+      logGateway: { warn: vi.fn() },
+    } as unknown as GatewayRequestContext;
+    gatewayContext.resolveGatewayContext = () => gatewayContext;
     const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
     server.on("connection", (socket) => {
       socket.send(
@@ -199,14 +210,7 @@ describe("board gateway runtime boundaries", () => {
           },
           client: null,
           isWebchatConnect: () => false,
-          context: {
-            broadcast,
-            getRuntimeConfig: () => ({
-              agents: { list: [{ id: "main" }] },
-              tools: { exec: { mode: "ask" } },
-            }),
-            logGateway: { warn: vi.fn() },
-          } as unknown as GatewayRequestContext,
+          context: gatewayContext,
           methodRegistry,
         });
       });
@@ -247,7 +251,7 @@ describe("board gateway runtime boundaries", () => {
 
       const { error } = await requestOutcome;
       expect(error).toBeInstanceOf(Error);
-      expect(String(error)).toContain("board request authority is no longer active");
+      expect(String(error)).toContain("dashboard unavailable");
       expect(harness.store.getSnapshot("session").widgets).toEqual([]);
       expect(events).not.toContain("board.changed");
 
@@ -268,6 +272,31 @@ describe("board gateway runtime boundaries", () => {
         server.close(() => resolve());
       });
     }
+  });
+
+  it("rejects ticketed events after the issuing request authority retires", async () => {
+    let active = true;
+    const requestContext: { value?: GatewayRequestContext } = {};
+    const harness = createHarness(undefined, undefined, undefined, {
+      resolveGatewayContext: () => (active ? requestContext.value : undefined),
+    });
+    requestContext.value = harness.context;
+    await harness.invoke("board.widget.put", {
+      sessionKey: "session",
+      name: "counter",
+      content: { kind: "html", html: "counter" },
+    });
+    const board = await harness.invoke("board.get", { sessionKey: "session" });
+    const snapshot = board.mock.calls[0]?.[1] as BoardSnapshot;
+    const ticket = snapshot.widgets[0]?.viewTicket;
+
+    const allowed = await harness.invoke("board.event", { ticket, payload: { count: 1 } });
+    expect(allowed.mock.calls[0]?.[0]).toBe(true);
+    active = false;
+    const denied = await harness.invoke("board.event", { ticket, payload: { count: 2 } });
+    expect(denied.mock.calls[0]?.[0]).toBe(false);
+    expect(denied.mock.calls[0]?.[2]).toMatchObject({ code: "UNAVAILABLE" });
+    expect(peekSystemEvents("agent:main:session")).toHaveLength(1);
   });
 
   it.each([
@@ -458,7 +487,11 @@ describe("board gateway runtime boundaries", () => {
       jobId: "job-1",
     });
     expect(allowed.mock.calls[0]?.[1]).toEqual({ ok: true, jobId: "job-1" });
-    expect(triggerCronJob).toHaveBeenCalledWith("job-1", expect.any(Object));
+    expect(triggerCronJob).toHaveBeenCalledWith(
+      "job-1",
+      expect.any(Object),
+      expect.objectContaining({ assertActive: expect.any(Function) }),
+    );
   });
 
   it("caps board.event payloads and preserves Unicode at the notice boundary", async () => {

--- a/src/gateway/server-methods/board.test-support.ts
+++ b/src/gateway/server-methods/board.test-support.ts
@@ -84,6 +84,17 @@ export function createBoardHarness(
   };
   const broadcast = vi.fn();
   const handlers = createBoardHandlers(store, undefined, readCanvasHtml, mcpApp);
+  const context = {
+    broadcast,
+    getMcpAppSandboxPort: () => 18790,
+    getRuntimeConfig: () => ({
+      agents: { list: [{ id: "main" }] },
+      mcp: { apps: { enabled: true } },
+      tools: { exec: { mode: "ask" } },
+    }),
+    ...contextOverrides,
+  } as unknown as GatewayRequestContext;
+  context.resolveGatewayContext ??= () => context;
   const invoke = async (method: string, params: Record<string, unknown>) => {
     const respond = vi.fn<RespondFn>();
     await handlers[method]!({
@@ -92,18 +103,9 @@ export function createBoardHarness(
       client,
       isWebchatConnect: () => false,
       respond,
-      context: {
-        broadcast,
-        getMcpAppSandboxPort: () => 18790,
-        getRuntimeConfig: () => ({
-          agents: { list: [{ id: "main" }] },
-          mcp: { apps: { enabled: true } },
-          tools: { exec: { mode: "ask" } },
-        }),
-        ...contextOverrides,
-      } as unknown as GatewayRequestContext,
+      context,
     });
     return respond;
   };
-  return { store, broadcast, handlers, invoke, mcpApp };
+  return { store, broadcast, context, handlers, invoke, mcpApp };
 }

--- a/src/gateway/server-methods/board.test.ts
+++ b/src/gateway/server-methods/board.test.ts
@@ -3,6 +3,7 @@ import type { BoardSnapshot } from "../../../packages/gateway-protocol/src/index
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { resetBoardEventNoticeStateForTest } from "../../boards/board-notices.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
+import { resetPluginRuntimeStateForTest } from "../../plugins/runtime.js";
 import { resolveCoreOperatorGatewayMethodScope } from "../methods/core-descriptors.js";
 import {
   boardWidgetContentPermissionCases,
@@ -23,10 +24,12 @@ vi.mock("../../config/sessions/session-accessor.entry.js", async (importOriginal
 
 describe("board gateway methods", () => {
   beforeEach(() => {
+    resetPluginRuntimeStateForTest();
     resetBoardEventNoticeStateForTest();
     resetSystemEventsForTest();
     reviewWidgetApproval.mockReset();
     readSessionEntry.mockReset();
+    return () => resetPluginRuntimeStateForTest();
   });
 
   it("registers every contract method with its required scope", () => {

--- a/src/gateway/server-methods/board.ts
+++ b/src/gateway/server-methods/board.ts
@@ -1,6 +1,4 @@
 import {
-  ErrorCodes,
-  errorShape,
   type BoardWidgetMaterializedPutParams,
   validateBoardActionParams,
   validateBoardDataReadParams,
@@ -20,7 +18,7 @@ import {
   normalizeBoardWidgetDeclared,
 } from "../../boards/board-capabilities.js";
 import { BoardValidationError } from "../../boards/board-layout.js";
-import { appendBoardEventNotice, BoardEventPayloadError } from "../../boards/board-notices.js";
+import { appendBoardEventNotice } from "../../boards/board-notices.js";
 import type { BoardStore } from "../../boards/board-store.js";
 import { readCanvasDocumentHtmlSource } from "../../canvas/documents.js";
 import { buildWidgetDocument } from "../../canvas/wrap.js";
@@ -34,14 +32,9 @@ import {
   resolveBoardWidgetContentKindResourceUrls,
 } from "../../plugins/board-widget-content-kinds.js";
 import {
-  capturePluginRegistryLifecycleEpoch,
-  isPluginRegistryLifecycleEpochActive,
-} from "../../plugins/registry-lifecycle.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
-import { getPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
-import { isGatewaySubordinateWorkAdmissionClosed } from "../../process/gateway-work-admission.js";
-import {
+  captureBoardRequestAuthority,
   readBoardDataBinding,
+  respondBoardError,
   runBoardActionVerb,
   triggerBoardCronJob,
 } from "../board-host-tools.js";
@@ -86,38 +79,6 @@ const defaultMcpAppDependencies: McpAppDependencies = {
   resolveAllowedToolNames: resolveMcpAppAllowedToolNames,
   mintFromTranscript: mintMcpAppViewFromTranscript,
 };
-
-function respondBoardError(
-  error: unknown,
-  respond: Parameters<GatewayRequestHandlers[string]>[0]["respond"],
-): void {
-  if (error instanceof BoardValidationError || error instanceof BoardEventPayloadError) {
-    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, error.message));
-    return;
-  }
-  respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(error)));
-}
-
-function captureBoardRequestAuthority() {
-  const scopedPluginRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
-  const pluginRegistryEpoch =
-    scopedPluginRegistry && capturePluginRegistryLifecycleEpoch(scopedPluginRegistry);
-  const assertActive = () => {
-    if (
-      isGatewaySubordinateWorkAdmissionClosed() ||
-      (scopedPluginRegistry &&
-        (!pluginRegistryEpoch ||
-          !isPluginRegistryLifecycleEpochActive(scopedPluginRegistry, pluginRegistryEpoch)))
-    ) {
-      throw new Error("board request authority is no longer active");
-    }
-  };
-  assertActive();
-  return {
-    assertActive,
-    pluginRegistry: scopedPluginRegistry ?? getActivePluginRegistry() ?? undefined,
-  };
-}
 
 function resolveBoardSessionKey(
   params: { sessionKey: string; agentId?: string | undefined },
@@ -205,104 +166,110 @@ export function createBoardHandlers(
     "board.get": defineValidatedGatewayMethod(
       "board.get",
       validateBoardGetParams,
-      async ({ params: boardParams, respond, context, client }) => {
-        const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
-        if (!boardSessionKey) {
-          return;
-        }
-        const { snapshot, htmlViewMetadata } =
-          store.getSnapshotWithHtmlViewMetadata(boardSessionKey);
-        let sandboxPort = context.getMcpAppSandboxPort?.();
-        let sandboxOrigin: string | undefined;
-        let sandboxOriginResolved = false;
-        for (const widget of snapshot.widgets) {
-          if (widget.grantState !== "none" && widget.grantState !== "granted") {
-            continue;
+      async (invocation) => {
+        const { params: boardParams, respond, context, client } = invocation;
+        try {
+          const authority = captureBoardRequestAuthority(invocation);
+          const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
+          if (!boardSessionKey) {
+            return;
           }
-          const viewMetadata = htmlViewMetadata.get(widget.name);
-          if (!viewMetadata || viewMetadata.revision !== widget.revision) {
-            continue;
-          }
-          const registration = widget.pluginKind
-            ? resolveBoardWidgetContentKindByPluginKind(
-                getActivePluginRegistry(),
-                widget.pluginKind,
-              )
-            : undefined;
-          const scopedHostUrl = registration
-            ? client?.pluginSurfaceUrls?.[registration.definition.resources.surface]
-            : undefined;
-          const resourceUrls =
-            registration && scopedHostUrl
-              ? resolveBoardWidgetContentKindResourceUrls(registration, scopedHostUrl)
+          const { snapshot, htmlViewMetadata } =
+            store.getSnapshotWithHtmlViewMetadata(boardSessionKey);
+          let sandboxPort = context.getMcpAppSandboxPort?.();
+          let sandboxOrigin: string | undefined;
+          let sandboxOriginResolved = false;
+          for (const widget of snapshot.widgets) {
+            if (widget.grantState !== "none" && widget.grantState !== "granted") {
+              continue;
+            }
+            const viewMetadata = htmlViewMetadata.get(widget.name);
+            if (!viewMetadata || viewMetadata.revision !== widget.revision) {
+              continue;
+            }
+            const registration = widget.pluginKind
+              ? resolveBoardWidgetContentKindByPluginKind(
+                  authority.pluginRegistry,
+                  widget.pluginKind,
+                )
               : undefined;
-          if (
-            widget.contentKind === "plugin" &&
-            (!registration || !resourceUrls || !scopedHostUrl)
-          ) {
-            continue;
-          }
-          const resourceOrigins = resourceUrls
-            ? [...new Set(Object.values(resourceUrls).map((url) => new URL(url).origin))]
-            : undefined;
-          if (sandboxPort === undefined && context.ensureSandboxHostPort) {
-            try {
+            const scopedHostUrl = registration
+              ? client?.pluginSurfaceUrls?.[registration.definition.resources.surface]
+              : undefined;
+            const resourceUrls =
+              registration && scopedHostUrl
+                ? resolveBoardWidgetContentKindResourceUrls(registration, scopedHostUrl)
+                : undefined;
+            if (
+              widget.contentKind === "plugin" &&
+              (!registration || !resourceUrls || !scopedHostUrl)
+            ) {
+              continue;
+            }
+            const resourceOrigins = resourceUrls
+              ? [...new Set(Object.values(resourceUrls).map((url) => new URL(url).origin))]
+              : undefined;
+            if (sandboxPort === undefined && context.ensureSandboxHostPort) {
               sandboxPort = await context.ensureSandboxHostPort();
-            } catch (error) {
-              respondBoardError(error, respond);
-              return;
+              authority.assertActive();
             }
-          }
-          const { ticket } = createBoardViewTicket({
-            sessionKey: snapshot.sessionKey,
-            name: widget.name,
-            revision: widget.revision,
-            viewGeneration: viewMetadata.viewGeneration,
-            ...(registration && scopedHostUrl
-              ? {
-                  pluginFrame: {
-                    pluginKind: registration.pluginKind,
-                    scopedHostUrl,
-                  },
-                }
-              : {}),
-          });
-          if (registration) {
-            widget.kindLabel = registration.definition.label;
-          }
-          widget.frameUrl = buildBoardWidgetFrameUrl({
-            sessionKey: snapshot.sessionKey,
-            name: widget.name,
-            ticket,
-          });
-          widget.viewTicket = ticket;
-          widget.viewTicketTtlMs = BOARD_VIEW_TICKET_TTL_MS;
-          widget.viewGeneration = viewMetadata.viewGeneration;
-          if (sandboxPort !== undefined) {
-            widget.sandboxUrl = buildBoardWidgetSandboxPath({
-              ...viewMetadata,
-              ...(resourceOrigins ? { resourceOrigins } : {}),
+            authority.assertActive();
+            const { ticket } = createBoardViewTicket({
+              sessionKey: snapshot.sessionKey,
+              name: widget.name,
+              revision: widget.revision,
+              viewGeneration: viewMetadata.viewGeneration,
+              ...(registration && scopedHostUrl
+                ? {
+                    pluginFrame: {
+                      pluginKind: registration.pluginKind,
+                      scopedHostUrl,
+                    },
+                  }
+                : {}),
+              authority: authority.ticketAuthority,
             });
-            widget.sandboxPort = sandboxPort;
-            if (!sandboxOriginResolved) {
-              const configuredOrigin = context.getRuntimeConfig?.().mcp?.apps?.sandboxOrigin;
-              sandboxOrigin = configuredOrigin ? new URL(configuredOrigin).origin : undefined;
-              sandboxOriginResolved = true;
+            if (registration) {
+              widget.kindLabel = registration.definition.label;
             }
-            if (sandboxOrigin) {
-              widget.sandboxOrigin = sandboxOrigin;
+            widget.frameUrl = buildBoardWidgetFrameUrl({
+              sessionKey: snapshot.sessionKey,
+              name: widget.name,
+              ticket,
+            });
+            widget.viewTicket = ticket;
+            widget.viewTicketTtlMs = BOARD_VIEW_TICKET_TTL_MS;
+            widget.viewGeneration = viewMetadata.viewGeneration;
+            if (sandboxPort !== undefined) {
+              widget.sandboxUrl = buildBoardWidgetSandboxPath({
+                ...viewMetadata,
+                ...(resourceOrigins ? { resourceOrigins } : {}),
+              });
+              widget.sandboxPort = sandboxPort;
+              if (!sandboxOriginResolved) {
+                const configuredOrigin = context.getRuntimeConfig?.().mcp?.apps?.sandboxOrigin;
+                sandboxOrigin = configuredOrigin ? new URL(configuredOrigin).origin : undefined;
+                sandboxOriginResolved = true;
+              }
+              if (sandboxOrigin) {
+                widget.sandboxOrigin = sandboxOrigin;
+              }
             }
           }
+          authority.assertActive();
+          respond(true, snapshot);
+        } catch (error) {
+          respondBoardError(error, respond);
         }
-        respond(true, snapshot);
       },
     ),
     "board.update": defineValidatedGatewayMethod(
       "board.update",
       validateBoardUpdateParams,
-      ({ params: boardParams, respond, context }) => {
+      (invocation) => {
+        const { params: boardParams, respond, context } = invocation;
         try {
-          const authority = captureBoardRequestAuthority();
+          const authority = captureBoardRequestAuthority(invocation);
           const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
           if (!boardSessionKey) {
             return;
@@ -324,9 +291,10 @@ export function createBoardHandlers(
     "board.widget.put": defineValidatedGatewayMethod(
       "board.widget.put",
       validateBoardWidgetPutParams,
-      async ({ params: requestParams, respond, context }) => {
+      async (invocation) => {
+        const { params: requestParams, respond, context } = invocation;
         try {
-          const authority = captureBoardRequestAuthority();
+          const authority = captureBoardRequestAuthority(invocation);
           const requestedBoardSessionKey = resolveBoardSessionKey(requestParams, context, respond);
           if (!requestedBoardSessionKey) {
             return;
@@ -502,9 +470,10 @@ export function createBoardHandlers(
     "board.widget.grant": defineValidatedGatewayMethod(
       "board.widget.grant",
       validateBoardWidgetGrantParams,
-      ({ params: boardParams, respond, context }) => {
+      (invocation) => {
+        const { params: boardParams, respond, context } = invocation;
         try {
-          const authority = captureBoardRequestAuthority();
+          const authority = captureBoardRequestAuthority(invocation);
           const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
           if (!boardSessionKey) {
             return;
@@ -588,12 +557,15 @@ export function createBoardHandlers(
     "board.event": defineValidatedGatewayMethod(
       "board.event",
       validateBoardEventParams,
-      ({ params: boardParams, respond, context }) => {
+      (invocation) => {
+        const { params: boardParams, respond, context } = invocation;
         try {
-          const authority = captureBoardRequestAuthority();
+          const authority = captureBoardRequestAuthority(invocation);
           const identity =
             "ticket" in boardParams
-              ? resolveAuthorizedBoardWidgetView(store, boardParams.ticket)
+              ? resolveAuthorizedBoardWidgetView(store, boardParams.ticket, {
+                  gatewayContext: context,
+                })
               : (() => {
                   const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
                   if (!boardSessionKey) {
@@ -629,9 +601,14 @@ export function createBoardHandlers(
     "board.prompt.authorize": defineValidatedGatewayMethod(
       "board.prompt.authorize",
       validateBoardPromptAuthorizeParams,
-      ({ params: boardParams, respond }) => {
+      (invocation) => {
+        const { params: boardParams, respond, context } = invocation;
         try {
-          const { document } = resolveAuthorizedBoardWidgetView(store, boardParams.ticket);
+          const authority = captureBoardRequestAuthority(invocation);
+          const { document } = resolveAuthorizedBoardWidgetView(store, boardParams.ticket, {
+            gatewayContext: context,
+          });
+          authority.assertActive();
           respond(true, {
             confirmationRequired: !boardWidgetHasGrantedTool(
               document.declared,
@@ -648,11 +625,14 @@ export function createBoardHandlers(
       "board.data.read",
       validateBoardDataReadParams,
       async (invocation) => {
-        const { params: boardParams, respond } = invocation;
+        const { params: boardParams, respond, context } = invocation;
         try {
+          const authority = captureBoardRequestAuthority(invocation);
           const bindingParams = boardParams.params ?? {};
           assertCapabilityParamsSize(bindingParams, "data binding");
-          const { document } = resolveAuthorizedBoardWidgetView(store, boardParams.ticket);
+          const { document } = resolveAuthorizedBoardWidgetView(store, boardParams.ticket, {
+            gatewayContext: context,
+          });
           if (
             !boardWidgetHasGrantedTool(
               document.declared,
@@ -665,7 +645,14 @@ export function createBoardHandlers(
               `board widget tool is not granted: ${boardParams.bindingId}`,
             );
           }
-          respond(true, await readDataBinding(boardParams.bindingId, bindingParams, invocation));
+          const result = await readDataBinding(
+            boardParams.bindingId,
+            bindingParams,
+            invocation,
+            authority,
+          );
+          authority.assertActive();
+          respond(true, result);
         } catch (error) {
           respondBoardError(error, respond);
         }
@@ -675,9 +662,12 @@ export function createBoardHandlers(
       "board.action",
       validateBoardActionParams,
       async (invocation) => {
-        const { params: boardParams, respond } = invocation;
+        const { params: boardParams, respond, context } = invocation;
         try {
-          const { document } = resolveAuthorizedBoardWidgetView(store, boardParams.ticket);
+          const authority = captureBoardRequestAuthority(invocation);
+          const { document } = resolveAuthorizedBoardWidgetView(store, boardParams.ticket, {
+            gatewayContext: context,
+          });
           const capability =
             "jobId" in boardParams ? `cron.trigger:${boardParams.jobId}` : boardParams.action;
           if (!boardWidgetHasGrantedTool(document.declared, document.grantState, capability)) {
@@ -687,12 +677,21 @@ export function createBoardHandlers(
             );
           }
           if ("jobId" in boardParams) {
-            respond(true, await triggerCronJob(boardParams.jobId, invocation));
+            const result = await triggerCronJob(boardParams.jobId, invocation, authority);
+            authority.assertActive();
+            respond(true, result);
             return;
           }
           const actionParams = boardParams.params ?? {};
           assertCapabilityParamsSize(actionParams, "action");
-          respond(true, await runActionVerb(boardParams.action, actionParams, invocation));
+          const result = await runActionVerb(
+            boardParams.action,
+            actionParams,
+            invocation,
+            authority,
+          );
+          authority.assertActive();
+          respond(true, result);
         } catch (error) {
           respondBoardError(error, respond);
         }

--- a/src/gateway/server-methods/sessions-sharing.board-authority.test.ts
+++ b/src/gateway/server-methods/sessions-sharing.board-authority.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { createBoardViewTicket } from "../board-view-ticket.js";
+import { resolveSessionMutationAuthorization } from "../session-sharing.js";
+import { identifiedClient, sessionSharingTestContext } from "./sessions-sharing.test-support.js";
+import type { GatewayRequestContext } from "./types.js";
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+});
+
+describe("session sharing board ticket authority", () => {
+  it("authorizes tickets against their signed agent and issuing Gateway", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey: "global" },
+        { sessionId: "session-main-global", updatedAt: 1, visibility: "shared" },
+      );
+      await upsertSessionEntryCore(
+        { agentId: "work", sessionKey: "global" },
+        {
+          sessionId: "session-work-global",
+          updatedAt: 1,
+          visibility: "read-only",
+          createdActor: { type: "human", id: "owner@example.com" },
+        },
+      );
+      const cfg = {
+        agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+      } as ReturnType<GatewayRequestContext["getRuntimeConfig"]>;
+      let gatewayAActive = true;
+      const gatewayARef: { value?: GatewayRequestContext } = {};
+      const gatewayA: GatewayRequestContext = {
+        ...sessionSharingTestContext(vi.fn(), cfg),
+        resolveGatewayContext: () => (gatewayAActive ? gatewayARef.value : undefined),
+      };
+      gatewayARef.value = gatewayA;
+      const gatewayBRef: { value?: GatewayRequestContext } = {};
+      const gatewayB: GatewayRequestContext = {
+        ...sessionSharingTestContext(vi.fn(), cfg),
+        resolveGatewayContext: () => gatewayBRef.value,
+      };
+      gatewayBRef.value = gatewayB;
+      const issueTicket = (agentId?: string) =>
+        createBoardViewTicket({
+          sessionKey: "global",
+          ...(agentId ? { agentId } : {}),
+          name: "status",
+          revision: 1,
+          viewGeneration: agentId ? "a".repeat(32) : "b".repeat(32),
+          authority: {
+            gatewayContext: gatewayA,
+            resolveGatewayContext: gatewayA.resolveGatewayContext!,
+          },
+        }).ticket;
+      const ticket = issueTicket("work");
+      const unscopedTicket = issueTicket();
+      const memberClient = identifiedClient("outsider@example.com");
+
+      expect(
+        resolveSessionMutationAuthorization({
+          client: memberClient,
+          method: "board.action",
+          requestParams: { ticket, agentId: "work" },
+          context: gatewayA,
+        }).error,
+      ).toMatchObject({ details: { code: "SESSION_PARTICIPATION_REQUIRED" } });
+      expect(
+        resolveSessionMutationAuthorization({
+          client: identifiedClient("owner@example.com"),
+          method: "board.action",
+          requestParams: { ticket, agentId: "work" },
+          context: gatewayA,
+        }).error,
+      ).toBeNull();
+      expect(
+        resolveSessionMutationAuthorization({
+          client: identifiedClient("owner@example.com"),
+          method: "board.action",
+          requestParams: { ticket, agentId: "work" },
+          context: gatewayB,
+        }).error,
+      ).toMatchObject({ details: { code: "SESSION_MUTATION_TARGET_REQUIRED" } });
+      gatewayAActive = false;
+      expect(
+        resolveSessionMutationAuthorization({
+          client: identifiedClient("owner@example.com"),
+          method: "board.event",
+          requestParams: { ticket, agentId: "work" },
+          context: gatewayA,
+        }).error,
+      ).toMatchObject({ details: { code: "SESSION_MUTATION_TARGET_REQUIRED" } });
+      expect(
+        resolveSessionMutationAuthorization({
+          client: memberClient,
+          method: "board.action",
+          requestParams: { ticket: unscopedTicket, agentId: "work" },
+          context: gatewayA,
+        }).error,
+      ).toMatchObject({ details: { code: "SESSION_MUTATION_TARGET_REQUIRED" } });
+    });
+  });
+});

--- a/src/gateway/server-methods/sessions-sharing.test-support.ts
+++ b/src/gateway/server-methods/sessions-sharing.test-support.ts
@@ -1,0 +1,48 @@
+import { vi } from "vitest";
+import type { GatewayClient, GatewayRequestContext } from "./types.js";
+
+export function soloClient(): GatewayClient {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: {
+        id: "openclaw-control-ui",
+        version: "test",
+        platform: "test",
+        mode: "webchat",
+      },
+      role: "operator",
+      scopes: ["operator.read", "operator.write"],
+    },
+  };
+}
+
+export function identifiedClient(
+  profileId: string,
+  displayName: string | null = null,
+): GatewayClient {
+  return {
+    ...soloClient(),
+    authenticatedUserId: `${profileId}@example.com`,
+    authenticatedUserProfile: {
+      profileId,
+      displayName,
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+  };
+}
+
+export function sessionSharingTestContext(
+  broadcast: ReturnType<typeof vi.fn>,
+  runtimeConfig: ReturnType<GatewayRequestContext["getRuntimeConfig"]> = {},
+): GatewayRequestContext {
+  return {
+    getRuntimeConfig: () => runtimeConfig,
+    broadcast,
+    broadcastToConnIds: vi.fn(),
+    getSessionEventSubscriberConnIds: () => new Set(),
+    chatAbortControllers: new Map(),
+  } as unknown as GatewayRequestContext;
+}

--- a/src/gateway/server-methods/sessions-sharing.test.ts
+++ b/src/gateway/server-methods/sessions-sharing.test.ts
@@ -24,7 +24,6 @@ import {
 } from "../../state/openclaw-agent-db.js";
 import { ensureProfileForEmail, listProfiles, setDisplayName } from "../../state/user-profiles.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
-import { createBoardViewTicket } from "../board-view-ticket.js";
 import {
   attachGatewayLocalUserIngress,
   getGatewayLocalUserIngress,
@@ -42,6 +41,11 @@ import { createControlUiHandlers } from "./control-ui.js";
 import { flushPendingSessionsChangedEvents } from "./session-change-event.js";
 import { sessionReadHandlers } from "./sessions-read.js";
 import { sessionSharingHandlers } from "./sessions-sharing.js";
+import {
+  identifiedClient,
+  sessionSharingTestContext as context,
+  soloClient,
+} from "./sessions-sharing.test-support.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
 type ResolveSessionSharingTarget =
@@ -75,49 +79,6 @@ afterEach(() => {
   targetResolutionMock.override = undefined;
   closeOpenClawAgentDatabasesForTest();
 });
-
-function soloClient(): GatewayClient {
-  return {
-    connect: {
-      minProtocol: 1,
-      maxProtocol: 1,
-      client: {
-        id: "openclaw-control-ui",
-        version: "test",
-        platform: "test",
-        mode: "webchat",
-      },
-      role: "operator",
-      scopes: ["operator.read", "operator.write"],
-    },
-  };
-}
-
-function identifiedClient(profileId: string, displayName: string | null = null): GatewayClient {
-  return {
-    ...soloClient(),
-    authenticatedUserId: `${profileId}@example.com`,
-    authenticatedUserProfile: {
-      profileId,
-      displayName,
-      hasAvatar: false,
-      updatedAt: 1,
-    },
-  };
-}
-
-function context(
-  broadcast: ReturnType<typeof vi.fn>,
-  runtimeConfig: ReturnType<GatewayRequestContext["getRuntimeConfig"]> = {},
-): GatewayRequestContext {
-  return {
-    getRuntimeConfig: () => runtimeConfig,
-    broadcast,
-    broadcastToConnIds: vi.fn(),
-    getSessionEventSubscriberConnIds: () => new Set(),
-    chatAbortControllers: new Map(),
-  } as unknown as GatewayRequestContext;
-}
 
 async function call(
   method:
@@ -767,60 +728,6 @@ describe("session sharing handlers", () => {
           agentId: "main",
         }),
       ).toBeNull();
-    });
-  });
-
-  it("authorizes board tickets against their signed agent-relative session", async () => {
-    await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      await upsertSessionEntryCore(
-        { agentId: "main", sessionKey: "global" },
-        { sessionId: "session-main-global", updatedAt: 1, visibility: "shared" },
-      );
-      await upsertSessionEntryCore(
-        { agentId: "work", sessionKey: "global" },
-        {
-          sessionId: "session-work-global",
-          updatedAt: 1,
-          visibility: "read-only",
-          createdActor: { type: "human", id: "owner@example.com" },
-        },
-      );
-      const { ticket } = createBoardViewTicket({
-        sessionKey: "global",
-        agentId: "work",
-        name: "status",
-        revision: 1,
-        viewGeneration: "a".repeat(32),
-      });
-      const memberClient = identifiedClient("outsider@example.com");
-      const cfg = {
-        agents: { list: [{ id: "main", default: true }, { id: "work" }] },
-      } as ReturnType<GatewayRequestContext["getRuntimeConfig"]>;
-      const requestContext = context(vi.fn(), cfg);
-
-      expect(
-        resolveSessionMutationAuthorization({
-          client: memberClient,
-          method: "board.action",
-          requestParams: { ticket, agentId: "work" },
-          context: requestContext,
-        }).error,
-      ).toMatchObject({ details: { code: "SESSION_PARTICIPATION_REQUIRED" } });
-
-      const { ticket: unscopedTicket } = createBoardViewTicket({
-        sessionKey: "global",
-        name: "status",
-        revision: 1,
-        viewGeneration: "b".repeat(32),
-      });
-      expect(
-        resolveSessionMutationAuthorization({
-          client: memberClient,
-          method: "board.action",
-          requestParams: { ticket: unscopedTicket, agentId: "work" },
-          context: requestContext,
-        }).error,
-      ).toMatchObject({ details: { code: "SESSION_MUTATION_TARGET_REQUIRED" } });
     });
   });
 

--- a/src/gateway/session-sharing-target-input.ts
+++ b/src/gateway/session-sharing-target-input.ts
@@ -4,7 +4,7 @@ import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { isIncognitoSessionKey } from "../shared/incognito-session-key.js";
-import { verifyBoardViewTicket } from "./board-view-ticket.js";
+import { resolveAuthorizedBoardViewTicketClaims } from "./board-view-ticket.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 import { canonicalizeSessionKeyForAgent } from "./session-store-key.js";
 
@@ -329,7 +329,9 @@ export function resolveSessionMutationTargets(params: {
   }
   if (params.method === "board.event" || params.method === "board.action") {
     const ticket = readSessionSharingStringParam(params.requestParams, "ticket");
-    const claims = ticket ? verifyBoardViewTicket(ticket) : undefined;
+    const claims = ticket
+      ? resolveAuthorizedBoardViewTicketClaims(ticket, { gatewayContext: params.context })
+      : undefined;
     if (!claims || (requestedAgentId && requestedAgentId !== claims.agentId)) {
       return undefined;
     }


### PR DESCRIPTION
Related: #129183

Depends on: #130131

## What Problem This Solves

Fixes board tickets that remained redeemable after the Gateway, request context, method registry, or plugin generation that issued them had been replaced.

The ticket HMAC authenticated widget claims, but it did not retain the exact live owner. A stale ticket could therefore authorize board HTTP, events, data reads, prompt authorization, or actions through a different Gateway generation.

## Why This Change Was Made

Ticket issuance now creates one opaque authority generation per live `GatewayRequestContext`. The generation is stored in signed ticket claims and redeemed through lifecycle-owned state.

Redemption requires the same live Gateway context resolver, method registry, and plugin-registry activation epoch. A `WeakMap` retains one replaceable entry per live Gateway context, so authority is bounded by Gateway lifetime rather than ticket count. There is no arbitrary entry cap, persistent ticket registry, or per-ticket timer.

This PR also moves the shared board request-authority capture into the existing board host owner so ticket issuance, HTTP redemption, ticket-backed methods, plugin handlers, and PR #130131 use one policy.

Agent dashboard routing and MCP App UI rendering are excluded.

## User Impact

Current tickets continue to work through their issuing Gateway. Tickets fail closed after Gateway replacement or retirement, method-registry replacement, plugin reload/reactivation, expiry, widget revision change, or view-generation change.

## Evidence

Baseline:

```text
4 intended failures, 35 passes
- wrong-Gateway HTTP redemption returned 200 instead of 503
- ticketed event succeeded after issuing authority retirement
- plugin action succeeded after registry reactivation
- session-sharing derived a target on the wrong Gateway
```

Candidate:

```text
43 focused tests passed across 5 files
check:changed passed
independent autoreview: clean
```

- Baseline Testbox: `tbx_01m0z4daawgkkfdh640x7rb4jv`
- Baseline Actions run: https://github.com/openclaw/openclaw/actions/runs/32974915923
- Final Testbox: `tbx_01m0z76zxw047gsnmfayfq26ax`
- Final Actions run: https://github.com/openclaw/openclaw/actions/runs/32979890286
- Changed-gate Testbox: `tbx_01m0z644tjgkkrr88cmeb0qc7v`
- Changed-gate Actions run: https://github.com/openclaw/openclaw/actions/runs/32977937105
- Exact candidate: `6137c8933e5`
- Production: `+388/-152`; tests and test support: `+172/-41`.
- Visual proof omitted because this is a backend authorization boundary with no rendered UI change.
