### PR TITLE
fix(ui): palette selections open the wrong agent and skip result rows

### DIFF
--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -443,7 +443,8 @@ export function renderApplicationShell(host: ShellViewHost) {
     ${renderLazyElementModal(host.lazyCustomElements)}
     ${isOptionalElementDefined(host.commandPaletteElement)
       ? html`<openclaw-command-palette
-          .onNavigate=${(routeId: RouteId) => host.navigate(routeId)}
+          .onNavigate=${(routeId: RouteId, options?: ApplicationNavigationOptions) =>
+            host.navigate(routeId, options)}
           .onSelectSession=${(sessionKey: string) => host.selectChatSession(sessionKey)}
           .onSlashCommand=${(command: string) => host.handleCommandPaletteSlashCommand(command)}
         ></openclaw-command-palette>`

--- a/ui/src/components/command-palette-catalog-search.ts
+++ b/ui/src/components/command-palette-catalog-search.ts
@@ -32,6 +32,7 @@ type CommandPaletteCatalogItem = {
   icon: IconName;
   category: CommandPaletteCatalogCategory;
   routeId: RouteId;
+  agentId?: string;
   description?: string;
   searchText?: string;
 };
@@ -215,6 +216,7 @@ export function toCommandPaletteItems(
     icon: item.icon,
     category: item.category,
     action: `nav:${item.routeId}`,
+    agentId: item.agentId,
     description: item.description,
     searchText: item.searchText,
   }));
@@ -298,6 +300,7 @@ export async function loadCommandPaletteCatalogItems(params: {
       icon: "bot" as const,
       category: "agents" as const,
       routeId: "agents" as const,
+      agentId: agent.id,
       description: agent.id,
       searchText: [agent.id, agent.workspace, agent.model?.primary, agent.identity?.theme]
         .filter(Boolean)

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -125,6 +125,13 @@ async function enterQuery(palette: CommandPalette, query: string) {
   await palette.updateComplete;
 }
 
+function findPaletteOption(palette: CommandPalette, label: string, exact = false) {
+  return [...palette.querySelectorAll<HTMLElement>('[role="option"]')].find((item) => {
+    const text = item.textContent?.replace(/\s+/g, " ").trim();
+    return exact ? text === label : text?.includes(label);
+  });
+}
+
 describe("CommandPalette lifecycle", () => {
   let restoreDialogPolyfill: () => void;
 
@@ -323,9 +330,7 @@ describe("CommandPalette lifecycle", () => {
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
     await palette.updateComplete;
 
-    const metadataItem = palette.querySelector<HTMLElement>(
-      "#cmd-palette-option-session-agent-main-metadata",
-    );
+    const metadataItem = findPaletteOption(palette, "Needle planning");
     expect(metadataItem?.textContent).toContain("Needle planning");
     metadataItem?.click();
     expect(palette.onSelectSession).toHaveBeenCalledWith("agent:main:metadata");
@@ -413,9 +418,7 @@ describe("CommandPalette lifecycle", () => {
     await enterQuery(palette, "reconciles");
     await vi.advanceTimersByTimeAsync(50);
     await vi.waitFor(() => expect(palette.textContent).toContain("Nightly invoices"));
-    const item = palette.querySelector<HTMLElement>(
-      "#cmd-palette-option-automation-nightly-invoices",
-    );
+    const item = findPaletteOption(palette, "Nightly invoices");
     item?.click();
     expect(palette.onNavigate).toHaveBeenCalledWith("cron");
 
@@ -435,6 +438,120 @@ describe("CommandPalette lifecycle", () => {
 
     expect(list).not.toHaveBeenCalled();
   });
+
+  it.each(["click", "keyboard"])(
+    "opens the selected catalog agent's encoded route by %s",
+    async (method) => {
+      const { gateway } = createGateway(true);
+      const context = createContext(
+        gateway,
+        vi.fn(async () => null),
+      );
+      const { palette } = await mountPalette({
+        ...context,
+        basePath: "/openclaw",
+        agents: {
+          ...context.agents,
+          ensureList: async () => ({
+            defaultId: "main",
+            mainKey: "main",
+            scope: "per-sender",
+            agents: [{ id: "reviewer.team", name: "Reviewer" }],
+          }),
+        },
+      });
+      await enterQuery(palette, "Reviewer");
+      await vi.advanceTimersByTimeAsync(50);
+      await palette.updateComplete;
+      const item = palette.querySelector<HTMLElement>('[role="option"]');
+      expect(item?.textContent).toContain("Reviewer");
+      if (method === "click") {
+        item?.click();
+      } else {
+        palette
+          .querySelector("input")
+          ?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      }
+      expect(palette.onNavigate).toHaveBeenCalledWith("agents", {
+        pathname: "/openclaw/settings/agents/reviewer%2Eteam",
+      });
+      expect(palette.isOpen).toBe(false);
+    },
+  );
+
+  it("moves the keyboard selection through catalog groups in visible order", async () => {
+    const { gateway } = createGateway(true, {
+      methods: ["cron.list"],
+      request: vi.fn(async () => ({
+        jobs: [{ id: "bravo", name: "Needle Bravo" }],
+      })) as GatewayBrowserClient["request"],
+    });
+    const context = createContext(
+      gateway,
+      vi.fn(async () => null),
+    );
+    const { palette } = await mountPalette({
+      ...context,
+      agents: {
+        ...context.agents,
+        ensureList: async () => ({
+          defaultId: "alpha",
+          mainKey: "main",
+          scope: "per-sender",
+          agents: [
+            { id: "alpha", name: "Needle Alpha" },
+            { id: "charlie", name: "Needle Charlie" },
+          ],
+        }),
+      },
+    });
+    await enterQuery(palette, "Needle");
+    await vi.advanceTimersByTimeAsync(50);
+    await palette.updateComplete;
+    const items = [...palette.querySelectorAll<HTMLElement>('[role="option"]')];
+    expect(items.map((item) => item.textContent?.replace(/\s+/g, " ").trim())).toEqual([
+      "Needle Alpha alpha",
+      "Needle Charlie charlie",
+      "Needle Bravo",
+    ]);
+    for (const expectedIndex of [1, 2, 0]) {
+      palette
+        .querySelector("input")
+        ?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+      await palette.updateComplete;
+      expect(palette.querySelector('[aria-selected="true"]')).toBe(items[expectedIndex]);
+    }
+  });
+
+  it.each(["agent:main:topic:thread", "agent:main:topic:\ud800"])(
+    "keeps the active descendant bound for session key %j",
+    async (key) => {
+      const { gateway } = createGateway(true);
+      const colon = createSessionResult(key, "Needle colon");
+      const hyphen = createSessionResult("agent:main:topic-thread", "Needle hyphen");
+      const { palette } = await mountPalette(
+        createContext(
+          gateway,
+          vi.fn(async () => ({
+            ...colon,
+            count: 2,
+            sessions: [...colon.sessions, ...hyphen.sessions],
+          })),
+        ),
+      );
+      await enterQuery(palette, "Needle");
+      await vi.advanceTimersByTimeAsync(50);
+      await palette.updateComplete;
+      palette
+        .querySelector("input")
+        ?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+      await palette.updateComplete;
+      const active = palette.querySelector('[aria-selected="true"]');
+      expect(active?.textContent).toContain("Needle hyphen");
+      const activeId = palette.querySelector("input")?.getAttribute("aria-activedescendant");
+      expect(document.getElementById(activeId ?? "")).toBe(active);
+    },
+  );
 
   it("keeps bounded metadata pagination when transcript search is unavailable", async () => {
     const list = vi.fn<ApplicationContext<RouteId>["sessions"]["list"]>(async (options) => {
@@ -527,7 +644,7 @@ describe("CommandPalette lifecycle", () => {
     );
     await enterQuery(palette, "plugins");
 
-    const item = palette.querySelector<HTMLButtonElement>("#cmd-palette-option-nav-plugins");
+    const item = findPaletteOption(palette, "Plugins");
     expect(item?.textContent).toContain("Plugins");
     item?.click();
 
@@ -550,9 +667,7 @@ describe("CommandPalette lifecycle", () => {
       palette.desktopAvailable = available;
       await enterQuery(palette, "desktop");
 
-      expect(palette.querySelectorAll("#cmd-palette-option-panel-desktop")).toHaveLength(
-        expectedCount,
-      );
+      expect(findPaletteOption(palette, "Desktop", true) ? 1 : 0).toBe(expectedCount);
     },
   );
 
@@ -570,7 +685,7 @@ describe("CommandPalette lifecycle", () => {
     const listener = (event: Event) => events.push(event as CustomEvent<DesktopPanelToggleDetail>);
     window.addEventListener(DESKTOP_PANEL_TOGGLE_EVENT, listener);
     try {
-      palette.querySelector<HTMLElement>("#cmd-palette-option-panel-desktop")?.click();
+      findPaletteOption(palette, "Desktop", true)?.click();
     } finally {
       window.removeEventListener(DESKTOP_PANEL_TOGGLE_EVENT, listener);
     }
@@ -595,9 +710,7 @@ describe("CommandPalette lifecycle", () => {
       palette.custodianAvailable = available;
       await enterQuery(palette, "openclaw");
 
-      expect(palette.querySelectorAll("#cmd-palette-option-panel-custodian")).toHaveLength(
-        expectedCount,
-      );
+      expect(findPaletteOption(palette, "Ask OpenClaw", true) ? 1 : 0).toBe(expectedCount);
     },
   );
 
@@ -616,7 +729,7 @@ describe("CommandPalette lifecycle", () => {
       events.push(event as CustomEvent<CustodianPanelToggleDetail>);
     window.addEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, listener);
     try {
-      palette.querySelector<HTMLElement>("#cmd-palette-option-panel-custodian")?.click();
+      findPaletteOption(palette, "Ask OpenClaw", true)?.click();
     } finally {
       window.removeEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, listener);
     }

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -5,7 +5,7 @@ import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { ref } from "lit/directives/ref.js";
 import type { SessionsSearchHit } from "../../../packages/gateway-protocol/src/index.js";
-import type { RouteId } from "../app-route-paths.ts";
+import { pathForAgentPanel, type RouteId } from "../app-route-paths.ts";
 import { applicationContext, type ApplicationContext } from "../app/context.ts";
 import { hasOperatorAdminAccess } from "../app/operator-access.ts";
 import { t } from "../i18n/index.ts";
@@ -54,6 +54,7 @@ const SESSION_TRANSCRIPT_MAX_SESSION_KEYS = 200;
 const CATALOG_CACHE_TTL_MS = 30_000;
 
 type CommandPaletteProps = {
+  basePath: string;
   open: boolean;
   query: string;
   activeIndex: number;
@@ -65,7 +66,7 @@ type CommandPaletteProps = {
   onToggle: () => void;
   onQueryChange: (query: string) => void;
   onActiveIndexChange: (index: number) => void;
-  onNavigate: (routeId: RouteId) => void;
+  onNavigate?: ApplicationContext<RouteId>["navigate"];
   onSelectSession?: (sessionKey: string) => void;
   onSlashCommand?: (command: string) => void;
   desktopAvailable: boolean;
@@ -73,22 +74,14 @@ type CommandPaletteProps = {
   onInputRef: (element: Element | undefined) => void;
 };
 
-function filteredItems(
-  query: string,
-  includeSlashCommands = true,
-  sessionItems: readonly PaletteItem[] = [],
-  catalogItems: readonly PaletteItem[] = [],
-  desktopAvailable = false,
-  custodianAvailable = false,
-): PaletteItem[] {
-  return filterCommandPaletteItems({
-    query,
-    includeSlashCommands,
-    sessionItems,
-    catalogItems,
-    desktopAvailable,
-    custodianAvailable,
-  });
+function filteredItems(props: CommandPaletteProps): PaletteItem[] {
+  // Keyboard selection and ARIA focus follow the same category order as the visible rows.
+  return groupItems(
+    filterCommandPaletteItems({
+      ...props,
+      includeSlashCommands: Boolean(props.onSlashCommand),
+    }),
+  ).flatMap(([, items]) => items);
 }
 
 function groupItems(items: PaletteItem[]): Array<[string, PaletteItem[]]> {
@@ -107,7 +100,14 @@ const paletteListboxId = "cmd-palette-listbox";
 
 function selectItem(item: PaletteItem, props: CommandPaletteProps) {
   if (item.action.startsWith("nav:")) {
-    props.onNavigate(item.action.slice(4) as RouteId);
+    const routeId = item.action.slice(4) as RouteId;
+    if (item.agentId) {
+      props.onNavigate?.(routeId, {
+        pathname: pathForAgentPanel(item.agentId, null, props.basePath),
+      });
+    } else {
+      props.onNavigate?.(routeId);
+    }
   } else if (item.action.startsWith(SESSION_ACTION_PREFIX)) {
     props.onSelectSession?.(item.action.slice(SESSION_ACTION_PREFIX.length));
   } else if (item.action === "panel:desktop") {
@@ -132,14 +132,7 @@ function scrollActiveIntoView() {
 }
 
 function handleKeydown(e: KeyboardEvent, props: CommandPaletteProps) {
-  const items = filteredItems(
-    props.query,
-    Boolean(props.onSlashCommand),
-    props.sessionItems,
-    props.catalogItems,
-    props.desktopAvailable,
-    props.custodianAvailable,
-  );
+  const items = filteredItems(props);
   if (items.length === 0 && (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter")) {
     return;
   }
@@ -171,8 +164,8 @@ function handleKeydown(e: KeyboardEvent, props: CommandPaletteProps) {
   }
 }
 
-function getOptionId(item: PaletteItem): string {
-  return `cmd-palette-option-${item.id.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+function getOptionId(index: number): string {
+  return `cmd-palette-option-${index}`;
 }
 
 function focusInput(el: Element | undefined) {
@@ -189,17 +182,10 @@ function renderCommandPalette(props: CommandPaletteProps) {
   if (!props.open) {
     return nothing;
   }
-  const items = filteredItems(
-    props.query,
-    Boolean(props.onSlashCommand),
-    props.sessionItems,
-    props.catalogItems,
-    props.desktopAvailable,
-    props.custodianAvailable,
-  );
+  const items = filteredItems(props);
   const grouped = groupItems(items);
   const activeItem = items[props.activeIndex];
-  const activeOptionId = activeItem ? getOptionId(activeItem) : nothing;
+  const activeOptionId = activeItem ? getOptionId(props.activeIndex) : nothing;
   const paletteLabel = t("palette.placeholder");
 
   return html`
@@ -265,7 +251,7 @@ function renderCommandPalette(props: CommandPaletteProps) {
                     const isActive = globalIndex === props.activeIndex;
                     return html`
                       <div
-                        id=${getOptionId(item)}
+                        id=${getOptionId(globalIndex)}
                         class="cmd-palette__item ${isActive ? "cmd-palette__item--active" : ""}"
                         role="option"
                         aria-selected=${isActive ? "true" : "false"}
@@ -299,7 +285,7 @@ function renderCommandPalette(props: CommandPaletteProps) {
 }
 
 export class CommandPalette extends OpenClawLightDomContentsElement {
-  @property({ attribute: false }) onNavigate?: (routeId: RouteId) => void;
+  @property({ attribute: false }) onNavigate?: ApplicationContext<RouteId>["navigate"];
   @property({ attribute: false }) onSelectSession?: (sessionKey: string) => void;
   @property({ attribute: false }) onSlashCommand?: (command: string) => void;
   @property({ attribute: false }) desktopAvailable = false;
@@ -654,6 +640,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
 
   override render() {
     return renderCommandPalette({
+      basePath: this.context?.basePath ?? "",
       open: this.open,
       query: this.query,
       activeIndex: this.activeIndex,
@@ -680,7 +667,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       onActiveIndexChange: (index) => {
         this.activeIndex = index;
       },
-      onNavigate: (routeId) => this.onNavigate?.(routeId),
+      onNavigate: this.onNavigate,
       onSelectSession: this.onSelectSession,
       onSlashCommand: this.onSlashCommand,
       onInputRef: this.handleInputRef,

--- a/ui/src/e2e/agent-page-scope.e2e.test.ts
+++ b/ui/src/e2e/agent-page-scope.e2e.test.ts
@@ -68,6 +68,104 @@ const multiAgentRoster = [
 ];
 
 suite.define(() => {
+  it("follows the visible catalog groups when selecting an agent with the keyboard", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { height: 900, width: 1440 } },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["cron.list"],
+          methodResponses: {
+            "agents.list": {
+              defaultId: "main",
+              mainKey: "main",
+              scope: "per-sender",
+              agents: [
+                multiAgentRoster[0],
+                { id: "alpha", name: "Needle Alpha" },
+                { id: "charlie", name: "Needle Charlie" },
+              ],
+            },
+            "cron.list": { jobs: [{ id: "bravo", name: "Needle Bravo" }] },
+            "sessions.list": { ts: 1, path: "", count: 0, defaults: {}, sessions: [] },
+            "sessions.usage": emptyUsage,
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}usage`);
+        await gateway.waitForRequest("agents.list");
+        await page.keyboard.press("ControlOrMeta+k");
+        const input = page.locator(".cmd-palette__input");
+        await input.fill("Needle");
+        await page.getByRole("option", { name: "Needle Bravo", exact: true }).waitFor();
+        const options = page.locator("openclaw-command-palette").getByRole("option");
+        await expect
+          .poll(async () =>
+            (await options.allTextContents()).map((text) => text.replace(/\s+/g, " ").trim()),
+          )
+          .toEqual(["Needle Alpha alpha", "Needle Charlie charlie", "Needle Bravo"]);
+        await input.press("ArrowDown");
+        await expect.poll(() => options.nth(1).getAttribute("aria-selected")).toBe("true");
+        await screenshot(page, "09-palette-keyboard-group-order.png");
+        await input.press("Enter");
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/charlie");
+      },
+    );
+  });
+
+  it("opens a named agent from the palette without changing the chat agent", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { height: 900, width: 1440 } },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "agents.list": {
+              defaultId: "main",
+              mainKey: "main",
+              scope: "per-sender",
+              agents: multiAgentRoster,
+            },
+            "sessions.usage": emptyUsage,
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}usage`);
+        await gateway.waitForRequest("agents.list");
+        const sidebar = page.locator("openclaw-app-sidebar");
+        await expect
+          .poll(async () =>
+            (await sidebar.locator(".sidebar-agent-card__name").textContent())?.trim(),
+          )
+          .toBe("Main");
+        await page.keyboard.press("ControlOrMeta+k");
+        await page.locator(".cmd-palette__input").fill("Reviewer");
+        const result = page.getByRole("option", { name: "Reviewer reviewer", exact: true });
+        await result.waitFor();
+        await screenshot(page, "07-palette-reviewer-result.png");
+        await result.click();
+        const selectedAgent = page.locator("openclaw-agents-page openclaw-agent-select");
+        await selectedAgent.waitFor();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/reviewer");
+        await expect
+          .poll(() =>
+            selectedAgent.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
+          )
+          .toBe("reviewer");
+        await screenshot(page, "08-palette-selected-agent.png");
+        await page.reload();
+        await expect
+          .poll(() =>
+            selectedAgent.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
+          )
+          .toBe("reviewer");
+        await page.goBack();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/usage");
+        await expect
+          .poll(async () =>
+            (await sidebar.locator(".sidebar-agent-card__name").textContent())?.trim(),
+          )
+          .toBe("Main");
+      },
+    );
+  });
+
   it("preserves an in-flight canonical roster refresh while chat startup is delayed", async () => {
     await suite.withPage(
       { locale: "en-US", serviceWorkers: "block", viewport: { height: 900, width: 1440 } },
@@ -92,7 +190,7 @@ suite.define(() => {
         await gateway.resolveDeferred("agents.list", {
           defaultId: "research",
           mainKey: "main",
-          scope: "agent",
+          scope: "per-sender",
           agents: [{ id: "research", name: "Research" }],
         });
 
@@ -127,7 +225,7 @@ suite.define(() => {
             "agents.list": {
               defaultId: "research",
               mainKey: "main",
-              scope: "agent",
+              scope: "per-sender",
               agents: [
                 { id: "research", name: "Research" },
                 { id: "writer", name: "Writer" },
@@ -201,14 +299,14 @@ suite.define(() => {
             "agents.list": {
               defaultId: "main",
               mainKey: "main",
-              scope: "agent",
+              scope: "per-sender",
               agents: multiAgentRoster,
             },
             "chat.startup": {
               agentsList: {
                 defaultId: "main",
                 mainKey: "main",
-                scope: "agent",
+                scope: "per-sender",
                 agents: multiAgentRoster,
               },
               messages: [],
@@ -295,7 +393,7 @@ suite.define(() => {
             "agents.list": {
               defaultId: "main",
               mainKey: "main",
-              scope: "agent",
+              scope: "per-sender",
               agents: multiAgentRoster,
             },
             "sessions.list": {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where selecting a named agent from the Control UI command palette opened the default agent's settings instead. Keyboard navigation also skipped visible rows when matches spanned categories, and session keys differing only in punctuation could give two options the same accessibility ID.

Related: #128356, which introduced catalog search (`798c21af7b96`, authored by @clawsweeper and merged by @VACInc on August 24).

## Why This Change Was Made

Keep the agent identity attached to its catalog result and carry the existing navigation options through the palette and shell to the canonical agent route. Agent settings remain URL-owned and do not change the selected chat agent. Keyboard selection and rendering now use the same grouped result order; accessibility IDs use that displayed position instead of lossy session-key conversion.

The repair removes the positional filter wrapper duplication. Production: +33/-42, net **-9 lines**. No new dependencies, configuration, storage, protocol, or Gateway behavior. AI-assisted; independently reviewed.

## User Impact

Clicking or pressing Enter on an agent result opens that agent, including under a mounted URL prefix. Arrow keys follow the visible rows and screen-reader focus identifies the selected result. Reload and browser Back preserve the expected route and chat-agent scope.

## Evidence

The named-agent regression failed in real Chromium before the fix: clicking **Reviewer** opened `/settings/agents` with **Main** selected. The same flow now opens `/settings/agents/reviewer` with **Reviewer** selected, survives reload, and leaves the chat agent unchanged after Back.

Before:

![Selecting Reviewer opened Main](https://github.com/user-attachments/assets/2765ee86-d00e-475f-b96b-bc479e3d10e6)

After:

![Selecting Reviewer opens Reviewer](https://github.com/user-attachments/assets/7998a7df-4089-4974-8571-18d94600ca6f)

Both images were inspected and contain only synthetic fixture data. Browser tests run the actual Control UI with a deterministic mocked Gateway; they are not authenticated provider/channel proof.

- 152 focused tests across palette, agent routing, application host, native shell, and lazy actions passed. New click/keyboard, grouped-order, and punctuation-collision regressions demonstrably failed before repair; accepted UTF-16 session keys also remain renderable.
- All six real Chromium multi-agent E2E scenarios passed, including named-agent click, mixed-category keyboard Enter, reload, browser Back, and existing agent-scope scenarios.
- Independent interactive browser proof exercised named-agent click and keyboard navigation, plus 120 ArrowUp/ArrowDown transitions with selected-row and accessibility-target assertions.
- `pnpm ui:build` passed, including 768 compressed-asset sidecars and the startup performance budget.
- Fresh structured Codex review passed with no actionable findings. The repository changed-file gates passed, including core-test and UI typechecks, formatting, lint, i18n, dead-export scans, and policy guards. Hosted CI is required before landing.

Focused browser command: `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/agent-page-scope.e2e.test.ts`.
