### PR TITLE
refactor(models): prepare selection policy once

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1949,7 +1949,7 @@ src/agents/model-fallback-runner.ts	2
 src/agents/model-provider-auth.ts	4
 src/agents/model-provider-auth.worker.ts	1
 src/agents/model-scan.ts	4
-src/agents/model-selection-shared.ts	2
+src/agents/model-selection-shared.ts	1
 src/agents/model-tool-support.ts	1
 src/agents/models-config-state.ts	1
 src/agents/models-config.merge.ts	2

--- a/src/agents/model-selection-manifest-workspace.test.ts
+++ b/src/agents/model-selection-manifest-workspace.test.ts
@@ -136,7 +136,7 @@ describe("configured model manifest workspace scope", () => {
 
   it("builds configured catalog facts once when resolving allowed models", async () => {
     getCurrentPluginMetadataSnapshotMock.mockReturnValue({ plugins: [] });
-    const { buildAllowedModelSetWithFallbacks } = await import("./model-selection-shared.js");
+    const { buildAllowedModelSet } = await import("./model-selection-shared.js");
     const cfg = {
       models: {
         providers: {
@@ -146,11 +146,10 @@ describe("configured model manifest workspace scope", () => {
     } as unknown as OpenClawConfig;
 
     expect(
-      buildAllowedModelSetWithFallbacks({
+      buildAllowedModelSet({
         cfg,
         catalog: [],
         defaultProvider: "custom",
-        fallbackModels: [],
       }).allowedCatalog,
     ).toMatchObject([{ provider: "custom", id: "fast-model" }]);
     expect(getCurrentPluginMetadataSnapshotMock).toHaveBeenCalledTimes(1);

--- a/src/agents/model-selection-resolve.ts
+++ b/src/agents/model-selection-resolve.ts
@@ -1,8 +1,7 @@
 /**
  * Model selection resolution facade.
  *
- * This module exposes model-selection helpers that need default fallback model
- * handling before checking aliases, allowlists, catalogs, and plugin manifests.
+ * This module resolves configured fallbacks and explicit model selections.
  */
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -11,13 +10,13 @@ import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import type { ModelManifestNormalizationContext, ModelRef } from "./model-ref-shared.js";
 import {
   buildModelAliasIndex,
-  getModelRefStatusWithFallbackModels,
+  getModelRefStatus,
   resolveAllowedModelRefFromAliasIndex,
-  type ModelRefStatus,
 } from "./model-selection-shared.js";
 
 export {
   buildModelAliasIndex,
+  getModelRefStatus,
   normalizeModelSelection,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
@@ -37,30 +36,6 @@ export function resolveConfiguredModelFallbacks(params: {
     }
   }
   return resolveAgentModelFallbackValues(params.cfg.agents?.defaults?.model);
-}
-
-/** Returns whether a normalized model ref is available, allowed, or fallback-backed. */
-export function getModelRefStatus(
-  params: {
-    cfg: OpenClawConfig;
-    catalog: ModelCatalogEntry[];
-    ref: ModelRef;
-    defaultProvider: string;
-    defaultModel?: string;
-    agentId?: string;
-  } & ModelManifestNormalizationContext,
-): ModelRefStatus {
-  const { cfg, catalog, ref, defaultProvider, defaultModel, agentId, manifestPlugins } = params;
-  return getModelRefStatusWithFallbackModels({
-    cfg,
-    catalog,
-    ref,
-    defaultProvider,
-    defaultModel,
-    agentId,
-    fallbackModels: resolveConfiguredModelFallbacks({ cfg, agentId }),
-    manifestPlugins,
-  });
 }
 
 /** Resolves a raw model string into an allowed model ref or an explanatory error. */

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -5,6 +5,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+export { resolvePrimaryStringValue as normalizeModelSelection } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog, stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import {
@@ -643,23 +644,17 @@ type ModelCatalogMetadata = {
   aliasByKey: Map<string, string>;
 };
 
-function buildModelCatalogMetadata(
-  params: {
-    cfg: OpenClawConfig;
-    configuredCatalog: readonly ModelCatalogEntry[];
-    defaultProvider: string;
-    agentId?: string;
-    allowManifestNormalization?: boolean;
-    allowPluginNormalization?: boolean;
-  } & ModelManifestNormalizationContext,
-): ModelCatalogMetadata {
+function buildModelCatalogMetadata(params: {
+  configuredCatalog: readonly ModelCatalogEntry[];
+  aliasIndex: ModelAliasIndex;
+}): ModelCatalogMetadata {
   const configuredByKey = new Map<string, ModelCatalogEntry>();
   for (const entry of params.configuredCatalog) {
     configuredByKey.set(modelKey(entry.provider, entry.id), entry);
   }
 
   const aliasByKey = new Map(
-    [...buildModelAliasIndex(params).byKey].flatMap(([key, aliases]) => {
+    [...params.aliasIndex.byKey].flatMap(([key, aliases]) => {
       const alias = aliases.at(-1);
       return alias ? [[key, alias] as const] : [];
     }),
@@ -997,72 +992,67 @@ export function resolveConfiguredModelRef(
   return { provider: params.defaultProvider, model: params.defaultModel };
 }
 
-/** Build explicit override authorization plus configured automatic fallback keys. */
-export function buildAllowedModelSetWithFallbacks(
+type ModelPolicyPreparationParams = BuildModelAliasIndexParams & {
+  catalog: ModelCatalogEntry[];
+  defaultModel?: string;
+};
+
+type AllowedModelSet = {
+  allowAny: boolean;
+  allowedCatalog: ModelCatalogEntry[];
+  allowedKeys: Set<string>;
+};
+
+/** Build explicit model override authorization without widening it for automatic fallbacks. */
+export function buildAllowedModelSet(
   params: {
     cfg: OpenClawConfig;
     catalog: ModelCatalogEntry[];
     defaultProvider: string;
     defaultModel?: string;
-    fallbackModels: readonly string[];
     agentId?: string;
-    aliasIndex?: ModelAliasIndex;
-    selectionAliasIndex?: ModelAliasIndex;
-    visibility?: ReturnType<typeof parseConfiguredModelVisibilityEntries>;
-    allowManifestNormalization?: boolean;
-    allowPluginNormalization?: boolean;
   } & ModelManifestNormalizationContext,
-): {
-  allowAny: boolean;
-  allowedCatalog: ModelCatalogEntry[];
-  allowedKeys: Set<string>;
-  automaticFallbackKeys: Set<string>;
-  configuredCatalog: ModelCatalogEntry[];
-} {
+): AllowedModelSet {
+  return buildAllowedModelSetFromPrepared(params, prepareModelPolicy(params));
+}
+
+function prepareModelPolicy(params: ModelPolicyPreparationParams) {
+  const visibility = parseConfiguredModelVisibilityEntries(params);
+  const policyAliasAgentId = resolvePolicyAliasAgentId(visibility.configPath, params.agentId);
+  const policyAliasIndex = buildModelAliasIndex({ ...params, agentId: policyAliasAgentId });
+  // Inherited policy aliases keep their owner's scope; selection and display
+  // aliases still honor the selected agent's overrides.
+  const selectionAliasIndex =
+    params.agentId && policyAliasAgentId !== params.agentId
+      ? buildModelAliasIndex(params)
+      : policyAliasIndex;
   const configuredCatalog = buildConfiguredModelCatalog({
     cfg: params.cfg,
     manifestPlugins: params.manifestPlugins,
   });
   const metadata = buildModelCatalogMetadata({
-    cfg: params.cfg,
     configuredCatalog,
-    defaultProvider: params.defaultProvider,
-    agentId: params.agentId,
-    allowManifestNormalization: params.allowManifestNormalization,
-    allowPluginNormalization: params.allowPluginNormalization,
-    manifestPlugins: params.manifestPlugins,
+    aliasIndex: selectionAliasIndex,
   });
   const catalog = mergeModelCatalogEntries({
     primary: params.catalog,
     secondary: configuredCatalog,
   }).map((entry) => applyModelCatalogMetadata({ entry, metadata }));
-  const visibility =
-    params.visibility ??
-    parseConfiguredModelVisibilityEntries({ cfg: params.cfg, agentId: params.agentId });
+  return {
+    visibility,
+    policyAliasIndex,
+    selectionAliasIndex,
+    configuredCatalog,
+    metadata,
+    catalog,
+  };
+}
+
+function buildAllowedModelSetFromPrepared(
+  params: ModelPolicyPreparationParams,
+  { visibility, policyAliasIndex, metadata, catalog }: ReturnType<typeof prepareModelPolicy>,
+): AllowedModelSet {
   const wildcardModelKeys = visibility.wildcardModelKeys;
-  const policyAliasAgentId = resolvePolicyAliasAgentId(visibility.configPath, params.agentId);
-  const policyAliasIndex =
-    params.aliasIndex ??
-    buildModelAliasIndex({
-      cfg: params.cfg,
-      defaultProvider: params.defaultProvider,
-      agentId: policyAliasAgentId,
-      allowManifestNormalization: params.allowManifestNormalization,
-      allowPluginNormalization: params.allowPluginNormalization,
-      manifestPlugins: params.manifestPlugins,
-    });
-  const selectionAliasIndex =
-    params.selectionAliasIndex ??
-    (params.agentId && policyAliasAgentId !== params.agentId
-      ? buildModelAliasIndex({
-          cfg: params.cfg,
-          defaultProvider: params.defaultProvider,
-          agentId: params.agentId,
-          allowManifestNormalization: params.allowManifestNormalization,
-          allowPluginNormalization: params.allowPluginNormalization,
-          manifestPlugins: params.manifestPlugins,
-        })
-      : policyAliasIndex);
   const allowAny = !visibility.hasEntries;
   const defaultModelNormalization = allowAny
     ? {
@@ -1087,7 +1077,7 @@ export function buildAllowedModelSetWithFallbacks(
         })
       : null;
   const defaultKey = defaultRef ? modelKey(defaultRef.provider, defaultRef.model) : undefined;
-  const resolveSelectionModelRef = (raw: string, aliasIndex: ModelAliasIndex) => {
+  const resolvePolicyModelRef = (raw: string) => {
     const trimmed = raw.trim();
     const defaultProvider = !trimmed.includes("/")
       ? resolveBareModelDefaultProvider({
@@ -1104,19 +1094,12 @@ export function buildAllowedModelSetWithFallbacks(
       agentId: params.agentId,
       raw,
       defaultProvider,
-      aliasIndex,
+      aliasIndex: policyAliasIndex,
       allowManifestNormalization: params.allowManifestNormalization,
       allowPluginNormalization: params.allowPluginNormalization,
       manifestPlugins: params.manifestPlugins,
     })?.ref;
   };
-  const automaticFallbackKeys = new Set<string>();
-  for (const fallback of params.fallbackModels) {
-    const parsed = resolveSelectionModelRef(fallback, selectionAliasIndex);
-    if (parsed) {
-      automaticFallbackKeys.add(modelKey(parsed.provider, parsed.model));
-    }
-  }
   const catalogKeys = new Set<string>();
   for (const entry of catalog) {
     catalogKeys.add(modelKey(entry.provider, entry.id));
@@ -1130,8 +1113,6 @@ export function buildAllowedModelSetWithFallbacks(
       allowAny: true,
       allowedCatalog: catalog,
       allowedKeys: catalogKeys,
-      automaticFallbackKeys,
-      configuredCatalog,
     };
   }
 
@@ -1155,8 +1136,8 @@ export function buildAllowedModelSetWithFallbacks(
     allowedKeys.add(modelKey(entry.provider, entry.id));
     addAllowedCatalogRef({ provider: entry.provider, model: entry.id });
   }
-  const addAllowedModelRef = (raw: string, aliasIndex: ModelAliasIndex) => {
-    const parsed = resolveSelectionModelRef(raw, aliasIndex);
+  const addAllowedModelRef = (raw: string) => {
+    const parsed = resolvePolicyModelRef(raw);
     if (!parsed) {
       return;
     }
@@ -1175,7 +1156,7 @@ export function buildAllowedModelSetWithFallbacks(
   };
 
   for (const raw of visibility.exactModelRefs) {
-    addAllowedModelRef(raw, policyAliasIndex);
+    addAllowedModelRef(raw);
   }
 
   if (
@@ -1207,8 +1188,6 @@ export function buildAllowedModelSetWithFallbacks(
       allowAny: true,
       allowedCatalog: catalog,
       allowedKeys: catalogKeys,
-      automaticFallbackKeys,
-      configuredCatalog,
     };
   }
 
@@ -1216,8 +1195,6 @@ export function buildAllowedModelSetWithFallbacks(
     allowAny: false,
     allowedCatalog,
     allowedKeys,
-    automaticFallbackKeys,
-    configuredCatalog,
   };
 }
 
@@ -1235,14 +1212,17 @@ type ResolveAllowedModelRefResult =
       error: string;
     };
 
-function getModelRefStatusFromAllowedSet(params: {
-  catalog: ModelCatalogEntry[];
-  ref: ModelRef;
-  allowed: {
-    allowAny: boolean;
-    allowedKeys: Set<string>;
-  };
-}): ModelRefStatus {
+export function getModelRefStatus(
+  params: {
+    cfg: OpenClawConfig;
+    catalog: ModelCatalogEntry[];
+    ref: ModelRef;
+    defaultProvider: string;
+    defaultModel?: string;
+    agentId?: string;
+  } & ModelManifestNormalizationContext,
+): ModelRefStatus {
+  const allowed = buildAllowedModelSet(params);
   const key = modelKey(params.ref.provider, params.ref.model);
   return {
     key,
@@ -1252,36 +1232,9 @@ function getModelRefStatusFromAllowedSet(params: {
         modelId: params.ref.model,
       }),
     ),
-    allowAny: params.allowed.allowAny,
-    allowed: params.allowed.allowAny || isModelKeyAllowedBySet(params.allowed.allowedKeys, key),
+    allowAny: allowed.allowAny,
+    allowed: allowed.allowAny || isModelKeyAllowedBySet(allowed.allowedKeys, key),
   };
-}
-
-export function getModelRefStatusWithFallbackModels(
-  params: {
-    cfg: OpenClawConfig;
-    catalog: ModelCatalogEntry[];
-    ref: ModelRef;
-    defaultProvider: string;
-    defaultModel?: string;
-    fallbackModels: readonly string[];
-    agentId?: string;
-  } & ModelManifestNormalizationContext,
-): ModelRefStatus {
-  const allowed = buildAllowedModelSetWithFallbacks({
-    cfg: params.cfg,
-    catalog: params.catalog,
-    defaultProvider: params.defaultProvider,
-    defaultModel: params.defaultModel,
-    fallbackModels: params.fallbackModels,
-    agentId: params.agentId,
-    manifestPlugins: params.manifestPlugins,
-  });
-  return getModelRefStatusFromAllowedSet({
-    catalog: params.catalog,
-    ref: params.ref,
-    allowed,
-  });
 }
 
 /** Resolve a requested model string only if it is allowed by the supplied status check. */
@@ -1513,21 +1466,6 @@ export function resolveHooksGmailModel(
   return resolved?.ref ?? null;
 }
 
-export function normalizeModelSelection(value: unknown): string | undefined {
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    return trimmed || undefined;
-  }
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  const primary = (value as { primary?: unknown }).primary;
-  if (typeof primary === "string" && primary.trim()) {
-    return primary.trim();
-  }
-  return undefined;
-}
-
 const DEFAULT_MODEL_POLICY_ALLOW_CONFIG_PATH = "agents.defaults.modelPolicy.allow";
 const AGENT_MODEL_POLICY_ALLOW_CONFIG_PATH = "agents.entries.*.modelPolicy.allow";
 export const LEGACY_MODEL_POLICY_ALLOW_CONFIG_PATH = "agents.defaults.models";
@@ -1693,7 +1631,6 @@ export type ModelVisibilityPolicy = {
   hasProviderWildcards: boolean;
   allowConfigPath?: string | null;
   allowRepairConfigPath: string;
-  automaticFallbackKeys: ReadonlySet<string>;
   allowsKey: (key: string) => boolean;
   allows: (ref: { provider: string; model: string }) => boolean;
   allowsByWildcard: (ref: { provider: string; model: string }) => boolean;
@@ -1743,38 +1680,11 @@ export function createModelVisibilityPolicyWithFallbacks(
     allowPluginNormalization?: boolean;
   } & ModelManifestNormalizationContext,
 ): ModelVisibilityPolicy {
-  const visibility = parseConfiguredModelVisibilityEntries({
-    cfg: params.cfg,
-    agentId: params.agentId,
-  });
+  const prepared = prepareModelPolicy(params);
+  const { visibility, policyAliasIndex, selectionAliasIndex, configuredCatalog } = prepared;
   const wildcardModelKeys = visibility.wildcardModelKeys;
-  const policyAliasAgentId = resolvePolicyAliasAgentId(visibility.configPath, params.agentId);
-  const policyAliasIndex = buildModelAliasIndex({
-    cfg: params.cfg,
-    defaultProvider: params.defaultProvider,
-    agentId: policyAliasAgentId,
-    allowManifestNormalization: params.allowManifestNormalization,
-    allowPluginNormalization: params.allowPluginNormalization,
-    manifestPlugins: params.manifestPlugins,
-  });
-  const selectionAliasIndex =
-    params.agentId && policyAliasAgentId !== params.agentId
-      ? buildModelAliasIndex({
-          cfg: params.cfg,
-          defaultProvider: params.defaultProvider,
-          agentId: params.agentId,
-          allowManifestNormalization: params.allowManifestNormalization,
-          allowPluginNormalization: params.allowPluginNormalization,
-          manifestPlugins: params.manifestPlugins,
-        })
-      : policyAliasIndex;
-  const allowed = buildAllowedModelSetWithFallbacks({
-    ...params,
-    aliasIndex: policyAliasIndex,
-    selectionAliasIndex,
-    visibility,
-  });
-  const configuredKeys = new Set(allowed.configuredCatalog.map(modelCatalogLogicalKey));
+  const allowed = buildAllowedModelSetFromPrepared(params, prepared);
+  const configuredKeys = new Set(configuredCatalog.map(modelCatalogLogicalKey));
   const retainedKeys = new Set<string>();
   const addConfiguredRef = (
     raw: string | undefined,
@@ -1805,9 +1715,14 @@ export function createModelVisibilityPolicyWithFallbacks(
     if (retained) {
       retainedKeys.add(key);
     }
+    return resolved.ref;
   };
+  const exactConfiguredKeys = new Set<string>();
   for (const raw of visibility.exactModelRefs) {
-    addConfiguredRef(raw, false, policyAliasIndex);
+    const resolved = addConfiguredRef(raw, false, policyAliasIndex);
+    if (resolved) {
+      exactConfiguredKeys.add(modelKey(resolved.provider, resolved.model));
+    }
   }
   for (const raw of params.additionalConfiguredModelRefs ?? []) {
     addConfiguredRef(raw, false, selectionAliasIndex);
@@ -1820,22 +1735,6 @@ export function createModelVisibilityPolicyWithFallbacks(
   }
   const allowsKey = (key: string): boolean =>
     allowed.allowAny || isModelKeyAllowedBySet(allowed.allowedKeys, key);
-  const exactConfiguredKeys = new Set<string>();
-  for (const raw of visibility.exactModelRefs) {
-    const resolved = resolveModelRefFromString({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      raw,
-      defaultProvider: params.defaultProvider,
-      aliasIndex: policyAliasIndex,
-      allowManifestNormalization: params.allowManifestNormalization,
-      allowPluginNormalization: params.allowPluginNormalization,
-      manifestPlugins: params.manifestPlugins,
-    })?.ref;
-    if (resolved) {
-      exactConfiguredKeys.add(modelKey(resolved.provider, resolved.model));
-    }
-  }
   const policy: ModelVisibilityPolicy = {
     allowAny: allowed.allowAny,
     allowedCatalog: allowed.allowedCatalog,
@@ -1850,7 +1749,6 @@ export function createModelVisibilityPolicyWithFallbacks(
     hasProviderWildcards: wildcardModelKeys.size > 0,
     allowConfigPath: visibility.configPath,
     allowRepairConfigPath: visibility.repairConfigPath,
-    automaticFallbackKeys: allowed.automaticFallbackKeys,
     allowsKey,
     allows: (ref) => allowsKey(modelKey(ref.provider, ref.model)),
     allowsByWildcard: (ref) =>

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -5,7 +5,6 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-export { resolvePrimaryStringValue as normalizeModelSelection } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog, stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import {
@@ -35,6 +34,8 @@ import {
   normalizeProviderId,
 } from "./model-ref-shared.js";
 import { findNormalizedProviderValue, parseModelRef } from "./model-selection-normalize.js";
+
+export { resolvePrimaryStringValue as normalizeModelSelection } from "@openclaw/normalization-core/string-coerce";
 
 // Shared model-selection helpers for config aliases, allowlists, provider
 // inference, and configured catalog rows used by CLI and runtime selectors.
@@ -1690,9 +1691,9 @@ export function createModelVisibilityPolicyWithFallbacks(
     raw: string | undefined,
     retained: boolean,
     aliasIndex: ModelAliasIndex,
-  ) => {
+  ): ModelRef | undefined => {
     if (!raw?.trim() || parseModelPolicyWildcardRef(raw)) {
-      return;
+      return undefined;
     }
     const resolved = resolveModelRefFromString({
       cfg: params.cfg,
@@ -1705,7 +1706,7 @@ export function createModelVisibilityPolicyWithFallbacks(
       manifestPlugins: params.manifestPlugins,
     });
     if (!resolved) {
-      return;
+      return undefined;
     }
     const key = modelCatalogLogicalKey({
       provider: resolved.ref.provider,

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -1510,9 +1510,6 @@ describe("model-selection", () => {
       expect(result.allowedKeys.has("openai/gpt-4o")).toBe(true);
       expect(result.allowedKeys.has("anthropic/claude-sonnet-4-6")).toBe(false);
       expect(result.allowedKeys.has("google/gemini-3.1-pro-preview")).toBe(false);
-      expect(result.automaticFallbackKeys).toEqual(
-        new Set(["anthropic/claude-sonnet-4-6", "google/gemini-3.1-pro-preview"]),
-      );
       expect(result.allowAny).toBe(false);
     });
 
@@ -1530,7 +1527,7 @@ describe("model-selection", () => {
       expect(result.allowAny).toBe(false);
     });
 
-    it("prefers per-agent fallback overrides when agentId is provided", () => {
+    it("keeps per-agent fallback overrides out of explicit selection", () => {
       const cfg = createAgentFallbackConfig({
         fallbacks: ["google/gemini-3-pro"],
         agentFallbacks: ["anthropic/claude-sonnet-4-6"],
@@ -1547,7 +1544,6 @@ describe("model-selection", () => {
       expect(result.allowedKeys.has("openai/gpt-4o")).toBe(true);
       expect(result.allowedKeys.has("anthropic/claude-sonnet-4-6")).toBe(false);
       expect(result.allowedKeys.has("google/gemini-3.1-pro-preview")).toBe(false);
-      expect(result.automaticFallbackKeys).toEqual(new Set(["anthropic/claude-sonnet-4-6"]));
       expect(result.allowAny).toBe(false);
     });
   });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -27,7 +27,6 @@ import {
 } from "./model-selection-config.js";
 import { findNormalizedProviderValue, parseModelRef } from "./model-selection-normalize.js";
 import { resolvePersistedOverrideModelRef } from "./model-selection-persisted.js";
-export { resolveAllowedModelRefCore as resolveAllowedModelRef } from "./model-selection-resolve.js";
 import {
   buildConfiguredModelCatalog,
   buildModelAliasIndex,
@@ -40,6 +39,7 @@ import {
   resolveModelRefFromString,
   type ModelAliasIndex,
 } from "./model-selection-shared.js";
+export { resolveAllowedModelRefCore as resolveAllowedModelRef } from "./model-selection-resolve.js";
 export { buildAllowedModelSet } from "./model-selection-shared.js";
 export {
   resolveThinkingDefault,

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -27,12 +27,8 @@ import {
 } from "./model-selection-config.js";
 import { findNormalizedProviderValue, parseModelRef } from "./model-selection-normalize.js";
 import { resolvePersistedOverrideModelRef } from "./model-selection-persisted.js";
+export { resolveAllowedModelRefCore as resolveAllowedModelRef } from "./model-selection-resolve.js";
 import {
-  resolveAllowedModelRefCore as resolveAllowedModelRefInternal,
-  resolveConfiguredModelFallbacks,
-} from "./model-selection-resolve.js";
-import {
-  buildAllowedModelSetWithFallbacks,
   buildConfiguredModelCatalog,
   buildModelAliasIndex,
   inferUniqueProviderFromConfiguredModels,
@@ -44,6 +40,7 @@ import {
   resolveModelRefFromString,
   type ModelAliasIndex,
 } from "./model-selection-shared.js";
+export { buildAllowedModelSet } from "./model-selection-shared.js";
 export {
   resolveThinkingDefault,
   resolveThinkingDefaultWithRuntimeCatalog,
@@ -264,7 +261,7 @@ export function resolveSubagentSpawnModelSelection(params: {
     return configured;
   }
   const raw =
-    normalizeModelSelection(resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model)) ??
+    resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model) ??
     `${runtimeDefault.provider}/${runtimeDefault.model}`;
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg,
@@ -303,51 +300,6 @@ export function resolveConfiguredSubagentSpawnModelSelection(params: {
     defaultProvider,
   });
   return resolveModelThroughAliases(raw, aliasIndex);
-}
-
-export function buildAllowedModelSet(
-  params: {
-    cfg: OpenClawConfig;
-    catalog: ModelCatalogEntry[];
-    defaultProvider: string;
-    defaultModel?: string;
-    agentId?: string;
-  } & ModelManifestNormalizationContext,
-): {
-  allowAny: boolean;
-  allowedCatalog: ModelCatalogEntry[];
-  allowedKeys: Set<string>;
-  automaticFallbackKeys: Set<string>;
-} {
-  return buildAllowedModelSetWithFallbacks({
-    cfg: params.cfg,
-    catalog: params.catalog,
-    defaultProvider: params.defaultProvider,
-    defaultModel: params.defaultModel,
-    agentId: params.agentId,
-    fallbackModels: resolveConfiguredModelFallbacks({
-      cfg: params.cfg,
-      agentId: params.agentId,
-    }),
-    manifestPlugins: params.manifestPlugins,
-  });
-}
-
-export function resolveAllowedModelRef(
-  params: {
-    cfg: OpenClawConfig;
-    catalog: ModelCatalogEntry[];
-    raw: string;
-    defaultProvider: string;
-    defaultModel?: string;
-    agentId?: string;
-  } & ModelManifestNormalizationContext,
-):
-  | { ref: ModelRef; key: string }
-  | {
-      error: string;
-    } {
-  return resolveAllowedModelRefInternal(params);
 }
 
 /** Default reasoning level when session/directive do not set it: "on" if model supports reasoning, else "off". */

--- a/src/agents/model-visibility-policy.test.ts
+++ b/src/agents/model-visibility-policy.test.ts
@@ -150,7 +150,7 @@ describe("explicit model visibility policy", () => {
         (entry) => entry.provider === "external" && entry.id === "sensitive",
       ),
     ).toBe(false);
-    expect(policy.automaticFallbackKeys).toEqual(new Set(["external/sensitive"]));
+    expect(policy.retainedKeys).toEqual(new Set(["openai/gpt-5.5", "external/sensitive"]));
   });
 
   it("allows a configured fallback when the explicit policy also allows it", () => {

--- a/src/auto-reply/reply/model-selection-directive.test.ts
+++ b/src/auto-reply/reply/model-selection-directive.test.ts
@@ -47,7 +47,6 @@ describe("resolveModelDirectiveSelection", () => {
       raw: "external/sensitive",
     });
 
-    expect(policy.automaticFallbackKeys).toEqual(new Set(["external/sensitive"]));
     expect(policy.allowedKeys.has("external/sensitive")).toBe(false);
     expect(result.selection).toBeUndefined();
     expect(result.error).toContain('Model "external/sensitive" is not allowed.');

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -4,10 +4,9 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { resolveAgentDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import {
-  buildAllowedModelSetWithFallbacks,
+  buildAllowedModelSet,
   isModelKeyAllowedBySet,
 } from "../../agents/model-selection-shared.js";
-import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions.js";
 import { SessionWorkStartInvalidatedError } from "../../config/sessions/lifecycle.js";
 import {
@@ -59,31 +58,14 @@ async function loadResetModelCatalog(params: {
   });
 }
 
-async function resolveResetFallbackModels(params: {
-  cfg: OpenClawConfig;
-  agentId?: string;
-  agentDir?: string;
-  workspaceDir?: string;
-}): Promise<string[]> {
-  if (params.agentId) {
-    const { resolveAgentModelFallbacksOverride } = await import("../../agents/agent-scope.js");
-    const override = resolveAgentModelFallbacksOverride(params.cfg, params.agentId);
-    if (override !== undefined) {
-      return override;
-    }
-  }
-  return resolveAgentModelFallbackValues(params.cfg.agents?.defaults?.model);
-}
-
-async function buildResetAllowedModelKeys(params: {
+function buildResetAllowedModelKeys(params: {
   cfg: OpenClawConfig;
   catalog: ModelCatalogEntry[];
   defaultProvider: string;
   defaultModel?: string;
-  fallbackModels: readonly string[];
   agentId?: string;
-}): Promise<Set<string>> {
-  const allowed = buildAllowedModelSetWithFallbacks(params);
+}): Set<string> {
+  const allowed = buildAllowedModelSet(params);
   const defaultModel = params.defaultModel?.trim();
   if (allowed.allowAny && defaultModel) {
     allowed.allowedKeys.add(modelKey(normalizeProviderId(params.defaultProvider), defaultModel));
@@ -221,15 +203,11 @@ export async function applyResetModelOverride(params: {
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
     }));
-  const allowedModelKeys = await buildResetAllowedModelKeys({
+  const allowedModelKeys = buildResetAllowedModelKeys({
     cfg: params.cfg,
     catalog,
     defaultProvider: params.defaultProvider,
     defaultModel: params.defaultModel,
-    fallbackModels: await resolveResetFallbackModels({
-      cfg: params.cfg,
-      agentId: params.agentId,
-    }),
     agentId: params.agentId,
   });
   if (allowedModelKeys.size === 0) {

--- a/src/commands/agent-command.test-mocks.ts
+++ b/src/commands/agent-command.test-mocks.ts
@@ -176,7 +176,6 @@ vi.mock("../agents/model-selection.js", () => {
         allowedKeys: refs,
         allowedCatalog: [],
         allowAny: policyRefs.length === 0,
-        automaticFallbackKeys: new Set<string>(),
       };
     }),
     createModelVisibilityPolicy: vi.fn(
@@ -210,7 +209,6 @@ vi.mock("../agents/model-selection.js", () => {
           hasProviderWildcards: wildcardModelKeys.size > 0,
           allowConfigPath: policy.configPath,
           allowRepairConfigPath: "agents.defaults.modelPolicy.allow",
-          automaticFallbackKeys: new Set<string>(),
           allowsKey,
           allows: ({ provider, model }: ModelRef) => allowsKey(modelKey(provider, model)),
           allowsByWildcard: ({ provider, model }: ModelRef) =>


### PR DESCRIPTION
## What Problem This Solves

Model selection and catalog visibility repeatedly prepare the same model policy, aliases, and catalog metadata. They also compute and forward an automatic-fallback set that no production code reads. This makes model handling harder to maintain and keeps redundant work in status, selection, and reset paths.

## Why This Change Was Made

Use one private preparation path and keep explicit selection authorization separate from automatic failover. Delete the unused fallback set, its reset-command resolver, forwarding wrappers, and the duplicate primary-model string normalizer. The existing fallback execution owner and catalog-retention path remain unchanged.

Policy aliases retain their policy owner's scope; selection/display aliases retain the selected agent's scope. Exact visibility refs are resolved once. Existing callable names remain exported, and the public allowed-set result retains the three fields published in v2026.7.1-2. The removed fallback property is absent throughout that stable tag and has no production readers on current main.

Production: **+91/-287 (net -196)**. Tests/support: **+4/-12 (net -8)**. One assertion-count baseline entry is reduced to match the deleted assertion; no new config, auth, persistence, SDK entrypoint, or default surface.

## User Impact

No intended behavior change. Model selection, inherited allowlists, per-agent aliases, configured fallback execution, and reset behavior keep their existing contracts with less duplicate code.

Release context: internal model-policy cleanup following #130381; no operator action required.

## Evidence

- Before-edit baseline: 191 selection/resolve/visibility/manifest-workspace/reset/directive tests passed.
- Rebuilt isolated CLI `models status --json --agent worker` matches its before-edit baseline: agent alias `approved -> lab/agent`, inherited allowed refs `lab/allowed` and `lab/primary`, automatic fallback `lab/fallback` retained but excluded from explicit selection.
- Independent Codex autoreview: no actionable findings.
- All 415 tests across 12 selection, manifest, visibility, plugin-runtime, reset, directive, fallback, cron, and CLI-status files passed.
- Changed-file checks passed ratchets, format, boundaries, dead-export scans, and production/test types. Import-order lint and return consistency are corrected, targeted lint passes, and 153 selection/visibility tests pass again. All remaining selected guards passed, including script lint, database-first, runtime sidecar, import cycles, webhook and pairing checks. These were completed across the original runs plus targeted correction/remaining-guard runs, not one uninterrupted full run.
- Fresh Codex review of the lint correction has no actionable findings. [Exact-head CI run 33015565242](https://github.com/openclaw/openclaw/actions/runs/33015565242) passed on `57cbb38e9dca602f7583498bb0afeaf55674a6e0`; the prior run failed lint.

Focused test command:

```sh
node scripts/run-vitest.mjs src/agents/model-selection.test.ts src/agents/model-selection-resolve.test.ts src/agents/model-visibility-policy.test.ts src/agents/model-selection-manifest-workspace.test.ts src/auto-reply/reply/session-reset-model.test.ts src/auto-reply/reply/model-selection-directive.test.ts src/agents/model-selection.plugin-runtime.test.ts src/agents/model-catalog-visibility.test.ts src/agents/model-fallback.test.ts src/cron/isolated-agent/run.cron-model-override.test.ts src/cron/isolated-agent/run.model-policy-config-preserved.test.ts src/commands/models/list.status.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/model-selection-shared.ts src/agents/model-selection.ts
```

No provider request transport or live Gateway configuration changed. The CLI proof uses only synthetic configuration and isolated state.
