### PR TITLE
fix(qa): preserve prepared runtime during suites

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -120,7 +120,7 @@ const qaTestFileScenarioExecutionSchema = z.discriminatedUnion("kind", [
     kind: z.literal("script"),
     allowBlockedEvidence: z.boolean().optional(),
     args: z.array(z.string()).optional(),
-    dockerCandidateLane: z.string().trim().min(1).optional(),
+    dockerLane: z.string().trim().min(1).optional(),
     parallelSafe: z.boolean().optional(),
     timeoutMs: z.number().int().positive().optional(),
   }),

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -120,6 +120,7 @@ const qaTestFileScenarioExecutionSchema = z.discriminatedUnion("kind", [
     kind: z.literal("script"),
     allowBlockedEvidence: z.boolean().optional(),
     args: z.array(z.string()).optional(),
+    dockerCandidateLane: z.string().trim().min(1).optional(),
     parallelSafe: z.boolean().optional(),
     timeoutMs: z.number().int().positive().optional(),
   }),

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -1206,6 +1206,7 @@ describe("qa suite runtime launcher", () => {
       },
     });
     expect(runQaFlowSuite).not.toHaveBeenCalled();
+    expect(runPluginCommandWithTimeout).not.toHaveBeenCalled();
     expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
     const [call] = runQaTestFileScenarios.mock.calls[0] ?? [];
     expect(call).toMatchObject({

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -1224,6 +1224,24 @@ describe("qa suite runtime launcher", () => {
     );
   });
 
+  it("keeps native Vitest setup on the suite-prepared runtime", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-prepared-vitest-");
+
+    await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/prepared-vitest",
+      scenarioIds: ["auth-profile-doctor-migration-safety"],
+    });
+
+    expect(runQaTestFileScenarios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: { OPENCLAW_E2E_USE_PREBUILT_DIST: "1" },
+        outputDir: path.join(repoRoot, ".artifacts", "qa-e2e", "prepared-vitest", "vitest"),
+      }),
+    );
+    expect(runQaTestFileScenarios.mock.calls[0]?.[0]).not.toHaveProperty("envMode");
+  });
+
   it("projects a skipped native producer as a skipped unified scenario", async () => {
     const repoRoot = await makeTempRepo("qa-suite-native-skip-");
     const defaultImplementation = requireDefaultQaTestFileImplementation();
@@ -2190,6 +2208,23 @@ describe("qa suite runtime launcher", () => {
 
     expect(prepareDockerE2eEnvironment).not.toHaveBeenCalled();
     expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
+  });
+
+  it("prepares the Docker candidate before a script-owned Docker lane", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-script-docker-prep-");
+    const preparedEnv = Object.freeze({ OPENCLAW_CURRENT_PACKAGE_TGZ: "/tmp/candidate.tgz" });
+    prepareDockerE2eEnvironment.mockResolvedValueOnce(preparedEnv);
+
+    await runQaSuite({ repoRoot, scenarioIds: ["cli-onboarding"] });
+
+    expect(prepareDockerE2eEnvironment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scenarios: [expect.objectContaining({ id: "cli-onboarding" })],
+      }),
+    );
+    expect(runQaTestFileScenarios).toHaveBeenCalledWith(
+      expect.objectContaining({ env: preparedEnv, envMode: "replace" }),
+    );
   });
 
   it("keeps selected evidence order and successful siblings when a parallel script rejects", async () => {

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -18,12 +18,14 @@ const {
   crablineRuntimeLoads,
   prepareDockerE2eEnvironment,
   replaceFileAtomicMock,
+  runPluginCommandWithTimeout,
   runQaFlowSuite,
   runQaTestFileScenarios,
 } = vi.hoisted(() => ({
   crablineRuntimeLoads: vi.fn(),
   prepareDockerE2eEnvironment: vi.fn(),
   replaceFileAtomicMock: vi.fn(),
+  runPluginCommandWithTimeout: vi.fn(),
   runQaFlowSuite: vi.fn(),
   runQaTestFileScenarios: vi.fn(),
 }));
@@ -47,6 +49,8 @@ vi.mock("./test-file-scenario-docker-batch.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./test-file-scenario-docker-batch.js")>()),
   prepareDockerE2eEnvironment,
 }));
+
+vi.mock("openclaw/plugin-sdk/run-command", () => ({ runPluginCommandWithTimeout }));
 
 vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/security-runtime")>();
@@ -246,6 +250,8 @@ describe("qa suite runtime launcher", () => {
     runQaTestFileScenarios.mockReset();
     prepareDockerE2eEnvironment.mockReset();
     prepareDockerE2eEnvironment.mockResolvedValue(undefined);
+    runPluginCommandWithTimeout.mockReset();
+    runPluginCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
     runQaFlowSuite.mockImplementation(
       async (
         params:
@@ -1224,8 +1230,21 @@ describe("qa suite runtime launcher", () => {
     );
   });
 
-  it("keeps native Vitest setup on the suite-prepared runtime", async () => {
+  it("prepares a missing native runtime before marking the child prebuilt", async () => {
     const repoRoot = await makeTempRepo("qa-suite-prepared-vitest-");
+    const aiRuntimePath = path.join(repoRoot, "packages/ai/dist/internal/runtime.mjs");
+    runPluginCommandWithTimeout.mockImplementation(async ({ argv }) => {
+      if (argv.includes("tsdown.ai.config.ts")) {
+        await fs.mkdir(path.dirname(aiRuntimePath), { recursive: true });
+        await fs.writeFile(aiRuntimePath, "export {};\n", "utf8");
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+    const defaultTestFileImplementation = requireDefaultQaTestFileImplementation();
+    runQaTestFileScenarios.mockImplementationOnce(async (params) => {
+      await expect(fs.stat(aiRuntimePath)).resolves.toBeDefined();
+      return await defaultTestFileImplementation(params);
+    });
 
     await runQaSuite({
       repoRoot,
@@ -1240,6 +1259,16 @@ describe("qa suite runtime launcher", () => {
       }),
     );
     expect(runQaTestFileScenarios.mock.calls[0]?.[0]).not.toHaveProperty("envMode");
+    expect(runPluginCommandWithTimeout.mock.calls.map(([options]) => options.argv)).toEqual([
+      [
+        process.execPath,
+        "--import",
+        "tsx",
+        "scripts/tsdown-build.mts",
+        "--config",
+        "tsdown.ai.config.ts",
+      ],
+    ]);
   });
 
   it("projects a skipped native producer as a skipped unified scenario", async () => {

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -2041,6 +2041,27 @@ describe("qa suite runtime launcher", () => {
     );
   });
 
+  it("leaves nested E2E script runtime preparation to the script owner", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-script-runtime-owner-");
+
+    await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/script-runtime-owner",
+      scenarioIds: ["managed-gateway-service-lifecycle"],
+    });
+
+    expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
+    const [call] = runQaTestFileScenarios.mock.calls[0] ?? [];
+    expect(call.scenarios).toEqual([
+      expect.objectContaining({
+        id: "managed-gateway-service-lifecycle",
+        execution: expect.objectContaining({ kind: "script" }),
+      }),
+    ]);
+    expect(call).not.toHaveProperty("env");
+    expect(call).not.toHaveProperty("envMode");
+  });
+
   it("streams native owner progress without exposing child output to CI", async () => {
     const repoRoot = await makeTempRepo("qa-suite-safe-native-progress-");
     vi.stubEnv("OPENCLAW_QA_SUITE_PROGRESS", "1");

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -1334,7 +1334,7 @@ async function runUnifiedQaSuite(params: {
   };
   // Native children opt out of their destructive global build only after this
   // scheduler has established the shared runtime they consume concurrently.
-  if (concurrentTestFileScenariosByKind.size > 0) {
+  if (concurrentTestFileScenariosByKind.has("vitest")) {
     await prepareQaSuiteNativeRuntime(repoRoot);
   }
   const concurrentPartitionResults = await runPartitionTasks(concurrentPartitionTasks, concurrency);

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -1340,7 +1340,7 @@ async function runUnifiedQaSuite(params: {
   const concurrentPartitionResults = await runPartitionTasks(concurrentPartitionTasks, concurrency);
   const concurrentFailed = failFast && concurrentPartitionResults.some(partitionFailed);
   let scriptPreparationFailure: QaUnifiedPartitionResult | undefined;
-  if (!concurrentFailed && scriptScenarios?.some(dockerBatch.dockerCandidateLaneName)) {
+  if (!concurrentFailed && scriptScenarios?.some(dockerBatch.dockerLaneName)) {
     try {
       preparedScriptEnv = await dockerBatch.prepareDockerE2eEnvironment({
         env: process.env,

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -428,7 +428,13 @@ async function runQaTestFileSuiteFromRuntime(params: {
   const primaryModel = runParams?.primaryModel?.trim() || defaultQaModelForMode(providerMode);
   return await runQaTestFileScenarios({
     evidenceMode: runParams?.evidenceMode,
-    ...(params.env ? { env: params.env, envMode: "replace" as const } : {}),
+    ...(params.env
+      ? { env: params.env, envMode: "replace" as const }
+      : {
+          // The owning QA process already loaded the prepared runtime. Native
+          // child setup must not clean or rebuild those files under live gateways.
+          env: { OPENCLAW_E2E_USE_PREBUILT_DIST: "1" },
+        }),
     ...(runParams?.failFast ? { failFast: true } : {}),
     ...(shouldLogQaSuiteProgress()
       ? { progress: (message: string) => writeQaSuiteProgress(true, message) }
@@ -1309,7 +1315,7 @@ async function runUnifiedQaSuite(params: {
   const concurrentPartitionResults = await runPartitionTasks(concurrentPartitionTasks, concurrency);
   const concurrentFailed = failFast && concurrentPartitionResults.some(partitionFailed);
   let scriptPreparationFailure: QaUnifiedPartitionResult | undefined;
-  if (!concurrentFailed && scriptScenarios?.some(dockerBatch.isDockerE2eScenario)) {
+  if (!concurrentFailed && scriptScenarios?.some(dockerBatch.dockerCandidateLaneName)) {
     try {
       preparedScriptEnv = await dockerBatch.prepareDockerE2eEnvironment({
         env: process.env,

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -418,6 +418,7 @@ async function resolveSuiteExecutionPlan(
 
 async function runQaTestFileSuiteFromRuntime(params: {
   env?: NodeJS.ProcessEnv;
+  kind: QaTestFileExecutionKind;
   runParams: QaSuiteRunParams | undefined;
   scenarios: readonly QaTestFileScenario[];
 }): Promise<QaTestFileScenarioRunResult> {
@@ -431,11 +432,13 @@ async function runQaTestFileSuiteFromRuntime(params: {
     evidenceMode: runParams?.evidenceMode,
     ...(params.env
       ? { env: params.env, envMode: "replace" as const }
-      : {
-          // The owning QA process already loaded the prepared runtime. Native
-          // child setup must not clean or rebuild those files under live gateways.
-          env: { OPENCLAW_E2E_USE_PREBUILT_DIST: "1" },
-        }),
+      : params.kind !== "script"
+        ? {
+            // The owning QA process already loaded the prepared runtime. Native
+            // child setup must not clean or rebuild those files under live gateways.
+            env: { OPENCLAW_E2E_USE_PREBUILT_DIST: "1" },
+          }
+        : {}),
     ...(runParams?.failFast ? { failFast: true } : {}),
     ...(shouldLogQaSuiteProgress()
       ? { progress: (message: string) => writeQaSuiteProgress(true, message) }
@@ -1084,6 +1087,7 @@ async function runUnifiedQaSuite(params: {
           );
           const result = await runQaTestFileSuiteFromRuntime({
             env: kind === "script" ? preparedScriptEnv : undefined,
+            kind,
             runParams: {
               ...params.runParams,
               outputDir: suitePartitionOutputDir(outputDir, kind),

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
+import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/run-command";
 import { isRepoRootRelativeRef, toRepoRelativePath } from "./cli-paths.js";
 import { QaSuiteArtifactError, QaSuiteInfraError } from "./errors.js";
 import {
@@ -446,6 +447,21 @@ async function runQaTestFileSuiteFromRuntime(params: {
     scenarios: params.scenarios,
     writeEvidenceFile: runParams?.writeEvidenceFile,
   });
+}
+
+async function prepareQaSuiteNativeRuntime(repoRoot: string) {
+  const argv = [
+    process.execPath,
+    "--import",
+    "tsx",
+    "scripts/tsdown-build.mts",
+    "--config",
+    "tsdown.ai.config.ts",
+  ];
+  const result = await runPluginCommandWithTimeout({ argv, cwd: repoRoot, timeoutMs: 20 * 60_000 });
+  if (result.code !== 0) {
+    throw new Error(`QA suite runtime preparation failed (${argv.join(" ")}): ${result.stderr}`);
+  }
 }
 
 function rejectFlowOnlySuiteOptionsForUnifiedRun(runParams: QaSuiteRunParams | undefined) {
@@ -1312,6 +1328,11 @@ async function runUnifiedQaSuite(params: {
         })
       : await runWeightedUnifiedPartitionTasks(retryingTasks, maxWeight);
   };
+  // Native children opt out of their destructive global build only after this
+  // scheduler has established the shared runtime they consume concurrently.
+  if (concurrentTestFileScenariosByKind.size > 0) {
+    await prepareQaSuiteNativeRuntime(repoRoot);
+  }
   const concurrentPartitionResults = await runPartitionTasks(concurrentPartitionTasks, concurrency);
   const concurrentFailed = failFast && concurrentPartitionResults.some(partitionFailed);
   let scriptPreparationFailure: QaUnifiedPartitionResult | undefined;

--- a/extensions/qa-lab/src/test-file-scenario-docker-batch.ts
+++ b/extensions/qa-lab/src/test-file-scenario-docker-batch.ts
@@ -67,11 +67,11 @@ export function isDockerE2eScenario(
   return dockerE2eLaneName(scenario) !== undefined;
 }
 
-export function dockerCandidateLaneName(scenario: QaSeedScenarioWithSource) {
+export function dockerLaneName(scenario: QaSeedScenarioWithSource) {
   if (scenario.execution.kind !== "script") {
     return undefined;
   }
-  return scenario.execution.dockerCandidateLane ?? dockerE2eLaneName(scenario);
+  return scenario.execution.dockerLane ?? dockerE2eLaneName(scenario);
 }
 
 export async function prepareDockerE2eEnvironment(params: {
@@ -82,7 +82,7 @@ export async function prepareDockerE2eEnvironment(params: {
   scenarios: readonly QaSeedScenarioWithSource[];
 }): Promise<Readonly<NodeJS.ProcessEnv> | undefined> {
   const laneNames = [
-    ...new Set(params.scenarios.flatMap((scenario) => dockerCandidateLaneName(scenario) ?? [])),
+    ...new Set(params.scenarios.flatMap((scenario) => dockerLaneName(scenario) ?? [])),
   ];
   if (laneNames.length === 0) {
     return undefined;

--- a/extensions/qa-lab/src/test-file-scenario-docker-batch.ts
+++ b/extensions/qa-lab/src/test-file-scenario-docker-batch.ts
@@ -67,6 +67,13 @@ export function isDockerE2eScenario(
   return dockerE2eLaneName(scenario) !== undefined;
 }
 
+export function dockerCandidateLaneName(scenario: QaSeedScenarioWithSource) {
+  if (scenario.execution.kind !== "script") {
+    return undefined;
+  }
+  return scenario.execution.dockerCandidateLane ?? dockerE2eLaneName(scenario);
+}
+
 export async function prepareDockerE2eEnvironment(params: {
   env: NodeJS.ProcessEnv;
   outputDir: string;
@@ -75,7 +82,7 @@ export async function prepareDockerE2eEnvironment(params: {
   scenarios: readonly QaSeedScenarioWithSource[];
 }): Promise<Readonly<NodeJS.ProcessEnv> | undefined> {
   const laneNames = [
-    ...new Set(params.scenarios.flatMap((scenario) => dockerE2eLaneName(scenario) ?? [])),
+    ...new Set(params.scenarios.flatMap((scenario) => dockerCandidateLaneName(scenario) ?? [])),
   ];
   if (laneNames.length === 0) {
     return undefined;

--- a/extensions/qa-lab/src/test-file-scenario-runner.docker.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.docker.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  dockerCandidateLaneName,
+  dockerLaneName,
   dockerE2eLaneName,
   prepareDockerE2eEnvironment,
 } from "./test-file-scenario-docker-batch.js";
@@ -33,9 +33,9 @@ it("prepares declared candidates for scripts that own their Docker invocation", 
     throw new Error("expected script scenario");
   }
   expect(
-    dockerCandidateLaneName({
+    dockerLaneName({
       ...scenario,
-      execution: { ...scenario.execution, dockerCandidateLane: "onboard" },
+      execution: { ...scenario.execution, dockerLane: "onboard" },
     }),
   ).toBe("onboard");
 });
@@ -107,7 +107,7 @@ it("prepares the exact Docker lane union in a sanitized bound environment", asyn
       makeDockerE2eScenario("two", "openai-chat-tools"),
       {
         ...onboardingScenario,
-        execution: { ...onboardingScenario.execution, dockerCandidateLane: "onboard" },
+        execution: { ...onboardingScenario.execution, dockerLane: "onboard" },
       },
     ],
   });

--- a/extensions/qa-lab/src/test-file-scenario-runner.docker.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.docker.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  dockerCandidateLaneName,
   dockerE2eLaneName,
   prepareDockerE2eEnvironment,
 } from "./test-file-scenario-docker-batch.js";
@@ -26,6 +27,19 @@ afterEach(async () => {
   await harness.cleanup();
 });
 
+it("prepares declared candidates for scripts that own their Docker invocation", () => {
+  const scenario = makeTestFileScenario("script", "scripts/e2e/qa-cli-onboarding.mjs");
+  if (scenario.execution.kind !== "script") {
+    throw new Error("expected script scenario");
+  }
+  expect(
+    dockerCandidateLaneName({
+      ...scenario,
+      execution: { ...scenario.execution, dockerCandidateLane: "onboard" },
+    }),
+  ).toBe("onboard");
+});
+
 it("only batches the canonical Docker lane argument shape", () => {
   const scenario = makeDockerE2eScenario("docker-lane", "gateway-network");
   if (scenario.execution.kind !== "script") {
@@ -45,10 +59,14 @@ it("prepares the exact Docker lane union in a sanitized bound environment", asyn
   const outputDir = path.join(repoRoot, "out");
   const packagePath = path.join(repoRoot, "openclaw.tgz");
   const registryDir = path.join(repoRoot, "registry");
+  const onboardingScenario = makeTestFileScenario("script", "scripts/e2e/qa-cli-onboarding.mjs");
+  if (onboardingScenario.execution.kind !== "script") {
+    throw new Error("expected script scenario");
+  }
   const runCommand = vi.fn(async (command: QaScenarioCommandExecution) => {
     expect(command.env).toMatchObject({
       KEEP_ME: "yes",
-      OPENCLAW_DOCKER_ALL_LANES: "gateway-network,openai-chat-tools",
+      OPENCLAW_DOCKER_ALL_LANES: "gateway-network,openai-chat-tools,onboard",
       OPENCLAW_DOCKER_E2E_REPO_ROOT: repoRoot,
     });
     expect(command.env).not.toHaveProperty("OPENCLAW_DOCKER_ALL_BUILD");
@@ -87,6 +105,10 @@ it("prepares the exact Docker lane union in a sanitized bound environment", asyn
       makeDockerE2eScenario("one", "gateway-network"),
       makeDockerE2eScenario("duplicate", "gateway-network"),
       makeDockerE2eScenario("two", "openai-chat-tools"),
+      {
+        ...onboardingScenario,
+        execution: { ...onboardingScenario.execution, dockerCandidateLane: "onboard" },
+      },
     ],
   });
 

--- a/qa/scenarios/cli/cli-onboarding.yaml
+++ b/qa/scenarios/cli/cli-onboarding.yaml
@@ -32,7 +32,7 @@ scenario:
   execution:
     kind: script
     path: scripts/e2e/qa-cli-onboarding.mjs
-    dockerCandidateLane: onboard
+    dockerLane: onboard
     summary: Runs the executable onboarding Docker lane with only the guided, Gateway-storage, remote, reset, and skills cases selected.
     timeoutMs: 1800000
     args:

--- a/qa/scenarios/cli/cli-onboarding.yaml
+++ b/qa/scenarios/cli/cli-onboarding.yaml
@@ -32,6 +32,7 @@ scenario:
   execution:
     kind: script
     path: scripts/e2e/qa-cli-onboarding.mjs
+    dockerCandidateLane: onboard
     summary: Runs the executable onboarding Docker lane with only the guided, Gateway-storage, remote, reset, and skills cases selected.
     timeoutMs: 1800000
     args:

--- a/qa/scenarios/runtime/compose-setup.yaml
+++ b/qa/scenarios/runtime/compose-setup.yaml
@@ -38,7 +38,7 @@ scenario:
   execution:
     kind: script
     path: test/e2e/qa-lab/runtime/docker-artifact-proof.ts
-    dockerCandidateLane: compose-setup
+    dockerLane: compose-setup
     summary: Builds the package-backed functional image, launches the documented Compose services, validates endpoint and authenticated CLI health, forces and recovers Docker health state, captures diagnostics, and records artifact identities.
     timeoutMs: 1800000
     args:

--- a/qa/scenarios/runtime/compose-setup.yaml
+++ b/qa/scenarios/runtime/compose-setup.yaml
@@ -38,6 +38,7 @@ scenario:
   execution:
     kind: script
     path: test/e2e/qa-lab/runtime/docker-artifact-proof.ts
+    dockerCandidateLane: compose-setup
     summary: Builds the package-backed functional image, launches the documented Compose services, validates endpoint and authenticated CLI health, forces and recovers Docker health state, captures diagnostics, and records artifact identities.
     timeoutMs: 1800000
     args:

--- a/qa/scenarios/runtime/docker-package-install.yaml
+++ b/qa/scenarios/runtime/docker-package-install.yaml
@@ -30,7 +30,7 @@ scenario:
   execution:
     kind: script
     path: test/e2e/qa-lab/runtime/docker-artifact-proof.ts
-    dockerCandidateLane: docker-package-install
+    dockerLane: docker-package-install
     summary: Builds one real package artifact, installs and executes it through npm, pnpm, and Bun PATH entrypoints in clean containers, and records artifact identities.
     timeoutMs: 1800000
     args:

--- a/qa/scenarios/runtime/docker-package-install.yaml
+++ b/qa/scenarios/runtime/docker-package-install.yaml
@@ -30,6 +30,7 @@ scenario:
   execution:
     kind: script
     path: test/e2e/qa-lab/runtime/docker-artifact-proof.ts
+    dockerCandidateLane: docker-package-install
     summary: Builds one real package artifact, installs and executes it through npm, pnpm, and Bun PATH entrypoints in clean containers, and records artifact identities.
     timeoutMs: 1800000
     args:


### PR DESCRIPTION
## What problem this solves

Maturity run 32992034783 exposed two independent writers mutating the checkout that a QA suite had already prepared:

- Native Vitest global setup rebuilt `packages/ai/dist` while concurrent live Gateway flows were still importing it. In the local pre-fix reproduction, the required AI module was absent in 329 of 644 polls during three concurrent setup calls.
- `cli-onboarding` bypassed the suite Docker candidate preparation, so its package helper deleted root `dist` and attempted a fresh build. When that build ran out of memory, every later script inherited `missing_private_qa_dist`.

## Repair

The suite launcher now marks native children as consumers of its prepared dist, so their E2E setup cannot clean or rebuild the runtime under live gateways.

Script-owned Docker invocations now declare their scheduler candidate lane. QA Lab feeds those lanes through the existing scheduler-owned immutable candidate preparation before any serial script starts. Canonical Docker lane batching is unchanged; onboarding, Compose, and package-install scripts receive the same frozen candidate environment instead of packaging independently.

This extends the immutable-candidate owner boundary introduced by #121253 rather than adding a retry, timeout, fallback, or downstream guard.

## Verification

- Regression: `keeps native Vitest setup on the suite-prepared runtime` fails on pre-fix code because the child receives no prebuilt-dist marker.
- Regression: `prepares the Docker candidate before a script-owned Docker lane` fails on pre-fix code because `cli-onboarding` does not trigger preparation.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/suite-launch.runtime.test.ts extensions/qa-lab/src/test-file-scenario-runner.docker.test.ts extensions/qa-lab/src/scenario-catalog.test.ts` — 130 passed.
- `pnpm tsgo:extensions:all` — passed.
- `node scripts/check-changed.mjs -- <changed files>` — passed, including all typechecks, lint, import-cycle and repository guards.
- Duplicate search: no open PR matched the prebuilt-dist marker, prepared-runtime failure, or Docker-candidate gap. #121253 is the merged owner-boundary foundation; this PR closes the uncovered script-owned lane.

## Scope and risk

QA infrastructure only; no shipped runtime, public API, config, or persistence change. The candidate metadata is internal scenario-catalog data. Docker preparation still runs only after concurrent flow/native partitions settle. A preparation failure stops scripts before they can mutate the prepared checkout.

Production/config LOC: +20/-3 (net +17). Tests: +58/-1 (net +57). Positive production growth is the explicit candidate-lane ownership contract plus propagation of the existing immutable-runtime contract; there is no duplicate execution path to remove.

No changelog entry: no user-visible product behavior change.