### PR TITLE
fix(cli): failed message actions report success

### DIFF
--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -2,6 +2,9 @@
 import { Command } from "commander";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerMessagePollCommand } from "./register.poll.js";
+import { registerMessageReactionsCommands } from "./register.reactions.js";
+import { registerMessageReadEditDeleteCommands } from "./register.read-edit-delete.js";
 import { registerMessageSendCommand } from "./register.send.js";
 
 const messageCommandMock = vi.fn(async (): Promise<unknown> => undefined);
@@ -202,6 +205,64 @@ describe("runMessageAction", () => {
             "channel:123",
             "--message",
             "hi",
+            ...(dryRun ? ["--dry-run"] : []),
+          ],
+          { from: "user" },
+        ),
+      ).rejects.toThrow("exit");
+
+      expect(exitMock).toHaveBeenCalledWith(exitCode);
+    },
+  );
+
+  it.each([
+    ["disabled reaction", "react", { ok: false, hint: "Reactions are disabled." }, 1],
+    ["rejected added reaction", "react", { ok: false, warning: "Unavailable", added: "✅" }, 1],
+    ["rejected delete", "delete", { ok: false, deleted: false, warning: "Not deleted" }, 1],
+    ["rejected poll", "poll", { ok: false, error: "Poll rejected" }, 1],
+    ["rejected send", "send", { ok: false, error: "Message rejected" }, 1],
+    ["successful reaction", "react", { ok: true, added: "✅" }, 0],
+    ["legacy reaction", "react", { added: "✅" }, 0],
+    ["non-boolean outcome", "react", { ok: "false", added: "✅" }, 0],
+    ["dry-run", "react", { ok: false, error: "Not executed" }, 0],
+  ] as const)(
+    "propagates %s through the real CLI parser",
+    async (name, action, payload, exitCode) => {
+      const dryRun = name === "dry-run";
+      const kind = action === "send" || action === "poll" ? action : "action";
+      messageCommandMock.mockResolvedValueOnce({
+        kind,
+        channel: "telegram",
+        action,
+        ...(kind === "action" ? {} : { to: "123" }),
+        handledBy: "plugin",
+        payload,
+        dryRun,
+      });
+      const program = new Command();
+      const message = program.command("message");
+      const helpers = createMessageCliHelpers(message, "telegram");
+      registerMessageSendCommand(message, helpers);
+      registerMessagePollCommand(message, helpers);
+      registerMessageReactionsCommands(message, helpers);
+      registerMessageReadEditDeleteCommands(message, helpers);
+      const args = {
+        react: ["--message-id", "456", "--emoji", "✅"],
+        delete: ["--message-id", "456"],
+        poll: ["--poll-question", "Ready?", "--poll-option", "Yes", "--poll-option", "No"],
+        send: ["--message", "hello"],
+      }[action];
+
+      await expect(
+        program.parseAsync(
+          [
+            "message",
+            action,
+            "--channel",
+            "telegram",
+            "--target",
+            "123",
+            ...args,
             ...(dryRun ? ["--dry-run"] : []),
           ],
           { from: "user" },

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -15,7 +15,7 @@ import { getRuntimeConfig } from "../../../config/config.js";
 import { danger, setVerbose } from "../../../globals.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { CHANNEL_TARGET_DESCRIPTION } from "../../../infra/outbound/channel-target.js";
-import { isMessageActionSuccessful } from "../../../infra/outbound/message-action-contracts.js";
+import { resolveMessageActionOutcome } from "../../../infra/outbound/message-action-contracts.js";
 import { withActivatedPluginIds } from "../../../plugins/activation-context.js";
 import {
   resolveConfiguredChannelPluginIds,
@@ -221,7 +221,7 @@ export function createMessageCliHelpers(
     if (!ACTIONS_WITHOUT_STOP_HOOKS.has(action)) {
       await withPluginRuntimeRegistryScope(pluginRegistry, runPluginStopHooks);
     }
-    failed ||= result !== undefined && !isMessageActionSuccessful(result);
+    failed ||= result !== undefined && !resolveMessageActionOutcome(result).ok;
     defaultRuntime.exit(failed ? 1 : 0);
   };
 

--- a/src/commands/message-format.test.ts
+++ b/src/commands/message-format.test.ts
@@ -294,6 +294,41 @@ describe("formatMessageCliText send results", () => {
   );
 });
 
+describe("formatMessageCliText provider-reported failures", () => {
+  it.each([
+    ["disabled reaction", "react", { ok: false, hint: "Reactions are disabled." }, "disabled"],
+    [
+      "rejected added reaction",
+      "react",
+      { ok: false, warning: "Unavailable", added: "✅" },
+      "Unavailable",
+    ],
+    [
+      "rejected delete",
+      "delete",
+      { ok: false, deleted: false, warning: "Not deleted" },
+      "Not deleted",
+    ],
+    ["rejected poll", "poll", { ok: false, error: "Poll rejected" }, "Poll rejected"],
+    ["rejected send", "send", { ok: false, error: "Message rejected" }, "Message rejected"],
+  ] as const)("reports %s without claiming success", (_name, action, payload, expected) => {
+    const result = {
+      kind: action === "send" || action === "poll" ? action : "action",
+      channel: "telegram",
+      action,
+      to: "123",
+      handledBy: "plugin",
+      payload,
+      dryRun: false,
+    } as MessageActionResult;
+
+    const output = textJoined(formatMessageCliText(result));
+
+    expect(output).toContain(expected);
+    expect(output).not.toContain("✅");
+  });
+});
+
 describe("formatMessageCliText poll results", () => {
   it("formats direct core poll results as direct deliveries", () => {
     const result = {

--- a/src/commands/message-format.ts
+++ b/src/commands/message-format.ts
@@ -8,8 +8,7 @@ import type { ChannelId } from "../channels/plugins/types.public.js";
 import type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
 import { formatGatewaySummary, formatOutboundDeliverySummary } from "../infra/outbound/format.js";
 import {
-  isMessageActionSuccessful,
-  resolveMessageSendOutcome,
+  resolveMessageActionOutcome,
   type MessageActionResult,
 } from "../infra/outbound/message-action-contracts.js";
 import { formatTargetDisplay } from "../infra/outbound/target-resolver.js";
@@ -290,6 +289,7 @@ export function formatMessageCliText(
     return [muted(`[dry-run] would run ${result.action} via ${result.channel}`)];
   }
 
+  const outcome = resolveMessageActionOutcome(result);
   if (result.kind === "broadcast") {
     const results = result.payload.results ?? [];
     const rows = results.map((entry) => ({
@@ -300,7 +300,7 @@ export function formatMessageCliText(
     }));
     const okCount = results.filter((entry) => entry.ok).length;
     const total = results.length;
-    const successful = isMessageActionSuccessful(result);
+    const successful = outcome.ok;
     const headingLine = (successful ? ok : fail)(
       `${successful ? "✅ Broadcast complete" : "❌ Broadcast failed"} (${okCount}/${total} succeeded, ${total - okCount} failed)`,
     );
@@ -319,12 +319,12 @@ export function formatMessageCliText(
     ];
   }
 
+  if (!outcome.ok) {
+    const messageId = result.kind === "send" ? result.sendResult?.result?.messageId : undefined;
+    return [fail(`❌ ${outcome.error}${messageId ? ` Message ID: ${messageId}` : ""}`)];
+  }
+
   if (result.kind === "send") {
-    const outcome = resolveMessageSendOutcome(result.sendResult);
-    if (!outcome.ok) {
-      const messageId = result.sendResult?.result?.messageId;
-      return [fail(`❌ ${outcome.error}${messageId ? ` Message ID: ${messageId}` : ""}`)];
-    }
     if (result.handledBy === "core" && result.sendResult) {
       const send = result.sendResult;
       if (send.via === "direct") {

--- a/src/commands/message.test.ts
+++ b/src/commands/message.test.ts
@@ -665,6 +665,49 @@ describe("messageCommand", () => {
     },
   );
 
+  it.each([
+    [
+      "disabled reaction",
+      "react",
+      { ok: false, hint: "Reactions are disabled." },
+      "Reactions are disabled.",
+    ],
+    [
+      "rejected added reaction",
+      "react",
+      { ok: false, warning: "Unavailable", added: "✅" },
+      "Unavailable",
+    ],
+    [
+      "rejected delete",
+      "delete",
+      { ok: false, deleted: false, warning: "Not deleted" },
+      "Not deleted",
+    ],
+    ["rejected poll", "poll", { ok: false, error: "Poll rejected" }, "Poll rejected"],
+    ["rejected send", "send", { ok: false, error: "Message rejected" }, "Message rejected"],
+  ] as const)("reports %s truthfully in JSON output", async (_name, action, payload, expected) => {
+    runMessageActionMock.mockResolvedValueOnce({
+      kind: action === "send" || action === "poll" ? action : "action",
+      channel: "telegram",
+      action,
+      to: "123456",
+      handledBy: "plugin",
+      payload,
+      dryRun: false,
+    } as MessageActionResult);
+
+    await runMessageCommand({ action });
+
+    const json = JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0]));
+    expect(json).toMatchObject({
+      ok: false,
+      error: { type: "cli_error", message: expected },
+    });
+    expect(json.payload).toEqual(payload);
+    expect(json).not.toHaveProperty("deliveryStatus");
+  });
+
   it("rejects unknown message actions before dispatch", async () => {
     await expect(runMessageCommand({ action: "nope" })).rejects.toThrow("Unknown message action");
     expect(runMessageActionMock).not.toHaveBeenCalled();

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -24,10 +24,7 @@ import {
   resolveMessageBroadcastAccountPlan,
   validateExplicitMessageAccountSelection,
 } from "../infra/outbound/message-account-selection.js";
-import {
-  isMessageActionSuccessful,
-  resolveMessageSendOutcome,
-} from "../infra/outbound/message-action-contracts.js";
+import { resolveMessageActionOutcome } from "../infra/outbound/message-action-contracts.js";
 import { runMessageAction } from "../infra/outbound/message-action-runner.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 
@@ -53,15 +50,15 @@ function extractMessageId(payload: unknown): string | undefined {
 function buildMessageCliJson(result: Awaited<ReturnType<typeof runMessageAction>>) {
   const messageId = extractMessageId(result.payload);
   const sendResult = result.kind === "send" ? result.sendResult : undefined;
-  const sendOutcome = result.kind === "send" ? resolveMessageSendOutcome(sendResult) : undefined;
+  const outcome = resolveMessageActionOutcome(result);
   return {
     ...(result.kind === "broadcast"
-      ? { ok: isMessageActionSuccessful(result) }
-      : sendOutcome && !sendOutcome.ok && !result.dryRun
+      ? { ok: outcome.ok }
+      : !outcome.ok
         ? {
-            ...formatCliJsonFailure(sendOutcome.error),
-            deliveryStatus: sendResult?.deliveryStatus,
-            ...(sendOutcome.sentBeforeError ? { sentBeforeError: true } : {}),
+            ...formatCliJsonFailure(outcome.error),
+            ...(sendResult ? { deliveryStatus: sendResult.deliveryStatus } : {}),
+            ...(outcome.sentBeforeError ? { sentBeforeError: true } : {}),
           }
         : {}),
     action: result.action,

--- a/src/infra/outbound/message-action-contracts.ts
+++ b/src/infra/outbound/message-action-contracts.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { AgentToolResult } from "../../agents/runtime/index.js";
 import type { ExecutionIdentityAdmissionToken } from "../../audit/execution-identity-admission.js";
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
@@ -208,10 +210,28 @@ export function resolveMessageSendOutcome(
   return sendResult.deliveryStatus satisfies never;
 }
 
-export const isMessageActionSuccessful = (result: MessageActionResult): boolean =>
-  result.kind === "broadcast"
-    ? result.payload.results.every((entry) => entry.ok)
-    : result.kind !== "send" || result.dryRun || resolveMessageSendOutcome(result.sendResult).ok;
+export function resolveMessageActionOutcome(
+  result: MessageActionResult,
+): ReturnType<typeof resolveMessageSendOutcome> {
+  if (result.kind === "broadcast") {
+    const failure = result.payload.results.find((entry) => !entry.ok);
+    return failure ? { ok: false, error: failure.error ?? "Broadcast failed." } : { ok: true };
+  }
+  if (result.dryRun) {
+    return { ok: true };
+  }
+  const outcome =
+    result.kind === "send" ? resolveMessageSendOutcome(result.sendResult) : { ok: true as const };
+  const payload = result.payload;
+  if (!outcome.ok || !isRecord(payload) || payload.ok !== false) {
+    return outcome;
+  }
+  const error =
+    [payload.error, payload.warning, payload.hint, payload.reason]
+      .map(normalizeOptionalString)
+      .find(Boolean) ?? `Message ${result.action} failed.`;
+  return { ok: false, error };
+}
 
 export type ResolvedActionContext = {
   cfg: OpenClawConfig;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running message actions would see a successful green checkmark and exit code zero even when a channel explicitly reported that the action failed. Disabled or rejected Telegram reactions could misleadingly print `Reaction updated` or `Reaction added`, failed message deletions looked successful, and plugin-handled sends or polls also hid their failures. JSON output kept the failure buried inside `payload` without the standard top-level failure envelope.

## Why This Change Was Made

Reuse one canonical message-action outcome at all three CLI boundaries: process exit status, human-readable output, and machine-readable JSON. Only an authoritative top-level `payload.ok === false` is treated as a provider-reported failure; existing core delivery statuses and broadcast aggregation remain authoritative, and provider `error`, `warning`, or `hint` text is surfaced without modifying the original payload. Channel plugins continue returning their intentional soft failures to model tools, preventing duplicate-action retry loops.

## User Impact

Failed reactions, deletions, edits, plugin-handled sends, and polls now explain the actual provider failure and exit nonzero; JSON callers receive the normal `ok: false` / `cli_error` envelope alongside the unchanged provider payload. Successful actions, legacy payloads without a boolean outcome, dry runs, broadcast results, and partially delivered messages retain their existing behavior.

## Evidence

- Authentic pre-fix RED: the real Commander message parser failed five new owner regressions because disabled reactions, rejected reactions carrying optimistic `added` metadata, deletes, plugin polls, and plugin sends all exited zero instead of one; 50 existing parser tests passed.
- Authentic pre-fix RED: five human-output regressions printed false success, and five JSON regressions omitted the canonical failure envelope; 41 existing command and formatter tests passed.
- GREEN: `node scripts/run-vitest.mjs src/cli/program/message/helpers.test.ts src/commands/message-format.test.ts src/commands/message.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts src/infra/outbound/message-action-runner.core-send.test.ts` — 128 tests passed across three routed shards.
- Targeted formatter check, typed owner-scope oxlint, `git diff --check`, independent source review, and configured Codex autoreview all passed.
- No real messages were sent, no provider credentials were accessed, and no plugin or model-tool failure contract changed.

AI-assisted.
