### PR TITLE
fix(file-transfer): remove wall-clock race from symlink promptness test

### DIFF
--- a/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
@@ -133,7 +133,7 @@ describe("dir.fetch archive extraction", () => {
   });
 
   it.runIf(process.platform !== "win32")(
-    "settles promptly when a Fleet-shaped archive contains a symlink",
+    "rejects a Fleet-shaped archive containing a symlink",
     async () => {
       const tarBuffer = await createTarBuffer({
         entries: ["data", "auth"],
@@ -147,20 +147,9 @@ describe("dir.fetch archive extraction", () => {
       });
       const { appendFileTransferAudit, archivePath, module } = await importTool(tarBuffer);
 
-      const settled = await Promise.race([
-        executeDirFetch(module).then(
-          () => ({ status: "resolved" as const }),
-          (error: unknown) => ({ status: "rejected" as const, error }),
-        ),
-        new Promise<{ status: "timeout" }>((resolve) => {
-          setTimeout(() => resolve({ status: "timeout" }), 2_000);
-        }),
-      ]);
-
-      expect(settled.status).toBe("rejected");
-      expect(settled.status === "rejected" ? String(settled.error) : "").toMatch(
-        /dir\.fetch UNSAFE_ARCHIVE:.*link/iu,
-      );
+      // A symlink entry used to hang extraction instead of rejecting; the test
+      // timeout bounds settling, so a hang regression fails without a wall-clock race.
+      await expect(executeDirFetch(module)).rejects.toThrow(/dir\.fetch UNSAFE_ARCHIVE:.*link/iu);
       await expect(fs.access(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
       expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
         expect.objectContaining({ decision: "error", errorCode: "UNSAFE_ARCHIVE" }),


### PR DESCRIPTION
## What Problem This Solves

`extensions/file-transfer/src/tools/dir-fetch-tool.test.ts`'s "settles promptly when a Fleet-shaped archive contains a symlink" test flaked on CI on 2026-08-26 (run 32978693452, shard `checks-node-changed-extensions-config-2`): the runner stalled ("no output for 90000ms") and the test's own `Promise.race` against a 2-second `setTimeout` resolved as `"timeout"` instead of `"rejected"`, even though the real rejection would have arrived once the runner resumed. It passes locally in ~600ms.

## Why This Change Was Made

The test used a manual wall-clock race to prove the archive rejects "promptly," but a stalled test runner stalls both sides of the race arbitrarily — no timeout value can make that race safe. The property actually being protected (a symlink entry must reject, not hang, during extraction) is already bounded by Vitest's own per-test timeout, which is calibrated for slow CI runners. Restructuring the assertion to a plain `await expect(...).rejects.toThrow(...)` (matching the sibling backslash-entry test in the same file) removes the redundant, flakier clock while keeping the same regression coverage: a hang trips Vitest's test timeout, and a wrong error shape trips the matcher.

## User Impact

Test-only change. No production code or behavior changes.

## Evidence

- `node scripts/run-vitest.mjs extensions/file-transfer/src/tools/dir-fetch-tool.test.ts` — 4 passed
- `node_modules/.bin/oxfmt extensions/file-transfer/src/tools/dir-fetch-tool.test.ts` — clean
- `node scripts/check-changed.mjs -- extensions/file-transfer/src/tools/dir-fetch-tool.test.ts` — green after formatting
- Autoreview (codex, gpt-5.6-sol, high): clean, no accepted/actionable findings
