### PR TITLE
fix: honor fresh provider catalog discovery

### DIFF
--- a/extensions/llama-cpp/src/external-server/discovery.test.ts
+++ b/extensions/llama-cpp/src/external-server/discovery.test.ts
@@ -1,3 +1,5 @@
+import { once } from "node:events";
+import { createServer } from "node:http";
 import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { discoverLlamaServer } from "./discovery.js";
@@ -88,21 +90,56 @@ describe("llama-server discovery projection", () => {
     });
   });
 
-  it("bypasses the shared cache for credential-scoped discovery", async () => {
-    discoverRowsMock.mockResolvedValue({
-      kind: "success",
-      health: "ready",
-      fetchedAt: 123,
-      rows: [],
+  it.each([
+    { name: "API key", access: { apiKey: "endpoint-key" } },
+    { name: "authorization header", access: { headers: { Authorization: "Bearer endpoint-key" } } },
+    { name: "explicit refresh", access: { cacheTtlMs: 0 } },
+  ])("fetches $name discovery after an anonymous catalog was cached", async ({ access }) => {
+    const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/provider-setup")>(
+      "openclaw/plugin-sdk/provider-setup",
+    );
+    discoverRowsMock.mockImplementation(actual.discoverOpenAICompatibleLocalModels);
+    let modelId = "anonymous-model";
+    const modelRequests: Array<string | undefined> = [];
+    const server = createServer((request, response) => {
+      response.setHeader("Content-Type", "application/json");
+      if (request.url === "/models") {
+        modelRequests.push(request.headers.authorization);
+        response.end(JSON.stringify({ data: [{ id: modelId, status: { value: "unloaded" } }] }));
+      } else {
+        response.end("{}");
+      }
     });
-
-    for (let index = 0; index < 2; index += 1) {
-      await discoverLlamaServer({
-        baseUrl: "http://localhost:8080",
-        headers: { Authorization: "Bearer endpoint-key" },
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected a listening TCP server");
+      }
+      const baseUrl = `http://127.0.0.1:${address.port}`;
+      await expect(discoverLlamaServer({ baseUrl })).resolves.toMatchObject({
+        kind: "success",
+        models: [{ config: { id: "anonymous-model" } }],
+      });
+      modelId = "fresh-model";
+      await expect(discoverLlamaServer({ baseUrl, ...access })).resolves.toMatchObject({
+        kind: "success",
+        models: [{ config: { id: "fresh-model" } }],
+      });
+      await expect(discoverLlamaServer({ baseUrl })).resolves.toMatchObject({
+        kind: "success",
+        models: [{ config: { id: "anonymous-model" } }],
+      });
+      expect(modelRequests).toEqual([
+        undefined,
+        "cacheTtlMs" in access ? undefined : "Bearer endpoint-key",
+      ]);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
       });
     }
-
-    expect(discoverRowsMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/plugin-sdk/provider-catalog-shared.test.ts
+++ b/src/plugin-sdk/provider-catalog-shared.test.ts
@@ -1,6 +1,7 @@
 // Provider catalog shared tests cover catalog hashing, normalization, and model visibility.
 import type { ModelCatalogProvider } from "@openclaw/model-catalog-core/model-catalog-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import {
   applyProviderNativeStreamingUsageCompat,
   buildManifestModelDefinition,
@@ -124,7 +125,7 @@ describe("provider-catalog-shared live catalog cache", () => {
     async (outcome) => {
       let now = 1_000;
       const keyParts = ["provider", "models"];
-      const pending = Promise.withResolvers<string>();
+      const pending = createDeferred<string>();
       const error = new Error("expired failure");
       const first = getCachedLiveCatalogValue({
         keyParts,

--- a/src/plugin-sdk/provider-catalog-shared.test.ts
+++ b/src/plugin-sdk/provider-catalog-shared.test.ts
@@ -94,6 +94,77 @@ describe("provider-catalog-shared live catalog cache", () => {
     expect(load).toHaveBeenCalledTimes(2);
   });
 
+  it.each(["resolve", "reject", "throw"] as const)(
+    "bypasses a warm cache without modifying it when the uncached loader will %s",
+    async (outcome) => {
+      const keyParts = ["provider", "models"];
+      await getCachedLiveCatalogValue({ keyParts, load: async () => "cached" });
+      const error = new Error("uncached failure");
+      const load = vi.fn(() => {
+        if (outcome === "throw") {
+          throw error;
+        }
+        return outcome === "reject" ? Promise.reject(error) : Promise.resolve("fresh");
+      });
+      const shouldCache = vi.fn(() => false);
+      const fresh = getCachedLiveCatalogValue({ keyParts, load, shouldCache, ttlMs: 0 });
+      if (outcome === "resolve") {
+        await expect(fresh).resolves.toBe("fresh");
+      } else {
+        await expect(fresh).rejects.toBe(error);
+      }
+      expect(shouldCache).not.toHaveBeenCalled();
+      await expect(getCachedLiveCatalogValue({ keyParts, load })).resolves.toBe("cached");
+      expect(load).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(["reject", "predicate-false", "predicate-throw", "same-promise"] as const)(
+    "preserves a replacement cache entry after expired work finishes with %s",
+    async (outcome) => {
+      let now = 1_000;
+      const keyParts = ["provider", "models"];
+      const pending = Promise.withResolvers<string>();
+      const error = new Error("expired failure");
+      const first = getCachedLiveCatalogValue({
+        keyParts,
+        load: () => pending.promise,
+        ttlMs: 100,
+        now: () => now,
+        shouldCache: () => {
+          if (outcome === "predicate-throw") {
+            throw error;
+          }
+          return false;
+        },
+      });
+      now = 1_101;
+      const replacement = getCachedLiveCatalogValue({
+        keyParts,
+        load: () => (outcome === "same-promise" ? pending.promise : Promise.resolve("replacement")),
+        ttlMs: 100,
+        now: () => now,
+      });
+      if (outcome === "reject") {
+        pending.reject(error);
+      } else {
+        pending.resolve("expired");
+      }
+      if (outcome === "reject" || outcome === "predicate-throw") {
+        await expect(first).rejects.toBe(error);
+      } else {
+        await expect(first).resolves.toBe("expired");
+      }
+      const expected = outcome === "same-promise" ? "expired" : "replacement";
+      await expect(replacement).resolves.toBe(expected);
+      const load = vi.fn(async () => "unnecessary reload");
+      await expect(getCachedLiveCatalogValue({ keyParts, load, now: () => now })).resolves.toBe(
+        expected,
+      );
+      expect(load).not.toHaveBeenCalled();
+    },
+  );
+
   it("does not retain resolved live catalog values rejected by the cache predicate", async () => {
     const load = vi
       .fn<() => Promise<string>>()

--- a/src/plugin-sdk/provider-catalog-shared.ts
+++ b/src/plugin-sdk/provider-catalog-shared.ts
@@ -80,7 +80,11 @@ export async function getCachedLiveCatalogValue<T>(params: {
   now?: () => number;
 }): Promise<T> {
   const rawNow = params.now?.() ?? Date.now();
-  const ttlMs = params.ttlMs ?? 30_000;
+  const expiresAt = resolveExpiresAtMsFromDurationMs(params.ttlMs ?? 30_000, { nowMs: rawNow });
+  // Uncached callers must neither reuse nor disturb an existing entry.
+  if (expiresAt === undefined) {
+    return await params.load();
+  }
   const key = buildLiveCatalogCacheKey(params.keyParts);
   const existing = liveCatalogCache.get(key) as LiveCatalogCacheEntry<T> | undefined;
   if (existing) {
@@ -89,27 +93,22 @@ export async function getCachedLiveCatalogValue<T>(params: {
     }
     liveCatalogCache.delete(key);
   }
-  const value = params.load();
-  const expiresAt = resolveExpiresAtMsFromDurationMs(ttlMs, { nowMs: rawNow });
-  if (expiresAt !== undefined) {
-    // Auth-scoped live provider catalogs can vary by token; keep this
-    // process-local cache bounded so discovery cannot grow without limit.
-    pruneMapToMaxSize(liveCatalogCache, LIVE_CATALOG_CACHE_MAX_ENTRIES - 1);
-    liveCatalogCache.set(key, {
-      expiresAt,
-      value,
-    });
-  }
+  const entry = { expiresAt, value: params.load() };
+  // Auth-scoped live provider catalogs can vary by token; keep this
+  // process-local cache bounded so discovery cannot grow without limit.
+  pruneMapToMaxSize(liveCatalogCache, LIVE_CATALOG_CACHE_MAX_ENTRIES - 1);
+  liveCatalogCache.set(key, entry);
+  let retain = false;
   try {
-    const resolved = await value;
-    if (params.shouldCache && !params.shouldCache(resolved)) {
+    const resolved = await entry.value;
+    retain = params.shouldCache?.(resolved) ?? true;
+    return resolved;
+  } finally {
+    // Expired work may finish after a replacement load. Only its own entry
+    // can be removed when loading or the cache predicate fails.
+    if (!retain && liveCatalogCache.get(key) === entry) {
       liveCatalogCache.delete(key);
     }
-    return resolved;
-  } catch (err) {
-    // Failed live discovery should not poison later retries for the same provider/config.
-    liveCatalogCache.delete(key);
-    throw err;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users refreshing an existing llama.cpp server's model discovery could receive the previous anonymous catalog instead of a fresh response. The shared cache reused a warm entry even when the caller explicitly disabled caching. Expired catalog loads could also remove a newer replacement entry when they subsequently failed or were rejected by their cache predicate.

## Why This Change Was Made

Resolve the existing cache-expiry policy before reading any cache entry. Uncached loads now run independently and never read, write, or remove a cached entry. Cached loads use one cleanup path bound to the exact entry they created, so late completion cannot discard newer work, even when loaders reuse the same Promise.

This repairs the shared owner instead of restoring a llama.cpp-only bypass. No SDK exports, signatures, configuration, auth policy, positive TTL defaults, or persistent storage change. Production LOC: +18/-19 (net -1); tests: +122/-13 (net +109). The old cold-cache mocked credential test is replaced by stronger real HTTP ordering coverage.

## User Impact

Explicit catalog refreshes and credential-scoped llama.cpp discovery fetch their own current model list. Ordinary cached discovery still reuses its original entry; late failures no longer cause unnecessary reloads.

## Evidence

Reviewed head: `09c4c344530e6a1f84d51358eea60d8bfde20b59`.

- Against unchanged main `0569c6ea6b401ac15cbffa171be664d8dcf08f52`, seven new shared-cache regressions failed: warm-cache bypass with success, rejection, or synchronous throw; and expired-entry cleanup after rejection, predicate rejection, predicate throw, or a replacement reusing the same Promise.
- Three real localhost HTTP regressions also failed before the repair: anonymous discovery followed by API-key discovery, authorization-header discovery, or an explicit refresh returned the old model list without fetching again. All three now fetch the current list and preserve the ordinary anonymous cache entry. These use a controlled HTTP fixture; no real model was loaded or inference performed.
- 211 tests passed across 10 files, including shared live-catalog consumers, llama.cpp external-server discovery/setup/auth/model/stream paths, and Ollama discovery.
- Exact changed source and tests passed the canonical type-aware lint wrappers. `OPENCLAW_OXLINT_SKIP_PREPARE=1` avoided regenerating unrelated package-boundary artifacts; it did not disable lint rules. Hosted CI must still verify full selected type/build gates.
- Fresh structured Codex review through P2: no actionable findings, confidence 0.95. Two independent code reviews also found no blocking issues.
- Hosted test types caught an unsupported direct `Promise.withResolvers` use in the new test fixture. The follow-up uses the existing shared deferred helper without changing production code or assertions. All 26 focused cache/discovery tests, typed lint, formatting, fresh P2 review (0.96), and independent review passed after correction. The owning local test-type shard no longer reports that error, but still fails on unrelated shared-install dependency-version drift; full local types are not claimed green. Fresh exact-head hosted CI is required.
- Landing check: [full CI run 33026918426](https://github.com/openclaw/openclaw/actions/runs/33026918426) passed on the reviewed head, including `openclaw/ci-gate`; all 203 check runs are terminal without failures. The latest ClawSweeper rank-up request is addressed by a fresh clean merge-tree against `main` at `35adcc6c6f3b` and confirmation that the touched owner/caller/test paths have not changed since the reviewed base. No rebase is needed solely for behind-main drift. Its stored-data warning is not applicable: the change affects an in-memory Map and test fixtures, not persisted state or a schema. Its live-proof excerpt reports all five tests passed, although the outer harness marked its output assertion failed; our independently completed loopback runs are the behavior proof.

Commands:

```sh
env -u LM_API_TOKEN -u OLLAMA_API_KEY OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-r9-catalog-sibling-cache node scripts/run-vitest.mjs src/plugin-sdk/provider-catalog-shared.test.ts src/plugin-sdk/provider-catalog-live-runtime.test.ts extensions/llama-cpp/src/external-server extensions/ollama/src/discovery-shared.test.ts --configLoader runner
OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugin-sdk/provider-catalog-shared.ts src/plugin-sdk/provider-catalog-shared.test.ts
OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/llama-cpp/src/external-server/discovery.test.ts
git diff --check
```

Provenance: the generic cache ordering predates stable `v2026.7.1`; the external llama.cpp path was not present in that tag. Its explicit bypass was removed in #126434 (`0135046830ae6887996dc35e91594077cfbe5745`, authored and merged by @steipete on August 19, 2026), exposing the older shared-cache defect. The shallow history does not establish the original introduction of the generic defect.

AI-assisted.
