### PR TITLE
fix(sessions): select the transcript header by type in bounded reads

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -182,13 +182,21 @@ export function readSessionTranscriptBoundedActiveContextCore(
       database: projection.database,
       ...projection.resolved,
     });
+    // The header is not always seq 0: a delivery mirror can land before it. Select it by
+    // type, or bounded loads lose the version and runtime rejects the session as legacy.
     const header = executeSqliteQueryTakeFirstSync(
       projection.database.db,
       db
-        .selectFrom("transcript_events")
-        .select("event_json")
-        .where("session_id", "=", projection.resolved.sessionId)
-        .orderBy("seq", "asc")
+        .selectFrom("transcript_event_identities as identity")
+        .innerJoin("transcript_events as event", (join) =>
+          join
+            .onRef("event.session_id", "=", "identity.session_id")
+            .onRef("event.seq", "=", "identity.seq"),
+        )
+        .select("event.event_json")
+        .where("identity.session_id", "=", projection.resolved.sessionId)
+        .where("identity.event_type", "=", "session")
+        .orderBy("identity.seq", "asc")
         .limit(1),
     );
     const headerBytes = header ? Buffer.byteLength(header.event_json, "utf8") + 1 : 0;

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -182,21 +182,21 @@ export function readSessionTranscriptBoundedActiveContextCore(
       database: projection.database,
       ...projection.resolved,
     });
-    // The header is not always seq 0: a delivery mirror can land before it. Select it by
-    // type, or bounded loads lose the version and runtime rejects the session as legacy.
+    // Migrated transcripts may place a delivery mirror before the header or lack the auxiliary
+    // identity rows entirely. Select the canonical stored event by type so runtime keeps its version.
     const header = executeSqliteQueryTakeFirstSync(
       projection.database.db,
       db
-        .selectFrom("transcript_event_identities as identity")
-        .innerJoin("transcript_events as event", (join) =>
-          join
-            .onRef("event.session_id", "=", "identity.session_id")
-            .onRef("event.seq", "=", "identity.seq"),
+        .selectFrom("transcript_events")
+        .select("event_json")
+        .where("session_id", "=", projection.resolved.sessionId)
+        .where(
+          /* kysely-allow-raw: the canonical transcript event type is stored inside event_json. */
+          sql<string>`json_extract(event_json, '$.type')`,
+          "=",
+          "session",
         )
-        .select("event.event_json")
-        .where("identity.session_id", "=", projection.resolved.sessionId)
-        .where("identity.event_type", "=", "session")
-        .orderBy("identity.seq", "asc")
+        .orderBy("seq", "asc")
         .limit(1),
     );
     const headerBytes = header ? Buffer.byteLength(header.event_json, "utf8") + 1 : 0;

--- a/src/config/sessions/session-accessor.sqlite-bounded-context.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-bounded-context.test.ts
@@ -4,6 +4,7 @@ import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import {
   appendTranscriptEvent,
+  appendTranscriptMessage,
   persistSessionTranscriptTurn,
   upsertSessionEntryCore,
 } from "./session-accessor.js";
@@ -11,6 +12,10 @@ import {
   readSessionTranscriptActiveStats,
   readSessionTranscriptBoundedActiveContextCore,
 } from "./session-accessor.sqlite-active-events.js";
+import {
+  startSessionTranscriptIndexReconcile,
+  waitForSessionTranscriptIndexReconcile,
+} from "./session-transcript-reconcile.js";
 
 async function withBoundedContextScope(
   run: (scope: {
@@ -86,6 +91,66 @@ it("reserves the transcript header inside the exact byte limit", async () => {
     expect(context.events[0]).toMatchObject({ id: scope.sessionId, type: "session" });
     expect(context.serializedBytes).toBe(headerBytes);
     expect(context.truncated).toBe(true);
+  });
+});
+
+it("selects the session header by type when a mirror row precedes it", async () => {
+  await withBoundedContextScope(async (scope) => {
+    const mirror = await appendTranscriptMessage(scope, {
+      message: { role: "assistant", content: [{ type: "text", text: "New session started." }] },
+    });
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        { eventId: "new", parentId: mirror.messageId, message: { role: "user", content: "new" } },
+      ],
+      touchSessionEntry: false,
+    });
+    // Settle the projection first, then reproduce the file-era import row order (delivery
+    // mirror ahead of the header), which current writers never emit, directly in the store.
+    startSessionTranscriptIndexReconcile({
+      agentId: scope.agentId,
+      preferredSessionId: scope.sessionId,
+    });
+    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId });
+    const database = openOpenClawAgentDatabase({ agentId: scope.agentId });
+    database.db.exec("BEGIN; PRAGMA defer_foreign_keys = ON;");
+    for (const [table, column] of [
+      ["transcript_events", "seq"],
+      ["transcript_event_identities", "seq"],
+      ["session_transcript_active_events", "event_seq"],
+    ]) {
+      // Swap seq 0 (header) and seq 1 (mirror) through a spare slot.
+      for (const [from, to] of [
+        [0, 99],
+        [1, 0],
+        [99, 1],
+      ]) {
+        database.db
+          .prepare(`UPDATE ${table} SET ${column} = ? WHERE session_id = ? AND ${column} = ?`)
+          .run(to, scope.sessionId, from);
+      }
+    }
+    database.db.exec("COMMIT;");
+    const order = database.db
+      .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? ORDER BY seq ASC")
+      .all(scope.sessionId) as Array<{ event_json: string }>;
+    expect(order.map((row) => JSON.parse(row.event_json).type)).toEqual([
+      "message",
+      "session",
+      "message",
+    ]);
+
+    const context = readSessionTranscriptBoundedActiveContextCore(scope, {
+      maxBytes: 4096,
+      maxEvents: 10,
+    });
+
+    expect(context.events.map((event) => (event as { id?: string }).id)).toEqual([
+      scope.sessionId,
+      mirror.messageId,
+      "new",
+    ]);
+    expect(context.events[0]).toMatchObject({ type: "session" });
   });
 });
 

--- a/src/config/sessions/session-accessor.sqlite-bounded-context.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-bounded-context.test.ts
@@ -118,13 +118,13 @@ it("selects the session header by type when a mirror row precedes it", async () 
       ["transcript_events", "seq"],
       ["transcript_event_identities", "seq"],
       ["session_transcript_active_events", "event_seq"],
-    ]) {
+    ] as const) {
       // Swap seq 0 (header) and seq 1 (mirror) through a spare slot.
       for (const [from, to] of [
         [0, 99],
         [1, 0],
         [99, 1],
-      ]) {
+      ] as const) {
         database.db
           .prepare(`UPDATE ${table} SET ${column} = ? WHERE session_id = ? AND ${column} = ?`)
           .run(to, scope.sessionId, from);

--- a/src/config/sessions/session-accessor.sqlite-bounded-context.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-bounded-context.test.ts
@@ -12,6 +12,7 @@ import {
   readSessionTranscriptActiveStats,
   readSessionTranscriptBoundedActiveContextCore,
 } from "./session-accessor.sqlite-active-events.js";
+import { importSqliteSessionRows } from "./session-accessor.sqlite-import.js";
 import {
   startSessionTranscriptIndexReconcile,
   waitForSessionTranscriptIndexReconcile,
@@ -151,6 +152,54 @@ it("selects the session header by type when a mirror row precedes it", async () 
       "new",
     ]);
     expect(context.events[0]).toMatchObject({ type: "session" });
+  });
+});
+
+it("selects the session header when an exact migrated transcript has no identity rows", async () => {
+  await withOpenClawTestState({ label: "bounded-transcript-exact-import" }, async (state) => {
+    const scope = {
+      agentId: "ops",
+      env: state.env,
+      sessionId: "exact-import-session",
+      sessionKey: "agent:ops:main",
+      storePath: path.join(state.sessionsDir("ops"), "sessions.json"),
+    };
+    await importSqliteSessionRows({
+      ...scope,
+      entry: { sessionId: scope.sessionId, updatedAt: 1 },
+      readExactTranscriptRows: (append) => {
+        append({
+          createdAt: 1,
+          eventJson: JSON.stringify({ type: "session", version: 3, id: scope.sessionId }),
+        });
+        append({
+          createdAt: 2,
+          eventJson: JSON.stringify({
+            type: "message",
+            id: "message-1",
+            parentId: null,
+            message: { role: "user", content: "hello" },
+          }),
+        });
+      },
+    });
+
+    const database = openOpenClawAgentDatabase({ agentId: scope.agentId, env: scope.env });
+    const identityCount = database.db
+      .prepare("SELECT COUNT(*) AS count FROM transcript_event_identities WHERE session_id = ?")
+      .get(scope.sessionId) as { count: number };
+    expect(identityCount.count).toBe(0);
+
+    const context = readSessionTranscriptBoundedActiveContextCore(scope, {
+      maxBytes: 4096,
+      maxEvents: 10,
+    });
+
+    expect(context.events.map((event) => (event as { id?: string }).id)).toEqual([
+      scope.sessionId,
+      "message-1",
+    ]);
+    expect(context.events[0]).toMatchObject({ type: "session", version: 3 });
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Since #129343 (bounded active transcript hydration), every turn in one long-lived Telegram session fails with `Persisted legacy session transcripts require doctor/import migration before runtime use` and the user sees no reply at all (`visible channel turn dispatched with no queued reply payloads`). The session is not legacy: its header is `{"type":"session","version":3,…}`.

The bounded loader fetches the header as the lowest-`seq` row of `transcript_events`. In this transcript — a July file-era import — a `delivery-mirror` "New session started." message was persisted at seq 0 and the header at seq 1. The header row is never part of `session_transcript_active_events`, so the bounded load returns no `session` event, `session-manager-core` reads `header?.version ?? 1`, and the run is rejected as a v1 transcript. Full (unbounded) loads still work, which is why the session ran fine before #129343 landed.

## Why This Change Was Made

`readSessionTranscriptBoundedActiveContextCore` now selects the first stored event whose JSON type is `session`, instead of assuming the header is the first row or requiring an auxiliary identity-index row. This covers both mirror-before-header imports and exact cross-store imports that legitimately lack identity rows.

## User Impact

Sessions whose header is not physically first load again under bounded hydration instead of dying silently on every turn.

## Evidence

- Live: main-agent Telegram session `…topic:1` on an operator gateway, 6 identical `lane task error` entries on 2026-08-26, transcript rows `seq 0 = message (delivery-mirror)`, `seq 1 = session v3`, active-event projection excludes seq 1.
- Regression test `selects the session header by type when a mirror row precedes it` reproduces the original row ordering.
- Regression test `selects the session header when an exact migrated transcript has no identity rows` covers the cross-store import gap; it failed before the follow-up fix and passes afterward.
- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-bounded-context.test.ts`: 5 passed.
- `node scripts/check-changed.mjs -- src/config/sessions/session-accessor.sqlite-active-events.ts src/config/sessions/session-accessor.sqlite-bounded-context.test.ts`: passed.
- Production LOC: +8 net against the merge base.

## Worked on by

- @VACInc
