### PR TITLE
fix(qa): track current Slack progress cards

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -666,6 +666,9 @@ describe("Slack live QA runtime helpers", () => {
       if (!commentaryMarker || !toolMarker || !finalMarker || !verifyObserved) {
         throw new Error(`missing Slack progress verifier: ${testCase.id}`);
       }
+      // Progress cards compact command details from the middle, so the QA marker
+      // stays at the command suffix where the real Slack presentation preserves it.
+      expect(input).toContain(`run: sleep 5 # ${toolMarker}.`);
       const messages = [
         {
           channelId: "C123456789",
@@ -678,7 +681,7 @@ describe("Slack live QA runtime helpers", () => {
                 channelId: "C123456789",
                 text: testCase.commentaryStyle === "lane" ? "Working…" : commentaryMarker,
                 ...(testCase.commentaryStyle === "lane"
-                  ? { blockText: ["Update", commentaryMarker] }
+                  ? { blockText: [`• *Update* — ${commentaryMarker}`] }
                   : {}),
                 ts: testCase.commentaryTs,
               },
@@ -734,7 +737,7 @@ describe("Slack live QA runtime helpers", () => {
       { text: `_${commentaryMarker}_` },
       { text: ` \n_${commentaryMarker}_\t` },
       { text: `💬 ${commentaryMarker}` },
-      { blockText: ["Update", commentaryMarker], text: "Working…" },
+      { blockText: [`• *Update* — ${commentaryMarker}`], text: "Working…" },
     ]) {
       expect(() => verifyCommentaryMessage(message)).not.toThrow();
     }

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
@@ -89,10 +89,7 @@ function hasSlackCommentaryLaneMarker(
     return true;
   }
   const blockText = message.blockText ?? [];
-  return (
-    blockText.some((text) => text.trim() === "Update") &&
-    blockText.some((text) => text.includes(marker))
-  );
+  return blockText.some((text) => text.trim() === `• *Update* — ${marker}`);
 }
 
 export function buildSlackProgressCommentaryRun(
@@ -110,7 +107,7 @@ export function buildSlackProgressCommentaryRun(
     input: [
       `<@${sutUserId}> This is a Slack progress protocol test. First, emit an assistant commentary message whose entire text is exactly ${commentaryMarker}.`,
       "Do not call any tool until that commentary message is complete.",
-      `Then use the exec tool exactly once to run: grep '${toolMarker}' /dev/null || sleep 5.`,
+      `Then use the exec tool exactly once to run: sleep 5 # ${toolMarker}.`,
       `After the command finishes, reply with only this exact marker: ${finalMarker}`,
     ].join(" "),
     matchText: finalMarker,


### PR DESCRIPTION
## Summary

- recognize the current single-block Slack progress activity row when proving commentary-lane delivery
- keep the tool-progress probe marker at the command suffix so Slack's bounded middle compaction preserves it
- update the focused verifier fixtures to exercise those exact observed presentations

Supersedes #119910 for the current session-card architecture and credits @vincentkoc for identifying that the QA classifier must follow Slack's canonical rendered form. That older branch predates the session-card owner and cannot be updated by maintainers. This intentionally does not adopt #121004's delivery workaround.

## Root cause and owner

The failed maturity scenarios were harness-oracle defects, not Slack delivery failures. `buildSlackProgressCardBlocks` now renders commentary as one activity block (`• *Update* — <text>`), while QA still required separate `Update` and marker block entries. Separately, Slack compacts bounded command details from the middle, but the probe placed its only tool marker in the middle of a longer command. The QA scenario fixture owns both observable probes, so this repairs the producer/verifier there without changing Slack runtime behavior.

## Maturity reproduction

Run [32992034783](https://github.com/openclaw/openclaw/actions/runs/32992034783) at tested SHA `67a310b2c6bafe7a8b74745ee958c34bca55dc84`, shard 03, retried and failed:

- `slack-progress-commentary-true`: `expected commentary in the Slack progress commentary lane`
- `slack-progress-commentary-verbose-dedupe`: `expected tool progress only in standalone verbose messages`

The downloaded flow artifacts exposed the bounded verifier errors but intentionally did not persist raw private Slack message content. Current source and focused renderer tests establish the corresponding public shapes: one activity block for commentary and middle-compacted command detail.

## Validation

- `pnpm exec oxfmt --check extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts`
- `pnpm exec vitest run extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts` — 50 passed
- `git diff --check`

Live rerun is left to the existing maturity workflow because the checkout has no directly provisioned Slack QA credential; this PR changes only its observation probes and does not print or broaden credential access.

## Scope / LOC

- Production: `+0/-0`
- QA test/support: `+7/-7`
- Removed stale path: split-block `Update` + marker classifier
- Sibling coverage: true/false/omitted/verbose-dedupe scenario matrix remains covered by the focused runtime test

## Risk

Low and test-only. The new block match intentionally keys to the current canonical Slack card row, and the suffix marker preserves the same single slow exec action while surviving the renderer's documented bounded compaction.
