### PR TITLE
fix(workers): protect in-flight workspace manifests from concurrent retention

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3430,7 +3430,7 @@ src/node-host/node-worker-supervisor.ts	1
 src/node-host/node-worker-transfer-client.ts	3
 src/node-host/node-worker-transfer-http.ts	2
 src/node-host/node-worker-tree-control.ts	2
-src/node-host/node-worker-workspace.ts	7
+src/node-host/node-worker-workspace.ts	6
 src/node-host/plugin-node-host.ts	1
 src/node-host/pty-command.ts	11
 src/node-host/runtime.ts	2

--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -368,6 +368,8 @@ unsynced-file and in-flight-work loss boundary as the Control UI confirmation.
 
 Placement moves through a durable state machine (`local → requested → provisioning → syncing → starting → active`), so a Gateway restart mid-dispatch reconciles instead of leaking machines. A failed model turn keeps the active placement available for a retry. Workspace path conflicts keep the local version, apply the rest of the cloud result, and preserve the staged cloud ref for inspection; other reconciliation or lifecycle failures retain their durable recovery fence and diagnostic tail until recovery can safely retry or reclaim the environment.
 
+If a turn reports `Cloud worker finished, but its workspace result could not be reconciled`, inspect the cause after the colon. A failed node manifest capture includes its bounded, redacted stderr, or its termination status when stderr is empty. Node cleanup preserves manifests needed between upload and verification, including when other workers finish simultaneously; increasing transfer timeouts does not repair a missing manifest.
+
 ## What survives a dead machine
 
 The Gateway owns the canonical session transcript in both modes. Worker-turn commits each complete user, assistant, and tool-result message before the worker's session write settles; remote-exec uses the normal local harness transcript path because the Codex app-server stays on the Gateway. If the machine disappears mid-message, durable history ends at the last committed message. Partial text or tool progress already shown by the live stream may disappear; the failed turn remains visible, and the failed placement records a bounded terminal reason above the composer.

--- a/src/gateway/worker-environments/node-worker-tunnel.test-support.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test-support.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../packages/gateway-protocol/src/client-info.js";
 import { WORKER_PROTOCOL_FEATURES } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../../infra/node-runner-inventory.js";
+import type { SpawnResult } from "../../process/exec.js";
 import type { NodeWorkerSupervisorTransport } from "../node-registry-private.js";
 import type { NodeWorkspaceTransferService } from "./node-workspace-transfer-service.js";
 import type { WorkerEnvironmentRecord } from "./store.js";
@@ -78,4 +79,17 @@ export function workspaceTransfer(): NodeWorkspaceTransferService {
     close: vi.fn(async () => {}),
     revoke: vi.fn(),
   } as unknown as NodeWorkspaceTransferService;
+}
+
+export function workspaceCommandPayload(workspaceDir: string, result: Partial<SpawnResult>) {
+  return JSON.stringify({
+    workspaceDir,
+    stdout: "",
+    stderr: "",
+    code: 0,
+    signal: null,
+    killed: false,
+    termination: "exit",
+    ...result,
+  });
 }

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -21,6 +21,7 @@ import {
   environment,
   startRequest,
   transport,
+  workspaceCommandPayload,
   workspaceTransfer,
 } from "./node-worker-tunnel.test-support.js";
 import type { NodeWorkspaceTransferService } from "./node-workspace-transfer-service.js";
@@ -875,32 +876,46 @@ describe("node worker tunnel manager", () => {
     expect(manager.status("environment-1")).toBe("stopped");
   });
 
-  it("recaptures the node manifest and rejects divergence before reconciliation", async () => {
+  it.each([
+    {
+      name: "divergence",
+      result: { stdout: `sha256:${"f".repeat(64)}\n` },
+      error: "changed during final reconciliation",
+    },
+    {
+      name: "missing manifest",
+      result: {
+        code: 1,
+        stderr: "ENOENT: no such file or directory, open '/worker/manifests/result.json'\n",
+      },
+      error: "Node workspace manifest capture failed: ENOENT: no such file or directory",
+    },
+    {
+      name: "timeout without stderr",
+      result: { code: null, signal: "SIGTERM", killed: true, termination: "timeout" },
+      error: "Node workspace manifest capture failed: timeout (exit code null, signal SIGTERM)",
+    },
+    {
+      name: "invalid reference",
+      result: { stdout: "invalid\n" },
+      error: "Node workspace manifest capture failed: invalid manifest reference",
+    },
+  ] as const)("reports $name during final manifest verification", async ({ result, error }) => {
     const record = environment();
     const localPath = tempDirs.make("node-worker-verify-stable-");
     const remoteWorkspaceDir = path.join(localPath, "remote");
     await fs.mkdir(remoteWorkspaceDir);
     const raw = serializeWorkerWorkspaceManifest({ version: 1, baseCommit: null, entries: [] });
     const baseManifestRef = `sha256:${createHash("sha256").update(raw).digest("hex")}`;
-    const divergentManifestRef = `sha256:${"f".repeat(64)}`;
-    const spawnResult = (stdout: string) =>
-      JSON.stringify({
-        workspaceDir: remoteWorkspaceDir,
-        stdout,
-        stderr: "",
-        code: 0,
-        signal: null,
-        killed: false,
-        termination: "exit",
-      });
     const nodeTransport = transport();
     nodeTransport.invoke = vi.fn(async ({ params }) => {
       const input = params as { transfer?: { direction?: string } };
       return {
         ok: true,
-        payloadJSON: spawnResult(
-          input.transfer ? `${baseManifestRef}\n` : `${divergentManifestRef}\n`,
-        ),
+        payloadJSON: workspaceCommandPayload(remoteWorkspaceDir, {
+          stdout: `${baseManifestRef}\n`,
+          ...(!input.transfer ? result : {}),
+        }),
       };
     });
     const transfer = {
@@ -944,7 +959,7 @@ describe("node worker tunnel manager", () => {
         baseManifestRef,
         journal: { load: () => undefined, begin: vi.fn(), commit: vi.fn(), abort: vi.fn() },
       }),
-    ).rejects.toThrow("changed during final reconciliation");
+    ).rejects.toThrow(error);
   });
 
   it("does not republish an accepted manifest already current on the node", async () => {
@@ -954,16 +969,6 @@ describe("node worker tunnel manager", () => {
     const manifest = { version: 1 as const, baseCommit: null, entries: [] };
     const raw = serializeWorkerWorkspaceManifest(manifest);
     const baseManifestRef = `sha256:${createHash("sha256").update(raw).digest("hex")}`;
-    const spawnResult = (stdout: string) =>
-      JSON.stringify({
-        workspaceDir: remoteWorkspaceDir,
-        stdout,
-        stderr: "",
-        code: 0,
-        signal: null,
-        killed: false,
-        termination: "exit",
-      });
     const transferDirections: string[] = [];
     const nodeTransport = transport();
     const invoke = vi.fn(async ({ params }) => {
@@ -971,7 +976,12 @@ describe("node worker tunnel manager", () => {
       if (input.transfer?.direction) {
         transferDirections.push(input.transfer.direction);
       }
-      return { ok: true, payloadJSON: spawnResult(`${baseManifestRef}\n`) };
+      return {
+        ok: true,
+        payloadJSON: workspaceCommandPayload(remoteWorkspaceDir, {
+          stdout: `${baseManifestRef}\n`,
+        }),
+      };
     });
     nodeTransport.invoke = invoke;
     const publishSnapshot = vi.fn(() => "accepted-download-token");

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -46,7 +46,6 @@ import {
   type WorkerWorkspaceApplyResult,
 } from "./workspace-reconcile.js";
 import { workerWorkspaceResultStaging } from "./workspace-result-staging.js";
-import { REMOTE_WORKSPACE_MANIFEST_JS } from "./workspace-sync-scripts.js";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 60_000;
 const COMMAND_RESULT_GRACE_MS = 5_000;
@@ -321,25 +320,6 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       sharedHost: true,
       runWorkspaceCommand: async (command) => await exec(command),
     });
-    const captureManifest = async (dir: string, base: string | null, reference: string) => {
-      const captured = await exec({
-        argv: [
-          "node",
-          "-e",
-          REMOTE_WORKSPACE_MANIFEST_JS,
-          dir,
-          ...(base ? [base, "eligible"] : ["", "all"]),
-          reference.slice("sha256:".length),
-        ],
-        transportRetry: "idempotent",
-      });
-      const manifestRef = captured.stdout.trim();
-      const validRef = /^sha256:[a-f0-9]{64}$/u.test(manifestRef);
-      if (captured.termination !== "exit" || captured.code !== 0 || !validRef) {
-        throw new Error("Node workspace manifest capture failed");
-      }
-      return manifestRef;
-    };
     const validateRestoredWorkspace = async (): Promise<void> => {
       if (!restoredWorkspace) {
         return;
@@ -361,7 +341,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       }
       const quiescence = await quiesceWorkspace(restoredWorkspace.remoteWorkspaceDir);
       try {
-        const remoteManifestRef = await captureManifest(
+        const remoteManifestRef = await workspace.captureManifest(
           restoredWorkspace.remoteWorkspaceDir,
           prepared.snapshot.manifest.baseCommit,
           restoredWorkspace.manifestRef,
@@ -411,7 +391,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
         const changed = uploaded.currentManifestRef !== request.baseManifestRef;
         let expectedRemoteRef = uploaded.currentManifestRef;
         const verifyStable = async () => {
-          const observed = await captureManifest(
+          const observed = await workspace.captureManifest(
             request.remoteWorkspaceDir,
             uploaded.base.baseCommit,
             expectedRemoteRef,

--- a/src/gateway/worker-environments/node-worker-workspace-fallback.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-fallback.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { runCommandWithTimeout, type SpawnResult } from "../../process/exec.js";
 import type { WorkerWorkspaceSyncRequest, WorkerWorkspaceSyncResult } from "./tunnel-contract.js";
+import { boundedWorkerError } from "./worker-error.js";
 import {
   resolveWorkerWorkspaceGitAuthor,
   validateWorkspaceSyncRequest,
@@ -173,7 +174,34 @@ function succeeded(result: SpawnResult): boolean {
 
 /** Optional published-origin fast path; HTTPS transfer remains the canonical fallback. */
 export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
+  const capture = async (dir: string, base: string | null, reference?: string) =>
+    await exec({
+      argv: [
+        "node",
+        "-e",
+        REMOTE_WORKSPACE_MANIFEST_JS,
+        dir,
+        ...(base ? [base, "eligible"] : ["", "all"]),
+        ...(reference ? [reference.slice("sha256:".length)] : []),
+      ],
+      timeoutMs: GIT_TIMEOUT_MS,
+      transportRetry: "idempotent",
+    });
   return {
+    async captureManifest(dir: string, base: string | null, reference: string) {
+      const captured = await capture(dir, base, reference);
+      const manifestRef = captured.stdout.trim();
+      if (!succeeded(captured) || !MANIFEST_REF_PATTERN.test(manifestRef)) {
+        const detail = boundedWorkerError(
+          captured.stderr.trim() ||
+            (!succeeded(captured)
+              ? `${captured.termination} (exit code ${captured.code}, signal ${captured.signal})`
+              : "invalid manifest reference"),
+        );
+        throw new Error(`Node workspace manifest capture failed: ${detail}`);
+      }
+      return manifestRef;
+    },
     async trySyncWorkspace(
       request: WorkerWorkspaceSyncRequest,
       expectedManifestRef: string,
@@ -219,18 +247,7 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
       if (!succeeded(checkedOut) || checkedOut.workspaceDir !== cloned.workspaceDir) {
         return { kind: "fallback", reason: "checkout-failed" };
       }
-      const captured = await exec({
-        argv: [
-          "node",
-          "-e",
-          REMOTE_WORKSPACE_MANIFEST_JS,
-          checkedOut.workspaceDir,
-          identity.commit,
-          "eligible",
-        ],
-        timeoutMs: GIT_TIMEOUT_MS,
-        transportRetry: "idempotent",
-      });
+      const captured = await capture(checkedOut.workspaceDir, identity.commit);
       const manifestRef = captured.stdout.trim();
       if (!succeeded(captured) || !MANIFEST_REF_PATTERN.test(manifestRef)) {
         return { kind: "fallback", reason: "manifest-capture-failed" };

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
@@ -94,6 +94,7 @@ function createHarness(
   params: {
     environments?: unknown[];
     placements?: unknown[];
+    pendingResults?: ReturnType<WorkerSessionPlacementStore["listPendingWorkspaceResults"]>;
     results?: Array<{
       applied: boolean;
       deleted: number;
@@ -145,7 +146,8 @@ function createHarness(
     } as Pick<WorkerEnvironmentService, "list">,
     placements: {
       list: () => (params.placements ?? [placement()]) as never,
-    } as Pick<WorkerSessionPlacementStore, "list">,
+      listPendingWorkspaceResults: () => params.pendingResults ?? [],
+    } as Pick<WorkerSessionPlacementStore, "list" | "listPendingWorkspaceResults">,
     warn,
   });
   coordinator.bindTransport(transport);
@@ -555,6 +557,54 @@ describe("node workspace retain coordinator", () => {
     });
     await coordinator.stop();
   });
+
+  it.each(["claimed", "pending", "stale-pending"])(
+    "protects unsettled manifests for %s ownership",
+    async (state) => {
+      const { coordinator, invoke } = createHarness({
+        placements: [
+          placement({
+            turnClaim:
+              state === "claimed"
+                ? {
+                    owner: "worker",
+                    claimId: "claim-1",
+                    runId: "run-1",
+                    generation: 3,
+                    ownerEpoch: 7,
+                  }
+                : null,
+          }),
+        ],
+        pendingResults:
+          state === "claimed"
+            ? []
+            : [
+                {
+                  sessionId: "session-1",
+                  environmentId: "environment-1",
+                  ownerEpoch: state === "pending" ? 7 : 6,
+                  placementGeneration: 3,
+                  claimId: "claim-1",
+                  runId: "run-1",
+                  gatewayInstanceId: "previous-gateway",
+                  recoveryRequestedAtMs: null,
+                  workspaceAcceptedAtMs: null,
+                  stagedResultRef: null,
+                },
+              ],
+      });
+      await coordinator.start();
+      expect(invoke.mock.calls[0]?.[0].params).toMatchObject({
+        retain: [
+          expect.objectContaining({
+            manifestRefs: state === "stale-pending" ? [`sha256:${"a".repeat(64)}`] : null,
+          }),
+        ],
+      });
+      await coordinator.stop();
+    },
+  );
 
   it("acknowledges the node bundle generation on the next same-connection snapshot", async () => {
     const { coordinator, invoke } = createHarness({

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.ts
@@ -24,7 +24,7 @@ const TERMINAL_ENVIRONMENT_STATES = new Set(["destroyed", "failed", "orphaned"])
 
 type NodeWorkspaceRetainCoordinatorOptions = {
   gatewayNamespace: string;
-  placements: Pick<WorkerSessionPlacementStore, "list">;
+  placements: Pick<WorkerSessionPlacementStore, "list" | "listPendingWorkspaceResults">;
   environments: Pick<WorkerEnvironmentService, "list">;
   warn: (message: string) => void;
 };
@@ -71,6 +71,9 @@ function snapshotEntriesForNode(
   const placements = new Map(
     options.placements.list().map((placement) => [placement.sessionId, placement] as const),
   );
+  const pendingResults = new Map(
+    options.placements.listPendingWorkspaceResults().map((result) => [result.sessionId, result]),
+  );
   return nodeEnvironments(options, nodeId)
     .flatMap((environment): NodeWorkerWorkspaceRetainEntry[] => {
       if (
@@ -82,6 +85,13 @@ function snapshotEntriesForNode(
       }
       const sessionId = environment.attachedSessionIds[0]!;
       const placement = placements.get(sessionId);
+      const pending = pendingResults.get(sessionId);
+      // The base is not a complete reachability set until reconciliation settles. Pending
+      // results preserve this protection across restarts, when node-local transfer pins are lost.
+      const unsettled =
+        placement?.turnClaim ||
+        (pending?.environmentId === environment.environmentId &&
+          pending.ownerEpoch === environment.ownerEpoch);
       const hasExactManifestOwner =
         placement?.state === "starting" ||
         placement?.state === "active" ||
@@ -89,6 +99,7 @@ function snapshotEntriesForNode(
         placement?.state === "reconciling";
       const exactManifest =
         hasExactManifestOwner &&
+        !unsettled &&
         placement.environmentId === environment.environmentId &&
         placement.workspaceBaseManifestRef &&
         (placement.activeOwnerEpoch === environment.ownerEpoch || placement.state === "starting")

--- a/src/gateway/worker-environments/workspace-result-finalize.test.ts
+++ b/src/gateway/worker-environments/workspace-result-finalize.test.ts
@@ -1,0 +1,241 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import { runNodeWorkerWorkspaceTransfer } from "../../node-host/node-worker-transfer-client.js";
+import { NodeWorkerWorkspaceRuntime } from "../../node-host/node-worker-workspace.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
+import type { NodeWorkerWorkspaceRetainEntry } from "../../worker/node-workspace-retain-protocol.js";
+import type { WorkerTunnelHandle } from "./tunnel-contract.js";
+import {
+  cleanupWorkerTurnLauncherTest,
+  placements,
+  root,
+  sessionTarget,
+  setupWorkerTurnLauncherTest,
+} from "./worker-turn-launcher.test-support.js";
+import { serializeWorkerWorkspaceManifest } from "./workspace-manifest.js";
+import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
+import { readActualWorkspaceManifest } from "./workspace-reconcile.js";
+import { reconcileWorkspaceAfterTurn } from "./workspace-result-finalize.js";
+import { workerWorkspaceResultStaging } from "./workspace-result-staging.js";
+import { REMOTE_WORKSPACE_MANIFEST_JS } from "./workspace-sync-scripts.js";
+
+vi.mock("../../node-host/node-worker-transfer-client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../node-host/node-worker-transfer-client.js")>()),
+  runNodeWorkerWorkspaceTransfer: vi.fn(),
+}));
+
+describe("concurrent worker workspace results", () => {
+  beforeEach(setupWorkerTurnLauncherTest);
+  afterEach(cleanupWorkerTurnLauncherTest);
+
+  it.each([1, 50])(
+    "reconciles %i completed turns when an older retention snapshot arrives after upload",
+    async (count) => {
+      const repository = path.join(root, "repository");
+      const payload = path.join(root, "payload");
+      await fs.mkdir(repository);
+      await fs.mkdir(payload);
+      const git = async (cwd: string, ...args: string[]) => {
+        const result = await runCommandWithTimeout(["git", "-C", cwd, ...args], {
+          timeoutMs: 10_000,
+        });
+        if (result.code !== 0) {
+          throw new Error(result.stderr || result.stdout);
+        }
+        return result.stdout.trim();
+      };
+      await git(repository, "init", "--quiet");
+      await git(
+        repository,
+        "-c",
+        "user.name=Workspace Test",
+        "-c",
+        "user.email=workspace@example.invalid",
+        "-c",
+        `core.hooksPath=${os.devNull}`,
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "--quiet",
+        "--allow-empty",
+        "-m",
+        "base",
+      );
+      const baseCommit = await git(repository, "rev-parse", "HEAD");
+      const base = await readActualWorkspaceManifest({ root: repository, baseCommit });
+      const bytes = Buffer.from("worker result\n\0binary\xff", "latin1");
+      await fs.writeFile(path.join(payload, "result.bin"), bytes);
+      const current = await readActualWorkspaceManifest({ root: payload, baseCommit });
+      const node = new NodeWorkerWorkspaceRuntime({ root: path.join(root, "node") });
+      // Model HTTP delivery only; command serialization, manifest verification, retention,
+      // claims, journals, and managed-worktree application all use their real owners.
+      vi.mocked(runNodeWorkerWorkspaceTransfer).mockImplementation(async (input) => {
+        await fs.mkdir(input.workspaceDir, { recursive: true });
+        await git(input.workspaceDir, "init", "--quiet");
+        await fs.copyFile(
+          path.join(payload, "result.bin"),
+          path.join(input.workspaceDir, "result.bin"),
+        );
+        const manifests = path.join(input.manifestHome, ".openclaw-worker", "manifests");
+        await fs.mkdir(manifests, { recursive: true });
+        for (const snapshot of [base, current]) {
+          await fs.writeFile(
+            path.join(manifests, `${snapshot.manifestRef.slice(7)}.json`),
+            serializeWorkerWorkspaceManifest(snapshot.manifest),
+          );
+        }
+        return current.manifestRef;
+      });
+      const retain: NodeWorkerWorkspaceRetainEntry[] = [];
+      const retained = createDeferred();
+      let uploadsRemaining = count;
+      const workspaceOperations = createWorkerWorkspaceOperationCoordinator();
+      const jobs = [];
+      for (let index = 0; index < count; index++) {
+        const sessionId = `session-${index}`;
+        const environmentId = `environment-${index}`;
+        const localWorkspaceDir = path.join(root, `worktree-${index}`);
+        await git(repository, "worktree", "add", "--quiet", "--detach", localWorkspaceDir);
+        const identity = { sessionId, sessionKey: `agent:main:${sessionId}`, agentId: "main" };
+        const transcriptTarget = { ...sessionTarget, ...identity };
+        await upsertSessionEntryCore(transcriptTarget, { sessionId, updatedAt: Date.now() });
+        let placement = placements.startDispatch(identity);
+        for (const transition of [
+          { from: "requested", to: "provisioning", patch: { environmentId } },
+          { from: "provisioning", to: "syncing", patch: { workerBundleHash: "a".repeat(64) } },
+          {
+            from: "syncing",
+            to: "starting",
+            patch: {
+              remoteWorkspaceDir: `/worker/${sessionId}`,
+              workspaceBaseManifestRef: base.manifestRef,
+            },
+          },
+          { from: "starting", to: "active", patch: { activeOwnerEpoch: 1 } },
+        ] as const) {
+          placement = placements.transition({
+            ...transition,
+            sessionId,
+            expectedGeneration: placement.generation,
+          });
+        }
+        if (placement.state !== "active") {
+          throw new Error("expected active placement");
+        }
+        const turnClaim = placements.claimTurn({
+          ...identity,
+          owner: { kind: "worker", environmentId, ownerEpoch: 1 },
+          claimId: `claim-${index}`,
+          runId: `run-${index}`,
+        });
+        placements.markWorkspaceResultPending(turnClaim);
+        const nodeIdentity = {
+          gatewayNamespace: "gateway-test",
+          environmentId,
+          sessionId,
+          generation: 1,
+        };
+        retain.push({ environmentId, sessionId, generation: 1, manifestRefs: [base.manifestRef] });
+        const tunnel: WorkerTunnelHandle = {
+          environmentId,
+          ownerEpoch: 1,
+          launchTurn: async () => {
+            throw new Error("turn already completed");
+          },
+          runWorkspaceCommand: async () => {
+            throw new Error("unexpected workspace command");
+          },
+          syncWorkspace: async () => {
+            throw new Error("workspace already synced");
+          },
+          stop: async () => {},
+          quiesceWorkspace: async () => ({ assertActive: async () => {}, resume: async () => {} }),
+          reconcileWorkspace: async (request) => {
+            const uploaded = await node.exec(
+              {
+                ...nodeIdentity,
+                argv: ["openclaw-internal-workspace-transfer"],
+                transfer: {
+                  direction: "upload",
+                  token: "fixture-upload",
+                  baseManifestRef: base.manifestRef,
+                },
+              },
+              undefined,
+              { url: "ws://gateway.invalid" },
+            );
+            if (--uploadsRemaining === 0) {
+              try {
+                await node.applyRetainSnapshot(
+                  {
+                    version: 1,
+                    gatewayNamespace: "gateway-test",
+                    controllerId: "controller",
+                    sequence: 1,
+                    retain,
+                  },
+                  () => [],
+                );
+                retained.resolve();
+              } catch (error) {
+                retained.reject(error);
+              }
+            }
+            await retained.promise;
+            const verifyStable = async () => {
+              const captured = await node.exec({
+                ...nodeIdentity,
+                argv: [
+                  "node",
+                  "-e",
+                  REMOTE_WORKSPACE_MANIFEST_JS,
+                  uploaded.workspaceDir,
+                  baseCommit,
+                  "eligible",
+                  current.manifestRef.slice(7),
+                ],
+              });
+              if (captured.code !== 0) {
+                throw new Error(captured.stderr);
+              }
+              expect(captured.stdout.trim()).toBe(current.manifestRef);
+            };
+            await verifyStable();
+            return {
+              ...(await workerWorkspaceResultStaging.prepareRequestedWorkerWorkspaceResult({
+                request,
+                stagingRoot: payload,
+                currentManifestRef: current.manifestRef,
+                baseManifestRaw: serializeWorkerWorkspaceManifest(base.manifest),
+                currentManifestRaw: serializeWorkerWorkspaceManifest(current.manifest),
+              })),
+              manifestRef: current.manifestRef,
+              changed: true,
+              verifyStable,
+            };
+          },
+        };
+        jobs.push({ placement, turnClaim, tunnel, localWorkspaceDir, transcriptTarget });
+      }
+      const outcomes = await Promise.allSettled(
+        jobs.map((job) =>
+          reconcileWorkspaceAfterTurn({
+            ...job,
+            placements,
+            workspaceOperations,
+          }),
+        ),
+      );
+      expect(outcomes.find((outcome) => outcome.status === "rejected")).toBeUndefined();
+      expect(placements.listPendingWorkspaceResults()).toEqual([]);
+      for (const job of jobs) {
+        expect(await fs.readFile(path.join(job.localWorkspaceDir, "result.bin"))).toEqual(bytes);
+        expect(placements.get(job.placement.sessionId)?.turnClaim).toBeNull();
+      }
+    },
+  );
+});

--- a/src/node-host/node-worker-workspace-retention.test.ts
+++ b/src/node-host/node-worker-workspace-retention.test.ts
@@ -13,6 +13,7 @@ import {
   testWorkerLaunchInput,
   writeNodeWorkerFixture,
 } from "./node-worker-supervisor.test-support.js";
+import * as workspaceTransfer from "./node-worker-transfer-client.js";
 import { NodeWorkerWorkspaceRuntime } from "./node-worker-workspace.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -315,6 +316,77 @@ describe("node worker workspace retention", () => {
     expect(fs.existsSync(stale)).toBe(false);
     await supervisor.close();
   });
+
+  it.each(["upload", "download"] as const)(
+    "retains the latest %s manifest across command gaps until superseded or retired",
+    async (direction) => {
+      const root = fs.realpathSync.native(tempDirs.make("node-worker-workspace-transfer-retain-"));
+      const workspace = new NodeWorkerWorkspaceRuntime({ root });
+      const input = testWorkerLaunchInput("/unused", "transfer-retention");
+      const generation = input.descriptor.admission.ownerEpoch;
+      const workspaceDir = seedGeneration(root, input, generation);
+      const baseDigest = "b".repeat(64);
+      const baseManifest = seedManifest(root, input, baseDigest);
+      const retainedEntry = {
+        environmentId: input.descriptor.admission.environmentId,
+        sessionId: input.descriptor.admission.sessionId,
+        generation,
+        manifestRefs: [`sha256:${baseDigest}`],
+      };
+      const runTransfer = vi.spyOn(workspaceTransfer, "runNodeWorkerWorkspaceTransfer");
+      const transferManifest = async (digest: string) => {
+        const manifestRef = `sha256:${digest}`;
+        const manifest = seedManifest(root, input, digest);
+        runTransfer.mockResolvedValueOnce(manifestRef);
+        await workspace.exec(
+          {
+            gatewayNamespace: input.gatewayNamespace,
+            environmentId: retainedEntry.environmentId,
+            sessionId: retainedEntry.sessionId,
+            generation,
+            argv: ["node"],
+            transfer:
+              direction === "upload"
+                ? { direction, token: "test-token", baseManifestRef: `sha256:${baseDigest}` }
+                : { direction, token: "test-token", manifestRef },
+          },
+          undefined,
+          { url: "http://127.0.0.1:1" },
+        );
+        return manifest;
+      };
+
+      const first = await transferManifest("c".repeat(64));
+      const artifacts = [
+        `.${generation}.workspace-transfer-stale`,
+        `${generation}.previous-123-stale`,
+      ].map((name) => path.join(sessionRoot(root, input), name));
+      for (const artifact of artifacts) {
+        fs.mkdirSync(artifact);
+      }
+      await workspace.applyRetainSnapshot(retainInput(input, 1, [retainedEntry]), () => []);
+
+      expect(fs.existsSync(first)).toBe(true);
+      expect(artifacts.every((artifact) => !fs.existsSync(artifact))).toBe(true);
+
+      const latest = await transferManifest("d".repeat(64));
+      await workspace.applyRetainSnapshot(retainInput(input, 2, [retainedEntry]), () => []);
+
+      expect(fs.existsSync(first)).toBe(false);
+      expect(fs.existsSync(latest)).toBe(true);
+      expect(fs.existsSync(baseManifest)).toBe(true);
+
+      const sibling = seedGeneration(root, input, generation + 1);
+      await workspace.applyRetainSnapshot(
+        retainInput(input, 3, [{ ...retainedEntry, generation: generation + 1 }]),
+        () => [],
+      );
+
+      expect(fs.existsSync(workspaceDir)).toBe(false);
+      expect(fs.existsSync(latest)).toBe(false);
+      expect(fs.existsSync(sibling)).toBe(true);
+    },
+  );
 
   it("keeps a nonterminal launch until a later authoritative snapshot", async () => {
     const root = tempDirs.make("node-worker-workspace-retention-active-");

--- a/src/node-host/node-worker-workspace.ts
+++ b/src/node-host/node-worker-workspace.ts
@@ -280,6 +280,7 @@ export class NodeWorkerWorkspaceRuntime {
   private readonly retainQueue = new KeyedAsyncQueue();
   private readonly acceptedSnapshots = new Map<string, AcceptedRetainSnapshot>();
   private readonly activeWorkspaceOperations = new Map<string, number>();
+  private readonly latestTransferredManifest = new Map<string, string>();
   private readonly deletingWorkspaceGenerations = new Set<string>();
   private readonly activeRetainProtections = new Map<string, Set<Set<string>>>();
 
@@ -530,6 +531,9 @@ export class NodeWorkerWorkspaceRuntime {
             }).finally(() => this.deletingWorkspaceGenerations.delete(candidate.generationKey))
           ) {
             deleted += 1;
+            if (parseGenerationName(path.basename(candidate.path)) !== undefined) {
+              this.latestTransferredManifest.delete(candidate.generationKey);
+            }
           }
         }
         const sessionPrefix = `${params.gatewayNamespace}/${session.environmentHash}/${session.sessionHash}/`;
@@ -546,13 +550,22 @@ export class NodeWorkerWorkspaceRuntime {
           workspaceSessionKey(session.environmentHash, session.sessionHash),
         );
         if (!hasLocalProtection && retainedManifestRefs !== null) {
+          const reachable = new Set(retainedManifestRefs);
+          for (const generation of existingGenerations) {
+            const latest = this.latestTransferredManifest.get(
+              workspaceGenerationKey({ ...session, generation }),
+            );
+            if (latest) {
+              reachable.add(latest);
+            }
+          }
           const manifestRoot = path.join(session.sessionRoot, ".openclaw-worker", "manifests");
           for (const entry of await listOwnedEntries(manifestRoot)) {
             if (
               !entry.isFile() ||
               entry.isSymbolicLink() ||
               !MANIFEST_FILE_PATTERN.test(entry.name) ||
-              retainedManifestRefs?.has(`sha256:${entry.name.slice(0, -5)}`)
+              reachable.has(`sha256:${entry.name.slice(0, -5)}`)
             ) {
               continue;
             }
@@ -636,13 +649,7 @@ export class NodeWorkerWorkspaceRuntime {
         const sessionRoot = ensureContainedDirectory(environmentRoot, sessionHash);
         const workspaceName = String(input.generation);
         const workspacePath = path.join(sessionRoot, workspaceName);
-        if (input.transfer) {
-          if (input.resetWorkspace) {
-            throw new Error("INVALID_REQUEST: workspace transfer owns its atomic replacement");
-          }
-          if (!gateway?.url) {
-            throw new Error("INVALID_REQUEST: workspace transfer gateway is unavailable");
-          }
+        if (input.transfer || input.resetWorkspace) {
           try {
             const stats = fs.lstatSync(workspacePath);
             const resolved = fs.realpathSync.native(workspacePath);
@@ -657,6 +664,14 @@ export class NodeWorkerWorkspaceRuntime {
             if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
               throw error;
             }
+          }
+        }
+        if (input.transfer) {
+          if (input.resetWorkspace) {
+            throw new Error("INVALID_REQUEST: workspace transfer owns its atomic replacement");
+          }
+          if (!gateway?.url) {
+            throw new Error("INVALID_REQUEST: workspace transfer gateway is unavailable");
           }
           const stdout = await runNodeWorkerWorkspaceTransfer({
             gatewayUrl: gateway.url,
@@ -668,6 +683,9 @@ export class NodeWorkerWorkspaceRuntime {
             transfer: input.transfer,
             signal,
           });
+          // A snapshot sent before this transfer knows only the old base. Keep the latest
+          // result across command gaps; supersede it on transfer or drop it with its generation.
+          this.latestTransferredManifest.set(generationKey, stdout);
           return projectWorkspaceResult(workspacePath, {
             stdout: `${stdout}\n`,
             stderr: "",
@@ -678,21 +696,6 @@ export class NodeWorkerWorkspaceRuntime {
           });
         }
         if (input.resetWorkspace) {
-          try {
-            const stats = fs.lstatSync(workspacePath);
-            const resolved = fs.realpathSync.native(workspacePath);
-            if (
-              stats.isSymbolicLink() ||
-              !stats.isDirectory() ||
-              !isPathInside(sessionRoot, resolved)
-            ) {
-              throw new Error("INVALID_REQUEST: node worker workspace path escaped its owner root");
-            }
-          } catch (error) {
-            if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-              throw error;
-            }
-          }
           // Reset never accepts a caller path: only the identity-derived workspace can be removed.
           fs.rmSync(workspacePath, { recursive: true, force: true });
         }


### PR DESCRIPTION
## What Problem This Solves
In the 50-session cross-machine farm run (openclaw/openclaw#129979), 12/50 turns ended with "Cloud worker finished, but its workspace result could not be reconciled" — the worker did its job and the result was silently lost, the worst failure class in this repo.

## Why This Change Was Made
Root cause is a manifest-retention race. Between a worker's manifest upload and its verification, a sibling completion can trigger workspace retention with a snapshot that only knows the old base manifest. The just-finished worker no longer protects the workspace, so cleanup deletes the newly uploaded manifest, and verification fails with ENOENT at `src/gateway/worker-environments/workspace-sync-scripts.ts:301`.

The repair closes the race at both owners:
- The node workspace runtime pins the latest transferred manifest per generation (`src/node-host/node-worker-workspace.ts`) and includes it in every cleanup's reachable set; the pin is cleared with its generation.
- Gateway retention snapshots treat unsettled results — an active turn claim or a pending-result fence matching the environment + owner epoch — as protection (`src/gateway/worker-environments/node-workspace-retain-coordinator.ts`), which also covers restarts where node-local pins are gone.
- Manifest-capture errors now retain bounded, redacted stderr (`src/gateway/worker-environments/node-worker-workspace-fallback.ts`) so this failure class can never be faceless again.

No deadlines, protocol, schema, or completion semantics changed. Production delta +11 lines.

## User Impact
Operators running many parallel worker sessions on one node no longer lose completed work to concurrent cleanup; capture failures that do occur carry actionable stderr.

## Evidence
- Deterministic 1-turn and 50-turn reproductions fail pre-fix with the exact missing-manifest ENOENT, pass post-fix with result bytes preserved and claims released.
- 110 focused tests across seven files (including real HTTP transfers and cleanup), `pnpm check:changed` green.
- Broad suites: 1,584 passed; remaining failures are unchanged pre-existing timing-sensitive tests (node-config startup import 18.6s vs 15s probe deadline; large-inventory recovery; large SSH workspace), reproduced in isolation without this change.
- Automated review (branch vs origin/main): no actionable findings.

Part of the openclaw/openclaw#129979 worker-mortality follow-up campaign. A combined live rig run with the lifecycle lane (#130446) follows before the campaign closes.
