### PR TITLE
docs(gateway): document the Daytona cloud-worker provider

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -80,6 +80,37 @@ printf '%s' "$CRABBOX_COORDINATOR_TOKEN" | crabbox login \
 
 Keep the token out of repository config and shell arguments.
 
+### Daytona
+
+The bundled Crabbox provider can also lease [Daytona](https://www.daytona.io) sandboxes as cloud workers (`settings.provider: "daytona"`). Unlike AWS, Daytona needs no separate `crabbox login` step: export `DAYTONA_API_KEY` (from the [Daytona dashboard](https://app.daytona.io/dashboard/keys)) in the Gateway process's environment before Crabbox allocates a lease. Verify it without provisioning anything:
+
+```bash
+DAYTONA_API_KEY=<key> crabbox doctor --provider daytona --json
+```
+
+A `daytona-fallback auth=ready control_plane=ready inventory=ready` finding confirms the key authenticates; `mutation=false` means the check is read-only. Daytona leases are Linux-only (`target: linux`) and reachable over SSH like any other Crabbox `ssh-lease` provider. Crabbox's default Daytona snapshot already ships Node.js and `npx`, so `settings.setup` is optional here — keep it only if your own snapshot needs it, as an idempotent guard like the AWS example above.
+
+```json
+{
+  "cloudWorkers": {
+    "profiles": {
+      "daytona": {
+        "provider": "crabbox",
+        "install": "bundle",
+        "settings": {
+          "provider": "daytona",
+          "class": "beast",
+          "ttl": "8h",
+          "idleTimeout": "45m"
+        }
+      }
+    }
+  }
+}
+```
+
+`class` defaults to `beast` (Crabbox's own default for this provider) when omitted; `crabbox providers describe daytona --json` lists the full flag set. Provide `DAYTONA_API_KEY` as an environment variable on the Gateway process (for example through a systemd `EnvironmentFile`), the same way other credential-bearing provider secrets are supplied — never in `openclaw.json` itself.
+
 ## Configuration
 
 Manage profiles in the Control UI under **Settings → Connections → Cloud workers**, or edit `cloudWorkers.profiles` directly in `openclaw.json` — both write the same config keys. The settings page lists each profile's backend, class, lifetime, and idle-stop in plain language, and shows whether it is advertised to `environments.list` or waiting on a Gateway restart. With no profiles configured it explains the feature, links back to this page, and starts the add flow.


### PR DESCRIPTION
## What Problem This Solves

`docs/gateway/cloud-workers.md` documented how to configure Crabbox cloud-worker profiles for AWS but said nothing about Daytona, even though the bundled Crabbox provider already supports it as a full `ssh-lease` backend.

## Why This Change Was Made

Confirmed via `crabbox providers describe daytona --json` and a real end-to-end live test that no new OpenClaw provider code is needed — `settings.provider: "daytona"` already passes straight through the existing Crabbox worker provider. The only gap was documentation: how to authenticate (`DAYTONA_API_KEY`, no `crabbox login` step required, unlike AWS), a profile example, and what the default snapshot provides out of the box.

## User Impact

Operators can now configure a Daytona-backed cloud-worker profile with a documented, live-verified example instead of reverse-engineering it from the AWS section or Crabbox source.

## Evidence

Live proof against the real Daytona API (isolated local Crabbox binary, not the shared team Gateway):

- `crabbox doctor --provider daytona --json` → `daytona-fallback auth=ready control_plane=ready inventory=ready leases=0 mutation=false`
- `crabbox run --provider daytona --no-sync -- 'node --version; npx --version; uname -a'` → real lease `cbx_7787281196a7`, exit 0, `node v25.9.0`, `npx 11.12.1`, Ubuntu 24.04 kernel — confirming the default snapshot ships Node/npx already, so `settings.setup` is optional for this provider (documented as such).
- `crabbox list --provider daytona --json` → `null` after the run, confirming clean teardown with no dangling billable resource.
- `pnpm docs:check-config-examples` and `node scripts/check-changed.mjs -- docs/gateway/cloud-workers.md` both pass.
- Codex-engine `autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings.

Docs-only change; no runtime/schema/config-contract impact.
