### PR TITLE
fix(tlon): await durable invite side effects

### DIFF
--- a/extensions/tlon/src/monitor/approval-runtime.ts
+++ b/extensions/tlon/src/monitor/approval-runtime.ts
@@ -49,7 +49,7 @@ export function createTlonApprovalRuntime(params: {
     refreshWatchedChannels,
   } = params;
 
-  const savePendingApprovals = async (): Promise<void> => {
+  const savePendingApprovals = async (required = false): Promise<void> => {
     try {
       await api.poke({
         app: "settings",
@@ -65,6 +65,9 @@ export function createTlonApprovalRuntime(params: {
       });
     } catch (err) {
       runtime.error?.(`[tlon] Failed to save pending approvals: ${String(err)}`);
+      if (required) {
+        throw err;
+      }
     }
   };
 
@@ -225,13 +228,13 @@ export function createTlonApprovalRuntime(params: {
       runtime.log?.(
         `[tlon] Updated existing approval for ${approval.requestingShip} (${approval.type}) - re-sending notification`,
       );
-      await savePendingApprovals();
+      await savePendingApprovals(true);
       await sendOwnerNotification(formatApprovalRequest(existing));
       return;
     }
 
     setPendingApprovals([...approvals, approval]);
-    await savePendingApprovals();
+    await savePendingApprovals(true);
     await sendOwnerNotification(formatApprovalRequest(approval));
     runtime.log?.(
       `[tlon] Queued approval request: ${approval.id} (${approval.type} from ${approval.requestingShip})`,

--- a/extensions/tlon/src/monitor/index.test.ts
+++ b/extensions/tlon/src/monitor/index.test.ts
@@ -253,6 +253,197 @@ it("awaits cumulative Tlon discovery persistence and retries failed writes", asy
   }
 });
 
+it.each([
+  { name: "owner", ship: "~nec", settings: {} },
+  {
+    name: "allowlisted",
+    ship: "~bus",
+    settings: { autoAcceptGroupInvites: true, groupInviteAllowlist: ["~bus"] },
+  },
+])("awaits $name group invite acceptance and retries failed writes", async ({ ship, settings }) => {
+  const controller = new AbortController();
+  const runtime = { error: vi.fn(), exit: vi.fn(), log: vi.fn() } satisfies RuntimeEnv;
+  authenticateMock.mockResolvedValueOnce("urbauth-~zod=proof");
+  settingsManagerMock.load.mockResolvedValueOnce(settings);
+
+  const monitor = monitorTlonProvider({ abortSignal: controller.signal, runtime });
+  try {
+    await vi.waitFor(() => expect(sseClientMock.connect).toHaveBeenCalledOnce());
+    const foreignsSubscription = sseClientMock.subscribe.mock.calls
+      .map(([subscription]) => subscription)
+      .find(({ app, path }) => app === "groups" && path === "/v1/foreigns");
+    if (!foreignsSubscription) {
+      throw new Error("expected foreigns subscription");
+    }
+    sseClientMock.poke.mockClear();
+
+    let releaseWrite = () => {};
+    sseClientMock.poke.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseWrite = resolve;
+        }),
+    );
+    let settled = false;
+    const firstResult = foreignsSubscription.event({
+      [`${ship}/first`]: { invites: [{ valid: true, from: ship }] },
+    });
+    expect(firstResult).toBeInstanceOf(Promise);
+    const firstProcessing = Promise.resolve(firstResult).then(() => {
+      settled = true;
+    });
+    await setImmediate();
+    expect(sseClientMock.poke).toHaveBeenCalledOnce();
+    expect(settled).toBe(false);
+
+    releaseWrite();
+    await firstProcessing;
+    expect(settled).toBe(true);
+
+    sseClientMock.poke.mockRejectedValueOnce(new Error("group join failed"));
+    const retryEvent = {
+      [`${ship}/retry`]: { invites: [{ valid: true, from: ship }] },
+    };
+    await expect(foreignsSubscription.event(retryEvent)).rejects.toThrow("group join failed");
+    await foreignsSubscription.event(retryEvent);
+
+    expect(sseClientMock.poke).toHaveBeenCalledTimes(3);
+    expect(sseClientMock.poke.mock.calls[2]?.[0]).toMatchObject({
+      app: "groups",
+      mark: "group-join",
+      json: { flag: `${ship}/retry`, "join-all": true },
+    });
+  } finally {
+    controller.abort();
+    await monitor;
+  }
+});
+
+it.each([
+  { name: "owner", ship: "~nec", settings: {} },
+  {
+    name: "allowlisted",
+    ship: "~bus",
+    settings: { autoAcceptDmInvites: true, dmAllowlist: ["~bus"] },
+  },
+])(
+  "retries failed $name DM invite acceptance before acknowledgement",
+  async ({ ship, settings }) => {
+    const controller = new AbortController();
+    const runtime = { error: vi.fn(), exit: vi.fn(), log: vi.fn() } satisfies RuntimeEnv;
+    authenticateMock.mockResolvedValueOnce("urbauth-~zod=proof");
+    settingsManagerMock.load.mockResolvedValueOnce(settings);
+
+    const monitor = monitorTlonProvider({ abortSignal: controller.signal, runtime });
+    try {
+      await vi.waitFor(() => expect(sseClientMock.connect).toHaveBeenCalledOnce());
+      const chatSubscription = sseClientMock.subscribe.mock.calls
+        .map(([subscription]) => subscription)
+        .find(({ app, path }) => app === "chat" && path === "/v3");
+      if (!chatSubscription) {
+        throw new Error("expected chat subscription");
+      }
+      sseClientMock.poke.mockClear();
+      ingressMock.receive
+        .mockResolvedValueOnce({ kind: "ignored" })
+        .mockResolvedValueOnce({ kind: "ignored" });
+
+      const inviteEvent = [{ ship }];
+      sseClientMock.poke.mockRejectedValueOnce(new Error("DM invite write failed"));
+      await expect(chatSubscription.event(inviteEvent)).rejects.toThrow("DM invite write failed");
+      await chatSubscription.event(inviteEvent);
+
+      expect(sseClientMock.poke).toHaveBeenCalledTimes(2);
+      expect(sseClientMock.poke.mock.calls[1]?.[0]).toMatchObject({
+        app: "chat",
+        mark: "chat-dm-rsvp",
+        json: { ship, ok: true },
+      });
+    } finally {
+      controller.abort();
+      await monitor;
+    }
+  },
+);
+
+it("persists group invite approval before notification and acknowledgement", async () => {
+  const controller = new AbortController();
+  const runtime = { error: vi.fn(), exit: vi.fn(), log: vi.fn() } satisfies RuntimeEnv;
+  authenticateMock.mockResolvedValueOnce("urbauth-~zod=proof");
+
+  const monitor = monitorTlonProvider({ abortSignal: controller.signal, runtime });
+  try {
+    await vi.waitFor(() => expect(sseClientMock.connect).toHaveBeenCalledOnce());
+    const foreignsSubscription = sseClientMock.subscribe.mock.calls
+      .map(([subscription]) => subscription)
+      .find(({ app, path }) => app === "groups" && path === "/v1/foreigns");
+    if (!foreignsSubscription) {
+      throw new Error("expected foreigns subscription");
+    }
+    sseClientMock.poke.mockClear();
+
+    const inviteEvent = {
+      "~bus/private": { invites: [{ valid: true, from: "~bus" }] },
+    };
+    sseClientMock.poke.mockRejectedValueOnce(new Error("approval save failed"));
+    await expect(foreignsSubscription.event(inviteEvent)).rejects.toThrow("approval save failed");
+    await foreignsSubscription.event(inviteEvent);
+
+    const pendingWrites = sseClientMock.poke.mock.calls.filter(
+      ([payload]) => payload.json?.["put-entry"]?.["entry-key"] === "pendingApprovals",
+    );
+    expect(pendingWrites).toHaveLength(2);
+    expect(sseClientMock.poke).toHaveBeenCalledTimes(3);
+    expect(sseClientMock.poke.mock.calls[2]?.[0]).toMatchObject({
+      app: "chat",
+      mark: "chat-dm-action",
+    });
+  } finally {
+    controller.abort();
+    await monitor;
+  }
+});
+
+it("continues startup after an initial group invite write fails", async () => {
+  const controller = new AbortController();
+  const runtime = { error: vi.fn(), exit: vi.fn(), log: vi.fn() } satisfies RuntimeEnv;
+  authenticateMock.mockResolvedValueOnce("urbauth-~zod=proof");
+  settingsManagerMock.load.mockResolvedValueOnce({
+    autoAcceptGroupInvites: true,
+    autoDiscoverChannels: true,
+  });
+  sseClientMock.scry.mockImplementation(async (path) =>
+    path === "/groups-ui/v6/init.json"
+      ? {
+          foreigns: {
+            "~nec/startup": { invites: [{ valid: true, from: "~nec" }] },
+          },
+        }
+      : {},
+  );
+  sseClientMock.poke.mockImplementation(async (payload) => {
+    if (payload.mark === "group-join") {
+      throw new Error("initial group join failed");
+    }
+  });
+
+  const monitor = monitorTlonProvider({ abortSignal: controller.signal, runtime });
+  try {
+    await vi.waitFor(() => expect(sseClientMock.connect).toHaveBeenCalledOnce());
+    expect(sseClientMock.subscribe.mock.calls.map(([subscription]) => subscription)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ app: "groups", path: "/v1/foreigns" })]),
+    );
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("initial group join failed"),
+    );
+  } finally {
+    controller.abort();
+    await monitor;
+    sseClientMock.scry.mockReset().mockResolvedValue({});
+    sseClientMock.poke.mockReset().mockResolvedValue(undefined);
+  }
+});
+
 describe("monitorTlonProvider inbound media truth", () => {
   it.each([
     {

--- a/extensions/tlon/src/monitor/index.ts
+++ b/extensions/tlon/src/monitor/index.ts
@@ -980,8 +980,9 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
             continue;
           }
 
-          // Owner is always allowed
-          if (isOwner(ship)) {
+          const ownerInvite = isOwner(ship);
+          const allowed = ownerInvite || (await isDmAllowedWithIngress(ship, effectiveDmAllowlist));
+          if (ownerInvite || (effectiveAutoAcceptDmInvites && allowed)) {
             try {
               await api.poke({
                 app: "chat",
@@ -989,26 +990,18 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
                 json: { ship, ok: true },
               });
               processedDmInvites.add(ship);
-              runtime.log?.(`[tlon] Auto-accepted DM invite from owner ${ship}`);
+              runtime.log?.(
+                ownerInvite
+                  ? `[tlon] Auto-accepted DM invite from owner ${ship}`
+                  : `[tlon] Auto-accepted DM invite from ${ship}`,
+              );
             } catch (err) {
-              runtime.error?.(`[tlon] Failed to auto-accept DM from owner: ${String(err)}`);
-            }
-            continue;
-          }
-
-          const allowed = await isDmAllowedWithIngress(ship, effectiveDmAllowlist);
-          // Auto-accept if on allowlist and auto-accept is enabled
-          if (effectiveAutoAcceptDmInvites && allowed) {
-            try {
-              await api.poke({
-                app: "chat",
-                mark: "chat-dm-rsvp",
-                json: { ship, ok: true },
-              });
-              processedDmInvites.add(ship);
-              runtime.log?.(`[tlon] Auto-accepted DM invite from ${ship}`);
-            } catch (err) {
-              runtime.error?.(`[tlon] Failed to auto-accept DM from ${ship}: ${String(err)}`);
+              runtime.error?.(
+                ownerInvite
+                  ? `[tlon] Failed to auto-accept DM from owner: ${String(err)}`
+                  : `[tlon] Failed to auto-accept DM from ${ship}: ${String(err)}`,
+              );
+              throw err;
             }
             continue;
           }
@@ -1376,11 +1369,12 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
       const processedGroupInvites = new Set<string>();
 
       // Helper to process pending invites
-      const processPendingInvites = async (foreigns: Foreigns) => {
+      const processPendingInvites = async (foreigns: Foreigns, propagateWriteFailures = false) => {
         if (!foreigns || typeof foreigns !== "object") {
           return;
         }
 
+        let firstWriteError: Error | undefined;
         for (const [groupFlag, foreign] of Object.entries(foreigns)) {
           if (processedGroupInvites.has(groupFlag)) {
             continue;
@@ -1395,8 +1389,12 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
           }
 
           const inviterShip = validInvite.from;
-          // Owner invites are always accepted
-          if (isOwner(inviterShip)) {
+          const ownerInvite = isOwner(inviterShip);
+          const shouldAccept =
+            ownerInvite ||
+            (effectiveAutoAcceptGroupInvites &&
+              isGroupInviteAllowed(inviterShip, effectiveGroupInviteAllowlist));
+          if (shouldAccept) {
             try {
               await api.poke({
                 app: "groups",
@@ -1407,89 +1405,69 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
                 },
               });
               processedGroupInvites.add(groupFlag);
-              runtime.log?.(`[tlon] Auto-accepted group invite from owner: ${groupFlag}`);
-            } catch (err) {
-              runtime.error?.(`[tlon] Failed to accept group invite from owner: ${String(err)}`);
-            }
-            continue;
-          }
-
-          // Skip if auto-accept is disabled
-          if (!effectiveAutoAcceptGroupInvites) {
-            // If owner is configured, queue approval
-            if (effectiveOwnerShip) {
-              const approval = createPendingApproval({
-                type: "group",
-                requestingShip: inviterShip,
-                groupFlag,
-              });
-              await queueApprovalRequest(approval);
-              processedGroupInvites.add(groupFlag);
-            }
-            continue;
-          }
-
-          // Check if inviter is on allowlist
-          const isAllowed = isGroupInviteAllowed(inviterShip, effectiveGroupInviteAllowlist);
-
-          if (!isAllowed) {
-            // If owner is configured, queue approval
-            if (effectiveOwnerShip) {
-              const approval = createPendingApproval({
-                type: "group",
-                requestingShip: inviterShip,
-                groupFlag,
-              });
-              await queueApprovalRequest(approval);
-              processedGroupInvites.add(groupFlag);
-            } else {
               runtime.log?.(
-                `[tlon] Rejected group invite from ${inviterShip} (not in groupInviteAllowlist): ${groupFlag}`,
+                ownerInvite
+                  ? `[tlon] Auto-accepted group invite from owner: ${groupFlag}`
+                  : `[tlon] Auto-accepted group invite: ${groupFlag} (from ${inviterShip})`,
               );
-              processedGroupInvites.add(groupFlag);
+            } catch (err) {
+              runtime.error?.(
+                ownerInvite
+                  ? `[tlon] Failed to accept group invite from owner: ${String(err)}`
+                  : `[tlon] Failed to auto-accept group ${groupFlag}: ${String(err)}`,
+              );
+              if (propagateWriteFailures && firstWriteError === undefined) {
+                firstWriteError = err instanceof Error ? err : new Error(formatErrorMessage(err));
+              }
             }
             continue;
           }
 
-          // Inviter is on allowlist - accept the invite
-          try {
-            await api.poke({
-              app: "groups",
-              mark: "group-join",
-              json: {
-                flag: groupFlag,
-                "join-all": true,
-              },
+          if (effectiveOwnerShip) {
+            const approval = createPendingApproval({
+              type: "group",
+              requestingShip: inviterShip,
+              groupFlag,
             });
+            await queueApprovalRequest(approval);
             processedGroupInvites.add(groupFlag);
-            runtime.log?.(
-              `[tlon] Auto-accepted group invite: ${groupFlag} (from ${validInvite.from})`,
-            );
-          } catch (err) {
-            runtime.error?.(`[tlon] Failed to auto-accept group ${groupFlag}: ${String(err)}`);
+            continue;
           }
+
+          if (effectiveAutoAcceptGroupInvites) {
+            runtime.log?.(
+              `[tlon] Rejected group invite from ${inviterShip} (not in groupInviteAllowlist): ${groupFlag}`,
+            );
+            processedGroupInvites.add(groupFlag);
+          }
+        }
+
+        if (firstWriteError !== undefined) {
+          throw firstWriteError;
         }
       };
 
       // Process existing pending invites from init data
       if (initForeigns) {
-        await processPendingInvites(initForeigns);
+        try {
+          await processPendingInvites(initForeigns);
+        } catch (error: unknown) {
+          runtime.error?.(`[tlon] Error handling initial foreigns: ${formatErrorMessage(error)}`);
+        }
       }
 
       try {
         await api.subscribe({
           app: "groups",
           path: "/v1/foreigns",
-          event: (data: unknown) => {
-            void (async () => {
-              try {
-                await processPendingInvites(data as Foreigns);
-              } catch (error: unknown) {
-                runtime.error?.(
-                  `[tlon] Error handling foreigns event: ${formatErrorMessage(error)}`,
-                );
-              }
-            })();
+          event: async (data: unknown) => {
+            try {
+              await processPendingInvites(data as Foreigns, true);
+            } catch (error: unknown) {
+              runtime.error?.(`[tlon] Error handling foreigns event: ${formatErrorMessage(error)}`);
+              // SSE advances its durable ack only after this callback resolves.
+              throw error;
+            }
           },
           err: (error) => {
             runtime.error?.(`[tlon] Foreigns subscription error: ${String(error)}`);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Tlon foreign-invite events could be acknowledged before group acceptance or approval state was durably written. Callback-side failures could therefore detach, be swallowed, or leave an invite marked processed even though its side effect never completed.

## Why This Change Was Made

The monitor now awaits owner and allowlisted group acceptance, direct-message RSVP handling, and approval persistence before acknowledging the event. Approval state is staged and rolled back on save failure; owner notification remains best effort only after the durable write succeeds. Startup and replay behavior are preserved.

## User Impact

Tlon invites are no longer silently lost when joining a group or persisting approval state fails; failed work remains retryable instead of being prematurely acknowledged.

## Evidence

- Three genuine ordering/persistence regressions failed before the repair and pass afterward.
- Focused monitor coverage passes 16/16; full Tlon coverage passes 289/289 tests.
- Focused formatting, type-aware lint, and diff checks pass.
- Fresh autoreview and independent review report no actionable findings.
- Production delta: +69/-88, net -19 lines.

## Follow-up

Model approval-response decisions as explicit durable/idempotent phases so response retries can share the same ownership contract.
