### PR TITLE
fix(plugins): show registered Gateway discovery services during inspection

### DIFF
--- a/src/cli/plugins-cli.inspect.test.ts
+++ b/src/cli/plugins-cli.inspect.test.ts
@@ -63,8 +63,8 @@ describe("plugins cli inspect", () => {
       tools: [],
       commands: [],
       cliCommands: [],
-      services: [],
-      gatewayDiscoveryServices: [],
+      services: ["mem0-background"],
+      gatewayDiscoveryServices: ["mem0-discovery", "mem0-discovery-secondary"],
       mcpServers: [
         { name: "local", hasStdioTransport: true },
         { name: "remote", hasStdioTransport: false },
@@ -89,6 +89,10 @@ describe("plugins cli inspect", () => {
     expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("Policy");
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("allowConversationAccess: true");
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain("Services:\nmem0-background");
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain(
+      "Gateway discovery:\nmem0-discovery\nmem0-discovery-secondary",
+    );
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("ClawHub package: openclaw-mem0");
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("Artifact kind: npm-pack");
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("Npm integrity: sha512-clawpack");
@@ -100,6 +104,12 @@ describe("plugins cli inspect", () => {
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("remote");
     expect(pluginsCliRuntimeLogs.join("\n")).not.toContain("remote (unsupported transport)");
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("broken (unsupported transport)");
+
+    await runPluginsCommand(["plugins", "inspect", "openclaw-mem0", "--json"]);
+    expect(JSON.parse(pluginsCliRuntimeLogs.at(-1) ?? "null")).toMatchObject({
+      services: ["mem0-background"],
+      gatewayDiscoveryServices: ["mem0-discovery", "mem0-discovery-secondary"],
+    });
 
     for (const { id, status, detail, label } of [
       {
@@ -159,7 +169,7 @@ describe("plugins cli inspect", () => {
       commands: [],
       cliCommands: [],
       services: [],
-      gatewayDiscoveryServices: [],
+      gatewayDiscoveryServices: ["mem0-runtime-discovery"],
       mcpServers: [],
       lspServers: [],
       httpRouteCount: 0,
@@ -179,6 +189,7 @@ describe("plugins cli inspect", () => {
         config: {},
         onlyPluginIds: ["openclaw-mem0"],
       });
+      expect(pluginsCliRuntimeLogs.at(-1)).toContain("Gateway discovery:\nmem0-runtime-discovery");
     }
   });
 

--- a/src/cli/plugins-inspect-command.ts
+++ b/src/cli/plugins-inspect-command.ts
@@ -373,6 +373,7 @@ export async function runPluginsInspectCommand(
   lines.push(...formatInspectSection("Commands", inspect.commands));
   lines.push(...formatInspectSection("CLI commands", inspect.cliCommands));
   lines.push(...formatInspectSection("Services", inspect.services));
+  lines.push(...formatInspectSection("Gateway discovery", inspect.gatewayDiscoveryServices));
   lines.push(...formatInspectSection("Gateway methods", inspect.gatewayMethods ?? []));
   lines.push(
     ...formatInspectSection(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators inspecting a plugin would see no evidence of its registered Gateway discovery services, even when runtime inspection had successfully loaded those services. This affected the bundled Bonjour plugin in particular: its only registered service was present in JSON inspection output but silently absent from the normal human-readable result.

## Why This Change Was Made

The plugin inspection owner already records Gateway discovery services separately from ordinary background services, but the human-readable projection omitted that existing field after discovery registrations were split into their own category. Render every discovery registration under the documented Gateway discovery heading while preserving ordinary services, exact plugin selection, cold and runtime inspection, and the existing JSON contract.

## User Impact

`openclaw plugins inspect <plugin>` and `openclaw plugins inspect <plugin> --runtime` now show all registered Gateway discovery services, so operators can verify Bonjour and other discovery plugins without switching to JSON or guessing whether registration succeeded.

## Evidence

- Authentic pre-fix real-Commander regression: `node scripts/run-vitest.mjs src/cli/plugins-cli.inspect.test.ts` failed in both normal and `--runtime` inspection because the registered discovery services were missing from human output; ordinary services remained visible.
- Final owner, CLI sibling, and actual bundled Bonjour coverage: `node scripts/run-vitest.mjs src/cli/plugins-cli.inspect.test.ts src/cli/plugins-list-command.test.ts src/cli/plugins-list-format.test.ts src/plugins/status.test.ts extensions/bonjour/index.test.ts` passed all 49 tests across five files and four Vitest lanes.
- Direct read-only execution of the real bundled Bonjour registration and production inspection owner returned `registeredDiscoveryServices: ["bonjour"]` and `actualProductionInspectJson: ["bonjour"]` without starting discovery or touching Gateway state.
- Changed-file formatting, typed lint, independent review, and structured Codex review all passed. Production delta: +1/-0; regression tests: +14/-3.
