### PR TITLE
refactor(claws): share rollback failure collection

### DIFF
--- a/src/claws/update-apply.test.ts
+++ b/src/claws/update-apply.test.ts
@@ -778,7 +778,7 @@ describe("applyClawUpdatePlan", () => {
     expect(applyPackage).toHaveBeenCalledOnce();
   });
 
-  it("rolls workspace and MCP changes back when root provenance cannot advance", async () => {
+  it("runs every rollback sequentially when root provenance cannot advance", async () => {
     const updatePlan = plan([
       {
         kind: "workspaceFile",
@@ -789,8 +789,23 @@ describe("applyClawUpdatePlan", () => {
         reason: "target changed",
       },
     ]);
-    const workspaceRollback = vi.fn(async () => undefined);
-    const mcpRollback = vi.fn(async () => undefined);
+    const rollbackOrder: string[] = [];
+    let activeRollback: string | undefined;
+    const failingRollback = (label: string, message: string) =>
+      vi.fn(async () => {
+        if (activeRollback) {
+          throw new Error(`rollback overlap: ${activeRollback} -> ${label}`);
+        }
+        activeRollback = label;
+        rollbackOrder.push(`${label}:start`);
+        await Promise.resolve();
+        rollbackOrder.push(`${label}:end`);
+        activeRollback = undefined;
+        throw new Error(message);
+      });
+    const cronRollback = failingRollback("cron", "cron failed");
+    const mcpRollback = failingRollback("MCP", "MCP failed");
+    const workspaceRollback = failingRollback("workspace", "workspace failed");
 
     await expect(
       applyClawUpdatePlan(
@@ -807,12 +822,26 @@ describe("applyClawUpdatePlan", () => {
             rollback: workspaceRollback,
           })),
           applyMcp: vi.fn(async () => ({ appliedNames: [], rollback: mcpRollback })),
+          applyCron: vi.fn(async () => ({ appliedIds: [], rollback: cronRollback })),
           persistInstall: vi.fn(() => {
             throw new Error("provenance race");
           }),
         },
       ),
-    ).rejects.toMatchObject({ code: "provenance_update_failed" });
+    ).rejects.toMatchObject({
+      code: "update_partial",
+      message:
+        "provenance race; cron rollback failed: cron failed; MCP rollback failed: MCP failed; workspace rollback failed: workspace failed",
+    });
+    expect(rollbackOrder).toEqual([
+      "cron:start",
+      "cron:end",
+      "MCP:start",
+      "MCP:end",
+      "workspace:start",
+      "workspace:end",
+    ]);
+    expect(cronRollback).toHaveBeenCalledOnce();
     expect(mcpRollback).toHaveBeenCalledOnce();
     expect(workspaceRollback).toHaveBeenCalledOnce();
   });

--- a/src/claws/update-apply.ts
+++ b/src/claws/update-apply.ts
@@ -47,6 +47,23 @@ export const CLAW_UPDATE_RESULT_SCHEMA_VERSION = "openclaw.clawUpdateResult.v1" 
 
 type ConfigCommit = (transform: (config: OpenClawConfig) => OpenClawConfig) => Promise<void>;
 
+type RollbackAttempt = {
+  readonly failurePrefix: string;
+  readonly rollback: () => Promise<void>;
+};
+
+async function collectRollbackFailures(attempts: readonly RollbackAttempt[]): Promise<string[]> {
+  const failures: string[] = [];
+  for (const { failurePrefix, rollback } of attempts) {
+    try {
+      await rollback();
+    } catch (error) {
+      failures.push(`${failurePrefix}: ${coerceErrorMessage(error)}`);
+    }
+  }
+  return failures;
+}
+
 function digest(value: unknown): string {
   return `sha256:${createHash("sha256").update(stableStringify(value)).digest("hex")}`;
 }
@@ -374,17 +391,10 @@ export async function applyClawUpdatePlan(
   try {
     packageExecution = await applyPackageActions(remainingPackageActions);
   } catch (error) {
-    const rollbackFailures: string[] = [];
-    try {
-      await mcpExecution.rollback();
-    } catch (rollbackError) {
-      rollbackFailures.push(`MCP rollback failed: ${coerceErrorMessage(rollbackError)}`);
-    }
-    try {
-      await workspaceExecution.rollback();
-    } catch (rollbackError) {
-      rollbackFailures.push(`workspace rollback failed: ${coerceErrorMessage(rollbackError)}`);
-    }
+    const rollbackFailures = await collectRollbackFailures([
+      { failurePrefix: "MCP rollback failed", rollback: mcpExecution.rollback },
+      { failurePrefix: "workspace rollback failed", rollback: workspaceExecution.rollback },
+    ]);
     if (error instanceof ClawPackageUpdateError && error.partial) {
       rollbackFailures.unshift("package artifact rollback is unavailable");
     }
@@ -461,27 +471,12 @@ export async function applyClawUpdatePlan(
         return { ...config, agents: { ...config.agents, entries: nextEntries } };
       });
     } catch (error) {
-      const rollbackFailures: string[] = [];
-      try {
-        await rollbackAgent();
-      } catch (rollbackError) {
-        rollbackFailures.push(`agent rollback failed: ${coerceErrorMessage(rollbackError)}`);
-      }
-      try {
-        await packageExecution.rollback();
-      } catch (rollbackError) {
-        rollbackFailures.push(`package rollback incomplete: ${coerceErrorMessage(rollbackError)}`);
-      }
-      try {
-        await mcpExecution.rollback();
-      } catch (rollbackError) {
-        rollbackFailures.push(`MCP rollback failed: ${coerceErrorMessage(rollbackError)}`);
-      }
-      try {
-        await workspaceExecution.rollback();
-      } catch (rollbackError) {
-        rollbackFailures.push(`workspace rollback failed: ${coerceErrorMessage(rollbackError)}`);
-      }
+      const rollbackFailures = await collectRollbackFailures([
+        { failurePrefix: "agent rollback failed", rollback: rollbackAgent },
+        { failurePrefix: "package rollback incomplete", rollback: packageExecution.rollback },
+        { failurePrefix: "MCP rollback failed", rollback: mcpExecution.rollback },
+        { failurePrefix: "workspace rollback failed", rollback: workspaceExecution.rollback },
+      ]);
       if (rollbackFailures.length > 0) {
         throw partialMutation(`${coerceErrorMessage(error)}; ${rollbackFailures.join("; ")}`);
       }
@@ -517,27 +512,12 @@ export async function applyClawUpdatePlan(
       }
       throw partialMutation(`${error.message}; cron gateway mutation outcome is uncertain`);
     }
-    const rollbackFailures: string[] = [];
-    try {
-      await rollbackAgent();
-    } catch (rollbackError) {
-      rollbackFailures.push(`agent rollback failed: ${coerceErrorMessage(rollbackError)}`);
-    }
-    try {
-      await packageExecution.rollback();
-    } catch (rollbackError) {
-      rollbackFailures.push(`package rollback incomplete: ${coerceErrorMessage(rollbackError)}`);
-    }
-    try {
-      await mcpExecution.rollback();
-    } catch (rollbackError) {
-      rollbackFailures.push(`MCP rollback failed: ${coerceErrorMessage(rollbackError)}`);
-    }
-    try {
-      await workspaceExecution.rollback();
-    } catch (rollbackError) {
-      rollbackFailures.push(`workspace rollback failed: ${coerceErrorMessage(rollbackError)}`);
-    }
+    const rollbackFailures = await collectRollbackFailures([
+      { failurePrefix: "agent rollback failed", rollback: rollbackAgent },
+      { failurePrefix: "package rollback incomplete", rollback: packageExecution.rollback },
+      { failurePrefix: "MCP rollback failed", rollback: mcpExecution.rollback },
+      { failurePrefix: "workspace rollback failed", rollback: workspaceExecution.rollback },
+    ]);
     if (rollbackFailures.length > 0) {
       throw partialMutation(`${coerceErrorMessage(error)}; ${rollbackFailures.join("; ")}`);
     }
@@ -556,32 +536,13 @@ export async function applyClawUpdatePlan(
       expectedClaw: fresh.currentClaw,
     });
   } catch (error) {
-    const rollbackFailures: string[] = [];
-    try {
-      await rollbackAgent();
-    } catch (rollbackError) {
-      rollbackFailures.push(`agent rollback failed: ${coerceErrorMessage(rollbackError)}`);
-    }
-    try {
-      await packageExecution.rollback();
-    } catch (rollbackError) {
-      rollbackFailures.push(`package rollback incomplete: ${coerceErrorMessage(rollbackError)}`);
-    }
-    try {
-      await cronExecution.rollback();
-    } catch (rollbackError) {
-      rollbackFailures.push(`cron rollback failed: ${coerceErrorMessage(rollbackError)}`);
-    }
-    try {
-      await mcpExecution.rollback();
-    } catch (rollbackError) {
-      rollbackFailures.push(`MCP rollback failed: ${coerceErrorMessage(rollbackError)}`);
-    }
-    try {
-      await workspaceExecution.rollback();
-    } catch (rollbackError) {
-      rollbackFailures.push(`workspace rollback failed: ${coerceErrorMessage(rollbackError)}`);
-    }
+    const rollbackFailures = await collectRollbackFailures([
+      { failurePrefix: "agent rollback failed", rollback: rollbackAgent },
+      { failurePrefix: "package rollback incomplete", rollback: packageExecution.rollback },
+      { failurePrefix: "cron rollback failed", rollback: cronExecution.rollback },
+      { failurePrefix: "MCP rollback failed", rollback: mcpExecution.rollback },
+      { failurePrefix: "workspace rollback failed", rollback: workspaceExecution.rollback },
+    ]);
     if (rollbackFailures.length > 0) {
       throw partialMutation(`${coerceErrorMessage(error)}; ${rollbackFailures.join("; ")}`);
     }


### PR DESCRIPTION
## What Problem This Solves

Claw update failures repeated four sequential rollback collectors. Keeping those compensation loops separate made rollback ordering, failure continuation, and operator-visible error labels easier to drift.

## Why This Change Was Made

Use one private sequential rollback-failure collector. Each failure branch still declares its exact rollback order and retains ownership of original-error composition and partial-mutation policy.

## User Impact

No intended update behavior change. Every available rollback still runs once in order, later rollbacks still run after earlier failures, and partial update errors retain their existing labels and message ordering.

## Evidence

- Strengthened the existing provenance-failure regression to prove sequential execution, continuation after multiple failures, exact aggregate ordering, and `update_partial`.
- 44 focused Claw update tests passed across six owner and rollback suites.
- Full `node scripts/check-changed.mjs` passed.
- `git diff --check` passed.
- Fresh branch autoreview reported no accepted/actionable findings (`0.98` confidence).
- Production delta: `+40/-79`, net `-39`; tests: `+33/-4`, net `+29`.
