### PR TITLE
test(qa): keep CLI log proof within its claimed bounds

### DIFF
--- a/test/e2e/qa-lab/runtime/remote-log-tailing-runtime.ts
+++ b/test/e2e/qa-lab/runtime/remote-log-tailing-runtime.ts
@@ -136,9 +136,9 @@ export async function runRemoteLogTailing(repoRoot: string, outputRoot: string) 
       gateway.token,
       "--json",
       "--limit",
-      "2",
+      "200",
       "--max-bytes",
-      "4096",
+      "250000",
     ]);
     const cliRecords = cliJson
       .trim()


### PR DESCRIPTION
## Problem

Maturity run 32992034783 failed `remote-log-tailing` even though the packaged `logs` CLI correctly returned the newest two records and reported truncation. The producer had appended `qa-cursor-line`, then invoked the CLI with `--limit 2 --max-bytes 4096`; normal Gateway startup/background records displaced that marker before the CLI read. The proof then incorrectly required an older record outside its requested tail window.

## Repair

Keep the strict `limit` and `maxBytes` behavior assertions on the direct `logs.tail` RPC calls that already own them. Give the independent packaged-CLI metadata/record proof a bounded 200-line, 250000-byte window (the product defaults), so it verifies CLI projection rather than contradicting its own truncation contract.

No retry, sleep, timeout increase, product fallback, or weakened product assertion is added.

## Verification

- Pre-fix maturity artifact: CLI emitted two newer records plus `Log tail truncated`; the required marker was outside the requested window.
- Built the private QA runtime and ran `test/e2e/qa-lab/runtime/remote-log-tailing-runtime.ts` through a real local Gateway; passed.
- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/remote-log-tailing-runtime.test.ts` — 2 passed.
- `node scripts/check-changed.mjs -- test/e2e/qa-lab/runtime/remote-log-tailing-runtime.ts` — passed.
- Duplicate search found no open PR for this failure.

Test/support LOC: +2/-2. No production LOC. No changelog: QA-only proof correction.