### PR TITLE
fix(macos): quit without leaving SSH tunnels behind

### DIFF
--- a/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
+++ b/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
@@ -1014,7 +1014,7 @@ extension ApplicationRelocator {
         do {
             try helper.run()
             TerminationSignalWatcher.scheduleExitFailsafe()
-            NSApp.terminate(nil)
+            AppDelegate.requestTermination()
             return .terminating
         } catch {
             self.logger.error("Could not schedule relaunch: \(error.localizedDescription, privacy: .public)")
@@ -1111,7 +1111,7 @@ extension ApplicationRelocator {
             }
             self.cancelSupervisorRestorationWatcher()
             TerminationSignalWatcher.scheduleExitFailsafe()
-            NSApp.terminate(nil)
+            AppDelegate.requestTermination()
         }
         return .scheduled
     }
@@ -1171,7 +1171,7 @@ extension ApplicationRelocator {
                 \(supervisor.label, privacy: .public) can restart the installed app.
                 """)
             TerminationSignalWatcher.scheduleExitFailsafe()
-            NSApp.terminate(nil)
+            AppDelegate.requestTermination()
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/DebugActions.swift
+++ b/apps/macos/Sources/OpenClaw/DebugActions.swift
@@ -174,21 +174,16 @@ enum DebugActions {
     static func restartApp() {
         let url = Bundle.main.bundleURL
         let task = Process()
-        // Relaunch shortly after this instance exits so we get a true restart even in debug.
-        task.launchPath = "/bin/sh"
-        if let profile = AppProfile.current.name {
-            task.arguments = [
-                "-c",
-                "sleep 0.2; open -n --env OPENCLAW_PROFILE=\"$2\" \"$1\"",
-                "_",
-                url.path,
-                profile,
-            ]
-        } else {
-            task.arguments = ["-c", "sleep 0.2; open -n \"$1\"", "_", url.path]
-        }
+        // The replacement must wait until cleanup releases this profile's instance lock.
+        task.executableURL = URL(fileURLWithPath: "/bin/sh")
+        task.arguments = [
+            "-c",
+            "while /bin/kill -0 \"$1\" 2>/dev/null; do /bin/sleep 0.1; done; shift; exec /usr/bin/open -n \"$@\"",
+            "openclaw-restart",
+            String(ProcessInfo.processInfo.processIdentifier),
+        ] + (AppProfile.current.name.map { ["--env", "OPENCLAW_PROFILE=\($0)"] } ?? []) + [url.path]
         try? task.run()
-        NSApp.terminate(nil)
+        AppDelegate.requestTermination()
     }
 
     @MainActor

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -253,7 +253,7 @@ struct GeneralSettings: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer(minLength: 18)
-                Button("Quit") { NSApp.terminate(nil) }
+                Button("Quit") { AppDelegate.requestTermination() }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
             }

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -154,26 +154,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var terminationCleanupFinished = false
     private var profileInstanceLock: AppInstanceLock?
     private let webChatAutoLogger = Logger(subsystem: "ai.openclaw", category: "Chat")
-    var nodeTerminationCleanup: @MainActor () async -> Void = {
-        // CUA shutdown drains the worker before closing the daemon socket; run it
-        // first so other cleanup cannot consume the app termination deadline.
+    private static func cleanUpProcesses() async {
+        // Start tunnel retirement before helper drains can consume the quit deadline.
+        async let tunnelCleanup: Void = RemoteTunnelManager.shared.shutdown()
+        async let gatewayCleanup: Void = GatewayConnection.shared.shutdown()
+        async let profileCleanup: Void = MacGatewayConnectionFleet.shared.shutdown()
+        // CUA must drain its worker before the node closes the daemon socket.
         if AppLaunchRuntimePlan.current.allowsCuaComputerControl {
             await CuaDriverHostCoordinator.shared.shutdown()
         }
         await TalkMLXSpeechSynthesizer.shared.shutdown()
         await MacNodeModeCoordinator.shared.stopAndWait()
-    }
-
-    var peekabooBridgeTerminationCleanup: @MainActor () async -> Void = {
-        await PeekabooBridgeHostCoordinator.shared.shutdown()
-    }
-
-    var waitForTerminationCleanupDeadline: @MainActor () async -> Void = {
-        try? await Task.sleep(for: .seconds(AppTerminationTiming.cleanupDeadlineSeconds))
-    }
-
-    var applicationTerminationReply: @MainActor (NSApplication, Bool) -> Void = { app, allow in
-        app.reply(toApplicationShouldTerminate: allow)
+        _ = await (tunnelCleanup, gatewayCleanup, profileCleanup)
     }
 
     var openDashboardAction: @MainActor () -> Void = { AppNavigationActions.openDashboard() }
@@ -431,9 +423,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         VoiceWakeGlobalSettingsSync.shared.stop()
         DashboardManager.shared.close()
         WebChatManager.shared.close()
-        WebChatManager.shared.resetTunnels()
-        Task { await RemoteTunnelManager.shared.stopAll() }
-        Task { await GatewayConnection.shared.shutdown() }
+    }
+
+    static func requestTermination() {
+        // terminateLater spins a nested AppKit loop. Calling terminate on the main
+        // dispatch queue prevents that loop from running MainActor cleanup or its deadline.
+        NSApp.perform(#selector(NSApplication.terminate(_:)), with: nil, afterDelay: 0, inModes: [.common])
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
@@ -443,17 +438,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard self.terminationCleanupTask == nil else {
             return .terminateLater
         }
-        let nodeCleanup = self.nodeTerminationCleanup
-        let bridgeCleanup = self.peekabooBridgeTerminationCleanup
         self.terminationCleanupTask = Task { @MainActor [weak self] in
-            async let nodeCleanupResult: Void = nodeCleanup()
-            async let bridgeCleanupResult: Void = bridgeCleanup()
-            _ = await (nodeCleanupResult, bridgeCleanupResult)
+            async let processCleanupResult: Void = Self.cleanUpProcesses()
+            async let bridgeCleanupResult: Void = PeekabooBridgeHostCoordinator.shared.shutdown()
+            _ = await (processCleanupResult, bridgeCleanupResult)
             self?.finishTerminationCleanup(for: sender)
         }
-        let waitForDeadline = self.waitForTerminationCleanupDeadline
         self.terminationDeadlineTask = Task { @MainActor [weak self] in
-            await waitForDeadline()
+            try? await Task.sleep(for: .seconds(AppTerminationTiming.cleanupDeadlineSeconds))
             guard !Task.isCancelled else { return }
             self?.finishTerminationCleanup(for: sender)
         }
@@ -469,7 +461,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         self.terminationDeadlineTask?.cancel()
         self.terminationCleanupTask = nil
         self.terminationDeadlineTask = nil
-        self.applicationTerminationReply(sender, true)
+        sender.reply(toApplicationShouldTerminate: true)
     }
 
     static func shouldPresentScheduledFirstRunOnboarding(onboardingSeen: Bool) -> Bool {

--- a/apps/macos/Sources/OpenClaw/RemoteTunnelManager.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteTunnelManager.swift
@@ -33,11 +33,12 @@ actor RemoteTunnelManager {
     private var retirementInFlight: (token: UUID, task: Task<Void, Never>)?
     private var tunnelGeneration: UInt64 = 0
     private var lifecycleGeneration: UInt64 = 0
+    private var isShutDown = false
     private var lastRestartAt: Date?
     private let restartBackoffSeconds: TimeInterval = 2.0
 
     func controlTunnelRouteIfRunning() async -> Route? {
-        guard self.retirementInFlight == nil else { return nil }
+        guard !self.isShutDown, self.retirementInFlight == nil else { return nil }
         guard let configuration = try? RemotePortTunnel.configuration(
             remotePort: GatewayEnvironment.gatewayPort())
         else {
@@ -162,7 +163,8 @@ actor RemoteTunnelManager {
     }
 
     func ensureControlTunnelRoute() async throws -> Route {
-        try await self.ensureControlTunnelRoute(
+        guard !self.isShutDown else { throw CancellationError() }
+        return try await self.ensureControlTunnelRoute(
             lifecycleGeneration: self.lifecycleGeneration)
     }
 
@@ -360,6 +362,12 @@ actor RemoteTunnelManager {
             "ssh tunnel ready localPort=\(resolvedPort, privacy: .public) " +
                 "generation=\(route.generation, privacy: .public)")
         return route
+    }
+
+    func shutdown() async {
+        // Quit closes admission permanently; reconnect and mode changes still use stopAll.
+        self.isShutDown = true
+        await self.stopAll()
     }
 
     func stopAll() async {

--- a/apps/macos/Sources/OpenClaw/StatusMenuRenderer.swift
+++ b/apps/macos/Sources/OpenClaw/StatusMenuRenderer.swift
@@ -260,7 +260,7 @@ final class StatusMenuRenderer: NSObject {
         case .about:
             AppNavigationActions.openSettings(tab: .about)
         case .quit:
-            NSApplication.shared.terminate(nil)
+            AppDelegate.requestTermination()
         case .debug:
             break
         }

--- a/apps/macos/Sources/OpenClaw/TerminationSignalWatcher.swift
+++ b/apps/macos/Sources/OpenClaw/TerminationSignalWatcher.swift
@@ -49,12 +49,11 @@ final class TerminationSignalWatcher {
         NodePairingApprovalPrompter.shared.stop()
         DevicePairingApprovalPrompter.shared.stop()
         Self.scheduleExitFailsafe()
-        NSApp.terminate(nil)
+        AppDelegate.requestTermination()
     }
 
     static func scheduleExitFailsafe() {
-        // AppKit waits in a nested event loop while async termination cleanup runs.
-        // A main-queue failsafe cannot fire from that loop, so enforce the deadline off-main.
+        // Keep the last-resort exit independent of a stuck main actor or AppKit loop.
         DispatchQueue.global(qos: .userInitiated).asyncAfter(
             deadline: .now() + AppTerminationTiming.signalExitFailsafeSeconds)
         {

--- a/apps/macos/Tests/OpenClawIPCTests/RemoteTunnelManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/RemoteTunnelManagerTests.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct RemoteTunnelManagerTests {
+    @Test func `shutdown rejects new tunnel work even after a reusable stop`() async {
+        let manager = RemoteTunnelManager()
+        await manager.shutdown()
+        await manager.stopAll()
+
+        #expect(await manager.controlTunnelRouteIfRunning() == nil)
+        await #expect(throws: CancellationError.self) {
+            try await manager.ensureControlTunnelRoute()
+        }
+        await #expect(throws: CancellationError.self) {
+            try await manager.ensureControlTunnel()
+        }
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where quitting the macOS app could leave its SSH tunnel and port-ownership receipt behind. This was observed during the live follow-up to #130332: SIGTERM exited the app through its failsafe, but the SSH listener remained until a later orphan sweep.

## Why This Change Was Made

The app scheduled tunnel shutdown in `applicationWillTerminate`, too late to await it. Programmatic quit also called `NSApplication.terminate` from the main dispatch queue; AppKit's nested `.terminateLater` loop could not drain that same queue, starving both MainActor cleanup and its deadline. A process sample captured that exact stack.

All seven app-owned quit entry points now schedule termination through the main run loop. The existing pre-quit cleanup joins primary tunnel retirement and primary/saved-profile connections, starting those drains before helper shutdown. `RemoteTunnelManager.shutdown()` permanently closes admission while `stopAll()` remains reusable for reconnects; existing lifecycle generations fence starts already in flight. CUA-before-node ordering and the two-second cleanup/three-second signal failsafe limits stay unchanged.

The nearby debug restart path now waits for the old PID to exit instead of guessing 200 ms, so the replacement cannot lose the profile-instance lock race. Removed duplicate WebChat reset/fire-and-forget teardown and unused injectable shutdown closures. Production: +44/-50 (**net -6**); tests: +19.

## User Impact

Quit cleans up owned SSH children before exiting, including an unfinished SSH handshake. Reconnect remains available during normal operation; quit cannot accidentally start a replacement tunnel. Debug restart waits for the old app to release ownership. No configuration, schema, protocol, or dependency changes.

## Evidence

- Signed real macOS app, matching Developer ID, isolated app/profile/config and task-owned local port; existing remote Gateway was not restarted.
- Same live SIGTERM probe before/after: old app exited in 3,584 ms with child/listener/receipt still present; fixed app exited in 1,051 ms with all three gone. Dashboard-open launch also cleaned up in 1,151 ms.
- Final-source signed bundle: three launch/quit cycles cleaned up child/listener/receipt in 1,080 / 1,842 / 1,330 ms. A real SSH child held at a task-owned loopback handshake server (no tunnel listener yet) was also reaped with no receipt left in 1,015 ms.
- `swift test --package-path apps/macos --scratch-path "$PWD/apps/macos/.build/arm64" --disable-automatic-resolution --skip-update --no-parallel`: **1,830 tests / 186 suites passed**, including terminal tunnel admission and existing subprocess/tunnel generation/retirement coverage. The initial parallel run had eight issues in audio callback, cron, onboarding, and shared Gateway recovery tests; the repository's serial retry path passed without weakening tests.
- Swift lint, changed-file SwiftFormat, and independent Codex autoreview passed. Repository changed-file gates passed 502 tests across seven Vitest shards and the native schema guard. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33015002339) is green at `c544e753be92b12f39ee7c2e28ba5e93f8e80455`, including the release build and Swift tests. The macOS job waited for runner assignment before executing; no runner configuration changes or CI reruns were needed.
- UI automation could not run: Computer Use reported `codex app-server exited before returning a response`. Menu-click and Debug Restart UI interactions are not claimed as live-tested; signal-driven real-app termination is. The proof bundle omits the optional MLX speech helper, whose existing tests passed. No visual layout changes or screenshot uploads.

Dependency contract: [Apple documents the nested modal termination loop](https://developer.apple.com/documentation/appkit/nsapplication/terminate(_:)); [CoreFoundation's run-loop dispatch guard](https://github.com/swiftlang/swift-corelibs-foundation/blob/main/Sources/CoreFoundation/CFRunLoop.c#L2743-L2744) excludes recursive main-queue servicing. Swift Subprocess 1.0.0 spawn/monitor/teardown contracts were inspected directly; no dependency change is needed.
