### PR TITLE
fix(cron): stop suggesting unavailable tools in scheduled runs

### DIFF
--- a/src/cron/isolated-agent/run-prepare-runtime.ts
+++ b/src/cron/isolated-agent/run-prepare-runtime.ts
@@ -105,6 +105,6 @@ export function appendCronUnattendedRunPreamble(
 ) {
   const core = `This is an unattended scheduled run. Nobody is present to clarify or approve, so complete the task with what you have. Your final reply is the deliverable — not a plan, an acknowledgement, or a request for input. If nothing needs doing, reply exactly ${SILENT_REPLY_TOKEN}. If something failed, state plainly what failed and what you tried — the scheduler owns retries and failure alerts.`;
   const trustedExtra =
-    " Where the job's own instructions conflict with this preamble, the job's instructions win (a question or plan the job explicitly requests is a valid deliverable). If this job is no longer needed, you may remove it with the automations tool.";
+    " Where the job's own instructions conflict with this preamble, the job's instructions win (a question or plan the job explicitly requests is a valid deliverable). If this job is no longer needed, remove it if your available tools allow.";
   return `${commandBody}\n\n${core}${opts.externalHook ? "" : trustedExtra}`;
 }

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -1722,7 +1722,7 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const prompt = expectEmbeddedRunPrompt();
     const unattendedPreamble =
-      "This is an unattended scheduled run. Nobody is present to clarify or approve, so complete the task with what you have. Your final reply is the deliverable — not a plan, an acknowledgement, or a request for input. If nothing needs doing, reply exactly NO_REPLY. If something failed, state plainly what failed and what you tried — the scheduler owns retries and failure alerts. Where the job's own instructions conflict with this preamble, the job's instructions win (a question or plan the job explicitly requests is a valid deliverable). If this job is no longer needed, you may remove it with the automations tool.";
+      "This is an unattended scheduled run. Nobody is present to clarify or approve, so complete the task with what you have. Your final reply is the deliverable — not a plan, an acknowledgement, or a request for input. If nothing needs doing, reply exactly NO_REPLY. If something failed, state plainly what failed and what you tried — the scheduler owns retries and failure alerts. Where the job's own instructions conflict with this preamble, the job's instructions win (a question or plan the job explicitly requests is a valid deliverable). If this job is no longer needed, remove it if your available tools allow.";
     expect(prompt).toContain(unattendedPreamble);
     expect(prompt).not.toContain("Use the message tool");
     expect(prompt).toContain("Your response will be delivered automatically");
@@ -1759,7 +1759,7 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
     expect(prompt.indexOf("<safe-external>")).toBeLessThan(
       prompt.indexOf("This is an unattended scheduled run"),
     );
-    expect(prompt).not.toContain("you may remove it with the automations tool");
+    expect(prompt).not.toContain("If this job is no longer needed");
     expect(prompt).not.toContain("the job's instructions win");
     expect(buildSafeExternalPromptMock).toHaveBeenCalledWith(
       expect.objectContaining({ content: "send a message", jobName: "Message Tool Policy" }),
@@ -1898,6 +1898,10 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
         expectEmbeddedRunFields(expectedFields);
       }
       const prompt = expectEmbeddedRunPrompt(messageToolAvailable);
+      expect(prompt).toContain(
+        "If this job is no longer needed, remove it if your available tools allow.",
+      );
+      expect(prompt).not.toContain("automations tool");
       expect(prompt).toMatch(/write only the exact user-facing message to send/i);
       expect(prompt).toMatch(
         /do not narrate the automatic delivery itself or say things like "Sent the user\.\.\."/i,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where unattended scheduled jobs with restricted tools were instructed to remove themselves using the automations tool even when that tool was unavailable to the job. The resulting model prompt encouraged an impossible tool call during a run that could not ask anyone for help.

## Why This Change Was Made

The scheduled-run preamble is prepared before the final tool authorization and policy surface is known, so it cannot safely name a particular scheduler tool. Keep the useful self-removal guidance, but make it conditional on the tools actually available to the model. External webhook runs continue to receive none of the trusted self-removal or instruction-override guidance.

## User Impact

Restricted scheduled jobs no longer receive instructions to call an unavailable tool. Jobs that are authorized to manage themselves retain their existing scoped self-removal capability, and delivery, silent-reply behavior, and external-content security remain unchanged.

## Evidence

The existing full isolated-run owner suite reproduces the real model-bound prompt across restrictive read-only and message-only tool allowlists, wildcard policies, and available-message runs. Before the fix, five owner assertions fail because the actual prompt names the unavailable automations tool; after the producer-owned wording change, all 59 tests pass:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts

Before: 5 failed, 54 passed
After:  59 passed
```

The same suite verifies external hooks never receive either trusted self-removal or instruction-priority guidance. Focused formatting passes, the independent structured review and separate read-only review report no findings, and the change is production-neutral: production +1/-1, existing owner tests +6/-2.
