### PR TITLE
fix(tui): isolate replacement sessions from stale async results

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -456,12 +456,30 @@ describe("tui command handlers", () => {
       initialSession: "global",
       replacementSession: "global",
     },
+    {
+      name: "same-key model",
+      command: "/models",
+      value: "private/research-only",
+      initialSession: "agent:research:incident",
+      replacementSession: "agent:research:incident",
+      sameAgent: true,
+    },
+    {
+      name: "same-key session",
+      command: "/sessions",
+      value: "agent:research:incident",
+      initialSession: "agent:research:incident",
+      replacementSession: "agent:research:incident",
+      sameAgent: true,
+    },
   ])(
-    "retires an open $name picker after its selected agent is replaced",
-    async ({ command, value, initialSession, replacementSession }) => {
+    "retires an open $name picker after its selected session incarnation is replaced",
+    async ({ command, value, initialSession, replacementSession, sameAgent }) => {
       const harness = createHarness({
         currentAgentId: "research",
         currentSessionKey: initialSession,
+        currentSessionId: "private-session",
+        sessionGeneration: 3,
         agents: [{ id: "research" }],
         listModels: vi.fn().mockResolvedValue([{ provider: "private", id: "research-only" }]),
         listSessions: vi
@@ -471,8 +489,10 @@ describe("tui command handlers", () => {
 
       await harness.handleCommand(command);
       const selector = firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay;
-      harness.state.currentAgentId = "ops";
+      harness.state.currentAgentId = sameAgent ? "research" : "ops";
       harness.state.currentSessionKey = replacementSession;
+      harness.state.currentSessionId = "replacement-session";
+      harness.state.sessionGeneration += 1;
       selector.onSelect?.({ value });
       await flushAsyncSelect();
 
@@ -514,6 +534,29 @@ describe("tui command handlers", () => {
       expect(harness.closeOverlay).toHaveBeenCalledExactlyOnceWith(harness.overlayHandle);
     },
   );
+
+  it("does not reveal a previous session's delayed picker failure in its replacement", async () => {
+    const selection = createDeferred();
+    const harness = createHarness({
+      currentSessionId: "private-session",
+      sessionGeneration: 2,
+      listSessions: vi
+        .fn()
+        .mockResolvedValue({ sessions: [{ key: "agent:main:other", updatedAt: 1 }] }),
+      setSession: vi.fn(() => selection.promise) as SetSessionMock,
+    });
+
+    await harness.handleCommand("/sessions");
+    const selector = firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay;
+    selector.onSelect?.({ value: "agent:main:other" });
+    harness.state.currentSessionId = "replacement-session";
+    harness.state.sessionGeneration += 1;
+    selection.reject(new Error("private previous-session details"));
+    await flushAsyncSelect();
+
+    expect(harness.addSystem).not.toHaveBeenCalled();
+    expect(harness.closeOverlay).toHaveBeenCalledExactlyOnceWith(harness.overlayHandle);
+  });
 
   it("bounds Ctrl+P hydration to recent non-global TUI sessions", async () => {
     const listSessions = vi.fn().mockResolvedValue({
@@ -3431,6 +3474,35 @@ describe("tui command handlers", () => {
     expect(harness.addSystem).not.toHaveBeenCalled();
     expect(harness.pendingSystemNotices.size).toBe(0);
   });
+
+  it.each(["models", "sessions"] as const)(
+    "does not open a stale %s selector after the same session key is reset",
+    async (picker) => {
+      const deferred = createDeferred<unknown>();
+      const harness = createHarness({
+        currentSessionKey: "agent:main:main",
+        currentSessionId: "private-session",
+        sessionGeneration: 2,
+        ...(picker === "models"
+          ? { listModels: vi.fn(() => deferred.promise) }
+          : { listSessions: vi.fn(() => deferred.promise) }),
+      });
+
+      const pending = harness.handleCommand(`/${picker}`);
+      harness.state.currentSessionId = "replacement-session";
+      harness.state.sessionGeneration += 1;
+      deferred.resolve(
+        picker === "models"
+          ? [{ provider: "openai", id: "gpt-5.6-luna" }]
+          : { sessions: [{ key: "agent:main:main", updatedAt: 1 }] },
+      );
+      await pending;
+
+      expect(harness.openOverlay).not.toHaveBeenCalled();
+      expect(harness.addSystem).not.toHaveBeenCalled();
+      expect(harness.pendingSystemNotices.size).toBe(0);
+    },
+  );
 
   it.each([
     { name: "another session", initialKey: "agent:main:first", nextKey: "agent:main:second" },

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -316,17 +316,19 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     onSelect: (value: string) => Promise<void>,
     request: { overlay?: OverlayHandle },
   ) => {
-    const selection = captureSessionSelection();
+    const { isCurrent } = captureSessionIncarnation();
     selector.onSelect = (item) => {
       void (async () => {
         try {
-          if (isCurrentSessionSelection(selection)) {
+          if (isCurrent()) {
             await onSelect(item.value);
           }
         } catch (err) {
           // A rejected selection must not strand the overlay open with an
           // unhandled rejection; close it and surface the cause in chat.
-          chatLog.addSystem(`selection failed: ${formatTuiErrorMessage(err)}`);
+          if (isCurrent()) {
+            chatLog.addSystem(`selection failed: ${formatTuiErrorMessage(err)}`);
+          }
         }
         closeOverlayAndRender(overlayHandle);
       })();
@@ -338,12 +340,12 @@ export function createCommandHandlers(context: CommandHandlerContext) {
 
   const openModelSelector = async () => {
     const request = beginPickerRequest();
-    const selection = captureSessionSelection();
+    const { selection, isCurrent } = captureSessionIncarnation();
     try {
       chatLog.addPendingSystem(request.noticeId, "loading models...");
       tui.requestRender();
       const models = await client.listModels({ agentId: selection.agentId });
-      if (request !== pickerRequest || !isCurrentSessionSelection(selection)) {
+      if (request !== pickerRequest || !isCurrent()) {
         return;
       }
       if (models.length === 0) {
@@ -365,7 +367,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         request,
       );
     } catch (err) {
-      if (request !== pickerRequest || !isCurrentSessionSelection(selection)) {
+      if (request !== pickerRequest || !isCurrent()) {
         return;
       }
       chatLog.addSystem(`model list failed: ${formatTuiErrorMessage(err)}`);
@@ -413,16 +415,16 @@ export function createCommandHandlers(context: CommandHandlerContext) {
 
   const openSessionSelector = async () => {
     const request = beginPickerRequest();
-    const selection = captureSessionSelection();
+    const { selection, isCurrent } = captureSessionIncarnation();
     try {
       const sessions = await loadRecentSessions(client, { agentId: selection.agentId });
-      if (request !== pickerRequest || !isCurrentSessionSelection(selection)) {
+      if (request !== pickerRequest || !isCurrent()) {
         return;
       }
       const selector = createFilterableSelectList(buildSessionChoices(sessions), 9);
       openSelector(selector, setSession, request);
     } catch (err) {
-      if (request !== pickerRequest || !isCurrentSessionSelection(selection)) {
+      if (request !== pickerRequest || !isCurrent()) {
         return;
       }
       chatLog.addSystem(`sessions list failed: ${formatTuiErrorMessage(err)}`);

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1503,6 +1503,47 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).toHaveBeenCalledWith(true);
   });
 
+  it("discards a delayed local BTW result from the previous same-key session incarnation", () => {
+    const { state, btw, noteLocalBtwRunId, handleBtwEvent, handleSessionsChangedEvent } =
+      createHandlersHarness({
+        localMode: true,
+        state: { activeChatRunId: null, currentSessionId: "private-session" },
+      });
+    noteLocalBtwRunId("private-btw-run");
+
+    handleSessionsChangedEvent({
+      sessionKey: state.currentSessionKey,
+      reason: "reset",
+      sessionId: "replacement-session",
+      updatedAt: Date.now(),
+    });
+    handleBtwEvent({
+      kind: "btw",
+      runId: "private-btw-run",
+      sessionKey: state.currentSessionKey,
+      question: "what was discussed?",
+      text: "answer from the previous session",
+    });
+
+    expect(state.currentSessionId).toBe("replacement-session");
+    expect(btw.showResult).not.toHaveBeenCalled();
+
+    noteLocalBtwRunId("replacement-btw-run");
+    handleBtwEvent({
+      kind: "btw",
+      runId: "replacement-btw-run",
+      sessionKey: state.currentSessionKey,
+      question: "what changed?",
+      text: "answer for the replacement session",
+    });
+
+    expect(btw.showResult).toHaveBeenCalledExactlyOnceWith({
+      question: "what changed?",
+      text: "answer for the replacement session",
+      isError: undefined,
+    });
+  });
+
   it("clears stale streaming for a local BTW empty final without hiding the result", () => {
     const {
       state,
@@ -3394,8 +3435,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       expect(tui.requestRender).not.toHaveBeenCalled();
     });
 
-    it("does not let an older transcript snapshot replace newer session metadata", () => {
-      const { state, loadHistory, handleSessionMessageEvent } = createHandlersHarness({
+    it.each([
+      { name: "older timestamp", updatedAt: 100 },
+      { name: "equal timestamp", updatedAt: 200 },
+      { name: "missing timestamp", updatedAt: undefined },
+    ])("rejects a retired session snapshot with a $name", ({ updatedAt }) => {
+      const { state, chatLog, loadHistory, handleSessionMessageEvent } = createHandlersHarness({
         state: {
           activeChatRunId: null,
           currentSessionId: "session-current",
@@ -3405,12 +3450,19 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
       handleSessionMessageEvent({
         sessionId: "session-stale",
-        updatedAt: 100,
+        ...(updatedAt === undefined ? {} : { updatedAt }),
+        message: {
+          role: "user",
+          content: "private previous-session prompt",
+          __openclaw: { id: "previous-session-message", seq: 1 },
+        },
       });
 
       expect(state.currentSessionId).toBe("session-current");
       expect(state.sessionInfo.updatedAt).toBe(200);
-      expect(loadHistory).toHaveBeenCalledTimes(1);
+      expect(chatLog.addLiveUser).not.toHaveBeenCalled();
+      expect(state.sessionProjection?.entries ?? []).toHaveLength(0);
+      expect(loadHistory).not.toHaveBeenCalled();
     });
 
     it("reloads a global session only for its selected agent", () => {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -505,7 +505,17 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const evt = payload as SessionMessageEvent;
     syncSessionKey();
-    if (!matchesSelectedTuiSession(state, evt, { requireAliasOwnership: true })) {
+    const currentUpdatedAt = state.sessionInfo.updatedAt;
+    const priorSession =
+      evt.sessionId && state.currentSessionId && evt.sessionId !== state.currentSessionId;
+    const isOlderSnapshot =
+      typeof evt.updatedAt === "number" && evt.updatedAt < (currentUpdatedAt ?? evt.updatedAt);
+    if (
+      !matchesSelectedTuiSession(state, evt, { requireAliasOwnership: true }) ||
+      (priorSession &&
+        (typeof evt.updatedAt !== "number" ||
+          (typeof currentUpdatedAt === "number" && evt.updatedAt <= currentUpdatedAt)))
+    ) {
       return;
     }
 
@@ -525,11 +535,6 @@ export function createEventHandlers(context: EventHandlerContext) {
       tui.requestRender();
     }
 
-    const currentUpdatedAt = state.sessionInfo.updatedAt;
-    const isOlderSnapshot =
-      typeof evt.updatedAt === "number" &&
-      typeof currentUpdatedAt === "number" &&
-      evt.updatedAt < currentUpdatedAt;
     if (!isOlderSnapshot) {
       if (typeof evt.sessionId === "string") {
         state.currentSessionId = evt.sessionId;
@@ -709,22 +714,18 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const evt = payload as BtwEvent;
     syncSessionKey();
-    if (!matchesSelectedTuiSession(state, evt)) {
+    if (
+      evt.kind !== "btw" ||
+      !matchesSelectedTuiSession(state, evt) ||
+      (localMode && (!evt.runId || !isLocalBtwRunId?.(evt.runId)))
+    ) {
       return;
     }
-    if (evt.kind !== "btw") {
-      return;
-    }
-    const question = evt.question.trim();
-    const text = evt.text.trim();
+    const [question, text] = [evt.question.trim(), evt.text.trim()];
     if (!question || !text) {
       return;
     }
-    btw.showResult({
-      question,
-      text,
-      isError: evt.isError,
-    });
+    btw.showResult({ question, text, isError: evt.isError });
     tui.requestRender();
   };
 

--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -394,14 +394,14 @@ export async function writeTuiPtyFixtureScript(dir: string) {
             }, 5);
           }
           const isSourceReplyProof = opts.message === "message tool only source reply proof";
-          const isXaiLimitProof = opts.message === "xai limit proof";
           setTimeout(() => {
-            if (isXaiLimitProof) {
+            if (opts.message === "xai limit proof") {
               this.onEvent?.({
                 event: "chat",
                 payload: {
                   runId,
                   sessionKey: opts.sessionKey,
+                  seq: 0,
                   state: "error",
                   errorMessage: xaiLimitError,
                 },

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -2259,6 +2259,52 @@ describe("tui session actions", () => {
     expect(clearAll).not.toHaveBeenCalled();
   });
 
+  it.each(["success", "failure"] as const)(
+    "discards an in-flight session-info %s after an external same-key reset",
+    async (outcome) => {
+      const sessionInfo = createDeferred<TuiSessionList>();
+      const addSystem = vi.fn();
+      const state = createBaseState({
+        currentSessionId: "session-before-reset",
+        sessionGeneration: 4,
+        sessionInfo: { model: "model-before-reset", updatedAt: 10 },
+      });
+      const { refreshSessionInfo } = createTestSessionActions({
+        client: makeTuiBackend({ listSessions: vi.fn(() => sessionInfo.promise) }),
+        chatLog: makeChatLog({ addSystem }),
+        state,
+      });
+
+      const staleSessionInfo = refreshSessionInfo();
+      state.sessionGeneration = 5;
+      state.currentSessionId = "session-after-reset";
+      state.sessionInfo = { model: "model-after-reset", updatedAt: 20 };
+      if (outcome === "failure") {
+        sessionInfo.reject(new Error("private previous-session details"));
+      } else {
+        sessionInfo.resolve(
+          makeTuiSessionList({
+            defaults: {},
+            sessions: [
+              {
+                key: "agent:main:main",
+                sessionId: "session-before-reset",
+                model: "private-old-model",
+                updatedAt: 10,
+              },
+            ],
+          }),
+        );
+      }
+
+      await staleSessionInfo;
+
+      expect(state.currentSessionId).toBe("session-after-reset");
+      expect(state.sessionInfo.model).toBe("model-after-reset");
+      expect(addSystem).not.toHaveBeenCalled();
+    },
+  );
+
   it("does not clear the selected session for another session's reset result", () => {
     const addSystem = vi.fn();
     const clearAll = vi.fn();

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -335,8 +335,11 @@ export function createSessionActions(context: SessionActionContext) {
   const runRefreshSessionInfo = async () => {
     const selection = captureSessionSelection();
     const historyGeneration = historyLoadGeneration;
+    const sessionGeneration = state.sessionGeneration ?? 0;
     const isCurrentRefresh = () =>
-      historyGeneration === historyLoadGeneration && isCurrentSessionSelection(selection);
+      historyGeneration === historyLoadGeneration &&
+      sessionGeneration === (state.sessionGeneration ?? 0) &&
+      isCurrentSessionSelection(selection);
     try {
       const resolveListAgentId = () => {
         if (selection.sessionKey === "global") {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users resetting or replacing a terminal session could see prompts, side answers, picker failures, or model/session selections from the previous session reappear in the replacement. An overlapping session refresh could also resurrect the old opaque session ID, and the existing account-limit PTY check could flake because its fake Gateway emitted an invalid event.

## Why This Change Was Made

Session ownership is the exact agent, session key, opaque session ID, and lifecycle generation; a key alone is not sufficient after an in-place reset. Reuse the existing session-incarnation owner for asynchronous model/session picker requests, selections, and failures; fence session-info refreshes with the canonical lifecycle generation; reject retired transcript snapshots before projection or rendering; and accept local side answers only while their locally owned run remains alive. The PTY fake Gateway now includes the sequence required by the actual Gateway chat-event contract.

## User Impact

Terminal sessions no longer leak an old conversation's prompt, side answer, or error into its replacement, and stale pickers cannot silently change the replacement session. Legitimate first-session identity binding, newer authoritative session adoption, cross-client Gateway answers, and normal local `/btw` replies remain intact.

## Evidence

- Captured failing regressions on clean `main`: same-key model/session picker mutations, stale catalog/session-list openings, delayed picker failure disclosure, retired `/btw` disclosure, retired transcript disclosure with older/equal/missing timestamps, and stale refresh success/failure.
- Independently reproduced the refresh race through the real session-actions owner, event handlers, `ChatLog`, and an already occupied history-reload coalescer.
- `node scripts/run-vitest.mjs src/tui/tui-command-handlers.test.ts src/tui/tui-event-handlers.test.ts src/tui/tui-session-actions.test.ts src/tui/tui-session-run-coordinator.test.ts src/tui/tui-session-events.test.ts src/tui/tui.submit-handler.test.ts src/tui/tui-pty-harness-assertion-test-support.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts` — four real-PTY files, 76 tests passed.
- `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs` — all changed-file formatting, core/test typecheck, lint, max-line ratchet, dependency, architecture, database, and import-cycle gates passed.
- Independent structured review: no accepted/actionable findings.
- Production LOC: +33/-27 (net +6); test and fixture support: +179/-9.
- Proof boundary: real terminal loop and fake Gateway; no live authenticated provider/channel call was needed for these deterministic TUI-owner defects. No screenshot or recording is attached because the user-visible regression is conditional cross-session transcript disclosure; the real PTY scenarios and red/green owner regressions are the safer direct evidence.

Follow-up: task-suggestion and plugin-approval asynchronous notices deserve a separate session-incarnation audit.
