### PR TITLE
fix(workers): preserve remote turns through drain and cancellation

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.worker.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.worker.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WebSocket } from "ws";
 import {
@@ -22,13 +25,28 @@ import {
   type WorkerInferenceTerminalFrame,
   WORKER_INFERENCE_PROTOCOL_FEATURE,
 } from "../../../../packages/gateway-protocol/src/schema/worker-inference.js";
+import { createTestAdmittedRunContext } from "../../../agents/admitted-run-context.test-support.js";
+import type { SessionPlacementTurnParams } from "../../../agents/session-placement-admission.js";
 import {
+  claimAgentRunDelegatedAuthority,
+  releaseAgentRunDelegatedAuthority,
+} from "../../../infra/agent-run-registry.js";
+import {
+  beginGatewayRestartSignalAdmission,
   resetGatewayWorkAdmission,
+  tryBeginGatewayRootWorkAdmission,
   tryBeginGatewaySuspendAdmission,
 } from "../../../process/gateway-work-admission.js";
 import { createDeferredCore } from "../../../shared/deferred.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../../state/openclaw-state-db.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { WorkerConnectionIdentity } from "../../worker-environments/connection-identity.js";
+import { createWorkerSessionPlacementStore } from "../../worker-environments/placement-store.js";
+import { signalWorkerTurnClaimClosed } from "../../worker-environments/placement-turn-claim-events.js";
+import { prepareWorkerAgentRuntimeIdentity } from "../../worker-environments/worker-turn-payload.js";
 import { createGatewayWsTestSocket } from "../ws-connection.test-helpers.js";
 import type { GatewayWsClient } from "../ws-types.js";
 import { attachWorkerWsMessageHandler, type WorkerConnectionService } from "./worker-connection.js";
@@ -859,6 +877,89 @@ describe("dedicated worker websocket protocol", () => {
       expect(harness.close).toHaveBeenCalledWith(1008, "credential-replaced"),
     );
     expect(harness.service.validateWorkerConnection).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { scenario: "an already-admitted unaudited worker", fence: "none", accepted: true },
+    { scenario: "a worker whose exact admitted run closed", fence: "run", accepted: false },
+    { scenario: "a worker whose exact placement closed", fence: "placement", accepted: false },
+    { scenario: "a worker during a restart signal", fence: "restart", accepted: false },
+  ] as const)("handles $scenario while suspension drains", async ({ fence, accepted }) => {
+    const claim = ATTACHED_IDENTITY.turnClaim;
+    if (!claim) {
+      throw new Error("expected attached worker turn claim");
+    }
+    const admittedRunContext = createTestAdmittedRunContext(claim.runId);
+    const delegatedAuthority = claimAgentRunDelegatedAuthority(
+      admittedRunContext.operationalRunInstance,
+    );
+    const stateDir = await fs.mkdtemp(
+      path.join(await fs.realpath(os.tmpdir()), "openclaw-worker-suspension-"),
+    );
+    const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+    const placements = createWorkerSessionPlacementStore({ database });
+    let placementActive = true;
+    vi.spyOn(placements, "validateTurnClaim").mockImplementation(
+      (current) => current === claim && placementActive,
+    );
+    const storePath = database.path;
+    const rootAdmission = tryBeginGatewayRootWorkAdmission();
+    if (!rootAdmission) {
+      throw new Error("expected parent worker turn root admission");
+    }
+    let suspension: ReturnType<typeof tryBeginGatewaySuspendAdmission> = null;
+    let restartSignal: ReturnType<typeof beginGatewayRestartSignalAdmission> = null;
+    try {
+      await rootAdmission.run(() =>
+        prepareWorkerAgentRuntimeIdentity({
+          agentId: "main",
+          placements,
+          runtimeInstanceId: ATTACHED_IDENTITY.environmentId,
+          sessionKey: "agent:main:worker-suspension",
+          turn: {
+            admittedRunContext,
+            runId: claim.runId,
+          } as SessionPlacementTurnParams,
+          turnClaim: claim,
+        }),
+      );
+      const harness = attachHarness({ identity: ATTACHED_IDENTITY });
+      await admit(harness);
+      suspension = tryBeginGatewaySuspendAdmission(() => {});
+      expect(suspension?.drain()).toBe(true);
+      if (fence === "run") {
+        releaseAgentRunDelegatedAuthority(delegatedAuthority);
+      } else if (fence === "placement") {
+        placementActive = false;
+        signalWorkerTurnClaimClosed(storePath, claim);
+      } else if (fence === "restart") {
+        restartSignal = beginGatewayRestartSignalAdmission();
+        expect(restartSignal).not.toBeNull();
+      }
+
+      harness.sendRequest("worker.transcript.commit", TRANSCRIPT_COMMIT);
+
+      if (accepted) {
+        await waitForWorkerProtocol(() =>
+          expect(harness.service.commitTranscript).toHaveBeenCalledOnce(),
+        );
+        expect(harness.close).not.toHaveBeenCalled();
+        expect(harness.responses[1]).toMatchObject({ ok: true });
+      } else {
+        await waitForWorkerProtocol(() =>
+          expect(harness.close).toHaveBeenCalledWith(1013, "gateway-unavailable"),
+        );
+        expect(harness.service.commitTranscript).not.toHaveBeenCalled();
+      }
+    } finally {
+      restartSignal?.rollback();
+      suspension?.release();
+      signalWorkerTurnClaimClosed(storePath, claim);
+      releaseAgentRunDelegatedAuthority(delegatedAuthority);
+      rootAdmission.release();
+      closeOpenClawStateDatabaseForTest();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("rejects authenticated heartbeats while gateway admission is suspended", async () => {

--- a/src/gateway/server/ws-connection/worker-connection.ts
+++ b/src/gateway/server/ws-connection/worker-connection.ts
@@ -54,12 +54,15 @@ import {
 import { GATEWAY_STARTUP_RETRY_AFTER_MS } from "../../../../packages/gateway-protocol/src/startup-unavailable.js";
 import { rawDataByteLength } from "../../../infra/ws.js";
 import {
+  getGatewaySuspendAdmissionPhase,
+  isGatewayRestartDraining,
   runWithGatewayIndependentRootWorkContinuation,
   tryBeginGatewayRootWorkAdmission,
 } from "../../../process/gateway-work-admission.js";
 import { AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION } from "../../auth-rate-limit.js";
 import type { WorkerConnectionIdentity } from "../../worker-environments/connection-identity.js";
 import { MAX_RUNNING_WORKER_SESSION_TOOL_OPERATIONS } from "../../worker-environments/placement-session-tool-operations.js";
+import { runWorkerTurnAdmissionContinuation } from "../../worker-environments/placement-turn-claim-events.js";
 import type { PublicWorkerIngressContext } from "../public-worker-ingress-context.js";
 import type { GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
 import { runWorkerAdmissionBoundary } from "./worker-admission-boundary.js";
@@ -669,6 +672,24 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
         }
         const admission = tryBeginGatewayRootWorkAdmission();
         if (!admission) {
+          const client = params.getClient();
+          const identity = client?.worker;
+          if (
+            client &&
+            getGatewaySuspendAdmissionPhase() === "draining" &&
+            !isGatewayRestartDraining() &&
+            identity?.turnClaim &&
+            !client.invalidated &&
+            params.service?.validateWorkerConnection(identity) === null
+          ) {
+            const continuation = runWorkerTurnAdmissionContinuation(identity, () =>
+              handleMessage(data, true),
+            );
+            if (continuation) {
+              await continuation;
+              return;
+            }
+          }
           await handleMessage(data, false);
           return;
         }

--- a/src/gateway/worker-environments/credential-broker.test.ts
+++ b/src/gateway/worker-environments/credential-broker.test.ts
@@ -33,6 +33,7 @@ describe("worker environment service", () => {
     const liveEvents = support.createLiveEvents();
     const placementStore = {
       readWorkerTurnClaim: vi.fn(),
+      readWorkerTurnLiveAckCursor: vi.fn(() => 0),
       validateWorkerTurn: vi.fn(() => true),
       isWorkerTurnToolAuthorized: vi.fn(() => true),
       updateAckCursors: vi.fn(),

--- a/src/gateway/worker-environments/credential-broker.ts
+++ b/src/gateway/worker-environments/credential-broker.ts
@@ -349,7 +349,8 @@ export function createWorkerCredentialBroker(options: WorkerCredentialBrokerOpti
   const acquireTurnCredential = (claim: WorkerSessionTurnClaim) => {
     const binding = bindingForClaim(claim);
     return withLock(binding.environmentId, async () => {
-      if (!validateTurnClaim(claim)) {
+      const placementStore = options.placementStore;
+      if (!placementStore || !validateTurnClaim(claim)) {
         throw serviceError("invalid_state", "Worker turn credential claim is not authoritative");
       }
       const pending = readPendingCredential(binding, claim)?.grant;
@@ -367,10 +368,15 @@ export function createWorkerCredentialBroker(options: WorkerCredentialBrokerOpti
         throw serviceError("invalid_state", "Worker session credential owner is not attached");
       }
       const previous = store.getCredential(binding.environmentId);
+      const ackedSeq =
+        previous?.sessionId === binding.sessionId
+          ? placementStore.readWorkerTurnLiveAckCursor(claim)
+          : undefined;
       const minted = mintCredentialLocked(binding, claim);
       const grant = stageCredential(minted.grant);
-      if (previous?.sessionId === binding.sessionId) {
+      if (previous && ackedSeq !== undefined) {
         options.liveEvents?.rotateCredential({
+          ackedSeq,
           credentialHash: minted.credentialHash,
           environmentId: binding.environmentId,
           newProcessTurn: true,

--- a/src/gateway/worker-environments/live-events.test.ts
+++ b/src/gateway/worker-environments/live-events.test.ts
@@ -409,6 +409,7 @@ describe("worker live events", () => {
 
     expect(
       rx.rotateCredential({
+        ackedSeq: 2,
         credentialHash,
         environmentId: ID.environmentId,
         newProcessTurn: true,
@@ -421,6 +422,34 @@ describe("worker live events", () => {
     const nextProcess = { ...ID, credentialHash };
     ack(live(3, lifecycle({ phase: "start", startedAt: 300 })), 3, nextProcess);
     expect(events.map((event) => event.data.phase)).toEqual(["start", "end", "start"]);
+  });
+
+  it("rewinds cancelled preview ACKs before delivering the replacement turn terminal", () => {
+    ack(msg(1, "cancelled preview"));
+    ack(msg(2, "another cancelled preview", 1));
+    const credentialHash = "replacement-process-credential";
+    const runId = "replacement-worker-run";
+
+    expect(
+      rx.rotateCredential({
+        ackedSeq: 0,
+        credentialHash,
+        environmentId: ID.environmentId,
+        newProcessTurn: true,
+        previousCredentialHash: ID.credentialHash,
+        runEpoch: EPOCH,
+        sessionId: SID,
+      }),
+    ).toBe(true);
+
+    const replacement = { ...ID, credentialHash, runId };
+    ack(live(1, lifecycle({ phase: "start", startedAt: 300 }), runId), 1, replacement);
+    ack(
+      live(2, lifecycle({ phase: "finishing", startedAt: 300, endedAt: 400 }), runId),
+      2,
+      replacement,
+    );
+    expect(events.slice(-2).map((event) => event.data.phase)).toEqual(["start", "finishing"]);
   });
 
   it("ACKs before buffered failure", () => {
@@ -665,6 +694,7 @@ describe("worker live events", () => {
         ack(live(2, lifecycle({ phase: "end", startedAt: 100, endedAt: 200 })));
         expect(
           rx.rotateCredential({
+            ackedSeq: 2,
             credentialHash: "next-process-credential-hash",
             environmentId: ID.environmentId,
             newProcessTurn: true,

--- a/src/gateway/worker-environments/live-events.ts
+++ b/src/gateway/worker-environments/live-events.ts
@@ -56,14 +56,15 @@ type OwnedLiveRun = {
   trajectoryRecorder: WorkerLiveTrajectoryRecorder;
 };
 
-type WorkerLiveCredentialRotation = Readonly<{
-  credentialHash: string;
-  environmentId: string;
-  newProcessTurn?: boolean;
-  previousCredentialHash: string;
-  runEpoch: number;
-  sessionId: string;
-}>;
+type WorkerLiveCredentialRotation = Readonly<
+  {
+    credentialHash: string;
+    environmentId: string;
+    previousCredentialHash: string;
+    runEpoch: number;
+    sessionId: string;
+  } & ({ newProcessTurn: true; ackedSeq: number } | { newProcessTurn?: false })
+>;
 
 type LiveEventWindow = {
   activeRuns: Map<string, OwnedLiveRun>;
@@ -173,13 +174,21 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
       window.runEpoch === rotation.runEpoch
     ) {
       if (rotation.newProcessTurn === true) {
+        if (
+          !Number.isSafeInteger(rotation.ackedSeq) ||
+          rotation.ackedSeq < 0 ||
+          rotation.ackedSeq > window.ackedSeq
+        ) {
+          return false;
+        }
         // A per-turn credential is an unforgeable process boundary. Retire only
-        // the prior process's transient run claims/fences while preserving the
-        // durable ACK cursor; cron may intentionally reuse its durable run id.
+        // the prior process's transient state and rewind previews to the durable
+        // ACK cursor; cron may intentionally reuse its durable run id.
         for (const [runId, owned] of window.activeRuns) {
           releaseAgentRunContext(runId, owned.claimId);
         }
         window.activeRuns.clear();
+        window.ackedSeq = rotation.ackedSeq;
         window.pending.clear();
         window.pendingBytes = 0;
         window.terminalRuns.clear();

--- a/src/gateway/worker-environments/placement-store.turn-claim-closure.test.ts
+++ b/src/gateway/worker-environments/placement-store.turn-claim-closure.test.ts
@@ -8,19 +8,23 @@ import {
   claimAgentRunDelegatedAuthority,
   releaseAgentRunDelegatedAuthority,
 } from "../../infra/agent-run-registry.js";
+import { tryBeginGatewayRootWorkAdmission } from "../../process/gateway-work-admission.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
+import type { WorkerConnectionIdentity } from "./connection-identity.js";
 import { placementTurnOwner, type WorkerSessionPlacementIdentity } from "./placement-record.js";
 import {
   createWorkerSessionPlacementStore,
   type WorkerSessionPlacementStore,
 } from "./placement-store.js";
 import {
+  bindWorkerTurnAdmissionContinuation,
   bindWorkerTurnExecutionIdentity,
   getWorkerTurnExecutionIdentityCapability,
+  runWorkerTurnAdmissionContinuation,
 } from "./placement-turn-claim-events.js";
 
 const SESSION: WorkerSessionPlacementIdentity = {
@@ -250,4 +254,54 @@ it("rejects retained worker lineage capabilities after either owner closes", asy
     }),
   ).rejects.toThrow("worker turn authority changed");
   store.releaseTurn(runClosedClaim);
+});
+
+it("lets an unaudited admitted worker complete the exact turn that closes its owners", async () => {
+  const active = advanceToActive();
+  const claim = store.claimTurn({
+    ...SESSION,
+    claimId: "claim-terminal-continuation",
+    runId: "run-terminal-continuation",
+    owner: {
+      kind: "worker",
+      environmentId: active.environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+    },
+  });
+  const operationalRunInstance = createOperationalRunInstanceRef(claim.runId);
+  const delegatedAuthority = claimAgentRunDelegatedAuthority(operationalRunInstance);
+  const rootAdmission = tryBeginGatewayRootWorkAdmission();
+  if (!rootAdmission) {
+    throw new Error("expected parent worker turn root admission");
+  }
+  try {
+    await rootAdmission.run(async () =>
+      bindWorkerTurnAdmissionContinuation(store, claim, operationalRunInstance),
+    );
+    expect(getWorkerTurnExecutionIdentityCapability(store, claim)).toBeUndefined();
+    const identity: WorkerConnectionIdentity = {
+      environmentId: active.environmentId,
+      credentialHash: "worker-terminal-continuation",
+      bundleHash: "a".repeat(64),
+      sessionId: claim.sessionId,
+      runId: claim.runId,
+      turnClaim: claim,
+      ownerEpoch: active.activeOwnerEpoch,
+      rpcSetVersion: 1,
+      protocolFeatures: [],
+      credentialExpiresAtMs: Date.now() + 60_000,
+    };
+
+    await expect(
+      runWorkerTurnAdmissionContinuation(identity, async () => {
+        store.releaseTurn(claim);
+        releaseAgentRunDelegatedAuthority(delegatedAuthority);
+        return "completed";
+      }),
+    ).resolves.toBe("completed");
+    expect(runWorkerTurnAdmissionContinuation(identity, async () => "stale")).toBeNull();
+  } finally {
+    releaseAgentRunDelegatedAuthority(delegatedAuthority);
+    rootAdmission.release();
+  }
 });

--- a/src/gateway/worker-environments/placement-turn-claim-events.ts
+++ b/src/gateway/worker-environments/placement-turn-claim-events.ts
@@ -5,7 +5,12 @@ import {
   validateAgentRunDelegatedAuthority,
   type AgentRunDelegatedAuthority,
 } from "../../infra/agent-run-registry.js";
+import {
+  captureGatewayRootWorkAdmissionContinuationScope,
+  type GatewayRootWorkAdmissionContinuationScope,
+} from "../../process/gateway-work-admission.js";
 import { resolveGlobalMap } from "../../shared/global-singleton.js";
+import type { WorkerConnectionIdentity } from "./connection-identity.js";
 import type { WorkerSessionTurnClaim } from "./placement-record.js";
 
 type TurnClaimReleaseWaiter = (error?: Error) => void;
@@ -46,16 +51,28 @@ export type WorkerTurnExecutionIdentityCapability = Readonly<{
   run<T>(callback: (identity: WorkerTurnExecutionIdentity) => Promise<T> | T): Promise<T>;
 }>;
 
-type BoundWorkerTurnExecutionIdentity = {
-  capability: WorkerTurnExecutionIdentityCapability;
+type BoundWorkerTurnOwner = {
+  capability?: WorkerTurnExecutionIdentityCapability;
   claim: WorkerSessionTurnClaim;
   claimKey: string;
+  continuation?: {
+    delegatedAuthority: AgentRunDelegatedAuthority;
+    scope: GatewayRootWorkAdmissionContinuationScope;
+    store: WorkerTurnExecutionIdentityStore;
+  };
 };
 
-const workerTurnExecutionIdentities = resolveGlobalMap<
-  string,
-  Map<string, BoundWorkerTurnExecutionIdentity>
->(Symbol.for("openclaw.workerTurnExecutionIdentities"), (identities) => identities.clear());
+const workerTurnOwners = resolveGlobalMap<string, Map<string, BoundWorkerTurnOwner>>(
+  Symbol.for("openclaw.workerTurnExecutionIdentities"),
+  (ownersByPath) => {
+    for (const owners of ownersByPath.values()) {
+      for (const owner of owners.values()) {
+        owner.continuation?.scope.release();
+      }
+    }
+    ownersByPath.clear();
+  },
+);
 
 const WORKER_TURN_EXECUTION_IDENTITY_PATH = Symbol("workerTurnExecutionIdentityPath");
 type WorkerTurnExecutionIdentityStore = {
@@ -113,9 +130,19 @@ export function bindWorkerTurnExecutionIdentity(
       return result;
     },
   });
-  const identities = workerTurnExecutionIdentities.get(path) ?? new Map();
-  identities.set(claim.sessionId, { capability, claim, claimKey: claimKey(claim) });
-  workerTurnExecutionIdentities.set(path, identities);
+  const owners = workerTurnOwners.get(path) ?? new Map();
+  const existing = owners.get(claim.sessionId);
+  const currentClaimKey = claimKey(claim);
+  if (existing && existing.claimKey !== currentClaimKey) {
+    existing.continuation?.scope.release();
+  }
+  owners.set(claim.sessionId, {
+    ...(existing?.claimKey === currentClaimKey ? existing : {}),
+    capability,
+    claim,
+    claimKey: currentClaimKey,
+  });
+  workerTurnOwners.set(path, owners);
 }
 
 export function getWorkerTurnExecutionIdentityCapability(
@@ -123,10 +150,78 @@ export function getWorkerTurnExecutionIdentityCapability(
   claim: WorkerSessionTurnClaim,
 ): WorkerTurnExecutionIdentityCapability | undefined {
   const path = store[WORKER_TURN_EXECUTION_IDENTITY_PATH];
-  const bound = path ? workerTurnExecutionIdentities.get(path)?.get(claim.sessionId) : undefined;
+  const bound = path ? workerTurnOwners.get(path)?.get(claim.sessionId) : undefined;
   return bound && bound.claimKey === claimKey(claim) && store.validateTurnClaim(claim)
     ? bound.capability
     : undefined;
+}
+
+/** Completion authority follows the exact admitted run, not optional audit provenance. */
+export function bindWorkerTurnAdmissionContinuation(
+  store: WorkerTurnExecutionIdentityStore,
+  claim: WorkerSessionTurnClaim,
+  operationalRunInstance: OperationalRunInstanceRef,
+): void {
+  const scope = captureGatewayRootWorkAdmissionContinuationScope();
+  if (!scope) {
+    return;
+  }
+  const path = store[WORKER_TURN_EXECUTION_IDENTITY_PATH];
+  const delegatedAuthority = getActiveAgentRunDelegatedAuthority(operationalRunInstance);
+  if (!path || !store.validateTurnClaim(claim) || !delegatedAuthority) {
+    scope.release();
+    throw new Error(`Session ${claim.sessionId} worker turn authority changed`);
+  }
+  const owners = workerTurnOwners.get(path) ?? new Map();
+  const existing = owners.get(claim.sessionId);
+  existing?.continuation?.scope.release();
+  const currentClaimKey = claimKey(claim);
+  owners.set(claim.sessionId, {
+    ...(existing?.claimKey === currentClaimKey ? existing : {}),
+    claim,
+    claimKey: currentClaimKey,
+    continuation: { delegatedAuthority, scope, store },
+  });
+  workerTurnOwners.set(path, owners);
+}
+
+export function runWorkerTurnAdmissionContinuation<T>(
+  identity: WorkerConnectionIdentity,
+  run: () => Promise<T>,
+): Promise<T> | null {
+  const claim = identity.turnClaim;
+  if (
+    !claim ||
+    claim.owner.kind !== "worker" ||
+    identity.sessionId !== claim.sessionId ||
+    identity.runId !== claim.runId ||
+    identity.environmentId !== claim.owner.environmentId ||
+    identity.ownerEpoch !== claim.owner.ownerEpoch
+  ) {
+    return null;
+  }
+  const currentClaimKey = claimKey(claim);
+  let owner: BoundWorkerTurnOwner | undefined;
+  for (const owners of workerTurnOwners.values()) {
+    const candidate = owners.get(claim.sessionId);
+    if (candidate?.claimKey !== currentClaimKey) {
+      continue;
+    }
+    if (owner) {
+      return null;
+    }
+    owner = candidate;
+  }
+  const continuation = owner?.continuation;
+  if (
+    !owner ||
+    !continuation ||
+    !continuation.store.validateTurnClaim(owner.claim) ||
+    !validateAgentRunDelegatedAuthority(continuation.delegatedAuthority)
+  ) {
+    return null;
+  }
+  return continuation.scope.run(run);
 }
 
 export function attachWorkerTurnExecutionIdentityStore(store: object, path: string): void {
@@ -198,11 +293,13 @@ export function registerWorkerTurnClaimClosedHandler(
 
 export function signalWorkerTurnClaimClosed(path: string, claim: WorkerSessionTurnClaim): void {
   signalTurnClaimRelease(path, claim.sessionId);
-  const identities = workerTurnExecutionIdentities.get(path);
-  if (identities?.get(claim.sessionId)?.claimKey === claimKey(claim)) {
-    identities.delete(claim.sessionId);
-    if (identities.size === 0) {
-      workerTurnExecutionIdentities.delete(path);
+  const owners = workerTurnOwners.get(path);
+  const owner = owners?.get(claim.sessionId);
+  if (owner?.claimKey === claimKey(claim)) {
+    owner.continuation?.scope.release();
+    owners?.delete(claim.sessionId);
+    if (owners?.size === 0) {
+      workerTurnOwners.delete(path);
     }
   }
   for (const handler of workerTurnClaimClosedHandlers.get(path) ?? []) {

--- a/src/gateway/worker-environments/placement-worker-gate.test.ts
+++ b/src/gateway/worker-environments/placement-worker-gate.test.ts
@@ -155,6 +155,8 @@ describe("worker session placement gate", () => {
 
     expect(gate.validateWorkerTurn(firstBinding)).toBe(false);
     expect(gate.validateWorkerTurn(secondBinding)).toBe(true);
+    expect(() => gate.readWorkerTurnLiveAckCursor(firstBinding)).toThrow("stale worker turn");
+    expect(gate.readWorkerTurnLiveAckCursor(secondBinding)).toBe(0);
     expect(gate.isWorkerTurnToolAuthorized(firstBinding, "sessions_send")).toBe(false);
     expect(gate.isWorkerTurnToolAuthorized(secondBinding, "sessions_send")).toBe(true);
     expect(() => gate.updateAckCursors({ claim: firstBinding, transcriptSeq: 3 })).toThrow(
@@ -176,6 +178,7 @@ describe("worker session placement gate", () => {
       lastTranscriptAckCursor: 4,
       lastLiveEventAckCursor: 9,
     });
+    expect(gate.readWorkerTurnLiveAckCursor(binding)).toBe(9);
     expect(store.listPendingWorkspaceResults()).toMatchObject([
       { sessionId: SESSION.sessionId, runId },
     ]);

--- a/src/gateway/worker-environments/placement-worker-gate.ts
+++ b/src/gateway/worker-environments/placement-worker-gate.ts
@@ -22,6 +22,7 @@ export type WorkerSessionPlacementGate = {
   getExecutionIdentityCapability?(
     claim: WorkerSessionTurnClaim,
   ): WorkerTurnExecutionIdentityCapability | undefined;
+  readWorkerTurnLiveAckCursor(claim: WorkerSessionTurnClaim): number;
   validateWorkerTurn(claim: WorkerSessionTurnClaim): boolean;
   isWorkerTurnToolAuthorized(claim: WorkerSessionTurnClaim, toolName: string): boolean;
   updateAckCursors(input: {
@@ -72,6 +73,17 @@ export function createWorkerSessionPlacementGate(
     getExecutionIdentityCapability: (claim) =>
       getWorkerTurnExecutionIdentityCapability(store, claim),
     validateWorkerTurn,
+
+    readWorkerTurnLiveAckCursor(claim): number {
+      if (!validateWorkerTurn(claim)) {
+        throw new Error(`Cannot read ACK cursor for stale worker turn ${claim.sessionId}`);
+      }
+      const placement = store.get(claim.sessionId);
+      if (!placement) {
+        throw new Error(`Worker placement disappeared for session ${claim.sessionId}`);
+      }
+      return placement.lastLiveEventAckCursor ?? 0;
+    },
 
     isWorkerTurnToolAuthorized(claim, toolName): boolean {
       return validateWorkerTurn(claim) && store.isWorkerTurnToolAuthorized(claim, toolName);

--- a/src/gateway/worker-environments/service-lifetime.test.ts
+++ b/src/gateway/worker-environments/service-lifetime.test.ts
@@ -125,6 +125,7 @@ describe("worker environment service", () => {
     const unsubscribeTurnClaimClosed = vi.fn();
     const placementStore = {
       readWorkerTurnClaim: vi.fn(),
+      readWorkerTurnLiveAckCursor: vi.fn(() => 0),
       validateWorkerTurn: vi.fn(() => false),
       isWorkerTurnToolAuthorized: vi.fn(() => false),
       updateAckCursors: vi.fn(),

--- a/src/gateway/worker-environments/service.test-support.ts
+++ b/src/gateway/worker-environments/service.test-support.ts
@@ -503,6 +503,7 @@ export function placementHarness(
   identity.credentialHash = credentialHash;
   const placementStore = {
     readWorkerTurnClaim: vi.fn(() => claim),
+    readWorkerTurnLiveAckCursor: vi.fn(() => 0),
     validateWorkerTurn: vi.fn(() => true),
     isWorkerTurnToolAuthorized: vi.fn(() => true),
     updateAckCursors: vi.fn(),

--- a/src/gateway/worker-environments/worker-turn-admission.ts
+++ b/src/gateway/worker-environments/worker-turn-admission.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { LocalTurnPlacementClaim } from "../../agents/session-placement-admission.js";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
 import { SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS } from "../../sessions/session-lifecycle-admission.js";
+import { projectWorkerSessionTurnClaim } from "./placement-record.js";
 import type {
   WorkerSessionPlacementRecord,
   WorkerSessionPlacementStore,
@@ -179,6 +180,7 @@ export async function claimWorkerTurn(params: {
   identity: ReturnType<typeof resolvePlacementIdentity>;
   placement: ActiveWorkerPlacement;
   runId: string;
+  isCancellationRequested: (claim: WorkerSessionTurnClaim) => boolean;
   signal?: AbortSignal;
 }): Promise<{ placement: ActiveWorkerPlacement; turnClaim: WorkerSessionTurnClaim }> {
   const claim = () =>
@@ -198,7 +200,8 @@ export async function claimWorkerTurn(params: {
     if (!(error instanceof ActiveTurnClaimError)) {
       throw error;
     }
-    const activeClaim = params.placements.get(params.identity.sessionId)?.turnClaim;
+    const activePlacement = params.placements.get(params.identity.sessionId);
+    const activeClaim = activePlacement?.turnClaim;
     if (activeClaim?.runId === params.runId) {
       throw error;
     }
@@ -211,12 +214,17 @@ export async function claimWorkerTurn(params: {
           pending.claimId === activeClaim.claimId &&
           pending.runId === activeClaim.runId,
       );
-    if (!resultIsReconciling) {
+    const cancelledClaim = activePlacement && projectWorkerSessionTurnClaim(activePlacement);
+    if (
+      !resultIsReconciling &&
+      !(cancelledClaim && params.isCancellationRequested(cancelledClaim))
+    ) {
       const refreshed = params.placements.get(params.identity.sessionId);
       if (
         refreshed?.state !== "active" ||
         refreshed.environmentId !== params.placement.environmentId ||
         refreshed.activeOwnerEpoch !== params.placement.activeOwnerEpoch ||
+        refreshed.generation !== params.placement.generation ||
         refreshed.turnClaim
       ) {
         throw error;
@@ -239,7 +247,8 @@ export async function claimWorkerTurn(params: {
   if (
     refreshed?.state !== "active" ||
     refreshed.environmentId !== params.placement.environmentId ||
-    refreshed.activeOwnerEpoch !== params.placement.activeOwnerEpoch
+    refreshed.activeOwnerEpoch !== params.placement.activeOwnerEpoch ||
+    refreshed.generation !== params.placement.generation
   ) {
     throw new Error(PREVIOUS_RESULT_RECONCILING_MESSAGE);
   }

--- a/src/gateway/worker-environments/worker-turn-launcher-claim-admission.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-claim-admission.test.ts
@@ -180,6 +180,141 @@ describe("worker turn launcher claim admission", () => {
     expect(placements.get(SESSION_ID)).toMatchObject({ state: "reclaimed", turnClaim: null });
   });
 
+  it("waits for an exact cancelled worker turn and preserves its placement for the next run", async () => {
+    seedActivePlacement();
+    const cancelled = new AbortController();
+    const cancellationStarted = createDeferred();
+    const finishCancellation = createDeferred();
+    let launchCount = 0;
+    const stopTunnel = vi.fn(async () => {});
+    const destroy = vi.fn(async () => attachedEnvironment());
+    const launchTurn = vi.fn(async (request: WorkerTurnLaunchRequest): Promise<SpawnResult> => {
+      request.onDispatchReady?.();
+      launchCount += 1;
+      if (launchCount === 1) {
+        cancellationStarted.resolve();
+        await finishCancellation.promise;
+        return {
+          stdout: "",
+          stderr: "",
+          code: 1,
+          signal: null,
+          killed: true,
+          termination: "exit",
+        };
+      }
+      const completed = openSessionManager();
+      const leafId = completed.appendMessage(
+        makeAgentAssistantMessage({
+          content: [{ type: "text", text: "Recovered after cancellation" }],
+          timestamp: 41,
+        }),
+      );
+      createWorkerSessionPlacementGate(placements).updateAckCursors({
+        claim: request.turnClaim,
+        transcriptSeq: 2,
+        liveSeq: 1,
+      });
+      return {
+        stdout: JSON.stringify({
+          status: "completed",
+          transcriptLeafId: leafId,
+          transcriptNextSeq: (placements.get(SESSION_ID)?.lastTranscriptAckCursor ?? 0) + 1,
+        }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+    const environments: WorkerTurnEnvironmentService = {
+      get: vi.fn(() => attachedEnvironment()),
+      acquireTurnCredential: vi.fn(async () => credential(String(launchCount + 1).repeat(43))),
+      acknowledgeCredentialDelivery: vi.fn(() => true),
+      startTunnel: vi.fn(async () => ({
+        environmentId: ENVIRONMENT_ID,
+        ownerEpoch: OWNER_EPOCH,
+        quiesceWorkspace: vi.fn(async () => ({
+          assertActive: vi.fn(async () => {}),
+          resume: vi.fn(async () => {}),
+        })),
+        runWorkspaceCommand: vi.fn(),
+        launchTurn,
+        syncWorkspace: vi.fn(async () => {
+          throw new Error("unexpected workspace sync");
+        }),
+        reconcileWorkspace: vi.fn(async (request) => {
+          request.journal.commit(MANIFEST_REF);
+          return {
+            manifestRef: MANIFEST_REF,
+            changed: false,
+            verifyStable: async () => {},
+            verifyLocalStable: async () => {},
+          };
+        }),
+        stop: vi.fn(async () => {}),
+      })),
+      stopTunnel,
+      destroy,
+    };
+    const provider = createWorkerSessionTurnPlacementProvider({ environments, placements });
+    const firstRunId = "run-cancelled-worker";
+    const runClaim = (runId: string) => ({
+      sessionId: SESSION_ID,
+      sessionKey: SESSION_KEY,
+      agentId: "main",
+      runId,
+    });
+    const first = provider.executeTurn(
+      runClaim(firstRunId),
+      { ...turn(firstRunId), abortSignal: cancelled.signal },
+      async () => ({ meta: { durationMs: 1 } }),
+    );
+    void first.catch(() => undefined);
+    let replacement: Promise<unknown> | undefined;
+
+    try {
+      await cancellationStarted.promise;
+      await expect(
+        provider.executeTurn(runClaim(firstRunId), turn(firstRunId), async () => ({
+          meta: { durationMs: 1 },
+        })),
+      ).rejects.toThrow("already has an active turn claim");
+      await expect(
+        provider.executeTurn(
+          runClaim("run-live-collision"),
+          turn("run-live-collision"),
+          async () => ({ meta: { durationMs: 1 } }),
+        ),
+      ).rejects.toThrow("already has an active turn claim");
+      const waitForRelease = vi.spyOn(placements, "waitForTurnClaimRelease");
+      cancelled.abort(new Error("operator stopped the previous turn"));
+      replacement = provider.executeTurn(
+        runClaim("run-after-cancellation"),
+        turn("run-after-cancellation"),
+        async () => ({ meta: { durationMs: 1 } }),
+      );
+      void replacement.catch(() => undefined);
+
+      await vi.waitFor(() => expect(waitForRelease).toHaveBeenCalledOnce());
+      expect(placements.get(SESSION_ID)?.turnClaim?.runId).toBe(firstRunId);
+      expect(launchTurn).toHaveBeenCalledOnce();
+
+      finishCancellation.resolve();
+      await expect(first).rejects.toThrow("Cloud worker process failed before completing the turn");
+      await expect(replacement).resolves.toMatchObject({
+        payloads: [{ text: "Recovered after cancellation" }],
+      });
+      expect(stopTunnel).not.toHaveBeenCalled();
+      expect(destroy).not.toHaveBeenCalled();
+      expect(placements.get(SESSION_ID)).toMatchObject({ state: "active", turnClaim: null });
+    } finally {
+      finishCancellation.resolve();
+      await Promise.allSettled([first, replacement].filter((operation) => operation !== undefined));
+    }
+  });
+
   it("launches only one worker loop for concurrent admission of the same run", async () => {
     seedActivePlacement();
     const commandStarted = createDeferred();

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -21,7 +21,7 @@ import {
   StaleWorkerBuildError,
   supportsWorkerExecutionContextLaunch,
 } from "./admission.js";
-import { placementTurnOwner } from "./placement-record.js";
+import { placementTurnOwner, sameWorkerSessionTurnClaim } from "./placement-record.js";
 import { createRemoteExecPlacementSandbox } from "./placement-sandbox.js";
 import type {
   WorkerSessionPlacementRecord,
@@ -418,6 +418,10 @@ async function executeWorkerTurn(params: {
 }
 
 export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLauncherOptions) {
+  const activeWorkerTurns = new Map<
+    string,
+    { claim: WorkerSessionTurnClaim; signal: AbortSignal }
+  >();
   const provider: SessionPlacementAdmissionProvider & {
     resolveSandbox(params: {
       agentId: string;
@@ -561,10 +565,23 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
           identity,
           placement,
           runId: claim.runId,
+          isCancellationRequested: (activeClaim) => {
+            const active = activeWorkerTurns.get(activeClaim.sessionId);
+            return Boolean(
+              active?.signal.aborted && sameWorkerSessionTurnClaim(active.claim, activeClaim),
+            );
+          },
           ...(turn.abortSignal ? { signal: turn.abortSignal } : {}),
         });
         placement = admitted.placement;
         turnClaim = admitted.turnClaim;
+      }
+      const activeWorkerTurn =
+        !remoteExec && turn.abortSignal
+          ? { claim: turnClaim, signal: turn.abortSignal }
+          : undefined;
+      if (activeWorkerTurn) {
+        activeWorkerTurns.set(turnClaim.sessionId, activeWorkerTurn);
       }
       let handedOff = false;
       try {
@@ -624,7 +641,9 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
         }
         if (
           error instanceof WorkerRunnerCapacityError ||
-          (error instanceof WorkerRunnerUnavailableError && !handedOff)
+          (error instanceof WorkerRunnerUnavailableError && !handedOff) ||
+          // Canceling the exact worker turn must not destroy its reusable placement.
+          (!remoteExec && handedOff && turn.abortSignal?.aborted)
         ) {
           await releaseClaimIfOwned(options.placements, turnClaim);
           throw error;
@@ -676,6 +695,10 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
           await releaseClaimIfOwned(options.placements, turnClaim);
         }
         throw error;
+      } finally {
+        if (activeWorkerTurn && activeWorkerTurns.get(turnClaim.sessionId) === activeWorkerTurn) {
+          activeWorkerTurns.delete(turnClaim.sessionId);
+        }
       }
     },
   };

--- a/src/gateway/worker-environments/worker-turn-payload.ts
+++ b/src/gateway/worker-environments/worker-turn-payload.ts
@@ -43,7 +43,10 @@ import {
 } from "../agent-runtime-identity-token.js";
 import type { WorkerSessionTurnClaim } from "./placement-record.js";
 import type { WorkerSessionPlacementStore } from "./placement-store.js";
-import { bindWorkerTurnExecutionIdentity } from "./placement-turn-claim-events.js";
+import {
+  bindWorkerTurnAdmissionContinuation,
+  bindWorkerTurnExecutionIdentity,
+} from "./placement-turn-claim-events.js";
 
 type WorkerInitialMessagePlan =
   | { kind: "complete"; messages: WorkerTranscriptMessage[] }
@@ -114,6 +117,11 @@ export async function prepareWorkerAgentRuntimeIdentity(
       { agentId: params.agentId, sessionKey: params.sessionKey },
     );
   }
+  bindWorkerTurnAdmissionContinuation(
+    params.placements,
+    params.turnClaim,
+    admittedRunContext.operationalRunInstance,
+  );
   return {
     operationalRunInstance: admittedRunContext.operationalRunInstance,
     runtimeIdentity,

--- a/src/worker/worker-fault-placement-lifecycle.test-support.ts
+++ b/src/worker/worker-fault-placement-lifecycle.test-support.ts
@@ -143,7 +143,7 @@ export class WorkerFaultPlacementLifecycle {
   }
 
   private bindCredentialToClaim(credential: string, claim: WorkerSessionTurnClaim): void {
-    if (claim.owner.kind !== "worker") {
+    if (claim.owner.kind !== "worker" || !this.options.placementStore.validateTurnClaim(claim)) {
       throw new Error("fault worker credential requires a worker-owned claim");
     }
     const previous = this.options.environmentStore.getCredential(this.options.environmentId);
@@ -158,6 +158,8 @@ export class WorkerFaultPlacementLifecycle {
     });
     if (previous && previous.credentialHash !== credentialHash) {
       this.options.getLiveEvents().rotateCredential({
+        ackedSeq:
+          this.options.placementStore.get(this.options.sessionId)?.lastLiveEventAckCursor ?? 0,
         credentialHash,
         environmentId: this.options.environmentId,
         newProcessTurn: true,

--- a/test/e2e/qa-lab/runtime/node-worker-container-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-container-wire.e2e.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { startQaMockOpenAiServer } from "../../../../extensions/qa-lab/api.js";
 import { NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND } from "../../../../src/infra/node-commands.js";
 import { resolveNodeWorkerContainerEngine } from "../../../../src/node-host/node-worker-container-engine.js";
+import { createDeferred } from "../../../helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
 import { MODEL_REF, PROOF_TIMEOUT_MS } from "./cloud-worker-midturn-loss-fixture.js";
 import {
@@ -35,6 +36,12 @@ const EXEC_MARKER = "NODE_WORKER_CONTAINER_YOLO_OK";
 const EXEC_FILE = "node-worker-container-yolo.txt";
 const EXEC_COMMAND = `test -f /.dockerenv && printf ${EXEC_MARKER} > ${EXEC_FILE} && sleep 1`;
 const PROMPT = `Tool progress QA check: call the exec tool exactly once with this exact command before answering: \`${EXEC_COMMAND}\`. After that exec command completes or fails, reply exactly \`${EXEC_MARKER}\`.`;
+const CANCEL_STARTED_FILE = "node-worker-container-cancel-started.txt";
+const CANCEL_LATE_FILE = "node-worker-container-cancel-late.txt";
+const CANCEL_COMMAND = `test -f /.dockerenv && printf started > ${CANCEL_STARTED_FILE} && sleep 30 && printf escaped > ${CANCEL_LATE_FILE}`;
+const CANCEL_PROMPT = `Tool progress QA check: call the exec tool exactly once with this exact command before answering: \`${CANCEL_COMMAND}\`. After that exec command completes or fails, reply exactly \`NODE_WORKER_CANCELLED\`.`;
+const RECOVERY_MARKER = "NODE_WORKER_CONTAINER_CANCEL_RECOVERED";
+const RECOVERY_PROMPT = `Reply with only this exact marker: ${RECOVERY_MARKER}`;
 const CONTAINER_INSPECT_FORMAT =
   '{"mounts":{{json .Mounts}},"image":{{json .Config.Image}},"state":{{json .State.Status}},"labels":{{json .Config.Labels}}}';
 
@@ -59,6 +66,8 @@ type ControlUiProof = {
       deviceId?: string;
       message?: string;
       idempotencyKey?: string;
+      runId?: string;
+      sessionKey?: string;
     };
   }>;
   fullAccessPatch: {
@@ -173,12 +182,16 @@ async function startControlUiProof(gateway: WireGateway): Promise<ControlUiProof
           message?: string;
           idempotencyKey?: string;
           permissionMode?: string;
+          runId?: string;
+          sessionKey?: string;
         };
       };
       if (
         request.method === "sessions.create" ||
         request.method === "sessions.dispatch" ||
-        request.method === "sessions.send"
+        request.method === "sessions.send" ||
+        request.method === "chat.send" ||
+        request.method === "chat.abort"
       ) {
         requests.push({ method: request.method, params: request.params });
       }
@@ -242,6 +255,7 @@ describe.runIf(CONTAINER_WIRE_ENABLED)("node worker real Docker wire", () => {
       let browserRunId: string | undefined;
       let launchId: string | undefined;
       let inspectLaunchedContainer = !CONTROL_UI_PROOF_ENABLED;
+      let releasePendingCancellation: (() => void) | undefined;
       let sessionKey = SESSION_KEY;
 
       try {
@@ -544,6 +558,134 @@ describe.runIf(CONTAINER_WIRE_ENABLED)("node worker real Docker wire", () => {
               wireMessageText(message).includes(EXEC_MARKER),
           ),
         ).toBe(true);
+        if (controlUiProof) {
+          const cancellationEntered = createDeferred();
+          const continueCancellation = createDeferred();
+          releasePendingCancellation = () => continueCancellation.resolve();
+          const originalCancel = workerNode.supervisor.cancel.bind(workerNode.supervisor);
+          vi.spyOn(workerNode.supervisor, "cancel").mockImplementation(async (...args) => {
+            cancellationEntered.resolve();
+            await continueCancellation.promise;
+            return await originalCancel(...args);
+          });
+
+          const previousLaunchId = launchId;
+          browserRunId = undefined;
+          await controlUiProof.page
+            .locator(".agent-chat__composer-combobox textarea")
+            .fill(CANCEL_PROMPT);
+          await controlUiProof.page.getByRole("button", { name: "Send message" }).click();
+          await vi.waitFor(
+            () => {
+              expect(launchId).toBeTruthy();
+              expect(launchId).not.toBe(previousLaunchId);
+              expect(browserRunId).toBeTruthy();
+            },
+            { timeout: PROOF_TIMEOUT_MS, interval: 100 },
+          );
+          const cancelledLaunchId = launchId!;
+          const cancelledRunId = browserRunId!;
+          const cancelledContainer = await observedContainer!;
+          await vi.waitFor(
+            async () =>
+              expect(
+                await fs.readFile(path.join(remoteWorkspaceDir!, CANCEL_STARTED_FILE), "utf8"),
+              ).toBe("started"),
+            { timeout: PROOF_TIMEOUT_MS, interval: 100 },
+          );
+
+          await controlUiProof.page.getByRole("button", { name: "Stop generating" }).click();
+          await cancellationEntered.promise;
+          expect(controlUiProof.requests.at(-1)).toMatchObject({
+            method: "chat.abort",
+            params: { sessionKey, runId: cancelledRunId },
+          });
+          await expect(workerNode.supervisor.status(cancelledLaunchId)).resolves.toMatchObject({
+            state: "running",
+          });
+
+          await controlUiProof.page
+            .locator(".agent-chat__composer-combobox textarea")
+            .fill(RECOVERY_PROMPT);
+          await controlUiProof.page.getByRole("button", { name: "Send message" }).click();
+          const recoveryRequest = controlUiProof.requests.at(-1);
+          expect(recoveryRequest).toMatchObject({
+            method: "chat.send",
+            params: { sessionKey, message: RECOVERY_PROMPT },
+          });
+          const recoveryRunId = recoveryRequest?.params?.idempotencyKey;
+          expect(recoveryRunId).toBeTruthy();
+          await controlUiProof.page.getByRole("button", { name: "Stop generating" }).waitFor();
+          releasePendingCancellation();
+          releasePendingCancellation = undefined;
+          const recovered = await operator.request<{
+            status?: string;
+            error?: string;
+            summary?: string;
+            stopReason?: string;
+          }>(
+            "agent.wait",
+            { runId: recoveryRunId, timeoutMs: PROOF_TIMEOUT_MS },
+            { timeoutMs: PROOF_TIMEOUT_MS + 5_000 },
+          );
+          if (recovered.status !== "ok") {
+            const recoveryPlacement = (await gateway.call("sessions.describe", {
+              key: sessionKey,
+            })) as {
+              session?: {
+                status?: string;
+                lastRunError?: string;
+                placement?: { state?: string; recoveryError?: string };
+              };
+            };
+            const cancelled = await workerNode.supervisor.status(cancelledLaunchId);
+            throw new Error(
+              `replacement worker turn failed: ${JSON.stringify({
+                result: recovered,
+                sessionStatus: recoveryPlacement.session?.status,
+                lastRunError: recoveryPlacement.session?.lastRunError,
+                placement: recoveryPlacement.session?.placement,
+                cancelledState: cancelled?.state,
+                cancelledError: cancelled?.errorText,
+              })}\n${gateway.logs().slice(-12_000)}`,
+            );
+          }
+          await workerNode.waitForWorkersIdle();
+          await expect(workerNode.supervisor.status(cancelledLaunchId)).resolves.toMatchObject({
+            state: "cancelled",
+          });
+          await expect(
+            dockerOutput([
+              "ps",
+              "--all",
+              "--filter",
+              `id=${cancelledContainer.id}`,
+              "--format",
+              "{{.ID}}",
+            ]),
+          ).resolves.toBe("");
+          await expect(fs.stat(path.join(remoteWorkspaceDir!, CANCEL_LATE_FILE))).rejects.toThrow();
+          const recoveryHistory = await operator.request<{ messages?: unknown[] }>("chat.history", {
+            sessionKey,
+            limit: 20,
+          });
+          expect(
+            recoveryHistory.messages?.some(
+              (message) =>
+                (message as { role?: unknown }).role === "assistant" &&
+                wireMessageText(message).includes(RECOVERY_MARKER),
+            ),
+          ).toBe(true);
+          expect(
+            await controlUiProof.page
+              .locator("[data-approval-id], .exec-approval-modal-stack")
+              .count(),
+          ).toBe(0);
+          await captureControlUiProof(
+            controlUiProof,
+            "05-cancelled-worker-continues-without-alerts",
+          );
+        }
         await expect(operator.request("exec.approval.list", {})).resolves.toEqual([]);
         expect(approvalEvents).toEqual([]);
         await workerNode.waitForInvokes();
@@ -553,6 +695,7 @@ describe.runIf(CONTAINER_WIRE_ENABLED)("node worker real Docker wire", () => {
           dockerOutput(["ps", "--all", "--filter", `id=${container.id}`, "--format", "{{.ID}}"]),
         ).resolves.toBe("");
       } finally {
+        releasePendingCancellation?.();
         if (controlUiProof) {
           controlUiProof.fullAccessPatch.release();
           await controlUiProof.context.close();

--- a/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
@@ -101,6 +101,68 @@ suite.define(() => {
     }
   });
 
+  it.each(deviceTargets)(
+    "does not dispatch the $name device from stale capacity during a topology refresh",
+    async ({ value }) => {
+      const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+      const page = await context.newPage();
+      const environment = {
+        id: "node:paired-runner",
+        type: "node",
+        label: "Paired runner",
+        status: "available",
+        sessionHost: true,
+        workerSlots: { total: 2, available: 1 },
+      };
+      const gateway = await installMockGateway(page, {
+        operatorScopes: ["operator.read", "operator.write"],
+        workspace: WORKSPACE,
+        workspaceGit: true,
+        methodResponses: {
+          "environments.list": { environments: [environment], profiles: [] },
+          "sessions.create": { key: "agent:main:stale-device-capacity" },
+        },
+      });
+
+      try {
+        await page.goto(`${suite.server.baseUrl}new`);
+        await gateway.waitForRequest("environments.list");
+        const where = page.locator("#new-session-where-trigger");
+        await where.click();
+        await page.locator(`[data-value="${value}"]`).click();
+        await page.locator(".new-session-page__message").fill("require current worker capacity");
+        const start = page.getByRole("button", { name: "Start session" });
+        await expect.poll(() => start.isEnabled()).toBe(true);
+
+        await gateway.deferNext("environments.list");
+        const requestsBeforeRefresh = (await gateway.getRequests("environments.list")).length;
+        await gateway.emitGatewayEvent("node.runnerInventory.changed", {
+          nodeId: "paired-runner",
+        });
+        await gateway.waitForRequest("environments.list", { after: requestsBeforeRefresh });
+        await expect.poll(() => start.isDisabled()).toBe(true);
+        expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
+        await expect
+          .poll(() =>
+            where.getAttribute(value === "auto-device" ? "data-auto-device" : "data-device-id"),
+          )
+          .toBe(value === "auto-device" ? "true" : "paired-runner");
+
+        await gateway.resolveDeferred("environments.list", {
+          environments: [{ ...environment, workerSlots: { total: 2, available: 0 } }],
+          profiles: [],
+        });
+        await expect.poll(() => start.isDisabled()).toBe(true);
+        await expect
+          .poll(() => start.locator("xpath=..").getAttribute("content"))
+          .toContain("No worker slots are available");
+        expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
+      } finally {
+        await context.close();
+      }
+    },
+  );
+
   it.each([
     {
       name: "paired device",

--- a/ui/src/pages/new-session/submit-gates.ts
+++ b/ui/src/pages/new-session/submit-gates.ts
@@ -180,16 +180,16 @@ export function resolveNewSessionSubmitBlock(
     return { gate: "device-runtime", reason: deviceRuntimeUnsupportedReason };
   }
   const placementTarget = host.placementTargetForSubmission();
-  if (placementTarget && (!client.recoveryScope || !client.recoveryScopeReady)) {
+  if (
+    placementTarget &&
+    (!client.recoveryScope || !client.recoveryScopeReady || gateway.cloudProfilesPending)
+  ) {
     return { gate: "placement-recovery", reason: t("newSession.placementNotReady") };
   }
   const cloudProfileId = placementTarget?.kind === "profile" ? placementTarget.profileId : "";
   if (
     cloudProfileId &&
-    (!client.recoveryScope ||
-      !client.recoveryScopeReady ||
-      !gateway.cloudProfilesReady ||
-      gateway.cloudProfilesPending ||
+    (!gateway.cloudProfilesReady ||
       !place.worktree ||
       !gateway.cloudProfiles.some((profile) => profile.id === cloudProfileId) ||
       Boolean(host.cloudRuntimeUnsupportedReason()))


### PR DESCRIPTION
## What Problem This Solves

Fixes three real paired-node and cloud-worker failures: cooperative Gateway suspension disconnected already-admitted workers before they could deliver their completion; stopping an active Docker worker and immediately sending another message raced its unreleased turn claim and destroyed the otherwise healthy remote environment; and selected or automatic remote nodes remained startable while authoritative capacity refresh was still pending.

## Why This Change Was Made

An admitted worker must finish only through the exact borrowed Gateway root, authoritative operational run, immutable placement generation, environment, owner epoch, and live turn claim that own its current turn. The worker claim owner now holds that non-diagnostic continuation separately from optional audit provenance; closed or replaced runs, revoked claims, fresh handshakes, and Gateway restart all remain fenced. The worker launcher retains the exact admitted claim and its own abort signal through asynchronous cancellation, waits only for that precise canceled predecessor, and preserves a healthy placement instead of misclassifying an intentional Stop as an unrecoverable worker failure. New-process credential rotation also resets speculative live-event acknowledgments to the current exact placement's durable cursor, so a canceled worker's preview events cannot make its replacement's terminal result disappear. The existing shared remote-placement readiness gate now covers paired devices, automatic placement, and cloud profiles consistently while deleting redundant cloud-only checks.

## User Impact

An operator can safely drain the Gateway while an already-running remote worker delivers its remaining transcript/events. Stop followed immediately by Send works on the selected paired node, leaves no escaped Docker process or orphan container, preserves the remote environment, and never introduces Full Access approval alerts. Start stays disabled with an actionable reason while selected-node inventory is being refreshed instead of dispatching against stale capacity.

## Evidence

Observed failing before the repair:

- A real Gateway, Chromium, paired node, Full Access session, and Docker container reproduced Stop followed immediately by Send; the replacement turn ended in an error instead of completing.
- An actual authenticated worker protocol frame against the real admission/placement/run owners was disconnected during cooperative drain and never committed its transcript.
- The worker owner regression proved the next turn did not wait for the exact canceled claim and that generic failure handling destroyed the still-healthy remote environment.
- After those first repairs, the rebuilt real Docker flow exposed a second owner defect: canceled preview events left a speculative in-memory ACK ahead of durable placement state, so the replacement's terminal event was discarded as a replay and never created its required workspace-result fence.
- Two real Chromium scenarios proved both explicitly selected and automatic devices left Start enabled while the authoritative environment refresh was unresolved.

Passing after the repair:

- 211 Gateway, worker-placement, cancellation, suspension, protocol, credential-rotation, durable-cursor, and security-owner tests passed across 12 focused suites.
- 23 real Chromium selection, refresh, and Full Access scenarios passed.
- Nine worker fault-injection and placement-lifecycle tests passed.
- The rebuilt real Chromium -> real Gateway -> paired node -> Docker worker flow passed end to end: select the actual remote node, complete a Full Access command, start a long-running container command, click Stop, immediately send a replacement turn, observe its successful reply, and verify zero approval alerts, no late process effect, and no orphan worker container.
- Cooperative draining admits only the already-authenticated exact worker; released run ownership, released placement claims, and restart-during-drain all fail closed.
- Core, Control UI, and root-test TypeScript validation passed; a fresh independent structured review reported no actionable findings.
- The complete changed-file maintainer gate passed, including formatting, dead exports, all four TypeScript projects, core/UI/script lint, plugin boundaries, import cycles, native schema, and database-first guards.
- Production LOC: +223/-38 (net +185). Tests and test support: +535/-2 (net +533). Production growth is required for a new closure-bound worker admission capability, exact claim-owned cancellation lifetime, and authoritative durable ACK rotation; selected-node UI gating is production-line neutral, with no SQLite schema, protocol, config, compatibility, or public API changes.

## Real Browser Proof

Full Access selected on the actual paired remote node while its real Docker command runs:

![Real paired-node Docker command running in Full Access](https://github.com/user-attachments/assets/752f7570-4472-467c-bfa5-b1ed0daa2d27)

The same session after canceling the long-running worker and immediately completing its replacement, with no approval dialog:

![Immediate replacement remote worker completed after cancellation without an approval alert](https://github.com/user-attachments/assets/0b4d2be8-c836-4dfa-ae50-963c75d30fc7)
