### PR TITLE
fix(agents): preserve workspace ownership across path aliases

### DIFF
--- a/src/agents/agent-delete-safety.test.ts
+++ b/src/agents/agent-delete-safety.test.ts
@@ -1,7 +1,9 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { isSharedAuthStoreOwner } from "./agent-delete-safety.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { findOverlappingWorkspaceAgentIds, isSharedAuthStoreOwner } from "./agent-delete-safety.js";
 
 describe("shared auth store deletion safety", () => {
   const sharedAuthDbPath = path.join(os.tmpdir(), "shared-auth", "openclaw-agent.sqlite");
@@ -28,5 +30,34 @@ describe("shared auth store deletion safety", () => {
     },
   ])("$name", ({ ownership, agentAuthDbPath, expected }) => {
     expect(isSharedAuthStoreOwner({ ownership, agentAuthDbPath, sharedAuthDbPath })).toBe(expected);
+  });
+});
+
+describe("shared workspace deletion safety", () => {
+  it("detects another agent behind a dangling workspace symlink", () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-delete-alias-"));
+    const workspaceDir = path.join(rootDir, "vanished-workspace");
+    const workspaceAliasDir = path.join(rootDir, "workspace-alias");
+    try {
+      fs.symlinkSync(
+        workspaceDir,
+        workspaceAliasDir,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      const config: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "alpha", workspace: workspaceAliasDir },
+            { id: "beta", workspace: workspaceDir },
+          ],
+        },
+      };
+
+      expect(findOverlappingWorkspaceAgentIds(config, "alpha", workspaceAliasDir)).toEqual([
+        "beta",
+      ]);
+    } finally {
+      fs.rmSync(rootDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agents/agent-delete-safety.ts
+++ b/src/agents/agent-delete-safety.ts
@@ -1,13 +1,11 @@
 /** Safety checks for deleting agents whose workspaces may overlap other agents. */
-import fs from "node:fs";
-import path from "node:path";
-import { lowercasePreservingWhitespace } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { isSameOpenClawAgentDatabasePath } from "../state/openclaw-agent-db-registry.js";
 import { listAgentEntries, resolveAgentWorkspaceDir } from "./agent-scope.js";
 import type { SharedAuthStoreOwnership } from "./auth-profiles/path-resolve.js";
+import { resolveCanonicalWorkspacePath } from "./workspace-state-identity.js";
 
 /** True when deleting this agent database would remove the legacy shared auth store. */
 export function isSharedAuthStoreOwner(params: {
@@ -25,23 +23,9 @@ export function formatSharedAuthStoreOwnerDeleteError(agentId: string): string {
   return `Agent "${agentId}" owns the legacy shared auth store and cannot be deleted. Run openclaw doctor --fix to migrate shared auth, then retry.`;
 }
 
-function normalizeWorkspacePathForComparison(input: string): string {
-  const resolved = path.resolve(input.replaceAll("\0", ""));
-  let normalized = resolved;
-  try {
-    normalized = fs.realpathSync.native(resolved);
-  } catch {
-    // Keep lexical path for non-existent directories.
-  }
-  if (process.platform === "win32") {
-    return lowercasePreservingWhitespace(normalized);
-  }
-  return normalized;
-}
-
 function workspacePathsOverlap(left: string, right: string): boolean {
-  const normalizedLeft = normalizeWorkspacePathForComparison(left);
-  const normalizedRight = normalizeWorkspacePathForComparison(right);
+  const normalizedLeft = resolveCanonicalWorkspacePath(left.replaceAll("\0", ""));
+  const normalizedRight = resolveCanonicalWorkspacePath(right.replaceAll("\0", ""));
   return (
     isPathInside(normalizedRight, normalizedLeft) || isPathInside(normalizedLeft, normalizedRight)
   );

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { withEnv } from "../test-utils/env.js";
+import { findOverlappingWorkspaceAgentIds } from "./agent-delete-safety.js";
 import {
   clearAutoFallbackPrimaryProbeSelection,
   hasLegacyAutoFallbackWithoutOrigin,
@@ -1128,6 +1129,34 @@ describe("resolveAgentConfig", () => {
 });
 
 describe("resolveAgentIdByWorkspacePath", () => {
+  it.runIf(process.platform === "linux")(
+    "keeps distinct Unicode workspace directories under their own agents",
+    () => {
+      const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "workspace-unicode-")));
+      const composed = path.join(root, "caf\u00e9");
+      const decomposed = path.join(root, "cafe\u0301");
+      try {
+        fs.mkdirSync(composed);
+        fs.mkdirSync(decomposed);
+        const cfg: OpenClawConfig = {
+          agents: {
+            entries: {
+              composed: { workspace: composed },
+              decomposed: { workspace: decomposed },
+            },
+          },
+        };
+
+        expect(fs.statSync(composed).ino).not.toBe(fs.statSync(decomposed).ino);
+        expect(resolveAgentIdByWorkspacePath(cfg, composed)).toBe("composed");
+        expect(resolveAgentIdByWorkspacePath(cfg, decomposed)).toBe("decomposed");
+        expect(findOverlappingWorkspaceAgentIds(cfg, "composed", composed)).toEqual([]);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("returns the most specific workspace match for a directory", () => {
     const workspaceRoot = `/tmp/openclaw-agent-scope-${Date.now()}-root`;
     const opsWorkspace = `${workspaceRoot}/projects/ops`;
@@ -1190,6 +1219,40 @@ describe("resolveAgentIdByWorkspacePath", () => {
       ).toBe("ops");
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("matches a dangling workspace symlink to its vanished target", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-scope-dangling-"));
+    const workspaceDir = path.join(tempRoot, "vanished-workspace");
+    const workspaceAliasDir = path.join(tempRoot, "workspace-alias");
+    try {
+      fs.symlinkSync(
+        workspaceDir,
+        workspaceAliasDir,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "ops", workspace: workspaceAliasDir }] },
+      };
+
+      expect(resolveAgentIdByWorkspacePath(cfg, workspaceDir)).toBe("ops");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a cyclic workspace alias bounded and separate from unrelated paths", () => {
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "workspace-cycle-")));
+    const alias = path.join(root, "alias");
+    try {
+      fs.symlinkSync(alias, alias, process.platform === "win32" ? "junction" : "dir");
+      const cfg: OpenClawConfig = { agents: { entries: { ops: { workspace: alias } } } };
+
+      expect(resolveAgentIdByWorkspacePath(cfg, alias)).toBe("ops");
+      expect(resolveAgentIdByWorkspacePath(cfg, path.join(root, "other"))).toBeUndefined();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
     }
   });
 });

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -1,8 +1,5 @@
 /** Higher-level agent scope helpers for model selection, fallbacks, skills, and workspaces. */
-import fs from "node:fs";
-import path from "node:path";
 import {
-  lowercasePreservingWhitespace,
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
   resolvePrimaryStringValue,
@@ -24,7 +21,6 @@ import {
   resolveAgentIdFromSessionKey,
 } from "../routing/session-key.js";
 import { resolveEffectiveAgentSkillFilter } from "../skills/discovery/agent-filter.js";
-import { resolveUserPath } from "../utils.js";
 import {
   AgentSelectionRequiredError,
   listAgentIds,
@@ -34,6 +30,7 @@ import {
   resolveDefaultAgentId,
   tryResolveLegacyCompatibilityAgentId,
 } from "./agent-scope-config.js";
+import { resolveCanonicalWorkspacePath } from "./workspace-state-identity.js";
 export { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
 export {
   listAgentEntries,
@@ -59,11 +56,6 @@ export {
   type AgentSelectionContext,
   type ResolvedAgentConfig,
 } from "./agent-scope-config.js";
-
-/** Strip null bytes from paths to prevent ENOTDIR errors. */
-function stripNullBytes(s: string): string {
-  return s.split("\0").join("");
-}
 
 const AUTO_FALLBACK_PRIMARY_PROBE_INTERVAL_MS = 5 * 60 * 1000;
 const AUTO_FALLBACK_PRIMARY_PROBE_MAX_KEYS = 4096;
@@ -607,32 +599,16 @@ export function resolveEffectiveModelFallbacks(params: {
   return agentFallbacksOverride ?? defaultFallbacks;
 }
 
-function normalizePathForComparison(input: string): string {
-  const resolved = path.resolve(stripNullBytes(resolveUserPath(input)));
-  let normalized = resolved;
-  // Prefer realpath when available to normalize aliases/symlinks (for example /tmp -> /private/tmp)
-  // and canonical path case without forcing case-folding on case-sensitive macOS volumes.
-  try {
-    normalized = fs.realpathSync.native(resolved);
-  } catch {
-    // Keep lexical path for non-existent directories.
-  }
-  if (process.platform === "win32") {
-    return lowercasePreservingWhitespace(normalized);
-  }
-  return normalized;
-}
-
 export function resolveAgentIdByWorkspacePath(
   cfg: OpenClawConfig,
   workspacePath: string,
 ): string | undefined {
-  const normalizedWorkspacePath = normalizePathForComparison(workspacePath);
+  const normalizedWorkspacePath = resolveCanonicalWorkspacePath(workspacePath.replaceAll("\0", ""));
   let matchedAgentId: string | undefined;
   let matchedWorkspaceLength = -1;
 
   for (const id of listAgentIds(cfg)) {
-    const workspaceDir = normalizePathForComparison(resolveAgentWorkspaceDir(cfg, id));
+    const workspaceDir = resolveCanonicalWorkspacePath(resolveAgentWorkspaceDir(cfg, id));
     if (!isPathInside(workspaceDir, normalizedWorkspacePath)) {
       continue;
     }

--- a/src/agents/workspace-state-identity.ts
+++ b/src/agents/workspace-state-identity.ts
@@ -18,8 +18,11 @@ function normalizeWorkspaceIdentityPath(value: string): string {
   return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 
-function canonicalizeWorkspaceIdentityPath(workspaceDir: string): string {
-  const fallback = normalizeWorkspaceIdentityPath(path.resolve(resolveUserPath(workspaceDir)));
+function canonicalizeWorkspacePath(
+  workspaceDir: string,
+  normalizePath: (value: string) => string,
+): string {
+  const fallback = normalizePath(path.resolve(resolveUserPath(workspaceDir)));
   let candidate = fallback;
   const followedSymlinks = new Set<string>();
 
@@ -28,7 +31,7 @@ function canonicalizeWorkspaceIdentityPath(workspaceDir: string): string {
     let current = candidate;
     while (true) {
       try {
-        return normalizeWorkspaceIdentityPath(
+        return normalizePath(
           path.join(fs.realpathSync.native(current), ...missingSegments.toReversed()),
         );
       } catch {
@@ -37,7 +40,7 @@ function canonicalizeWorkspaceIdentityPath(workspaceDir: string): string {
       }
       try {
         if (fs.lstatSync(current).isSymbolicLink()) {
-          const normalizedLink = normalizeWorkspaceIdentityPath(current);
+          const normalizedLink = normalizePath(current);
           if (followedSymlinks.has(normalizedLink)) {
             return fallback;
           }
@@ -63,6 +66,12 @@ function canonicalizeWorkspaceIdentityPath(workspaceDir: string): string {
   return fallback;
 }
 
+// Filesystem ownership preserves path bytes; NFC state keys are a separate stored
+// contract and can identify distinct directories as equal on Linux.
+export function resolveCanonicalWorkspacePath(workspaceDir: string): string {
+  return canonicalizeWorkspacePath(workspaceDir, path.normalize);
+}
+
 export function createWorkspaceStateIdentity(workspacePath: string): WorkspaceStateIdentity {
   return {
     workspacePath,
@@ -72,10 +81,12 @@ export function createWorkspaceStateIdentity(workspacePath: string): WorkspaceSt
 
 export function resolveWorkspaceStateAliases(workspaceDir: string): WorkspaceStateIdentity[] {
   const lexicalPath = normalizeWorkspaceIdentityPath(path.resolve(resolveUserPath(workspaceDir)));
-  const canonicalPath = canonicalizeWorkspaceIdentityPath(workspaceDir);
+  const canonicalPath = canonicalizeWorkspacePath(workspaceDir, normalizeWorkspaceIdentityPath);
   return [...new Set([lexicalPath, canonicalPath])].map(createWorkspaceStateIdentity);
 }
 
 export function resolveWorkspaceStateIdentity(workspaceDir: string): WorkspaceStateIdentity {
-  return createWorkspaceStateIdentity(canonicalizeWorkspaceIdentityPath(workspaceDir));
+  return createWorkspaceStateIdentity(
+    canonicalizeWorkspacePath(workspaceDir, normalizeWorkspaceIdentityPath),
+  );
 }

--- a/src/memory-host-sdk/dreaming.test.ts
+++ b/src/memory-host-sdk/dreaming.test.ts
@@ -236,6 +236,21 @@ describe("memory dreaming host helpers", () => {
     ]);
   });
 
+  it("uses canonical roster identities when agent aliases share a workspace", () => {
+    const cfg = {
+      agents: {
+        list: [
+          { id: "Team Alpha", workspace: "/workspace/shared" },
+          { id: "team-alpha", workspace: "/workspace/shared" },
+        ],
+      },
+    } as OpenClawConfig;
+
+    expect(resolveMemoryDreamingWorkspaces(cfg)).toEqual([
+      { workspaceDir: "/workspace/shared", agentIds: ["team-alpha"] },
+    ]);
+  });
+
   it("does not require a default owner when no primary workspace is supplied", () => {
     const cfg = {
       agents: {

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -12,7 +12,7 @@ import {
   normalizeStringifiedOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import {
-  listAgentEntries,
+  listAgentIds,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
@@ -286,10 +286,6 @@ function resolveExecutionConfig(
     ...(typeof temperature === "number" ? { temperature } : {}),
     ...(typeof timeoutMs === "number" ? { timeoutMs } : {}),
   };
-}
-
-function normalizePathForComparison(input: string): string {
-  return resolveWorkspaceStateIdentity(input).workspacePath;
 }
 
 function formatLocalIsoDay(epochMs: number): string {
@@ -584,20 +580,7 @@ export function resolveMemoryDreamingWorkspaces(
   cfg: OpenClawConfig,
   options: MemoryDreamingWorkspaceOptions = {},
 ): MemoryDreamingWorkspace[] {
-  const configured = listAgentEntries(cfg);
-  const agentIds: string[] = [];
-  const seenAgents = new Set<string>();
-  for (const entry of configured) {
-    if (!entry || typeof entry !== "object" || typeof entry.id !== "string") {
-      continue;
-    }
-    const id = normalizeOptionalLowercaseString(entry.id);
-    if (!id || seenAgents.has(id)) {
-      continue;
-    }
-    seenAgents.add(id);
-    agentIds.push(id);
-  }
+  const agentIds = listAgentIds(cfg);
   if (agentIds.length === 0) {
     agentIds.push(resolveDefaultAgentId(cfg));
   }
@@ -609,7 +592,7 @@ export function resolveMemoryDreamingWorkspaces(
       return;
     }
     const agentId = normalizeOptionalLowercaseString(agentIdRaw) || resolveDefaultAgentId(cfg);
-    const key = normalizePathForComparison(workspaceDir);
+    const key = resolveWorkspaceStateIdentity(workspaceDir).workspacePath;
     const existing = byWorkspace.get(key);
     if (existing) {
       if (!existing.agentIds.includes(agentId)) {


### PR DESCRIPTION
## What Problem This Solves

Workspace lookup and agent-deletion safety each used a private realpath-or-lexical fallback. A dangling symlink lost its target identity: lookup could miss the owning agent, and deletion could miss another agent sharing the vanished workspace. Dreaming separately retained duplicate roster aliases already normalized by agent configuration.

## Why This Change Was Made

Reuse the existing bounded workspace symlink walker for filesystem ownership, removing both duplicate canonicalizers and the separate dreaming roster loop. Share traversal, not stored-key normalization: filesystem paths preserve Unicode bytes, while persisted state-key normalization stays exactly where it was. There is no schema, hash, alias, or stored-data migration.

Production LOC: +26/-72 (net -46). Tests: +110/-1 (net +109).

## User Impact

Workspace ownership and shared-workspace deletion protection follow dangling symlink targets correctly. Distinct Linux NFC/NFD directory names remain distinct for routing and deletion. Dreaming processes canonical agent identities once.

Existing persisted state keys still NFC-fold those names; repairing that separate storage identity needs an explicit migration/design decision and is **not** part of this PR.

## Evidence

- Exact candidate: `2296f3f6cb232ae61956a22077a083eeb5718153`.
- Three original-code regressions reproduced: duplicate dreaming roster IDs, missed dangling shared workspace, and missed workspace owner.
- Independent review caught a Unicode error in the first candidate. Real Linux proof created distinct NFC/NFD inodes, reproduced wrong-agent routing, and passed after filesystem path and stored identity were separated.
- 142 local tests pass, with one Linux-only skip; 98 tests pass on real Linux, including distinct Unicode inodes, dangling links, cycles, ownership/deletion and state-store contracts. Remote workflow: https://github.com/openclaw/openclaw/actions/runs/33006357752 . The proof lease was stopped.
- Full selected changed gate passed after task-only dependency links were corrected to an existing matching install. No dependency files or checker rules were changed.
- Fresh structured Codex P1 and separate independent exact-commit review passed. Dependency source inspection confirms the alternative existing-ancestor resolver loses dangling targets, so it cannot replace the bounded walker here.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/agents/agent-delete-safety.test.ts src/agents/agent-scope.test.ts src/memory-host-sdk/dreaming.test.ts src/agents/workspace-state-store.test.ts src/commands/agents.delete.test.ts src/commands/agents.delete.workspace.test.ts src/gateway/server-methods/agents-workspace.test.ts
```

Maintainer-requested, AI-assisted. Required exact-head hosted CI and native landing checks remain mandatory.
