### PR TITLE
fix(memory): prevent forgotten session content from returning

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -793,7 +793,6 @@ extensions/memory-core/src/short-term-promotion-artifacts.ts	2
 extensions/memory-core/src/short-term-promotion-memory-write.ts	4
 extensions/memory-core/src/short-term-promotion-record.ts	1
 extensions/memory-core/src/short-term-promotion-rehydrate.ts	1
-extensions/memory-core/src/short-term-promotion-store.ts	1
 extensions/memory-core/src/short-term-promotion-utils.ts	4
 extensions/memory-core/src/short-term-promotion.ts	1
 extensions/memory-core/src/standing-intents-tool.ts	5

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -6,6 +6,7 @@ read_when:
   - You want to promote recalled short-term memory into `MEMORY.md`
   - You need to delete provenance-tracked memories derived from specific sessions or participants
 title: "Memory"
+doc-schema-version: 1
 ---
 
 # `openclaw memory`
@@ -84,75 +85,141 @@ absent.
 
 ## `memory forget`
 
-Delete provenance-tracked durable memory entries derived from selected
-sessions, together with their indexed and short-term copies. The concepts
-behind this command — recorded lineage, admission policy, and the deletion
-guarantees and boundaries — are explained in
-[Memory provenance and deletion](/concepts/memory-provenance). Select sessions
-by ID or session key, their external-content hook source, or a participant's
-actor ID:
-
-```bash
-openclaw memory forget --session <id-or-key> [--session <id-or-key> ...]
-openclaw memory forget --hook-source gmail [--since 2026-01-01]
-openclaw memory forget --participant <actor-id> [--agent <id>] [--dry-run] [--json]
-```
-
-`--session`, `--hook-source`, and `--participant` are repeatable. At least one
-selector is required. `--agent` selects one agent and otherwise defaults to the
-default agent. Explicit session IDs and keys match both live sessions and
-retained archived sessions. An unknown explicit value is still treated as an
-exact session ID, purged where matching artifacts exist, and durably excluded
-from future memory ingestion. The report identifies each selected session as
-`live`, `archived`, or `unresolved`. Hook-source and participant selectors only
-match sessions whose corresponding metadata still exists; archived sessions do
-not retain those facts, so select them by ID or key instead. `--since <date>`
-filters live sessions by their creation time and archived sessions by their
-archive creation time; unresolved explicit IDs have no timestamp and remain
-selected.
-
-Run with `--dry-run` before deleting. It computes the same complete report as
-the real purge without changing memory files, SQLite indexes, plugin state, or
-durable deletion records. `--json` prints that report as machine-readable JSON.
-
-A purge removes matching pipeline-promoted entries, session-corpus lines,
-selected-session transcript index chunks, full-text and vector index records,
-embedding-cache entries, short-term recall, seen-hash scopes, dreaming rewrite
-backups, and recorded origins. It also clears stale index records for internal
-dreaming-narrative, cron, or heartbeat sessions. An entry derived from both
-selected and unselected sessions is deleted whole and reported as a
-mixed-lineage entry; dreaming can regenerate supported facts from surviving
-sessions later. Entries without recorded origins remain searchable and are not
-deleted by an unrelated selector; the report lists them as untargetable.
-
-A real purge records each selected session as forgotten in the agent's SQLite
-database. Future dreaming sweeps record that session as excluded with reason
-`forgotten`; `memory session-backfill` and transcript indexing, including
-`memory index --force`, also reject it. Repeating the purge is safe and does
-not undo this exclusion.
-
-Dream diaries and other workspace memory files can quote source-session corpus
-lines without retaining a session reference. The purge removes any whole line
-containing an exact purged corpus-line snippet from files such as
-`memory/dreaming/**/*.md` and `DREAMS.md`, as well as matching dreaming
-backups. `artifacts.memoryLines` reports the number of these additional removed
-memory-file lines. Model-paraphrased prose that does not contain the exact
-source text cannot be attributed reliably and is not removed automatically.
-
-Direct agent edits to memory files are tracked at the file level, not per
-entry. When such a write happened during a selected session, `curatedWrites`
-lists its `relativePath` and `observedAt` without modifying the file. Evidence
-comes from native write-observer records and the selected sessions' live or
-archived transcripts, including writes performed by external agent harnesses.
-Review those files separately: a freeform edit cannot be attributed to
-individual lines safely enough for automatic deletion.
+Remove identifiable memory artifacts derived from selected sessions and record
+those sessions as forgotten in one agent's store. See
+[Memory provenance and deletion](/concepts/memory-provenance) for the
+relationship between lineage, admission policy, and deletion coverage.
 
 <Warning>
-`memory forget` removes selected-session transcript chunks from the memory
-index and permanently prevents their memory-pipeline readmission, but does not
-delete the original source session transcripts. The report identifies the
-selected sessions so you can remove transcript data separately through its
-owning session-management workflow when required.
+This command deletes immediately unless `--dry-run` is set. There is no
+confirmation prompt or `--apply` flag. Source session transcripts are retained.
+</Warning>
+
+Start with a preview:
+
+```bash
+openclaw memory forget --agent <agent-id> --session <id-or-key> --dry-run --json
+openclaw memory forget --agent <agent-id> --hook-source gmail --dry-run --json
+openclaw memory forget --agent <agent-id> --participant <actor-id> --dry-run --json
+```
+
+After checking the report, repeat the intended command without `--dry-run`.
+
+| Flag                       | Effect                                                                                                         |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `--agent <id>`             | Select one agent. Defaults to the default agent, not all agents.                                               |
+| `--session <id-or-key>`    | Select by session ID or key; repeatable.                                                                       |
+| `--hook-source <source>`   | Select live sessions with this recorded external-content hook source; repeatable.                              |
+| `--participant <actor-id>` | Select live sessions with this recorded participant actor ID; repeatable.                                      |
+| `--since <date>`           | Include sessions created on or after the date. Use an ISO timestamp with a timezone for an unambiguous cutoff. |
+| `--dry-run`                | Compute a report without changing memory files, indexes, plugin state, or forgotten-session records.           |
+| `--json`                   | Print the full report as JSON.                                                                                 |
+
+### Session selection
+
+At least one selector is required. Repeated values and different selector
+types combine with **OR**: a session matching any selector is selected, subject
+to `--since`. Selectors match recorded identifiers, not names or text in
+messages. A participant selector selects the whole session, including other
+participants' contributions.
+
+Explicit IDs and keys resolve against live sessions and retained archives.
+The report labels each result `live`, `archived`, or `unresolved`. An
+unresolved explicit value is recorded literally as a session ID for future
+exclusion; it does not prove that the requested session was found. IDs match
+exactly and case-sensitively, including when matching retained archive names.
+An abbreviation does not select a longer session ID.
+
+Hook-source and participant selectors require live metadata; archived-only
+records do not retain those facts. Select those archives by full ID or key.
+`--since` uses the live session's creation time or the archive's creation time,
+not individual message timestamps. Unresolved explicit IDs have no timestamp
+and remain selected.
+
+### Read the report
+
+| Field                              | Meaning                                                                                                                                              |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agentId`, `dryRun`                | Store selected and whether this was a preview.                                                                                                       |
+| `sessionIds`, `sessionResolutions` | Selected IDs and how each resolved; a resolution may also include `sessionKey`.                                                                      |
+| `entryKeys`                        | Entry keys with at least one origin in the selected sessions.                                                                                        |
+| `mixedLineageEntryKeys`            | Selected entries that also have unselected origins; they are removed whole.                                                                          |
+| `untargetableEntryKeys`            | Promotion markers found without origin rows in this agent's store. This does not enumerate unmarked prose.                                           |
+| `curatedWrites`                    | Files to review, with `relativePath` and `observedAt` (Unix milliseconds). Includes supported recorded write attempts, which may not have succeeded. |
+| `artifacts`                        | Counts of matching files, entries, lines, and store rows described below.                                                                            |
+| `refusals`                         | Reserved report list; currently empty. An empty list does not establish complete deletion coverage.                                                  |
+
+Preview and apply use the same matching logic, but each reads current state;
+a preview is not an immutable plan or a lock on subsequent writes. Apply
+coordinates with the memory plugin's staging and file mutations. Indexing
+discards stale results instead of restoring purged chunks or cached embeddings;
+rerun an index command that reports a source change. Direct agent edits and
+external writers do not share that lock, so pause them during a sensitive
+cleanup. Rerun the preview afterward. An empty selection or zero counts do not
+prove that no related data remains.
+
+### Artifacts removed
+
+The purge removes matching promotion-marker entries and session-reference
+sections from scanned memory files, selected session-corpus lines, and
+selected-session transcript index chunks. It clears associated full-text and
+vector rows, cached embeddings, matching short-term state, ingestion seen-hash
+scopes, and origin rows. Matching content is scrubbed from dreaming rewrite
+backups, rather than deleting every backup.
+
+It also clears stale index records for internal dreaming-narrative, cron, or
+heartbeat sessions when the selection is nonempty. Index cleanup can therefore
+include more than the selected sessions, and all chunks from a changed memory
+file may be invalidated for later reindexing.
+
+The `artifacts` counters are:
+
+- `memoryFiles`, `memoryEntries`, `memoryLines`: changed memory files,
+  removed marked entries or session-reference sections, and extra whole lines
+  containing exact selected corpus snippets.
+- `sessionCorpusFiles`, `sessionCorpusLines`: changed corpus files and
+  removed corpus lines.
+- `indexChunks`, `indexSources`, `ftsRows`, `vectorRows`,
+  `embeddingCacheRows`: removed index and cache records.
+- `shortTermEntries`, `seenHashScopes`, `backups`, `originRows`: removed
+  short-term entries and deduplication scopes, rewritten backup records, and
+  deleted source-origin rows.
+
+Entries with mixed lineage are deleted whole; the command does not rewrite
+them to preserve only unselected contributions. Surviving sources may support
+new entries later, but regeneration is not guaranteed.
+
+### Readmission and retained data
+
+A real purge records the selected session IDs as forgotten in the agent's
+SQLite database before removing artifacts. Automatic dreaming ingestion,
+`memory session-backfill`, and transcript indexing, including
+`memory index --force`, check those records. Automatic ingestion records the
+reason `forgotten`. Repeating the purge does not remove the exclusion, and
+removing an admission-policy rule does not undo it. Future sessions with new
+IDs are not excluded by a previous purge.
+
+Exact corpus quotations in dream diaries such as `DREAMS.md` and
+`memory/dreaming/**/*.md` can be removed as whole lines. Untracked paraphrases
+cannot be reliably attributed and remain.
+
+A `curatedWrites` record alone does not delete a file or its freeform edits.
+The latest file-level write-observer record and supported `write`, `edit`,
+and `apply_patch` calls in retained transcripts identify files to review.
+This is not a complete audit of shell writes or external editors. A reported
+file may still be changed by the separate marker, session-reference, or
+exact-quotation cleanup.
+
+<Warning>
+Entries staged before source-session tracking may lack origin rows and remain
+after a purge; review them separately. Current session backfill preserves
+origins, but does not reconstruct missing historical lineage.
+`untargetableEntryKeys` does not enumerate every untracked candidate or memory.
+
+Source transcripts, retained archives, other agents' indexes, exports, and
+external backups also require separate review. In particular,
+[session deletion](/cli/sessions#delete-sessions) ordinarily retains a
+deleted-transcript archive; it is not an erasure of every conversation copy.
 </Warning>
 
 ## `memory promote`
@@ -231,8 +298,12 @@ openclaw memory rem-backfill --rollback [--rollback-short-term] [--json]
 
 ## `memory session-backfill`
 
-Distill retained session history through the same provenance and short-term
-staging pipeline used by dreaming. The default is a read-only preview, ordered
+Distill retained session history into grounded short-term candidates. It shares
+transcript trust classification, admission policy, and corpus storage with
+dreaming. Staged candidates retain every contributing session's origin so
+`memory forget` can select them later. Configured exclusions apply in preview,
+REM, and apply modes; forgotten sessions remain excluded in every mode.
+The default is a read-only preview, ordered
 from the oldest unprocessed day to the newest.
 
 ```bash

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -69,7 +69,7 @@ Dreaming runs three cooperative phases per sweep, in order: light -> REM -> deep
 
 Dreaming can ingest redacted session transcripts into the dreaming corpus. Only interactive sessions are eligible. Cron, heartbeat, subagent, and unknown sessions stay out of durable candidate ingestion. Personal and sensitive content is redacted before ingestion, and runtime-marked recalled context is removed so recalled snippets cannot be learned again as new memory.
 
-Two operator controls remove whole sessions from ingestion, each with a recorded reason: the [memory admission policy](/concepts/memory-provenance#admission-keeping-sources-out-of-memory) excludes sessions by external-content hook source, channel, or chat type, and [`memory forget`](/cli/memory#memory-forget) durably excludes purged sessions as `forgotten` so a later sweep cannot re-learn what was deleted.
+Two operator controls exclude sessions from automatic ingestion, each with a recorded reason: the [memory admission policy](/concepts/memory-provenance#admission-keeping-sources-out-of-memory) matches retained hook-source, channel, or chat-type metadata, and [`memory forget`](/cli/memory#memory-forget) records selected session IDs as `forgotten` for future scans. Policy changes do not erase existing candidates or prevent direct file writes. Manual session backfill applies both controls in preview, REM, and apply modes, and preserves source-session origins when staging candidates.
 
 ## Consolidation safety
 

--- a/docs/concepts/memory-architecture.md
+++ b/docs/concepts/memory-architecture.md
@@ -96,14 +96,13 @@ noise, and recall feedback loops:
   structurally marked and never re-extracted as a new memory. A fact recalled
   one hundred times stays one fact.
 
-Beyond per-chunk trust metadata, every pipeline-promoted durable entry also
-records **which sessions it came from**, and that lineage survives
-consolidation merges. Session lineage is what makes two operator guarantees
-possible: excluding configured sources (an email hook, a channel) from
-durable memory by policy, and purging everything derived from a session, a
-person, or a source with `openclaw memory forget` — including a durable
-exclusion that keeps purged sessions from ever being re-ingested. That
-policy story is covered end to end in
+Beyond per-chunk trust metadata, automatic session ingestion records source
+sessions for its staged entries. Consolidation carries those origins forward,
+so `openclaw memory forget` can remove tracked entries derived from selected
+sessions and exclude those session IDs from future ingestion. Separately,
+admission policy can exclude matching sources from dreaming ingestion and session backfill.
+Neither control covers every workspace write or retained copy; see the
+coverage, retained-data boundaries, and operator workflow in
 [Memory provenance and deletion](/concepts/memory-provenance).
 
 ## Trust boundaries and limits

--- a/docs/concepts/memory-builtin.md
+++ b/docs/concepts/memory-builtin.md
@@ -96,9 +96,9 @@ only injects curated or promoted-trusted entries.
 Each indexed chunk also has SQLite-owned provenance: origin class (`owner`,
 `agent`, `untrusted`, or `system`), session kind, observation time, and an
 optional supersession key. This metadata is stored separately from Markdown
-so recalled prose cannot rewrite its own trust classification. Durable
-entries additionally record their source sessions, which powers admission
-policy and selective deletion — see
+so recalled prose cannot rewrite its own trust classification. Automatic
+session ingestion also records source-session origins for its staged entries,
+which support selective deletion after promotion. For coverage and limits, see
 [Memory provenance and deletion](/concepts/memory-provenance).
 
 - **Index location:** the owning agent database at

--- a/docs/concepts/memory-provenance.md
+++ b/docs/concepts/memory-provenance.md
@@ -1,67 +1,98 @@
 ---
-summary: "Session-level memory provenance: how OpenClaw records where every durable memory came from, keeps configured sources out of memory by policy, and deletes everything derived from a session on request"
+summary: "Trace session-derived memories, control ingestion, and preview or delete tracked memory artifacts"
 title: "Memory provenance and deletion"
 sidebarTitle: "Provenance & deletion"
+doc-schema-version: 1
 read_when:
-  - You need to keep email, a channel, or another content source out of durable memory
-  - You need to purge every memory derived from a session, a person, or a source, e.g. for GDPR erasure or an employee exit
-  - You are reviewing OpenClaw memory for a security, privacy, or compliance assessment
+  - You want to exclude a source from automatic memory ingestion
+  - You need to remove memories derived from specific sessions or participants
+  - You are reviewing memory provenance, deletion coverage, or retained data
 ---
 
-Every durable memory OpenClaw creates through its pipeline records which
-sessions it came from, as queryable SQLite facts — not as prose the model
-could rewrite. That lineage supports two operator guarantees this page
-explains end to end: **admission** (configured sources never enter durable
-memory, deterministically) and **deletion** (`openclaw memory forget` purges
-everything the pipeline derived from a chosen set of sessions and permanently
-prevents its re-admission).
+OpenClaw records source-session lineage for memories staged by automatic
+session ingestion and historical session backfill. `openclaw memory forget` uses that lineage to remove
+tracked entries and related artifacts, and records the selected sessions as
+forgotten so later ingestion does not restore them.
 
-This page owns the policy story: what is recorded, what the guarantees cover,
-and where their boundaries are. The command contract lives in
-[`memory forget`](/cli/memory#memory-forget), the configuration keys in
-[Memory config](/reference/memory-config#memory-admission-policy), and the
-surrounding trust model in
-[Memory architecture](/concepts/memory-architecture).
+Two controls serve different purposes: **admission policy** excludes matching
+sessions from future dreaming ingestion and session backfill; **forget** removes
+identifiable artifacts from selected sessions. Neither is a general erasure
+of everything the agent has seen or written.
+
+These controls belong to the bundled `memory-core` plugin. Other memory
+plugins may expose different commands and deletion behavior.
+
+<Warning>
+`memory forget` deletes immediately unless you pass `--dry-run`. It does not
+delete original session transcripts, every freeform memory edit, or copies
+outside the memory stores it scans. Review the report and the
+[deletion boundaries](#what-deletion-does-not-cover) before applying it.
+</Warning>
+
+## Preview and forget a session
+
+Use an explicit agent so you know which store you are changing. List its
+sessions to find the full session key or ID. Session IDs are exact and
+case-sensitive; an abbreviation does not select a longer ID:
+
+```bash
+openclaw sessions --agent <agent-id> --limit all --json
+openclaw memory forget --agent <agent-id> --session <id-or-key> --dry-run --json
+```
+
+Check `sessionResolutions` for the intended sessions, `entryKeys` and
+`mixedLineageEntryKeys` for whole-entry removals, and `artifacts` for the
+affected stores. Review `curatedWrites` and `untargetableEntryKeys` separately;
+neither is a complete inventory of data that will remain.
+
+When the selection is correct, repeat the same command without `--dry-run`:
+
+```bash
+openclaw memory forget --agent <agent-id> --session <id-or-key> --json
+```
+
+There is no additional confirmation prompt or `--apply` flag. A preview is
+computed from current state, not saved as a deletion plan. Pause direct agent
+edits and external writers during a sensitive cleanup; they do not share the
+memory plugin's mutation lock. Run the preview again afterward to check for
+remaining attributable artifacts.
+
+The full flags, selector semantics, and report fields are in
+[`memory forget`](/cli/memory#memory-forget).
 
 ## What lineage is recorded
 
-Three kinds of provenance exist, at different granularities:
+Three records serve different purposes:
 
-| Record                | Granularity   | Written by                                       | Used for                                              |
-| --------------------- | ------------- | ------------------------------------------------ | ----------------------------------------------------- |
-| Chunk provenance      | Index chunk   | Classification code at index time                | Trust gating: promotion eligibility, recall framing   |
-| Entry origins         | Durable entry | Ingestion and promotion, per source session      | Selective deletion; auditing where an entry came from |
-| Curated-write records | Memory file   | The memory write observer, per authoring session | Reporting agent-authored edits during a purge         |
+| Record                | Granularity   | Written by                                     | Used for                                        |
+| --------------------- | ------------- | ---------------------------------------------- | ----------------------------------------------- |
+| Chunk provenance      | Index chunk   | Classification code at index time              | Trust gating and recall framing                 |
+| Entry origins         | Tracked entry | Session ingestion, backfill, and consolidation | Finding entries derived from a selected session |
+| Curated-write records | Memory file   | The memory write observer                      | Identifying files to review during a purge      |
 
-Chunk provenance (origin class, session kind) is the trust model described in
-[Memory architecture](/concepts/memory-architecture#provenance-every-memory-knows-where-it-came-from).
-Entry origins are what make deletion possible: when the dreaming pipeline
-turns session content into a durable candidate, it records
-`(entry, agent, source session)` rows in the agent's SQLite database, and
-every pipeline-promoted `MEMORY.md` entry carries a stable marker that ties
-the file text back to those rows.
+[Chunk provenance](/concepts/memory-architecture#provenance-every-memory-knows-where-it-came-from)
+describes the origin class and session kind. Entry origins instead associate
+an entry key with an agent and source session in SQLite. Promotion markers in
+`MEMORY.md` connect the visible entry to those origin rows.
 
-Lineage survives [dreaming](/concepts/dreaming) consolidation. When
-consolidation merges two entries, the result's origin set is the union of its
-parents'; when a newer observation supersedes an older one, the origins move
-to the surviving entry. This bookkeeping is deterministic code wrapped around
-the consolidation model call — the model never carries or rewrites
-provenance. In a workspace shared by several agents, the same reconciliation
-runs against every participating agent's origins, so any agent's later
-deletion request still finds the live entry.
+When [dreaming](/concepts/dreaming) merges or supersedes tracked entries,
+reconciliation transfers the parents' origins to the surviving entry. It
+runs in code around the model call, including for participating agents that
+share a workspace; the model does not own the origin rows.
 
-Not every entry has origin rows. Operator-curated content and direct agent
-edits never receive entry lineage (their file-level authoring sessions are
-tracked separately — see
-[the admission boundary](#the-admission-boundary) below), and entries
-promoted before lineage recording existed have none either. All such entries
-remain searchable, are never deleted by an unrelated selector, and are
-listed as untargetable in a purge report rather than silently skipped.
+When backfill coalesces the same claim from several sessions, it retains every
+source origin without counting the repeated claim as extra evidence.
+
+Coverage is not universal. Handwritten notes, direct agent edits, and entries
+staged before lineage tracking may lack entry origins. The report's
+`untargetableEntryKeys` lists **promotion markers with
+no origins in the selected agent's store**, not all untracked prose. Such
+entries cannot be selected by lineage alone, although explicit session
+references or exact corpus quotations may still match the file scrub.
 
 ## Admission: keeping sources out of memory
 
-If a source must never reach durable memory — email content is the classic
-case — exclude it by policy instead of prompting the model to be careful:
+To keep Gmail hook sessions out of **dreaming ingestion and session backfill**:
 
 ```json5
 {
@@ -72,8 +103,6 @@ case — exclude it by policy instead of prompting the model to be careful:
           memoryPolicy: {
             excludeSessions: {
               hookExternalContentSources: ["gmail"],
-              channels: ["email"],
-              chatTypes: ["group"],
             },
           },
         },
@@ -83,107 +112,138 @@ case — exclude it by policy instead of prompting the model to be careful:
 }
 ```
 
-A session matching any configured exclusion never enters the dreaming
-corpus, so it cannot produce candidates, survive consolidation, or promote
-into `MEMORY.md`. The exclusion is enforced before the transcript is read,
-and it is **recorded**, not silent: the ingestion checkpoint stores the
-exclusion reason, visible to a later audit. Removing the policy re-admits
-the session on the next sweep. Key semantics and matching rules are in
-[Memory config](/reference/memory-config#memory-admission-policy).
+You can also exclude channel/plugin identifiers (not room IDs) or chat types.
+Empty or omitted lists add no policy exclusions. A match in any list excludes
+the whole session; values
+match recorded session metadata, not words in the conversation.
+
+Both paths check the policy before reading the transcript. Automatic ingestion
+also records the exclusion reason in its ingestion checkpoint. Removing a matching
+rule makes a session eligible for a later sweep, subject to the other trust
+and ingestion gates. A session recorded as forgotten remains excluded.
+
+Policy is prospective: it does not erase an existing corpus, staged
+candidate, or promoted entry. Use `memory forget` for existing attributable
+data. See [Memory config](/reference/memory-config#memory-admission-policy)
+for exact matching rules and exclusion reasons.
 
 ### The admission boundary
 
-The policy governs the **memory pipeline**. An agent running inside an
-excluded session can still edit `MEMORY.md` or another memory file directly
-during its turn — "remember this" resolved by the agent writing the file is
-a workspace edit, governed by tool policy and the workspace trust boundary,
-not by memory admission. OpenClaw records those writes with their authoring
-session (the curated-write records above), so they are auditable and are
-surfaced by a later purge, but preventing them is a tool-policy decision,
-not a memory-policy one. If the requirement is "this session must not be
-able to write memory files at all," restrict the agent's file tools for that
-context rather than relying on admission policy.
+| Path                            | Configured admission exclusions          |
+| ------------------------------- | ---------------------------------------- |
+| Automatic dreaming ingestion    | Applied before transcript reads          |
+| Manual `session-backfill`       | Applied in preview, REM, and apply modes |
+| Raw transcript indexing         | Not applied                              |
+| Direct writes and session hooks | Not applied                              |
+
+Matching requires retained session metadata; missing fields do not match a
+rule. Automatic dreaming separately skips retained archives. To exclude an
+archived session from backfill and transcript indexing too, explicitly forget
+its full session ID. Those paths check forgotten-session records even when
+the former channel, chat type, or hook-source metadata is no longer available.
+
+An excluded session can still edit `MEMORY.md`, `USER.md`, or another
+workspace file if its tools permit it. Restrict the relevant file, shell, and
+external-harness capabilities when you need to prevent those writes, and
+review enabled memory-writing hooks. Admission policy is not a filesystem
+permission. Observed writes are reported for review, not given per-entry
+lineage.
 
 ## Deletion: purging what a session produced
 
-`openclaw memory forget` deletes everything the memory pipeline derived from
-a chosen session set. Sessions are selected by explicit ID or key, by their
-recorded external-content hook source, or by a participant's actor ID —
-"everything derived from Gmail" and "everything derived from sessions this
-person took part in" are both one command. Selection resolves against live
-session records **and** retained archived sessions, and an explicitly named
-session that matches neither is still purged and excluded as an exact ID: an
-operator-named session never produces a silent no-op. The report labels each
-selected session `live`, `archived`, or `unresolved`.
+Selectors identify **sessions**, not individual facts about a person.
+`--participant` selects sessions with that recorded actor ID; it does not
+search memory text for a name. `--hook-source` selects sessions with that
+recorded external-content source. Both require retained metadata. Explicit
+IDs and keys can also resolve retained archives.
 
-A purge is **whole-entry and deterministic**. An entry with any origin in the
-selected set is removed entirely — there is no model-mediated attempt to
-subtract one source's contribution from merged prose, because a deletion
-guarantee an LLM adjudicates is not one you can defend in an audit. Entries
-that also had unselected origins are reported as mixed-lineage removals;
-dreaming can regenerate what the surviving sessions still support.
+A tracked entry with any selected origin is removed whole, even when it also
+has unselected origins. These removals appear in `mixedLineageEntryKeys`.
+The purge does not ask a model to subtract one person's contribution from
+merged prose. Surviving sources may support a new entry later, but automatic
+reconstruction is not guaranteed.
 
-The sweep covers every derived artifact, not just the visible entry: memory
-files, verbatim quoted lines in dream diaries, session-corpus lines, index
-chunks with their full-text and vector records, embedding-cache entries,
-short-term recall state, ingestion dedup state, and dreaming's own pre-rewrite
-backups. A deletion that survives in a backup or an index is not a deletion.
-Always start with `--dry-run`, which computes the identical report without
-writing; the full artifact list and report shape are in the
-[command reference](/cli/memory#memory-forget).
+The cleanup covers matching promoted entries, session-corpus lines, memory
+index chunks and their full-text/vector rows, cached embeddings, short-term
+state, ingestion deduplication state, and dreaming rewrite preimages. It also
+removes whole lines containing exact selected corpus snippets from scanned
+memory files and dream diaries. The
+[command reference](/cli/memory#memory-forget) describes the counters and
+selection limits.
 
 ### Purged sessions stay purged
 
-Deleting derived data is not enough on its own: the memory pipeline
-continuously re-reads session history, so a purge that only removed artifacts
-would be silently undone by the next dreaming sweep or index rebuild. A real
-purge therefore records each selected session as **forgotten** in the agent's
-SQLite database. Dreaming ingestion, historical backfill, and transcript
-indexing — including `memory index --force` — all treat forgotten sessions
-exactly like policy-excluded ones, with the recorded reason `forgotten`.
-Re-running the purge is safe and changes nothing.
+A real purge records each selected session as forgotten in the selected
+agent's SQLite database before removing its artifacts. Automatic ingestion,
+historical session backfill, and transcript indexing, including
+`memory index --force`, check these records. Automatic ingestion records the
+reason `forgotten`.
 
-### What deletion does not cover
+The memory plugin coordinates purges with its staging and file mutations.
+A pending dream narrative is skipped if its tracked source entries or prior
+diary context were removed before publication. This does not retroactively
+identify untracked paraphrases in older diary entries.
 
-The boundaries are deliberate, and each one is reported rather than silent:
+Indexing checks again before publishing chunks or cached embeddings, so a
+result prepared before the purge cannot restore forgotten session data or a
+stale memory-file snapshot. An affected index run reports that its source
+changed; rerun `openclaw memory index --agent <agent-id>` to index current data.
 
-- **Source transcripts.** The session transcript itself belongs to session
-  management, not memory. A purge removes its copies from the memory index
-  and permanently fences it out of the pipeline, then names the session in
-  the report so you can remove the transcript through its owning workflow.
-- **Agent-authored edits.** Freeform file edits cannot be attributed to
-  individual lines safely enough for automatic deletion. The purge reports
-  them as `curatedWrites` — file and timestamp, recovered from write-observer
-  records and from the selected sessions' transcripts across all agent
-  harnesses — and leaves the files for review.
-- **Paraphrased prose.** Dream-diary lines quoting a purged session verbatim
-  are removed; model-paraphrased prose that no longer contains the source
-  text cannot be reliably attributed and stays. Keeping the affected sessions
-  out of memory in the first place, via admission policy, is the stronger
-  tool when a source is sensitive.
+Repeating a purge does not lift that exclusion. It applies to those session
+IDs in that agent's store, not to future conversations with the same person
+or hook source. Keep an admission rule for future matching sessions, within
+[the admission boundary](#the-admission-boundary).
+
+## What deletion does not cover
+
+- **Original transcripts and archives.** Memory cleanup leaves them in the
+  session store. [Session deletion](/cli/sessions#delete-sessions) is a
+  separate lifecycle operation and ordinarily retains a deleted-transcript
+  archive. Do not treat either command as proof that all conversation copies
+  have been erased.
+- **Untracked older memories.** No origin row means no lineage-based deletion.
+  New session backfill preserves origins, but it does not retroactively supply
+  lineage for candidates staged by older versions. Inspect those separately.
+- **Freeform edits.** `curatedWrites` reports recognized writes or write
+  attempts with a `relativePath` and `observedAt`. That record alone does
+  not delete a file or identify contributing lines. Supported write/edit/patch
+  transcript records supplement the latest file-level observer record, but
+  can include unsuccessful attempts. Arbitrary shell writes and external edits
+  are not fully tracked.
+- **Paraphrases and other copies.** Exact corpus quotations can be removed,
+  but untracked paraphrases, exports, external backups, other plugins' stores,
+  and independently copied files are outside this cleanup. A reported curated
+  file can still lose lines that match a tracked entry or exact quotation.
+- **Other agents.** Selection and forgotten-session records are per agent.
+  Repeat the review for each relevant agent, including agents sharing a
+  workspace; one agent's report does not establish that every index is clean.
+
+An empty preview means no more artifacts were found by those selectors and
+matching rules. It is not a certificate that no related information remains.
 
 ## Purging a person or a source end to end
 
-The employee-exit / GDPR-erasure workflow, using a departed teammate as the
-example:
+For a participant, start with a preview in each relevant agent:
 
 ```bash
-# 1. Preview everything derived from sessions they took part in.
-openclaw memory forget --participant <actor-id> --dry-run --json
-
-# 2. Review the report: entries, artifacts, mixed-lineage removals,
-#    curatedWrites, and each session's resolution source.
-
-# 3. Purge. Selected sessions are durably excluded from re-ingestion.
-openclaw memory forget --participant <actor-id>
-
-# 4. Review curatedWrites files by hand, and remove the source transcripts
-#    through session management if required.
+openclaw memory forget --agent <agent-id> --participant <actor-id> --dry-run --json
 ```
 
-For archived sessions that no longer carry participant metadata, select them
-explicitly with `--session <id-or-key>`. For a source-wide purge, use the
-recorded hook source instead: `openclaw memory forget --hook-source gmail`.
+Verify the resolved session IDs before removing `--dry-run`. This removes
+tracked entries derived from **any content in those sessions**, not only
+messages authored by that participant. If participant metadata is missing
+from an archive, add its explicit `--session <id-or-key>` selector.
+
+For a source, use its recorded hook identifier:
+
+```bash
+openclaw memory forget --agent <agent-id> --hook-source gmail --dry-run --json
+```
+
+After applying the reviewed selection, inspect retained files and untracked
+memories, handle transcript and archive retention separately, and rerun the
+preview. Add an admission rule if future sessions from that source should
+also stay out of dreaming ingestion and session backfill.
 
 ## Related
 

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -1,12 +1,13 @@
 ---
-summary: "Built-in memory search providers, retrieval modes, and multimodal indexing"
+summary: "Built-in memory search, admission exclusions, and dreaming configuration"
 title: "Memory configuration reference"
 sidebarTitle: "Memory config"
+doc-schema-version: 1
 read_when:
   - You want to configure memory search providers or embedding models
   - You want to understand hybrid search, MMR, or temporal-decay defaults
   - You want to enable multimodal memory indexing
-  - You need to exclude specific session sources from memory-pipeline ingestion
+  - You need to exclude specific session sources from automatic dreaming ingestion
 ---
 
 This page lists every configuration knob for OpenClaw memory search. For conceptual overviews, see:
@@ -574,35 +575,30 @@ Built-in memory indexes live in each agent's OpenClaw SQLite database at
 
 ## Memory admission policy
 
-Configure deterministic session exclusions under
-`plugins.entries.memory-core.config.memoryPolicy.excludeSessions`. Excluded
-sessions never enter the dreaming corpus, so the memory pipeline cannot turn
-them into promotion candidates or consolidated entries. For the policy story
-behind these keys — what admission and deletion guarantee and where their
-boundaries are — see
-[Memory provenance and deletion](/concepts/memory-provenance).
+Configure session exclusions for **dreaming ingestion and session backfill** under
+`plugins.entries.memory-core.config.memoryPolicy.excludeSessions`. These
+settings do not disable transcript search, restrict workspace writes, or
+erase existing memories. See
+[Memory provenance and deletion](/concepts/memory-provenance) for coverage and
+deletion workflows.
 
-| Key                          | Type       | Default | Matches                                   |
-| ---------------------------- | ---------- | ------- | ----------------------------------------- |
-| `hookExternalContentSources` | `string[]` | `[]`    | External-content hook sources, like Gmail |
-| `channels`                   | `string[]` | `[]`    | Session channel identifiers               |
-| `chatTypes`                  | `string[]` | `[]`    | `"direct"`, `"group"`, or `"channel"`     |
+| Key                          | Type       | Default | Matches                                                    |
+| ---------------------------- | ---------- | ------- | ---------------------------------------------------------- |
+| `hookExternalContentSources` | `string[]` | `[]`    | Recorded external-content hook sources, such as `"gmail"`. |
+| `channels`                   | `string[]` | `[]`    | Recorded channel/plugin identifiers, not room IDs.         |
+| `chatTypes`                  | `string[]` | `[]`    | Recorded chat type: `"direct"`, `"group"`, or `"channel"`. |
 
-Every setting is optional. Empty or omitted arrays preserve the existing
-admission behavior. A session matching any configured exclusion is recorded as
-excluded rather than silently ignored. Sessions previously purged by
-[`openclaw memory forget`](/cli/memory#memory-forget) are also excluded
-regardless of these settings; their recorded exclusion reason is `forgotten`.
-This durable per-agent exclusion prevents later dreaming sweeps, session
-backfills, and transcript reindexing from restoring the purged memory.
+Every setting is optional. Omitted or empty arrays add no exclusions;
+the normal provenance and session-kind gates still apply. Configured strings
+are trimmed, with empty values dropped, then matched exactly and case-sensitively.
+There are no glob patterns, substring matches, or message-content searches.
 
-<Warning>
-This is an ingestion boundary, not a file-write restriction. An agent running
-inside an excluded session can still edit `MEMORY.md`, `USER.md`, or another
-memory file directly during its turn. Such freeform edits do not gain
-entry-level lineage and are not removed automatically by `memory forget`;
-matching observed file writes appear in its `curatedWrites` report instead.
-</Warning>
+Lists combine with **OR**. For example, configuring a hook source and
+`chatTypes: ["group"]` excludes that hook source **and every group session**,
+not just group sessions from that source. Matching uses retained live session
+metadata. Missing metadata does not match a rule. Automatic dreaming separately
+skips retained archives; these lists do not establish whether another memory
+path can read an archived transcript.
 
 ```json5
 {
@@ -613,8 +609,6 @@ matching observed file writes appear in its `curatedWrites` report instead.
           memoryPolicy: {
             excludeSessions: {
               hookExternalContentSources: ["gmail"],
-              channels: ["email"],
-              chatTypes: ["group"],
             },
           },
         },
@@ -624,12 +618,32 @@ matching observed file writes appear in its `curatedWrites` report instead.
 }
 ```
 
-The policy alone prevents future ingestion; it does not erase memories already
-derived from those sources. To preview and remove existing entries and their
-derived artifacts while durably excluding the selected sessions from future
-memory ingestion, session backfill, and transcript indexing, use
-[`openclaw memory forget`](/cli/memory#memory-forget). The source session
-transcripts themselves remain in the session store.
+Automatic ingestion checks these rules before reading the transcript. A
+matched session's ingestion checkpoint records `excludedReason` as
+`hookExternalContentSource:<source>`,
+`channel:<channel>`, or `chatType:<type>`, in that precedence order.
+Removing the rule makes the session eligible for a later sweep, subject to
+the other ingestion gates.
+
+Sessions selected by [`memory forget`](/cli/memory#memory-forget) are checked
+first and receive the reason `forgotten`. Their durable per-agent exclusion
+also applies to session backfill and transcript indexing, and removing a
+configured rule does not undo it. It excludes the selected IDs, not every
+future session from the same source.
+
+<Warning>
+Configured admission rules apply to automatic dreaming ingestion and manual
+`memory session-backfill` previews, REM output, and apply runs. Raw transcript
+indexing does not apply these lists. Direct agent writes and session-memory hooks are also
+outside this policy. Use tool permissions and hook configuration when a
+session must not write memory files at all.
+</Warning>
+
+Adding a rule does not remove an existing corpus, short-term candidate, or
+promoted memory. Preview existing attributable artifacts with
+`memory forget --dry-run`, then review its
+[deletion boundaries](/concepts/memory-provenance#what-deletion-does-not-cover)
+before applying it. Source session transcripts remain in the session store.
 
 ---
 

--- a/extensions/memory-core/src/cli-rem.runtime.ts
+++ b/extensions/memory-core/src/cli-rem.runtime.ts
@@ -44,8 +44,9 @@ export async function runMemorySessionBackfill(
         process.exitCode = 1;
         return;
       }
+      const pluginConfig = resolveMemoryPluginConfig(cfg);
       const remConfig = resolveMemoryRemDreamingConfig({
-        pluginConfig: resolveMemoryPluginConfig(cfg),
+        pluginConfig,
         cfg,
       });
       let result;
@@ -53,6 +54,7 @@ export async function runMemorySessionBackfill(
         result = await runSessionBackfill({
           agentId,
           workspaceDir,
+          pluginConfig,
           ...(opts.from !== undefined ? { from: opts.from } : {}),
           ...(opts.to !== undefined ? { to: opts.to } : {}),
           ...(opts.limitDays !== undefined ? { limitDays: opts.limitDays } : {}),

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -6,7 +6,10 @@ import { Command } from "commander";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { resolveSessionTranscriptsDirForAgent as resolveTestSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  normalizeSessionDeliveryState,
+  upsertSessionEntry,
+} from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
 import {
@@ -51,12 +54,16 @@ async function expectPathMissing(targetPath: string): Promise<void> {
   expect((error as NodeJS.ErrnoException).code).toBe("ENOENT");
 }
 
-async function seedCliBackfillTranscript(sessionId: string, days: string[]): Promise<void> {
+async function seedCliBackfillTranscript(
+  sessionId: string,
+  days: string[],
+  metadata: Partial<Parameters<typeof upsertSessionEntry>[0]["entry"]> = {},
+): Promise<void> {
   const agentId = "main";
   const sessionsDir = resolveTestSessionTranscriptsDirForAgent(agentId);
   const storePath = path.join(sessionsDir, "sessions.json");
   const sessionKey = `agent:${agentId}:cli-session-backfill:${sessionId}`;
-  const entry = { sessionId, updatedAt: Date.parse(`${days.at(-1)}T12:00:00.000Z`) };
+  const entry = { ...metadata, sessionId, updatedAt: Date.now() };
   await fs.mkdir(sessionsDir, { recursive: true });
   await upsertSessionEntry({ agentId, sessionKey, storePath, entry });
   for (const day of days) {
@@ -465,12 +472,27 @@ describe("memory cli", () => {
     );
   });
 
-  it("drains session backfill in one apply command before preview", async () => {
+  it("drains admitted session backfill in one apply command before preview", async () => {
     const workspaceDir = path.join(workspaceFixtureRoot, `session-backfill-${workspaceCaseId++}`);
     vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, "state"));
     vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(workspaceDir, "openclaw.json"));
     await fs.mkdir(workspaceDir, { recursive: true });
     await seedCliBackfillTranscript("drain", ["2026-01-01", "2026-01-02", "2026-01-03"]);
+    await seedCliBackfillTranscript("excluded", ["2026-01-04"], {
+      delivery: normalizeSessionDeliveryState({
+        context: { channel: "discord", to: "channel:admission-fixture" },
+        origin: { provider: "discord", to: "channel:admission-fixture" },
+      }),
+    });
+    getRuntimeConfig.mockReturnValue({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: { memoryPolicy: { excludeSessions: { channels: ["discord"] } } },
+          },
+        },
+      },
+    });
 
     mockManager({ status: () => makeMemoryStatus({ workspaceDir }), close: vi.fn() });
     const applyJson = spyRuntimeJson(defaultRuntime);

--- a/extensions/memory-core/src/dreaming-dreams-file.ts
+++ b/extensions/memory-core/src/dreaming-dreams-file.ts
@@ -1,23 +1,14 @@
 // Memory Core helpers for safe managed DREAMS.md updates.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { createAsyncLock } from "openclaw/plugin-sdk/async-lock-runtime";
 import { extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
-import { resolveGlobalMap } from "openclaw/plugin-sdk/global-singleton";
 import { replaceManagedMarkdownBlock } from "openclaw/plugin-sdk/memory-host-markdown";
 import { readRegularFile, replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
+import { withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
 
 const DREAMS_FILENAMES = ["DREAMS.md", "dreams.md"] as const;
 const DEEP_START_MARKER = "<!-- openclaw:dreaming:deep:start -->";
 const DEEP_END_MARKER = "<!-- openclaw:dreaming:deep:end -->";
-const DREAMS_FILE_LOCKS_KEY = Symbol.for("openclaw.memoryCore.dreamingNarrative.fileLocks");
-
-type DreamsFileLockEntry = {
-  withLock: ReturnType<typeof createAsyncLock>;
-  refs: number;
-};
-
-const dreamsFileLocks = resolveGlobalMap<string, DreamsFileLockEntry>(DREAMS_FILE_LOCKS_KEY);
 
 export async function resolveDreamsPath(workspaceDir: string): Promise<string> {
   for (const name of DREAMS_FILENAMES) {
@@ -104,29 +95,18 @@ export async function updateDreamsFile<T>(params: {
         shouldWrite?: boolean;
       };
 }): Promise<T> {
-  const dreamsPath = await resolveDreamsPath(params.workspaceDir);
-  await fs.mkdir(path.dirname(dreamsPath), { recursive: true });
-  let lockEntry = dreamsFileLocks.get(dreamsPath);
-  if (!lockEntry) {
-    lockEntry = { withLock: createAsyncLock(), refs: 0 };
-    dreamsFileLocks.set(dreamsPath, lockEntry);
-  }
-  lockEntry.refs += 1;
-  try {
-    return await lockEntry.withLock(async () => {
-      const existing = await readDreamsFile(dreamsPath);
-      const { content, result, shouldWrite = true } = await params.updater(existing, dreamsPath);
-      if (shouldWrite) {
-        await writeDreamsFileAtomic(dreamsPath, content.endsWith("\n") ? content : `${content}\n`);
-      }
-      return result;
-    });
-  } finally {
-    lockEntry.refs -= 1;
-    if (lockEntry.refs <= 0 && dreamsFileLocks.get(dreamsPath) === lockEntry) {
-      dreamsFileLocks.delete(dreamsPath);
+  // Read and replace under the purge owner's lock so an awaited diary update
+  // cannot write a pre-deletion file snapshot back over the scrubbed contents.
+  return await withMemoryWorkspaceLock(params.workspaceDir, async () => {
+    const dreamsPath = await resolveDreamsPath(params.workspaceDir);
+    await fs.mkdir(path.dirname(dreamsPath), { recursive: true });
+    const existing = await readDreamsFile(dreamsPath);
+    const { content, result, shouldWrite = true } = await params.updater(existing, dreamsPath);
+    if (shouldWrite) {
+      await writeDreamsFileAtomic(dreamsPath, content.endsWith("\n") ? content : `${content}\n`);
     }
-  }
+    return result;
+  });
 }
 
 export async function updateDeepDreamsFile(params: {

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -6,6 +6,7 @@ import {
   RequestScopedSubagentRuntimeError,
   SUBAGENT_RUNTIME_REQUEST_SCOPE_ERROR_CODE,
 } from "openclaw/plugin-sdk/error-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { resolveGlobalMap } from "openclaw/plugin-sdk/global-singleton";
 import { resolveStateDir } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import * as runtimeConfigSnapshotModule from "openclaw/plugin-sdk/runtime-config-snapshot";
@@ -17,6 +18,7 @@ import {
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSqliteSessionTranscriptEventForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { updateDreamsFile } from "./dreaming-dreams-file.js";
 import {
   dedupeDreamDiaryEntries,
   readRecentDreamDiaryEntries,
@@ -24,12 +26,20 @@ import {
   runDreamNarrative,
   writeBackfillDiaryEntries,
 } from "./dreaming-narrative.js";
+import {
+  SHORT_TERM_LOCK_MAX_ENTRIES,
+  SHORT_TERM_LOCK_NAMESPACE,
+  memoryCoreWorkspaceStateKey,
+  openMemoryCoreStateStore,
+} from "./dreaming-state.js";
+import { forgetMemoryEntries } from "./memory-forget.js";
+import { SESSION_CORPUS_RELATIVE_DIR } from "./session-ingestion.js";
+import { readShortTermRecallEntries, recordShortTermRecalls } from "./short-term-promotion.js";
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
 
 vi.mock("openclaw/plugin-sdk/memory-core-host-runtime-core", { spy: true });
 
 const { createTempWorkspace } = createMemoryCoreTestHarness();
-const DREAMS_FILE_LOCKS_KEY = Symbol.for("openclaw.memoryCore.dreamingNarrative.fileLocks");
 const NARRATIVE_SESSION_LOCKS_KEY = Symbol.for(
   "openclaw.memoryCore.dreamingNarrative.sessionLocks",
 );
@@ -137,11 +147,53 @@ async function expectPathMissing(targetPath: string): Promise<void> {
 afterEach(() => {
   vi.restoreAllMocks();
   restoreNarrativeTestEnv();
-  resolveGlobalMap<string, unknown>(DREAMS_FILE_LOCKS_KEY).clear();
   resolveGlobalMap<string, unknown>(NARRATIVE_SESSION_LOCKS_KEY).clear();
 });
 
 describe("dream diary file behavior", () => {
+  it("does not restore deleted diary content from an update already in progress", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-forget-update-");
+    setNarrativeTestEnv(path.join(workspaceDir, ".state"));
+    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+    const claim = "A private cobalt archive phrase.";
+    await fs.writeFile(dreamsPath, `# Diary\n\n## Session ID: forgotten\n${claim}\n`);
+    const prepared = createDeferred<void>();
+    const publish = createDeferred<void>();
+    const update = updateDreamsFile({
+      workspaceDir,
+      updater: async (existing) => {
+        expect(existing).toContain(claim);
+        prepared.resolve();
+        await publish.promise;
+        return { content: `${existing}\n## Other\nA new unrelated entry.\n`, result: undefined };
+      },
+    });
+    let forgotten: ReturnType<typeof forgetMemoryEntries> | undefined;
+    try {
+      await prepared.promise;
+      const writerOwnsLock = await openMemoryCoreStateStore({
+        namespace: SHORT_TERM_LOCK_NAMESPACE,
+        maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
+      }).lookup(memoryCoreWorkspaceStateKey(workspaceDir));
+      forgotten = forgetMemoryEntries({
+        cfg: { agents: { entries: { main: { workspace: workspaceDir } } } },
+        agentId: "main",
+        sessionIds: ["forgotten"],
+      });
+      if (!writerOwnsLock) {
+        await forgotten;
+      }
+      publish.resolve();
+      await Promise.all([update, forgotten]);
+      const content = await fs.readFile(dreamsPath, "utf8");
+      expect(content).not.toContain(claim);
+      expect(content).toContain("A new unrelated entry.");
+    } finally {
+      publish.resolve();
+      await Promise.allSettled([update, ...(forgotten ? [forgotten] : [])]);
+    }
+  });
+
   it("writes, reads, deduplicates, and removes backfill entries", async () => {
     const workspaceDir = await createTempWorkspace("dreaming-narrative-backfill-");
     const written = await writeBackfillDiaryEntries({
@@ -1295,6 +1347,142 @@ describe("runDreamNarrative", () => {
     expect(deleteKeys.filter((key: string) => key === firstSessionKey)).toHaveLength(2);
     expect(deleteKeys.filter((key: string) => key === secondSessionKey)).toHaveLength(2);
   });
+});
+
+describe("runDreamNarrative deletion boundary", () => {
+  it.each([
+    { source: "tracked source", mutation: "forget" },
+    { source: "prior diary", mutation: "forget" },
+    { source: "prior diary", mutation: "unrelated append" },
+  ] as const)(
+    "validates $source before publishing generated quotes after $mutation",
+    async ({ source, mutation }) => {
+      const workspaceDir = await createTempWorkspace("dreaming-forget-generated-");
+      setNarrativeTestEnv(path.join(workspaceDir, ".state"));
+      const nowMs = Date.now();
+      const claim = "The private cobalt archive opens every midnight.";
+      const retainedClaim = "A public archive is open throughout the afternoon.";
+      const sourcePath = "memory/2026-08-26.md";
+      const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+      await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, sourcePath), `${claim}\n${retainedClaim}\n`);
+      await fs.mkdir(path.join(workspaceDir, SESSION_CORPUS_RELATIVE_DIR), { recursive: true });
+      await fs.writeFile(
+        path.join(workspaceDir, SESSION_CORPUS_RELATIVE_DIR, "2026-08-26.txt"),
+        `[main:forgotten-narrative-source#L1] ${claim}\n`,
+      );
+      await fs.writeFile(dreamsPath, "# Dream Diary\n\nA retained public diary entry.\n");
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "archive opening time",
+        signalType: "daily",
+        nowMs,
+        results: [
+          {
+            path: sourcePath,
+            startLine: 1,
+            endLine: 1,
+            score: 0.9,
+            snippet: claim,
+            source: "memory",
+            sessionOrigin: { agentId: "main", sessionId: "forgotten-narrative-source" },
+          },
+          {
+            path: sourcePath,
+            startLine: 2,
+            endLine: 2,
+            score: 0.9,
+            snippet: retainedClaim,
+            source: "memory",
+          },
+        ],
+      });
+      const entries = (await readShortTermRecallEntries({ workspaceDir, nowMs })).filter(
+        (entry) => entry.snippet === (source === "prior diary" ? retainedClaim : claim),
+      );
+      if (source === "prior diary") {
+        await writeBackfillDiaryEntries({
+          workspaceDir,
+          preserveExisting: true,
+          entries: [{ isoDay: "2026-08-26", bodyLines: [claim] }],
+        });
+      }
+      const waiting = createDeferred<void>();
+      const terminal = createDeferred<{
+        status: string;
+        terminalReply: { disposition: "visible"; text: string };
+      }>();
+      const reply = {
+        status: "ok",
+        terminalReply: { disposition: "visible" as const, text: `I remembered: ${claim}` },
+      };
+      const subagent = {
+        run: vi.fn().mockResolvedValue({ runId: "generated-after-forget" }),
+        waitForRun: vi.fn(async () => {
+          waiting.resolve();
+          return await terminal.promise;
+        }),
+        getSessionMessages: vi.fn().mockResolvedValue({ messages: [] }),
+        deleteSession: vi.fn().mockResolvedValue(undefined),
+      };
+      const data = {
+        phase: "light" as const,
+        snippets: entries.map((entry) => entry.snippet),
+        sourceEntryKeys: entries.map((entry) => entry.key),
+        ...(source === "prior diary"
+          ? { recentDiaryEntries: await readRecentDreamDiaryEntries({ workspaceDir }) }
+          : {}),
+      };
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const operation = runDreamNarrative({
+        agentId: "main",
+        subagent,
+        workspaceDir,
+        data,
+        nowMs,
+        logger,
+      });
+      try {
+        await waiting.promise;
+        expect(mockObjectArg(subagent.run, "subagent run").message).toContain(claim);
+        if (mutation === "forget") {
+          const forgotten = await forgetMemoryEntries({
+            cfg: { agents: { entries: { main: { workspace: workspaceDir } } } },
+            agentId: "main",
+            sessionIds: ["forgotten-narrative-source"],
+          });
+          expect(forgotten.artifacts.shortTermEntries).toBe(1);
+          expect(await fs.readFile(dreamsPath, "utf8")).not.toContain(claim);
+        } else {
+          // The original context remains valid even after it falls outside
+          // the recent-entry window used to prepare the next narrative.
+          await writeBackfillDiaryEntries({
+            workspaceDir,
+            preserveExisting: true,
+            entries: Array.from({ length: 4 }, (_, index) => ({
+              isoDay: "2026-08-26",
+              bodyLines: [`Another retained diary entry ${index}.`],
+            })),
+          });
+        }
+        terminal.resolve(reply);
+        const outcome = await operation;
+        const content = await fs.readFile(dreamsPath, "utf8");
+        expect(content).toContain("A retained public diary entry.");
+        if (mutation === "forget") {
+          expect(content).not.toContain(claim);
+          expect(outcome).toEqual({ status: "skipped" });
+          expectLogIncludes(logger.info, "narrative publication skipped");
+        } else {
+          expect(content).toContain(reply.terminalReply.text);
+          expect(outcome).toEqual({ status: "completed" });
+        }
+      } finally {
+        terminal.resolve(reply);
+        await operation;
+      }
+    },
+  );
 });
 
 describe("runDreamNarrative ownership gate", () => {

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -18,6 +18,7 @@ import {
   scrubDreamingNarrativeArtifacts,
 } from "./dreaming-session-cleanup.js";
 import { extractAssistantText } from "./dreaming-shared.js";
+import { readStore } from "./short-term-promotion-store.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -64,6 +65,8 @@ export type NarrativePhaseData = {
   promotions?: string[];
   currentDate?: string;
   recentDiaryEntries?: string[];
+  /** Tracked inputs that must still exist when generated text is published. */
+  sourceEntryKeys?: readonly string[];
 };
 
 type Logger = {
@@ -517,6 +520,18 @@ function isOptionalDiaryContextReadError(err: unknown): boolean {
   return err instanceof Error && err.message === "path must be a regular file";
 }
 
+function getDiaryContextEntries(existing: string): string[] {
+  const startIdx = existing.indexOf(DIARY_START_MARKER);
+  const endIdx = existing.indexOf(DIARY_END_MARKER);
+  if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
+    return [];
+  }
+  const inner = existing.slice(startIdx + DIARY_START_MARKER.length, endIdx);
+  return splitDiaryBlocks(inner)
+    .map(normalizeDiaryBlockBody)
+    .filter((entry) => entry.length > 0);
+}
+
 export async function readRecentDreamDiaryEntries(params: {
   workspaceDir: string;
   limit?: number;
@@ -535,17 +550,7 @@ export async function readRecentDreamDiaryEntries(params: {
     }
     throw err;
   }
-  const startIdx = existing.indexOf(DIARY_START_MARKER);
-  const endIdx = existing.indexOf(DIARY_END_MARKER);
-  if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
-    return [];
-  }
-  const inner = existing.slice(startIdx + DIARY_START_MARKER.length, endIdx);
-  return splitDiaryBlocks(inner)
-    .map(normalizeDiaryBlockBody)
-    .filter((entry) => entry.length > 0)
-    .slice(-limit)
-    .toReversed();
+  return getDiaryContextEntries(existing).slice(-limit).toReversed();
 }
 
 function normalizeDiaryBlockFingerprint(block: string): string {
@@ -780,12 +785,28 @@ async function appendNarrativeEntry(params: {
   narrative: string;
   nowMs: number;
   timezone?: string;
-}): Promise<string> {
+  sourceEntryKeys?: readonly string[];
+  recentDiaryEntries?: readonly string[];
+}): Promise<string | undefined> {
   const dateStr = formatNarrativeDate(params.nowMs, params.timezone);
   const entry = buildDiaryEntry(params.narrative, dateStr);
-  return await updateDreamsFile({
+  return await updateDreamsFile<string | undefined>({
     workspaceDir: params.workspaceDir,
-    updater: (existing, dreamsPath) => {
+    updater: async (existing, dreamsPath) => {
+      const sourceKeys = params.sourceEntryKeys ?? [];
+      const currentSources =
+        sourceKeys.length > 0
+          ? (await readStore(params.workspaceDir, new Date(params.nowMs).toISOString())).entries
+          : undefined;
+      const currentDiary = new Set(getDiaryContextEntries(existing));
+      // The updater holds the purge lock. Model work ran outside it, so both
+      // staged inputs and prior diary quotes must survive until this commit.
+      if (
+        sourceKeys.some((key) => !currentSources?.[key]) ||
+        params.recentDiaryEntries?.some((block) => !currentDiary.has(clampDiaryContextEntry(block)))
+      ) {
+        return { content: existing, result: undefined, shouldWrite: false };
+      }
       let updated: string;
       if (existing.includes(DIARY_START_MARKER) && existing.includes(DIARY_END_MARKER)) {
         const endIdx = existing.lastIndexOf(DIARY_END_MARKER);
@@ -844,6 +865,7 @@ async function generateAndAppendDreamNarrative(
   });
   const message = buildNarrativePrompt(params.data);
   let cleanupFailure: string | undefined;
+  let outcome: DreamNarrativeOutcome = { status: "completed" };
   await withNarrativeSessionLock(sessionKey, async () => {
     const attempts: Array<{ sessionKey: string; runId: string | null }> = [];
     let successfulSessionKey: string | null = null;
@@ -974,12 +996,21 @@ async function generateAndAppendDreamNarrative(
         return;
       }
 
-      await appendNarrativeEntry({
+      const dreamsPath = await appendNarrativeEntry({
         workspaceDir: params.workspaceDir,
         narrative,
         nowMs,
         timezone: params.timezone,
+        sourceEntryKeys: params.data.sourceEntryKeys,
+        recentDiaryEntries: params.data.recentDiaryEntries,
       });
+      if (dreamsPath === undefined) {
+        outcome = { status: "skipped" };
+        params.logger.info(
+          `memory-core: narrative publication skipped for ${params.data.phase} phase because source memory or diary context changed.`,
+        );
+        return;
+      }
 
       params.logger.info(
         `memory-core: dream diary entry written for ${params.data.phase} phase [workspace=${params.workspaceDir}].`,
@@ -1030,7 +1061,7 @@ async function generateAndAppendDreamNarrative(
       });
     }
   });
-  return cleanupFailure ? { status: "degraded", error: cleanupFailure } : { status: "completed" };
+  return cleanupFailure ? { status: "degraded", error: cleanupFailure } : outcome;
 }
 
 // ── Detached narrative concurrency limit ───────────────────────────────

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { RequestScopedSubagentRuntimeError } from "openclaw/plugin-sdk/error-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
   listMemoryArtifactProvenance,
   resolveMemoryDreamingPluginConfig,
@@ -20,9 +21,15 @@ import {
   runDreamingSweepPhases,
   seedHistoricalDailyMemorySignals,
 } from "./dreaming-phases.js";
+import {
+  memoryCoreWorkspaceStateKey,
+  openMemoryCoreStateStore,
+  SHORT_TERM_LOCK_MAX_ENTRIES,
+  SHORT_TERM_LOCK_NAMESPACE,
+} from "./dreaming-state.js";
 import { forgetMemoryEntries } from "./memory-forget.js";
 import { previewRemHarness } from "./rem-harness.js";
-import { writeSessionIngestionState } from "./session-ingestion.js";
+import { appendSessionCorpusLines, writeSessionIngestionState } from "./session-ingestion.js";
 import {
   applyShortTermPromotions,
   rankShortTermPromotionCandidates,
@@ -169,6 +176,7 @@ async function seedDreamingSessionTranscript(params: {
   messages: Array<{
     role: "assistant" | "user";
     content: unknown;
+    owner?: boolean;
     provenance?: { kind: "internal_system"; sourceTool: "heartbeat" };
     timestamp: number | string;
   }>;
@@ -212,6 +220,7 @@ async function seedDreamingSessionTranscript(params: {
       message: {
         role: message.role,
         content: message.content,
+        ...(message.owner ? { __openclaw: { senderIsOwner: true } } : {}),
         ...(message.provenance ? { provenance: message.provenance } : {}),
         timestamp: message.timestamp,
       },
@@ -1413,6 +1422,116 @@ describe("memory-core dreaming phases", () => {
       restoreDreamingTestEnv();
     }
   });
+
+  it.each(["light", "rem"] as const)(
+    "does not restore forgotten session quotes when %s publication is already prepared",
+    async (phase) => {
+      const workspaceDir = await createDreamingWorkspace();
+      setDreamingTestEnv(path.join(workspaceDir, ".state"));
+      const sessionId = "phase-publication";
+      const claim = "Keep the cobalt archive phrase only until deletion.";
+      const nowMs = Date.parse("2026-04-05T19:00:00.000Z");
+      await seedDreamingSessionTranscript({
+        sessionId,
+        messages: [{ role: "user", content: claim, timestamp: nowMs, owner: true }],
+      });
+      const results = await appendSessionCorpusLines({
+        workspaceDir,
+        day: DREAMING_TEST_DAY,
+        lines: [
+          {
+            day: DREAMING_TEST_DAY,
+            snippet: `User: ${claim}`,
+            rendered: `[main/sessions/main/${sessionId}#L2] User: ${claim}`,
+            provenance: { originClass: "owner", sessionKind: "interactive", observedAt: nowMs },
+            sessionOrigin: { agentId: "main", sessionId },
+          },
+        ],
+      });
+      for (const query of ["archive", "cobalt", "retention"]) {
+        await recordShortTermRecalls({ workspaceDir, query, results, nowMs });
+      }
+      expect(await readCandidateSnippets(workspaceDir, new Date(nowMs).toISOString())).toContain(
+        `User: ${claim}`,
+      );
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", workspace: workspaceDir }] },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  timezone: "UTC",
+                  storage: { mode: "both", separateReports: true },
+                  phases: {
+                    light: { enabled: phase === "light", limit: 20, lookbackDays: 7 },
+                    rem: { enabled: phase === "rem", limit: 20, lookbackDays: 7 },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const prepared = createDeferred<string>();
+      const publish = createDeferred<void>();
+      const dailyPath = path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`);
+      const originalRename = fs.rename;
+      let paused = false;
+      const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+        if (!paused && String(destination) === dailyPath) {
+          paused = true;
+          prepared.resolve(await fs.readFile(source, "utf8"));
+          await publish.promise;
+        }
+        await originalRename(source, destination);
+      });
+      const sweep = runDreamingSweepPhases({
+        agentId: "main",
+        workspaceDir,
+        cfg,
+        pluginConfig: resolveMemoryDreamingPluginConfig(cfg),
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        nowMs,
+      });
+      let forgotten: ReturnType<typeof forgetMemoryEntries> | undefined;
+      try {
+        const pendingContent = await Promise.race([
+          prepared.promise,
+          sweep.then(() => {
+            throw new Error("phase did not reach publication");
+          }),
+        ]);
+        expect(pendingContent).toContain(claim);
+        const publisherOwnsLock = await openMemoryCoreStateStore({
+          namespace: SHORT_TERM_LOCK_NAMESPACE,
+          maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
+        }).lookup(memoryCoreWorkspaceStateKey(workspaceDir));
+        forgotten = forgetMemoryEntries({ cfg, agentId: "main", sessionIds: [sessionId] });
+        // Finish deletion before a writer without a lease resumes. A serialized
+        // writer must finish first; this exercises both orders without sleeps.
+        if (!publisherOwnsLock) {
+          await forgotten;
+        }
+        publish.resolve();
+        await Promise.all([sweep, forgotten]);
+        for (const file of [
+          dailyPath,
+          path.join(workspaceDir, "memory", "dreaming", phase, `${DREAMING_TEST_DAY}.md`),
+        ]) {
+          expect(await fs.readFile(file, "utf8")).not.toContain(claim);
+        }
+        expect(
+          await readCandidateSnippets(workspaceDir, new Date(nowMs).toISOString()),
+        ).not.toContain(`User: ${claim}`);
+      } finally {
+        publish.resolve();
+        await Promise.allSettled([sweep, ...(forgotten ? [forgotten] : [])]);
+        renameSpy.mockRestore();
+      }
+    },
+  );
 
   it("redacts sensitive session content before writing session corpus", async () => {
     const workspaceDir = await createDreamingWorkspace();

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -41,6 +41,7 @@ import {
   writeMemoryCoreWorkspaceEntries,
 } from "./dreaming-state.js";
 import { listMemorySessionTombstones } from "./memory-entry-origins.js";
+import { withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
 import { textSimilarity as snippetSimilarity } from "./memory/tokenize.js";
 import {
   appendSessionCorpusLines,
@@ -763,33 +764,35 @@ async function ingestSessionTranscriptSignals(params: {
   timezone?: string;
   admissionPolicy?: SessionAdmissionPolicy;
 }): Promise<void> {
-  const state = await readSessionIngestionState(params.workspaceDir);
-  const collected = await collectSessionIngestionBatches({
-    workspaceDir: params.workspaceDir,
-    cfg: params.cfg,
-    primaryWorkspaceDir: params.primaryWorkspaceDir,
-    lookbackDays: params.lookbackDays,
-    nowMs: params.nowMs,
-    timezone: params.timezone,
-    state,
-    admissionPolicy: params.admissionPolicy,
-  });
-  const ingestionDayBucket = formatMemoryDreamingDay(params.nowMs, params.timezone);
-  for (const batch of collected.batches) {
-    await recordShortTermRecalls({
+  await withMemoryWorkspaceLock(params.workspaceDir, async () => {
+    const state = await readSessionIngestionState(params.workspaceDir);
+    const collected = await collectSessionIngestionBatches({
       workspaceDir: params.workspaceDir,
-      query: `__dreaming_sessions__:${batch.day}`,
-      results: batch.results,
-      signalType: "daily",
-      dedupeByQueryPerDay: true,
-      dayBucket: ingestionDayBucket,
+      cfg: params.cfg,
+      primaryWorkspaceDir: params.primaryWorkspaceDir,
+      lookbackDays: params.lookbackDays,
       nowMs: params.nowMs,
       timezone: params.timezone,
+      state,
+      admissionPolicy: params.admissionPolicy,
     });
-  }
-  if (collected.changed) {
-    await writeSessionIngestionState(params.workspaceDir, collected.nextState);
-  }
+    const ingestionDayBucket = formatMemoryDreamingDay(params.nowMs, params.timezone);
+    for (const batch of collected.batches) {
+      await recordShortTermRecalls({
+        workspaceDir: params.workspaceDir,
+        query: `__dreaming_sessions__:${batch.day}`,
+        results: batch.results,
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: ingestionDayBucket,
+        nowMs: params.nowMs,
+        timezone: params.timezone,
+      });
+    }
+    if (collected.changed) {
+      await writeSessionIngestionState(params.workspaceDir, collected.nextState);
+    }
+  });
 }
 
 type DailyIngestionCollectionResult = {
@@ -943,34 +946,36 @@ async function ingestDailyMemorySignals(params: {
   nowMs: number;
   timezone?: string;
 }): Promise<void> {
-  const state = await readDailyIngestionState(params.workspaceDir);
-  const ingestionDayBucket = formatMemoryDreamingDay(params.nowMs, params.timezone);
-  const collected = await collectDailyIngestionBatches({
-    workspaceDir: params.workspaceDir,
-    lookbackDays: params.lookbackDays,
-    limit: params.limit,
-    nowMs: params.nowMs,
-    ingestionDreamingDay: ingestionDayBucket,
-    state,
-  });
-  for (const batch of collected.batches) {
-    await recordShortTermRecalls({
+  await withMemoryWorkspaceLock(params.workspaceDir, async () => {
+    const state = await readDailyIngestionState(params.workspaceDir);
+    const ingestionDayBucket = formatMemoryDreamingDay(params.nowMs, params.timezone);
+    const collected = await collectDailyIngestionBatches({
       workspaceDir: params.workspaceDir,
-      query: `__dreaming_daily__:${batch.day}`,
-      results: batch.results,
-      signalType: "daily",
-      // The ingestion checkpoint already prevents duplicate unchanged files.
-      // File days remain the recurrence buckets; later changed-file ingestions
-      // still add a signal instead of being mistaken for the original pass.
-      dedupeByQueryPerDay: false,
-      dayBucket: batch.day,
+      lookbackDays: params.lookbackDays,
+      limit: params.limit,
       nowMs: params.nowMs,
-      timezone: params.timezone,
+      ingestionDreamingDay: ingestionDayBucket,
+      state,
     });
-  }
-  if (collected.changed) {
-    await writeDailyIngestionState(params.workspaceDir, collected.nextState);
-  }
+    for (const batch of collected.batches) {
+      await recordShortTermRecalls({
+        workspaceDir: params.workspaceDir,
+        query: `__dreaming_daily__:${batch.day}`,
+        results: batch.results,
+        signalType: "daily",
+        // The ingestion checkpoint already prevents duplicate unchanged files.
+        // File days remain the recurrence buckets; later changed-file ingestions
+        // still add a signal instead of being mistaken for the original pass.
+        dedupeByQueryPerDay: false,
+        dayBucket: batch.day,
+        nowMs: params.nowMs,
+        timezone: params.timezone,
+      });
+    }
+    if (collected.changed) {
+      await writeDailyIngestionState(params.workspaceDir, collected.nextState);
+    }
+  });
 }
 
 export async function seedHistoricalDailyMemorySignals(params: {
@@ -992,102 +997,104 @@ export async function seedHistoricalDailyMemorySignals(params: {
       skippedPaths: [],
     };
   }
-  const provenanceEntries = await listMemoryArtifactProvenance({
-    workspaceDir: params.workspaceDir,
-  });
-  const provenanceByPath = new Map(
-    provenanceEntries.map((entry) => [entry.relativePath, entry.provenance]),
-  );
-
-  const resolved = normalizedPaths
-    .map((filePath) => {
-      const fileName = path.basename(filePath);
-      const file = parseDailyMemoryFileName(fileName);
-      if (!file) {
-        return { filePath, fileName, relativePath: "", file: null as DailyMemoryFile | null };
-      }
-      return {
-        filePath,
-        fileName,
-        relativePath: resolveWorkspaceMemoryRelativePath(params.workspaceDir, filePath),
-        file,
-      };
-    })
-    .toSorted((a, b) => {
-      if (a.file && b.file) {
-        return compareDailyMemoryFilesByNewestDay(a.file, b.file);
-      }
-      if (a.file) {
-        return -1;
-      }
-      if (b.file) {
-        return 1;
-      }
-      return a.filePath.localeCompare(b.filePath);
-    });
-
-  const valid = resolved.filter(
-    (
-      entry,
-    ): entry is {
-      filePath: string;
-      fileName: string;
-      relativePath: string;
-      file: DailyMemoryFile;
-    } => Boolean(entry.file),
-  );
-  const skippedPaths = resolved.filter((entry) => !entry.file).map((entry) => entry.filePath);
-  const totalCap = Math.max(20, params.limit * 4);
-  const perFileCap = Math.max(6, Math.ceil(totalCap / Math.max(1, valid.length)));
-  let importedSignalCount = 0;
-  let importedFileCount = 0;
-
-  for (const entry of valid) {
-    if (importedSignalCount >= totalCap) {
-      break;
-    }
-    const raw = await fs.readFile(entry.filePath, "utf-8").catch((err: unknown) => {
-      if (extractErrorCode(err) === "ENOENT") {
-        skippedPaths.push(entry.filePath);
-        return "";
-      }
-      throw err;
-    });
-    if (!raw) {
-      continue;
-    }
-    const recordedProvenance = provenanceByPath.get(entry.relativePath);
-    // Same owner-controlled default as live daily ingestion above: workspace
-    // notes are 'agent' unless the flush explicitly recorded a downgrade.
-    const results = buildDailyIngestionResults({
-      raw,
-      path: entry.relativePath,
-      limit: Math.min(perFileCap, totalCap - importedSignalCount),
-      defaultObservedAt: params.nowMs,
-      ...(recordedProvenance ? { recorded: recordedProvenance } : {}),
-    });
-    if (results.length === 0) {
-      continue;
-    }
-    await recordShortTermRecalls({
+  return await withMemoryWorkspaceLock(params.workspaceDir, async () => {
+    const provenanceEntries = await listMemoryArtifactProvenance({
       workspaceDir: params.workspaceDir,
-      query: `__dreaming_daily__:${entry.file.day}`,
-      results,
-      signalType: "daily",
-      dedupeByQueryPerDay: true,
-      dayBucket: formatMemoryDreamingDay(params.nowMs, params.timezone),
-      nowMs: params.nowMs,
-      timezone: params.timezone,
     });
-    importedSignalCount += results.length;
-    importedFileCount += 1;
-  }
+    const provenanceByPath = new Map(
+      provenanceEntries.map((entry) => [entry.relativePath, entry.provenance]),
+    );
 
-  return {
-    importedFileCount,
-    importedSignalCount,
-    skippedPaths,
-  };
+    const resolved = normalizedPaths
+      .map((filePath) => {
+        const fileName = path.basename(filePath);
+        const file = parseDailyMemoryFileName(fileName);
+        if (!file) {
+          return { filePath, fileName, relativePath: "", file: null as DailyMemoryFile | null };
+        }
+        return {
+          filePath,
+          fileName,
+          relativePath: resolveWorkspaceMemoryRelativePath(params.workspaceDir, filePath),
+          file,
+        };
+      })
+      .toSorted((a, b) => {
+        if (a.file && b.file) {
+          return compareDailyMemoryFilesByNewestDay(a.file, b.file);
+        }
+        if (a.file) {
+          return -1;
+        }
+        if (b.file) {
+          return 1;
+        }
+        return a.filePath.localeCompare(b.filePath);
+      });
+
+    const valid = resolved.filter(
+      (
+        entry,
+      ): entry is {
+        filePath: string;
+        fileName: string;
+        relativePath: string;
+        file: DailyMemoryFile;
+      } => Boolean(entry.file),
+    );
+    const skippedPaths = resolved.filter((entry) => !entry.file).map((entry) => entry.filePath);
+    const totalCap = Math.max(20, params.limit * 4);
+    const perFileCap = Math.max(6, Math.ceil(totalCap / Math.max(1, valid.length)));
+    let importedSignalCount = 0;
+    let importedFileCount = 0;
+
+    for (const entry of valid) {
+      if (importedSignalCount >= totalCap) {
+        break;
+      }
+      const raw = await fs.readFile(entry.filePath, "utf-8").catch((err: unknown) => {
+        if (extractErrorCode(err) === "ENOENT") {
+          skippedPaths.push(entry.filePath);
+          return "";
+        }
+        throw err;
+      });
+      if (!raw) {
+        continue;
+      }
+      const recordedProvenance = provenanceByPath.get(entry.relativePath);
+      // Same owner-controlled default as live daily ingestion above: workspace
+      // notes are 'agent' unless the flush explicitly recorded a downgrade.
+      const results = buildDailyIngestionResults({
+        raw,
+        path: entry.relativePath,
+        limit: Math.min(perFileCap, totalCap - importedSignalCount),
+        defaultObservedAt: params.nowMs,
+        ...(recordedProvenance ? { recorded: recordedProvenance } : {}),
+      });
+      if (results.length === 0) {
+        continue;
+      }
+      await recordShortTermRecalls({
+        workspaceDir: params.workspaceDir,
+        query: `__dreaming_daily__:${entry.file.day}`,
+        results,
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: formatMemoryDreamingDay(params.nowMs, params.timezone),
+        nowMs: params.nowMs,
+        timezone: params.timezone,
+      });
+      importedSignalCount += results.length;
+      importedFileCount += 1;
+    }
+
+    return {
+      importedFileCount,
+      importedSignalCount,
+      skippedPaths,
+    };
+  });
 }
 
 function entryAverageScore(entry: ShortTermRecallEntry): number {
@@ -1102,8 +1109,11 @@ function entryAverageScore(entry: ShortTermRecallEntry): number {
 
 // Use the shared CJK-aware similarity helper so close-but-not-identical CJK
 // snippets do not slip past the dedupe threshold via the old ASCII-only path.
-function dedupeEntries(entries: ShortTermRecallEntry[], threshold: number): ShortTermRecallEntry[] {
-  const deduped: ShortTermRecallEntry[] = [];
+function dedupeEntries(
+  entries: ShortTermRecallEntry[],
+  threshold: number,
+): Array<ShortTermRecallEntry & { sourceEntryKeys: string[] }> {
+  const deduped: Array<ShortTermRecallEntry & { sourceEntryKeys: string[] }> = [];
   for (const entry of entries) {
     const duplicate = deduped.find(
       (candidate) =>
@@ -1111,6 +1121,8 @@ function dedupeEntries(entries: ShortTermRecallEntry[], threshold: number): Shor
         snippetSimilarity(candidate.snippet, entry.snippet) >= threshold,
     );
     if (duplicate) {
+      // Merged tags also become narrative input, so retain their source keys.
+      duplicate.sourceEntryKeys.push(entry.key);
       if (entry.recallCount > duplicate.recallCount) {
         duplicate.recallCount = entry.recallCount;
       }
@@ -1127,7 +1139,7 @@ function dedupeEntries(entries: ShortTermRecallEntry[], threshold: number): Shor
           : duplicate.lastRecalledAt;
       continue;
     }
-    deduped.push({ ...entry });
+    deduped.push({ ...entry, sourceEntryKeys: [entry.key] });
   }
   return deduped;
 }
@@ -1153,15 +1165,15 @@ function isEntryCoveredByRecentDiary(
   });
 }
 
-function prioritizeLightEntriesByDiaryCoverage(
-  entries: ShortTermRecallEntry[],
+function prioritizeLightEntriesByDiaryCoverage<T extends ShortTermRecallEntry>(
+  entries: T[],
   recentDiaryEntries: readonly string[],
-): ShortTermRecallEntry[] {
+): T[] {
   if (recentDiaryEntries.length === 0) {
     return entries;
   }
-  const fresh: ShortTermRecallEntry[] = [];
-  const covered: ShortTermRecallEntry[] = [];
+  const fresh: T[] = [];
+  const covered: T[] = [];
   for (const entry of entries) {
     if (isEntryCoveredByRecentDiary(entry, recentDiaryEntries)) {
       covered.push(entry);
@@ -1350,62 +1362,72 @@ async function runLightDreaming(
   params: DreamingPhaseRunParams<LightDreamingConfig>,
 ): Promise<DreamNarrativeOutcome> {
   const nowMs = await ingestDreamingPhaseSignals(params);
-  const recentEntries = (
-    await filterLiveShortTermRecallEntries({
-      workspaceDir: params.workspaceDir,
-      entries: await filterFreshLightDreamingEntries({
+  // Freeze source selection through publication so forget cannot finish
+  // between reading a candidate and writing its quote into a phase report.
+  const prepared = await withMemoryWorkspaceLock(params.workspaceDir, async () => {
+    const recentEntries = (
+      await filterLiveShortTermRecallEntries({
         workspaceDir: params.workspaceDir,
-        nowMs,
-        entries: filterRecallEntriesWithinLookback({
-          entries: await readShortTermRecallEntries({ workspaceDir: params.workspaceDir, nowMs }),
+        entries: await filterFreshLightDreamingEntries({
+          workspaceDir: params.workspaceDir,
           nowMs,
-          lookbackDays: params.config.lookbackDays,
+          entries: filterRecallEntriesWithinLookback({
+            entries: await readShortTermRecallEntries({
+              workspaceDir: params.workspaceDir,
+              nowMs,
+            }),
+            nowMs,
+            lookbackDays: params.config.lookbackDays,
+          }),
         }),
+      })
+    ).filter((entry) => !isPromotionOriginBlocked(entry));
+    const rankedEntries = dedupeEntries(
+      recentEntries.toSorted((a, b) => {
+        const byTime = compareStoreTimestampDesc(a.lastRecalledAt, b.lastRecalledAt);
+        if (byTime !== 0) {
+          return byTime;
+        }
+        return b.recallCount - a.recallCount;
       }),
-    })
-  ).filter((entry) => !isPromotionOriginBlocked(entry));
-  const rankedEntries = dedupeEntries(
-    recentEntries.toSorted((a, b) => {
-      const byTime = compareStoreTimestampDesc(a.lastRecalledAt, b.lastRecalledAt);
-      if (byTime !== 0) {
-        return byTime;
-      }
-      return b.recallCount - a.recallCount;
-    }),
-    params.config.dedupeSimilarity,
-  );
-  const recentDiaryEntries = await readRecentDreamDiaryEntries({
-    workspaceDir: params.workspaceDir,
-    limit: LIGHT_DIARY_HISTORY_LIMIT,
-  });
-  const entries = prioritizeLightEntriesByDiaryCoverage(rankedEntries, recentDiaryEntries);
-  const capped = entries.slice(0, params.config.limit);
-  const bodyLines = buildLightDreamingBody(capped);
-  await writeDailyDreamingPhaseBlock({
-    workspaceDir: params.workspaceDir,
-    phase: "light",
-    bodyLines,
-    nowMs,
-    timezone: params.config.timezone,
-    storage: params.config.storage,
-  });
-  await recordDreamingPhaseSignals({
-    workspaceDir: params.workspaceDir,
-    phase: "light",
-    keys: capped.map((entry) => entry.key),
-    nowMs,
-  });
-  if (params.config.enabled && entries.length > 0 && params.config.storage.mode !== "separate") {
-    params.logger.info(
-      `memory-core: light dreaming staged ${Math.min(entries.length, params.config.limit)} candidate(s) [workspace=${params.workspaceDir}].`,
+      params.config.dedupeSimilarity,
     );
-  }
+    const recentDiaryEntries = await readRecentDreamDiaryEntries({
+      workspaceDir: params.workspaceDir,
+      limit: LIGHT_DIARY_HISTORY_LIMIT,
+    });
+    const entries = prioritizeLightEntriesByDiaryCoverage(rankedEntries, recentDiaryEntries);
+    const capped = entries.slice(0, params.config.limit);
+    const bodyLines = buildLightDreamingBody(capped);
+    await writeDailyDreamingPhaseBlock({
+      workspaceDir: params.workspaceDir,
+      phase: "light",
+      bodyLines,
+      nowMs,
+      timezone: params.config.timezone,
+      storage: params.config.storage,
+    });
+    await recordDreamingPhaseSignals({
+      workspaceDir: params.workspaceDir,
+      phase: "light",
+      keys: capped.map((entry) => entry.key),
+      nowMs,
+    });
+    if (params.config.enabled && entries.length > 0 && params.config.storage.mode !== "separate") {
+      params.logger.info(
+        `memory-core: light dreaming staged ${Math.min(entries.length, params.config.limit)} candidate(s) [workspace=${params.workspaceDir}].`,
+      );
+    }
+    return { capped, recentDiaryEntries };
+  });
+  const { capped, recentDiaryEntries } = prepared;
   // Generate dream diary narrative from the staged entries.
   if (params.subagent && capped.length > 0) {
     const themes = uniqueStrings(capped.flatMap((e) => e.conceptTags).filter(Boolean));
     const data: NarrativePhaseData = {
       phase: "light",
       snippets: capped.map((e) => e.snippet).filter(Boolean),
+      sourceEntryKeys: capped.flatMap((entry) => entry.sourceEntryKeys),
       currentDate: formatMemoryDreamingDay(nowMs, params.config.timezone),
       ...(themes.length > 0 ? { themes } : {}),
       ...(recentDiaryEntries.length > 0 ? { recentDiaryEntries } : {}),
@@ -1429,56 +1451,60 @@ async function runRemDreaming(
   params: DreamingPhaseRunParams<RemDreamingConfig>,
 ): Promise<DreamNarrativeOutcome> {
   const nowMs = await ingestDreamingPhaseSignals(params);
-  const allEntries = (
-    await filterLiveShortTermRecallEntries({
+  const prepared = await withMemoryWorkspaceLock(params.workspaceDir, async () => {
+    const allEntries = (
+      await filterLiveShortTermRecallEntries({
+        workspaceDir: params.workspaceDir,
+        entries: filterRecallEntriesWithinLookback({
+          entries: await readShortTermRecallEntries({ workspaceDir: params.workspaceDir, nowMs }),
+          nowMs,
+          lookbackDays: params.config.lookbackDays,
+        }),
+      })
+    ).filter((entry) => !isPromotionOriginBlocked(entry));
+    // Prefer entries staged by light sleep so REM synthesises from the
+    // sequential light→REM pipeline instead of rescanning the full store.
+    const lightKeys = await readLightStagedKeys({
       workspaceDir: params.workspaceDir,
-      entries: filterRecallEntriesWithinLookback({
-        entries: await readShortTermRecallEntries({ workspaceDir: params.workspaceDir, nowMs }),
-        nowMs,
-        lookbackDays: params.config.lookbackDays,
-      }),
-    })
-  ).filter((entry) => !isPromotionOriginBlocked(entry));
-  // Prefer entries staged by light sleep so REM synthesises from the
-  // sequential light→REM pipeline instead of rescanning the full store.
-  const lightKeys = await readLightStagedKeys({
-    workspaceDir: params.workspaceDir,
-    nowMs,
-  });
-  const stagedEntries =
-    lightKeys.size > 0 ? allEntries.filter((entry) => lightKeys.has(entry.key)) : [];
-  const entries = stagedEntries.length > 0 ? stagedEntries : allEntries;
-  const preview = previewRemDreaming({
-    entries,
-    limit: params.config.limit,
-    minPatternStrength: params.config.minPatternStrength,
-  });
-  await writeDailyDreamingPhaseBlock({
-    workspaceDir: params.workspaceDir,
-    phase: "rem",
-    bodyLines: preview.bodyLines,
-    nowMs,
-    timezone: params.config.timezone,
-    storage: params.config.storage,
-  });
-  if (stagedEntries.length > 0) {
-    await recordRemConsideredPhaseSignals({
-      workspaceDir: params.workspaceDir,
-      keys: stagedEntries.map((entry) => entry.key),
       nowMs,
     });
-  }
-  await recordDreamingPhaseSignals({
-    workspaceDir: params.workspaceDir,
-    phase: "rem",
-    keys: preview.candidateKeys,
-    nowMs,
+    const stagedEntries =
+      lightKeys.size > 0 ? allEntries.filter((entry) => lightKeys.has(entry.key)) : [];
+    const entries = stagedEntries.length > 0 ? stagedEntries : allEntries;
+    const preview = previewRemDreaming({
+      entries,
+      limit: params.config.limit,
+      minPatternStrength: params.config.minPatternStrength,
+    });
+    await writeDailyDreamingPhaseBlock({
+      workspaceDir: params.workspaceDir,
+      phase: "rem",
+      bodyLines: preview.bodyLines,
+      nowMs,
+      timezone: params.config.timezone,
+      storage: params.config.storage,
+    });
+    if (stagedEntries.length > 0) {
+      await recordRemConsideredPhaseSignals({
+        workspaceDir: params.workspaceDir,
+        keys: stagedEntries.map((entry) => entry.key),
+        nowMs,
+      });
+    }
+    await recordDreamingPhaseSignals({
+      workspaceDir: params.workspaceDir,
+      phase: "rem",
+      keys: preview.candidateKeys,
+      nowMs,
+    });
+    if (params.config.enabled && entries.length > 0 && params.config.storage.mode !== "separate") {
+      params.logger.info(
+        `memory-core: REM dreaming wrote reflections from ${entries.length} recent memory trace(s) [workspace=${params.workspaceDir}].`,
+      );
+    }
+    return { entries, preview };
   });
-  if (params.config.enabled && entries.length > 0 && params.config.storage.mode !== "separate") {
-    params.logger.info(
-      `memory-core: REM dreaming wrote reflections from ${entries.length} recent memory trace(s) [workspace=${params.workspaceDir}].`,
-    );
-  }
+  const { entries, preview } = prepared;
   // Generate dream diary narrative from REM reflections.
   if (params.subagent && entries.length > 0) {
     const snippets = preview.candidateTruths.map((t) => t.snippet).filter(Boolean);
@@ -1487,6 +1513,7 @@ async function runRemDreaming(
     );
     const data: NarrativePhaseData = {
       phase: "rem",
+      sourceEntryKeys: entries.map((entry) => entry.key),
       snippets:
         snippets.length > 0
           ? snippets

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -758,6 +758,9 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
           phase: "deep",
           snippets: candidates.map((c) => c.snippet).filter(Boolean),
           promotions: applied.appliedCandidates.map((c) => c.snippet).filter(Boolean),
+          sourceEntryKeys: [
+            ...new Set([...candidates, ...applied.appliedCandidates].map((c) => c.key)),
+          ],
         };
         if (!params.subagent) {
           await appendFallbackNarrativeEntry({

--- a/extensions/memory-core/src/memory-entry-origins.test.ts
+++ b/extensions/memory-core/src/memory-entry-origins.test.ts
@@ -77,6 +77,7 @@ describe("memory entry origins", () => {
   it("lazily persists forgotten sessions without recreating tombstones on reads or repeat writes", () => {
     const db = openOpenClawAgentDatabase({ agentId: "main" }).db;
     const version = db.prepare("PRAGMA user_version").get();
+    const revisionBefore = db.prepare("SELECT revision FROM memory_index_state WHERE id = 1").get();
     db.exec("DROP TABLE IF EXISTS memory_session_tombstones");
 
     expect(listMemorySessionTombstones({ agentId: "main" })).toEqual([]);
@@ -96,6 +97,10 @@ describe("memory entry origins", () => {
         createdAt: 1_000,
       }),
     ).toBe(2);
+    const deletionRevision = db
+      .prepare("SELECT revision FROM memory_index_state WHERE id = 1")
+      .get();
+    expect(deletionRevision).not.toEqual(revisionBefore);
     expect(
       recordMemorySessionTombstones({
         agentId: "main",
@@ -104,6 +109,9 @@ describe("memory entry origins", () => {
         createdAt: 2_000,
       }),
     ).toBe(0);
+    expect(db.prepare("SELECT revision FROM memory_index_state WHERE id = 1").get()).toEqual(
+      deletionRevision,
+    );
     expect(listMemorySessionTombstones({ agentId: "main" })).toEqual([
       { sessionId: "session-1", agentId: "main", reason: "forgotten", createdAt: 1_000 },
       { sessionId: "session-2", agentId: "main", reason: "forgotten", createdAt: 1_000 },

--- a/extensions/memory-core/src/memory-entry-origins.ts
+++ b/extensions/memory-core/src/memory-entry-origins.ts
@@ -44,6 +44,7 @@ type MemorySessionTombstoneRow = {
 type MemoryOriginDatabase = {
   memory_entry_origins: MemoryEntryOriginRow;
   memory_session_tombstones: MemorySessionTombstoneRow;
+  memory_index_state: { id: number; revision: number };
 };
 type SqliteSchemaDatabase = { sqlite_schema: { type: string; name: string } };
 const ensuredDatabases = new WeakSet<DatabaseSync>();
@@ -202,8 +203,40 @@ export function recordMemorySessionTombstones(params: {
       );
       recorded += Number(result.numAffectedRows ?? 0n);
     }
+    if (recorded > 0) {
+      // A shadow index can have no published chunks yet. Its existing revision
+      // fence must still reject a rebuild prepared before this deletion.
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .updateTable("memory_index_state")
+          .set((expression) => ({ revision: expression("revision", "+", 1) }))
+          .where("id", "=", 1),
+      );
+    }
     return recorded;
   });
+}
+
+export function hasMemorySessionTombstone(
+  db: DatabaseSync,
+  agentId: string,
+  sessionId: string,
+): boolean {
+  if (!ensuredTombstoneDatabases.has(db) && !hasMemoryTable(db, "memory_session_tombstones")) {
+    return false;
+  }
+  const kysely = getNodeSqliteKysely<MemoryOriginDatabase>(db);
+  return (
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .selectFrom("memory_session_tombstones")
+        .select("session_id")
+        .where("agent_id", "=", agentId)
+        .where("session_id", "=", sessionId),
+    ).rows.length > 0
+  );
 }
 
 export function recordMemoryEntryOrigins(params: {

--- a/extensions/memory-core/src/memory-forget-curated-writes.test.ts
+++ b/extensions/memory-core/src/memory-forget-curated-writes.test.ts
@@ -1,0 +1,224 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { zstdCompressSync } from "node:zlib";
+import { createOpenClawCodingTools } from "openclaw/plugin-sdk/agent-harness";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { listSessionTranscriptCorpusEntriesForAgent } from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
+import { listMemoryArtifactProvenance } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  closeOpenClawStateDatabaseForTest,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { forgetMemoryEntries } from "./memory-forget.js";
+import {
+  configureMemoryCoreDreamingStateForTests,
+  createMemoryCoreTestHarness,
+} from "./test-helpers.js";
+
+describe("memory forget curated writes", () => {
+  const { createTempWorkspace } = createMemoryCoreTestHarness();
+  let stateDir: string;
+  let workspaceDir: string;
+  let cfg: OpenClawConfig;
+
+  beforeEach(async () => {
+    stateDir = await fs.realpath(await createTempWorkspace("memory-forget-curated-writes-"));
+    workspaceDir = path.join(stateDir, "workspace");
+    await fs.mkdir(workspaceDir);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    await configureMemoryCoreDreamingStateForTests();
+    cfg = {
+      agents: { defaults: { workspace: workspaceDir }, list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    resetPluginStateStoreForTests();
+    vi.unstubAllEnvs();
+  });
+
+  async function seedSession(sessionId: string): Promise<void> {
+    await upsertSessionEntry({
+      agentId: "main",
+      sessionKey: `agent:main:${sessionId}`,
+      entry: { sessionId, updatedAt: 1_000 },
+    });
+  }
+
+  it("reports session-authored curated memory without deleting unattributable file content", async () => {
+    await seedSession("target");
+    const curatedContent = "# Long-Term Memory\nThe launch code is violet.\n";
+    const writeTool = createOpenClawCodingTools({
+      workspaceDir,
+      config: cfg,
+      sessionId: "target",
+      sessionKey: "agent:main:target",
+      senderIsOwner: true,
+    }).find((tool) => tool.name === "write");
+    expect(writeTool).toBeDefined();
+    await writeTool!.execute("write-curated-memory", {
+      path: "MEMORY.md",
+      content: curatedContent,
+    });
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: "main",
+      sessionId: "target",
+      sessionKey: "agent:main:target",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "observed-write",
+            name: "write",
+            arguments: { path: "MEMORY.md" },
+          },
+        ],
+      },
+    });
+
+    const preview = await forgetMemoryEntries({
+      cfg,
+      agentId: "main",
+      sessionIds: ["target"],
+      dryRun: true,
+    });
+    expect(preview.curatedWrites).toEqual([
+      { relativePath: "MEMORY.md", observedAt: expect.any(Number) },
+    ]);
+    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(curatedContent);
+
+    const report = await forgetMemoryEntries({
+      cfg,
+      agentId: "main",
+      sessionIds: ["target"],
+    });
+    expect(report).toEqual({ ...preview, dryRun: false });
+    expect(report.artifacts.memoryFiles).toBe(0);
+    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(curatedContent);
+  });
+
+  it("reports harness memory writes from selected live and archived transcripts without observer state", async () => {
+    await seedSession("survivor");
+    await seedSession("target");
+    const observedAt = Date.parse("2026-08-26T12:34:56.000Z");
+    const memoryContent = "# Long-Term Memory\nA harness-authored private fact.\n";
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memoryContent);
+    await fs.writeFile(path.join(workspaceDir, "USER.md"), "# User\n");
+    await fs.writeFile(path.join(workspaceDir, "memory", "profile.md"), "# Profile\n");
+    const patchInput = [
+      "*** Begin Patch",
+      "*** Update File: MEMORY.md",
+      "@@",
+      "+A harness-authored private fact.",
+      "*** Update File: README.md",
+      "@@",
+      "+Not a memory file.",
+      "*** End Patch",
+    ].join("\n");
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: "main",
+      sessionId: "target",
+      sessionKey: "agent:main:target",
+      message: {
+        role: "assistant",
+        timestamp: observedAt,
+        content: [
+          { type: "toolCall", id: "patch", name: "apply_patch", arguments: { input: patchInput } },
+          { type: "toolCall", id: "profile", name: "write", arguments: { path: "USER.md" } },
+          {
+            type: "toolCall",
+            id: "nested",
+            name: "edit",
+            input: { file_path: path.join(workspaceDir, "memory", "profile.md") },
+          },
+          {
+            type: "toolCall",
+            id: "structured",
+            name: "apply_patch",
+            arguments: { changes: [{ path: "memory/structured.md" }, { path: "README.md" }] },
+          },
+          { type: "toolCall", id: "ordinary", name: "write", arguments: { path: "README.md" } },
+          { type: "toolCall", id: "escaping", name: "edit", arguments: { path: "../MEMORY.md" } },
+          { type: "toolCall", id: "malformed", name: "apply_patch", arguments: { input: 42 } },
+          { type: "toolCall", id: "read-only", name: "read", arguments: { path: "MEMORY.md" } },
+          { type: "toolCall", id: "missing", name: "write", arguments: null },
+          null,
+        ],
+      },
+    });
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: "main",
+      sessionId: "survivor",
+      sessionKey: "agent:main:survivor",
+      message: {
+        role: "assistant",
+        timestamp: observedAt + 1,
+        content: [
+          {
+            type: "toolCall",
+            id: "unselected",
+            name: "write",
+            arguments: { path: "memory/keep.md" },
+          },
+        ],
+      },
+    });
+    const archiveDir = path.join(stateDir, "agents", "main", "sessions");
+    await fs.mkdir(archiveDir, { recursive: true });
+    const archivedMessage = {
+      type: "message",
+      timestamp: new Date(observedAt + 1).toISOString(),
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "archived",
+            name: "edit",
+            input: { filePath: "memory/archive.md" },
+          },
+        ],
+      },
+    };
+    await fs.writeFile(
+      path.join(archiveDir, "target.jsonl.deleted.2026-08-26T12-35-00.000Z.zst"),
+      zstdCompressSync(`${JSON.stringify(archivedMessage)}\n`),
+    );
+    expect(await listSessionTranscriptCorpusEntriesForAgent("main")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sessionId: "target", artifactKind: "active-session" }),
+        expect.objectContaining({ sessionId: "target", artifactKind: "archive-artifact" }),
+      ]),
+    );
+    expect(await listMemoryArtifactProvenance({ workspaceDir })).toEqual([]);
+
+    const preview = await forgetMemoryEntries({
+      cfg,
+      agentId: "main",
+      sessionIds: ["target"],
+      dryRun: true,
+    });
+
+    expect(preview.curatedWrites).toEqual([
+      { relativePath: "MEMORY.md", observedAt },
+      { relativePath: "memory/archive.md", observedAt: observedAt + 1 },
+      { relativePath: "memory/profile.md", observedAt },
+      { relativePath: "memory/structured.md", observedAt },
+      { relativePath: "USER.md", observedAt },
+    ]);
+    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(memoryContent);
+
+    const report = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["target"] });
+    expect(report).toEqual({ ...preview, dryRun: false });
+    expect(report.artifacts.memoryFiles).toBe(0);
+    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(memoryContent);
+  });
+});

--- a/extensions/memory-core/src/memory-forget.test.ts
+++ b/extensions/memory-core/src/memory-forget.test.ts
@@ -4,11 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { zstdCompressSync } from "node:zlib";
-import { createOpenClawCodingTools } from "openclaw/plugin-sdk/agent-harness";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
-import { listSessionTranscriptCorpusEntriesForAgent } from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
 import { loadSqliteVecExtension } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
-import { listMemoryArtifactProvenance } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { deleteSessionEntry, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
@@ -31,11 +28,13 @@ import {
 } from "./memory-entry-origins.js";
 import { forgetMemoryEntries } from "./memory-forget.js";
 import { closeMemoryDatabase, openMemoryDatabaseAtPath } from "./memory/manager-db.js";
+import { runSessionBackfill } from "./session-backfill.js";
 import { readSessionIngestionState, writeSessionIngestionState } from "./session-ingestion.js";
 import { buildPromotionRecallAnnotations } from "./short-term-promotion-metadata.js";
 import {
   applyShortTermPromotions,
   rankShortTermPromotionCandidates,
+  readShortTermRecallEntries,
   recordShortTermRecalls,
 } from "./short-term-promotion.js";
 import { configureMemoryCoreDreamingStateForTests } from "./test-helpers.js";
@@ -208,6 +207,73 @@ describe("memory forget", () => {
     ).toEqual(report);
     expect(listMemorySessionTombstones({ agentId: "main" })).toEqual(tombstones);
   });
+
+  it("removes staged backfill entries when their source session is forgotten", async () => {
+    await seedSession("backfilled");
+    const nowMs = Date.parse("2026-08-26T12:00:00.000Z");
+    const privateFact = "The project launch code is amber-indigo.";
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: "main",
+      sessionId: "backfilled",
+      sessionKey: "agent:main:backfilled",
+      message: {
+        role: "user",
+        content: privateFact,
+        timestamp: nowMs,
+        __openclaw: { senderIsOwner: true },
+      },
+    });
+    const applied = await runSessionBackfill({
+      agentId: "main",
+      workspaceDir,
+      apply: true,
+      nowMs,
+      timezone: "UTC",
+    });
+    expect(applied.stagedEntries).toBe(1);
+    const report = await forgetMemoryEntries({
+      cfg,
+      agentId: "main",
+      sessionIds: ["backfilled"],
+    });
+    const remaining = await readShortTermRecallEntries({ workspaceDir, nowMs });
+    expect(report.artifacts.shortTermEntries).toBe(1);
+    expect(remaining.map((entry) => entry.snippet)).not.toContain(privateFact);
+  });
+
+  it.each(["prefix-survivor", "prefix.jsonl.other", "PREFIX"])(
+    "does not purge session %s when an unresolved explicit selector is prefix",
+    async (survivorId) => {
+      await seedSession(survivorId);
+      const corpusDir = path.join(workspaceDir, "memory", ".dreams", "session-corpus");
+      await fs.mkdir(corpusDir, { recursive: true });
+      const corpusPath = path.join(corpusDir, "2026-08-26.txt");
+      const content = `[main/sessions/main/${survivorId}#L1] User: Preserve this unrelated fact.\n`;
+      await fs.writeFile(corpusPath, content);
+      const db = openOpenClawAgentDatabase({ agentId: "main" }).db;
+      db.prepare(
+        `INSERT INTO memory_index_chunks
+        (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+       VALUES ('survivor-chunk', ?, 'sessions', 1, 1,
+         'survivor-hash', 'test', 'Preserve this unrelated fact.', '[1,0]', 1)`,
+      ).run(`sessions/main/${survivorId}.jsonl`);
+      db.prepare(
+        `INSERT INTO memory_index_chunk_provenance
+        (chunk_id, origin_class, session_kind, observed_at)
+       VALUES ('survivor-chunk', 'owner', 'interactive', 1)`,
+      ).run();
+      const report = await forgetMemoryEntries({
+        cfg,
+        agentId: "main",
+        sessionIds: ["prefix"],
+      });
+      const remainingContent = await fs.readFile(corpusPath, "utf8").catch(() => "missing");
+      const remainingChunks = db.prepare("SELECT id FROM memory_index_chunks").all();
+      expect(report.sessionResolutions).toEqual([{ sessionId: "prefix", source: "unresolved" }]);
+      expect(remainingContent).toBe(content);
+      expect(remainingChunks).toEqual([{ id: "survivor-chunk" }]);
+    },
+  );
 
   it("does not infer hook or participant facts for an archived-only session", async () => {
     await seedSession("archived", "gmail");
@@ -615,7 +681,11 @@ describe("memory forget", () => {
         source: "memory",
         originClass: "owner",
       },
-      { path: "sessions/main/target", source: "sessions", originClass: "owner" },
+      {
+        path: "sessions/main/target.jsonl.reset.2026-08-25T10-00-00.000Z.zst",
+        source: "sessions",
+        originClass: "owner",
+      },
       {
         path: `sessions/main/${narrativeArchiveName}`,
         source: "sessions",
@@ -624,7 +694,7 @@ describe("memory forget", () => {
         text: "violet",
       },
       {
-        path: "sessions/main/survivor.jsonl.deleted-2026-08-25.zst",
+        path: "sessions/main/survivor.jsonl.deleted.2026-08-25T10-00-00.000Z.zst",
         source: "sessions",
         originClass: "owner",
       },
@@ -743,7 +813,7 @@ describe("memory forget", () => {
       (db.prepare("SELECT path FROM memory_index_sources").all() as Array<{ path: string }>).map(
         (row) => row.path,
       ),
-    ).toEqual(["MEMORY.md", "sessions/main/survivor.jsonl.deleted-2026-08-25.zst"]);
+    ).toEqual(["MEMORY.md", "sessions/main/survivor.jsonl.deleted.2026-08-25T10-00-00.000Z.zst"]);
     expect(
       db
         .prepare("SELECT id FROM memory_index_chunks_fts WHERE memory_index_chunks_fts MATCH ?")
@@ -794,177 +864,6 @@ describe("memory forget", () => {
     expect(repeated.sessionIds).toEqual(["target"]);
     expect(Object.values(repeated.artifacts).every((count) => count === 0)).toBe(true);
     expect(listMemorySessionTombstones({ agentId: "main" })).toEqual(tombstones);
-  });
-
-  it("reports session-authored curated memory without deleting unattributable file content", async () => {
-    await seedSession("target");
-    const curatedContent = "# Long-Term Memory\nThe launch code is violet.\n";
-    const writeTool = createOpenClawCodingTools({
-      workspaceDir,
-      config: cfg,
-      sessionId: "target",
-      sessionKey: "agent:main:target",
-      senderIsOwner: true,
-    }).find((tool) => tool.name === "write");
-    expect(writeTool).toBeDefined();
-    await writeTool!.execute("write-curated-memory", {
-      path: "MEMORY.md",
-      content: curatedContent,
-    });
-    await appendSessionTranscriptMessageByIdentity({
-      agentId: "main",
-      sessionId: "target",
-      sessionKey: "agent:main:target",
-      message: {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "observed-write",
-            name: "write",
-            arguments: { path: "MEMORY.md" },
-          },
-        ],
-      },
-    });
-
-    const preview = await forgetMemoryEntries({
-      cfg,
-      agentId: "main",
-      sessionIds: ["target"],
-      dryRun: true,
-    });
-    expect(preview.curatedWrites).toEqual([
-      { relativePath: "MEMORY.md", observedAt: expect.any(Number) },
-    ]);
-    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(curatedContent);
-
-    const report = await forgetMemoryEntries({
-      cfg,
-      agentId: "main",
-      sessionIds: ["target"],
-    });
-    expect(report).toEqual({ ...preview, dryRun: false });
-    expect(report.artifacts.memoryFiles).toBe(0);
-    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(curatedContent);
-  });
-
-  it("reports harness memory writes from selected live and archived transcripts without observer state", async () => {
-    await seedSession("survivor");
-    await seedSession("target");
-    const observedAt = Date.parse("2026-08-26T12:34:56.000Z");
-    const memoryContent = "# Long-Term Memory\nA harness-authored private fact.\n";
-    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
-    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memoryContent);
-    await fs.writeFile(path.join(workspaceDir, "USER.md"), "# User\n");
-    await fs.writeFile(path.join(workspaceDir, "memory", "profile.md"), "# Profile\n");
-    const patchInput = [
-      "*** Begin Patch",
-      "*** Update File: MEMORY.md",
-      "@@",
-      "+A harness-authored private fact.",
-      "*** Update File: README.md",
-      "@@",
-      "+Not a memory file.",
-      "*** End Patch",
-    ].join("\n");
-    await appendSessionTranscriptMessageByIdentity({
-      agentId: "main",
-      sessionId: "target",
-      sessionKey: "agent:main:target",
-      message: {
-        role: "assistant",
-        timestamp: observedAt,
-        content: [
-          { type: "toolCall", id: "patch", name: "apply_patch", arguments: { input: patchInput } },
-          { type: "toolCall", id: "profile", name: "write", arguments: { path: "USER.md" } },
-          {
-            type: "toolCall",
-            id: "nested",
-            name: "edit",
-            input: { file_path: path.join(workspaceDir, "memory", "profile.md") },
-          },
-          {
-            type: "toolCall",
-            id: "structured",
-            name: "apply_patch",
-            arguments: { changes: [{ path: "memory/structured.md" }, { path: "README.md" }] },
-          },
-          { type: "toolCall", id: "ordinary", name: "write", arguments: { path: "README.md" } },
-          { type: "toolCall", id: "escaping", name: "edit", arguments: { path: "../MEMORY.md" } },
-          { type: "toolCall", id: "malformed", name: "apply_patch", arguments: { input: 42 } },
-          { type: "toolCall", id: "read-only", name: "read", arguments: { path: "MEMORY.md" } },
-          { type: "toolCall", id: "missing", name: "write", arguments: null },
-          null,
-        ],
-      },
-    });
-    await appendSessionTranscriptMessageByIdentity({
-      agentId: "main",
-      sessionId: "survivor",
-      sessionKey: "agent:main:survivor",
-      message: {
-        role: "assistant",
-        timestamp: observedAt + 1,
-        content: [
-          {
-            type: "toolCall",
-            id: "unselected",
-            name: "write",
-            arguments: { path: "memory/keep.md" },
-          },
-        ],
-      },
-    });
-    const archiveDir = path.join(stateDir, "agents", "main", "sessions");
-    await fs.mkdir(archiveDir, { recursive: true });
-    const archivedMessage = {
-      type: "message",
-      timestamp: new Date(observedAt + 1).toISOString(),
-      message: {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            id: "archived",
-            name: "edit",
-            input: { filePath: "memory/archive.md" },
-          },
-        ],
-      },
-    };
-    await fs.writeFile(
-      path.join(archiveDir, "target.jsonl.deleted.2026-08-26T12-35-00.000Z.zst"),
-      zstdCompressSync(`${JSON.stringify(archivedMessage)}\n`),
-    );
-    expect(await listSessionTranscriptCorpusEntriesForAgent("main")).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ sessionId: "target", artifactKind: "active-session" }),
-        expect.objectContaining({ sessionId: "target", artifactKind: "archive-artifact" }),
-      ]),
-    );
-    expect(await listMemoryArtifactProvenance({ workspaceDir })).toEqual([]);
-
-    const preview = await forgetMemoryEntries({
-      cfg,
-      agentId: "main",
-      sessionIds: ["target"],
-      dryRun: true,
-    });
-
-    expect(preview.curatedWrites).toEqual([
-      { relativePath: "MEMORY.md", observedAt },
-      { relativePath: "memory/archive.md", observedAt: observedAt + 1 },
-      { relativePath: "memory/profile.md", observedAt },
-      { relativePath: "memory/structured.md", observedAt },
-      { relativePath: "USER.md", observedAt },
-    ]);
-    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(memoryContent);
-
-    const report = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["target"] });
-    expect(report).toEqual({ ...preview, dryRun: false });
-    expect(report.artifacts.memoryFiles).toBe(0);
-    expect(await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8")).toBe(memoryContent);
   });
 
   it("keeps missing provenance untargetable without creating its table during dry-run", async () => {

--- a/extensions/memory-core/src/memory-forget.ts
+++ b/extensions/memory-core/src/memory-forget.ts
@@ -8,6 +8,7 @@ import {
 import {
   buildSessionEntry,
   listSessionTranscriptCorpusEntriesForAgent,
+  parseUsageCountedSessionIdFromFileName,
   resolveMemorySessionTargets,
 } from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
 import {
@@ -36,6 +37,7 @@ import {
   recordMemorySessionTombstones,
 } from "./memory-entry-origins.js";
 import { collectTranscriptWrites } from "./memory-forget-curated-writes.js";
+import { withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
 import { closeMemoryDatabase, openMemoryDatabaseAtPath } from "./memory/manager-db.js";
 import { isMemorySessionIndexable } from "./memory/manager-session-sync-state.js";
 import {
@@ -62,6 +64,7 @@ type ForgetDatabase = {
   memory_index_chunks_fts: { id: string; path: string; source: string };
   memory_index_chunks_vec: { id: string };
   memory_embedding_cache: { hash: string };
+  memory_index_state: { id: number; revision: number };
 };
 
 type MemoryBackup = { createdAt: string; content: string; contentHash: string };
@@ -120,11 +123,20 @@ function referencesSession(
   agentId: string,
   sessionIds: ReadonlySet<string>,
 ): boolean {
-  return [...sessionIds].some(
-    (sessionId) =>
-      value.includes(`sessions/${agentId}/${sessionId}`) ||
-      value.includes(`${agentId}:${sessionId}`) ||
-      new RegExp(`\\bSession ID:\\s*${escapePattern(sessionId)}(?:[;\\s]|$)`, "iu").test(value),
+  const agent = escapePattern(agentId);
+  const references = new RegExp(
+    `(?:^|[\\s[/:])(?:sessions/${agent}/|${agent}:(?!sessions/))([^\\s\\]#;:/]+)`,
+    "gu",
+  );
+  // Decode archive filenames with the session owner's grammar; a shared prefix
+  // or an arbitrary dotted suffix is not the selected session's identity.
+  return (
+    [...value.matchAll(references)].some(([, reference]) =>
+      sessionIds.has(parseUsageCountedSessionIdFromFileName(reference!) ?? reference!),
+    ) ||
+    [...value.matchAll(/\bSession ID:\s*([^;\s]+)/giu)].some(([, sessionId]) =>
+      sessionIds.has(sessionId!),
+    )
   );
 }
 
@@ -325,7 +337,7 @@ async function planMemoryIndex(params: {
   return { ...result.value, vectorRows };
 }
 
-export async function forgetMemoryEntries(params: {
+type MemoryForgetParams = {
   cfg: OpenClawConfig;
   agentId: string;
   sessionIds?: string[];
@@ -333,11 +345,24 @@ export async function forgetMemoryEntries(params: {
   participants?: string[];
   since?: string;
   dryRun?: boolean;
-}): Promise<MemoryForgetReport> {
+};
+
+export async function forgetMemoryEntries(params: MemoryForgetParams): Promise<MemoryForgetReport> {
   if (!params.sessionIds?.length && !params.hookSources?.length && !params.participants?.length) {
     throw new Error("memory forget requires a session, hook source, or participant selector");
   }
   const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+  // Plan against the same locked state we remove; staging and promotion must
+  // not publish an earlier snapshot after a successful purge. Preview never writes a lock.
+  return params.dryRun
+    ? forgetWorkspaceMemory(params, workspaceDir)
+    : withMemoryWorkspaceLock(workspaceDir, () => forgetWorkspaceMemory(params, workspaceDir));
+}
+
+async function forgetWorkspaceMemory(
+  params: MemoryForgetParams,
+  workspaceDir: string,
+): Promise<MemoryForgetReport> {
   const targets = resolveMemorySessionTargets({
     agentId: params.agentId,
     sessionIds: params.sessionIds,
@@ -610,7 +635,21 @@ export async function forgetMemoryEntries(params: {
 
     // Forget is durable admission policy: persist it before removing the
     // checkpoints that would otherwise make this session look newly eligible.
-    recordMemorySessionTombstones({ agentId: params.agentId, sessionIds: [...sessionIds] });
+    const recorded = recordMemorySessionTombstones({
+      agentId: params.agentId,
+      sessionIds: [...sessionIds],
+    });
+    if (recorded === 0 && changedPaths.size > 0) {
+      // Repeating a partial purge can still rewrite an unindexed file. Fence
+      // pending shadow rebuilds before any filesystem mutation, even on failure.
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .updateTable("memory_index_state")
+          .set((expression) => ({ revision: expression("revision", "+", 1) }))
+          .where("id", "=", 1),
+      );
+    }
 
     for (const rewrite of [...memoryRewrites, ...corpusRewrites]) {
       if (rewrite.remove) {

--- a/extensions/memory-core/src/memory-workspace-lock.ts
+++ b/extensions/memory-core/src/memory-workspace-lock.ts
@@ -1,0 +1,173 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import fsSync from "node:fs";
+import { extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { sleep } from "openclaw/plugin-sdk/runtime-env";
+import {
+  SHORT_TERM_LOCK_MAX_ENTRIES,
+  SHORT_TERM_LOCK_NAMESPACE,
+  memoryCoreStateReference,
+  memoryCoreWorkspaceStateKey,
+  openMemoryCoreStateStore,
+} from "./dreaming-state.js";
+import type { ShortTermLockEntry } from "./short-term-promotion-types.js";
+
+const MEMORY_WORKSPACE_LOCK_WAIT_TIMEOUT_MS = 10_000;
+export const SHORT_TERM_LOCK_STALE_MS = 60_000;
+const MEMORY_WORKSPACE_LOCK_RETRY_DELAY_MS = 40;
+const inProcessMemoryWorkspaceLocks = new KeyedAsyncQueue();
+
+type MemoryWorkspaceLease = { key: string; active: boolean };
+type MemoryWorkspaceLockScope = {
+  lease: MemoryWorkspaceLease;
+  active: boolean;
+  childTail: Promise<void>;
+  parent: MemoryWorkspaceLockScope | undefined;
+};
+const memoryWorkspaceLockScopes = new AsyncLocalStorage<MemoryWorkspaceLockScope>();
+
+function findActiveWorkspaceLockScope(key: string): MemoryWorkspaceLockScope | undefined {
+  let scope = memoryWorkspaceLockScopes.getStore();
+  while (scope) {
+    if (!scope.active || !scope.lease.active) {
+      return undefined;
+    }
+    if (scope.lease.key === key) {
+      return scope;
+    }
+    scope = scope.parent;
+  }
+  return undefined;
+}
+
+async function runWorkspaceLockScope<T>(
+  lease: MemoryWorkspaceLease,
+  task: () => Promise<T>,
+): Promise<T> {
+  const scope: MemoryWorkspaceLockScope = {
+    lease,
+    active: true,
+    childTail: Promise.resolve(),
+    parent: memoryWorkspaceLockScopes.getStore(),
+  };
+  try {
+    return await memoryWorkspaceLockScopes.run(scope, task);
+  } finally {
+    // Closed async contexts must acquire a new lease. Already accepted children
+    // finish before the owner releases the cross-process lock.
+    scope.active = false;
+    await scope.childTail;
+  }
+}
+
+export function resolveLockPath(workspaceDir: string): string {
+  return memoryCoreStateReference(SHORT_TERM_LOCK_NAMESPACE, workspaceDir);
+}
+
+export function parseLockOwnerPid(raw: string): number | null {
+  const match = raw.trim().match(/^(\d+):/);
+  if (!match) {
+    return null;
+  }
+  const pid = Number.parseInt(match[1] ?? "", 10);
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return null;
+  }
+  return pid;
+}
+
+export function isProcessLikelyAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+  } catch (err) {
+    if (extractErrorCode(err) === "ESRCH") {
+      return false;
+    }
+    // EPERM and unknown errors remain potentially alive unless procfs proves a zombie.
+  }
+  if (process.platform !== "linux") {
+    return true;
+  }
+  try {
+    const status = fsSync.readFileSync(`/proc/${pid}/status`, "utf8");
+    const state = status.match(/^State:\s+(\S)/m)?.[1];
+    return state !== "Z" && state !== "X";
+  } catch {
+    // An unreadable proc entry is not enough evidence to steal an active lock.
+    return true;
+  }
+}
+
+export async function deleteShortTermLockEntryIfCurrent(
+  lockStore: PluginStateKeyedStore<ShortTermLockEntry>,
+  lockKey: string,
+  expected: ShortTermLockEntry,
+): Promise<boolean> {
+  if (!lockStore.deleteIf) {
+    throw new Error("memory-core short-term lock store requires conditional deletion");
+  }
+  return await lockStore.deleteIf(
+    lockKey,
+    (current) => current.owner === expected.owner && current.acquiredAt === expected.acquiredAt,
+  );
+}
+
+export async function withMemoryWorkspaceLock<T>(
+  workspaceDir: string,
+  task: () => Promise<T>,
+): Promise<T> {
+  const lockKey = memoryCoreWorkspaceStateKey(workspaceDir);
+  const scope = findActiveWorkspaceLockScope(lockKey);
+  if (scope) {
+    // Each scope queues its children separately: nested calls can reenter,
+    // while Promise.all siblings cannot race read-modify-write operations.
+    const child = scope.childTail.then(() => runWorkspaceLockScope(scope.lease, task));
+    scope.childTail = child.then(
+      () => undefined,
+      () => undefined,
+    );
+    return await child;
+  }
+  const lockRef = resolveLockPath(workspaceDir);
+  const lockStore = openMemoryCoreStateStore<ShortTermLockEntry>({
+    namespace: SHORT_TERM_LOCK_NAMESPACE,
+    maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
+  });
+  return await inProcessMemoryWorkspaceLocks.enqueue(lockKey, async () => {
+    const startedAt = Date.now();
+
+    while (true) {
+      const lockEntry: ShortTermLockEntry = {
+        owner: `${process.pid}:${Date.now()}`,
+        acquiredAt: Date.now(),
+      };
+      const acquired = await lockStore.registerIfAbsent(lockKey, lockEntry);
+      if (acquired) {
+        const lease = { key: lockKey, active: true };
+        try {
+          return await runWorkspaceLockScope(lease, task);
+        } finally {
+          lease.active = false;
+          await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, lockEntry).catch(() => false);
+        }
+      }
+
+      const existing = await lockStore.lookup(lockKey);
+      if (existing && Date.now() - existing.acquiredAt > SHORT_TERM_LOCK_STALE_MS) {
+        const ownerPid = parseLockOwnerPid(existing.owner);
+        if (ownerPid === null || !isProcessLikelyAlive(ownerPid)) {
+          if (await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, existing)) {
+            continue;
+          }
+        }
+      }
+
+      if (Date.now() - startedAt >= MEMORY_WORKSPACE_LOCK_WAIT_TIMEOUT_MS) {
+        throw new Error(`Timed out waiting for memory workspace lock at ${lockRef}`);
+      }
+
+      await sleep(MEMORY_WORKSPACE_LOCK_RETRY_DELAY_MS);
+    }
+  });
+}

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
+  buildFileEntry,
   buildMultimodalChunkForIndexing,
   chunkMarkdown,
   extractProjectKeysFromCuratedEntry,
@@ -33,6 +34,8 @@ import { MAX_TIMER_TIMEOUT_MS, resolveTimerTimeoutMs } from "openclaw/plugin-sdk
 import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { runSqliteImmediateTransactionSync } from "openclaw/plugin-sdk/sqlite-runtime";
 import { chunkItems } from "openclaw/plugin-sdk/text-chunking";
+import { hasMemorySessionTombstone } from "../memory-entry-origins.js";
+import { withMemoryWorkspaceLock } from "../memory-workspace-lock.js";
 import { readSessionResetRecallCutoffMetadata } from "../session-reset-recall-metadata.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import {
@@ -383,12 +386,13 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     this.syncProviderGeneration = provider
       ? {
           kind: "semantic",
+          database: this.db,
           provider,
           ...(runtime ? { runtime } : {}),
           providerKey,
           identities,
         }
-      : { kind: "fts-only", provider: null, providerKey, identities };
+      : { kind: "fts-only", database: this.db, provider: null, providerKey, identities };
     this.syncProviderGenerationRelease = provider ? this.acquireProviderUse(provider) : null;
     this.syncProviderGenerationOwners = 1;
   }
@@ -432,20 +436,6 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       .run(excess);
   }
 
-  private upsertEmbeddingCacheEntries(
-    entries: Array<{ hash: string; embedding: number[] }>,
-    generation: MemorySemanticProviderGeneration,
-  ): void {
-    upsertMemoryEmbeddingCache({
-      db: this.db,
-      enabled: this.cache.enabled,
-      provider: generation.provider,
-      providerKey: generation.providerKey,
-      entries,
-      tableName: EMBEDDING_CACHE_TABLE,
-    });
-  }
-
   private async embedChunksInBatches(
     chunks: IndexedMemoryChunk[],
     generation: MemorySemanticProviderGeneration,
@@ -481,16 +471,13 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
             batch.map((chunk) => chunk.text),
             generation,
           );
-      const batchCacheEntries: Array<{ hash: string; embedding: number[] }> = [];
       for (let i = 0; i < batch.length; i += 1) {
         const item = missing[cursor + i];
         const embedding = batchEmbeddings[i] ?? [];
         if (item) {
           embeddings[item.index] = embedding;
-          batchCacheEntries.push({ hash: item.chunk.hash, embedding });
         }
       }
-      this.upsertEmbeddingCacheEntries(batchCacheEntries, generation);
       cursor += batch.length;
     }
     return embeddings;
@@ -527,7 +514,6 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
   private async embedChunksWithBatch(
     chunks: IndexedMemoryChunk[],
-    _entry: MemoryIndexEntry,
     source: string,
     generation: MemorySemanticProviderGeneration,
     debugContext: Record<string, unknown> = {},
@@ -563,7 +549,6 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     if (!batchResult) {
       return this.embedChunksInBatches(chunks, generation);
     }
-    const toCache: Array<{ hash: string; embedding: number[] }> = [];
     for (let index = 0; index < missing.length; index += 1) {
       const item = missing[index];
       const embedding = batchResult[index] ?? [];
@@ -571,9 +556,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         continue;
       }
       embeddings[item.index] = embedding;
-      toCache.push({ hash: item.chunk.hash, embedding });
     }
-    this.upsertEmbeddingCacheEntries(toCache, generation);
     return embeddings;
   }
 
@@ -952,22 +935,60 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       .run(pathname, source);
   }
 
-  /**
-   * Write chunks (and optional embeddings) for a file into the index.
-   * Handles both the chunks table, the vector table, and the FTS table.
-   * Pass an empty embeddings array to skip vector writes (FTS-only mode).
-   */
-  private writeChunks(
+  private assertMemoryFileSnapshot(entry: MemoryIndexEntry, currentHash: string | undefined): void {
+    if (currentHash === entry.hash) {
+      return;
+    }
+    this.markFailedFullReindexRetry({ memory: true, sessions: false });
+    throw new Error(`Memory source ${entry.path} changed while indexing; retry the memory index.`);
+  }
+
+  private async writeChunks(
     entry: MemoryIndexEntry,
     source: MemorySource,
-    model: string,
+    generation: MemorySyncProviderGeneration | null,
+    chunks: IndexedMemoryChunk[],
+    embeddings: number[][],
+    vectorReady: boolean,
+  ): Promise<void> {
+    await withMemoryWorkspaceLock(this.workspaceDir, async () => {
+      if (source === "memory") {
+        // The lock excludes purge and promotion writers while the exact file
+        // snapshot is validated and its derived index records are committed.
+        const current = await buildFileEntry(
+          entry.absPath,
+          this.workspaceDir,
+          this.settings.multimodal,
+        );
+        this.assertMemoryFileSnapshot(entry, current?.hash);
+      }
+      this.commitIndexChunks(entry, source, generation, chunks, embeddings, vectorReady);
+    });
+  }
+
+  private commitIndexChunks(
+    entry: MemoryIndexEntry,
+    source: MemorySource,
+    generation: MemorySyncProviderGeneration | null,
     chunks: IndexedMemoryChunk[],
     embeddings: number[][],
     vectorReady: boolean,
   ): void {
     const now = Date.now();
+    const model = generation?.provider?.model ?? "fts-only";
     const needsVectorRebuild = !vectorReady && embeddings.some((embedding) => embedding.length > 0);
     runSqliteImmediateTransactionSync(this.db, () => {
+      if (source === "sessions") {
+        const sessionId = expectDefined(entry.sessionId, "memory index session identity");
+        // Embedding and vector setup may await while a purge completes. Read the
+        // live owner, never the shadow index, immediately before publishing.
+        if (hasMemorySessionTombstone(generation?.database ?? this.db, this.agentId, sessionId)) {
+          this.markFailedFullReindexRetry({ memory: false, sessions: true });
+          throw new Error(
+            "A session was forgotten while memory indexing was running; retry the memory index.",
+          );
+        }
+      }
       this.clearIndexedFileData(entry.path, source);
       for (const [i, chunk] of chunks.entries()) {
         const embedding = embeddings[i] ?? [];
@@ -1048,6 +1069,18 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
             .run(chunk.text, id, entry.path, source, model, chunk.startLine, chunk.endLine);
         }
       }
+      upsertMemoryEmbeddingCache({
+        db: this.db,
+        enabled: this.cache.enabled,
+        provider: generation?.provider ?? null,
+        providerKey: generation?.providerKey ?? null,
+        entries: chunks.map((chunk, index) => ({
+          hash: chunk.hash,
+          embedding: embeddings[index] ?? [],
+        })),
+        now,
+        tableName: EMBEDDING_CACHE_TABLE,
+      });
       this.upsertFileRecord(entry, source);
       if (needsVectorRebuild) {
         this.markVectorRebuildRequired();
@@ -1064,6 +1097,16 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   }
 
   private async prepareIndexEntry(
+    entry: MemoryIndexEntry,
+    options: { source: MemorySource; content?: string },
+    generation: MemorySyncProviderGeneration | null,
+  ): Promise<PreparedMemoryIndexEntry | null> {
+    return await withMemoryWorkspaceLock(this.workspaceDir, () =>
+      this.prepareLockedIndexEntry(entry, options, generation),
+    );
+  }
+
+  private async prepareLockedIndexEntry(
     entry: MemoryIndexEntry,
     options: { source: MemorySource; content?: string },
     generation: MemorySyncProviderGeneration | null,
@@ -1107,6 +1150,9 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         () => fs.readFile(entry.absPath, "utf-8"),
         `read memory markdown for indexing ${entry.absPath}`,
       ));
+    if (options.source === "memory") {
+      this.assertMemoryFileSnapshot(entry, hashText(content));
+    }
     const normalizedEntryPath = entry.path.replaceAll("\\", "/");
     const perEntry =
       options.source === "memory" &&
@@ -1247,8 +1293,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     let preparedRequestCount = 0;
     let sourceWideBatchGroup = 0;
     const flushPrepared = async (reason: "max-files" | "max-requests" | "end") => {
-      const firstEntry = prepared[0]?.entry;
-      if (!firstEntry) {
+      if (prepared.length === 0) {
         return;
       }
       const current = prepared;
@@ -1277,7 +1322,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       for (let requestIndex = 0; requestIndex < chunkBatches.length; requestIndex += 1) {
         const chunkBatch = chunkBatches[requestIndex] ?? [];
         embeddings.push(
-          ...(await this.embedChunksWithBatch(chunkBatch, firstEntry, source, generation, {
+          ...(await this.embedChunksWithBatch(chunkBatch, source, generation, {
             sourceWideFiles: current.length,
             sourceWideSources: sourceCounts,
             sourceWideBatchGroup,
@@ -1292,10 +1337,10 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       for (const item of current) {
         const fileEmbeddings = embeddings.slice(offset, offset + item.chunks.length);
         offset += item.chunks.length;
-        this.writeChunks(
+        await this.writeChunks(
           item.entry,
           item.source,
-          generation.provider.model,
+          generation,
           item.chunks,
           fileEmbeddings,
           vectorReady,
@@ -1362,7 +1407,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         return;
       }
       const prepared = await this.prepareIndexEntry(entry, options, null);
-      this.writeChunks(entry, options.source, "fts-only", prepared?.chunks ?? [], [], false);
+      await this.writeChunks(entry, options.source, generation, prepared?.chunks ?? [], [], false);
       return;
     }
 
@@ -1374,7 +1419,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     let embeddings: number[][];
     try {
       embeddings = this.batch.enabled
-        ? await this.embedChunksWithBatch(prepared.chunks, entry, options.source, generation)
+        ? await this.embedChunksWithBatch(prepared.chunks, options.source, generation)
         : await this.embedChunksInBatches(prepared.chunks, generation);
     } catch (err) {
       const message = formatErrorMessage(err);
@@ -1392,18 +1437,17 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           model: generation.provider.model,
           error: message,
         });
-        this.clearIndexedFileData(entry.path, options.source);
-        this.upsertFileRecord(entry, options.source);
+        await this.writeChunks(entry, options.source, generation, [], [], false);
         return;
       }
       throw err;
     }
     const sample = embeddings.find((embedding) => embedding.length > 0);
     const vectorReady = sample ? await this.ensureVectorReady(sample.length) : false;
-    this.writeChunks(
+    await this.writeChunks(
       entry,
       options.source,
-      generation.provider.model,
+      generation,
       prepared.chunks,
       embeddings,
       vectorReady,

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle-leases.test.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle-leases.test.ts
@@ -1,4 +1,5 @@
 // Memory Core tests cover manager provider lifecycle lease behavior.
+import fs from "node:fs/promises";
 import path from "node:path";
 import { hashText } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { describe, expect, it, vi } from "vitest";
@@ -72,6 +73,8 @@ describe("memory index", () => {
     };
     const first = createEntry("fts-first");
     const second = createEntry("fts-second");
+    await fs.writeFile(first.absPath, first.content);
+    await fs.writeFile(second.absPath, second.content);
 
     fields.beginSyncProviderGeneration();
     try {

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle.test.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle.test.ts
@@ -1,4 +1,5 @@
 // Memory Core tests cover manager provider lifecycle availability behavior.
+import fs from "node:fs/promises";
 import path from "node:path";
 import { hashText } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { describe, expect, it, vi } from "vitest";
@@ -301,6 +302,8 @@ describe("memory index", () => {
     const indexedProviderKey = fields.providerKey;
     const firstContent = "# Log\nFirst memory line indexed during provider fallback.";
     const secondContent = "# Log\nSecond memory line indexed during provider fallback.";
+    await fs.writeFile(path.join(fixture.paths.memory, "generation-race-first.md"), firstContent);
+    await fs.writeFile(path.join(fixture.paths.memory, "generation-race-second.md"), secondContent);
 
     let releaseFirstEmbedding: () => void = () => {};
     let releaseSecondEmbedding: () => void = () => {};

--- a/extensions/memory-core/src/memory/manager-session-update-race.test.ts
+++ b/extensions/memory-core/src/memory/manager-session-update-race.test.ts
@@ -8,7 +8,11 @@ import { deleteSessionEntry, upsertSessionEntry } from "openclaw/plugin-sdk/sess
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
 import { describe, expect, it, vi } from "vitest";
-import { recordMemorySessionTombstones } from "../memory-entry-origins.js";
+import {
+  recordMemoryEntryOrigins,
+  recordMemorySessionTombstones,
+} from "../memory-entry-origins.js";
+import { forgetMemoryEntries } from "../memory-forget.js";
 import { createManagerIndexFixture } from "./manager-index.test-support.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
@@ -326,6 +330,149 @@ describe("memory session update sync", () => {
       sessions: [{ agentId: "main", sessionId, sessionKey }],
     });
     expectSessionIndexRemoved(database, sessionPath);
+  });
+
+  it.each([
+    { mode: "targeted per-file", provider: "batch-test", force: false },
+    { mode: "full per-file", provider: "batch-test", force: true },
+    { mode: "full source-wide", provider: "batch-wide-test", force: true },
+  ])(
+    "does not publish forgotten data after pending $mode embeddings",
+    async ({ provider, force }) => {
+      const sessionId = "forgotten-during-embedding";
+      const sessionKey = `agent:main:chat:${sessionId}`;
+      const cfg = createConfig({
+        provider,
+        batchEnabled: true,
+        vectorEnabled: false,
+        cacheEnabled: true,
+        sources: ["sessions"],
+        sessionMemory: true,
+      });
+      const manager = await getFreshManager(cfg, "cli");
+      await manager.sync({ reason: "index-empty-corpus", force: true });
+      await seedSessionTranscript({
+        sessionId,
+        sessionKey,
+        messages: [
+          { role: "user", timestamp: Date.now(), content: "Private violet alpha fragment." },
+        ],
+      });
+      let releaseEmbedding = () => {};
+      fixture.provider.providerRuntimeBatchGate = new Promise<void>((resolve) => {
+        releaseEmbedding = resolve;
+      });
+      const activeSync = manager.sync({
+        reason: "forget-during-embedding",
+        ...(force ? { force: true } : { sessions: [{ agentId: "main", sessionId, sessionKey }] }),
+      });
+      try {
+        await vi.waitFor(() => expect(fixture.provider.providerRuntimeActiveBatchCalls).toBe(1));
+        await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: [sessionId] });
+        releaseEmbedding();
+        await expect(activeSync).rejects.toThrow("forgotten while memory indexing");
+        const database = Reflect.get(manager, "db") as DatabaseSync;
+        expectSessionIndexRemoved(database, `sessions/main/${sessionId}.jsonl`);
+        expect(database.prepare("SELECT hash FROM memory_embedding_cache").all()).toEqual([]);
+        expect(manager.status().dirty).toBe(true);
+
+        await manager.sync({ reason: "retry-after-forget", force: true });
+        expectSessionIndexRemoved(database, `sessions/main/${sessionId}.jsonl`);
+        expect(manager.status().dirty).toBe(false);
+      } finally {
+        releaseEmbedding();
+        await activeSync.catch(() => undefined);
+        fixture.provider.providerRuntimeBatchGate = null;
+      }
+    },
+  );
+
+  it.each([
+    { mode: "incremental embeddings", force: false, repeatPurge: false },
+    { mode: "full reindex embeddings", force: true, repeatPurge: false },
+    { mode: "completed shadow before repeat purge", force: true, repeatPurge: true },
+  ])("does not publish a stale workspace file after $mode", async ({ force, repeatPurge }) => {
+    const cfg = createConfig({
+      provider: "batch-test",
+      batchEnabled: true,
+      vectorEnabled: false,
+      cacheEnabled: true,
+      sources: ["memory"],
+    });
+    const baseline = await getFreshManager(cfg, "cli");
+    await baseline.sync({ reason: "index-before-new-memory", force: true });
+    await baseline.close();
+    const sessionId = "forgotten-memory-source";
+    const memoryPath = path.join(fixture.paths.workspace, "MEMORY.md");
+    await fs.writeFile(
+      memoryPath,
+      "# Memory\n<!-- openclaw-memory-promotion:private-entry -->\n- Private violet alpha fragment.\n",
+    );
+    recordMemoryEntryOrigins({
+      agentId: "main",
+      origins: [
+        {
+          agentId: "main",
+          sessionId,
+          sessionKey: null,
+          entryKey: "private-entry",
+          originClass: "owner",
+          observedAt: Date.now(),
+        },
+      ],
+    });
+    if (repeatPurge) {
+      // An earlier purge persisted its tombstone but failed before rewriting
+      // this previously unindexed file. Retrying must fence a completed shadow.
+      recordMemorySessionTombstones({ agentId: "main", sessionIds: [sessionId] });
+    }
+    const manager = await getFreshManager(cfg, "cli", true);
+    let releaseEmbedding = () => {};
+    if (!repeatPurge) {
+      fixture.provider.providerRuntimeBatchGate = new Promise<void>((resolve) => {
+        releaseEmbedding = resolve;
+      });
+    }
+    let purge: ReturnType<typeof forgetMemoryEntries> | undefined;
+    const activeSync = manager.sync({
+      reason: "forget-during-file-index",
+      force,
+      progress: ({ completed, total }) => {
+        if (repeatPurge && total > 0 && completed === total && !purge) {
+          purge = forgetMemoryEntries({ cfg, agentId: "main", sessionIds: [sessionId] });
+          void purge.catch(() => undefined);
+        }
+      },
+    });
+    try {
+      if (!repeatPurge) {
+        await vi.waitFor(() => expect(fixture.provider.providerRuntimeActiveBatchCalls).toBe(1));
+        await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: [sessionId] });
+        releaseEmbedding();
+      }
+      await expect(activeSync).rejects.toThrow(
+        repeatPurge ? "full reindex was building" : "changed while indexing",
+      );
+      await purge;
+      expect(await fs.readFile(memoryPath, "utf8")).not.toContain("Private violet");
+      const database = Reflect.get(manager, "db") as DatabaseSync;
+      expect(
+        database.prepare("SELECT text FROM memory_index_chunks WHERE path = 'MEMORY.md'").all(),
+      ).toEqual([]);
+      expect(manager.status().dirty).toBe(true);
+      await manager.sync({ reason: "retry-after-memory-forget", force: true });
+      expect(manager.status().dirty).toBe(false);
+      expect(
+        database
+          .prepare("SELECT text FROM memory_index_chunks WHERE text LIKE '%Private violet%'")
+          .all(),
+      ).toEqual([]);
+    } finally {
+      releaseEmbedding();
+      await activeSync.catch(() => undefined);
+      await purge?.catch(() => undefined);
+      fixture.provider.providerRuntimeBatchGate = null;
+    }
   });
 
   it.each([

--- a/extensions/memory-core/src/memory/manager-source-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-source-sync-ops.ts
@@ -313,7 +313,7 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
         this.advanceSyncProgress(params.progress);
         return null;
       }
-      return entry;
+      return { ...entry, sessionId: corpusEntryForPath(absPath).sessionId };
     };
 
     if (params.deferIndex) {

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -68,6 +68,7 @@ export type MemoryIndexEntry = {
   contentText?: string;
   lineMap?: number[];
   lineProvenance?: MemoryEntryProvenance[];
+  sessionId?: string;
 };
 
 export type MemoryIndexWorkItem = {

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -13,6 +13,7 @@ import {
   type MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { withMemoryWorkspaceLock } from "../memory-workspace-lock.js";
 import {
   createEmbeddingProvider,
   type EmbeddingProvider,
@@ -52,6 +53,7 @@ import { markMemoryVectorIndexClean } from "./manager-vector-rebuild-state.js";
 export type { MemoryIndexWorkItem } from "./manager-sync-base.js";
 
 type MemorySyncProviderGenerationBase = {
+  database: DatabaseSync;
   providerKey: string;
   identities: MemoryIndexProviderIdentity[];
 };
@@ -622,13 +624,15 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
 
       closeMemoryDatabase(tempDb);
       tempDbClosed = true;
-      await publishMemoryDatabaseTables({
-        targetDb: originalDb,
-        sourcePath: tempDbPath,
-        metaKey: MEMORY_INDEX_META_KEY,
-        expectedRevision: originalRevision,
-        vectorExtensionPath: this.vector.extensionPath,
-      });
+      await withMemoryWorkspaceLock(this.workspaceDir, () =>
+        publishMemoryDatabaseTables({
+          targetDb: originalDb,
+          sourcePath: tempDbPath,
+          metaKey: MEMORY_INDEX_META_KEY,
+          expectedRevision: originalRevision,
+          vectorExtensionPath: this.vector.extensionPath,
+        }),
+      );
 
       this.db = originalDb;
       if (vectorIndexComplete) {

--- a/extensions/memory-core/src/session-backfill-gateway.test.ts
+++ b/extensions/memory-core/src/session-backfill-gateway.test.ts
@@ -75,7 +75,10 @@ describe("session backfill gateway methods", () => {
   });
 
   it("validates preview params and returns at most three samples per day", async () => {
-    const { methods } = createHarness();
+    const pluginConfig = { memoryPolicy: { excludeSessions: { channels: ["discord"] } } };
+    const { methods } = createHarness({
+      plugins: { entries: { "memory-core": { config: pluginConfig } } },
+    });
     executeBatchMock.mockResolvedValueOnce({
       result: {
         agentId: "main",
@@ -110,6 +113,7 @@ describe("session backfill gateway methods", () => {
       to: "2026-07-31",
       limitDays: 14,
       workspaceDir: "/tmp/main-workspace",
+      pluginConfig,
     });
     expect(respond).toHaveBeenCalledWith(true, {
       days: 1,
@@ -202,7 +206,10 @@ describe("session backfill gateway methods", () => {
   });
 
   it("applies a chunk with cursor progress and rolls back by agent", async () => {
-    const { methods } = createHarness();
+    const pluginConfig = { memoryPolicy: { excludeSessions: { chatTypes: ["group"] } } };
+    const { methods } = createHarness({
+      plugins: { entries: { "memory-core": { config: pluginConfig } } },
+    });
     executeBatchMock.mockResolvedValueOnce({
       result: {
         agentId: "main",
@@ -234,6 +241,7 @@ describe("session backfill gateway methods", () => {
       agentId: "main",
       limitDays: 14,
     });
+    expect(executeBatchMock).toHaveBeenCalledWith(expect.objectContaining({ pluginConfig }));
     expect(applyRespond).toHaveBeenCalledWith(
       true,
       expect.objectContaining({

--- a/extensions/memory-core/src/session-backfill-gateway.ts
+++ b/extensions/memory-core/src/session-backfill-gateway.ts
@@ -98,12 +98,14 @@ function resolveExecutionContext(api: OpenClawPluginApi, agentId: string) {
     throw new InvalidSessionBackfillRequestError(`Unknown agent id "${agentId}".`);
   }
   const workspaceDir = api.runtime.agent.resolveAgentWorkspaceDir(config, agentId);
+  const pluginConfig = resolvePluginConfigObject(config, "memory-core");
   const remConfig = resolveMemoryRemDreamingConfig({
     cfg: config,
-    pluginConfig: resolvePluginConfigObject(config, "memory-core"),
+    pluginConfig,
   });
   return {
     workspaceDir,
+    ...(pluginConfig ? { pluginConfig } : {}),
     ...(remConfig.timezone !== undefined ? { timezone: remConfig.timezone } : {}),
   };
 }

--- a/extensions/memory-core/src/session-backfill.test.ts
+++ b/extensions/memory-core/src/session-backfill.test.ts
@@ -6,7 +6,10 @@ import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
-import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  normalizeSessionDeliveryState,
+  upsertSessionEntry,
+} from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { writeBackfillDiaryEntries } from "./dreaming-narrative.js";
@@ -14,7 +17,7 @@ import {
   clearMemoryCoreWorkspaceNamespace,
   SESSION_BACKFILL_REWIND_NAMESPACE,
 } from "./dreaming-state.js";
-import { recordMemorySessionTombstones } from "./memory-entry-origins.js";
+import { listMemoryEntryOrigins, recordMemorySessionTombstones } from "./memory-entry-origins.js";
 import {
   markSessionBackfillRewindBaseline,
   resetSessionBackfillIngestionState,
@@ -26,7 +29,11 @@ import {
   runSessionBackfill,
 } from "./session-backfill.js";
 import { writeSessionIngestionState } from "./session-ingestion.js";
-import { readShortTermRecallEntries } from "./short-term-promotion.js";
+import {
+  readShortTermRecallEntries,
+  recordGroundedShortTermCandidates,
+  recordShortTermRecalls,
+} from "./short-term-promotion.js";
 import { createMemoryCoreTestHarness, dreamingTestState } from "./test-helpers.js";
 
 const harness = createMemoryCoreTestHarness();
@@ -57,6 +64,7 @@ async function writeTranscript(filePath: string, messages: TranscriptMessage[]):
 async function seedCanonicalTranscript(
   sessionId: string,
   messages: TranscriptMessage[],
+  metadata: Partial<Parameters<typeof upsertSessionEntry>[0]["entry"]> = {},
 ): Promise<void> {
   const agentId = "main";
   const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
@@ -67,7 +75,7 @@ async function seedCanonicalTranscript(
     ...messages.map((message) => Date.parse(message.timestamp)),
   );
   await fs.mkdir(sessionsDir, { recursive: true });
-  const entry = { sessionId, updatedAt };
+  const entry = { ...metadata, sessionId, updatedAt };
   await upsertSessionEntry({ agentId, sessionKey, storePath, entry });
   for (const message of messages) {
     await appendSessionTranscriptMessageByIdentity({
@@ -163,6 +171,139 @@ describe("runSessionBackfill", () => {
     expect(result.days[0]?.topCandidates).toEqual(["User: Retained owner claim remains eligible."]);
     const ingestion = await dreamingTestState.readSessionIngestionState(workspaceDir);
     expect(ingestion.files).not.toHaveProperty("main:sessions/main/forgotten");
+  });
+
+  it.each([{ mode: "preview" }, { mode: "rem", rem: true }, { mode: "apply", apply: true }])(
+    "honors admission exclusions during $mode",
+    async ({ mode, ...options }) => {
+      const workspaceDir = await createIsolatedWorkspace(`admission-${mode}-`);
+      const sources = [
+        { sessionId: "hook", metadata: { hookExternalContentSource: "gmail" as const } },
+        {
+          sessionId: "channel",
+          metadata: {
+            delivery: normalizeSessionDeliveryState({
+              context: { channel: "discord", to: "channel:admission-fixture" },
+              origin: { provider: "discord", to: "channel:admission-fixture" },
+            }),
+          },
+        },
+        { sessionId: "group", metadata: { chatType: "group" as const } },
+        { sessionId: "retained", metadata: {} },
+      ];
+      for (const { sessionId, metadata } of sources) {
+        await seedCanonicalTranscript(
+          sessionId,
+          [
+            {
+              role: "user",
+              content: `${sessionId} trusted session preference.`,
+              timestamp: "2026-01-02T12:00:00.000Z",
+              owner: true,
+            },
+          ],
+          metadata,
+        );
+      }
+
+      const result = await runSessionBackfill({
+        agentId: "main",
+        workspaceDir,
+        ...options,
+        timezone: "UTC",
+        pluginConfig: {
+          memoryPolicy: {
+            excludeSessions: {
+              hookExternalContentSources: ["gmail"],
+              channels: ["discord"],
+              chatTypes: ["group"],
+            },
+          },
+        },
+      });
+
+      expect(result.candidateCount).toBe(1);
+      expect(result.days[0]?.topCandidates).toEqual(["User: retained trusted session preference."]);
+    },
+  );
+
+  it("preserves every session origin when backfill coalesces equivalent snippets", async () => {
+    const workspaceDir = await createIsolatedWorkspace("coalesced-origins-");
+    const sources = [
+      { sessionId: "first", role: "assistant", originClass: "agent", hour: "10" },
+      { sessionId: "second", role: "user", originClass: "owner", hour: "11" },
+    ] as const;
+    for (const source of sources) {
+      await seedCanonicalTranscript(source.sessionId, [
+        {
+          role: "user",
+          content: "OK",
+          timestamp: "2026-03-01T09:00:00.000Z",
+          owner: true,
+        },
+        {
+          role: source.role,
+          content: "The preferred editor is Nova",
+          timestamp: `2026-03-01T${source.hour}:00:00.000Z`,
+          owner: source.role === "user",
+        },
+      ]);
+    }
+
+    const result = await runSessionBackfill({
+      agentId: "main",
+      workspaceDir,
+      apply: true,
+      timezone: "UTC",
+    });
+    const entries = await readShortTermRecallEntries({ workspaceDir });
+
+    expect(result.stagedEntries).toBe(1);
+    expect(entries).toHaveLength(1);
+    expect(
+      listMemoryEntryOrigins({ agentId: "main" }).map((origin) => ({
+        entryKey: origin.entryKey,
+        sessionId: origin.sessionId,
+        originClass: origin.originClass,
+        observedAt: origin.observedAt,
+      })),
+    ).toEqual(
+      sources.map((source) => ({
+        entryKey: entries[0]?.key,
+        sessionId: source.sessionId,
+        originClass: source.originClass,
+        observedAt: Date.parse(`2026-03-01T${source.hour}:00:00.000Z`),
+      })),
+    );
+  });
+
+  it("does not stage already-read session content after its source is forgotten", async () => {
+    const workspaceDir = await createIsolatedWorkspace("stale-staging-");
+    const result = {
+      path: "memory/.dreams/session-corpus/2026-03-01.txt",
+      startLine: 1,
+      endLine: 1,
+      snippet: "The preferred editor is Nova",
+      score: 0.9,
+      source: "memory" as const,
+      sessionOrigin: { agentId: "main", sessionId: "forgotten" },
+    };
+    recordMemorySessionTombstones({ agentId: "main", sessionIds: ["forgotten"] });
+
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "__dreaming_sessions__:2026-03-01",
+      results: [result],
+      signalType: "daily",
+    });
+    await recordGroundedShortTermCandidates({
+      workspaceDir,
+      query: "__dreaming_session_backfill__:2026-03-01",
+      items: [result],
+    });
+
+    expect(await readShortTermRecallEntries({ workspaceDir })).toEqual([]);
+    expect(listMemoryEntryOrigins({ agentId: "main" })).toEqual([]);
   });
 
   it("buckets messages in the configured timezone and processes days oldest first", async () => {

--- a/extensions/memory-core/src/session-backfill.ts
+++ b/extensions/memory-core/src/session-backfill.ts
@@ -6,6 +6,7 @@ import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import type { SessionIngestionFileState } from "./dreaming-ingestion-state.js";
 import { removeBackfillDiaryEntries, writeBackfillDiaryEntries } from "./dreaming-narrative.js";
 import { listMemorySessionTombstones } from "./memory-entry-origins.js";
+import { withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
 import { previewGroundedRemMarkdown } from "./rem-evidence.js";
 import type {
   SessionBackfillDay,
@@ -30,6 +31,7 @@ import {
   foreignSessionIngestionSource,
   mergeTrackedMessageHashes,
   readSessionIngestionState,
+  resolveAdmissionPolicy,
   scanSessionIngestionSource,
   sessionExclusionReason,
   sessionIngestionSourceFromCorpus,
@@ -37,6 +39,8 @@ import {
   writeSessionIngestionState,
   type SessionIngestionCandidate,
   type SessionIngestionSource,
+  type SessionAdmissionPolicy,
+  type SessionEntryOrigin,
 } from "./session-ingestion.js";
 import {
   readShortTermRecallEntries,
@@ -76,6 +80,7 @@ type SessionBackfillScan = {
 type RunSessionBackfillParams = {
   agentId: string;
   workspaceDir: string;
+  pluginConfig?: Record<string, unknown>;
   from?: string;
   to?: string;
   limitDays?: number;
@@ -90,6 +95,7 @@ type RunSessionBackfillParams = {
 async function listSessionBackfillSources(params: {
   agentId: string;
   archiveFiles: string[];
+  admissionPolicy?: SessionAdmissionPolicy;
 }): Promise<SessionIngestionSource[]> {
   const corpus = await listSessionTranscriptCorpusEntriesForAgent(params.agentId, {
     includeRetainedSqlite: true,
@@ -104,7 +110,7 @@ async function listSessionBackfillSources(params: {
         entry !== null &&
         !entry.buildOptions.generatedByDreamingNarrative &&
         !entry.buildOptions.generatedByCronRun &&
-        !sessionExclusionReason(entry, undefined, forgottenSessionIds),
+        !sessionExclusionReason(entry, params.admissionPolicy, forgottenSessionIds),
     );
   const canonicalPaths = new Set(sources.map((entry) => path.resolve(entry.absolutePath)));
   for (const archiveFile of params.archiveFiles) {
@@ -303,16 +309,29 @@ async function buildRemDiaryEntries(params: {
   }
 }
 
-function uniqueGroundedItems(results: MemorySearchResult[]): MemorySearchResult[] {
-  const seen = new Set<string>();
+function coalesceBackfillClaims(
+  results: Array<MemorySearchResult & { sessionOrigin?: SessionEntryOrigin }>,
+) {
+  const claims = new Map<
+    string,
+    Pick<MemorySearchResult, "path" | "startLine" | "endLine" | "snippet">
+  >();
   return results.flatMap((result) => {
     const snippet = result.snippet.replace(/^(?:Assistant|User):\s*/i, "").trim();
     const key = snippet.replace(/\s+/g, " ").toLowerCase();
-    if (!key || seen.has(key)) {
+    if (!key) {
       return [];
     }
-    seen.add(key);
-    return [{ ...result, snippet }];
+    const claim = claims.get(key) ?? {
+      path: result.path,
+      startLine: result.startLine,
+      endLine: result.endLine,
+      snippet,
+    };
+    claims.set(key, claim);
+    // Share the first citation for query/day dedupe, but retain each source's
+    // identity so coalescing a claim cannot discard its deletion lineage.
+    return [{ ...result, ...claim }];
   });
 }
 
@@ -332,12 +351,10 @@ async function applySessionBackfillDays(params: {
       day: day.day,
       lines: day.candidates,
     });
-    const grounded = uniqueGroundedItems(results);
+    const grounded = coalesceBackfillClaims(results);
     if (grounded.length === 0) {
       continue;
     }
-    // Standard grounded staging owns claim identity. Exact duplicates are
-    // collapsed here; claim-hash keying also converges the same fact across sources.
     await recordGroundedShortTermCandidates({
       workspaceDir: params.workspaceDir,
       query: `${SESSION_BACKFILL_QUERY_PREFIX}:${day.day}`,
@@ -348,6 +365,8 @@ async function applySessionBackfillDays(params: {
         snippet: result.snippet,
         score: SESSION_INGESTION_SCORE,
         dayBucket: day.day,
+        provenance: result.provenance,
+        sessionOrigin: result.sessionOrigin,
       })),
       dedupeByQueryPerDay: true,
       nowMs: params.nowMs,
@@ -371,6 +390,16 @@ async function executeSessionBackfillCore(
   if (params.rem && params.apply) {
     throw new Error("Memory session-backfill --rem cannot be combined with --apply.");
   }
+  const execute = () => executeSessionBackfillBatchCore({ ...params, workspaceDir });
+  return params.apply || params.rem || params.rollback
+    ? withMemoryWorkspaceLock(workspaceDir, execute)
+    : execute();
+}
+
+async function executeSessionBackfillBatchCore(
+  params: RunSessionBackfillParams,
+): Promise<SessionBackfillExecution> {
+  const workspaceDir = params.workspaceDir;
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
   if (params.rollback) {
     // Backfill diary markers and grounded-only candidates are a shared artifact
@@ -414,6 +443,7 @@ async function executeSessionBackfillCore(
   const sources = await listSessionBackfillSources({
     agentId: params.agentId,
     archiveFiles: params.archiveFiles ?? [],
+    admissionPolicy: resolveAdmissionPolicy(params.pluginConfig),
   });
   const collected = await collectSessionBackfillCandidates({
     sources,

--- a/extensions/memory-core/src/short-term-promotion-apply.ts
+++ b/extensions/memory-core/src/short-term-promotion-apply.ts
@@ -22,6 +22,7 @@ import {
 import { applyMemoryConsolidationPlan, consolidateMemory } from "./dreaming-consolidation.js";
 import { compactMemoryForBudget, DEFAULT_MEMORY_FILE_MAX_CHARS } from "./memory-budget.js";
 import { reconcileMemoryEntryOrigins } from "./memory-entry-origins.js";
+import { withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
 import {
   buildPromotionMarker,
   hashMemoryContent,
@@ -37,7 +38,7 @@ import {
 } from "./short-term-promotion-metadata.js";
 import { resolveShortTermSourcePathCandidates } from "./short-term-promotion-record.js";
 import { rehydratePromotionCandidate } from "./short-term-promotion-rehydrate.js";
-import { readStore, withShortTermLock, writeStore } from "./short-term-promotion-store.js";
+import { readStore, writeStore } from "./short-term-promotion-store.js";
 import {
   DEFAULT_PROMOTION_MIN_RECALL_COUNT,
   DEFAULT_PROMOTION_MIN_SCORE,
@@ -263,7 +264,9 @@ export async function applyShortTermPromotions(
       entry.provenance,
     ]),
   );
-  const store = await withShortTermLock(workspaceDir, async () => readStore(workspaceDir, nowIso));
+  const store = await withMemoryWorkspaceLock(workspaceDir, async () =>
+    readStore(workspaceDir, nowIso),
+  );
   const currentCandidates = options.candidates.map((candidate) => {
     const entry = store.entries[candidate.key];
     const authoritative = entry
@@ -418,7 +421,7 @@ export async function applyShortTermPromotions(
   let rewriteSkippedReason: string | undefined;
   const promotionLockTarget = await resolveMemoryPromotionLockTarget(workspaceDir);
   await withFileLock(promotionLockTarget, MEMORY_WRITE_LOCK_OPTIONS, async () => {
-    await withShortTermLock(workspaceDir, async () => {
+    await withMemoryWorkspaceLock(workspaceDir, async () => {
       const latestStore = await readStore(workspaceDir, nowIso);
       const authoritativeSelected: PromotionCandidate[] = [];
       for (const candidate of rehydratedSelected) {
@@ -630,19 +633,22 @@ export async function applyShortTermPromotions(
         });
       }
       committedCandidates = [...successfulCandidates.values()];
+      // Publish quotes before releasing the deletion boundary; otherwise a
+      // completed forget can be followed by a stale consolidation highlight.
+      if (consolidationResult) {
+        await appendConsolidationSummary({
+          workspaceDir,
+          result: consolidationResult,
+          nowMs,
+        }).catch((error: unknown) => {
+          options.consolidation?.logger.warn(
+            `memory-core: MEMORY.md was consolidated but DREAMS.md summary failed: ${String(error)}`,
+          );
+        });
+      }
     });
   });
-  if (consolidationResult) {
-    await appendConsolidationSummary({
-      workspaceDir,
-      result: consolidationResult,
-      nowMs,
-    }).catch((error: unknown) => {
-      options.consolidation?.logger.warn(
-        `memory-core: MEMORY.md was consolidated but DREAMS.md summary failed: ${String(error)}`,
-      );
-    });
-  } else if (rewriteSkippedReason) {
+  if (!consolidationResult && rewriteSkippedReason) {
     await appendConsolidationSkippedSummary({
       workspaceDir,
       nowMs,

--- a/extensions/memory-core/src/short-term-promotion-artifacts.ts
+++ b/extensions/memory-core/src/short-term-promotion-artifacts.ts
@@ -11,17 +11,19 @@ import {
   openMemoryCoreStateStore,
   readMemoryCoreWorkspaceEntries,
 } from "./dreaming-state.js";
-import { filterLiveShortTermRecallEntries } from "./short-term-promotion-record.js";
 import {
   SHORT_TERM_LOCK_STALE_MS,
   deleteShortTermLockEntryIfCurrent,
   isProcessLikelyAlive,
   parseLockOwnerPid,
+  resolveLockPath,
+  withMemoryWorkspaceLock,
+} from "./memory-workspace-lock.js";
+import { filterLiveShortTermRecallEntries } from "./short-term-promotion-record.js";
+import {
   readPhaseSignalStore,
   readStore,
-  resolveLockPath,
   resolveStorePath,
-  withShortTermLock,
   writePhaseSignalStore,
   writeStore,
 } from "./short-term-promotion-store.js";
@@ -191,7 +193,7 @@ export async function repairShortTermPromotionArtifacts(params: {
     }
   }
 
-  await withShortTermLock(workspaceDir, async () => {
+  await withMemoryWorkspaceLock(workspaceDir, async () => {
     const rawEntries = await readMemoryCoreWorkspaceEntries<unknown>({
       namespace: SHORT_TERM_RECALL_NAMESPACE,
       workspaceDir,
@@ -297,7 +299,7 @@ export async function removeGroundedShortTermCandidates(params: {
   const nowIso = new Date().toISOString();
   let removed = 0;
 
-  await withShortTermLock(workspaceDir, async () => {
+  await withMemoryWorkspaceLock(workspaceDir, async () => {
     const [store, phaseSignals] = await Promise.all([
       readStore(workspaceDir, nowIso),
       readPhaseSignalStore(workspaceDir, nowIso),

--- a/extensions/memory-core/src/short-term-promotion-record.ts
+++ b/extensions/memory-core/src/short-term-promotion-record.ts
@@ -8,9 +8,15 @@ import { formatMemoryDreamingDay } from "openclaw/plugin-sdk/memory-core-host-st
 import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
 import pLimit from "p-limit";
 import { deriveConceptTags } from "./concept-vocabulary.js";
-import { recordMemoryEntryOrigins, type MemoryEntryOrigin } from "./memory-entry-origins.js";
-import { readStore, withShortTermLock, writeStore } from "./short-term-promotion-store.js";
-import type { ShortTermRecallEntry, ShortTermRecallStore } from "./short-term-promotion-types.js";
+import {
+  listMemorySessionTombstones,
+  recordMemoryEntryOrigins,
+  type MemoryEntryOrigin,
+} from "./memory-entry-origins.js";
+import { withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
+import type { SessionEntryOrigin } from "./session-ingestion.js";
+import { readStore, writeStore } from "./short-term-promotion-store.js";
+import type { ShortTermRecallEntry } from "./short-term-promotion-types.js";
 import {
   buildDailyClaimEntryKey,
   buildClaimHash,
@@ -36,30 +42,20 @@ const SHORT_TERM_SOURCE_FILE_CHECK_CONCURRENCY = 32;
 
 function mergeRecallProvenance(
   existing: MemoryEntryProvenance | undefined,
-  incoming: MemoryEntryProvenance | undefined,
-  nowMs: number,
+  incoming: MemoryEntryProvenance,
 ): MemoryEntryProvenance {
-  // Recorded recalls are memory-source only (workspace files, filtered by the
-  // caller), so a hit that carries no explicit provenance defaults to 'agent'
-  // to match the index provenance trigger. Untrusted only arrives when a hit
-  // explicitly carries it, and then the merge below keeps the taint.
-  const next = incoming ?? {
-    originClass: "agent" as const,
-    sessionKind: "unknown" as const,
-    observedAt: nowMs,
-  };
   if (!existing) {
-    return next;
+    return incoming;
   }
   const priority = ["owner", "agent", "system", "untrusted"] as const;
   const originClass = priority.findLast(
-    (origin) => origin === existing.originClass || origin === next.originClass,
+    (origin) => origin === existing.originClass || origin === incoming.originClass,
   );
   return {
     originClass: originClass ?? "untrusted",
-    sessionKind: existing.sessionKind === next.sessionKind ? next.sessionKind : "unknown",
-    observedAt: Math.max(existing.observedAt, next.observedAt),
-    ...(existing.supersedesKey && existing.supersedesKey === next.supersedesKey
+    sessionKind: existing.sessionKind === incoming.sessionKind ? incoming.sessionKind : "unknown",
+    observedAt: Math.max(existing.observedAt, incoming.observedAt),
+    ...(existing.supersedesKey && existing.supersedesKey === incoming.supersedesKey
       ? { supersedesKey: existing.supersedesKey }
       : {}),
   };
@@ -134,31 +130,19 @@ function buildMemoryRecallSkippedEvent(params: {
   };
 }
 
-async function updateShortTermRecallStore(
-  workspaceDir: string,
-  nowIso: string,
-  update: (store: ShortTermRecallStore) => void | Promise<void>,
-  afterWrite?: () => Promise<void>,
-): Promise<void> {
-  await withShortTermLock(workspaceDir, async () => {
-    const store = await readStore(workspaceDir, nowIso);
-    await update(store);
-    store.updatedAt = nowIso;
-    await writeStore(workspaceDir, store);
-    await afterWrite?.();
-  });
-}
-
 export async function recordShortTermRecalls(params: {
   workspaceDir?: string;
   query: string;
   results: Array<
     MemorySearchResult & {
       identitySnippet?: string;
-      sessionOrigin?: { agentId: string; sessionId: string; sessionKey?: string };
+      sessionOrigin?: SessionEntryOrigin;
+      query?: string;
+      signalCount?: number;
+      dayBucket?: string;
     }
   >;
-  signalType?: "recall" | "daily";
+  signalType?: "recall" | "daily" | "grounded";
   dedupeByQueryPerDay?: boolean;
   dayBucket?: string;
   nowMs?: number;
@@ -172,10 +156,11 @@ export async function recordShortTermRecalls(params: {
   if (!query) {
     return;
   }
+  const signalType = params.signalType ?? "recall";
   const memoryResults = params.results.filter((result) => result.source === "memory");
   const relevant = memoryResults.filter((result) => isShortTermMemoryPath(result.path));
   const skipped = memoryResults.filter((result) => !isShortTermMemoryPath(result.path));
-  if (relevant.length === 0 && skipped.length === 0) {
+  if (relevant.length === 0 && (skipped.length === 0 || signalType === "grounded")) {
     return;
   }
 
@@ -193,175 +178,215 @@ export async function recordShortTermRecalls(params: {
     );
     return;
   }
-  const signalType = params.signalType ?? "recall";
-  const queryHash = hashQuery(query);
-  const origins: MemoryEntryOrigin[] = [];
-  const todayBucket =
-    normalizeIsoDay(params.dayBucket ?? "") ?? formatMemoryDreamingDay(nowMs, params.timezone);
-  await updateShortTermRecallStore(
-    workspaceDir,
-    nowIso,
-    (store) => {
-      for (const result of relevant) {
-        const normalizedPath = normalizeMemoryPath(result.path);
-        const rawSnippet = normalizeSnippet(result.snippet);
-        const snippet = truncateShortTermSnippet(rawSnippet);
-        if (
-          !rawSnippet ||
-          isContaminatedDreamingSnippet(rawSnippet, {
-            allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(normalizedPath),
-          })
-        ) {
-          continue;
-        }
-        const identitySnippet =
-          signalType === "daily"
-            ? normalizeSnippet(result.identitySnippet ?? rawSnippet)
-            : rawSnippet;
-        const claimHash = buildClaimHash(identitySnippet);
-        const nonDailyEntry =
-          signalType === "daily"
-            ? Object.values(store.entries).find(
-                (entry) =>
-                  !entry.key.startsWith("memory:claim:") &&
-                  Math.max(0, Math.floor(entry.recallCount ?? 0)) +
-                    Math.max(0, Math.floor(entry.groundedCount ?? 0)) >
-                    0 &&
-                  entry.claimHash === claimHash,
-              )
-            : undefined;
-        // Interactive/grounded writers retain their path-qualified identity. Do
-        // not create a competing daily aggregate for the same claim; reinforce
-        // the existing authoritative candidate instead.
-        const groundedKey = claimHash
-          ? signalType === "daily"
-            ? // Interactive recall intentionally retains its path/range identity;
-              // only daily ingestion aggregates cross-file recurrence by claim.
-              buildDailyClaimEntryKey(claimHash)
-            : buildEntryKey({
-                path: normalizedPath,
-                startLine: Math.max(1, Math.floor(result.startLine)),
-                endLine: Math.max(1, Math.floor(result.endLine)),
-                source: "memory",
-                claimHash,
-              })
-          : null;
-        const baseKey = buildEntryKey(result);
-        const key =
-          nonDailyEntry?.key ??
-          (signalType === "daily" && groundedKey
-            ? groundedKey
-            : groundedKey && store.entries[groundedKey]
-              ? groundedKey
-              : baseKey);
-        const existing = store.entries[key];
-        const score = clampScore(result.score);
-        const recallDaysBase = existing?.recallDays ?? [];
-        const queryHashesBase = existing?.queryHashes ?? [];
-        const dedupeSignal =
-          Boolean(params.dedupeByQueryPerDay) &&
-          queryHashesBase.includes(queryHash) &&
-          recallDaysBase.includes(todayBucket);
-        const recallCount =
-          signalType === "recall"
-            ? Math.max(0, Math.floor(existing?.recallCount ?? 0) + (dedupeSignal ? 0 : 1))
-            : Math.max(0, Math.floor(existing?.recallCount ?? 0));
-        const dailyCount =
-          signalType === "daily"
-            ? Math.max(0, Math.floor(existing?.dailyCount ?? 0) + (dedupeSignal ? 0 : 1))
-            : Math.max(0, Math.floor(existing?.dailyCount ?? 0));
-        const totalScore = Math.max(0, (existing?.totalScore ?? 0) + (dedupeSignal ? 0 : score));
-        const maxScore = Math.max(existing?.maxScore ?? 0, dedupeSignal ? 0 : score);
-        const queryHashes = mergeQueryHashes(existing?.queryHashes ?? [], queryHash);
-        const recallDays = mergeRecentDistinct(recallDaysBase, todayBucket, MAX_RECALL_DAYS);
-        const conceptTags = deriveConceptTags({ path: normalizedPath, snippet });
-        const provenance = mergeRecallProvenance(existing?.provenance, result.provenance, nowMs);
-        const projectKey = mergeProjectKeyLists(existing?.projectKey, result.projectKey);
-
-        const unchangedRepeatedSignal =
-          (Boolean(params.dedupeByQueryPerDay) || signalType === "daily") &&
-          queryHashesBase.includes(queryHash) &&
-          existing?.snippet === snippet;
-        // This preserves freshness only. dedupeSignal above independently owns
-        // whether counts/scores advance, so changed-file daily ingestion still adds evidence.
-        const lastRecalledAt = unchangedRepeatedSignal
-          ? (existing?.lastRecalledAt ?? nowIso)
-          : nowIso;
-        // Daily claim keys deliberately omit the file path so the same fact in
-        // three distinct day files accumulates three query/day signals and can
-        // clear the default dreaming gates. Keep the first source for citation.
-        const preserveFirstDailySource = signalType === "daily" && existing !== undefined;
-
-        store.entries[key] = {
-          key,
-          path: preserveFirstDailySource ? existing.path : normalizedPath,
-          startLine: preserveFirstDailySource
-            ? existing.startLine
-            : Math.max(1, Math.floor(result.startLine)),
-          endLine: preserveFirstDailySource
-            ? existing.endLine
-            : Math.max(1, Math.floor(result.endLine)),
-          source: "memory",
-          snippet: snippet || existing?.snippet || "",
-          recallCount,
-          dailyCount,
-          groundedCount: Math.max(0, Math.floor(existing?.groundedCount ?? 0)),
-          totalScore,
-          maxScore,
-          firstRecalledAt: existing?.firstRecalledAt ?? nowIso,
-          lastRecalledAt,
-          queryHashes,
-          recallDays,
-          conceptTags: conceptTags.length > 0 ? conceptTags : (existing?.conceptTags ?? []),
-          provenance,
-          claimHash,
-          ...(projectKey ? { projectKey } : {}),
-          ...(existing?.promotedAt ? { promotedAt: existing.promotedAt } : {}),
-        };
-        if (result.sessionOrigin) {
-          origins.push({
-            entryKey: key,
-            agentId: result.sessionOrigin.agentId,
-            sessionId: result.sessionOrigin.sessionId,
-            sessionKey: result.sessionOrigin.sessionKey ?? null,
-            originClass: provenance.originClass,
-            observedAt: provenance.observedAt,
-          });
-        }
+  const sourceSessions = new Map<string, Set<string>>();
+  for (const { sessionOrigin } of relevant) {
+    if (sessionOrigin) {
+      const sessions = sourceSessions.get(sessionOrigin.agentId) ?? new Set<string>();
+      sessions.add(sessionOrigin.sessionId);
+      sourceSessions.set(sessionOrigin.agentId, sessions);
+    }
+  }
+  const todayBucket = formatMemoryDreamingDay(nowMs, params.timezone);
+  await withMemoryWorkspaceLock(workspaceDir, async () => {
+    const store = await readStore(workspaceDir, nowIso);
+    const forgottenByAgent = new Map<string, Set<string>>();
+    for (const [agentId, sessionIds] of sourceSessions) {
+      forgottenByAgent.set(
+        agentId,
+        new Set(
+          listMemorySessionTombstones({ agentId, sessionIds: [...sessionIds] }).map(
+            (entry) => entry.sessionId,
+          ),
+        ),
+      );
+    }
+    // Revalidate after acquiring the shared mutation lock: a purge can finish
+    // while transcript scanning or a previous staging operation is awaited.
+    const admitted = relevant.filter(
+      ({ sessionOrigin }) =>
+        !sessionOrigin ||
+        !forgottenByAgent.get(sessionOrigin.agentId)?.has(sessionOrigin.sessionId),
+    );
+    if (admitted.length === 0) {
+      return;
+    }
+    const origins: MemoryEntryOrigin[] = [];
+    for (const result of admitted) {
+      const normalizedPath = normalizeMemoryPath(result.path);
+      const rawSnippet = normalizeSnippet(result.snippet);
+      const snippet = truncateShortTermSnippet(rawSnippet);
+      if (
+        !rawSnippet ||
+        (signalType === "grounded" &&
+          (!Number.isFinite(result.startLine) || !Number.isFinite(result.endLine))) ||
+        isContaminatedDreamingSnippet(rawSnippet, {
+          allowTranscriptTurnSnippet:
+            signalType !== "grounded" && isShortTermSessionCorpusPath(normalizedPath),
+        })
+      ) {
+        continue;
       }
-    },
-    async () => {
-      for (const agentId of new Set(origins.map((origin) => origin.agentId))) {
-        recordMemoryEntryOrigins({
-          agentId,
-          origins: origins.filter((origin) => origin.agentId === agentId),
+      const identitySnippet =
+        signalType === "daily"
+          ? normalizeSnippet(result.identitySnippet ?? rawSnippet)
+          : rawSnippet;
+      const claimHash = buildClaimHash(identitySnippet);
+      const nonDailyEntry =
+        signalType === "daily"
+          ? Object.values(store.entries).find(
+              (entry) =>
+                !entry.key.startsWith("memory:claim:") &&
+                Math.max(0, Math.floor(entry.recallCount ?? 0)) +
+                  Math.max(0, Math.floor(entry.groundedCount ?? 0)) >
+                  0 &&
+                entry.claimHash === claimHash,
+            )
+          : undefined;
+      // Interactive/grounded writers retain their path-qualified identity.
+      // Daily recurrence reinforces that candidate instead of creating a rival.
+      const claimKey =
+        signalType === "daily"
+          ? buildDailyClaimEntryKey(claimHash)
+          : buildEntryKey({
+              path: normalizedPath,
+              startLine: Math.max(1, Math.floor(result.startLine)),
+              endLine: Math.max(1, Math.floor(result.endLine)),
+              source: "memory",
+              claimHash,
+            });
+      const key =
+        nonDailyEntry?.key ??
+        (signalType !== "recall" || store.entries[claimKey] ? claimKey : buildEntryKey(result));
+      const existing = store.entries[key];
+      const score = clampScore(result.score);
+      const effectiveQuery =
+        signalType === "grounded" ? normalizeSnippet(result.query ?? query) || query : query;
+      const queryHash = hashQuery(effectiveQuery);
+      const dayBucket =
+        normalizeIsoDay(
+          (signalType === "grounded" ? result.dayBucket : undefined) ?? params.dayBucket ?? "",
+        ) ?? todayBucket;
+      const signalCount =
+        signalType === "grounded" ? Math.max(1, Math.floor(result.signalCount ?? 1)) : 1;
+      const recallDaysBase = existing?.recallDays ?? [];
+      const queryHashesBase = existing?.queryHashes ?? [];
+      const dedupeSignal =
+        Boolean(params.dedupeByQueryPerDay) &&
+        queryHashesBase.includes(queryHash) &&
+        recallDaysBase.includes(dayBucket);
+      const addedSignals = dedupeSignal ? 0 : signalCount;
+      const recallCount = Math.max(
+        0,
+        Math.floor(existing?.recallCount ?? 0) + (signalType === "recall" ? addedSignals : 0),
+      );
+      const dailyCount = Math.max(
+        0,
+        Math.floor(existing?.dailyCount ?? 0) + (signalType === "daily" ? addedSignals : 0),
+      );
+      const groundedCount = Math.max(
+        0,
+        Math.floor(existing?.groundedCount ?? 0) + (signalType === "grounded" ? addedSignals : 0),
+      );
+      const totalScore = Math.max(0, (existing?.totalScore ?? 0) + score * addedSignals);
+      const maxScore = Math.max(existing?.maxScore ?? 0, dedupeSignal ? 0 : score);
+      const queryHashes = mergeQueryHashes(existing?.queryHashes ?? [], queryHash);
+      const recallDays = mergeRecentDistinct(recallDaysBase, dayBucket, MAX_RECALL_DAYS);
+      const conceptTags = deriveConceptTags({ path: normalizedPath, snippet });
+      // Workspace-file hits without explicit provenance retain the index's
+      // agent default; source-origin rows keep these facts before trust merges.
+      const sourceProvenance = result.provenance ?? {
+        originClass: "agent" as const,
+        sessionKind: "unknown" as const,
+        observedAt: nowMs,
+      };
+      const provenance = mergeRecallProvenance(existing?.provenance, sourceProvenance);
+      const projectKey = mergeProjectKeyLists(existing?.projectKey, result.projectKey);
+      const unchangedRepeatedSignal =
+        (Boolean(params.dedupeByQueryPerDay) || signalType === "daily") &&
+        queryHashesBase.includes(queryHash) &&
+        existing?.snippet === snippet;
+      // Freshness and signal counting are independent: changed daily content
+      // may add evidence without a repeated query refreshing an old claim.
+      const lastRecalledAt = unchangedRepeatedSignal
+        ? (existing?.lastRecalledAt ?? nowIso)
+        : nowIso;
+      // Daily claim keys omit the file path; retain the first source citation
+      // while observations from distinct days accumulate on the same claim.
+      const preserveFirstDailySource = signalType === "daily" && existing !== undefined;
+      store.entries[key] = {
+        key,
+        path: preserveFirstDailySource ? existing.path : normalizedPath,
+        startLine: preserveFirstDailySource
+          ? existing.startLine
+          : Math.max(1, Math.floor(result.startLine)),
+        endLine: preserveFirstDailySource
+          ? existing.endLine
+          : Math.max(1, Math.floor(result.endLine)),
+        source: "memory",
+        snippet: snippet || existing?.snippet || "",
+        recallCount,
+        dailyCount,
+        groundedCount,
+        totalScore,
+        maxScore,
+        firstRecalledAt: existing?.firstRecalledAt ?? nowIso,
+        lastRecalledAt,
+        queryHashes,
+        recallDays,
+        conceptTags: conceptTags.length > 0 ? conceptTags : (existing?.conceptTags ?? []),
+        provenance,
+        claimHash,
+        ...(projectKey ? { projectKey } : {}),
+        ...(existing?.promotedAt ? { promotedAt: existing.promotedAt } : {}),
+      };
+      if (result.sessionOrigin) {
+        origins.push({
+          entryKey: key,
+          agentId: result.sessionOrigin.agentId,
+          sessionId: result.sessionOrigin.sessionId,
+          sessionKey: result.sessionOrigin.sessionKey ?? null,
+          originClass: sourceProvenance.originClass,
+          observedAt: sourceProvenance.observedAt,
         });
       }
-      await appendMemoryHostEvent(workspaceDir, {
-        type: "memory.recall.recorded",
-        timestamp: nowIso,
-        query,
-        resultCount: relevant.length,
-        results: relevant.map((result) => ({
-          path: normalizeMemoryPath(result.path),
-          startLine: Math.max(1, Math.floor(result.startLine)),
-          endLine: Math.max(1, Math.floor(result.endLine)),
-          score: clampScore(result.score),
-        })),
+    }
+    // Reserve lineage before publishing candidates. A failed provenance write
+    // must not leave durable staged content without its source-session facts.
+    for (const agentId of sourceSessions.keys()) {
+      recordMemoryEntryOrigins({
+        agentId,
+        origins: origins.filter((origin) => origin.agentId === agentId),
       });
-      if (skipped.length > 0) {
-        await appendMemoryHostEvent(
-          workspaceDir,
-          buildMemoryRecallSkippedEvent({
-            timestamp: nowIso,
-            query,
-            eligibleResultCount: relevant.length,
-            skipped,
-          }),
-        );
-      }
-    },
-  );
+    }
+    store.updatedAt = nowIso;
+    await writeStore(workspaceDir, store);
+    if (signalType === "grounded") {
+      return;
+    }
+    await appendMemoryHostEvent(workspaceDir, {
+      type: "memory.recall.recorded",
+      timestamp: nowIso,
+      query,
+      resultCount: admitted.length,
+      results: admitted.map((result) => ({
+        path: normalizeMemoryPath(result.path),
+        startLine: Math.max(1, Math.floor(result.startLine)),
+        endLine: Math.max(1, Math.floor(result.endLine)),
+        score: clampScore(result.score),
+      })),
+    });
+    if (skipped.length > 0) {
+      await appendMemoryHostEvent(
+        workspaceDir,
+        buildMemoryRecallSkippedEvent({
+          timestamp: nowIso,
+          query,
+          eligibleResultCount: admitted.length,
+          skipped,
+        }),
+      );
+    }
+  });
 }
 
 export async function recordGroundedShortTermCandidates(params: {
@@ -377,133 +402,19 @@ export async function recordGroundedShortTermCandidates(params: {
     signalCount?: number;
     dayBucket?: string;
     projectKey?: string;
+    provenance?: MemoryEntryProvenance;
+    sessionOrigin?: SessionEntryOrigin;
   }>;
   dedupeByQueryPerDay?: boolean;
   dayBucket?: string;
   nowMs?: number;
   timezone?: string;
 }): Promise<void> {
-  const workspaceDir = params.workspaceDir?.trim();
-  if (!workspaceDir) {
-    return;
-  }
-  const query = params.query.trim();
-  if (!query) {
-    return;
-  }
-  const relevant = params.items
-    .map((item) => {
-      const rawSnippet = normalizeSnippet(item.snippet);
-      const snippet = truncateShortTermSnippet(rawSnippet);
-      const normalizedPath = normalizeMemoryPath(item.path);
-      if (
-        !rawSnippet ||
-        isContaminatedDreamingSnippet(rawSnippet) ||
-        !normalizedPath ||
-        !isShortTermMemoryPath(normalizedPath) ||
-        !Number.isFinite(item.startLine) ||
-        !Number.isFinite(item.endLine)
-      ) {
-        return null;
-      }
-      return {
-        path: normalizedPath,
-        startLine: Math.max(1, Math.floor(item.startLine)),
-        endLine: Math.max(1, Math.floor(item.endLine)),
-        snippet,
-        identitySnippet: rawSnippet,
-        score: clampScore(item.score),
-        query: normalizeSnippet(item.query ?? query),
-        signalCount: Math.max(1, Math.floor(item.signalCount ?? 1)),
-        dayBucket: normalizeIsoDay(item.dayBucket ?? params.dayBucket ?? ""),
-        projectKey: mergeProjectKeyLists(item.projectKey),
-      };
-    })
-    .filter((item): item is NonNullable<typeof item> => item !== null);
-  if (relevant.length === 0) {
-    return;
-  }
-
-  const nowMs = resolveMemoryCoreNowMs(params.nowMs);
-  const nowIso = resolveMemoryCoreTimestamp(nowMs);
-  const fallbackDayBucket = formatMemoryDreamingDay(nowMs, params.timezone);
-  await updateShortTermRecallStore(workspaceDir, nowIso, (store) => {
-    for (const item of relevant) {
-      const dayBucket = item.dayBucket ?? fallbackDayBucket;
-      const effectiveQuery = item.query || query;
-      if (!effectiveQuery) {
-        continue;
-      }
-      const queryHash = hashQuery(effectiveQuery);
-      const claimHash = buildClaimHash(item.identitySnippet);
-      const key = buildEntryKey({
-        path: item.path,
-        startLine: item.startLine,
-        endLine: item.endLine,
-        source: "memory",
-        claimHash,
-      });
-      const existing = store.entries[key];
-      const recallDaysBase = existing?.recallDays ?? [];
-      const queryHashesBase = existing?.queryHashes ?? [];
-      const dedupeSignal =
-        Boolean(params.dedupeByQueryPerDay) &&
-        queryHashesBase.includes(queryHash) &&
-        recallDaysBase.includes(dayBucket);
-      const groundedCount = Math.max(
-        0,
-        Math.floor(existing?.groundedCount ?? 0) + (dedupeSignal ? 0 : item.signalCount),
-      );
-      const totalScore = Math.max(
-        0,
-        (existing?.totalScore ?? 0) + (dedupeSignal ? 0 : item.score * item.signalCount),
-      );
-      const maxScore = Math.max(existing?.maxScore ?? 0, dedupeSignal ? 0 : item.score);
-      const queryHashes = mergeQueryHashes(existing?.queryHashes ?? [], queryHash);
-      const recallDays = mergeRecentDistinct(recallDaysBase, dayBucket, MAX_RECALL_DAYS);
-      const conceptTags = deriveConceptTags({ path: item.path, snippet: item.snippet });
-      const provenance = mergeRecallProvenance(
-        existing?.provenance,
-        {
-          originClass: "agent",
-          sessionKind: "unknown",
-          observedAt: nowMs,
-        },
-        nowMs,
-      );
-      const projectKey = mergeProjectKeyLists(existing?.projectKey, item.projectKey);
-
-      const unchangedRepeatedSignal =
-        Boolean(params.dedupeByQueryPerDay) &&
-        queryHashesBase.includes(queryHash) &&
-        existing?.snippet === item.snippet;
-      const lastRecalledAt = unchangedRepeatedSignal
-        ? (existing?.lastRecalledAt ?? nowIso)
-        : nowIso;
-
-      store.entries[key] = {
-        key,
-        path: item.path,
-        startLine: item.startLine,
-        endLine: item.endLine,
-        source: "memory",
-        snippet: item.snippet,
-        recallCount: Math.max(0, Math.floor(existing?.recallCount ?? 0)),
-        dailyCount: Math.max(0, Math.floor(existing?.dailyCount ?? 0)),
-        groundedCount,
-        totalScore,
-        maxScore,
-        firstRecalledAt: existing?.firstRecalledAt ?? nowIso,
-        lastRecalledAt,
-        queryHashes,
-        recallDays,
-        conceptTags: conceptTags.length > 0 ? conceptTags : (existing?.conceptTags ?? []),
-        provenance,
-        claimHash,
-        ...(projectKey ? { projectKey } : {}),
-        ...(existing?.promotedAt ? { promotedAt: existing.promotedAt } : {}),
-      };
-    }
+  const { items, ...options } = params;
+  await recordShortTermRecalls({
+    ...options,
+    signalType: "grounded",
+    results: items.map((item) => Object.assign({}, item, { source: "memory" as const })),
   });
 }
 

--- a/extensions/memory-core/src/short-term-promotion-stats.ts
+++ b/extensions/memory-core/src/short-term-promotion-stats.ts
@@ -2,13 +2,13 @@ import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { isSameMemoryDreamingDay } from "openclaw/plugin-sdk/memory-core-host-status";
 import { normalizeStringEntries, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { formatErrorMessage } from "./dreaming-shared.js";
+import { withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
 import {
   emptyPhaseSignalStore,
   readPhaseSignalStore,
   readStore,
   resolvePhaseSignalPath,
   resolveStorePath,
-  withShortTermLock,
   writePhaseSignalStore,
 } from "./short-term-promotion-store.js";
 import type {
@@ -236,7 +236,7 @@ async function updatePhaseSignals(
   }
   const nowIso = resolveMemoryCoreTimestamp(resolveMemoryCoreNowMs(params.nowMs));
 
-  await withShortTermLock(workspaceDir, async () => {
+  await withMemoryWorkspaceLock(workspaceDir, async () => {
     const [store, phaseSignals] = await Promise.all([
       readStore(workspaceDir, nowIso),
       readPhaseSignalStore(workspaceDir, nowIso),

--- a/extensions/memory-core/src/short-term-promotion-store.ts
+++ b/extensions/memory-core/src/short-term-promotion-store.ts
@@ -1,23 +1,14 @@
-import fsSync from "node:fs";
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
-import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
-import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
-  SHORT_TERM_LOCK_MAX_ENTRIES,
-  SHORT_TERM_LOCK_NAMESPACE,
   SHORT_TERM_META_NAMESPACE,
   SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
   SHORT_TERM_RECALL_NAMESPACE,
   memoryCoreStateReference,
-  memoryCoreWorkspaceStateKey,
-  openMemoryCoreStateStore,
   readMemoryCoreWorkspaceEntries,
   writeMemoryCoreWorkspaceEntries,
   writeMemoryCoreWorkspaceEntry,
 } from "./dreaming-state.js";
 import type {
-  ShortTermLockEntry,
   ShortTermPhaseSignalEntry,
   ShortTermPhaseSignalStore,
   ShortTermRecallEntry,
@@ -31,120 +22,12 @@ import {
   toFiniteNonNegativeInt,
 } from "./short-term-promotion-utils.js";
 
-const SHORT_TERM_LOCK_WAIT_TIMEOUT_MS = 10_000;
-export const SHORT_TERM_LOCK_STALE_MS = 60_000;
-const SHORT_TERM_LOCK_RETRY_DELAY_MS = 40;
-const inProcessShortTermLocks = new KeyedAsyncQueue();
-
 export function resolveStorePath(workspaceDir: string): string {
   return memoryCoreStateReference(SHORT_TERM_RECALL_NAMESPACE, workspaceDir);
 }
 
 export function resolvePhaseSignalPath(workspaceDir: string): string {
   return memoryCoreStateReference(SHORT_TERM_PHASE_SIGNAL_NAMESPACE, workspaceDir);
-}
-
-export function resolveLockPath(workspaceDir: string): string {
-  return memoryCoreStateReference(SHORT_TERM_LOCK_NAMESPACE, workspaceDir);
-}
-
-export function parseLockOwnerPid(raw: string): number | null {
-  const match = raw.trim().match(/^(\d+):/);
-  if (!match) {
-    return null;
-  }
-  const pid = Number.parseInt(match[1] ?? "", 10);
-  if (!Number.isInteger(pid) || pid <= 0) {
-    return null;
-  }
-  return pid;
-}
-
-export function isProcessLikelyAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ESRCH") {
-      return false;
-    }
-    // EPERM and unknown errors remain potentially alive unless procfs proves a zombie.
-  }
-  if (process.platform !== "linux") {
-    return true;
-  }
-  try {
-    const status = fsSync.readFileSync(`/proc/${pid}/status`, "utf8");
-    const state = status.match(/^State:\s+(\S)/m)?.[1];
-    return state !== "Z" && state !== "X";
-  } catch {
-    // An unreadable proc entry is not enough evidence to steal an active lock.
-    return true;
-  }
-}
-
-export async function deleteShortTermLockEntryIfCurrent(
-  lockStore: PluginStateKeyedStore<ShortTermLockEntry>,
-  lockKey: string,
-  expected: ShortTermLockEntry,
-): Promise<boolean> {
-  if (!lockStore.deleteIf) {
-    throw new Error("memory-core short-term lock store requires conditional deletion");
-  }
-  return await lockStore.deleteIf(
-    lockKey,
-    (current) => current.owner === expected.owner && current.acquiredAt === expected.acquiredAt,
-  );
-}
-
-async function withInProcessShortTermLock<T>(lockPath: string, task: () => Promise<T>): Promise<T> {
-  return await inProcessShortTermLocks.enqueue(lockPath, task);
-}
-
-export async function withShortTermLock<T>(
-  workspaceDir: string,
-  task: () => Promise<T>,
-): Promise<T> {
-  const lockKey = memoryCoreWorkspaceStateKey(workspaceDir);
-  const lockRef = resolveLockPath(workspaceDir);
-  const lockStore = openMemoryCoreStateStore<ShortTermLockEntry>({
-    namespace: SHORT_TERM_LOCK_NAMESPACE,
-    maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
-  });
-  return withInProcessShortTermLock(lockKey, async () => {
-    const startedAt = Date.now();
-
-    while (true) {
-      const lockEntry: ShortTermLockEntry = {
-        owner: `${process.pid}:${Date.now()}`,
-        acquiredAt: Date.now(),
-      };
-      const acquired = await lockStore.registerIfAbsent(lockKey, lockEntry);
-      if (acquired) {
-        try {
-          return await task();
-        } finally {
-          await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, lockEntry).catch(() => false);
-        }
-      }
-
-      const existing = await lockStore.lookup(lockKey);
-      if (existing && Date.now() - existing.acquiredAt > SHORT_TERM_LOCK_STALE_MS) {
-        const ownerPid = parseLockOwnerPid(existing.owner);
-        if (ownerPid === null || !isProcessLikelyAlive(ownerPid)) {
-          if (await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, existing)) {
-            continue;
-          }
-        }
-      }
-
-      if (Date.now() - startedAt >= SHORT_TERM_LOCK_WAIT_TIMEOUT_MS) {
-        throw new Error(`Timed out waiting for short-term promotion lock at ${lockRef}`);
-      }
-
-      await sleep(SHORT_TERM_LOCK_RETRY_DELAY_MS);
-    }
-  });
 }
 
 export async function readStore(

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { listMemoryArtifactProvenance } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { createPluginStateKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
@@ -25,7 +26,10 @@ import {
   SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
   SHORT_TERM_RECALL_NAMESPACE,
 } from "./dreaming-state.js";
-import { deleteShortTermLockEntryIfCurrent } from "./short-term-promotion-store.js";
+import {
+  deleteShortTermLockEntryIfCurrent,
+  withMemoryWorkspaceLock,
+} from "./memory-workspace-lock.js";
 import {
   applyShortTermPromotions,
   auditShortTermPromotionArtifacts,
@@ -2574,6 +2578,72 @@ describe("short-term promotion", () => {
       vi.useRealTimers();
     }
   });
+
+  it("preserves recall updates from sequential and parallel nested workspace writers", async (workspaceDir) => {
+    const result = memoryRecallResult(
+      "memory/2026-04-03.md",
+      1,
+      1,
+      0.9,
+      "Nested workspace writers retain every recall signal.",
+    );
+    await withMemoryWorkspaceLock(workspaceDir, async () => {
+      await recordMemoryRecalls(workspaceDir, "first", [result]);
+      await withMemoryWorkspaceLock(workspaceDir, async () => {
+        await Promise.all(
+          ["second", "third"].map((query) => recordMemoryRecalls(workspaceDir, query, [result])),
+        );
+      });
+    });
+
+    const entries = Object.values(await readRecallStoreEntries(workspaceDir));
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.recallCount).toBe(3);
+  });
+
+  baseIt.each(["root", "nested"] as const)(
+    "queues work resumed from a closed %s workspace scope behind the current writer",
+    async (closedScope) => {
+      await withTempWorkspace(async (workspaceDir) => {
+        const resume = createDeferred<void>();
+        const attempted = createDeferred<void>();
+        const entered = createDeferred<void>();
+        const release = createDeferred<void>();
+        const order: string[] = [];
+        const retainWork = async () => ({
+          work: resume.promise.then(async () => {
+            attempted.resolve();
+            await withMemoryWorkspaceLock(workspaceDir, async () => {
+              order.push("resumed");
+            });
+          }),
+        });
+        let retained =
+          closedScope === "root"
+            ? await withMemoryWorkspaceLock(workspaceDir, retainWork)
+            : undefined;
+        const owner = withMemoryWorkspaceLock(workspaceDir, async () => {
+          if (closedScope === "nested") {
+            retained = await withMemoryWorkspaceLock(workspaceDir, retainWork);
+          }
+          entered.resolve();
+          await release.promise;
+          order.push("released");
+        });
+        try {
+          await entered.promise;
+          resume.resolve();
+          await attempted.promise;
+          expect(order).toEqual([]);
+        } finally {
+          release.resolve();
+          await owner;
+          await retained?.work;
+        }
+        expect(order).toEqual(["released", "resumed"]);
+      });
+    },
+  );
 
   it("reports stale sqlite locks as repairable audit issues", async (workspaceDir) => {
     await testing.writeShortTermLock(workspaceDir, {


### PR DESCRIPTION
Closes #130409

## What Problem This Solves

Fixes an issue where users running `memory forget` could retain session-derived candidates or see forgotten content return after indexing or dreaming finished. Historical backfill also ignored configured admission exclusions and did not reliably retain every source origin when identical claims were coalesced. Prefix-shaped session references could select an unrelated longer session ID.

The affected operator surfaces are the memory CLI, session backfill in the Control UI, and automatic dreaming. The provenance docs previously described broader erasure guarantees than these paths provided.

## Why This Change Was Made

The memory plugin now shares one workspace mutation lock across ingestion, staging, promotion, diary/report updates, and deletion. Index publication rechecks exact session tombstones and current file content at its commit boundary, including completed shadow rebuilds; pending narratives recheck tracked source entries and the diary context supplied to the model before publication. Embedding and model requests remain outside the lock.

Backfill uses the same configured admission policy as automatic ingestion, records each source origin before publishing its candidate, and preserves coalesced-claim deduplication. Session reference matching uses the canonical exact-ID/archive filename contract. The refactor removes the separate diary lock and duplicate grounded-staging path; it reuses the existing SQLite lock namespace and index revision without adding a table, schema version, configuration key, or dependency.

Production LOC: +965/-794 (net +171). Tests: +1024/-192 (net +832), including an existing curated-write suite moved into its owning test file. The added production code enforces publication and reentrant-lock lifetime boundaries; the duplicated recorder and old lock implementation were removed.

## User Impact

Admission exclusions now apply to CLI and Gateway backfill preview, REM, and apply. Forgetting an exact session removes its tracked candidates and derived artifacts without selecting prefix neighbors, and in-flight index, phase-report, and narrative work cannot restore removed inputs. An invalidated index run reports a retryable source change; a stale narrative records an intentional skipped outcome.

The docs now lead with a dry-run workflow and explain the actual limits. Original transcripts and archives, unrelated agents' stores, old untracked memories, and unattributable freeform/paraphrased text are not blanket-erased. Direct tools and external writers do not participate in the memory plugin lock. Existing admission lists still do not govern raw transcript indexing or direct file writes.

## Evidence

- Captured failing regressions before the fixes for backfill lineage, exact session matching, index/cache resurrection, stale workspace-file publication, diary read/modify/write, phase reports, and model narratives. The diary-context regression also proves that unrelated appends remain allowed.
- Final-head memory suite: **492 tests passed across 17 files**, covering CLI/Gateway backfill, lazy loading, deletion/origins, staging, dreaming, cache, provider lifecycle, and incremental/forced index races. Changed lint/format, max-lines, assertion-safety, and Kysely guardrails passed.
- MDX validation passed; all 6,644 internal docs links resolve; 1,201 configuration examples validate; the glossary check passed.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33018779108) is green, including the required CI gate, full build, types, lint, architecture, memory tests, and docs. A clean Linux ARM64 frozen-lockfile install and complete CLI/plugin/Control UI build also passed at the exact PR head.
- [Real CLI/Gateway/Control UI proof and recordings](https://github.com/openclaw/openclaw/pull/130451#issuecomment-5432182471): 21 commands passed on macOS, and the same base flow passed on Linux, using real provider turns and embeddings. Admission exclusions affected preview/apply; forget removed staged entries plus index/FTS/vector/cache records; forced reindex and backfill did not resurrect them. Original transcript hashes/history and an unrelated searchable control were retained.
- [Pending-publication live proof](https://github.com/openclaw/openclaw/pull/130451#issuecomment-5432255129): stopped the owned CLI and respawned worker after real embedding start, verified no workspace lock or published chunks, completed forget in 3.6 seconds, then resumed into the expected stale-session error (exit 1). A fresh index, empty forgotten search/backfill, unchanged transcript, and unrelated control all passed. All nine commands matched their expected outcomes with no timeouts.
- Codex autoreview: no actionable findings at the configured P0-only threshold; that reviewer did not execute tests. The current ClawSweeper review found no discrete correctness defect, and both Rank-up proof requests are now addressed.

Verification limits: phase-report/narrative timing and nested lock lifetimes have deterministic failing-before/passing-after coverage; the real provider race exercises index publication. Local shared-install IMAP/`pako` gaps were resolved as validation gaps by clean hosted checks and the clean Linux build. Remote test infrastructure was unavailable, so live proof used isolated host state and an ephemeral local Linux container. Harness-only retries corrected multi-agent config, debug logging, and respawned process-group targeting; the product head did not change.

Provenance: the admission/deletion contract was introduced by #130151 on 2026-08-26, commit `9d9dc3127521d556c37865e4f78ba20ee95fe8e3` (code author, PR author, and merger: @steipete). Reproductions are against current-main development code; this PR does not claim a confirmed stable-release regression.

