### PR TITLE
fix(failover): classify bare "Model is unavailable." as model_not_found

### DIFF
--- a/src/agents/failover/classify.message-predicates.test.ts
+++ b/src/agents/failover/classify.message-predicates.test.ts
@@ -43,6 +43,45 @@ describe("GENERIC_MODEL_NOT_FOUND_RE (#19 bare-unavailable RCA)", () => {
   });
 });
 
+describe("classify.ts full pipeline: A-F required cases (#130389 ClawSweeper re-review)", () => {
+  it("A: bare plan-entitlement prose (no Z.ai code marker) classifies as billing", () => {
+    expect(classifyFailoverReason("The model is unavailable in your current plan")).toBe("billing");
+  });
+
+  it("B: original 'not available ... current plan' wording classifies as billing", () => {
+    expect(
+      classifyFailoverReason("The model you requested is not available in your current plan"),
+    ).toBe("billing");
+  });
+
+  it("C: Z.ai code:1311 JSON with 'is unavailable' wording classifies as billing", () => {
+    expect(
+      classifyFailoverReason(
+        '{"code":1311,"message":"The model is unavailable in your current plan"}',
+      ),
+    ).toBe("billing");
+  });
+
+  it("D: bare 'Model is unavailable.' classifies as model_not_found", () => {
+    expect(classifyFailoverReason("Model is unavailable.")).toBe("model_not_found");
+  });
+
+  it("E: exact production body classifies as model_not_found", () => {
+    expect(
+      classifyFailoverReason(
+        "400 Error from provider (Console): Upstream request failed: Model is unavailable.",
+      ),
+    ).toBe("model_not_found");
+  });
+
+  it("F: unrelated service/provider-unavailable wording is not model_not_found", () => {
+    expect(classifyFailoverReason("503 service unavailable")).not.toBe("model_not_found");
+    expect(classifyFailoverReason("The model service is temporarily unavailable")).not.toBe(
+      "model_not_found",
+    );
+  });
+});
+
 describe("Z.ai vendor error codes (#48988)", () => {
   describe("error 1311 — model not included in subscription plan", () => {
     it("classifies Z.ai 1311 JSON body as billing", () => {

--- a/src/agents/failover/classify.message-predicates.test.ts
+++ b/src/agents/failover/classify.message-predicates.test.ts
@@ -11,11 +11,35 @@ import {
   isTimeoutErrorMessage,
   matchesFormatErrorPattern,
 } from "./classify.js";
+import { GENERIC_MODEL_NOT_FOUND_RE } from "./message-patterns.js";
 import { renderRateLimitOrOverloadedCopy } from "./user-copy.js";
 
 describe("matchesFormatErrorPattern", () => {
   it("retains the direct format compatibility predicate", () => {
     expect(matchesFormatErrorPattern("invalid request format")).toBe(true);
+  });
+});
+
+describe("GENERIC_MODEL_NOT_FOUND_RE (#19 bare-unavailable RCA)", () => {
+  it("matches the exact production body: bare 'Model is unavailable.' (no 'not')", () => {
+    expect(
+      GENERIC_MODEL_NOT_FOUND_RE.test(
+        "400 Error from provider (Console): Upstream request failed: Model is unavailable.",
+      ),
+    ).toBe(true);
+    expect(GENERIC_MODEL_NOT_FOUND_RE.test("Model is unavailable.")).toBe(true);
+  });
+
+  it("still matches the original 'not found'/'not available' wording", () => {
+    expect(GENERIC_MODEL_NOT_FOUND_RE.test("model not found")).toBe(true);
+    expect(GENERIC_MODEL_NOT_FOUND_RE.test("model not available")).toBe(true);
+  });
+
+  it("does not fire on unrelated 'unavailable' wording that doesn't name the model", () => {
+    expect(GENERIC_MODEL_NOT_FOUND_RE.test("503 service unavailable")).toBe(false);
+    expect(GENERIC_MODEL_NOT_FOUND_RE.test("The model service is temporarily unavailable")).toBe(
+      false,
+    );
   });
 });
 

--- a/src/agents/failover/classify.message-predicates.test.ts
+++ b/src/agents/failover/classify.message-predicates.test.ts
@@ -40,6 +40,9 @@ describe("GENERIC_MODEL_NOT_FOUND_RE (#19 bare-unavailable RCA)", () => {
     expect(GENERIC_MODEL_NOT_FOUND_RE.test("The model service is temporarily unavailable")).toBe(
       false,
     );
+    // "service", not the model itself, is the subject that is unavailable —
+    // must not match even though "model" and "is unavailable" both appear.
+    expect(GENERIC_MODEL_NOT_FOUND_RE.test("The model service is unavailable.")).toBe(false);
   });
 });
 
@@ -75,10 +78,15 @@ describe("classify.ts full pipeline: A-F required cases (#130389 ClawSweeper re-
   });
 
   it("F: unrelated service/provider-unavailable wording is not model_not_found", () => {
+    // "The model service is unavailable." previously matched: the old
+    // "model" ... ".{0,60}?" ... "is unavailable" alternative tolerated
+    // arbitrary intervening text, so "service" between "model" and "is
+    // unavailable" still satisfied it (#130389 ClawSweeper re-review).
     expect(classifyFailoverReason("503 service unavailable")).not.toBe("model_not_found");
     expect(classifyFailoverReason("The model service is temporarily unavailable")).not.toBe(
       "model_not_found",
     );
+    expect(classifyFailoverReason("The model service is unavailable.")).not.toBe("model_not_found");
   });
 });
 

--- a/src/agents/failover/failover-classification.corpus.test.ts
+++ b/src/agents/failover/failover-classification.corpus.test.ts
@@ -196,6 +196,18 @@ describe("cross-layer drift (documents current behavior, see refactor-02)", () =
     expect(classifyReplyRequest({ message })).toMatchObject({ code: "provider_model_unavailable" });
   });
 
+  it("classifies bare plan-entitlement prose (no Z.ai code marker) as billing, not model_not_found", () => {
+    // ClawSweeper (#130389 re-review): the billing plan-entitlement pattern
+    // only recognized "not available ... current plan"; "is unavailable ...
+    // current plan" is the same equivalent plan-entitlement wording but,
+    // without a "code":1311 (or similar) marker, previously fell through
+    // billing entirely and was picked up by the widened generic model regex.
+    const message = "The model is unavailable in your current plan";
+    const classification = classifyFailoverSignal({ message });
+
+    expect(classification).toEqual({ kind: "reason", reason: "billing" });
+  });
+
   it("keeps billing/plan-entitlement precedence over the literal bare model-unavailable phrase", () => {
     // This phrase contains the exact literal substring the bare-unavailable
     // fix matches ("model" ... "is unavailable"), so it is the phrase that

--- a/src/agents/failover/failover-classification.corpus.test.ts
+++ b/src/agents/failover/failover-classification.corpus.test.ts
@@ -184,6 +184,29 @@ describe("cross-layer drift (documents current behavior, see refactor-02)", () =
     expect(classifyReplyRequest({ message })).toMatchObject({ code: "provider_model_unavailable" });
   });
 
+  it("classifies bare 'Model is unavailable.' as model_not_found, not the generic format fallback", () => {
+    // OpenCode Zen's actual withdrawn-route body (#19 RCA): no "not found"/"not
+    // available" wording, so this previously fell through to the HTTP-400
+    // default `format` reason instead of the correct model-unavailable copy.
+    const message =
+      "400 Error from provider (Console): Upstream request failed: Model is unavailable.";
+    const classification = classifyFailoverSignal({ message });
+
+    expect(classification).toEqual({ kind: "reason", reason: "model_not_found" });
+    expect(classifyReplyRequest({ message })).toMatchObject({ code: "provider_model_unavailable" });
+  });
+
+  it("keeps billing/plan-entitlement precedence over the bare model-unavailable wording", () => {
+    // Billing/plan text must still win even though it also contains "model" +
+    // "unavailable"-adjacent wording; precedence is enforced by check ordering
+    // in classifyFailoverClassificationFromMessage, not by regex exclusivity.
+    const message =
+      '{"code":1311,"message":"The model you requested is not available in your current plan"}';
+    const classification = classifyFailoverSignal({ message });
+
+    expect(classification).toEqual({ kind: "reason", reason: "billing" });
+  });
+
   it.each([
     "Custom tool call output is missing for call id: call_live_123.",
     "The number of toolResult blocks at messages.186.content exceeds the number of toolUse blocks of previous turn.",

--- a/src/agents/failover/failover-classification.corpus.test.ts
+++ b/src/agents/failover/failover-classification.corpus.test.ts
@@ -196,10 +196,22 @@ describe("cross-layer drift (documents current behavior, see refactor-02)", () =
     expect(classifyReplyRequest({ message })).toMatchObject({ code: "provider_model_unavailable" });
   });
 
-  it("keeps billing/plan-entitlement precedence over the bare model-unavailable wording", () => {
-    // Billing/plan text must still win even though it also contains "model" +
-    // "unavailable"-adjacent wording; precedence is enforced by check ordering
-    // in classifyFailoverClassificationFromMessage, not by regex exclusivity.
+  it("keeps billing/plan-entitlement precedence over the literal bare model-unavailable phrase", () => {
+    // This phrase contains the exact literal substring the bare-unavailable
+    // fix matches ("model" ... "is unavailable"), so it is the phrase that
+    // actually exercises the new detector's collision risk against billing —
+    // unlike the older "not available ... current plan" sample below, which
+    // never reaches the new regex at all. The "code":1311 marker is required
+    // for this exact prose to classify as billing at all (bare prose without
+    // a billing marker doesn't match isBillingErrorMessage on its own).
+    // Billing/plan wording must still win despite also matching the new regex.
+    const message = '{"code":1311,"message":"The model is unavailable in your current plan"}';
+    const classification = classifyFailoverSignal({ message });
+
+    expect(classification).toEqual({ kind: "reason", reason: "billing" });
+  });
+
+  it("keeps billing/plan-entitlement precedence over 'not available' wording", () => {
     const message =
       '{"code":1311,"message":"The model you requested is not available in your current plan"}';
     const classification = classifyFailoverSignal({ message });

--- a/src/agents/failover/message-patterns.ts
+++ b/src/agents/failover/message-patterns.ts
@@ -72,13 +72,17 @@ const RATE_LIMIT_429_RE =
   /^\s*429\b|\b(?:https?|status(?:[ _-]?code)?|response(?:[ _-]?code)?|http(?:[ _-]?status)?)\b[\s:=#"'(]{0,6}429\b|["'](?:status|code)["']\s*:\s*429\b|\b429\b[\s:)\].,-]*(?:rate[_ -]?limit(?:ed|ing)?|too many requests|resource has been exhausted|quota(?:\s+(?:exceeded|exhausted|depleted|reached))?)\b/i;
 // Catches provider "model X not found" wording; the legacy provider table
 // only covers Groq's deactivated-model forms.
-// Runs after billing/plan classification in classify.ts, so bare "is
-// unavailable" wording (e.g. OpenCode Zen's "Model is unavailable.") is safe
-// to catch here without shadowing billing/plan-entitlement text — unlike the
-// earlier-run isModelNotFoundErrorMessage(), which billing has not yet had a
-// chance to classify.
+// Runs after billing/plan classification in classify.ts, so the direct
+// "model is unavailable" phrase (e.g. OpenCode Zen's "Model is unavailable.")
+// is safe to catch here without shadowing billing/plan-entitlement text —
+// unlike the earlier-run isModelNotFoundErrorMessage(), which billing has
+// not yet had a chance to classify. The bare-unavailable alternative is
+// anchored to the direct adjacent phrase (only whitespace between "model"
+// and "is unavailable") rather than a wildcard gap, so text like "The model
+// service is unavailable." — a different subject ("service"), not the model
+// itself — does not match (#130389 ClawSweeper re-review).
 export const GENERIC_MODEL_NOT_FOUND_RE =
-  /\bmodel\b.{0,60}?\b(?:not (?:found|available)|is unavailable)\b/i;
+  /\bmodel\b.{0,60}?\bnot (?:found|available)\b|\bmodel\s+is\s+unavailable\b/i;
 const ZAI_AUTH_ERROR_PATTERNS = [
   // Z.ai: error 1113 = wrong endpoint or invalid credentials (#48988)
   ZAI_AUTH_CODE_1113_RE,

--- a/src/agents/failover/message-patterns.ts
+++ b/src/agents/failover/message-patterns.ts
@@ -250,7 +250,10 @@ const ERROR_PATTERNS = {
     // Z.ai: error 1311 = model not included in current subscription plan (#48988)
     ZAI_BILLING_CODE_1311_RE,
     /\bcurrent\s+subscription\s+plan\b.*\b(?:does\s+not|doesn't|not)\b.*\binclude\s+access\b/i,
-    /\bmodel\b.*\bnot\s+available\b.*\bcurrent\s+plan\b/i,
+    // Equivalent plan-entitlement phrasing: "not available" and bare "is
+    // unavailable" (#130389 ClawSweeper re-review) both describe the same
+    // condition when scoped to "current plan" wording.
+    /\bmodel\b.*\b(?:not\s+available|is\s+unavailable)\b.*\bcurrent\s+plan\b/i,
   ],
   authPermanent: HIGH_CONFIDENCE_AUTH_PERMANENT_PATTERNS,
   auth: [

--- a/src/agents/failover/message-patterns.ts
+++ b/src/agents/failover/message-patterns.ts
@@ -72,7 +72,13 @@ const RATE_LIMIT_429_RE =
   /^\s*429\b|\b(?:https?|status(?:[ _-]?code)?|response(?:[ _-]?code)?|http(?:[ _-]?status)?)\b[\s:=#"'(]{0,6}429\b|["'](?:status|code)["']\s*:\s*429\b|\b429\b[\s:)\].,-]*(?:rate[_ -]?limit(?:ed|ing)?|too many requests|resource has been exhausted|quota(?:\s+(?:exceeded|exhausted|depleted|reached))?)\b/i;
 // Catches provider "model X not found" wording; the legacy provider table
 // only covers Groq's deactivated-model forms.
-export const GENERIC_MODEL_NOT_FOUND_RE = /\bmodel\b.{0,60}?\bnot (?:found|available)\b/i;
+// Runs after billing/plan classification in classify.ts, so bare "is
+// unavailable" wording (e.g. OpenCode Zen's "Model is unavailable.") is safe
+// to catch here without shadowing billing/plan-entitlement text — unlike the
+// earlier-run isModelNotFoundErrorMessage(), which billing has not yet had a
+// chance to classify.
+export const GENERIC_MODEL_NOT_FOUND_RE =
+  /\bmodel\b.{0,60}?\b(?:not (?:found|available)|is unavailable)\b/i;
 const ZAI_AUTH_ERROR_PATTERNS = [
   // Z.ai: error 1113 = wrong endpoint or invalid credentials (#48988)
   ZAI_AUTH_CODE_1113_RE,

--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -83,20 +83,12 @@ describe("live model error helpers", () => {
       false,
     );
     expect(isModelNotFoundErrorMessage("request ended without sending any chunks")).toBe(false);
-  });
-
-  it("detects bare model-unavailable wording (no 'not')", () => {
-    // OpenCode Zen's actual body for a withdrawn/deactivated route is the bare
-    // "Model is unavailable." (no "not"), which none of the "not found"/"not
-    // available" patterns above match.
-    expect(
-      isModelNotFoundErrorMessage(
-        "400 Error from provider (Console): Upstream request failed: Model is unavailable.",
-      ),
-    ).toBe(true);
-    expect(isModelNotFoundErrorMessage("Model is unavailable.")).toBe(true);
-    // Must not fire on unrelated "unavailable" wording that doesn't name the model.
-    expect(isModelNotFoundErrorMessage("503 service unavailable")).toBe(false);
-    expect(isModelNotFoundErrorMessage("The model service is temporarily unavailable")).toBe(false);
+    // Bare "Model is unavailable." (no "not") is intentionally NOT handled by
+    // this early detector: classify.ts consults it before billing/plan
+    // classification, and a bare "is unavailable" match here would shadow
+    // billing text like "The model is unavailable in your current plan" (see
+    // GENERIC_MODEL_NOT_FOUND_RE in failover/message-patterns.ts, which runs
+    // after billing and owns this case instead).
+    expect(isModelNotFoundErrorMessage("Model is unavailable.")).toBe(false);
   });
 });

--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -84,4 +84,19 @@ describe("live model error helpers", () => {
     );
     expect(isModelNotFoundErrorMessage("request ended without sending any chunks")).toBe(false);
   });
+
+  it("detects bare model-unavailable wording (no 'not')", () => {
+    // OpenCode Zen's actual body for a withdrawn/deactivated route is the bare
+    // "Model is unavailable." (no "not"), which none of the "not found"/"not
+    // available" patterns above match.
+    expect(
+      isModelNotFoundErrorMessage(
+        "400 Error from provider (Console): Upstream request failed: Model is unavailable.",
+      ),
+    ).toBe(true);
+    expect(isModelNotFoundErrorMessage("Model is unavailable.")).toBe(true);
+    // Must not fire on unrelated "unavailable" wording that doesn't name the model.
+    expect(isModelNotFoundErrorMessage("503 service unavailable")).toBe(false);
+    expect(isModelNotFoundErrorMessage("The model service is temporarily unavailable")).toBe(false);
+  });
 });

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -45,6 +45,11 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
   if (/model:\s*[a-z0-9._/-]+/i.test(msg) && /not(?:[_\-\s])?found/i.test(msg)) {
     return true;
   }
+  // OpenCode Zen's withdrawn-route body is the bare "Model is unavailable."
+  // (no "not"); the patterns above only match "not found"/"not available".
+  if (/\bmodel\b.{0,60}?\bis unavailable\b/i.test(msg)) {
+    return true;
+  }
   if (/models\/[^\s]+ is not found/i.test(msg)) {
     return true;
   }

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -45,11 +45,6 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
   if (/model:\s*[a-z0-9._/-]+/i.test(msg) && /not(?:[_\-\s])?found/i.test(msg)) {
     return true;
   }
-  // OpenCode Zen's withdrawn-route body is the bare "Model is unavailable."
-  // (no "not"); the patterns above only match "not found"/"not available".
-  if (/\bmodel\b.{0,60}?\bis unavailable\b/i.test(msg)) {
-    return true;
-  }
   if (/models\/[^\s]+ is not found/i.test(msg)) {
     return true;
   }


### PR DESCRIPTION
## What Problem This Solves

Provider error text of the exact bare form `Model is unavailable.` (no "not")
is missed by every existing model-availability detector:

- `isModelNotFoundErrorMessage` (`src/agents/live-model-errors.ts`)
- `GENERIC_MODEL_NOT_FOUND_RE` (`src/agents/failover/message-patterns.ts`)

Both only match "not found" / "not available" wording. With no message-level
classification, the signal falls through to the generic HTTP-400 default
(`format` reason in `classifyFailoverClassificationFromHttpStatus`), which
surfaces the wrong user-facing copy (schema-rejection text) instead of the
already-existing, correct model-unavailable message.

Reproduced live against a currently-withdrawn provider route (same request
shape, fresh single-turn session, zero prior tool-call history):

```
400 Error from provider (Console): Upstream request failed: Model is unavailable.
```

## Fix

**Revision history:**

1. `38dfda1` widened `isModelNotFoundErrorMessage`, which
   `classifyFailoverClassificationFromMessage` consults *before* billing/plan
   classification. Web review found this let the new pattern shadow billing
   text (`{"code":1311,"message":"The model is unavailable in your current
   plan"}` misclassified as `model_not_found` instead of `billing`) — proven
   red against `38dfda1` first.
2. `03cdf6c` corrected this by reverting the `isModelNotFoundErrorMessage`
   change and instead widening `GENERIC_MODEL_NOT_FOUND_RE`
   (`src/agents/failover/message-patterns.ts`), which classify.ts consults
   strictly *after* billing/periodic-usage-limit classification — making the
   billing-wins-first guarantee structural (check ordering), not
   regex-dependent.
3. ClawSweeper re-review on `03cdf6c` found a second, narrower gap: the
   billing plan-entitlement pattern itself only recognized "not available
   ... current plan" wording; the equivalent "is unavailable ... current
   plan" prose without a Z.ai `"code":1311` marker fell through billing
   entirely. `3e7603c` widened the plan-entitlement billing regex to accept
   both forms, matching the shape of its sibling rows.
4. ClawSweeper re-review on `3e7603c` found one remaining false positive:
   the "is unavailable" alternative used a wildcard gap
   (`\bmodel\b.{0,60}?\bis unavailable\b`), so arbitrary intervening text
   was tolerated — `"The model service is unavailable."` (a *service*
   outage, not a missing model) still matched and misclassified as
   `model_not_found`. Proven red against `3e7603c` first. `d4c2037` fixes
   this by anchoring the alternative to the **direct, adjacent phrase**
   (only whitespace between "model" and "is unavailable") instead of a
   wildcard gap or an exclusion list, per the handoff's stated preference:

   ```ts
   // before (3e7603c):
   /\bmodel\b.{0,60}?\b(?:not (?:found|available)|is unavailable)\b/i
   // after (d4c2037):
   /\bmodel\b.{0,60}?\bnot (?:found|available)\b|\bmodel\s+is\s+unavailable\b/i
   ```

`isModelNotFoundErrorMessage` remains untouched at its original "not found"/
"not available" patterns throughout all four commits — deliberately not
widened, since that is exactly the earlier-run function whose widening
caused the first precedence bug.

## Evidence

**Required regression matrix (all cases, `classify.message-predicates.test.ts`,
full pipeline via `classifyFailoverReason`):**

| Case | Input | Expected |
|---|---|---|
| A | `The model is unavailable in your current plan` | `billing` |
| B | `The model you requested is not available in your current plan` | `billing` |
| C | `{"code":1311,"message":"The model is unavailable in your current plan"}` | `billing` |
| D | `Model is unavailable.` | `model_not_found` |
| E | `400 Error from provider (Console): Upstream request failed: Model is unavailable.` | `model_not_found` |
| F | `503 service unavailable` / `The model service is temporarily unavailable` / `The model service is unavailable.` | not `model_not_found` |

Cases A (against `03cdf6c`) and the `"The model service is unavailable."`
sub-case of F (against `3e7603c`) were each proven red before their
respective corrective production edits landed. Corpus-level end-to-end
coverage of A/B/C/E also lives in `failover-classification.corpus.test.ts`.

**Real-behavior proof (not just unit tests):** in the isolated dev worktree
(`/home/michael/dev/tools/openclaw-upstream-wt-model-unavailable` — separate
clone/fork from the production OpenClaw runtime, no production
runtime/gateway/config touched), made a live network call through
`openclaw/plugin-sdk/llm`'s `completeSimple()` against the actual withdrawn
`opencode/deepseek-v4-flash-free` route, using the `OPENCODE_ZEN_API_KEY`
credential already present in the shell environment (no secrets printed, no
credential files created or modified). The real, current response was the
exact production body verbatim:

```
400 Error from provider (Console): Upstream request failed: Model is unavailable.
```

That real (not hardcoded) error text was then piped through this worktree's
actual patched `classifyFailoverReason` / `classifyFailoverSignal` /
`resolveReplyFailoverFacts` code, confirming:

```
classifyFailoverReason: model_not_found
classifyFailoverSignal:  { kind: "reason", reason: "model_not_found" }
classifyReplyRequest.code: provider_model_unavailable
```

Reproduced twice (elapsedMs ~258–301ms both times, consistent with the
original RCA's ~250ms pattern). The disposable probe script used for this
call was not committed — it is not part of the diff.

Ran the focused vitest suite locally at each of the four commits — all
green, including full existing `classify.*` and corpus suites (no
regressions). Ran `node scripts/check-changed.mjs` against the diff at each
commit — passed clean (format, typecheck, import-cycle, deadcode, and other
changed-file guards).

## LOC delta

Across all four commits vs. `main`: `message-patterns.ts` +15/-2 (net +13),
`live-model-errors.ts` net 0 (added then fully reverted, zero diff vs.
`main`) => **+13 net production**. Tests: +125 across three files. Each
correction was the narrowest change at its own location — a direct-phrase
anchor rather than an exclusion list, matching the repository's existing
pattern style rather than duplicating logic across sibling matchers.

## Non-goals

Does not address a separate observed >3-minute hang on the same provider
route family — that is unrelated and out of scope for this fix.
