### PR TITLE
fix(ui): make dashboard side panels enter split view

### DIFF
--- a/ui/src/e2e/board-split-transcript.e2e.test.ts
+++ b/ui/src/e2e/board-split-transcript.e2e.test.ts
@@ -171,7 +171,7 @@ describeControlUiE2e("Board split transcript restore", () => {
     await page.locator(".board-session-surface").waitFor();
     await page.getByText("Message number 39:").first().waitFor({ timeout: 15_000 });
 
-    const mode = (value: "split" | "dashboard") =>
+    const mode = (value: "chat" | "split" | "dashboard") =>
       page.locator(`wa-radio.settings-segmented__btn[value="${value}"]`);
 
     // Defer each dock update so the pane render that stamps the transcript into
@@ -267,8 +267,17 @@ describeControlUiE2e("Board split transcript restore", () => {
     }
   }, 120_000);
 
-  it("closes and reopens the whole multi-tab dashboard side panel", async () => {
-    const context = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+  it("transitions between Dashboard and Split with the whole side panel", async () => {
+    const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
+    if (recordProof) {
+      await mkdir(proofDir, { recursive: true });
+    }
+    const context = await browser.newContext({
+      viewport: { width: 1400, height: 900 },
+      ...(recordProof
+        ? { recordVideo: { dir: proofDir, size: { width: 1400, height: 900 } } }
+        : {}),
+    });
     contexts.add(context);
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -284,7 +293,13 @@ describeControlUiE2e("Board split transcript restore", () => {
       ],
       methodResponses: {
         "board.get": boardSnapshot("right"),
-        "board.update": boardSnapshot("right", 2),
+        "board.update": {
+          sequence: [
+            boardSnapshot("hidden", 2),
+            boardSnapshot("right", 3),
+            boardSnapshot("hidden", 4),
+          ],
+        },
         "browser.request": {
           cases: [
             { match: { method: "GET", path: "/tabs" }, response: { running: false, tabs: [] } },
@@ -299,6 +314,17 @@ describeControlUiE2e("Board split transcript restore", () => {
 
     const board = page.locator(".board-session-surface__board");
     const sidePanel = page.locator(".side-panel");
+    const mode = (value: "chat" | "split" | "dashboard") =>
+      page.locator(`wa-radio.settings-segmented__btn[value="${value}"]`);
+    const activeMode = () =>
+      page.locator("wa-radio.settings-segmented__btn--active").getAttribute("value");
+    const recordStep = async (name: string) => {
+      if (!recordProof) {
+        return;
+      }
+      await page.screenshot({ path: path.join(proofDir, `${name}.png`) });
+      await page.waitForTimeout(500);
+    };
     await sidePanel.waitFor();
     const expectedTabLabels = ["Board chat", "Browser", "Terminal"];
     await expectSidePanelTabs(page, expectedTabLabels);
@@ -310,19 +336,45 @@ describeControlUiE2e("Board split transcript restore", () => {
       (element) => element.getBoundingClientRect().width,
     );
 
-    await sidePanel.getByRole("button", { name: "Close", exact: true }).click();
+    await mode("dashboard").click();
 
     await expect.poll(() => sidePanel.count()).toBe(0);
     await expect
       .poll(() => board.evaluate((element) => element.getBoundingClientRect().width))
       .toBeGreaterThan(widthBeforeClose);
-    expect(await gateway.getRequests("board.update")).toEqual([]);
+    await expect.poll(() => activeMode()).toBe("dashboard");
+    expect(await gateway.getRequests("board.update")).toHaveLength(1);
+    await recordStep("transition-01-dashboard");
 
     await page.getByRole("button", { name: "Side panel", exact: true }).click();
     await sidePanel.waitFor();
     await expectSidePanelTabs(page, expectedTabLabels);
     expect(await sidePanel.locator('[data-panel-slot="chat"]').count()).toBe(1);
-    expect(await gateway.getRequests("board.update")).toEqual([]);
+    await expect.poll(() => activeMode()).toBe("split");
+    expect(await gateway.getRequests("board.update")).toHaveLength(2);
+    await recordStep("transition-02-split-reopened");
+
+    await sidePanel.getByRole("button", { name: "Close", exact: true }).click();
+
+    await expect.poll(() => sidePanel.count()).toBe(0);
+    await expect.poll(() => activeMode()).toBe("dashboard");
+    expect(await gateway.getRequests("board.update")).toHaveLength(3);
+    await recordStep("transition-03-panel-closed");
+    await mode("chat").click();
+    await expect.poll(() => activeMode()).toBe("chat");
+    await expect.poll(() => sidePanel.count()).toBe(0);
+    await recordStep("transition-04-chat");
+    await mode("dashboard").click();
+    await expect.poll(() => activeMode()).toBe("dashboard");
+    await expect.poll(() => sidePanel.count()).toBe(0);
+    expect(await gateway.getRequests("board.update")).toHaveLength(3);
+    await recordStep("transition-05-dashboard-final");
+    if (recordProof) {
+      const video = page.video();
+      await context.close();
+      contexts.delete(context);
+      await video?.saveAs(path.join(proofDir, "dashboard-side-panel-transition.webm"));
+    }
   }, 120_000);
 
   it("activates Side chat from a split dashboard panel", async () => {
@@ -438,7 +490,7 @@ describeControlUiE2e("Board split transcript restore", () => {
     }
   }, 120_000);
 
-  it("closes and reopens sole projected Board chat from either close control", async () => {
+  it("transitions sole Board chat from either close control", async () => {
     const context = await browser.newContext({ viewport: { width: 1400, height: 900 } });
     contexts.add(context);
     const page = await context.newPage();
@@ -447,7 +499,14 @@ describeControlUiE2e("Board split transcript restore", () => {
       featureMethods: ["board.get", "board.update", "chat.metadata", "chat.startup"],
       methodResponses: {
         "board.get": boardSnapshot("right"),
-        "board.update": boardSnapshot("right", 2),
+        "board.update": {
+          sequence: [
+            boardSnapshot("hidden", 2),
+            boardSnapshot("right", 3),
+            boardSnapshot("hidden", 4),
+            boardSnapshot("right", 5),
+          ],
+        },
       },
     });
     await showDashboard(page);
@@ -464,21 +523,22 @@ describeControlUiE2e("Board split transcript restore", () => {
     await expect.poll(() => sidePanel.count()).toBe(0);
     expect(await headerToggle.getAttribute("aria-expanded")).toBe("false");
     expect(await headerToggle.getAttribute("aria-label")).toBe("Side panel");
-    expect(await gateway.getRequests("board.update")).toEqual([]);
+    expect(await gateway.getRequests("board.update")).toHaveLength(1);
 
     await headerToggle.click();
     await sidePanel.waitFor();
     await expectSidePanelTabs(page, ["Board chat"]);
     expect(await headerToggle.getAttribute("aria-expanded")).toBe("true");
-    expect(await gateway.getRequests("board.update")).toEqual([]);
+    expect(await gateway.getRequests("board.update")).toHaveLength(2);
 
     await headerToggle.click();
     await expect.poll(() => sidePanel.count()).toBe(0);
     expect(await headerToggle.getAttribute("aria-expanded")).toBe("false");
-    expect(await gateway.getRequests("board.update")).toEqual([]);
+    expect(await gateway.getRequests("board.update")).toHaveLength(3);
 
     await headerToggle.click();
     await sidePanel.waitFor();
     await expectSidePanelTabs(page, ["Board chat"]);
+    expect(await gateway.getRequests("board.update")).toHaveLength(4);
   }, 120_000);
 });

--- a/ui/src/e2e/board-split-transcript.e2e.test.ts
+++ b/ui/src/e2e/board-split-transcript.e2e.test.ts
@@ -390,6 +390,54 @@ describeControlUiE2e("Board split transcript restore", () => {
     }
   }, 120_000);
 
+  it("does not offer Discussion when the gateway has no discussion provider", async () => {
+    const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
+    if (recordProof) {
+      await mkdir(proofDir, { recursive: true });
+    }
+    const context = await browser.newContext({
+      viewport: { width: 1400, height: 900 },
+      ...(recordProof
+        ? { recordVideo: { dir: proofDir, size: { width: 1400, height: 900 } } }
+        : {}),
+    });
+    contexts.add(context);
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      sessionKey,
+      featureMethods: ["board.get", "chat.metadata", "chat.startup", "session.discussion.info"],
+      methodResponses: {
+        "board.get": boardSnapshot("right"),
+        "session.discussion.info": { state: "none" },
+      },
+    });
+
+    try {
+      await showDashboard(page);
+      const sidePanel = page.locator(".side-panel");
+      await sidePanel.waitFor();
+      await expect
+        .poll(() =>
+          gateway.getRequests("session.discussion.info").then((requests) => requests.length),
+        )
+        .toBe(1);
+      await sidePanel.getByRole("button", { name: "Add side panel tab" }).click();
+      await expect
+        .poll(() => sidePanel.locator("wa-dropdown-item").filter({ hasText: "Discussion" }).count())
+        .toBe(0);
+      if (recordProof) {
+        await page.screenshot({ path: path.join(proofDir, "03-discussion-hidden.png") });
+      }
+    } finally {
+      const video = page.video();
+      await context.close();
+      contexts.delete(context);
+      if (recordProof && video) {
+        await video.saveAs(path.join(proofDir, "dashboard-discussion-unavailable.webm"));
+      }
+    }
+  }, 120_000);
+
   it("closes and reopens sole projected Board chat from either close control", async () => {
     const context = await browser.newContext({ viewport: { width: 1400, height: 900 } });
     contexts.add(context);

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -287,7 +287,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
     if (renderedLayout.columns[0]?.panels.some((panel) => panel.slot === "companion")) {
       this.setSessionObserverVisibility(open);
     }
-    state.updateSidebarLayout(setSidebarOpen(renderedLayout, open));
+    this.commitSidebarLayout(setSidebarOpen(renderedLayout, open));
   }
 
   protected requestSessionRail(intent: "open" | "toggle"): void {
@@ -297,11 +297,11 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
     }
     const visible = this.selectedSessionRailMode(state.sessionKey) === "expanded";
     if (intent === "toggle" && visible) {
-      state.updateSidebarLayout(closeSlot(state.sidebarLayout, "companion"));
+      this.commitSidebarLayout(closeSlot(state.sidebarLayout, "companion"));
       this.setSessionObserverVisibility(false);
       return;
     }
-    state.updateSidebarLayout(openSlot(state.sidebarLayout, "companion"));
+    this.commitSidebarLayout(openSlot(state.sidebarLayout, "companion"));
     this.setSessionObserverVisibility(true);
   }
 
@@ -487,6 +487,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   }
 
   protected abstract refreshSessionPullRequests(options?: { refresh?: boolean }): Promise<void>;
+  protected abstract commitSidebarLayout(layout: SidebarLayout): void;
   protected abstract refreshSwarmRoster(): void;
   protected abstract resolveBoardProvider(): BoardProvider;
   protected abstract handleBoardCommand(event: BoardCommandEvent): void;

--- a/ui/src/pages/chat/chat-pane-board.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.test.ts
@@ -56,6 +56,7 @@ type TestChatPane = HTMLElement & {
   routeFace: "chat" | "dashboard";
   onFaceChange?: (paneId: string, sessionKey: string, face: "chat" | "dashboard") => void;
   confirmConversationReset: () => Promise<boolean>;
+  commitSidebarLayout: (layout: ChatPageHost["sidebarLayout"]) => void;
   settleResetConfirmation: (confirmed: boolean) => void;
   updated: () => void;
   handleBoardCommand: (event: BoardCommandEvent) => void;
@@ -173,6 +174,26 @@ afterEach(() => {
 });
 
 describe("chat pane board shell", () => {
+  it("couples explicit side-panel visibility to the Board dock", () => {
+    const pane = createTestPane();
+    const provider = mockBoardProvider("agent:main:current");
+    const applyOps = vi.spyOn(provider, "applyOps");
+    pane.boardProvider = provider;
+    pane.routeFace = "dashboard";
+    pane.handleBoardDockChange("hidden");
+    applyOps.mockClear();
+
+    pane.commitSidebarLayout(openSlot(pane.state.sidebarLayout, "terminal"));
+    expect(applyOps).toHaveBeenLastCalledWith([
+      { kind: "tab_update", tabId: "main", chatDock: "right" },
+    ]);
+
+    pane.commitSidebarLayout({ ...pane.state.sidebarLayout, open: false });
+    expect(applyOps).toHaveBeenLastCalledWith([
+      { kind: "tab_update", tabId: "main", chatDock: "hidden" },
+    ]);
+  });
+
   it("does not hydrate the swarm after becoming hidden during module loading", async () => {
     vi.useFakeTimers();
     const list = vi.fn().mockResolvedValue({ sessions: [] });

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -50,6 +50,16 @@ import {
 
 export abstract class ChatPaneBoard extends ChatPaneHistory {
   protected commitSidebarLayout(layout: SidebarLayout): void {
+    // User panel intents and the Board mode must move together. Restored state
+    // bypasses this seam so loading a session never mutates its active tab.
+    const board = this.resolveBoardView();
+    if (board.hasBoard && board.face === "dashboard" && board.provider.canMutate) {
+      if (layout.open === true && board.dock === "hidden") {
+        this.handleBoardDockChange(board.reopenDock);
+      } else if (layout.open !== true && (board.dock === "left" || board.dock === "right")) {
+        this.handleBoardDockChange("hidden");
+      }
+    }
     const state = this.state;
     if (!state) {
       return;

--- a/ui/src/pages/chat/chat-pane-discussion.ts
+++ b/ui/src/pages/chat/chat-pane-discussion.ts
@@ -144,7 +144,7 @@ export abstract class ChatPaneDiscussion extends ChatPaneSessionMenu {
       this.paneWidth >= SIDEBAR_NARROW_BREAKPOINT_PX
         ? (fitSidebarLayout(opened, this.paneWidth) ?? opened)
         : opened;
-    state.updateSidebarLayout(fitted);
+    this.commitSidebarLayout(fitted);
     if (discussionPanel) {
       state.updateSidebarActivePanel(discussionPanel.id);
     }
@@ -181,7 +181,7 @@ export abstract class ChatPaneDiscussion extends ChatPaneSessionMenu {
       label,
       onToggle: () =>
         active
-          ? state.updateSidebarLayout(closeSlot(state.sidebarLayout, "discussion"))
+          ? this.commitSidebarLayout(closeSlot(state.sidebarLayout, "discussion"))
           : this.openSessionDiscussionSlot(),
     };
   }

--- a/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
@@ -1,0 +1,24 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import { availableSidebarSlots, sidebarPanelDefinitions } from "./chat-pane-embedded-panels.ts";
+import type { SessionDiscussionPanelConfig } from "./components/session-discussion-panel.ts";
+
+function discussionSlots(discussionAvailable: boolean) {
+  const discussion = {} as SessionDiscussionPanelConfig;
+  const definitions = sidebarPanelDefinitions({
+    discussion,
+    discussionAvailable,
+  } as Parameters<typeof sidebarPanelDefinitions>[0]);
+  return availableSidebarSlots(definitions);
+}
+
+describe("chat pane embedded panels", () => {
+  it("does not offer Discussion when no provider is available", () => {
+    expect(discussionSlots(false)).not.toContain("discussion");
+  });
+
+  it("offers Discussion after the provider reports it available", () => {
+    expect(discussionSlots(true)).toContain("discussion");
+  });
+});

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -47,6 +47,7 @@ type SidebarPanelDefinitionParams = {
   pendingQuestion: string | null;
   onClearCompanion: () => void;
   discussion: SessionDiscussionPanelConfig | null;
+  discussionAvailable: boolean;
   discussionOpenUrl: string | null;
   discussionSourceGeneration: number;
 };
@@ -228,7 +229,7 @@ export function sidebarPanelDefinitions(
         : {}),
     }),
     definePanel("discussion", "discussion", icons.messageSquare, discussion, {
-      available: discussion !== null,
+      available: discussion !== null && params?.discussionAvailable === true,
       ...(params?.discussionOpenUrl
         ? {
             headerAction: html`<a

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -85,6 +85,8 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       ${board.face === "dashboard" ? header : nothing}${this.renderBoardPrimary(board, chat)}
     </div>`;
     const discussion = this.buildSessionDiscussionPanel(state, state.sessionKey.trim());
+    const discussionState = this.sessionDiscussionStates.get(state.sessionKey.trim());
+    const discussionAvailable = discussionState === "available" || discussionState === "open";
     const desktopAvailable = isDesktopPanelAvailable(this.context.gateway.snapshot);
     const companionThread = this.sessionCompanionThreads.view(state.sessionKey, currentAgentId);
     const browserPresented =
@@ -128,6 +130,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       pendingQuestion: companionThread.pendingQuestion,
       onClearCompanion: () => void this.clearSessionCompanion(),
       discussion,
+      discussionAvailable,
       discussionOpenUrl: discussion?.openUrl ?? null,
       discussionSourceGeneration: this.connectionGeneration,
     });

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -92,6 +92,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     },
     pending: this.pendingPanelToggleRequests,
     requestUpdate: () => this.requestUpdate(),
+    updateSidebarLayout: (layout) => this.commitSidebarLayout(layout),
   });
 
   private chatRouteReadyReported = false;
@@ -313,7 +314,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
       if (visible) {
         releaseAttachmentWorkspaceOwner(state, slot);
       }
-      state.updateSidebarLayout(
+      this.commitSidebarLayout(
         visible ? closeSlot(state.sidebarLayout, slot) : openSlot(state.sidebarLayout, slot),
       );
     };

--- a/ui/src/pages/chat/chat-pane-rails.ts
+++ b/ui/src/pages/chat/chat-pane-rails.ts
@@ -24,12 +24,13 @@ export function createChatPaneRails(params: {
   presented: boolean;
   gatewaySnapshot: ChatPaneGatewaySnapshot;
   setObserverVisibility: (visible: boolean) => void;
+  updateSidebarLayout: ChatPageHost["updateSidebarLayout"];
 }) {
   const { state, sidebarLayout } = params;
   const hasPanelSlot = (slot: SidebarSlotId) =>
     sidebarLayout.columns[0]?.panels.some((panel) => panel.slot === slot) === true;
   const openPanelSlot = (slot: SidebarSlotId) => {
-    state.updateSidebarLayout(openSlot(state.sidebarLayout, slot));
+    params.updateSidebarLayout(openSlot(sidebarLayout, slot));
     if (slot === "companion") {
       params.setObserverVisibility(true);
     }
@@ -39,7 +40,7 @@ export function createChatPaneRails(params: {
       params.setObserverVisibility(false);
     }
     releaseAttachmentWorkspaceOwner(state, slot);
-    state.updateSidebarLayout(closeSlot(state.sidebarLayout, slot));
+    params.updateSidebarLayout(closeSlot(sidebarLayout, slot));
   };
   const togglePanelSlot = (slot: SidebarSlotId) =>
     hasPanelSlot(slot) ? closePanelSlot(slot) : openPanelSlot(slot);

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -234,6 +234,7 @@ export class ChatPane extends ChatPaneLayoutRender {
         presented: this.presented,
         gatewaySnapshot,
         setObserverVisibility: this.setSessionObserverVisibility,
+        updateSidebarLayout: (layout) => this.commitSidebarLayout(layout),
       });
     const selfUser = resolveCurrentSelfUser({
       snapshotUser: gatewaySnapshot.selfUser,

--- a/ui/src/pages/chat/chat-pane-session-panel-toggle.ts
+++ b/ui/src/pages/chat/chat-pane-session-panel-toggle.ts
@@ -23,6 +23,7 @@ interface SessionPanelToggleControllerOptions {
   current: () => ActivePanelOwner | null;
   pending: Map<SessionPanelToggleSlot, Event>;
   requestUpdate: () => void;
+  updateSidebarLayout: (layout: ChatPageHost["sidebarLayout"]) => void;
 }
 
 /** Owns shell-to-pane panel intent handoff for the active chat presentation. */
@@ -38,7 +39,7 @@ export class ChatPaneSessionPanelToggleController {
     const detail = event instanceof CustomEvent ? event.detail : null;
     if (detail?.open === false) {
       this.options.pending.delete(slot);
-      owner.state.updateSidebarLayout(closeSlot(owner.state.sidebarLayout, slot));
+      this.options.updateSidebarLayout(closeSlot(owner.state.sidebarLayout, slot));
       return true;
     }
     if (slot === "terminal") {
@@ -54,11 +55,11 @@ export class ChatPaneSessionPanelToggleController {
           deferUntilHostChange: !embeddedTerminalMounted,
         });
       }
-      owner.state.updateSidebarLayout(openSlot(owner.state.sidebarLayout, slot));
+      this.options.updateSidebarLayout(openSlot(owner.state.sidebarLayout, slot));
       return true;
     }
     this.options.pending.set(slot, event);
-    owner.state.updateSidebarLayout(openSlot(owner.state.sidebarLayout, slot));
+    this.options.updateSidebarLayout(openSlot(owner.state.sidebarLayout, slot));
     void Promise.all([
       customElements.whenDefined("openclaw-chat-sidebar-region"),
       customElements.whenDefined(tagName),

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.test.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.test.ts
@@ -12,8 +12,17 @@ import type { ChatPageHost } from "./chat-state-host.ts";
 import "./components/chat-sidebar-region.runtime.ts";
 import { openSlot, setSidebarOpen, type SidebarLayout } from "./sidebar-layout.ts";
 
-function board(dock: ResolvedBoardView["dock"], face: ResolvedBoardView["face"] = "dashboard") {
-  return { hasBoard: true, face, dock } as ResolvedBoardView;
+function board(
+  dock: ResolvedBoardView["dock"],
+  face: ResolvedBoardView["face"] = "dashboard",
+  canMutate = true,
+) {
+  return {
+    hasBoard: true,
+    face,
+    dock,
+    provider: { canMutate },
+  } as ResolvedBoardView;
 }
 
 const containers: HTMLElement[] = [];
@@ -186,14 +195,15 @@ describe("chat pane sidebar layout", () => {
     expect(updateSidebarActivePanel).toHaveBeenCalledWith(chatPanel!.id);
   });
 
-  it("keeps bottom and hidden board chat outside the side panel", () => {
+  it("keeps bottom and narrow hidden Board chat outside the side panel", () => {
     for (const dock of ["bottom", "hidden"] as const) {
       const layout = resolveSidebarLayoutForBoard({
         board: board(dock),
         layout: openSlot(openSlot({ columns: [] }, "chat"), "detail"),
-        paneWidth: 1_400,
+        paneWidth: dock === "hidden" ? 620 : 1_400,
       });
       expect(layout.columns[0]?.panels.map((panel) => panel.slot)).toEqual(["detail"]);
+      expect(layout.open).toBe(dock === "bottom");
     }
   });
 
@@ -217,6 +227,25 @@ describe("chat pane sidebar layout", () => {
       expect(withDetail.columns[0]?.panels.map((panel) => panel.slot)).toEqual(["detail"]);
       expect(withDetail.open).toBe(open);
     }
+  });
+
+  it("does not reinterpret restored state for Chat or a read-only dashboard", () => {
+    const restored = openSlot({ columns: [] }, "detail");
+
+    expect(
+      resolveSidebarLayoutForBoard({
+        board: board("hidden", "chat"),
+        layout: restored,
+        paneWidth: 1_400,
+      }).open,
+    ).toBe(true);
+    expect(
+      resolveSidebarLayoutForBoard({
+        board: board("hidden", "dashboard", false),
+        layout: restored,
+        paneWidth: 1_400,
+      }).open,
+    ).toBe(true);
   });
 
   it("keeps the detail tab when its transient content is no longer available", () => {

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.ts
@@ -24,6 +24,7 @@ import {
   reorderPanel,
   setSidebarDock,
   setSidebarExpanded,
+  setSidebarOpen,
   sidebarDock,
   type SidebarLayout,
   type SidebarSlotId,
@@ -197,6 +198,16 @@ export function resolveSidebarLayoutForBoard(params: {
       : null;
   if (!chatSide) {
     layout = closeSlot(layout, "chat");
+    if (
+      params.board.hasBoard &&
+      params.board.face === "dashboard" &&
+      params.board.dock === "hidden" &&
+      params.board.provider.canMutate
+    ) {
+      // Dashboard is the board-only mode. Preserve the stored tabs for the
+      // next explicit Split transition, but never render them over the board.
+      layout = setSidebarOpen(layout, false);
+    }
     return fitSidebarLayout(layout, params.paneWidth) ?? layout;
   }
   const explicitlyClosed = layout.columns.length > 0 && layout.open === false;

--- a/ui/src/pages/chat/sidebar-layout.ts
+++ b/ui/src/pages/chat/sidebar-layout.ts
@@ -122,6 +122,9 @@ export function closeSlot(layout: SidebarLayout, slot: SidebarSlotId): SidebarLa
       next.open = false;
     }
   }
+  if (next.columns.length === 0) {
+    next.open = false;
+  }
   return next;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Dashboard, Split, and the side panel could disagree. Selecting Dashboard could leave a panel visible, while closing the whole panel could leave Split selected. The Add side panel menu could also offer Discussion before the gateway reported a Discussion provider for the session.

## Why This Change Was Made

Explicit side-panel intents now pass through the Board owner so panel visibility and the active Board chat dock change together. Passive restored state remains passive, bottom-docked chat stays independent, and Discussion appears only after the session probe reports it as available or open.

## User Impact

Dashboard is now the board-only view. Opening any available side panel enters Split with the remembered tabs, and closing the whole side panel returns to Dashboard. Disconnected or unavailable Discussion providers no longer leave a non-working Discussion launcher in the Add tab menu.

## Evidence

Canonical base remained red after the overlapping empty-panel resize fix at `f290d6bc815c605a5e6af6ce3ea53bc20abe661c`: after selecting Dashboard, the browser test expected no side panel but still found one. Current base `d64d8464c1c48c66f65ecb893759aaf5d6b23d98` only adds unrelated CLI, plugin, channel, provider, and test changes.

https://github.com/user-attachments/assets/cc6b3ff1-daeb-4aad-847e-865cb255e60b

The corrected flow is green: Dashboard settles without a panel, the header launcher restores Split with Board chat, Browser, and Terminal, whole-panel close returns to Dashboard, and Chat-to-Dashboard navigation does not reopen the panel.

https://github.com/user-attachments/assets/71e0f556-1726-4b9b-9501-127ffbda449e

The linked playback predates the final test-hardening and rebases. The same focused recording was rerun at `0908ee6a969fe21a2bbbb6ca309619a0f8916b2c` (SHA-256 `f77f9ce840b6ac8e4514b3bb520d75b0f46b3a55ced31cac8c64f72e16a985ce`). Final head `5166dcfec5c98a7c0e12b2c1db9f0965c8c0a58c` preserves stable patch ID `0592bc3101f0f69f70c2600c68a7ec9820242359` after the unrelated final base update.

- Focused UI tests: 8 files, 145 tests passed.
- Control UI E2E: 2 files, 8 tests passed.
- Upstream empty-panel resize E2E: 1 file, 5 tests passed.
- Exact-base changed gate: passed, including UI and UI/E2E typechecks, formatting, lint, stylelint, dead-export, i18n, dependency, and source ratchets.
- Source-blind behavior validation: all transition clauses passed; no settled mode/panel mismatch.
- Autoreview at the patch-identical pre-rebase head: clean, no accepted or actionable findings (0.97).
- Production LOC: +45/-12, net +33. Tests: +198/-16. The production growth establishes one Board-aware transition seam and routes the existing launchers and close controls through it; the alternative leaves duplicate transition policy at each launcher.
