### PR TITLE
refactor(infra): share package manager context scan

### DIFF
--- a/src/infra/package-manager-exec-wrapper.test.ts
+++ b/src/infra/package-manager-exec-wrapper.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { hasKnownPackageManagerExecContextOptions } from "./package-manager-exec-wrapper.js";
+
+describe("hasKnownPackageManagerExecContextOptions", () => {
+  it.each([
+    ["leading", "continues after a terminator", [[["npx", "--", "--workspace=app"], true]]],
+    ["leading", "stops at a positional token", [[["npx", "tsx", "--workspace=app"], false]]],
+    ["leading", "stops at an unknown option", [[["npx", "--unknown", "--workspace=app"], false]]],
+    ["leading", "matches context before generic options", [[["npx", "--package=tsx"], true]]],
+    [
+      "leading",
+      "skips inline generic values",
+      [[["npx", "--loglevel=silent", "--workspace=app"], true]],
+    ],
+    [
+      "leading",
+      "skips separate generic values",
+      [[["npx", "--loglevel", "silent", "--workspace=app"], true]],
+    ],
+    [
+      "leading",
+      "skips missing generic values",
+      [[["npx", "--loglevel", "--workspace=app"], false]],
+    ],
+    [
+      "leading",
+      "matches only exact uppercase -C",
+      [
+        [["npx", "-C", "./package"], true],
+        [["npx", "-c", "./package"], false],
+      ],
+    ],
+    ["leading", "does not split short clusters", [[["npx", "-pw"], false]]],
+    [
+      "before-terminator",
+      "stops at a terminator",
+      [[["npm", "exec", "--", "--workspace=app"], false]],
+    ],
+    [
+      "before-terminator",
+      "continues after a positional token",
+      [[["npm", "exec", "tsx", "--workspace=app"], true]],
+    ],
+    [
+      "before-terminator",
+      "continues after an unknown option",
+      [[["npm", "exec", "--unknown", "--workspace=app"], true]],
+    ],
+    [
+      "before-terminator",
+      "matches context before generic options",
+      [[["npm", "exec", "--package=tsx"], true]],
+    ],
+    [
+      "before-terminator",
+      "skips inline generic values",
+      [[["npm", "exec", "--loglevel=silent", "--workspace=app"], true]],
+    ],
+    [
+      "before-terminator",
+      "skips separate generic values",
+      [[["npm", "exec", "--loglevel", "silent", "--workspace=app"], true]],
+    ],
+    [
+      "before-terminator",
+      "skips missing generic values",
+      [[["npm", "exec", "--loglevel", "--workspace=app"], false]],
+    ],
+    [
+      "before-terminator",
+      "matches only exact uppercase -C",
+      [
+        [["npm", "exec", "-C", "./package"], true],
+        [["npm", "exec", "-c", "./package"], false],
+      ],
+    ],
+    ["before-terminator", "does not split short clusters", [[["npm", "exec", "-pw"], false]]],
+  ] as Array<[string, string, Array<[string[], boolean]>]>)(
+    "%s scanner %s",
+    (_mode, _name, checks) => {
+      for (const [argv, expected] of checks) {
+        expect(hasKnownPackageManagerExecContextOptions(argv)).toBe(expected);
+      }
+    },
+  );
+});

--- a/src/infra/package-manager-exec-wrapper.ts
+++ b/src/infra/package-manager-exec-wrapper.ts
@@ -195,7 +195,7 @@ function findFirstNonOptionIndex(
   return null;
 }
 
-function hasLeadingContextOption(
+function hasContextOption(
   argv: string[],
   startIdx: number,
   params: {
@@ -205,8 +205,10 @@ function hasLeadingContextOption(
     contextOptionsWithValue: ReadonlySet<string>;
     contextCaseSensitiveOptionsWithValue?: ReadonlySet<string>;
     contextFlagOptions?: ReadonlySet<string>;
+    mode: "leading" | "before-terminator";
   },
 ): boolean {
+  const { mode } = params;
   let idx = startIdx;
   while (idx < argv.length) {
     const token = argv[idx]?.trim() ?? "";
@@ -215,61 +217,16 @@ function hasLeadingContextOption(
       continue;
     }
     if (token === "--") {
+      if (mode === "before-terminator") {
+        return false;
+      }
       idx += 1;
       continue;
     }
     if (!token.startsWith("-")) {
-      return false;
-    }
-    const parsedOption = parseInlineOptionToken(token);
-    const flag = normalizeLowercaseStringOrEmpty(parsedOption.name);
-    if (
-      params.contextCaseSensitiveOptionsWithValue?.has(parsedOption.name) ||
-      params.contextOptionsWithValue.has(flag) ||
-      params.contextFlagOptions?.has(flag)
-    ) {
-      return true;
-    }
-    if (params.caseSensitiveOptionsWithValue?.has(parsedOption.name)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (params.optionsWithValue.has(flag)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (params.flagOptions.has(flag)) {
-      idx += 1;
-      continue;
-    }
-    return false;
-  }
-  return false;
-}
-
-function hasContextOptionBeforeTerminator(
-  argv: string[],
-  startIdx: number,
-  params: {
-    optionsWithValue: ReadonlySet<string>;
-    caseSensitiveOptionsWithValue?: ReadonlySet<string>;
-    flagOptions: ReadonlySet<string>;
-    contextOptionsWithValue: ReadonlySet<string>;
-    contextCaseSensitiveOptionsWithValue?: ReadonlySet<string>;
-    contextFlagOptions?: ReadonlySet<string>;
-  },
-): boolean {
-  let idx = startIdx;
-  while (idx < argv.length) {
-    const token = argv[idx]?.trim() ?? "";
-    if (!token) {
-      idx += 1;
-      continue;
-    }
-    if (token === "--") {
-      return false;
-    }
-    if (!token.startsWith("-")) {
+      if (mode === "leading") {
+        return false;
+      }
       idx += 1;
       continue;
     }
@@ -293,6 +250,9 @@ function hasContextOptionBeforeTerminator(
     if (params.flagOptions.has(flag)) {
       idx += 1;
       continue;
+    }
+    if (mode === "leading") {
+      return false;
     }
     idx += 1;
   }
@@ -309,36 +269,39 @@ export function hasKnownPackageManagerExecContextOptions(argv: string[]): boolea
         flagOptions: NPM_EXEC_FLAG_OPTIONS,
       };
       if (
-        hasLeadingContextOption(argv, 1, {
+        hasContextOption(argv, 1, {
           ...leadingOptions,
           contextOptionsWithValue: NPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
           contextCaseSensitiveOptionsWithValue: new Set(["-C"]),
           contextFlagOptions: new Set(["--ws", "--workspaces"]),
+          mode: "leading",
         })
       ) {
         return true;
       }
       const subcommandIdx = findFirstNonOptionIndex(argv, 1, leadingOptions);
       return subcommandIdx !== null && NPM_EXEC_SUBCOMMANDS.has(argv[subcommandIdx] ?? "")
-        ? hasContextOptionBeforeTerminator(argv, subcommandIdx + 1, {
+        ? hasContextOption(argv, subcommandIdx + 1, {
             optionsWithValue: NPM_EXEC_OPTIONS_WITH_VALUE,
             caseSensitiveOptionsWithValue: new Set(["-C"]),
             flagOptions: NPM_EXEC_FLAG_OPTIONS,
             contextOptionsWithValue: NPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
             contextCaseSensitiveOptionsWithValue: new Set(["-C"]),
             contextFlagOptions: new Set(["--ws", "--workspaces"]),
+            mode: "before-terminator",
           })
         : false;
     }
     case "npx":
     case "bunx":
-      return hasLeadingContextOption(argv, 1, {
+      return hasContextOption(argv, 1, {
         optionsWithValue: NPM_EXEC_OPTIONS_WITH_VALUE,
         caseSensitiveOptionsWithValue: new Set(["-C"]),
         flagOptions: NPM_EXEC_FLAG_OPTIONS,
         contextOptionsWithValue: NPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
         contextCaseSensitiveOptionsWithValue: new Set(["-C"]),
         contextFlagOptions: new Set(["--ws", "--workspaces"]),
+        mode: "leading",
       });
     case "pnpm": {
       const leadingOptions = {
@@ -347,22 +310,24 @@ export function hasKnownPackageManagerExecContextOptions(argv: string[]): boolea
         flagOptions: PNPM_FLAG_OPTIONS,
       };
       if (
-        hasLeadingContextOption(argv, 1, {
+        hasContextOption(argv, 1, {
           ...leadingOptions,
           contextOptionsWithValue: PNPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
           contextCaseSensitiveOptionsWithValue: new Set(["-C"]),
           contextFlagOptions: new Set(["--recursive", "--workspace-root", "-r", "-w"]),
+          mode: "leading",
         })
       ) {
         return true;
       }
       const subcommandIdx = findFirstNonOptionIndex(argv, 1, leadingOptions);
       return argv[subcommandIdx ?? -1] === "dlx"
-        ? hasLeadingContextOption(argv, (subcommandIdx ?? 0) + 1, {
+        ? hasContextOption(argv, (subcommandIdx ?? 0) + 1, {
             ...leadingOptions,
             contextOptionsWithValue: PNPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
             contextCaseSensitiveOptionsWithValue: new Set(["-C"]),
             contextFlagOptions: new Set(["--recursive", "--workspace-root", "-r", "-w"]),
+            mode: "leading",
           })
         : false;
     }
@@ -372,19 +337,21 @@ export function hasKnownPackageManagerExecContextOptions(argv: string[]): boolea
         flagOptions: new Set([...YARN_FLAG_OPTIONS, ...YARN_DLX_FLAG_OPTIONS]),
       };
       if (
-        hasLeadingContextOption(argv, 1, {
+        hasContextOption(argv, 1, {
           ...leadingOptions,
           contextOptionsWithValue: new Set(["--cwd"]),
+          mode: "leading",
         })
       ) {
         return true;
       }
       const subcommandIdx = findFirstNonOptionIndex(argv, 1, leadingOptions);
       return argv[subcommandIdx ?? -1] === "dlx"
-        ? hasLeadingContextOption(argv, (subcommandIdx ?? 0) + 1, {
+        ? hasContextOption(argv, (subcommandIdx ?? 0) + 1, {
             optionsWithValue: YARN_DLX_OPTIONS_WITH_VALUE,
             flagOptions: YARN_DLX_FLAG_OPTIONS,
             contextOptionsWithValue: new Set(["--package", "-p"]),
+            mode: "leading",
           })
         : false;
     }


### PR DESCRIPTION
## What Problem This Solves

Package-manager exec approval checks used two nearly identical option scanners. Their only intended differences were how they treat terminators, positional tokens, and unknown options, but separate loops made those security semantics easier to drift.

## Why This Change Was Made

Use one private scanner with a closed `leading` or `before-terminator` mode. Every package-manager call site keeps its existing option sets and selects the mode matching its prior scanner.

## User Impact

No intended approval-policy change. Context-changing package-manager invocations remain ineligible for durable allow-always approval under the same command-specific parsing rules.

## Evidence

- 201 focused package-manager and exec-approval tests passed.
- Added table-driven public-boundary coverage for terminators, positional tokens, unknown options, value skipping, case-sensitive `-C`, and short clusters in both modes.
- Full `node scripts/check-changed.mjs` passed on an isolated Testbox.
- `git diff --check` passed.
- Fresh branch autoreview reported no accepted/actionable findings (`0.99` confidence).
- Production delta: `+26/-59`, net `-33`; tests: `+86/-0`.
