### PR TITLE
fix(onboard): SSH tunnel hints use HTTPS for TLS gateways

### DIFF
--- a/src/commands/dashboard.links.test.ts
+++ b/src/commands/dashboard.links.test.ts
@@ -71,14 +71,20 @@ function expectNoLogWith(text: string): void {
   expect(logMessages().join("\n")).not.toContain(text);
 }
 
-function mockSnapshot(token: unknown = "abc") {
+function mockSnapshot(
+  token: unknown = "abc",
+  gatewayOptions?: {
+    controlUi?: { basePath: string };
+    tls?: { enabled: boolean };
+  },
+) {
   readConfigFileSnapshotMock.mockResolvedValue({
     path: "/tmp/openclaw.json",
     exists: true,
     raw: "{}",
     parsed: {},
     valid: true,
-    config: { gateway: { auth: { token } } },
+    config: { gateway: { auth: { token }, ...gatewayOptions } },
     issues: [],
     legacyIssues: [],
   });
@@ -216,6 +222,30 @@ describe("dashboardCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith("ssh hint");
   });
 
+  it("preserves Gateway TLS after remote browser delivery fails", async () => {
+    vi.stubEnv("SSH_CONNECTION", "192.0.2.1 12345 192.0.2.2 22");
+    mockSnapshot("shhhh", {
+      controlUi: { basePath: "/control" },
+      tls: { enabled: true },
+    });
+    resolveControlUiLinksMock.mockReturnValue({
+      httpUrl: "https://127.0.0.1:18789/control/",
+      wsUrl: "wss://127.0.0.1:18789/control",
+    });
+    copyToClipboardMock.mockResolvedValue(false);
+    detectBrowserOpenSupportMock.mockResolvedValue({ ok: true });
+    openUrlMock.mockResolvedValue(false);
+    formatControlUiSshHintMock.mockReturnValue("ssh hint");
+
+    await dashboardCommand(runtime);
+
+    expect(formatControlUiSshHintMock).toHaveBeenCalledWith({
+      port: 18789,
+      basePath: "/control",
+      tlsEnabled: true,
+    });
+  });
+
   it("reports opener failure without claiming the host has no GUI", async () => {
     mockSnapshot("shhhh");
     copyToClipboardMock.mockResolvedValue(true);
@@ -243,6 +273,7 @@ describe("dashboardCommand", () => {
     expect(formatControlUiSshHintMock).toHaveBeenCalledWith({
       port: 18789,
       basePath: undefined,
+      tlsEnabled: false,
     });
     expect(runtime.log).toHaveBeenCalledWith("ssh hint");
   });
@@ -259,7 +290,11 @@ describe("dashboardCommand", () => {
     // formatControlUiSshHint must NOT receive the token — the returned
     // hint string is written to runtime.log, which flows into the same
     // console-captured log file readable by operator.read-scoped devices.
-    expect(formatControlUiSshHintMock).toHaveBeenCalledWith({ port: 18789, basePath: undefined });
+    expect(formatControlUiSshHintMock).toHaveBeenCalledWith({
+      port: 18789,
+      basePath: undefined,
+      tlsEnabled: false,
+    });
     const [sshHintOptions] = formatControlUiSshHintMock.mock.calls[0] ?? [];
     expect(sshHintOptions).not.toHaveProperty("token");
 

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -186,7 +186,7 @@ export async function dashboardCommand(
     runtime.log("Run `openclaw doctor`, then retry `openclaw dashboard`.");
     return;
   }
-  const { port, basePath, links, includeTokenInUrl } = target;
+  const { port, basePath, links, includeTokenInUrl, tlsConfig } = target;
 
   runtime.log(`Dashboard URL: ${links.httpUrl}`);
   runtime.log("One-time browser pairing included in browser/clipboard URL.");
@@ -204,6 +204,7 @@ export async function dashboardCommand(
         hint = formatControlUiSshHint({
           port,
           basePath,
+          tlsEnabled: tlsConfig?.enabled === true,
         });
       } else {
         hint = opened
@@ -216,6 +217,7 @@ export async function dashboardCommand(
       hint = formatControlUiSshHint({
         port,
         basePath,
+        tlsEnabled: tlsConfig?.enabled === true,
       });
     }
   } else {

--- a/src/commands/onboard-browser-handoff.test.ts
+++ b/src/commands/onboard-browser-handoff.test.ts
@@ -247,6 +247,37 @@ describe("runBrowserHatchHandoff", () => {
     expect(displayed).not.toContain("#bootstrapToken=");
   });
 
+  it("prints an HTTPS tunnel destination for a headless loopback TLS Gateway", async () => {
+    const prompter = createWizardPrompter();
+    const config = {
+      gateway: {
+        port: 18789,
+        bind: "loopback" as const,
+        controlUi: { basePath: "/control" },
+        tls: { enabled: true },
+      },
+    };
+
+    await runBrowserHatchHandoff(
+      { config, prompter },
+      {
+        env: {},
+        platform: "linux",
+        waitForDocument: async () => ({ ready: true }),
+        verifyLoopbackAlias: async () => true,
+        probePresence: async () => ({ reachable: true, clientKeys: [] }),
+        pollForClient: async () => ({ connected: false, reason: "timeout" }),
+      },
+    );
+
+    const displayed = vi
+      .mocked(prompter.note)
+      .mock.calls.map(([message]) => message)
+      .join("\n");
+    expect(displayed).toContain("https://localhost:18789/control/");
+    expect(displayed).not.toContain("http://localhost:18789/control/");
+  });
+
   it.each([
     {
       openerOutcome: "returns false",

--- a/src/commands/onboard-browser-handoff.ts
+++ b/src/commands/onboard-browser-handoff.ts
@@ -108,6 +108,7 @@ async function resolveBrowserHatchTarget(
           sshHint: formatControlUiSshHint({
             port: shared.port,
             ...(shared.basePath ? { basePath: shared.basePath } : {}),
+            tlsEnabled: shared.tlsConfig?.enabled === true,
           }),
         }
       : {}),
@@ -300,6 +301,7 @@ export async function runBrowserHatchHandoff(
                 ...(target.config.gateway?.controlUi?.basePath
                   ? { basePath: target.config.gateway.controlUi.basePath }
                   : {}),
+                tlsEnabled: target.tlsConfig?.enabled === true,
               })
             : undefined))
         : undefined;

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -533,8 +533,39 @@ describe("resolveBrowserOpenCommand", () => {
 });
 
 describe("formatControlUiSshHint", () => {
+  it.each([
+    {
+      label: "plain HTTP root",
+      tlsEnabled: false,
+      basePath: undefined,
+      expectedUrl: "http://localhost:18789/",
+    },
+    {
+      label: "plain HTTP base path",
+      tlsEnabled: false,
+      basePath: "/control",
+      expectedUrl: "http://localhost:18789/control/",
+    },
+    {
+      label: "HTTPS root",
+      tlsEnabled: true,
+      basePath: undefined,
+      expectedUrl: "https://localhost:18789/",
+    },
+    {
+      label: "HTTPS base path",
+      tlsEnabled: true,
+      basePath: "/control",
+      expectedUrl: "https://localhost:18789/control/",
+    },
+  ])("uses the Gateway transport for $label", ({ tlsEnabled, basePath, expectedUrl }) => {
+    const hint = formatControlUiSshHint({ port: 18789, basePath, tlsEnabled });
+
+    expect(hint).toContain(`Then open:\n${expectedUrl}`);
+  });
+
   it("includes the IPv4-only BYOH note and workaround", () => {
-    const hint = formatControlUiSshHint({ port: 18789 });
+    const hint = formatControlUiSshHint({ port: 18789, tlsEnabled: false });
     expect(hint).toContain("BYOH note: lan, tailnet, and custom bind are currently IPv4-only.");
     expect(hint).toContain(
       "If your host is IPv6-only, use an IPv4 sidecar or proxy in front of the Gateway.",

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -187,10 +187,15 @@ export function applyWizardMetadata(
 }
 
 /** Formats the no-GUI SSH tunnel hint for opening the Control UI remotely. */
-export function formatControlUiSshHint(params: { port: number; basePath?: string }): string {
+export function formatControlUiSshHint(params: {
+  port: number;
+  basePath?: string;
+  tlsEnabled: boolean;
+}): string {
   const basePath = normalizeControlUiBasePath(params.basePath);
   const uiPath = basePath ? `${basePath}/` : "/";
-  const localUrl = `http://localhost:${params.port}${uiPath}`;
+  const protocol = params.tlsEnabled ? "https" : "http";
+  const localUrl = `${protocol}://localhost:${params.port}${uiPath}`;
   const sshTarget = resolveSshTargetHint();
   return [
     "No GUI detected. Open from your computer:",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators opening a TLS-enabled Gateway through the no-GUI SSH tunnel handoff were told to open an `http://localhost` URL. TLS Gateways accept HTTPS only, so the displayed destination failed even though the forwarding command was correct.

## Why This Change Was Made

The shared SSH hint formatter now requires the resolved Gateway TLS state and selects HTTP or HTTPS from that canonical input. Guided onboarding and both dashboard fallback branches pass the handoff target's TLS state; the SSH forwarding target, base-path handling, and plaintext behavior stay unchanged.

The HTTP-only hint predates Gateway TLS dashboard support. PR #71499 made canonical dashboard links TLS-aware but did not update this shared tunnel destination.

## User Impact

Headless and remote operators can open the displayed SSH tunnel URL directly for both plaintext and TLS-enabled Gateways, including dashboards mounted at a custom base path.

## Evidence

- Before the fix, owner regressions showed `http://localhost:18789/control/` for a headless loopback TLS Gateway and omitted TLS from both dashboard formatter calls.
- After the fix, 118 focused command tests pass across SSH formatting, browser handoff, dashboard fallbacks, JSON handoff, and Control UI target ownership.
- Formatter coverage exercises HTTP/HTTPS × root/custom base path; onboarding renders the HTTPS tunnel URL; dashboard preserves TLS after remote browser and clipboard delivery fail.
- `node scripts/check-changed.mjs -- <six changed paths>` passes the complete `core, coreTests` gate, including formatting, lint, core/core-test typechecks, dead exports, import cycles, and persistence/security guards.
- Fresh Codex autoreview on exact head `89bd0490e0803778c960451a0ec3754c1ccaba1c` reported no accepted findings, confidence 0.96.
