### PR TITLE
refactor(auto-reply): share command body resolution

### DIFF
--- a/src/auto-reply/command-turn-context.ts
+++ b/src/auto-reply/command-turn-context.ts
@@ -47,7 +47,7 @@ export type CommandTurnContextInput = {
   BotUsername?: unknown;
 };
 
-function resolveCommandBody(input: CommandTurnContextInput): string | undefined {
+export function resolveCommandBody(input: CommandTurnContextInput): string | undefined {
   if (typeof input.commandText === "string") {
     return input.commandText;
   }

--- a/src/auto-reply/command-turn-detection.ts
+++ b/src/auto-reply/command-turn-detection.ts
@@ -4,21 +4,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isControlCommandMessage } from "./command-detection.js";
 import {
   isExplicitCommandTurn,
+  resolveCommandBody,
   resolveCommandTurnContext,
   type CommandTurnContextInput,
 } from "./command-turn-context.js";
-
-function resolveCommandBody(input: CommandTurnContextInput): string | undefined {
-  if (typeof input.commandText === "string") {
-    return input.commandText;
-  }
-  return (
-    normalizeOptionalString(input.CommandBody) ??
-    normalizeOptionalString(input.BodyForCommands) ??
-    normalizeOptionalString(input.RawBody) ??
-    normalizeOptionalString(input.Body)
-  );
-}
 
 function resolveVisibleMessageBody(input: CommandTurnContextInput): string | undefined {
   if (typeof input.rawText === "string") {


### PR DESCRIPTION
## What Problem This Solves

Command-body fallback precedence was implemented twice inside the auto-reply command-turn path. Keeping both copies aligned made future normalization changes easier to miss.

## Why This Change Was Made

Exports the existing command-turn context resolver and reuses it from fallback detection. The canonical empty `commandText` precedence and legacy field order remain unchanged.

## User Impact

No user-visible behavior change. This removes duplicate command normalization policy and keeps detection aligned with command-turn context construction.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/command-turn-context.test.ts src/auto-reply/reply/source-reply-delivery-mode.test.ts` — 46 tests passed.
- `node scripts/check-changed.mjs -- src/auto-reply/command-turn-context.ts src/auto-reply/command-turn-detection.ts` — all checks passed except the initial core-test typecheck, which resolved root `pako@1` because this sparse worktree lacked its UI workspace dependency link.
- `node scripts/run-tsgo-core-test-shards.mjs` — passed after linking the existing shared `ui/node_modules`; hosted exact-head typechecks also use the complete workspace install.
- Autoreview: clean, no accepted/actionable findings; correctness 0.99.
- AWS Crabbox `run_1016adef13a8` on lease `cbx_d27fd6fdfe2a` — fresh PR checkout, frozen install, and 46 tests passed; lease stopped after the run.
- Production delta: +2/-13, net -11. Tests unchanged.

AI-assisted: yes
