### PR TITLE
test(live): resolve thinking from prepared model

### DIFF
--- a/src/agents/models.profiles.live.test.ts
+++ b/src/agents/models.profiles.live.test.ts
@@ -7,6 +7,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { type Api, completeSimple, type Model } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
+import { resolveThinkingProfile } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef, type SecretInput } from "../config/types.secrets.js";
 import { parseLiveCsvFilter } from "../media-generation/live-test-helpers.js";
@@ -1269,13 +1270,37 @@ function resolveTestReasoning(
   if (model.provider === "xai" && id.startsWith("grok-4")) {
     return undefined;
   }
+  let preferred: "low" | "medium" | "high" = "low";
   if (model.provider === "openai") {
     if (id.includes("pro")) {
-      return "high";
+      preferred = "high";
+    } else {
+      preferred = "medium";
     }
-    return "medium";
   }
-  return "low";
+  const profile = resolveThinkingProfile({
+    provider: model.provider,
+    model: model.id,
+    catalog: [
+      {
+        provider: model.provider,
+        id: model.id,
+        api: model.api,
+        reasoning: model.reasoning,
+      },
+    ],
+    agentRuntime: "openclaw",
+  });
+  if (profile.levels.some((level) => level.id === preferred)) {
+    return preferred;
+  }
+  return profile.defaultLevel === "minimal" ||
+    profile.defaultLevel === "low" ||
+    profile.defaultLevel === "medium" ||
+    profile.defaultLevel === "high" ||
+    profile.defaultLevel === "xhigh"
+    ? profile.defaultLevel
+    : undefined;
 }
 
 function resolveLiveSystemPrompt(model: Model): string | undefined {
@@ -1284,6 +1309,19 @@ function resolveLiveSystemPrompt(model: Model): string | undefined {
   }
   return undefined;
 }
+
+describe("resolveTestReasoning", () => {
+  it("honors the prepared OpenCode Go transport profile", () => {
+    const model = {
+      provider: "opencode-go",
+      id: "glm-5",
+      reasoning: true,
+    } as Model;
+
+    expect(resolveTestReasoning(model)).toBe("low");
+    expect(resolveTestReasoning({ ...model, api: "openai-completions" } as Model)).toBeUndefined();
+  });
+});
 
 describe("resolveLiveSystemPrompt", () => {
   it("adds instructions for openai probes", () => {
@@ -1338,10 +1376,13 @@ async function completeSimpleWithTimeout<TApi extends Api>(
       model,
       cfg: activeLiveCompletionConfig,
     });
+    const reasoning =
+      options?.reasoning === undefined ? undefined : resolveTestReasoning(completionModel);
     return await withLiveHeartbeat(
       Promise.race([
         completeSimple(completionModel, context, {
           ...options,
+          reasoning,
           signal: controller.signal,
         }),
         timeout,


### PR DESCRIPTION
## Summary

- resolve the live-suite thinking profile from the prepared completion model
- apply the owning provider policy after transport preparation
- cover OpenCode Go GLM-5 switching to its fixed OpenAI-completions profile

## Root cause

The live profile suite selected `low` from the raw catalog model before `prepareModelForSimpleCompletion`. OpenCode Go GLM-5 is prepared onto `openai-completions`, where the plugin policy exposes a fixed always-on profile and rejects `low`. The suite now carries the prepared API into the canonical policy resolver.

## Verification

- `pnpm exec vitest run --config test/vitest/vitest.live.config.ts src/agents/models.profiles.live.test.ts` (37 passed, 1 skipped)
- focused prepared OpenCode Go profile regression (passed)
- target lint, format, and diff checks (clean)
- autoreview (clean, 0.99)

Production LOC: 0. Test LOC: +37/-3. Local credential environment did not expose the OpenCode Go live key; the credentialed workflow is the remaining real-provider proof.