### PR TITLE
test: restore doctor release validation coverage

### DIFF
--- a/src/commands/doctor.fast-path-mocks.ts
+++ b/src/commands/doctor.fast-path-mocks.ts
@@ -18,7 +18,10 @@ vi.mock("./doctor-auth-flat-profiles.js", () => ({
 }));
 
 vi.mock("./doctor-auth-legacy-oauth.js", () => ({
-  maybeRepairLegacyOAuthProfileIds: vi.fn(async (cfg: unknown) => cfg),
+  maybeRepairLegacyOAuthProfileIds: vi.fn(async (cfg: unknown) => ({
+    config: cfg,
+    retiredProfileCleanupPlans: [],
+  })),
 }));
 
 vi.mock("./doctor-auth-oauth-sidecar.js", () => ({


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the repo-E2E doctor suite lost its canonical config after the auth-profile phase, causing 15 doctor assertions to fail in release validation.

## Why This Change Was Made

The shared fast-path mock now implements the current `maybeRepairLegacyOAuthProfileIds` result contract: it returns the unchanged config together with an empty retired-profile cleanup plan. The production owner changed to this structured result in #129052, but this fixture retained the former bare-config contract.

## User Impact

No runtime behavior changes. Release validation once again exercises all doctor phases instead of cascading through caught `cfg`-undefined failures.

## Evidence

- Before, current main in original order: 15 failed / 12 passed; every failure followed `doctor:auth-profiles run failed` and subsequent `Cannot read properties of undefined (reading 'agents')` warnings.
- After: `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts --reporter=dot` — 27 passed.
- Sibling shared-fixture consumer: `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/commands/doctor.warns-per-agent-sandbox-docker-browser-prune.e2e.test.ts --reporter=dot` — 2 passed.
- Exact failing jobs: [98097288314](https://github.com/openclaw/openclaw/actions/runs/32942593540/job/98097288314), [98084893822](https://github.com/openclaw/openclaw/actions/runs/32938513977/job/98084893822).
- Packaged doctor-switch lane was already green: [98026858758](https://github.com/openclaw/openclaw/actions/runs/32917859227/job/98026858758).
- Autoreview: clean, no actionable findings.

Test audit: the existing 27 assertions are the regression proof and fail before this fixture repair; no new test seam, timeout, retry, or assertion weakening was added.

Production LOC delta: 0. Test-support delta: +4/-1.
