### PR TITLE
fix(ui): show dashboard refresh failures with a retry action

### DIFF
--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -24,6 +24,8 @@ the most recently updated thread first. Open any row to go directly to that
 thread's `/dashboard/<agent>/<sessionRef>` URL. An open Dashboards page updates
 as threads are renamed, archived, deleted, or switched between Chat and
 Dashboard, including after a Gateway reconnect.
+If a refresh fails, the page keeps the last loaded dashboards visible with a
+stale-data warning. Choose **Retry** to load the list again.
 
 Use **Open dashboard in focus mode** on a row to open its board as a standalone
 browser document at `/focus/dashboard/<agent>/<sessionRef>`, with no sidebar,

--- a/ui/src/e2e/dashboards-list-demand.e2e.test.ts
+++ b/ui/src/e2e/dashboards-list-demand.e2e.test.ts
@@ -1,4 +1,6 @@
 // Control UI E2E proves dashboard tabs do not multiply server-owned session-list demand.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import {
@@ -57,6 +59,141 @@ async function requestCounts(gateways: MockGatewayControls[]) {
 }
 
 suite.define(() => {
+  it("shows failed dashboard refreshes beside retained rows and retries the same query", async () => {
+    const artifactDir = path.resolve(".artifacts/control-ui-e2e/dashboard-refresh-errors");
+    await mkdir(artifactDir, { recursive: true });
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1440 } });
+    const page = await context.newPage();
+    try {
+      const key = "agent:main:dashboard-12345678";
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "sessions.list": {
+            cases: [
+              {
+                match: { boardFace: "dashboard" },
+                response: sessionsResult(key, "Deploy monitor", 1),
+              },
+            ],
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}dashboards`);
+      const dashboards = page.locator("openclaw-dashboards-page");
+      await dashboards.getByText("Deploy monitor", { exact: true }).waitFor();
+      const before = (await gateway.getRequests("sessions.list")).filter(isDashboardRequest);
+      await gateway.deferNext("sessions.list", { boardFace: "dashboard" });
+      await gateway.emitGatewayEvent("sessions.changed", {
+        agentId: "main",
+        key,
+        sessionKey: key,
+        kind: "direct",
+        reason: "update",
+        updatedAt: 2,
+      });
+      await expect
+        .poll(
+          async () =>
+            (await gateway.getRequests("sessions.list")).filter(isDashboardRequest).length,
+        )
+        .toBe(before.length + 1);
+      await gateway.rejectDeferred("sessions.list", {
+        code: "UNAVAILABLE",
+        message: "Dashboard refresh unavailable",
+        retryable: true,
+      });
+      // Confirm the real store consumed the failed wire response before capturing the UI.
+      await page.waitForFunction(() => {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: {
+            context: {
+              agentSelection: { state: { scopeId: string | null } };
+              sessions: {
+                listSnapshot: (query: Record<string, unknown>) => {
+                  error: string | null;
+                  loading: boolean;
+                };
+              };
+            };
+          };
+        };
+        const appContext = app.runtime?.context;
+        return (
+          appContext?.sessions.listSnapshot({
+            limit: 50,
+            boardFace: "dashboard",
+            archivedFilter: "all",
+            agentId: appContext.agentSelection.state.scopeId ?? undefined,
+          }).error === "Dashboard refresh unavailable"
+        );
+      });
+      await page.screenshot({ path: path.join(artifactDir, "refresh-failed.png") });
+      expect(await dashboards.getByText("Deploy monitor", { exact: true }).isVisible()).toBe(true);
+      expect(await page.locator("openclaw-router-outlet").getAttribute("inert")).toBeNull();
+      await expect.poll(() => dashboards.getByRole("alert").allTextContents()).toHaveLength(1);
+      expect(await dashboards.getByRole("alert").textContent()).toContain(
+        "Dashboard refresh unavailable",
+      );
+      expect(await dashboards.getByRole("alert").textContent()).toContain("Showing stale data");
+
+      await gateway.setMethodResponse("sessions.list", {
+        cases: [
+          {
+            match: { boardFace: "dashboard" },
+            response: sessionsResult(key, "Updated deploy monitor", 2),
+          },
+        ],
+      });
+      await dashboards.getByRole("button", { name: "Retry", exact: true }).click();
+      await dashboards.getByText("Updated deploy monitor", { exact: true }).waitFor();
+      expect(await dashboards.getByRole("alert").count()).toBe(0);
+      const after = (await gateway.getRequests("sessions.list")).filter(isDashboardRequest);
+      expect(after).toHaveLength(before.length + 2);
+      expect(after.at(-1)?.params).toEqual(before.at(-1)?.params);
+      await page.screenshot({ path: path.join(artifactDir, "refresh-recovered.png") });
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("retries an initial dashboard failure without claiming the list is empty", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1440 } });
+    const page = await context.newPage();
+    try {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "sessions.list": {
+            cases: [
+              {
+                match: { boardFace: "dashboard" },
+                response: {
+                  __mockError: { code: "UNAVAILABLE", message: "Dashboard list unavailable" },
+                },
+              },
+            ],
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}dashboards`);
+      const dashboards = page.locator("openclaw-dashboards-page");
+      await dashboards.getByRole("alert").waitFor();
+      expect(await dashboards.getByRole("alert").textContent()).toContain(
+        "Dashboard list unavailable",
+      );
+      expect(await dashboards.textContent()).not.toContain("Showing stale data");
+      expect(await dashboards.locator("[data-dashboards-empty]").count()).toBe(0);
+      const emptyResult = { ...sessionsResult("", "", 1), count: 0, sessions: [] };
+      await gateway.setMethodResponse("sessions.list", {
+        cases: [{ match: { boardFace: "dashboard" }, response: emptyResult }],
+      });
+      await dashboards.getByRole("button", { name: "Retry", exact: true }).click();
+      await dashboards.locator("[data-dashboards-empty]").waitFor();
+      expect(await dashboards.getByRole("alert").count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps dashboard query demand at one request per real browser tab", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const tabs: Array<{

--- a/ui/src/pages/dashboards/dashboards-page.test.ts
+++ b/ui/src/pages/dashboards/dashboards-page.test.ts
@@ -102,6 +102,7 @@ describe("DashboardsPage", () => {
       expect.any(Function),
     );
     expect(refreshList).not.toHaveBeenCalled();
+    const retiredListener = listListeners.get("all")!;
 
     selectionState.scopeId = "writer";
     selectionListeners.forEach((listener) => listener());
@@ -122,13 +123,44 @@ describe("DashboardsPage", () => {
       error: null,
     });
     await vi.waitFor(() => expect(element.textContent).toContain("Writer dashboard"));
-    listListeners.get("all")?.({
+    retiredListener({
       result: result(row("agent:main:retired", "Retired")),
       agentId: null,
       loading: false,
-      error: null,
+      error: "Retired scope refresh failed",
     });
     await element.updateComplete;
     expect(element.textContent).not.toContain("Retired");
+
+    const writerListener = listListeners.get("writer")!;
+    writerListener({
+      result: result(row("agent:writer:current", "Writer dashboard")),
+      agentId: "writer",
+      loading: false,
+      error: "Writer refresh failed",
+    });
+    await element.updateComplete;
+    expect(element.textContent).toContain("Writer dashboard");
+    expect(element.querySelector('[role="alert"]')?.textContent).toContain("Writer refresh failed");
+    refreshList.mockClear();
+    element.querySelector<HTMLButtonElement>('[role="alert"] button')?.click();
+    expect(refreshList).toHaveBeenCalledOnce();
+    expect(refreshList).toHaveBeenLastCalledWith({
+      limit: 50,
+      boardFace: "dashboard",
+      archivedFilter: "all",
+      agentId: "writer",
+      force: true,
+    });
+
+    element.remove();
+    writerListener({
+      result: null,
+      agentId: "writer",
+      loading: false,
+      error: "Detached refresh failed",
+    });
+    await element.updateComplete;
+    expect(element.textContent).not.toContain("Detached refresh failed");
   });
 });

--- a/ui/src/pages/dashboards/dashboards-page.ts
+++ b/ui/src/pages/dashboards/dashboards-page.ts
@@ -76,7 +76,12 @@ class DashboardsPage extends OpenClawLightDomElement {
   }
 
   override render() {
-    return renderDashboards(this.data);
+    return renderDashboards(this.data, () => {
+      const context = this.context;
+      if (context?.gateway.snapshot.phase === "connected") {
+        void context.sessions.refreshList({ ...dashboardSessionListQuery(context), force: true });
+      }
+    });
   }
 }
 

--- a/ui/src/pages/dashboards/route.ts
+++ b/ui/src/pages/dashboards/route.ts
@@ -28,7 +28,7 @@ export function dashboardsRouteData(
 ): DashboardsRouteData {
   return {
     result: snapshot.result,
-    error: snapshot.result ? null : snapshot.error,
+    error: snapshot.error,
     basePath: context.basePath,
     fallbackAgentId: resolveSessionNavigationAgentId(context),
     mainKey: resolveUiConfiguredMainKey({

--- a/ui/src/pages/dashboards/view.test.ts
+++ b/ui/src/pages/dashboards/view.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { render } from "lit";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { SessionsListResult } from "../../api/types.ts";
 import { renderDashboards, type DashboardsRouteData } from "./view.ts";
 
@@ -40,6 +40,7 @@ describe("dashboards index", () => {
             ],
             basePath,
           ),
+          vi.fn(),
         ),
         container,
       );
@@ -60,7 +61,7 @@ describe("dashboards index", () => {
 
   it("explains how to create a dashboard when the list is empty", () => {
     const container = document.createElement("div");
-    render(renderDashboards(routeData([])), container);
+    render(renderDashboards(routeData([]), vi.fn()), container);
 
     const empty = container.querySelector("[data-dashboards-empty]");
     expect(empty?.textContent).toContain("No dashboards yet");

--- a/ui/src/pages/dashboards/view.ts
+++ b/ui/src/pages/dashboards/view.ts
@@ -4,6 +4,7 @@ import { repeat } from "lit/directives/repeat.js";
 import type { SessionsListResult } from "../../api/types.ts";
 import { titleForRoute } from "../../app-navigation.ts";
 import { icons } from "../../components/icons.ts";
+import { renderPanelRefreshStatus } from "../../components/panel-refresh-status.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { formatRelativeTimestamp } from "../../lib/format.ts";
@@ -20,10 +21,8 @@ export type DashboardsRouteData = {
 
 function renderDashboardList(data: DashboardsRouteData) {
   const rows = data.result?.sessions ?? [];
-  if (data.error) {
-    return html`<section class="card" role="alert">
-      ${t("dashboardsPage.loadError", { error: data.error })}
-    </section>`;
+  if (data.error && !data.result) {
+    return nothing;
   }
   if (rows.length === 0) {
     return html`<section class="card stack" data-dashboards-empty role="status">
@@ -71,9 +70,22 @@ function renderDashboardList(data: DashboardsRouteData) {
   </section>`;
 }
 
-export function renderDashboards(data: DashboardsRouteData | undefined) {
+export function renderDashboards(data: DashboardsRouteData | undefined, onRetry: () => void) {
   const body = data
-    ? renderDashboardList(data)
+    ? html`
+        ${renderPanelRefreshStatus({
+          status: {
+            error: data.error,
+            hasLoaded: data.result !== null,
+            stale: data.result !== null && data.error !== null,
+          },
+          errorMessage: data.error
+            ? t("dashboardsPage.loadError", { error: data.error })
+            : undefined,
+          onRetry,
+        })}
+        ${renderDashboardList(data)}
+      `
     : html`<section class="card" aria-busy="true">${t("common.loading")}</section>`;
   return html`
     <section class="content-header">


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing Dashboards would see cached rows as if they were current when a background list refresh failed while the Gateway remained connected. The failure had no visible warning or retry action.

## Why This Change Was Made

The dashboard adapter discarded the session store's recorded refresh error whenever a cached result existed. It now preserves both facts and reuses the shared refresh-status UI to show the error, mark the retained data stale, and retry the current dashboard/agent query. Initial failures show a retry action without claiming the list is empty; existing query ownership and disposal still reject retired scope callbacks.

## User Impact

Operators keep the last loaded dashboards visible, can tell when the list failed to refresh, and can choose **Retry** to recover. A successful retry replaces the rows and removes the warning. No configuration, authentication, storage, protocol, or dependency changes are required.

## Evidence

- Before the fix, a real Chromium run against the bundled Control UI received a rejected dashboard-filtered `sessions.list` after `sessions.changed`. The real session store recorded the error and the cached row remained visible, but the assertion for a visible alert failed. The page was connected and not inert.
- After the fix, all **3 browser E2E tests passed**, covering retained-row failure and recovery, initial failure and recovery, and the existing per-tab dashboard query demand checks. The browser uses deterministic mocked Gateway transport, not a live operator Gateway.
- All **8 focused unit tests passed** across the dashboard route, page, view, and shared refresh-status component. The scope test covers retrying the current agent query and ignoring retired/disposed callbacks.
- Scoped formatting, lint, style checks, the i18n catalog check, dead-export checks, and `git diff --check` passed. Independent source/flow review found no blocking findings; the configured Codex review reported no P0 findings.
- Full changed-file and UI typechecks are limited by existing installed-dependency mismatches in untouched code: Google `FinishReason`, `markdown-it` type exports, `pi-tui`, and missing `pako` types. No diagnostics implicated the changed files. Shared dependencies were not modified or reconciled.

Commands:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/dashboards-list-demand.e2e.test.ts
node scripts/run-vitest.mjs ui/src/pages/dashboards/dashboards-page.test.ts ui/src/pages/dashboards/route.test.ts ui/src/pages/dashboards/view.test.ts ui/src/components/panel-refresh-status.test.ts
```

Production LOC: +25/-8 (net +17), adding the visible failure/retry behavior through existing owners. Tests: +174/-4. Docs: +2/-0.

Before: a failed refresh leaves the cached dashboard visible without any error or recovery action.

![Before: failed dashboard refresh with no visible warning](https://github.com/user-attachments/assets/7c113ea2-a39a-42c2-bee5-604fe6267622)

After: the cached dashboard remains visible with the error, stale-data warning, and Retry.

![After: dashboard refresh error with stale-data warning and Retry](https://github.com/user-attachments/assets/b13b5e01-60ef-4570-a408-f2a3b8776a5f)

Recovered: Retry loads the updated dashboard and clears the warning.

![Recovered: updated dashboard after retry](https://github.com/user-attachments/assets/bb92c624-f30a-49d3-b53f-80e094426d4c)

AI-assisted.
