### PR TITLE
fix(browser): restore new-element markers across snapshot requests

### DIFF
--- a/extensions/browser/src/browser/routes/agent.snapshot.local-managed.test.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.local-managed.test.ts
@@ -103,17 +103,17 @@ vi.mock("./agent.shared.js", () => ({
 
 const { registerBrowserAgentSnapshotRoutes } = await import("./agent.snapshot.js");
 
-function getSnapshotGetHandler() {
+function getSnapshotGetHandler(
+  state = {
+    resolved: {
+      actionTimeoutMs: 60_000,
+      extraArgs: [],
+      ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
+    },
+  },
+) {
   const { app, getHandlers } = createBrowserRouteApp();
-  registerBrowserAgentSnapshotRoutes(app, {
-    state: () => ({
-      resolved: {
-        actionTimeoutMs: 60_000,
-        extraArgs: [],
-        ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
-      },
-    }),
-  } as never);
+  registerBrowserAgentSnapshotRoutes(app, { state: () => state } as never);
   const handler = getHandlers.get("/snapshot");
   expect(handler).toBeTypeOf("function");
   return handler;
@@ -242,6 +242,31 @@ describe("local-managed browser snapshot routes", () => {
 
     const secondCall = cdpMocks.snapshotRoleViaCdp.mock.calls[1]?.[0];
     expect(secondCall).toMatchObject({
+      delta: { mode: "role", previousKeys: expect.any(Set) },
+    });
+  });
+
+  it("reuses same-document delta keys across request contexts in one browser runtime", async () => {
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockResolvedValue(undefined);
+    const state = {
+      resolved: {
+        actionTimeoutMs: 60_000,
+        extraArgs: [],
+        ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
+      },
+    };
+    const firstHandler = getSnapshotGetHandler(state);
+    const secondHandler = getSnapshotGetHandler(state);
+    const first = createBrowserRouteResponse();
+    const second = createBrowserRouteResponse();
+    const request = { params: {}, query: { format: "ai", interactive: "true" } };
+
+    await firstHandler?.(request, first.res);
+    await secondHandler?.(request, second.res);
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(cdpMocks.snapshotRoleViaCdp.mock.calls[1]?.[0]).toMatchObject({
       delta: { mode: "role", previousKeys: expect.any(Set) },
     });
   });

--- a/extensions/browser/src/browser/snapshot-delta-cache.test.ts
+++ b/extensions/browser/src/browser/snapshot-delta-cache.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { finalizeRoleSnapshot } from "./pw-role-snapshot.js";
-import type { BrowserRouteContext } from "./server-context.types.js";
+import type { BrowserRouteContext, BrowserServerState } from "./server-context.types.js";
 import {
+  clearSnapshotKeysForTab,
   getPreviousSnapshotKeys,
   recordSnapshotKeys,
   type SnapshotDeltaFamily,
@@ -9,8 +10,8 @@ import {
 
 const family: SnapshotDeltaFamily = { identity: "role", interactive: true };
 
-function createContext(): BrowserRouteContext {
-  return {} as BrowserRouteContext;
+function createContext(state: BrowserServerState = {} as BrowserServerState): BrowserRouteContext {
+  return { state: () => state } as BrowserRouteContext;
 }
 
 function cacheScope(documentIdentity: string) {
@@ -56,5 +57,108 @@ describe("snapshot delta cache", () => {
 
     expect(snapshot.snapshot).toContain('- alert "Required" [ref=e8] [new]');
     expect(snapshot.newElements).toBe(1);
+  });
+
+  it("marks new elements across requests sharing one browser runtime", () => {
+    const state = {} as BrowserServerState;
+    const firstRequest = createContext(state);
+    const secondRequest = createContext(state);
+    const scope = cacheScope("pw:document-1");
+
+    recordSnapshotKeys(firstRequest, {
+      ...scope,
+      refs: { e1: { role: "button", name: "Save" } },
+    });
+
+    const snapshot = finalizeRoleSnapshot({
+      snapshot: ['- button "Save" [ref=e7]', '- alert "Required" [ref=e8]'].join("\n"),
+      refs: {
+        e7: { role: "button", name: "Save" },
+        e8: { role: "alert", name: "Required" },
+      },
+      delta: { mode: "role", previousKeys: getPreviousSnapshotKeys(secondRequest, scope) },
+    });
+
+    expect(snapshot.snapshot).toContain('- alert "Required" [ref=e8] [new]');
+    expect(snapshot.newElements).toBe(1);
+  });
+
+  it("does not reuse snapshot baselines after a browser runtime restart", () => {
+    const previousRuntime = createContext();
+    const restartedRuntime = createContext();
+    const scope = cacheScope("pw:document-1");
+
+    recordSnapshotKeys(previousRuntime, {
+      ...scope,
+      refs: { e1: { role: "button", name: "Save" } },
+    });
+
+    expect(getPreviousSnapshotKeys(restartedRuntime, scope)).toBeUndefined();
+  });
+
+  it.each([
+    { name: "profile", scope: { profile: "other" } },
+    { name: "tab", scope: { targetId: "tab-2" } },
+    { name: "snapshot options", scope: { family: { ...family, compact: true } } },
+  ])("isolates snapshot baselines by $name", ({ scope: alternateScope }) => {
+    const state = {} as BrowserServerState;
+    const firstRequest = createContext(state);
+    const secondRequest = createContext(state);
+    const scope = cacheScope("pw:document-1");
+
+    recordSnapshotKeys(firstRequest, {
+      ...scope,
+      refs: { e1: { role: "button", name: "Save" } },
+    });
+
+    expect(getPreviousSnapshotKeys(secondRequest, { ...scope, ...alternateScope })).toBeUndefined();
+  });
+
+  it("clears a closed tab's baseline from a later browser request", () => {
+    const state = {} as BrowserServerState;
+    const snapshotRequest = createContext(state);
+    const closeRequest = createContext(state);
+    const laterRequest = createContext(state);
+    const scope = cacheScope("pw:document-1");
+    const otherTab = { ...scope, targetId: "tab-2" };
+
+    for (const tabScope of [scope, otherTab]) {
+      recordSnapshotKeys(snapshotRequest, {
+        ...tabScope,
+        refs: { e1: { role: "button", name: "Save" } },
+      });
+    }
+
+    clearSnapshotKeysForTab(closeRequest, scope.profile, scope.targetId);
+
+    expect(getPreviousSnapshotKeys(laterRequest, scope)).toBeUndefined();
+    expect(getPreviousSnapshotKeys(laterRequest, otherTab)).toBeInstanceOf(Set);
+  });
+
+  it("evicts the oldest snapshot baseline after the 32-entry runtime limit", () => {
+    const state = {} as BrowserServerState;
+    const firstRequest = createContext(state);
+    const secondRequest = createContext(state);
+
+    for (let index = 0; index < 33; index += 1) {
+      recordSnapshotKeys(firstRequest, {
+        ...cacheScope("pw:document-1"),
+        targetId: `tab-${index}`,
+        refs: { e1: { role: "button", name: "Save" } },
+      });
+    }
+
+    expect(
+      getPreviousSnapshotKeys(secondRequest, {
+        ...cacheScope("pw:document-1"),
+        targetId: "tab-0",
+      }),
+    ).toBeUndefined();
+    expect(
+      getPreviousSnapshotKeys(secondRequest, {
+        ...cacheScope("pw:document-1"),
+        targetId: "tab-32",
+      }),
+    ).toBeInstanceOf(Set);
   });
 });

--- a/extensions/browser/src/browser/snapshot-delta-cache.ts
+++ b/extensions/browser/src/browser/snapshot-delta-cache.ts
@@ -3,11 +3,11 @@ import {
   type RoleRefMap,
   type RoleSnapshotIdentityMode,
 } from "./pw-role-snapshot.js";
-import type { BrowserRouteContext } from "./server-context.types.js";
+import type { BrowserRouteContext, BrowserServerState } from "./server-context.types.js";
 
 /**
- * Process-local snapshot delta state owned by one Browser control-server context.
- * Each tab/options family keeps one bounded previous-key slot; restart or tab close drops it.
+ * Process-local snapshot delta state owned by one browser control runtime.
+ * Each tab/options family keeps one previous-key slot; restart or tab close drops it.
  */
 const SNAPSHOT_DELTA_CACHE_MAX_ENTRIES = 32;
 
@@ -29,15 +29,15 @@ type SnapshotDeltaEntry = {
   keys: Set<string>;
 };
 
-const cacheByContext = new WeakMap<BrowserRouteContext, Map<string, SnapshotDeltaEntry>>();
+const cacheByState = new WeakMap<BrowserServerState, Map<string, SnapshotDeltaEntry>>();
 
 function getCache(ctx: BrowserRouteContext): Map<string, SnapshotDeltaEntry> {
-  const existing = cacheByContext.get(ctx);
+  const existing = cacheByState.get(ctx.state());
   if (existing) {
     return existing;
   }
   const cache = new Map<string, SnapshotDeltaEntry>();
-  cacheByContext.set(ctx, cache);
+  cacheByState.set(ctx.state(), cache);
   return cache;
 }
 
@@ -108,7 +108,7 @@ export function clearSnapshotKeysForTab(
   profile: string,
   targetId: string,
 ): void {
-  const cache = cacheByContext.get(ctx);
+  const cache = cacheByState.get(ctx.state());
   if (!cache) {
     return;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users taking consecutive managed-browser snapshots through the Gateway, local browser dispatch, or node-host browser proxy would never see newly appeared controls marked `[new]`, even though the browser tool advertises snapshot deltas. Closing a tab through a later request also failed to clear that tab's previous snapshot baseline.

This affects the snapshot-delta capability on current `main` and beta builds; it is not claimed to be a regression in a stable release.

## Why This Change Was Made

The snapshot cache was keyed by `BrowserRouteContext`, but each of those three request entry points creates a fresh context. Key its existing 32-entry `WeakMap` by the shared lifecycle-owned `BrowserServerState` instead, so contexts in the same browser runtime share baselines and tab cleanup while runtime restarts remain isolated. Existing profile, tab, snapshot-option, and authoritative document-identity boundaries are preserved. Existing-session Chrome MCP remains intentionally excluded when it cannot provide a stable document identity.

Production code: +7/-7 (net zero). No new configuration, public API, persistence, fallback, or dependency.

## User Impact

Managed-browser and CDP snapshots now identify newly added page controls across normal independent requests, helping agents notice and interact with dynamic UI. A first snapshot and a newly navigated document correctly start without delta markers; closing a tab clears only that tab's history.

## Evidence

- Added realistic owner and actual managed-route regressions; before the fix, four tests failed because new request contexts lost visible `[new]` markers, previous keys, cross-request cleanup, and cache retention.
- After the fix, focused owner/route regressions pass: `node scripts/run-vitest.mjs extensions/browser/src/browser/snapshot-delta-cache.test.ts extensions/browser/src/browser/routes/agent.snapshot.local-managed.test.ts` (17/17).
- Broader browser, tab, Gateway, node-host, lifecycle, and existing-session sibling coverage passes: 9 test files, 119 tests.
- Real isolated headless Chrome driven by the patched production browser dispatcher, with an independently recreated route context for every request: first snapshot unmarked; after adding a button, the next snapshot contains `[new]` and reports `newElements: 1`; navigating to a new document resets the baseline. Task-owned browser, tab, and temporary profile were removed afterward.
- Formatting, both browser-plugin typecheck lanes, changed-file lint, dead-export checks, architecture checks, and mandatory independent Codex autoreview pass. The global runtime-sidecar-loader guard also passes from the installed-dependency checkout; running that unrelated guard inside a dependency-less linked worktree cannot resolve its hard-coded `node_modules/playwright-core` path.

Codex-assisted; reviewed against the browser runtime lifecycle and all three request entry points.
