### PR TITLE
refactor(browser): share operation post transport

### DIFF
--- a/extensions/browser/src/browser/client-actions-core.hooks.test.ts
+++ b/extensions/browser/src/browser/client-actions-core.hooks.test.ts
@@ -8,14 +8,17 @@ vi.mock("./client-fetch.js", () => clientFetchMocks);
 
 import { browserArmDialog, browserArmFileChooser } from "./client-actions-core.js";
 
-function lastFetchCall(): { url: string; options: { body?: string; timeoutMs?: number } } {
+function lastFetchCall(): {
+  url: string;
+  options: Omit<RequestInit, "body"> & { body?: string; timeoutMs?: number };
+} {
   const call = clientFetchMocks.fetchBrowserJson.mock.calls.at(-1);
   if (!call) {
     throw new Error("fetchBrowserJson was not called");
   }
   return {
     url: String(call[0]),
-    options: call[1] as { body?: string; timeoutMs?: number },
+    options: call[1] as Omit<RequestInit, "body"> & { body?: string; timeoutMs?: number },
   };
 }
 
@@ -33,6 +36,10 @@ describe("browser hook client actions", () => {
 
     const call = lastFetchCall();
     expect(call.url).toBe("/hooks/file-chooser?profile=openclaw");
+    expect(call.options).toMatchObject({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
     expect(call.options.timeoutMs).toBe(35_000);
     expect(JSON.parse(call.options.body ?? "{}")).toEqual({
       paths: ["/tmp/openclaw/uploads/report.pdf"],

--- a/extensions/browser/src/browser/client-actions-core.ts
+++ b/extensions/browser/src/browser/client-actions-core.ts
@@ -58,21 +58,19 @@ function resolveBrowserOperationRequestTimeoutMs(timeoutMs: unknown): number {
   return addTimerTimeoutGraceMs(operationTimeoutMs, BROWSER_ACTION_TRANSPORT_SLACK_MS) ?? 1;
 }
 
-async function postDownloadRequest(
+async function postBrowserOperationRequest<T>(
   baseUrl: string | undefined,
-  route: "/download" | "/wait/download",
+  route: "/download" | "/wait/download" | "/hooks/dialog" | "/hooks/file-chooser",
   body: Record<string, unknown>,
-  profile?: string,
-  timeoutMs?: number,
-  signal?: AbortSignal,
-): Promise<BrowserDownloadActionResult> {
-  const q = buildProfileQuery(profile);
-  return await fetchBrowserJson<BrowserDownloadActionResult>(withBaseUrl(baseUrl, `${route}${q}`), {
+  opts: { profile?: string; timeoutMs?: number; signal?: AbortSignal },
+): Promise<T> {
+  const q = buildProfileQuery(opts.profile);
+  return await fetchBrowserJson<T>(withBaseUrl(baseUrl, `${route}${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
-    timeoutMs: resolveBrowserOperationRequestTimeoutMs(timeoutMs),
-    signal,
+    timeoutMs: resolveBrowserOperationRequestTimeoutMs(opts.timeoutMs),
+    signal: opts.signal,
   });
 }
 
@@ -113,20 +111,18 @@ export async function browserArmDialog(
     signal?: AbortSignal;
   },
 ): Promise<BrowserActionOk> {
-  const q = buildProfileQuery(opts.profile);
-  return await fetchBrowserJson<BrowserActionOk>(withBaseUrl(baseUrl, `/hooks/dialog${q}`), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
+  return await postBrowserOperationRequest<BrowserActionOk>(
+    baseUrl,
+    "/hooks/dialog",
+    {
       accept: opts.accept,
       promptText: opts.promptText,
       dialogId: opts.dialogId,
       targetId: opts.targetId,
       timeoutMs: opts.timeoutMs,
-    }),
-    timeoutMs: resolveBrowserOperationRequestTimeoutMs(opts.timeoutMs),
-    signal: opts.signal,
-  });
+    },
+    opts,
+  );
 }
 
 /** Arm or execute a browser file chooser upload. */
@@ -143,21 +139,19 @@ export async function browserArmFileChooser(
     signal?: AbortSignal;
   },
 ): Promise<BrowserActionOk> {
-  const q = buildProfileQuery(opts.profile);
-  return await fetchBrowserJson<BrowserActionOk>(withBaseUrl(baseUrl, `/hooks/file-chooser${q}`), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
+  return await postBrowserOperationRequest<BrowserActionOk>(
+    baseUrl,
+    "/hooks/file-chooser",
+    {
       paths: opts.paths,
       ref: opts.ref,
       inputRef: opts.inputRef,
       element: opts.element,
       targetId: opts.targetId,
       timeoutMs: opts.timeoutMs,
-    }),
-    timeoutMs: resolveBrowserOperationRequestTimeoutMs(opts.timeoutMs),
-    signal: opts.signal,
-  });
+    },
+    opts,
+  );
 }
 
 /** Wait for the next managed browser download and save it under the guarded download root. */
@@ -171,7 +165,7 @@ export async function browserWaitForDownload(
     signal?: AbortSignal;
   },
 ): Promise<BrowserDownloadActionResult> {
-  return await postDownloadRequest(
+  return await postBrowserOperationRequest<BrowserDownloadActionResult>(
     baseUrl,
     "/wait/download",
     {
@@ -179,9 +173,7 @@ export async function browserWaitForDownload(
       path: opts.path,
       timeoutMs: opts.timeoutMs,
     },
-    opts.profile,
-    opts.timeoutMs,
-    opts.signal,
+    opts,
   );
 }
 
@@ -197,7 +189,7 @@ export async function browserDownload(
     signal?: AbortSignal;
   },
 ): Promise<BrowserDownloadActionResult> {
-  return await postDownloadRequest(
+  return await postBrowserOperationRequest<BrowserDownloadActionResult>(
     baseUrl,
     "/download",
     {
@@ -206,9 +198,7 @@ export async function browserDownload(
       path: opts.path,
       timeoutMs: opts.timeoutMs,
     },
-    opts.profile,
-    opts.timeoutMs,
-    opts.signal,
+    opts,
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Browser downloads, dialog hooks, and file-chooser hooks repeated the same operation POST transport setup. Keeping those requests separate made profile query handling, JSON headers, timeout slack, and abort propagation easier to drift.

## Why This Change Was Made

Use one private browser-operation POST helper with a closed route union. Each public action still owns its payload, while the helper owns only the shared transport contract.

## User Impact

No intended behavior change. Download and hook requests retain their existing routes, payloads, profile queries, timeout grace, abort signals, and response types.

## Evidence

- 38 focused browser client-action tests passed across four files.
- Full `node scripts/check-changed.mjs` passed on an isolated Testbox.
- `git diff --check` passed.
- Fresh branch autoreview reported no accepted/actionable findings (`0.99` confidence).
- Production delta: `+26/-36`, net `-10`; tests: `+9/-2`, net `+7`.
