### PR TITLE
fix(onboard): preserve the saved skills package manager

### DIFF
--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -84,7 +84,8 @@ Most skills configuration lives under `skills` in
   with WAL-reset-safe `node:sqlite` is supported as an explicit runtime opt-in.
   `openclaw setup --node-manager` and `openclaw onboard --node-manager` accept
   `npm`, `pnpm`, or `bun`; set `"yarn"` directly in config for Yarn-backed skill
-  installs.
+  installs. Setup preserves this preference unless you pass `--node-manager`;
+  fresh configurations default to `npm`.
 </ParamField>
 
 <ParamField path="skills.install.allowUploadedArchives" type="boolean" default="false">

--- a/src/commands/onboard-non-interactive/local/skills-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/skills-config.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { applyNonInteractiveSkillsConfig } from "./skills-config.js";
+
+describe("non-interactive skills config", () => {
+  it.each([
+    [undefined, undefined, "npm"],
+    ["npm", undefined, "npm"],
+    ["pnpm", undefined, "pnpm"],
+    ["bun", undefined, "bun"],
+    ["yarn", undefined, "yarn"],
+    ["yarn", "npm", "npm"],
+    ["bun", "pnpm", "pnpm"],
+    ["pnpm", "bun", "bun"],
+  ] as const)("resolves saved %s with requested %s to %s", (saved, requested, expected) => {
+    const nextConfig: OpenClawConfig = {
+      skills: { install: { nodeManager: saved, preferBrew: false } },
+    };
+    const result = applyNonInteractiveSkillsConfig({
+      nextConfig,
+      opts: { nodeManager: requested },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    });
+
+    expect(result.skills?.install).toEqual({ nodeManager: expected, preferBrew: false });
+    expect(nextConfig.skills?.install?.nodeManager).toBe(saved);
+  });
+
+  it("leaves skills untouched when setup is skipped, even with an explicit manager", () => {
+    const nextConfig: OpenClawConfig = {
+      skills: { install: { nodeManager: "yarn", preferBrew: false } },
+    };
+    expect(
+      applyNonInteractiveSkillsConfig({
+        nextConfig,
+        opts: { skipSkills: true, nodeManager: "npm" },
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      }),
+    ).toEqual(nextConfig);
+  });
+});

--- a/src/commands/onboard-non-interactive/local/skills-config.ts
+++ b/src/commands/onboard-non-interactive/local/skills-config.ts
@@ -21,8 +21,8 @@ export function applyNonInteractiveSkillsConfig(params: {
     return nextConfig;
   }
 
-  const nodeManager = opts.nodeManager ?? "npm";
-  if (!["npm", "pnpm", "bun"].includes(nodeManager)) {
+  const nodeManager = opts.nodeManager;
+  if (nodeManager !== undefined && !["npm", "pnpm", "bun"].includes(nodeManager)) {
     runtime.error('Invalid --node-manager. Use "npm", "pnpm", or "bun".');
     runtime.exit(1);
     return nextConfig;
@@ -33,7 +33,7 @@ export function applyNonInteractiveSkillsConfig(params: {
       ...nextConfig.skills,
       install: {
         ...nextConfig.skills?.install,
-        nodeManager,
+        nodeManager: nodeManager ?? nextConfig.skills?.install?.nodeManager ?? "npm",
       },
     },
   };

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -436,35 +436,51 @@ describe("setupSkills", () => {
     );
   });
 
-  it("uses the requested node manager for selected node-backed installs", async () => {
-    mockMissingBrewStatus([
-      createBundledSkill({
-        name: "node-helper",
-        description: "Node helper",
-        bins: ["node-helper"],
-        installLabel: "Install node-helper",
-        installKind: "node",
-      }),
-    ]);
+  it.each([
+    [undefined, undefined, "npm"],
+    ["npm", undefined, "npm"],
+    ["pnpm", undefined, "pnpm"],
+    ["bun", undefined, "bun"],
+    ["yarn", undefined, "yarn"],
+    ["yarn", "npm", "npm"],
+    ["bun", "pnpm", "pnpm"],
+    ["pnpm", "bun", "bun"],
+  ] as const)(
+    "installs with saved %s and requested %s using %s",
+    async (saved, requested, expected) => {
+      mockMissingBrewStatus([
+        createBundledSkill({
+          name: "node-helper",
+          description: "Node helper",
+          bins: ["node-helper"],
+          installLabel: "Install node-helper",
+          installKind: "node",
+        }),
+      ]);
 
-    const { prompter } = createPrompter({ multiselect: ["node-helper"] });
-    const next = await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter, {
-      nodeManager: "pnpm",
-    });
+      const { prompter } = createPrompter({ multiselect: ["node-helper"] });
+      const next = await setupSkills(
+        { skills: { install: { nodeManager: saved } } },
+        "/tmp/ws",
+        runtime,
+        prompter,
+        { nodeManager: requested },
+      );
 
-    expect(next.skills?.install?.nodeManager).toBe("pnpm");
-    expect(mocks.installSkill).toHaveBeenCalledWith(
-      expect.objectContaining({
-        skillName: "node-helper",
-        installId: "node",
-        config: expect.objectContaining({
-          skills: expect.objectContaining({
-            install: expect.objectContaining({ nodeManager: "pnpm" }),
+      expect(next.skills?.install?.nodeManager).toBe(expected);
+      expect(mocks.installSkill).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skillName: "node-helper",
+          installId: "node",
+          config: expect.objectContaining({
+            skills: expect.objectContaining({
+              install: expect.objectContaining({ nodeManager: expected }),
+            }),
           }),
         }),
-      }),
-    );
-  });
+      );
+    },
+  );
 
   it("does not show Homebrew guidance when a missing brew dependency is not selected", async () => {
     if (!supportsHomebrewPrompt) {

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -120,7 +120,7 @@ function resolveDefaultNodeManager(
   config: OpenClawConfig,
   requested: NodeManagerChoice | undefined,
   runtime: RuntimeEnv,
-): NodeManagerChoice {
+) {
   if (requested !== undefined) {
     if (!isNodeManagerChoice(requested)) {
       runtime.error('Invalid --node-manager. Use "npm", "pnpm", or "bun".');
@@ -129,8 +129,7 @@ function resolveDefaultNodeManager(
     }
     return requested;
   }
-  const existing = config.skills?.install?.nodeManager;
-  return existing === "npm" || existing === "pnpm" || existing === "bun" ? existing : "npm";
+  return config.skills?.install?.nodeManager ?? "npm";
 }
 
 /** Runs the interactive skills setup step and returns the updated config. */


### PR DESCRIPTION
Closes #130433

## What Problem This Solves

Fixes an issue where operators rerunning non-interactive onboarding would silently lose a saved pnpm, Bun, or Yarn skill-install preference when they did not pass `--node-manager`. Interactive skills setup also replaced a valid saved Yarn preference with npm, affecting classic onboarding, configure, and hosted skills setup.

## Why This Change Was Made

Both existing setup owners now resolve explicit CLI choice, then saved configuration, then npm. Validation applies to explicitly supplied CLI choices; the persisted config contract is intentionally wider because it also supports Yarn. No new helper, dependency, setting, migration, or installer-policy change is needed.

The removed path is the interactive resolver's redundant three-value filter on already-validated persisted configuration. CLI validation still accepts only npm, pnpm, and Bun, and `--skip-skills` leaves existing settings untouched.

## User Impact

Setup no longer silently changes which package manager subsequent skill installs use. Existing preferences survive, explicit overrides still win, and fresh configurations still default to npm. The skills configuration reference now states this precedence.

## Evidence

- Four regression cases failed on unchanged main production code: non-interactive saved pnpm/Bun/Yarn, and interactive saved Yarn at the installer handoff. All 160 tests across six owner/orchestration suites passed after the fix, including fresh defaults, explicit overrides, and skipping skills.
- Actual pure owner invocation reproduced pnpm/Bun/Yarn becoming npm before the patch and preserving each value afterward.
- Independent source/caller/config/installer review: no actionable findings. Fresh Codex autoreview: clean. Configured oxlint, oxfmt, and `git diff --check`: passed.
- Production LOC: +5/-6 (net -1). Tests: +82/-25 (net +57). Docs: +2/-1.
- Built CLI before/after proof passed in isolated temporary homes and state directories. Current main `99a2434f7b89c682f934326be9f7cc786f7ddeca` reset saved pnpm/Bun/Yarn to npm with exit 0. Exact PR head `541dc3bba62b99ea85917b3bd6364556e198f256` preserved npm/pnpm/Bun/Yarn, defaulted fresh config to npm, and honored explicit npm/pnpm/Bun overrides: all eight cases exited 0 with the expected persisted value and unrelated `preferBrew: false` retained.
- Both baseline and candidate passed `node --import tsx scripts/build-all.mts cliStartup` with frozen worktree-local dependencies. The candidate build included CLI bootstrap import validation and 48 built plugin-control-plane load checks.
- The 160-test focused suite also passed again with the fresh native-worktree dependencies. The broad local changed check passed formatting, production types, ratchets, dependency/boundary guards and all dead-export scans, then stopped on two unrelated gateway test-type errors. Running the exact gateway-other typecheck on the unmodified base `d916808353e42b419c3fd5ec9ed5739c26eacbcf` reproduces both errors unchanged (`sessions-mutations.sticky-model.test.ts:216,245`, assigning the readonly `model` property). This is recorded as a separate gateway test-fixture follow-up, not treated as a passing full changed check.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33017517178) completed successfully on `541dc3bba62b99ea85917b3bd6364556e198f256`; required `openclaw/ci-gate` is SUCCESS. The focused commands test-type graph and configured changed-file oxlint also passed with the fresh PR-owned dependencies.

The same defect exists in stable tag `v2026.7.1-2`. Local blame stops at a shallow-history boundary, so the original introducing author/PR is unknown and that boundary is not attributed as the introduction.

Earlier shared-install build attempts encountered existing checkout dependency issues (missing worktree dependency roots, then an installed TUI dependency lacking `TuiMainScreen`). Installing frozen dependencies in the native PR-owned checkout resolved these without changing product code. A remote changed-gate upload timed out before tests ran; its Blacksmith test machine was stopped and verified completed. Local gate results are recorded above.

The latest ClawSweeper review on this exact head has no actionable code, test, documentation or security findings. Its rank-up move, finishing exact-head CI and focused onboarding validation, is complete. Independent maintainer review and fresh Codex autoreview are also complete; landing uses the native prepare/merge flow.

The CLI proof runs `node openclaw.mjs onboard --non-interactive --accept-risk --auth-choice skip --skip-health --skip-hooks --skip-bootstrap --skip-channels --skip-search --skip-ui --no-install-daemon --json`, with optional `--node-manager` overrides, against isolated config seeded with each saved manager. State is created by `scripts/lib/openclaw-test-state.mts create --scenario minimal`; only the expected manager result is reported, and each temporary root is removed afterward. No daemon, real provider, external package installation, or live user state is involved.

AI-assisted maintainer repair. No credentials, live user configuration, or running Gateway were changed.
