### PR TITLE
Backport native Codex completion delivery fix

### DIFF
--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -4,11 +4,18 @@ import type {
   AgentHarnessTaskRecord,
   AgentHarnessTaskRuntimeScope,
 } from "openclaw/plugin-sdk/agent-harness-task-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+import {
+  buildEmptyToolTelemetry,
+  CodexAppServerEventProjector,
+  createParams,
+  registerCodexEventProjectorTestLifecycle,
+} from "./event-projector.test-harness.js";
 import { codexNativeSubagentMonitorRuntime } from "./native-subagent-monitor.js";
 import type {
   CodexAppServerRequestResult,
   CodexServerNotification,
+  JsonObject,
   JsonValue,
 } from "./protocol.js";
 
@@ -56,6 +63,12 @@ function createClient() {
       throw new Error(`thread not loaded: ${childThreadId}`);
     }
     return typeof response === "function" ? await response(readParams) : response;
+  });
+  onTestFinished(async () => {
+    for (const handler of [...closeHandlers]) {
+      handler();
+    }
+    await Promise.resolve();
   });
   return {
     request,
@@ -189,12 +202,22 @@ async function notifyChildStarted(
   return notification;
 }
 
+async function registerDetachedChild(
+  client: ReturnType<typeof createClient>,
+  monitor: CodexNativeSubagentMonitorInstance,
+): Promise<void> {
+  const owner = registerParent(monitor);
+  await notifyChildStarted(client);
+  owner.unregister();
+}
+
 function nativeCompletionNotification(
   params: {
     agentPath?: string;
     statusLabel?: string;
     result?: string | null;
     parentThreadId?: string;
+    turnId?: string;
   } = {},
 ): CodexServerNotification {
   const agentPath = params.agentPath ?? "child-thread";
@@ -208,6 +231,7 @@ function nativeCompletionNotification(
     method: "rawResponseItem/completed",
     params: {
       threadId: params.parentThreadId ?? "parent-thread",
+      ...(params.turnId ? { turnId: params.turnId } : {}),
       item: {
         type: "message",
         role: "assistant",
@@ -350,6 +374,223 @@ function taskRecord(params: {
 }
 
 describe("CodexNativeSubagentMonitor", () => {
+  describe("native completion delivery ownership", () => {
+    registerCodexEventProjectorTestLifecycle();
+
+    function deliveredNativeCompletion(): CodexServerNotification {
+      return {
+        method: "rawResponseItem/completed",
+        params: {
+          threadId: "parent-thread",
+          turnId: "parent-turn",
+          item: {
+            type: "agent_message",
+            author: "/root/worker",
+            recipient: "/root",
+            content: [
+              {
+                type: "input_text",
+                text: "Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/worker\nPayload:\nThe build passed.",
+              },
+            ],
+          },
+        },
+      };
+    }
+
+    const completedChild = () =>
+      childTurnCompletedNotification({
+        status: "completed",
+        items: [
+          {
+            type: "agentMessage",
+            id: "child-final",
+            phase: "final_answer",
+            text: "The build passed.",
+          },
+        ],
+      });
+
+    it.each([
+      { order: "native-first", final: "The build passed. The change is ready." },
+      { order: "terminal-first", final: "The build passed. The change is ready." },
+      { order: "native-first", final: "NO_REPLY" },
+    ])(
+      "preserves $final when native delivery and child completion arrive $order",
+      async ({ order, final }) => {
+        const client = createClient();
+        const runtime = createRuntime();
+        const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
+        const owner = registerParent(monitor);
+        owner.bindTurn("parent-turn");
+        await notifyChildStarted(client, "parent-thread", "child-thread", "/root/worker");
+        const projector = new CodexAppServerEventProjector(
+          await createParams(),
+          "parent-thread",
+          "parent-turn",
+        );
+        let lastAnswer = "";
+        const answer = async (text: string, id: string) => {
+          lastAnswer = text;
+          await projector.handleNotification({
+            method: "item/completed",
+            params: {
+              threadId: "parent-thread",
+              turnId: "parent-turn",
+              item: { type: "agentMessage", id, phase: "final_answer", text },
+            },
+          });
+        };
+        runtime.deliverAgentHarnessTaskCompletion.mockImplementation(async () => {
+          await answer("NO_REPLY", "duplicate-answer");
+          return { delivered: true, path: "steered" };
+        });
+        try {
+          if (order === "terminal-first") {
+            await client.notify(completedChild());
+          }
+          await client.notify(deliveredNativeCompletion());
+          await answer(final, "parent-answer");
+          if (order === "native-first") {
+            await client.notify(completedChild());
+          }
+          await projector.handleNotification({
+            method: "turn/completed",
+            params: {
+              threadId: "parent-thread",
+              turn: {
+                id: "parent-turn",
+                status: "completed",
+                items: [{ type: "agentMessage", id: "last-answer", text: lastAnswer }],
+                error: null,
+              },
+            },
+          });
+          owner.unregister();
+          expect(projector.buildResult(buildEmptyToolTelemetry()).assistantTexts).toEqual([final]);
+          expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+          expect(runtime.setDetachedTaskDeliveryStatusByRunId).toHaveBeenLastCalledWith({
+            runId: "codex-thread:child-thread",
+            deliveryStatus: "delivered",
+          });
+        } finally {
+          owner.unregister();
+          client.close();
+        }
+      },
+    );
+
+    it("defers delivery during unbound parent startup and drains it if startup is released", async () => {
+      const client = createClient();
+      const runtime = createRuntime();
+      const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
+      const owner = registerParent(monitor);
+      await notifyChildStarted(client);
+      await client.notify(completedChild());
+      try {
+        expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+        owner.unregister();
+        expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledOnce();
+        expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledWith(
+          expect.objectContaining({ result: "The build passed." }),
+        );
+      } finally {
+        owner.unregister();
+        client.close();
+      }
+    });
+
+    it("defers completion when turn/started races ahead of the turn/start response", async () => {
+      const client = createClient();
+      const runtime = createRuntime();
+      const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
+      const owner = registerParent(monitor);
+      try {
+        await client.notify({
+          method: "turn/started",
+          params: {
+            threadId: "parent-thread",
+            turn: { id: "parent-turn", status: "inProgress", items: [] },
+          },
+        });
+        await notifyChildStarted(client, "parent-thread", "child-thread", "/root/worker");
+        await client.notify(completedChild());
+        expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+        await client.notify(deliveredNativeCompletion());
+        owner.bindTurn("parent-turn");
+        owner.unregister();
+        expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+        expect(runtime.setDetachedTaskDeliveryStatusByRunId).toHaveBeenLastCalledWith({
+          runId: "codex-thread:child-thread",
+          deliveryStatus: "delivered",
+        });
+      } finally {
+        owner.unregister();
+        client.close();
+      }
+    });
+
+    it.each([
+      "other-turn",
+      "other-parent",
+      "other-child",
+      "ordinary-message",
+      "user-text",
+    ] as const)("does not acknowledge a completion from %s", async (source) => {
+      const client = createClient();
+      const runtime = createRuntime();
+      const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
+      const owner = registerParent(monitor);
+      owner.bindTurn("parent-turn");
+      await notifyChildStarted(client, "parent-thread", "child-thread", "/root/worker");
+      const receipt = deliveredNativeCompletion();
+      const params = receipt.params as JsonObject;
+      const item = params.item as JsonObject;
+      if (source === "other-turn") {
+        params.turnId = "older-turn";
+      } else if (source === "other-parent") {
+        params.threadId = "another-parent";
+      } else if (source === "other-child") {
+        item.author = "/root/another-child";
+        item.content = [
+          {
+            type: "input_text",
+            text: "Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/another-child\nPayload:\nThe build passed.",
+          },
+        ];
+      } else if (source === "ordinary-message") {
+        item.content = [{ type: "input_text", text: "Still working on the build." }];
+      } else {
+        item.type = "message";
+        item.role = "user";
+      }
+      try {
+        await client.notify(completedChild());
+        await client.notify(receipt);
+        expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+        owner.unregister();
+        expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledOnce();
+      } finally {
+        owner.unregister();
+        client.close();
+      }
+    });
+
+    it("delivers a deferred completion if the parent client closes", async () => {
+      const client = createClient();
+      const runtime = createRuntime();
+      const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
+      const owner = registerParent(monitor);
+      owner.bindTurn("parent-turn");
+      await notifyChildStarted(client);
+      await client.notify(completedChild());
+      expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+      client.close();
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledOnce();
+      owner.unregister();
+    });
+  });
+
   it("keeps native subagent task mirroring on the shared client", async () => {
     const client = createClient();
     const runtime = createRuntime();
@@ -381,7 +622,7 @@ describe("CodexNativeSubagentMonitor", () => {
     const client = createClient();
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor, "parent-thread", "agent:main:main");
+    const owner = registerParent(monitor, "parent-thread", "agent:main:main");
 
     await client.notify({
       method: "item/completed",
@@ -417,6 +658,8 @@ describe("CodexNativeSubagentMonitor", () => {
         terminalSummary: "child v2 result",
       }),
     );
+    expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+    owner.unregister();
     expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledWith(
       expect.objectContaining({
         childSessionId: "child-v2",
@@ -465,7 +708,7 @@ describe("CodexNativeSubagentMonitor", () => {
     const client = createClient();
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    monitor.registerParent({
+    const parent = monitor.registerParent({
       parentThreadId: "parent-thread",
       requesterSessionKey: "agent:main:discord:channel:C123",
       taskRuntimeScope: createTaskScope(),
@@ -473,6 +716,7 @@ describe("CodexNativeSubagentMonitor", () => {
     });
 
     await notifyChildStarted(client);
+    parent.unregister();
     await client.notify({
       method: "thread/status/changed",
       params: {
@@ -511,8 +755,7 @@ describe("CodexNativeSubagentMonitor", () => {
     const client = createClient();
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
-    await notifyChildStarted(client);
+    await registerDetachedChild(client, monitor);
     await client.notify({
       method: "item/started",
       params: {
@@ -551,8 +794,7 @@ describe("CodexNativeSubagentMonitor", () => {
     const client = createClient();
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
-    await notifyChildStarted(client);
+    await registerDetachedChild(client, monitor);
 
     await client.notify(
       childTurnCompletedNotification({
@@ -580,8 +822,7 @@ describe("CodexNativeSubagentMonitor", () => {
     client.setThreadRead("child-thread", threadRead({ result: "history final result" }));
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
-    await notifyChildStarted(client);
+    await registerDetachedChild(client, monitor);
 
     await client.notify(childTurnCompletedNotification({ status: "completed" }));
 
@@ -679,8 +920,7 @@ describe("CodexNativeSubagentMonitor", () => {
     const client = createClient();
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
-    await notifyChildStarted(client);
+    await registerDetachedChild(client, monitor);
 
     const completion = nativeCompletionNotification();
     await client.notify(completion);
@@ -703,8 +943,7 @@ describe("CodexNativeSubagentMonitor", () => {
     client.setThreadRead("child-thread", threadRead({ result: "history final result" }));
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
-    await notifyChildStarted(client);
+    await registerDetachedChild(client, monitor);
 
     await client.notify(nativeCompletionNotification({ result: null }));
 
@@ -733,8 +972,7 @@ describe("CodexNativeSubagentMonitor", () => {
       const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
         recoveryPollDelaysMs: [10],
       });
-      registerParent(monitor);
-      await notifyChildStarted(client);
+      await registerDetachedChild(client, monitor);
 
       await client.notify(nativeCompletionNotification({ result: null }));
       await vi.advanceTimersByTimeAsync(20);
@@ -760,8 +998,7 @@ describe("CodexNativeSubagentMonitor", () => {
       const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
         recoveryPollDelaysMs: [10],
       });
-      registerParent(monitor);
-      await notifyChildStarted(client);
+      await registerDetachedChild(client, monitor);
 
       await client.notify(nativeCompletionNotification({ result: null }));
       await vi.advanceTimersByTimeAsync(20);
@@ -783,8 +1020,7 @@ describe("CodexNativeSubagentMonitor", () => {
       const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
         recoveryPollDelaysMs: [10],
       });
-      registerParent(monitor);
-      await notifyChildStarted(client);
+      await registerDetachedChild(client, monitor);
 
       await client.notify(nativeCompletionNotification({ result: null }));
       client.setThreadRead(
@@ -828,8 +1064,7 @@ describe("CodexNativeSubagentMonitor", () => {
     );
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
-    await notifyChildStarted(client);
+    await registerDetachedChild(client, monitor);
 
     await expect(monitor.reconcileChildThread("child-thread")).resolves.toBe(true);
 
@@ -845,8 +1080,7 @@ describe("CodexNativeSubagentMonitor", () => {
     const releaseClient = vi.fn();
     const retainClient = vi.fn(() => releaseClient);
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime, { retainClient });
-    registerParent(monitor);
-    await notifyChildStarted(client);
+    await registerDetachedChild(client, monitor);
 
     await client.notify(childTurnCompletedNotification({ status: "interrupted" }));
 
@@ -882,8 +1116,7 @@ describe("CodexNativeSubagentMonitor", () => {
     );
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
-    await notifyChildStarted(client);
+    await registerDetachedChild(client, monitor);
 
     await expect(monitor.reconcileChildThread("child-thread")).resolves.toBe(false);
 
@@ -903,8 +1136,7 @@ describe("CodexNativeSubagentMonitor", () => {
     );
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
-    await notifyChildStarted(client);
+    await registerDetachedChild(client, monitor);
 
     await expect(monitor.reconcileChildThread("child-thread")).resolves.toBe(false);
 
@@ -931,8 +1163,7 @@ describe("CodexNativeSubagentMonitor", () => {
       const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
         recoveryPollDelaysMs: [10],
       });
-      registerParent(monitor);
-      await notifyChildStarted(client);
+      await registerDetachedChild(client, monitor);
 
       await expect(monitor.reconcileChildThread("child-thread")).resolves.toBe(false);
       await vi.advanceTimersByTimeAsync(30);
@@ -965,8 +1196,7 @@ describe("CodexNativeSubagentMonitor", () => {
     });
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
-    await notifyChildStarted(client);
+    await registerDetachedChild(client, monitor);
 
     await expect(monitor.reconcileChildThread("child-thread")).resolves.toBe(false);
 
@@ -996,8 +1226,7 @@ describe("CodexNativeSubagentMonitor", () => {
     });
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
-    await notifyChildStarted(client);
+    await registerDetachedChild(client, monitor);
 
     await expect(monitor.reconcileChildThread("child-thread")).resolves.toBe(true);
 
@@ -1025,8 +1254,7 @@ describe("CodexNativeSubagentMonitor", () => {
         recoveryPollDelaysMs: [10],
         retainClient: () => releaseClient,
       });
-      registerParent(monitor);
-      await notifyChildStarted(client);
+      await registerDetachedChild(client, monitor);
 
       await client.notify({
         method: "thread/status/changed",
@@ -1075,8 +1303,7 @@ describe("CodexNativeSubagentMonitor", () => {
         recoveryPollDelaysMs: [10],
         retainClient: () => releaseClient,
       });
-      registerParent(monitor);
-      await notifyChildStarted(client);
+      await registerDetachedChild(client, monitor);
 
       await client.notify({
         method: "thread/status/changed",
@@ -1119,8 +1346,7 @@ describe("CodexNativeSubagentMonitor", () => {
         recoveryPollDelaysMs: [10],
         retainClient: () => releaseClient,
       });
-      registerParent(monitor);
-      await notifyChildStarted(client);
+      await registerDetachedChild(client, monitor);
 
       await client.notify({
         method: "thread/status/changed",
@@ -1165,8 +1391,7 @@ describe("CodexNativeSubagentMonitor", () => {
     );
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
-    await notifyChildStarted(client);
+    await registerDetachedChild(client, monitor);
 
     await expect(monitor.reconcileChildThread("child-thread")).resolves.toBe(true);
 
@@ -1180,10 +1405,11 @@ describe("CodexNativeSubagentMonitor", () => {
     const client = createClient();
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
+    const parent = registerParent(monitor);
     await notifyChildStarted(client, "parent-thread", "child-thread", "1.2", {
       directParentField: false,
     });
+    parent.unregister();
 
     await client.notify(nativeCompletionNotification({ agentPath: "1.2" }));
 
@@ -1209,8 +1435,7 @@ describe("CodexNativeSubagentMonitor", () => {
     const client = createClient();
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
-    await notifyChildStarted(client);
+    await registerDetachedChild(client, monitor);
 
     // Trust boundary: only assistant commentary carries inter-agent envelopes.
     // User-authored text quoting the markup must never finalize a real child.
@@ -1242,7 +1467,7 @@ describe("CodexNativeSubagentMonitor", () => {
     const client = createClient();
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor, "parent-a", "agent:main:a");
+    const parent = registerParent(monitor, "parent-a", "agent:main:a");
     registerParent(monitor, "parent-b", "agent:main:b");
     await notifyChildStarted(client, "parent-a", "child-thread");
     await notifyChildStarted(client, "parent-b", "child-thread");
@@ -1255,6 +1480,7 @@ describe("CodexNativeSubagentMonitor", () => {
     );
     expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
 
+    parent.unregister();
     await client.notify(
       nativeCompletionNotification({
         parentThreadId: "parent-a",
@@ -1285,8 +1511,7 @@ describe("CodexNativeSubagentMonitor", () => {
       replacementClient as never,
       replacementRuntime,
     );
-    registerParent(replacementMonitor);
-    await notifyChildStarted(replacementClient);
+    await registerDetachedChild(replacementClient, replacementMonitor);
     await replacementClient.notify(nativeCompletionNotification());
 
     expect(replacementRuntime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
@@ -1307,8 +1532,7 @@ describe("CodexNativeSubagentMonitor", () => {
         completionDeliveryRetryDelaysMs: [10],
         retainClient: () => releaseClient,
       });
-      registerParent(monitor);
-      await notifyChildStarted(client);
+      await registerDetachedChild(client, monitor);
       await client.notify(nativeCompletionNotification());
       expect(releaseClient).toHaveBeenCalledTimes(1);
       client.close();
@@ -1336,16 +1560,17 @@ describe("CodexNativeSubagentMonitor", () => {
       const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
         completionDeliveryRetryDelaysMs: [10],
       });
-      registerParent(monitor);
-      await notifyChildStarted(client);
+      await registerDetachedChild(client, monitor);
       await client.notify(nativeCompletionNotification());
 
       expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
-      registerParent(monitor);
+      const parent = registerParent(monitor);
       await vi.advanceTimersByTimeAsync(0);
       expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(10);
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
+      parent.unregister();
       expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(2);
       client.close();
     } finally {
@@ -1385,8 +1610,7 @@ describe("CodexNativeSubagentMonitor", () => {
       const firstMonitor = new CodexNativeSubagentMonitor(firstClient as never, runtime, {
         completionDeliveryRetryDelaysMs: [10],
       });
-      registerParent(firstMonitor);
-      await notifyChildStarted(firstClient);
+      await registerDetachedChild(firstClient, firstMonitor);
       await firstClient.notify(nativeCompletionNotification());
       expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
 
@@ -1425,8 +1649,7 @@ describe("CodexNativeSubagentMonitor", () => {
         completionDeliveryMaxRetries: 2,
         retainClient: () => releaseClient,
       });
-      registerParent(monitor);
-      await notifyChildStarted(client);
+      await registerDetachedChild(client, monitor);
       await client.notify(nativeCompletionNotification());
 
       expect(releaseClient).toHaveBeenCalledTimes(1);
@@ -1513,7 +1736,9 @@ describe("CodexNativeSubagentMonitor", () => {
       taskRecord({ childThreadId: "foreign-child", requesterSessionKey: "agent:main:other" }),
     ]);
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
-    registerParent(monitor);
+    const parent = registerParent(monitor);
+    await vi.waitFor(() => expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(1));
+    parent.unregister();
     await vi.waitFor(() =>
       expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1),
     );
@@ -1582,13 +1807,14 @@ describe("CodexNativeSubagentMonitor", () => {
     const second = registerParent(monitor);
     expect(client.request).toHaveBeenCalledTimes(1);
     releaseRead();
+    await vi.waitFor(() => expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(1));
+    first.unregister();
+    second.unregister();
     await vi.waitFor(() =>
       expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1),
     );
 
     expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
-    first.unregister();
-    second.unregister();
     client.close();
   });
 
@@ -1606,7 +1832,7 @@ describe("CodexNativeSubagentMonitor", () => {
       const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
         recoveryPollDelaysMs: [10],
       });
-      registerParent(monitor);
+      const parent = registerParent(monitor);
       await Promise.resolve();
       expect(client.request).toHaveBeenCalledTimes(1);
 
@@ -1621,6 +1847,7 @@ describe("CodexNativeSubagentMonitor", () => {
 
       client.setThreadRead("child-thread", threadRead({ result: "fresh completed result" }));
       await vi.advanceTimersByTimeAsync(10);
+      parent.unregister();
 
       expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
       expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledWith(
@@ -1654,7 +1881,7 @@ describe("CodexNativeSubagentMonitor", () => {
       const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
         recoveryPollDelaysMs: [10],
       });
-      registerParent(monitor);
+      const parent = registerParent(monitor);
       await vi.advanceTimersByTimeAsync(0);
       expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
       expect(client.request).toHaveBeenCalledWith(
@@ -1664,6 +1891,7 @@ describe("CodexNativeSubagentMonitor", () => {
       );
 
       await vi.advanceTimersByTimeAsync(10);
+      parent.unregister();
 
       expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledWith(
         expect.objectContaining({ result: "eventual history result" }),
@@ -1759,8 +1987,7 @@ describe("CodexNativeSubagentMonitor", () => {
       const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
         recoveryPollDelaysMs: [10],
       });
-      registerParent(monitor);
-      await notifyChildStarted(client);
+      await registerDetachedChild(client, monitor);
 
       await vi.advanceTimersByTimeAsync(10);
       await vi.advanceTimersByTimeAsync(10);
@@ -1794,11 +2021,12 @@ describe("CodexNativeSubagentMonitor", () => {
       runtime,
     });
     first.unregister();
+    second.bindTurn("parent-turn");
     await notifyChildStarted(client);
-    await client.notify(nativeCompletionNotification());
+    await client.notify(nativeCompletionNotification({ turnId: "parent-turn" }));
 
     expect(runtime.createRunningTaskRun).toHaveBeenCalledTimes(1);
-    expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
+    expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
     second.unregister();
     await notifyChildStarted(client, "parent-thread", "late-child");
     expect(runtime.createRunningTaskRun).toHaveBeenCalledTimes(1);
@@ -1813,8 +2041,7 @@ describe("CodexNativeSubagentMonitor", () => {
       const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
         recoveryPollDelaysMs: [10],
       });
-      registerParent(monitor);
-      await notifyChildStarted(client);
+      await registerDetachedChild(client, monitor);
 
       client.close();
       await vi.advanceTimersByTimeAsync(30);

--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -65,7 +65,7 @@ function createClient() {
     return typeof response === "function" ? await response(readParams) : response;
   });
   onTestFinished(async () => {
-    for (const handler of [...closeHandlers]) {
+    for (const handler of closeHandlers) {
       handler();
     }
     await Promise.resolve();

--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -277,6 +277,7 @@ function threadRead(
   params: {
     childThreadId?: string;
     parentThreadId?: string;
+    agentPath?: string;
     status?: "completed" | "failed" | "interrupted" | "inProgress";
     result?: string;
     error?: string;
@@ -319,7 +320,11 @@ function threadRead(
       ...(params.directParentField === false ? {} : { parentThreadId }),
       source: {
         subAgent: {
-          thread_spawn: { parent_thread_id: parentThreadId, depth: 1 },
+          thread_spawn: {
+            parent_thread_id: parentThreadId,
+            depth: 1,
+            ...(params.agentPath ? { agent_path: params.agentPath } : {}),
+          },
         },
       },
       status: { type: params.threadStatus ?? "idle" },
@@ -574,6 +579,95 @@ describe("CodexNativeSubagentMonitor", () => {
         owner.unregister();
         client.close();
       }
+    });
+
+    it.each(["before", "after"])(
+      "retains a native receipt when task recovery finishes %s parent release",
+      async (order) => {
+        const client = createClient();
+        let releaseRead!: (response: CodexThreadReadResponse) => void;
+        client.setThreadReadFactory(
+          "child-thread",
+          () =>
+            new Promise((resolve) => {
+              releaseRead = resolve;
+            }),
+        );
+        const runtime = createRuntime();
+        runtime.listTaskRecords.mockReturnValue([taskRecord({ childThreadId: "child-thread" })]);
+        const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
+        const owner = registerParent(monitor);
+        owner.bindTurn("parent-turn");
+        expect(client.request).toHaveBeenCalledOnce();
+        await client.notify(deliveredNativeCompletion());
+        if (order === "after") {
+          owner.unregister();
+        }
+        releaseRead(threadRead({ agentPath: "/root/worker", result: "The build passed." }));
+        await vi.waitFor(() => expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledOnce());
+        owner.unregister();
+        expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+        expect(runtime.setDetachedTaskDeliveryStatusByRunId).toHaveBeenLastCalledWith({
+          runId: "codex-thread:child-thread",
+          deliveryStatus: "delivered",
+        });
+        client.close();
+      },
+    );
+
+    it.each(["other-turn", "other-lineage"])(
+      "does not acknowledge recovered delivery from %s",
+      async (source) => {
+        const client = createClient();
+        let releaseRead!: (response: CodexThreadReadResponse) => void;
+        client.setThreadReadFactory(
+          "child-thread",
+          () =>
+            new Promise((resolve) => {
+              releaseRead = resolve;
+            }),
+        );
+        const runtime = createRuntime();
+        runtime.listTaskRecords.mockReturnValue([taskRecord({ childThreadId: "child-thread" })]);
+        const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
+        const owner = registerParent(monitor);
+        owner.bindTurn("parent-turn");
+        const receipt = deliveredNativeCompletion();
+        if (source === "other-turn") {
+          (receipt.params as JsonObject).turnId = "old-turn";
+        }
+        await client.notify(receipt);
+        owner.unregister();
+        releaseRead(
+          threadRead({
+            agentPath: "/root/worker",
+            parentThreadId: source === "other-lineage" ? "old-parent" : "parent-thread",
+            result: "The build passed.",
+          }),
+        );
+        await vi.waitFor(() =>
+          expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledOnce(),
+        );
+        client.close();
+      },
+    );
+
+    it("does not carry an unmatched receipt into a later parent run", async () => {
+      const client = createClient();
+      const runtime = createRuntime();
+      const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
+      const first = registerParent(monitor);
+      first.bindTurn("parent-turn");
+      await notifyChildStarted(client, "parent-thread", "waiting-child");
+      await client.notify(deliveredNativeCompletion());
+      first.unregister();
+      const second = registerParent(monitor);
+      second.bindTurn("next-turn");
+      await notifyChildStarted(client, "parent-thread", "child-thread", "/root/worker");
+      await client.notify(completedChild());
+      second.unregister();
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledOnce();
+      client.close();
     });
 
     it("delivers a deferred completion if the parent client closes", async () => {

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -44,6 +44,9 @@ type ParentState = {
   // Overlapping runs share this parent; the last owner releases it only after
   // detached children finish recovery and delivery.
   ownerCount: number;
+  // turn/started can precede bindTurn; retain receipt ownership until the
+  // foreground run has finalized its reply and releases this registration.
+  turnIds: Set<string>;
   requesterSessionKey?: string;
   taskRuntimeScope?: AgentHarnessTaskRuntimeScope;
   agentId?: string;
@@ -62,6 +65,7 @@ type ChildState = {
   terminal: boolean;
   fallbackCompletion?: RecoveredCompletion;
   pendingCompletion?: CodexNativeSubagentCompletion;
+  nativeCompletionDelivered: boolean;
   completionDeliveryAttempt: number;
   completionDeliveryTimer?: ReturnType<typeof setTimeout>;
   deliveringCompletion: boolean;
@@ -153,7 +157,7 @@ function registerMonitor(params: {
   agentId?: string;
   runtime?: NativeSubagentMonitorRuntime;
   retainClient?: () => (() => void) | undefined;
-}): { unregister: () => void } {
+}): { bindTurn: (turnId: string) => void; unregister: () => void } {
   let monitor = monitors.get(params.client);
   if (!monitor) {
     monitor = new Monitor(params.client, params.runtime ?? defaultRuntime, {
@@ -230,6 +234,8 @@ class Monitor {
     this.releaseRetainedClient();
     for (const state of this.parentStates.values()) {
       state.ownerCount = 0;
+      state.turnIds.clear();
+      this.deliverDetachedCompletions(state);
     }
     for (const [parentThreadId] of this.parentStates) {
       if (
@@ -247,7 +253,7 @@ class Monitor {
     requesterSessionKey?: string;
     taskRuntimeScope?: AgentHarnessTaskRuntimeScope;
     agentId?: string;
-  }): { unregister: () => void } {
+  }): { bindTurn: (turnId: string) => void; unregister: () => void } {
     const parentThreadId = params.parentThreadId.trim();
     if (!parentThreadId) {
       throw new Error("Codex native subagent monitor requires a parent thread id");
@@ -264,7 +270,7 @@ class Monitor {
       throw new Error(`Codex thread ${parentThreadId} is already bound to another session`);
     }
     if (!state) {
-      state = { parentThreadId, ownerCount: 0 };
+      state = { parentThreadId, ownerCount: 0, turnIds: new Set() };
       this.parentStates.set(parentThreadId, state);
     }
     state.ownerCount += 1;
@@ -278,6 +284,7 @@ class Monitor {
       }
     }
     let registered = true;
+    let boundTurnId: string | undefined;
     const registeredState = state;
     // Recovery may perform several bounded history reads. It must never delay
     // the foreground parent turn that established this registration.
@@ -288,14 +295,32 @@ class Monitor {
       });
     });
     return {
+      bindTurn: (turnIdInput) => {
+        const turnId = turnIdInput.trim();
+        if (!registered || !turnId || this.parentStates.get(parentThreadId) !== registeredState) {
+          return;
+        }
+        if (boundTurnId) {
+          registeredState.turnIds.delete(boundTurnId);
+        }
+        boundTurnId = turnId;
+        registeredState.turnIds.add(turnId);
+      },
       unregister: () => {
         if (!registered) {
           return;
         }
         registered = false;
         const current = this.parentStates.get(parentThreadId);
-        if (current) {
+        if (current === registeredState) {
           current.ownerCount -= 1;
+          if (boundTurnId) {
+            current.turnIds.delete(boundTurnId);
+          }
+          if (current.ownerCount === 0) {
+            current.turnIds.clear();
+          }
+          this.deliverDetachedCompletions(current);
           this.pruneParentIfUnused(current);
         }
       },
@@ -335,6 +360,13 @@ class Monitor {
     const threadStatus = isJsonObject(params?.status)
       ? normalizeIdentifier(readString(params.status, "type"))
       : undefined;
+    const parent = threadId ? this.parentStates.get(threadId) : undefined;
+    if (parent && parent.ownerCount > 0 && notification.method === "turn/started") {
+      const turnId = isJsonObject(params?.turn) ? readString(params.turn, "id") : undefined;
+      if (turnId) {
+        parent.turnIds.add(turnId);
+      }
+    }
     const tracksRecoveryRevision = Boolean(threadId && this.threadStatusRevisions.has(threadId));
     if (
       RECOVERY_REVISION_NOTIFICATION_METHODS.has(notification.method) &&
@@ -364,7 +396,11 @@ class Monitor {
     }
     const childState = threadId ? this.childStates.get(threadId) : undefined;
     if (notification.method === "turn/started" && childState) {
+      childState.nativeCompletionDelivered = false;
       this.resumeChild(childState);
+    }
+    if (parent && parent.turnIds.has(readString(params, "turnId") ?? "")) {
+      this.recordNativeCompletionDelivery(parent, notification);
     }
     this.captureChildAssistantMessage(notification);
     await this.handleChildTurnCompletion(notification);
@@ -873,6 +909,10 @@ class Monitor {
       this.unregisterChild(childState);
       return;
     }
+    if (childState.nativeCompletionDelivered) {
+      this.finishCompletionDelivery(state, childState);
+      return;
+    }
     childState.pendingCompletion = completion;
     state.taskRuntime?.setDetachedTaskDeliveryStatusByRunId({
       runId: codexNativeSubagentRunId(completion.childThreadId),
@@ -888,6 +928,11 @@ class Monitor {
   ): Promise<void> {
     const completion = childState.pendingCompletion;
     if (!completion || !state.requesterSessionKey || !state.taskRuntimeScope) {
+      return;
+    }
+    // Codex owns completion input from registration through reply finalization,
+    // including turn startup before its id is bound. Only wake detached parents.
+    if (state.ownerCount > 0) {
       return;
     }
     if (childState.deliveringCompletion || childState.completionDeliveryTimer) {
@@ -909,13 +954,7 @@ class Monitor {
           "Use the Codex native subagent result to continue or wrap up the parent task. If this is a Discord/channel session, send the visible response with the message tool instead of only writing a transcript final answer. Reply in your normal assistant voice and do not expose internal notification markup.",
       });
       if (isDurableAgentHarnessCompletionDelivery(delivery)) {
-        childState.pendingCompletion = undefined;
-        childState.completionDeliveryAttempt = 0;
-        state.taskRuntime?.setDetachedTaskDeliveryStatusByRunId({
-          runId: codexNativeSubagentRunId(completion.childThreadId),
-          deliveryStatus: "delivered",
-        });
-        this.unregisterChild(childState);
+        this.finishCompletionDelivery(state, childState);
         return;
       }
       const error = delivery.error ?? "completion delivery did not produce a parent response";
@@ -940,6 +979,43 @@ class Monitor {
       });
     } finally {
       childState.deliveringCompletion = false;
+    }
+  }
+
+  private recordNativeCompletionDelivery(
+    state: ParentState,
+    notification: CodexServerNotification,
+  ): void {
+    for (const agentPath of nativeSubagentNotifications.deliveredAgentPaths(notification)) {
+      const childThreadId = this.childThreadIdsByAgentPath.get(
+        buildParentAgentPathKey(state.parentThreadId, agentPath),
+      );
+      const child = childThreadId ? this.childStates.get(childThreadId) : undefined;
+      if (!child || child.parentThreadId !== state.parentThreadId) {
+        continue;
+      }
+      child.nativeCompletionDelivered = true;
+      if (child.pendingCompletion && !child.deliveringCompletion) {
+        this.finishCompletionDelivery(state, child);
+      }
+    }
+  }
+
+  private finishCompletionDelivery(state: ParentState, child: ChildState): void {
+    child.pendingCompletion = undefined;
+    child.completionDeliveryAttempt = 0;
+    state.taskRuntime?.setDetachedTaskDeliveryStatusByRunId({
+      runId: codexNativeSubagentRunId(child.childThreadId),
+      deliveryStatus: "delivered",
+    });
+    this.unregisterChild(child);
+  }
+
+  private deliverDetachedCompletions(state: ParentState): void {
+    for (const child of this.childStates.values()) {
+      if (child.parentThreadId === state.parentThreadId && child.pendingCompletion) {
+        void this.deliverPendingCompletion(state, child);
+      }
     }
   }
 
@@ -1006,6 +1082,7 @@ class Monitor {
         assistantMessagesByTurn: new Map<string, ChildAssistantMessages>(),
         recoveryAttempt: 0,
         terminal: false,
+        nativeCompletionDelivered: false,
         settledWithoutCompletion: false,
         completionDeliveryAttempt: 0,
         deliveringCompletion: false,
@@ -1362,6 +1439,7 @@ class Monitor {
         state = {
           parentThreadId,
           ownerCount: 0,
+          turnIds: new Set(),
           requesterSessionKey: candidate.requesterSessionKey,
           taskRuntimeScope: candidate.taskRuntimeScope,
           agentId: candidate.agentId,

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -47,6 +47,7 @@ type ParentState = {
   // turn/started can precede bindTurn; retain receipt ownership until the
   // foreground run has finalized its reply and releases this registration.
   turnIds: Set<string>;
+  nativeCompletionReceipts: Set<string>;
   requesterSessionKey?: string;
   taskRuntimeScope?: AgentHarnessTaskRuntimeScope;
   agentId?: string;
@@ -86,6 +87,7 @@ type RecoveredCompletion = CodexNativeSubagentCompletion & {
 
 type ThreadRecovery = {
   parentThreadId?: string;
+  agentPath?: string;
   completion?: RecoveredCompletion;
   fallbackCompletion?: RecoveredCompletion;
   resumable: boolean;
@@ -98,6 +100,7 @@ type ThreadStatusRevision = {
 };
 
 type TaskRecoveryCandidate = {
+  nativeCompletionReceipts: Set<string>;
   childThreadId: string;
   recoveryAttempt: number;
   requesterSessionKey: string;
@@ -270,7 +273,12 @@ class Monitor {
       throw new Error(`Codex thread ${parentThreadId} is already bound to another session`);
     }
     if (!state) {
-      state = { parentThreadId, ownerCount: 0, turnIds: new Set() };
+      state = {
+        parentThreadId,
+        ownerCount: 0,
+        turnIds: new Set(),
+        nativeCompletionReceipts: new Set(),
+      };
       this.parentStates.set(parentThreadId, state);
     }
     state.ownerCount += 1;
@@ -319,6 +327,9 @@ class Monitor {
           }
           if (current.ownerCount === 0) {
             current.turnIds.clear();
+            // In-flight recovery retains this run's receipts; a later run must
+            // not inherit them merely because it reuses an agent path.
+            current.nativeCompletionReceipts = new Set();
           }
           this.deliverDetachedCompletions(current);
           this.pruneParentIfUnused(current);
@@ -397,6 +408,9 @@ class Monitor {
     const childState = threadId ? this.childStates.get(threadId) : undefined;
     if (notification.method === "turn/started" && childState) {
       childState.nativeCompletionDelivered = false;
+      for (const key of childState.agentPathKeys) {
+        state?.nativeCompletionReceipts.delete(key);
+      }
       this.resumeChild(childState);
     }
     if (parent && parent.turnIds.has(readString(params, "turnId") ?? "")) {
@@ -762,6 +776,9 @@ class Monitor {
         this.unregisterChild(childState);
         return false;
       }
+      if (recovery.agentPath) {
+        this.registerAgentPath(childState, recovery.agentPath);
+      }
       if (recovery.threadState === "active") {
         this.observeActiveChild(childState);
         return false;
@@ -873,6 +890,7 @@ class Monitor {
     }
     return {
       parentThreadId: readThreadParentThreadId(thread),
+      agentPath: normalizeOptionalString(readString(readThreadSpawnSource(thread), "agent_path")),
       completion,
       fallbackCompletion,
       resumable,
@@ -987,9 +1005,11 @@ class Monitor {
     notification: CodexServerNotification,
   ): void {
     for (const agentPath of nativeSubagentNotifications.deliveredAgentPaths(notification)) {
-      const childThreadId = this.childThreadIdsByAgentPath.get(
-        buildParentAgentPathKey(state.parentThreadId, agentPath),
-      );
+      const key = buildParentAgentPathKey(state.parentThreadId, agentPath);
+      // Native input can arrive before asynchronous history restores the child
+      // mapping. Preserve the observed delivery, not a guess from task status.
+      state.nativeCompletionReceipts.add(key);
+      const childThreadId = this.childThreadIdsByAgentPath.get(key);
       const child = childThreadId ? this.childStates.get(childThreadId) : undefined;
       if (!child || child.parentThreadId !== state.parentThreadId) {
         continue;
@@ -1119,6 +1139,9 @@ class Monitor {
     }
     this.childThreadIdsByAgentPath.set(key, childState.childThreadId);
     childState.agentPathKeys.add(key);
+    if (this.parentStates.get(childState.parentThreadId)?.nativeCompletionReceipts.has(key)) {
+      childState.nativeCompletionDelivered = true;
+    }
   }
 
   private unregisterChild(childState: ChildState): void {
@@ -1337,6 +1360,7 @@ class Monitor {
       }
       const childThreadId = task.runId!.slice(CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX.length).trim();
       candidates.set(childThreadId, {
+        nativeCompletionReceipts: state.nativeCompletionReceipts,
         requesterSessionKey: state.requesterSessionKey,
         childThreadId,
         recoveryAttempt: 0,
@@ -1440,6 +1464,7 @@ class Monitor {
           parentThreadId,
           ownerCount: 0,
           turnIds: new Set(),
+          nativeCompletionReceipts: new Set(),
           requesterSessionKey: candidate.requesterSessionKey,
           taskRuntimeScope: candidate.taskRuntimeScope,
           agentId: candidate.agentId,
@@ -1448,10 +1473,19 @@ class Monitor {
         this.prepareParentTaskRuntime(state);
         this.parentStates.set(parentThreadId, state);
       }
-      const childState = this.registerChildThread(parentThreadId, candidate.childThreadId);
+      const childState = this.registerChildThread(
+        parentThreadId,
+        candidate.childThreadId,
+        recovery.agentPath ? { agentPath: recovery.agentPath } : {},
+      );
       if (!childState) {
         this.pruneParentIfUnused(state);
         return;
+      }
+      if (
+        [...childState.agentPathKeys].some((key) => candidate.nativeCompletionReceipts.has(key))
+      ) {
+        childState.nativeCompletionDelivered = true;
       }
       if (recovery.threadState === "active") {
         this.observeActiveChild(childState);

--- a/extensions/codex/src/app-server/native-subagent-notification.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-notification.test.ts
@@ -36,6 +36,40 @@ function trustedInterAgentNotification(params: {
 }
 
 describe("Codex native subagent notifications", () => {
+  it("recognizes a native completion receipt without treating its payload as a status", () => {
+    expect(
+      codexNativeSubagentNotifications.deliveredAgentPaths({
+        method: "rawResponseItem/completed",
+        params: {
+          threadId: "parent-thread",
+          turnId: "parent-turn",
+          item: {
+            type: "agent_message",
+            author: "/root/worker",
+            recipient: "/root",
+            content: [
+              {
+                type: "input_text",
+                text: "Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/worker\nPayload:\nBuild result",
+              },
+            ],
+          },
+        },
+      }),
+    ).toEqual(["/root/worker"]);
+  });
+
+  it("recognizes the earlier trusted inter-agent completion envelope as a delivery receipt", () => {
+    expect(
+      codexNativeSubagentNotifications.deliveredAgentPaths(
+        trustedInterAgentNotification({
+          agentPath: "child-thread",
+          text: '<subagent_notification>{"agent_path":"child-thread","status":{"completed":"done"}}</subagent_notification>',
+        }),
+      ),
+    ).toEqual(["child-thread"]);
+  });
+
   it("parses completed child results from Codex notification XML", () => {
     expect(
       extractCodexNativeSubagentCompletionsFromText(

--- a/extensions/codex/src/app-server/native-subagent-notification.ts
+++ b/extensions/codex/src/app-server/native-subagent-notification.ts
@@ -77,7 +77,40 @@ function extractCodexNativeSubagentCompletionsFromText(
 export const codexNativeSubagentNotifications = {
   fromNotification: extractCodexNativeSubagentCompletions,
   fromText: extractCodexNativeSubagentCompletionsFromText,
+  deliveredAgentPaths: readDeliveredNativeCompletionPaths,
 };
+
+/** Reads native delivery receipts, leaving status and result ownership with the child lifecycle. */
+function readDeliveredNativeCompletionPaths(notification: CodexServerNotification): string[] {
+  if (notification.method !== "rawResponseItem/completed") {
+    return [];
+  }
+  const params = isJsonObject(notification.params) ? notification.params : undefined;
+  const item = isJsonObject(params?.item) ? params.item : undefined;
+  if (!item || readString(item, "type") !== "agent_message") {
+    return extractCodexNativeSubagentCompletions(notification).map(
+      (completion) => completion.agentPath,
+    );
+  }
+  const author = readString(item, "author");
+  const recipient = readString(item, "recipient");
+  const content = item.content;
+  if (!author || !recipient || !Array.isArray(content) || content.length !== 1) {
+    return [];
+  }
+  const part = content[0];
+  if (!isJsonObject(part) || readString(part, "type") !== "input_text") {
+    return [];
+  }
+  const text = readString(part, "text");
+  // Codex's native completion envelope identifies both endpoints outside the
+  // payload. Ordinary messages and quoted completion text are not receipts.
+  return text?.startsWith(
+    `Message Type: FINAL_ANSWER\nTask name: ${recipient}\nSender: ${author}\nPayload:\n`,
+  )
+    ? [author]
+    : [];
+}
 
 function parseCodexNativeSubagentNotificationBody(
   body: string,

--- a/extensions/codex/src/app-server/run-attempt-turn-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-start.ts
@@ -303,5 +303,6 @@ export async function startCodexAttemptTurn(
     throw new Error("codex app-server turn/start failed without an error");
   }
   turnIdRef.current = turn.turn.id;
+  resourceState.nativeSubagentMonitor?.bindTurn(turn.turn.id);
   return { turn };
 }


### PR DESCRIPTION
Backports [the native Codex completion fix](https://github.com/openclaw/openclaw/pull/130311) and its [history-recovery follow-up](https://github.com/openclaw/openclaw/pull/130347) onto this release branch. A child result already consumed by Codex must not be injected a second time after the parent writes its answer: that extra turn can replace the answer with `NO_REPLY` and leave the user with nothing.

The backport preserves this branch's existing monitor and reference-counted owners. It adds the small turn-binding hook needed to recognize native delivery, including results that arrive during startup. It does not pull in main's newer child-subscription and hook-retention changes. Detached children still wake their parent, and intentional silence remains unchanged.

The same ordering, startup, history-recovery, and trust-boundary regressions run here alongside this branch's existing monitor, projector, client, and task-mirroring tests. There are no dependency, configuration, model, prompt, or persisted-state changes.
