### PR TITLE
fix(channels): preserve long presentation text

### DIFF
--- a/extensions/discord/src/actions/handle-action.presentation.test.ts
+++ b/extensions/discord/src/actions/handle-action.presentation.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  defaultActionOptions,
+  discordConfig,
+  expectDiscordActionCall,
+  handleDiscordActionMock,
+  handleDiscordMessageAction,
+} from "./handle-action.test-support.js";
+
+describe("handleDiscordMessageAction presentations", () => {
+  beforeEach(() => {
+    handleDiscordActionMock.mockClear();
+  });
+
+  it("downgrades chart-only presentations to Discord component text", async () => {
+    const cfg = discordConfig();
+
+    await handleDiscordMessageAction({
+      action: "send",
+      params: {
+        to: "channel:123",
+        presentation: {
+          blocks: [
+            {
+              type: "chart",
+              chartType: "bar",
+              title: "Revenue",
+              categories: ["Q1", "Q2"],
+              series: [{ name: "USD", values: [12, 18] }],
+            },
+          ],
+        },
+      },
+      cfg,
+    });
+
+    expectDiscordActionCall({
+      payload: {
+        action: "sendMessage",
+        accountId: undefined,
+        to: "channel:123",
+        content: "",
+        mediaUrl: undefined,
+        filename: undefined,
+        replyTo: undefined,
+        components: {
+          blocks: [
+            {
+              type: "text",
+              text: "-# Revenue (bar chart)\n- USD: Q1: 12; Q2: 18",
+            },
+          ],
+        },
+        embeds: undefined,
+        asVoice: false,
+        silent: false,
+        __sessionKey: undefined,
+        __agentId: undefined,
+      },
+      cfg,
+      options: defaultActionOptions(),
+    });
+  });
+
+  it("downgrades oversized table presentations to complete text", async () => {
+    const cfg = discordConfig();
+    const authoredText = `${"x".repeat(1997)}AUTHORED_TAIL`;
+
+    await handleDiscordMessageAction({
+      action: "send",
+      params: {
+        to: "channel:123",
+        presentation: {
+          title: authoredText,
+          blocks: [
+            { type: "text", text: authoredText },
+            { type: "context", text: authoredText },
+            {
+              type: "buttons",
+              buttons: [{ label: `${"x".repeat(80)}LABEL_TAIL`, value: "choice" }],
+            },
+            {
+              type: "table",
+              caption: "Large pipeline",
+              headers: ["Account", "Stage"],
+              rows: Array.from({ length: 900 }, (_entry, index) => [
+                `account-${String(index)}-${"x".repeat(80)}`,
+                "Review",
+              ]),
+            },
+          ],
+        },
+      },
+      cfg,
+    });
+
+    const [call] = handleDiscordActionMock.mock.calls;
+    const payload = call?.[0] as Record<string, unknown> | undefined;
+    expect(payload?.components).toBeUndefined();
+    expect(payload?.content).toEqual(expect.stringContaining("account-0-"));
+    expect(payload?.content).toEqual(expect.stringContaining("account-899-"));
+    expect(String(payload?.content).split("AUTHORED_TAIL")).toHaveLength(4);
+    expect(payload?.content).toEqual(expect.stringContaining("LABEL_TAIL"));
+  });
+});

--- a/extensions/discord/src/actions/handle-action.test-support.ts
+++ b/extensions/discord/src/actions/handle-action.test-support.ts
@@ -1,0 +1,42 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { expect, vi } from "vitest";
+
+const runtimeModule = await import("./runtime.js");
+export const handleDiscordActionMock = vi
+  .spyOn(runtimeModule, "handleDiscordAction")
+  .mockResolvedValue({ content: [], details: { ok: true } });
+export const { handleDiscordMessageAction } = await import("./handle-action.js");
+
+export function discordConfig(actions?: Record<string, boolean>): OpenClawConfig {
+  return {
+    channels: { discord: { token: "tok", ...(actions ? { actions } : {}) } },
+  } as OpenClawConfig;
+}
+
+export function defaultActionOptions() {
+  return {
+    mediaAccess: undefined,
+    mediaLocalRoots: undefined,
+    mediaReadFile: undefined,
+  };
+}
+
+export function expectDiscordActionCall(params: {
+  payload: unknown;
+  cfg: OpenClawConfig;
+  options?: unknown;
+}) {
+  expect(handleDiscordActionMock).toHaveBeenCalledTimes(1);
+  const [call] = handleDiscordActionMock.mock.calls;
+  if (!call) {
+    throw new Error("expected Discord action call");
+  }
+  const [payload, cfg, options] = call;
+  expect(payload).toEqual(params.payload);
+  expect(cfg).toBe(params.cfg);
+  if ("options" in params) {
+    expect(options).toEqual(params.options);
+  } else {
+    expect(options).toBeUndefined();
+  }
+}

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -937,13 +937,21 @@ describe("handleDiscordMessageAction", () => {
 
   it("downgrades oversized table presentations to complete text", async () => {
     const cfg = discordConfig();
+    const authoredText = `${"x".repeat(1997)}AUTHORED_TAIL`;
 
     await handleDiscordMessageAction({
       action: "send",
       params: {
         to: "channel:123",
         presentation: {
+          title: authoredText,
           blocks: [
+            { type: "text", text: authoredText },
+            { type: "context", text: authoredText },
+            {
+              type: "buttons",
+              buttons: [{ label: `${"x".repeat(80)}LABEL_TAIL`, value: "choice" }],
+            },
             {
               type: "table",
               caption: "Large pipeline",
@@ -964,6 +972,8 @@ describe("handleDiscordMessageAction", () => {
     expect(payload?.components).toBeUndefined();
     expect(payload?.content).toEqual(expect.stringContaining("account-0-"));
     expect(payload?.content).toEqual(expect.stringContaining("account-899-"));
+    expect(String(payload?.content).split("AUTHORED_TAIL")).toHaveLength(4);
+    expect(payload?.content).toEqual(expect.stringContaining("LABEL_TAIL"));
   });
 
   it("does not use another provider's current target for Discord sends", async () => {

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -1,53 +1,19 @@
 // Discord tests cover handle action plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const runtimeModule = await import("./runtime.js");
-const handleDiscordActionMock = vi
-  .spyOn(runtimeModule, "handleDiscordAction")
-  .mockResolvedValue({ content: [], details: { ok: true } });
-const { handleDiscordMessageAction } = await import("./handle-action.js");
+import {
+  defaultActionOptions,
+  discordConfig,
+  expectDiscordActionCall,
+  handleDiscordActionMock,
+  handleDiscordMessageAction,
+} from "./handle-action.test-support.js";
 const {
   beginDiscordActiveTurnThreadRoute,
   notifyDiscordActiveTurnThreadCreated,
   notifyDiscordActiveTurnThreadReplyDelivered,
 } = await import("../active-turn-thread-route.js");
 const { discordInboundEventDelivery } = await import("../inbound-event-delivery.js");
-
-function discordConfig(actions?: Record<string, boolean>): OpenClawConfig {
-  return {
-    channels: { discord: { token: "tok", ...(actions ? { actions } : {}) } },
-  } as OpenClawConfig;
-}
-
-function defaultActionOptions() {
-  return {
-    mediaAccess: undefined,
-    mediaLocalRoots: undefined,
-    mediaReadFile: undefined,
-  };
-}
-
-function expectDiscordActionCall(params: {
-  payload: unknown;
-  cfg: OpenClawConfig;
-  options?: unknown;
-}) {
-  expect(handleDiscordActionMock).toHaveBeenCalledTimes(1);
-  const [call] = handleDiscordActionMock.mock.calls;
-  if (!call) {
-    throw new Error("expected Discord action call");
-  }
-  const [payload, cfg, options] = call;
-  expect(payload).toEqual(params.payload);
-  expect(cfg).toBe(params.cfg);
-  if ("options" in params) {
-    expect(options).toEqual(params.options);
-  } else {
-    expect(options).toBeUndefined();
-  }
-}
 
 describe("handleDiscordMessageAction", () => {
   beforeEach(() => {
@@ -883,97 +849,6 @@ describe("handleDiscordMessageAction", () => {
       cfg,
       defaultActionOptions(),
     );
-  });
-
-  it("downgrades chart-only presentations to Discord component text", async () => {
-    const cfg = discordConfig();
-
-    await handleDiscordMessageAction({
-      action: "send",
-      params: {
-        to: "channel:123",
-        presentation: {
-          blocks: [
-            {
-              type: "chart",
-              chartType: "bar",
-              title: "Revenue",
-              categories: ["Q1", "Q2"],
-              series: [{ name: "USD", values: [12, 18] }],
-            },
-          ],
-        },
-      },
-      cfg,
-    });
-
-    expectDiscordActionCall({
-      payload: {
-        action: "sendMessage",
-        accountId: undefined,
-        to: "channel:123",
-        content: "",
-        mediaUrl: undefined,
-        filename: undefined,
-        replyTo: undefined,
-        components: {
-          blocks: [
-            {
-              type: "text",
-              text: "-# Revenue (bar chart)\n- USD: Q1: 12; Q2: 18",
-            },
-          ],
-        },
-        embeds: undefined,
-        asVoice: false,
-        silent: false,
-        __sessionKey: undefined,
-        __agentId: undefined,
-      },
-      cfg,
-      options: defaultActionOptions(),
-    });
-  });
-
-  it("downgrades oversized table presentations to complete text", async () => {
-    const cfg = discordConfig();
-    const authoredText = `${"x".repeat(1997)}AUTHORED_TAIL`;
-
-    await handleDiscordMessageAction({
-      action: "send",
-      params: {
-        to: "channel:123",
-        presentation: {
-          title: authoredText,
-          blocks: [
-            { type: "text", text: authoredText },
-            { type: "context", text: authoredText },
-            {
-              type: "buttons",
-              buttons: [{ label: `${"x".repeat(80)}LABEL_TAIL`, value: "choice" }],
-            },
-            {
-              type: "table",
-              caption: "Large pipeline",
-              headers: ["Account", "Stage"],
-              rows: Array.from({ length: 900 }, (_entry, index) => [
-                `account-${String(index)}-${"x".repeat(80)}`,
-                "Review",
-              ]),
-            },
-          ],
-        },
-      },
-      cfg,
-    });
-
-    const [call] = handleDiscordActionMock.mock.calls;
-    const payload = call?.[0] as Record<string, unknown> | undefined;
-    expect(payload?.components).toBeUndefined();
-    expect(payload?.content).toEqual(expect.stringContaining("account-0-"));
-    expect(payload?.content).toEqual(expect.stringContaining("account-899-"));
-    expect(String(payload?.content).split("AUTHORED_TAIL")).toHaveLength(4);
-    expect(payload?.content).toEqual(expect.stringContaining("LABEL_TAIL"));
   });
 
   it("does not use another provider's current target for Discord sends", async () => {

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -230,10 +230,10 @@ export async function handleDiscordMessageAction(
       allowEmpty: true,
     });
     const deliveryContent =
-      presentationFellBack && adaptedPresentation
+      presentationFellBack && presentation
         ? renderMessagePresentationFallbackText({
             text: content,
-            presentation: adaptedPresentation,
+            presentation,
           })
         : content;
     const filename = readStringParam(params, "filename");

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -4,6 +4,8 @@ import {
   renderMessagePresentationFallbackText,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDiscordComponentMessage } from "./components.builders.js";
+import type { DiscordComponentMessageSpec } from "./components.types.js";
 import {
   createDiscordOutboundHoisted,
   expectDiscordThreadBotSend,
@@ -1050,6 +1052,42 @@ describe("discordOutbound", () => {
       target: { kind: "channel", id: "ch-1" },
     });
   });
+
+  it.each(["title", "text", "context"] as const)(
+    "delivers complete authored %s through native presentation components",
+    async (kind) => {
+      const text = `${"x".repeat(1996)} \n  TAIL_NOT_DELIVERED`;
+      const presentation = adaptMessagePresentationForChannel({
+        capabilities: discordOutbound.presentationCapabilities,
+        presentation:
+          kind === "title" ? { title: text, blocks: [] } : { blocks: [{ type: kind, text }] },
+      });
+      const payload = await discordOutbound.renderPresentation?.({
+        payload: { presentation },
+        presentation,
+        ctx: { cfg: {}, to: "channel:123456", text: "", payload: { presentation } },
+      });
+      if (!payload) {
+        throw new Error("expected native Discord presentation");
+      }
+      await discordOutbound.sendPayload?.({ cfg: {}, to: "channel:123456", text: "", payload });
+      const spec = mockObjectArg(
+        hoisted.sendDiscordComponentMessageMock,
+        "component send",
+        0,
+        1,
+      ) as DiscordComponentMessageSpec;
+      const components = buildDiscordComponentMessage({ spec }).components;
+      const wire = JSON.stringify(components.map((component) => component.serialize()));
+      expect(wire).toContain("TAIL_NOT_DELIVERED");
+      expect(
+        (spec.blocks ?? [])
+          .flatMap((block) => (block.type === "text" ? [block.text.replace(/^-# /u, "")] : []))
+          .join(""),
+      ).toBe(text);
+      expect(hoisted.sendMessageDiscordMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("preserves disabled presentation buttons through channel adaptation", async () => {
     const adaptedPresentation = adaptMessagePresentationForChannel({

--- a/extensions/discord/src/shared-interactive.ts
+++ b/extensions/discord/src/shared-interactive.ts
@@ -197,7 +197,7 @@ export function buildDiscordPresentationComponents(
   }
   for (const block of presentation.blocks) {
     if (block.type === "text" || block.type === "context") {
-      const text = block.text.trim();
+      const text = block.text;
       if (text) {
         blocks.push({
           type: "text",

--- a/extensions/feishu/src/channel.outbound.test.ts
+++ b/extensions/feishu/src/channel.outbound.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { feishuPlugin } from "../channel-plugin-api.js";
+
+const renderPresentation = vi.hoisted(() => vi.fn());
+const sendPayload = vi.hoisted(() => vi.fn());
+
+vi.mock("./channel.runtime.js", () => ({
+  feishuChannelRuntime: { feishuOutbound: { renderPresentation, sendPayload } },
+}));
+
+afterAll(() => {
+  vi.doUnmock("./channel.runtime.js");
+  vi.resetModules();
+});
+
+describe("Feishu public outbound presentation hooks", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const presentation = { title: "Status", blocks: [{ type: "text" as const, text: "Ready" }] };
+  const payload = { presentation };
+  const ctx = {
+    cfg: {},
+    to: "chat:oc_group",
+    accountId: "work",
+    threadId: "om_parent",
+    text: "",
+    payload,
+  };
+
+  it("renders and sends native payloads through the advertised plugin capability", async () => {
+    const rendered = { channelData: { feishu: { card: { schema: "2.0" } } } };
+    const receipt = { channel: "feishu", messageId: "om_card" };
+    renderPresentation.mockResolvedValueOnce(rendered);
+    sendPayload.mockResolvedValueOnce(receipt);
+
+    expect(feishuPlugin.outbound?.presentationCapabilities?.supported).toBe(true);
+    const renderContext = { ctx, payload, presentation };
+    const result = await feishuPlugin.outbound?.renderPresentation?.(renderContext);
+    expect(renderPresentation).toHaveBeenCalledExactlyOnceWith(renderContext);
+    expect(result).toBe(rendered);
+
+    const sendContext = { ...ctx, payload: rendered };
+    await expect(feishuPlugin.outbound?.sendPayload?.(sendContext)).resolves.toBe(receipt);
+    expect(sendPayload).toHaveBeenCalledExactlyOnceWith(sendContext);
+  });
+
+  it("preserves native renderer and sender failures", async () => {
+    const renderError = new Error("card rendering failed");
+    renderPresentation.mockRejectedValueOnce(renderError);
+    await expect(
+      feishuPlugin.outbound?.renderPresentation?.({ ctx, payload, presentation }),
+    ).rejects.toBe(renderError);
+
+    const sendError = new Error("card delivery failed");
+    sendPayload.mockRejectedValueOnce(sendError);
+    await expect(feishuPlugin.outbound?.sendPayload?.(ctx)).rejects.toBe(sendError);
+  });
+});

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1985,21 +1985,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
           },
         },
       },
-      renderPresentation: async (ctx) => {
-        const runtime = await loadFeishuChannelRuntime();
-        const renderPresentation = runtime.feishuOutbound.renderPresentation;
-        return renderPresentation ? await renderPresentation(ctx) : null;
-      },
-      sendPayload: async (ctx) => {
-        const runtime = await loadFeishuChannelRuntime();
-        const sendPayload = runtime.feishuOutbound.sendPayload;
-        if (!sendPayload) {
-          throw new Error("Feishu payload sending is not available.");
-        }
-        return await sendPayload(ctx);
-      },
       ...createRuntimeOutboundDelegates({
         getRuntime: loadFeishuChannelRuntime,
+        renderPresentation: { resolve: (runtime) => runtime.feishuOutbound.renderPresentation },
+        sendPayload: {
+          resolve: (runtime) => runtime.feishuOutbound.sendPayload,
+          unavailableMessage: "Feishu payload sending is not available.",
+        },
         sendText: { resolve: (runtime) => runtime.feishuOutbound.sendText },
         sendMedia: { resolve: (runtime) => runtime.feishuOutbound.sendMedia },
       }),

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -854,6 +854,48 @@ describe("feishuOutbound.sendPayload native cards", () => {
     expectFeishuResult(result, "native_card_msg");
   });
 
+  it.each(["title", "text", "context"] as const)(
+    "delivers complete authored %s through native presentation cards",
+    async (kind) => {
+      const text = `${"x".repeat(3999)} \n  TAIL_NOT_DELIVERED`;
+      const original: MessagePresentation =
+        kind === "title" ? { title: text, blocks: [] } : { blocks: [{ type: kind, text }] };
+      const presentation = adaptMessagePresentationForChannel({
+        presentation: original,
+        capabilities: feishuOutbound.presentationCapabilities,
+      });
+      const payload = { presentation };
+      const rendered = await feishuOutbound.renderPresentation?.({
+        payload,
+        presentation,
+        ctx: { cfg: emptyConfig, to: "chat_1", text: "", accountId: "main", payload },
+      });
+      if (!rendered) {
+        throw new Error("expected native Feishu presentation");
+      }
+      expect(rendered.text).toBe(text);
+      const { presentation: _presentation, ...coreRenderedPayload } = rendered;
+      await feishuOutbound.sendPayload?.({
+        cfg: emptyConfig,
+        to: "chat_1",
+        text: rendered.text ?? "",
+        accountId: "main",
+        payload: coreRenderedPayload,
+      });
+      const card = sendCardCall()?.card;
+      expect(JSON.stringify(card)).toContain("TAIL_NOT_DELIVERED");
+      expect(
+        [
+          card?.header?.title?.content ?? "",
+          ...(card?.body?.elements ?? []).map((element: { content?: string }) =>
+            (element.content ?? "").replace(/<\/?font[^>]*>/gu, ""),
+          ),
+        ].join(""),
+      ).toBe(text);
+      expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("renders webApp presentation buttons into Feishu channelData link buttons", async () => {
     const presentation: MessagePresentation = {
       blocks: [

--- a/src/channels/plugins/outbound/interactive.test.ts
+++ b/src/channels/plugins/outbound/interactive.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   renderMessagePresentationChartFallbackText,
   renderMessagePresentationFallbackText,
+  normalizeMessagePresentation,
 } from "../../../interactive/payload.js";
 import {
   adaptMessagePresentationForChannel,
@@ -720,7 +721,7 @@ describe("presentation capability limits", () => {
     );
   });
 
-  it("applies advertised text limits to titles, text, context, and generated fallback", () => {
+  it("splits titles, text, context, and generated fallback without losing content", () => {
     const presentation = adaptMessagePresentationForChannel({
       presentation: {
         title: "abcdef",
@@ -749,32 +750,60 @@ describe("presentation capability limits", () => {
     expect(presentation).toEqual({
       title: "abcde",
       blocks: [
+        { type: "text", text: "f" },
         { type: "text", text: "hello" },
+        { type: "text", text: " worl" },
+        { type: "text", text: "d" },
         { type: "context", text: "abcde" },
+        { type: "context", text: "f" },
         { type: "context", text: "Actio" },
         { type: "context", text: "ns:\n" },
         { type: "context", text: "- Dep" },
         { type: "context", text: "loy" },
       ],
     });
+    expect(renderMessagePresentationFallbackText({ presentation })).toBe(
+      "abcdef\n\nhello world\n\nabcdef\n\nActions:\n- Deploy",
+    );
   });
 
-  it("does not split code points when applying utf8 byte text limits", () => {
+  it.each([
+    { encoding: "characters" as const, length: (text: string) => Array.from(text).length },
+    { encoding: "utf8-bytes" as const, length: (text: string) => Buffer.byteLength(text, "utf8") },
+    { encoding: "utf16-units" as const, length: (text: string) => text.length },
+  ])("preserves authored Unicode content under $encoding limits", ({ encoding, length }) => {
+    const text = "abc😀 def\nlast";
+    const original = {
+      title: text,
+      blocks: [
+        { type: "text" as const, text },
+        { type: "context" as const, text },
+      ],
+    };
+    const capabilities = { context: false, limits: { text: { maxLength: 6, encoding } } };
     const presentation = adaptMessagePresentationForChannel({
-      presentation: {
-        blocks: [{ type: "text", text: "abc😀def" }],
-      },
-      capabilities: {
-        limits: {
-          text: {
-            maxLength: 6,
-            encoding: "utf8-bytes",
-          },
-        },
-      },
+      presentation: original,
+      capabilities,
     });
-
-    expect(presentation.blocks).toEqual([{ type: "text", text: "abc" }]);
+    expect(length(presentation.title ?? "")).toBeLessThanOrEqual(6);
+    for (const block of presentation.blocks) {
+      expect(block.type).toBe("text");
+      if (block.type === "text") {
+        expect(length(block.text)).toBeLessThanOrEqual(6);
+        expect(block.text.isWellFormed()).toBe(true);
+      }
+    }
+    expect(renderMessagePresentationFallbackText({ presentation })).toBe(
+      renderMessagePresentationFallbackText({ presentation: original }),
+    );
+    expect(
+      renderMessagePresentationFallbackText({
+        presentation: normalizeMessagePresentation(
+          adaptMessagePresentationForChannel({ presentation, capabilities }),
+        ),
+      }),
+    ).toBe(renderMessagePresentationFallbackText({ presentation: original }));
+    expect(adaptMessagePresentationForChannel({ presentation: original })).toEqual(original);
   });
 
   it("does not split code points when applying label limits", () => {

--- a/src/channels/plugins/outbound/interactive.test.ts
+++ b/src/channels/plugins/outbound/interactive.test.ts
@@ -790,7 +790,7 @@ describe("presentation capability limits", () => {
       expect(block.type).toBe("text");
       if (block.type === "text") {
         expect(length(block.text)).toBeLessThanOrEqual(6);
-        expect(block.text.isWellFormed()).toBe(true);
+        expect(Buffer.from(block.text, "utf8").toString("utf8")).toBe(block.text);
       }
     }
     expect(renderMessagePresentationFallbackText({ presentation })).toBe(

--- a/src/channels/plugins/outbound/presentation-limits.ts
+++ b/src/channels/plugins/outbound/presentation-limits.ts
@@ -1,7 +1,7 @@
 /**
  * Presentation limit adapters for channel outbound payloads.
  *
- * Truncates and reshapes portable presentation blocks to match per-channel limits.
+ * Splits text and reshapes portable controls to match per-channel limits.
  */
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -108,14 +108,15 @@ function splitPresentationText(value: string, limits: TextLimits | undefined): s
   return chunks;
 }
 
-function fallbackTextBlocks(params: {
+function presentationTextBlocks(params: {
   blockType: "context" | "text";
   text: string;
   limits?: TextLimits;
-}): MessagePresentationBlock[] {
+  continuation?: boolean;
+}): Array<{ type: "context" | "text"; text: string }> {
   return splitPresentationText(params.text, params.limits).map((text, index) => {
     const block = { type: params.blockType, text };
-    if (index > 0) {
+    if (index > 0 || params.continuation) {
       // Native fallback renderers must reassemble split fragments without inserting paragraph breaks.
       Object.defineProperty(block, PRESENTATION_FALLBACK_CONTINUATION, { value: true });
     }
@@ -143,7 +144,7 @@ function fallbackListBlocks(params: {
     return [];
   }
   // Action labels are operator-visible content; split like chart/table fallbacks instead of dropping them.
-  return fallbackTextBlocks({
+  return presentationTextBlocks({
     blockType: params.blockType,
     text: `${params.heading}:\n${labels.map((label) => `- ${label}`).join("\n")}`,
     limits: params.limits,
@@ -455,31 +456,11 @@ function createGlobalButtonSelection(params: {
   );
 }
 
-function adaptTextBlock(
-  block: MessagePresentationBlock,
-  limits: TextLimits | undefined,
-): MessagePresentationBlock {
-  if (block.type === "text" || block.type === "context") {
-    const adapted = {
-      ...block,
-      text: truncatePresentationText(block.text, limits),
-    };
-    if (
-      Object.getOwnPropertyDescriptor(block, PRESENTATION_FALLBACK_CONTINUATION)?.value === true
-    ) {
-      // Text normalization clones blocks; keep continuation ownership across that boundary.
-      Object.defineProperty(adapted, PRESENTATION_FALLBACK_CONTINUATION, { value: true });
-    }
-    return adapted;
-  }
-  return block;
-}
-
 /**
  * Adapt a portable presentation to the target channel's advertised capabilities.
  *
  * Unsupported controls are downgraded to text/context fallback blocks where possible, and
- * labels, values, rows, options, styles, disabled state, and text are clipped to channel limits.
+ * controls honor channel limits while authored and fallback text retain every character.
  */
 export function adaptMessagePresentationForChannel(params: {
   presentation: MessagePresentation;
@@ -495,11 +476,31 @@ export function adaptMessagePresentationForChannel(params: {
     limits: limits?.actions,
     selectLimits: limits?.selects,
   });
-  const blocks: MessagePresentationBlock[] = [];
+  const titleBlocks = params.presentation.title
+    ? presentationTextBlocks({
+        blockType: "text",
+        text: params.presentation.title,
+        limits: limits?.text,
+      })
+    : [];
+  const blocks: MessagePresentationBlock[] = titleBlocks.slice(1);
   for (const block of params.presentation.blocks) {
+    if (block.type === "text" || block.type === "context") {
+      blocks.push(
+        ...presentationTextBlocks({
+          blockType: block.type === "context" ? fallbackBlockType : "text",
+          text: block.text,
+          limits: limits?.text,
+          continuation:
+            Object.getOwnPropertyDescriptor(block, PRESENTATION_FALLBACK_CONTINUATION)?.value ===
+            true,
+        }),
+      );
+      continue;
+    }
     if (block.type === "chart" && capabilities?.charts !== true) {
       blocks.push(
-        ...fallbackTextBlocks({
+        ...presentationTextBlocks({
           blockType: fallbackBlockType,
           text: renderMessagePresentationChartFallbackText(block),
           limits: limits?.text,
@@ -509,7 +510,7 @@ export function adaptMessagePresentationForChannel(params: {
     }
     if (block.type === "table" && capabilities?.tables !== true) {
       blocks.push(
-        ...fallbackTextBlocks({
+        ...presentationTextBlocks({
           blockType: fallbackBlockType,
           text: renderMessagePresentationTableFallbackText(block),
           limits: limits?.text,
@@ -558,10 +559,6 @@ export function adaptMessagePresentationForChannel(params: {
       );
       continue;
     }
-    if (block.type === "context" && capabilities?.context === false) {
-      blocks.push({ type: "text", text: block.text });
-      continue;
-    }
     if (block.type === "divider" && capabilities?.divider === false) {
       continue;
     }
@@ -569,10 +566,8 @@ export function adaptMessagePresentationForChannel(params: {
   }
   return {
     ...params.presentation,
-    ...(params.presentation.title
-      ? { title: truncatePresentationText(params.presentation.title, limits?.text) }
-      : {}),
-    blocks: blocks.map((block) => adaptTextBlock(block, limits?.text)),
+    ...(params.presentation.title ? { title: titleBlocks[0]?.text } : {}),
+    blocks,
   };
 }
 

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -825,15 +825,36 @@ export function normalizeLegacyInteractiveReply(raw: unknown): LegacyInteractive
 /** @deprecated Use normalizeMessagePresentation. */
 export const normalizeInteractiveReply = normalizeLegacyInteractiveReply;
 
-function normalizePresentationBlock(raw: unknown): MessagePresentationBlock | undefined {
+function isPresentationContinuation(raw: unknown): boolean {
+  const record = toRecord(raw);
+  return Boolean(
+    record &&
+    Object.getOwnPropertyDescriptor(record, PRESENTATION_FALLBACK_CONTINUATION)?.value === true,
+  );
+}
+
+function normalizePresentationBlock(
+  raw: unknown,
+  followedByContinuation: boolean,
+): MessagePresentationBlock | undefined {
   const record = toRecord(raw);
   if (!record) {
     return undefined;
   }
   const type = normalizeOptionalLowercaseString(record.type);
   if (type === "text" || type === "context") {
-    const text = normalizeOptionalString(record.text);
-    return text ? { type, text } : undefined;
+    const continuation = isPresentationContinuation(record);
+    // Adapted fragments share one authored paragraph; trimming either side loses
+    // whitespace at the split, and dropping the marker changes fallback layout.
+    const text =
+      (continuation || followedByContinuation) && typeof record.text === "string"
+        ? record.text
+        : normalizeOptionalString(record.text);
+    const block: MessagePresentationBlock | undefined = text ? { type, text } : undefined;
+    if (block && continuation) {
+      Object.defineProperty(block, PRESENTATION_FALLBACK_CONTINUATION, { value: true });
+    }
+    return block;
   }
   if (type === "divider") {
     return { type: "divider" };
@@ -866,8 +887,18 @@ export function normalizeMessagePresentation(raw: unknown): MessagePresentation 
   if (!record) {
     return undefined;
   }
-  const blocks = normalizeList(record.blocks, normalizePresentationBlock);
-  const title = normalizeOptionalString(record.title);
+  const rawBlocks: unknown[] = Array.isArray(record.blocks) ? record.blocks : [];
+  const blocks = rawBlocks.flatMap((block, index) => {
+    const normalized = normalizePresentationBlock(
+      block,
+      isPresentationContinuation(rawBlocks[index + 1]),
+    );
+    return normalized ? [normalized] : [];
+  });
+  const title =
+    isPresentationContinuation(rawBlocks[0]) && typeof record.title === "string"
+      ? record.title
+      : normalizeOptionalString(record.title);
   if (!title && blocks.length === 0) {
     return undefined;
   }
@@ -1129,11 +1160,7 @@ export function renderMessagePresentationFallbackText(params: {
   for (const block of presentation.blocks) {
     if (block.type === "text" || block.type === "context") {
       // Generated continuation blocks are bounded native fragments, not new paragraphs.
-      if (
-        Object.getOwnPropertyDescriptor(block, PRESENTATION_FALLBACK_CONTINUATION)?.value ===
-          true &&
-        lines.length
-      ) {
+      if (isPresentationContinuation(block) && lines.length) {
         lines[lines.length - 1] += block.text;
       } else {
         lines.push(block.text);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending long rich messages would silently lose the end of their title, body, or context text when a channel applied presentation limits. Discord shortened each authored field to 1,997 characters and Feishu to 4,000, even though the message was otherwise accepted. Discord's fallback for presentations exceeding its component envelope could also omit shortened text and action labels. Full-Gateway testing additionally exposed that Feishu's advertised native-card hooks were overwritten during plugin registration, sending text fallback instead of native cards.

## Why This Change Was Made

The invariant is that channel adaptation must preserve the full authored text, in order, including meaningful whitespace at split boundaries. The shared presentation owner already split generated chart, table, and action fallback text, but separately truncated authored title/body/context. This change uses that existing splitter for all presentation text and deletes the destructive text adapter. Title overflow becomes ordered body continuations.

Splitting alone was insufficient: Feishu normalized the adapted fragments again, and Discord trimmed each rendered fragment. Canonical normalization now retains the existing private continuation metadata and split-boundary whitespace while keeping ordinary raw-input trimming unchanged. Discord preserves fragment text and uses the original presentation when it falls back to plain text.

Feishu defined `renderPresentation` and `sendPayload` before spreading runtime delegates configured only for text/media. The helper returns own undefined properties for unconfigured hooks, so that spread erased both native methods. The plugin now configures both through the existing delegate factory and deletes its handwritten wrappers; the shared helper's semantics are unchanged. The regression tests enter through Feishu's public plugin barrel, which the earlier internal-renderer tests did not cover.

Transport caps, configuration, exported API contracts, and native action budgets are unchanged. Production LOC is **+77/-63 (net +14)**; tests and test support are **+338/-137 (net +201)**. The Feishu registration repair contributes **+5/-13 (net -8)** production lines and 60 test lines. The test totals also include moving existing chart/table action cases and their shared setup into focused files; the earlier CI repair added 22 net lines of test organization and no production code. Remaining production growth belongs to canonical normalization preserving split-continuation text, not a parallel delivery path.

## User Impact

Long Discord and Feishu presentations retain complete titles, body text, context, and fallback action labels. Spaces, newlines, indentation, and Unicode characters survive splitting and repeated normalization. Channels without a shared text-length cap retain their existing behavior.

Release-note context: preserve long channel presentation text instead of silently truncating it, including Discord and Feishu rendering and Discord component-overflow fallback; restore Feishu native-card rendering and payload delivery through its public plugin registration.

## Evidence

AI-assisted implementation with maintainer-directed scope and independent review.

Before the production change, the owner regressions failed in four cases, and the native Discord and Feishu regressions each failed in all three authored-field cases. After the fix, **417 distinct tests passed**: owner/payload 87, Discord 117, Feishu 139, LINE 8, Telegram 31, and Slack 35.

```sh
node scripts/run-vitest.mjs src/channels/plugins/outbound/interactive.test.ts src/interactive/payload.test.ts extensions/discord/src/outbound-adapter.test.ts extensions/discord/src/actions/handle-action.test.ts extensions/discord/src/actions/handle-action.presentation.test.ts extensions/discord/src/shared-interactive.test.ts extensions/feishu/src/outbound.test.ts
node scripts/run-vitest.mjs extensions/slack/src/shared-interactive.test.ts extensions/telegram/src/interactive-fallback.test.ts extensions/telegram/src/outbound-adapter.presentation.test.ts extensions/line/src/channel.rich-messages.test.ts
```

The boundary tests reconstruct the entire authored string across a space/newline/indentation split. Discord uses the real component builder and serializer; Feishu verifies the real rendered card handed to the sender. Shared tests cover Unicode code-point, UTF-8-byte, and UTF-16-unit limits, repeated adaptation/normalization, context downgrade, and uncapped behavior. Discord's oversized-table regression checks complete authored text and an untruncated action label in plain fallback.

The original type-only corrections were rerun: 87 owner/payload tests and all three new Discord cases passed. Independent source review found no actionable defects; the configured Codex review passed its P0 gate with no findings.

[Ready-event CI run 33010497418](https://github.com/openclaw/openclaw/actions/runs/33010497418) completed with two introduced test-only failures: the Unicode assertion used ES2024 `String.isWellFormed` under the repository's ES2023 declarations, and the expanded Discord action test file exceeded its unchanged 1,000-line cap. All selected runtime test jobs, build artifacts, production types, and channel/plugin boundary checks passed. Commit `0dcad8208462617fc85bdabeb655a48459427527` replaces the assertion with equivalent UTF-8 Buffer round-trip equality and splits the existing chart/table action tests using shared test support. No compiler settings, lint caps, or assertions were weakened.

After that repair, **132 focused tests passed** (87 owner/payload and 45 Discord action tests, including adjacent upload/adopted-thread suites); this rerun is not added to the 417-test coverage count. Formatting, `git diff --check`, scoped core lint, and syntax-only extension lint with the unchanged repository rules passed. The fresh configured Codex P0 review and independent review of the test-only diff were clean. [CI run 33012557087](https://github.com/openclaw/openclaw/actions/runs/33012557087) subsequently passed every selected gate on `0dcad8208462617fc85bdabeb655a48459427527`, including types, lint, builds, and runtime tests. That result predates the Feishu hook repair and is not claimed as its CI proof.

```sh
node scripts/run-vitest.mjs src/channels/plugins/outbound/interactive.test.ts src/interactive/payload.test.ts extensions/discord/src/actions/handle-action.test.ts extensions/discord/src/actions/handle-action.presentation.test.ts extensions/discord/src/actions/handle-action.upload-file-caption.test.ts extensions/discord/src/actions/handle-action.adopted-thread.test.ts
```

Additional native HTTP proof passed: the real Feishu adapter, card renderer, sender, and Lark SDK performed a loopback token exchange and four authenticated local message POSTs for title, text, context, and combined cases. Exact received card text preserved split whitespace and all **12,089 characters** in the combined case. Only the SDK's public HTTP interceptor redirected the configured loopback origin; the adapter, renderer, and sender were not mocked. The actual Vitest result was `{"numTotalTests":1,"numPassedTests":1,"numFailedTests":0,"success":true}`. Its SHA-256 is `9c79e4946022ea5b5bb07dec181b01887d5e108044b113ebd3c981df98a591f6`; the received-wire capture SHA-256 is `9b9aeffd5340d24c96dd246edfaab18af3f9116b86bb32324275e1c0935de15a`.

Validation limitations: the local install's Google enum, markdown-it, and Pi TUI dependency mismatches still block canonical typechecking and full extension lint declaration preparation. Extension test typechecking also reports dependency mismatches in unrelated plugins; no changed-file diagnostics remain. These local broad gates are not claimed green.

The full ephemeral Gateway + mock provider + native Feishu API flow then ran against CI build `6eef1ac78ddc5267c0e04a0fce8107615eb50cd1` (PR-head parent `cd057142b3ccecacb6a57275169450136abcc77a`). Actual HTTP chat ingress, agent execution, message-tool invocation, Feishu startup/authentication, and platform HTTP delivery all occurred. The native-card assertion correctly failed: the receiver got `post` text messages rather than an `interactive` card. Inspecting the compiled public plugin confirmed that both native hooks were undefined. This is genuine failing Gateway evidence, not a successful verdict.

History traces the overwrite to [e582cebf2d4c](https://github.com/openclaw/openclaw/commit/e582cebf2d4c17f37d678b1b8ecfdf8502a3f6dc) (May 9, 2026), when the runtime helper gained these optional hook properties. Feishu's native hooks had been added in [#72667](https://github.com/openclaw/openclaw/pull/72667); its trailing delegate spread predates them. The repair is plugin-owned because Matrix/MSTeams already configure native hooks through the helper, Slack overrides its relevant methods afterward, and Tlon has no native presentation hooks.

The two new public-hook regressions both failed before the registration repair and passed afterward. **332 targeted tests passed** across four Feishu suites (public outbound wrapper 2, channel 189, outbound 139, presentation card 2); these overlap the earlier suites and are not added to the 417-test count. They preserve exact context/result forwarding and native error propagation. The incremental configured Codex P0 review and independent review were clean. Scoped syntax lint, formatting, guards, dead-export checks, and five doctor-contract tests passed; the broader changed gate stopped on local dependency type errors outside the changed files. Commit `d50b177b4605c5ec42c38c091451d498ea065aae` contains only the Feishu registration fix and its public-wrapper regressions.

**The full compiled Gateway rerun passed on the new head.** [CI run 33022725998](https://github.com/openclaw/openclaw/actions/runs/33022725998) produced `dist-runtime-build` artifact `9627291614`, built from merge commit `8965a8e4495f0756eec7e04d5bc6a413dae89dba` with parents `395e5db41b5c3f14cbb40114daa801135d2e6fde` and reviewed PR head `d50b177b4605c5ec42c38c091451d498ea065aae`. Exact merge-commit manifests/templates were verified by Git blob SHA; no source overlay or compiled-JS patch was used. The test launched the unmodified compiled Gateway, actual registered Feishu plugin, native renderer/sender and Lark SDK, with the existing scripted mock provider and an isolated loopback native API.

Three real `/v1/chat/completions` ingress calls produced six mock-provider requests, three native `interactive` card POSTs, and three model-visible `sent` receipts with matching platform IDs and one result per payload. Complete received title (4,029 characters), text (4,027), and context (4,033) matched the authored strings exactly, including boundary whitespace. This is mock-Gateway/native-API proof, not an authenticated live-platform send or visual screenshot.

Actual verdict from `ci-gateway-fixed-33022725998-result.json`:

```json
{"numTotalTests":1,"numPassedTests":1,"numFailedTests":0,"success":true}
```

Frozen SHA-256 evidence: verdict `19972115fde868d0046d26e36b602aa864dca82857dbba550450729d1c6221c0`; received wire `cc9a74bc142667902f2faddb6989fe1765b4da94392defeca89769ae597ed19a`; extracted actual tool receipts `af265f01b69f9a52c7f722ce108a1d60c403166286224331c5b85bf3e255a182`; CI archive `c48caaf928e2fd683cbbe499f29e03f37ab3773b6f2e5571b8285f1d393f5f37`. Gateway/provider servers shut down and fixture state was cleaned. The earlier failed compiled build remains historical RED evidence.

Independent source-blind validation of the frozen wire, agent-result, and receipt captures passed all three behavior-contract clauses with no findings: three native cards, exact full authored text, and matching successful receipts/completions. It did not inspect source or witness the run. HTTP statuses/native response bodies are absent from those exported captures; the actual fixture separately asserted HTTP 200. Authenticated platform acceptance and visual application rendering remain outside this artifact-only validation.

Proof limits and named follow-up: outbound transcript mirroring logged `session rebound` warnings after successful native delivery; the old pre-repair Gateway run shows the same warning. This proof validates channel delivery and model-visible receipts, not transcript mirroring. Investigate the isolated cross-channel target/session lifecycle separately; this diagnostic is not yet classified as a product defect. No live-channel or clean-install proof is claimed. **Exact-head CI run 33022725998 completed successfully, including `openclaw/ci-gate`; the compiled Gateway delivery verdict also passed.**

Review follow-up: the latest exact-head [ClawSweeper review](https://github.com/openclaw/openclaw/pull/130368#issuecomment-5431260535) found no actionable source defect and endorsed the single shared splitter and canonical Feishu delegates; both rank-up items are fulfilled by exact-head green CI and the passing Gateway native-card result above. Its live-command transcript passed both new tests twice; the reported partial failure was the review harness expecting a suite-title string absent from Vitest's normal output, not a failed test. Maintainer inspection of current main found no changes to the shared presentation/helper owners and no overlapping Feishu outbound-registration change; unrelated Feishu action/sticker updates are included in the new CI merge-ref build and passed compiled Gateway proof. Rebase is intentionally skipped absent a conflict or stale-code risk, preserving the reviewed stack. Test serialization assertions do not change persisted state or schemas, so no migration is involved.
