### PR TITLE
fix(ollama): keep local setup local and skip embedding chat defaults

### DIFF
--- a/extensions/ollama/src/node-inference.test.ts
+++ b/extensions/ollama/src/node-inference.test.ts
@@ -47,6 +47,12 @@ async function withOllamaServer<T>(
               details: {},
             },
             {
+              name: "remote-model-only:latest",
+              size: 1,
+              remote_model: "upstream-chat",
+              details: {},
+            },
+            {
               name: "tagged-only:cloud",
               size: 1,
               details: {},
@@ -259,26 +265,19 @@ describe("Ollama node host inference", () => {
 
   it("rejects remote and non-chat models before inference", async () => {
     await withOllamaServer(async (baseUrl, chatRequests) => {
-      await expect(
-        commandByName(baseUrl, OLLAMA_CHAT_COMMAND).handle(
-          JSON.stringify({ model: "remote:cloud", prompt: "hello" }),
-        ),
-      ).rejects.toThrow("is not a local chat model");
-      await expect(
-        commandByName(baseUrl, OLLAMA_CHAT_COMMAND).handle(
-          JSON.stringify({ model: "tagged-only:cloud", prompt: "hello" }),
-        ),
-      ).rejects.toThrow("is not a local chat model");
-      await expect(
-        commandByName(baseUrl, OLLAMA_CHAT_COMMAND).handle(
-          JSON.stringify({ model: "tagged-only:120b-cloud", prompt: "hello" }),
-        ),
-      ).rejects.toThrow("is not a local chat model");
-      await expect(
-        commandByName(baseUrl, OLLAMA_CHAT_COMMAND).handle(
-          JSON.stringify({ model: "embedding:latest", prompt: "hello" }),
-        ),
-      ).rejects.toThrow("is not a local chat model");
+      for (const model of [
+        "remote:cloud",
+        "remote-model-only:latest",
+        "tagged-only:cloud",
+        "tagged-only:120b-cloud",
+        "embedding:latest",
+      ]) {
+        await expect(
+          commandByName(baseUrl, OLLAMA_CHAT_COMMAND).handle(
+            JSON.stringify({ model, prompt: "hello" }),
+          ),
+        ).rejects.toThrow("is not a local chat model");
+      }
       expect(chatRequests).toHaveLength(0);
     });
   });

--- a/extensions/ollama/src/node-inference.ts
+++ b/extensions/ollama/src/node-inference.ts
@@ -41,7 +41,7 @@ import {
   enrichOllamaModelsWithContext,
   fetchLoadedOllamaModelNames,
   fetchOllamaModels,
-  isOllamaCloudModel,
+  isOllamaRemoteModel,
   resolveOllamaApiBase,
   throwIfOllamaRequestAborted,
 } from "./provider-models.js";
@@ -159,9 +159,7 @@ async function discoverOllamaNodeModels(
   if (!discovered.reachable) {
     throw new Error(`Ollama is not running at ${apiBase}`);
   }
-  const localModels = discovered.models.filter(
-    (model) => !model.remote_host?.trim() && !isOllamaCloudModel(model.name),
-  );
+  const localModels = discovered.models.filter((model) => !isOllamaRemoteModel(model));
   const loaded = await fetchLoadedOllamaModelNames(apiBase, signal ? { signal } : undefined);
   // Model discovery still works against Ollama versions without /api/ps.
   const loadedNames = new Set(loaded.models);
@@ -240,8 +238,7 @@ async function runOllamaNodeChat(params: {
     ...(params.signal ? { signal: params.signal } : {}),
   });
   const localModel = discovered.models.find(
-    (model) =>
-      model.name === params.model && !model.remote_host?.trim() && !isOllamaCloudModel(model.name),
+    (model) => model.name === params.model && !isOllamaRemoteModel(model),
   );
   const [model] = localModel
     ? await enrichOllamaModelsWithContext(apiBase, [localModel], {

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -102,7 +102,8 @@ export const mergeOllamaModelShowInfo = (
   const incomplete =
     info.capabilities === undefined &&
     model.capabilities !== undefined &&
-    Boolean(model.remote_host || model.remote_model || isOllamaCloudModel(model.name));
+    isOllamaRemoteModel(model) &&
+    !isOllamaEmbeddingOnlyModel(model);
   return {
     ...model,
     ...info,
@@ -351,10 +352,10 @@ export async function enrichOllamaCompletionModels(
     for (const model of batch) {
       const canComplete = model.capabilities?.includes("completion");
       if (
-        !canComplete &&
-        (opts?.requireCompletionCapability ||
-          model.capabilities?.includes("embedding") ||
-          (model.capabilities && !model.capabilitiesFromList))
+        isOllamaEmbeddingOnlyModel(model) ||
+        (!canComplete &&
+          (opts?.requireCompletionCapability ||
+            (model.capabilities && !model.capabilitiesFromList)))
       ) {
         continue;
       }
@@ -369,6 +370,21 @@ export async function enrichOllamaCompletionModels(
 
 export function isOllamaCloudModel(modelName: string | undefined): boolean {
   return isCloudModelRef(modelName);
+}
+
+export function isOllamaEmbeddingOnlyModel(model: OllamaTagModel): boolean {
+  // Advertised tools do not turn an embedding-only row into a chat model.
+  return (
+    model.capabilities?.includes("embedding") === true && !model.capabilities.includes("completion")
+  );
+}
+
+export function isOllamaRemoteModel(model: OllamaTagModel): boolean {
+  // Remote stubs can identify only the upstream model, without a host or cloud suffix.
+  return (
+    Boolean(model.remote_host?.trim() || model.remote_model?.trim()) ||
+    isOllamaCloudModel(model.name)
+  );
 }
 
 /**

--- a/extensions/ollama/src/setup-model-selection.test.ts
+++ b/extensions/ollama/src/setup-model-selection.test.ts
@@ -1,5 +1,6 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-auth";
 import type { WizardPrompter } from "openclaw/plugin-sdk/setup";
-import { requestUrl } from "openclaw/plugin-sdk/test-env";
+import { requestBodyText, requestUrl } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildOllamaModelsConfig,
@@ -9,7 +10,7 @@ import {
   normalizeOllamaModelName,
   selectAppGuidedOllamaModelFromDiscovery,
 } from "./setup-model-selection.js";
-import { promptAndConfigureOllama } from "./setup.js";
+import { configureOllamaNonInteractive, promptAndConfigureOllama } from "./setup.js";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -226,7 +227,7 @@ describe("Ollama onboarding model selection", () => {
       ),
     );
     const prompter = {
-      select: vi.fn().mockResolvedValueOnce("local-only"),
+      select: vi.fn().mockResolvedValueOnce("cloud-local"),
       text: vi.fn().mockResolvedValueOnce("http://127.0.0.1:11434"),
       note: vi.fn(async () => undefined),
       confirm: vi.fn().mockResolvedValue(false),
@@ -242,6 +243,134 @@ describe("Ollama onboarding model selection", () => {
         reasoning: true,
         compat: expect.objectContaining({ supportsTools: true }),
       }),
+    );
+  });
+
+  it.each([
+    ["local-only", "completion"],
+    ["cloud-local", "completion"],
+    ["cloud-local", "embedding"],
+  ] as const)(
+    "respects %s mode with %s remote rows before inspecting and configuring mixed inventory",
+    async (mode, remoteCapability) => {
+      const remoteModels = Array.from({ length: 201 }, (_, index) => ({
+        name: index % 3 === 2 ? `remote-${index}:cloud` : `remote-${index}:latest`,
+        ...(index % 3 === 0 ? { remote_host: "https://ollama.com" } : {}),
+        ...(index % 3 === 1 ? { remote_model: `upstream-${index}` } : {}),
+        size: 1,
+      }));
+      const inspected: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+          if (requestUrl(input).endsWith("/api/tags")) {
+            return Response.json({
+              models: [...remoteModels, { name: "local-chat:latest", size: 500 }],
+            });
+          }
+          if (requestUrl(input).endsWith("/api/show")) {
+            const { model } = JSON.parse(requestBodyText(init?.body));
+            inspected.push(model);
+            return Response.json({
+              capabilities: [
+                model.startsWith("remote-") ? remoteCapability : "completion",
+                "tools",
+              ],
+              model_info: { "test.context_length": 32_768 },
+            });
+          }
+          return Response.json({});
+        }),
+      );
+      const prompter = {
+        select: vi.fn().mockResolvedValueOnce(mode),
+        text: vi.fn().mockResolvedValueOnce("http://127.0.0.1:11434"),
+        note: vi.fn(async () => undefined),
+        confirm: vi.fn().mockResolvedValue(false),
+      } as unknown as WizardPrompter;
+
+      const result = await promptAndConfigureOllama({ cfg: {}, prompter });
+      const configured = result.config.models?.providers?.ollama?.models.map((model) => model.id);
+
+      if (mode === "local-only") {
+        expect(inspected).toEqual(["local-chat:latest"]);
+        expect(result.defaultModel).toBe("ollama/local-chat:latest");
+        expect(configured).toContain("local-chat:latest");
+        expect(configured?.filter((name) => name.startsWith("remote-"))).toEqual([]);
+      } else {
+        expect(inspected).toContain(remoteModels[0]?.name);
+        expect(configured).toEqual(expect.arrayContaining(remoteModels.map((model) => model.name)));
+        if (remoteCapability === "embedding") {
+          expect(inspected).toContain("local-chat:latest");
+          expect(result.defaultModel).toBe("ollama/local-chat:latest");
+        }
+      }
+    },
+  );
+
+  describe.each(["interactive", "non-interactive"] as const)("%s defaults", (mode) => {
+    it.each([
+      ["embedding-only", ["embedding"], undefined, false, false],
+      ["embedding with advertised tools", ["embedding", "tools"], undefined, false, true],
+      ["completion and embedding", ["completion", "embedding"], undefined, true, true],
+      ["unknown remote capabilities", [], undefined, true, true],
+      ["authoritative empty inspection", ["completion", "tools"], [], false, false],
+    ] as const)(
+      "respects %s capabilities when selecting and configuring a default",
+      async (_description, capabilities, inspectedCapabilities, useRemote, supportsTools) => {
+        const remoteName = "remote-model:latest";
+        const localName = "local-chat:latest";
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+            if (requestUrl(input).endsWith("/api/tags")) {
+              return Response.json({
+                models: [
+                  { name: remoteName, remote_model: "upstream-model", size: 1, capabilities },
+                  { name: localName, size: 500 },
+                ],
+              });
+            }
+            if (requestUrl(input).endsWith("/api/show")) {
+              const { model } = JSON.parse(requestBodyText(init?.body));
+              return Response.json({
+                model_info: { "test.context_length": 32_768 },
+                capabilities:
+                  model === remoteName ? inspectedCapabilities : ["completion", "tools"],
+              });
+            }
+            return Response.json({});
+          }),
+        );
+        const expectedDefault = `ollama/${useRemote ? remoteName : localName}`;
+        let config: OpenClawConfig;
+        if (mode === "interactive") {
+          const result = await promptAndConfigureOllama({
+            cfg: {},
+            prompter: {
+              select: vi.fn().mockResolvedValueOnce("cloud-local"),
+              text: vi.fn().mockResolvedValueOnce("http://127.0.0.1:11434"),
+              note: vi.fn(async () => undefined),
+              confirm: vi.fn().mockResolvedValue(false),
+            } as unknown as WizardPrompter,
+          });
+          expect(result.defaultModel).toBe(expectedDefault);
+          config = result.config;
+        } else {
+          config = await configureOllamaNonInteractive({
+            nextConfig: {},
+            opts: { customBaseUrl: "http://127.0.0.1:11434" },
+            runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+          });
+          expect(config.agents?.defaults?.model).toEqual({ primary: expectedDefault });
+        }
+        expect(config.models?.providers?.ollama?.models).toContainEqual(
+          expect.objectContaining({
+            id: remoteName,
+            compat: expect.objectContaining({ supportsTools }),
+          }),
+        );
+      },
     );
   });
 

--- a/extensions/ollama/src/setup-model-selection.ts
+++ b/extensions/ollama/src/setup-model-selection.ts
@@ -6,6 +6,8 @@ import {
   buildOllamaModelDefinition,
   enrichOllamaModelsWithContext,
   fetchOllamaModels,
+  isOllamaEmbeddingOnlyModel,
+  isOllamaRemoteModel,
   isReasoningModelHeuristic,
   mergeOllamaModelShowInfo,
   readOllamaModelShowInfo,
@@ -105,6 +107,10 @@ function selectAppGuidedOllamaModelId(
   return orderPreferredOllamaModelIds(fastest.map((model) => model.id))[0];
 }
 
+function isOllamaToolsCapableModel(model: OllamaModelWithContext): boolean {
+  return !isOllamaEmbeddingOnlyModel(model) && model.capabilities?.includes("tools") === true;
+}
+
 export function selectAppGuidedOllamaModelFromDiscovery(
   models: Iterable<OllamaModelWithContext>,
 ): string | undefined {
@@ -112,7 +118,7 @@ export function selectAppGuidedOllamaModelFromDiscovery(
     [...models].map((model) => ({
       id: model.name,
       contextWindow: model.contextWindow,
-      supportsTools: model.capabilities?.includes("tools") === true,
+      supportsTools: isOllamaToolsCapableModel(model),
       reasoning: model.capabilities?.includes("thinking") ?? isReasoningModelHeuristic(model.name),
       size: model.size,
     })),
@@ -184,12 +190,18 @@ export async function inspectOllamaModelsForSetup(
 
 export async function discoverOllamaModelsForSetup(params: {
   baseUrl: string;
+  includeRemoteModels?: boolean;
   inspectTools?: boolean;
   signal?: AbortSignal;
 }) {
-  const { reachable, models } = await fetchOllamaModels(params.baseUrl, {
+  const { reachable, models: listedModels } = await fetchOllamaModels(params.baseUrl, {
     signal: params.signal,
   });
+  // Filter before probe caps so remote stubs cannot crowd out Local only models.
+  const models =
+    params.includeRemoteModels === false
+      ? listedModels.filter((model) => !isOllamaRemoteModel(model))
+      : listedModels;
   const firstModels = models.slice(0, OLLAMA_CONTEXT_ENRICH_LIMIT);
   const inspection: { inspected: OllamaModelWithContext[]; inspectionFailures: string[] } =
     !reachable
@@ -204,7 +216,7 @@ export async function discoverOllamaModelsForSetup(params: {
           };
   if (
     params.inspectTools &&
-    !inspection.inspected.some((model) => model.capabilities?.includes("tools")) &&
+    !inspection.inspected.some(isOllamaToolsCapableModel) &&
     models.length > OLLAMA_CONTEXT_ENRICH_LIMIT
   ) {
     const remainingScan = await inspectOllamaModelsForSetup(
@@ -221,8 +233,6 @@ export async function discoverOllamaModelsForSetup(params: {
     inspectedModels: inspection.inspected,
     discoveredModelsByName: new Map(inspection.inspected.map((model) => [model.name, model])),
     inspectionFailures: inspection.inspectionFailures,
-    hasToolsCapableModel: inspection.inspected.some((model) =>
-      model.capabilities?.includes("tools"),
-    ),
+    hasToolsCapableModel: inspection.inspected.some(isOllamaToolsCapableModel),
   };
 }

--- a/extensions/ollama/src/setup.non-interactive-auth.test.ts
+++ b/extensions/ollama/src/setup.non-interactive-auth.test.ts
@@ -110,13 +110,64 @@ describe("Ollama non-interactive onboarding", () => {
     expect(runtime.error).toHaveBeenCalledWith(error);
     expect(runtime.error).toHaveBeenCalledWith(
       [
-        "No Ollama models are available at http://127.0.0.1:11434.",
-        "Pull a model first, then re-run setup.",
+        "No Ollama chat models are available at http://127.0.0.1:11434.",
+        "Pull a chat model first, then re-run setup.",
       ].join("\n"),
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(upsertAuthProfileWithLock).not.toHaveBeenCalled();
     expect(result).toBe(nextConfig);
+  });
+
+  it.each([
+    { description: "an installed chat model", embeddings: 0, chat: true },
+    { description: "only an embedding model", embeddings: 1, chat: false },
+    { description: "embedding models before chat", embeddings: 201, chat: true },
+  ])("handles $description when a requested download fails", async ({ embeddings, chat }) => {
+    const embeddingNames = Array.from({ length: embeddings }, (_, index) => `embedding-${index}`);
+    const fetchMock = createOllamaFetchMock({
+      tags: [...embeddingNames, ...(chat ? ["qwen2.5-coder:7b"] : [])],
+      capabilities: {
+        ...Object.fromEntries(embeddingNames.map((name) => [name, ["embedding", "tools"]])),
+        "qwen2.5-coder:7b": ["tools"],
+      },
+      pullResponse: new Response('{"error":"disk full"}\n', { status: 200 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const runtime = createRuntime();
+
+    const nextConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.6-luna",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+        },
+      },
+    };
+    const result = await configureOllamaNonInteractive({
+      nextConfig,
+      opts: {
+        customBaseUrl: "http://127.0.0.1:11434",
+        customModelId: "missing-model",
+      },
+      runtime,
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith("Download failed: disk full");
+    if (!chat) {
+      expect(result).toEqual(nextConfig);
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("chat model"));
+      return;
+    }
+    expect(result.agents?.defaults?.model).toEqual({
+      primary: "ollama/qwen2.5-coder:7b",
+      fallbacks: ["anthropic/claude-sonnet-4-6"],
+    });
+    expect(result.models?.providers?.ollama?.apiKey).toBe("ollama-local");
+    expect(upsertAuthProfileWithLock).not.toHaveBeenCalled();
   });
 
   it("persists only installed local models when selecting a discovered custom model", async () => {

--- a/extensions/ollama/src/setup.runtime.ts
+++ b/extensions/ollama/src/setup.runtime.ts
@@ -33,6 +33,7 @@ import {
   enrichOllamaModelsWithContext,
   fetchOllamaModels,
   isOllamaCloudModel,
+  isOllamaEmbeddingOnlyModel,
   queryOllamaModelShowInfo,
   resolveOllamaApiBase,
   type OllamaModelWithContext,
@@ -276,6 +277,7 @@ async function promptAndConfigureHostBackedOllama(params: {
   const baseUrl = await promptForOllamaBaseUrl(params.prompter, params.env);
   let discovery = await discoverOllamaModelsForSetup({
     baseUrl,
+    includeRemoteModels: HOST_BACKED_OLLAMA_MODE_CONFIG[params.mode].includeCloudModels,
     inspectTools: true,
     ...(params.signal ? { signal: params.signal } : {}),
   });
@@ -292,6 +294,7 @@ async function promptAndConfigureHostBackedOllama(params: {
     params.signal?.throwIfAborted();
     discovery = await discoverOllamaModelsForSetup({
       baseUrl,
+      includeRemoteModels: HOST_BACKED_OLLAMA_MODE_CONFIG[params.mode].includeCloudModels,
       inspectTools: true,
       ...(params.signal ? { signal: params.signal } : {}),
     });
@@ -569,37 +572,53 @@ export async function configureOllamaNonInteractive(params: {
     allModelNames = [...allModelNames, requestedDefaultModelId];
   }
 
+  const inspectAvailableModel = async (name: string): Promise<OllamaModelWithContext> => {
+    const model =
+      discoveredModelsByName.get(name) ??
+      expectDefined(
+        (
+          await enrichOllamaModelsWithContext(baseUrl, [
+            models.find((candidate) => candidate.name === name) ?? { name },
+          ])
+        )[0],
+        "selected Ollama setup model",
+      );
+    discoveredModelsByName.set(name, model);
+    return model;
+  };
+
   if (!findAvailableOllamaModelName(defaultModelId, availableModelNames)) {
-    if (availableModelNames.size === 0) {
+    let fallbackModelId: string | undefined;
+    for (const name of allModelNames) {
+      const availableName = findAvailableOllamaModelName(name, availableModelNames);
+      // Fallbacks beyond the initial scan must be inspected before becoming the chat default.
+      if (
+        availableName &&
+        !isOllamaEmbeddingOnlyModel(await inspectAvailableModel(availableName))
+      ) {
+        fallbackModelId = availableName;
+        break;
+      }
+    }
+    if (!fallbackModelId) {
       params.runtime.error(
         [
-          `No Ollama models are available at ${baseUrl}.`,
-          "Pull a model first, then re-run setup.",
+          `No Ollama chat models are available at ${baseUrl}.`,
+          "Pull a chat model first, then re-run setup.",
         ].join("\n"),
       );
       params.runtime.exit(1);
       return params.nextConfig;
     }
 
-    defaultModelId =
-      allModelNames.find((name) => findAvailableOllamaModelName(name, availableModelNames)) ??
-      expectDefined(availableModelNames.values().next().value, "available Ollama setup model");
+    defaultModelId = fallbackModelId;
     params.runtime.log(
       `Ollama model ${requestedDefaultModelId} was not available; using ${defaultModelId} instead.`,
     );
   }
 
-  if (!requestedCloudModel && !discoveredModelsByName.has(defaultModelId)) {
-    // Explicit and newly pulled models can fall outside the bounded catalog scan.
-    const selectedModel = expectDefined(
-      (
-        await enrichOllamaModelsWithContext(baseUrl, [
-          models.find((model) => model.name === defaultModelId) ?? { name: defaultModelId },
-        ])
-      )[0],
-      "selected Ollama setup model",
-    );
-    discoveredModelsByName.set(defaultModelId, selectedModel);
+  if (!requestedCloudModel) {
+    await inspectAvailableModel(defaultModelId);
   }
 
   const config = applyOllamaProviderConfig(

--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -950,41 +950,6 @@ describe("ollama setup", () => {
     });
   });
 
-  it("uses discovered model when requested non-interactive download fails", async () => {
-    const fetchMock = createOllamaFetchMock({
-      tags: ["qwen2.5-coder:7b"],
-      pullResponse: new Response('{"error":"disk full"}\n', { status: 200 }),
-    });
-    vi.stubGlobal("fetch", fetchMock);
-    const runtime = createRuntime();
-
-    const result = await configureOllamaNonInteractive({
-      nextConfig: {
-        agents: {
-          defaults: {
-            model: {
-              primary: "openai/gpt-4o-mini",
-              fallbacks: ["anthropic/claude-sonnet-4-5"],
-            },
-          },
-        },
-      },
-      opts: {
-        customBaseUrl: "http://127.0.0.1:11434",
-        customModelId: "missing-model",
-      },
-      runtime,
-    });
-
-    expect(runtime.error).toHaveBeenCalledWith("Download failed: disk full");
-    expect(result.agents?.defaults?.model).toEqual({
-      primary: "ollama/qwen2.5-coder:7b",
-      fallbacks: ["anthropic/claude-sonnet-4-5"],
-    });
-    expect(result.models?.providers?.ollama?.apiKey).toBe("ollama-local");
-    expect(upsertAuthProfileWithLock).not.toHaveBeenCalled();
-  });
-
   it("normalizes ollama/ prefix in non-interactive custom model download", async () => {
     const fetchMock = createOllamaFetchMock({
       tags: [],


### PR DESCRIPTION
Related: #130240

AI-assisted follow-up. Thanks to @Yigtwxx for the original remote-discovery work in #130240; this change builds on that merged fix without replaying it.

## What Problem This Solves

Fixes an issue where Ollama setup could select a cloud model after the operator chose **Local only**, or choose an embedding model as the default chat model. A remote alias identified only by `remote_model` could also appear in the local node-inference inventory.

Embedding rows could gain inferred tool support when their remote inspection omitted capabilities. Separately, an embedding row advertising tools could stop setup from scanning a later chat model, and a failed model download could fall back to the first installed embedding model.

## Why This Change Was Made

Keep remote identity and embedding-only classification in the Ollama plugin's metadata owner. Local node discovery/chat and Local-only setup now share remote classification; setup filters inventory before inspection limits, default selection, and config projection. Capability inference, catalog admission, setup selection, and failed-download fallback share the embedding-only rule while retaining truthful advertised metadata.

The fallback reuses inspected metadata and inspects an unscanned candidate before making it the default. If only embedding models are available, setup reports the failure and preserves the prior config. Existing unknown-capability and plain-chat fallback behavior is retained; no new tool/context requirement, public option, SDK surface, dependency, or schema is introduced.

Production LOC: +76/-34 (net +42). Tests: +204/-60 (net +144). Growth implements the shared identity/eligibility boundary and inspection-before-fallback ownership; duplicate remote predicates, raw-tools decisions, and the unchecked first-available fallback are removed. The failed-download regression table replaces the old standalone fallback test in the existing noninteractive suite.

## User Impact

Local-only operators keep local models throughout discovery, selection, and saved configuration. Embedding models no longer become automatic chat defaults through inferred capabilities or failed-download fallback. Cloud + Local remains inclusive, mixed completion/embedding models remain eligible, and advertised tool metadata is not erased.

## Evidence

Reviewed head: `7519d705926228e4f355e8f700a1b0181bc3b5c2`.

- Captured failing regressions before each production repair: remote-model-only node discovery/chat; Local-only inventory filtering; interactive and noninteractive embedding defaults; scan continuation beyond 200 embedding/tool rows; and failed-pull fallback with embedding-only or embedding-first inventory.
- Final `node scripts/run-vitest.mjs extensions/ollama`: **28 files, 742 tests passed**.
- Eight-file formatting, lint, extension production/test types, and all changed-path guards passed in aggregate. The initial native changed-gate run stopped only at the setup test file's line limit; moving the regression matrix into the existing noninteractive suite fixed that without changing limits or suppressions. The actual failed lint, affected typecheck, and remaining planned guards then passed.
- Fresh structured and separate independent Codex reviews of the complete final diff both returned no actionable P0/P1 findings within their selected review scope.
- Real Ollama 0.32.15, isolated state/model storage, with public qwen3:0.6b, embeddinggemma, and a Mistral cloud manifest: unchanged main chose the cloud model under Local only; the repair chose qwen and excluded the cloud inventory. This before/after result did not use capability injection.
- Real provider/setup/node paths also exercised explicitly labeled HTTP fault injection for incomplete/embedding/mixed/empty capabilities, remote aliases, long inventories, failed inspection, and failed downloads. These are fault-injection proofs, not claims that current official cloud manifests naturally omit capabilities.
- Actual local inference through the OpenClaw node command returned `Pong!` (4 completion tokens). Final built-CLI noninteractive onboarding against the real daemon completed and saved the selected local model in isolated config.
- Independent source-blind validation through the built public CLI passed all six scoped contract clauses: real classic onboarding and local inference; Local-only exclusion with 201 remote rows and remote aliases; explicit Cloud + Local inclusion; embedding/tool inventories and failed-download fallback; visible empty/unavailable/invalid-inventory errors; and separate labeling of real versus injected evidence. Successful cases saved configs that passed public config validation; no-chat cases exited 1 without creating config. The Cloud + Local UI control used explicitly injected dummy identity metadata, not real cloud authentication.

No authenticated cloud completion was performed. Current official cloud manifest metadata was complete. Real model names/digests stayed unchanged throughout independent validation, and the isolated daemon/proxy were stopped afterward. Separate follow-ups remain for signed-out Cloud + Local wording/inventory consistency and remote-alias provenance in local context capping; this PR does not claim to repair those paths. Initial noninteractive discovery can still attempt a suggested download before finding a usable chat model after more than 200 embedding rows; the safe failed-download fallback is tested, but avoiding that unnecessary download remains a source-only follow-up. An initial fixture streaming failure followed by the wizard's Continue anyway left model/provider unset; this is preserved as an unconfirmed generic-wizard follow-up, not an accepted finding against this repair.
