### PR TITLE
fix(agents): preserve compaction prompt tool policy

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -4,12 +4,14 @@
 import { vi, type Mock } from "vitest";
 import type { CompactResult } from "../../context-engine/types.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
+import type { createOpenClawCodingTools } from "../agent-tools.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { clearAgentHarnesses } from "../harness/registry.js";
 import type { AgentHarness } from "../harness/types.js";
 import type { ModelAuthMode } from "../model-auth.js";
 import type { AgentRuntimePlan, BuildAgentRuntimePlanParams } from "../runtime-plan/types.js";
 import { agentSessionAutomaticCompaction } from "../sessions/agent-session-compaction.js";
+import type { buildEmbeddedSystemPrompt } from "./system-prompt.js";
 
 type MockResolvedModel = {
   model: {
@@ -202,7 +204,7 @@ function createMockToolDefinitions(tools: unknown[] = []) {
     };
   });
 }
-export const createOpenClawCodingToolsMock = vi.fn(() => []);
+export const createOpenClawCodingToolsMock = vi.fn<typeof createOpenClawCodingTools>(() => []);
 export const buildEmbeddedExtensionFactoriesMock = vi.fn(() => []);
 export const resolveEffectiveCompactionModeMock = vi.fn(() => "default");
 export const guardSessionManagerMock = vi.fn(() => ({
@@ -219,7 +221,8 @@ export const listRegisteredPluginAgentPromptGuidanceMock = vi.fn((params?: { sur
       ? ["ACP compact command guidance."]
       : ["Main compact command guidance."],
 );
-export const buildEmbeddedSystemPromptMock = vi.fn(() => "");
+export const buildEmbeddedSystemPromptMock = vi.fn<typeof buildEmbeddedSystemPrompt>(() => "");
+export const resolveSkillsPromptMock = vi.fn((): string | undefined => undefined);
 export const resolveEmbeddedAgentStreamFnMock: Mock<
   (params?: unknown) => MockEmbeddedAgentStreamFn
 > = vi.fn((_params?: unknown) => vi.fn());
@@ -563,6 +566,8 @@ export function resetCompactSessionStateMocks(): void {
   );
   buildEmbeddedSystemPromptMock.mockReset();
   buildEmbeddedSystemPromptMock.mockReturnValue("");
+  resolveSkillsPromptMock.mockReset();
+  resolveSkillsPromptMock.mockReturnValue(undefined);
 }
 
 export function resetCompactHooksHarnessMocks(): void {
@@ -995,7 +1000,7 @@ export async function loadCompactHooksHarness(): Promise<{
   });
 
   vi.doMock("../../skills/loading/workspace-skill-prompt.js", () => ({
-    resolveSkillsPrompt: vi.fn(() => undefined),
+    resolveSkillsPrompt: resolveSkillsPromptMock,
   }));
 
   vi.doMock("../agent-scope.js", () => ({

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -49,6 +49,7 @@ import {
   resolveModelAsyncMock,
   resolveModelMock,
   resolveSandboxContextMock,
+  resolveSkillsPromptMock,
   resolveSessionAgentIdMock,
   resolveSessionAgentIdsMock,
   rotateTranscriptAfterCompactionMock,
@@ -389,6 +390,96 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     );
     expect(sessionManualCompactionMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      label: "unrestricted",
+      toolsAllow: undefined,
+      expectedPromptMode: "full",
+      expectedSkillsPrompt: "PRIVATE_SKILL_MARKER",
+      expectedToolNames: ["read", "exec"],
+    },
+    {
+      label: "wildcard",
+      toolsAllow: ["*"],
+      expectedPromptMode: "full",
+      expectedSkillsPrompt: "PRIVATE_SKILL_MARKER",
+      expectedToolNames: ["read", "exec"],
+    },
+    {
+      label: "finite",
+      toolsAllow: ["read"],
+      expectedPromptMode: "minimal",
+      expectedSkillsPrompt: null,
+      expectedToolNames: ["read"],
+    },
+  ])(
+    "projects the $label tool policy into the compact endpoint prompt",
+    async ({ toolsAllow, expectedPromptMode, expectedSkillsPrompt, expectedToolNames }) => {
+      resolveSkillsPromptMock.mockReturnValue("PRIVATE_SKILL_MARKER");
+      createOpenClawCodingToolsMock.mockReturnValue([
+        {
+          name: "read",
+          label: "Read",
+          description: "Read a file",
+          parameters: { type: "object", properties: {} },
+          execute: vi.fn(),
+        },
+        {
+          name: "exec",
+          label: "Exec",
+          description: "Run a command",
+          parameters: { type: "object", properties: {} },
+          execute: vi.fn(),
+        },
+      ]);
+      buildEmbeddedSystemPromptMock.mockImplementation((params) =>
+        JSON.stringify({
+          promptMode: params.promptMode,
+          skillsPrompt: params.skillsPrompt ?? null,
+          toolNames: params.tools.map((tool) => tool.name),
+        }),
+      );
+      let endpointSystemPrompt: string | undefined;
+      attemptServerEndpointCompactionMock.mockImplementationOnce(async (input: unknown) => {
+        endpointSystemPrompt = (input as { context: { systemPrompt: string } }).context
+          .systemPrompt;
+        return {
+          item: { type: "compaction", encrypted_content: "opaque" },
+          usage: { input_tokens: 1_000, output_tokens: 200 },
+        };
+      });
+
+      const result = await compactEmbeddedAgentSessionDirect(
+        wrappedCompactionArgs({
+          provider: "xai",
+          model: "grok-4.5",
+          config: {
+            models: {
+              providers: {
+                xai: {
+                  api: "openai-responses",
+                  baseUrl: "https://api.x.ai/v1",
+                  models: [],
+                },
+              },
+            },
+          },
+          customInstructions: undefined,
+          trigger: "manual",
+          toolsAllow,
+        }),
+      );
+
+      expect(result).toMatchObject({ compacted: true, compactionKind: "server-endpoint" });
+      expect(endpointSystemPrompt).toBeDefined();
+      expect(JSON.parse(endpointSystemPrompt ?? "{}")).toEqual({
+        promptMode: expectedPromptMode,
+        skillsPrompt: expectedSkillsPrompt,
+        toolNames: expectedToolNames,
+      });
+    },
+  );
 
   it("never calls the compact endpoint during overflow recovery", async () => {
     mockResolvedModel();

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -172,6 +172,18 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     expect(result.model).toBe("gpt-5.4");
   });
 
+  it("preserves the finite tool allowlist for delegated compaction", () => {
+    const result = buildEmbeddedCompactionRuntimeContext({
+      workspaceDir: "/tmp/workspace",
+      agentDir: "/tmp/agent",
+      provider: "openai",
+      modelId: "gpt-5.4",
+      toolsAllow: ["read"],
+    });
+
+    expect(result.toolsAllow).toEqual(["read"]);
+  });
+
   it("normalizes nullable compaction routing fields to undefined", () => {
     const result = buildEmbeddedCompactionRuntimeContext({
       sessionKey: null,

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.ts
@@ -352,6 +352,7 @@ export function buildEmbeddedCompactionRuntimeContext(
     agentDir: params.agentDir,
     config: params.config,
     toolOverrides: params.toolOverrides,
+    toolsAllow: params.toolsAllow,
     skillsSnapshot: params.skillsSnapshot,
     senderIsOwner: params.senderIsOwner,
     senderId: params.senderId ?? undefined,

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -17,7 +17,7 @@ import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-r
 import { extractModelCompat } from "../../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { transformProviderSystemPrompt } from "../../plugins/provider-runtime.js";
-import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
+import { getPluginToolMeta } from "../../plugins/tools.js";
 import { resolveSkillsPrompt } from "../../skills/loading/workspace-skill-prompt.js";
 import { resolveEmbeddedRunSkillEntries } from "../../skills/runtime/embedded-run-entries.js";
 import {
@@ -58,6 +58,7 @@ import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
 import type { AgentRuntimePlan } from "../runtime-plan/types.js";
 import { resolveSessionPermissionExecMode } from "../session-permission-exec-mode.js";
 import { detectRuntimeShell } from "../shell-utils.js";
+import { toolPolicyRestrictsTools } from "../tool-policy.js";
 import {
   filterProviderNormalizableTools,
   filterRuntimeCompatibleTools,
@@ -69,7 +70,9 @@ import type { DirectCompactionPreparation } from "./direct-compaction-preparatio
 import { applyFinalEffectiveToolPolicy } from "./effective-tool-policy.js";
 import { log } from "./logger.js";
 import { buildEmbeddedMessageActionDiscoveryInput } from "./message-action-discovery-input.js";
+import { resolvePromptModeForSession } from "./run/attempt-prompt-helpers.js";
 import { resolveAttemptSpawnWorkspaceDir } from "./run/attempt-thread-helpers.js";
+import { applyEmbeddedAttemptToolsAllow } from "./run/attempt-tool-construction-plan.js";
 import { buildEmbeddedSandboxInfo, resolveEmbeddedSandboxInfoExecPolicy } from "./sandbox-info.js";
 import {
   createSandboxPromptEntryLoader,
@@ -454,6 +457,13 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
     });
     const effectiveTools = [...toolSchemaProjection.tools];
     const allowedToolNames = collectAllowedToolNames({ tools: effectiveTools });
+    const promptPolicyRestricted = toolPolicyRestrictsTools({ allow: params.toolsAllow });
+    // Compaction execution retains its existing tool objects. Only the model-visible endpoint
+    // prompt is narrowed to the caller's policy so private capability guidance cannot leak.
+    const promptTools = applyEmbeddedAttemptToolsAllow(effectiveTools, params.toolsAllow, {
+      toolMeta: (tool) => getPluginToolMeta(tool),
+    });
+    const promptAllowedToolNames = collectAllowedToolNames({ tools: promptTools });
     runtimePlan.tools.logDiagnostics(effectiveTools, runtimePlanModelContext);
     const machineName = await getMachineDisplayName();
     const runtimeChannel = normalizeMessageChannel(params.messageChannel ?? params.messageProvider);
@@ -545,10 +555,9 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
     const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
     const userDate = formatDateStamp(Date.now(), userTimezone);
     const promptSurface = resolveAgentPromptSurfaceForSessionKey(params.sessionKey);
-    const promptMode =
-      isSubagentSessionKey(params.sessionKey) || isCronSessionKey(params.sessionKey)
-        ? "minimal"
-        : "full";
+    const promptMode = promptPolicyRestricted
+      ? "minimal"
+      : resolvePromptModeForSession(params.sessionKey);
     const nativeCommandGuidanceLines = listRegisteredPluginAgentPromptGuidance({
       surface: promptSurface,
     });
@@ -575,23 +584,21 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       runtimePlan.prompt.resolveSystemPromptContribution(promptContributionContext);
     const preparedMemoryPrompt = await prepareAgentMemoryPrompt({
       enabled: promptMode === "full",
-      toolNames: effectiveTools.map((tool) => tool.name),
+      toolNames: promptTools.map((tool) => tool.name),
       citationsMode: params.config?.memory?.citations,
       agentId: runtimeInfo.agentId,
       agentSessionKey: runtimeInfo.sessionKey,
       sandboxed: sandboxInfo?.enabled === true,
     });
-    // Compaction must build byte-identical prompt sections to live turns, or
-    // the compaction run misses the transcript's cached prompt prefix. The
-    // allowlist doubles as the capability set so a session-read tool reachable
-    // only through capability names gates the section the same way live turns do.
+    // Match live-turn policy gates so restricted endpoint compaction cannot disclose
+    // private ambient sections through its model-visible developer prompt.
     const preparedWatchedSessions = prepareWatchedSessionsPrompt({
       enabled: promptMode === "full",
       config: params.config,
       sessionKey: params.sessionKey,
       sandboxed: sandboxInfo?.enabled === true,
-      toolNames: effectiveTools.map((tool) => tool.name),
-      capabilityToolNames: allowedToolNames,
+      toolNames: promptTools.map((tool) => tool.name),
+      capabilityToolNames: promptAllowedToolNames,
     });
     const activeProjectKeys = params.preparedModelRuntime?.activeProjectKeys ?? [];
     const buildSystemPromptText = (defaultThinkLevel: ThinkLevel) => {
@@ -604,7 +611,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
         extraSystemPrompt: params.extraSystemPrompt,
         ownerNumbers: params.ownerNumbers,
         reasoningTagHint,
-        skillsPrompt,
+        skillsPrompt: promptPolicyRestricted ? undefined : skillsPrompt,
         docsPath: openClawReferences.docsPath ?? undefined,
         sourcePath: openClawReferences.sourcePath ?? undefined,
         promptMode,
@@ -618,7 +625,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
         reactionGuidance,
         messageToolHints,
         sandboxInfo,
-        tools: effectiveTools,
+        tools: promptTools,
         userTimezone,
         userDate,
         contextFiles,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-helpers.ts
@@ -476,6 +476,7 @@ type AfterTurnRuntimeContextAttempt = Pick<
   | "currentMessageId"
   | "config"
   | "skillsSnapshot"
+  | "toolsAllow"
   | "senderId"
   | "provider"
   | "modelId"
@@ -552,6 +553,7 @@ export function buildAfterTurnRuntimeContext(params: {
       cwd: params.cwd,
       agentDir: params.agentDir,
       config: params.attempt.config,
+      toolsAllow: params.attempt.toolsAllow,
       skillsSnapshot: params.attempt.skillsSnapshot,
       senderId: params.attempt.senderId,
       provider: params.attempt.provider,

--- a/src/agents/embedded-agent-runner/run/compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-runtime.ts
@@ -103,6 +103,7 @@ export async function compactEmbeddedRunForRecovery(
       agentDir: input.agentDir,
       config: runParams.config,
       toolOverrides: runParams.toolOverrides,
+      toolsAllow: runParams.toolsAllow,
       skillsSnapshot: runParams.skillsSnapshot,
       senderId: runParams.senderId,
       provider: input.provider,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where compact-endpoint prompts could lose a finite tool allowlist and expose the full prompt/tool policy, including private skill guidance, during manual, recovery, or after-turn compaction.

## Why This Change Was Made

The compaction runtime now carries the exact finite `toolsAllow` fact through every compaction entry path. Prompt construction applies a prompt-only projection: finite policies produce the minimal prompt with only allowed tool names and no private skills, while wildcard or unrestricted policies retain the existing full prompt. Executable/effective tools, custom tools, auth, sandboxing, and disposal behavior are unchanged.

## User Impact

Compaction respects the session's finite tool policy without leaking broader private prompt guidance or silently dropping the allowlist.

## Evidence

- Genuine regressions proved both failures: the finite endpoint prompt received full/private guidance and runtime context dropped `toolsAllow`.
- Focused policy matrix passes 4/4; nine owner/sibling files pass 361/361 tests.
- Exact lint and diff checks pass; touched type diagnostics are zero.
- Fresh autoreview and independent review report no actionable findings.
- Production delta: +25/-14, net +11 lines, justified by the prompt privacy boundary; no executable tool behavior changes.
