### PR TITLE
fix(telegram): stop the bot answering the same message twice after a slow turn

### DIFF
--- a/extensions/telegram/src/bot-handlers.message-pipeline.replay-guard.test.ts
+++ b/extensions/telegram/src/bot-handlers.message-pipeline.replay-guard.test.ts
@@ -1,0 +1,192 @@
+/** Verifies the ingress replay guard reads the visible-reply fact of its own attempt. */
+import type { Message } from "grammy/types";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultTelegramBotDeps } from "./bot-deps.js";
+import {
+  createTelegramMessagePipeline,
+  type TelegramMessagePipeline,
+} from "./bot-handlers.message-pipeline.js";
+import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
+import {
+  markTelegramVisibleReplyDelivered,
+  runWithTelegramUpdateProcessingFrame,
+  type TelegramMessageProcessingResult,
+} from "./bot-processing-outcome.js";
+import type { TelegramContext } from "./bot/types.js";
+
+type SettleSpooledReplay = (
+  result: TelegramMessageProcessingResult,
+) => Promise<TelegramMessageProcessingResult>;
+
+const BOT_USER_ID = 99;
+const SPOOLED_MESSAGE = {
+  message_id: 12949,
+  date: 1736380800,
+  chat: { id: 4242, type: "private" },
+  from: { id: 77, is_bot: false, first_name: "Operator" },
+  text: "does this answer twice?",
+} as Message;
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let previousStateDir: string | undefined;
+
+beforeEach(() => {
+  previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  process.env.OPENCLAW_STATE_DIR = tempDirs.make("openclaw-telegram-replay-guard-");
+  resetPluginStateStoreForTests({ closeDatabase: false });
+});
+
+afterEach(() => {
+  resetPluginStateStoreForTests();
+  if (previousStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = previousStateDir;
+  }
+});
+
+/**
+ * Builds the real pipeline over the real dispatch-dedupe guard. The stubbed
+ * message processor hands back the retained `finalizeSpooledReplayResult` and
+ * then stays pending, exactly as a deferred turn does while the reply queue owns
+ * it, so the test can settle the attempt from a context the attempt never owned.
+ */
+function createPipelineUnderTest(): {
+  pipeline: TelegramMessagePipeline;
+  dispatched: Promise<SettleSpooledReplay>;
+  replyDuringDispatch: { enabled: boolean };
+  turnResult: ReturnType<typeof createDeferred<TelegramMessageProcessingResult>>;
+} {
+  const dispatched = createDeferred<SettleSpooledReplay>();
+  const turnResult = createDeferred<TelegramMessageProcessingResult>();
+  const replyDuringDispatch = { enabled: false };
+  const cfg = { channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } } } as OpenClawConfig;
+  const processMessage = vi.fn(async (args: { turnContext?: Record<string, unknown> }) => {
+    if (replyDuringDispatch.enabled) {
+      markTelegramVisibleReplyDelivered();
+    }
+    dispatched.resolve(args.turnContext?.finalizeSpooledReplayResult as SettleSpooledReplay);
+    return await turnResult.promise;
+  });
+  const params = {
+    accountId: "default",
+    ownerAgentId: "main",
+    bot: { api: {} } as RegisterTelegramHandlerParams["bot"],
+    cfg,
+    mediaMaxBytes: 1,
+    opts: { token: "tok" },
+    telegramCfg: {},
+    logger: getChildLogger({ module: "telegram/replay-guard-test" }),
+    runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    shouldSkipUpdate: () => false,
+    resolveGroupPolicy: () => ({ allowlistEnabled: false, allowed: true }),
+    resolveGroupActivation: () => undefined,
+    resolveGroupRequireMention: () => false,
+    resolveTelegramGroupConfig: () => ({ groupConfig: undefined, topicConfig: undefined }),
+    processMessage: processMessage as unknown as RegisterTelegramHandlerParams["processMessage"],
+    telegramDeps: {
+      ...defaultTelegramBotDeps,
+      getRuntimeConfig: () => cfg,
+      wasSentByBot: () => false,
+      readChannelAllowFromStore: async () => [],
+    },
+  } as unknown as RegisterTelegramHandlerParams;
+  return {
+    pipeline: createTelegramMessagePipeline(params),
+    dispatched: dispatched.promise,
+    replyDuringDispatch,
+    turnResult,
+  };
+}
+
+function dispatchSpooledAttempt(
+  pipeline: TelegramMessagePipeline,
+  claims: Awaited<ReturnType<TelegramMessagePipeline["claimMessageDispatchDedupe"]>>,
+) {
+  return runWithTelegramUpdateProcessingFrame(
+    async () =>
+      await pipeline.processMessageWithReplyChain({
+        ctx: { message: SPOOLED_MESSAGE, update: { update_id: 991 } } as unknown as TelegramContext,
+        msg: SPOOLED_MESSAGE,
+        allMedia: [],
+        storeAllowFrom: [],
+        options: { spooledReplay: true },
+        dispatchDedupeClaims: claims.process ? claims.claims : [],
+      }),
+  );
+}
+
+describe("Telegram spooled ingress replay guard", () => {
+  it("suppresses the redelivery of an attempt that replied before the queue abandoned it", async () => {
+    // The reviewer-requested sequence in one trace: confirmed send -> abandonment
+    // settled on the queue's own chain (outside this update's frame) -> the spool
+    // redelivery of the same logical message is refused as a duplicate.
+    const trace: string[] = [];
+    const { pipeline, dispatched, replyDuringDispatch, turnResult } = createPipelineUnderTest();
+    const claimed = await pipeline.claimMessageDispatchDedupe(SPOOLED_MESSAGE, BOT_USER_ID);
+    trace.push(`claim attempt=1 process=${claimed.process}`);
+
+    replyDuringDispatch.enabled = true;
+    const dispatch = dispatchSpooledAttempt(pipeline, claimed);
+    const settleFromQueueChain = await dispatched;
+    trace.push(`outbound send ok chatId=${SPOOLED_MESSAGE.chat.id} replyToMessageId=<redacted>`);
+
+    const settled = await settleFromQueueChain({
+      kind: "failed-retryable",
+      error: new Error("turn-abandoned"),
+    });
+    turnResult.resolve(settled);
+    await dispatch;
+    trace.push(`settled kind=${settled.kind}`);
+
+    const redelivered = await pipeline.claimMessageDispatchDedupe(SPOOLED_MESSAGE, BOT_USER_ID);
+    trace.push(`claim attempt=2 process=${redelivered.process}`);
+
+    expect(trace).toEqual([
+      "claim attempt=1 process=true",
+      "outbound send ok chatId=4242 replyToMessageId=<redacted>",
+      "settled kind=failed-retryable",
+      "claim attempt=2 process=false",
+    ]);
+  });
+
+  it("redelivers an abandoned attempt that never replied, even while another update's frame is current", async () => {
+    // Settlement runs on the followup drain chain, whose frame belongs to
+    // whichever update rooted it. Committing on that update's reply would drop
+    // this message without ever answering it.
+    const trace: string[] = [];
+    const { pipeline, dispatched, turnResult } = createPipelineUnderTest();
+    const claimed = await pipeline.claimMessageDispatchDedupe(SPOOLED_MESSAGE, BOT_USER_ID);
+    trace.push(`claim attempt=1 process=${claimed.process}`);
+
+    const dispatch = dispatchSpooledAttempt(pipeline, claimed);
+    const settleFromQueueChain = await dispatched;
+
+    const foreign = await runWithTelegramUpdateProcessingFrame(async () => {
+      markTelegramVisibleReplyDelivered();
+      trace.push("outbound send ok update=other-attempt");
+      return await settleFromQueueChain({
+        kind: "failed-retryable",
+        error: new Error("turn-abandoned"),
+      });
+    });
+    turnResult.resolve(foreign.value);
+    await dispatch;
+    trace.push(`settled kind=${foreign.value.kind}`);
+
+    const redelivered = await pipeline.claimMessageDispatchDedupe(SPOOLED_MESSAGE, BOT_USER_ID);
+    trace.push(`claim attempt=2 process=${redelivered.process}`);
+
+    expect(trace).toEqual([
+      "claim attempt=1 process=true",
+      "outbound send ok update=other-attempt",
+      "settled kind=failed-retryable",
+      "claim attempt=2 process=true",
+    ]);
+  });
+});

--- a/extensions/telegram/src/bot-handlers.message-pipeline.ts
+++ b/extensions/telegram/src/bot-handlers.message-pipeline.ts
@@ -37,6 +37,7 @@ import {
   createTelegramSpooledReplayParticipant,
   getTelegramSpooledReplayDeferredParticipant,
   getTelegramSpooledReplayLifecycle,
+  hasTelegramVisibleReplyDelivered,
   isTelegramSpooledReplayUpdate,
   recordTelegramMessageProcessingResult,
   type TelegramMessageProcessingResult,
@@ -443,7 +444,14 @@ export function createTelegramMessagePipeline({
       }
       const finalization = (async () => {
         const finalized = result;
-        if (result.kind === "completed") {
+        // A retryable failure that ALREADY delivered a reply is not safely
+        // retryable: releasing the guard lets the spool replay a turn that has
+        // spoken, and the user sees the answer twice. Commit the guard instead so
+        // the replay is duplicate-suppressed. Only the guard is committed - the
+        // spool row still follows its own retry/dead-letter policy.
+        const repliedBeforeFailing =
+          result.kind === "failed-retryable" && hasTelegramVisibleReplyDelivered();
+        if (result.kind === "completed" || repliedBeforeFailing) {
           // Do not cache or settle a durable-adoption failure. Deferred queue
           // ownership retries this callback with the same spool participants.
           const releaseSettlementHolds = beginSpooledReplaySettlementHolds(

--- a/extensions/telegram/src/bot-handlers.message-pipeline.ts
+++ b/extensions/telegram/src/bot-handlers.message-pipeline.ts
@@ -33,11 +33,11 @@ import type {
   TelegramMessageContextOptions,
 } from "./bot-message-context.types.js";
 import {
+  captureTelegramVisibleReplyDelivered,
   createTelegramSpooledReplayDeferredParticipant,
   createTelegramSpooledReplayParticipant,
   getTelegramSpooledReplayDeferredParticipant,
   getTelegramSpooledReplayLifecycle,
-  hasTelegramVisibleReplyDelivered,
   isTelegramSpooledReplayUpdate,
   recordTelegramMessageProcessingResult,
   type TelegramMessageProcessingResult,
@@ -393,6 +393,10 @@ export function createTelegramMessagePipeline({
     let dispatchDedupeCommitted = false;
     let spooledReplayFinalResult: TelegramMessageProcessingResult | undefined;
     let spooledReplayFinalization: Promise<TelegramMessageProcessingResult> | undefined;
+    // Settlement below is also invoked from contexts this dispatch does not own
+    // (the reply queue's retained onAbandoned runs on the followup drain chain),
+    // so bind the visible-reply fact here while this attempt's frame is current.
+    const hasDeliveredVisibleReply = captureTelegramVisibleReplyDelivered();
     // Callback-submit retries also set options.spooledReplay without durable ingress.
     // Media aborts retry only when the update frame or a buffered participant owns replay.
     const durableMediaReplay =
@@ -450,7 +454,7 @@ export function createTelegramMessagePipeline({
         // the replay is duplicate-suppressed. Only the guard is committed - the
         // spool row still follows its own retry/dead-letter policy.
         const repliedBeforeFailing =
-          result.kind === "failed-retryable" && hasTelegramVisibleReplyDelivered();
+          result.kind === "failed-retryable" && hasDeliveredVisibleReply();
         if (result.kind === "completed" || repliedBeforeFailing) {
           // Do not cache or settle a durable-adoption failure. Deferred queue
           // ownership retries this callback with the same spool participants.

--- a/extensions/telegram/src/bot-processing-outcome.test.ts
+++ b/extensions/telegram/src/bot-processing-outcome.test.ts
@@ -1,8 +1,8 @@
 /** Verifies Telegram update outcomes stay attached to their durable ingress owner. */
 import { describe, expect, it } from "vitest";
 import {
+  captureTelegramVisibleReplyDelivered,
   ensureTelegramMessageProcessingResult,
-  hasTelegramVisibleReplyDelivered,
   markTelegramVisibleReplyDelivered,
   recordTelegramMessageProcessingResult,
   runWithTelegramUpdateProcessingFrame,
@@ -50,42 +50,47 @@ describe("Telegram update processing outcomes", () => {
 describe("Telegram visible-reply delivery fact", () => {
   it("records delivery on the owning frame and reads it back", async () => {
     await runWithTelegramUpdateProcessingFrame(async () => {
-      expect(hasTelegramVisibleReplyDelivered()).toBe(false);
+      const hasDelivered = captureTelegramVisibleReplyDelivered();
+      expect(hasDelivered()).toBe(false);
       markTelegramVisibleReplyDelivered();
-      expect(hasTelegramVisibleReplyDelivered()).toBe(true);
+      expect(hasDelivered()).toBe(true);
       return undefined;
     });
   });
 
   it("shares the fact with nested middleware, which is the ingress owner's frame", async () => {
     await runWithTelegramUpdateProcessingFrame(async () => {
+      const hasDelivered = captureTelegramVisibleReplyDelivered();
       await runWithTelegramUpdateProcessingFrame(async () => {
         markTelegramVisibleReplyDelivered();
         return undefined;
       });
       // The nested call reuses the outer frame, so a reply sent by inner
       // middleware must still fence the outer attempt's retry decision.
-      expect(hasTelegramVisibleReplyDelivered()).toBe(true);
+      expect(hasDelivered()).toBe(true);
       return undefined;
     });
   });
 
-  it("does not leak between updates", async () => {
+  it("answers for its own update while another update's frame is current", async () => {
+    // Settlement runs on the followup drain chain, whose ambient frame belongs to
+    // whichever update rooted it. Reading there must not answer for this attempt.
+    const captured = await runWithTelegramUpdateProcessingFrame(async () =>
+      captureTelegramVisibleReplyDelivered(),
+    );
     await runWithTelegramUpdateProcessingFrame(async () => {
       markTelegramVisibleReplyDelivered();
+      expect(captured.value()).toBe(false);
       return undefined;
     });
-    await runWithTelegramUpdateProcessingFrame(async () => {
-      expect(hasTelegramVisibleReplyDelivered()).toBe(false);
-      return undefined;
-    });
+    expect(captured.value()).toBe(false);
   });
 
-  it("defaults to false with no active frame so an unknown state still retries", () => {
-    // False is the safe default: a false negative costs a duplicate reply, a
-    // false positive would silently drop the user's message.
-    expect(hasTelegramVisibleReplyDelivered()).toBe(false);
+  it("stays false for a dispatch captured with no active frame", () => {
+    // A false negative costs a duplicate reply; a false positive drops the
+    // user's message, so an unknown owner keeps the pre-existing retry.
+    const hasDelivered = captureTelegramVisibleReplyDelivered();
     markTelegramVisibleReplyDelivered();
-    expect(hasTelegramVisibleReplyDelivered()).toBe(false);
+    expect(hasDelivered()).toBe(false);
   });
 });

--- a/extensions/telegram/src/bot-processing-outcome.test.ts
+++ b/extensions/telegram/src/bot-processing-outcome.test.ts
@@ -2,6 +2,8 @@
 import { describe, expect, it } from "vitest";
 import {
   ensureTelegramMessageProcessingResult,
+  hasTelegramVisibleReplyDelivered,
+  markTelegramVisibleReplyDelivered,
   recordTelegramMessageProcessingResult,
   runWithTelegramUpdateProcessingFrame,
 } from "./bot-processing-outcome.js";
@@ -42,5 +44,48 @@ describe("Telegram update processing outcomes", () => {
     });
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe("Telegram visible-reply delivery fact", () => {
+  it("records delivery on the owning frame and reads it back", async () => {
+    await runWithTelegramUpdateProcessingFrame(async () => {
+      expect(hasTelegramVisibleReplyDelivered()).toBe(false);
+      markTelegramVisibleReplyDelivered();
+      expect(hasTelegramVisibleReplyDelivered()).toBe(true);
+      return undefined;
+    });
+  });
+
+  it("shares the fact with nested middleware, which is the ingress owner's frame", async () => {
+    await runWithTelegramUpdateProcessingFrame(async () => {
+      await runWithTelegramUpdateProcessingFrame(async () => {
+        markTelegramVisibleReplyDelivered();
+        return undefined;
+      });
+      // The nested call reuses the outer frame, so a reply sent by inner
+      // middleware must still fence the outer attempt's retry decision.
+      expect(hasTelegramVisibleReplyDelivered()).toBe(true);
+      return undefined;
+    });
+  });
+
+  it("does not leak between updates", async () => {
+    await runWithTelegramUpdateProcessingFrame(async () => {
+      markTelegramVisibleReplyDelivered();
+      return undefined;
+    });
+    await runWithTelegramUpdateProcessingFrame(async () => {
+      expect(hasTelegramVisibleReplyDelivered()).toBe(false);
+      return undefined;
+    });
+  });
+
+  it("defaults to false with no active frame so an unknown state still retries", () => {
+    // False is the safe default: a false negative costs a duplicate reply, a
+    // false positive would silently drop the user's message.
+    expect(hasTelegramVisibleReplyDelivered()).toBe(false);
+    markTelegramVisibleReplyDelivered();
+    expect(hasTelegramVisibleReplyDelivered()).toBe(false);
   });
 });

--- a/extensions/telegram/src/bot-processing-outcome.ts
+++ b/extensions/telegram/src/bot-processing-outcome.ts
@@ -81,9 +81,9 @@ export function ensureTelegramMessageProcessingResult(
 }
 
 /**
- * Records that this attempt delivered a user-visible reply. Called from the one
- * chokepoint that knows a send actually succeeded; a no-op outside an update
- * frame, so bot-initiated sends (cron, alerts) never set it.
+ * Records that this attempt delivered a user-visible reply, from the durable
+ * send funnel's success log — the point that knows a send actually landed. A
+ * no-op outside an update frame, so sends with no turn in flight never set it.
  */
 export function markTelegramVisibleReplyDelivered(): void {
   const frame = telegramUpdateProcessingFrames.getStore();
@@ -93,12 +93,16 @@ export function markTelegramVisibleReplyDelivered(): void {
 }
 
 /**
- * True when this attempt already replied. Defaults false when no frame is
- * active, which keeps the pre-existing retry behaviour: a false negative costs a
- * duplicate reply, a false positive would drop the user's message entirely.
+ * Binds the fact to the frame owning the caller's dispatch, while that frame is
+ * still the current async context. Settlement is also reached from contexts the
+ * attempt does not own (the reply queue's retained `onAbandoned`, the ingress
+ * drain chain); reading ambiently there resolves whichever update's frame is
+ * current, so it both misses this attempt's own reply and can read another
+ * attempt's reply and drop a message that was never answered.
  */
-export function hasTelegramVisibleReplyDelivered(): boolean {
-  return telegramUpdateProcessingFrames.getStore()?.visibleReplyDelivered === true;
+export function captureTelegramVisibleReplyDelivered(): () => boolean {
+  const frame = telegramUpdateProcessingFrames.getStore();
+  return () => frame?.visibleReplyDelivered === true;
 }
 
 export function recordTelegramMessageProcessingResult(

--- a/extensions/telegram/src/bot-processing-outcome.ts
+++ b/extensions/telegram/src/bot-processing-outcome.ts
@@ -8,6 +8,12 @@ export type TelegramMessageProcessingResult =
 
 type TelegramUpdateProcessingFrame = {
   result?: TelegramMessageProcessingResult;
+  /**
+   * Set once this attempt has put a reply in front of the user. A retryable
+   * failure after that point is NOT safely retryable: the spool would replay a
+   * turn that already spoke, and the user sees the answer twice.
+   */
+  visibleReplyDelivered?: boolean;
 };
 
 type TelegramSpooledReplayLifecycle = {
@@ -72,6 +78,27 @@ export function ensureTelegramMessageProcessingResult(
   if (frame && !frame.result) {
     frame.result = result;
   }
+}
+
+/**
+ * Records that this attempt delivered a user-visible reply. Called from the one
+ * chokepoint that knows a send actually succeeded; a no-op outside an update
+ * frame, so bot-initiated sends (cron, alerts) never set it.
+ */
+export function markTelegramVisibleReplyDelivered(): void {
+  const frame = telegramUpdateProcessingFrames.getStore();
+  if (frame) {
+    frame.visibleReplyDelivered = true;
+  }
+}
+
+/**
+ * True when this attempt already replied. Defaults false when no frame is
+ * active, which keeps the pre-existing retry behaviour: a false negative costs a
+ * duplicate reply, a false positive would drop the user's message entirely.
+ */
+export function hasTelegramVisibleReplyDelivered(): boolean {
+  return telegramUpdateProcessingFrames.getStore()?.visibleReplyDelivered === true;
 }
 
 export function recordTelegramMessageProcessingResult(

--- a/extensions/telegram/src/send-context.ts
+++ b/extensions/telegram/src/send-context.ts
@@ -59,9 +59,10 @@ type TelegramOutboundSuccessLogParams = {
 };
 
 export function logTelegramOutboundSendOk(params: TelegramOutboundSuccessLogParams): void {
-  // Single chokepoint that knows a send actually landed, so it is where the
-  // "this attempt already spoke to the user" fact is recorded. The ingress
-  // settlement reads it to decide whether a retryable failure may replay.
+  // The durable funnel's confirmation point, so it is where the "this attempt
+  // already spoke to the user" fact is recorded. The ingress settlement reads it
+  // to decide whether a retryable failure may replay. Note the streaming funnel
+  // (`bot/delivery.send.ts`) confirms sends without recording it.
   markTelegramVisibleReplyDelivered();
   const parts = [
     "telegram outbound send ok",

--- a/extensions/telegram/src/send-context.ts
+++ b/extensions/telegram/src/send-context.ts
@@ -12,6 +12,7 @@ import { getOrCreateAccountThrottler } from "./account-throttler.js";
 import { type ResolvedTelegramAccount, resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { normalizeTelegramApiRoot } from "./api-root.js";
+import { markTelegramVisibleReplyDelivered } from "./bot-processing-outcome.js";
 import { asTelegramClientFetch, createTelegramClientFetch } from "./client-fetch.js";
 import { resolveTelegramTransport, type TelegramTransport } from "./fetch.js";
 import { rethrowTelegramSendError, shouldRetryTelegramSendError } from "./network-errors.js";
@@ -58,6 +59,10 @@ type TelegramOutboundSuccessLogParams = {
 };
 
 export function logTelegramOutboundSendOk(params: TelegramOutboundSuccessLogParams): void {
+  // Single chokepoint that knows a send actually landed, so it is where the
+  // "this attempt already spoke to the user" fact is recorded. The ingress
+  // settlement reads it to decide whether a retryable failure may replay.
+  markTelegramVisibleReplyDelivered();
   const parts = [
     "telegram outbound send ok",
     `accountId=${params.accountId}`,


### PR DESCRIPTION
## What Problem This Solves

A Telegram turn that has already replied can be replayed from the durable ingress spool and run again, so the user receives the same answer twice.

The trigger is the ingress adoption watchdog. An attempt that does not reach adoption within 5 minutes is settled `failed-retryable` and its dispatch-replay claim is released, so the spool redelivers the update. That is correct for an attempt that never reached the user. It is wrong for one that already spoke.

Captured on a live gateway, the watchdog naming itself:

```
[telegram] spooled update 735974100 failed; keeping for retry:
  Channel ingress claim→adoption stalled for event 735974100 on lane
  telegram:<chat> after 300003ms; applying retry policy (handler-timeout).
```

300003ms is `DEFAULT_INGRESS_ADOPTION_STALL_MS` (`src/channels/message/ingress-drain.ts:51`, pinned by an existing assertion at `ingress-drain.test.ts:965`), overridable via `OPENCLAW_TELEGRAM_SPOOLED_HANDLER_TIMEOUT_MS` (`extensions/telegram/src/telegram-ingress-drain.ts:45`).

## Why This Change Was Made

Nothing at the settlement decision knew whether a reply had gone out, so this records the fact where it is known and reads it where it is needed. `logTelegramOutboundSendOk` (`extensions/telegram/src/send-context.ts:61`) is the durable funnel's confirmation point and marks the active update-processing frame; settlement reads that mark and commits the replay guard instead of releasing it.

**The first revision of this PR read that fact ambiently, and did not work.** The ClawSweeper P1 was correct and I have fixed it rather than argued with it.

The mark lives on an `AsyncLocalStorage` frame entered around `bot.handleUpdate` (`bot-processing-outcome.ts:48`, entered at `telegram-ingress-drain-factory.ts:68`). Settlement is reached two ways:

- `bot-message.ts:455-465` and `:525`, the handler's own await path, inside the frame. The read worked.
- `bot-message.ts:439-446`, the retained `onAbandoned` callback invoked by the reply queue at `src/auto-reply/reply/queue/types.ts:348`, outside it. The read returned `false`.

The second is the deferred-phase watchdog case, which is the case this PR exists to fix. So the original patch missed its own target.

It was also unsafe in the other direction, which contradicts what the first revision of this body claimed. Because `getStore()` resolves at call time, update A's settlement running inside update B's frame reads B's mark. If B replied and A did not, A's guard commits and **A is silently dropped**. That is reachable, not theoretical: the reply-queue drain never detaches its async context (`src/auto-reply/reply/queue/drain.ts:1267-1272` swaps only the callback and self-reschedules from its own `finally` at `:1535`, `:1538`, `:1548`), so one starter's context propagates across drain cycles and updates.

**The fix binds the frame instead of resolving it later.** `captureTelegramVisibleReplyDelivered()` is called during dispatch setup, while the attempt's own frame is current, and returns a closure over that frame object:

```ts
export function captureTelegramVisibleReplyDelivered(): () => boolean {
  const frame = telegramUpdateProcessingFrames.getStore();
  return () => frame?.visibleReplyDelivered === true;
}
```

There is no `getStore()` at settlement, so the deferred route reads the right frame and the foreign-frame read becomes unrepresentable.

**On the review's suggested shape - storing the fact with the deferred participant - I did not take it, and I want to be explicit about why.** `getTelegramSpooledReplayDeferredParticipant()` (`bot-processing-outcome.ts:216`) is itself an `AsyncLocalStorage` read:

```ts
return telegramSpooledReplayFrames.getStore()?.deferredWork;
```

There are two stores, declared at `:48` and `:49`, entered at `telegram-ingress-drain.ts:335` and `telegram-ingress-drain-factory.ts:68` around the same `bot.handleUpdate` region. They have identical async lifetime, so moving the fact between them changes nothing about which attempt a settlement reads. Settlement lifetime was not the missing property: the frame is alive and reachable when `onAbandoned` runs, and `getStore()` simply returns a different one. Both shapes fix the read; neither fixes the write. Happy to switch if that reasoning is wrong.

Only the replay guard is committed. The spool row still follows its own retry and dead-letter policy, and the drain contract is untouched.

## User Impact

Users stop seeing the bot repeat itself when a turn outruns the 5 minute watchdog. A message whose turn fails *before* replying still retries exactly as before, so this does not trade duplicates for lost messages - and with this revision it also no longer risks dropping an unanswered message from an unrelated update.

Operators on tool-heavy or long-context workloads see the largest difference, because those are the turns that outrun the watchdog.

## Evidence

**Three-beat proof, in the shape the review asked for.** Neutralizing the capture back to an ambient read reproduces both production failure modes as ordered traces:

```
duplicate reply:  ... "settled kind=failed-retryable",
                  -   "claim attempt=2 process=false"     expected: suppressed
                  +   "claim attempt=2 process=true"      pre-fix: replayed

silent drop:      ... "outbound send ok update=other-attempt",
                  -   "claim attempt=2 process=true"      expected: redelivered
                  +   "claim attempt=2 process=false"     pre-fix: dropped
```

Neutralize cycle, re-derived independently rather than taken on report:

```
pass          10/10
neutralized    3 failed / 7 passed
restored      10/10   (file byte-identical to the fix)
```

The three that go red, by name:

```
× suppresses the redelivery of an attempt that replied before the queue abandoned it
× redelivers an abandoned attempt that never replied, even while another update's frame is current
× answers for its own update while another update's frame is current
```

The middle one is the silent-drop guard, covering the failure the first revision of this body wrongly ruled out.

**Suite.** 4 files, 298 passed: `bot-processing-outcome.test.ts`, the new `bot-handlers.message-pipeline.replay-guard.test.ts`, plus `bot.test.ts` and `bot.create-telegram-bot.test.ts` - the last two included deliberately because a sibling Telegram change broke exactly those with pinned-date fixtures.

**`pnpm check:changed`.** 18 of 19 lanes green, including `typecheck extensions`, `format changed files`, `plugin boundaries`, the dead-export scan and the max-lines ratchet. The 19th, `typecheck extension tests`, fails on two pre-existing errors in `extensions/qa-lab/src/*.cleanup.test.ts` (`providerReadinessArtifactPath` missing). Those test files were last touched in #127715 and the type requiring the property in #106039; this branch changes no qa-lab file. I could not re-execute that lane on the untouched base to prove it independently - the run was OOM-killed on this machine, which is not a build host - so this is provenance and file-scope rather than a clean re-run, and CI is the better arbiter.

**Rebased onto current `main` (`849e35ce36d`)** from 1,351 commits behind, no conflicts. Suite re-run after the rebase: **299 passed**, one more than before, from an upstream test added in the interval.

**Real-behavior proof: I could not produce one, and the reason is specific rather than a shortage of effort.** I wrote a QA Lab scenario for this path (driving the real Telegram plugin over Crabline), ran it in three states with the shipped bundle content verified each time, and **it passes with the fix neutralized** - so it does not cover the fix and I am not offering it as proof.

The blocker is an ordering fact, not scenario authoring. The claim-to-adoption stall watchdog only fires while the drain claim is `dispatching` or `deferred` (`src/channels/message/ingress-drain.ts:391-422`); `onAdopted` clears that timer (`:449-465`) and fires at run start, before the model emits anything (`src/auto-reply/reply/agent-runner-execute.ts:294`). **So no agent answer for a claim can precede that claim's own watchdog**, and the confirmed-send arm is unreachable end to end. Genuinely pre-adoption durable sends do exist (`dispatch-from-config.finalize.ts:127`, `get-reply-run-queue.ts:38-46`), but the drain adopts callback-free immediately afterwards (`ingress-drain.ts:602-608`), so landing the watchdog in that window is a race and would be flaky by construction.

What would unblock it is what the plugin's own e2e test already has: a controllable Bot API fault after the first visible send (`telegram-ingress-coalescing.e2e.test.ts:356-390` stalls `getFile` with a 429). Crabline records provider traffic but exposes no fault-injection seam to a YAML scenario. That is a bounded qa-lab change and explicitly **not** a production seam. I have not made it here - happy to, if that is the preferred route to closing this checkbox.

**Size.** Production +9, tests +197 over the previous revision of this branch.

**A gap this does not close, stated rather than discovered later.** `logTelegramOutboundSendOk` is not the only confirmation point. `extensions/telegram/src/bot/delivery.send.ts:115` logs `telegram text delivery ok` and does not record the fact, so a reply delivered through that funnel still leaves the guard blind and the duplicate remains possible on that path. Fixing it is a one-line call in the same shape; I have left it out of this PR because it is a second delivery surface with its own tests and it should not ride in on a P1 repair.

**Corrections to the first revision of this body.** It said no related issue existed - four overlap: #127090 (merged, the direct predecessor that introduced the retry disposition), #128042 (closed, same symptom, mirror mechanism), #127229 (open, same watchdog release path, opposite outcome), and this PR. It reported core ingress at 97/97; the real figure is 100/100 across 7 files. It rendered the log line as `claim->adoption`; the shipped string uses a real arrow (`src/channels/message/ingress-drain.ts:400`). It also claimed the guard could only ever produce a duplicate and never a drop, which is refuted above.

**Not verified.** No live-channel or mock-gateway run for this revision; the traces are from the regression harness driving the real dispatch-dedupe guard, not from a production replay. The originally reported duplicate was observed in production but I did not reproduce that end to end under test. A separate 2-3s double dispatch on the same host, with no `keeping for retry` in the window, is not this bug and is not fixed here.

Claude assisted with the AsyncLocalStorage analysis and the regression harness. The submitter owns the conclusions and final review.
