### PR TITLE
fix(code-mode): treat tool input rejections as no-start failures

### DIFF
--- a/src/agents/code-mode-bridge.ts
+++ b/src/agents/code-mode-bridge.ts
@@ -29,6 +29,7 @@ import { resolveSwarmConfig } from "./subagents/swarm/swarm-config.js";
 import { isToolExecutionAllowed, TOOL_EXECUTION_GATED_MESSAGE } from "./tool-policy-shared.js";
 import {
   consumeTrustedToolNoStartError,
+  isTrustedToolExecutionPreflightError,
   registerTrustedToolNoStartError,
 } from "./tool-result-error.js";
 import { ToolSearchRuntime, type ToolSearchToolContext } from "./tool-search.js";
@@ -595,7 +596,9 @@ export async function runBridgeRequest(params: {
       ok: false,
       error: redactCodeModeCatalogIds(formatErrorMessage(error), catalogProjection.bindings),
     };
-    if (consumeTrustedToolNoStartError(error)) {
+    // A host-minted input rejection (ToolInputError) means the tool never acted; without this
+    // every mistyped argument reads as a possible partial mutation and ends the run.
+    if (consumeTrustedToolNoStartError(error) || isTrustedToolExecutionPreflightError(error)) {
       registerTrustedToolNoStartError(settled);
     }
     return settled;

--- a/src/agents/code-mode.agent-loop.test.ts
+++ b/src/agents/code-mode.agent-loop.test.ts
@@ -140,6 +140,41 @@ describe("Code Mode agent-loop error recovery", () => {
     });
   });
 
+  it("returns a tool's own input rejection to the model without reconciliation", async () => {
+    const history = pluginToolWithExecute("sessions_history", "Read history", async () => {
+      throw new ToolInputError("sessionId requires messageId");
+    });
+    const recover = pluginToolWithExecute("recover_task", "Recover the task", async () =>
+      jsonResult({ recovered: true }),
+    );
+
+    const { agent, providerContexts, reconciliationCandidates } = await runCodeModeAgent({
+      hiddenTools: [history, recover],
+      programs: ["return await sessions_history({});", "return await recover_task({});"],
+    });
+
+    expect(providerContexts).toHaveLength(3);
+    expect(providerContexts[1]?.messages).toContainEqual(
+      expect.objectContaining({
+        role: "toolResult",
+        toolName: "exec",
+        isError: true,
+        details: expect.objectContaining({
+          status: "failed",
+          bridgeDispatchStarted: true,
+          error: expect.stringContaining("sessionId requires messageId"),
+        }),
+      }),
+    );
+    expect(history.execute).toHaveBeenCalledOnce();
+    expect(recover.execute).toHaveBeenCalledOnce();
+    expect(reconciliationCandidates).toBe(0);
+    expect(agent.state.messages.at(-1)).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "recovered" }],
+    });
+  });
+
   it("lets the model correct successive JavaScript syntax and runtime errors", async () => {
     const complete = pluginToolWithExecute("complete_task", "Complete the task", async () =>
       jsonResult({ completed: true }),


### PR DESCRIPTION
## What Problem This Solves

In Code Mode, a nested tool that rejects its arguments (`ToolInputError`, e.g. `sessions_history` → "sessionId requires messageId", `terminal` → "terminal action unavailable", `session_status` → catalog owner replaced) is classified as a possible partial mutation: the bridge dispatch had started, every nested call except `nodes list/get` counts as potentially mutating, and the failure ends the run and forces the read-only reconciliation phase from #128071 ("The previous Code Mode mutation may have partially applied…"). The model then produces an "applied / not applied / unknown" report and the turn is over.

Observed five times on one operator gateway on 2026-08-26 across two Telegram sessions; every trigger was an argument error on a read-only tool, zero mutations. Each one stopped an authorized multi-step task.

## Why This Change Was Made

`ToolInputError` is the host-minted "input rejected before acting" signal (`src/agents/tools/common.ts:89`, status 400, registered as a trusted input error). The before-tool-call wrapper already treats it as a no-start at the `tool_preparation` stage; the bridge only honoured that path. `code-mode-bridge.ts` now also registers a trusted no-start when the settled error is a trusted input error, so `potentiallyMutatingDispatches` is released exactly as for preflight rejections and ordinary recovery continues. Mutating failures that are not input rejections keep the reconciliation path.

Follow-up worth considering: a read-only annotation on tool definitions so read-only tools never count as mutating dispatches regardless of error type.

## User Impact

A mistyped argument inside Code Mode returns the error to the model and the run continues, instead of terminating the run and locking the agent into a read-only report.

## Evidence

- New test `returns a tool's own input rejection to the model without reconciliation` in `src/agents/code-mode.agent-loop.test.ts`: a nested tool throwing `ToolInputError` from `execute` must yield `reconciliationCandidates === 0` and let the next program run. Fails on `main` (reconciliation candidate raised, recovery tool never called), passes with the fix; `node scripts/run-vitest.mjs src/agents/code-mode.agent-loop.test.ts`: 6 passed.
- Production LOC: +4 / -1.
