### PR TITLE
fix(e2e): stable-to-main upgrade checks fail before install

### DIFF
--- a/scripts/lib/docker-e2e-package.sh
+++ b/scripts/lib/docker-e2e-package.sh
@@ -274,6 +274,7 @@ docker_e2e_harness_mount_args() {
     -v "$harness_root/tsconfig.json:/app/tsconfig.json:ro"
     -v "$harness_root/test/e2e/qa-lab:/app/test/e2e/qa-lab:ro"
     -v "$harness_root/test/helpers:/app/test/helpers:ro"
+    -v "$harness_root/scripts/prepublish-plugin-registry-artifact.mjs:/app/scripts/prepublish-plugin-registry-artifact.mjs:ro"
     -v "$harness_root/scripts/windows-cmd-helpers.mjs:/app/scripts/windows-cmd-helpers.mjs:ro"
   )
 }

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -4682,6 +4682,7 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     expectTextToIncludeAll(helper, [
       "--allow-unreleased-changelog",
       'local harness_root="${DOCKER_E2E_HARNESS_ROOT_DIR:-$ROOT_DIR}"',
+      '-v "$harness_root/scripts/prepublish-plugin-registry-artifact.mjs:/app/scripts/prepublish-plugin-registry-artifact.mjs:ro"',
       '-v "$harness_root/scripts/windows-cmd-helpers.mjs:/app/scripts/windows-cmd-helpers.mjs:ro"',
       '-v "$harness_root/packages/gateway-client/src:/app/packages/gateway-client/src:ro"',
       '-v "$harness_root/packages/normalization-core/package.json:/app/packages/normalization-core/package.json:ro"',


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release operators running Package Acceptance against a stable npm installation would see every `published-upgrade-survivor` scenario fail before installing the candidate when a prerelease plugin registry artifact was present.

The shared registry helper invokes `/app/scripts/prepublish-plugin-registry-artifact.mjs`, but the generic Docker E2E harness did not mount that trusted root-level verifier. Three 13-scenario stress cycles and one independent reproduction all failed with `Cannot find module '/app/scripts/prepublish-plugin-registry-artifact.mjs'`.

## Why This Change Was Made

The generic Docker E2E harness now mounts the existing verifier at the absolute path already owned by the shared registry helper. The mount is read-only and follows the existing explicit root-helper mount pattern rather than broadening the container to the whole `scripts/` tree.

The existing root-helper mount contract test now covers this verifier. No package, registry, migration, or runtime behavior changes.

## User Impact

Release operators can run stable-to-main upgrade-survivor acceptance far enough to install and validate the selected candidate instead of failing during harness setup.

## Evidence

- Pre-fix regression proof: `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts -t "mounts root helper modules imported by bare Docker E2E scripts"` failed because the verifier mount was absent.
- Post-fix focused proof: the same test passed.
- Tooling-Docker + registry integration: 203/203 tests passed across `test/scripts/docker-build-helper.test.ts` and `test/scripts/prepublish-plugin-registry-shell.test.ts`.
- `node scripts/check-changed.mjs -- scripts/lib/docker-e2e-package.sh test/scripts/docker-build-helper.test.ts` passed, including test-root typecheck and script lint.
- `bash -n scripts/lib/docker-e2e-package.sh scripts/e2e/lib/prepublish-plugin-registry.sh` and `git diff --check` passed.
- Autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings; patch correct at 0.99 confidence.
- Original package evidence: https://github.com/openclaw/openclaw/actions/runs/32938891218
- Stress reproductions: https://github.com/openclaw/openclaw/actions/runs/32939822354 and https://github.com/openclaw/openclaw/actions/runs/32939825518
- Independent 13-scenario reproduction: https://github.com/openclaw/openclaw/actions/runs/32942163026
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/32999705292 (`openclaw/ci-gate` passed; no failing checks).
- Package Acceptance: https://github.com/openclaw/openclaw/actions/runs/32999746515 passed registry artifact verification, tarball integrity/content checks, Docker setup, candidate global installation, and exact-ref validation. It then exposed a distinct downstream stable-candidate dist-tag defect during Discord plugin repair; that owner bug is outside this mount patch and is being repaired separately before the full stress rerun.

## Repair Shape

- Root cause: commit `67c5a856194c41e8cab07919efe001a3ed1a217e` introduced a shared helper whose default verifier path sits outside the directories mounted by `docker_e2e_harness_mount_args`.
- Owner boundary: the generic trusted Docker E2E harness mount list.
- Production/tooling LOC: +1/-0.
- Tests: +1/-0.
- Alternatives rejected: mounting all of `scripts/` broadens the trusted container surface unnecessarily; caller-specific overrides duplicate the path contract and leave sibling harness users exposed.

AI-assisted: yes. The implementation, root-cause trace, regression proof, and validation were reviewed by the submitting maintainer.

