### PR TITLE
fix(telegram): make ask_user controls native and reliable

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1265,7 +1265,6 @@ extensions/telegram/src/bot/body-helpers.ts	1
 extensions/telegram/src/bot/delivery.replies.ts	1
 extensions/telegram/src/bot/delivery.resolve-media.ts	1
 extensions/telegram/src/bot/helpers.ts	2
-extensions/telegram/src/button-types.ts	1
 extensions/telegram/src/callback-query-answer-state.ts	1
 extensions/telegram/src/channel-actions.ts	1
 extensions/telegram/src/channel.ts	1

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -525,6 +525,9 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     Scopes: `off`, `dm`, `group`, `all`, `allowlist` (default). Legacy `capabilities: ["inlineButtons"]` maps to `"all"`.
 
+    `ask_user` uses these native controls for one single-select question.
+    Choices use one row each, and **Other…** opens Telegram's reply input.
+
     Message action example:
 
 ```json5

--- a/docs/plugins/message-presentation.md
+++ b/docs/plugins/message-presentation.md
@@ -82,6 +82,11 @@ type MessagePresentationAction =
       questionId: string;
       optionValue: string;
     }
+  | {
+      type: "question";
+      questionId: string;
+      intent: "custom-input";
+    }
   | { type: "url"; url: string }
   | {
       type: "web-app";
@@ -151,6 +156,12 @@ Button semantics:
   four single-select choices as `1️⃣` through `4️⃣` reactions. Other question
   shapes degrade to label text, and the user can answer with a plain-text
   reply.
+- `intent: "custom-input"` switches a live question to its free-text answer
+  path without resolving it. Producers must also state the free-text route in
+  visible text. A channel can omit this one native control while keeping
+  declared-choice controls native when it cannot target a text composer safely.
+  Telegram maps it to **Other…** and Force Reply. Discord and Slack keep the
+  visible text route.
 - `action.type: "url"` opens a normal link.
 - `action.type: "web-app"` launches a channel-native web app. Set `url` for a
   URL-backed app or `widgetId` for an OpenClaw-hosted widget whose launch

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -130,7 +130,7 @@ new code; see the per-row notes below.
     | `plugin-sdk/channel-targets` | Private-local after July 2026; Target parsing helpers; route comparison callers should use `plugin-sdk/channel-route` |
     | `plugin-sdk/channel-contract` | Channel contract types |
     | `plugin-sdk/channel-feedback` | Feedback/reaction wiring |
-    | `plugin-sdk/reply-payload` | Reply payload types, normalization, content/media inspection, chunked send helpers, reasoning detection, and reply fan-out |
+    | `plugin-sdk/reply-payload` | Reply payload types, normalization, content/media inspection, native question option ordering, chunked send helpers, reasoning detection, and reply fan-out |
   </Accordion>
 
 Later-window channel compatibility subpaths remain public only through their

--- a/docs/tools/ask-user.md
+++ b/docs/tools/ask-user.md
@@ -23,10 +23,13 @@ You can answer from any supported conversation surface:
   multi-question prompts, the panel shows one question at a time and advances
   through a short stepper. After resolution, the panel closes and the chat
   keeps only a compact answer summary.
-- Telegram, Discord, and Slack render native buttons for a single-choice,
-  single-question prompt.
+- Telegram renders each choice as a full-width native button for one
+  single-select question. **Other…** switches to Telegram's reply input without
+  resolving the question.
+- Discord and Slack render native buttons for a single-choice, single-question
+  prompt.
 - A plain-text reply works on any channel. Reply with a number, an option label,
-  or your own answer.
+  or your own answer. For multi-select questions, separate choices with commas.
 
 OpenClaw always enables a free-text **Other** answer. The agent must not add an
 `Other` option to the authored option list.
@@ -44,9 +47,8 @@ inline cards; multiple questions stay stacked as an intentional touch-friendly
 idiom. Every platform keeps the question-to-answer summary in the active chat
 timeline without timed eviction, and **Skip** is available everywhere.
 
-Prompts that cannot use native buttons, including multi-question and
-multi-select prompts, degrade to readable text on channels. The Control UI
-keeps the full structured stepper.
+Multi-question and multi-select prompts degrade to readable text on messaging
+channels. The Control UI keeps the full structured stepper.
 
 ## Timeout and no answer
 
@@ -101,7 +103,10 @@ Example answered result:
 The model-facing contract tells the agent to:
 
 - ask only when blocked on a genuinely user-owned decision;
-- prefer one question and use no more than three;
+- ask exactly one question per call unless several answers must be submitted
+  together, because one-question prompts can use native messaging controls;
+- put every selectable choice in `options`, never only in question prose;
+- use `multiSelect` only when several choices can be selected at once;
 - put the recommended option first and suffix its label with `(Recommended)`;
 - omit an authored `Other` option because free text is added automatically;
 - continue with best judgment after `no_answer`.

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -1139,6 +1139,45 @@ describe("discordOutbound", () => {
     });
   });
 
+  it("encodes question buttons from Gateway option order", async () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const payload = await discordOutbound.renderPresentation?.({
+      payload: {
+        channelData: { askUser: { questionId, optionValues: ["Staging", "Production"] } },
+      },
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Production",
+                action: { type: "question", questionId, optionValue: "Production" },
+              },
+              {
+                label: "Other…",
+                action: { type: "question", questionId, intent: "custom-input" },
+              },
+              {
+                label: "Staging",
+                action: { type: "question", questionId, optionValue: "Staging" },
+              },
+            ],
+          },
+        ],
+      },
+      ctx: { cfg: {}, to: "channel:123456" },
+    } as never);
+
+    const discordData = payload?.channelData?.discord as
+      | { presentationComponents?: { blocks?: Array<{ buttons?: unknown[] }> } }
+      | undefined;
+    expect(discordData?.presentationComponents?.blocks?.[0]?.buttons).toMatchObject([
+      { internalCustomId: `ocq:id=${questionId};i=1` },
+      { internalCustomId: `ocq:id=${questionId};i=0` },
+    ]);
+  });
+
   it("falls back to chunked text when a table exceeds the Discord component envelope", async () => {
     const table = {
       type: "table" as const,

--- a/extensions/discord/src/outbound-components.ts
+++ b/extensions/discord/src/outbound-components.ts
@@ -4,6 +4,7 @@ import {
   createLazyRuntimeModule,
   createLazyRuntimeNamedExport,
 } from "openclaw/plugin-sdk/lazy-runtime";
+import { resolveAskUserQuestionOptionIndices } from "openclaw/plugin-sdk/reply-payload";
 import { readDiscordComponentSpec, type DiscordComponentMessageSpec } from "./components.js";
 
 type DiscordComponentSendFn = typeof import("./send.components.js").sendDiscordComponentMessage;
@@ -134,6 +135,7 @@ export async function buildDiscordPresentationPayload(params: {
 }): Promise<typeof params.payload | null> {
   const componentSpec = (await loadDiscordSharedInteractive()).buildDiscordPresentationComponents(
     params.presentation,
+    { questionOptionIndices: resolveAskUserQuestionOptionIndices(params.payload) },
   );
   if (!componentSpec) {
     return null;

--- a/extensions/discord/src/shared-interactive.test.ts
+++ b/extensions/discord/src/shared-interactive.test.ts
@@ -128,24 +128,32 @@ describe("buildDiscordInteractiveComponents", () => {
         questionId: "ask_0123456789abcdef0123456789abcdef",
         optionValue: "Production",
       },
-      expected: { internalCustomId: "ocq:id=ask_0123456789abcdef0123456789abcdef;i=1" },
+      expected: { internalCustomId: "ocq:id=ask_0123456789abcdef0123456789abcdef;i=0" },
     },
   ])("preserves typed $name authority through the legacy renderer", ({ action, expected }) => {
     expect(
-      buildDiscordInteractiveComponents({
-        blocks: [
-          {
-            type: "buttons",
-            buttons: [
-              {
-                label: "Unavailable",
-                action: { type: "web-app", widgetId: "invalid" },
-              },
-              { label: "Continue", action },
-            ],
-          },
-        ],
-      }),
+      buildDiscordInteractiveComponents(
+        {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                {
+                  label: "Unavailable",
+                  action: { type: "web-app", widgetId: "invalid" },
+                },
+                { label: "Continue", action },
+              ],
+            },
+          ],
+        },
+        {
+          questionOptionIndices:
+            action.type === "question"
+              ? new Map([[action.questionId, new Map([[action.optionValue.toLowerCase(), 0]])]])
+              : undefined,
+        },
+      ),
     ).toMatchObject({
       blocks: [{ type: "actions", buttons: [{ label: "Continue", ...expected }] }],
     });
@@ -360,17 +368,30 @@ describe("buildDiscordInteractiveComponents", () => {
   it("renders question choices with compact option indices", () => {
     const questionId = "ask_0123456789abcdef0123456789abcdef";
     expect(
-      buildDiscordPresentationComponents({
-        blocks: [
-          {
-            type: "buttons",
-            buttons: ["Staging", "Production"].map((label) => ({
-              label,
-              action: { type: "question" as const, questionId, optionValue: label },
-            })),
-          },
-        ],
-      }),
+      buildDiscordPresentationComponents(
+        {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: ["Staging", "Production"].map((label) => ({
+                label,
+                action: { type: "question" as const, questionId, optionValue: label },
+              })),
+            },
+          ],
+        },
+        {
+          questionOptionIndices: new Map([
+            [
+              questionId,
+              new Map([
+                ["staging", 0],
+                ["production", 1],
+              ]),
+            ],
+          ]),
+        },
+      ),
     ).toEqual({
       blocks: [
         {
@@ -382,6 +403,55 @@ describe("buildDiscordInteractiveComponents", () => {
               style: "secondary",
               internalCustomId: `ocq:id=${questionId};i=1`,
             },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("uses declared-choice indices when custom input is interleaved", () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    expect(
+      buildDiscordPresentationComponents(
+        {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                {
+                  label: "Production",
+                  action: { type: "question", questionId, optionValue: "Production" },
+                },
+                {
+                  label: "Other…",
+                  action: { type: "question", questionId, intent: "custom-input" },
+                },
+                {
+                  label: "Staging",
+                  action: { type: "question", questionId, optionValue: "Staging" },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          questionOptionIndices: new Map([
+            [
+              questionId,
+              new Map([
+                ["staging", 0],
+                ["production", 1],
+              ]),
+            ],
+          ]),
+        },
+      ),
+    ).toMatchObject({
+      blocks: [
+        {
+          buttons: [
+            { internalCustomId: `ocq:id=${questionId};i=1` },
+            { internalCustomId: `ocq:id=${questionId};i=0` },
           ],
         },
       ],

--- a/extensions/discord/src/shared-interactive.ts
+++ b/extensions/discord/src/shared-interactive.ts
@@ -13,6 +13,10 @@ import type {
   MessagePresentationOption,
   MessagePresentationSelectBlock,
 } from "openclaw/plugin-sdk/interactive-runtime";
+import {
+  resolveAskUserQuestionOptionIndex,
+  type AskUserQuestionOptionIndices,
+} from "openclaw/plugin-sdk/reply-payload";
 import { buildDiscordApprovalCustomId } from "./approval-custom-id.js";
 import {
   buildDiscordActivityCustomId,
@@ -58,7 +62,7 @@ const DISCORD_INTERACTIVE_BUTTON_ROW_SIZE = 5;
 
 function buildDiscordButtonComponent(
   button: MessagePresentationButton,
-  optionIndex: number,
+  options: DiscordPresentationBuildOptions,
 ): DiscordComponentButtonSpec | undefined {
   const action = resolveMessagePresentationButtonAction(button);
   if (!action) {
@@ -78,6 +82,14 @@ function buildDiscordButtonComponent(
   }
   if (action.type === "question") {
     if ("intent" in action) {
+      return undefined;
+    }
+    const optionIndex = resolveAskUserQuestionOptionIndex({
+      questionOptionIndices: options.questionOptionIndices,
+      questionId: action.questionId,
+      optionValue: action.optionValue,
+    });
+    if (optionIndex === undefined) {
       return undefined;
     }
     const internalCustomId = buildDiscordQuestionCustomId({
@@ -136,11 +148,12 @@ function buildDiscordButtonComponent(
 function appendDiscordButtonBlocks(
   blocks: NonNullable<DiscordComponentMessageSpec["blocks"]>,
   buttons: readonly MessagePresentationButton[],
+  options: DiscordPresentationBuildOptions,
 ): void {
-  // Index is position in the question's options; core emits one buttons block in option order.
-  const components = buttons
-    .map((button, optionIndex) => buildDiscordButtonComponent(button, optionIndex))
-    .filter((button): button is DiscordComponentButtonSpec => Boolean(button));
+  const components = buttons.flatMap((button) => {
+    const component = buildDiscordButtonComponent(button, options);
+    return component ? [component] : [];
+  });
   for (let index = 0; index < components.length; index += DISCORD_INTERACTIVE_BUTTON_ROW_SIZE) {
     blocks.push({
       type: "actions",
@@ -182,14 +195,21 @@ function appendDiscordSelectBlock(
  */
 export function buildDiscordInteractiveComponents(
   interactive?: LegacyInteractiveReply,
+  options: DiscordPresentationBuildOptions = {},
 ): DiscordComponentMessageSpec | undefined {
   return buildDiscordPresentationComponents(
     interactive ? legacyInteractiveReplyToPresentation(interactive) : undefined,
+    options,
   );
 }
 
+export type DiscordPresentationBuildOptions = {
+  questionOptionIndices?: AskUserQuestionOptionIndices;
+};
+
 export function buildDiscordPresentationComponents(
   presentation?: MessagePresentation,
+  options: DiscordPresentationBuildOptions = {},
 ): DiscordComponentMessageSpec | undefined {
   if (!presentation) {
     return undefined;
@@ -214,7 +234,7 @@ export function buildDiscordPresentationComponents(
       continue;
     }
     if (block.type === "buttons") {
-      appendDiscordButtonBlocks(blocks, block.buttons);
+      appendDiscordButtonBlocks(blocks, block.buttons, options);
       continue;
     }
     if (block.type === "select") {

--- a/extensions/discord/src/shared-interactive.ts
+++ b/extensions/discord/src/shared-interactive.ts
@@ -77,6 +77,9 @@ function buildDiscordButtonComponent(
     };
   }
   if (action.type === "question") {
+    if ("intent" in action) {
+      return undefined;
+    }
     const internalCustomId = buildDiscordQuestionCustomId({
       questionId: action.questionId,
       optionIndex,

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
@@ -420,6 +420,22 @@ export function buildAssistantText(input: ResponsesInputItem[], body: Record<str
   if (
     toolOutput &&
     /"status"\s*:\s*"answered"/.test(askUserResult) &&
+    /\bask_user_fixture=single\b/i.test(allInputText) &&
+    askUserDeploy
+  ) {
+    return `ASK-USER-SINGLE-OK | deploy=${askUserDeploy}`;
+  }
+  if (
+    toolOutput &&
+    /"status"\s*:\s*"answered"/.test(askUserResult) &&
+    /\bask_user_fixture=multi\b/i.test(allInputText) &&
+    askUserChecks
+  ) {
+    return `ASK-USER-MULTI-OK | checks=${askUserChecks}`;
+  }
+  if (
+    toolOutput &&
+    /"status"\s*:\s*"answered"/.test(askUserResult) &&
     askUserDeploy &&
     askUserChecks &&
     askUserNote

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
@@ -237,6 +237,7 @@ export function toolSearchOutputHasCandidate(output: unknown, targetTool: string
 export function buildQaToolSearchArgs(
   targetTool: string,
   failureMode: boolean,
+  prompt = "",
 ): Record<string, unknown> {
   if (failureMode && targetTool === "web_search") {
     return { query: QA_LAB_WEB_SEARCH_DENIED_INPUT_QUERY };
@@ -304,6 +305,40 @@ export function buildQaToolSearchArgs(
     };
   }
   if (targetTool === "ask_user") {
+    if (/\bask_user_fixture=single\b/i.test(prompt)) {
+      return {
+        questions: [
+          {
+            id: "deploy_target",
+            header: "Deploy",
+            question: "Where should this deploy?",
+            options: [
+              { label: "Staging (Recommended)", description: "Safer default" },
+              { label: "Production 🚀", description: "Ship to users" },
+            ],
+          },
+        ],
+        timeoutSeconds: 60,
+      };
+    }
+    if (/\bask_user_fixture=multi\b/i.test(prompt)) {
+      return {
+        questions: [
+          {
+            id: "checks",
+            header: "Checks",
+            question: "Which checks should run?",
+            options: [
+              { label: "Unit (Recommended)", description: "Fast focused coverage" },
+              { label: "E2E", description: "Full user-path coverage" },
+              { label: "Lint", description: "Static checks" },
+            ],
+            multiSelect: true,
+          },
+        ],
+        timeoutSeconds: 60,
+      };
+    }
     return {
       questions: [
         {

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -5582,6 +5582,35 @@ Update and merge these partial structured summaries.`,
     );
   });
 
+  it.each([
+    {
+      fixture: "single",
+      expectedQuestionId: "deploy_target",
+      expectedMultiSelect: undefined,
+    },
+    { fixture: "multi", expectedQuestionId: "checks", expectedMultiSelect: true },
+  ])("plans the $fixture ask_user Telegram fixture", async (entry) => {
+    const server = await startMockServer();
+    const response = await expectNonStreamingResponses(server, {
+      input: [
+        makeUserInput(
+          `tool search qa check target=ask_user ask_user_fixture=${entry.fixture}. Ask the question.`,
+        ),
+      ],
+    });
+
+    const call = outputItem(await response.json());
+    const args = JSON.parse(String(call.arguments)) as {
+      questions?: Array<{ id?: string; multiSelect?: boolean }>;
+    };
+    expect(call.name).toBe("ask_user");
+    expect(args.questions).toHaveLength(1);
+    expect(args.questions?.[0]).toMatchObject({
+      id: entry.expectedQuestionId,
+      ...(entry.expectedMultiSelect ? { multiSelect: true } : {}),
+    });
+  });
+
   it("plans QA tool-search failure calls with denied-input args", async () => {
     const server = await startMockServer();
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1101,7 +1101,11 @@ async function buildResponsesPayload(
   ) {
     const targetTool = extractToolSearchTarget(allInputText);
     const plannedArgs = targetTool
-      ? buildQaToolSearchArgs(targetTool, QA_TOOL_SEARCH_FAILURE_PROMPT_RE.test(allInputText))
+      ? buildQaToolSearchArgs(
+          targetTool,
+          QA_TOOL_SEARCH_FAILURE_PROMPT_RE.test(allInputText),
+          allInputText,
+        )
       : {};
     if (
       targetTool &&

--- a/extensions/slack/src/blocks-render.ts
+++ b/extensions/slack/src/blocks-render.ts
@@ -14,6 +14,10 @@ import type {
   MessagePresentationChartBlock,
   MessagePresentationSelectBlock,
 } from "openclaw/plugin-sdk/interactive-runtime";
+import {
+  resolveAskUserQuestionOptionIndex,
+  type AskUserQuestionOptionIndices,
+} from "openclaw/plugin-sdk/reply-payload";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
 import { encodeSlackApprovalAction } from "./approval-actions.js";
@@ -61,6 +65,7 @@ export type SlackBlockRenderOptions = {
   buttonIndexOffset?: number;
   dataTableCellCharacterCountOffset?: number;
   dataVisualizationCountOffset?: number;
+  questionOptionIndices?: AskUserQuestionOptionIndices;
   selectIndexOffset?: number;
 };
 
@@ -117,7 +122,7 @@ type SlackActionTarget =
 
 function resolveSlackActionTarget(
   action: MessagePresentationAction | undefined,
-  optionIndex?: number,
+  questionOptionIndices?: AskUserQuestionOptionIndices,
 ): SlackActionTarget | undefined {
   if (!action) {
     return undefined;
@@ -129,6 +134,11 @@ function resolveSlackActionTarget(
     if ("intent" in action) {
       return undefined;
     }
+    const optionIndex = resolveAskUserQuestionOptionIndex({
+      questionOptionIndices,
+      questionId: action.questionId,
+      optionValue: action.optionValue,
+    });
     const value =
       optionIndex === undefined
         ? undefined
@@ -153,11 +163,11 @@ function resolveSlackActionTarget(
 
 function resolveSlackButtonTarget(
   button: MessagePresentationButtonsBlock["buttons"][number],
-  optionIndex?: number,
+  questionOptionIndices?: AskUserQuestionOptionIndices,
 ): SlackActionTarget | undefined {
   if (button.action !== undefined) {
     const action = resolveMessagePresentationButtonAction(button);
-    return action ? resolveSlackActionTarget(action, optionIndex) : undefined;
+    return action ? resolveSlackActionTarget(action, questionOptionIndices) : undefined;
   }
 
   // Legacy buttons could carry both a URL and callback fallback. Preserve the
@@ -173,6 +183,15 @@ function resolveSlackButtonTarget(
     return { kind: "reply", value: legacyValue };
   }
   return legacyUrl ? { kind: "link", url: legacyUrl } : undefined;
+}
+
+function isSlackTextFallbackButton(
+  button: MessagePresentationButtonsBlock["buttons"][number],
+): boolean {
+  // ask_user already names the free-text path in visible copy. Omitting only
+  // this action keeps declared choices native without a composer hook.
+  const action = resolveMessagePresentationButtonAction(button);
+  return action?.type === "question" && "intent" in action && action.intent === "custom-input";
 }
 
 function resolveSlackOptionTarget(
@@ -302,7 +321,11 @@ export function buildSlackPresentationBlocks(
       continue;
     }
     if (block.type === "buttons") {
-      const rendered = buildSlackPresentationButtonBlock(block, buttonIndex + 1);
+      const rendered = buildSlackPresentationButtonBlock(
+        block,
+        buttonIndex + 1,
+        options.questionOptionIndices,
+      );
       if (rendered) {
         buttonIndex += 1;
         blocks.push(rendered);
@@ -363,10 +386,11 @@ function buildSlackPresentationChartBlock(
 function buildSlackPresentationButtonBlock(
   block: MessagePresentationButtonsBlock,
   buttonIndex: number,
+  questionOptionIndices?: AskUserQuestionOptionIndices,
 ): SlackBlock | undefined {
   const elements = block.buttons
     .flatMap((button, choiceIndex) => {
-      const target = resolveSlackButtonTarget(button, choiceIndex);
+      const target = resolveSlackButtonTarget(button, questionOptionIndices);
       if (
         !target ||
         (target.kind === "link"
@@ -448,19 +472,23 @@ export function canRenderSlackPresentation(
       continue;
     }
     if (block.type === "buttons") {
+      let nativeButtonCount = 0;
       const allButtonsRenderable =
-        block.buttons.length <= SLACK_ACTION_BLOCK_ELEMENTS_MAX &&
-        block.buttons.every((button, choiceIndex) => {
+        block.buttons.every((button) => {
+          if (isSlackTextFallbackButton(button)) {
+            return true;
+          }
+          nativeButtonCount += 1;
           if (!isWithinSlackLimit(button.label, SLACK_ACTION_LABEL_MAX)) {
             return false;
           }
-          const target = resolveSlackButtonTarget(button, choiceIndex);
+          const target = resolveSlackButtonTarget(button, options.questionOptionIndices);
           return target
             ? target.kind === "link"
               ? isWithinSlackLimit(target.url, SLACK_BUTTON_URL_MAX)
               : isWithinSlackLimit(target.value, SLACK_BUTTON_VALUE_MAX)
             : false;
-        });
+        }) && nativeButtonCount <= SLACK_ACTION_BLOCK_ELEMENTS_MAX;
       if (!allButtonsRenderable) {
         return false;
       }

--- a/extensions/slack/src/blocks-render.ts
+++ b/extensions/slack/src/blocks-render.ts
@@ -126,6 +126,9 @@ function resolveSlackActionTarget(
     return { kind: "approval", value: encodeSlackApprovalAction(action) };
   }
   if (action.type === "question") {
+    if ("intent" in action) {
+      return undefined;
+    }
     const value =
       optionIndex === undefined
         ? undefined

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -1764,6 +1764,7 @@ describe("slackPlugin outbound", () => {
         text: "",
         mediaUrls: ["https://example.com/context.png"],
         channelData: {
+          askUser: { questionId, optionValues: ["one", "two"] },
           slack: { blocks: Array.from({ length: 48 }, () => ({ type: "divider" as const })) },
         },
         presentation: {

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -823,6 +823,7 @@ vi.mock("openclaw/plugin-sdk/reply-history", () => ({
 }));
 
 vi.mock("openclaw/plugin-sdk/reply-payload", () => ({
+  resolveAskUserQuestionOptionIndices: () => undefined,
   isReplyPayloadNonTerminalToolErrorWarning: () => false,
   buildTtsSupplementMediaPayload: (payload: {
     text?: string;

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -38,8 +38,12 @@ describe("slackOutbound", () => {
           type: "buttons" as const,
           buttons: [
             {
-              label: "Continue",
-              action: { type: "question" as const, questionId, optionValue: "Continue" },
+              label: "Production",
+              action: { type: "question" as const, questionId, optionValue: "Production" },
+            },
+            {
+              label: "Staging",
+              action: { type: "question" as const, questionId, optionValue: "Staging" },
             },
           ],
         },
@@ -47,7 +51,7 @@ describe("slackOutbound", () => {
     };
     const payload = {
       channelData: {
-        askUser: { questionId },
+        askUser: { questionId, optionValues: ["Staging", "Production"] },
         slack: { blocks: Array.from({ length: 49 }, () => ({ type: "divider" as const })) },
       },
       presentation,
@@ -64,7 +68,10 @@ describe("slackOutbound", () => {
     expect(sendMessageSlackMock).toHaveBeenCalledOnce();
     expect(sendMessageSlackMock.mock.calls[0]?.[2]?.blocks).toHaveLength(50);
     expect(sendMessageSlackMock.mock.calls[0]?.[2]?.blocks.at(-1)).toMatchObject({
-      elements: [{ action_id: "openclaw:question_button:1:1" }],
+      elements: [
+        { action_id: "openclaw:question_button:1:1", value: `slq1:${questionId}:1` },
+        { action_id: "openclaw:question_button:1:2", value: `slq1:${questionId}:0` },
+      ],
     });
   });
 

--- a/extensions/slack/src/question-finalization.test.ts
+++ b/extensions/slack/src/question-finalization.test.ts
@@ -59,7 +59,7 @@ describe("Slack question finalization", () => {
     const questionId = "ask_0123456789abcdef0123456789abcdef";
     const headers = Array.from({ length: 21 }, (_value, index) => `Column ${String(index)}`);
     const payload = {
-      channelData: { askUser: { questionId } },
+      channelData: { askUser: { questionId, optionValues: ["One", "Two"] } },
       presentation: {
         blocks: [
           {
@@ -146,7 +146,7 @@ describe("Slack question finalization", () => {
     const payload = {
       text: "Pick one",
       mediaUrl: "https://example.invalid/question-context.png",
-      channelData: { askUser: { questionId } },
+      channelData: { askUser: { questionId, optionValues: ["One", "Two"] } },
       presentation: {
         blocks: [
           {
@@ -220,7 +220,7 @@ describe("Slack question finalization", () => {
     const payload = {
       text: "Pick one",
       mediaUrl: "https://example.invalid/question-context.png",
-      channelData: { askUser: { questionId } },
+      channelData: { askUser: { questionId, optionValues: ["One", "Two"] } },
       presentation: {
         blocks: [
           {
@@ -318,7 +318,7 @@ describe("Slack question finalization", () => {
     const cfg = { channels: { slack: { botToken: "xoxb-test" } } };
     const payload = {
       text: "Pick one",
-      channelData: { askUser: { questionId } },
+      channelData: { askUser: { questionId, optionValues: ["One", "Two"] } },
       presentation: {
         blocks: [
           {

--- a/extensions/slack/src/reply-blocks.test.ts
+++ b/extensions/slack/src/reply-blocks.test.ts
@@ -600,6 +600,12 @@ describe("renderSlackMessagePresentationFallbackText", () => {
     } satisfies MessagePresentation;
 
     const { segments } = resolveSlackReplyBlockResolution({
+      channelData: {
+        askUser: {
+          questionId: "ask_0123456789abcdef0123456789abcdef",
+          optionValues: ["Question", "Unused"],
+        },
+      },
       presentation,
       interactive: presentationToInteractiveControlsReply(presentation),
     });

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -4,7 +4,11 @@ import {
   type MessagePresentation,
 } from "openclaw/plugin-sdk/interactive-runtime";
 // Slack plugin module implements reply blocks behavior.
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import {
+  resolveAskUserQuestionOptionIndices,
+  type AskUserQuestionOptionIndices,
+  type ReplyPayload,
+} from "openclaw/plugin-sdk/reply-payload";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   resolveSlackAuthoredTextPlacement,
@@ -326,21 +330,22 @@ function renderNativePresentation(
 function appendPresentationPart(
   segments: SlackReplyBlockSegment[],
   presentation: MessagePresentation,
+  questionOptionIndices?: AskUserQuestionOptionIndices,
 ): void {
   const currentBlocks = readLastBlockSegment(segments);
-  const currentRendered = renderNativePresentation(
-    presentation,
-    resolvePresentationRenderOptions(segments, "current"),
-  );
+  const currentRendered = renderNativePresentation(presentation, {
+    ...resolvePresentationRenderOptions(segments, "current"),
+    questionOptionIndices,
+  });
   if (currentRendered && currentBlocks.length + currentRendered.length <= SLACK_MAX_BLOCKS) {
     appendBlockSegment(segments, currentRendered);
     return;
   }
 
-  const freshRendered = renderNativePresentation(
-    presentation,
-    resolvePresentationRenderOptions(segments, "new-message"),
-  );
+  const freshRendered = renderNativePresentation(presentation, {
+    ...resolvePresentationRenderOptions(segments, "new-message"),
+    questionOptionIndices,
+  });
   if (freshRendered) {
     appendBlockSegment(segments, freshRendered, true);
     return;
@@ -461,19 +466,24 @@ export function resolveSlackReplyBlockResolution(
   }
 
   const presentation = normalizeMessagePresentation(payload.presentation);
+  const questionOptionIndices = resolveAskUserQuestionOptionIndices(payload);
   const presentationBlockOffset = readAllNativeBlocks(segments).length;
   if (presentation?.title) {
-    appendPresentationPart(segments, { title: presentation.title, blocks: [] });
+    appendPresentationPart(
+      segments,
+      { title: presentation.title, blocks: [] },
+      questionOptionIndices,
+    );
   }
   for (const block of presentation?.blocks ?? []) {
-    appendPresentationPart(segments, { blocks: [block] });
+    appendPresentationPart(segments, { blocks: [block] }, questionOptionIndices);
   }
   const renderedPresentationBlocks = readAllNativeBlocks(segments).slice(presentationBlockOffset);
 
-  const interactiveBlocks = buildSlackInteractiveBlocks(
-    payload.interactive,
-    resolveSlackBlockOffsets(readAllNativeBlocks(segments)),
-  );
+  const interactiveBlocks = buildSlackInteractiveBlocks(payload.interactive, {
+    ...resolveSlackBlockOffsets(readAllNativeBlocks(segments)),
+    questionOptionIndices,
+  });
   // Compare final Slack rows, not source payloads: fallbacks and transport
   // limits can prevent an apparent source mirror from rendering at all.
   appendBlockSegment(

--- a/extensions/slack/src/shared-interactive.test.ts
+++ b/extensions/slack/src/shared-interactive.test.ts
@@ -399,7 +399,13 @@ describe("buildSlackInteractiveBlocks", () => {
       expect(
         buildSlackInteractiveBlocks(
           { blocks: [{ type: "buttons", buttons: [{ label: "Continue", action }] }] },
-          { buttonIndexOffset: 4 },
+          {
+            buttonIndexOffset: 4,
+            questionOptionIndices:
+              action.type === "question"
+                ? new Map([[action.questionId, new Map([[action.optionValue.toLowerCase(), 0]])]])
+                : undefined,
+          },
         ),
       ).toMatchObject([
         {
@@ -440,17 +446,30 @@ describe("buildSlackPresentationBlocks", () => {
   it("renders question choices with compact private indices", () => {
     const questionId = "ask_0123456789abcdef0123456789abcdef";
     expect(
-      buildSlackPresentationBlocks({
-        blocks: [
-          {
-            type: "buttons",
-            buttons: ["Staging", "Production"].map((label) => ({
-              label,
-              action: { type: "question" as const, questionId, optionValue: label },
-            })),
-          },
-        ],
-      }),
+      buildSlackPresentationBlocks(
+        {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: ["Staging", "Production"].map((label) => ({
+                label,
+                action: { type: "question" as const, questionId, optionValue: label },
+              })),
+            },
+          ],
+        },
+        {
+          questionOptionIndices: new Map([
+            [
+              questionId,
+              new Map([
+                ["staging", 0],
+                ["production", 1],
+              ]),
+            ],
+          ]),
+        },
+      ),
     ).toEqual([
       {
         type: "actions",
@@ -464,6 +483,55 @@ describe("buildSlackPresentationBlocks", () => {
             action_id: "openclaw:question_button:1:2",
             value: `slq1:${questionId}:1`,
           }),
+        ],
+      },
+    ]);
+  });
+
+  it("keeps question choices native when custom input stays on the text path", () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const presentation: MessagePresentation = {
+      blocks: [
+        { type: "text", text: "Tap a choice, or reply with your own answer." },
+        {
+          type: "buttons",
+          buttons: [
+            {
+              label: "Production",
+              action: { type: "question" as const, questionId, optionValue: "Production" },
+            },
+            {
+              label: "Other…",
+              action: { type: "question" as const, questionId, intent: "custom-input" as const },
+            },
+            {
+              label: "Staging",
+              action: { type: "question" as const, questionId, optionValue: "Staging" },
+            },
+          ],
+        },
+      ],
+    };
+
+    const renderOptions = {
+      questionOptionIndices: new Map([
+        [
+          questionId,
+          new Map([
+            ["staging", 0],
+            ["production", 1],
+          ]),
+        ],
+      ]),
+    };
+    expect(canRenderSlackPresentation(presentation, renderOptions)).toBe(true);
+    expect(buildSlackPresentationBlocks(presentation, renderOptions)).toMatchObject([
+      { type: "section" },
+      {
+        type: "actions",
+        elements: [
+          { action_id: "openclaw:question_button:1:1", value: `slq1:${questionId}:1` },
+          { action_id: "openclaw:question_button:1:3", value: `slq1:${questionId}:0` },
         ],
       },
     ]);

--- a/extensions/telegram/src/bot-handlers.callback-actions.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.ts
@@ -136,31 +136,46 @@ type ResolveQuestionParams = Parameters<typeof questionGatewayRuntime.resolveOpt
 type QuestionResolver = (
   params: ResolveQuestionParams,
 ) => ReturnType<typeof questionGatewayRuntime.resolveOption>;
+type QuestionFeedbackMode = "terminal" | "retry" | "custom-input";
 
 export async function handleTelegramQuestionCallback(params: {
   callback: TelegramQuestionCallback;
   cfg: ResolveQuestionParams["cfg"];
   senderId: string;
-  feedback: (text: string, terminal: boolean) => Promise<unknown>;
+  feedback: (text: string, mode: QuestionFeedbackMode) => Promise<unknown>;
   resolveQuestion?: QuestionResolver;
 }): Promise<void> {
-  let result: Awaited<ReturnType<QuestionResolver>>;
   try {
-    result = await (params.resolveQuestion ?? questionGatewayRuntime.resolveOption)({
+    if (params.callback.intent === "custom-input") {
+      const result = await (params.resolveQuestion ?? questionGatewayRuntime.resolveOption)({
+        cfg: params.cfg,
+        questionId: params.callback.questionId,
+        customInput: true,
+        senderId: params.senderId,
+        clientDisplayName: "Telegram question",
+      });
+      if (result.status === "already-terminal") {
+        await params.feedback("This question was already answered.", "terminal");
+        return;
+      }
+      await params.feedback("Reply with your own answer.", "custom-input");
+      return;
+    }
+    const result = await (params.resolveQuestion ?? questionGatewayRuntime.resolveOption)({
       cfg: params.cfg,
       questionId: params.callback.questionId,
       optionIndex: params.callback.optionIndex,
       senderId: params.senderId,
       clientDisplayName: "Telegram question",
     });
+    await params
+      .feedback(
+        result.status === "answered" ? "Answer submitted." : "This question was already answered.",
+        "terminal",
+      )
+      .catch(() => {});
   } catch (error) {
-    await params.feedback("Could not submit this answer.", false).catch(() => {});
+    await params.feedback("Could not submit this answer.", "retry").catch(() => {});
     throw error;
   }
-  await params
-    .feedback(
-      result.status === "answered" ? "Answer submitted." : "This question was already answered.",
-      true,
-    )
-    .catch(() => {});
 }

--- a/extensions/telegram/src/bot-handlers.callback-actions.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.ts
@@ -1,4 +1,4 @@
-import type { Message } from "grammy/types";
+import type { Message, User } from "grammy/types";
 import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
 import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
@@ -137,6 +137,48 @@ type QuestionResolver = (
   params: ResolveQuestionParams,
 ) => ReturnType<typeof questionGatewayRuntime.resolveOption>;
 type QuestionFeedbackMode = "terminal" | "retry" | "custom-input";
+
+export async function sendTelegramQuestionFeedback(params: {
+  actions: TelegramCallbackMessageActions;
+  text: string;
+  mode: QuestionFeedbackMode;
+  isGroup: boolean;
+  user: User;
+}): Promise<void> {
+  if (params.mode === "terminal") {
+    await params.actions.clearCallbackButtons().catch(() => {});
+  }
+  const groupCustomInput = params.mode === "custom-input" && params.isGroup;
+  const text = groupCustomInput
+    ? `${params.user.first_name}, reply with your own answer.`
+    : params.text;
+  await params.actions.replyToCallbackChat(
+    text,
+    params.mode === "custom-input"
+      ? {
+          ...(groupCustomInput
+            ? {
+                // Selective Force Reply targets mentioned users or the sender of the
+                // replied-to message. The question is bot-authored, so mention the tapper.
+                entities: [
+                  {
+                    type: "text_mention" as const,
+                    offset: 0,
+                    length: params.user.first_name.length,
+                    user: params.user,
+                  },
+                ],
+              }
+            : {}),
+          reply_markup: { force_reply: true, selective: groupCustomInput },
+        }
+      : undefined,
+  );
+  if (params.mode === "custom-input") {
+    // Keep the existing answer route until Telegram accepts its replacement.
+    await params.actions.clearCallbackButtons().catch(() => {});
+  }
+}
 
 export async function handleTelegramQuestionCallback(params: {
   callback: TelegramQuestionCallback;

--- a/extensions/telegram/src/bot-handlers.callback-questions.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.callback-questions.runtime.test.ts
@@ -1,12 +1,70 @@
 // Telegram question callback feedback tests.
 import { describe, expect, it, vi } from "vitest";
-import { handleTelegramQuestionCallback } from "./bot-handlers.callback-actions.js";
+import {
+  handleTelegramQuestionCallback,
+  sendTelegramQuestionFeedback,
+  type TelegramCallbackMessageActions,
+} from "./bot-handlers.callback-actions.js";
 
 const callback = {
   questionId: "ask_0123456789abcdef0123456789abcdef",
   intent: "select" as const,
   optionIndex: 1,
 };
+
+function createCallbackActions(): TelegramCallbackMessageActions {
+  const clearCallbackButtons = vi.fn<TelegramCallbackMessageActions["clearCallbackButtons"]>();
+  clearCallbackButtons.mockResolvedValue(true);
+  return {
+    editCallbackMessage: vi.fn<TelegramCallbackMessageActions["editCallbackMessage"]>(),
+    clearCallbackButtons,
+    editCallbackButtons: vi.fn<TelegramCallbackMessageActions["editCallbackButtons"]>(),
+    editCallbackMessageWithButtons:
+      vi.fn<TelegramCallbackMessageActions["editCallbackMessageWithButtons"]>(),
+    deleteCallbackMessage: vi.fn<TelegramCallbackMessageActions["deleteCallbackMessage"]>(),
+    replyToCallbackChat: vi.fn<TelegramCallbackMessageActions["replyToCallbackChat"]>(),
+  };
+}
+
+describe("sendTelegramQuestionFeedback", () => {
+  it("sends the custom-input prompt before retiring question controls", async () => {
+    const actions = createCallbackActions();
+
+    await sendTelegramQuestionFeedback({
+      actions,
+      text: "Reply with your own answer.",
+      mode: "custom-input",
+      isGroup: false,
+      user: { id: 42, is_bot: false, first_name: "Ayaan" },
+    });
+
+    const [replyOrder] = actions.replyToCallbackChat.mock.invocationCallOrder;
+    const [clearOrder] = actions.clearCallbackButtons.mock.invocationCallOrder;
+    expect(replyOrder).toBeDefined();
+    expect(clearOrder).toBeDefined();
+    if (replyOrder === undefined || clearOrder === undefined) {
+      throw new Error("Expected both custom-input feedback operations");
+    }
+    expect(replyOrder).toBeLessThan(clearOrder);
+  });
+
+  it("keeps question controls when Telegram rejects the custom-input prompt", async () => {
+    const actions = createCallbackActions();
+    actions.replyToCallbackChat.mockRejectedValue(new Error("send rejected"));
+
+    await expect(
+      sendTelegramQuestionFeedback({
+        actions,
+        text: "Reply with your own answer.",
+        mode: "custom-input",
+        isGroup: false,
+        user: { id: 42, is_bot: false, first_name: "Ayaan" },
+      }),
+    ).rejects.toThrow("send rejected");
+
+    expect(actions.clearCallbackButtons).not.toHaveBeenCalled();
+  });
+});
 
 describe("handleTelegramQuestionCallback", () => {
   it.each([

--- a/extensions/telegram/src/bot-handlers.callback-questions.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.callback-questions.runtime.test.ts
@@ -4,6 +4,7 @@ import { handleTelegramQuestionCallback } from "./bot-handlers.callback-actions.
 
 const callback = {
   questionId: "ask_0123456789abcdef0123456789abcdef",
+  intent: "select" as const,
   optionIndex: 1,
 };
 
@@ -26,7 +27,7 @@ describe("handleTelegramQuestionCallback", () => {
       resolveQuestion,
     });
 
-    expect(feedback).toHaveBeenCalledWith(expectedText, true);
+    expect(feedback).toHaveBeenCalledWith(expectedText, "terminal");
   });
 
   it("does not turn a committed answer into an error when feedback fails", async () => {
@@ -48,6 +49,23 @@ describe("handleTelegramQuestionCallback", () => {
       }),
     ).resolves.toBeUndefined();
     expect(feedback).toHaveBeenCalledOnce();
-    expect(feedback).toHaveBeenCalledWith("Answer submitted.", true);
+    expect(feedback).toHaveBeenCalledWith("Answer submitted.", "terminal");
+  });
+
+  it("switches an active question to Telegram force-reply input", async () => {
+    const feedback = vi.fn(async () => undefined);
+
+    await handleTelegramQuestionCallback({
+      callback: { questionId: callback.questionId, intent: "custom-input" },
+      cfg: {} as never,
+      senderId: "42",
+      feedback,
+      resolveQuestion: vi.fn(async () => ({
+        status: "custom-input" as const,
+        questionId: "target",
+      })),
+    });
+
+    expect(feedback).toHaveBeenCalledWith("Reply with your own answer.", "custom-input");
   });
 });

--- a/extensions/telegram/src/bot-handlers.callback-questions.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.callback-questions.runtime.test.ts
@@ -12,7 +12,7 @@ const callback = {
   optionIndex: 1,
 };
 
-function createCallbackActions(): TelegramCallbackMessageActions {
+function createCallbackActions() {
   const clearCallbackButtons = vi.fn<TelegramCallbackMessageActions["clearCallbackButtons"]>();
   clearCallbackButtons.mockResolvedValue(true);
   return {
@@ -23,7 +23,7 @@ function createCallbackActions(): TelegramCallbackMessageActions {
       vi.fn<TelegramCallbackMessageActions["editCallbackMessageWithButtons"]>(),
     deleteCallbackMessage: vi.fn<TelegramCallbackMessageActions["deleteCallbackMessage"]>(),
     replyToCallbackChat: vi.fn<TelegramCallbackMessageActions["replyToCallbackChat"]>(),
-  };
+  } satisfies TelegramCallbackMessageActions;
 }
 
 describe("sendTelegramQuestionFeedback", () => {

--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -294,11 +294,19 @@ export function createTelegramCallbackRouter({
           callback: typedQuestionCallback,
           cfg: runtimeCfg,
           senderId,
-          feedback: async (text, terminal) => {
-            if (terminal) {
+          feedback: async (text, mode) => {
+            if (mode === "terminal" || mode === "custom-input") {
               await actions.clearCallbackButtons().catch(() => {});
             }
-            await actions.replyToCallbackChat(text);
+            await actions.replyToCallbackChat(
+              text,
+              mode === "custom-input"
+                ? {
+                    reply_markup: { force_reply: true, selective: true },
+                    reply_parameters: { message_id: callbackMessage.message_id },
+                  }
+                : undefined,
+            );
           },
         });
         return;

--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -17,6 +17,7 @@ import { resolveAgentDir, resolveDefaultModelForAgent } from "./bot-handlers.age
 import {
   createTelegramCallbackMessageActions,
   handleTelegramQuestionCallback,
+  sendTelegramQuestionFeedback,
   type TelegramCallbackMessageActions,
 } from "./bot-handlers.callback-actions.js";
 import {
@@ -294,20 +295,14 @@ export function createTelegramCallbackRouter({
           callback: typedQuestionCallback,
           cfg: runtimeCfg,
           senderId,
-          feedback: async (text, mode) => {
-            if (mode === "terminal" || mode === "custom-input") {
-              await actions.clearCallbackButtons().catch(() => {});
-            }
-            await actions.replyToCallbackChat(
+          feedback: async (text, mode) =>
+            await sendTelegramQuestionFeedback({
+              actions,
               text,
-              mode === "custom-input"
-                ? {
-                    reply_markup: { force_reply: true, selective: true },
-                    reply_parameters: { message_id: callbackMessage.message_id },
-                  }
-                : undefined,
-            );
-          },
+              mode,
+              isGroup,
+              user: callback.from,
+            }),
         });
         return;
       }

--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -6,6 +6,7 @@ import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-ru
 import {
   isFastModeAutoProgressPayload,
   isReplyPayloadNonTerminalToolErrorWarning,
+  resolveAskUserQuestionOptionIndices,
   resolveSendableOutboundReplyParts,
   type ReplyPayload,
 } from "openclaw/plugin-sdk/reply-payload";
@@ -44,7 +45,6 @@ import type {
 import {
   appendTelegramDroppedControlFallback,
   resolveTelegramInlineButtons,
-  resolveTelegramQuestionOptionIndices,
   type TelegramDroppedControl,
   type TelegramInlineButtons,
 } from "./button-types.js";
@@ -108,7 +108,7 @@ function resolvePayloadTelegramControls(
     {
       allowWebAppButtons: resolveTelegramTargetChatType(String(turn.context.chatId)) === "direct",
       onDroppedControl: (control) => droppedControls.push(control),
-      questionOptionIndices: resolveTelegramQuestionOptionIndices(payload),
+      questionOptionIndices: resolveAskUserQuestionOptionIndices(payload),
     },
   );
   const text = appendTelegramDroppedControlFallback(payload.text ?? "", droppedControls);
@@ -425,7 +425,7 @@ export async function deliverReply(
             payload: lanePayload,
             infoKind: info.kind,
             buttons: telegramButtons,
-            finalizePreview: isAskUserPayload,
+            ...(isAskUserPayload ? { finalizePreview: true } : {}),
             allowStream: !isDurableProgressCommentary,
             onPlatformSendDispatch: info.onPlatformSendDispatch,
             bindPendingFinalDelivery: info.bindPendingFinalDelivery,

--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -408,6 +408,7 @@ export async function deliverReply(
       turn.activeAnswerDraftIsToolProgressOnly = false;
       turn.progressCompositor.reset();
     }
+    const isAskUserPayload = effectivePayload.channelData?.askUser !== undefined;
     const result =
       segment.lane === "answer" && info.kind === "final"
         ? await deliverFinalAnswerText(
@@ -424,6 +425,7 @@ export async function deliverReply(
             payload: lanePayload,
             infoKind: info.kind,
             buttons: telegramButtons,
+            finalizePreview: isAskUserPayload,
             allowStream: !isDurableProgressCommentary,
             onPlatformSendDispatch: info.onPlatformSendDispatch,
             bindPendingFinalDelivery: info.bindPendingFinalDelivery,
@@ -434,12 +436,11 @@ export async function deliverReply(
       (result.kind === "preview-finalized" || result.kind === "preview-finalized-partial");
     if (finalizedPreview) {
       await handlePreviewFinalizedResult(turn, result);
-    }
-    if (segment.lane === "answer" && info.kind === "tool" && result.kind === "preview-updated") {
-      const messageId = turn.answerLane.stream?.messageId();
-      const text = turn.answerLane.stream?.lastDeliveredText?.();
-      if (typeof messageId === "number" && text) {
-        registerTelegramQuestionDeliveryForMessage(turn, effectivePayload, { messageId, text });
+      if (isAskUserPayload && result.kind === "preview-finalized") {
+        registerTelegramQuestionDeliveryForMessage(turn, effectivePayload, {
+          messageId: result.delivery.messageId,
+          text: result.delivery.content,
+        });
       }
     }
     if (segment.lane === "answer" && info.kind === "block" && result.kind === "preview-updated") {

--- a/extensions/telegram/src/bot-message-dispatch.draft-rotation.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-rotation.test.ts
@@ -376,7 +376,6 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
     const firstPayload = {
       text: "Pick one",
       channelData: {
-        askUser: { questionId },
         telegram: { buttons: [[{ text: "One", callback_data: `tgq1:${questionId}:0` }]] },
       },
     };

--- a/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
@@ -437,30 +437,38 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
     expectDeliveredReply(0, { text: "Post-processing failed", isError: true });
   });
 
-  it("registers a streamed ask_user on its concrete message exactly once", async () => {
+  it("finalizes a streamed ask_user before later progress can replace it", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     const buttons = [[{ text: "One", callback_data: "ask:one" }]];
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
-      await dispatcherOptions.deliver(
-        {
-          text: "Pick one",
-          channelData: {
-            askUser: { questionId: "ask_0123456789abcdef0123456789abcdef" },
-            telegram: { buttons },
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await dispatcherOptions.deliver(
+          {
+            text: "Pick one",
+            channelData: {
+              askUser: { questionId: "ask_0123456789abcdef0123456789abcdef" },
+              telegram: { buttons },
+            },
           },
-        },
-        { kind: "tool" },
-      );
-      return { queuedFinal: true };
-    });
+          { kind: "tool" },
+        );
+        await replyOptions?.onToolStart?.({ name: "wait", phase: "start" });
+        return { queuedFinal: true };
+      },
+    );
 
     await dispatchWithContext({ context: createContext(), textLimit: 80 });
 
-    expect(answerDraftStream.update).toHaveBeenCalledWith("Pick one");
+    expect(answerDraftStream.update).toHaveBeenCalledWith(
+      "Pick one",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
     expect(mockCallArg(editMessageTelegram)).toBe(123);
     expect(mockCallArg(editMessageTelegram, 0, 1)).toBe(2001);
     expect(mockCallArg(editMessageTelegram, 0, 2)).toBe("Pick one");
     expectRecordFields(mockCallArg(editMessageTelegram, 0, 3), { buttons });
+    expect(answerDraftStream.stop).toHaveBeenCalled();
+    expect(answerDraftStream.updatePreview).not.toHaveBeenCalled();
     expect(deliverReplies).not.toHaveBeenCalled();
     expect(registerChannelDelivery).toHaveBeenCalledOnce();
     const registration = mockCallArg(registerChannelDelivery) as {
@@ -496,7 +504,10 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
 
     await dispatchWithContext({ context: createContext(), streamMode: "progress" });
 
-    expect(answerDraftStream.update).toHaveBeenCalledWith("Pick one or more");
+    expect(answerDraftStream.update).toHaveBeenCalledWith(
+      "Pick one or more",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
     expect(registerChannelDelivery).toHaveBeenCalledOnce();
   });
 

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -1804,6 +1804,37 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-question-blocked");
   });
 
+  it("targets the group member who requests custom question input", async () => {
+    const config = makeTelegramConfig({
+      dmPolicy: "open",
+      allowFrom: ["9"],
+      capabilities: { inlineButtons: "all" },
+      groupPolicy: "open",
+      groups: { "*": { requireMention: false, allowFrom: ["9"] } },
+    });
+    loadConfig.mockReturnValue(config);
+    createTelegramBot({ token: "tok", config });
+    const callbackHandler = getTelegramCallbackHandlerForTests();
+    const from = { id: 9, is_bot: false, first_name: "Ada", username: "ada_bot" };
+
+    await callbackHandler(
+      createTelegramCallbackContext({
+        id: "cbq-question-other",
+        data: "tgqo1:ask_0123456789abcdef0123456789abcdef",
+        from,
+        message: {
+          chat: { id: -100999, type: "supergroup", title: "Test Group" },
+          message_id: 21,
+        },
+      }),
+    );
+
+    expect(sendMessageSpy).toHaveBeenCalledWith(-100999, "Ada, reply with your own answer.", {
+      entities: [{ type: "text_mention", offset: 0, length: 3, user: from }],
+      reply_markup: { force_reply: true, selective: true },
+    });
+  });
+
   it("replaces legacy approval controls with a visible terminal receipt", async () => {
     mockTelegramConfig(makeExecApprovalTelegramConfig());
     createTelegramBot({ token: "tok" });

--- a/extensions/telegram/src/button-types.test.ts
+++ b/extensions/telegram/src/button-types.test.ts
@@ -143,10 +143,60 @@ describe("buildTelegramPresentationButtons", () => {
         questionButtonOptions([{ questionId, optionValues: ["Staging", "Production"] }]),
       ),
     ).toEqual([
-      [
-        { text: "Staging", callback_data: `tgq1:${questionId}:0`, style: undefined },
-        { text: "Production", callback_data: `tgq1:${questionId}:1`, style: undefined },
-      ],
+      [{ text: "Staging", callback_data: `tgq1:${questionId}:0`, style: undefined }],
+      [{ text: "Production", callback_data: `tgq1:${questionId}:1`, style: undefined }],
+    ]);
+  });
+
+  it("puts full question choices on separate Telegram rows", () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const optionValues = ["Use the safe deployment target", "Deploy directly to production"];
+
+    expect(
+      buildTelegramPresentationButtons(
+        {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: optionValues.map((optionValue) => ({
+                label: optionValue,
+                action: { type: "question" as const, questionId, optionValue },
+              })),
+            },
+          ],
+        },
+        questionButtonOptions([{ questionId, optionValues }]),
+      )?.map((row) => row.map((button) => button.text)),
+    ).toEqual([[optionValues[0]], [optionValues[1]]]);
+  });
+
+  it("renders the typed custom-input action as a native Other button", () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const optionValues = ["Unit", "Lint"];
+
+    expect(
+      buildTelegramPresentationButtons(
+        {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                {
+                  label: "Other…",
+                  action: {
+                    type: "question" as const,
+                    questionId,
+                    intent: "custom-input" as const,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        questionButtonOptions([{ questionId, optionValues }]),
+      ),
+    ).toEqual([
+      [expect.objectContaining({ text: "Other…", callback_data: `tgqo1:${questionId}` })],
     ]);
   });
 
@@ -218,9 +268,12 @@ describe("buildTelegramPresentationButtons", () => {
     );
 
     expect(rows?.map((row) => row.map((button) => button.callback_data))).toEqual([
-      [`tgq1:${firstQuestionId}:0`, `tgq1:${firstQuestionId}:1`],
-      [`tgq1:${secondQuestionId}:0`, `tgq1:${secondQuestionId}:1`],
-      [`tgq1:${firstQuestionId}:0`, `tgq1:${firstQuestionId}:2`],
+      [`tgq1:${firstQuestionId}:0`],
+      [`tgq1:${firstQuestionId}:1`],
+      [`tgq1:${secondQuestionId}:0`],
+      [`tgq1:${secondQuestionId}:1`],
+      [`tgq1:${firstQuestionId}:0`],
+      [`tgq1:${firstQuestionId}:2`],
     ]);
   });
 

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -10,7 +10,10 @@ import {
   type MessagePresentation,
   type MessagePresentationButton,
 } from "openclaw/plugin-sdk/interactive-runtime";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import {
+  resolveAskUserQuestionOptionIndex,
+  type AskUserQuestionOptionIndices,
+} from "openclaw/plugin-sdk/reply-payload";
 import {
   buildTelegramApprovalCallbackData,
   TELEGRAM_CALLBACK_DATA_MAX_BYTES,
@@ -50,12 +53,10 @@ export type TelegramDroppedControl = {
   callbackDataBytes?: number;
 };
 
-type TelegramQuestionOptionIndices = ReadonlyMap<string, ReadonlyMap<string, number>>;
-
 export type TelegramButtonBuildOptions = {
   allowWebAppButtons?: boolean;
   onDroppedControl?: (control: TelegramDroppedControl) => void;
-  questionOptionIndices?: TelegramQuestionOptionIndices;
+  questionOptionIndices?: AskUserQuestionOptionIndices;
 };
 
 export function appendTelegramDroppedControlFallback(
@@ -79,42 +80,6 @@ export function appendTelegramDroppedControlFallback(
 }
 
 const TELEGRAM_INTERACTIVE_ROW_SIZE = 3;
-
-/** Reads only bounded, unambiguous Gateway-owned question option ordering. */
-export function resolveTelegramQuestionOptionIndices(
-  payload: Pick<ReplyPayload, "channelData">,
-): TelegramQuestionOptionIndices | undefined {
-  const askUser = payload.channelData?.askUser;
-  if (!askUser || typeof askUser !== "object" || Array.isArray(askUser)) {
-    return undefined;
-  }
-  const { questionId, optionValues } = askUser as {
-    questionId?: unknown;
-    optionValues?: unknown;
-  };
-  if (
-    typeof questionId !== "string" ||
-    !questionId ||
-    !Array.isArray(optionValues) ||
-    optionValues.length < 2 ||
-    optionValues.length > 4
-  ) {
-    return undefined;
-  }
-
-  const optionIndices = new Map<string, number>();
-  for (const [optionIndex, optionValue] of optionValues.entries()) {
-    if (typeof optionValue !== "string") {
-      return undefined;
-    }
-    const normalizedOptionValue = optionValue.trim().toLowerCase();
-    if (!normalizedOptionValue || optionIndices.has(normalizedOptionValue)) {
-      return undefined;
-    }
-    optionIndices.set(normalizedOptionValue, optionIndex);
-  }
-  return new Map([[questionId, optionIndices]]);
-}
 
 function toTelegramButtonStyle(
   style?: MessagePresentationButton["style"],
@@ -173,10 +138,11 @@ function toTelegramInlineButton(
         ? { text: button.label, callback_data: callbackData, style }
         : recordDroppedControl(button, options, "question_context_unavailable");
     }
-    const normalizedOptionValue = action.optionValue.trim().toLowerCase();
-    const optionIndex = options?.questionOptionIndices
-      ?.get(action.questionId)
-      ?.get(normalizedOptionValue);
+    const optionIndex = resolveAskUserQuestionOptionIndex({
+      questionOptionIndices: options?.questionOptionIndices,
+      questionId: action.questionId,
+      optionValue: action.optionValue,
+    });
     if (optionIndex === undefined) {
       return recordDroppedControl(button, options, "question_context_unavailable");
     }

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -24,6 +24,7 @@ import {
 } from "./native-command-callback-data.js";
 import {
   buildTelegramQuestionCallbackData,
+  buildTelegramQuestionCustomInputCallbackData,
   hasTelegramQuestionCallbackPrefix,
 } from "./question-callback-data.js";
 
@@ -163,6 +164,15 @@ function toTelegramInlineButton(
       : recordDroppedControl(button, options, "invalid_action");
   }
   if (action.type === "question") {
+    const hasQuestionContext = options?.questionOptionIndices?.has(action.questionId) === true;
+    if ("intent" in action) {
+      const callbackData = hasQuestionContext
+        ? buildTelegramQuestionCustomInputCallbackData(action.questionId)
+        : undefined;
+      return callbackData
+        ? { text: button.label, callback_data: callbackData, style }
+        : recordDroppedControl(button, options, "question_context_unavailable");
+    }
     const normalizedOptionValue = action.optionValue.trim().toLowerCase();
     const optionIndex = options?.questionOptionIndices
       ?.get(action.questionId)
@@ -216,15 +226,29 @@ function chunkInteractiveButtons(
   rows: TelegramInlineButton[][],
   options?: TelegramButtonBuildOptions,
 ) {
-  for (let i = 0; i < buttons.length; i += TELEGRAM_INTERACTIVE_ROW_SIZE) {
-    const row = buttons
-      .slice(i, i + TELEGRAM_INTERACTIVE_ROW_SIZE)
-      .map((button) => toTelegramInlineButton(button, options))
-      .filter((button): button is TelegramInlineButton => Boolean(button));
+  let row: TelegramInlineButton[] = [];
+  const flush = () => {
     if (row.length > 0) {
       rows.push(row);
+      row = [];
+    }
+  };
+  for (const button of buttons) {
+    const rendered = toTelegramInlineButton(button, options);
+    if (!rendered) {
+      continue;
+    }
+    if (resolveMessagePresentationButtonAction(button)?.type === "question") {
+      flush();
+      rows.push([rendered]);
+      continue;
+    }
+    row.push(rendered);
+    if (row.length === TELEGRAM_INTERACTIVE_ROW_SIZE) {
+      flush();
     }
   }
+  flush();
 }
 
 /** Convert portable presentation controls to Telegram inline keyboard rows. */

--- a/extensions/telegram/src/interactive-fallback.test.ts
+++ b/extensions/telegram/src/interactive-fallback.test.ts
@@ -127,12 +127,13 @@ describe("canonicalizeTelegramPresentationPayload", () => {
       | undefined;
     const rows = telegram?.buttons;
 
-    expect(rows?.map((row) => row.length)).toEqual([3, 1]);
+    expect(rows?.map((row) => row.length)).toEqual([1, 1, 1, 1]);
     expect(rows?.flatMap((row) => row.map((button) => button.callback_data))).toEqual(
       optionValues.map((_, optionIndex) => `tgq1:${questionId}:${optionIndex}`),
     );
-    expect(parseTelegramQuestionCallbackData(rows?.[1]?.[0]?.callback_data)).toEqual({
+    expect(parseTelegramQuestionCallbackData(rows?.[3]?.[0]?.callback_data)).toEqual({
       questionId,
+      intent: "select",
       optionIndex: 3,
     });
   });
@@ -158,16 +159,17 @@ describe("canonicalizeTelegramPresentationPayload", () => {
       | undefined;
     const rows = telegram?.buttons;
 
-    expect(rows?.map((row) => row.length)).toEqual([2, 2]);
+    expect(rows?.map((row) => row.length)).toEqual([1, 1, 1, 1]);
     expect(rows?.flatMap((row) => row.map((button) => button.callback_data))).toEqual([
       `tgq1:${questionId}:0`,
       `tgq1:${questionId}:0`,
       `tgq1:${questionId}:1`,
       `tgq1:${questionId}:2`,
     ]);
-    const callback = parseTelegramQuestionCallbackData(rows?.[1]?.[1]?.callback_data);
+    const callback = parseTelegramQuestionCallbackData(rows?.[3]?.[0]?.callback_data);
     expect(callback).toEqual({
       questionId,
+      intent: "select",
       optionIndex: 2,
     });
     if (!callback) {
@@ -196,7 +198,7 @@ describe("canonicalizeTelegramPresentationPayload", () => {
       questionId: "destination",
       optionValue: "C",
     });
-    expect(feedback).toHaveBeenCalledWith("Answer submitted.", true);
+    expect(feedback).toHaveBeenCalledWith("Answer submitted.", "terminal");
   });
 
   it.each([

--- a/extensions/telegram/src/interactive-fallback.ts
+++ b/extensions/telegram/src/interactive-fallback.ts
@@ -11,11 +11,13 @@ import {
   type MessagePresentationInteractiveBlock,
   type MessagePresentationTableBlock,
 } from "openclaw/plugin-sdk/interactive-runtime";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import {
+  resolveAskUserQuestionOptionIndices,
+  type ReplyPayload,
+} from "openclaw/plugin-sdk/reply-payload";
 import {
   buildTelegramPresentationButtons,
   resolveTelegramInlineButtons,
-  resolveTelegramQuestionOptionIndices,
   type TelegramButtonBuildOptions,
 } from "./button-types.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
@@ -223,7 +225,7 @@ export function canonicalizeTelegramPresentationPayload(
   const interactive = normalizeLegacyInteractiveReply(payload.interactive);
   const buttonOptions: TelegramButtonBuildOptions = {
     allowWebAppButtons: options?.allowWebAppButtons === true,
-    questionOptionIndices: resolveTelegramQuestionOptionIndices(payload),
+    questionOptionIndices: resolveAskUserQuestionOptionIndices(payload),
   };
   const existingButtons = resolveTelegramInlineButtons(
     {

--- a/extensions/telegram/src/question-callback-data.test.ts
+++ b/extensions/telegram/src/question-callback-data.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildTelegramQuestionCallbackData,
+  buildTelegramQuestionCustomInputCallbackData,
   parseTelegramQuestionCallbackData,
 } from "./question-callback-data.js";
 
@@ -14,11 +15,26 @@ describe("question callback data", () => {
     expect(data).toBe(`tgq1:${questionId}:3`);
     expect(Buffer.byteLength(data ?? "", "utf8")).toBe(43);
     expect(Buffer.byteLength(data ?? "", "utf8")).toBeLessThanOrEqual(64);
-    expect(parseTelegramQuestionCallbackData(data)).toEqual({ questionId, optionIndex: 3 });
+    expect(parseTelegramQuestionCallbackData(data)).toEqual({
+      questionId,
+      intent: "select",
+      optionIndex: 3,
+    });
+  });
+
+  it("round-trips the native custom-input action", () => {
+    const data = buildTelegramQuestionCustomInputCallbackData(questionId);
+
+    expect(Buffer.byteLength(data ?? "", "utf8")).toBeLessThanOrEqual(64);
+    expect(parseTelegramQuestionCallbackData(data)).toEqual({
+      questionId,
+      intent: "custom-input",
+    });
   });
 
   it.each([
     `tgq1:${questionId}:4`,
+    `tgqo1:${questionId}:extra`,
     `tgq2:${questionId}:0`,
     "tgq1:ask_short:0",
     `tgq1:${questionId}:0:extra`,

--- a/extensions/telegram/src/question-callback-data.ts
+++ b/extensions/telegram/src/question-callback-data.ts
@@ -1,20 +1,24 @@
 // Telegram-private ask_user callback envelope.
 import { fitsTelegramCallbackData } from "./approval-callback-data.js";
 
-const TELEGRAM_QUESTION_CALLBACK_PREFIX = "tgq1:";
+const TELEGRAM_QUESTION_CALLBACK_PREFIXES = ["tgq1:", "tgqo1:"] as const;
 const QUESTION_RECORD_ID_PATTERN = /^ask_[a-f0-9]{32}$/u;
 
-export type TelegramQuestionCallback = {
-  questionId: string;
-  optionIndex: number;
-};
+export type TelegramQuestionCallback =
+  | { questionId: string; intent: "select"; optionIndex: number }
+  | { questionId: string; intent: "custom-input" };
 
 export function hasTelegramQuestionCallbackPrefix(data?: string | null): boolean {
-  return data?.startsWith(TELEGRAM_QUESTION_CALLBACK_PREFIX) === true;
+  return TELEGRAM_QUESTION_CALLBACK_PREFIXES.some((prefix) => data?.startsWith(prefix) === true);
 }
 
 export function buildTelegramQuestionCallbackData(
-  callback: TelegramQuestionCallback,
+  callback:
+    | Extract<TelegramQuestionCallback, { intent: "select" }>
+    | {
+        questionId: string;
+        optionIndex: number;
+      },
 ): string | undefined {
   if (
     !QUESTION_RECORD_ID_PATTERN.test(callback.questionId) ||
@@ -24,7 +28,17 @@ export function buildTelegramQuestionCallbackData(
   ) {
     return undefined;
   }
-  const data = `${TELEGRAM_QUESTION_CALLBACK_PREFIX}${callback.questionId}:${callback.optionIndex}`;
+  const data = `tgq1:${callback.questionId}:${callback.optionIndex}`;
+  return fitsTelegramCallbackData(data) ? data : undefined;
+}
+
+export function buildTelegramQuestionCustomInputCallbackData(
+  questionId: string,
+): string | undefined {
+  if (!QUESTION_RECORD_ID_PATTERN.test(questionId)) {
+    return undefined;
+  }
+  const data = `tgqo1:${questionId}`;
   return fitsTelegramCallbackData(data) ? data : undefined;
 }
 
@@ -34,6 +48,10 @@ export function parseTelegramQuestionCallbackData(
   if (!hasTelegramQuestionCallbackPrefix(data) || !data || !fitsTelegramCallbackData(data)) {
     return null;
   }
-  const match = /^tgq1:(ask_[a-f0-9]{32}):([0-3])$/u.exec(data);
-  return match?.[1] && match[2] ? { questionId: match[1], optionIndex: Number(match[2]) } : null;
+  const selectMatch = /^tgq1:(ask_[a-f0-9]{32}):([0-3])$/u.exec(data);
+  if (selectMatch?.[1] && selectMatch[2]) {
+    return { questionId: selectMatch[1], intent: "select", optionIndex: Number(selectMatch[2]) };
+  }
+  const customInputMatch = /^tgqo1:(ask_[a-f0-9]{32})$/u.exec(data);
+  return customInputMatch?.[1] ? { questionId: customInputMatch[1], intent: "custom-input" } : null;
 }

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -316,7 +316,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: typed owner-declared approval-scope contract for plugin-authored approvals.
       // -5: approval display sanitizers moved to a non-public leaf module
       //     (exec-approval-text-sanitize) to break the exec-approvals cycle.
-      4338,
+      // +3: typed ask_user option-index contract and two bounded owner-order resolvers.
+      4341,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -411,7 +412,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: embedded foreground prompt context builder.
       // -4: approval display sanitizers moved to a non-public leaf module
       //     (exec-approval-text-sanitize) to break the exec-approvals cycle.
-      2578,
+      // +2: bounded ask_user owner-order map builder and option resolver.
+      2580,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -431,6 +431,14 @@ describe("handleToolExecutionStart read path checks", () => {
                   optionValue: "Production",
                 },
               },
+              {
+                label: "Other…",
+                action: {
+                  type: "question",
+                  questionId,
+                  intent: "custom-input",
+                },
+              },
             ],
           },
         ],
@@ -486,41 +494,25 @@ describe("handleToolExecutionStart read path checks", () => {
     await pending;
   });
 
-  it.each([
-    {
-      name: "multi-question",
-      questions: [
-        {
-          id: "target",
-          header: "Target",
-          question: "Where next?",
-          options: [{ label: "Staging" }, { label: "Production" }],
-        },
-        {
-          id: "region",
-          header: "Region",
-          question: "Which region?",
-          options: [{ label: "EU" }, { label: "US" }],
-        },
-      ],
-    },
-    {
-      name: "multi-select",
-      questions: [
-        {
-          id: "targets",
-          header: "Targets",
-          question: "Where next?",
-          options: [{ label: "Staging" }, { label: "Production" }],
-          multiSelect: true,
-        },
-      ],
-    },
-  ])("keeps $name ask_user prompts text-only", async ({ questions }) => {
+  it("keeps multi-question ask_user prompts text-only", async () => {
+    const questions = [
+      {
+        id: "target",
+        header: "Target",
+        question: "Where next?",
+        options: [{ label: "Staging" }, { label: "Production" }],
+      },
+      {
+        id: "region",
+        header: "Region",
+        question: "Which region?",
+        options: [{ label: "EU" }, { label: "US" }],
+      },
+    ];
     const { ctx } = createTestContext();
     const onToolResult = vi.fn();
     ctx.params.onToolResult = onToolResult;
-    const toolCallId = `ask-${questions[0]?.id ?? "unknown"}`;
+    const toolCallId = "ask-multi-question";
 
     await startTool(ctx, {
       toolName: "ask_user",
@@ -532,12 +524,37 @@ describe("handleToolExecutionStart read path checks", () => {
 
     const payload = onToolResult.mock.calls[0]?.[0];
     expect(payload?.text).toContain(
-      questions.length > 1
-        ? "Reply by number or question id. Use a declared option where choices are fixed."
-        : "Reply with the number, the option text, or your own answer.",
+      "Reply by number or question id. Use a declared option where choices are fixed.",
     );
     expect(payload).not.toHaveProperty("presentation");
     expect(payload).not.toHaveProperty("presentationTextMode");
+    await activation.finish();
+  });
+
+  it("keeps a multi-select ask_user prompt readable without partial native state", async () => {
+    const { ctx } = createTestContext();
+    const onToolResult = vi.fn();
+    ctx.params.onToolResult = onToolResult;
+    const questions = [
+      {
+        id: "checks",
+        header: "Checks",
+        question: "Which checks should run?",
+        options: [{ label: "Unit" }, { label: "Lint" }],
+        multiSelect: true,
+      },
+    ];
+
+    await startTool(ctx, { toolName: "ask_user", toolCallId: "ask-checks", args: { questions } });
+    const activation = await activateAskUserPrompt("ask-checks", { questions });
+    await vi.waitFor(() => expect(onToolResult).toHaveBeenCalledOnce());
+
+    const payload = onToolResult.mock.calls[0]?.[0];
+    expect(payload?.text).toContain(
+      "Reply with comma-separated option numbers or text, or your own answer.",
+    );
+    expect(payload).not.toHaveProperty("presentation");
+    expect(payload?.channelData).toEqual({ askUser: { questionId: activation.questionId } });
     await activation.finish();
   });
 

--- a/src/agents/harness/user-input-bridge.ts
+++ b/src/agents/harness/user-input-bridge.ts
@@ -264,6 +264,12 @@ function normalizeAgentHarnessUserInputAnswers(
     const normalized = normalizeAgentHarnessUserInputAnswer(answer, question);
     return normalized ? [normalized] : [];
   }
+  // A declared label can contain list delimiters. Match it whole before
+  // splitting a reply that selects several options.
+  const declaredAnswer = normalizeAgentHarnessUserInputOption(answer, question);
+  if (declaredAnswer) {
+    return [declaredAnswer];
+  }
   const normalized = answer
     .split(/[,;\n]/u)
     .map((part) => normalizeAgentHarnessUserInputAnswer(part, question))
@@ -272,6 +278,21 @@ function normalizeAgentHarnessUserInputAnswers(
 }
 
 export function normalizeAgentHarnessUserInputAnswer(
+  answer: string,
+  question: AgentHarnessUserInputQuestion,
+): string | undefined {
+  const trimmed = answer.trim();
+  const declaredAnswer = normalizeAgentHarnessUserInputOption(trimmed, question);
+  if (declaredAnswer) {
+    return declaredAnswer;
+  }
+  if ((question.options?.length ?? 0) > 0 && !question.isOther) {
+    return undefined;
+  }
+  return trimmed || undefined;
+}
+
+function normalizeAgentHarnessUserInputOption(
   answer: string,
   question: AgentHarnessUserInputQuestion,
 ): string | undefined {
@@ -288,10 +309,7 @@ export function normalizeAgentHarnessUserInputAnswer(
   if (exact) {
     return exact.label;
   }
-  if (options.length > 0 && !question.isOther) {
-    return undefined;
-  }
-  return trimmed || undefined;
+  return undefined;
 }
 
 function parseKeyedAnswers(inputText: string): Map<string, string> {

--- a/src/agents/harness/user-input-bridge.ts
+++ b/src/agents/harness/user-input-bridge.ts
@@ -33,7 +33,9 @@ type AgentHarnessQuestionPromptPayload = {
   text: string;
   presentation?: MessagePresentation;
   presentationTextMode?: "fallback";
-  channelData: { askUser: { questionId: string; optionValues?: string[] } };
+  channelData: {
+    askUser: { questionId: string; optionValues?: string[] };
+  };
 };
 
 type PromptDeliveryParams = Pick<EmbeddedRunAttemptParams, "onBlockReply" | "onPartialReply">;
@@ -94,7 +96,8 @@ function buildAgentHarnessQuestionPresentation(params: {
   questions: readonly AgentHarnessUserInputQuestion[];
   formatText?: (text: string) => string;
 }): MessagePresentation | undefined {
-  // Button taps resolve atomically, so v1 keeps multi-question records text-only.
+  // Button taps resolve atomically, so multi-question and multi-select records
+  // remain text-only until partial answer state has one shared owner.
   if (params.questions.length !== 1) {
     return undefined;
   }
@@ -122,14 +125,28 @@ function buildAgentHarnessQuestionPresentation(params: {
       { type: "text", text: optionGuidance },
       {
         type: "buttons",
-        buttons: options.map((option) => ({
-          label: formatText(option.label),
-          action: {
-            type: "question",
-            questionId: params.questionId,
-            optionValue: option.label,
-          },
-        })),
+        buttons: [
+          ...options.map((option) => ({
+            label: formatText(option.label),
+            action: {
+              type: "question" as const,
+              questionId: params.questionId,
+              optionValue: option.label,
+            },
+          })),
+          ...(question.isOther
+            ? [
+                {
+                  label: "Other…",
+                  action: {
+                    type: "question" as const,
+                    questionId: params.questionId,
+                    intent: "custom-input" as const,
+                  },
+                },
+              ]
+            : []),
+        ],
       },
     ],
   };
@@ -180,6 +197,9 @@ function questionReplyGuidance(questions: readonly AgentHarnessUserInputQuestion
   if (!question || (question.options?.length ?? 0) === 0) {
     return "Reply with your answer.";
   }
+  if (question.multiSelect) {
+    return "Reply with comma-separated option numbers or text, or your own answer.";
+  }
   return question.isOther
     ? "Reply with the number, the option text, or your own answer."
     : "Reply with the number or option text.";
@@ -211,8 +231,9 @@ export function buildAgentHarnessUserInputAnswers(
   if (questions.length === 1) {
     const question = questions[0];
     if (question) {
-      const answer = normalizeAgentHarnessUserInputAnswer(inputText, question);
-      answers[question.id] = { answers: answer ? [answer] : [] };
+      answers[question.id] = {
+        answers: normalizeAgentHarnessUserInputAnswers(inputText, question),
+      };
     }
     return { answers };
   }
@@ -228,10 +249,26 @@ export function buildAgentHarnessUserInputAnswers(
       keyed.get(question.question.toLowerCase()) ??
       keyed.get(String(index + 1));
     const answer = key ?? fallbackLines[index] ?? "";
-    const normalized = answer ? normalizeAgentHarnessUserInputAnswer(answer, question) : undefined;
-    answers[question.id] = { answers: normalized ? [normalized] : [] };
+    answers[question.id] = {
+      answers: answer ? normalizeAgentHarnessUserInputAnswers(answer, question) : [],
+    };
   });
   return { answers };
+}
+
+function normalizeAgentHarnessUserInputAnswers(
+  answer: string,
+  question: AgentHarnessUserInputQuestion,
+): string[] {
+  if (!question.multiSelect) {
+    const normalized = normalizeAgentHarnessUserInputAnswer(answer, question);
+    return normalized ? [normalized] : [];
+  }
+  const normalized = answer
+    .split(/[,;\n]/u)
+    .map((part) => normalizeAgentHarnessUserInputAnswer(part, question))
+    .filter((part): part is string => Boolean(part));
+  return [...new Set(normalized)];
 }
 
 export function normalizeAgentHarnessUserInputAnswer(

--- a/src/agents/tool-description-presets.test.ts
+++ b/src/agents/tool-description-presets.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
+  describeAskUserTool,
   describeSessionsHistoryTool,
   describeSessionsListTool,
   describeSessionsSearchTool,
   describeSessionsSendTool,
   SESSIONS_SEND_TOOL_DISPLAY_SUMMARY,
 } from "./tool-description-presets.js";
+
+describe("ask_user tool guidance", () => {
+  it("keeps native-control requirements visible to the model", () => {
+    const description = describeAskUserTool();
+
+    expect(description).toContain("exactly one question per call");
+    expect(description).toContain("native controls");
+    expect(description).toContain("Put every selectable choice in `options`");
+    expect(description).toContain("Use `multiSelect` only");
+  });
+});
 
 const SESSION_LINK_BASE = "http://127.0.0.1:18789/control";
 const SESSION_LINK_LINE =

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -161,7 +161,9 @@ export function describeAskUserTool(): string {
   return [
     "Ask the human user 1-3 structured questions and wait for their answer; `multiSelect` allows picking several options and `timeoutSeconds` bounds the wait.",
     "Use only when blocked on a decision genuinely theirs that cannot be resolved from the request, code, or sensible defaults; never ask whether to proceed or confirm a plan.",
-    "Prefer one question. Put the recommended option first and suffix its label with ` (Recommended)`.",
+    "Ask exactly one question per call unless several answers must be submitted together; one single-select question uses native controls on supported messaging channels.",
+    "Put every selectable choice in `options`, never only in the question text. Put the recommended option first and suffix its label with ` (Recommended)`.",
+    "Use `multiSelect` only when the user may choose several options at once; otherwise omit it.",
     "Do not include an Other option; free text is added automatically.",
     "If the result is no_answer, continue with best judgment.",
   ].join(" ");

--- a/src/agents/tools/ask-user-tool.test.ts
+++ b/src/agents/tools/ask-user-tool.test.ts
@@ -82,6 +82,14 @@ describe("ask_user normalization", () => {
     expect(normalized.questions[0]).not.toHaveProperty("isSecret");
   });
 
+  it("repeats the structured-choice contract in the model-visible schema", () => {
+    const schema = JSON.stringify(createAskUserTool({}).parameters);
+
+    expect(schema).toContain("Put all selectable choices in options");
+    expect(schema).toContain("Every selectable choice");
+    expect(schema).toContain("True only when the user may choose several options at once");
+  });
+
   it.each([
     ["empty questions", { questions: [] }, "1 to 3 questions"],
     [

--- a/src/agents/tools/ask-user-tool.ts
+++ b/src/agents/tools/ask-user-tool.ts
@@ -41,7 +41,7 @@ const AskUserToolSchema = Type.Object(
           }),
           question: Type.String({
             minLength: 1,
-            description: "Single-sentence question for the user.",
+            description: "Single-sentence question only. Put all selectable choices in options.",
           }),
           options: Type.Array(
             Type.Object(
@@ -51,9 +51,18 @@ const AskUserToolSchema = Type.Object(
               },
               { additionalProperties: false },
             ),
-            { minItems: 2, maxItems: 4 },
+            {
+              minItems: 2,
+              maxItems: 4,
+              description:
+                "Every selectable choice. Put the recommended choice first; do not repeat choices only in the question text.",
+            },
           ),
-          multiSelect: Type.Optional(Type.Boolean()),
+          multiSelect: Type.Optional(
+            Type.Boolean({
+              description: "True only when the user may choose several options at once.",
+            }),
+          ),
         },
         { additionalProperties: false },
       ),

--- a/src/infra/question-gateway-resolver.test.ts
+++ b/src/infra/question-gateway-resolver.test.ts
@@ -145,4 +145,18 @@ describe("resolveQuestionOverGateway", () => {
     ).rejects.toThrow("one tappable question");
     expect(hoisted.callGateway).toHaveBeenCalledOnce();
   });
+
+  it("validates native custom input without resolving the question", async () => {
+    hoisted.callGateway.mockResolvedValueOnce({
+      question: {
+        ...pendingRecord,
+        questions: [{ ...pendingRecord.questions[0], isOther: true }],
+      },
+    });
+
+    await expect(
+      resolveQuestionOverGateway({ cfg: {} as never, questionId: recordId, customInput: true }),
+    ).resolves.toEqual({ status: "custom-input", questionId: "deploy_target" });
+    expect(hoisted.callGateway).toHaveBeenCalledOnce();
+  });
 });

--- a/src/infra/question-gateway-resolver.ts
+++ b/src/infra/question-gateway-resolver.ts
@@ -10,6 +10,7 @@ const QUESTION_RECORD_ID_PATTERN = /^ask_[a-f0-9]{32}$/u;
 
 export type ResolveQuestionOverGatewayResult =
   | { status: "answered"; questionId: string; optionValue: string }
+  | { status: "custom-input"; questionId: string }
   | { status: "already-terminal"; reason: "already-terminal" | "not-found" };
 
 export type ResolveQuestionOverGatewayParams = {
@@ -23,10 +24,18 @@ export type ResolveQuestionOverGatewayParams = {
       /** Rendered option value carried by the pressed control (reactions). */
       optionValue: string;
       optionIndex?: never;
+      customInput?: never;
     }
   | {
       /** Compact callback index; mapped to the canonical label via question.get. */
       optionIndex: number;
+      optionValue?: never;
+      customInput?: never;
+    }
+  | {
+      /** Validate and retain the Gateway question for a typed custom answer. */
+      customInput: true;
+      optionIndex?: never;
       optionValue?: never;
     }
 );
@@ -46,14 +55,18 @@ function readTerminalReason(error: unknown): "already-terminal" | "not-found" | 
   return reason === "QUESTION_NOT_FOUND" ? "not-found" : undefined;
 }
 
-/** Resolves one rendered option value against the gateway-owned question. */
+/** Resolves one rendered choice or validates a custom-input transition. */
 export async function resolveQuestionOverGateway(
   params: ResolveQuestionOverGatewayParams,
 ): Promise<ResolveQuestionOverGatewayResult> {
   if (!QUESTION_RECORD_ID_PATTERN.test(params.questionId)) {
     throw new Error("question resolution requires a valid question record id");
   }
-  if (params.optionValue === undefined && !Number.isInteger(params.optionIndex)) {
+  if (
+    params.customInput !== true &&
+    params.optionValue === undefined &&
+    !Number.isInteger(params.optionIndex)
+  ) {
     throw new Error("question resolution requires an option value or index");
   }
   if (params.optionValue !== undefined && !params.optionValue) {
@@ -88,6 +101,12 @@ export async function resolveQuestionOverGateway(
   const question = record.questions.length === 1 ? record.questions[0] : undefined;
   if (!question || question.multiSelect || question.isSecret) {
     throw new Error("question button resolution requires one tappable question");
+  }
+  if (params.customInput === true) {
+    if (!question.isOther) {
+      throw new Error("question does not allow a custom answer");
+    }
+    return { status: "custom-input", questionId: question.questionId };
   }
   const optionValue = params.optionValue ?? question.options[params.optionIndex as number]?.label;
   if (!optionValue) {

--- a/src/infra/question-reaction-runtime.test.ts
+++ b/src/infra/question-reaction-runtime.test.ts
@@ -68,6 +68,7 @@ describe("question reaction runtime", () => {
       questionId,
       optionValues: ["Staging", "Production"],
     });
+    expect(payload?.text).toContain("Or reply with your own answer.");
   });
 
   it("keeps a one-option prompt reaction-eligible", () => {

--- a/src/infra/question-reaction-runtime.test.ts
+++ b/src/infra/question-reaction-runtime.test.ts
@@ -10,15 +10,16 @@ const hoisted = vi.hoisted(() => ({ callGateway: vi.fn() }));
 vi.mock("../gateway/call.js", () => ({ callGateway: hoisted.callGateway }));
 
 const questionId = "ask_0123456789abcdef0123456789abcdef";
+const optionButtons = ["Staging", "Production"].map((label) => ({
+  label,
+  action: { type: "question" as const, questionId, optionValue: label },
+}));
 const presentation = {
   blocks: [
     { type: "text" as const, text: "Deploy where?" },
     {
       type: "buttons" as const,
-      buttons: ["Staging", "Production"].map((label) => ({
-        label,
-        action: { type: "question" as const, questionId, optionValue: label },
-      })),
+      buttons: optionButtons,
     },
   ],
 };
@@ -47,7 +48,7 @@ describe("question reaction runtime", () => {
         {
           type: "buttons" as const,
           buttons: [
-            ...presentation.blocks[1]!.buttons,
+            ...optionButtons,
             {
               label: "Other…",
               action: { type: "question" as const, questionId, intent: "custom-input" as const },

--- a/src/infra/question-reaction-runtime.test.ts
+++ b/src/infra/question-reaction-runtime.test.ts
@@ -39,6 +39,37 @@ describe("question reaction runtime", () => {
     });
   });
 
+  it("keeps declared choices when the presentation also offers custom input", () => {
+    const presentationWithCustomInput = {
+      ...presentation,
+      blocks: [
+        presentation.blocks[0]!,
+        {
+          type: "buttons" as const,
+          buttons: [
+            ...presentation.blocks[1]!.buttons,
+            {
+              label: "Other…",
+              action: { type: "question" as const, questionId, intent: "custom-input" as const },
+            },
+          ],
+        },
+      ],
+    };
+    const payload = prepareQuestionReactionPayloadForDelivery({
+      payload: {
+        channelData: { askUser: { questionId } },
+        presentation: presentationWithCustomInput,
+      },
+      presentation: presentationWithCustomInput,
+    });
+
+    expect(readQuestionReactionBinding(payload ?? {})).toEqual({
+      questionId,
+      optionValues: ["Staging", "Production"],
+    });
+  });
+
   it("keeps a one-option prompt reaction-eligible", () => {
     const singleOptionPresentation = {
       ...presentation,

--- a/src/infra/question-reaction-runtime.ts
+++ b/src/infra/question-reaction-runtime.ts
@@ -53,19 +53,23 @@ export function prepareQuestionReactionPayloadForDelivery(params: {
     return null;
   }
   const buttonBlocks = presentation.blocks.filter((block) => block.type === "buttons");
-  if (buttonBlocks.length !== 1) {
+  const buttonBlock = buttonBlocks[0];
+  if (!buttonBlock || buttonBlocks.length !== 1) {
     return null;
   }
-  const [buttonBlock] = buttonBlocks;
-  if (!buttonBlock || buttonBlock.buttons.length < 1 || buttonBlock.buttons.length > 4) {
+  const optionButtons = buttonBlock.buttons.filter(
+    (button) => button.action?.type === "question" && !("intent" in button.action),
+  );
+  if (optionButtons.length < 1 || optionButtons.length > 4) {
     return null;
   }
   const labels: string[] = [];
   const optionValues: string[] = [];
-  for (const button of buttonBlock.buttons) {
+  for (const button of optionButtons) {
     if (
       button.action?.type !== "question" ||
       button.action.questionId !== questionId ||
+      !("optionValue" in button.action) ||
       !button.action.optionValue
     ) {
       return null;

--- a/src/infra/question-reaction-runtime.ts
+++ b/src/infra/question-reaction-runtime.ts
@@ -89,9 +89,14 @@ export function prepareQuestionReactionPayloadForDelivery(params: {
   const reactionHint = labels
     .map((label, index) => `${QUESTION_REACTION_EMOJIS[index]} ${label}`)
     .join("\n");
+  const hasCustomInput = buttonBlock.buttons.some((button) => {
+    const action = button.action;
+    return action?.type === "question" && "intent" in action && action.intent === "custom-input";
+  });
+  const customInputHint = hasCustomInput ? "\n\nOr reply with your own answer." : "";
   return {
     ...params.payload,
-    text: `${prompt}\n\nReact with:\n${reactionHint}`,
+    text: `${prompt}\n\nReact with:\n${reactionHint}${customInputHint}`,
     presentation: undefined,
     presentationTextMode: undefined,
     channelData: {

--- a/src/interactive/payload.fallback.test.ts
+++ b/src/interactive/payload.fallback.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { renderMessagePresentationFallbackText } from "./payload.js";
+import { normalizeMessagePresentation, renderMessagePresentationFallbackText } from "./payload.js";
 
-describe("presentation fallback controls", () => {
+describe("presentation payload controls", () => {
   it("keeps typed select commands actionable without exposing callback values", () => {
     expect(
       renderMessagePresentationFallbackText({
@@ -25,5 +25,22 @@ describe("presentation fallback controls", () => {
     ).toBe(
       "Environment:\n- Canary: `/deploy canary`\n- Production: `/deploy production`\n- Opaque",
     );
+  });
+
+  it("normalizes only the known custom-input question intent", () => {
+    const action = {
+      type: "question" as const,
+      questionId: "ask_0123456789abcdef0123456789abcdef",
+    };
+    const presentation = (intent: string) => ({
+      blocks: [
+        { type: "buttons" as const, buttons: [{ label: "Other…", action: { ...action, intent } }] },
+      ],
+    });
+
+    expect(normalizeMessagePresentation(presentation("custom-input"))).toEqual(
+      presentation("custom-input"),
+    );
+    expect(normalizeMessagePresentation(presentation("unknown"))).toBeUndefined();
   });
 });

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -19,6 +19,20 @@ export type MessagePresentationTone = "info" | "success" | "warning" | "danger" 
 /** Button style hint for renderers that support styled actions. */
 export type MessagePresentationButtonStyle = InteractiveButtonStyle;
 
+type QuestionPresentationAction =
+  | {
+      /** Resolve one declared choice. */
+      type: "question";
+      questionId: string;
+      optionValue: string;
+    }
+  | {
+      /** Switch this question to its free-text answer path. */
+      type: "question";
+      questionId: string;
+      intent: "custom-input";
+    };
+
 /** Core-owned model-picker action; channels serialize it only inside private envelopes. */
 export type ModelPickerAction = (
   | {
@@ -88,12 +102,7 @@ export type MessagePresentationAction =
       approvalKind: ChannelApprovalKind;
       decision: "allow-once" | "allow-always" | "deny";
     }
-  | {
-      /** Resolve one runtime-authored operator question choice. */
-      type: "question";
-      questionId: string;
-      optionValue: string;
-    }
+  | QuestionPresentationAction
   | {
       /** Open a normal external link. */
       type: "url";
@@ -546,15 +555,19 @@ function normalizePresentationAction(raw: unknown): MessagePresentationAction | 
     }
     const questionId = record.questionId;
     const optionValue = record.optionValue;
-    if (
-      typeof questionId !== "string" ||
-      !isWellFormedApprovalId(questionId) ||
-      typeof optionValue !== "string" ||
-      !optionValue.trim()
-    ) {
+    if (typeof questionId !== "string" || !isWellFormedApprovalId(questionId)) {
       return undefined;
     }
-    return { type: "question", questionId, optionValue };
+    const intent = record.intent;
+    if (intent === undefined) {
+      return typeof optionValue === "string" && optionValue.trim()
+        ? { type: "question", questionId, optionValue }
+        : undefined;
+    }
+    if (intent === "custom-input") {
+      return { type: "question", questionId, intent };
+    }
+    return undefined;
   }
   if (type === "url") {
     const url = normalizeOptionalString(record.url);

--- a/src/plugin-sdk/agent-harness-runtime.test.ts
+++ b/src/plugin-sdk/agent-harness-runtime.test.ts
@@ -325,6 +325,24 @@ describe("agent harness user input helpers", () => {
     ).toEqual({ answers: { checks: { answers: ["Unit", "Deploy preview"] } } });
   });
 
+  it("keeps a comma-containing option label as one multi-select answer", () => {
+    expect(
+      buildAgentHarnessUserInputAnswers(
+        [
+          {
+            id: "region",
+            header: "Region",
+            question: "Which region should deploy?",
+            multiSelect: true,
+            isOther: true,
+            options: [{ label: "Frankfurt, Germany" }, { label: "Dublin, Ireland" }],
+          },
+        ],
+        "Frankfurt, Germany",
+      ),
+    ).toEqual({ answers: { region: { answers: ["Frankfurt, Germany"] } } });
+  });
+
   it("supports runtime-specific text formatting", () => {
     expect(
       formatAgentHarnessUserInputPrompt(

--- a/src/plugin-sdk/agent-harness-runtime.test.ts
+++ b/src/plugin-sdk/agent-harness-runtime.test.ts
@@ -307,6 +307,24 @@ describe("agent harness user input helpers", () => {
     });
   });
 
+  it("normalizes every selected option in a multi-select answer", () => {
+    expect(
+      buildAgentHarnessUserInputAnswers(
+        [
+          {
+            id: "checks",
+            header: "Checks",
+            question: "Which checks should run?",
+            multiSelect: true,
+            isOther: true,
+            options: [{ label: "Unit" }, { label: "Lint" }, { label: "Deploy preview" }],
+          },
+        ],
+        "1, Deploy preview",
+      ),
+    ).toEqual({ answers: { checks: { answers: ["Unit", "Deploy preview"] } } });
+  });
+
   it("supports runtime-specific text formatting", () => {
     expect(
       formatAgentHarnessUserInputPrompt(

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -16,6 +16,8 @@ import {
   markReplyPayloadAsTtsSupplement,
   normalizeOutboundReplyPayload,
   resolveOutboundMediaUrls,
+  resolveAskUserQuestionOptionIndex,
+  resolveAskUserQuestionOptionIndices,
   resolveSendableOutboundReplyParts,
   resolveTextChunksWithFallback,
   sendPayloadMediaSequence,
@@ -25,6 +27,32 @@ import {
   sendPayloadTextChunkSequence,
   sendPayloadWithChunkedTextAndMedia,
 } from "./reply-payload.js";
+
+describe("ask_user question option indices", () => {
+  it("reads bounded owner order and matches presented values case-insensitively", () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const questionOptionIndices = resolveAskUserQuestionOptionIndices({
+      channelData: { askUser: { questionId, optionValues: ["Staging", "Production"] } },
+    });
+
+    expect(
+      resolveAskUserQuestionOptionIndex({
+        questionOptionIndices,
+        questionId,
+        optionValue: " production ",
+      }),
+    ).toBe(1);
+  });
+
+  it.each([
+    undefined,
+    { questionId: "ask_1", optionValues: ["Only"] },
+    { questionId: "ask_1", optionValues: ["A", " a "] },
+    { questionId: "ask_1", optionValues: ["A", "B", "C", "D", "E"] },
+  ])("rejects missing or ambiguous owner context %#", (askUser) => {
+    expect(resolveAskUserQuestionOptionIndices({ channelData: { askUser } })).toBeUndefined();
+  });
+});
 
 describe("isReasoningReplyPayload", () => {
   it.each([

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -20,6 +20,55 @@ export type { MediaPayload } from "../channels/plugins/media-payload.js";
 export { buildMediaPayload } from "../channels/plugins/media-payload.js";
 /** Plugin-facing reply payload without core-only trusted local media internals. */
 export type ReplyPayload = Omit<InternalReplyPayload, "trustedLocalMedia">;
+export type AskUserQuestionOptionIndices = ReadonlyMap<string, ReadonlyMap<string, number>>;
+
+/** Read bounded Gateway-owned option ordering for one native ask_user question. */
+export function resolveAskUserQuestionOptionIndices(
+  payload: Pick<ReplyPayload, "channelData">,
+): AskUserQuestionOptionIndices | undefined {
+  const askUser = payload.channelData?.askUser;
+  if (!askUser || typeof askUser !== "object" || Array.isArray(askUser)) {
+    return undefined;
+  }
+  // SAFETY: channelData.askUser is an internal record after the object and array checks above.
+  const { questionId, optionValues } = askUser as {
+    questionId?: unknown;
+    optionValues?: unknown;
+  };
+  if (
+    typeof questionId !== "string" ||
+    !questionId ||
+    !Array.isArray(optionValues) ||
+    optionValues.length < 2 ||
+    optionValues.length > 4
+  ) {
+    return undefined;
+  }
+
+  const optionIndices = new Map<string, number>();
+  for (const [optionIndex, optionValue] of optionValues.entries()) {
+    if (typeof optionValue !== "string") {
+      return undefined;
+    }
+    const normalizedOptionValue = optionValue.trim().toLowerCase();
+    if (!normalizedOptionValue || optionIndices.has(normalizedOptionValue)) {
+      return undefined;
+    }
+    optionIndices.set(normalizedOptionValue, optionIndex);
+  }
+  return new Map([[questionId, optionIndices]]);
+}
+
+/** Match one presented choice to its Gateway-owned option index. */
+export function resolveAskUserQuestionOptionIndex(params: {
+  questionOptionIndices?: AskUserQuestionOptionIndices;
+  questionId: string;
+  optionValue: string;
+}): number | undefined {
+  return params.questionOptionIndices
+    ?.get(params.questionId)
+    ?.get(params.optionValue.trim().toLowerCase());
+}
 export type { ReplyPayloadTtsSupplement } from "../auto-reply/reply-payload.js";
 export {
   buildTtsSupplementMediaPayload,

--- a/test/telegram-question-gateway.test.ts
+++ b/test/telegram-question-gateway.test.ts
@@ -108,7 +108,7 @@ describe("Telegram question Gateway resolution", () => {
         | { buttons?: ReadonlyArray<ReadonlyArray<{ callback_data?: string }>> }
         | undefined;
       const rows = telegram?.buttons;
-      expect(rows?.map((row) => row.length)).toEqual([2, 2]);
+      expect(rows?.map((row) => row.length)).toEqual([1, 1, 1, 1]);
       expect(rows?.flatMap((row) => row.map((button) => button.callback_data))).toEqual([
         `tgq1:${questionId}:2`,
         `tgq1:${questionId}:0`,


### PR DESCRIPTION
## Problem

`ask_user` allowed one to three questions and multi-select, but its channel presentation only produced native controls for one single-select question. The model guidance did not explain that boundary, typed multi-select replies collapsed into one answer, and Telegram placed long choices side by side. Telegram also had no native way to switch **Other** into free-text input. A later progress event could overwrite the delivered question with `Working…` because Telegram left the question draft mutable.

## Root cause

The harness owned a richer question contract than the portable presentation and answer bridge represented. Telegram could only encode declared option callbacks, so every unsupported shape silently fell back to text and **Other** had no typed action. Telegram registered the question as a preview update instead of finalizing its concrete delivery, so later progress reused and replaced the same draft. Slack and Discord also inferred callback indices from presentation positions instead of the Gateway-owned option order.

## Fix

- Tell the model to ask one single-select question when possible and put every choice in `options`.
- Add one portable `custom-input` question action. Telegram maps it to a compact callback and native Force Reply without resolving the Gateway-owned question.
- Render every Telegram question choice on its own row. Keep multi-question and multi-select prompts on the canonical text path.
- Normalize comma-, semicolon-, and newline-separated multi-select replies into distinct answers.
- Match a full declared label before splitting delimiters, so labels such as `Frankfurt, Germany` remain one answer.
- Keep Slack declared choices native while its unsupported custom-input action stays on the visible text path.
- Keep visible free-text guidance on reaction channels when custom input is available.
- Map Telegram, Slack, and Discord choices through one bounded Gateway-owned option index helper, so reordered or interleaved controls resolve the intended answer.
- In Telegram groups, target the Other tapper with a native text mention and selective Force Reply.
- Send Force Reply before retiring the original controls, so a rejected Telegram send preserves the existing answer route.
- Finalize the Telegram question draft when `ask_user` is delivered so later progress cannot replace it.
- Publish the portable custom-input action and its required fallback behavior in the Plugin SDK docs.
- Add deterministic QA Lab fixtures for single-select and multi-select Telegram proof.

## Proof

- Pre-fix owner tests showed missing one-question guidance, `1, Deploy preview` becoming one answer, and two long Telegram choices sharing one row.
- The owner-boundary regression test fails without the finalization fix: after a later `wait` tool start, `answerDraftStream.stop` was not called. It passes with the fix.
- ClawSweeper regressions were reproduced before repair: Slack native rendering returned false, group Force Reply targeted the bot-authored message, `Frankfurt, Germany` split into two answers, reaction fallback lost its free-text path, and Slack/Discord encoded interleaved choices from source positions.
- Focused proof on patch-identical `970b0974c90c4e3ae2b02b5211d76553ceeb23c2`: 25 files and 1,252 tests passed through the repository project router. Rebase head `a50a32be742ad0cea289ebefef69377be6e8f5f5` has the same stable aggregate patch ID, and `git range-diff` reports all four commits unchanged.
- Full channel proof: Slack 138 files/2,572 tests; Discord 228 files/2,959 tests; Telegram 216 repository-routed Vitest shards in 892.95 seconds.
- Force Reply failure proof: the new owner-boundary test fails before the ordering repair because controls are cleared, then passes with send-before-clear ordering.
- Local checks: full format, non-type-aware focused lint, full docs checks, max-lines, assertion safety, coercion helpers, plugin boundaries, deprecated API use, storage guards, and import cycles passed.
- Local type-checks were intentionally not run. Repository policy assigns compiler checks to hosted CI on this host.
- Hosted exact-head CI on `a50a32be742ad0cea289ebefef69377be6e8f5f5`: `openclaw/ci-gate` passed; 161 checks passed, 0 failed, and 0 remain pending, including production and test type checks.
- Autoreview: clean with 0.98 patch-correct confidence and no accepted or actionable findings.
- Codex contract checked directly: `../codex/codex-rs/protocol/src/request_user_input.rs:8-33` and `../codex/codex-rs/core/src/tools/handlers/request_user_input_spec.rs:16-88,105-127`. Codex requires structured options, adds free-form Other, and prefers one of at most three questions; it has no multi-select contract to copy.
- Distill and performance reviews are clean. Option parsing is bounded to two to four values, built once per payload, and reused by every channel adapter.
- Final exact-head Telegram real-user proof passed on `a50a32be742ad0cea289ebefef69377be6e8f5f5`: native `Other…`, Force Reply before button removal, typed-answer resolution, question finalization, and separate progress cleanup all appeared in the recorded DM stream. The patch-identical five-run suite also exercised native choice, multi-select text, three-question text, and selective group Other paths. Each accepted run passed `doctor --json` first and retained its event stream, summary, Gateway log, and provider log.

### Final exact-head Telegram transcript (redacted)

```text
single: bot -> Where should this deploy? [Staging (Recommended)] [Production 🚀] [Other…]
single: user taps Production 🚀 -> keyboard cleared -> question edit: Answered: Production 🚀

other: user taps Other… -> bot sends Telegram Force Reply -> original keyboard clears
other: user replies Disaster recovery -> tool result contains deploy_target=[Disaster recovery] -> question edit: Answered
other: later Working progress was a separate message; it did not edit or replace the question

multi: bot -> Which checks should run? (no reply markup)
multi: user replies 1, 3 -> checks=[Unit (Recommended), Lint] -> question edit shows both choices

batch: bot -> three keyed questions (no reply markup)
batch: user replies deploy_target: 2 / checks: 1,3 / release_note: 1
batch: result -> Production / Unit (Recommended)+Lint / Routine (Recommended)

group: user taps Other… -> bot sends personal Force Reply with a native text mention -> keyboard clears
group: bot -> OpenClaw, reply with your own answer.
group: typed answer resolves deploy_target through the live Gateway question
```

Free-text values are intentionally not echoed into the final question annotation because they can contain secrets, mentions, or transport markup. Telegram keeps the Force Reply helper message after submission; the native composer closes when the user sends the reply. The group proof disabled streaming so the recorder could inspect one new button message; the default-progress DM runs separately proved the question cannot be overwritten.

## Scope

- Overlap checked: #130223 gates tool availability by channel capability. This PR owns presentation, answer normalization, and Telegram interaction, so it does not duplicate that change.
- Production LOC: +452/-159 (net +293). The growth adds the portable custom-input contract, compact native callbacks, sender-targeted Force Reply, model guidance, answer normalization, and one shared owner-order mapping for three channel adapters. No new persistent state or request-time network lookup was added. Test/support: +756/-126. Docs: +27/-8. Assertion baseline: -1.
