### PR TITLE
refactor(buzz): consolidate relay snapshot lifecycle owners

### DIFF
--- a/extensions/buzz/src/directory-relay.ts
+++ b/extensions/buzz/src/directory-relay.ts
@@ -6,14 +6,13 @@ import {
   BUZZ_ROOM_METADATA_KIND,
   type BuzzDirectoryState,
 } from "./directory-state.js";
-import { openBuzzRelaySubscription } from "./relay-subscription.js";
+import { openBuzzRelaySubscription, queryBuzzRelaySnapshot } from "./relay-subscription.js";
 
 const BUZZ_ROOM_QUERY_CHUNK_SIZE = 1_000;
 const PROFILE_SUBSCRIPTION_REPLACED_REASON = "directory profile subscription replaced";
 const PROFILE_SUBSCRIPTION_FAILED_REASON = "directory profile subscription generation failed";
 const DIRECTORY_SHUTDOWN_REASON = "directory shutdown";
 const DIRECTORY_QUERY_COMPLETE_REASON = "directory query complete";
-const DIRECTORY_QUERY_TIMEOUT_MS = 10_000;
 const PROFILE_SUBSCRIPTION_READY_TIMEOUT_MS = 10_000;
 
 type BuzzSubscription = ReturnType<Relay["prepareSubscription"]>;
@@ -32,69 +31,20 @@ async function queryBuzzDirectoryBatch(params: {
   signal?: AbortSignal;
 }): Promise<void> {
   params.signal?.throwIfAborted();
-  await new Promise<void>((resolve, reject) => {
-    let settled = false;
-    let receivedEose = false;
-    const timeout = setTimeout(() => {
-      const error = new Error("Timed out loading Buzz directory snapshot");
-      finish(error);
-      if (params.onTimeout) {
-        params.onTimeout(error);
-      } else {
-        params.relay.close();
-      }
-    }, DIRECTORY_QUERY_TIMEOUT_MS);
-    const subscriptionRef: { current?: BuzzSubscription } = {};
-    const finish = (error?: unknown) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      params.signal?.removeEventListener("abort", onAbort);
-      if (receivedEose) {
-        subscriptionRef.current?.close(DIRECTORY_QUERY_COMPLETE_REASON);
-      }
-      if (error === undefined) {
-        resolve();
-      } else {
-        reject(
-          error instanceof Error
-            ? error
-            : new Error("Buzz directory query failed", { cause: error }),
-        );
-      }
-    };
-    const onAbort = () =>
-      finish(params.signal?.reason ?? new Error("Buzz directory query aborted"));
-    params.signal?.addEventListener("abort", onAbort, { once: true });
-    try {
-      subscriptionRef.current = openBuzzRelaySubscription(params.relay, [params.filter], {
-        onevent: params.onEvent,
-        oneose: () => {
-          receivedEose = true;
-          if (settled) {
-            subscriptionRef.current?.close(DIRECTORY_QUERY_COMPLETE_REASON);
-          } else {
-            finish();
-          }
-        },
-        onclose: (reason) => {
-          if (reason !== DIRECTORY_QUERY_COMPLETE_REASON) {
-            finish(new Error(`Buzz directory query closed: ${reason}`));
-          }
-        },
-      });
-    } catch (error) {
-      finish(error);
-      return;
-    }
-    if (settled && receivedEose) {
-      subscriptionRef.current.close(DIRECTORY_QUERY_COMPLETE_REASON);
-    }
-    if (params.signal?.aborted) {
-      onAbort();
-    }
+  await queryBuzzRelaySnapshot({
+    relay: params.relay,
+    filters: [params.filter],
+    signal: params.signal,
+    timeoutMessage: "Timed out loading Buzz directory snapshot",
+    abortMessage: "Buzz directory query aborted",
+    failureMessage: "Buzz directory query failed",
+    closeReason: DIRECTORY_QUERY_COMPLETE_REASON,
+    closeMessage: (reason) => `Buzz directory query closed: ${reason}`,
+    onEvent: params.onEvent,
+    result: () => {},
+    onTimeout: params.onTimeout,
+    closeRelayOnTimeout: !params.onTimeout,
+    checkAbortAfterSubscribe: true,
   });
 }
 

--- a/extensions/buzz/src/history-catchup.ts
+++ b/extensions/buzz/src/history-catchup.ts
@@ -1,12 +1,11 @@
 import type { Event, Relay } from "nostr-tools";
 import { BUZZ_INBOUND_MESSAGE_KINDS } from "./message-event.js";
-import { openBuzzRelaySubscription } from "./relay-subscription.js";
+import { queryBuzzRelaySnapshot } from "./relay-subscription.js";
 import {
   BUZZ_REPLAY_DISPATCH_MAX_PENDING,
   type BuzzReplayDispatchReservation,
 } from "./replay-dispatch.js";
 
-const HISTORY_PAGE_TIMEOUT_MS = 10_000;
 const HISTORY_PAGE_COMPLETE_REASON = "buzz room history page loaded";
 
 type BuzzRoomHistoryCatchUp = "complete" | "aborted" | "timestamp-over-limit";
@@ -28,88 +27,35 @@ async function queryBuzzRoomHistoryPage(params: {
 }): Promise<BuzzRoomHistoryPage> {
   const events: Event[] = [];
   let overLimit = false;
-  return await new Promise<BuzzRoomHistoryPage>((resolve, reject) => {
-    let settled = false;
-    let receivedEose = false;
-    const timeout = setTimeout(() => {
-      const error = new Error(`Timed out loading Buzz room history for ${params.channelId}`);
-      finish(error);
-      params.relay.close();
-    }, HISTORY_PAGE_TIMEOUT_MS);
-    const subscriptionRef: { current?: ReturnType<Relay["prepareSubscription"]> } = {};
-    const finish = (error?: unknown) => {
-      if (settled) {
+  return await queryBuzzRelaySnapshot({
+    relay: params.relay,
+    filters: [
+      {
+        kinds: [...BUZZ_INBOUND_MESSAGE_KINDS],
+        "#h": [params.channelId],
+        since: params.since,
+        until: params.until,
+        ...(params.requestLimit === undefined ? {} : { limit: params.requestLimit }),
+      },
+    ],
+    signal: params.signal,
+    timeoutMessage: `Timed out loading Buzz room history for ${params.channelId}`,
+    abortMessage: "Buzz room history query aborted",
+    failureMessage: "Buzz room history query failed",
+    closeReason: HISTORY_PAGE_COMPLETE_REASON,
+    closeMessage: (reason) => `Buzz room history query closed for ${params.channelId}: ${reason}`,
+    onEvent: (event) => {
+      if (params.skipEventIds?.has(event.id)) {
         return;
       }
-      settled = true;
-      clearTimeout(timeout);
-      params.signal?.removeEventListener("abort", onAbort);
-      if (receivedEose) {
-        subscriptionRef.current?.close(HISTORY_PAGE_COMPLETE_REASON);
-      }
-      if (error === undefined) {
-        resolve({ events, overLimit });
+      if (events.length < params.maxEvents) {
+        events.push(event);
       } else {
-        reject(
-          error instanceof Error
-            ? error
-            : new Error("Buzz room history query failed", { cause: error }),
-        );
+        overLimit = true;
       }
-    };
-    const onAbort = () =>
-      finish(params.signal?.reason ?? new Error("Buzz room history query aborted"));
-    params.signal?.addEventListener("abort", onAbort, { once: true });
-    try {
-      subscriptionRef.current = openBuzzRelaySubscription(
-        params.relay,
-        [
-          {
-            kinds: [...BUZZ_INBOUND_MESSAGE_KINDS],
-            "#h": [params.channelId],
-            since: params.since,
-            until: params.until,
-            ...(params.requestLimit === undefined ? {} : { limit: params.requestLimit }),
-          },
-        ],
-        {
-          onevent: (event) => {
-            if (params.skipEventIds?.has(event.id)) {
-              return;
-            }
-            if (events.length < params.maxEvents) {
-              events.push(event);
-            } else {
-              overLimit = true;
-            }
-          },
-          oneose: () => {
-            receivedEose = true;
-            if (settled) {
-              subscriptionRef.current?.close(HISTORY_PAGE_COMPLETE_REASON);
-            } else {
-              finish();
-            }
-          },
-          onclose: (reason) => {
-            if (reason !== HISTORY_PAGE_COMPLETE_REASON) {
-              finish(
-                new Error(`Buzz room history query closed for ${params.channelId}: ${reason}`),
-              );
-            }
-          },
-        },
-      );
-    } catch (error) {
-      finish(error);
-      return;
-    }
-    if (settled && receivedEose) {
-      subscriptionRef.current.close(HISTORY_PAGE_COMPLETE_REASON);
-    }
-    if (params.signal?.aborted) {
-      onAbort();
-    }
+    },
+    result: () => ({ events, overLimit }),
+    checkAbortAfterSubscribe: true,
   });
 }
 

--- a/extensions/buzz/src/profile.ts
+++ b/extensions/buzz/src/profile.ts
@@ -1,11 +1,10 @@
 import { finalizeEvent, type Event, type Relay } from "nostr-tools";
-import { openBuzzRelaySubscription } from "./relay-subscription.js";
+import { queryBuzzRelaySnapshot } from "./relay-subscription.js";
 
 const PROFILE_KIND = 0;
 const AGENT_PROFILE_KIND = 10_100;
 const DEFAULT_CHANNEL_ADD_POLICY = "anyone";
 const CHANNEL_ADD_POLICIES = new Set(["anyone", "owner_only", "nobody"]);
-const PROFILE_QUERY_TIMEOUT_MS = 10_000;
 
 type BuzzProfileSyncResult = { status: "unchanged" } | { status: "published"; eventId: string };
 
@@ -54,70 +53,27 @@ async function queryCurrentProfiles(params: {
   signal?: AbortSignal;
 }): Promise<Map<number, Event>> {
   params.signal?.throwIfAborted();
-  return await new Promise<Map<number, Event>>((resolve, reject) => {
-    const latestByKind = new Map<number, Event>();
-    const state: {
-      settled: boolean;
-      receivedEose: boolean;
-      subscription?: ReturnType<Relay["prepareSubscription"]>;
-    } = { settled: false, receivedEose: false };
-    const timeout = setTimeout(() => {
-      const error = new Error("Timed out loading current Buzz profile");
-      finish(error);
-      params.onTimeout?.(error);
-      params.relay.close();
-    }, PROFILE_QUERY_TIMEOUT_MS);
-    const finish = (error?: unknown) => {
-      if (state.settled) {
-        return;
+  const latestByKind = new Map<number, Event>();
+  return await queryBuzzRelaySnapshot({
+    relay: params.relay,
+    filters: [
+      { kinds: [PROFILE_KIND], authors: [params.publicKey], limit: 1 },
+      { kinds: [AGENT_PROFILE_KIND], authors: [params.publicKey], limit: 1 },
+    ],
+    signal: params.signal,
+    timeoutMessage: "Timed out loading current Buzz profile",
+    abortMessage: "Buzz profile query aborted",
+    failureMessage: "Buzz profile query failed",
+    closeReason: "profile query complete",
+    closeMessage: (reason) => `Buzz profile query closed: ${reason}`,
+    onEvent: (event) => {
+      const current = latestByKind.get(event.kind);
+      if (!current || event.created_at > current.created_at) {
+        latestByKind.set(event.kind, event);
       }
-      state.settled = true;
-      clearTimeout(timeout);
-      params.signal?.removeEventListener("abort", onAbort);
-      if (state.receivedEose) {
-        state.subscription?.close("profile query complete");
-      }
-      if (error !== undefined) {
-        reject(
-          error instanceof Error ? error : new Error("Buzz profile query failed", { cause: error }),
-        );
-        return;
-      }
-      resolve(latestByKind);
-    };
-    const onAbort = () => finish(params.signal?.reason ?? new Error("Buzz profile query aborted"));
-    params.signal?.addEventListener("abort", onAbort, { once: true });
-    state.subscription = openBuzzRelaySubscription(
-      params.relay,
-      [
-        { kinds: [PROFILE_KIND], authors: [params.publicKey], limit: 1 },
-        { kinds: [AGENT_PROFILE_KIND], authors: [params.publicKey], limit: 1 },
-      ],
-      {
-        onevent: (event) => {
-          const current = latestByKind.get(event.kind);
-          if (!current || event.created_at > current.created_at) {
-            latestByKind.set(event.kind, event);
-          }
-        },
-        oneose: () => {
-          state.receivedEose = true;
-          if (state.settled) {
-            state.subscription?.close("profile query complete");
-          } else {
-            finish();
-          }
-        },
-        onclose: (reason) => {
-          if (reason !== "profile query complete") {
-            finish(new Error(`Buzz profile query closed: ${reason}`));
-          }
-        },
-      },
-    );
-    if (state.settled && state.receivedEose) {
-      state.subscription.close("profile query complete");
-    }
+    },
+    result: () => latestByKind,
+    onTimeout: params.onTimeout,
   });
 }
 

--- a/extensions/buzz/src/relay-subscription.ts
+++ b/extensions/buzz/src/relay-subscription.ts
@@ -1,6 +1,23 @@
-import type { Filter, Relay } from "nostr-tools";
+import type { Event, Filter, Relay } from "nostr-tools";
 
 type BuzzRelaySubscriptionParams = Omit<Parameters<Relay["prepareSubscription"]>[1], "abort">;
+
+type BuzzRelaySnapshotParams<TResult> = {
+  relay: Relay;
+  filters: Filter[];
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  timeoutMessage: string;
+  abortMessage: string;
+  failureMessage: string;
+  closeReason: string;
+  closeMessage: (reason: string) => string;
+  onEvent: (event: Event) => void;
+  result: () => TResult;
+  onTimeout?: (error: Error) => void;
+  closeRelayOnTimeout?: boolean;
+  checkAbortAfterSubscribe?: boolean;
+};
 
 export function openBuzzRelaySubscription(
   relay: Relay,
@@ -34,4 +51,70 @@ export function openBuzzRelaySubscription(
     subscription.close(`Buzz relay subscription request failed: ${message}`);
   });
   return subscription;
+}
+
+export async function queryBuzzRelaySnapshot<TResult>(
+  params: BuzzRelaySnapshotParams<TResult>,
+): Promise<TResult> {
+  return await new Promise<TResult>((resolve, reject) => {
+    let settled = false;
+    let receivedEose = false;
+    let subscriptionClosed = false;
+    let subscription: ReturnType<Relay["prepareSubscription"]> | undefined;
+    const timeout = setTimeout(() => {
+      const error = new Error(params.timeoutMessage);
+      finish(error);
+      params.onTimeout?.(error);
+      if (params.closeRelayOnTimeout !== false) {
+        params.relay.close();
+      }
+    }, params.timeoutMs ?? 10_000);
+    const closeAfterRealEose = () => {
+      if (receivedEose && subscription && !subscriptionClosed) {
+        subscriptionClosed = true;
+        subscription.close(params.closeReason);
+      }
+    };
+    const finish = (error?: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      params.signal?.removeEventListener("abort", onAbort);
+      closeAfterRealEose();
+      if (error === undefined) {
+        resolve(params.result());
+      } else {
+        reject(error instanceof Error ? error : new Error(params.failureMessage, { cause: error }));
+      }
+    };
+    const onAbort = () => finish(params.signal?.reason ?? new Error(params.abortMessage));
+    params.signal?.addEventListener("abort", onAbort, { once: true });
+    try {
+      subscription = openBuzzRelaySubscription(params.relay, params.filters, {
+        onevent: params.onEvent,
+        oneose: () => {
+          receivedEose = true;
+          if (settled) {
+            closeAfterRealEose();
+          } else {
+            finish();
+          }
+        },
+        onclose: (reason) => {
+          if (reason !== params.closeReason) {
+            finish(new Error(params.closeMessage(reason)));
+          }
+        },
+      });
+    } catch (error) {
+      finish(error);
+      return;
+    }
+    closeAfterRealEose();
+    if (params.checkAbortAfterSubscribe && params.signal?.aborted) {
+      onAbort();
+    }
+  });
 }

--- a/extensions/buzz/src/room-discovery.ts
+++ b/extensions/buzz/src/room-discovery.ts
@@ -1,6 +1,6 @@
 import type { Event, Filter, Relay } from "nostr-tools";
 import { connectAuthenticatedBuzzRelaySession, parseBuzzAuthTag } from "./relay-auth.js";
-import { openBuzzRelaySubscription } from "./relay-subscription.js";
+import { queryBuzzRelaySnapshot } from "./relay-subscription.js";
 import { BUZZ_ROOM_MEMBERSHIP_KIND, parseBuzzRoomMembershipEvent } from "./room-membership.js";
 import { BUZZ_CHANNEL_ID_PATTERN } from "./target.js";
 import { decodeBuzzPrivateKey, resolveBuzzPublicKey } from "./types.js";
@@ -25,64 +25,19 @@ async function queryRelay(params: {
   signal?: AbortSignal;
 }): Promise<Event[]> {
   params.signal?.throwIfAborted();
-  return await new Promise<Event[]>((resolve, reject) => {
-    const events: Event[] = [];
-    const state: {
-      settled: boolean;
-      receivedEose: boolean;
-      timeout?: ReturnType<typeof setTimeout>;
-      subscription?: ReturnType<Relay["prepareSubscription"]>;
-    } = { settled: false, receivedEose: false };
-    const finish = (error?: unknown) => {
-      if (state.settled) {
-        return;
-      }
-      state.settled = true;
-      if (state.timeout) {
-        clearTimeout(state.timeout);
-      }
-      params.signal?.removeEventListener("abort", onAbort);
-      if (state.receivedEose) {
-        state.subscription?.close("query complete");
-      }
-      if (error !== undefined) {
-        reject(
-          error instanceof Error ? error : new Error("Buzz room query failed", { cause: error }),
-        );
-      } else {
-        resolve(events);
-      }
-    };
-    const onAbort = () => finish(params.signal?.reason ?? new Error("Buzz room query aborted"));
-    params.signal?.addEventListener("abort", onAbort, { once: true });
-    state.timeout = setTimeout(() => {
-      finish(new Error("Timed out querying Buzz room membership"));
-      params.relay.close();
-    }, params.timeoutMs);
-    try {
-      state.subscription = openBuzzRelaySubscription(params.relay, [params.filter], {
-        onevent: (event) => events.push(event),
-        oneose: () => {
-          state.receivedEose = true;
-          if (state.settled) {
-            state.subscription?.close("query complete");
-          } else {
-            finish();
-          }
-        },
-        onclose: (reason) => {
-          if (reason !== "query complete") {
-            finish(new Error(`Buzz room query closed: ${reason}`));
-          }
-        },
-      });
-    } catch (error) {
-      finish(error);
-      return;
-    }
-    if (state.settled && state.receivedEose) {
-      state.subscription.close("query complete");
-    }
+  const events: Event[] = [];
+  return await queryBuzzRelaySnapshot({
+    relay: params.relay,
+    filters: [params.filter],
+    signal: params.signal,
+    timeoutMs: params.timeoutMs,
+    timeoutMessage: "Timed out querying Buzz room membership",
+    abortMessage: "Buzz room query aborted",
+    failureMessage: "Buzz room query failed",
+    closeReason: "query complete",
+    closeMessage: (reason) => `Buzz room query closed: ${reason}`,
+    onEvent: (event) => events.push(event),
+    result: () => events,
   });
 }
 

--- a/extensions/buzz/src/room-membership-query.ts
+++ b/extensions/buzz/src/room-membership-query.ts
@@ -1,5 +1,5 @@
 import type { Relay } from "nostr-tools";
-import { openBuzzRelaySubscription } from "./relay-subscription.js";
+import { queryBuzzRelaySnapshot } from "./relay-subscription.js";
 import {
   BUZZ_ROOM_MEMBERSHIP_KIND,
   isNewerBuzzRoomMembership,
@@ -9,7 +9,6 @@ import {
 
 const RELAY_QUERY_EVENT_LIMIT = 1_000;
 const MEMBERSHIP_QUERY_COMPLETE_REASON = "membership snapshot loaded";
-const MEMBERSHIP_QUERY_TIMEOUT_MS = 10_000;
 
 async function queryBuzzRoomMembershipBatch(params: {
   relay: Relay;
@@ -19,86 +18,34 @@ async function queryBuzzRoomMembershipBatch(params: {
 }): Promise<Map<string, BuzzRoomMembership>> {
   const configuredRooms = new Set(params.channelIds);
   const memberships = new Map<string, BuzzRoomMembership>();
-  return await new Promise<Map<string, BuzzRoomMembership>>((resolve, reject) => {
-    let settled = false;
-    let receivedEose = false;
-    const timeout = setTimeout(() => {
-      const error = new Error("Timed out loading Buzz room membership snapshot");
-      finish(error);
-      params.relay.close();
-    }, MEMBERSHIP_QUERY_TIMEOUT_MS);
-    const subscriptionRef: { current?: ReturnType<Relay["prepareSubscription"]> } = {};
-    const finish = (error?: unknown) => {
-      if (settled) {
-        return;
+  return await queryBuzzRelaySnapshot({
+    relay: params.relay,
+    filters: [
+      {
+        kinds: [BUZZ_ROOM_MEMBERSHIP_KIND],
+        authors: [params.relayPublicKey],
+        "#d": params.channelIds,
+        limit: params.channelIds.length,
+      },
+    ],
+    signal: params.signal,
+    timeoutMessage: "Timed out loading Buzz room membership snapshot",
+    abortMessage: "Buzz room membership query aborted",
+    failureMessage: "Buzz room membership query failed",
+    closeReason: MEMBERSHIP_QUERY_COMPLETE_REASON,
+    closeMessage: (reason) => `Buzz room membership query closed: ${reason}`,
+    onEvent: (event) => {
+      const membership = parseBuzzRoomMembershipEvent(event, params.relayPublicKey);
+      if (
+        membership &&
+        configuredRooms.has(membership.roomId) &&
+        isNewerBuzzRoomMembership(membership, memberships.get(membership.roomId))
+      ) {
+        memberships.set(membership.roomId, membership);
       }
-      settled = true;
-      clearTimeout(timeout);
-      params.signal?.removeEventListener("abort", onAbort);
-      if (receivedEose) {
-        subscriptionRef.current?.close(MEMBERSHIP_QUERY_COMPLETE_REASON);
-      }
-      if (error === undefined) {
-        resolve(memberships);
-      } else {
-        reject(
-          error instanceof Error
-            ? error
-            : new Error("Buzz room membership query failed", { cause: error }),
-        );
-      }
-    };
-    const onAbort = () =>
-      finish(params.signal?.reason ?? new Error("Buzz room membership query aborted"));
-    params.signal?.addEventListener("abort", onAbort, { once: true });
-    try {
-      subscriptionRef.current = openBuzzRelaySubscription(
-        params.relay,
-        [
-          {
-            kinds: [BUZZ_ROOM_MEMBERSHIP_KIND],
-            authors: [params.relayPublicKey],
-            "#d": params.channelIds,
-            limit: params.channelIds.length,
-          },
-        ],
-        {
-          onevent: (event) => {
-            const membership = parseBuzzRoomMembershipEvent(event, params.relayPublicKey);
-            if (
-              !membership ||
-              !configuredRooms.has(membership.roomId) ||
-              !isNewerBuzzRoomMembership(membership, memberships.get(membership.roomId))
-            ) {
-              return;
-            }
-            memberships.set(membership.roomId, membership);
-          },
-          oneose: () => {
-            receivedEose = true;
-            if (settled) {
-              subscriptionRef.current?.close(MEMBERSHIP_QUERY_COMPLETE_REASON);
-            } else {
-              finish();
-            }
-          },
-          onclose: (reason) => {
-            if (reason !== MEMBERSHIP_QUERY_COMPLETE_REASON) {
-              finish(new Error(`Buzz room membership query closed: ${reason}`));
-            }
-          },
-        },
-      );
-    } catch (error) {
-      finish(error);
-      return;
-    }
-    if (settled && receivedEose) {
-      subscriptionRef.current.close(MEMBERSHIP_QUERY_COMPLETE_REASON);
-    }
-    if (params.signal?.aborted) {
-      onAbort();
-    }
+    },
+    result: () => memberships,
+    checkAbortAfterSubscribe: true,
   });
 }
 


### PR DESCRIPTION
Consolidate the five private Buzz relay snapshot flows into their existing relay subscription owner and remove 163 net production lines. Directory, history, membership, profile, and room discovery retain their exact filters, authentication, result ordering, timeout messages, callback ownership, and abort behavior.

The shared owner waits only for a real relay EOSE and closes each subscription at most once. This preserves the verified nostr-tools 2.24.2 dependency contract: its convenience subscribe path synthesizes EOSE, and its subscription close operation is not idempotent. Existing public plugin APIs, package dependencies, and all historical caller differences remain unchanged.

Validation: the complete Buzz plugin suite passed all 30 files and 198 assertions; all six changed production files passed formatting and direct configured lint; two independent full owner/dependency/security audits and an authenticated full-diff review found no issues. The existing shared checkout has nostr-tools 2.24.1 installed, while the exact locked 2.24.2 upstream tarball was independently integrity-verified and its relevant lifecycle implementation inspected directly; clean hosted CI installs the locked version.