### PR TITLE
refactor(google-meet): share token source resolution

### DIFF
--- a/extensions/google-meet/src/cli-artifact-commands.ts
+++ b/extensions/google-meet/src/cli-artifact-commands.ts
@@ -38,6 +38,10 @@ async function resolveCliArtifactQuery(
   };
 }
 
+function resolveTokenSource(refreshed: boolean) {
+  return refreshed ? "refresh-token" : "cached-access-token";
+}
+
 export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommandContext): void {
   const params = context;
   const { root } = context;
@@ -61,7 +65,7 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
           JSON.stringify(
             {
               ...result,
-              tokenSource: resolved.token.refreshed ? "refresh-token" : "cached-access-token",
+              tokenSource: resolveTokenSource(resolved.token.refreshed),
             },
             null,
             2,
@@ -77,10 +81,7 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
         throw new Error("Unsupported format. Expected summary or markdown.");
       }
       writeArtifactsSummary(result);
-      writeStdoutLine(
-        "token source: %s",
-        resolved.token.refreshed ? "refresh-token" : "cached-access-token",
-      );
+      writeStdoutLine("token source: %s", resolveTokenSource(resolved.token.refreshed));
     });
 
   addGoogleMeetArtifactOptions(
@@ -101,7 +102,7 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
           JSON.stringify(
             {
               ...result,
-              tokenSource: resolved.token.refreshed ? "refresh-token" : "cached-access-token",
+              tokenSource: resolveTokenSource(resolved.token.refreshed),
             },
             null,
             2,
@@ -121,10 +122,7 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
         throw new Error("Unsupported format. Expected summary, markdown, or csv.");
       }
       writeAttendanceSummary(result);
-      writeStdoutLine(
-        "token source: %s",
-        resolved.token.refreshed ? "refresh-token" : "cached-access-token",
-      );
+      writeStdoutLine("token source: %s", resolveTokenSource(resolved.token.refreshed));
     });
 
   addGoogleMeetArtifactOptions(
@@ -175,11 +173,11 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
             attendance,
             files: googleMeetExportFileNames(),
             request,
-            tokenSource: resolved.token.refreshed ? "refresh-token" : "cached-access-token",
+            tokenSource: resolveTokenSource(resolved.token.refreshed),
             ...(resolved.calendarEvent ? { calendarEvent: resolved.calendarEvent } : {}),
           }),
           ...(resolved.calendarEvent ? { calendarEvent: resolved.calendarEvent } : {}),
-          tokenSource: resolved.token.refreshed ? "refresh-token" : "cached-access-token",
+          tokenSource: resolveTokenSource(resolved.token.refreshed),
         });
         return;
       }
@@ -189,13 +187,13 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
         attendance,
         zip: Boolean(options.zip),
         request,
-        tokenSource: resolved.token.refreshed ? "refresh-token" : "cached-access-token",
+        tokenSource: resolveTokenSource(resolved.token.refreshed),
         ...(resolved.calendarEvent ? { calendarEvent: resolved.calendarEvent } : {}),
       });
       const payload = {
         ...bundle,
         ...(resolved.calendarEvent ? { calendarEvent: resolved.calendarEvent } : {}),
-        tokenSource: resolved.token.refreshed ? "refresh-token" : "cached-access-token",
+        tokenSource: resolveTokenSource(resolved.token.refreshed),
       };
       if (options.json) {
         writeStdoutJson(payload);


### PR DESCRIPTION
## What Problem This Solves

Google Meet artifact commands repeated the same token-source mapping across eight JSON, summary, dry-run, manifest, bundle, and export payload projections. Repeating that projection made output labels easier to drift.

## Why This Change Was Made

Use one private boolean-to-token-source helper while keeping every `tokenSource` property and optional calendar-event spread in its existing position. Output modes, request shapes, and serialization order remain unchanged.

## User Impact

No user-visible behavior changes. Google Meet artifact-command outputs use one canonical token-source mapping.

## Evidence

- Exact-head local proof passed 30/30 tests across `cli-artifacts.test.ts`, `oauth.test.ts`, and `cli-export.test.ts`.
- Exact-head Blacksmith Testbox proof passed the same 30/30 tests: lease `tbx_01m10prh1zjqyfhb7gnsc83dj4`, Actions run https://github.com/openclaw/openclaw/actions/runs/33038750008, delegated remote sync, `exitCode: 0`, `runStatus: succeeded`.
- Native `node scripts/check-changed.mjs` passed, including extension production/test typecheck, lint, dead exports, plugin boundaries, and import cycles.
- `git diff --check` passed.
- Fresh branch autoreview reported no accepted/actionable findings (`0.99` confidence).
- Production delta: `+12/-14`, net `-2`.

## ClawSweeper Disposition

- The failed `pnpm exec openclaw googlemeet artifacts --help` probe used a CLI invocation unavailable in the review checkout. It is not evidence against this private projection refactor; the command-boundary suites pass locally and in exact-head Testbox.
- No rebase is warranted. Against live `main`, the artifact-command owner, OAuth token producer, export consumer, and all three focused test files are byte-identical to the PR base. GitHub recomputed the exact head as mergeable and clean; native preparation and merge verification will validate the current merge result before landing.
