### PR TITLE
fix(agents): read the published model catalog owner from session_status

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -205,7 +205,12 @@ function createConfigModuleMock() {
 function createModelCatalogModuleMock() {
   return {
     loadProviderScopedThinkingCatalog: async () => [],
-    loadPreparedModelCatalog: async () => [
+    // A run's captured config goes stale after any Gateway config republish; the exact
+    // loader then throws, and session_status must read the published owner instead.
+    loadPreparedModelCatalog: async () => {
+      throw new Error("prepared model catalog owner config was replaced during the read (/tmp)");
+    },
+    loadPublishedPreparedModelCatalog: async () => [
       {
         provider: "anthropic",
         id: "claude-sonnet-4-6",

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -68,7 +68,7 @@ import {
   resolveThinkingDefaultWithRuntimeCatalog,
 } from "../model-selection.js";
 import { createModelVisibilityPolicy } from "../model-visibility-policy.js";
-import { loadPreparedModelCatalog } from "../prepared-model-catalog.js";
+import { loadPublishedPreparedModelCatalog } from "../prepared-model-catalog.js";
 import { resolveSessionModelIdentityRef } from "../session-model-ref.js";
 import {
   describeSessionStatusTool,
@@ -502,7 +502,7 @@ async function resolveModelOverride(params: {
     agentId: params.agentId,
     defaultProvider: currentProvider,
   });
-  const catalog = await loadPreparedModelCatalog({
+  const catalog = await loadPublishedPreparedModelCatalog({
     config: params.cfg,
     agentId: params.agentId,
     agentDir: params.agentDir,
@@ -1130,7 +1130,7 @@ export function createSessionStatusTool(opts?: {
             config: cfg,
           });
           // Tool status may read persisted/configured facts, but must not start provider discovery.
-          const thinkingCatalog = await loadPreparedModelCatalog({
+          const thinkingCatalog = await loadPublishedPreparedModelCatalog({
             config: cfg,
             agentId,
             agentDir: selectedAgentDir,
@@ -1163,7 +1163,7 @@ export function createSessionStatusTool(opts?: {
                 provider: providerForCard,
                 model: defaultModelForCard,
                 loadRuntimeCatalog: () =>
-                  loadPreparedModelCatalog({
+                  loadPublishedPreparedModelCatalog({
                     config: cfg,
                     agentId,
                     agentDir: selectedAgentDir,


### PR DESCRIPTION
## What Problem This Solves

`session_status` fails with `prepared model catalog owner config was replaced during the read (<agentDir>)` whenever the Gateway has republished its runtime config since the current run was admitted (config edit, skills hot-reload, plugin reload). The tool passes the run's captured `cfg` to `loadPreparedModelCatalog({ readOnly: true })`, which resolves the owner under the `exact` config policy and throws on any generation mismatch. Nothing retries, so the model gets a hard tool error for the rest of that run.

Seen 18 times in one operator's transcripts (Aug 2–26, 2026): `session_status`, nested `session_status` from code mode, and `sessions_spawn`.

## Why This Change Was Made

`session_status` is a turn-path read that wants the currently published catalog generation, not a catalog prepared from a stale run snapshot. The module already exposes that contract as `loadPublishedPreparedModelCatalog` (the same owner the Gateway uses after a config reload, #112026). The tool's three read-only reads now use it; no new fallback path.

Related: #127284 applies the same tolerance to the thinking-catalog lookup. `sessions_spawn` (`src/agents/subagents/spawn/subagent-spawn-child-plan.ts`) hits the same class and is left as a follow-up.

## User Impact

`session_status` keeps working after a mid-run Gateway config republish instead of erroring until the next run.

## Evidence

- `src/agents/openclaw-tools.session-status.test.ts` mock now makes the exact loader throw the replaced-config error and serves the catalog from the published loader; the suite fails on `main` and passes with the fix (75 passed).
- Production LOC: +1 / -1 (import) plus three call-site renames.

Worked on by:
- @VACInc
