### PR TITLE
fix(plugins): avoid repeated command names in plugin inspection

### DIFF
--- a/src/plugins/captured-registration.test.ts
+++ b/src/plugins/captured-registration.test.ts
@@ -9,6 +9,7 @@ describe("captured plugin registration", () => {
     const captured = capturePluginRegistration({
       register(api) {
         api.registerCli(() => {}, {
+          commands: [" captured-machine ", "captured-machine", "captured-extra"],
           descriptors: [
             {
               name: "captured-machine",
@@ -21,6 +22,7 @@ describe("captured plugin registration", () => {
       },
     });
 
+    expect(captured.cliRegistrars[0]?.commands).toEqual(["captured-machine", "captured-extra"]);
     const descriptor = captured.cliRegistrars[0]?.descriptors[0];
     expect(descriptor?.machineOutput).toBe(machineOutput);
     expect(

--- a/src/plugins/captured-registration.ts
+++ b/src/plugins/captured-registration.ts
@@ -1,5 +1,8 @@
 // Captures plugin registrations for controlled registry assembly.
-import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import {
+  normalizeStringEntries,
+  normalizeUniqueStringEntries,
+} from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
   AgentToolResultMiddleware,
@@ -202,7 +205,7 @@ export function createCapturedPluginRegistration(params?: {
               return normalized;
             })
             .filter((descriptor) => descriptor.name && descriptor.description);
-          const commands = normalizeStringEntries([
+          const commands = normalizeUniqueStringEntries([
             ...(opts?.commands ?? []),
             ...descriptors.map((descriptor) => descriptor.name),
           ]);

--- a/src/plugins/loader.cli-metadata.test.ts
+++ b/src/plugins/loader.cli-metadata.test.ts
@@ -970,6 +970,7 @@ module.exports = {
   id: "machine-output-cli",
   register(api) {
     api.registerCli(() => {}, {
+      commands: [" machine-output-cli ", "machine-output-cli", "additional-cli"],
       descriptors: [{
         name: "machine-output-cli",
         description: "Machine output CLI",
@@ -979,6 +980,7 @@ module.exports = {
     });
     api.registerCli(() => {}, {
       parentPath: ["nodes"],
+      commands: ["nested-machine-output", " nested-machine-output "],
       descriptors: [{
         name: "nested-machine-output",
         description: "Nested metadata",
@@ -999,6 +1001,10 @@ module.exports = {
     const metadataRegistry = await loadOpenClawPluginCliRegistry({ cache: false, config });
     const fullRegistry = loadOpenClawPlugins({ cache: false, config });
     for (const registry of [metadataRegistry, fullRegistry]) {
+      expect(registry.cliRegistrars[0]?.commands).toEqual(["machine-output-cli", "additional-cli"]);
+      expect(
+        registry.plugins.find((entry) => entry.id === "machine-output-cli")?.cliCommands,
+      ).toEqual(["machine-output-cli", "additional-cli", "nodes nested-machine-output"]);
       const resolver = registry.cliRegistrars[0]?.descriptors[0]?.machineOutput;
       expect(
         resolver?.({ argv: ["node", "openclaw", "machine-output-cli"], stdoutIsTTY: false }),
@@ -1010,6 +1016,7 @@ module.exports = {
         }),
       ).toBe(true);
       const nested = registry.cliRegistrars.find((entry) => entry.parentPath.length > 0);
+      expect(nested?.commands).toEqual(["nested-machine-output"]);
       expect(nested?.descriptors[0]).not.toHaveProperty("machineOutput");
     }
   });

--- a/src/plugins/registry-registrars-operations.ts
+++ b/src/plugins/registry-registrars-operations.ts
@@ -163,12 +163,11 @@ export function createOperationRegistrars(state: PluginRegistryState) {
       .filter(
         (descriptor): descriptor is OpenClawPluginCliRootCommandDescriptor => descriptor !== null,
       );
-    const commands = [
-      ...(opts?.commands ?? []),
-      ...descriptors.map((descriptor) => descriptor.name),
-    ]
-      .map((command) => normalizeCommandRoot(command, "command"))
-      .filter((command): command is string => command !== null);
+    const commands = normalizeUniqueStringEntries(
+      [...(opts?.commands ?? []), ...descriptors.map((descriptor) => descriptor.name)]
+        .map((command) => normalizeCommandRoot(command, "command"))
+        .filter((command): command is string => command !== null),
+    );
     if (commands.length === 0) {
       pushDiagnostic({
         level: "error",


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users inspecting a plugin would see repeated CLI command names when the plugin supplies both explicit command names and matching help descriptors, or repeats a name with surrounding whitespace. The plugin registration record retained every occurrence, and the inspection report faithfully displayed them.

Found during maintainer-requested CLI QA. This is a small, self-contained repair; archive and live duplicate searches found no matching open fix.

## Why This Change Was Made

Normalize the combined names once at the registration owner with the existing first-seen unique-string helper, after the existing command validation. Apply the same rule to captured plugin registration so its public test-support contract matches real registry assembly. This removes duplicate metadata at its producer rather than hiding it in the inspection renderer.

The command descriptors, validation diagnostics, command execution, collision handling, and ordering are unchanged. Parent paths remain sequences: repeated path segments are deliberately not deduplicated. No new helper, fallback, configuration, dependency, or storage contract is introduced.

Provenance: the current concatenation path was carried forward by #105783, merged on 2026-07-13 as `fbade914f59f3ac1e8060ae007a822b39f67068a`; blamed code author, PR author, and merger are all @steipete. This identifies the current ownership refactor, not a claim that the original duplication began there.

## User Impact

Plugin inspection and CLI metadata consumers now receive each owned command name once, preserving its first-seen position. Both lightweight CLI metadata loading and full plugin loading follow the same invariant. This does not change how often a registrar or command executes.

AI-assisted implementation and review. The author has inspected and understands the registration, normalization, collision, and inspection paths.

## Evidence

- Before the implementation change, the strengthened existing capture/loader tests failed on both duplicate arrays: **2 failed, 19 passed**. The same tests pass after the fix: **21 passed**.
- Final broader local run: **55 tests passed across 5 files**: `captured-registration.test.ts`, `loader.cli-metadata.test.ts`, `cli.test.ts`, `register-plugin-cli-command-groups.test.ts`, and `plugin-registry-inspection.test.ts` under `src/plugins/`.
- An unmocked registration-to-`buildPluginInspectReport` probe returned exactly `["qa-command", "qa-extra", "nodes nodes qa-nested"]`, retained `parentPath: ["nodes", "nodes"]`, and emitted no diagnostics. This exercises the real producer and report projection, not a packaged CLI invocation.
- Actual built CLI proof subsequently passed in an isolated temporary home/state/config: `node openclaw.mjs plugins inspect qa-cli-metadata --runtime --json` exited 0 with `status: "loaded"`, no diagnostics, and exactly `["qa-command", "qa-extra", "nodes qa-child"]`. The human-output command also exited 0 and rendered each command exactly once. The external fixture supplied overlapping names/descriptors and padded duplicate root/nested names.
- Built CLI proof used `dist-runtime-build` artifact `9621482208` from [CI run 33008053117](https://github.com/openclaw/openclaw/actions/runs/33008053117). Its build commit `977d14cc503c3157d866d6f82d5c3525e31a64ae` is the CI merge ref with parents `8585e7e04eef67c43e49a3db290d6d8e4f709ae3` and reviewed PR head `aa6fa9fd8575a66145a8b8e7c3e48c67527fffaa`; it is not described as a literal-head build. Launcher metadata came from the reviewed head.
- Targeted formatting, AST lint, max-lines ratchet, assertion-safety ratchet, and `git diff --check` passed. Fresh authenticated Codex autoreview and independent source review reported no actionable findings.
- Runtime production LOC: **+5/-6 (net -1)**. Published capture test-support LOC: **+5/-2 (net +3)**, from retaining the non-unique normalizer for parent paths alongside the existing unique helper. Tests: **+9/-0**. Combined executable source is net +2; there is no new abstraction or policy branch.

Local proof limitations: the linked checkout lacks complete local dependency links. Focused source and built CLI probes reused installed primary-checkout dependencies through an explicit private resolver (`@openclaw/fs-safe` 0.5.5 versus lockfile 0.5.6). The built CLI probe is not clean-machine package/install proof. Native `tsgo` stopped with TS2688 because local Node type definitions could not be resolved. Hosted pinned CI must pass before landing and is the authority for the complete type/build/dependency checks. No authenticated provider or channel flow is involved in this metadata-only repair.
