### PR TITLE
fix(lobster): keep rejected approvals cancelled and enforce output limits

### DIFF
--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -297,7 +297,7 @@ Run a workflow file with args:
 | `pipeline`       | required    | Inline pipeline string, or a path ending in `.lobster`/`.yaml`/`.yml`/`.json` for a workflow file.           |
 | `cwd`            | gateway cwd | Relative working directory; must resolve inside the gateway working directory (absolute paths are rejected). |
 | `timeoutMs`      | `20000`     | Aborts the run if exceeded.                                                                                  |
-| `maxStdoutBytes` | `512000`    | Aborts the run if captured stdout or stderr exceeds this size.                                               |
+| `maxStdoutBytes` | `512000`    | Aborts if captured stdout, stderr, or the embedded JSON result exceeds this size.                            |
 | `argsJson`       | -           | JSON string of args for a workflow file (ignored for inline pipelines).                                      |
 
 ### `resume`
@@ -320,7 +320,7 @@ Passing `flowControllerId` and `flowGoal` on `run` (or `flowId` and
 `flowExpectedRevision` on `resume`) drives the call through the plugin
 runtime's managed [Task Flow](/automation/taskflow) API instead of returning
 a bare envelope: OpenClaw creates or resumes a durable flow record, applies the
-Lobster envelope to it (`waiting` on approval, `succeeded`/`failed` on
+Lobster envelope to it (`waiting` on approval, `succeeded`/`failed`/`cancelled` on
 completion), and returns `{ ok, envelope, flow, mutation }`. This mode requires
 a bound Task Flow runtime and is intended for plugin/controller code that needs
 durable flow state across gateway restarts, not typical ad hoc agent use.
@@ -365,6 +365,7 @@ pointer to that state, not the full pipeline state.
 | ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | `lobster runtime timed out`                                   | Pipeline exceeded `timeoutMs`. Increase it or split the pipeline.                |
 | `lobster stdout exceeded maxStdoutBytes` (or `stderr`)        | Captured output exceeded the cap. Raise `maxStdoutBytes` or reduce output.       |
+| `lobster runtime result exceeded maxStdoutBytes`              | The JSON result exceeded the cap. Raise `maxStdoutBytes` or reduce output.       |
 | `run --args-json must be valid JSON`                          | `argsJson` (workflow-file runs) failed to parse. Fix the JSON string.            |
 | `lobster runtime failed` (or another `runtime_error` message) | The embedded runtime returned an error envelope. Check gateway logs for details. |
 

--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -3,11 +3,17 @@ import os from "node:os";
 import path from "node:path";
 // Lobster tests cover lobster runner plugin behavior.
 import { toErrorObject as toLintErrorObject } from "openclaw/plugin-sdk/error-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createEmbeddedLobsterRunner, resolveLobsterCwd } from "./lobster-runner.js";
+import {
+  createEmbeddedLobsterRunner,
+  resolveLobsterCwd,
+  type LobsterRunnerParams,
+} from "./lobster-runner.js";
 
 const requireRecord = createRequireRecord("record", "expected-label-record");
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function requireFirstCallParam(calls: ReadonlyArray<readonly unknown[]>, label: string) {
   const call = calls[0];
@@ -81,6 +87,51 @@ describe("createEmbeddedLobsterRunner", () => {
       requiresApproval: null,
     });
   });
+
+  it.each(["inline", "workflow", "resume"])(
+    "bounds the model-visible result for an embedded %s request",
+    async (requestKind) => {
+      const runtimeResult = {
+        ok: true,
+        protocolVersion: 1,
+        status: "ok" as const,
+        output: Array.from({ length: 115 }, () => ({ a: 1 })),
+        requiresApproval: null,
+        requiresInput: null,
+      };
+      const runtime = {
+        runToolRequest: vi.fn().mockResolvedValue(runtimeResult),
+        resumeToolRequest: vi.fn().mockResolvedValue(runtimeResult),
+      };
+      const runner = createEmbeddedLobsterRunner({
+        loadRuntime: vi.fn().mockResolvedValue(runtime),
+      });
+      const tempDir = tempDirs.make("openclaw-lobster-limit-");
+      const workflowPath = path.join(tempDir, "workflow.lobster");
+      await fs.writeFile(workflowPath, "steps: []\n", "utf8");
+      const params: LobsterRunnerParams =
+        requestKind === "resume"
+          ? {
+              action: "resume",
+              token: "resume-token",
+              approve: false,
+              cwd: tempDir,
+              timeoutMs: 2000,
+              maxStdoutBytes: 1024,
+            }
+          : {
+              action: "run",
+              pipeline: requestKind === "workflow" ? workflowPath : "exec --json=true echo bounded",
+              cwd: tempDir,
+              timeoutMs: 2000,
+              maxStdoutBytes: 1024,
+            };
+
+      await expect(runner.run(params)).rejects.toThrow(
+        "lobster runtime result exceeded maxStdoutBytes",
+      );
+    },
+  );
 
   it.each([
     "exec --json=true cat data.json",
@@ -495,7 +546,7 @@ describe("createEmbeddedLobsterRunner", () => {
         pipeline: "commands.list",
         cwd: process.cwd(),
         timeoutMs: 2000,
-        maxStdoutBytes: 4096,
+        maxStdoutBytes: 512_000,
       }),
     ).resolves.toMatchObject({ ok: true, status: "ok" });
   });

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -112,14 +112,17 @@ function createLimitedSink(maxBytes: number, label: "stdout" | "stderr") {
   });
 }
 
-function normalizeEnvelope(envelope: EmbeddedToolEnvelope): Extract<LobsterEnvelope, { ok: true }> {
+function normalizeEnvelope(
+  envelope: EmbeddedToolEnvelope,
+  maxStdoutBytes: number,
+): Extract<LobsterEnvelope, { ok: true }> {
   if (!envelope.ok) {
     throw new Error(envelope.error?.message ?? "lobster runtime failed");
   }
   if (envelope.status === "needs_input") {
     throw new Error("Lobster input requests are not supported by the OpenClaw Lobster tool yet");
   }
-  return {
+  const normalized: Extract<LobsterEnvelope, { ok: true }> = {
     ok: true,
     status: envelope.status ?? "ok",
     output: Array.isArray(envelope.output) ? envelope.output : [],
@@ -137,6 +140,10 @@ function normalizeEnvelope(envelope: EmbeddedToolEnvelope): Extract<LobsterEnvel
         }
       : null,
   };
+  if (Buffer.byteLength(JSON.stringify(normalized, null, 2), "utf8") > maxStdoutBytes) {
+    throw new Error("lobster runtime result exceeded maxStdoutBytes");
+  }
+  return normalized;
 }
 
 function isMissingPathError(error: unknown) {
@@ -229,6 +236,7 @@ export function createEmbeddedLobsterRunner(options?: {
       const runtime = await runtimePromise;
       return await withTimeout(params.timeoutMs, async (signal) => {
         const ctx = createEmbeddedToolContext(params, signal);
+        let envelope: EmbeddedToolEnvelope;
 
         if (params.action === "run") {
           const pipeline = params.pipeline?.trim() ?? "";
@@ -247,29 +255,27 @@ export function createEmbeddedLobsterRunner(options?: {
                 throw new Error("run --args-json must be valid JSON");
               }
             }
-            return normalizeEnvelope(await runtime.runToolRequest({ filePath, args, ctx }));
+            envelope = await runtime.runToolRequest({ filePath, args, ctx });
+          } else {
+            envelope = await runtime.runToolRequest({ pipeline, ctx });
           }
-
-          return normalizeEnvelope(await runtime.runToolRequest({ pipeline, ctx }));
-        }
-
-        const token = params.token?.trim() ?? "";
-        const approvalId = params.approvalId?.trim() ?? "";
-        if (!token && !approvalId) {
-          throw new Error("token or approvalId required");
-        }
-        if (typeof params.approve !== "boolean") {
-          throw new Error("approve required");
-        }
-
-        return normalizeEnvelope(
-          await runtime.resumeToolRequest({
+        } else {
+          const token = params.token?.trim() ?? "";
+          const approvalId = params.approvalId?.trim() ?? "";
+          if (!token && !approvalId) {
+            throw new Error("token or approvalId required");
+          }
+          if (typeof params.approve !== "boolean") {
+            throw new Error("approve required");
+          }
+          envelope = await runtime.resumeToolRequest({
             ...(token ? { token } : {}),
             ...(approvalId ? { approvalId } : {}),
             approved: params.approve,
             ctx,
-          }),
-        );
+          });
+        }
+        return normalizeEnvelope(envelope, Math.max(1024, params.maxStdoutBytes));
       });
     },
   };

--- a/extensions/lobster/src/lobster-taskflow.test.ts
+++ b/extensions/lobster/src/lobster-taskflow.test.ts
@@ -1,4 +1,5 @@
 // Lobster tests cover lobster taskflow plugin behavior.
+import { createRuntimeTaskFlow } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type { LobsterRunner } from "./lobster-runner.js";
 import { resumeManagedLobsterFlow, runManagedLobsterFlow } from "./lobster-taskflow.js";
@@ -25,6 +26,7 @@ function createRunFlowParams(
 ): Parameters<typeof runManagedLobsterFlow>[0] {
   return {
     taskFlow,
+    config: {},
     runner,
     runnerParams: {
       action: "run",
@@ -44,6 +46,7 @@ function createResumeFlowParams(
 ): Parameters<typeof resumeManagedLobsterFlow>[0] {
   return {
     taskFlow,
+    config: {},
     runner,
     flowId: "flow-1",
     expectedRevision: 4,
@@ -225,4 +228,71 @@ describe("resumeManagedLobsterFlow", () => {
       },
     });
   });
+});
+
+describe("cancelled managed Lobster flows", () => {
+  it.each(["run", "resume"])(
+    "persists a cancelled TaskFlow for a rejected Lobster %s",
+    async (action) => {
+      const taskFlow = createRuntimeTaskFlow().bindSession({
+        sessionKey: `agent:main:lobster-cancel-${action}`,
+      });
+      const runner = createRunner({
+        ok: true,
+        status: "cancelled",
+        output: [],
+        requiresApproval: null,
+      });
+      let result;
+      if (action === "run") {
+        result = await runManagedLobsterFlow(createRunFlowParams(taskFlow, runner));
+      } else {
+        const waitingFlow = taskFlow.createManaged({
+          controllerId: "tests/lobster",
+          goal: "Resume Lobster workflow",
+          status: "waiting",
+        });
+        result = await resumeManagedLobsterFlow({
+          ...createResumeFlowParams(taskFlow, runner),
+          flowId: waitingFlow.flowId,
+          expectedRevision: waitingFlow.revision,
+        });
+      }
+
+      if (!result.ok) {
+        throw result.error;
+      }
+      expect(taskFlow.get(result.flow.flowId)?.status).toBe("cancelled");
+    },
+  );
+
+  it.each(["unsettled", "rejected"])(
+    "does not finish or fail when TaskFlow cancellation is %s",
+    async (outcome) => {
+      const cancel =
+        outcome === "unsettled"
+          ? vi.fn().mockResolvedValue({
+              found: true,
+              cancelled: false,
+              reason: "One or more child tasks are still active.",
+              tasks: [],
+            })
+          : vi.fn().mockRejectedValue(new Error("cancel transport error"));
+      const taskFlow = createFakeTaskFlow({ cancel });
+      const runner = createRunner({
+        ok: true,
+        status: "cancelled",
+        output: [],
+        requiresApproval: null,
+      });
+
+      const result = expectManagedFlowFailure(
+        await resumeManagedLobsterFlow(createResumeFlowParams(taskFlow, runner)),
+      );
+
+      expect(result.error.message).toMatch(/cancellation failed|cancel transport error/u);
+      expect(taskFlow.finish).not.toHaveBeenCalled();
+      expect(taskFlow.fail).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/extensions/lobster/src/lobster-taskflow.ts
+++ b/extensions/lobster/src/lobster-taskflow.ts
@@ -17,7 +17,9 @@ export type BoundTaskFlow = ReturnType<
 >;
 
 type FlowRecord = NonNullable<ReturnType<BoundTaskFlow["tryCreateManaged"]>>;
-type MutationResult = ReturnType<BoundTaskFlow["setWaiting"]>;
+type MutationResult =
+  | ReturnType<BoundTaskFlow["setWaiting"]>
+  | Awaited<ReturnType<BoundTaskFlow["cancel"]>>;
 
 type LobsterApprovalWaitState = {
   kind: "lobster_approval";
@@ -29,6 +31,7 @@ type LobsterApprovalWaitState = {
 
 type RunManagedLobsterFlowParams = {
   taskFlow: BoundTaskFlow;
+  config: OpenClawPluginApi["config"];
   runner: LobsterRunner;
   runnerParams: LobsterRunnerParams;
   controllerId: string;
@@ -40,6 +43,7 @@ type RunManagedLobsterFlowParams = {
 
 type ResumeManagedLobsterFlowParams = {
   taskFlow: BoundTaskFlow;
+  config: OpenClawPluginApi["config"];
   runner: LobsterRunner;
   runnerParams: LobsterRunnerParams & {
     action: "resume";
@@ -117,46 +121,45 @@ function buildApprovalWaitState(envelope: Extract<LobsterEnvelope, { ok: true }>
   } satisfies LobsterApprovalWaitState;
 }
 
-function applyEnvelopeToFlow(params: {
-  taskFlow: BoundTaskFlow;
-  flow: FlowRecord;
-  envelope: LobsterEnvelope;
-  waitingStep: string;
-}): MutationResult {
-  const { taskFlow, flow, envelope, waitingStep } = params;
-  const flowMutation = { flowId: flow.flowId, expectedRevision: flow.revision };
-
-  if (!envelope.ok) {
-    return taskFlow.fail(flowMutation);
-  }
-
-  if (envelope.status === "needs_approval") {
-    return taskFlow.setWaiting({
-      ...flowMutation,
-      currentStep: waitingStep,
-      waitJson: buildApprovalWaitState(envelope),
-    });
-  }
-
-  return taskFlow.finish(flowMutation);
-}
-
 async function executeManagedLobsterFlow(
-  params: Pick<RunManagedLobsterFlowParams, "taskFlow" | "runner" | "runnerParams" | "waitingStep">,
+  params: Pick<
+    RunManagedLobsterFlowParams,
+    "taskFlow" | "config" | "runner" | "runnerParams" | "waitingStep"
+  >,
   flow: FlowRecord,
   failureFlowId = flow.flowId,
 ): Promise<ManagedLobsterFlowResult> {
   try {
     const envelope = await params.runner.run(params.runnerParams);
-    const mutation = applyEnvelopeToFlow({
-      taskFlow: params.taskFlow,
-      flow,
-      envelope,
-      waitingStep: params.waitingStep ?? "await_lobster_approval",
-    });
+    if (envelope.ok && envelope.status === "cancelled") {
+      try {
+        const mutation = await params.taskFlow.cancel({ flowId: flow.flowId, cfg: params.config });
+        return mutation.cancelled
+          ? { ok: true, envelope, flow, mutation }
+          : {
+              ok: false,
+              flow,
+              mutation,
+              error: new Error(`TaskFlow cancellation failed: ${mutation.reason ?? "unknown"}`),
+            };
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        return { ok: false, flow, error: err };
+      }
+    }
+    const flowMutation = { flowId: flow.flowId, expectedRevision: flow.revision };
     if (!envelope.ok) {
+      const mutation = params.taskFlow.fail(flowMutation);
       return { ok: false, flow, mutation, error: new Error(envelope.error.message) };
     }
+    const mutation =
+      envelope.status === "needs_approval"
+        ? params.taskFlow.setWaiting({
+            ...flowMutation,
+            currentStep: params.waitingStep ?? "await_lobster_approval",
+            waitJson: buildApprovalWaitState(envelope),
+          })
+        : params.taskFlow.finish(flowMutation);
     return { ok: true, envelope, flow, mutation };
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -268,6 +268,7 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
         return resolveManagedFlowToolResult(
           await runManagedLobsterFlow({
             taskFlow: requireTaskFlowRuntime(taskFlow, "run"),
+            config: api.config,
             runner,
             runnerParams,
             controllerId: flowParams.controllerId,
@@ -282,6 +283,7 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
         return resolveManagedFlowToolResult(
           await resumeManagedLobsterFlow({
             taskFlow: requireTaskFlowRuntime(taskFlow, "resume"),
+            config: api.config,
             runner,
             runnerParams: flowParams.runnerParams,
             flowId: flowParams.flowId,


### PR DESCRIPTION
## What Problem This Solves

Rejecting a Lobster approval returns a successful `cancelled` envelope. The managed-flow adapter treated every successful non-waiting envelope as complete, so the authoritative TaskFlow record became `succeeded`.

Embedded Lobster calls also returned structured output outside the bounded stdout and stderr streams. A model-visible JSON result could exceed `maxStdoutBytes`.

## Why This Change Was Made

The shared run and resume path now sends `cancelled` envelopes to the session-bound TaskFlow cancellation authority. It never sends that outcome to generic completion. If cancellation cannot settle or rejects, the adapter returns an error without changing the flow to `succeeded` or `failed`.

All embedded run, workflow-file, and resume results now pass through one normalization point. That point measures the same pretty JSON form returned to the model and rejects it when it exceeds the configured limit.

## User Impact

Rejected Lobster approvals now leave their managed TaskFlow records `cancelled`. Oversized embedded results now fail with `lobster runtime result exceeded maxStdoutBytes` instead of bypassing the output cap.

## Evidence

The live check used the pinned Lobster runtime to execute a real approval-gated workflow and the production session-bound TaskFlow runtime to inspect persisted state. It ran the same inputs against exact main `8d51e415d6a14ae7b6d1023fc9661e4bc1e9c725` and head `1bbb034e2bfa8a288a8de10cce005d39e3c9da45`.

| Check | Main | Head |
| --- | --- | --- |
| Reject approval after `waiting` | Persisted `succeeded` | Persisted `cancelled` |
| 115-item result, 980 compact bytes and 3,070 model-visible bytes, with a 1,024-byte limit | Returned the oversized result | Rejected with the documented limit error |
| 10-item result below the limit | Returned 10 items | Returned 10 items |

- `node scripts/run-vitest.mjs extensions/lobster`: 73 tests passed.
- `pnpm build`: passed on the exact head in an isolated Linux checkout.
- `pnpm check:changed`: passed on the exact head, including extension production types, test types, lint, formatting, contract tests, dead exports, database-first checks, and import-cycle checks.
- `node scripts/check-docs-mdx.mjs docs/tools/lobster.md`: passed.
- `node scripts/docs-link-audit.mjs docs/tools/lobster.md`: 6,908 internal links checked, 0 broken.
- Judged line count: production +11, tests +121, docs +1. The production growth adds the TaskFlow cancellation authority and the model-visible byte contract; one canonical normalization path replaces three return-site checks.

Co-authored-by: Nonosword <37948612+Nonosword@users.noreply.github.com>
