### PR TITLE
fix(telegram): show buttonless ask-user prompts

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -329,6 +329,7 @@ export async function deliverReply(
       const canRepresentAsTransientProgress =
         !reply.hasMedia &&
         telegramButtons === undefined &&
+        effectivePayload.channelData?.askUser === undefined &&
         !hasExecApprovalPayload(effectivePayload);
       const isFastModeProgressPayload = isFastModeAutoProgressPayload(effectivePayload);
       if (turn.streamMode === "progress") {

--- a/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
@@ -479,6 +479,27 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
     expect(finalText.length).toBeLessThanOrEqual(80);
   });
 
+  it("delivers buttonless ask_user prompts outside transient progress", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        {
+          text: "Pick one or more",
+          channelData: {
+            askUser: { questionId: "ask_0123456789abcdef0123456789abcdef" },
+          },
+        },
+        { kind: "tool" },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "progress" });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Pick one or more");
+    expect(registerChannelDelivery).toHaveBeenCalledOnce();
+  });
+
   it("streams interactive buttons into the same message", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram users never received ask-user prompts without native buttons, including multi-question prompts, when progress streaming was active.

## Why This Change Was Made

Telegram classified buttonless ask-user tool replies as transient progress. The delivery owner now keeps ask-user payloads out of that transient path, so the existing durable question flow sends and registers them.

## User Impact

Telegram users can see and answer ask-user prompts that require a text reply. Single-choice prompts with native buttons keep their existing behavior.

## Evidence

- Exact head: `cc44a6e9c6442ded0ef6402a96fe122b67f51e35`.
- Before: the owner-boundary regression failed because progress mode did not update the Telegram draft with the question.
- After: 78 focused tests pass across progress rendering, draft rotation, interactive fallback, question finalization, and stream-mode defaults.
- Changed gates: formatter, extension lint, plugin boundaries, dependency guards, dead-code checks, storage guards, and import-cycle checks passed.
- Production delta: +1 line. Regression test delta: +21 lines.
- Open PR search found no overlapping Telegram ask-user delivery fix.

### Real Telegram user proof

The canonical Telegram userbot ran against the exact CI-built runtime from Actions run `32987870998`.

- At 5.052 seconds, the bot delivered the full 590-character, three-question text prompt with no native buttons.
- At 8.384 seconds, the real Telegram user replied with `Production`, `Unit (Recommended), Lint`, and `Urgent`.
- The bot edited the prompt to `Answered: Production, Urgent`, then sent the final answer at 12.706 seconds.
- Recorded side effects: typing events, two prompt edits, one final message, and deletion of the transient prompt at 14.474 seconds.
- Gateway evidence recorded the inbound messages, the 7.615-second `question.waitAnswer`, and the successful Telegram outbound send.
