### PR TITLE
docs(himalaya): update v2.1 configuration examples

### DIFF
--- a/skills/himalaya/SKILL.md
+++ b/skills/himalaya/SKILL.md
@@ -35,8 +35,12 @@ Use `himalaya` for IMAP/SMTP email from shell.
 
 ```bash
 himalaya --version
-himalaya account configure
+himalaya
 ```
+
+For Himalaya v2.1+, the bare command opens the account wizard and prints the
+current TOML configuration. Save or merge that output into the config path
+below before running the account checks.
 
 Config path: `~/.config/himalaya/config.toml`.
 

--- a/skills/himalaya/references/configuration.md
+++ b/skills/himalaya/references/configuration.md
@@ -2,6 +2,9 @@
 
 Configuration file location: `~/.config/himalaya/config.toml`
 
+> **Compatibility:** This guide follows the Himalaya v2.1+ config schema. Check
+> `himalaya --version` before applying examples from older guides.
+
 ## Minimal IMAP + SMTP Setup
 
 ```toml
@@ -11,46 +14,41 @@ display-name = "Your Name"
 default = true
 
 # IMAP backend for reading emails
-backend.type = "imap"
-backend.host = "imap.example.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "user@example.com"
-backend.auth.type = "password"
-backend.auth.raw = "your-password"
+imap.server = "imaps://imap.example.com:993"
+imap.sasl.plain.username = "user@example.com"
+imap.sasl.plain.password.raw = "your-password"
 
 # SMTP backend for sending emails
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.example.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "user@example.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.raw = "your-password"
+smtp.server = "smtp://smtp.example.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "user@example.com"
+smtp.sasl.plain.password.raw = "your-password"
 ```
+
+**Schema notes (v2.1+):** `imap.server` and `smtp.server` use protocol URLs;
+`imaps://` and `smtps://` enable implicit TLS, while `imap://` and `smtp://`
+can use STARTTLS. Authentication is configured under the protocol-specific
+SASL tables.
 
 ## Password Options
 
 ### Raw password (testing only, not recommended)
 
 ```toml
-backend.auth.raw = "your-password"
+imap.sasl.plain.password.raw = "your-password"
+smtp.sasl.plain.password.raw = "your-password"
 ```
 
 ### Password from command (recommended)
 
 ```toml
-backend.auth.cmd = "pass show email/imap"
-# backend.auth.cmd = "security find-generic-password -a user@example.com -s imap -w"
+imap.sasl.plain.password.command = "pass show email/imap"
+smtp.sasl.plain.password.command = "pass show email/smtp"
+# imap.sasl.plain.password.command = "security find-generic-password -a user@example.com -s imap -w"
 ```
 
-### System keyring (requires keyring feature)
-
-```toml
-backend.auth.keyring = "imap-example"
-```
-
-Then run `himalaya account configure <account>` to store the password.
+Himalaya v2 reads command output for credentials; use a password manager or
+keyring CLI rather than putting secrets in the TOML file.
 
 ## Gmail Configuration
 
@@ -60,21 +58,14 @@ email = "you@gmail.com"
 display-name = "Your Name"
 default = true
 
-backend.type = "imap"
-backend.host = "imap.gmail.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@gmail.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show google/app-password"
+imap.server = "imaps://imap.gmail.com:993"
+imap.sasl.plain.username = "you@gmail.com"
+imap.sasl.plain.password.command = "pass show google/app-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.gmail.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@gmail.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show google/app-password"
+smtp.server = "smtp://smtp.gmail.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@gmail.com"
+smtp.sasl.plain.password.command = "pass show google/app-password"
 ```
 
 **Note:** Gmail requires an App Password if 2FA is enabled.
@@ -86,21 +77,14 @@ message.send.backend.auth.cmd = "pass show google/app-password"
 email = "you@icloud.com"
 display-name = "Your Name"
 
-backend.type = "imap"
-backend.host = "imap.mail.me.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@icloud.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show icloud/app-password"
+imap.server = "imaps://imap.mail.me.com:993"
+imap.sasl.plain.username = "you@icloud.com"
+imap.sasl.plain.password.command = "pass show icloud/app-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.mail.me.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@icloud.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show icloud/app-password"
+smtp.server = "smtp://smtp.mail.me.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@icloud.com"
+smtp.sasl.plain.password.command = "pass show icloud/app-password"
 ```
 
 **Note:** Generate an app-specific password at appleid.apple.com
@@ -110,11 +94,11 @@ message.send.backend.auth.cmd = "pass show icloud/app-password"
 Map custom folder names:
 
 ```toml
-[accounts.default.folder.alias]
-inbox = "INBOX"
-sent = "Sent"
-drafts = "Drafts"
-trash = "Trash"
+[accounts.default]
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash = "Trash"
 ```
 
 ## Multiple Accounts
@@ -136,27 +120,25 @@ Switch accounts with `--account`:
 himalaya --account work envelope list
 ```
 
-## Notmuch Backend (local mail)
+## OAuth2 / token authentication
 
 ```toml
-[accounts.local]
-email = "user@example.com"
+[accounts.gmail-oauth]
+email = "you@gmail.com"
 
-backend.type = "notmuch"
-backend.db-path = "~/.mail/.notmuch"
+imap.server = "imaps://imap.gmail.com:993"
+imap.sasl.xoauth2.username = "you@gmail.com"
+imap.sasl.xoauth2.token.command = ["pass", "show", "gmail/xoauth2-token"]
+
+smtp.server = "smtp://smtp.gmail.com:587"
+smtp.starttls = true
+smtp.sasl.xoauth2.username = "you@gmail.com"
+smtp.sasl.xoauth2.token.command = ["pass", "show", "gmail/xoauth2-token"]
 ```
 
-## OAuth2 Authentication (for providers that support it)
-
-```toml
-backend.auth.type = "oauth2"
-backend.auth.client-id = "your-client-id"
-backend.auth.client-secret.cmd = "pass show oauth/client-secret"
-backend.auth.access-token.cmd = "pass show oauth/access-token"
-backend.auth.refresh-token.cmd = "pass show oauth/refresh-token"
-backend.auth.auth-url = "https://provider.com/oauth/authorize"
-backend.auth.token-url = "https://provider.com/oauth/token"
-```
+Himalaya v2 does not manage OAuth flows or refresh tokens. Use a token broker
+or password manager command and provide the resulting token through the
+protocol-specific SASL table.
 
 ## Additional Options
 
@@ -182,3 +164,11 @@ Set via environment variable:
 ```bash
 export EDITOR="vim"
 ```
+
+## Troubleshooting
+
+If `himalaya account check` reports `No backend matching \`auto\` is
+configured`, first check the version and schema. Himalaya v2.1+ expects
+protocol-specific `imap.server`, `smtp.server`, and SASL keys; the older
+nested backend and message.send.backend keys can parse as TOML without
+configuring a usable backend.


### PR DESCRIPTION
Closes #129034

## What Problem This Solves

Fixes an issue where users following the bundled Himalaya configuration guide would create a TOML file with the pre-2.1 `backend.*` schema, leaving current Himalaya without a usable IMAP or SMTP backend.

## Why This Change Was Made

Update the bundled setup examples and password/token guidance to the current Himalaya v2.1+ `imap.*`, `smtp.*`, and SASL tables. The skill entry point now uses the v2.1+ wizard command and the reference includes a version boundary plus troubleshooting guidance for the old backend error.

## User Impact

Users can copy the bundled IMAP, SMTP, Gmail, iCloud, mailbox-alias, and token-auth examples into a current Himalaya configuration without relying on removed schema keys.

## Evidence

- Compared the final examples with the official Himalaya v2.1.0 `config.sample.toml` and v2.1.0 README contract: `imap.server`, `smtp.server`, protocol-specific SASL credentials, mailbox aliases, and token commands are documented with current keys.
- `pnpm docs:list` passed.
- `oxfmt --check skills/himalaya/SKILL.md skills/himalaya/references/configuration.md` passed.
- `git diff --check` passed.
- Exact head: `8456435ccea3429e1464997c6ff41216d013fc59`.

Proof boundary: this documentation change does not claim live mailbox authentication, message delivery, or provider-specific connectivity.
