### PR TITLE
fix(anthropic): prevent retired Claude CLI profile from breaking setup

### DIFF
--- a/src/agents/cli-execution-auth.test.ts
+++ b/src/agents/cli-execution-auth.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileCredential } from "./auth-profiles/types.js";
 
 const mocks = vi.hoisted(() => ({
+  order: [] as string[],
   profiles: {} as Record<string, AuthProfileCredential>,
 }));
 
@@ -10,16 +11,65 @@ vi.mock("./auth-profiles/store.js", () => ({
 }));
 
 vi.mock("./auth-profiles/order.js", () => ({
-  resolveAuthProfileOrder: () => [],
+  resolveAuthProfileOrder: () => mocks.order,
 }));
 
 import { resolveCliExecutionAuthProfileId } from "./cli-execution-auth.js";
 
 describe("resolveCliExecutionAuthProfileId", () => {
   beforeEach(() => {
+    mocks.order.length = 0;
     for (const profileId of Object.keys(mocks.profiles)) {
       delete mocks.profiles[profileId];
     }
+  });
+
+  it.each(["auto", "user"] as const)(
+    "ignores a retired native Claude profile selected by %s",
+    (authProfileIdSource) => {
+      const authProfileId = "anthropic:claude-cli";
+      mocks.profiles[authProfileId] = {
+        type: "oauth",
+        provider: "claude-cli",
+        access: "retired-access",
+        refresh: "retired-refresh",
+        expires: Date.now() - 60_000,
+      };
+      mocks.order.push(authProfileId);
+
+      expect(
+        resolveCliExecutionAuthProfileId({
+          cliExecutionProvider: "claude-cli",
+          authProfileProvider: "claude-cli",
+          config: {},
+          agentDir: "/tmp/unused-agent",
+          ...(authProfileIdSource === "user"
+            ? { selected: { authProfileId, authProfileIdSource } }
+            : {}),
+        }),
+      ).toBeUndefined();
+    },
+  );
+
+  it("keeps forwarding a non-retired Claude profile", () => {
+    const authProfileId = "claude-cli:work";
+    mocks.profiles[authProfileId] = {
+      type: "oauth",
+      provider: "claude-cli",
+      access: "test-access",
+      refresh: "test-refresh",
+      expires: Date.now() + 60_000,
+    };
+
+    expect(
+      resolveCliExecutionAuthProfileId({
+        cliExecutionProvider: "claude-cli",
+        authProfileProvider: "claude-cli",
+        config: {},
+        agentDir: "/tmp/unused-agent",
+        selected: { authProfileId, authProfileIdSource: "user" },
+      }),
+    ).toBe(authProfileId);
   });
 
   it("rejects an explicitly selected profile from another provider", () => {

--- a/src/agents/cli-execution-auth.ts
+++ b/src/agents/cli-execution-auth.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAuthProfileOrder } from "./auth-profiles/order.js";
 import { loadAuthProfileStoreForRuntime } from "./auth-profiles/store.js";
 import { resolveCliBackendConfig } from "./cli-backends.js";
+import { resolveBundledCliBackendAuthPolicy } from "./cli-runner/cli-backend-auth-policy.js";
 
 const GOOGLE_GEMINI_CLI_PROVIDER_ID = "google-gemini-cli";
 const GOOGLE_PROVIDER_ID = "google";
@@ -50,7 +51,13 @@ export function resolveCliExecutionAuthProfileId(params: {
     allowKeychainPrompt: false,
     externalCliProviderIds: [params.cliExecutionProvider],
   });
+  const nativeAuthProfileIds = resolveBundledCliBackendAuthPolicy(
+    params.cliExecutionProvider,
+  )?.nativeAuthProfileIds;
   const selectedAuthProfileId = params.selected?.authProfileId?.trim();
+  if (selectedAuthProfileId && nativeAuthProfileIds?.includes(selectedAuthProfileId)) {
+    return undefined;
+  }
   if (selectedAuthProfileId) {
     const credential = store.profiles[selectedAuthProfileId];
     if (credential?.provider === params.cliExecutionProvider) {
@@ -82,7 +89,7 @@ export function resolveCliExecutionAuthProfileId(params: {
     provider: params.cliExecutionProvider,
   })[0];
   if (cliProfileId) {
-    return cliProfileId;
+    return nativeAuthProfileIds?.includes(cliProfileId) ? undefined : cliProfileId;
   }
 
   if (

--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -494,14 +494,13 @@ describe("runSystemAgentTurn", () => {
       },
     );
 
-    expect(runCliAgent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: "claude-cli",
-        model: "claude-opus-4-8",
-        agentDir,
-        authProfileId: "anthropic:claude-cli",
-      }),
-    );
+    expect(runCliAgent).toHaveBeenCalledOnce();
+    expect(runCliAgent.mock.calls[0]?.[0]).toMatchObject({
+      provider: "claude-cli",
+      model: "claude-opus-4-8",
+      agentDir,
+    });
+    expect(runCliAgent.mock.calls[0]?.[0].authProfileId).toBeUndefined();
   });
 
   it("reuses the guarded CLI binding when a denied proposal becomes approved", async () => {

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -5719,6 +5719,74 @@ describe("verifySetupInference", () => {
     });
   });
 
+  it("binds Claude native login when a retired profile remains in the store", async () => {
+    const authProfileId = "anthropic:claude-cli";
+    const config = {
+      agents: { defaults: { model: "claude-cli/claude-opus-5" } },
+    } satisfies OpenClawConfig;
+    const profiles = {
+      [authProfileId]: {
+        type: "oauth" as const,
+        provider: "claude-cli",
+        access: "retired-access",
+        refresh: "retired-refresh",
+        expires: Date.now() - 60_000,
+      },
+    };
+    const nativeRuntimeOwner = "native-claude-runtime-owner";
+    const resolveCliRuntimeOwnerFingerprint = vi.fn(async (params: { authProfileId?: string }) =>
+      params.authProfileId ? "retired-profile-owner" : nativeRuntimeOwner,
+    );
+    const runCliAgent = vi.fn(
+      async (params: {
+        authProfileId?: string;
+        onSuccessfulAuthBinding?: (binding: AgentExecutionAuthBinding) => void;
+      }) => {
+        params.onSuccessfulAuthBinding?.({
+          runtimeOwnerFingerprint: nativeRuntimeOwner,
+          runtimeOwnerKind: "cli-runtime",
+          runtimeOwnerId: "claude-cli",
+          runtimeArtifactFingerprint: testCliRuntimeArtifactFingerprint,
+          runtimeArtifactId: "claude-cli",
+        });
+        return {
+          meta: {
+            finalAssistantVisibleText: "OK",
+            executionTrace: {
+              winnerProvider: "claude-cli",
+              winnerModel: "claude-opus-5",
+            },
+          },
+        };
+      },
+    );
+
+    const result = await verifySetupInference({
+      bindSession: true,
+      deps: {
+        readConfigFileSnapshot: vi.fn(async () => ({ exists: true, valid: true, config })) as never,
+        loadAuthProfileStoreForRuntime: vi.fn(() => ({ version: 1, profiles })) as never,
+        ensureAuthProfileStore: vi.fn(() => ({ version: 1, profiles })) as never,
+        createSystemAgentVerifiedInferenceBinding,
+        resolveCliRuntimeArtifactFingerprint: vi.fn(async () => testCliRuntimeArtifactFingerprint),
+        resolveCliRuntimeOwnerFingerprint: resolveCliRuntimeOwnerFingerprint as never,
+        runCliAgent: runCliAgent as never,
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      binding: {
+        auth: { authFingerprint: nativeRuntimeOwner, proofKind: "runtime-owner" },
+        execution: { provider: "claude-cli", model: "claude-opus-5" },
+      },
+    });
+    expect(runCliAgent).toHaveBeenCalledOnce();
+    expect(runCliAgent.mock.calls[0]?.[0].authProfileId).toBeUndefined();
+    expect(resolveCliRuntimeOwnerFingerprint).toHaveBeenCalledOnce();
+    expect(resolveCliRuntimeOwnerFingerprint.mock.calls[0]?.[0].authProfileId).toBeUndefined();
+  });
+
   it("rejects an owner plugin replacement during the live inference turn", async () => {
     const profileId = "openai:verified";
     const credential = {


### PR DESCRIPTION
Related: #129052

## What Problem This Solves

Fixes an issue where users upgrading from the retired `anthropic:claude-cli` auth profile could complete a successful native Claude CLI inference check but still have setup fail with an inference-owner-changed error.

## Why This Change Was Made

Claude CLI execution already discards this retired OpenClaw-managed profile and delegates authentication to Claude's native login. Route-owner projection now applies the same bundled native-profile policy, so setup and execution agree on the active owner while normal non-retired Claude profiles continue to be forwarded. `doctor --fix` still removes the legacy profile as migration cleanup, but runtime correctness no longer depends on Doctor running first.

## User Impact

Upgraded users with a stale `anthropic:claude-cli` profile can activate and run Claude CLI normally through their existing native Claude login instead of being blocked by owner revalidation.

## Evidence

- Reconstructed on current `main` base `bdc0c924ce0`; exact head `ba2886c427c`.
- Regression proof: reverting the production change makes the new resolver test fail because it returns `anthropic:claude-cli` instead of native/profile-free ownership.
- `node scripts/run-vitest.mjs src/agents/cli-execution-auth.test.ts src/agents/cli-runner/prepare.test.ts` — 127 passed.
- `node scripts/run-vitest.mjs src/system-agent/setup-inference.test.ts src/system-agent/agent-turn.test.ts` — 161 passed.
- `node scripts/run-vitest.mjs src/commands/doctor-auth.deprecated-cli-profiles.test.ts` — 7 passed.
- `node scripts/check-changed.mjs -- src/agents/cli-execution-auth.ts src/agents/cli-execution-auth.test.ts src/system-agent/setup-inference.test.ts src/system-agent/agent-turn.test.ts` — passed on exact head.
- Exact-head live isolated run: seeded a retired profile, ran the patched local agent through the real Claude CLI, and received `CLAUDE_RETIRED_PROFILE_FIXED` from `claude-cli/claude-opus-5`.
