### PR TITLE
fix(tui): reload auth store ownership after login

### DIFF
--- a/src/agents/auth-profiles/path-resolve.shared-store.test.ts
+++ b/src/agents/auth-profiles/path-resolve.shared-store.test.ts
@@ -72,6 +72,22 @@ describe("shared auth store path resolution", () => {
     });
   });
 
+  it("reloads ownership after an explicit out-of-process auth mutation", async () => {
+    const env = makeStateEnv();
+    const {
+      reloadSharedAuthStoreOwnership,
+      resolveSharedAuthStoreOwnership,
+      resolveSharedAuthStorePath,
+    } = await import("./path-resolve.js");
+
+    expect(resolveSharedAuthStoreOwnership(env)).toEqual({ location: "legacy-main" });
+    writeConfigMachineState("auth.sharedStore", { location: "state-db" }, { env });
+    expect(resolveSharedAuthStoreOwnership(env)).toEqual({ location: "legacy-main" });
+
+    expect(reloadSharedAuthStoreOwnership(env)).toEqual({ location: "state-db" });
+    expect(resolveSharedAuthStorePath(env)).toBe(resolveOpenClawStateSqlitePath(env));
+  });
+
   it("resolves the relocated store to the canonical shared state database", async () => {
     const env = makeStateEnv();
     writeConfigMachineState("auth.sharedStore", { location: "state-db" }, { env });

--- a/src/agents/auth-profiles/path-resolve.ts
+++ b/src/agents/auth-profiles/path-resolve.ts
@@ -87,6 +87,18 @@ export function noteCommittedSharedAuthStoreOwnership(
   sharedAuthStoreOwnershipByDatabasePath.set(databasePath, ownership);
 }
 
+/** Reload shared auth ownership after an explicit out-of-process auth mutation. */
+export function reloadSharedAuthStoreOwnership(
+  env: NodeJS.ProcessEnv = process.env,
+): SharedAuthStoreOwnership {
+  const databasePath = path.resolve(resolveOpenClawStateSqlitePath(env));
+  const ownership = parseSharedAuthStoreOwnership(
+    readConfigMachineState<unknown>(SHARED_AUTH_STORE_STATE_KEY, { env, path: databasePath }),
+  );
+  sharedAuthStoreOwnershipByDatabasePath.set(databasePath, ownership);
+  return ownership;
+}
+
 /** Resolve the canonical shared auth database path. */
 export function resolveSharedAuthStorePath(env: NodeJS.ProcessEnv = process.env): string {
   if (resolveSharedAuthStoreOwnership(env).location === "state-db") {

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -13,12 +13,14 @@ import {
 } from "../../test/helpers/openclaw-test-instance.js";
 import { isProcessAlive, waitForPidFile } from "../../test/helpers/process-wait.js";
 import { createDeferred } from "../../test/helpers/promise.js";
-import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
+import { reloadSharedAuthStoreOwnership } from "../agents/auth-profiles/path-resolve.js";
+import { loadAuthProfileStoreForRuntime } from "../agents/auth-profiles/store.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { connectGatewayClient } from "../gateway/test-helpers.e2e.js";
 import { runExec } from "../process/exec.js";
+import { withEnv } from "../test-utils/env.js";
 import { killPidIfAlive } from "../test-utils/process-tree.js";
 import { sleep } from "../utils/sleep.js";
 import { GatewayChatClient } from "./gateway-chat.js";
@@ -1587,7 +1589,13 @@ export default {
         const agentDir = path.join(fixture.stateDir, "agents", "main", "agent");
         const sqlitePath = path.join(agentDir, "openclaw-agent.sqlite");
         expect(await stat(sqlitePath).then((entry) => entry.isFile())).toBe(true);
-        const store = loadPersistedAuthProfileStore(agentDir);
+        const store = withEnv({ OPENCLAW_STATE_DIR: fixture.stateDir }, () => {
+          reloadSharedAuthStoreOwnership();
+          return loadAuthProfileStoreForRuntime(agentDir, {
+            readOnly: true,
+            syncExternalCli: false,
+          });
+        });
         const profile = store?.profiles[profileId];
         expect(profile?.type === "api_key").toBe(true);
         expect(profile?.provider === providerId).toBe(true);

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -61,6 +61,7 @@ type MockModelBehavior = {
 type MockModelRequest = {
   method: string;
   path: string;
+  authorization?: string;
   body: Record<string, unknown>;
 };
 
@@ -348,7 +349,12 @@ async function startRoutedMockModelServer(
         const body = await readJsonRequest(req);
         if (url.pathname === "/v1/responses" || url.pathname === "/responses") {
           const modelId = typeof body.model === "string" ? body.model : "";
-          const request = { method: req.method, path: url.pathname, body };
+          const request = {
+            method: req.method,
+            path: url.pathname,
+            authorization: req.headers.authorization,
+            body,
+          };
           const behavior = behaviors[modelId];
           if (!behavior) {
             rejectedRequests.push(request);
@@ -1471,7 +1477,7 @@ describe("TUI PTY real backends", () => {
     "authenticates a manifest-discovered provider and resumes the unchanged local model",
     async ({ onTestFinished }) => {
       const pluginId = "t05-local-auth-fixture";
-      const providerId = "t05-local-auth-provider";
+      const providerId = "tui-pty-mock";
       const profileId = `${providerId}:default`;
       const sentinel = `t05-${randomUUID()}`;
       const expectedDigest = createHash("sha256").update(sentinel).digest("hex");
@@ -1616,6 +1622,7 @@ export default {
           onTimeout: () => new Error("post-auth prompt did not reach the mock provider"),
         });
         expect(fixture.mockModel.requests()[0]?.body.model).toBe("gpt-5.5");
+        expect(fixture.mockModel.requests()[0]?.authorization).toBe(`Bearer ${sentinel}`);
         await fixture.run.waitForOutput("LOCAL_AUTH_RESPONSE", LOCAL_OUTPUT_TIMEOUT_MS);
 
         await fixture.run.write("/exit\r", { delay: false });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -19,6 +19,7 @@ import {
   tryResolveDefaultAgentId,
 } from "../agents/agent-scope.js";
 import { reloadSharedAuthStoreOwnership } from "../agents/auth-profiles/path-resolve.js";
+import { clearRuntimeAuthProfileStoreSnapshots } from "../agents/auth-profiles/runtime-snapshots.js";
 import { normalizeThinkLevel } from "../auto-reply/thinking.shared.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
@@ -1405,7 +1406,12 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
             const outcome = `argv=${commandArgv} exitCode=${String(result.exitCode)} signal=${String(result.signal)}`;
             if (result.exitCode === 0 && !result.signal) {
               tuiAuthLog.info(`auth child finished: ${outcome}`);
-              reloadSharedAuthStoreOwnership();
+              if (!codexBin) {
+                reloadSharedAuthStoreOwnership();
+                // The auth child persisted outside this process. Invalidate the
+                // published generation so retained local runtimes rebuild from it.
+                clearRuntimeAuthProfileStoreSnapshots();
+              }
             } else {
               tuiAuthLog.error(`auth child failed: ${outcome}`);
             }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -18,6 +18,7 @@ import {
   resolveSessionAgentId,
   tryResolveDefaultAgentId,
 } from "../agents/agent-scope.js";
+import { reloadSharedAuthStoreOwnership } from "../agents/auth-profiles/path-resolve.js";
 import { normalizeThinkLevel } from "../auto-reply/thinking.shared.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
@@ -1404,6 +1405,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
             const outcome = `argv=${commandArgv} exitCode=${String(result.exitCode)} signal=${String(result.signal)}`;
             if (result.exitCode === 0 && !result.signal) {
               tuiAuthLog.info(`auth child finished: ${outcome}`);
+              reloadSharedAuthStoreOwnership();
             } else {
               tuiAuthLog.error(`auth child failed: ${outcome}`);
             }


### PR DESCRIPTION
## Summary

Local TUI `/auth` now reloads shared auth-store ownership after a successful out-of-process login. The login child can relocate the shared auth store into `state/openclaw.sqlite`, while the already-running TUI remained pinned to its pre-login legacy owner and could not see the new credential until restart.

This keeps ownership process-stable during normal runtime and reloads it only at the explicit auth lifecycle boundary. No schema, migration, config, fallback, or compatibility path changes. The PTY assertion now reads the effective runtime store rather than the retired agent-local persistence row.

## Evidence

- Before: exact built-CLI PTY test failed at `src/tui/tui-pty-local.e2e.test.ts:1592`; the auth child exited 0, the shared `auth_profile_stores` row contained the credential, and the caller still resolved the empty legacy agent row.
- After: focused real PTY auth flow passed (1 passed, 25 skipped), including persisted credential digest, unchanged local model, and post-auth inference.
- `pnpm test src/agents/auth-profiles/path-resolve.shared-store.test.ts src/tui/tui-command-handlers.test.ts`: 225 passed.
- `pnpm check:changed`: passed.
- `pnpm build`: passed.

Production LOC: +18/-1 (net +17) for the explicit cross-process ownership reload boundary. Tests: +26/-2.

AI-assisted: yes.