### PR TITLE
fix(code-mode): serialize catalog handles nested in final values

### DIFF
--- a/src/agents/code-mode-controller-source.ts
+++ b/src/agents/code-mode-controller-source.ts
@@ -246,11 +246,21 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
     callableMetadata.set(frozen, metadata);
     return frozen;
   }
-  function serializeCatalogHandles(value) {
+  // Final values may nest handles (Promise.all of searches, keyed maps); an
+  // unserialized handle dumps as null and the model never learns the tool name.
+  function serializeCatalogHandles(value, seen = new Set()) {
     const metadata = callableMetadata.get(value);
     if (metadata) return metadata;
-    if (!Array.isArray(value)) return value;
-    return value.map((entry) => callableMetadata.get(entry) ?? entry);
+    if (value === null || typeof value !== "object" || seen.has(value)) return value;
+    const proto = Object.getPrototypeOf(value);
+    if (!Array.isArray(value) && proto !== Object.prototype && proto !== null) return value;
+    seen.add(value);
+    if (Array.isArray(value)) return value.map((entry) => serializeCatalogHandles(entry, seen));
+    const plain = {};
+    for (const [key, entry] of Object.entries(value)) {
+      plain[key] = serializeCatalogHandles(entry, seen);
+    }
+    return plain;
   }
   const catalog = Object.freeze({
     search: async (query, options) => {

--- a/src/agents/code-mode-controller-source.ts
+++ b/src/agents/code-mode-controller-source.ts
@@ -255,12 +255,16 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
     const proto = Object.getPrototypeOf(value);
     if (!Array.isArray(value) && proto !== Object.prototype && proto !== null) return value;
     seen.add(value);
-    if (Array.isArray(value)) return value.map((entry) => serializeCatalogHandles(entry, seen));
-    const plain = {};
-    for (const [key, entry] of Object.entries(value)) {
-      plain[key] = serializeCatalogHandles(entry, seen);
+    try {
+      if (Array.isArray(value)) return value.map((entry) => serializeCatalogHandles(entry, seen));
+      const plain = {};
+      for (const [key, entry] of Object.entries(value)) {
+        plain[key] = serializeCatalogHandles(entry, seen);
+      }
+      return plain;
+    } finally {
+      seen.delete(value);
     }
-    return plain;
   }
   const catalog = Object.freeze({
     search: async (query, options) => {

--- a/src/agents/code-mode.guest.test.ts
+++ b/src/agents/code-mode.guest.test.ts
@@ -148,6 +148,35 @@ describe("Code Mode guest execution", () => {
     expect(testing.resumingRunIds.size).toBe(0);
   });
 
+  it("serializes catalog handles nested inside arrays and plain objects", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const noop = pluginTool("fake_noop", "Noop");
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, noop],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = await runUntilCompleted({
+      execTool: expectDefined(codeModeTools[0], "codeModeTools[0] test invariant"),
+      waitTool: expectDefined(codeModeTools[1], "codeModeTools[1] test invariant"),
+      code: `
+        const batches = await Promise.all([catalog.search("noop"), catalog.search("noop")]);
+        return { batches, byKey: { tool: batches[0][0] } };
+      `,
+    });
+
+    const handle = { callableName: "fake_noop", toolName: "fake_noop", description: "Noop" };
+    expect(details).toMatchObject({
+      status: "completed",
+      value: { batches: [[handle], [handle]], byKey: { tool: handle } },
+    });
+    expect(JSON.stringify(details.value)).not.toContain("null");
+  });
+
   it("exposes catalog tools as bare globals and removes the legacy guest surface", async () => {
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
     const search = pluginTool("web_search", "Search the web");

--- a/src/agents/code-mode.guest.test.ts
+++ b/src/agents/code-mode.guest.test.ts
@@ -165,14 +165,19 @@ describe("Code Mode guest execution", () => {
       waitTool: expectDefined(codeModeTools[1], "codeModeTools[1] test invariant"),
       code: `
         const batches = await Promise.all([catalog.search("noop"), catalog.search("noop")]);
-        return { batches, byKey: { tool: batches[0][0] } };
+        const shared = { tool: batches[0][0] };
+        return { batches, byKey: shared, aliases: { first: shared, second: shared } };
       `,
     });
 
     const handle = { callableName: "fake_noop", toolName: "fake_noop", description: "Noop" };
     expect(details).toMatchObject({
       status: "completed",
-      value: { batches: [[handle], [handle]], byKey: { tool: handle } },
+      value: {
+        batches: [[handle], [handle]],
+        byKey: { tool: handle },
+        aliases: { first: { tool: handle }, second: { tool: handle } },
+      },
     });
     expect(JSON.stringify(details.value)).not.toContain("null");
   });

--- a/src/node-host/mcp.test.ts
+++ b/src/node-host/mcp.test.ts
@@ -73,7 +73,7 @@ async function startManagerWithTools(listed: ReadonlyArray<{ serverName: string;
 
 function itWithFrozenClock(name: string, run: () => Promise<void>): void {
   it(name, async () => {
-    // Size and pagination proofs must not spend the separately tested catalog deadline.
+    // Non-timeout catalog proofs must not spend the separately tested catalog deadline.
     useFrozenTime(1_000);
     try {
       await run();
@@ -115,7 +115,7 @@ describe("node host MCP manager", () => {
     await manager.close();
   });
 
-  it("terminates streamable HTTP sessions on failed startup and manager close", async () => {
+  itWithFrozenClock("terminates HTTP sessions on failed startup and manager close", async () => {
     const events = new Map<string, string[]>();
     const transports = new Map(
       ["failed", "healthy"].map((serverName) => {


### PR DESCRIPTION
## What Problem This Solves

In OpenClaw code mode, `catalog.search()` results are callable handles that serialize to `{callableName, toolName, ...}` metadata when returned as the program's final value. That only worked for a bare handle or a flat array of handles. Any nesting — `Promise.all([catalog.search(a), catalog.search(b)])`, or `{ tools: [...] }` — dumped each handle as `null`, so the model saw `[[null,null,...]]` and concluded no matching tool existed.

Observed in a live Telegram session on 2026-08-26: three parallel searches returned 24 `null`s; the model then declared its tool surface read-only and stopped, although the shell `exec` global it was searching for was present.

## Why This Change Was Made

`serializeCatalogHandles` in `src/agents/code-mode-controller-source.ts` now walks arrays and plain objects recursively (cycle-guarded, prototype-checked so class instances and `toJSON` hooks are untouched). The cycle guard tracks the active recursion path, so shared non-cyclic containers are projected at every returned alias instead of being mistaken for cycles. Metadata projection stays the single serialization path; no new bridge surface.

The previously failing MCP CI assertion now uses the test file's existing frozen-clock helper. That assertion is not testing the catalog deadline, and a concurrent identical shard passed while this PR's shard exhausted its 50 ms wall-clock deadline under CI contention.

## User Impact

Nested catalog handles in a code-mode return value now surface their tool names/schemas instead of `null`, including when the containing object is shared across multiple return paths. Tool discovery through `catalog.search` therefore composes with `Promise.all`, keyed results, and shared containers.

## Evidence

- Regression test `serializes catalog handles nested inside arrays and plain objects` covers a shared container through three paths; it fails before the active-path fix and passes afterward.
- `node scripts/run-vitest.mjs src/agents/code-mode.guest.test.ts`: 22 passed.
- `node scripts/run-vitest.mjs src/node-host/mcp.test.ts`: 18 passed.
- Affected core-test typecheck graphs (`agents-root`, `other`) pass.
- Production LOC: +17 / -3; tests +36 / -2.
