### PR TITLE
fix(qa): restore TUI PTY maturity evidence

### DIFF
--- a/qa/scenarios/ui/tui-local-shell-pty.yaml
+++ b/qa/scenarios/ui/tui-local-shell-pty.yaml
@@ -36,10 +36,10 @@ scenario:
           testNamePattern: ^TUI PTY real backends keeps whitespace-prefixed bang input in chat after local shell approval$
         - coverageId: tui.approval-prompt
           testFile: src/tui/tui-pty-local.e2e.test.ts
-          testNamePattern: ^TUI PTY real backends confirms and renders local shell output and environment through a real local PTY$
+          testNamePattern: ^TUI PTY real backends confirms and renders local shell output, then extinguishes descendants before TUI exit$
         - coverageId: tui.command-output-display
           testFile: src/tui/tui-pty-local.e2e.test.ts
-          testNamePattern: ^TUI PTY real backends confirms and renders local shell output and environment through a real local PTY$
+          testNamePattern: ^TUI PTY real backends confirms and renders local shell output, then extinguishes descendants before TUI exit$
         - coverageId: tui.execution-environment-marker
           testFile: src/tui/tui-pty-local.e2e.test.ts
-          testNamePattern: ^TUI PTY real backends confirms and renders local shell output and environment through a real local PTY$
+          testNamePattern: ^TUI PTY real backends confirms and renders local shell output, then extinguishes descendants before TUI exit$

--- a/qa/scenarios/ui/tui-session-management-pty.yaml
+++ b/qa/scenarios/ui/tui-session-management-pty.yaml
@@ -32,4 +32,4 @@ scenario:
           testNamePattern: ^TUI PTY real backends lists local session history through a real PTY$
         - coverageId: tui.resume
           testFile: src/tui/tui-pty-local.e2e.test.ts
-          testNamePattern: ^TUI PTY real backends with shared Gateway fixture restores the remembered Gateway session and history after a real TUI relaunch$
+          testNamePattern: ^TUI PTY real backends with shared Gateway fixture gates input while a real Gateway restores the remembered session and history$


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the maturity scorecard's TUI local-shell and session-management scenarios failed even though their real PTY assertions passed, after those assertions were renamed to cover descendant cleanup and startup input gating.

## Why This Change Was Made

The four stale coverage mappings now select their assertions' current full names. This preserves exact assertion authentication and does not weaken or broaden the evidence match.

## User Impact

Maintainers can run the affected TUI maturity scenarios without false failures caused by stale evidence metadata.

## Evidence

- Failures reproduced in QA Profile Evidence run 32992034783:
  - `tui-local-shell-pty` reported no passed assertion matching the stale local-shell title.
  - `tui-session-management-pty` reported no passed assertion matching the stale remembered-session title while its other two selected PTY assertions passed.
- Current assertions are:
  - `TUI PTY real backends confirms and renders local shell output, then extinguishes descendants before TUI exit`.
  - `TUI PTY real backends with shared Gateway fixture gates input while a real Gateway restores the remembered session and history`.
- `git diff --check` passes.
- Focused local Vitest was unavailable in the isolated worktree because dependencies are intentionally not reconciled there; exact-head CI is the execution proof.
- Production LOC: +0/-0. QA scenario metadata: +4/-4.

Provenance: clearly made visible by #127652 and #126046; code author , commits merged through GitHub's web-flow identity. Both runtime tests were strengthened but their exact-name evidence mappings were not updated.

