### PR TITLE
fix(cli): validate node options before contacting the Gateway

### DIFF
--- a/src/cli/nodes-cli.coverage.test.ts
+++ b/src/cli/nodes-cli.coverage.test.ts
@@ -98,7 +98,7 @@ describe("nodes-cli coverage", () => {
       return;
     }
     sharedProgram.exitOverride();
-    await registerNodesCli(sharedProgram);
+    await registerNodesCli(sharedProgram, ["node", "openclaw", "nodes", "status"]);
   });
 
   beforeEach(() => {
@@ -291,6 +291,42 @@ describe("nodes-cli coverage", () => {
       command: "rename",
       args: ["nodes", "rename", "--node", "mac-1", "--name", "   "],
       message: "--name must not be empty",
+    },
+    {
+      label: "push with an invalid environment",
+      command: "push",
+      args: ["nodes", "push", "--node", "mac-1", "--environment", "staging"],
+      message: "invalid --environment (use sandbox|production)",
+    },
+    {
+      label: "notify without a title or body",
+      command: "notify",
+      args: ["nodes", "notify", "--node", "mac-1", "--title", " ", "--body", " "],
+      message: "missing --title or --body",
+    },
+    {
+      label: "camera snap with an invalid facing",
+      command: "camera snap",
+      args: ["nodes", "camera", "snap", "--node", "mac-1", "--facing", "side"],
+      message: "invalid facing: side (expected front|back|both)",
+    },
+    {
+      label: "camera clip with an invalid facing",
+      command: "camera clip",
+      args: ["nodes", "camera", "clip", "--node", "mac-1", "--facing", "both"],
+      message: "invalid facing: both (expected front|back)",
+    },
+    {
+      label: "camera clip with an invalid duration",
+      command: "camera clip",
+      args: ["nodes", "camera", "clip", "--node", "mac-1", "--duration", "later"],
+      message: "Invalid duration",
+    },
+    {
+      label: "screen record with an invalid duration",
+      command: "screen record",
+      args: ["nodes", "screen", "record", "--node", "mac-1", "--duration", "later"],
+      message: "Invalid duration",
     },
   ])("reports $label once before calling the gateway", async ({ command, args, message }) => {
     await expect(sharedProgram.parseAsync(args, { from: "user" })).rejects.toThrow("__exit__:1");
@@ -605,9 +641,13 @@ describe("nodes-cli coverage", () => {
       ],
       flag: "--invoke-timeout",
     },
-  ])("rejects partial numeric option for $args", async ({ args, flag }) => {
-    await expect(sharedProgram.parseAsync(args, { from: "user" })).rejects.toThrow("__exit__:1");
-    expect(runtimeErrors.at(-1)).toContain(`${flag} must be`);
-    expect(lastNodeInvokeCall).toBeNull();
-  });
+  ])(
+    "rejects invalid numeric option before calling the gateway for $args",
+    async ({ args, flag }) => {
+      await expect(sharedProgram.parseAsync(args, { from: "user" })).rejects.toThrow("__exit__:1");
+      expect(runtimeErrors.at(-1)).toContain(`${flag} must be`);
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(lastNodeInvokeCall).toBeNull();
+    },
+  );
 });

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -128,8 +128,6 @@ export function registerNodesCameraCommands(nodes: Command) {
       .option("--invoke-timeout <ms>", "Node invoke timeout in ms (default 20000)", "20000")
       .action(async (opts: NodesRpcOpts) => {
         await runNodesCommand("camera snap", async () => {
-          const node = await resolveCliNode(opts, normalizeOptionalString(opts.node) ?? "");
-          const nodeId = node.nodeId;
           const facingOpt = normalizeLowercaseStringOrEmpty(
             normalizeOptionalString(opts.facing) ?? "",
           );
@@ -151,6 +149,12 @@ export function registerNodesCameraCommands(nodes: Command) {
           });
           const delayMs = parseOptionalNodeNonNegativeInteger(opts.delayMs, "--delay-ms");
           const deviceId = normalizeOptionalString(opts.deviceId);
+          const timeoutMs = parseOptionalNodePositiveInteger(
+            opts.invokeTimeout,
+            "--invoke-timeout",
+          );
+          const node = await resolveCliNode(opts, normalizeOptionalString(opts.node) ?? "");
+          const nodeId = node.nodeId;
           if (deviceId && facing === "both" && node.platform?.toLowerCase() !== "linux") {
             throw new Error("facing=both is not allowed when --device-id is set");
           }
@@ -159,11 +163,6 @@ export function registerNodesCameraCommands(nodes: Command) {
             platform: node.platform,
             deviceId,
           });
-          const timeoutMs = parseOptionalNodePositiveInteger(
-            opts.invokeTimeout,
-            "--invoke-timeout",
-          );
-
           const results: Array<{
             facing: CameraArtifactFacing;
             path: string;
@@ -235,10 +234,7 @@ export function registerNodesCameraCommands(nodes: Command) {
       .option("--invoke-timeout <ms>", "Node invoke timeout in ms (default 90000)", "90000")
       .action(async (opts: NodesRpcOpts & { audio?: boolean }) => {
         await runNodesCommand("camera clip", async () => {
-          const node = await resolveCliNode(opts, normalizeOptionalString(opts.node) ?? "");
-          const nodeId = node.nodeId;
           const facing = parseFacing(opts.facing ?? "front");
-          const target = resolveCameraClipTarget({ facing, platform: node.platform });
           const durationMs = parseDurationMs(opts.duration ?? "3000");
           const includeAudio = opts.audio !== false;
           const timeoutMs = parseOptionalNodePositiveInteger(
@@ -246,6 +242,9 @@ export function registerNodesCameraCommands(nodes: Command) {
             "--invoke-timeout",
           );
           const deviceId = normalizeOptionalString(opts.deviceId);
+          const node = await resolveCliNode(opts, normalizeOptionalString(opts.node) ?? "");
+          const nodeId = node.nodeId;
+          const target = resolveCameraClipTarget({ facing, platform: node.platform });
 
           const invokeParams = buildNodeInvokeParams({
             nodeId,

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -49,11 +49,11 @@ export function registerNodesInvokeCommands(nodes: Command) {
             );
           }
           const params = parseNodeInvokeParams(opts.params);
-          const nodeId = await resolveCliNodeId(opts, nodeQuery);
           const timeoutMs = parseOptionalNodePositiveInteger(
             opts.invokeTimeout,
             "--invoke-timeout",
           );
+          const nodeId = await resolveCliNodeId(opts, nodeQuery);
 
           const invokeParams: Record<string, unknown> = {
             nodeId,

--- a/src/cli/nodes-cli/register.location.ts
+++ b/src/cli/nodes-cli/register.location.ts
@@ -41,7 +41,6 @@ export function registerNodesLocationCommands(nodes: Command) {
           if (opts.accuracy !== undefined && desiredAccuracy === undefined) {
             throw new Error("invalid --accuracy (use coarse|balanced|precise)");
           }
-          const nodeId = await resolveCliNodeId(opts, opts.node ?? "");
           const maxAgeMs = parseOptionalNodeNonNegativeInteger(opts.maxAge, "--max-age");
           const timeoutMs = parseOptionalNodePositiveInteger(
             opts.locationTimeout,
@@ -51,6 +50,7 @@ export function registerNodesLocationCommands(nodes: Command) {
             opts.invokeTimeout,
             "--invoke-timeout",
           );
+          const nodeId = await resolveCliNodeId(opts, opts.node ?? "");
 
           const invokeParams: Record<string, unknown> = {
             nodeId,

--- a/src/cli/nodes-cli/register.notify.ts
+++ b/src/cli/nodes-cli/register.notify.ts
@@ -37,7 +37,6 @@ export function registerNodesNotifyCommand(nodes: Command) {
       .option("--invoke-timeout <ms>", "Node invoke timeout in ms (default 15000)", "15000")
       .action(async (opts: NodesRpcOpts) => {
         await runNodesCommand("notify", async () => {
-          const nodeId = await resolveCliNodeId(opts, normalizeOptionalString(opts.node) ?? "");
           const title = normalizeOptionalString(opts.title) ?? "";
           const body = normalizeOptionalString(opts.body) ?? "";
           if (!title && !body) {
@@ -47,6 +46,7 @@ export function registerNodesNotifyCommand(nodes: Command) {
             opts.invokeTimeout,
             "--invoke-timeout",
           );
+          const nodeId = await resolveCliNodeId(opts, normalizeOptionalString(opts.node) ?? "");
           const invokeParams: Record<string, unknown> = {
             nodeId,
             command: "system.notify",

--- a/src/cli/nodes-cli/register.push.ts
+++ b/src/cli/nodes-cli/register.push.ts
@@ -10,24 +10,6 @@ import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
 import { callNodesGatewayCli, nodesCallOpts, resolveCliNodeId } from "./rpc.js";
 import type { NodesRpcOpts } from "./types.js";
 
-type NodesPushOpts = NodesRpcOpts & {
-  node?: string;
-  title?: string;
-  body?: string;
-  environment?: string;
-};
-
-function normalizeEnvironment(value: unknown): "sandbox" | "production" | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const normalized = normalizeOptionalLowercaseString(value);
-  if (normalized === "sandbox" || normalized === "production") {
-    return normalized;
-  }
-  return null;
-}
-
 /** Register the node push-test command. */
 export function registerNodesPushCommand(nodes: Command) {
   nodesCallOpts(
@@ -38,15 +20,15 @@ export function registerNodesPushCommand(nodes: Command) {
       .option("--title <text>", "Push title", "OpenClaw")
       .option("--body <text>", "Push body")
       .option("--environment <sandbox|production>", "Override APNs environment")
-      .action(async (opts: NodesPushOpts) => {
+      .action(async (opts: NodesRpcOpts & { environment?: string }) => {
         await runNodesCommand("push", async () => {
+          const environment = normalizeOptionalLowercaseString(opts.environment);
+          if (opts.environment && environment !== "sandbox" && environment !== "production") {
+            throw new Error("invalid --environment (use sandbox|production)");
+          }
           const nodeId = await resolveCliNodeId(opts, normalizeOptionalString(opts.node) ?? "");
           const title = normalizeOptionalString(opts.title) || "OpenClaw";
           const body = normalizeOptionalString(opts.body) || `Push test for node ${nodeId}`;
-          const environment = normalizeEnvironment(opts.environment);
-          if (opts.environment && !environment) {
-            throw new Error("invalid --environment (use sandbox|production)");
-          }
 
           const params: Record<string, unknown> = {
             nodeId,

--- a/src/cli/nodes-cli/register.screen.ts
+++ b/src/cli/nodes-cli/register.screen.ts
@@ -39,7 +39,6 @@ export function registerNodesScreenCommands(nodes: Command) {
       .option("--invoke-timeout <ms>", "Node invoke timeout in ms (default 120000)", "120000")
       .action(async (opts: NodesRpcOpts & { out?: string }) => {
         await runNodesCommand("screen record", async () => {
-          const nodeId = await resolveCliNodeId(opts, opts.node ?? "");
           const durationMs = parseDurationMs(opts.duration ?? "");
           const screenIndex = parseOptionalNodeNonNegativeInteger(opts.screen ?? "0", "--screen");
           const fps = parseOptionalNodeFiniteNumber(opts.fps ?? "10", "--fps", {
@@ -49,6 +48,7 @@ export function registerNodesScreenCommands(nodes: Command) {
             opts.invokeTimeout,
             "--invoke-timeout",
           );
+          const nodeId = await resolveCliNodeId(opts, opts.node ?? "");
 
           const invokeParams = buildNodeInvokeParams({
             nodeId,

--- a/src/cli/program.nodes-push.e2e.test.ts
+++ b/src/cli/program.nodes-push.e2e.test.ts
@@ -90,28 +90,43 @@ describe("cli program (nodes push)", () => {
   });
 
   it.each([
-    ["text", []],
-    ["JSON", ["--json"]],
-  ])("keeps successful APNs push %s output at exit zero", async (_label, extraArgs) => {
-    const result: PushTestResult = {
-      ok: true,
-      status: 200,
-      apnsId: "apns-id",
-      tokenSuffix: "1234abcd",
-      topic: "ai.openclaw.ios",
-      environment: "sandbox",
-      transport: "direct",
-    };
-    mockPushResult(result);
+    { label: "text", extraArgs: [], environment: undefined },
+    { label: "JSON", extraArgs: ["--json"], environment: undefined },
+    { label: "empty environment", extraArgs: ["--environment", ""], environment: undefined },
+    { label: "sandbox", extraArgs: ["--environment", " SaNdBoX "], environment: "sandbox" },
+    { label: "production", extraArgs: ["--environment", "PrOdUcTiOn"], environment: "production" },
+  ])(
+    "keeps successful APNs push $label output at exit zero",
+    async ({ extraArgs, environment }) => {
+      const result: PushTestResult = {
+        ok: true,
+        status: 200,
+        apnsId: "apns-id",
+        tokenSuffix: "1234abcd",
+        topic: "ai.openclaw.ios",
+        environment: "sandbox",
+        transport: "direct",
+      };
+      mockPushResult(result);
 
-    await runPush(extraArgs);
+      await runPush(extraArgs);
 
-    expect(process.exitCode).toBeUndefined();
-    if (extraArgs.length > 0) {
-      expect(JSON.parse(runtimeOutput())).toEqual(result);
-    } else {
-      expect(runtimeOutput()).toContain("push.test status=200 ok=true env=sandbox");
-    }
-    expect(runtime.exit).not.toHaveBeenCalled();
-  });
+      expect(process.exitCode).toBeUndefined();
+      const pushRequest = programGatewayCallMock.mock.calls
+        .map(([request]) => request as { method?: string; params?: unknown })
+        .find(({ method }) => method === "push.test");
+      expect(pushRequest?.params).toEqual({
+        nodeId: "ios-node",
+        title: "OpenClaw",
+        body: "Push test for node ios-node",
+        ...(environment ? { environment } : {}),
+      });
+      if (extraArgs.includes("--json")) {
+        expect(JSON.parse(runtimeOutput())).toEqual(result);
+      } else {
+        expect(runtimeOutput()).toContain("push.test status=200 ok=true env=sandbox");
+      }
+      expect(runtime.exit).not.toHaveBeenCalled();
+    },
+  );
 });


### PR DESCRIPTION
Related: #116652

## What Problem This Solves

Fixes an issue where malformed `openclaw nodes` options contacted the Gateway before reporting their local validation error. An offline Gateway or unknown node could hide the useful error for invoke, notify, push, location, screen, and camera commands.

## Why This Change Was Made

Run the existing pure option validators before resolving a node. Checks requiring a node's platform still happen after lookup. The push command directly uses the canonical normalized environment value, removing a one-use wrapper and duplicated option fields. Flags, defaults, error text, mixed-case environment names, and successful APNs output are preserved.

Production LOC: +18/-37 (net -19). Tests: +85/-30 (net +55). No dependency, configuration, schema, protocol, or API changes.

## User Impact

Invalid local arguments now produce the intended diagnostic without needing a reachable Gateway. Valid invocations still contact the Gateway normally.

## Evidence

- Candidate `ebd6139f28d116e9de96081608a3eb7bc1fe9f7e`.
- Before: 21 regression cases detected an unwanted `node.list` call before rejection. After: 97 owner and CLI E2E tests passed.
- Actual built CLI: 20 invalid-input scenarios each exited with the expected diagnostic and made zero connections to an isolated TCP observer. A valid invocation reached that observer once, proving the check could detect traffic. No real APNs request was sent.
- All 11 runtime/declaration build stages and native require validation passed. The complete changed-file gate passed with matching dependencies and no skipped gates.
- Fresh structured Codex P1 review and independent source/runtime evidence review passed on this commit.
- Maintainer-requested, AI-assisted repair and simplification. CI on the published candidate is required before landing.
