### PR TITLE
feat(zai): add GLM-5.3 Flash model support

### DIFF
--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -165,18 +165,20 @@ openclaw models list --all --provider zai
 
 The manifest-backed catalog currently includes:
 
-| Model ref          | Notes                                             |
-| ------------------ | ------------------------------------------------- |
-| `zai/glm-5.3`      | Coding Plan default; 1,048,576-token context      |
-| `zai/glm-5.2`      | General API default; 1M context                   |
-| `zai/glm-5-turbo`  | OpenClaw-optimized text model; 200K context       |
-| `zai/glm-5v-turbo` | Multimodal coding model; 200K context             |
-| `zai/glm-5.1`      | Deprecated; hidden unless configured; use GLM-5.2 |
+| Model ref           | Notes                                              |
+| ------------------- | -------------------------------------------------- |
+| `zai/glm-5.3`       | Coding Plan default; 1,048,576-token context       |
+| `zai/glm-5.3-flash` | Multimodal text and image model; 1,048,576 context |
+| `zai/glm-5.2`       | General API default; 1M context                    |
+| `zai/glm-5-turbo`   | OpenClaw-optimized text model; 200K context        |
+| `zai/glm-5v-turbo`  | Multimodal coding model; 200K context              |
+| `zai/glm-5.1`       | Deprecated; hidden unless configured; use GLM-5.2  |
 
 Pay-as-you-go catalog rows follow Z.AI's current
-[API pricing](https://docs.z.ai/guides/overview/pricing). GLM-5.3 is currently a
-Coding Plan model, so its local catalog cost is zero; Coding Plan subscriptions
-use plan quota instead of per-token billing. See the live
+[API pricing](https://docs.z.ai/guides/overview/pricing). GLM-5.3 Flash uses
+its pay-as-you-go list prices even when temporary discounts are available.
+GLM-5.3 is currently a Coding Plan model, so its local catalog cost is zero;
+Coding Plan subscriptions use plan quota instead of per-token billing. See the live
 [subscription page](https://z.ai/subscribe) for plan pricing and availability.
 
 <Tip>
@@ -196,11 +198,11 @@ installed version.
 ## Thinking levels
 
 <Tabs>
-  <Tab title="GLM-5.3">
+  <Tab title="GLM-5.3 and Flash">
     Levels: `low`, `high`, and `max` (default `max`). OpenClaw maps these to
-    Z.AI's `reasoning_effort` request field. An explicit `off` setting sends
-    `thinking: { type: "disabled" }`; Z.AI treats disabled thinking as its
-    lightweight `low` effort rather than disabling reasoning entirely.
+    Z.AI's `reasoning_effort` request field. An explicit `off` setting maps to
+    `reasoning_effort: "low"` because GLM-5.3 models do not support disabling
+    reasoning entirely.
   </Tab>
   <Tab title="GLM-5.2">
     Full range: `off`, `low`, `high`, `max` (default `off`). OpenClaw maps

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -122,6 +122,17 @@ describe("zai provider plugin", () => {
         },
       },
       {
+        modelId: "glm-5.3-flash",
+        providerBaseUrl: "https://api.z.ai/api/coding/paas/v4",
+        expected: {
+          baseUrl: "https://api.z.ai/api/coding/paas/v4",
+          input: ["text", "image"],
+          reasoning: true,
+          contextWindow: 1_048_576,
+          maxTokens: 131_072,
+        },
+      },
+      {
         modelId: "glm-5.2",
         providerBaseUrl: "https://api.z.ai/api/coding/paas/v4",
         expected: {
@@ -416,14 +427,19 @@ describe("zai provider plugin", () => {
       return { payload } as never;
     };
 
-    for (const [thinkingLevel, expectedEffort] of [
-      ["low", "low"],
-      ["high", "high"],
-      ["max", "max"],
+    for (const [modelId, thinkingLevel, expectedEffort] of [
+      ["glm-5.3", "off", "low"],
+      ["glm-5.3", "low", "low"],
+      ["glm-5.3", "high", "high"],
+      ["glm-5.3", "max", "max"],
+      ["glm-5.3-flash", "off", "low"],
+      ["glm-5.3-flash", "low", "low"],
+      ["glm-5.3-flash", "high", "high"],
+      ["glm-5.3-flash", "max", "max"],
     ] as const) {
       const wrapped = provider.wrapStreamFn?.({
         provider: "zai",
-        modelId: "glm-5.3",
+        modelId,
         extraParams: {},
         thinkingLevel,
         streamFn: baseStreamFn,
@@ -433,7 +449,7 @@ describe("zai provider plugin", () => {
         {
           api: "openai-completions",
           provider: "zai",
-          id: "glm-5.3",
+          id: modelId,
         } as Model<"openai-completions">,
         { messages: [] } as Context,
         {},

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -115,8 +115,9 @@ function wrapZaiStreamFn(ctx: ProviderWrapStreamFnContext) {
   let streamFn = createToolStreamWrapper(ctx.streamFn, ctx.extraParams?.tool_stream !== false);
   const preserveThinking = shouldPreserveZaiThinking(ctx.extraParams);
   const reasoningEffort = resolveZaiReasoningEffort(ctx.modelId, ctx.thinkingLevel);
+  const disableThinking = isDisabledThinkingLevel(ctx.thinkingLevel) && !reasoningEffort;
 
-  if (!isDisabledThinkingLevel(ctx.thinkingLevel) && !preserveThinking && !reasoningEffort) {
+  if (!disableThinking && !preserveThinking && !reasoningEffort) {
     return streamFn;
   }
 
@@ -125,7 +126,7 @@ function wrapZaiStreamFn(ctx: ProviderWrapStreamFnContext) {
       return;
     }
 
-    if (isDisabledThinkingLevel(ctx.thinkingLevel)) {
+    if (disableThinking) {
       payload.thinking = { type: "disabled" };
       return;
     }

--- a/extensions/zai/model-definitions.test.ts
+++ b/extensions/zai/model-definitions.test.ts
@@ -50,6 +50,20 @@ describe("zai model definitions", () => {
     });
   });
 
+  it("uses official multimodal GLM-5.3 Flash catalog metadata", () => {
+    expectZaiModelFields({
+      id: "glm-5.3-flash",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 1_048_576,
+      maxTokens: 131_072,
+      cost: { input: 0.15, output: 0.5, cacheRead: 0.03, cacheWrite: 0 },
+    });
+    expect(buildZaiCatalogModels().find((model) => model.id === "glm-5.3-flash")?.compat).toEqual({
+      codeMode: "preferred",
+    });
+  });
+
   it("uses official GLM-5.2 Coding Plan metadata", () => {
     expectZaiModelFields({
       id: "glm-5.2",

--- a/extensions/zai/onboard.test.ts
+++ b/extensions/zai/onboard.test.ts
@@ -48,7 +48,7 @@ describe("zai onboard", () => {
     });
   });
 
-  it("resolves GLM-5.3 through the selected Coding Plan or custom endpoint", async () => {
+  it("resolves GLM-5.3 models through the selected Coding Plan or custom endpoint", async () => {
     for (const [name, cfg, expectedBaseUrl] of [
       ["coding-cn", applyZaiConfig({}, { endpoint: "coding-cn" }), ZAI_CODING_CN_BASE_URL],
       [
@@ -82,7 +82,9 @@ describe("zai onboard", () => {
         );
         const registry = ModelRegistry.create(AuthStorage.inMemory(), modelsPath);
         expect(registry.getError()).toBeUndefined();
-        expect(registry.find("zai", "glm-5.3")?.baseUrl).toBe(expectedBaseUrl);
+        for (const modelId of ["glm-5.3", "glm-5.3-flash"]) {
+          expect(registry.find("zai", modelId)?.baseUrl).toBe(expectedBaseUrl);
+        }
       } finally {
         await fs.rm(dir, { recursive: true, force: true });
       }

--- a/extensions/zai/openclaw.plugin.json
+++ b/extensions/zai/openclaw.plugin.json
@@ -50,6 +50,21 @@
             "compat": { "codeMode": "preferred" }
           },
           {
+            "id": "glm-5.3-flash",
+            "name": "GLM-5.3-Flash",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1048576,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 0.15,
+              "output": 0.5,
+              "cacheRead": 0.03,
+              "cacheWrite": 0
+            },
+            "compat": { "codeMode": "preferred" }
+          },
+          {
             "id": "glm-5.2",
             "name": "GLM-5.2",
             "reasoning": true,

--- a/extensions/zai/provider-policy-api.test.ts
+++ b/extensions/zai/provider-policy-api.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { resolveThinkingProfile, resolveZaiReasoningEffort } from "./provider-policy-api.js";
 
 describe("zai provider thinking policy", () => {
-  it.each(["glm-5.3", "glm-5.3-preview"])(
+  it.each(["glm-5.3", "glm-5.3-flash", "glm-5.3-preview"])(
     "exposes GLM 5.3 effort levels and default for %s",
     (modelId) => {
       expect(resolveThinkingProfile({ provider: "zai", modelId })).toEqual({
@@ -40,6 +40,7 @@ describe("zai provider thinking policy", () => {
   });
 
   it.each([
+    ["glm-5.3", "off", "low"],
     ["glm-5.3", "minimal", "low"],
     ["glm-5.3", "low", "low"],
     ["glm-5.3", "medium", "high"],
@@ -47,6 +48,10 @@ describe("zai provider thinking policy", () => {
     ["glm-5.3", "adaptive", "max"],
     ["glm-5.3", "xhigh", "max"],
     ["glm-5.3", "max", "max"],
+    ["glm-5.3-flash", "off", "low"],
+    ["glm-5.3-flash", "low", "low"],
+    ["glm-5.3-flash", "high", "high"],
+    ["glm-5.3-flash", "max", "max"],
     ["glm-5.2", "low", "high"],
     ["glm-5.2", "max", "max"],
     ["glm-5.1", "high", undefined],

--- a/extensions/zai/provider-policy-api.ts
+++ b/extensions/zai/provider-policy-api.ts
@@ -15,6 +15,7 @@ const ZAI_REASONING_EFFORT_MAPS: Record<
 > = {
   "5.2": { low: "high", medium: "high", high: "high", adaptive: "high", xhigh: "max", max: "max" },
   "5.3": {
+    off: "low",
     minimal: "low",
     low: "low",
     medium: "high",


### PR DESCRIPTION
## What Problem This Solves

Operators could not select Z.AI's new GLM-5.3 Flash model from OpenClaw's model catalog, and GLM-5.3 requests configured with thinking off sent a disabled-thinking payload rejected by the provider.

## Why This Change Was Made

Register `glm-5.3-flash` in the Z.AI plugin-owned manifest so model discovery, onboarding, persisted registry resolution, and image capability all share one canonical catalog entry. Translate thinking off to `reasoning_effort: low` for the entire GLM-5.3 family while preserving disabled-thinking behavior for older models.

## User Impact

Users can select `zai/glm-5.3-flash` for text and image input with a 1,048,576-token context, 131,072 maximum output tokens, and durable pay-as-you-go list pricing. GLM-5.3 and Flash no longer send provider-rejected disabled-thinking requests.

## Evidence

- Real authenticated Z.AI Coding Plan request: `glm-5.3-flash`, `reasoning_effort: low`, HTTP 200, visible text `GLM_FLASH_LIVE_OK`.
- Real authenticated multimodal request: synthetic red PNG, same model and endpoint, HTTP 200, visible answer `RED`.
- `node scripts/run-vitest.mjs extensions/zai`: 6 files, 61 tests passed.
- `node scripts/check-changed.mjs -- <changed paths>`: extension production/test type checks, extension lint, metadata checks, doctor contract tests, and architecture guards all passed.
- Independent structured code review reported no actionable findings.
- Regression tests failed before the fix for missing catalog registration, lost image capability, incorrect endpoint-backed model resolution, and unsupported GLM-5.3 disabled-thinking payloads.
