### PR TITLE
fix(cli): reject --agent for global model refresh

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -28,7 +28,7 @@ openclaw models set-image <model-or-alias>
 openclaw models scan
 ```
 
-`status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`, `set-image`, `scan`, and `aliases` reject `--agent` outright because they are global and never agent-scoped. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
+`status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`, `set-image`, `scan`, `refresh`, and `aliases` reject `--agent` outright because they are global and never agent-scoped. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
 
 `models set` and `models set-image` require the provider to be declared by an installed plugin or configured under `models.providers`. An unknown provider exits nonzero without changing config. If the provider is known but the model is absent from the local catalog, the command saves the selection and prints a warning because newly released and self-hosted models may not be cataloged yet. `openclaw doctor --json` reports configured unknown providers; add `--severity-min info` to also see active models that the local catalog cannot confirm.
 
@@ -73,7 +73,7 @@ For OpenAI ChatGPT/Codex OAuth troubleshooting, `openclaw models status`, `openc
 
 `openclaw models list` is read-only: it reads config, auth profiles, existing catalog state, and provider-owned catalog rows, but never rewrites `models.json`.
 
-`openclaw models refresh [--json]` forces an immediate hosted catalog check.
+`openclaw models refresh [--json]` forces an immediate hosted catalog check. Like `scan`, it rejects `--agent` because the hosted catalog is global, not agent-scoped.
 Updated rows apply to a running Gateway after its next restart. The command
 prints a clear disabled result when `models.catalogRefresh.enabled` is `false`.
 The catalog's public change history lives in

--- a/src/cli/models-cli.runtime.ts
+++ b/src/cli/models-cli.runtime.ts
@@ -27,7 +27,8 @@ export type GlobalOnlyModelCommandName =
   | "scan"
   | "aliases list"
   | "aliases add"
-  | "aliases remove";
+  | "aliases remove"
+  | "refresh";
 
 export function rejectAgentScopedModelCommand(
   command: Command,

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   modelsStatusCommand: vi.fn().mockResolvedValue(undefined),
   modelsSetCommand: vi.fn().mockResolvedValue(undefined),
   modelsSetImageCommand: vi.fn().mockResolvedValue(undefined),
+  modelsRefreshCommand: vi.fn().mockResolvedValue(undefined),
   noopAsync: vi.fn(async () => undefined),
   modelsAliasesAddCommand: vi.fn().mockResolvedValue(undefined),
   modelsAliasesListCommand: vi.fn().mockResolvedValue(undefined),
@@ -42,6 +43,7 @@ const {
   modelsAuthPasteApiKeyCommand,
   modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand,
+  modelsRefreshCommand,
   modelsScanCommand,
   modelsSetCommand,
   modelsSetImageCommand,
@@ -98,6 +100,9 @@ vi.mock("../commands/models/set.js", () => ({
 vi.mock("../commands/models/set-image.js", () => ({
   modelsSetImageCommand: mocks.modelsSetImageCommand,
 }));
+vi.mock("../commands/models/refresh.js", () => ({
+  modelsRefreshCommand: mocks.modelsRefreshCommand,
+}));
 
 describe("models cli", () => {
   beforeEach(() => {
@@ -105,6 +110,7 @@ describe("models cli", () => {
     modelsAliasesAddCommand.mockClear();
     modelsAliasesListCommand.mockClear();
     modelsAliasesRemoveCommand.mockClear();
+    modelsRefreshCommand.mockClear();
     modelsScanCommand.mockClear();
     modelsAuthAddCommand.mockClear();
     modelsAuthListCommand.mockClear();
@@ -582,6 +588,11 @@ describe("models cli", () => {
       args: ["models", "--agent", "poe", "scan", "--no-probe", "--no-input"],
       command: modelsScanCommand,
     },
+    {
+      label: "refresh",
+      args: ["models", "--agent", "poe", "refresh"],
+      command: modelsRefreshCommand,
+    },
   ])("rejects parent --agent for models $label", async ({ args, command }) => {
     await expect(runModelsCommand(args)).rejects.toThrow("does not support --agent");
 
@@ -598,6 +609,11 @@ describe("models cli", () => {
       label: "scan",
       args: ["models", "scan", "--no-probe", "--no-input"],
       command: modelsScanCommand,
+    },
+    {
+      label: "refresh",
+      args: ["models", "refresh"],
+      command: modelsRefreshCommand,
     },
   ])("still runs models $label without --agent", async ({ args, command }) => {
     await runModelsCommand(args);

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -131,10 +131,12 @@ export function registerModelsCli(program: Command) {
     .command("refresh")
     .description("Refresh the hosted model catalog")
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (opts, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(command, "refresh");
+      await runtime.runModelsCommand(async () => {
         const { modelsRefreshCommand } = await import("../commands/models/refresh.js");
-        await modelsRefreshCommand({ json: hasJsonOutput(opts) }, defaultRuntime);
+        await modelsRefreshCommand({ json: hasJsonOutput(opts) }, runtime.defaultRuntime);
       });
     });
 


### PR DESCRIPTION
## What Problem This Solves

`models refresh` updates the global hosted model catalog. It has no agent input
and writes no per-agent configuration, but `openclaw models --agent <id>
refresh` silently accepted the inherited parent option and ran the global
operation. That made an operator-visible scope claim the command did not honor.

## Why This Change Was Made

The CLI registration layer owns this scope contract. This PR adds `refresh` to
the existing closed set of global-only model commands and runs the same
pre-dispatch `rejectAgentScopedModelCommand` guard already used by `set`,
`set-image`, `aliases`, and `scan`.

The normal unscoped path is unchanged. No new configuration, compatibility
shim, storage, protocol, dependency, or provider behavior is introduced.

## User Impact

- `openclaw models --agent <id> refresh` now exits nonzero with an actionable
  global-scope error before catalog refresh dispatch.
- `openclaw models refresh --agent <id>` remains a parser error because the
  leaf command does not expose that option.
- `openclaw models refresh` continues to dispatch normally.

Compatibility note: scripts that previously supplied the ignored parent
`--agent` option will now fail intentionally instead of silently performing a
global refresh. Remove `--agent` from those invocations.

## Evidence

Exact reviewed head: `1ef98b97943de52e233268d3312259778994ce8f`.

Secretless built-CLI proof used isolated state, disabled catalog refresh, and a
network namespace with no routes:

```text
network_namespace_routes=none

current main: models --agent proof refresh
exit=0
Remote catalog refresh is disabled (models.catalogRefresh.enabled=false)

exact PR head: models --agent proof refresh
exit=1
openclaw models refresh does not support --agent; it is global and never agent-scoped.

exact PR head: models refresh --agent proof
exit=1
OpenClaw does not recognize option "--agent".

exact PR head: models refresh
exit=0
Remote catalog refresh is disabled (models.catalogRefresh.enabled=false)
```

- Current-main red plus both exact-head rejection paths:
  https://github.com/vincentkoc/openclaw/actions/runs/33043633517
- Exact-head parent, leaf, unscoped, network-isolation, and focused-test proof:
  https://github.com/vincentkoc/openclaw/actions/runs/33044537772
- Exact-head OpenClaw CI, including `openclaw/ci-gate`:
  https://github.com/openclaw/openclaw/actions/runs/33040336619
- Focused proof: 64 CLI tests and 7 refresh tests passed.
- Fresh high-reasoning autoreview: no accepted/actionable findings; correctness
  confidence 0.99.
- `git diff --check`: pass.

Run `33044537772` concluded failure after all behavior proof and focused tests
passed because its redundant `check-changed` invocation expected `origin/main`
while the isolated checkout configured the canonical repository as
`upstream/main`. Exact-head OpenClaw CI passed the same changed-path gates.

## Scope

- Production: `+7/-4`, net `+3`.
- Tests: `+16/-0`.
- Docs: `+2/-2`, net `0`.
- Four files changed.

The production growth is the existing guard call plus one closed-union member;
a generic wrapper refactor would add more surface for no additional capability.

## Release Note

`openclaw models --agent <id> refresh` now reports that model catalog refresh
is global instead of silently ignoring the agent scope.

AI-assisted maintainer validation; implementation and evidence were reviewed
before landing.
