### PR TITLE
fix(e2e): stable candidate plugin repair fails after update

### DIFF
--- a/scripts/e2e/lib/prepublish-plugin-registry.sh
+++ b/scripts/e2e/lib/prepublish-plugin-registry.sh
@@ -57,8 +57,12 @@ NODE
 
   mkdir -p "$registry_root"
   local port_file="$registry_root/port" log_file="$registry_root/server.log"
+  local latest_version="$candidate_version"
+  if [[ "$candidate_version" =~ -(alpha|beta)\.[1-9][0-9]*$ ]]; then
+    latest_version="0.0.0"
+  fi
   rm -f "$port_file"
-  OPENCLAW_NPM_REGISTRY_DIST_TAGS="latest=0.0.0,beta=$candidate_version" \
+  OPENCLAW_NPM_REGISTRY_DIST_TAGS="latest=$latest_version,beta=$candidate_version" \
     OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org \
     node "$server_script" "$port_file" "${registry_args[@]}" >"$log_file" 2>&1 &
   local server_pid="$!"

--- a/scripts/e2e/lib/prepublish-plugin-registry.sh
+++ b/scripts/e2e/lib/prepublish-plugin-registry.sh
@@ -57,12 +57,12 @@ NODE
 
   mkdir -p "$registry_root"
   local port_file="$registry_root/port" log_file="$registry_root/server.log"
-  local latest_version="$candidate_version"
+  local dist_tags="beta=$candidate_version"
   if [[ "$candidate_version" =~ -(alpha|beta)\.[1-9][0-9]*$ ]]; then
-    latest_version="0.0.0"
+    dist_tags="latest=0.0.0,$dist_tags"
   fi
   rm -f "$port_file"
-  OPENCLAW_NPM_REGISTRY_DIST_TAGS="latest=$latest_version,beta=$candidate_version" \
+  OPENCLAW_NPM_REGISTRY_DIST_TAGS="$dist_tags" \
     OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org \
     node "$server_script" "$port_file" "${registry_args[@]}" >"$log_file" 2>&1 &
   local server_pid="$!"

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2510,7 +2510,9 @@ docker_e2e_docker_run_cmd run demo
     }
     expectTextToIncludeAll(registryHelper, [
       "OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org",
-      'OPENCLAW_NPM_REGISTRY_DIST_TAGS="latest=0.0.0,beta=$candidate_version"',
+      '[[ "$candidate_version" =~ -(alpha|beta)\\.[1-9][0-9]*$ ]]',
+      'latest_version="0.0.0"',
+      'OPENCLAW_NPM_REGISTRY_DIST_TAGS="latest=$latest_version,beta=$candidate_version"',
       'export NPM_CONFIG_REGISTRY="http://127.0.0.1:$(cat "$port_file")"',
       'export npm_config_registry="$NPM_CONFIG_REGISTRY"',
     ]);
@@ -3886,7 +3888,7 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
       "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_REQUIRED_PACKAGES_JSON='[\"@openclaw/codex\"]'",
     ]);
     expectTextToIncludeAll(registryHelper, [
-      'OPENCLAW_NPM_REGISTRY_DIST_TAGS="latest=0.0.0,beta=$candidate_version"',
+      'OPENCLAW_NPM_REGISTRY_DIST_TAGS="latest=$latest_version,beta=$candidate_version"',
       "OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org",
     ]);
     expect(runner.indexOf("openclaw_e2e_install_package")).toBeLessThan(

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2511,8 +2511,8 @@ docker_e2e_docker_run_cmd run demo
     expectTextToIncludeAll(registryHelper, [
       "OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org",
       '[[ "$candidate_version" =~ -(alpha|beta)\\.[1-9][0-9]*$ ]]',
-      'latest_version="0.0.0"',
-      'OPENCLAW_NPM_REGISTRY_DIST_TAGS="latest=$latest_version,beta=$candidate_version"',
+      'dist_tags="latest=0.0.0,$dist_tags"',
+      'OPENCLAW_NPM_REGISTRY_DIST_TAGS="$dist_tags"',
       'export NPM_CONFIG_REGISTRY="http://127.0.0.1:$(cat "$port_file")"',
       'export npm_config_registry="$NPM_CONFIG_REGISTRY"',
     ]);
@@ -3888,7 +3888,7 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
       "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_REQUIRED_PACKAGES_JSON='[\"@openclaw/codex\"]'",
     ]);
     expectTextToIncludeAll(registryHelper, [
-      'OPENCLAW_NPM_REGISTRY_DIST_TAGS="latest=$latest_version,beta=$candidate_version"',
+      'OPENCLAW_NPM_REGISTRY_DIST_TAGS="$dist_tags"',
       "OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org",
     ]);
     expect(runner.indexOf("openclaw_e2e_install_package")).toBeLessThan(

--- a/test/scripts/prepublish-plugin-registry-shell.test.ts
+++ b/test/scripts/prepublish-plugin-registry-shell.test.ts
@@ -129,12 +129,20 @@ NODE
     (version) => {
       const root = tempDirs.make("openclaw-stable-prepublish-registry-shell-");
       const registryRoot = join(root, "registry");
-      const tarball = createTarball(
+      const discordTarball = createTarball(
         root,
         root,
         "@openclaw/discord",
         `openclaw-discord-${version}.tgz`,
         version,
+      );
+      const fixtureVersion = "2026.5.2";
+      const braveTarball = createTarball(
+        root,
+        root,
+        "@openclaw/brave-plugin",
+        `openclaw-brave-${fixtureVersion}.tgz`,
+        fixtureVersion,
       );
       const result = spawnSync(
         "bash",
@@ -153,17 +161,21 @@ cleanup() {
 trap cleanup EXIT
 openclaw_prepublish_plugin_registry_start \
   "" "" "$VERSION" "" "$REGISTRY_ROOT" registry_pid \
-  "@openclaw/discord" "$VERSION" "$TARBALL"
+  "@openclaw/discord" "$VERSION" "$DISCORD_TARBALL" \
+  "@openclaw/brave-plugin" "$FIXTURE_VERSION" "$BRAVE_TARBALL"
 test "$(npm view @openclaw/discord version)" = "$VERSION"
+test "$(npm view @openclaw/brave-plugin version)" = "$FIXTURE_VERSION"
 `,
         ],
         {
           encoding: "utf8",
           env: {
             ...process.env,
+            BRAVE_TARBALL: braveTarball,
+            DISCORD_TARBALL: discordTarball,
+            FIXTURE_VERSION: fixtureVersion,
             HELPER: SCRIPT,
             REGISTRY_ROOT: registryRoot,
-            TARBALL: tarball,
             VERSION: version,
           },
         },

--- a/test/scripts/prepublish-plugin-registry-shell.test.ts
+++ b/test/scripts/prepublish-plugin-registry-shell.test.ts
@@ -14,13 +14,16 @@ function sha256(path: string): string {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
-function createTarball(root: string, outputDir: string, name: string, filename: string): string {
+function createTarball(
+  root: string,
+  outputDir: string,
+  name: string,
+  filename: string,
+  version = VERSION,
+): string {
   const packageRoot = join(root, "staging", filename, "package");
   mkdirSync(packageRoot, { recursive: true });
-  writeFileSync(
-    join(packageRoot, "package.json"),
-    `${JSON.stringify({ name, version: VERSION })}\n`,
-  );
+  writeFileSync(join(packageRoot, "package.json"), `${JSON.stringify({ name, version })}\n`);
   const tarball = join(outputDir, filename);
   execFileSync("tar", ["-czf", tarball, "-C", join(packageRoot, ".."), "package"]);
   return tarball;
@@ -120,6 +123,55 @@ NODE
 
     expect(result.status, result.stderr).toBe(0);
   });
+
+  it.each(["2026.8.1", "2026.8.1-2"])(
+    "resolves stable candidate %s from an unversioned npm spec",
+    (version) => {
+      const root = tempDirs.make("openclaw-stable-prepublish-registry-shell-");
+      const registryRoot = join(root, "registry");
+      const tarball = createTarball(
+        root,
+        root,
+        "@openclaw/discord",
+        `openclaw-discord-${version}.tgz`,
+        version,
+      );
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          `
+set -euo pipefail
+source "$HELPER"
+registry_pid=""
+cleanup() {
+  if [ -n "$registry_pid" ]; then
+    kill "$registry_pid" >/dev/null 2>&1 || true
+    wait "$registry_pid" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+openclaw_prepublish_plugin_registry_start \
+  "" "" "$VERSION" "" "$REGISTRY_ROOT" registry_pid \
+  "@openclaw/discord" "$VERSION" "$TARBALL"
+test "$(npm view @openclaw/discord version)" = "$VERSION"
+`,
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            HELPER: SCRIPT,
+            REGISTRY_ROOT: registryRoot,
+            TARBALL: tarball,
+            VERSION: version,
+          },
+        },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+    },
+  );
 
   it("is valid Bash", () => {
     const result = spawnSync("bash", ["-n", SCRIPT], { encoding: "utf8" });


### PR DESCRIPTION
Follow-up to #130288.

## What Problem This Solves

Fixes an issue where release operators testing an update from stable npm to a stable candidate would reach post-update plugin repair and then fail to install candidate-bundled channel plugins from an unversioned npm spec.

The local candidate registry advertised `latest=0.0.0` for every candidate. That is intentional for alpha/beta candidates, but for a stable candidate it made ordinary stable resolution select a nonexistent version even though the candidate tarball was present and verified.

## Why This Change Was Made

The shared candidate-registry publisher now keeps the invalid `latest=0.0.0` guard only for alpha and beta candidates. Stable candidates omit the global `latest` override, allowing the registry server to retain each package's actual loaded version as its own `latest`; this supports both candidate-bundled plugins and older scenario fixtures in the same registry. The existing `beta` mirror remains unchanged.

The regression proof starts the real shell-owned registry and resolves both a candidate-version Discord package and a mismatched-version Brave fixture through unversioned `npm view` requests for stable final and stable correction candidate forms.

## User Impact

Release operators can complete post-update repair against stable candidate plugin artifacts instead of failing with `No match found for version 0.0.0`. Mixed-version acceptance fixtures also retain correct unversioned resolution. There is no product runtime or public npm behavior change; this repairs release-acceptance infrastructure.

## Evidence

- Original Package Acceptance root-cause evidence: https://github.com/openclaw/openclaw/actions/runs/32999746515 passed candidate registry verification, integrity/content checks, Docker setup, candidate installation, and exact-ref validation, then failed when post-update Discord repair resolved `latest=0.0.0`.
- ClawSweeper sibling-path finding: https://github.com/openclaw/openclaw/pull/130306#issuecomment-5430072334 identified that the first implementation globally overrode `latest` for an older Brave fixture. Both rank-up moves were applied: stable candidates now preserve per-package tags, and the regression contains a mismatched-version package.
- Pre-correction mismatched fixture reproduction: unversioned `npm view @openclaw/brave-plugin version` exited 1 with npm 404 when candidate version `2026.8.1` globally replaced the fixture's loaded `2026.5.2` latest tag.
- Post-fix focused proof: 205/205 tests passed across `test/scripts/docker-build-helper.test.ts` and `test/scripts/prepublish-plugin-registry-shell.test.ts`.
- `node scripts/check-changed.mjs -- scripts/e2e/lib/prepublish-plugin-registry.sh test/scripts/prepublish-plugin-registry-shell.test.ts test/scripts/docker-build-helper.test.ts` passed after installing the current lockfile dependencies, including formatting, test-root typecheck, and script lint.
- `bash -n scripts/e2e/lib/prepublish-plugin-registry.sh` and `git diff --check` passed.
- Fresh Codex autoreview (`gpt-5.6-sol`, high) returned no accepted/actionable findings and rated the corrected patch 0.99 correct.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/33006135787 passed at `8676408af1bb3be33ec841be73347af62bab85ab`.
- Exact-head Package Acceptance: https://github.com/openclaw/openclaw/actions/runs/33006242421 passed package integrity, npm 12 install, candidate packaging, Docker setup, and both `channel-post-core-restore` and `configured-plugin-installs` upgrades from `openclaw@2026.7.1-2`; the downloaded summary recorded two status-0 lanes, no retries, no timeouts, and no failures.

## Repair Shape

- Root cause: the registry publisher unconditionally advertised an invalid `latest`, conflating prerelease isolation with stable candidate semantics.
- Owner boundary: `openclaw_prepublish_plugin_registry_start`, which owns candidate registry dist-tags while the registry server owns per-package defaults.
- Production/tooling LOC: +5/-1.
- Tests: +73/-7.
- Alternatives rejected: changing stable product install specs would make release-test infrastructure leak into product policy; globally setting the stable candidate as `latest` breaks mixed-version fixtures; a Package Acceptance-only override would leave sibling registry consumers inconsistent.

AI-assisted: yes. The implementation, root-cause trace, failing/passing regressions, and validation were reviewed by the submitting maintainer.
