### PR TITLE
fix(cli): return JSON errors for rejected onboarding recommendation options

### DIFF
--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -69,7 +69,7 @@ vi.mock("../../runtime.js", async (importOriginal) => ({
 
 describe("registerOnboardCommand", () => {
   async function runCli(args: string[]) {
-    const program = new Command();
+    const program = new Command().enablePositionalOptions();
     registerOnboardCommand(program);
     await program.parseAsync(args, { from: "user" });
   }
@@ -144,6 +144,7 @@ describe("registerOnboardCommand", () => {
     const unsupportedFlag = args.includes("--reset") ? "--reset" : "--json";
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(unsupportedFlag));
     expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.log).not.toHaveBeenCalled();
     expect(mocks.onboardRecommendationsCommand).not.toHaveBeenCalled();
     expect(mocks.acknowledgeOnboardRecommendationsCommand).not.toHaveBeenCalled();
     expect(mocks.refreshOnboardRecommendationsCommand).not.toHaveBeenCalled();
@@ -154,6 +155,36 @@ describe("registerOnboardCommand", () => {
     await runCli(["onboard", "--json", "recommendations"]);
 
     expect(mocks.onboardRecommendationsCommand).toHaveBeenCalledWith({ json: true }, runtime);
+  });
+
+  it.each(
+    [
+      { flag: "--reset", option: ["--reset"] },
+      { flag: "--workspace", option: ["--workspace", "/tmp/recommendations"] },
+      { flag: "--classic", option: ["--classic"] },
+      { flag: "--flow", option: ["--flow", "advanced"] },
+      { flag: "--mode", option: ["--mode", "remote"] },
+      { flag: "--gateway-port", option: ["--gateway-port", "18789"] },
+      { flag: "--install-daemon", option: ["--install-daemon"] },
+      { flag: "--skip-skills", option: ["--skip-skills"] },
+      { flag: "--import-from", option: ["--import-from", "hermes"] },
+    ].flatMap(({ flag, option }) => [
+      { flag, placement: "parent", args: ["--json", ...option, "recommendations"] },
+      { flag, placement: "leaf", args: [...option, "recommendations", "--json"] },
+    ]),
+  )("reports rejected $flag as one $placement JSON error", async ({ flag, args }) => {
+    await runCli(["onboard", ...args]);
+
+    const message = `This recommendations command does not support parent option(s): ${flag}.`;
+    expect(runtime.log).toHaveBeenCalledExactlyOnceWith(
+      JSON.stringify({ ok: false, phase: "options", message }, null, 2),
+    );
+    expect(runtime.error).toHaveBeenCalledExactlyOnceWith(message);
+    expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(1);
+    expect(mocks.onboardRecommendationsCommand).not.toHaveBeenCalled();
+    expect(mocks.acknowledgeOnboardRecommendationsCommand).not.toHaveBeenCalled();
+    expect(mocks.refreshOnboardRecommendationsCommand).not.toHaveBeenCalled();
+    expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 
   it("defaults installDaemon to undefined when no daemon flags are provided", async () => {

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -48,20 +48,20 @@ const MODERN_ONBOARD_OPTION_KEYS = new Set([
 function validateRecommendationParentOptions(
   command: Command,
   runtime: RuntimeEnv,
-  allowJson = false,
+  json = false,
 ): boolean {
   const unsupported = listExplicitOptionFlagsExcept(
     command,
-    allowJson ? RECOMMENDATION_READ_PARENT_OPTIONS : NO_RECOMMENDATION_PARENT_OPTIONS,
+    json ? RECOMMENDATION_READ_PARENT_OPTIONS : NO_RECOMMENDATION_PARENT_OPTIONS,
   );
   if (unsupported.length === 0) {
     return true;
   }
-  runtime.error(
+  return rejectOnboardingOption(
+    { json },
+    runtime,
     `This recommendations command does not support parent option(s): ${unsupported.join(", ")}.`,
   );
-  runtime.exit(1);
-  return false;
 }
 
 const AUTH_CHOICE_HELP = formatAuthChoiceChoicesForCli({ includeSkip: true });
@@ -320,17 +320,13 @@ export function registerOnboardCommand(program: Command): void {
     .action(async (opts, recommendationsCommand: Command) => {
       const { defaultRuntime } = await import("../../runtime.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
-        if (!validateRecommendationParentOptions(command, defaultRuntime, true)) {
+        const json = Boolean(opts.json || recommendationsCommand.parent?.opts().json);
+        if (!validateRecommendationParentOptions(command, defaultRuntime, json)) {
           return;
         }
         const { onboardRecommendationsCommand } =
           await import("../../commands/onboard-recommendations.js");
-        onboardRecommendationsCommand(
-          {
-            json: Boolean(opts.json || recommendationsCommand.parent?.opts().json),
-          },
-          defaultRuntime,
-        );
+        onboardRecommendationsCommand({ json }, defaultRuntime);
       });
     });
 

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1914,7 +1914,11 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         await waitForLayoutSettled(page, ".chat-main__conversation, .agent-chat__composer-shell");
         const after = await geometry();
 
-        expect(after).toEqual(before);
+        for (const key of ["composer", "conversation", "thread"] as const) {
+          expect(after[key].height).toBe(before[key].height);
+          expect(after[key].width).toBe(before[key].width);
+          expect(Math.abs(after[key].top - before[key].top)).toBeLessThanOrEqual(0.5);
+        }
         expect(
           await page
             .locator(".chat-topbar-notices")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users requesting machine-readable onboarding recommendations received no JSON output when an incompatible onboarding option was also present. Both `openclaw onboard --json --reset recommendations` and `openclaw onboard --reset recommendations --json` exited with an error but left stdout empty, so automation could not inspect the failure.

## Why This Change Was Made

Resolve the recommendations reader's effective JSON mode once before validating its parent options, and route rejected options through onboarding's existing canonical JSON-aware rejection handler. Keep recommendation acknowledgement and refresh on their existing non-JSON contracts; do not change recommendation storage, configuration, authentication, or onboarding policy. Production code is four lines smaller. CI also exposed an existing Chromium layout-test flake: keep its width and height checks exact while applying the same test file's established half-pixel tolerance to fractional top coordinates only.

## User Impact

Recommendation readers now receive exactly one structured `{ ok: false, phase: "options", message }` error on stdout regardless of whether `--json` appears before or after `recommendations`. The human diagnostic remains on stderr, the exit status remains 1, non-JSON invocations are unchanged, and incompatible flags never reach recommendation or setup state.

## Evidence

- Before the fix, 18 real Commander positional-parser regressions failed across nine unsupported parent-option families and both supported `--json` placements; all 48 existing controls passed.
- After the fix, all 66 direct command-registration tests pass and seven affected registration, setup, recommendation, Commander-option, root-program, and help suites pass: **241 tests**.
- Real source-backed CLI subprocesses independently verify exact stdout JSON, stderr diagnostics, exit status 1, unchanged non-JSON rejection, acknowledgement's continued rejection of inherited JSON, and that no isolated state/config directory is created.
- The exact hosted CI failure showed coherent browser rounding of **0.292419 px** with unchanged dimensions; both affected real Chromium viewport tests now pass, and the bounded assertion still rejects movement greater than **0.5 px**. No UI or production behavior changed.
- Genuine strict production, CLI-test, and UI-test project graphs pass with **10,424**, **10,484**, and **10,513** source files respectively, with zero diagnostics.
- Scoped Rust AST lint, formatting, assertion-safety and max-lines ratchets, plugin-boundary checks, independent source-blind review, and fresh authenticated Codex review are clean.
- Production: `+8/-12` (**net -4**). Tests: `+37/-2`.
- Reviewed head: `d2483bcd6aa93dc3083583cbe3bb3f74e859004b`.
