### PR TITLE
refactor(plugins): derive private config types from schemas

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -313,7 +313,7 @@ extensions/diagnostics-otel/src/service-propagation.ts	2
 extensions/diagnostics-otel/src/service-trace-context.ts	1
 extensions/diagnostics-otel/src/service.ts	1
 extensions/diagnostics-prometheus/src/service.ts	1
-extensions/diffs/src/config.ts	5
+extensions/diffs/src/config.ts	4
 extensions/diffs/src/language-hints.ts	9
 extensions/diffs/src/plugin.ts	4
 extensions/diffs/src/store.ts	3
@@ -875,7 +875,6 @@ extensions/msteams/src/sqlite-state.ts	1
 extensions/msteams/src/sso-token-store.ts	2
 extensions/msteams/src/token-response.ts	2
 extensions/msteams/src/user-agent.ts	1
-extensions/mxc/src/config.ts	1
 extensions/mxc/src/fs-bridge.ts	1
 extensions/nextcloud-talk/src/approval-auth.ts	1
 extensions/nextcloud-talk/src/channel.ts	2
@@ -958,7 +957,6 @@ extensions/openrouter/usage.ts	2
 extensions/openrouter/video-generation-provider.ts	1
 extensions/openrouter/video-model-catalog.ts	1
 extensions/openshell/src/backend.ts	2
-extensions/openshell/src/config.ts	1
 extensions/openshell/src/fs-bridge.ts	2
 extensions/parallel/src/parallel-free-web-search-provider.runtime.ts	1
 extensions/parallel/src/parallel-search-normalize.ts	1

--- a/extensions/diffs/src/config.ts
+++ b/extensions/diffs/src/config.ts
@@ -21,39 +21,7 @@ import {
 } from "./types.js";
 import { normalizeViewerBaseUrl } from "./url.js";
 
-type DiffsPluginConfig = {
-  viewerBaseUrl?: string;
-  defaults?: {
-    fontFamily?: string;
-    fontSize?: number;
-    lineSpacing?: number;
-    layout?: DiffLayout;
-    showLineNumbers?: boolean;
-    diffIndicators?: DiffIndicators;
-    wordWrap?: boolean;
-    background?: boolean;
-    theme?: DiffTheme;
-    fileFormat?: DiffOutputFormat;
-    fileQuality?: DiffImageQualityPreset;
-    fileScale?: number;
-    fileMaxWidth?: number;
-    /** @deprecated Use fileFormat. */
-    format?: DiffOutputFormat;
-    /** @deprecated Use fileFormat. */
-    imageFormat?: DiffOutputFormat;
-    /** @deprecated Use fileQuality. */
-    imageQuality?: DiffImageQualityPreset;
-    /** @deprecated Use fileScale. */
-    imageScale?: number;
-    /** @deprecated Use fileMaxWidth. */
-    imageMaxWidth?: number;
-    mode?: DiffMode;
-    ttlSeconds?: number;
-  };
-  security?: {
-    allowRemoteViewer?: boolean;
-  };
-};
+type DiffsPluginConfig = z.input<typeof DiffsPluginJsonSchemaSource>;
 
 const DEFAULT_IMAGE_QUALITY_PROFILES = {
   standard: {
@@ -192,7 +160,7 @@ const diffsPluginConfigSchemaBase = buildPluginConfigSchema(DiffsPluginJsonSchem
     if (result.success) {
       return {
         success: true,
-        data: buildDiffsPluginConfigShape(result.data as DiffsPluginConfig),
+        data: buildDiffsPluginConfigShape(result.data),
       };
     }
     return {

--- a/extensions/file-transfer/src/node-host/dir-list.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-list.test.ts
@@ -67,11 +67,6 @@ describe("handleDirList — happy path", () => {
       await fs.mkdir(replacement);
       await fs.writeFile(path.join(approved, "approved.txt"), "approved");
       await fs.writeFile(path.join(replacement, "secret.txt"), "secret");
-      await Promise.all(
-        Array.from({ length: 5000 }, (_, index) =>
-          fs.writeFile(path.join(approved, `f-${String(index).padStart(4, "0")}`), ""),
-        ),
-      );
       await fs.symlink(approved, current);
       const approvedStats = await fs.stat(approved, { bigint: true });
 
@@ -80,40 +75,50 @@ describe("handleDirList — happy path", () => {
         expectedCanonicalPath: approved,
         expectedDevice: String(approvedStats.dev),
         expectedInode: String(approvedStats.ino),
-        maxEntries: 5001,
+        maxEntries: 10,
         offset: 0,
       });
-      const child = spawn(command[0]!, command.slice(1), {
-        stdio: ["ignore", "pipe", "pipe"],
-      });
+      // Retarget after the real chdir, before the unchanged worker checks and
+      // enumerates its bound directory. Polling /proc can miss the entire child.
+      const retargetAfterBinding = `(() => {
+        const fs = require("node:fs");
+        const chdir = process.chdir;
+        process.chdir = (directory) => {
+          chdir(directory);
+          process.chdir = chdir;
+          fs.unlinkSync(${JSON.stringify(current)});
+          fs.symlinkSync(${JSON.stringify(replacement)}, ${JSON.stringify(current)});
+        };
+      })();`;
+      const child = spawn(
+        command[0]!,
+        [command[1]!, retargetAfterBinding + command[2]!, ...command.slice(3)],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
       const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
       child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+      child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
       const exit = new Promise<number | null>((resolve, reject) => {
         child.once("error", reject);
-        child.once("exit", resolve);
+        child.once("close", resolve);
       });
-
-      let observedBoundCwd = false;
-      for (let attempt = 0; attempt < 200 && child.exitCode === null; attempt += 1) {
-        const cwd = await fs.readlink(`/proc/${child.pid}/cwd`).catch(() => "");
-        if (cwd === approved) {
-          observedBoundCwd = true;
-          break;
+      try {
+        expect(await exit, Buffer.concat(stderr).toString("utf8")).toBe(0);
+        expect(await fs.readlink(current)).toBe(replacement);
+        const result = JSON.parse(Buffer.concat(stdout).toString("utf8")) as {
+          entries: Array<{ name: string }>;
+        };
+        expect(result.entries.some((entry) => entry.name === "approved.txt")).toBe(true);
+        expect(result.entries.some((entry) => entry.name === "secret.txt")).toBe(false);
+      } finally {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGKILL");
         }
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 1);
-        });
+        await exit.catch(() => undefined);
       }
-      expect(observedBoundCwd).toBe(true);
-      await fs.unlink(current);
-      await fs.symlink(replacement, current);
-
-      expect(await exit).toBe(0);
-      const result = JSON.parse(Buffer.concat(stdout).toString("utf8")) as {
-        entries: Array<{ name: string }>;
-      };
-      expect(result.entries.some((entry) => entry.name === "approved.txt")).toBe(true);
-      expect(result.entries.some((entry) => entry.name === "secret.txt")).toBe(false);
     },
   );
 

--- a/extensions/mxc/src/config.ts
+++ b/extensions/mxc/src/config.ts
@@ -14,15 +14,6 @@ type MxcContainment = (typeof MXC_CONTAINMENTS)[number];
 
 type MxcNetworkMode = (typeof MXC_NETWORK_MODES)[number];
 
-type MxcPluginConfig = {
-  mxcBinaryPath?: string;
-  containment?: MxcContainment;
-  network?: MxcNetworkMode;
-  timeoutSeconds?: number;
-  debug?: boolean;
-  mxcPolicyPaths?: string[];
-};
-
 export type MxcConfig = {
   mxcBinaryPath?: string;
   containment: MxcContainment;
@@ -126,7 +117,7 @@ export function resolveConfig(value: unknown): MxcConfig {
     throw new Error(`Invalid mxc plugin config: ${message}`);
   }
 
-  const config = parsed.data as MxcPluginConfig;
+  const config = parsed.data;
   const resolved: MxcConfig = {
     mxcBinaryPath: config.mxcBinaryPath,
     containment: config.containment ?? DEFAULT_CONTAINMENT,

--- a/extensions/openshell/src/config.ts
+++ b/extensions/openshell/src/config.ts
@@ -8,22 +8,6 @@ import {
 import { MAX_TIMER_TIMEOUT_SECONDS } from "openclaw/plugin-sdk/number-runtime";
 import { z } from "zod";
 
-type OpenShellPluginConfig = {
-  mode?: "mirror" | "remote";
-  command?: string;
-  gateway?: string;
-  gatewayEndpoint?: string;
-  workspace?: string;
-  from?: string;
-  policy?: string;
-  providers?: string[];
-  gpu?: boolean;
-  autoProviders?: boolean;
-  remoteWorkspaceDir?: string;
-  remoteAgentWorkspaceDir?: string;
-  timeoutSeconds?: number;
-};
-
 export type ResolvedOpenShellPluginConfig = {
   mode: "mirror" | "remote";
   command: string;
@@ -193,7 +177,7 @@ export function resolveOpenShellPluginConfig(value: unknown): ResolvedOpenShellP
     const message = formatPluginConfigIssue(parsed.error.issues[0]);
     throw new Error(`Invalid openshell plugin config: ${message}`);
   }
-  const cfg = parsed.data as OpenShellPluginConfig;
+  const cfg = parsed.data;
   const mode = cfg.mode ?? DEFAULT_MODE;
   return {
     mode,


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of duplicate private configuration types in the Diffs, OpenShell, and MXC plugins. Hand-maintained input shapes repeat information already owned by the runtime schemas, while assertions hide the schemas' inferred result types.

## Why This Change Was Made

Diffs derives its private input shape from the existing Zod schema. OpenShell and MXC use their already-validated parse results directly and delete the unused private type copies. Runtime schema definitions, defaults, legacy aliases, normalization, permissions, manifests, and exported resolved types are unchanged. The assertion-safety baseline shrinks by exactly the three removed casts.

The first hosted CI run also exposed a pre-existing timing-dependent file-transfer test. Its parent process tried to observe a short-lived child's working directory through 200 polling attempts and 5,000 padding files. The assertion failed before the test retargeted the symlink; it did not observe an unsafe directory listing. The repaired test preserves the entire real worker program, prefixes a child-local wrapper that performs the real `chdir` and then retargets the fixture symlink synchronously, and checks the actual retarget plus the approved-only listing. All canonical-path, inode, enumeration, and metadata checks still execute unchanged. The child is joined and cleaned up before fixture removal.

Test provenance: the polling-based regression was introduced in #129762, authored and merged by @joshavant on August 26, 2026 (`424521a3d3924c943f441da1b799f3563450662f`). The regression's security invariant is retained; only its race-prone scheduling is replaced.

The separate Windows packaging failure was already fixed by #130387. This branch was rebased onto a main revision containing that fix; no duplicate packaging repair is included.

Production: **+4/-61, net -57 lines**. Test-only CI repair: +35/-30, net +5. Assertion baseline: +1/-3, net -2, excluded from production. No generated, lockfile, dependency, or documentation changes. Exported input types in other plugins were explicitly excluded because stricter consumer compiler settings could make their optional-property contract observable.

## User Impact

No user-visible or public API change. Operators retain the exact same accepted configuration, errors, defaults, and security settings. This is AI-assisted internal maintenance.

## Evidence

- Existing configuration tests pass before and after: Diffs 33, OpenShell 18, MXC 8 assertions. These include manifest/schema equality, legacy Diffs aliases, viewer URL restrictions, managed OpenShell paths, MXC containment/network settings, and timeout bounds.
- Complete before/after TypeScript output is byte-identical for both JavaScript and public declarations in all three modules, including with `strict` and `exactOptionalPropertyTypes` enabled. Declaration sizes are 1,144 / 645 / 726 bytes respectively; emission diagnostics are zero.
- An in-memory semantic TypeScript program using the pinned, installed Zod 4.4.3 declarations proves equality and bidirectional assignability of the old and inferred private shapes under repository compiler settings, with zero diagnostics. Stricter exact-optional private-field widening does not escape into any public declaration.
- Real Linux Node 24.19.0 proof: [Blacksmith Testbox run 33023814464](https://github.com/openclaw/openclaw/actions/runs/33023814464), lease `tbx_01m106s7cymkmzcevn49bhc1xf`, wrapper terminal exit 0. Six focused files passed all 88 assertions, including both Linux-only directory-binding cases and directory-fetch/invocation-policy siblings.
- The same exact Linux candidate passed 20 real-child retarget iterations. An in-memory negative control changed enumeration and metadata reads to absolute paths under the same retarget hook; it returned the replacement secret and a standalone exact-entry assertion rejected it. The unchanged Vitest predicates also reject that result; this was not a literal mutated Vitest run. This proves test sensitivity, not an observed production vulnerability. The original worker program bytes are preserved.
- Exact remote source identity: public base `02a60e0d871480b7c9db87cb59eec5583e2ec3ce`, candidate tree `b12a89187f9a7b241ba47861f30d3f5470293144`, full five-file patch SHA-256 `09b1690fc0dc475ea145217c87b952b74b714c1286779e691dc604ca310f1b46`. The canonical complete dependency fingerprint matched the hydrated install, all workspace package source trees matched, and all 772 actual Vitest workspace/SDK aliases resolved into the owned candidate. The temporary remote worktree was removed and the lease stopped after success.
- Assertion-safety ratchet passed on the exact Linux candidate: 4,238 governed files / 13,245 grandfathered assertions. Formatting and `git diff --check` pass.
- Complete five-file pre-commit Codex review finished successfully with no actionable findings (confidence 0.98). Its single, untruncated pass included the full patch and 19 complete owner, caller, worker, test, and contract files. Commit `7e280b0d1264d420f0bb01f4eb39670356406802` preserves the reviewed full candidate tree exactly. A separate authenticated read-only Codex review of that published head also finished successfully with no findings (confidence 0.98), covering the complete five-file patch, 26 whole context files, and both actual Linux proof datasets. Source identity remained unchanged after review exit.
- [Ordinary pull-request CI run 33025280107](https://github.com/openclaw/openclaw/actions/runs/33025280107) completed successfully on exact head `7e280b0d1264d420f0bb01f4eb39670356406802`, including both Windows test lanes, all three changed-plugin configuration lanes, assertion-baseline ratchets, production/test types, lint, dependencies, package boundaries, and `openclaw/ci-gate`.

Focused command: `OPENCLAW_VITEST_MAX_WORKERS=3 node scripts/run-vitest.mjs extensions/diffs/src/config.test.ts extensions/openshell/src/config.test.ts extensions/mxc/test/config.test.ts extensions/file-transfer/src/node-host/dir-list.test.ts extensions/file-transfer/src/node-host/dir-fetch.test.ts extensions/file-transfer/src/shared/node-invoke-policy.dir-list.test.ts`. Ratchet command: `node --import tsx scripts/check-assertion-safety-ratchet.mts --base 02a60e0d871480b7c9db87cb59eec5583e2ec3ce`.

ClawSweeper's earlier replay showed all 33 + 18 + 8 configuration tests passing, but its output matcher incorrectly expected one aggregate `59 passed` line. The repository wrapper prints per-shard totals and a final shard summary. No test output was rewritten to satisfy that matcher. Its rank-up request to investigate the failed Windows and changed-extension jobs is addressed by the canonical Windows fix and deterministic test repair above; the new exact-head normal CI must still be green before native preparation and merge.

Local shared dependency drift previously prevented full declaration preparation; no local dependency reconciliation was performed. Clean installed hosted lint/type gates remain required. No new live-provider behavior or package boundary is introduced, and emitted runtime code and public declarations are unchanged.

Latest ClawSweeper review (August 27, 00:03 UTC) reviewed this exact head and found no actionable patch or security findings; its rank-up request to finish exact-head hosted CI is now satisfied by the successful run above. Its newer live replay printed all 73 assertions passing across four files and a final successful three-shard summary in 31.93 seconds, but its terminal harness had a 30-second wait and expected an individual test name not printed by the normal reporter. The independent 88-assertion Linux run and exact-head hosted CI provide completed proof; no output, timeout, or assertion was altered for that replay. Its generic stored-data warning points only to test-fixture serialization in `dir-list.test.ts`: no production persistence, schema, migration, or upgrade contract changed.
