### PR TITLE
fix(usage): prevent model identity collisions

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3020,7 +3020,7 @@ src/gateway/server-methods/terminal.ts	7
 src/gateway/server-methods/tools-catalog.ts	2
 src/gateway/server-methods/ui-command.ts	2
 src/gateway/server-methods/update.ts	2
-src/gateway/server-methods/usage.ts	7
+src/gateway/server-methods/usage.ts	3
 src/gateway/server-methods/web.ts	3
 src/gateway/server-methods/wizard.ts	1
 src/gateway/server-methods/workspace-fs.ts	2

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -736,27 +736,58 @@ describe("sessions.usage", () => {
         },
       });
       vi.mocked(loadSessionCostSummariesFromCache).mockImplementation(async ({ sessions }) => ({
-        summaries: sessions.map((session) => ({
-          input: session.sessionId === "old" ? 10 : 20,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: session.sessionId === "old" ? 10 : 20,
-          totalCost: session.sessionId === "old" ? 0.01 : 0.02,
-          inputCost: session.sessionId === "old" ? 0.01 : 0.02,
-          outputCost: 0,
-          cacheReadCost: 0,
-          cacheWriteCost: 0,
-          missingCostEntries: 0,
-          messageCounts: {
-            total: 1,
-            user: 1,
-            assistant: 0,
-            toolCalls: 0,
-            toolResults: 0,
-            errors: 0,
-          },
-        })),
+        summaries: sessions.map((session) => {
+          const historical = session.sessionId === "old";
+          const totalTokens = historical ? 10 : 20;
+          const totalCost = historical ? 0.02 : 0.01;
+          const totals = {
+            input: totalTokens,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens,
+            totalCost,
+            inputCost: totalCost,
+            outputCost: 0,
+            cacheReadCost: 0,
+            cacheWriteCost: 0,
+            missingCostEntries: 0,
+          };
+          return {
+            ...totals,
+            messageCounts: {
+              total: 1,
+              user: 1,
+              assistant: 0,
+              toolCalls: 0,
+              toolResults: 0,
+              errors: 0,
+            },
+            modelUsage: [
+              {
+                provider: historical ? "fixture::bedrock" : "fixture",
+                model: historical ? "arn" : "bedrock::arn",
+                count: 1,
+                totals,
+              },
+            ],
+            toolUsage: {
+              totalCalls: 1,
+              uniqueTools: 1,
+              tools: [{ name: historical ? "a-second" : "z-first", count: 1 }],
+            },
+            dailyModelUsage: [
+              {
+                date: "2026-02-01",
+                provider: historical ? "fixture:bedrock" : "fixture",
+                model: historical ? "arn" : "bedrock:arn",
+                tokens: totalTokens,
+                cost: totalCost,
+                count: 1,
+              },
+            ],
+          };
+        }),
         cacheStatus: {
           status: "fresh",
           cachedFiles: sessions.length,
@@ -779,9 +810,20 @@ describe("sessions.usage", () => {
           key: string;
           scope?: string;
           includedSessionIds?: string[];
-          usage?: { totalTokens: number; totalCost: number; messageCounts?: { total: number } };
+          usage?: {
+            totalTokens: number;
+            totalCost: number;
+            messageCounts?: { total: number };
+            modelUsage?: Array<{ provider?: string; model?: string }>;
+            dailyModelUsage?: Array<{ provider?: string; model?: string }>;
+            toolUsage?: { tools: Array<{ name: string }> };
+          };
         }>;
         totals: { totalTokens: number; totalCost: number };
+        aggregates: {
+          byModel: Array<{ provider?: string; model?: string }>;
+          modelDaily: Array<{ provider?: string; model?: string }>;
+        };
       };
       expect(result.sessions).toHaveLength(1);
       expect(result.sessions[0]?.key).toBe(storeKey);
@@ -790,6 +832,26 @@ describe("sessions.usage", () => {
       expect(result.sessions[0]?.usage?.totalTokens).toBe(30);
       expect(result.sessions[0]?.usage?.totalCost).toBeCloseTo(0.03);
       expect(result.sessions[0]?.usage?.messageCounts?.total).toBe(2);
+      expect(result.sessions[0]?.usage?.toolUsage?.tools.map((tool) => tool.name)).toEqual([
+        "z-first",
+        "a-second",
+      ]);
+      expect(result.sessions[0]?.usage?.modelUsage).toMatchObject([
+        { provider: "fixture", model: "bedrock::arn" },
+        { provider: "fixture::bedrock", model: "arn" },
+      ]);
+      expect(result.sessions[0]?.usage?.dailyModelUsage).toMatchObject([
+        { provider: "fixture", model: "bedrock:arn" },
+        { provider: "fixture:bedrock", model: "arn" },
+      ]);
+      expect(result.aggregates.byModel).toMatchObject([
+        { provider: "fixture::bedrock", model: "arn" },
+        { provider: "fixture", model: "bedrock::arn" },
+      ]);
+      expect(result.aggregates.modelDaily).toMatchObject([
+        { provider: "fixture:bedrock", model: "arn" },
+        { provider: "fixture", model: "bedrock:arn" },
+      ]);
       expect(result.totals.totalTokens).toBe(30);
       expect(result.totals.totalCost).toBeCloseTo(0.03);
     });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -25,6 +25,7 @@ import {
   resolveTimezone,
   resolveTimeZoneDayStartMs,
 } from "../../infra/format-time/format-datetime.js";
+import { mergeSessionCostSummaryInto } from "../../infra/session-cost-usage-rollup.js";
 import {
   addCostUsageTotals,
   createEmptyCostUsageTotals,
@@ -52,6 +53,8 @@ import {
   buildUsageAggregateTail,
   mergeUsageDailyLatency,
   mergeUsageLatency,
+  usageDailyModelIdentity,
+  usageModelIdentity,
 } from "../../shared/usage-aggregates.js";
 import type {
   SessionUsageEntry,
@@ -813,210 +816,6 @@ function maybeMergeFamilyEntry(params: {
   });
 }
 
-function mergeSessionUsageInto(target: SessionCostSummary, source: SessionCostSummary): void {
-  addCostUsageTotals(target, source);
-  target.firstActivity =
-    target.firstActivity === undefined
-      ? source.firstActivity
-      : source.firstActivity === undefined
-        ? target.firstActivity
-        : Math.min(target.firstActivity, source.firstActivity);
-  target.lastActivity =
-    target.lastActivity === undefined
-      ? source.lastActivity
-      : source.lastActivity === undefined
-        ? target.lastActivity
-        : Math.max(target.lastActivity, source.lastActivity);
-  if (target.firstActivity !== undefined && target.lastActivity !== undefined) {
-    target.durationMs = Math.max(0, target.lastActivity - target.firstActivity);
-  }
-
-  const activityDates = new Set([...(target.activityDates ?? []), ...(source.activityDates ?? [])]);
-  if (activityDates.size > 0) {
-    target.activityDates = Array.from(activityDates).toSorted();
-  }
-
-  target.dailyBreakdown = mergeUsageRows(target.dailyBreakdown, source.dailyBreakdown, [
-    "tokens",
-    "cost",
-  ]);
-  target.dailyMessageCounts = mergeUsageRows(target.dailyMessageCounts, source.dailyMessageCounts, [
-    "total",
-    "user",
-    "assistant",
-    "toolCalls",
-    "toolResults",
-    "errors",
-  ]);
-  target.utcQuarterHourMessageCounts = mergeUsageRows(
-    target.utcQuarterHourMessageCounts,
-    source.utcQuarterHourMessageCounts,
-    ["total", "user", "assistant", "toolCalls", "toolResults", "errors"],
-  );
-  target.utcQuarterHourTokenUsage = mergeUsageRows(
-    target.utcQuarterHourTokenUsage,
-    source.utcQuarterHourTokenUsage,
-    ["input", "output", "cacheRead", "cacheWrite", "totalTokens", "totalCost"],
-  );
-  target.dailyLatency = mergeDailyLatencyRows(target.dailyLatency, source.dailyLatency);
-  target.dailyModelUsage = mergeDailyModelRows(target.dailyModelUsage, source.dailyModelUsage);
-  target.messageCounts = mergeMessageCounts(target.messageCounts, source.messageCounts);
-  target.toolUsage = mergeToolUsage(target.toolUsage, source.toolUsage);
-  target.modelUsage = mergeModelUsage(target.modelUsage, source.modelUsage);
-  target.latency = mergeLatency(target.latency, source.latency);
-}
-
-function mergeUsageRows<T extends { date: string; quarterIndex?: number }>(
-  left: T[] | undefined,
-  right: T[] | undefined,
-  fields: Array<keyof T>,
-): T[] | undefined {
-  const map = new Map<string, T>();
-  for (const row of [...(left ?? []), ...(right ?? [])]) {
-    const key = row.quarterIndex === undefined ? row.date : `${row.date}:${row.quarterIndex}`;
-    const existing = map.get(key);
-    if (!existing) {
-      map.set(key, { ...row });
-      continue;
-    }
-    for (const field of fields) {
-      existing[field] = (((existing[field] as number | undefined) ?? 0) +
-        ((row[field] as number | undefined) ?? 0)) as T[keyof T];
-    }
-  }
-  return map.size > 0
-    ? Array.from(map.values()).toSorted(
-        (a, b) => a.date.localeCompare(b.date) || (a.quarterIndex ?? 0) - (b.quarterIndex ?? 0),
-      )
-    : undefined;
-}
-
-function mergeMessageCounts(
-  left: SessionMessageCounts | undefined,
-  right: SessionMessageCounts | undefined,
-): SessionMessageCounts | undefined {
-  if (!left && !right) {
-    return undefined;
-  }
-  return {
-    total: (left?.total ?? 0) + (right?.total ?? 0),
-    user: (left?.user ?? 0) + (right?.user ?? 0),
-    assistant: (left?.assistant ?? 0) + (right?.assistant ?? 0),
-    toolCalls: (left?.toolCalls ?? 0) + (right?.toolCalls ?? 0),
-    toolResults: (left?.toolResults ?? 0) + (right?.toolResults ?? 0),
-    errors: (left?.errors ?? 0) + (right?.errors ?? 0),
-  };
-}
-
-function mergeToolUsage(
-  left: SessionCostSummary["toolUsage"],
-  right: SessionCostSummary["toolUsage"],
-): SessionCostSummary["toolUsage"] {
-  const map = new Map<string, number>();
-  for (const tool of [...(left?.tools ?? []), ...(right?.tools ?? [])]) {
-    map.set(tool.name, (map.get(tool.name) ?? 0) + tool.count);
-  }
-  return map.size > 0
-    ? {
-        totalCalls: Array.from(map.values()).reduce((sum, count) => sum + count, 0),
-        uniqueTools: map.size,
-        tools: Array.from(map.entries())
-          .map(([name, count]) => ({ name, count }))
-          .toSorted((a, b) => b.count - a.count),
-      }
-    : undefined;
-}
-
-function mergeModelUsage(
-  left: SessionCostSummary["modelUsage"],
-  right: SessionCostSummary["modelUsage"],
-): SessionCostSummary["modelUsage"] {
-  const map = new Map<string, SessionModelUsage>();
-  for (const entry of [...(left ?? []), ...(right ?? [])]) {
-    const key = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
-    const existing =
-      map.get(key) ??
-      ({
-        provider: entry.provider,
-        model: entry.model,
-        count: 0,
-        totals: createEmptyCostUsageTotals(),
-      } as SessionModelUsage);
-    existing.count += entry.count;
-    addCostUsageTotals(existing.totals, entry.totals);
-    map.set(key, existing);
-  }
-  return map.size > 0 ? Array.from(map.values()) : undefined;
-}
-
-function mergeLatency(
-  left: SessionCostSummary["latency"],
-  right: SessionCostSummary["latency"],
-): SessionCostSummary["latency"] {
-  if (!left && !right) {
-    return undefined;
-  }
-  const leftCount = left?.count ?? 0;
-  const rightCount = right?.count ?? 0;
-  const count = leftCount + rightCount;
-  return {
-    count,
-    avgMs:
-      count > 0 ? ((left?.avgMs ?? 0) * leftCount + (right?.avgMs ?? 0) * rightCount) / count : 0,
-    p95Ms: Math.max(left?.p95Ms ?? 0, right?.p95Ms ?? 0),
-    minMs: Math.min(
-      left?.minMs ?? Number.POSITIVE_INFINITY,
-      right?.minMs ?? Number.POSITIVE_INFINITY,
-    ),
-    maxMs: Math.max(left?.maxMs ?? 0, right?.maxMs ?? 0),
-  };
-}
-
-function mergeDailyLatencyRows(
-  left: SessionCostSummary["dailyLatency"],
-  right: SessionCostSummary["dailyLatency"],
-): SessionCostSummary["dailyLatency"] {
-  const map = new Map<string, NonNullable<SessionCostSummary["dailyLatency"]>[number]>();
-  for (const row of [...(left ?? []), ...(right ?? [])]) {
-    const existing = map.get(row.date);
-    if (!existing) {
-      map.set(row.date, { ...row });
-      continue;
-    }
-    const count = existing.count + row.count;
-    existing.avgMs =
-      count > 0 ? (existing.avgMs * existing.count + row.avgMs * row.count) / count : 0;
-    existing.count = count;
-    existing.p95Ms = Math.max(existing.p95Ms, row.p95Ms);
-    existing.minMs = Math.min(existing.minMs, row.minMs);
-    existing.maxMs = Math.max(existing.maxMs, row.maxMs);
-  }
-  return map.size > 0
-    ? Array.from(map.values()).toSorted((a, b) => a.date.localeCompare(b.date))
-    : undefined;
-}
-
-function mergeDailyModelRows(
-  left: SessionCostSummary["dailyModelUsage"],
-  right: SessionCostSummary["dailyModelUsage"],
-): SessionCostSummary["dailyModelUsage"] {
-  const map = new Map<string, NonNullable<SessionCostSummary["dailyModelUsage"]>[number]>();
-  for (const row of [...(left ?? []), ...(right ?? [])]) {
-    const key = `${row.date}:${row.provider ?? "unknown"}:${row.model ?? "unknown"}`;
-    const existing = map.get(key);
-    if (!existing) {
-      map.set(key, { ...row });
-      continue;
-    }
-    existing.tokens += row.tokens;
-    existing.cost += row.cost;
-    existing.count += row.count;
-  }
-  return map.size > 0
-    ? Array.from(map.values()).toSorted((a, b) => a.date.localeCompare(b.date))
-    : undefined;
-}
-
 async function loadCostUsageSummaryCached(params: {
   startMs: number;
   endMs: number;
@@ -1547,7 +1346,7 @@ export const usageHandlers: GatewayRequestHandlers = {
                 usageByEntryIndex[session.entryIndex] ?? createEmptyCostUsageTotals();
               usage.sessionId = merged.sessionId;
               usage.sessionFile = merged.sessionFile;
-              mergeSessionUsageInto(usage, summary);
+              mergeSessionCostSummaryInto(usage, summary);
               usageByEntryIndex[session.entryIndex] = usage;
             }
           }
@@ -1597,7 +1396,7 @@ export const usageHandlers: GatewayRequestHandlers = {
 
               if (usage.modelUsage) {
                 for (const entry of usage.modelUsage) {
-                  const modelKey = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+                  const modelKey = usageModelIdentity(entry.provider, entry.model);
                   const modelExisting =
                     byModelMap.get(modelKey) ??
                     ({
@@ -1630,7 +1429,7 @@ export const usageHandlers: GatewayRequestHandlers = {
 
               if (usage.dailyModelUsage) {
                 for (const entry of usage.dailyModelUsage) {
-                  const key = `${entry.date}::${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+                  const key = usageDailyModelIdentity(entry.date, entry.provider, entry.model);
                   const existing =
                     modelDailyMap.get(key) ??
                     ({

--- a/src/infra/session-cost-usage-rollup.ts
+++ b/src/infra/session-cost-usage-rollup.ts
@@ -1,3 +1,4 @@
+import { usageDailyModelIdentity, usageModelIdentity } from "../shared/usage-aggregates.js";
 import {
   addCostUsageTotals,
   cloneCostUsageTotals,
@@ -160,10 +161,6 @@ function mergeTools(
   }
 }
 
-function modelKey(provider?: string, model?: string): string {
-  return `${provider ?? "unknown"}\0${model ?? "unknown"}`;
-}
-
 function addModelUsage(
   models: SessionModelUsage[],
   provider: string | undefined,
@@ -173,8 +170,10 @@ function addModelUsage(
   if (!provider && !model) {
     return;
   }
-  const modelRef = modelKey(provider, model);
-  let existing = models.find((entry) => modelKey(entry.provider, entry.model) === modelRef);
+  const modelRef = usageModelIdentity(provider, model);
+  let existing = models.find(
+    (entry) => usageModelIdentity(entry.provider, entry.model) === modelRef,
+  );
   if (!existing) {
     existing = { provider, model, count: 0, totals: createEmptyCostUsageTotals() };
     models.push(existing);
@@ -185,7 +184,7 @@ function addModelUsage(
 
 function mergeModels(target: Map<string, SessionModelUsage>, models: SessionModelUsage[]): void {
   for (const model of models) {
-    const modelRef = modelKey(model.provider, model.model);
+    const modelRef = usageModelIdentity(model.provider, model.model);
     const existing = target.get(modelRef) ?? {
       provider: model.provider,
       model: model.model,
@@ -312,28 +311,215 @@ function addMessageCounts(target: SessionMessageCounts, source: SessionMessageCo
   target.errors += source.errors;
 }
 
-function sortedModelUsage(models: Map<string, SessionModelUsage>): SessionModelUsage[] | undefined {
+function sortedModelUsage(
+  models: Map<string, SessionModelUsage>,
+  sortByUsage = true,
+): SessionModelUsage[] | undefined {
   if (models.size === 0) {
     return undefined;
   }
-  return Array.from(models.values()).toSorted((a, b) => {
-    const costDiff = b.totals.totalCost - a.totals.totalCost;
-    return costDiff || b.totals.totalTokens - a.totals.totalTokens;
-  });
+  const values = Array.from(models.values());
+  return sortByUsage
+    ? values.toSorted((a, b) => {
+        const costDiff = b.totals.totalCost - a.totals.totalCost;
+        return costDiff || b.totals.totalTokens - a.totals.totalTokens;
+      })
+    : values;
 }
 
-function buildToolUsage(tools: Map<string, number>): SessionToolUsage | undefined {
+function buildToolUsage(
+  tools: Map<string, number>,
+  sortTiesByName = true,
+): SessionToolUsage | undefined {
   if (tools.size === 0) {
     return undefined;
   }
   const entries = Array.from(tools.entries())
     .map(([name, count]) => ({ name, count }))
-    .toSorted((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+    .toSorted((a, b) => b.count - a.count || (sortTiesByName ? a.name.localeCompare(b.name) : 0));
   return {
     totalCalls: entries.reduce((sum, entry) => sum + entry.count, 0),
     uniqueTools: entries.length,
     tools: entries,
   };
+}
+
+function mergeDatedRows<T extends { date: string; quarterIndex?: number }>(
+  left: T[] | undefined,
+  right: T[] | undefined,
+  add: (target: T, source: T) => void,
+): T[] | undefined {
+  const rows = new Map<string, T>();
+  for (const row of [...(left ?? []), ...(right ?? [])]) {
+    const key = row.quarterIndex === undefined ? row.date : `${row.date}:${row.quarterIndex}`;
+    const existing = rows.get(key);
+    if (existing) {
+      add(existing, row);
+    } else {
+      rows.set(key, { ...row });
+    }
+  }
+  return rows.size
+    ? Array.from(rows.values()).toSorted(
+        (a, b) => a.date.localeCompare(b.date) || (a.quarterIndex ?? 0) - (b.quarterIndex ?? 0),
+      )
+    : undefined;
+}
+
+function mergeMessageCountSummaries(
+  left: SessionMessageCounts | undefined,
+  right: SessionMessageCounts | undefined,
+): SessionMessageCounts | undefined {
+  if (!left && !right) {
+    return undefined;
+  }
+  const counts = emptyMessageCounts();
+  for (const source of [left, right]) {
+    if (source) {
+      addMessageCounts(counts, source);
+    }
+  }
+  return counts;
+}
+
+function mergeLatencyStats(
+  left: SessionLatencyStats | undefined,
+  right: SessionLatencyStats | undefined,
+): SessionLatencyStats | undefined {
+  if (!left && !right) {
+    return undefined;
+  }
+  const leftCount = left?.count ?? 0;
+  const rightCount = right?.count ?? 0;
+  const count = leftCount + rightCount;
+  return {
+    count,
+    avgMs:
+      count > 0 ? ((left?.avgMs ?? 0) * leftCount + (right?.avgMs ?? 0) * rightCount) / count : 0,
+    p95Ms: Math.max(left?.p95Ms ?? 0, right?.p95Ms ?? 0),
+    minMs: Math.min(
+      left?.minMs ?? Number.POSITIVE_INFINITY,
+      right?.minMs ?? Number.POSITIVE_INFINITY,
+    ),
+    maxMs: Math.max(left?.maxMs ?? 0, right?.maxMs ?? 0),
+  };
+}
+
+function mergeDailyLatencyStats(
+  left: SessionDailyLatency[] | undefined,
+  right: SessionDailyLatency[] | undefined,
+): SessionDailyLatency[] | undefined {
+  const rows = new Map<string, SessionDailyLatency>();
+  for (const row of [...(left ?? []), ...(right ?? [])]) {
+    const existing = rows.get(row.date);
+    if (!existing) {
+      rows.set(row.date, { ...row });
+      continue;
+    }
+    const count = existing.count + row.count;
+    existing.avgMs =
+      count > 0 ? (existing.avgMs * existing.count + row.avgMs * row.count) / count : 0;
+    existing.count = count;
+    existing.p95Ms = Math.max(existing.p95Ms, row.p95Ms);
+    existing.minMs = Math.min(existing.minMs, row.minMs);
+    existing.maxMs = Math.max(existing.maxMs, row.maxMs);
+  }
+  return rows.size
+    ? Array.from(rows.values()).toSorted((a, b) => a.date.localeCompare(b.date))
+    : undefined;
+}
+
+function mergeDailyModels(
+  left: SessionDailyModelUsage[] | undefined,
+  right: SessionDailyModelUsage[] | undefined,
+): SessionDailyModelUsage[] | undefined {
+  const rows = new Map<string, SessionDailyModelUsage>();
+  for (const row of [...(left ?? []), ...(right ?? [])]) {
+    const key = usageDailyModelIdentity(row.date, row.provider, row.model);
+    const existing = rows.get(key);
+    if (!existing) {
+      rows.set(key, { ...row });
+      continue;
+    }
+    existing.tokens += row.tokens;
+    existing.cost += row.cost;
+    existing.count += row.count;
+  }
+  return rows.size
+    ? Array.from(rows.values()).toSorted((a, b) => a.date.localeCompare(b.date))
+    : undefined;
+}
+
+/** Merges historical session summaries through the canonical usage aggregation rules. */
+export function mergeSessionCostSummaryInto(
+  target: SessionCostSummary,
+  source: SessionCostSummary,
+): void {
+  addCostUsageTotals(target, source);
+  target.firstActivity =
+    target.firstActivity === undefined
+      ? source.firstActivity
+      : source.firstActivity === undefined
+        ? target.firstActivity
+        : Math.min(target.firstActivity, source.firstActivity);
+  target.lastActivity =
+    target.lastActivity === undefined
+      ? source.lastActivity
+      : source.lastActivity === undefined
+        ? target.lastActivity
+        : Math.max(target.lastActivity, source.lastActivity);
+  if (target.firstActivity !== undefined && target.lastActivity !== undefined) {
+    target.durationMs = Math.max(0, target.lastActivity - target.firstActivity);
+  }
+
+  const activityDates = new Set([...(target.activityDates ?? []), ...(source.activityDates ?? [])]);
+  if (activityDates.size) {
+    target.activityDates = Array.from(activityDates).toSorted();
+  }
+  target.dailyBreakdown = mergeDatedRows(
+    target.dailyBreakdown,
+    source.dailyBreakdown,
+    (current, row) => {
+      current.tokens += row.tokens;
+      current.cost += row.cost;
+    },
+  );
+  target.dailyMessageCounts = mergeDatedRows(
+    target.dailyMessageCounts,
+    source.dailyMessageCounts,
+    addMessageCounts,
+  );
+  target.utcQuarterHourMessageCounts = mergeDatedRows(
+    target.utcQuarterHourMessageCounts,
+    source.utcQuarterHourMessageCounts,
+    addMessageCounts,
+  );
+  target.utcQuarterHourTokenUsage = mergeDatedRows(
+    target.utcQuarterHourTokenUsage,
+    source.utcQuarterHourTokenUsage,
+    (current, row) => {
+      current.input += row.input;
+      current.output += row.output;
+      current.cacheRead += row.cacheRead;
+      current.cacheWrite += row.cacheWrite;
+      current.totalTokens += row.totalTokens;
+      current.totalCost += row.totalCost;
+    },
+  );
+  target.dailyLatency = mergeDailyLatencyStats(target.dailyLatency, source.dailyLatency);
+  target.dailyModelUsage = mergeDailyModels(target.dailyModelUsage, source.dailyModelUsage);
+  target.messageCounts = mergeMessageCountSummaries(target.messageCounts, source.messageCounts);
+
+  // Family rows retain first-seen/tie order; response-wide aggregates sort independently later.
+  const tools = new Map<string, number>();
+  mergeTools(tools, target.toolUsage?.tools ?? []);
+  mergeTools(tools, source.toolUsage?.tools ?? []);
+  target.toolUsage = buildToolUsage(tools, false);
+  const models = new Map<string, SessionModelUsage>();
+  mergeModels(models, target.modelUsage ?? []);
+  mergeModels(models, source.modelUsage ?? []);
+  target.modelUsage = sortedModelUsage(models, false);
+  target.latency = mergeLatencyStats(target.latency, source.latency);
 }
 
 function usageBucketsInRange(
@@ -422,7 +608,7 @@ export function buildSessionCostSummaryFromRollup(params: {
     quarterTokens.set(quarter.bucketId, quarterUsage);
 
     for (const model of bucket.models) {
-      const modelBucketId = `${dayKey}\0${modelKey(model.provider, model.model)}`;
+      const modelBucketId = usageDailyModelIdentity(dayKey, model.provider, model.model);
       const existing = dailyModels.get(modelBucketId) ?? {
         date: dayKey,
         provider: model.provider,

--- a/src/shared/usage-aggregates.test.ts
+++ b/src/shared/usage-aggregates.test.ts
@@ -4,9 +4,24 @@ import {
   buildUsageAggregateTail,
   mergeUsageDailyLatency,
   mergeUsageLatency,
+  usageDailyModelIdentity,
+  usageModelIdentity,
 } from "./usage-aggregates.js";
 
 describe("shared/usage-aggregates", () => {
+  it("builds collision-free model identities with legacy unknown grouping", () => {
+    expect(usageModelIdentity("fixture", "bedrock::arn")).not.toBe(
+      usageModelIdentity("fixture::bedrock", "arn"),
+    );
+    expect(usageDailyModelIdentity("2026-02-01", "fixture", "bedrock:arn")).not.toBe(
+      usageDailyModelIdentity("2026-02-01", "fixture:bedrock", "arn"),
+    );
+    expect(usageModelIdentity("fixture\0bedrock", "arn")).not.toBe(
+      usageModelIdentity("fixture", "bedrock\0arn"),
+    );
+    expect(usageModelIdentity()).toBe(usageModelIdentity("unknown", "unknown"));
+  });
+
   it("merges latency totals and ignores empty inputs", () => {
     const totals = {
       count: 1,

--- a/src/shared/usage-aggregates.ts
+++ b/src/shared/usage-aggregates.ts
@@ -30,6 +30,16 @@ type LatencyLike = {
 
 type DailyLatencyInput = LatencyLike & { date: string };
 
+/** Builds a collision-free identity while preserving legacy missing-as-unknown grouping. */
+export function usageModelIdentity(provider?: string, model?: string): string {
+  return JSON.stringify([provider ?? "unknown", model ?? "unknown"]);
+}
+
+/** Extends the model identity with its calendar bucket without delimiter ambiguity. */
+export function usageDailyModelIdentity(date: string, provider?: string, model?: string): string {
+  return JSON.stringify([date, provider ?? "unknown", model ?? "unknown"]);
+}
+
 /** Merges latency summaries by keeping weighted averages as sum/count accumulator state. */
 export function mergeUsageLatency(
   totals: LatencyTotalsLike,

--- a/ui/src/pages/usage/metrics.test.ts
+++ b/ui/src/pages/usage/metrics.test.ts
@@ -2,6 +2,7 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  buildAggregatesFromSessions,
   buildPeakErrorHours,
   formatUsageCost,
   formatUsageTokens,
@@ -66,6 +67,64 @@ function peakErrorSummaries(result: ReturnType<typeof buildPeakErrorHours>) {
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe("usage aggregate model identity", () => {
+  it("keeps colon-bearing provider and model identities distinct", () => {
+    const session = (
+      key: string,
+      provider: string,
+      model: string,
+      dailyProvider: string,
+      dailyModel: string,
+      totalCost: number,
+    ): UsageSessionEntry => {
+      const totals = {
+        input: 1,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 1,
+        totalCost,
+        inputCost: totalCost,
+        outputCost: 0,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 0,
+      };
+      return {
+        key,
+        usage: {
+          ...totals,
+          modelUsage: [{ provider, model, count: 1, totals }],
+          dailyModelUsage: [
+            {
+              date: "2026-02-01",
+              provider: dailyProvider,
+              model: dailyModel,
+              tokens: 1,
+              cost: totalCost,
+              count: 1,
+            },
+          ],
+        },
+      };
+    };
+
+    const aggregates = buildAggregatesFromSessions([
+      session("current", "fixture", "bedrock::arn", "fixture", "bedrock:arn", 0.02),
+      session("old", "fixture::bedrock", "arn", "fixture:bedrock", "arn", 0.01),
+    ]);
+
+    expect(aggregates.byModel).toMatchObject([
+      { provider: "fixture", model: "bedrock::arn" },
+      { provider: "fixture::bedrock", model: "arn" },
+    ]);
+    expect(aggregates.modelDaily).toMatchObject([
+      { provider: "fixture", model: "bedrock:arn" },
+      { provider: "fixture:bedrock", model: "arn" },
+    ]);
+  });
 });
 
 describe("buildPeakErrorHours", () => {

--- a/ui/src/pages/usage/metrics.ts
+++ b/ui/src/pages/usage/metrics.ts
@@ -5,6 +5,8 @@ import {
   buildUsageAggregateTail,
   mergeUsageDailyLatency,
   mergeUsageLatency,
+  usageDailyModelIdentity,
+  usageModelIdentity,
 } from "../../../../src/shared/usage-aggregates.js";
 import { renderSettingsSection } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
@@ -678,7 +680,7 @@ const buildAggregatesFromSessions = (
 
     if (usage.modelUsage) {
       for (const entry of usage.modelUsage) {
-        const modelKey = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+        const modelKey = usageModelIdentity(entry.provider, entry.model);
         const modelExisting = modelMap.get(modelKey) ?? {
           provider: entry.provider,
           model: entry.model,
@@ -744,7 +746,7 @@ const buildAggregatesFromSessions = (
     }
     mergeUsageDailyLatency(dailyLatencyMap, usage.dailyLatency);
     for (const day of usage.dailyModelUsage ?? []) {
-      const key = `${day.date}::${day.provider ?? "unknown"}::${day.model ?? "unknown"}`;
+      const key = usageDailyModelIdentity(day.date, day.provider, day.model);
       const existing = modelDailyMap.get(key) ?? {
         date: day.date,
         provider: day.provider,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where distinct model/provider identities containing colons could collapse into one usage bucket, combining request counts and costs in Gateway and Control UI usage reports.

## Why This Change Was Made

Usage aggregation now carries one canonical structured model identity through the shared rollup, Gateway family/global projections, and filtered UI metrics. This removes the ambiguous delimiter key while preserving first-seen family order, count/cost sorting, unknown-model grouping, and existing JSON output contracts.

## User Impact

Operators get accurate per-model request counts and costs even when provider or model identifiers contain delimiter characters.

## Evidence

- Genuine regressions failed in both Gateway and UI before the repair and pass afterward.
- Shared, Gateway, and UI owner coverage passes: 133/133 tests.
- Assertion/max-lines ratchets, dead-code, i18n, formatting, type-aware lint, and UI stylelint pass for the exact change.
- Fresh autoreview and independent review report no actionable findings.
- Production delta: +221/-224, net -3 lines.
