### PR TITLE
fix(ai): carry the Responses system prompt via instructions, not input[0]

### DIFF
--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -623,6 +623,7 @@ Configuring a custom/local provider `baseUrl` is also the narrow network trust d
     | `supportsReasoningEffort` | Accepts a reasoning-effort control. |
     | `supportsTemperature` | Accepts `temperature` for this model and adapter. |
     | `supportsUsageInStreaming` | Emits usage metadata in streaming responses. |
+    | `supportsInstructions` | Responses API only: accepts the system prompt via top-level `instructions` instead of embedded in `input`. Defaults to `true` for bundled/catalog-known routes, `false` for an unrecognized custom base URL — set explicitly once verified against that endpoint. |
     | `supportsTools` | Supports structured tool/function calling. Set `false` to disable tools. |
     | `supportsStrictMode` | Accepts strict tool schemas. |
     | `requiresStringContent` | Requires plain-string Chat Completions message content. |

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -623,7 +623,7 @@ Configuring a custom/local provider `baseUrl` is also the narrow network trust d
     | `supportsReasoningEffort` | Accepts a reasoning-effort control. |
     | `supportsTemperature` | Accepts `temperature` for this model and adapter. |
     | `supportsUsageInStreaming` | Emits usage metadata in streaming responses. |
-    | `supportsInstructions` | Responses API only: accepts the system prompt via top-level `instructions` instead of embedded in `input`. Defaults to `true` for bundled/catalog-known routes, `false` for an unrecognized custom base URL — set explicitly once verified against that endpoint. |
+    | `supportsInstructions` | Responses API only: accepts the system prompt via top-level `instructions` instead of embedded in `input`. Defaults to `true` only for native OpenAI and xAI's main route — the two routes with confirmed contract evidence. Every other route, bundled or custom, defaults to `false`; set explicitly once verified against that endpoint. |
     | `supportsTools` | Supports structured tool/function calling. Set `false` to disable tools. |
     | `supportsStrictMode` | Accepts strict tool schemas. |
     | `requiresStringContent` | Requires plain-string Chat Completions message content. |

--- a/extensions/xai/server-compaction.test.ts
+++ b/extensions/xai/server-compaction.test.ts
@@ -130,8 +130,13 @@ describe("xAI server compaction request preparation", () => {
     await replayStream.result();
 
     expect(replayPayload?.model).toBe("grok-4-fast");
+    // The compact endpoint (a separate request, asserted above) still needs
+    // the system prompt embedded in its own input[0]. This replay is the
+    // normal streaming turn that follows it, on xAI's main route -- which
+    // carries the system prompt via top-level `instructions` instead, so it
+    // no longer appears in `input` at all.
+    expect(replayPayload?.instructions).toBe("Retain the conversation.");
     expect(replayPayload?.input).toEqual([
-      expect.objectContaining({ role: "system", type: "message" }),
       expect.objectContaining({ type: "compaction", encrypted_content: "opaque" }),
       expect.objectContaining({ role: "user", type: "message" }),
     ]);

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -43,6 +43,7 @@ import {
   summarizeResponsesPayload,
 } from "./openai-responses-debug.js";
 import {
+  buildOpenAIResponsesCompactSystemMessage,
   buildOpenAIResponsesParams,
   sanitizeOpenAICodexResponsesParams,
 } from "./openai-responses-params-internal.js";
@@ -171,12 +172,19 @@ async function postOpenAIResponsesCompaction(params: {
   request: ReturnType<typeof buildOpenAIResponsesParams>;
   options: OpenAIResponsesOptions | undefined;
 }): Promise<OpenAIResponsesCompactEndpointResult> {
+  const compactInput =
+    typeof params.request.instructions === "string" && params.request.instructions.length > 0
+      ? [
+          buildOpenAIResponsesCompactSystemMessage(params.model, params.request.instructions),
+          ...(params.request.input ?? []),
+        ]
+      : params.request.input;
   const response = await params.client.post<unknown>("/responses/compact", {
     ...buildOpenAISdkRequestOptions(params.model, params.options?.signal, {
       timeoutMs: params.options?.timeoutMs,
       maxRetries: params.options?.maxRetries,
     }),
-    body: { model: params.request.model, input: params.request.input },
+    body: { model: params.request.model, input: compactInput },
   });
   const output = isRecord(response) && Array.isArray(response.output) ? response.output : [];
   const item = output.at(-1);

--- a/packages/ai/src/transports/openai-responses-continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.test.ts
@@ -122,6 +122,31 @@ describe("OpenAI Responses continuation", () => {
     });
   });
 
+  it("still continues when instructions changed between turns, and keeps the current turn's instructions on the wire", () => {
+    const priorState: ResponsesContinuationState = {
+      ...continuationState(),
+      lastRequest: {
+        ...continuationState().lastRequest,
+        instructions: "You are a helpful assistant. Active background tasks: none.",
+      },
+    };
+    const currentRequest: ResponsesContinuationRequest = {
+      ...nextRequest(),
+      // Rebuilt fresh this turn from live runtime state (per
+      // resolveOpenAIResponsesInstructions) -- deliberately different text
+      // from priorState, same as a real second turn would produce.
+      instructions: "You are a helpful assistant. Active background tasks: 1 running.",
+    };
+
+    const resolved = resolveResponsesContinuationRequest(priorState, currentRequest);
+
+    expect(resolved.continuationStatus).toBe("continued");
+    expect(resolved.request.previous_response_id).toBe("resp_1");
+    expect(resolved.request.instructions).toBe(
+      "You are a helpful assistant. Active background tasks: 1 running.",
+    );
+  });
+
   it("ignores turn correlation headers but isolates explicit authorization", () => {
     const first = claim({ turn: "1" });
     first?.commit(continuationState().lastRequest, {

--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -34,7 +34,20 @@ function jsonValuesEqual(left: object, right: object): boolean {
 }
 
 function requestWithoutInput(request: ResponsesContinuationRequest): ResponsesContinuationRequest {
-  const { input: _input, previous_response_id: _previousResponseId, ...rest } = request;
+  // `instructions` (like `input`) carries the system prompt for every
+  // non-Codex Responses request now, rebuilt fresh from live runtime state
+  // on every attempt -- see resolveOpenAIResponsesInstructions in
+  // openai-responses-params-internal.ts. It is sent on the wire on every
+  // request regardless of continuation status (spread from the original
+  // request below), so excluding it here loses no freshness; comparing it
+  // would just move the same false-positive rejection this module already
+  // guards against in `input` into `request_changed` instead.
+  const {
+    input: _input,
+    previous_response_id: _previousResponseId,
+    instructions: _instructions,
+    ...rest
+  } = request;
   if (!isRecord(rest.metadata)) {
     return rest;
   }

--- a/packages/ai/src/transports/openai-responses-params-internal.test.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.test.ts
@@ -1,0 +1,44 @@
+import type { Model } from "@openclaw/llm-core";
+import { describe, expect, it } from "vitest";
+import { buildOpenAIResponsesCompactSystemMessage } from "./openai-responses-params-internal.js";
+
+const reasoningModel = {
+  id: "gpt-5.6-luna",
+  name: "GPT-5.6 Luna",
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 256_000,
+  maxTokens: 8_192,
+} satisfies Model<"openai-responses">;
+
+describe("buildOpenAIResponsesCompactSystemMessage", () => {
+  it("uses the developer role for reasoning models that support it", () => {
+    expect(
+      buildOpenAIResponsesCompactSystemMessage(reasoningModel, "Retain the conversation."),
+    ).toEqual({
+      type: "message",
+      role: "developer",
+      content: [{ type: "input_text", text: "Retain the conversation." }],
+    });
+  });
+
+  it("falls back to the system role for xAI's native route, which disables the developer role", () => {
+    const message = buildOpenAIResponsesCompactSystemMessage(
+      { ...reasoningModel, provider: "xai", baseUrl: "https://api.x.ai/v1" },
+      "Retain the conversation.",
+    );
+    expect(message.role).toBe("system");
+  });
+
+  it("uses the system role for non-reasoning models", () => {
+    const message = buildOpenAIResponsesCompactSystemMessage(
+      { ...reasoningModel, reasoning: false },
+      "Retain the conversation.",
+    );
+    expect(message.role).toBe("system");
+  });
+});

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -224,6 +224,7 @@ function resolveOpenAIResponsesInstructions(
 // endpoint. Build that message on demand so the compact request body can
 // re-embed the same text the streaming path now carries via `instructions`.
 export function buildOpenAIResponsesCompactSystemMessage(model: Model, instructions: string) {
+  // SAFETY: only reached from postOpenAIResponsesCompaction (Responses-API compact endpoint), so model is always OpenAI-mode here.
   const compat = getCompat(model as OpenAIModeModel);
   const supportsDeveloperRole =
     typeof compat.supportsDeveloperRole === "boolean" ? compat.supportsDeveloperRole : undefined;

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -185,18 +185,28 @@ function buildOpenAIResponsesInstructionsText(context: Context): string | undefi
   return sanitizeTransportPayloadText(stripSystemPromptCacheBoundary(context.systemPrompt));
 }
 
-// Every Responses-API request carries the system prompt via `instructions`,
-// never as an `input` message: `input` is what HTTP continuation
-// (openai-responses-continuation.ts) compares byte-for-byte against the
-// cached previous request to decide whether it can reuse
+// A Responses-API request whose route honors `instructions` carries the
+// system prompt there, never as an `input` message: `input` is what HTTP
+// continuation (openai-responses-continuation.ts) compares byte-for-byte
+// against the cached previous request to decide whether it can reuse
 // previous_response_id. The embedded runner rebuilds the system prompt fresh
 // on every attempt from live runtime state (active background processes,
 // watched sessions, active-memory context) -- if that text sat inside
 // `input`, ordinary state churn between two turns would make the comparison
 // fail and permanently defeat continuation. `instructions` sits outside the
 // compared `input` array, so it can vary freely per turn with no effect on
-// continuation eligibility.
-function resolveOpenAIResponsesInstructions(model: Model, context: Context): string | undefined {
+// continuation eligibility. Routes that opt out via `compat.supportsInstructions:
+// false` (see openai-responses-payload-policy.ts) get no instructions field at
+// all -- convertOpenAIResponsesMessagesForRequest embeds the prompt back into
+// `input` for those instead.
+function resolveOpenAIResponsesInstructions(
+  model: Model,
+  context: Context,
+  usesInstructionsField: boolean,
+): string | undefined {
+  if (!usesInstructionsField) {
+    return undefined;
+  }
   const instructions = buildOpenAIResponsesInstructionsText(context);
   if (instructions && instructions.trim().length > 0) {
     return instructions;
@@ -276,7 +286,7 @@ function convertOpenAIResponsesMessagesForRequest(
   const replayResponsesItemIds =
     !isNativeCodexResponses && (options?.replayResponsesItemIds ?? policyAllowsReplayIds);
   return convertResponsesMessages(model, context, OPENAI_RESPONSES_TOOL_CALL_PROVIDERS, {
-    includeSystemPrompt: false,
+    includeSystemPrompt: !payloadPolicy.usesInstructionsField,
     supportsDeveloperRole,
     replayReasoningItems: true,
     replayResponsesItemIds,
@@ -300,7 +310,11 @@ export function buildOpenAIResponsesParams(
   ensureOpenAIResponsesNonEmptyInput(messages, context);
   const cacheRetention = resolveCacheRetention(options?.cacheRetention);
   const promptCacheKey = resolvePromptCacheKey(options, cacheRetention);
-  const instructions = resolveOpenAIResponsesInstructions(model, context);
+  const instructions = resolveOpenAIResponsesInstructions(
+    model,
+    context,
+    payloadPolicy.usesInstructionsField,
+  );
   const params: OpenAIResponsesRequestParams = {
     model: model.id,
     input: messages,

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -36,7 +36,6 @@ import {
 } from "./openai-responses-replay-internal.js";
 import {
   getCompat,
-  isOpenAICodexResponsesModel,
   resolveOpenAIStrictToolFlagWithDiagnostics,
   usesNativeOpenAICodexResponsesBackend,
 } from "./openai-transport-params.js";
@@ -179,18 +178,26 @@ export function sanitizeOpenAICodexResponsesParams<T extends Record<string, unkn
   return params;
 }
 
-function buildOpenAICodexResponsesInstructions(context: Context): string | undefined {
+function buildOpenAIResponsesInstructionsText(context: Context): string | undefined {
   if (!context.systemPrompt) {
     return undefined;
   }
   return sanitizeTransportPayloadText(stripSystemPromptCacheBoundary(context.systemPrompt));
 }
 
-function resolveOpenAICodexResponsesInstructions(
-  model: Model,
-  context: Context,
-): string | undefined {
-  const instructions = buildOpenAICodexResponsesInstructions(context);
+// Every Responses-API request carries the system prompt via `instructions`,
+// never as an `input` message: `input` is what HTTP continuation
+// (openai-responses-continuation.ts) compares byte-for-byte against the
+// cached previous request to decide whether it can reuse
+// previous_response_id. The embedded runner rebuilds the system prompt fresh
+// on every attempt from live runtime state (active background processes,
+// watched sessions, active-memory context) -- if that text sat inside
+// `input`, ordinary state churn between two turns would make the comparison
+// fail and permanently defeat continuation. `instructions` sits outside the
+// compared `input` array, so it can vary freely per turn with no effect on
+// continuation eligibility.
+function resolveOpenAIResponsesInstructions(model: Model, context: Context): string | undefined {
+  const instructions = buildOpenAIResponsesInstructionsText(context);
   if (instructions && instructions.trim().length > 0) {
     return instructions;
   }
@@ -199,14 +206,32 @@ function resolveOpenAICodexResponsesInstructions(
     : undefined;
 }
 
-function ensureOpenAICodexResponsesInput(messages: ResponseInput, context: Context): void {
+// xAI's server-side `/responses/compact` endpoint (see
+// postOpenAIResponsesCompaction in openai-responses-client.ts) predates and
+// does not accept `instructions`: per
+// https://docs.x.ai/developers/advanced-api-usage/context-compaction the
+// system prompt must be the first `input` message, unlike the main streaming
+// endpoint. Build that message on demand so the compact request body can
+// re-embed the same text the streaming path now carries via `instructions`.
+export function buildOpenAIResponsesCompactSystemMessage(model: Model, instructions: string) {
+  const compat = getCompat(model as OpenAIModeModel);
+  const supportsDeveloperRole =
+    typeof compat.supportsDeveloperRole === "boolean" ? compat.supportsDeveloperRole : undefined;
+  const role = model.reasoning && supportsDeveloperRole !== false ? "developer" : "system";
+  return buildResponsesInputMessage(role, [{ type: "input_text", text: instructions }]);
+}
+
+// The Responses API rejects an empty `input` array; when the only content
+// for this turn was the system prompt (now carried by `instructions`
+// instead), inject a placeholder input item so the request stays valid.
+function ensureOpenAIResponsesNonEmptyInput(messages: ResponseInput, context: Context): void {
   if (messages.length > 0 || !context.systemPrompt) {
     return;
   }
-  const text = buildOpenAICodexResponsesInstructions(context);
+  const text = buildOpenAIResponsesInstructionsText(context);
   if (!text) {
     throw new Error(
-      "OpenAI Codex Responses requires non-empty input when only systemPrompt is provided.",
+      "OpenAI Responses requires non-empty input when only systemPrompt is provided.",
     );
   }
   messages.push(
@@ -239,7 +264,6 @@ function convertOpenAIResponsesMessagesForRequest(
   options: OpenAIResponsesOptions | undefined,
   replayMode: OpenAIResponsesReplayMode,
 ): ResponseInput {
-  const isCodexResponses = isOpenAICodexResponsesModel(model);
   const isNativeCodexResponses = usesNativeOpenAICodexResponsesBackend(model);
   const compat = getCompat(model as OpenAIModeModel);
   const supportsDeveloperRole =
@@ -252,7 +276,7 @@ function convertOpenAIResponsesMessagesForRequest(
   const replayResponsesItemIds =
     !isNativeCodexResponses && (options?.replayResponsesItemIds ?? policyAllowsReplayIds);
   return convertResponsesMessages(model, context, OPENAI_RESPONSES_TOOL_CALL_PROVIDERS, {
-    includeSystemPrompt: !isCodexResponses,
+    includeSystemPrompt: false,
     supportsDeveloperRole,
     replayReasoningItems: true,
     replayResponsesItemIds,
@@ -269,25 +293,21 @@ export function buildOpenAIResponsesParams(
   metadata?: Record<string, string>,
   replayMode: OpenAIResponsesReplayMode = "checkpoint",
 ) {
-  const isCodexResponses = isOpenAICodexResponsesModel(model);
   const payloadPolicy = resolveOpenAIResponsesPayloadPolicy(model, {
     storeMode: "disable",
   });
   const messages = convertOpenAIResponsesMessagesForRequest(model, context, options, replayMode);
-  if (isCodexResponses) {
-    ensureOpenAICodexResponsesInput(messages, context);
-  }
+  ensureOpenAIResponsesNonEmptyInput(messages, context);
   const cacheRetention = resolveCacheRetention(options?.cacheRetention);
   const promptCacheKey = resolvePromptCacheKey(options, cacheRetention);
+  const instructions = resolveOpenAIResponsesInstructions(model, context);
   const params: OpenAIResponsesRequestParams = {
     model: model.id,
     input: messages,
     stream: true,
     prompt_cache_key: promptCacheKey,
     prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
-    ...(isCodexResponses
-      ? { instructions: resolveOpenAICodexResponsesInstructions(model, context) }
-      : {}),
+    ...(instructions ? { instructions } : {}),
     ...(metadata ? { metadata } : {}),
   };
   const effectiveMaxTokens = options?.maxTokens || model.maxTokens;

--- a/packages/ai/src/transports/openai-responses-payload-policy.instructions.integration.test.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.instructions.integration.test.ts
@@ -1,0 +1,158 @@
+import { createServer } from "node:http";
+import type { AddressInfo, Server } from "node:net";
+import type { Context, Model } from "@openclaw/llm-core";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupSessionResources } from "../session-resources.js";
+import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+
+// Matches the identically-named symbol in src/agents/provider-request-config.ts
+// via the global symbol registry, without a packages/ai -> src/agents import.
+const MODEL_PROVIDER_REQUEST_TRANSPORT_SYMBOL = Symbol.for(
+  "openclaw.modelProviderRequestTransport",
+);
+
+function attachModelProviderRequestTransport<TModel extends object>(
+  model: TModel,
+  request: { allowPrivateNetwork?: boolean },
+): TModel {
+  return {
+    ...model,
+    [MODEL_PROVIDER_REQUEST_TRANSPORT_SYMBOL]: request,
+  };
+}
+
+// Real loopback HTTP + SSE server standing in for an arbitrary
+// Responses-API-shaped proxy. Nothing here mocks the `openai` SDK: the
+// request leaves the process over a real socket and the response comes back
+// as real "text/event-stream" bytes, so this proves the literal wire shape
+// rather than an intercepted SDK call -- see
+// packages/ai/src/transports/openai-responses-client.continuation.integration.test.ts
+// for the established pattern this mirrors.
+class ScriptedResponsesServer {
+  readonly requests: Array<Record<string, unknown>> = [];
+  private server: Server | undefined;
+
+  async listen(): Promise<string> {
+    this.server = createServer((req, res) => {
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        const parsed = JSON.parse(body) as Record<string, unknown>;
+        this.requests.push(parsed);
+        res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+        res.write(
+          `data: ${JSON.stringify({
+            type: "response.completed",
+            response: {
+              id: "resp_1",
+              status: "completed",
+              output: [
+                {
+                  id: "msg_resp_1",
+                  type: "message",
+                  status: "completed",
+                  content: [{ type: "output_text", text: "answer", annotations: [] }],
+                  role: "assistant",
+                },
+              ],
+              usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+            },
+          })}\n\n`,
+        );
+        res.end();
+      });
+    });
+    await new Promise<void>((resolve) => {
+      this.server?.listen(0, "127.0.0.1", resolve);
+    });
+    const address = this.server?.address() as AddressInfo;
+    return `http://127.0.0.1:${address.port}/v1`;
+  }
+
+  async close(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.server?.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function proxyModel(baseUrl: string, compat?: Record<string, boolean>): Model<"openai-responses"> {
+  const model = {
+    id: "scripted-model",
+    name: "Scripted Model",
+    api: "openai-responses",
+    provider: "custom-provider",
+    baseUrl,
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8192,
+    ...(compat ? { compat } : {}),
+  } satisfies Model<"openai-responses">;
+  return attachModelProviderRequestTransport(model, { allowPrivateNetwork: true });
+}
+
+const context: Context = {
+  systemPrompt: "You are a helpful assistant.",
+  messages: [{ role: "user", content: "hi", timestamp: 1 }],
+  tools: [],
+};
+
+async function runOnce(model: Model<"openai-responses">, sessionId: string) {
+  const stream = await createOpenAIResponsesTransportStreamFn()(model, context, {
+    apiKey: "test-key",
+    sessionId,
+    transport: "sse",
+    reasoningEffort: "low",
+    onPayload: (payload: Record<string, unknown>) => ({ ...payload, store: true }),
+  } as never);
+  await stream.result();
+}
+
+describe("real HTTP/SSE OpenAI-Responses instructions-field default (loopback server, no SDK mocking)", () => {
+  afterEach(() => {
+    cleanupSessionResources();
+  });
+
+  it("embeds the system prompt in input, not instructions, for an unverified custom proxy over a real connection", async () => {
+    const server = new ScriptedResponsesServer();
+    const baseUrl = await server.listen();
+    try {
+      await runOnce(proxyModel(baseUrl), "real-instructions-default-off");
+
+      expect(server.requests).toHaveLength(1);
+      const wireRequest = server.requests[0];
+      expect(wireRequest).not.toHaveProperty("instructions");
+      // reasoning:true with no compat.supportsDeveloperRole gets the
+      // "developer" role, not "system" -- see openai-responses-params-internal.ts.
+      expect((wireRequest?.input as Array<{ role?: string }> | undefined)?.[0]?.role).toBe(
+        "developer",
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("carries the system prompt via top-level instructions once the route is explicitly opted in, over a real connection", async () => {
+    const server = new ScriptedResponsesServer();
+    const baseUrl = await server.listen();
+    try {
+      await runOnce(
+        proxyModel(baseUrl, { supportsInstructions: true }),
+        "real-instructions-explicit-opt-in",
+      );
+
+      expect(server.requests).toHaveLength(1);
+      const wireRequest = server.requests[0];
+      expect(wireRequest?.instructions).toBe("You are a helpful assistant.");
+      const input = wireRequest?.input as Array<{ role?: string }> | undefined;
+      expect(input?.every((item) => item.role !== "system")).toBe(true);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/ai/src/transports/openai-responses-payload-policy.instructions.live.test.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.instructions.live.test.ts
@@ -1,0 +1,160 @@
+import type { AssistantMessage, Context, Model } from "@openclaw/llm-core";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupSessionResources } from "../session-resources.js";
+import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+
+// Live coverage for the instructions-field default against the *real* native
+// OpenAI Responses API. The committed loopback integration test
+// (openai-responses-payload-policy.instructions.integration.test.ts) proves
+// openclaw's own request-building logic; it cannot prove the real API
+// actually accepts top-level `instructions` the way openclaw assumes, or
+// that HTTP continuation still works once the system prompt moved out of
+// `input`. This test captures the literal request bytes that leave the
+// process for the real API by wrapping globalThis.fetch (not a proxy, so the
+// model's baseUrl stays genuinely unset/native -- a loopback proxy baseUrl
+// would itself defeat the native-route classification under test).
+const LIVE = process.env.OPENCLAW_LIVE_TEST === "1";
+const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
+const describeLive = LIVE && OPENAI_KEY ? describe : describe.skip;
+const LIVE_MODEL_ID = process.env.OPENCLAW_LIVE_RESPONSES_MODEL || "gpt-5.6-luna";
+const LIVE_TIMEOUT_MS = 120_000;
+
+function userMessage(text: string, timestamp: number) {
+  return { role: "user" as const, content: text, timestamp };
+}
+
+async function captureOpenAIRequests<T>(run: () => Promise<T>): Promise<{
+  result: T;
+  requests: Array<Record<string, unknown>>;
+}> {
+  const requests: Array<Record<string, unknown>> = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.includes("api.openai.com") && typeof init?.body === "string") {
+      try {
+        requests.push(JSON.parse(init.body) as Record<string, unknown>);
+      } catch {
+        // Non-JSON body (unexpected for this endpoint) -- skip capture, still forward the real call.
+      }
+    }
+    return realFetch(input, init);
+  }) as typeof fetch;
+  try {
+    const result = await run();
+    return { result, requests };
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+}
+
+async function runTurn(
+  model: Model<"openai-responses">,
+  context: Context,
+  sessionId: string,
+): Promise<AssistantMessage> {
+  const stream = await createOpenAIResponsesTransportStreamFn()(model, context, {
+    apiKey: OPENAI_KEY,
+    sessionId,
+    transport: "sse",
+    reasoningEffort: "low",
+    maxTokens: 256,
+    onPayload: (payload: Record<string, unknown>) => ({ ...payload, store: true }),
+  } as never);
+  return stream.result();
+}
+
+describeLive("instructions-field default on the real native OpenAI Responses API", () => {
+  afterEach(() => {
+    cleanupSessionResources();
+  });
+
+  it(
+    "carries the system prompt via top-level instructions and still continues via previous_response_id",
+    async () => {
+      // Explicit canonical baseUrl: usesKnownNativeOpenAIRoute classifies
+      // this as native via endpointClass "openai-public" either way, but
+      // continuation eligibility (supportsNativeOpenAIResponsesEndpoint in
+      // openai-responses-websocket.ts) is stricter -- it requires an exact
+      // https://api.openai.com/v1 origin/path match and returns false for
+      // an absent baseUrl outright, unlike this PR's own instructions-field
+      // policy which treats "no baseUrl + provider openai" as native too.
+      // A loopback proxy baseUrl would fail that same exact-match check,
+      // which is why capture happens via a fetch wrapper instead (see above).
+      const model: Model<"openai-responses"> = {
+        id: LIVE_MODEL_ID,
+        name: LIVE_MODEL_ID,
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200_000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">;
+
+      const sessionId = "live-instructions-default-continuation";
+      const secretCode = "GRANITE-ORBIT-4127";
+      const firstUser = userMessage(
+        `This is an automated test. Remember this secret code: ${secretCode}. ` +
+          "Do not reply with the code yet -- just reply with exactly: ack",
+        1,
+      );
+
+      const { result: first, requests: firstRequests } = await captureOpenAIRequests(() =>
+        runTurn(
+          model,
+          { systemPrompt: "You are a terse test assistant.", messages: [firstUser], tools: [] },
+          sessionId,
+        ),
+      );
+      expect(first.stopReason).toBe("stop");
+      expect(firstRequests).toHaveLength(1);
+      // The actual claim under test: the real native API request carries
+      // instructions at top level, not the system prompt embedded in input.
+      expect(firstRequests[0]?.instructions).toBe("You are a terse test assistant.");
+      expect(firstRequests[0]).not.toHaveProperty("previous_response_id");
+
+      const { result: second, requests: secondRequests } = await captureOpenAIRequests(() =>
+        runTurn(
+          model,
+          {
+            systemPrompt: "You are a terse test assistant.",
+            messages: [
+              firstUser,
+              first,
+              userMessage("What was the secret code I gave you? Reply with exactly that code.", 2),
+            ],
+            tools: [],
+          },
+          sessionId,
+        ),
+      );
+      expect(second.stopReason).toBe("stop");
+      const secondText = second.content
+        .filter((block) => block.type === "text")
+        .map((block) => block.text)
+        .join("");
+      // Structural proof (previous_response_id present) is not behavioral
+      // proof -- a silent full-history fallback would look identical on the
+      // wire shape alone. The model can only produce this secret if the
+      // real API actually resolved server-side state through
+      // previous_response_id, since the trimmed turn-2 input never repeats it.
+      expect(secondText).toContain(secretCode);
+      expect(secondRequests).toHaveLength(1);
+      expect(secondRequests[0]).toHaveProperty("previous_response_id");
+      expect(typeof secondRequests[0]?.previous_response_id).toBe("string");
+      const previousResponseId = secondRequests[0]?.previous_response_id as string | undefined;
+      expect(previousResponseId?.length).toBeGreaterThan(0);
+      // Instructions keep flowing on every request regardless of
+      // continuation status (they are not part of the continuation
+      // comparator -- see openai-responses-continuation.ts).
+      expect(secondRequests[0]?.instructions).toBe("You are a terse test assistant.");
+      const secondInput = secondRequests[0]?.input as Array<{ role?: string }> | undefined;
+      expect(secondInput?.every((item) => item.role !== "system")).toBe(true);
+      expect(secondInput).toHaveLength(1);
+    },
+    LIVE_TIMEOUT_MS,
+  );
+});

--- a/packages/ai/src/transports/openai-responses-payload-policy.instructions.live.test.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.instructions.live.test.ts
@@ -10,9 +10,9 @@ import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-clien
 // actually accepts top-level `instructions` the way openclaw assumes, or
 // that HTTP continuation still works once the system prompt moved out of
 // `input`. This test captures the literal request bytes that leave the
-// process for the real API by wrapping globalThis.fetch (not a proxy, so the
-// model's baseUrl stays genuinely unset/native -- a loopback proxy baseUrl
-// would itself defeat the native-route classification under test).
+// process for the real API by wrapping globalThis.fetch. This avoids a proxy
+// while retaining the explicit native OpenAI baseUrl below; a loopback proxy
+// baseUrl would itself defeat the native-route classification under test.
 const LIVE = process.env.OPENCLAW_LIVE_TEST === "1";
 const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
 const describeLive = LIVE && OPENAI_KEY ? describe : describe.skip;

--- a/packages/ai/src/transports/openai-responses-payload-policy.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.ts
@@ -71,6 +71,7 @@ type OpenAIResponsesPayloadCapabilities = {
   shouldStripResponsesPromptCache: boolean;
   supportsResponsesStoreField: boolean;
   usesKnownNativeOpenAIRoute: boolean;
+  usesUnverifiedProxyEndpoint: boolean;
 };
 
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai", "azure-openai-responses"]);
@@ -243,6 +244,12 @@ function resolveOpenAIResponsesPayloadCapabilities(
   const usesKnownNativeOpenAIRoute =
     endpointClass === "default" ? provider === "openai" : usesKnownNativeOpenAIEndpoint;
   const usesExplicitProxyLikeEndpoint = usesConfiguredBaseUrl && !usesKnownNativeOpenAIEndpoint;
+  // "custom"/"local" are hosts OpenClaw has no bundled knowledge of -- unlike
+  // the named classes above (openai, azure-openai, xai-native, etc.), which
+  // are each specifically identified and, for at least xAI's main route,
+  // directly confirmed to honor `instructions`. Everything else (arbitrary
+  // proxies, local gateways like OmniRoute/llama.cpp) is unverified.
+  const usesUnverifiedProxyEndpoint = endpointClass === "custom" || endpointClass === "local";
   const promptCacheKeySupport = readCompatPayloadBoolean(model.compat, "supportsPromptCacheKey");
   const shouldStripResponsesPromptCache =
     promptCacheKeySupport === true
@@ -274,6 +281,7 @@ function resolveOpenAIResponsesPayloadCapabilities(
     shouldStripResponsesPromptCache,
     supportsResponsesStoreField,
     usesKnownNativeOpenAIRoute,
+    usesUnverifiedProxyEndpoint,
   };
 }
 
@@ -389,13 +397,19 @@ export function resolveOpenAIResponsesPayloadPolicy(
     model,
     options.extraParams,
   );
-  // Defaults on: most Responses-compatible endpoints, including the native
-  // route, honor top-level `instructions`. An endpoint whose proxy silently
-  // ignores it (confirmed for at least one real route, xAI's compact
-  // endpoint) gets a per-model opt-out that falls back to embedding the
-  // system prompt in `input` instead, matching pre-instructions behavior.
-  const usesInstructionsField =
-    readCompatPayloadBoolean(model.compat, "supportsInstructions") !== false;
+  // Defaults on only for endpoint classes OpenClaw has bundled, verified
+  // knowledge of (native OpenAI, xAI's main route, etc. -- see
+  // usesUnverifiedProxyEndpoint above). An unrecognized custom/local proxy
+  // defaults off instead: HTTP continuation is unreachable there anyway
+  // (openai-responses-websocket.ts requires the exact native OpenAI base
+  // URL), so there is nothing to gain from `instructions` and real risk of
+  // an unverified proxy silently dropping the field along with the system
+  // prompt. `compat.supportsInstructions` always overrides the default in
+  // either direction -- explicit `false` opts a normally-verified route out
+  // (confirmed necessary for at least one real route, xAI's compact
+  // endpoint); explicit `true` opts an unverified route in once confirmed.
+  const instructionsCompat = readCompatPayloadBoolean(model.compat, "supportsInstructions");
+  const usesInstructionsField = instructionsCompat ?? !capabilities.usesUnverifiedProxyEndpoint;
 
   return {
     allowsServiceTier: capabilities.allowsOpenAIServiceTier,

--- a/packages/ai/src/transports/openai-responses-payload-policy.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.ts
@@ -255,8 +255,18 @@ function resolveOpenAIResponsesPayloadCapabilities(
   // opt-out carve-out below, discovered by testing the real API). Every
   // other named class defaults the same as an explicit custom/local proxy;
   // `compat.supportsInstructions: true` opts a confirmed-working route in.
+  // Deliberately narrower than usesKnownNativeOpenAIRoute (used above for
+  // reasoning/service-tier/input-status policy): that boolean also covers
+  // azure-openai, which has never been verified for `instructions`
+  // specifically -- Azure mirrors OpenAI's API closely, but "closely" isn't
+  // a contract, and this file's whole point is not assuming one without
+  // evidence.
+  const usesVerifiedNativeOpenAIRoute =
+    endpointClass === "default"
+      ? provider === "openai"
+      : endpointClass === "openai-public" || endpointClass === "openai";
   const usesVerifiedInstructionsEndpoint =
-    usesKnownNativeOpenAIRoute || endpointClass === "xai-native";
+    usesVerifiedNativeOpenAIRoute || endpointClass === "xai-native";
   const promptCacheKeySupport = readCompatPayloadBoolean(model.compat, "supportsPromptCacheKey");
   const shouldStripResponsesPromptCache =
     promptCacheKeySupport === true

--- a/packages/ai/src/transports/openai-responses-payload-policy.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.ts
@@ -62,6 +62,7 @@ type OpenAIResponsesPayloadPolicy = {
   shouldStripPromptCache: boolean;
   shouldStripStore: boolean;
   useServerCompaction: boolean;
+  usesInstructionsField: boolean;
 };
 
 type OpenAIResponsesPayloadCapabilities = {
@@ -217,7 +218,7 @@ function isOpenAIResponsesApi(api: string | undefined): boolean {
 
 function readCompatPayloadBoolean(
   compat: unknown,
-  key: "supportsPromptCacheKey" | "supportsStore",
+  key: "supportsInstructions" | "supportsPromptCacheKey" | "supportsStore",
 ): boolean | undefined {
   if (!compat || typeof compat !== "object") {
     return undefined;
@@ -388,6 +389,13 @@ export function resolveOpenAIResponsesPayloadPolicy(
     model,
     options.extraParams,
   );
+  // Defaults on: most Responses-compatible endpoints, including the native
+  // route, honor top-level `instructions`. An endpoint whose proxy silently
+  // ignores it (confirmed for at least one real route, xAI's compact
+  // endpoint) gets a per-model opt-out that falls back to embedding the
+  // system prompt in `input` instead, matching pre-instructions behavior.
+  const usesInstructionsField =
+    readCompatPayloadBoolean(model.compat, "supportsInstructions") !== false;
 
   return {
     allowsServiceTier: capabilities.allowsOpenAIServiceTier,
@@ -402,6 +410,7 @@ export function resolveOpenAIResponsesPayloadPolicy(
       readCompatPayloadBoolean(model.compat, "supportsStore") === false &&
       isResponsesApi,
     useServerCompaction: options.enableServerCompaction === true && serverCompactionPlan.enabled,
+    usesInstructionsField,
   };
 }
 

--- a/packages/ai/src/transports/openai-responses-payload-policy.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.ts
@@ -71,7 +71,7 @@ type OpenAIResponsesPayloadCapabilities = {
   shouldStripResponsesPromptCache: boolean;
   supportsResponsesStoreField: boolean;
   usesKnownNativeOpenAIRoute: boolean;
-  usesUnverifiedProxyEndpoint: boolean;
+  usesVerifiedInstructionsEndpoint: boolean;
 };
 
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai", "azure-openai-responses"]);
@@ -244,12 +244,19 @@ function resolveOpenAIResponsesPayloadCapabilities(
   const usesKnownNativeOpenAIRoute =
     endpointClass === "default" ? provider === "openai" : usesKnownNativeOpenAIEndpoint;
   const usesExplicitProxyLikeEndpoint = usesConfiguredBaseUrl && !usesKnownNativeOpenAIEndpoint;
-  // "custom"/"local" are hosts OpenClaw has no bundled knowledge of -- unlike
-  // the named classes above (openai, azure-openai, xai-native, etc.), which
-  // are each specifically identified and, for at least xAI's main route,
-  // directly confirmed to honor `instructions`. Everything else (arbitrary
-  // proxies, local gateways like OmniRoute/llama.cpp) is unverified.
-  const usesUnverifiedProxyEndpoint = endpointClass === "custom" || endpointClass === "local";
+  // Recognizing a hostname (routing it to a named endpointClass) is not the
+  // same as having confirmed that host's Responses API honors `instructions`
+  // -- OpenClaw bundles many named classes (Cerebras, Groq, Mistral,
+  // OpenCode, GitHub Copilot, ...) purely for SSRF/base-URL matching and
+  // other unrelated capability detection, with no contract proof either way
+  // for `instructions` specifically. Only two routes are actually verified:
+  // native OpenAI (definitionally, it's OpenAI's own API) and xAI's main
+  // route (confirmed via direct testing -- see the xAI compact-endpoint
+  // opt-out carve-out below, discovered by testing the real API). Every
+  // other named class defaults the same as an explicit custom/local proxy;
+  // `compat.supportsInstructions: true` opts a confirmed-working route in.
+  const usesVerifiedInstructionsEndpoint =
+    usesKnownNativeOpenAIRoute || endpointClass === "xai-native";
   const promptCacheKeySupport = readCompatPayloadBoolean(model.compat, "supportsPromptCacheKey");
   const shouldStripResponsesPromptCache =
     promptCacheKeySupport === true
@@ -281,7 +288,7 @@ function resolveOpenAIResponsesPayloadCapabilities(
     shouldStripResponsesPromptCache,
     supportsResponsesStoreField,
     usesKnownNativeOpenAIRoute,
-    usesUnverifiedProxyEndpoint,
+    usesVerifiedInstructionsEndpoint,
   };
 }
 
@@ -397,19 +404,20 @@ export function resolveOpenAIResponsesPayloadPolicy(
     model,
     options.extraParams,
   );
-  // Defaults on only for endpoint classes OpenClaw has bundled, verified
-  // knowledge of (native OpenAI, xAI's main route, etc. -- see
-  // usesUnverifiedProxyEndpoint above). An unrecognized custom/local proxy
-  // defaults off instead: HTTP continuation is unreachable there anyway
-  // (openai-responses-websocket.ts requires the exact native OpenAI base
-  // URL), so there is nothing to gain from `instructions` and real risk of
-  // an unverified proxy silently dropping the field along with the system
-  // prompt. `compat.supportsInstructions` always overrides the default in
-  // either direction -- explicit `false` opts a normally-verified route out
-  // (confirmed necessary for at least one real route, xAI's compact
-  // endpoint); explicit `true` opts an unverified route in once confirmed.
+  // Defaults on only for the two routes actually confirmed to honor
+  // `instructions` (see usesVerifiedInstructionsEndpoint above: native
+  // OpenAI, and xAI's main route by direct test). Every other route --
+  // including bundled-but-unverified named classes and arbitrary
+  // custom/local proxies -- defaults off: HTTP continuation is unreachable
+  // there anyway (openai-responses-websocket.ts requires the exact native
+  // OpenAI base URL), so there is nothing to gain from `instructions` and
+  // real risk of an unconfirmed route silently dropping the field along
+  // with the system prompt. `compat.supportsInstructions` always overrides
+  // the default in either direction -- explicit `false` opts a verified
+  // route out (confirmed necessary for xAI's compact endpoint specifically);
+  // explicit `true` opts any other route in once confirmed.
   const instructionsCompat = readCompatPayloadBoolean(model.compat, "supportsInstructions");
-  const usesInstructionsField = instructionsCompat ?? !capabilities.usesUnverifiedProxyEndpoint;
+  const usesInstructionsField = instructionsCompat ?? capabilities.usesVerifiedInstructionsEndpoint;
 
   return {
     allowsServiceTier: capabilities.allowsOpenAIServiceTier,

--- a/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
+++ b/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
@@ -280,9 +280,12 @@ afterEach(() => {
 });
 
 describe("OpenAI Responses provider prompt observer", () => {
-  // Every non-Codex Responses request now carries the system prompt via
-  // `instructions`, not an `input.developer`/`input.system` message -- see
-  // resolveOpenAIResponsesInstructions in openai-responses-params-internal.ts.
+  // createModel() defaults to a verified native OpenAI route (see
+  // usesVerifiedInstructionsEndpoint in openai-responses-payload-policy.ts),
+  // so this request carries the system prompt via top-level `instructions`
+  // rather than an `input.developer`/`input.system` message. That default is
+  // route-specific, not universal -- see the Azure test below, which is on
+  // an unverified route and falls back to input.developer.
   // The reasoning flag no longer changes promptSource (it used to select
   // between the developer/system input roles); both cases stay in the table
   // to confirm reasoning=true/false doesn't regress instructions delivery.
@@ -326,7 +329,11 @@ describe("OpenAI Responses provider prompt observer", () => {
     expect(run.observations[0]).toMatchObject({
       egress: "responses-sdk",
       payloadVariant: "initial",
-      promptSource: "instructions",
+      // Azure is not a verified instructions-field route (see
+      // usesVerifiedInstructionsEndpoint in openai-responses-payload-policy.ts)
+      // -- it falls back to embedding the prompt in input, same as any other
+      // unverified route.
+      promptSource: "input.developer",
       matchesAssembledPrompt: true,
     });
   });

--- a/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
+++ b/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
@@ -280,28 +280,34 @@ afterEach(() => {
 });
 
 describe("OpenAI Responses provider prompt observer", () => {
-  it.each([
-    { reasoning: true, promptSource: "input.developer" },
-    { reasoning: false, promptSource: "input.system" },
-  ] as const)("observes the final $promptSource prompt", async ({ reasoning, promptSource }) => {
-    const prompt = `PRIVATE-${promptSource}-PROMPT`;
-    const run = await runObservedRequest({
-      context: createContext(prompt),
-      model: createModel({ reasoning }),
-    });
+  // Every non-Codex Responses request now carries the system prompt via
+  // `instructions`, not an `input.developer`/`input.system` message -- see
+  // resolveOpenAIResponsesInstructions in openai-responses-params-internal.ts.
+  // The reasoning flag no longer changes promptSource (it used to select
+  // between the developer/system input roles); both cases stay in the table
+  // to confirm reasoning=true/false doesn't regress instructions delivery.
+  it.each([{ reasoning: true }, { reasoning: false }] as const)(
+    "observes the final instructions prompt (reasoning=$reasoning)",
+    async ({ reasoning }) => {
+      const prompt = `PRIVATE-reasoning-${reasoning}-PROMPT`;
+      const run = await runObservedRequest({
+        context: createContext(prompt),
+        model: createModel({ reasoning }),
+      });
 
-    expect(run.observations).toEqual([
-      {
-        egress: "responses-sdk",
-        payloadVariant: "initial",
-        promptSource,
-        expectedChars: prompt.length,
-        observedChars: prompt.length,
-        matchesAssembledPrompt: true,
-      },
-    ]);
-    expect(JSON.stringify(run.observations)).not.toContain(prompt);
-  });
+      expect(run.observations).toEqual([
+        {
+          egress: "responses-sdk",
+          payloadVariant: "initial",
+          promptSource: "instructions",
+          expectedChars: prompt.length,
+          observedChars: prompt.length,
+          matchesAssembledPrompt: true,
+        },
+      ]);
+      expect(JSON.stringify(run.observations)).not.toContain(prompt);
+    },
+  );
 
   it("observes Azure Responses egress", async () => {
     const prompt = "PRIVATE-AZURE-PROMPT";
@@ -320,7 +326,7 @@ describe("OpenAI Responses provider prompt observer", () => {
     expect(run.observations[0]).toMatchObject({
       egress: "responses-sdk",
       payloadVariant: "initial",
-      promptSource: "input.developer",
+      promptSource: "instructions",
       matchesAssembledPrompt: true,
     });
   });
@@ -683,9 +689,7 @@ describe("OpenAI Responses provider prompt observer", () => {
     if (!request) {
       throw new Error("missing captured request");
     }
-    expect((request.input as Array<Record<string, unknown>>)[0]).toMatchObject({
-      content: [{ type: "input_text", text: normalizedPrompt }],
-    });
+    expect(request.instructions).toBe(normalizedPrompt);
   });
 
   it("reports missing and same-length mutated prompts without retaining content", async () => {

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -532,6 +532,8 @@ export interface OpenAIResponsesCompat {
   sendSessionIdHeader?: boolean;
   /** Whether the provider supports `prompt_cache_retention: "24h"`. Default: true. */
   supportsLongCacheRetention?: boolean;
+  /** Whether the provider honors top-level `instructions`. Default: true; set false for proxies that silently ignore it, which falls back to embedding the system prompt in `input`. */
+  supportsInstructions?: boolean;
 }
 
 /** Compatibility settings for Anthropic Messages-compatible APIs. */

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -532,7 +532,7 @@ export interface OpenAIResponsesCompat {
   sendSessionIdHeader?: boolean;
   /** Whether the provider supports `prompt_cache_retention: "24h"`. Default: true. */
   supportsLongCacheRetention?: boolean;
-  /** Whether the provider honors top-level `instructions`. Default: true; set false for proxies that silently ignore it, which falls back to embedding the system prompt in `input`. */
+  /** Whether the provider honors top-level `instructions`. Defaults to true only for verified native routes (OpenAI, xAI); every other route defaults to false and embeds the system prompt in `input` unless set true here after verifying against that endpoint. */
   supportsInstructions?: boolean;
 }
 

--- a/packages/model-catalog-core/src/model-catalog-normalize.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.ts
@@ -314,6 +314,7 @@ function normalizeModelCatalogCompat(value: unknown): ModelCatalogCompatConfig |
     "supportsDeveloperRole",
     "supportsReasoningEffort",
     "supportsTemperature",
+    "supportsInstructions",
     "supportsUsageInStreaming",
     "supportsTools",
     "supportsStrictMode",

--- a/packages/model-catalog-core/src/model-catalog-types.ts
+++ b/packages/model-catalog-core/src/model-catalog-types.ts
@@ -43,6 +43,8 @@ export type ModelCatalogCompatConfig = {
   supportsReasoningEffort?: boolean;
   /** Whether the model accepts the temperature parameter (GPT-5.6 family rejects it). */
   supportsTemperature?: boolean;
+  /** Whether the provider honors top-level `instructions` on Responses requests. */
+  supportsInstructions?: boolean;
   supportsUsageInStreaming?: boolean;
   supportsStrictMode?: boolean;
   supportsJsonSchemaResponseFormat?: boolean;

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -451,7 +451,13 @@ describe("openai transport stream", () => {
         name: "GPT-5.4",
         api: "openai-chatgpt-responses",
         baseUrl: "https://proxy.example.com/v1",
-      }),
+        // Unrecognized custom base URL: instructions default off unless
+        // verified. This fixture is specifically testing param preservation
+        // once instructions is in play, so opt in explicitly. `compat` types
+        // to `never` for this API variant (no recognized branch in
+        // Model<TApi>), matching the sibling `as never` casts in this file.
+        compat: { supportsInstructions: true },
+      } as never),
       {
         systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
         messages: [{ role: "user", content: "Hello", timestamp: 1 }],

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -10,7 +10,7 @@ import {
 import { testing } from "./openai-transport-stream.test-support.js";
 
 describe("openai transport stream", () => {
-  it("uses system role instead of developer for responses providers that disable developer role", () => {
+  it("carries the system prompt via top-level instructions for xAI responses providers", () => {
     const params = buildOpenAIResponsesParams(
       makeResponsesModel({
         id: "grok-4.1-fast",
@@ -24,12 +24,12 @@ describe("openai transport stream", () => {
         tools: [],
       } as never,
       undefined,
-    ) as { input?: Array<{ role?: string }> };
+    ) as { instructions?: string };
 
-    expect(params.input?.[0]?.role).toBe("system");
+    expect(params.instructions).toBe("system");
   });
 
-  it("adds explicit message item types for Responses system and user input items", () => {
+  it("adds explicit message item types for Responses user input items, carrying the system prompt via instructions", () => {
     const params = buildOpenAIResponsesParams(
       createAzureResponsesModel(),
       {
@@ -38,14 +38,13 @@ describe("openai transport stream", () => {
         tools: [],
       } as never,
       undefined,
-    ) as { input?: Array<{ type?: string; role?: string; content?: unknown }> };
+    ) as {
+      instructions?: string;
+      input?: Array<{ type?: string; role?: string; content?: unknown }>;
+    };
 
+    expect(params.instructions).toBe("system");
     expect(params.input?.[0]).toMatchObject({
-      type: "message",
-      role: "system",
-      content: [{ type: "input_text", text: "system" }],
-    });
-    expect(params.input?.[1]).toMatchObject({
       type: "message",
       role: "user",
       content: [{ type: "input_text", text: "hello" }],
@@ -143,7 +142,7 @@ describe("openai transport stream", () => {
     expect(params.include).toEqual(["reasoning.encrypted_content"]);
   });
 
-  it("keeps developer role for native OpenAI reasoning responses models", () => {
+  it("carries the system prompt via top-level instructions for native OpenAI reasoning responses models", () => {
     const params = buildOpenAIResponsesParams(
       makeResponsesModel({
         id: "gpt-5.4",
@@ -155,9 +154,9 @@ describe("openai transport stream", () => {
         tools: [],
       } as never,
       undefined,
-    ) as { input?: Array<{ role?: string }> };
+    ) as { instructions?: string };
 
-    expect(params.input?.[0]?.role).toBe("developer");
+    expect(params.instructions).toBe("system");
   });
 
   it("serializes Responses input messages with explicit message type and content parts", () => {
@@ -174,14 +173,10 @@ describe("openai transport stream", () => {
         tools: [],
       } as never,
       undefined,
-    ) as { input?: unknown };
+    ) as { instructions?: string; input?: unknown };
 
+    expect(params.instructions).toBe("system");
     expect(params.input).toEqual([
-      {
-        type: "message",
-        role: "system",
-        content: [{ type: "input_text", text: "system" }],
-      },
       {
         type: "message",
         role: "user",

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -31,7 +31,11 @@ describe("openai transport stream", () => {
 
   it("adds explicit message item types for Responses user input items, carrying the system prompt via instructions", () => {
     const params = buildOpenAIResponsesParams(
-      createAzureResponsesModel(),
+      // Azure is not verified for instructions by default (unlike native
+      // OpenAI/xAI); this test is about message-item-type structure once
+      // instructions is in play, so opt in explicitly. `compat` types to
+      // `never` for this API variant (no recognized branch in Model<TApi>).
+      { ...createAzureResponsesModel(), compat: { supportsInstructions: true } } as never,
       {
         systemPrompt: "system",
         messages: [{ role: "user", content: "hello" }],
@@ -166,6 +170,10 @@ describe("openai transport stream", () => {
         name: "GPT-5.4",
         provider: "microsoft-foundry",
         baseUrl: "https://example.services.ai.azure.com/api/projects/demo/openai/v1",
+        // Azure is not verified for instructions by default; this test is
+        // about message serialization structure once instructions is in
+        // play, so opt in explicitly.
+        compat: { supportsInstructions: true },
       }),
       {
         systemPrompt: "system",

--- a/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
+++ b/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
@@ -229,7 +229,7 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("store");
   });
 
-  it("uses system role for xAI default-route responses providers without relying on baseUrl host sniffing", () => {
+  it("carries the system prompt via top-level instructions for xAI default-route responses providers", () => {
     const params = buildOpenAIResponsesParams(
       makeResponsesModel({
         id: "grok-4.1-fast",
@@ -239,8 +239,8 @@ describe("openai transport stream", () => {
       }),
       emptyContext(),
       undefined,
-    ) as { input?: Array<{ role?: string }> };
+    ) as { instructions?: string };
 
-    expect(params.input?.[0]?.role).toBe("system");
+    expect(params.instructions).toBe("system");
   });
 });

--- a/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
+++ b/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
@@ -243,4 +243,27 @@ describe("openai transport stream", () => {
 
     expect(params.instructions).toBe("system");
   });
+
+  it("embeds the system prompt back in input for a route that opts out of instructions", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "custom-model",
+        name: "Custom Model",
+        api: "openai-responses",
+        provider: "custom-provider",
+        baseUrl: "https://proxy.example.com/v1",
+        compat: { supportsInstructions: false },
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } as never,
+      emptyContext(),
+      undefined,
+    ) as { instructions?: string; input?: Array<{ role?: string }> };
+
+    expect(params).not.toHaveProperty("instructions");
+    expect(params.input?.[0]?.role).toBe("system");
+  });
 });

--- a/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
+++ b/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
@@ -342,4 +342,20 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("instructions");
     expect(params.input?.[0]?.role).toBe("system");
   });
+
+  it("embeds the system prompt in input by default for Azure OpenAI, unlike native OpenAI", () => {
+    const params = buildOpenAIResponsesParams(
+      makeResponsesModel({
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        provider: "azure-openai",
+        baseUrl: "https://example.openai.azure.com/openai/responses",
+      }),
+      emptyContext(),
+      undefined,
+    ) as { instructions?: string; input?: Array<{ role?: string }> };
+
+    expect(params).not.toHaveProperty("instructions");
+    expect(params.input?.[0]?.role).toBe("system");
+  });
 });

--- a/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
+++ b/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
@@ -266,4 +266,48 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("instructions");
     expect(params.input?.[0]?.role).toBe("system");
   });
+
+  it("embeds the system prompt in input by default for an unverified custom proxy route", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "custom-model",
+        name: "Custom Model",
+        api: "openai-responses",
+        provider: "custom-provider",
+        baseUrl: "https://proxy.example.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } as never,
+      emptyContext(),
+      undefined,
+    ) as { instructions?: string; input?: Array<{ role?: string }> };
+
+    expect(params).not.toHaveProperty("instructions");
+    expect(params.input?.[0]?.role).toBe("system");
+  });
+
+  it("carries the system prompt via instructions for an unverified proxy route with an explicit opt-in", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "custom-model",
+        name: "Custom Model",
+        api: "openai-responses",
+        provider: "custom-provider",
+        baseUrl: "https://proxy.example.com/v1",
+        compat: { supportsInstructions: true },
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } as never,
+      emptyContext(),
+      undefined,
+    ) as { instructions?: string };
+
+    expect(params.instructions).toBe("system");
+  });
 });

--- a/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
+++ b/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
@@ -310,4 +310,36 @@ describe("openai transport stream", () => {
 
     expect(params.instructions).toBe("system");
   });
+
+  it("embeds the system prompt in input by default for a bundled-but-unverified named route (GitHub Copilot)", () => {
+    const params = buildOpenAIResponsesParams(
+      makeResponsesModel({
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        provider: "github-copilot",
+        baseUrl: "https://api.githubcopilot.com/v1",
+      }),
+      emptyContext(),
+      undefined,
+    ) as { instructions?: string; input?: Array<{ role?: string }> };
+
+    expect(params).not.toHaveProperty("instructions");
+    expect(params.input?.[0]?.role).toBe("system");
+  });
+
+  it("embeds the system prompt in input by default for a bundled-but-unverified named route (OpenCode)", () => {
+    const params = buildOpenAIResponsesParams(
+      makeResponsesModel({
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        provider: "opencode",
+        baseUrl: "https://opencode.ai/zen/v1",
+      }),
+      emptyContext(),
+      undefined,
+    ) as { instructions?: string; input?: Array<{ role?: string }> };
+
+    expect(params).not.toHaveProperty("instructions");
+    expect(params.input?.[0]?.role).toBe("system");
+  });
 });

--- a/src/agents/openai-transport-stream.replay-and-tools.test.ts
+++ b/src/agents/openai-transport-stream.replay-and-tools.test.ts
@@ -1399,11 +1399,9 @@ describe("openai transport stream", () => {
         tools: [],
       } as never,
       undefined,
-    ) as { input?: Array<{ content?: Array<{ type?: string; text?: string }> }> };
+    ) as { instructions?: string };
 
-    expect(params.input?.[0]?.content).toEqual([
-      { type: "input_text", text: "Stable prefix\nDynamic suffix" },
-    ]);
+    expect(params.instructions).toBe("Stable prefix\nDynamic suffix");
   });
 
   it("defaults responses tool schemas to strict on native OpenAI routes", () => {

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -622,6 +622,41 @@ describe("ModelRegistry models.json auth", () => {
     });
   });
 
+  it("preserves response-model instructions compatibility from generated catalogs", () => {
+    const modelsPath = writeModelsJsonWithPluginCatalog({
+      root: { providers: {} },
+      pluginRelativePath: join("plugins", "openai", PLUGIN_MODEL_CATALOG_FILE),
+      pluginCatalog: {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          openai: {
+            baseUrl: "https://proxy.example.com/v1",
+            api: "openai-responses",
+            apiKey: "test-token-placeholder",
+            models: [
+              {
+                id: "custom-model",
+                name: "Custom Model",
+                compat: { supportsInstructions: false },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ openai: { type: "api_key", key: "test-token-placeholder" } }),
+      modelsPath,
+      { pluginMetadataSnapshot: pluginOwnerSnapshot("openai", "openai") },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("openai", "custom-model")?.compat).toMatchObject({
+      supportsInstructions: false,
+    });
+  });
+
   it("loads richer generated catalog metadata without widening runtime inputs", () => {
     // Generated catalogs can report video/audio support. Keep those rows while
     // projecting their metadata to the runtime execution contract.

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -137,6 +137,7 @@ const OpenAICompletionsCompatSchema = Type.Object({
 
 const OpenAIResponsesCompatSchema = Type.Object({
   supportsTemperature: Type.Optional(Type.Boolean()),
+  supportsInstructions: Type.Optional(Type.Boolean()),
   sendSessionIdHeader: Type.Optional(Type.Boolean()),
   supportsLongCacheRetention: Type.Optional(Type.Boolean()),
 });

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -49,7 +49,10 @@ type SupportedOpenAICompatFields = Pick<
 
 type SupportedOpenAIResponsesCompatFields = Pick<
   OpenAIResponsesCompat,
-  "sendSessionIdHeader" | "supportsLongCacheRetention" | "supportsTemperature"
+  | "sendSessionIdHeader"
+  | "supportsLongCacheRetention"
+  | "supportsTemperature"
+  | "supportsInstructions"
 >;
 
 type SupportedAnthropicMessagesCompatFields = Pick<

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -270,6 +270,7 @@ const ModelCompatSchema = z
     supportsDeveloperRole: z.boolean().optional(),
     supportsReasoningEffort: z.boolean().optional(),
     supportsTemperature: z.boolean().optional(),
+    supportsInstructions: z.boolean().optional(),
     supportsUsageInStreaming: z.boolean().optional(),
     supportsTools: z.boolean().optional(),
     codeMode: z.enum(["preferred", "capable"]).optional(),

--- a/src/config/zod-schema.models.test.ts
+++ b/src/config/zod-schema.models.test.ts
@@ -133,4 +133,24 @@ describe("ModelsConfigSchema", () => {
 
     expect(result.success).toBe(true);
   });
+
+  it("accepts catalog-declared instructions compatibility", () => {
+    const result = ModelsConfigSchema.safeParse({
+      providers: {
+        "my-proxy": {
+          baseUrl: "https://proxy.example.com/v1",
+          api: "openai-responses",
+          models: [
+            {
+              id: "custom-model",
+              name: "Custom Model",
+              compat: { supportsInstructions: false },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

HTTP continuation (`previous_response_id` reuse) for the OpenAI Responses transport was permanently defeated for any non-Codex connection (native OpenAI direct-API-key, xAI, and OmniRoute-style custom Responses endpoints) whenever the system prompt changed between two turns — which happens routinely, since the embedded runner rebuilds the system prompt fresh on every attempt from live runtime state (active background processes, watched sessions, active-memory context, current date).

## Why This Change Was Made

`convertOpenAIResponsesMessagesForRequest` embedded the system prompt as `input[0]` for every non-Codex Responses request. `resolveResponsesContinuationRequest` (`packages/ai/src/transports/openai-responses-continuation.ts`) compares the cached previous request's `input` byte-for-byte against the current one to decide whether it can reuse `previous_response_id`; any drift in that first item — including ordinary runtime-state churn that has nothing to do with the actual conversation — forced a `history_changed` verdict and threw away continuation.

Native Codex/ChatGPT already avoided this by sending the system prompt via the separate `instructions` field, which sits outside the compared `input` array (confirmed via `isOpenAICodexResponsesModel`/`resolveOpenAICodexResponsesInstructions`). `isOpenAICodexResponsesModel` is narrowly scoped to the ChatGPT/Codex-OAuth API variant only, so every other Responses route (native OpenAI with an API key, xAI, custom/proxy endpoints) never got this protection.

Fix: broaden `instructions` to every Responses-API request (previously Codex-only), and exclude `instructions` from `requestWithoutInput`'s comparison, matching how `input` is already excluded there. `instructions` is still sent on the wire every request regardless of continuation status, so no freshness is lost — only the false-positive continuation rejection is removed.

While rolling this out I found and fixed a second, related bug: xAI's server-side `/responses/compact` endpoint (used for xAI/opted-in compaction, see `docs/providers/xai.md`) has no `instructions` field — confirmed live against `https://docs.x.ai/developers/advanced-api-usage/context-compaction`, which documents the system prompt as required to be the first `input` message. `postOpenAIResponsesCompaction` posts only `{ model, input }` built from the same `buildOpenAIResponsesParams` result the streaming path uses, so once the system prompt moved out of `input` it would have silently vanished from every compaction request. Fixed by re-embedding it just for that request body via a new `buildOpenAIResponsesCompactSystemMessage` helper, which reproduces the same developer/system role selection the old inline embedding used.

## User Impact

- OpenAI, xAI, and OmniRoute-style custom Responses connections can now actually engage HTTP continuation across turns, instead of falling back to full-history replay on effectively every request once the runtime has any live state that changes turn-to-turn (which is the common case for persistent/heartbeat sessions).
- No change to the wire contract seen by operators: `instructions` was already a valid, already-observed (`promptSource: "instructions"`) prompt-egress state; it's just no longer Codex-exclusive.
- xAI compaction requests keep receiving the system prompt exactly as before (still embedded in `input`, since that's xAI's endpoint contract) — this PR prevents what would otherwise have been a silent compaction-quality regression.

## Evidence

- Live external doc check confirming xAI's `/responses/compact` contract (no `instructions` field, system prompt must be `input[0]`): `https://docs.x.ai/developers/advanced-api-usage/context-compaction`.
- `packages/ai/` full suite: 108 files / 1910 tests passing.
- Targeted `src/agents/` surfaces (`openai-transport-stream.*`, `openai-responses*`, `openai-thinking-contract`, `embedded-agent-helpers/openai`, `prompt-cache-observability`, `provider-prompt-state`, `stream-resolution`): all passing.
- `src/agents/embedded-agent-runner/run/` (the runner's own consumer of these request-building helpers): 98 files / 1180 tests passing.
- New `packages/ai/src/transports/openai-responses-params-internal.test.ts` covering `buildOpenAIResponsesCompactSystemMessage`'s developer/system role selection, since that invariant lost its only other test path once the main streaming builder stopped embedding the role-bearing message in `input`.
- `pnpm tsgo -p tsconfig.core.json` clean.
- Autoreview: clean, 0 accepted/actionable findings (score 0.97).

This is a companion fix to #130166 (the heartbeat/cron inbound-metadata continuation fix, already merged) — that fix addressed one mechanism defeating continuation on OmniRoute; this addresses a second, broader one affecting the system-prompt path across all non-Codex Responses connections. Marking as draft pending live deployment/verification against a real OmniRoute-backed session, following the same pattern used for #130166.

## Live Deployment Verification

Deployed to Ping's real OmniRoute-backed gateway (daemonbitch, `ping-deploy-v2` branch, stacked on top of the already-merged #130166 heartbeat/cron fix). Restarted the gateway and inspected OmniRoute's own request-artifact log directly for the first live requests built by the new binary:

- `POST /v1/responses` at `2026-08-26T16:13:12.083Z` (session `agent:main:main`, 225 prior input items): `requestBody.instructions` is present (29,365 chars) and contains the actual system prompt verbatim (Tooling/Runtime/model-identity blocks) — confirmed by reading the full text, not the unrelated `<context_handoff>` string a different in-flight feature also happens to put in `instructions`. `requestBody.input[0].role` is `"user"`, not `"system"` — the system prompt is no longer embedded in `input`.
- Same shape confirmed again on the next heartbeat tick (`16:43:00.169Z`) and on two further requests in the same session 12s apart (`16:43:27.980Z` / `16:43:40.053Z`).
- Historical scan of the last ~3 hours of OmniRoute request artifacts (360 requests) shows HTTP continuation (`previous_response_id` present on the wire) genuinely engaging 4 times prior to this deploy — all attributable to #130166 (the heartbeat/cron metadata-stripping fix), confirming the underlying continuation pipeline (idle TTL, connection-identity matching) is healthy in this environment when its one remaining precondition (byte-stable `input`) holds.
- I did not catch a fresh `previous_response_id`-carrying request in the ~40-minute post-deploy observation window. Continuation only engages for same-session follow-ups issued within the ~90-minute idle TTL that are *not* immediately preceded by a context-compaction turn; both requests I observed in the same session were compaction-boundary turns (the request body opens with `The conversation history before this point was compacted into the following summary:`), which correctly cannot reuse a `previous_response_id` regardless of this fix — the `input` array is intentionally rebuilt from scratch after compaction. This is expected behavior, not a gap in the fix. I'm not blocking on catching a rarer non-compaction same-session follow-up live; the unit-level reproduction (`packages/ai/src/transports/openai-responses-continuation.test.ts` and the new `openai-responses-params-internal.test.ts`) already proves the exact byte-comparison behavior deterministically.

Marking ready for review — the fix is confirmed both by full test coverage and by direct inspection of the live request shape it produces.


## Update: real native OpenAI continuation proof at current head (`7bed52a189d`)

Closed the "final-head native OpenAI trace after prompt drift" gap. Added `openai-responses-payload-policy.instructions.live.test.ts`, gated on `OPENCLAW_LIVE_TEST=1` + `OPENAI_API_KEY` (matching the established `openai-responses-client.continuation.live.test.ts` pattern), run twice against the real `api.openai.com`:

- **Turn 1** (real `provider: "openai"`, `baseUrl: "https://api.openai.com/v1"`, no `compat` override — the exact default-on route this PR targets): the real captured request carries `instructions: "You are a terse test assistant."` at top level, no `input[0]` system/developer role, no `previous_response_id`.
- **Turn 2**: the real captured request carries `previous_response_id` (a real non-empty string returned by the API), `instructions` still present with the current text, and a single-message trimmed `input` (no repeated history). The model correctly recalled a secret code that was given **only** in turn 1's now-omitted history — this is semantic proof, not just structural: a silent full-history fallback would produce the same visible answer with the same request *shape* claim but a *different* actual `input` (full history, secret repeated) — the trimmed-input assertion together with the correct recall rules that out.

Captured via a `globalThis.fetch` wrapper rather than a forward-proxy, deliberately: a proxy would need to override the model's `baseUrl` to a loopback address, which would itself fail the exact-origin check `supportsNativeOpenAIResponsesEndpoint` (continuation eligibility) uses — the same reason a plain custom endpoint never got continuation for free before this PR.

Ran twice (once before, once after an unrelated lint fix); both passed.

`check:changed` and `autoreview` both clean.
