### PR TITLE
refactor(cron): retain the prepared watcher handoff owner

### DIFF
--- a/src/agents/mcp-connection-resolver.test.ts
+++ b/src/agents/mcp-connection-resolver.test.ts
@@ -331,7 +331,6 @@ describe("mcp connection resolver helpers", () => {
           storePath: "/tmp/openclaw-mcp-gateway-reload-proof-cron",
           cronEnabled: false,
           reconcileExitWatchers: async () => {},
-          stopExitWatchers: () => {},
           reconcileStreamWatchers: async () => {},
           stopStreamWatchers: async () => {},
           reconcileHeartbeatJobs: async () => {},

--- a/src/gateway/server-cron-lazy.test.ts
+++ b/src/gateway/server-cron-lazy.test.ts
@@ -106,13 +106,14 @@ describe("createLazyGatewayCronState", () => {
       updateHandlers: vi.fn(),
     };
     const stopOwner = vi.fn(async () => {});
+    const prepareExitWatcherHandoff = vi.fn(async () => ({
+      current: () => watchers,
+      adopt: vi.fn(),
+      stopOwner,
+    }));
     hoisted.setState({
       ...createCronState(cron),
-      prepareExitWatcherHandoff: vi.fn(async () => ({
-        current: () => watchers,
-        adopt: vi.fn(),
-        stopOwner,
-      })),
+      prepareExitWatcherHandoff,
     });
     const lazy = createLazyGatewayCronState(createParams());
 
@@ -124,7 +125,9 @@ describe("createLazyGatewayCronState", () => {
     await handoff?.stopOwner();
     finishStart.resolve();
     await start;
+    await handoff?.stopOwner();
 
+    expect(prepareExitWatcherHandoff).toHaveBeenCalledOnce();
     expect(stopOwner).toHaveBeenCalledOnce();
     expect(watchers.cancelAll).not.toHaveBeenCalled();
     expect(cron["stop"]).not.toHaveBeenCalled();
@@ -401,7 +404,6 @@ describe("createLazyGatewayCronState", () => {
     const lazy = createLazyGatewayCronState(createParams());
 
     // Teardown before load must not force the heavy import.
-    lazy.stopExitWatchers();
     await lazy.stopStreamWatchers();
     expect(hoisted.buildGatewayCronService).not.toHaveBeenCalled();
 
@@ -410,9 +412,7 @@ describe("createLazyGatewayCronState", () => {
     expect(state.reconcileExitWatchers).toHaveBeenCalledTimes(1);
     expect(state.reconcileStreamWatchers).toHaveBeenCalledTimes(1);
 
-    lazy.stopExitWatchers();
     await lazy.stopStreamWatchers();
-    expect(state.stopExitWatchers).toHaveBeenCalledTimes(1);
     expect(state.stopStreamWatchers).toHaveBeenCalledTimes(1);
   });
 
@@ -449,7 +449,6 @@ function createCronState(cron: GatewayCronServiceContract): GatewayCronState {
     storePath: "/tmp/openclaw-cron.json",
     cronEnabled: true,
     reconcileExitWatchers: vi.fn(async () => {}),
-    stopExitWatchers: vi.fn(),
     reconcileStreamWatchers: vi.fn(async () => {}),
     stopStreamWatchers: vi.fn(async () => {}),
     reconcileHeartbeatJobs: vi.fn(async () => {}),

--- a/src/gateway/server-cron-lazy.ts
+++ b/src/gateway/server-cron-lazy.ts
@@ -38,7 +38,7 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
   const cronEnabled = env.OPENCLAW_SKIP_CRON !== "1" && params.cfg.cron?.enabled !== false;
   let loaded: LoadedGatewayCronState | null = null;
   let stopped = false;
-  let preserveExitWatchersOnStop = false;
+  let exitWatcherHandoff: GatewayCronExitWatcherHandoff | undefined;
   let exitWatcherHandoffStop: Promise<void> | undefined;
   let lifecycleGeneration = 0;
   let schedulingPaused = false;
@@ -88,17 +88,13 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
     return await cronStateLoader.load();
   };
 
-  const stopResolvedCron = async (
-    resolved: LoadedGatewayCronState,
-    preserveExitWatchers: boolean,
-  ): Promise<void> => {
+  const stopResolvedCron = async (resolved: LoadedGatewayCronState): Promise<void> => {
     resolved.phase = "stopped";
     resolved.underlyingStarted = false;
-    const handoff = preserveExitWatchers
-      ? await resolved.state.prepareExitWatcherHandoff?.()
-      : undefined;
-    if (handoff) {
-      await handoff.stopOwner();
+    if (exitWatcherHandoff) {
+      // A cancelled startup must join the exact prepared owner's drain, not
+      // prepare or stop another owner after its watchers have been adopted.
+      await (exitWatcherHandoffStop ??= exitWatcherHandoff.stopOwner());
     } else if (resolved.state.cron.stopAndDrain) {
       await resolved.state.cron.stopAndDrain();
     } else {
@@ -107,26 +103,15 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
     }
   };
 
-  const stopResolvedCronOnce = (
-    resolved: LoadedGatewayCronState,
-    preserveExitWatchers: boolean,
-  ): Promise<void> => {
-    if (!preserveExitWatchers) {
-      return stopResolvedCron(resolved, false);
-    }
-    exitWatcherHandoffStop ??= stopResolvedCron(resolved, true);
-    return exitWatcherHandoffStop;
-  };
-
-  const stopLoadedCronAndDrain = async (preserveExitWatchers = false): Promise<void> => {
+  const stopLoadedCronAndDrain = async (handoff?: GatewayCronExitWatcherHandoff): Promise<void> => {
     stopped = true;
-    preserveExitWatchersOnStop ||= preserveExitWatchers;
+    exitWatcherHandoff ??= handoff;
     lifecycleGeneration += 1;
     releaseSchedulingResumeWaiters();
     const loading = cronStateLoader.peek();
     const resolved = loaded ?? (loading ? await loading : null);
     if (resolved) {
-      await stopResolvedCronOnce(resolved, preserveExitWatchersOnStop);
+      await stopResolvedCron(resolved);
     }
   };
 
@@ -184,7 +169,7 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
           resolved.underlyingStartInFlight = false;
         }
         if (startCancelled()) {
-          await stopResolvedCronOnce(resolved, preserveExitWatchersOnStop);
+          await stopResolvedCron(resolved);
           return;
         }
         if (schedulingPaused) {
@@ -205,7 +190,7 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
           throw err;
         }
         if (startCancelled()) {
-          await stopResolvedCronOnce(resolved, preserveExitWatchersOnStop);
+          await stopResolvedCron(resolved);
           return;
         }
         resolved.phase = "started";
@@ -354,7 +339,7 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
       return {
         ...handoff,
         stopOwner: async () => {
-          await stopLoadedCronAndDrain(true);
+          await stopLoadedCronAndDrain(handoff);
         },
       };
     },
@@ -363,9 +348,6 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
     // no-op until a gateway restart (system-owned cron cadence changes never applied).
     async reconcileExitWatchers() {
       await (await load()).state.reconcileExitWatchers();
-    },
-    stopExitWatchers() {
-      loaded?.state.stopExitWatchers();
     },
     async reconcileStreamWatchers() {
       await (await load()).state.reconcileStreamWatchers();

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -130,7 +130,6 @@ export type GatewayCronState = {
   // the proxy silently omit reconcileHeartbeatJobs, turning every
   // restart-heartbeat reload into a permanent no-op until gateway restart.
   reconcileExitWatchers: () => Promise<void>;
-  stopExitWatchers: () => void;
   reconcileStreamWatchers: () => Promise<void>;
   stopStreamWatchers: () => Promise<void>;
   reconcileHeartbeatJobs: (cfg?: OpenClawConfig) => Promise<void>;
@@ -1627,7 +1626,6 @@ export function buildGatewayCronService(params: {
       },
     }),
     reconcileExitWatchers,
-    stopExitWatchers,
     reconcileStreamWatchers,
     stopStreamWatchers,
     reconcileHeartbeatJobs,

--- a/src/gateway/server-reload-handlers.hot-reload-status.test.ts
+++ b/src/gateway/server-reload-handlers.hot-reload-status.test.ts
@@ -83,7 +83,6 @@ describe("startManagedGatewayConfigReloader hotReloadStatus plumbing", () => {
           storePath: "/tmp/cron.json",
           cronEnabled: false,
           reconcileExitWatchers: vi.fn(async () => {}),
-          stopExitWatchers: vi.fn(),
           reconcileStreamWatchers: vi.fn(async () => {}),
           stopStreamWatchers: vi.fn(async () => {}),
           reconcileHeartbeatJobs: vi.fn(async () => {}),

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -84,6 +84,7 @@ import {
 import { shouldRewarmProviderAuthState } from "./config-reload-recovery.js";
 import { applyHookMappings } from "./hooks-mapping.js";
 import { commitHooksConfigReload } from "./hooks.js";
+import { createLazyGatewayCronState } from "./server-cron-lazy.js";
 import type { GatewayCronState } from "./server-cron.js";
 import type { GatewayPluginReloadResult } from "./server-reload-handlers.js";
 import {
@@ -175,7 +176,6 @@ function createTestCronState(overrides: Partial<GatewayCronState> = {}): Gateway
     storePath: "/tmp/cron.json",
     cronEnabled: false,
     reconcileExitWatchers: vi.fn(async () => {}),
-    stopExitWatchers: vi.fn(),
     reconcileStreamWatchers: vi.fn(async () => {}),
     stopStreamWatchers: vi.fn(async () => {}),
     reconcileHeartbeatJobs: vi.fn(async () => {}),
@@ -287,7 +287,6 @@ const hoisted = vi.hoisted(() => ({
     storePath: "/tmp/rebuilt-cron.json",
     cronEnabled: true,
     reconcileExitWatchers: vi.fn(async () => {}),
-    stopExitWatchers: vi.fn(),
     reconcileStreamWatchers: vi.fn(async () => {}),
     stopStreamWatchers: vi.fn(async () => {}),
     reconcileHeartbeatJobs: vi.fn(async () => {}),
@@ -629,7 +628,6 @@ function createReloadHandlersForTest(
   },
 ) {
   const cron = { start: vi.fn(async () => {}), stop: vi.fn() };
-  const stopExitWatchers = vi.fn();
   const reconcileHeartbeatJobs = vi.fn(async () => {});
   const heartbeatRunner = {
     stop: vi.fn(),
@@ -641,7 +639,6 @@ function createReloadHandlersForTest(
     heartbeatRunner: heartbeatRunner as never,
     cronState: createTestCronState({
       cron: cron as never,
-      stopExitWatchers,
       reconcileHeartbeatJobs,
     }),
     channelHealthMonitor: null,
@@ -684,7 +681,6 @@ function createReloadHandlersForTest(
     logCron,
     reconcileHeartbeatJobs,
     setState,
-    stopExitWatchers,
   };
 }
 
@@ -1360,109 +1356,119 @@ describe("gateway hot reload model state", () => {
     }
   });
 
-  it("keeps a supervised on-exit child alive exactly once across same-store cron reload", async () => {
-    const fixtureDir = autoCleanupTempDirs.make("openclaw-cron-exit-reload-");
-    const childScriptPath = path.join(fixtureDir, "watcher.cjs");
-    const markerPath = path.join(fixtureDir, "watcher-runs.txt");
-    const releasePath = path.join(fixtureDir, "release-watcher");
-    const config = {
-      session: { mainKey: "main", store: path.join(fixtureDir, "sessions.json") },
-      cron: { enabled: true, store: path.join(fixtureDir, "jobs.json") },
-    } as OpenClawConfig;
-    await writeFile(
-      childScriptPath,
-      "const fs=require('node:fs');" +
-        "fs.appendFileSync(process.argv[2],'run\\n');" +
-        "const timer=setInterval(()=>{if(fs.existsSync(process.argv[3]))clearInterval(timer)},10)",
-      "utf8",
-    );
-    const childArgs = [childScriptPath, markerPath, releasePath];
-    const command =
-      process.platform === "win32"
-        ? buildWindowsCmdExeCommandLine(process.execPath, childArgs)
-        : [process.execPath, ...childArgs].map((argument) => JSON.stringify(argument)).join(" ");
-    const supervisor = getProcessSupervisor();
-    const spawn = vi.spyOn(supervisor, "spawn");
-    let state: ReturnType<ReloadHandlerParams["getState"]> | undefined;
-
-    vi.stubEnv("OPENCLAW_STATE_DIR", fixtureDir);
-    vi.stubEnv("OPENCLAW_SKIP_CRON", "0");
-    hoisted.runtimeConfig.value = config;
-    setRuntimeConfigSnapshot(config, config);
-
-    try {
-      const actualCron =
-        await vi.importActual<typeof import("./server-cron.js")>("./server-cron.js");
-      const initialCronState = actualCron.buildGatewayCronService({
-        cfg: config,
-        deps: {} as never,
-        broadcast: vi.fn(),
-      });
-      state = {
-        ...createDefaultGatewayReloadState(),
-        cronState: initialCronState,
-      };
-      await initialCronState.cron.start();
-      const job = await initialCronState.cron.add({
-        name: "preserve the real watched child",
-        enabled: true,
-        schedule: { kind: "on-exit", command },
-        sessionTarget: "main",
-        wakeMode: "next-heartbeat",
-        payload: { kind: "systemEvent", text: "watched child finished" },
-      });
-      await initialCronState.reconcileExitWatchers();
-      await waitForFast(async () => expect(await readFile(markerPath, "utf8")).toBe("run\n"), {
-        timeout: 10_000,
-      });
-      expect(spawn).toHaveBeenCalledOnce();
-      const watchedRun = await spawn.mock.results[0]?.value;
-      if (!watchedRun) {
-        throw new Error("expected the supervised cron exit watcher to start");
-      }
-
-      hoisted.buildGatewayCronService.mockImplementationOnce(
-        (params) =>
-          actualCron.buildGatewayCronService(
-            params as Parameters<typeof actualCron.buildGatewayCronService>[0],
-          ) as unknown as ReturnType<typeof hoisted.buildGatewayCronService>,
+  it.each(["eager", "lazy"] as const)(
+    "keeps a supervised on-exit child alive exactly once across %s cron reload",
+    async (initialOwner) => {
+      const fixtureDir = autoCleanupTempDirs.make("openclaw-cron-exit-reload-");
+      const childScriptPath = path.join(fixtureDir, "watcher.cjs");
+      const markerPath = path.join(fixtureDir, "watcher-runs.txt");
+      const releasePath = path.join(fixtureDir, "release-watcher");
+      const config = {
+        session: { mainKey: "main", store: path.join(fixtureDir, "sessions.json") },
+        cron: { enabled: true, store: path.join(fixtureDir, "jobs.json") },
+      } as OpenClawConfig;
+      await writeFile(
+        childScriptPath,
+        "const fs=require('node:fs');" +
+          "fs.appendFileSync(process.argv[2],'run\\n');" +
+          "const timer=setInterval(()=>{if(fs.existsSync(process.argv[3]))clearInterval(timer)},10)",
+        "utf8",
       );
-      const handlers = createGatewayReloadHandlers({
-        getState: () => {
-          if (!state) {
-            throw new Error("expected gateway state");
-          }
-          return state;
-        },
-        setState: (nextState) => {
-          state = nextState;
-        },
-      });
+      const childArgs = [childScriptPath, markerPath, releasePath];
+      const command =
+        process.platform === "win32"
+          ? buildWindowsCmdExeCommandLine(process.execPath, childArgs)
+          : [process.execPath, ...childArgs].map((argument) => JSON.stringify(argument)).join(" ");
+      const supervisor = getProcessSupervisor();
+      const spawn = vi.spyOn(supervisor, "spawn");
+      const previousCronFactory = hoisted.buildGatewayCronService.getMockImplementation();
+      if (!previousCronFactory) {
+        throw new Error("expected the default cron test factory");
+      }
+      let state: ReturnType<ReloadHandlerParams["getState"]> | undefined;
 
-      await withGatewayRestartSignal(async () => {
-        await handlers.applyHotReload(createCronRestartPlan(), config);
-      });
+      vi.stubEnv("OPENCLAW_STATE_DIR", fixtureDir);
+      vi.stubEnv("OPENCLAW_SKIP_CRON", "0");
+      hoisted.runtimeConfig.value = config;
+      setRuntimeConfigSnapshot(config, config);
 
-      expect(supervisor.getRecord(watchedRun.runId)).toMatchObject({
-        pid: watchedRun.pid,
-        state: "running",
-      });
-      expect(await readFile(markerPath, "utf8")).toBe("run\n");
-      expect(spawn).toHaveBeenCalledOnce();
+      try {
+        const actualCron =
+          await vi.importActual<typeof import("./server-cron.js")>("./server-cron.js");
+        hoisted.buildGatewayCronService.mockImplementation(
+          (params) =>
+            actualCron.buildGatewayCronService(
+              params as Parameters<typeof actualCron.buildGatewayCronService>[0],
+            ) as unknown as ReturnType<typeof hoisted.buildGatewayCronService>,
+        );
+        const buildInitialCron =
+          initialOwner === "lazy" ? createLazyGatewayCronState : actualCron.buildGatewayCronService;
+        const initialCronState = buildInitialCron({
+          cfg: config,
+          deps: {} as never,
+          broadcast: vi.fn(),
+        });
+        state = {
+          ...createDefaultGatewayReloadState(),
+          cronState: initialCronState,
+        };
+        await initialCronState.cron.start();
+        const job = await initialCronState.cron.add({
+          name: "preserve the real watched child",
+          enabled: true,
+          schedule: { kind: "on-exit", command },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "watched child finished" },
+        });
+        await initialCronState.reconcileExitWatchers();
+        await waitForFast(async () => expect(await readFile(markerPath, "utf8")).toBe("run\n"), {
+          timeout: 10_000,
+        });
+        expect(spawn).toHaveBeenCalledOnce();
+        const watchedRun = await spawn.mock.results[0]?.value;
+        if (!watchedRun) {
+          throw new Error("expected the supervised cron exit watcher to start");
+        }
 
-      await writeFile(releasePath, "release");
-      await waitForFast(() => expect(state?.cronState.cron.getJob(job.id)?.enabled).toBe(false), {
-        timeout: 10_000,
-      });
-      expect(await readFile(markerPath, "utf8")).toBe("run\n");
-      expect(spawn).toHaveBeenCalledOnce();
-    } finally {
-      await writeFile(releasePath, "release").catch(() => {});
-      await state?.cronState.cron.stopAndDrain?.();
-      spawn.mockRestore();
-      vi.unstubAllEnvs();
-    }
-  });
+        const handlers = createGatewayReloadHandlers({
+          getState: () => {
+            if (!state) {
+              throw new Error("expected gateway state");
+            }
+            return state;
+          },
+          setState: (nextState) => {
+            state = nextState;
+          },
+        });
+
+        await withGatewayRestartSignal(async () => {
+          await handlers.applyHotReload(createCronRestartPlan(), config);
+        });
+
+        expect(supervisor.getRecord(watchedRun.runId)).toMatchObject({
+          pid: watchedRun.pid,
+          state: "running",
+        });
+        expect(await readFile(markerPath, "utf8")).toBe("run\n");
+        expect(spawn).toHaveBeenCalledOnce();
+
+        await writeFile(releasePath, "release");
+        await waitForFast(() => expect(state?.cronState.cron.getJob(job.id)?.enabled).toBe(false), {
+          timeout: 10_000,
+        });
+        expect(await readFile(markerPath, "utf8")).toBe("run\n");
+        expect(spawn).toHaveBeenCalledOnce();
+      } finally {
+        hoisted.buildGatewayCronService.mockImplementation(previousCronFactory);
+        await writeFile(releasePath, "release").catch(() => {});
+        await state?.cronState.cron.stopAndDrain?.();
+        spawn.mockRestore();
+        vi.unstubAllEnvs();
+      }
+    },
+  );
 
   it.each([
     "agents.defaults.compaction.model",
@@ -1516,7 +1522,6 @@ describe("gateway hot reload model state", () => {
       storePath: "/tmp/rebuilt-cron.json",
       cronEnabled: true,
       reconcileExitWatchers: newReconcileExitWatchers,
-      stopExitWatchers: vi.fn(),
       reconcileStreamWatchers: vi.fn(async () => {}),
       stopStreamWatchers: vi.fn(async () => {}),
       reconcileHeartbeatJobs: vi.fn(async () => {}),
@@ -1525,13 +1530,9 @@ describe("gateway hot reload model state", () => {
       order.push("build-new");
       return rebuiltCronState;
     });
-    const { applyHotReload, cron, cronReconciliation, setState, stopExitWatchers } =
-      createReloadHandlersForTest();
+    const { applyHotReload, cron, cronReconciliation, setState } = createReloadHandlersForTest();
     cron.stop.mockImplementation(() => {
       order.push("stop-old");
-    });
-    stopExitWatchers.mockImplementation(() => {
-      order.push("stop-old-watchers");
     });
     cronReconciliation.invalidate.mockImplementation(() => {
       order.push("invalidate-old");
@@ -1548,7 +1549,6 @@ describe("gateway hot reload model state", () => {
     });
 
     expect(cron.stop).toHaveBeenCalledTimes(1);
-    expect(stopExitWatchers).toHaveBeenCalledTimes(1);
     expect(newCron.start).toHaveBeenCalledTimes(1);
     await waitForFast(() => expect(newReconcileExitWatchers).toHaveBeenCalledTimes(1));
     await waitForFast(() => expect(order.at(-1)).toBe("hook"));
@@ -1556,7 +1556,6 @@ describe("gateway hot reload model state", () => {
       "build-new",
       "invalidate-old",
       "stop-old",
-      "stop-old-watchers",
       "start-new",
       "reconcile-watchers",
       "hook",
@@ -1592,7 +1591,6 @@ describe("gateway hot reload model state", () => {
       storePath: "/tmp/rebuilt-cron.json",
       cronEnabled: false,
       reconcileExitWatchers: vi.fn(async () => {}),
-      stopExitWatchers: vi.fn(),
       reconcileStreamWatchers: vi.fn(async () => {}),
       stopStreamWatchers: vi.fn(async () => {}),
       reconcileHeartbeatJobs: vi.fn(async () => {}),
@@ -1733,7 +1731,6 @@ describe("gateway hot reload model state", () => {
         storePath: "/tmp/rebuilt-cron.json",
         cronEnabled: true,
         reconcileExitWatchers: vi.fn(async () => {}),
-        stopExitWatchers: vi.fn(),
         reconcileStreamWatchers: vi.fn(async () => {}),
         stopStreamWatchers: vi.fn(async () => {}),
         reconcileHeartbeatJobs: vi.fn(async () => {}),
@@ -1769,7 +1766,6 @@ describe("gateway hot reload model state", () => {
       storePath: "/tmp/first-cron.json",
       cronEnabled: true,
       reconcileExitWatchers: vi.fn(async () => {}),
-      stopExitWatchers: vi.fn(),
       reconcileStreamWatchers: vi.fn(async () => {}),
       stopStreamWatchers: vi.fn(async () => {}),
       reconcileHeartbeatJobs: vi.fn(async () => {}),
@@ -1779,7 +1775,6 @@ describe("gateway hot reload model state", () => {
       storePath: "/tmp/second-cron.json",
       cronEnabled: true,
       reconcileExitWatchers: vi.fn(async () => {}),
-      stopExitWatchers: vi.fn(),
       reconcileStreamWatchers: vi.fn(async () => {}),
       stopStreamWatchers: vi.fn(async () => {}),
       reconcileHeartbeatJobs: vi.fn(async () => {}),
@@ -5329,7 +5324,6 @@ describe("gateway plugin hot reload handlers", () => {
       storePath: "/tmp/rebuilt-cron.json",
       cronEnabled: true,
       reconcileExitWatchers: vi.fn(async () => {}),
-      stopExitWatchers: vi.fn(),
       reconcileStreamWatchers: vi.fn(async () => {}),
       stopStreamWatchers: vi.fn(async () => {}),
       reconcileHeartbeatJobs: vi.fn(async () => {}),

--- a/src/gateway/server-reload-hot.ts
+++ b/src/gateway/server-reload-hot.ts
@@ -226,7 +226,6 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
             await state.cronState.cron.stopAndDrain();
           } else {
             state.cronState.cron.stop();
-            state.cronState.stopExitWatchers();
             await state.cronState.stopStreamWatchers();
           }
           startGatewayCronWithLogging({

--- a/src/gateway/server-request-context.test.ts
+++ b/src/gateway/server-request-context.test.ts
@@ -27,7 +27,6 @@ function makeCronState(overrides: Partial<TestCronState> = {}): TestCronState {
     storePath: "/tmp/cron",
     cronEnabled: true,
     reconcileExitWatchers: vi.fn(async () => {}),
-    stopExitWatchers: vi.fn(),
     reconcileStreamWatchers: vi.fn(async () => {}),
     stopStreamWatchers: vi.fn(async () => {}),
     reconcileHeartbeatJobs: vi.fn(async () => {}),


### PR DESCRIPTION
## What Problem This Solves

The lazy Gateway cron proxy discarded its prepared watcher-handoff handle when stopping and prepared another wrapper through a boolean-preservation helper. An additional exposed stop hook duplicated work already owned by `cron.stop`. This made reload shutdown ownership harder to follow after #115761.

## Why This Change Was Made

Retain the exact prepared handoff and join its memoized owner drain. Remove the redundant Gateway state hook, lazy forwarding method, and hot-reload duplicate call. Keep `cron.stop` as the synchronous cancellation owner and preserve awaited stream-watcher cleanup in the legacy/fake drain path.

Production LOC: +12/-33 (net -21). Tests: +118/-128 (net -10; primarily tabulating existing eager/lazy real-process coverage). No public API, config, protocol, database, dependency, watcher implementation, or process-supervisor changes. This is internal owner consolidation, not a newly claimed operator bug or changed handoff-retry guarantee.

## User Impact

Watched cron commands retain their existing reload behavior: the replacement adopts watchers while the original owner drains. The same live child PID survives reload and is terminated when the final owner disables it.

## Evidence

- Exact candidate: `c6e89818f5135c87d345548e1989399cdbc1848c`.
- The pending-start owner test fails before the change because handoff preparation occurs twice, and passes afterward. This proves the owner contract; the old real implementation only returned wrappers, so this is not presented as a new user-visible failure.
- 412 owner/sibling tests pass, including actual OS child processes, the real supervisor, real cron service/SQLite store and reload handler. Both eager and lazy owners retain one PID, one spawn and one marker through reload, then terminate on disable.
- Independent review caught a test fixture override leak; after restoring its factory in `finally`, all 226 reload-handler tests passed again. The independent verifier separately passed 29 lazy/drain tests and both real-process paths.
- Full selected changed gate passed; fresh structured Codex P1 and separate exact-commit independent review passed.
- This is real-process integration proof, not a fully booted Gateway or authenticated provider test.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-cron-lazy.test.ts src/gateway/server-cron.test.ts src/gateway/cron-exit-watchers.test.ts src/gateway/server-reload-handlers.test.ts src/gateway/server-request-context.test.ts src/gateway/server-reload-handlers.hot-reload-status.test.ts src/agents/mcp-connection-resolver.test.ts
```

Maintainer-requested, AI-assisted. Required exact-head hosted CI and native landing checks remain mandatory.
