### PR TITLE
fix(ui): resize empty chat side panel

### DIFF
--- a/ui/src/e2e/chat-rail-columns.e2e.test.ts
+++ b/ui/src/e2e/chat-rail-columns.e2e.test.ts
@@ -18,6 +18,7 @@ const suite = createControlUiE2eSuite({
 
 const sessionKey = "agent:main:rail-tabs";
 const proofDir = process.env.OPENCLAW_UI_RAIL_PROOF_DIR?.trim();
+const videoDir = process.env.OPENCLAW_UI_RAIL_VIDEO_DIR?.trim();
 
 const historyMessages = Array.from({ length: 10 }, (_, index) => ({
   id: `rail-tabs-${index}`,
@@ -362,6 +363,9 @@ suite.define(() => {
         {
           colorScheme: themeMode,
           locale: "en-US",
+          ...(videoDir && themeMode === "light"
+            ? { recordVideo: { dir: videoDir, size: { height: 900, width: 1600 } } }
+            : {}),
           serviceWorkers: "block",
           viewport: { height: 900, width: 1600 },
         },
@@ -822,7 +826,44 @@ suite.define(() => {
           await page.locator(".chat-side-panel-toggle").click();
           await sidePanel(page).locator(".side-panel-empty--selector").waitFor();
           expect(await sidePanel(page).locator("wa-tab").count()).toBe(0);
+          const emptyDividerBox = await divider.boundingBox();
+          expect(emptyDividerBox).not.toBeNull();
+          await page.mouse.move(
+            emptyDividerBox!.x + 1,
+            emptyDividerBox!.y + emptyDividerBox!.height / 2,
+          );
+          await page.mouse.down();
+          await page.mouse.move(
+            emptyDividerBox!.x - 70,
+            emptyDividerBox!.y + emptyDividerBox!.height / 2,
+          );
+          await page.mouse.up();
+          await expect
+            .poll(() =>
+              sidePanel(page).evaluate((element) => element.getBoundingClientRect().width),
+            )
+            .toBeGreaterThan(resizedWidth + 50);
+          const emptyResizedWidth = await sidePanel(page).evaluate(
+            (element) => element.getBoundingClientRect().width,
+          );
+          await divider.evaluate((element) => element.blur());
+          await captureRichPanel(page, `rails-tabs-empty-resized-${themeMode}`);
+
+          await page.reload();
+          await page.locator(".chat-group").first().waitFor();
+          await sidePanel(page).locator(".side-panel-empty--selector").waitFor();
+          expect(await divider.boundingBox()).not.toBeNull();
+          await expect
+            .poll(() =>
+              sidePanel(page).evaluate((element) => element.getBoundingClientRect().width),
+            )
+            .toBeCloseTo(emptyResizedWidth, 0);
           await openFromEmpty(page, "Terminal");
+          await expect
+            .poll(() =>
+              sidePanel(page).evaluate((element) => element.getBoundingClientRect().width),
+            )
+            .toBeCloseTo(emptyResizedWidth, 0);
           const terminalLabel = sidePanel(page)
             .locator(sidePanelTabLabelSelector)
             .filter({ hasText: "Terminal" });

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.test.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.test.ts
@@ -204,7 +204,10 @@ describe("chat pane sidebar layout", () => {
         layout: { ...openSlot({ columns: [] }, "chat"), open },
         paneWidth: 1_400,
       });
-      expect(empty).toMatchObject({ columns: [], open: false });
+      expect(empty).toMatchObject({
+        columns: [{ panels: [], activePanelId: "", height: 360, width: 480 }],
+        open: false,
+      });
 
       const withDetail = resolveSidebarLayoutForBoard({
         board: board("hidden", "chat"),

--- a/ui/src/pages/chat/chat-pane.session-discussion.test.ts
+++ b/ui/src/pages/chat/chat-pane.session-discussion.test.ts
@@ -134,7 +134,8 @@ describe("chat pane session discussion", () => {
     expect(action?.ariaLabel).toBe("Hide discussion");
     expect(action?.getAttribute("aria-pressed")).toBe("true");
     action?.click();
-    expect(state.sidebarLayout.columns).toEqual([]);
+    expect(state.sidebarLayout.columns[0]?.panels).toEqual([]);
+    expect(state.sidebarLayout.open).toBe(false);
     expect(updateSidebarLayout).toHaveBeenCalledTimes(2);
 
     container.remove();

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -921,7 +921,7 @@ describe("chat pane keyboard shortcuts", () => {
     expect(press().defaultPrevented).toBe(true);
     expect(state.sidebarLayout.columns[0]?.panels.map((panel) => panel.slot)).toEqual(["terminal"]);
     expect(press().defaultPrevented).toBe(true);
-    expect(state.sidebarLayout.columns).toEqual([]);
+    expect(state.sidebarLayout.columns[0]?.panels).toEqual([]);
     expect(state.sidebarLayout.open).toBe(false);
   });
 });

--- a/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
@@ -275,7 +275,7 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
   }
 
   private renderBody(column?: SidebarColumn) {
-    if (!column) {
+    if (!column || column.panels.length === 0) {
       return html`<div id="chat-side-panel-content" class="side-panel__body">
         ${this.renderEmpty()}
       </div>`;
@@ -359,7 +359,7 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
         style=${styleMap({ width, height })}
         aria-label=${t("chat.sidePanel.label")}
       >
-        ${column
+        ${column?.panels.length
           ? this.renderHeader(column)
           : html`<header class="rail-header side-panel__header side-panel__header--empty">
               <strong class="side-panel__empty-header-title">${t("chat.sidePanel.label")}</strong>

--- a/ui/src/pages/chat/components/chat-sidebar-region.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import "../../../components/resizable-divider.ts";
 import {
   openSlot,
+  setSidebarOpen,
   setSidebarDock,
   setSidebarExpanded,
   type SidebarLayout,
@@ -219,7 +220,7 @@ describe("chat sidebar region", () => {
   });
 
   it("opens into a type selector instead of restoring a previous tab", async () => {
-    const region = await createRegion({ columns: [], open: true, expanded: false });
+    const region = await createRegion(setSidebarOpen({ columns: [], expanded: false }, true));
     const selector = root(region).querySelector(".side-panel-empty--selector");
 
     expect(selector?.querySelector(".side-panel-empty__title")?.textContent).toBe("Open a tab");
@@ -321,8 +322,9 @@ describe("chat sidebar region", () => {
   });
 
   it("offers expand and minimize controls in the no-tabs selector", async () => {
-    const region = await createRegion({ columns: [], open: true });
+    const region = await createRegion(setSidebarOpen({ columns: [] }, true));
     expect(root(region).querySelector<HTMLElement>(".side-panel")?.style.width).toBe("480px");
+    expect(root(region).querySelector("resizable-divider")).not.toBeNull();
     root(region).querySelector<HTMLButtonElement>(".side-panel__expand")?.click();
     root(region).querySelector<HTMLButtonElement>(".side-panel__minimize")?.click();
     expect(region.callbacks?.setExpanded).toHaveBeenCalledWith(true);

--- a/ui/src/pages/chat/sidebar-layout-normalize.ts
+++ b/ui/src/pages/chat/sidebar-layout-normalize.ts
@@ -76,9 +76,6 @@ export function normalizeSidebarLayout(value: unknown): SidebarLayout {
       usedSlots.add(rawPanel.slot);
       columnPanels.push({ id: panelId, slot: rawPanel.slot });
     }
-    if (columnPanels.length === 0) {
-      continue;
-    }
     const requestedActiveId =
       typeof rawColumn.activePanelId === "string" ? rawColumn.activePanelId.trim() : "";
     activePanelId = panelIds.get(requestedActiveId) ?? activePanelId;
@@ -92,20 +89,21 @@ export function normalizeSidebarLayout(value: unknown): SidebarLayout {
         : height;
     panels.push(...columnPanels);
   }
-  const columns = panels.length
-    ? [
-        {
-          id: usedColumnIds.values().next().value ?? "side-panel-column",
-          side: "right" as const,
-          panels,
-          activePanelId: panels.some((panel) => panel.id === activePanelId)
-            ? activePanelId
-            : panels[0]!.id,
-          height,
-          width,
-        },
-      ]
-    : [];
+  const columns =
+    usedColumnIds.size > 0 || value.open === true
+      ? [
+          {
+            id: usedColumnIds.values().next().value ?? "side-panel-column",
+            side: "right" as const,
+            panels,
+            activePanelId: panels.some((panel) => panel.id === activePanelId)
+              ? activePanelId
+              : (panels[0]?.id ?? ""),
+            height,
+            width,
+          },
+        ]
+      : [];
   return {
     columns,
     dock: value.dock === "bottom" ? "bottom" : "right",

--- a/ui/src/pages/chat/sidebar-layout.test.ts
+++ b/ui/src/pages/chat/sidebar-layout.test.ts
@@ -73,7 +73,19 @@ describe("sidebar layout", () => {
 
   it("collapses the panel after its final tab closes", () => {
     const closed = closeSlot(openSlot({ columns: [] }, "detail"), "detail");
-    expect(closed).toEqual({ columns: [], open: false });
+    expect(closed).toEqual({
+      columns: [
+        {
+          id: "side-panel-column",
+          side: "right",
+          panels: [],
+          activePanelId: "",
+          height: 360,
+          width: 480,
+        },
+      ],
+      open: false,
+    });
   });
 
   it("does not reopen a minimized panel when another tab remains", () => {
@@ -160,6 +172,21 @@ describe("sidebar layout", () => {
 
   it("deduplicates slots and repairs untrusted persisted values", () => {
     expect(normalizeSidebarLayout(null)).toEqual({ columns: [], open: false, expanded: false });
+    expect(normalizeSidebarLayout({ columns: [], open: true })).toEqual({
+      columns: [
+        {
+          id: "side-panel-column",
+          side: "right",
+          panels: [],
+          activePanelId: "",
+          height: 360,
+          width: 480,
+        },
+      ],
+      dock: "right",
+      open: true,
+      expanded: false,
+    });
     expect(
       normalizeSidebarLayout({
         columns: [

--- a/ui/src/pages/chat/sidebar-layout.ts
+++ b/ui/src/pages/chat/sidebar-layout.ts
@@ -1,4 +1,5 @@
 import type {
+  SidebarColumn,
   SidebarDock,
   SidebarLayout,
   SidebarPanel,
@@ -26,6 +27,17 @@ const SIDEBAR_DIVIDER_WIDTH_PX = 4;
 
 function cloneLayout(layout: SidebarLayout): SidebarLayout {
   return structuredClone(layout);
+}
+
+function createSidebarColumn(): SidebarColumn {
+  return {
+    id: "side-panel-column",
+    side: "right",
+    panels: [],
+    activePanelId: "",
+    height: SIDEBAR_DEFAULT_HEIGHT_PX,
+    width: SIDEBAR_DEFAULT_WIDTH_PX,
+  };
 }
 
 function clampWidth(width: number): number {
@@ -63,16 +75,13 @@ function nextPanelId(layout: SidebarLayout, slot: SidebarSlotId): string {
 }
 
 function removePanel(layout: SidebarLayout, panelId: string): SidebarPanel | null {
-  for (let columnIndex = 0; columnIndex < layout.columns.length; columnIndex += 1) {
-    const column = layout.columns[columnIndex]!;
+  for (const column of layout.columns) {
     const panelIndex = column.panels.findIndex((panel) => panel.id === panelId);
     if (panelIndex < 0) {
       continue;
     }
     const panel = column.panels.splice(panelIndex, 1)[0]!;
-    if (column.panels.length === 0) {
-      layout.columns.splice(columnIndex, 1);
-    } else if (column.activePanelId === panelId) {
+    if (column.activePanelId === panelId) {
       column.activePanelId =
         column.panels[Math.min(panelIndex, column.panels.length - 1)]?.id ?? "";
     }
@@ -95,22 +104,9 @@ export function openSlot(layout: SidebarLayout, slot: SidebarSlotId): SidebarLay
     return next;
   }
   const panel: SidebarPanel = { id: nextPanelId(next, slot), slot };
-  const column = next.columns[0];
-  if (column) {
-    column.panels.push(panel);
-    column.activePanelId = panel.id;
-  } else {
-    next.columns = [
-      {
-        id: "side-panel-column",
-        side: "right",
-        panels: [panel],
-        activePanelId: panel.id,
-        height: SIDEBAR_DEFAULT_HEIGHT_PX,
-        width: SIDEBAR_DEFAULT_WIDTH_PX,
-      },
-    ];
-  }
+  const column = (next.columns[0] ??= createSidebarColumn());
+  column.panels.push(panel);
+  column.activePanelId = panel.id;
   next.open = true;
   return next;
 }
@@ -122,7 +118,7 @@ export function closeSlot(layout: SidebarLayout, slot: SidebarSlotId): SidebarLa
     .find((entry) => entry.slot === slot);
   if (panel) {
     removePanel(next, panel.id);
-    if (next.columns.length === 0) {
+    if (next.columns.every((column) => column.panels.length === 0)) {
       next.open = false;
     }
   }
@@ -162,7 +158,12 @@ export function reorderPanel(
 }
 
 export function setSidebarOpen(layout: SidebarLayout, open: boolean): SidebarLayout {
-  return { ...cloneLayout(layout), open };
+  const next = cloneLayout(layout);
+  if (open) {
+    next.columns[0] ??= createSidebarColumn();
+  }
+  next.open = open;
+  return next;
 }
 
 export function setSidebarExpanded(layout: SidebarLayout, expanded: boolean): SidebarLayout {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the chat side panel with no tabs would see the “Open a tab” selector without a resize handle. Resizing and persisted width worked only after a tab had been opened.

## Why This Change Was Made

The tabbed side panel introduced in #123874 rendered the empty selector without a `SidebarColumn`, while the existing splitter and persisted geometry are owned by that column. The layout now retains one empty geometry column when the last tab closes or the empty panel opens, so both empty and populated states use the same divider, resize callback, clamps, docking, and persistence path.

No issue was opened because this bounded defect and its provenance were already discussed with the maintainer.

Production LOC: +41/-42 (net -1) | Tests: +77/-4

## User Impact

Users can resize the chat side panel before opening a tab. The chosen width persists across reloads and carries into newly opened tabs, matching the behavior of a populated side panel.

## Evidence

- Pre-fix regression: the focused Chromium flow timed out waiting for `.sidebar-column__divider` after reopening the empty selector.
- Post-fix Chromium boundary flow passes in light and dark themes. It drags the divider while populated, closes every tab, drags the same divider while empty, reloads, and verifies the width persists when a tab opens.
- `node scripts/run-vitest.mjs ui/src/pages/chat/sidebar-layout.test.ts ui/src/pages/chat/sidebar-layout-persistence.test.ts ui/src/pages/chat/components/chat-sidebar-region.test.ts ui/src/pages/chat/chat-pane-sidebar-layout.test.ts ui/src/pages/chat/components/chat-task-detail-state.test.ts ui/src/components/resizable-divider.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-rail-columns.e2e.test.ts -t "navigates and persists one tabbed side panel"`
- `pnpm check:changed`
- Fresh autoreview on `5de14738d4fe2da5108b605f9aa22186e44aa4b5`: no accepted/actionable findings.

### Before

Light and dark: the empty selector has no splitter and remains at its fallback width.

| Light | Dark |
| --- | --- |
| ![Empty side panel before the fix in light mode](https://github.com/user-attachments/assets/10fdf365-804b-49a2-9957-5b72afa7bc84) | ![Empty side panel before the fix in dark mode](https://github.com/user-attachments/assets/25fb9564-ac91-46d9-870d-accd7c75e2f0) |

### After

Light and dark: the same splitter used by populated tabs resizes the empty selector. The video shows both populated and empty drag flows.

| Light | Dark |
| --- | --- |
| ![Resizable empty side panel in light mode](https://github.com/user-attachments/assets/d49512c5-2210-40fd-8a67-85df72cf2fe5) | ![Resizable empty side panel in dark mode](https://github.com/user-attachments/assets/0fd84da2-f645-4ea7-bebe-fb01d4d2d34c) |

https://github.com/user-attachments/assets/004d3d07-8c1e-481b-bacf-d67772774aaa

AI-assisted: implementation, regression coverage, and evidence capture were completed with an AI coding agent; the resulting code and behavior were reviewed and verified.
