### PR TITLE
fix(qa): retain failed empty checks in exported evidence

### DIFF
--- a/extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
@@ -24,15 +24,25 @@ afterEach(async () => {
 });
 
 describe("qa test file scenario runner", () => {
-  it.each([
-    { evidence: "missing", expectedFailure: /without writing fresh producer QA evidence/u },
-    { evidence: "stale", expectedFailure: /without writing fresh producer QA evidence/u },
-    { evidence: "empty", expectedFailure: /without reporting an executed producer check/u },
-    { evidence: "malformed", expectedFailure: /invalid JSON/u },
-    { evidence: "outside", expectedFailure: /inside its scenario output directory/u },
-  ] as const)(
-    "fails a successful script with $evidence producer evidence",
-    async ({ evidence, expectedFailure }) => {
+  it.each(
+    (
+      [
+        { evidence: "missing", expectedFailure: /without writing fresh producer QA evidence/u },
+        { evidence: "stale", expectedFailure: /without writing fresh producer QA evidence/u },
+        { evidence: "empty", expectedFailure: /without reporting an executed producer check/u },
+        { evidence: "malformed", expectedFailure: /invalid JSON/u },
+        { evidence: "outside", expectedFailure: /inside its scenario output directory/u },
+      ] as const
+    ).flatMap(({ evidence, expectedFailure }) =>
+      (["full", "slim"] as const).map((evidenceMode) => ({
+        evidence,
+        expectedFailure,
+        evidenceMode,
+      })),
+    ),
+  )(
+    "retains $evidence producer failure alongside passing evidence in $evidenceMode mode",
+    async ({ evidence, evidenceMode, expectedFailure }) => {
       const repoRoot = await makeTempRepo(`qa-script-${evidence}-producer-evidence-`);
       const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "scenario-script");
       const scenarioOutputDir = path.join(outputDir, "scenario-script");
@@ -54,8 +64,24 @@ describe("qa test file scenario runner", () => {
         repoRoot,
         outputDir,
         ...QA_TEST_RUNNER_DEFAULTS,
-        scenarios: [makeTestFileScenario("script", "scripts/evidence-producer.ts")],
-        runCommand: async () => {
+        evidenceMode,
+        scenarios: [
+          makeTestFileScenario("script", "scripts/evidence-producer.ts"),
+          {
+            ...makeTestFileScenario("script", "scripts/healthy-evidence-producer.ts"),
+            id: "healthy-scenario",
+          },
+        ],
+        runCommand: async (command) => {
+          if (command.args.includes("scripts/healthy-evidence-producer.ts")) {
+            await writeScriptProducerEvidence({
+              outputDir,
+              scenarioId: "healthy-scenario",
+              producerId: "healthy-check",
+              status: "pass",
+            });
+            return { exitCode: 0, stdout: "healthy check passed\n", stderr: "" };
+          }
           await fs.mkdir(scenarioOutputDir, { recursive: true });
           if (evidence === "stale") {
             await expect(fs.access(latestRunPath)).rejects.toMatchObject({ code: "ENOENT" });
@@ -106,11 +132,18 @@ describe("qa test file scenario runner", () => {
 
       expect(result.results[0]).toMatchObject({ status: "fail" });
       expect(result.results[0]?.failureMessage).toMatch(expectedFailure);
-      expect(result.evidence.entries).toHaveLength(1);
-      expect(result.evidence.entries[0]).toMatchObject({
-        test: { id: "scenario-script" },
-        result: { status: "fail" },
-      });
+      expect(result.results[1]).toMatchObject({ status: "pass" });
+      const exportedEvidence = validateQaEvidenceSummaryJson(
+        JSON.parse(await fs.readFile(result.evidencePath, "utf8")),
+      );
+      expect(exportedEvidence.evidenceMode).toBe(evidenceMode);
+      expect(exportedEvidence.entries).toMatchObject([
+        { test: { id: "scenario-script" }, result: { status: "fail" } },
+        { test: { id: "healthy-check" }, result: { status: "pass" } },
+      ]);
+      if (evidenceMode === "slim") {
+        expect(exportedEvidence.entries.every((entry) => entry.execution === undefined)).toBe(true);
+      }
     },
   );
 

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -524,7 +524,7 @@ function buildTestFileEvidence(params: {
     // colliding non-fail results without discarding producer execution facts.
     const producerEntryIds = new Set(producerEntries.map((entry) => entry.test.id));
     const fallbackResults = params.results.filter(
-      (result) => !result.producerEvidence || result.includeFallbackEvidence,
+      (result) => !result.producerEvidence?.entries.length || result.includeFallbackEvidence,
     );
     const evidenceMode =
       params.evidenceMode ??


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators reviewing exported QA evidence would lose a failed script scenario when that script emitted an empty evidence bundle and another script emitted a valid check. The separate suite summary still reported the failure, but both full and slim `qa-evidence.json` artifacts could contain only the passing sibling.

## Why This Change Was Made

The existing aggregation owner treated the presence of an evidence object as proof that it supplied a row. Use its actual entry count when selecting scenario-level fallback evidence. This retains the recorded failure without changing execution, producer validation, terminal-failure precedence, artifact schemas, or persistent state.

The malformed-evidence regression table now includes a healthy sibling and reads the exported artifact in both full and slim modes. No new production abstraction or dependency is needed. Production LOC: +1/-1 (net 0); tests: +49/-16 (net +33).

## User Impact

QA evidence consumers see every failed empty-evidence scenario alongside successful producer checks. Existing producer details, ordering, coverage attribution, and slim-mode omission of execution metadata are preserved.

## Evidence

- Before the fix: two real child processes recorded `empty-scenario: fail` and `healthy-scenario: pass`, but the exported artifact contained only `healthy-check: pass`, in both modes. The corresponding two regression cases failed for the same missing row.
- After the fix: the same real-process reproduction retains `empty-scenario: fail` plus `healthy-check: pass` in both exported artifacts.
- 54 tests pass across the script-evidence, native, process, and E2E-routing suites, including real child-process streaming and timeout checks. Existing missing, stale, malformed, and out-of-directory evidence cases remain failures beside the healthy sibling.
- Targeted formatting, AST lint, max-lines and assertion-safety ratchets, and `git diff --check` pass. Independent source review and authenticated Codex autoreview report no actionable findings.
- Local proof uses current checkout source with installed primary dependencies through a private resolution harness. The linked checkout lacks its own complete dependency installation. Test isolation intentionally clears `NODE_OPTIONS`; the private harness resolves only the child's leading `--import tsx` to the installed loader, preserving the actual process, environment, arguments, output, and timeouts. This is not packaged CLI or fully pinned dependency proof; hosted CI must validate the lockfile installation before landing.

Provenance: the object-presence predicate was introduced in #94276 (Colin Johnson, @Solvely-Colin; merged by @RomneyDa). The inconsistency became observable after empty bundles were classified as failed checks in #115404 (@steipete), while aggregation retained the older predicate. No applicable open duplicate repair was found.

AI-assisted; implementation and runtime evidence manually verified.
