### PR TITLE
refactor(diagnostics): merge tool call content branches

### DIFF
--- a/extensions/diagnostics-otel/src/service-genai-content.ts
+++ b/extensions/diagnostics-otel/src/service-genai-content.ts
@@ -111,14 +111,10 @@ function contentParts(value: unknown): Record<string, unknown>[] {
     const text = textPartContent(part);
     if (text !== undefined) {
       parts.push(textPart(text));
-    } else if (part.type === "toolCall" && typeof part.name === "string") {
-      parts.push({
-        type: "tool_call",
-        name: part.name,
-        ...(typeof part.id === "string" ? { id: part.id } : {}),
-        ...(part.arguments !== undefined ? { arguments: part.arguments } : {}),
-      });
-    } else if (part.type === "tool_call" && typeof part.name === "string") {
+    } else if (
+      (part.type === "toolCall" || part.type === "tool_call") &&
+      typeof part.name === "string"
+    ) {
       parts.push({
         type: "tool_call",
         name: part.name,


### PR DESCRIPTION
## What Problem This Solves

OTEL GenAI content normalization handled camelCase `toolCall` and snake_case
`tool_call` parts in separate branches with byte-identical output projection.
Keeping both branches made one telemetry contract easier to drift.

## Why This Change Was Made

Both accepted input dialects now share one parenthesized condition and the same
existing bounded `{ type, name, id, arguments }` projection.

No helper, export, telemetry schema, SDK, config, persistence, or protocol
surface changed.

## User Impact

No user-visible behavior change. OTEL telemetry keeps accepting both tool-call
dialects while using one canonical projection path.

## Evidence

- Exact pushed head: `e58dd76185da6934156b560c001c4eb13cae08b7`
- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts` - 191/191 tests passed at exact head.
- Existing focused coverage exercises both camelCase `toolCall` and snake_case `tool_call`, including extra-field dropping.
- Native `scripts/pr review-tests 130379` - 191 tests passed.
- Blacksmith Testbox exact-head proof: provider `blacksmith-testbox`, lease `tbx_01m10m8pc1v0j79xqrv41qw5yr`, Actions run https://github.com/openclaw/openclaw/actions/runs/33036535570, exact head `e58dd76185da6934156b560c001c4eb13cae08b7`, 191/191 tests passed, timing JSON `exitCode=0` and `runStatus=succeeded`. The one-shot lease stopped after success.
- Native `node scripts/check-changed.mjs` passed every relevant changed-surface gate, including production/test typechecks, lint, dead exports, and import cycles, after a frozen install of the exact current lockfile.
- Fresh exact-head Autoreview: clean, 0.99, no actionable findings.
- AWS Crabbox run `run_26be8111a7e1`, lease `cbx_83b0a64fe369`: fresh public-network checkout, no instance role, no Tailscale, no hydration, frozen install, exact head `e58dd76185da6934156b560c001c4eb13cae08b7`, 191/191 tests passed. Lease released after proof.
- The trusted bootstrap was uploaded with a transient `umask 022` insertion because the current AWS image otherwise creates its Node install root as root-only and cannot expose the pinned binaries to the unprivileged test user. This is a Crabbox bootstrap follow-up, not a branch change.

Root cause: two adjacent OTEL input-dialect branches repeated the same validated projection.

Architectural owner and canonical fix: `contentParts` remains the private owner and now groups the two accepted type tags before one projection body.

Removed path: the second duplicate tool-call projection body.

Production LOC: +4/-8, net -4. Tests: +0/-0.

Sibling coverage: text, tool response, image, and malformed-part branches remain unchanged and retain their existing order.

Changelog: not required for an internal behavior-neutral refactor.

AI-assisted: yes.
