### PR TITLE
fix(ui): make archived chat sessions visibly inert

### DIFF
--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -440,7 +440,34 @@ suite.define(() => {
     const archivedBy = { type: "human" as const, id: "profile-mira", label: "Mira" };
     const batchRows = [sessionRows[0]!, sessionRows[1]!, sessionRows[3]!];
     const gateway = await installMockGateway(page, {
+      featureMethods: [
+        "chat.metadata",
+        "chat.startup",
+        "progressCard.get",
+        "sessions.patch",
+        "sessions.patchMany",
+      ],
+      historyMessages: [
+        {
+          id: "archived-reply",
+          role: "assistant",
+          timestamp: baseTime - 2_000,
+          content: "Reply retained in the transcript.",
+          openclawDelivery: { replyToCurrent: true },
+        },
+      ],
       methodResponses: {
+        "progressCard.get": {
+          card: {
+            revision: 1,
+            sessionKey: selected.key,
+            steps: [
+              { step: "Inspect archive", status: "completed" },
+              { step: "Finish archive", status: "in_progress" },
+            ],
+            updatedAt: baseTime,
+          },
+        },
         "sessions.list": sessionsListResponse([
           sessionRow("agent:main:main", "Main", baseTime),
           ...sessionRows,
@@ -478,6 +505,12 @@ suite.define(() => {
       await rowFor(selected.key).locator("a").first().click();
       await assertSelectedRoute();
       await activePane.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
+      const replyPreview = activePane.locator(".chat-reply-preview", {
+        hasText: "Replying to current message",
+      });
+      const progressCard = activePane.locator('[data-progress-card-placement="composer"]');
+      await replyPreview.waitFor({ state: "visible" });
+      await progressCard.waitFor({ state: "visible" });
       await page.evaluate((sessionKey) => {
         const titleHistory: string[] = [];
         const paneTitleHistory: string[] = [];
@@ -653,6 +686,8 @@ suite.define(() => {
       await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
       await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
       await expect.poll(() => activePane.locator(".agent-chat__input").count()).toBe(0);
+      await expect.poll(() => replyPreview.locator(".session-run-spinner").count()).toBe(0);
+      await expect.poll(() => progressCard.count()).toBe(0);
       const archiveEvent = activePane.locator(".chat-notice", { hasText: "Archived by Mira" });
       await archiveEvent.waitFor({ state: "visible", timeout: 10_000 });
       await captureUiProof(page, "archive-attribution-notice-after.png");
@@ -681,6 +716,7 @@ suite.define(() => {
       await archiveEvent.waitFor({ state: "detached", timeout: 10_000 });
       await selectedRow.waitFor({ state: "visible", timeout: 10_000 });
       await activePane.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
+      await progressCard.waitFor({ state: "visible" });
       await expect
         .poll(() =>
           activePane.evaluate(

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -37,6 +37,7 @@ import type { BoardFace, BoardVisibleChatDock } from "../../lib/board/settings.t
 import type { BoardTab } from "../../lib/board/types.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { parseCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
+import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import type { SwarmRosterHydrator } from "../../lib/sessions/swarm-roster.ts";
 import { SessionUnreadPatchGuard } from "../../lib/sessions/unread.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -198,7 +199,8 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   protected readonly taskSidebarTranscript = new ChatTranscriptController(this);
   protected readonly progressCard = new SessionProgressCardController(this, {
     gateway: () => this.context?.gateway,
-    sessionKey: () => this.state?.sessionKey,
+    sessionKey: () =>
+      this.state && !this.isCurrentSessionArchived(this.state) ? this.state.sessionKey : undefined,
   });
   private boardFullscreenController: FullscreenController | null = null;
   protected get boardFullscreen(): FullscreenController {
@@ -222,6 +224,15 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   });
   protected questionPrompts: QuestionPrompt[] = [];
   protected state: ChatPageHost | undefined;
+
+  protected isCurrentSessionArchived(state: ChatPageHost): boolean {
+    return (
+      state.selectedChatSessionArchived ||
+      state.sessionsResult?.sessions.some(
+        (row) => row.archived === true && areUiSessionKeysEquivalent(row.key, state.sessionKey),
+      ) === true
+    );
+  }
   /* Infinity until the first ResizeObserver tick so an unmeasured pane keeps
    * the wide side-by-side layout instead of flashing the stacked one. */
   @litState() protected paneWidth = Number.POSITIVE_INFINITY;

--- a/ui/src/pages/chat/chat-pane-sharing.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.ts
@@ -29,7 +29,6 @@ import {
   type ChatPaneConnectionScope,
 } from "./chat-pane-shared.ts";
 import { resetSessionCompanion } from "./chat-session-companion.ts";
-import type { ChatPageHost } from "./chat-state-host.ts";
 import { resolveChatAgentId } from "./chat-state-route.ts";
 import { clearTypingActorForSessionMessage } from "./chat-typing-presence.ts";
 import {
@@ -333,15 +332,6 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
 
   protected hasMultipleIdentities(): boolean {
     return hasMultiplePresenceIdentities(this.presencePayload);
-  }
-
-  protected isCurrentSessionArchived(state: ChatPageHost): boolean {
-    return (
-      state.selectedChatSessionArchived ||
-      state.sessionsResult?.sessions.some(
-        (row) => row.archived === true && areUiSessionKeysEquivalent(row.key, state.sessionKey),
-      ) === true
-    );
   }
 
   protected resetSessionSuggestions(): void {

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -451,10 +451,8 @@ export function renderGroupedMessage(
             : undefined,
           opts.onOpenReply,
           opts.onResolveReply,
-          opts.replyNavigationId ===
-            (normalizedMessage.replyTarget?.kind === "id"
-              ? normalizedMessage.replyTarget.id
-              : null),
+          normalizedMessage.replyTarget?.kind === "id" &&
+            opts.replyNavigationId === normalizedMessage.replyTarget.id,
         )}
         ${renderInlineToolCards(toolCards, {
           messageKey,
@@ -498,8 +496,8 @@ export function renderGroupedMessage(
           : undefined,
         opts.onOpenReply,
         opts.onResolveReply,
-        opts.replyNavigationId ===
-          (normalizedMessage.replyTarget?.kind === "id" ? normalizedMessage.replyTarget.id : null),
+        normalizedMessage.replyTarget?.kind === "id" &&
+          opts.replyNavigationId === normalizedMessage.replyTarget.id,
       )}
       ${isStandaloneToolMessage
         ? html`

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -3393,6 +3393,7 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector(".chat-reply-preview__label")?.textContent?.trim()).toBe(
       "Replying to current message",
     );
+    expect(container.querySelector(".chat-reply-preview .session-run-spinner")).toBeNull();
     expect(container.querySelector(".chat-text")?.textContent?.trim()).toBe("Here is the image.");
     expect(expectElement(container, ".chat-message-image", HTMLImageElement).src).toBe(
       "https://example.com/photo.png",


### PR DESCRIPTION
Closes #130442

## What Problem This Solves

Fixes an issue where users archiving a Control UI session would still see a live reply spinner and unfinished Task progress even after the Gateway had cancelled and drained the session's run.

## Why This Change Was Made

The Gateway already makes archive terminal: it fences admission, cancels authoritative work, waits for the lifecycle to drain, and only then records `archivedAt`. The Control UI now consumes that same archive fact at the progress-card observation boundary, so archived panes become inert without deleting the durable card; unarchive observes it again. Persisted reply attribution remains readable, but only a real reply-ID navigation can show its loading spinner.

Production code remains net neutral at `+16/-16`; tests add `+37/-1`.

## User Impact

Archived sessions now read as parked: their transcript and archive attribution remain visible, but no reply spinner or Task progress suggests ongoing work. Unarchiving restores the composer and durable progress card without resuming the cancelled run.

## Evidence

### Before

The archived route retained a spinning "Replying to current message" indicator and unfinished Task progress despite `hasActiveRun: false`.

![Archived session before fix](https://github.com/user-attachments/assets/6d636f9e-9a58-4f3f-b37f-3c8e934dc310)

### After

The same deterministic browser flow retains historical reply context with a static icon, removes Task progress while archived, and shows only the archive notice. Unarchive restores the composer and progress card.

![Archived session after fix](https://github.com/user-attachments/assets/157d514d-560f-4578-bbbd-adc31bca5472)

Full archive/unarchive browser flow:

https://github.com/user-attachments/assets/79deb6ab-53c5-4496-980c-058fd38153be

Validation:

- Pre-fix regression failed because the reply spinner count remained `1` after archive.
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts ui/src/components/session-progress-card.test.ts ui/src/pages/chat/chat-pane-sharing.test.ts` (259 tests passed)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.archive.e2e.test.ts` (11 tests passed)
- `node scripts/check-changed.mjs -- <changed files>`
- `pnpm ui:build`
- Autoreview: clean, no accepted/actionable findings

AI-assisted implementation; the behavior, lifecycle owner, tests, screenshots, and recording were reviewed directly.
