### PR TITLE
fix(process): self-heal dropped poll delivery via aggregated read-offset

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -10,6 +10,7 @@ import {
   attachInternalSyncSteeringGetter,
   attachInternalToolBatchLifecycle,
   attachInternalToolExecutionPreparer,
+  attachInternalToolResultAcknowledgement,
   setInternalBeforeToolBatch,
   takeInternalToolBatchLifecycle,
 } from "./internal-hooks.js";
@@ -2591,6 +2592,52 @@ describe("agentLoop tool termination", () => {
       expect(metadata(assistant)).toEqual(tainted ? { turnTainted: true } : undefined);
     },
   );
+
+  it.each([
+    { name: "attached", failAttachment: false, expectedAcknowledgements: 1 },
+    { name: "dropped", failAttachment: true, expectedAcknowledgements: 0 },
+  ])("acknowledges an internal tool result only after it is $name", async (testCase) => {
+    const acknowledge = vi.fn();
+    const tool: AgentTool = {
+      ...makeTool("commit_probe", []),
+      execute: async () =>
+        attachInternalToolResultAcknowledgement(
+          { content: [{ type: "text", text: "committed" }], details: { phase: "execute" } },
+          acknowledge,
+        ),
+    };
+    const streamFn = createTurnSequenceStream([
+      [{ type: "toolCall", id: "commit-probe", name: tool.name, arguments: {} }],
+      [{ type: "text", text: "done" }],
+    ]);
+    const run = runAgentLoop(
+      [{ role: "user", content: "commit", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [tool] },
+      {
+        ...config,
+        afterToolCall: async () => ({ details: { phase: "after-call" } }),
+        afterToolOutcome: async () => ({ details: { phase: "after-outcome" } }),
+      },
+      async (event) => {
+        if (
+          testCase.failAttachment &&
+          event.type === "message_end" &&
+          event.message.role === "toolResult"
+        ) {
+          throw new Error("attachment failed");
+        }
+      },
+      undefined,
+      streamFn,
+    );
+
+    if (testCase.failAttachment) {
+      await expect(run).rejects.toThrow("attachment failed");
+    } else {
+      await run;
+    }
+    expect(acknowledge).toHaveBeenCalledTimes(testCase.expectedAcknowledgements);
+  });
 
   it.each([
     ["sequential", "invalid arguments"],

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -7,6 +7,7 @@ import { agentLoop, agentLoopContinue, runAgentLoop, runAgentLoopContinue } from
 import { Agent } from "./agent.js";
 import { TRANSCRIPT_NOT_CONTINUABLE_ERROR_CODE, TranscriptNotContinuableError } from "./errors.js";
 import {
+  acknowledgeInternalToolResult,
   attachInternalSyncSteeringGetter,
   attachInternalToolBatchLifecycle,
   attachInternalToolExecutionPreparer,
@@ -2619,6 +2620,13 @@ describe("agentLoop tool termination", () => {
         afterToolOutcome: async () => ({ details: { phase: "after-outcome" } }),
       },
       async (event) => {
+        if (
+          !testCase.failAttachment &&
+          event.type === "message_end" &&
+          event.message.role === "toolResult"
+        ) {
+          acknowledgeInternalToolResult(event.message);
+        }
         if (
           testCase.failAttachment &&
           event.type === "message_end" &&

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -15,7 +15,6 @@ import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { TranscriptNotContinuableError } from "./errors.js";
 import { uuidv7 } from "./harness/session/uuid.js";
 import {
-  acknowledgeInternalToolResult,
   copyInternalToolResultAcknowledgement,
   getInternalToolExecutionPreparer,
   getInternalSyncSteeringGetter,
@@ -1902,7 +1901,5 @@ async function emitToolResultMessage(
 ): Promise<void> {
   await emit({ type: "message_start", message: toolResultMessage });
   await emit({ type: "message_end", message: toolResultMessage });
-  // Guarded sessions acknowledge at persistence; this covers unguarded Agent consumers.
-  acknowledgeInternalToolResult(toolResultMessage);
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -15,6 +15,8 @@ import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { TranscriptNotContinuableError } from "./errors.js";
 import { uuidv7 } from "./harness/session/uuid.js";
 import {
+  acknowledgeInternalToolResult,
+  copyInternalToolResultAcknowledgement,
   getInternalToolExecutionPreparer,
   getInternalSyncSteeringGetter,
   type InternalToolExecutionPreparation,
@@ -1599,12 +1601,12 @@ async function finalizeExecutedToolCall(
         batch.signal,
       );
       if (afterResult) {
-        result = {
+        result = copyInternalToolResultAcknowledgement(result, {
           ...result,
           content: afterResult.content ?? result.content,
           details: afterResult.details ?? result.details,
           terminate: afterResult.terminate ?? result.terminate,
-        };
+        });
         isError = afterResult.isError ?? isError;
       }
     } catch (error) {
@@ -1658,12 +1660,12 @@ async function finalizeToolCallOutcome(
     }
     return {
       ...finalized,
-      result: {
+      result: copyInternalToolResultAcknowledgement(finalized.result, {
         ...finalized.result,
         content: afterResult.content ?? finalized.result.content,
         details: afterResult.details ?? finalized.result.details,
         terminate: afterResult.terminate ?? finalized.result.terminate,
-      },
+      }),
       isError: afterResult.isError ?? finalized.isError,
     };
   } catch (error) {
@@ -1817,17 +1819,20 @@ async function emitToolExecutionEnd(
 }
 
 function createToolResultMessage(finalized: FinalizedToolCallOutcome): ToolResultMessage {
-  return withToolResultContentSource(
-    {
-      role: "toolResult",
-      toolCallId: finalized.toolCall.id,
-      toolName: finalized.toolCall.name,
-      content: finalized.result.content ?? [],
-      details: finalized.result.details,
-      isError: finalized.isError,
-      timestamp: Date.now(),
-    },
-    finalized.resultContentSource,
+  return copyInternalToolResultAcknowledgement(
+    finalized.result,
+    withToolResultContentSource(
+      {
+        role: "toolResult",
+        toolCallId: finalized.toolCall.id,
+        toolName: finalized.toolCall.name,
+        content: finalized.result.content ?? [],
+        details: finalized.result.details,
+        isError: finalized.isError,
+        timestamp: Date.now(),
+      },
+      finalized.resultContentSource,
+    ),
   );
 }
 
@@ -1897,5 +1902,7 @@ async function emitToolResultMessage(
 ): Promise<void> {
   await emit({ type: "message_start", message: toolResultMessage });
   await emit({ type: "message_end", message: toolResultMessage });
+  // Guarded sessions acknowledge at persistence; this covers unguarded Agent consumers.
+  acknowledgeInternalToolResult(toolResultMessage);
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/packages/agent-core/src/internal-hooks.ts
+++ b/packages/agent-core/src/internal-hooks.ts
@@ -60,6 +60,9 @@ export type InternalToolExecutionPreparer = (params: {
 
 const toolExecutionPreparerByTool = new WeakMap<object, InternalToolExecutionPreparer>();
 
+type InternalToolResultAcknowledgement = () => void;
+const toolResultAcknowledgementByValue = new WeakMap<object, InternalToolResultAcknowledgement>();
+
 /** Install OpenClaw-owned loop control without adding a plugin-facing Agent option. */
 export function setInternalBeforeToolBatch(
   agent: object,
@@ -130,4 +133,35 @@ export function copyInternalToolExecutionPreparer<T extends object>(source: obje
     toolExecutionPreparerByTool.set(target, preparer);
   }
   return target;
+}
+
+/** Keep a destructive tool-side commit behind the result persistence boundary. */
+export function attachInternalToolResultAcknowledgement<T extends object>(
+  value: T,
+  acknowledge: InternalToolResultAcknowledgement,
+): T {
+  toolResultAcknowledgementByValue.set(value, acknowledge);
+  return value;
+}
+
+/** Carry private commit ownership through result transforms and message construction. */
+export function copyInternalToolResultAcknowledgement<T extends object>(
+  source: object,
+  target: T,
+): T {
+  const acknowledge = toolResultAcknowledgementByValue.get(source);
+  if (acknowledge) {
+    toolResultAcknowledgementByValue.set(target, acknowledge);
+  }
+  return target;
+}
+
+/** Commit one tool result after its owning message has attached. */
+export function acknowledgeInternalToolResult(value: object): void {
+  const acknowledge = toolResultAcknowledgementByValue.get(value);
+  if (!acknowledge) {
+    return;
+  }
+  toolResultAcknowledgementByValue.delete(value);
+  acknowledge();
 }

--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -10,7 +10,6 @@ import {
   addSession,
   appendOutput,
   deleteSession,
-  drainSession,
   getActiveBackgroundExecSessionCount,
   getFinishedSession,
   isProcessSessionIdTaken,
@@ -19,6 +18,7 @@ import {
   markBackgrounded,
   markExited,
   markTerminalPollObserved,
+  prepareSessionPoll,
   recordNotifyOnExitRemoval,
   setJobTtlMs,
   tail,
@@ -26,6 +26,8 @@ import {
 import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
 import { createSessionSlug } from "./session-slug.js";
+
+const drainSession = (session: ProcessSession) => prepareSessionPoll(session, undefined);
 
 const randomMocks = vi.hoisted(() => ({
   generateSecureInt: vi.fn(() => 0),

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -50,6 +50,12 @@ type PendingOutputChunk = {
   text: string;
 };
 
+type PendingPollDelivery = {
+  output: string;
+  outputDropped: boolean;
+  scope: object;
+};
+
 /** One process record from execution through completed retention. */
 export interface ProcessSession {
   id: string;
@@ -97,6 +103,8 @@ export interface ProcessSession {
   pendingStderrChars: number;
   /** Output was dropped from the pending poll buffers since their last drain. */
   pendingOutputDropped: boolean;
+  /** Output prepared for a poll but not yet attached to the agent transcript. */
+  pendingPollDelivery?: PendingPollDelivery;
   aggregated: string;
   tail: string;
   exitCode?: number | null;
@@ -228,7 +236,7 @@ export function appendOutput(session: ProcessSession, stream: "stdout" | "stderr
 }
 
 /** Drains pending chunks in producer callback order for a process poll. */
-export function drainSession(session: ProcessSession) {
+function drainSession(session: ProcessSession) {
   const pending = session.pendingOutput;
   const output =
     typeof pending === "string" ? pending : pending.map((chunk) => chunk.text).join("");
@@ -239,6 +247,43 @@ export function drainSession(session: ProcessSession) {
   session.pendingStderrChars = 0;
   session.pendingOutputDropped = false;
   return { output, outputDropped };
+}
+
+/** Stages one poll result until the agent transcript acknowledges its attachment. */
+export function prepareSessionPoll(session: ProcessSession, scope: object | undefined) {
+  if (!scope) {
+    return { ...drainSession(session), acknowledge() {} };
+  }
+  const pending = session.pendingPollDelivery;
+  if (pending) {
+    // Parallel polls from one assistant turn must not receive the same staged bytes.
+    if (pending.scope === scope) {
+      return { output: "", outputDropped: false, acknowledge() {} };
+    }
+    return {
+      output: pending.output,
+      outputDropped: pending.outputDropped,
+      acknowledge() {
+        if (session.pendingPollDelivery === pending) {
+          session.pendingPollDelivery = undefined;
+        }
+      },
+    };
+  }
+  const drained = drainSession(session);
+  if (drained.output.length === 0 && !drained.outputDropped) {
+    return { ...drained, acknowledge() {} };
+  }
+  const delivery = { ...drained, scope };
+  session.pendingPollDelivery = delivery;
+  return {
+    ...drained,
+    acknowledge() {
+      if (session.pendingPollDelivery === delivery) {
+        session.pendingPollDelivery = undefined;
+      }
+    },
+  };
 }
 
 /** Moves a session to finished state and records exit metadata. */

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -256,10 +256,12 @@ export function prepareSessionPoll(session: ProcessSession, scope: object | unde
   }
   const pending = session.pendingPollDelivery;
   if (pending) {
-    // Parallel polls from one assistant turn must not receive the same staged bytes.
+    // The first retry claims the staged bytes for its turn. Parallel siblings then
+    // observe that scope and cannot duplicate the recovery result.
     if (pending.scope === scope) {
       return { output: "", outputDropped: false, acknowledge() {} };
     }
+    pending.scope = scope;
     return {
       output: pending.output,
       outputDropped: pending.outputDropped,

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -286,6 +286,11 @@ export function prepareSessionPoll(session: ProcessSession, scope: object | unde
   };
 }
 
+/** Returns whether a prior poll has output ready for immediate replay. */
+export function hasPendingPollDelivery(session: ProcessSession): boolean {
+  return session.pendingPollDelivery !== undefined;
+}
+
 /** Moves a session to finished state and records exit metadata. */
 export function markExited(
   session: ProcessSession,

--- a/src/agents/bash-tools.process.delivery.test.ts
+++ b/src/agents/bash-tools.process.delivery.test.ts
@@ -112,21 +112,53 @@ test.each(["running", "completed"] as const)(
   },
 );
 
-test("does not duplicate staged output across parallel polls from one assistant turn", async () => {
-  const session: ProcessSession = createProcessSessionFixture({
-    id: "parallel-delivery",
+test.each(["initial", "retry"] as const)(
+  "does not duplicate $phase output across parallel polls from one assistant turn",
+  async (phase) => {
+    const session: ProcessSession = createProcessSessionFixture({
+      id: `parallel-${phase}-delivery`,
+      backgrounded: true,
+    });
+    addSession(session);
+    appendOutput(session, "stdout", "one-copy\n");
+    const processTool = createProcessTool();
+    if (phase === "retry") {
+      await poll(processTool, session.id, "parallel-dropped");
+    }
+    const turn = processTurn("parallel-first", session.id);
+
+    const first = await poll(processTool, session.id, "parallel-first", turn);
+    const second = await poll(processTool, session.id, "parallel-second", turn);
+
+    expect(resultText(first)).toContain("one-copy");
+    expect(resultText(second)).not.toContain("one-copy");
+  },
+);
+
+test("consumes staged output after transformed transcript persistence", async () => {
+  const session = createProcessSessionFixture({
+    id: "transformed-delivery",
     backgrounded: true,
   });
   addSession(session);
-  appendOutput(session, "stdout", "one-copy\n");
+  appendOutput(session, "stdout", "transformed-output\n");
   const processTool = createProcessTool();
-  const turn = processTurn("parallel-first", session.id);
+  const turn = processTurn("transformed-result", session.id);
+  const result = await poll(processTool, session.id, turn.toolCall.id, turn);
+  const manager = SessionManager.inMemory();
+  installSessionToolResultGuard(manager, {
+    runId: "transformed-run",
+    maxToolResultChars: 16,
+    transformMessageForPersistence: (message) => ({ ...message }),
+    transformToolResultForPersistence: (message) => ({ ...message }),
+    beforeMessageWriteHook: ({ message }) => ({ message: { ...message } }),
+  });
 
-  const first = await poll(processTool, session.id, "parallel-first", turn);
-  const second = await poll(processTool, session.id, "parallel-second", turn);
+  manager.appendMessage(turn.assistantMessage);
+  persistResult(manager, turn.toolCall.id, result);
 
-  expect(resultText(first)).toContain("one-copy");
-  expect(resultText(second)).not.toContain("one-copy");
+  const observed = await poll(processTool, session.id, "transformed-observed");
+  expect(resultText(observed)).not.toContain("transformed-output");
 });
 
 test("replays blocked poll output immediately when the retry has a timeout", async () => {

--- a/src/agents/bash-tools.process.delivery.test.ts
+++ b/src/agents/bash-tools.process.delivery.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, expect, test } from "vitest";
+import { copyInternalToolResultAcknowledgement } from "../../packages/agent-core/src/internal-hooks.js";
+import { runWithAgentToolExecutionContext } from "../../packages/agent-core/src/tool-execution-context.js";
+import {
+  addSession,
+  appendOutput,
+  markExited,
+  type ProcessSession,
+} from "./bash-process-registry.js";
+import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
+import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
+import { createProcessTool } from "./bash-tools.process.js";
+import type { AgentToolResult } from "./runtime/index.js";
+import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
+import { SessionManager } from "./sessions/index.js";
+import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+});
+
+function processTurn(toolCallId: string, sessionId: string) {
+  const toolCall = {
+    type: "toolCall" as const,
+    id: toolCallId,
+    name: "process",
+    arguments: { action: "poll", sessionId },
+  };
+  return {
+    assistantMessage: makeAgentAssistantMessage({
+      content: [toolCall],
+      stopReason: "toolUse",
+    }),
+    toolCall,
+  };
+}
+
+async function poll(
+  processTool: ReturnType<typeof createProcessTool>,
+  sessionId: string,
+  toolCallId: string,
+  turn = processTurn(toolCallId, sessionId),
+) {
+  return await runWithAgentToolExecutionContext(turn, () =>
+    processTool.execute(toolCallId, { action: "poll", sessionId }),
+  );
+}
+
+function resultText(result: AgentToolResult<unknown>): string {
+  return result.content.find((part) => part.type === "text")?.text ?? "";
+}
+
+function persistResult(
+  manager: ReturnType<typeof SessionManager.inMemory>,
+  toolCallId: string,
+  result: AgentToolResult<unknown>,
+): void {
+  const message = copyInternalToolResultAcknowledgement(result, {
+    role: "toolResult" as const,
+    toolCallId,
+    toolName: "process",
+    content: result.content,
+    details: result.details,
+    isError: false,
+    timestamp: Date.now(),
+  });
+  manager.appendMessage(message);
+}
+
+test.each(["running", "completed"] as const)(
+  "replays $status poll output after transcript repair and consumes it after persistence",
+  async (status) => {
+    const sessionId = `delivery-${status}`;
+    const session = createProcessSessionFixture({
+      id: sessionId,
+      backgrounded: true,
+    });
+    addSession(session);
+    appendOutput(session, "stdout", `${status}-output\n`);
+    if (status === "completed") {
+      markExited(session, 0, null, "completed");
+    }
+    const processTool = createProcessTool();
+    const manager = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(manager);
+
+    const droppedTurn = processTurn(`${status}-dropped`, sessionId);
+    const dropped = await poll(processTool, sessionId, droppedTurn.toolCall.id, droppedTurn);
+    expect(resultText(dropped)).toContain(`${status}-output`);
+    manager.appendMessage(droppedTurn.assistantMessage);
+    guard.flushPendingToolResults();
+
+    const retryTurn = processTurn(`${status}-retry`, sessionId);
+    const retry = await poll(processTool, sessionId, retryTurn.toolCall.id, retryTurn);
+    expect(resultText(retry)).toContain(`${status}-output`);
+    manager.appendMessage(retryTurn.assistantMessage);
+    persistResult(manager, retryTurn.toolCall.id, retry);
+
+    const observed = await poll(processTool, sessionId, `${status}-observed`);
+    expect(resultText(observed)).not.toContain(`${status}-output`);
+  },
+);
+
+test("does not duplicate staged output across parallel polls from one assistant turn", async () => {
+  const session: ProcessSession = createProcessSessionFixture({
+    id: "parallel-delivery",
+    backgrounded: true,
+  });
+  addSession(session);
+  appendOutput(session, "stdout", "one-copy\n");
+  const processTool = createProcessTool();
+  const turn = processTurn("parallel-first", session.id);
+
+  const first = await poll(processTool, session.id, "parallel-first", turn);
+  const second = await poll(processTool, session.id, "parallel-second", turn);
+
+  expect(resultText(first)).toContain("one-copy");
+  expect(resultText(second)).not.toContain("one-copy");
+});

--- a/src/agents/bash-tools.process.delivery.test.ts
+++ b/src/agents/bash-tools.process.delivery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 import { copyInternalToolResultAcknowledgement } from "../../packages/agent-core/src/internal-hooks.js";
 import { runWithAgentToolExecutionContext } from "../../packages/agent-core/src/tool-execution-context.js";
 import {
@@ -10,7 +10,7 @@ import {
 import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
 import { createProcessTool } from "./bash-tools.process.js";
-import type { AgentToolResult } from "./runtime/index.js";
+import type { AgentMessage, AgentToolResult } from "./runtime/index.js";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { SessionManager } from "./sessions/index.js";
 import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
@@ -40,9 +40,14 @@ async function poll(
   sessionId: string,
   toolCallId: string,
   turn = processTurn(toolCallId, sessionId),
+  timeout?: number,
 ) {
   return await runWithAgentToolExecutionContext(turn, () =>
-    processTool.execute(toolCallId, { action: "poll", sessionId }),
+    processTool.execute(toolCallId, {
+      action: "poll",
+      sessionId,
+      ...(timeout === undefined ? {} : { timeout }),
+    }),
   );
 }
 
@@ -50,12 +55,11 @@ function resultText(result: AgentToolResult<unknown>): string {
   return result.content.find((part) => part.type === "text")?.text ?? "";
 }
 
-function persistResult(
-  manager: ReturnType<typeof SessionManager.inMemory>,
+function toolResultMessage(
   toolCallId: string,
   result: AgentToolResult<unknown>,
-): void {
-  const message = copyInternalToolResultAcknowledgement(result, {
+): Extract<AgentMessage, { role: "toolResult" }> {
+  return copyInternalToolResultAcknowledgement(result, {
     role: "toolResult" as const,
     toolCallId,
     toolName: "process",
@@ -64,7 +68,14 @@ function persistResult(
     isError: false,
     timestamp: Date.now(),
   });
-  manager.appendMessage(message);
+}
+
+function persistResult(
+  manager: ReturnType<typeof SessionManager.inMemory>,
+  toolCallId: string,
+  result: AgentToolResult<unknown>,
+): void {
+  manager.appendMessage(toolResultMessage(toolCallId, result));
 }
 
 test.each(["running", "completed"] as const)(
@@ -116,4 +127,49 @@ test("does not duplicate staged output across parallel polls from one assistant 
 
   expect(resultText(first)).toContain("one-copy");
   expect(resultText(second)).not.toContain("one-copy");
+});
+
+test("replays blocked poll output immediately when the retry has a timeout", async () => {
+  const session = createProcessSessionFixture({
+    id: "blocked-delivery",
+    backgrounded: true,
+  });
+  addSession(session);
+  appendOutput(session, "stdout", "blocked-output\n");
+  const processTool = createProcessTool();
+  const droppedTurn = processTurn("blocked-result", session.id);
+  const dropped = await poll(processTool, session.id, droppedTurn.toolCall.id, droppedTurn);
+  const manager = SessionManager.inMemory();
+  installSessionToolResultGuard(manager, {
+    beforeMessageWriteHook(event) {
+      return event.message.role === "toolResult" && event.message.toolCallId === "blocked-result"
+        ? { block: true }
+        : undefined;
+    },
+  });
+  manager.appendMessage(droppedTurn.assistantMessage);
+  expect(
+    manager.appendMessage(toolResultMessage(droppedTurn.toolCall.id, dropped)),
+  ).toBeUndefined();
+
+  vi.useFakeTimers();
+  try {
+    const retryTurn = processTurn("blocked-retry", session.id);
+    let settled = false;
+    const retryPromise = poll(
+      processTool,
+      session.id,
+      retryTurn.toolCall.id,
+      retryTurn,
+      30_000,
+    ).then((result) => {
+      settled = true;
+      return result;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(settled).toBe(true);
+    expect(resultText(await retryPromise)).toContain("blocked-output");
+  } finally {
+    vi.useRealTimers();
+  }
 });

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -16,6 +16,7 @@ import {
   deleteSession,
   getFinishedSession,
   getSession,
+  hasPendingPollDelivery,
   listFinishedSessions,
   listRunningSessions,
   markTerminalPollObserved,
@@ -463,6 +464,7 @@ export function createProcessTool(
             // Interactive children cannot progress until their pending prompt reaches the model.
             while (
               !scopedSession.exited &&
+              !hasPendingPollDelivery(scopedSession) &&
               scopedSession.pendingOutput.length === 0 &&
               !scopedSession.pendingOutputDropped &&
               Date.now() < deadline

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -208,11 +208,8 @@ function finishedPollResult(
 ): AgentToolResult<unknown> {
   resetPollRetrySuggestion(sessionId);
   acknowledgeNotifyOnExit(finished);
-  const {
-    output: unreadOutput,
-    outputDropped,
-    acknowledge,
-  } = prepareSessionPoll(finished, pollScope);
+  const delivery = prepareSessionPoll(finished, pollScope);
+  const { output: unreadOutput, outputDropped } = delivery;
   const output = unreadOutput.trim();
   // Omitted retained output is pageable only while this public id still owns
   // the exact process; a reused slug must never point the model at successor logs.
@@ -240,7 +237,7 @@ function finishedPollResult(
         aggregated: finished.aggregated,
       },
     },
-    acknowledge,
+    () => delivery.acknowledge(),
   );
 }
 
@@ -482,11 +479,8 @@ export function createProcessTool(
             resetPollRetrySuggestion(params.sessionId);
             return failText(`No session found for ${params.sessionId}`);
           }
-          const {
-            output: unreadOutput,
-            outputDropped,
-            acknowledge,
-          } = prepareSessionPoll(scopedSession, pollScope);
+          const delivery = prepareSessionPoll(scopedSession, pollScope);
+          const { output: unreadOutput, outputDropped } = delivery;
           const output = unreadOutput.trim();
           const aggregateOutputNote = retentionCapNote(scopedSession);
           const retainedOutputNote = outputDropped
@@ -516,7 +510,7 @@ export function createProcessTool(
                 ...(typeof retryInMs === "number" ? { retryInMs } : {}),
               },
             },
-            acknowledge,
+            () => delivery.acknowledge(),
           );
         }
 

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -1,3 +1,4 @@
+import { getAgentToolExecutionContext } from "../../packages/agent-core/src/tool-execution-context.js";
 /**
  * Process-control tool factory.
  * Lists, polls, logs, writes to, sends keys to, pastes into, kills, clears,
@@ -13,12 +14,12 @@ import {
   type ProcessSession,
   compareProcessSessionStartOrder,
   deleteSession,
-  drainSession,
   getFinishedSession,
   getSession,
   listFinishedSessions,
   listRunningSessions,
   markTerminalPollObserved,
+  prepareSessionPoll,
   setJobTtlMs,
 } from "./bash-process-registry.js";
 import { describeProcessTool } from "./bash-tools.descriptions.js";
@@ -40,6 +41,7 @@ import {
 import { recordCommandPoll, resetCommandPollCount } from "./command-poll-backoff.js";
 import { encodePaste } from "./pty-keys.js";
 import type { AgentToolResult } from "./runtime/index.js";
+import { attachInternalToolResultAcknowledgement } from "./runtime/internal-hooks.js";
 import { PROCESS_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 import type { AgentToolWithMeta } from "./tools/common.js";
 
@@ -61,6 +63,22 @@ const PROCESS_TOOL_ACTIONS = (
   }
 ).enum;
 type ProcessToolAction = (typeof PROCESS_TOOL_ACTIONS)[number];
+const pollScopeByAssistantMessage = new WeakMap<object, object>();
+
+function currentPollScope(): object | undefined {
+  const assistantMessage = getAgentToolExecutionContext()?.assistantMessage;
+  if (!assistantMessage) {
+    return undefined;
+  }
+  const existing = pollScopeByAssistantMessage.get(assistantMessage);
+  if (existing) {
+    return existing;
+  }
+  // Retained sessions must not keep a full assistant message alive after a dropped result.
+  const scope = {};
+  pollScopeByAssistantMessage.set(assistantMessage, scope);
+  return scope;
+}
 
 function resolveLogSliceWindow(offset?: number, limit?: number) {
   const usingDefaultTail = offset === undefined && limit === undefined;
@@ -182,10 +200,18 @@ function finishedSessionDetails(sessionId: string, finished: ProcessSession) {
   };
 }
 
-function finishedPollResult(sessionId: string, finished: ProcessSession): AgentToolResult<unknown> {
+function finishedPollResult(
+  sessionId: string,
+  finished: ProcessSession,
+  pollScope: object | undefined,
+): AgentToolResult<unknown> {
   resetPollRetrySuggestion(sessionId);
   acknowledgeNotifyOnExit(finished);
-  const { output: unreadOutput, outputDropped } = drainSession(finished);
+  const {
+    output: unreadOutput,
+    outputDropped,
+    acknowledge,
+  } = prepareSessionPoll(finished, pollScope);
   const output = unreadOutput.trim();
   // Omitted retained output is pageable only while this public id still owns
   // the exact process; a reused slug must never point the model at successor logs.
@@ -194,24 +220,27 @@ function finishedPollResult(sessionId: string, finished: ProcessSession): AgentT
       ? "\n\n[earlier output is omitted from this poll; use action=log with offset and limit to inspect retained output]"
       : "\n\n[earlier output is omitted from this poll; omitted output is no longer available through action=log]"
     : "";
-  return {
-    content: [
-      {
-        type: "text",
-        text: appendExecTimeoutRetryGuidance(
-          (output || "(no new output)") +
-            retentionCapNote(finished) +
-            retainedOutputNote +
-            `\n\nProcess exited with ${renderExecExitLabel(finished)}.`,
-          finished.exitReason,
-        ),
+  return attachInternalToolResultAcknowledgement(
+    {
+      content: [
+        {
+          type: "text",
+          text: appendExecTimeoutRetryGuidance(
+            (output || "(no new output)") +
+              retentionCapNote(finished) +
+              retainedOutputNote +
+              `\n\nProcess exited with ${renderExecExitLabel(finished)}.`,
+            finished.exitReason,
+          ),
+        },
+      ],
+      details: {
+        ...finishedSessionDetails(sessionId, finished),
+        aggregated: finished.aggregated,
       },
-    ],
-    details: {
-      ...finishedSessionDetails(sessionId, finished),
-      aggregated: finished.aggregated,
     },
-  };
+    acknowledge,
+  );
 }
 
 function createAbortError(reason: unknown): Error {
@@ -414,9 +443,10 @@ export function createProcessTool(
 
       switch (params.action) {
         case "poll": {
+          const pollScope = currentPollScope();
           if (!scopedSession) {
             if (scopedFinished) {
-              return finishedPollResult(params.sessionId, scopedFinished);
+              return finishedPollResult(params.sessionId, scopedFinished, pollScope);
             }
             resetPollRetrySuggestion(params.sessionId);
             return failText(`No session found for ${params.sessionId}`);
@@ -445,12 +475,16 @@ export function createProcessTool(
             // Retention admission survives clear/eviction on this exact object.
             // A process removed before exit was never retained; never read a successor.
             if (scopedSession.endedAt !== undefined && isInScope(scopedSession)) {
-              return finishedPollResult(params.sessionId, scopedSession);
+              return finishedPollResult(params.sessionId, scopedSession, pollScope);
             }
             resetPollRetrySuggestion(params.sessionId);
             return failText(`No session found for ${params.sessionId}`);
           }
-          const { output: unreadOutput, outputDropped } = drainSession(scopedSession);
+          const {
+            output: unreadOutput,
+            outputDropped,
+            acknowledge,
+          } = prepareSessionPoll(scopedSession, pollScope);
           const output = unreadOutput.trim();
           const aggregateOutputNote = retentionCapNote(scopedSession);
           const retainedOutputNote = outputDropped
@@ -459,26 +493,29 @@ export function createProcessTool(
           const hasNewOutput = output.length > 0;
           const retryInMs = recordPollRetrySuggestion(params.sessionId, hasNewOutput);
           const runtime = describeRunningSession(scopedSession);
-          return {
-            content: [
-              {
-                type: "text",
-                text:
-                  (output || "(no new output)") +
-                  aggregateOutputNote +
-                  retainedOutputNote +
-                  (buildInputWaitHint(runtime) || "\n\nProcess still running."),
+          return attachInternalToolResultAcknowledgement(
+            {
+              content: [
+                {
+                  type: "text",
+                  text:
+                    (output || "(no new output)") +
+                    aggregateOutputNote +
+                    retainedOutputNote +
+                    (buildInputWaitHint(runtime) || "\n\nProcess still running."),
+                },
+              ],
+              details: {
+                status: "running",
+                sessionId: params.sessionId,
+                aggregated: scopedSession.aggregated,
+                name: deriveSessionName(scopedSession.command),
+                ...runningSessionInputDetails(runtime),
+                ...(typeof retryInMs === "number" ? { retryInMs } : {}),
               },
-            ],
-            details: {
-              status: "running",
-              sessionId: params.sessionId,
-              aggregated: scopedSession.aggregated,
-              name: deriveSessionName(scopedSession.command),
-              ...runningSessionInputDetails(runtime),
-              ...(typeof retryInMs === "number" ? { retryInMs } : {}),
             },
-          };
+            acknowledge,
+          );
         }
 
         case "log": {

--- a/src/agents/runtime/internal-hooks.ts
+++ b/src/agents/runtime/internal-hooks.ts
@@ -1,6 +1,8 @@
 export {
+  acknowledgeInternalToolResult,
   attachInternalToolBatchLifecycle,
   attachInternalToolExecutionPreparer,
+  attachInternalToolResultAcknowledgement,
   copyInternalToolExecutionPreparer,
   getInternalToolExecutionPreparer,
   setInternalBeforeToolBatch,

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -701,6 +701,7 @@ export function installSessionToolResultGuard(
     message: AgentMessage,
     options?: AppendMessageOptions,
     sourceAppend?: CodeModeSourceAppend,
+    acknowledgementSource: AgentMessage = message,
   ): {
     anchor?: TranscriptEntryAnchor;
     entryId: string;
@@ -724,7 +725,7 @@ export function installSessionToolResultGuard(
     }
     const persistedMessage = entry.message;
     // Destructive tool-side state commits only after this exact result is durable.
-    acknowledgeInternalToolResult(message);
+    acknowledgeInternalToolResult(acknowledgementSource);
     const persistedId =
       persistedMessage.role === "toolResult" ? extractToolResultId(persistedMessage) : null;
     // Update only committed state, before callbacks can re-enter or throw.
@@ -890,6 +891,8 @@ export function installSessionToolResultGuard(
             toolResultTransformerMayMutate ||
             persisted.changed,
         },
+        undefined,
+        message,
       ).entryId;
     }
 

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -35,6 +35,7 @@ import {
   truncateToolResultMessage,
 } from "./embedded-agent-runner/tool-result-truncation.js";
 import type { AgentMessage } from "./runtime/index.js";
+import { acknowledgeInternalToolResult } from "./runtime/internal-hooks.js";
 import {
   getRawSessionAppendMessage,
   setRawSessionAppendMessage,
@@ -722,6 +723,8 @@ export function installSessionToolResultGuard(
       throw new Error(`Appended transcript message is unavailable: ${entryId}`);
     }
     const persistedMessage = entry.message;
+    // Destructive tool-side state commits only after this exact result is durable.
+    acknowledgeInternalToolResult(message);
     const persistedId =
       persistedMessage.role === "toolResult" ? extractToolResultId(persistedMessage) : null;
     // Update only committed state, before callbacks can re-enter or throw.


### PR DESCRIPTION
## What Problem This Solves

A completed background process could return its output from `process poll`, then lose that tool result before it entered the agent transcript. The destructive poll drain had already cleared the output, so the next poll returned no output even though `process log` still retained it.

Refs #130396.

## Root cause

The process registry treated result construction as successful delivery. Transcript persistence happens later, after tool-result hooks and message delivery. The old poll path had no acknowledgement from that boundary.

## Fix

- Stage one bounded poll delivery on the existing process session.
- Acknowledge and clear it only after the tool-result message attaches to the agent transcript.
- Reuse the same staged delivery for running and completed sessions.
- Keep parallel polls from one assistant turn from receiving the same bytes.
- Preserve the direct `process log` path and existing retention limits.

## Evidence

The same real-child scenario ran against current main `cda8825fa4ac` and current repair head `956d220fd53d`.

| Scenario | Current main | This head |
| --- | --- | --- |
| First completed poll result is deliberately omitted before transcript persistence | Next poll loses the marker; `process log` retains it | Next poll recovers the marker |
| Recovered poll result is persisted | Not applicable | Following poll does not repeat the marker |

The proof used a unique child-process marker, the real process tool, and the real transcript-repair owner.

```json
{
  "currentMain": {
    "firstPollHadCompletedOutput": true,
    "transcriptRepairInsertedMissingResult": true,
    "retryPollRecoveredCompletedOutput": false,
    "retainedLogHadCompletedOutput": true
  },
  "candidate": {
    "firstPollHadCompletedOutput": true,
    "transcriptRepairInsertedMissingResult": true,
    "retryPollRecoveredCompletedOutput": true,
    "retainedLogHadCompletedOutput": true,
    "parallelRetryDidNotDuplicateCompletedOutput": true,
    "healthyPollDidNotRepeatCompletedOutput": true
  }
}
```

### Validation

- 168 focused process, transcript, and agent-loop tests pass, including blocked-write and timeout retries.
- The final six-test staged-delivery suite and focused type-aware lint pass on `956d220fd53d`.
- Formatting and lint pass for every changed file.
- Dead-code, import-cycle, max-lines, assertion-safety, conflict-marker, and coercion-helper checks pass.
- Host type-check and build were not run; hosted CI owns them.
