### PR TITLE
Keep text-only completions out of the media fallback

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -996,6 +996,42 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
 });
 
 describe("deliverSubagentAnnouncement completion delivery", () => {
+  it.each(["empty reply", "failed handoff"])(
+    "does not invent a media warning for a text-only harness completion after %s",
+    async (outcome) => {
+      const previousTestFast = process.env.OPENCLAW_TEST_FAST;
+      process.env.OPENCLAW_TEST_FAST = "1";
+      try {
+        const callGateway =
+          outcome === "empty reply"
+            ? createPayloadGatewayMock()
+            : (vi.fn(async () => {
+                throw new Error("requester handoff failed before dispatch");
+              }) as unknown as typeof runtimeCallGateway);
+        const sendMessage = createSendMessageMock();
+
+        const result = await deliverDiscordDirectMessageCompletion({
+          callGateway,
+          sendMessage,
+          sourceTool: "agent_harness_task",
+          internalEvents: taskCompletionEvents({ childSessionId: "child-session-id" }),
+        });
+
+        expect(result.delivered).toBe(false);
+        expect(sendMessage).not.toHaveBeenCalled();
+        expect(
+          generatedMediaWakeMocks.wakeSessionForGeneratedMediaDirectDelivery,
+        ).not.toHaveBeenCalled();
+      } finally {
+        if (previousTestFast === undefined) {
+          delete process.env.OPENCLAW_TEST_FAST;
+        } else {
+          process.env.OPENCLAW_TEST_FAST = previousTestFast;
+        }
+      }
+    },
+  );
+
   it("uses an active requester queue as the completion handoff when message-tool delivery is not required", async () => {
     const callGateway = createGatewayMock();
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1234,6 +1234,7 @@ async function sendSubagentAnnounceDirectly(params: {
         failureNotice ??
         (params.allowGeneratedMediaDirectFallback &&
         agentMediatedCompletion &&
+        hasGeneratedMediaCompletionEvent(params.internalEvents) &&
         expectedMediaUrls.length === 0
           ? `${mediaLabel[0]?.toUpperCase() ?? "M"}${mediaLabel.slice(1)} generation completed, but the generated media could not be attached here.`
           : undefined);


### PR DESCRIPTION
This release branch can mistake a text-only harness task for generated media. If the requester handoff fails or produces no reply, it posts a warning about a missing attachment even though no media generation happened, then incorrectly records that warning as successful task delivery.

Main already removed this fallback in https://github.com/openclaw/openclaw/pull/117150. That change also rewrites the broader media-delivery lifecycle. This bounded release adaptation uses the existing typed media-completion event to gate the old missing-attachment notice, without importing that unrelated rewrite.

Actual generated-media recovery is unchanged. A failed text-only handoff stays a failed handoff; it cannot manufacture an attachment warning or a follow-up media wake.
