### PR TITLE
refactor(plugins): share install choice normalization

### DIFF
--- a/src/plugins/install-source-info.test.ts
+++ b/src/plugins/install-source-info.test.ts
@@ -133,6 +133,21 @@ describe("describePluginInstallSource", () => {
     });
   });
 
+  it("preserves local as the default install source", () => {
+    expect(
+      describePluginInstallSource({
+        localPath: "extensions/demo",
+        defaultChoice: "local",
+      }),
+    ).toEqual({
+      defaultChoice: "local",
+      local: {
+        path: "extensions/demo",
+      },
+      warnings: [],
+    });
+  });
+
   it("warns when defaultChoice is not a supported install source", () => {
     expect(
       describePluginInstallSource({

--- a/src/plugins/install-source-info.ts
+++ b/src/plugins/install-source-info.ts
@@ -3,6 +3,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
 import { parseRegistryNpmSpec, type ParsedRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import type { PluginPackageInstall } from "./manifest.js";
+import { normalizePluginInstallDefaultChoice } from "./plugin-install-default-choice.js";
 
 /** Warning emitted while describing plugin package install source metadata. */
 type PluginInstallSourceWarning =
@@ -72,10 +73,6 @@ function resolveNpmPinState(params: {
   return params.hasIntegrity ? "floating-with-integrity" : "floating-without-integrity";
 }
 
-function resolveDefaultChoice(value: unknown): PluginPackageInstall["defaultChoice"] | undefined {
-  return value === "clawhub" || value === "npm" || value === "local" ? value : undefined;
-}
-
 function normalizeExpectedPackageName(value: string | null | undefined): string | undefined {
   const expected = normalizeOptionalString(value);
   if (!expected) {
@@ -92,7 +89,7 @@ export function describePluginInstallSource(
   const clawhubSpec = normalizeOptionalString(install.clawhubSpec);
   const npmSpec = normalizeOptionalString(install.npmSpec);
   const localPath = normalizeOptionalString(install.localPath);
-  const defaultChoice = resolveDefaultChoice(install.defaultChoice);
+  const defaultChoice = normalizePluginInstallDefaultChoice(install.defaultChoice);
   const expectedIntegrity = normalizeOptionalString(install.expectedIntegrity);
   const expectedPackageName = normalizeExpectedPackageName(options?.expectedPackageName);
   const warnings: PluginInstallSourceWarning[] = [];

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -16,6 +16,7 @@ import type {
   PluginPackageInstall,
 } from "./manifest.js";
 import { BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOGS } from "./official-external-plugin-bundled-catalogs.js";
+import { normalizePluginInstallDefaultChoice } from "./plugin-install-default-choice.js";
 
 type ManifestKey = typeof MANIFEST_KEY;
 
@@ -1358,10 +1359,6 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   }
 }
 
-function normalizeDefaultChoice(value: unknown): PluginPackageInstall["defaultChoice"] | undefined {
-  return value === "clawhub" || value === "npm" || value === "local" ? value : undefined;
-}
-
 function formatFeedInstallCandidateSpec(
   candidate: OfficialExternalPluginCatalogInstallCandidate,
 ): string | undefined {
@@ -1564,7 +1561,7 @@ export function resolveOfficialExternalPluginInstall(
   const npmSpec =
     manifestNpmSpec ?? (hasFeedInstallCandidates ? undefined : normalizeOptionalString(entry.name));
   const defaultChoice =
-    normalizeDefaultChoice(install?.defaultChoice) ??
+    normalizePluginInstallDefaultChoice(install?.defaultChoice) ??
     (npmSpec ? "npm" : clawhubSpec ? "clawhub" : localPath ? "local" : undefined);
   if (!clawhubSpec && !npmSpec && !localPath) {
     return null;

--- a/src/plugins/plugin-install-default-choice.ts
+++ b/src/plugins/plugin-install-default-choice.ts
@@ -1,0 +1,7 @@
+import type { PluginPackageInstall } from "./manifest.js";
+
+export function normalizePluginInstallDefaultChoice(
+  value: unknown,
+): PluginPackageInstall["defaultChoice"] | undefined {
+  return value === "clawhub" || value === "npm" || value === "local" ? value : undefined;
+}

--- a/src/plugins/provider-install-catalog.ts
+++ b/src/plugins/provider-install-catalog.ts
@@ -18,6 +18,7 @@ import {
   resolveOfficialExternalPluginInstall,
   type OfficialExternalProviderAuthChoice,
 } from "./official-external-plugin-catalog.js";
+import { normalizePluginInstallDefaultChoice } from "./plugin-install-default-choice.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 import { loadPluginRegistrySnapshot, type PluginRegistryRecord } from "./plugin-registry.js";
 import {
@@ -76,10 +77,6 @@ function isPreferredOrigin(candidate: PluginOrigin, current: PluginOrigin | unde
   return !current || INSTALL_ORIGIN_PRIORITY[candidate] < INSTALL_ORIGIN_PRIORITY[current];
 }
 
-function normalizeDefaultChoice(value: unknown): PluginPackageInstall["defaultChoice"] | undefined {
-  return value === "clawhub" || value === "npm" || value === "local" ? value : undefined;
-}
-
 function resolveInstallInfoFromInstallRecord(
   record: InstalledPluginInstallRecordInfo | undefined,
 ): PluginPackageInstall | null {
@@ -130,7 +127,7 @@ function resolveInstallInfoFromPackageSource(params: {
   if (!clawhubSpec && !npmSpec && !localPath) {
     return null;
   }
-  const defaultChoice = normalizeDefaultChoice(source?.defaultChoice);
+  const defaultChoice = normalizePluginInstallDefaultChoice(source?.defaultChoice);
   const expectedIntegrity = normalizeOptionalString(npm?.expectedIntegrity);
   return {
     ...(clawhubSpec ? { clawhubSpec } : {}),
@@ -173,7 +170,7 @@ function resolveInstallInfoFromProviderIndex(
     return null;
   }
   const defaultChoice =
-    normalizeDefaultChoice(install.defaultChoice) ?? (clawhubSpec ? "clawhub" : "npm");
+    normalizePluginInstallDefaultChoice(install.defaultChoice) ?? (clawhubSpec ? "clawhub" : "npm");
   return {
     ...(clawhubSpec ? { clawhubSpec } : {}),
     ...(npmSpec ? { npmSpec } : {}),


### PR DESCRIPTION
## What Problem This Solves

Plugin install metadata normalized the same default-source field in three separate catalog paths. Keeping those validators duplicated makes the accepted source set easier to drift when plugin installation evolves.

## Why This Change Was Made

Move the existing `clawhub` / `npm` / `local` validation into one plugin-private helper and reuse it from install-source descriptions, provider install catalogs, and the official external plugin catalog. The accepted values and each caller's fallback order remain unchanged.

## User Impact

No user-visible behavior change. Plugin install source selection now has one canonical normalization path, reducing future drift.

## Evidence

- Focused tests: 108 passed; one existing current-main catalog completeness failure remains for `diffs` and `diffs-language-pack`.
- Current-main baseline reproduces the identical catalog completeness failure.
- Fresh AWS Crabbox run `run_f03708829c98` on lease `cbx_a3c7e6ed859e`: frozen install passed; 108 tests passed; the identical current-main catalog completeness failure reproduced; lease stopped.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `pnpm build`: passed.
- `check-changed`: all code, formatting, lint, boundary, dead-export, and typecheck lanes passed after expanding the sparse worktree to include the native schema guard input.
- Autoreview: clean, 0.99 confidence.
- Production delta: +14 / -16, net -2 lines. Tests: +15 lines.
