### PR TITLE
perf(ui): bootstrap session rosters in one request

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -5205,6 +5205,7 @@ public struct SessionsListParams: Codable, Sendable {
     public let boardface: AnyCodable?
     public let creatorid: String?
     public let ownerid: String?
+    public let ownerfirst: Bool?
     public let involvingme: Bool?
     public let spawnedby: String?
     public let agentid: String?
@@ -5226,6 +5227,7 @@ public struct SessionsListParams: Codable, Sendable {
         boardface: AnyCodable? = nil,
         creatorid: String? = nil,
         ownerid: String? = nil,
+        ownerfirst: Bool? = nil,
         involvingme: Bool? = nil,
         spawnedby: String? = nil,
         agentid: String? = nil,
@@ -5246,6 +5248,7 @@ public struct SessionsListParams: Codable, Sendable {
         self.boardface = boardface
         self.creatorid = creatorid
         self.ownerid = ownerid
+        self.ownerfirst = ownerfirst
         self.involvingme = involvingme
         self.spawnedby = spawnedby
         self.agentid = agentid
@@ -5268,6 +5271,7 @@ public struct SessionsListParams: Codable, Sendable {
         case boardface = "boardFace"
         case creatorid = "creatorId"
         case ownerid = "ownerId"
+        case ownerfirst = "ownerFirst"
         case involvingme = "involvingMe"
         case spawnedby = "spawnedBy"
         case agentid = "agentId"

--- a/docs/gateway/clients.md
+++ b/docs/gateway/clients.md
@@ -145,8 +145,10 @@ snapshot, so re-read them on every reconnect.
 Treat every successful reconnect as a new projection over durable history and
 current in-memory run state:
 
-1. Re-establish `sessions.subscribe` and the selected session's
-   `sessions.messages.subscribe` subscription.
+1. Re-establish `sessions.subscribe` with your list parameters to receive the
+   current roster in the same response, as described
+   [below](/gateway/clients#subscribe-instead-of-polling-usage). Also re-establish
+   the selected session's `sessions.messages.subscribe` subscription.
 2. Call `chat.history` for the selected `sessionKey` and replace local persisted
    rows with the returned `messages` projection.
 3. If `inFlightRun` is present, adopt its `runId`, buffered `text`, and optional
@@ -240,8 +242,27 @@ archive history; anchored responses intentionally omit numeric paging metadata.
 
 ## Subscribe instead of polling usage
 
-Load the initial catalog with `sessions.list`, then call `sessions.subscribe` once
-per connection. Merge `sessions.changed` events by `sessionKey`. Session change
+Install the `sessions.changed` listener, then call `sessions.subscribe` once per
+connection with your `sessions.list` parameters, such as
+`{ limit: 60, ownerFirst: true }`. The response is `{ subscribed: true, list }`,
+where `list` is the normal `SessionsListResult` snapshot. Passing `{}` activates
+the subscription but returns only `{ subscribed: true }`, without a list.
+
+The Gateway activates the subscription before reading the snapshot. Events can
+therefore arrive before the response. Track changes received during bootstrap
+and follow the response with a `sessions.list` refresh when needed; do not let
+the snapshot silently overwrite a newer event. Re-establish this flow after
+every reconnect.
+
+`ownerFirst: true` prepends up to 60 matching sessions owned by the authenticated
+viewer to the normal first page, removing duplicates within that response. It
+applies only when `offset` is zero or omitted. The Gateway derives the viewer
+identity from the authenticated connection, not a client-supplied identity.
+The shared page's pagination metadata is unchanged, so use `nextOffset`, not the
+number of returned rows, when loading another page, and merge rows by session
+key. See [Session list bootstrap](/gateway/protocol#session-list-bootstrap).
+
+Merge subsequent `sessions.changed` events by `sessionKey`. Session change
 payloads can carry live `inputTokens`, `outputTokens`, `totalTokens`,
 `totalTokensFresh`, `contextTokens`, `estimatedCostUsd`, response-usage settings,
 and active-run state.

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -651,7 +651,7 @@ methods. Treat this as feature discovery, not a full enumeration of
 
   <Accordion title="Session control">
     - `sessions.list` returns the current session index, including per-row `agentRuntime` metadata when an agent runtime backend is configured. `hasActiveRun` is the authoritative aggregate direct-session activity fact. When projected, `activeRunIds` is the complete exact active set; an empty array proves the session is idle. If aggregate activity is true while the field is omitted, another runtime owner is active but its exact identities are unavailable. Snapshot omission means identities unavailable. On incremental events, omission means no change, `null` is the event-only tombstone that clears cached exact IDs to unavailable, and an array replaces the cache. Clients correlate only exact IDs they own locally or received from requests, history, or events and never select the first list entry as an owner. When cloud-worker placement is enabled or durable recovery state exists, session rows also include a closed `placement` state (`local`, `requested`, `provisioning`, `syncing`, `starting`, `active`, `draining`, `reconciling`, `reclaimed`, or `failed`) plus state-specific environment, owner-epoch, workspace, bundle, ACK-cursor, or recovery fields. Active placements may include an advisory `diskSpace` sample with `status` (`ok`, `warning`, or `critical`), `availableBytes`, `totalBytes`, and `observedAtMs`. An active paired-device placement also includes `runner: { kind: "device", status: "available" | "offline", deviceId? }`; `deviceId` names the paired device hosting the placement (the selected host for `autoDevice` dispatch), and non-device placements omit the field. This availability is process-current, derived from the exact active environment binding and reconnect-scoped node-runner proof, and starts offline after Gateway restart until that runner reconnects. Inventory changes emit `sessions.changed` so clients refresh the canonical row. Rows carry ownership projections — write-once `createdActor`, the mutable `owner` (actor plus `assignedBy`/`assignedAt`), a bounded `participants` list (owner excluded, up to 4 actors), and the full `participantCount`; actor display labels and avatars are resolved from current profiles and agent identities at read time. Pass `creatorId` to filter by immutable `createdActor.id`; pass `ownerId` to filter by the current assignable owner, falling back to `createdActor` when no owner is assigned. The complete `owners` facet is independent of pagination and remains unfiltered by either query, so clients can render the full owner picker. Authenticated callers can pass `involvingMe: true` to keep only sessions the caller owns or has prompted, evaluated against the full participant history (profile-backed human participants only).
-    - `sessions.subscribe` enables session change events for the current WebSocket client. The subscription ends when that client disconnects.
+    - `sessions.subscribe` enables session change events for the current WebSocket client and accepts the same parameters as `sessions.list` to return an initial list in the same response. Empty `{}` parameters return only the subscription acknowledgment. The subscription ends when that client disconnects. See [Session list bootstrap](/gateway/protocol#session-list-bootstrap).
     - `sessions.messages.subscribe` and `sessions.messages.unsubscribe` toggle transcript/message event subscriptions for one session. Pass `includeApprovals: true` to also receive sanitized `session.approval` lifecycle events for approvals whose persisted audience includes that exact session and whose reviewer binding authorizes the subscribing client. The subscribe response then includes a bounded pending `approvalReplay`; it is authoritative when `truncated` is false. The opt-in is per subscribe call, not sticky: re-subscribing to the same session without `includeApprovals: true` removes an existing approval subscription. In addition to normal session-read authority, this opt-in requires `operator.admin`, or `operator.approvals` on a paired device.
     - `sessions.preview` returns bounded transcript previews for specific session keys.
     - `sessions.describe` returns one gateway session row for an exact session key.
@@ -747,6 +747,37 @@ methods. Treat this as feature discovery, not a full enumeration of
 
   </Accordion>
 </AccordionGroup>
+
+### Session list bootstrap
+
+Call `sessions.subscribe` with a non-empty `sessions.list` parameter object, such
+as `{ limit: 60, ownerFirst: true }`, to subscribe and load the initial roster in
+one request. A successful WebSocket response has the payload
+`{ subscribed: true, list }`, where `list` is the normal `SessionsListResult`.
+Calling with `{}` preserves the acknowledgment-only response
+`{ subscribed: true }` and does not read a snapshot.
+List parameters select the snapshot; they do not filter the connection's session
+event subscription.
+
+The Gateway registers the subscription before projecting the list. Clients must
+listen for `sessions.changed` before making the request: events can arrive while
+the snapshot is being built. Reconcile those events with the response and issue
+a trailing `sessions.list` refresh when needed, including when an event only
+invalidates the cached list. Reconnects require a new subscription and snapshot.
+
+Both methods accept `ownerFirst: true` to prepend up to 60 matching viewer-owned
+rows (or `limit`, when smaller) to the normal first page, deduplicated by session key. This applies only
+when `offset` is zero or omitted; later pages use normal pagination. Owned rows
+must pass the same visibility and list filters as the shared page. The Gateway
+resolves the viewer from the authenticated connection; no client-supplied
+identity selects these rows. Without an authenticated viewer identity, or when
+`ownerFirst` is false or omitted, the list uses normal ordering.
+
+The shared page still determines `limitApplied`, `offset`, `nextOffset`,
+`hasMore`, and `totalCount`. Prepended rows can make `sessions.length` and `count`
+exceed the shared page size. Use `nextOffset` to advance and deduplicate rows by
+session key across pages; do not derive the next offset from the displayed row
+count.
 
 ### Common event families
 

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -418,6 +418,8 @@ export const SessionsListParamsSchema = closedObject({
   creatorId: Type.Optional(NonEmptyString),
   /** Filter rows by their current assignable owner identity. */
   ownerId: Type.Optional(NonEmptyString),
+  /** Prepend the authenticated viewer's owned rows to the normal first page. */
+  ownerFirst: Type.Optional(Type.Boolean()),
   /** Limit rows to sessions owned by or previously prompted by the authenticated viewer. */
   involvingMe: Type.Optional(Type.Boolean()),
   spawnedBy: Type.Optional(NonEmptyString),

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -258,7 +258,7 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["secrets.resolve", null, "operator.admin", "<=2026.7"],
   ["voicewake.routing.get", "voicewake-routing", "operator.read", "<=2026.7"],
   ["sessions.list", "sessions-read", "operator.read", "<=2026.7", { startup: true }],
-  ["sessions.subscribe", "sessions-subscriptions", "operator.read", "<=2026.7"],
+  ["sessions.subscribe", "sessions-subscriptions", "operator.read", "<=2026.7", { startup: true }],
   ["sessions.messages.subscribe", "sessions-subscriptions", "operator.read", "<=2026.7"],
   ["sessions.messages.unsubscribe", "sessions-subscriptions", "operator.read", "<=2026.7"],
   ["sessions.viewers.set", "sessions-subscriptions", "operator.read", "2026.7"],

--- a/src/gateway/server-methods.control-plane-rate-limit.test.ts
+++ b/src/gateway/server-methods.control-plane-rate-limit.test.ts
@@ -233,7 +233,9 @@ describe("gateway control-plane write rate limit", () => {
     expect(suspension?.release()).toBe(true);
   });
 
-  it.each(STARTUP_UNAVAILABLE_GATEWAY_METHODS)(
+  it.each([
+    ...new Set(["sessions.list", "sessions.subscribe", ...STARTUP_UNAVAILABLE_GATEWAY_METHODS]),
+  ])(
     "blocks startup-gated method %s before dispatch with a retryable startup error",
     async (method) => {
       const handlerCalls = vi.fn();

--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -116,28 +116,15 @@ function matchesSessionListFence(value: SessionListFence, fence: SessionListFenc
   );
 }
 
-function sessionListVisibilityIdentity(
-  client: GatewayClient | null,
-  config: OpenClawConfig,
-): string {
-  if (isGatewayAdmin(client)) {
-    return "admin";
-  }
-  const profileId = gatewayClientSessionCreator(client)?.id;
-  if (!profileId) {
-    return "anonymous";
-  }
-  const sessionPolicy = operatorSessionCap(client, config);
-  return sessionPolicy ? `profile:${profileId}:sessions:${sessionPolicy}` : `profile:${profileId}`;
-}
-
 function sessionListWorkKey(
   params: SessionsListParams,
   client: GatewayClient | null,
   config: OpenClawConfig,
 ): string {
   return JSON.stringify([
-    sessionListVisibilityIdentity(client, config),
+    // Admin visibility is global, but owner-first and involving-me rows remain viewer-specific.
+    gatewayClientSessionCreator(client)?.id ?? null,
+    isGatewayAdmin(client) ? "admin" : (operatorSessionCap(client, config) ?? null),
     Object.entries(params).toSorted(([left], [right]) => left.localeCompare(right)),
   ]);
 }

--- a/src/gateway/server-methods/sessions-read-cache.test-support.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test-support.ts
@@ -1,0 +1,58 @@
+import { expect, vi } from "vitest";
+import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { GatewaySessionRow } from "../session-utils.types.js";
+import { sessionReadHandlers } from "./sessions-read.js";
+import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
+
+export { sessionReadHandlers };
+
+export function identifiedClient(profileId: string): GatewayClient {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: { id: "openclaw-control-ui", version: "test", platform: "test", mode: "webchat" },
+      role: "operator",
+      scopes: ["operator.read", "operator.write"],
+    },
+    authenticatedUserProfile: {
+      profileId,
+      displayName: profileId,
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+  };
+}
+
+export function requestContext(config: OpenClawConfig): GatewayRequestContext {
+  return {
+    chatAbortControllers: new Map(),
+    getRuntimeConfig: () => config,
+    getSessionEventSubscriberConnIds: () => new Set(),
+    loadGatewayModelCatalog: async () => [],
+    logGateway: { debug: vi.fn() },
+  } as unknown as GatewayRequestContext;
+}
+
+export async function listSessions(params: {
+  client: GatewayClient;
+  context: GatewayRequestContext;
+  request: SessionsListParams;
+}) {
+  const responses: Parameters<RespondFn>[] = [];
+  await sessionReadHandlers["sessions.list"]?.({
+    params: params.request,
+    client: params.client,
+    context: params.context,
+    respond: (...response: Parameters<RespondFn>) => responses.push(response),
+  } as never);
+  expect(responses).toHaveLength(1);
+  expect(responses[0]?.[0]).toBe(true);
+  return responses[0]?.[1] as {
+    count: number;
+    nextOffset: number | null;
+    sessions: GatewaySessionRow[];
+    totalCount: number;
+  };
+}

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -938,6 +938,42 @@ describe("sessions.list single-flight", () => {
     });
   });
 
+  it.each(["ownerFirst", "involvingMe"] as const)(
+    "keeps administrator %s projections scoped to their authenticated profiles",
+    async (projection) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const config: OpenClawConfig = { agents: { list: [{ id: "main", default: true }] } };
+        const context = requestContext(config);
+        const clients = ["ada@example.com", "bob@example.com"].map((email) => {
+          const client = identifiedClient(ensureProfileForEmail(email).id);
+          client.connect.scopes = ["operator.admin"];
+          return client;
+        });
+        for (const [index, client] of clients.entries()) {
+          await upsertSessionEntryCore(
+            { agentId: "main", sessionKey: `agent:main:profile-${index}` },
+            {
+              sessionId: `profile-${index}`,
+              updatedAt: index + 1,
+              createdActor: { type: "human", id: client.authenticatedUserProfile!.profileId },
+            },
+          );
+        }
+        const request: SessionsListParams = { agentId: "main", limit: 1, [projection]: true };
+
+        const results = await Promise.all(
+          clients.map((client) => listSessions({ client, context, request })),
+        );
+
+        for (const [index, client] of clients.entries()) {
+          expect(results[index]?.sessions[0]?.key).toBe(`agent:main:profile-${index}`);
+          expect(await listSessions({ client, context, request })).toBe(results[index]);
+        }
+        expect(loader.calls).toHaveBeenCalledTimes(2);
+      });
+    },
+  );
+
   it("fences cached rows across client identities and operator-role changes", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const config = await seedSessions();

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -33,9 +33,14 @@ import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { invalidateOperatorRolePolicy } from "../operator-role-policy.js";
 import { bumpSessionAutomationVersion } from "../session-automation-index.js";
 import { persistGatewaySessionLifecycleEvent } from "../session-lifecycle-state.js";
-import type { GatewaySessionRow } from "../session-utils.types.js";
 import type { WorkerSessionPlacementRecord } from "../worker-environments/placement-store.js";
-import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
+import {
+  identifiedClient,
+  listSessions,
+  requestContext,
+  sessionReadHandlers,
+} from "./sessions-read-cache.test-support.js";
+import type { GatewayRequestContext } from "./types.js";
 
 const loader = vi.hoisted(() => ({
   calls: vi.fn(),
@@ -68,59 +73,8 @@ vi.mock("../session-utils.js", async (importOriginal) => {
   };
 });
 
-const { sessionReadHandlers } = await import("./sessions-read.js");
 const { emitSessionsChanged } = await import("./session-change-event.js");
 const { emitSessionTranscriptUpdate } = await import("../../sessions/transcript-events.js");
-
-function identifiedClient(profileId: string): GatewayClient {
-  return {
-    connect: {
-      minProtocol: 1,
-      maxProtocol: 1,
-      client: { id: "openclaw-control-ui", version: "test", platform: "test", mode: "webchat" },
-      role: "operator",
-      scopes: ["operator.read", "operator.write"],
-    },
-    authenticatedUserProfile: {
-      profileId,
-      displayName: profileId,
-      hasAvatar: false,
-      updatedAt: 1,
-    },
-  };
-}
-
-function requestContext(config: OpenClawConfig): GatewayRequestContext {
-  return {
-    chatAbortControllers: new Map(),
-    getRuntimeConfig: () => config,
-    getSessionEventSubscriberConnIds: () => new Set(),
-    loadGatewayModelCatalog: async () => [],
-    logGateway: { debug: vi.fn() },
-  } as unknown as GatewayRequestContext;
-}
-
-async function listSessions(params: {
-  client: GatewayClient;
-  context: GatewayRequestContext;
-  request: SessionsListParams;
-}) {
-  const responses: Parameters<RespondFn>[] = [];
-  await sessionReadHandlers["sessions.list"]?.({
-    params: params.request,
-    client: params.client,
-    context: params.context,
-    respond: (...response: Parameters<RespondFn>) => responses.push(response),
-  } as never);
-  expect(responses).toHaveLength(1);
-  expect(responses[0]?.[0]).toBe(true);
-  return responses[0]?.[1] as {
-    count: number;
-    nextOffset: number | null;
-    sessions: GatewaySessionRow[];
-    totalCount: number;
-  };
-}
 
 async function seedSessions(): Promise<OpenClawConfig> {
   const config: OpenClawConfig = {

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -307,6 +307,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                 modelCatalog: modelCatalogByAgent,
                 opts: p,
                 ...(p.involvingMe === true && identityId ? { involvingActorId: identityId } : {}),
+                ...(p.ownerFirst === true && identityId ? { ownerFirstActorId: identityId } : {}),
               }),
             {
               config: cfg,
@@ -720,3 +721,5 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
     respond(true, { messages }, undefined);
   },
 };
+
+export const sessionsListHandler = sessionReadHandlers["sessions.list"]!;

--- a/src/gateway/server-methods/sessions-subscriptions.ts
+++ b/src/gateway/server-methods/sessions-subscriptions.ts
@@ -4,6 +4,7 @@ import {
   errorShape,
   validateSessionsMessagesSubscribeParams,
   validateSessionsMessagesUnsubscribeParams,
+  validateSessionsListParams,
   validateSessionsViewerPresenceSetParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
@@ -14,17 +15,34 @@ import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { resolveSessionStoreAgentId } from "../session-store-key.js";
 import { resolveSessionSubscriptionKey } from "../session-subscription-keys.js";
 import { resolveSessionStoreKey } from "../session-utils.js";
+import { sessionsListHandler } from "./sessions-read.js";
 import { requireSessionKey } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 export const sessionSubscriptionHandlers: GatewayRequestHandlers = {
-  "sessions.subscribe": ({ client, context, respond }) => {
+  "sessions.subscribe": async (options) => {
+    const { client, context, params, respond } = options;
+    if (!assertValidParams(params, validateSessionsListParams, "sessions.subscribe", respond)) {
+      return;
+    }
     const connId = client?.connId?.trim();
     if (connId) {
+      // Subscribe before projecting the snapshot so mutations during the read
+      // become live events; the UI queues one trailing refresh when needed.
       context.subscribeSessionEvents(connId);
     }
-    respond(true, { subscribed: Boolean(connId) }, undefined);
+    if (!connId || Object.keys(params).length === 0) {
+      respond(true, { subscribed: Boolean(connId) }, undefined);
+      return;
+    }
+    await sessionsListHandler({
+      ...options,
+      params,
+      respond: (ok, payload, error, meta) => {
+        respond(ok, ok ? { subscribed: true, list: payload } : undefined, error, meta);
+      },
+    });
   },
   "sessions.viewers.set": ({ params, client, context, respond }) => {
     if (

--- a/src/gateway/server-methods/sessions-viewers.test.ts
+++ b/src/gateway/server-methods/sessions-viewers.test.ts
@@ -1,6 +1,15 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import { SESSION_VIEWER_PRESENCE_MAX_KEYS } from "../../../packages/gateway-protocol/src/schema/sessions-viewer-presence.js";
+
+const sessionsListHandler = vi.hoisted(() =>
+  vi.fn(async ({ respond }: GatewayRequestHandlerOptions) => {
+    respond(true, { count: 1 }, undefined);
+  }),
+);
+
+vi.mock("./sessions-read.js", () => ({ sessionsListHandler }));
+
 import { sessionSubscriptionHandlers } from "./sessions-subscriptions.js";
 import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./types.js";
 
@@ -132,6 +141,38 @@ describe("sessions.viewers.set", () => {
       false,
       undefined,
       expect.objectContaining({ code: "INVALID_REQUEST" }),
+    );
+  });
+});
+
+describe("sessions.subscribe", () => {
+  it("registers events before projecting an atomic bootstrap roster", async () => {
+    const subscribeSessionEvents = vi.fn();
+    const context = { subscribeSessionEvents } as unknown as GatewayRequestContext;
+    const respond = vi.fn();
+    sessionsListHandler.mockClear();
+
+    await expectDefined(
+      sessionSubscriptionHandlers["sessions.subscribe"],
+      'sessionSubscriptionHandlers["sessions.subscribe"] test invariant',
+    )({
+      req: { id: "req-subscribe", method: "sessions.subscribe" } as never,
+      params: { limit: 1, ownerFirst: true },
+      respond,
+      context,
+      client: { connId: "control-ui-1" } as never,
+      isWebchatConnect: () => false,
+    } satisfies GatewayRequestHandlerOptions);
+
+    expect(subscribeSessionEvents).toHaveBeenCalledWith("control-ui-1");
+    expect(subscribeSessionEvents.mock.invocationCallOrder[0]).toBeLessThan(
+      sessionsListHandler.mock.invocationCallOrder[0]!,
+    );
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      { subscribed: true, list: { count: 1 } },
+      undefined,
+      undefined,
     );
   });
 });

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -83,6 +83,7 @@ type ListSessionsFromStoreParams = {
   lightweightListRows?: boolean;
   opts: SessionsListParams;
   involvingActorId?: string;
+  ownerFirstActorId?: string;
 };
 
 type SessionEntrySelection = {
@@ -180,7 +181,8 @@ function filterSessionEntries(params: {
   getRowContext?: SessionListRowContextProvider;
   entryFilter?: (key: string, entry: SessionEntry) => boolean;
   involvingActorId?: string;
-}): Pick<SessionEntrySelection, "ownerFacet" | "entries"> {
+  ownerFirstActorId?: string;
+}): Pick<SessionEntrySelection, "ownerFacet" | "entries"> & { ownerEntries: SessionEntryPair[] } {
   const { cfg, store, opts, now } = params;
   const includeGlobal = opts.includeGlobal === true;
   const includeUnknown = opts.includeUnknown === true;
@@ -196,8 +198,10 @@ function filterSessionEntries(params: {
   const creatorId = normalizeOptionalString(opts.creatorId);
   const ownerId = normalizeOptionalString(opts.ownerId);
   const involvingActorId = normalizeOptionalString(params.involvingActorId);
+  const ownerFirstActorId = normalizeOptionalString(params.ownerFirstActorId);
   const activeCutoff = activeMinutes === undefined ? undefined : now - activeMinutes * 60_000;
   const entries: SessionEntryPair[] = [];
+  const ownerEntries: SessionEntryPair[] = [];
   const ownerFacet = new Map<string, SessionOwnerFacetIdentity>();
   let configuredAgentIds = params.configuredAgentIds;
   let filterOwnerIdentityById: Map<string, SessionActorProfileIdentity | undefined> | undefined;
@@ -317,7 +321,7 @@ function filterSessionEntries(params: {
       if (effectiveOwner) {
         addSessionOwnerFacetIdentity(ownerFacet, effectiveOwner);
       }
-    } else if (ownerId || involvingActorId) {
+    } else if (ownerId || involvingActorId || ownerFirstActorId) {
       filterOwnerIdentityById ??= new Map();
       configuredAgentIds ??= new Set(listAgentIds(cfg));
       effectiveOwner = projectAssignableSessionOwner(
@@ -347,10 +351,13 @@ function filterSessionEntries(params: {
         continue;
       }
     }
+    if (effectiveOwner?.type === "human" && effectiveOwner.id === ownerFirstActorId) {
+      ownerEntries.push([key, entry]);
+    }
     entries.push([key, entry]);
   }
 
-  return { entries, ownerFacet: sortSessionOwnerFacet(ownerFacet) };
+  return { entries, ownerEntries, ownerFacet: sortSessionOwnerFacet(ownerFacet) };
 }
 
 function isPhantomAgentStoreListEntry(key: string, entry: SessionEntry | undefined): boolean {
@@ -373,15 +380,22 @@ function selectSessionEntries(params: {
   configuredAgentIds?: ReadonlySet<string>;
   entryFilter?: (key: string, entry: SessionEntry) => boolean;
   involvingActorId?: string;
+  ownerFirstActorId?: string;
 }): SessionEntrySelection {
-  const { ownerFacet, entries: filtered } = filterSessionEntries(params);
+  const { ownerFacet, ownerEntries, entries: filtered } = filterSessionEntries(params);
   const limit = resolveSessionsListLimit(params.opts, params.defaultLimit);
   const offset = resolveSessionsListOffset(params.opts);
   const windowLimit = resolveSessionsListWindowLimit(limit, offset);
   const sortedWindow = sortAndLimitSessionEntries(filtered, windowLimit, params.opts.sortBy);
-  const entries =
+  const sharedEntries =
     limit === undefined ? sortedWindow.slice(offset) : sortedWindow.slice(offset, offset + limit);
-  const nextOffset = offset + entries.length;
+  let entries = sharedEntries;
+  if (params.ownerFirstActorId && offset === 0) {
+    const owned = sortAndLimitSessionEntries(ownerEntries, limit, params.opts.sortBy);
+    const ownedKeys = new Set(owned.map(([key]) => key));
+    entries = [...owned, ...sharedEntries.filter(([key]) => !ownedKeys.has(key))];
+  }
+  const nextOffset = offset + sharedEntries.length;
   const hasMore = nextOffset < filtered.length;
   return {
     entries,
@@ -429,6 +443,7 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
     userProfileIdentityById,
     configuredAgentIds,
     involvingActorId: params.involvingActorId,
+    ownerFirstActorId: params.ownerFirstActorId,
   });
   const fullRowContext =
     rowContext ||
@@ -461,6 +476,10 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
     ...selection,
     includeDerivedTitles: opts.includeDerivedTitles === true,
     includeLastMessage: opts.includeLastMessage === true,
+    // This request replaces two independently enriched pages; retain their combined bound.
+    transcriptFieldRows: params.ownerFirstActorId
+      ? SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS * 2
+      : SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS,
     now,
     configuredAgentIds,
     rowContext: sharedRowContext,
@@ -523,7 +542,7 @@ export function listSessionsFromStore(params: ListSessionsFromStoreParams): Sess
   const { cfg, store, opts } = params;
   const list = prepareSessionList(params);
   const sessions = list.entries.map(([key, entry], index) => {
-    const includeTranscriptFields = index < SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS;
+    const includeTranscriptFields = index < list.transcriptFieldRows;
     const rowAgentId =
       !parseAgentSessionKey(key) && typeof opts.agentId === "string"
         ? normalizeAgentId(opts.agentId)
@@ -587,7 +606,7 @@ export async function listSessionsFromStoreAsync(
     const list = prepareSessionList(params);
     const sessions: GatewaySessionRow[] = [];
     const transcriptScopes = list.entries
-      .slice(0, SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS)
+      .slice(0, list.transcriptFieldRows)
       .flatMap(([key, entry]) => {
         if (!entry.sessionId || (!list.includeDerivedTitles && !list.includeLastMessage)) {
           return [];
@@ -610,7 +629,7 @@ export async function listSessionsFromStoreAsync(
     let transcriptFieldIndex = 0;
     for (let i = 0; i < list.entries.length; i++) {
       const [key, entry] = expectDefined(list.entries[i], "entries entry at i");
-      const includeTranscriptFields = i < SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS;
+      const includeTranscriptFields = i < list.transcriptFieldRows;
       const rowAgentId =
         !parseAgentSessionKey(key) && typeof opts.agentId === "string"
           ? normalizeAgentId(opts.agentId)

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -23,6 +23,7 @@ import {
   parseAgentSessionKey,
 } from "../routing/session-key.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { SESSIONS_LIST_OWNER_LIMIT } from "../shared/session-list-limits.js";
 import type { SessionOwnerFacetIdentity } from "../shared/session-types.js";
 import { type SessionEntryPair, sortAndLimitSessionEntries } from "./session-list-order.js";
 import {
@@ -88,6 +89,7 @@ type ListSessionsFromStoreParams = {
 
 type SessionEntrySelection = {
   entries: SessionEntryPair[];
+  ownerCount: number;
   ownerFacet: SessionOwnerFacetIdentity[];
   totalCount: number;
   limitApplied?: number;
@@ -390,8 +392,14 @@ function selectSessionEntries(params: {
   const sharedEntries =
     limit === undefined ? sortedWindow.slice(offset) : sortedWindow.slice(offset, offset + limit);
   let entries = sharedEntries;
+  let ownerCount = 0;
   if (params.ownerFirstActorId && offset === 0) {
-    const owned = sortAndLimitSessionEntries(ownerEntries, limit, params.opts.sortBy);
+    const owned = sortAndLimitSessionEntries(
+      ownerEntries,
+      Math.min(limit ?? SESSIONS_LIST_OWNER_LIMIT, SESSIONS_LIST_OWNER_LIMIT),
+      params.opts.sortBy,
+    );
+    ownerCount = owned.length;
     const ownedKeys = new Set(owned.map(([key]) => key));
     entries = [...owned, ...sharedEntries.filter(([key]) => !ownedKeys.has(key))];
   }
@@ -399,6 +407,7 @@ function selectSessionEntries(params: {
   const hasMore = nextOffset < filtered.length;
   return {
     entries,
+    ownerCount,
     ownerFacet,
     totalCount: filtered.length,
     limitApplied: limit,
@@ -476,10 +485,8 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
     ...selection,
     includeDerivedTitles: opts.includeDerivedTitles === true,
     includeLastMessage: opts.includeLastMessage === true,
-    // This request replaces two independently enriched pages; retain their combined bound.
-    transcriptFieldRows: params.ownerFirstActorId
-      ? SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS * 2
-      : SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS,
+    // The independent owner window must not consume the shared page's transcript budget.
+    transcriptFieldRows: SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS + selection.ownerCount,
     now,
     configuredAgentIds,
     rowContext: sharedRowContext,

--- a/src/gateway/session-utils-owners.test.ts
+++ b/src/gateway/session-utils-owners.test.ts
@@ -123,6 +123,35 @@ it("returns the complete deterministic owner facet independently of pagination",
   expect(filtered.owners).toEqual(result.owners);
 });
 
+it("prepends an owner window without advancing shared-page pagination", () => {
+  const store: Record<string, SessionEntry> = {
+    "agent:main:foreign-newest": {
+      createdActor: { type: "human", id: "profile-ada" },
+      sessionId: "session-foreign-newest",
+      updatedAt: 2,
+    },
+    "agent:main:owner-older": {
+      createdActor: { type: "human", id: "profile-bob" },
+      sessionId: "session-owner-older",
+      updatedAt: 1,
+    },
+  };
+
+  const result = listSessionsFromStore({
+    cfg: {} as OpenClawConfig,
+    storePath: "/tmp/openclaw-session-owner-first",
+    store,
+    opts: { archived: "all", limit: 1 },
+    ownerFirstActorId: "profile-bob",
+  });
+
+  expect(result.sessions.map((row) => row.key)).toEqual([
+    "agent:main:owner-older",
+    "agent:main:foreign-newest",
+  ]);
+  expect(result).toMatchObject({ count: 2, totalCount: 2, nextOffset: 1, hasMore: true });
+});
+
 it("projects only durable profiles and configured agents as effective owners", () => {
   const cases = [
     { createdActor: { type: "human" as const, id: "profile-ada" }, ownerId: "profile-ada" },

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -15,6 +15,7 @@ import type { SessionEntry } from "../config/sessions.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { ensureProfileForEmail } from "../state/user-profiles.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import * as usageFormat from "../utils/usage-format.js";
 import * as titleReader from "./session-transcript-title-reader.js";
@@ -245,7 +246,18 @@ describe("listSessionsFromStore resolver cache", () => {
     });
   });
 
-  test("batches transcript title hydration once instead of O(rows)", async () => {
+  test.each([
+    { name: "ordinary", count: 30, owned: 0, limit: 30, rows: 30, enriched: 30, sharedTail: 29 },
+    {
+      name: "retained owner-first",
+      count: 480,
+      owned: 240,
+      limit: 240,
+      rows: 300,
+      enriched: 160,
+      sharedTail: 99,
+    },
+  ])("batches $name transcript hydration without starving shared rows", async (scenario) => {
     await withStateDirEnv("openclaw-perf-title-batch-", async () => {
       resetPluginRuntimeStateForTest();
       setActivePluginRegistry(createEmptyPluginRegistry());
@@ -256,10 +268,17 @@ describe("listSessionsFromStore resolver cache", () => {
       setRuntimeConfigSnapshot(cfg);
       const storePath = "/tmp/sessions.json";
       const store: Record<string, SessionEntry> = {};
-      for (let index = 0; index < 30; index += 1) {
+      const ownerId = scenario.owned ? ensureProfileForEmail("owner@example.com").id : undefined;
+      for (let index = 0; index < scenario.count; index += 1) {
         const sessionId = `title-batch-${index}`;
         const sessionKey = `agent:main:${sessionId}`;
-        const entry = { sessionId, updatedAt: 1_000 - index } satisfies SessionEntry;
+        const entry: SessionEntry = {
+          sessionId,
+          updatedAt: 1_000 - index,
+          ...(ownerId && index >= scenario.count - scenario.owned
+            ? { createdActor: { type: "human", id: ownerId } }
+            : {}),
+        };
         store[sessionKey] = entry;
       }
 
@@ -277,20 +296,21 @@ describe("listSessionsFromStore resolver cache", () => {
           storePath,
           store,
           lightweightListRows: true,
-          opts: { includeDerivedTitles: true, includeLastMessage: true, limit: 30 },
+          ownerFirstActorId: ownerId,
+          opts: { includeDerivedTitles: true, includeLastMessage: true, limit: scenario.limit },
         });
 
-        expect(result.sessions).toHaveLength(30);
+        expect(result.sessions).toHaveLength(scenario.rows);
         expect(titleBatchSpy).toHaveBeenCalledOnce();
-        expect(titleBatchSpy.mock.calls[0]?.[0]).toHaveLength(30);
+        expect(titleBatchSpy.mock.calls[0]?.[0]).toHaveLength(scenario.enriched);
         const sessionsByKey = new Map(result.sessions.map((session) => [session.key, session]));
         expect(sessionsByKey.get("agent:main:title-batch-0")).toMatchObject({
           derivedTitle: "title 0",
           lastMessagePreview: "last 0",
         });
-        expect(sessionsByKey.get("agent:main:title-batch-29")).toMatchObject({
-          derivedTitle: "title 29",
-          lastMessagePreview: "last 29",
+        expect(sessionsByKey.get(`agent:main:title-batch-${scenario.sharedTail}`)).toMatchObject({
+          derivedTitle: `title ${scenario.sharedTail}`,
+          lastMessagePreview: `last ${scenario.sharedTail}`,
         });
 
         titleBatchSpy.mockClear();
@@ -299,7 +319,8 @@ describe("listSessionsFromStore resolver cache", () => {
           storePath,
           store,
           lightweightListRows: true,
-          opts: { includeDerivedTitles: false, includeLastMessage: false, limit: 30 },
+          ownerFirstActorId: ownerId,
+          opts: { includeDerivedTitles: false, includeLastMessage: false, limit: scenario.limit },
         });
         expect(titleBatchSpy).toHaveBeenCalledOnce();
         expect(titleBatchSpy).toHaveBeenCalledWith([]);

--- a/src/gateway/test-helpers.config-runtime.ts
+++ b/src/gateway/test-helpers.config-runtime.ts
@@ -13,6 +13,7 @@ import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { AgentBinding } from "../config/types.agents.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
+import { writeJsonAtomic } from "../infra/json-files.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
 import { buildTestConfigSnapshot } from "./test-helpers.config-snapshots.js";
 import { testConfigRoot, testIsNixMode, testState } from "./test-helpers.runtime-state.js";
@@ -217,9 +218,7 @@ export function createGatewayConfigModuleMock(actual: GatewayConfigModule): Gate
 
   const writeConfigFile = vi.fn(async (cfg: Record<string, unknown>) => {
     const configPath = resolveConfigPath();
-    await fs.mkdir(path.dirname(configPath), { recursive: true });
-    const raw = JSON.stringify(cfg, null, 2).trimEnd().concat("\n");
-    await fs.writeFile(configPath, raw, "utf-8");
+    await writeJsonAtomic(configPath, cfg, { durable: false, trailingNewline: true });
     actual.resetConfigRuntimeState();
     return {
       persistedHash: "test-config-hash",

--- a/src/gateway/test-helpers.server-env.test.ts
+++ b/src/gateway/test-helpers.server-env.test.ts
@@ -1,8 +1,15 @@
+import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import { createGatewayConfigModuleMock } from "./test-helpers.config-runtime.js";
 import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
-import { installGatewayTestHooks, withGatewayServer } from "./test-helpers.server.js";
+import { testState } from "./test-helpers.runtime-state.js";
+import {
+  installGatewayTestHooks,
+  withGatewayServer,
+  writeSessionStore,
+} from "./test-helpers.server.js";
 
 const envBeforeSuite = {
   PATH: process.env.PATH,
@@ -27,6 +34,46 @@ describe("Gateway test environment lifecycle", () => {
       OPENCLAW_PATH_BOOTSTRAPPED: process.env.OPENCLAW_PATH_BOOTSTRAPPED,
     }).toEqual(envBeforeSuite);
   });
+
+  it.each(["session store", "config mock"])(
+    "keeps config readable while the %s fixture publishes an update",
+    async (fixture) => {
+      const actual =
+        await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+      const { writeConfigFile } = createGatewayConfigModuleMock(actual);
+      await writeConfigFile({ session: { reset: { idleMinutes: 30 } } });
+      const configPath = process.env.OPENCLAW_CONFIG_PATH!;
+      const readIdleMinutes = () =>
+        actual.loadConfig({ pin: false, skipPluginValidation: true, skipShellEnvFallback: true })
+          .session?.reset?.idleMinutes;
+      expect(readIdleMinutes()).toBe(30);
+      const writeFile = fs.writeFile.bind(fs);
+      const writeSpy = vi.spyOn(fs, "writeFile").mockImplementation(async (file, data, options) => {
+        // Schedule the background reader after open: a direct path write has
+        // already truncated the live config; a staged descriptor has not.
+        const handle = file === configPath ? await fs.open(file, "w") : undefined;
+        try {
+          expect([30, 60]).toContain(readIdleMinutes());
+          await writeFile(handle ?? file, data, options);
+        } finally {
+          await handle?.close();
+        }
+      });
+
+      try {
+        if (fixture === "session store") {
+          testState.sessionStorePath = path.join(path.dirname(configPath), "sessions.json");
+          testState.sessionConfig = { reset: { idleMinutes: 60 } };
+          await writeSessionStore({ entries: {} });
+        } else {
+          await writeConfigFile({ session: { reset: { idleMinutes: 60 } } });
+        }
+        expect(readIdleMinutes()).toBe(60);
+      } finally {
+        writeSpy.mockRestore();
+      }
+    },
+  );
 
   it("restores startup-owned environment when a direct E2E server closes", async () => {
     const stateDir = process.env.OPENCLAW_STATE_DIR;

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -30,6 +30,7 @@ import {
 import { approveDevicePairing } from "../infra/device-pairing-approval.js";
 import { getPairedDevice, requestDevicePairing } from "../infra/device-pairing.js";
 import { resetGatewaySuspendCoordinatorForLifecycleRestart } from "../infra/gateway-suspend-coordinator.js";
+import { writeJsonAtomic } from "../infra/json-files.js";
 import {
   resetGatewayRestartStateForInProcessRestart,
   setGatewaySigusr1RestartPolicy,
@@ -201,8 +202,8 @@ async function persistTestSessionConfig(): Promise<void> {
     } else {
       delete config.session;
     }
-    await fs.mkdir(path.dirname(configPath), { recursive: true });
-    await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+    // Suite servers may still read config from pending session-change callbacks.
+    await writeJsonAtomic(configPath, config, { durable: false, trailingNewline: true });
   }
   resetConfigRuntimeState();
   lastSyncedSessionStorePath = testState.sessionStorePath;

--- a/src/shared/session-list-limits.ts
+++ b/src/shared/session-list-limits.ts
@@ -1,0 +1,2 @@
+/** Owner-first rosters retain this window independently of shared-page pagination. */
+export const SESSIONS_LIST_OWNER_LIMIT = 60;

--- a/ui/src/e2e/session-owner-first.e2e.test.ts
+++ b/ui/src/e2e/session-owner-first.e2e.test.ts
@@ -52,53 +52,32 @@ async function captureSidebar(page: Page, fileName: string) {
 }
 
 suite.define(() => {
-  it("publishes the signed-in owner's sessions before the shared roster", async () => {
+  it("hydrates the owner-first roster with the event subscription", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const page = await context.newPage();
     const sharedRoster = sessionsList();
-    const ownerRoster = {
-      ...sharedRoster,
-      count: 1,
-      owners: sharedRoster.owners.slice(0, 1),
-      sessions: sharedRoster.sessions.slice(0, 1),
-    };
     const gateway = await installMockGateway(page, {
-      deferredMethods: ["sessions.list", "sessions.list"],
+      deferredMethods: ["sessions.subscribe"],
       presenceUsers: [{ self: true, id: "profile-ada", name: "Ada" }],
       sessionKey: "agent:main:ada",
-      methodResponses: {
-        "sessions.list": {
-          cases: [
-            { match: { ownerId: "profile-ada" }, response: ownerRoster },
-            { response: sharedRoster },
-          ],
-        },
-      },
+      methodResponses: { "sessions.subscribe": { subscribed: true, list: sharedRoster } },
     });
 
     try {
       await page.goto(`${suite.server?.baseUrl ?? ""}chat`);
-      await expect
-        .poll(async () => (await gateway.getRequests("sessions.list")).length)
-        .toBeGreaterThanOrEqual(2);
-      expect(
-        (await gateway.getRequests("sessions.list")).some(
-          (request) =>
-            (request.params as { ownerId?: unknown } | undefined)?.ownerId === "profile-ada",
-        ),
-      ).toBe(true);
-      await gateway.resolveDeferred("sessions.list", ownerRoster);
-
+      const subscribe = await gateway.waitForRequest("sessions.subscribe");
+      expect(subscribe.params).toEqual(expect.objectContaining({ ownerFirst: true, limit: 60 }));
+      expect(await gateway.getRequests("sessions.list")).toHaveLength(0);
       const adaRow = page.locator('[data-session-key="agent:main:ada"]');
       const bobRow = page.locator('[data-session-key="agent:main:bob"]');
-      await adaRow.waitFor();
-      await expect.poll(() => bobRow.count()).toBe(0);
-      await captureSidebar(page, "owner-first-roster.png");
-
-      await gateway.resolveDeferred("sessions.list", sharedRoster);
-      await bobRow.waitFor();
+      // The selected session has an optimistic placeholder before roster hydration.
       await expect.poll(() => adaRow.count()).toBe(1);
-      await captureSidebar(page, "owner-first-shared-roster.png");
+      await expect.poll(() => bobRow.count()).toBe(0);
+
+      await gateway.resolveDeferred("sessions.subscribe", { subscribed: true, list: sharedRoster });
+      await adaRow.waitFor();
+      await bobRow.waitFor();
+      await captureSidebar(page, "owner-first-bootstrap.png");
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-owner-warm-refresh.e2e.test.ts
+++ b/ui/src/e2e/session-owner-warm-refresh.e2e.test.ts
@@ -49,7 +49,7 @@ async function captureSidebar(page: Page, fileName: string) {
 }
 
 suite.define(() => {
-  it("keeps foreign-owned rows visible while a warm refresh's shared phase is in flight", async () => {
+  it("keeps foreign-owned rows visible while one warm owner-first refresh is in flight", async () => {
     const context = await suite.browser.newContext({
       viewport: { height: 800, width: 1200 },
       ...(captureProof
@@ -60,17 +60,12 @@ suite.define(() => {
     const adaRow = sessionRow("profile-ada", "agent:main:ada", "Ada research", 2);
     const bobRow = sessionRow("profile-bob", "agent:main:bob", "Bob operations", 1);
     const sharedRoster = rosterOf([adaRow, bobRow]);
-    const ownerRoster = rosterOf([adaRow]);
     const gateway = await installMockGateway(page, {
       presenceUsers: [{ self: true, id: "profile-ada", name: "Ada" }],
       sessionKey: "agent:main:ada",
       methodResponses: {
-        "sessions.list": {
-          cases: [
-            { match: { ownerId: "profile-ada" }, response: ownerRoster },
-            { response: sharedRoster },
-          ],
-        },
+        "sessions.subscribe": { subscribed: true, list: sharedRoster },
+        "sessions.list": sharedRoster,
       },
     });
 
@@ -82,10 +77,8 @@ suite.define(() => {
       await bob.waitFor();
       await captureSidebar(page, "warm-before-event.png");
 
-      // Hold the warm refresh open at its vulnerable point: release the
-      // owner-scoped response while the shared response remains deferred.
+      // Hold the single warm roster projection open and observe the existing DOM.
       const before = (await gateway.getRequests("sessions.list")).length;
-      await gateway.deferNext("sessions.list", { ownerId: "profile-ada" });
       await gateway.deferNext("sessions.list");
       await gateway.emitGatewayEvent("sessions.changed", {
         sessionKey: adaRow.key,
@@ -94,8 +87,8 @@ suite.define(() => {
         reason: "create",
         updatedAt: 3,
       });
-      await gateway.waitForRequest("sessions.list", { after: before + 1 });
-      const ownerProbe = await page.evaluateHandle(() => {
+      await gateway.waitForRequest("sessions.list", { after: before });
+      const refreshProbe = await page.evaluateHandle(() => {
         const app = document.querySelector<
           HTMLElement & { runtime?: { context: ApplicationContext } }
         >("openclaw-app");
@@ -125,9 +118,7 @@ suite.define(() => {
           wasRemoved: () => removed,
         };
       });
-      await gateway.resolveDeferred("sessions.list", ownerRoster);
-
-      const ownerPhase = await ownerProbe.evaluate(async (probe) => {
+      const inFlight = await refreshProbe.evaluate(async (probe) => {
         await new Promise<void>((resolve) => {
           requestAnimationFrame(() => resolve());
         });
@@ -140,7 +131,7 @@ suite.define(() => {
           rowRemoved: probe.wasRemoved(),
         };
       });
-      expect(ownerPhase).toEqual({
+      expect(inFlight).toEqual({
         connected: true,
         loading: true,
         revisionAdvanced: false,
@@ -148,19 +139,17 @@ suite.define(() => {
         rowRemoved: false,
       });
       expect(
-        (await gateway.getRequests("sessions.list"))
-          .slice(before)
-          .map((request) => (request.params as { ownerId?: string }).ownerId ?? null),
-      ).toEqual(["profile-ada", null]);
+        (await gateway.getRequests("sessions.list")).slice(before).map((request) => request.params),
+      ).toEqual([expect.objectContaining({ ownerFirst: true, limit: 60 })]);
 
       for (let sample = 0; sample < 6; sample += 1) {
         expect(await bob.count()).toBe(1);
         expect(await ada.count()).toBe(1);
       }
-      await captureSidebar(page, "warm-shared-deferred.png");
+      await captureSidebar(page, "warm-refresh-deferred.png");
 
       await gateway.resolveDeferred("sessions.list", sharedRoster);
-      const sharedPhase = await ownerProbe.evaluate(async (probe) => {
+      const completed = await refreshProbe.evaluate(async (probe) => {
         if (probe.sessions.canonicalListRevision === probe.revision) {
           await new Promise<void>((resolve) => {
             const unsubscribe = probe.sessions.subscribe(() => {
@@ -185,7 +174,7 @@ suite.define(() => {
           rowRemoved: probe.wasRemoved(),
         };
       });
-      expect(sharedPhase).toEqual({
+      expect(completed).toEqual({
         connected: true,
         loading: false,
         revisionAdvanced: true,
@@ -194,8 +183,8 @@ suite.define(() => {
       });
       await expect.poll(() => bob.count()).toBe(1);
       expect(await ada.count()).toBe(1);
-      await captureSidebar(page, "warm-after-merge.png");
-      await ownerProbe.dispose();
+      await captureSidebar(page, "warm-after-refresh.png");
+      await refreshProbe.dispose();
     } finally {
       await context.close();
     }

--- a/ui/src/lib/sessions/connection-hydration.test.ts
+++ b/ui/src/lib/sessions/connection-hydration.test.ts
@@ -114,10 +114,10 @@ const targetedSessionReconciliationCases = [
 ];
 
 describe("session connection hydration", () => {
-  it("publishes the signed-in owner's roster before loading the shared roster", async () => {
-    const ownerResult: SessionsListResult = {
+  it("subscribes and hydrates the owner-first roster in one bootstrap request", async () => {
+    const roster: SessionsListResult = {
       ...emptySessionsResult(),
-      count: 2,
+      count: 3,
       sessions: [
         {
           key: "agent:main:mine-new",
@@ -131,13 +131,6 @@ describe("session connection hydration", () => {
           updatedAt: 1,
           createdActor: { type: "human", id: "operator" },
         },
-      ],
-    };
-    const sharedResult: SessionsListResult = {
-      ...emptySessionsResult(),
-      count: 2,
-      sessions: [
-        ownerResult.sessions[0]!,
         {
           key: "agent:main:theirs",
           kind: "direct",
@@ -146,18 +139,14 @@ describe("session connection hydration", () => {
         },
       ],
     };
-    const ownerList = createDeferred<SessionsListResult>();
-    const sharedList = createDeferred<SessionsListResult>();
+    const bootstrap = createDeferred<{ subscribed: true; list: SessionsListResult }>();
     const queuedList = createDeferred<SessionsListResult>();
     const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       if (method === "sessions.subscribe") {
-        return { subscribed: true };
+        return await bootstrap.promise;
       }
       if (method === "sessions.list") {
-        if (params?.ownerId === "operator") {
-          return await ownerList.promise;
-        }
-        return params?.search === "queued" ? await queuedList.promise : await sharedList.promise;
+        return params?.search === "queued" ? await queuedList.promise : emptySessionsResult();
       }
       throw new Error(`Unexpected request: ${method}`);
     });
@@ -187,25 +176,20 @@ describe("session connection hydration", () => {
 
     await waitForFast(() =>
       expect(request).toHaveBeenCalledWith(
-        "sessions.list",
-        expect.objectContaining({ ownerId: "operator", limit: 60 }),
+        "sessions.subscribe",
+        expect.objectContaining({
+          agentId: "main",
+          ownerFirst: true,
+          limit: 60,
+        }),
+        { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
       ),
     );
-    await waitForFast(() =>
-      expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(2),
-    );
+    expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(0);
     expect(sessions.state.result).toBeNull();
-    expect(request.mock.calls.at(-1)?.[1]).toEqual(
-      expect.objectContaining({ agentId: "main", limit: 60 }),
-    );
-    expect(request.mock.calls.at(-1)?.[1]).not.toHaveProperty("ownerId");
     const queuedRefresh = sessions.refresh({ agentId: "other", search: "queued", force: true });
 
-    ownerList.resolve(ownerResult);
-    await waitForFast(() => expect(sessions.state.result).toBe(ownerResult));
-    expect(sessions.state.loading).toBe(false);
-
-    sharedList.resolve(sharedResult);
+    bootstrap.resolve({ subscribed: true, list: roster });
     await waitForFast(() =>
       expect(sessions.state.result?.sessions.map((row) => row.key)).toEqual([
         "agent:main:mine-new",
@@ -214,7 +198,7 @@ describe("session connection hydration", () => {
       ]),
     );
     await waitForFast(() =>
-      expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(3),
+      expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(1),
     );
     expect(request.mock.calls.at(-1)?.[1]).toEqual(
       expect.objectContaining({ agentId: "other", search: "queued" }),
@@ -332,16 +316,15 @@ describe("session connection hydration", () => {
     snapshot = { ...snapshot, selfUser: { id: "operator", name: "Operator" } };
     gatewayListener?.(snapshot);
     resolveList(result);
-    await waitForFast(() => expect(listCalls).toBe(3));
+    await waitForFast(() => expect(listCalls).toBe(2));
 
     expect(
       request.mock.calls
         .filter(([method]) => method === "sessions.list")
         .map(([, params]) => params),
     ).toEqual([
-      expect.not.objectContaining({ ownerId: expect.anything() }),
-      expect.objectContaining({ ownerId: "operator", limit: 60 }),
-      expect.not.objectContaining({ ownerId: expect.anything() }),
+      expect.not.objectContaining({ ownerFirst: expect.anything() }),
+      expect.objectContaining({ ownerFirst: true, limit: 60 }),
     ]);
     expect(sessions.state.result?.sessions).toEqual([]);
     expect(sessions.state.agentId).toBe("main");

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -133,19 +133,6 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   const decorateRows = (result: SessionsListResult | null): SessionsListResult | null =>
     mutations.applyConfirmedArchives(mutations.applyPendingPins(swarmActivity.decorate(result)));
 
-  const roster = createSessionRosterRefresh({
-    connection,
-    snapshot: () => gateway.snapshot,
-    readState: () => state,
-    publish,
-    observerError: () => sessionEventSubscriptionError,
-    decorate: decorateRows,
-    onCanonicalList(result) {
-      mutations.settlePrepared(result);
-      canonicalListRevision += 1;
-    },
-  });
-
   const sessionEventSubscription = createSessionEventSubscriptionOwner({
     isCurrent: (scope) => connection.isCurrent(scope),
     retryDelayMs: sessionRetryDelayMs,
@@ -165,6 +152,20 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         // Observer outages do not replay events; one canonical list closes the gap.
         void roster.refresh({ ...roster.lastOptions(), backgroundHydrate: true, force: true });
       }
+    },
+  });
+
+  const roster = createSessionRosterRefresh({
+    connection,
+    snapshot: () => gateway.snapshot,
+    readState: () => state,
+    publish,
+    observerError: () => sessionEventSubscriptionError,
+    bootstrap: (scope, list) => sessionEventSubscription.ensure(scope, list),
+    decorate: decorateRows,
+    onCanonicalList(result) {
+      mutations.settlePrepared(result);
+      canonicalListRevision += 1;
     },
   });
 
@@ -384,13 +385,12 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       hydratedClient = scope.client;
       hydratedSelfUserId = selfUserId;
       void (async () => {
-        await sessionEventSubscription.ensure(scope);
         if (connection.isCurrent(scope)) {
           const sessionKey = gateway.snapshot.sessionKey?.trim();
           const agentScope = sessionKey
             ? scopedAgentListParamsForSession(gateway.snapshot, sessionKey)
             : { agentId: resolveUiSelectedGlobalAgentId(gateway.snapshot) };
-          await roster.refresh({
+          await roster.bootstrap({
             ...roster.lastOptions(), // Keep visible roster filters through reconnect hydration.
             ...agentScope,
             includeDerivedTitles: true,

--- a/ui/src/lib/sessions/owner-first-roster.test.ts
+++ b/ui/src/lib/sessions/owner-first-roster.test.ts
@@ -35,15 +35,21 @@ describe("owner-first session roster plan", () => {
       })),
     ];
     const request = vi.fn(
-      async (method: string, params?: { limit?: number; offset?: number; ownerId?: string }) => {
+      async (
+        method: string,
+        params?: { limit?: number; offset?: number; ownerFirst?: boolean },
+      ) => {
         if (method !== "sessions.list") {
           throw new Error(`Unexpected request: ${method}`);
         }
-        if (params?.ownerId === ownerId) {
-          return sessionsResult([ownerHead, ownerTail], 1);
-        }
         const offset = params?.offset ?? 0;
-        return sessionsResult(sharedRows.slice(offset, offset + (params?.limit ?? 50)), 2);
+        const shared = sharedRows.slice(offset, offset + (params?.limit ?? 50));
+        return sessionsResult(
+          params?.ownerFirst
+            ? [ownerHead, ownerTail, ...shared.filter((row) => row !== ownerHead)]
+            : shared,
+          2,
+        );
       },
     );
     const { sessions, emitEvent } = createSessionCapabilityHarness(
@@ -59,13 +65,11 @@ describe("owner-first session roster plan", () => {
       emitEvent(sessionChangedEvent(sharedRows[1]!.key));
       await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
 
-      expect(request.mock.calls).toHaveLength(5);
+      expect(request.mock.calls).toHaveLength(3);
       expect(request.mock.calls.map(([, params]) => params)).toEqual([
-        expect.objectContaining({ ownerId, limit: 60 }),
-        expect.objectContaining({ limit: 60 }),
+        expect.objectContaining({ ownerFirst: true, limit: 60 }),
         expect.objectContaining({ limit: 60, offset: 60 }),
-        expect.objectContaining({ ownerId, limit: 60 }),
-        expect.objectContaining({ limit: 120 }),
+        expect.objectContaining({ ownerFirst: true, limit: 120 }),
       ]);
       expect(sessions.state.result?.sessions).toHaveLength(121);
       expect(sessions.state.result?.sessions.map((row) => row.key)).toContain(ownerTail.key);
@@ -90,13 +94,11 @@ describe("owner-first session roster plan", () => {
       updatedAt: 1,
       createdActor: { type: "human" as const, id: "profile-bob" },
     };
-    const request = vi.fn(async (method: string, params?: { ownerId?: string }) => {
+    const request = vi.fn(async (method: string) => {
       if (method !== "sessions.list") {
         throw new Error(`Unexpected request: ${method}`);
       }
-      return params?.ownerId === ownerId
-        ? sessionsResult([ownRow], 1)
-        : sessionsResult([ownRow, foreignRow], 2);
+      return sessionsResult([ownRow, foreignRow], 2);
     });
     const { sessions, emitEvent } = createSessionCapabilityHarness(
       request as unknown as GatewayBrowserClient["request"],
@@ -117,8 +119,7 @@ describe("owner-first session roster plan", () => {
       await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
       stop();
 
-      // Cold start fired owner + shared; the warm event refresh fired both again.
-      expect(request.mock.calls).toHaveLength(4);
+      expect(request.mock.calls).toHaveLength(2);
       expect(publishedKeySets.length).toBeGreaterThan(0);
       for (const keys of publishedKeySets) {
         expect(keys).toContain(foreignRow.key);
@@ -129,7 +130,7 @@ describe("owner-first session roster plan", () => {
     }
   });
 
-  it("keeps the previous roster when the shared phase of a warm refresh fails", async () => {
+  it("keeps the previous roster when a warm owner-first refresh fails", async () => {
     vi.useFakeTimers();
     const ownerId = "profile-ada";
     const ownRow = {
@@ -144,16 +145,13 @@ describe("owner-first session roster plan", () => {
       updatedAt: 1,
       createdActor: { type: "human" as const, id: "profile-bob" },
     };
-    let failShared = false;
-    const request = vi.fn(async (method: string, params?: { ownerId?: string }) => {
+    let failRefresh = false;
+    const request = vi.fn(async (method: string) => {
       if (method !== "sessions.list") {
         throw new Error(`Unexpected request: ${method}`);
       }
-      if (params?.ownerId === ownerId) {
-        return sessionsResult([ownRow], 1);
-      }
-      if (failShared) {
-        throw new Error("shared roster unavailable");
+      if (failRefresh) {
+        throw new Error("session roster unavailable");
       }
       return sessionsResult([ownRow, foreignRow], 2);
     });
@@ -166,7 +164,7 @@ describe("owner-first session roster plan", () => {
       await sessions.refresh({ agentId: "main", limit: 60, force: true });
       expect(sessions.state.result?.sessions).toHaveLength(2);
 
-      failShared = true;
+      failRefresh = true;
       emitEvent(sessionChangedEvent(ownRow.key));
       await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
 

--- a/ui/src/lib/sessions/session-capability.ts
+++ b/ui/src/lib/sessions/session-capability.ts
@@ -65,6 +65,7 @@ export type SessionListOptions = {
   activeMinutes?: number;
   search?: string;
   ownerId?: string;
+  ownerFirst?: boolean;
   involvingMe?: boolean;
   offset?: number;
   limit?: number;

--- a/ui/src/lib/sessions/session-event-subscription.ts
+++ b/ui/src/lib/sessions/session-event-subscription.ts
@@ -3,6 +3,7 @@ import {
   GatewayProtocolRequestTimeoutError,
 } from "@openclaw/gateway-client/browser";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionsListResult } from "../../api/types.ts";
 import { formatUiError } from "../format-error.ts";
 
 type SessionEventSubscriptionScope = {
@@ -11,7 +12,10 @@ type SessionEventSubscriptionScope = {
 };
 
 type SessionEventSubscriptionOwner = {
-  ensure: (scope: SessionEventSubscriptionScope) => Promise<void>;
+  ensure: (
+    scope: SessionEventSubscriptionScope,
+    list?: Readonly<Record<string, unknown>>,
+  ) => Promise<SessionsListResult | null>;
   reset: () => void;
   dispose: () => void;
 };
@@ -24,7 +28,7 @@ export function createSessionEventSubscriptionOwner(params: {
 }): SessionEventSubscriptionOwner {
   let generation = 0;
   let confirmed: SessionEventSubscriptionScope | null = null;
-  let pending: { generation: number; promise: Promise<void> } | null = null;
+  let pending: { generation: number; promise: Promise<SessionsListResult | null> } | null = null;
   let retryTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
 
   const clearRetry = () => {
@@ -37,9 +41,12 @@ export function createSessionEventSubscriptionOwner(params: {
   const isCurrent = (scope: SessionEventSubscriptionScope, expectedGeneration: number): boolean =>
     generation === expectedGeneration && params.isCurrent(scope);
 
-  const ensure = (scope: SessionEventSubscriptionScope): Promise<void> => {
+  const ensure = (
+    scope: SessionEventSubscriptionScope,
+    list?: Readonly<Record<string, unknown>>,
+  ): Promise<SessionsListResult | null> => {
     if (confirmed?.client === scope.client && confirmed.epoch === scope.epoch) {
-      return Promise.resolve();
+      return Promise.resolve(null);
     }
     if (pending?.generation === generation) {
       return pending.promise;
@@ -48,13 +55,12 @@ export function createSessionEventSubscriptionOwner(params: {
     const expectedGeneration = generation;
     const request = (async () => {
       try {
-        const response = await scope.client.request<{ subscribed?: boolean }>(
-          "sessions.subscribe",
-          {},
-          { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
-        );
+        const response = await scope.client.request<{
+          subscribed?: boolean;
+          list?: SessionsListResult;
+        }>("sessions.subscribe", list ?? {}, { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS });
         if (!isCurrent(scope, expectedGeneration)) {
-          return;
+          return null;
         }
         if (response?.subscribed !== true) {
           throw new GatewayRequestError({
@@ -65,9 +71,10 @@ export function createSessionEventSubscriptionOwner(params: {
         }
         confirmed = scope;
         params.onError(scope, null);
+        return response.list ?? null;
       } catch (error) {
         if (!isCurrent(scope, expectedGeneration)) {
-          return;
+          return null;
         }
         // A connected transport can outlive an application acknowledgement.
         // Only this idempotent observer turns its typed deadline into a retry.
@@ -82,7 +89,7 @@ export function createSessionEventSubscriptionOwner(params: {
         params.onError(scope, formatUiError(failure));
         const delayMs = params.retryDelayMs(failure);
         if (delayMs === null || !isCurrent(scope, expectedGeneration)) {
-          return;
+          return null;
         }
         // A retired connection must never revive an observer on its replacement.
         retryTimer = globalThis.setTimeout(() => {
@@ -91,6 +98,7 @@ export function createSessionEventSubscriptionOwner(params: {
             void ensure(scope);
           }
         }, delayMs);
+        return null;
       }
     })().finally(() => {
       if (pending?.promise === request) {

--- a/ui/src/lib/sessions/session-requests.ts
+++ b/ui/src/lib/sessions/session-requests.ts
@@ -99,6 +99,9 @@ export function buildSessionListParams(options: SessionListOptions = {}): Record
   const spawnedBy = options.spawnedBy?.trim();
   const search = options.search?.trim();
   const ownerId = options.ownerId?.trim();
+  if (options.ownerFirst === true) {
+    params.ownerFirst = true;
+  }
   if (options.involvingMe === true) {
     params.involvingMe = true;
   }

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -4,6 +4,7 @@ import { createSessionEventRefreshCoordinator } from "./event-refresh-coordinato
 import { appendSessionResults, reconcileRosterPresentationMetadata } from "./reconcile.ts";
 import type {
   SessionConnectionOwner,
+  SessionConnectionScope,
   SessionGateway,
   SessionListOptions,
   SessionListScope,
@@ -30,6 +31,10 @@ type SessionRosterRefreshHost = {
   readState: () => SessionState;
   publish: (state: SessionState, errorSource?: "session-observer" | "operation") => void;
   observerError: () => string | null;
+  bootstrap: (
+    scope: SessionConnectionScope,
+    list: Readonly<Record<string, unknown>>,
+  ) => Promise<SessionsListResult | null>;
   decorate: (result: SessionsListResult | null) => SessionsListResult | null;
   onCanonicalList: (result: SessionsListResult | null) => void;
 };
@@ -38,10 +43,6 @@ type ManagedSessionListRefresh = {
   append: boolean;
   offset?: number;
   invalidated?: true;
-};
-
-type SessionRosterLoadOptions = SessionRefreshOptions & {
-  provisional?: boolean;
 };
 
 const OWNER_FIRST_SESSION_LIST_LIMIT = 60;
@@ -280,37 +281,28 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   };
 
   const load = async (
-    options: SessionRosterLoadOptions,
-    ownerFirst?: Promise<SessionsListResult | null>,
+    options: SessionRefreshOptions,
+    bootstrap = false,
   ): Promise<SessionsListResult | null> => {
     const scope = host.connection.capture();
     if (!scope) {
       return null;
     }
-    const {
-      append = false,
-      force: _force,
-      backgroundHydrate = false,
-      provisional = false,
-      ...requestOptions
-    } = options;
+    const { append = false, force: _force, backgroundHydrate = false, ...requestOptions } = options;
     // Every canonical roster replaces visible session names, so omitted title
     // enrichment must inherit the UI default instead of publishing fallback ids.
     requestOptions.includeDerivedTitles ??= true;
     const durableListOptions: SessionListOptions = { ...requestOptions };
     // Pagination is request-local; replacements retain filters but restart at page one.
     delete durableListOptions.offset;
-    if (!backgroundHydrate && !provisional) {
+    if (!backgroundHydrate) {
       lastListOptions = durableListOptions;
       listOptionsSource = "foreground";
-    } else if (!provisional && listOptionsSource === "none") {
+    } else if (listOptionsSource === "none") {
       lastListOptions = durableListOptions;
       listOptionsSource = "seeded";
     }
-    // A provisional owner window may only paint an empty sidebar faster; once a
-    // roster is on screen it stays silent so foreign-owned rows never blink out.
-    const provisionalSilent = provisional && Boolean(host.readState().result);
-    if (!backgroundHydrate && !provisionalSilent) {
+    if (!backgroundHydrate) {
       const error = host.observerError();
       host.publish(
         { ...host.readState(), loading: true, error, deletedSessions: [] },
@@ -318,22 +310,23 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       );
     }
     try {
-      const request = requestSessionList(scope.client, requestOptions);
-      const ownerRows = ownerFirst ? await ownerFirst.catch(() => null) : null;
-      const result = await request;
+      const listParams = buildSessionListParams(requestOptions);
+      let result = bootstrap ? await host.bootstrap(scope, listParams) : null;
+      if (bootstrap && !host.connection.isCurrent(scope)) {
+        return null;
+      }
+      result ??= bootstrap
+        ? await requestSessionListParams(scope.client, listParams)
+        : await requestSessionList(scope.client, requestOptions);
       if (!host.connection.isCurrent(scope)) {
         return null;
       }
       const currentState = host.readState();
-      if (provisional && currentState.result) {
-        return result;
-      }
-      const merged = result && ownerRows ? appendSessionResults(ownerRows, result) : result;
       const mergeWithCurrent = append && typeof requestOptions.offset === "number";
       let nextResult =
-        merged && mergeWithCurrent && currentState.result
-          ? appendSessionResults(currentState.result, merged)
-          : reconcileRosterPresentationMetadata(merged, currentState.result);
+        result && mergeWithCurrent && currentState.result
+          ? appendSessionResults(currentState.result, result)
+          : reconcileRosterPresentationMetadata(result, currentState.result);
       if (append && nextResult && !backgroundHydrate) {
         lastListOptions = retainSessionPaginationWindow(
           durableListOptions,
@@ -352,9 +345,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
         );
       }
       nextResult = host.decorate(nextResult);
-      if (!provisional) {
-        host.onCanonicalList(nextResult);
-      }
+      host.onCanonicalList(nextResult);
       const state = host.readState();
       const error = host.observerError();
       host.publish(
@@ -373,7 +364,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       );
       return result;
     } catch (error) {
-      if (host.connection.isCurrent(scope) && !(provisional && host.readState().result)) {
+      if (host.connection.isCurrent(scope)) {
         const state = host.readState();
         host.publish(
           {
@@ -414,45 +405,37 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     return { ...lastListOptions, force: true };
   };
 
-  const refreshPlan = (options: SessionRefreshOptions) => {
-    const ownerId = host.snapshot().selfUser?.id.trim();
-    if (!ownerId || options.append === true || !isPrimarySessionListQuery(options)) {
-      return { initial: options, shared: undefined };
+  const prepareRefreshOptions = (options: SessionRefreshOptions): SessionRefreshOptions => {
+    if (
+      !host.snapshot().selfUser?.id.trim() ||
+      options.append === true ||
+      !isPrimarySessionListQuery(options)
+    ) {
+      return options;
     }
-    const sharedLimit = Math.max(
+    const limit = Math.max(
       OWNER_FIRST_SESSION_LIST_LIMIT,
       typeof options.limit === "number" && options.limit > 0
         ? Math.floor(options.limit)
         : DEFAULT_SESSION_LIST_QUERY.limit,
     );
-    // Keep owner-first and shared loads atomic in the existing refresh queue.
-    // Only the shared phase advances canonical membership and durable options;
-    // it merges the owner window from the initial load's returned rows, so the
-    // provisional phase never has to publish to be part of the final roster.
     return {
-      initial: {
-        ...options,
-        ownerId,
-        limit: OWNER_FIRST_SESSION_LIST_LIMIT,
-        provisional: true,
-      },
-      shared: {
-        ...options,
-        limit: sharedLimit,
-      },
+      ...options,
+      ownerFirst: true,
+      limit,
     };
   };
 
-  const drainRefreshQueue = async (options: SessionRefreshOptions) => {
+  const drainRefreshQueue = async (options: SessionRefreshOptions, bootstrap: boolean) => {
     const scope = host.connection.capture();
     if (!scope) {
       return;
     }
+    let bootstrapPending = bootstrap;
     let next: SessionRefreshOptions | null = options;
     while (next) {
-      const { initial, shared } = refreshPlan(next);
-      const initialLoad = load(initial);
-      await (shared ? load(shared, initialLoad) : initialLoad);
+      await load(prepareRefreshOptions(next), bootstrapPending);
+      bootstrapPending = false;
       if (!host.connection.isCurrent(scope)) {
         return;
       }
@@ -460,8 +443,8 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     }
   };
 
-  const startRefresh = (options: SessionRefreshOptions) => {
-    const request = drainRefreshQueue(options).finally(() => {
+  const startRefresh = (options: SessionRefreshOptions, bootstrap = false) => {
+    const request = drainRefreshQueue(options, bootstrap).finally(() => {
       if (inFlight === request) {
         inFlight = null;
       }
@@ -470,7 +453,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     return request;
   };
 
-  const refresh = (options: SessionRefreshOptions = {}): Promise<void> => {
+  const refreshInternal = (options: SessionRefreshOptions, bootstrap: boolean): Promise<void> => {
     if (!host.connection.capture()) {
       return Promise.resolve();
     }
@@ -487,8 +470,11 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     if (options.append !== true) {
       absorbPendingEventRefresh();
     }
-    return startRefresh(options);
+    return startRefresh(options, bootstrap);
   };
+
+  const refresh = (options: SessionRefreshOptions = {}): Promise<void> =>
+    refreshInternal(options, false);
 
   const refreshFromEvent = () => {
     if (!host.connection.capture()) {
@@ -597,6 +583,9 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       );
     },
     refresh,
+    bootstrap(options: SessionRefreshOptions) {
+      return refreshInternal(options, true);
+    },
     refreshReplacement,
     /** The row as currently published. The archived/all sidebars render their
      * own snapshot, so a displayed row can be absent from the primary state.

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -1,3 +1,4 @@
+import { SESSIONS_LIST_OWNER_LIMIT } from "../../../../src/shared/session-list-limits.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import { formatUiError } from "../format-error.ts";
 import { createSessionEventRefreshCoordinator } from "./event-refresh-coordinator.ts";
@@ -44,8 +45,6 @@ type ManagedSessionListRefresh = {
   offset?: number;
   invalidated?: true;
 };
-
-const OWNER_FIRST_SESSION_LIST_LIMIT = 60;
 
 type ManagedSessionListQuery = Readonly<Record<string, unknown>> & { readonly limit: number };
 
@@ -315,9 +314,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       if (bootstrap && !host.connection.isCurrent(scope)) {
         return null;
       }
-      result ??= bootstrap
-        ? await requestSessionListParams(scope.client, listParams)
-        : await requestSessionList(scope.client, requestOptions);
+      result ??= await requestSessionListParams(scope.client, listParams);
       if (!host.connection.isCurrent(scope)) {
         return null;
       }
@@ -414,7 +411,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       return options;
     }
     const limit = Math.max(
-      OWNER_FIRST_SESSION_LIST_LIMIT,
+      SESSIONS_LIST_OWNER_LIMIT,
       typeof options.limit === "number" && options.limit > 0
         ? Math.floor(options.limit)
         : DEFAULT_SESSION_LIST_QUERY.limit,


### PR DESCRIPTION
## What Problem This Solves

The Control UI previously waited on three Gateway requests to load its initial session roster: subscribe, list the signed-in owner's sessions, then list the shared page. Warm session-change refreshes required two lists. This PR reduces each flow to one request while preserving visibility, filters, pagination, and connection lifecycle.

## Why This Change Was Made

`sessions.subscribe` now registers the observer before returning the canonical authorized list projection. `ownerFirst` uses the authenticated profile to prepend an independent window of at most 60 owned sessions, then deduplicates the normal shared page without advancing its cursor. The UI consumes that bootstrap and uses one canonical list for warm refreshes, removing the two-phase orchestration.

Maintainer review repaired three connected defects: administrator cache keys now include the viewer identity, bootstrap shares the list's startup admission gate, and retained owner windows cannot consume the shared transcript-enrichment budget. The existing `involvingMe` cache path gets the same identity repair. Swift protocol models and client/protocol documentation were updated.

The related CI fixture race was reproduced at both config writers. Both now use the existing atomic JSON writer so deferred session notifications cannot read a truncated config. Cache-test fixtures were extracted to keep the regression suite below its file-length limit, without suppressions or weakened coverage.

## User Impact

Cold roster loading is one `sessions.subscribe` and no separate list; a warm change is one `sessions.list`. Older owned sessions remain available alongside shared sessions, and paging retains the shared cursor and previously hydrated preview metadata. Observer errors remain visible and reconnects establish a fresh bootstrap.

No new configuration or environment setting, storage schema change, or protocol-version bump. Empty-parameter subscriptions retain their acknowledgment-only response; subscription requests now receive the same retryable startup admission response as lists while the Gateway warms up. The optional `ownerFirst` request parameter and non-empty subscribe snapshot response are the only protocol additions.

## Evidence

[Inspected live video, before/after screenshots, commands, and results](https://github.com/openclaw/openclaw/pull/130294#issuecomment-5429494065).

- Real built Gateway and served Control UI, isolated state, two authenticated trusted-proxy profiles, 390 sessions: **53/53 checks passed**. Verified concurrent administrator projections, bounded owner/shared previews, cold and warm RPC counts, retained paging, reconnect, served asset bytes, and zero browser exceptions. No provider turn or operator credentials were used.
- Gateway: **147 tests passed**, including the original chat test execution order. All four new roster regression cases failed on the incoming code before repair.
- Full UI unit suite: **10,649 passed**, 67 existing skips.
- Final fixture suite: **5/5 passed**; both cases reproduced the original JSON5 EOF before repair. Extracted cache suite: **31/31 passed** and targeted lint passed.
- Focused browser E2Es: **3/3 passed**.
- Full build, UI performance budget, protocol registry/generated Swift/generated Kotlin/`since` checks, and core/UI/test typechecks passed.
- Fresh Codex autoreview of the full change and the later fixture extraction: no accepted/actionable findings at the configured default P0 threshold. Maintainer review additionally found and fixed the P2 defects above.
- [Final-head CI](https://github.com/openclaw/openclaw/actions/runs/33012934737) passed on `96e5796c7afcdaf4b0b2678a3f02ba6dd71d078a`; required `openclaw/ci-gate` is green.

Production LOC: **+154/-118 (net +36)**. This implements the combined bootstrap and bounded authenticated projection while removing duplicate client orchestration; the maintainer repairs reduce handwritten production code by seven lines relative to the incoming PR. Tests and support: **+327/-190** before discounting the pure fixture move; generated Swift: **+4**; docs: **+57/-5**.

The latest ClawSweeper review found no actionable patch defect. Its rank-up request is satisfied: final-head CI is green, and GitHub merge ref `5c34be2844a001bce4da32d1a70d7e21b675d1b6` was fetched and compared against the verified PR head on main `26d3b08758fbb0fca0b474b8c4c533cf87ba89e7`. All handwritten roster runtime/UI files are unchanged; current-main differences in touched files are unrelated generated approval/portal models and an independent mock-reset ordering change. The earlier rebase-only move remains intentionally skipped because the branch is conflict-free. The reviewer harness stopped after 30 seconds without a completed browser verdict; the completed three-test browser run, full hosted browser shards, and real Gateway/browser evidence above provide the actual results. No persistent-store schema changed.
