### PR TITLE
refactor(workboard): centralize dispatch owner selection

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1431,7 +1431,7 @@ extensions/workboard/src/store-card-helpers.ts	1
 extensions/workboard/src/store-core.ts	5
 extensions/workboard/src/store-normalizers.ts	11
 extensions/workboard/src/store-workflow.ts	2
-extensions/workboard/src/store.ts	5
+extensions/workboard/src/store.ts	1
 extensions/workboard/src/tools.ts	11
 extensions/workboard/src/workspace-access.ts	1
 extensions/xai/code-execution.ts	2

--- a/extensions/workboard/src/dispatcher-ownership.test.ts
+++ b/extensions/workboard/src/dispatcher-ownership.test.ts
@@ -84,6 +84,36 @@ describe("Workboard dispatcher ownership", () => {
     await expect(store.get(unassigned.id)).resolves.toMatchObject({ status: "ready" });
   });
 
+  it("keeps an active blank-assignment card in the default worker slot", async () => {
+    const keyed = createMemoryStore();
+    const store = new WorkboardStore(keyed);
+    const active = await store.create({
+      title: "Active default worker",
+      status: "running",
+      workspaceAccess: { unrestricted: true },
+    });
+    await keyed.register(active.id, {
+      version: 1,
+      card: { ...active, agentId: "" },
+    });
+    const queued = await store.create({
+      title: "Queued default worker",
+      status: "ready",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "unexpected-second-worker" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 1 },
+    });
+
+    expect(result.started).toEqual([]);
+    expect(run).not.toHaveBeenCalled();
+    await expect(store.get(queued.id)).resolves.toMatchObject({ status: "ready" });
+  });
+
   it("bounds failed worker attempts without draining the ready queue", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const cards = [];
@@ -424,42 +454,49 @@ describe("Workboard dispatcher ownership", () => {
     },
   );
 
-  it("replaces an expired ready-card claim without waiting for stale-claim cleanup", async () => {
-    const store = new WorkboardStore(createMemoryStore());
-    const now = Date.now();
-    const card = await store.create({
-      title: "Ready with an expired lease",
-      status: "ready",
-      agentId: "shared-worker",
-      workspaceAccess: { unrestricted: true },
-      metadata: {
-        claim: {
-          ownerId: "retired-worker",
-          token: "expired-token",
-          claimedAt: now - 60_000,
-          lastHeartbeatAt: now - 60_000,
-          expiresAt: now - 1_000,
+  it.each([
+    { agentId: "shared-worker", ownerId: "shared-worker" },
+    { agentId: undefined, ownerId: "workboard-dispatcher" },
+  ])(
+    "replaces an expired ready-card claim with the $ownerId slot",
+    async ({ agentId, ownerId }) => {
+      const store = new WorkboardStore(createMemoryStore());
+      const now = Date.now();
+      const card = await store.create({
+        title: "Ready with an expired lease",
+        status: "ready",
+        agentId,
+        workspaceAccess: { unrestricted: true },
+        metadata: {
+          claim: {
+            ownerId: "retired-worker",
+            token: "expired-token",
+            claimedAt: now - 60_000,
+            lastHeartbeatAt: now - 60_000,
+            expiresAt: now - 1_000,
+          },
         },
-      },
-    });
-    const run = vi.fn().mockResolvedValue({ runId: "run-reclaimed" });
+      });
+      const run = vi.fn().mockResolvedValue({ runId: "run-reclaimed" });
 
-    const result = await dispatchAndStartWorkboardCards({
-      store,
-      subagent: { run },
-      options: { maxStarts: 1 },
-    });
+      const result = await dispatchAndStartWorkboardCards({
+        store,
+        subagent: { run },
+        options: { maxStarts: 1 },
+      });
 
-    expect(result.started).toEqual([
-      expect.objectContaining({ cardId: card.id, runId: "run-reclaimed" }),
-    ]);
-    expect(run).toHaveBeenCalledOnce();
-    await expect(store.get(card.id)).resolves.toMatchObject({
-      status: "running",
-      metadata: { claim: { ownerId: "shared-worker" } },
-    });
-    expect((await store.get(card.id))?.metadata?.claim?.token).not.toBe("expired-token");
-  });
+      expect(result.started).toEqual([
+        expect.objectContaining({ cardId: card.id, runId: "run-reclaimed" }),
+      ]);
+      expect(run).toHaveBeenCalledOnce();
+      await expect(store.get(card.id)).resolves.toMatchObject({
+        status: "running",
+        metadata: { claim: { ownerId } },
+      });
+      expect((await store.get(card.id))?.agentId).toBe(agentId);
+      expect((await store.get(card.id))?.metadata?.claim?.token).not.toBe("expired-token");
+    },
+  );
 
   it("serializes concurrent board dispatches for the same worker", async () => {
     const store = new WorkboardStore(createMemoryStore());

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -22,11 +22,7 @@ import {
 } from "./dispatcher-workspace.js";
 import { workboardSessionKeyForCard } from "./session-link.js";
 import { cardBoardId } from "./store-card-helpers.js";
-import {
-  DEFAULT_WORKBOARD_DISPATCH_OWNER,
-  workboardCardConsumesOwnerSlot,
-  workboardCardSlotOwner,
-} from "./store-constants.js";
+import { workboardCardConsumesOwnerSlot, workboardCardSlotOwner } from "./store-constants.js";
 import { WorkboardStore, type WorkboardDispatchResult } from "./store.js";
 import {
   assertCanonicalWorkboardRootAccess,
@@ -228,15 +224,6 @@ function sortReadyCards(a: WorkboardCard, b: WorkboardCard): number {
   );
 }
 
-function resolveDispatchOwner(card: WorkboardCard, now: number, ownerOverride?: string): string {
-  return (
-    ownerOverride ||
-    (cardHasActiveClaim(card, now) ? card.metadata?.claim?.ownerId : undefined) ||
-    card.agentId ||
-    DEFAULT_WORKBOARD_DISPATCH_OWNER
-  );
-}
-
 function selectStartableCards(
   cards: WorkboardCard[],
   limit: number,
@@ -261,7 +248,7 @@ function selectStartableCards(
   const selectedOwners = new Set<string>();
   const ordered = mode === "scheduled" ? candidates.toSorted(sortReadyCards) : candidates;
   for (const card of ordered) {
-    const owner = resolveDispatchOwner(card, now, ownerOverride);
+    const owner = ownerOverride || workboardCardSlotOwner(card, now);
     const rejection = cardIsArchived(card)
       ? "Card is archived; restore it before starting."
       : cardHasActiveClaim(card, now)
@@ -356,7 +343,7 @@ async function runWorkboardDispatch(
     startFailures.push(selection.rejection);
   }
   for (const card of selection.cards) {
-    const ownerId = resolveDispatchOwner(card, now, ownerOverride);
+    const ownerId = ownerOverride || workboardCardSlotOwner(card, now);
     if (acceptedStarts >= maxStarts || attemptedStarts >= maxAttempts) {
       break;
     }

--- a/extensions/workboard/src/store-constants.ts
+++ b/extensions/workboard/src/store-constants.ts
@@ -14,7 +14,6 @@ export const MAX_CARD_LINKS = 50;
 export const MAX_CARD_PROOF = 40;
 export const MAX_CARD_ARTIFACTS = 40;
 export const MAX_CARD_ATTACHMENTS = 20;
-export const MAX_ATTACHMENT_ENTRIES = MAX_CARDS * (MAX_CARD_ATTACHMENTS + 1);
 export const MAX_CARD_WORKER_LOGS = 40;
 export const MAX_ATTACHMENT_BYTES = 256 * 1024;
 export const MAX_CARD_DIAGNOSTICS = 12;
@@ -46,8 +45,17 @@ export function workboardCardConsumesOwnerSlot(card: WorkboardCard, now: number)
   );
 }
 
-export function workboardCardSlotOwner(card: WorkboardCard): string {
-  return card.metadata?.claim?.ownerId ?? card.agentId ?? DEFAULT_WORKBOARD_DISPATCH_OWNER;
+export function workboardCardSlotOwner(card: WorkboardCard, now?: number): string {
+  const claim = card.metadata?.claim;
+  // Ready candidates pass now to ignore expired claims. Occupied slots omit it
+  // so the claim owner keeps its slot through the heartbeat-reclaim grace period.
+  return (
+    (claim && (now === undefined || isFutureDateTimestampMs(claim.expiresAt, { nowMs: now }))
+      ? claim.ownerId
+      : undefined) ||
+    card.agentId ||
+    DEFAULT_WORKBOARD_DISPATCH_OWNER
+  );
 }
 
 export function secondsToDurationMs(seconds: number): number {

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -11,12 +11,6 @@ import type {
   WorkboardStaleState,
   WorkboardStatus,
 } from "@openclaw/workboard-contract";
-import type {
-  PersistedWorkboardAttachment,
-  PersistedWorkboardBoard,
-  PersistedWorkboardNotificationSubscription,
-  WorkboardKeyedStore,
-} from "./persistence-types.js";
 import { createWorkboardSqliteStores } from "./sqlite-store.js";
 import {
   buildWorkerContext,
@@ -35,8 +29,6 @@ import {
 } from "./store-card-helpers.js";
 import {
   isWorkboardClaimReclaimable,
-  MAX_ATTACHMENT_ENTRIES,
-  MAX_CARDS,
   MAX_CARD_NOTIFICATIONS,
   secondsToDurationMs,
 } from "./store-constants.js";
@@ -643,34 +635,6 @@ export class WorkboardStore extends WorkboardNotificationStore {
       throw new Error(`card not found: ${id}`);
     }
     return buildWorkerContext(card, await this.list());
-  }
-
-  static open(
-    openKeyedStore: (options: {
-      namespace: string;
-      maxEntries: number;
-    }) => WorkboardKeyedStore<unknown>,
-  ) {
-    return new WorkboardStore(
-      openKeyedStore({
-        namespace: "workboard.cards",
-        maxEntries: MAX_CARDS,
-      }) as WorkboardKeyedStore,
-      {
-        boards: openKeyedStore({
-          namespace: "workboard.boards",
-          maxEntries: 200,
-        }) as WorkboardKeyedStore<PersistedWorkboardBoard>,
-        subscriptions: openKeyedStore({
-          namespace: "workboard.notify",
-          maxEntries: 2000,
-        }) as WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>,
-        attachments: openKeyedStore({
-          namespace: "workboard.attachments",
-          maxEntries: MAX_ATTACHMENT_ENTRIES,
-        }) as WorkboardKeyedStore<PersistedWorkboardAttachment>,
-      },
-    );
   }
 
   static openSqlite() {


### PR DESCRIPTION
Related: #115119

## What Problem This Solves

Workboard used separate owner-selection logic when choosing ready tasks and when counting occupied worker slots. Its private store also retained an unused KV constructor after runtime registration moved to SQLite.

## Why This Change Was Made

Use one private owner selector for dispatch and occupied-slot checks. Ready tasks ignore expired claims; occupied tasks retain their claim owner through the existing heartbeat-reclaim grace period. Delete the unused private KV factory and its unused attachment-entry cap. Doctor's legacy KV migration and the canonical SQLite runtime remain unchanged.

Production LOC: +14/-55 (net -41). Tests: +70/-33 (net +37). The assertion baseline shrinks from 5 to 1 only because four assertions were deleted with the dead constructor. No schema, migration, config, or public API change.

## User Impact

No intended SQLite behavior change. Worker selection and occupied-slot accounting now share one policy while preserving claim expiry and reclaim behavior. The blank-assignment regression covers the in-memory store boundary; SQLite already normalizes empty assignment values, so this is not presented as a new reachable SQLite bug.

## Evidence

- Candidate `099bd5a64aee6f0e41a358a9085cdb392f78f2aa`.
- 288 owner, dispatch, race, real SQLite, lifecycle, restart, cleanup, and doctor-migration tests passed using an install matching the candidate's dependency manifests.
- Complete changed-file gate and typed lint passed without skipped guards or checks.
- Independent reviewer inspected the final source and public exports and reran all 30 ownership tests. Fresh structured Codex P1 review passed.
- Model/subagent acceptance is fixture controlled; this is actual SQLite/lifecycle proof, not authenticated provider or live Gateway proof.
- Maintainer-requested, AI-assisted refactor. CI on the published candidate remains required before landing.
