### PR TITLE
fix(onboard): remote setup no longer enables local hooks

### DIFF
--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -566,7 +566,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         url: `ws://127.0.0.1:${port}`,
         token,
       });
-      expect(cfg.hooks?.internal?.entries?.["session-memory"]).toEqual({ enabled: true });
+      expect(cfg.hooks).toBeUndefined();
     });
   }, 60_000);
 
@@ -593,9 +593,16 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
           },
         },
       ];
+      const seededHooks = {
+        internal: {
+          enabled: false,
+          entries: { "session-memory": { enabled: false } },
+        },
+      };
       testConfigStore.set(resolveTestConfigPath(), {
         agents: { list: seededAgents },
         bindings: seededBindings,
+        hooks: seededHooks,
         gateway: {
           mode: "remote",
           remote: {
@@ -621,6 +628,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       const cfg = readTestConfig();
       expect(cfg.agents?.list?.map((a) => a.id)).toEqual(["alpha", "beta"]);
       expect(cfg.bindings).toEqual(seededBindings);
+      expect(cfg.hooks).toEqual(seededHooks);
       expect(cfg.gateway?.remote).toEqual({
         url: `ws://127.0.0.1:${port}`,
         token: tokenRef,

--- a/src/commands/onboard-non-interactive/remote.ts
+++ b/src/commands/onboard-non-interactive/remote.ts
@@ -12,7 +12,6 @@ import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { createGatewayEnvSecretRef } from "../../secrets/ref-contract.js";
 import { applySkipBootstrapConfig } from "../onboard-config.js";
 import { applyWizardMetadata } from "../onboard-helpers.js";
-import { enableDefaultOnboardingInternalHooks } from "../onboard-hooks.js";
 import type { OnboardOptions } from "../onboard-types.js";
 import { commitNonInteractiveOnboardConfig } from "./config-write.js";
 
@@ -94,9 +93,6 @@ export async function runNonInteractiveRemoteSetup(params: {
   };
   if (opts.skipBootstrap) {
     nextConfig = applySkipBootstrapConfig(nextConfig);
-  }
-  if (!opts.skipHooks) {
-    nextConfig = enableDefaultOnboardingInternalHooks(nextConfig);
   }
   nextConfig = applyWizardMetadata(nextConfig, { command: "onboard", mode });
   await commitNonInteractiveOnboardConfig({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running non-interactive remote onboarding would have the local `session-memory` internal hook enabled even though remote mode only configures a connection to an existing Gateway.

## Why This Change Was Made

Remote onboarding no longer invokes the local default-hook policy. Existing user-authored hook configuration is still preserved through the base config, while classic and non-interactive local onboarding keep their existing default behavior.

## User Impact

Remote onboarding remains connection-only and no longer introduces local hook behavior. Rerunning remote onboarding does not overwrite authored hook settings.

## Evidence

- Before the source change, `src/commands/onboard-non-interactive.gateway.test.ts` failed the new regression because fresh remote setup wrote `hooks.internal.entries.session-memory.enabled=true`.
- `node scripts/run-vitest.mjs src/commands/onboard-non-interactive.gateway.test.ts src/commands/onboard-non-interactive/remote.test.ts` — 38 tests passed on exact head `9627166a22f368e6bea50764519c421b76d229be`.
- `node scripts/check-changed.mjs -- src/commands/onboard-non-interactive/remote.ts src/commands/onboard-non-interactive.gateway.test.ts` — complete changed gate passed.
- Autoreview on the exact branch diff: no accepted/actionable findings, correctness 0.98.
- Targeted duplicate search found no open issue or PR for remote onboarding enabling local internal hooks.

AI-assisted change; implementation and validation were reviewed end to end.
