### PR TITLE
fix(tests): restore sticky model fixture typecheck

### DIFF
--- a/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
@@ -3,6 +3,7 @@ import {
   loadSessionEntry,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import type { AgentConfig } from "../../config/types.agents.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import {
@@ -92,13 +93,15 @@ vi.mock("../../logging/subsystem.js", async () => {
 
 import { sessionMutationHandlers } from "./sessions-mutations.js";
 
+const defaultAgents: AgentConfig[] = [
+  { id: "main", default: true },
+  { id: "work", model: "anthropic/claude-sonnet-4-6" },
+];
+
 const defaultConfig = {
   agents: {
     defaults: { model: "anthropic/claude-opus-4-6" },
-    list: [
-      { id: "main", default: true },
-      { id: "work", model: "anthropic/claude-sonnet-4-6" },
-    ],
+    list: defaultAgents,
   },
 } satisfies OpenClawConfig;
 


### PR DESCRIPTION
Closes #130440.

## What Problem This Solves

Resolves a problem where current-main core test-type CI fails on two sticky-model Gateway fixture assignments, blocking otherwise unrelated PRs. This is a maintainer-directed repair of the failure introduced by #127813.

## Why This Change Was Made

The fixture's heterogeneous list inferred a narrower shape than the mutable `AgentConfig[]` used by real configuration. The outer `satisfies OpenClawConfig` check validates compatibility without changing that inferred list type. Declare the agent list at its producer using the canonical `AgentConfig[]` contract; cloned expected configurations can then receive the tested model updates.

All original test cases, value assertions, and clone isolation remain unchanged. No casts, checker waivers, dependency changes, or production changes. Production LOC: +0/-0. Tests: +7/-4.

Provenance: the failing expectations were introduced by #127813 (`ce4a680544a3502f98d3c9dc49ab9b9e77e7c43b`), authored by @Marvinthebored and merged by @steipete on 2026-08-26. This repair changes only the test fixture's type ownership, not that feature's runtime contract.

## User Impact

Restores the test-type gate for maintainers and contributors. No application, model-selection, authorization, configuration, protocol, or storage behavior changes.

## Evidence

- Before: the [hosted core test-types job](https://github.com/openclaw/openclaw/actions/runs/33015906921/job/98334846725) failed with TS2540 at sticky-model test lines 216 and 245. The same owning shard reproduced both errors locally on main `54db7d4f99e8286fa26367151db3f3a34fbe08b0` before edits.
- After: `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.gateway-other.json --builders 1` removes both changed-file errors. The older local dependency installation still reports 11 unrelated Google, MarkdownIt, and Pi TUI type errors, so this is not claimed as a fully green local shard; fresh-install exact-head CI remains required before landing.
- Focused runtime proof: `node scripts/run-vitest.mjs src/gateway/server-methods/sessions-mutations.sticky-model.test.ts src/agents/sticky-model-selection.test.ts` passes all 26 tests with one worker. An independent verifier repeated all 26 successfully and confirmed the same typecheck diagnostic reduction.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/server-methods/sessions-mutations.sticky-model.test.ts` passes. Targeted formatting and `git diff --check` pass.
- The actual `node scripts/check-changed.mjs -- src/gateway/server-methods/sessions-mutations.sticky-model.test.ts` run passes all 17 preceding guards, then stops at the same older-dependency core-test type errors; targeted typed lint was run separately and passes.
- Authenticated Codex review of the complete final patch and owning type/runtime context reports no actionable findings through P2.
- [Exact-head CI run 33017620794](https://github.com/openclaw/openclaw/actions/runs/33017620794) passes for `8a9dbadd341a2f3ecf03c7a2ace09eb69bffd259`, including the complete [test-types job](https://github.com/openclaw/openclaw/actions/runs/33017620794/job/98340066466) and required `openclaw/ci-gate`. This fresh-install hosted proof resolves the local dependency-validation gap; no CI gate is bypassed.

AI-assisted maintainer repair. No live-provider proof is applicable to this test-only type correction.
