### PR TITLE
fix(status): preserve service inspection errors in overview

### DIFF
--- a/src/commands/status-all/format.test.ts
+++ b/src/commands/status-all/format.test.ts
@@ -171,10 +171,46 @@ describe("status-all format", () => {
         label: "systemd",
         installed: true,
         loadedText: "not loaded",
-        runtimeStatus: "failed",
-        runtimePid: 42,
+        runtime: { status: "failed", pid: 42 },
       }),
     ).toBe("systemd not loaded · failed (pid 42)");
+  });
+
+  it.each([
+    {
+      installed: false,
+      loadedText: "unknown",
+      expected: "LaunchAgent unknown (inspection failed: permission denied)",
+    },
+    {
+      installed: null,
+      loadedText: "unknown",
+      expected: "LaunchAgent unknown (inspection failed: permission denied)",
+    },
+    {
+      installed: true,
+      managedByOpenClaw: true,
+      loadedText: "unknown",
+      runtimeShort: "running (pid 42)",
+      expected:
+        "LaunchAgent installed · unknown (inspection failed: permission denied) · running (pid 42)",
+    },
+    {
+      installed: true,
+      managedByOpenClaw: false,
+      loadedText: "running (externally managed)",
+      runtime: { status: "running", pid: 42 },
+      expected:
+        "LaunchAgent running (externally managed) (inspection failed: permission denied) · running (pid 42)",
+    },
+  ])("keeps inspection errors visible: $expected", ({ expected, ...service }) => {
+    expect(
+      formatStatusServiceValue({
+        ...service,
+        label: "LaunchAgent",
+        loadState: { status: "unknown", detail: "permission denied" },
+      }),
+    ).toBe(expected);
   });
 
   it("builds gateway json payloads consistently", () => {

--- a/src/commands/status-all/format.ts
+++ b/src/commands/status-all/format.ts
@@ -4,6 +4,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveGatewayPort } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.js";
+import type { GatewayServiceLoadState } from "../../daemon/service-types.js";
 import { projectGatewayUrlForDiagnostics } from "../../gateway/connection-details.js";
 import { resolveControlUiLinks } from "../../gateway/control-ui-links.js";
 import { formatDurationPrecise } from "../../infra/format-time/format-duration.ts";
@@ -12,6 +13,7 @@ import {
   resolveUpdateChannelDisplay,
 } from "../../infra/update-channels.js";
 import { formatGitInstallLabel, type UpdateCheckResult } from "../../infra/update-check.js";
+import { redactSensitiveText } from "../../logging/redact.js";
 import { VERSION } from "../../version.js";
 import { formatUpdateOneLiner, resolveUpdateAvailability } from "../status.update.js";
 
@@ -56,12 +58,14 @@ type StatusGatewaySelf =
 type StatusManagedService = {
   label: string;
   installed: boolean | null;
+  loadState?: GatewayServiceLoadState;
   managedByOpenClaw?: boolean;
   loadedText: string;
   runtimeShort?: string | null;
   runtime?: {
     status?: string | null;
     pid?: number | null;
+    detail?: string | null;
   } | null;
 };
 
@@ -153,26 +157,32 @@ export function formatStatusTailscaleValue(params: {
 }
 
 /** Formats launchd/systemd service state into one row-friendly string. */
-export function formatStatusServiceValue(params: {
-  label: string;
-  installed: boolean;
-  managedByOpenClaw?: boolean;
-  loadedText: string;
-  runtimeShort?: string | null;
-  runtimeStatus?: string | null;
-  runtimePid?: number | null;
-}): string {
-  if (!params.installed) {
+export function formatStatusServiceValue(params: StatusManagedService): string {
+  const inspectionDetail =
+    params.loadState?.status === "unknown"
+      ? params.loadState.detail
+      : params.runtime?.status === "unknown"
+        ? params.runtime.detail
+        : undefined;
+  const inspectionFailed = params.loadState?.status === "unknown" || Boolean(inspectionDetail);
+  // A missing definition does not make a failed native inspection evidence of absence.
+  if (params.installed === false && !inspectionFailed) {
     return `${params.label} not installed`;
   }
   const installedPrefix = params.managedByOpenClaw ? "installed · " : "";
+  const loadedText = inspectionDetail
+    ? `${params.loadedText} (inspection failed: ${redactSensitiveText(inspectionDetail, { mode: "tools" })})`
+    : params.loadedText;
   const runtimeSuffix = params.runtimeShort
     ? ` · ${params.runtimeShort}`
     : [
-        params.runtimeStatus ? ` · ${params.runtimeStatus}` : "",
-        params.runtimePid ? ` (pid ${params.runtimePid})` : "",
+        params.runtime?.status ? ` · ${params.runtime.status}` : "",
+        params.runtime?.pid ? ` (pid ${params.runtime.pid})` : "",
       ].join("");
-  return `${params.label} ${installedPrefix}${params.loadedText}${runtimeSuffix}`;
+  const runtimeText = inspectionFailed
+    ? redactSensitiveText(runtimeSuffix, { mode: "tools" })
+    : runtimeSuffix;
+  return `${params.label} ${installedPrefix}${loadedText}${runtimeText}`;
 }
 
 /** Returns the dashboard URL when the Control UI is enabled for the current gateway binding. */
@@ -457,24 +467,8 @@ export function buildStatusGatewaySurfaceValues(params: {
       params.advertisedControlUiLinks?.httpUrl ?? resolveStatusDashboardUrl({ cfg: params.cfg }),
     gatewayValue,
     gatewaySelfValue,
-    gatewayServiceValue: formatStatusServiceValue({
-      label: params.gatewayService.label,
-      installed: params.gatewayService.installed !== false,
-      managedByOpenClaw: params.gatewayService.managedByOpenClaw,
-      loadedText: params.gatewayService.loadedText,
-      runtimeShort: params.gatewayService.runtimeShort,
-      runtimeStatus: params.gatewayService.runtime?.status,
-      runtimePid: params.gatewayService.runtime?.pid,
-    }),
-    nodeServiceValue: formatStatusServiceValue({
-      label: params.nodeService.label,
-      installed: params.nodeService.installed !== false,
-      managedByOpenClaw: params.nodeService.managedByOpenClaw,
-      loadedText: params.nodeService.loadedText,
-      runtimeShort: params.nodeService.runtimeShort,
-      runtimeStatus: params.nodeService.runtime?.status,
-      runtimePid: params.nodeService.runtime?.pid,
-    }),
+    gatewayServiceValue: formatStatusServiceValue(params.gatewayService),
+    nodeServiceValue: formatStatusServiceValue(params.nodeService),
   };
 }
 

--- a/src/commands/status-overview-rows.test.ts
+++ b/src/commands/status-overview-rows.test.ts
@@ -15,6 +15,42 @@ function findRowValue(rows: Array<{ Item: string; Value: string }>, item: string
 }
 
 describe("status-overview-rows", () => {
+  it.each(["default", "all"])("preserves service inspection failures in %s output", (mode) => {
+    const params = createStatusCommandOverviewRowsParams();
+    const service = {
+      label: "LaunchAgent",
+      installed: false,
+      loadedText: "unknown",
+      loadState: { status: "unknown" as const, detail: "permission denied token=fixture" },
+    };
+    const surface = {
+      ...params.surface,
+      gatewayService: service,
+      nodeService: {
+        ...service,
+        loadedText: "not loaded",
+        loadState: { status: "not-loaded" as const },
+        runtime: { status: "unknown", detail: "system domain permission denied token=fixture" },
+      },
+    };
+    const rows =
+      mode === "default"
+        ? buildStatusCommandOverviewRows({ ...params, surface })
+        : buildStatusAllOverviewRows({
+            ...params,
+            surface,
+            configPath: "/tmp/openclaw.json",
+            secretDiagnosticsCount: 0,
+          });
+
+    expect(findRowValue(rows, "Gateway service")).toBe(
+      "LaunchAgent unknown (inspection failed: permission denied token=***)",
+    );
+    expect(findRowValue(rows, "Node service")).toBe(
+      "LaunchAgent not loaded (inspection failed: system domain permission denied token=***) · unknown",
+    );
+  });
+
   it("builds command overview rows from the shared surface", () => {
     const rows = buildStatusCommandOverviewRows(createStatusCommandOverviewRowsParams());
 

--- a/src/commands/status.service-summary.test.ts
+++ b/src/commands/status.service-summary.test.ts
@@ -8,6 +8,7 @@ import { resolveGatewayService, type GatewayService } from "../daemon/service.js
 import { createMockGatewayService } from "../daemon/service.test-helpers.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
+import { formatStatusServiceValue } from "./status-all/format.js";
 import { readServiceStatusSummary } from "./status.service-summary.js";
 
 function createService(overrides: Partial<GatewayService>): GatewayService {
@@ -58,14 +59,62 @@ describe("readServiceStatusSummary", () => {
     expect(summary.loadedText).toBe("running (externally managed)");
   });
 
-  it("keeps missing services as not installed when nothing is running", async () => {
-    const summary = await readServiceStatusSummary(createService({}), "Daemon");
+  it.each([{ status: "stopped" }, { status: "unknown", missingUnit: true }])(
+    "keeps missing services as not installed with runtime $status",
+    async (runtime) => {
+      const summary = await readServiceStatusSummary(
+        createService({ readRuntime: vi.fn(async () => runtime) }),
+        "Daemon",
+      );
 
-    expect(summary.installed).toBe(false);
-    expect(summary.managedByOpenClaw).toBe(false);
-    expect(summary.externallyManaged).toBe(false);
-    expect(summary.loadedText).toBe("disabled");
-  });
+      expect(summary.installed).toBe(false);
+      expect(summary.managedByOpenClaw).toBe(false);
+      expect(summary.externallyManaged).toBe(false);
+      expect(summary.loadedText).toBe("disabled");
+      expect(formatStatusServiceValue(summary)).toBe("systemd not installed");
+    },
+  );
+
+  it.each(["load", "runtime", "runtime with missing unit"])(
+    "reports %s inspection failures without a readable definition",
+    async (probe) => {
+      const failInspection = vi.fn(async () => {
+        throw new Error("service manager permission denied");
+      });
+      const summary = await readServiceStatusSummary(
+        createService(
+          probe === "load"
+            ? { isLoaded: failInspection }
+            : {
+                readRuntime:
+                  probe === "runtime"
+                    ? failInspection
+                    : vi.fn(async () => ({
+                        status: "unknown",
+                        detail: "Error: service manager permission denied",
+                        missingUnit: true,
+                      })),
+              },
+        ),
+        "Daemon",
+      );
+
+      expect(summary.installed).toBe(false);
+      expect(summary.loadState).toEqual(
+        probe === "load"
+          ? {
+              status: "unknown",
+              detail: "Error: service manager permission denied",
+            }
+          : { status: "not-loaded" },
+      );
+      expect(formatStatusServiceValue(summary)).toBe(
+        probe === "load"
+          ? "systemd unknown (inspection failed: Error: service manager permission denied) · stopped"
+          : "systemd disabled (inspection failed: Error: service manager permission denied) · unknown",
+      );
+    },
+  );
 
   it("preserves running service state when optional layout diagnostics fail", async () => {
     const layoutSpy = vi


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw status` or `openclaw status --all` would see a Gateway or Node service reported as “not installed” when native service inspection failed and no service definition could be read. This also affected independent runtime inspection failures, such as an unverifiable macOS system-domain owner.

Related: #125734, which introduced explicit unknown service inspection state.

## Why This Change Was Made

The service reader already records unknown load state and runtime diagnostics. The shared human formatter discarded those facts by returning early on `installed: false`, and its Gateway/Node field projections omitted the load-state object.

The formatter now consumes the original service summary and retains both load and runtime inspection errors before declaring absence. Error text uses the existing credential redactor. Duplicate Gateway/Node projections are removed; JSON fields, installation values, service readers, and lifecycle behavior are unchanged.

## User Impact

Operators now see the inspection failure instead of a misleading installation diagnosis. Confirmed missing services, including `missingUnit` without an error detail, still report “not installed.” Managed and externally managed running services retain their runtime information.

Release-note context: Status overview now preserves native service inspection failures for both Gateway and Node services in default and full reports.

## Evidence

The new regressions failed before each owner repair: load-inspection errors and independent runtime errors both produced `LaunchAgent not installed`. After the repair, the same overview path reports, for example:

```text
LaunchAgent unknown (inspection failed: permission denied token=***)
LaunchAgent not loaded (inspection failed: system domain permission denied token=***) · unknown
```

Focused proof: 54 tests passed across six existing suites:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/status.service-summary.test.ts src/commands/status-overview-rows.test.ts src/commands/status-all/format.test.ts src/commands/status.daemon.test.ts src/commands/status-json-payload.test.ts src/commands/status.node-mode.test.ts
```

Coverage includes the real service-summary producer with injected native-adapter failures, both overview variants, Gateway and Node rows, diagnostic redaction, missing-unit distinctions, null installation state, and managed/unmanaged runtime preservation. Formatting, scoped lint, and `git diff --check` pass. Independent source review is clean; configured Codex autoreview completed successfully with no findings at its default P0 threshold.

The local changed gate passed its first 17 guards, then stopped on installed-dependency type errors involving Google `FinishReason`, `markdown-it`, and `pi-tui`. The complete commands-test typecheck output is byte-identical on this patch and its pristine baseline; this establishes baseline parity, not a passing typecheck. Exact-head CI remains the merge gate.

This is deterministic production-module and regression-test proof, not a live native-service test. No operator service or credentials were touched. Native lifecycle behavior is unchanged.

Production LOC: +25/−31 (net −6). Tests: +130/−9. AI-assisted.
