### PR TITLE
refactor(outbound): consolidate transport completion

### DIFF
--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -354,13 +354,15 @@ export async function deliverOutboundPayloadsCore(
         });
       const deliveryTarget = () =>
         deliveryHandler.buildTargetRef({ threadId: preparedTarget.threadId });
+      const beforeCount = results.length;
+      let mirroredPayload = payloadSummary;
+      let mediaMessageIds: { first?: string; last?: string } | undefined;
       if (
         deliveryHandler.sendPayload &&
         payloadRequiresDurablePayloadTransport(effectivePayload, {
           sendTextOnlyErrorPayloads: deliveryHandler.sendTextOnlyErrorPayloads,
         })
       ) {
-        const beforeCount = results.length;
         const delivery = await deliveryHandler.sendPayload(
           effectivePayload,
           withPreparedTarget(applySendReplyToConsumption(sendOverrides)),
@@ -378,35 +380,7 @@ export async function deliverOutboundPayloadsCore(
           );
           continue;
         }
-        recordPayloadOutcome({
-          index: payloadIndex,
-          status: "sent",
-          results: deliveredResults,
-        });
-        recordDeliveredPayload(payloadSummary, deliveredResults);
-        recordMessageSentEvent({
-          success: true,
-          content: payloadSummary.hookContent ?? payloadSummary.text,
-          messageId: deliveredResults.at(-1)?.messageId,
-        });
-        await maybePinDeliveredMessage({
-          handler: deliveryHandler,
-          payload: effectivePayload,
-          target: deliveryTarget(),
-          messageId: deliveredResults.find((entry) => entry.messageId)?.messageId,
-          gatewayClientScopes: params.gatewayClientScopes,
-        });
-        await maybeNotifyAfterDeliveredPayload({
-          handler: deliveryHandler,
-          payload: effectivePayload,
-          target: deliveryTarget(),
-          results: deliveredResults,
-        });
-        completeDeliveryDiagnostics(deliveredResults.length);
-        continue;
-      }
-      if (payloadSummary.mediaUrls.length === 0) {
-        const beforeCount = results.length;
+      } else if (payloadSummary.mediaUrls.length === 0) {
         if (deliveryHandler.sendFormattedText) {
           await recordIdentifiedDeliveryResults(
             await deliveryHandler.sendFormattedText(
@@ -418,47 +392,7 @@ export async function deliverOutboundPayloadsCore(
         } else {
           await sendTextChunks(deliveryHandler, payloadSummary.text, sendOverrides);
         }
-        const deliveredResults = results.slice(beforeCount);
-        if (deliveredResults.length > 0) {
-          recordPayloadOutcome({
-            index: payloadIndex,
-            status: "sent",
-            results: deliveredResults,
-          });
-          recordDeliveredPayload(payloadSummary, deliveredResults);
-        } else {
-          recordPayloadOutcome(
-            suppressedPayloadOutcome({
-              index: payloadIndex,
-              reason: "adapter_returned_no_identity",
-            }),
-          );
-        }
-        const messageId = deliveredResults.at(-1)?.messageId;
-        const pinMessageId = deliveredResults.find((entry) => entry.messageId)?.messageId;
-        recordMessageSentEvent({
-          success: deliveredResults.length > 0,
-          content: payloadSummary.hookContent ?? payloadSummary.text,
-          messageId,
-        });
-        await maybePinDeliveredMessage({
-          handler: deliveryHandler,
-          payload: effectivePayload,
-          target: deliveryTarget(),
-          messageId: pinMessageId,
-          gatewayClientScopes: params.gatewayClientScopes,
-        });
-        await maybeNotifyAfterDeliveredPayload({
-          handler: deliveryHandler,
-          payload: effectivePayload,
-          target: deliveryTarget(),
-          results: deliveredResults,
-        });
-        completeDeliveryDiagnostics(deliveredResults.length);
-        continue;
-      }
-
-      if (!deliveryHandler.supportsMedia) {
+      } else if (!deliveryHandler.supportsMedia) {
         log.warn(
           "Plugin outbound adapter does not implement sendMedia; media URLs will be dropped and text fallback will be used",
           {
@@ -473,84 +407,44 @@ export async function deliverOutboundPayloadsCore(
             "Plugin outbound adapter does not implement sendMedia and no text fallback is available for media payload",
           );
         }
-        const beforeCount = results.length;
         await sendTextChunks(deliveryHandler, fallbackText, sendOverrides);
-        const deliveredResults = results.slice(beforeCount);
-        if (deliveredResults.length > 0) {
-          recordPayloadOutcome({
-            index: payloadIndex,
-            status: "sent",
-            results: deliveredResults,
-          });
-          recordDeliveredPayload(
-            { ...payloadSummary, text: fallbackText, mediaUrls: [] },
-            deliveredResults,
-          );
-        } else {
-          recordPayloadOutcome(
-            suppressedPayloadOutcome({
-              index: payloadIndex,
-              reason: "adapter_returned_no_identity",
-            }),
-          );
+        mirroredPayload = { ...payloadSummary, text: fallbackText, mediaUrls: [] };
+      } else {
+        // Media observers use final adapter identities, not intermediate progress
+        // results that may also remain in the reconciled delivery list.
+        mediaMessageIds = {};
+        const mediaUnits = planOutboundMediaMessageUnits({
+          mediaUrls: payloadSummary.mediaUrls,
+          caption: payloadSummary.text,
+          overrides: sendOverrides,
+          consumeReplyTo: applySendReplyToConsumption,
+        });
+        for (const unit of mediaUnits) {
+          if (unit.kind !== "media") {
+            continue;
+          }
+          throwIfAborted(abortSignal);
+          const resultIndex = results.length;
+          const delivery = deliveryHandler.sendFormattedMedia
+            ? await deliveryHandler.sendFormattedMedia(
+                unit.caption ?? "",
+                unit.mediaUrl,
+                withPreparedTarget(unit.overrides),
+              )
+            : await deliveryHandler.sendMedia(
+                unit.caption ?? "",
+                unit.mediaUrl,
+                withPreparedTarget(unit.overrides),
+              );
+          const recorded = await recordIdentifiedDeliveryResult(delivery);
+          adoptSuccessfulResultsSince(resultIndex);
+          if (recorded) {
+            mediaMessageIds.first ??= delivery.messageId;
+            mediaMessageIds.last = delivery.messageId;
+          }
         }
-        const messageId = deliveredResults.at(-1)?.messageId;
-        const pinMessageId = deliveredResults.find((entry) => entry.messageId)?.messageId;
-        recordMessageSentEvent({
-          success: deliveredResults.length > 0,
-          content: payloadSummary.hookContent ?? payloadSummary.text,
-          messageId,
-        });
-        await maybePinDeliveredMessage({
-          handler: deliveryHandler,
-          payload: effectivePayload,
-          target: deliveryTarget(),
-          messageId: pinMessageId,
-          gatewayClientScopes: params.gatewayClientScopes,
-        });
-        await maybeNotifyAfterDeliveredPayload({
-          handler: deliveryHandler,
-          payload: effectivePayload,
-          target: deliveryTarget(),
-          results: deliveredResults,
-        });
-        completeDeliveryDiagnostics(deliveredResults.length);
-        continue;
       }
 
-      let firstMessageId: string | undefined;
-      let lastMessageId: string | undefined;
-      const beforeCount = results.length;
-      const mediaUnits = planOutboundMediaMessageUnits({
-        mediaUrls: payloadSummary.mediaUrls,
-        caption: payloadSummary.text,
-        overrides: sendOverrides,
-        consumeReplyTo: applySendReplyToConsumption,
-      });
-      for (const unit of mediaUnits) {
-        if (unit.kind !== "media") {
-          continue;
-        }
-        throwIfAborted(abortSignal);
-        const resultIndex = results.length;
-        const delivery = deliveryHandler.sendFormattedMedia
-          ? await deliveryHandler.sendFormattedMedia(
-              unit.caption ?? "",
-              unit.mediaUrl,
-              withPreparedTarget(unit.overrides),
-            )
-          : await deliveryHandler.sendMedia(
-              unit.caption ?? "",
-              unit.mediaUrl,
-              withPreparedTarget(unit.overrides),
-            );
-        const recorded = await recordIdentifiedDeliveryResult(delivery);
-        adoptSuccessfulResultsSince(resultIndex);
-        if (recorded) {
-          firstMessageId ??= delivery.messageId;
-          lastMessageId = delivery.messageId;
-        }
-      }
       const deliveredResults = results.slice(beforeCount);
       if (deliveredResults.length > 0) {
         recordPayloadOutcome({
@@ -558,7 +452,7 @@ export async function deliverOutboundPayloadsCore(
           status: "sent",
           results: deliveredResults,
         });
-        recordDeliveredPayload(payloadSummary, deliveredResults);
+        recordDeliveredPayload(mirroredPayload, deliveredResults);
       } else {
         recordPayloadOutcome(
           suppressedPayloadOutcome({
@@ -567,6 +461,12 @@ export async function deliverOutboundPayloadsCore(
           }),
         );
       }
+      const firstMessageId = mediaMessageIds
+        ? mediaMessageIds.first
+        : deliveredResults.find((entry) => entry.messageId)?.messageId;
+      const lastMessageId = mediaMessageIds
+        ? mediaMessageIds.last
+        : deliveredResults.at(-1)?.messageId;
       recordMessageSentEvent({
         success: deliveredResults.length > 0,
         content: payloadSummary.hookContent ?? payloadSummary.text,
@@ -585,7 +485,7 @@ export async function deliverOutboundPayloadsCore(
         target: deliveryTarget(),
         results: deliveredResults,
       });
-      completeDeliveryDiagnostics(results.length - beforeCount);
+      completeDeliveryDiagnostics(deliveredResults.length);
     } catch (err) {
       // A rejected adapter has no final return to reconcile with its progress
       // results. Keep the results, but never match them to a later payload.

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -5458,14 +5458,22 @@ describe("deliverOutboundPayloads", () => {
   it("does not count no-op sendPayload results as delivered", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendText = vi.fn();
+    const pinDeliveredMessage = vi.fn<OutboundPinDeliveredMessage>();
+    const afterDeliverPayload = vi.fn();
     const sendPayload = installPayloadOutbound(
       { channel: "matrix", messageId: "" },
-      { sendText, sendTextOnlyErrorPayloads: true },
+      { sendText, sendTextOnlyErrorPayloads: true, pinDeliveredMessage, afterDeliverPayload },
     );
 
     const results = await deliverMatrix({
       to: "!room:1",
-      payloads: [{ text: "provider exploded", isError: true }],
+      payloads: [
+        {
+          text: "provider exploded",
+          isError: true,
+          delivery: { pin: { enabled: true, required: true } },
+        },
+      ],
       mirror: {
         sessionKey: "agent:main:main",
         agentId: "main",
@@ -5476,6 +5484,8 @@ describe("deliverOutboundPayloads", () => {
     expect(results).toStrictEqual([]);
     expect(sendPayload).toHaveBeenCalledTimes(1);
     expect(sendText).not.toHaveBeenCalled();
+    expect(pinDeliveredMessage).not.toHaveBeenCalled();
+    expect(afterDeliverPayload).not.toHaveBeenCalled();
     expect(hookMocks.runner.runMessageSent).not.toHaveBeenCalled();
     expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
@@ -5655,13 +5665,22 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("pins the first delivered media message for multi-media payloads", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name?: string) => name === "message_sent");
+    const order: string[] = [];
     const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-text" });
     const sendMedia = vi
       .fn()
       .mockResolvedValueOnce({ channel: "matrix", messageId: "mx-1" })
       .mockResolvedValueOnce({ channel: "matrix", messageId: "mx-2" });
-    const pinDeliveredMessage = vi.fn<OutboundPinDeliveredMessage>();
-    setTestOutbound({ sendText, sendMedia, pinDeliveredMessage });
+    const pinDeliveredMessage = vi.fn<OutboundPinDeliveredMessage>(async () => {
+      order.push("pin");
+    });
+    const afterDeliverPayload = vi.fn<NonNullable<ChannelOutboundAdapter["afterDeliverPayload"]>>(
+      async () => {
+        order.push("after-delivery");
+      },
+    );
+    setTestOutbound({ sendText, sendMedia, pinDeliveredMessage, afterDeliverPayload });
 
     await deliverMatrix({
       to: "!room:1",
@@ -5672,11 +5691,22 @@ describe("deliverOutboundPayloads", () => {
           delivery: { pin: true },
         },
       ],
+      onDeliveredPayload: () => order.push("delivered"),
+      onMessageSentEvent: () => order.push("message-sent-staged"),
     });
 
     expect(sendMedia).toHaveBeenCalledTimes(2);
     const pinOptions = requireMockCallArg(pinDeliveredMessage, "pin delivered message");
     expect(pinOptions?.messageId).toBe("mx-1");
+    expect(order).toEqual(["delivered", "message-sent-staged", "pin", "after-delivery"]);
+    expect(requireMockCallArg(afterDeliverPayload, "after delivered payload").results).toEqual([
+      { channel: "matrix", messageId: "mx-1" },
+      { channel: "matrix", messageId: "mx-2" },
+    ]);
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "mx-2", success: true }),
+      expect.any(Object),
+    );
   });
 
   it.each([
@@ -5710,15 +5740,30 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("falls back to sendText when plugin outbound omits sendMedia", async () => {
-    const sendText = installTextOutbound({ channel: "matrix", messageId: "mx-1" });
+    const afterDeliverPayload = vi.fn();
+    const onDeliveredPayload = vi.fn();
+    const sendText = installTextOutbound(
+      { channel: "matrix", messageId: "mx-1" },
+      { afterDeliverPayload },
+    );
 
     const results = await deliverMatrix({
       to: "!room:1",
       payloads: [{ text: "caption", mediaUrl: "https://example.com/file.png" }],
+      onDeliveredPayload,
     });
 
     expect(sendText).toHaveBeenCalledTimes(1);
     expect(requireMockCallArg(sendText, "sendText").text).toBe("caption");
+    expect(onDeliveredPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "caption", mediaUrls: [] }),
+    );
+    expect(
+      requireMockCallArg(afterDeliverPayload, "after delivered payload").payload,
+    ).toMatchObject({
+      text: "caption",
+      mediaUrl: "https://example.com/file.png",
+    });
     const warnCall = requireMockCall(logMocks.warn, "warn");
     expect(warnCall[0]).toBe(
       "Plugin outbound adapter does not implement sendMedia; media URLs will be dropped and text fallback will be used",


### PR DESCRIPTION
## What Problem This Solves

Outbound delivery maintained parallel completion tails for durable and direct transport branches. The duplicated result projection made identity, media pinning, event emission, and completion-callback ordering harder to reason about and easier to drift.

## Why This Change Was Made

The outbound owner now projects one internal transport-completion outcome and shares the common completion tail. Branch-specific behavior remains explicit: identityless durable deliveries still return early, unsupported-media fallback keeps its mirrored text-only payload, and media/event identities continue to come from the final adapter result. No public API, persistence format, queue authority, or transport contract changes.

## User Impact

There is no intended user-visible behavior change. The delivery lifecycle has one smaller canonical completion path while retaining existing results, events, media handling, and callback order.

## Evidence

- Focused outbound owner and sibling coverage passes 214 tests.
- Exact changed-path type checks, lint, guards, dead-export checks, import cycles, and UI/core test gates pass.
- Added regression coverage preserves identityless durable return, unsupported-media fallback payload, final-result media/event identities, and completion callback ordering.
- Fresh autoreview reports no actionable findings with 0.97 confidence.
- Production delta: +47/-147, net -100 lines; tests +50/-5.
