### PR TITLE
fix(workers): re-arm admission-deadline launches, terminalize dead-worker turns, defer debris cleanup

### DIFF
--- a/docs/gateway/cloud-sessions.md
+++ b/docs/gateway/cloud-sessions.md
@@ -29,6 +29,10 @@ openclaw connect <join-url> --service --session-host
 
 The device holds an outbound connection to the Gateway, advertises worker slots (one per CPU core by default, tunable with `nodeHost.workerRuns.capacity`), and can optionally run each hosted session in a Docker-compatible container (`nodeHost.workerRuns.isolation: "container"`). A device that goes offline keeps its active placement — the session waits for it to reconnect rather than losing work.
 
+The node host reconnects after transient transport loss. A worker child has a bounded 120-second admission window. If that window expires **before the turn starts**, the Gateway can launch another child, up to five attempts total (about ten minutes plus backoff), within the original turn timeout. Launch retries use exponential backoff with jitter; each attempt keeps its own terminal result and reason in the node launch journal. Credential and build rejections are terminal, and work that already started is never replayed by this policy.
+
+If a journal-terminal worker has released its turn claim but teardown stalls, stuck-session recovery records the turn failure after a 30-second cleanup grace, on the next diagnostic cycle. Live workers and turns that still hold their claims are unaffected. On Gateway restart, orphan workspace cleanup for failed placements runs in the background after readiness; ownership fencing and pending workspace-result recovery still run before readiness.
+
 See [Nodes](/nodes) for pairing, capacity, isolation, and offline behavior, and [Connect](/cli/connect) for the CLI.
 
 ## Cloud workers: rented machines through Crabbox

--- a/src/agents/session-placement-admission.ts
+++ b/src/agents/session-placement-admission.ts
@@ -23,6 +23,7 @@ type SessionPlacementSandboxParams = {
 };
 
 export type SessionPlacementAdmissionProvider = {
+  recoverTerminalTurn?: (session: { sessionId: string; sessionKey?: string }) => string | undefined;
   executeLocalTurn: <T>(claim: LocalTurnPlacementClaim, runLocal: () => Promise<T>) => Promise<T>;
   executeTurn: (
     claim: LocalTurnPlacementClaim,
@@ -119,4 +120,12 @@ export async function resolveSessionPlacementSandbox(
   params: SessionPlacementSandboxParams,
 ): Promise<SandboxContext | null> {
   return (await state.provider?.resolveSandbox?.(params)) ?? null;
+}
+
+/** The current placement owner alone can settle a proven terminal worker turn. */
+export function recoverTerminalSessionPlacementTurn(session: {
+  sessionId: string;
+  sessionKey?: string;
+}): string | undefined {
+  return state.provider?.recoverTerminalTurn?.(session);
 }

--- a/src/gateway/server-worker-placement-startup-cleanup.test.ts
+++ b/src/gateway/server-worker-placement-startup-cleanup.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { collectSessionMaintenancePreserveKeys } from "../config/sessions/store-maintenance-preserve.js";
 import { createDeferredCore } from "../shared/deferred.js";
@@ -21,12 +22,89 @@ vi.mock("./worker-environments/placement-disk-space.js", async (importOriginal) 
 });
 
 import { createGatewayWorkerPlacementRuntime } from "./server-worker-placement-startup.js";
+import { createPlacementFailureActions } from "./worker-environments/placement-dispatch-failure.js";
+import { createPlacementRecoveryActions } from "./worker-environments/placement-dispatch-recovery.js";
 import { seedActivePlacement } from "./worker-environments/placement-dispatch-test-fixtures.js";
 import { createWorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
 import * as workerEnvironmentSupport from "./worker-environments/service.test-support.js";
+import { createWorkerWorkspaceOperationCoordinator } from "./worker-environments/workspace-operation-coordinator.js";
 
 describe("worker placement startup cleanup ownership", () => {
   workerEnvironmentSupport.setupWorkerEnvironmentServiceSuite();
+
+  it("defers workspace cleanup for 50 failed placements until the first background sweep", async () => {
+    const placements = createWorkerSessionPlacementStore({
+      database: workerEnvironmentSupport.testState.stateDb,
+      now: () => workerEnvironmentSupport.testState.nowMs,
+    });
+    for (let index = 0; index < 50; index += 1) {
+      const requested = placements.startDispatch({
+        sessionId: `session-debris-${index}`,
+        sessionKey: `agent:main:debris-${index}`,
+        agentId: "main",
+        executionMode: "worker-turn",
+      });
+      const provisioning = placements.transition({
+        sessionId: requested.sessionId,
+        from: "requested",
+        to: "provisioning",
+        expectedGeneration: requested.generation,
+        patch: { environmentId: `worker-debris-${index}` },
+      });
+      placements.fail({
+        sessionId: requested.sessionId,
+        expectedGeneration: provisioning.generation,
+        recoveryError: "worker admission deadline exceeded",
+      });
+    }
+    const before = placements.list();
+    const environments = workerEnvironmentSupport.createService(
+      workerEnvironmentSupport.createProvider(),
+    );
+    const cleanupStarted = createDeferredCore();
+    const releaseCleanup = createDeferredCore();
+    const resolveWorkspacePath = vi.fn(async ({ sessionId }: { sessionId: string }) => {
+      cleanupStarted.resolve();
+      await releaseCleanup.promise;
+      return path.join(workerEnvironmentSupport.testState.root, sessionId);
+    });
+    const recovery = createPlacementRecoveryActions({
+      placements,
+      environments,
+      failure: createPlacementFailureActions({ placements, environments }),
+      workspaceOperations: createWorkerWorkspaceOperationCoordinator(),
+      resolveWorkspacePath,
+      reportWorkspaceResultConflict: async () => {},
+      resolveWorkspaceResultConflict: async () => undefined,
+    });
+    const starting = recovery.reconcile("startup");
+    let sweeping: Promise<void> | undefined;
+    try {
+      expect(
+        await Promise.race([
+          starting.then(() => "ready"),
+          cleanupStarted.promise.then(() => "cleanup"),
+        ]),
+      ).toBe("ready");
+      expect(resolveWorkspacePath).not.toHaveBeenCalled();
+      await recovery.reconcileActive("worker-debris-0");
+      expect(resolveWorkspacePath).not.toHaveBeenCalled();
+
+      sweeping = recovery.reconcileActive();
+      await cleanupStarted.promise;
+      expect(resolveWorkspacePath).toHaveBeenCalledOnce();
+      releaseCleanup.resolve();
+      await sweeping;
+      expect(resolveWorkspacePath).toHaveBeenCalledTimes(50);
+      await recovery.reconcileActive();
+      expect(resolveWorkspacePath).toHaveBeenCalledTimes(50);
+      expect(placements.list()).toEqual(before);
+    } finally {
+      releaseCleanup.resolve();
+      await starting;
+      await sweeping;
+    }
+  });
 
   it.each([
     { retainedAuthority: "a local turn claim", claimLocalTurn: true },

--- a/src/gateway/worker-environments/node-launch-adapter.test.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.test.ts
@@ -129,6 +129,128 @@ function launchRequest(input = launchInput()) {
 }
 
 describe("node worker launch adapter", () => {
+  it("re-arms only a settled pre-admission deadline with fresh idempotent launch identities", async () => {
+    const input = launchInput();
+    const launches: NodeWorkerLaunchInput[] = [];
+    const delays: number[] = [];
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      const attempt = request.params as NodeWorkerLaunchInput;
+      launches.push(attempt);
+      return wire({
+        ...receipt(attempt, "completed"),
+        state: "completed",
+        resultJson: JSON.stringify(
+          launches.length === 1
+            ? {
+                status: "not-started",
+                reason: "admission-deadline",
+                errorText: "gateway unreachable",
+              }
+            : { status: "completed", transcriptLeafId: "leaf-1", transcriptNextSeq: 2 },
+        ),
+      });
+    });
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke),
+      sleep: async (ms) => {
+        delays.push(ms);
+      },
+    });
+    await expect(adapter.launch(launchRequest(input))).resolves.toMatchObject({
+      resultJson: JSON.stringify({
+        status: "completed",
+        transcriptLeafId: "leaf-1",
+        transcriptNextSeq: 2,
+      }),
+    });
+    expect(launches).toHaveLength(2);
+    expect(launches[1]?.launchId).not.toBe(input.launchId);
+    expect(launches[1]?.descriptor.assignment.turnId).toBe(launches[1]?.launchId);
+    expect(launches[1]?.descriptor.assignment.runId).toBe(input.descriptor.assignment.runId);
+    expect(delays[0]).toBeGreaterThanOrEqual(1_000);
+    expect(delays[0]).toBeLessThanOrEqual(1_100);
+    const retried = launches[1];
+    launches.length = 0;
+    await adapter.launch(launchRequest(input));
+    expect(launches[1]).toEqual(retried);
+  });
+
+  it("bounds admission re-arms to five journaled attempts", async () => {
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      const input = request.params as NodeWorkerLaunchInput;
+      return wire({
+        ...receipt(input, "completed"),
+        state: "completed",
+        resultJson: JSON.stringify({
+          status: "not-started",
+          reason: "admission-deadline",
+          errorText: "gateway unreachable",
+        }),
+      });
+    });
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke),
+      sleep: async () => {},
+    });
+    await adapter.launch(launchRequest());
+    expect(invoke).toHaveBeenCalledTimes(5);
+    expect(
+      new Set(
+        invoke.mock.calls.map(([request]) => (request.params as NodeWorkerLaunchInput).launchId),
+      ).size,
+    ).toBe(5);
+  });
+
+  it.each(["invalid-credential", "stale-worker-build", "admission deadline exceeded"])(
+    "does not re-arm terminal rejection text: %s",
+    async (errorText) => {
+      const input = launchInput();
+      const terminal = { ...receipt(input, "failed"), state: "failed" as const, errorText };
+      const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async () => wire(terminal));
+      const adapter = createNodeWorkerLaunchAdapter({ getTransport: () => transportWith(invoke) });
+      await expect(adapter.launch(launchRequest(input))).resolves.toEqual(terminal);
+      expect(invoke).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(["abort", "claim-loss"])(
+    "fences admission re-arm after %s during backoff",
+    async (reason) => {
+      const input = launchInput();
+      const controller = new AbortController();
+      let authorized = true;
+      const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async () =>
+        wire({
+          ...receipt(input, "completed"),
+          state: "completed",
+          resultJson: JSON.stringify({
+            status: "not-started",
+            reason: "admission-deadline",
+            errorText: "gateway unreachable",
+          }),
+        }),
+      );
+      const adapter = createNodeWorkerLaunchAdapter({
+        getTransport: () => transportWith(invoke),
+        sleep: async () => {
+          if (reason === "abort") {
+            controller.abort(new Error("turn cancelled"));
+          } else {
+            authorized = false;
+          }
+        },
+      });
+      await expect(
+        adapter.launch({
+          ...launchRequest(input),
+          signal: controller.signal,
+          isDispatchAuthorized: () => authorized,
+        }),
+      ).rejects.toThrow(reason === "abort" ? "turn cancelled" : "authority closed");
+      expect(invoke).toHaveBeenCalledOnce();
+    },
+  );
+
   it.each([
     { label: "offline", slots: [undefined], code: "runner-offline" },
     { label: "full", slots: [0], code: NODE_WORKER_CAPACITY_EXHAUSTED_ERROR_CODE },

--- a/src/gateway/worker-environments/node-launch-adapter.test.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.test.ts
@@ -175,6 +175,77 @@ describe("node worker launch adapter", () => {
     expect(launches[1]).toEqual(retried);
   });
 
+  it("stops re-arming once the next attempt would outlive the admission credential", async () => {
+    const nowMs = 1_700_000_000_000;
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      const input = request.params as NodeWorkerLaunchInput;
+      return wire({
+        ...receipt(input, "completed"),
+        state: "completed",
+        resultJson: JSON.stringify({
+          status: "not-started",
+          reason: "admission-deadline",
+          errorText: "gateway unreachable",
+        }),
+      });
+    });
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke),
+      now: () => nowMs,
+      sleep: async () => {},
+    });
+    // First re-arm backoff is at most 1_100ms and fits; the second needs at
+    // least 2_000ms and would start inside the final admission window.
+    const result = await adapter.launch({
+      ...launchRequest(),
+      credentialExpiresAtMs: nowMs + 120_000 + 1_500,
+    });
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(JSON.parse((result as { resultJson: string }).resultJson)).toMatchObject({
+      reason: "admission-deadline",
+    });
+  });
+
+  it("admits a final re-arm that fits inside the credential lifetime", async () => {
+    const nowMs = 1_700_000_000_000;
+    const launches: NodeWorkerLaunchInput[] = [];
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      const input = request.params as NodeWorkerLaunchInput;
+      launches.push(input);
+      return wire({
+        ...receipt(input, "completed"),
+        state: "completed",
+        resultJson: JSON.stringify(
+          launches.length === 1
+            ? {
+                status: "not-started",
+                reason: "admission-deadline",
+                errorText: "gateway unreachable",
+              }
+            : { status: "completed", transcriptLeafId: "leaf-1", transcriptNextSeq: 2 },
+        ),
+      });
+    });
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke),
+      now: () => nowMs,
+      sleep: async () => {},
+    });
+    await expect(
+      adapter.launch({
+        ...launchRequest(),
+        credentialExpiresAtMs: nowMs + 10 * 60_000,
+      }),
+    ).resolves.toMatchObject({
+      resultJson: JSON.stringify({
+        status: "completed",
+        transcriptLeafId: "leaf-1",
+        transcriptNextSeq: 2,
+      }),
+    });
+    expect(launches).toHaveLength(2);
+  });
+
   it("bounds admission re-arms to five journaled attempts", async () => {
     const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
       const input = request.params as NodeWorkerLaunchInput;

--- a/src/gateway/worker-environments/node-launch-adapter.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.ts
@@ -1,4 +1,5 @@
-import { sleepWithAbort } from "../../infra/backoff.js";
+import { createHash } from "node:crypto";
+import { computeBackoff, sleepWithAbort } from "../../infra/backoff.js";
 import {
   NODE_WORKER_CAPACITY_EXHAUSTED_ERROR_CODE,
   NODE_WORKER_SUPERVISOR_CANCEL_COMMAND,
@@ -13,6 +14,7 @@ import {
   type NodeWorkerSupervisorIdentity,
   type NodeWorkerSupervisorReceipt,
 } from "../../worker/node-supervisor-protocol.js";
+import { parseWorkerAdmissionDeadlineResult } from "../../worker/worker-connection-contract.js";
 import type {
   NodeWorkerSupervisorNodeProof,
   NodeWorkerSupervisorTransport,
@@ -24,6 +26,10 @@ const DEFAULT_POLL_INTERVAL_MS = 250;
 const MAX_RETRY_DELAY_MS = 2_000;
 const DEFAULT_CANCELLATION_TIMEOUT_MS = 30_000;
 const DEFAULT_AVAILABILITY_TIMEOUT_MS = 10_000;
+// Five 120s admission windows cover about ten minutes, still capped by the caller.
+// Use the node host's exponential reconnect cadence plus worker reconnect jitter.
+const MAX_ADMISSION_ATTEMPTS = 5;
+const ADMISSION_REARM_BACKOFF = { initialMs: 1_000, maxMs: 30_000, factor: 2, jitter: 0.1 };
 
 const RETRYABLE_TRANSPORT_CODES = new Set([
   "AT_CAPACITY",
@@ -403,9 +409,12 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
   const launch = async (
     request: DeviceWorkerLaunchRequest,
   ): Promise<TerminalNodeWorkerSupervisorReceipt> => {
-    const input = snapshotLaunchInput(request.input);
+    const originalInput = snapshotLaunchInput(request.input);
+    let input = originalInput;
+    const originalLaunchId = input.launchId;
     const stableRequest = { ...request, input };
-    const expected = expectedIdentity(input);
+    let expected = expectedIdentity(input);
+    let admissionAttempts = 1;
     const deadline = createDeadline({
       now,
       timeoutMs: request.timeoutMs,
@@ -464,6 +473,36 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
             const validated = validateReceipt(receipt, expected);
             mayHaveLaunched = true;
             if (isTerminalReceipt(validated)) {
+              const admissionFailure =
+                validated.state === "completed"
+                  ? parseWorkerAdmissionDeadlineResult(JSON.parse(validated.resultJson))
+                  : undefined;
+              if (admissionFailure && admissionAttempts < MAX_ADMISSION_ATTEMPTS) {
+                // The node journal holds this attempt's reason and proves its child
+                // is gone. Re-arm only after backoff and current authority revalidation.
+                mayHaveLaunched = false;
+                await waitBeforeRetry({
+                  delayMs: computeBackoff(ADMISSION_REARM_BACKOFF, admissionAttempts),
+                  deadline,
+                });
+                const launchId = createHash("sha256")
+                  .update(`${originalLaunchId}:admission-rearm:${admissionAttempts++}`)
+                  .digest("hex");
+                // Deterministic IDs make a replay of this adapter find the same journal
+                // rows, never another child for an already completed retry.
+                input = {
+                  ...originalInput,
+                  launchId,
+                  descriptor: {
+                    ...originalInput.descriptor,
+                    assignment: { ...originalInput.descriptor.assignment, turnId: launchId },
+                  },
+                };
+                expected = expectedIdentity(input);
+                pollStatus = false;
+                delayMs = pollIntervalMs;
+                continue;
+              }
               return validated;
             }
             pollStatus = true;

--- a/src/gateway/worker-environments/node-launch-adapter.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.ts
@@ -14,7 +14,10 @@ import {
   type NodeWorkerSupervisorIdentity,
   type NodeWorkerSupervisorReceipt,
 } from "../../worker/node-supervisor-protocol.js";
-import { parseWorkerAdmissionDeadlineResult } from "../../worker/worker-connection-contract.js";
+import {
+  parseWorkerAdmissionDeadlineResult,
+  WORKER_ADMISSION_DEADLINE_MS,
+} from "../../worker/worker-connection-contract.js";
 import type {
   NodeWorkerSupervisorNodeProof,
   NodeWorkerSupervisorTransport,
@@ -53,6 +56,7 @@ type DeviceWorkerLaunchRequest = {
   isDispatchAuthorized: () => boolean;
   isCancellationAuthorized: () => boolean;
   timeoutMs: number;
+  credentialExpiresAtMs?: number;
   signal?: AbortSignal;
   onDispatchReady?: () => void;
 };
@@ -477,12 +481,24 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
                 validated.state === "completed"
                   ? parseWorkerAdmissionDeadlineResult(JSON.parse(validated.resultJson))
                   : undefined;
-              if (admissionFailure && admissionAttempts < MAX_ADMISSION_ATTEMPTS) {
+              const rearmDelayMs = computeBackoff(ADMISSION_REARM_BACKOFF, admissionAttempts);
+              // Re-arm only while the retried child still gets a full admission
+              // window on the originally minted credential; a later start is
+              // guaranteed to be rejected as credential-expired.
+              const rearmAdmitsWithinCredential =
+                stableRequest.credentialExpiresAtMs === undefined ||
+                now() + rearmDelayMs + WORKER_ADMISSION_DEADLINE_MS <=
+                  stableRequest.credentialExpiresAtMs;
+              if (
+                admissionFailure &&
+                admissionAttempts < MAX_ADMISSION_ATTEMPTS &&
+                rearmAdmitsWithinCredential
+              ) {
                 // The node journal holds this attempt's reason and proves its child
                 // is gone. Re-arm only after backoff and current authority revalidation.
                 mayHaveLaunched = false;
                 await waitBeforeRetry({
-                  delayMs: computeBackoff(ADMISSION_REARM_BACKOFF, admissionAttempts),
+                  delayMs: rearmDelayMs,
                   deadline,
                 });
                 const launchId = createHash("sha256")

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -73,6 +73,7 @@ type NodeWorkerLaunch = (request: {
   isDispatchAuthorized: () => boolean;
   isCancellationAuthorized: () => boolean;
   timeoutMs: number;
+  credentialExpiresAtMs?: number;
   signal?: AbortSignal;
   onDispatchReady?: () => void;
 }) => Promise<Exclude<NodeWorkerSupervisorReceipt, { state: "pending" | "running" }>>;
@@ -516,6 +517,9 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
           isDispatchAuthorized,
           isCancellationAuthorized: () => hasDurableBinding(entry as NodeTunnelEntry),
           timeoutMs: request.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS,
+          ...(request.credentialExpiresAtMs === undefined
+            ? {}
+            : { credentialExpiresAtMs: request.credentialExpiresAtMs }),
           onDispatchReady: request.onDispatchReady,
           signal: request.signal
             ? AbortSignal.any([entry.abortController.signal, request.signal])

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -517,13 +517,16 @@ export async function recoverPendingWorkspaceResults(
     }
   }
   if (cleanupOrphans) {
-    const retainedCleanupRefs = new Set(
-      placements
-        .listPendingWorkspaceResults()
-        .flatMap((pending) =>
-          pending.stagedResultRef ? [cleanupWorkerWorkspaceResultRef(pending.stagedResultRef)] : [],
-        ),
-    );
+    const retainedRefs = () =>
+      new Set(
+        placements
+          .listPendingWorkspaceResults()
+          .flatMap((pending) =>
+            pending.stagedResultRef
+              ? [cleanupWorkerWorkspaceResultRef(pending.stagedResultRef)]
+              : [],
+          ),
+      );
     const cleanedWorkspaceRoots = new Set<string>();
     for (const placement of placements.list()) {
       try {
@@ -532,11 +535,11 @@ export async function recoverPendingWorkspaceResults(
           cleanedWorkspaceRoots.add(root);
           await deleteWorkerWorkspaceResultCleanupRefs({
             root,
-            retainedRefs: retainedCleanupRefs,
+            retainedRefs,
           });
         }
       } catch {
-        // Cleanup refs are independently retryable on the next startup sweep.
+        // Cleanup refs are independently retryable after the next restart.
       }
     }
   }

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -92,6 +92,9 @@ function blockingWorkspaceJournalSessions(
 
 export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
   const { environments, failure, placements } = deps;
+  // Orphan Git refs carry no live authority. Scan them once in the tracked full
+  // post-start sweep, never on readiness or targeted turn recovery.
+  let orphanCleanupPending = false;
 
   const adoptActive = async (placement: WorkerActiveDispatchPlacement): Promise<void> => {
     // Turn claims belong to the previous Gateway lifecycle and cannot prove live authority
@@ -158,7 +161,8 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
     } else {
       await environments.reconcileOnce();
     }
-    const pendingResultOwners = await recoverPendingWorkspaceResults(deps, true);
+    const pendingResultOwners = await recoverPendingWorkspaceResults(deps, mode !== "startup");
+    orphanCleanupPending = mode === "startup";
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     const moveOwners = (await deps.recoverPlacementMoves?.()) ?? new Set<string>();
     for (const placement of placements.listForReconcile()) {
@@ -231,7 +235,15 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
   // durable active ownership and retry teardown already fenced by a previous failure.
   const reconcileActive = async (environmentId?: string): Promise<void> => {
     await environments.reconcileOnce();
-    const pendingResultOwners = await recoverPendingWorkspaceResults(deps, false, environmentId);
+    const cleanupOrphans = orphanCleanupPending && environmentId === undefined;
+    const pendingResultOwners = await recoverPendingWorkspaceResults(
+      deps,
+      cleanupOrphans,
+      environmentId,
+    );
+    if (cleanupOrphans) {
+      orphanCleanupPending = false;
+    }
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     const moveOwners = (await deps.recoverPlacementMoves?.()) ?? new Set<string>();
     for (const placement of placements.listForReconcile()) {

--- a/src/gateway/worker-environments/tunnel-contract.ts
+++ b/src/gateway/worker-environments/tunnel-contract.ts
@@ -104,6 +104,9 @@ export type WorkerTurnLaunchRequest = {
   plan: WorkerLaunchPlan;
   turnClaim: WorkerSessionTurnClaim;
   timeoutMs?: number;
+  // Expiry of the minted admission credential; launch adapters cap admission
+  // re-arms so no advertised retry can outlive it.
+  credentialExpiresAtMs?: number;
   signal?: AbortSignal;
   onDispatchReady?: () => void;
 };

--- a/src/gateway/worker-environments/worker-turn-admission.ts
+++ b/src/gateway/worker-environments/worker-turn-admission.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from "node:crypto";
-import type { LocalTurnPlacementClaim } from "../../agents/session-placement-admission.js";
+import {
+  withSessionPlacementForcedTerminalSettlement,
+  type LocalTurnPlacementClaim,
+} from "../../agents/session-placement-admission.js";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
 import { SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS } from "../../sessions/session-lifecycle-admission.js";
 import { projectWorkerSessionTurnClaim } from "./placement-record.js";
@@ -172,6 +175,28 @@ export async function releaseClaimIfOwned(
       await placements.closeWorkerTurnToolState(turnClaim);
     }
     placements.releaseTurn(turnClaim);
+  }
+}
+
+export async function executeLocalTurn<T>(params: {
+  claim: LocalTurnPlacementClaim;
+  placements: WorkerSessionPlacementStore;
+  runLocal: () => Promise<T>;
+}): Promise<T> {
+  const current = params.placements.get(params.claim.sessionId);
+  const turnClaim = params.placements.claimTurn({
+    ...resolvePlacementIdentity(params.claim, current),
+    claimId: randomUUID(),
+    runId: params.claim.runId,
+    owner: { kind: "local" },
+  });
+  // Forced terminalization and ordinary completion share this exact-claim closure.
+  // Replacement fencing makes a late finally harmless after recovery settles it.
+  const settle = () => releaseClaimIfOwned(params.placements, turnClaim);
+  try {
+    return await withSessionPlacementForcedTerminalSettlement(settle, params.runLocal);
+  } finally {
+    await settle();
   }
 }
 

--- a/src/gateway/worker-environments/worker-turn-failure.ts
+++ b/src/gateway/worker-environments/worker-turn-failure.ts
@@ -1,6 +1,7 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { redactSensitiveText } from "../../logging/redact.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import type {
   WorkerSessionPlacementRecord,
   WorkerSessionPlacementStore,
@@ -24,6 +25,10 @@ export type ActiveWorkerPlacement = Extract<WorkerSessionPlacementRecord, { stat
 
 export class WorkerTurnExecutionError extends Error {}
 
+// Journal-terminal launches get a short cleanup grace before failure is surfaced.
+// This never limits a live launch or a turn still holding its claim.
+const TERMINAL_WORKER_CLEANUP_GRACE_MS = 30_000;
+
 function workerTurnRecoveryError(error: unknown): string {
   const message = redactSensitiveText(formatErrorMessage(error), { mode: "tools" })
     .replace(/\s+/gu, " ")
@@ -37,11 +42,15 @@ export async function failHandedOffTurn(params: {
   placement: ActiveWorkerPlacement;
   turnClaim: WorkerSessionTurnClaim;
   error: unknown;
+  terminal?: {
+    observedAtMs: number;
+    registerRecovery(recover: () => string | undefined): void;
+  };
 }): Promise<void> {
   const failures = [workerTurnRecoveryError(params.error)];
-  let draining: WorkerSessionPlacementRecord;
+  let drained: WorkerSessionPlacementRecord;
   try {
-    draining = params.placements.startDrain({
+    drained = params.placements.startDrain({
       sessionId: params.placement.sessionId,
       environmentId: params.placement.environmentId,
       ownerEpoch: params.placement.activeOwnerEpoch,
@@ -64,39 +73,82 @@ export async function failHandedOffTurn(params: {
     // tear down an environment after losing the exact source-generation CAS.
     return;
   }
-  if (draining.state !== "draining") {
+  if (drained.state !== "draining") {
     return;
   }
+  const draining = drained;
   await releaseClaimIfOwned(params.placements, params.turnClaim);
+  const isCurrentDrain = () => {
+    const current = params.placements.get(draining.sessionId);
+    return (
+      current?.state === "draining" &&
+      current.generation === draining.generation &&
+      current.environmentId === draining.environmentId &&
+      current.activeOwnerEpoch === draining.activeOwnerEpoch &&
+      current.turnClaim === null
+    );
+  };
+  const recordFailure = (): string | undefined => {
+    if (!isCurrentDrain()) {
+      return undefined;
+    }
+    try {
+      const reconciling = params.placements.startReconcile({
+        sessionId: draining.sessionId,
+        environmentId: draining.environmentId,
+        ownerEpoch: draining.activeOwnerEpoch,
+        expectedGeneration: draining.generation,
+      });
+      const recoveryError = failures.join("; ");
+      params.placements.fail({
+        sessionId: reconciling.sessionId,
+        expectedGeneration: reconciling.generation,
+        recoveryError,
+      });
+      return recoveryError;
+    } catch {
+      // Leave the durable draining or reconciling row for startup reconciliation.
+      return undefined;
+    }
+  };
+  const terminalRecovery = params.terminal ? createDeferredCore() : undefined;
+  if (params.terminal && terminalRecovery) {
+    const observedAtMs = params.terminal.observedAtMs;
+    params.terminal.registerRecovery(() => {
+      if (Date.now() - observedAtMs < TERMINAL_WORKER_CLEANUP_GRACE_MS) {
+        return undefined;
+      }
+      const recorded = recordFailure();
+      if (recorded !== undefined) {
+        terminalRecovery.resolve();
+      }
+      return recorded;
+    });
+  }
+  const waitForCleanup = (operation: Promise<unknown>) =>
+    terminalRecovery ? Promise.race([operation, terminalRecovery.promise]) : operation;
+  if (!isCurrentDrain()) {
+    return;
+  }
   try {
-    await params.environments.stopTunnel(
-      params.placement.environmentId,
-      params.placement.activeOwnerEpoch,
+    await waitForCleanup(
+      params.environments.stopTunnel(
+        params.placement.environmentId,
+        params.placement.activeOwnerEpoch,
+      ),
     );
   } catch (error) {
     failures.push(`tunnel stop: ${workerTurnRecoveryError(error)}`);
   }
+  // Recovery may have recorded failure, or a replacement may own the session.
+  // A late cleanup completion must never destroy that newer placement.
+  if (!isCurrentDrain()) {
+    return;
+  }
   try {
-    await params.environments.destroy(params.placement.environmentId);
+    await waitForCleanup(params.environments.destroy(params.placement.environmentId));
   } catch (error) {
     failures.push(`environment destroy: ${workerTurnRecoveryError(error)}`);
   }
-  try {
-    const reconciling = params.placements.startReconcile({
-      sessionId: draining.sessionId,
-      environmentId: draining.environmentId,
-      ownerEpoch: draining.activeOwnerEpoch,
-      expectedGeneration: draining.generation,
-    });
-    if (reconciling.state !== "reconciling") {
-      return;
-    }
-    params.placements.fail({
-      sessionId: reconciling.sessionId,
-      expectedGeneration: reconciling.generation,
-      recoveryError: failures.join("; "),
-    });
-  } catch {
-    // Leave the durable draining or reconciling row for startup reconciliation.
-  }
+  recordFailure();
 }

--- a/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WORKER_PROTOCOL_MAX_INFERENCE_PAYLOAD_BYTES } from "../../../packages/gateway-protocol/src/schema/worker-inference.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { installSessionPlacementAdmissionProvider } from "../../agents/session-placement-admission.js";
 import { makeAgentAssistantMessage } from "../../agents/test-helpers/agent-message-fixtures.js";
+import { createReplyOperation } from "../../auto-reply/reply/reply-run-registry.js";
+import { recoverStuckDiagnosticSession } from "../../logging/diagnostic-stuck-session-recovery.runtime.js";
 import type { SpawnResult } from "../../process/exec.js";
 import { WORKER_PROVIDER_REPLAY_LOCAL_RETRY_MESSAGE } from "../../worker/transcript-message.js";
 import { STALE_WORKER_BUILD_REASON, StaleWorkerBuildError } from "./admission.js";
@@ -44,6 +47,175 @@ import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation
 describe("worker turn launcher failure recovery", () => {
   beforeEach(setupWorkerTurnLauncherTest);
   afterEach(cleanupWorkerTurnLauncherTest);
+
+  it("terminalizes a journal-settled dead worker without waiting for blocked teardown", async () => {
+    seedActivePlacement();
+    const launchStarted = createDeferred();
+    const finishLaunch = createDeferred();
+    const teardownStarted = createDeferred();
+    const finishTeardown = createDeferred();
+    const environment = {
+      ...attachedEnvironment(),
+      nodeDeviceId: "node-worker",
+      sshEndpoint: null,
+    };
+    const environments: WorkerTurnEnvironmentService = {
+      ...unusedEnvironments(),
+      get: () => environment,
+      acquireTurnCredential: async () => credential(),
+      acknowledgeCredentialDelivery: () => true,
+      startTunnel: async () => ({
+        environmentId: ENVIRONMENT_ID,
+        ownerEpoch: OWNER_EPOCH,
+        runWorkspaceCommand: vi.fn(),
+        quiesceWorkspace: vi.fn(),
+        syncWorkspace: vi.fn(),
+        reconcileWorkspace: vi.fn(),
+        stop: vi.fn(),
+        launchTurn: async (request) => {
+          request.onDispatchReady?.();
+          launchStarted.resolve();
+          await finishLaunch.promise;
+          return {
+            stdout: "",
+            stderr: "worker admission deadline exceeded",
+            code: 1,
+            signal: null,
+            killed: false,
+            termination: "exit",
+          };
+        },
+      }),
+      stopTunnel: async () => {
+        teardownStarted.resolve();
+        await finishTeardown.promise;
+      },
+      destroy: vi.fn(async () => environment),
+    };
+    const provider = createWorkerSessionTurnPlacementProvider({ environments, placements });
+    const uninstall = installSessionPlacementAdmissionProvider(provider);
+    const operation = createReplyOperation({
+      sessionId: SESSION_ID,
+      sessionKey: SESSION_KEY,
+      resetTriggered: false,
+    });
+    operation.setPhase("waiting_for_deferred_maintenance");
+    const clock = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    const attempt = provider
+      .executeTurn(
+        {
+          sessionId: SESSION_ID,
+          sessionKey: SESSION_KEY,
+          agentId: "main",
+          runId: "run-dead-worker",
+        },
+        turn("run-dead-worker"),
+        async () => ({ meta: { durationMs: 1 } }),
+      )
+      .then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+    const recover = () =>
+      recoverStuckDiagnosticSession({
+        sessionId: SESSION_ID,
+        sessionKey: SESSION_KEY,
+        ageMs: 180_000,
+      });
+    try {
+      await launchStarted.promise;
+      await expect(recover()).resolves.toMatchObject({ status: "skipped", action: "keep_lane" });
+      finishLaunch.resolve();
+      await teardownStarted.promise;
+      expect(placements.get(SESSION_ID)).toMatchObject({ state: "draining", turnClaim: null });
+      await expect(recover()).resolves.toMatchObject({ status: "skipped", action: "keep_lane" });
+      clock.mockReturnValue(1_030_000);
+      await expect(recover()).resolves.toMatchObject({
+        status: "failed",
+        action: "fail_worker_turn",
+        reason: "terminal_worker",
+      });
+      expect(await attempt).toMatchObject({
+        message:
+          "Cloud worker process failed before completing the turn: worker admission deadline exceeded",
+      });
+      expect(placements.get(SESSION_ID)).toMatchObject({
+        state: "failed",
+        turnClaim: null,
+        terminalReason: expect.stringContaining("worker admission deadline exceeded"),
+      });
+      expect(environments.destroy).not.toHaveBeenCalled();
+      finishTeardown.reject(new Error("late tunnel cleanup rejection"));
+      await Promise.resolve();
+      expect(environments.destroy).not.toHaveBeenCalled();
+    } finally {
+      finishLaunch.resolve();
+      finishTeardown.resolve();
+      await attempt;
+      clock.mockRestore();
+      operation.complete();
+      uninstall();
+    }
+  });
+
+  it("does not destroy a replacement after failed-turn teardown loses its placement", async () => {
+    seedActivePlacement();
+    const active = placements.get(SESSION_ID);
+    if (active?.state !== "active") {
+      throw new Error("expected active placement");
+    }
+    const turnClaim = placements.claimTurn({
+      sessionId: SESSION_ID,
+      sessionKey: SESSION_KEY,
+      agentId: "main",
+      claimId: "old-turn-claim",
+      runId: "old-turn-run",
+      owner: placementTurnOwner(active),
+    });
+    const teardownStarted = createDeferred();
+    const finishTeardown = createDeferred();
+    const destroy = vi.fn(async () => attachedEnvironment());
+    const cleanup = failHandedOffTurn({
+      environments: {
+        ...unusedEnvironments(),
+        stopTunnel: async () => {
+          teardownStarted.resolve();
+          await finishTeardown.promise;
+        },
+        destroy,
+      },
+      placements,
+      placement: active,
+      turnClaim,
+      error: new Error("original turn failed"),
+    });
+    try {
+      await teardownStarted.promise;
+      const reconciling = placements.startReconcile({
+        sessionId: SESSION_ID,
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+        expectedGeneration: active.generation + 1,
+      });
+      placements.fail({
+        sessionId: SESSION_ID,
+        expectedGeneration: reconciling.generation,
+        recoveryError: "recovered elsewhere",
+      });
+      const replacement = placements.startDispatch({
+        sessionId: SESSION_ID,
+        sessionKey: SESSION_KEY,
+        agentId: "main",
+      });
+      finishTeardown.resolve();
+      await cleanup;
+      expect(destroy).not.toHaveBeenCalled();
+      expect(placements.get(SESSION_ID)).toEqual(replacement);
+    } finally {
+      finishTeardown.resolve();
+      await cleanup;
+    }
+  });
 
   it.each(["worker-turn", "remote-exec"] as const)(
     "releases an exact %s claim after another lifecycle owner starts draining",

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -2,11 +2,10 @@ import { randomUUID } from "node:crypto";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { mapThinkingLevelForProvider } from "../../agents/embedded-agent-runner/utils.js";
 import type { SandboxContext } from "../../agents/sandbox/types.js";
-import {
-  withSessionPlacementForcedTerminalSettlement,
-  type LocalTurnPlacementClaim,
-  type SessionPlacementAdmissionProvider,
-  type SessionPlacementTurnParams,
+import type {
+  LocalTurnPlacementClaim,
+  SessionPlacementAdmissionProvider,
+  SessionPlacementTurnParams,
 } from "../../agents/session-placement-admission.js";
 import { convertToLlm } from "../../agents/sessions/messages.js";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
@@ -32,6 +31,7 @@ import { WorkerRunnerCapacityError, WorkerRunnerUnavailableError } from "./tunne
 import { resolveWorkerBrowserLaunchPlan } from "./worker-browser-launch-plan.js";
 import {
   claimWorkerTurn,
+  executeLocalTurn,
   rejectPendingWorkerResult,
   releaseClaimIfOwned,
   requireActivePlacement,
@@ -64,6 +64,12 @@ import {
 } from "./workspace-result-finalize.js";
 
 type ReclaimedWorkerPlacement = Extract<WorkerSessionPlacementRecord, { state: "reclaimed" }>;
+type ActiveWorkerTurn = {
+  claim: WorkerSessionTurnClaim;
+  sessionKey: string;
+  signal?: AbortSignal;
+  recoverTerminal?: () => string | undefined;
+};
 
 type WorkerTurnLauncherOptions = {
   environments: WorkerTurnEnvironmentService;
@@ -76,31 +82,10 @@ type WorkerTurnLauncherOptions = {
   publishAcceptedWorkspace?: (claim: WorkerSessionTurnClaim) => Promise<void>;
 };
 
-async function executeLocalTurn<T>(params: {
-  claim: LocalTurnPlacementClaim;
-  placements: WorkerSessionPlacementStore;
-  runLocal: () => Promise<T>;
-}): Promise<T> {
-  const current = params.placements.get(params.claim.sessionId);
-  const turnClaim = params.placements.claimTurn({
-    ...resolvePlacementIdentity(params.claim, current),
-    claimId: randomUUID(),
-    runId: params.claim.runId,
-    owner: { kind: "local" },
-  });
-  // Forced terminalization and ordinary completion share this exact-claim closure.
-  // Replacement fencing makes a late finally harmless after recovery settles it.
-  const settle = () => releaseClaimIfOwned(params.placements, turnClaim);
-  try {
-    return await withSessionPlacementForcedTerminalSettlement(settle, params.runLocal);
-  } finally {
-    await settle();
-  }
-}
-
 async function executeWorkerTurn(params: {
   environments: WorkerTurnEnvironmentService;
   onHandoff: () => void;
+  onTerminal: () => void;
   placement: ActiveWorkerPlacement;
   placements: WorkerSessionPlacementStore;
   reconcileActivePlacement: (environmentId: string) => Promise<void>;
@@ -324,6 +309,11 @@ async function executeWorkerTurn(params: {
     onDispatchReady,
   });
   const processResult = await processPromise;
+  // Node launches return only after the exact launch journal receipt is terminal,
+  // including any admission re-arms. Transport failures never reach this fact.
+  if (environment.nodeDeviceId && environment.sshEndpoint === null) {
+    params.onTerminal();
+  }
   if (handoffError) {
     throw handoffError;
   }
@@ -426,10 +416,7 @@ async function executeWorkerTurn(params: {
 }
 
 export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLauncherOptions) {
-  const activeWorkerTurns = new Map<
-    string,
-    { claim: WorkerSessionTurnClaim; signal: AbortSignal }
-  >();
+  const activeWorkerTurns = new Map<string, ActiveWorkerTurn>();
   const provider: SessionPlacementAdmissionProvider & {
     resolveSandbox(params: {
       agentId: string;
@@ -439,6 +426,12 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
       workspaceDir: string;
     }): Promise<SandboxContext | null>;
   } = {
+    recoverTerminalTurn(session) {
+      const active = activeWorkerTurns.get(session.sessionId);
+      return active && (!session.sessionKey || active.sessionKey === session.sessionKey)
+        ? active.recoverTerminal?.()
+        : undefined;
+    },
     async resolveSandbox(params) {
       const placement = options.placements.get(params.sessionId);
       if (
@@ -576,7 +569,7 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
           isCancellationRequested: (activeClaim) => {
             const active = activeWorkerTurns.get(activeClaim.sessionId);
             return Boolean(
-              active?.signal.aborted && sameWorkerSessionTurnClaim(active.claim, activeClaim),
+              active?.signal?.aborted && sameWorkerSessionTurnClaim(active.claim, activeClaim),
             );
           },
           ...(turn.abortSignal ? { signal: turn.abortSignal } : {}),
@@ -584,14 +577,14 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
         placement = admitted.placement;
         turnClaim = admitted.turnClaim;
       }
-      const activeWorkerTurn =
-        !remoteExec && turn.abortSignal
-          ? { claim: turnClaim, signal: turn.abortSignal }
-          : undefined;
+      const activeWorkerTurn: ActiveWorkerTurn | undefined = !remoteExec
+        ? { claim: turnClaim, sessionKey: placement.sessionKey, signal: turn.abortSignal }
+        : undefined;
       if (activeWorkerTurn) {
         activeWorkerTurns.set(turnClaim.sessionId, activeWorkerTurn);
       }
       let handedOff = false;
+      let terminalAtMs: number | undefined;
       try {
         // Release queue protection only after the placement claim is durable.
         onAdmitted?.();
@@ -599,6 +592,9 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
           environments: options.environments,
           onHandoff: () => {
             handedOff = true;
+          },
+          onTerminal: () => {
+            terminalAtMs = Date.now();
           },
           placement,
           placements: options.placements,
@@ -698,6 +694,16 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
             placement,
             turnClaim,
             error,
+            ...(activeWorkerTurn && terminalAtMs !== undefined
+              ? {
+                  terminal: {
+                    observedAtMs: terminalAtMs,
+                    registerRecovery: (recover: () => string | undefined) => {
+                      activeWorkerTurn.recoverTerminal = recover;
+                    },
+                  },
+                }
+              : {}),
           });
         } else {
           await releaseClaimIfOwned(options.placements, turnClaim);

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -303,6 +303,7 @@ async function executeWorkerTurn(params: {
     plan,
     turnClaim: params.turnClaim,
     timeoutMs: turn.timeoutMs,
+    credentialExpiresAtMs: credential.expiresAtMs,
     signal: turn.abortSignal
       ? AbortSignal.any([turn.abortSignal, handoffAbort.signal])
       : handoffAbort.signal,

--- a/src/gateway/worker-environments/worker-turn-payload.ts
+++ b/src/gateway/worker-environments/worker-turn-payload.ts
@@ -35,6 +35,7 @@ import {
   toWorkerTranscriptMessage,
   type WorkerProviderReplayUnavailable,
 } from "../../worker/transcript-message.js";
+import { parseWorkerAdmissionDeadlineResult } from "../../worker/worker-connection-contract.js";
 import type { WorkerRuntimeResult } from "../../worker/worker.runtime.js";
 import {
   measureAgentRuntimeIdentityTokenBytes,
@@ -238,12 +239,18 @@ function fitLaunchDescriptor(
   }
 }
 
-export function parseRuntimeResult(stdout: string): WorkerRuntimeResult {
+type StartedWorkerRuntimeResult = Exclude<WorkerRuntimeResult, { status: "not-started" }>;
+
+export function parseRuntimeResult(stdout: string): StartedWorkerRuntimeResult {
   let value: unknown;
   try {
     value = JSON.parse(stdout.trim()) as unknown;
   } catch (error) {
     throw new Error("Worker process returned invalid output", { cause: error });
+  }
+  const admissionFailure = parseWorkerAdmissionDeadlineResult(value);
+  if (admissionFailure) {
+    throw new Error(admissionFailure.errorText);
   }
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("Worker process returned invalid output");
@@ -260,7 +267,7 @@ export function parseRuntimeResult(stdout: string): WorkerRuntimeResult {
       ["status", "reason", "transcriptLeafId", "transcriptNextSeq"].includes(key),
     )
   ) {
-    return result as WorkerRuntimeResult;
+    return result as StartedWorkerRuntimeResult;
   }
   if (
     result.status === "completed" &&
@@ -272,14 +279,14 @@ export function parseRuntimeResult(stdout: string): WorkerRuntimeResult {
       ["status", "transcriptLeafId", "transcriptNextSeq"].includes(key),
     )
   ) {
-    return result as WorkerRuntimeResult;
+    return result as StartedWorkerRuntimeResult;
   }
   if (
     result.status === "fenced" &&
     (result.reason === "credential-replaced" || result.reason === "owner-epoch-mismatch") &&
     Object.keys(result).every((key) => ["status", "reason"].includes(key))
   ) {
-    return result as WorkerRuntimeResult;
+    return result as StartedWorkerRuntimeResult;
   }
   throw new Error("Worker process returned invalid output");
 }

--- a/src/gateway/worker-environments/workspace-reconcile.test.ts
+++ b/src/gateway/worker-environments/workspace-reconcile.test.ts
@@ -480,10 +480,13 @@ describe("worker workspace reconciliation", () => {
     });
 
     expect(cleanupRef).toBe(cleanupWorkerWorkspaceResultRef(stagedResultRef));
-    await deleteWorkerWorkspaceResultCleanupRefs({
+    const retainedRefs = new Set<string>();
+    const cleanup = deleteWorkerWorkspaceResultCleanupRefs({
       root: local,
-      retainedRefs: new Set([cleanupRef]),
+      retainedRefs: () => retainedRefs,
     });
+    retainedRefs.add(cleanupRef);
+    await cleanup;
     await expect(
       hasWorkerWorkspaceResultRef({ root: local, stagedResultRef: cleanupRef }),
     ).resolves.toBe(true);

--- a/src/gateway/worker-environments/workspace-result-staging.ts
+++ b/src/gateway/worker-environments/workspace-result-staging.ts
@@ -672,7 +672,7 @@ export async function restoreStagedWorkerWorkspaceResultFromCleanup(params: {
 
 export async function deleteWorkerWorkspaceResultCleanupRefs(params: {
   root: string;
-  retainedRefs?: ReadonlySet<string>;
+  retainedRefs?: () => ReadonlySet<string>;
 }): Promise<void> {
   const root = await fs.realpath(params.root);
   const output = await requireGit(root, [
@@ -680,9 +680,13 @@ export async function deleteWorkerWorkspaceResultCleanupRefs(params: {
     "--format=%(refname)",
     `${WORKER_RESULT_CLEANUP_REF_PREFIX}/`,
   ]);
-  for (const cleanupRef of output.split("\n").filter(Boolean)) {
+  const cleanupRefs = output.split("\n").filter(Boolean);
+  // A post-start turn can stage a result during the Git scan. Read its fence
+  // after inventory; later claims cannot appear in these immutable claim refs.
+  const retainedRefs = cleanupRefs.length > 0 ? params.retainedRefs?.() : undefined;
+  for (const cleanupRef of cleanupRefs) {
     requireWorkerResultStorageRef(cleanupRef);
-    if (!params.retainedRefs?.has(cleanupRef)) {
+    if (!retainedRefs?.has(cleanupRef)) {
       await requireGit(root, ["update-ref", "-d", cleanupRef]);
     }
   }

--- a/src/logging/diagnostic-session-recovery.ts
+++ b/src/logging/diagnostic-session-recovery.ts
@@ -81,6 +81,12 @@ export type StuckSessionRecoveryOutcome =
       action: "none";
       reason: "exception";
       error: string;
+    })
+  | (DiagnosticSessionRecoveryBaseOutcome & {
+      status: "failed";
+      action: "fail_worker_turn";
+      reason: "terminal_worker";
+      error: string;
     });
 
 export function recoveryOutcomeClearsQueuedSessionState(

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -10,6 +10,7 @@ import {
   resolveActiveEmbeddedRunHandleSessionId,
   resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
 } from "../agents/embedded-agent-runner/runs.js";
+import { recoverTerminalSessionPlacementTurn } from "../agents/session-placement-admission.js";
 import {
   getCommandLaneActiveTaskIds,
   getCommandLaneSnapshot,
@@ -147,6 +148,24 @@ export async function recoverStuckDiagnosticSession(
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
       };
+    }
+    const terminalWorkerError = params.sessionId
+      ? recoverTerminalSessionPlacementTurn({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+        })
+      : undefined;
+    if (terminalWorkerError !== undefined) {
+      // The placement owner already recorded failure and released its cleanup wait.
+      // Let ordinary turn completion unwind the reply and lane instead of resetting them.
+      return reportRecoveryOutcome({
+        status: "failed",
+        action: "fail_worker_turn",
+        reason: "terminal_worker",
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        error: terminalWorkerError,
+      });
     }
     const fallbackActiveSessionId =
       params.sessionId && isEmbeddedAgentRunHandleActive(params.sessionId)

--- a/src/node-host/node-worker-supervisor.admission.test.ts
+++ b/src/node-host/node-worker-supervisor.admission.test.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../../packages/gateway-protocol/src/client-info.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { NodeWorkerSupervisorTransport } from "../gateway/node-registry-private.js";
+import { createNodeWorkerLaunchAdapter } from "../gateway/worker-environments/node-launch-adapter.js";
+import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../infra/node-runner-inventory.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  parseNodeWorkerLaunchInput,
+  projectNodeWorkerSupervisorReceipt,
+} from "./node-worker-supervisor-contract.js";
+import { createNodeWorkerSupervisor } from "./node-worker-supervisor.js";
+import {
+  TEST_WORKER_ENDPOINT,
+  testWorkerLaunchInput,
+  writeNodeWorkerFixture,
+} from "./node-worker-supervisor.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(closeOpenClawStateDatabaseForTest);
+
+describe("node worker admission re-arm journal", () => {
+  it("retains each child's reason and replays the same attempts after supervisor restart", async () => {
+    const fixture = writeNodeWorkerFixture(tempDirs.make("node-admission-journal-"));
+    let supervisor = createNodeWorkerSupervisor(fixture);
+    const launchIds = new Set<string>();
+    const transport: NodeWorkerSupervisorTransport = {
+      isCurrent: () => true,
+      hasCurrentRunner: () => true,
+      listCurrentNodes: async () => [
+        {
+          nodeId: "node-1",
+          connId: "conn-1",
+          pairingIdentity: "identity-1",
+          pairingGeneration: "generation-1",
+          clientId: GATEWAY_CLIENT_IDS.NODE_HOST,
+          clientMode: GATEWAY_CLIENT_MODES.NODE,
+          protocolFeature: NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
+          workerHost: { enabled: true, capacity: { total: 1, available: 1 } },
+          commands: [],
+        },
+      ],
+      invoke: async (request) => {
+        let receipt;
+        if (request.command === "worker.launch.v1") {
+          const input = parseNodeWorkerLaunchInput(JSON.stringify(request.params));
+          launchIds.add(input.launchId);
+          request.onDispatchReady?.("invoke-1");
+          receipt = await supervisor.launch(input, TEST_WORKER_ENDPOINT);
+        } else if (request.command === "worker.status.v1") {
+          receipt = await supervisor.status((request.params as { launchId: string }).launchId);
+        } else {
+          throw new Error("unexpected cancellation");
+        }
+        return {
+          ok: true,
+          payloadJSON: JSON.stringify(receipt ? projectNodeWorkerSupervisorReceipt(receipt) : null),
+        };
+      },
+    };
+    const request = {
+      deviceId: "node-1",
+      input: testWorkerLaunchInput(fixture.workspaceDir, "admission-launch", "admission-rearm"),
+      isDispatchAuthorized: () => true,
+      isCancellationAuthorized: () => true,
+      timeoutMs: 10_000,
+    };
+    const createAdapter = () =>
+      createNodeWorkerLaunchAdapter({ getTransport: () => transport, pollIntervalMs: 10 });
+    try {
+      const completed = await createAdapter().launch(request);
+      expect(completed).toMatchObject({
+        state: "completed",
+        resultJson: JSON.stringify({
+          status: "completed",
+          transcriptLeafId: "leaf-1",
+          transcriptNextSeq: 2,
+        }),
+      });
+      expect(launchIds.size).toBe(2);
+      const first = await supervisor.status(request.input.launchId);
+      expect(JSON.parse(first?.resultJson ?? "null")).toEqual({
+        status: "not-started",
+        reason: "admission-deadline",
+        errorText: "gateway unreachable [REDACTED]",
+      });
+      expect(first?.completedAtMs).not.toBeNull();
+      const marker = path.join(fixture.workspaceDir, "admission-attempt");
+      expect(fs.readFileSync(marker, "utf8")).toBe(completed.launchId);
+      await supervisor.close();
+      supervisor = createNodeWorkerSupervisor(fixture);
+      expect(await createAdapter().launch(request)).toEqual(completed);
+      expect(fs.readFileSync(marker, "utf8")).toBe(completed.launchId);
+      expect(launchIds.size).toBe(2);
+    } finally {
+      await supervisor.close();
+    }
+  });
+});

--- a/src/node-host/node-worker-supervisor.test-support.ts
+++ b/src/node-host/node-worker-supervisor.test-support.ts
@@ -84,7 +84,14 @@ const writeResultAndExit = (value) => {
   exitWorker(0);
 };
 const mode = descriptor.assignment.prompt;
-if (mode === "connection-failure" || mode === "connection-deadline") {
+if (mode === "admission-rearm") {
+  const marker = path.join(descriptor.assignment.workspaceDir, "admission-attempt");
+  const first = !fs.existsSync(marker);
+  fs.writeFileSync(marker, descriptor.assignment.turnId);
+  writeResultAndExit(JSON.stringify(first
+    ? { status: "not-started", reason: "admission-deadline", errorText: "gateway unreachable " + descriptor.admission.credential }
+    : { status: "completed", transcriptLeafId: "leaf-1", transcriptNextSeq: 2 }) + "\n");
+} else if (mode === "connection-failure" || mode === "connection-deadline") {
   const target = new URL(descriptor.connectionEndpoint.url).host;
   const report = (cause) => new Promise((resolve) => process.send(
     { type: "openclaw-worker-connection-failure-v1", cause }, resolve,

--- a/src/worker/worker-connection-contract.ts
+++ b/src/worker/worker-connection-contract.ts
@@ -1,4 +1,5 @@
 import { toStructuredErrorObject } from "@openclaw/normalization-core/error-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { ClientOptions, WebSocket } from "ws";
 import type {
@@ -80,6 +81,32 @@ export class WorkerAdmissionDeadlineExceededError extends Error {
     super(diagnosis);
     this.name = "WorkerAdmissionDeadlineExceededError";
   }
+}
+
+// Only the initial admission boundary can author this result. A reconnect deadline
+// after execution started cannot prove that replaying the turn is safe.
+export type WorkerAdmissionDeadlineResult = {
+  status: "not-started";
+  reason: "admission-deadline";
+  errorText: string;
+};
+
+export function parseWorkerAdmissionDeadlineResult(
+  value: unknown,
+): WorkerAdmissionDeadlineResult | undefined {
+  if (
+    isRecord(value) &&
+    Object.keys(value).length === 3 &&
+    value.status === "not-started" &&
+    value.reason === "admission-deadline" &&
+    typeof value.errorText === "string" &&
+    value.errorText.length > 0 &&
+    Buffer.byteLength(value.errorText, "utf8") <= 4_096 &&
+    !/[\r\n\0]/u.test(value.errorText)
+  ) {
+    return { status: value.status, reason: value.reason, errorText: value.errorText };
+  }
+  return undefined;
 }
 
 export class WorkerFencedError extends Error {

--- a/src/worker/worker-connection-contract.ts
+++ b/src/worker/worker-connection-contract.ts
@@ -76,6 +76,10 @@ export class WorkerAdmissionError extends Error {
   }
 }
 
+// One worker admission window; the launch adapter also uses it to cap re-arms
+// within the minted credential's lifetime.
+export const WORKER_ADMISSION_DEADLINE_MS = 120_000;
+
 export class WorkerAdmissionDeadlineExceededError extends Error {
   constructor(diagnosis: string) {
     super(diagnosis);

--- a/src/worker/worker-connection.ts
+++ b/src/worker/worker-connection.ts
@@ -33,6 +33,7 @@ import {
   isRetryableWorkerCloseReason,
 } from "./worker-connection-admission.js";
 import {
+  WORKER_ADMISSION_DEADLINE_MS,
   WorkerAdmissionDeadlineExceededError,
   WorkerAdmissionError,
   WorkerConnectionInterruptedError,
@@ -61,7 +62,6 @@ const DEFAULT_RECONNECT_BACKOFF: BackoffPolicy = {
 };
 
 const DEFAULT_ADMISSION_TIMEOUT_MS = DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
-const DEFAULT_ADMISSION_DEADLINE_MS = 120_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const WORKER_SESSION_SPAWN_TIMEOUT_MS = 15 * 60_000;
 const WORKER_SESSION_SEND_TIMEOUT_SLACK_MS = 60_000;
@@ -97,7 +97,7 @@ export class WorkerConnection {
     );
     this.admissionDeadlineMs = resolvePositiveTimeout(
       options.admissionDeadlineMs,
-      DEFAULT_ADMISSION_DEADLINE_MS,
+      WORKER_ADMISSION_DEADLINE_MS,
     );
     this.requestTimeoutMs = resolvePositiveTimeout(
       options.requestTimeoutMs,

--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -1283,6 +1283,64 @@ describe("worker runtime", () => {
     expect(gateway.connectionCount).toBe(1);
   });
 
+  it.each(["initial admission", "running turn"] as const)(
+    "marks only an initial admission deadline as safe to re-arm: %s",
+    async (phase) => {
+      const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-worker-admission-"));
+      tempDirs.push(workspaceDir);
+      const launch = descriptor(path.join(workspaceDir, "gateway.sock"), workspaceDir);
+      const connection = createWorkerConnection({
+        endpoint: launch.connectionEndpoint,
+        connectParams: buildWorkerConnectParams(launch),
+      });
+      const deadline = new WorkerAdmissionDeadlineExceededError();
+      const start = vi.spyOn(connection, "start");
+      if (phase === "initial admission") {
+        start.mockRejectedValue(deadline);
+      } else {
+        start.mockResolvedValue({
+          type: "worker-hello-ok",
+          environmentId: launch.admission.environmentId,
+          sessionId: SESSION_ID,
+          ownerEpoch: OWNER_EPOCH,
+          rpcSetVersion: WORKER_RPC_SET_VERSION,
+          protocolFeatures: [...WORKER_PROTOCOL_FEATURES],
+          credentialExpiresAtMs: Date.now() + 60_000,
+          policy: { heartbeatIntervalMs: 60_000, maxPayload: 25 * 1024 * 1024 },
+        });
+      }
+      const connectionModule = await import("./worker-connection.js");
+      const factory = vi
+        .spyOn(connectionModule, "createWorkerConnection")
+        .mockImplementation((options) => {
+          options.onConnectionFailure?.(new Error("connect ECONNREFUSED"));
+          return connection;
+        });
+      const embeddedRuntime = await import("./embedded-agent.runtime.js");
+      const runTurn = vi
+        .spyOn(embeddedRuntime, "runWorkerEmbeddedTurn")
+        .mockRejectedValue(deadline);
+      try {
+        if (phase === "initial admission") {
+          await expect(runWorkerDescriptor(launch)).resolves.toEqual({
+            status: "not-started",
+            reason: "admission-deadline",
+            errorText: expect.stringContaining("connect ECONNREFUSED"),
+          });
+          expect(runTurn).not.toHaveBeenCalled();
+        } else {
+          await expect(runWorkerDescriptor(launch)).rejects.toBe(deadline);
+          expect(runTurn).toHaveBeenCalledOnce();
+        }
+      } finally {
+        runTurn.mockRestore();
+        factory.mockRestore();
+        start.mockRestore();
+        await connection.stop();
+      }
+    },
+  );
+
   it("exits cleanly when admission observes a superseded owner epoch", async () => {
     const { launch } = await setup({ admissionFailure: "owner-epoch-mismatch" });
 

--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -1293,7 +1293,11 @@ describe("worker runtime", () => {
         endpoint: launch.connectionEndpoint,
         connectParams: buildWorkerConnectParams(launch),
       });
-      const deadline = new WorkerAdmissionDeadlineExceededError();
+      // Production formats the last failure into the deadline message
+      // (WorkerConnection.failAdmissionDeadline); model that here.
+      const deadline = new WorkerAdmissionDeadlineExceededError(
+        "no admission after 3 attempts to gateway.sock: connect ECONNREFUSED",
+      );
       const start = vi.spyOn(connection, "start");
       if (phase === "initial admission") {
         start.mockRejectedValue(deadline);

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -10,7 +10,6 @@ import { registerSecretValueForRedaction } from "../logging/secret-redaction-reg
 import type { WorkerBrowserRuntime } from "./browser-runtime.js";
 import { buildWorkerConnectParams, type WorkerLaunchDescriptor } from "./launch-descriptor.js";
 import {
-  formatWorkerConnectionFailure,
   WorkerAdmissionDeadlineExceededError,
   type WorkerAdmissionDeadlineResult,
 } from "./worker-connection-contract.js";
@@ -98,12 +97,10 @@ export async function runWorkerDescriptor(
   let turnStarted = false;
   let resultFenceAcked = false;
   let forcedStopTimer: NodeJS.Timeout | undefined;
-  let lastConnectionFailure: Error | undefined;
   const connection = createWorkerConnection({
     endpoint: descriptor.connectionEndpoint,
     connectParams: buildWorkerConnectParams(descriptor),
     onConnectionFailure: (error) => {
-      lastConnectionFailure = error;
       options.onConnectionFailure?.(error?.message);
     },
   });
@@ -153,10 +150,9 @@ export async function runWorkerDescriptor(
         return {
           status: "not-started",
           reason: "admission-deadline",
-          errorText: `${error.message}: ${formatWorkerConnectionFailure(
-            descriptor.connectionEndpoint,
-            lastConnectionFailure ?? error,
-          )}`,
+          // The deadline error message already carries the formatted, redacted
+          // last-failure diagnosis (see WorkerConnection.failAdmissionDeadline).
+          errorText: error.message,
         };
       }
       throw error;

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -9,6 +9,11 @@ import { isPathInside } from "../infra/path-guards.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import type { WorkerBrowserRuntime } from "./browser-runtime.js";
 import { buildWorkerConnectParams, type WorkerLaunchDescriptor } from "./launch-descriptor.js";
+import {
+  formatWorkerConnectionFailure,
+  WorkerAdmissionDeadlineExceededError,
+  type WorkerAdmissionDeadlineResult,
+} from "./worker-connection-contract.js";
 import { createWorkerConnection, type WorkerConnectionState } from "./worker-connection.js";
 import {
   WorkerInferenceProxyClient,
@@ -19,6 +24,7 @@ import {
 // Cross-process contract: serialized to stdout by runWorkerCommand and parsed by the
 // gateway worker turn launcher.
 export type WorkerRuntimeResult =
+  | WorkerAdmissionDeadlineResult
   | { status: "completed"; transcriptLeafId: string | null; transcriptNextSeq: number }
   | {
       status: "failed";
@@ -92,10 +98,14 @@ export async function runWorkerDescriptor(
   let turnStarted = false;
   let resultFenceAcked = false;
   let forcedStopTimer: NodeJS.Timeout | undefined;
+  let lastConnectionFailure: Error | undefined;
   const connection = createWorkerConnection({
     endpoint: descriptor.connectionEndpoint,
     connectParams: buildWorkerConnectParams(descriptor),
-    onConnectionFailure: (error) => options.onConnectionFailure?.(error?.message),
+    onConnectionFailure: (error) => {
+      lastConnectionFailure = error;
+      options.onConnectionFailure?.(error?.message);
+    },
   });
   const abortFromCaller = () => {
     abortController.abort(options.signal?.reason);
@@ -138,6 +148,16 @@ export async function runWorkerDescriptor(
       const fenced = fencedResult(connection.state);
       if (fenced) {
         return fenced;
+      }
+      if (error instanceof WorkerAdmissionDeadlineExceededError && !options.signal?.aborted) {
+        return {
+          status: "not-started",
+          reason: "admission-deadline",
+          errorText: `${error.message}: ${formatWorkerConnectionFailure(
+            descriptor.connectionEndpoint,
+            lastConnectionFailure ?? error,
+          )}`,
+        };
       }
       throw error;
     }


### PR DESCRIPTION
## What Problem This Solves

Three lifecycle defects proven live in the 50-worker farm campaign (#129979):

1. **Worker mortality asymmetry:** on a transient network flap the node host retries its own gateway WS forever and recovers, but each worker child dies at one fixed 120s admission deadline — the launch adapter's replacement dies the same way, so a brief partition killed every in-flight turn while the node looked healthy.
2. **Stuck turns never terminalize:** gateway diagnostics logged `stuck session recovery: status=skipped action=keep_lane` every cycle for 25+ minutes over provably dead workers; turns only ended via caller timeouts.
3. **Startup over placement debris:** a gateway restart above ~50 failed placements hung startup recovery for many minutes doing per-placement git cleanup before readiness.

## Why This Change Was Made

- **Bounded admission re-arm at the launch owner:** when the node's launch journal proves the child died on the admission deadline specifically (parsed result, not string matching), the gateway launch adapter re-arms the launch — up to five attempts (~10 minutes of 120s windows), exponential backoff with jitter, always capped by the caller's deadline. Deterministic derived launch/turn ids mean an adapter replay finds the same journal rows and never spawns a duplicate child for a completed retry. Credential/build rejections and post-start failures remain immediately terminal; every attempt's reason is journaled.
- **Terminalization with a grace:** once a worker is journal-terminal with no live claim past a 30s cleanup grace, stuck-turn recovery records a terminal turn failure (drain + recorded reason) instead of `keep_lane` forever. Genuinely live slow turns are untouched — the predicate requires journal-terminal + claim-free + grace elapsed, revalidated against the exact drain generation.
- **Debris off the readiness path:** orphan git cleanup for already-terminal placements moves into the first tracked background sweep; pending-result recovery and ownership fences stay ahead of readiness. Fixture with 50 failed placements: startup git scans 50 → 0, ~556ms → ~5ms.

## User Impact

A farm node surviving a network blip finishes its turns instead of burying them; dead-worker turns fail visibly within seconds, not after 25-minute waits; gateways restart promptly even after a bad night of failed placements.

## Evidence

All regressions verified failing pre-fix (re-arm on admission-deadline with journaled attempts and terminal-rejection immediacy; grace-gated terminalization vs. live-turn preservation; deferred-cleanup ordering with fences ahead of readiness). Focused suites green: launcher (67), supervisor child processes, journal replay, runtime admission, diagnostics; `pnpm check:changed` green; Codex autoreview clean (0.94). Two failing tests in unchanged files (`config.test.ts` subprocess startup, `workspace-sync-scripts.test.ts` quiescence fixtures) reproduce on clean `origin/main` — pre-existing, not introduced here. Production +229, tests/support +544; no schema/config changes. A combined live rig run with the reconciliation lane follows before the campaign closes.

Context: openclaw/openclaw#129979
