### PR TITLE
fix(crabbox): keep the setup failure reason and name its phase

### DIFF
--- a/extensions/crabbox/src/crabbox-worker-command-error.ts
+++ b/extensions/crabbox/src/crabbox-worker-command-error.ts
@@ -1,26 +1,22 @@
 import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import { WorkerProviderError } from "openclaw/plugin-sdk/plugin-entry";
 import type { SpawnResult } from "openclaw/plugin-sdk/process-runtime";
-import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 const MAX_COMMAND_DETAIL_CHARS = 512;
 
 function crabboxCommandDetail(result: SpawnResult): string {
-  const raw = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
+  const raw = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
   if (!raw) {
     return "";
   }
   const compressed = redactSensitiveText(raw).replace(/\s+/gu, " ");
-  const omitted = " ... ";
-  const remaining = MAX_COMMAND_DETAIL_CHARS - omitted.length;
-  const redacted =
-    compressed.length <= MAX_COMMAND_DETAIL_CHARS
-      ? compressed
-      : `${truncateUtf16Safe(compressed, Math.ceil(remaining / 2))}${omitted}${sliceUtf16Safe(
-          compressed,
-          -Math.floor(remaining / 2),
-        )}`;
-  return redacted ? `: ${redacted}` : "";
+  // Failure diagnoses come last; Crabbox's fixed banner is leading boilerplate.
+  // Keep stderr last, matching the per-stream suffix capture in src/process/exec-output.ts.
+  const tailMarker = "... ";
+  return compressed.length <= MAX_COMMAND_DETAIL_CHARS
+    ? `: ${compressed}`
+    : `: ${tailMarker}${sliceUtf16Safe(compressed, tailMarker.length - MAX_COMMAND_DETAIL_CHARS)}`;
 }
 
 export function crabboxCommandError(action: string, result: SpawnResult): Error {

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -956,17 +956,17 @@ describe("Crabbox worker provider", () => {
     {
       name: "fails",
       result: commandResult({ code: 7, stderr: "apt exploded" }),
-      message: "Crabbox setup failed with exit code 7",
+      message: "Crabbox profile setup failed with exit code 7",
     },
     {
       name: "times out",
       result: commandResult({ code: null, killed: true, termination: "timeout" }),
-      message: "Crabbox setup did not exit normally (timeout)",
+      message: "Crabbox profile setup did not exit normally (timeout)",
     },
     {
       name: "cannot start",
       result: undefined,
-      message: "Crabbox setup could not start",
+      message: "Crabbox profile setup could not start",
     },
   ])(
     "stops the lease and removes its private env profile when setup $name",
@@ -1023,6 +1023,64 @@ describe("Crabbox worker provider", () => {
       expect(calls.at(-1)).toEqual([SIBLING_BINARY, "stop", "--provider", "aws", "--id", LEASE_ID]);
     },
   );
+
+  it.each([
+    { phase: "profile setup", setupAttempt: 1 },
+    { phase: "desktop setup", setupAttempt: 2 },
+    { phase: "node enrollment setup", setupAttempt: 3 },
+  ])("identifies the failed $phase phase", async ({ phase, setupAttempt }) => {
+    let attempts = 0;
+    const provider = providerWithRunner(async (argv) => {
+      if (argv[1] === "inspect") {
+        return commandResult({ stdout: inspectJson() });
+      }
+      if (argv[1] === "run" && ++attempts === setupAttempt) {
+        return commandResult({ code: 7, stderr: "setup command rejected" });
+      }
+      return commandResult();
+    });
+
+    await expect(
+      provider.provision({ ...PROFILE, setup: "install-node", desktop: true }, OPERATION_ID),
+    ).rejects.toMatchObject({
+      code: "invalid_profile",
+      message: `Crabbox ${phase} failed with exit code 7: setup command rejected`,
+    });
+  });
+
+  it("preserves the node enrollment diagnosis after the Crabbox banner and setup noise", async () => {
+    const diagnosis =
+      "Error: Codex remote-exec requires the exact official @openclaw/codex@2026.8.1 plugin to be installed by cloudWorkers profile setup";
+    const stderr = [
+      `workspace owner acquired wait=218ms recovered=false run context: run=${"a".repeat(32)} lease=${LEASE_ID} slug=openclaw-${"b".repeat(32)} provider=machine0 ssh=openclaw@worker.example.test:2222 workspace=/workspace/openclaw`,
+      "x".repeat(2_000),
+      diagnosis,
+      "    at prepareCodex ([eval]:20:11)",
+      "    at runScriptInThisContext (node:internal/vm:209:10)",
+      "    at node:internal/process/execution:446:12",
+      "    at [eval]-wrapper:6:24",
+      "    at runScriptInContext (node:internal/process/execution:444:60)",
+      "    at evalFunction (node:internal/process/execution:279:30)",
+      "Node.js v24.15.0",
+    ].join("\n");
+    const provider = providerWithRunner(async (argv) => {
+      if (argv[1] === "status") {
+        return commandResult({ stdout: inspectJson() });
+      }
+      return argv[1] === "run"
+        ? commandResult({ code: 1, stderr, stdout: "setup progress ".repeat(200) })
+        : commandResult();
+    });
+
+    await expect(
+      provider.provision({ ...PROFILE, provider: "machine0" }, OPERATION_ID, {
+        executionMode: "remote-exec",
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_profile",
+      message: expect.stringContaining(diagnosis),
+    });
+  });
 
   it("preserves the allocated lease and both failures when setup cleanup times out", async () => {
     let releaseCommitted = false;
@@ -2854,8 +2912,8 @@ describe("Crabbox worker provider", () => {
           code,
           termination,
           killed: termination !== "exit",
-          stderr: `provider warning ${secret} ${"provider progress ".repeat(90)}${terminalStderr}`,
-          stdout: terminalStdout,
+          stderr: `provider warning ${secret}\n${terminalStderr}`,
+          stdout: `${"provider progress ".repeat(90)}\n${terminalStdout}`,
         }),
       );
       const operation =
@@ -2870,10 +2928,11 @@ describe("Crabbox worker provider", () => {
         action === "warmup"
           ? "Crabbox warmup failed with exit code 5: "
           : "Crabbox inspect did not exit normally (timeout): ";
-      expect(message).toContain("provider warning");
+      expect(message.startsWith(`${failurePrefix}... `)).toBe(true);
       expect(message).toContain(terminalStderr);
       expect(message).toContain(terminalStdout);
       expect(message).not.toContain(secret);
+      expect(message).not.toMatch(/\s{2,}/u);
       expect(message.length).toBeLessThanOrEqual(failurePrefix.length + 512);
       expect(hasLoneSurrogate(message)).toBe(false);
     },
@@ -2882,10 +2941,11 @@ describe("Crabbox worker provider", () => {
   it.each(["stderr", "stdout"] as const)(
     "preserves UTF-16 boundaries and terminal detail from %s",
     async (stream) => {
+      const terminalDetail = "😀 terminal failure";
       const provider = providerWithRunner(async () =>
         commandResult({
           code: 2,
-          [stream]: `${"x".repeat(253)}😀${"y".repeat(300)}😀 terminal failure`,
+          [stream]: `${"x".repeat(600)}😀${"y".repeat(507 - terminalDetail.length)}${terminalDetail}`,
         }),
       );
 

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -305,6 +305,7 @@ async function waitForProvisionReady(
 // otherwise the caller cannot release a box it never learned about.
 async function runProvisionSetupAndWaitReady(
   params: ProvisionInspectContext & {
+    phase: string;
     setup: string;
     timeoutMs?: number;
     forwardedEnv?: Record<string, string>;
@@ -316,7 +317,7 @@ async function runProvisionSetupAndWaitReady(
       params.forwardedEnv,
       (names, profilePath, childEnv) =>
         runCrabboxCommand({
-          action: "setup",
+          action: params.phase,
           args: leaseRunArgs({ ...params, id: params.inspect.id }, names, profilePath),
           binary: params.binary,
           env: childEnv,
@@ -329,7 +330,7 @@ async function runProvisionSetupAndWaitReady(
         }),
     );
     if (result.termination !== "exit" || result.code !== 0) {
-      throw permanentCrabboxCommandError("setup", result);
+      throw permanentCrabboxCommandError(params.phase, result);
     }
   } catch (error) {
     return await failProvisionAfterCleanup({ ...params, id: params.inspect.id }, error);
@@ -588,10 +589,7 @@ export function createCrabboxWorkerProvider(
       } catch (error) {
         // Transport failure after warmup is indeterminate; preserve the lease for durable replay.
         if (error instanceof WorkerProviderError) {
-          return await failProvisionAfterCleanup(
-            { binary, id: leaseId, provider: parsed.provider, runCommand },
-            error,
-          );
+          return await failProvisionAfterCleanup({ ...context, id: leaseId, runCommand }, error);
         }
         throw error;
       }
@@ -599,11 +597,10 @@ export function createCrabboxWorkerProvider(
         throw new Error("Crabbox warmup lease was not found during inspection");
       }
       const inspectedParams = {
-        binary,
+        ...context,
         deadline,
         inspect: inspected.inspect,
         profile: parsed,
-        provider: parsed.provider,
         runCommand,
       };
       if (isUnusableProvisionState(inspected.inspect.state)) {
@@ -617,6 +614,7 @@ export function createCrabboxWorkerProvider(
       if (parsed.setup) {
         inspectedParams.inspect = await runProvisionSetupAndWaitReady({
           ...inspectedParams,
+          phase: "profile setup",
           setup: parsed.setup,
           forwardedEnv,
           sleep,
@@ -625,6 +623,7 @@ export function createCrabboxWorkerProvider(
       if (parsed.desktop) {
         inspectedParams.inspect = await runProvisionSetupAndWaitReady({
           ...inspectedParams,
+          phase: "desktop setup",
           setup: createCrabboxWorkerDesktopSetup(leaseId, wallpaperBase64),
           sleep,
         });
@@ -652,6 +651,7 @@ export function createCrabboxWorkerProvider(
       });
       inspectedParams.inspect = await runProvisionSetupAndWaitReady({
         ...inspectedParams,
+        phase: "node enrollment setup",
         setup: nodeEnrollmentSetup.command,
         timeoutMs: CRABBOX_NODE_ENROLLMENT_TIMEOUT_MS,
         ...(nodeEnrollmentSetup.forwardedEnv

--- a/extensions/crabbox/src/crabbox-worker-warm-image.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-warm-image.test.ts
@@ -339,7 +339,7 @@ describe("Crabbox profile warm images", () => {
 
     await expect(
       provisionWarmProfile(provider, { ...PROFILE, setup: "install-node" }),
-    ).rejects.toThrow("Crabbox setup failed");
+    ).rejects.toThrow("Crabbox profile setup failed");
 
     expect(calls.some(({ argv }) => argv[1] === "checkpoint")).toBe(false);
     expect(calls.at(-1)?.argv[1]).toBe("stop");


### PR DESCRIPTION
## What Problem This Solves

A Crabbox cloud-worker provision that fails during setup can report an error that contains
none of the reason it failed.

Dispatching a Codex `remote-exec` session to a `machine0` cloud-worker profile on a live
Gateway failed with:

```
Worker provider rejected profile: Crabbox setup failed with exit code 1: workspace owner
acquired wait=218ms recovered=false run context: run=run_b5ffd42c76eb portal=- logs=-
lease=cbx_b0b0d3f1d563 slug=openclaw-b379499e4e816b8f4ec082d9ffc3... <node stack tail>
```

That reads like a workspace-lock problem. It is not. The real message, captured live from the
worker, was:

```
Error: Codex remote-exec requires the exact official @openclaw/codex@2026.8.1 plugin to be
installed by cloudWorkers profile setup
```

That sentence is exactly the actionable guidance the operator needs, and it was deleted before
the operator ever saw it. Two production defects combined:

1. **Middle truncation discarded the diagnosis.** `crabboxCommandDetail()` kept the first ~254
   and last ~253 characters of combined output and dropped the middle. Crabbox always prints a
   fixed ~250-character run-context banner first, so head preservation was guaranteed to spend
   half the budget on boilerplate. In the real failure (8031 chars of stderr) the actionable
   line sat at collapsed index 2570 — squarely in the deleted middle.

2. **Three setup phases shared one anonymous label.** Profile setup, desktop setup, and node
   enrollment setup all failed as `Crabbox setup failed …`, so the message never said which
   phase broke.

Per the repo's severity order, this is the worst class in play: the action ended with an
outcome the operator could not act on.

## Why This Change Was Made

**Truncation keeps the tail.** A failing command's diagnosis is last; the Crabbox banner is
leading boilerplate. This also makes the pipeline self-consistent — the capture layer
(`src/process/exec-output.ts`) already retains each stream's *suffix*. The streams are joined
`[stdout, stderr]` so stderr, the more diagnostic stream for a failure, occupies the retained
tail instead of being pushed out by a chatty stdout. The 512-character budget is unchanged;
core re-truncates the composed message to 1024 UTF-16 units
(`src/gateway/worker-environments/worker-error.ts`), so 512 stays well inside it.

**Phases are named.** Each of the three setup calls now carries its own operator-facing label,
matching the sibling that already does this correctly: the shared SSH bootstrap in
`src/gateway/worker-environments/bootstrap.ts` labels its phases `preflight` / `bundle
transfer` / `install`.

No behavior outside error formatting changes. The `prepareCodex()` assertion and its message
are untouched: refusing to install a plugin during enrollment is deliberate and documented
(`docs/gateway/cloud-workers.md:191`), and this change only makes its refusal legible.

## User Impact

Operators debugging a failed cloud-worker provision now see which setup phase failed and the
end of that phase's output, where the reason lives. The same failure now reports:

```
Crabbox node enrollment setup failed with exit code 1: ... Error: Codex remote-exec requires
the exact official @openclaw/codex@2026.8.1 plugin to be installed by cloudWorkers profile
setup at [eval]:1:399 ...
```

No config, schema, or protocol surface changes.

## Evidence

Root cause was reproduced live on a real `machine0` lease, not simulated.

**Live root-cause reproduction (machine0, real lease).** Warmed a real Crabbox `machine0`
lease, ran the gateway's own profile setup script through the same
`crabbox run --no-sync --script-stdin` path the provider uses, then replayed the generated node
enrollment command:

- Profile setup succeeded, exit 0 in 49.5s — so the failing phase was never profile setup.
- `openclaw plugins inspect codex --json` on the worker returned
  `{"ok":false,"error":{"message":"Plugin not found: codex..."}}` (57 stock plugins installed,
  no codex). That JSON parses cleanly, so `prepareCodex()` reached its plugin assertion and
  threw synchronously at eval top level — matching the
  `evalFunction` / `evalTypeScript` / `eval_string` frames in the original report.
- Replaying the enrollment step reproduced the failure exactly: exit 1, 8031 chars of stderr,
  0 stdout.

The lease was destroyed afterwards (`released lease=... action=destroy`, `crabbox list` empty).

**Before/after on the real captured bytes.** Running that exact 8031-char stderr through the
production formatter:

Before — the reason is absent; only the fixed banner survives:

```
Crabbox setup failed with exit code 1: workspace owner acquired wait=212ms recovered=false
run context: run=run_4241a40b22f5 portal=- logs=- lease=cbx_0a52cf884f68 slug=amber-crayfish
provider=machine0 target=linux type=large ssh=ubuntu@... workdir= ...
```

After — the phase is named and the actionable instruction survives:

```
Crabbox node enrollment setup failed with exit code 1: ... exact official
@openclaw/codex@2026.8.1 plugin to be installed by cloudWorkers profile setup at [eval]:1:399
at runScriptInThisContext (node:internal/vm:209:10) ...
```

Known bound: at the unchanged 512-character budget the retained tail starts a few characters
into that sentence (`... exact official ...` rather than `requires the exact official ...`),
because roughly half the window is Node stack frames. The operator-actionable content is
present; widening the budget was deliberately left out of this change.

**Regression tests fail before the production change.** Added first, then verified:

```
× identifies the failed 'profile setup' phase
× identifies the failed 'desktop setup' phase
× identifies the failed 'node enrollment setup' phase
× preserves the node enrollment diagnosis after the Crabbox banner and setup noise
Test Files  1 failed (1)
```

**Validation.**

```
node scripts/run-vitest.mjs extensions/crabbox
Test Files  5 passed (5)
     Tests  200 passed (200)
```

`node scripts/check-changed.mjs` — green (format, tsgo extensions + extension tests, lint,
knip dead-code, database-first guard, import cycles).

Autoreview (codex / gpt-5.6-sol / high): clean, no accepted or actionable findings.

**Production LOC.** Net **−4** production lines (+16 / −20); tests +60.

## Notes for reviewers

This change makes the failure legible; it does not change the underlying requirement. Codex
remote-exec on a cloud worker requires the profile's `settings.setup` or the image to install
the official `@openclaw/codex` plugin — that is documented at `docs/gateway/cloud-workers.md:191`
and is **not** machine0-specific. Enrollment deliberately refuses to install plugins itself,
which is why asserting-and-failing is correct behavior here.
