### PR TITLE
Fix Slack mrkdwn formatting for updates

### DIFF
--- a/src/config/markdown-tables.test.ts
+++ b/src/config/markdown-tables.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { resolveMarkdownTableMode } from "./markdown-tables.js";
+
+describe("resolveMarkdownTableMode", () => {
+  it("defaults Slack tables to bullets", () => {
+    expect(resolveMarkdownTableMode({ cfg: {}, channel: "slack", accountId: "default" })).toBe(
+      "bullets",
+    );
+  });
+
+  it("allows Slack table mode overrides", () => {
+    expect(
+      resolveMarkdownTableMode({
+        cfg: { channels: { slack: { markdown: { tables: "code" } } } },
+        channel: "slack",
+        accountId: "default",
+      }),
+    ).toBe("code");
+  });
+});

--- a/src/config/markdown-tables.ts
+++ b/src/config/markdown-tables.ts
@@ -15,6 +15,7 @@ type MarkdownConfigSection = MarkdownConfigEntry & {
 
 const DEFAULT_TABLE_MODES = new Map<string, MarkdownTableMode>([
   ["signal", "bullets"],
+  ["slack", "bullets"],
   ["whatsapp", "bullets"],
 ]);
 

--- a/src/markdown/ir.table-bullets.test.ts
+++ b/src/markdown/ir.table-bullets.test.ts
@@ -12,12 +12,9 @@ describe("markdownToIR tableMode bullets", () => {
 
     const ir = markdownToIR(md, { tableMode: "bullets" });
 
-    // Should contain bullet points with header:value format
-    expect(ir.text).toContain("• Value: 1");
-    expect(ir.text).toContain("• Value: 2");
-    // Should use first column as labels
-    expect(ir.text).toContain("A");
-    expect(ir.text).toContain("B");
+    // Two-column tables render as compact key:value bullets.
+    expect(ir.text).toContain("• A: 1");
+    expect(ir.text).toContain("• B: 2");
   });
 
   it("handles table with multiple columns", () => {
@@ -67,20 +64,19 @@ describe("markdownToIR tableMode bullets", () => {
     const ir = markdownToIR(md, { tableMode: "bullets" });
 
     // Should handle empty cell without crashing
-    expect(ir.text).toContain("B");
-    expect(ir.text).toContain("• Value: 2");
+    expect(ir.text).toContain("• A");
+    expect(ir.text).toContain("• B: 2");
   });
 
-  it("bolds row labels in bullets mode", () => {
+  it("preserves explicit bold in two-column bullet labels", () => {
     const md = `
 | Name | Value |
 |------|-------|
-| Row1 | Data1 |
+| **Row1** | Data1 |
 `.trim();
 
     const ir = markdownToIR(md, { tableMode: "bullets" });
 
-    // Should have bold style for row label
     const hasRowLabelBold = ir.styles.some(
       (s) => s.style === "bold" && ir.text.slice(s.start, s.end) === "Row1",
     );

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -384,11 +384,35 @@ function renderTableAsBullets(state: RenderState) {
     return;
   }
 
+  // Two-column tables are usually key/value summaries. Render them as compact
+  // bullets so chat clients do not show raw pipe syntax.
+  const useTwoColumnKeyValues = headers.length === 2 && rows.every((row) => row.length <= 2);
+
   // Determine if first column should be used as row labels
   // (common pattern: first column is category/feature name)
   const useFirstColAsLabel = headers.length > 1 && rows.length > 0;
 
-  if (useFirstColAsLabel) {
+  if (useTwoColumnKeyValues) {
+    for (const row of rows) {
+      const label = row[0];
+      const value = row[1];
+      if (!label?.text && !value?.text) {
+        continue;
+      }
+      state.text += "• ";
+      if (label?.text) {
+        appendCell(state, label);
+      }
+      if (label?.text && value?.text) {
+        state.text += ": ";
+      }
+      if (value?.text) {
+        appendCell(state, value);
+      }
+      state.text += "\n";
+    }
+    state.text += "\n";
+  } else if (useFirstColAsLabel) {
     // Format: each row becomes a section with header as row[0], then key:value pairs
     for (const row of rows) {
       if (row.length === 0) {

--- a/src/slack/actions.format.test.ts
+++ b/src/slack/actions.format.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createSlackEditTestClient, installSlackBlockTestMocks } from "./blocks.test-helpers.js";
+
+installSlackBlockTestMocks();
+const { editSlackMessage } = await import("./actions.js");
+
+describe("editSlackMessage markdown formatting", () => {
+  it("converts edited Markdown content to Slack mrkdwn", async () => {
+    const client = createSlackEditTestClient();
+
+    await editSlackMessage("C123", "171234.567", "## Deploy\n\n**green**", {
+      token: "xoxb-test",
+      client,
+    });
+
+    expect(client.chat.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "*Deploy*\n\n*green*",
+      }),
+    );
+  });
+
+  it("leaves plain edited text unchanged", async () => {
+    const client = createSlackEditTestClient();
+
+    await editSlackMessage("C123", "171234.567", "plain status update", {
+      token: "xoxb-test",
+      client,
+    });
+
+    expect(client.chat.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "plain status update",
+      }),
+    );
+  });
+});

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -1,10 +1,12 @@
 import type { Block, KnownBlock, WebClient } from "@slack/web-api";
 import { loadConfig } from "../config/config.js";
+import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
 import { resolveSlackAccount } from "./accounts.js";
 import { buildSlackBlocksFallbackText } from "./blocks-fallback.js";
 import { validateSlackBlocksArray } from "./blocks-input.js";
 import { createSlackWebClient } from "./client.js";
+import { markdownToSlackMrkdwn } from "./format.js";
 import { sendMessageSlack } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
 
@@ -33,7 +35,7 @@ export type SlackPin = {
   file?: { id?: string; name?: string };
 };
 
-function resolveToken(explicit?: string, accountId?: string) {
+function resolveAccountContext(explicit?: string, accountId?: string) {
   const cfg = loadConfig();
   const account = resolveSlackAccount({ cfg, accountId });
   const token = resolveSlackBotToken(explicit ?? account.botToken ?? undefined);
@@ -45,7 +47,11 @@ function resolveToken(explicit?: string, accountId?: string) {
     );
     throw new Error("SLACK_BOT_TOKEN or channels.slack.botToken is required for Slack actions");
   }
-  return token;
+  return { cfg, account, token };
+}
+
+function resolveToken(explicit?: string, accountId?: string) {
+  return resolveAccountContext(explicit, accountId).token;
 }
 
 function normalizeEmoji(raw: string) {
@@ -171,13 +177,24 @@ export async function editSlackMessage(
   content: string,
   opts: SlackActionClientOpts & { blocks?: (Block | KnownBlock)[] } = {},
 ) {
-  const client = await getClient(opts);
+  const { cfg, account, token } = resolveAccountContext(opts.token, opts.accountId);
+  const client = opts.client ?? createSlackWebClient(token);
   const blocks = opts.blocks == null ? undefined : validateSlackBlocksArray(opts.blocks);
   const trimmedContent = content.trim();
+  const tableMode = resolveMarkdownTableMode({
+    cfg,
+    channel: "slack",
+    accountId: account.accountId,
+  });
+  const slackText = trimmedContent
+    ? markdownToSlackMrkdwn(trimmedContent, { tableMode })
+    : blocks
+      ? buildSlackBlocksFallbackText(blocks)
+      : " ";
   await client.chat.update({
     channel: channelId,
     ts: messageId,
-    text: trimmedContent || (blocks ? buildSlackBlocksFallbackText(blocks) : " "),
+    text: slackText,
     ...(blocks ? { blocks } : {}),
   });
 }

--- a/src/slack/format.test.ts
+++ b/src/slack/format.test.ts
@@ -56,4 +56,55 @@ describe("markdownToSlackMrkdwn", () => {
       "*Important:* Check the _docs_ at <https://example.com|link>\n\n• first\n• second",
     );
   });
+
+  it("converts Markdown tables into Slack-safe bullets", () => {
+    const res = markdownToSlackMrkdwn(
+      [
+        "| Item | Estimate |",
+        "|---|---:|",
+        "| 25% deposit | **£45,000** |",
+        "| Legal/survey/mortgage costs | **£2,000–£4,000** |",
+      ].join("\n"),
+      { tableMode: "bullets" },
+    );
+
+    expect(res).toBe("• 25% deposit: *£45,000*\n• Legal/survey/mortgage costs: *£2,000–£4,000*");
+    expect(res).not.toContain("|---|");
+  });
+
+  it("keeps code fences intact while converting surrounding markdown", () => {
+    const res = markdownToSlackMrkdwn(
+      "**before**\n\n```ts\nconst ok = true;\n```\n\n[docs](https://example.com)",
+    );
+
+    expect(res).toBe("*before*\n\n```\nconst ok = true;\n```\n<https://example.com|docs>");
+  });
+
+  it("converts the mortgage cash table sample to Slack mrkdwn", () => {
+    const input = [
+      "Realistically: **the £18k deposit is probably the problem.**",
+      "",
+      "| Item | Estimate |",
+      "|---|---:|",
+      "| 25% deposit | **£45,000** |",
+      "| Additional-property stamp duty | **~£10,100** |",
+      "| Legal/survey/mortgage costs | **£2,000–£4,000** |",
+      "| **Total cash needed** | **~£57k–£59k** |",
+    ].join("\n");
+
+    const res = markdownToSlackMrkdwn(input, { tableMode: "bullets" });
+
+    expect(res).toBe(
+      [
+        "Realistically: *the £18k deposit is probably the problem.*",
+        "",
+        "• 25% deposit: *£45,000*",
+        "• Additional-property stamp duty: *~£10,100*",
+        "• Legal/survey/mortgage costs: *£2,000–£4,000*",
+        "• *Total cash needed*: *~£57k–£59k*",
+      ].join("\n"),
+    );
+    expect(res).not.toContain("**");
+    expect(res).not.toContain("|---|");
+  });
 });

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -7,10 +7,12 @@ import { removeAckReactionAfterReply } from "../../../channels/ack-reactions.js"
 import { logAckFailure, logTypingFailure } from "../../../channels/logging.js";
 import { createReplyPrefixOptions } from "../../../channels/reply-prefix.js";
 import { createTypingCallbacks } from "../../../channels/typing.js";
+import { resolveMarkdownTableMode } from "../../../config/markdown-tables.js";
 import { resolveStorePath, updateLastRoute } from "../../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../../globals.js";
 import { removeSlackReaction } from "../../actions.js";
 import { createSlackDraftStream } from "../../draft-stream.js";
+import { markdownToSlackMrkdwn } from "../../format.js";
 import {
   applyAppendOnlyStreamUpdate,
   buildStatusFinalPreviewText,
@@ -158,6 +160,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     nativeStreaming: account.config.nativeStreaming,
   });
   const previewStreamingEnabled = slackStreaming.mode !== "off";
+  const slackTableMode = resolveMarkdownTableMode({
+    cfg,
+    channel: "slack",
+    accountId: account.accountId,
+  });
   const streamingEnabled = isSlackStreamingEnabled({
     mode: slackStreaming.mode,
     nativeStreaming: slackStreaming.nativeStreaming,
@@ -264,7 +271,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             token: ctx.botToken,
             channel: draftChannelId,
             ts: draftMessageId,
-            text: finalText.trim(),
+            text: markdownToSlackMrkdwn(finalText.trim(), { tableMode: slackTableMode }),
           });
           return;
         } catch (err) {


### PR DESCRIPTION
## Summary
- convert edited Slack message text through the existing Markdown → Slack `mrkdwn` adapter before `chat.update`
- default Slack Markdown tables to bullet output, so pipe tables do not appear raw in Slack
- render two-column Markdown tables as compact `• key: value` bullets
- convert preview-stream final edits through the same Slack adapter
- add regressions for bold, headings, tables, code fences, links, plain text, and the mortgage cash table sample

## What Problem This Solves
Slack Web API update calls (`chat.update`) do not render GitHub/CommonMark Markdown the same way normal OpenClaw text is authored. The send path already converted Markdown to Slack `mrkdwn`, but edited/updated Slack messages could bypass that adapter and leak raw headings/tables/pipes into Slack.

This keeps OpenWire/core content as normal Markdown and applies Slack-specific rendering only at the Slack provider edge.

Docs:
- https://docs.slack.dev/messaging/formatting-message-text/
- https://docs.slack.dev/reference/methods/chat.postMessage

Recent PR review: recent Slack/provider formatting commits are mostly tests/refactors/modal handling. The raw `chat.update` path appears to predate those changes; I did not find a recent PR that clearly introduced the regression.

## Evidence
Local validation after the final patch:
- focused tests: 47/47 passed
  - `src/config/markdown-tables.test.ts`
  - `src/slack/actions.format.test.ts`
  - `src/slack/actions.blocks.test.ts`
  - `src/slack/format.test.ts`
  - `src/markdown/ir.table-bullets.test.ts`
  - `src/auto-reply/reply/route-reply.test.ts`
  - `src/channels/plugins/outbound/slack.test.ts`
- `pnpm format:check` passed
- `pnpm tsgo` passed
- `pnpm build` passed

Usage/conflict check:
- `markdownToSlackMrkdwn()` is used only in Slack paths.
- `editSlackMessage()` now converts before `chat.update`.
- preview-stream finalisation now converts before `chat.update`.
- non-Slack provider routes still resolve their own table modes and do not receive Slack `mrkdwn` output.

## Test plan
- `pnpm vitest run src/config/markdown-tables.test.ts src/slack/actions.format.test.ts src/slack/actions.blocks.test.ts src/slack/format.test.ts src/markdown/ir.table-bullets.test.ts src/auto-reply/reply/route-reply.test.ts src/channels/plugins/outbound/slack.test.ts`
- `pnpm format:check`
- `pnpm tsgo`
- `pnpm build`
