### PR TITLE
fix(ui): Cron shows a false empty state during initial loading

### DIFF
--- a/ui/src/e2e/cron-loading.e2e.test.ts
+++ b/ui/src/e2e/cron-loading.e2e.test.ts
@@ -1,0 +1,86 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { expect, it } from "vitest";
+import {
+  installMockGateway,
+  startControlUiE2eServer,
+  type MockGatewayRequest,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI Cron loading mocked Gateway E2E",
+  startServer: () => startControlUiE2eServer(undefined, { source: true }),
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}.`,
+});
+
+const emptyList = {
+  jobs: [],
+  snapshotRevision: "cron-loading-empty",
+  total: 0,
+  offset: 0,
+  limit: 50,
+  hasMore: false,
+  nextOffset: null,
+};
+
+function tableListRequests(requests: MockGatewayRequest[]) {
+  return requests.filter(
+    ({ params }) => isRecord(params) && params.scheduleKind === "all" && params.trigger === "all",
+  );
+}
+
+suite.define(() => {
+  it("shows pending before empty and keeps empty visible after a run-history failure", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          heldMethods: ["cron.list"],
+          methodResponses: {
+            "cron.list": emptyList,
+            "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
+            "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+          },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}cron`);
+        expect(response?.status()).toBe(200);
+        await gateway.waitForRequest("cron.list");
+
+        const loading = page.locator('[data-test-id="cron-jobs-loading"]');
+        await loading.waitFor({ state: "visible" });
+        expect(await loading.getAttribute("role")).toBe("status");
+        expect(await loading.getAttribute("aria-live")).toBe("polite");
+        await expect.poll(() => loading.textContent()).toContain("Loading...");
+        expect(await page.getByText("No automations yet").count()).toBe(0);
+        expect(await page.locator(".cron-table").getAttribute("aria-busy")).toBe("true");
+        expect(tableListRequests(await gateway.getRequests("cron.list"))).toHaveLength(1);
+
+        await gateway.resolveDeferred("cron.list", emptyList);
+        await page.getByText("No automations yet").waitFor({ state: "visible" });
+        expect(await loading.count()).toBe(0);
+        expect(await page.locator(".cron-table").getAttribute("aria-busy")).toBeNull();
+
+        await gateway.setMethodResponse("cron.runs", {
+          __mockError: { code: "UNAVAILABLE", message: "Run history unavailable." },
+        });
+        const previousTableRequests = tableListRequests(
+          await gateway.getRequests("cron.list"),
+        ).length;
+        await page.getByRole("button", { name: "Refresh" }).click();
+
+        await page.getByText("Run history unavailable.").waitFor({ state: "visible" });
+        await page.getByText("No automations yet").waitFor({ state: "visible" });
+        await expect
+          .poll(async () => tableListRequests(await gateway.getRequests("cron.list")))
+          .toHaveLength(previousTableRequests + 1);
+      },
+    );
+  });
+});

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -2400,7 +2400,8 @@ describe("cron controller", () => {
     expect(state.cronJobs).toEqual([existingJob]);
     expect(state.cronJobsSnapshotRevision).toBe("accepted-revision");
     expect(state.cronJobsTotal).toBe(1);
-    expect(state.cronError).toContain("cron.list returned an invalid inventory page");
+    expect(state.cronJobsError).toContain("cron.list returned an invalid inventory page");
+    expect(state.cronError).toBeNull();
   });
 
   it("keeps table-only filters out of shared cron jobs loads", async () => {
@@ -2549,6 +2550,26 @@ describe("cron controller", () => {
     expect(state.cronJobs.map((job) => job.id)).toEqual(["job-ok"]);
     expect(state.cronJobsTotal).toBe(2);
     expect(state.cronJobsHasMore).toBe(false);
+  });
+
+  it("keeps list failures separate from other Cron errors", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "cron.list") {
+        return emptyCronListResponse({ snapshotRevision: "loaded-empty" });
+      }
+      if (method === "cron.runs") {
+        throw new Error("run history unavailable");
+      }
+      return {};
+    });
+    const state = createStateWithRequest(request);
+
+    await loadCronJobsPage(state);
+    await expect(loadCronRuns(state, null)).resolves.toBe("error");
+
+    expect(state.cronJobsSnapshotRevision).toBe("loaded-empty");
+    expect(state.cronJobsError).toBeNull();
+    expect(state.cronError).toBe("run history unavailable");
   });
 
   it("loads and appends paged run history", async () => {

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -206,6 +206,7 @@ export type CronState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
   cronLoading: boolean;
+  cronJobsError: string | null;
   cronJobsLoadingMore: boolean;
   cronJobsReloadPending: boolean;
   cronJobsReloadPendingTableFilters: boolean;
@@ -270,6 +271,7 @@ export function createInitialCronState(
     client: snapshot.client ?? null,
     connected: snapshot.connected ?? false,
     cronLoading: false,
+    cronJobsError: null,
     cronJobsLoadingMore: false,
     cronJobsReloadPending: false,
     cronJobsReloadPendingTableFilters: false,
@@ -713,7 +715,7 @@ export async function loadCronJobsPage(
   } else {
     state.cronLoading = true;
   }
-  state.cronError = null;
+  state.cronJobsError = null;
   try {
     const offset = append ? Math.max(0, state.cronJobsNextOffset ?? state.cronJobs.length) : 0;
     const res = await state.client.request<CronJobsListResult>("cron.list", {
@@ -756,7 +758,7 @@ export async function loadCronJobsPage(
     // A filtered/paged list is not deletion authority. Only an explicit remove
     // may clear an editor opened from an exact job definition.
   } catch (err) {
-    state.cronError = formatUiError(err);
+    state.cronJobsError = formatUiError(err);
   } finally {
     if (append) {
       state.cronJobsLoadingMore = false;

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -433,6 +433,8 @@ class CronPage extends OpenClawLightDomElement {
           basePath: this.context.basePath,
           agentId: fallbackAgentId,
           loading: this.cron.cronLoading,
+          hasLoaded: this.cron.cronJobsSnapshotRevision !== null,
+          listError: this.cron.cronJobsError,
           canManage,
           status: this.cron.cronStatus,
           failingCount: this.cron.cronFailingCount,

--- a/ui/src/pages/cron/view.test-support.ts
+++ b/ui/src/pages/cron/view.test-support.ts
@@ -26,6 +26,8 @@ function createCronViewProps(overrides: Partial<CronProps> = {}): CronProps {
     basePath: "",
     agentId: "main",
     loading: false,
+    hasLoaded: true,
+    listError: null,
     canManage: true,
     jobsLoadingMore: false,
     status: {

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -256,6 +256,81 @@ describe("cron view list pane", () => {
     expect(findStarterSection(renderView({ jobsEnabledFilter: "enabled" }))).toBeNull();
   });
 
+  it("renders a truthful inventory state matrix for the tasks table", () => {
+    // Initial pending: polite loading status, not a false completed-empty message.
+    const pending = renderView({ loading: true, hasLoaded: false, jobs: [], jobsTotal: 0 });
+    const pendingStatus = getElement(pending, '[data-test-id="cron-jobs-loading"]', HTMLDivElement);
+    expect(pendingStatus.getAttribute("role")).toBe("status");
+    expect(pendingStatus.getAttribute("aria-live")).toBe("polite");
+    expect(pendingStatus.textContent).toContain("Loading...");
+    expect(pending.textContent).not.toContain("No automations yet");
+    expect(getElement(pending, ".cron-table", HTMLDivElement).getAttribute("aria-busy")).toBe(
+      "true",
+    );
+
+    // Loaded empty: completed empty guidance with no busy state.
+    const loadedEmpty = renderView({ loading: false, hasLoaded: true, jobs: [], jobsTotal: 0 });
+    expect(loadedEmpty.querySelector('[data-test-id="cron-jobs-loading"]')).toBeNull();
+    const empty = getElement(loadedEmpty, ".cron-empty-state", HTMLDivElement);
+    expect(empty.textContent).toContain("No automations yet");
+    expect(empty.textContent).toContain("Describe what OpenClaw should do");
+    expect(
+      getElement(loadedEmpty, ".cron-table", HTMLDivElement).getAttribute("aria-busy"),
+    ).toBeNull();
+
+    // Filtered empty keeps the matching-copy variant.
+    const filtered = renderView({ loading: false, hasLoaded: true, jobs: [], jobsQuery: "zzz" });
+    expect(getElement(filtered, ".cron-empty-state", HTMLDivElement).textContent).toContain(
+      "No automations match the current filters.",
+    );
+
+    // Refresh with retained rows keeps the rows and marks the region busy.
+    const refreshing = renderView({
+      loading: true,
+      hasLoaded: true,
+      jobs: [createJob("refresh-me")],
+      jobsTotal: 1,
+    });
+    expect(refreshing.querySelector('[data-test-id="cron-jobs-loading"]')).toBeNull();
+    expect(getElement(refreshing, ".cron-table", HTMLDivElement).getAttribute("aria-busy")).toBe(
+      "true",
+    );
+    expect(refreshing.textContent).toContain("Daily ping");
+
+    // Refresh of a loaded-empty inventory keeps the empty message (no false loading copy).
+    const refreshingEmpty = renderView({ loading: true, hasLoaded: true, jobs: [], jobsTotal: 0 });
+    expect(refreshingEmpty.querySelector('[data-test-id="cron-jobs-loading"]')).toBeNull();
+    expect(getElement(refreshingEmpty, ".cron-empty-state", HTMLDivElement).textContent).toContain(
+      "No automations yet",
+    );
+
+    // A first list failure reports its own error instead of claiming the inventory is empty.
+    const failed = renderView({
+      loading: false,
+      hasLoaded: false,
+      jobs: [],
+      listError: "Unable to load automations.",
+    });
+    expect(failed.querySelector(".cron-empty-state")).toBeNull();
+    expect(failed.querySelector('[data-test-id="cron-jobs-loading"]')).toBeNull();
+    const failedAlert = getElement(failed, ".cron-error-banner", HTMLDivElement);
+    expect(failedAlert.getAttribute("role")).toBe("alert");
+    expect(failedAlert.textContent).toContain("Unable to load automations.");
+
+    // A non-list failure cannot hide a successfully loaded empty inventory.
+    const unrelatedFailure = renderView({
+      hasLoaded: true,
+      jobs: [],
+      error: "Run history unavailable.",
+    });
+    expect(unrelatedFailure.querySelector(".cron-empty-state")?.textContent).toContain(
+      "No automations yet",
+    );
+    expect(
+      unrelatedFailure.querySelector('.cron-error-banner[role="alert"]')?.textContent,
+    ).toContain("Run history unavailable.");
+  });
+
   it("shows a scheduler banner only while the scheduler is off", () => {
     const off = renderView({
       status: { enabled: false, triggersEnabled: true, jobs: 2 },

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -72,6 +72,9 @@ type CronProps = {
   basePath: string;
   agentId: string;
   loading: boolean;
+  /** True once a cron.list response has completed (initial load finished). */
+  hasLoaded: boolean;
+  listError: string | null;
   /** Canonical gateway capability for every mutation-capable cron control. */
   canManage: boolean;
   jobsLoadingMore: boolean;
@@ -475,6 +478,8 @@ function renderListView(props: CronProps) {
     props.jobsEnabledFilter !== "all";
   const showStarterAutomations =
     !props.loading &&
+    props.hasLoaded &&
+    !props.listError &&
     !props.error &&
     props.jobsTotal === 0 &&
     !hasAnyJobsFilters &&
@@ -493,7 +498,12 @@ function renderListView(props: CronProps) {
               </div>
             `
           : nothing}
-        ${props.error ? html`<div class="cron-error-banner">${props.error}</div>` : nothing}
+        ${props.listError
+          ? html`<div class="cron-error-banner" role="alert">${props.listError}</div>`
+          : nothing}
+        ${props.error
+          ? html`<div class="cron-error-banner" role="alert">${props.error}</div>`
+          : nothing}
         ${renderToolbar(props, hasAdvancedJobsFilters)}
       </div>
     `,
@@ -729,8 +739,15 @@ function renderJobsFilterPopover(props: CronProps, active: boolean) {
 }
 
 function renderJobsTable(props: CronProps, hasAnyJobsFilters: boolean) {
+  // A snapshot revision is the successful-list fact. Until one exists, show
+  // pending or failure, never completed-empty guidance.
+  const initialPending = props.loading && !props.hasLoaded;
+  const tableBusy = props.loading || props.jobsLoadingMore;
   return html`
-    <div class="cron-table ${props.canManage ? "" : "cron-table--read-only"}">
+    <div
+      class="cron-table ${props.canManage ? "" : "cron-table--read-only"}"
+      aria-busy=${tableBusy ? "true" : nothing}
+    >
       <div class="cron-table__head">
         <span>${t("cron.jobs.name")}</span>
         <span>${t("cron.jobs.schedule")}</span>
@@ -739,16 +756,29 @@ function renderJobsTable(props: CronProps, hasAnyJobsFilters: boolean) {
         ${props.canManage ? html`<span aria-hidden="true"></span>` : nothing}
       </div>
       ${props.jobs.length === 0
-        ? html`
-            <div class="cron-empty-state">
-              <div class="cron-empty-state__title">
-                ${hasAnyJobsFilters ? t("cron.list.noMatching") : t("cron.list.emptyTitle")}
+        ? initialPending
+          ? html`
+              <div
+                class="cron-empty-state"
+                role="status"
+                aria-live="polite"
+                data-test-id="cron-jobs-loading"
+              >
+                <div class="cron-empty-state__title">${t("cron.list.loading")}</div>
               </div>
-              ${hasAnyJobsFilters
-                ? nothing
-                : html`<div class="cron-empty-state__copy">${t("cron.list.emptyHint")}</div>`}
-            </div>
-          `
+            `
+          : props.hasLoaded
+            ? html`
+                <div class="cron-empty-state">
+                  <div class="cron-empty-state__title">
+                    ${hasAnyJobsFilters ? t("cron.list.noMatching") : t("cron.list.emptyTitle")}
+                  </div>
+                  ${hasAnyJobsFilters
+                    ? nothing
+                    : html`<div class="cron-empty-state__copy">${t("cron.list.emptyHint")}</div>`}
+                </div>
+              `
+            : nothing
         : repeat(
             props.jobs,
             (job) => job.id,


### PR DESCRIPTION
Closes #127331

## What Problem This Solves

The Automations page rendered “No automations yet” before its first `cron.list` response arrived. A later patch also treated every Cron error as a list error, so a run-history failure could hide a valid empty inventory.

## Root cause

The table selected its completed empty state from `jobs.length` alone. The Cron store also used one shared error field for list, status, mutation, and run-history requests.

## Fix

- Use the validated list snapshot revision as the existing first-success fact.
- Keep `cron.list` failures separate from other Cron errors.
- Show a polite loading status before first success and mark list refreshes busy.
- Keep loaded rows or the completed empty state visible during refreshes and unrelated failures.
- Preserve the existing serialized list request path and queued-refresh ownership.

## Evidence

https://github.com/user-attachments/assets/15d865f7-90cd-4f10-aedb-46670826fbd3

- Current main `de969147e7f3ba404e20d8f9966b97f1981e5f17`: with the first list response held, the page showed “No automations yet,” exposed no loading status, and had no busy state.
- This patch, now at head `83e9070d8a5776123b069e084ffd354b6f968981`: the same delayed response showed `Loading...` with `role="status"`, `aria-live="polite"`, and `aria-busy="true"`; it showed no empty claim.
- Releasing the empty snapshot changed the page to “No automations yet” and cleared the busy state.
- A later run-history failure stayed visible as an alert while the valid empty inventory remained visible.
- Request capture showed one page-owned `cron.list` request at initial load and one more after one manual refresh.

## Verification

- `node scripts/run-vitest.mjs ui/src/lib/cron/index.test.ts ui/src/pages/cron/view.test.ts` — 166 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/cron-loading.e2e.test.ts` — 1 passed.
- The new browser regression fails on current main while it waits for the missing loading status.
- Changed-file formatting, lint, repository ratchets, and `git diff --check` pass.
- Production delta: +34 lines. Tests and test support: +184 lines. The production growth adds the missing accessible state and list-error ownership without a second loaded flag or request path.

## Docs

The Automations and Control UI docs do not define request-state presentation, so no docs change is needed.
