### PR TITLE
fix(cron): preserve script worker timeouts across clock changes

### DIFF
--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -1,3 +1,8 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCodeModeCatalogProjection } from "./code-mode-catalog.js";
 import { createCodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
@@ -73,6 +78,87 @@ afterEach(() => {
 });
 
 describe("Code Mode worker lifecycle", () => {
+  it.each(
+    (["exec", "resume"] as const).flatMap((kind) =>
+      [1, -1].map((clockDirection) => ({ kind, clockDirection })),
+    ),
+  )(
+    "keeps $kind guest timeouts independent of a $clockDirection clock jump",
+    async ({ kind, clockDirection }) => {
+      const config = resolveCodeModeConfig({
+        tools: { codeMode: { enabled: true, timeoutMs: clockDirection > 0 ? 1_000 : 250 } },
+      } as never);
+      const source =
+        clockDirection > 0
+          ? "let total = 0; for (let index = 0; index < 100_000; index++) total += index; return total;"
+          : "while (true) {}";
+      let input: Record<string, unknown> = { kind: "exec", source, config, catalog: [] };
+      if (kind === "resume") {
+        const suspended = await runCodeModeWorker(
+          { ...input, source: `await yield_control("clock jump"); ${source}` },
+          10_000,
+        );
+        expect(suspended.status).toBe("waiting");
+        if (suspended.status !== "waiting") {
+          throw new Error("expected a suspended guest before the clock jump");
+        }
+        input = {
+          kind,
+          config,
+          snapshotBytes: suspended.snapshotBytes,
+          settledRequests: suspended.pendingRequests.map(({ id }) => ({
+            id,
+            ok: true,
+            value: null,
+          })),
+        };
+      }
+
+      const fixtureDir = await mkdtemp(path.join(os.tmpdir(), "code-mode-worker-clock-"));
+      try {
+        await writeFile(path.join(fixtureDir, "package.json"), '{"type":"module"}');
+        const workerPath = path.join(fixtureDir, "clock-worker.ts");
+        const quickJsUrl = pathToFileURL(createRequire(import.meta.url).resolve("quickjs-wasi"));
+        const productionWorkerUrl = new URL("./code-mode.worker.ts", import.meta.url);
+        // Change the clock inside the real worker, after its VM deadline starts.
+        // Parent-only clock spies cannot reach this isolated thread.
+        await writeFile(
+          workerPath,
+          `
+        const { QuickJS } = await import(${JSON.stringify(quickJsUrl.href)});
+        const realNow = Date.now;
+        let shifted = false;
+        for (const method of ["create", "restore"]) {
+          const original = QuickJS[method];
+          QuickJS[method] = function (...args) {
+            const optionsIndex = method === "create" ? 0 : 1;
+            const options = args[optionsIndex];
+            const interrupt = options.interruptHandler;
+            args[optionsIndex] = { ...options, interruptHandler: () => {
+              if (!shifted) {
+                shifted = true;
+                Date.now = () => realNow() + ${clockDirection * 60_000};
+              }
+              return interrupt();
+            } };
+            return original.apply(this, args);
+          };
+        }
+        await import(${JSON.stringify(productionWorkerUrl.href)});
+      `,
+        );
+        const result = await runCodeModeWorker(input, 5_000, pathToFileURL(workerPath));
+        expect(result, JSON.stringify(result)).toMatchObject(
+          clockDirection > 0
+            ? { status: "completed", value: 4_999_950_000 }
+            : { status: "failed", code: "timeout", failurePhase: "guest" },
+        );
+      } finally {
+        await rm(fixtureDir, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("cancels every suspended run, releases capacity, and clears its expiry timer", () => {
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     const firstRunId = `${CAPACITY_RUN_PREFIX}shutdown_first`;

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -152,9 +152,9 @@ async function createVm(params: {
   config: CodeModeConfig;
   pendingRequests: PendingBridgeRequest[];
 }): Promise<VmRun> {
-  const startedAt = Date.now();
+  const startedAt = performance.now();
   let timedOut = false;
-  const deadlineReached = () => Date.now() - startedAt >= params.config.timeoutMs;
+  const deadlineReached = () => performance.now() - startedAt >= params.config.timeoutMs;
   const vm = await QuickJS.create({
     wasm: params.wasmModule,
     memoryLimit: params.config.memoryLimitBytes,
@@ -200,9 +200,9 @@ async function restoreVm(params: {
   config: CodeModeConfig;
   pendingRequests: PendingBridgeRequest[];
 }): Promise<VmRun> {
-  const startedAt = Date.now();
+  const startedAt = performance.now();
   let timedOut = false;
-  const deadlineReached = () => Date.now() - startedAt >= params.config.timeoutMs;
+  const deadlineReached = () => performance.now() - startedAt >= params.config.timeoutMs;
   const snapshot = QuickJS.deserializeSnapshot(params.snapshotBytes);
   const vm = await QuickJS.restore(snapshot, {
     wasm: params.wasmModule,


### PR DESCRIPTION
Related: #130238

## What Problem This Solves

Fixes an issue where users running automation conditions or script payloads would still see premature script timeouts when the system clock moved forward during guest execution. A backward correction also prevented the guest from enforcing its execution limit until the parent watchdog stopped it. Both fresh execution and resumed scripts were affected.

## Why This Change Was Made

#130238 repaired cron preparation and headless execution budgets, but the isolated QuickJS worker still measured its own elapsed time with the system clock. Fresh and restored VMs now use `performance.now()` for those existing checks. This completes that private worker boundary without adding another timer or moving timestamps across workers or snapshots.

Native watchdogs, abort handling, guest-visible `Date`, snapshot expiration, authority, and interactive approval timing remain unchanged. Increasing watchdog timeouts would not repair premature interruption. The separate interactive exec/wait approval-clock owner remains follow-up work; this PR does not claim to resolve every Code Mode clock-sensitive path.

## User Impact

Scheduled scripts keep their bounded execution time through forward and backward clock corrections, including after a tool call resumes the VM. The shared worker correction also applies when other Code Mode callers execute or restore a guest.

## Evidence

Head: `459ea4803d122dcc0131ec1e841238a00cf65ebe`.

Four regressions use real Node workers and real QuickJS VMs. A temporary worker bootstrap changes only that worker's clock on the first actual QuickJS interrupt callback, after the VM records its starting time. It invokes the original callback and imports the production worker; no production test seam or global system-clock change is involved. Unlike a parent-process clock spy, this reaches the clock used by the isolated worker.

On unchanged production, both fresh and resumed forward-jump cases failed with a premature guest timeout. Both backward-jump cases fell through to the host watchdog instead of the guest interrupt. With the four-line repair, all four pass: the finite computation returns its correct result, and the infinite loop ends with a guest timeout.

Final proof uses the package and lockfile's pinned `quickjs-wasi@3.4.0`. Its installed source was inspected directly: create and restore apply the supplied interrupt callback, including after restoring snapshot memory. Earlier runs against an older 3.2.0 installation were exploratory and are not the final compatibility evidence.

All 130 focused tests passed on 3.4.0, covering worker creation/restore, timeout, abort, compiled-module sharing, snapshot/output limits, headless execution, and the real cron caller:

```sh
node scripts/run-vitest.mjs src/agents/code-mode-worker-lifecycle.test.ts --configLoader runner --reporter=verbose --maxWorkers=1 -t 'guest timeouts independent'
node scripts/run-vitest.mjs src/agents/code-mode-worker-lifecycle.test.ts src/agents/code-mode.limits.test.ts src/agents/code-mode-headless.test.ts --configLoader runner --reporter=dot --maxWorkers=1
node scripts/run-vitest.mjs src/cron/trigger-script.test.ts --configLoader runner --reporter=dot --maxWorkers=1
```

Targeted type-aware lint, formatting, maximum-file-length guard, and `git diff --check` pass. Structured autoreview, a separate read-only Codex review, and independent architecture/dependency review found no actionable issues. The dependency-version gap identified during review was corrected and the failing/passing proof rerun against 3.4.0 before publication. Hosted CI must pass on this head before landing.

Production: +4/-4 lines (net zero). Tests: +86/-0 lines. AI-assisted maintainer repair.
