### PR TITLE
refactor(agents): unify access policy across every session tool

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -12,7 +12,6 @@ import type {
   ThinkLevel,
   VerboseLevel,
 } from "../../auto-reply/thinking.js";
-import { getRuntimeConfig } from "../../config/config.js";
 import {
   patchSessionEntryWithKey,
   resolveSessionStorePathCore,
@@ -95,13 +94,11 @@ import {
   resolveStoreScopedRequesterKey,
 } from "./session-status-session-resolve.js";
 import {
-  createAgentToAgentPolicy,
   formatSessionToolAccessDenial,
   resolveCurrentSessionClientAlias,
-  resolveEffectiveSessionToolsVisibility,
-  resolveSandboxedSessionToolContext,
   resolveSessionReference,
   resolveSessionToolAccess,
+  resolveSessionToolContext,
   resolveVisibleSessionReference,
   shouldResolveSessionIdInput,
 } from "./sessions-helpers.js";
@@ -597,15 +594,16 @@ export function createSessionStatusTool(opts?: {
       const params = args as Record<string, unknown>;
       const gatewayCall = opts?.callGateway ?? callAgentToolGatewayRequest;
       const changesSince = readNonNegativeIntegerParam(params, "changesSince");
-      const cfg = opts?.config ?? getRuntimeConfig();
-      const { mainKey, alias, effectiveRequesterKey, mainSessionKey, restrictToSpawned } =
-        resolveSandboxedSessionToolContext({
-          cfg,
-          agentSessionKey: opts?.agentSessionKey,
-          requesterAgentId: opts?.requesterAgentIdOverride,
-          sandboxed: opts?.sandboxed,
-        });
-      const a2aPolicy = createAgentToAgentPolicy(cfg);
+      const {
+        cfg,
+        mainKey,
+        alias,
+        effectiveRequesterKey,
+        mainSessionKey,
+        restrictToSpawned,
+        sessionVisibility,
+        a2aPolicy,
+      } = resolveSessionToolContext(opts);
       const requesterAgentId = resolveSessionAgentIds({
         config: cfg,
         sessionKey: opts?.agentSessionKey ?? effectiveRequesterKey,
@@ -650,10 +648,6 @@ export function createSessionStatusTool(opts?: {
         }
         return trimmed;
       };
-      const sessionVisibility = resolveEffectiveSessionToolsVisibility({
-        cfg,
-        sandboxed: opts?.sandboxed === true,
-      });
       const accessByTarget = new Map<
         string,
         Awaited<ReturnType<typeof resolveSessionToolAccess>>

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -12,7 +12,11 @@ import type { FastModeSource } from "../../shared/fast-mode.js";
  *
  * Keeps list/send/status tools aligned on rows, visibility context, and compact kind/channel labels.
  */
-import { resolveSandboxedSessionToolContext } from "./sessions-access.js";
+import {
+  createAgentToAgentPolicy,
+  resolveEffectiveSessionToolsVisibility,
+  resolveSandboxedSessionToolContext,
+} from "./sessions-access.js";
 export {
   createAgentToAgentPolicy,
   createSessionVisibilityRowChecker,
@@ -148,6 +152,11 @@ export function resolveSessionToolContext(opts?: {
   const cfg = opts?.config ?? getRuntimeConfig();
   return {
     cfg,
+    a2aPolicy: createAgentToAgentPolicy(cfg),
+    sessionVisibility: resolveEffectiveSessionToolsVisibility({
+      cfg,
+      sandboxed: opts?.sandboxed === true,
+    }),
     ...resolveSandboxedSessionToolContext({
       cfg,
       agentSessionKey: opts?.agentSessionKey,

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -18,7 +18,6 @@ import {
   resolveSandboxedSessionToolContext,
 } from "./sessions-access.js";
 export {
-  createAgentToAgentPolicy,
   createSessionVisibilityRowChecker,
   formatSessionToolAccessDenial,
   recordSessionToolActionFact,

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -5,7 +5,6 @@
  */
 import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
 import { Type } from "typebox";
-import { getRuntimeConfig } from "../../config/config.js";
 import { resolvePersistedSessionStoreOwnerForKey } from "../../config/sessions/session-store-owner.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { capArrayByJsonBytes } from "../../gateway/session-transcript-readers.js";
@@ -39,12 +38,10 @@ import {
 } from "./scoped-session-access.js";
 import {
   createSessionVisibilityRowChecker,
-  createAgentToAgentPolicy,
   formatSessionToolAccessDenial,
-  resolveEffectiveSessionToolsVisibility,
   resolveSessionReference,
-  resolveSandboxedSessionToolContext,
   resolveSessionToolAccess,
+  resolveSessionToolContext,
   resolveVisibleSessionReference,
   shouldResolveSessionIdInput,
 } from "./sessions-helpers.js";
@@ -394,14 +391,16 @@ export function createSessionsHistoryTool(opts?: {
         throw new ToolInputError("sessionId requires messageId");
       }
       const includeTools = Boolean(params.includeTools);
-      const cfg = opts?.config ?? getRuntimeConfig();
-      const { mainKey, alias, effectiveRequesterKey, mainSessionKey, restrictToSpawned } =
-        resolveSandboxedSessionToolContext({
-          cfg,
-          agentSessionKey: opts?.agentSessionKey,
-          requesterAgentId: opts?.requesterAgentIdOverride,
-          sandboxed: opts?.sandboxed,
-        });
+      const {
+        cfg,
+        mainKey,
+        alias,
+        effectiveRequesterKey,
+        mainSessionKey,
+        restrictToSpawned,
+        sessionVisibility: visibility,
+        a2aPolicy,
+      } = resolveSessionToolContext(opts);
       const requesterAgentId = resolveSessionAgentIds({
         config: cfg,
         sessionKey: effectiveRequesterKey,
@@ -436,11 +435,6 @@ export function createSessionsHistoryTool(opts?: {
       if (!resolvedSession.ok) {
         return jsonResult({ status: resolvedSession.status, error: resolvedSession.error });
       }
-      const a2aPolicy = createAgentToAgentPolicy(cfg);
-      const visibility = resolveEffectiveSessionToolsVisibility({
-        cfg,
-        sandboxed: opts?.sandboxed === true,
-      });
       const resolutionAccess = createSessionVisibilityRowChecker({
         action: "history",
         defaultAgentId:

--- a/src/agents/tools/sessions-list-tool.test.ts
+++ b/src/agents/tools/sessions-list-tool.test.ts
@@ -14,22 +14,11 @@ const SESSION_LINK_RULE = describeSessionLinkRule(SESSION_LINK_BASE);
 
 const VALID_CONFIG: OpenClawConfig = {
   agents: { entries: { main: { default: true } } },
+  tools: { sessions: { visibility: "all" } },
 };
 
 const mocks = vi.hoisted(() => ({
   gatewayCall: vi.fn(),
-  createAgentToAgentPolicy: vi.fn(() => ({})),
-  createSessionVisibilityGuard: vi.fn(async () => ({
-    check: () => ({ allowed: true }),
-  })),
-  resolveEffectiveSessionToolsVisibility: vi.fn(() => "all"),
-  resolveSandboxedSessionToolContext: vi.fn(() => ({
-    mainKey: "main",
-    alias: "main",
-    requesterInternalKey: undefined as string | undefined,
-    mainSessionKey: undefined as string | undefined,
-    restrictToSpawned: false,
-  })),
   getSessionStateVersions: vi.fn(
     (_refs: Array<{ sessionKey: string; agentId: string }>) =>
       ({}) as Record<string, Record<string, number>>,
@@ -44,17 +33,6 @@ vi.mock("../../sessions/session-state-events.js", () => ({
   getSessionStateVersions: (refs: Array<{ sessionKey: string; agentId: string }>) =>
     mocks.getSessionStateVersions(refs),
 }));
-
-vi.mock("./sessions-helpers.js", async (importActual) => {
-  const actual = await importActual<typeof import("./sessions-helpers.js")>();
-  return {
-    ...actual,
-    createAgentToAgentPolicy: () => mocks.createAgentToAgentPolicy(),
-    createSessionVisibilityGuard: async () => await mocks.createSessionVisibilityGuard(),
-    resolveEffectiveSessionToolsVisibility: () => mocks.resolveEffectiveSessionToolsVisibility(),
-    resolveSandboxedSessionToolContext: () => mocks.resolveSandboxedSessionToolContext(),
-  };
-});
 
 type SessionsListDetails = {
   sessions?: Array<{
@@ -95,18 +73,6 @@ function mockSessionPages(pages: Array<Array<Record<string, unknown>>>) {
 describe("sessions-list-tool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.createAgentToAgentPolicy.mockReturnValue({});
-    mocks.createSessionVisibilityGuard.mockResolvedValue({
-      check: () => ({ allowed: true }),
-    });
-    mocks.resolveEffectiveSessionToolsVisibility.mockReturnValue("all");
-    mocks.resolveSandboxedSessionToolContext.mockReturnValue({
-      mainKey: "main",
-      alias: "main",
-      requesterInternalKey: undefined,
-      mainSessionKey: undefined,
-      restrictToSpawned: false,
-    });
     mocks.getSessionStateVersions.mockReturnValue({});
   });
 
@@ -223,14 +189,6 @@ describe("sessions-list-tool", () => {
   });
 
   it("lists unspawned same-agent sessions from the canonical main session under tree visibility", async () => {
-    mocks.resolveEffectiveSessionToolsVisibility.mockReturnValue("tree");
-    mocks.resolveSandboxedSessionToolContext.mockReturnValue({
-      mainKey: "main",
-      alias: "main",
-      requesterInternalKey: "agent:main:main",
-      mainSessionKey: "agent:main:main",
-      restrictToSpawned: false,
-    });
     mocks.gatewayCall.mockResolvedValue({
       sessions: [
         sessionRow("agent:main:main", "main"),
@@ -250,14 +208,6 @@ describe("sessions-list-tool", () => {
   });
 
   it("keeps a sandboxed main session clamped to spawned rows", async () => {
-    mocks.resolveEffectiveSessionToolsVisibility.mockReturnValue("tree");
-    mocks.resolveSandboxedSessionToolContext.mockReturnValue({
-      mainKey: "main",
-      alias: "main",
-      requesterInternalKey: "agent:main:main",
-      mainSessionKey: undefined,
-      restrictToSpawned: true,
-    });
     mocks.gatewayCall.mockImplementation(async (request: unknown) => {
       expect(request).toEqual(
         expect.objectContaining({
@@ -706,13 +656,6 @@ describe("sessions-list-tool", () => {
   });
 
   it("keeps a bare row's gateway owner during transcript hydration", async () => {
-    mocks.resolveSandboxedSessionToolContext.mockReturnValue({
-      mainKey: "main",
-      alias: "global",
-      requesterInternalKey: "global",
-      mainSessionKey: undefined,
-      restrictToSpawned: false,
-    });
     mocks.gatewayCall
       .mockResolvedValueOnce({
         path: "/tmp/shared-sessions.sqlite",
@@ -751,13 +694,6 @@ describe("sessions-list-tool", () => {
   });
 
   it("does not attribute an ownerless fixed-store bare row to the requester", async () => {
-    mocks.resolveSandboxedSessionToolContext.mockReturnValue({
-      mainKey: "main",
-      alias: "global",
-      requesterInternalKey: "agent:research:main",
-      mainSessionKey: "global",
-      restrictToSpawned: false,
-    });
     mocks.gatewayCall.mockResolvedValue({
       path: "/tmp/ownerless-shared.sqlite",
       sessions: [

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -7,7 +7,6 @@ import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import pMap from "p-map";
 import { Type } from "typebox";
 import type { SessionRunStatus } from "../../../packages/gateway-protocol/src/schema/sessions-row.js";
-import { getRuntimeConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readSessionTitleFieldsFromTranscriptAsync } from "../../gateway/session-transcript-title-reader.js";
@@ -41,14 +40,12 @@ import {
 } from "./in-process-gateway.js";
 import { resolveSessionToolTargetAgentId } from "./scoped-session-access.js";
 import {
-  createAgentToAgentPolicy,
   createSessionVisibilityRowChecker,
   classifySessionListKind,
   deriveChannel,
   resolveDisplaySessionKey,
-  resolveEffectiveSessionToolsVisibility,
   resolveInternalSessionKey,
-  resolveSandboxedSessionToolContext,
+  resolveSessionToolContext,
   SESSION_LIST_KINDS,
   type GatewaySessionListRow,
   type SessionListRow,
@@ -158,25 +155,21 @@ export function createSessionsListTool(opts?: {
     outputSchema: SessionsListOutputSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
-      const cfg = opts?.config ?? getRuntimeConfig();
-      const { mainKey, alias, requesterInternalKey, mainSessionKey, restrictToSpawned } =
-        resolveSandboxedSessionToolContext({
-          cfg,
-          agentSessionKey: opts?.agentSessionKey,
-          requesterAgentId: opts?.requesterAgentIdOverride,
-          sandboxed: opts?.sandboxed,
-        });
-      const effectiveRequesterKey = requesterInternalKey ?? alias;
+      const {
+        cfg,
+        mainKey,
+        alias,
+        effectiveRequesterKey,
+        mainSessionKey,
+        restrictToSpawned,
+        sessionVisibility: visibility,
+        a2aPolicy,
+      } = resolveSessionToolContext(opts);
       const requesterAgentId = resolveSessionAgentIds({
         config: cfg,
         sessionKey: effectiveRequesterKey,
         agentId: opts?.requesterAgentIdOverride,
       }).sessionAgentId;
-      const visibility = resolveEffectiveSessionToolsVisibility({
-        cfg,
-        sandboxed: opts?.sandboxed === true,
-      });
-
       const kindsRaw = readStringArrayParam(params, "kinds")?.map((value) => value.toLowerCase());
       const requestedKinds = params.kinds;
       const allowedKinds =
@@ -196,7 +189,6 @@ export function createSessionsListTool(opts?: {
       const includeDerivedTitles = params.includeDerivedTitles === true;
       const includeLastMessage = params.includeLastMessage === true;
       const gatewayCall = opts?.callGateway ?? callAgentToolGatewayRequest;
-      const a2aPolicy = createAgentToAgentPolicy(cfg);
       const hydrateTranscriptFieldsAfterFiltering = includeDerivedTitles || includeLastMessage;
       const defaultAgentId = requesterAgentId;
       const visibilityGuard = createSessionVisibilityRowChecker({

--- a/src/agents/tools/sessions-search-tool.ts
+++ b/src/agents/tools/sessions-search-tool.ts
@@ -1,6 +1,5 @@
 /** Full-text search over visible session transcripts. */
 import { Type } from "typebox";
-import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { redactToolPayloadText } from "../../logging/redact.js";
@@ -33,14 +32,12 @@ import {
   runWithScopedSessionAccess,
 } from "./scoped-session-access.js";
 import {
-  createAgentToAgentPolicy,
   createSessionVisibilityRowChecker,
   formatSessionToolAccessDenial,
   resolveDisplaySessionKey,
-  resolveEffectiveSessionToolsVisibility,
-  resolveSandboxedSessionToolContext,
   resolveSessionReference,
   resolveSessionToolAccess,
+  resolveSessionToolContext,
   resolveVisibleSessionReference,
 } from "./sessions-helpers.js";
 
@@ -372,14 +369,16 @@ export function createSessionsSearchTool(opts?: {
           max: SESSIONS_SEARCH_MAX_LIMIT,
         }) ?? SESSIONS_SEARCH_DEFAULT_LIMIT;
       const requestedSessionKey = readToolStringParam(params, "sessionKey");
-      const cfg = opts?.config ?? getRuntimeConfig();
-      const { mainKey, alias, effectiveRequesterKey, mainSessionKey, restrictToSpawned } =
-        resolveSandboxedSessionToolContext({
-          cfg,
-          agentSessionKey: opts?.agentSessionKey,
-          requesterAgentId: opts?.agentId,
-          sandboxed: opts?.sandboxed,
-        });
+      const {
+        cfg,
+        mainKey,
+        alias,
+        effectiveRequesterKey,
+        mainSessionKey,
+        restrictToSpawned,
+        sessionVisibility: visibility,
+        a2aPolicy,
+      } = resolveSessionToolContext(opts);
       const requesterAgentId = resolveSessionAgentId({
         sessionKey: effectiveRequesterKey,
         config: cfg,
@@ -447,11 +446,6 @@ export function createSessionsSearchTool(opts?: {
         };
       }
 
-      const visibility = resolveEffectiveSessionToolsVisibility({
-        cfg,
-        sandboxed: opts?.sandboxed === true,
-      });
-      const a2aPolicy = createAgentToAgentPolicy(cfg);
       const defaultAgentId = requesterAgentId;
       const rowGuard = createSessionVisibilityRowChecker({
         action: "history",

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -80,12 +80,10 @@ import {
 import { runWithScopedSessionAccess } from "./scoped-session-access.js";
 import {
   createSessionVisibilityRowChecker,
-  createAgentToAgentPolicy,
   formatSessionToolAccessDenial,
   isExpectedSessionLookupMiss,
   recordSessionToolActionFact,
   resolveDisplaySessionKey,
-  resolveEffectiveSessionToolsVisibility,
   resolveSessionReference,
   resolveSessionToolAccess,
   resolveSessionToolContext,
@@ -509,8 +507,16 @@ export function createSessionsSendTool(opts?: {
       const gatewayCall = opts?.callGateway ?? callAgentToolGatewayRequest;
       const message = readToolStringParam(params, "message", { required: true });
       const timeoutSeconds = readNonNegativeIntegerParam(params, "timeoutSeconds") ?? 30;
-      const { cfg, mainKey, alias, effectiveRequesterKey, mainSessionKey, restrictToSpawned } =
-        resolveSessionToolContext(opts);
+      const {
+        cfg,
+        mainKey,
+        alias,
+        effectiveRequesterKey,
+        mainSessionKey,
+        restrictToSpawned,
+        sessionVisibility,
+        a2aPolicy,
+      } = resolveSessionToolContext(opts);
       let requesterAgentId: string;
       try {
         requesterAgentId = resolveSessionAgentId({
@@ -525,12 +531,6 @@ export function createSessionsSendTool(opts?: {
           error: formatErrorMessage(err),
         });
       }
-
-      const a2aPolicy = createAgentToAgentPolicy(cfg);
-      const sessionVisibility = resolveEffectiveSessionToolsVisibility({
-        cfg,
-        sandboxed: opts?.sandboxed === true,
-      });
 
       const sessionKeyParam = readToolStringParam(params, "sessionKey");
       const labelParam = normalizeOptionalString(readToolStringParam(params, "label"));

--- a/src/agents/tools/sessions-tool.ts
+++ b/src/agents/tools/sessions-tool.ts
@@ -9,7 +9,6 @@ import {
   SESSION_AGENT_ATTENTION_ICON_IDS,
   SESSION_ICON_GLYPH_IDS,
 } from "../../../packages/gateway-protocol/src/session-agent-status.js";
-import { getRuntimeConfig } from "../../config/config.js";
 import { resolveAgentMainSessionKey } from "../../config/sessions/main-session.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
@@ -38,10 +37,8 @@ import {
 } from "./in-process-gateway.js";
 import { resolveSessionToolTargetAgentId } from "./scoped-session-access.js";
 import {
-  createAgentToAgentPolicy,
   formatSessionToolAccessDenial,
   recordSessionToolActionFact,
-  resolveEffectiveSessionToolsVisibility,
   resolveSessionToolAccess,
   runSessionToolActionWithConflictReceipt,
 } from "./sessions-access.js";
@@ -305,11 +302,8 @@ async function resolvePatchTarget(
       targetAgentId: agentId,
       targetSessionKey: resolved.key,
       requesterOwned: resolved.requesterOwned === true,
-      visibility: resolveEffectiveSessionToolsVisibility({
-        cfg: context.cfg,
-        sandboxed: opts.sandboxed === true,
-      }),
-      a2aPolicy: createAgentToAgentPolicy(context.cfg),
+      visibility: context.sessionVisibility,
+      a2aPolicy: context.a2aPolicy,
       callGateway,
     });
     if (!access.allowed) {
@@ -349,7 +343,7 @@ export function createSessionsTool(opts: SessionsToolOptions = {}): AnyAgentTool
       if (action === "reset" || action === "delete") {
         const rawKey = readToolStringParam(params, "sessionKey", { required: true });
         const { agentId, isRequesterSession, key } = await resolvePatchTarget(
-          { ...opts, config: opts.config ?? getRuntimeConfig() },
+          opts,
           rawKey,
           gatewayRequest,
         );
@@ -442,7 +436,7 @@ export function createSessionsTool(opts: SessionsToolOptions = {}): AnyAgentTool
           throw new ToolInputError("assign_owner requires ownerType and ownerId");
         }
         const { agentId, key, requesterAgentId, requesterSessionKey } = await resolvePatchTarget(
-          { ...opts, config: opts.config ?? getRuntimeConfig() },
+          opts,
           normalizeOptionalString(readToolStringParam(params, "sessionKey")),
           gatewayRequest,
         );
@@ -491,7 +485,7 @@ export function createSessionsTool(opts: SessionsToolOptions = {}): AnyAgentTool
       }
 
       const { agentId, cfg, isRequesterSession, key } = await resolvePatchTarget(
-        { ...opts, config: opts.config ?? getRuntimeConfig() },
+        opts,
         normalizeOptionalString(readToolStringParam(params, "sessionKey")),
         gatewayRequest,
       );


### PR DESCRIPTION
Related: #114027

## What Problem This Solves

Session list, history, search, status, send, and mutation tools independently reconstructed the same requester, visibility, sandbox, and agent-to-agent access policy. That duplication makes permission refresh and cross-tool behavior more likely to drift.

## Why This Change Was Made

The existing canonical session-tool context owner now computes visibility and agent-to-agent policy once, and every session tool consumes that same prepared context. Obsolete partial mocks that replaced the real policy owner were deleted rather than maintained.

## User Impact

Session permissions, cross-agent visibility, sandbox restrictions, and immediate configuration changes remain consistent across every session action. No public behavior or configuration changes are introduced.

## Evidence

- Current candidate: `95e3175dce6cfebd81850d2394fc8a3b4a81718c`.
- 357 focused session/Gateway tests passed during recovery: 350 session-tool cases and 7 actual isolated loopback Gateway/WebSocket permission and hook cases. External agents/hooks use controlled fixtures.
- Independent owner-boundary review and fresh structured P1 review both passed.
- Production code: +69/-93 (net -24) across the canonical session policy owner and sibling tools. The final one-line cleanup removes the obsolete policy re-export identified by CI; all three unused-export scans now pass.
- Tests: net -64 lines by deleting implementation-coupled partial mocks while retaining stronger real-policy coverage.
- The initial shared install had older Google/Markdown/Pi-TUI dependencies. Recovery located an existing install with byte-identical package, lockfile, and workspace manifests; the local gate is being rechecked against that matching install. CI on the new head remains required before landing.
