### PR TITLE
fix(macos): onboarding setup rows ignore clicks across their blank areas

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
@@ -438,10 +438,10 @@ struct OnboardingAISetupView: View {
                                 .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.accentColor)
                         }
+                        .openClawSelectableRowChrome(selected: false)
                     }
                     .buttonStyle(.plain)
                     .disabled(self.model.isBusy)
-                    .openClawSelectableRowChrome(selected: false)
                 }
             }
             .padding(12)
@@ -511,10 +511,10 @@ struct OnboardingAISetupView: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(Color.accentColor)
             }
+            .openClawSelectableRowChrome(selected: self.model.showManualEntry)
         }
         .buttonStyle(.plain)
         .disabled(self.model.isBusy)
-        .openClawSelectableRowChrome(selected: self.model.showManualEntry)
     }
 
     private func providerAuthRow(_ option: OnboardingAISetupModel.AuthOption) -> some View {
@@ -544,10 +544,10 @@ struct OnboardingAISetupView: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(Color.accentColor)
             }
+            .openClawSelectableRowChrome(selected: false)
         }
         .buttonStyle(.plain)
         .disabled(self.model.isBusy)
-        .openClawSelectableRowChrome(selected: false)
     }
 
     private var providerAuthSheet: some View {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users setting up OpenClaw on macOS would see nothing happen when clicking the blank portion of a local-model setup, API-key, or provider-sign-in row during onboarding.

## Why This Change Was Made

The shared selectable-row styling already provides the complete rounded hit target, but these three plain buttons applied it outside their labels. Move the existing styling inside each label, matching the healthy onboarding and Gateway-selection rows, so the actual button owns the complete visible hit target. Preserve existing actions, selected styling, disabled states, and the separately fixed model-selection row. Production change: +3/-3, net zero.

## User Impact

The complete visible local-model, API-key, and provider-sign-in rows respond to clicks instead of silently ignoring clicks across their blank areas.

## Evidence

- Authentic Swift owner-invariant probe against the real onboarding source failed before the change for all three affected button labels while the existing model-selection row passed; after the change all four label-owned hit targets pass.
- `swift test --package-path apps/macos --skip-build --filter 'OnboardingAISetupTests|OnboardingViewSmokeTests'`: 125 tests passed across both complete native onboarding suites.
- The native OpenClaw app and complete test bundle built successfully. An existing local SwiftPM cache omitted Sparkle from its test bundle runtime search path; restoring its framework link only inside ignored build output allowed the unchanged suites to run.
- `swiftformat --lint apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift --config config/swiftformat` and `git diff --check` passed.
- Independent owner/sibling review and the configured structured Codex review both reported no actionable findings.
- Live screenshots or click recordings are unavailable because this task cannot launch or alter the operator's signed macOS app, Gateway, or TCC state; hidden AppKit-hosted synthetic clicks do not dispatch reliably, so no brittle or private-API test was added.
