### PR TITLE
fix(telegram): history claims rejected voice attachments were delivered

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -296,12 +296,15 @@ async function deliverMediaReply(params: {
   recordMessageId: (messageId: number) => void;
   textMode?: "html";
   onPlatformSendDispatch?: () => Promise<void>;
-}): Promise<{ firstDeliveredMessageId?: number; visibleFallbackText?: string }> {
+}): Promise<{
+  firstDeliveredMessageId?: number;
+  visibleFallbackText?: string;
+  mediaUrls: string[];
+}> {
   let firstDeliveredMessageId: number | undefined;
   let visibleFallbackText: string | undefined;
   let firstDeliveredCaption: string | undefined;
-  let first = true;
-  let pendingFollowUpText: string | undefined;
+  const mediaUrls: string[] = [];
   const recordPromptContextMessage = async (message: Message, text?: string) => {
     const promptContextMessage = {
       messageId: message.message_id,
@@ -312,6 +315,7 @@ async function deliverMediaReply(params: {
   };
   const deliverAcceptedMedia = async (options: {
     sender: TelegramOutboundMediaSender<Message>;
+    mediaUrl: string;
     requestParams: Record<string, unknown>;
     plainCaption?: string;
     shouldLog?: (err: unknown) => boolean;
@@ -332,6 +336,7 @@ async function deliverMediaReply(params: {
         }),
     });
     const message = delivery.result;
+    mediaUrls.push(options.mediaUrl);
     // Acceptance precedes topic checks and bookkeeping; losing this id lets
     // later failures trigger a duplicate reply for an already visible message.
     params.acceptedMessageIds.push(String(message.message_id));
@@ -358,8 +363,8 @@ async function deliverMediaReply(params: {
     deliveredCount: 0,
     ...(params.progress.promptContext ? { promptContext: params.progress.promptContext } : {}),
   });
-  for (const mediaUrl of params.mediaList) {
-    const isFirstMedia = first;
+  for (const [index, mediaUrl] of params.mediaList.entries()) {
+    const isFirstMedia = index === 0;
     const media = await params.mediaLoader(
       mediaUrl,
       buildOutboundMediaLoadOptions({
@@ -382,10 +387,6 @@ async function deliverMediaReply(params: {
       asVoice: params.reply.audioAsVoice,
     });
     const { htmlCaption, plainCaption, followUpText } = mediaPlan;
-    if (followUpText) {
-      pendingFollowUpText = followUpText;
-    }
-    first = false;
     const replyToMessageId = resolveReplyToForSend({
       replyToId: params.replyToId,
       replyToMode: params.replyToMode,
@@ -417,6 +418,7 @@ async function deliverMediaReply(params: {
         const hasCaption = typeof requestParams.caption === "string";
         await deliverAcceptedMedia({
           sender: mediaSender,
+          mediaUrl,
           requestParams,
           plainCaption: hasCaption ? plainCaption : undefined,
           shouldLog,
@@ -521,6 +523,7 @@ async function deliverMediaReply(params: {
         send: (sender) =>
           deliverAcceptedMedia({
             sender,
+            mediaUrl,
             requestParams: mediaParams,
             plainCaption,
             ...(sender.label === "photo"
@@ -530,7 +533,7 @@ async function deliverMediaReply(params: {
       });
     }
     markReplyApplied(params.progress, replyToMessageId);
-    if (pendingFollowUpText && isFirstMedia) {
+    if (followUpText) {
       try {
         const followUpMessageId = await deliverTextReply({
           bot: params.bot,
@@ -538,7 +541,7 @@ async function deliverMediaReply(params: {
           runtime: params.runtime,
           thread: params.thread,
           chunkText: params.chunkText,
-          text: pendingFollowUpText,
+          text: followUpText,
           replyMarkup: params.replyMarkup,
           richMessages: params.richMessages,
           tableMode: params.tableMode,
@@ -567,10 +570,9 @@ async function deliverMediaReply(params: {
           });
         }
       }
-      pendingFollowUpText = undefined;
     }
   }
-  return { firstDeliveredMessageId, visibleFallbackText };
+  return { firstDeliveredMessageId, visibleFallbackText, mediaUrls };
 }
 
 async function maybePinFirstDeliveredMessage(params: {
@@ -881,6 +883,7 @@ export async function deliverReplies(params: {
         }),
       );
       let firstDeliveredMessageId: number | undefined;
+      let deliveredMediaUrls: string[] = [];
       if (reactionEmoji && typeof targetId === "number") {
         await params.onPlatformSendDispatch?.();
         const reactionResult = await reactMessageTelegram(params.chatId, targetId, reactionEmoji, {
@@ -953,6 +956,7 @@ export async function deliverReplies(params: {
           ...(params.textMode ? { textMode: params.textMode } : {}),
         });
         firstDeliveredMessageId = mediaDelivery.firstDeliveredMessageId;
+        deliveredMediaUrls = mediaDelivery.mediaUrls;
         if (mediaDelivery.visibleFallbackText !== undefined) {
           contentForSentHook = mediaDelivery.visibleFallbackText;
         }
@@ -966,7 +970,7 @@ export async function deliverReplies(params: {
       });
 
       if (progress.deliveredCount > deliveredCountBeforeReply && transcriptMirror) {
-        deliveredContents.push({ text: contentForSentHook, mediaUrls: mediaList });
+        deliveredContents.push({ text: contentForSentHook, mediaUrls: deliveredMediaUrls });
       }
 
       emitMessageSentHooks({

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -2863,10 +2863,46 @@ describe("deliverReplies", () => {
     expect(sendVoice).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(firstMockCallArg(sendMessage, 1)).toContain("Hidden voice fallback");
-    expect(transcriptMirror).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "Hidden voice fallback" }),
-    );
+    expect(transcriptMirror).toHaveBeenCalledWith({
+      text: "Hidden voice fallback",
+      mediaUrls: undefined,
+    });
   });
+
+  it.each(["before", "after"])(
+    "mirrors accepted media %s a rejected voice without the rejected attachment",
+    async (position) => {
+      const voiceUrl = "https://example.com/note.ogg";
+      const photoUrl = "https://example.com/photo.jpg";
+      const mediaUrls = position === "before" ? [photoUrl, voiceUrl] : [voiceUrl, photoUrl];
+      const sendVoice = vi.fn().mockRejectedValue(createVoiceMessagesForbiddenError());
+      const sendPhoto = vi.fn().mockResolvedValue({ message_id: 7, chat: { id: "123" } });
+      const sendMessage = vi.fn().mockResolvedValue({ message_id: 8, chat: { id: "123" } });
+      const transcriptMirror = vi.fn();
+      for (const url of mediaUrls) {
+        mockMediaLoad(
+          url === voiceUrl ? "note.ogg" : "photo.jpg",
+          url === voiceUrl ? "audio/ogg" : "image/jpeg",
+          "media",
+        );
+      }
+
+      await deliverWith({
+        replies: [{ mediaUrls, audioAsVoice: true, spokenText: "Voice fallback" }],
+        runtime: createRuntime(),
+        bot: createBot({ sendVoice, sendPhoto, sendMessage }),
+        transcriptMirror,
+      });
+
+      expect(sendVoice).toHaveBeenCalledOnce();
+      expect(sendPhoto).toHaveBeenCalledOnce();
+      expect(sendMessage).toHaveBeenCalledOnce();
+      expect(transcriptMirror).toHaveBeenCalledWith({
+        text: "Voice fallback",
+        mediaUrls: [photoUrl],
+      });
+    },
+  );
 
   it("runs message_sending hooks over spokenText voice fallback content", async () => {
     messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sending");


### PR DESCRIPTION
Closes #130398

## What Problem This Solves

Fixes an issue where users receiving a text alternative after Telegram rejects an automatically generated final voice message would see the rejected audio filename in the conversation history instead of the text that was delivered. The affected final-reply mirror also incorrectly includes rejected attachments in mixed-media payloads.

## Why This Change Was Made

Record accepted media at the Telegram delivery boundary and pass that fact to the existing transcript mirror. Keep the existing media-first history representation, partial-failure handling, storage, and durable-send behavior unchanged. Remove redundant first-item and pending-follow-up bookkeeping within the same media owner.

Production LOC: +18/-14 (net +4). The added state distinguishes media actually accepted by Telegram from a successful text alternative; tests are +40/-4.

## User Impact

When a voice message cannot be delivered but its text alternative succeeds, the conversation history now retains that text. Mixed replies retain accepted attachments without claiming rejected ones were sent. Ordinary media and captionless-media recovery keep their existing behavior.

## Evidence

- Three focused regression cases failed against unchanged production: rejected voice alone and an accepted image before/after the rejected voice. Each failure showed the rejected voice URL in the mirror payload.
- Owner verification: 407 passing tests across Telegram delivery, durable sends, caption editing, and dispatch transcript behavior.
- Independent verification: 414 passing tests, including seven real grammY serialized HTTP request/response cases through the actual transcript formatter. Cases cover text recovery, both mixed-media orders, accepted voice, caption-too-long recovery, photo-to-document recovery, and complete fallback failure.
- Fresh authenticated Codex review of the complete patch and owner/caller/sibling context returned no actionable findings through priority P2.
- Provider-wire evidence used an intercepted HTTP endpoint and a stub database append. It is not live Telegram or running-Gateway evidence.
- An isolated running Gateway used documented automatic final-answer speech, native quoted Telegram ingress, a synthetic Bot API and speech endpoint, and a scripted provider. It synthesized real OGG/Opus, received `VOICE_MESSAGES_FORBIDDEN`, and delivered the text alternative. The actual Gateway `chat.history` response contains a `channel-final` delivery-mirror entry with the delivered text and no rejected audio filename. Independent source-blind validation passed all five cases below. This is mock-provider Gateway proof, not live Telegram.
- Scope clarification from runtime investigation: ordinary model `MEDIA:` directives are delivered as blocks and do not activate this final-reply mirror. Mixed-media combinations are covered at the delivery-owner boundary, not claimed as the automatic-speech Gateway flow.
- Local changed gates passed the first 17 stages, including formatting, boundary guards, doctor tests, and dead-export scans. Global plugin typechecking is locally blocked by missing unrelated IMAP dependencies; hosted exact-head CI remains required.

Hosted [CI run 33012032715](https://github.com/openclaw/openclaw/actions/runs/33012032715) passed on `803821394a15270d157c40bf97fb94012264cf64`, including the required CI gate.

Independent source-blind operator evidence (fresh synthetic chats, real Gateway API; sequential completion observed in Gateway diagnostics):

| Case | Observed Telegram requests | Observed delivery history |
| --- | --- | --- |
| 900101: voice forbidden | Voice rejected, text accepted | Exact accepted text; no audio filename |
| 900102: changed fallback text | Voice rejected, new text accepted | Exact changed text; no stale or audio entry |
| 900103: ordinary voice | Voice accepted; no text fallback | Accepted voice filename retained |
| 900104: caption recovery | Caption-bearing voice rejected; captionless voice and separate text accepted | Accepted voice filename retained |
| 900105: total failure | Voice and both text attempts rejected | No successful-delivery mirror |

The validator inspected all 11 Telegram send attempts and exactly four matching `channel-final` history entries. Total failure produced the explicit diagnostic `final reply failed: GrammyError: Call to 'sendMessage' failed! (400: Bad Request: text must be non-empty)`; the synthetic endpoint deliberately rejected nonempty text, so this proves failure handling, not Telegram's real validation rules. Final refreshed history still contained no success record for that failed case.

```json
{"kind":"mock-provider-gateway","verdict":"pass","head":"803821394a15270d157c40bf97fb94012264cf64","flow":"automatic final-only TTS with native quote","cases":5,"telegramSendAttempts":11,"channelFinalMirrors":4,"falseSuccessMirrors":0,"sourceBlind":true,"liveTelegram":false}
```

AI-assisted. No configuration, public SDK, authentication, protocol, schema, or migration changes.
