### PR TITLE
fix(discord): prevent bots interrupting replies to other bots

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -589,7 +589,7 @@ Example:
     When writing outbound Discord messages, use canonical mention syntax: `<@USER_ID>` for users, `<#CHANNEL_ID>` for channels, and `<@&ROLE_ID>` for roles. Do not use the legacy `<@!USER_ID>` nickname mention form.
 
     `requireMention` is configured per guild/channel (`channels.discord.guilds...`).
-    `ignoreOtherMentions` optionally drops messages that mention another user/role but not the bot (excluding @everyone/@here).
+    `ignoreOtherMentions` optionally drops messages addressed to another identity but not the bot. This covers explicit user/role mentions (excluding @everyone/@here) and replies to another non-webhook bot. An explicit mention of the current bot still wins.
 
     Group DMs:
 

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -334,7 +334,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - Guild slugs are lowercase with spaces replaced by `-`; channel keys use the slugged name (no `#`). Prefer guild IDs.
 - Bot-authored messages are ignored by default. `allowBots: true` enables them; use `allowBots: "mentions"` to only accept bot messages that mention the bot (own messages still filtered).
 - Channels that support bot-authored inbound messages can use shared [bot loop protection](/channels/bot-loop-protection). Set `channels.defaults.botLoopProtection` for baseline pair budgets, then override the channel or account only when one surface needs different limits.
-- `channels.discord.guilds.<id>.ignoreOtherMentions` (and channel overrides) drops messages that mention another user or role but not the bot (excluding @everyone/@here).
+- `channels.discord.guilds.<id>.ignoreOtherMentions` (and channel overrides) drops messages addressed to another identity but not the bot. This covers explicit user/role mentions (excluding @everyone/@here) and replies to another non-webhook bot; an explicit mention of the current bot still wins.
 - `channels.discord.mentionAliases` maps stable outbound `@handle` text to Discord user IDs before sending, so known teammates can be mentioned deterministically even when the transient directory cache is empty. Per-account overrides live under `channels.discord.accounts.<accountId>.mentionAliases`.
 - `maxLinesPerMessage` (default `17`) splits tall messages even when under 2000 chars.
 - `channels.discord.suppressEmbeds` defaults to `true`, so outbound URLs do not expand into Discord link previews unless disabled. Explicit `embeds` payloads still send normally; per-message tool calls can override with `suppressEmbeds`.

--- a/extensions/discord/src/monitor/message-dispatcher.ts
+++ b/extensions/discord/src/monitor/message-dispatcher.ts
@@ -17,7 +17,10 @@ import type {
 import type { DiscordMessageEvent } from "./listeners.js";
 import { createDiscordAvatarResolver } from "./message-avatar.js";
 import { resolveDiscordMessageChannelId } from "./message-channel-info.js";
-import { hasDiscordMessageStickers } from "./message-forwarded.js";
+import {
+  hasDiscordMessageStickers,
+  resolveDiscordReferencedReplyMessageId,
+} from "./message-forwarded.js";
 import { applyImplicitReplyBatchGate } from "./message-handler.batch-gate.js";
 import type { DiscordMessagePreflightParams } from "./message-handler.preflight.types.js";
 import {
@@ -103,7 +106,11 @@ export function createDiscordMessageDispatcher(
       message,
       eventChannelId: entry.data.channel_id,
     });
-    return channelId ? `discord:${params.accountId}:${channelId}:${authorId}` : null;
+    if (!channelId) {
+      return null;
+    }
+    const replyTargetId = resolveDiscordReferencedReplyMessageId(message);
+    return `discord:${params.accountId}:${channelId}:${authorId}:reply:${replyTargetId ?? "none"}`;
   };
   const { debouncer } = createChannelInboundDebouncer<DiscordDebounceEntry>({
     cfg: params.cfg,

--- a/extensions/discord/src/monitor/message-forwarded.ts
+++ b/extensions/discord/src/monitor/message-forwarded.ts
@@ -91,6 +91,18 @@ export function resolveDiscordReferencedReplyMessage(message: Message): Message 
     : (message.referencedMessage ?? null);
 }
 
+export function resolveDiscordReferencedReplyMessageId(message: Message): string | null {
+  const referenceType = message.messageReference?.type;
+  if (Number(referenceType) === FORWARD_MESSAGE_REFERENCE_TYPE) {
+    return null;
+  }
+  return (
+    normalizeOptionalString(message.messageReference?.message_id) ??
+    normalizeOptionalString(message.referencedMessage?.id) ??
+    null
+  );
+}
+
 export function formatDiscordSnapshotAuthor(
   author: DiscordSnapshotAuthor | null | undefined,
 ): string | undefined {

--- a/extensions/discord/src/monitor/message-handler.debounce-reply-target.test.ts
+++ b/extensions/discord/src/monitor/message-handler.debounce-reply-target.test.ts
@@ -1,0 +1,102 @@
+// Discord tests cover debounce partitioning by reply target.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  createDiscordMessageHandler,
+  preflightDiscordMessageMock,
+  processDiscordMessageMock,
+} from "./message-handler.module-test-helpers.js";
+import {
+  createDiscordHandlerParams,
+  createDiscordPreflightContext,
+} from "./message-handler.test-helpers.js";
+
+function createTextMessageData(messageId: string, channelId = "ch-1") {
+  return {
+    channel_id: channelId,
+    author: { id: "user-1" },
+    message: {
+      id: messageId,
+      author: { id: "user-1", bot: false },
+      content: "hello",
+      channel_id: channelId,
+      attachments: [],
+    },
+  };
+}
+
+function createPreflightContext(channelId = "ch-1") {
+  const discordConfig = {
+    enabled: true,
+    token: "test-token",
+    groupPolicy: "allowlist" as const,
+  };
+  const cfg: OpenClawConfig = {
+    channels: { discord: discordConfig },
+    messages: { inbound: { debounceMs: 0 } },
+  };
+  return {
+    ...createDiscordPreflightContext(channelId),
+    cfg,
+    accountId: "default",
+    token: "test-token",
+    runtime: {
+      log: () => {},
+      error: () => {},
+      exit: (code: number): never => {
+        throw new Error(`exit ${code}`);
+      },
+    },
+    textLimit: 2_000,
+    replyToMode: "off" as const,
+    discordConfig,
+    messageText: "hello",
+    isDirectMessage: false,
+    isGuildMessage: true,
+  };
+}
+
+describe("Discord reply-target debounce partitioning", () => {
+  beforeEach(() => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+  });
+
+  it("keeps replies to a different message out of an ordinary debounced batch", async () => {
+    const params = createDiscordHandlerParams();
+    params.cfg.messages = { inbound: { debounceMs: 20 } };
+    preflightDiscordMessageMock.mockImplementation(
+      async (preflightParams: { data: ReturnType<typeof createTextMessageData> }) => ({
+        ...createPreflightContext(preflightParams.data.channel_id),
+        message: preflightParams.data.message,
+        messageText: preflightParams.data.message.content,
+      }),
+    );
+    const handler = createDiscordMessageHandler(params);
+    const ordinary = createTextMessageData("m-ordinary");
+    const reply = createTextMessageData("m-other-bot-reply");
+    Object.assign(reply.message, {
+      messageReference: {
+        type: 0,
+        message_id: "m-other-bot",
+        channel_id: reply.channel_id,
+      },
+      referencedMessage: {
+        id: "m-other-bot",
+        author: { id: "other-bot", bot: true },
+      },
+    });
+
+    await handler(ordinary as never, {} as never);
+    await handler(reply as never, {} as never);
+
+    await expect.poll(() => preflightDiscordMessageMock.mock.calls.length).toBe(2);
+    expect(
+      preflightDiscordMessageMock.mock.calls.map(
+        ([call]) =>
+          (call as { data: ReturnType<typeof createTextMessageData> }).data.message.content,
+      ),
+    ).toEqual(["hello", "hello"]);
+    expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extensions/discord/src/monitor/message-handler.preflight.test-helpers.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test-helpers.ts
@@ -64,6 +64,8 @@ export function createDiscordMessage(params: {
   };
   mentionedUsers?: Array<{ id: string }>;
   mentionedEveryone?: boolean;
+  messageReference?: import("../internal/discord.js").Message["messageReference"];
+  referencedMessage?: import("../internal/discord.js").Message;
   attachments?: Array<Record<string, unknown>>;
   webhookId?: string;
   type?: import("../internal/discord.js").MessageType;
@@ -80,6 +82,8 @@ export function createDiscordMessage(params: {
     mentionedUsers: params.mentionedUsers ?? [],
     mentionedRoles: [],
     mentionedEveryone: params.mentionedEveryone ?? false,
+    messageReference: params.messageReference,
+    referencedMessage: params.referencedMessage,
     author: params.author,
   } as unknown as import("../internal/discord.js").Message;
 }

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -1,4 +1,5 @@
 // Discord tests cover message handler.preflight plugin behavior.
+import { MessageReferenceType } from "discord-api-types/v10";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { ChannelType, MessageType } from "../internal/discord.js";
 import { createPartialDiscordChannelWithThrowingGetters } from "../test-support/partial-channel.js";
@@ -1928,6 +1929,162 @@ describe("preflightDiscordMessage", () => {
     const result = await runIgnoreOtherMentionsPreflight({ channelId, guildId, message });
 
     expect(result).toBeNull();
+  });
+
+  it("drops guild replies to another bot when ignoreOtherMentions=true", async () => {
+    const channelId = "channel-other-bot-reply";
+    const guildId = "guild-other-bot-reply";
+    const message = createDiscordMessage({
+      id: "m-other-bot-reply",
+      channelId,
+      content: "following up",
+      author: { id: "user-1", bot: false, username: "Alice" },
+      referencedMessage: createDiscordMessage({
+        id: "m-other-bot",
+        channelId,
+        content: "earlier answer",
+        author: { id: "other-bot", bot: true, username: "OtherBot" },
+      }),
+    });
+
+    expect(await runIgnoreOtherMentionsPreflight({ channelId, guildId, message })).toBeNull();
+  });
+
+  it("keeps forwarded messages from another bot when ignoreOtherMentions=true", async () => {
+    const channelId = "channel-other-bot-forward";
+    const guildId = "guild-other-bot-forward";
+    const message = createDiscordMessage({
+      id: "m-other-bot-forward",
+      channelId,
+      content: "forwarding this",
+      author: { id: "user-1", bot: false, username: "Alice" },
+      messageReference: { type: MessageReferenceType.Forward, channel_id: channelId },
+      referencedMessage: createDiscordMessage({
+        id: "m-forwarded-other-bot",
+        channelId,
+        content: "earlier answer",
+        author: { id: "other-bot", bot: true, username: "OtherBot" },
+      }),
+    });
+
+    const result = await runIgnoreOtherMentionsPreflight({ channelId, guildId, message });
+
+    expect(expectPreflightResult(result).message.id).toBe("m-other-bot-forward");
+  });
+
+  it("keeps replies to the current bot when ignoreOtherMentions=true", async () => {
+    const channelId = "channel-current-bot-reply";
+    const guildId = "guild-current-bot-reply";
+    const message = createDiscordMessage({
+      id: "m-current-bot-reply",
+      channelId,
+      content: "following up",
+      author: { id: "user-1", bot: false, username: "Alice" },
+      referencedMessage: createDiscordMessage({
+        id: "m-current-bot",
+        channelId,
+        content: "earlier answer",
+        author: { id: "openclaw-bot", bot: true, username: "OpenClaw" },
+      }),
+    });
+
+    const result = await runIgnoreOtherMentionsPreflight({ channelId, guildId, message });
+
+    expect(expectPreflightResult(result).message.id).toBe("m-current-bot-reply");
+  });
+
+  it("lets an explicit current-bot mention override a reply to another bot", async () => {
+    const channelId = "channel-other-bot-reply-override";
+    const guildId = "guild-other-bot-reply-override";
+    const message = createDiscordMessage({
+      id: "m-other-bot-reply-override",
+      channelId,
+      content: "<@openclaw-bot> please weigh in",
+      mentionedUsers: [{ id: "openclaw-bot" }],
+      author: { id: "user-1", bot: false, username: "Alice" },
+      referencedMessage: createDiscordMessage({
+        id: "m-other-bot-override-target",
+        channelId,
+        content: "earlier answer",
+        author: { id: "other-bot", bot: true, username: "OtherBot" },
+      }),
+    });
+
+    const result = await runIgnoreOtherMentionsPreflight({ channelId, guildId, message });
+
+    expect(expectPreflightResult(result).wasMentioned).toBe(true);
+  });
+
+  it("keeps replies to humans when ignoreOtherMentions=true", async () => {
+    const channelId = "channel-human-reply";
+    const guildId = "guild-human-reply";
+    const message = createDiscordMessage({
+      id: "m-human-reply",
+      channelId,
+      content: "following up",
+      author: { id: "user-1", bot: false, username: "Alice" },
+      referencedMessage: createDiscordMessage({
+        id: "m-human-target",
+        channelId,
+        content: "earlier question",
+        author: { id: "user-2", bot: false, username: "Bob" },
+      }),
+    });
+
+    expect(
+      expectPreflightResult(await runIgnoreOtherMentionsPreflight({ channelId, guildId, message }))
+        .message.id,
+    ).toBe("m-human-reply");
+  });
+
+  it("keeps replies to webhook bots when ignoreOtherMentions=true", async () => {
+    const channelId = "channel-webhook-bot-reply";
+    const guildId = "guild-webhook-bot-reply";
+    const message = createDiscordMessage({
+      id: "m-webhook-bot-reply",
+      channelId,
+      content: "following up",
+      author: { id: "user-1", bot: false, username: "Alice" },
+      referencedMessage: createDiscordMessage({
+        id: "m-webhook-bot-target",
+        channelId,
+        content: "relayed human message",
+        webhookId: "webhook-1",
+        author: { id: "webhook-bot", bot: true, username: "Webhook" },
+      }),
+    });
+
+    expect(
+      expectPreflightResult(await runIgnoreOtherMentionsPreflight({ channelId, guildId, message }))
+        .message.id,
+    ).toBe("m-webhook-bot-reply");
+  });
+
+  it("keeps replies to another bot when ignoreOtherMentions=false", async () => {
+    const channelId = "channel-other-bot-reply-open";
+    const guildId = "guild-other-bot-reply-open";
+    const message = createDiscordMessage({
+      id: "m-other-bot-reply-open",
+      channelId,
+      content: "room is open",
+      author: { id: "user-1", bot: false, username: "Alice" },
+      referencedMessage: createDiscordMessage({
+        id: "m-other-bot-open-target",
+        channelId,
+        content: "earlier answer",
+        author: { id: "other-bot", bot: true, username: "OtherBot" },
+      }),
+    });
+
+    const result = await runGuildPreflight({
+      channelId,
+      guildId,
+      message,
+      discordConfig: {} as DiscordConfig,
+      guildEntries: { [guildId]: { requireMention: false, ignoreOtherMentions: false } },
+    });
+
+    expect(expectPreflightResult(result).message.id).toBe("m-other-bot-reply-open");
   });
 
   it("records local image media for skipped mention-gated guild history", async () => {

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -35,7 +35,10 @@ import {
   resolveDiscordChannelInfo,
   resolveDiscordMessageChannelId,
 } from "./message-channel-info.js";
-import { resolveDiscordMessageStickers } from "./message-forwarded.js";
+import {
+  resolveDiscordMessageStickers,
+  resolveDiscordReferencedReplyMessage,
+} from "./message-forwarded.js";
 import { resolveDiscordDmPreflightAccess } from "./message-handler.dm-preflight.js";
 import type { DiscordHistoryEntry } from "./message-handler.history.js";
 import { hydrateDiscordMessageIfNeeded } from "./message-handler.hydration.js";
@@ -739,16 +742,24 @@ export async function preflightDiscordMessage(
   }
   const ignoreOtherMentions =
     channelConfig?.ignoreOtherMentions ?? guildInfo?.ignoreOtherMentions ?? false;
+  const referencedReply = resolveDiscordReferencedReplyMessage(message);
+  const referencedWebhookId = referencedReply ? resolveDiscordWebhookId(referencedReply) : null;
+  const referencedAuthor = referencedReply?.author;
+  const replyTargetsOtherBot =
+    Boolean(botId) &&
+    Boolean(referencedAuthor?.bot) &&
+    referencedAuthor?.id !== botId &&
+    !referencedWebhookId;
   if (
     isGuildMessage &&
     ignoreOtherMentions &&
-    hasUserOrRoleMention &&
+    (hasUserOrRoleMention || replyTargetsOtherBot) &&
     !wasMentioned &&
     !mentionDecision.implicitMention
   ) {
-    logDebug(`[discord-preflight] drop: other-mention`);
+    logDebug(`[discord-preflight] drop: addressed-to-other`);
     logVerbose(
-      `discord: drop guild message (another user/role mentioned, ignoreOtherMentions=true, botId=${botId})`,
+      `discord: drop guild message (addressed to another identity, ignoreOtherMentions=true, botId=${botId})`,
     );
     await recordDiscordPendingHistoryEntry({
       preflight: params,

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -38,7 +38,8 @@ export type DiscordDmConfig = {
 export type DiscordGuildChannelConfig = {
   requireMention?: boolean;
   /**
-   * If true, drop messages that mention another user/role but not this one (not @everyone/@here).
+   * If true, drop messages addressed to another identity by mention or bot reply, but not this
+   * bot (not @everyone/@here).
    * Default: false.
    */
   ignoreOtherMentions?: boolean;
@@ -71,7 +72,8 @@ export type DiscordGuildEntry = {
   slug?: string;
   requireMention?: boolean;
   /**
-   * If true, drop messages that mention another user/role but not this one (not @everyone/@here).
+   * If true, drop messages addressed to another identity by mention or bot reply, but not this
+   * bot (not @everyone/@here).
    * Default: false.
    */
   ignoreOtherMentions?: boolean;


### PR DESCRIPTION
Related: #13487

## What Problem This Solves

Fixes an issue where an ambient Discord bot could still process a reply addressed to a different bot in the same guild channel, causing an unnecessary second model turn or competing response.

## Why This Change Was Made

The existing opt-in `ignoreOtherMentions` preflight gate now treats a reply to another non-webhook bot as addressed elsewhere. An explicit mention of the current bot still overrides suppression. Discord debounce batches are partitioned by genuine reply target so the preflight decision cannot be smeared across an adjacent ordinary message. Defaults, open-room behavior, forwards, human replies, webhook replies, and reply-to-current-bot behavior remain unchanged.

This deliberately extends the existing Discord policy seam instead of introducing cross-account routing or a new policy engine. The earlier overlapping PRs #47393 and #67460 are closed; this change is narrower and composes with the current provider preflight.

## User Impact

Operators can keep conversational multi-bot Discord rooms ambient while preventing bots from barging into replies intended for another bot. Setting `ignoreOtherMentions: false` preserves the previous permissive behavior.

## Evidence

- **Real Discord red/green proof:** an isolated Gateway used the real Discord transport in a private multi-bot guild channel with `allowBots: true`, `requireMention: false`, and `ignoreOtherMentions: true`. Discord's automatic replied-user mention was disabled so the test exercised reply targeting rather than the existing mention gate.
  - Current main `0594a100d9710a94cd8c80d72713a3565eefd2ff`: the unmentioned reply reached the model once and produced one bot reply.
  - Proofed PR head `b33ad807e7ce5e6501fc72bf1771bde21c6bf540`: preflight recorded `wasMentioned=false` and `drop: addressed-to-other`; the reply produced zero model requests and zero bot replies.
  - Landing head `476e89d713367b86a3fc8479090280f28d1a80ce` replays the same two contributor commits onto current main. The stable patch ID is unchanged, and current main added no behavior change to the Discord owner files.
  - Anti-cheat control on both revisions: explicitly mentioning the OpenClaw bot on the same reply path produced one model request and one visible `OPENCLAW_E2E_OK` reply.
  - Cleanup: each run deleted its four test messages, stopped its isolated Gateway and mock provider, and released its QA bot lease.
- **Fresh landing-head CI:** run `33317478099` completed successfully on `476e89d713367b86a3fc8479090280f28d1a80ce`. The full check set passed or was intentionally skipped, including production and test type checks, lint, guards, security scans, build artifacts, Discord extension shards, and `openclaw/ci-gate`.
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.preflight.test.ts extensions/discord/src/monitor/message-handler.debounce-reply-target.test.ts` — 71/71 passed on landing head `476e89d713367b86a3fc8479090280f28d1a80ce`.
- `pnpm test:extension discord` — 3,041/3,041 tests passed across 236 files on the behavior-identical predecessor tree; the final commit only moves the debounce regression into a focused file to satisfy the merge-base line cap.
- Dependency contract: `discord-api-types@0.38.53` defines standard replies as reference type `0`, forwards as type `1`, and `message_id` as the originating message ID. Existing hydration fetches a missing reply target before preflight.
- `git diff --check origin/main...HEAD` — passed.

### Maintainer decision

- The existing-option semantic expansion is accepted: with `ignoreOtherMentions=true`, an unmentioned reply to another non-webhook bot is suppressed.
- **Boundary:** one existing Discord inbound preflight option plus its preflight-owned debounce partition key; no default or route-resolution change.
- **Known gap/falsifier:** if Discord cannot hydrate the referenced author, the gate fails open and does not suppress the message.
- **Rollback:** disable `ignoreOtherMentions` or revert these two commits.
- **Reviewability:** nine files, 305 additions and 10 deletions; most additions are focused behavior regressions.

AI-assisted: yes. The behavior, scope, tests, and final diff were reviewed and understood before publication.
