### PR TITLE
fix(cli): honor container selection in root help

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -725,7 +725,7 @@ const tryOutputBareRootHelp = async () => {
   if (!isBareRootHelpInvocation(process.argv)) {
     return false;
   }
-  if (shouldDeferRootHelpToRuntimeEntry()) {
+  if (hasLauncherContainerTarget(process.argv) || shouldDeferRootHelpToRuntimeEntry()) {
     return false;
   }
   const precomputed = loadPrecomputedHelpText("rootHelpText");

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -496,6 +496,16 @@ describe("openclaw launcher", () => {
 
   it.each([
     {
+      name: "container env with root --help",
+      args: ["--help"],
+      env: { OPENCLAW_CONTAINER: "demo" },
+    },
+    {
+      name: "container env with root -h",
+      args: ["-h"],
+      env: { OPENCLAW_CONTAINER: "demo" },
+    },
+    {
       name: "container env",
       args: ["browser", "--help"],
       env: { OPENCLAW_CONTAINER: "demo" },
@@ -514,7 +524,10 @@ describe("openclaw launcher", () => {
     const fixtureRoot = await makeLauncherFixture(fixtureRoots);
     await fs.writeFile(
       path.join(fixtureRoot, "dist", "cli-startup-metadata.json"),
-      JSON.stringify({ browserHelpText: "PRECOMPUTED browser help\n" }),
+      JSON.stringify({
+        rootHelpText: "PRECOMPUTED root help\n",
+        browserHelpText: "PRECOMPUTED browser help\n",
+      }),
       "utf8",
     );
     await fs.writeFile(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch; repository maintainers can edit it directly.

</details>

## What Problem This Solves

Fixes an issue where users selecting a container through `OPENCLAW_CONTAINER` would get the host's root help from `openclaw --help` or `openclaw -h`, instead of running the command against their selected container. With a nonexistent target, those commands misleadingly exited successfully while `openclaw models --help` and explicit `--container` correctly reported the missing target.

## Why This Change Was Made

The bare-root launcher fast path checked whether plugin configuration could affect help, but omitted the existing container-target check used by command help. Reuse that check before either cached or dynamic host help. The runtime remains the sole container-dispatch owner; no duplicate parser, new option, dependency, or fallback is added. Ordinary host help keeps its fast path.

This restores the documented container selector contract without changing container execution, authentication, configuration, persistence, or protocol behavior. Production LOC: +1/-1 (net 0). Tests: +14/-1 (net +13), extending the existing child-process table.

## User Impact

Root help honors the selected container consistently with command help and version requests. Missing containers produce the existing actionable error rather than silently showing unrelated host help.

## Evidence

- Baseline: `70c87cc98d7a96577282a65db8eb7f96a9976c61`.
- Reviewed candidate: `39935e43f34175ff94bd09e9a982dc8c0b179b2a`.
- Before the production change, the two added real-launcher regression cases failed: expected `RUNTIME ENTRY`, received `PRECOMPUTED root help`; the three existing container-routing cases passed.
- Afterward, all 23 launcher help-path tests passed, including both new cases and ordinary host, plugin-sensitive, and subcommand help.
- Actual CLI before/after with isolated config/state and a deliberately nonexistent container: bare `--help` and `-h` changed from exit 0 / host usage to exit 1 / the existing missing-container error; command help and explicit `--container` retained the correct error. No running container or operator Gateway was changed. Initial before/after used retained CI runtime with relevant runtime-entry/container-dispatch sources verified unchanged.
- Fresh candidate CI artifact confirmation also passed all four real CLI forms using `dist-runtime-build` artifact `9623425326` from [CI run 33012913633](https://github.com/openclaw/openclaw/actions/runs/33012913633). Build metadata identifies merge-ref `48e3e7e2e979e6c6ed565dd76ee1ab2e4bf20000`, whose live-verified parents include reviewed head `39935e43f34175ff94bd09e9a982dc8c0b179b2a`; the merge-ref launcher blob is identical to the candidate launcher. All commands exit 1 with the existing missing-container diagnostic and no host help. Dependencies still resolve through the primary checkout: this is actual candidate CI-built runtime proof, not a fresh npm/package installation.
- Full local launcher run: 41 passed, 1 conditional Bun skip, 1 unrelated sparse-checkout dependency failure (`string-width` in the compiled-entry child). Focused proof uses the canonical E2E configuration and its supported fixture-only `OPENCLAW_E2E_SKIP_BUILD=1` mode, with dependency resolution through the primary checkout.
- Syntax, targeted formatting/lint, diff whitespace, maximum-lines and assertion-safety ratchets passed. The changed gate passed its first eight checks, then stopped because the sparse checkout has no local `oxfmt` binary; the direct targeted formatter passed. Pinned hosted CI is required before landing.
- Fresh Codex autoreview and independent owner/sibling review: no actionable findings; canonical launcher-boundary fix confirmed.

Provenance: the bare-root fast path dates to `805bff6e7e1f` (2026-03-24, code author Vincent Koc). The omission was carried forward in #83841 (`eb6dd2c65d1147225dcf2d42f4e80fd9580c5747`, code/PR author and merger @joshavant, merged 2026-05-19T01:35:56Z); this is carry-forward evidence, not a claim that the memory-help repair introduced container selection. The container omission also exists in stable `v2026.7.1`; no new container capability is introduced here.

AI-assisted implementation and verification, with maintainer-owned review and landing.
