### PR TITLE
refactor(msteams): share delimited token protection

### DIFF
--- a/extensions/msteams/src/format.test.ts
+++ b/extensions/msteams/src/format.test.ts
@@ -253,6 +253,12 @@ describe("formatMSTeamsMarkdown", () => {
     expect(output).toContain("![x](https://e.test/x.png)");
   });
 
+  it("does not let nested mentions complete malformed outer candidates", () => {
+    const output = formatMSTeamsMarkdown("@[broken\n# Next @[Alice](29:abc)", "off");
+    expect(output).toContain("**Next");
+    expect(output).toContain("@[Alice](29:abc)");
+  });
+
   it("tracks fences opened on list continuation lines", () => {
     const before = [
       "- item",

--- a/extensions/msteams/src/format.ts
+++ b/extensions/msteams/src/format.ts
@@ -201,16 +201,22 @@ function scanDelimitedMarkdown(
   return fallbackNext === undefined ? undefined : { next: fallbackNext };
 }
 
-function protectMarkdownImages(text: string, tokenPrefix: string, images: string[]): string {
+function protectDelimitedTokens(
+  text: string,
+  tokenPrefix: string,
+  values: string[],
+  opener: "![" | "@[",
+): string {
+  const tokenTag = opener === "![" ? "i" : "m";
   let protectedText = "";
   let cursor = 0;
   let searchFrom = 0;
   while (searchFrom < text.length) {
-    const start = text.indexOf("![", searchFrom);
+    const start = text.indexOf(opener, searchFrom);
     if (start < 0) {
       break;
     }
-    const scan = scanDelimitedMarkdown(text, start, "![");
+    const scan = scanDelimitedMarkdown(text, start, opener);
     if (!scan) {
       break;
     }
@@ -219,34 +225,8 @@ function protectMarkdownImages(text: string, tokenPrefix: string, images: string
       continue;
     }
     protectedText += text.slice(cursor, start);
-    const index = images.push(text.slice(start, scan.end)) - 1;
-    protectedText += `${tokenPrefix}i${index}${TOKEN_END}`;
-    cursor = scan.end;
-    searchFrom = scan.end;
-  }
-  return protectedText + text.slice(cursor);
-}
-
-function protectMSTeamsMentions(text: string, tokenPrefix: string, mentions: string[]): string {
-  let protectedText = "";
-  let cursor = 0;
-  let searchFrom = 0;
-  while (searchFrom < text.length) {
-    const start = text.indexOf("@[", searchFrom);
-    if (start < 0) {
-      break;
-    }
-    const scan = scanDelimitedMarkdown(text, start, "@[");
-    if (!scan) {
-      break;
-    }
-    if ("next" in scan) {
-      searchFrom = scan.next;
-      continue;
-    }
-    protectedText += text.slice(cursor, start);
-    const index = mentions.push(text.slice(start, scan.end)) - 1;
-    protectedText += `${tokenPrefix}m${index}${TOKEN_END}`;
+    const index = values.push(text.slice(start, scan.end)) - 1;
+    protectedText += `${tokenPrefix}${tokenTag}${index}${TOKEN_END}`;
     cursor = scan.end;
     searchFrom = scan.end;
   }
@@ -515,8 +495,8 @@ export function formatMSTeamsMarkdown(markdown: string, tableMode: MarkdownTable
     const index = entities.push(entity) - 1;
     return `${tokenPrefix}h${index}${TOKEN_END}`;
   });
-  const imagesProtected = protectMarkdownImages(entitiesProtected, tokenPrefix, images);
-  const mentionsProtected = protectMSTeamsMentions(imagesProtected, tokenPrefix, mentions);
+  const imagesProtected = protectDelimitedTokens(entitiesProtected, tokenPrefix, images, "![");
+  const mentionsProtected = protectDelimitedTokens(imagesProtected, tokenPrefix, mentions, "@[");
   const tableInput = convertMarkdownTables(mentionsProtected, tableMode);
   const converted =
     tableMode === "off"


### PR DESCRIPTION
## What Problem This Solves

Microsoft Teams markdown formatting used separate, nearly identical scanners to protect images and native mentions. Keeping those loops separate made malformed-candidate progression and placeholder generation easier to drift.

## Why This Change Was Made

Use one private delimited-token protector with a closed image-or-mention opener. Images are still protected first, token namespaces remain distinct, and the existing scanner owns all nested/malformed parsing behavior.

## User Impact

No intended formatting changes. Malformed outer mentions continue to leave later valid mentions and markdown blocks available for formatting.

## Evidence

- Added a regression case for a malformed outer mention followed by a valid nested mention.
- 114 focused Teams formatting, messenger, and send tests passed.
- Full `node scripts/check-changed.mjs` passed.
- `git diff --check` passed.
- Fresh branch autoreview reported no accepted/actionable findings (`0.99` confidence).
- Production delta: `+13/-33`, net `-20`; tests: `+6/-0`.
