### PR TITLE
improve(ui): calm the task progress card with relative time and clear terminal states

### DIFF
--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -141,10 +141,13 @@ export type SidebarSessionHovercardRow = Pick<
   | "createdActor"
   | "createdAt"
   | "channelAvatarUrl"
+  | "endedAt"
   | "label"
   | "lastMessagePreview"
   | "participantCount"
   | "participants"
+  | "status"
+  | "startedAt"
   | "updatedAt"
   | "workContext"
 >;

--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -33,6 +33,9 @@ export const icons = {
   activity: strokeIcon(svg` <path d="M22 12h-4l-3 9L9 3l-3 9H2" />`),
   clock: strokeIcon(svg` <circle cx="12" cy="12" r="10" />
     <polyline points="12 6 12 12 16 14" />`),
+  circleX: strokeIcon(svg` <circle cx="12" cy="12" r="10" />
+    <path d="m15 9-6 6" />
+    <path d="m9 9 6 6" />`),
   arrowUpRight: strokeIcon(svg` <path d="M7 17 17 7" />
     <path d="M7 7h10v10" />`),
   link: strokeIcon(svg` <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />

--- a/ui/src/components/portaled-hovercard.ts
+++ b/ui/src/components/portaled-hovercard.ts
@@ -17,6 +17,7 @@ export class PortaledHovercardController {
   private placement: PortaledHovercardPlacement = "vertical";
   private stopPositioning: (() => void) | null = null;
   private trigger: HTMLElement | null = null;
+  private unmountContents: (() => void) | null = null;
 
   constructor(
     private readonly close: () => void,
@@ -69,11 +70,13 @@ export class PortaledHovercardController {
     card: HTMLDivElement,
     placement: PortaledHovercardPlacement,
     observeVisualViewport = true,
+    unmountContents?: () => void,
   ): void {
     this.clearCard();
     this.anchor = anchor;
     this.card = card;
     this.placement = placement;
+    this.unmountContents = unmountContents ?? null;
     this.stopPositioning = mountPortaledHovercard({
       anchor,
       trigger: this.trigger ?? anchor,
@@ -89,11 +92,14 @@ export class PortaledHovercardController {
     this.exitCleanup?.();
     this.exitCleanup = null;
     const card = this.card;
+    const unmountContents = this.unmountContents;
     this.card = null;
+    this.unmountContents = null;
     if (!card) {
       return;
     }
     if (exitDurationMs <= 0 || !card.isConnected) {
+      unmountContents?.();
       card.remove();
       return;
     }
@@ -106,6 +112,7 @@ export class PortaledHovercardController {
         exitTimer = null;
       }
       card.removeEventListener("transitionend", handleTransitionEnd);
+      unmountContents?.();
       card.remove();
       if (this.exitCleanup === finish) {
         this.exitCleanup = null;

--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -308,6 +308,23 @@ describe("renderSessionHovercard", () => {
     expect(container.textContent).not.toContain("This must not appear.");
   });
 
+  it("uses the session terminal status and endedAt for progress activity", () => {
+    const container = document.createElement("div");
+    const endedAt = Date.now() - 30_000;
+    render(
+      renderSessionHovercard({
+        row: row({ status: "failed", endedAt }),
+        progressCard: progressCard(),
+      }),
+      container,
+    );
+
+    expect(container.querySelector("time")?.textContent).toBe("Failed just now");
+    expect(container.querySelector("time")?.getAttribute("datetime")).toBe(
+      new Date(endedAt).toISOString(),
+    );
+  });
+
   it("deduplicates creator and self from the compact participant identity", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -489,7 +489,14 @@ export function renderSessionHovercard(input: SessionHovercardInput) {
       : nothing}
     ${input.progressCard
       ? html`<footer class="session-hovercard__section session-hovercard__progress-footer">
-          ${renderSessionProgressCard(input.progressCard, "hovercard")}
+          ${renderSessionProgressCard(
+            input.progressCard,
+            "hovercard",
+            undefined,
+            input.row?.status,
+            input.row?.startedAt,
+            input.row?.endedAt,
+          )}
         </footer>`
       : nothing}
   </div>`;

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -2,13 +2,15 @@
 
 import type { ProgressCard } from "@openclaw/gateway-protocol";
 import { render } from "lit";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderSessionProgressCard } from "./session-progress-card.ts";
+
+const NOW_MS = Date.UTC(2026, 7, 26, 13, 37);
 
 const progressCard: ProgressCard = {
   sessionKey: "agent:main:work",
   revision: 2,
-  updatedAt: 1,
+  updatedAt: NOW_MS - 2 * 60_000,
   markdown: '**Focused change**\n\n<progress value="1" max="3"></progress>',
   steps: [
     { step: "Inspect the route", status: "completed" },
@@ -18,8 +20,17 @@ const progressCard: ProgressCard = {
 };
 
 describe("renderSessionProgressCard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it.each(["board", "composer", "hovercard"] as const)(
-    "shows the last activity time for %s cards with and without checklist steps",
+    "shows relative activity for %s cards with and without checklist steps",
     (placement) => {
       const container = document.createElement("div");
 
@@ -30,8 +41,8 @@ describe("renderSessionProgressCard", () => {
         expect(timestamp?.getAttribute("datetime")).toBe(
           new Date(progressCard.updatedAt).toISOString(),
         );
-        expect(timestamp?.textContent).toMatch(/\d{1,2}:\d{2}:\d{2}/);
-        expect(timestamp?.getAttribute("aria-label")).toMatch(/^Last activity: /);
+        expect(timestamp?.textContent).toBe("Updated 2m ago");
+        expect(timestamp?.getAttribute("aria-label")).toBe("Updated 2m ago");
         expect(timestamp?.getAttribute("title")).toBe(timestamp?.getAttribute("aria-label"));
         const accessibleCard =
           placement === "composer"
@@ -44,12 +55,44 @@ describe("renderSessionProgressCard", () => {
     },
   );
 
+  it.each([
+    [undefined, "Updated 2m ago"],
+    ["queued", "Updated 2m ago"],
+    ["running", "Updated 2m ago"],
+    ["done", "Completed 2m ago"],
+    ["failed", "Failed 2m ago"],
+    ["timeout", "Failed 2m ago"],
+    ["killed", "Stopped 2m ago"],
+  ] as const)("maps canonical session status %s to %s", (status, expected) => {
+    const container = document.createElement("div");
+
+    render(renderSessionProgressCard(progressCard, "composer", undefined, status), container);
+
+    expect(container.querySelector("time")?.textContent).toBe(expected);
+  });
+
+  it("labels activity from the last minute as just now", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderSessionProgressCard(
+        { ...progressCard, updatedAt: NOW_MS - 10_000 },
+        "composer",
+        undefined,
+        "running",
+      ),
+      container,
+    );
+
+    expect(container.querySelector("time")?.textContent).toBe("Updated just now");
+  });
+
   it("renders sanitized markdown and one accessible typed checklist", () => {
     const container = document.createElement("div");
     render(renderSessionProgressCard(progressCard, "hovercard"), container);
 
     const card = container.querySelector(".session-progress-card");
-    expect(card?.getAttribute("aria-label")).toMatch(/^1 of 3 completed\. Last activity: /);
+    expect(card?.getAttribute("aria-label")).toBe("1 of 3 completed. Updated 2m ago");
     expect(card?.querySelector("strong")?.textContent).toBe("Focused change");
     expect(card?.querySelector("progress")?.getAttribute("value")).toBe("1");
     expect(card?.querySelectorAll(".session-progress-card__count")).toHaveLength(0);
@@ -143,13 +186,19 @@ describe("renderSessionProgressCard", () => {
     );
     expect(card?.open).toBe(true);
     expect(card?.dataset.complete).toBe("false");
-    expect(card?.querySelector("summary")?.getAttribute("aria-label")).toMatch(
-      /^1 of 3 completed\. Last activity: /,
+    expect(card?.querySelector("summary")?.getAttribute("aria-label")).toBe(
+      "1 of 3 completed. Updated 2m ago",
     );
     expect(card?.querySelector("[role=region]")?.getAttribute("aria-label")).toBe(
       "1 of 3 completed",
     );
     expect(card?.querySelector("summary")?.textContent).toContain("Task progress");
+    expect(
+      card
+        ?.querySelector(".session-progress-card__heading-actions")
+        ?.textContent?.replaceAll(/\s+/gu, " ")
+        .trim(),
+    ).toBe("Updated 2m ago · 2 of 3");
     expect(card?.querySelector("progress")).toBeNull();
     expect(card?.querySelectorAll(".session-progress-card__step")).toHaveLength(3);
   });
@@ -168,6 +217,38 @@ describe("renderSessionProgressCard", () => {
     expect(count?.nextElementSibling?.classList).toContain(
       "session-progress-card__summary-expanded",
     );
+  });
+
+  it.each([
+    ["running", "2/3"],
+    ["done", "Completed"],
+    ["failed", "Failed"],
+    ["timeout", "Failed"],
+    ["killed", "Stopped"],
+  ] as const)("shows %s as %s in the closed summary", (status, expected) => {
+    const container = document.createElement("div");
+    render(renderSessionProgressCard(progressCard, "composer", undefined, status), container);
+
+    expect(
+      container.querySelector(".session-progress-card__summary-count--collapsed")?.textContent,
+    ).toBe(expected);
+  });
+
+  it("uses a terminal circle-x instead of a spinner after the run stops", () => {
+    const container = document.createElement("div");
+    render(renderSessionProgressCard(progressCard, "composer", undefined, "killed"), container);
+
+    const indicator = container.querySelector(".session-progress-card__summary-indicator");
+    expect(container.querySelector(".session-run-spinner")).toBeNull();
+    expect(indicator?.querySelector('circle[cx="12"][cy="12"][r="10"]')).not.toBeNull();
+    expect(indicator?.querySelector('path[d="m15 9-6 6"]')).not.toBeNull();
+    expect(indicator?.querySelector('path[d="m9 9 6 6"]')).not.toBeNull();
+    expect(
+      container.querySelector('.session-progress-card__step-marker[data-outcome="killed"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('.session-progress-card__step[aria-label$=", stopped"]'),
+    ).not.toBeNull();
   });
 
   it("starts completed composer progress collapsed", () => {

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -1,11 +1,14 @@
 /* @vitest-environment jsdom */
 
 import type { ProgressCard } from "@openclaw/gateway-protocol";
+import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderSessionProgressCard } from "./session-progress-card.ts";
 
 const NOW_MS = Date.UTC(2026, 7, 26, 13, 37);
+const RUN_STARTED_MS = NOW_MS - 3 * 60_000;
+const RUN_ENDED_MS = NOW_MS - 30_000;
 
 const progressCard: ProgressCard = {
   sessionKey: "agent:main:work",
@@ -48,9 +51,7 @@ describe("renderSessionProgressCard", () => {
           placement === "composer"
             ? timestamp?.closest("summary")
             : timestamp?.closest(".session-progress-card");
-        expect(accessibleCard?.getAttribute("aria-label")).toContain(
-          timestamp?.getAttribute("aria-label"),
-        );
+        expect(accessibleCard?.getAttribute("aria-label")).not.toContain("Updated");
       }
     },
   );
@@ -59,16 +60,53 @@ describe("renderSessionProgressCard", () => {
     [undefined, "Updated 2m ago"],
     ["queued", "Updated 2m ago"],
     ["running", "Updated 2m ago"],
-    ["done", "Completed 2m ago"],
-    ["failed", "Failed 2m ago"],
-    ["timeout", "Failed 2m ago"],
-    ["killed", "Stopped 2m ago"],
+    ["done", "Updated 2m ago"],
+    ["failed", "Updated 2m ago"],
+    ["timeout", "Updated 2m ago"],
+    ["killed", "Updated 2m ago"],
   ] as const)("maps canonical session status %s to %s", (status, expected) => {
     const container = document.createElement("div");
 
     render(renderSessionProgressCard(progressCard, "composer", undefined, status), container);
 
     expect(container.querySelector("time")?.textContent).toBe(expected);
+  });
+
+  it("uses endedAt for terminal wording and falls back to Updated without it", () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionProgressCard(
+        progressCard,
+        "composer",
+        undefined,
+        "done",
+        RUN_STARTED_MS,
+        RUN_ENDED_MS,
+      ),
+      container,
+    );
+    expect(container.querySelector("time")?.textContent).toBe("Completed just now");
+    expect(container.querySelector("time")?.getAttribute("datetime")).toBe(
+      new Date(RUN_ENDED_MS).toISOString(),
+    );
+
+    render(renderSessionProgressCard(progressCard, "composer", undefined, "done"), container);
+    expect(container.querySelector("time")?.textContent).toBe("Updated 2m ago");
+  });
+
+  it("refreshes relative time while connected and stops after disconnect", async () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionProgressCard({ ...progressCard, updatedAt: NOW_MS - 10_000 }, "composer"),
+      container,
+    );
+    expect(container.querySelector("time")?.textContent).toBe("Updated just now");
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(container.querySelector("time")?.textContent).toBe("Updated 1m ago");
+
+    render(null, container);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("labels activity from the last minute as just now", () => {
@@ -92,7 +130,7 @@ describe("renderSessionProgressCard", () => {
     render(renderSessionProgressCard(progressCard, "hovercard"), container);
 
     const card = container.querySelector(".session-progress-card");
-    expect(card?.getAttribute("aria-label")).toBe("1 of 3 completed. Updated 2m ago");
+    expect(card?.getAttribute("aria-label")).toBe("1 of 3 completed");
     expect(card?.querySelector("strong")?.textContent).toBe("Focused change");
     expect(card?.querySelector("progress")?.getAttribute("value")).toBe("1");
     expect(card?.querySelectorAll(".session-progress-card__count")).toHaveLength(0);
@@ -187,7 +225,7 @@ describe("renderSessionProgressCard", () => {
     expect(card?.open).toBe(true);
     expect(card?.dataset.complete).toBe("false");
     expect(card?.querySelector("summary")?.getAttribute("aria-label")).toBe(
-      "1 of 3 completed. Updated 2m ago",
+      "Wire the checklist. 1 of 3 completed",
     );
     expect(card?.querySelector("[role=region]")?.getAttribute("aria-label")).toBe(
       "1 of 3 completed",
@@ -227,7 +265,17 @@ describe("renderSessionProgressCard", () => {
     ["killed", "Stopped"],
   ] as const)("shows %s as %s in the closed summary", (status, expected) => {
     const container = document.createElement("div");
-    render(renderSessionProgressCard(progressCard, "composer", undefined, status), container);
+    render(
+      renderSessionProgressCard(
+        progressCard,
+        "composer",
+        undefined,
+        status,
+        RUN_STARTED_MS,
+        RUN_ENDED_MS,
+      ),
+      container,
+    );
 
     expect(
       container.querySelector(".session-progress-card__summary-count--collapsed")?.textContent,
@@ -236,7 +284,17 @@ describe("renderSessionProgressCard", () => {
 
   it("uses a terminal circle-x instead of a spinner after the run stops", () => {
     const container = document.createElement("div");
-    render(renderSessionProgressCard(progressCard, "composer", undefined, "killed"), container);
+    render(
+      renderSessionProgressCard(
+        progressCard,
+        "composer",
+        undefined,
+        "killed",
+        RUN_STARTED_MS,
+        RUN_ENDED_MS,
+      ),
+      container,
+    );
 
     const indicator = container.querySelector(".session-progress-card__summary-indicator");
     expect(container.querySelector(".session-run-spinner")).toBeNull();
@@ -249,6 +307,48 @@ describe("renderSessionProgressCard", () => {
     expect(
       container.querySelector('.session-progress-card__step[aria-label$=", stopped"]'),
     ).not.toBeNull();
+    expect(container.querySelector("summary")?.getAttribute("aria-label")).toBe(
+      "Wire the checklist. Stopped",
+    );
+  });
+
+  it("does not apply a later run outcome to an older progress card", () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionProgressCard(
+        { ...progressCard, updatedAt: RUN_STARTED_MS - 1 },
+        "composer",
+        undefined,
+        "failed",
+        RUN_STARTED_MS,
+        RUN_ENDED_MS,
+      ),
+      container,
+    );
+
+    expect(container.querySelector("time")?.textContent).toBe("Updated 3m ago");
+    expect(container.querySelector("[data-outcome=failed]")).toBeNull();
+    expect(container.querySelector(".session-run-spinner")).not.toBeNull();
+  });
+
+  it("falls back safely for timestamps outside the Date range", () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionProgressCard(
+        { ...progressCard, updatedAt: MAX_DATE_TIMESTAMP_MS + 1 },
+        "composer",
+        undefined,
+        "failed",
+        RUN_STARTED_MS,
+        MAX_DATE_TIMESTAMP_MS + 1,
+      ),
+      container,
+    );
+
+    expect(container.querySelector("time")?.getAttribute("datetime")).toBe(
+      new Date(NOW_MS).toISOString(),
+    );
+    expect(container.querySelector("[data-outcome=failed]")).toBeNull();
   });
 
   it("starts completed composer progress collapsed", () => {

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -1,5 +1,8 @@
 import type { ProgressCard, ProgressCardStep, SessionRunStatus } from "@openclaw/gateway-protocol";
+import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { html, nothing } from "lit";
+import { AsyncDirective } from "lit/async-directive.js";
+import { directive } from "lit/directive.js";
 import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { t } from "../i18n/index.ts";
@@ -31,14 +34,63 @@ const TERMINAL_OUTCOME_LABEL_KEYS: Partial<Record<SessionRunStatus, Parameters<t
   timeout: "sessionProgressCard.outcome.failed",
 };
 
-const TERMINAL_STEP_STATUS_LABEL_KEYS: Partial<
-  Record<SessionRunStatus, Parameters<typeof t>[0]>
-> = {
-  done: "sessionProgressCard.status.completed",
-  failed: "sessionProgressCard.status.failed",
-  killed: "sessionProgressCard.status.stopped",
-  timeout: "sessionProgressCard.status.failed",
-};
+const TERMINAL_STEP_STATUS_LABEL_KEYS: Partial<Record<SessionRunStatus, Parameters<typeof t>[0]>> =
+  {
+    done: "sessionProgressCard.status.completed",
+    failed: "sessionProgressCard.status.failed",
+    killed: "sessionProgressCard.status.stopped",
+    timeout: "sessionProgressCard.status.failed",
+  };
+
+class ProgressActivityTimeDirective extends AsyncDirective {
+  private timestamp = 0;
+  private labelKey: Parameters<typeof t>[0] = "sessionProgressCard.activity.updated";
+  private timer: ReturnType<typeof setInterval> | undefined;
+
+  render(timestamp: number, labelKey: Parameters<typeof t>[0]) {
+    this.timestamp = timestamp;
+    this.labelKey = labelKey;
+    if (this.isConnected) {
+      this.startTimer();
+    }
+    return this.renderTime();
+  }
+
+  protected override disconnected(): void {
+    this.stopTimer();
+  }
+
+  protected override reconnected(): void {
+    this.setValue(this.renderTime());
+    this.startTimer();
+  }
+
+  private startTimer(): void {
+    if (this.timer) {
+      return;
+    }
+    this.timer = setInterval(() => this.setValue(this.renderTime()), 30_000);
+  }
+
+  private stopTimer(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  private renderTime() {
+    const label = t(this.labelKey, { time: formatRelativeTimestamp(this.timestamp) });
+    return html`<time
+      datetime=${new Date(this.timestamp).toISOString()}
+      aria-label=${label}
+      title=${label}
+      >${label}</time
+    >`;
+  }
+}
+
+const progressActivityTime = directive(ProgressActivityTimeDirective);
 
 const composerDisclosureOwners = new WeakMap<HTMLDetailsElement, string>();
 
@@ -154,6 +206,8 @@ export function renderSessionProgressCard(
   placement: SessionProgressCardPlacement,
   onDismiss?: (card: ProgressCard) => void,
   sessionStatus?: SessionRunStatus,
+  startedAt?: number,
+  endedAt?: number,
 ) {
   if (!card) {
     return nothing;
@@ -165,18 +219,29 @@ export function renderSessionProgressCard(
         total: String(counts.total),
       })
     : t("sessionProgressCard.noteLabel");
-  const activityTime = formatRelativeTimestamp(card.updatedAt);
-  const activityLabel = t(
-    sessionStatus ? ACTIVITY_LABEL_KEYS[sessionStatus] : "sessionProgressCard.activity.updated",
-    { time: activityTime },
-  );
-  const accessibleLabel = `${countLabel}. ${activityLabel}`;
-  const lastActivity = html`<time
-    datetime=${new Date(card.updatedAt).toISOString()}
-    aria-label=${activityLabel}
-    title=${activityLabel}
-    >${activityLabel}</time
-  >`;
+  const validStartedAt = asDateTimestampMs(startedAt);
+  const validEndedAt = asDateTimestampMs(endedAt);
+  const validUpdatedAt = asDateTimestampMs(card.updatedAt);
+  const hasValidRunWindow =
+    validStartedAt !== undefined &&
+    validEndedAt !== undefined &&
+    validEndedAt >= validStartedAt &&
+    validUpdatedAt !== undefined &&
+    validUpdatedAt >= validStartedAt;
+  const terminalTimestamp =
+    sessionStatus && TERMINAL_OUTCOME_LABEL_KEYS[sessionStatus] && hasValidRunWindow
+      ? validEndedAt
+      : undefined;
+  const effectiveSessionStatus =
+    sessionStatus && TERMINAL_OUTCOME_LABEL_KEYS[sessionStatus] && !terminalTimestamp
+      ? undefined
+      : sessionStatus;
+  const activityTimestamp = terminalTimestamp ?? validUpdatedAt ?? Date.now();
+  const activityKey = terminalTimestamp
+    ? ACTIVITY_LABEL_KEYS[sessionStatus!]
+    : "sessionProgressCard.activity.updated";
+  const accessibleLabel = countLabel;
+  const lastActivity = progressActivityTime(activityTimestamp, activityKey);
   const dismissible = Boolean(
     onDismiss && card.steps?.length && card.steps.every((step) => step.status === "completed"),
   );
@@ -207,9 +272,10 @@ export function renderSessionProgressCard(
         })
       : t("sessionProgressCard.noteLabel");
     const stepLabel = currentStep?.step ?? t("sessionProgressCard.noteLabel");
-    const terminalOutcomeKey = sessionStatus
-      ? TERMINAL_OUTCOME_LABEL_KEYS[sessionStatus]
+    const terminalOutcomeKey = effectiveSessionStatus
+      ? TERMINAL_OUTCOME_LABEL_KEYS[effectiveSessionStatus]
       : undefined;
+    const summaryLabel = `${stepLabel}. ${terminalOutcomeKey ? t(terminalOutcomeKey) : countLabel}`;
     const shortCount = counts
       ? t("sessionProgressCard.shortCount", {
           completed: String(currentPosition),
@@ -217,9 +283,11 @@ export function renderSessionProgressCard(
         })
       : nothing;
     const summaryIndicator =
-      sessionStatus === "done"
+      effectiveSessionStatus === "done"
         ? icons.check
-        : sessionStatus === "failed" || sessionStatus === "timeout" || sessionStatus === "killed"
+        : effectiveSessionStatus === "failed" ||
+            effectiveSessionStatus === "timeout" ||
+            effectiveSessionStatus === "killed"
           ? icons.circleX
           : complete
             ? icons.check
@@ -232,14 +300,14 @@ export function renderSessionProgressCard(
       data-complete=${String(complete)}
       ${ref((element) => initializeComposerDisclosure(element, card.sessionKey, !complete))}
     >
-      <summary class="session-progress-card__summary" aria-label=${accessibleLabel}>
+      <summary class="session-progress-card__summary" aria-label=${summaryLabel}>
         <span
           class="session-progress-card__summary-indicator session-progress-card__current-marker${complete ||
-          sessionStatus === "done"
+          effectiveSessionStatus === "done"
             ? " session-progress-card__summary-indicator--complete"
             : ""}"
           data-status=${currentStep?.status ?? "pending"}
-          data-outcome=${sessionStatus ?? nothing}
+          data-outcome=${effectiveSessionStatus ?? nothing}
           aria-hidden="true"
         >
           ${summaryIndicator}
@@ -250,7 +318,7 @@ export function renderSessionProgressCard(
         ${counts
           ? html`<span
               class="session-progress-card__summary-count session-progress-card__summary-count--collapsed"
-              data-outcome=${sessionStatus ?? nothing}
+              data-outcome=${effectiveSessionStatus ?? nothing}
               >${terminalOutcomeKey
                 ? t(terminalOutcomeKey)
                 : `${currentPosition}/${counts.total}`}</span
@@ -272,7 +340,7 @@ export function renderSessionProgressCard(
         >
       </summary>
       <div class="session-progress-card__body" role="region" aria-label=${composerCountLabel}>
-        ${renderMarkdown(card.markdown)} ${renderSteps(card, sessionStatus)}
+        ${renderMarkdown(card.markdown)} ${renderSteps(card, effectiveSessionStatus)}
       </div>
     </details>`;
   }
@@ -289,6 +357,6 @@ export function renderSessionProgressCard(
         >${dismiss}
       </span>
     </div>
-    ${renderBody(card, sessionStatus)}
+    ${renderBody(card, effectiveSessionStatus)}
   </section>`;
 }

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -1,9 +1,9 @@
-import type { ProgressCard, ProgressCardStep } from "@openclaw/gateway-protocol";
+import type { ProgressCard, ProgressCardStep, SessionRunStatus } from "@openclaw/gateway-protocol";
 import { html, nothing } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { t } from "../i18n/index.ts";
-import { formatTimeMs } from "../lib/format.ts";
+import { formatRelativeTimestamp } from "../lib/format.ts";
 import { icons } from "./icons.ts";
 import { toSanitizedMarkdownHtml } from "./markdown.ts";
 
@@ -13,6 +13,31 @@ const STATUS_LABEL_KEYS: Record<ProgressCardStep["status"], Parameters<typeof t>
   completed: "sessionProgressCard.status.completed",
   in_progress: "sessionProgressCard.status.inProgress",
   pending: "sessionProgressCard.status.pending",
+};
+
+const ACTIVITY_LABEL_KEYS: Record<SessionRunStatus, Parameters<typeof t>[0]> = {
+  queued: "sessionProgressCard.activity.updated",
+  running: "sessionProgressCard.activity.updated",
+  done: "sessionProgressCard.activity.completed",
+  failed: "sessionProgressCard.activity.failed",
+  killed: "sessionProgressCard.activity.stopped",
+  timeout: "sessionProgressCard.activity.failed",
+};
+
+const TERMINAL_OUTCOME_LABEL_KEYS: Partial<Record<SessionRunStatus, Parameters<typeof t>[0]>> = {
+  done: "sessionProgressCard.outcome.completed",
+  failed: "sessionProgressCard.outcome.failed",
+  killed: "sessionProgressCard.outcome.stopped",
+  timeout: "sessionProgressCard.outcome.failed",
+};
+
+const TERMINAL_STEP_STATUS_LABEL_KEYS: Partial<
+  Record<SessionRunStatus, Parameters<typeof t>[0]>
+> = {
+  done: "sessionProgressCard.status.completed",
+  failed: "sessionProgressCard.status.failed",
+  killed: "sessionProgressCard.status.stopped",
+  timeout: "sessionProgressCard.status.failed",
 };
 
 const composerDisclosureOwners = new WeakMap<HTMLDetailsElement, string>();
@@ -53,7 +78,16 @@ function currentProgressStep(steps: readonly ProgressCardStep[]): ProgressCardSt
   );
 }
 
-function progressStepMarker(status: ProgressCardStep["status"]) {
+function progressStepMarker(status: ProgressCardStep["status"], sessionStatus?: SessionRunStatus) {
+  if (status === "in_progress" && sessionStatus === "done") {
+    return icons.check;
+  }
+  if (
+    status === "in_progress" &&
+    (sessionStatus === "failed" || sessionStatus === "timeout" || sessionStatus === "killed")
+  ) {
+    return icons.circleX;
+  }
   switch (status) {
     case "completed":
       return icons.check;
@@ -80,14 +114,18 @@ function renderMarkdown(markdown: string | undefined) {
   </div>`;
 }
 
-function renderSteps(card: ProgressCard) {
+function renderSteps(card: ProgressCard, sessionStatus?: SessionRunStatus) {
   const steps = card.steps;
   if (!steps?.length) {
     return nothing;
   }
   return html`<ol class="session-progress-card__steps">
     ${steps.map((step) => {
-      const statusLabel = t(STATUS_LABEL_KEYS[step.status]);
+      const terminalStatusKey =
+        step.status === "in_progress" && sessionStatus
+          ? TERMINAL_STEP_STATUS_LABEL_KEYS[sessionStatus]
+          : undefined;
+      const statusLabel = t(terminalStatusKey ?? STATUS_LABEL_KEYS[step.status]);
       return html`<li
         class="session-progress-card__step session-progress-card__step--${step.status}"
         aria-label=${t("sessionProgressCard.stepLabel", { status: statusLabel, step: step.step })}
@@ -95,8 +133,9 @@ function renderSteps(card: ProgressCard) {
         <span
           class="session-progress-card__step-marker"
           data-status=${step.status}
+          data-outcome=${terminalStatusKey ? sessionStatus : nothing}
           aria-hidden="true"
-          >${progressStepMarker(step.status)}</span
+          >${progressStepMarker(step.status, sessionStatus)}</span
         >
         <span class="session-progress-card__step-text">${step.step}</span>
       </li>`;
@@ -104,9 +143,9 @@ function renderSteps(card: ProgressCard) {
   </ol>`;
 }
 
-function renderBody(card: ProgressCard) {
+function renderBody(card: ProgressCard, sessionStatus?: SessionRunStatus) {
   return html`<div class="session-progress-card__body">
-    ${renderMarkdown(card.markdown)} ${renderSteps(card)}
+    ${renderMarkdown(card.markdown)} ${renderSteps(card, sessionStatus)}
   </div>`;
 }
 
@@ -114,6 +153,7 @@ export function renderSessionProgressCard(
   card: ProgressCard | null | undefined,
   placement: SessionProgressCardPlacement,
   onDismiss?: (card: ProgressCard) => void,
+  sessionStatus?: SessionRunStatus,
 ) {
   if (!card) {
     return nothing;
@@ -125,18 +165,17 @@ export function renderSessionProgressCard(
         total: String(counts.total),
       })
     : t("sessionProgressCard.noteLabel");
-  const activityTime = formatTimeMs(card.updatedAt, {
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-  });
-  const activityLabel = t("sessionProgressCard.lastActivity", { time: activityTime });
+  const activityTime = formatRelativeTimestamp(card.updatedAt);
+  const activityLabel = t(
+    sessionStatus ? ACTIVITY_LABEL_KEYS[sessionStatus] : "sessionProgressCard.activity.updated",
+    { time: activityTime },
+  );
   const accessibleLabel = `${countLabel}. ${activityLabel}`;
   const lastActivity = html`<time
     datetime=${new Date(card.updatedAt).toISOString()}
     aria-label=${activityLabel}
     title=${activityLabel}
-    >${activityTime}</time
+    >${activityLabel}</time
   >`;
   const dismissible = Boolean(
     onDismiss && card.steps?.length && card.steps.every((step) => step.status === "completed"),
@@ -168,17 +207,25 @@ export function renderSessionProgressCard(
         })
       : t("sessionProgressCard.noteLabel");
     const stepLabel = currentStep?.step ?? t("sessionProgressCard.noteLabel");
+    const terminalOutcomeKey = sessionStatus
+      ? TERMINAL_OUTCOME_LABEL_KEYS[sessionStatus]
+      : undefined;
     const shortCount = counts
       ? t("sessionProgressCard.shortCount", {
           completed: String(currentPosition),
           total: String(counts.total),
         })
       : nothing;
-    const summaryIndicator = complete
-      ? icons.check
-      : currentStep?.status === "in_progress"
-        ? html`<span class="session-run-spinner"></span>`
-        : icons.clock;
+    const summaryIndicator =
+      sessionStatus === "done"
+        ? icons.check
+        : sessionStatus === "failed" || sessionStatus === "timeout" || sessionStatus === "killed"
+          ? icons.circleX
+          : complete
+            ? icons.check
+            : currentStep?.status === "in_progress"
+              ? html`<span class="session-run-spinner"></span>`
+              : icons.clock;
     return html`<details
       class="session-progress-card session-progress-card--composer"
       data-progress-card-placement="composer"
@@ -187,10 +234,12 @@ export function renderSessionProgressCard(
     >
       <summary class="session-progress-card__summary" aria-label=${accessibleLabel}>
         <span
-          class="session-progress-card__summary-indicator session-progress-card__current-marker${complete
+          class="session-progress-card__summary-indicator session-progress-card__current-marker${complete ||
+          sessionStatus === "done"
             ? " session-progress-card__summary-indicator--complete"
             : ""}"
           data-status=${currentStep?.status ?? "pending"}
+          data-outcome=${sessionStatus ?? nothing}
           aria-hidden="true"
         >
           ${summaryIndicator}
@@ -201,7 +250,10 @@ export function renderSessionProgressCard(
         ${counts
           ? html`<span
               class="session-progress-card__summary-count session-progress-card__summary-count--collapsed"
-              >${currentPosition}/${counts.total}</span
+              data-outcome=${sessionStatus ?? nothing}
+              >${terminalOutcomeKey
+                ? t(terminalOutcomeKey)
+                : `${currentPosition}/${counts.total}`}</span
             >`
           : nothing}
         <span class="session-progress-card__summary-expanded">
@@ -209,7 +261,8 @@ export function renderSessionProgressCard(
             >${t("sessionProgressCard.composerTitle")}</span
           >
           <span class="session-progress-card__heading-actions"
-            >${lastActivity} ${shortCount}${dismiss}</span
+            ><span>${lastActivity}${counts ? html` · ${shortCount}` : nothing}</span
+            >${dismiss}</span
           >
         </span>
         <span
@@ -219,7 +272,7 @@ export function renderSessionProgressCard(
         >
       </summary>
       <div class="session-progress-card__body" role="region" aria-label=${composerCountLabel}>
-        ${renderMarkdown(card.markdown)} ${renderSteps(card)}
+        ${renderMarkdown(card.markdown)} ${renderSteps(card, sessionStatus)}
       </div>
     </details>`;
   }
@@ -231,10 +284,11 @@ export function renderSessionProgressCard(
     <div class="session-progress-card__heading">
       <span>${t("sessionProgressCard.title")}</span>
       <span class="session-progress-card__heading-actions">
-        ${lastActivity} ${counts ? html`<span>${counts.completed}/${counts.total}</span>` : nothing}
-        ${dismiss}
+        <span
+          >${lastActivity}${counts ? html` · ${counts.completed}/${counts.total}` : nothing}</span
+        >${dismiss}
       </span>
     </div>
-    ${renderBody(card)}
+    ${renderBody(card, sessionStatus)}
   </section>`;
 }

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -1,5 +1,5 @@
 import type { ProgressCard } from "@openclaw/gateway-protocol";
-import { ReactiveElement, render } from "lit";
+import { nothing, ReactiveElement, render } from "lit";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { resolveControlUiAuthCandidates } from "../app/control-ui-auth.ts";
@@ -48,6 +48,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private applicationGateway: ApplicationGateway | null = null;
   private progressCards: SessionProgressCardStore | null = null;
   private stopProgressCardUpdates: (() => void) | null = null;
+  private stopSessionUpdates: (() => void) | null = null;
   private pullRequests: SessionPullRequestSnapshotStore | null = null;
   private stopPullRequestUpdates: (() => void) | null = null;
   private activeTarget: HTMLElement | null = null;
@@ -93,10 +94,13 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   }
 
   set context(value: ApplicationContext | null) {
+    this.stopSessionUpdates?.();
+    this.stopSessionUpdates = null;
     this.applicationContext = value;
     this.sessionLinkTitler.context = value;
     if (this.isConnected) {
       this.sessionLinkTitler.refresh();
+      this.connectStore();
     }
   }
 
@@ -150,6 +154,11 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   }
 
   private connectStore(): void {
+    if (this.applicationContext && !this.stopSessionUpdates) {
+      this.stopSessionUpdates = this.applicationContext.sessions.subscribe(
+        this.handleSessionUpdate,
+      );
+    }
     if (!this.applicationGateway || this.progressCards) {
       return;
     }
@@ -161,6 +170,8 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.progressCards?.unwatch(this);
     this.stopProgressCardUpdates?.();
     this.stopProgressCardUpdates = null;
+    this.stopSessionUpdates?.();
+    this.stopSessionUpdates = null;
     this.progressCards = null;
     this.releasePullRequestStore();
   }
@@ -175,6 +186,12 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       this.lastProgressCard = card;
     }
     this.showCurrent();
+  };
+
+  private readonly handleSessionUpdate = () => {
+    if (this.open && this.hovercard.held) {
+      this.showCurrent();
+    }
   };
 
   private readonly handlePullRequestUpdate = () => {
@@ -415,7 +432,10 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
             participantCount: sidebarRow.participantCount,
             workContext: sidebarRow.workContext,
             createdAt: sidebarRow.createdAt,
+            startedAt: sidebarRow.startedAt,
             updatedAt: sidebarRow.updatedAt,
+            status: sidebarRow.status,
+            endedAt: sidebarRow.endedAt,
           }
         : null,
     });
@@ -493,7 +513,9 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     card.addEventListener("focusin", this.handleCardFocusIn);
     card.addEventListener("focusout", this.handleCardFocusOut);
     card.addEventListener("keydown", this.handleCardKeyDown);
-    this.hovercard.mount(target, card, sessionProgressHoverPlacementForTarget(target), false);
+    this.hovercard.mount(target, card, sessionProgressHoverPlacementForTarget(target), false, () =>
+      render(nothing, card),
+    );
     if (animateEntry) {
       void card.offsetWidth;
       window.setTimeout(() => {

--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -106,13 +106,13 @@ suite.define(() => {
           await expect
             .poll(() => timestamp.getAttribute("datetime"))
             .toBe(new Date(updatedAt).toISOString());
-          await expect.poll(() => timestamp.getAttribute("aria-label")).toMatch(/^Last activity: /);
-          await expect.poll(() => timestamp.textContent()).toMatch(/\d{1,2}:\d{2}:\d{2}/);
+          await expect.poll(() => timestamp.getAttribute("aria-label")).toMatch(/^Updated /);
+          await expect.poll(() => timestamp.textContent()).toMatch(/^Updated /);
           await expect.poll(() => timestamp.isVisible()).toBe(true);
           const accessibleCard = placement === "composer" ? card.locator("summary") : card;
           await expect
             .poll(() => accessibleCard.getAttribute("aria-label"))
-            .toContain("Last activity:");
+            .not.toContain("Updated");
           const timestampBounds = await timestamp.boundingBox();
           const cardBounds = await card.boundingBox();
           if (!timestampBounds || !cardBounds) {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -242,12 +242,24 @@ export const en: TranslationMap = {
     widgetUnavailable: "Session progress is unavailable.",
     widgetAccessDenied: "Select a session you can access or change sharing for this session.",
     countLabel: "{completed} of {total} completed",
-    lastActivity: "Last activity: {time}",
+    activity: {
+      updated: "Updated {time}",
+      completed: "Completed {time}",
+      failed: "Failed {time}",
+      stopped: "Stopped {time}",
+    },
+    outcome: {
+      completed: "Completed",
+      failed: "Failed",
+      stopped: "Stopped",
+    },
     stepLabel: "{step}, {status}",
     status: {
       completed: "completed",
+      failed: "failed",
       inProgress: "in progress",
       pending: "pending",
+      stopped: "stopped",
     },
     receipt: {
       updating: "Updating progress",

--- a/ui/src/lib/board/widgets/session-progress.ts
+++ b/ui/src/lib/board/widgets/session-progress.ts
@@ -28,6 +28,7 @@ class OpenClawSessionProgressWidget extends OpenClawLightDomElement {
   private store?: SessionProgressCardStore;
   private targetSessionKey = "";
   private unsubscribe?: () => void;
+  private unsubscribeSessions?: () => void;
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -76,7 +77,17 @@ class OpenClawSessionProgressWidget extends OpenClawLightDomElement {
         ${t("sessionProgressCard.widgetEmpty")}
       </p>`;
     }
-    return renderSessionProgressCard(card, "board");
+    const row = this.context?.sessions?.state.result?.sessions.find(
+      (entry) => entry.key === this.targetSessionKey,
+    );
+    return renderSessionProgressCard(
+      card,
+      "board",
+      undefined,
+      row?.status,
+      row?.startedAt,
+      row?.endedAt,
+    );
   }
 
   private syncStore(): void {
@@ -94,6 +105,7 @@ class OpenClawSessionProgressWidget extends OpenClawLightDomElement {
     if (store && targetSessionKey) {
       store.watch(this, [targetSessionKey]);
       this.unsubscribe = store.subscribe(() => this.requestUpdate());
+      this.unsubscribeSessions = this.context?.sessions?.subscribe(() => this.requestUpdate());
     }
   }
 
@@ -107,8 +119,10 @@ class OpenClawSessionProgressWidget extends OpenClawLightDomElement {
   private releaseStore(): void {
     this.store?.unwatch(this);
     this.unsubscribe?.();
+    this.unsubscribeSessions?.();
     this.store = undefined;
     this.unsubscribe = undefined;
+    this.unsubscribeSessions = undefined;
   }
 }
 

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -4123,8 +4123,10 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           <div class="agent-chat__progress-float">
             <details class="session-progress-card session-progress-card--composer" open>
               <summary class="session-progress-card__summary">
+                <span class="session-progress-card__summary-indicator">
+                  <span class="session-run-spinner"></span>
+                </span>
                 <span class="session-progress-card__summary-collapsed">
-                  <span class="session-progress-card__summary-indicator">${iconSvg()}</span>
                   <span class="session-progress-card__current">Abrir a interface</span>
                 </span>
                 <span class="session-progress-card__summary-count session-progress-card__summary-count--collapsed">1/10</span>
@@ -4146,27 +4148,67 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
               </div>
             </div>
           </div>
+          <div class="agent-chat__goal-float">
+            <div class="agent-chat__goal agent-chat__goal--active" data-expanded="false">
+              <div class="agent-chat__goal-row">
+                <span class="agent-chat__goal-icon">${iconSvg()}</span>
+                <span class="agent-chat__goal-copy">
+                  <span class="agent-chat__goal-label">Pursuing goal</span>
+                  <span class="agent-chat__goal-objective">Ship the aligned stack</span>
+                </span>
+                <span class="agent-chat__goal-elapsed">14m</span>
+                <span class="agent-chat__goal-actions"></span>
+              </div>
+            </div>
+          </div>
           <div class="agent-chat__input">Composer</div>
         </div>
+        <span id="failed-outcome-probe" class="session-progress-card__summary-count" data-outcome="failed">Failed</span>
+        <span id="danger-color-probe" style="color: var(--danger)">Danger</span>
       </body></html>`);
 
       const summary = page.locator(".session-progress-card__summary");
       const card = page.locator(".session-progress-card--composer");
       const list = page.locator(".session-progress-card__steps");
       const widthBefore = (await card.boundingBox())?.width;
-      const summaryBefore = await summary.evaluate((node) => {
-        const style = getComputedStyle(node);
-        return { background: style.backgroundColor, y: node.getBoundingClientRect().y };
+      const expandedBefore = await page.evaluate(() => {
+        const style = (selector: string) =>
+          getComputedStyle(document.querySelector<HTMLElement>(selector)!);
+        const bounds = (selector: string) =>
+          document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
+        return {
+          cardBackground: style(".session-progress-card--composer").backgroundColor,
+          summaryBackground: style(".session-progress-card__summary").backgroundColor,
+          titleColor: style(".session-progress-card__summary-title").color,
+          actionsColor: style(".session-progress-card__heading-actions").color,
+          chevronColor: style(".session-progress-card__summary-chevron").color,
+          titleLeft: bounds(".session-progress-card__summary-title").left,
+          firstMarkerLeft: bounds(".session-progress-card__step-marker").left,
+          y: bounds(".session-progress-card__summary").y,
+        };
       });
       await summary.hover();
+      await page.waitForTimeout(180);
       const widthAfter = (await card.boundingBox())?.width;
-      const summaryAfter = await summary.evaluate((node) => {
-        const style = getComputedStyle(node);
-        return { background: style.backgroundColor, y: node.getBoundingClientRect().y };
+      const expandedAfter = await page.evaluate(() => {
+        const style = (selector: string) =>
+          getComputedStyle(document.querySelector<HTMLElement>(selector)!);
+        return {
+          cardBackground: style(".session-progress-card--composer").backgroundColor,
+          summaryBackground: style(".session-progress-card__summary").backgroundColor,
+          titleColor: style(".session-progress-card__summary-title").color,
+          actionsColor: style(".session-progress-card__heading-actions").color,
+          chevronColor: style(".session-progress-card__summary-chevron").color,
+        };
       });
       expect(widthBefore).toBeCloseTo(760, 1);
       expect(widthAfter).toBeCloseTo(widthBefore ?? 0, 1);
-      expect(summaryAfter.background).toBe(summaryBefore.background);
+      expect(expandedBefore.titleLeft).toBeCloseTo(expandedBefore.firstMarkerLeft, 1);
+      expect(expandedAfter.cardBackground).toBe(expandedBefore.cardBackground);
+      expect(expandedAfter.summaryBackground).toBe(expandedBefore.summaryBackground);
+      expect(expandedAfter.titleColor).not.toBe(expandedBefore.titleColor);
+      expect(expandedAfter.actionsColor).not.toBe(expandedBefore.actionsColor);
+      expect(expandedAfter.chevronColor).not.toBe(expandedBefore.chevronColor);
 
       const listLayout = await list.evaluate((node) => {
         const bounds = node.getBoundingClientRect();
@@ -4185,6 +4227,37 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(listLayout.scrollHeight).toBeGreaterThan(listLayout.clientHeight);
       expect(listLayout.visibleItems).toBeGreaterThanOrEqual(5);
       expect(listLayout.visibleItems).toBeLessThanOrEqual(7);
+      const openStackAxes = await page.evaluate(() => {
+        const centerX = (selector: string) => {
+          const rect = document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
+          return rect.left + rect.width / 2;
+        };
+        const left = (selector: string) =>
+          document.querySelector<HTMLElement>(selector)!.getBoundingClientRect().left;
+        return {
+          iconCenters: [
+            ...[
+              ...document.querySelectorAll<HTMLElement>(".session-progress-card__step-marker > *"),
+            ].map((icon) => {
+              const rect = icon.getBoundingClientRect();
+              return rect.left + rect.width / 2;
+            }),
+            centerX(".chat-queue__leading svg"),
+            centerX(".agent-chat__goal-icon svg"),
+          ],
+          contentLefts: [
+            left(".session-progress-card__step-text"),
+            left(".chat-queue__copy"),
+            left(".agent-chat__goal-label"),
+          ],
+        };
+      });
+      expect(
+        Math.max(...openStackAxes.iconCenters) - Math.min(...openStackAxes.iconCenters),
+      ).toBeLessThan(0.5);
+      expect(
+        Math.max(...openStackAxes.contentLefts) - Math.min(...openStackAxes.contentLefts),
+      ).toBeLessThan(0.5);
       expect(
         await page
           .locator(".session-progress-card__body")
@@ -4194,7 +4267,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       await list.evaluate((node) => {
         node.scrollTop = node.scrollHeight;
       });
-      expect((await summary.boundingBox())?.y).toBeCloseTo(summaryBefore.y, 1);
+      expect((await summary.boundingBox())?.y).toBeCloseTo(expandedBefore.y, 1);
       expect(await page.evaluate(() => window.scrollY)).toBe(0);
 
       const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
@@ -4209,22 +4282,91 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         });
       }
 
+      await page.mouse.move(0, 0);
       await card.evaluate((node) => node.removeAttribute("open"));
+      await page.waitForTimeout(180);
+      const collapsedBefore = await page.evaluate(() => {
+        const style = (selector: string) =>
+          getComputedStyle(document.querySelector<HTMLElement>(selector)!);
+        const spinner = style(".session-progress-card__summary-indicator .session-run-spinner");
+        return {
+          cardBackground: style(".session-progress-card--composer").backgroundColor,
+          summaryBackground: style(".session-progress-card__summary").backgroundColor,
+          currentColor: style(".session-progress-card__current").color,
+          countColor: style(".session-progress-card__summary-count--collapsed").color,
+          chevronColor: style(".session-progress-card__summary-chevron").color,
+          spinnerBorderColor: spinner.borderColor,
+          spinnerBorderTopColor: spinner.borderTopColor,
+        };
+      });
+      await summary.hover();
+      await page.waitForTimeout(180);
+      const collapsedAfter = await page.evaluate(() => {
+        const style = (selector: string) =>
+          getComputedStyle(document.querySelector<HTMLElement>(selector)!);
+        const spinner = style(".session-progress-card__summary-indicator .session-run-spinner");
+        return {
+          cardBackground: style(".session-progress-card--composer").backgroundColor,
+          summaryBackground: style(".session-progress-card__summary").backgroundColor,
+          currentColor: style(".session-progress-card__current").color,
+          countColor: style(".session-progress-card__summary-count--collapsed").color,
+          chevronColor: style(".session-progress-card__summary-chevron").color,
+          spinnerBorderColor: spinner.borderColor,
+          spinnerBorderTopColor: spinner.borderTopColor,
+        };
+      });
+      expect(collapsedAfter.cardBackground).toBe(collapsedBefore.cardBackground);
+      expect(collapsedAfter.summaryBackground).toBe(collapsedBefore.summaryBackground);
+      expect(collapsedAfter.currentColor).not.toBe(collapsedBefore.currentColor);
+      expect(collapsedAfter.countColor).not.toBe(collapsedBefore.countColor);
+      expect(collapsedAfter.chevronColor).not.toBe(collapsedBefore.chevronColor);
+      expect(collapsedAfter.spinnerBorderColor).toBe(collapsedBefore.spinnerBorderColor);
+      expect(collapsedAfter.spinnerBorderTopColor).toBe(collapsedBefore.spinnerBorderTopColor);
       const collapsed = await page.evaluate(() => {
         const rect = (selector: string) =>
           document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
         const current = rect(".session-progress-card__current");
         const count = rect(".session-progress-card__summary-count--collapsed");
         const chevron = rect(".session-progress-card__summary-chevron");
+        const iconCenter = (selector: string) => {
+          const bounds = rect(selector);
+          return bounds.left + bounds.width / 2;
+        };
         return {
           countLeft: count.left,
           countRight: count.right,
           currentRight: current.right,
           chevronLeft: chevron.left,
+          iconCenters: [
+            iconCenter(".session-progress-card__summary-indicator > *"),
+            iconCenter(".chat-queue__leading svg"),
+            iconCenter(".agent-chat__goal-icon svg"),
+          ],
         };
       });
       expect(collapsed.countLeft).toBeGreaterThan(collapsed.currentRight);
       expect(collapsed.countRight).toBeLessThanOrEqual(collapsed.chevronLeft);
+      expect(Math.max(...collapsed.iconCenters) - Math.min(...collapsed.iconCenters)).toBeLessThan(
+        0.5,
+      );
+      const closedRowCenters = await page.evaluate(() => {
+        const centerY = (selector: string) => {
+          const bounds = document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
+          return bounds.top + bounds.height / 2;
+        };
+        return [
+          centerY(".session-progress-card__summary-indicator > *"),
+          centerY(".session-progress-card__current"),
+          centerY(".session-progress-card__summary-count--collapsed"),
+          centerY(".session-progress-card__summary-chevron > svg"),
+        ];
+      });
+      expect(Math.max(...closedRowCenters) - Math.min(...closedRowCenters)).toBeLessThan(0.5);
+      const outcomeColors = await page.evaluate(() => ({
+        danger: getComputedStyle(document.querySelector("#danger-color-probe")!).color,
+        failed: getComputedStyle(document.querySelector("#failed-outcome-probe")!).color,
+      }));
+      expect(outcomeColors.failed).toBe(outcomeColors.danger);
       if (artifactDir) {
         await page.locator(".agent-chat__composer-shell").screenshot({
           animations: "disabled",

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -264,6 +264,8 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
           "composer",
           props.onDismissProgressCard,
           activeSession?.status,
+          activeSession?.startedAt,
+          activeSession?.endedAt,
         )}
       </div>`
     : nothing;

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -259,7 +259,12 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
   const compactionStatus = renderCompactionIndicator(props.compactionStatus);
   const progressCard = props.progressCard
     ? html`<div class="agent-chat__progress-float">
-        ${renderSessionProgressCard(props.progressCard, "composer", props.onDismissProgressCard)}
+        ${renderSessionProgressCard(
+          props.progressCard,
+          "composer",
+          props.onDismissProgressCard,
+          activeSession?.status,
+        )}
       </div>`
     : nothing;
   const queue = renderChatQueue({

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -308,10 +308,7 @@
   }
 
   .session-progress-card__summary:hover
-    .session-progress-card__summary-count:is(
-      [data-outcome="failed"],
-      [data-outcome="timeout"]
-    ) {
+    .session-progress-card__summary-count:is([data-outcome="failed"], [data-outcome="timeout"]) {
     color: var(--danger);
   }
 }

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -1,4 +1,6 @@
 .session-progress-card--composer {
+  --session-progress-marker-size: var(--chat-stack-icon-size, 14px);
+
   position: relative;
   display: block;
   box-sizing: border-box;
@@ -91,7 +93,7 @@
 
 .session-progress-card__summary {
   display: grid;
-  grid-template-columns: 14px minmax(0, 1fr) auto auto;
+  grid-template-columns: var(--session-progress-marker-size) minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 12px;
   width: 100%;
@@ -134,7 +136,7 @@
 
 .session-progress-card__summary-expanded {
   display: none;
-  grid-column: 2 / 4;
+  grid-column: 1 / 4;
   justify-content: space-between;
   gap: 16px;
 }
@@ -190,16 +192,16 @@
 .session-progress-card__summary-indicator {
   position: relative;
   display: inline-grid;
-  width: 14px;
-  height: 14px;
+  width: var(--session-progress-marker-size);
+  height: var(--session-progress-marker-size);
   place-items: center;
-  flex: 0 0 14px;
+  flex: 0 0 var(--session-progress-marker-size);
   color: var(--muted);
 }
 
 .session-progress-card__summary-indicator > svg {
-  width: 14px;
-  height: 14px;
+  width: var(--session-progress-marker-size);
+  height: var(--session-progress-marker-size);
 }
 
 .session-progress-card__summary-indicator--complete {
@@ -208,8 +210,8 @@
 
 .session-progress-card__summary-indicator > .session-run-spinner {
   display: block;
-  width: 14px;
-  height: 14px;
+  width: var(--session-progress-marker-size);
+  height: var(--session-progress-marker-size);
   border-color: color-mix(in srgb, var(--muted) 24%, transparent);
   border-top-color: var(--muted);
   animation-duration: 1.8s;
@@ -233,6 +235,12 @@
   font-variant-numeric: tabular-nums;
   line-height: 18px;
   transition: color 140ms ease;
+}
+
+.session-progress-card__summary-count:is([data-outcome="failed"], [data-outcome="timeout"]),
+.session-progress-card__summary-indicator:is([data-outcome="failed"], [data-outcome="timeout"]),
+.session-progress-card__step-marker:is([data-outcome="failed"], [data-outcome="timeout"]) {
+  color: var(--danger);
 }
 
 .session-progress-card--composer .session-progress-card__body {
@@ -285,16 +293,26 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-  /* Collapsed, the visible card extends past the summary (underlap arcs beside
-     the composer's rounded corners), so the highlight lives on the container to
-     fill the whole shape; a summary-only fill leaves slivers of the resting
-     background at those corners. */
-  .session-progress-card--composer:not([open]):hover {
-    background: color-mix(
-      in srgb,
-      var(--text-strong) 5%,
-      var(--chat-composer-surface, var(--popover))
-    );
+  .session-progress-card__summary:hover
+    :is(.session-progress-card__summary-title, .session-progress-card__current) {
+    color: var(--text-strong);
+  }
+
+  .session-progress-card__summary:hover
+    :is(
+      .session-progress-card__heading-actions,
+      .session-progress-card__summary-count,
+      .session-progress-card__summary-chevron
+    ) {
+    color: color-mix(in srgb, var(--text) 78%, var(--muted));
+  }
+
+  .session-progress-card__summary:hover
+    .session-progress-card__summary-count:is(
+      [data-outcome="failed"],
+      [data-outcome="timeout"]
+    ) {
+    color: var(--danger);
   }
 }
 

--- a/ui/src/styles/chat/composer-queue.css
+++ b/ui/src/styles/chat/composer-queue.css
@@ -2,6 +2,7 @@
    queue visibly subordinate; only its protected bottom space may underlap. */
 .agent-chat__composer-shell {
   --chat-queue-divider: color-mix(in srgb, var(--text-strong) 6%, transparent);
+  --chat-stack-icon-size: 14px;
   --chat-stack-leading-inset: 13px;
   --chat-stack-trailing-inset: 8px;
 }
@@ -122,14 +123,14 @@
 
   position: relative;
   display: grid;
-  grid-template-columns: 24px 20px minmax(0, 1fr) auto;
+  grid-template-columns: var(--chat-stack-icon-size) 20px minmax(0, 1fr) auto;
   align-items: center;
   column-gap: 8px;
   box-sizing: border-box;
   min-width: 0;
   width: 100%;
   min-height: var(--chat-queue-row-height);
-  padding: 6px var(--chat-stack-trailing-inset);
+  padding: 6px var(--chat-stack-trailing-inset) 6px var(--chat-stack-leading-inset);
   border-bottom: 1px solid var(--chat-queue-divider);
   background: var(--chat-queue-row-surface);
   color: var(--muted);
@@ -152,7 +153,7 @@
 }
 
 .chat-queue__item--no-avatar {
-  grid-template-columns: 24px minmax(0, 1fr) auto;
+  grid-template-columns: var(--chat-stack-icon-size) minmax(0, 1fr) auto;
 }
 
 .chat-queue__item--no-avatar .chat-queue__copy,
@@ -273,6 +274,7 @@
   flex-shrink: 0;
   width: 24px;
   height: 28px;
+  margin-inline: calc((var(--chat-stack-icon-size) - 24px) / 2);
   color: var(--muted);
   grid-column: 1;
 }
@@ -536,13 +538,13 @@
 
 @media (max-width: 560px) {
   .chat-queue__item {
-    grid-template-columns: 22px 18px minmax(0, 1fr) auto;
+    grid-template-columns: var(--chat-stack-icon-size) 18px minmax(0, 1fr) auto;
     column-gap: 6px;
-    padding-inline: 6px;
+    padding-inline: var(--chat-stack-leading-inset) var(--chat-stack-trailing-inset);
   }
 
   .chat-queue__item--no-avatar {
-    grid-template-columns: 22px minmax(0, 1fr) auto;
+    grid-template-columns: var(--chat-stack-icon-size) minmax(0, 1fr) auto;
   }
 
   .chat-queue__retry span {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1152,7 +1152,7 @@ openclaw-chat-page {
 
 .agent-chat__goal-row {
   display: grid;
-  grid-template-columns: 14px minmax(0, 1fr) auto auto;
+  grid-template-columns: var(--chat-stack-icon-size, 14px) minmax(0, 1fr) auto auto;
   align-items: center;
   min-width: 0;
   column-gap: 8px;
@@ -1162,14 +1162,14 @@ openclaw-chat-page {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 14px;
+  width: var(--chat-stack-icon-size, 14px);
   height: 18px;
   flex-shrink: 0;
 }
 
 .agent-chat__goal-icon svg {
-  width: 14px;
-  height: 14px;
+  width: var(--chat-stack-icon-size, 14px);
+  height: var(--chat-stack-icon-size, 14px);
   stroke: currentColor;
   fill: none;
   stroke-width: 1.7px;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading Task progress in chat would see a raw timestamp with seconds, ambiguous terminal counters or spinners, a left-indented expanded title, surface-level hover fills, and inconsistent icon alignment across the progress, queue, and goal stack.

## Why This Change Was Made

This PR uses the canonical `SessionRunStatus` already projected from the agent-run terminal outcome owner; it does not rederive timeout/cancel precedence. It presents Updated, Completed, Failed, or Stopped relative activity through the existing chat refresh cycle, with no new timer.

It also:

- keeps the running counter and replaces closed terminal counters with Completed, Failed, or Stopped
- uses the design-system danger token for Failed
- replaces terminal in-progress spinners with circle-x markers and terminal accessibility copy
- restores element-only hover feedback without changing card or header surfaces
- aligns the expanded title with body content
- gives progress, queue, and goal icons one shared gutter
- vertically centers every closed-header element on one row
- restores normal transcript scrolling

Gap provenance: #127823 / `18beca535036813918e8826e27abf2a564ed1b0b` added a leading marker column to the composer summary while `.session-progress-card__summary-expanded` remained on `grid-column: 2 / 4`. That reserved the marker column and gap even when expanded. This PR spans the expanded summary across columns 1 through 3.

The surface-hover regression was removed rather than compensated: hover now changes only title/current text, metadata, and chevron colors; the spinner and both surfaces remain unchanged.

## User Impact

Users can scan relative activity and terminal outcomes at a glance. Open cards read `Updated 2m ago · 2 of 3`, `Completed 12m ago · 3 of 3`, `Failed 12m ago · 2 of 3`, or `Stopped 12m ago · 2 of 3`. Closed terminal cards say Completed, Failed, or Stopped, while running cards keep `2/3`.

## Evidence

Before/after screenshots use current `main` at `0707fcb039a01571cb1c8538e561736cff9f328e` and this PR head at `fc6c1301c8138e644f5739cd9bb387f54b4ad50e`. Every capture was inspected in the real Chrome fixture at matching viewport geometry.

### Dark

| Scenario | Before · main | After · this PR |
| --- | --- | --- |
| Running · open (relative activity + middot counter) | ![Before — Running · open (relative activity + middot counter) — dark](https://github.com/user-attachments/assets/d7c6cac4-bdae-4075-9af1-54ab373f9bb9) | ![After — Running · open (relative activity + middot counter) — dark](https://github.com/user-attachments/assets/717c984d-0b5f-4d7e-81c4-ca4f15d31a21) |
| Running · closed (counter retained) | ![Before — Running · closed (counter retained) — dark](https://github.com/user-attachments/assets/11a35217-fa9f-4938-a7ee-83b054d1b0c5) | ![After — Running · closed (counter retained) — dark](https://github.com/user-attachments/assets/3400b0b4-a815-4ffc-acdc-3da7c3ee77db) |
| Completed · open (relative activity) | ![Before — Completed · open (relative activity) — dark](https://github.com/user-attachments/assets/a6346994-3792-4e0b-8303-19deb63eeb3f) | ![After — Completed · open (relative activity) — dark](https://github.com/user-attachments/assets/98a1699b-9689-4043-a4fa-5ec44578970c) |
| Completed · closed (terminal label) | ![Before — Completed · closed (terminal label) — dark](https://github.com/user-attachments/assets/be844b37-818c-4e62-9a21-4571f81ed46b) | ![After — Completed · closed (terminal label) — dark](https://github.com/user-attachments/assets/c5b92b61-639a-47fd-bd56-f82ebec4dd9d) |
| Failed · closed (danger token) | ![Before — Failed · closed (danger token) — dark](https://github.com/user-attachments/assets/ed32771a-b962-49cc-a634-f8956e0c03ce) | ![After — Failed · closed (danger token) — dark](https://github.com/user-attachments/assets/9c3c0627-a5a6-41d7-8d6b-7694ec04f304) |
| Failed · open (relative activity + terminal step) | ![Before — Failed · open (relative activity + terminal step) — dark](https://github.com/user-attachments/assets/acaed556-7067-4a26-a1e9-7493cf7f2945) | ![After — Failed · open (relative activity + terminal step) — dark](https://github.com/user-attachments/assets/f8b3c9a9-bd9b-43cf-9a15-39c058d525d5) |
| Stopped · closed (circle-x) | ![Before — Stopped · closed (circle-x) — dark](https://github.com/user-attachments/assets/7c1f0e3a-b10f-4de6-99da-42740b479348) | ![After — Stopped · closed (circle-x) — dark](https://github.com/user-attachments/assets/85bf88aa-f928-4552-b3ea-6527af33f9c2) |
| Stopped · open (relative activity, no spinner) | ![Before — Stopped · open (relative activity, no spinner) — dark](https://github.com/user-attachments/assets/940a1602-3e4f-4549-804a-71f5a8a660c9) | ![After — Stopped · open (relative activity, no spinner) — dark](https://github.com/user-attachments/assets/e831a033-34b9-4b35-bf30-df3c640e9c83) |
| Hover · closed (elements only) | ![Before — Hover · closed (elements only) — dark](https://github.com/user-attachments/assets/7b7da34b-9433-46f7-9aec-9b8ba4be50bc) | ![After — Hover · closed (elements only) — dark](https://github.com/user-attachments/assets/38ded5f6-2114-4d2a-ac0f-465013db1e33) |
| Hover · open (elements only) | ![Before — Hover · open (elements only) — dark](https://github.com/user-attachments/assets/b64d35ad-e83a-46ec-97c4-eb09fe26279a) | ![After — Hover · open (elements only) — dark](https://github.com/user-attachments/assets/151b8ded-fd84-47e1-b486-b5e54edfb9d3) |
| Stack · progress closed (queue + goal + progress) | ![Before — Stack · progress closed (queue + goal + progress) — dark](https://github.com/user-attachments/assets/0e8faa84-6ccb-4920-8456-5cf4656a9369) | ![After — Stack · progress closed (queue + goal + progress) — dark](https://github.com/user-attachments/assets/b91526dd-d189-44b8-bb73-cf249fdb558c) |
| Stack · progress open (queue + goal + expanded progress) | ![Before — Stack · progress open (queue + goal + expanded progress) — dark](https://github.com/user-attachments/assets/e3ead727-0f1e-4fcc-8114-7ae722d3d005) | ![After — Stack · progress open (queue + goal + expanded progress) — dark](https://github.com/user-attachments/assets/660721a4-4628-48c2-bd89-f2e972406f53) |

### Light

| Scenario | Before · main | After · this PR |
| --- | --- | --- |
| Running · open (relative activity + middot counter) | ![Before — Running · open (relative activity + middot counter) — light](https://github.com/user-attachments/assets/a4ce34d7-db89-408e-a469-9b4750081bc1) | ![After — Running · open (relative activity + middot counter) — light](https://github.com/user-attachments/assets/f776d9e0-fd35-4724-82d6-7c9851e1ad81) |
| Running · closed (counter retained) | ![Before — Running · closed (counter retained) — light](https://github.com/user-attachments/assets/50a0ce5c-b857-4993-85eb-7fb4ead4b4d3) | ![After — Running · closed (counter retained) — light](https://github.com/user-attachments/assets/3eb18387-3787-4807-a019-832d13a56ef0) |
| Completed · open (relative activity) | ![Before — Completed · open (relative activity) — light](https://github.com/user-attachments/assets/4f772aef-d19c-4bb4-bd93-0fca6cfa46e4) | ![After — Completed · open (relative activity) — light](https://github.com/user-attachments/assets/d78dffab-3506-4b16-b660-8cc06361700b) |
| Completed · closed (terminal label) | ![Before — Completed · closed (terminal label) — light](https://github.com/user-attachments/assets/2c348076-91cc-44e5-816e-62a7a180bed8) | ![After — Completed · closed (terminal label) — light](https://github.com/user-attachments/assets/e6ed2980-b38f-46da-8c6d-c9210a38bf71) |
| Failed · closed (danger token) | ![Before — Failed · closed (danger token) — light](https://github.com/user-attachments/assets/75533ad3-0aef-4ab9-9c58-fe0d9c5a0d0b) | ![After — Failed · closed (danger token) — light](https://github.com/user-attachments/assets/221b9356-0480-4484-98fa-48858ba5b6a8) |
| Failed · open (relative activity + terminal step) | ![Before — Failed · open (relative activity + terminal step) — light](https://github.com/user-attachments/assets/a97eebb3-ab7a-4945-b936-d2f7c9cdbed0) | ![After — Failed · open (relative activity + terminal step) — light](https://github.com/user-attachments/assets/c5a699af-1b53-43ee-b12d-22974c2386d8) |
| Stopped · closed (circle-x) | ![Before — Stopped · closed (circle-x) — light](https://github.com/user-attachments/assets/6a162965-b01a-411f-aa7d-dac5f91138e1) | ![After — Stopped · closed (circle-x) — light](https://github.com/user-attachments/assets/aa963864-c2be-408f-9514-4c7eadfda470) |
| Stopped · open (relative activity, no spinner) | ![Before — Stopped · open (relative activity, no spinner) — light](https://github.com/user-attachments/assets/0460692c-d90c-4698-9263-7ac9bde2ec18) | ![After — Stopped · open (relative activity, no spinner) — light](https://github.com/user-attachments/assets/685d6f08-fd1a-473a-9fff-63f2dbc5a3c4) |
| Hover · closed (elements only) | ![Before — Hover · closed (elements only) — light](https://github.com/user-attachments/assets/67d66196-2ea7-45f7-a94c-8fdd57bff0d4) | ![After — Hover · closed (elements only) — light](https://github.com/user-attachments/assets/198f7e96-506b-47da-bb52-5cb393ad5ce5) |
| Hover · open (elements only) | ![Before — Hover · open (elements only) — light](https://github.com/user-attachments/assets/ba6c1a38-7f7c-4899-8f79-952572a395dd) | ![After — Hover · open (elements only) — light](https://github.com/user-attachments/assets/5d8df6e3-18c6-4b10-9ce3-ac197307ab75) |
| Stack · progress closed (queue + goal + progress) | ![Before — Stack · progress closed (queue + goal + progress) — light](https://github.com/user-attachments/assets/1f21a086-755c-447f-9aa5-e719a8a0eec8) | ![After — Stack · progress closed (queue + goal + progress) — light](https://github.com/user-attachments/assets/5e6424b0-eb7c-47ef-b7bd-53335f4221d7) |
| Stack · progress open (queue + goal + expanded progress) | ![Before — Stack · progress open (queue + goal + expanded progress) — light](https://github.com/user-attachments/assets/7d174e43-cf8c-43bc-957c-c07802d5f65d) | ![After — Stack · progress open (queue + goal + expanded progress) — light](https://github.com/user-attachments/assets/bd353b04-f5eb-4164-ac2a-b91188c0af29) |

Final browser measurements:

- expanded title left edge = first step-marker left edge
- open icon-center delta: < 0.001 px; closed icon-center delta: 0 px
- closed header vertical-center delta: 0 px
- Failed = `rgb(248, 113, 113)`, resolving from `--danger: #f87171`
- Stopped has circle-x in both summary and terminal step, with zero spinners
- transcript scroll reached its measured maximum

Local gates were not run on macOS per bench policy; the lander owns gates on r8g.

Production LOC: +152/-58 (net +94) | Tests: +240/-17. The production growth covers the requested canonical status presentation, terminal-safe step semantics, and shared stack alignment. Removed behavior includes raw clock copy, full-surface hover fills, and terminal spinner presentation.

## Landing Order

This PR must land **after #130109**, which touches the same Task progress card and is already queued with the lander.

