### PR TITLE
fix(ollama): cloud models vanish from discovery when inspection returns nothing

### DIFF
--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -11,6 +11,7 @@ import {
   buildOllamaProvider,
   buildOllamaModelDefinition,
   capLocalOllamaProviderContext,
+  enrichOllamaCompletionModels,
   enrichOllamaModelsWithContext,
   fetchLoadedOllamaModelNames,
   isOllamaCloudModel,
@@ -267,6 +268,113 @@ describe("ollama provider models", () => {
     await expect(buildOllamaProvider("http://127.0.0.1:11434")).resolves.toMatchObject({
       models: [],
     });
+  });
+
+  it.each([
+    {
+      description: "remote host metadata",
+      listed: {
+        name: "deepseek-r1:671b",
+        remote_host: "https://ollama.example",
+        capabilities: ["vision"],
+      },
+      reasoning: true,
+    },
+    {
+      description: "upstream remote-model-only metadata",
+      listed: {
+        name: "remote-chat:latest",
+        remote_model: "upstream-chat:latest",
+        capabilities: ["vision"],
+      },
+      reasoning: false,
+    },
+    {
+      description: "the existing explicit cloud model contract",
+      listed: { name: "remote-chat:cloud", capabilities: ["vision"] },
+      reasoning: false,
+    },
+  ])(
+    "keeps incomplete cloud metadata discoverable with $description",
+    async ({ listed, reasoning }) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | URL | Request) =>
+          requestUrl(input).endsWith("/api/tags")
+            ? jsonResponse({ models: [listed] })
+            : jsonResponse({}),
+        ),
+      );
+
+      await expect(buildOllamaProvider("http://127.0.0.1:11434")).resolves.toMatchObject({
+        models: [
+          {
+            id: listed.name,
+            input: ["text", "image"],
+            reasoning,
+            compat: { supportsTools: true },
+          },
+        ],
+      });
+    },
+  );
+
+  it.each([
+    {
+      description: "an explicitly empty inspection result",
+      listed: {
+        name: "remote-chat:cloud",
+        remote_model: "upstream-chat",
+        capabilities: ["completion", "tools"],
+      },
+      inspected: { capabilities: [] },
+    },
+    {
+      description: "an advertised remote embedding model",
+      listed: {
+        name: "remote-embedding:latest",
+        remote_model: "upstream-embedding",
+        capabilities: ["embedding"],
+      },
+    },
+    {
+      description: "an advertised local embedding model",
+      listed: { name: "local-embedding:latest", capabilities: ["embedding"] },
+    },
+  ])("does not expose $description as a completion model", async ({ listed, inspected = {} }) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) =>
+        requestUrl(input).endsWith("/api/tags")
+          ? jsonResponse({ models: [listed] })
+          : jsonResponse(inspected),
+      ),
+    );
+
+    await expect(buildOllamaProvider("http://127.0.0.1:11434")).resolves.toMatchObject({
+      models: [],
+    });
+  });
+
+  it("keeps strict node discovery closed when remote completion is only inferred", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({})),
+    );
+
+    await expect(
+      enrichOllamaCompletionModels(
+        "http://127.0.0.1:11434",
+        [
+          {
+            name: "remote-chat:latest",
+            remote_model: "upstream-chat:latest",
+            capabilities: ["tools"],
+          },
+        ],
+        { requireCompletionCapability: true },
+      ),
+    ).resolves.toEqual([]);
   });
 
   it("forwards remote auth to model listing and show probes", async () => {
@@ -878,7 +986,30 @@ describe("ollama provider models", () => {
       },
       expected: { contextWindow: 32_768, supportsTools: true },
     },
-  ])("$description", async ({ listed, expected }) => {
+    {
+      description: "preserves remote-model-only list capabilities after a live inspection failure",
+      listed: {
+        name: "remote-chat:latest",
+        remote_model: "upstream-chat:latest",
+        digest: "sha256:remote-model-list-metadata",
+        details: { context_length: 32_768 },
+        capabilities: ["tools"],
+      },
+      expected: { contextWindow: 32_768, supportsTools: true },
+    },
+    {
+      description: "preserves remote-model-only metadata after a live incomplete inspection",
+      listed: {
+        name: "remote-incomplete:latest",
+        remote_model: "upstream-incomplete:latest",
+        digest: "sha256:remote-model-incomplete-inspection",
+        details: { context_length: 32_768 },
+        capabilities: ["vision"],
+      },
+      showFailed: false,
+      expected: { contextWindow: 32_768, supportsTools: true },
+    },
+  ])("$description", async ({ listed, expected, showFailed = true }) => {
     const server = createServer((request, response) => {
       response.setHeader("Content-Type", "application/json");
       if (request.url === "/api/tags") {
@@ -890,8 +1021,8 @@ describe("ollama provider models", () => {
         return;
       }
       if (request.url === "/api/show") {
-        response.statusCode = 500;
-        response.end(JSON.stringify({ error: "show failed" }));
+        response.statusCode = showFailed ? 500 : 200;
+        response.end(JSON.stringify(showFailed ? { error: "show failed" } : {}));
         return;
       }
       response.statusCode = 404;

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -25,6 +25,7 @@ export type OllamaTagModel = {
   size?: number;
   digest?: string;
   remote_host?: string;
+  remote_model?: string;
   capabilities?: string[];
   details?: {
     context_length?: number;
@@ -45,7 +46,8 @@ type OllamaRunningModel = {
 
 type OllamaModelRow = OllamaTagModel | OllamaRunningModel;
 
-export type OllamaModelWithContext = OllamaTagModel & OllamaModelShowInfo;
+export type OllamaModelWithContext = OllamaTagModel &
+  OllamaModelShowInfo & { capabilitiesFromList?: boolean };
 
 const OLLAMA_SHOW_CONCURRENCY = 8;
 const OLLAMA_CONTEXT_ENRICH_LIMIT = 200;
@@ -96,12 +98,27 @@ export type OllamaModelShowInfo = {
 export const mergeOllamaModelShowInfo = (
   model: OllamaModelWithContext,
   info: OllamaModelShowInfo,
-): OllamaModelWithContext => ({
-  ...model,
-  ...info,
-  contextWindow: info.contextWindow ?? model.contextWindow ?? model.details?.context_length,
-  capabilities: info.capabilities ?? model.capabilities,
-});
+): OllamaModelWithContext => {
+  const incomplete =
+    info.capabilities === undefined &&
+    model.capabilities !== undefined &&
+    Boolean(model.remote_host || model.remote_model || isOllamaCloudModel(model.name));
+  return {
+    ...model,
+    ...info,
+    contextWindow: info.contextWindow ?? model.contextWindow ?? model.details?.context_length,
+    capabilities: incomplete
+      ? [
+          ...new Set([
+            ...(model.capabilities ?? []),
+            ...(info.showInspectionFailed ? [] : ["tools"]),
+            ...(isReasoningModelHeuristic(model.name) ? ["thinking"] : []),
+          ]),
+        ]
+      : (info.capabilities ?? model.capabilities),
+    ...(incomplete ? { capabilitiesFromList: true } : {}),
+  };
+};
 
 const OLLAMA_FAILED_SHOW_INFO: OllamaModelShowInfo = Object.freeze({
   showInspectionFailed: true,
@@ -333,7 +350,12 @@ export async function enrichOllamaCompletionModels(
     );
     for (const model of batch) {
       const canComplete = model.capabilities?.includes("completion");
-      if (!canComplete && (opts?.requireCompletionCapability || model.capabilities)) {
+      if (
+        !canComplete &&
+        (opts?.requireCompletionCapability ||
+          model.capabilities?.includes("embedding") ||
+          (model.capabilities && !model.capabilitiesFromList))
+      ) {
         continue;
       }
       completionModels.push(model);
@@ -371,30 +393,26 @@ export function buildOllamaModelDefinition(
   capabilities?: string[],
   opts?: { showInspectionFailed?: boolean },
 ): ModelDefinitionConfig {
-  const hasVision = capabilities?.includes("vision") ?? false;
-  const input: ("text" | "image")[] = hasVision ? ["text", "image"] : ["text"];
-  const reasoning =
-    supportsOllamaCloudFullThinkingEffort(modelId) ||
-    (capabilities === undefined
-      ? isReasoningModelHeuristic(modelId)
-      : capabilities.includes("thinking"));
-  const compat = {
-    supportsTools: capabilities?.includes("tools") ?? opts?.showInspectionFailed !== true,
-    supportsUsageInStreaming: true,
-    supportsJsonSchemaResponseFormat: !isOllamaCloudModel(modelId),
-  };
   return {
     id: modelId,
     name: modelId,
-    reasoning,
-    input,
+    reasoning:
+      supportsOllamaCloudFullThinkingEffort(modelId) ||
+      (capabilities === undefined
+        ? isReasoningModelHeuristic(modelId)
+        : capabilities.includes("thinking")),
+    input: capabilities?.includes("vision") ? ["text", "image"] : ["text"],
     cost: OLLAMA_DEFAULT_COST,
     contextWindow:
       contextWindow ??
       resolveOllamaCloudDefaultModel(modelId)?.contextWindow ??
       OLLAMA_DEFAULT_CONTEXT_WINDOW,
     maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
-    compat,
+    compat: {
+      supportsTools: capabilities?.includes("tools") ?? opts?.showInspectionFailed !== true,
+      supportsUsageInStreaming: true,
+      supportsJsonSchemaResponseFormat: !isOllamaCloudModel(modelId),
+    },
   };
 }
 

--- a/extensions/ollama/src/setup-model-selection.test.ts
+++ b/extensions/ollama/src/setup-model-selection.test.ts
@@ -206,6 +206,45 @@ describe("Ollama onboarding model selection", () => {
     },
   );
 
+  it("preserves incomplete remote-model-only capabilities during interactive setup", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) =>
+        requestUrl(input).endsWith("/api/tags")
+          ? Response.json({
+              models: [
+                {
+                  name: "deepseek-r1:remote",
+                  remote_model: "upstream-deepseek-r1",
+                  size: 2_000_000_000,
+                  details: { context_length: 32_768 },
+                  capabilities: ["tools"],
+                },
+              ],
+            })
+          : Response.json({}),
+      ),
+    );
+    const prompter = {
+      select: vi.fn().mockResolvedValueOnce("local-only"),
+      text: vi.fn().mockResolvedValueOnce("http://127.0.0.1:11434"),
+      note: vi.fn(async () => undefined),
+      confirm: vi.fn().mockResolvedValue(false),
+    } as unknown as WizardPrompter;
+
+    const result = await promptAndConfigureOllama({ cfg: {}, prompter });
+
+    expect(result.defaultModel).toBe("ollama/deepseek-r1:remote");
+    expect(result.config.models?.providers?.ollama?.models).toContainEqual(
+      expect.objectContaining({
+        id: "deepseek-r1:remote",
+        contextWindow: 32_768,
+        reasoning: true,
+        compat: expect.objectContaining({ supportsTools: true }),
+      }),
+    );
+  });
+
   it("aborts pending model discovery with the setup signal", async () => {
     const controller = new AbortController();
     vi.stubGlobal(


### PR DESCRIPTION
Related: #130000

## What Problem This Solves

Fixes an issue where operators running Ollama with cloud models would lose those models from provider discovery and from onboarding whenever the daemon answered `/api/show` without describing the model — the same degraded-inspection case #130000 set out to improve. The models disappear from the provider catalog entirely, so no cloud model can be selected until inspection starts working again.

## Why This Change Was Made

#130000 made the `/api/tags` row fill in what an inspection could not report. That is correct for a local row, which the daemon derives from the model itself, but a remote row is built differently upstream: `buildModelListSummary` only calls `readModelListGGUF` when the manifest carries neither `RemoteHost` nor `RemoteModel`, and `completion` is appended inside that read (`server/model_list_cache.go`). `thinking` is likewise appended only when a template layer is present. A remote row therefore advertises whatever its manifest config declares and stays silent about the rest — but discovery reads that silence as a denial:

- `enrichOllamaCompletionModels` excludes any row that carries capabilities without `completion`, which is every remote row.
- `buildOllamaModelDefinition` treats a present list as a full account, so the name heuristic behind `reasoning` and the optimistic `supportsTools` default stop being reachable for those rows.

This change records where a capability list came from (`mergeOllamaModelShowInfo` now marks list-sourced capabilities) and reads a remote row's advertised list as authoritative for what it asserts and unknown for what it omits — the same rule this module already applies to `contextWindow`. Once `/api/show` answers with capabilities, the list is settled again and every existing rule applies unchanged.

Non-goal: local rows keep today's behavior exactly. A local list entry is derived from the model's own GGUF and template, so its omissions are meaningful and stay authoritative — including a local reasoning model whose list omits `thinking`.

## User Impact

Cloud Ollama models stay discoverable, keep tool support, and keep their reasoning flag when the daemon cannot inspect them, instead of vanishing from the catalog. Local model metadata, embedding-model exclusion, and the context and tool precedence introduced by #130000 are unchanged.

## Evidence

Runtime probe, no mocking: a real loopback HTTP server stands in for the daemon, serving the `/api/tags` rows below and answering `/api/show` with `200 {}` (the degraded case). `buildOllamaProvider` runs against it unmodified; the same probe ran against three checkouts of the two changed files.

| `/api/tags` row | before #130000 (`296227fdf^`) | main (`a2d54319bc3`) | this branch |
| --- | --- | --- | --- |
| `glm-5.1:cloud`, `remote_host` set, `["vision"]` | discovered, tools `true` | **dropped** | discovered, tools `true` |
| `deepseek-r1:671b-cloud`, `remote_host` set, `["tools"]` | discovered, reasoning `true` | **dropped** | discovered, reasoning `true` |
| `llama3.1:8b`, `["completion","tools"]` | ctx `128000` | ctx `131072` | ctx `131072` |
| `deepseek-r1:8b`, `["completion","tools"]` | reasoning `true` | reasoning `false` | reasoning `false` |
| `nomic-embed-text`, `["embedding"]` | discovered | excluded | excluded |

The last two rows are the control arms: this branch reproduces main exactly for local rows, so the difference the first two rows show is the remote-row rule and not the harness.

Six focused cases were added. Five of them fail against main's `provider-models.ts` and `setup-model-selection.ts` with the tests unchanged; the sixth (a local `["embedding"]` row must stay excluded) passes on both arms and is there to prove the completion filter was not loosened.

```
extensions/ollama: 28 files, 723 tests passed
check:assertion-safety  OK (4248 files)
check:max-lines-ratchet OK
oxlint / oxfmt          clean
```
