### PR TITLE
fix(codex): Fix codex apps disappear when plugin is in read-only or prompt mode

### DIFF
--- a/extensions/codex/src/app-server/app-inventory-cache.test.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.test.ts
@@ -36,6 +36,7 @@ describe("Codex app inventory cache", () => {
     expect(request).toHaveBeenNthCalledWith(1, "app/installed", { forceRefresh: true });
     expect(request).toHaveBeenNthCalledWith(2, "app/read", {
       appIds: ["app-1", "app-2"],
+      includeTools: true,
     });
 
     const fresh = cache.read({ key, request, nowMs: 50 });
@@ -82,6 +83,7 @@ describe("Codex app inventory cache", () => {
     expect(request).toHaveBeenNthCalledWith(1, "app/installed", { forceRefresh: true });
     expect(request).toHaveBeenNthCalledWith(2, "app/read", {
       appIds: ["google-calendar-app"],
+      includeTools: true,
     });
   });
 
@@ -123,8 +125,8 @@ describe("Codex app inventory cache", () => {
       ["app/installed", { forceRefresh: false }],
     ]);
     expect(request.mock.calls.filter(([method]) => method === "app/read")).toEqual([
-      ["app/read", { appIds: ["google-calendar-app"] }],
-      ["app/read", { appIds: ["google-calendar-app", "unrelated-slack-app"] }],
+      ["app/read", { appIds: ["google-calendar-app"], includeTools: true }],
+      ["app/read", { appIds: ["google-calendar-app", "unrelated-slack-app"], includeTools: true }],
     ]);
   });
 
@@ -184,12 +186,15 @@ describe("Codex app inventory cache", () => {
     expect(request).toHaveBeenCalledTimes(4);
     expect(request).toHaveBeenNthCalledWith(2, "app/read", {
       appIds: apps.slice(0, 100).map((entry) => entry.id),
+      includeTools: true,
     });
     expect(request).toHaveBeenNthCalledWith(3, "app/read", {
       appIds: apps.slice(100, 200).map((entry) => entry.id),
+      includeTools: true,
     });
     expect(request).toHaveBeenNthCalledWith(4, "app/read", {
       appIds: apps.slice(200).map((entry) => entry.id),
+      includeTools: true,
     });
   });
 
@@ -221,6 +226,7 @@ describe("Codex app inventory cache", () => {
     expect(snapshot.apps).toEqual([]);
     expect(request).toHaveBeenNthCalledWith(2, "app/read", {
       appIds: ["policy-disabled-app"],
+      includeTools: true,
     });
   });
 
@@ -420,7 +426,10 @@ describe("Codex app inventory cache", () => {
 
     await expect(cache.refreshNow({ key: "runtime", request })).rejects.toThrow("Method not found");
     expect(request).toHaveBeenNthCalledWith(1, "app/installed", { forceRefresh: true });
-    expect(request).toHaveBeenNthCalledWith(2, "app/read", { appIds: ["current-app"] });
+    expect(request).toHaveBeenNthCalledWith(2, "app/read", {
+      appIds: ["current-app"],
+      includeTools: true,
+    });
     expect(cache.read({ key: "runtime", request, suppressRefresh: true }).snapshot).toBeUndefined();
   });
 

--- a/extensions/codex/src/app-server/app-inventory-cache.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.ts
@@ -486,6 +486,7 @@ async function readInstalledApps(
         appIds: apps
           .slice(index * CODEX_APP_READ_BATCH_LIMIT, (index + 1) * CODEX_APP_READ_BATCH_LIMIT)
           .map((app) => app.id),
+        includeTools: true,
       }),
     ),
   );
@@ -519,6 +520,7 @@ async function readInstalledApps(
           isAccessible: true,
           isEnabled: installedApp.enabled,
           pluginDisplayNames: metadata.pluginDisplayNames,
+          ...(metadata.toolSummaries ? { toolSummaries: metadata.toolSummaries } : {}),
         },
       ];
     }),

--- a/extensions/codex/src/app-server/app-inventory.test-helpers.ts
+++ b/extensions/codex/src/app-server/app-inventory.test-helpers.ts
@@ -20,7 +20,8 @@ export function codexAppInventoryResponse<Method extends CodexAppInventoryMethod
     } as CodexAppServerRequestResult<Method>;
   }
 
-  const requestedIds = (params as CodexAppServerRequestParams<"app/read"> | undefined)?.appIds;
+  const readParams = params as CodexAppServerRequestParams<"app/read"> | undefined;
+  const requestedIds = readParams?.appIds;
   const requestedIdSet = requestedIds ? new Set(requestedIds) : undefined;
   const matchingApps = apps.filter(
     (app) => app.isAccessible && (!requestedIdSet || requestedIdSet.has(app.id)),
@@ -37,6 +38,7 @@ export function codexAppInventoryResponse<Method extends CodexAppInventoryMethod
       distributionChannel: app.distributionChannel,
       installUrl: app.installUrl,
       pluginDisplayNames: app.pluginDisplayNames,
+      toolSummaries: readParams?.includeTools ? (app.toolSummaries ?? null) : null,
     })),
     missingAppIds: requestedIds?.filter((id) => !returnedIds.has(id)) ?? [],
   } as CodexAppServerRequestResult<Method>;

--- a/extensions/codex/src/app-server/plugin-inventory.test.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.test.ts
@@ -6,11 +6,7 @@ import {
   CODEX_PLUGINS_MARKETPLACE_NAME,
   CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
 } from "./config.js";
-import {
-  findCodexMarketplacePluginSummary,
-  readCodexPluginInventory,
-  resolveOwnedAppReadOnlyToolConfigKeys,
-} from "./plugin-inventory.js";
+import { findCodexMarketplacePluginSummary, readCodexPluginInventory } from "./plugin-inventory.js";
 import {
   appInfo,
   appSummary,
@@ -24,34 +20,6 @@ import { CodexPluginMetadataCache } from "./plugin-metadata-cache.js";
 import type { v2 } from "./protocol.js";
 
 describe("Codex plugin inventory", () => {
-  it("does not classify keys shared with writable tools as read-only", () => {
-    const app: v2.AppInfo = {
-      ...appInfo("linear", true),
-      toolSummaries: [
-        {
-          name: "fetch",
-          title: "Fetch",
-          description: "Fetch a Linear issue.",
-          isEnabled: true,
-          disabledReason: null,
-          isReadOnly: true,
-        },
-        {
-          name: "linear_fetch",
-          title: "Save issue",
-          description: "Create or update a Linear issue.",
-          isEnabled: true,
-          disabledReason: null,
-          isReadOnly: false,
-        },
-      ],
-    };
-
-    expect(resolveOwnedAppReadOnlyToolConfigKeys(app)).toStrictEqual({
-      readOnlyToolConfigKeys: ["Fetch", "fetch"],
-    });
-  });
-
   it("returns enabled migrated curated plugins with stable owned app ids", async () => {
     const appCache = await cachedApps(appInfo("google-calendar-app", true));
     const calls: string[] = [];

--- a/extensions/codex/src/app-server/plugin-inventory.test.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.test.ts
@@ -6,7 +6,11 @@ import {
   CODEX_PLUGINS_MARKETPLACE_NAME,
   CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
 } from "./config.js";
-import { findCodexMarketplacePluginSummary, readCodexPluginInventory } from "./plugin-inventory.js";
+import {
+  findCodexMarketplacePluginSummary,
+  readCodexPluginInventory,
+  resolveOwnedAppReadOnlyToolConfigKeys,
+} from "./plugin-inventory.js";
 import {
   appInfo,
   appSummary,
@@ -20,6 +24,34 @@ import { CodexPluginMetadataCache } from "./plugin-metadata-cache.js";
 import type { v2 } from "./protocol.js";
 
 describe("Codex plugin inventory", () => {
+  it("does not classify keys shared with writable tools as read-only", () => {
+    const app: v2.AppInfo = {
+      ...appInfo("linear", true),
+      toolSummaries: [
+        {
+          name: "fetch",
+          title: "Fetch",
+          description: "Fetch a Linear issue.",
+          isEnabled: true,
+          disabledReason: null,
+          isReadOnly: true,
+        },
+        {
+          name: "linear_fetch",
+          title: "Save issue",
+          description: "Create or update a Linear issue.",
+          isEnabled: true,
+          disabledReason: null,
+          isReadOnly: false,
+        },
+      ],
+    };
+
+    expect(resolveOwnedAppReadOnlyToolConfigKeys(app)).toStrictEqual({
+      readOnlyToolConfigKeys: ["Fetch", "fetch"],
+    });
+  });
+
   it("returns enabled migrated curated plugins with stable owned app ids", async () => {
     const appCache = await cachedApps(appInfo("google-calendar-app", true));
     const calls: string[] = [];

--- a/extensions/codex/src/app-server/plugin-inventory.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.ts
@@ -66,6 +66,8 @@ export type CodexPluginOwnedApp = {
   accessible: boolean;
   enabled: boolean;
   needsAuth: boolean;
+  /** Tool config keys Codex explicitly classifies as read-only. */
+  readOnlyToolConfigKeys?: readonly string[];
 };
 
 /** Inventory record for one configured Codex plugin policy. */
@@ -521,17 +523,30 @@ function resolveOwnedApps(params: {
           needsAuth: true,
         };
       }
-      return {
-        id: app.id,
-        name: app.name,
-        accessible: info.isAccessible,
-        enabled: info.isEnabled,
-        // Modern plugin summaries carry no auth bit; account-authorized
-        // app/read metadata is the canonical connector access proof.
-        needsAuth: !info.isAccessible,
-      };
+      return Object.assign(
+        {
+          id: app.id,
+          name: app.name,
+          accessible: info.isAccessible,
+          enabled: info.isEnabled,
+          // Modern plugin summaries carry no auth bit; account-authorized
+          // app/read metadata is the canonical connector access proof.
+          needsAuth: !info.isAccessible,
+        },
+        resolveOwnedAppReadOnlyToolConfigKeys(info),
+      );
     })
     .toSorted((left, right) => left.id.localeCompare(right.id));
+}
+
+/** Returns the config keys that Codex metadata proves belong to read-only tools. */
+export function resolveOwnedAppReadOnlyToolConfigKeys(
+  app: v2.AppInfo,
+): Pick<CodexPluginOwnedApp, "readOnlyToolConfigKeys"> {
+  const keys = (app.toolSummaries ?? [])
+    .filter((tool) => tool.isReadOnly)
+    .flatMap((tool) => (tool.title ? [tool.name, tool.title] : [tool.name]));
+  return keys.length > 0 ? { readOnlyToolConfigKeys: Array.from(new Set(keys)).toSorted() } : {};
 }
 
 function findPluginSummary(

--- a/extensions/codex/src/app-server/plugin-inventory.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.ts
@@ -543,9 +543,16 @@ function resolveOwnedApps(params: {
 export function resolveOwnedAppReadOnlyToolConfigKeys(
   app: v2.AppInfo,
 ): Pick<CodexPluginOwnedApp, "readOnlyToolConfigKeys"> {
+  const appName = app.name.trim();
+  const appNameLower = appName.toLowerCase();
   const keys = (app.toolSummaries ?? [])
     .filter((tool) => tool.isReadOnly)
-    .flatMap((tool) => (tool.title ? [tool.name, tool.title] : [tool.name]));
+    .flatMap((tool) => [
+      tool.name,
+      ...(tool.title ? [tool.title] : []),
+      ...(appName ? [`${appName}_${tool.name}`] : []),
+      ...(appNameLower && appNameLower !== appName ? [`${appNameLower}_${tool.name}`] : []),
+    ]);
   return keys.length > 0 ? { readOnlyToolConfigKeys: Array.from(new Set(keys)).toSorted() } : {};
 }
 

--- a/extensions/codex/src/app-server/plugin-inventory.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.ts
@@ -545,23 +545,35 @@ export function resolveOwnedAppReadOnlyToolConfigKeys(
 ): Pick<CodexPluginOwnedApp, "readOnlyToolConfigKeys"> {
   const appName = app.name.trim();
   const appNameLower = appName.toLowerCase();
-  const keys: string[] = [];
-  for (const tool of app.toolSummaries ?? []) {
-    if (!tool.isReadOnly) {
-      continue;
-    }
-    keys.push(tool.name);
-    if (tool.title) {
-      keys.push(tool.title);
-    }
-    if (appName) {
-      keys.push(`${appName}_${tool.name}`);
-    }
-    if (appNameLower && appNameLower !== appName) {
-      keys.push(`${appNameLower}_${tool.name}`);
-    }
-  }
+  const tools = app.toolSummaries ?? [];
+  const writableToolConfigKeys = new Set(
+    tools
+      .filter((tool) => !tool.isReadOnly)
+      .flatMap((tool) => resolveAppToolConfigKeys({ appName, appNameLower, tool })),
+  );
+  const keys = tools
+    .filter((tool) => tool.isReadOnly)
+    .flatMap((tool) => resolveAppToolConfigKeys({ appName, appNameLower, tool }))
+    .filter((key) => !writableToolConfigKeys.has(key));
   return keys.length > 0 ? { readOnlyToolConfigKeys: Array.from(new Set(keys)).toSorted() } : {};
+}
+
+function resolveAppToolConfigKeys(params: {
+  appName: string;
+  appNameLower: string;
+  tool: { name: string; title?: string | null };
+}): string[] {
+  const keys = [params.tool.name];
+  if (params.tool.title) {
+    keys.push(params.tool.title);
+  }
+  if (params.appName) {
+    keys.push(`${params.appName}_${params.tool.name}`);
+  }
+  if (params.appNameLower && params.appNameLower !== params.appName) {
+    keys.push(`${params.appNameLower}_${params.tool.name}`);
+  }
+  return keys;
 }
 
 function findPluginSummary(

--- a/extensions/codex/src/app-server/plugin-inventory.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.ts
@@ -545,14 +545,22 @@ export function resolveOwnedAppReadOnlyToolConfigKeys(
 ): Pick<CodexPluginOwnedApp, "readOnlyToolConfigKeys"> {
   const appName = app.name.trim();
   const appNameLower = appName.toLowerCase();
-  const keys = (app.toolSummaries ?? [])
-    .filter((tool) => tool.isReadOnly)
-    .flatMap((tool) => [
-      tool.name,
-      ...(tool.title ? [tool.title] : []),
-      ...(appName ? [`${appName}_${tool.name}`] : []),
-      ...(appNameLower && appNameLower !== appName ? [`${appNameLower}_${tool.name}`] : []),
-    ]);
+  const keys: string[] = [];
+  for (const tool of app.toolSummaries ?? []) {
+    if (!tool.isReadOnly) {
+      continue;
+    }
+    keys.push(tool.name);
+    if (tool.title) {
+      keys.push(tool.title);
+    }
+    if (appName) {
+      keys.push(`${appName}_${tool.name}`);
+    }
+    if (appNameLower && appNameLower !== appName) {
+      keys.push(`${appNameLower}_${tool.name}`);
+    }
+  }
   return keys.length > 0 ? { readOnlyToolConfigKeys: Array.from(new Set(keys)).toSorted() } : {};
 }
 

--- a/extensions/codex/src/app-server/plugin-thread-app-admission.ts
+++ b/extensions/codex/src/app-server/plugin-thread-app-admission.ts
@@ -6,11 +6,12 @@ import {
   type CodexAppInventorySnapshot,
 } from "./app-inventory-cache.js";
 import type { ResolvedCodexPluginsPolicy } from "./config.js";
-import type {
-  CodexPluginInventory,
-  CodexPluginInventoryRecord,
-  CodexPluginOwnedApp,
-  CodexPluginRuntimeRequest,
+import {
+  resolveOwnedAppReadOnlyToolConfigKeys,
+  type CodexPluginInventory,
+  type CodexPluginInventoryRecord,
+  type CodexPluginOwnedApp,
+  type CodexPluginRuntimeRequest,
 } from "./plugin-inventory.js";
 import {
   type CodexAppServerRequestResult,
@@ -187,6 +188,7 @@ export function toCodexPluginOwnedAccountApp(app: v2.AppInfo): CodexPluginOwnedA
     accessible: app.isAccessible,
     enabled: app.isEnabled,
     needsAuth: !app.isAccessible,
+    ...resolveOwnedAppReadOnlyToolConfigKeys(app),
   };
 }
 

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -669,13 +669,120 @@ describe("Codex plugin thread config", () => {
     expect(configPatch).not.toHaveProperty("approvals_reviewer");
   });
 
-  it("omits ask policy apps when cwd effective approval overrides remain after cleanup", async () => {
+  it("keeps ask policy apps when managed approval overrides cover only read-only tools", async () => {
     const appCache = new CodexAppInventoryCache();
+    const linearApp: v2.AppInfo = {
+      ...appInfo("linear", true),
+      toolSummaries: [
+        {
+          name: "linear_fetch",
+          title: "linear/fetch",
+          description: "Fetch a Linear issue.",
+          isEnabled: true,
+          disabledReason: null,
+          isReadOnly: true,
+        },
+        {
+          name: "save_issue",
+          title: "linear/save_issue",
+          description: "Create or update a Linear issue.",
+          isEnabled: true,
+          disabledReason: null,
+          isReadOnly: false,
+        },
+      ],
+    };
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async (method, params) =>
-        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
+      request: async (method, params) => codexAppInventoryResponse(method, [linearApp], params),
+    });
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "plugin/installed" || method === "plugin/list") {
+        return pluginList([pluginSummary("linear", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginDetail("linear", [appSummary("linear")], ["linear"]);
+      }
+      if (method === "config/read") {
+        expect(params).toEqual({ includeLayers: true, cwd: "/repo/project" });
+        return {
+          config: {
+            apps: {
+              linear: {
+                tools: {
+                  linear_fetch: { approval_mode: "approve" },
+                },
+              },
+            },
+          },
+          layers: [],
+        };
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          allow_destructive_actions: "ask",
+          plugins: {
+            linear: {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "linear",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      configCwd: "/repo/project",
+      nowMs: 1,
+      request,
+    });
+
+    expect(config.configPatch).toEqual({
+      apps: {
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+        linear: {
+          enabled: true,
+          approvals_reviewer: "user",
+          destructive_enabled: true,
+          open_world_enabled: true,
+          default_tools_approval_mode: "auto",
+        },
+      },
+    });
+    expect(config.provisionalAppIds).toEqual(["linear"]);
+    expect(config.diagnostics).toStrictEqual([]);
+    expect(request.mock.calls.filter(([method]) => method === "config/read")).toHaveLength(1);
+    expect(request.mock.calls.map(([method]) => method)).not.toContain("config/batchWrite");
+  });
+
+  it("omits ask policy apps when cwd effective approval overrides remain after cleanup", async () => {
+    const appCache = new CodexAppInventoryCache();
+    const calendarApp: v2.AppInfo = {
+      ...appInfo("google-calendar-app", true),
+      toolSummaries: [
+        {
+          name: "calendar/create",
+          title: null,
+          description: "Create a calendar event.",
+          isEnabled: true,
+          disabledReason: null,
+          isReadOnly: false,
+        },
+      ],
+    };
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async (method, params) => codexAppInventoryResponse(method, [calendarApp], params),
     });
     let configReadCount = 0;
     const request = vi.fn(async (method: string, params?: unknown) => {
@@ -2544,7 +2651,7 @@ describe("Codex plugin thread config", () => {
       ["app/installed", { forceRefresh: true }],
     ]);
     expect(request.mock.calls.filter(([method]) => method === "app/read")).toEqual([
-      ["app/read", { appIds: ["calendar-app", "meetings-app"] }],
+      ["app/read", { appIds: ["calendar-app", "meetings-app"], includeTools: true }],
     ]);
     expect(request.mock.calls.filter(([method]) => method === "config/read")).toHaveLength(1);
   });
@@ -3149,6 +3256,7 @@ describe("Codex plugin thread config", () => {
     });
     expect(request.mock.calls.find(([method]) => method === "app/read")?.[1]).toEqual({
       appIds: ["google-calendar-app"],
+      includeTools: true,
       threadId: "thread-149",
     });
     expect(request.mock.calls.find(([method]) => method === "config/read")?.[1]).toEqual({

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -6,7 +6,10 @@ import {
   CODEX_PLUGINS_MARKETPLACE_NAME,
   CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
 } from "./config.js";
-import { resolveRecoverableCodexPluginConfigKeys } from "./plugin-inventory.js";
+import {
+  resolveOwnedAppReadOnlyToolConfigKeys,
+  resolveRecoverableCodexPluginConfigKeys,
+} from "./plugin-inventory.js";
 import { CodexPluginMetadataCache } from "./plugin-metadata-cache.js";
 import { createCodexPluginThreadConfigStartupProvider } from "./plugin-thread-config-deadline.js";
 import {
@@ -23,6 +26,34 @@ import type { CodexAppServerRequestParams, JsonObject, v2 } from "./protocol.js"
 describe("Codex plugin thread config", () => {
   beforeEach(() => {
     defaultCodexAppInventoryCache.clear();
+  });
+
+  it("does not classify keys shared with writable tools as read-only", () => {
+    const app: v2.AppInfo = {
+      ...appInfo("linear", true),
+      toolSummaries: [
+        {
+          name: "fetch",
+          title: "Fetch",
+          description: "Fetch a Linear issue.",
+          isEnabled: true,
+          disabledReason: null,
+          isReadOnly: true,
+        },
+        {
+          name: "linear_fetch",
+          title: "Save issue",
+          description: "Create or update a Linear issue.",
+          isEnabled: true,
+          disabledReason: null,
+          isReadOnly: false,
+        },
+      ],
+    };
+
+    expect(resolveOwnedAppReadOnlyToolConfigKeys(app)).toStrictEqual({
+      readOnlyToolConfigKeys: ["Fetch", "fetch"],
+    });
   });
 
   it("defaults destructive app access on for accessible migrated plugin apps", async () => {

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -675,8 +675,8 @@ describe("Codex plugin thread config", () => {
       ...appInfo("linear", true),
       toolSummaries: [
         {
-          name: "linear_fetch",
-          title: "linear/fetch",
+          name: "fetch",
+          title: "Fetch",
           description: "Fetch a Linear issue.",
           isEnabled: true,
           disabledReason: null,

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -675,6 +675,7 @@ function readPersistedAppToolApprovalOverrideNames(
     return [];
   }
   return Object.entries(tools)
+    .filter(([toolName]) => !app.readOnlyToolConfigKeys?.includes(toolName))
     .filter(([, value]) => hasPersistedToolApprovalOverride(value))
     .map(([toolName]) => toolName)
     .toSorted();

--- a/extensions/codex/src/app-server/protocol-control-plane.ts
+++ b/extensions/codex/src/app-server/protocol-control-plane.ts
@@ -106,6 +106,8 @@ export type CodexAppInfo = {
   isAccessible: boolean;
   isEnabled: boolean;
   pluginDisplayNames: string[];
+  /** Present when app/read was requested with includeTools. */
+  toolSummaries?: CodexAppToolSummary[];
 };
 
 export type CodexAppsListParams = {
@@ -136,7 +138,7 @@ export type CodexAppsInstalledResponse = {
   apps: CodexInstalledApp[];
 };
 
-type CodexAppToolSummary = {
+export type CodexAppToolSummary = {
   name: string;
   title: string | null;
   description: string;

--- a/extensions/codex/src/app-server/protocol-control-plane.ts
+++ b/extensions/codex/src/app-server/protocol-control-plane.ts
@@ -138,7 +138,7 @@ export type CodexAppsInstalledResponse = {
   apps: CodexInstalledApp[];
 };
 
-export type CodexAppToolSummary = {
+type CodexAppToolSummary = {
   name: string;
   title: string | null;
   description: string;


### PR DESCRIPTION
## Why This Change Was Made

Codex apps could disappear from the available tool inventory when a managed approval layer pre-approved a read-only tool while the app kept write tools in ask mode. OpenClaw needs to retain the app, trust Codex's tool mutability metadata for read-only exceptions, and leave reviewer compatibility to Codex.

For models that require automatic review, Codex selects `auto_review`; an app-level prompt reviewer is intentionally not promoted to a thread-level `user` reviewer. Models that permit user approval can continue to use the app-scoped prompt setting.

## What This Changes

- Requests and retains Codex tool mutability metadata in the app inventory.
- Ignores persisted approval overrides only for tool names or titles that Codex explicitly marks read-only.
- Keeps write tools and tools with missing metadata fail-closed.
- Refuses to classify a key as read-only when the same key is attributable to any writable tool.
- Keeps ask-mode reviewer configuration app-scoped so Codex can enforce model-required `auto_review`.

## User Impact

Apps such as issue trackers remain available for reading and approval-gated writes when workspace policy pre-approves their read-only tools. Models that require automatic review no longer receive an incompatible thread-level user reviewer from this change.

## Evidence

- Focused Codex app-server tests: 3 files passed, 127 tests passed.
- Changed-file guards, formatting, boundary checks, and package-patch checks passed.
- Knip production, full-tree, and script unused-export scans passed with zero entries.
- Branch autoreview: clean, no accepted/actionable findings; overall patch correctness 0.98.
- Exact-head GitHub Actions: 7 of 7 workflows passed, including 30 of 30 jobs in the main CI workflow.

### Managed end-to-end proof

A public-safe trace, exact upstream Codex source links, collision proof, and current-head test output are attached in [this PR comment](https://github.com/openclaw/openclaw/pull/130394#issuecomment-5465664913).


The behavior-bearing PR head (`ff98af10d3a9ff1d25022c901fdd03b70b082fad`) was built through the native ARM64 Tilt path without a source overlay. Rebased head `8c02632301e99e2d859d875e57317ced50753132` was patch-equivalent by Git range-diff, and every uploaded blob and rebased tree matched the locally validated Git object IDs. Current head `0d77c14d674c19c2370b9f3fe077fbf0948b4d50` adds only the localized fail-closed collision guard and its regression test. A fresh natural-language Slack request used a model that requires `auto_review`, with the Linear app configured in ask mode. The trace retained the app, exposed its read and write tools, called the team lookup, issue create, and issue read-back actions, recorded an automatic reviewer approval, and delivered the final reply. An independent Linear read confirmed the exact created title and description. No fallback model was used, and both gateway health and readiness checks passed.

The remaining destructive-action policies were exercised with fresh requests against the same runtime:

| Policy | Observed result |
| --- | --- |
| `ask` | The write was automatically reviewed, approved, executed, and independently read back. |
| `auto` | The write was reviewed, approved, executed, and independently read back. |
| `true` | The write executed and was independently read back; the runtime-level `auto_review` reviewer still recorded its approval. |
| `false` | The write action was unavailable, no write call occurred, read-only Linear actions remained available, and an independent exact-marker search found no created issue. |

The runtime was restored to `ask` with `approvals_reviewer = "auto_review"` after the matrix completed.
