### PR TITLE
fix(plugins): restore diffs external catalog validation

### DIFF
--- a/extensions/diffs-language-pack/package.json
+++ b/extensions/diffs-language-pack/package.json
@@ -17,7 +17,6 @@
     "install": {
       "npmSpec": "@openclaw/diffs-language-pack",
       "clawhubSpec": "clawhub:@openclaw/diffs-language-pack",
-      "localPath": "extensions/diffs-language-pack",
       "defaultChoice": "npm",
       "minHostVersion": ">=2026.5.27"
     },

--- a/extensions/diffs/package.json
+++ b/extensions/diffs/package.json
@@ -23,7 +23,7 @@
     ],
     "install": {
       "npmSpec": "@openclaw/diffs",
-      "localPath": "extensions/diffs",
+      "clawhubSpec": "clawhub:@openclaw/diffs",
       "defaultChoice": "npm",
       "minHostVersion": ">=2026.4.30"
     },


### PR DESCRIPTION
Related: #129782

## What Problem This Solves

Fixes an issue where release validation rejected the official external plugin catalog after the diffs plugins moved out of the core distribution.

## Why This Change Was Made

The two independently published diffs packages no longer advertise a bundled local install path. The base diffs manifest also declares its existing ClawHub route, matching its release policy and the official catalog.

## User Impact

Release validation can verify the external plugin catalog again. Operators continue to install the diffs plugins through their published npm or ClawHub packages.

## Evidence

- Pre-fix reproduction: `node scripts/run-vitest.mjs src/plugins/official-external-plugin-catalog.test.ts` failed with `diffs` and `diffs-language-pack` install metadata gaps.
- Post-fix owner and sibling proof: 92 tests passed across `src/plugins/official-external-plugin-catalog.test.ts`, `src/plugins/bundled-sources.test.ts`, and `src/cli/plugin-install-plan.test.ts`.
- `node scripts/check-changed.mjs -- extensions/diffs/package.json extensions/diffs-language-pack/package.json` passed 16 gates through plugin boundaries and package patch validation. Extension typecheck then stopped on unrelated missing `imapflow`, `mailauth`, and `mailparser` dependencies in the existing worktree dependency tree.
- Duplicate search: no open PR or issue found for this exact catalog drift.

Production/config LOC: +1/-2 (net -1). Tests: +0/-0. The existing catalog ownership test is the regression proof and demonstrably failed before this repair.

This change was developed with AI assistance.
