### PR TITLE
fix(doctor): cron migration ignores agents.defaults.systemAgent under explicit ownership [AI-assisted]

### DIFF
--- a/src/commands/doctor-config-flow.workspace-persistence.test.ts
+++ b/src/commands/doctor-config-flow.workspace-persistence.test.ts
@@ -1,16 +1,52 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import { makeCronJob } from "../cron/delivery.test-helpers.js";
+import { cronStoreKey } from "../cron/store/key.js";
+import { loadCronRows } from "../cron/store/row-codec.js";
 import {
   runInitialConfigWriteHealth,
   runWriteConfigHealth,
 } from "../flows/doctor-health-contribution-runners.config.js";
 import type { DoctorHealthFlowContext } from "../flows/doctor-health-contribution-types.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
 import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
+
+async function prepareDoctorContext(configPath: string): Promise<DoctorHealthFlowContext> {
+  const runtime: RuntimeEnv = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
+  const options: DoctorOptions = { nonInteractive: true, repair: true };
+  const prompter = createDoctorPrompter({ runtime, options });
+  const configResult = await loadAndMaybeMigrateDoctorConfig({
+    options,
+    confirm: (params) => prompter.confirm(params),
+    runtime,
+    prompter,
+  });
+  return {
+    runtime,
+    options,
+    prompter,
+    configResult,
+    cfg: configResult.cfg,
+    cfgForPersistence: structuredClone(configResult.cfg),
+    sourceConfigValid: configResult.sourceConfigValid ?? true,
+    configPath,
+    stateDirExistedAtStart: true,
+    ...(configResult.runWithPluginMetadataSnapshot
+      ? { runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot }
+      : {}),
+    ...(configResult.invalidatePluginMetadataSnapshot
+      ? { invalidatePluginMetadataSnapshot: configResult.invalidatePluginMetadataSnapshot }
+      : {}),
+  };
+}
 
 describe("Doctor workspace persistence", () => {
   afterEach(() => {
@@ -30,37 +66,9 @@ describe("Doctor workspace persistence", () => {
             },
           },
           gateway: { mode: "local" },
+          plugins: { enabled: false },
         });
-        const runtime: RuntimeEnv = {
-          error: vi.fn(),
-          exit: vi.fn(),
-          log: vi.fn(),
-        };
-        const options: DoctorOptions = { nonInteractive: true, repair: true };
-        const prompter = createDoctorPrompter({ runtime, options });
-        const configResult = await loadAndMaybeMigrateDoctorConfig({
-          options,
-          confirm: (params) => prompter.confirm(params),
-          runtime,
-          prompter,
-        });
-        const ctx: DoctorHealthFlowContext = {
-          runtime,
-          options,
-          prompter,
-          configResult,
-          cfg: configResult.cfg,
-          cfgForPersistence: structuredClone(configResult.cfg),
-          sourceConfigValid: configResult.sourceConfigValid ?? true,
-          configPath,
-          stateDirExistedAtStart: true,
-          ...(configResult.runWithPluginMetadataSnapshot
-            ? { runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot }
-            : {}),
-          ...(configResult.invalidatePluginMetadataSnapshot
-            ? { invalidatePluginMetadataSnapshot: configResult.invalidatePluginMetadataSnapshot }
-            : {}),
-        };
+        const ctx = await prepareDoctorContext(configPath);
 
         await runInitialConfigWriteHealth(ctx);
         expect((await readConfigFileSnapshot()).config.agents?.entries?.main?.workspace).toBe(
@@ -78,6 +86,78 @@ describe("Doctor workspace persistence", () => {
         expect(snapshot.config.agents?.ownership).toBe("explicit");
         expect(snapshot.config.agents?.entries?.main?.workspace).toBe(workspace);
       });
+    });
+  });
+
+  it("persists cron runtime policy on the retained owner before rewriting its model", async () => {
+    await withTempHome(async (home) => {
+      const stateDir = path.join(home, ".openclaw");
+      await withEnvOverride(
+        { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1", OPENCLAW_STATE_DIR: stateDir },
+        async () => {
+          const configPath = await writeOpenClawConfig(home, {
+            agents: {
+              defaults: { systemAgent: { agentId: "ops" } },
+              entries: { main: { default: true }, ops: {} },
+            },
+            gateway: { mode: "local" },
+            plugins: { enabled: false },
+          });
+          const storePath = path.join(stateDir, "cron", "jobs.json");
+          await fs.mkdir(path.dirname(storePath), { recursive: true });
+          await fs.writeFile(
+            storePath,
+            JSON.stringify({
+              version: 1,
+              jobs: [
+                makeCronJob({
+                  id: "retained-owner",
+                  enabled: false,
+                  payload: {
+                    kind: "agentTurn",
+                    message: "Do not run this disabled job",
+                    model: "codex/gpt-5.6-sol",
+                  },
+                }),
+              ],
+            }),
+          );
+
+          let firstPolicies: unknown;
+          let firstRows: unknown;
+          for (const pass of [1, 2]) {
+            const ctx = await prepareDoctorContext(configPath);
+            await runInitialConfigWriteHealth(ctx);
+            await runWriteConfigHealth(ctx);
+            const snapshot = await readConfigFileSnapshot();
+            const policies = {
+              main: snapshot.config.agents?.entries?.main?.models,
+              ops: snapshot.config.agents?.entries?.ops?.models,
+            };
+            const rows = loadCronRows(openOpenClawStateDatabase().db, cronStoreKey(storePath));
+            expect.soft(snapshot.valid, `pass ${pass}`).toBe(true);
+            expect.soft(snapshot.config.agents?.defaults?.systemAgent?.agentId).toBe("ops");
+            expect.soft(policies, `pass ${pass}`).toEqual({
+              main: { "openai/gpt-5.6-sol": { agentRuntime: { id: "codex" } } },
+              ops: undefined,
+            });
+            expect.soft(rows).toHaveLength(1);
+            expect.soft(rows[0]?.agent_id).toBe("main");
+            expect
+              .soft(
+                rows.map((row) => JSON.parse(row.job_json)),
+                `pass ${pass}`,
+              )
+              .toMatchObject([{ agentId: "main", payload: { model: "openai/gpt-5.6-sol" } }]);
+            if (pass === 2) {
+              expect.soft(policies).toEqual(firstPolicies);
+              expect.soft(rows).toEqual(firstRows);
+            }
+            firstPolicies = policies;
+            firstRows = rows;
+          }
+        },
+      );
     });
   });
 });

--- a/src/commands/doctor/cron/legacy-repair.test.ts
+++ b/src/commands/doctor/cron/legacy-repair.test.ts
@@ -15,36 +15,67 @@ afterEach(async () => {
   }
 });
 
-it("projects a canonical agent-less row through the runtime default", async () => {
-  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-owner-projection-"));
-  const storePath = path.join(tempRoot, "cron", "jobs.json");
-  await saveCronStore(storePath, {
-    version: 1,
-    jobs: [
-      {
-        id: "dynamic-default",
-        name: "Dynamic default",
-        enabled: true,
-        createdAtMs: 1,
-        updatedAtMs: 1,
-        schedule: { kind: "every", everyMs: 60_000 },
-        sessionTarget: "isolated",
-        wakeMode: "now",
-        payload: { kind: "agentTurn", message: "run" },
-        state: {},
-      },
-    ],
-  });
-
-  const cfg = {
-    cron: { store: storePath },
+it.each<{
+  name: string;
+  agents: NonNullable<OpenClawConfig["agents"]>;
+  agentId?: string;
+  expectedOwner: { kind: "runtime-default" | "explicit"; agentId: string };
+}>([
+  {
+    name: "sole configured agent",
     agents: { entries: { ops: {} } },
-  } as OpenClawConfig;
-  const state = await loadLegacyCronRepairState({ cfg, storePath, readOnly: true });
+    expectedOwner: { kind: "runtime-default", agentId: "ops" },
+  },
+  {
+    name: "configured system agent under explicit ownership",
+    agents: {
+      ownership: "explicit",
+      defaults: { systemAgent: { agentId: "ops" } },
+      entries: { main: {}, ops: {} },
+    },
+    expectedOwner: { kind: "runtime-default", agentId: "ops" },
+  },
+  {
+    name: "explicit job owner before the configured system agent",
+    agents: {
+      ownership: "explicit",
+      defaults: { systemAgent: { agentId: "ops" } },
+      entries: { main: {}, ops: {} },
+    },
+    agentId: "main",
+    expectedOwner: { kind: "explicit", agentId: "main" },
+  },
+])(
+  "projects the $name without changing the stored owner",
+  async ({ agents, agentId, expectedOwner }) => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-owner-projection-"));
+    const storePath = path.join(tempRoot, "cron", "jobs.json");
+    await saveCronStore(storePath, {
+      version: 1,
+      jobs: [
+        {
+          id: "dynamic-default",
+          agentId,
+          name: "Dynamic default",
+          enabled: true,
+          createdAtMs: 1,
+          updatedAtMs: 1,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "isolated",
+          wakeMode: "now",
+          payload: { kind: "agentTurn", message: "run" },
+          state: {},
+        },
+      ],
+    });
 
-  expect(state?.projectedOwnersByJobId.get("dynamic-default")).toEqual({
-    kind: "runtime-default",
-    agentId: "ops",
-  });
-  expect(state?.rawJobs[0]?.agentId).toBeUndefined();
-});
+    const cfg = {
+      cron: { store: storePath },
+      agents,
+    } as OpenClawConfig;
+    const state = await loadLegacyCronRepairState({ cfg, storePath, readOnly: true });
+
+    expect(state?.rawJobs[0]?.agentId).toBe(agentId);
+    expect(state?.projectedOwnersByJobId.get("dynamic-default")).toEqual(expectedOwner);
+  },
+);

--- a/src/commands/doctor/cron/legacy-repair.ts
+++ b/src/commands/doctor/cron/legacy-repair.ts
@@ -1,6 +1,6 @@
 // Doctor cron storage repair mechanics for legacy stores, run logs, payloads, and Codex refs.
 import { normalizeOptionalString } from "../../../../packages/normalization-core/src/string-coerce.js";
-import { tryResolveLegacyCompatibilityAgentId } from "../../../agents/agent-scope-config.js";
+import { tryResolveAmbientOwnerAgentId } from "../../../agents/agent-scope-config.js";
 import { formatCliCommand } from "../../../cli/command-format.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
@@ -134,7 +134,7 @@ export async function loadLegacyCronRepairState(params: {
   const loaded = params.readOnly
     ? await loadCronJobsStoreWithConfigJobsReadOnly(storePath, params.env)
     : await loadCronJobsStoreWithConfigJobs(storePath);
-  const runtimeDefaultAgentId = tryResolveLegacyCompatibilityAgentId(params.cfg);
+  const runtimeDefaultAgentId = tryResolveAmbientOwnerAgentId(params.cfg);
   const projectedOwnersByJobId = new Map(
     loaded.store.jobs.map((job) => [job.id, projectCronOwner(job, runtimeDefaultAgentId)]),
   );

--- a/src/commands/doctor/cron/runtime-policy-migration.ts
+++ b/src/commands/doctor/cron/runtime-policy-migration.ts
@@ -1,6 +1,10 @@
 // Doctor-only runtime policy repair for migrated cron Codex model refs.
 import { asOptionalRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
-import { tryResolveDefaultAgentId } from "../../../agents/agent-scope-config.js";
+import { tryResolveAmbientOwnerAgentId } from "../../../agents/agent-scope-config.js";
+import {
+  inheritLegacyDefaultAgentId,
+  tryGetLegacyDefaultAgentId,
+} from "../../../config/legacy.default-agent-owner.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { normalizeAgentId } from "../../../routing/session-key.js";
 import {
@@ -31,7 +35,12 @@ function resolvePolicyOwner(params: {
   const requestedAgentId = params.target.agentId
     ? normalizeAgentId(params.target.agentId)
     : undefined;
-  const defaultAgentId = tryResolveDefaultAgentId(params.cfg);
+  // The roster writer pins ownerless jobs to the retained legacy owner.
+  // Plan policy for that durable owner, which can differ from the system agent.
+  const defaultAgentId = tryResolveAmbientOwnerAgentId(
+    params.cfg,
+    tryGetLegacyDefaultAgentId(params.cfg),
+  );
   const effectiveAgentId = requestedAgentId ?? defaultAgentId;
   if (!effectiveAgentId) {
     return undefined;
@@ -79,7 +88,7 @@ export function repairCronCodexRuntimePolicies(params: {
       changedTargets: [],
     };
   }
-  const next = structuredClone(params.cfg);
+  const next = inheritLegacyDefaultAgentId(params.cfg, structuredClone(params.cfg));
   const changes: string[] = [];
   const warnings: string[] = [];
   const blockedTargets: CronCodexRuntimePolicyTarget[] = [];

--- a/src/commands/doctor/cron/store-migration.test.ts
+++ b/src/commands/doctor/cron/store-migration.test.ts
@@ -2,6 +2,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import { resolveAgentHarnessPolicy } from "../../../agents/harness/policy.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { legacyCodexProviderIdentityKey } from "../shared/codex-route-model-ref.js";
 import {
   IMAGE_INSPECTION_TOOL_NAME_MIGRATION,
@@ -452,10 +453,46 @@ describe("normalizeStoredCronJobs", () => {
     expect((job.payload as Record<string, unknown>).model).toBe("openai/gpt-5.6-sol");
   });
 
-  it("writes the configured default agent policy to its canonical keyed entry", () => {
+  it.each<{
+    name: string;
+    agents: NonNullable<OpenClawConfig["agents"]>;
+    agentId?: string;
+    expectedAgentId: string;
+  }>([
+    {
+      name: "configured default agent",
+      agents: { entries: { main: { default: true } } },
+      expectedAgentId: "main",
+    },
+    {
+      name: "sole configured agent",
+      agents: { entries: { ops: {} } },
+      expectedAgentId: "ops",
+    },
+    {
+      name: "configured system agent under explicit ownership",
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "ops" } },
+        entries: { main: {}, ops: {} },
+      },
+      expectedAgentId: "ops",
+    },
+    {
+      name: "explicit job owner before the configured system agent",
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "ops" } },
+        entries: { main: {}, ops: {} },
+      },
+      agentId: "main",
+      expectedAgentId: "main",
+    },
+  ])("writes policy only to the $name", ({ agents, agentId, expectedAgentId }) => {
     const jobs = [
       makeLegacyJob({
         id: "implicit-default-codex-model",
+        agentId,
         schedule: { kind: "every", everyMs: 60_000 },
         payload: {
           kind: "agentTurn",
@@ -465,14 +502,22 @@ describe("normalizeStoredCronJobs", () => {
       }),
     ];
     const policyRepair = repairCronCodexRuntimePolicies({
-      cfg: { agents: { entries: { main: { default: true } } } },
+      cfg: { agents },
       targets: collectStoredCronCodexRuntimePolicyTargets(jobs),
     });
 
-    expect(policyRepair.config.agents?.entries?.main?.models).toMatchObject({
+    expect(jobs[0]?.agentId).toBe(agentId);
+    expect(policyRepair.config.agents?.entries?.[expectedAgentId]?.models).toEqual({
       "openai/gpt-5.6-sol": { agentRuntime: { id: "codex" } },
     });
+    for (const [entryId, entry] of Object.entries(policyRepair.config.agents?.entries ?? {})) {
+      if (entryId !== expectedAgentId) {
+        expect(entry.models).toBeUndefined();
+      }
+    }
     expect(policyRepair.config.agents?.defaults?.models).toBeUndefined();
+    expect(policyRepair.warnings).toEqual([]);
+    expect(policyRepair.blockedTargets).toEqual([]);
   });
 
   it("retains a post-snapshot Codex ref until its runtime policy is persisted", () => {


### PR DESCRIPTION
Closes #130019

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can update this branch.

</details>

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --fix` could leave legacy cron model migration blocked, or write runtime policy to the wrong agent, when an explicit fleet names a system agent other than `main`.

A related upgrade case needs the same ownership discipline: when doctor retires a legacy default-owner marker, the retained cron owner can differ from the configured system agent. The migration must finish correctly on the first pass without leaving unnecessary policy on another agent.

## Why This Change Was Made

Doctor now uses the existing ambient-owner resolver for ordinary ownerless cron jobs. During legacy roster retirement, its policy planner preserves the existing retained-owner fact across cloning and uses the owner that the config writer will durably assign. Explicit job owners still win; raw target identities, runtime routing, the store materializer, and SQLite schemas are unchanged.

This retains Sean Bennett's (@8exgh) original repair and adds the ordered upgrade regression found during maintainer review. Thanks also to @josephbergvinson for reporting the issue.

Production LOC: +14/-5 (net +9). Tests: +221/-65 (net +156). The additional production lines carry the existing upgrade-only ownership fact and explain the persistence-order invariant; they add no new config, fallback, or storage path.

## User Impact

Doctor installs cron model policy on the correct agent and can complete the model-reference migration in one pass. Ownerless jobs in an explicit fleet remain dynamically owned; only the existing legacy-roster migration materializes a retained owner. A second doctor pass leaves the repaired ownership, policy, and cron rows unchanged.

## Evidence

- Independently reproduced both original owner-selection failures on trusted main: two intended failures and 42 passing controls. The focused projection and policy suites then passed after repair.
- A real config-writer/SQLite integration test exposed the retained-owner ordering defect in the initial proposal: first-pass policy on `ops`, persisted job on `main`, legacy model unchanged; the second pass added another policy and rewrote the job. Repeated the failure with plugins disabled, then verified first-pass correctness and second-pass stability after preserving the retained-owner fact.
- All 46 focused tests pass across `legacy-repair.test.ts`, `store-migration.test.ts`, and `doctor-config-flow.workspace-persistence.test.ts`. Coverage includes configured system, sole, explicit job, and retained legacy owners.
- Full canonical five-path `check:changed` passed, including core types, all 14 core-test typecheck shards, changed-file lint, and repository guards. An initial shared-dependency attempt resolved UI `pako` 1.0.11 instead of pinned 3.0.1; a fresh frozen-lockfile install in the isolated task checkout resolved that environment issue. No dependency or lockfile changes are included.
- Fresh structured Codex review and a separate enforced-read-only Codex review found no actionable findings after the ordered regression was repaired.
- A fresh candidate build passed, followed by six actual `doctor --fix --yes --non-interactive` CLI runs: three isolated scenarios, each run twice. The ambient case placed policy on `ops` while preserving the raw ownerless row; the explicit-owner case used `main`; the retained legacy-owner case materialized `main` and installed policy there despite system agent `ops`. All model references were canonical after the first pass, with no sibling/global policy pollution and identical second-pass model-policy and persisted-job snapshots. Source and built-artifact hashes stayed unchanged throughout. Jobs and plugins were disabled: this proves doctor migration, not scheduled model execution or plugin provisioning.
- The isolated CLI still reports expected disabled-plugin and unreachable-test-Gateway diagnostics. Named follow-up: doctor prints its pre-repair cron model warning on the first pass even though the final persisted row is normalized; the second pass no longer prints it. This PR does not claim warning cleanup or complete environment health.
- Current-main comparison: the five changed files and canonical ownership helpers are unchanged between the independently reproduced base `b4d6aff0988bf6c761275334141a916c1687b4c6` and main `d18b0a966141afda6dc7848d6d7029190aaf2441`. The nearby keyed-entry model normalization does not change ownership.
- **PENDING before merge:** required CI on the published exact head. This and the current-main comparison address the latest ClawSweeper rank-up move. A fresh review will be requested for the strengthened upgrade repair.
