### PR TITLE
docs(memory): add memory provenance and deletion concepts page

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1830,5 +1830,25 @@
   {
     "source": "geolocation",
     "target": "geolocation"
+  },
+  {
+    "source": "Memory provenance and deletion",
+    "target": "记忆溯源与删除"
+  },
+  {
+    "source": "Provenance & deletion",
+    "target": "溯源与删除"
+  },
+  {
+    "source": "Memory admission policy configuration",
+    "target": "记忆准入策略配置"
+  },
+  {
+    "source": "Memory architecture",
+    "target": "记忆架构"
+  },
+  {
+    "source": "Built-in memory",
+    "target": "内置记忆"
   }
 ]

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -85,9 +85,12 @@ absent.
 ## `memory forget`
 
 Delete provenance-tracked durable memory entries derived from selected
-sessions, together with their indexed and short-term copies. Select sessions by
-ID or session key, their external-content hook source, or a participant's actor
-ID:
+sessions, together with their indexed and short-term copies. The concepts
+behind this command — recorded lineage, admission policy, and the deletion
+guarantees and boundaries — are explained in
+[Memory provenance and deletion](/concepts/memory-provenance). Select sessions
+by ID or session key, their external-content hook source, or a participant's
+actor ID:
 
 ```bash
 openclaw memory forget --session <id-or-key> [--session <id-or-key> ...]

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -69,6 +69,8 @@ Dreaming runs three cooperative phases per sweep, in order: light -> REM -> deep
 
 Dreaming can ingest redacted session transcripts into the dreaming corpus. Only interactive sessions are eligible. Cron, heartbeat, subagent, and unknown sessions stay out of durable candidate ingestion. Personal and sensitive content is redacted before ingestion, and runtime-marked recalled context is removed so recalled snippets cannot be learned again as new memory.
 
+Two operator controls remove whole sessions from ingestion, each with a recorded reason: the [memory admission policy](/concepts/memory-provenance#admission-keeping-sources-out-of-memory) excludes sessions by external-content hook source, channel, or chat type, and [`memory forget`](/cli/memory#memory-forget) durably excludes purged sessions as `forgotten` so a later sweep cannot re-learn what was deleted.
+
 ## Consolidation safety
 
 The deterministic score, recall-count, and query-diversity thresholds remain

--- a/docs/concepts/memory-architecture.md
+++ b/docs/concepts/memory-architecture.md
@@ -96,6 +96,16 @@ noise, and recall feedback loops:
   structurally marked and never re-extracted as a new memory. A fact recalled
   one hundred times stays one fact.
 
+Beyond per-chunk trust metadata, every pipeline-promoted durable entry also
+records **which sessions it came from**, and that lineage survives
+consolidation merges. Session lineage is what makes two operator guarantees
+possible: excluding configured sources (an email hook, a channel) from
+durable memory by policy, and purging everything derived from a session, a
+person, or a source with `openclaw memory forget` — including a durable
+exclusion that keeps purged sessions from ever being re-ingested. That
+policy story is covered end to end in
+[Memory provenance and deletion](/concepts/memory-provenance).
+
 ## Trust boundaries and limits
 
 Workspace memory files are inside the operator trust boundary: any process
@@ -417,6 +427,7 @@ knobs that exist:
 | Concern                         | Where                                                           | Reference                                                |
 | ------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------- |
 | Dreaming enable, cadence, model | `plugins.entries.memory-core.config.dreaming`                   | [Dreaming](/concepts/dreaming)                           |
+| Session admission exclusions    | `plugins.entries.memory-core.config.memoryPolicy`               | [Provenance & deletion](/concepts/memory-provenance)     |
 | Search providers, hybrid tuning | `memory.search`                                                 | [Memory config](/reference/memory-config)                |
 | Escalation lane mode, scope     | `plugins.entries.active-memory`                                 | [Active memory](/concepts/active-memory)                 |
 | Cross-conversation recall       | `agents.entries.<id>.memory.search.rememberAcrossConversations` | [Active memory](/concepts/active-memory)                 |
@@ -426,6 +437,7 @@ knobs that exist:
 ## Related
 
 - [Memory overview](/concepts/memory)
+- [Memory provenance and deletion](/concepts/memory-provenance)
 - [Dreaming](/concepts/dreaming)
 - [Active memory](/concepts/active-memory)
 - [User model](/concepts/user-model)

--- a/docs/concepts/memory-builtin.md
+++ b/docs/concepts/memory-builtin.md
@@ -96,7 +96,10 @@ only injects curated or promoted-trusted entries.
 Each indexed chunk also has SQLite-owned provenance: origin class (`owner`,
 `agent`, `untrusted`, or `system`), session kind, observation time, and an
 optional supersession key. This metadata is stored separately from Markdown
-so recalled prose cannot rewrite its own trust classification.
+so recalled prose cannot rewrite its own trust classification. Durable
+entries additionally record their source sessions, which powers admission
+policy and selective deletion — see
+[Memory provenance and deletion](/concepts/memory-provenance).
 
 - **Index location:** the owning agent database at
   `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite`

--- a/docs/concepts/memory-provenance.md
+++ b/docs/concepts/memory-provenance.md
@@ -1,0 +1,191 @@
+---
+summary: "Session-level memory provenance: how OpenClaw records where every durable memory came from, keeps configured sources out of memory by policy, and deletes everything derived from a session on request"
+title: "Memory provenance and deletion"
+sidebarTitle: "Provenance & deletion"
+read_when:
+  - You need to keep email, a channel, or another content source out of durable memory
+  - You need to purge every memory derived from a session, a person, or a source, e.g. for GDPR erasure or an employee exit
+  - You are reviewing OpenClaw memory for a security, privacy, or compliance assessment
+---
+
+Every durable memory OpenClaw creates through its pipeline records which
+sessions it came from, as queryable SQLite facts — not as prose the model
+could rewrite. That lineage supports two operator guarantees this page
+explains end to end: **admission** (configured sources never enter durable
+memory, deterministically) and **deletion** (`openclaw memory forget` purges
+everything the pipeline derived from a chosen set of sessions and permanently
+prevents its re-admission).
+
+This page owns the policy story: what is recorded, what the guarantees cover,
+and where their boundaries are. The command contract lives in
+[`memory forget`](/cli/memory#memory-forget), the configuration keys in
+[Memory config](/reference/memory-config#memory-admission-policy), and the
+surrounding trust model in
+[Memory architecture](/concepts/memory-architecture).
+
+## What lineage is recorded
+
+Three kinds of provenance exist, at different granularities:
+
+| Record                | Granularity   | Written by                                       | Used for                                              |
+| --------------------- | ------------- | ------------------------------------------------ | ----------------------------------------------------- |
+| Chunk provenance      | Index chunk   | Classification code at index time                | Trust gating: promotion eligibility, recall framing   |
+| Entry origins         | Durable entry | Ingestion and promotion, per source session      | Selective deletion; auditing where an entry came from |
+| Curated-write records | Memory file   | The memory write observer, per authoring session | Reporting agent-authored edits during a purge         |
+
+Chunk provenance (origin class, session kind) is the trust model described in
+[Memory architecture](/concepts/memory-architecture#provenance-every-memory-knows-where-it-came-from).
+Entry origins are what make deletion possible: when the dreaming pipeline
+turns session content into a durable candidate, it records
+`(entry, agent, source session)` rows in the agent's SQLite database, and
+every pipeline-promoted `MEMORY.md` entry carries a stable marker that ties
+the file text back to those rows.
+
+Lineage survives [dreaming](/concepts/dreaming) consolidation. When
+consolidation merges two entries, the result's origin set is the union of its
+parents'; when a newer observation supersedes an older one, the origins move
+to the surviving entry. This bookkeeping is deterministic code wrapped around
+the consolidation model call — the model never carries or rewrites
+provenance. In a workspace shared by several agents, the same reconciliation
+runs against every participating agent's origins, so any agent's later
+deletion request still finds the live entry.
+
+Entries with no origin rows are the **curated tier**: content the operator
+wrote by hand, or the agent edited directly on request. That absence is
+itself recorded state, not a gap — see
+[the admission boundary](#the-admission-boundary) below.
+
+## Admission: keeping sources out of memory
+
+If a source must never reach durable memory — email content is the classic
+case — exclude it by policy instead of prompting the model to be careful:
+
+```json5
+{
+  plugins: {
+    entries: {
+      "memory-core": {
+        config: {
+          memoryPolicy: {
+            excludeSessions: {
+              hookExternalContentSources: ["gmail"],
+              channels: ["email"],
+              chatTypes: ["group"],
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+A session matching any configured exclusion never enters the dreaming
+corpus, so it cannot produce candidates, survive consolidation, or promote
+into `MEMORY.md`. The exclusion is enforced before the transcript is read,
+and it is **recorded**, not silent: the ingestion checkpoint stores the
+exclusion reason, visible to a later audit. Removing the policy re-admits
+the session on the next sweep. Key semantics and matching rules are in
+[Memory config](/reference/memory-config#memory-admission-policy).
+
+### The admission boundary
+
+The policy governs the **memory pipeline**. An agent running inside an
+excluded session can still edit `MEMORY.md` or another memory file directly
+during its turn — "remember this" resolved by the agent writing the file is
+a workspace edit, governed by tool policy and the workspace trust boundary,
+not by memory admission. OpenClaw records those writes with their authoring
+session (the curated-write records above), so they are auditable and are
+surfaced by a later purge, but preventing them is a tool-policy decision,
+not a memory-policy one. If the requirement is "this session must not be
+able to write memory files at all," restrict the agent's file tools for that
+context rather than relying on admission policy.
+
+## Deletion: purging what a session produced
+
+`openclaw memory forget` deletes everything the memory pipeline derived from
+a chosen session set. Sessions are selected by explicit ID or key, by their
+recorded external-content hook source, or by a participant's actor ID —
+"everything derived from Gmail" and "everything derived from sessions this
+person took part in" are both one command. Selection resolves against live
+session records **and** retained archived sessions, and an explicitly named
+session that matches neither is still purged and excluded as an exact ID: an
+operator-named session never produces a silent no-op. The report labels each
+selected session `live`, `archived`, or `unresolved`.
+
+A purge is **whole-entry and deterministic**. An entry with any origin in the
+selected set is removed entirely — there is no model-mediated attempt to
+subtract one source's contribution from merged prose, because a deletion
+guarantee an LLM adjudicates is not one you can defend in an audit. Entries
+that also had unselected origins are reported as mixed-lineage removals;
+dreaming can regenerate what the surviving sessions still support.
+
+The sweep covers every derived artifact, not just the visible entry: memory
+files, verbatim quoted lines in dream diaries, session-corpus lines, index
+chunks with their full-text and vector records, embedding-cache entries,
+short-term recall state, ingestion dedup state, and dreaming's own pre-rewrite
+backups. A deletion that survives in a backup or an index is not a deletion.
+Always start with `--dry-run`, which computes the identical report without
+writing; the full artifact list and report shape are in the
+[command reference](/cli/memory#memory-forget).
+
+### Purged sessions stay purged
+
+Deleting derived data is not enough on its own: the memory pipeline
+continuously re-reads session history, so a purge that only removed artifacts
+would be silently undone by the next dreaming sweep or index rebuild. A real
+purge therefore records each selected session as **forgotten** in the agent's
+SQLite database. Dreaming ingestion, historical backfill, and transcript
+indexing — including `memory index --force` — all treat forgotten sessions
+exactly like policy-excluded ones, with the recorded reason `forgotten`.
+Re-running the purge is safe and changes nothing.
+
+### What deletion does not cover
+
+The boundaries are deliberate, and each one is reported rather than silent:
+
+- **Source transcripts.** The session transcript itself belongs to session
+  management, not memory. A purge removes its copies from the memory index
+  and permanently fences it out of the pipeline, then names the session in
+  the report so you can remove the transcript through its owning workflow.
+- **Agent-authored edits.** Freeform file edits cannot be attributed to
+  individual lines safely enough for automatic deletion. The purge reports
+  them as `curatedWrites` — file and timestamp, recovered from write-observer
+  records and from the selected sessions' transcripts across all agent
+  harnesses — and leaves the files for review.
+- **Paraphrased prose.** Dream-diary lines quoting a purged session verbatim
+  are removed; model-paraphrased prose that no longer contains the source
+  text cannot be reliably attributed and stays. Keeping the affected sessions
+  out of memory in the first place, via admission policy, is the stronger
+  tool when a source is sensitive.
+
+## Purging a person or a source end to end
+
+The employee-exit / GDPR-erasure workflow, using a departed teammate as the
+example:
+
+```bash
+# 1. Preview everything derived from sessions they took part in.
+openclaw memory forget --participant <actor-id> --dry-run --json
+
+# 2. Review the report: entries, artifacts, mixed-lineage removals,
+#    curatedWrites, and each session's resolution source.
+
+# 3. Purge. Selected sessions are durably excluded from re-ingestion.
+openclaw memory forget --participant <actor-id>
+
+# 4. Review curatedWrites files by hand, and remove the source transcripts
+#    through session management if required.
+```
+
+For archived sessions that no longer carry participant metadata, select them
+explicitly with `--session <id-or-key>`. For a source-wide purge, use the
+recorded hook source instead: `openclaw memory forget --hook-source gmail`.
+
+## Related
+
+- [`memory forget` command reference](/cli/memory#memory-forget)
+- [Memory admission policy configuration](/reference/memory-config#memory-admission-policy)
+- [Memory architecture](/concepts/memory-architecture)
+- [Dreaming](/concepts/dreaming)
+- [Built-in memory](/concepts/memory-builtin)

--- a/docs/concepts/memory-provenance.md
+++ b/docs/concepts/memory-provenance.md
@@ -50,10 +50,13 @@ provenance. In a workspace shared by several agents, the same reconciliation
 runs against every participating agent's origins, so any agent's later
 deletion request still finds the live entry.
 
-Entries with no origin rows are the **curated tier**: content the operator
-wrote by hand, or the agent edited directly on request. That absence is
-itself recorded state, not a gap — see
-[the admission boundary](#the-admission-boundary) below.
+Not every entry has origin rows. Operator-curated content and direct agent
+edits never receive entry lineage (their file-level authoring sessions are
+tracked separately — see
+[the admission boundary](#the-admission-boundary) below), and entries
+promoted before lineage recording existed have none either. All such entries
+remain searchable, are never deleted by an unrelated selector, and are
+listed as untargetable in a purge report rather than silently skipped.
 
 ## Admission: keeping sources out of memory
 

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -319,6 +319,7 @@ openclaw memory index --force   # Rebuild the index
 - [Memory LanceDB](/plugins/memory-lancedb): LanceDB-backed plugin with OpenAI-compatible embeddings.
 - [Memory Wiki](/plugins/memory-wiki): compiled knowledge vault and wiki-native tools.
 - [Dreaming](/concepts/dreaming): background promotion from short-term recall to long-term memory.
+- [Memory provenance and deletion](/concepts/memory-provenance): session lineage, admission policy, and `memory forget`.
 - [Memory configuration reference](/reference/memory-config): all config knobs.
 - [Compaction](/concepts/compaction): how compaction interacts with memory.
 - [Active memory](/concepts/active-memory): sub-agent memory for interactive chat sessions.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1266,6 +1266,7 @@
                     "pages": [
                       "concepts/memory",
                       "concepts/memory-architecture",
+                      "concepts/memory-provenance",
                       "concepts/user-model",
                       "concepts/standing-intents",
                       "concepts/memory-builtin",

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -577,7 +577,10 @@ Built-in memory indexes live in each agent's OpenClaw SQLite database at
 Configure deterministic session exclusions under
 `plugins.entries.memory-core.config.memoryPolicy.excludeSessions`. Excluded
 sessions never enter the dreaming corpus, so the memory pipeline cannot turn
-them into promotion candidates or consolidated entries.
+them into promotion candidates or consolidated entries. For the policy story
+behind these keys — what admission and deletion guarantee and where their
+boundaries are — see
+[Memory provenance and deletion](/concepts/memory-provenance).
 
 | Key                          | Type       | Default | Matches                                   |
 | ---------------------------- | ---------- | ------- | ----------------------------------------- |


### PR DESCRIPTION
## What Problem This Solves

PR #130151 shipped memory provenance, admission policy, and `openclaw memory forget`, but the documentation for it landed only as reference material: the `memory forget` command contract in `docs/cli/memory.md` and the `memoryPolicy` keys in `docs/reference/memory-config.md`, plus the internal design note. There was no concepts-level page answering the questions the feature exists for — "how do I keep email out of memory?" and "how do I purge a departed person?" — and the memory concepts pages (architecture, dreaming, builtin) still described only chunk-level provenance, with no mention of session lineage, tombstones, or deletion.

## Why This Change Was Made

Adds `docs/concepts/memory-provenance.md` — a topic page telling the operator policy story end to end: the three provenance granularities (chunk trust metadata, entry origins, curated-write records), how lineage survives consolidation across shared-workspace agents, the admission policy with its honest pipeline-only boundary, the deletion guarantees (whole-entry, full derived-artifact sweep, dry-run parity, forgotten tombstones preventing re-ingestion), the reported-not-silent boundaries (source transcripts, agent-authored curated writes, paraphrased prose), and the employee-exit/GDPR purge workflow.

Integrates it into the existing docs rather than leaving it an island: registered in `docs/docs.json` navigation (Memory group, after architecture); memory-architecture gains a session-lineage paragraph in its provenance section plus a configuration-map row and Related link; dreaming's ingestion section names the two recorded session-exclusion controls; memory-builtin and the memory overview link the page; the CLI `memory forget` section and the config admission section point back to the concepts story.

## User Impact

Operators, security reviewers, and compliance assessments now have one public page — docs.openclaw.ai/concepts/memory-provenance — that explains what OpenClaw records about memory lineage, what admission and deletion guarantee, and exactly where the boundaries are, with the command and config pages as linked reference. Docs-only; no runtime changes.

## Evidence

Docs-only change. `pnpm docs:check-mdx` (786 files), `pnpm docs:check-links` (6,620 internal links, 0 broken), `node scripts/check-docs-config-examples.mjs` (config example validated), `pnpm format:docs:check` (clean), `pnpm docs:list` (new page indexed with read-when hints), `git diff --check` — all green. Content is source-backed by the landed implementation in #130151 and its live-verification evidence.
