### PR TITLE
fix: stale dashboard app views render after Gateway replacement

### DIFF
--- a/ui/src/components/board/board-document.ts
+++ b/ui/src/components/board/board-document.ts
@@ -259,6 +259,7 @@ export class OpenClawBoardDocument extends OpenClawLightDomElement {
       return nothing;
     }
     const callbacks = {
+      appViewGeneration: provider.appViewGeneration,
       applyOps: (ops) => provider.applyOps(ops),
       grant: (name, decision) => provider.grant(name, decision),
       selectTab: (tabId) => {

--- a/ui/src/components/board/board-mcp-app-lifecycle.ts
+++ b/ui/src/components/board/board-mcp-app-lifecycle.ts
@@ -70,6 +70,7 @@ class NearViewportObserver {
 }
 
 type AppViewCallbacks = {
+  appViewGeneration: () => number;
   widgetAppView: (name: string, revision: number) => Promise<BoardWidgetAppViewState>;
   refreshWidgetAppView: (name: string, revision: number) => Promise<BoardWidgetAppViewState>;
 };
@@ -87,6 +88,7 @@ export class BoardMcpAppLifecycle {
   loading = false;
 
   private callbacks?: AppViewCallbacks;
+  private appViewGeneration = 0;
   private key = "";
   private generation = 0;
   private renewalTimer?: number;
@@ -106,11 +108,13 @@ export class BoardMcpAppLifecycle {
       return;
     }
     const key = appViewKey(this.host.sessionKey(), widget);
-    if (key !== this.key) {
+    const appViewGeneration = callbacks.appViewGeneration();
+    if (key !== this.key || appViewGeneration !== this.appViewGeneration) {
       this.clearTimers();
       this.generation += 1;
       this.loading = false;
       this.key = key;
+      this.appViewGeneration = appViewGeneration;
       this.state = undefined;
     }
   }
@@ -187,6 +191,7 @@ export class BoardMcpAppLifecycle {
     this.clearTimers();
     this.generation += 1;
     this.key = "";
+    this.appViewGeneration = 0;
     this.state = undefined;
     this.loading = false;
   }

--- a/ui/src/components/board/board-view.ts
+++ b/ui/src/components/board/board-view.ts
@@ -197,6 +197,7 @@ class OpenClawBoardView extends OpenClawLightDomElement {
   }
 
   private readonly cellCallbacks: BoardWidgetCellCallbacks = {
+    appViewGeneration: () => this.callbacks?.appViewGeneration ?? 0,
     grant: async (name: string, decision: BoardGrantDecision) => {
       if (!this.callbacks) {
         return;

--- a/ui/src/components/board/board-widget-cell-mcp-app.test.ts
+++ b/ui/src/components/board/board-widget-cell-mcp-app.test.ts
@@ -37,6 +37,7 @@ function widget(overrides: Partial<BoardWidget> = {}): BoardWidget {
 function callbacks(overrides: Partial<BoardWidgetCellCallbacks> = {}): BoardWidgetCellCallbacks {
   const noAction = vi.fn(async () => undefined);
   return {
+    appViewGeneration: () => 0,
     grant: noAction,
     movePointerDown: vi.fn(),
     resizePointerDown: vi.fn(),

--- a/ui/src/components/board/board-widget-cell-plugin.test.ts
+++ b/ui/src/components/board/board-widget-cell-plugin.test.ts
@@ -9,6 +9,7 @@ import "./board-widget-cell.ts";
 function callbacks(): BoardWidgetCellCallbacks {
   const noAction = vi.fn(async () => undefined);
   return {
+    appViewGeneration: () => 0,
     grant: noAction,
     movePointerDown: vi.fn(),
     resizePointerDown: vi.fn(),

--- a/ui/src/components/board/board-widget-cell.ts
+++ b/ui/src/components/board/board-widget-cell.ts
@@ -42,6 +42,7 @@ import "../web-awesome.ts";
 const loadMcpAppView = () => import("../mcp-app-view-registration.ts");
 
 export type BoardWidgetCellCallbacks = {
+  appViewGeneration: () => number;
   grant: (name: string, decision: BoardGrantDecision) => Promise<void>;
   movePointerDown: (widget: BoardWidget, event: PointerEvent) => void;
   resizePointerDown: (widget: BoardWidget, event: PointerEvent) => void;

--- a/ui/src/e2e/board-mcp-app.e2e.test.ts
+++ b/ui/src/e2e/board-mcp-app.e2e.test.ts
@@ -259,6 +259,65 @@ describeControlUiE2e("Control UI dashboard MCP Apps", () => {
     });
   });
 
+  it("drops a pending app view across reconnect and mounts the current lease", async () => {
+    const context = await browser.newContext({
+      permissions: ["local-network-access"],
+      viewport: { width: 1280, height: 800 },
+    });
+    contexts.add(context);
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["board.widget.appView"],
+      sessionKey,
+      featureMethods: [
+        "board.get",
+        "board.widget.appView",
+        "chat.history",
+        "chat.metadata",
+        "chat.startup",
+        "mcp.app.view",
+      ],
+      methodResponses: {
+        "board.get": boardSnapshot(1),
+        "board.widget.appView": {
+          viewId: "current-view",
+          expiresAtMs: Date.now() + 3_600_000,
+        },
+        "mcp.app.view": appViewPayload(),
+      },
+    });
+
+    await openDashboard(page);
+    await gateway.waitForRequest("board.widget.appView");
+    const boardGetCount = (await gateway.getRequests("board.get")).length;
+    await gateway.closeLatest();
+    await expect
+      .poll(async () => (await gateway.getRequests("board.get")).length)
+      .toBeGreaterThan(boardGetCount);
+    await expect
+      .poll(async () => (await gateway.getRequests("board.widget.appView")).length)
+      .toBe(2);
+
+    await gateway.resolveDeferred("board.widget.appView", {
+      viewId: "retired-view",
+      expiresAtMs: Date.now() + 3_600_000,
+    });
+    await waitForMountedApp(page);
+    await expect
+      .poll(async () =>
+        (await gateway.getRequests("mcp.app.view")).map((request) => request.params),
+      )
+      .toContainEqual({
+        sessionKey,
+        viewId: "current-view",
+      });
+    expect(await gateway.getRequests("mcp.app.view")).not.toContainEqual(
+      expect.objectContaining({
+        params: expect.objectContaining({ viewId: "retired-view" }),
+      }),
+    );
+  });
+
   it("retains one board runtime across Chat, Split, and Dashboard", async () => {
     const context = await browser.newContext({
       permissions: ["local-network-access"],

--- a/ui/src/e2e/board-mcp-app.e2e.test.ts
+++ b/ui/src/e2e/board-mcp-app.e2e.test.ts
@@ -90,6 +90,22 @@ async function waitForMountedApp(page: Page): Promise<void> {
   );
 }
 
+async function cycleBoardProviderConnection(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const surface = document.querySelector(".board-session-surface");
+    const pane = surface?.closest("openclaw-chat-pane");
+    const lease = pane ? Reflect.get(pane, "boardProviderLease") : undefined;
+    const scopedProvider = lease?.provider;
+    const transport = scopedProvider ? Reflect.get(scopedProvider, "transport") : undefined;
+    const client = transport ? Reflect.get(transport, "client") : undefined;
+    if (!transport || !client || typeof transport.attachClient !== "function") {
+      throw new Error("Dashboard Gateway provider is unavailable");
+    }
+    transport.attachClient(client, false);
+    transport.attachClient(client, true);
+  });
+}
+
 async function captureBoardIdentity(page: Page): Promise<void> {
   await page.evaluate(() => {
     const surface = document.querySelector<HTMLElement>(".board-session-surface");
@@ -289,17 +305,30 @@ describeControlUiE2e("Control UI dashboard MCP Apps", () => {
 
     await openDashboard(page);
     await gateway.waitForRequest("board.widget.appView");
+    await gateway.deferNext("board.widget.appView");
     const boardGetCount = (await gateway.getRequests("board.get")).length;
-    await gateway.closeLatest();
+    await cycleBoardProviderConnection(page);
     await expect
       .poll(async () => (await gateway.getRequests("board.get")).length)
       .toBeGreaterThan(boardGetCount);
-    await expect
-      .poll(async () => (await gateway.getRequests("board.widget.appView")).length)
-      .toBe(2);
 
     await gateway.resolveDeferred("board.widget.appView", {
       viewId: "retired-view",
+      expiresAtMs: Date.now() + 3_600_000,
+    });
+    await page.evaluate(
+      async () =>
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        }),
+    );
+    expect(await gateway.getRequests("mcp.app.view")).toEqual([]);
+
+    await expect
+      .poll(async () => (await gateway.getRequests("board.widget.appView")).length)
+      .toBe(2);
+    await gateway.resolveDeferred("board.widget.appView", {
+      viewId: "current-view",
       expiresAtMs: Date.now() + 3_600_000,
     });
     await waitForMountedApp(page);

--- a/ui/src/lib/board/gateway-provider.ts
+++ b/ui/src/lib/board/gateway-provider.ts
@@ -74,12 +74,19 @@ export class GatewayBoardProvider implements BoardProvider {
     if (this.disposed || (client !== this.client && this.retiredClients.has(client))) {
       return;
     }
+    const connectionChanged = connected !== this.connected;
     const connectionActivated = connected && !this.connected;
     this.connected = connected;
     if (!connected) {
       this.wakeRetryDelay?.();
     }
     if (client === this.client) {
+      if (connectionChanged) {
+        this.clientGeneration += 1;
+        this.stateGeneration += 1;
+        this.appViews.clear();
+        this.publishAppViewGeneration();
+      }
       if (connectionActivated) {
         void this.activate();
       }
@@ -108,6 +115,10 @@ export class GatewayBoardProvider implements BoardProvider {
 
   get hasLoadedSnapshot(): boolean {
     return this.snapshotLoaded;
+  }
+
+  get appViewGeneration(): number {
+    return this.clientGeneration;
   }
 
   dispose(): void {
@@ -215,6 +226,9 @@ export class GatewayBoardProvider implements BoardProvider {
     revision: number,
     force: boolean,
   ): Promise<BoardWidgetAppViewState> {
+    if (this.disposed || !this.connected) {
+      return { status: "stale", error: "Dashboard MCP App view unavailable" };
+    }
     const widget = this.snapshotSignal.value.widgets.find(
       (candidate) =>
         candidate.name === name &&
@@ -225,7 +239,8 @@ export class GatewayBoardProvider implements BoardProvider {
       return { status: "stale", error: "Dashboard MCP App widget unavailable" };
     }
     const client = this.client;
-    return await this.appViews.resolve(
+    const clientGeneration = this.clientGeneration;
+    const result = await this.appViews.resolve(
       widget,
       async () =>
         await client.request<BoardWidgetAppViewResult>("board.widget.appView", {
@@ -236,6 +251,15 @@ export class GatewayBoardProvider implements BoardProvider {
         }),
       force,
     );
+    if (
+      this.disposed ||
+      !this.connected ||
+      client !== this.client ||
+      clientGeneration !== this.clientGeneration
+    ) {
+      return { status: "stale", error: "Dashboard MCP App view unavailable" };
+    }
+    return result;
   }
 
   private subscribe(client: BoardGatewayClient): void {
@@ -467,6 +491,20 @@ export class GatewayBoardProvider implements BoardProvider {
   private setLoadError(error: string | null): void {
     if (this.loadErrorSignal.value !== error) {
       this.loadErrorSignal.set(error);
+    }
+  }
+
+  private publishAppViewGeneration(): void {
+    const snapshot = this.snapshotSignal.value;
+    if (snapshot.widgets.some((widget) => widget.contentKind === "mcp-app")) {
+      // Retained cells need a new widget identity to observe the connection
+      // generation and cancel pending loads or renewals from the retired socket.
+      this.snapshotSignal.set({
+        ...snapshot,
+        widgets: snapshot.widgets.map((widget) =>
+          widget.contentKind === "mcp-app" ? Object.assign({}, widget) : widget,
+        ),
+      });
     }
   }
 }

--- a/ui/src/lib/board/provider-types.ts
+++ b/ui/src/lib/board/provider-types.ts
@@ -15,6 +15,7 @@ export type BoardPinMcpAppInput = BoardPinPlacement & { viewId: string };
 
 export type BoardProvider = {
   readonly sessionKey: string;
+  readonly appViewGeneration: number;
   readonly canMutate: boolean;
   readonly canGrant: boolean;
   readonly canPinWidgets: boolean;

--- a/ui/src/lib/board/provider.mcp-app.test.ts
+++ b/ui/src/lib/board/provider.mcp-app.test.ts
@@ -15,28 +15,32 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+function mcpAppSnapshot(sessionKey: string) {
+  return {
+    sessionKey,
+    revision: 1,
+    tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" as const }],
+    widgets: [
+      {
+        name: "server-app",
+        tabId: "main",
+        contentKind: "mcp-app" as const,
+        sizeW: 6,
+        sizeH: 4,
+        position: 0,
+        grantState: "none" as const,
+        revision: 1,
+        instanceId: "app-instance",
+      },
+    ],
+  };
+}
+
 describe("board provider MCP App views", () => {
   it("deduplicates leases until an explicit refresh", async () => {
     let now = 0;
     vi.spyOn(Date, "now").mockImplementation(() => now);
-    const snapshot = {
-      sessionKey: "agent:main:app",
-      revision: 1,
-      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" as const }],
-      widgets: [
-        {
-          name: "server-app",
-          tabId: "main",
-          contentKind: "mcp-app" as const,
-          sizeW: 6,
-          sizeH: 4,
-          position: 0,
-          grantState: "none" as const,
-          revision: 1,
-          instanceId: "app-instance",
-        },
-      ],
-    };
+    const snapshot = mcpAppSnapshot("agent:main:app");
     let lease = 0;
     const request = vi.fn(async (method: string) => {
       if (method === "board.get") {
@@ -106,6 +110,78 @@ describe("board provider MCP App views", () => {
       cache.resolve({ ...widget, instanceId: "instance-b" }, request, false),
     ).resolves.toMatchObject({ viewId: "view-b" });
     expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reuse a cached lease after a same-client reconnect", async () => {
+    const snapshot = mcpAppSnapshot("agent:main:reconnected-app");
+    let lease = 0;
+    const client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "board.get") {
+          return snapshot;
+        }
+        lease += 1;
+        return { viewId: `view-${lease}`, expiresAtMs: Date.now() + 60_000 };
+      }) as never,
+      addEventListener: () => () => {},
+    };
+    const provider = new GatewayBoardProvider(snapshot.sessionKey, client);
+    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(snapshot));
+    await expect(provider.widgetAppView("server-app", 1)).resolves.toMatchObject({
+      viewId: "view-1",
+    });
+
+    provider.attachClient(client, false);
+    provider.attachClient(client, true);
+
+    await expect(provider.widgetAppView("server-app", 1)).resolves.toMatchObject({
+      viewId: "view-2",
+    });
+  });
+
+  it("rejects pending leases after replacement, reconnect, and disposal", async () => {
+    for (const transition of ["replacement", "reconnect", "disposal"] as const) {
+      const sessionKey = `agent:main:app-view-${transition}`;
+      const snapshot = mcpAppSnapshot(sessionKey);
+      let resolvePending: ((value: { viewId: string; expiresAtMs: number }) => void) | undefined;
+      const client = {
+        request: vi.fn((method: string) =>
+          method === "board.get"
+            ? Promise.resolve(snapshot)
+            : new Promise<{ viewId: string; expiresAtMs: number }>((resolve) => {
+                resolvePending = resolve;
+              }),
+        ) as never,
+        addEventListener: () => () => {},
+      };
+      const provider = new GatewayBoardProvider(sessionKey, client);
+      await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(snapshot));
+
+      const pending = provider.widgetAppView("server-app", 1);
+      await vi.waitFor(() =>
+        expect(client.request).toHaveBeenCalledWith("board.widget.appView", expect.any(Object)),
+      );
+      if (transition === "replacement") {
+        provider.attachClient(
+          {
+            request: vi.fn(async () => snapshot) as never,
+            addEventListener: () => () => {},
+          },
+          true,
+        );
+      } else if (transition === "reconnect") {
+        provider.attachClient(client, false);
+        provider.attachClient(client, true);
+      } else {
+        provider.dispose();
+      }
+      resolvePending?.({ viewId: "retired-view", expiresAtMs: Date.now() + 60_000 });
+
+      await expect(pending).resolves.toEqual({
+        status: "stale",
+        error: "Dashboard MCP App view unavailable",
+      });
+    }
   });
 
   it("contains re-mint failures as stale widget state and retries on demand", async () => {

--- a/ui/src/lib/board/provider.ts
+++ b/ui/src/lib/board/provider.ts
@@ -85,6 +85,7 @@ export function boardExists(snapshot: BoardSnapshot): boolean {
 }
 
 class NullProvider implements BoardProvider {
+  readonly appViewGeneration = 0;
   readonly canMutate = false;
   readonly canGrant = false;
   readonly canPinWidgets = false;
@@ -125,6 +126,7 @@ class NullProvider implements BoardProvider {
 }
 
 class MockBoardProvider implements BoardProvider {
+  readonly appViewGeneration = 0;
   readonly canMutate = true;
   readonly canGrant = true;
   readonly canPinWidgets = true;
@@ -260,6 +262,10 @@ class ScopedGatewayBoardProvider implements BoardProvider {
 
   get sessionKey(): string {
     return this.transport.sessionKey;
+  }
+
+  get appViewGeneration(): number {
+    return this.transport.appViewGeneration;
   }
 
   get canPinWidgets(): boolean {

--- a/ui/src/lib/board/view-types.ts
+++ b/ui/src/lib/board/view-types.ts
@@ -6,6 +6,7 @@ export type BoardWidgetAppViewState =
   | { status: "stale"; error: string };
 
 export type BoardViewCallbacks = {
+  appViewGeneration?: number;
   applyOps: (ops: BoardOp[]) => Promise<void>;
   grant: (name: string, decision: BoardGrantDecision) => Promise<void>;
   selectTab: (tabId: string) => void;

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -365,6 +365,7 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
         canMutate: board.provider.canMutate,
         canGrant: board.provider.canGrant,
         callbacks: {
+          appViewGeneration: board.provider.appViewGeneration,
           applyOps: (ops) => board.provider.applyOps(ops),
           grant: (name, decision) => board.provider.grant(name, decision),
           selectTab: (tabId) => {

--- a/ui/src/pages/workboard/workboard-card-dashboard.ts
+++ b/ui/src/pages/workboard/workboard-card-dashboard.ts
@@ -114,6 +114,7 @@ class WorkboardCardDashboard extends OpenClawLightDomElement {
     const hasBoard = Boolean(snapshot && boardExists(snapshot));
     const callbacks = provider
       ? ({
+          appViewGeneration: provider.appViewGeneration,
           applyOps: (ops) => provider.applyOps(ops),
           grant: (name, decision) => provider.grant(name, decision),
           selectTab: (tabId) => {


### PR DESCRIPTION
Related: #129183

Depends on: #130131

## What Problem This Solves

Fixes stale MCP App view results that could survive a Gateway client replacement or same-client reconnect.

The provider cleared its cache, but an older pending `board.widget.appView` promise could still resolve into a retained board cell whose lifecycle key contained only widget identity. The retired result could leave the app stale or overwrite the current connection's view.

## Why This Change Was Made

The existing Gateway client generation now owns MCP App view results. Disconnect, reconnect, replacement, and disposal advance that generation, clear app-view cache state, and notify retained MCP App cells.

The provider rejects any result whose client or generation changed while the request was pending. The cell lifecycle includes the generation in its invalidation key, cancelling stale loads and renewal timers without adding global state or changing the Gateway protocol.

Board ticket/action authorization and agent dashboard routing are excluded.

## User Impact

After a Gateway reconnect, a pinned MCP App requests and renders a view from the current connection. A late result from the retired connection is discarded and never materialized.

## Evidence

Runtime scenario:

```text
1. Defer board.widget.appView.
2. Replace the Gateway connection.
3. Resolve the retired response after reconnect.

Before: one app-view request; dashboard settles on the stale panel.
After: two app-view requests; current connection iframe renders.
Retired view materializations on exact head: 0.
```

- Exact candidate: `aa081739f79b22d088fe91be78e170afbe8145e2`
- Final Testbox: `tbx_01m0z6mca8b26wwde78x620013`
- Final Actions run: https://github.com/openclaw/openclaw/actions/runs/32978828012
- Supporting Testbox runs: https://github.com/openclaw/openclaw/actions/runs/32976501888 and https://github.com/openclaw/openclaw/actions/runs/32975061135
- Visual proof validated against exact head with the same route, fixture, theme, viewport, and framing.
- Recording: 4.28 seconds at 1280×800.
- Patch surface: 14 files, 213 additions and 20 deletions; production logic is 58 additions and 2 deletions.

### Visual Proof

Media links will be inserted from the validated exact-head artifact bundle after the draft PR exists.
