### PR TITLE
test(qa): await gateway startup before network probes

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-loopback-lan-access.ts
+++ b/test/e2e/qa-lab/runtime/gateway-loopback-lan-access.ts
@@ -309,12 +309,16 @@ async function probeTcpUnreachable(params: {
 }
 
 async function startGateway(port: number, bind: "lan" | "loopback", token: string) {
-  return await startGatewayServer(port, {
+  const server = await startGatewayServer(port, {
     auth: { mode: "token", token },
     bind,
     controlUiEnabled: false,
     sidecarStartup: "defer",
   });
+  // HTTP attachment precedes mandatory sidecar settlement. Network probes own
+  // a fully admitted generation, not the intentional startup-unavailable phase.
+  await server.startupSettled;
+  return server;
 }
 
 async function stopGateway(server: GatewayServer | undefined): Promise<void> {


### PR DESCRIPTION
## Problem

Maturity run 32992034783 failed `gateway-loopback-lan-access` after its LAN HTTP endpoint was attached but before mandatory Gateway startup settled. The invalid-token probe correctly exercised auth, while the immediately following valid-token connection received the intentional `gateway starting; retry shortly` admission response.

`startGatewayServer` deliberately publishes the HTTP transport before deferred sidecar startup completes and exposes `startupSettled` as the owner-native readiness boundary. The QA producer treated server construction and HTTP health as full admission readiness.

## Repair

Await the returned server generation’s `startupSettled` promise inside the producer’s startup owner before any loopback or LAN probe. This removes the race without retries, sleeps, timeouts, or weakened assertions.

## Verification

- Pre-fix run artifact: valid LAN token rejected with `gateway starting; retry shortly`.
- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/gateway-loopback-lan-access.test.ts` — 3 passed, including the real loopback/LAN HTTP and WebSocket proof.
- `node scripts/check-changed.mjs -- test/e2e/qa-lab/runtime/gateway-loopback-lan-access.ts` — passed (test-root typecheck and script/Docker E2E lint included).
- Duplicate search found no open PR for this producer/startup-settlement gap.

Test/support LOC: +5/-1. No production LOC. No changelog: QA-only synchronization repair.