### PR TITLE
fix(ui): dictation duplicates words on Stop and retains canceled speech

### DIFF
--- a/ui/src/e2e/browser-dictation-status.e2e.test.ts
+++ b/ui/src/e2e/browser-dictation-status.e2e.test.ts
@@ -15,6 +15,135 @@ const suite = createControlUiE2eSuite({
 });
 
 suite.define(() => {
+  it.each([
+    { name: "caret insertion", start: 5, end: 5, expected: "ship please it", cancel: false },
+    { name: "selection replacement", start: 5, end: 7, expected: "ship please", cancel: false },
+    { name: "cancel after blur", start: 7, end: 7, expected: "ship it please", cancel: true },
+  ])("preserves the draft through $name", async ({ name, start, end, expected, cancel }) => {
+    await suite.withPage({ permissions: ["microphone"] }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["talk.session.create"],
+        methodResponses: {
+          "talk.catalog": {
+            transcription: { ready: true, providers: [] },
+            realtime: { providers: [] },
+            speech: { providers: [] },
+            modes: [],
+            transports: [],
+            brains: [],
+          },
+          "talk.session.create": {
+            sessionId: "dictation-preview-proof",
+            transcriptionSessionId: "dictation-preview-proof",
+            audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
+          },
+        },
+      });
+      await installTalkBrowserFixtures(page);
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const textarea = page.locator(".agent-chat__composer-combobox textarea");
+      await textarea.fill("ship it");
+      await textarea.evaluate(
+        (element: HTMLTextAreaElement, selection) =>
+          element.setSelectionRange(selection.start, selection.end),
+        { start, end },
+      );
+      await page.getByRole("button", { name: "Start voice input" }).hover();
+      await page.mouse.down();
+      await gateway.waitForRequest("talk.session.create");
+      await gateway.resolveDeferred("talk.session.create");
+      await page.mouse.up();
+      await gateway.emitGatewayEvent("talk.event", {
+        transcriptionSessionId: "dictation-preview-proof",
+        type: "partial",
+        text: "please",
+      });
+      await expect.poll(() => textarea.inputValue()).toBe(expected);
+      if (cancel) {
+        await page.getByRole("button", { name: "Collapse sidebar", exact: true }).click();
+        await page.keyboard.press("Escape");
+      } else {
+        await page.getByRole("button", { name: "Stop and keep text" }).click();
+      }
+      await gateway.waitForRequest("talk.session.close");
+      const committedDraft = cancel ? "ship it" : expected;
+      expect(await textarea.inputValue()).toBe(committedDraft);
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+      await captureComposerProof(page, `dictation-${name.replaceAll(" ", "-")}-committed.png`);
+      expect(await textarea.inputValue()).toBe(committedDraft);
+    });
+  });
+
+  it("keeps recognized speech visible until Escape cancels new-session dictation", async () => {
+    await suite.withPage({ permissions: ["microphone"] }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["talk.session.create"],
+        featureMethods: ["chat.metadata", "chat.startup", "sessions.create", "sessions.dispatch"],
+        methodResponses: {
+          "talk.catalog": {
+            transcription: { ready: true, providers: [] },
+            realtime: { providers: [] },
+            speech: { providers: [] },
+            modes: [],
+            transports: [],
+            brains: [],
+          },
+          "talk.session.create": {
+            sessionId: "dictation-direct-proof",
+            transcriptionSessionId: "dictation-direct-proof",
+            audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
+          },
+        },
+      });
+      await installTalkBrowserFixtures(page);
+      await page.goto(`${suite.server.baseUrl}new`);
+      const textarea = page.locator(".new-session-page__message");
+      await textarea.fill("keep this draft");
+      await page.getByRole("button", { name: "Dictate", exact: true }).click();
+      await gateway.waitForRequest("talk.session.create");
+      await gateway.resolveDeferred("talk.session.create");
+      await gateway.emitGatewayEvent("talk.event", {
+        transcriptionSessionId: "dictation-direct-proof",
+        type: "partial",
+        text: "discard this speech",
+      });
+      await expect.poll(() => textarea.inputValue()).toContain("discard this speech");
+      await gateway.emitGatewayEvent("talk.event", {
+        transcriptionSessionId: "dictation-direct-proof",
+        type: "transcript",
+        text: "discard this speech",
+        final: true,
+      });
+      await expect.poll(() => textarea.inputValue()).toBe("keep this draft discard this speech");
+      await gateway.emitGatewayEvent("talk.event", {
+        transcriptionSessionId: "dictation-direct-proof",
+        type: "partial",
+        text: "too",
+      });
+      await expect
+        .poll(() => textarea.inputValue())
+        .toBe("keep this draft discard this speech too");
+      await gateway.emitGatewayEvent("talk.event", {
+        transcriptionSessionId: "dictation-direct-proof",
+        type: "transcript",
+        text: "",
+        final: true,
+      });
+      await expect
+        .poll(() => textarea.inputValue())
+        .toBe("keep this draft discard this speech too");
+      await captureComposerProof(page, "dictation-new-session-recognized-preview.png");
+      await page.keyboard.press("Escape");
+      await expect.poll(() => textarea.inputValue()).toBe("keep this draft");
+      await gateway.waitForRequest("talk.session.close");
+      expect(await page.getByRole("button", { name: "Dictate", exact: true }).isVisible()).toBe(
+        true,
+      );
+      expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
+      await captureComposerProof(page, "dictation-new-session-cancelled.png");
+    });
+  });
+
   it("keeps the hold-to-dictate switch interactive without closing the microphone picker", async () => {
     await suite.withPage({ permissions: ["microphone"] }, async ({ page }) => {
       await installMockGateway(page, {

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -174,5 +174,5 @@ export type ChatComposerState = SkillMenuState &
     dictation: ComposerDictationController | null;
     dictationDraftKey: string | null;
     dictationError: string | null;
-    dictationSelection: { start: number; end: number } | null;
+    dictationSelection: { start: number; end: number; value: string } | null;
   };

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -242,15 +242,14 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
       : nothing;
   // Dictation previews at the captured selection. The textarea remains
   // read-only until stop commits the same insertion into the real draft.
-  const dictationPreviewDraft =
-    dictation?.active && dictation.partial
-      ? insertComposerDictation(
-          visibleDraft,
-          dictation.partial,
-          state.dictationSelection?.start ?? visibleDraft.length,
-          state.dictationSelection?.end ?? visibleDraft.length,
-        ).value
-      : visibleDraft;
+  const dictationPreviewDraft = dictation?.active
+    ? insertComposerDictation(
+        state.dictationSelection?.value ?? visibleDraft,
+        dictation.transcript,
+        state.dictationSelection?.start ?? visibleDraft.length,
+        state.dictationSelection?.end ?? visibleDraft.length,
+      ).value
+    : visibleDraft;
   const draftDirection = detectTextDirection(dictationPreviewDraft);
   const interruptedStatus = props.runError
     ? nothing

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -384,12 +384,15 @@ export function renderChatComposer(props: ChatComposerProps) {
     if (state.composingDraft?.key === draftKey) {
       state.composingDraft = null;
     }
-    const normalizedDraft = normalizeChatComposerDraft(target.value);
-    if (target.value !== normalizedDraft) {
-      target.value = normalizedDraft;
-      adjustTextareaHeight(target);
+    // Dictation owns the read-only preview; blur must not commit discarded speech.
+    if (!state.dictation?.locksComposer) {
+      const normalizedDraft = normalizeChatComposerDraft(target.value);
+      if (target.value !== normalizedDraft) {
+        target.value = normalizedDraft;
+        adjustTextareaHeight(target);
+      }
+      commitComposerDraft(props, normalizedDraft);
     }
-    commitComposerDraft(props, normalizedDraft);
     props.onTypingChange?.(false);
   };
   const handleSend = (submissionAction?: Event) => {
@@ -467,10 +470,10 @@ export function renderChatComposer(props: ChatComposerProps) {
       const selection = state.dictationSelection ?? {
         start: target?.selectionStart ?? visibleDraft.length,
         end: target?.selectionEnd ?? visibleDraft.length,
+        value: props.getDraft?.() ?? props.draft,
       };
-      const currentDraft = target?.value ?? props.getDraft?.() ?? props.draft;
       const insertion = insertComposerDictation(
-        currentDraft,
+        selection.value,
         transcript,
         selection.start,
         selection.end,
@@ -525,12 +528,17 @@ export function renderChatComposer(props: ChatComposerProps) {
       requestUpdate();
     }
     const target = state.composerTextarea;
-    state.dictationSelection = {
+    const selection = {
       start: target?.selectionStart ?? visibleDraft.length,
       end: target?.selectionEnd ?? visibleDraft.length,
+      value: target?.value ?? visibleDraft,
     };
-    if (dictation?.handlePointerDown(event) && target) {
-      target.readOnly = true;
+    if (dictation?.handlePointerDown(event)) {
+      // Stop also emits pointerdown; only a new gesture owns a draft snapshot.
+      state.dictationSelection = selection;
+      if (target) {
+        target.readOnly = true;
+      }
     }
   };
   const runControlsProps: ChatRunControlsProps = {

--- a/ui/src/pages/chat/composer-dictation.test.ts
+++ b/ui/src/pages/chat/composer-dictation.test.ts
@@ -190,17 +190,38 @@ afterEach(() => {
 });
 
 describe("ComposerDictationController", () => {
-  it("starts the canonical session immediately for a direct-dictation surface", async () => {
-    const { controller } = createHarness();
+  it.each(["Escape", "blur", "hidden"])("cancels direct dictation on %s", async (action) => {
+    const { controller, onCommit } = createHarness();
+    const stopTrack = vi.fn();
+    getUserMedia.mockResolvedValue({ getTracks: () => [{ stop: stopTrack }] });
 
-    expect(controller.startDirect()).toBe(true);
-    await waitForFast(() =>
-      expect(request).toHaveBeenCalledWith("talk.session.create", expect.anything()),
-    );
+    try {
+      expect(controller.startDirect()).toBe(true);
+      await waitForFast(() =>
+        expect(request).toHaveBeenCalledWith("talk.session.create", expect.anything()),
+      );
+      expect(getUserMedia).toHaveBeenCalledOnce();
+      expect(controller.active).toBe(true);
+      emit({ transcriptionSessionId: "dictation-1", type: "partial", text: "discard me" });
 
-    expect(getUserMedia).toHaveBeenCalledOnce();
-    expect(controller.active).toBe(true);
-    controller.dispose();
+      if (action === "Escape") {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      } else if (action === "blur") {
+        window.dispatchEvent(new Event("blur"));
+      } else {
+        vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+        document.dispatchEvent(new Event("visibilitychange"));
+      }
+
+      expect(controller.active).toBe(false);
+      expect(stopTrack).toHaveBeenCalledOnce();
+      expect(onCommit).not.toHaveBeenCalled();
+      await waitForFast(() =>
+        expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+      );
+    } finally {
+      controller.dispose();
+    }
   });
 
   it("commits and unlocks immediately while remote close finishes in background", async () => {
@@ -208,11 +229,13 @@ describe("ComposerDictationController", () => {
     const close = new Promise<void>((resolve) => {
       resolveClose = resolve;
     });
+    let sessionsCreated = 0;
     request = vi.fn(async (method: string) => {
       if (method === "talk.session.create") {
+        const sessionId = `dictation-${++sessionsCreated}`;
         return {
-          sessionId: "dictation-1",
-          transcriptionSessionId: "dictation-1",
+          sessionId,
+          transcriptionSessionId: sessionId,
           audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
         };
       }
@@ -232,9 +255,26 @@ describe("ComposerDictationController", () => {
     expect(onCommit).toHaveBeenCalledWith("keep this now");
     await expect(committed).resolves.toBe(true);
     expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" });
-    resolveClose();
-    await Promise.resolve();
-    controller.dispose();
+    try {
+      expect(controller.startDirect()).toBe(true);
+      await waitForFast(() => expect(sessionsCreated).toBe(2));
+      emit({ transcriptionSessionId: "dictation-2", type: "partial", text: "new preview" });
+      expect(controller.transcript).toBe("new preview");
+      emit({ transcriptionSessionId: "dictation-1", type: "partial", text: "stale preview" });
+      expect(controller.transcript).toBe("new preview");
+      emit({
+        transcriptionSessionId: "dictation-1",
+        type: "transcript",
+        text: "late final",
+        final: true,
+      });
+      expect(controller.transcript).toBe("new preview");
+      expect(onCommit).toHaveBeenCalledExactlyOnceWith("keep this now");
+    } finally {
+      resolveClose();
+      controller.dispose();
+      await Promise.resolve();
+    }
   });
 
   it("consumes the click tail when a hold falls back to unavailable dictation", async () => {
@@ -397,7 +437,7 @@ describe("ComposerDictationController", () => {
       type: "partial",
       text: "hello wor",
     });
-    expect(controller.partial).toBe("hello wor");
+    expect(controller.transcript).toBe("hello wor");
     emit({
       transcriptionSessionId: "dictation-1",
       type: "transcript",
@@ -431,7 +471,7 @@ describe("ComposerDictationController", () => {
     controller.dispose();
   });
 
-  it("previews non-final transcript frames without committing them", async () => {
+  it("previews the complete transcript without committing until Stop", async () => {
     const { controller, onCommit, target } = createHarness();
     await startHold(target);
     emit({
@@ -440,19 +480,25 @@ describe("ComposerDictationController", () => {
       text: "hello",
       final: false,
     });
-    expect(controller.partial).toBe("hello");
+    expect(controller.transcript).toBe("hello");
     emit({
       transcriptionSessionId: "dictation-1",
       type: "transcript",
       text: "hello world",
       final: true,
     });
+    expect(controller.transcript).toBe("hello world");
+    emit({ transcriptionSessionId: "dictation-1", type: "partial", text: "again" });
+    expect(controller.transcript).toBe("hello world again");
+    emit({ transcriptionSessionId: "dictation-1", type: "transcript", text: "", final: true });
+    expect(controller.transcript).toBe("hello world again");
+    expect(onCommit).not.toHaveBeenCalled();
 
     await commitLatched(controller, target);
     await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
     );
-    expect(onCommit).toHaveBeenCalledWith("hello world");
+    expect(onCommit).toHaveBeenCalledWith("hello world again");
     controller.dispose();
   });
 

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -43,7 +43,7 @@ type DictationSessionResult = {
 type ComposerDictationSessionCallbacks = {
   onError: (message: string, preservesText: boolean) => void;
   onLevel: (level: number) => void;
-  onPartial: (text: string) => void;
+  onTranscriptChange: () => void;
   onReady: () => void;
 };
 
@@ -124,7 +124,6 @@ class ComposerDictationSession {
   private closePromise: Promise<void> | null = null;
   private stopped = false;
   private discarded = false;
-  private closed = false;
   private failed = false;
 
   constructor(
@@ -201,7 +200,6 @@ class ComposerDictationSession {
     });
     await this.appendChain;
     await this.closeRemote();
-    this.cleanupEvents();
   }
 
   async cancel(): Promise<void> {
@@ -210,7 +208,6 @@ class ComposerDictationSession {
     await this.startPromise?.catch(() => undefined);
     await this.appendChain;
     await this.closeRemote();
-    this.cleanupEvents();
   }
 
   markGatewayDisconnected(): boolean {
@@ -218,7 +215,7 @@ class ComposerDictationSession {
   }
 
   private appendAudio(samples: Float32Array): void {
-    if (this.closed) {
+    if (this.stopped) {
       return;
     }
     if (!this.sessionId) {
@@ -259,26 +256,30 @@ class ComposerDictationSession {
 
   private handleEvent(frame: GatewayEventFrame): void {
     const payload = eventPayload(frame);
-    if (!payload || payload.transcriptionSessionId !== this.transcriptionSessionId || this.closed) {
+    if (
+      !payload ||
+      payload.transcriptionSessionId !== this.transcriptionSessionId ||
+      this.stopped
+    ) {
       return;
     }
     if (payload.type === "partial" && typeof payload.text === "string") {
       this.currentPartial = payload.text.trim();
-      this.callbacks.onPartial(this.currentPartial);
+      this.callbacks.onTranscriptChange();
       return;
     }
     if (payload.type === "transcript" && typeof payload.text === "string") {
       const text = payload.text.trim();
       if (payload.final !== true) {
         this.currentPartial = text;
-        this.callbacks.onPartial(text);
+        this.callbacks.onTranscriptChange();
         return;
       }
       if (text) {
         this.finalTranscripts.push(text);
         this.currentPartial = "";
       }
-      this.callbacks.onPartial("");
+      this.callbacks.onTranscriptChange();
       return;
     }
     if (payload.type === "error") {
@@ -318,18 +319,15 @@ class ComposerDictationSession {
     this.stopped = true;
     this.abortController.abort();
     this.inputPump.stop();
+    // Retire UI events immediately; queued audio may still drain into remote close.
+    this.unsubscribe?.();
+    this.unsubscribe = null;
     this.inputMeter?.stop();
     this.inputMeter = null;
     this.media?.getTracks().forEach((track) => track.stop());
     this.media = null;
     await this.context?.close();
     this.context = null;
-  }
-
-  private cleanupEvents(): void {
-    this.closed = true;
-    this.unsubscribe?.();
-    this.unsubscribe = null;
   }
 
   private closeRemote(): Promise<void> {
@@ -348,7 +346,6 @@ export class ComposerDictationController {
   readonly inputLevel = new RealtimeTalkLevelSignal();
   private options: ComposerDictationControllerOptions;
   private phase: DictationPhase = "idle";
-  private partialTranscript = "";
   private pointerId: number | null = null;
   private pointerTarget: HTMLElement | null = null;
   private pointerBounds: DOMRect | null = null;
@@ -383,8 +380,8 @@ export class ComposerDictationController {
     return this.phase !== "idle";
   }
 
-  get partial(): string {
-    return this.partialTranscript;
+  get transcript(): string {
+    return this.session?.transcriptSnapshot() ?? "";
   }
 
   // Returns the stop promise so the confirming control can remain tied to the
@@ -449,9 +446,6 @@ export class ComposerDictationController {
     document.addEventListener("pointercancel", this.handleDocumentPointerCancel);
     document.addEventListener("pointerup", this.handleSuppressedPointerRelease);
     document.addEventListener("pointercancel", this.handleSuppressedPointerRelease);
-    document.addEventListener("keydown", this.handleDocumentKeyDown);
-    document.addEventListener("visibilitychange", this.handleVisibilityChange);
-    window.addEventListener("blur", this.handleWindowBlur);
     return true;
   }
 
@@ -506,7 +500,7 @@ export class ComposerDictationController {
     }
     if (this.phase === "pressing" || this.phase === "holding") {
       const cleanTap = this.phase === "pressing";
-      this.clearGesture();
+      this.clearPointerGesture();
       this.setPhase("idle");
       if (cleanTap) {
         this.options.onTap?.();
@@ -572,7 +566,7 @@ export class ComposerDictationController {
       return;
     }
     if (this.options.dictationAvailable === false) {
-      this.clearGesture();
+      this.clearPointerGesture();
       this.setPhase("idle");
       this.options.onDictationUnavailable?.();
       // The held pointer still owns a synthetic click. Its release expires this
@@ -592,10 +586,7 @@ export class ComposerDictationController {
         void this.stop({ commit: true });
       },
       onLevel: (level) => this.inputLevel.set(level),
-      onPartial: (text) => {
-        this.partialTranscript = text;
-        this.options.onStateChange();
-      },
+      onTranscriptChange: () => this.options.onStateChange(),
       onReady: () => {
         if (this.session === session && this.phase === "connecting") {
           this.setPhase("recording");
@@ -619,7 +610,7 @@ export class ComposerDictationController {
       return Promise.resolve(false);
     }
     const wasActive = this.active;
-    this.clearGesture();
+    this.clearPointerGesture();
     const session = this.session;
     if (!session) {
       this.reset();
@@ -641,14 +632,8 @@ export class ComposerDictationController {
   }
 
   private reset(): void {
-    this.partialTranscript = "";
     this.inputLevel.set(0);
     this.setPhase("idle");
-  }
-
-  private clearGesture(): void {
-    this.clearPointerGesture();
-    this.clearLifecycleListeners();
   }
 
   private clearPointerGesture(): void {
@@ -670,12 +655,6 @@ export class ComposerDictationController {
     document.removeEventListener("pointermove", this.handleDocumentPointerMove);
     document.removeEventListener("pointerup", this.handleDocumentPointerUp);
     document.removeEventListener("pointercancel", this.handleDocumentPointerCancel);
-  }
-
-  private clearLifecycleListeners(): void {
-    document.removeEventListener("keydown", this.handleDocumentKeyDown);
-    document.removeEventListener("visibilitychange", this.handleVisibilityChange);
-    window.removeEventListener("blur", this.handleWindowBlur);
   }
 
   private expireClickSuppression(): void {
@@ -703,6 +682,15 @@ export class ComposerDictationController {
   private setPhase(phase: DictationPhase): void {
     if (this.phase === phase) {
       return;
+    }
+    if (this.phase === "idle") {
+      document.addEventListener("keydown", this.handleDocumentKeyDown);
+      document.addEventListener("visibilitychange", this.handleVisibilityChange);
+      window.addEventListener("blur", this.handleWindowBlur);
+    } else if (phase === "idle") {
+      document.removeEventListener("keydown", this.handleDocumentKeyDown);
+      document.removeEventListener("visibilitychange", this.handleVisibilityChange);
+      window.removeEventListener("blur", this.handleWindowBlur);
     }
     this.phase = phase;
     this.options.onStateChange();

--- a/ui/src/pages/new-session/composer-dictation-control.test.ts
+++ b/ui/src/pages/new-session/composer-dictation-control.test.ts
@@ -11,7 +11,7 @@ const dictationHarness = vi.hoisted(() => ({
   controllers: [] as Array<{
     active: boolean;
     finalizing: boolean;
-    partial: string;
+    transcript: string;
     finishActive: ReturnType<typeof vi.fn>;
     handleClick: ReturnType<typeof vi.fn>;
     handlePointerDown: () => void;
@@ -24,7 +24,7 @@ vi.mock("../chat/composer-dictation.ts", () => ({
     active = false;
     connecting = false;
     finalizing = false;
-    partial = "";
+    transcript = "";
     private options: { onCommit: (transcript: string) => void; onStateChange?: () => void };
 
     get locksComposer() {
@@ -168,7 +168,7 @@ describe("NewSessionDictationControl", () => {
     }
 
     controller.active = true;
-    controller.partial = "spoken";
+    controller.transcript = "spoken";
     expect(control.previewDraft()).toBe("draft spoken");
     render(html`${control.renderStatus()}${control.render("agent-a")}`, container);
     expect(container.querySelector(".agent-chat__dictation-status")?.textContent).toContain(

--- a/ui/src/pages/new-session/composer-dictation-control.ts
+++ b/ui/src/pages/new-session/composer-dictation-control.ts
@@ -50,7 +50,7 @@ export class NewSessionDictationControl {
   previewDraft(): string | undefined {
     const dictation = this.dictation;
     return dictation?.active
-      ? this.options.textarea.previewTranscript(dictation.partial)
+      ? this.options.textarea.previewTranscript(dictation.transcript)
       : undefined;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users dictating into Control UI could see words duplicated when pressing Stop, recognized words disappear from the preview, or canceled speech remain after moving focus. Direct dictation on the new-session page also missed Escape, window-blur and hidden-page cancellation; a closing session could overwrite a newer preview.

## Why This Change Was Made

The dictation session now owns the complete transcript used by both preview and commit. Chat captures the draft and caret only when admitting a new gesture, so Stop cannot capture the preview as a new draft; the textarea blur producer no longer publishes a read-only preview. Phase transitions own cancellation listeners for both entry paths, and stopping retires session events immediately while queued audio and remote close still drain in the background.

This removes the partial-only mirror and duplicate closed/late-event-cleanup state. It changes no provider, protocol, persisted setting, dependency, or storage contract. Production LOC: +56/-61 (net -5). Tests: +197/-22 (net +175).

Provenance: direct start and immediate UI release arrived in #127823 (code/PR author @vyctorbrzezowski, merged by @steipete on August 26). Its preview made the older DOM-valued commit and partial-only display behavior visible; those lines originated in #111114 (code/PR author and merger @steipete, July 19). This repair follows the shared draft/session owners rather than adding per-surface transcript workarounds.

## User Impact

Dictated words stay visible and are inserted exactly once at the original caret or selection. Escape discards speech without changing the draft, including after moving focus. Starting another dictation while the old remote close is pending cannot let old speech replace the new preview. Stop remains immediate and never sends a chat message by itself.

## Evidence

Authentic before/after Chromium reproduction: dictating “please” into `ship it` at the caret displayed `ship please it`, but Stop produced `ship please it please`. The repaired Stop keeps exactly `ship please it`. Selection replacement, recognized-final plus interim speech, and focus-away followed by Escape also failed before their owner repairs and pass afterward.

Before — Stop duplicates the preview:

![Before: ship please it please](https://github.com/user-attachments/assets/a7fb9a24-6008-45fe-b60f-7ff1b72d529a)

After — Stop commits exactly once:

![After: ship please it](https://github.com/user-attachments/assets/a7e215b6-48cf-46ad-b1f3-b4ec531f9b91)

- 150 focused tests across seven dictation, composer, pointer/IME, new-session and audio-owner files passed.
- All seven real Chromium browser-dictation scenarios passed, including actual Stop pointerdown/click and Collapse-sidebar blur followed by Escape.
- Additional Chromium recording passed Escape, immediate restart while old close remained deferred, stale old partial/final events, and Stop; exactly two dictation sessions were created/closed and no chat/session dispatch was sent.
- Full changed-file policy, formatting, type, lint, i18n and Knip gates passed. Production UI build and startup performance passed (341390 bytes gzip, below the 341845-byte budget).
- Fresh final structured Codex autoreview and independent source review found no actionable findings.

Browser proof uses deterministic mocked Gateway traffic and fake media hardware, not an actual microphone or authenticated transcription provider. The repaired browser state ownership is exercised through the real rendered UI; provider behavior is unchanged. Exact-head hosted CI remains the landing gate.
