### PR TITLE
Control UI: unify composer attachment chip layout

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5869,11 +5869,11 @@ describe("chat attachment picker", () => {
     expect(preview.querySelector(".chat-attachment-file__name")?.textContent).toBe("brief.pdf");
   });
 
-  it("accepts video file attachments with the generic file preview", async () => {
+  it("infers video preview glyphs from filenames when MIME is absent", async () => {
     const onAttachmentsChange = vi.fn();
     const container = renderChatView({ onAttachmentsChange });
     const input = container.querySelector<HTMLInputElement>(".agent-chat__file-input");
-    const file = new File(["video"], "clip.mp4", { type: "video/mp4" });
+    const file = new File(["video"], "clip.mp4");
 
     expect(input).toBeInstanceOf(HTMLInputElement);
     expect(input?.accept).toContain("video/*");
@@ -5883,7 +5883,7 @@ describe("chat attachment picker", () => {
       const attachments = requireFirstAttachmentsChange(onAttachmentsChange);
       expect(attachments).toHaveLength(1);
       expect(attachments[0]?.fileName).toBe("clip.mp4");
-      expect(attachments[0]?.mimeType).toBe("video/mp4");
+      expect(attachments[0]?.mimeType).toBe("application/octet-stream");
       expect(attachments[0]?.sizeBytes).toBe(file.size);
     });
 
@@ -5891,6 +5891,10 @@ describe("chat attachment picker", () => {
     const preview = renderChatView({ attachments: nextAttachments });
     expect(preview.querySelectorAll(".chat-attachment-thumb--file")).toHaveLength(1);
     expect(preview.querySelector(".chat-attachment-file__name")?.textContent).toBe("clip.mp4");
+    expect(preview.querySelector(".chat-attachment-file__icon")?.getAttribute("data-family")).toBe(
+      "video",
+    );
+    expect(preview.querySelector(".chat-attachment-file__type")?.textContent).toBe("MP4");
   });
 });
 

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -17,7 +17,7 @@ import {
   releaseChatAttachmentPayload,
 } from "../attachment-payload-store.ts";
 import { admitAttachmentFiles } from "./chat-attachment-admission.ts";
-import { renderAttachmentFileIcon } from "./chat-attachment-file-icon.ts";
+import { resolveAttachmentFileIcon } from "./chat-attachment-file-icon.ts";
 import { syncChatAttachmentRailScroll } from "./chat-attachment-viewport.ts";
 
 const CHAT_ATTACHMENT_ACCEPT =
@@ -193,6 +193,21 @@ function pastedTextPreview(attachment: ChatAttachment): string {
   return (
     pastedTextPreviews.get(attachment) ?? attachment.fileName ?? t("chat.attachments.attachedFile")
   );
+}
+
+function attachmentFileGlyph(attachment: ChatAttachment) {
+  if (attachment.mimeType.startsWith("video/")) {
+    return icons.play;
+  }
+  if (attachment.mimeType.startsWith("audio/")) {
+    return icons.music;
+  }
+  return icons.fileText;
+}
+
+function attachmentFileType(attachment: ChatAttachment): string {
+  return resolveAttachmentFileIcon(attachment.fileName ?? "attachment", attachment.mimeType)
+    .extensionLabel;
 }
 
 function appendPastedTextToDraft(draft: string, text: string): string {
@@ -685,13 +700,7 @@ export function renderAttachmentPreview(props: ChatAttachmentControlsProps) {
                   : isLargePastedTextAttachment(att)
                     ? html`
                         <div class="chat-attachment-file chat-attachment-file--pasted-text">
-                          <span class="chat-attachment-file__icon"
-                            >${renderAttachmentFileIcon({
-                              filename: att.fileName ?? "pasted-text.txt",
-                              mimeType: att.mimeType,
-                              mode: "preview-with-favicon",
-                            })}</span
-                          >
+                          <span class="chat-attachment-file__icon">${icons.fileText}</span>
                           <span class="chat-attachment-file__body">
                             <span class="chat-attachment-file__name"
                               >${pastedTextPreview(att)}</span
@@ -715,15 +724,16 @@ export function renderAttachmentPreview(props: ChatAttachmentControlsProps) {
                         >
                           <div class="chat-attachment-file">
                             <span class="chat-attachment-file__icon"
-                              >${renderAttachmentFileIcon({
-                                filename: att.fileName ?? "attachment",
-                                mimeType: att.mimeType,
-                                mode: "large-placeholder",
-                              })}</span
+                              >${attachmentFileGlyph(att)}</span
                             >
-                            <span class="chat-attachment-file__name"
-                              >${att.fileName ?? t("chat.attachments.attachedFile")}</span
-                            >
+                            <span class="chat-attachment-file__body">
+                              <span class="chat-attachment-file__name"
+                                >${att.fileName ?? t("chat.attachments.attachedFile")}</span
+                              >
+                              <span class="chat-attachment-file__type"
+                                >${attachmentFileType(att)}</span
+                              >
+                            </span>
                           </div>
                         </openclaw-tooltip>
                       `}

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -195,19 +195,30 @@ function pastedTextPreview(attachment: ChatAttachment): string {
   );
 }
 
-function attachmentFileGlyph(attachment: ChatAttachment) {
-  if (attachment.mimeType.startsWith("video/")) {
-    return icons.play;
-  }
-  if (attachment.mimeType.startsWith("audio/")) {
-    return icons.music;
-  }
-  return icons.fileText;
-}
-
-function attachmentFileType(attachment: ChatAttachment): string {
-  return resolveAttachmentFileIcon(attachment.fileName ?? "attachment", attachment.mimeType)
-    .extensionLabel;
+function renderCompactAttachmentFile(attachment: ChatAttachment) {
+  const resolved = resolveAttachmentFileIcon(
+    attachment.fileName ?? "attachment",
+    attachment.mimeType,
+  );
+  const glyph =
+    resolved.family === "video"
+      ? icons.play
+      : resolved.family === "audio"
+        ? icons.music
+        : icons.fileText;
+  return html`
+    <openclaw-tooltip .content=${attachment.fileName ?? t("chat.attachments.attachedFile")}>
+      <div class="chat-attachment-file">
+        <span class="chat-attachment-file__icon" data-family=${resolved.family}>${glyph}</span>
+        <span class="chat-attachment-file__body">
+          <span class="chat-attachment-file__name"
+            >${attachment.fileName ?? t("chat.attachments.attachedFile")}</span
+          >
+          <span class="chat-attachment-file__type">${resolved.extensionLabel}</span>
+        </span>
+      </div>
+    </openclaw-tooltip>
+  `;
 }
 
 function appendPastedTextToDraft(draft: string, text: string): string {
@@ -718,25 +729,7 @@ export function renderAttachmentPreview(props: ChatAttachmentControlsProps) {
                           </span>
                         </div>
                       `
-                    : html`
-                        <openclaw-tooltip
-                          .content=${att.fileName ?? t("chat.attachments.attachedFile")}
-                        >
-                          <div class="chat-attachment-file">
-                            <span class="chat-attachment-file__icon"
-                              >${attachmentFileGlyph(att)}</span
-                            >
-                            <span class="chat-attachment-file__body">
-                              <span class="chat-attachment-file__name"
-                                >${att.fileName ?? t("chat.attachments.attachedFile")}</span
-                              >
-                              <span class="chat-attachment-file__type"
-                                >${attachmentFileType(att)}</span
-                              >
-                            </span>
-                          </div>
-                        </openclaw-tooltip>
-                      `}
+                    : renderCompactAttachmentFile(att)}
                 <openclaw-tooltip .content=${t("chat.composer.removeAttachment")}>
                   <button
                     class="chat-attachment-remove"

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -6001,11 +6001,7 @@ button.chat-pr__diff {
 }
 
 .chat-attachment-thumb--file:is(:hover, :focus-within) .chat-attachment-file {
-  background: color-mix(
-    in srgb,
-    var(--chat-composer-surface, var(--popover)) 86%,
-    var(--text)
-  );
+  background: color-mix(in srgb, var(--chat-composer-surface, var(--popover)) 86%, var(--text));
 }
 
 .chat-attachment-file--pasted-text {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -5780,7 +5780,7 @@ button.chat-pr__diff {
   padding-block-start: 10px;
   padding-block-end: 5px;
   padding-inline: 10px;
-  margin-bottom: 8px;
+  margin-bottom: 2px;
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-inline: contain;
@@ -5820,7 +5820,7 @@ button.chat-pr__diff {
   corner-shape: superellipse(1.5);
   overflow: hidden;
   border: 1px solid var(--border);
-  background: var(--panel);
+  background: var(--chat-composer-surface, var(--popover));
   transition:
     border-color var(--duration-fast) ease,
     background var(--duration-fast) ease;
@@ -5832,13 +5832,13 @@ button.chat-pr__diff {
 }
 
 .chat-attachment-thumb--file {
-  width: 220px;
-  height: 82px;
+  width: 162px;
+  height: 56px;
 }
 
 .chat-attachment-thumb--pasted-text {
-  width: min(220px, calc(100vw - 64px));
-  background: transparent;
+  width: min(162px, calc(100vw - 64px));
+  background: var(--chat-composer-surface, var(--popover));
 }
 
 .chat-attachment-thumb--browser-annotation {
@@ -5849,7 +5849,7 @@ button.chat-pr__diff {
   max-width: min(300px, calc(100vw - 64px));
   min-width: 0;
   height: 56px;
-  background: transparent;
+  background: var(--chat-composer-surface, var(--popover));
 }
 
 .chat-browser-annotation-card__preview {
@@ -5911,7 +5911,7 @@ button.chat-pr__diff {
   object-fit: cover;
 }
 
-.chat-attachment-image-button {
+.chat-attachment-image-button.chat-attachment-image-button {
   position: relative;
   width: 100%;
   height: 100%;
@@ -5919,11 +5919,12 @@ button.chat-pr__diff {
   corner-shape: superellipse(1.5);
 }
 
-.chat-attachment-image-button::after {
+.chat-attachment-image-button.chat-attachment-image-button::after {
   content: "";
   position: absolute;
   inset: 0;
-  border-radius: inherit;
+  border-radius: calc(var(--chat-attachment-radius) - 1px);
+  corner-shape: superellipse(1.5);
   background: color-mix(in srgb, var(--text-strong) 8%, transparent);
   opacity: 0;
   pointer-events: none;
@@ -5942,7 +5943,8 @@ button.chat-pr__diff {
   width: 20px;
   height: 20px;
   padding: 0;
-  border-radius: 50%;
+  border-radius: calc(7px * var(--openclaw-corner-radius-scale));
+  corner-shape: superellipse(1.5);
   border: none;
   background: color-mix(in srgb, var(--bg) 82%, transparent);
   color: var(--text-strong);
@@ -5984,11 +5986,11 @@ button.chat-pr__diff {
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 9px;
-  width: fit-content;
+  gap: 10px;
+  width: 100%;
   max-width: 100%;
   height: 100%;
-  padding: 7px 10px;
+  padding: 8px 12px;
   overflow: hidden;
   font-size: 0.72rem;
   color: var(--text);
@@ -5999,13 +6001,17 @@ button.chat-pr__diff {
 }
 
 .chat-attachment-thumb--file:is(:hover, :focus-within) .chat-attachment-file {
-  background: color-mix(in srgb, var(--panel) 86%, var(--text));
+  background: color-mix(
+    in srgb,
+    var(--chat-composer-surface, var(--popover)) 86%,
+    var(--text)
+  );
 }
 
 .chat-attachment-file--pasted-text {
   justify-content: flex-start;
-  gap: 8px;
-  padding: 10px 42px 10px 10px;
+  gap: 10px;
+  padding: 8px 32px 8px 12px;
   background: transparent;
 }
 
@@ -6014,11 +6020,19 @@ button.chat-pr__diff {
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  color: var(--muted);
 }
 
-.chat-attachment-file--pasted-text .chat-attachment-file__icon {
-  width: 16px;
-  height: 16px;
+.chat-attachment-file__icon svg {
+  width: 20px;
+  height: 20px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.8px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .chat-attachment-file__name {
@@ -6030,17 +6044,26 @@ button.chat-pr__diff {
 }
 
 .chat-attachment-file--pasted-text .chat-attachment-file__name {
-  font-size: 0.86rem;
-  line-height: 1.2;
+  font-size: 0.72rem;
+  line-height: 1.15;
 }
 
 .chat-attachment-file__body {
   display: flex;
   min-width: 0;
-  max-width: 220px;
+  max-width: 100%;
   flex-direction: column;
   justify-content: center;
   gap: 3px;
+}
+
+.chat-attachment-file__type {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 0.64rem;
+  line-height: 1.1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .chat-attachment-text-action {
@@ -6055,10 +6078,14 @@ button.chat-pr__diff {
   background: transparent;
   cursor: var(--cursor-action);
   font: inherit;
+  overflow: hidden;
+  font-size: 0.64rem;
   line-height: 1.15;
   text-align: left;
+  text-overflow: ellipsis;
   text-decoration: underline;
   text-underline-offset: 2px;
+  white-space: nowrap;
 }
 
 .chat-attachment-text-action:hover {


### PR DESCRIPTION
## What Problem This Solves

Composer attachments currently use inconsistent footprints: image thumbnails are compact, while video, audio, pasted text, and document chips are substantially larger and use oversized file artwork. Mixed attachment sets become visually uneven and consume too much composer space.

## Why This Change Was Made

This PR gives composer attachment chips one compact geometry, uses the existing Control UI glyphs for video, audio, and documents, and reuses the canonical attachment resolver for the file-type label. Image hover geometry follows the thumbnail shape, pasted text keeps its `Show in text field` action, and chip surfaces inherit the active composer theme.

The shared attachment renderer continues to serve both the chat and new-session composers. No fixture or mock scaffolding is included.

## User Impact

- Mixed image, pasted-text, video, audio, PDF, and generic-file attachments align in one consistent row.
- File chips show a restrained glyph, filename, and type label.
- Pasted text remains identifiable by its content preview and keeps the underlined recovery action.
- Attachment backgrounds and hover states follow the composer surface across dark and light themes.
- The attachment rail sits closer to the editable field without changing attachment behavior.

## Evidence

All screenshots use deterministic mock-only files and are cropped to the attachment rail; they contain no credentials, personal data, or external content.

### Dark theme

| Before | After |
| --- | --- |
| <img width="1532" height="194" alt="Composer attachments before, dark theme" src="https://github.com/user-attachments/assets/c14114e0-bf18-4255-884e-42e3ac4fdda1" /> | <img width="1532" height="142" alt="Composer attachments after, dark theme" src="https://github.com/user-attachments/assets/2665e89c-5378-4f95-ba20-cb7ba4b811c2" /> |

### Light theme

| Before | After |
| --- | --- |
| <img width="1532" height="194" alt="Composer attachments before, light theme" src="https://github.com/user-attachments/assets/52d7d6fe-64a7-4a43-9343-75713b34496d" /> | <img width="1532" height="142" alt="Composer attachments after, light theme" src="https://github.com/user-attachments/assets/b6abf3cd-8581-43c0-8b36-a3276176f2ed" /> |

- Real Control UI mock: before from current `origin/main`; after from the approved attachment bench on `127.0.0.1:5223`.
- Representative row: image thumbnails, pasted text, screen recording/video, audio, PDF, and generic archive.
- Existing coverage owns file admission, video admission, pasted-text preview, and `Show in text field` behavior.
- Local gates intentionally not run; validation is delegated to the remote lander as requested.
