### PR TITLE
refactor(chat): share terminal ack normalization

### DIFF
--- a/src/acp/translator.prompt-stream.ts
+++ b/src/acp/translator.prompt-stream.ts
@@ -11,9 +11,9 @@ import type {
 import { readBool, readMetadataString, readNonNegativeInteger } from "@openclaw/acp-core/meta";
 import type { AcpSessionStore } from "@openclaw/acp-core/session";
 import type { AcpServerOptions } from "@openclaw/acp-core/types";
-import { normalizeLowercaseStringOrEmpty as normalizedChatSendAckStatus } from "@openclaw/normalization-core/string-coerce";
 import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
 import type { GatewayClient } from "../gateway/client.js";
+import { normalizeTerminalChatSendAckStatus } from "../shared/chat-send-ack-status.js";
 import { createDeferredCore, type Deferred } from "../shared/deferred.js";
 import { shortenHomePath } from "../utils.js";
 import { extractAttachmentsFromPrompt, extractTextFromPrompt } from "./event-mapper.js";
@@ -43,15 +43,6 @@ type AcpPendingPromptAdmission = {
   closure: Deferred;
   settled: Deferred;
 };
-
-function isTerminalChatSendAckFailure(status: unknown): boolean {
-  const normalized = normalizedChatSendAckStatus(status);
-  return normalized === "timeout" || normalized === "error";
-}
-
-function isTerminalChatSendAckSuccess(status: unknown): boolean {
-  return normalizedChatSendAckStatus(status) === "ok";
-}
 
 function isAdminScopeProvenanceRejection(err: unknown): boolean {
   if (!(err instanceof Error)) {
@@ -301,7 +292,7 @@ export class AcpTranslatorPromptStream {
           return true;
         };
         const applyTerminalAck = async (ack: ChatSendAck | undefined): Promise<boolean> => {
-          const status = normalizedChatSendAckStatus(ack?.status);
+          const status = normalizeTerminalChatSendAckStatus(ack?.status);
           const pending = () => this.getPendingPrompt(params.sessionId, runId);
           if (status === "timeout") {
             const current = pending();
@@ -331,7 +322,7 @@ export class AcpTranslatorPromptStream {
             }
             return true;
           }
-          return isTerminalChatSendAckFailure(status) || isTerminalChatSendAckSuccess(status);
+          return false;
         };
 
         const sendChat = async (payload: Record<string, unknown>): Promise<boolean> => {

--- a/src/shared/chat-send-ack-status.test.ts
+++ b/src/shared/chat-send-ack-status.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTerminalChatSendAckStatus } from "./chat-send-ack-status.js";
+
+describe("normalizeTerminalChatSendAckStatus", () => {
+  it.each<[unknown, "ok" | "timeout" | "error" | undefined]>([
+    ["ok", "ok"],
+    ["timeout", "timeout"],
+    ["error", "error"],
+    ["ERROR", "error"],
+    [" timeout ", "timeout"],
+    ["started", undefined],
+    ["", undefined],
+    [42, undefined],
+    [null, undefined],
+    [{}, undefined],
+  ])("normalizes %j to %s", (status, expected) => {
+    expect(normalizeTerminalChatSendAckStatus(status)).toBe(expected);
+  });
+});

--- a/src/shared/chat-send-ack-status.ts
+++ b/src/shared/chat-send-ack-status.ts
@@ -1,0 +1,10 @@
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+
+export function normalizeTerminalChatSendAckStatus(
+  status: unknown,
+): "ok" | "timeout" | "error" | undefined {
+  const normalized = normalizeLowercaseStringOrEmpty(status);
+  return normalized === "ok" || normalized === "timeout" || normalized === "error"
+    ? normalized
+    : undefined;
+}

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -2,7 +2,6 @@
 import { randomUUID } from "node:crypto";
 import type { Component, OverlayHandle, SelectItem, TUI } from "@earendil-works/pi-tui";
 import type { Result } from "@openclaw/normalization-core/result";
-import { normalizeLowercaseStringOrEmpty as normalizedChatSendAckStatus } from "@openclaw/normalization-core/string-coerce";
 import type { SessionsPatchResult } from "../../packages/gateway-protocol/src/index.js";
 import { modelKey } from "../agents/model-ref-shared.js";
 import { shouldForwardModelCommandToServer } from "../auto-reply/commands-registry.shared.js";
@@ -19,6 +18,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
+import { normalizeTerminalChatSendAckStatus } from "../shared/chat-send-ack-status.js";
 import {
   formatTuiLevelCommandUsage,
   helpText,
@@ -106,15 +106,6 @@ function isBtwCommand(text: string): boolean {
 function isSlashStopCommand(text: string): boolean {
   const trimmed = text.trim();
   return trimmed.startsWith("/") && isChatStopCommandText(trimmed);
-}
-
-function isTerminalChatSendAckFailure(status: unknown): boolean {
-  const normalized = normalizedChatSendAckStatus(status);
-  return normalized === "timeout" || normalized === "error";
-}
-
-function isTerminalChatSendAckSuccess(status: unknown): boolean {
-  return normalizedChatSendAckStatus(status) === "ok";
 }
 
 const TERMINAL_CHAT_SEND_FAILURE_MESSAGE = "Chat failed before the run started; try again.";
@@ -934,9 +925,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         runId,
       });
       const acceptedRunId = sendResult.runId || runId;
-      const terminalAckFailure = isTerminalChatSendAckFailure(sendResult.status);
-      const terminalAckSuccess = isTerminalChatSendAckSuccess(sendResult.status);
-      const terminalAck = terminalAckFailure || terminalAckSuccess;
+      const terminalAckStatus = normalizeTerminalChatSendAckStatus(sendResult.status);
+      const terminalAckFailure = terminalAckStatus === "timeout" || terminalAckStatus === "error";
+      const terminalAck = terminalAckStatus !== undefined;
       if (!isCurrentSendViewport()) {
         if (isBtw) {
           forgetLocalBtwRunId?.(runId);


### PR DESCRIPTION
## What Problem This Solves

ACP and TUI independently normalized the same terminal `chat.send` acknowledgement statuses. Keeping those predicates duplicated makes the accepted terminal set easier to drift across two operator-facing clients.

## Why This Change Was Made

Move the existing `ok` / `timeout` / `error` normalization into one private shared helper and reuse it from ACP and TUI. Each caller keeps its existing success, failure, cleanup, and non-terminal behavior.

## User Impact

No user-visible behavior change. Terminal chat acknowledgements now have one canonical normalization path across ACP and TUI.

## Evidence

- Focused ACP, TUI, and helper tests: 260 passed.
- Fresh AWS Crabbox run `run_33c91e58be63` on lease `cbx_ba45a4cdcebf`: frozen install passed; all 260 tests passed; lease stopped.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `check-changed`: passed.
- Autoreview: clean, 0.99 confidence.
- Production delta: +17 / -25, net -8 lines. Tests: +19 lines.
