### PR TITLE
fix(ai): require explicit endpoints for compatible providers

### DIFF
--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -93,6 +93,11 @@ const openRouterModel = {
   baseUrl: "https://openrouter.ai/api/v1",
 } satisfies Model<"openai-completions">;
 
+const openRouterModelWithoutBaseUrl = {
+  ...openRouterModel,
+  baseUrl: undefined,
+} as unknown as Model<"openai-completions">;
+
 const context = {
   systemPrompt: "Be exact.",
   messages: [{ role: "user", content: "Find the answer.", timestamp: 1 }],
@@ -734,6 +739,24 @@ describe("provider and transport observable parity fixtures", () => {
           { type: "text", text: " Visible third." },
         ]);
       }
+    }
+  });
+
+  it("fails closed before using the OpenAI default endpoint for another provider", async () => {
+    for (const implementation of ["provider", "transport"] as const) {
+      const result = await runOpenAi(
+        implementation,
+        "success",
+        openAiChunks,
+        true,
+        openRouterModelWithoutBaseUrl,
+      );
+
+      expect(result.terminal.stopReason).toBe("error");
+      expect(result.errorFields.errorMessage).toContain(
+        'Provider "openrouter" requires an explicit base URL',
+      );
+      expect(openAiMockState.payloads).toEqual([]);
     }
   });
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -21,6 +21,7 @@ import { resolveOpenAIReasoningEffortMap } from "../transports/openai-reasoning-
 import {
   createOpenAIProviderAcceptanceHook,
   isOpenAICompletionsThinkingEnabled,
+  resolveOpenAIClientBaseUrl,
 } from "../transports/openai-transport-shared.js";
 import {
   transportAbortError,
@@ -334,9 +335,12 @@ function createClient(
         }
       : headers;
 
+  const baseUrl = isCloudflareProvider(model.provider)
+    ? resolveCloudflareBaseUrl(model)
+    : model.baseUrl;
   return new OpenAI({
     apiKey,
-    baseURL: isCloudflareProvider(model.provider) ? resolveCloudflareBaseUrl(model) : model.baseUrl,
+    baseURL: resolveOpenAIClientBaseUrl(model, baseUrl),
     dangerouslyAllowBrowser: true,
     defaultHeaders,
     // OpenAI supports custom fetch, so sentinels stay opaque until guarded egress.

--- a/packages/ai/src/providers/openai-responses.test.ts
+++ b/packages/ai/src/providers/openai-responses.test.ts
@@ -24,6 +24,7 @@ vi.mock("openai", () => ({
   },
 }));
 
+import { createOpenAIResponsesClient } from "../transports/openai-responses-client.js";
 import { streamOpenAIResponses } from "./openai-responses.js";
 
 const context = {
@@ -65,6 +66,39 @@ describe("OpenAI Responses provider", () => {
     expect(result.stopReason).toBe("error");
     expect(openAiMockState.configs).toHaveLength(1);
     expect((openAiMockState.configs[0] as { fetch?: unknown }).fetch).toBe(hostFetch);
+  });
+
+  it("fails closed before constructing an OpenAI client for another provider without an endpoint", async () => {
+    const missingEndpointModel = {
+      ...model(),
+      provider: "openrouter",
+      baseUrl: undefined,
+    } as unknown as Model<"openai-responses">;
+
+    const result = await streamOpenAIResponses(missingEndpointModel, context, {
+      apiKey: "sentinel-openrouter-key",
+    }).result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain('Provider "openrouter" requires an explicit base URL');
+    expect(() =>
+      createOpenAIResponsesClient(missingEndpointModel, context, "sentinel-openrouter-key"),
+    ).toThrow('Provider "openrouter" requires an explicit base URL');
+    expect(openAiMockState.configs).toEqual([]);
+
+    const configuredModel = {
+      ...missingEndpointModel,
+      baseUrl: "https://openrouter.ai/api/v1",
+    };
+    await streamOpenAIResponses(configuredModel, context, {
+      apiKey: "sentinel-openrouter-key",
+    }).result();
+    expect(() =>
+      createOpenAIResponsesClient(configuredModel, context, "sentinel-openrouter-key"),
+    ).not.toThrow();
+    expect(
+      openAiMockState.configs.map((config) => (config as { baseURL?: string }).baseURL),
+    ).toEqual(["https://openrouter.ai/api/v1", "https://openrouter.ai/api/v1"]);
   });
 
   it("keeps Cloudflare composed upstream auth opaque in SDK headers", async () => {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -6,6 +6,7 @@ import { getAiTransportHost } from "../host.js";
 import type { BaseOpenAIStreamOptions } from "../provider-options.js";
 import type { OpenAIResponsesReplayMode } from "../transports/openai-responses-compaction-replay.js";
 import type { OpenAIResponsesRequestParams } from "../transports/openai-responses-contracts.js";
+import { resolveOpenAIClientBaseUrl } from "../transports/openai-transport-shared.js";
 import type {
   CacheRetention,
   Context,
@@ -160,9 +161,12 @@ function createClient(
         }
       : headers;
 
+  const baseUrl = isCloudflareProvider(model.provider)
+    ? resolveCloudflareBaseUrl(model)
+    : model.baseUrl;
   return new OpenAI({
     apiKey,
-    baseURL: isCloudflareProvider(model.provider) ? resolveCloudflareBaseUrl(model) : model.baseUrl,
+    baseURL: resolveOpenAIClientBaseUrl(model, baseUrl),
     dangerouslyAllowBrowser: true,
     defaultHeaders,
     // OpenAI supports custom fetch, so sentinels stay opaque until guarded egress.

--- a/packages/ai/src/transports/openai-completions-transport.test.ts
+++ b/packages/ai/src/transports/openai-completions-transport.test.ts
@@ -182,7 +182,7 @@ describe("openai completions transport", () => {
       id: "qwen-coder-plus",
       name: "qwen-coder-plus",
       provider: "qwen",
-      baseUrl: "",
+      baseUrl: "https://modelstudio.example/v1",
       reasoning: false,
       contextWindow: 4096,
       maxTokens: 256,

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -28,6 +28,7 @@ import {
 } from "./openai-transport-params.js";
 import {
   createOpenAIProviderAcceptanceHook,
+  resolveOpenAIClientBaseUrl,
   type MutableAssistantOutput,
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
@@ -128,7 +129,7 @@ function buildOpenAICompletionsClientConfig(
   context: Context,
   optionHeaders?: Record<string, string>,
 ): {
-  baseURL: string;
+  baseURL: string | undefined;
   defaultHeaders: Record<string, string>;
   defaultQuery?: Record<string, string>;
 } {
@@ -165,7 +166,7 @@ function buildOpenAICompletionsClientConfig(
   }
 
   return {
-    baseURL,
+    baseURL: resolveOpenAIClientBaseUrl(model, baseURL),
     defaultHeaders: headers,
     defaultQuery: Object.keys(defaultQuery).length > 0 ? defaultQuery : undefined,
   };

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -70,7 +70,11 @@ import {
   isOpenAICodexResponsesModel,
   resolveCodeModeResponsesVisibleToolNames,
 } from "./openai-transport-params.js";
-import { createOpenAIProviderAcceptanceHook, log } from "./openai-transport-shared.js";
+import {
+  createOpenAIProviderAcceptanceHook,
+  log,
+  resolveOpenAIClientBaseUrl,
+} from "./openai-transport-shared.js";
 import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitizer.js";
 import {
   createWritableTransportEventStream,
@@ -157,7 +161,7 @@ export function createOpenAIResponsesClient(
 ) {
   return new OpenAI({
     apiKey,
-    baseURL: model.baseUrl,
+    baseURL: resolveOpenAIClientBaseUrl(model),
     dangerouslyAllowBrowser: true,
     defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders, sessionId),
     fetch: buildGuardedModelFetch(model),

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -37,6 +37,23 @@ export const log = {
 
 export type { OpenAICompletionsOptions } from "../provider-options.js";
 
+export function resolveOpenAIClientBaseUrl(
+  model: Pick<Model, "provider" | "baseUrl">,
+  baseUrl: string | undefined = model.baseUrl,
+): string | undefined {
+  if (baseUrl?.trim()) {
+    return baseUrl;
+  }
+  if (model.provider.trim().toLowerCase() === "openai") {
+    return undefined;
+  }
+  // The OpenAI SDK defaults a missing endpoint to api.openai.com. Only OpenAI may
+  // inherit that default; otherwise a third-party bearer token can cross providers.
+  throw new Error(
+    `Provider "${model.provider}" requires an explicit base URL before using an OpenAI-compatible API. Reload provider metadata or configure an endpoint.`,
+  );
+}
+
 export type OpenAICompletionsTextSource = "reasoning_detail" | "refusal";
 
 export type OpenAICompletionsContentDelta =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an OpenAI-compatible provider with incomplete endpoint metadata could inherit the OpenAI SDK's default endpoint instead of failing closed.

## Why This Change Was Made

OpenAI remains allowed to use its SDK default. Every other provider must now supply an explicit base URL before an OpenAI Responses or Completions client is constructed.

The check lives at the shared OpenAI-compatible transport boundary and covers both package and managed Responses/Completions clients. This avoids a provider-specific exception and keeps Azure on its existing dedicated client path.

Alternatives considered:

- Guard only the configured-model fallback: too narrow, because any malformed runtime model could still reach the SDK constructors.
- Guard only the fetch wrapper: too late in the lifecycle and incomplete for package consumers that provide their own host fetch implementation.

## User Impact

OpenAI-compatible providers with valid configured endpoints continue to work normally. If provider metadata is incomplete, the request now stops with an actionable configuration error before an SDK client or request is created.

Production LOC: +36/-6 (net +30) | Tests: +58/-1

The production growth establishes one explicit endpoint invariant across four existing client constructors.

## Evidence

### Real behavior proof

Claim: a non-OpenAI provider without an endpoint is rejected before SDK client construction, while the same provider with an explicit endpoint sends only to that configured origin.

Exercised surface: the production `createOpenAIResponsesClient` boundary using the real installed OpenAI SDK and a local HTTP server. The probe used a sentinel credential; no live provider or real credential was involved.

Environment: local Node runtime, exact commit `b48a1d3003456412bdd9a4da6aa11b80c7b9688f`.

Command: `node --import tsx --input-type=module` with an inline production-boundary probe.

Observed terminal output:

```json
{
  "head": "b48a1d3003456412bdd9a4da6aa11b80c7b9688f",
  "missingEndpoint": "blocked before SDK client construction",
  "configuredEndpoint": "request reached only the configured loopback origin",
  "requestPath": "/v1/responses",
  "credential": "sentinel bearer observed only at configured loopback origin"
}
```

Limits: this proves real SDK construction and HTTP destination binding without contacting an external provider. Model-resolution fallback reachability is covered by source tracing and the regression tests below.

### Regression and sibling coverage

- Pre-fix Responses regression constructed the SDK client without an endpoint; it now fails before construction.
- Pre-fix Completions parity surfaced an accidental undefined-base-URL error; both package and managed clients now return the same actionable failure.
- Explicit OpenRouter endpoints remain accepted across Responses and Completions.
- Focused verification: 84 tests passed across four files.
- Full changed-file gate passed, including formatting, lint, core and test typechecks, dependency and package-boundary guards, dead-export scans, database guards, and import-cycle checks.
- `git diff --check` passed.
- Local structured review reported no actionable findings.

