### PR TITLE
fix(webchat): render generated documents as attachments

### DIFF
--- a/src/agents/embedded-agent-messaging-extraction.ts
+++ b/src/agents/embedded-agent-messaging-extraction.ts
@@ -1,4 +1,5 @@
 /** Extracts message delivery evidence from embedded-agent tool calls and results. */
+import { asNonNegativeFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeOptionalLowercaseString,
@@ -6,7 +7,6 @@ import {
   normalizeOptionalStringifiedId,
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.js";
 import type { ChannelMessageActionName } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -49,11 +49,48 @@ export function extractMessagingToolSourceReplyPayload(
     : Array.isArray(details.mediaUrls)
       ? details.mediaUrls
       : [];
-  const mediaUrls = uniqueStrings(
-    rawMediaUrls.filter((value): value is string => typeof value === "string"),
-  );
+  const mediaUrls = rawMediaUrls.filter((value): value is string => typeof value === "string");
   if (mediaUrls.length > 0) {
     payload.mediaUrls = mediaUrls;
+  }
+  if (Array.isArray(sourceReply.attachments)) {
+    const attachments = sourceReply.attachments.flatMap((value) => {
+      const attachment = readRecord(value);
+      if (!attachment) {
+        return [];
+      }
+      const durationMs = asNonNegativeFiniteNumber(attachment.durationMs);
+      const width = asNonNegativeFiniteNumber(attachment.width);
+      const height = asNonNegativeFiniteNumber(attachment.height);
+      const attachmentPath = readStringValue(attachment.path);
+      const attachmentUrl = readStringValue(attachment.url);
+      const attachmentMediaUrl = readStringValue(attachment.mediaUrl);
+      const filePath = readStringValue(attachment.filePath);
+      const mimeType = readStringValue(attachment.mimeType);
+      const name = readStringValue(attachment.name);
+      return [
+        {
+          ...(attachmentPath ? { path: attachmentPath } : {}),
+          ...(attachmentUrl ? { url: attachmentUrl } : {}),
+          ...(attachmentMediaUrl ? { mediaUrl: attachmentMediaUrl } : {}),
+          ...(filePath ? { filePath } : {}),
+          ...(mimeType ? { mimeType } : {}),
+          ...(name ? { name } : {}),
+          ...(typeof attachment.trustedLocalMedia === "boolean"
+            ? { trustedLocalMedia: attachment.trustedLocalMedia }
+            : {}),
+          ...(durationMs !== undefined ? { durationMs } : {}),
+          ...(width !== undefined ? { width } : {}),
+          ...(height !== undefined ? { height } : {}),
+        },
+      ];
+    });
+    if (attachments.length > 0) {
+      payload.attachments = attachments;
+    }
+  }
+  if (typeof sourceReply.trustedLocalMedia === "boolean") {
+    payload.trustedLocalMedia = sourceReply.trustedLocalMedia;
   }
   if (sourceReply.audioAsVoice === true || details.audioAsVoice === true) {
     payload.audioAsVoice = true;

--- a/src/agents/embedded-agent-messaging.types.ts
+++ b/src/agents/embedded-agent-messaging.types.ts
@@ -21,12 +21,14 @@ export type MessagingToolSend = {
 export type MessagingToolSourceReplyPayload = Pick<
   ReplyPayload,
   | "audioAsVoice"
+  | "attachments"
   | "channelData"
   | "interactive"
   | "mediaUrl"
   | "mediaUrls"
   | "presentation"
   | "text"
+  | "trustedLocalMedia"
 > & {
   idempotencyKey?: string;
   transcriptOwner?: true;

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -467,6 +467,12 @@ export function buildEmbeddedRunPayloads(params: {
       if (item.media?.length) {
         payload.mediaUrls = item.media;
       }
+      if (item.attachments?.length) {
+        payload.attachments = item.attachments;
+      }
+      if (item.trustedLocalMedia !== undefined) {
+        payload.trustedLocalMedia = item.trustedLocalMedia;
+      }
       if (item.isError !== undefined) {
         payload.isError = item.isError;
       }

--- a/src/agents/embedded-agent-runner/run/source-reply-payloads.ts
+++ b/src/agents/embedded-agent-runner/run/source-reply-payloads.ts
@@ -16,6 +16,8 @@ type EmbeddedRunReplyItem = {
   /** Marks pre-tool commentary (💬) — a display lane, suppressed unless the channel opts in. */
   isCommentary?: boolean;
   audioAsVoice?: boolean;
+  attachments?: ReplyPayload["attachments"];
+  trustedLocalMedia?: boolean;
   replyToId?: string;
   replyToTag?: boolean;
   replyToCurrent?: boolean;
@@ -43,8 +45,8 @@ export function buildSourceReplyPayloadState(params: {
   const sourceReplyPayloads = params.payloads ?? [];
   const replyItems = sourceReplyPayloads.flatMap((payload, index): EmbeddedRunReplyItem[] => {
     const text = normalizeOptionalString(payload.text) ?? "";
-    const media = Array.from(
-      new Set([...(payload.mediaUrl ? [payload.mediaUrl] : []), ...(payload.mediaUrls ?? [])]),
+    const media = (
+      payload.mediaUrls?.length ? payload.mediaUrls : payload.mediaUrl ? [payload.mediaUrl] : []
     ).filter((value) => value.trim().length > 0);
     if (
       !text &&
@@ -63,6 +65,10 @@ export function buildSourceReplyPayloadState(params: {
         ...(payload.mediaUrl ? { mediaUrl: payload.mediaUrl } : {}),
         ...(media.length ? { media } : {}),
         ...(payload.audioAsVoice ? { audioAsVoice: true } : {}),
+        ...(payload.attachments?.length ? { attachments: payload.attachments } : {}),
+        ...(payload.trustedLocalMedia !== undefined
+          ? { trustedLocalMedia: payload.trustedLocalMedia }
+          : {}),
         ...(payload.presentation ? { presentation: payload.presentation } : {}),
         ...(payload.interactive ? { interactive: payload.interactive } : {}),
         ...(payload.channelData ? { channelData: payload.channelData } : {}),

--- a/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
+++ b/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
@@ -119,6 +119,13 @@ describe("WebChat message tool internal source reply", () => {
         const sourceReply = extractMessagingToolSourceReplyPayload(toolResult);
         expect(sourceReply).toMatchObject({ text: "Attached proof." });
         expect(sourceReply?.mediaUrls).toHaveLength(1);
+        expect(sourceReply?.attachments).toEqual([
+          expect.objectContaining({
+            name: "proof.txt",
+            mimeType: "text/plain",
+            trustedLocalMedia: true,
+          }),
+        ]);
         const mediaPath = sourceReply?.mediaUrls?.[0];
         expect(mediaPath).toBeTruthy();
         await expect(fs.readFile(mediaPath as string)).resolves.toEqual(attachment);
@@ -147,7 +154,7 @@ describe("WebChat message tool internal source reply", () => {
     );
   });
 
-  it("publishes managed images with the current run owner", async () => {
+  it("publishes managed media with aligned metadata and the current run owner", async () => {
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-internal-source-reply-" },
       async (state) => {
@@ -157,12 +164,14 @@ describe("WebChat message tool internal source reply", () => {
         const sessionKey = "agent:main:webchat:dm:restart-proof";
         const sessionId = "restart-proof-session";
         const imagePaths = ["first.png", "second.png"].map((name) => path.join(workspaceDir, name));
+        const documentPath = path.join(workspaceDir, "report.json");
         await fs.mkdir(workspaceDir, { recursive: true });
         await Promise.all(
           imagePaths.map((imagePath) =>
             fs.writeFile(imagePath, Buffer.from(TINY_PNG_BASE64, "base64")),
           ),
         );
+        await fs.writeFile(documentPath, '{"status":"ready"}\n');
 
         await replaceSessionEntry(
           { agentId: "main", sessionKey, storePath },
@@ -195,7 +204,7 @@ describe("WebChat message tool internal source reply", () => {
         const sendParams = {
           action: "send" as const,
           message: "Durable image reply",
-          mediaUrls: imagePaths,
+          mediaUrls: [...imagePaths, documentPath],
         };
         const updates: SessionTranscriptUpdate[] = [];
         const publishedDownloads: Array<Promise<unknown>> = [];
@@ -239,6 +248,18 @@ describe("WebChat message tool internal source reply", () => {
           reasoningLevel: "off",
           toolResultFormat: "plain",
         });
+        expect(sourcePayloads[0]).toMatchObject({
+          attachments: [
+            expect.objectContaining({ name: "first.png", trustedLocalMedia: true }),
+            expect.objectContaining({ name: "second.png", trustedLocalMedia: true }),
+            expect.objectContaining({
+              name: "report.json",
+              mimeType: "application/json",
+              trustedLocalMedia: true,
+            }),
+          ],
+          trustedLocalMedia: true,
+        });
         const mirror = getReplyPayloadMetadata(
           sourcePayloads[0] as object,
         )?.sourceReplyTranscriptMirror;
@@ -262,6 +283,7 @@ describe("WebChat message tool internal source reply", () => {
           ? (assistant.content as Array<Record<string, unknown>>)
           : [];
         const image = content.find((block) => block.type === "image");
+        const document = content.find((block) => block.type === "attachment");
         expect(toolResult.details).toMatchObject({
           sourceReplySink: "internal-ui",
           idempotencyKey: expect.any(String),
@@ -272,8 +294,17 @@ describe("WebChat message tool internal source reply", () => {
           artifactId: expect.stringMatching(/^artifact_managed_image_/u),
         });
         expect(content.filter((block) => block.type === "image")).toHaveLength(2);
+        expect(document).toMatchObject({
+          type: "attachment",
+          attachment: {
+            artifactId: expect.stringMatching(/^artifact_managed_media_/u),
+            kind: "document",
+            label: "report.json",
+            mimeType: "application/json",
+          },
+        });
         expect(JSON.stringify(assistant)).not.toContain(workspaceDir);
-        expect(listManagedImageRecordEntries({ stateDir, sessionKey })).toHaveLength(2);
+        expect(listManagedImageRecordEntries({ stateDir, sessionKey })).toHaveLength(3);
         const published = updates.find(
           (update) =>
             update.runId === "restart-proof-run" &&
@@ -303,6 +334,15 @@ describe("WebChat message tool internal source reply", () => {
             }),
           ).resolves.toMatchObject({ type: "image" });
         }
+        const documentAttachment = document?.attachment as { artifactId?: unknown } | undefined;
+        await expect(
+          resolveManagedOutgoingMediaArtifactDownload({
+            sessionKey,
+            agentId: "main",
+            artifactId: String(documentAttachment?.artifactId),
+            stateDir,
+          }),
+        ).resolves.toMatchObject({ type: "file", title: "report.json" });
       },
     );
   });

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -248,6 +248,8 @@ export type ReplyPayloadMetadata = {
   ttsExplicit?: true;
   /** Original runtime MEDIA references used to identify the persisted assistant row. */
   assistantTranscriptMediaUrls?: string[];
+  /** Media normalization rejected at least one source before delivery. */
+  assistantMediaNormalizationFailed?: true;
   /** The runtime owns the transcript decision for this assistant payload. */
   assistantTranscriptOwned?: boolean;
   /** Exact channel/account transform owner that already accepted this payload. */

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -742,6 +742,8 @@ describe("runReplyAgent media path normalization", () => {
       text: "here is the chart",
       mediaUrl: "/tmp/outbound-media/1-chart.png",
       mediaUrls: ["/tmp/outbound-media/1-chart.png"],
+      attachments: [{ name: "chart.png", mimeType: "image/png", trustedLocalMedia: true }],
+      trustedLocalMedia: true,
     });
     expect(finalPayload).toEqual(blockPayload);
     expect(resolveOutboundAttachmentFromUrlMock).toHaveBeenCalledTimes(1);

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -508,6 +508,7 @@ describe("createReplyMediaPathNormalizer", () => {
       "⚠️ Media failed. Try sending a smaller supported file or a different format.",
     );
     expectNoMedia(result);
+    expect(getReplyPayloadMetadata(result)?.assistantMediaNormalizationFailed).toBe(true);
   });
 
   it("threads requester context into shared outbound media access", async () => {

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -96,6 +96,7 @@ describe("createReplyMediaPathNormalizer", () => {
     ensureSandboxWorkspaceForSession.mockReset().mockResolvedValue(null);
     resolveOutboundAttachmentFromUrl.mockReset().mockImplementation(async (mediaUrl: string) => ({
       path: path.join("/tmp/outbound-media", path.basename(mediaUrl.replace(/^file:\/\//i, ""))),
+      contentType: mediaUrl.endsWith(".mp3") ? "audio/mpeg" : "image/png",
     }));
     resolveAgentScopedOutboundMediaAccess
       .mockReset()
@@ -126,7 +127,9 @@ describe("createReplyMediaPathNormalizer", () => {
     const mediaAccess = requireRecord(options.mediaAccess, "media access");
     expect(mediaAccess.workspaceDir).toBe("/tmp/agent-workspace");
     expect(result.trustedLocalMedia).toBe(true);
-    expect(result.attachments).toEqual([{ name: "photo.png", trustedLocalMedia: true }]);
+    expect(result.attachments).toEqual([
+      { name: "photo.png", mimeType: "image/png", trustedLocalMedia: true },
+    ]);
   });
 
   it("does not grant local-media trust to remote-only replies", async () => {

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -26,9 +26,11 @@ vi.mock("../../media/read-capability.js", () => ({
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 
 type NormalizedReply = {
+  attachments?: Array<{ name?: string; trustedLocalMedia?: boolean }>;
   mediaUrl?: string;
   mediaUrls?: string[];
   text?: string;
+  trustedLocalMedia?: boolean;
 };
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -123,6 +125,16 @@ describe("createReplyMediaPathNormalizer", () => {
     );
     const mediaAccess = requireRecord(options.mediaAccess, "media access");
     expect(mediaAccess.workspaceDir).toBe("/tmp/agent-workspace");
+    expect(result.trustedLocalMedia).toBe(true);
+    expect(result.attachments).toEqual([{ name: "photo.png", trustedLocalMedia: true }]);
+  });
+
+  it("does not grant local-media trust to remote-only replies", async () => {
+    const normalize = createTestReplyMediaNormalizer();
+
+    const result = await normalize({ mediaUrls: ["https://example.com/voice.mp3"] });
+
+    expect(result.trustedLocalMedia).toBeUndefined();
   });
 
   it("preserves reply metadata when media normalization clones the payload", async () => {

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -16,7 +16,11 @@ import { logVerbose } from "../../globals.js";
 import { resolveOutboundMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { resolveOutboundAttachmentFromUrl } from "../../media/outbound-attachment.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
-import { appendReplyMediaFailureWarning, copyReplyPayloadMetadata } from "../reply-payload.js";
+import {
+  appendReplyMediaFailureWarning,
+  copyReplyPayloadMetadata,
+  setReplyPayloadMetadata,
+} from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 
 const FILE_URL_RE = /^file:/i;
@@ -294,15 +298,18 @@ export function createReplyMediaPathNormalizer(params: {
         : appendReplyMediaFailureWarning(payload.text);
 
     if (normalizedMedia.length === 0) {
-      return copyReplyPayloadMetadata(payload, {
+      const normalized = copyReplyPayloadMetadata(payload, {
         ...payload,
         text,
         mediaUrl: undefined,
         mediaUrls: undefined,
       });
+      return firstMediaDropError === undefined
+        ? normalized
+        : setReplyPayloadMetadata(normalized, { assistantMediaNormalizationFailed: true });
     }
 
-    return copyReplyPayloadMetadata(payload, {
+    const normalized = copyReplyPayloadMetadata(payload, {
       ...payload,
       text,
       mediaUrl: normalizedMedia[0],
@@ -312,6 +319,9 @@ export function createReplyMediaPathNormalizer(params: {
         : {}),
       ...(hasTrustedLocalMedia ? { trustedLocalMedia: true } : {}),
     });
+    return firstMediaDropError === undefined
+      ? normalized
+      : setReplyPayloadMetadata(normalized, { assistantMediaNormalizationFailed: true });
   };
 }
 

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -1,6 +1,7 @@
 // Resolves media paths from reply payloads into runtime attachment metadata.
 import path from "node:path";
 import { isPassThroughRemoteMediaSource } from "@openclaw/media-core/media-source-url";
+import { mimeTypeFromFilePath } from "@openclaw/media-core/mime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolvePathFromInput, toRelativeWorkspacePath } from "../../agents/path-policy.js";
@@ -80,7 +81,7 @@ export function createReplyMediaPathNormalizer(params: {
         containerWorkdir: params.sandboxContainerWorkdir,
       })
     : undefined;
-  const persistedMediaBySource = new Map<string, Promise<string>>();
+  const persistedMediaBySource = new Map<string, Promise<{ path: string; contentType?: string }>>();
 
   const resolveSandboxWorkspace = async () => {
     if (!sandboxWorkspacePromise) {
@@ -115,13 +116,18 @@ export function createReplyMediaPathNormalizer(params: {
       groupSpace: params.groupSpace,
     });
 
-  const persistLocalReplyMedia = async (media: string): Promise<string> => {
+  const persistLocalReplyMedia = async (
+    media: string,
+  ): Promise<{ path: string; contentType?: string }> => {
     if (!isLikelyLocalMediaSource(media)) {
-      return media;
+      return { path: media };
     }
     const managedMediaPath = await resolveAllowedManagedMediaPath(media);
     if (managedMediaPath) {
-      return managedMediaPath;
+      return {
+        path: managedMediaPath,
+        contentType: mimeTypeFromFilePath(managedMediaPath),
+      };
     }
     const cached = persistedMediaBySource.get(media);
     if (cached) {
@@ -130,7 +136,10 @@ export function createReplyMediaPathNormalizer(params: {
     const persistPromise = resolveOutboundAttachmentFromUrl(media, maxBytes, {
       mediaAccess: resolveMediaAccessForSource(media),
     })
-      .then((saved) => saved.path)
+      .then((saved) => ({
+        ...saved,
+        contentType: saved.contentType ?? mimeTypeFromFilePath(media) ?? "application/octet-stream",
+      }))
       .catch((err: unknown) => {
         persistedMediaBySource.delete(media);
         throw err;
@@ -159,7 +168,12 @@ export function createReplyMediaPathNormalizer(params: {
 
   const normalizeMediaSource = async (
     raw: string,
-  ): Promise<{ mediaUrl: string; trustedLocalMedia: boolean; fileName?: string }> => {
+  ): Promise<{
+    mediaUrl: string;
+    trustedLocalMedia: boolean;
+    fileName?: string;
+    mimeType?: string;
+  }> => {
     const media = raw.trim();
     if (!media) {
       return { mediaUrl: media, trustedLocalMedia: false };
@@ -170,10 +184,12 @@ export function createReplyMediaPathNormalizer(params: {
     }
     const absoluteWorkspaceMedia = resolveAbsoluteWorkspaceMedia(media);
     if (absoluteWorkspaceMedia) {
+      const persisted = await persistLocalReplyMedia(absoluteWorkspaceMedia);
       return {
-        mediaUrl: await persistLocalReplyMedia(absoluteWorkspaceMedia),
+        mediaUrl: persisted.path,
         trustedLocalMedia: true,
         fileName: path.basename(absoluteWorkspaceMedia),
+        ...(persisted.contentType ? { mimeType: persisted.contentType } : {}),
       };
     }
     const isRelativeLocalMedia =
@@ -200,18 +216,22 @@ export function createReplyMediaPathNormalizer(params: {
         }
         throw err;
       }
+      const persisted = await persistLocalReplyMedia(sandboxResolvedMedia);
       return {
-        mediaUrl: await persistLocalReplyMedia(sandboxResolvedMedia),
+        mediaUrl: persisted.path,
         trustedLocalMedia: true,
         fileName: path.basename(sandboxResolvedMedia),
+        ...(persisted.contentType ? { mimeType: persisted.contentType } : {}),
       };
     }
     if (isRelativeLocalMedia) {
       const workspaceMedia = resolveWorkspaceRelativeMedia(media);
+      const persisted = await persistLocalReplyMedia(workspaceMedia);
       return {
-        mediaUrl: await persistLocalReplyMedia(workspaceMedia),
+        mediaUrl: persisted.path,
         trustedLocalMedia: true,
         fileName: path.basename(workspaceMedia),
+        ...(persisted.contentType ? { mimeType: persisted.contentType } : {}),
       };
     }
     if (!isLikelyLocalMediaSource(media)) {
@@ -222,10 +242,12 @@ export function createReplyMediaPathNormalizer(params: {
         "Host-local MEDIA file URLs are blocked in normal replies. Use a safe path or the message tool.",
       );
     }
+    const persisted = await persistLocalReplyMedia(media);
     return {
-      mediaUrl: await persistLocalReplyMedia(media),
+      mediaUrl: persisted.path,
       trustedLocalMedia: true,
       fileName: path.basename(media),
+      ...(persisted.contentType ? { mimeType: persisted.contentType } : {}),
     };
   };
 
@@ -259,6 +281,9 @@ export function createReplyMediaPathNormalizer(params: {
       normalizedAttachments.push({
         ...existingAttachment,
         ...(normalized.fileName && !existingAttachment.name ? { name: normalized.fileName } : {}),
+        ...(normalized.mimeType && !existingAttachment.mimeType
+          ? { mimeType: normalized.mimeType }
+          : {}),
         ...(normalized.trustedLocalMedia ? { trustedLocalMedia: true } : {}),
       });
     }

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -157,18 +157,24 @@ export function createReplyMediaPathNormalizer(params: {
     }
   };
 
-  const normalizeMediaSource = async (raw: string): Promise<string> => {
+  const normalizeMediaSource = async (
+    raw: string,
+  ): Promise<{ mediaUrl: string; trustedLocalMedia: boolean; fileName?: string }> => {
     const media = raw.trim();
     if (!media) {
-      return media;
+      return { mediaUrl: media, trustedLocalMedia: false };
     }
     assertMediaNotDataUrl(media);
     if (isPassThroughRemoteMediaSource(media)) {
-      return media;
+      return { mediaUrl: media, trustedLocalMedia: false };
     }
     const absoluteWorkspaceMedia = resolveAbsoluteWorkspaceMedia(media);
     if (absoluteWorkspaceMedia) {
-      return await persistLocalReplyMedia(absoluteWorkspaceMedia);
+      return {
+        mediaUrl: await persistLocalReplyMedia(absoluteWorkspaceMedia),
+        trustedLocalMedia: true,
+        fileName: path.basename(absoluteWorkspaceMedia),
+      };
     }
     const isRelativeLocalMedia =
       isLikelyLocalMediaSource(media) &&
@@ -194,20 +200,33 @@ export function createReplyMediaPathNormalizer(params: {
         }
         throw err;
       }
-      return await persistLocalReplyMedia(sandboxResolvedMedia);
+      return {
+        mediaUrl: await persistLocalReplyMedia(sandboxResolvedMedia),
+        trustedLocalMedia: true,
+        fileName: path.basename(sandboxResolvedMedia),
+      };
     }
     if (isRelativeLocalMedia) {
-      return await persistLocalReplyMedia(resolveWorkspaceRelativeMedia(media));
+      const workspaceMedia = resolveWorkspaceRelativeMedia(media);
+      return {
+        mediaUrl: await persistLocalReplyMedia(workspaceMedia),
+        trustedLocalMedia: true,
+        fileName: path.basename(workspaceMedia),
+      };
     }
     if (!isLikelyLocalMediaSource(media)) {
-      return media;
+      return { mediaUrl: media, trustedLocalMedia: false };
     }
     if (FILE_URL_RE.test(media)) {
       throw new Error(
         "Host-local MEDIA file URLs are blocked in normal replies. Use a safe path or the message tool.",
       );
     }
-    return await persistLocalReplyMedia(media);
+    return {
+      mediaUrl: await persistLocalReplyMedia(media),
+      trustedLocalMedia: true,
+      fileName: path.basename(media),
+    };
   };
 
   return async (payload) => {
@@ -217,10 +236,12 @@ export function createReplyMediaPathNormalizer(params: {
     }
 
     const normalizedMedia: string[] = [];
+    const normalizedAttachments: NonNullable<ReplyPayload["attachments"]> = [];
     const seen = new Set<string>();
+    let hasTrustedLocalMedia = payload.trustedLocalMedia === true;
     let firstMediaDropError: unknown;
-    for (const media of mediaList) {
-      let normalized: string;
+    for (const [mediaIndex, media] of mediaList.entries()) {
+      let normalized: Awaited<ReturnType<typeof normalizeMediaSource>>;
       try {
         normalized = await normalizeMediaSource(media);
       } catch (err) {
@@ -228,11 +249,18 @@ export function createReplyMediaPathNormalizer(params: {
         logVerbose(`dropping blocked reply media ${media}: ${String(err)}`);
         continue;
       }
-      if (!normalized || seen.has(normalized)) {
+      if (!normalized.mediaUrl || seen.has(normalized.mediaUrl)) {
         continue;
       }
-      seen.add(normalized);
-      normalizedMedia.push(normalized);
+      seen.add(normalized.mediaUrl);
+      normalizedMedia.push(normalized.mediaUrl);
+      hasTrustedLocalMedia ||= normalized.trustedLocalMedia;
+      const existingAttachment = payload.attachments?.[mediaIndex] ?? {};
+      normalizedAttachments.push({
+        ...existingAttachment,
+        ...(normalized.fileName && !existingAttachment.name ? { name: normalized.fileName } : {}),
+        ...(normalized.trustedLocalMedia ? { trustedLocalMedia: true } : {}),
+      });
     }
 
     const text =
@@ -254,6 +282,10 @@ export function createReplyMediaPathNormalizer(params: {
       text,
       mediaUrl: normalizedMedia[0],
       mediaUrls: normalizedMedia,
+      ...(normalizedAttachments.some((attachment) => Object.keys(attachment).length > 0)
+        ? { attachments: normalizedAttachments }
+        : {}),
+      ...(hasTrustedLocalMedia ? { trustedLocalMedia: true } : {}),
     });
   };
 }

--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -229,7 +229,8 @@ export function sanitizeChatHistoryContentBlock(
     changed = true;
   }
   const mediaChanged = projectChatHistoryMediaBlock(entry);
-  changed ||= mediaChanged || projectChatHistoryAttachmentBlock(entry);
+  const attachmentChanged = projectChatHistoryAttachmentBlock(entry);
+  changed ||= mediaChanged || attachmentChanged;
   return { block: changed ? entry : block, changed, truncated };
 }
 

--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -129,6 +129,28 @@ function projectChatHistoryMediaBlock(entry: Record<string, unknown>, fact = fal
   return true;
 }
 
+function projectChatHistoryAttachmentBlock(entry: Record<string, unknown>): boolean {
+  if (entry.type !== "attachment") {
+    return false;
+  }
+  const attachment = readRecord(entry.attachment);
+  if (!attachment) {
+    return false;
+  }
+  const projected = { ...attachment };
+  for (const field of MEDIA_PRIVATE_FIELDS) {
+    delete projected[field];
+  }
+  const url = projectChatHistoryMediaReference(projected.url);
+  if (!url) {
+    delete projected.url;
+  } else {
+    projected.url = url;
+  }
+  entry.attachment = projected;
+  return true;
+}
+
 function projectChatHistoryMediaFacts(value: unknown): unknown[] | undefined {
   return Array.isArray(value)
     ? value.map((fact) => {
@@ -207,7 +229,7 @@ export function sanitizeChatHistoryContentBlock(
     changed = true;
   }
   const mediaChanged = projectChatHistoryMediaBlock(entry);
-  changed ||= mediaChanged;
+  changed ||= mediaChanged || projectChatHistoryAttachmentBlock(entry);
   return { block: changed ? entry : block, changed, truncated };
 }
 

--- a/src/gateway/chat-display-projection.test.ts
+++ b/src/gateway/chat-display-projection.test.ts
@@ -60,10 +60,44 @@ describe("managed document chat history", () => {
       },
     ]);
   });
+
+  it("sanitizes attachment capabilities after another field already changed", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "attachment",
+          thinkingSignature: "private-reasoning-signature",
+          attachment: {
+            kind: "document",
+            label: "report.csv",
+            path: "/tmp/private-report.csv",
+            url: "/api/chat/media/outgoing/agent%3Amain%3Amain/id/full?mediaTicket=secret",
+          },
+        },
+      ],
+    };
+
+    expect(sanitizeChatHistoryMessages([message])).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "attachment",
+            attachment: {
+              kind: "document",
+              label: "report.csv",
+              url: "/api/chat/media/outgoing/agent%3Amain%3Amain/id/full",
+            },
+          },
+        ],
+      },
+    ]);
+  });
 });
 
 describe("oversized multimodal chat history", () => {
-  it("projects one mixed-media message through every history boundary", async () => {
+  it("keeps legacy image, audio, and video transcript blocks through every history boundary", async () => {
     const inlineImage = Buffer.from("inline image").toString("base64");
     const inlineAudio = Buffer.from("inline audio").toString("base64");
     const inlineVideo = Buffer.from("inline video").toString("base64");
@@ -129,6 +163,12 @@ describe("oversized multimodal chat history", () => {
         role: "user",
         content: expected[0]?.content,
       });
+      expect((messages[0] as { content?: unknown[] }).content).toEqual([
+        expect.objectContaining({ type: "text" }),
+        expect.objectContaining({ type: "image", mimeType: "image/png" }),
+        expect.objectContaining({ type: "audio", mimeType: "audio/wav" }),
+        expect.objectContaining({ type: "video", mimeType: "video/mp4" }),
+      ]);
       const serialized = JSON.stringify(messages);
       for (const secret of [
         inlineImage,

--- a/src/gateway/chat-display-projection.test.ts
+++ b/src/gateway/chat-display-projection.test.ts
@@ -22,6 +22,46 @@ function projectHistoryTransports(message: Record<string, unknown>) {
   return [websocket, sse];
 }
 
+describe("managed document chat history", () => {
+  it("keeps the attachment envelope while stripping URL capabilities", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "attachment",
+          attachment: {
+            artifactId: "artifact_managed_media_11111111-1111-4111-8111-111111111111",
+            kind: "document",
+            label: "report.csv",
+            mimeType: "text/csv",
+            sizeBytes: 12,
+            url: "/api/chat/media/outgoing/agent%3Amain%3Amain/11111111-1111-4111-8111-111111111111/full?mediaTicket=secret",
+          },
+        },
+      ],
+    };
+
+    expect(sanitizeChatHistoryMessages([message])).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "attachment",
+            attachment: {
+              artifactId: "artifact_managed_media_11111111-1111-4111-8111-111111111111",
+              kind: "document",
+              label: "report.csv",
+              mimeType: "text/csv",
+              sizeBytes: 12,
+              url: "/api/chat/media/outgoing/agent%3Amain%3Amain/11111111-1111-4111-8111-111111111111/full",
+            },
+          },
+        ],
+      },
+    ]);
+  });
+});
+
 describe("oversized multimodal chat history", () => {
   it("projects one mixed-media message through every history boundary", async () => {
     const inlineImage = Buffer.from("inline image").toString("base64");

--- a/src/gateway/internal-source-reply-persistence.ts
+++ b/src/gateway/internal-source-reply-persistence.ts
@@ -13,6 +13,7 @@ import { createKeyedFifoLeaseRegistry } from "../shared/keyed-fifo-lease.js";
 import { isOpenClawDeliveryMirrorAssistantMessage } from "../shared/transcript-only-openclaw-assistant.js";
 import {
   createManagedOutgoingMediaBlocks,
+  prepareOutgoingMediaFromReplyPayload,
   removeManagedOutgoingMediaBlocks,
 } from "./managed-image-attachments.js";
 import { prepareGatewayInjectedAssistantContent } from "./server-methods/chat-transcript-inject.js";
@@ -20,12 +21,6 @@ import { prepareGatewayInjectedAssistantContent } from "./server-methods/chat-tr
 const internalSourceReplyPersistenceLeases = createKeyedFifoLeaseRegistry(
   Symbol.for("openclaw.internalSourceReplyPersistenceLeases"),
 );
-
-function collectSourceReplyMediaUrls(payload: ReplyPayload): string[] {
-  return Array.from(
-    new Set([...(payload.mediaUrl ? [payload.mediaUrl] : []), ...(payload.mediaUrls ?? [])]),
-  ).filter((value) => value.trim().length > 0);
-}
 
 async function hasPersistedInternalSourceReply(params: {
   cfg: OpenClawConfig;
@@ -95,17 +90,17 @@ export async function persistInternalSourceReply(params: {
     if (await hasPersistedInternalSourceReply(params)) {
       return;
     }
-    const mediaUrls = collectSourceReplyMediaUrls(params.payload);
     const messageId = randomUUID();
+    const media = prepareOutgoingMediaFromReplyPayload(params.payload);
     const mediaBlocks = await createManagedOutgoingMediaBlocks({
       sessionKey: params.sessionKey,
       agentId: params.agentId,
-      mediaUrls,
+      items: media,
       messageId,
       localRoots: getAgentScopedMediaLocalRootsForSources({
         cfg: params.cfg,
         agentId: params.agentId,
-        mediaSources: mediaUrls,
+        mediaSources: media.map((item) => item.url),
       }),
     });
     const content: Array<Record<string, unknown>> = [

--- a/src/gateway/managed-image-actions.e2e.test.ts
+++ b/src/gateway/managed-image-actions.e2e.test.ts
@@ -38,7 +38,12 @@ describe("managed image actions Gateway E2E", () => {
     const blocks = await createManagedOutgoingMediaBlocks({
       sessionKey: SESSION_KEY,
       messageId,
-      mediaUrls: [`data:image/png;base64,${source.toString("base64")}`],
+      items: [
+        {
+          url: `data:image/png;base64,${source.toString("base64")}`,
+          trustedLocal: false,
+        },
+      ],
       stateDir,
     });
     const block = blocks.find(

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -2032,11 +2032,12 @@ describe("createManagedOutgoingImageBlocks", () => {
       mimeType: "application/octet-stream",
       body: Buffer.from([0, 1, 2, 3]),
     },
-  ])("creates a visible document card for $mimeType metadata", async (fixture) => {
+  ])("rejects unsupported $mimeType metadata before persistence", async (fixture) => {
     const sourcePath = path.join(stateDir, "workspace", fixture.fileName);
     await fs.mkdir(path.dirname(sourcePath), { recursive: true });
     await fs.writeFile(sourcePath, fixture.body);
 
+    const onPrepareError = vi.fn();
     const blocks = await createManagedOutgoingImageBlocksActual({
       sessionKey: "agent:main:main",
       items: [
@@ -2049,18 +2050,53 @@ describe("createManagedOutgoingImageBlocks", () => {
       ],
       stateDir,
       localRoots: [path.dirname(sourcePath)],
+      continueOnPrepareError: true,
+      onPrepareError,
     });
 
-    expect(blocks).toEqual([
-      {
-        type: "attachment",
-        attachment: expect.objectContaining({
-          kind: "document",
-          label: fixture.fileName,
-          mimeType: fixture.expectedMimeType ?? fixture.mimeType,
-        }),
-      },
-    ]);
+    expect(blocks).toEqual([]);
+    expect(onPrepareError).toHaveBeenCalledOnce();
+    expect(listManagedImageRecordEntries({ stateDir })).toEqual([]);
+    const originalsDir = path.join(stateDir, "media", MANAGED_OUTGOING_ORIGINALS_SUBDIR);
+    await expectPathMissing(originalsDir);
+  });
+
+  it.each(["GET", "HEAD"])("does not serve legacy SVG records over %s", async (method) => {
+    const body = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><script/></svg>');
+    const { attachmentId, sessionKey } = await createFixture(stateDir, {
+      filename: "vector.svg",
+      contentType: "image/svg+xml",
+      body,
+    });
+    const pathName = `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`;
+
+    const { result } = await requestManagedImage({
+      stateDir,
+      pathName,
+      method,
+      authResponse: { authMethod: "token" },
+      transcriptMessages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "attachment",
+              attachment: {
+                kind: "document",
+                label: "vector.svg",
+                mimeType: "image/svg+xml",
+                url: pathName,
+              },
+            },
+          ],
+          __openclaw: { id: "msg-1" },
+        },
+      ],
+    });
+
+    expect(result.statusCode).toBe(404);
+    expect(result.headers["content-disposition"]).toBeUndefined();
+    expect(result.body).toEqual(method === "HEAD" ? Buffer.alloc(0) : Buffer.from("not found"));
   });
 
   it("rolls back earlier managed artifacts when a later item fails", async () => {

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -2046,7 +2046,7 @@ describe("createManagedOutgoingImageBlocks", () => {
     }
   });
 
-  it("drops downloaded non-image sources without leaving orphaned originals", async () => {
+  it("creates managed document attachment envelopes for trusted local files", async () => {
     const pdfPath = path.join(stateDir, "not-an-image.pdf");
     await fs.writeFile(pdfPath, Buffer.from("%PDF-1.4\n% test\n"));
 
@@ -2055,16 +2055,56 @@ describe("createManagedOutgoingImageBlocks", () => {
       mediaUrls: [pdfPath],
       stateDir,
       localRoots: [stateDir],
+      allowLocalNonImage: true,
+      messageId: "msg-1",
     });
-    expect(blocks).toStrictEqual([]);
-    const originalsDir = path.join(stateDir, "media", "outgoing", "originals");
-    let originals: string[] | null = null;
-    try {
-      originals = await fs.readdir(originalsDir);
-    } catch (error) {
-      expect((error as NodeJS.ErrnoException).code).toBe("ENOENT");
-    }
-    expect(originals ?? []).toStrictEqual([]);
+
+    expect(blocks).toEqual([
+      {
+        type: "attachment",
+        attachment: expect.objectContaining({
+          artifactId: expect.stringMatching(/^artifact_managed_media_/u),
+          kind: "document",
+          label: "not-an-image.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 16,
+          url: expect.stringMatching(/^\/api\/chat\/media\/outgoing\//u),
+        }),
+      },
+    ]);
+
+    const attachment = (blocks[0] as { attachment?: { artifactId?: string; url?: string } })
+      .attachment;
+    const { result } = await requestManagedImage({
+      stateDir,
+      pathName: attachment?.url ?? "",
+      authResponse: { authMethod: "token" },
+      transcriptMessages: [
+        {
+          role: "assistant",
+          content: blocks,
+          __openclaw: { id: "msg-1" },
+        },
+      ],
+    });
+
+    expect(result.statusCode).toBe(200);
+    expect(result.headers["content-type"]).toBe("application/pdf");
+    expect(result.headers["content-disposition"]).toContain("attachment;");
+    expect(result.body).toEqual(Buffer.from("%PDF-1.4\n% test\n"));
+
+    const download = await resolveManagedOutgoingImageArtifactDownload({
+      sessionKey: "agent:main:main",
+      artifactId: attachment?.artifactId ?? "",
+      stateDir,
+    });
+    expect(download).toMatchObject({
+      artifactId: attachment?.artifactId,
+      type: "file",
+      title: "not-an-image.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 16,
+    });
   });
 
   it("does not apply the configured image cap to managed audio", async () => {

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../test/helpers/image-fixtures.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { extractToolResultMediaArtifact } from "../agents/embedded-agent-tool-media.js";
+import type { ReplyMediaAttachment } from "../auto-reply/reply-payload.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import { resolveExistingAgentSessionStoreTargetsReadOnlyResult } from "../config/sessions/targets-read-availability.js";
 import { createPinnedLookup } from "../infra/net/ssrf.js";
@@ -113,11 +114,39 @@ const {
   MANAGED_OUTGOING_MEDIA_ARTIFACT_ID_PREFIX,
   attachManagedOutgoingMediaToMessage: attachManagedOutgoingImagesToMessage,
   cleanupManagedOutgoingMediaRecords: cleanupManagedOutgoingImageRecords,
-  createManagedOutgoingMediaBlocks: createManagedOutgoingImageBlocks,
+  createManagedOutgoingMediaBlocks: createManagedOutgoingImageBlocksActual,
   handleManagedOutgoingMediaHttpRequest: handleManagedOutgoingImageHttpRequest,
+  prepareOutgoingMediaFromReplyPayload,
   resolveManagedOutgoingMediaArtifactDownload: resolveManagedOutgoingImageArtifactDownload,
   resolveManagedImageAttachmentLimits,
 } = await import("./managed-image-attachments.js");
+
+type ManagedOutgoingImageTestParams = Omit<
+  Parameters<typeof createManagedOutgoingImageBlocksActual>[0],
+  "items"
+> & {
+  mediaUrls?: string[] | null;
+  attachments?: ReplyMediaAttachment[] | null;
+  allowLocalNonImage?: boolean;
+};
+
+function createManagedOutgoingImageBlocks(params: ManagedOutgoingImageTestParams) {
+  const { mediaUrls, attachments, allowLocalNonImage, ...ownerParams } = params;
+  return createManagedOutgoingImageBlocksActual({
+    ...ownerParams,
+    items: (mediaUrls ?? []).map((url, index) => {
+      const attachment = attachments?.[index];
+      return Object.assign(
+        { url, trustedLocal: allowLocalNonImage === true },
+        typeof attachment?.name === "string" ? { filename: attachment.name } : {},
+        typeof attachment?.mimeType === "string" ? { mimeType: attachment.mimeType } : {},
+        typeof attachment?.durationMs === "number" ? { durationMs: attachment.durationMs } : {},
+        typeof attachment?.width === "number" ? { width: attachment.width } : {},
+        typeof attachment?.height === "number" ? { height: attachment.height } : {},
+      );
+    }),
+  });
+}
 
 async function replaceTestSessionEntry(
   scope: {
@@ -1307,6 +1336,42 @@ describe("createManagedOutgoingImageBlocks", () => {
     await prepareManagedSessionStore(stateDir);
   });
 
+  it("prepares deduplicated media with metadata and per-item trust aligned by URL", () => {
+    expect(
+      prepareOutgoingMediaFromReplyPayload({
+        mediaUrls: ["/tmp/a.json", "/tmp/a.json", "/tmp/b.json"],
+        trustedLocalMedia: true,
+        attachments: [
+          {
+            path: "/tmp/a.json",
+            name: "a.json",
+            mimeType: "application/json",
+            trustedLocalMedia: false,
+          },
+          {
+            path: "/tmp/b.json",
+            name: "b.json",
+            mimeType: "application/json",
+            trustedLocalMedia: true,
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        url: "/tmp/a.json",
+        filename: "a.json",
+        mimeType: "application/json",
+        trustedLocal: false,
+      },
+      {
+        url: "/tmp/b.json",
+        filename: "b.json",
+        mimeType: "application/json",
+        trustedLocal: true,
+      },
+    ]);
+  });
+
   afterEach(async () => {
     closeOpenClawStateDatabaseForTest();
     setMediaStoreNetworkDepsForTest();
@@ -1928,6 +1993,97 @@ describe("createManagedOutgoingImageBlocks", () => {
     expect(blocks).toHaveLength(1);
     expect(requireBlock(blocks).type).toBe("image");
     expect(onPrepareError).toHaveBeenCalledOnce();
+  });
+
+  it("reports media with no supported content type instead of dropping it silently", async () => {
+    const sourcePath = path.join(stateDir, "workspace", "mystery.blob");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, Buffer.from([0, 1, 2, 3]));
+    const onPrepareError = vi.fn();
+
+    const blocks = await createManagedOutgoingImageBlocksActual({
+      sessionKey: "agent:main:main",
+      items: [{ url: sourcePath, trustedLocal: true }],
+      stateDir,
+      localRoots: [path.dirname(sourcePath)],
+      continueOnPrepareError: true,
+      onPrepareError,
+    });
+
+    expect(blocks).toEqual([]);
+    expect(onPrepareError).toHaveBeenCalledOnce();
+    expect(onPrepareError.mock.calls[0]?.[0]).toMatchObject({
+      message: expect.stringMatching(/could not be prepared/u),
+    });
+  });
+
+  it.each([
+    {
+      fileName: "config.xml",
+      mimeType: "application/xml",
+      expectedMimeType: "text/xml",
+      body: "<config/>",
+    },
+    { fileName: "vector.svg", mimeType: "image/svg+xml", body: "<svg/>" },
+    { fileName: "worker.py", mimeType: "text/x-python", body: "print('ready')" },
+    { fileName: "script.js", mimeType: "text/javascript", body: "export default true" },
+    {
+      fileName: "mystery.blob",
+      mimeType: "application/octet-stream",
+      body: Buffer.from([0, 1, 2, 3]),
+    },
+  ])("creates a visible document card for $mimeType metadata", async (fixture) => {
+    const sourcePath = path.join(stateDir, "workspace", fixture.fileName);
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, fixture.body);
+
+    const blocks = await createManagedOutgoingImageBlocksActual({
+      sessionKey: "agent:main:main",
+      items: [
+        {
+          url: sourcePath,
+          filename: fixture.fileName,
+          mimeType: fixture.mimeType,
+          trustedLocal: true,
+        },
+      ],
+      stateDir,
+      localRoots: [path.dirname(sourcePath)],
+    });
+
+    expect(blocks).toEqual([
+      {
+        type: "attachment",
+        attachment: expect.objectContaining({
+          kind: "document",
+          label: fixture.fileName,
+          mimeType: fixture.expectedMimeType ?? fixture.mimeType,
+        }),
+      },
+    ]);
+  });
+
+  it("rolls back earlier managed artifacts when a later item fails", async () => {
+    const sourcePath = path.join(stateDir, "workspace", "mystery.blob");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, Buffer.from([0, 1, 2, 3]));
+
+    await expect(
+      createManagedOutgoingImageBlocksActual({
+        sessionKey: "agent:main:main",
+        items: [
+          {
+            url: `data:image/png;base64,${TINY_PNG_BASE64}`,
+            trustedLocal: false,
+          },
+          { url: sourcePath, trustedLocal: true },
+        ],
+        stateDir,
+        localRoots: [path.dirname(sourcePath)],
+      }),
+    ).rejects.toThrow(/could not be prepared/u);
+
+    expect(listManagedImageRecordEntries({ stateDir })).toEqual([]);
   });
 
   it("accepts URL images up to the configured managed-image byte limit", async () => {

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -1,5 +1,5 @@
 // Gateway managed media attachment store.
-// Validates, stores, serves, and cleans up outgoing image/audio/video attachments.
+// Validates, stores, serves, and cleans up outgoing media and document attachments.
 import { createHmac, randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -12,6 +12,7 @@ import {
   asNonNegativeFiniteNumber,
   resolveTimestampMsToIsoString,
 } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import pLimit from "p-limit";
 import type { ReplyMediaAttachment } from "../auto-reply/reply-payload.js";
 import { getRuntimeConfig } from "../config/config.js";
@@ -110,7 +111,7 @@ type ManagedImageAttachmentLimitsConfig = Partial<
   Pick<ManagedImageAttachmentLimits, "maxBytes" | "maxWidth" | "maxHeight" | "maxPixels">
 >;
 
-type ManagedMediaKind = Extract<MediaKind, "image" | "audio" | "video">;
+type ManagedMediaKind = Extract<MediaKind, "image" | "audio" | "video" | "document">;
 
 type ParsedMediaDataUrl =
   | { kind: "not-data-url" }
@@ -165,7 +166,7 @@ type ManagedOutgoingImageTicketPayload = {
 export type ManagedOutgoingMediaArtifactDownload = {
   artifactId: string;
   sessionKey: string;
-  type: ManagedMediaKind;
+  type: Exclude<ManagedMediaKind, "document"> | "file";
   title: string;
   mimeType?: string;
   sizeBytes?: number;
@@ -818,7 +819,9 @@ function resolveManagedSessionOwnerAgentId(
 
 function resolveManagedRecordKind(record: ManagedImageRecord): ManagedMediaKind | null {
   const kind = mediaKindFromMime(record.original.contentType);
-  return kind === "image" || kind === "audio" || kind === "video" ? kind : null;
+  return kind === "image" || kind === "audio" || kind === "video" || kind === "document"
+    ? kind
+    : null;
 }
 
 function buildManagedMediaBlock(
@@ -830,9 +833,23 @@ function buildManagedMediaBlock(
     throw new Error("Managed media record has an unsupported content type");
   }
   const fullUrl = buildOutgoingVariantUrl(record.sessionKey, record.attachmentId, "full");
+  const artifactId = buildManagedOutgoingArtifactId(record.attachmentId, kind);
+  if (kind === "document") {
+    return {
+      type: "attachment",
+      attachment: {
+        artifactId,
+        url: fullUrl,
+        kind,
+        label: record.original.filename ?? record.alt,
+        mimeType: record.original.contentType,
+        sizeBytes: record.original.sizeBytes,
+      },
+    };
+  }
   return {
     type: kind,
-    artifactId: buildManagedOutgoingArtifactId(record.attachmentId, kind),
+    artifactId,
     url: fullUrl,
     openUrl: fullUrl,
     ...(kind === "image" ? { alt: record.alt } : { fileName: record.original.filename }),
@@ -908,10 +925,17 @@ function collectManagedOutgoingAttachmentRefs(
 ) {
   const refs = new Map<string, { attachmentId: string; sessionKey: string }>();
   for (const block of blocks ?? []) {
-    if (block?.type !== "image" && block?.type !== "audio" && block?.type !== "video") {
+    const attachment =
+      block?.type === "attachment" ? asOptionalRecord(block.attachment) : undefined;
+    if (
+      block?.type !== "image" &&
+      block?.type !== "audio" &&
+      block?.type !== "video" &&
+      !attachment
+    ) {
       continue;
     }
-    for (const candidate of [block.url, block.openUrl]) {
+    for (const candidate of [block.url, block.openUrl, attachment?.url]) {
       if (typeof candidate !== "string") {
         continue;
       }
@@ -1252,7 +1276,7 @@ async function resolveManagedOutgoingMediaArtifactDownloadForRecord(
   return {
     artifactId: buildManagedOutgoingArtifactId(record.attachmentId, kind),
     sessionKey: record.sessionKey,
-    type: kind,
+    type: kind === "document" ? "file" : kind,
     title: kind === "image" ? record.alt : (record.original.filename ?? record.alt),
     ...(record.original.contentType ? { mimeType: record.original.contentType } : {}),
     ...(record.original.sizeBytes != null ? { sizeBytes: record.original.sizeBytes } : {}),
@@ -1373,7 +1397,10 @@ export async function createManagedOutgoingMediaBlocks(params: {
     const hintedKind =
       dataUrlKind === "image" || dataUrlKind === "audio" || dataUrlKind === "video"
         ? dataUrlKind
-        : inferredKind === "image" || inferredKind === "audio" || inferredKind === "video"
+        : inferredKind === "image" ||
+            inferredKind === "audio" ||
+            inferredKind === "video" ||
+            inferredKind === "document"
           ? inferredKind
           : "media";
 
@@ -1425,6 +1452,7 @@ export async function createManagedOutgoingMediaBlocks(params: {
                   limits.maxBytes,
                   maxBytesForKind("audio"),
                   maxBytesForKind("video"),
+                  maxBytesForKind("document"),
                   MEDIA_MAX_BYTES,
                 ),
               );
@@ -1437,7 +1465,12 @@ export async function createManagedOutgoingMediaBlocks(params: {
         continue;
       }
       const mediaKind = mediaKindFromMime(savedOriginalContentType);
-      if (mediaKind !== "image" && mediaKind !== "audio" && mediaKind !== "video") {
+      if (
+        mediaKind !== "image" &&
+        mediaKind !== "audio" &&
+        mediaKind !== "video" &&
+        mediaKind !== "document"
+      ) {
         await fs.rm(savedOriginal.path, { force: true }).catch(() => {});
         savedOriginalPath = null;
         continue;
@@ -1614,6 +1647,9 @@ function buildManagedMediaContentDisposition(value: string | null, contentType: 
   const fallback = contentType.startsWith("image/") ? "generated-image" : "generated-media";
   const base = (value ?? fallback).replace(/[\r\n"\\]/g, "_").trim();
   const filename = base || fallback;
+  if (mediaKindFromMime(contentType) === "document") {
+    return buildAssistantMediaContentDisposition(filename, contentType);
+  }
   return /^[\x20-\x7e]+$/u.test(filename)
     ? `inline; filename="${filename}"`
     : buildAssistantMediaContentDisposition(filename, contentType);

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -5,7 +5,7 @@ import fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import { maxBytesForKind, mediaKindFromMime, type MediaKind } from "@openclaw/media-core/constants";
-import { mimeTypeFromFilePath } from "@openclaw/media-core/mime";
+import { mimeTypeFromFilePath, normalizeMimeType } from "@openclaw/media-core/mime";
 import { expectDefined } from "@openclaw/normalization-core";
 import {
   asDateTimestampMs,
@@ -113,14 +113,29 @@ type ManagedImageAttachmentLimitsConfig = Partial<
 
 type ManagedMediaKind = Extract<MediaKind, "image" | "audio" | "video" | "document">;
 
+const MANAGED_DOCUMENT_MIME_TYPES = new Set([
+  "application/json",
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/yaml",
+  "application/zip",
+  "text/csv",
+  "text/html",
+  "text/markdown",
+  "text/plain",
+]);
+
 function resolveManagedMediaKind(contentType: string | undefined): ManagedMediaKind | null {
-  if (contentType === "image/svg+xml") {
-    return "document";
+  const normalized = normalizeMimeType(contentType);
+  if (normalized === "image/svg+xml") {
+    return null;
   }
-  const kind = mediaKindFromMime(contentType);
-  return kind === "image" || kind === "audio" || kind === "video" || kind === "document"
-    ? kind
-    : null;
+  const kind = mediaKindFromMime(normalized);
+  if (kind === "image" || kind === "audio" || kind === "video") {
+    return kind;
+  }
+  return normalized && MANAGED_DOCUMENT_MIME_TYPES.has(normalized) ? "document" : null;
 }
 
 type ParsedMediaDataUrl =
@@ -1846,6 +1861,11 @@ export async function handleManagedOutgoingMediaHttpRequest(
     sendStatus(res, 404, "not found");
     return true;
   }
+  const mediaKind = resolveManagedRecordKind(record);
+  if (!mediaKind) {
+    sendStatus(res, 404, "not found");
+    return true;
+  }
 
   let opened: Awaited<ReturnType<typeof openLocalFileSafely>>;
   try {
@@ -1860,7 +1880,6 @@ export async function handleManagedOutgoingMediaHttpRequest(
 
   let responseContentType = record.original.contentType || "application/octet-stream";
   let responseFilename = record.original.filename;
-  const mediaKind = resolveManagedRecordKind(record);
   if (variant === "thumbnail") {
     if (mediaKind !== "image") {
       await opened.handle.close();

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -14,7 +14,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import pLimit from "p-limit";
-import type { ReplyMediaAttachment } from "../auto-reply/reply-payload.js";
+import type { ReplyMediaAttachment, ReplyPayload } from "../auto-reply/reply-payload.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { loadExactSessionEntryReadOnlyResult } from "../config/sessions/session-accessor.sqlite-entry-availability.js";
@@ -113,6 +113,16 @@ type ManagedImageAttachmentLimitsConfig = Partial<
 
 type ManagedMediaKind = Extract<MediaKind, "image" | "audio" | "video" | "document">;
 
+function resolveManagedMediaKind(contentType: string | undefined): ManagedMediaKind | null {
+  if (contentType === "image/svg+xml") {
+    return "document";
+  }
+  const kind = mediaKindFromMime(contentType);
+  return kind === "image" || kind === "audio" || kind === "video" || kind === "document"
+    ? kind
+    : null;
+}
+
 type ParsedMediaDataUrl =
   | { kind: "not-data-url" }
   | { kind: "unsupported-data-url" }
@@ -124,6 +134,16 @@ type ParsedMediaDataUrl =
     };
 
 type ManagedMediaBlock = Record<string, unknown>;
+
+export type PreparedOutgoingMedia = {
+  url: string;
+  filename?: string;
+  mimeType?: string;
+  trustedLocal: boolean;
+  durationMs?: number;
+  width?: number;
+  height?: number;
+};
 
 type CleanupManagedOutgoingMediaRecordsResult = {
   deletedRecordCount: number;
@@ -818,10 +838,7 @@ function resolveManagedSessionOwnerAgentId(
 }
 
 function resolveManagedRecordKind(record: ManagedImageRecord): ManagedMediaKind | null {
-  const kind = mediaKindFromMime(record.original.contentType);
-  return kind === "image" || kind === "audio" || kind === "video" || kind === "document"
-    ? kind
-    : null;
+  return resolveManagedMediaKind(record.original.contentType);
 }
 
 function buildManagedMediaBlock(
@@ -879,19 +896,87 @@ function buildManagedImageResizeWarningBlock(params: {
   };
 }
 
-function toRecordFilename(filePath: string, attachmentName?: string, fallbackName?: string) {
+function toRecordFilename(
+  filePath: string,
+  attachmentName?: string,
+  fallbackName?: string,
+  contentType?: string,
+) {
   const fallback = fallbackName ?? path.basename(filePath).trim();
   if (!attachmentName?.trim()) {
     return fallback || null;
   }
   const safeName = sanitizeUntrustedFileName(attachmentName, fallback);
-  return `${path.parse(safeName).name}${path.extname(filePath)}`;
+  const extension =
+    contentType === "application/octet-stream" || mimeTypeFromFilePath(safeName) === contentType
+      ? path.extname(safeName)
+      : path.extname(filePath);
+  return `${path.parse(safeName).name}${extension}`;
 }
 
-function asArray(value: string[] | undefined | null) {
-  return Array.isArray(value)
-    ? value.filter((item) => typeof item === "string" && item.trim())
-    : [];
+function collectReplyMediaEntries(payload: ReplyPayload) {
+  const attachmentByReference = new Map<string, ReplyMediaAttachment>();
+  for (const attachment of payload.attachments ?? []) {
+    const reference = (
+      attachment.path ??
+      attachment.url ??
+      attachment.mediaUrl ??
+      attachment.filePath
+    )?.trim();
+    if (reference && !attachmentByReference.has(reference)) {
+      attachmentByReference.set(reference, attachment);
+    }
+  }
+  const mediaUrlCount = payload.mediaUrls?.length ?? 0;
+  return [
+    ...(payload.mediaUrls ?? []).map((url, index) => ({
+      url,
+      attachment: attachmentByReference.get(url.trim()) ?? payload.attachments?.[index],
+    })),
+    ...(typeof payload.mediaUrl === "string"
+      ? [
+          {
+            url: payload.mediaUrl,
+            attachment:
+              attachmentByReference.get(payload.mediaUrl.trim()) ??
+              payload.attachments?.[mediaUrlCount],
+          },
+        ]
+      : []),
+  ];
+}
+
+export function prepareOutgoingMediaFromReplyPayload(
+  payload: ReplyPayload,
+  metadataSource: ReplyPayload = payload,
+): PreparedOutgoingMedia[] {
+  const metadataByUrl = new Map<string, ReplyMediaAttachment>();
+  for (const entry of collectReplyMediaEntries(metadataSource)) {
+    const key = entry.url.trim();
+    if (key && entry.attachment && !metadataByUrl.has(key)) {
+      metadataByUrl.set(key, entry.attachment);
+    }
+  }
+  const seen = new Set<string>();
+  return collectReplyMediaEntries(payload).flatMap((entry) => {
+    const key = entry.url.trim();
+    if (!key || seen.has(key)) {
+      return [];
+    }
+    seen.add(key);
+    const attachment = metadataByUrl.get(key) ?? entry.attachment;
+    return [
+      {
+        url: entry.url,
+        ...(attachment?.name ? { filename: attachment.name } : {}),
+        ...(attachment?.mimeType ? { mimeType: attachment.mimeType } : {}),
+        trustedLocal: attachment?.trustedLocalMedia ?? payload.trustedLocalMedia === true,
+        ...(attachment?.durationMs !== undefined ? { durationMs: attachment.durationMs } : {}),
+        ...(attachment?.width !== undefined ? { width: attachment.width } : {}),
+        ...(attachment?.height !== undefined ? { height: attachment.height } : {}),
+      },
+    ];
+  });
 }
 
 function parseManagedOutgoingRoute(value: string) {
@@ -954,6 +1039,20 @@ function collectManagedOutgoingAttachmentRefs(
     }
   }
   return [...refs.values()];
+}
+
+async function removePreparedManagedOutgoingMedia(
+  blocks: readonly ManagedMediaBlock[],
+  stateDir: string,
+): Promise<void> {
+  await Promise.all(
+    collectManagedOutgoingAttachmentRefs(blocks).map(async ({ attachmentId }) => {
+      const record = readManagedImageRecord(attachmentId, stateDir);
+      if (record) {
+        await deleteManagedImageRecordArtifacts(record, stateDir);
+      }
+    }),
+  );
 }
 
 async function loadPendingPreparedAttachmentIds(stateDir: string): Promise<Set<string> | null> {
@@ -1363,13 +1462,11 @@ export function attachManagedOutgoingMediaToMessage(params: {
 export async function createManagedOutgoingMediaBlocks(params: {
   sessionKey: string;
   agentId?: string;
-  mediaUrls?: string[] | null;
-  attachments?: readonly ReplyMediaAttachment[] | null;
+  items?: readonly PreparedOutgoingMedia[] | null;
   stateDir?: string;
   messageId?: string | null;
   limits?: ManagedImageAttachmentLimitsConfig | null;
   localRoots?: readonly string[] | "any";
-  allowLocalNonImage?: boolean;
   continueOnPrepareError?: boolean;
   onPrepareError?: (error: Error) => void;
 }): Promise<ManagedMediaBlock[]> {
@@ -1377,23 +1474,27 @@ export async function createManagedOutgoingMediaBlocks(params: {
   if (!sessionKey) {
     return [];
   }
-  const mediaUrls = asArray(params.mediaUrls);
-  if (mediaUrls.length === 0) {
+  const items = params.items ?? [];
+  if (items.length === 0) {
     return [];
   }
   const stateDir = params.stateDir ?? resolveStateDir();
   const limits = resolveManagedImageAttachmentLimits(params.limits);
   const blocks: ManagedMediaBlock[] = [];
   let resolvedLocalRoots: readonly string[] | undefined;
-  for (const [index, mediaUrl] of mediaUrls.entries()) {
-    const attachmentMetadata = params.attachments?.[index];
+  for (const [index, item] of items.entries()) {
+    const mediaUrl = item.url;
     const trimmedMediaUrl = mediaUrl.trim();
     const dataUrlKind = /^data:(image|audio|video)\//iu.exec(trimmedMediaUrl)?.[1];
     const fallbackLabel = `Generated ${dataUrlKind ?? "media"} ${index + 1}`;
     const isDataUrl = trimmedMediaUrl.startsWith("data:");
     const localMediaPath = isDataUrl ? undefined : resolveLocalMediaPath(mediaUrl);
-    const label = isDataUrl ? fallbackLabel : deriveAltText(localMediaPath ?? mediaUrl, index);
-    const inferredKind = mediaKindFromMime(mimeTypeFromFilePath(localMediaPath ?? mediaUrl));
+    const label = isDataUrl
+      ? fallbackLabel
+      : item.filename?.trim() || deriveAltText(localMediaPath ?? mediaUrl, index);
+    const inferredKind = resolveManagedMediaKind(
+      item.mimeType ?? mimeTypeFromFilePath(localMediaPath ?? mediaUrl),
+    );
     const hintedKind =
       dataUrlKind === "image" || dataUrlKind === "audio" || dataUrlKind === "video"
         ? dataUrlKind
@@ -1408,12 +1509,12 @@ export async function createManagedOutgoingMediaBlocks(params: {
     try {
       const parsedDataUrl = parseMediaDataUrl(mediaUrl, fallbackLabel, limits);
       if (parsedDataUrl.kind === "unsupported-data-url") {
-        continue;
+        throw new Error("Managed media attachment has an unsupported data URL content type");
       }
       if (
         localMediaPath &&
         (hintedKind === "audio" || hintedKind === "video") &&
-        params.allowLocalNonImage !== true
+        !item.trustedLocal
       ) {
         throw new Error("Local audio/video media requires an explicitly trusted reply payload");
       }
@@ -1458,24 +1559,15 @@ export async function createManagedOutgoingMediaBlocks(params: {
               );
             })();
       savedOriginalPath = savedOriginal.path;
-      let savedOriginalContentType = savedOriginal.contentType;
+      let savedOriginalContentType = savedOriginal.contentType ?? item.mimeType;
       if (!savedOriginalContentType) {
-        await fs.rm(savedOriginal.path, { force: true }).catch(() => {});
-        savedOriginalPath = null;
-        continue;
+        throw new Error("Managed media attachment has no detectable content type");
       }
-      const mediaKind = mediaKindFromMime(savedOriginalContentType);
-      if (
-        mediaKind !== "image" &&
-        mediaKind !== "audio" &&
-        mediaKind !== "video" &&
-        mediaKind !== "document"
-      ) {
-        await fs.rm(savedOriginal.path, { force: true }).catch(() => {});
-        savedOriginalPath = null;
-        continue;
+      const mediaKind = resolveManagedMediaKind(savedOriginalContentType);
+      if (!mediaKind) {
+        throw new Error("Managed media attachment has an unsupported content type");
       }
-      if (localMediaPath && mediaKind !== "image" && params.allowLocalNonImage !== true) {
+      if (localMediaPath && mediaKind !== "image" && !item.trustedLocal) {
         throw new Error("Local audio/video media requires an explicitly trusted reply payload");
       }
       const maxBytes = maxBytesForManagedMediaKind(mediaKind, limits);
@@ -1584,8 +1676,9 @@ export async function createManagedOutgoingMediaBlocks(params: {
           sizeBytes: originalStats.sizeBytes,
           filename: toRecordFilename(
             savedOriginal.path,
-            attachmentMetadata?.name,
+            item.filename,
             mediaKind === "image" ? undefined : label,
+            savedOriginalContentType,
           ),
         },
       };
@@ -1607,9 +1700,9 @@ export async function createManagedOutgoingMediaBlocks(params: {
       }
       const block = buildManagedMediaBlock(record, playback);
       insertManagedImageRecord(record, stateDir);
-      const durationMs = asNonNegativeFiniteNumber(attachmentMetadata?.durationMs);
-      const width = asNonNegativeFiniteNumber(attachmentMetadata?.width);
-      const height = asNonNegativeFiniteNumber(attachmentMetadata?.height);
+      const durationMs = asNonNegativeFiniteNumber(item.durationMs);
+      const width = asNonNegativeFiniteNumber(item.width);
+      const height = asNonNegativeFiniteNumber(item.height);
       blocks.push({
         ...block,
         ...(durationMs !== undefined ? { durationMs } : {}),
@@ -1628,6 +1721,7 @@ export async function createManagedOutgoingMediaBlocks(params: {
         params.onPrepareError?.(sanitizedError);
         continue;
       }
+      await removePreparedManagedOutgoingMedia(blocks, stateDir);
       throw sanitizedError;
     }
   }

--- a/src/gateway/server-methods/artifacts.managed-lifecycle.test.ts
+++ b/src/gateway/server-methods/artifacts.managed-lifecycle.test.ts
@@ -81,4 +81,55 @@ describe("managed artifact lifecycle", () => {
     expect(hoisted.resolveManagedUrlDownload).not.toHaveBeenCalled();
     expect(hoisted.visitSessionMessagesAsync).not.toHaveBeenCalled();
   });
+
+  it("lists managed attachment envelopes as file artifacts", async () => {
+    hoisted.visitSessionMessagesAsync.mockImplementationOnce(async (_scope, visit) => {
+      visit(
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "attachment",
+              attachment: {
+                artifactId: "artifact_managed_media_11111111-1111-4111-8111-111111111111",
+                kind: "document",
+                label: "report.csv",
+                mimeType: "text/csv",
+                sizeBytes: 12,
+                url: "/api/chat/media/outgoing/agent%3Amain%3Amain/11111111-1111-4111-8111-111111111111/full",
+              },
+            },
+          ],
+          __openclaw: { seq: 2 },
+        },
+        2,
+      );
+      return 1;
+    });
+    const calls: Array<{ ok: boolean; payload?: unknown }> = [];
+
+    await artifactsHandlers["artifacts.list"]?.({
+      req: { type: "req", id: "list", method: "artifacts.list", params: {} },
+      params: { sessionKey: "agent:main:main" },
+      client: null,
+      isWebchatConnect: () => false,
+      respond: (ok, payload) => calls.push({ ok, payload }),
+      context: { getRuntimeConfig: () => ({}) } as never,
+    });
+
+    expect(calls[0]).toMatchObject({
+      ok: true,
+      payload: {
+        artifacts: [
+          {
+            id: "artifact_managed_media_11111111-1111-4111-8111-111111111111",
+            type: "file",
+            title: "report.csv",
+            mimeType: "text/csv",
+            sizeBytes: 12,
+          },
+        ],
+      },
+    });
+  });
 });

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -96,6 +96,9 @@ function normalizeArtifactType(value: string): string {
   if (normalized === "file" || normalized === "input_file") {
     return "file";
   }
+  if (normalized === "attachment") {
+    return "file";
+  }
   return "file";
 }
 
@@ -216,6 +219,7 @@ function isArtifactBlock(block: Record<string, unknown>): boolean {
     type === "audio" ||
     type === "video" ||
     type === "file" ||
+    type === "attachment" ||
     type === "input_image" ||
     type === "input_audio" ||
     type === "input_video" ||
@@ -260,13 +264,16 @@ function collectArtifactsFromMessage(params: {
       continue;
     }
     const type = normalizeArtifactType(asNonEmptyString(block.type) ?? "file");
+    const attachment = asOptionalRecord(block.attachment);
     const title =
       asNonEmptyString(block.title) ??
       asNonEmptyString(block.fileName) ??
       asNonEmptyString(block.filename) ??
       asNonEmptyString(block.alt) ??
+      asNonEmptyString(attachment?.label) ??
       `${type} ${params.artifacts.length + 1}`;
-    const declaredArtifactId = asNonEmptyString(block.artifactId);
+    const declaredArtifactId =
+      asNonEmptyString(block.artifactId) ?? asNonEmptyString(attachment?.artifactId);
     const id =
       declaredArtifactId && parseManagedOutgoingArtifactId(declaredArtifactId)
         ? declaredArtifactId
@@ -280,7 +287,7 @@ function collectArtifactsFromMessage(params: {
     const includeData = params.downloadArtifactId
       ? params.downloadArtifactId === id
       : params.includeDownloadData !== false;
-    const download = resolveBlockDownload(block, { includeData });
+    const download = resolveBlockDownload(attachment ?? block, { includeData });
     const summary: ArtifactRecord = {
       id,
       type,

--- a/src/gateway/server-methods/chat-assistant-content.ts
+++ b/src/gateway/server-methods/chat-assistant-content.ts
@@ -1,4 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   appendReplyMediaFailureWarning,
   readPairingQrReplyChannelData,
@@ -366,10 +367,21 @@ export function stripManagedOutgoingAssistantContentBlocks(
     return undefined;
   }
   const filtered = content.filter((block) => {
-    if (block?.type !== "image" && block?.type !== "audio" && block?.type !== "video") {
+    const attachment =
+      block?.type === "attachment" ? asOptionalRecord(block.attachment) : undefined;
+    if (
+      block?.type !== "image" &&
+      block?.type !== "audio" &&
+      block?.type !== "video" &&
+      !attachment
+    ) {
       return true;
     }
-    return !(isManagedOutgoingMediaUrl(block.url) || isManagedOutgoingMediaUrl(block.openUrl));
+    return !(
+      isManagedOutgoingMediaUrl(block.url) ||
+      isManagedOutgoingMediaUrl(block.openUrl) ||
+      isManagedOutgoingMediaUrl(attachment?.url)
+    );
   });
   return filtered.length > 0 ? filtered : undefined;
 }
@@ -422,8 +434,10 @@ export function hasManagedOutgoingAssistantContent(
   return Boolean(
     content?.some(
       (block) =>
-        (block?.type === "image" || block?.type === "audio" || block?.type === "video") &&
-        (isManagedOutgoingMediaUrl(block.url) || isManagedOutgoingMediaUrl(block.openUrl)),
+        ((block?.type === "image" || block?.type === "audio" || block?.type === "video") &&
+          (isManagedOutgoingMediaUrl(block.url) || isManagedOutgoingMediaUrl(block.openUrl))) ||
+        (block?.type === "attachment" &&
+          isManagedOutgoingMediaUrl(asOptionalRecord(block.attachment)?.url)),
     ),
   );
 }

--- a/src/gateway/server-methods/chat-assistant-content.ts
+++ b/src/gateway/server-methods/chat-assistant-content.ts
@@ -10,104 +10,15 @@ import { renderQrPngDataUrl } from "../../media/qr-image.js";
 import { renderQrTerminal } from "../../media/qr-terminal.js";
 import { stripInlineDirectiveTagsForDelivery } from "../../utils/directive-tags.js";
 import { stripEnvelopeFromMessage } from "../chat-sanitize.js";
-import { createManagedOutgoingMediaBlocks } from "../managed-image-attachments.js";
+import {
+  createManagedOutgoingMediaBlocks,
+  prepareOutgoingMediaFromReplyPayload,
+} from "../managed-image-attachments.js";
 import { formatForLog } from "../ws-log.js";
 
 const MANAGED_OUTGOING_MEDIA_PATH_PREFIX = "/api/chat/media/outgoing/";
 
 export type AssistantDisplayContentBlock = Record<string, unknown>;
-
-function collectReplyMediaEntries(payload: ReplyPayload) {
-  const attachmentByReference = new Map<string, NonNullable<ReplyPayload["attachments"]>[number]>();
-  for (const attachment of payload.attachments ?? []) {
-    const reference = (
-      attachment.path ??
-      attachment.url ??
-      attachment.mediaUrl ??
-      attachment.filePath
-    )?.trim();
-    if (reference && !attachmentByReference.has(reference)) {
-      attachmentByReference.set(reference, attachment);
-    }
-  }
-  const mediaUrlCount = payload.mediaUrls?.length ?? 0;
-  return [
-    ...(payload.mediaUrls ?? []).map((url, index) => ({
-      url,
-      attachment: attachmentByReference.get(url.trim()) ?? payload.attachments?.[index],
-    })),
-    ...(typeof payload.mediaUrl === "string"
-      ? [
-          {
-            url: payload.mediaUrl,
-            attachment:
-              attachmentByReference.get(payload.mediaUrl.trim()) ??
-              payload.attachments?.[mediaUrlCount],
-          },
-        ]
-      : []),
-  ];
-}
-
-function resolveAlignedReplyMedia(
-  payload: ReplyPayload,
-  metadataSource: ReplyPayload = payload,
-): {
-  mediaUrls: string[];
-  attachments?: NonNullable<ReplyPayload["attachments"]>;
-} {
-  const metadataByUrl = new Map<string, NonNullable<ReplyPayload["attachments"]>[number]>();
-  for (const entry of collectReplyMediaEntries(metadataSource)) {
-    const key = entry.url.trim();
-    if (key && entry.attachment && !metadataByUrl.has(key)) {
-      metadataByUrl.set(key, entry.attachment);
-    }
-  }
-  const seen = new Set<string>();
-  const mediaUrls: string[] = [];
-  const attachments: NonNullable<ReplyPayload["attachments"]> = [];
-  let hasMetadata = false;
-  for (const entry of collectReplyMediaEntries(payload)) {
-    const key = entry.url.trim();
-    if (!key || seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    mediaUrls.push(entry.url);
-    const attachment = metadataByUrl.get(key) ?? entry.attachment ?? {};
-    attachments.push(attachment);
-    hasMetadata ||= Object.keys(attachment).length > 0;
-  }
-  return { mediaUrls, ...(hasMetadata ? { attachments } : {}) };
-}
-
-function splitReplyMediaByTrust(
-  media: ReturnType<typeof resolveAlignedReplyMedia>,
-  payloadTrusted: boolean,
-) {
-  // One payload per trust class is the authorization boundary. Class order follows
-  // first occurrence; interleaved entries are intentionally coalesced within their class.
-  const groups = new Map<
-    boolean,
-    {
-      mediaUrls: string[];
-      attachments: NonNullable<ReplyPayload["attachments"]>;
-      sourceIndexes: number[];
-    }
-  >();
-  for (const [index, url] of media.mediaUrls.entries()) {
-    const attachment = media.attachments?.[index] ?? {};
-    const trusted = attachment.trustedLocalMedia ?? payloadTrusted;
-    const group = groups.get(trusted) ?? { mediaUrls: [], attachments: [], sourceIndexes: [] };
-    group.mediaUrls.push(url);
-    group.attachments.push(attachment);
-    group.sourceIndexes.push(index);
-    groups.set(trusted, group);
-  }
-  return [...groups].map(([trustedLocalMedia, group]) =>
-    Object.assign(group, { trustedLocalMedia }),
-  );
-}
 
 /** Recombine non-streamed text without destroying Markdown's meaningful indentation. */
 export function combineNonStreamingReplyParts(parts: readonly string[]): string {
@@ -263,39 +174,28 @@ export async function buildAssistantDisplayContentFromReplyPayloads(params: {
     if (params.includeSensitiveMedia === false && payload.sensitiveMedia === true) {
       continue;
     }
-    const media = resolveAlignedReplyMedia(payload, params.payloads[entry.sourceIndex] ?? payload);
-    const preparedMedia: Array<{ sourceIndex: number; blocks: AssistantDisplayContentBlock[] }> =
-      [];
-    for (const mediaGroup of splitReplyMediaByTrust(media, payload.trustedLocalMedia === true)) {
-      for (const [groupIndex, mediaUrl] of mediaGroup.mediaUrls.entries()) {
-        const mediaBlocks = await createManagedOutgoingMediaBlocks({
-          sessionKey: params.sessionKey,
-          ...(params.agentId ? { agentId: params.agentId } : {}),
-          mediaUrls: [mediaUrl],
-          attachments: [mediaGroup.attachments[groupIndex] ?? {}],
-          localRoots: params.managedMediaLocalRoots,
-          allowLocalNonImage: mediaGroup.trustedLocalMedia,
-          continueOnPrepareError: true,
-          onPrepareError: (error) => {
-            managedMediaPrepareFailed = true;
-            params.onManagedMediaPrepareError?.(error.message);
-          },
-        });
-        if (payload.audioAsVoice === true) {
-          for (const block of mediaBlocks) {
-            if (block.type === "audio") {
-              block.isVoiceNote = true;
-            }
-          }
+    const mediaBlocks = await createManagedOutgoingMediaBlocks({
+      sessionKey: params.sessionKey,
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+      items: prepareOutgoingMediaFromReplyPayload(
+        payload,
+        params.payloads[entry.sourceIndex] ?? payload,
+      ),
+      localRoots: params.managedMediaLocalRoots,
+      continueOnPrepareError: true,
+      onPrepareError: (error) => {
+        managedMediaPrepareFailed = true;
+        params.onManagedMediaPrepareError?.(error.message);
+      },
+    });
+    if (payload.audioAsVoice === true) {
+      for (const block of mediaBlocks) {
+        if (block.type === "audio") {
+          block.isVoiceNote = true;
         }
-        preparedMedia.push({
-          sourceIndex: mediaGroup.sourceIndexes[groupIndex] ?? groupIndex,
-          blocks: mediaBlocks,
-        });
       }
     }
-    preparedMedia.sort((left, right) => left.sourceIndex - right.sourceIndex);
-    content.push(...preparedMedia.flatMap((preparedEntry) => preparedEntry.blocks));
+    content.push(...mediaBlocks);
     if (managedMediaPrepareFailed) {
       content.push({ type: "text", text: appendReplyMediaFailureWarning(undefined) });
     }
@@ -326,17 +226,24 @@ export function replaceAssistantContentTextBlocks(
   }
   const merged: AssistantDisplayContentBlock[] = [];
   let transcriptTextIndex = 0;
+  const mediaFailureWarning = appendReplyMediaFailureWarning(undefined);
   for (const block of content) {
     if (
       block?.type === "text" &&
       typeof block.text === "string" &&
+      block.text !== mediaFailureWarning &&
       transcriptTextIndex < transcriptTextBlocks.length
     ) {
+      const replacement = expectDefined(
+        transcriptTextBlocks[transcriptTextIndex++],
+        "transcript text blocks entry at transcript text index++",
+      );
       merged.push(
-        expectDefined(
-          transcriptTextBlocks[transcriptTextIndex++],
-          "transcript text blocks entry at transcript text index++",
-        ),
+        block.text.includes(mediaFailureWarning) &&
+          typeof replacement.text === "string" &&
+          !replacement.text.includes(mediaFailureWarning)
+          ? { ...replacement, text: appendReplyMediaFailureWarning(replacement.text) }
+          : replacement,
       );
       continue;
     }

--- a/src/gateway/server-methods/chat-reply-media.test.ts
+++ b/src/gateway/server-methods/chat-reply-media.test.ts
@@ -12,7 +12,10 @@ import {
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
 import { createManagedOutgoingMediaBlocks as createManagedOutgoingImageBlocks } from "../managed-image-attachments.js";
-import { buildAssistantDisplayContentFromReplyPayloads } from "./chat-assistant-content.js";
+import {
+  buildAssistantDisplayContentFromReplyPayloads,
+  replaceAssistantContentTextBlocks,
+} from "./chat-assistant-content.js";
 import { normalizeWebchatReplyMediaPathsForDisplay } from "./chat-reply-media.js";
 
 const PNG_BYTES = Buffer.from(
@@ -133,7 +136,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
   }) {
     return createManagedOutgoingImageBlocks({
       sessionKey: TEST_SESSION_KEY,
-      mediaUrls: params.mediaUrls ?? [],
+      items: (params.mediaUrls ?? []).map((url) => ({ url, trustedLocal: false })),
       localRoots: getAgentScopedMediaLocalRoots(params.cfg, "main"),
     });
   }
@@ -177,6 +180,73 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     expect(requireString(payload?.text, "suppressed media text")).toBe(
       "⚠️ Media failed. Try sending a smaller supported file or a different format.",
     );
+  });
+
+  it("preserves a visible warning when mixed media normalization rejects one item", async () => {
+    const { workspaceDir, cfg } = createMediaTestContext({ allowRead: true });
+    const imagePath = path.join(workspaceDir, "image.png");
+    const unsupportedPath = path.join(workspaceDir, "script.js");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(imagePath, PNG_BYTES);
+    await fs.writeFile(unsupportedPath, "export default true;\n");
+
+    const payload = await normalizeReplyMedia({
+      cfg,
+      payloads: [
+        {
+          text: "Artifacts ready",
+          mediaUrls: [imagePath, unsupportedPath],
+        },
+      ],
+    });
+
+    expect(payload).toMatchObject({
+      text: "Artifacts ready\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
+      mediaUrls: [expect.stringMatching(/\.png$/u)],
+      attachments: [
+        expect.objectContaining({
+          name: "image.png",
+          mimeType: "image/png",
+          trustedLocalMedia: true,
+        }),
+      ],
+    });
+  });
+
+  it("preserves rejection warnings and metadata beside trusted local audio", async () => {
+    const { workspaceDir, cfg } = createMediaTestContext({ allowRead: true });
+    const documentPath = path.join(workspaceDir, "report.json");
+    const unsupportedPath = path.join(workspaceDir, "script.js");
+    const audioPath = path.join(workspaceDir, "voice.mp3");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(documentPath, '{"ready":true}\n');
+    await fs.writeFile(unsupportedPath, "export default true;\n");
+    await createAudioFile(audioPath);
+
+    const payload = await normalizeReplyMedia({
+      cfg,
+      payloads: [
+        {
+          text: "Artifacts ready",
+          mediaUrls: [documentPath, unsupportedPath, audioPath],
+          attachments: [
+            { name: "report.json", mimeType: "application/json", trustedLocalMedia: true },
+            { name: "script.js", mimeType: "text/javascript", trustedLocalMedia: true },
+            { name: "voice.mp3", mimeType: "audio/mpeg", trustedLocalMedia: true },
+          ],
+          trustedLocalMedia: true,
+        },
+      ],
+    });
+
+    expect(payload).toMatchObject({
+      text: "Artifacts ready\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
+      mediaUrls: [expect.stringMatching(/\.json$/u), audioPath],
+      attachments: [
+        expect.objectContaining({ name: "report.json", mimeType: "application/json" }),
+        expect.objectContaining({ name: "voice.mp3", mimeType: "audio/mpeg" }),
+      ],
+    });
   });
 
   it("does not stage sensitive media before display suppression", async () => {
@@ -224,6 +294,69 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     expect(errors).toEqual(["Invalid image data URL"]);
     expect(JSON.stringify(content)).not.toContain(source);
     expect(Buffer.byteLength(JSON.stringify(content))).toBeLessThan(256);
+  });
+
+  it("keeps an explicit warning when one media item cannot become an attachment", async () => {
+    const { workspaceDir } = createMediaTestContext({ allowRead: true });
+    const sourcePath = path.join(workspaceDir, "mystery.blob");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(sourcePath, Buffer.from([0, 1, 2, 3]));
+
+    const content = await buildAssistantDisplayContentFromReplyPayloads({
+      sessionKey: TEST_SESSION_KEY,
+      agentId: "main",
+      payloads: [
+        {
+          text: "Artifact result",
+          mediaUrls: [sourcePath],
+          attachments: [{ name: "mystery.blob", trustedLocalMedia: true }],
+        },
+      ],
+      managedMediaLocalRoots: [workspaceDir],
+    });
+
+    expect(content).toEqual([
+      { type: "text", text: "Artifact result" },
+      {
+        type: "text",
+        text: "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+      },
+    ]);
+  });
+
+  it("preserves a media failure warning beside synthetic media-only text", () => {
+    const warning = "⚠️ Media failed. Try sending a smaller supported file or a different format.";
+
+    expect(
+      replaceAssistantContentTextBlocks(
+        [
+          { type: "image", url: "/managed/image" },
+          { type: "text", text: warning },
+        ],
+        { content: [{ type: "text", text: "Image reply" }] },
+      ),
+    ).toEqual([
+      { type: "text", text: "Image reply" },
+      { type: "image", url: "/managed/image" },
+      { type: "text", text: warning },
+    ]);
+  });
+
+  it("preserves a media failure warning appended to replaced transcript text", () => {
+    const warning = "⚠️ Media failed. Try sending a smaller supported file or a different format.";
+
+    expect(
+      replaceAssistantContentTextBlocks(
+        [
+          { type: "text", text: `Artifact result\n${warning}` },
+          { type: "attachment", attachment: { label: "report.pdf" } },
+        ],
+        { content: [{ type: "text", text: "Artifact result" }] },
+      ),
+    ).toEqual([
+      { type: "text", text: `Artifact result\n${warning}` },
+      { type: "attachment", attachment: { label: "report.pdf" } },
+    ]);
   });
 
   it("preserves local audio paths for WebChat audio embedding", async () => {

--- a/src/gateway/server-methods/chat-reply-media.test.ts
+++ b/src/gateway/server-methods/chat-reply-media.test.ts
@@ -2,11 +2,15 @@
  * Tests chat reply media handling for gateway message delivery.
  */
 import fs from "node:fs/promises";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { consumePendingToolMediaIntoReply } from "../../agents/embedded-agent-subscribe.handlers.messages.replies.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createPinnedLookup } from "../../infra/net/ssrf.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
+import { setMediaStoreNetworkDepsForTest } from "../../media/store.test-support.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -47,6 +51,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
   });
 
   afterEach(async () => {
+    setMediaStoreNetworkDepsForTest();
     await testState.cleanup();
   });
 
@@ -182,35 +187,84 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     );
   });
 
-  it("preserves a visible warning when mixed media normalization rejects one item", async () => {
+  it("preserves ordered document and image metadata beside one rejected SVG", async () => {
     const { workspaceDir, cfg } = createMediaTestContext({ allowRead: true });
-    const imagePath = path.join(workspaceDir, "image.png");
-    const unsupportedPath = path.join(workspaceDir, "script.js");
+    const documentPath = path.join(workspaceDir, "artifact.json");
+    const localImagePath = path.join(workspaceDir, "local.png");
+    const unsupportedPath = path.join(workspaceDir, "vector.svg");
     await fs.mkdir(workspaceDir, { recursive: true });
-    await fs.writeFile(imagePath, PNG_BYTES);
-    await fs.writeFile(unsupportedPath, "export default true;\n");
+    await fs.writeFile(documentPath, '{"ready":true}\n');
+    await fs.writeFile(localImagePath, PNG_BYTES);
+    await fs.writeFile(unsupportedPath, "<svg><script/></svg>\n");
+    const upstream = http.createServer((req, res) => {
+      expect(req.url).toBe("/remote.png?sig=secret");
+      res.statusCode = 200;
+      res.setHeader("content-type", "image/png");
+      res.end(PNG_BYTES);
+    });
+    await new Promise<void>((resolve) => {
+      upstream.listen(0, "127.0.0.1", resolve);
+    });
+    const address = upstream.address() as AddressInfo;
+    setMediaStoreNetworkDepsForTest({
+      resolvePinnedHostname: async (hostname) => ({
+        hostname,
+        addresses: ["127.0.0.1"],
+        lookup: createPinnedLookup({ hostname, addresses: ["127.0.0.1"] }),
+      }),
+    });
 
-    const payload = await normalizeReplyMedia({
-      cfg,
-      payloads: [
+    try {
+      const remoteImageUrl = `http://127.0.0.1:${address.port}/remote.png?sig=secret`;
+      const payload = await normalizeReplyMedia({
+        cfg,
+        payloads: [
+          {
+            text: "Artifacts ready",
+            mediaUrls: [documentPath, remoteImageUrl, localImagePath, unsupportedPath],
+          },
+        ],
+      });
+
+      expect(payload).toMatchObject({
+        text: "Artifacts ready\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
+        attachments: [
+          expect.objectContaining({ name: "artifact.json", mimeType: "application/json" }),
+          {},
+          expect.objectContaining({ name: "local.png", mimeType: "image/png" }),
+        ],
+      });
+      expect(payload?.mediaUrls).toHaveLength(3);
+      const content = await buildAssistantDisplayContentFromReplyPayloads({
+        sessionKey: TEST_SESSION_KEY,
+        agentId: "main",
+        payloads: payload ? [payload] : [],
+        managedMediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, "main"),
+      });
+      expect(content).toEqual([
         {
-          text: "Artifacts ready",
-          mediaUrls: [imagePath, unsupportedPath],
+          type: "text",
+          text: "Artifacts ready\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
         },
-      ],
-    });
-
-    expect(payload).toMatchObject({
-      text: "Artifacts ready\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
-      mediaUrls: [expect.stringMatching(/\.png$/u)],
-      attachments: [
         expect.objectContaining({
-          name: "image.png",
-          mimeType: "image/png",
-          trustedLocalMedia: true,
+          type: "attachment",
+          attachment: expect.objectContaining({
+            label: "artifact.json",
+            mimeType: "application/json",
+          }),
         }),
-      ],
-    });
+        expect.objectContaining({ type: "image", alt: "remote.png", mimeType: "image/png" }),
+        expect.objectContaining({ type: "image", alt: "local.png", mimeType: "image/png" }),
+      ]);
+      const serialized = JSON.stringify(content);
+      expect(serialized).not.toContain("vector.svg");
+      expect(serialized.match(/Media failed/gu)).toHaveLength(1);
+      expect(serialized).not.toContain("sig=secret");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        upstream.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it("preserves rejection warnings and metadata beside trusted local audio", async () => {

--- a/src/gateway/server-methods/chat-reply-media.ts
+++ b/src/gateway/server-methods/chat-reply-media.ts
@@ -65,10 +65,13 @@ export async function normalizeWebchatReplyMediaPathsForDisplay(params: {
       continue;
     }
     const mergedMediaUrls: string[] = [];
+    const mergedAttachments: NonNullable<ReplyPayload["attachments"]> = [];
     let text = payload.text;
-    for (const mediaUrl of mediaUrls) {
+    for (const [index, mediaUrl] of mediaUrls.entries()) {
+      const attachment = payload.attachments?.[index];
       if (shouldPreserveDisplayMediaUrl(payload, mediaUrl)) {
         mergedMediaUrls.push(mediaUrl);
+        mergedAttachments.push(attachment ?? {});
         continue;
       }
       const normalizedPayload = await normalizeMediaPaths({
@@ -76,6 +79,7 @@ export async function normalizeWebchatReplyMediaPathsForDisplay(params: {
         text,
         mediaUrl,
         mediaUrls: [mediaUrl],
+        attachments: attachment ? [attachment] : undefined,
       });
       const normalizedMediaUrls = resolveSendableOutboundReplyParts(normalizedPayload).mediaUrls;
       text = normalizedPayload.text;
@@ -83,12 +87,16 @@ export async function normalizeWebchatReplyMediaPathsForDisplay(params: {
         continue;
       }
       mergedMediaUrls.push(...normalizedMediaUrls);
+      mergedAttachments.push(
+        ...(normalizedPayload.attachments ?? normalizedMediaUrls.map(() => ({}))),
+      );
     }
     normalized.push({
       ...payload,
       text,
       mediaUrl: mergedMediaUrls[0],
       mediaUrls: mergedMediaUrls,
+      attachments: mergedAttachments,
     });
   }
   return normalized;

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -137,6 +137,9 @@ export function createChatSendReplyDispatch(params: {
   const deliveredReplies: DeliveredChatSendReply[] = [];
   const finalizedAgentMediaTranscriptKeys = new Set<string>();
   let appendedWebchatAgentMedia = false;
+  const needsAgentMediaTranscriptFinalization = (payload: ReplyPayload): boolean =>
+    isMediaBearingPayload(payload) ||
+    getReplyPayloadMetadata(payload)?.assistantMediaNormalizationFailed === true;
   const agentMediaTranscriptKey = (payload: ReplyPayload): string => {
     const metadata = getReplyPayloadMetadata(payload);
     const ownedIdempotencyKey =
@@ -152,7 +155,7 @@ export function createChatSendReplyDispatch(params: {
     return "unkeyed";
   };
   const appendWebchatAgentMediaTranscriptIfNeeded = async (payload: ReplyPayload) => {
-    if (!isAgentRunStarted() || !isMediaBearingPayload(payload)) {
+    if (!isAgentRunStarted() || !needsAgentMediaTranscriptFinalization(payload)) {
       return;
     }
     const finalizationKey = agentMediaTranscriptKey(payload);
@@ -202,9 +205,12 @@ export function createChatSendReplyDispatch(params: {
       assistantContent,
       mediaMessage,
     );
-    const persistedContentForAppend = hasAssistantDisplayMediaContent(persistedAssistantContent)
-      ? persistedAssistantContent
-      : undefined;
+    const mediaNormalizationFailed =
+      getReplyPayloadMetadata(transcriptPayload)?.assistantMediaNormalizationFailed === true;
+    const persistedContentForAppend =
+      hasAssistantDisplayMediaContent(persistedAssistantContent) || mediaNormalizationFailed
+        ? persistedAssistantContent
+        : undefined;
     if (!persistedContentForAppend?.length) {
       return;
     }
@@ -366,7 +372,7 @@ export function createChatSendReplyDispatch(params: {
     const latestPayloadByKey = new Map<string, ReplyPayload>();
     const orderedKeys: string[] = [];
     for (const { payload } of deliveredReplies) {
-      if (!isMediaBearingPayload(payload)) {
+      if (!needsAgentMediaTranscriptFinalization(payload)) {
         continue;
       }
       const key = agentMediaTranscriptKey(payload);

--- a/src/gateway/server-methods/chat-transcript-persistence.ts
+++ b/src/gateway/server-methods/chat-transcript-persistence.ts
@@ -147,9 +147,6 @@ function mergeManagedMediaIntoAssistantContent(params: {
     ? (params.message.content as AssistantDisplayContentBlock[])
     : [];
   const managedBlocks = params.replacement.filter((block) => block?.type !== "text");
-  if (managedBlocks.length === 0) {
-    return null;
-  }
   const mediaFailureWarning = appendReplyMediaFailureWarning(undefined);
   const preserveMediaFailureWarning = params.replacement.some(
     (block) =>
@@ -157,6 +154,9 @@ function mergeManagedMediaIntoAssistantContent(params: {
       typeof block.text === "string" &&
       block.text.includes(mediaFailureWarning),
   );
+  if (managedBlocks.length === 0 && !preserveMediaFailureWarning) {
+    return null;
+  }
   let replaced = false;
   const merged: AssistantDisplayContentBlock[] = [];
   for (const block of original) {
@@ -181,6 +181,9 @@ function mergeManagedMediaIntoAssistantContent(params: {
       merged.push(...managedBlocks);
       replaced = true;
     }
+  }
+  if (replaced && preserveMediaFailureWarning && merged.length === 0) {
+    merged.push({ type: "text", text: mediaFailureWarning });
   }
   return replaced ? merged : null;
 }

--- a/src/gateway/server-methods/chat-transcript-persistence.ts
+++ b/src/gateway/server-methods/chat-transcript-persistence.ts
@@ -1,6 +1,9 @@
 // Transcript persistence and source-reply rewrites shared by chat send and abort.
 import { asOptionalRecord as transcriptEventRecord } from "@openclaw/normalization-core/record-coerce";
-import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
+import {
+  appendReplyMediaFailureWarning,
+  getReplyPayloadMetadata,
+} from "../../auto-reply/reply-payload.js";
 import {
   findTranscriptEvent,
   loadTranscriptEventRowsAfterSeqSync,
@@ -147,6 +150,13 @@ function mergeManagedMediaIntoAssistantContent(params: {
   if (managedBlocks.length === 0) {
     return null;
   }
+  const mediaFailureWarning = appendReplyMediaFailureWarning(undefined);
+  const preserveMediaFailureWarning = params.replacement.some(
+    (block) =>
+      block?.type === "text" &&
+      typeof block.text === "string" &&
+      block.text.includes(mediaFailureWarning),
+  );
   let replaced = false;
   const merged: AssistantDisplayContentBlock[] = [];
   for (const block of original) {
@@ -160,7 +170,12 @@ function mergeManagedMediaIntoAssistantContent(params: {
     });
     if (visibleText) {
       const { textSignature: _textSignature, ...rest } = block;
-      merged.push({ ...rest, text: visibleText });
+      merged.push({
+        ...rest,
+        text: preserveMediaFailureWarning
+          ? appendReplyMediaFailureWarning(visibleText)
+          : visibleText,
+      });
     }
     if (split.mediaUrls?.length && !replaced) {
       merged.push(...managedBlocks);

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -2771,6 +2771,35 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(JSON.stringify(assistantEntries)).not.toContain(source);
   });
 
+  it("keeps managed media failures visible when rewriting an existing assistant row", async () => {
+    await createTranscriptFixture("openclaw-chat-send-managed-media-partial-failure-");
+    const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+    const mirrorKey = "idem-managed-media-partial-failure:internal-source-reply:0";
+    await appendSourceReplyMirrorEntry({
+      idempotencyKey: mirrorKey,
+      text: `Artifacts ready\nMEDIA:${mediaUrl}`,
+    });
+    setAgentRunReplies([
+      createMainSourceReply({
+        idempotencyKey: mirrorKey,
+        text: "Artifacts ready\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
+        mediaUrls: [mediaUrl],
+      }),
+    ]);
+    const { send } = createChatRequestFixture();
+
+    await send({
+      idempotencyKey: "idem-managed-media-partial-failure",
+      message: "hello from codex",
+    });
+
+    const assistantEntries = await readActiveAssistantTranscriptMessages();
+    expect(JSON.stringify(assistantEntries[0])).toContain(
+      "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+    );
+    expect(JSON.stringify(assistantEntries[0])).not.toContain("MEDIA:");
+  });
+
   it("does not cross a plugin-bound session rotation during finalization", async () => {
     await createTranscriptFixture("openclaw-chat-send-plugin-binding-rotation-");
     const targetSessionKey = "plugin-binding:codex:rotated";

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -156,6 +156,7 @@ function assistantAudioAttachmentHistoryMessage(
   text: string,
   timestamp: number,
   fields: ChatHistoryTestMessage = {},
+  includeLocalUrl = true,
 ): ChatHistoryTestMessage {
   return {
     role: "assistant",
@@ -164,7 +165,7 @@ function assistantAudioAttachmentHistoryMessage(
       {
         type: "attachment",
         attachment: {
-          url: "/tmp/tts.mp3",
+          ...(includeLocalUrl ? { url: "/tmp/tts.mp3" } : {}),
           kind: "audio",
           label: "tts.mp3",
           mimeType: "audio/mpeg",
@@ -184,6 +185,19 @@ function ttsSupplementHistoryMessage(
   return assistantAudioAttachmentHistoryMessage(text, timestamp, {
     openclawTtsSupplement: marker,
   });
+}
+
+function projectedTtsSupplementHistoryMessage(
+  marker: { textSha256: string; spokenText?: string },
+  timestamp: number,
+  text = "Audio reply",
+): ChatHistoryTestMessage {
+  return assistantAudioAttachmentHistoryMessage(
+    text,
+    timestamp,
+    { openclawTtsSupplement: marker },
+    false,
+  );
 }
 
 function deliveryMirrorHistoryMessage(
@@ -1841,7 +1855,7 @@ describe("projectChatDisplayMessages", () => {
 
     expect(result).toEqual([
       projectedSessionsSendHistoryMessage(visibleText, 1),
-      ttsSupplementHistoryMessage({ textSha256 }, 2),
+      projectedTtsSupplementHistoryMessage({ textSha256 }, 2),
     ]);
   });
 
@@ -2162,7 +2176,7 @@ describe("projectChatDisplayMessages", () => {
 
     expect(result).toEqual([
       userHistoryMessage("first", { timestamp: 1 }),
-      assistantAudioAttachmentHistoryMessage(visibleText, 2),
+      assistantAudioAttachmentHistoryMessage(visibleText, 2, {}, false),
       userHistoryMessage("second", { timestamp: 3 }),
     ]);
   });
@@ -2184,6 +2198,7 @@ describe("projectChatDisplayMessages", () => {
         `${projectedVisibleText.slice(0, 24)}\n...(truncated)...`,
         1,
         { __openclaw: { truncated: true, reason: "display-cap" } },
+        false,
       ),
     ]);
   });
@@ -2202,7 +2217,7 @@ describe("projectChatDisplayMessages", () => {
     expect(result).toEqual([
       assistantHistoryMessage(visibleText, { timestamp: 1 }),
       userHistoryMessage("again", { timestamp: 2 }),
-      ttsSupplementHistoryMessage(ttsSupplement, 3, visibleText),
+      projectedTtsSupplementHistoryMessage(ttsSupplement, 3, visibleText),
     ]);
   });
 });

--- a/src/gateway/server-restart-sentinel-agent-delivery.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.ts
@@ -355,7 +355,10 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
               if (
                 !blocks.some(
                   (block) =>
-                    block.type === "image" || block.type === "audio" || block.type === "video",
+                    block.type === "image" ||
+                    block.type === "audio" ||
+                    block.type === "video" ||
+                    block.type === "attachment",
                 )
               ) {
                 throw new Error("queued internal generated media could not be prepared");

--- a/src/gateway/server-restart-sentinel-agent-delivery.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.ts
@@ -343,14 +343,25 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
           for (const mediaUrl of mediaUrls) {
             let blocks = preparedMediaBlocks[mediaUrl];
             if (!blocks) {
+              const attachment = entry.expectedMediaAttachments?.[mediaUrl];
               blocks = await createManagedOutgoingMediaBlocks({
                 sessionKey: params.canonicalKey,
                 agentId: params.agentId,
-                mediaUrls: [mediaUrl],
-                attachments: [entry.expectedMediaAttachments?.[mediaUrl] ?? {}],
+                items: [
+                  {
+                    url: mediaUrl,
+                    ...(attachment?.name ? { filename: attachment.name } : {}),
+                    ...(attachment?.mimeType ? { mimeType: attachment.mimeType } : {}),
+                    trustedLocal: true,
+                    ...(attachment?.durationMs !== undefined
+                      ? { durationMs: attachment.durationMs }
+                      : {}),
+                    ...(attachment?.width !== undefined ? { width: attachment.width } : {}),
+                    ...(attachment?.height !== undefined ? { height: attachment.height } : {}),
+                  },
+                ],
                 stateDir,
                 localRoots: [getMediaDir()],
-                allowLocalNonImage: true,
               });
               if (
                 !blocks.some(

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -185,11 +185,11 @@ const mocks = vi.hoisted(() => {
       }),
     ),
     createManagedOutgoingMediaBlocks: vi.fn<CreateManagedOutgoingMediaBlocksMock>(async (params) =>
-      (params.mediaUrls ?? []).map((mediaUrl) => ({
-        type: params.attachments?.[0]?.type ?? "image",
-        artifactId: `artifact:${mediaUrl}`,
-        url: `/api/chat/media/outgoing/${encodeURIComponent(params.sessionKey)}/${encodeURIComponent(mediaUrl)}/full`,
-        openUrl: `/api/chat/media/outgoing/${encodeURIComponent(params.sessionKey)}/${encodeURIComponent(mediaUrl)}/full`,
+      (params.items ?? []).map((item) => ({
+        type: item.mimeType?.startsWith("audio/") ? "audio" : "image",
+        artifactId: `artifact:${item.url}`,
+        url: `/api/chat/media/outgoing/${encodeURIComponent(params.sessionKey)}/${encodeURIComponent(item.url)}/full`,
+        openUrl: `/api/chat/media/outgoing/${encodeURIComponent(params.sessionKey)}/${encodeURIComponent(item.url)}/full`,
       })),
     ),
     attachManagedOutgoingMediaToMessage: vi.fn<AttachManagedOutgoingMediaToMessageMock>(() => true),
@@ -1570,13 +1570,15 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.createManagedOutgoingMediaBlocks).toHaveBeenCalledWith({
       sessionKey: "agent:main:main",
       agentId: "main",
-      mediaUrls: [attachment.mediaUrl],
-      attachments: [
-        { type: attachment.type, path: attachment.mediaUrl, mimeType: attachment.mimeType },
+      items: [
+        {
+          url: attachment.mediaUrl,
+          mimeType: attachment.mimeType,
+          trustedLocal: true,
+        },
       ],
       stateDir: testState.stateDir,
       localRoots: [testState.statePath("media")],
-      allowLocalNonImage: true,
     });
     expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1786,8 +1788,13 @@ describe("scheduleRestartSentinelWake", () => {
     );
     expect(mocks.createManagedOutgoingMediaBlocks).toHaveBeenCalledWith(
       expect.objectContaining({
-        mediaUrls: ["/tmp/one.png"],
-        attachments: [{ type: "image", path: "/tmp/one.png", name: "one.png" }],
+        items: [
+          {
+            url: "/tmp/one.png",
+            filename: "one.png",
+            trustedLocal: true,
+          },
+        ],
       }),
     );
     expect(mocks.mergeSessionDeliveryPreparedMediaBlocks).toHaveBeenCalledWith(

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -515,7 +515,6 @@ describe("SessionHistorySseState", () => {
           {
             type: "attachment",
             attachment: {
-              url: "/tmp/tts.mp3",
               kind: "audio",
               label: "tts.mp3",
               mimeType: "audio/mpeg",

--- a/src/infra/outbound/message-action-send.ts
+++ b/src/infra/outbound/message-action-send.ts
@@ -156,10 +156,10 @@ export async function buildMessagePayload(params: {
     readToolStringParam(actionParams, "fileUrl", { trim: false }) ??
     readToolStringParam(actionParams, "image", { trim: false });
   const mediaUrlHints = readStringArrayParam(actionParams, "mediaUrls") ?? [];
-  const attachmentMediaHints = collectAttachmentSources(actionParams).map((source) => source.value);
+  const attachmentSources = collectAttachmentSources(actionParams);
   const hasBuffer = Boolean(readToolStringParam(actionParams, "buffer", { trim: false }));
   const hasMediaHint =
-    hasBuffer || Boolean(mediaHint) || mediaUrlHints.length > 0 || attachmentMediaHints.length > 0;
+    hasBuffer || Boolean(mediaHint) || mediaUrlHints.length > 0 || attachmentSources.length > 0;
   const hasPresentation = hasMessagePresentationBlocks(actionParams.presentation);
   const hasInteractive = hasLegacyInteractiveReplyBlocks(actionParams.interactive);
   const rawLocation = actionParams.location;
@@ -189,31 +189,69 @@ export async function buildMessagePayload(params: {
     stripAudioTag: true,
     stripReplyTags: true,
   });
-  const mergedMediaUrls: string[] = [];
-  const seenMedia = new Set<string>();
-  const pushMedia = (value?: string | null) => {
+  const topLevelFilename = readToolStringParam(actionParams, "filename");
+  const topLevelMimeType = readToolStringParam(actionParams, "contentType");
+  const attachmentByUrl = new Map(
+    attachmentSources.map((source) => [
+      normalizeOptionalString(source.value),
+      { filename: source.filename, mimeType: source.contentType },
+    ]),
+  );
+  const mediaEntries: Array<{ url: string; filename?: string; mimeType?: string }> = [];
+  const pushMedia = (
+    value?: string | null,
+    metadata?: { filename?: string; mimeType?: string },
+  ) => {
     const trimmed = normalizeOptionalString(value);
-    if (!trimmed || seenMedia.has(trimmed)) {
+    if (!trimmed) {
       return;
     }
-    seenMedia.add(trimmed);
-    mergedMediaUrls.push(trimmed);
+    mediaEntries.push({ url: trimmed, ...metadata });
   };
-  pushMedia(mediaHint);
+  pushMedia(mediaHint, {
+    ...attachmentByUrl.get(normalizeOptionalString(mediaHint)),
+    filename: topLevelFilename ?? attachmentByUrl.get(normalizeOptionalString(mediaHint))?.filename,
+    mimeType: topLevelMimeType ?? attachmentByUrl.get(normalizeOptionalString(mediaHint))?.mimeType,
+  });
   for (const mediaUrlHint of mediaUrlHints) {
-    pushMedia(mediaUrlHint);
+    pushMedia(mediaUrlHint, attachmentByUrl.get(normalizeOptionalString(mediaUrlHint)));
   }
-  for (const attachmentMediaHint of attachmentMediaHints) {
-    pushMedia(attachmentMediaHint);
+  for (const attachmentSource of attachmentSources) {
+    pushMedia(attachmentSource.value, {
+      filename: attachmentSource.filename,
+      mimeType: attachmentSource.contentType,
+    });
   }
 
-  const normalizedMediaUrls = await normalizeSandboxMediaList({
-    values: mergedMediaUrls,
-    sandboxRoot: input.sandboxRoot,
-    sandboxContainerWorkdir: input.sandboxContainerWorkdir,
+  const normalizedMedia = await Promise.all(
+    mediaEntries.map(async (entry) => {
+      const normalizedUrl = (
+        await normalizeSandboxMediaList({
+          values: [entry.url],
+          sandboxRoot: input.sandboxRoot,
+          sandboxContainerWorkdir: input.sandboxContainerWorkdir,
+        })
+      )[0];
+      entry.url = normalizedUrl ?? entry.url;
+      return entry;
+    }),
+  );
+  const seenMedia = new Set<string>();
+  const preparedMedia = normalizedMedia.filter((entry) => {
+    if (seenMedia.has(entry.url)) {
+      return false;
+    }
+    seenMedia.add(entry.url);
+    return true;
   });
-  mergedMediaUrls.length = 0;
-  mergedMediaUrls.push(...normalizedMediaUrls);
+  const mergedMediaUrls = preparedMedia.map((entry) => entry.url);
+  const mediaAttachments = preparedMedia.map((entry) =>
+    Object.assign(
+      { path: entry.url },
+      entry.filename ? { name: entry.filename } : {},
+      entry.mimeType ? { mimeType: entry.mimeType } : {},
+    ),
+  );
 
   message = stripPlainTextToolCallBlocks(stripUnsupportedCitationControlMarkers(parsed.text), {
     resolveProtectedRanges: findCodeRegions,
@@ -320,6 +358,9 @@ export async function buildMessagePayload(params: {
     text: message,
     ...(mediaUrl ? { mediaUrl } : {}),
     ...(mergedMediaUrls.length ? { mediaUrls: mergedMediaUrls } : {}),
+    ...(mediaAttachments.some((attachment) => Object.keys(attachment).length > 1)
+      ? { attachments: mediaAttachments }
+      : {}),
     ...(asVoice ? { audioAsVoice: true } : {}),
     ...(asVideoNote ? { videoAsNote: true } : {}),
     ...(location ? { location } : {}),

--- a/src/media/local-media-path.windows.test.ts
+++ b/src/media/local-media-path.windows.test.ts
@@ -100,7 +100,12 @@ describe.runIf(process.platform === "win32")("Windows local media file URLs", ()
         const blocks = await createManagedOutgoingMediaBlocks({
           stateDir: root,
           sessionKey: "agent:main:main",
-          mediaUrls: [sourceUrl.href.replace(/^file:/u, "FILE:")],
+          items: [
+            {
+              url: sourceUrl.href.replace(/^file:/u, "FILE:"),
+              trustedLocal: false,
+            },
+          ],
           localRoots: [path.join(root, "workspace")],
         });
 

--- a/test/e2e/qa-lab/runtime/gateway-agent-artifact-apis.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-agent-artifact-apis.e2e.test.ts
@@ -362,7 +362,12 @@ describe("Gateway agent and artifact APIs", () => {
     const [managedBlock] = await createManagedOutgoingMediaBlocks({
       sessionKey,
       agentId: "main",
-      mediaUrls: [`data:image/png;base64,${TINY_PNG_BASE64}`],
+      items: [
+        {
+          url: `data:image/png;base64,${TINY_PNG_BASE64}`,
+          trustedLocal: false,
+        },
+      ],
       stateDir,
       messageId,
     });

--- a/test/e2e/qa-lab/runtime/gateway-agent-artifact-apis.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-agent-artifact-apis.e2e.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../src/config/sessions/session-accessor.js";
 import { clearSessionStoreCacheForTest } from "../../../../src/config/sessions/store-writer-state.js";
 import { createManagedOutgoingMediaBlocks } from "../../../../src/gateway/managed-image-attachments.js";
+import { listManagedImageRecordEntries } from "../../../../src/gateway/managed-image-record-store.js";
 import { ADMIN_SCOPE, READ_SCOPE } from "../../../../src/gateway/method-scopes.js";
 import { startGatewayServer } from "../../../../src/gateway/server.js";
 import {
@@ -115,9 +116,6 @@ const ENV_KEYS = [
   "OPENCLAW_SKIP_PROVIDERS",
   "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
 ] as const;
-
-const TINY_PNG_BASE64 =
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WnXcZ0AAAAASUVORK5CYII=";
 
 type Cleanup = () => Promise<void> | void;
 
@@ -359,24 +357,42 @@ describe("Gateway agent and artifact APIs", () => {
     cleanup.push(() => {
       deleteTaskRecordById(task.taskId);
     });
-    const [managedBlock] = await createManagedOutgoingMediaBlocks({
+    const documentFixtures = [
+      {
+        name: "artifact.json",
+        mimeType: "application/json",
+        body: Buffer.from('{"ready":true}\n'),
+      },
+      {
+        name: "report.pdf",
+        mimeType: "application/pdf",
+        body: Buffer.from("%PDF-1.4\n% OpenClaw artifact proof\n"),
+      },
+    ];
+    await Promise.all(
+      documentFixtures.map((fixture) =>
+        fs.writeFile(path.join(mainWorkspace, fixture.name), fixture.body),
+      ),
+    );
+    const managedBlocks = await createManagedOutgoingMediaBlocks({
       sessionKey,
       agentId: "main",
-      items: [
-        {
-          url: `data:image/png;base64,${TINY_PNG_BASE64}`,
-          trustedLocal: false,
-        },
-      ],
+      items: documentFixtures.map((fixture) => ({
+        url: path.join(mainWorkspace, fixture.name),
+        filename: fixture.name,
+        mimeType: fixture.mimeType,
+        trustedLocal: true,
+      })),
+      localRoots: [mainWorkspace],
       stateDir,
       messageId,
     });
-    expect(managedBlock).toBeDefined();
+    expect(managedBlocks).toHaveLength(2);
     await appendTranscriptMessage(scope, {
       eventId: messageId,
       message: {
         role: "assistant",
-        content: [managedBlock],
+        content: managedBlocks,
         timestamp: Date.now(),
         __openclaw: {
           id: messageId,
@@ -386,42 +402,80 @@ describe("Gateway agent and artifact APIs", () => {
       } as never,
     });
 
-    const artifactList = await client.request<{
+    await disconnectGatewayClient(client);
+    client = await connectGatewayClient({
+      url: `ws://127.0.0.1:${port}`,
+      token,
+      clientDisplayName: "gateway artifact APIs after reload",
+      scopes: [ADMIN_SCOPE, READ_SCOPE],
+      timeoutMs: 30_000,
+    });
+    type ArtifactList = {
       artifacts: Array<{
         id: string;
         sessionKey: string;
         taskId?: string;
+        type: string;
+        title: string;
+        mimeType?: string;
         download: { mode: string };
       }>;
-    }>("artifacts.list", { taskId: task.taskId });
-    expect(artifactList.artifacts).toHaveLength(1);
-    const artifact = artifactList.artifacts[0]!;
-    expect(artifact).toMatchObject({
-      sessionKey,
+    };
+    const reloadedArtifactList = await client.request<ArtifactList>("artifacts.list", {
       taskId: task.taskId,
-      download: { mode: "url" },
     });
-    await expect(
-      client.request("artifacts.get", {
-        taskId: task.taskId,
-        artifactId: artifact.id,
-      }),
-    ).resolves.toMatchObject({ artifact: { id: artifact.id, taskId: task.taskId } });
+    expect(reloadedArtifactList.artifacts.map((artifact) => artifact.title)).toEqual([
+      "artifact.json",
+      "report.pdf",
+    ]);
+    expect(reloadedArtifactList.artifacts.every((artifact) => artifact.type === "file")).toBe(true);
+    expect(listManagedImageRecordEntries({ stateDir, sessionKey })).toHaveLength(2);
 
-    const download = await client.request<{ url: string; expiresAt: string }>(
-      "artifacts.download",
-      {
+    await restartGateway("gateway artifact APIs after document restart");
+    expect(listManagedImageRecordEntries({ stateDir, sessionKey })).toHaveLength(2);
+    const artifactList = await client.request<ArtifactList>("artifacts.list", {
+      taskId: task.taskId,
+    });
+    expect(artifactList.artifacts).toHaveLength(2);
+    for (const fixture of documentFixtures) {
+      const artifact = artifactList.artifacts.find((entry) => entry.title === fixture.name);
+      expect(artifact).toMatchObject({
         sessionKey,
-        artifactId: artifact.id,
-      },
-    );
-    expect(download.url).toContain("mediaTicket=");
-    expect(download.expiresAt).toBeTruthy();
-    const response = await fetch(`http://127.0.0.1:${port}${download.url}`);
-    expect(response.status).toBe(200);
-    expect(Buffer.from(await response.arrayBuffer())).toEqual(
-      Buffer.from(TINY_PNG_BASE64, "base64"),
-    );
+        taskId: task.taskId,
+        type: "file",
+        title: fixture.name,
+        mimeType: fixture.mimeType,
+        download: { mode: "url" },
+      });
+      await expect(
+        client.request("artifacts.get", {
+          taskId: task.taskId,
+          artifactId: artifact?.id,
+        }),
+      ).resolves.toMatchObject({ artifact: { id: artifact?.id, taskId: task.taskId } });
+
+      const download = await client.request<{ url: string; expiresAt: string }>(
+        "artifacts.download",
+        {
+          sessionKey,
+          artifactId: artifact?.id,
+        },
+      );
+      expect(download.url).toContain("mediaTicket=");
+      expect(download.expiresAt).toBeTruthy();
+      const downloadUrl = `http://127.0.0.1:${port}${download.url}`;
+      const response = await fetch(downloadUrl);
+      expect(response.status).toBe(200);
+      expect(Buffer.from(await response.arrayBuffer())).toEqual(fixture.body);
+      const head = await fetch(downloadUrl, { method: "HEAD" });
+      expect(head.status).toBe(200);
+      expect((await head.arrayBuffer()).byteLength).toBe(0);
+      const range = await fetch(downloadUrl, { headers: { Range: "bytes=0-3" } });
+      expect(range.status).toBe(206);
+      expect(Buffer.from(await range.arrayBuffer())).toEqual(fixture.body.subarray(0, 4));
+    }
+
+    const artifact = artifactList.artifacts[0]!;
 
     await expect(
       client.request("artifacts.get", {

--- a/test/e2e/qa-lab/runtime/webchat-media-artifacts.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/webchat-media-artifacts.e2e.test.ts
@@ -1,0 +1,248 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import JSZip from "jszip";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createQaBusState,
+  createQaChannelTransport,
+  startQaBusServer,
+} from "../../../../extensions/qa-lab/api.js";
+import { startQaLiveLaneGateway } from "../../../../extensions/qa-lab/runtime-api.js";
+import { GatewayClient } from "../../../../src/gateway/client.js";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../../../src/utils/message-channel.js";
+import { createSolidPngBuffer, createTinyJpegBuffer } from "../../../helpers/image-fixtures.js";
+
+const SESSION_KEY = "agent:qa:main";
+const FIXTURES = [
+  ["artifact.json", "application/json", "attachment", "artifact"],
+  ["table.csv", "text/csv", "attachment", "artifact"],
+  ["config.xml", "text/xml", "attachment", "visible-error"],
+  ["deploy.yaml", "application/yaml", "attachment", "artifact"],
+  ["notes.md", "text/markdown", "attachment", "artifact"],
+  ["readme.txt", "text/plain", "attachment", "artifact"],
+  ["page.html", "text/html", "attachment", "artifact"],
+  ["vector.svg", "image/svg+xml", "attachment", "visible-error"],
+  ["report.pdf", "application/pdf", "attachment", "artifact"],
+  ["bundle.zip", "application/zip", "attachment", "artifact"],
+  ["worker.py", "text/x-python", "attachment", "visible-error"],
+  ["script.js", "text/javascript", "attachment", "visible-error"],
+  [
+    "brief.docx",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "attachment",
+    "artifact",
+  ],
+  [
+    "report.xlsx",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "attachment",
+    "artifact",
+  ],
+  ["tone.wav", "audio/wav", "audio", "artifact"],
+  ["voice.mp3", "audio/mpeg", "audio", "artifact"],
+  ["clip.mp4", "video/mp4", "video", "artifact"],
+  ["image.png", "image/png", "image", "artifact"],
+  ["photo.jpg", "image/jpeg", "image", "artifact"],
+  ["mystery.blob", "application/octet-stream", "attachment", "visible-error"],
+] as const;
+const MEDIA_FAILURE_WARNING =
+  "Media failed. Try sending a smaller supported file or a different format.";
+
+let harness: Awaited<ReturnType<typeof startQaLiveLaneGateway>> | undefined;
+let bus: Awaited<ReturnType<typeof startQaBusServer>> | undefined;
+let client: GatewayClient | undefined;
+
+afterEach(async () => {
+  client?.stop();
+  client = undefined;
+  await harness?.stop().catch(() => undefined);
+  harness = undefined;
+  await bus?.stop().catch(() => undefined);
+  bus = undefined;
+});
+
+async function writeFixtures(workspaceDir: string): Promise<void> {
+  const textFiles: Record<string, string> = {
+    "artifact.json": '{"status":"ready"}\n',
+    "table.csv": "name,status\nrabbit,ready\n",
+    "config.xml": '<?xml version="1.0"?><artifact ready="true"/>\n',
+    "deploy.yaml": "name: media-artifacts\nready: true\n",
+    "notes.md": "# Artifact proof\n\nManaged Markdown document.\n",
+    "readme.txt": "Managed plain text document.\n",
+    "page.html": "<!doctype html><title>Artifact proof</title><h1>Ready</h1>\n",
+    "vector.svg":
+      '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect width="320" height="180" fill="#2563eb"/></svg>',
+    "report.pdf": "%PDF-1.4\n% OpenClaw artifact proof\n",
+    "worker.py": "def ready():\n    return True\n",
+    "script.js": "export const ready = true;\n",
+  };
+  await Promise.all(
+    Object.entries(textFiles).map(([name, body]) =>
+      fs.writeFile(path.join(workspaceDir, name), body),
+    ),
+  );
+  const archive = new JSZip();
+  archive.file("README.txt", "OpenClaw artifact proof\n");
+  await fs.writeFile(
+    path.join(workspaceDir, "bundle.zip"),
+    await archive.generateAsync({ type: "nodebuffer" }),
+  );
+  await fs.writeFile(path.join(workspaceDir, "brief.docx"), await officeZip("docx"));
+  await fs.writeFile(path.join(workspaceDir, "report.xlsx"), await officeZip("xlsx"));
+  await fs.writeFile(path.join(workspaceDir, "tone.wav"), createWavBuffer());
+  await fs.writeFile(path.join(workspaceDir, "voice.mp3"), Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+  await fs.writeFile(
+    path.join(workspaceDir, "image.png"),
+    createSolidPngBuffer(320, 180, { r: 37, g: 99, b: 235 }),
+  );
+  await fs.writeFile(path.join(workspaceDir, "photo.jpg"), createTinyJpegBuffer());
+  await fs.writeFile(path.join(workspaceDir, "mystery.blob"), Buffer.from([0, 1, 2, 3]));
+  await fs.writeFile(path.join(workspaceDir, "clip.mp4"), createMp4Buffer());
+}
+
+async function officeZip(kind: "docx" | "xlsx"): Promise<Buffer> {
+  const zip = new JSZip();
+  const root = kind === "docx" ? "word/document.xml" : "xl/workbook.xml";
+  const mime =
+    kind === "docx"
+      ? "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"
+      : "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml";
+  zip.file(
+    "[Content_Types].xml",
+    `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/${root}" ContentType="${mime}"/></Types>`,
+  );
+  zip.file(root, "<document/>");
+  return await zip.generateAsync({ type: "nodebuffer" });
+}
+
+function createWavBuffer(): Buffer {
+  const samples = 8_000;
+  const body = Buffer.alloc(44 + samples * 2);
+  body.write("RIFF", 0, "ascii");
+  body.writeUInt32LE(body.length - 8, 4);
+  body.write("WAVEfmt ", 8, "ascii");
+  body.writeUInt32LE(16, 16);
+  body.writeUInt16LE(1, 20);
+  body.writeUInt16LE(1, 22);
+  body.writeUInt32LE(8_000, 24);
+  body.writeUInt32LE(16_000, 28);
+  body.writeUInt16LE(2, 32);
+  body.writeUInt16LE(16, 34);
+  body.write("data", 36, "ascii");
+  body.writeUInt32LE(samples * 2, 40);
+  return body;
+}
+
+function createMp4Buffer(): Buffer {
+  return Buffer.from([
+    0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
+    0x69, 0x73, 0x6f, 0x6d, 0x6d, 0x70, 0x34, 0x31,
+  ]);
+}
+
+function isExpectedMediaBlock(block: unknown, expected: (typeof FIXTURES)[number]): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const [name, mimeType, type] = expected;
+  const candidate = block as Record<string, unknown>;
+  if (type === "attachment") {
+    const attachment = candidate.attachment;
+    return (
+      candidate.type === "attachment" &&
+      Boolean(attachment) &&
+      typeof attachment === "object" &&
+      (attachment as Record<string, unknown>).label === name &&
+      (attachment as Record<string, unknown>).mimeType === mimeType
+    );
+  }
+  const label = type === "image" ? candidate.alt : candidate.fileName;
+  return candidate.type === type && candidate.mimeType === mimeType && label === name;
+}
+
+async function connectWebchat(url: string, token: string): Promise<GatewayClient> {
+  return await new Promise<GatewayClient>((resolve, reject) => {
+    const connecting = new GatewayClient({
+      url,
+      origin: new URL(url.replace(/^ws/u, "http")).origin,
+      token,
+      clientName: GATEWAY_CLIENT_NAMES.WEBCHAT_UI,
+      mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+      role: "operator",
+      scopes: ["operator.read", "operator.write", "operator.admin"],
+      platform: "qa",
+      onHelloOk: () => resolve(connecting),
+      onConnectError: reject,
+      onClose: (code, reason) => reject(new Error(`Gateway closed ${code}: ${reason}`)),
+    });
+    connecting.start();
+  });
+}
+
+describe("WebChat managed media artifact matrix", () => {
+  it(
+    "renders every supported MEDIA reference or a visible failure",
+    { timeout: 180_000 },
+    async () => {
+      const state = createQaBusState();
+      const transport = createQaChannelTransport(state);
+      bus = await startQaBusServer({ state });
+      harness = await startQaLiveLaneGateway({
+        repoRoot: process.cwd(),
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        alternateModel: "mock-openai/gpt-5.6-luna-alt",
+        transport,
+        transportBaseUrl: bus.baseUrl,
+        controlUiAllowedOrigins: ["http://127.0.0.1"],
+        controlUiEnabled: false,
+      });
+      await transport.waitReady({ gateway: harness.gateway });
+      await writeFixtures(harness.gateway.workspaceDir);
+      client = await connectWebchat(harness.gateway.wsUrl, harness.gateway.token);
+      const runId = randomUUID();
+      const exactReply = `Artifacts ready\n${FIXTURES.map(([name]) => `MEDIA:./${name}`).join("\n")}`;
+      const started = await client.request<{ runId?: string }>("chat.send", {
+        sessionKey: SESSION_KEY,
+        message: `Reply exactly \`${exactReply}\``,
+        deliver: false,
+        idempotencyKey: runId,
+      });
+      await client.request(
+        "agent.wait",
+        { runId: started.runId ?? runId, timeoutMs: 120_000 },
+        { timeoutMs: 125_000 },
+      );
+      const history = await client.request<{
+        messages?: Array<{ role?: string; content?: unknown }>;
+      }>("chat.history", { sessionKey: SESSION_KEY, limit: 20 });
+      const assistant = history.messages?.findLast((message) => message.role === "assistant");
+      const content = Array.isArray(assistant?.content) ? assistant.content : [];
+      const serialized = JSON.stringify(content);
+      const hasVisibleFailure = serialized.includes(MEDIA_FAILURE_WARNING);
+      const observed = FIXTURES.map((fixture) => ({
+        name: fixture[0],
+        mimeType: fixture[1],
+        type: fixture[2],
+        outcome: fixture[3],
+        present:
+          fixture[3] === "artifact"
+            ? content.some((block) => isExpectedMediaBlock(block, fixture))
+            : hasVisibleFailure,
+      }));
+      const verdict = {
+        expected: FIXTURES.length,
+        observed: observed.filter((entry) => entry.present).length,
+        missing: observed.filter((entry) => !entry.present).map((entry) => entry.name),
+        rawMediaVisible: serialized.includes("MEDIA:./"),
+      };
+
+      expect(verdict).toEqual({ expected: 20, observed: 20, missing: [], rawMediaVisible: false });
+      console.log(`WEBCHAT_MEDIA_ARTIFACTS_PROOF=${JSON.stringify(verdict)}`);
+    },
+  );
+});

--- a/test/e2e/qa-lab/runtime/webchat-media-artifacts.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/webchat-media-artifacts.e2e.test.ts
@@ -51,6 +51,8 @@ const FIXTURES = [
 ] as const;
 const MEDIA_FAILURE_WARNING =
   "Media failed. Try sending a smaller supported file or a different format.";
+const ARTIFACT_FIXTURES = FIXTURES.filter((fixture) => fixture[3] === "artifact");
+const REJECTED_FIXTURES = FIXTURES.filter((fixture) => fixture[3] === "visible-error");
 
 let harness: Awaited<ReturnType<typeof startQaLiveLaneGateway>> | undefined;
 let bus: Awaited<ReturnType<typeof startQaBusServer>> | undefined;
@@ -183,6 +185,31 @@ async function connectWebchat(url: string, token: string): Promise<GatewayClient
   });
 }
 
+async function sendMediaReply(
+  gatewayClient: GatewayClient,
+  sessionKey: string,
+  fixtureNames: readonly string[],
+): Promise<unknown[]> {
+  const runId = randomUUID();
+  const exactReply = `Artifacts ready\n${fixtureNames.map((name) => `MEDIA:./${name}`).join("\n")}`;
+  const started = await gatewayClient.request<{ runId?: string }>("chat.send", {
+    sessionKey,
+    message: `Reply exactly \`${exactReply}\``,
+    deliver: false,
+    idempotencyKey: runId,
+  });
+  await gatewayClient.request(
+    "agent.wait",
+    { runId: started.runId ?? runId, timeoutMs: 120_000 },
+    { timeoutMs: 125_000 },
+  );
+  const history = await gatewayClient.request<{
+    messages?: Array<{ role?: string; content?: unknown }>;
+  }>("chat.history", { sessionKey, limit: 20 });
+  const assistant = history.messages?.findLast((message) => message.role === "assistant");
+  return Array.isArray(assistant?.content) ? assistant.content : [];
+}
+
 describe("WebChat managed media artifact matrix", () => {
   it(
     "renders every supported MEDIA reference or a visible failure",
@@ -204,41 +231,50 @@ describe("WebChat managed media artifact matrix", () => {
       await transport.waitReady({ gateway: harness.gateway });
       await writeFixtures(harness.gateway.workspaceDir);
       client = await connectWebchat(harness.gateway.wsUrl, harness.gateway.token);
-      const runId = randomUUID();
-      const exactReply = `Artifacts ready\n${FIXTURES.map(([name]) => `MEDIA:./${name}`).join("\n")}`;
-      const started = await client.request<{ runId?: string }>("chat.send", {
-        sessionKey: SESSION_KEY,
-        message: `Reply exactly \`${exactReply}\``,
-        deliver: false,
-        idempotencyKey: runId,
-      });
-      await client.request(
-        "agent.wait",
-        { runId: started.runId ?? runId, timeoutMs: 120_000 },
-        { timeoutMs: 125_000 },
+      const content = await sendMediaReply(
+        client,
+        SESSION_KEY,
+        ARTIFACT_FIXTURES.map((fixture) => fixture[0]),
       );
-      const history = await client.request<{
-        messages?: Array<{ role?: string; content?: unknown }>;
-      }>("chat.history", { sessionKey: SESSION_KEY, limit: 20 });
-      const assistant = history.messages?.findLast((message) => message.role === "assistant");
-      const content = Array.isArray(assistant?.content) ? assistant.content : [];
-      const serialized = JSON.stringify(content);
-      const hasVisibleFailure = serialized.includes(MEDIA_FAILURE_WARNING);
-      const observed = FIXTURES.map((fixture) => ({
+      const accepted = ARTIFACT_FIXTURES.map((fixture) => ({
         name: fixture[0],
         mimeType: fixture[1],
         type: fixture[2],
         outcome: fixture[3],
-        present:
-          fixture[3] === "artifact"
-            ? content.some((block) => isExpectedMediaBlock(block, fixture))
-            : hasVisibleFailure,
+        present: content.some((block) => isExpectedMediaBlock(block, fixture)),
       }));
+      const rejected: Array<{
+        name: string;
+        mimeType: string;
+        type: string;
+        outcome: string;
+        present: boolean;
+      }> = [];
+      for (const fixture of REJECTED_FIXTURES) {
+        const sessionKey = `agent:qa:rejected-${fixture[0].replace(/[^a-z0-9]+/giu, "-")}`;
+        const rejectedContent = await sendMediaReply(client, sessionKey, [fixture[0]]);
+        const serialized = JSON.stringify(rejectedContent);
+        expect(serialized, fixture[0]).toContain(MEDIA_FAILURE_WARNING);
+        expect(rejectedContent.some((block) => isExpectedMediaBlock(block, fixture))).toBe(false);
+        expect(serialized).not.toContain("MEDIA:./");
+        const artifactList = await client.request<{ artifacts?: unknown[] }>("artifacts.list", {
+          sessionKey,
+        });
+        expect(artifactList.artifacts ?? [], fixture[0]).toEqual([]);
+        rejected.push({
+          name: fixture[0],
+          mimeType: fixture[1],
+          type: fixture[2],
+          outcome: fixture[3],
+          present: true,
+        });
+      }
+      const observed = [...accepted, ...rejected];
       const verdict = {
         expected: FIXTURES.length,
         observed: observed.filter((entry) => entry.present).length,
         missing: observed.filter((entry) => !entry.present).map((entry) => entry.name),
-        rawMediaVisible: serialized.includes("MEDIA:./"),
+        rawMediaVisible: JSON.stringify(content).includes("MEDIA:./"),
       };
 
       expect(verdict).toEqual({ expected: 20, observed: 20, missing: [], rawMediaVisible: false });

--- a/test/e2e/qa-lab/runtime/webchat-media-artifacts.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/webchat-media-artifacts.e2e.test.ts
@@ -189,9 +189,11 @@ async function sendMediaReply(
   gatewayClient: GatewayClient,
   sessionKey: string,
   fixtureNames: readonly string[],
+  includeText = true,
 ): Promise<unknown[]> {
   const runId = randomUUID();
-  const exactReply = `Artifacts ready\n${fixtureNames.map((name) => `MEDIA:./${name}`).join("\n")}`;
+  const mediaDirectives = fixtureNames.map((name) => `MEDIA:./${name}`).join("\n");
+  const exactReply = includeText ? `Artifacts ready\n${mediaDirectives}` : mediaDirectives;
   const started = await gatewayClient.request<{ runId?: string }>("chat.send", {
     sessionKey,
     message: `Reply exactly \`${exactReply}\``,
@@ -252,7 +254,7 @@ describe("WebChat managed media artifact matrix", () => {
       }> = [];
       for (const fixture of REJECTED_FIXTURES) {
         const sessionKey = `agent:qa:rejected-${fixture[0].replace(/[^a-z0-9]+/giu, "-")}`;
-        const rejectedContent = await sendMediaReply(client, sessionKey, [fixture[0]]);
+        const rejectedContent = await sendMediaReply(client, sessionKey, [fixture[0]], false);
         const serialized = JSON.stringify(rejectedContent);
         expect(serialized, fixture[0]).toContain(MEDIA_FAILURE_WARNING);
         expect(rejectedContent.some((block) => isExpectedMediaBlock(block, fixture))).toBe(false);


### PR DESCRIPTION
Closes #130338

## What Problem This Solves

WebChat could strip generated local-document `MEDIA:` directives without creating downloadable attachment cards. Current-source message-tool replies also lost filename, MIME, and per-item trust metadata before managed-media persistence.

## Why This Change Was Made

The existing managed outgoing media owner now receives one atomic prepared-media item per source and emits document attachment envelopes through the existing SQLite record, authenticated download, cleanup, and artifact lifecycle. Current-source, embedded-run, restart-recovery, and normal WebChat projection all preserve the same filename, MIME, trust, and playback metadata.

Unsupported active or opaque formats keep the existing security boundary and now produce bounded visible failure guidance rather than disappearing. No schema, retention, or protocol version changed.

**Product decision:** legacy managed SVG records remain unavailable with HTTP `404`; this intentionally keeps the active-content download boundary closed rather than reviving previously stored SVG capabilities.

## User Impact

Generated JSON, CSV, YAML, Markdown, plain text, trusted generated HTML, PDF, ZIP, DOCX, and XLSX files appear as named attachment cards. WAV, MP3, and MP4 use managed playback cards; PNG and JPEG keep image previews and their source labels. XML, SVG, Python, JavaScript, and unknown binary files remain rejected by host-read policy, with a visible retry message and no raw `MEDIA:` leakage.

## Evidence

### Before

WebChat history rendered document directives as raw text:

![Before: raw MEDIA directives in WebChat](https://github.com/user-attachments/assets/1ccde2c5-a073-4895-96a5-ace518f81b6a)

### Current 20-format proof

The deterministic flow uses one mock-provider response, an ephemeral Gateway, a real WebChat client, workspace files, and `chat.history`. It validates 20 outcomes: 15 structured artifacts and five policy rejections represented by visible failure guidance.

```json
{"expected":20,"observed":20,"missing":[],"rawMediaVisible":false}
```

JSON, CSV, YAML, Markdown, text, and trusted generated HTML:

![Text and markup MIME cards](https://github.com/user-attachments/assets/b2774f5f-c060-4948-b96e-e60fd58a9027)

PDF, ZIP, DOCX, and XLSX:

![Office and archive MIME cards](https://github.com/user-attachments/assets/079d55ea-f04d-4449-8183-058fce8360e5)

WAV, MP3, and MP4:

![Audio and video MIME cards](https://github.com/user-attachments/assets/d9143ab7-c47c-40d8-9c6d-e988955df1ee)

PNG and JPEG previews with original source labels:

![PNG and JPEG previews](https://github.com/user-attachments/assets/00b34602-a4eb-4fc1-9868-8d5d7f429ed4)

XML, SVG, Python, JavaScript, and unknown binary remain blocked and end visibly:

![Rejected formats with visible warning](https://github.com/user-attachments/assets/4566b50c-183a-4cbb-8e5e-09b05bc3f7b7)

All five current screenshots are dark-mode Control UI captures generated from the fresh Gateway transcript and inspected after capture.

### Validation

- Rebasing preserved main's Codex logout recovery and proactive-compaction changes alongside attachment metadata/trust propagation.
- Sanitizer regression failed before the fix with `thinkingSignature` removed while `attachment.path` and `mediaTicket` leaked; it passes after unconditional media and attachment projection.
- `node scripts/check-changed.mjs` passed in clean Testbox execution before the chained E2E build.
- Focused local suites: 648 tests passed across payload/logout recovery, media/reply/history, managed HTTP/artifacts, current-source, and restart surfaces.
- Mixed reply smoke passed with ordered JSON, remote PNG, local PNG, one rejected SVG, preserved names/MIME, and exactly one warning.
- Testbox `tbx_01m12d9x50qs75x6fkms6q8jn5`: 20-format media-only rejection matrix and JSON/PDF reload/restart lifecycle with `artifacts.list` type `file` plus GET/HEAD/Range, https://github.com/openclaw/openclaw/actions/runs/33111717894
- Exact-head CI for `310e73ca179e3a4fcd897815e0662073edbfa657`: green, https://github.com/openclaw/openclaw/actions/runs/33157434453
- Exact-head autoreview: no accepted/actionable P0/P1 findings

Production LOC: +547/-245 (net +302). Tests: +1081/-68 (net +1013). Production growth consolidates atomic media metadata, managed document projection, source-reply persistence/recovery, sanitizer capability stripping, and visible failure preservation into existing owner paths; no parallel store or fallback was added.

AI-assisted: yes. I reviewed the complete diff and validation evidence.
