### PR TITLE
fix(agents): validate terminal receipt metadata

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1666,7 +1666,6 @@ src/agents/agent-project-settings-snapshot.ts	5
 src/agents/agent-run-terminal-delivery.ts	1
 src/agents/agent-run-terminal-error.ts	1
 src/agents/agent-run-terminal-outcome.ts	2
-src/agents/agent-run-terminal-receipt.ts	1
 src/agents/agent-run-terminal-reply.ts	4
 src/agents/agent-runtime-config.ts	1
 src/agents/agent-scope-config.ts	7

--- a/src/agents/agent-run-terminal-receipt.ts
+++ b/src/agents/agent-run-terminal-receipt.ts
@@ -8,20 +8,65 @@ export type AgentRunTerminalReceipt = {
   effective: AgentRunTerminalModelRef & { responseModel: string };
   successfulToolNames: string[];
   rerouted: boolean;
-  terminalDisposition: "visible" | "not-visible";
+  /** Added by the run entry after producer metadata is normalized. */
+  terminalDisposition?: "visible" | "not-visible";
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isModelRef(value: unknown): value is AgentRunTerminalModelRef {
+  return isRecord(value) && typeof value.provider === "string" && typeof value.model === "string";
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
 
 export function normalizeAgentRunTerminalReceipt(
   value: unknown,
 ): AgentRunTerminalReceipt | undefined {
-  const receipt = value as AgentRunTerminalReceipt | undefined;
-  return receipt &&
-    typeof receipt.runId === "string" &&
-    typeof receipt.sessionId === "string" &&
-    typeof receipt.turnId === "string" &&
-    receipt.requested &&
-    receipt.effective &&
-    Array.isArray(receipt.successfulToolNames)
-    ? receipt
-    : undefined;
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const receipt = value;
+  if (
+    typeof receipt.runId !== "string" ||
+    typeof receipt.sessionId !== "string" ||
+    typeof receipt.turnId !== "string" ||
+    !isModelRef(receipt.requested) ||
+    !isModelRef(receipt.effective) ||
+    typeof receipt.effective.responseModel !== "string" ||
+    !isStringArray(receipt.successfulToolNames) ||
+    typeof receipt.rerouted !== "boolean"
+  ) {
+    return undefined;
+  }
+  if (
+    receipt.terminalDisposition !== undefined &&
+    receipt.terminalDisposition !== "visible" &&
+    receipt.terminalDisposition !== "not-visible"
+  ) {
+    return undefined;
+  }
+  return {
+    runId: receipt.runId,
+    sessionId: receipt.sessionId,
+    turnId: receipt.turnId,
+    requested: {
+      provider: receipt.requested.provider,
+      model: receipt.requested.model,
+    },
+    effective: {
+      provider: receipt.effective.provider,
+      model: receipt.effective.model,
+      responseModel: receipt.effective.responseModel,
+    },
+    successfulToolNames: receipt.successfulToolNames,
+    rerouted: receipt.rerouted,
+    ...(receipt.terminalDisposition !== undefined
+      ? { terminalDisposition: receipt.terminalDisposition }
+      : {}),
+  };
 }

--- a/src/agents/agent-run-terminal-receipt.ts
+++ b/src/agents/agent-run-terminal-receipt.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+
 type AgentRunTerminalModelRef = { provider: string; model: string };
 
 export type AgentRunTerminalReceipt = {
@@ -12,12 +14,21 @@ export type AgentRunTerminalReceipt = {
   terminalDisposition?: "visible" | "not-visible";
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
 function isModelRef(value: unknown): value is AgentRunTerminalModelRef {
   return isRecord(value) && typeof value.provider === "string" && typeof value.model === "string";
+}
+
+function isEffectiveModelRef(
+  value: unknown,
+): value is AgentRunTerminalModelRef & { responseModel: string } {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    typeof value.provider === "string" &&
+    typeof value.model === "string" &&
+    typeof value.responseModel === "string"
+  );
 }
 
 function isStringArray(value: unknown): value is string[] {
@@ -36,8 +47,7 @@ export function normalizeAgentRunTerminalReceipt(
     typeof receipt.sessionId !== "string" ||
     typeof receipt.turnId !== "string" ||
     !isModelRef(receipt.requested) ||
-    !isModelRef(receipt.effective) ||
-    typeof receipt.effective.responseModel !== "string" ||
+    !isEffectiveModelRef(receipt.effective) ||
     !isStringArray(receipt.successfulToolNames) ||
     typeof receipt.rerouted !== "boolean"
   ) {
@@ -63,7 +73,7 @@ export function normalizeAgentRunTerminalReceipt(
       model: receipt.effective.model,
       responseModel: receipt.effective.responseModel,
     },
-    successfulToolNames: receipt.successfulToolNames,
+    successfulToolNames: [...receipt.successfulToolNames],
     rerouted: receipt.rerouted,
     ...(receipt.terminalDisposition !== undefined
       ? { terminalDisposition: receipt.terminalDisposition }

--- a/src/agents/agent-run-terminal-receipt.ts
+++ b/src/agents/agent-run-terminal-receipt.ts
@@ -2,7 +2,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 
 type AgentRunTerminalModelRef = { provider: string; model: string };
 
-export type AgentRunTerminalReceipt = {
+type AgentRunTerminalReceiptFields = {
   runId: string;
   sessionId: string;
   turnId: string;
@@ -10,6 +10,13 @@ export type AgentRunTerminalReceipt = {
   effective: AgentRunTerminalModelRef & { responseModel: string };
   successfulToolNames: string[];
   rerouted: boolean;
+};
+
+export type AgentRunTerminalReceipt = AgentRunTerminalReceiptFields & {
+  terminalDisposition: "visible" | "not-visible";
+};
+
+export type AgentRunTerminalReceiptMetadata = AgentRunTerminalReceiptFields & {
   /** Added by the run entry after producer metadata is normalized. */
   terminalDisposition?: "visible" | "not-visible";
 };
@@ -37,7 +44,7 @@ function isStringArray(value: unknown): value is string[] {
 
 export function normalizeAgentRunTerminalReceipt(
   value: unknown,
-): AgentRunTerminalReceipt | undefined {
+): AgentRunTerminalReceiptMetadata | undefined {
   if (!isRecord(value)) {
     return undefined;
   }
@@ -78,5 +85,18 @@ export function normalizeAgentRunTerminalReceipt(
     ...(receipt.terminalDisposition !== undefined
       ? { terminalDisposition: receipt.terminalDisposition }
       : {}),
+  };
+}
+
+export function normalizeCompletedAgentRunTerminalReceipt(
+  value: unknown,
+): AgentRunTerminalReceipt | undefined {
+  const receipt = normalizeAgentRunTerminalReceipt(value);
+  if (!receipt?.terminalDisposition) {
+    return undefined;
+  }
+  return {
+    ...receipt,
+    terminalDisposition: receipt.terminalDisposition,
   };
 }

--- a/src/agents/command/lifecycle.real.test.ts
+++ b/src/agents/command/lifecycle.real.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAgentEventLifecycleGeneration,
+  onAgentEvent,
+  resetAgentEventsForTest,
+} from "../../infra/agent-events.js";
+import { buildAgentRunTerminalOutcome } from "../agent-run-terminal-outcome.js";
+import { createAgentCommandLifecycle } from "./lifecycle.js";
+
+describe("createAgentCommandLifecycle real event bus", () => {
+  it("does not publish malformed receipt metadata or retain producer-owned arrays", () => {
+    resetAgentEventsForTest();
+    const events: Array<{ data: Record<string, unknown> }> = [];
+    const unsubscribe = onAgentEvent((event) => events.push(event));
+    const malformedLifecycle = createAgentCommandLifecycle({
+      runId: "real-lifecycle-proof-malformed",
+      lifecycleGeneration: getAgentEventLifecycleGeneration,
+      startedAt: 100,
+      state: {
+        currentTurnUserMessagePersisted: true,
+        lifecycleFinishing: false,
+        lifecycleEnded: false,
+      },
+    });
+
+    malformedLifecycle.emitEnd({
+      metadata: {
+        terminalReceipt: {
+          runId: "real-lifecycle-proof-malformed",
+          sessionId: "session-1",
+          turnId: "turn-1",
+          requested: {
+            provider: "provider-1",
+            model: { syntheticSecret: "redacted-proof-secret" },
+          },
+          effective: { provider: "provider-1", model: "model-1", responseModel: "model-1" },
+          successfulToolNames: ["read"],
+          rerouted: false,
+          terminalDisposition: "visible",
+        },
+      },
+      outcome: buildAgentRunTerminalOutcome({ status: "ok", stopReason: "end_turn" }),
+    });
+
+    const successfulToolNames = Object.assign(["read"], {
+      syntheticSecret: "redacted-proof-secret",
+    });
+    const validLifecycle = createAgentCommandLifecycle({
+      runId: "real-lifecycle-proof-valid",
+      lifecycleGeneration: getAgentEventLifecycleGeneration,
+      startedAt: 100,
+      state: {
+        currentTurnUserMessagePersisted: true,
+        lifecycleFinishing: false,
+        lifecycleEnded: false,
+      },
+    });
+    validLifecycle.emitEnd({
+      metadata: {
+        terminalReceipt: {
+          runId: "real-lifecycle-proof-valid",
+          sessionId: "session-1",
+          turnId: "turn-1",
+          requested: { provider: "provider-1", model: "model-1" },
+          effective: { provider: "provider-1", model: "model-1", responseModel: "model-1" },
+          successfulToolNames,
+          rerouted: false,
+          terminalDisposition: "visible",
+        },
+      },
+      outcome: buildAgentRunTerminalOutcome({ status: "ok", stopReason: "end_turn" }),
+    });
+    successfulToolNames.push("mutated-after-publication");
+    unsubscribe();
+    resetAgentEventsForTest();
+
+    const malformedEvent = events[0];
+    const validEvent = events[1];
+    const malformedSerialized = JSON.stringify(malformedEvent);
+    const validSerialized = JSON.stringify(validEvent);
+    const malformedHasTerminalReceipt = Object.hasOwn(
+      malformedEvent?.data ?? {},
+      "terminalReceipt",
+    );
+    const validReceipt = validEvent?.data.terminalReceipt;
+    const validHasTerminalReceipt = Object.hasOwn(validEvent?.data ?? {}, "terminalReceipt");
+    const publishedToolNames =
+      validReceipt && typeof validReceipt === "object" && !Array.isArray(validReceipt)
+        ? (validReceipt as Record<string, unknown>).successfulToolNames
+        : null;
+    console.log(
+      JSON.stringify({
+        eventCount: events.length,
+        malformedHasTerminalReceipt,
+        validHasTerminalReceipt,
+        publishedToolNames,
+        containsSyntheticSecret:
+          malformedSerialized.includes("redacted-proof-secret") ||
+          validSerialized.includes("redacted-proof-secret"),
+      }),
+    );
+    expect(events).toHaveLength(2);
+    expect(malformedHasTerminalReceipt).toBe(false);
+    expect(validHasTerminalReceipt).toBe(true);
+    expect(publishedToolNames).toEqual(["read"]);
+    expect(malformedSerialized).not.toContain("redacted-proof-secret");
+    expect(validSerialized).not.toContain("redacted-proof-secret");
+  });
+});

--- a/src/agents/command/lifecycle.real.test.ts
+++ b/src/agents/command/lifecycle.real.test.ts
@@ -36,7 +36,6 @@ describe("createAgentCommandLifecycle real event bus", () => {
           effective: { provider: "provider-1", model: "model-1", responseModel: "model-1" },
           successfulToolNames: ["read"],
           rerouted: false,
-          terminalDisposition: "visible",
         },
       },
       outcome: buildAgentRunTerminalOutcome({ status: "ok", stopReason: "end_turn" }),

--- a/src/agents/command/lifecycle.test.ts
+++ b/src/agents/command/lifecycle.test.ts
@@ -255,6 +255,91 @@ describe("createAgentCommandLifecycle", () => {
     }
   });
 
+  it("drops malformed nested terminal receipts before publishing lifecycle events", () => {
+    emitAgentEvent.mockClear();
+    const secret = ["sk", "abcdefghijklmnopqrstuv"].join("-");
+    const lifecycle = createAgentCommandLifecycle({
+      runId: "malformed-receipt-owner",
+      lifecycleGeneration: () => "test-generation",
+      startedAt: 100,
+      state: {
+        currentTurnUserMessagePersisted: true,
+        lifecycleFinishing: false,
+        lifecycleEnded: false,
+      },
+    });
+
+    lifecycle.emitEnd({
+      metadata: {
+        terminalReceipt: {
+          runId: "malformed-receipt-owner",
+          sessionId: "session-1",
+          turnId: "turn-1",
+          requested: { provider: "provider-1", model: { secret } },
+          effective: { provider: "provider-1", model: "model-1", responseModel: "model-1" },
+          successfulToolNames: ["read"],
+          rerouted: false,
+          terminalDisposition: "visible",
+        },
+      },
+      outcome: buildAgentRunTerminalOutcome({ status: "ok", stopReason: "end_turn" }),
+    });
+
+    const event = emitAgentEvent.mock.calls[0]?.[0];
+    expect(event.data).not.toHaveProperty("terminalReceipt");
+    expect(JSON.stringify(event)).not.toContain(secret);
+  });
+
+  it("publishes only allowlisted fields from valid terminal receipts", () => {
+    emitAgentEvent.mockClear();
+    const secret = ["sk", "abcdefghijklmnopqrstuv"].join("-");
+    const lifecycle = createAgentCommandLifecycle({
+      runId: "bounded-receipt-owner",
+      lifecycleGeneration: () => "test-generation",
+      startedAt: 100,
+      state: {
+        currentTurnUserMessagePersisted: true,
+        lifecycleFinishing: false,
+        lifecycleEnded: false,
+      },
+    });
+
+    lifecycle.emitEnd({
+      metadata: {
+        terminalReceipt: {
+          runId: "bounded-receipt-owner",
+          sessionId: "session-1",
+          turnId: "turn-1",
+          requested: { provider: "provider-1", model: "model-1", secret },
+          effective: {
+            provider: "provider-1",
+            model: "model-1",
+            responseModel: "model-1",
+            secret,
+          },
+          successfulToolNames: ["read"],
+          rerouted: false,
+          terminalDisposition: "visible",
+          secret,
+        },
+      },
+      outcome: buildAgentRunTerminalOutcome({ status: "ok", stopReason: "end_turn" }),
+    });
+
+    const event = emitAgentEvent.mock.calls[0]?.[0];
+    expect(event.data.terminalReceipt).toEqual({
+      runId: "bounded-receipt-owner",
+      sessionId: "session-1",
+      turnId: "turn-1",
+      requested: { provider: "provider-1", model: "model-1" },
+      effective: { provider: "provider-1", model: "model-1", responseModel: "model-1" },
+      successfulToolNames: ["read"],
+      rerouted: false,
+      terminalDisposition: "visible",
+    });
+    expect(JSON.stringify(event)).not.toContain(secret);
+  });
+
   it.each(["finishing", "end", "error"] as const)(
     "rejects malformed canonical metadata on %s events",
     (phase) => {

--- a/src/agents/command/lifecycle.test.ts
+++ b/src/agents/command/lifecycle.test.ts
@@ -293,6 +293,7 @@ describe("createAgentCommandLifecycle", () => {
   it("publishes only allowlisted fields from valid terminal receipts", () => {
     emitAgentEvent.mockClear();
     const secret = ["sk", "abcdefghijklmnopqrstuv"].join("-");
+    const successfulToolNames = Object.assign(["read"], { secret });
     const lifecycle = createAgentCommandLifecycle({
       runId: "bounded-receipt-owner",
       lifecycleGeneration: () => "test-generation",
@@ -317,7 +318,7 @@ describe("createAgentCommandLifecycle", () => {
             responseModel: "model-1",
             secret,
           },
-          successfulToolNames: ["read"],
+          successfulToolNames,
           rerouted: false,
           terminalDisposition: "visible",
           secret,
@@ -337,6 +338,9 @@ describe("createAgentCommandLifecycle", () => {
       rerouted: false,
       terminalDisposition: "visible",
     });
+    successfulToolNames.push("mutated-after-publication");
+    expect(event.data.terminalReceipt.successfulToolNames).not.toHaveProperty("secret");
+    expect(event.data.terminalReceipt.successfulToolNames).toEqual(["read"]);
     expect(JSON.stringify(event)).not.toContain(secret);
   });
 

--- a/src/agents/command/lifecycle.ts
+++ b/src/agents/command/lifecycle.ts
@@ -3,7 +3,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { normalizeAgentRunTerminalDeliverySnapshot } from "../agent-run-terminal-delivery.js";
 import type { AgentRunTerminalOutcome } from "../agent-run-terminal-outcome.js";
-import { normalizeAgentRunTerminalReceipt } from "../agent-run-terminal-receipt.js";
+import { normalizeCompletedAgentRunTerminalReceipt } from "../agent-run-terminal-receipt.js";
 import type { EmbeddedAgentRunEntryTerminal } from "../embedded-agent-runner/run-entry.js";
 import {
   AGENT_RUN_SUPERSEDED_STOP_REASON,
@@ -70,7 +70,9 @@ export function createAgentCommandLifecycle(params: {
     const terminalDelivery = normalizeAgentRunTerminalDeliverySnapshot(
       terminal.metadata.terminalDelivery,
     );
-    const terminalReceipt = normalizeAgentRunTerminalReceipt(terminal.metadata.terminalReceipt);
+    const terminalReceipt = normalizeCompletedAgentRunTerminalReceipt(
+      terminal.metadata.terminalReceipt,
+    );
     const { stopReason, livenessState, timeoutPhase, providerStarted } = terminal.outcome;
     const abortFields = resolveAgentRunAbortLifecycleFields(params.abortSignal);
     emitAgentEvent({

--- a/src/gateway/agent-turn/agent-job.ts
+++ b/src/gateway/agent-turn/agent-job.ts
@@ -16,7 +16,7 @@ import {
   type AgentRunTerminalOutcome,
 } from "../../agents/agent-run-terminal-outcome.js";
 import {
-  normalizeAgentRunTerminalReceipt,
+  normalizeCompletedAgentRunTerminalReceipt,
   type AgentRunTerminalReceipt,
 } from "../../agents/agent-run-terminal-receipt.js";
 import {
@@ -313,7 +313,9 @@ function createSnapshotFromLifecycleEvent(params: {
     terminalOutcome.reason === "aborted" && data?.stopReason == null && data?.status == null;
   const terminalDelivery = normalizeAgentRunTerminalDeliverySnapshot(data?.terminalDelivery);
   const terminalReply = normalizeAgentRunTerminalReplySnapshot(data?.terminalReply);
-  const normalizedTerminalReceipt = normalizeAgentRunTerminalReceipt(data?.terminalReceipt);
+  const normalizedTerminalReceipt = normalizeCompletedAgentRunTerminalReceipt(
+    data?.terminalReceipt,
+  );
   const terminalReceipt =
     normalizedTerminalReceipt?.runId === runId ? normalizedTerminalReceipt : undefined;
   return {


### PR DESCRIPTION
## What Problem This Solves

Malformed agent terminal receipt metadata could pass the lifecycle normalizer and be published through agent lifecycle events and `agent.wait` snapshots.

## Why This Change Was Made

The producer receipt normalizer validates and reconstructs pre-disposition metadata. Lifecycle publication and Gateway `agent.wait` snapshots use a separate completed-receipt normalizer that requires `terminalDisposition`, so incomplete final metadata is discarded.

## User Impact

Malformed or incomplete terminal receipts are discarded instead of polluting agent run metadata or exposing unexpected nested values. Valid receipts retain canonical fields and isolate producer-owned arrays.

## Evidence

### Real behavior proof

- A no-mock in-process lifecycle probe used the production event bus and exercised both an incomplete final receipt and a valid receipt, then mutated the producer-owned tool-name array after publication.
- [CI run](https://github.com/openclaw/openclaw/actions/runs/33069836031) executed the real lifecycle test and completed all checks successfully.

```text
{"eventCount":2,"malformedHasTerminalReceipt":false,"validHasTerminalReceipt":true,"publishedToolNames":["read"],"containsSyntheticSecret":false}
```

### Supporting checks

- `src/agents/command/lifecycle.real.test.ts`: passed in the CI agents-support shard.
- `src/agents/command/lifecycle.test.ts`: lifecycle regression coverage passed in CI.
- `src/gateway/agent-turn/agent-job.ts` and lifecycle consumer paths passed CI type/test validation.
- 250 CI checks: 0 failed, 0 pending.
- `check-test-types`, `check-prod-types`, `check-lint`, and `checks-fast-baseline-ratchets`: passed.
- `git diff --check` and targeted `oxfmt --check`: passed.

### Before-fix behavior

The same normalizer accepted a receipt without `terminalDisposition`, allowing incomplete metadata into final lifecycle and Gateway-retained `agent.wait` state. It also previously returned producer-owned arrays by reference.

### Proof boundary

The runtime proof uses synthetic in-process lifecycle metadata and the production event bus. It does not claim live channel delivery or provider behavior.

### Current head

Current head: `7668cb76085bede50b5bf3b0c5d2682577144243`