### PR TITLE
fix: prevent false chat layout test failures

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -771,11 +771,13 @@ async function closeBrowserPage(page: Page): Promise<void> {
 
 async function waitForLayoutSettled(page: Page, selector: string): Promise<void> {
   // content-visibility and container queries can defer descendant layout beyond
-  // a fixed rAF pair. Measure the owning geometry until two frames agree.
+  // a fixed rAF pair. Require a short quiet window so a delayed update cannot
+  // land immediately after two coincidentally identical frames.
   await page.evaluate(
-    async ({ maxFrames, selector: targetSelector }) => {
+    async ({ maxFrames, minStableFrames, minStableMs, selector: targetSelector }) => {
       let previousGeometry: string | undefined;
       let stableFrames = 0;
+      let stableSince = performance.now();
       for (let frame = 0; frame < maxFrames; frame += 1) {
         await new Promise<void>((resolve) => {
           requestAnimationFrame(() => resolve());
@@ -790,15 +792,20 @@ async function waitForLayoutSettled(page: Page, selector: string): Promise<void>
             return [rect.x, rect.y, rect.width, rect.height];
           }),
         );
-        stableFrames = geometry === previousGeometry ? stableFrames + 1 : 1;
-        if (stableFrames >= 2) {
+        if (geometry === previousGeometry) {
+          stableFrames += 1;
+        } else {
+          stableFrames = 1;
+          stableSince = performance.now();
+        }
+        if (stableFrames >= minStableFrames && performance.now() - stableSince >= minStableMs) {
           return;
         }
         previousGeometry = geometry;
       }
       throw new Error(`Layout did not stabilize for ${targetSelector} within ${maxFrames} frames`);
     },
-    { maxFrames: 60, selector },
+    { maxFrames: 60, minStableFrames: 4, minStableMs: 50, selector },
   );
 }
 
@@ -879,6 +886,43 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     sharedLayoutContext = null;
     await sharedBrowser?.close();
     sharedBrowser = null;
+  });
+
+  it("waits through delayed layout updates", async () => {
+    const page = await openBrowserPage(320, 568);
+    try {
+      await page.setContent(
+        '<div id="delayed-layout" style="position:absolute;top:0">Layout</div>',
+      );
+      await page.locator("#delayed-layout").evaluate((node) => {
+        const element = node as HTMLElement;
+        const nativeGetBoundingClientRect = element.getBoundingClientRect.bind(element);
+        let scheduled = false;
+        element.getBoundingClientRect = () => {
+          const rect = nativeGetBoundingClientRect();
+          element.dataset.lastObservedTop = String(rect.top);
+          if (!scheduled) {
+            scheduled = true;
+            requestAnimationFrame(() => {
+              requestAnimationFrame(() => {
+                element.style.top = "12px";
+              });
+            });
+          }
+          return rect;
+        };
+      });
+
+      await waitForLayoutSettled(page, "#delayed-layout");
+
+      expect(
+        await page
+          .locator("#delayed-layout")
+          .evaluate((node) => Number((node as HTMLElement).dataset.lastObservedTop)),
+      ).toBe(12);
+    } finally {
+      await closeBrowserPage(page);
+    }
   });
 
   it("keeps transcript search icons compact", async () => {


### PR DESCRIPTION
Related: #130112

## What Problem This Solves

Resolves a problem where the concurrent chat responsive browser suite could report a false layout regression when two intermediate animation frames happened to match before a delayed geometry update completed.

## Why This Change Was Made

The shared layout-settling helper now requires four matching frames and at least 50 ms without a geometry change before capturing assertions. A deterministic regression schedules a real DOM position change after two matching frames, proving the previous helper returned too early without weakening any existing layout assertion.

## User Impact

There is no shipped UI behavior change. Maintainers get reliable chat layout CI results without hiding real geometry differences behind a larger tolerance or retry.

## Evidence

- Original failure: CI run `33007665495` attempt 1 observed a `3.1867px` composer position change after the helper had declared the layout settled.
- Deterministic negative proof: with the old two-frame helper, `waits through delayed layout updates` fails with `expected 0 to be 12`.
- Local focused suite:
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/pages/chat/chat-responsive.browser.test.ts`
  - Result: `103 passed`.
- Blacksmith Testbox stress:
  - Run: `33011200227`
  - Five consecutive full-file passes: `515/515` tests.
- Review correction proof:
  - Independent review required a real delayed DOM mutation instead of simulated geometry values.
  - Updated Testbox run `33011905535`: `103/103` passed.
- Static checks:
  - `pnpm format ui/src/pages/chat/chat-responsive.browser.test.ts`
  - `node scripts/run-oxlint.mjs ui/src/pages/chat/chat-responsive.browser.test.ts`
  - `git diff --check`
- Visual proof omitted because this changes only the test harness; production Control UI code and rendering are unchanged.

AI-assisted. I reviewed and understand the change.
