### PR TITLE
fix(auth): inherit the shared auth store once it owns credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,7 +335,7 @@ Mechanics only; policy lives above.
 ## Security / Release
 
 - Never commit real phone numbers, videos, credentials, live config.
-- Secrets: channel/provider creds in `~/.openclaw/credentials/`; model auth profiles in `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite` (`auth_profile_store`).
+- Secrets: channel/provider creds in `~/.openclaw/credentials/`; shared model auth profiles in `~/.openclaw/state/openclaw.sqlite`, with agent-local profiles overriding the shared read-through base; see `docs/auth-credential-semantics.md`.
 - SecretRef failures isolate to the smallest known owning surface; unknown ownership fails closed. Gateway starts degraded (exact owner marked configured-unavailable, typed redacted diagnostic, no implicit credential fallback) rather than refusing startup, except for its own ingress protection or structurally invalid config. Doctor and status list every degraded owner. Full doctrine: `docs/gateway/secrets.md`.
 - Dependency patches/overrides/vendor changes need explicit approval. `pnpm-workspace.yaml` patched dependencies use exact versions only.
 - Release/package guards: no hard-coded retired-package denylists; use generic artifact/dependency checks or fix build source.

--- a/src/agents/legacy-inherited-auth-dir.ts
+++ b/src/agents/legacy-inherited-auth-dir.ts
@@ -5,6 +5,7 @@ import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveAgentDir } from "./agent-scope-config.js";
+import { resolveSharedAuthStoreOwnership } from "./auth-profiles/path-resolve.js";
 
 export function resolveLegacyInheritedAuthAgentId(config: OpenClawConfig): string {
   return (
@@ -14,11 +15,20 @@ export function resolveLegacyInheritedAuthAgentId(config: OpenClawConfig): strin
   );
 }
 
-export function resolveLegacyInheritedAuthDir(
+export function resolveLegacyInheritedAuthAgentDir(
   config: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
   return resolveAgentDir(config, resolveLegacyInheritedAuthAgentId(config), env);
+}
+
+export function resolveLegacyInheritedAuthDir(
+  config: OpenClawConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return resolveSharedAuthStoreOwnership(env).location === "legacy-main"
+    ? resolveLegacyInheritedAuthAgentDir(config, env)
+    : undefined;
 }
 
 export function pinLegacyInheritedAuthOwnerForRosterTransition(

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -10,6 +10,10 @@ import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths
 import { withEnvAsync } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { clearRuntimeAuthProfileStoreSnapshots } from "./auth-profiles/runtime-snapshots.js";
+import {
+  inspectPersistedAuthProfileStoreRaw,
+  writePersistedAuthProfileStoreRaw,
+} from "./auth-profiles/sqlite.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
 import type {
   AuthProfileCredential,
@@ -17,7 +21,9 @@ import type {
   OAuthCredential,
   RuntimeAuthProfileStore,
 } from "./auth-profiles/types.js";
+import { upsertAuthProfileWithLockOrThrow } from "./auth-profiles/upsert-with-lock.js";
 import { resolveInlineProviderApiKeyUsageId } from "./auth-profiles/usage.js";
+import { resolveLegacyInheritedAuthDir } from "./legacy-inherited-auth-dir.js";
 import {
   createRuntimeProviderAuthLookup,
   getApiKeyForModelCore,
@@ -413,6 +419,92 @@ async function resolveDemoLocalApiKey(params: {
     });
   });
 }
+
+describe("shared auth profile read-through", () => {
+  it.each([
+    {
+      name: "resolves a freshly pasted shared API key without an agent-local profile",
+      baseKey: "shared-state-key",
+      legacy: false,
+      localKey: undefined,
+    },
+    {
+      name: "keeps the populated legacy main store authoritative before relocation",
+      baseKey: "legacy-main-key",
+      legacy: true,
+      localKey: undefined,
+    },
+    {
+      name: "lets an agent-local profile override its shared read-through base",
+      baseKey: "shared-state-key",
+      legacy: false,
+      localKey: "agent-local-key",
+    },
+  ])("$name", async ({ baseKey, legacy, localKey }) => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-auth-read-through-",
+        agentEnv: "main",
+        env: { OPENAI_API_KEY: undefined },
+      },
+      async (state) => {
+        const profileId = "openai:manual";
+        const mainAgentDir = state.agentDir();
+        const agentDir = state.agentDir("worker");
+        const credential = {
+          type: "api_key" as const,
+          provider: "openai",
+          key: baseKey,
+        };
+
+        if (legacy) {
+          writePersistedAuthProfileStoreRaw(
+            { version: 1, profiles: { [profileId]: credential } },
+            mainAgentDir,
+          );
+        }
+        await upsertAuthProfileWithLockOrThrow({
+          profileId,
+          credential,
+          agentDir: mainAgentDir,
+        });
+        if (localKey) {
+          writePersistedAuthProfileStoreRaw(
+            {
+              version: 1,
+              profiles: { [profileId]: { ...credential, key: localKey } },
+            },
+            agentDir,
+          );
+        }
+
+        expect(inspectPersistedAuthProfileStoreRaw(mainAgentDir).status).toBe(
+          legacy ? "readable" : "missing",
+        );
+        expect(inspectPersistedAuthProfileStoreRaw(agentDir).status).toBe(
+          localKey ? "readable" : "missing",
+        );
+
+        const inheritedAuthDir = resolveLegacyInheritedAuthDir({}, state.env);
+        const store = ensureAuthProfileStore(agentDir, {
+          allowKeychainPrompt: false,
+          syncExternalCli: false,
+          ...(inheritedAuthDir ? { inheritedAuthDir } : {}),
+        });
+        const resolved = await resolveApiKeyForProviderCore({
+          provider: "openai",
+          cfg: {},
+          agentDir,
+          store,
+        });
+
+        expect(resolved.apiKey).toBe(localKey ?? baseKey);
+        expect(resolved.source).toBe(`profile:${profileId}`);
+      },
+    );
+  });
+});
 
 describe("getApiKeyForModelCore", () => {
   it("reads oauth auth-profiles entries from auth-profiles.json via explicit profile", async () => {

--- a/src/agents/prepared-model-catalog-worker.test.ts
+++ b/src/agents/prepared-model-catalog-worker.test.ts
@@ -84,6 +84,7 @@ describe("prepared model catalog worker input", () => {
     expect(cloned.input.runtimePluginSelections).toEqual([
       { provider: "selected", modelId: "model" },
     ]);
+    expect(cloned.input).not.toHaveProperty("inheritedAuthDir");
     expect(cloned.input).not.toHaveProperty("loadRuntimePlugins");
   });
 });

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -102,7 +102,7 @@ export function createPreparedModelCatalogWorkerInput(params: {
   const input: PreparedModelRuntimeInput = {
     ...(source.agentId ? { agentId: source.agentId } : {}),
     agentDir: source.agentDir,
-    inheritedAuthDir: source.inheritedAuthDir ?? source.agentDir,
+    ...(source.inheritedAuthDir ? { inheritedAuthDir: source.inheritedAuthDir } : {}),
     ...(source.workspaceDir ? { workspaceDir: source.workspaceDir } : {}),
     ...(source.readOnly ? { readOnly: true } : {}),
     skipCredentials: true,

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -50,7 +50,7 @@ import type {
   AuthProfileState,
   AuthProfileStore,
 } from "../agents/auth-profiles/types.js";
-import { resolveLegacyInheritedAuthDir } from "../agents/legacy-inherited-auth-dir.js";
+import { resolveLegacyInheritedAuthAgentDir } from "../agents/legacy-inherited-auth-dir.js";
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { AuthProfileConfig } from "../config/types.auth.js";
@@ -450,7 +450,7 @@ function isDefaultAgentCandidate(
 ): boolean {
   return (
     candidate.agentDir === undefined ||
-    path.resolve(candidate.agentDir) === path.resolve(resolveLegacyInheritedAuthDir(cfg, env))
+    path.resolve(candidate.agentDir) === path.resolve(resolveLegacyInheritedAuthAgentDir(cfg, env))
   );
 }
 

--- a/src/commands/doctor-auth-legacy-paths.ts
+++ b/src/commands/doctor-auth-legacy-paths.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import { listAgentIds, resolveAgentDir } from "../agents/agent-scope.js";
 import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
-import { resolveLegacyInheritedAuthDir } from "../agents/legacy-inherited-auth-dir.js";
+import { resolveLegacyInheritedAuthAgentDir } from "../agents/legacy-inherited-auth-dir.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveUserPath } from "../utils.js";
@@ -67,7 +67,7 @@ export function listAuthProfileRepairCandidates(
   // The shared-main default store (undefined agentDir) must stay first so the
   // canonical location wins the per-path dedupe over agent-scoped aliases.
   addCandidate(candidates, undefined);
-  addCandidate(candidates, resolveLegacyInheritedAuthDir(cfg, env));
+  addCandidate(candidates, resolveLegacyInheritedAuthAgentDir(cfg, env));
   const envAgentDir =
     readNonBlankString(env.OPENCLAW_AGENT_DIR) ?? readNonBlankString(env.PI_CODING_AGENT_DIR);
   if (envAgentDir) {

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -428,7 +428,9 @@ describe("modelsListCommand forward-compat", () => {
     expect(mocks.resolveModelsTargetAgent).toHaveBeenCalledWith(mocks.resolvedConfig, "research", {
       kind: "read",
     });
-    expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/openclaw-agent-research");
+    expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/openclaw-agent-research", {
+      inheritedAuthDir: expect.any(String),
+    });
   });
 
   it("rejects unknown provider filters before loading the model registry", async () => {

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -2,6 +2,7 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import { resolveLegacyInheritedAuthDir } from "../../agents/legacy-inherited-auth-dir.js";
 import { parseModelRef } from "../../agents/model-selection-normalize.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { ExpectedCliError } from "../../cli/failure-output.js";
@@ -119,7 +120,10 @@ export async function modelsListCommand(
       throw new ExpectedCliError({ message, humanOutput: message, machineOutput: message });
     }
   }
-  const authStore = loadAuthProfileStoreWithoutExternalProfiles(agentDir);
+  const inheritedAuthDir = resolveLegacyInheritedAuthDir(cfg);
+  const authStore = inheritedAuthDir
+    ? loadAuthProfileStoreWithoutExternalProfiles(agentDir, { inheritedAuthDir })
+    : loadAuthProfileStoreWithoutExternalProfiles(agentDir);
   const authIndex = createModelListAuthIndex({
     cfg,
     authStore,
@@ -215,7 +219,7 @@ export async function modelsListCommand(
     cfg,
     agentId,
     agentDir,
-    inheritedAuthDir: agentDir,
+    ...(inheritedAuthDir ? { inheritedAuthDir } : {}),
     authIndex,
     providerDiscoveryProviderIds,
     providerRuntimeDiscoveryProviderIds,

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -1026,7 +1026,6 @@ describe("appendAuthenticatedCatalogRows", () => {
     expect(mocks.loadScopedModelCatalogSnapshot).toHaveBeenCalledWith({
       cfg: {},
       agentDir: "/tmp/openclaw-agent",
-      inheritedAuthDir: "/tmp/openclaw-agent",
       workspaceDir: "/tmp/openclaw-workspace",
       providerIds: ["local-openai"],
       runtimeProviderIds: ["local-openai"],

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -404,7 +404,7 @@ export async function loadListModelCatalogSnapshot(
       cfg: context.cfg,
       ...(context.agentId ? { agentId: context.agentId } : {}),
       agentDir: context.agentDir,
-      inheritedAuthDir: context.inheritedAuthDir ?? context.agentDir,
+      ...(context.inheritedAuthDir ? { inheritedAuthDir: context.inheritedAuthDir } : {}),
       ...(workspaceDir ? { workspaceDir } : {}),
       providerIds: context.providerDiscoveryProviderIds,
       runtimeProviderIds: context.providerRuntimeDiscoveryProviderIds,

--- a/src/commands/models/list.scoped-catalog.test.ts
+++ b/src/commands/models/list.scoped-catalog.test.ts
@@ -108,6 +108,9 @@ describe("loadScopedListModelCatalogSnapshot", () => {
       expect.objectContaining({ readOnly: true }),
       ["openai"],
     );
+    expect(mocks.prepareScopedReadOnlyLiveModelCatalog.mock.calls[0]?.[0]).not.toHaveProperty(
+      "inheritedAuthDir",
+    );
   });
 
   it("uses authenticated manifest fallback rows without loading provider runtime", async () => {

--- a/src/commands/models/list.scoped-catalog.ts
+++ b/src/commands/models/list.scoped-catalog.ts
@@ -234,7 +234,7 @@ export async function loadScopedListModelCatalogSnapshot(params: {
       config: params.cfg,
       ...(params.agentId ? { agentId: params.agentId } : {}),
       agentDir: params.agentDir,
-      inheritedAuthDir: params.inheritedAuthDir ?? params.agentDir,
+      ...(params.inheritedAuthDir ? { inheritedAuthDir: params.inheritedAuthDir } : {}),
       ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
       readOnly: true,
     },

--- a/src/gateway/server-methods/provider-usage-runtime.ts
+++ b/src/gateway/server-methods/provider-usage-runtime.ts
@@ -1,4 +1,5 @@
 // Prepared provider-usage discovery and credential ownership for Gateway status RPCs.
+import { resolveAgentDir } from "../../agents/agent-scope-config.js";
 import {
   ensureAuthProfileStore,
   externalCliDiscoveryForConfigStatus,
@@ -11,10 +12,7 @@ import {
   fingerprintAuthProfileOwnerShape,
   fingerprintResolvedProviderAuth,
 } from "../../agents/execution-auth-binding.js";
-import {
-  resolveLegacyInheritedAuthAgentId,
-  resolveLegacyInheritedAuthDir,
-} from "../../agents/legacy-inherited-auth-dir.js";
+import { resolveLegacyInheritedAuthAgentId } from "../../agents/legacy-inherited-auth-dir.js";
 import { resolveEnvApiKey } from "../../agents/model-auth-env.js";
 import { resolveUsableCustomProviderApiKey } from "../../agents/model-auth.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -113,7 +111,7 @@ export function getProviderUsageRuntimeSnapshot(params: {
   store?: AuthProfileStore;
 }): ProviderUsageRuntimeSnapshot {
   const agentId = params.agentId ?? resolveLegacyInheritedAuthAgentId(params.config);
-  const agentDir = params.agentDir ?? resolveLegacyInheritedAuthDir(params.config);
+  const agentDir = params.agentDir ?? resolveAgentDir(params.config, agentId);
   // Config publication replaces the object, so identity is the exact mutation signal.
   const configRef = params.config;
   // Registry publication owns descriptor lifetime; request paths only compare its O(1) counter.

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -2426,6 +2426,9 @@ describe("gateway server chat", () => {
           },
         },
       });
+      agentDiscoveryMock.enabled = true;
+      agentDiscoveryMock.models = [{ id: "gpt-5", provider: "openai", reasoning: true }];
+      await prepareGatewayReplyRuntimeForTest({ force: true });
 
       const historyRes = await rpcReq<{
         thinkingLevel?: string;
@@ -2436,6 +2439,7 @@ describe("gateway server chat", () => {
       expect(historyRes.payload?.thinkingLevel).toBe("minimal");
       expect(historyRes.payload?.sessionInfo?.thinkingLevel).toBeUndefined();
     } finally {
+      Object.assign(agentDiscoveryMock, { enabled: false, models: [] });
       testState.agentConfig = undefined;
       testState.agentsConfig = undefined;
       testState.sessionStorePath = undefined;

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -359,6 +359,9 @@ function resetGatewayLifecycleTestState(options: { preserveRuntimeBindings: bool
 function resetGatewayMutableTestFixtures(): void {
   testTailnetIPv4.value = undefined;
   testTailscaleWhois.value = null;
+  agentDiscoveryMock.enabled = false;
+  agentDiscoveryMock.discoverCalls = 0;
+  agentDiscoveryMock.models = [];
   testState.gatewayBind = DEFAULT_GATEWAY_TEST_BIND;
   testState.gatewayAuth = { mode: "token", token: "test-gateway-token-1234567890" };
   testState.gatewayControlUi = undefined;
@@ -480,9 +483,6 @@ async function resetGatewayTestState(options: { uniqueConfigRoot: boolean }) {
   const mod = await getServerModule();
   await mod.resetPreparedModelCatalogForTest();
   gatewayReplyRuntimePrepared = false;
-  agentDiscoveryMock.enabled = false;
-  agentDiscoveryMock.discoverCalls = 0;
-  agentDiscoveryMock.models = [];
 }
 
 async function cleanupGatewayTestHome(options: { restoreEnv: boolean }) {

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -6,7 +6,7 @@ import { resolveSharedAuthStorePath } from "../agents/auth-profiles/path-resolve
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
 import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import { resolveLegacyInheritedAuthDir } from "../agents/legacy-inherited-auth-dir.js";
+import { resolveLegacyInheritedAuthAgentDir } from "../agents/legacy-inherited-auth-dir.js";
 import { cloneConfigWithResolutionFacts } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
@@ -60,7 +60,7 @@ export function collectCandidateAgentDirs(
 ): string[] {
   const dirs = new Set<string>();
   dirs.add(resolveUserPath(resolveAgentDir(config, "main", env), env));
-  dirs.add(resolveUserPath(resolveLegacyInheritedAuthDir(config, env), env));
+  dirs.add(resolveUserPath(resolveLegacyInheritedAuthAgentDir(config, env), env));
   for (const agentId of listAgentIds(config)) {
     dirs.add(resolveUserPath(resolveAgentDir(config, agentId, env), env));
   }


### PR DESCRIPTION
## What Problem This Solves

On a fresh install (and any install after the doctor shared-store relocation), `openclaw models auth paste-api-key` prints success — `Auth profile: anthropic:manual (anthropic/api_key)` — but every turn fails with `No API key found for provider ... | missing-provider-auth`. `models status` even displays the shared store with the profile present, so setup looks healthy while the runtime is dead: the worst silent-failure class. Found live during the 50-session cross-machine farm test (openclaw/openclaw#129979), where it zeroed an entire run: 49/50 worker launches completed and every turn failed on missing auth.

## Why This Change Was Made

Root cause: `resolveLegacyInheritedAuthDir` unconditionally selected the legacy main-agent directory as the read-through inheritance base. Per `docs/auth-credential-semantics.md`, agent auth inheritance is read-through to the **shared** store (`state/openclaw.sqlite`, canonical after the doctor relocation — and from birth on fresh installs); the legacy directory is only meaningful while it still owns credentials. With the unconditional selection, a fresh install's empty main-agent DB shadowed the canonical shared store and the runtime never consulted it.

- The resolver now returns the legacy directory only while `resolveSharedAuthStoreOwnership` reports `legacy-main`; otherwise inheritance resolves through the shared store (the existing `undefined → resolveSharedAuthPath` path). Credential writes and the doctor relocation are unchanged — no dual-write, no new fallback reader.
- A separate physical-directory resolver (`resolveLegacyInheritedAuthAgentDir`) preserves doctor migration and secrets discovery, which genuinely address the legacy location.
- The same empty-legacy-shadow existed in sibling catalog paths (`prepared-model-catalog-worker`, `models list` command/rows/scoped-catalog) — fixed with the same predicate.
- The stale root `AGENTS.md` security line naming the per-agent DB as the profile home now states the shared-store + read-through contract (that stale line misdirected the initial diagnosis).

## User Impact

`paste-api-key` (and token/OAuth profiles in the shared store) work on the first turn of a fresh gateway, in any setup ordering. Pre-relocation installs keep their legacy-store behavior; agent-local profiles still override the shared base.

## Evidence

- Live pre/post on the cross-machine rig: identical state dir failed with `missing-provider-auth` on the unfixed build; after deploying this fix (only change), the probe turn replied `FIXED-OK`, and a full 50-session dispatch+turn wave ran (50/50 dispatched in 29s; 38/50 turns completed end-to-end in 105s — the 12 failures are a separate workspace-reconciliation contention finding tracked in openclaw/openclaw#129979).
- Regression tests (verified failing pre-fix): fresh shared-store credential resolves with no agent-local profile; populated legacy store stays authoritative pre-relocation; agent-local profile overrides the shared base. Plus sibling catalog coverage.
- `pnpm check:changed` green; 287 tests across 11 focused files green; Codex autoreview clean (0.96).

Production LOC: +38/-13; tests +91/-7.
