### PR TITLE
refactor(telegram): unify model selection and callback bounds

### DIFF
--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -51,7 +51,6 @@ import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
 import {
   buildModelsKeyboard,
   calculateTotalPages,
-  getModelsPageSize,
   parseModelCallbackData,
   resolveModelListCallback,
   resolveModelSelection,
@@ -568,8 +567,7 @@ async function handleTelegramModelCallback(params: {
       return true;
     }
     const models = [...modelSet].toSorted((left, right) => left.localeCompare(right));
-    const pageSize = getModelsPageSize();
-    const totalPages = calculateTotalPages(models.length, pageSize);
+    const totalPages = calculateTotalPages(models.length);
     const safePage = Math.max(1, Math.min(page, totalPages));
     const currentModel =
       sessionState.model || `${activeResolvedDefault.provider}/${activeResolvedDefault.model}`;
@@ -579,7 +577,6 @@ async function handleTelegramModelCallback(params: {
       currentModel,
       currentPage: safePage,
       totalPages,
-      pageSize,
       modelNames,
     });
     const text = formatModelsAvailableHeader({

--- a/extensions/telegram/src/model-buttons.test.ts
+++ b/extensions/telegram/src/model-buttons.test.ts
@@ -409,37 +409,30 @@ describe("buildModelsKeyboard", () => {
     const cases = [
       {
         name: "first page",
-        params: { currentPage: 1, models: ["model1", "model2"] },
+        currentPage: 1,
         expectedPagination: ["1/3", "Next ▶"],
       },
       {
         name: "middle page",
-        params: {
-          currentPage: 2,
-          models: ["model1", "model2", "model3", "model4", "model5", "model6"],
-        },
+        currentPage: 2,
         expectedPagination: ["◀ Prev", "2/3", "Next ▶"],
       },
       {
         name: "last page",
-        params: {
-          currentPage: 3,
-          models: ["model1", "model2", "model3", "model4", "model5", "model6"],
-        },
+        currentPage: 3,
         expectedPagination: ["◀ Prev", "3/3"],
       },
     ] as const;
+    const models = Array.from({ length: 24 }, (_, index) => `model${index + 1}`);
     for (const testCase of cases) {
       const result = buildModelsKeyboard({
         provider: "anthropic",
-        models: [...testCase.params.models],
-        currentPage: testCase.params.currentPage,
+        models,
+        currentPage: testCase.currentPage,
         totalPages: 3,
-        pageSize: 2,
       });
-      // 2 model rows + pagination row + back button
-      expect(result, testCase.name).toHaveLength(4);
-      expect(result[2]?.map((button) => button.text)).toEqual(testCase.expectedPagination);
+      expect(result, testCase.name).toHaveLength(10);
+      expect(result[8]?.map((button) => button.text)).toEqual(testCase.expectedPagination);
     }
   });
 
@@ -526,13 +519,11 @@ describe("buildBrowseProvidersButton", () => {
   });
 });
 
-describe("getModelsPageSize", () => {
-  it("returns default page size", () => {
+describe("model picker pagination contracts", () => {
+  it("keeps the default page size available to public plugin consumers", () => {
     expect(getModelsPageSize()).toBe(8);
   });
-});
 
-describe("calculateTotalPages", () => {
   it("calculates pages correctly", () => {
     expect(calculateTotalPages(0)).toBe(0);
     expect(calculateTotalPages(1)).toBe(1);
@@ -542,9 +533,18 @@ describe("calculateTotalPages", () => {
     expect(calculateTotalPages(17)).toBe(3);
   });
 
-  it("uses custom page size", () => {
+  it("preserves custom page sizes for public plugin consumers", () => {
     expect(calculateTotalPages(10, 5)).toBe(2);
     expect(calculateTotalPages(11, 5)).toBe(3);
+    expect(
+      buildModelsKeyboard({
+        provider: "openai",
+        models: ["first", "second", "third"],
+        currentPage: 2,
+        totalPages: 2,
+        pageSize: 2,
+      })[0]?.[0]?.text,
+    ).toBe("third");
   });
 });
 

--- a/extensions/telegram/src/model-buttons.ts
+++ b/extensions/telegram/src/model-buttons.ts
@@ -11,7 +11,6 @@
  * - mdl_back              - back to providers list
  */
 import { createHash } from "node:crypto";
-import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { fitsTelegramCallbackData } from "./approval-callback-data.js";
@@ -83,10 +82,6 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
       return { type: "list-ref", digest: opaqueProviderMatch[1], page };
     }
   }
-  if (!trimmed.startsWith("mdl_")) {
-    return null;
-  }
-
   if (trimmed === CALLBACK_PREFIX.providers || trimmed === CALLBACK_PREFIX.back) {
     return { type: trimmed === CALLBACK_PREFIX.providers ? "providers" : "back" };
   }
@@ -102,34 +97,14 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
   }
 
   // mdl_sel/{model} (compact fallback)
-  const compactSelMatch = trimmed.match(/^mdl_sel\/(.+)$/);
-  if (compactSelMatch) {
-    const modelRef = compactSelMatch[1];
-    if (modelRef) {
-      return {
-        type: "select",
-        model: modelRef,
-      };
-    }
+  const compactModel = trimmed.match(/^mdl_sel\/(.+)$/)?.[1];
+  if (compactModel) {
+    return { type: "select", model: compactModel };
   }
 
   // mdl_sel_{provider/model}
-  const selMatch = trimmed.match(/^mdl_sel_(.+)$/);
-  if (selMatch) {
-    const modelRef = selMatch[1];
-    if (modelRef) {
-      const slashIndex = modelRef.indexOf("/");
-      if (slashIndex > 0 && slashIndex < modelRef.length - 1) {
-        return {
-          type: "select",
-          provider: modelRef.slice(0, slashIndex),
-          model: modelRef.slice(slashIndex + 1),
-        };
-      }
-    }
-  }
-
-  return null;
+  const [, provider, model] = trimmed.match(/^mdl_sel_([^/]+)\/(.+)$/) ?? [];
+  return provider && model ? { type: "select", provider, model } : null;
 }
 
 export function buildModelSelectionCallbackData(params: {
@@ -164,42 +139,30 @@ export function resolveModelSelection(params: {
   byProvider: ReadonlyMap<string, ReadonlySet<string>>;
 }): ResolveModelSelectionResult {
   const callback = params.callback;
-  if (callback.type === "select-ref") {
-    const matches = params.providers.flatMap((provider) =>
-      [...(params.byProvider.get(provider) ?? [])]
-        .filter((model) => hashOpaqueCallback("model", provider, model) === callback.digest)
-        .map((model) => ({ provider, model })),
-    );
-    return matches.length === 1
-      ? { kind: "resolved", ...expectDefined(matches[0], "single matching model") }
-      : {
-          kind: "ambiguous",
-          model: callback.digest,
-          matchingProviders: matches.map(({ provider }) => provider),
-        };
-  }
-  if (callback.provider) {
+  if (callback.type === "select" && callback.provider) {
     return {
       kind: "resolved",
       provider: callback.provider,
       model: callback.model,
     };
   }
-  const matchingProviders = params.providers.filter((id) =>
-    params.byProvider.get(id)?.has(callback.model),
-  );
-  if (matchingProviders.length === 1) {
-    return {
-      kind: "resolved",
-      provider: expectDefined(matchingProviders.at(0), "single matching model provider"),
-      model: callback.model,
-    };
-  }
-  return {
-    kind: "ambiguous",
-    model: callback.model,
-    matchingProviders,
-  };
+  const matches = params.providers.flatMap((provider) => {
+    const models = params.byProvider.get(provider);
+    if (callback.type === "select") {
+      return models?.has(callback.model) ? [{ provider, model: callback.model }] : [];
+    }
+    return [...(models ?? [])]
+      .filter((model) => hashOpaqueCallback("model", provider, model) === callback.digest)
+      .map((model) => ({ provider, model }));
+  });
+  const [match] = matches;
+  return matches.length === 1 && match
+    ? { kind: "resolved", ...match }
+    : {
+        kind: "ambiguous",
+        model: callback.type === "select" ? callback.model : callback.digest,
+        matchingProviders: matches.map(({ provider }) => provider),
+      };
 }
 
 export function resolveModelListCallback(params: {
@@ -213,8 +176,9 @@ export function resolveModelListCallback(params: {
   const matches = params.providers.filter(
     (provider) => hashOpaqueCallback("provider", provider) === callback.digest,
   );
-  return matches.length === 1
-    ? { provider: expectDefined(matches[0], "single matching provider"), page: callback.page }
+  const [provider] = matches;
+  return matches.length === 1 && provider !== undefined
+    ? { provider, page: callback.page }
     : undefined;
 }
 
@@ -236,32 +200,13 @@ function isCurrentModelSelection(params: {
  * Build provider selection keyboard with 2 providers per row.
  */
 export function buildProviderKeyboard(providers: ProviderInfo[]): ButtonRow[] {
-  if (providers.length === 0) {
-    return [];
-  }
-
   const rows: ButtonRow[] = [];
-  let currentRow: ButtonRow = [];
-
-  for (const provider of providers) {
-    const button = {
+  for (const [index, provider] of providers.entries()) {
+    (rows[Math.floor(index / 2)] ??= []).push({
       text: `${provider.id} (${provider.count})`,
       callback_data: buildProviderListCallbackData(provider.id, 1),
-    };
-
-    currentRow.push(button);
-
-    if (currentRow.length === 2) {
-      rows.push(currentRow);
-      currentRow = [];
-    }
+    });
   }
-
-  // Push any remaining button
-  if (currentRow.length > 0) {
-    rows.push(currentRow);
-  }
-
   return rows;
 }
 

--- a/extensions/telegram/src/question-callback-data.ts
+++ b/extensions/telegram/src/question-callback-data.ts
@@ -1,6 +1,7 @@
 // Telegram-private ask_user callback envelope.
+import { fitsTelegramCallbackData } from "./approval-callback-data.js";
+
 const TELEGRAM_QUESTION_CALLBACK_PREFIX = "tgq1:";
-const TELEGRAM_CALLBACK_DATA_MAX_BYTES = 64;
 const QUESTION_RECORD_ID_PATTERN = /^ask_[a-f0-9]{32}$/u;
 
 export type TelegramQuestionCallback = {
@@ -24,17 +25,13 @@ export function buildTelegramQuestionCallbackData(
     return undefined;
   }
   const data = `${TELEGRAM_QUESTION_CALLBACK_PREFIX}${callback.questionId}:${callback.optionIndex}`;
-  return Buffer.byteLength(data, "utf8") <= TELEGRAM_CALLBACK_DATA_MAX_BYTES ? data : undefined;
+  return fitsTelegramCallbackData(data) ? data : undefined;
 }
 
 export function parseTelegramQuestionCallbackData(
   data?: string | null,
 ): TelegramQuestionCallback | null {
-  if (
-    !hasTelegramQuestionCallbackPrefix(data) ||
-    !data ||
-    Buffer.byteLength(data, "utf8") > TELEGRAM_CALLBACK_DATA_MAX_BYTES
-  ) {
+  if (!hasTelegramQuestionCallbackPrefix(data) || !data || !fitsTelegramCallbackData(data)) {
     return null;
   }
   const match = /^tgq1:(ask_[a-f0-9]{32}):([0-3])$/u.exec(data);

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -9,6 +9,7 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { clampPositiveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
+  fitsTelegramCallbackData,
   hasTelegramApprovalCallbackPrefix,
   parseTelegramApprovalCallbackData,
 } from "./approval-callback-data.js";
@@ -98,7 +99,7 @@ function isNonemptyTelegramCallbackValue(value: unknown): value is string {
 }
 
 function isBoundedTelegramCallbackData(value: unknown): value is string {
-  return isNonemptyTelegramCallbackValue(value) && Buffer.byteLength(value, "utf8") <= 64;
+  return isNonemptyTelegramCallbackValue(value) && fitsTelegramCallbackData(value);
 }
 
 function canReconcileTelegramLegacyLane(params: {


### PR DESCRIPTION
Related: #114472

## What Problem This Solves

Telegram's model picker repeated selection and keyboard-building logic, while question callbacks and durable ingress each separately implemented the callback byte limit. These copies made the long-model callback repair harder to maintain consistently.

## Why This Change Was Made

Unify compact and opaque model selection, simplify provider keyboard construction, and reuse the existing Telegram callback byte-limit helper at the question and ingress boundaries. The router uses the existing default page size. Public custom page-size APIs and callback formats are preserved.

Production LOC: +36/-96 (net -60). Tests: +20/-20 (net 0). No configuration, storage, protocol, dependency, or custom-reaction changes.

## User Impact

No intended user-visible behavior change. Long model names, provider navigation, selection recovery, and ordinary question/approval callbacks keep their existing behavior.

## Evidence

- Candidate `f8002353b6fb7c6cbcce8062fb68d816119d4810`.
- Recovery: **478 tests across13 files passed**, including real grammY/HTTP callback processing and SQLite close/reopen/durable callback replay. The complete selected changed gate and five additional doctor contract tests passed on matching dependencies.
- Fresh structured Codex P1 and separate independent SOURCE+BEHAVIOR review passed on this exact candidate.
- New authenticated Telegram proof passed: https://github.com/openclaw/openclaw/actions/runs/33007968230 . Public recordings and proof: https://github.com/openclaw/openclaw/pull/130336#issuecomment-5430406976 . A leased real Telegram user activated callbacks through TDLib while native Telegram Desktop was observed and recorded; these were not simulated Bot API injections or Desktop mouse clicks.
- Both baseline and candidate passed default eight-model pagination (three pages), Prev/Next/Back, opaque provider names, compact ambiguity recovery, long and ordinary model selection and reopened selected-model checkmarks. Typed question selection preserved `env|prod` in the provider tool result. Both lanes recorded168 callback payloads, at most52UTF-8 bytes each. The final cropped videos show the last question flow; earlier model-selection evidence is in the full authenticated event/request facts.
- Provenance: trusted baseline/harness `8585e7e04eef67c43e49a3db290d6d8e4f709ae3`; synthetic merged candidate `c4f5a1f57aa9d0333addd2686a81e1adf0398e18` has that baseline and exact PRhead as parents. Lane attestations, media hashes and cleanup were verified. Burner lease and private state were released/removed. The old #114472 run was not reused.
- Limitations: live session CLI commands exited0 but their JSON output was not retained; persisted selection is corroborated by reopened picker checkmarks, while the local real-HTTP test directly verifies session-store fields. One redundant second reply-markup clear returned400 on both baseline and candidate with no visible failure; consolidating that pre-existing duplicate cleanup is a named follow-up, not a regression fixed here.
- Exact-head CI is green: https://github.com/openclaw/openclaw/actions/runs/33007875625 . Maintainer-requested, AI-assisted refactor; native prepare/merge remains the final landing gate.
