### PR TITLE
fix(gateway): prevent mismatched core command payload types

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2942,7 +2942,6 @@ src/gateway/server-methods/approval-shared.ts	1
 src/gateway/server-methods/approval.ts	8
 src/gateway/server-methods/attachment-normalize.ts	1
 src/gateway/server-methods/base-hash.ts	1
-src/gateway/server-methods/board.ts	10
 src/gateway/server-methods/channel-pairing.ts	3
 src/gateway/server-methods/channels.ts	16
 src/gateway/server-methods/chat-abort-authorization.ts	3
@@ -2963,14 +2962,12 @@ src/gateway/server-methods/chat-tts-markers.ts	1
 src/gateway/server-methods/chat.ts	2
 src/gateway/server-methods/config-write-flow.ts	1
 src/gateway/server-methods/config.ts	7
-src/gateway/server-methods/conversations.ts	4
 src/gateway/server-methods/cron.ts	17
 src/gateway/server-methods/device-scope-upgrade.ts	2
 src/gateway/server-methods/devices.ts	6
 src/gateway/server-methods/doctor.ts	5
 src/gateway/server-methods/exec-approval.ts	3
 src/gateway/server-methods/exec-approvals.ts	2
-src/gateway/server-methods/logs.ts	1
 src/gateway/server-methods/mcp-app.ts	1
 src/gateway/server-methods/memory-search.ts	3
 src/gateway/server-methods/migrations.ts	1
@@ -2990,7 +2987,6 @@ src/gateway/server-methods/open-path.ts	1
 src/gateway/server-methods/optional-model-catalog.ts	2
 src/gateway/server-methods/plugin-approval.ts	3
 src/gateway/server-methods/plugin-host-hooks.ts	1
-src/gateway/server-methods/portals.ts	3
 src/gateway/server-methods/question.ts	4
 src/gateway/server-methods/restart-request.ts	8
 src/gateway/server-methods/send.ts	5
@@ -3018,7 +3014,7 @@ src/gateway/server-methods/task-suggestions.ts	7
 src/gateway/server-methods/terminal-upload.ts	1
 src/gateway/server-methods/terminal.ts	7
 src/gateway/server-methods/tools-catalog.ts	2
-src/gateway/server-methods/ui-command.ts	2
+src/gateway/server-methods/ui-command.ts	1
 src/gateway/server-methods/update.ts	2
 src/gateway/server-methods/usage.ts	7
 src/gateway/server-methods/web.ts	3

--- a/packages/gateway-protocol/src/core-request-params.ts
+++ b/packages/gateway-protocol/src/core-request-params.ts
@@ -1,0 +1,29 @@
+import type * as AgentSchema from "./schema/agent.js";
+import type * as BoardSchema from "./schema/board.js";
+import type { CommandsListParams } from "./schema/commands.js";
+import type { LogsTailParams } from "./schema/logs-chat.js";
+import type { PortalCloseParams, PortalListParams, PortalOpenParams } from "./schema/portals.js";
+import type { UiCommandParams } from "./schema/ui-command.js";
+
+/** Schema-derived payload ownership for statically validated core Gateway methods. */
+export type GatewayCoreRequestParams = {
+  "board.action": BoardSchema.BoardActionParams;
+  "board.data.read": BoardSchema.BoardDataReadParams;
+  "board.event": BoardSchema.BoardEventParams;
+  "board.get": BoardSchema.BoardGetParams;
+  "board.prompt.authorize": BoardSchema.BoardPromptAuthorizeParams;
+  "board.update": BoardSchema.BoardUpdateParams;
+  "board.widget.appView": BoardSchema.BoardWidgetAppViewParams;
+  "board.widget.grant": BoardSchema.BoardWidgetGrantParams;
+  "board.widget.put": BoardSchema.BoardWidgetPutParams;
+  "commands.list": CommandsListParams;
+  "conversations.list": AgentSchema.ConversationListParams;
+  "conversations.send": AgentSchema.ConversationSendParams;
+  "conversations.turn": AgentSchema.ConversationTurnParams;
+  "conversations.turn.cancel": AgentSchema.ConversationTurnCancelParams;
+  "logs.tail": LogsTailParams;
+  "portal.close": PortalCloseParams;
+  "portal.list": PortalListParams;
+  "portal.open": PortalOpenParams;
+  "ui.command": UiCommandParams;
+};

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -54,4 +54,5 @@ export {
   PROTOCOL_VERSION,
 } from "./version.js";
 export type * from "./schema-types.js";
+export type { GatewayCoreRequestParams } from "./core-request-params.js";
 export type { SessionsPatchResult } from "./sessions-patch-result.js";

--- a/packages/gateway-protocol/src/schema-types.ts
+++ b/packages/gateway-protocol/src/schema-types.ts
@@ -4,4 +4,34 @@
  * Routing root type exports through the runtime-only `protocol-schemas`
  * registry retains the full registry in downstream declaration bundles.
  */
+import type * as AgentSchema from "./schema/agent.js";
+import type * as BoardSchema from "./schema/board.js";
+import type { CommandsListParams } from "./schema/commands.js";
+import type { LogsTailParams } from "./schema/logs-chat.js";
+import type { PortalCloseParams, PortalListParams, PortalOpenParams } from "./schema/portals.js";
+import type { UiCommandParams } from "./schema/ui-command.js";
+
+/** Schema-derived payload ownership for statically validated core Gateway methods. */
+export type GatewayCoreRequestParams = {
+  "board.action": BoardSchema.BoardActionParams;
+  "board.data.read": BoardSchema.BoardDataReadParams;
+  "board.event": BoardSchema.BoardEventParams;
+  "board.get": BoardSchema.BoardGetParams;
+  "board.prompt.authorize": BoardSchema.BoardPromptAuthorizeParams;
+  "board.update": BoardSchema.BoardUpdateParams;
+  "board.widget.appView": BoardSchema.BoardWidgetAppViewParams;
+  "board.widget.grant": BoardSchema.BoardWidgetGrantParams;
+  "board.widget.put": BoardSchema.BoardWidgetPutParams;
+  "commands.list": CommandsListParams;
+  "conversations.list": AgentSchema.ConversationListParams;
+  "conversations.send": AgentSchema.ConversationSendParams;
+  "conversations.turn": AgentSchema.ConversationTurnParams;
+  "conversations.turn.cancel": AgentSchema.ConversationTurnCancelParams;
+  "logs.tail": LogsTailParams;
+  "portal.close": PortalCloseParams;
+  "portal.list": PortalListParams;
+  "portal.open": PortalOpenParams;
+  "ui.command": UiCommandParams;
+};
+
 export type * from "./schema-modules.js";

--- a/packages/gateway-protocol/src/schema-types.ts
+++ b/packages/gateway-protocol/src/schema-types.ts
@@ -4,34 +4,4 @@
  * Routing root type exports through the runtime-only `protocol-schemas`
  * registry retains the full registry in downstream declaration bundles.
  */
-import type * as AgentSchema from "./schema/agent.js";
-import type * as BoardSchema from "./schema/board.js";
-import type { CommandsListParams } from "./schema/commands.js";
-import type { LogsTailParams } from "./schema/logs-chat.js";
-import type { PortalCloseParams, PortalListParams, PortalOpenParams } from "./schema/portals.js";
-import type { UiCommandParams } from "./schema/ui-command.js";
-
-/** Schema-derived payload ownership for statically validated core Gateway methods. */
-export type GatewayCoreRequestParams = {
-  "board.action": BoardSchema.BoardActionParams;
-  "board.data.read": BoardSchema.BoardDataReadParams;
-  "board.event": BoardSchema.BoardEventParams;
-  "board.get": BoardSchema.BoardGetParams;
-  "board.prompt.authorize": BoardSchema.BoardPromptAuthorizeParams;
-  "board.update": BoardSchema.BoardUpdateParams;
-  "board.widget.appView": BoardSchema.BoardWidgetAppViewParams;
-  "board.widget.grant": BoardSchema.BoardWidgetGrantParams;
-  "board.widget.put": BoardSchema.BoardWidgetPutParams;
-  "commands.list": CommandsListParams;
-  "conversations.list": AgentSchema.ConversationListParams;
-  "conversations.send": AgentSchema.ConversationSendParams;
-  "conversations.turn": AgentSchema.ConversationTurnParams;
-  "conversations.turn.cancel": AgentSchema.ConversationTurnCancelParams;
-  "logs.tail": LogsTailParams;
-  "portal.close": PortalCloseParams;
-  "portal.list": PortalListParams;
-  "portal.open": PortalOpenParams;
-  "ui.command": UiCommandParams;
-};
-
 export type * from "./schema-modules.js";

--- a/src/gateway/server-methods/board.ts
+++ b/src/gateway/server-methods/board.ts
@@ -1,17 +1,7 @@
 import {
   ErrorCodes,
   errorShape,
-  formatValidationErrors,
-  type BoardActionParams,
-  type BoardDataReadParams,
-  type BoardEventParams,
-  type BoardGetParams,
-  type BoardPromptAuthorizeParams,
-  type BoardWidgetAppViewParams,
-  type BoardUpdateParams,
-  type BoardWidgetGrantParams,
   type BoardWidgetMaterializedPutParams,
-  type BoardWidgetPutParams,
   validateBoardActionParams,
   validateBoardDataReadParams,
   validateBoardEventParams,
@@ -67,6 +57,7 @@ import { sessionObserverScopeKey } from "../session-observer-model.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { resolveSessionStoreKey } from "../session-store-key.js";
 import type { GatewayRequestHandlers } from "./types.js";
+import { assertValidParams, defineValidatedGatewayMethod } from "./validation.js";
 
 type NoticeAppender = typeof appendBoardEventNotice;
 type CanvasDocumentReader = typeof readCanvasDocumentHtmlSource;
@@ -89,21 +80,6 @@ const defaultMcpAppDependencies: McpAppDependencies = {
   resolveAllowedToolNames: resolveMcpAppAllowedToolNames,
   mintFromTranscript: mintMcpAppViewFromTranscript,
 };
-
-function invalidParams(
-  method: string,
-  errors: unknown,
-  respond: Parameters<GatewayRequestHandlers[string]>[0]["respond"],
-): void {
-  respond(
-    false,
-    undefined,
-    errorShape(
-      ErrorCodes.INVALID_REQUEST,
-      `invalid ${method} params: ${formatValidationErrors(errors as never)}`,
-    ),
-  );
-}
 
 function respondBoardError(
   error: unknown,
@@ -199,476 +175,488 @@ export function createBoardHandlers(
   const runActionVerb = dependencies.runActionVerb ?? runBoardActionVerb;
   const triggerCronJob = dependencies.triggerCronJob ?? triggerBoardCronJob;
   return {
-    "board.get": async ({ params, respond, context, client }) => {
-      if (!validateBoardGetParams(params)) {
-        invalidParams("board.get", validateBoardGetParams.errors, respond);
-        return;
-      }
-      const boardParams = params as BoardGetParams;
-      const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
-      if (!boardSessionKey) {
-        return;
-      }
-      const { snapshot, htmlViewMetadata } = store.getSnapshotWithHtmlViewMetadata(boardSessionKey);
-      let sandboxPort = context.getMcpAppSandboxPort?.();
-      let sandboxOrigin: string | undefined;
-      let sandboxOriginResolved = false;
-      for (const widget of snapshot.widgets) {
-        if (widget.grantState !== "none" && widget.grantState !== "granted") {
-          continue;
-        }
-        const viewMetadata = htmlViewMetadata.get(widget.name);
-        if (!viewMetadata || viewMetadata.revision !== widget.revision) {
-          continue;
-        }
-        const registration = widget.pluginKind
-          ? resolveBoardWidgetContentKindByPluginKind(getActivePluginRegistry(), widget.pluginKind)
-          : undefined;
-        const scopedHostUrl = registration
-          ? client?.pluginSurfaceUrls?.[registration.definition.resources.surface]
-          : undefined;
-        const resourceUrls =
-          registration && scopedHostUrl
-            ? resolveBoardWidgetContentKindResourceUrls(registration, scopedHostUrl)
-            : undefined;
-        if (widget.contentKind === "plugin" && (!registration || !resourceUrls || !scopedHostUrl)) {
-          continue;
-        }
-        const resourceOrigins = resourceUrls
-          ? [...new Set(Object.values(resourceUrls).map((url) => new URL(url).origin))]
-          : undefined;
-        if (sandboxPort === undefined && context.ensureSandboxHostPort) {
-          try {
-            sandboxPort = await context.ensureSandboxHostPort();
-          } catch (error) {
-            respondBoardError(error, respond);
-            return;
-          }
-        }
-        const { ticket } = createBoardViewTicket({
-          sessionKey: snapshot.sessionKey,
-          name: widget.name,
-          revision: widget.revision,
-          viewGeneration: viewMetadata.viewGeneration,
-          ...(registration && scopedHostUrl
-            ? {
-                pluginFrame: {
-                  pluginKind: registration.pluginKind,
-                  scopedHostUrl,
-                },
-              }
-            : {}),
-        });
-        if (registration) {
-          widget.kindLabel = registration.definition.label;
-        }
-        widget.frameUrl = buildBoardWidgetFrameUrl({
-          sessionKey: snapshot.sessionKey,
-          name: widget.name,
-          ticket,
-        });
-        widget.viewTicket = ticket;
-        widget.viewTicketTtlMs = BOARD_VIEW_TICKET_TTL_MS;
-        widget.viewGeneration = viewMetadata.viewGeneration;
-        if (sandboxPort !== undefined) {
-          widget.sandboxUrl = buildBoardWidgetSandboxPath({
-            ...viewMetadata,
-            ...(resourceOrigins ? { resourceOrigins } : {}),
-          });
-          widget.sandboxPort = sandboxPort;
-          if (!sandboxOriginResolved) {
-            const configuredOrigin = context.getRuntimeConfig?.().mcp?.apps?.sandboxOrigin;
-            sandboxOrigin = configuredOrigin ? new URL(configuredOrigin).origin : undefined;
-            sandboxOriginResolved = true;
-          }
-          if (sandboxOrigin) {
-            widget.sandboxOrigin = sandboxOrigin;
-          }
-        }
-      }
-      respond(true, snapshot);
-    },
-    "board.update": ({ params, respond, context }) => {
-      if (!validateBoardUpdateParams(params)) {
-        invalidParams("board.update", validateBoardUpdateParams.errors, respond);
-        return;
-      }
-      try {
-        const boardParams = params as BoardUpdateParams;
+    "board.get": defineValidatedGatewayMethod(
+      "board.get",
+      validateBoardGetParams,
+      async ({ params: boardParams, respond, context, client }) => {
         const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
         if (!boardSessionKey) {
           return;
         }
-        const snapshot = store.applyOps(boardSessionKey, boardParams.ops);
-        if (boardParams.ops.length > 0) {
+        const { snapshot, htmlViewMetadata } =
+          store.getSnapshotWithHtmlViewMetadata(boardSessionKey);
+        let sandboxPort = context.getMcpAppSandboxPort?.();
+        let sandboxOrigin: string | undefined;
+        let sandboxOriginResolved = false;
+        for (const widget of snapshot.widgets) {
+          if (widget.grantState !== "none" && widget.grantState !== "granted") {
+            continue;
+          }
+          const viewMetadata = htmlViewMetadata.get(widget.name);
+          if (!viewMetadata || viewMetadata.revision !== widget.revision) {
+            continue;
+          }
+          const registration = widget.pluginKind
+            ? resolveBoardWidgetContentKindByPluginKind(
+                getActivePluginRegistry(),
+                widget.pluginKind,
+              )
+            : undefined;
+          const scopedHostUrl = registration
+            ? client?.pluginSurfaceUrls?.[registration.definition.resources.surface]
+            : undefined;
+          const resourceUrls =
+            registration && scopedHostUrl
+              ? resolveBoardWidgetContentKindResourceUrls(registration, scopedHostUrl)
+              : undefined;
+          if (
+            widget.contentKind === "plugin" &&
+            (!registration || !resourceUrls || !scopedHostUrl)
+          ) {
+            continue;
+          }
+          const resourceOrigins = resourceUrls
+            ? [...new Set(Object.values(resourceUrls).map((url) => new URL(url).origin))]
+            : undefined;
+          if (sandboxPort === undefined && context.ensureSandboxHostPort) {
+            try {
+              sandboxPort = await context.ensureSandboxHostPort();
+            } catch (error) {
+              respondBoardError(error, respond);
+              return;
+            }
+          }
+          const { ticket } = createBoardViewTicket({
+            sessionKey: snapshot.sessionKey,
+            name: widget.name,
+            revision: widget.revision,
+            viewGeneration: viewMetadata.viewGeneration,
+            ...(registration && scopedHostUrl
+              ? {
+                  pluginFrame: {
+                    pluginKind: registration.pluginKind,
+                    scopedHostUrl,
+                  },
+                }
+              : {}),
+          });
+          if (registration) {
+            widget.kindLabel = registration.definition.label;
+          }
+          widget.frameUrl = buildBoardWidgetFrameUrl({
+            sessionKey: snapshot.sessionKey,
+            name: widget.name,
+            ticket,
+          });
+          widget.viewTicket = ticket;
+          widget.viewTicketTtlMs = BOARD_VIEW_TICKET_TTL_MS;
+          widget.viewGeneration = viewMetadata.viewGeneration;
+          if (sandboxPort !== undefined) {
+            widget.sandboxUrl = buildBoardWidgetSandboxPath({
+              ...viewMetadata,
+              ...(resourceOrigins ? { resourceOrigins } : {}),
+            });
+            widget.sandboxPort = sandboxPort;
+            if (!sandboxOriginResolved) {
+              const configuredOrigin = context.getRuntimeConfig?.().mcp?.apps?.sandboxOrigin;
+              sandboxOrigin = configuredOrigin ? new URL(configuredOrigin).origin : undefined;
+              sandboxOriginResolved = true;
+            }
+            if (sandboxOrigin) {
+              widget.sandboxOrigin = sandboxOrigin;
+            }
+          }
+        }
+        respond(true, snapshot);
+      },
+    ),
+    "board.update": defineValidatedGatewayMethod(
+      "board.update",
+      validateBoardUpdateParams,
+      ({ params: boardParams, respond, context }) => {
+        try {
+          const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
+          if (!boardSessionKey) {
+            return;
+          }
+          const snapshot = store.applyOps(boardSessionKey, boardParams.ops);
+          if (boardParams.ops.length > 0) {
+            context.broadcast("board.changed", {
+              sessionKey: snapshot.sessionKey,
+              revision: snapshot.revision,
+            });
+          }
+          respond(true, snapshot);
+        } catch (error) {
+          respondBoardError(error, respond);
+        }
+      },
+    ),
+    "board.widget.put": defineValidatedGatewayMethod(
+      "board.widget.put",
+      validateBoardWidgetPutParams,
+      async ({ params: requestParams, respond, context }) => {
+        try {
+          const requestedBoardSessionKey = resolveBoardSessionKey(requestParams, context, respond);
+          if (!requestedBoardSessionKey) {
+            return;
+          }
+          const boardSessionKey = store.getSnapshot(requestedBoardSessionKey).sessionKey;
+          const {
+            agentId: _agentId,
+            declared: requestDeclared,
+            ...requestWithoutDeclared
+          } = requestParams;
+          let content: BoardWidgetMaterializedPutParams["content"];
+          let declared = requestDeclared;
+          if (requestParams.content.kind === "canvas-doc") {
+            const document = await readCanvasDocument(requestParams.content.docId);
+            if (document.cspSandbox !== "scripts") {
+              throw new BoardValidationError(
+                "invalid_operation",
+                `canvas document is not script-enabled: ${requestParams.content.docId}`,
+              );
+            }
+            content = { kind: "html", html: document.html };
+          } else if (requestParams.content.kind === "mcp-app") {
+            const active = await mcpApp.resolveActiveView({
+              sessionKey: boardSessionKey,
+              viewId: requestParams.content.viewId,
+              cfg: context.getRuntimeConfig(),
+            });
+            const { view } = active;
+            if (!view.toolCallId) {
+              throw new BoardValidationError(
+                "invalid_operation",
+                "MCP App view is missing its originating tool call",
+              );
+            }
+            let interactive = false;
+            try {
+              await requireMcpAppInteraction(view);
+              interactive = true;
+            } catch {
+              // Reconstructed or revoked source leases may be pinned only as read-only content.
+            }
+            const allowedTools = interactive ? await mcpApp.resolveAllowedToolNames(active) : [];
+            if (interactive) {
+              try {
+                await requireMcpAppInteraction(view);
+              } catch {
+                interactive = false;
+              }
+            }
+            content = {
+              kind: "mcp-app",
+              descriptor: {
+                serverName: view.serverName,
+                toolName: view.toolName,
+                uiResourceUri: view.uiResourceUri,
+                toolCallId: view.toolCallId,
+              },
+              interactive,
+            };
+            declared = interactive && allowedTools.length > 0 ? { tools: allowedTools } : undefined;
+          } else if (requestParams.content.kind === "registered") {
+            const registration = resolveBoardWidgetContentKind(
+              getActivePluginRegistry(),
+              requestParams.content.contentKind,
+            );
+            if (!registration) {
+              throw new BoardValidationError(
+                "invalid_operation",
+                `widget kind ${JSON.stringify(requestParams.content.contentKind)} is unavailable; enable the plugin that provides it and retry`,
+              );
+            }
+            try {
+              registration.definition.validateSource(requestParams.content.source);
+            } catch (error) {
+              throw new BoardValidationError(
+                "invalid_operation",
+                `invalid ${requestParams.content.contentKind} widget source: ${String(error)}`,
+              );
+            }
+            content = {
+              ...requestParams.content,
+              pluginKind: registration.pluginKind,
+            };
+          } else {
+            content = requestParams.content;
+          }
+          const persistedContent =
+            content.kind === "mcp-app"
+              ? { kind: content.kind, descriptor: content.descriptor }
+              : content.kind === "registered"
+                ? {
+                    kind: content.kind,
+                    contentKind: content.contentKind,
+                    source: content.source,
+                  }
+                : content;
+          if (
+            !assertValidParams(
+              persistedContent,
+              validateBoardWidgetContent,
+              "board.widget.put content",
+              respond,
+            )
+          ) {
+            return;
+          }
+          declared = normalizeBoardWidgetDeclared(declared);
+          const materializedContent: BoardWidgetMaterializedPutParams["content"] =
+            content.kind === "html"
+              ? {
+                  kind: "html",
+                  // Authority-bearing bridge code must precede every admitted
+                  // byte, including complete HTML and managed Canvas documents.
+                  // The wrapper is idempotent so an already-wrapped Canvas view
+                  // keeps one effective bridge owner.
+                  html: buildWidgetDocument(
+                    requestParams.title ?? requestParams.name,
+                    content.html,
+                    {
+                      connectOrigins: declared?.netOrigins,
+                    },
+                  ),
+                }
+              : content;
+          const boardParams: BoardWidgetMaterializedPutParams = {
+            ...requestWithoutDeclared,
+            sessionKey: boardSessionKey,
+            content: materializedContent,
+            ...(declared ? { declared } : {}),
+          };
+          let snapshot = store.putWidget(boardParams);
+          const widget = snapshot.widgets.find(
+            (candidate) => candidate.name === snapshot.resolvedWidgetName,
+          );
+          if (widget?.grantState === "pending") {
+            const decision = await resolveBoardWidgetApproval({
+              cfg: context.getRuntimeConfig(),
+              sessionKey: snapshot.sessionKey,
+              name: snapshot.resolvedWidgetName,
+              declared: declared ?? {},
+            });
+            if (decision) {
+              snapshot = {
+                ...store.grant(
+                  snapshot.sessionKey,
+                  snapshot.resolvedWidgetName,
+                  decision,
+                  widget.revision,
+                  widget.instanceId,
+                ),
+                resolvedWidgetName: snapshot.resolvedWidgetName,
+              };
+            }
+          }
+          context.broadcast("board.changed", {
+            sessionKey: snapshot.sessionKey,
+            revision: snapshot.revision,
+            widget: snapshot.resolvedWidgetName,
+          });
+          respond(true, snapshot);
+        } catch (error) {
+          respondBoardError(error, respond);
+        }
+      },
+    ),
+    "board.widget.grant": defineValidatedGatewayMethod(
+      "board.widget.grant",
+      validateBoardWidgetGrantParams,
+      ({ params: boardParams, respond, context }) => {
+        try {
+          const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
+          if (!boardSessionKey) {
+            return;
+          }
+          const snapshot = store.grant(
+            boardSessionKey,
+            boardParams.name,
+            boardParams.decision,
+            boardParams.revision,
+            boardParams.instanceId,
+          );
           context.broadcast("board.changed", {
             sessionKey: snapshot.sessionKey,
             revision: snapshot.revision,
           });
+          respond(true, snapshot);
+        } catch (error) {
+          respondBoardError(error, respond);
         }
-        respond(true, snapshot);
-      } catch (error) {
-        respondBoardError(error, respond);
-      }
-    },
-    "board.widget.put": async ({ params, respond, context }) => {
-      if (!validateBoardWidgetPutParams(params)) {
-        invalidParams("board.widget.put", validateBoardWidgetPutParams.errors, respond);
-        return;
-      }
-      try {
-        const requestParams = params as BoardWidgetPutParams;
-        const requestedBoardSessionKey = resolveBoardSessionKey(requestParams, context, respond);
-        if (!requestedBoardSessionKey) {
-          return;
-        }
-        const boardSessionKey = store.getSnapshot(requestedBoardSessionKey).sessionKey;
-        const {
-          agentId: _agentId,
-          declared: requestDeclared,
-          ...requestWithoutDeclared
-        } = requestParams;
-        let content: BoardWidgetMaterializedPutParams["content"];
-        let declared = requestDeclared;
-        if (requestParams.content.kind === "canvas-doc") {
-          const document = await readCanvasDocument(requestParams.content.docId);
-          if (document.cspSandbox !== "scripts") {
+      },
+    ),
+    "board.widget.appView": defineValidatedGatewayMethod(
+      "board.widget.appView",
+      validateBoardWidgetAppViewParams,
+      async ({ params: boardParams, respond, context }) => {
+        try {
+          const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
+          if (!boardSessionKey) {
+            return;
+          }
+          const snapshot = store.getSnapshot(boardSessionKey);
+          const widget = snapshot.widgets.find((candidate) => candidate.name === boardParams.name);
+          const document = store.readWidgetMcpApp(snapshot.sessionKey, boardParams.name);
+          if (
+            !widget ||
+            widget.contentKind !== "mcp-app" ||
+            widget.revision !== boardParams.revision ||
+            widget.instanceId !== boardParams.instanceId ||
+            !document ||
+            document.revision !== boardParams.revision ||
+            document.instanceId !== boardParams.instanceId
+          ) {
             throw new BoardValidationError(
-              "invalid_operation",
-              `canvas document is not script-enabled: ${requestParams.content.docId}`,
+              "not_found",
+              `board MCP App widget not found: ${boardParams.name}`,
             );
           }
-          content = { kind: "html", html: document.html };
-        } else if (requestParams.content.kind === "mcp-app") {
-          const active = await mcpApp.resolveActiveView({
-            sessionKey: boardSessionKey,
-            viewId: requestParams.content.viewId,
-            cfg: context.getRuntimeConfig(),
-          });
-          const { view } = active;
-          if (!view.toolCallId) {
-            throw new BoardValidationError(
-              "invalid_operation",
-              "MCP App view is missing its originating tool call",
-            );
-          }
-          let interactive = false;
-          try {
-            await requireMcpAppInteraction(view);
-            interactive = true;
-          } catch {
-            // Reconstructed or revoked source leases may be pinned only as read-only content.
-          }
-          const allowedTools = interactive ? await mcpApp.resolveAllowedToolNames(active) : [];
-          if (interactive) {
-            try {
-              await requireMcpAppInteraction(view);
-            } catch {
-              interactive = false;
-            }
-          }
-          content = {
-            kind: "mcp-app",
-            descriptor: {
-              serverName: view.serverName,
-              toolName: view.toolName,
-              uiResourceUri: view.uiResourceUri,
-              toolCallId: view.toolCallId,
-            },
-            interactive,
-          };
-          declared = interactive && allowedTools.length > 0 ? { tools: allowedTools } : undefined;
-        } else if (requestParams.content.kind === "registered") {
-          const registration = resolveBoardWidgetContentKind(
-            getActivePluginRegistry(),
-            requestParams.content.contentKind,
-          );
-          if (!registration) {
-            throw new BoardValidationError(
-              "invalid_operation",
-              `widget kind ${JSON.stringify(requestParams.content.contentKind)} is unavailable; enable the plugin that provides it and retry`,
-            );
-          }
-          try {
-            registration.definition.validateSource(requestParams.content.source);
-          } catch (error) {
-            throw new BoardValidationError(
-              "invalid_operation",
-              `invalid ${requestParams.content.contentKind} widget source: ${String(error)}`,
-            );
-          }
-          content = {
-            ...requestParams.content,
-            pluginKind: registration.pluginKind,
-          };
-        } else {
-          content = requestParams.content;
-        }
-        const persistedContent =
-          content.kind === "mcp-app"
-            ? { kind: content.kind, descriptor: content.descriptor }
-            : content.kind === "registered"
-              ? {
-                  kind: content.kind,
-                  contentKind: content.contentKind,
-                  source: content.source,
-                }
-              : content;
-        if (!validateBoardWidgetContent(persistedContent)) {
-          invalidParams("board.widget.put content", validateBoardWidgetContent.errors, respond);
-          return;
-        }
-        declared = normalizeBoardWidgetDeclared(declared);
-        const materializedContent: BoardWidgetMaterializedPutParams["content"] =
-          content.kind === "html"
-            ? {
-                kind: "html",
-                // Authority-bearing bridge code must precede every admitted
-                // byte, including complete HTML and managed Canvas documents.
-                // The wrapper is idempotent so an already-wrapped Canvas view
-                // keeps one effective bridge owner.
-                html: buildWidgetDocument(requestParams.title ?? requestParams.name, content.html, {
-                  connectOrigins: declared?.netOrigins,
-                }),
+          const interactive = document.interactive && document.grantState === "granted";
+          const authorizeAppInteraction = interactive
+            ? () => {
+                const current = store.readWidgetMcpApp(snapshot.sessionKey, boardParams.name);
+                return (
+                  current?.interactive === true &&
+                  current.grantState === "granted" &&
+                  current.revision === boardParams.revision &&
+                  current.instanceId === boardParams.instanceId
+                );
               }
-            : content;
-        const boardParams: BoardWidgetMaterializedPutParams = {
-          ...requestWithoutDeclared,
-          sessionKey: boardSessionKey,
-          content: materializedContent,
-          ...(declared ? { declared } : {}),
-        };
-        let snapshot = store.putWidget(boardParams);
-        const widget = snapshot.widgets.find(
-          (candidate) => candidate.name === snapshot.resolvedWidgetName,
-        );
-        if (widget?.grantState === "pending") {
-          const decision = await resolveBoardWidgetApproval({
+            : undefined;
+          const minted = await mcpApp.mintFromTranscript({
             cfg: context.getRuntimeConfig(),
             sessionKey: snapshot.sessionKey,
-            name: snapshot.resolvedWidgetName,
-            declared: declared ?? {},
+            descriptor: document.descriptor,
+            allowedAppToolNames: new Set(interactive ? document.declaredTools : []),
+            ...(authorizeAppInteraction ? { authorizeAppInteraction } : {}),
+            readOnly: !interactive,
           });
-          if (decision) {
-            snapshot = {
-              ...store.grant(
-                snapshot.sessionKey,
-                snapshot.resolvedWidgetName,
-                decision,
-                widget.revision,
-                widget.instanceId,
-              ),
-              resolvedWidgetName: snapshot.resolvedWidgetName,
-            };
+          if (!minted) {
+            throw new Error("Pinned MCP App source is no longer available");
           }
+          respond(true, {
+            viewId: minted.view.viewId,
+            expiresAtMs: minted.view.expiresAtMs,
+          });
+        } catch (error) {
+          respondBoardError(error, respond);
         }
-        context.broadcast("board.changed", {
-          sessionKey: snapshot.sessionKey,
-          revision: snapshot.revision,
-          widget: snapshot.resolvedWidgetName,
-        });
-        respond(true, snapshot);
-      } catch (error) {
-        respondBoardError(error, respond);
-      }
-    },
-    "board.widget.grant": ({ params, respond, context }) => {
-      if (!validateBoardWidgetGrantParams(params)) {
-        invalidParams("board.widget.grant", validateBoardWidgetGrantParams.errors, respond);
-        return;
-      }
-      try {
-        const boardParams = params as BoardWidgetGrantParams;
-        const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
-        if (!boardSessionKey) {
-          return;
-        }
-        const snapshot = store.grant(
-          boardSessionKey,
-          boardParams.name,
-          boardParams.decision,
-          boardParams.revision,
-          boardParams.instanceId,
-        );
-        context.broadcast("board.changed", {
-          sessionKey: snapshot.sessionKey,
-          revision: snapshot.revision,
-        });
-        respond(true, snapshot);
-      } catch (error) {
-        respondBoardError(error, respond);
-      }
-    },
-    "board.widget.appView": async ({ params, respond, context }) => {
-      if (!validateBoardWidgetAppViewParams(params)) {
-        invalidParams("board.widget.appView", validateBoardWidgetAppViewParams.errors, respond);
-        return;
-      }
-      try {
-        const boardParams = params as BoardWidgetAppViewParams;
-        const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
-        if (!boardSessionKey) {
-          return;
-        }
-        const snapshot = store.getSnapshot(boardSessionKey);
-        const widget = snapshot.widgets.find((candidate) => candidate.name === boardParams.name);
-        const document = store.readWidgetMcpApp(snapshot.sessionKey, boardParams.name);
-        if (
-          !widget ||
-          widget.contentKind !== "mcp-app" ||
-          widget.revision !== boardParams.revision ||
-          widget.instanceId !== boardParams.instanceId ||
-          !document ||
-          document.revision !== boardParams.revision ||
-          document.instanceId !== boardParams.instanceId
-        ) {
-          throw new BoardValidationError(
-            "not_found",
-            `board MCP App widget not found: ${boardParams.name}`,
-          );
-        }
-        const interactive = document.interactive && document.grantState === "granted";
-        const authorizeAppInteraction = interactive
-          ? () => {
-              const current = store.readWidgetMcpApp(snapshot.sessionKey, boardParams.name);
-              return (
-                current?.interactive === true &&
-                current.grantState === "granted" &&
-                current.revision === boardParams.revision &&
-                current.instanceId === boardParams.instanceId
-              );
-            }
-          : undefined;
-        const minted = await mcpApp.mintFromTranscript({
-          cfg: context.getRuntimeConfig(),
-          sessionKey: snapshot.sessionKey,
-          descriptor: document.descriptor,
-          allowedAppToolNames: new Set(interactive ? document.declaredTools : []),
-          ...(authorizeAppInteraction ? { authorizeAppInteraction } : {}),
-          readOnly: !interactive,
-        });
-        if (!minted) {
-          throw new Error("Pinned MCP App source is no longer available");
-        }
-        respond(true, {
-          viewId: minted.view.viewId,
-          expiresAtMs: minted.view.expiresAtMs,
-        });
-      } catch (error) {
-        respondBoardError(error, respond);
-      }
-    },
-    "board.event": ({ params, respond, context }) => {
-      if (!validateBoardEventParams(params)) {
-        invalidParams("board.event", validateBoardEventParams.errors, respond);
-        return;
-      }
-      try {
-        const boardParams = params as BoardEventParams;
-        const identity =
-          "ticket" in boardParams
-            ? resolveAuthorizedBoardWidgetView(store, boardParams.ticket)
-            : (() => {
-                const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
-                if (!boardSessionKey) {
-                  return undefined;
-                }
-                const snapshot = store.getSnapshot(boardSessionKey);
-                const widget = snapshot.widgets.some(
-                  (candidate) => candidate.name === boardParams.widget,
-                );
-                if (!widget) {
-                  throw new BoardValidationError(
-                    "not_found",
-                    `board widget not found: ${boardParams.widget}`,
+      },
+    ),
+    "board.event": defineValidatedGatewayMethod(
+      "board.event",
+      validateBoardEventParams,
+      ({ params: boardParams, respond, context }) => {
+        try {
+          const identity =
+            "ticket" in boardParams
+              ? resolveAuthorizedBoardWidgetView(store, boardParams.ticket)
+              : (() => {
+                  const boardSessionKey = resolveBoardSessionKey(boardParams, context, respond);
+                  if (!boardSessionKey) {
+                    return undefined;
+                  }
+                  const snapshot = store.getSnapshot(boardSessionKey);
+                  const widget = snapshot.widgets.some(
+                    (candidate) => candidate.name === boardParams.widget,
                   );
-                }
-                return { sessionKey: snapshot.sessionKey, name: boardParams.widget };
-              })();
-        if (!identity) {
-          return;
+                  if (!widget) {
+                    throw new BoardValidationError(
+                      "not_found",
+                      `board widget not found: ${boardParams.widget}`,
+                    );
+                  }
+                  return { sessionKey: snapshot.sessionKey, name: boardParams.widget };
+                })();
+          if (!identity) {
+            return;
+          }
+          const appended = appendNotice({
+            sessionKey: identity.sessionKey,
+            widget: identity.name,
+            payload: boardParams.payload,
+          });
+          respond(true, { ok: true, appended });
+        } catch (error) {
+          respondBoardError(error, respond);
         }
-        const appended = appendNotice({
-          sessionKey: identity.sessionKey,
-          widget: identity.name,
-          payload: boardParams.payload,
-        });
-        respond(true, { ok: true, appended });
-      } catch (error) {
-        respondBoardError(error, respond);
-      }
-    },
-    "board.prompt.authorize": ({ params, respond }) => {
-      if (!validateBoardPromptAuthorizeParams(params)) {
-        invalidParams("board.prompt.authorize", validateBoardPromptAuthorizeParams.errors, respond);
-        return;
-      }
-      try {
-        const boardParams = params as BoardPromptAuthorizeParams;
-        const { document } = resolveAuthorizedBoardWidgetView(store, boardParams.ticket);
-        respond(true, {
-          confirmationRequired: !boardWidgetHasGrantedTool(
-            document.declared,
-            document.grantState,
-            "prompt",
-          ),
-        });
-      } catch (error) {
-        respondBoardError(error, respond);
-      }
-    },
-    "board.data.read": async (invocation) => {
-      const { params, respond } = invocation;
-      if (!validateBoardDataReadParams(params)) {
-        invalidParams("board.data.read", validateBoardDataReadParams.errors, respond);
-        return;
-      }
-      try {
-        const boardParams = params as BoardDataReadParams;
-        const bindingParams = boardParams.params ?? {};
-        assertCapabilityParamsSize(bindingParams, "data binding");
-        const { document } = resolveAuthorizedBoardWidgetView(store, boardParams.ticket);
-        if (
-          !boardWidgetHasGrantedTool(document.declared, document.grantState, boardParams.bindingId)
-        ) {
-          throw new BoardValidationError(
-            "invalid_operation",
-            `board widget tool is not granted: ${boardParams.bindingId}`,
-          );
+      },
+    ),
+    "board.prompt.authorize": defineValidatedGatewayMethod(
+      "board.prompt.authorize",
+      validateBoardPromptAuthorizeParams,
+      ({ params: boardParams, respond }) => {
+        try {
+          const { document } = resolveAuthorizedBoardWidgetView(store, boardParams.ticket);
+          respond(true, {
+            confirmationRequired: !boardWidgetHasGrantedTool(
+              document.declared,
+              document.grantState,
+              "prompt",
+            ),
+          });
+        } catch (error) {
+          respondBoardError(error, respond);
         }
-        respond(true, await readDataBinding(boardParams.bindingId, bindingParams, invocation));
-      } catch (error) {
-        respondBoardError(error, respond);
-      }
-    },
-    "board.action": async (invocation) => {
-      const { params, respond } = invocation;
-      if (!validateBoardActionParams(params)) {
-        invalidParams("board.action", validateBoardActionParams.errors, respond);
-        return;
-      }
-      try {
-        const boardParams = params as BoardActionParams;
-        const { document } = resolveAuthorizedBoardWidgetView(store, boardParams.ticket);
-        const capability =
-          "jobId" in boardParams ? `cron.trigger:${boardParams.jobId}` : boardParams.action;
-        if (!boardWidgetHasGrantedTool(document.declared, document.grantState, capability)) {
-          throw new BoardValidationError(
-            "invalid_operation",
-            `board widget tool is not granted: ${capability}`,
-          );
+      },
+    ),
+    "board.data.read": defineValidatedGatewayMethod(
+      "board.data.read",
+      validateBoardDataReadParams,
+      async (invocation) => {
+        const { params: boardParams, respond } = invocation;
+        try {
+          const bindingParams = boardParams.params ?? {};
+          assertCapabilityParamsSize(bindingParams, "data binding");
+          const { document } = resolveAuthorizedBoardWidgetView(store, boardParams.ticket);
+          if (
+            !boardWidgetHasGrantedTool(
+              document.declared,
+              document.grantState,
+              boardParams.bindingId,
+            )
+          ) {
+            throw new BoardValidationError(
+              "invalid_operation",
+              `board widget tool is not granted: ${boardParams.bindingId}`,
+            );
+          }
+          respond(true, await readDataBinding(boardParams.bindingId, bindingParams, invocation));
+        } catch (error) {
+          respondBoardError(error, respond);
         }
-        if ("jobId" in boardParams) {
-          respond(true, await triggerCronJob(boardParams.jobId, invocation));
-          return;
+      },
+    ),
+    "board.action": defineValidatedGatewayMethod(
+      "board.action",
+      validateBoardActionParams,
+      async (invocation) => {
+        const { params: boardParams, respond } = invocation;
+        try {
+          const { document } = resolveAuthorizedBoardWidgetView(store, boardParams.ticket);
+          const capability =
+            "jobId" in boardParams ? `cron.trigger:${boardParams.jobId}` : boardParams.action;
+          if (!boardWidgetHasGrantedTool(document.declared, document.grantState, capability)) {
+            throw new BoardValidationError(
+              "invalid_operation",
+              `board widget tool is not granted: ${capability}`,
+            );
+          }
+          if ("jobId" in boardParams) {
+            respond(true, await triggerCronJob(boardParams.jobId, invocation));
+            return;
+          }
+          const actionParams = boardParams.params ?? {};
+          assertCapabilityParamsSize(actionParams, "action");
+          respond(true, await runActionVerb(boardParams.action, actionParams, invocation));
+        } catch (error) {
+          respondBoardError(error, respond);
         }
-        const actionParams = boardParams.params ?? {};
-        assertCapabilityParamsSize(actionParams, "action");
-        respond(true, await runActionVerb(boardParams.action, actionParams, invocation));
-      } catch (error) {
-        respondBoardError(error, respond);
-      }
-    },
+      },
+    ),
   };
 }
 

--- a/src/gateway/server-methods/commands.ts
+++ b/src/gateway/server-methods/commands.ts
@@ -4,35 +4,36 @@ import { validateCommandsListParams } from "../../../packages/gateway-protocol/s
 import { resolveAgentIdOrRespondError } from "./agent-id-shared.js";
 import { buildCommandsListResult } from "./commands-list-result.js";
 import type { GatewayRequestHandlers } from "./types.js";
-import { assertValidParams } from "./validation.js";
+import { defineValidatedGatewayMethod } from "./validation.js";
 
 export { buildCommandsListResult };
 
 /** Gateway handler for enumerating available chat/native commands. */
 export const commandsHandlers: GatewayRequestHandlers = {
-  "commands.list": ({ params, respond, context }) => {
-    if (!assertValidParams(params, validateCommandsListParams, "commands.list", respond)) {
-      return;
-    }
-    const resolved = resolveAgentIdOrRespondError({
-      rawAgentId: params.agentId,
-      respond,
-      cfg: context.getRuntimeConfig(),
-      normalize: (rawAgentId) => (typeof rawAgentId === "string" ? rawAgentId.trim() : undefined),
-    });
-    if (!resolved) {
-      return;
-    }
-    respond(
-      true,
-      buildCommandsListResult({
-        cfg: resolved.cfg,
-        agentId: resolved.agentId,
-        provider: params.provider,
-        scope: params.scope,
-        includeArgs: params.includeArgs,
-      }),
-      undefined,
-    );
-  },
+  "commands.list": defineValidatedGatewayMethod(
+    "commands.list",
+    validateCommandsListParams,
+    ({ params, respond, context }) => {
+      const resolved = resolveAgentIdOrRespondError({
+        rawAgentId: params.agentId,
+        respond,
+        cfg: context.getRuntimeConfig(),
+        normalize: (rawAgentId) => (typeof rawAgentId === "string" ? rawAgentId.trim() : undefined),
+      });
+      if (!resolved) {
+        return;
+      }
+      respond(
+        true,
+        buildCommandsListResult({
+          cfg: resolved.cfg,
+          agentId: resolved.agentId,
+          provider: params.provider,
+          scope: params.scope,
+          includeArgs: params.includeArgs,
+        }),
+        undefined,
+      );
+    },
+  ),
 };

--- a/src/gateway/server-methods/conversations.ts
+++ b/src/gateway/server-methods/conversations.ts
@@ -6,10 +6,6 @@ import {
   validateConversationSendParams,
   validateConversationTurnCancelParams,
   validateConversationTurnParams,
-  type ConversationListParams,
-  type ConversationSendParams,
-  type ConversationTurnCancelParams,
-  type ConversationTurnParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { cancelPendingConversationTurn } from "../../sessions/conversation-turns.js";
@@ -36,7 +32,7 @@ import type {
   GatewayRequestHandlers,
   RespondFn,
 } from "./types.js";
-import { assertValidParams } from "./validation.js";
+import { defineValidatedGatewayMethod } from "./validation.js";
 
 type ConversationHandlerDeps = {
   cancelConversationTurn: typeof cancelPendingConversationTurn;
@@ -238,188 +234,175 @@ export function createConversationHandlers(
 ): GatewayRequestHandlers {
   const deps = { ...defaultConversationHandlerDeps, ...overrides };
   return {
-    "conversations.list": async ({ params, respond, context }) => {
-      if (
-        !assertValidParams(params, validateConversationListParams, "conversations.list", respond)
-      ) {
-        return;
-      }
-      const request = params as ConversationListParams;
-      const readCurrentConfig = () =>
-        resolveGatewayPluginConfig({ config: context.getRuntimeConfig() });
-      try {
+    "conversations.list": defineValidatedGatewayMethod(
+      "conversations.list",
+      validateConversationListParams,
+      async ({ params: request, respond, context }) => {
+        const readCurrentConfig = () =>
+          resolveGatewayPluginConfig({ config: context.getRuntimeConfig() });
+        try {
+          respond(
+            true,
+            await deps.runConversationList({
+              config: readCurrentConfig(),
+              readCurrentConfig,
+              agentId: request.agentId,
+              ...(request.channel ? { channel: request.channel } : {}),
+              ...(request.query ? { query: request.query } : {}),
+              limit: request.limit ?? 50,
+            }),
+            undefined,
+          );
+        } catch (cause) {
+          respond(
+            false,
+            undefined,
+            errorShape(
+              ErrorCodes.UNAVAILABLE,
+              cause instanceof Error ? cause.message : String(cause),
+            ),
+          );
+        }
+      },
+    ),
+    "conversations.send": defineValidatedGatewayMethod(
+      "conversations.send",
+      validateConversationSendParams,
+      async ({ params: request, respond, context, client }) => {
+        const readCurrentConfig = () =>
+          resolveGatewayPluginConfig({ config: context.getRuntimeConfig() });
+        const config = readCurrentConfig();
+        if (
+          !validateConversationSourceSession({
+            config,
+            agentId: request.agentId,
+            sourceSessionKey: request.sourceSessionKey,
+            respond,
+          })
+        ) {
+          return;
+        }
+        const requestIdentity = bindConversationOperationIdentity(context, {
+          method: "send",
+          operationId: request.operationId,
+          agentId: request.agentId,
+          ...(request.sourceSessionKey ? { sourceSessionKey: request.sourceSessionKey } : {}),
+          conversationRef: request.conversationRef,
+          message: request.message,
+        });
+        if (!requestIdentity) {
+          respond(
+            false,
+            undefined,
+            errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              `conversation send ${request.operationId} was already used with different input`,
+            ),
+          );
+          return;
+        }
+        await runConversationOperation({
+          context,
+          dedupeKey: conversationOperationKey({
+            method: "send",
+            agentId: request.agentId,
+            operationId: request.operationId,
+          }),
+          operationId: request.operationId,
+          requestIdentity,
+          respond,
+          execute: async () =>
+            await deps.runConversationSend({
+              config,
+              readCurrentConfig,
+              agentId: request.agentId,
+              senderIsOwner: isAuthenticatedOwner(client),
+              ...(request.sourceSessionKey ? { sourceSessionKey: request.sourceSessionKey } : {}),
+              operationId: request.operationId,
+              conversationRef: request.conversationRef,
+              message: request.message,
+            }),
+        });
+      },
+    ),
+    "conversations.turn.cancel": defineValidatedGatewayMethod(
+      "conversations.turn.cancel",
+      validateConversationTurnCancelParams,
+      ({ params: request, respond }) => {
         respond(
           true,
-          await deps.runConversationList({
-            config: readCurrentConfig(),
-            readCurrentConfig,
-            agentId: request.agentId,
-            ...(request.channel ? { channel: request.channel } : {}),
-            ...(request.query ? { query: request.query } : {}),
-            limit: request.limit ?? 50,
-          }),
+          {
+            cancelled: deps.cancelConversationTurn({
+              agentId: request.agentId,
+              id: request.turnId,
+            }),
+          },
           undefined,
         );
-      } catch (cause) {
-        respond(
-          false,
-          undefined,
-          errorShape(
-            ErrorCodes.UNAVAILABLE,
-            cause instanceof Error ? cause.message : String(cause),
-          ),
-        );
-      }
-    },
-    "conversations.send": async ({ params, respond, context, client }) => {
-      if (
-        !assertValidParams(params, validateConversationSendParams, "conversations.send", respond)
-      ) {
-        return;
-      }
-      const request = params as ConversationSendParams;
-      const readCurrentConfig = () =>
-        resolveGatewayPluginConfig({ config: context.getRuntimeConfig() });
-      const config = readCurrentConfig();
-      if (
-        !validateConversationSourceSession({
-          config,
-          agentId: request.agentId,
-          sourceSessionKey: request.sourceSessionKey,
-          respond,
-        })
-      ) {
-        return;
-      }
-      const requestIdentity = bindConversationOperationIdentity(context, {
-        method: "send",
-        operationId: request.operationId,
-        agentId: request.agentId,
-        ...(request.sourceSessionKey ? { sourceSessionKey: request.sourceSessionKey } : {}),
-        conversationRef: request.conversationRef,
-        message: request.message,
-      });
-      if (!requestIdentity) {
-        respond(
-          false,
-          undefined,
-          errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            `conversation send ${request.operationId} was already used with different input`,
-          ),
-        );
-        return;
-      }
-      await runConversationOperation({
-        context,
-        dedupeKey: conversationOperationKey({
-          method: "send",
-          agentId: request.agentId,
-          operationId: request.operationId,
-        }),
-        operationId: request.operationId,
-        requestIdentity,
-        respond,
-        execute: async () =>
-          await deps.runConversationSend({
+      },
+    ),
+    "conversations.turn": defineValidatedGatewayMethod(
+      "conversations.turn",
+      validateConversationTurnParams,
+      async ({ params: request, respond, context, client }) => {
+        const readCurrentConfig = () =>
+          resolveGatewayPluginConfig({ config: context.getRuntimeConfig() });
+        const config = readCurrentConfig();
+        if (
+          !validateConversationSourceSession({
             config,
-            readCurrentConfig,
             agentId: request.agentId,
-            senderIsOwner: isAuthenticatedOwner(client),
-            ...(request.sourceSessionKey ? { sourceSessionKey: request.sourceSessionKey } : {}),
-            operationId: request.operationId,
-            conversationRef: request.conversationRef,
-            message: request.message,
-          }),
-      });
-    },
-    "conversations.turn.cancel": ({ params, respond }) => {
-      if (
-        !assertValidParams(
-          params,
-          validateConversationTurnCancelParams,
-          "conversations.turn.cancel",
-          respond,
-        )
-      ) {
-        return;
-      }
-      const request = params as ConversationTurnCancelParams;
-      respond(
-        true,
-        {
-          cancelled: deps.cancelConversationTurn({
-            agentId: request.agentId,
-            id: request.turnId,
-          }),
-        },
-        undefined,
-      );
-    },
-    "conversations.turn": async ({ params, respond, context, client }) => {
-      if (
-        !assertValidParams(params, validateConversationTurnParams, "conversations.turn", respond)
-      ) {
-        return;
-      }
-      const request = params as ConversationTurnParams;
-      const readCurrentConfig = () =>
-        resolveGatewayPluginConfig({ config: context.getRuntimeConfig() });
-      const config = readCurrentConfig();
-      if (
-        !validateConversationSourceSession({
-          config,
-          agentId: request.agentId,
-          sourceSessionKey: request.sourceSessionKey,
-          respond,
-        })
-      ) {
-        return;
-      }
-      const requestIdentity = bindConversationOperationIdentity(context, {
-        method: "turn",
-        operationId: request.turnId,
-        agentId: request.agentId,
-        ...(request.sourceSessionKey ? { sourceSessionKey: request.sourceSessionKey } : {}),
-        conversationRef: request.conversationRef,
-        message: request.message,
-        timeoutMs: request.timeoutMs,
-      });
-      if (!requestIdentity) {
-        respond(
-          false,
-          undefined,
-          errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            `conversation turn ${request.turnId} was already used with different input`,
-          ),
-        );
-        return;
-      }
-      await runConversationOperation({
-        context,
-        dedupeKey: conversationOperationKey({
+            sourceSessionKey: request.sourceSessionKey,
+            respond,
+          })
+        ) {
+          return;
+        }
+        const requestIdentity = bindConversationOperationIdentity(context, {
           method: "turn",
-          agentId: request.agentId,
           operationId: request.turnId,
-        }),
-        operationId: request.turnId,
-        requestIdentity,
-        respond,
-        execute: async () =>
-          await deps.runConversationTurn({
-            config,
-            readCurrentConfig,
+          agentId: request.agentId,
+          ...(request.sourceSessionKey ? { sourceSessionKey: request.sourceSessionKey } : {}),
+          conversationRef: request.conversationRef,
+          message: request.message,
+          timeoutMs: request.timeoutMs,
+        });
+        if (!requestIdentity) {
+          respond(
+            false,
+            undefined,
+            errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              `conversation turn ${request.turnId} was already used with different input`,
+            ),
+          );
+          return;
+        }
+        await runConversationOperation({
+          context,
+          dedupeKey: conversationOperationKey({
+            method: "turn",
             agentId: request.agentId,
-            senderIsOwner: isAuthenticatedOwner(client),
-            ...(request.sourceSessionKey ? { sourceSessionKey: request.sourceSessionKey } : {}),
-            turnId: request.turnId,
-            conversationRef: request.conversationRef,
-            message: request.message,
-            timeoutMs: request.timeoutMs,
+            operationId: request.turnId,
           }),
-      });
-    },
+          operationId: request.turnId,
+          requestIdentity,
+          respond,
+          execute: async () =>
+            await deps.runConversationTurn({
+              config,
+              readCurrentConfig,
+              agentId: request.agentId,
+              senderIsOwner: isAuthenticatedOwner(client),
+              ...(request.sourceSessionKey ? { sourceSessionKey: request.sourceSessionKey } : {}),
+              turnId: request.turnId,
+              conversationRef: request.conversationRef,
+              message: request.message,
+              timeoutMs: request.timeoutMs,
+            }),
+        });
+      },
+    ),
   };
 }
 

--- a/src/gateway/server-methods/logs.ts
+++ b/src/gateway/server-methods/logs.ts
@@ -6,31 +6,30 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { readConfiguredLogTail } from "../../logging/log-tail.js";
 import type { GatewayRequestHandlers } from "./types.js";
-import { assertValidParams } from "./validation.js";
+import { defineValidatedGatewayMethod } from "./validation.js";
 
 /** Gateway handler for bounded reads from the configured gateway log. */
 export const logsHandlers: GatewayRequestHandlers = {
-  "logs.tail": async ({ params, respond }) => {
-    if (!assertValidParams(params, validateLogsTailParams, "logs.tail", respond)) {
-      return;
-    }
-
-    const p = params as { cursor?: number; limit?: number; maxBytes?: number };
-    try {
-      // The log-tail reader enforces cursor/byte limits and source selection;
-      // the handler only maps protocol params and failure shape.
-      const result = await readConfiguredLogTail({
-        cursor: p.cursor,
-        limit: p.limit,
-        maxBytes: p.maxBytes,
-      });
-      respond(true, result, undefined);
-    } catch (err) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.UNAVAILABLE, `log read failed: ${String(err)}`),
-      );
-    }
-  },
+  "logs.tail": defineValidatedGatewayMethod(
+    "logs.tail",
+    validateLogsTailParams,
+    async ({ params, respond }) => {
+      try {
+        // The log-tail reader enforces cursor/byte limits and source selection;
+        // the handler only maps protocol params and failure shape.
+        const result = await readConfiguredLogTail({
+          cursor: params.cursor,
+          limit: params.limit,
+          maxBytes: params.maxBytes,
+        });
+        respond(true, result, undefined);
+      } catch (err) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, `log read failed: ${String(err)}`),
+        );
+      }
+    },
+  ),
 };

--- a/src/gateway/server-methods/portals.ts
+++ b/src/gateway/server-methods/portals.ts
@@ -1,9 +1,6 @@
 import {
   ErrorCodes,
   errorShape,
-  formatValidationErrors,
-  type PortalCloseParams,
-  type PortalOpenParams,
   type PortalSummary,
   validatePortalCloseParams,
   validatePortalListParams,
@@ -11,17 +8,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { ADMIN_SCOPE, WRITE_SCOPE } from "../operator-scopes.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
-
-function invalidParams(method: string, errors: unknown, respond: RespondFn): void {
-  respond(
-    false,
-    undefined,
-    errorShape(
-      ErrorCodes.INVALID_REQUEST,
-      `invalid ${method} params: ${formatValidationErrors(errors as never)}`,
-    ),
-  );
-}
+import { defineValidatedGatewayMethod } from "./validation.js";
 
 function requirePortalService(
   context: Parameters<GatewayRequestHandlers[string]>[0]["context"],
@@ -40,82 +27,87 @@ function redactPortalSummary(summary: PortalSummary): PortalSummary {
 }
 
 export const portalHandlers: GatewayRequestHandlers = {
-  "portal.list": ({ params, respond, context, client }) => {
-    if (!validatePortalListParams(params)) {
-      invalidParams("portal.list", validatePortalListParams.errors, respond);
-      return;
-    }
-    const service = requirePortalService(context, respond);
-    if (!service) {
-      return;
-    }
-    const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
-    const portals = service.list();
-    respond(
-      true,
-      {
-        portals:
-          scopes.includes(WRITE_SCOPE) || scopes.includes(ADMIN_SCOPE)
-            ? portals
-            : portals.map(redactPortalSummary),
-      },
-      undefined,
-    );
-  },
-  "portal.open": async ({ params, respond, context }) => {
-    if (!validatePortalOpenParams(params)) {
-      invalidParams("portal.open", validatePortalOpenParams.errors, respond);
-      return;
-    }
-    const service = requirePortalService(context, respond);
-    if (!service) {
-      return;
-    }
-    try {
-      const request = params as PortalOpenParams;
-      const portal = await service.open({
-        targetPort: request.port,
-        ...(request.title !== undefined ? { title: request.title } : {}),
-        ...(request.description !== undefined ? { description: request.description } : {}),
-        ...(request.path !== undefined ? { path: request.path } : {}),
-      });
-      context.broadcast(
-        "portal.changed",
-        { portals: service.list().map(redactPortalSummary) },
-        { dropIfSlow: true },
-      );
-      respond(true, portal, undefined);
-    } catch (error) {
+  "portal.list": defineValidatedGatewayMethod(
+    "portal.list",
+    validatePortalListParams,
+    ({ respond, context, client }) => {
+      const service = requirePortalService(context, respond);
+      if (!service) {
+        return;
+      }
+      const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
+      const portals = service.list();
       respond(
-        false,
+        true,
+        {
+          portals:
+            scopes.includes(WRITE_SCOPE) || scopes.includes(ADMIN_SCOPE)
+              ? portals
+              : portals.map(redactPortalSummary),
+        },
         undefined,
-        errorShape(ErrorCodes.UNAVAILABLE, error instanceof Error ? error.message : String(error)),
       );
-    }
-  },
-  "portal.close": async ({ params, respond, context }) => {
-    if (!validatePortalCloseParams(params)) {
-      invalidParams("portal.close", validatePortalCloseParams.errors, respond);
-      return;
-    }
-    const service = requirePortalService(context, respond);
-    if (!service) {
-      return;
-    }
-    try {
-      await service.close((params as PortalCloseParams).id);
-      context.broadcast(
-        "portal.changed",
-        { portals: service.list().map(redactPortalSummary) },
-        { dropIfSlow: true },
-      );
-      respond(true, { closed: true }, undefined);
-    } catch (error) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.UNAVAILABLE, error instanceof Error ? error.message : String(error)),
-      );
-    }
-  },
+    },
+  ),
+  "portal.open": defineValidatedGatewayMethod(
+    "portal.open",
+    validatePortalOpenParams,
+    async ({ params: request, respond, context }) => {
+      const service = requirePortalService(context, respond);
+      if (!service) {
+        return;
+      }
+      try {
+        const portal = await service.open({
+          targetPort: request.port,
+          ...(request.title !== undefined ? { title: request.title } : {}),
+          ...(request.description !== undefined ? { description: request.description } : {}),
+          ...(request.path !== undefined ? { path: request.path } : {}),
+        });
+        context.broadcast(
+          "portal.changed",
+          { portals: service.list().map(redactPortalSummary) },
+          { dropIfSlow: true },
+        );
+        respond(true, portal, undefined);
+      } catch (error) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.UNAVAILABLE,
+            error instanceof Error ? error.message : String(error),
+          ),
+        );
+      }
+    },
+  ),
+  "portal.close": defineValidatedGatewayMethod(
+    "portal.close",
+    validatePortalCloseParams,
+    async ({ params, respond, context }) => {
+      const service = requirePortalService(context, respond);
+      if (!service) {
+        return;
+      }
+      try {
+        await service.close(params.id);
+        context.broadcast(
+          "portal.changed",
+          { portals: service.list().map(redactPortalSummary) },
+          { dropIfSlow: true },
+        );
+        respond(true, { closed: true }, undefined);
+      } catch (error) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.UNAVAILABLE,
+            error instanceof Error ? error.message : String(error),
+          ),
+        );
+      }
+    },
+  ),
 };

--- a/src/gateway/server-methods/setup-admission.test.ts
+++ b/src/gateway/server-methods/setup-admission.test.ts
@@ -102,21 +102,22 @@ describe("setup admission", () => {
     const continueAfterStart = createDeferred();
     let runner: Promise<void> | undefined;
 
-    await runWithGatewayIndependentRootWorkAdmission(async () => {
-      await createAdmittedWizardSession(() => {
+    const session = await runWithGatewayIndependentRootWorkAdmission(async () =>
+      createAdmittedWizardSession(() => {
         runner = (async () => {
           await continueAfterStart.promise;
           await enqueueCommandInLane("setup-post-start-proof", async () => undefined);
         })();
         return { whenSettled: () => runner! };
-      });
-    });
+      }),
+    );
 
     const activeAfterStart = getActiveGatewayRootWorkCount();
     continueAfterStart.resolve();
     await expect(runner).resolves.toBeUndefined();
     expect(activeAfterStart).toBe(1);
-    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    await whenAdmittedWizardSessionSettled(session!);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
   });
 
   it("releases an admitted session lease when construction fails", async () => {

--- a/src/gateway/server-methods/ui-command.ts
+++ b/src/gateway/server-methods/ui-command.ts
@@ -13,61 +13,60 @@ import type { GatewayRequestContextWithClientLookup } from "../server-request-co
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { resolveStoredSessionKeyForAgentStore } from "../session-store-key.js";
 import type { GatewayRequestHandlers } from "./types.js";
-import { assertValidParams } from "./validation.js";
+import { defineValidatedGatewayMethod } from "./validation.js";
 
 export const uiCommandHandlers: GatewayRequestHandlers = {
-  "ui.command": ({ params, respond, context }) => {
-    if (!assertValidParams(params, validateUiCommandParams, "ui.command", respond)) {
-      return;
-    }
-
-    const commandParams = params as UiCommandParams;
-    const commandSessionKey =
-      "sessionKey" in commandParams.command
-        ? commandParams.command.sessionKey
-        : commandParams.sessionKey;
-    const requestedSession = commandSessionKey
-      ? resolveRequestedSessionAgentId(
-          context.getRuntimeConfig(),
-          commandSessionKey,
-          commandParams.agentId,
-        )
-      : undefined;
-    if (requestedSession && !requestedSession.ok) {
-      respond(false, undefined, requestedSession.error);
-      return;
-    }
-    const canonicalSessionKey =
-      commandSessionKey && requestedSession?.ok
-        ? resolveStoredSessionKeyForAgentStore({
-            cfg: context.getRuntimeConfig(),
-            agentId: requestedSession.agentId,
-            sessionKey: commandSessionKey,
-          })
+  "ui.command": defineValidatedGatewayMethod(
+    "ui.command",
+    validateUiCommandParams,
+    ({ params: commandParams, respond, context }) => {
+      const commandSessionKey =
+        "sessionKey" in commandParams.command
+          ? commandParams.command.sessionKey
+          : commandParams.sessionKey;
+      const requestedSession = commandSessionKey
+        ? resolveRequestedSessionAgentId(
+            context.getRuntimeConfig(),
+            commandSessionKey,
+            commandParams.agentId,
+          )
         : undefined;
-    const normalizedParams: UiCommandParams = {
-      ...commandParams,
-      ...(canonicalSessionKey ? { sessionKey: canonicalSessionKey } : {}),
-      ...(requestedSession?.ok ? { agentId: requestedSession.agentId } : {}),
-      command:
-        canonicalSessionKey && "sessionKey" in commandParams.command
-          ? { ...commandParams.command, sessionKey: canonicalSessionKey }
-          : commandParams.command,
-    };
-    const clientContext = context as GatewayRequestContextWithClientLookup;
-    // v1 intentionally fans out to every capable Control UI; session-targeted routing is out of scope.
-    const connIds =
-      clientContext.getClientConnIds?.(
-        (client) =>
-          client.connect.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI &&
-          hasGatewayClientCap(client.connect.caps, GATEWAY_CLIENT_CAPS.UI_COMMANDS),
-      ) ?? new Set<string>();
-    if (connIds.size === 0) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "no ui client"));
-      return;
-    }
+      if (requestedSession && !requestedSession.ok) {
+        respond(false, undefined, requestedSession.error);
+        return;
+      }
+      const canonicalSessionKey =
+        commandSessionKey && requestedSession?.ok
+          ? resolveStoredSessionKeyForAgentStore({
+              cfg: context.getRuntimeConfig(),
+              agentId: requestedSession.agentId,
+              sessionKey: commandSessionKey,
+            })
+          : undefined;
+      const normalizedParams: UiCommandParams = {
+        ...commandParams,
+        ...(canonicalSessionKey ? { sessionKey: canonicalSessionKey } : {}),
+        ...(requestedSession?.ok ? { agentId: requestedSession.agentId } : {}),
+        command:
+          canonicalSessionKey && "sessionKey" in commandParams.command
+            ? { ...commandParams.command, sessionKey: canonicalSessionKey }
+            : commandParams.command,
+      };
+      const clientContext = context as GatewayRequestContextWithClientLookup;
+      // v1 intentionally fans out to every capable Control UI; session-targeted routing is out of scope.
+      const connIds =
+        clientContext.getClientConnIds?.(
+          (client) =>
+            client.connect.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI &&
+            hasGatewayClientCap(client.connect.caps, GATEWAY_CLIENT_CAPS.UI_COMMANDS),
+        ) ?? new Set<string>();
+      if (connIds.size === 0) {
+        respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "no ui client"));
+        return;
+      }
 
-    context.broadcastToConnIds("ui.command", normalizedParams, connIds);
-    respond(true, { ok: true });
-  },
+      context.broadcastToConnIds("ui.command", normalizedParams, connIds);
+      respond(true, { ok: true });
+    },
+  ),
 };

--- a/src/gateway/server-methods/validation.test.ts
+++ b/src/gateway/server-methods/validation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import {
+  validateConversationListParams,
+  validateUiCommandParams,
+  type ConversationListParams,
+  type GatewayCoreRequestParams,
+} from "../../../packages/gateway-protocol/src/index.js";
+import type { GatewayRequestContext, GatewayRequestHandlerOptions, RespondFn } from "./types.js";
+import { defineValidatedGatewayMethod } from "./validation.js";
+
+describe("typed gateway method validation", () => {
+  it("binds core method names to their schema-derived payloads", () => {
+    expectTypeOf<
+      GatewayCoreRequestParams["conversations.list"]
+    >().toEqualTypeOf<ConversationListParams>();
+
+    if (false) {
+      // @ts-expect-error A method must use its own protocol payload validator.
+      defineValidatedGatewayMethod("conversations.list", validateUiCommandParams, () => undefined);
+    }
+
+    const respond = vi.fn<RespondFn>();
+    const handler = defineValidatedGatewayMethod(
+      "conversations.list",
+      validateConversationListParams,
+      ({ params, respond: reply }) => {
+        expectTypeOf(params).toEqualTypeOf<ConversationListParams>();
+        reply(true, { agentId: params.agentId, limit: params.limit });
+      },
+    );
+    const options: GatewayRequestHandlerOptions = {
+      req: { type: "req", id: "typed-1", method: "conversations.list" },
+      params: { agentId: "main", limit: 5 },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as GatewayRequestContext,
+    };
+
+    handler(options);
+
+    expect(respond).toHaveBeenCalledWith(true, { agentId: "main", limit: 5 });
+  });
+
+  it("rejects malformed payloads before invoking the typed handler", () => {
+    const action = vi.fn();
+    const respond = vi.fn<RespondFn>();
+    const handler = defineValidatedGatewayMethod(
+      "conversations.list",
+      validateConversationListParams,
+      action,
+    );
+
+    handler({
+      req: { type: "req", id: "typed-2", method: "conversations.list" },
+      params: { agentId: "main", limit: "five" },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as GatewayRequestContext,
+    });
+
+    expect(action).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("invalid conversations.list params"),
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/validation.test.ts
+++ b/src/gateway/server-methods/validation.test.ts
@@ -9,15 +9,17 @@ import type { GatewayRequestContext, GatewayRequestHandlerOptions, RespondFn } f
 import { defineValidatedGatewayMethod } from "./validation.js";
 
 describe("typed gateway method validation", () => {
-  it("binds core method names to their schema-derived payloads", () => {
+  it("binds core method names to their schema-derived payloads", async () => {
     expectTypeOf<
       GatewayCoreRequestParams["conversations.list"]
     >().toEqualTypeOf<ConversationListParams>();
 
-    if (false) {
-      // @ts-expect-error A method must use its own protocol payload validator.
-      defineValidatedGatewayMethod("conversations.list", validateUiCommandParams, () => undefined);
-    }
+    expectTypeOf(validateConversationListParams).toMatchTypeOf<
+      Parameters<typeof defineValidatedGatewayMethod<"conversations.list">>[1]
+    >();
+    expectTypeOf(validateUiCommandParams).not.toMatchTypeOf<
+      Parameters<typeof defineValidatedGatewayMethod<"conversations.list">>[1]
+    >();
 
     const respond = vi.fn<RespondFn>();
     const handler = defineValidatedGatewayMethod(
@@ -37,12 +39,12 @@ describe("typed gateway method validation", () => {
       context: {} as GatewayRequestContext,
     };
 
-    handler(options);
+    await handler(options);
 
     expect(respond).toHaveBeenCalledWith(true, { agentId: "main", limit: 5 });
   });
 
-  it("rejects malformed payloads before invoking the typed handler", () => {
+  it("rejects malformed payloads before invoking the typed handler", async () => {
     const action = vi.fn();
     const respond = vi.fn<RespondFn>();
     const handler = defineValidatedGatewayMethod(
@@ -51,7 +53,7 @@ describe("typed gateway method validation", () => {
       action,
     );
 
-    handler({
+    await handler({
       req: { type: "req", id: "typed-2", method: "conversations.list" },
       params: { agentId: "main", limit: "five" },
       client: null,

--- a/src/gateway/server-methods/validation.ts
+++ b/src/gateway/server-methods/validation.ts
@@ -5,8 +5,12 @@ import {
   errorShape,
   formatValidationErrors,
 } from "../../../packages/gateway-protocol/src/index.js";
-import type { ErrorShape, ValidationError } from "../../../packages/gateway-protocol/src/index.js";
-import type { RespondFn } from "./types.js";
+import type {
+  ErrorShape,
+  GatewayCoreRequestParams,
+  ValidationError,
+} from "../../../packages/gateway-protocol/src/index.js";
+import type { GatewayRequestHandler, GatewayRequestHandlerOptions, RespondFn } from "./types.js";
 
 /** Type guard function shape produced by gateway-protocol validators. */
 export type Validator<T> = ((params: unknown) => params is T) & {
@@ -41,4 +45,22 @@ export function assertValidParams<T>(
   }
   respond(false, undefined, error);
   return false;
+}
+
+/** Bind a core method to its schema before exposing it through the open plugin registry. */
+export function defineValidatedGatewayMethod<Method extends keyof GatewayCoreRequestParams>(
+  method: Method,
+  validate: Validator<NoInfer<GatewayCoreRequestParams[Method]>>,
+  handler: (
+    options: Omit<GatewayRequestHandlerOptions, "params"> & {
+      params: GatewayCoreRequestParams[Method];
+    },
+  ) => ReturnType<GatewayRequestHandler>,
+): GatewayRequestHandler {
+  return (options) => {
+    if (!assertValidParams(options.params, validate, method, options.respond)) {
+      return;
+    }
+    return handler({ ...options, params: options.params });
+  };
 }


### PR DESCRIPTION
Closes #107499

## What Problem This Solves

Gateway core RPC handlers accepted broadly typed payload records, which let command names, validators, and handler payloads drift apart without a compile-time failure.

## Why This Change Was Made

Add a type-only, schema-derived core method payload map and one canonical validated handler adapter. Migrate board, conversation, portal, command-listing, log, and UI-command methods to inferred payloads while preserving open request envelopes, dynamically registered plugin methods, existing validation order, and standard invalid-request responses. No protocol version, plugin SDK, or wire contract changes.

## User Impact

Gateway and plugin behavior is unchanged; core protocol mistakes are caught during typechecking instead of being masked by unsafe assertions.

## Evidence

- Regression-first proof: both new typed-handler tests failed on the previous code because the validated method adapter did not exist.
- Focused Gateway proof: 8 files, 116 tests passing, including malformed payload rejection, board capability boundaries, portal access, conversation behavior, and runtime plugin method dispatch.
- Compile-time negative case rejects pairing a conversation method with the UI command validator.
- Independent structured review: clean, no actionable findings.
- Production LOC: +857/-843, net +14; tests: +73/-0.
- Hosted clean-environment changed gate is running; required PR CI will verify the exact pushed head.