### PR TITLE
test(scripts): pin assertion-ratchet SAFETY-comment scanner fix

### DIFF
--- a/test/scripts/check-assertion-safety-ratchet.test.ts
+++ b/test/scripts/check-assertion-safety-ratchet.test.ts
@@ -79,6 +79,21 @@ describe("check-assertion-safety-ratchet", () => {
     expect(isGovernedAssertionSourcePath("scripts/example.ts")).toBe(false);
   });
 
+  it("recognizes SAFETY comments after template substitutions and division", () => {
+    // A raw skipTrivia scanner never re-scans the `}` ending a template
+    // substitution, so the closing backtick opened a phantom template that
+    // swallowed every later comment; this pins the line-text approach.
+    const source = [
+      "const label = `count ${total} items`;",
+      "const half = total / 2;",
+      "// SAFETY: the schema parser established Shape.",
+      "const safe = value as Shape;",
+      "const unsafe = value as Shape;",
+    ].join("\n");
+
+    expect(countUnsafeAssertions(source, "src/example.ts")).toBe(1);
+  });
+
   it("blocks new debt, accepts SAFETY comments, and prunes reduced counts", () => {
     const root = tempDirs.make("openclaw-assertion-safety-");
     fs.mkdirSync(path.join(root, "config"), { recursive: true });


### PR DESCRIPTION
## What Problem This Solves

`collectSafetyCommentLines` in `scripts/check-assertion-safety-ratchet.mts` had zero regression coverage for the exact bug that motivated its rewrite in #129769: a raw `ts.createScanner(..., skipTrivia=false, ...)` pass never re-scans the `}` that ends a template substitution, so it lexes a phantom `NoSubstitutionTemplateLiteral` starting at the template's closing backtick and swallows every later comment in the file — including `// SAFETY:` comments that should exempt real assertions from the ratchet.

## Why This Change Was Made

#129769 already replaced the token scanner with per-line text matching and fixed the bug, but shipped without a test pinning the fix. Every existing test in the file passes equally well against the pre-fix scanner code, so a future refactor could reintroduce token-based scanning and nothing would catch it.

## User Impact

Test-only; no production behavior change.

## Evidence

- Added `test/scripts/check-assertion-safety-ratchet.test.ts`: a source with a template substitution and a division operator ahead of a SAFETY-commented assertion, plus one genuinely uncommented assertion.
- Verified the regression test fails on the pre-fix scanner: temporarily swapped in the `4bd88591264^` version of `check-assertion-safety-ratchet.mts`, ran the new test (fails: counts 2 instead of 1 because the SAFETY comment gets swallowed), then restored the current script (diff empty afterward).
- `node scripts/run-vitest.mjs test/scripts/check-assertion-safety-ratchet.test.ts` — 5/5 pass on current `main` code.
- `node scripts/check-changed.mjs -- test/scripts/check-assertion-safety-ratchet.test.ts` — test-root typecheck, scripts lint, boundary guards all pass.
- `node --import tsx scripts/check-assertion-safety-ratchet.mts` — ratchet green: `4248 files, 13304 grandfathered assertions`, no stale baseline entries.
- Autoreview (Codex, gpt-5.6-sol, high): clean, no accepted findings, patch correctness 0.99.
