### PR TITLE
fix(portals): keep worker previews reachable and owned by the active environment

### DIFF
--- a/docs/gateway/portals.md
+++ b/docs/gateway/portals.md
@@ -55,6 +55,8 @@ The Gateway never executes these commands automatically. The agent reads the fil
 
 The application must honor `PORT`. Use `PUBLIC_URL` when it needs to generate absolute URLs.
 
+The server can listen on IPv4 or IPv6 loopback (`127.0.0.1` or `::1`), both on the Gateway host and on a worker. Worker streams also preserve the node's configured Gateway context path when connecting through a reverse proxy.
+
 The proxy rewrites `Host` to the local target, so typical development servers such as Vite and Next.js need no additional configuration. WebSockets and hot module replacement are proxied through the same portal.
 
 ## Availability and configuration

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -880,7 +880,7 @@ export async function loadCompactHooksHarness(): Promise<{
     resolveBootstrapContextForRun: vi.fn(async () => ({ contextFiles: [] })),
   }));
 
-  vi.doMock("../bundle-mcp-tools.js", () => ({
+  vi.doMock("../agent-bundle-mcp-tools.js", () => ({
     retireSessionMcpRuntime: vi.fn(async () => true),
     createBundleMcpToolRuntime: vi.fn(async () => ({
       tools: [],
@@ -888,7 +888,7 @@ export async function loadCompactHooksHarness(): Promise<{
     })),
   }));
 
-  vi.doMock("../bundle-lsp-runtime.js", () => ({
+  vi.doMock("../agent-bundle-lsp-runtime.js", () => ({
     createBundleLspToolRuntime: vi.fn(async () => ({
       tools: [],
       sessions: [],

--- a/src/gateway/portals/portal-http-proxy.test.ts
+++ b/src/gateway/portals/portal-http-proxy.test.ts
@@ -97,11 +97,21 @@ async function listenTargetServer(server: Server): Promise<number> {
   return (server.address() as AddressInfo).port;
 }
 
-function createWorkerStream(port: number): Duplex {
+function createWorkerStreamPair() {
   const [gatewayStream, workerStream] = duplexPair({ allowHalfOpen: false });
+  // WebSocket closure delivers EOF to its peer; Node 22's duplexPair does not forward destroy.
+  gatewayStream.once("close", () => workerStream.push(null));
+  workerStream.once("close", () => gatewayStream.push(null));
+  return [gatewayStream, workerStream] as const;
+}
+
+function createWorkerStream(port: number): Duplex {
+  const [gatewayStream, workerStream] = createWorkerStreamPair();
   const appSocket = net.connect({ host: "127.0.0.1", port });
   workerStream.on("error", () => appSocket.destroy());
   appSocket.on("error", () => workerStream.destroy());
+  workerStream.once("close", () => appSocket.destroy());
+  appSocket.once("close", () => workerStream.destroy());
   workerStream.pipe(appSocket).pipe(workerStream);
   return gatewayStream;
 }
@@ -646,7 +656,7 @@ describe("portal HTTP proxy", () => {
         if (streamState === "rejected") {
           throw new Error("Worker node stream unavailable");
         }
-        const [gatewayStream, workerStream] = duplexPair({ allowHalfOpen: false });
+        const [gatewayStream, workerStream] = createWorkerStreamPair();
         if (streamState === "closed") {
           workerStream.end();
         } else {

--- a/src/gateway/portals/portal-http-proxy.test.ts
+++ b/src/gateway/portals/portal-http-proxy.test.ts
@@ -7,7 +7,7 @@ import {
 } from "node:http";
 import net, { type AddressInfo } from "node:net";
 import { duplexPair, type Duplex } from "node:stream";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { type RawData, WebSocket, WebSocketServer } from "ws";
 import type { PortalTarget } from "./portal-http-proxy.js";
 import { createGatewayPortalService, type GatewayPortalService } from "./portal-service.js";
@@ -228,7 +228,7 @@ describe("portal HTTP proxy", () => {
       res.statusCode = 200;
       res.end("proxied");
     };
-    const portal = (await portalService().open({ targetPort, title: "App" })).portal;
+    const portal = await portalService().open({ targetPort, title: "App" });
 
     const unauthorized = await httpCall({ port: portal.listenPort });
     expect(unauthorized.status).toBe(401);
@@ -266,8 +266,8 @@ describe("portal HTTP proxy", () => {
       res.end("target-b");
     });
     const service = portalService();
-    const portalA = (await service.open({ targetPort })).portal;
-    const portalB = (await service.open({ targetPort: targetPortB })).portal;
+    const portalA = await service.open({ targetPort });
+    const portalB = await service.open({ targetPort: targetPortB });
     const jar = new Map<string, string>();
 
     expect(
@@ -321,7 +321,7 @@ describe("portal HTTP proxy", () => {
       res.write("hello ");
       res.end("portal");
     };
-    const portal = (await portalService().open({ targetPort })).portal;
+    const portal = await portalService().open({ targetPort });
     const result = await httpCall({
       port: portal.listenPort,
       path: "/asset?q=1",
@@ -367,8 +367,8 @@ describe("portal HTTP proxy", () => {
       res.end("target-b");
     });
     const service = portalService();
-    const portalA = (await service.open({ targetPort })).portal;
-    const portalB = (await service.open({ targetPort: targetPortB })).portal;
+    const portalA = await service.open({ targetPort });
+    const portalB = await service.open({ targetPort: targetPortB });
     const jar = new Map<string, string>();
 
     const initialA = await browserCall(jar, {
@@ -418,7 +418,7 @@ describe("portal HTTP proxy", () => {
       res.end("target-a");
     };
     const service = portalService();
-    const portalA = (await service.open({ targetPort })).portal;
+    const portalA = await service.open({ targetPort });
     const jar = new Map<string, string>();
     await browserCall(jar, {
       port: portalA.listenPort,
@@ -434,7 +434,7 @@ describe("portal HTTP proxy", () => {
       }
       res.end("target-b");
     };
-    const portalB = (await service.open({ targetPort })).portal;
+    const portalB = await service.open({ targetPort });
     expect(portalB.tokenQuery).not.toBe(portalA.tokenQuery);
 
     await browserCall(jar, {
@@ -456,7 +456,7 @@ describe("portal HTTP proxy", () => {
       res.statusCode = 200;
       res.end("proxied");
     };
-    const portal = (await portalService().open({ targetPort })).portal;
+    const portal = await portalService().open({ targetPort });
     const token = portal.tokenQuery.slice("openclaw_portal=".length);
 
     const result = await httpCall({
@@ -485,7 +485,7 @@ describe("portal HTTP proxy", () => {
         res.end();
       });
     };
-    const portal = (await portalService().open({ targetPort })).portal;
+    const portal = await portalService().open({ targetPort });
     const result = await httpCall({
       port: portal.listenPort,
       method: "POST",
@@ -509,7 +509,7 @@ describe("portal HTTP proxy", () => {
     await new Promise<void>((resolve) => {
       unavailableTarget.close(() => resolve());
     });
-    const portal = (await portalService().open({ targetPort: port })).portal;
+    const portal = await portalService().open({ targetPort: port });
 
     const result = await httpCall({
       port: portal.listenPort,
@@ -536,15 +536,13 @@ describe("portal HTTP proxy", () => {
       socket.on("message", (data) => socket.send(data));
     });
     const appPort = await listenTargetServer(appServer);
-    const portal = (
-      await portalService().open({
-        targetPort: remotePort,
-        target: workerTarget(async () => {
-          connectionCount += 1;
-          return createWorkerStream(appPort);
-        }, remotePort),
-      })
-    ).portal;
+    const portal = await portalService().open({
+      targetPort: remotePort,
+      target: workerTarget(async () => {
+        connectionCount += 1;
+        return createWorkerStream(appPort);
+      }, remotePort),
+    });
 
     expect(
       await httpCall({ port: portal.listenPort, path: `/preview?${portal.tokenQuery}` }),
@@ -577,16 +575,14 @@ describe("portal HTTP proxy", () => {
       releaseDial = resolve;
     });
     const remotePort = 4173;
-    const portal = (
-      await portalService().open({
-        targetPort: remotePort,
-        target: workerTarget(async () => {
-          notifyDialStarted();
-          await dialReleased;
-          return createWorkerStream(targetPort);
-        }, remotePort),
-      })
-    ).portal;
+    const portal = await portalService().open({
+      targetPort: remotePort,
+      target: workerTarget(async () => {
+        notifyDialStarted();
+        await dialReleased;
+        return createWorkerStream(targetPort);
+      }, remotePort),
+    });
 
     const response = httpCall({
       port: portal.listenPort,
@@ -596,6 +592,50 @@ describe("portal HTTP proxy", () => {
     releaseDial();
 
     expect(await response).toMatchObject({ status: 200, body: "worker /slow" });
+  });
+
+  it.each([
+    ["local", "browser"],
+    ["worker", "browser"],
+    ["local", "app"],
+    ["worker", "app"],
+  ] as const)("closes both sides when the %s portal's %s disconnects", async (kind, disconnect) => {
+    let appResponse: ServerResponse | undefined;
+    let appClosed = false;
+    targetHandler = (_req, res) => {
+      appResponse = res;
+      res.once("close", () => {
+        appClosed = true;
+      });
+      res.setHeader("Content-Type", "text/event-stream");
+      res.write("data: ready\n\n");
+    };
+    const portal = await portalService().open({
+      targetPort,
+      ...(kind === "worker"
+        ? {
+            target: workerTarget(async () => createWorkerStream(targetPort), targetPort),
+          }
+        : {}),
+    });
+    const browserResponse = await new Promise<IncomingMessage>((resolve, reject) => {
+      const browserRequest = request(portal.url, (res) => {
+        res.on("error", () => undefined);
+        res.once("data", () => resolve(res));
+      });
+      browserRequest.once("error", reject);
+      browserRequest.end();
+    });
+    try {
+      (disconnect === "browser" ? browserResponse : appResponse)?.destroy();
+      await vi.waitFor(() => {
+        expect(browserResponse.destroyed).toBe(true);
+        expect(appClosed).toBe(true);
+      });
+    } finally {
+      browserResponse.destroy();
+      appResponse?.destroy();
+    }
   });
 
   it.each(["rejected", "closed", "reset"] as const)(
@@ -614,12 +654,10 @@ describe("portal HTTP proxy", () => {
         }
         return gatewayStream;
       };
-      const portal = (
-        await portalService().open({
-          targetPort: remotePort,
-          target: workerTarget(connect, remotePort),
-        })
-      ).portal;
+      const portal = await portalService().open({
+        targetPort: remotePort,
+        target: workerTarget(connect, remotePort),
+      });
       const cookie = portalAuthCookie(portal);
       const requestHeaders: Record<string, string>[] = [
         { Cookie: cookie },
@@ -647,7 +685,7 @@ describe("portal HTTP proxy", () => {
     });
     try {
       const v6Port = (v6Target.address() as AddressInfo).port;
-      const portal = (await portalService().open({ targetPort: v6Port })).portal;
+      const portal = await portalService().open({ targetPort: v6Port });
       const result = await httpCall({
         port: portal.listenPort,
         path: `/?${portal.tokenQuery}`,
@@ -662,7 +700,7 @@ describe("portal HTTP proxy", () => {
 
   it("splices WebSockets and destroys upgraded sockets and listeners on close", async () => {
     const service = portalService();
-    const portal = (await service.open({ targetPort })).portal;
+    const portal = await service.open({ targetPort });
     targetWebSocketSetCookie = "socket=ready; Domain=target.example; Path=/; HttpOnly";
     let upgradeCookies: string[] | undefined;
     const ws = new WebSocket(
@@ -706,8 +744,8 @@ describe("portal HTTP proxy", () => {
       res.end("target-b");
     });
     const service = portalService();
-    const portalA = (await service.open({ targetPort })).portal;
-    const portalB = (await service.open({ targetPort: targetPortB })).portal;
+    const portalA = await service.open({ targetPort });
+    const portalB = await service.open({ targetPort: targetPortB });
     const jar = new Map<string, string>();
     await browserCall(jar, {
       port: portalA.listenPort,
@@ -739,7 +777,7 @@ describe("portal HTTP proxy", () => {
 
   it("does not forward WebSocket cookies from a closed portal when its target port is reused", async () => {
     const service = portalService();
-    const portalA = (await service.open({ targetPort })).portal;
+    const portalA = await service.open({ targetPort });
     targetWebSocketSetCookie = "socket=portal-a-secret; Path=/; HttpOnly";
     const connectionA = await openWebSocket(
       `ws://127.0.0.1:${portalA.listenPort}/hmr?${portalA.tokenQuery}`,
@@ -749,7 +787,7 @@ describe("portal HTTP proxy", () => {
     await closeWebSocket(connectionA.socket);
     await service.close(portalA.id);
 
-    const portalB = (await service.open({ targetPort })).portal;
+    const portalB = await service.open({ targetPort });
     targetWebSocketSetCookie = "socket=portal-b; Path=/; HttpOnly";
     const connectionB = await openWebSocket(
       `ws://127.0.0.1:${portalB.listenPort}/hmr?${portalB.tokenQuery}`,

--- a/src/gateway/portals/portal-http-proxy.ts
+++ b/src/gateway/portals/portal-http-proxy.ts
@@ -318,6 +318,7 @@ export function handlePortalProxyRequest(params: {
         // send the token-bearing portal URL to every third-party origin it references.
         res.setHeader("Referrer-Policy", PORTAL_REFERRER_POLICY);
         res.statusCode = proxyRes.statusCode ?? 502;
+        proxyRes.once("error", () => res.destroy());
         proxyRes.pipe(res);
       });
       proxyReq.once("error", () => {
@@ -332,7 +333,8 @@ export function handlePortalProxyRequest(params: {
           respondPortalWaiting(req, res, targetPort);
         }
       });
-      req.once("aborted", () => proxyReq.destroy());
+      // A browser can leave after its request body ended (for example during SSE).
+      res.once("close", () => proxyReq.destroy());
       req.pipe(proxyReq);
     },
     () => {

--- a/src/gateway/portals/portal-service.test.ts
+++ b/src/gateway/portals/portal-service.test.ts
@@ -48,11 +48,13 @@ async function getDistinctFreePort(excluded: number): Promise<number> {
 describe("portal open authority fence", () => {
   it("refuses to mutate a reused portal when the caller's authority lapsed", async () => {
     const { service } = makeService(["127.0.0.1"]);
-    const first = (await service.open({ targetPort: 41234, title: "Live" })).portal;
+    const first = await service.open({ targetPort: 41234, title: "Live" });
+    const releaseRejected = vi.fn();
     await expect(
       service.open({
         targetPort: 41234,
         title: "Hijacked",
+        onClose: releaseRejected,
         assertCurrent: () => {
           throw new Error("authority lapsed");
         },
@@ -60,13 +62,44 @@ describe("portal open authority fence", () => {
     ).rejects.toThrow("authority lapsed");
     const summary = service.list().find((portal) => portal.id === first.id);
     expect(summary?.title).toBe("Live");
+    expect(releaseRejected).toHaveBeenCalledOnce();
+  });
+
+  it("releases the listener and target when authority is lost during startup", async () => {
+    const actualListen = httpListen.listenGatewayHttpServer;
+    let authorityCurrent = true;
+    let listener: Server | undefined;
+    vi.spyOn(httpListen, "listenGatewayHttpServer").mockImplementation(async (params) => {
+      listener = params.httpServer;
+      await actualListen(params);
+      authorityCurrent = false;
+    });
+    const { service, httpServers } = makeService(["127.0.0.1"]);
+    const releaseTarget = vi.fn();
+
+    await expect(
+      service.open({
+        targetPort: 3000,
+        onClose: releaseTarget,
+        assertCurrent: () => {
+          if (!authorityCurrent) {
+            throw new Error("Worker portal authority changed");
+          }
+        },
+      }),
+    ).rejects.toThrow("Worker portal authority changed");
+
+    expect(service.list()).toEqual([]);
+    expect(httpServers).toEqual([]);
+    expect(listener?.listening).toBe(false);
+    expect(releaseTarget).toHaveBeenCalledOnce();
   });
 });
 
 describe("gateway portal service", () => {
   it("allocates one port across every frozen bind host", async () => {
     const { service, httpServers } = makeService(["127.0.0.1", "::1"]);
-    const portal = (await service.open({ targetPort: 3000, title: "App" })).portal;
+    const portal = await service.open({ targetPort: 3000, title: "App" });
 
     expect(portal).toMatchObject({ id: "p3000", port: 3000, title: "App" });
     expect(portal.listenPort).toBeGreaterThan(0);
@@ -95,7 +128,7 @@ describe("gateway portal service", () => {
     });
     const { service, httpServers } = makeService(["127.0.0.1", "::1"]);
 
-    const portal = (await service.open({ targetPort })).portal;
+    const portal = await service.open({ targetPort });
 
     expect(portal.listenPort).toBe(acceptedPort);
     expect(calls).toEqual([
@@ -141,15 +174,20 @@ describe("gateway portal service", () => {
 
   it("updates an existing target without replacing its listener or token", async () => {
     const { service, httpServers } = makeService(["127.0.0.1"]);
-    const first = (await service.open({ targetPort: 3000, title: "First" })).portal;
-    const second = (
-      await service.open({
-        targetPort: 3000,
-        title: "Second",
-        description: "Updated",
-        path: "/preview",
-      })
-    ).portal;
+    const releaseFirst = vi.fn();
+    const releaseRedundant = vi.fn();
+    const first = await service.open({
+      targetPort: 3000,
+      title: "First",
+      onClose: releaseFirst,
+    });
+    const second = await service.open({
+      targetPort: 3000,
+      title: "Second",
+      description: "Updated",
+      path: "/preview",
+      onClose: releaseRedundant,
+    });
 
     expect(second).toMatchObject({
       id: first.id,
@@ -163,48 +201,48 @@ describe("gateway portal service", () => {
     expect(second.url).toBe(`${second.publicUrl}?${second.tokenQuery}`);
     expect(httpServers).toHaveLength(1);
     expect(service.list()).toEqual([second]);
+    expect(releaseFirst).not.toHaveBeenCalled();
+    expect(releaseRedundant).toHaveBeenCalledOnce();
+
+    await service.close(first.id);
+    expect(releaseFirst).toHaveBeenCalledOnce();
+    expect(releaseRedundant).toHaveBeenCalledOnce();
   });
 
   it("keeps local and worker portals on the same application port distinct", async () => {
     const { service } = makeService(["127.0.0.1"]);
-    const local = (await service.open({ targetPort: 3000 })).portal;
-    const worker = (
-      await service.open({
-        targetPort: 3000,
-        target: {
-          kind: "worker",
-          environmentId: "cloud/a",
-          ownerEpoch: 7,
-          remotePort: 3000,
-          connect: unavailableWorkerConnection,
-        },
-        origin: "Cloud worker A",
-      })
-    ).portal;
-    const otherWorker = (
-      await service.open({
-        targetPort: 3000,
-        target: {
-          kind: "worker",
-          environmentId: "cloud-a",
-          ownerEpoch: 7,
-          remotePort: 3000,
-          connect: unavailableWorkerConnection,
-        },
-      })
-    ).portal;
-    const staleWorker = (
-      await service.open({
-        targetPort: 3000,
-        target: {
-          kind: "worker",
-          environmentId: "cloud/a",
-          ownerEpoch: 6,
-          remotePort: 3000,
-          connect: unavailableWorkerConnection,
-        },
-      })
-    ).portal;
+    const local = await service.open({ targetPort: 3000 });
+    const worker = await service.open({
+      targetPort: 3000,
+      target: {
+        kind: "worker",
+        environmentId: "cloud/a",
+        ownerEpoch: 7,
+        remotePort: 3000,
+        connect: unavailableWorkerConnection,
+      },
+      origin: "Cloud worker A",
+    });
+    const otherWorker = await service.open({
+      targetPort: 3000,
+      target: {
+        kind: "worker",
+        environmentId: "cloud-a",
+        ownerEpoch: 7,
+        remotePort: 3000,
+        connect: unavailableWorkerConnection,
+      },
+    });
+    const staleWorker = await service.open({
+      targetPort: 3000,
+      target: {
+        kind: "worker",
+        environmentId: "cloud/a",
+        ownerEpoch: 6,
+        remotePort: 3000,
+        connect: unavailableWorkerConnection,
+      },
+    });
 
     expect(local.id).toBe("p3000");
     expect(new Set([local.id, worker.id, otherWorker.id, staleWorker.id]).size).toBe(4);
@@ -220,32 +258,28 @@ describe("gateway portal service", () => {
     const { service } = makeService(["127.0.0.1"]);
     const closeStaleForward = vi.fn();
     const closeCurrentForward = vi.fn();
-    const stale = (
-      await service.open({
-        targetPort: 3000,
-        target: {
-          kind: "worker",
-          environmentId: "cloud-a",
-          ownerEpoch: 6,
-          remotePort: 3000,
-          connect: unavailableWorkerConnection,
-        },
-        onClose: closeStaleForward,
-      })
-    ).portal;
-    const current = (
-      await service.open({
-        targetPort: 3000,
-        target: {
-          kind: "worker",
-          environmentId: "cloud-a",
-          ownerEpoch: 7,
-          remotePort: 3000,
-          connect: unavailableWorkerConnection,
-        },
-        onClose: closeCurrentForward,
-      })
-    ).portal;
+    const stale = await service.open({
+      targetPort: 3000,
+      target: {
+        kind: "worker",
+        environmentId: "cloud-a",
+        ownerEpoch: 6,
+        remotePort: 3000,
+        connect: unavailableWorkerConnection,
+      },
+      onClose: closeStaleForward,
+    });
+    const current = await service.open({
+      targetPort: 3000,
+      target: {
+        kind: "worker",
+        environmentId: "cloud-a",
+        ownerEpoch: 7,
+        remotePort: 3000,
+        connect: unavailableWorkerConnection,
+      },
+      onClose: closeCurrentForward,
+    });
 
     await service.closeWorkerPortals("cloud-a", 6);
 
@@ -261,18 +295,16 @@ describe("gateway portal service", () => {
   it("keeps worker portal ids bounded for the longest supported environment id", async () => {
     const { service } = makeService(["127.0.0.1"]);
     const environmentId = "w".repeat(256);
-    const portal = (
-      await service.open({
-        targetPort: 3000,
-        target: {
-          kind: "worker",
-          environmentId,
-          ownerEpoch: 7,
-          remotePort: 3000,
-          connect: unavailableWorkerConnection,
-        },
-      })
-    ).portal;
+    const portal = await service.open({
+      targetPort: 3000,
+      target: {
+        kind: "worker",
+        environmentId,
+        ownerEpoch: 7,
+        remotePort: 3000,
+        connect: unavailableWorkerConnection,
+      },
+    });
 
     expect(portal.id.length).toBeLessThanOrEqual(256);
     expect(service.listWorkerPortals(environmentId, 7)).toEqual([portal]);
@@ -282,7 +314,7 @@ describe("gateway portal service", () => {
 
   it("revalidates worker close authority immediately before queued removal", async () => {
     const { service } = makeService(["127.0.0.1"]);
-    const portal = (await service.open({ targetPort: 3000 })).portal;
+    const portal = await service.open({ targetPort: 3000 });
     let authorityCurrent = true;
     const assertCurrent = () => {
       if (!authorityCurrent) {
@@ -337,9 +369,9 @@ describe("gateway portal service", () => {
 
   it("closes idempotently and closes every portal on shutdown", async () => {
     const { service, httpServers } = makeService(["127.0.0.1"]);
-    const first = (await service.open({ targetPort: 3000 })).portal;
+    const first = await service.open({ targetPort: 3000 });
     const firstServer = httpServers.at(-1);
-    const second = (await service.open({ targetPort: 4000 })).portal;
+    const second = await service.open({ targetPort: 4000 });
     const secondServer = httpServers.at(-1);
     expect(firstServer).toBeDefined();
     expect(secondServer).toBeDefined();
@@ -372,7 +404,7 @@ describe("gateway portal service", () => {
     ["::", "[::1]"],
   ])("maps wildcard bind host %s to openable host %s", async (bindHost, openableHost) => {
     const { service } = makeService([bindHost]);
-    const portal = (await service.open({ targetPort: 3000 })).portal;
+    const portal = await service.open({ targetPort: 3000 });
 
     expect(portal.publicUrl).toBe(`http://${openableHost}:${portal.listenPort}/`);
     expect(portal.url).toBe(`${portal.publicUrl}?${portal.tokenQuery}`);

--- a/src/gateway/portals/portal-service.ts
+++ b/src/gateway/portals/portal-service.ts
@@ -41,8 +41,9 @@ type PortalRuntimeEntry = {
 type GatewayPortalOpenParams = {
   targetPort: number;
   target?: PortalTarget;
-  /** Revalidated inside the serialized operation; reuse must not mutate a live portal for a caller whose authority lapsed. */
+  /** Revalidated before metadata mutation or publication after asynchronous listener startup. */
   assertCurrent?: () => void;
+  /** Ownership transfers to open; unused targets are released even when it rejects or reuses a portal. */
   onClose?: () => Promise<void> | void;
   origin?: string;
   title?: string;
@@ -51,10 +52,7 @@ type GatewayPortalOpenParams = {
 };
 
 export type GatewayPortalService = {
-  /** `created` is false when an already-registered portal was reused; its target and onClose are unchanged. */
-  open: (
-    params: GatewayPortalOpenParams,
-  ) => Promise<{ portal: PortalOpenResult; created: boolean }>;
+  open: (params: GatewayPortalOpenParams) => Promise<PortalOpenResult>;
   list: () => PortalSummary[];
   listWorkerPortals: (environmentId: string, ownerEpoch: number) => PortalSummary[];
   close: (id: string, assertCurrent?: () => void) => Promise<void>;
@@ -174,117 +172,124 @@ export function createGatewayPortalService(params: {
           ? `p${targetPort}`
           : `p${targetPort}-worker-${sha256HexPrefixCore(target.environmentId, 32)}-${target.ownerEpoch}`;
       return await serialize(id, async () => {
-        if (closed) {
-          throw new Error("portals unavailable");
-        }
-        input.assertCurrent?.();
-        const existing = entries.get(id);
-        if (existing) {
-          existing.portal.title = input.title?.trim() || existing.portal.title;
-          if (input.description !== undefined) {
-            existing.portal.description = input.description;
-          }
-          if (input.path !== undefined) {
-            existing.portal.path = input.path;
-          }
-          if (input.origin !== undefined) {
-            existing.portal.origin = input.origin;
-          }
-          return { portal: summarize(existing.portal), created: false };
-        }
-        if (params.httpBindHosts.length === 0) {
-          throw new Error("Gateway listener must start before opening a portal");
-        }
-
-        const portal: PortalEntry = {
-          id,
-          title: input.title?.trim() || `Port ${targetPort}`,
-          ...(input.description ? { description: input.description } : {}),
-          ...(input.path ? { path: input.path } : {}),
-          ...(input.origin ? { origin: input.origin } : {}),
-          target,
-          token: randomBytes(32).toString("hex"),
-          cookieNamespace: randomBytes(16).toString("hex"),
-          listenPort: 0,
-          createdAtMs: Date.now(),
-        };
-        const upgradedSockets = new Set<Duplex>();
-        const handler = (
-          req: import("node:http").IncomingMessage,
-          res: import("node:http").ServerResponse,
-        ) =>
-          handlePortalProxyRequest({ req, res, target: portal, tls: Boolean(params.tlsOptions) });
-        const servers = params.httpBindHosts.map(() =>
-          params.tlsOptions
-            ? createHttpsServer(params.tlsOptions, handler)
-            : createHttpServer(handler),
-        );
-        for (const server of servers) {
-          server.on("upgrade", (req, socket, head) =>
-            handlePortalProxyUpgrade({ req, socket, head, target: portal, upgradedSockets }),
-          );
-        }
-        // Registration precedes every bind so whole-gateway cleanup owns partial startup.
-        params.httpServers.push(...servers);
+        let releaseTarget = input.onClose;
         try {
-          const primaryServer = servers[0];
-          const primaryHost = params.httpBindHosts[0];
-          if (!primaryServer || !primaryHost) {
-            throw new Error("Missing primary portal HTTP server");
+          if (closed) {
+            throw new Error("portals unavailable");
           }
-          for (let attempt = 0; attempt < PORTAL_PORT_ALLOCATION_ATTEMPTS; attempt += 1) {
-            await listenGatewayHttpServer({
-              httpServer: primaryServer,
-              bindHost: primaryHost,
-              port: 0,
-              retryEaddrinuse: false,
-              serviceName: "portal",
-              endpointScheme: params.tlsOptions ? "https" : "http",
-            });
-            const address = primaryServer.address() as AddressInfo | null;
-            if (!address || typeof address === "string") {
-              throw new Error("Portal listener failed to resolve its port");
+          input.assertCurrent?.();
+          const existing = entries.get(id);
+          if (existing) {
+            existing.portal.title = input.title?.trim() || existing.portal.title;
+            if (input.description !== undefined) {
+              existing.portal.description = input.description;
             }
-            if (target.kind === "worker" || address.port !== targetPort) {
-              portal.listenPort = address.port;
-              break;
+            if (input.path !== undefined) {
+              existing.portal.path = input.path;
             }
-            // A proxy cannot share its target port: it would dial itself and fail auth.
-            await closeServers([primaryServer]);
+            if (input.origin !== undefined) {
+              existing.portal.origin = input.origin;
+            }
+            return summarize(existing.portal);
           }
-          if (portal.listenPort === 0) {
-            throw new Error(`Portal listener repeatedly allocated target port ${targetPort}`);
+          if (params.httpBindHosts.length === 0) {
+            throw new Error("Gateway listener must start before opening a portal");
           }
-          for (const [index, host] of params.httpBindHosts.entries()) {
-            if (index === 0) {
-              continue;
-            }
-            const server = servers[index];
-            if (!server) {
-              throw new Error(`Missing portal HTTP server for bind host ${host}`);
-            }
-            await listenGatewayHttpServer({
-              httpServer: server,
-              bindHost: host,
-              port: portal.listenPort,
-              retryEaddrinuse: false,
-              serviceName: "portal",
-              endpointScheme: params.tlsOptions ? "https" : "http",
-            });
+
+          const portal: PortalEntry = {
+            id,
+            title: input.title?.trim() || `Port ${targetPort}`,
+            ...(input.description ? { description: input.description } : {}),
+            ...(input.path ? { path: input.path } : {}),
+            ...(input.origin ? { origin: input.origin } : {}),
+            target,
+            token: randomBytes(32).toString("hex"),
+            cookieNamespace: randomBytes(16).toString("hex"),
+            listenPort: 0,
+            createdAtMs: Date.now(),
+          };
+          const upgradedSockets = new Set<Duplex>();
+          const handler = (
+            req: import("node:http").IncomingMessage,
+            res: import("node:http").ServerResponse,
+          ) =>
+            handlePortalProxyRequest({ req, res, target: portal, tls: Boolean(params.tlsOptions) });
+          const servers = params.httpBindHosts.map(() =>
+            params.tlsOptions
+              ? createHttpsServer(params.tlsOptions, handler)
+              : createHttpServer(handler),
+          );
+          for (const server of servers) {
+            server.on("upgrade", (req, socket, head) =>
+              handlePortalProxyUpgrade({ req, socket, head, target: portal, upgradedSockets }),
+            );
           }
-        } catch (error) {
-          removeServers(params.httpServers, servers);
-          await closeServers(servers);
-          await input.onClose?.();
-          throw error;
+          // Registration precedes every bind so whole-gateway cleanup owns partial startup.
+          params.httpServers.push(...servers);
+          try {
+            const primaryServer = servers[0];
+            const primaryHost = params.httpBindHosts[0];
+            if (!primaryServer || !primaryHost) {
+              throw new Error("Missing primary portal HTTP server");
+            }
+            for (let attempt = 0; attempt < PORTAL_PORT_ALLOCATION_ATTEMPTS; attempt += 1) {
+              await listenGatewayHttpServer({
+                httpServer: primaryServer,
+                bindHost: primaryHost,
+                port: 0,
+                retryEaddrinuse: false,
+                serviceName: "portal",
+                endpointScheme: params.tlsOptions ? "https" : "http",
+              });
+              const address = primaryServer.address() as AddressInfo | null;
+              if (!address || typeof address === "string") {
+                throw new Error("Portal listener failed to resolve its port");
+              }
+              if (target.kind === "worker" || address.port !== targetPort) {
+                portal.listenPort = address.port;
+                break;
+              }
+              // A proxy cannot share its target port: it would dial itself and fail auth.
+              await closeServers([primaryServer]);
+            }
+            if (portal.listenPort === 0) {
+              throw new Error(`Portal listener repeatedly allocated target port ${targetPort}`);
+            }
+            for (const [index, host] of params.httpBindHosts.entries()) {
+              if (index === 0) {
+                continue;
+              }
+              const server = servers[index];
+              if (!server) {
+                throw new Error(`Missing portal HTTP server for bind host ${host}`);
+              }
+              await listenGatewayHttpServer({
+                httpServer: server,
+                bindHost: host,
+                port: portal.listenPort,
+                retryEaddrinuse: false,
+                serviceName: "portal",
+                endpointScheme: params.tlsOptions ? "https" : "http",
+              });
+            }
+            // A queued successor must not discover a portal created by a now-revoked turn.
+            input.assertCurrent?.();
+          } catch (error) {
+            removeServers(params.httpServers, servers);
+            await closeServers(servers);
+            throw error;
+          }
+          entries.set(id, {
+            portal,
+            servers,
+            upgradedSockets,
+            ...(input.onClose ? { onClose: input.onClose } : {}),
+          });
+          releaseTarget = undefined;
+          return summarize(portal);
+        } finally {
+          await releaseTarget?.();
         }
-        entries.set(id, {
-          portal,
-          servers,
-          upgradedSockets,
-          ...(input.onClose ? { onClose: input.onClose } : {}),
-        });
-        return { portal: summarize(portal), created: true };
       });
     },
     list: () => summarizeEntries(entries.values()),

--- a/src/gateway/server-methods/portals.test.ts
+++ b/src/gateway/server-methods/portals.test.ts
@@ -50,7 +50,7 @@ describe("portal gateway methods", () => {
       listWorkerPortals: () => [],
       open: vi.fn(async () => {
         portals = [portal];
-        return { portal, created: true };
+        return portal;
       }),
       close: vi.fn(async () => {
         portals = [];

--- a/src/gateway/server-methods/portals.ts
+++ b/src/gateway/server-methods/portals.ts
@@ -69,7 +69,7 @@ export const portalHandlers: GatewayRequestHandlers = {
           { portals: service.list().map(redactPortalSummary) },
           { dropIfSlow: true },
         );
-        respond(true, opened.portal, undefined);
+        respond(true, opened, undefined);
       } catch (error) {
         respond(
           false,

--- a/src/gateway/worker-environments/worker-portal-tool-executor.test.ts
+++ b/src/gateway/worker-environments/worker-portal-tool-executor.test.ts
@@ -7,6 +7,8 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
+import { createGatewayPortalService } from "../portals/portal-service.js";
+import * as httpListen from "../server/http-listen.js";
 import type { WorkerConnectionIdentity } from "./connection-identity.js";
 import {
   createWorkerSessionPlacementStore,
@@ -60,6 +62,16 @@ describe("worker portal tool execution", () => {
   const portalCarrierConnect = vi.fn();
   const portalCarrierClose = vi.fn();
   const portalChanged = vi.fn();
+  const actualServices = new Set<ReturnType<typeof createGatewayPortalService>>();
+
+  function useActualPortalService() {
+    const httpServers: import("node:http").Server[] = [];
+    const service = createGatewayPortalService({ httpBindHosts: ["127.0.0.1"], httpServers });
+    portalOpen.mockImplementation(service.open);
+    portalClose.mockImplementation(service.close);
+    actualServices.add(service);
+    return { service, httpServers };
+  }
 
   beforeEach(async () => {
     root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-worker-portal-"));
@@ -124,7 +136,7 @@ describe("worker portal tool execution", () => {
     };
     sessionEntries.clear();
     sessionEntries.set(SOURCE.sessionKey, { sessionId: SOURCE.sessionId, updatedAt: Date.now() });
-    portalOpen.mockReset().mockResolvedValue({ portal: PORTAL, created: true });
+    portalOpen.mockReset().mockResolvedValue(PORTAL);
     portalList.mockReset().mockReturnValue([PORTAL]);
     portalWorkerList.mockReset().mockReturnValue([PORTAL]);
     portalClose.mockReset().mockResolvedValue(undefined);
@@ -171,6 +183,9 @@ describe("worker portal tool execution", () => {
   });
 
   afterEach(async () => {
+    await Promise.all([...actualServices].map((service) => service.closeAll()));
+    actualServices.clear();
+    vi.restoreAllMocks();
     closeOpenClawStateDatabaseForTest();
     await fs.rm(root, { recursive: true, force: true });
   });
@@ -322,42 +337,12 @@ describe("worker portal tool execution", () => {
     expect(portalOpen).not.toHaveBeenCalled();
   });
 
-  it("never closes a reused portal when authority is lost after open", async () => {
-    // Regression: a revoked turn's duplicate open must not tear down the live
-    // portal a still-authorized predecessor established.
-    portalOpen.mockImplementationOnce(async () => {
-      sourceEnvironmentEpoch += 1;
-      return { portal: PORTAL, created: false };
-    });
-
-    await expect(
-      execute({
-        identity,
-        toolName: "portal",
-        request: { toolCallId: "reused-worker-portal", action: "open", port: 4321 },
-      }),
-    ).rejects.toThrow("Worker source environment changed");
-    expect(portalClose).not.toHaveBeenCalled();
-    expect(portalCarrierClose).toHaveBeenCalled();
-  });
-
-  it("closes the redundant carrier handle when an existing portal is reused", async () => {
-    portalOpen.mockResolvedValueOnce({ portal: PORTAL, created: false });
-
-    const result = await execute({
-      identity,
-      toolName: "portal",
-      request: { toolCallId: "reuse-worker-portal", action: "open", port: 4321 },
-    });
-    expect(result.resultJson).toContain(PORTAL.id);
-    expect(portalCarrierClose).toHaveBeenCalledOnce();
-    expect(portalClose).not.toHaveBeenCalled();
-  });
-
-  it("closes only the portal this turn created when authority is lost after open", async () => {
-    portalOpen.mockImplementationOnce(async () => {
-      sourceEnvironmentEpoch += 1;
-      return { portal: PORTAL, created: true };
+  it("retains the environment-owned portal when its source turn closes after publication", async () => {
+    const { service, httpServers } = useActualPortalService();
+    portalOpen.mockImplementationOnce(async (params) => {
+      const portal = await service.open(params);
+      placements.releaseTurn(sourceClaim);
+      return portal;
     });
 
     await expect(
@@ -366,8 +351,75 @@ describe("worker portal tool execution", () => {
         toolName: "portal",
         request: { toolCallId: "created-worker-portal", action: "open", port: 4321 },
       }),
-    ).rejects.toThrow("Worker source environment changed");
-    expect(portalClose).toHaveBeenCalledWith(PORTAL.id);
+    ).rejects.toThrow("Worker source session placement changed");
+
+    expect(service.list()).toHaveLength(1);
+    expect(httpServers[0]?.listening).toBe(true);
+    expect(portalChanged).toHaveBeenCalledOnce();
+    expect(portalCarrierClose).not.toHaveBeenCalled();
+    await service.closeAll();
+    expect(portalCarrierClose).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the successor portal when the original open loses authority during listener startup", async () => {
+    const actualListen = httpListen.listenGatewayHttpServer;
+    let notifyBindStarted!: () => void;
+    let releaseBind!: () => void;
+    const bindStarted = new Promise<void>((resolve) => {
+      notifyBindStarted = resolve;
+    });
+    const bindReleased = new Promise<void>((resolve) => {
+      releaseBind = resolve;
+    });
+    vi.spyOn(httpListen, "listenGatewayHttpServer").mockImplementation(async (params) => {
+      notifyBindStarted();
+      await bindReleased;
+      await actualListen(params);
+    });
+    const { service, httpServers } = useActualPortalService();
+    const first = execute({
+      identity,
+      toolName: "portal",
+      request: { toolCallId: "first-opening-portal", action: "open", port: 4321 },
+    });
+    const firstRejected = expect(first).rejects.toThrow("Worker source session placement changed");
+    let successor: ReturnType<typeof execute> | undefined;
+    try {
+      await bindStarted;
+      placements.releaseTurn(sourceClaim);
+      const nextClaim = placements.claimTurn({
+        sessionId: SOURCE.sessionId,
+        agentId: SOURCE.agentId,
+        sessionKey: SOURCE.sessionKey,
+        claimId: "successor-claim",
+        runId: "successor-run",
+        owner: sourceClaim.owner,
+      });
+      placements.authorizeWorkerTurnTools(nextClaim, ["portal"]);
+      successor = execute({
+        identity: { ...identity, runId: nextClaim.runId, turnClaim: nextClaim },
+        toolName: "portal",
+        request: {
+          toolCallId: "successor-opening-portal",
+          action: "open",
+          port: 4321,
+          title: "Successor app",
+        },
+      });
+      await vi.waitFor(() => expect(portalOpen).toHaveBeenCalledTimes(2));
+      releaseBind();
+      await firstRejected;
+      const result = JSON.parse((await successor).resultJson);
+
+      expect(service.list()).toEqual([
+        expect.objectContaining({ id: result.details.id, title: "Successor app" }),
+      ]);
+      expect(httpServers).toHaveLength(1);
+      expect(httpServers[0]?.listening).toBe(true);
+    } finally {
+      releaseBind();
+      await Promise.allSettled([firstRejected, successor]);
+    }
   });
 
   it("rejects SSH-backed placements before preparing a node portal", async () => {

--- a/src/gateway/worker-environments/worker-portal-tool-executor.ts
+++ b/src/gateway/worker-environments/worker-portal-tool-executor.ts
@@ -86,8 +86,8 @@ export function createWorkerPortalToolExecutor(params: WorkerPortalToolExecutorD
         throw new Error("Worker portal is not owned by the active environment");
       }
       await service.close(id, assertPortalAuthority);
-      assertPortalAuthority();
       params.portals.onChanged();
+      assertPortalAuthority();
       return {
         resultJson: serializeWorkerSessionToolResult(
           formatPortalResult({ action: "close", id, result: { closed: true } }),
@@ -103,52 +103,39 @@ export function createWorkerPortalToolExecutor(params: WorkerPortalToolExecutorD
       ownerEpoch: environment.ownerEpoch,
       remotePort,
     });
-    let createdPortalId: string | undefined;
     try {
       // Node discovery can yield; a replaced turn must never publish its former owner's portal.
       assertPortalAuthority();
       request.signal?.throwIfAborted();
-      const opened = await service.open({
-        targetPort: remotePort,
-        assertCurrent: assertPortalAuthority,
-        target: {
-          kind: "worker",
-          environmentId: environment.environmentId,
-          ownerEpoch: environment.ownerEpoch,
-          connect: connection.connect,
-          remotePort,
-        },
-        onClose: connection.close,
-        origin: environment.profileId,
-        ...(request.request.title !== undefined ? { title: request.request.title } : {}),
-        ...(request.request.description !== undefined
-          ? { description: request.request.description }
-          : {}),
-        ...(request.request.path !== undefined ? { path: request.request.path } : {}),
-      });
-      if (opened.created) {
-        createdPortalId = opened.portal.id;
-      } else {
-        // Reuse keeps the existing entry's connect/onClose; this turn's carrier handle is redundant.
-        await connection.close();
-      }
-      assertPortalAuthority();
-      params.portals.onChanged();
-      return {
-        resultJson: serializeWorkerSessionToolResult(
-          formatPortalResult({ action: "open", result: opened.portal }),
-        ),
-      };
     } catch (error) {
-      // Only tear down what this turn created: closing a reused portal here would let a
-      // revoked turn destroy the live portal a still-authorized predecessor established.
-      if (createdPortalId) {
-        await service.close(createdPortalId);
-        params.portals.onChanged();
-      } else {
-        await connection.close();
-      }
+      await connection.close();
       throw error;
     }
+    const opened = await service.open({
+      targetPort: remotePort,
+      assertCurrent: assertPortalAuthority,
+      target: {
+        kind: "worker",
+        environmentId: environment.environmentId,
+        ownerEpoch: environment.ownerEpoch,
+        connect: connection.connect,
+        remotePort,
+      },
+      onClose: connection.close,
+      origin: environment.profileId,
+      ...(request.request.title !== undefined ? { title: request.request.title } : {}),
+      ...(request.request.description !== undefined
+        ? { description: request.request.description }
+        : {}),
+      ...(request.request.path !== undefined ? { path: request.request.path } : {}),
+    });
+    // Publication transfers ownership to the environment; later turn revocation only denies its result.
+    params.portals.onChanged();
+    assertPortalAuthority();
+    return {
+      resultJson: serializeWorkerSessionToolResult(
+        formatPortalResult({ action: "open", result: opened }),
+      ),
+    };
   };
 }

--- a/src/gateway/worker-environments/worker-turn-rpc.portal.test.ts
+++ b/src/gateway/worker-environments/worker-turn-rpc.portal.test.ts
@@ -39,4 +39,61 @@ describe("worker portal RPC authority", () => {
       closeReason: "placement-mismatch",
     });
   });
+
+  it("returns actionable portal failures to an authorized worker", async () => {
+    const executeSessionTool = vi
+      .fn<NonNullable<support.WorkerEnvironmentServiceOptions["executeSessionTool"]>>()
+      .mockRejectedValue(new Error("portal port required"));
+    const { identity, workerService } = support.placementHarness(
+      "worker-portal-error",
+      "session-portal-error",
+      { executeSessionTool },
+    );
+
+    const result = await workerService.executeSessionTool(identity, "portal", {
+      toolCallId: "portal-missing-port",
+      action: "open",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("Expected a worker tool result");
+    }
+    expect(JSON.parse(result.result.resultJson)).toEqual({
+      content: [{ type: "text", text: expect.stringContaining("portal port required") }],
+      details: { status: "error", error: "portal port required" },
+    });
+  });
+
+  it.each(["placement", "tool"] as const)(
+    "fences a failed portal operation after its %s authority is revoked",
+    async (authority) => {
+      const executeSessionTool =
+        vi.fn<NonNullable<support.WorkerEnvironmentServiceOptions["executeSessionTool"]>>();
+      const { identity, placementStore, workerService } = support.placementHarness(
+        `worker-portal-revoked-${authority}`,
+        `session-portal-revoked-${authority}`,
+        { executeSessionTool },
+      );
+      executeSessionTool.mockImplementationOnce(async () => {
+        if (authority === "placement") {
+          placementStore.validateWorkerTurn.mockReturnValue(false);
+        } else {
+          placementStore.isWorkerTurnToolAuthorized.mockReturnValue(false);
+        }
+        throw new Error("Portal operation failed after authority changed");
+      });
+
+      await expect(
+        workerService.executeSessionTool(identity, "portal", {
+          toolCallId: "revoked-portal-call",
+          action: "open",
+          port: 3000,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        closeReason: authority === "placement" ? "placement-mismatch" : "method-not-allowed",
+      });
+    },
+  );
 });

--- a/src/gateway/worker-environments/worker-turn-rpc.ts
+++ b/src/gateway/worker-environments/worker-turn-rpc.ts
@@ -35,6 +35,10 @@ import { sameWorkerSessionTurnClaim, type WorkerSessionTurnClaim } from "./place
 import type { WorkerTurnExecutionIdentityCapability } from "./placement-turn-claim-events.js";
 import type { WorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import type { WorkerEnvironmentStore } from "./store.js";
+import {
+  serializeWorkerSessionToolResult,
+  workerSessionToolErrorResult,
+} from "./worker-session-tool-result.js";
 
 type WorkerProcessTurnBinding = {
   turnClaim: WorkerSessionTurnClaim;
@@ -442,11 +446,13 @@ export function createWorkerTurnRpc(options: WorkerTurnRpcOptions) {
         ...operation,
         ...(signal ? { signal } : {}),
       });
-    } catch {
-      return { ok: false, reason: "gateway-unavailable" };
+    } catch (error) {
+      result = {
+        resultJson: serializeWorkerSessionToolResult(workerSessionToolErrorResult(error)),
+      };
     }
     // The tool may have awaited provider provisioning or another session turn.
-    // Never return its result after the source turn or placement was revoked.
+    // Neither success nor failure may return after the source turn or placement was revoked.
     const current = validate();
     return current.ok ? { ok: true, result } : current;
   };

--- a/src/node-host/desktop-stream-command.test.ts
+++ b/src/node-host/desktop-stream-command.test.ts
@@ -165,107 +165,118 @@ describe("node desktop stream command", () => {
     ).rejects.toThrow("ticket and attachPath required");
   });
 
-  it("authenticates public and worker attaches and tears down both sockets when cancelled", async () => {
-    const rfbPeers = new Set<net.Socket>();
-    const rfbServer = net.createServer((socket) => {
-      rfbPeers.add(socket);
-      socket.once("close", () => rfbPeers.delete(socket));
-      // Cancellation destroys the client socket; the synthetic server owns the matching reset.
-      socket.on("error", handleExpectedPeerTeardownError);
-      socket.write(Buffer.from("RFB 003.008\n", "ascii"));
-      socket.once("data", () => socket.write(Buffer.from([1, 2])));
-    });
-    await new Promise<void>((resolve) => {
-      rfbServer.listen(0, "127.0.0.1", resolve);
-    });
-    const rfbAddress = rfbServer.address();
-    if (!rfbAddress || typeof rfbAddress === "string") {
-      throw new Error("expected RFB test address");
-    }
-    cleanups.push(
-      async () =>
-        await new Promise<void>((resolve) => {
-          for (const peer of rfbPeers) {
-            peer.destroy();
-          }
-          rfbServer.close(() => resolve());
-        }),
-    );
-
-    const httpServer = http.createServer();
-    const wss = new WebSocketServer({ server: httpServer });
-    const streams: Array<{
-      accessHeaders: [string | undefined, string | undefined];
-      closed: boolean;
-    }> = [];
-    wss.on("connection", (ws, request) => {
-      const stream = {
-        accessHeaders: [
-          request.headers["cf-access-client-id"],
-          request.headers["cf-access-client-secret"],
-        ] as [string | undefined, string | undefined],
-        closed: false,
-      };
-      streams.push(stream);
-      ws.once("close", () => {
-        stream.closed = true;
+  it.each(["", "/openclaw-gw", "/openclaw-gw/"])(
+    "authenticates public and worker attaches through Gateway context %j and tears down on cancellation",
+    async (contextPath) => {
+      const rfbPeers = new Set<net.Socket>();
+      const rfbServer = net.createServer((socket) => {
+        rfbPeers.add(socket);
+        socket.once("close", () => rfbPeers.delete(socket));
+        // Cancellation destroys the client socket; the synthetic server owns the matching reset.
+        socket.on("error", handleExpectedPeerTeardownError);
+        socket.write(Buffer.from("RFB 003.008\n", "ascii"));
+        socket.once("data", () => socket.write(Buffer.from([1, 2])));
       });
-    });
-    await new Promise<void>((resolve) => {
-      httpServer.listen(0, "127.0.0.1", resolve);
-    });
-    const gatewayAddress = httpServer.address();
-    if (!gatewayAddress || typeof gatewayAddress === "string") {
-      throw new Error("expected Gateway test address");
-    }
-    cleanups.push(
-      async () =>
-        await new Promise<void>((resolve) => {
-          wss.close(() => httpServer.close(() => resolve()));
-        }),
-    );
-
-    for (const kind of ["public", "worker"] as const) {
-      const controller = new AbortController();
-      const emitStatus = vi.fn(async () => undefined);
-      const connection = {
-        paramsJSON: JSON.stringify({
-          ticket: TICKET,
-          attachPath: `/node-desktop/attach?ticket=${TICKET}`,
-          ...(kind === "worker" ? { port: rfbAddress.port } : {}),
-        }),
-        gatewayUrl: `ws://127.0.0.1:${gatewayAddress.port}`,
-        gatewayCloudflareAccess: {
-          clientId: "desktop-client-id",
-          clientSecret: "desktop-client-secret",
-        },
-        signal: controller.signal,
-      };
-      const running =
-        kind === "worker"
-          ? invokeNodeWorkerDesktopStream(connection)
-          : invokeNodeDesktopStream({
-              ...connection,
-              config: { enabled: true, port: rfbAddress.port },
-              emitStatus,
-            });
-      await vi.waitFor(() => expect(streams).toHaveLength(kind === "public" ? 1 : 2));
-      const stream = streams.at(-1);
-      if (!stream) {
-        throw new Error("expected desktop stream attachment");
+      await new Promise<void>((resolve) => {
+        rfbServer.listen(0, "127.0.0.1", resolve);
+      });
+      const rfbAddress = rfbServer.address();
+      if (!rfbAddress || typeof rfbAddress === "string") {
+        throw new Error("expected RFB test address");
       }
-      expect(stream.accessHeaders).toEqual(["desktop-client-id", "desktop-client-secret"]);
-      if (kind === "public") {
-        await vi.waitFor(() =>
-          expect(emitStatus).toHaveBeenCalledWith("desktop stream attached\n"),
-        );
+      cleanups.push(
+        async () =>
+          await new Promise<void>((resolve) => {
+            for (const peer of rfbPeers) {
+              peer.destroy();
+            }
+            rfbServer.close(() => resolve());
+          }),
+      );
+
+      const httpServer = http.createServer();
+      const wss = new WebSocketServer({
+        server: httpServer,
+        path: `${contextPath.replace(/\/$/u, "")}/node-desktop/attach`,
+      });
+      const streams: Array<{
+        accessHeaders: [string | undefined, string | undefined];
+        closed: boolean;
+      }> = [];
+      wss.on("connection", (ws, request) => {
+        const stream = {
+          accessHeaders: [
+            request.headers["cf-access-client-id"],
+            request.headers["cf-access-client-secret"],
+          ] as [string | undefined, string | undefined],
+          closed: false,
+        };
+        streams.push(stream);
+        ws.once("close", () => {
+          stream.closed = true;
+        });
+      });
+      await new Promise<void>((resolve) => {
+        httpServer.listen(0, "127.0.0.1", resolve);
+      });
+      const gatewayAddress = httpServer.address();
+      if (!gatewayAddress || typeof gatewayAddress === "string") {
+        throw new Error("expected Gateway test address");
       }
+      cleanups.push(
+        async () =>
+          await new Promise<void>((resolve) => {
+            wss.close(() => httpServer.close(() => resolve()));
+          }),
+      );
 
-      controller.abort();
+      for (const kind of ["public", "worker"] as const) {
+        const controller = new AbortController();
+        const emitStatus = vi.fn(async () => undefined);
+        const connection = {
+          paramsJSON: JSON.stringify({
+            ticket: TICKET,
+            attachPath: `/node-desktop/attach?ticket=${TICKET}`,
+            ...(kind === "worker" ? { port: rfbAddress.port } : {}),
+          }),
+          gatewayUrl: `ws://127.0.0.1:${gatewayAddress.port}${contextPath}`,
+          gatewayCloudflareAccess: {
+            clientId: "desktop-client-id",
+            clientSecret: "desktop-client-secret",
+          },
+          signal: controller.signal,
+        };
+        const running =
+          kind === "worker"
+            ? invokeNodeWorkerDesktopStream(connection)
+            : invokeNodeDesktopStream({
+                ...connection,
+                config: { enabled: true, port: rfbAddress.port },
+                emitStatus,
+              });
+        void running.catch(() => undefined);
+        cleanups.push(async () => {
+          controller.abort();
+          await running.catch(() => undefined);
+        });
+        await vi.waitFor(() => expect(streams).toHaveLength(kind === "public" ? 1 : 2));
+        const stream = streams.at(-1);
+        if (!stream) {
+          throw new Error("expected desktop stream attachment");
+        }
+        expect(stream.accessHeaders).toEqual(["desktop-client-id", "desktop-client-secret"]);
+        if (kind === "public") {
+          await vi.waitFor(() =>
+            expect(emitStatus).toHaveBeenCalledWith("desktop stream attached\n"),
+          );
+        }
 
-      await expect(running).resolves.toBeUndefined();
-      await vi.waitFor(() => expect(stream.closed).toBe(true));
-      await vi.waitFor(() => expect(rfbPeers.size).toBe(0));
-    }
-  });
+        controller.abort();
+
+        await expect(running).resolves.toBeUndefined();
+        await vi.waitFor(() => expect(stream.closed).toBe(true));
+        await vi.waitFor(() => expect(rfbPeers.size).toBe(0));
+      }
+    },
+  );
 });

--- a/src/node-host/node-stream-transport.ts
+++ b/src/node-host/node-stream-transport.ts
@@ -35,6 +35,8 @@ function attachWebSocketUrl(params: {
   if (url.origin !== gateway.origin || url.pathname !== params.expectedAttachPath) {
     throw new Error(`${params.streamName} stream attachPath must stay on the connected gateway`);
   }
+  // Auxiliary streams share the enrolled node's reverse-proxy mount point.
+  url.pathname = `${gateway.pathname.replace(/\/$/u, "")}${url.pathname}`;
   return url.toString();
 }
 
@@ -239,7 +241,8 @@ export async function runNodeStreamTransport(params: {
       // Attach first so a refused target closes a claimed ticket instead of leaving it pending.
       await Promise.race([waitForWebSocketOpen(ws), abort]);
       if (!aborted) {
-        socket.connect(params.port, "127.0.0.1");
+        // Like Gateway-local portals, reach dev servers bound to either localhost family.
+        socket.connect({ port: params.port, host: "localhost", autoSelectFamily: true });
         await Promise.race([waitForSocketConnect(socket), abort]);
       }
     } else {

--- a/src/node-host/portal-stream-command.test.ts
+++ b/src/node-host/portal-stream-command.test.ts
@@ -7,9 +7,15 @@ import { invokeNodeWorkerPortalStream } from "./portal-stream-command.js";
 const TICKET = "a".repeat(48);
 const cleanups: Array<() => Promise<void>> = [];
 
-async function listenGateway(onConnection: (ws: WebSocket, request: http.IncomingMessage) => void) {
+async function listenGateway(
+  onConnection: (ws: WebSocket, request: http.IncomingMessage) => void,
+  contextPath = "",
+) {
   const server = http.createServer();
-  const wss = new WebSocketServer({ server });
+  const wss = new WebSocketServer({
+    server,
+    path: `${contextPath.replace(/\/$/u, "")}/node-portal/attach`,
+  });
   wss.on("connection", onConnection);
   await new Promise<void>((resolve) => {
     server.listen(0, "127.0.0.1", resolve);
@@ -27,7 +33,7 @@ async function listenGateway(onConnection: (ws: WebSocket, request: http.Incomin
         wss.close(() => server.close(() => resolve()));
       }),
   );
-  return `ws://127.0.0.1:${address.port}`;
+  return `ws://127.0.0.1:${address.port}${contextPath}`;
 }
 
 function portalCommand(port: number) {
@@ -65,76 +71,89 @@ describe("node worker portal stream command", () => {
     ).rejects.toThrow("INVALID_REQUEST");
   });
 
-  it("attaches an enrolled loopback socket, exchanges binary data, and closes on cancellation", async () => {
-    const peers = new Set<net.Socket>();
-    const local = net.createServer((socket) => {
-      peers.add(socket);
-      socket.once("close", () => peers.delete(socket));
-      socket.on("data", (chunk) =>
-        socket.write(Buffer.concat([Buffer.from("echo:"), Buffer.from(chunk)])),
+  it.each([
+    ["127.0.0.1", ""],
+    ["::1", ""],
+    ["127.0.0.1", "/openclaw-gw"],
+    ["127.0.0.1", "/openclaw-gw/"],
+  ])(
+    "attaches %s loopback through Gateway context %j and closes on cancellation",
+    async (host, contextPath) => {
+      const peers = new Set<net.Socket>();
+      const local = net.createServer((socket) => {
+        peers.add(socket);
+        socket.once("close", () => peers.delete(socket));
+        socket.on("data", (chunk) =>
+          socket.write(Buffer.concat([Buffer.from("echo:"), Buffer.from(chunk)])),
+        );
+      });
+      await new Promise<void>((resolve) => {
+        local.listen(0, host, resolve);
+      });
+      const address = local.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected portal loopback test address");
+      }
+      cleanups.push(
+        async () =>
+          await new Promise<void>((resolve) => {
+            for (const peer of peers) {
+              peer.destroy();
+            }
+            local.close(() => resolve());
+          }),
       );
-    });
-    await new Promise<void>((resolve) => {
-      local.listen(0, "127.0.0.1", resolve);
-    });
-    const address = local.address();
-    if (!address || typeof address === "string") {
-      throw new Error("expected portal loopback test address");
-    }
-    cleanups.push(
-      async () =>
-        await new Promise<void>((resolve) => {
-          for (const peer of peers) {
-            peer.destroy();
+
+      const frames: Buffer[] = [];
+      let attached: WebSocket | undefined;
+      let accessHeaders: [string | undefined, string | undefined] | undefined;
+      let closed = false;
+      const gatewayUrl = await listenGateway((ws, request) => {
+        attached = ws;
+        accessHeaders = [
+          request.headers["cf-access-client-id"]?.toString(),
+          request.headers["cf-access-client-secret"]?.toString(),
+        ];
+        ws.on("message", (data, isBinary) => {
+          expect(isBinary).toBe(true);
+          if (!Buffer.isBuffer(data)) {
+            throw new Error("expected binary portal stream frame");
           }
-          local.close(() => resolve());
-        }),
-    );
-
-    const frames: Buffer[] = [];
-    let attached: WebSocket | undefined;
-    let accessHeaders: [string | undefined, string | undefined] | undefined;
-    let closed = false;
-    const gatewayUrl = await listenGateway((ws, request) => {
-      attached = ws;
-      accessHeaders = [
-        request.headers["cf-access-client-id"]?.toString(),
-        request.headers["cf-access-client-secret"]?.toString(),
-      ];
-      ws.on("message", (data, isBinary) => {
-        expect(isBinary).toBe(true);
-        if (!Buffer.isBuffer(data)) {
-          throw new Error("expected binary portal stream frame");
-        }
-        frames.push(data);
+          frames.push(data);
+        });
+        ws.once("close", () => {
+          closed = true;
+        });
+      }, contextPath);
+      const controller = new AbortController();
+      const running = invokeNodeWorkerPortalStream({
+        paramsJSON: portalCommand(address.port),
+        gatewayUrl,
+        gatewayCloudflareAccess: {
+          clientId: "portal-client-id",
+          clientSecret: "portal-client-secret",
+        },
+        signal: controller.signal,
       });
-      ws.once("close", () => {
-        closed = true;
+      cleanups.push(async () => {
+        controller.abort();
+        await running.catch(() => undefined);
       });
-    });
-    const controller = new AbortController();
-    const running = invokeNodeWorkerPortalStream({
-      paramsJSON: portalCommand(address.port),
-      gatewayUrl,
-      gatewayCloudflareAccess: {
-        clientId: "portal-client-id",
-        clientSecret: "portal-client-secret",
-      },
-      signal: controller.signal,
-    });
+      void running.catch(() => undefined);
 
-    await vi.waitFor(() => expect(frames).toHaveLength(1));
-    expect(frames[0]?.toString("utf8")).toBe(JSON.stringify({ ok: true }));
-    expect(accessHeaders).toEqual(["portal-client-id", "portal-client-secret"]);
-    attached?.send(Buffer.from("hello"), { binary: true });
-    await vi.waitFor(() => expect(frames[1]?.toString("utf8")).toBe("echo:hello"));
+      await vi.waitFor(() => expect(frames).toHaveLength(1));
+      expect(frames[0]?.toString("utf8")).toBe(JSON.stringify({ ok: true }));
+      expect(accessHeaders).toEqual(["portal-client-id", "portal-client-secret"]);
+      attached?.send(Buffer.from("hello"), { binary: true });
+      await vi.waitFor(() => expect(frames[1]?.toString("utf8")).toBe("echo:hello"));
 
-    controller.abort();
+      controller.abort();
 
-    await expect(running).resolves.toBeUndefined();
-    await vi.waitFor(() => expect(closed).toBe(true));
-    await vi.waitFor(() => expect(peers.size).toBe(0));
-  });
+      await expect(running).resolves.toBeUndefined();
+      await vi.waitFor(() => expect(closed).toBe(true));
+      await vi.waitFor(() => expect(peers.size).toBe(0));
+    },
+  );
 
   it("closes an attached Gateway socket without a readiness frame when loopback refuses", async () => {
     const unavailable = net.createServer();
@@ -172,7 +191,7 @@ describe("node worker portal stream command", () => {
         gatewayUrl,
         signal: new AbortController().signal,
       }),
-    ).rejects.toThrow("ECONNREFUSED");
+    ).rejects.toMatchObject({ code: "ECONNREFUSED" });
 
     expect(attached).toBe(true);
     await vi.waitFor(() => expect(closed).toBe(true));

--- a/src/worker/worker-command.runtime.test.ts
+++ b/src/worker/worker-command.runtime.test.ts
@@ -1,12 +1,17 @@
+import { Console } from "node:console";
 import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   WORKER_PROTOCOL_FEATURES,
   WORKER_RPC_SET_VERSION,
 } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { setLoggerOverride } from "../logging/logger.js";
+import { loggingState } from "../logging/state.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { WorkerBrowserRuntime } from "./browser-runtime.js";
 import type { WorkerLaunchDescriptor } from "./launch-descriptor.js";
 import { runWorkerCommand } from "./worker-command.runtime.js";
+import { runWorkerProcess } from "./worker-process.js";
 import { runWorkerDescriptor } from "./worker.runtime.js";
 
 vi.mock("./worker.runtime.js", () => ({
@@ -104,6 +109,53 @@ describe("worker command lifetime gate", () => {
     expect(JSON.parse(Buffer.concat(chunks).toString("utf8"))).toMatchObject({
       status: "completed",
     });
+  });
+
+  it("keeps worker process stdout valid JSON when runtime diagnostics are emitted", async () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const originalConsole = globalThis.console;
+    const previousLogging = { ...loggingState };
+    const originalStreams = {
+      stdin: Object.getOwnPropertyDescriptor(process, "stdin")!,
+      stdout: Object.getOwnPropertyDescriptor(process, "stdout")!,
+      stderr: Object.getOwnPropertyDescriptor(process, "stderr")!,
+    };
+    Object.defineProperties(process, {
+      stdin: { configurable: true, value: commandInput() },
+      stdout: { configurable: true, value: stdout },
+      stderr: { configurable: true, value: stderr },
+    });
+    globalThis.console = new Console({ stdout, stderr });
+    loggingState.consolePatched = false;
+    loggingState.forceConsoleToStderr = false;
+    loggingState.rawConsole = null;
+    loggingState.streamErrorHandlersInstalled = false;
+    setLoggerOverride({ level: "silent", consoleLevel: "info", consoleStyle: "compact" });
+    vi.mocked(runWorkerDescriptor).mockImplementationOnce(async () => {
+      createSubsystemLogger("state/db").info("worker state diagnostic");
+      return { status: "completed", transcriptLeafId: null, transcriptNextSeq: 1 };
+    });
+    let output = "";
+    let diagnostics = "";
+    try {
+      await runWorkerProcess();
+      output = String(stdout.read() ?? "");
+      diagnostics = String(stderr.read() ?? "");
+    } finally {
+      Object.defineProperties(process, originalStreams);
+      globalThis.console = originalConsole;
+      Object.assign(loggingState, previousLogging);
+      stdout.destroy();
+      stderr.destroy();
+    }
+
+    expect(JSON.parse(output)).toEqual({
+      status: "completed",
+      transcriptLeafId: null,
+      transcriptNextSeq: 1,
+    });
+    expect(diagnostics).toContain("worker state diagnostic");
   });
 
   it("passes the build-composed Browser runtime into the worker boundary", async () => {

--- a/src/worker/worker-process.ts
+++ b/src/worker/worker-process.ts
@@ -1,3 +1,4 @@
+import { enableConsoleCapture, routeLogsToStderr } from "../logging/console.js";
 import { signalProcessTree } from "../process/kill-tree.js";
 import type { WorkerBrowserRuntime } from "./browser-runtime.js";
 import {
@@ -116,6 +117,9 @@ export async function runWorkerProcess(
     browserRuntime?: WorkerBrowserRuntime;
   } = {},
 ): Promise<void> {
+  // Stdout belongs to the worker result; diagnostics stay on stderr through process shutdown.
+  routeLogsToStderr();
+  enableConsoleCapture();
   await runWorkerCommand({
     input: process.stdin,
     output: process.stdout,


### PR DESCRIPTION
Related: #130105

## What Problem This Solves

Fixes an issue where users opening worker portals could get a permanent waiting page for IPv6-only apps or nodes behind a Gateway URL prefix. Interrupted HTTP streams could also remain open, and a revoked turn could remove a successor turn's portal while listener startup was still pending. Worker tool failures hid the actionable error behind a generic protocol rejection.

Live testing also exposed worker diagnostics contaminating the JSON result stream after an otherwise successful model turn. The original feature PR was already merged as c3ea9775ca7; this is its reviewed follow-up repair.

## Why This Change Was Made

Portal publication and carrier cleanup now belong to the serialized portal service. It validates authority after listener startup and releases unused targets itself. The executor no longer rolls back a registered portal by its stable ID after another turn can reuse it. The internal `created` bookkeeping/result wrapper is removed; the public RPC result is unchanged.

Auxiliary node streams retain the enrolled Gateway context path. Portal dialing uses the same localhost family selection as Gateway-local portals; desktop dialing remains IPv4. HTTP response lifetimes close their opposite side, and worker RPC errors use the existing bounded, redacted tool-result formatter before the final authority check. The worker process entry enables existing stderr routing/console capture, keeping the JSON parser strict and diagnostics intact.

Production: +158/-151 (net +7). Portal ownership simplification absorbs the race fix and removes rollback bookkeeping; remaining growth implements route preservation, dual-family dialing, response cleanup, error-result fencing, and the worker stdout boundary. Tests: +610/-339 (net +271); docs: +2. No new dependencies, config keys, schemas, persistent-store semantics, or compatibility layers. The review's stored-data detector flagged existing placement reads/test fixtures; this patch adds no store or migration.

## User Impact

Worker portals support IPv4 and IPv6 loopback apps and Gateway reverse-proxy prefixes, report useful errors, and survive a revoked predecessor racing with a valid successor. Browser departures and interrupted app streams clean up promptly. The prefix fix also covers desktop streams. Worker diagnostics no longer turn a completed model run into a JSON protocol failure.

A separate existing limitation remains: worker turn cleanup cancels background development servers after the turn ends. Tracked with live reproduction in #130450. This patch does not delete cleanup or create unowned background processes.

## Evidence

- Before repair: 14 failing regressions covering IPv6, prefixed portal/desktop routes, both HTTP disconnect directions on local/worker targets, startup revocation/reuse, error/revocation handling, and worker stdout contamination.
- After repair: 207 tests pass across 15 focused suites, including real HTTP/WebSocket transport, the real portal service/placement-store race, node carrier/broker, sibling worker session-tool RPC paths, and worker/logging boundaries.
- Broad `node scripts/check-changed.mjs` passed for the portal repair. The additional worker fix passed core/core-test typechecks, targeted typed lint, formatting, and its worker/logging suites. `git diff --check` passes.
- Independent Codex autoreview passed for the portal repair and again for the live-discovered stdout repair, with no actionable findings.
- `OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1 pnpm build` passed, including runtime bundling, postbuild guards, and Control UI. This is the supported runtime-only build; full declaration-build validation is left to CI. The initial UI build needed this worktree's existing shared UI dependency link.

### Live trace

Used a disposable authenticated Gateway plus a separate enrolled node process on the same macOS host, routed through a reverse proxy mounted at `/proof`. This was a real OpenClaw worker turn with a real OpenAI model; no mocked Gateway, worker carrier, or inference provider. The operator Gateway and state were untouched. Final worker bundle: `74e251c82982411e1488916cdd94402b2e99148173b094043c662c6132c2fded`.

1. Real worker tool request for an unowned portal returned `Worker portal is not owned by the active environment`; the model recovered and opened the valid port.
2. Unauthenticated portal request: HTTP 401. Authorized request before app startup: HTTP 502 waiting page.
3. An IPv6-only `[::1]` app in the assigned node workspace returned HTTP 200 through the portal. WebSocket echo returned the exact sent payload. The reverse proxy observed `/proof/node-portal/attach` requests (and forwarded the stripped route).
4. Closing the HTTP event-stream client left zero active app streams. Interrupting the app response closed the client in 223 ms. `Referrer-Policy: no-referrer` remained intact.
5. Real model `portal.close` removed the portal; its listener refused new connections and the portal list was empty.
6. After the stdout fix, a fresh worker bundle ran real `exec` plus `process poll`, confirmed the IPv6 app had started, and completed with `agent.wait: status=ok` rather than a JSON parse failure.

For sustained traffic checks, the test runner launched the same fixture in the assigned node workspace because the existing turn cleanup stops model-owned background apps (#130450). This is live same-host node transport proof, not a remote-cloud allocation or browser click-through. Chrome automation stalled on a dialog; no rendered UI/screenshot proof is claimed. No UI source changed.

### Review follow-through

The requested mounted-path/IPv6 live evidence is above. [Node 22's documented `socket.connect` contract](https://nodejs.org/docs/latest-v22.x/api/net.html#socketconnectoptions-connectlistener) explicitly supports `autoSelectFamily`, trying both address families and emitting an aggregate error when all attempts fail. Node 22.23.2 compatibility checks passed for the node transport and worker stdout suites (28 tests) and the HTTP proxy suite (21 tests). The first proxy run exposed a test fixture relying on Node 26 duplex-pair destroy propagation: the corrected fixture now delivers the same peer EOF as a real WebSocket and releases its app socket. With that corrected fixture, restoring the old production proxy still reproduces all four disconnect failures; no assertions or timeouts were relaxed. Final-commit CI remains the landing gate.

Regression provenance: worker IPv6 and startup ownership paths came from #130105 (2026-08-26); the shared desktop prefix bug predates it in #122724 (0c824f09d54, 2026-08-12). HTTP disconnect cleanup dates to the original portals implementation, #122536 (2026-08-13). The generic worker RPC catch was carried forward by #122138 (2d6a5d7356bb, 2026-08-11), but #130105 newly exposed portal errors through it. The worker-only entry skipping logging setup dates to #124037 (78502eda6dec, merged 2026-08-16 UTC). All five predecessor PRs and their blamed code were authored by @steipete, and GitHub records @steipete as each merger. This follow-up is also authored by @steipete. Codex remote-exec remains outside the worker tool loop (direct upstream inspection: `codex-rs/exec-server/src/environment.rs:720-925`).

### CI follow-through

[CI run 33019643520](https://github.com/openclaw/openclaw/actions/runs/33019643520) timed out in the first xAI compaction hook test, outside the portal changes. Investigation found two existing harness mocks targeting retired module names; they now target the current `agent-bundle-*` owners, matching sibling harnesses and restoring the intended tool-runtime isolation. The mock implementations, test assertions, and timeouts are unchanged. All 152 compaction hook tests pass locally on Node 24.19.0 and Node 26.7.0; the exact cause of the hosted timeout remains unproven, so the mock correction is not claimed as a measured timing fix. Typed lint, formatting, and independent Codex autoreview passed. This is a bounded test-only cleanup; compaction production code is unchanged. Blame reaches the shallow-history boundary e357203be57 (2026-07-12, Vincent Koc), so the original rename provenance is not established.

Final head `4e27784a8b3ec235e935510c972b3ec96e613d12` passed [CI run 33021008211](https://github.com/openclaw/openclaw/actions/runs/33021008211), including the previously failing compaction shard and `openclaw/ci-gate`. The hydrated current-main comparison at `34ccf63e1379` found all seven changed runtime owners and the compaction harness unchanged from the PR base. No rebase was needed for that drift.

The lifecycle choice for this repair is environment ownership after successful portal publication. Existing environment tunnel teardown already closes portals by environment/owner epoch (`src/gateway/worker-environments/service.ts:140`, `:608`); a revoked originating turn must not delete a portal reused by its successor. Pre-publication revocation still prevents publication, and post-operation revocation still denies the stale result. This retains the service-owned cleanup simplification requested in the latest review. The Node dependency contract and supported-version proof are recorded above; no store/schema migration is involved.

The latest automated live-check wrapper reported a terminal-wait/output-matching failure, while its attached test output reports 30 passing tests and a completed runner in 24.61 seconds. No test-case failure appears in that output. Our completed focused runs and final hosted CI independently cover those paths. Named tooling follow-up: audit ClawSweeper terminal completion and output matching so a completed passing test report is not presented as a product-test failure.
