### PR TITLE
fix(browser): preserve exact select option values

### DIFF
--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -254,6 +254,8 @@ openclaw browser evaluate --fn 'const title = document.title; return title;'
 openclaw browser evaluate --timeout-ms 30000 --fn 'async () => { await window.ready; return true; }'
 ```
 
+For managed browser profiles, `select` preserves option values exactly. Quote empty or whitespace-sensitive values, such as `openclaw browser select <ref> ""` or `openclaw browser select <ref> " padded "`.
+
 `evaluate --fn` accepts a function source, an expression, or a statement body. Statement bodies are wrapped as async functions, so use `return` for the value you want back. Use `--timeout-ms` when the page-side function may need longer than the default evaluate timeout. `browser.evaluateEnabled=false` (default: `true`) disables both `evaluate` and `wait --fn`.
 
 Action responses return the current raw `targetId` after action-triggered page replacement when OpenClaw can prove the replacement tab. Scripts should still store and pass `suggestedTargetId`/labels for long-lived workflows.

--- a/extensions/browser/src/browser/routes/agent.act.normalize.ts
+++ b/extensions/browser/src/browser/routes/agent.act.normalize.ts
@@ -4,6 +4,7 @@
  * Converts loosely typed route bodies into the closed BrowserActRequest union
  * used by Playwright and Chrome MCP action executors.
  */
+import { filterStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   ACT_MAX_BATCH_ACTIONS,
   ACT_MAX_BATCH_DEPTH,
@@ -15,12 +16,7 @@ import {
 import type { BrowserActRequest, BrowserFormField } from "../client-actions.types.js";
 import { normalizeBrowserFormField } from "../form-fields.js";
 import { resolveTargetIdFromTabs } from "../target-id.js";
-import {
-  type ActKind,
-  isActKind,
-  parseClickButton,
-  parseClickModifiers,
-} from "./agent.act.shared.js";
+import { isActKind, parseClickButton, parseClickModifiers } from "./agent.act.shared.js";
 import {
   readRouteFiniteNumber,
   readRouteInteger,
@@ -28,14 +24,6 @@ import {
   readRouteTimerTimeoutMs,
 } from "./route-numeric.js";
 import { toBoolean, toStringArray, toStringOrEmpty } from "./utils.js";
-
-function normalizeActKind(raw: unknown): ActKind {
-  const kind = toStringOrEmpty(raw);
-  if (!isActKind(kind)) {
-    throw new Error("kind is required");
-  }
-  return kind;
-}
 
 function countBatchActions(actions: BrowserActRequest[]): number {
   let count = 0;
@@ -136,7 +124,10 @@ export function normalizeActRequest(
 ): BrowserActRequest {
   const source = options?.source ?? "request";
   const depth = options?.depth ?? 0;
-  const kind = normalizeActKind(body.kind);
+  const kind = toStringOrEmpty(body.kind);
+  if (!isActKind(kind)) {
+    throw new Error("kind is required");
+  }
 
   switch (kind) {
     case "click": {
@@ -289,8 +280,9 @@ export function normalizeActRequest(
     case "select": {
       const ref = toStringOrEmpty(body.ref) || undefined;
       const selector = toStringOrEmpty(body.selector) || undefined;
-      const values = toStringArray(body.values);
-      if ((!ref && !selector) || !values?.length) {
+      // Option values are content: empty strings and surrounding whitespace can identify a choice.
+      const values = filterStringEntries(body.values);
+      if ((!ref && !selector) || !values.length) {
         throw new Error("select requires ref/selector and values");
       }
       const targetId = toStringOrEmpty(body.targetId) || undefined;

--- a/extensions/browser/src/browser/routes/agent.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/agent.existing-session.test.ts
@@ -166,6 +166,20 @@ describe("existing-session browser routes", () => {
       .mockResolvedValueOnce(true);
   });
 
+  it.each(["", "  spaced  "])("forwards exact select input %j to Chrome MCP", async (value) => {
+    const handler = getActPostHandler();
+    const response = createBrowserRouteResponse();
+    await handler?.(
+      { params: {}, query: {}, body: { kind: "select", ref: "select-1", values: [value] } },
+      response.res,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(chromeMcpMocks.fillChromeMcpElement).toHaveBeenCalledWith(
+      expect.objectContaining({ targetId: "7", uid: "select-1", value }),
+    );
+  });
+
   it("allows labeled AI snapshots for existing-session profiles", async () => {
     const handler = getSnapshotGetHandler();
     const response = createBrowserRouteResponse();

--- a/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -215,17 +215,19 @@ describe("browser control server", () => {
     async () => {
       const base = await startServerAndBase();
 
-      const select = await postJson<{ ok: boolean }>(`${base}/act`, {
-        kind: "select",
-        ref: "5",
-        values: ["a", "b"],
-      });
-      expect(select.ok).toBe(true);
-      expectBrowserCallFields(requirePwMock("selectOptionViaPlaywright"), {
-        targetId: "abcd1234",
-        ref: "5",
-        values: ["a", "b"],
-      });
+      for (const values of [["a", "b"], [""], ["  spaced  "], ["", "  spaced  "]]) {
+        const select = await postJson<{ ok: boolean }>(`${base}/act`, {
+          kind: "select",
+          ref: "5",
+          values,
+        });
+        expect(select.ok).toBe(true);
+        expectBrowserCallFields(
+          requirePwMock("selectOptionViaPlaywright"),
+          { targetId: "abcd1234", ref: "5", values },
+          requirePwMock("selectOptionViaPlaywright").mock.calls.length - 1,
+        );
+      }
 
       const fillCases: Array<{
         input: Record<string, unknown>;
@@ -368,7 +370,7 @@ describe("browser control server", () => {
   );
 
   it(
-    "preserves exact type text in batch normalization",
+    "preserves exact type text and select values in batch normalization",
     async () => {
       const base = await startServerAndBase();
 
@@ -377,6 +379,7 @@ describe("browser control server", () => {
         actions: [
           { kind: "type", selector: "input.name", text: "  padded  " },
           { kind: "type", selector: "input.clearable", text: "" },
+          { kind: "select", selector: "select.choice", values: ["", "  spaced  "] },
         ],
       });
 
@@ -393,6 +396,7 @@ describe("browser control server", () => {
             selector: "input.clearable",
             text: "",
           },
+          { kind: "select", selector: "select.choice", values: ["", "  spaced  "] },
         ],
       });
     },


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch; repository maintainers can edit it directly.

</details>

## What Problem This Solves

Fixes an issue where browser users selecting an option with an empty or whitespace-sensitive value would either receive an error or silently select a different option. For example, requesting `"  spaced  "` could report success while selecting `"spaced"`. Multi-select lost empty choices, and batches containing an empty selection could fail before dispatch.

## Why This Change Was Made

The shared action normalizer treated option content like trimmed identifiers. Use the existing `filterStringEntries` SDK helper to preserve the documented `string[]` values at their canonical input boundary, so direct and nested actions share the repair. Keep modifier/upload normalization and all browser security, target, timeout, and batch limits unchanged. Inline the one-use action-kind helper into that same normalization owner, removing an unnecessary layer without changing validation.

Production: +9/-17, net **-8 lines**. Tests: +30/-12, net +18. Docs: +2. No new helper, dependency, option, schema, persistent store, or fallback. Nonstring entries are filtered rather than incidentally stringified; the public action/tool contract accepts `string[]` only.

## User Impact

Managed-browser selections preserve empty and padded values exactly, including multiple values and batch actions. CLI documentation shows how to quote these values. Existing-session routes also preserve the supplied strings, but Chrome MCP's label-based selection semantics are unchanged; this PR does not claim new empty-DOM-value support for that driver.

## Evidence

- Frozen baseline: `70c87cc98d7a96577282a65db8eb7f96a9976c61`.
- Reviewed candidate: `c48aeb0f80a9515de135c7b028453ee886508a36`. AI-assisted implementation and independent review.
- Regression tests before the production change: **4 failed / 59 passed**, demonstrating empty-value rejection, padded-value trimming, and batch corruption at existing route boundaries. After the repair: **78 passed across 4 files**, including action normalization and batch contract siblings.
- Real isolated Chromium, matching Playwright **1.62.1**, through the production authenticated loopback browser bridge and HTTP `browserAct`, using refs obtained from the actual browser snapshot. A synthetic page contains separate padded and unpadded option values with distinct labels, preventing label fallback from hiding the failure.

| Request | Before | After |
| --- | --- | --- |
| Single empty value | rejected; initial option retained | succeeds; `""` selected |
| Single `"  spaced  "` | success, wrong `"spaced"` option | success, exact `"  spaced  "` option |
| Multi `""` and `"  spaced  "` | only `"spaced"` selected | both exact requested values selected |
| Batch empty plus multi-select | rejected before dispatch | two successful actions, exact selected values |

- Inspected DOM readbacks and before/after screenshots. Each run used fresh task-owned profile/config/state, random loopback ports and memory-only bridge authentication. All owned browser/bridge/fixture ports closed and temporary profiles were removed; no operator Gateway/profile was used.
- Existing-session tests assert exact argument passthrough only; no authenticated Chrome MCP session was used. Directly inspected upstream Playwright selection semantics and the MCP sibling's distinct label contract.
- Targeted formatting/lint, whitespace, maximum-lines and assertion-safety ratchets passed. Canonical browser Vitest configuration retained; this sparse checkout uses dependency resolution from the primary checkout, not a fresh pinned installation. Required hosted CI remains the pinned full-check authority.
- Fresh Codex autoreview and independent owner/caller/sibling review found no actionable issues and confirmed the canonical-boundary repair.

Focused test files: `server.agent-contract-form-layout-act-commands.test.ts`, `routes/agent.existing-session.test.ts`, `routes/agent.act.normalize.test.ts`, and `routes/agent.act.normalize.batch-contract.test.ts` under the browser plugin.

Provenance: the select normalization is carried from `f096fc440686` (2026-04-09, code author Josh Avant) and also appears in stable `v2026.7.1`. Separate queued investigations remain for dialog prompt whitespace and Chrome MCP upload parameter drift; neither is bundled into this option-value repair.
