### PR TITLE
fix(android): require listener access before forwarding notifications

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -1079,7 +1079,7 @@ private fun NotificationSettingsScreen(
 
   val notificationPermissionLauncher =
     rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-      viewModel.setNotificationForwardingEnabled(granted)
+      viewModel.setNotificationForwardingEnabled(granted && DeviceNotificationListenerService.isAccessEnabled(context))
     }
 
   fun setForwarding(checked: Boolean) {
@@ -1087,12 +1087,16 @@ private fun NotificationSettingsScreen(
       viewModel.setNotificationForwardingEnabled(false)
       return
     }
+    listenerEnabled = DeviceNotificationListenerService.isAccessEnabled(context)
+    if (!listenerEnabled) {
+      openNotificationListenerSettings(context)
+      return
+    }
     if (Build.VERSION.SDK_INT >= 33 && !hasPermission(context, Manifest.permission.POST_NOTIFICATIONS)) {
       notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
     } else {
       viewModel.setNotificationForwardingEnabled(true)
     }
-    listenerEnabled = DeviceNotificationListenerService.isAccessEnabled(context)
   }
 
   SettingsDetailFrame(title = nativeString("Notifications"), subtitle = nativeString("Choose what reaches OpenClaw."), icon = Icons.Default.Notifications, onBack = onBack) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/NotificationSettingsScreenTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/NotificationSettingsScreenTest.kt
@@ -13,7 +13,7 @@ import android.app.NotificationManager
 import android.content.ComponentName
 import android.content.Context
 import android.provider.Settings
-import androidx.compose.ui.platform.LocalContext
+import androidx.activity.compose.LocalActivity
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -135,7 +135,7 @@ class NotificationSettingsScreenTest {
   private fun showNotificationSettings() {
     val viewModel = MainViewModel(app, prefs, SavedStateHandle())
     composeRule.setContent {
-      activity = LocalContext.current as Activity
+      activity = requireNotNull(LocalActivity.current)
       ClawDesignTheme {
         SettingsDetailScreen(
           viewModel = viewModel,

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/NotificationSettingsScreenTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/NotificationSettingsScreenTest.kt
@@ -1,0 +1,184 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.NodeApp
+import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.NodeRuntimeMode
+import ai.openclaw.app.SecurePrefs
+import ai.openclaw.app.node.DeviceNotificationListenerService
+import ai.openclaw.app.ui.design.ClawDesignTheme
+import android.Manifest
+import android.app.Activity
+import android.app.NotificationManager
+import android.content.ComponentName
+import android.content.Context
+import android.provider.Settings
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.SavedStateHandle
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadow.api.Shadow
+import org.robolectric.shadows.ShadowNotificationManager
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NotificationSettingsScreenTest {
+  @get:Rule
+  val composeRule = createComposeRule()
+
+  private lateinit var app: NodeApp
+  private lateinit var prefs: SecurePrefs
+  private lateinit var runtime: NodeRuntime
+  private lateinit var activity: Activity
+  private var originalRuntime: NodeRuntime? = null
+
+  @Before
+  fun setUp() {
+    app = RuntimeEnvironment.getApplication() as NodeApp
+    clearPlainPreferences()
+    prefs =
+      SecurePrefs(
+        app,
+        app.getSharedPreferences("notification-settings-${UUID.randomUUID()}", Context.MODE_PRIVATE),
+      )
+    runtime = NodeRuntime(app, prefs, NodeRuntimeMode.ScreenshotFixture)
+    originalRuntime = app.peekRuntime()
+    setApplicationRuntime(runtime)
+    shadowOf(app).grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+    setListenerAccess(granted = false)
+  }
+
+  @After
+  fun tearDown() {
+    setApplicationRuntime(originalRuntime)
+    runtime.disconnect()
+    clearPlainPreferences()
+  }
+
+  @Test
+  fun enablingWithoutListenerAccessKeepsForwardingDisabledAndOpensSystemAccess() {
+    showNotificationSettings()
+
+    clickForwarding()
+
+    assertListenerSetupRequired()
+  }
+
+  @Test
+  fun listenerAccessIsRequestedBeforeNotificationPostingPermission() {
+    shadowOf(app).denyPermissions(Manifest.permission.POST_NOTIFICATIONS)
+    showNotificationSettings()
+
+    clickForwarding()
+
+    assertListenerSetupRequired()
+  }
+
+  @Test
+  @Config(sdk = [31])
+  fun olderAndroidAlsoRequiresListenerAccessBeforeEnablingForwarding() {
+    showNotificationSettings()
+
+    clickForwarding()
+
+    assertListenerSetupRequired()
+  }
+
+  @Test
+  fun listenerRevokedAfterScreenMountCannotEnableForwarding() {
+    setListenerAccess(granted = true)
+    showNotificationSettings()
+    setListenerAccess(granted = false)
+
+    clickForwarding()
+
+    assertListenerSetupRequired()
+  }
+
+  @Test
+  fun grantedListenerAccessAllowsForwardingWithoutOpeningSystemAccess() {
+    setListenerAccess(granted = true)
+    showNotificationSettings()
+
+    clickForwarding()
+
+    assertTrue(prefs.notificationForwardingEnabled.value)
+    assertNull(shadowOf(activity).nextStartedActivity)
+  }
+
+  @Test
+  fun disablingForwardingDoesNotRequireListenerAccess() {
+    prefs.setNotificationForwardingEnabled(true)
+    showNotificationSettings()
+
+    clickForwarding()
+
+    assertFalse(prefs.notificationForwardingEnabled.value)
+    assertNull(shadowOf(activity).nextStartedActivity)
+  }
+
+  private fun showNotificationSettings() {
+    val viewModel = MainViewModel(app, prefs, SavedStateHandle())
+    composeRule.setContent {
+      activity = LocalContext.current as Activity
+      ClawDesignTheme {
+        SettingsDetailScreen(
+          viewModel = viewModel,
+          route = SettingsRoute.Notifications,
+          onBack = {},
+        )
+      }
+    }
+  }
+
+  private fun clickForwarding() {
+    composeRule.onNodeWithText("Forward Notifications").performClick()
+    composeRule.waitForIdle()
+  }
+
+  private fun assertListenerSetupRequired() {
+    assertFalse(prefs.notificationForwardingEnabled.value)
+    assertEquals(
+      Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS,
+      shadowOf(activity).nextStartedActivity?.action,
+    )
+  }
+
+  private fun setListenerAccess(granted: Boolean) {
+    val manager = app.getSystemService(NotificationManager::class.java)
+    Shadow.extract<ShadowNotificationManager>(manager).setNotificationListenerAccessGranted(
+      ComponentName(app, DeviceNotificationListenerService::class.java),
+      granted,
+    )
+  }
+
+  private fun setApplicationRuntime(value: NodeRuntime?) {
+    NodeApp::class.java
+      .getDeclaredField("runtimeInstance")
+      .apply { isAccessible = true }
+      .set(app, value)
+  }
+
+  private fun clearPlainPreferences() {
+    app
+      .getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+      .edit()
+      .clear()
+      .commit()
+  }
+}


### PR DESCRIPTION
## Summary

Android currently lets the **Forward Notifications** master switch turn on while Notification Listener Access is denied. The screen then claims OpenClaw can receive selected alerts, but Android never delivers notifications to the listener.

- Check the actual listener authorization before enabling forwarding. If access is missing, leave forwarding off and open the existing Android notification-listener settings.
- Recheck live listener authorization when the Android notification permission callback returns, so a revoked listener grant cannot silently enable forwarding.
- Preserve explicit disable, already-granted access, the existing notification-permission flow, Android 12 and newer behavior, and both distribution flavors.

## Real Android proof

The default Play build was exercised through the actual production UI: Chat → Show Sidebar → Open Settings → Notifications → Forward Notifications.

**Before:** listener access is denied, but tapping the switch visibly enables forwarding and claims alerts can be received while access still requires setup.

![Before: forwarding incorrectly enabled while listener access still requires setup](https://github.com/user-attachments/assets/40e95fc6-68bf-4a34-91cb-9a1558e84f36)

**After:** the same denied-access action keeps forwarding off and opens Android's existing notification-listener settings, where OpenClaw is shown as not allowed.

![After: missing listener access opens Android notification listener settings](https://github.com/user-attachments/assets/f243b160-89c0-408f-a2a4-eb63a7e9cb45)

**Granted-access control:** after the user explicitly grants listener access, tapping forwarding enables it normally and the screen reports access granted.

![Control: explicitly granted listener access allows notification forwarding](https://github.com/user-attachments/assets/59ec3f45-e750-4641-bab4-7989a2e6affe)

## Validation

- Frozen-main regression: three of five actual Compose Settings interactions failed for missing or revoked listener access; granted-access and disable controls passed.
- Added six durable owner-level Compose interaction cases covering denied access on Android 12 and Android 13+, denial before the notification-permission prompt, listener revocation after screen composition, granted access, and explicit disable.
- Google Play: 125 passing owner and notification/onboarding/persistence sibling tests.
- Third-party flavor: the same 125 passing owner and sibling tests.
- All four Android ktlint modules pass: app, benchmark, wear, and wear-shared.
- Real default Play Android device: frozen denied-access failure, fixed denied-access redirect, and explicitly granted-access positive control all reproduced and passed.
- Independent autoreview reported no actionable findings.
- Production delta: +6/-2 lines, net +4, to enforce the documented Android listener-access prerequisite at its existing Settings owner.
