### PR TITLE
fix(ui): show dashboard replies when final events omit messages

### DIFF
--- a/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
@@ -1,0 +1,116 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { controlUiSessionPath, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI dashboard final reply recovery",
+  startServerBeforeBrowser: true,
+});
+
+const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
+const proofDir = path.resolve(".artifacts/control-ui-e2e/dashboard-final-reply-recovery");
+
+function dashboardPath(): string {
+  return controlUiSessionPath(sessionKey).replace(/^\/chat\//u, "/dashboard/");
+}
+
+suite.define(() => {
+  it("projects a durable reply when the dashboard terminal event has no message", async () => {
+    const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
+    if (recordProof) {
+      await mkdir(proofDir, { recursive: true });
+    }
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      viewport: { height: 900, width: 1280 },
+      ...(recordProof
+        ? { recordVideo: { dir: proofDir, size: { height: 900, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      sessionKey,
+      featureMethods: ["board.get", "chat.metadata", "chat.startup"],
+      historyMessages: [],
+      methodResponses: {
+        "board.get": {
+          revision: 1,
+          sessionKey,
+          tabs: [{ tabId: "main", title: "Nightly Disk Cleanup", position: 0, chatDock: "right" }],
+          widgets: [],
+        },
+        "sessions.list": {
+          count: 1,
+          defaults: { contextTokens: null, model: "gpt-5.6-sol", modelProvider: "openai" },
+          path: "",
+          sessions: [
+            {
+              boardFace: "dashboard",
+              key: sessionKey,
+              kind: "direct",
+              label: "Nightly Disk Cleanup",
+              updatedAt: Date.now(),
+            },
+          ],
+          ts: Date.now(),
+        },
+      },
+    });
+
+    try {
+      await page.goto(new URL(dashboardPath(), suite.server.baseUrl).href);
+      const prompt = "Why did Done appear without my reply?";
+      const finalText = "The durable dashboard reply is visible after Done.";
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill(prompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+      const send = await gateway.waitForRequest("chat.send");
+      const params = send.params as Record<string, unknown>;
+      const runId = String(params.idempotencyKey ?? "");
+      expect(runId).not.toBe("");
+
+      await gateway.setHistoryMessages([
+        {
+          role: "user",
+          content: [{ type: "text", text: prompt }],
+          timestamp: 1,
+          __openclaw: { id: "dashboard-prompt", idempotencyKey: `${runId}:user`, seq: 1 },
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: finalText }],
+          stopReason: "stop",
+          timestamp: 2,
+          __openclaw: { id: "dashboard-final", runId, seq: 2 },
+        },
+      ]);
+      const historyCount = (await gateway.getRequests("chat.history")).length;
+      await gateway.emitGatewayEvent("chat", {
+        runId,
+        sessionKey,
+        state: "final",
+      });
+
+      await expect
+        .poll(async () => (await gateway.getRequests("chat.history")).length)
+        .toBeGreaterThan(historyCount);
+      const visibleFinal = page.locator(".chat-thread-inner .chat-text", { hasText: finalText });
+      await visibleFinal.waitFor({ timeout: 10_000 });
+      await expect.poll(() => visibleFinal.count()).toBe(1);
+      if (recordProof) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(proofDir, "dashboard-final-reply-recovered.png"),
+        });
+      }
+    } finally {
+      const video = page.video();
+      await context.close();
+      if (recordProof && video) {
+        await video.saveAs(path.join(proofDir, "dashboard-final-reply-recovered.webm"));
+      }
+    }
+  });
+});

--- a/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
@@ -68,7 +68,7 @@ suite.define(() => {
       await page.getByRole("button", { name: "Send message" }).click();
       const send = await gateway.waitForRequest("chat.send");
       const params = send.params as Record<string, unknown>;
-      const runId = String(params.idempotencyKey ?? "");
+      const runId = typeof params.idempotencyKey === "string" ? params.idempotencyKey : "";
       expect(runId).not.toBe("");
 
       await gateway.setHistoryMessages([

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -973,6 +973,7 @@ export async function syncSelectedSessionMessageSubscription(
 
 type LoadChatHistoryOptions = {
   deferBranches?: boolean;
+  supersedeInFlight?: boolean;
   startup?: boolean;
 };
 
@@ -1590,6 +1591,7 @@ export async function loadChatHistory(
   // Live events replace the rendered array while their snapshot is pending;
   // only stable session and connection ownership may start another request.
   if (
+    opts.supersedeInFlight !== true &&
     inFlight.phase === "in-flight" &&
     inFlight.key === requestKey &&
     inFlight.client === client &&

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -483,6 +483,17 @@ export function handlePageGatewayEvent(
       void state.refreshSessionPullRequests?.({ refresh: true });
     }
     replayPendingSessionMessageReload(state, payload, isPresented);
+    if (
+      payload?.state === "final" &&
+      (payload.message === undefined || payload.message === null) &&
+      sessionMatches
+    ) {
+      // Lifecycle completion can arrive without a live assistant projection.
+      // Reconcile the durable transcript so Done never strands a persisted reply.
+      void loadChatHistory(state, { deferBranches: !isPresented() }).finally(() =>
+        state.requestUpdate?.(),
+      );
+    }
     if (terminalPayload) {
       if (outboxScope) {
         removeDeliveredQueuedChatSendForRun(state, terminalPayload.runId, outboxScope);

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -49,7 +49,11 @@ import {
   storedChatOutboxScopeKey,
   type StoredChatOutboxScope,
 } from "./composer-persistence.ts";
-import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
+import {
+  getChatSessionProjection,
+  readChatSessionProjectionScope,
+  reduceChatSessionProjection,
+} from "./history-merge.ts";
 import {
   reconcileChatRunFromCurrentSessionRow,
   reconcileChatRunFromSessionRow,
@@ -431,6 +435,19 @@ export function handlePageGatewayEvent(
     const sessionMatches = Boolean(
       payload && chatScopedEventSessionMatches(state, payload.sessionKey, payload.agentId),
     );
+    const recoveryRunId =
+      payload?.state === "final" &&
+      (payload.message === undefined || payload.message === null) &&
+      sessionMatches &&
+      typeof payload.runId === "string" &&
+      (!state.chatRunId || state.chatRunId === payload.runId)
+        ? payload.runId
+        : null;
+    const recoveryScope = recoveryRunId ? readChatSessionProjectionScope(state) : null;
+    const projectedRunBeforeEvent =
+      recoveryRunId && recoveryScope
+        ? getChatSessionProjection(state, state.chatMessages, recoveryScope).runs[recoveryRunId]
+        : undefined;
     if (
       payload?.state === "delta" &&
       typeof payload.runId === "string" &&
@@ -484,12 +501,14 @@ export function handlePageGatewayEvent(
     }
     replayPendingSessionMessageReload(state, payload, isPresented);
     if (
-      payload?.state === "final" &&
-      (payload.message === undefined || payload.message === null) &&
-      sessionMatches
+      recoveryRunId &&
+      recoveryScope &&
+      (projectedRunBeforeEvent === undefined || projectedRunBeforeEvent.status === "streaming") &&
+      getChatSessionProjection(state, state.chatMessages, recoveryScope).runs[recoveryRunId]
+        ?.status === "completed"
     ) {
-      // Lifecycle completion can arrive without a live assistant projection.
-      // Reconcile the durable transcript so Done never strands a persisted reply.
+      // Only the first owned completion can recover history. Replayed, yielded,
+      // or background-run terminals must not repeat I/O or disturb the foreground pane.
       void loadChatHistory(state, { deferBranches: !isPresented() }).finally(() =>
         state.requestUpdate?.(),
       );

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -200,7 +200,7 @@ function replayPendingSessionMessageReload(
   state: ChatPageHost,
   payload: ChatEventPayload | undefined,
   presentation: ChatPanePresentation,
-) {
+): boolean {
   const pendingSessionKey = state.pendingSessionMessageReloadSessionKey;
   const payloadSessionKey = payload?.sessionKey?.trim();
   if (
@@ -210,12 +210,13 @@ function replayPendingSessionMessageReload(
     !areUiSessionKeysEquivalent(payloadSessionKey, state.sessionKey) ||
     state.chatRunId
   ) {
-    return;
+    return false;
   }
   state.pendingSessionMessageReloadSessionKey = null;
   void loadChatHistory(state, { deferBranches: !presentation() }).finally(() =>
     state.requestUpdate?.(),
   );
+  return true;
 }
 
 function handleSessionsChangedEvent(
@@ -499,8 +500,13 @@ export function handlePageGatewayEvent(
     if (shouldRefreshPullRequests) {
       void state.refreshSessionPullRequests?.({ refresh: true });
     }
-    replayPendingSessionMessageReload(state, payload, isPresented);
+    const replayedPendingSessionReload = replayPendingSessionMessageReload(
+      state,
+      payload,
+      isPresented,
+    );
     if (
+      !replayedPendingSessionReload &&
       recoveryRunId &&
       recoveryScope &&
       (projectedRunBeforeEvent === undefined || projectedRunBeforeEvent.status === "streaming") &&

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -200,6 +200,7 @@ function replayPendingSessionMessageReload(
   state: ChatPageHost,
   payload: ChatEventPayload | undefined,
   presentation: ChatPanePresentation,
+  supersedeInFlight = false,
 ): boolean {
   const pendingSessionKey = state.pendingSessionMessageReloadSessionKey;
   const payloadSessionKey = payload?.sessionKey?.trim();
@@ -213,9 +214,10 @@ function replayPendingSessionMessageReload(
     return false;
   }
   state.pendingSessionMessageReloadSessionKey = null;
-  void loadChatHistory(state, { deferBranches: !presentation() }).finally(() =>
-    state.requestUpdate?.(),
-  );
+  void loadChatHistory(state, {
+    deferBranches: !presentation(),
+    supersedeInFlight,
+  }).finally(() => state.requestUpdate?.());
   return true;
 }
 
@@ -500,19 +502,20 @@ export function handlePageGatewayEvent(
     if (shouldRefreshPullRequests) {
       void state.refreshSessionPullRequests?.({ refresh: true });
     }
-    const replayedPendingSessionReload = replayPendingSessionMessageReload(
-      state,
-      payload,
-      isPresented,
-    );
-    if (
-      !replayedPendingSessionReload &&
+    const shouldRecoverMissingTerminal = Boolean(
       recoveryRunId &&
       recoveryScope &&
       (projectedRunBeforeEvent === undefined || projectedRunBeforeEvent.status === "streaming") &&
       getChatSessionProjection(state, state.chatMessages, recoveryScope).runs[recoveryRunId]
-        ?.status === "completed"
-    ) {
+        ?.status === "completed",
+    );
+    const replayedPendingSessionReload = replayPendingSessionMessageReload(
+      state,
+      payload,
+      isPresented,
+      shouldRecoverMissingTerminal,
+    );
+    if (!replayedPendingSessionReload && shouldRecoverMissingTerminal) {
       // Only the first owned completion can recover history. Replayed, yielded,
       // or background-run terminals must not repeat I/O or disturb the foreground pane.
       // The terminal boundary must observe a request started after persistence;

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -515,9 +515,12 @@ export function handlePageGatewayEvent(
     ) {
       // Only the first owned completion can recover history. Replayed, yielded,
       // or background-run terminals must not repeat I/O or disturb the foreground pane.
-      void loadChatHistory(state, { deferBranches: !isPresented() }).finally(() =>
-        state.requestUpdate?.(),
-      );
+      // The terminal boundary must observe a request started after persistence;
+      // an older coalesced snapshot can legitimately finish without the reply.
+      void loadChatHistory(state, {
+        deferBranches: !isPresented(),
+        supersedeInFlight: true,
+      }).finally(() => state.requestUpdate?.());
     }
     if (terminalPayload) {
       if (outboxScope) {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -538,11 +538,16 @@ describe("canonical session message recovery", () => {
   });
 
   it.each([
-    { name: "omitted", terminalMessage: undefined },
-    { name: "null", terminalMessage: null },
+    { name: "omitted", terminalMessage: undefined, startsActive: true },
+    { name: "null", terminalMessage: null, startsActive: true },
+    {
+      name: "omitted for an idle selected session",
+      terminalMessage: undefined,
+      startsActive: false,
+    },
   ])(
     "recovers the durable reply when the terminal message is $name",
-    async ({ terminalMessage }) => {
+    async ({ terminalMessage, startsActive }) => {
       const runId = "run-with-message-less-terminal";
       const replyText = "The durable reply must appear below Done.";
       const prompt = {
@@ -571,7 +576,7 @@ describe("canonical session message recovery", () => {
       const { state } = createSessionEventState({
         chatMessages: [prompt],
         chatHistoryPagination: { hasMore: false },
-        chatRunId: runId,
+        chatRunId: startsActive ? runId : null,
         chatStream: null,
         chatStreamSegments: [],
         chatToolMessages: [],
@@ -607,8 +612,69 @@ describe("canonical session message recovery", () => {
           { role: "assistant", text: replyText },
         ]),
       );
+
+      request.mockClear();
+      handlePageGatewayEvent(state, {
+        type: "event",
+        event: "chat",
+        payload: {
+          sessionKey: state.sessionKey,
+          runId,
+          state: "final",
+          message: terminalMessage,
+        },
+      });
+      expect(request).not.toHaveBeenCalled();
     },
   );
+
+  it("does not reload for a background run's message-less final", () => {
+    const request = vi.fn();
+    const { state } = createSessionEventState({
+      chatRunId: "foreground-run",
+      chatStream: "The foreground reply is still streaming.",
+      chatStreamStartedAt: 123,
+      client: { request } as unknown as GatewayBrowserClient,
+    });
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId: "background-run",
+        state: "final",
+      },
+    });
+
+    expect(request).not.toHaveBeenCalled();
+    expect(state.chatRunId).toBe("foreground-run");
+    expect(state.chatStream).toBe("The foreground reply is still streaming.");
+    expect(state.chatStreamStartedAt).toBe(123);
+  });
+
+  it("does not reload for a yielded message-less final", () => {
+    const runId = "yielded-run";
+    const request = vi.fn();
+    const { state } = createSessionEventState({
+      chatRunId: runId,
+      client: { request } as unknown as GatewayBrowserClient,
+    });
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId,
+        state: "final",
+        yielded: true,
+        stopReason: "end_turn",
+      },
+    });
+
+    expect(request).not.toHaveBeenCalled();
+  });
 
   it("keeps the live final projection without an unnecessary history reload", () => {
     const runId = "run-with-live-terminal-message";

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -637,7 +637,10 @@ describe("canonical session message recovery", () => {
     },
   );
 
-  it("starts a fresh history request after a pre-final request resolves stale", async () => {
+  it.each([
+    { name: "without a pending session-message reload", pendingReload: false },
+    { name: "after a pending session-message reload", pendingReload: true },
+  ])("starts a fresh history request $name", async ({ pendingReload }) => {
     const runId = "run-with-pre-final-history";
     const prompt = {
       role: "user",
@@ -663,6 +666,7 @@ describe("canonical session message recovery", () => {
       chatStream: null,
       chatStreamSegments: [],
       chatToolMessages: [],
+      pendingSessionMessageReloadSessionKey: pendingReload ? "agent:main:main" : null,
       client: { request } as unknown as GatewayBrowserClient,
     });
     const sessionInfo = {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -538,16 +538,23 @@ describe("canonical session message recovery", () => {
   });
 
   it.each([
-    { name: "omitted", terminalMessage: undefined, startsActive: true },
-    { name: "null", terminalMessage: null, startsActive: true },
+    { name: "omitted", terminalMessage: undefined, startsActive: true, pendingReload: false },
+    { name: "null", terminalMessage: null, startsActive: true, pendingReload: false },
     {
       name: "omitted for an idle selected session",
       terminalMessage: undefined,
       startsActive: false,
+      pendingReload: false,
+    },
+    {
+      name: "omitted while a session-message reload is pending",
+      terminalMessage: undefined,
+      startsActive: true,
+      pendingReload: true,
     },
   ])(
     "recovers the durable reply when the terminal message is $name",
-    async ({ terminalMessage, startsActive }) => {
+    async ({ terminalMessage, startsActive, pendingReload }) => {
       const runId = "run-with-message-less-terminal";
       const replyText = "The durable reply must appear below Done.";
       const prompt = {
@@ -580,6 +587,7 @@ describe("canonical session message recovery", () => {
         chatStream: null,
         chatStreamSegments: [],
         chatToolMessages: [],
+        pendingSessionMessageReloadSessionKey: pendingReload ? "agent:main:main" : null,
         client: { request } as unknown as GatewayBrowserClient,
       });
 
@@ -606,6 +614,7 @@ describe("canonical session message recovery", () => {
         }),
       );
       await vi.waitFor(() => expect(state.chatLoading).toBe(false));
+      expect(request).toHaveBeenCalledTimes(1);
       await vi.waitFor(() =>
         expect(renderedTranscript(state)).toEqual([
           { role: "user", text: "Finish the dashboard task" },

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -11,7 +11,7 @@ import {
   SLASH_COMMANDS,
 } from "../../lib/chat/commands.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
-import { loadChatHistory } from "./chat-history.ts";
+import { loadChatHistory, type ChatHistoryResult } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
 import { ChatStateController } from "./chat-state-controller.ts";
 import { handlePageGatewayEvent } from "./chat-state-events.ts";
@@ -636,6 +636,75 @@ describe("canonical session message recovery", () => {
       expect(request).not.toHaveBeenCalled();
     },
   );
+
+  it("starts a fresh history request after a pre-final request resolves stale", async () => {
+    const runId = "run-with-pre-final-history";
+    const prompt = {
+      role: "user",
+      content: [{ type: "text", text: "Finish after the stale snapshot" }],
+      __openclaw: { id: "prompt-1", idempotencyKey: `${runId}:user`, seq: 1 },
+    };
+    const persistedReply = {
+      role: "assistant",
+      content: [{ type: "text", text: "The post-final snapshot contains this reply." }],
+      stopReason: "stop",
+      __openclaw: { id: "reply-1", runId, seq: 2 },
+    };
+    const staleHistory = createDeferred<ChatHistoryResult>();
+    const freshHistory = createDeferred<ChatHistoryResult>();
+    const request = vi
+      .fn()
+      .mockReturnValueOnce(staleHistory.promise)
+      .mockReturnValueOnce(freshHistory.promise);
+    const { state } = createSessionEventState({
+      chatMessages: [prompt],
+      chatHistoryPagination: { hasMore: false },
+      chatRunId: runId,
+      chatStream: null,
+      chatStreamSegments: [],
+      chatToolMessages: [],
+      client: { request } as unknown as GatewayBrowserClient,
+    });
+    const sessionInfo = {
+      key: state.sessionKey,
+      kind: "direct" as const,
+      updatedAt: 2,
+      hasActiveRun: false,
+      activeRunIds: [],
+      status: "done",
+    };
+
+    const preFinalLoad = loadChatHistory(state);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId,
+        state: "final",
+      },
+    });
+
+    expect(request).toHaveBeenCalledTimes(2);
+    staleHistory.resolve({ messages: [prompt], sessionId: "selected-session", sessionInfo });
+    await preFinalLoad;
+    expect(renderedTranscript(state)).toEqual([
+      { role: "user", text: "Finish after the stale snapshot" },
+    ]);
+
+    freshHistory.resolve({
+      messages: [prompt, persistedReply],
+      sessionId: "selected-session",
+      sessionInfo,
+    });
+    await vi.waitFor(() => expect(state.chatLoading).toBe(false));
+    expect(renderedTranscript(state)).toEqual([
+      { role: "user", text: "Finish after the stale snapshot" },
+      { role: "assistant", text: "The post-final snapshot contains this reply." },
+    ]);
+  });
 
   it("does not reload for a background run's message-less final", () => {
     const request = vi.fn();

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -671,7 +671,7 @@ describe("canonical session message recovery", () => {
       updatedAt: 2,
       hasActiveRun: false,
       activeRunIds: [],
-      status: "done",
+      status: "done" as const,
     };
 
     const preFinalLoad = loadChatHistory(state);

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -538,6 +538,118 @@ describe("canonical session message recovery", () => {
   });
 
   it.each([
+    { name: "omitted", terminalMessage: undefined },
+    { name: "null", terminalMessage: null },
+  ])(
+    "recovers the durable reply when the terminal message is $name",
+    async ({ terminalMessage }) => {
+      const runId = "run-with-message-less-terminal";
+      const replyText = "The durable reply must appear below Done.";
+      const prompt = {
+        role: "user",
+        content: [{ type: "text", text: "Finish the dashboard task" }],
+        __openclaw: { id: "prompt-1", idempotencyKey: `${runId}:user`, seq: 1 },
+      };
+      const persistedReply = {
+        role: "assistant",
+        content: [{ type: "text", text: replyText }],
+        stopReason: "stop",
+        __openclaw: { id: "reply-1", runId, seq: 2 },
+      };
+      const request = vi.fn().mockResolvedValue({
+        messages: [prompt, persistedReply],
+        sessionId: "selected-session",
+        sessionInfo: {
+          key: "agent:main:main",
+          kind: "direct",
+          updatedAt: 2,
+          hasActiveRun: false,
+          activeRunIds: [],
+          status: "done",
+        },
+      });
+      const { state } = createSessionEventState({
+        chatMessages: [prompt],
+        chatHistoryPagination: { hasMore: false },
+        chatRunId: runId,
+        chatStream: null,
+        chatStreamSegments: [],
+        chatToolMessages: [],
+        client: { request } as unknown as GatewayBrowserClient,
+      });
+
+      handlePageGatewayEvent(state, {
+        type: "event",
+        event: "chat",
+        payload: {
+          sessionKey: state.sessionKey,
+          runId,
+          state: "final",
+          message: terminalMessage,
+        },
+      });
+
+      expect(state.chatRunId).toBeNull();
+      expect(renderedTranscript(state)).toEqual([
+        { role: "user", text: "Finish the dashboard task" },
+      ]);
+      await vi.waitFor(() =>
+        expect(request).toHaveBeenCalledWith("chat.history", {
+          agentId: "main",
+          sessionKey: state.sessionKey,
+          limit: 100,
+        }),
+      );
+      await vi.waitFor(() => expect(state.chatLoading).toBe(false));
+      await vi.waitFor(() =>
+        expect(renderedTranscript(state)).toEqual([
+          { role: "user", text: "Finish the dashboard task" },
+          { role: "assistant", text: replyText },
+        ]),
+      );
+    },
+  );
+
+  it("keeps the live final projection without an unnecessary history reload", () => {
+    const runId = "run-with-live-terminal-message";
+    const prompt = {
+      role: "user",
+      content: [{ type: "text", text: "Finish the dashboard task" }],
+      __openclaw: { id: "prompt-1", idempotencyKey: `${runId}:user`, seq: 1 },
+    };
+    const request = vi.fn();
+    const { state } = createSessionEventState({
+      chatMessages: [prompt],
+      chatRunId: runId,
+      chatStream: null,
+      chatStreamSegments: [],
+      chatToolMessages: [],
+      client: { request } as unknown as GatewayBrowserClient,
+    });
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId,
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "The live reply is already projected." }],
+        },
+      },
+    });
+
+    expect(state.chatRunId).toBeNull();
+    expect(request).not.toHaveBeenCalled();
+    expect(renderedTranscript(state)).toEqual([
+      { role: "user", text: "Finish the dashboard task" },
+      { role: "assistant", text: "The live reply is already projected." },
+    ]);
+  });
+
+  it.each([
     { name: "an unowned legacy", runId: undefined },
     { name: "an exactly producer-owned", runId: "older-run" },
   ])("never lets $name delayed older assistant row displace a newer run's reply", ({ runId }) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a dashboard chat could reach Done while its durable assistant reply remained absent when the matching final event did not carry a message.

## Why This Change Was Made

The Control UI event coordinator now reconciles durable history after the first owned, message-less completion for the selected session. That read supersedes any history request started before the terminal boundary, including when it consumes a pending session-message reload, so a stale in-flight snapshot cannot hide the newly persisted reply. Yielded, duplicate, background, and message-bearing finals keep their existing behavior.

## User Impact

Dashboard users see the persisted assistant reply after the run finishes instead of waiting for another event or a manual recovery path. Finals that already carry a visible reply do not trigger redundant history work.

## Evidence

- Base RED: canonical `70c87cc98d7` on Blacksmith Testbox `tbx_01m0zxcghrj4dxmmv64gasrk06`; the focused Chromium regression observed zero post-final history requests. [Actions run](https://github.com/openclaw/openclaw/actions/runs/33012377932)
- Initial head GREEN: patch at `cdc65c29c1d` on Blacksmith Testbox `tbx_01m0zynrb4c2bm6ac2v0matm7z`; 249/249 owner and adjacent unit tests plus 12/12 Chromium tests passed. [Actions run](https://github.com/openclaw/openclaw/actions/runs/33014263983)
- Stale-history race RED: prior PR head `8456bcf2272` reused the pre-final request and made only one history call. Testbox `tbx_01m1002xzt577k3e85f7xvbb3b`. [Actions run](https://github.com/openclaw/openclaw/actions/runs/33016210210)
- Repaired matrix GREEN: head `35e51721f80` passed 250/250 owner and adjacent unit tests plus 12/12 Chromium tests on Testbox `tbx_01m1008rmyn3nagsp368f66str`. [Actions run](https://github.com/openclaw/openclaw/actions/runs/33016451538)
- Combined pending-reload race RED: head `7027481d42b` made one request instead of the required post-final second request. Testbox `tbx_01m102ew7sxkhk4p91xj2zq18c`. [Actions run](https://github.com/openclaw/openclaw/actions/runs/33019199208)
- Final repair GREEN: the combined test passed 2/2, then the full matrix passed formatting, 139/139 focused and adjacent unit tests, 1/1 real Chromium recovery test, and the Control UI test type graph. Testboxes `tbx_01m102h3dw8m91fbs8be4kc7r7` and `tbx_01m102meve40cy2txyp5gm4v1t`. [Focused run](https://github.com/openclaw/openclaw/actions/runs/33019282587), [matrix run](https://github.com/openclaw/openclaw/actions/runs/33019405526)
- Fresh automated review after the combined-order repair: clean, correctness 0.99, no actionable findings. Exact-head hosted CI is required before merge.
- Recorded browser proof: direct AWS Crabbox run `run_199e30c7cbfb` passed 1/1 and captured the recovered reply exactly once. [Run and artifacts](https://crabbox.openclaw.ai/portal/runs/run_199e30c7cbfb)

The browser fixture uses a mocked Gateway transport while exercising the production Control UI event, projection, history, and render path in real Chromium.
