### PR TITLE
fix(onboard): recover manual handoff after browser launch failure

### DIFF
--- a/src/commands/dashboard.links.test.ts
+++ b/src/commands/dashboard.links.test.ts
@@ -1,5 +1,5 @@
 // Dashboard link tests cover dashboard command URL resolution and config snapshot handling.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { dashboardCommand } from "./dashboard.js";
 
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
@@ -91,6 +91,10 @@ function mockSnapshot(token: unknown = "abc") {
 }
 
 describe("dashboardCommand", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   beforeEach(() => {
     resetRuntime();
     readConfigFileSnapshotMock.mockClear();
@@ -224,6 +228,23 @@ describe("dashboardCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith(
       "Browser launch failed. Open the one-time pairing URL copied to clipboard.",
     );
+  });
+
+  it("prints the SSH hint when browser and clipboard delivery fail after support detection", async () => {
+    vi.stubEnv("SSH_CONNECTION", "192.0.2.1 12345 192.0.2.2 22");
+    mockSnapshot("shhhh");
+    copyToClipboardMock.mockResolvedValue(false);
+    detectBrowserOpenSupportMock.mockResolvedValue({ ok: true });
+    openUrlMock.mockResolvedValue(false);
+    formatControlUiSshHintMock.mockReturnValue("ssh hint");
+
+    await dashboardCommand(runtime);
+
+    expect(formatControlUiSshHintMock).toHaveBeenCalledWith({
+      port: 18789,
+      basePath: undefined,
+    });
+    expect(runtime.log).toHaveBeenCalledWith("ssh hint");
   });
 
   it("never passes token to SSH hint (CVE regression — SSH path)", async () => {

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1,6 +1,7 @@
 // Implements `openclaw dashboard` URL resolution, readiness check, clipboard, and browser launch.
 import { readConfigFileSnapshot } from "../config/config.js";
 import { copyToClipboard } from "../infra/clipboard.js";
+import { isRemoteEnvironment } from "../infra/remote-env.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import {
   hasVerifiedControlUiLoopbackAlias,
@@ -199,11 +200,18 @@ export async function dashboardCommand(
     const browserSupport = await detectBrowserOpenSupport();
     if (browserSupport.ok) {
       opened = await openUrl(browserUrl);
-      hint = opened
-        ? undefined
-        : copied
-          ? "Browser launch failed. Open the one-time pairing URL copied to clipboard."
-          : "Browser launch failed. Open the Dashboard URL above manually.";
+      if (!opened && !copied && isRemoteEnvironment()) {
+        hint = formatControlUiSshHint({
+          port,
+          basePath,
+        });
+      } else {
+        hint = opened
+          ? undefined
+          : copied
+            ? "Browser launch failed. Open the one-time pairing URL copied to clipboard."
+            : "Browser launch failed. Open the Dashboard URL above manually.";
+      }
     } else {
       hint = formatControlUiSshHint({
         port,

--- a/src/commands/onboard-browser-handoff.test.ts
+++ b/src/commands/onboard-browser-handoff.test.ts
@@ -247,42 +247,62 @@ describe("runBrowserHatchHandoff", () => {
     expect(displayed).not.toContain("#bootstrapToken=");
   });
 
-  it("attempts a forwarded-display SSH browser open and uses the GUI timeout on failure", async () => {
-    sharedMocks.detectBrowserOpenSupport.mockResolvedValueOnce({ ok: true, command: "xdg-open" });
-    const prompter = createWizardPrompter();
-    const openBrowser = vi.fn(async () => false);
-    const pollForClient = vi.fn(async () => ({
-      connected: false as const,
-      reason: "timeout" as const,
-    }));
-    const env = {
-      DISPLAY: "localhost:10.0",
-      SSH_CONNECTION: "192.0.2.1 12345 192.0.2.2 22",
-    };
+  it.each([
+    {
+      openerOutcome: "returns false",
+      openBrowser: vi.fn(async () => false),
+    },
+    {
+      openerOutcome: "rejects",
+      openBrowser: vi.fn(async () => {
+        throw new Error("browser command failed");
+      }),
+    },
+  ])(
+    "falls back to the SSH hint and manual timeout when the browser opener $openerOutcome",
+    async ({ openBrowser }) => {
+      sharedMocks.detectBrowserOpenSupport.mockResolvedValueOnce({
+        ok: true,
+        command: "xdg-open",
+      });
+      const prompter = createWizardPrompter();
+      const pollForClient = vi.fn(async () => ({
+        connected: false as const,
+        reason: "timeout" as const,
+      }));
+      const env = {
+        DISPLAY: "localhost:10.0",
+        SSH_CONNECTION: "192.0.2.1 12345 192.0.2.2 22",
+      };
 
-    const result = await runBrowserHatchHandoff(
-      { config: {}, prompter },
-      {
-        env,
-        platform: "linux",
-        openBrowser,
-        resolveTarget: async () => target,
-        probePresence: async () => ({ reachable: true, clientKeys: [] }),
-        pollForClient,
-      },
-    );
+      const result = await runBrowserHatchHandoff(
+        { config: {}, prompter },
+        {
+          env,
+          platform: "linux",
+          openBrowser,
+          resolveTarget: async () => target,
+          probePresence: async () => ({ reachable: true, clientKeys: [] }),
+          pollForClient,
+        },
+      );
 
-    expect(result).toEqual({ handedOff: false, reason: "timeout" });
-    expect(sharedMocks.detectBrowserOpenSupport).toHaveBeenCalledWith(
-      expect.objectContaining({ env, platform: "linux" }),
-    );
-    expect(openBrowser).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=one-time-bootstrap",
-    );
-    expect(pollForClient).toHaveBeenCalledWith(
-      expect.objectContaining({ target, timeoutMs: 60_000 }),
-    );
-  });
+      expect(result).toEqual({ handedOff: false, reason: "timeout" });
+      expect(sharedMocks.detectBrowserOpenSupport).toHaveBeenCalledWith(
+        expect.objectContaining({ env, platform: "linux" }),
+      );
+      expect(openBrowser).toHaveBeenCalledWith(
+        "http://127.0.0.1:18789/#bootstrapToken=one-time-bootstrap",
+      );
+      expect(prompter.note).toHaveBeenCalledWith(
+        expect.stringContaining(target.sshHint),
+        "Continue in your browser",
+      );
+      expect(pollForClient).toHaveBeenCalledWith(
+        expect.objectContaining({ target, timeoutMs: 300_000 }),
+      );
+    },
+  );
 
   it("prints the URL when browser launch fails", async () => {
     sharedMocks.detectBrowserOpenSupport.mockResolvedValueOnce({ ok: true, command: "open" });

--- a/src/commands/onboard-browser-handoff.ts
+++ b/src/commands/onboard-browser-handoff.ts
@@ -258,13 +258,19 @@ export async function runBrowserHatchHandoff(
 
   let opened = false;
   if (canOpenBrowser) {
+    let browserUrl: string;
     try {
       const browserHandoff = await (deps.issueBrowserHandoff ?? issueControlUiBrowserHandoff)(
         target.dashboardUrl,
       );
-      opened = await (deps.openBrowser ?? openUrl)(browserHandoff.browserUrl);
+      browserUrl = browserHandoff.browserUrl;
     } catch {
       return { handedOff: false, reason: "target-unavailable" };
+    }
+    try {
+      opened = await (deps.openBrowser ?? openUrl)(browserUrl);
+    } catch {
+      opened = false;
     }
   }
   if (opened) {
@@ -275,11 +281,18 @@ export async function runBrowserHatchHandoff(
   } else {
     const bind = target.config.gateway?.bind;
     const remoteBind = bind === "lan" || bind === "tailnet" || bind === "custom";
+    const remoteSession = Boolean(
+      env.SSH_CLIENT ||
+      env.SSH_TTY ||
+      env.SSH_CONNECTION ||
+      env.REMOTE_CONTAINERS ||
+      env.CODESPACES,
+    );
     // Plain HTTP on a remote host cannot create the device identity required by
     // the Control UI. Keep those browsers on a tunneled localhost secure context.
-    const directRemoteDisplay = !canOpenBrowser && remoteBind && target.tlsConfig?.enabled === true;
+    const directRemoteDisplay = remoteBind && target.tlsConfig?.enabled === true;
     const tunnelHint =
-      !canOpenBrowser && !directRemoteDisplay
+      !directRemoteDisplay && (!canOpenBrowser || remoteSession)
         ? (target.sshHint ??
           (remoteBind
             ? formatControlUiSshHint({
@@ -318,7 +331,7 @@ export async function runBrowserHatchHandoff(
   const wait = await (deps.pollForClient ?? waitForDashboardClient)({
     target,
     baselineClientKeys: new Set(baseline.clientKeys),
-    timeoutMs: canOpenBrowser ? GUI_HANDOFF_TIMEOUT_MS : HEADLESS_HANDOFF_TIMEOUT_MS,
+    timeoutMs: opened ? GUI_HANDOFF_TIMEOUT_MS : HEADLESS_HANDOFF_TIMEOUT_MS,
     probe: probePresence,
     ...(deps.now ? { now: deps.now } : {}),
     ...(deps.sleep ? { sleep: deps.sleep } : {}),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where onboarding users whose detected browser opener failed would receive only 60 seconds to complete the manual browser handoff. Remote SSH users could also be shown a loopback URL without the tunnel command needed to reach the Gateway, and a rejected opener could terminate the handoff instead of falling back to manual continuation.

The same delivery-state mismatch affected `openclaw dashboard` when both browser launch and clipboard delivery failed in a remote session.

## Why This Change Was Made

Browser capability detection now decides only whether to attempt launch. The actual launch result decides the fallback timeout and guidance: failed or rejected launches enter the five-minute manual path, remote sessions receive SSH tunnel instructions, and local launch failures keep the ordinary clean URL guidance. Bootstrap issuance failures remain fail-closed.

The dashboard sibling now applies the same actual-delivery rule when no browser or clipboard delivery succeeded.

Provenance: the capability-based onboarding fallback was made visible by #124704; browser bootstrap issuance/opening shared one catch from #118388; the dashboard delivery branch came from #118231.

## User Impact

Users can recover from stale display state, broken browser associations, forwarded SSH display failures, WSL opener failures, and opener command errors without restarting onboarding. Remote users get the tunnel command they need and five minutes to connect manually.

Production LOC: +30/-9 (net +21) | Tests: +76/-35

## Evidence

- Pre-fix owner-boundary proof:
  - forwarded SSH opener returning `false` omitted the SSH hint;
  - opener rejection returned `target-unavailable` instead of polling the manual path;
  - dashboard support detection followed by browser/clipboard failure omitted the SSH hint;
  - the original timeout regression produced 60,000 ms instead of 300,000 ms.
- Post-fix focused tests:
  - `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/onboard-browser-handoff.test.ts src/commands/dashboard.links.test.ts --reporter=verbose`
  - 2 shards, 2 files, 41 tests passed.
- `node scripts/check-changed.mjs -- src/commands/onboard-browser-handoff.ts src/commands/onboard-browser-handoff.test.ts src/commands/dashboard.ts src/commands/dashboard.links.test.ts`
  - passed all selected formatting, lint, typecheck, boundary, dead-code, and repository guards.
- Autoreview: clean, no accepted/actionable findings; correctness 0.97.
