### PR TITLE
fix(sessions): release reconcile lease before terminal state (#130161)

### DIFF
--- a/src/config/sessions/session-transcript-reconcile.lifecycle.test.ts
+++ b/src/config/sessions/session-transcript-reconcile.lifecycle.test.ts
@@ -1,0 +1,206 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { Worker, type WorkerOptions } from "node:worker_threads";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { persistSessionTranscriptTurn } from "./session-accessor.js";
+import {
+  reconcileSessionTranscriptIndexes,
+  waitForSessionTranscriptIndexReconcile,
+} from "./session-transcript-reconcile.js";
+import type { SessionTranscriptReconcileWorkerMessage } from "./session-transcript-reconcile.worker.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+type TerminalType = Extract<
+  SessionTranscriptReconcileWorkerMessage,
+  { type: "done" | "failed" }
+>["type"];
+
+function countAgentDatabaseLeases(pathname: string): number {
+  // SAFETY: SQLite COUNT(*) always returns one row with the numeric alias requested here.
+  const row = openOpenClawStateDatabase()
+    .db.prepare(
+      `SELECT COUNT(*) AS count
+       FROM agent_database_leases
+       WHERE owner_pid = ? AND path = ?`,
+    )
+    .get(process.pid, pathname) as { count: number };
+  return row.count;
+}
+
+function createCleanupFenceProbe() {
+  const stateDatabase = openOpenClawStateDatabase();
+  let lockHeld = false;
+  let resolvePlanStarted!: () => void;
+  let resolveTerminal!: (type: TerminalType) => void;
+  const planStarted = new Promise<void>((resolve) => {
+    resolvePlanStarted = resolve;
+  });
+  const terminal = new Promise<TerminalType>((resolve) => {
+    resolveTerminal = resolve;
+  });
+  const createWorker = (filename: string | URL, options: WorkerOptions): Worker => {
+    const worker = new Worker(filename, options);
+    // This listener is registered before the reconciler's listener. Holding
+    // the state writer after plan-start fences the worker's lease release.
+    worker.on("message", (message: SessionTranscriptReconcileWorkerMessage) => {
+      if (message.type === "plan-start" && !lockHeld) {
+        stateDatabase.db.exec("BEGIN IMMEDIATE;");
+        lockHeld = true;
+        resolvePlanStarted();
+      }
+      if (message.type === "done" || message.type === "failed") {
+        resolveTerminal(message.type);
+      }
+    });
+    return worker;
+  };
+
+  return {
+    createWorker,
+    planStarted,
+    release(): void {
+      if (!lockHeld) {
+        return;
+      }
+      stateDatabase.db.exec("ROLLBACK;");
+      lockHeld = false;
+    },
+    terminal,
+  };
+}
+
+async function waitForCurrentProjection(databasePath: string, sessionId: string): Promise<void> {
+  const database = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+  await vi.waitFor(
+    () => {
+      expect(
+        database.db
+          .prepare("SELECT needs_rebuild FROM session_transcript_index_state WHERE session_id = ?")
+          .get(sessionId),
+      ).toEqual({ needs_rebuild: 0 });
+    },
+    { interval: 10, timeout: 5_000 },
+  );
+}
+
+describe("session transcript reconcile worker lifecycle", () => {
+  it.each([
+    { expectedTerminal: "done" as const, failAfterFirstPlan: false },
+    { expectedTerminal: "failed" as const, failAfterFirstPlan: true },
+  ])(
+    "releases its database before reporting $expectedTerminal",
+    async ({ expectedTerminal, failAfterFirstPlan }) => {
+      const stateDir = tempDirs.make("openclaw-transcript-worker-cleanup-");
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        const primarySessionId = "cleanup-primary";
+        const primaryScope = {
+          agentId: "main",
+          sessionId: primarySessionId,
+          sessionKey: "agent:main:cleanup-primary",
+        };
+        try {
+          await persistSessionTranscriptTurn(primaryScope, {
+            messages: [
+              {
+                eventId: "primary-message",
+                message: { role: "user", content: "primary" },
+              },
+            ],
+            touchSessionEntry: false,
+          });
+          if (failAfterFirstPlan) {
+            await persistSessionTranscriptTurn(
+              {
+                agentId: "main",
+                sessionId: "cleanup-malformed",
+                sessionKey: "agent:main:cleanup-malformed",
+              },
+              {
+                messages: [
+                  {
+                    eventId: "malformed-message",
+                    message: { role: "user", content: "malformed" },
+                  },
+                ],
+                touchSessionEntry: false,
+              },
+            );
+          }
+          await waitForSessionTranscriptIndexReconcile({ agentId: "main" });
+
+          const database = openOpenClawAgentDatabase({ agentId: "main" });
+          const databasePath = database.path;
+          database.db
+            .prepare(
+              "UPDATE session_transcript_index_state SET needs_rebuild = 1 WHERE session_id = ?",
+            )
+            .run(primarySessionId);
+          if (failAfterFirstPlan) {
+            database.db
+              .prepare(
+                "UPDATE session_transcript_index_state SET needs_rebuild = 1 WHERE session_id = ?",
+              )
+              .run("cleanup-malformed");
+            database.db
+              .prepare(
+                "UPDATE transcript_events SET event_json = '{' WHERE session_id = ? AND seq = 1",
+              )
+              .run("cleanup-malformed");
+          }
+
+          const baselineLeaseCount = countAgentDatabaseLeases(databasePath);
+          expect(baselineLeaseCount).toBe(1);
+          const probe = createCleanupFenceProbe();
+          const outcome = reconcileSessionTranscriptIndexes({
+            agentId: "main",
+            createWorker: probe.createWorker,
+            preferredSessionId: primarySessionId,
+          }).then(
+            (value) => ({ status: "fulfilled" as const, value }),
+            (error: unknown) => ({ status: "rejected" as const, error }),
+          );
+
+          let terminalWhileCleanupWasFenced: TerminalType | undefined;
+          try {
+            await probe.planStarted;
+            expect(countAgentDatabaseLeases(databasePath)).toBe(baselineLeaseCount + 1);
+            await waitForCurrentProjection(databasePath, primarySessionId);
+            terminalWhileCleanupWasFenced = await Promise.race([
+              probe.terminal,
+              delay(1_000).then(() => undefined),
+            ]);
+          } finally {
+            probe.release();
+          }
+
+          const result = await outcome;
+          expect(terminalWhileCleanupWasFenced).toBeUndefined();
+          await expect(probe.terminal).resolves.toBe(expectedTerminal);
+          expect(countAgentDatabaseLeases(databasePath)).toBe(baselineLeaseCount);
+          if (expectedTerminal === "done") {
+            expect(result).toEqual({
+              status: "fulfilled",
+              value: { reconciledSessions: 1 },
+            });
+          } else {
+            expect(result.status).toBe("rejected");
+          }
+        } finally {
+          closeOpenClawAgentDatabasesForTest();
+          closeOpenClawStateDatabaseForTest();
+        }
+      });
+    },
+    20_000,
+  );
+});

--- a/src/config/sessions/session-transcript-reconcile.worker.ts
+++ b/src/config/sessions/session-transcript-reconcile.worker.ts
@@ -169,6 +169,10 @@ async function streamPreparedProjection(plan: PreparedSessionTranscriptProjectio
 }
 
 async function run(): Promise<void> {
+  let terminalMessage: Extract<
+    SessionTranscriptReconcileWorkerMessage,
+    { type: "done" | "failed" }
+  >;
   try {
     const database = openOpenClawAgentDatabase({
       agentId: reconcileInput.agentId,
@@ -184,14 +188,20 @@ async function run(): Promise<void> {
         await streamPreparedProjection(plan);
       }
     }
-    port.postMessage({ type: "done" } satisfies SessionTranscriptReconcileWorkerMessage);
+    terminalMessage = { type: "done" };
   } catch (error) {
-    port.postMessage({
+    terminalMessage = {
       type: "failed",
       error: error instanceof Error ? error.message : String(error),
-    } satisfies SessionTranscriptReconcileWorkerMessage);
-  } finally {
+    };
+  }
+
+  try {
+    // The parent terminates this worker as soon as it receives a terminal
+    // message, so release the durable database lease before reporting one.
     closeOpenClawAgentDatabaseByPath(reconcileInput.path);
+    port.postMessage(terminalMessage);
+  } finally {
     port.close();
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes a lifecycle race where the deferred transcript-reconciliation Worker could publish `done` or `failed` before releasing its durable agent-database lease. The parent immediately terminates the Worker after either terminal message, so the lease row could remain until the Gateway process exited.

Fixes #130161

## Why This Change Was Made

The Worker now computes one terminal result, closes its cached agent database, releases the durable lease, and then publishes that result. Success and failure use the same cleanup-before-terminal path. A cleanup failure cannot publish a false cleanup-complete result.

## User Impact

Deferred transcript reconciliation no longer leaves active-looking lease metadata that can block later agent-database lifecycle work.

## Evidence

- Real process proof used the production transcript persistence and reconciliation owners, a real Node Worker, and a real temporary agent SQLite database.
- On current `main` at `9bd50c803cce88f2ab387ddaf6cc29b4ef004005`, both `done` and `failed` reached the parent while lease cleanup was fenced. The parent settled immediately. An independent process still found one lease, and a real retry/open succeeded but left that lease present.
- On exact head `062bbded12ec99e0247c9af9c6b7b5854f6d677a`, neither terminal result reached the parent while cleanup was fenced. After cleanup, an independent process found zero leases, passed the no-open-lease check, reopened and closed the agent database, and still found zero leases. Both `done` and `failed` paths passed.
- `node scripts/run-vitest.mjs run src/config/sessions/session-transcript-reconcile.lifecycle.test.ts` — 2 passed.
- `node scripts/run-vitest.mjs run src/config/sessions/session-accessor.sqlite-active-events.test.ts src/config/sessions/session-accessor.sqlite-message-cut.test.ts` — 38 passed.
- `node scripts/run-vitest.mjs run src/state/openclaw-agent-db.test.ts -t 'closes only the cached database|retains its durable lease'` — 2 passed.
- Targeted Oxfmt and type-aware Oxlint checks passed. Hosted CI owns the exact-head build and type checks.

AI-assisted: built with Codex
