### PR TITLE
refactor(google): share video capability metadata

### DIFF
--- a/extensions/google/generation-provider-metadata.ts
+++ b/extensions/google/generation-provider-metadata.ts
@@ -2,6 +2,7 @@
 import type { MusicGenerationProvider } from "openclaw/plugin-sdk/music-generation";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import type {
+  VideoGenerationModeCapabilities,
   VideoGenerationProvider,
   VideoGenerationProviderConfiguredContext,
 } from "openclaw/plugin-sdk/video-generation";
@@ -17,6 +18,19 @@ export const GOOGLE_VIDEO_MAX_DURATION_SECONDS = GOOGLE_VIDEO_ALLOWED_DURATION_S
 
 function isGoogleProviderConfigured(ctx: VideoGenerationProviderConfiguredContext): boolean {
   return isProviderApiKeyConfigured({ provider: "google", ...ctx });
+}
+
+function createGoogleVideoCommonCapabilities() {
+  return {
+    maxDurationSeconds: GOOGLE_VIDEO_MAX_DURATION_SECONDS,
+    supportedDurationSeconds: [...GOOGLE_VIDEO_ALLOWED_DURATION_SECONDS],
+    aspectRatios: ["16:9", "9:16"],
+    resolutions: ["720P", "1080P"],
+    supportsAspectRatio: true,
+    supportsResolution: true,
+    supportsSize: true,
+    supportsAudio: false,
+  } satisfies VideoGenerationModeCapabilities;
 }
 
 export function createGoogleMusicGenerationProviderMetadata(): Omit<
@@ -73,40 +87,19 @@ export function createGoogleVideoGenerationProviderMetadata(): Omit<
     capabilities: {
       generate: {
         maxVideos: 1,
-        maxDurationSeconds: GOOGLE_VIDEO_MAX_DURATION_SECONDS,
-        supportedDurationSeconds: [...GOOGLE_VIDEO_ALLOWED_DURATION_SECONDS],
-        aspectRatios: ["16:9", "9:16"],
-        resolutions: ["720P", "1080P"],
-        supportsAspectRatio: true,
-        supportsResolution: true,
-        supportsSize: true,
-        supportsAudio: false,
+        ...createGoogleVideoCommonCapabilities(),
       },
       imageToVideo: {
         enabled: true,
         maxVideos: 1,
         maxInputImages: 1,
-        maxDurationSeconds: GOOGLE_VIDEO_MAX_DURATION_SECONDS,
-        supportedDurationSeconds: [...GOOGLE_VIDEO_ALLOWED_DURATION_SECONDS],
-        aspectRatios: ["16:9", "9:16"],
-        resolutions: ["720P", "1080P"],
-        supportsAspectRatio: true,
-        supportsResolution: true,
-        supportsSize: true,
-        supportsAudio: false,
+        ...createGoogleVideoCommonCapabilities(),
       },
       videoToVideo: {
         enabled: true,
         maxVideos: 1,
         maxInputVideos: 1,
-        maxDurationSeconds: GOOGLE_VIDEO_MAX_DURATION_SECONDS,
-        supportedDurationSeconds: [...GOOGLE_VIDEO_ALLOWED_DURATION_SECONDS],
-        aspectRatios: ["16:9", "9:16"],
-        resolutions: ["720P", "1080P"],
-        supportsAspectRatio: true,
-        supportsResolution: true,
-        supportsSize: true,
-        supportsAudio: false,
+        ...createGoogleVideoCommonCapabilities(),
       },
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Google video generation metadata repeated the same eight capability fields across generate, image-to-video, and video-to-video modes. That made future capability changes easier to apply inconsistently.

## Why This Change Was Made

Use one private capability factory while keeping mode-specific limits inline. The factory is called separately for each mode, preserving fresh arrays, exact field ordering, and all existing values.

## User Impact

No user-visible behavior changes. Provider metadata is easier to keep consistent.

## Evidence

- 43 focused Google generation metadata tests passed.
- Native PR review reran the focused video/music provider suites successfully.
- Native `node scripts/check-changed.mjs` passed, including extension production/test typecheck, lint, dead exports, plugin boundaries, and import cycles.
- Scoped TypeScript typecheck, formatting, and `git diff --check` passed.
- Exact-head one-shot metadata proof passed at `81c91b819ea77f73f59cc48d97e99d77e81def1c`:

  ```bash
  EXPECTED_SHA=81c91b819ea77f73f59cc48d97e99d77e81def1c node --import tsx --input-type=module -e '
  import { createGoogleVideoGenerationProviderMetadata } from "./extensions/google/generation-provider-metadata.ts";
  const first = createGoogleVideoGenerationProviderMetadata().capabilities;
  const second = createGoogleVideoGenerationProviderMetadata().capabilities;
  if (!first || !second || !first.generate || !first.imageToVideo || !first.videoToVideo || !second.generate || !second.imageToVideo || !second.videoToVideo) throw new Error("missing mode capabilities");
  const modes = ["generate", "imageToVideo", "videoToVideo"];
  const fields = ["supportedDurationSeconds", "aspectRatios", "resolutions"];
  const expectedKeys = {
    generate: ["maxVideos", "maxDurationSeconds", "supportedDurationSeconds", "aspectRatios", "resolutions", "supportsAspectRatio", "supportsResolution", "supportsSize", "supportsAudio"],
    imageToVideo: ["enabled", "maxVideos", "maxInputImages", "maxDurationSeconds", "supportedDurationSeconds", "aspectRatios", "resolutions", "supportsAspectRatio", "supportsResolution", "supportsSize", "supportsAudio"],
    videoToVideo: ["enabled", "maxVideos", "maxInputVideos", "maxDurationSeconds", "supportedDurationSeconds", "aspectRatios", "resolutions", "supportsAspectRatio", "supportsResolution", "supportsSize", "supportsAudio"],
  };
  const keys = Object.fromEntries(modes.map((mode) => [mode, Object.keys(first[mode])]));
  for (const mode of modes) {
    if (JSON.stringify(keys[mode]) !== JSON.stringify(expectedKeys[mode])) throw new Error(`key order mismatch: ${mode}`);
  }
  const references = Object.fromEntries(fields.map((field) => [field, {
    acrossModes: new Set(modes.map((mode) => first[mode][field])).size === modes.length,
    acrossCalls: modes.every((mode) => first[mode][field] !== second[mode][field]),
  }]));
  if (Object.values(references).some((result) => !result.acrossModes || !result.acrossCalls)) throw new Error("shared array reference detected");
  console.log(JSON.stringify({ sha: process.env.EXPECTED_SHA, keys, references, result: "pass" }, null, 2));
  '
  ```

  Result: `pass`; exact `Object.keys` order matched for all three modes, and `supportedDurationSeconds`, `aspectRatios`, and `resolutions` were separate references across modes and across two metadata calls.
- Blacksmith Testbox exact-head proof passed `43/43` with `exitCode: 0` and `runStatus: succeeded`: lease `tbx_01m10ntmdehvddbwpmrwv13hz3`, Actions run https://github.com/openclaw/openclaw/actions/runs/33037904045.
- Fresh branch autoreview reported no accepted/actionable findings (`0.99` confidence).
- Production delta: `+17/-24`, net `-7`.

## ClawSweeper Disposition

- The persistent-data classification is false: this change constructs ephemeral, nonstored provider capability metadata. It does not alter SQLite, files, migrations, schemas, retention, vectors, or embedding data.
- Rebase/refresh and the matching rank-up move are skipped. Against current `main` `8dac217ce94e14a67ad2fc65837e518a2fbe0669`, the metadata owner, Plugin SDK capability type, concrete video caller, and focused video/music tests are byte-identical to the PR parent. The only drift in the lazy entry file is unrelated embedding-provider registration; its video-specific lazy caller is unchanged. The synthetic merge completed cleanly.
