### PR TITLE
docs: document node install --no-tls option

### DIFF
--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -149,6 +149,7 @@ Options:
 - `--port <port>`: Gateway WebSocket port (default: `18789`)
 - `--context-path <path>`: Gateway WebSocket context path (e.g. `/openclaw-gw`). Appended to the WebSocket URL.
 - `--tls`: Use TLS for the gateway connection
+- `--no-tls`: Force a plaintext Gateway connection even when the local Gateway config enables TLS
 - `--tls-fingerprint <sha256>`: Expected TLS certificate fingerprint (sha256)
 - `--node-id <id>`: Override the client instance ID stored in shared SQLite state (does not reset pairing)
 - `--display-name <name>`: Override the node display name


### PR DESCRIPTION
## What Problem This Solves

The `node install` reference omitted the existing `--no-tls` flag, making the managed-service plaintext override hard to discover. Add it beside `--tls`, matching the existing foreground `node run` wording.

## Why This Change Was Made

The CLI resolver preserves explicit false, and the service argument builder carries `--no-tls` into the managed command so the node does not inherit local Gateway TLS. Fingerprint and Cloudflare Access safety checks are unchanged. This is a documentation-only correction; no runtime or configuration behavior changes.

## User Impact

Node service operators can discover the supported plaintext override from the CLI reference.

## Evidence

Maintainer checks passed on the unchanged contributor head: docs-list, target-file MDX compilation, formatting with the trusted repository configuration, whitespace validation, and fresh Codex autoreview with no accepted P0 findings. Existing parser, install and service-argument tests were source-inspected; no runtime code changed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/32994222528) passed on rerun attempt 2, including check-docs and openclaw/ci-gate. The original CLI-help observation remains contributor evidence.

Thanks @qingminglong.
