### PR TITLE
refactor(qa-lab): reuse model reference splitter

### DIFF
--- a/extensions/qa-lab/src/model-catalog.runtime.test.ts
+++ b/extensions/qa-lab/src/model-catalog.runtime.test.ts
@@ -53,8 +53,11 @@ describe("qa runner model catalog", () => {
     );
 
     await expect(loadQaRunnerModelOptions({ repoRoot })).resolves.toEqual([
-      expect.objectContaining({ key: "openai/gpt-5.6-luna" }),
-      expect.objectContaining({ key: "anthropic/claude-sonnet-4-6" }),
+      expect.objectContaining({ key: "openai/gpt-5.6-luna", provider: "openai" }),
+      expect.objectContaining({
+        key: "anthropic/claude-sonnet-4-6",
+        provider: "anthropic",
+      }),
     ]);
   });
 

--- a/extensions/qa-lab/src/model-catalog.runtime.ts
+++ b/extensions/qa-lab/src/model-catalog.runtime.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { runCommandWithTimeout } from "openclaw/plugin-sdk/process-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { QA_CHILD_STDERR_TAIL_BYTES, QA_CHILD_STDOUT_MAX_BYTES } from "./child-output.js";
+import { splitQaModelRef } from "./model-selection.js";
 import { resolveQaNodeExecPath } from "./node-exec.js";
 import {
   isPreferredQaLiveFrontierCatalogModel,
@@ -33,22 +34,11 @@ export type QaRunnerModelOption = {
   preferred: boolean;
 };
 
-function splitModelKey(key: string) {
-  const slash = key.indexOf("/");
-  if (slash <= 0 || slash === key.length - 1) {
-    return null;
-  }
-  return {
-    provider: key.slice(0, slash),
-    model: key.slice(slash + 1),
-  };
-}
-
 function selectQaRunnerModelOptions(rows: ModelRow[]): QaRunnerModelOption[] {
   const options = rows
     .filter((row) => row.available === true && !row.missing)
     .map((row) => {
-      const parsed = splitModelKey(row.key);
+      const parsed = splitQaModelRef(row.key);
       return {
         key: row.key,
         name: row.name,


### PR DESCRIPTION
## What Problem This Solves

The QA runner model catalog maintained a second parser for `provider/model` references beside the established QA model-selection parser. Keeping both implementations made a simple internal contract easier to drift.

## Why This Change Was Made

The catalog now reuses the plugin-owned `splitQaModelRef` helper and removes its private duplicate. Catalog coverage also asserts the parsed provider for OpenAI and Anthropic rows.

The canonical owner remains inside the QA Lab plugin. No SDK, package export, config, persistence, protocol, or user-visible behavior changes.

## User Impact

No user-visible behavior change. QA model catalog parsing now has one canonical implementation.

## Evidence

- Exact pushed head: `4a7735098972179056711b25acb10775c1563082`
- `node_modules/.bin/oxfmt --check extensions/qa-lab/src/model-catalog.runtime.ts extensions/qa-lab/src/model-catalog.runtime.test.ts`
- `pnpm exec vitest run extensions/qa-lab/src/model-catalog.runtime.test.ts` - 4 tests passed
- `pnpm check:import-cycles` - 0 runtime value cycles
- `pnpm check:changed` passed twice on the same patch before the final mainline refresh.
- Fresh exact-head `pnpm check:changed` reached extension typecheck, then stopped only because the shared worktree dependency symlink predates the newly merged IMAP plugin dependencies (`imapflow`, `mailauth`, `mailparser`). Per worktree policy, no install was run inside the Codex worktree; hosted CI will install the exact current lockfile.
- Fresh Autoreview: clean, 0.99, no actionable findings.
- Exact-head Blacksmith Testbox: provider `blacksmith-testbox`, lease `tbx_01m10rn5zhe0198e05s36nybfw`, Actions run `https://github.com/openclaw/openclaw/actions/runs/33040433439`. Delegated remote-fetch sync completed; expected, local, and live PR SHA were all `4a7735098972179056711b25acb10775c1563082`; focused catalog tests passed 4/4; timing receipt recorded `exitCode: 0` and `runStatus: succeeded`.
- AWS Crabbox run `run_0ba94b4e6df3`, lease `cbx_de6bb8a16264`: fresh public-network checkout, no instance role, no Tailscale, no hydration, frozen install, exact head `4a7735098972179056711b25acb10775c1563082`, 4/4 focused tests passed. Lease released after proof.
- The trusted bootstrap was uploaded with a transient `umask 022` insertion because the current AWS image otherwise creates its Node install root as root-only and cannot expose the pinned binaries to the unprivileged test user. This is a Crabbox bootstrap follow-up, not a branch change.

Root cause: two QA Lab consumers independently implemented the same slash validation and provider/model projection.

Architectural owner and canonical fix: `extensions/qa-lab/src/model-selection.ts` already owns QA model-reference parsing, so `model-catalog.runtime.ts` now imports that helper.

Removed path: the private `splitModelKey` implementation.

Production LOC: +2/-12, net -10. Tests: +5/-2.

Sibling coverage: existing model-selection callers remain unchanged; catalog tests cover both OpenAI and Anthropic provider projection. Malformed references retain the existing shared-helper behavior.

Changelog: not required for an internal behavior-neutral refactor.

ClawSweeper rank-up disposition: completed. The sole remaining move was normal maintainer review; native review artifacts record no actionable findings and recommend `READY FOR /prepare-pr`.
