### PR TITLE
fix(gateway): return complete errors after HTTP route failures

### DIFF
--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -8,6 +8,7 @@ import {
   parseContentLengthHeader,
 } from "../logging/diagnostic-payload.js";
 import type { GatewayAuthResult } from "./auth.js";
+import { respondPlainText } from "./control-ui-http-utils.js";
 import { readJsonBody } from "./hooks.js";
 import { PROXY_ATTRIBUTION_REQUIRED_REASON } from "./ingress-attribution.js";
 
@@ -36,9 +37,23 @@ export function finishFailedGatewayHttpResponse(res: ServerResponse): void {
     return;
   }
   if (!res.headersSent) {
-    res.statusCode = 500;
-    res.setHeader("Content-Type", "text/plain; charset=utf-8");
-    res.end("Internal Server Error");
+    // Replace representation metadata, not request-owned security or CORS headers.
+    for (const header of [
+      "Content-Encoding",
+      "Content-Disposition",
+      "Content-Range",
+      "Content-Language",
+      "Content-Location",
+      "ETag",
+      "Last-Modified",
+      "Transfer-Encoding",
+      "Trailer",
+    ]) {
+      res.removeHeader(header);
+    }
+    res.setHeader("Cache-Control", "no-store");
+    res.statusMessage = "Internal Server Error";
+    respondPlainText(res, 500, res.statusMessage);
     return;
   }
 
@@ -52,15 +67,9 @@ export function sendJson(res: ServerResponse, status: number, body: unknown) {
   res.end(JSON.stringify(body));
 }
 
-function sendText(res: ServerResponse, status: number, body: string) {
-  res.statusCode = status;
-  res.setHeader("Content-Type", "text/plain; charset=utf-8");
-  res.end(body);
-}
-
 export function sendMethodNotAllowed(res: ServerResponse, allow = "POST") {
   res.setHeader("Allow", allow);
-  sendText(res, 405, "Method Not Allowed");
+  respondPlainText(res, 405, "Method Not Allowed");
 }
 
 export function sendUnauthorized(res: ServerResponse) {

--- a/src/gateway/server-http.request-trace.test.ts
+++ b/src/gateway/server-http.request-trace.test.ts
@@ -1,7 +1,7 @@
 // HTTP request trace tests ensure gateway request scope reaches logs and
 // diagnostic events for per-request debugging.
 import fs from "node:fs";
-import type { ServerResponse } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -18,6 +18,8 @@ import { getLogger, resetLogger, setLoggerOverride } from "../logging.js";
 import { flushLogger } from "../logging/logger.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import { createGatewayHttpServer } from "./server-http.js";
+import { createGatewayTestRegistry } from "./server/__tests__/test-utils.js";
+import { createGatewayPluginRequestHandler } from "./server/plugins-http.js";
 import { withTempConfig } from "./test-temp-config.js";
 
 const resolvedAuth: ResolvedGatewayAuth = { mode: "none", allowTailscale: false };
@@ -256,32 +258,105 @@ describe("gateway HTTP request error cleanup", () => {
     }
   });
 
-  it("preserves the 500 response when its route fails before writing headers", async () => {
-    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
-    const server = createGatewayHttpServer({
-      clients: new Set(),
-      controlUiEnabled: false,
-      controlUiBasePath: "",
-      openAiChatCompletionsEnabled: false,
-      openResponsesEnabled: false,
-      handleHooksRequest: async () => {
-        throw new Error("route failed before writing a response");
+  describe.each(["hook", "plugin"] as const)("uncommitted %s response failures", (owner) => {
+    it.each([
+      { label: "no staged headers", headers: {}, method: "GET" },
+      { label: "short length", headers: { "Content-Length": "1" }, method: "GET" },
+      { label: "long length", headers: { "Content-Length": "1000" }, method: "GET" },
+      { label: "gzip", headers: { "Content-Encoding": "gzip" }, method: "GET" },
+      {
+        label: "chunked trailers",
+        headers: { "Transfer-Encoding": "chunked", Trailer: "Digest" },
+        method: "GET",
       },
-      resolvedAuth,
-      getRuntimeConfig: () => ({}),
+      { label: "HEAD length", headers: { "Content-Length": "1000" }, method: "HEAD" },
+      {
+        label: "cached download",
+        headers: {
+          "Cache-Control": "public, max-age=31536000",
+          "Content-Disposition": "attachment; filename=report.txt",
+          "Content-Range": "bytes 0-99/1000",
+          "Content-Language": "fr",
+          "Content-Location": "/report.txt",
+          ETag: '"report-version"',
+          "Last-Modified": "Wed, 26 Aug 2026 12:00:00 GMT",
+        },
+        method: "GET",
+      },
+    ])("returns a complete plain 500 after $label", async ({ headers, method }) => {
+      const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+      const route = async (_req: IncomingMessage, res: ServerResponse) => {
+        for (const [name, value] of Object.entries(headers)) {
+          res.setHeader(name, value);
+        }
+        res.statusMessage = "Download Ready";
+        res.setHeader("Access-Control-Allow-Origin", "https://example.test");
+        throw new Error("route failed before writing a response");
+      };
+      const handlePluginRequest = createGatewayPluginRequestHandler({
+        registry: createGatewayTestRegistry({
+          httpRoutes: [
+            {
+              pluginId: "route",
+              source: "route",
+              path: "/failure",
+              auth: "plugin",
+              match: "exact",
+              handler: route,
+            },
+          ],
+        }),
+        log: { warn: vi.fn() } as unknown as Parameters<
+          typeof createGatewayPluginRequestHandler
+        >[0]["log"],
+      });
+      const server = createGatewayHttpServer({
+        clients: new Set(),
+        controlUiEnabled: false,
+        controlUiBasePath: "",
+        openAiChatCompletionsEnabled: false,
+        openResponsesEnabled: false,
+        handleHooksRequest: owner === "hook" ? route : async () => false,
+        handlePluginRequest: owner === "plugin" ? handlePluginRequest : undefined,
+        shouldEnforcePluginGatewayAuth: () => false,
+        resolvedAuth,
+        getRuntimeConfig: () => ({}),
+      });
+      const port = await listen(server);
+
+      try {
+        const response = await fetch(`http://127.0.0.1:${port}/failure`, {
+          method,
+          signal: AbortSignal.timeout(1_000),
+        });
+
+        expect(response.status).toBe(500);
+        expect.soft(response.statusText).toBe("Internal Server Error");
+        expect(await response.text()).toBe(method === "HEAD" ? "" : "Internal Server Error");
+        expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+        expect(response.headers.get("content-length")).toBe("21");
+        expect(response.headers.get("content-encoding")).toBeNull();
+        expect(response.headers.get("transfer-encoding")).toBeNull();
+        expect(response.headers.get("trailer")).toBeNull();
+        expect.soft(response.headers.get("cache-control")).toBe("no-store");
+        for (const header of [
+          "content-disposition",
+          "content-range",
+          "content-language",
+          "content-location",
+          "etag",
+          "last-modified",
+        ]) {
+          expect.soft(response.headers.get(header), header).toBeNull();
+        }
+        expect(response.headers.get("access-control-allow-origin")).toBe("https://example.test");
+        expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+      } finally {
+        server.closeAllConnections();
+        await closeServer(server);
+        errorLog.mockRestore();
+      }
     });
-    const port = await listen(server);
-
-    try {
-      const response = await fetch(`http://127.0.0.1:${port}/hooks/test`);
-
-      expect(response.status).toBe(500);
-      expect(await response.text()).toBe("Internal Server Error");
-    } finally {
-      server.closeAllConnections();
-      await closeServer(server);
-      errorLog.mockRestore();
-    }
   });
 
   it("preserves plugin route ownership when plugin dispatch fails", async () => {

--- a/src/gateway/server-http.test-harness.ts
+++ b/src/gateway/server-http.test-harness.ts
@@ -95,6 +95,7 @@ export function createResponse(): {
     headersSent: false,
     statusCode: 200,
     setHeader,
+    removeHeader: vi.fn(),
     end,
   } as unknown as ServerResponse;
   responseEndPromises.set(res, ended);

--- a/src/gateway/test-http-response.ts
+++ b/src/gateway/test-http-response.ts
@@ -26,6 +26,7 @@ export function makeMockHttpResponse(): {
     headersSent: false,
     statusCode: 200,
     setHeader,
+    removeHeader: vi.fn(),
     end,
   }) as unknown as ServerResponse;
   return { res, setHeader, end };


### PR DESCRIPTION
Closes #130380

## What Problem This Solves

Fixes an issue where users calling a Gateway HTTP route could receive a truncated or unreadable error, wait indefinitely for missing response bytes, or download/cache an error when the route failed after preparing success headers but before writing its response.

Actual localhost requests reproduced a one-character `I` response, a body waiting for an obsolete longer length, and invalid gzip decoding. Both normal Gateway handlers and registered plugin routes were affected. A connected case preserved a download's cache policy, attachment metadata, validators, and custom success reason on a 500.

## Why This Change Was Made

The shared HTTP failure owner now replaces a bounded set of representation/framing headers, disables caching of the replacement error, resets its reason phrase, and uses the existing plain-text response owner to provide the correct GET/HEAD content length. It retains security/CORS headers, already-completed responses, and termination of committed partial responses. The duplicate private plain-text writer is removed rather than adding a second error-response path.

No route admission, authentication, public protocol, configuration, or persisted-state contract changes. Production LOC is +19/-10 (net +9); tests and test support are +101/-24. The remaining production growth is the explicit metadata replacement policy needed to avoid wiping unrelated security/CORS headers.

## User Impact

Failed HTTP calls return the complete, non-cacheable plain-text 500 error instead of inheriting a failed download's encoding, length, cache policy, disposition, or validators. HEAD has the same correct representation length without a body. Existing successful and already-committed response behavior is preserved.

## Evidence

- Before editing production, the real Gateway HTTP regression failed ten framing cases across both hook and registered-plugin dispatch. A connected stale-metadata regression then failed both route owners with sixteen explicit assertion failures before its repair.
- Final focused proof passed **84 tests**; an independent reviewer reran **84/84** and found no actionable issue. Coverage includes short/long lengths, gzip, chunked trailers, HEAD, cached downloads, security/CORS preservation, completed/destroyed responses, committed partial failures, and existing HTTP helper/plugin behavior.
- Initial CI exposed the other shared HTTP test-response double missing the `removeHeader` method now used by the real response owner. Its unchanged MCP App admission suite reproduced the exact failure locally; adding only that missing mock binding fixed it. Expanded proof then passed **216 tests across 15 files**, covering all direct consumers of that harness plus the original HTTP suites. No production code or timeout was changed for this CI repair.
- A separate source-blind validator exercised **36 actual localhost HTTP requests** against an isolated running Gateway HTTP factory with controlled faults through both genuine route owners. All seven behavior-contract clauses passed with zero contract failures, including varied nonces, repeated/combined headers, HEAD metadata, security/CORS preservation, complete replies after late failure, and eight expected connection resets for incomplete/destroyed replies; no client timeout occurred. This is real HTTP fixture proof, not a packaged deployment or full agent-session claim. The task-owned server was stopped after validation.
- Command: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-http.request-trace.test.ts src/gateway/server/plugins-http.test.ts src/gateway/http-common.test.ts`.
- Actual targeted typed lint, formatting, and `git diff --check` passed. The changed gate passed its preceding guards and all unused-export scans, then stopped on preexisting installed-dependency type mismatches in untouched Google, markdown-it, and terminal code. The full local gate is not claimed green; exact-head CI must validate the pinned dependency environment before landing.
- Read the full shared response owner, both dispatch callers, existing plain-text sibling, regression suites, documented plugin HTTP route contract, and the installed Node response framing implementation. The uncommitted-error branch originates in #116874; #126130 repaired the separate committed-partial branch, whose behavior remains unchanged.
- Fresh authenticated Codex review of the complete three-file patch completed successfully with no actionable P0–P2 findings. Exact-head CI is required before landing.

AI-assisted repair. No runtime model or external service is needed for the HTTP proof.
