### PR TITLE
docs(plugins): register imap in generated plugin inventory

### DIFF
--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -52,7 +52,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-58 plugins
+59 plugins
 
 - **[a2a](/plugins/reference/a2a)** (`@openclaw/a2a`) - included in OpenClaw. A2A v1.0 Agent-to-Agent protocol channel plugin.
 
@@ -101,6 +101,8 @@ Each entry lists the package, distribution route, and description.
 - **[google](/plugins/reference/google)** (`@openclaw/google-plugin`) - included in OpenClaw. Adds Google, Google Gemini CLI, Google Vertex model provider support to OpenClaw.
 
 - **[huggingface](/plugins/reference/huggingface)** (`@openclaw/huggingface-provider`) - included in OpenClaw. Adds Hugging Face model provider support to OpenClaw.
+
+- **[imap](/plugins/reference/imap)** (`@openclaw/imap`) - included in OpenClaw. Watch IMAP mailboxes and dispatch authenticated incoming email to isolated agent sessions.
 
 - **[linux-node](/plugins/reference/linux-node)** (`@openclaw/linux-node`) - included in OpenClaw. Desktop notifications, camera capture, and location for Linux node hosts.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -16,5 +16,5 @@ Regenerate it with:
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 149
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 150
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/imap.md
+++ b/docs/plugins/reference/imap.md
@@ -1,0 +1,23 @@
+---
+summary: "Watch IMAP mailboxes and dispatch authenticated incoming email to isolated agent sessions."
+read_when:
+  - You are installing, configuring, or auditing the imap plugin
+title: "Imap plugin"
+---
+
+# Imap plugin
+
+Watch IMAP mailboxes and dispatch authenticated incoming email to isolated agent sessions.
+
+## Distribution
+
+- Package: `@openclaw/imap`
+- Install route: included in OpenClaw
+
+## Surface
+
+plugin
+
+## Related docs
+
+- [imap](/automation/imap)

--- a/scripts/generate-plugin-inventory-doc.mts
+++ b/scripts/generate-plugin-inventory-doc.mts
@@ -33,6 +33,7 @@ const PLUGIN_DOC_ALIASES = new Map([
   ["duckduckgo", "/tools/duckduckgo-search"],
   ["exa", "/tools/exa-search"],
   ["firecrawl", "/tools/firecrawl"],
+  ["imap", "/automation/imap"],
   ["parallel", "/tools/parallel-search"],
   ["perplexity", "/tools/perplexity-search"],
   ["policy", "/cli/policy"],


### PR DESCRIPTION
## What Problem This Solves

The bundled `imap` plugin landed in #130230 without regenerating the generated plugin docs. As a result `pnpm plugins:inventory:check` fails on current `main` (`docs/plugins/plugin-inventory.md is stale`), and the plugin is invisible in the plugin reference: no entry in the inventory, no `docs/plugins/reference/imap.md` page, while 149 other plugins have one.

This is not currently caught by PR CI — `plugins:inventory:check` is not wired into any workflow or check lane — but it **is** run by `scripts/release-preflight.mts`, so the drift would have failed the next release preflight.

## Why This Change Was Made

Two parts, both minimal:

1. **Regenerate** the three generated artifacts with `pnpm plugins:inventory:gen` (never hand-edited, per `docs/AGENTS.md`): inventory count 58 -> 59 plus the imap entry, reference index 149 -> 150, and the new generated `docs/plugins/reference/imap.md`.
2. **Register the operator guide** in `PLUGIN_DOC_ALIASES`. The imap plugin is neither a channel nor a provider, so the generator's convention-based doc resolution (`docs/channels/<id>.md`, `docs/providers/<id>.md`, `docs/plugins/<id>.md`) cannot find its guide at `docs/automation/imap.md`. `PLUGIN_DOC_ALIASES` is the existing mechanism for exactly this case — `codex -> /plugins/codex-harness`, `acpx -> /tools/acp-agents-setup`, `firecrawl -> /tools/firecrawl`. Adding `imap -> /automation/imap` gives the generated reference page a `## Related docs` link to the real operator guide instead of dead-ending on the manifest summary.

## User Impact

The imap plugin now appears in the plugin inventory and has a reference page that links to its setup guide. No runtime behavior changes; docs and one generator alias entry only.

## Evidence

- `pnpm plugins:inventory:check` now passes (failed on `main` before this change).
- `pnpm check:changed --staged` green (typecheck, lint, format, architecture and boundary guards).
- Regeneration diff verified to be imap-only: `+59 plugins`, one inventory entry, `+150 generated plugin reference pages`, and the new page. No unrelated plugin churn.
- Generated `Related docs` link renders as `- [imap](/automation/imap)`, matching the existing lowercase alias rendering for codex/firecrawl/acpx.

Follow-up worth considering separately: wiring `plugins:inventory:check` into the changed-files lane so a future bundled plugin cannot repeat this silently. Not included here because it is a CI-policy change.
