### PR TITLE
fix(qa): stop rejecting unrelated decision receipts

### DIFF
--- a/qa/scenarios/runtime/autonomous-task-lifecycle-receipts.yaml
+++ b/qa/scenarios/runtime/autonomous-task-lifecycle-receipts.yaml
@@ -13,7 +13,7 @@ scenario:
     - A real forced scheduled agent run binds one exact context/execution to its cron receipt and task row.
     - A real Gateway agent action binds one exact context/execution to its CLI task row; focused owner tests cover bound flow rows.
     - JSON and human audit inspection expose only bounded attribution-only lifecycle displays with closed producers, accept the cron cursor prefix, and omit task/prompt content.
-    - A replacement Gateway returns byte-equivalent JSON and the generic decision-fact table remains empty.
+    - A replacement Gateway returns byte-equivalent JSON and owner-native lifecycle rows have no matching generic decision-fact copies.
   docsRefs:
     - docs/gateway/audit.md
     - docs/cli/audit.md

--- a/test/e2e/qa-lab/runtime/autonomous-task-lifecycle-receipts.ts
+++ b/test/e2e/qa-lab/runtime/autonomous-task-lifecycle-receipts.ts
@@ -439,11 +439,36 @@ async function runProof(options: ProducerOptions): Promise<string> {
     }
 
     const db = new DatabaseSync(stateDatabasePath(gateway), { readOnly: true });
-    let genericCount = 0;
+    let duplicatedOwnerCount = 0;
     try {
-      if (hasSqliteColumns(db, "execution_decision_facts", ["receipt_id"])) {
-        genericCount = (
-          db.prepare("SELECT COUNT(*) AS count FROM execution_decision_facts").get() as {
+      if (
+        hasSqliteColumns(db, "execution_decision_facts", [
+          "context_id",
+          "execution_id",
+          "owner",
+          "source_ref",
+        ]) &&
+        hasSqliteColumns(db, "execution_owner_lifecycle_bindings", [
+          "context_id",
+          "execution_id",
+          "owner_id",
+          "owner_kind",
+        ])
+      ) {
+        duplicatedOwnerCount = (
+          db
+            .prepare(
+              `SELECT COUNT(*) AS count
+               FROM execution_decision_facts AS fact
+               JOIN execution_owner_lifecycle_bindings AS binding
+                 ON binding.context_id = fact.context_id
+                AND binding.execution_id = fact.execution_id
+                AND binding.owner_id = fact.source_ref
+               WHERE (binding.owner_kind = 'cron' AND fact.owner = 'cron_run_receipts')
+                  OR (binding.owner_kind = 'task' AND fact.owner = 'task_runs')
+                  OR (binding.owner_kind = 'flow' AND fact.owner = 'flow_runs')`,
+            )
+            .get() as {
             count: number;
           }
         ).count;
@@ -451,7 +476,7 @@ async function runProof(options: ProducerOptions): Promise<string> {
     } finally {
       db.close();
     }
-    if (genericCount !== 0) {
+    if (duplicatedOwnerCount !== 0) {
       throw new Error("owner lifecycle rows were duplicated into execution_decision_facts");
     }
 

--- a/test/e2e/qa-lab/runtime/autonomous-task-lifecycle-receipts.ts
+++ b/test/e2e/qa-lab/runtime/autonomous-task-lifecycle-receipts.ts
@@ -500,7 +500,7 @@ async function runProof(options: ProducerOptions): Promise<string> {
             displayProducers: ["task-lifecycle"],
           },
           cursorCompatibility: { cronPrefixAccepted: true },
-          genericDuplicateAbsent: true,
+          ownerLifecycleDuplicateAbsent: true,
           byteEquivalentAfterRestart: true,
           privacy: { cronPromptAbsent: true, taskPromptAbsent: true },
           resultSha256: sha256(afterRestart),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the autonomous lifecycle maturity scenario failed whenever any legitimate generic decision receipt existed in the isolated Gateway database, even when cron/task lifecycle rows were correctly stored only in their owner-native tables.

## Why This Change Was Made

The negative assertion now checks the actual forbidden duplication contract: a generic decision fact must match the same lifecycle binding, exact execution/context, owner table, and owner record reference before it is counted as a duplicate. Unrelated generic receipts remain valid evidence and no longer fail the lifecycle scenario.

## User Impact

Maintainers can run the autonomous lifecycle maturity proof alongside other audit producers without a false failure from unrelated generic decision facts.

## Evidence

- Failure reproduced in QA Profile Evidence run 32992034783: the scenario rejected a nonzero global `execution_decision_facts` count.
- Source inspection confirms owner-native projections are keyed by `execution_owner_lifecycle_bindings`, while generic receipts are a separately valid decision surface.
- `oxfmt --check test/e2e/qa-lab/runtime/autonomous-task-lifecycle-receipts.ts` passes using the normal checkout's installed formatter.
- `git diff --check` passes.
- Focused runtime execution is delegated to exact-head CI because isolated worktrees intentionally do not reconcile dependencies.
- Production LOC: +0/-0. QA producer: +30/-5.

Provenance: clearly introduced by #126082 on 2026-08-24; code author @joshavant. The original producer asserted that the entire generic table must be empty instead of identifying an owner-native duplicate.
