### PR TITLE
refactor(infra): share error cause reader

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3258,7 +3258,7 @@ src/infra/system-run-approval-context.ts	6
 src/infra/tailscale.ts	9
 src/infra/terminal-file-upload.ts	2
 src/infra/tmp-openclaw-dir.ts	3
-src/infra/unhandled-rejections.ts	7
+src/infra/unhandled-rejections.ts	6
 src/infra/update-check-package-target.ts	3
 src/infra/update-doctor-result.ts	2
 src/infra/update-global.ts	3
@@ -3603,7 +3603,7 @@ src/process/supervisor/adapters/pty.ts	1
 src/process/terminal-pty.ts	1
 src/process/windows-command.ts	1
 src/projects/project-registry.ts	1
-src/provider-runtime/operation-retry.ts	4
+src/provider-runtime/operation-retry.ts	3
 src/proxy-capture/env.ts	1
 src/proxy-capture/runtime.ts	10
 src/proxy-capture/store.sqlite.ts	27

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -10,6 +10,7 @@ import {
   hasErrnoCode,
   isErrno,
   isMissingPathError,
+  readErrorCause,
   readErrorName,
 } from "./errors.js";
 
@@ -35,6 +36,34 @@ describe("error helpers", () => {
     { value: null, expected: "" },
   ])("reads error names from %j", ({ value, expected }) => {
     expect(readErrorName(value)).toBe(expected);
+  });
+
+  it.each([
+    ["missing cause", {}, undefined],
+    ["undefined cause", { cause: undefined }, undefined],
+    ["null cause", { cause: null }, null],
+    ["arbitrary cause", { cause: "boom" }, "boom"],
+    ["null input", null, undefined],
+    ["primitive input", "boom", undefined],
+    ["function input", Object.assign(() => {}, { cause: "boom" }), undefined],
+  ])("reads %s directly", (_name, value, expected) => {
+    expect(readErrorCause(value)).toBe(expected);
+  });
+
+  it("preserves self-referential causes", () => {
+    const error: { cause?: unknown } = {};
+    error.cause = error;
+    expect(readErrorCause(error)).toBe(error);
+  });
+
+  it("propagates cause accessor failures", () => {
+    const failure = new Error("cause access failed");
+    const error = {
+      get cause(): never {
+        throw failure;
+      },
+    };
+    expect(() => readErrorCause(error)).toThrow(failure);
   });
 
   it("walks nested error graphs once in breadth-first order", () => {

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -25,6 +25,14 @@ export function readErrorName(err: unknown): string {
   return typeof name === "string" ? name : "";
 }
 
+export function readErrorCause(error: unknown): unknown {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  // SAFETY: The object guard permits direct optional cause access without coercion.
+  return (error as { cause?: unknown }).cause;
+}
+
 export function collectErrorGraphCandidates(
   err: unknown,
   resolveNested?: (current: Record<string, unknown>) => Iterable<unknown>,

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -4,7 +4,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { restoreRuntimeTerminalState } from "../runtime.js";
 import { isAbortError } from "./abort-signal.js";
 import { collectNestedErrorCandidates, extractErrorCodeOrErrno } from "./error-graph-internal.js";
-import { extractErrorCode, formatUncaughtError, readErrorName } from "./errors.js";
+import { extractErrorCode, formatUncaughtError, readErrorCause, readErrorName } from "./errors.js";
 import { runFatalErrorHooks } from "./fatal-error-hooks.js";
 import { isTransientNetworkError } from "./retryable-network-errors.js";
 
@@ -134,13 +134,6 @@ function isBenignUncaughtNetworkMessage(message: string): boolean {
   return message === WS_PRE_HANDSHAKE_CLOSE_MESSAGE;
 }
 
-function getErrorCause(err: unknown): unknown {
-  if (!err || typeof err !== "object") {
-    return undefined;
-  }
-  return (err as { cause?: unknown }).cause;
-}
-
 function extractNumericErrorCode(err: unknown, key: "errno" | "errcode"): number | undefined {
   if (!err || typeof err !== "object") {
     return undefined;
@@ -161,7 +154,7 @@ function extractErrorCodeWithCause(err: unknown): string | undefined {
   if (direct) {
     return direct;
   }
-  return extractErrorCode(getErrorCause(err));
+  return extractErrorCode(readErrorCause(err));
 }
 
 function isFatalError(err: unknown): boolean {

--- a/src/provider-runtime/operation-retry.ts
+++ b/src/provider-runtime/operation-retry.ts
@@ -1,6 +1,6 @@
 // Provider operation retry helpers run retryable provider operations with backoff.
 import { sleepWithAbort } from "../infra/backoff.js";
-import { formatErrorMessage } from "../infra/errors.js";
+import { formatErrorMessage, readErrorCause } from "../infra/errors.js";
 import { hasRetryableConnectionErrorCode } from "../infra/retryable-network-errors.js";
 
 export type ProviderOperationRetryStage = "read" | "poll" | "download" | "create";
@@ -95,13 +95,6 @@ function readErrorCode(error: unknown): string | undefined {
   }
   const code = (error as { code?: unknown }).code;
   return typeof code === "string" ? code : undefined;
-}
-
-function readErrorCause(error: unknown): unknown {
-  if (typeof error !== "object" || error === null) {
-    return undefined;
-  }
-  return (error as { cause?: unknown }).cause;
 }
 
 // Provider reads get one bounded retry for negative DNS responses. Gateway


### PR DESCRIPTION
## What Problem This Solves

Unhandled-rejection classification and provider retry logic independently implemented the same direct error-cause reader. Keeping those helpers duplicated makes their deliberately narrow object-only contract easier to drift.

## Why This Change Was Made

Add one private `readErrorCause` helper beside the existing error readers and reuse it from both consumers. The helper preserves direct property access, arbitrary cause values, self-references, and throwing getter behavior; recursive and guarded error readers remain separate.

## User Impact

No user-visible behavior change. Error-cause inspection now has one canonical implementation for these two runtime paths.

## Evidence

- Focused infra and provider tests: 120 passed.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `check-changed`: passed.
- Autoreview: clean, 0.99 confidence.
- AWS Crabbox `run_ceabb7e07af8` on lease `cbx_7378729265c2`: fresh public/no-role/no-Tailscale checkout at exact head, frozen install, 120 focused tests passed; lease released.
- The trusted untrusted-code bootstrap required `umask 022` to be prepended because the current AWS image otherwise creates its root-owned Node install unreadable to the `crabbox` user; no PR code was changed for the workaround.
- Assertion safety baseline pruned by the repository tool from 13,295 to 13,293 after removing two local assertions.
- Production delta: +11 / -17, net -6 lines. Tests: +29 lines.
