### PR TITLE
refactor(lmstudio): unify catalog discovery provider assembly

### DIFF
--- a/extensions/lmstudio/src/setup.ts
+++ b/extensions/lmstudio/src/setup.ts
@@ -990,21 +990,15 @@ export async function discoverLmstudioProvider(ctx: ProviderCatalogContext): Pro
   const hasExplicitModels = Array.isArray(explicit?.models) && explicit.models.length > 0;
   const { apiKey, discoveryApiKey } = ctx.resolveProviderApiKey(PROVIDER_ID);
   let resolvedHeaders: Record<string, string> | undefined;
+  let hasAuthorizationHeader: boolean;
+  let configuredDiscoveryApiKey: string | undefined;
   try {
     resolvedHeaders = await resolveLmstudioProviderHeaders({
       config: ctx.config,
       env: ctx.env,
       headers: explicit?.headers,
     });
-  } catch (error) {
-    if (isLmstudioDiscoveryConfigResolutionError(error)) {
-      return null;
-    }
-    throw error;
-  }
-  const hasAuthorizationHeader = hasLmstudioAuthorizationHeader(resolvedHeaders);
-  let configuredDiscoveryApiKey: string | undefined;
-  try {
+    hasAuthorizationHeader = hasLmstudioAuthorizationHeader(resolvedHeaders);
     configuredDiscoveryApiKey = await resolveLmstudioConfiguredApiKey({
       config: ctx.config,
       env: ctx.env,
@@ -1021,39 +1015,22 @@ export async function discoverLmstudioProvider(ctx: ProviderCatalogContext): Pro
     : (discoveryApiKey ?? configuredDiscoveryApiKey);
   // CLI/runtime-resolved key takes precedence over static provider config key.
   const resolvedApiKey = apiKey ?? explicit?.apiKey;
-  if (hasExplicitModels && explicitWithoutHeaders) {
-    const persistedApiKey = resolvePersistedLmstudioApiKey({
-      currentApiKey: resolvedApiKey,
-      explicitAuth,
-      fallbackApiKey: LMSTUDIO_DEFAULT_API_KEY_ENV_VAR,
-      hasModels: hasExplicitModels,
-      hasAuthorizationHeader,
-    });
-    const persistedAuth = resolveLmstudioProviderAuthMode(persistedApiKey);
-    return {
-      provider: {
-        ...explicitWithoutHeaders,
-        ...(resolvedHeaders ? { headers: resolvedHeaders } : {}),
-        baseUrl: resolveLmstudioInferenceBase(explicitWithoutHeaders.baseUrl),
-        // Keep explicit API unless absent, then fall back to provider default.
-        api: explicitWithoutHeaders.api ?? "openai-completions",
-        ...(persistedApiKey ? { apiKey: persistedApiKey } : {}),
-        ...(persistedAuth ? { auth: persistedAuth } : {}),
-        models: explicitWithoutHeaders.models,
-      },
-    };
-  }
-  const provider = await discoverLmstudioProviderCatalog({
-    baseUrl: explicit?.baseUrl,
-    // Prefer resolved discovery auth, then configured provider auth.
-    apiKey: resolvedDiscoveryApiKey,
-    headers: resolvedHeaders,
-    quiet: !apiKey && !explicit && !resolvedDiscoveryApiKey,
-  });
-  const models = mergeDiscoveredModels({
-    explicitModels: explicit?.models,
-    discoveredModels: provider.models,
-  });
+  const explicitProvider = hasExplicitModels ? explicitWithoutHeaders : undefined;
+  const provider =
+    explicitProvider ??
+    (await discoverLmstudioProviderCatalog({
+      baseUrl: explicit?.baseUrl,
+      // Prefer resolved discovery auth, then configured provider auth.
+      apiKey: resolvedDiscoveryApiKey,
+      headers: resolvedHeaders,
+      quiet: !apiKey && !explicit && !resolvedDiscoveryApiKey,
+    }));
+  const models = explicitProvider
+    ? explicitProvider.models
+    : mergeDiscoveredModels({
+        explicitModels: explicit?.models,
+        discoveredModels: provider.models,
+      });
   if (models.length === 0 && !apiKey && !explicit?.apiKey) {
     return null;
   }
@@ -1071,6 +1048,7 @@ export async function discoverLmstudioProvider(ctx: ProviderCatalogContext): Pro
       ...explicitWithoutHeaders,
       ...(resolvedHeaders ? { headers: resolvedHeaders } : {}),
       baseUrl: resolveLmstudioInferenceBase(explicit?.baseUrl ?? provider.baseUrl),
+      ...(explicitProvider ? { api: explicitProvider.api ?? "openai-completions" } : {}),
       ...(persistedApiKey ? { apiKey: persistedApiKey } : {}),
       ...(persistedAuth ? { auth: persistedAuth } : {}),
       models,


### PR DESCRIPTION
## What Problem This Solves

LM Studio catalog discovery maintained separate provider-construction and credential-resolution error paths for explicitly configured models and live-discovered models. Keeping those paths aligned made a stable, security-sensitive provider boundary harder to maintain.

## Why This Change Was Made

Consolidate ordered provider-header and configured-key resolution into its existing fail-closed error boundary, then select either the explicit provider or live catalog before using one provider/auth materialization path. Explicit models still bypass network discovery and retain their original model array, explicit-only API default, property ordering, and normalized URL. Discovered providers retain their existing field precedence, empty-catalog behavior, quiet mode, Authorization-header precedence, SecretRef handling, and authentication-marker semantics.

This is an owner-local refactor of `extensions/lmstudio/src/setup.ts`: **20 production lines added, 42 removed, net -22**. No test, public API, configuration, storage, or security-policy changes.

## User Impact

No user-visible behavior changes. Existing installed LM Studio configurations, credentials, configured models, and automatic discovery continue to work identically.

## Evidence

- Unchanged existing LM Studio discovery/setup owner suite: **47/47 passed on the unmodified baseline**, then passed again after the refactor.
- Complete LM Studio plugin suite: **211/211 tests passed across all 10 files**, including explicit-model/no-network, unresolved SecretRef, Authorization-header, discovery-key precedence, synthetic-auth, and empty-catalog coverage.
- Canonical repository lint wrapper with full `--type-aware --type-check` and the extensions tsconfig: **clean, zero diagnostics**. Documented `OPENCLAW_OXLINT_SKIP_PREPARE=1` skipped only unrelated global SDK-artifact preparation; all type-aware policy remained enabled.
- Scoped formatter: clean. Two independent source reviews and the required automated review: no actionable findings.
- Read-only verification against the existing local LM Studio models endpoint: **14 installed models, 0 loaded models, 1 embedding model**; no service or model state was changed.
