### PR TITLE
fix(onboarding): remote retry hint omits required risk acknowledgment

### DIFF
--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -230,8 +230,7 @@ describe("setupWizardCommand", () => {
       runtime,
     );
 
-    expect(runtime.error).toHaveBeenCalledOnce();
-    expect(runtime.error).toHaveBeenCalledWith(
+    expect(runtime.error).toHaveBeenCalledExactlyOnceWith(
       `Invalid --secret-input-mode. Use "plaintext" or "ref", or run ${formatCliCommand("openclaw onboard")} for the interactive setup.`,
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
@@ -445,8 +444,7 @@ describe("setupWizardCommand", () => {
       runtime,
     );
 
-    expect(runtime.error).toHaveBeenCalledOnce();
-    expect(runtime.error).toHaveBeenCalledWith(
+    expect(runtime.error).toHaveBeenCalledExactlyOnceWith(
       `Invalid --reset-scope. Use "config", "config+creds+sessions", or "full". Run ${formatCliCommand("openclaw onboard --reset --reset-scope config")} for a config-only reset.`,
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
@@ -521,79 +519,64 @@ describe("setupWizardCommand", () => {
   });
 
   it.each([
-    {
-      label: "unsupported flow",
-      options: { flow: "bogus" as never },
-      expectedError: "Invalid --flow",
-    },
-    {
-      label: "remote mode without a URL",
-      options: { mode: "remote" as const },
-      expectedError: formatCliCommand(
-        "openclaw onboard --non-interactive --accept-risk --mode remote --remote-url ws://127.0.0.1:3000",
-      ),
-    },
-    {
-      label: "remote mode without a URL in JSON output",
-      options: { mode: "remote" as const, json: true },
-      expectedError: formatCliCommand(
-        "openclaw onboard --non-interactive --accept-risk --mode remote --remote-url ws://127.0.0.1:3000",
-      ),
-    },
-    {
-      label: "malformed remote URL",
-      options: { mode: "remote" as const, remoteUrl: "garbage" },
-      expectedError: "URL must start with ws:// or wss://",
-    },
-    {
-      label: "non-WebSocket remote URL",
-      options: { mode: "remote" as const, remoteUrl: "https://example.invalid" },
-      expectedError: "URL must start with ws:// or wss://",
-    },
-    {
-      label: "remote URL in local mode",
-      options: { mode: "local" as const, remoteUrl: "wss://gateway.example.invalid" },
-      expectedError: "--remote-url requires --mode remote in non-interactive setup.",
-    },
-    {
-      label: "remote token in default local mode",
-      options: { remoteToken: "fixture-token" },
-      expectedError: "--remote-token requires --mode remote in non-interactive setup.",
-    },
-    {
-      label: "remote password in default local mode",
-      options: { remotePassword: "fixture-password" },
-      expectedError: "--remote-password requires --mode remote in non-interactive setup.",
-    },
-    {
-      label: "unsupported daemon runtime while daemon install is skipped",
-      options: { daemonRuntime: "bogus" as never, installDaemon: false },
-      expectedError: "Invalid --daemon-runtime",
-    },
-    {
-      label: "unsupported node manager",
-      options: { nodeManager: "bogus" as never },
-      expectedError: "Invalid --node-manager",
-    },
-  ])(
-    "rejects $label before non-interactive setup without reset",
-    async ({ options, expectedError }) => {
-      const runtime = makeRuntime();
+    ["unsupported flow", { flow: "bogus" as never }, "Invalid --flow"],
+    ...([false, true] as const).map(
+      (json) =>
+        [
+          `remote mode without a URL${json ? " in JSON output" : ""}`,
+          { mode: "remote" as const, json },
+          formatCliCommand(
+            "openclaw onboard --non-interactive --accept-risk --mode remote --remote-url ws://127.0.0.1:3000",
+          ),
+        ] as const,
+    ),
+    [
+      "malformed remote URL",
+      { mode: "remote" as const, remoteUrl: "garbage" },
+      "URL must start with ws:// or wss://",
+    ],
+    [
+      "non-WebSocket remote URL",
+      { mode: "remote" as const, remoteUrl: "https://example.invalid" },
+      "URL must start with ws:// or wss://",
+    ],
+    [
+      "remote URL in local mode",
+      { mode: "local" as const, remoteUrl: "wss://gateway.example.invalid" },
+      "--remote-url requires --mode remote in non-interactive setup.",
+    ],
+    [
+      "remote token in default local mode",
+      { remoteToken: "fixture-token" },
+      "--remote-token requires --mode remote in non-interactive setup.",
+    ],
+    [
+      "remote password in default local mode",
+      { remotePassword: "fixture-password" },
+      "--remote-password requires --mode remote in non-interactive setup.",
+    ],
+    [
+      "unsupported daemon runtime while daemon install is skipped",
+      { daemonRuntime: "bogus" as never, installDaemon: false },
+      "Invalid --daemon-runtime",
+    ],
+    ["unsupported node manager", { nodeManager: "bogus" as never }, "Invalid --node-manager"],
+  ] as const)("rejects %s before non-interactive setup without reset", async (_, opts, error) => {
+    const runtime = makeRuntime();
 
-      await setupWizardCommand({ nonInteractive: true, acceptRisk: true, ...options }, runtime);
+    await setupWizardCommand({ nonInteractive: true, acceptRisk: true, ...opts }, runtime);
 
-      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(expectedError));
-      if ("json" in options && options.json) {
-        expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(expectedError));
-      }
-      expect(runtime.exit).toHaveBeenCalledWith(1);
-      expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
-      expect(mocks.handleReset).not.toHaveBeenCalled();
-      expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
-      expect(mocks.runInteractiveSetup).not.toHaveBeenCalled();
-      expect(mocks.runGuidedOnboarding).not.toHaveBeenCalled();
-    },
-  );
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(error));
+    if ("json" in opts && opts.json) {
+      expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(error));
+    }
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+    expect(mocks.handleReset).not.toHaveBeenCalled();
+    expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
+    expect(mocks.runInteractiveSetup).not.toHaveBeenCalled();
+    expect(mocks.runGuidedOnboarding).not.toHaveBeenCalled();
+  });
 
   const tokenError =
     "--gateway-token configures local gateway auth. Use --remote-token in remote mode.";

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -527,6 +527,20 @@ describe("setupWizardCommand", () => {
       expectedError: "Invalid --flow",
     },
     {
+      label: "remote mode without a URL",
+      options: { mode: "remote" as const },
+      expectedError: formatCliCommand(
+        "openclaw onboard --non-interactive --accept-risk --mode remote --remote-url ws://127.0.0.1:3000",
+      ),
+    },
+    {
+      label: "remote mode without a URL in JSON output",
+      options: { mode: "remote" as const, json: true },
+      expectedError: formatCliCommand(
+        "openclaw onboard --non-interactive --accept-risk --mode remote --remote-url ws://127.0.0.1:3000",
+      ),
+    },
+    {
       label: "malformed remote URL",
       options: { mode: "remote" as const, remoteUrl: "garbage" },
       expectedError: "URL must start with ws:// or wss://",
@@ -569,6 +583,9 @@ describe("setupWizardCommand", () => {
       await setupWizardCommand({ nonInteractive: true, acceptRisk: true, ...options }, runtime);
 
       expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(expectedError));
+      if ("json" in options && options.json) {
+        expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(expectedError));
+      }
       expect(runtime.exit).toHaveBeenCalledWith(1);
       expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
       expect(mocks.handleReset).not.toHaveBeenCalled();

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -204,7 +204,7 @@ function validatePreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): bo
     return rejectOption(
       opts,
       runtime,
-      `Missing --remote-url for remote mode. Example: ${formatCliCommand("openclaw onboard --non-interactive --mode remote --remote-url ws://127.0.0.1:3000")}.`,
+      `Missing --remote-url for remote mode. Example: ${formatCliCommand("openclaw onboard --non-interactive --accept-risk --mode remote --remote-url ws://127.0.0.1:3000")}.`,
     );
   }
   if (opts.nonInteractive && opts.mode === "remote" && opts.remoteUrl?.trim()) {


### PR DESCRIPTION
Closes #130169

## What Problem This Solves

Fixes an issue where users running noninteractive remote onboarding without `--remote-url` received a suggested retry command that immediately failed again because it omitted mandatory `--accept-risk`.

## Why This Change Was Made

Include the already-required risk acknowledgment flag in the canonical missing-remote-URL validation example. Keep the existing validation owner, real risk-enforcement behavior, profile/container formatting, and side-effect-free preflight path unchanged.

## User Impact

Operators can copy the remote-onboarding recovery command and continue setup immediately instead of hitting a second risk-acknowledgment error. Human-readable and JSON onboarding errors now provide the same usable guidance.

## Evidence

- Both new human and JSON owner regressions failed on unchanged production because the suggested command omitted `--accept-risk`.
- All 91 onboarding command tests pass after the change.
- The real Commander CLI now emits the corrected retry command; actual parsing accepts that command for both `onboard` and `setup`.
- Real named-profile and container contexts preserve their existing correctly scoped command formatting.
- Validation remains side-effect free: no Gateway, user configuration, or state was created.
- Formatting, independent source review, and Codex autoreview passed without findings.
- Production change: +1/-1 line, net zero. Regression tests extend the existing preflight table by 17 lines.

AI-assisted and independently validated through actual CLI registration and execution.
