### PR TITLE
fix(ui): clarify gateway disconnect status in tab title

### DIFF
--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -180,13 +180,13 @@ describe("formatDocumentTitle", () => {
   it("names the disconnected gateway without implying internet loss", () => {
     expect(
       formatDocumentTitle({ context: "Usage", gatewayDisconnected: true, queuedCount: 0 }),
-    ).toBe("(Gateway disconnected) Usage — OpenClaw");
+    ).toBe("(Disconnected) Usage — OpenClaw");
   });
 
   it("includes the queued outbox count in the disconnected marker", () => {
     expect(
       formatDocumentTitle({ context: "Usage", gatewayDisconnected: true, queuedCount: 3 }),
-    ).toBe("(Gateway disconnected · 3 queued) Usage — OpenClaw");
+    ).toBe("(Disconnected · 3 queued) Usage — OpenClaw");
   });
 
   it("ignores a queued count while online", () => {
@@ -196,7 +196,7 @@ describe("formatDocumentTitle", () => {
   it("suppresses the attention count while disconnected", () => {
     expect(
       formatDocumentTitle({ context: "Usage", attentionCount: 2, gatewayDisconnected: true }),
-    ).toBe("(Gateway disconnected) Usage — OpenClaw");
+    ).toBe("(Disconnected) Usage — OpenClaw");
   });
 });
 

--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -177,26 +177,26 @@ describe("formatDocumentTitle", () => {
     );
   });
 
-  it("does not add a queued count for an empty offline outbox", () => {
-    expect(formatDocumentTitle({ context: "Usage", offline: true, queuedCount: 0 })).toBe(
-      "(Offline) Usage — OpenClaw",
-    );
+  it("names the disconnected gateway without implying internet loss", () => {
+    expect(
+      formatDocumentTitle({ context: "Usage", gatewayDisconnected: true, queuedCount: 0 }),
+    ).toBe("(Gateway disconnected) Usage — OpenClaw");
   });
 
-  it("includes the queued outbox count in the offline marker", () => {
-    expect(formatDocumentTitle({ context: "Usage", offline: true, queuedCount: 3 })).toBe(
-      "(Offline · 3 queued) Usage — OpenClaw",
-    );
+  it("includes the queued outbox count in the disconnected marker", () => {
+    expect(
+      formatDocumentTitle({ context: "Usage", gatewayDisconnected: true, queuedCount: 3 }),
+    ).toBe("(Gateway disconnected · 3 queued) Usage — OpenClaw");
   });
 
   it("ignores a queued count while online", () => {
     expect(formatDocumentTitle({ context: "Usage", queuedCount: 3 })).toBe("Usage — OpenClaw");
   });
 
-  it("suppresses the attention count while offline", () => {
-    expect(formatDocumentTitle({ context: "Usage", attentionCount: 2, offline: true })).toBe(
-      "(Offline) Usage — OpenClaw",
-    );
+  it("suppresses the attention count while disconnected", () => {
+    expect(
+      formatDocumentTitle({ context: "Usage", attentionCount: 2, gatewayDisconnected: true }),
+    ).toBe("(Gateway disconnected) Usage — OpenClaw");
   });
 });
 

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -441,24 +441,24 @@ export function titleForRoute(routeId: NavigationRouteId): string {
 }
 
 /** Window/tab title, markers leftmost because tabs truncate from the right.
- * Offline replaces the approval count (a stale queue is not actionable) and
- * carries the pending-outbox total; titles already ending in the brand
+ * A disconnected Gateway replaces the approval count (a stale queue is not
+ * actionable) and carries the pending-outbox total; titles already ending in the brand
  * ("Ask OpenClaw") skip the suffix so it never reads "… OpenClaw — OpenClaw". */
 export function formatDocumentTitle(options: {
   context: string;
   attentionCount?: number;
-  offline?: boolean;
+  gatewayDisconnected?: boolean;
   queuedCount?: number;
 }): string {
   const base = options.context.endsWith("OpenClaw")
     ? options.context
     : `${options.context} — OpenClaw`;
-  if (options.offline) {
+  if (options.gatewayDisconnected) {
     const queued =
       options.queuedCount && options.queuedCount > 0
         ? ` · ${t("connection.queuedCount", { count: String(options.queuedCount) })}`
         : "";
-    return `(${t("common.offline")}${queued}) ${base}`;
+    return `(${t("connection.disconnectedTitle")}${queued}) ${base}`;
   }
   if (options.attentionCount && options.attentionCount > 0) {
     return `(${options.attentionCount}) ${base}`;

--- a/ui/src/app/app-host.document-title.test.ts
+++ b/ui/src/app/app-host.document-title.test.ts
@@ -167,16 +167,16 @@ describe("OpenClaw shell document title", () => {
     expect(document.title).toBe("(2) Usage — OpenClaw");
   });
 
-  it("shows offline instead of a stale approval count", () => {
+  it("shows disconnected instead of a stale approval count", () => {
     const shell = createShell(createContext({ connected: false, approvalCount: 2 }));
     shell.routeState = { routeId: "usage" };
 
     shell.syncDocumentTitle();
 
-    expect(document.title).toBe("(Offline) Usage — OpenClaw");
+    expect(document.title).toBe("(Disconnected) Usage — OpenClaw");
   });
 
-  it("includes stored chat outbox messages in the offline marker", () => {
+  it("includes stored chat outbox messages in the disconnected marker", () => {
     const shell = createShell(createContext({ connected: false }));
     shell.routeState = { routeId: "usage" };
     shell.outboxStoreRuntime = {
@@ -185,7 +185,7 @@ describe("OpenClaw shell document title", () => {
 
     shell.syncDocumentTitle();
 
-    expect(document.title).toBe("(Offline · 3 queued) Usage — OpenClaw");
+    expect(document.title).toBe("(Disconnected · 3 queued) Usage — OpenClaw");
   });
 
   it("uses the meaningful custodian label without a brand suffix", () => {

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -646,12 +646,12 @@ class OpenClawShell
     if (isSessionRouteId(routeId) && this.activeSessionKey) {
       primaryContext = this.chatTitleContext(context, outboxScopeHost) || primaryContext;
     }
-    const offline = context.gateway.snapshot.phase !== "connected";
+    const gatewayDisconnected = context.gateway.snapshot.phase !== "connected";
     let title = formatDocumentTitle({
       context: primaryContext,
       attentionCount: context.overlays.snapshot.approvalQueue.length,
-      offline,
-      ...(offline && {
+      gatewayDisconnected,
+      ...(gatewayDisconnected && {
         queuedCount: this.outboxStoreRuntime?.summarizeStoredChatOutboxes(outboxScopeHost).total,
       }),
     });

--- a/ui/src/e2e/sidebar-account-footer.e2e.test.ts
+++ b/ui/src/e2e/sidebar-account-footer.e2e.test.ts
@@ -174,6 +174,7 @@ suite.define(() => {
       await offline.waitFor({ state: "visible", timeout: 10_000 });
       expect(await offline.textContent()).toContain("Offline");
       expect(await offline.textContent()).toContain("Reconnecting…");
+      await expect.poll(() => page.title()).toContain("(Gateway disconnected)");
       await captureUnionProof(page, "sidebar-account-footer", "feature-dark-offline.png", [footer]);
 
       const socketCount = await gateway.getSocketCount();
@@ -186,6 +187,7 @@ suite.define(() => {
       await expect
         .poll(() => footer.locator(".sidebar-footer-bar__status").count(), { timeout: 10_000 })
         .toBe(0);
+      await expect.poll(() => page.title()).not.toContain("Gateway disconnected");
       await gateway.emitGatewayEvent("shutdown", {
         reason: "gateway restart",
         restartExpectedMs: 5_000,

--- a/ui/src/e2e/sidebar-account-footer.e2e.test.ts
+++ b/ui/src/e2e/sidebar-account-footer.e2e.test.ts
@@ -174,7 +174,7 @@ suite.define(() => {
       await offline.waitFor({ state: "visible", timeout: 10_000 });
       expect(await offline.textContent()).toContain("Offline");
       expect(await offline.textContent()).toContain("Reconnecting…");
-      await expect.poll(() => page.title()).toContain("(Gateway disconnected)");
+      await expect.poll(() => page.title()).toContain("(Disconnected)");
       await captureUnionProof(page, "sidebar-account-footer", "feature-dark-offline.png", [footer]);
 
       const socketCount = await gateway.getSocketCount();
@@ -187,7 +187,7 @@ suite.define(() => {
       await expect
         .poll(() => footer.locator(".sidebar-footer-bar__status").count(), { timeout: 10_000 })
         .toBe(0);
-      await expect.poll(() => page.title()).not.toContain("Gateway disconnected");
+      await expect.poll(() => page.title()).not.toContain("Disconnected");
       await gateway.emitGatewayEvent("shutdown", {
         reason: "gateway restart",
         restartExpectedMs: 5_000,

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4276,6 +4276,7 @@ export const en: TranslationMap = {
     eventStale: "Stale session",
   },
   connection: {
+    disconnectedTitle: "Gateway disconnected",
     queuedCount: "{count} queued",
     reconnecting: "Reconnecting…",
     restarting: "Restarting…",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4276,7 +4276,7 @@ export const en: TranslationMap = {
     eventStale: "Stale session",
   },
   connection: {
-    disconnectedTitle: "Gateway disconnected",
+    disconnectedTitle: "Disconnected",
     queuedCount: "{count} queued",
     reconnecting: "Reconnecting…",
     restarting: "Restarting…",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users saw “Offline” in the Control UI tab title whenever its Gateway WebSocket was not connected, even when their internet connection was healthy. The marker could appear during initial connection, reconnects, Gateway startup or authentication errors, and intentional stops.

## Why This Change Was Made

The title now says “Disconnected,” matching the condition the UI actually observes while keeping the meaningful word visible in narrow tabs. The formatter input is renamed to keep future callers from confusing Gateway connectivity with browser internet access.

## User Impact

Disconnected Control UI tabs now distinguish a lost Gateway connection from a loss of internet access. Pending outbox counts remain visible, and the marker still clears immediately after reconnection.

## Evidence

- Focused formatter regression: 74 tests passed; the new expectation failed against the pre-fix implementation.
- Mock-Gateway browser flow: 3 tests passed, including disconnect title assertion and reconnect clearing assertion.
- `node scripts/check-changed.mjs`: passed UI/core-test formatting, i18n, typecheck, lint, and repository guards.
- `pnpm ui:build`: passed, including Control UI performance budgets.
- Structured autoreview: clean, no actionable findings.

```json
{
  "scenario": "control-ui-gateway-title-disconnect-reconnect",
  "gateway": "mock WebSocket Gateway",
  "browser": "Chromium via Playwright",
  "observed": {
    "disconnectedTitle": "(Disconnected)",
    "reconnectedTitleMarkerPresent": false,
    "sidebarRetryState": "Offline / Reconnecting…"
  },
  "verdict": "pass"
}
```
