### PR TITLE
fix(browser): response body reads outlive their timeout

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -93,7 +93,6 @@ extensions/browser/src/browser/pw-tools-core.interactions.actions.ts	2
 extensions/browser/src/browser/pw-tools-core.interactions.content.ts	1
 extensions/browser/src/browser/pw-tools-core.interactions.execution.ts	4
 extensions/browser/src/browser/pw-tools-core.interactions.navigation.ts	3
-extensions/browser/src/browser/pw-tools-core.responses.ts	4
 extensions/browser/src/browser/pw-tools-core.snapshot.ts	2
 extensions/browser/src/browser/pw-tools-core.state.ts	3
 extensions/browser/src/browser/routes/agent.act.normalize.ts	2

--- a/extensions/browser/src/browser/pw-response-body.chromium.test.ts
+++ b/extensions/browser/src/browser/pw-response-body.chromium.test.ts
@@ -49,8 +49,7 @@ describe.runIf(process.env.OPENCLAW_BROWSER_RESPONSE_E2E === "1")(
         const { targetInfo } = await session.send("Target.getTargetInfo");
         await session.detach();
         const targetId = targetInfo.targetId;
-        const controlledPage = await getPageForTargetId({ cdpUrl, targetId });
-        const listeners = controlledPage.listenerCount("response");
+        await getPageForTargetId({ cdpUrl, targetId });
         let outcome: unknown = "pending";
         const result = responseBodyViaPlaywright({
           cdpUrl,
@@ -61,13 +60,11 @@ describe.runIf(process.env.OPENCLAW_BROWSER_RESPONSE_E2E === "1")(
           (value) => (outcome = value),
           (error: unknown) => (outcome = error),
         );
-        await expect.poll(() => controlledPage.listenerCount("response")).toBe(listeners + 1);
         await page.getByRole("button", { name: "Fetch" }).click();
         await expect.poll(() => streams.size).toBe(1);
         try {
           await expect.poll(() => outcome, { timeout: 2_000 }).toBeInstanceOf(Error);
           expect(String(outcome)).toMatch(/timed out|timeout/i);
-          expect(controlledPage.listenerCount("response")).toBe(listeners);
           expect(page.isClosed()).toBe(false);
         } finally {
           for (const stream of streams) {

--- a/extensions/browser/src/browser/pw-response-body.chromium.test.ts
+++ b/extensions/browser/src/browser/pw-response-body.chromium.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs/promises";
+import { createServer, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test-support.js";
+import { getPlaywrightCore } from "./playwright-core.runtime.js";
+import { closePlaywrightBrowserConnection, getPageForTargetId } from "./pw-session.js";
+import { responseBodyViaPlaywright } from "./pw-tools-core.responses.js";
+import { getFreePort } from "./test-port.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe.runIf(process.env.OPENCLAW_BROWSER_RESPONSE_E2E === "1")(
+  "Chromium response body deadline",
+  () => {
+    it("settles a streamed response without closing the tab or consuming late body bytes", async () => {
+      const rootDir = tempDirs.make("openclaw-response-deadline-");
+      const streams = new Set<ServerResponse>();
+      const server = createServer((request, response) => {
+        if (request.url === "/api") {
+          streams.add(response);
+          response.on("close", () => streams.delete(response));
+          response.writeHead(200, { "content-type": "text/plain" });
+          response.write("incomplete response");
+          return;
+        }
+        response.writeHead(200, { "content-type": "text/html" });
+        response.end("<button onclick=\"fetch('/api')\">Fetch</button>");
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const port = (server.address() as AddressInfo).port;
+      const cdpPort = await getFreePort();
+      const cdpUrl = `http://127.0.0.1:${cdpPort}`;
+      const context = await getPlaywrightCore().chromium.launchPersistentContext(
+        path.join(rootDir, "profile"),
+        {
+          headless: true,
+          executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+          args: [`--remote-debugging-port=${cdpPort}`],
+        },
+      );
+      try {
+        const page = context.pages()[0] ?? (await context.newPage());
+        await page.goto(`http://127.0.0.1:${port}`);
+        const session = await context.newCDPSession(page);
+        const { targetInfo } = await session.send("Target.getTargetInfo");
+        await session.detach();
+        const targetId = targetInfo.targetId;
+        const controlledPage = await getPageForTargetId({ cdpUrl, targetId });
+        const listeners = controlledPage.listenerCount("response");
+        let outcome: unknown = "pending";
+        const result = responseBodyViaPlaywright({
+          cdpUrl,
+          targetId,
+          url: "**/api",
+          timeoutMs: 500,
+        }).then(
+          (value) => (outcome = value),
+          (error: unknown) => (outcome = error),
+        );
+        await expect.poll(() => controlledPage.listenerCount("response")).toBe(listeners + 1);
+        await page.getByRole("button", { name: "Fetch" }).click();
+        await expect.poll(() => streams.size).toBe(1);
+        try {
+          await expect.poll(() => outcome, { timeout: 2_000 }).toBeInstanceOf(Error);
+          expect(String(outcome)).toMatch(/timed out|timeout/i);
+          expect(controlledPage.listenerCount("response")).toBe(listeners);
+          expect(page.isClosed()).toBe(false);
+        } finally {
+          for (const stream of streams) {
+            stream.end("late bytes");
+          }
+          await result;
+        }
+      } finally {
+        await closePlaywrightBrowserConnection({ cdpUrl });
+        await context.close();
+        for (const stream of streams) {
+          stream.destroy();
+        }
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+        await fs.rm(rootDir, { recursive: true, force: true });
+      }
+    }, 20_000);
+  },
+);

--- a/extensions/browser/src/browser/pw-tools-core.responses.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.responses.test.ts
@@ -62,7 +62,7 @@ describe("response body operation lifecycle", () => {
   it.each(["headers", "body"])("honors caller cancellation while waiting for %s", async (phase) => {
     const controller = new AbortController();
     const reason = new Error("response request cancelled");
-    const body = vi.fn(async () => Buffer.from("late response"));
+    const body = vi.fn(async (): Promise<Buffer> => Buffer.from("late response"));
     let finishBody!: (body: Buffer) => void;
     if (phase === "body") {
       body.mockImplementation(

--- a/extensions/browser/src/browser/pw-tools-core.responses.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.responses.test.ts
@@ -1,0 +1,159 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { responseBodyViaPlaywright } from "./pw-tools-core.responses.js";
+
+const mocks = vi.hoisted(() => ({
+  getPageForTargetId: vi.fn(),
+  ensurePageState: vi.fn(),
+}));
+vi.mock("./pw-session.js", () => mocks);
+
+describe("response body operation lifecycle", () => {
+  let page: EventEmitter;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    page = new EventEmitter();
+    mocks.getPageForTargetId.mockResolvedValue(page);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  const options = { cdpUrl: "http://127.0.0.1:18792", url: "**/api", timeoutMs: 500 };
+
+  function response(body: () => Promise<Buffer>) {
+    return {
+      url: () => "https://example.com/api",
+      status: () => 200,
+      headers: () => ({ "content-type": "text/plain" }),
+      body,
+    };
+  }
+
+  it.each([0, 400])("keeps the total deadline when headers take %i ms", async (headerDelay) => {
+    let finishBody!: (body: Buffer) => void;
+    const pendingBody = new Promise<Buffer>((resolve) => {
+      finishBody = resolve;
+    });
+    const body = vi.fn(() => pendingBody);
+    const result = responseBodyViaPlaywright(options).then(
+      () => "success",
+      (error: unknown) => error,
+    );
+    let outcome: unknown = "pending";
+    void result.then((value) => (outcome = value));
+    await vi.advanceTimersByTimeAsync(headerDelay);
+    page.emit("response", response(body));
+    await vi.advanceTimersByTimeAsync(500 - headerDelay);
+    try {
+      expect(outcome).toBeInstanceOf(Error);
+      expect(String(outcome)).toMatch(/timed out|timeout/i);
+      expect(page.listenerCount("response")).toBe(0);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      finishBody(Buffer.from("late response"));
+      await result;
+    }
+  });
+
+  it.each(["headers", "body"])("honors caller cancellation while waiting for %s", async (phase) => {
+    const controller = new AbortController();
+    const reason = new Error("response request cancelled");
+    const body = vi.fn(async () => Buffer.from("late response"));
+    let finishBody!: (body: Buffer) => void;
+    if (phase === "body") {
+      body.mockImplementation(
+        () =>
+          new Promise<Buffer>((resolve) => {
+            finishBody = resolve;
+          }),
+      );
+    }
+    const opts = { ...options, signal: controller.signal };
+    const result = responseBodyViaPlaywright(opts).then(
+      () => "success",
+      (error: unknown) => error,
+    );
+    let outcome: unknown = "pending";
+    void result.then((value) => (outcome = value));
+    await vi.advanceTimersByTimeAsync(0);
+    if (phase === "body") {
+      page.emit("response", response(body));
+      await vi.advanceTimersByTimeAsync(0);
+    }
+    controller.abort(reason);
+    await vi.advanceTimersByTimeAsync(0);
+    try {
+      expect(outcome).toBe(reason);
+      expect(page.listenerCount("response")).toBe(0);
+    } finally {
+      if (phase === "body") {
+        finishBody(Buffer.from("late response"));
+      } else {
+        page.emit("response", response(body));
+      }
+      await result;
+    }
+    if (phase === "headers") {
+      expect(body).not.toHaveBeenCalled();
+    }
+  });
+
+  it("preserves the missing-response recovery hint and removes its listeners", async () => {
+    const result = responseBodyViaPlaywright(options).catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(String(await result)).toContain("openclaw browser requests");
+    expect(page.eventNames()).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not resolve a page for an already cancelled caller", async () => {
+    const reason = new Error("already cancelled");
+    const opts = { ...options, signal: AbortSignal.abort(reason) };
+    await expect(responseBodyViaPlaywright(opts)).rejects.toBe(reason);
+    expect(mocks.getPageForTargetId).not.toHaveBeenCalled();
+  });
+
+  it("selects only the first matching response and clears its deadline", async () => {
+    const result = responseBodyViaPlaywright(options);
+    const ignoredBody = vi.fn(async () => Buffer.from("ignored"));
+    const firstBody = Buffer.from("first response");
+    await vi.advanceTimersByTimeAsync(0);
+    page.emit("response", { ...response(ignoredBody), url: () => "https://example.com/other" });
+    page.emit(
+      "response",
+      response(async () => firstBody),
+    );
+    page.emit("response", response(ignoredBody));
+    await expect(result).resolves.toMatchObject({ body: "first response", status: 200 });
+    expect(ignoredBody).not.toHaveBeenCalled();
+    expect(page.eventNames()).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("settles page closure and absorbs a late body failure", async () => {
+    let rejectBody!: (reason: Error) => void;
+    const result = responseBodyViaPlaywright(options).catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(0);
+    page.emit(
+      "response",
+      response(
+        () =>
+          new Promise<Buffer>((_resolve, reject) => {
+            rejectBody = reject;
+          }),
+      ),
+    );
+    page.emit("close");
+    await expect(result).resolves.toMatchObject({
+      message: "Page closed before response body was available.",
+    });
+    rejectBody(new Error("late transport failure"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(page.eventNames()).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/extensions/browser/src/browser/pw-tools-core.responses.ts
+++ b/extensions/browser/src/browser/pw-tools-core.responses.ts
@@ -3,6 +3,8 @@
  */
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import type { Response } from "playwright-core";
+import { toErrorObject } from "../infra/errors.js";
 import { ensurePageState, getPageForTargetId } from "./pw-session.js";
 import { normalizeTimeoutMs } from "./pw-tools-core.shared.js";
 import { matchBrowserUrlPattern } from "./url-pattern.js";
@@ -14,6 +16,7 @@ export async function responseBodyViaPlaywright(opts: {
   url: string;
   timeoutMs?: number;
   maxChars?: number;
+  signal?: AbortSignal;
 }): Promise<{
   url: string;
   status?: number;
@@ -32,84 +35,68 @@ export async function responseBodyViaPlaywright(opts: {
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
   const maxBytes = maxChars * 4;
 
+  opts.signal?.throwIfAborted();
   const page = await getPageForTargetId(opts);
+  opts.signal?.throwIfAborted();
   ensurePageState(page);
 
-  const promise = new Promise<unknown>((resolve, reject) => {
-    let done = false;
-    let timer: NodeJS.Timeout | undefined;
-
-    const cleanup = () => {
-      if (timer) {
-        clearTimeout(timer);
+  let cleanup!: () => void;
+  const promise = new Promise<{ response: Response; buffer: Buffer }>((resolve, reject) => {
+    let matched = false;
+    const handler = (response: Response) => {
+      if (matched || !matchBrowserUrlPattern(pattern, response.url())) {
+        return;
       }
-      timer = undefined;
-      if (handler) {
-        page.off("response", handler as never);
-      }
+      matched = true;
+      page.off("response", handler);
+      // Response headers arrive before the body completes. Keep the same
+      // deadline and cancellation owner until those bytes are available.
+      void response.body().then(
+        (buffer) => resolve({ response, buffer }),
+        (error: unknown) =>
+          reject(
+            new Error(`Failed to read response body for "${response.url()}": ${String(error)}`, {
+              cause: error,
+            }),
+          ),
+      );
     };
-
-    const handler: ((resp: unknown) => void) | undefined = (resp: unknown) => {
-      if (done) {
-        return;
-      }
-      const r = resp as { url?: () => string };
-      const u = r.url?.() || "";
-      if (!matchBrowserUrlPattern(pattern, u)) {
-        return;
-      }
-      done = true;
-      cleanup();
-      resolve(resp);
-    };
-
-    page.on("response", handler as never);
-    timer = setTimeout(() => {
-      if (done) {
-        return;
-      }
-      done = true;
-      cleanup();
+    const onAbort = () => reject(toErrorObject(opts.signal?.reason, "Response request aborted."));
+    const onClose = () => reject(new Error("Page closed before response body was available."));
+    const timer = setTimeout(() => {
       reject(
         new Error(
-          `Response not found for url pattern "${pattern}". Run 'openclaw browser requests' to inspect recent network activity.`,
+          matched
+            ? `Response body timed out after ${timeout}ms for url pattern "${pattern}".`
+            : `Response not found for url pattern "${pattern}". Run 'openclaw browser requests' to inspect recent network activity.`,
         ),
       );
     }, timeout);
+    cleanup = () => {
+      clearTimeout(timer);
+      page.off("response", handler);
+      page.off("close", onClose);
+      opts.signal?.removeEventListener("abort", onAbort);
+    };
+    page.on("response", handler);
+    page.on("close", onClose);
+    opts.signal?.addEventListener("abort", onAbort, { once: true });
   });
 
-  const resp = (await promise) as {
-    url?: () => string;
-    status?: () => number;
-    headers?: () => Record<string, string>;
-    body?: () => Promise<Buffer>;
-    text?: () => Promise<string>;
-  };
-
-  const url = resp.url?.() || "";
-  const status = resp.status?.();
-  const headers = resp.headers?.();
-
-  let bodyText = "";
-  let bodyByteLength = 0;
   try {
-    if (typeof resp.body === "function") {
-      const buf = await resp.body();
-      bodyByteLength = buf.byteLength;
-      // Playwright exposes only a full-body Buffer. Bound the second allocation
-      // while preserving the existing response-prefix contract.
-      bodyText = new TextDecoder("utf-8").decode(buf.subarray(0, maxBytes));
-    }
-  } catch (err) {
-    throw new Error(`Failed to read response body for "${url}": ${String(err)}`, { cause: err });
+    const { response, buffer } = await promise;
+    // Playwright exposes only a full-body Buffer. Bound the second allocation
+    // while preserving the existing response-prefix contract.
+    const bodyText = new TextDecoder("utf-8").decode(buffer.subarray(0, maxBytes));
+    const body = bodyText.length > maxChars ? truncateUtf16Safe(bodyText, maxChars) : bodyText;
+    return {
+      url: response.url(),
+      status: response.status(),
+      headers: response.headers(),
+      body,
+      truncated: buffer.byteLength > maxBytes || bodyText.length > maxChars ? true : undefined,
+    };
+  } finally {
+    cleanup();
   }
-
-  const trimmed = bodyText.length > maxChars ? truncateUtf16Safe(bodyText, maxChars) : bodyText;
-  return {
-    url,
-    status,
-    headers,
-    body: trimmed,
-    truncated: bodyByteLength > maxBytes || bodyText.length > maxChars ? true : undefined,
-  };
 }

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -805,6 +805,7 @@ export function registerBrowserAgentActRoutes(
         const result = await pw.responseBodyViaPlaywright({
           cdpUrl,
           targetId: tab.targetId,
+          signal,
           url,
           timeoutMs: timeoutMs ?? undefined,
           maxChars: maxChars ?? undefined,

--- a/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -845,37 +845,47 @@ describe("browser control server", () => {
     expect(String(waitCall.path)).toContain("safe-wait.pdf");
   });
 
-  it("cancels wait/download when its HTTP caller disconnects", async () => {
-    const base = await startServerAndBase();
-    let operationSignal: AbortSignal | undefined;
-    requirePwMock("waitForDownloadViaPlaywright").mockImplementationOnce(async (value) => {
-      const options = value as { signal?: AbortSignal };
-      operationSignal = options.signal;
-      await new Promise<void>((_resolve, reject) => {
-        options.signal?.addEventListener(
-          "abort",
-          () => {
-            const reason = options.signal?.reason;
-            reject(reason instanceof Error ? reason : new Error("request aborted"));
-          },
-          { once: true },
-        );
+  it.each([
+    {
+      route: "/wait/download",
+      mockName: "waitForDownloadViaPlaywright",
+      body: { path: "cancelled-wait.pdf" },
+    },
+    { route: "/response/body", mockName: "responseBodyViaPlaywright", body: { url: "**/api" } },
+  ] as const)(
+    "cancels $route when its HTTP caller disconnects",
+    async ({ route, mockName, body }) => {
+      const base = await startServerAndBase();
+      let operationSignal: AbortSignal | undefined;
+      requirePwMock(mockName).mockImplementationOnce(async (value) => {
+        const options = value as { signal?: AbortSignal };
+        operationSignal = options.signal;
+        await new Promise<void>((_resolve, reject) => {
+          options.signal?.addEventListener(
+            "abort",
+            () => {
+              const reason = options.signal?.reason;
+              reject(reason instanceof Error ? reason : new Error("request aborted"));
+            },
+            { once: true },
+          );
+        });
+        throw new Error("unreachable");
       });
-      throw new Error("unreachable");
-    });
-    const controller = new AbortController();
-    const response = realFetch(`${base}/wait/download`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path: "cancelled-wait.pdf" }),
-      signal: controller.signal,
-    });
+      const controller = new AbortController();
+      const response = realFetch(`${base}${route}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
 
-    await vi.waitFor(() => expect(operationSignal).toBeInstanceOf(AbortSignal));
-    controller.abort(new Error("caller disconnected"));
-    await expect(response).rejects.toThrow();
-    await vi.waitFor(() => expect(operationSignal?.aborted).toBe(true));
-  });
+      await vi.waitFor(() => expect(operationSignal).toBeInstanceOf(AbortSignal));
+      controller.abort(new Error("caller disconnected"));
+      await expect(response).rejects.toThrow();
+      await vi.waitFor(() => expect(operationSignal?.aborted).toBe(true));
+    },
+  );
 
   it("download accepts in-root relative output path", async () => {
     const base = await startServerAndBase();

--- a/extensions/browser/src/cli/browser-cli-actions-observe.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-observe.ts
@@ -88,7 +88,7 @@ export function registerBrowserActionObserveCommands(
     .option("--target-id <id>", BROWSER_TAB_REFERENCE_HELP)
     .option(
       "--timeout-ms <ms>",
-      "How long to wait for the response (default: 20000)",
+      "How long to wait for the complete response body (default: 20000)",
       (v: string) => parseBrowserPositiveIntegerOption(v, "--timeout-ms"),
     )
     .option("--max-chars <n>", "Max body chars to return (default: 200000)", (v: string) =>


### PR DESCRIPTION
Closes #130384

## What Problem This Solves

Fixes an issue where users running `openclaw browser responsebody` could keep waiting after their requested timeout when a server sent response headers but never finished its body. Disconnecting the request also left the browser operation waiting, which could delay profile cleanup.

## Why This Change Was Made

Keep the existing operation deadline alive until the complete body is available, and connect the HTTP caller's cancellation to that same owner. The first matching response remains selected; completion, cancellation, page closure, and timeout all retire the operation's listeners and timer. This does not close the user's tab, disconnect sibling operations, or change the timeout limits.

The implementation now uses Playwright's actual `Response` contract instead of speculative structural casts. Production code is net -12 lines; the assertion-safety baseline loses the corresponding four obsolete assertions. This repair is AI-assisted.

## User Impact

Incomplete or streaming responses now produce a bounded, visible timeout. Cancelled requests settle promptly, and the browser remains available for subsequent work. Existing response metadata, URL matching, body prefixes, and UTF-16-safe truncation are preserved. The CLI help clarifies that the timeout covers the complete response body.

## Evidence

- Reproduced before editing production: all three initial lifecycle regressions failed because the operation remained pending after its deadline or caller cancellation.
- Real Chromium, a temporary profile/private CDP port, and a localhost HTTP server reproduced the same failure: an incomplete body stayed pending beyond a 500 ms timeout and a 2000 ms observation. The same flow passes after the fix, without using the operator's browser or Gateway.
- Final owner proof: 74 tests passed across the response lifecycle, real Chromium, existing response/download, real HTTP caller-disconnect, and browser CLI suites.
- Independent proof: 75 cases passed, including first-match selection and a real browser interaction after timeout; 13 overlapping delta checks passed again on the final Error-normalization, test-executor, and assertion-ratchet cleanup changes (not 88 unique cases).
- Targeted typed lint, formatting/diff checks, max-lines/environment ratchets, and assertion-safety ratchet passed. Local stale dependencies were corrected only by linking already installed, manifest-matching packages in this task's ignored dependency directory; no shared installation was modified.
- Fresh authenticated whole-diff Codex review found no actionable P0–P2 defects.
- Fresh source-blind validation through the actual Browser HTTP API and isolated Chromium passed all six contract clauses: changing matched body/status, incomplete-body deadline, one headers-plus-body budget, unmatched recovery hint, caller cancellation followed by profile stop/start and a fresh action/body, and Unicode-safe truncation. The 500 ms deadline returned in 535 ms; the 1500 ms total budget returned in 1531 ms; profile stop after cancellation returned in 28 ms.

The validator also checked empty responses. A discarded page fetch was recorded by the public requests API as `ok:false` with `net::ERR_ABORTED`, even though its headers carried HTTP 200; consuming the completed empty response returned the expected empty body. The same distinction was reproduced on prepatch main and raw Playwright, so no empty-body fallback was added.

Initial CI found only test-type errors: the Chromium test used a listener-count method absent from Playwright's public `Page` type, and the cancellation fixture inferred too narrow a Buffer type. The follow-up removes the redundant listener introspection (unit cleanup assertions remain) and types the fixture's producer. Nine focused tests including Chromium, a targeted test typecheck, typed lint, and formatting pass after that test-only correction. Production bytes are unchanged. Fresh full CI on `a66c97fa3555acf5863c05b73c0d98e665a555f7` passed every selected lane and `openclaw/ci-gate`: [run 33012791603](https://github.com/openclaw/openclaw/actions/runs/33012791603).

Focused test command:

```sh
OPENCLAW_BROWSER_RESPONSE_E2E=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/browser/src/browser/pw-tools-core.responses.test.ts extensions/browser/src/browser/pw-response-body.chromium.test.ts extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts extensions/browser/src/cli/browser-cli-actions-observe.test.ts
```

Directly inspected Playwright 1.62.1: `Response.body()` uses no deadline and waits for the request to finish, so observing response headers is not completion proof. No new dependency, configuration, storage, public API, or browser policy is introduced.
