### PR TITLE
fix(ui): clear stale transcript results when session filters change

### DIFF
--- a/ui/src/e2e/session-transcript-search.e2e.test.ts
+++ b/ui/src/e2e/session-transcript-search.e2e.test.ts
@@ -188,6 +188,81 @@ describeControlUiE2e("Control UI session transcript search", () => {
     await captureUiProof("04-matching-chat.png");
   });
 
+  it("clears transcript matches when switching from active to archived sessions", async () => {
+    const timestamp = Date.parse("2026-08-26T12:00:00.000Z");
+    context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 1000, width: 1440 },
+      ...(captureProof
+        ? { recordVideo: { dir: artifactDir, size: { height: 1000, width: 1440 } } }
+        : {}),
+    });
+    page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.search"],
+      sessionArchiveFiltering: true,
+      methodResponses: {
+        "sessions.list": {
+          count: 2,
+          defaults: { contextTokens: null, model: null, modelProvider: null },
+          path: "",
+          sessions: [
+            {
+              key: "agent:main:active",
+              label: "Active task",
+              kind: "direct",
+              updatedAt: timestamp,
+            },
+            {
+              key: "agent:main:archived",
+              label: "Archived task",
+              kind: "direct",
+              archived: true,
+              updatedAt: timestamp,
+            },
+          ],
+          ts: timestamp,
+        },
+        "sessions.search": {
+          results: [
+            {
+              messageId: "message-active",
+              role: "assistant",
+              score: 1,
+              sessionId: "session-active",
+              sessionKey: "agent:main:active",
+              snippet: "Release notes from the active task.",
+              timestamp,
+            },
+          ],
+        },
+      },
+    });
+    await page.goto(`${server?.baseUrl ?? ""}sessions`);
+    const search = page.getByRole("search", { name: "Search transcripts" });
+    const input = search.getByRole("searchbox", { name: "Search session transcripts" });
+    await input.fill("Release notes");
+    await input.press("Enter");
+    await page.getByText("Release notes from the active task.", { exact: true }).waitFor();
+    expect((await gateway.getRequests("sessions.search"))[0]?.params).toMatchObject({
+      sessionKeys: ["agent:main:active"],
+    });
+
+    await page.locator('.sessions-view-segment wa-radio[value="archived"]').click();
+    await expect.poll(() => new URL(page!.url()).searchParams.get("status")).toBe("archived");
+    await page.locator(".session-data-row").getByText("Archived task", { exact: true }).waitFor();
+    await captureUiProof("filter-scope.png");
+    expect(await page.locator(".sessions-transcript-search__result").count()).toBe(0);
+    expect(await input.inputValue()).toBe("Release notes");
+    await gateway.setMethodResponse("sessions.search", { results: [] });
+    await input.press("Enter");
+    await expect.poll(async () => gateway.getRequests("sessions.search")).toHaveLength(2);
+    expect((await gateway.getRequests("sessions.search"))[1]?.params).toMatchObject({
+      sessionKeys: ["agent:main:archived"],
+    });
+  });
+
   it("finds a transcript when updated session order moves across a paged roster", async () => {
     const timestamp = Date.parse("2026-07-12T14:30:00.000Z");
     const first = { key: "agent:main:first", kind: "direct", updatedAt: timestamp };
@@ -249,7 +324,7 @@ describeControlUiE2e("Control UI session transcript search", () => {
       agentId: "main",
       limit: 25,
       query: "launch code",
-      sessionKeys: [first.key, moved.key, missed.key],
+      sessionKeys: [first.key, missed.key, moved.key],
     });
   });
 

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -181,6 +181,7 @@ describe("sessions page lifecycle", () => {
       count: 1,
       sessions: [{ key: "agent:main:launch" }],
     } as SessionsListResult;
+    vi.mocked(page.context.sessions.list).mockResolvedValue(page.result);
 
     page.updateTranscriptSearchQuery("  launch code  ");
     const pending = page.runTranscriptSearch();
@@ -245,6 +246,7 @@ describe("sessions page lifecycle", () => {
       count: 2,
       sessions: [{ key: "agent:main:one" }, { key: "agent:writer:one" }],
     } as SessionsListResult;
+    vi.mocked(context.sessions.list).mockResolvedValue(page.result);
 
     page.updateTranscriptSearchQuery("needle");
     await page.runTranscriptSearch();
@@ -345,6 +347,7 @@ describe("sessions page lifecycle", () => {
       count: 1,
       sessions: [{ key: "agent:main:stale" }],
     } as SessionsListResult;
+    vi.mocked(page.context.sessions.list).mockResolvedValue(page.result);
 
     page.updateTranscriptSearchQuery("old query");
     const pending = page.runTranscriptSearch();
@@ -388,6 +391,7 @@ describe("sessions page lifecycle", () => {
       count: 1,
       sessions: [{ key: "agent:main:stale" }],
     } as SessionsListResult;
+    vi.mocked(context.sessions.list).mockResolvedValue(page.result);
 
     page.updateTranscriptSearchQuery("needle");
     const pending = page.runTranscriptSearch();

--- a/ui/src/pages/sessions/sessions-page.transcript-search.test.ts
+++ b/ui/src/pages/sessions/sessions-page.transcript-search.test.ts
@@ -1,0 +1,125 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionsSearchResult } from "../../../../packages/gateway-protocol/src/index.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionsListResult } from "../../api/types.ts";
+import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
+import {
+  createContext,
+  createGateway,
+  createManagedSessions,
+  createRenderedPage,
+  createSessions,
+} from "./sessions-page.test-support.ts";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("Sessions transcript search scope", () => {
+  it("does not reuse old roster keys while a changed filter is loading", async () => {
+    const request = vi.fn(async () => ({ results: [] }));
+    const mutableGateway = createGateway({ request } as unknown as GatewayBrowserClient);
+    mutableGateway.emit({
+      hello: { features: { methods: ["sessions.search"] } } as ApplicationGatewaySnapshot["hello"],
+    });
+    const listed = {
+      count: 1,
+      sessions: [{ key: "agent:main:new-scope", kind: "direct" }],
+    } as SessionsListResult;
+    const managed = createManagedSessions({ list: vi.fn(async () => listed) });
+    const page = await createRenderedPage(createContext(mutableGateway.gateway, managed.sessions), {
+      count: 1,
+      sessions: [{ key: "agent:main:old-scope", kind: "direct" }],
+    } as SessionsListResult);
+    const unknown = page.querySelector<HTMLInputElement>('input[name="includeUnknown"]');
+    expect(unknown).toBeDefined();
+    unknown!.checked = true;
+    unknown!.dispatchEvent(new Event("change", { bubbles: true }));
+    await page.updateComplete;
+    page.updateTranscriptSearchQuery("needle");
+    await page.runTranscriptSearch();
+
+    expect(managed.sessions.list).toHaveBeenCalledWith(
+      expect.objectContaining({ includeUnknown: true }),
+    );
+    expect(request).toHaveBeenCalledWith(
+      "sessions.search",
+      expect.objectContaining({
+        sessionKeys: ["agent:main:new-scope"],
+      }),
+    );
+  });
+
+  it.each(["completed", "pending"])(
+    "retires %s active-session matches when the route changes to archived sessions",
+    async (completion) => {
+      let resolveSearch!: (value: SessionsSearchResult) => void;
+      const response = new Promise<SessionsSearchResult>((resolve) => {
+        resolveSearch = resolve;
+      });
+      const request = vi.fn(() => response);
+      const mutableGateway = createGateway({ request } as unknown as GatewayBrowserClient);
+      mutableGateway.emit({
+        hello: {
+          features: { methods: ["sessions.search"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const context = createContext(mutableGateway.gateway, createSessions());
+      const page = await createRenderedPage(context, {
+        count: 1,
+        sessions: [{ key: "agent:main:active", label: "Active task", archived: false }],
+      } as SessionsListResult);
+      vi.mocked(context.sessions.list).mockResolvedValue(page.result);
+      page.updateTranscriptSearchQuery("release notes");
+      const pending = page.runTranscriptSearch();
+      await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+      const result: SessionsSearchResult = {
+        results: [
+          {
+            sessionKey: "agent:main:active",
+            sessionId: "active",
+            messageId: "message-active",
+            role: "assistant",
+            timestamp: 42,
+            snippet: "release notes from the active task",
+            score: 1,
+          },
+        ],
+      };
+      if (completion === "completed") {
+        resolveSearch(result);
+        await pending;
+        await page.updateComplete;
+        expect(page.textContent).toContain("release notes from the active task");
+      }
+
+      page.routeData = {
+        gateway: context.gateway,
+        gatewaySnapshot: context.gateway.snapshot,
+        sessions: context.sessions,
+        result: {
+          count: 1,
+          sessions: [{ key: "agent:main:archived", label: "Archived task", archived: true }],
+        } as SessionsListResult,
+        loading: false,
+        error: null,
+        expandedSessionKey: null,
+        statusFilter: "archived",
+      };
+      await page.updateComplete;
+      if (completion === "pending") {
+        resolveSearch(result);
+        await pending;
+        await page.updateComplete;
+      }
+
+      expect(page.statusFilter).toBe("archived");
+      expect(page.textContent).not.toContain("release notes from the active task");
+      expect(page.transcriptSearchQuery).toBe("release notes");
+      expect(page.transcriptSearch).toEqual({ status: "idle" });
+    },
+  );
+});

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -207,7 +207,6 @@ class SessionsPage extends OpenClawLightDomElement {
       const result = await searchVisibleSessionTranscripts({
         client,
         query,
-        result: this.result,
         listSessions: context.sessions.list,
         listOptions: this.sessionListOptions(context),
         resolveAgentId: (sessionKey) =>
@@ -482,6 +481,8 @@ class SessionsPage extends OpenClawLightDomElement {
       return current;
     }
     this.unsubscribeList?.();
+    // Search hits and pending work belong to the roster query, not just its agent.
+    this.resetTranscriptSearchState(this.transcriptSearchQuery);
     const binding = { sessions, query, key };
     this.listBinding = binding;
     this.appliedListResult = undefined;


### PR DESCRIPTION
Closes #130377

## What Problem This Solves

Fixes an issue where users searching transcripts in the Control UI Sessions page would continue seeing matches from the previous session filter after switching to Archived or changing the roster filters. A search submitted while the new roster loaded could also search the previous roster's session keys.

## Why This Change Was Made

The Sessions page already scopes transcript searches to its roster query, but only query-text, agent, and connection changes retired the search results. The canonical session-list binding now retires both completed and pending searches whenever that query changes, retaining the text for resubmission. Searches enumerate the current query instead of mixing its filters with a retained last-good table snapshot.

No Gateway, authorization, storage, protocol, or configuration contract changes. The command palette already uses current-query enumeration and is unchanged. Production executable LOC is net zero; one brief ownership comment is the only net production growth. AI-assisted.

## User Impact

Transcript results follow the selected session scope. Changing a roster filter clears outdated matches without discarding the typed phrase; the next search uses the new scope even if the table is still loading. Table-only sorting, grouping, pagination, and metadata filtering do not reset transcript search.

## Evidence

- Reproduced on `a868258156a6708dd798deb3d43d3a4277a4d511`: three rendered-controller regressions failed before the repair, covering completed results, late responses, and a new search during roster replacement. All passed afterward.
- A real Chromium Control UI flow reproduced an active-task match above the Archived roster before the repair. The same flow passes afterward and verifies the next Gateway search contains only the archived session key. Before/after screenshots were inspected and contain synthetic fixtures only.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs ui/src/pages/sessions/sessions-page.transcript-search.test.ts ui/src/pages/sessions/sessions-page.test.ts ui/src/pages/sessions/sessions-page.roster.test.ts ui/src/pages/sessions/agent-scope.test.ts ui/src/pages/sessions/route.test.ts` — 54 passed.
- `OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-transcript-search.e2e.test.ts` — all seven browser scenarios passed, including pagination, request failures, and existing query invalidation.
- Independent verification reran 61 tests successfully and inspected both screenshots.
- `node scripts/check-changed.mjs -- ui/src/pages/sessions/sessions-page.ts ui/src/pages/sessions/sessions-page.test.ts ui/src/pages/sessions/sessions-page.transcript-search.test.ts ui/src/e2e/session-transcript-search.e2e.test.ts` — passed, including generic guards, dead-export checks, UI localization verification, core-test/UI types, typed lint, and stylelint.

Browser evidence uses a deterministic mocked Gateway, not an authenticated live provider. No model or channel credentials are involved.

Fresh authenticated Codex review completed with no actionable findings on the exact four-file candidate.

A separate source-blind validator exercised commit `643fe28bf244bbf12ba0d144093cac5ded5f8314` through a fresh Chromium instance and a declared stateful mock Gateway: all seven behavioral clauses passed, with no findings or blockers. It verified completed-search retirement, resubmission using only archived keys, an actually in-flight response released after switching scopes, the Unknown filter, table-only filtering without transcript invalidation, changed query/backend data, empty and no-match results, and reload. Requests and rendered outcomes were both observed; no source, tests, diffs, or component state were inspected. This companion proof does not claim real Gateway indexing or provider behavior.

Before: the Archived roster is visible, but the Active search match remains.

![Before: stale Active transcript match above Archived sessions](https://github.com/user-attachments/assets/f355567f-5cab-4e7a-aca4-6d307846d693)

After: the old match is retired while the search phrase is preserved.

![After: Archived sessions without stale Active transcript matches](https://github.com/user-attachments/assets/438846f5-58d7-442c-b1e9-924f9c037ba5)
