### PR TITLE
fix(workers): report full nodes as at capacity, not offline

### DIFF
--- a/src/gateway/worker-environments/node-launch-adapter.test.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.test.ts
@@ -175,8 +175,11 @@ describe("node worker launch adapter", () => {
       );
       const sleep = vi.fn(async () => {
         expect(invoke).not.toHaveBeenCalled();
-        if (outcome === "abort") controller.abort(new Error("operator cancelled capacity wait"));
-        else available = 1;
+        if (outcome === "abort") {
+          controller.abort(new Error("operator cancelled capacity wait"));
+        } else {
+          available = 1;
+        }
       });
       const adapter = createNodeWorkerLaunchAdapter({
         getTransport: () => transportWith(invoke, async () => [nodeProof("conn-1", available)]),

--- a/src/gateway/worker-environments/node-launch-adapter.test.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.test.ts
@@ -129,11 +129,26 @@ function launchRequest(input = launchInput()) {
 }
 
 describe("node worker launch adapter", () => {
-  it("fails with a typed availability result when no node dispatches within the grace", async () => {
+  it.each([
+    { label: "offline", slots: [undefined], code: "runner-offline" },
+    { label: "full", slots: [0], code: NODE_WORKER_CAPACITY_EXHAUSTED_ERROR_CODE },
+    { label: "full then offline", slots: [0, undefined], code: "runner-offline" },
+    {
+      label: "offline then full",
+      slots: [undefined, 0],
+      code: NODE_WORKER_CAPACITY_EXHAUSTED_ERROR_CODE,
+    },
+  ])("reports $label availability when the dispatch grace expires", async ({ slots, code }) => {
     vi.useFakeTimers();
     const onDispatchReady = vi.fn();
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>();
+    let reads = 0;
     const adapter = createNodeWorkerLaunchAdapter({
-      getTransport: () => transportWith(vi.fn(), async () => []),
+      getTransport: () =>
+        transportWith(invoke, async () => {
+          const available = slots[Math.min(reads++, slots.length - 1)];
+          return available === undefined ? [] : [nodeProof("conn-1", available)];
+        }),
     });
     try {
       const launch = adapter
@@ -141,15 +156,43 @@ describe("node worker launch adapter", () => {
         .catch((error: unknown) => error);
       await vi.runAllTimersAsync();
 
-      expect(await launch).toMatchObject({
-        name: "WorkerRunnerUnavailableError",
-        code: "runner-offline",
-      });
+      expect(await launch).toMatchObject({ code });
+      expect(invoke).not.toHaveBeenCalled();
       expect(onDispatchReady).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }
   });
+
+  it.each(["available", "abort"] as const)(
+    "waits at capacity until %s without dispatching early",
+    async (outcome) => {
+      const input = launchInput();
+      const controller = new AbortController();
+      let available = 0;
+      const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async () =>
+        wire(receipt(input, "completed")),
+      );
+      const sleep = vi.fn(async () => {
+        expect(invoke).not.toHaveBeenCalled();
+        if (outcome === "abort") controller.abort(new Error("operator cancelled capacity wait"));
+        else available = 1;
+      });
+      const adapter = createNodeWorkerLaunchAdapter({
+        getTransport: () => transportWith(invoke, async () => [nodeProof("conn-1", available)]),
+        sleep,
+      });
+      const launch = adapter.launch({ ...launchRequest(input), signal: controller.signal });
+      if (outcome === "abort") {
+        await expect(launch).rejects.toThrow("operator cancelled capacity wait");
+        expect(invoke).not.toHaveBeenCalled();
+      } else {
+        await expect(launch).resolves.toEqual(receipt(input, "completed"));
+        expect(invoke).toHaveBeenCalledOnce();
+      }
+      expect(sleep).toHaveBeenCalledOnce();
+    },
+  );
 
   it("launches once, polls status, and returns the exact completed receipt", async () => {
     const input = launchInput();

--- a/src/gateway/worker-environments/node-launch-adapter.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.ts
@@ -26,6 +26,7 @@ const DEFAULT_CANCELLATION_TIMEOUT_MS = 30_000;
 const DEFAULT_AVAILABILITY_TIMEOUT_MS = 10_000;
 
 const RETRYABLE_TRANSPORT_CODES = new Set([
+  "AT_CAPACITY",
   "DISCONNECTED",
   "NOT_CONNECTED",
   "PAIRING_CHANGED",
@@ -224,16 +225,15 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
         "device worker node discovery is unavailable",
       );
     }
-    const node = nodes.find(
-      (candidate) =>
-        candidate.nodeId === params.deviceId &&
-        (!params.requireLaunchAvailability || candidate.workerHost.capacity.available > 0),
-    );
+    const node = nodes.find((candidate) => candidate.nodeId === params.deviceId);
     if (!node) {
       throw new NodeWorkerLaunchTransportError(
         "NOT_CONNECTED",
         "device worker node is not currently connected",
       );
+    }
+    if (params.requireLaunchAvailability && node.workerHost.capacity.available === 0) {
+      throw new NodeWorkerLaunchTransportError("AT_CAPACITY", "device worker capacity is full");
     }
     return node;
   };
@@ -422,6 +422,7 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
     let dispatchReady = false;
     let pollStatus = false;
     let delayMs = pollIntervalMs;
+    let availabilityCode: string | undefined;
     const markDispatchReady = () => {
       mayHaveLaunched = true;
       if (!dispatchReady) {
@@ -433,9 +434,6 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
       while (true) {
         if (deadline.signal.aborted) {
           throw signalError(deadline.signal, "node worker launch aborted");
-        }
-        if (!dispatchReady && availabilityDeadline.signal.aborted) {
-          throw new WorkerRunnerUnavailableError();
         }
         if (!stableRequest.isDispatchAuthorized()) {
           throw new Error("node worker launch authority closed");
@@ -472,11 +470,12 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
             delayMs = pollIntervalMs;
           }
         } catch (error) {
-          if (deadline.signal.aborted || !stableRequest.isDispatchAuthorized()) {
+          if (
+            deadline.signal.aborted ||
+            (!dispatchReady && availabilityDeadline.signal.aborted) ||
+            !stableRequest.isDispatchAuthorized()
+          ) {
             throw error;
-          }
-          if (!dispatchReady && availabilityDeadline.signal.aborted) {
-            throw new WorkerRunnerUnavailableError();
           }
           if (
             !(error instanceof NodeWorkerLaunchTransportError) ||
@@ -484,6 +483,7 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
           ) {
             throw error;
           }
+          availabilityCode = error.code;
           pollStatus = false;
         }
         delayMs = await waitBeforeRetry({
@@ -493,7 +493,11 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
       }
     } catch (error) {
       if (!dispatchReady && availabilityDeadline.signal.aborted && !deadline.signal.aborted) {
-        throw new WorkerRunnerUnavailableError();
+        // Keep the latest discovery reason through the grace; a connected full
+        // node is retryable capacity, not an instruction to reconnect the device.
+        throw availabilityCode === "AT_CAPACITY"
+          ? new WorkerRunnerCapacityError()
+          : new WorkerRunnerUnavailableError();
       }
       // The node authors this result only after its durable claim stayed absent.
       // Transport dispatch is therefore not launch ambiguity and needs no cancel.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending a turn to an existing remote-node session were told the device was offline when it was connected but all worker slots were occupied. The incorrect reconnect guidance appeared after the bounded availability wait.

## Why This Change Was Made

Node discovery combined device identity and free capacity in one filter, losing the distinction between a missing node and a full node. The launch adapter now retains the latest retryable observation and converts availability-grace expiry in one place. A connected full node produces the existing capacity error; an absent node retains the existing offline error.

The ten-second availability grace, durable supervisor admission, exact pairing/connection/authority checks, status/cancel access at capacity, and retryable placement behavior remain unchanged. No UI, config, protocol, permission policy, or storage changes. This aligns the existing node capacity/wait documentation rather than introducing a new operator contract.

Production +17/-13 (net +4); tests +52/-6 (net +46). The small growth records the missing capacity-versus-connectivity fact while removing duplicated timeout classification. AI-assisted.

## User Impact

A saturated remote node reports capacity exhaustion rather than asking the operator to reconnect a healthy device. The session remains retryable after a slot becomes free. Nodes that actually disconnect still report offline.

## Evidence

- Found through a real Gateway, two signed paired node hosts, and four simultaneous Linux Docker workers on a dedicated bridge network. Both stale-slot supervisor rejection and freshly published zero-slot inventory were exercised. On unchanged `a482a50cda8850e9479d28a1ae29785a509841b2`, fresh zero capacity produced `The device runner is offline` despite `node.list` confirming the node remained connected.
- That baseline stress run also completed forced container death, network-disconnected worker cancellation and immediate replacement, unaffected peer completion, six waves of four successful turns, three node disconnect/reconnect cycles, local-session availability, and cleanup. It failed only its final diagnostic assertion; zero owned containers remained.
- Focused regression: `node scripts/run-vitest.mjs src/gateway/worker-environments/node-launch-adapter.test.ts` failed two new cases before the repair (2 failed, 19 passed). With the repair, this file plus `src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts` passed all 31 tests.
- Regression cases include full, offline, full-to-offline, offline-to-full, capacity becoming available, and cancellation while waiting. Existing status/cancel-at-capacity, supervisor admission, reconnect, and authority tests remain green.
- Independent owner review and Codex autoreview completed without actionable findings.
- Candidate QA-enabled build and the complete network stress passed: 37 real containers, peak concurrency four across two nodes, six four-turn burst waves, forced worker death, network-detached cancellation/replacement in 2.8 seconds, three reconnect cycles, and successful retries after both capacity rejections. Zero approval events and zero remaining containers.
- Three consecutive Chromium/real-Gateway/Docker cycles passed remote-node selection, Full Access settings-before-send ordering, real in-container exec and workspace reconciliation, Stop with delayed cancellation followed by immediate replacement, and no late command side effects. Each cycle asserted zero approval events, zero pending approvals, and no approval UI. Screenshots were inspected. Docker events confirm all 49 candidate containers were created and removed; the dedicated network was removed after verifying it was empty.
- Full changed-file gate passed, including core and core-test typechecks, type-aware lint, dead-code scans, and architectural guards. The paired-node lifecycle wire test also passed bundle loss/reinstall, moving sessions to the Gateway and back, disconnect/retry, capacity, and role removal; this companion uses real supervisor subprocess workers rather than Docker. Final exact-head adapter/placement-recovery rerun passed all 31 tests. The model endpoint is deterministic; this is real worker/network/process/browser proof, not authenticated live model inference.
- Exact-head [normal PR CI33018340964, attempt2](https://github.com/openclaw/openclaw/actions/runs/33018340964/attempts/2) passed, including `openclaw/ci-gate`, on `c65cdab10df2dc96f8efae79eb20582fc4359f28`. This resolves the exact-head CI item below; no check was waived.

Provenance: the capacity-as-connectivity filter came from #124356 (`dbad5e385d38`, August 16), carried into exact slot inventory by #125708 (`efaa867d934c`, August 18). Both code author, PR author, and merger were @steipete. This repair preserves those intentional capacity gates and fixes their diagnostic classification.

Test setup note: the diagnostic helper initially waited for a receipt for a capacity-rejected launch, which correctly has no durable receipt. The probe was corrected to distinguish rejected launches from admitted workers before the complete baseline above. A redundant dirty-checkout bootstrap rebuild was interrupted; candidate repetitions use the repository's documented prebuilt-dist E2E mode after a complete QA-enabled build.

Build provenance: the local build began while the repair was uncommitted on the baseline, so its pinned build stamp and the ad-hoc report's baseline SHA retain `a482a50cda8850e9479d28a1ae29785a509841b2`. The candidate run contains the repaired adapter (confirmed in the emitted device-provider bundle); the subsequently committed production source is identical. Hosted CI validates the exact PR head separately. Ordinary PR CI was cancelled; the exact-head fallback run's lint runner received a shutdown signal (exit 143), not a lint diagnostic. Hosted validation is being recovered before landing.

ClawSweeper follow-through (reviewed head `c65cdab10df2dc96f8efae79eb20582fc4359f28`): no actionable correctness findings. Its two before-merge items are exact-head CI (still required) and the net-four-line production increase. The latter is accepted for the missing latest-observation fact at its existing owner, after consolidating duplicate expiry handling; removing the fact or moving classification downstream would recreate the bug. The generated stored-data-model warning does not apply: the complete two-file diff changes no schema, SQL, persistent shape, storage writer, or migration. The new observation is a launch-local variable, and the transport code is internal; no durable/protocol compatibility change is introduced. Final test LOC is +52/-6, correcting the review's older metric.

Named infrastructure follow-up: hosted full-repository lint runner shutdowns. Fallback run [33018353920](https://github.com/openclaw/openclaw/actions/runs/33018353920) lost its 4-vCPU/16-GB hosted runners during `oxlint:core`; baseline-ratchets repeated the same shutdown on attempt 2, again exit 143 with no lint diagnostic. Its 20-minute job timeout had not elapsed. Normal PR CI run [33018340964](https://github.com/openclaw/openclaw/actions/runs/33018340964), attempt 2, passed both lint and baseline-ratchets on the same source head. This PR changes no CI policy or lint execution settings; normal exact-head CI is being recovered rather than relaxing checks.
