### PR TITLE
fix(nodes): validate capture batches before publishing files

### DIFF
--- a/src/agents/openclaw-tools.camera.test.ts
+++ b/src/agents/openclaw-tools.camera.test.ts
@@ -293,6 +293,47 @@ describe("nodes camera_snap", () => {
     ).rejects.toThrow(/facing=both is not allowed when deviceId is set/i);
   });
 
+  it.each([
+    { name: "malformed image data", payload: { ...JPG_PAYLOAD, base64: "not-base64!" } },
+    { name: "an unsupported image format", payload: { ...JPG_PAYLOAD, format: "webp" } },
+  ])(
+    "does not publish the front camera when the back camera returns $name",
+    async ({ payload }) => {
+      let captures = 0;
+      setupNodeInvokeMock({
+        onInvoke: () => ({ payload: captures++ === 0 ? JPG_PAYLOAD : payload }),
+      });
+      const rename = vi.spyOn(fs, "rename");
+
+      try {
+        await expect(
+          executeNodes({ action: "camera_snap", node: NODE_ID, facing: "both" }),
+        ).rejects.toThrow(/invalid base64|unsupported camera\.snap format/i);
+        expect(rename).not.toHaveBeenCalled();
+      } finally {
+        const publishedPaths = rename.mock.calls.map(([, destination]) => String(destination));
+        rename.mockRestore();
+        await Promise.all(
+          publishedPaths.map(async (filePath) => fs.unlink(filePath).catch(() => {})),
+        );
+      }
+    },
+  );
+
+  it("does not activate the back camera after the front returns an unsupported format", async () => {
+    let captures = 0;
+    setupNodeInvokeMock({
+      onInvoke: () => ({
+        payload: captures++ === 0 ? { ...JPG_PAYLOAD, format: "webp" } : JPG_PAYLOAD,
+      }),
+    });
+
+    await expect(
+      executeNodes({ action: "camera_snap", node: NODE_ID, facing: "both" }),
+    ).rejects.toThrow(/unsupported camera\.snap format/i);
+    expect(captures).toBe(1);
+  });
+
   it("downloads camera_snap url payloads when node remoteIp is available", async () => {
     stubFetchTextResponse("url-image");
     setupNodeInvokeMock({

--- a/src/agents/tools/nodes-tool-media.ts
+++ b/src/agents/tools/nodes-tool-media.ts
@@ -12,6 +12,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import {
+  type CameraArtifactFacing,
   cameraTempPath,
   parseCameraClipPayload,
   parseCameraSnapPayload,
@@ -121,23 +122,72 @@ export async function executeNodeMediaAction(
   throw new Error("Unsupported node media action");
 }
 
-async function sanitizeNodePhotoResult(params: {
+function validateNodePhoto(
+  photo: ReturnType<typeof parseCameraSnapPayload>,
+  command: "camera.snap" | "photos.latest",
+) {
+  const format = normalizeLowercaseStringOrEmpty(photo.format);
+  if (format !== "jpg" && format !== "jpeg" && format !== "png") {
+    throw new Error(`unsupported ${command} format: ${photo.format}`);
+  }
+  return { photo, isJpeg: format !== "png" };
+}
+
+type ValidatedNodePhoto = ReturnType<typeof validateNodePhoto> & {
+  facing?: CameraArtifactFacing;
+  createdAt?: unknown;
+};
+
+async function createNodePhotoResult(params: {
   kind: "snaps" | "photos";
-  content: AgentToolResult<unknown>["content"];
-  details: Array<Record<string, unknown>>;
+  photos: ValidatedNodePhoto[];
+  expectedHost?: string;
+  modelHasVision?: boolean;
   imageSanitization: ImageSanitizationLimits;
 }): Promise<AgentToolResult<unknown>> {
-  if (params.details.length === 0) {
-    params.content.push({ type: "text", text: "No photos found." });
+  const command = params.kind === "snaps" ? "camera.snap" : "photos.latest";
+  const content: AgentToolResult<unknown>["content"] = [];
+  const details: Array<Record<string, unknown> & { path: string }> = [];
+  for (const [index, { photo, facing, createdAt, isJpeg }] of params.photos.entries()) {
+    const filePath = cameraTempPath({
+      kind: "snap",
+      ...(facing ? { facing } : { id: crypto.randomUUID() }),
+      ext: isJpeg ? "jpg" : "png",
+    });
+    await writeCameraPayloadToFile({
+      filePath,
+      payload: photo,
+      expectedHost: params.expectedHost,
+      invalidPayloadMessage: `invalid ${command} payload`,
+    });
+    content.push(
+      params.modelHasVision && photo.base64
+        ? {
+            type: "image",
+            data: photo.base64,
+            mimeType: imageMimeFromFormat(photo.format) ?? (isJpeg ? "image/jpeg" : "image/png"),
+          }
+        : {
+            type: "text",
+            text: `${facing ? "Camera" : "Library"} photo saved to ${filePath}.`,
+          },
+    );
+    details.push({
+      ...(facing ? { facing } : { index }),
+      path: filePath,
+      width: photo.width,
+      height: photo.height,
+      ...(typeof createdAt === "string" ? { createdAt } : {}),
+    });
   }
-  const mediaUrls = params.details
-    .map((entry) => entry.path)
-    .filter((entry): entry is string => typeof entry === "string");
+  if (details.length === 0) {
+    content.push({ type: "text", text: "No photos found." });
+  }
+  const mediaUrls = details.map((entry) => entry.path);
   return await sanitizeToolResultImages(
     {
-      content: params.content,
-      details:
-        params.details.length > 0 ? { [params.kind]: params.details, media: { mediaUrls } } : [],
+      content,
+      details: details.length > 0 ? { [params.kind]: details, media: { mediaUrls } } : [],
     },
     params.kind === "snaps" ? "nodes:camera_snap" : "nodes:photos_latest",
     params.imageSanitization,
@@ -181,9 +231,7 @@ async function executeCameraSnap({
     deviceId,
   });
 
-  const content: AgentToolResult<unknown>["content"] = [];
-  const details: Array<Record<string, unknown>> = [];
-
+  const photos: ValidatedNodePhoto[] = [];
   for (const target of targets) {
     const raw = await callNodesToolNodeInvoke<{ payload: unknown }>(gatewayOpts, {
       nodeId,
@@ -198,42 +246,19 @@ async function executeCameraSnap({
       },
       idempotencyKey: crypto.randomUUID(),
     });
-    const payload = parseCameraSnapPayload(raw?.payload, { expectedHost: resolvedNode.remoteIp });
-    const normalizedFormat = normalizeLowercaseStringOrEmpty(payload.format);
-    if (normalizedFormat !== "jpg" && normalizedFormat !== "jpeg" && normalizedFormat !== "png") {
-      throw new Error(`unsupported camera.snap format: ${payload.format}`);
-    }
-
-    const isJpeg = normalizedFormat === "jpg" || normalizedFormat === "jpeg";
-    const filePath = cameraTempPath({
-      kind: "snap",
+    const photo = parseCameraSnapPayload(raw?.payload, { expectedHost: resolvedNode.remoteIp });
+    photos.push({
+      ...validateNodePhoto(photo, "camera.snap"),
       facing: target.artifactFacing,
-      ext: isJpeg ? "jpg" : "png",
-    });
-    await writeCameraPayloadToFile({
-      filePath,
-      payload,
-      expectedHost: resolvedNode.remoteIp,
-      invalidPayloadMessage: "invalid camera.snap payload",
-    });
-    if (modelHasVision && payload.base64) {
-      content.push({
-        type: "image",
-        data: payload.base64,
-        mimeType: imageMimeFromFormat(payload.format) ?? (isJpeg ? "image/jpeg" : "image/png"),
-      });
-    } else {
-      content.push({ type: "text", text: `Camera photo saved to ${filePath}.` });
-    }
-    details.push({
-      facing: target.artifactFacing,
-      path: filePath,
-      width: payload.width,
-      height: payload.height,
     });
   }
-
-  return await sanitizeNodePhotoResult({ kind: "snaps", content, details, imageSanitization });
+  return await createNodePhotoResult({
+    kind: "snaps",
+    photos,
+    expectedHost: resolvedNode.remoteIp,
+    modelHasVision,
+    imageSanitization,
+  });
 }
 
 async function executePhotosLatest({
@@ -276,54 +301,20 @@ async function executePhotosLatest({
     );
   }
 
-  const content: AgentToolResult<unknown>["content"] = [];
-  const details: Array<Record<string, unknown>> = [];
-
-  // Reject every malformed batch member before creating any capture artifact.
+  // Validate the complete native batch before the shared owner writes private artifacts.
   const photos = payload.photos.map((photoRaw) => {
     const photo = parseCameraSnapPayload(photoRaw, { expectedHost: resolvedNode.remoteIp });
-    const normalizedFormat = normalizeLowercaseStringOrEmpty(photo.format);
-    if (normalizedFormat !== "jpg" && normalizedFormat !== "jpeg" && normalizedFormat !== "png") {
-      throw new Error(`unsupported photos.latest format: ${photo.format}`);
-    }
-    return { photoRaw, photo, normalizedFormat };
+    return Object.assign(validateNodePhoto(photo, "photos.latest"), {
+      createdAt: isRecord(photoRaw) ? photoRaw.createdAt : undefined,
+    });
   });
-
-  for (const [index, { photoRaw, photo, normalizedFormat }] of photos.entries()) {
-    const isJpeg = normalizedFormat === "jpg" || normalizedFormat === "jpeg";
-    const filePath = cameraTempPath({
-      kind: "snap",
-      ext: isJpeg ? "jpg" : "png",
-      id: crypto.randomUUID(),
-    });
-    await writeCameraPayloadToFile({
-      filePath,
-      payload: photo,
-      expectedHost: resolvedNode.remoteIp,
-      invalidPayloadMessage: "invalid photos.latest payload",
-    });
-
-    if (modelHasVision && photo.base64) {
-      content.push({
-        type: "image",
-        data: photo.base64,
-        mimeType: imageMimeFromFormat(photo.format) ?? (isJpeg ? "image/jpeg" : "image/png"),
-      });
-    } else {
-      content.push({ type: "text", text: `Library photo saved to ${filePath}.` });
-    }
-
-    const createdAt = isRecord(photoRaw) ? photoRaw.createdAt : undefined;
-    details.push({
-      index,
-      path: filePath,
-      width: photo.width,
-      height: photo.height,
-      ...(typeof createdAt === "string" ? { createdAt } : {}),
-    });
-  }
-
-  return await sanitizeNodePhotoResult({ kind: "photos", content, details, imageSanitization });
+  return await createNodePhotoResult({
+    kind: "photos",
+    photos,
+    expectedHost: resolvedNode.remoteIp,
+    modelHasVision,
+    imageSanitization,
+  });
 }
 
 async function executeCameraClip({

--- a/src/cli/nodes-cli/register.camera.test.ts
+++ b/src/cli/nodes-cli/register.camera.test.ts
@@ -1,6 +1,8 @@
 // Node camera command tests cover help text and RPC handling for optional values.
+import fs from "node:fs/promises";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { writeCameraPayloadToFile } from "../nodes-camera.js";
 import { registerNodesCameraCommands } from "./register.camera.js";
 import * as rpc from "./rpc.js";
 
@@ -119,6 +121,60 @@ describe("nodes camera snap CLI option forwarding", () => {
     const forwardedParams = firstInvokeParams.params as Record<string, unknown>;
     expect(forwardedParams.quality).toBe(0.7);
     expect(forwardedParams.delayMs).toBe(500);
+  });
+
+  it.each([
+    {
+      name: "malformed image data",
+      payload: { format: "jpg", base64: "not-base64!", width: 1, height: 1 },
+    },
+    {
+      name: "an unsafe image extension",
+      payload: { format: "../evil", base64: "aGk=", width: 1, height: 1 },
+    },
+  ])(
+    "does not publish the front camera when the back camera returns $name",
+    async ({ payload }) => {
+      vi.mocked(rpc.callNodesGatewayCli)
+        .mockResolvedValueOnce({
+          payload: { format: "jpg", base64: "aGk=", width: 1, height: 1 },
+        })
+        .mockResolvedValueOnce({ payload });
+      const actualCamera =
+        await vi.importActual<typeof import("../nodes-camera.js")>("../nodes-camera.js");
+      const writer = vi.mocked(writeCameraPayloadToFile);
+      writer.mockImplementation(actualCamera.writeCameraPayloadToFile);
+      const rename = vi.spyOn(fs, "rename");
+
+      try {
+        await expect(
+          buildRootCommand().parseAsync(
+            cameraSnapArgs(["--node", "test-node", "--facing", "both"]),
+          ),
+        ).rejects.toThrow(/invalid base64|invalid media format/i);
+        expect(rename).not.toHaveBeenCalled();
+        expect(writer).not.toHaveBeenCalled();
+      } finally {
+        const publishedPaths = rename.mock.calls.map(([, destination]) => String(destination));
+        rename.mockRestore();
+        writer.mockImplementation(async () => {});
+        await Promise.all(
+          publishedPaths.map(async (filePath) => fs.unlink(filePath).catch(() => {})),
+        );
+      }
+    },
+  );
+
+  it("does not activate the back camera after the front returns an unsafe extension", async () => {
+    vi.mocked(rpc.callNodesGatewayCli).mockResolvedValueOnce({
+      payload: { format: "../evil", base64: "aGk=", width: 1, height: 1 },
+    });
+
+    await expect(
+      buildRootCommand().parseAsync(cameraSnapArgs(["--node", "test-node", "--facing", "both"])),
+    ).rejects.toThrow(/invalid media format/i);
+    expect(rpc.callNodesGatewayCli).toHaveBeenCalledTimes(1);
+    expect(writeCameraPayloadToFile).not.toHaveBeenCalled();
   });
 
   it("rejects out-of-range --quality", async () => {

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -163,13 +163,11 @@ export function registerNodesCameraCommands(nodes: Command) {
             platform: node.platform,
             deviceId,
           });
-          const results: Array<{
+          const captures: Array<{
             facing: CameraArtifactFacing;
-            path: string;
-            width: number;
-            height: number;
+            payload: ReturnType<typeof parseCameraSnapPayload>;
+            filePath: string;
           }> = [];
-
           for (const target of targets) {
             const invokeParams = buildNodeInvokeParams({
               nodeId,
@@ -189,11 +187,19 @@ export function registerNodesCameraCommands(nodes: Command) {
             const payload = parseCameraSnapPayload(getGatewayInvokePayload(raw), {
               expectedHost: node.remoteIp,
             });
-            const filePath = cameraTempPath({
-              kind: "snap",
+            captures.push({
               facing: target.artifactFacing,
-              ext: payload.format === "jpeg" ? "jpg" : payload.format,
+              payload,
+              filePath: cameraTempPath({
+                kind: "snap",
+                facing: target.artifactFacing,
+                ext: payload.format === "jpeg" ? "jpg" : payload.format,
+              }),
             });
+          }
+
+          const results = [];
+          for (const { facing: artifactFacing, payload, filePath } of captures) {
             await writeCameraPayloadToFile({
               filePath,
               payload,
@@ -201,7 +207,7 @@ export function registerNodesCameraCommands(nodes: Command) {
               invalidPayloadMessage: "invalid camera.snap payload",
             });
             results.push({
-              facing: target.artifactFacing,
+              facing: artifactFacing,
               path: filePath,
               width: payload.width,
               height: payload.height,


### PR DESCRIPTION
## What Problem This Solves

The agent camera tool and `nodes camera snap --facing both` published the front image before checking the back response. A malformed second native payload could leave a private photo on disk even though the command failed. The photo-library path already preflighted its native batch but duplicated result construction.

## Why This Change Was Made

Gather and validate native responses before publishing any capture file. Reuse one artifact/result owner for agent camera and photo-library responses; the CLI gathers safe output paths before writing. Invalid first responses still stop before the second camera is invoked. Existing safe CLI format extensions remain accepted.

Production LOC: +98/-101 (net -3). Tests: +97/-0. No config, schema, protocol, dependency, or model tool-result contract changes. This follows the parser hardening in #116927; the older per-capture publishing loop remained in place after that repair.

## User Impact

A malformed later native response no longer leaves an earlier private camera image published. This is native-payload/path preflight, **not batch rollback for later network or filesystem errors**. All requested captures now precede downloads; a later download or write failure can still leave a valid earlier file. Per-file atomic publication remains unchanged.

## Evidence

- Exact candidate: `1807f208710b09ddefc906a54aa51dbaa70a03ea`, rebased onto landed CLI #130352 at `52beb5e113ead4730b7488c42e97d19feaeaeb9b`. Original reviewed camera head was `14d88d0a2d91c5ddbb82b9cc51b6d08ba29b6c3a`.
- Four new agent/CLI regressions fail on the original code, observing a real `fs.rename` of the first JPG before rejection of malformed base64 or format. They pass with this change; actual published files are read back/cleaned up.
- 168 owner and sibling tests pass with matching dependencies. Native node responses are controlled fixtures; this is real filesystem publication proof, not physical-camera testing.
- Fresh structured Codex P1 and separate independent review passed on the final candidate; the independent reviewer also ran 47 camera tests.
- All selected changed-gate components passed. The aggregate run first stopped on a missing task UI dependency link; after repairing only that environment link, the exact remaining type/lint/guard commands passed. The original aggregate exit was not green; required clean hosted CI remains mandatory.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/openclaw-tools.camera.test.ts src/agents/tools/nodes-tool.test.ts src/cli/nodes-cli/register.camera.test.ts src/cli/nodes-camera.test.ts src/cli/nodes-media-utils.test.ts
```

The coordinated CLI preflight refactor #130352 is now landed. Its one actual camera-registration merge conflict was resolved by retaining early pure input/timeout validation and the capture preflight array, removing only the duplicated old timeout declaration. The exact combined tree `5867ed2101a8bb1417693684146ee249ca96d9ed` passed 260 tests across ten files, all eleven runtime/declaration build phases, formatting, lint, core and core-test TypeScript. Twenty actual rebuilt CLI invalid-input subprocesses produced the expected local diagnostic with zero Gateway TCP connections; a valid canary made one connection. Both independent source/proof reviewers approved the exact tree.

Fresh integration review initially asked for broader URL-download/filesystem rollback. The finding was checked against complete parser/writer source and the pre-existing explicit scope above: native-payload/path preflight is repaired; later network/filesystem rollback is not promised. The raw findings and source-based disposition are retained. A fresh review with the full contracts passed without accepted/actionable findings. No production changes were made to obtain that result. Current-head hosted CI must pass before landing.

Named pre-existing follow-ups: the human-duration clip E2E case lacks its neighboring artifact-readback/cleanup assertion; camera docs still mention `--duration-ms` although registration exposes `--duration`. Neither is claimed fixed here. Maintainer-requested, AI-assisted.
