### PR TITLE
fix(gateway): chat history shows injected skill instructions on claude-cli sessions

### DIFF
--- a/extensions/anthropic/session-catalog-history.test.ts
+++ b/extensions/anthropic/session-catalog-history.test.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it, vi } from "vitest";
 import { importClaudeHistory } from "./session-catalog-history.js";
+import { parseTranscriptLine } from "./session-catalog-transcript.js";
 
 const appended: Array<Record<string, unknown>> = [];
 
@@ -20,6 +21,59 @@ vi.mock("openclaw/plugin-sdk/session-transcript-runtime", () => ({
 }));
 
 describe("importClaudeHistory", () => {
+  it("omits metadata without changing other native conversation rows", async () => {
+    appended.length = 0;
+    const parse = (entry: Record<string, unknown>) =>
+      parseTranscriptLine(Buffer.from(JSON.stringify(entry)), (value, maxLength) =>
+        typeof value === "string" && value.length <= maxLength ? value : undefined,
+      );
+    const items = [
+      parse({
+        type: "user",
+        isMeta: true,
+        message: { role: "user", content: "private skill instructions" },
+      }),
+      parse({
+        type: "user",
+        uuid: "operator-1",
+        message: { role: "user", content: "run the review" },
+      }),
+      parse({
+        type: "user",
+        isCompactSummary: true,
+        message: { role: "user", content: "compacted context" },
+      }),
+      parse({
+        type: "user",
+        isVisibleInTranscriptOnly: true,
+        message: { role: "user", content: "transcript-only context" },
+      }),
+      parse({
+        type: "assistant",
+        message: { role: "assistant", content: "done" },
+      }),
+    ].filter((item) => item !== undefined);
+
+    await importClaudeHistory({
+      items,
+      threadId: "thread-1",
+      storePath: "/tmp/sessions.json",
+      sessionId: "session-1",
+      sessionKey: "agent:main:catalog-adopt",
+      agentId: "main",
+      config: {} as OpenClawConfig,
+    });
+
+    expect(JSON.stringify(appended)).not.toContain("private skill instructions");
+    expect(appended.find((message) => message.content === "run the review")?.provenance).toBe(
+      undefined,
+    );
+    expect(appended.map((message) => message.content)).toEqual(
+      expect.arrayContaining(["run the review", "compacted context", "transcript-only context"]),
+    );
+    expect(appended.find((message) => message.role === "assistant")).toBeDefined();
+  });
+
   it("preserves Date.parse semantics for valid strings and falls back for invalid values", async () => {
     appended.length = 0;
     const fallbackTimestamp = new Date("2026-07-18T12:00:00.000Z").getTime();

--- a/extensions/anthropic/session-catalog-transcript.ts
+++ b/extensions/anthropic/session-catalog-transcript.ts
@@ -66,7 +66,7 @@ export function parseTranscriptLine(
   } catch {
     return undefined;
   }
-  if (!isRecord(raw) || raw.isSidechain === true || !isRecord(raw.message)) {
+  if (!isRecord(raw) || raw.isSidechain === true || raw.isMeta === true || !isRecord(raw.message)) {
     return undefined;
   }
   const role = raw.message.role;

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -275,24 +275,17 @@ type ClaudeCliPromptTextCandidate = {
   blockIndex?: number;
 };
 
-// Claude marks harness-written user turns with isMeta (skill instruction
-// bodies, injected notices), isCompactSummary (compaction summaries), and
-// isVisibleInTranscriptOnly (transcript-only synthetic rows); its own UI
-// groups these flags as "not a real operator turn" (verified against the
-// v2.1.246 bundle). The operator never typed these rows.
-function isClaudeCliHarnessInjectedEntry(entry: ClaudeCliProjectEntry): boolean {
-  return (
-    entry.isMeta === true ||
-    entry.isCompactSummary === true ||
-    entry.isVisibleInTranscriptOnly === true
-  );
+// Claude keeps compact summaries and transcript-only rows as visible harness
+// context. isMeta rows are private injections and never reach this projection.
+function isClaudeCliVisibleHarnessContext(entry: ClaudeCliProjectEntry): boolean {
+  return entry.isCompactSummary === true || entry.isVisibleInTranscriptOnly === true;
 }
 
 export function resolveClaudeCliPromptTextCandidates(
   entry: ClaudeCliProjectEntry,
   content: string | unknown[],
 ): ClaudeCliPromptTextCandidate[] {
-  if (isClaudeCliHarnessInjectedEntry(entry)) {
+  if (entry.isMeta === true || isClaudeCliVisibleHarnessContext(entry)) {
     return [];
   }
   if (typeof content === "string") {
@@ -328,7 +321,12 @@ export function parseClaudeCliHistoryEntry(
     reseedState?: ReseedImportState;
   },
 ): TranscriptLikeMessage | null {
-  if (entry.isSidechain === true || !entry.message || typeof entry.message !== "object") {
+  if (
+    entry.isSidechain === true ||
+    entry.isMeta === true ||
+    !entry.message ||
+    typeof entry.message !== "object"
+  ) {
     return null;
   }
   const type = typeof entry.type === "string" ? entry.type : undefined;
@@ -412,7 +410,7 @@ export function parseClaudeCliHistoryEntry(
     }
     // Record provenance here, where the native flags are known, so downstream
     // display never has to infer operator authorship from message text.
-    const harnessInjected = isClaudeCliHarnessInjectedEntry(entry);
+    const harnessInjected = isClaudeCliVisibleHarnessContext(entry);
     return attachOpenClawTranscriptMeta(
       {
         role: "user",

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -415,7 +415,7 @@ describe("cli session history", () => {
     });
   });
 
-  it("records internal_system provenance for harness-injected user turns only", async () => {
+  it("omits isMeta rows and records visible harness context provenance", async () => {
     await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
       await fs.writeFile(
         filePath,
@@ -470,20 +470,17 @@ describe("cli session history", () => {
 
       const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
 
-      expect(messages).toHaveLength(4);
+      expect(messages).toHaveLength(3);
+      expect(JSON.stringify(messages)).not.toContain("Base directory for this skill");
       // The operator-authored turn stays free of injected provenance.
       expectFields(messages[0], { role: "user" });
       expect(readRecord(messages[0]).provenance).toBeUndefined();
-      // Harness-written turns carry the provenance recorded by the CLI flags.
+      // Compact summaries and transcript-only rows stay visible as internal context.
       expectFields(readRecord(messages[1]).provenance, {
         kind: "internal_system",
         sourceTool: "cli_harness_context",
       });
       expectFields(readRecord(messages[2]).provenance, {
-        kind: "internal_system",
-        sourceTool: "cli_harness_context",
-      });
-      expectFields(readRecord(messages[3]).provenance, {
         kind: "internal_system",
         sourceTool: "cli_harness_context",
       });

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -5208,7 +5208,7 @@ describe("gateway server chat", () => {
         }>(ws, "chat.history", makeMainSessionParams({ limit: 100 }));
         expect(history.ok).toBe(true);
         const messages = history.payload?.messages ?? [];
-        expect(messages).toHaveLength(108);
+        expect(messages).toHaveLength(107);
         const userMessage = expectDefined(messages[0], "oldest imported user message") as {
           role?: string;
           content?: string;
@@ -5218,17 +5218,9 @@ describe("gateway server chat", () => {
         expect(userMessage.content).toBe("hi");
         // The operator-authored turn carries no injected provenance.
         expect(userMessage.provenance).toBeUndefined();
-        const injectedMessage = expectDefined(
-          messages[1],
-          "harness-injected imported user message",
-        ) as { role?: string; provenance?: unknown };
-        expect(injectedMessage.role).toBe("user");
-        expect(injectedMessage.provenance).toMatchObject({
-          kind: "internal_system",
-          sourceTool: "cli_harness_context",
-        });
+        expect(JSON.stringify(messages)).not.toContain("Base directory for this skill");
         const assistantMessage = expectDefined(
-          messages[2],
+          messages[1],
           "oldest imported assistant message",
         ) as { role?: string; provider?: string };
         expect(assistantMessage.role).toBe("assistant");
@@ -5236,9 +5228,9 @@ describe("gateway server chat", () => {
         expect(JSON.stringify(messages)).toContain("imported message 105");
         expect(history.payload?.hasMore).toBe(false);
         expect(history.payload?.nextOffset).toBeUndefined();
-        expect(history.payload?.totalMessages).toBe(108);
+        expect(history.payload?.totalMessages).toBe(107);
         expect(history.payload?.completeSnapshot).toBe(true);
-        expect(new Set(messages.map((message) => message["__openclaw"]?.id)).size).toBe(108);
+        expect(new Set(messages.map((message) => message["__openclaw"]?.id)).size).toBe(107);
       } finally {
         homeEnvSnapshot.restore();
       }


### PR DESCRIPTION
Closes #130268

## What Problem This Solves

Claude Code marks injected skill bodies and other private harness input with `isMeta: true`. OpenClaw imported those rows as ordinary user messages, so `chat.history` returned instructions that the operator did not write.

## Why This Change Was Made

Both Claude transcript import paths now reject `isMeta` rows before they create an OpenClaw message. The fix uses Claude's native marker and does not inspect message text.

The repair keeps real user commands, assistant replies, compact summaries, transcript-only context, tool rows, and reseed handling on their existing paths.

### Maintainer decision

Full omission is intentional. `isMeta` is private harness input, so it must not be inspectable through `chat.history`. This replaces the collapsed-notice treatment for `isMeta` only; compact summaries and transcript-only context keep that treatment.

## User Impact

Claude CLI session history now contains only the real conversation and the existing visible context rows. Private skill instructions no longer enter `chat.history`, including after session-catalog adoption.

## Evidence

- Live red/green: generated an isolated Claude Code 2.1.246 transcript with one test skill command, its native `isMeta` instruction row, and one assistant reply.
- Exact main `345b2235e3c0b2f702bc1ccf06ce42a397dc0991`: the production importer and an authenticated isolated Gateway `chat.history` request each returned three messages, including the injected instruction body.
- Exact pre-rebase head `7de3acdc38379e2e30bd8c76c32754455ea67524`: the same importer and Gateway request each returned only the real command and assistant reply; both native message identifiers remained stable.
- Current head `2bf55f694ee883ac8e3986796bf1b7ff7930c367` is a patch-identical rebase onto main `871b18dff5039484e86c76d282699a8defcb1654`; stable patch ID: `7b13b4157d151c06374494252ed1e33acce9bf06`.
- Regression proof: the importer, Gateway request, and session-catalog tests fail on the frozen main implementation and pass on this head.
- Validation: 53 Claude history tests pass; 5 Anthropic session-catalog import tests pass; the focused Gateway request test passes; `pnpm check:changed` passes.

```text
main  importer=3 gateway=3 injected=true  command=true reply=true stable-ids=true
head  importer=2 gateway=2 injected=false command=true reply=true stable-ids=true
```

### Control UI

The head capture uses the proven pre-rebase head with the sanitized message set retained from the exact Gateway run. The current head has the same patch, and the UI renderer does not change in this pull request.

| Main | Head |
| --- | --- |
| The injected context is present and expanded. | Only the real user and assistant messages remain. |
| ![Main shows injected context](https://github.com/user-attachments/assets/75676eb9-bf00-4412-a050-8488de9b7f9f) | ![Head omits injected context](https://github.com/user-attachments/assets/984f2f8b-6b0d-4e27-8586-c3c9b75f5caf) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
