### PR TITLE
refactor(agents): share node id fragment sanitizer

### DIFF
--- a/src/agents/agent-bundle-mcp-names.test.ts
+++ b/src/agents/agent-bundle-mcp-names.test.ts
@@ -3,11 +3,21 @@ import { describe, expect, it } from "vitest";
 import {
   buildSafeToolName,
   normalizeReservedToolNames,
+  sanitizeNodeIdFragment,
   sanitizeServerName,
   TOOL_NAME_SEPARATOR,
 } from "./agent-bundle-mcp-names.js";
 
 describe("agent bundle MCP names", () => {
+  it.each([
+    { value: "", expected: "node" },
+    { value: " North !! Node ", expected: "north_node" },
+    { value: "123-node", expected: "node_123_node" },
+    { value: "a".repeat(40), expected: "a".repeat(32) },
+  ])("sanitizes node ID fragment $value", ({ value, expected }) => {
+    expect(sanitizeNodeIdFragment(value)).toBe(expected);
+  });
+
   it("sanitizes and disambiguates server names", () => {
     const usedNames = new Set<string>();
 

--- a/src/agents/agent-bundle-mcp-names.ts
+++ b/src/agents/agent-bundle-mcp-names.ts
@@ -11,6 +11,20 @@ export const TOOL_NAME_SEPARATOR = "__";
 const TOOL_NAME_MAX_PREFIX = 30;
 const TOOL_NAME_MAX_TOTAL = 64;
 
+/** Builds stable node-ID prefixes capped at 32 characters. */
+export function sanitizeNodeIdFragment(value: string): string {
+  const fragment = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 32);
+  if (!fragment) {
+    return "node";
+  }
+  return /^[a-z]/.test(fragment) ? fragment : `node_${fragment}`.slice(0, 32);
+}
+
 function sanitizeToolFragment(raw: string, fallback: string, maxChars?: number): string {
   const cleaned = raw.trim().replace(TOOL_NAME_SAFE_RE, "-");
   const normalized = cleaned || fallback;

--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -7,6 +7,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { tokTypes } from "acorn";
 import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
 import type { PluginToolMcpMeta } from "../plugins/tools.js";
+import { sanitizeNodeIdFragment } from "./agent-bundle-mcp-names.js";
 import { toCodeModeJsonSafe } from "./code-mode-json.js";
 import {
   buildMcpApiResponse,
@@ -295,19 +296,6 @@ function mcpNamespaceServerKey(mcp: NonNullable<CodeModeNamespaceCatalogEntry["m
     : JSON.stringify(["gateway", mcp.safeServerName]);
 }
 
-function sanitizeNodeFragment(value: string): string {
-  const fragment = value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9_]+/g, "_")
-    .replace(/^_+|_+$/g, "")
-    .slice(0, 32);
-  if (!fragment) {
-    return "node";
-  }
-  return /^[a-z]/.test(fragment) ? fragment : `node_${fragment}`.slice(0, 32);
-}
-
 function assignMcpNamespaceServerNames(
   servers: readonly McpNamespaceServer[],
 ): Map<string, string> {
@@ -333,7 +321,7 @@ function assignMcpNamespaceServerNames(
     if (!server.node || assignments.has(server.key)) {
       continue;
     }
-    const base = `${sanitizeNodeFragment(server.node.id)}_${server.safeServerName}`;
+    const base = `${sanitizeNodeIdFragment(server.node.id)}_${server.safeServerName}`;
     let candidate = base;
     let index = 2;
     while (used.has(candidate.toLowerCase())) {

--- a/src/agents/node-plugin-tools.ts
+++ b/src/agents/node-plugin-tools.ts
@@ -7,7 +7,7 @@ import {
   NODE_MCP_TOOLS_CALL_COMMAND,
 } from "../infra/node-commands.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
-import { sanitizeServerName } from "./agent-bundle-mcp-names.js";
+import { sanitizeNodeIdFragment, sanitizeServerName } from "./agent-bundle-mcp-names.js";
 import { compileGlobPatterns, matchesAnyGlobPattern } from "./glob-pattern.js";
 import {
   projectMcpCallToolResult,
@@ -106,19 +106,6 @@ function describeNodeToolLocation(params: {
   return `${params.description} (node: ${label})`;
 }
 
-function sanitizeToolNameFragment(value: string): string {
-  const fragment = value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9_]+/g, "_")
-    .replace(/^_+|_+$/g, "")
-    .slice(0, 32);
-  if (!fragment) {
-    return "node";
-  }
-  return /^[a-z]/.test(fragment) ? fragment : `node_${fragment}`.slice(0, 32);
-}
-
 function isProviderSafeToolName(value: string): boolean {
   return NODE_PLUGIN_TOOL_NAME_RE.test(value);
 }
@@ -142,7 +129,7 @@ function resolveUniqueToolName(params: {
   if (params.duplicateCount === 1 && !params.existingNormalized.has(params.normalizedName)) {
     return params.baseName;
   }
-  const nodeFragment = sanitizeToolNameFragment(params.nodeId);
+  const nodeFragment = sanitizeNodeIdFragment(params.nodeId);
   for (let index = 0; index < 100; index += 1) {
     const suffix = index === 0 ? "" : `_${index + 1}`;
     const candidate = prependToolNameFragment(params.baseName, nodeFragment, suffix);


### PR DESCRIPTION
## What Problem This Solves

Code-mode MCP namespaces and node plugin tools independently implemented the same node-ID fragment sanitizer. Keeping the normalization duplicated makes model-facing server and tool names easier to drift.

## Why This Change Was Made

Move the byte-identical sanitizer into the existing agent bundle MCP naming owner and reuse it from both callers. The callers retain their separate collision algorithms, provider limits, and policy checks; no SDK export is added.

## User Impact

No intended user-visible behavior change. Node-derived MCP server and tool prefixes keep the same lowercase, underscore, fallback, numeric-prefix, and 32-character rules.

## Evidence

- Focused agent tests: 34 passed across three files at exact head `b8d2f736debbe130e009aa13ba167b0d53f14ea1`.
- Current-main combined tree: clean four-file merge against `a678ed6565c209023ceb962d849972fc962497f6`; 34 focused tests plus `src/gateway/node-plugin-tool-invoke-deadline.e2e.test.ts` passed (35/35), preserving the 30-second node and 35-second Gateway budgets.
- `check-changed`: passed, including dead-export scans after materializing the sparse UI config dependency.
- Runtime import cycles: 0.
- Autoreview: clean, 0.99 confidence.
- Test audit: the added table protects the canonical normalization contract and needs no test-only production seam; existing composed collision tests remain unchanged.
- Blacksmith Testbox: lease `tbx_01m10ttzbqkrhxe2j9af13f1cb`, Actions run `33042409271`; remote-fetch synchronization confirmed expected/local/live SHA `b8d2f736debbe130e009aa13ba167b0d53f14ea1`, 34/34 focused tests passed, `exitCode: 0`, `runStatus: succeeded`.
- AWS Crabbox `run_3823235a277a` on lease `cbx_8b213bfaad36`: fresh public/no-role/no-Tailscale checkout at exact head, frozen install, 34 focused tests passed; lease released.
- The trusted untrusted-code bootstrap used the same explicit `umask 022` workaround documented on #130280; no PR code was changed for it.
- ClawSweeper rank-up disposition: the exact-head failed shard and required CI gate were rerun from run `33000658245`; `checks-node-compact-small-17` job `98415272654` and `openclaw/ci-gate` job `98415696594` both passed.
- Production delta: +18 / -29, net -11 lines. Tests: +10 lines.
