### PR TITLE
docs(gateway): add Cloud Sessions overview page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1335,7 +1335,7 @@
                   "plugins/workboard",
                   "plugins/webhooks",
                   "plugins/admin-http-rpc",
-              "plugins/geolocation",
+                  "plugins/geolocation",
                   "plugins/beam",
                   "plugins/voice-call",
                   "plugins/vault",
@@ -1695,6 +1695,7 @@
                       "gateway/gateway-lock",
                       "gateway/background-process",
                       "gateway/restart-recovery",
+                      "gateway/cloud-sessions",
                       "gateway/cloud-workers",
                       "gateway/multiple-gateways",
                       "gateway/multi-tenant-hosting"

--- a/docs/gateway/cloud-sessions.md
+++ b/docs/gateway/cloud-sessions.md
@@ -7,7 +7,7 @@ status: active
 doc-schema-version: 1
 ---
 
-A cloud session is an ordinary session whose coding work runs on another machine. It appears in the sidebar, streams into chat, and keeps its transcript exactly like a local session — the Gateway stays the owner of the conversation, the reconciled workspace, model credentials, and placement records, while commands, file edits, and tool work execute remotely. If the remote machine disappears, the session survives; the next message provisions a replacement and continues from the durable state.
+A cloud session is an ordinary session whose coding work runs on another machine. It appears in the sidebar, streams into chat, and keeps its transcript exactly like a local session — the Gateway stays the owner of the conversation, the reconciled workspace, model credentials, and placement records, while commands, file edits, and tool work execute remotely. If the remote machine disappears, the session and its durable state survive; how it resumes depends on the destination — cloud workers are replaced automatically on the next message, while an offline paired device keeps its placement and waits for the device to return.
 
 Sessions can run in three places, and every one of them uses the same session, the same chat, and the same Place picker:
 
@@ -39,7 +39,7 @@ See [Cloud Workers](/gateway/cloud-workers) for profiles, requirements, dispatch
 
 ## Automatic load balancing across devices
 
-You do not have to pick a device. Choosing **Any available node** in the Place picker — or dispatching with `autoDevice: true` — selects the paired session host with the most free worker slots, breaking ties by device ID, and retries up to three ranked hosts if provisioning fails before a machine is allocated. When no host qualifies, the error says exactly why: no session hosts paired, all disconnected, or all at capacity.
+You do not have to pick a device. Choosing **Any available node** in the Place picker — or dispatching with `autoDevice: true` — selects a paired session host automatically and retries up to three ranked hosts if provisioning fails before a machine is allocated. OpenClaw `worker-turn` placements rank hosts by most free worker slots, breaking ties by device ID; Codex `remote-exec` placements do not consume worker slots, so eligible hosts are ranked by device ID alone. When no host qualifies, the error says exactly why: no session hosts paired, all disconnected, or all at capacity.
 
 See [Nodes](/nodes#host-openclaw-sessions) for the selection rules and [Control UI](/web/control-ui) for the picker.
 
@@ -54,7 +54,7 @@ Suspension never interrupts work: sessions with an active turn, queued messages,
 
 ## What stays with the Gateway
 
-Placement is disposable; the session is not. The transcript, the last-reconciled workspace files, placement history, and every provider credential live with the Gateway in all placements. A dead cloud machine, an offline device, or an idle suspension all resolve the same way: the session remains in your sidebar, and the next message continues it — warm when an image exists, cold otherwise. Workspace changes made after the last reconciliation are the only loss window, and clean stops (including auto-suspension) reconcile before releasing the machine.
+Placement is disposable; the session is not. The transcript, the last-reconciled workspace files, placement history, and every provider credential live with the Gateway in all placements. A dead cloud machine or an idle suspension resolves automatically: the session remains in your sidebar, and the next message provisions a replacement — warm when an image exists, cold otherwise. An offline paired device is different by design: the placement stays active and waits for the device to reconnect, and **Continue on Gateway…** is an explicit action that can lose unsynced device files. Workspace changes made after the last reconciliation are the only loss window, and clean stops (including auto-suspension) reconcile before releasing the machine.
 
 ## Related
 

--- a/docs/gateway/cloud-sessions.md
+++ b/docs/gateway/cloud-sessions.md
@@ -1,0 +1,66 @@
+---
+summary: "Run sessions on paired devices or throwaway cloud machines while the Gateway keeps the transcript, workspace, and credentials"
+title: "Cloud Sessions"
+sidebarTitle: "Cloud Sessions"
+read_when: "You want sessions to run somewhere other than the Gateway host, or you are choosing between paired devices, cloud workers, automatic placement, and idle suspension."
+status: active
+doc-schema-version: 1
+---
+
+A cloud session is an ordinary session whose coding work runs on another machine. It appears in the sidebar, streams into chat, and keeps its transcript exactly like a local session — the Gateway stays the owner of the conversation, the reconciled workspace, model credentials, and placement records, while commands, file edits, and tool work execute remotely. If the remote machine disappears, the session survives; the next message provisions a replacement and continues from the durable state.
+
+Sessions can run in three places, and every one of them uses the same session, the same chat, and the same Place picker:
+
+| Destination       | The machine                                                                       | Best for                                                    | Scope to dispatch |
+| ----------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------- |
+| Gateway (default) | The host running `openclaw gateway`                                               | Everyday sessions                                           | —                 |
+| Paired device     | Your own hardware, connected once with `openclaw connect`                         | Spare Macs, build boxes, servers you already own            | `operator.write`  |
+| Cloud worker      | A throwaway machine leased through [Crabbox](https://github.com/openclaw/crabbox) | Burst capacity, long jobs, isolation from your own machines | `operator.admin`  |
+
+In all remote placements, model inference stays proxied through the Gateway — provider credentials never reach the remote machine — and completed work reconciles back into the session's managed worktree. Both the OpenClaw runtime (`worker-turn`) and Codex (`remote-exec`) can use the same destinations.
+
+## Paired devices: your own hardware as session hosts
+
+Pair any machine with one pasted command, then opt it into session hosting:
+
+```bash
+openclaw connect <join-url> --service --session-host
+```
+
+The device holds an outbound connection to the Gateway, advertises worker slots (one per CPU core by default, tunable with `nodeHost.workerRuns.capacity`), and can optionally run each hosted session in a Docker-compatible container (`nodeHost.workerRuns.isolation: "container"`). A device that goes offline keeps its active placement — the session waits for it to reconnect rather than losing work.
+
+See [Nodes](/nodes) for pairing, capacity, isolation, and offline behavior, and [Connect](/cli/connect) for the CLI.
+
+## Cloud workers: rented machines through Crabbox
+
+Configure a profile under `cloudWorkers.profiles` and the bundled Crabbox plugin provisions machines on demand across cloud backends (AWS, Hetzner, and others), runs your setup command, enrolls the box as a temporary node, and tears everything down when the session stops. The machine is disposable by design: no standing credentials live on it, and the durable state stays with the Gateway.
+
+See [Cloud Workers](/gateway/cloud-workers) for profiles, requirements, dispatching, moving sessions between destinations, and the security model.
+
+## Automatic load balancing across devices
+
+You do not have to pick a device. Choosing **Any available node** in the Place picker — or dispatching with `autoDevice: true` — selects the paired session host with the most free worker slots, breaking ties by device ID, and retries up to three ranked hosts if provisioning fails before a machine is allocated. When no host qualifies, the error says exactly why: no session hosts paired, all disconnected, or all at capacity.
+
+See [Nodes](/nodes#host-openclaw-sessions) for the selection rules and [Control UI](/web/control-ui) for the picker.
+
+## Sleeping and waking: idle suspension and warm images
+
+Two profile settings turn cloud workers from always-on machines into compute that sleeps when idle:
+
+- `suspendAfter: "2h"` — after the session has been idle for the duration, the Gateway performs the same safe stop as **Stop cloud worker…**: it reconciles the workspace first, then releases the machine. While suspended, you pay for retained snapshot storage only. The next message provisions a replacement automatically — no button to press.
+- `settings.warmImage: true` — capture a scrubbed machine image when a worker stops, and start later workers for the same profile from that image instead of provisioning cold. Paired with `suspendAfter`, a suspended session wakes on a warm machine in a fraction of the cold provisioning time.
+
+Suspension never interrupts work: sessions with an active turn, queued messages, or unreconciled results are skipped and re-checked on the next sweep. See the profile fields in [Cloud Workers](/gateway/cloud-workers#configuration) for costs, capture boundaries, and prerequisites.
+
+## What stays with the Gateway
+
+Placement is disposable; the session is not. The transcript, the last-reconciled workspace files, placement history, and every provider credential live with the Gateway in all placements. A dead cloud machine, an offline device, or an idle suspension all resolve the same way: the session remains in your sidebar, and the next message continues it — warm when an image exists, cold otherwise. Workspace changes made after the last reconciliation are the only loss window, and clean stops (including auto-suspension) reconcile before releasing the machine.
+
+## Related
+
+- [Cloud Workers](/gateway/cloud-workers) — profiles, dispatch, moves, security model
+- [Nodes](/nodes) — pairing, session hosting, capacity, container isolation
+- [Control UI](/web/control-ui) — the Place picker and session badges
+- [Connect](/cli/connect) — one-command device onboarding
+- [Managed worktrees](/concepts/managed-worktrees) — the workspace cloud sessions reconcile into
+- [Sandboxing](/gateway/sandboxing) — reducing blast radius for local execution instead


### PR DESCRIPTION
## What Problem This Solves

The remote-session story — paired devices as session hosts, Crabbox cloud workers, automatic device load balancing, and the new idle suspension with warm wakes — had no single reader-facing home. Each piece is documented in its own deep page (Nodes, Cloud Workers, Control UI), but nothing explains the product as one system or routes a new operator to the right path; the headline capabilities live in dense per-page tables.

## Why This Change Was Made

Maintainer-requested dedicated overview page. `docs/gateway/cloud-sessions.md` is an overview/topic page per the docs playbook: what a cloud session is (an ordinary session whose work runs elsewhere while the Gateway owns transcript, workspace, and credentials), a three-destination table with dispatch scopes, one short section each for paired devices, Crabbox workers, automatic load balancing ("Any available node" / `autoDevice` selection and retry rules), and sleeping/waking (`suspendAfter` + `warmImage` pairing, reconcile-before-suspend guarantee), a durability section stating the single loss window, and Related links. All claims are qualitative and sourced from the existing deep pages; dense contracts stay linked, not duplicated. Nav: inserted into Gateway → "Scaling and operations" directly before Cloud Workers.

## User Impact

Docs-only. Operators get one page answering "where can my sessions run and what happens when machines sleep, die, or disconnect", with the enablement path for each capability.

## Evidence

Docs-only validation: `git diff --check` clean; every internal link target verified against existing pages and nav (`/nodes`, `/nodes#host-openclaw-sessions` anchor confirmed against the heading, `/gateway/cloud-workers#configuration`, `/web/control-ui`, `/cli/connect`, `/concepts/managed-worktrees`, `/gateway/sandboxing`); `pnpm docs:list` picks the page up with its summary; no schema-validated config fences added; behavior claims cross-checked against `docs/nodes/index.md`, `docs/gateway/cloud-workers.md`, and `docs/web/control-ui.md` (selection ranking, retry cap, scope split, suspension guards).
