### PR TITLE
fix(plugins): snapshot channel ingress before owner checks

### DIFF
--- a/src/plugins/registry-runtime.channel-ingress.test.ts
+++ b/src/plugins/registry-runtime.channel-ingress.test.ts
@@ -196,15 +196,26 @@ describe("bundled channel ingress runtime ownership", () => {
         return channelReads++ === 0 ? "community" : "discord";
       },
     };
-    await expect(retainedGuest(changingGuestOptions, commandRuntime)).resolves.toEqual({
+    await expect(retainedGuest(changingGuestOptions, commandRuntime)).rejects.toThrow(
+      'Plugin "impostor" cannot admit accessor-backed channel ingress.',
+    );
+    expect(ownerClaimReads).toBe(0);
+    expect(channelReads).toBe(0);
+    let proxyReads = 0;
+    const proxiedGuestOptions = new Proxy(guestOptions, {
+      get(target, property, receiver) {
+        proxyReads += 1;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    await expect(retainedGuest(proxiedGuestOptions, commandRuntime)).resolves.toEqual({
       payloads: [],
     });
     expect(command).toHaveBeenLastCalledWith(
       expect.objectContaining({ messageChannel: "community", senderIsOwner: false }),
       commandRuntime,
     );
-    expect(ownerClaimReads).toBe(1);
-    expect(channelReads).toBe(1);
+    expect(proxyReads).toBe(0);
     await expect(
       retainedGuest({ ...guestOptions, senderIsOwner: true }, commandRuntime),
     ).rejects.toThrow('Plugin "impostor" cannot admit authenticated owner authority');

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -1003,10 +1003,24 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
             params,
             commandRuntime,
           ) => {
-            const { senderIsOwner: claimedOwner, messageChannel, ...remainingParams } = params;
-            const senderIsOwner = claimedOwner === true;
-            // Validate and dispatch the same host-owned values; never re-read plugin-owned authority.
-            const ingressParams = { ...remainingParams, senderIsOwner, messageChannel };
+            const ingressParams = Object.create(null) as typeof params;
+            for (const [key, descriptor] of Object.entries(
+              Object.getOwnPropertyDescriptors(params),
+            )) {
+              if (!descriptor.enumerable) {
+                continue;
+              }
+              if (!("value" in descriptor)) {
+                throw new Error(
+                  `Plugin "${pluginId}" cannot admit accessor-backed channel ingress.`,
+                );
+              }
+              Reflect.set(ingressParams, key, descriptor.value);
+            }
+            // Snapshot host-owned admission facts without invoking plugin getters or proxy reads.
+            const senderIsOwner = ingressParams.senderIsOwner === true;
+            const { messageChannel } = ingressParams;
+            ingressParams.senderIsOwner = senderIsOwner;
             if (
               !channelOwnerRecord ||
               // Community channels may admit guests; trusted provenance is required only for owner elevation.


### PR DESCRIPTION
Related: #104872

## What Problem This Solves

Fixes an issue where a plugin could supply dynamically changing channel-ingress metadata that was inspected and dispatched as different values, undermining the authenticated-owner boundary introduced in #104872.

## Why This Change Was Made

The plugin registry now snapshots all enumerable own ingress fields from property descriptors into host-owned, null-prototype state before checking or forwarding them. Accessor-backed input is rejected without running plugin-controlled getters, while trusted authenticated owners, ordinary community-channel guests, revoked owners, and descriptor-backed proxies retain their intended behavior.

## User Impact

Legitimate authenticated operators keep their existing owner-only capabilities. Untrusted plugin input cannot change its effective channel or owner claim during admission.

## Evidence

- The original failure was reproduced against current main and passes after the canonical plugin-registry owner repair.
- `node scripts/run-vitest.mjs src/plugins/registry-runtime.channel-ingress.test.ts`: 26 tests passed against the final integration branch.
- A real `createPluginRuntime`/registry API subprocess verified genuine owner admission, community guest admission, malformed dynamic state rejection, and revoked-owner rejection.
- Independent human-equivalent code review and a separate structured P1 review found no actionable issues.
- Direct upstream Codex MCP inspection confirmed that plugin/tool arguments do not provide host-minted owner authority: `codex-rs/core/src/tools/handlers/mcp.rs`, `codex-rs/core/src/mcp_tool_call.rs`, and `codex-rs/codex-mcp/src/binding.rs`.
- Production: +18/-4 (net +14), necessary for one host-owned immutable admission snapshot; tests: +14/-3 (net +11). No new configuration, public API, protocol, persistence, or migration surface.
