### PR TITLE
refactor(oc-path): share JSONC positional resolver

### DIFF
--- a/extensions/oc-path/src/oc-path/find.ts
+++ b/extensions/oc-path/src/oc-path/find.ts
@@ -11,6 +11,7 @@ import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { isMap, isScalar, isSeq, type Node, type Pair } from "yaml";
 import type { MdAst } from "./ast.js";
 import type { JsoncValue } from "./jsonc/ast.js";
+import { resolveJsoncPositionalSeg } from "./jsonc/positional.js";
 import type { JsonlAst, JsonlLine } from "./jsonl/ast.js";
 import { pickJsonlLine } from "./jsonl/line.js";
 import type { OcPath, PredicateSpec } from "./oc-path.js";
@@ -303,7 +304,7 @@ const jsoncOps: WalkOps<JsoncValue> = {
     return null;
   },
   positional(node, seg) {
-    const concrete = positionalForJsoncNode(node, seg);
+    const concrete = resolveJsoncPositionalSeg(node, seg);
     if (concrete === null) {
       return null;
     }
@@ -326,17 +327,6 @@ const jsoncOps: WalkOps<JsoncValue> = {
   },
   walk: walkJsonc,
 };
-
-function positionalForJsoncNode(node: JsoncValue, seg: string): string | null {
-  if (node.kind === "object") {
-    const keys = node.entries.map((e) => e.key);
-    return resolvePositionalSeg(seg, { indexable: false, size: keys.length, keys });
-  }
-  if (node.kind === "array") {
-    return resolvePositionalSeg(seg, { indexable: true, size: node.items.length });
-  }
-  return null;
-}
 
 // ---------- JSONL walker ---------------------------------------------------
 

--- a/extensions/oc-path/src/oc-path/jsonc/edit.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/edit.ts
@@ -5,13 +5,13 @@ import {
   isPositionalSeg,
   isQuotedSeg,
   parseArrayIndexSegment,
-  resolvePositionalSeg,
   splitRespectingBrackets,
   unquoteSeg,
 } from "../oc-path.js";
 import { OcEmitSentinelError, REDACTED_SENTINEL } from "../sentinel.js";
 import type { JsoncAst, JsoncValue } from "./ast.js";
 import { parseJsonc } from "./parse.js";
+import { resolveJsoncPositionalSeg } from "./positional.js";
 
 type JsoncEditPath = Array<string | number>;
 type JsoncEditTarget = { readonly path: JsoncEditPath; readonly value: JsoncValue };
@@ -126,7 +126,7 @@ function resolveEditTarget(root: JsoncValue, segments: readonly string[]): Jsonc
       return null;
     }
     if (isPositionalSeg(segment)) {
-      const concrete = positionalForJsonc(current, segment);
+      const concrete = resolveJsoncPositionalSeg(current, segment);
       if (concrete !== null) {
         segment = concrete;
       }
@@ -152,17 +152,6 @@ function resolveEditTarget(root: JsoncValue, segments: readonly string[]): Jsonc
     return null;
   }
   return { path: out, value: current };
-}
-
-function positionalForJsonc(node: JsoncValue, segment: string): string | null {
-  if (node.kind === "object") {
-    const keys = node.entries.map((entry) => entry.key);
-    return resolvePositionalSeg(segment, { indexable: false, size: keys.length, keys });
-  }
-  if (node.kind === "array") {
-    return resolvePositionalSeg(segment, { indexable: true, size: node.items.length });
-  }
-  return null;
 }
 
 function jsoncValueToJson(value: JsoncValue): unknown {

--- a/extensions/oc-path/src/oc-path/jsonc/positional.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/positional.ts
@@ -1,0 +1,13 @@
+import { resolvePositionalSeg } from "../oc-path.js";
+import type { JsoncValue } from "./ast.js";
+
+export function resolveJsoncPositionalSeg(node: JsoncValue, segment: string): string | null {
+  if (node.kind === "object") {
+    const keys = node.entries.map((entry) => entry.key);
+    return resolvePositionalSeg(segment, { indexable: false, size: keys.length, keys });
+  }
+  if (node.kind === "array") {
+    return resolvePositionalSeg(segment, { indexable: true, size: node.items.length });
+  }
+  return null;
+}

--- a/extensions/oc-path/src/oc-path/jsonc/resolve-value.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/resolve-value.ts
@@ -1,6 +1,7 @@
 // OC Path module implements resolve value behavior.
-import { isPositionalSeg, parseArrayIndexSegment, resolvePositionalSeg } from "../oc-path.js";
+import { isPositionalSeg, parseArrayIndexSegment } from "../oc-path.js";
 import type { JsoncEntry, JsoncValue } from "./ast.js";
+import { resolveJsoncPositionalSeg } from "./positional.js";
 
 type JsoncValueOcPathMatch =
   | { readonly kind: "value"; readonly node: JsoncValue; readonly path: readonly string[] }
@@ -23,7 +24,7 @@ export function resolveJsoncValueOcPath(
       return null;
     }
     if (isPositionalSeg(seg)) {
-      const concrete = positionalForJsonc(current, seg);
+      const concrete = resolveJsoncPositionalSeg(current, seg);
       if (concrete !== null) {
         seg = concrete;
       }
@@ -58,15 +59,4 @@ export function resolveJsoncValueOcPath(
     return { kind: "object-entry", node: lastEntry, path: walked };
   }
   return { kind: "value", node: current, path: walked };
-}
-
-function positionalForJsonc(node: JsoncValue, seg: string): string | null {
-  if (node.kind === "object") {
-    const keys = node.entries.map((e) => e.key);
-    return resolvePositionalSeg(seg, { indexable: false, size: keys.length, keys });
-  }
-  if (node.kind === "array") {
-    return resolvePositionalSeg(seg, { indexable: true, size: node.items.length });
-  }
-  return null;
 }

--- a/extensions/oc-path/src/oc-path/tests/find.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/find.test.ts
@@ -117,6 +117,14 @@ describe("findOcPaths — JSONC kind", () => {
       }
     }
   });
+
+  it("$last on an object emits the concrete key", () => {
+    const out = findOcPaths(jsonc, parseOcPath("oc://config/plugins/$last/enabled"));
+    expect(out).toHaveLength(1);
+    const result = requireFirstResult(out);
+    expect(result.path.item).toBe("slack");
+    expect(result.match.kind === "leaf" && result.match.valueText).toBe("true");
+  });
 });
 
 describe("findOcPaths — slash-deep JSONC paths", () => {


### PR DESCRIPTION
## What Problem This Solves

JSONC path finding, value resolution, and editing each maintained the same positional-segment resolver. Keeping three implementations made `$first`, `$last`, and ordinal behavior easier to drift between operations.

## Why This Change Was Made

The JSONC implementation now uses one internal positional resolver shared by find, resolve, and edit. Focused find coverage also verifies that `$last` on an object emits the resolved concrete key.

The helper remains private to the JSONC implementation. JSONL, YAML, Markdown, SDK, config, persistence, and protocol surfaces are unchanged.

## User Impact

No user-visible behavior change. JSONC positional paths now have one canonical implementation across find, resolve, and edit.

## Evidence

- Exact pushed head: `05dc22996fea034a6445482dd410bb524d43ae3c`
- `node scripts/run-vitest.mjs extensions/oc-path/src/oc-path` - 39 files, 654 tests passed after rebase.
- Native `scripts/pr review-tests 130341` - 3 files, 82 tests passed.
- Native `node scripts/check-changed.mjs` passed every relevant changed-surface gate, including production/test typechecks, lint, dead exports, and import cycles, after a frozen install of the exact current lockfile.
- Fresh Autoreview after rebase: clean, 0.99, no actionable findings.
- AWS Crabbox run `run_5ac456624e92`, lease `cbx_c9c11dde3031`: fresh public-network checkout, no instance role, no Tailscale, no hydration, frozen install, exact head `05dc22996fea034a6445482dd410bb524d43ae3c`, 82/82 focused tests passed. Lease released after proof.
- The trusted bootstrap was uploaded with a transient `umask 022` insertion because the current AWS image otherwise creates its Node install root as root-only and cannot expose the pinned binaries to the unprivileged test user. This is a Crabbox bootstrap follow-up, not a branch change.

Root cause: three JSONC consumers independently projected object keys and array indexes into the shared positional-segment contract.

Architectural owner and canonical fix: `extensions/oc-path/src/oc-path/jsonc/positional.ts` now owns JSONC container projection and delegates positional semantics to the existing `resolvePositionalSeg`.

Removed paths: the private JSONC positional helpers in find, edit, and value resolution.

Production LOC: +20/-38, net -18. Tests: +8/-0.

Sibling coverage: JSONL, YAML, and Markdown positional implementations remain unchanged because their container semantics differ. Existing JSONC resolve/edit tests plus the new find assertion cover the three migrated consumers.

Changelog: not required for an internal behavior-neutral refactor.
