### PR TITLE
refactor(slack): consolidate deferred ingress settlement

### DIFF
--- a/extensions/slack/src/monitor/ingress.ts
+++ b/extensions/slack/src/monitor/ingress.ts
@@ -11,6 +11,7 @@ import {
   extractErrorCode,
   formatErrorMessage,
 } from "openclaw/plugin-sdk/error-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { PluginJsonValue } from "openclaw/plugin-sdk/plugin-entry";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getSlackRuntime } from "../runtime.js";
@@ -281,16 +282,15 @@ export function createSlackDurableIngress(
       let releaseSession: (() => void) | undefined;
       let releaseChannel: (() => void) | undefined;
       let routedSession: string | undefined;
-      let migrationAwaitedChannelTurns = false;
-      let downstreamDeferred = false;
-      let settled = false;
+      let adoptOnCompletion = false;
       const settleSession = () => {
-        settled = true;
+        adoptOnCompletion = false;
         releaseSession?.();
       };
       const settleTurn = () => {
         settleSession();
         releaseChannel?.();
+        lifecycle.abortSignal.removeEventListener("abort", settleTurn);
       };
       const routedLifecycle: SlackIngressTurnLifecycle = {
         ...lifecycle,
@@ -303,45 +303,31 @@ export function createSlackDurableIngress(
           }
           lifecycle.abortSignal.throwIfAborted();
           routedSession = sessionKey;
+          adoptOnCompletion = true;
           const previousTurn = activeSessionTurns.get(sessionKey);
-          let resolveCurrentTurn: () => void = () => {};
-          const releasedCurrentTurn = new Promise<void>((resolve) => {
-            resolveCurrentTurn = resolve;
-          });
+          const releasedCurrentTurn = createDeferred<void>();
           const currentTurn = previousTurn
-            ? previousTurn.then(() => releasedCurrentTurn)
-            : releasedCurrentTurn;
+            ? previousTurn.then(() => releasedCurrentTurn.promise)
+            : releasedCurrentTurn.promise;
           activeSessionTurns.set(sessionKey, currentTurn);
-          let resolveChannelTurn: () => void = () => {};
-          const channelTurn = new Promise<void>((resolve) => {
-            resolveChannelTurn = resolve;
-          });
+          const channelTurn = createDeferred<void>();
           const channelTurns = activeChannelTurns.get(laneKey) ?? new Set<Promise<void>>();
-          channelTurns.add(channelTurn);
+          channelTurns.add(channelTurn.promise);
           activeChannelTurns.set(laneKey, channelTurns);
-          const releaseCurrentSession = () => {
-            lifecycle.abortSignal.removeEventListener("abort", releaseCurrentSession);
-            resolveCurrentTurn();
-          };
-          const releaseCurrentChannel = () => {
-            lifecycle.abortSignal.removeEventListener("abort", releaseCurrentChannel);
-            resolveChannelTurn();
-          };
           void currentTurn.then(() => {
             if (activeSessionTurns.get(sessionKey) === currentTurn) {
               activeSessionTurns.delete(sessionKey);
             }
           });
-          void channelTurn.then(() => {
-            channelTurns.delete(channelTurn);
+          void channelTurn.promise.then(() => {
+            channelTurns.delete(channelTurn.promise);
             if (channelTurns.size === 0 && activeChannelTurns.get(laneKey) === channelTurns) {
               activeChannelTurns.delete(laneKey);
             }
           });
-          releaseSession = releaseCurrentSession;
-          releaseChannel = releaseCurrentChannel;
-          lifecycle.abortSignal.addEventListener("abort", releaseSession, { once: true });
-          lifecycle.abortSignal.addEventListener("abort", releaseChannel, { once: true });
+          releaseSession = () => releasedCurrentTurn.resolve();
+          releaseChannel = () => channelTurn.resolve();
+          lifecycle.abortSignal.addEventListener("abort", settleTurn, { once: true });
           // Preserve shipped channel lanes until the prepared route proves its
           // session; channel-ID migration therefore still fences all traffic.
           lifecycle.onDeferred();
@@ -362,7 +348,6 @@ export function createSlackDurableIngress(
           }
         },
         onDeferred: () => {
-          downstreamDeferred = true;
           lifecycle.onDeferred();
           // Reply handoff releases session order; migration remains fenced
           // until the durable turn is actually adopted or abandoned.
@@ -384,7 +369,7 @@ export function createSlackDurableIngress(
           if (channelTurns && channelTurns.size > 0) {
             // A migration owns the channel lane while earlier routed sessions
             // settle; later channel traffic cannot overtake the config change.
-            migrationAwaitedChannelTurns = true;
+            adoptOnCompletion = true;
             lifecycle.onAdoptionFinalizing();
             await Promise.all(channelTurns);
             lifecycle.abortSignal.throwIfAborted();
@@ -411,11 +396,7 @@ export function createSlackDurableIngress(
             },
           });
         }
-        if (
-          (routedSession !== undefined || migrationAwaitedChannelTurns) &&
-          !settled &&
-          !downstreamDeferred
-        ) {
+        if (adoptOnCompletion) {
           await routedLifecycle.onAdopted();
         }
       } catch (error) {

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -4,6 +4,7 @@ import {
   shouldDebounceTextInbound,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   getRuntimeConfigSnapshot,
@@ -51,11 +52,7 @@ export type SlackMessageHandler = (
   },
 ) => Promise<void>;
 
-type SlackDispatchCompletion = {
-  promise: Promise<void>;
-  resolve: () => void;
-  reject: (error: unknown) => void;
-};
+type SlackDispatchCompletion = ReturnType<typeof createDeferred<void>>;
 
 type IngressSlackMessageOptions = Parameters<SlackMessageHandler>[1] & {
   retryAttempt?: number;
@@ -64,16 +61,6 @@ type IngressSlackMessageOptions = Parameters<SlackMessageHandler>[1] & {
 type QueuedSlackMessageOptions = IngressSlackMessageOptions & {
   dispatchCompletion?: Omit<SlackDispatchCompletion, "promise">;
 };
-
-function createSlackDispatchCompletion(): SlackDispatchCompletion {
-  let resolve!: () => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<void>((nextResolve, nextReject) => {
-    resolve = nextResolve;
-    reject = nextReject;
-  });
-  return { promise, resolve, reject };
-}
 
 const RETRYABLE_FLUSH_MAX_ATTEMPTS = 3;
 const RETRYABLE_FLUSH_RETRY_DELAY_MS = 1_000;
@@ -468,7 +455,7 @@ export function createSlackMessageHandler(params: {
       pendingKeys.add(debounceKey);
       pendingTopLevelDebounceKeys.set(conversationKey, pendingKeys);
     }
-    const dispatchCompletion = opts.awaitDispatch ? createSlackDispatchCompletion() : undefined;
+    const dispatchCompletion = opts.awaitDispatch ? createDeferred<void>() : undefined;
     await debouncer.enqueue({
       message: resolvedMessage,
       opts: {


### PR DESCRIPTION
## What Problem This Solves

Slack's deferred ingress used three handwritten promise factories and overlapping completion flags to express the same lifecycle. That duplication made it harder to verify the crucial distinction between session ordering and channel-ID migration fencing after #114552.

## Why This Change Was Made

Reuse the existing Plugin SDK deferred primitive, already used by Slack slash dispatch. One adoption-pending fact replaces overlapping flags; one terminal abort callback releases both latches and removes itself. Keep the latches separate: reply handoff releases session ordering, while adoption, abandonment, or abort releases the channel migration fence. Do not merge those ownership boundaries.

Production LOC: +20/-52 (net -32). Tests unchanged. No public SDK, config, database, protocol, dependency, or external Slack API change. This is a maintainer-requested behavior-preserving refactor, not a newly discovered Slack service bug.

## User Impact

Independent Slack sessions still run concurrently; same-session turns retain FIFO ordering. Deferred replies do not let channel-ID migration overtake unfinished work. Relay dispatch completion and failure propagation remain unchanged.

## Evidence

- Exact candidate: `7195da4af690604c0eecd2a36dcb9f475dd3234d`.
- 57 existing tests in seven files pass on dependencies matching the candidate's package/lockfiles. The ingress suite uses actual Bolt and on-disk SQLite queues for active/deferred migration, session concurrency, FIFO, watchdogs, restart recovery, and dedupe.
- Full selected changed gate passed, including types, typed lint, all guards, zero dead exports, and five doctor contract tests.
- Fresh structured Codex P1 review and a separate independent source review passed on this exact commit. Direct dependency review confirms Bolt awaits listener completion through `Promise.allSettled`; the shared deferred primitive delegates to native `Promise.withResolvers`.
- Proof is deterministic real-library/filesystem and queue-boundary testing, not a fresh authenticated Slack Desktop or service round trip. No Slack wire behavior changed.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/slack/src/monitor/ingress.test.ts extensions/slack/src/monitor/message-handler.test.ts extensions/slack/src/monitor/message-handler.debounce-key.test.ts extensions/slack/src/monitor/provider.ingress-start-cleanup.test.ts src/channels/message/ingress-drain-lifecycle.test.ts src/channels/message/ingress-drain.watchdog.test.ts src/channels/message/ingress-drain.cancellation.test.ts
node scripts/check-changed.mjs -- extensions/slack/src/monitor/ingress.ts extensions/slack/src/monitor/message-handler.ts
```

Maintainer-requested, AI-assisted. Required exact-head hosted CI and native landing checks remain mandatory.
