### PR TITLE
fix(control-ui): darken the Absolutely surface ramp

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -123,7 +123,7 @@
       }
 
       html[data-theme="absolutely"] {
-        background: #262624;
+        background: #1c1c1a;
       }
 
       html[data-theme="absolutely-light"] {

--- a/ui/src/app/mount-fallback.test.ts
+++ b/ui/src/app/mount-fallback.test.ts
@@ -100,7 +100,7 @@ describe("Control UI mount fallback", () => {
       "Absolutely dark",
       { theme: "absolutely", themeMode: "dark" },
       "absolutely",
-      "rgb(38, 38, 36)",
+      "rgb(28, 28, 26)",
     ],
     [
       "Absolutely light",

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -931,16 +931,19 @@
   /*
    * Accent — terracotta clay on warm graphite
    *
-   * WCAG 2.1 AA audit (bg = #262624, relative luminance ≈ 0.0198):
-   *   --accent #d97757  L ≈ 0.257  contrast ≈ 4.9:1  AA text ✓
-   *   --accent-hover #e68b6b  L ≈ 0.338  contrast ≈ 6.0:1  ✓
+   * WCAG 2.1 AA audit (bg = #1c1c1a, relative luminance ≈ 0.0115):
+   *   --accent #d97757  L ≈ 0.257  contrast ≈ 5.5:1  AA text ✓
+   *   --accent-hover #e68b6b  L ≈ 0.338  contrast ≈ 6.7:1  ✓
    *   --primary-foreground #241f1b on #d97757 button: 5.2:1 AA ✓
    *   --primary-foreground #241f1b on #e68b6b hover: 6.4:1 AA ✓
    *   --destructive-foreground #fafafa on #d32f2f button: 4.77:1 AA ✓
-   *   focus-ring at 75% opacity: ≈ 3.3:1 against bg ✓ (non-text 3:1 required)
+   *   focus-ring at 75% opacity: ≈ 3.6:1 against bg ✓ (non-text 3:1 required)
    *
-   * The accent dims below AA on the lightest surfaces (3.7:1 on --bg-muted),
-   * so it stays a fill/indicator color there; body copy uses --text.
+   * The surface ramp sits a step below the original #262624 launch palette,
+   * which was the lightest dark theme in the set by a wide margin. Every
+   * pairing improved: worst text 4.68 -> 5.42:1, accent on --card 4.47 ->
+   * 5.05:1 (AA where it previously was not). The accent still dims below AA on
+   * --bg-muted (4.3:1), so it stays a fill/indicator color there, not body copy.
    */
   --ring: #d97757;
   --accent: #d97757;
@@ -961,23 +964,23 @@
   --focus-ring: 0 0 0 2px var(--bg), 0 0 0 3px color-mix(in srgb, var(--ring) 75%, transparent);
 
   /* Surfaces — warm graphite, a shade off true neutral */
-  --bg: #262624;
-  --bg-accent: #2d2c29;
-  --bg-elevated: #33322e;
-  --bg-hover: #3a3934;
-  --bg-muted: #3a3934;
+  --bg: #1c1c1a;
+  --bg-accent: #232320;
+  --bg-elevated: #292825;
+  --bg-hover: #302f2b;
+  --bg-muted: #302f2b;
 
-  --card: #2d2c29;
+  --card: #232320;
   --card-foreground: #ede8dd;
   --card-highlight: rgba(255, 246, 232, 0.04);
-  --popover: #33322e;
+  --popover: #292825;
   --popover-foreground: #ede8dd;
 
-  --panel: #262624;
-  --panel-strong: #33322e;
-  --panel-hover: #3a3934;
-  --chrome: rgba(38, 38, 36, 0.96);
-  --chrome-strong: rgba(38, 38, 36, 0.98);
+  --panel: #1c1c1a;
+  --panel-strong: #292825;
+  --panel-hover: #302f2b;
+  --chrome: rgba(28, 28, 26, 0.96);
+  --chrome-strong: rgba(28, 28, 26, 0.98);
 
   --text: #e4dfd4;
   --text-strong: #f5f1e8;
@@ -986,12 +989,12 @@
   --muted-strong: #b8b1a4;
   --muted-foreground: #aba498;
 
-  --border: #383630;
-  --border-strong: #48453d;
-  --border-hover: #5c584e;
-  --input: #383630;
+  --border: #2e2c27;
+  --border-strong: #3d3a33;
+  --border-hover: #514d44;
+  --input: #2e2c27;
 
-  --secondary: #2d2c29;
+  --secondary: #232320;
   --secondary-foreground: #ede8dd;
   --accent-2: #b8926a;
   --accent-2-muted: rgba(184, 146, 106, 0.7);

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -362,7 +362,7 @@
 
 .settings-theme-card--absolutely,
 .settings-accent-theme--absolutely {
-  --theme-chip-bg: #262624;
+  --theme-chip-bg: #1c1c1a;
   --theme-chip-accent: #d97757;
   --theme-chip-accent-2: #b8926a;
 }


### PR DESCRIPTION
## What Problem This Solves

Absolutely shipped as the lightest dark theme in the set by a wide margin. Its `--bg` `#262624` sat well above Dash `#1a1210`, Claw `#0e1015`, and Knot `#080808`, which left the clay accent and the Lora prose with less separation from the surface than the palette was designed for.

## Why This Change Was Made

Steps the whole surface ramp down one notch — `--bg` `#262624` → `#1c1c1a`, with the card, elevated, hover, chrome, and border tiers following — while keeping the warm graphite cast that distinguishes it from the cooler dark themes. Text and accent tokens are untouched, so this is purely a surface change; the theme still reads as clay-on-graphite, just seated deeper.

`index.html`'s first-paint background and the Appearance preview chip both mirror `--bg` by hand, so they move with it. The existing pre-paint assertion in `mount-fallback` covers that they stay in lockstep.

## User Impact

Absolutely looks closer to the other dark themes in depth, and every contrast pairing improved rather than regressed. Nothing changes for the other six themes or for Absolutely's light mode.

## Evidence

Before (`#262624`) and after (`#1c1c1a`), captured from a real browser against the built bundle:

![before](https://github.com/user-attachments/assets/ed17dab5-0ec6-4cbd-9b6e-2f4622b8c17c)

![after](https://github.com/user-attachments/assets/6557b878-d607-44d9-9f0a-e2b829abb4f4)

Measured, in-browser where noted:

| Pairing | Before | After |
| --- | --- | --- |
| Worst text pair (`--muted` on `--bg-muted`, in-browser) | 4.68:1 | **5.42:1** |
| `--accent` on `--card` | 4.47:1 | **5.05:1** (AA where it previously was not) |
| `--accent` on `--bg` | 4.86:1 | **5.47:1** |
| `--danger` on its own subtle tint over `--bg-muted` | 3.76:1 | **4.32:1** |

**Tests and checks.** `ui/src/styles`, `ui/src/app`, `mount-fallback`, and `theme.test` (10,632 passed), both theme E2E suites, `pnpm format:check` clean, stylelint exit 0, clean `pnpm ui:build` with no budget violations. Autoreview clean.

Stacked note: this touches the same `base.css` region as no other in-flight PR — [#130232](https://github.com/openclaw/openclaw/pull/130232) adds new theme blocks further down the file — so the two land independently.
