### PR TITLE
refactor(openai): inline non-negative config ranges

### DIFF
--- a/extensions/openai/realtime-transcription-provider.ts
+++ b/extensions/openai/realtime-transcription-provider.ts
@@ -131,13 +131,9 @@ function normalizeProviderConfig(
     language: normalizeOptionalString(raw?.language),
     model: normalizeOptionalString(raw?.model) ?? normalizeOptionalString(raw?.sttModel),
     prompt: normalizeOptionalString(raw?.prompt),
-    silenceDurationMs: normalizeNonNegativeInteger(raw?.silenceDurationMs),
+    silenceDurationMs: asSafeIntegerInRange(raw?.silenceDurationMs, { min: 0 }),
     vadThreshold: normalizeVadThreshold(raw?.vadThreshold),
   };
-}
-
-function normalizeNonNegativeInteger(value: unknown): number | undefined {
-  return asSafeIntegerInRange(value, { min: 0 });
 }
 
 function normalizeVadThreshold(value: unknown): number | undefined {

--- a/extensions/openai/realtime-voice-session-policy.ts
+++ b/extensions/openai/realtime-voice-session-policy.ts
@@ -242,22 +242,18 @@ export function normalizeProviderConfig(
     voice: normalizeOpenAIRealtimeVoice(raw?.speakerVoice ?? raw?.voice),
     temperature: asFiniteNumber(raw?.temperature),
     vadThreshold: asUnitInterval(raw?.vadThreshold),
-    silenceDurationMs: asNonNegativeInteger(raw?.silenceDurationMs),
-    prefixPaddingMs: asNonNegativeInteger(raw?.prefixPaddingMs),
+    silenceDurationMs: asSafeIntegerInRange(raw?.silenceDurationMs, { min: 0 }),
+    prefixPaddingMs: asSafeIntegerInRange(raw?.prefixPaddingMs, { min: 0 }),
     interruptResponseOnInputAudio:
       typeof raw?.interruptResponseOnInputAudio === "boolean"
         ? raw.interruptResponseOnInputAudio
         : undefined,
-    minBargeInAudioEndMs: asNonNegativeInteger(raw?.minBargeInAudioEndMs),
+    minBargeInAudioEndMs: asSafeIntegerInRange(raw?.minBargeInAudioEndMs, { min: 0 }),
     reasoningEffort: normalizeOptionalString(raw?.reasoningEffort),
     azureEndpoint: normalizeOptionalString(raw?.azureEndpoint),
     azureDeployment: normalizeOptionalString(raw?.azureDeployment),
     azureApiVersion: normalizeOptionalString(raw?.azureApiVersion),
   };
-}
-
-function asNonNegativeInteger(value: unknown): number | undefined {
-  return asSafeIntegerInRange(value, { min: 0 });
 }
 
 function asUnitInterval(value: unknown): number | undefined {


### PR DESCRIPTION
## What Problem This Solves

Two OpenAI realtime config paths each keep a private wrapper around the same
canonical non-negative safe-integer coercion. That duplication obscures the
actual shared contract and creates unnecessary local policy names.

## Why This Change Was Made

Inline `asSafeIntegerInRange(value, { min: 0 })` at the four owning config
fields and delete both one-call wrappers. This preserves the existing plugin
boundary and adds no SDK surface.

## User Impact

No user-visible behavior changes. OpenAI realtime timing config keeps the same
number-only, safe-integer, and non-negative validation.

## Evidence

- Exact pushed head: `ed5631b83eaebd37f4f82a65b378ea2da1c27a06`
- `pnpm native:i18n:check` passed after rebasing onto the native-locale refresh on current main.
- `node scripts/run-vitest.mjs extensions/openai/realtime-transcription-provider.test.ts extensions/openai/realtime-voice-provider-routing.test.ts` - 63 tests passed.
- `node scripts/check-changed.mjs` passed in the native PR worktree after a frozen install of the exact current lockfile.
- Fresh Autoreview: clean, 0.99, no actionable findings.
- AWS Crabbox run `run_c2a1e3f387f4`, lease `cbx_6d30b61bd910`: fresh public-network checkout, no instance role, no Tailscale, no hydration, frozen install, exact head `ed5631b83eaebd37f4f82a65b378ea2da1c27a06`, 63/63 focused tests passed. Lease released after proof.
- The trusted bootstrap was uploaded with a transient `umask 022` insertion because the current AWS image otherwise creates its Node install root as root-only and cannot expose the pinned binaries to the unprivileged test user. This is a Crabbox bootstrap follow-up, not a branch change.

Root cause: two owner-local one-call wrappers duplicate the canonical range-coercion expression without adding policy.

Architectural owner and canonical fix: the OpenAI realtime config fields now call the existing normalization helper directly.

Removed paths: `asNonNegativeInteger` and `normalizeNonNegativeInteger`.

Production LOC: +4/-12, net -8. Tests: +0/-0.

Sibling coverage: transcription and realtime voice routing tests cover all four migrated fields and retain their existing invalid-value behavior.

Changelog: not required for an internal behavior-neutral refactor.

AI-assisted: yes.
