### PR TITLE
refactor(qa-lab): share process tree metric reader

### DIFF
--- a/extensions/qa-lab/src/process-tree-cpu.ts
+++ b/extensions/qa-lab/src/process-tree-cpu.ts
@@ -202,17 +202,23 @@ function readWindowsProcessTreeSnapshot(): ProcessTreeSnapshot | null {
   return parseWindowsProcessTreeSnapshot(result.stdout);
 }
 
-export function readProcessTreeCpuMs(rootPid: number | null | undefined): number | null {
+function readProcessTreeMetric(params: {
+  rootPid: number | null | undefined;
+  posixColumn: "time=" | "rss=";
+  parsePosixMetric: (raw: string) => number | null;
+  windowsMetric: "cpuByPid" | "rssByPid";
+}): number | null {
+  const { rootPid } = params;
   if (typeof rootPid !== "number" || !Number.isInteger(rootPid) || rootPid <= 0) {
     return null;
   }
   if (process.platform === "win32") {
     const snapshot = readWindowsProcessTreeSnapshot();
     return snapshot
-      ? collectProcessTreeMetric(rootPid, snapshot.childrenByParent, snapshot.cpuByPid)
+      ? collectProcessTreeMetric(rootPid, snapshot.childrenByParent, snapshot[params.windowsMetric])
       : null;
   }
-  const result = spawnSync("ps", ["-eo", "pid=,ppid=,time="], {
+  const result = spawnSync("ps", ["-eo", `pid=,ppid=,${params.posixColumn}`], {
     encoding: "utf8",
     killSignal: "SIGKILL",
     stdio: ["ignore", "pipe", "ignore"],
@@ -223,73 +229,42 @@ export function readProcessTreeCpuMs(rootPid: number | null | undefined): number
   }
 
   const childrenByParent = new Map<number, number[]>();
-  const cpuByPid = new Map<number, number>();
+  const metricByPid = new Map<number, number>();
   for (const line of result.stdout.split("\n")) {
     const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)$/u);
     if (!match) {
       continue;
     }
-    const [, pidRaw, ppidRaw, cpuRaw] = match;
+    const [, pidRaw, ppidRaw, metricRaw] = match;
     const pid = Number(pidRaw);
     const ppid = Number(ppidRaw);
-    const cpuMs = parsePsCpuTimeMs(cpuRaw ?? "");
-    if (!Number.isInteger(pid) || !Number.isInteger(ppid) || cpuMs === null) {
+    const metric = params.parsePosixMetric(metricRaw ?? "");
+    if (!Number.isInteger(pid) || !Number.isInteger(ppid) || metric === null) {
       continue;
     }
-    cpuByPid.set(pid, cpuMs);
+    metricByPid.set(pid, metric);
     const children = childrenByParent.get(ppid) ?? [];
     children.push(pid);
     childrenByParent.set(ppid, children);
   }
-  if (!cpuByPid.has(rootPid)) {
-    return null;
-  }
 
-  return collectProcessTreeMetric(rootPid, childrenByParent, cpuByPid);
+  return collectProcessTreeMetric(rootPid, childrenByParent, metricByPid);
+}
+
+export function readProcessTreeCpuMs(rootPid: number | null | undefined): number | null {
+  return readProcessTreeMetric({
+    rootPid,
+    posixColumn: "time=",
+    parsePosixMetric: parsePsCpuTimeMs,
+    windowsMetric: "cpuByPid",
+  });
 }
 
 export function readProcessTreeRssBytes(rootPid: number | null | undefined): number | null {
-  if (typeof rootPid !== "number" || !Number.isInteger(rootPid) || rootPid <= 0) {
-    return null;
-  }
-  if (process.platform === "win32") {
-    const snapshot = readWindowsProcessTreeSnapshot();
-    return snapshot
-      ? collectProcessTreeMetric(rootPid, snapshot.childrenByParent, snapshot.rssByPid)
-      : null;
-  }
-  const result = spawnSync("ps", ["-eo", "pid=,ppid=,rss="], {
-    encoding: "utf8",
-    killSignal: "SIGKILL",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: PROCESS_TREE_SNAPSHOT_TIMEOUT_MS,
+  return readProcessTreeMetric({
+    rootPid,
+    posixColumn: "rss=",
+    parsePosixMetric: parsePsRssBytes,
+    windowsMetric: "rssByPid",
   });
-  if (result.status !== 0) {
-    return null;
-  }
-
-  const childrenByParent = new Map<number, number[]>();
-  const rssByPid = new Map<number, number>();
-  for (const line of result.stdout.split("\n")) {
-    const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)$/u);
-    if (!match) {
-      continue;
-    }
-    const [, pidRaw, ppidRaw, rssRaw] = match;
-    const pid = Number(pidRaw);
-    const ppid = Number(ppidRaw);
-    const rssBytes = parsePsRssBytes(rssRaw ?? "");
-    if (!Number.isInteger(pid) || !Number.isInteger(ppid) || rssBytes === null) {
-      continue;
-    }
-    rssByPid.set(pid, rssBytes);
-    const children = childrenByParent.get(ppid) ?? [];
-    children.push(pid);
-    childrenByParent.set(ppid, children);
-  }
-  if (!rssByPid.has(rootPid)) {
-    return null;
-  }
-
-  return collectProcessTreeMetric(rootPid, childrenByParent, rssByPid);
 }


### PR DESCRIPTION
## What Problem This Solves

QA process-tree CPU and RSS readers duplicated the same input validation, platform dispatch, bounded process snapshot, tree construction, root validation, and aggregation flow. Keeping those paths separate made platform and failure semantics easier to drift.

## Why This Change Was Made

Use one private metric reader parameterized by the closed POSIX column/parser and Windows metric map. The exported CPU and RSS wrappers, subprocess options, unit conversions, and null behavior remain unchanged.

## User Impact

No user-visible behavior changes. QA runtime resource metrics are easier to maintain consistently across platforms.

## Evidence

- Exact-head local proof passed both focused platform suites: 2 files, 9/9 tests.
- Exact-head Blacksmith Testbox proof passed the same suites: provider `blacksmith-testbox`, lease `tbx_01m10qmwynap26xr9xd2qvptqm`, remote-fetch sync, 9/9 tests, timing JSON `exitCode: 0` and `runStatus: succeeded`: https://github.com/openclaw/openclaw/actions/runs/33039543090
- Native `node scripts/check-changed.mjs` passed, including extension production/test typecheck, lint, dead exports, plugin boundaries, and import cycles.
- `git diff --check` passed.
- Fresh exact-head branch autoreview with `gpt-5.6-sol` at high reasoning reported no accepted/actionable findings (`0.93` confidence).
- Required exact-head `openclaw/ci-gate` passed via run `33015327766`.
- Exact-head ClawSweeper completed with no findings. Its rebase rank-up is intentionally skipped: against current-main snapshot `71d4a8c3e305c623aa3ffe92696eec18f116cfc6`, the process-tree owner, production caller, metric consumer, and both focused test blobs are byte-identical to the PR parent; the synthetic merge and live GitHub merge result are clean.
- Production delta: `+29/-54`, net `-25`.
