### PR TITLE
fix(agents): disclose 64 KiB code-mode stderr-tail truncation

### DIFF
--- a/docs/tools/tool-search.md
+++ b/docs/tools/tool-search.md
@@ -273,6 +273,11 @@ network grants, and no child-process or worker grants. OpenClaw enforces a
 parent-process wall-clock timeout and kills the subprocess on timeout, including
 after async continuations.
 
+Outstanding bridged tool calls are canceled when the child settles, including
+fatal exits and final results. Failed exits wait for stderr to drain before
+rendering a bounded diagnostic. The error separately reports bytes discarded
+from the 64 KiB retained tail and bytes omitted from its final text preview.
+
 The runtime exposes only:
 
 - `console.log`, `console.warn`, and `console.error`

--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -312,7 +312,7 @@ export function createFindToolDefinition(
             // cannot split multibyte characters into U+FFFD replacement noise.
             child.stderr?.setEncoding("utf8");
             child.stderr?.on("data", (chunk: string) => {
-              stderr = appendBoundedTextTail(stderr, chunk);
+              stderr = appendBoundedTextTail(stderr, chunk).tail;
             });
             // Readline re-emits input failures, while the stream listener also catches
             // implementations that do not. settle() keeps the shared failure path one-shot.

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -284,7 +284,7 @@ export function createGrepToolDefinition(
             // cannot split multibyte characters into U+FFFD replacement noise.
             spawnedChild.stderr?.setEncoding("utf8");
             spawnedChild.stderr?.on("data", (chunk: string) => {
-              stderr = appendBoundedTextTail(stderr, chunk);
+              stderr = appendBoundedTextTail(stderr, chunk).tail;
             });
             const onStreamError = (stream: "stdout" | "stderr", error: Error) => {
               if (settled) {

--- a/src/agents/sessions/tools/limits.test.ts
+++ b/src/agents/sessions/tools/limits.test.ts
@@ -20,50 +20,36 @@ describe("session tool limits", () => {
     expect(normalizePositiveLimit(input, 500)).toBe(expected);
   });
 
-  it("keeps a bounded tail of accumulated child output", () => {
-    let output = appendBoundedTextTail("old-", "middle-", 12);
-    output = appendBoundedTextTail(output, "recent", 12);
-
-    expect(output).toBe("iddle-recent");
-    expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(12);
-  });
-
-  it("clips oversized chunks to the configured tail bytes", () => {
-    const output = appendBoundedTextTail("ignored", "x".repeat(128), 16);
-
-    expect(output).toBe("x".repeat(16));
-    expect(Buffer.byteLength(output, "utf8")).toBe(16);
-  });
-
-  it("does not exceed the byte cap when clipping multibyte text", () => {
-    // Never return a partial UTF-8 character just to fill the final byte.
-    const output = appendBoundedTextTail("ignored", "é", 1);
-
-    expect(output).toBe("");
-    expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(1);
-  });
-
-  it("keeps complete multibyte characters at the bounded tail", () => {
-    const output = appendBoundedTextTail("prefix", "aé", 2);
-
-    expect(output).toBe("é");
-    expect(Buffer.byteLength(output, "utf8")).toBe(2);
-  });
-
-  it("drops orphan continuation bytes when the byte window splits a character", () => {
-    // "aaaa😀ccccccc" is 15 bytes; a 6-byte chunk under a 16-byte cap keeps a
-    // 10-byte tail whose cut lands inside the 4-byte emoji. The orphan
-    // continuation bytes must not surface as U+FFFD at the head of the tail.
-    const output = appendBoundedTextTail("aaaa😀ccccccc", "dddddd", 16);
-
-    expect(output).toBe("cccccccdddddd");
-    expect(output).not.toContain("�");
-    expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(16);
-  });
+  it.each([
+    { chunks: ["old-", "middle-", "recent"], cap: 12, tail: "iddle-recent", dropped: 5 },
+    { chunks: ["ignored", "x".repeat(128)], cap: 16, tail: "x".repeat(16), dropped: 119 },
+    { chunks: ["é"], cap: 1, tail: "", dropped: 2 },
+    { chunks: ["prefix", "aé"], cap: 2, tail: "é", dropped: 7 },
+    // The cap cuts inside the emoji; orphan continuation bytes must also be counted.
+    { chunks: ["aaaa😀ccccccc", "dddddd"], cap: 16, tail: "cccccccdddddd", dropped: 8 },
+    { chunks: ["short", " note"], cap: 16, tail: "short note", dropped: 0 },
+  ])(
+    "retains $tail and accounts for $dropped discarded bytes",
+    ({ chunks, cap, tail, dropped }) => {
+      let retained = "";
+      let discarded = 0;
+      for (const chunk of chunks) {
+        const appended = appendBoundedTextTail(retained, chunk, cap);
+        retained = appended.tail;
+        discarded += appended.droppedBytes;
+      }
+      expect(retained).toBe(tail);
+      expect(retained).not.toContain("�");
+      expect(discarded).toBe(dropped);
+      expect(Buffer.byteLength(retained)).toBeLessThanOrEqual(cap);
+      expect(Buffer.byteLength(retained) + discarded).toBe(Buffer.byteLength(chunks.join("")));
+    },
+  );
 
   it("uses the session stderr tail limit by default", () => {
     const output = appendBoundedTextTail("", "x".repeat(SESSION_TOOL_STDERR_TAIL_BYTES + 1));
 
-    expect(Buffer.byteLength(output, "utf8")).toBe(SESSION_TOOL_STDERR_TAIL_BYTES);
+    expect(Buffer.byteLength(output.tail, "utf8")).toBe(SESSION_TOOL_STDERR_TAIL_BYTES);
+    expect(output.droppedBytes).toBe(1);
   });
 });

--- a/src/agents/sessions/tools/limits.ts
+++ b/src/agents/sessions/tools/limits.ts
@@ -4,6 +4,7 @@
  * Tail storage is byte-bounded but decoded as UTF-8, so truncation avoids
  * splitting multi-byte characters in display output.
  */
+import { Buffer } from "node:buffer";
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf8Suffix } from "../../../utils/utf8-truncate.js";
 
@@ -15,12 +16,14 @@ export function normalizePositiveLimit(value: number | undefined, fallback: numb
 /** Default stderr tail retained for long-running session tools. */
 export const SESSION_TOOL_STDERR_TAIL_BYTES = 64 * 1024;
 
-/** Appends a chunk while retaining only the UTF-8-safe tail within maxBytes. */
+/** Retains a UTF-8-safe tail and counts bytes discarded by this append. */
 export function appendBoundedTextTail(
   current: string,
   chunk: string,
   maxBytes = SESSION_TOOL_STDERR_TAIL_BYTES,
-): string {
+): { tail: string; droppedBytes: number } {
   const effectiveMaxBytes = normalizePositiveLimit(maxBytes, SESSION_TOOL_STDERR_TAIL_BYTES);
-  return truncateUtf8Suffix(`${current}${chunk}`, effectiveMaxBytes);
+  const combined = `${current}${chunk}`;
+  const tail = truncateUtf8Suffix(combined, effectiveMaxBytes);
+  return { tail, droppedBytes: Buffer.byteLength(combined) - Buffer.byteLength(tail) };
 }

--- a/src/agents/tool-search-code-mode.ts
+++ b/src/agents/tool-search-code-mode.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { spawn } from "node:child_process";
 import os from "node:os";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -99,10 +100,6 @@ async function runCodeModeBridgeRequest(
   throw new ToolInputError("Unsupported tool_search_code bridge method.");
 }
 
-export function appendToolSearchCodeStderrTail(current: string, chunk: string): string {
-  return appendBoundedTextTail(current, chunk, SESSION_TOOL_STDERR_TAIL_BYTES);
-}
-
 export function runCodeModeChild(params: {
   code: string;
   config: ToolSearchConfig;
@@ -121,11 +118,11 @@ export function runCodeModeChild(params: {
       stdio: ["ignore", "ignore", "pipe", "ipc"],
     });
     let stderrTail = "";
+    let stderrDroppedBytes = 0;
     let settled = false;
-    let timedOut = false;
     let exitRejectionTimer: ReturnType<typeof setTimeout> | undefined;
     const bridgeAbortController = new AbortController();
-    const settle = (callback: () => void) => {
+    const settle = (callback: () => void, abortReason?: unknown) => {
       if (settled) {
         return;
       }
@@ -137,19 +134,19 @@ export function runCodeModeChild(params: {
         clearTimeout(exitRejectionTimer);
       }
       params.signal?.removeEventListener("abort", abortFromParent);
+      // Host tool calls share the child lifetime, including fatal exits and final IPC results.
+      bridgeAbortController.abort(abortReason);
       child.kill();
       callback();
     };
     const abortFromParent: () => void = () => {
-      bridgeAbortController.abort(params.signal?.reason);
       child.kill("SIGKILL");
-      settle(() => reject(new Error("tool_search_code aborted")));
+      settle(() => reject(new Error("tool_search_code aborted")), params.signal?.reason);
     };
     const timer: ReturnType<typeof setTimeout> | undefined = setTimeout(() => {
-      timedOut = true;
-      bridgeAbortController.abort(new Error("tool_search_code timed out"));
+      const error = new Error("tool_search_code timed out");
       child.kill("SIGKILL");
-      settle(() => reject(new Error("tool_search_code timed out")));
+      settle(() => reject(error), error);
     }, params.config.codeTimeoutMs);
     params.signal?.addEventListener("abort", abortFromParent, { once: true });
     if (params.signal?.aborted) {
@@ -159,7 +156,9 @@ export function runCodeModeChild(params: {
 
     child.stderr?.setEncoding("utf8");
     child.stderr?.on("data", (chunk: string) => {
-      stderrTail = appendToolSearchCodeStderrTail(stderrTail, chunk);
+      const appended = appendBoundedTextTail(stderrTail, chunk);
+      stderrTail = appended.tail;
+      stderrDroppedBytes += appended.droppedBytes;
     });
     child.stderr?.on("error", (error) => {
       settle(() => reject(error));
@@ -167,29 +166,37 @@ export function runCodeModeChild(params: {
     child.on("error", (error) => {
       settle(() => reject(error));
     });
+    const rejectOnExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      const suffix = stderrTail.trim();
+      const preview = sliceUtf16Safe(suffix, -500);
+      const previewDroppedBytes = Buffer.byteLength(suffix) - Buffer.byteLength(preview);
+      const notices = [
+        stderrDroppedBytes > 0
+          ? `${stderrDroppedBytes} UTF-8 bytes of earlier stderr discarded at the ${SESSION_TOOL_STDERR_TAIL_BYTES}-byte retention cap`
+          : "",
+        previewDroppedBytes > 0
+          ? `${previewDroppedBytes} UTF-8 bytes omitted from the trimmed stderr preview`
+          : "",
+      ].filter(Boolean);
+      const detail =
+        preview || notices.length > 0
+          ? `: ${preview}${notices.length > 0 ? ` [${notices.join("; ")}]` : ""}`
+          : "";
+      settle(() =>
+        reject(new Error(`tool_search_code child exited with ${signal ?? code}${detail}`)),
+      );
+    };
     child.on("exit", (code, signal) => {
-      if (settled) {
-        return;
+      // Preserve the existing IPC grace even when stderr closes first or never closes.
+      if (!settled && code === 0 && signal === null) {
+        exitRejectionTimer = setTimeout(() => rejectOnExit(code, signal), 250);
       }
-      const rejectOnExit = () => {
-        const suffix = stderrTail.trim();
-        const detail = suffix ? `: ${sliceUtf16Safe(suffix, -500)}` : "";
-        settle(() =>
-          reject(
-            new Error(
-              timedOut
-                ? "tool_search_code timed out"
-                : `tool_search_code child exited with ${signal ?? code}${detail}`,
-            ),
-          ),
-        );
-      };
-      if (code === 0 && signal === null) {
-        // A clean exit can race the final IPC result.
-        exitRejectionTimer = setTimeout(rejectOnExit, 250);
-        return;
+    });
+    child.on("close", (code, signal) => {
+      // Node owns exit + stdio drain ordering; rendering at exit can miss the final chunk.
+      if (!settled && (code !== 0 || signal !== null)) {
+        rejectOnExit(code, signal);
       }
-      rejectOnExit();
     });
     child.on("message", (message: CodeModeChildMessage) => {
       if (settled || !isRecord(message) || typeof message.type !== "string") {

--- a/src/agents/tool-search.stream-errors.test.ts
+++ b/src/agents/tool-search.stream-errors.test.ts
@@ -1,7 +1,8 @@
 // Regression tests for code-mode child stderr stream errors in Tool Search.
-import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { SESSION_TOOL_STDERR_TAIL_BYTES } from "./sessions/tools/limits.js";
 
 type MockSpawnChild = EventEmitter & {
   stderr?: EventEmitter & { setEncoding?: (enc: string) => void };
@@ -12,8 +13,8 @@ type MockSpawnChild = EventEmitter & {
 
 function createMockSpawnChild() {
   const child = new EventEmitter() as MockSpawnChild;
-  const stderr = new EventEmitter() as MockSpawnChild["stderr"];
-  stderr!.setEncoding = vi.fn();
+  const stderr = new EventEmitter() as NonNullable<MockSpawnChild["stderr"]>;
+  stderr.setEncoding = vi.fn();
   child.stderr = stderr;
   child.connected = true;
   child.kill = vi.fn();
@@ -23,24 +24,23 @@ function createMockSpawnChild() {
 
 vi.mock("node:child_process", async () => {
   const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
-  const spawnLocal = vi.fn(
-    (_command: string, _args: readonly string[], _options: SpawnOptions): ChildProcess => {
-      const { child } = createMockSpawnChild();
-      return child as unknown as ChildProcess;
-    },
-  );
   return mockNodeBuiltinModule(
     () => vi.importActual<typeof import("node:child_process")>("node:child_process"),
-    {
-      spawn: spawnLocal as unknown as typeof import("node:child_process").spawn,
-    },
+    { spawn: vi.fn() as unknown as typeof import("node:child_process").spawn },
   );
 });
 
 const spawnMock = vi.mocked(spawn);
-
 let toolSearch: typeof import("./tool-search.js");
 let testing: (typeof import("./tool-search.test-support.js"))["testing"];
+
+async function rejectedMessage(promise: Promise<unknown>): Promise<string> {
+  await expect(promise).rejects.toBeInstanceOf(Error);
+  return promise.then(
+    () => "",
+    (error: Error) => error.message,
+  );
+}
 
 describe("tool-search code-mode stream errors", () => {
   beforeAll(async () => {
@@ -48,82 +48,229 @@ describe("tool-search code-mode stream errors", () => {
     testing = (await import("./tool-search.test-support.js")).testing;
   });
 
-  afterEach(() => {
-    testing.setToolSearchCodeModeSupportedForTest(undefined);
-    testing.setToolSearchMinCodeTimeoutMsForTest(undefined);
-  });
+  afterEach(() => vi.useRealTimers());
+
+  function startChild(signal?: AbortSignal) {
+    const { child, stderr } = createMockSpawnChild();
+    spawnMock.mockReturnValueOnce(child as unknown as ChildProcess);
+    const config = { ...toolSearch.resolveToolSearchConfig({}), codeTimeoutMs: 1000 };
+    const runtime = new toolSearch.ToolSearchRuntime({}, config);
+    const promise = testing.runCodeModeChild({
+      code: "return 7;",
+      config,
+      logs: [],
+      parentToolCallId: "stderr-lifecycle",
+      runtime,
+      signal,
+    });
+    const settled = vi.fn();
+    void promise.then(settled, settled);
+    return { child, stderr, promise, settled, runtime };
+  }
 
   it("rejects stderr errors and leaves the unused stdout unpiped", async () => {
-    testing.setToolSearchCodeModeSupportedForTest(true);
-    testing.setToolSearchMinCodeTimeoutMsForTest(1000);
-
-    let spawnedChild: MockSpawnChild | undefined;
-    spawnMock.mockImplementationOnce(
-      (_command: string, _args: readonly string[], _options: SpawnOptions): ChildProcess => {
-        const { child, stderr } = createMockSpawnChild();
-        spawnedChild = child;
-        process.nextTick(() => {
-          stderr?.emit("error", new Error("stderr read failed"));
-        });
-        return child as unknown as ChildProcess;
-      },
-    );
-
-    const runtime = new toolSearch.ToolSearchRuntime({}, toolSearch.resolveToolSearchConfig({}));
-
-    await expect(
-      testing.runCodeModeChild({
-        code: "return 1;",
-        config: toolSearch.resolveToolSearchConfig({}),
-        logs: [],
-        parentToolCallId: "call-stderr-error",
-        runtime,
-      }),
-    ).rejects.toThrow("stderr read failed");
-    expect(spawnMock).toHaveBeenCalledOnce();
-    expect(spawnMock.mock.calls[0]?.[2]).toMatchObject({
+    const { child, stderr, promise } = startChild();
+    const failure = rejectedMessage(promise);
+    stderr.emit("error", new Error("stderr read failed"));
+    expect(await failure).toBe("stderr read failed");
+    expect(spawnMock.mock.calls.at(-1)?.[2]).toMatchObject({
       stdio: ["ignore", "ignore", "pipe", "ipc"],
     });
-    expect(spawnedChild?.kill).toHaveBeenCalledOnce();
+    expect(child.kill).toHaveBeenCalledOnce();
   });
 
-  it("keeps stderr tail in exit error messages valid at UTF-16 boundaries", async () => {
-    testing.setToolSearchCodeModeSupportedForTest(true);
-    testing.setToolSearchMinCodeTimeoutMsForTest(1000);
-
-    spawnMock.mockImplementationOnce(
-      (_command: string, _args: readonly string[], _options: SpawnOptions): ChildProcess => {
-        const { child, stderr } = createMockSpawnChild();
-        process.nextTick(() => {
-          stderr?.emit("data", `${"a".repeat(500)}😀${"a".repeat(499)}`);
-          process.nextTick(() => {
-            child.emit("exit", 1, null);
-          });
-        });
-        return child as unknown as ChildProcess;
-      },
+  it("discloses preview loss below the retention cap without splitting a surrogate pair", async () => {
+    const { child, stderr, promise } = startChild();
+    const failure = rejectedMessage(promise);
+    stderr.emit("data", `${"a".repeat(500)}😀${"a".repeat(499)}`);
+    child.emit("exit", 1, null);
+    stderr.emit("close");
+    child.emit("close", 1, null);
+    const message = await failure;
+    expect(message).toContain(
+      `: ${"a".repeat(499)} [504 UTF-8 bytes omitted from the trimmed stderr preview]`,
     );
-
-    const runtime = new toolSearch.ToolSearchRuntime({}, toolSearch.resolveToolSearchConfig({}));
-
-    let caught: Error | undefined;
-    try {
-      await testing.runCodeModeChild({
-        code: "return 1;",
-        config: toolSearch.resolveToolSearchConfig({}),
-        logs: [],
-        parentToolCallId: "call-stderr-utf16",
-        runtime,
-      });
-    } catch (error) {
-      caught = error instanceof Error ? error : new Error(String(error));
-    }
-
-    expect(caught).toBeDefined();
-    expect(caught?.message).toMatch(/tool_search_code child exited with 1/);
-    expect(caught?.message).not.toMatch(
+    expect(message).not.toContain("retention cap");
+    expect(message).not.toMatch(
       /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
     );
-    expect(caught?.message.endsWith("a".repeat(499))).toBe(true);
+  });
+
+  it.each([false, true])(
+    "waits for child close with stderr-first=%s and reports both losses",
+    async (stderrFirst) => {
+      const { child, stderr, promise, settled } = startChild();
+      const failure = rejectedMessage(promise);
+      const early = `HEAD_${"é".repeat(400)}`;
+      const late = `${"z".repeat(SESSION_TOOL_STDERR_TAIL_BYTES)}_TAIL`;
+      stderr.emit("data", early);
+      if (stderrFirst) {
+        stderr.emit("data", late);
+        stderr.emit("close");
+      }
+      child.emit("exit", 1, null);
+      await Promise.resolve();
+      expect(settled).not.toHaveBeenCalled();
+      if (!stderrFirst) {
+        stderr.emit("data", late);
+        stderr.emit("close");
+      }
+      child.emit("close", 1, null);
+      const message = await failure;
+      expect(message).toContain("_TAIL");
+      expect(message).not.toContain("HEAD_");
+      expect(message).toContain(
+        `${Buffer.byteLength(early + late) - SESSION_TOOL_STDERR_TAIL_BYTES} UTF-8 bytes of earlier stderr discarded at the ${SESSION_TOOL_STDERR_TAIL_BYTES}-byte retention cap`,
+      );
+      expect(message).toContain(
+        `${SESSION_TOOL_STDERR_TAIL_BYTES - 500} UTF-8 bytes omitted from the trimmed stderr preview`,
+      );
+    },
+  );
+
+  it("keeps short stderr readable without a loss notice", async () => {
+    const { child, stderr, promise } = startChild();
+    const failure = rejectedMessage(promise);
+    stderr.emit("data", "  short stderr note\n");
+    child.emit("exit", 1, null);
+    child.emit("close", 1, null);
+    expect(await failure).toBe("tool_search_code child exited with 1: short stderr note");
+  });
+
+  it.each([true, false])(
+    "settles IPC result ok=%s without waiting for exit or stderr close",
+    async (ok) => {
+      const { child, promise } = startChild();
+      const outcome = ok
+        ? expect(promise).resolves.toBe(7)
+        : expect(promise).rejects.toThrow("guest failed");
+      child.emit("message", { type: "result", ok, value: 7, error: "guest failed" });
+      await outcome;
+      expect(child.kill).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([false, true])(
+    "preserves clean-exit IPC grace with stderr-first=%s",
+    async (stderrFirst) => {
+      vi.useFakeTimers();
+      const { child, stderr, promise, settled } = startChild();
+      if (stderrFirst) stderr.emit("close");
+      child.emit("exit", 0, null);
+      if (!stderrFirst) stderr.emit("close");
+      child.emit("close", 0, null);
+      await vi.advanceTimersByTimeAsync(249);
+      expect(settled).not.toHaveBeenCalled();
+      child.emit("message", { type: "result", ok: true, value: 7 });
+      await expect(promise).resolves.toBe(7);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it("rejects a result-less clean exit after 250ms even if stderr never closes", async () => {
+    vi.useFakeTimers();
+    const { child, promise, settled } = startChild();
+    const failure = rejectedMessage(promise);
+    child.emit("exit", 0, null);
+    await vi.advanceTimersByTimeAsync(249);
+    expect(settled).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(await failure).toBe("tool_search_code child exited with 0");
+  });
+
+  it.each(["abort", "timeout"])(
+    "preserves %s while a failed child is waiting for stream closure",
+    async (kind) => {
+      vi.useFakeTimers();
+      const controller = new AbortController();
+      const { child, promise } = startChild(controller.signal);
+      const failure = rejectedMessage(promise);
+      child.emit("exit", 1, null);
+      if (kind === "abort") controller.abort();
+      else await vi.advanceTimersByTimeAsync(1000);
+      expect(await failure).toBe(
+        kind === "abort" ? "tool_search_code aborted" : "tool_search_code timed out",
+      );
+      expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+    },
+  );
+
+  it.each([
+    "failed-exit",
+    "clean-exit",
+    "result-success",
+    "result-error",
+    "stderr-error",
+    "spawn-error",
+    "abort",
+    "timeout",
+  ])("cancels an already-started bridge when settling %s", async (terminal) => {
+    vi.useFakeTimers();
+    const parent = new AbortController();
+    const reason = new Error("operator cancelled this run");
+    const { child, stderr, promise, runtime } = startChild(parent.signal);
+    const outcome = promise.then(
+      (value) => value,
+      (error: unknown) => error,
+    );
+    let bridgeSignal: AbortSignal | undefined;
+    const aborted = vi.fn();
+    const call = vi.spyOn(runtime, "call").mockImplementation(async (_id, _input, options) => {
+      bridgeSignal = options?.signal;
+      await new Promise<void>((resolve) => {
+        bridgeSignal?.addEventListener(
+          "abort",
+          () => {
+            aborted();
+            resolve();
+          },
+          { once: true },
+        );
+      });
+      throw bridgeSignal?.reason;
+    });
+    const request = { type: "bridge", id: "pending", method: "call", args: ["fixture", {}] };
+    child.emit("message", request);
+    expect(call).toHaveBeenCalledOnce();
+    expect(bridgeSignal?.aborted).toBe(false);
+    if (terminal === "failed-exit") {
+      child.emit("exit", 1, null);
+      child.emit("close", 1, null);
+    } else if (terminal === "clean-exit") {
+      child.emit("exit", 0, null);
+      await vi.advanceTimersByTimeAsync(250);
+    } else if (terminal.startsWith("result-")) {
+      child.emit("message", {
+        type: "result",
+        ok: terminal === "result-success",
+        value: 7,
+        error: "guest failed",
+      });
+    } else if (terminal === "stderr-error") {
+      stderr.emit("error", new Error("stderr failed"));
+    } else if (terminal === "spawn-error") {
+      child.emit("error", new Error("spawn failed"));
+    } else if (terminal === "abort") {
+      parent.abort(reason);
+    } else {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+    const result = await outcome;
+    if (terminal === "result-success") expect(result).toBe(7);
+    else expect(result).toBeInstanceOf(Error);
+    expect(bridgeSignal?.aborted).toBe(true);
+    expect(aborted).toHaveBeenCalledOnce();
+    if (terminal === "abort") expect(bridgeSignal?.reason).toBe(reason);
+    if (terminal === "timeout") {
+      expect(bridgeSignal?.reason).toMatchObject({ message: "tool_search_code timed out" });
+    }
+    child.emit("message", request);
+    child.emit("close", 1, null);
+    parent.abort(reason);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(call).toHaveBeenCalledOnce();
+    expect(aborted).toHaveBeenCalledOnce();
+    expect(child.send).toHaveBeenCalledTimes(1); // Initial run only; no reply after settlement.
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/src/agents/tool-search.stream-errors.test.ts
+++ b/src/agents/tool-search.stream-errors.test.ts
@@ -38,7 +38,12 @@ async function rejectedMessage(promise: Promise<unknown>): Promise<string> {
   await expect(promise).rejects.toBeInstanceOf(Error);
   return promise.then(
     () => "",
-    (error: Error) => error.message,
+    (error: unknown) => {
+      if (!(error instanceof Error)) {
+        throw error;
+      }
+      return error.message;
+    },
   );
 }
 
@@ -155,9 +160,13 @@ describe("tool-search code-mode stream errors", () => {
     async (stderrFirst) => {
       vi.useFakeTimers();
       const { child, stderr, promise, settled } = startChild();
-      if (stderrFirst) stderr.emit("close");
+      if (stderrFirst) {
+        stderr.emit("close");
+      }
       child.emit("exit", 0, null);
-      if (!stderrFirst) stderr.emit("close");
+      if (!stderrFirst) {
+        stderr.emit("close");
+      }
       child.emit("close", 0, null);
       await vi.advanceTimersByTimeAsync(249);
       expect(settled).not.toHaveBeenCalled();
@@ -186,8 +195,11 @@ describe("tool-search code-mode stream errors", () => {
       const { child, promise } = startChild(controller.signal);
       const failure = rejectedMessage(promise);
       child.emit("exit", 1, null);
-      if (kind === "abort") controller.abort();
-      else await vi.advanceTimersByTimeAsync(1000);
+      if (kind === "abort") {
+        controller.abort();
+      } else {
+        await vi.advanceTimersByTimeAsync(1000);
+      }
       expect(await failure).toBe(
         kind === "abort" ? "tool_search_code aborted" : "tool_search_code timed out",
       );
@@ -256,11 +268,16 @@ describe("tool-search code-mode stream errors", () => {
       await vi.advanceTimersByTimeAsync(1000);
     }
     const result = await outcome;
-    if (terminal === "result-success") expect(result).toBe(7);
-    else expect(result).toBeInstanceOf(Error);
+    if (terminal === "result-success") {
+      expect(result).toBe(7);
+    } else {
+      expect(result).toBeInstanceOf(Error);
+    }
     expect(bridgeSignal?.aborted).toBe(true);
     expect(aborted).toHaveBeenCalledOnce();
-    if (terminal === "abort") expect(bridgeSignal?.reason).toBe(reason);
+    if (terminal === "abort") {
+      expect(bridgeSignal?.reason).toBe(reason);
+    }
     if (terminal === "timeout") {
       expect(bridgeSignal?.reason).toMatchObject({ message: "tool_search_code timed out" });
     }

--- a/src/agents/tool-search.test-support.ts
+++ b/src/agents/tool-search.test-support.ts
@@ -5,7 +5,6 @@ type ToolSearchTestApi = {
   maxToolSchemaDirectoryPromptChars: number;
   setToolSearchCodeModeSupportedForTest(value: boolean | undefined): void;
   setToolSearchMinCodeTimeoutMsForTest(value: number | undefined): void;
-  appendToolSearchCodeStderrTail(current: string, chunk: string): string;
   runCodeModeChild(params: {
     code: string;
     config: ToolSearchConfig;
@@ -30,7 +29,5 @@ export const testing: ToolSearchTestApi = {
     getTestApi().setToolSearchCodeModeSupportedForTest(value),
   setToolSearchMinCodeTimeoutMsForTest: (value) =>
     getTestApi().setToolSearchMinCodeTimeoutMsForTest(value),
-  appendToolSearchCodeStderrTail: (current, chunk) =>
-    getTestApi().appendToolSearchCodeStderrTail(current, chunk),
   runCodeModeChild: (params) => getTestApi().runCodeModeChild(params),
 };

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -23,7 +23,6 @@ import { resetAdjustedParamsByToolCallIdForTests } from "./agent-tools.before-to
 import { finalizeAgentTools } from "./agent-tools.finalize.js";
 import { filterToolsByPolicy } from "./agent-tools.policy.js";
 import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
-import { SESSION_TOOL_STDERR_TAIL_BYTES } from "./sessions/tools/limits.js";
 import {
   formatToolExecutionErrorMessage,
   resolveToolExecutionErrorKind,
@@ -4272,20 +4271,6 @@ describe("Tool Search", () => {
 
     const second = applyToolSearchCatalog({ tools: [codeTool, tool], config, sessionId });
     expect(second.catalogReused).toBe(false);
-  });
-
-  it("bounds tool_search_code stderr accumulation to the session tool tail limit", () => {
-    let stderrTail = "";
-    stderrTail = testing.appendToolSearchCodeStderrTail(
-      stderrTail,
-      `HEAD_OVERFLOW_${"x".repeat(SESSION_TOOL_STDERR_TAIL_BYTES + 10_000)}TAIL`,
-    );
-
-    expect(stderrTail).not.toContain("HEAD_OVERFLOW_");
-    expect(stderrTail.endsWith("TAIL")).toBe(true);
-    expect(Buffer.byteLength(stderrTail, "utf8")).toBeLessThanOrEqual(
-      SESSION_TOOL_STDERR_TAIL_BYTES,
-    );
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -13,12 +13,7 @@ import {
   isDirectVisibleCatalogTool,
   resolveCatalog,
 } from "./tool-search-catalog.js";
-import {
-  appendToolSearchCodeStderrTail,
-  readToolSearchCode,
-  runCodeMode,
-  runCodeModeChild,
-} from "./tool-search-code-mode.js";
+import { readToolSearchCode, runCodeMode, runCodeModeChild } from "./tool-search-code-mode.js";
 import {
   isToolSearchCodeModeSupported,
   resolveToolSearchConfig,
@@ -424,7 +419,6 @@ const testing = {
   setToolSearchMinCodeTimeoutMsForTest,
   applyToolSearchCatalog,
   addClientToolsToToolSearchCatalog,
-  appendToolSearchCodeStderrTail,
   runCodeModeChild,
 };
 


### PR DESCRIPTION
## What Problem This Solves

Partially addresses #128967 for Tool Search's `tool_search_code` child. Find/grep retention disclosure remains separate work under that issue; this PR must not close it.

A failed child could lose diagnostics arriving after `exit`, silently discard earlier stderr at the retention cap, and then silently shorten the retained text again for display. A real child probe also found that failure could return while an already-started bridged tool remained alive.

## What Changed

The shared bounded-tail helper returns retained text and discarded UTF-8 bytes. All internal callers use that one API; the tracked-helper wrapper and Tool Search test facade are removed. Find/grep keep their existing display behavior.

Node's `close` event owns failed-exit rendering after stdio drains. The existing 250 ms clean-exit IPC grace remains unchanged; IPC results, spawn/stream errors, abort, and timeout retain prompt settlement. The error distinguishes retention-cap loss from bytes omitted from the trimmed 500-character preview.

The common settlement boundary now aborts outstanding bridge work for every terminal outcome, including fatal exits and successful final results with unfinished calls. It preserves the parent's cancellation reason and timeout error. No per-call controller registry or new timeout is introduced.

Production +48/-44 (net +4); tests/support +272/-140; documentation +5. No config option, dependency, storage schema, or native Codex/QuickJS behavior changes. This is the separate permission-restricted Node Tool Search bridge.

Thanks @Finn763 for the original repair and lifecycle cases. The maintainer rewrite preserves contributor credit and simplifies the owner boundary against current main.

## Evidence

- Eleven regression cases failed on the original implementation. All 197 focused tests now pass across the stream lifecycle, complete Tool Search suite, shared UTF-8 tail accounting, find, and grep.
- Real public Tool Search control, real scoped catalog, and real permission-restricted Node child: successful IPC control returns `{proof:7}`; fatal child failure now cancels an already-started host tool exactly once before fixture cleanup. Before the repair, the outer failure returned with that tool unfinished and its signal un-aborted. The timeout positive control also passes.
- Deterministic event-order tests prove late stderr is included after nonzero exit, clean-exit late IPC still succeeds, result-less clean exit still expires, and abort/timeout remain prompt while waiting for close. Multi-chunk/multibyte tests prove byte conservation.
- Directly checked Node's documented `exit` versus `close` contract. On this Mac, Node's fatal reporter can itself stop writing after 65,536 bytes; that sender-side loss is not counted as parent retention loss. The isolated Linux owner-path proof received 70,355 bytes and exactly reported 4,819 discarded at retention plus 65,035 omitted from the trimmed preview. A read-only child-process observer independently counted received chunks; source hashes matched this candidate. Larger probes also matched the bytes actually received, without claiming sender-discarded bytes. [Linux proof run](https://github.com/openclaw/openclaw/actions/runs/33234604785); the Testbox command and timing result passed and the owned lease was stopped.
- Fresh independent Codex autoreview is clean. The complete changed-file gate passed; exact-head CI passed on the reviewed commit.

[Node child-process close contract](https://nodejs.org/api/child_process.html#event-close).

Hosted CI initially timed out fetching the comparison base in `check-guards` (exit124 after120 seconds), after the duplication and coercion checks passed. The unchanged exact head passed on the retry; no guard or timeout was weakened. The PR evidence-check heading was also corrected.
