### PR TITLE
fix(slack): stop giving HTTP onboarding an invalid Socket manifest

### DIFF
--- a/extensions/slack/src/setup-core.ts
+++ b/extensions/slack/src/setup-core.ts
@@ -361,15 +361,12 @@ export function createSlackSetupWizardBase(handlers: {
           "Slack user identity",
         );
       } else {
-        await prompter.note(
-          buildSlackSetupLines().join("\n"),
-          t("wizard.slack.socketModeTokensTitle"),
-        );
-        const manifest = buildSlackManifest();
-        if (prompter.plain) {
-          await prompter.plain(manifest);
-        } else {
-          await prompter.note(manifest, "Slack manifest JSON");
+        await prompter.note(buildSlackSetupLines().join("\n"), t("wizard.channels.setupTitle"));
+        if (currentAccount.config.mode !== "http") {
+          const manifest = buildSlackManifest();
+          await (prompter.plain
+            ? prompter.plain(manifest)
+            : prompter.note(manifest, "Slack manifest JSON"));
         }
       }
       return { cfg: next };

--- a/extensions/slack/src/setup-shared.ts
+++ b/extensions/slack/src/setup-shared.ts
@@ -106,13 +106,13 @@ export function buildSlackManifest(botName = "OpenClaw") {
 
 export function buildSlackSetupLines(): string[] {
   return [
-    "1) Slack API -> Create App -> From scratch or From manifest (with the JSON below)",
-    "2) Add Socket Mode + enable it to get the app-level token (xapp-...)",
-    "3) Install App to workspace to get the xoxb- bot token",
-    "4) Enable Event Subscriptions (socket) for message, App Home, and Agent View events",
-    "5) App Home -> enable the Home tab, Messages tab for DMs, and Agent View",
-    "Manifest JSON follows as plain text for copy/paste.",
-    "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
+    "1) Slack API -> Create App -> From scratch or a transport-specific manifest",
+    "2) Install App to workspace to get the xoxb- bot token",
+    "3) Socket Mode: enable it and create an app-level token (xapp-...)",
+    "4) HTTP: configure a public HTTPS Request URL and copy the app Signing Secret",
+    "5) Enable Event Subscriptions for message, App Home, and Agent View events",
+    "6) App Home -> enable the Home tab, Messages tab for DMs, and Agent View",
+    "Tip: Socket Mode can use SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
     `Docs: ${formatDocsLink("/slack", "slack")}`,
   ];
 }

--- a/extensions/slack/src/setup-surface.test.ts
+++ b/extensions/slack/src/setup-surface.test.ts
@@ -59,7 +59,24 @@ describe("slackSetupWizard.prepare", () => {
 
     expect(lines.join("\n")).not.toContain("Manifest (JSON):");
     expect(lines.join("\n")).not.toContain('"display_information"');
-    expect(lines).toContain("Manifest JSON follows as plain text for copy/paste.");
+    expect(lines).toContain("3) Socket Mode: enable it and create an app-level token (xapp-...)");
+  });
+
+  it("gives HTTP bot setup signing guidance without a Socket Mode manifest", async () => {
+    const plain = vi.fn<NonNullable<WizardPrompter["plain"]>>(async () => {});
+    const note = vi.fn(async () => {});
+
+    await runSetupWizardPrepare({
+      prepare: slackSetupWizard.prepare,
+      cfg: { channels: { slack: { mode: "http" } } } as OpenClawConfig,
+      prompter: createTestWizardPrompter({ plain, note }),
+    });
+
+    const instructions = requireFirstStringArg(note, "Slack HTTP setup instructions");
+    expect(instructions).toContain("Signing Secret");
+    expect(instructions).toContain("public HTTPS Request URL");
+    expect(note).toHaveBeenCalledWith(instructions, "Channel setup");
+    expect(plain).not.toHaveBeenCalled();
   });
 
   it("prints the manifest as plain JSON when Slack is not configured", async () => {


### PR DESCRIPTION
Closes #130233

## What Problem This Solves

Slack HTTP bot onboarding presented Socket-only instructions and an incompatible Socket Mode manifest. Following that manifest omitted the public Slack Request URLs needed for events, slash commands, and interactivity, while never explaining the required Signing Secret.

## Why This Change Was Made

The Slack plugin's existing setup instructions now explain both supported transport contracts. Its real setup wizard suppresses the Socket-only generated manifest when the account already selects HTTP and uses the existing translated generic setup heading. HTTP operators are directed to the existing Slack documentation, which already contains complete HTTP manifests with public Gateway URLs.

Default Socket onboarding still prints the exact existing Socket manifest. User identity, relay behavior, account configuration, credential ownership, signing verification, SecretRefs, and existing environment shortcuts are unchanged. Production delta: +13/-16, net -3 lines.

## User Impact

HTTP setup now clearly requests a public HTTPS Request URL and Signing Secret instead of misleading operators into creating a Socket Mode app. Socket Mode remains the default and keeps its existing manifest behavior.

## Evidence

- Added an actual `runSetupWizardPrepare` HTTP bot regression that failed against unmodified production code because its setup note did not mention the Signing Secret.
- On the fixed owner path, that regression verifies public HTTPS guidance, signing-secret guidance, a transport-neutral translated title, and the absence of the incompatible Socket manifest.
- Passed all 58 focused Slack setup, account-inspection, transport-probe, lazy-proxy, and channel-status contract tests; existing tests verify the exact unchanged Socket manifest plus HTTP bot/user credential handling.
- Configured formatter, lint, and whitespace checks passed.
- Independent source-level review verified HTTP, default Socket, configured accounts, user identity, relay, localization, SecretRefs, and plugin ownership; fresh Codex autoreview reported no actionable findings.
