### PR TITLE
fix(xai): preserve transcription audio on reopen

### DIFF
--- a/extensions/xai/lazy-capability-providers.test.ts
+++ b/extensions/xai/lazy-capability-providers.test.ts
@@ -228,8 +228,8 @@ describe("xAI lazy capability providers", () => {
       third,
     ]);
     expect(runtimeMocks.transcriptionConnect).toHaveBeenCalledOnce();
-    expect(runtimeMocks.transcriptionSendAudio.mock.invocationCallOrder.at(-1)).toBeLessThan(
-      runtimeMocks.transcriptionConnect.mock.invocationCallOrder[0]!,
+    expect(runtimeMocks.transcriptionConnect.mock.invocationCallOrder[0]).toBeLessThan(
+      runtimeMocks.transcriptionSendAudio.mock.invocationCallOrder[0]!,
     );
   });
 
@@ -250,30 +250,68 @@ describe("xAI lazy capability providers", () => {
   });
 
   it("reopens transcription after close without replaying discarded audio", async () => {
+    const reconnecting = createDeferred<void>();
+    const forwarded: Buffer[] = [];
+    const events: string[] = [];
+    let connectCount = 0;
+    let providerClosed = false;
+    runtimeMocks.transcriptionConnect.mockImplementation(() => {
+      providerClosed = false;
+      connectCount += 1;
+      if (connectCount === 1) {
+        return Promise.resolve();
+      }
+      events.push("connect-start");
+      return reconnecting.promise.then(() => {
+        events.push("connect-settle");
+      });
+    });
+    runtimeMocks.transcriptionClose.mockImplementation(() => {
+      providerClosed = true;
+    });
+    runtimeMocks.transcriptionSendAudio.mockImplementation((audio: Buffer) => {
+      events.push(`${providerClosed ? "drop" : "audio"}:${audio[0]}`);
+      if (!providerClosed) {
+        forwarded.push(audio);
+      }
+    });
     const lazy = await loadLazyProviders();
     const session = lazy.createLazyXaiRealtimeTranscriptionProvider().createSession({
       providerConfig: {},
     });
     const first = Buffer.from([0x01]);
     const discarded = Buffer.from([0x02]);
-    const second = Buffer.from([0x03]);
+    const droppedByLimit = Buffer.alloc(1024 * 1024, 0x03);
+    const retainedFirst = Buffer.alloc(1024 * 1024, 0x04);
+    const retainedSecond = Buffer.alloc(1024 * 1024, 0x05);
+    const live = Buffer.from([0x06]);
 
     session.sendAudio(first);
     await session.connect();
     session.close();
     session.close();
     session.sendAudio(discarded);
+    events.length = 0;
 
     const reconnectPromise = session.connect();
-    session.sendAudio(second);
-    await reconnectPromise;
+    session.sendAudio(droppedByLimit);
+    session.sendAudio(retainedFirst);
+    session.sendAudio(retainedSecond);
+    await vi.waitFor(() => expect(runtimeMocks.transcriptionConnect).toHaveBeenCalledTimes(2));
+    session.sendAudio(live);
 
-    expect(runtimeMocks.transcriptionConnect).toHaveBeenCalledTimes(2);
     expect(runtimeMocks.transcriptionClose).toHaveBeenCalledOnce();
-    expect(runtimeMocks.transcriptionSendAudio.mock.calls.map(([audio]) => audio)).toEqual([
-      first,
-      second,
+    expect(forwarded.map((audio) => [audio[0], audio.byteLength])).toEqual([
+      [1, 1],
+      [4, 1024 * 1024],
+      [5, 1024 * 1024],
+      [6, 1],
     ]);
+    expect(events).toEqual(["connect-start", "audio:4", "audio:5", "audio:6"]);
+
+    reconnecting.resolve();
+    await reconnectPromise;
+    expect(events.at(-1)).toBe("connect-settle");
   });
 
   it("preserves voice startup ordering and waits to trigger the greeting", async () => {

--- a/extensions/xai/lazy-capability-providers.ts
+++ b/extensions/xai/lazy-capability-providers.ts
@@ -135,17 +135,13 @@ function createLazyXaiRealtimeTranscriptionSession(
     session = await sessionPromise;
     return session;
   };
-  const beginConnectGeneration = () => {
-    if (closed) {
-      generation += 1;
-      closed = false;
-    }
-    return generation;
-  };
-
   return {
     connect: async () => {
-      const connectGeneration = beginConnectGeneration();
+      if (closed) {
+        generation += 1;
+        closed = false;
+      }
+      const connectGeneration = generation;
       if (activeConnect?.generation === connectGeneration) {
         await activeConnect.promise;
         return;
@@ -158,11 +154,14 @@ function createLazyXaiRealtimeTranscriptionSession(
           }
           return;
         }
+        // connect() synchronously reopens a closed provider session. Starting it
+        // first keeps explicit-reconnect audio from being silently discarded.
+        const providerConnect = loadedSession.connect();
         for (const audio of pendingAudio.drain()) {
           loadedSession.sendAudio(audio);
         }
         acceptsInput = true;
-        await loadedSession.connect();
+        await providerConnect;
         if (connectGeneration === generation && closed) {
           closeSession(connectGeneration, loadedSession);
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where audio queued while reopening an xAI realtime transcription session could be silently dropped after the previous underlying WebSocket session had closed.

## Why This Change Was Made

The lazy provider now begins the underlying reconnect before draining queued audio. The session's synchronous connect prefix reopens input acceptance, so queued chunks are delivered in order to the new generation instead of being sent into the still-closed session. Existing close, ordering, and concurrent-open behavior remains unchanged.

## User Impact

Users reopening realtime transcription no longer lose the first queued audio chunks during reconnect.

## Evidence

- Genuine stateful regression: pre-fix lazy suite 28 passing / 2 failing; fixed suite 30/30.
- Focused owner and sibling coverage passes: 38 shared owner tests, 29 WebSocket-session tests, 82 voice tests, and 481 xAI tests.
- Exact focused formatting, type-aware lint, and diff checks pass.
- Fresh autoreview and two independent reviews report no actionable findings.
- Production delta: +18/-19, net -1 line; tests add the realistic reconnect regression.
