### PR TITLE
fix(docs): respect nested fenced code boundaries

### DIFF
--- a/scripts/docs-list.js
+++ b/scripts/docs-list.js
@@ -216,8 +216,12 @@ function extractHeadings(raw) {
     const trimmed = rawLine.trim();
     const fenceMatch = /^(?<marker>`{3,}|~{3,})/u.exec(trimmed);
     if (fenceMatch) {
-      const marker = fenceMatch.groups.marker[0];
-      fenceMarker = fenceMarker === marker ? null : (fenceMarker ?? marker);
+      const marker = fenceMatch.groups.marker;
+      if (!fenceMarker) {
+        fenceMarker = marker;
+      } else if (marker[0] === fenceMarker[0] && marker.length >= fenceMarker.length) {
+        fenceMarker = null;
+      }
       continue;
     }
     if (fenceMarker) {

--- a/test/scripts/docs-list.test.ts
+++ b/test/scripts/docs-list.test.ts
@@ -75,6 +75,12 @@ summary: "Page"
 \`\`\`md
 ### Hidden fenced heading
 \`\`\`
+
+\`\`\`\`md
+\`\`\`json
+### Hidden nested fenced heading
+\`\`\`
+\`\`\`\`
 `,
       "utf8",
     );
@@ -90,6 +96,7 @@ summary: "Page"
     expect(output).toContain("  - H4: `![label](https://example.test/image)`");
     expect(output).toContain("## nested/index.mdx\n\n- Route: /nested");
     expect(output).not.toContain("Hidden fenced heading");
+    expect(output).not.toContain("Hidden nested fenced heading");
     expect(output).not.toContain("AGENTS.md");
     expect(existsSync(path.join(tempRepoRoot, "docs", "docs_map.md"))).toBe(false);
   });


### PR DESCRIPTION
## What problem this solves

The generated documentation map incorrectly lists headings from code examples when a four-or-more-backtick fence contains a shorter fence. Agents and maintainers can then navigate to a heading that is only example text.

## Why this fix

The heading extractor kept only the opening fence character, so any fence with that character closed the block. It now retains the complete opening marker and requires a matching character and an equal-or-longer closing marker, as specified by [CommonMark’s fenced-code rules](https://spec.commonmark.org/0.31.2/#fenced-code-blocks). This repairs the shared generator used by the CLI, documentation publishing, and npm packaging.

The change adds four net tooling lines to retain the information needed for that boundary and seven test lines in the existing CLI regression fixture. It adds no configuration or dependency.

## Evidence

- The trusted current-main CLI, against a scratch documentation tree, printed `H3: Hidden nested fenced heading` from inside an outer four-backtick block containing a three-backtick fence. The real heading after the outer closing fence remained visible.
- On contributor head `5eeea9272a4bd713934a21edfc85acd927dc1d70`, the contributor's same CLI reproduction printed only the visible heading and omitted the hidden H3. The existing CLI-boundary test includes this regression; the contributor reports four focused tests passing.
- The maintainer-requested exact-head CI rerun passed on 2026-08-31 at 00:14:14 UTC: [CI run 33042080057](https://github.com/openclaw/openclaw/actions/runs/33042080057).
- Fresh independent Codex review found no P0 issues in the complete PR.
- Maintainer review inspected the complete generator and test file, publishing and packaging callers, current-main behavior, and the CommonMark fence-length contract. Contributor code was not executed on the credentialed maintainer host.

## Scope and follow-up

This corrects opening-length loss. Named follow-up: **docs-map fence conformance** in `scripts/docs-list.js`, covering pre-existing closing-fence suffix handling and MDX/list container indentation. This PR does not claim full CommonMark or MDX parsing. The separate link-audit parser repair in #132727 remains independent.

AI-assisted: yes.

Thanks @qingminglong.
