### PR TITLE
fix(daemon): recovery hints target the wrong profile or container

### DIFF
--- a/src/cli/daemon-cli/shared.test.ts
+++ b/src/cli/daemon-cli/shared.test.ts
@@ -6,7 +6,6 @@ import {
   parsePortFromArgs,
   renderRuntimeHints,
   renderGatewayServiceStartHints,
-  resolveDaemonContainerContext,
   resolveRuntimeStatusColor,
 } from "./shared.js";
 
@@ -59,19 +58,6 @@ describe("renderGatewayServiceStartHints", () => {
         {} as NodeJS.ProcessEnv,
       ).join("\n"),
     ).toContain("logged-in macOS GUI session");
-  });
-
-  it("resolves daemon container context from either env key", () => {
-    expect(
-      resolveDaemonContainerContext({
-        OPENCLAW_CONTAINER: "openclaw-demo-container",
-      } as NodeJS.ProcessEnv),
-    ).toBe("openclaw-demo-container");
-    expect(
-      resolveDaemonContainerContext({
-        OPENCLAW_CONTAINER_HINT: "openclaw-demo-container",
-      } as NodeJS.ProcessEnv),
-    ).toBe("openclaw-demo-container");
   });
 
   it("prepends a single container restart hint when OPENCLAW_CONTAINER is set", () => {

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -19,7 +19,6 @@ import { createDaemonActionContext } from "./response.js";
 
 export { formatRuntimeStatus };
 export { parsePort };
-export { resolveDaemonContainerContext };
 
 /** Create install action context with JSON flag normalization. */
 export function createDaemonInstallActionContext(jsonFlag: unknown) {

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -475,7 +475,7 @@ describe("printDaemonStatus", () => {
     expect(renderSystemdUnavailableHintsMock).toHaveBeenCalledWith({
       wsl: true,
       kind: "generic_unavailable",
-      container: false,
+      env: { WSL_DISTRO_NAME: "Ubuntu" },
     });
     expectMockLineContains(runtime.log, "Service: systemd (unknown)");
     expect(runtime.log.mock.calls.flat().join("\n")).not.toContain("Service: systemd (not loaded)");

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -107,7 +107,6 @@ vi.mock("./shared.js", () => ({
   filterDaemonEnv: () => ({}),
   formatRuntimeStatus: () => "running (pid 8000)",
   resolveRuntimeStatusColor: () => "",
-  resolveDaemonContainerContext: () => null,
   renderRuntimeHints: () => [],
   safeDaemonEnv: () => [],
 }));

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -29,7 +29,6 @@ import {
   createCliStatusTextStyles,
   filterDaemonEnv,
   formatRuntimeStatus,
-  resolveDaemonContainerContext,
   resolveRuntimeStatusColor,
   renderRuntimeHints,
   safeDaemonEnv,
@@ -407,12 +406,11 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
     isSystemdUnavailableDetail(systemdUnavailableDetail);
   if (systemdUnavailable) {
     const serviceEnv = service.command?.environment ?? process.env;
-    const container = Boolean(resolveDaemonContainerContext(serviceEnv));
     defaultRuntime.error(errorText("systemd user services unavailable."));
     for (const hint of renderSystemdUnavailableHints({
       wsl: isWSLEnv(serviceEnv),
       kind: classifySystemdUnavailableDetail(systemdUnavailableDetail),
-      container,
+      env: serviceEnv,
     })) {
       defaultRuntime.error(errorText(hint));
     }

--- a/src/commands/doctor-format.test.ts
+++ b/src/commands/doctor-format.test.ts
@@ -58,6 +58,34 @@ describe("buildGatewayRuntimeHints", () => {
     expect(hints.join("\n")).not.toContain("systemd user services are unavailable");
   });
 
+  it.each([
+    {
+      env: { OPENCLAW_PROFILE: "blue" },
+      command: "openclaw --profile blue gateway",
+    },
+    {
+      env: { OPENCLAW_CONTAINER_HINT: "sandbox" },
+      command: "openclaw --container sandbox gateway",
+    },
+    {
+      env: { OPENCLAW_PROFILE: "blue", OPENCLAW_CONTAINER_HINT: "sandbox" },
+      command: "openclaw --container sandbox gateway",
+    },
+  ])("preserves the active target in systemd recovery commands: $command", ({ env, command }) => {
+    const hints = buildGatewayRuntimeHints(
+      {
+        status: "unknown",
+        detail: "systemctl --user unavailable: Failed to connect to bus",
+      },
+      { platform: "linux", env },
+    );
+
+    expect(hints.some((hint) => hint.includes(command))).toBe(true);
+    expect(hints.some((hint) => hint.includes("headless server"))).toBe(
+      !env.OPENCLAW_CONTAINER_HINT,
+    );
+  });
+
   it("guides recovery when systemd hit its restart start limit (crash loop)", () => {
     // Real give-up shape: process kept failing (Result=exit-code) until NRestarts
     // reached StartLimitBurst and systemd stopped restarting.

--- a/src/commands/doctor-format.ts
+++ b/src/commands/doctor-format.ts
@@ -5,7 +5,6 @@ import {
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
 } from "../daemon/constants.js";
-import { resolveDaemonContainerContext } from "../daemon/container-context.js";
 import { formatRuntimeStatus } from "../daemon/runtime-format.js";
 import { buildPlatformRuntimeLogHints } from "../daemon/runtime-hints.js";
 import {
@@ -45,7 +44,6 @@ export function buildGatewayRuntimeHints(
   }
   const platform = options.platform ?? process.platform;
   const env = options.env ?? process.env;
-  const container = Boolean(resolveDaemonContainerContext(env));
   const fileLog = (() => {
     try {
       return getResolvedLoggerSettings().file;
@@ -58,7 +56,7 @@ export function buildGatewayRuntimeHints(
       ...renderSystemdUnavailableHints({
         wsl: isWSLEnv(env),
         kind: classifySystemdUnavailableDetail(runtime.detail),
-        container,
+        env,
       }),
     );
     if (fileLog) {

--- a/src/daemon/systemd-hints.test.ts
+++ b/src/daemon/systemd-hints.test.ts
@@ -49,14 +49,15 @@ describe("renderSystemdUnavailableHints", () => {
   });
 
   it("skips headless recovery hints when container context is known", () => {
+    const env = { OPENCLAW_CONTAINER_HINT: "sandbox" };
     expect(
       renderSystemdUnavailableHints({
         kind: "user_bus_unavailable",
-        container: true,
+        env,
       }),
     ).toEqual([
       "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
-      `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway")}\`.`,
+      `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway", env)}\`.`,
     ]);
   });
 });

--- a/src/daemon/systemd-hints.ts
+++ b/src/daemon/systemd-hints.ts
@@ -1,5 +1,6 @@
 /** Renders Linux systemd availability hints for gateway service commands. */
 import { formatCliCommand } from "../cli/command-format.js";
+import { resolveDaemonContainerContext } from "./container-context.js";
 import {
   classifySystemdUnavailableDetail,
   type SystemdUnavailableKind,
@@ -8,7 +9,7 @@ import {
 type SystemdUnavailableHintOptions = {
   wsl?: boolean;
   kind?: SystemdUnavailableKind | null;
-  container?: boolean;
+  env?: Record<string, string | undefined>;
 };
 
 /** Detects details that should get systemd availability repair hints. */
@@ -36,9 +37,9 @@ export function renderSystemdUnavailableHints(
   }
   return [
     "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
-    ...(options.container || options.kind !== "user_bus_unavailable"
+    ...(resolveDaemonContainerContext(options.env) || options.kind !== "user_bus_unavailable"
       ? []
       : renderSystemdHeadlessServerHints()),
-    `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway")}\`.`,
+    `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway", options.env)}\`.`,
   ];
 }


### PR DESCRIPTION
Closes #130214

## What Problem This Solves

Fixes an issue where Linux users diagnosing a gateway without an available systemd user service would receive a recovery command for the default gateway instead of their selected profile or container. Copying the suggested command could therefore start the wrong gateway.

## Why This Change Was Made

The shared systemd-hint owner now receives the same service environment that already drives doctor and gateway-status diagnostics. It resolves container context and formats the command from that one canonical environment; existing callers without an explicit environment continue to use their current process environment.

This removes duplicated container detection from both callers and deletes the resulting obsolete CLI helper re-export instead of preserving a test-only production seam. Existing WSL and headless-server behavior and container-over-profile precedence remain unchanged. Production delta: +6/-10, net -4 lines.

## User Impact

Recovery hints now remain copy-pasteable for `openclaw --profile blue gateway` and `openclaw --container sandbox gateway`, including when both settings are present. No service, authentication, configuration, or persistence behavior changes.

## Evidence

- Added one table-driven production-boundary regression covering profile, container, and container-over-profile precedence. All three cases failed against the unmodified code before the fix.
- Passed 256 exact-head owner and sibling tests across eight suites covering systemd hints, doctor formatting, gateway-status rendering, daemon responses, service environments, and doctor repair policy; one existing unrelated test is skipped.
- Reproduced the exact hosted dependency/export failure and passed the full `pnpm deadcode:full` gate locally after removing the obsolete re-export.
- Passed the actual repository formatter, configured lint rule, and whitespace checks.
- Independent source-level review verified all five production callers; a fresh Codex autoreview found no actionable issues.
- Reproduced the operator-visible production formatter with isolated profile/container environments; no user state, services, provider credentials, or external systems were touched.
