### PR TITLE
improve(worker): diagnose admission-deadline failures and widen daemon revalidation budget

### DIFF
--- a/docs/cli/worker.md
+++ b/docs/cli/worker.md
@@ -34,6 +34,17 @@ no longer current. Missing, duplicate, or unknown tool names also invalidate the
 envelope. Operators should start workers through the cloud worker
 orchestrator rather than invoke this entry point directly.
 
+If admission exhausts its 120-second retry budget, the terminal error includes
+the attempt count, Gateway host and port (or local socket path), and last failure.
+`connect failed` means the WebSocket did not open; check reachability and TLS.
+`no hello within deadline` means it opened but the Gateway did not complete worker
+admission. A retryable admission rejection retains its reason. These bounded,
+credential-redacted details appear in the node launch journal and turn error.
+
+Container launches revalidate the pinned daemon identity before creating each
+container. This check allows 30 seconds for a busy daemon; a timeout still fails
+the launch and names the command. A changed daemon identity remains a hard failure.
+
 ## Runtime boundary
 
 The process runs the normal embedded agent loop with a restricted backend:

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -249,7 +249,7 @@ describe("node worker tunnel manager", () => {
   it("projects a terminal gateway connection failure into the launch result", async () => {
     const record = environment();
     const errorText =
-      "worker could not reach gateway gateway.example: certificate rejected; check TLS pin/publicUrl configuration";
+      "worker admission deadline exceeded after 3 attempts to gateway.example:18789: connect failed: Opening handshake has timed out";
     const manager = createNodeWorkerTunnelManager({
       gatewayDeviceId: "gateway-device-1",
       getEnvironment: () => record,

--- a/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
@@ -556,14 +556,16 @@ describe("worker turn launcher failure recovery", () => {
     expect(teardownStates).toEqual([]);
   });
 
-  it("keeps redacted process failure details on a valid UTF-16 boundary", async () => {
+  it("preserves the admission diagnosis with bounded redacted process failure details", async () => {
     seedActivePlacement();
     const secret = "$SUPERSECRET123";
-    const redactedPrefix = "DISCORD_BOT_TOKEN=*** ";
+    const diagnosis =
+      "worker admission deadline exceeded after 3 attempts to gateway.example:18789: connect failed: Opening handshake has timed out; ";
+    const redactedPrefix = `${diagnosis}DISCORD_BOT_TOKEN=*** `;
     const padding = "a".repeat(399 - redactedPrefix.length);
     const retained = `${redactedPrefix}${padding}`;
     const emoji = String.fromCodePoint(0x1f600);
-    const stderr = `DISCORD_BOT_TOKEN=${secret} ${padding}${emoji}tail`;
+    const stderr = `${diagnosis}DISCORD_BOT_TOKEN=${secret} ${padding}${emoji}tail`;
     const stopTunnel = vi.fn(async () => {});
     const destroy = vi.fn(async () => attachedEnvironment());
     const environments: WorkerTurnEnvironmentService = {

--- a/src/node-host/node-worker-container-engine.ts
+++ b/src/node-host/node-worker-container-engine.ts
@@ -26,6 +26,9 @@ type NodeWorkerContainerExpectedOwner = {
 };
 
 const DEFAULT_NODE_WORKER_CONTAINER_IMAGE = "node:22-slim";
+// Burst launches can delay a healthy daemon's identity response; keep revalidation
+// fail-closed without treating temporary daemon contention as an unavailable engine.
+const CONTAINER_REVALIDATION_TIMEOUT_MS = 30_000;
 
 const HOST_LABEL = "openclaw.node-worker.host";
 const GATEWAY_LABEL = "openclaw.node-worker.gateway";
@@ -95,6 +98,7 @@ async function resolveContainerEngineTarget(
   options: { pinned?: boolean } = {},
 ): Promise<Pick<NodeWorkerContainerEngine, "target" | "env">> {
   const env = engine.env ?? process.env;
+  const timeoutMs = options.pinned ? CONTAINER_REVALIDATION_TIMEOUT_MS : 5_000;
   if (engine.id === "docker") {
     const endpoint =
       env.DOCKER_HOST?.trim() ||
@@ -114,7 +118,7 @@ async function resolveContainerEngineTarget(
     const daemonId = await runContainerCommand(
       { ...engine, env: frozenEnv },
       ["info", "--format", "{{.ID}}"],
-      5_000,
+      timeoutMs,
     );
     if (!daemonId || daemonId === "<no value>") {
       throw new Error("Docker daemon did not report a stable identity");
@@ -128,7 +132,7 @@ async function resolveContainerEngineTarget(
   const info = await runContainerCommand(
     engine,
     ["info", "--format", "{{.Host.Hostname}}\t{{.Store.GraphRoot}}\t{{.Host.RemoteSocket.Path}}"],
-    5_000,
+    timeoutMs,
   );
   const [hostname, graphRoot, remoteSocket = "", extra] = info.split("\t");
   if (extra !== undefined || !hostname || !graphRoot || hostname === "<no value>") {

--- a/src/node-host/node-worker-launch-transport.ts
+++ b/src/node-host/node-worker-launch-transport.ts
@@ -2,7 +2,6 @@ import { isGatewayLoopbackHost } from "../../packages/gateway-client/src/websock
 import { createChildAdapter } from "../process/supervisor/adapters/child.js";
 import type { WorkerLaunchDescriptor } from "../worker/launch-descriptor.js";
 import { parseNodeWorkerConnectionFailureMessage } from "../worker/node-supervisor-protocol.js";
-import { formatWorkerConnectionFailure } from "../worker/worker-connection-contract.js";
 import {
   buildNodeWorkerContainerStartArgv,
   createNodeWorkerContainer,
@@ -68,13 +67,10 @@ export async function prepareNodeWorkerLaunchTransport(
             return;
           }
           options.connectionFailure.errorText = diagnostic.cause
-            ? formatWorkerConnectionFailure(
-                options.descriptor.connectionEndpoint,
-                sanitizeNodeWorkerDiagnostic(
-                  diagnostic.cause,
-                  "node worker gateway connection failed",
-                  options.scrubber.scrub,
-                ),
+            ? sanitizeNodeWorkerDiagnostic(
+                diagnostic.cause,
+                "node worker gateway connection failed",
+                options.scrubber.scrub,
               )
             : undefined;
         },

--- a/src/node-host/node-worker-supervisor.container.test.ts
+++ b/src/node-host/node-worker-supervisor.container.test.ts
@@ -33,7 +33,9 @@ if (process.connected || process.argv.includes("--internal-worker-ipc")) {
   process.stderr.write("container worker unexpectedly received Node IPC");
   process.exit(24);
 }
-if (descriptor.assignment.prompt === "wait") {
+if (descriptor.assignment.prompt === "admission-failure") {
+  throw new Error("worker admission deadline exceeded after 9 attempts to gateway.example:443: connect failed: Opening handshake has timed out " + descriptor.admission.credential);
+} else if (descriptor.assignment.prompt === "wait") {
   fs.writeFileSync(descriptor.assignment.workspaceDir + "/worker-started", "started");
   setInterval(() => {}, 1000);
 } else {
@@ -131,7 +133,9 @@ if (command === "version") {
 } else if (command === "info") {
   const daemonId = fs.readFileSync(path.join(engineRoot, "daemon-id"), "utf8");
   record({ argv: args, daemonId });
-  process.stdout.write(daemonId + "\n");
+  const delayFile = path.join(engineRoot, "info-delay-ms");
+  const delayMs = fs.existsSync(delayFile) ? Number(fs.readFileSync(delayFile, "utf8")) : 0;
+  setTimeout(() => process.stdout.write(daemonId + "\n"), delayMs);
 } else if (command === "create") {
   const id = createHash("sha256").update(JSON.stringify(args)).digest("hex");
   const labels = {};
@@ -497,6 +501,28 @@ describe("node worker supervisor container isolation", () => {
     }
   });
 
+  it("persists the container worker's admission diagnosis from stderr without credentials", async () => {
+    const fixture = containerFixture();
+    const input = testWorkerLaunchInput(
+      fixture.workspaceDir,
+      "container-admission-failure",
+      "admission-failure",
+    );
+    try {
+      await fixture.supervisor.launch(input, endpoint);
+      const failed = await waitForTerminal(fixture.supervisor, input.launchId);
+      expect(failed).toMatchObject({ state: "failed" });
+      expect(failed?.errorText).toContain(
+        "worker admission deadline exceeded after 9 attempts to gateway.example:443: connect failed: Opening handshake has timed out",
+      );
+      expect(failed?.errorText).not.toContain(input.descriptor.admission.credential);
+      expect(Buffer.byteLength(failed?.errorText ?? "", "utf8")).toBeLessThanOrEqual(4_096);
+      expect((await fixture.supervisor.status(input.launchId))?.errorText).toBe(failed?.errorText);
+    } finally {
+      await fixture.supervisor.close();
+    }
+  });
+
   it("keeps a launch running while its container is still starting", async () => {
     const fixture = containerFixture();
     const input = testWorkerLaunchInput(fixture.workspaceDir, "container-startup-poll");
@@ -566,6 +592,56 @@ describe("node worker supervisor container isolation", () => {
       await fixture.supervisor.close();
     }
   });
+
+  it(
+    "launches after a busy daemon takes six seconds to revalidate",
+    { timeout: 15_000 },
+    async () => {
+      const fixture = containerFixture();
+      const input = testWorkerLaunchInput(fixture.workspaceDir, "container-busy-daemon");
+      fs.writeFileSync(path.join(fixture.engineRoot, "info-delay-ms"), "6000");
+
+      try {
+        expect(await fixture.supervisor.launch(input, endpoint)).toMatchObject({
+          state: "running",
+        });
+        expect(await waitForTerminal(fixture.supervisor, input.launchId)).toMatchObject({
+          state: "completed",
+        });
+      } finally {
+        await fixture.supervisor.close();
+      }
+    },
+  );
+
+  it(
+    "records the revalidation command when the daemon exceeds its deadline",
+    { timeout: 45_000 },
+    async () => {
+      const fixture = containerFixture();
+      const input = testWorkerLaunchInput(fixture.workspaceDir, "container-unresponsive-daemon");
+      fs.writeFileSync(path.join(fixture.engineRoot, "info-delay-ms"), "35000");
+
+      try {
+        const failed = await fixture.supervisor.launch(input, endpoint);
+
+        expect(failed.state).toBe("failed");
+        expect(failed.errorText).toMatch(/Command timed out after \d+ milliseconds:/u);
+        expect(failed.errorText).toContain("docker info --format '{{.ID}}'");
+        expect(await fixture.supervisor.status(input.launchId)).toMatchObject({
+          state: "failed",
+          errorText: failed.errorText,
+        });
+        expect(
+          fixture
+            .events()
+            .filter((event) => event.argv[0] === "create" || event.argv[0] === "start"),
+        ).toEqual([]);
+      } finally {
+        await fixture.supervisor.close();
+      }
+    },
+  );
 
   it("keeps a pending cancelled container slot occupied until the fake engine confirms removal", async () => {
     const capacitySnapshots: Array<{ total: number; available: number }> = [];

--- a/src/node-host/node-worker-supervisor.test-support.ts
+++ b/src/node-host/node-worker-supervisor.test-support.ts
@@ -84,19 +84,22 @@ const writeResultAndExit = (value) => {
   exitWorker(0);
 };
 const mode = descriptor.assignment.prompt;
-if (mode === "connection-failure") {
-  process.send(
-    {
-      type: "openclaw-worker-connection-failure-v1",
-      cause: "certificate rejected " + descriptor.admission.credential,
-    },
-    () =>
-      fs.writeFileSync(
-        path.join(descriptor.assignment.workspaceDir, "connection-failure-reported"),
-        "reported",
-      ),
-  );
-  setInterval(() => {}, 1000);
+if (mode === "connection-failure" || mode === "connection-deadline") {
+  const target = new URL(descriptor.connectionEndpoint.url).host;
+  const report = (cause) => new Promise((resolve) => process.send(
+    { type: "openclaw-worker-connection-failure-v1", cause }, resolve,
+  ));
+  await report("worker could not reach gateway " + target + ": certificate rejected " +
+    descriptor.admission.credential + "; check TLS pin/publicUrl configuration");
+  if (mode === "connection-deadline") {
+    await report("worker admission deadline exceeded after 3 attempts to " + target +
+      ": connect failed: Opening handshake has timed out " + descriptor.admission.credential);
+    process.stderr.write("worker admission deadline exceeded\n");
+    exitWorker(7);
+  } else {
+    fs.writeFileSync(path.join(descriptor.assignment.workspaceDir, "connection-failure-reported"), "reported");
+    setInterval(() => {}, 1000);
+  }
 } else if (mode === "wait") {
   setInterval(() => {}, 1000);
 } else if (mode === "tree") {

--- a/src/node-host/node-worker-supervisor.test.ts
+++ b/src/node-host/node-worker-supervisor.test.ts
@@ -632,31 +632,39 @@ describe("node worker supervisor", () => {
     await supervisor.close();
   });
 
-  it("records the child's last gateway connection failure when cancelling admission", async () => {
-    const { supervisor, workspaceDir } = fixture();
-    const input = launchInput(workspaceDir, "connection-failure-launch", "connection-failure");
-    expect(
+  it.each([
+    [
+      "connection-failure",
+      "cancelled",
+      "worker could not reach gateway gateway.example:18789: certificate rejected ",
+    ],
+    [
+      "connection-deadline",
+      "failed",
+      "worker admission deadline exceeded after 3 attempts to gateway.example:18789: connect failed: Opening handshake has timed out ",
+    ],
+  ] as const)(
+    "records the child's %s diagnosis in the terminal journal",
+    async (prompt, state, errorText) => {
+      const { supervisor, workspaceDir } = fixture();
+      const input = launchInput(workspaceDir, "connection-failure-launch", prompt);
       await supervisor.launch(input, {
         kind: "websocket",
-        url: "wss://gateway.example/__openclaw__/worker",
-      }),
-    ).toMatchObject({
-      state: "running",
-    });
-    await vi.waitFor(() =>
-      expect(fs.existsSync(path.join(workspaceDir, "connection-failure-reported"))).toBe(true),
-    );
-
-    const cancelled = await supervisor.cancel(testNodeWorkerLaunchIdentity(input));
-    expect(cancelled).toMatchObject({
-      state: "cancelled",
-      errorText: expect.stringMatching(
-        /^worker could not reach gateway gateway\.example: certificate rejected .+; check TLS pin\/publicUrl configuration$/u,
-      ),
-    });
-    expect(cancelled?.errorText).not.toContain(TEST_WORKER_CREDENTIAL);
-    await supervisor.close();
-  });
+        url: "wss://gateway.example:18789/__openclaw__/worker",
+      });
+      if (state === "cancelled") {
+        await vi.waitFor(() =>
+          expect(fs.existsSync(path.join(workspaceDir, "connection-failure-reported"))).toBe(true),
+        );
+        await supervisor.cancel(testNodeWorkerLaunchIdentity(input));
+      }
+      const terminal = await waitForTerminal(supervisor, input.launchId);
+      expect(terminal).toMatchObject({ state, errorText: expect.stringContaining(errorText) });
+      expect(Buffer.byteLength(terminal.errorText ?? "", "utf8")).toBeLessThanOrEqual(4 * 1024);
+      expect(terminal.errorText).not.toContain(TEST_WORKER_CREDENTIAL);
+      await supervisor.close();
+    },
+  );
 
   it.each([
     ["cancel", "cancelled"],

--- a/src/worker/worker-connection-admission.ts
+++ b/src/worker/worker-connection-admission.ts
@@ -39,7 +39,7 @@ type WorkerConnectionAttemptOptions = {
   onAdmitting: () => void;
   onReady: (hello: WorkerHelloOk) => void;
   onReadyFrame: (frame: unknown, socket: WebSocket) => void;
-  onSocketClosed: () => WorkerConnectionInterruptedError;
+  onSocketClosed: () => void;
   onReadyClose: (reason: WorkerProtocolCloseReason | undefined) => void;
 };
 
@@ -87,6 +87,7 @@ export function connectWorkerConnectionAttempt(
   options.onSocket(socket);
   const admissionId = randomUUID();
   let admitted = false;
+  let opened = false;
   let attemptSettled = false;
 
   return new Promise<WorkerHelloOk>((resolve, reject) => {
@@ -103,14 +104,23 @@ export function connectWorkerConnectionAttempt(
       reject(error);
     };
     attemptTimeout = setTimeout(() => {
-      rejectAttempt(new WorkerConnectionInterruptedError("worker admission timed out"));
+      rejectAttempt(
+        new WorkerConnectionInterruptedError(
+          opened ? "no hello within deadline" : "connect failed: opening handshake timed out",
+        ),
+      );
       socket.terminate();
     }, options.attemptTimeoutMs);
     attemptTimeout.unref?.();
 
     socket.on("error", (error) => {
       if (!admitted) {
-        rejectAttempt(new WorkerConnectionInterruptedError(toWorkerConnectionError(error).message));
+        const kind = opened ? "admission interrupted" : "connect failed";
+        rejectAttempt(
+          new WorkerConnectionInterruptedError(
+            `${kind}: ${toWorkerConnectionError(error).message}`,
+          ),
+        );
       }
     });
     socket.on("open", () => {
@@ -125,6 +135,7 @@ export function connectWorkerConnectionAttempt(
         return;
       }
       options.onAdmitting();
+      opened = true;
       const frame: WorkerConnectRequestFrame = {
         type: "req",
         id: admissionId,
@@ -137,7 +148,9 @@ export function connectWorkerConnectionAttempt(
       };
       socket.send(JSON.stringify(frame), (error) => {
         if (error) {
-          rejectAttempt(new WorkerConnectionInterruptedError(error.message));
+          rejectAttempt(
+            new WorkerConnectionInterruptedError(`admission send failed: ${error.message}`),
+          );
           socket.terminate();
         }
       });
@@ -190,17 +203,19 @@ export function connectWorkerConnectionAttempt(
       }
       options.onReadyFrame(frame, socket);
     });
-    socket.on("close", (_code, reason) => {
+    socket.on("close", (code, reason) => {
       if (!options.isCurrentGeneration()) {
         return;
       }
-      const interrupted = options.onSocketClosed();
+      options.onSocketClosed();
       const closeReason = parseCloseReason(reason);
       if (!admitted) {
         rejectAttempt(
           closeReason
             ? new WorkerAdmissionError(closeReason, isRetryableWorkerCloseReason(closeReason))
-            : interrupted,
+            : new WorkerConnectionInterruptedError(
+                `${opened ? "admission interrupted" : "connect failed"}: socket closed (${code}) before hello`,
+              ),
         );
         return;
       }

--- a/src/worker/worker-connection-contract.ts
+++ b/src/worker/worker-connection-contract.ts
@@ -8,6 +8,7 @@ import type {
   WorkerProtocolCloseReason,
 } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type { BackoffPolicy } from "../infra/backoff.js";
+import { redactSensitiveText } from "../logging/redact.js";
 import type { WorkerConnectionEndpoint } from "./worker-connection-endpoint.js";
 
 const FENCED_CLOSE_REASONS = new Set<WorkerProtocolCloseReason>([
@@ -75,8 +76,8 @@ export class WorkerAdmissionError extends Error {
 }
 
 export class WorkerAdmissionDeadlineExceededError extends Error {
-  constructor() {
-    super("worker admission deadline exceeded");
+  constructor(diagnosis: string) {
+    super(diagnosis);
     this.name = "WorkerAdmissionDeadlineExceededError";
   }
 }
@@ -103,16 +104,48 @@ export function toWorkerConnectionError(error: unknown): Error {
 }
 
 export function formatWorkerConnectionFailure(
-  endpoint: WorkerConnectionEndpoint,
+  options: WorkerConnectionOptions,
   error: unknown,
+  attempts?: number,
 ): string {
-  const target =
-    endpoint.kind === "websocket"
-      ? truncateUtf16Safe(new URL(endpoint.url).host, 128)
-      : truncateUtf16Safe(endpoint.socketPath, 128);
+  const endpoint = options.endpoint;
+  let address: string;
+  if (endpoint.kind === "websocket") {
+    const url = new URL(endpoint.url);
+    address = `${url.hostname}:${url.port || (url.protocol === "wss:" ? "443" : "80")}`;
+  } else {
+    address = endpoint.socketPath;
+  }
+  const target = truncateUtf16Safe(address, 128);
+  let detail = toWorkerConnectionError(error).message;
+  const access = endpoint.kind === "websocket" ? endpoint.cloudflareAccess : undefined;
+  const credentials = [
+    options.connectParams.admission.credential,
+    ...(access ? [access.clientId, access.clientSecret] : []),
+  ];
+  // Scrub before truncating so a cut credential cannot escape into stderr or IPC.
+  for (const credential of credentials) {
+    for (const value of [
+      credential,
+      encodeURIComponent(credential),
+      JSON.stringify(credential).slice(1, -1),
+    ]) {
+      if (value) {
+        detail = detail.replaceAll(value, "[REDACTED]");
+      }
+    }
+  }
+  if (endpoint.kind === "websocket") {
+    detail = detail.replaceAll(endpoint.url, target);
+  }
   const cause =
-    truncateUtf16Safe(toWorkerConnectionError(error).message.replace(/\s+/gu, " ").trim(), 160) ||
-    "connection failed";
+    truncateUtf16Safe(
+      redactSensitiveText(detail, { mode: "tools" }).replace(/\s+/gu, " ").trim(),
+      160,
+    ) || "connection failed";
+  if (attempts !== undefined) {
+    return `worker admission deadline exceeded after ${attempts} attempts to ${target}: ${cause}`;
+  }
   const hint =
     endpoint.kind === "websocket"
       ? "check TLS pin/publicUrl configuration"

--- a/src/worker/worker-connection.test.ts
+++ b/src/worker/worker-connection.test.ts
@@ -1,4 +1,4 @@
-import { once } from "node:events";
+import { EventEmitter, once } from "node:events";
 import net from "node:net";
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { describe, expect, it, vi } from "vitest";
@@ -18,7 +18,6 @@ import type {
   WorkerInferenceTerminalFrame,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
 import {
-  formatWorkerConnectionFailure,
   toWorkerConnectionError,
   WorkerAdmissionDeadlineExceededError,
   WorkerConnectionStoppedError,
@@ -143,6 +142,107 @@ function installThrowingThenHealthyListeners(connection: ReturnType<typeof creat
 }
 
 describe("worker connection endpoint failures", () => {
+  it.each([
+    "connect failure",
+    "no hello",
+    "retryable rejection",
+    "redacted connect failure",
+  ] as const)("retains the last %s diagnosis at the admission deadline", async (scenario) => {
+    vi.useFakeTimers();
+    const sockets: EventEmitter[] = [];
+    const diagnostics: Array<Error | undefined> = [];
+    const endpointUrl =
+      "wss://fixture-user:fixture-password@gateway.example:8443/private/__openclaw__/worker?token=fixture-token";
+    const connection = createWorkerConnection({
+      endpoint: {
+        kind: "websocket",
+        url: endpointUrl,
+        cloudflareAccess: { clientId: "fixture-client-id", clientSecret: "fixture-client-secret" },
+      },
+      connectParams: FRAME_CONNECT_PARAMS,
+      admissionTimeoutMs: 300,
+      admissionDeadlineMs: 1_000,
+      reconnectBackoff: { initialMs: 100, maxMs: 100, factor: 1, jitter: 0 },
+      onConnectionFailure: (error) => diagnostics.push(error),
+      createSocket: () => {
+        const socket = Object.assign(new EventEmitter(), {
+          readyState: 0,
+          send: (raw: string) => {
+            if (scenario === "retryable rejection") {
+              socket.emit(
+                "message",
+                Buffer.from(
+                  JSON.stringify({
+                    type: "res",
+                    id: JSON.parse(raw).id,
+                    ok: false,
+                    error: {
+                      code: "INVALID_REQUEST",
+                      message: "unavailable",
+                      details: { reason: "gateway-unavailable" },
+                      retryable: true,
+                    },
+                  }),
+                ),
+              );
+            }
+          },
+          close: () => socket.emit("close", 1006, Buffer.alloc(0)),
+          terminate: () => socket.emit("close", 1006, Buffer.alloc(0)),
+        });
+        sockets.push(socket);
+        setTimeout(() => {
+          if (scenario === "connect failure" || scenario === "redacted connect failure") {
+            const detail =
+              scenario === "redacted connect failure"
+                ? `Opening handshake has timed out ${FRAME_CONNECT_PARAMS.admission.credential} fixture-client-secret ${endpointUrl} ${"x".repeat(4_096)}`
+                : "Opening handshake has timed out";
+            socket.emit("error", new Error(sockets.length === 1 ? "ECONNREFUSED" : detail));
+            socket.emit("close", 1006, Buffer.alloc(0));
+          } else {
+            socket.readyState = 1;
+            socket.emit("open");
+          }
+        }, 0);
+        return socket as unknown as WebSocket;
+      },
+    });
+    const expected =
+      scenario === "connect failure" || scenario === "redacted connect failure"
+        ? "connect failed: Opening handshake has timed out"
+        : scenario === "no hello"
+          ? "no hello within deadline"
+          : "worker admission rejected: gateway-unavailable";
+    try {
+      const starting = connection.start().catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(1_000);
+      const error = await starting;
+      expect(error).toBeInstanceOf(WorkerAdmissionDeadlineExceededError);
+      expect(error).toMatchObject({ message: expect.stringContaining(expected) });
+      expect(error).toMatchObject({ message: expect.stringContaining("gateway.example:8443") });
+      expect(error).toMatchObject({
+        message: expect.stringContaining(`after ${sockets.length} attempts`),
+      });
+      expect(sockets.length).toBeGreaterThan(1);
+      expect(diagnostics.at(-1)).toBe(error);
+      const message = (error as Error).message;
+      expect(message.length).toBeLessThan(400);
+      for (const secret of [
+        "fixture-user",
+        "fixture-password",
+        "fixture-token",
+        "fixture-client-secret",
+        FRAME_CONNECT_PARAMS.admission.credential,
+      ]) {
+        expect(message).not.toContain(secret);
+      }
+      await expect(connection.waitForExit()).resolves.toEqual({ kind: "failed", error });
+    } finally {
+      await connection.stop();
+      vi.useRealTimers();
+    }
+  });
+
   it("fails insecure public endpoints without entering reconnect backoff", async () => {
     const createSocket = vi.fn();
     const connection = createWorkerConnection({
@@ -190,14 +290,14 @@ describe("worker connection endpoint failures", () => {
       reconnectBackoff: { initialMs: 1, maxMs: 1, factor: 1, jitter: 0 },
       onConnectionFailure: (error) => {
         if (error) {
-          failures.push(formatWorkerConnectionFailure(endpoint, error));
+          failures.push(error.message);
         }
       },
     });
 
     try {
       await expect(connection.start()).rejects.toBeInstanceOf(WorkerAdmissionDeadlineExceededError);
-      expect(failures.at(-1)).toMatch(
+      expect(failures.at(-2)).toMatch(
         new RegExp(
           `^worker could not reach gateway 127\\.0\\.0\\.1:${port}: .*ECONNREFUSED.*; check TLS pin/publicUrl configuration$`,
           "u",

--- a/src/worker/worker-connection.ts
+++ b/src/worker/worker-connection.ts
@@ -38,6 +38,7 @@ import {
   WorkerConnectionInterruptedError,
   WorkerConnectionStoppedError,
   WorkerFencedError,
+  formatWorkerConnectionFailure,
   isFencedCloseReason,
   resolvePositiveTimeout,
   toWorkerConnectionError,
@@ -272,10 +273,11 @@ export class WorkerConnection {
   private async connectUntilReady(): Promise<WorkerHelloOk> {
     const startedAt = Date.now();
     let attempt = 0;
+    let lastFailure: Error | undefined;
     while (!this.isTerminal()) {
       let remainingMs = this.admissionDeadlineMs - (Date.now() - startedAt);
       if (remainingMs <= 0) {
-        throw this.failAdmissionDeadline();
+        throw this.failAdmissionDeadline(attempt, lastFailure);
       }
       if (attempt > 0) {
         this.transition({ kind: "reconnecting", attempt });
@@ -292,7 +294,7 @@ export class WorkerConnection {
         }
         remainingMs = this.admissionDeadlineMs - (Date.now() - startedAt);
         if (remainingMs <= 0) {
-          throw this.failAdmissionDeadline();
+          throw this.failAdmissionDeadline(attempt, lastFailure);
         }
       }
       try {
@@ -306,7 +308,10 @@ export class WorkerConnection {
         if (this.isTerminal()) {
           throw this.terminalError();
         }
-        this.reportConnectionFailure(toWorkerConnectionError(error));
+        lastFailure = toWorkerConnectionError(error);
+        this.reportConnectionFailure(
+          new Error(formatWorkerConnectionFailure(this.options, lastFailure)),
+        );
         if (error instanceof WorkerAdmissionError) {
           if (error.retryable) {
             attempt += 1;
@@ -352,7 +357,6 @@ export class WorkerConnection {
         this.socket = undefined;
         const interrupted = new WorkerConnectionInterruptedError();
         this.frames.rejectPending(interrupted);
-        return interrupted;
       },
       onReadyClose: (reason) => this.handleReadyClose(reason),
     });
@@ -508,11 +512,18 @@ export class WorkerConnection {
     this.resolveExit(exit);
   }
 
-  private failAdmissionDeadline(): Error {
+  private failAdmissionDeadline(attempts: number, lastFailure: Error | undefined): Error {
     if (this.isTerminal()) {
       return this.terminalError();
     }
-    const error = new WorkerAdmissionDeadlineExceededError();
+    const error = new WorkerAdmissionDeadlineExceededError(
+      formatWorkerConnectionFailure(
+        this.options,
+        lastFailure ?? "no connection attempt completed",
+        attempts,
+      ),
+    );
+    this.reportConnectionFailure(error);
     this.finishFailed(error);
     return error;
   }


### PR DESCRIPTION
## What Problem This Solves

Two diagnosability/tuning items from the 50-worker farm campaign (#129979):

1. `WorkerAdmissionDeadlineExceededError` was a bare "worker admission deadline exceeded" — identical whether the worker's TCP dials never connected (network partition), the socket opened but no hello arrived, or admission was retryably rejected. During the campaign this masked a LAN partition as a gateway admission wedge for a full day of misdiagnosis.
2. The container engine's per-launch daemon revalidation ran `docker info` under a 5s timeout; under a 50-container burst a slammed-but-healthy OrbStack daemon exceeded it and correctly failed a launch closed — but the budget, not the daemon, was the problem.

## Why This Change Was Made

- The deadline error now carries the terminal diagnosis: last connection-failure kind and detail, attempt count, and the redacted endpoint (`host:port`, never URLs with material). That text propagates end-to-end: worker IPC / container stderr → node launch journal `error_text` → gateway turn error. Credential material is scrubbed in raw, URL-encoded, and JSON-escaped forms *before* truncation so a cut credential can never escape into stderr or the journal.
- Daemon revalidation budget raised to a named 30s constant with the invariant documented inline; startup discovery, identity fencing, and fail-closed semantics unchanged. No new config.

## User Impact

A node worker that dies on a flaky network now records *why* ("connect failed: Opening handshake has timed out … after N attempts to 192.168.x.x:19801") wherever operators look — the session error, `openclaw` logs, and the launch journal — instead of a sentence that reads like a gateway bug. Burst launches on a loaded container daemon no longer fail spuriously at 5s.

## Evidence

Regressions verified failing pre-fix: dial-failure-to-deadline carries the failure kind + endpoint; open-socket-no-hello carries that variant; fenced/retryable close behavior unchanged; slow-but-within-budget engine revalidation succeeds while the timeout message still names the command. Full sweep: 617 passed / 4 skipped across src/worker, src/node-host, tunnel and turn-launcher failure-recovery suites; `pnpm check:changed` green; Codex autoreview clean (0.99). Production delta +91/−32 (diagnostic state + redaction, minus removed downstream reformatting); tests +235/−46.

Context: openclaw/openclaw#129979
