### PR TITLE
ci(i18n): add non-publishing native locale refresh

### DIFF
--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -25,12 +25,26 @@ on:
       - .github/actions/publish-generated-pr/action.yml
       - .github/workflows/native-app-locale-refresh.yml
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the generated locale PR after validation.
+        required: false
+        default: true
+        type: boolean
+      preflight_only:
+        description: Verify an exact branch dispatch without translation or publishing secrets.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
 
 concurrency:
-  group: native-app-locale-refresh
+  group: >-
+    ${{ github.event_name == 'workflow_dispatch' && inputs.preflight_only &&
+      format('native-app-locale-preflight-{0}', github.ref) ||
+      'native-app-locale-refresh' }}
   # Finish the active full refresh; GitHub retains only the newest pending run for this group.
   # Publisher overlap checks defer stale generated paths to that queued reconciliation run.
   cancel-in-progress: false
@@ -39,23 +53,33 @@ jobs:
   resolve-base:
     if: >-
       github.repository == 'openclaw/openclaw' &&
-      (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')
+      (github.event_name != 'workflow_dispatch' ||
+        (inputs.publish && !inputs.preflight_only && github.ref == 'refs/heads/main') ||
+        ((!inputs.publish || inputs.preflight_only) && github.ref_type == 'branch'))
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.base.outputs.sha }}
     steps:
-      - name: Resolve default branch head
+      - name: Resolve source commit
         id: base
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
+          NON_PUBLISHING: >-
+            ${{ github.event_name == 'workflow_dispatch' &&
+              (!inputs.publish || inputs.preflight_only) }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
-          sha="$(
-            timeout --signal=TERM --kill-after=10s 60s \
-              gh api --method GET "repos/${REPOSITORY}/commits/${DEFAULT_BRANCH}" --jq .sha
-          )"
+          if [[ "${NON_PUBLISHING}" == "true" ]]; then
+            sha="${WORKFLOW_SHA}"
+          else
+            sha="$(
+              timeout --signal=TERM --kill-after=10s 60s \
+                gh api --method GET "repos/${REPOSITORY}/commits/${DEFAULT_BRANCH}" --jq .sha
+            )"
+          fi
           if [[ ! "${sha}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Unable to resolve ${DEFAULT_BRANCH} to an exact commit." >&2
             exit 1
@@ -65,7 +89,10 @@ jobs:
   publisher-preflight:
     name: Verify generated PR App permissions
     needs: resolve-base
-    if: needs.resolve-base.result == 'success'
+    if: >-
+      needs.resolve-base.result == 'success' &&
+      (github.event_name != 'workflow_dispatch' ||
+        (inputs.publish && !inputs.preflight_only))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -107,8 +134,12 @@ jobs:
   refresh:
     needs: [resolve-base, publisher-preflight]
     if: >-
+      always() &&
       needs.resolve-base.result == 'success' &&
-      needs.publisher-preflight.result == 'success'
+      (needs.publisher-preflight.result == 'success' ||
+        (github.event_name == 'workflow_dispatch' && !inputs.publish &&
+          needs.publisher-preflight.result == 'skipped')) &&
+      !(github.event_name == 'workflow_dispatch' && inputs.preflight_only)
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -250,11 +281,14 @@ jobs:
           retention-days: 1
 
   finalize:
-    name: Commit native locale refresh
+    name: Finalize native locale refresh
     needs: [resolve-base, publisher-preflight, refresh]
     if: >-
+      always() &&
       needs.resolve-base.result == 'success' &&
-      needs.publisher-preflight.result == 'success' &&
+      (needs.publisher-preflight.result == 'success' ||
+        (github.event_name == 'workflow_dispatch' && !inputs.publish &&
+          needs.publisher-preflight.result == 'skipped')) &&
       needs.refresh.result == 'success'
     runs-on: ubuntu-latest
     steps:
@@ -296,7 +330,42 @@ jobs:
       - name: Validate native locale refresh
         run: node --import tsx scripts/native-app-i18n.ts check
 
+      - name: Prepare non-publishing locale patch
+        if: github.event_name == 'workflow_dispatch' && !inputs.publish
+        run: |
+          set -euo pipefail
+          patch="${RUNNER_TEMP}/native-app-locale-refresh.patch"
+          git add -A
+          while IFS= read -r path; do
+            case "${path}" in
+              apps/.i18n/native/* | \
+              apps/android/app/src/main/java/ai/openclaw/app/i18n/NativeStringResources.kt | \
+              apps/android/app/src/main/res/values*/assistant.xml | \
+              apps/android/app/src/main/res/values*/strings.xml | \
+              apps/android/app/src/thirdParty/res/values*/accessibility_strings.xml | \
+              apps/android/wear/src/main/res/values*/strings.xml | \
+              apps/ios/Resources/Localizable.xcstrings | \
+              apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings | \
+              apps/ios/Sources/*.lproj/InfoPlist.strings | \
+              apps/ios/WatchApp/*.lproj/InfoPlist.strings | \
+              apps/ios/ShareExtension/*.lproj/InfoPlist.strings | \
+              apps/ios/ActivityWidget/*.lproj/InfoPlist.strings) ;;
+              *) echo "Unexpected generated path: ${path}" >&2; exit 1 ;;
+            esac
+          done < <(git diff --cached --name-only)
+          git diff --cached --binary --full-index > "${patch}"
+
+      - name: Upload non-publishing locale patch
+        if: github.event_name == 'workflow_dispatch' && !inputs.publish
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: native-app-locale-refresh-${{ needs.resolve-base.outputs.sha }}
+          path: ${{ runner.temp }}/native-app-locale-refresh.patch
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Open or update generated locale PR
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
         uses: ./.github/actions/publish-generated-pr
         with:
           contents-client-id: Iv23liOECG0slfuhz093

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2092,8 +2092,8 @@ NODE
       (step: { name?: string }) => step.name === "Validate control UI locale refresh",
     );
 
-    expect(refresh.if).toBe(
-      "needs.resolve-base.result == 'success' && needs.publisher-preflight.result == 'success'",
+    expect(refresh.if.replace(/\s+/gu, " ")).toBe(
+      "always() && needs.resolve-base.result == 'success' && (needs.publisher-preflight.result == 'success' || (github.event_name == 'workflow_dispatch' && !inputs.publish && needs.publisher-preflight.result == 'skipped')) && !(github.event_name == 'workflow_dispatch' && inputs.preflight_only)",
     );
     expect(refresh.strategy.matrix.locale).toEqual(NATIVE_I18N_LOCALES);
     expect(controlUiWorkflow.concurrency["cancel-in-progress"]).toBe(false);
@@ -2108,7 +2108,9 @@ NODE
       SUPPORTED_LOCALES.filter((locale) => locale !== "en"),
     );
     expect(workflow.concurrency["cancel-in-progress"]).toBe(false);
-    expect(workflow.concurrency.group).toBe("native-app-locale-refresh");
+    expect(workflow.concurrency.group.replace(/\s+/gu, " ")).toBe(
+      "${{ github.event_name == 'workflow_dispatch' && inputs.preflight_only && format('native-app-locale-preflight-{0}', github.ref) || 'native-app-locale-refresh' }}",
+    );
     expect(controlUiResolveBase.if).not.toContain("chore(ui): refresh control ui locales");
     const controlResolveCondition = controlUiResolveBase.if.replace(/\s+/gu, " ");
     expect(controlResolveCondition).toBe(
@@ -2116,16 +2118,36 @@ NODE
     );
     expect(controlResolveCondition).not.toContain("inputs.token_preflight_only");
     expect(controlResolveCondition).not.toContain("github.ref_type");
-    expect(nativeResolveBase.if).toBe(
-      "github.repository == 'openclaw/openclaw' && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')",
+    expect(nativeResolveBase.if.replace(/\s+/gu, " ")).toBe(
+      "github.repository == 'openclaw/openclaw' && (github.event_name != 'workflow_dispatch' || (inputs.publish && !inputs.preflight_only && github.ref == 'refs/heads/main') || ((!inputs.publish || inputs.preflight_only) && github.ref_type == 'branch'))",
     );
+    const nativeResolveStep = nativeResolveBase.steps.find(
+      (step: { name?: string }) => step.name === "Resolve source commit",
+    );
+    expect(nativeResolveStep.env.WORKFLOW_SHA).toBe("${{ github.workflow_sha }}");
+    expect(nativeResolveStep.env.NON_PUBLISHING.replace(/\s+/gu, " ")).toBe(
+      "${{ github.event_name == 'workflow_dispatch' && (!inputs.publish || inputs.preflight_only) }}",
+    );
+    expect(nativeResolveStep.run).toContain('if [[ "${NON_PUBLISHING}" == "true" ]]; then');
+    expect(nativeResolveStep.run).toContain('sha="${WORKFLOW_SHA}"');
     expect(controlUiWorkflow.on.workflow_dispatch.inputs.token_preflight_only).toEqual({
       description: "Verify generated PR App permissions without running locale generation.",
       required: false,
       default: false,
       type: "boolean",
     });
-    expect(workflow.on.workflow_dispatch?.inputs).toBeUndefined();
+    expect(workflow.on.workflow_dispatch.inputs.publish).toEqual({
+      description: "Publish the generated locale PR after validation.",
+      required: false,
+      default: true,
+      type: "boolean",
+    });
+    expect(workflow.on.workflow_dispatch.inputs.preflight_only).toEqual({
+      description: "Verify an exact branch dispatch without translation or publishing secrets.",
+      required: false,
+      default: false,
+      type: "boolean",
+    });
     expect(workflow.on.push.paths).toContain("ui/src/i18n/.i18n/glossary.*.json");
     expect(workflow.on.push.paths).toContain("apps/.i18n/native/**");
     expect(workflow.on.push.paths).toContain("apps/.i18n/native-source.json");
@@ -2183,6 +2205,20 @@ NODE
       "apps/android/app/src/thirdParty",
     );
     expect(nativePublishStep.with["auto-merge"]).toBe("true");
+    expect(nativePublishStep.if).toBe("github.event_name != 'workflow_dispatch' || inputs.publish");
+    const nativePatchStep = nativeFinalize.steps.find(
+      (step: { name?: string }) => step.name === "Prepare non-publishing locale patch",
+    );
+    const nativePatchUploadStep = nativeFinalize.steps.find(
+      (step: { name?: string }) => step.name === "Upload non-publishing locale patch",
+    );
+    expect(nativePatchStep.if).toBe("github.event_name == 'workflow_dispatch' && !inputs.publish");
+    expect(nativePatchStep.run).toContain("Unexpected generated path");
+    expect(nativePatchStep.run).toContain("git diff --cached --binary --full-index");
+    expect(nativePatchUploadStep.uses).toBe(UPLOAD_ARTIFACT_V7);
+    expect(nativePatchUploadStep.if).toBe(
+      "github.event_name == 'workflow_dispatch' && !inputs.publish",
+    );
     expect(controlUiRefreshStep.run).toContain("run_refresh anthropic");
     expect(controlUiRefreshStep.run).toContain("retrying with OpenAI");
     expect(controlUiRefreshStep.run).toContain("run_openai_refresh");
@@ -2237,11 +2273,7 @@ NODE
       expect(ownerWorkflow.on.push.paths).toContain(PUBLISH_GENERATED_PR_ACTION);
       const resolveBase = ownerWorkflow.jobs["resolve-base"];
       const resolveStep = resolveBase.steps.find(
-        (step: { name?: string }) =>
-          step.name ===
-          (ownerWorkflow === controlUiWorkflow
-            ? "Resolve source commit"
-            : "Resolve default branch head"),
+        (step: { name?: string }) => step.name === "Resolve source commit",
       );
       expect(resolveBase.outputs.sha).toBe("${{ steps.base.outputs.sha }}");
       expect(resolveStep.env.GH_TOKEN).toBe("${{ github.token }}");
@@ -2276,7 +2308,11 @@ NODE
 
     for (const preflight of [controlUiPreflight, nativePreflight]) {
       expect(preflight.needs).toBe("resolve-base");
-      expect(preflight.if).toBe("needs.resolve-base.result == 'success'");
+      expect(preflight.if.replace(/\s+/gu, " ")).toBe(
+        preflight === nativePreflight
+          ? "needs.resolve-base.result == 'success' && (github.event_name != 'workflow_dispatch' || (inputs.publish && !inputs.preflight_only))"
+          : "needs.resolve-base.result == 'success'",
+      );
       expect(preflight.strategy).toBeUndefined();
       expect(preflight.steps).toHaveLength(3);
       const checkoutStep = preflight.steps.find(
@@ -2536,9 +2572,9 @@ NODE
       expect(refreshJob.needs).toEqual(["resolve-base", "publisher-preflight"]);
       expect(finalizeJob.needs).toEqual(["resolve-base", "publisher-preflight", "refresh"]);
       const isNative = automationBranch.includes("native");
-      expect(finalizeJob.if).toBe(
+      expect(finalizeJob.if.replace(/\s+/gu, " ")).toBe(
         isNative
-          ? "needs.resolve-base.result == 'success' && needs.publisher-preflight.result == 'success' && needs.refresh.result == 'success'"
+          ? "always() && needs.resolve-base.result == 'success' && (needs.publisher-preflight.result == 'success' || (github.event_name == 'workflow_dispatch' && !inputs.publish && needs.publisher-preflight.result == 'skipped')) && needs.refresh.result == 'success'"
           : "needs.resolve-base.result == 'success' && needs.publisher-preflight.result == 'success' && needs.refresh.result == 'success' && !(github.event_name == 'workflow_dispatch' && inputs.token_preflight_only)",
       );
       expect(uploadStep.uses).toBe(UPLOAD_ARTIFACT_V7);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where maintainers cannot refresh secret-backed native translations for review without also creating and arming an auto-merge generated PR.

## Why This Change Was Made

Adds an explicit non-publishing dispatch mode that runs the existing bounded locale matrix and validation, then uploads an allowlisted binary patch artifact. The default publishing path remains unchanged. A separate preflight-only mode proves an exact branch workflow definition without using translation or publishing secrets.

## User Impact

No direct user-facing change. Maintainers gain a review-only native translation refresh path that cannot push, open a PR, or enable auto-merge.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 129 passed, 2 skipped
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -- -t 'keeps locale refresh matrices alive'` — passed after both review repairs
- `oxfmt --check` and `git diff --check` — passed
- `check-workflows` could not install its pinned `pre-commit==4.6.2` from the configured package index; exact GitHub branch preflight and PR CI will provide the hosted workflow proof.
- Production LOC: 0. Workflow policy: +80/-11. Guard tests: +50/-14.
