### PR TITLE
fix(embeddings): preserve provider endpoint query parameters

### DIFF
--- a/extensions/openai/embedding-batch.test.ts
+++ b/extensions/openai/embedding-batch.test.ts
@@ -2,6 +2,7 @@
 import { createServer } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runOpenAiEmbeddingBatches } from "./embedding-batch.js";
+import { createOpenAiEmbeddingProvider } from "./embedding-provider.js";
 
 const jsonlEncoder = new TextEncoder();
 
@@ -88,6 +89,113 @@ afterEach(() => {
 });
 
 describe("OpenAI embedding batch output", () => {
+  it("preserves configured query parameters on real direct embedding requests", async () => {
+    const received: Array<{ url: string; authorization: string | undefined }> = [];
+    const server = createServer((request, response) => {
+      received.push({ url: request.url ?? "", authorization: request.headers.authorization });
+      if (request.url !== "/tenant/v1/embeddings?api-version=2024-10-21&tenant=alpha") {
+        response.writeHead(404).end("wrong embedding endpoint");
+        return;
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ data: [{ embedding: [3, 5] }] }));
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      const { provider } = await createOpenAiEmbeddingProvider({
+        config: {},
+        provider: "openai",
+        model: "text-embedding-3-small",
+        fallback: "none",
+        remote: {
+          baseUrl: `http://127.0.0.1:${port}/tenant/v1/?api-version=2024-10-21&tenant=alpha#local`,
+          apiKey: "openai-loopback-key",
+        },
+      });
+
+      await expect(provider.embedQuery("hello")).resolves.toEqual([3, 5]);
+      expect(received).toEqual([
+        {
+          url: "/tenant/v1/embeddings?api-version=2024-10-21&tenant=alpha",
+          authorization: "Bearer openai-loopback-key",
+        },
+      ]);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("preserves configured query parameters through real batch upload, create, status, and output", async () => {
+    const received: Array<{ url: string; authorization: string | undefined }> = [];
+    const server = createServer((request, response) => {
+      const url = request.url ?? "";
+      received.push({ url, authorization: request.headers.authorization });
+      const parsed = new URL(url, "http://localhost");
+      if (parsed.search !== "?api-version=2024-10-21&tenant=alpha") {
+        response.writeHead(404).end("missing embedding tenant query");
+        return;
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      if (parsed.pathname === "/tenant/v1/files") {
+        response.end(JSON.stringify({ id: "input-0" }));
+      } else if (parsed.pathname === "/tenant/v1/batches") {
+        response.end(JSON.stringify({ id: "batch-0", status: "in_progress" }));
+      } else if (parsed.pathname === "/tenant/v1/batches/batch-0") {
+        response.end(
+          JSON.stringify({ id: "batch-0", status: "completed", output_file_id: "output-0" }),
+        );
+      } else if (parsed.pathname === "/tenant/v1/files/output-0/content") {
+        response.end(
+          JSON.stringify({
+            custom_id: "0",
+            response: { status_code: 200, body: { data: [{ embedding: [3, 5] }] } },
+          }),
+        );
+      } else {
+        response.end(JSON.stringify({ error: "unexpected embedding path" }));
+      }
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      const result = await runOpenAiEmbeddingBatches({
+        openAi: {
+          baseUrl: `http://127.0.0.1:${port}/tenant/v1/?api-version=2024-10-21&tenant=alpha#local`,
+          headers: { Authorization: "Bearer openai-loopback-key" },
+          model: "text-embedding-3-small",
+          ssrfPolicy: { allowedHostnames: ["127.0.0.1"] },
+        },
+        agentId: "main",
+        requests: [
+          {
+            custom_id: "0",
+            method: "POST",
+            url: "/v1/embeddings",
+            body: { model: "text-embedding-3-small", input: "hello" },
+          },
+        ],
+        wait: true,
+        concurrency: 1,
+        pollIntervalMs: 1,
+        timeoutMs: 10_000,
+      });
+
+      expect(result).toEqual(new Map([["0", [3, 5]]]));
+      expect(received.map(({ url }) => url)).toEqual([
+        "/tenant/v1/files?api-version=2024-10-21&tenant=alpha",
+        "/tenant/v1/batches?api-version=2024-10-21&tenant=alpha",
+        "/tenant/v1/batches/batch-0?api-version=2024-10-21&tenant=alpha",
+        "/tenant/v1/files/output-0/content?api-version=2024-10-21&tenant=alpha",
+      ]);
+      expect(
+        received.every(({ authorization }) => authorization === "Bearer openai-loopback-key"),
+      ).toBe(true);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
   it.each([
     {
       name: "pending status",

--- a/extensions/openai/embedding-batch.ts
+++ b/extensions/openai/embedding-batch.ts
@@ -8,9 +8,9 @@ import {
   extractBatchErrorMessage,
   formatBatchErrorDetail,
   formatUnavailableBatchError,
-  normalizeBatchBaseUrl,
   postJsonWithRetry,
   readEmbeddingBatchJsonl,
+  resolveEmbeddingEndpointUrl,
   resolveBatchCompletionFromStatus,
   resolveCompletedBatchResult,
   runEmbeddingBatchGroups,
@@ -66,7 +66,6 @@ async function submitOpenAiBatch(params: {
   requests: OpenAiBatchRequest[];
   agentId: string;
 }): Promise<OpenAiBatchStatus> {
-  const baseUrl = normalizeBatchBaseUrl(params.openAi);
   const inputFileId = await uploadBatchJsonlFile({
     client: params.openAi,
     requests: params.requests,
@@ -74,7 +73,7 @@ async function submitOpenAiBatch(params: {
   });
 
   return await postJsonWithRetry<OpenAiBatchStatus>({
-    url: `${baseUrl}/batches`,
+    url: resolveEmbeddingEndpointUrl(params.openAi.baseUrl, "batches"),
     headers: buildBatchHeaders(params.openAi, { json: true }),
     ssrfPolicy: params.openAi.ssrfPolicy,
     fetchImpl: params.openAi.fetchImpl,
@@ -143,9 +142,8 @@ async function fetchOpenAiBatchResource<T>(params: {
   signal?: AbortSignal;
   parse: (res: Response) => Promise<T>;
 }): Promise<T> {
-  const baseUrl = normalizeBatchBaseUrl(params.openAi);
   return await withRemoteHttpResponse({
-    url: `${baseUrl}${params.path}`,
+    url: resolveEmbeddingEndpointUrl(params.openAi.baseUrl, params.path),
     ssrfPolicy: params.openAi.ssrfPolicy,
     fetchImpl: params.openAi.fetchImpl,
     signal: params.signal,

--- a/extensions/openai/embedding-provider.test.ts
+++ b/extensions/openai/embedding-provider.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", () => ({
   fetchRemoteEmbeddingVectors: mocks.fetchRemoteEmbeddingVectors,
+  resolveEmbeddingEndpointUrl: (baseUrl: string, endpoint: string) => `${baseUrl}/${endpoint}`,
   resolveRemoteEmbeddingClient: mocks.resolveRemoteEmbeddingClient,
 }));
 

--- a/extensions/openai/embedding-provider.ts
+++ b/extensions/openai/embedding-provider.ts
@@ -1,6 +1,7 @@
 // Openai provider module implements model/runtime integration.
 import {
   fetchRemoteEmbeddingVectors,
+  resolveEmbeddingEndpointUrl,
   resolveRemoteEmbeddingClient,
   type MemoryEmbeddingProvider,
   type MemoryEmbeddingProviderCreateOptions,
@@ -49,7 +50,7 @@ export async function createOpenAiEmbeddingProvider(
   options: MemoryEmbeddingProviderCreateOptions,
 ): Promise<{ provider: MemoryEmbeddingProvider; client: OpenAiEmbeddingClient }> {
   const client = await resolveOpenAiEmbeddingClient(options);
-  const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
+  const url = resolveEmbeddingEndpointUrl(client.baseUrl, "embeddings");
 
   const resolveInputType = (kind: "query" | "document"): string | undefined => {
     const explicit = kind === "query" ? client.queryInputType : client.documentInputType;

--- a/extensions/voyage/embedding-batch.test.ts
+++ b/extensions/voyage/embedding-batch.test.ts
@@ -1,7 +1,9 @@
 // Voyage batch tests cover the real HTTP boundary and bounded response reads.
+import { once } from "node:events";
+import { createServer } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runVoyageEmbeddingBatches } from "./embedding-batch.js";
-import type { VoyageEmbeddingClient } from "./embedding-provider.js";
+import { createVoyageEmbeddingProvider, type VoyageEmbeddingClient } from "./embedding-provider.js";
 
 type VoyageBatchOptions = Parameters<typeof runVoyageEmbeddingBatches>[0];
 type BatchStage = "upload" | "create" | "status" | "output" | "error";
@@ -133,6 +135,121 @@ afterEach(() => {
 });
 
 describe("voyage batch bounded reads", () => {
+  it("preserves configured query parameters on real direct embedding requests", async () => {
+    const received: Array<{ url: string; authorization: string | undefined }> = [];
+    const server = createServer((request, response) => {
+      received.push({ url: request.url ?? "", authorization: request.headers.authorization });
+      if (request.url !== "/tenant/v1/embeddings?api-version=2024-10-21&tenant=beta") {
+        response.writeHead(404).end("wrong embedding endpoint");
+        return;
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ data: [{ embedding: [7, 11] }] }));
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback TCP address");
+    }
+
+    try {
+      const { provider } = await createVoyageEmbeddingProvider({
+        config: {},
+        provider: "voyage",
+        model: "voyage-3",
+        fallback: "none",
+        remote: {
+          baseUrl: `http://127.0.0.1:${address.port}/tenant/v1/?api-version=2024-10-21&tenant=beta#local`,
+          apiKey: "voyage-loopback-key",
+        },
+      });
+
+      await expect(provider.embedQuery("hello")).resolves.toEqual([7, 11]);
+      expect(received).toEqual([
+        {
+          url: "/tenant/v1/embeddings?api-version=2024-10-21&tenant=beta",
+          authorization: "Bearer voyage-loopback-key",
+        },
+      ]);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("preserves configured query parameters through real batch upload, create, status, and error output", async () => {
+    const received: Array<{ url: string; authorization: string | undefined }> = [];
+    const server = createServer((request, response) => {
+      const url = request.url ?? "";
+      received.push({ url, authorization: request.headers.authorization });
+      const parsed = new URL(url, "http://localhost");
+      if (parsed.search !== "?api-version=2024-10-21&tenant=beta") {
+        response.writeHead(404).end("missing embedding tenant query");
+        return;
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      if (parsed.pathname === "/tenant/v1/files") {
+        response.end(JSON.stringify({ id: "input-0" }));
+      } else if (parsed.pathname === "/tenant/v1/batches") {
+        response.end(JSON.stringify({ id: "batch-0", status: "in_progress" }));
+      } else if (parsed.pathname === "/tenant/v1/batches/batch-0") {
+        response.end(
+          JSON.stringify({
+            id: "batch-0",
+            status: "completed",
+            output_file_id: "output-0",
+            error_file_id: "error-0",
+          }),
+        );
+      } else if (parsed.pathname === "/tenant/v1/files/error-0/content") {
+        response.end(
+          JSON.stringify({
+            custom_id: "req-0",
+            response: { status_code: 500, message: "provider rejected request" },
+            error: null,
+          }),
+        );
+      } else {
+        response.end(JSON.stringify({ error: "unexpected embedding path" }));
+      }
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback TCP address");
+    }
+
+    try {
+      await expect(
+        runBatch({
+          client: {
+            baseUrl: `http://127.0.0.1:${address.port}/tenant/v1/?api-version=2024-10-21&tenant=beta#local`,
+            headers: { Authorization: "Bearer voyage-loopback-key" },
+            model: "voyage-3",
+            ssrfPolicy: { allowedHostnames: ["127.0.0.1"] },
+          },
+        }),
+      ).rejects.toThrow("voyage batch batch-0 completed: provider rejected request");
+
+      expect(received.map(({ url }) => url)).toEqual([
+        "/tenant/v1/files?api-version=2024-10-21&tenant=beta",
+        "/tenant/v1/batches?api-version=2024-10-21&tenant=beta",
+        "/tenant/v1/batches/batch-0?api-version=2024-10-21&tenant=beta",
+        "/tenant/v1/files/error-0/content?api-version=2024-10-21&tenant=beta",
+      ]);
+      expect(
+        received.every(({ authorization }) => authorization === "Bearer voyage-loopback-key"),
+      ).toBe(true);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("clamps polling to the remaining batch timeout", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);

--- a/extensions/voyage/embedding-batch.ts
+++ b/extensions/voyage/embedding-batch.ts
@@ -7,9 +7,9 @@ import {
   extractBatchErrorMessage,
   formatBatchErrorDetail,
   formatUnavailableBatchError,
-  normalizeBatchBaseUrl,
   postJsonWithRetry,
   readEmbeddingBatchJsonl,
+  resolveEmbeddingEndpointUrl,
   resolveBatchCompletionFromStatus,
   resolveCompletedBatchResult,
   runEmbeddingBatchGroups,
@@ -60,9 +60,8 @@ function buildVoyageBatchRequest<T>(params: {
   signal?: AbortSignal;
   onResponse: (res: Response) => Promise<T>;
 }) {
-  const baseUrl = normalizeBatchBaseUrl(params.client);
   return {
-    url: `${baseUrl}/${params.path}`,
+    url: resolveEmbeddingEndpointUrl(params.client.baseUrl, params.path),
     ssrfPolicy: params.client.ssrfPolicy,
     signal: params.signal,
     init: {
@@ -77,7 +76,6 @@ async function submitVoyageBatch(params: {
   requests: VoyageBatchRequest[];
   agentId: string;
 }): Promise<VoyageBatchStatus> {
-  const baseUrl = normalizeBatchBaseUrl(params.client);
   const inputFileId = await uploadBatchJsonlFile({
     client: params.client,
     requests: params.requests,
@@ -86,7 +84,7 @@ async function submitVoyageBatch(params: {
 
   // 2. Create batch job using Voyage Batches API
   return await postJsonWithRetry<VoyageBatchStatus>({
-    url: `${baseUrl}/batches`,
+    url: resolveEmbeddingEndpointUrl(params.client.baseUrl, "batches"),
     headers: buildBatchHeaders(params.client, { json: true }),
     ssrfPolicy: params.client.ssrfPolicy,
     body: {
@@ -294,12 +292,14 @@ export async function runVoyageEmbeddingBatches(
           }),
       });
 
-      const baseUrl = normalizeBatchBaseUrl(params.client);
       const errors: string[] = [];
       const remaining = new Set(group.map((request) => request.custom_id));
 
       await withRemoteHttpResponse({
-        url: `${baseUrl}/files/${completed.outputFileId}/content`,
+        url: resolveEmbeddingEndpointUrl(
+          params.client.baseUrl,
+          `files/${completed.outputFileId}/content`,
+        ),
         ssrfPolicy: params.client.ssrfPolicy,
         init: {
           headers: buildBatchHeaders(params.client, { json: true }),

--- a/extensions/voyage/embedding-provider.ts
+++ b/extensions/voyage/embedding-provider.ts
@@ -2,6 +2,7 @@
 import {
   fetchRemoteEmbeddingVectors,
   normalizeEmbeddingModelWithPrefixes,
+  resolveEmbeddingEndpointUrl,
   resolveRemoteEmbeddingBearerClient,
   type MemoryEmbeddingProvider,
   type MemoryEmbeddingProviderCreateOptions,
@@ -35,7 +36,7 @@ export async function createVoyageEmbeddingProvider(
   options: MemoryEmbeddingProviderCreateOptions,
 ): Promise<{ provider: MemoryEmbeddingProvider; client: VoyageEmbeddingClient }> {
   const client = await resolveVoyageEmbeddingClient(options);
-  const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
+  const url = resolveEmbeddingEndpointUrl(client.baseUrl, "embeddings");
 
   const embed = async (
     input: string[],

--- a/packages/memory-host-sdk/src/host/batch-upload.ts
+++ b/packages/memory-host-sdk/src/host/batch-upload.ts
@@ -1,9 +1,6 @@
 // Memory Host SDK module implements batch upload behavior.
-import {
-  buildBatchHeaders,
-  normalizeBatchBaseUrl,
-  type BatchHttpClientConfig,
-} from "./batch-utils.js";
+import { buildBatchHeaders, type BatchHttpClientConfig } from "./batch-utils.js";
+import { resolveEmbeddingEndpointUrl } from "./embeddings-remote-client.js";
 import { formatErrorMessage } from "./error-utils.js";
 import { hashText } from "./hash.js";
 import { withRemoteHttpResponse } from "./remote-http.js";
@@ -22,7 +19,6 @@ export async function uploadBatchJsonlFile(params: {
   maxResponseBytes?: number;
   signal?: AbortSignal;
 }): Promise<string> {
-  const baseUrl = normalizeBatchBaseUrl(params.client);
   const jsonl = params.requests.map((request) => JSON.stringify(request)).join("\n");
   const form = new FormData();
   form.append("purpose", "batch");
@@ -33,7 +29,7 @@ export async function uploadBatchJsonlFile(params: {
   );
 
   const filePayload = await withRemoteHttpResponse({
-    url: `${baseUrl}/files`,
+    url: resolveEmbeddingEndpointUrl(params.client.baseUrl ?? "", "files"),
     ssrfPolicy: params.client.ssrfPolicy,
     fetchImpl: params.client.fetchImpl,
     signal: params.signal,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenAI-compatible and Voyage embedding providers fail when a configured endpoint includes query parameters, such as an API version or tenant identifier. Direct embedding requests and asynchronous batch uploads, job creation, polling, and result/error downloads previously appended their route after the query string, producing an invalid endpoint.

## Why This Change Was Made

Both providers and the shared batch uploader now construct their endpoint URLs through the existing canonical embedding endpoint resolver. This preserves the configured origin, base path, and query parameters, strips fragments, and removes duplicated string-concatenation paths. Existing authorization headers, SSRF policy, stable public batch URL normalization, and the batch JSONL `/v1/embeddings` contract remain unchanged. Google batch routing is deliberately excluded because its upload/download routes and query parameters have a separate provider-specific contract.

Production LOC: +17/-21 (net -4). Tests: +227/-1 (net +226).

## User Impact

OpenAI-compatible and Voyage deployments that require query-bearing embedding endpoints can now execute both direct embeddings and their complete asynchronous batch workflows without losing API-version or tenant parameters.

## Evidence

- Before the change, four genuine localhost HTTP scenarios failed: direct OpenAI embeddings, direct Voyage embeddings, OpenAI batch upload/create/poll/result download, and Voyage batch upload/create/poll/error download.
- After the change, all 117 tests across 13 provider and shared-memory SDK suites pass, including all four real-network regressions and coverage for authorization headers, SSRF handling, upload, polling, results, and errors.
- Full type-aware and type-check lint passes for six of the eight changed files. The two OpenAI production modules require generated plugin SDK declarations that are unavailable in this isolated checkout; existing generated declarations predate the current endpoint-resolver export and were deliberately not reused. Exact-head hosted type-aware CI must pass before landing.
- Formatting, an independent architecture review, an adversarial contract review, and the complete change review all pass.
