### PR TITLE
docs(skills): align mcporter CLI workflow

### DIFF
--- a/skills/mcporter/SKILL.md
+++ b/skills/mcporter/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: mcporter
-description: "List, configure, authenticate, call, and inspect MCP servers/tools with mcporter over HTTP or stdio."
-homepage: http://mcporter.dev
+description: "Discover, inspect, call, and read resources from MCP servers with mcporter."
+homepage: https://mcporter.sh
 metadata:
   {
     "openclaw":
       {
         "emoji": "📦",
-        "requires": { "bins": ["mcporter"] },
+        "requires": { "anyBins": ["mcporter"] },
         "install":
           [
             {
@@ -15,7 +15,7 @@ metadata:
               "kind": "node",
               "package": "mcporter",
               "bins": ["mcporter"],
-              "label": "Install mcporter (node)",
+              "label": "Install mcporter (npm)",
             },
           ],
       },
@@ -24,38 +24,84 @@ metadata:
 
 # mcporter
 
-Use `mcporter` to work with MCP servers directly.
+Use MCPorter as a command-line MCP client: discover servers and tools, call tools,
+and list or read MCP Resources. Examples use `npx mcporter`; a globally installed
+`mcporter` binary can replace that prefix.
 
-Quick start
+## Discover servers and tools
 
-- `mcporter list`
-- `mcporter list <server> --schema`
-- `mcporter call <server.tool> key=value`
+Start with discovery rather than guessing a tool name:
 
-Call tools
+```sh
+npx mcporter list
+npx mcporter list <server> --brief
+npx mcporter list <server> --schema
+```
 
-- Selector: `mcporter call linear.list_issues team=ENG limit:5`
-- Function syntax: `mcporter call "linear.create_issue(title: \"Bug\")"`
-- Full URL: `mcporter call https://api.example.com/mcp.fetch url:https://example.com`
-- Stdio: `mcporter call --stdio "bun run ./server.ts" scrape url=https://example.com`
-- JSON payload: `mcporter call <server.tool> --args '{"limit":5}'`
+## Call tools
 
-Auth + config
+Use a `server.tool` selector with named arguments, the signature syntax printed by
+`list`, or an explicit JSON payload:
 
-- OAuth: `mcporter auth <server | url> [--reset]`
-- Config: `mcporter config list|get|add|remove|import|login|logout`
+```sh
+npx mcporter call linear.list_issues team=ENG limit:5
+npx mcporter call 'linear.create_issue(title: "Bug", team: "ENG")'
+npx mcporter call linear.list_issues --args '{"limit":5}'
+```
 
-Daemon
+Add `--output json` when another tool parses the result. Inspect the schema before
+sending unfamiliar arguments, and do not invoke write, delete, or other mutating
+tools without the user's authorization.
 
-- `mcporter daemon start|status|stop|restart`
+## List and read MCP Resources
 
-Codegen
+`resource` covers the MCP `resources/list` and `resources/read` operations. Without a
+URI it lists the server's Resources; with a URI it reads that one:
 
-- CLI: `mcporter generate-cli --server <name>` or `--command <url>`
-- Inspect: `mcporter inspect-cli <path> [--json]`
-- TS: `mcporter emit-ts <server> --mode client|types`
+```sh
+npx mcporter resource <server>
+npx mcporter resource <server> <uri> --output json
+```
 
-Notes
+Quote the URI when it contains `?`, `&`, or spaces.
 
-- Config default: `./config/mcporter.json` (override with `--config`).
-- Prefer `--output json` for machine-readable results.
+## HTTP and stdio servers
+
+`list`, `call`, and `auth` accept a server description for a single invocation, so no
+config file is needed:
+
+```sh
+npx mcporter list --http-url https://mcp.example.com/mcp --name example --brief
+npx mcporter list --http-url http://localhost:3001/mcp --allow-http --name local --brief
+npx mcporter list --stdio "npx -y example-mcp@latest" --name local --brief
+```
+
+A cleartext `http://` endpoint is refused until `--allow-http` confirms it, including
+loopback hosts like `localhost`, `127.0.0.1`, or `[::1]`.
+
+These definitions are ephemeral, and `resource` only accepts a configured server, so
+persist the endpoint first:
+
+```sh
+npx mcporter config add local http://localhost:3001/mcp
+```
+
+## Auth and config
+
+```sh
+npx mcporter auth <server-or-url> [--reset]
+npx mcporter config list
+npx mcporter config add <name> <url>
+```
+
+Keep credentials in environment placeholders or a local secret store; do not paste
+tokens, headers, or OAuth URLs into prompts, committed config, or logs.
+
+Run `npx mcporter --help` or `npx mcporter <command> --help` for the remaining
+commands and flags in the installed version.
+
+## References
+
+- [MCPorter README and Core Workflows](https://github.com/openclaw/mcporter#core-workflows)
+- [CLI reference](https://github.com/openclaw/mcporter/blob/main/docs/cli-reference.md)
+- [MCP Resources specification](https://modelcontextprotocol.io/specification/latest/server/resources)


### PR DESCRIPTION
## What Problem This Solves

The bundled `skills/mcporter/SKILL.md` had drifted from the current `openclaw/mcporter` CLI. It did not describe the upstream `npx mcporter` entry point, ad-hoc `--http-url`/stdio connections, or the dedicated `mcporter resource` workflow. That made it difficult for agents to discover and read MCP Resources, especially for MCP servers such as x64dbgMCP whose primary read-only navigation surface is exposed as Resources.

## Why This Change Was Made

This change rewrites the skill around the current mcporter CLI contract: `npx mcporter` for discovery and calls, explicit `--allow-http` for cleartext endpoints, and `resource <server> [uri]` for listing/reading Resources. It documents the necessary persist-then-`--config` bridge for ad-hoc Resource reads, keeps the HTTP/stdio boundary explicit, and adds an x64dbgMCP `/mcp` smoke-test path without changing runtime code.

## User Impact

Agents can now copy the documented commands to discover servers, inspect schemas, call tools, persist an ad-hoc endpoint, enumerate Resources, and read concrete Resource URIs. The x64dbgMCP examples also distinguish fixed Resources from Resource Templates and remind callers to confirm asynchronous debugger state through Resources.

## Evidence

- Compared the skill with `openclaw/mcporter` at commit `ae3d9000c3205c0cb79cf5c13251d6dfd2a174d5` and its current README Core Workflows, CLI reference, ad-hoc, configuration, and quickstart documentation.
- Cross-checked the x64dbgMCP endpoint and Resource catalog against `docs/README.md`, `docs/implementation-status.md`, `docs/tools-spec.md`, and `docs/architecture.md` in the local project.
- `pnpm docs:list` completed successfully.
- `git diff --check` completed successfully before commit and after rebase.
- A real `mcporter@0.13.7` offline probe accepted `--http-url`, `--allow-http`, `--status --json`, and `--persist`; the follow-up `resource --config` invocation returned the expected structured offline error for the deliberately closed test port.
- `autoreview` was attempted but could not run because TruffleHog is not installed in this environment; no automatic installation was performed.

This PR is AI-assisted and was reviewed manually against the upstream CLI source/docs and the x64dbgMCP project contract.

## Worked on by

- @nblog
