### PR TITLE
refactor(auto-reply): share restart termination fields

### DIFF
--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -10,10 +10,6 @@ import {
 import type { RunEmbeddedAgentParams } from "../../agents/embedded-agent-runner/run/params.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import type { ContextEngineLogicalTurnLease } from "../../agents/harness/context-engine-logical-turn.js";
-import {
-  AGENT_RUN_RESTART_ABORT_STOP_REASON,
-  resolveAgentRunErrorLifecycleFields,
-} from "../../agents/run-termination.js";
 import { withLocalSessionPlacementTurnAdmission } from "../../agents/session-placement-admission.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -42,7 +38,7 @@ import { shouldBridgeCliPreambleEvents } from "./get-reply.types.js";
 import { hasInboundAudio } from "./inbound-media.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import type { FollowupRun } from "./queue.js";
-import { isReplyOperationRestartAbort } from "./reply-operation-abort.js";
+import { resolveReplyOperationTerminationFields } from "./reply-operation-abort.js";
 import { resolveFollowupRunToolAuthorityFingerprint } from "./reply-tool-authority.js";
 
 type CliPresentation = Pick<
@@ -117,15 +113,8 @@ export async function runCliFallbackCandidate(params: {
     sessionKey: turn.sessionKey,
     startedAt: cliLifecycleStartedAt,
     getLifecycleGeneration: () => params.lifecycleGeneration,
-    resolveTerminationFields: (error) => ({
-      ...resolveAgentRunErrorLifecycleFields(error, params.runAbortSignal),
-      ...(isReplyOperationRestartAbort(turn.replyOperation)
-        ? {
-            aborted: true as const,
-            stopReason: AGENT_RUN_RESTART_ABORT_STOP_REASON,
-          }
-        : {}),
-    }),
+    resolveTerminationFields: (error) =>
+      resolveReplyOperationTerminationFields(error, params.runAbortSignal, turn.replyOperation),
   });
   params.onLifecycleBackstop(lifecycleBackstop);
   const authProfile = resolveRunAuthProfile(params.candidateRun, params.cliExecutionProvider, {

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -9,10 +9,6 @@ import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import type { ContextEngineLogicalTurnLease } from "../../agents/harness/context-engine-logical-turn.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import { resolveOpenAIRuntimeProvider } from "../../agents/openai-routing.js";
-import {
-  AGENT_RUN_RESTART_ABORT_STOP_REASON,
-  resolveAgentRunErrorLifecycleFields,
-} from "../../agents/run-termination.js";
 import { resolveGroupSessionKey } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -42,7 +38,7 @@ import type { createAgentTurnPresentation } from "./agent-runner-presentation.js
 import type { AgentTurnTimingTracker } from "./agent-runner-turn-timing.js";
 import { buildEmbeddedRunExecutionParams } from "./agent-runner-utils.js";
 import type { FollowupRun } from "./queue.js";
-import { isReplyOperationRestartAbort } from "./reply-operation-abort.js";
+import { resolveReplyOperationTerminationFields } from "./reply-operation-abort.js";
 import { markReplyOperationGlobalLaneWaitProgress } from "./reply-run-registry.js";
 import { resolveFollowupRunToolAuthorityFingerprint } from "./reply-tool-authority.js";
 import {
@@ -191,15 +187,8 @@ export async function runEmbeddedFallbackCandidate(params: {
     runId: params.runId,
     sessionKey: turn.sessionKey,
     getLifecycleGeneration: params.getLifecycleGeneration,
-    resolveTerminationFields: (error) => ({
-      ...resolveAgentRunErrorLifecycleFields(error, params.runAbortSignal),
-      ...(isReplyOperationRestartAbort(turn.replyOperation)
-        ? {
-            aborted: true as const,
-            stopReason: AGENT_RUN_RESTART_ABORT_STOP_REASON,
-          }
-        : {}),
-    }),
+    resolveTerminationFields: (error) =>
+      resolveReplyOperationTerminationFields(error, params.runAbortSignal, turn.replyOperation),
   });
   params.onLifecycleBackstop(lifecycleBackstop);
   const toolAuthorityRoute = { provider: embeddedRunProvider, model: params.model };

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -17,10 +17,7 @@ import {
   renderRateLimitReplyCopy,
 } from "../../agents/failover/user-copy.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
-import {
-  AGENT_RUN_RESTART_ABORT_STOP_REASON,
-  resolveAgentRunErrorLifecycleFields,
-} from "../../agents/run-termination.js";
+import { resolveAgentRunErrorLifecycleFields } from "../../agents/run-termination.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
@@ -498,12 +495,7 @@ export async function handleAgentExecutionError(params: {
       : turn.opts?.abortSignal?.aborted === true
         ? turn.opts.abortSignal
         : undefined;
-  const abortLifecycleFields = {
-    ...resolveAgentRunErrorLifecycleFields(err, abortedSignal),
-    ...(isReplyOperationRestartAbort(turn.replyOperation)
-      ? { aborted: true as const, stopReason: AGENT_RUN_RESTART_ABORT_STOP_REASON }
-      : {}),
-  };
+  const abortLifecycleFields = resolveAgentRunErrorLifecycleFields(err, abortedSignal);
   const failedLifecycleTerminal = takePendingLifecycleTerminal();
   if (failedLifecycleTerminal) {
     failedLifecycleTerminal.emit("error", err, { fallbackExhaustedFailure: true });

--- a/src/auto-reply/reply/reply-operation-abort.ts
+++ b/src/auto-reply/reply/reply-operation-abort.ts
@@ -1,7 +1,9 @@
 import { isFallbackSummaryError } from "../../agents/model-fallback-attempt.js";
 import {
+  AGENT_RUN_RESTART_ABORT_STOP_REASON,
   isAgentRunRestartAbortReason,
   isAgentRunSupersededAbortReason,
+  resolveAgentRunErrorLifecycleFields,
 } from "../../agents/run-termination.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
@@ -34,6 +36,19 @@ export function isReplyOperationRestartAbort(replyOperation?: ReplyOperation): b
   }
   const abortSignal = replyOperation?.abortSignal;
   return abortSignal?.aborted === true && isAgentRunRestartAbortReason(abortSignal.reason);
+}
+
+export function resolveReplyOperationTerminationFields(
+  error: unknown,
+  signal: AbortSignal | undefined,
+  replyOperation?: ReplyOperation,
+) {
+  return {
+    ...resolveAgentRunErrorLifecycleFields(error, signal),
+    ...(isReplyOperationRestartAbort(replyOperation)
+      ? { aborted: true as const, stopReason: AGENT_RUN_RESTART_ABORT_STOP_REASON }
+      : {}),
+  };
 }
 
 export function isReplyOperationSuperseded(replyOperation?: ReplyOperation): boolean {


### PR DESCRIPTION
## Summary

- centralize reply-operation restart termination fields
- reuse the shared resolver in CLI and embedded lifecycle backstops
- remove the unreachable restart overlay from the terminal error handler

## Architecture

`src/auto-reply/reply/reply-operation-abort.ts` now composes the canonical
agent-run termination fields with the reply-operation restart override. The
CLI and embedded backstops retain their caller-owned abort signals. The error
handler keeps its selected signal and drops an overlay that cannot be reached
after the earlier restart-return path.

No config, persistence, protocol, dependency, or SDK surface changes.

Production delta: `+23/-38` (net `-15`). Tests unchanged.

## Verification

- focused Vitest: 4 files, 157 tests passed
- formatting, core and core-test typechecks, Oxlint, dead exports, and import cycles passed
- `git diff --check`
- pre-rebase identical-diff autoreview: no actionable findings
- rebased autoreview rerun was unavailable because the standalone Codex CLI is not installed
- Blacksmith Testbox `tbx_01m0z8h3jqejk1c4gns475ysbj`: passed

Testbox run: https://github.com/openclaw/openclaw/actions/runs/32982276102

## Dependency contract

OpenAI Codex `a6e63f9f32525d171676ac49c4e87ab00d76f0ce` confirms that
`turn/interrupt` emits a terminal interrupted turn rather than an error.

## Changelog

Not required for an internal behavior-preserving refactor.
