### PR TITLE
fix(gateway): images sent to Claude CLI sessions show as raw cache-path links in chat history

### DIFF
--- a/src/agents/cli-image-turn-correlation.ts
+++ b/src/agents/cli-image-turn-correlation.ts
@@ -1,0 +1,36 @@
+import { createHash } from "node:crypto";
+import { markInboundContextLabel } from "../auto-reply/reply/inbound-context-marker.js";
+
+const CLI_IMAGE_TURN_LABEL = "Image turn:";
+const CLI_IMAGE_TURN_HEADER = markInboundContextLabel(CLI_IMAGE_TURN_LABEL);
+// Only a complete producer block is correlation evidence. Conflicting or
+// malformed copies must fail open so history merge cannot hide a real turn.
+const CLI_IMAGE_TURN_BLOCK_PATTERN = new RegExp(
+  `${CLI_IMAGE_TURN_HEADER}\\n\`\`\`json\\n\\{"turnKey":"([a-f0-9]{64})"\\}\\n\`\`\``,
+  "g",
+);
+
+export function hashCliImageTurnEntryId(entryId: string): string {
+  return createHash("sha256").update(entryId).digest("hex");
+}
+
+export function formatCliImageTurnContext(turnKey: string): string {
+  return `${CLI_IMAGE_TURN_HEADER}\n\`\`\`json\n${JSON.stringify({ turnKey })}\n\`\`\``;
+}
+
+export function readCliImageTurnContext(text: string): string | undefined {
+  const keys = Array.from(text.matchAll(CLI_IMAGE_TURN_BLOCK_PATTERN), (match) => match[1]);
+  if (keys.length !== text.split(CLI_IMAGE_TURN_HEADER).length - 1) {
+    return undefined;
+  }
+  const first = keys[0];
+  return first && keys.every((key) => key === first) ? first : undefined;
+}
+
+export function stripCliImageTurnContext(text: string, turnKey: string): string {
+  const block = formatCliImageTurnContext(turnKey);
+  return text
+    .replace(`\n\n${block}\n\n`, "\n\n")
+    .replace(`${block}\n\n`, "")
+    .replace(`\n\n${block}`, "");
+}

--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -8,10 +8,16 @@ import type { ImageContent } from "openclaw/plugin-sdk/llm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
 import { buildInboundMediaNoteProjection } from "../auto-reply/media-note.js";
+import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
 import { escapeRegExp } from "../shared/regexp.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import {
+  formatCliImageTurnContext,
+  hashCliImageTurnEntryId,
+  readCliImageTurnContext,
+} from "./cli-image-turn-correlation.js";
 import {
   buildCliArgs,
   prepareCliPromptImagePayload,
@@ -419,6 +425,41 @@ describe("writeCliImages", () => {
       });
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }
+  });
+
+  it("carries exact image-turn correlation beside Claude prompt paths", async () => {
+    const turnKey = hashCliImageTurnEntryId("transcript-entry-1");
+    const prepared = await prepareCliPromptImagePayload({
+      backend: { command: "claude", imageArg: "@" },
+      prompt: "describe this",
+      workspaceDir: "/workspace",
+      images: [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }],
+      imageTurnKey: turnKey,
+    });
+
+    try {
+      expect(readCliImageTurnContext(prepared.prompt)).toBe(turnKey);
+      expect(stripInboundMetadata(prepared.prompt)).not.toContain(turnKey);
+      expect(stripInboundMetadata(prepared.prompt)).toContain(
+        `@${expectDefined(prepared.imagePaths?.[0], "correlated image path")}`,
+      );
+    } finally {
+      await fs.rm(expectDefined(prepared.imagePaths?.[0], "correlated image path"), {
+        force: true,
+      });
+    }
+  });
+
+  it("rejects conflicting or malformed image-turn correlation", () => {
+    const first = hashCliImageTurnEntryId("transcript-entry-1");
+    const second = hashCliImageTurnEntryId("transcript-entry-2");
+
+    expect(
+      readCliImageTurnContext(
+        `${formatCliImageTurnContext(first)}\n\n${formatCliImageTurnContext(second)}`,
+      ),
+    ).toBeUndefined();
+    expect(readCliImageTurnContext(formatCliImageTurnContext("not-a-key"))).toBeUndefined();
   });
 
   it("uses the shared media extension map for image formats beyond the tiny builtin list", async () => {

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -18,7 +18,10 @@ import {
 } from "../../infra/diagnostic-events.js";
 import type { CliBackendParseJsonlEvent } from "../../plugins/cli-backend.types.js";
 import type { getProcessSupervisor } from "../../process/supervisor/index.js";
+import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
+import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
 import { createTestAdmittedRunContext } from "../admitted-run-context.test-support.js";
+import { hashCliImageTurnEntryId } from "../cli-image-turn-correlation.js";
 import { findCliMaxTurnsError } from "../failover-error.js";
 import { getCliMessagingDeliveryEvidence } from "./delivery-evidence.js";
 import { executePreparedCliRun } from "./execute.js";
@@ -150,6 +153,58 @@ beforeEach(() => {
 });
 
 describe("executePreparedCliRun supervisor output capture", () => {
+  it("binds Claude image prompts to the persisted local transcript turn", async () => {
+    const entryId = "persisted-image-turn";
+    const recorder = createUserTurnTranscriptRecorder({
+      input: { text: "describe this" },
+      target: createTestUserTurnTranscriptTarget(),
+    });
+    const message = recorder.message;
+    if (!message) {
+      throw new Error("expected prepared user turn");
+    }
+    recorder.markRuntimePersisted(message, {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath: "/tmp/sessions.db",
+      generation: "generation-1",
+      entryId,
+      rawSeq: 1,
+      effectiveParentId: null,
+      activeMessagePosition: 0,
+      logicalTurnId: "logical-turn-1",
+      role: "user",
+    });
+    const context = buildPreparedCliRunContext({ output: "text", provider: "claude-cli" });
+    context.preparedBackend.backend.imageArg = "@";
+    context.params.userTurnTranscriptRecorder = recorder;
+    context.params.images = [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }];
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as SupervisorSpawnInput;
+      input.onStdout?.("done");
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    await executePreparedCliRun(context);
+
+    const spawnInput = requireSupervisorSpawnInput();
+    if (!("input" in spawnInput)) {
+      throw new Error("expected direct CLI process input");
+    }
+    const prompt = spawnInput.input;
+    expect(prompt).toContain(hashCliImageTurnEntryId(entryId));
+  });
+
   it("passes native compaction as an argument and requires backend acknowledgement", async () => {
     const raw = `${JSON.stringify({ type: "system", subtype: "compacting" })}\n`;
     supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -14,6 +14,7 @@ import {
   resolveCliRuntimeOwnerFingerprint,
 } from "../cli-auth-epoch.js";
 import { resolveCliExecutableIdentity } from "../cli-executable-identity.js";
+import { hashCliImageTurnEntryId } from "../cli-image-turn-correlation.js";
 import type { CliOutput } from "../cli-output-contracts.js";
 import {
   detectImageReferences,
@@ -48,6 +49,7 @@ import { createCliToolTracking } from "./execute-tool-tracking.js";
 import {
   buildCliArgs,
   enqueueCliRun,
+  isClaudeCliBackendId,
   prepareCliPromptImagePayload,
   resolveCliNoOutputTimeoutMs,
   resolveCliRunQueueKey,
@@ -176,6 +178,9 @@ export async function executePreparedCliRun(
   ) {
     throw new Error("paired-node Claude CLI sessions do not support attachments or images");
   }
+  const imageTurnEntryId = isClaudeCliBackendId(context.backendResolved.id)
+    ? params.userTurnTranscriptRecorder?.getAdmissionReceipt()?.entryId
+    : undefined;
   const imagePayload = nodePlacement
     ? { prompt, imagePaths: [] as string[], cleanupImages: async () => {} }
     : await prepareCliPromptImagePayload({
@@ -188,6 +193,7 @@ export async function executePreparedCliRun(
         imageOrder: params.imageOrder,
         mediaImageLayout: params.mediaImageLayout,
         media: params.media,
+        ...(imageTurnEntryId ? { imageTurnKey: hashCliImageTurnEntryId(imageTurnEntryId) } : {}),
       });
   prompt = imagePayload.prompt;
   const promptInputBackend =

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -29,6 +29,7 @@ import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import type { CliBackendConfig } from "../../plugins/cli-backend.types.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-registry-state.js";
 import type { BootstrapMode } from "../bootstrap-mode.js";
+import { formatCliImageTurnContext } from "../cli-image-turn-correlation.js";
 import type { EmbeddedContextFile } from "../embedded-agent-helpers.js";
 import {
   detectAndLoadPromptImages,
@@ -393,6 +394,7 @@ export async function prepareCliPromptImagePayload(params: {
   imageOrder?: PromptImageOrderEntry[];
   mediaImageLayout?: MediaImageLayout;
   media?: MediaFact[];
+  imageTurnKey?: string;
 }): Promise<{
   prompt: string;
   imagePaths?: string[];
@@ -438,6 +440,9 @@ export async function prepareCliPromptImagePayload(params: {
     params.backend.input === "stdin" ||
     params.backend.imageArg === "@"
   ) {
+    if (params.imageTurnKey) {
+      prompt = `${prompt.trimEnd()}\n\n${formatCliImageTurnContext(params.imageTurnKey)}`;
+    }
     prompt = appendImagePathsToPrompt(
       prompt,
       imagePaths,

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -336,13 +336,25 @@ function stripTrailingCliImageMentions(text: string): string {
   return lines.slice(0, end).join("\n").trimEnd();
 }
 
-// Returns null when stripping leaves no visible content (image-only prompt);
-// the local transcript row already represents that turn with media facts.
+type CliImageMentionStripResult =
+  | { kind: "unchanged" }
+  | { kind: "stripped"; content: string | unknown[] }
+  | { kind: "mention-only" };
+
+// Rows reduced to nothing but image mentions keep their original content and
+// are only tagged; the history merge decides whether a local media-bearing row
+// makes them redundant, because the parser cannot know that a local
+// counterpart survives (the local transcript may be reset or lost while the
+// external JSONL persists).
 function stripCliImageMentionsFromUserContent(
   content: string | unknown[],
-): string | unknown[] | null {
+): CliImageMentionStripResult {
   if (typeof content === "string") {
-    return stripTrailingCliImageMentions(content) || null;
+    const stripped = stripTrailingCliImageMentions(content);
+    if (stripped === content) {
+      return { kind: "unchanged" };
+    }
+    return stripped ? { kind: "stripped", content: stripped } : { kind: "mention-only" };
   }
   let changed = false;
   const next: unknown[] = [];
@@ -365,9 +377,9 @@ function stripCliImageMentionsFromUserContent(
     next.push(block);
   }
   if (!changed) {
-    return content;
+    return { kind: "unchanged" };
   }
-  return next.length > 0 ? next : null;
+  return next.length > 0 ? { kind: "stripped", content: next } : { kind: "mention-only" };
 }
 
 export function parseClaudeCliHistoryEntry(
@@ -467,9 +479,9 @@ export function parseClaudeCliHistoryEntry(
         }
       }
     }
-    const strippedContent = stripCliImageMentionsFromUserContent(content);
-    if (strippedContent === null) {
-      return null;
+    const stripResult = stripCliImageMentionsFromUserContent(content);
+    if (stripResult.kind === "stripped") {
+      content = stripResult.content;
     }
     // Record provenance here, where the native flags are known, so downstream
     // display never has to infer operator authorship from message text.
@@ -477,13 +489,13 @@ export function parseClaudeCliHistoryEntry(
     return attachOpenClawTranscriptMeta(
       {
         role: "user",
-        content: strippedContent,
+        content,
         ...(harnessInjected
           ? { provenance: { kind: "internal_system", sourceTool: "cli_harness_context" } }
           : {}),
         ...(timestamp !== undefined ? { timestamp } : {}),
       },
-      baseMeta,
+      stripResult.kind === "mention-only" ? { ...baseMeta, cliImageMentionOnly: true } : baseMeta,
     ) as TranscriptLikeMessage;
   }
 

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -9,6 +9,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { hashCliReseedPrompt, parseCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
+import { isOpenClawCliImageCachePath } from "../agents/embedded-agent-runner/run/images.media-refs.js";
 import type { AgentMessage } from "../agents/runtime/index.js";
 import { redactTranscriptMessage } from "../agents/transcript-redact.js";
 import {
@@ -311,6 +312,64 @@ export function resolveClaudeCliPromptTextCandidates(
   );
 }
 
+// The CLI runner cannot pass structured image blocks to the Claude CLI, so it
+// appends "@<cache path>" mention lines to the prompt it hands the CLI (see
+// appendImagePathsToPrompt in agents/cli-runner/helpers.ts). Claude Code records
+// that mutated prompt as its user message, so without stripping, the imported
+// row fails text dedupe against the local transcript row — which carries the
+// original text plus the media facts that render the image preview — and the
+// raw path surfaces in chat history as a duplicate user row.
+function isCliImageMentionLine(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith("@") && isOpenClawCliImageCachePath(trimmed.slice(1));
+}
+
+function stripTrailingCliImageMentions(text: string): string {
+  const lines = text.split("\n");
+  let end = lines.length;
+  while (end > 0 && isCliImageMentionLine(lines[end - 1] ?? "")) {
+    end -= 1;
+  }
+  if (end === lines.length) {
+    return text;
+  }
+  return lines.slice(0, end).join("\n").trimEnd();
+}
+
+// Returns null when stripping leaves no visible content (image-only prompt);
+// the local transcript row already represents that turn with media facts.
+function stripCliImageMentionsFromUserContent(
+  content: string | unknown[],
+): string | unknown[] | null {
+  if (typeof content === "string") {
+    return stripTrailingCliImageMentions(content) || null;
+  }
+  let changed = false;
+  const next: unknown[] = [];
+  for (const block of content) {
+    if (
+      block &&
+      typeof block === "object" &&
+      (block as { type?: unknown }).type === "text" &&
+      typeof (block as { text?: unknown }).text === "string"
+    ) {
+      const stripped = stripTrailingCliImageMentions((block as { text: string }).text);
+      if (stripped !== (block as { text: string }).text) {
+        changed = true;
+        if (stripped) {
+          next.push({ ...(block as Record<string, unknown>), text: stripped });
+        }
+        continue;
+      }
+    }
+    next.push(block);
+  }
+  if (!changed) {
+    return content;
+  }
+  return next.length > 0 ? next : null;
+}
+
 export function parseClaudeCliHistoryEntry(
   entry: ClaudeCliProjectEntry,
   cliSessionId: string,
@@ -408,13 +467,17 @@ export function parseClaudeCliHistoryEntry(
         }
       }
     }
+    const strippedContent = stripCliImageMentionsFromUserContent(content);
+    if (strippedContent === null) {
+      return null;
+    }
     // Record provenance here, where the native flags are known, so downstream
     // display never has to infer operator authorship from message text.
     const harnessInjected = isClaudeCliVisibleHarnessContext(entry);
     return attachOpenClawTranscriptMeta(
       {
         role: "user",
-        content,
+        content: strippedContent,
         ...(harnessInjected
           ? { provenance: { kind: "internal_system", sourceTool: "cli_harness_context" } }
           : {}),

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -8,6 +8,10 @@ import {
   parseDateStringTimestampMs,
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  readCliImageTurnContext,
+  stripCliImageTurnContext,
+} from "../agents/cli-image-turn-correlation.js";
 import { hashCliReseedPrompt, parseCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
 import type { AgentMessage } from "../agents/runtime/index.js";
 import { redactTranscriptMessage } from "../agents/transcript-redact.js";
@@ -408,6 +412,11 @@ export function parseClaudeCliHistoryEntry(
         }
       }
     }
+    const cliImageTurnKey =
+      typeof content === "string" ? readCliImageTurnContext(content) : undefined;
+    if (cliImageTurnKey && typeof content === "string") {
+      content = stripCliImageTurnContext(content, cliImageTurnKey);
+    }
     // Record provenance here, where the native flags are known, so downstream
     // display never has to infer operator authorship from message text.
     const harnessInjected = isClaudeCliVisibleHarnessContext(entry);
@@ -420,7 +429,7 @@ export function parseClaudeCliHistoryEntry(
           : {}),
         ...(timestamp !== undefined ? { timestamp } : {}),
       },
-      baseMeta,
+      { ...baseMeta, ...(cliImageTurnKey ? { cliImageTurnKey } : {}) },
     ) as TranscriptLikeMessage;
   }
 

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -7,10 +7,8 @@ import {
   asFiniteNumber,
   parseDateStringTimestampMs,
 } from "@openclaw/normalization-core/number-coercion";
-import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { hashCliReseedPrompt, parseCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
-import { isOpenClawCliImageCachePath } from "../agents/embedded-agent-runner/run/images.media-refs.js";
 import type { AgentMessage } from "../agents/runtime/index.js";
 import { redactTranscriptMessage } from "../agents/transcript-redact.js";
 import {
@@ -313,73 +311,6 @@ export function resolveClaudeCliPromptTextCandidates(
   );
 }
 
-// The CLI runner cannot pass structured image blocks to the Claude CLI, so it
-// appends "@<cache path>" mention lines to the prompt it hands the CLI (see
-// appendImagePathsToPrompt in agents/cli-runner/helpers.ts). Claude Code records
-// that mutated prompt as its user message, so without stripping, the imported
-// row fails text dedupe against the local transcript row — which carries the
-// original text plus the media facts that render the image preview — and the
-// raw path surfaces in chat history as a duplicate user row.
-function isCliImageMentionLine(line: string): boolean {
-  const trimmed = line.trim();
-  return trimmed.startsWith("@") && isOpenClawCliImageCachePath(trimmed.slice(1));
-}
-
-function stripTrailingCliImageMentions(text: string): string {
-  const lines = text.split("\n");
-  let end = lines.length;
-  while (end > 0 && isCliImageMentionLine(lines[end - 1] ?? "")) {
-    end -= 1;
-  }
-  if (end === lines.length) {
-    return text;
-  }
-  return lines.slice(0, end).join("\n").trimEnd();
-}
-
-type CliImageMentionStripResult =
-  | { kind: "unchanged" }
-  | { kind: "stripped"; content: string | unknown[] }
-  | { kind: "mention-only" };
-
-// Rows reduced to nothing but image mentions keep their original content and
-// are only tagged; the history merge decides whether a local media-bearing row
-// makes them redundant, because the parser cannot know that a local
-// counterpart survives (the local transcript may be reset or lost while the
-// external JSONL persists).
-function stripCliImageMentionsFromUserContent(
-  content: string | unknown[],
-): CliImageMentionStripResult {
-  if (typeof content === "string") {
-    const stripped = stripTrailingCliImageMentions(content);
-    if (stripped === content) {
-      return { kind: "unchanged" };
-    }
-    return stripped ? { kind: "stripped", content: stripped } : { kind: "mention-only" };
-  }
-  let changed = false;
-  const next: unknown[] = [];
-  for (const block of content) {
-    const record = asOptionalRecord(block);
-    const text = record?.type === "text" && typeof record.text === "string" ? record.text : null;
-    if (record && text !== null) {
-      const stripped = stripTrailingCliImageMentions(text);
-      if (stripped !== text) {
-        changed = true;
-        if (stripped) {
-          next.push({ ...record, text: stripped });
-        }
-        continue;
-      }
-    }
-    next.push(block);
-  }
-  if (!changed) {
-    return { kind: "unchanged" };
-  }
-  return next.length > 0 ? { kind: "stripped", content: next } : { kind: "mention-only" };
-}
-
 export function parseClaudeCliHistoryEntry(
   entry: ClaudeCliProjectEntry,
   cliSessionId: string,
@@ -477,10 +408,6 @@ export function parseClaudeCliHistoryEntry(
         }
       }
     }
-    const stripResult = stripCliImageMentionsFromUserContent(content);
-    if (stripResult.kind === "stripped") {
-      content = stripResult.content;
-    }
     // Record provenance here, where the native flags are known, so downstream
     // display never has to infer operator authorship from message text.
     const harnessInjected = isClaudeCliVisibleHarnessContext(entry);
@@ -493,7 +420,7 @@ export function parseClaudeCliHistoryEntry(
           : {}),
         ...(timestamp !== undefined ? { timestamp } : {}),
       },
-      stripResult.kind === "mention-only" ? { ...baseMeta, cliImageMentionOnly: true } : baseMeta,
+      baseMeta,
     ) as TranscriptLikeMessage;
   }
 

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -7,6 +7,7 @@ import {
   asFiniteNumber,
   parseDateStringTimestampMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { hashCliReseedPrompt, parseCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
 import { isOpenClawCliImageCachePath } from "../agents/embedded-agent-runner/run/images.media-refs.js";
@@ -359,17 +360,14 @@ function stripCliImageMentionsFromUserContent(
   let changed = false;
   const next: unknown[] = [];
   for (const block of content) {
-    if (
-      block &&
-      typeof block === "object" &&
-      (block as { type?: unknown }).type === "text" &&
-      typeof (block as { text?: unknown }).text === "string"
-    ) {
-      const stripped = stripTrailingCliImageMentions((block as { text: string }).text);
-      if (stripped !== (block as { text: string }).text) {
+    const record = asOptionalRecord(block);
+    const text = record?.type === "text" && typeof record.text === "string" ? record.text : null;
+    if (record && text !== null) {
+      const stripped = stripTrailingCliImageMentions(text);
+      if (stripped !== text) {
         changed = true;
         if (stripped) {
-          next.push({ ...(block as Record<string, unknown>), text: stripped });
+          next.push({ ...record, text: stripped });
         }
         continue;
       }

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -121,15 +121,12 @@ function addTimestampToSummary(summary: TimestampSummary, timestamp: number | un
   }
 }
 
-function summaryMatchesTimestamp(
+function summaryHasTimestampMatch(
   summary: TimestampSummary | undefined,
   timestamp: number | undefined,
 ): boolean {
-  if (!summary) {
+  if (!summary || timestamp === undefined) {
     return false;
-  }
-  if (timestamp === undefined || summary.hasMissingTimestamp) {
-    return true;
   }
   const bucketKey = Math.floor(timestamp / DEDUPE_TIMESTAMP_WINDOW_MS);
   if (summary.buckets.has(bucketKey)) {
@@ -141,6 +138,16 @@ function summaryMatchesTimestamp(
   }
   const next = summary.buckets.get(bucketKey + 1);
   return next !== undefined && next.min <= timestamp + DEDUPE_TIMESTAMP_WINDOW_MS;
+}
+
+function summaryMatchesTimestamp(
+  summary: TimestampSummary | undefined,
+  timestamp: number | undefined,
+): boolean {
+  return (
+    Boolean(summary && (timestamp === undefined || summary.hasMissingTimestamp)) ||
+    summaryHasTimestampMatch(summary, timestamp)
+  );
 }
 
 function addRoleTextCandidate(index: RoleTextIndex, entry: ComparableHistoryMessage): void {
@@ -237,7 +244,7 @@ export function mergeImportedChatHistoryMessages(params: {
     }
     if (
       isCliImageMentionOnlyImport(message) &&
-      summaryMatchesTimestamp(localImageMediaTimestamps, imported.timestamp)
+      summaryHasTimestampMatch(localImageMediaTimestamps, imported.timestamp)
     ) {
       continue;
     }

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -6,6 +6,11 @@ import {
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
+import {
+  isImageMediaFact,
+  normalizeMediaFacts,
+  type MediaFactInput,
+} from "../media/media-facts.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 
 const DEDUPE_TIMESTAMP_WINDOW_MS = 5 * 60 * 1000;
@@ -100,6 +105,43 @@ function resolveImportedExternalIdentityKey(message: unknown): string | undefine
     : undefined;
 }
 
+function addTimestampToSummary(summary: TimestampSummary, timestamp: number | undefined): void {
+  if (timestamp === undefined) {
+    summary.hasMissingTimestamp = true;
+    return;
+  }
+  const bucketKey = Math.floor(timestamp / DEDUPE_TIMESTAMP_WINDOW_MS);
+  const bucket = summary.buckets.get(bucketKey);
+  if (bucket) {
+    bucket.min = Math.min(bucket.min, timestamp);
+    bucket.max = Math.max(bucket.max, timestamp);
+  } else {
+    summary.buckets.set(bucketKey, { min: timestamp, max: timestamp });
+  }
+}
+
+function summaryMatchesTimestamp(
+  summary: TimestampSummary | undefined,
+  timestamp: number | undefined,
+): boolean {
+  if (!summary) {
+    return false;
+  }
+  if (timestamp === undefined || summary.hasMissingTimestamp) {
+    return true;
+  }
+  const bucketKey = Math.floor(timestamp / DEDUPE_TIMESTAMP_WINDOW_MS);
+  if (summary.buckets.has(bucketKey)) {
+    return true;
+  }
+  const previous = summary.buckets.get(bucketKey - 1);
+  if (previous && previous.max >= timestamp - DEDUPE_TIMESTAMP_WINDOW_MS) {
+    return true;
+  }
+  const next = summary.buckets.get(bucketKey + 1);
+  return next !== undefined && next.min <= timestamp + DEDUPE_TIMESTAMP_WINDOW_MS;
+}
+
 function addRoleTextCandidate(index: RoleTextIndex, entry: ComparableHistoryMessage): void {
   if (!entry.role || !entry.text) {
     return;
@@ -114,41 +156,46 @@ function addRoleTextCandidate(index: RoleTextIndex, entry: ComparableHistoryMess
     summary = { hasMissingTimestamp: false, buckets: new Map() };
     byText.set(entry.text, summary);
   }
-  if (entry.timestamp === undefined) {
-    summary.hasMissingTimestamp = true;
-    return;
-  }
-  const bucketKey = Math.floor(entry.timestamp / DEDUPE_TIMESTAMP_WINDOW_MS);
-  const bucket = summary.buckets.get(bucketKey);
-  if (bucket) {
-    bucket.min = Math.min(bucket.min, entry.timestamp);
-    bucket.max = Math.max(bucket.max, entry.timestamp);
-  } else {
-    summary.buckets.set(bucketKey, { min: entry.timestamp, max: entry.timestamp });
-  }
+  addTimestampToSummary(summary, entry.timestamp);
 }
 
 function hasRoleTextCandidate(index: RoleTextIndex, entry: ComparableHistoryMessage): boolean {
   if (!entry.role || !entry.text) {
     return false;
   }
-  const summary = index.get(entry.role)?.get(entry.text);
-  if (!summary) {
+  return summaryMatchesTimestamp(index.get(entry.role)?.get(entry.text), entry.timestamp);
+}
+
+// Imported user rows containing only CLI-injected image cache mentions (tagged
+// by the Claude importer) are redundant only when a local user row with image
+// media facts represents the same turn. Local history can be reset or lost
+// while the external JSONL persists, so redundancy is proven per-merge by a
+// media-bearing local row inside the dedupe timestamp window, never assumed.
+function isCliImageMentionOnlyImport(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
     return false;
   }
-  if (entry.timestamp === undefined || summary.hasMissingTimestamp) {
-    return true;
+  const meta = (message as { __openclaw?: unknown })["__openclaw"];
+  if (!meta || typeof meta !== "object") {
+    return false;
   }
-  const bucketKey = Math.floor(entry.timestamp / DEDUPE_TIMESTAMP_WINDOW_MS);
-  if (summary.buckets.has(bucketKey)) {
-    return true;
+  return (meta as { cliImageMentionOnly?: unknown }).cliImageMentionOnly === true;
+}
+
+function hasLocalImageMediaFacts(entry: ComparableHistoryMessage): boolean {
+  const message = entry.message;
+  if (entry.role !== "user" || !message || typeof message !== "object") {
+    return false;
   }
-  const previous = summary.buckets.get(bucketKey - 1);
-  if (previous && previous.max >= entry.timestamp - DEDUPE_TIMESTAMP_WINDOW_MS) {
-    return true;
+  const meta = (message as { __openclaw?: unknown })["__openclaw"];
+  if (!meta || typeof meta !== "object") {
+    return false;
   }
-  const next = summary.buckets.get(bucketKey + 1);
-  return next !== undefined && next.min <= entry.timestamp + DEDUPE_TIMESTAMP_WINDOW_MS;
+  const media = (meta as { media?: unknown }).media;
+  if (!Array.isArray(media)) {
+    return false;
+  }
+  return normalizeMediaFacts(media as readonly MediaFactInput[]).some(isImageMediaFact);
 }
 
 function compareHistoryMessages(a: ComparableHistoryMessage, b: ComparableHistoryMessage): number {
@@ -170,6 +217,7 @@ export function mergeImportedChatHistoryMessages(params: {
   const exactExternalIdentityIndex = new Set<string>();
   const allMessageRoleTextIndex: RoleTextIndex = new Map();
   const identitylessRoleTextIndex: RoleTextIndex = new Map();
+  let localImageMediaTimestamps: TimestampSummary | undefined;
   const indexEntry = (entry: ComparableHistoryMessage) => {
     if (entry.externalIdentityKey) {
       exactExternalIdentityIndex.add(entry.externalIdentityKey);
@@ -180,6 +228,10 @@ export function mergeImportedChatHistoryMessages(params: {
   };
   for (const entry of merged) {
     indexEntry(entry);
+    if (hasLocalImageMediaFacts(entry)) {
+      localImageMediaTimestamps ??= { hasMissingTimestamp: false, buckets: new Map() };
+      addTimestampToSummary(localImageMediaTimestamps, entry.timestamp);
+    }
   }
   let nextOrder = merged.length;
   for (const message of params.importedMessages) {
@@ -189,6 +241,12 @@ export function mergeImportedChatHistoryMessages(params: {
         hasRoleTextCandidate(identitylessRoleTextIndex, imported)
       : hasRoleTextCandidate(allMessageRoleTextIndex, imported);
     if (duplicate) {
+      continue;
+    }
+    if (
+      isCliImageMentionOnlyImport(message) &&
+      summaryMatchesTimestamp(localImageMediaTimestamps, imported.timestamp)
+    ) {
       continue;
     }
     merged.push(imported);

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -227,7 +227,11 @@ function findLocalImageMediaMatch(
   candidates: ComparableHistoryMessage[],
   imported: ComparableHistoryMessage,
 ): number {
-  if (!imported.hasCliImageMentions || imported.timestamp === undefined) {
+  if (
+    !imported.hasCliImageMentions ||
+    imported.timestamp === undefined ||
+    imported.text === undefined
+  ) {
     return -1;
   }
   const importedTimestamp = imported.timestamp;
@@ -235,7 +239,7 @@ function findLocalImageMediaMatch(
     (candidate) =>
       candidate.timestamp !== undefined &&
       Math.abs(candidate.timestamp - importedTimestamp) <= DEDUPE_TIMESTAMP_WINDOW_MS &&
-      (imported.text === undefined || candidate.text === imported.text),
+      candidate.text === imported.text,
   );
 }
 

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -6,6 +6,10 @@ import {
   normalizeOptionalString,
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
+import {
+  hashCliImageTurnEntryId,
+  readCliImageTurnContext,
+} from "../agents/cli-image-turn-correlation.js";
 import { isOpenClawCliImageCachePath } from "../agents/embedded-agent-runner/run/images.media-refs.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import { isImageMediaFact, readPersistedMediaFacts } from "../media/media-facts.js";
@@ -18,6 +22,7 @@ type ComparableHistoryMessage = {
   order: number;
   externalIdentityKey?: string;
   hasCliImageMentions: boolean;
+  cliImageTurnKey?: string;
   role?: string;
   text?: string;
   timestamp?: number;
@@ -64,6 +69,7 @@ function extractComparableText(
   role: string | undefined,
 ): {
   hasCliImageMentions: boolean;
+  cliImageTurnKey?: string;
   text?: string;
 } {
   if (!message || typeof message !== "object") {
@@ -103,8 +109,13 @@ function extractComparableText(
     role === "user" ? stripInboundMetadata(stripResult.text) : stripResult.text,
   ).text;
   const normalized = visible.replace(/\s+/g, " ").trim();
+  const meta = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
+  const storedImageTurnKey = normalizeOptionalString(meta?.cliImageTurnKey);
   return {
     hasCliImageMentions: stripResult.stripped,
+    ...(stripResult.stripped && isClaudeCliImportedUserMessage(message, role)
+      ? { cliImageTurnKey: storedImageTurnKey ?? readCliImageTurnContext(joined) }
+      : {}),
     ...(normalized ? { text: normalized } : {}),
   };
 }
@@ -121,6 +132,7 @@ function prepareComparableMessage(message: unknown, order: number): ComparableHi
     order,
     externalIdentityKey: resolveImportedExternalIdentityKey(message),
     hasCliImageMentions: comparableText.hasCliImageMentions,
+    ...(comparableText.cliImageTurnKey ? { cliImageTurnKey: comparableText.cliImageTurnKey } : {}),
     role,
     text: comparableText.text,
     timestamp: asFiniteNumber(record.timestamp),
@@ -227,19 +239,11 @@ function findLocalImageMediaMatch(
   candidates: ComparableHistoryMessage[],
   imported: ComparableHistoryMessage,
 ): number {
-  if (
-    !imported.hasCliImageMentions ||
-    imported.timestamp === undefined ||
-    imported.text === undefined
-  ) {
+  if (!imported.hasCliImageMentions || !imported.cliImageTurnKey) {
     return -1;
   }
-  const importedTimestamp = imported.timestamp;
   return candidates.findIndex(
-    (candidate) =>
-      candidate.timestamp !== undefined &&
-      Math.abs(candidate.timestamp - importedTimestamp) <= DEDUPE_TIMESTAMP_WINDOW_MS &&
-      candidate.text === imported.text,
+    (candidate) => candidate.cliImageTurnKey === imported.cliImageTurnKey,
   );
 }
 
@@ -272,8 +276,13 @@ export function mergeImportedChatHistoryMessages(params: {
     addRoleTextCandidate(allMessageRoleTextIndex, entry);
   };
   for (const entry of merged) {
+    const localMeta = asOptionalRecord(asOptionalRecord(entry.message)?.["__openclaw"]);
+    const localEntryId = normalizeOptionalString(localMeta?.id);
+    if (localEntryId) {
+      entry.cliImageTurnKey = hashCliImageTurnEntryId(localEntryId);
+    }
     indexEntry(entry);
-    if (hasLocalImageMediaFacts(entry) && entry.timestamp !== undefined) {
+    if (hasLocalImageMediaFacts(entry)) {
       localImageMediaCandidates.push(entry);
     }
   }

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -179,6 +179,8 @@ function hasRoleTextCandidate(index: RoleTextIndex, entry: ComparableHistoryMess
 // media facts represents the same turn. Local history can be reset or lost
 // while the external JSONL persists, so redundancy is proven per-merge by a
 // media-bearing local row inside the dedupe timestamp window, never assumed.
+// Each local candidate is consumed once so partial local history cannot hide
+// multiple distinct imported image turns.
 function isCliImageMentionOnlyImport(message: unknown): boolean {
   const meta = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
   return meta?.cliImageMentionOnly === true;
@@ -216,7 +218,7 @@ export function mergeImportedChatHistoryMessages(params: {
   const exactExternalIdentityIndex = new Set<string>();
   const allMessageRoleTextIndex: RoleTextIndex = new Map();
   const identitylessRoleTextIndex: RoleTextIndex = new Map();
-  let localImageMediaTimestamps: TimestampSummary | undefined;
+  const localImageMediaTimestamps: number[] = [];
   const indexEntry = (entry: ComparableHistoryMessage) => {
     if (entry.externalIdentityKey) {
       exactExternalIdentityIndex.add(entry.externalIdentityKey);
@@ -227,9 +229,8 @@ export function mergeImportedChatHistoryMessages(params: {
   };
   for (const entry of merged) {
     indexEntry(entry);
-    if (hasLocalImageMediaFacts(entry)) {
-      localImageMediaTimestamps ??= { hasMissingTimestamp: false, buckets: new Map() };
-      addTimestampToSummary(localImageMediaTimestamps, entry.timestamp);
+    if (hasLocalImageMediaFacts(entry) && entry.timestamp !== undefined) {
+      localImageMediaTimestamps.push(entry.timestamp);
     }
   }
   let nextOrder = merged.length;
@@ -242,10 +243,15 @@ export function mergeImportedChatHistoryMessages(params: {
     if (duplicate) {
       continue;
     }
-    if (
-      isCliImageMentionOnlyImport(message) &&
-      summaryHasTimestampMatch(localImageMediaTimestamps, imported.timestamp)
-    ) {
+    const importedTimestamp = imported.timestamp;
+    const localImageMediaIndex =
+      isCliImageMentionOnlyImport(message) && importedTimestamp !== undefined
+        ? localImageMediaTimestamps.findIndex(
+            (timestamp) => Math.abs(timestamp - importedTimestamp) <= DEDUPE_TIMESTAMP_WINDOW_MS,
+          )
+        : -1;
+    if (localImageMediaIndex !== -1) {
+      localImageMediaTimestamps.splice(localImageMediaIndex, 1);
       continue;
     }
     merged.push(imported);

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -1,6 +1,7 @@
 // Imported CLI history merge helpers.
 // Deduplicates external history messages against local OpenClaw transcripts.
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeOptionalString,
   readStringValue,
@@ -172,29 +173,20 @@ function hasRoleTextCandidate(index: RoleTextIndex, entry: ComparableHistoryMess
 // while the external JSONL persists, so redundancy is proven per-merge by a
 // media-bearing local row inside the dedupe timestamp window, never assumed.
 function isCliImageMentionOnlyImport(message: unknown): boolean {
-  if (!message || typeof message !== "object") {
-    return false;
-  }
-  const meta = (message as { __openclaw?: unknown })["__openclaw"];
-  if (!meta || typeof meta !== "object") {
-    return false;
-  }
-  return (meta as { cliImageMentionOnly?: unknown }).cliImageMentionOnly === true;
+  const meta = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
+  return meta?.cliImageMentionOnly === true;
 }
 
 function hasLocalImageMediaFacts(entry: ComparableHistoryMessage): boolean {
-  const message = entry.message;
-  if (entry.role !== "user" || !message || typeof message !== "object") {
+  if (entry.role !== "user") {
     return false;
   }
-  const meta = (message as { __openclaw?: unknown })["__openclaw"];
-  if (!meta || typeof meta !== "object") {
-    return false;
-  }
-  const media = (meta as { media?: unknown }).media;
+  const meta = asOptionalRecord(asOptionalRecord(entry.message)?.["__openclaw"]);
+  const media = meta?.media;
   if (!Array.isArray(media)) {
     return false;
   }
+  // SAFETY: normalizeMediaFacts accepts loose MediaFactInput shapes and drops invalid entries.
   return normalizeMediaFacts(media as readonly MediaFactInput[]).some(isImageMediaFact);
 }
 

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -6,12 +6,9 @@ import {
   normalizeOptionalString,
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
+import { isOpenClawCliImageCachePath } from "../agents/embedded-agent-runner/run/images.media-refs.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
-import {
-  isImageMediaFact,
-  normalizeMediaFacts,
-  type MediaFactInput,
-} from "../media/media-facts.js";
+import { isImageMediaFact, readPersistedMediaFacts } from "../media/media-facts.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 
 const DEDUPE_TIMESTAMP_WINDOW_MS = 5 * 60 * 1000;
@@ -20,6 +17,7 @@ type ComparableHistoryMessage = {
   message: unknown;
   order: number;
   externalIdentityKey?: string;
+  hasCliImageMentions: boolean;
   role?: string;
   text?: string;
   timestamp?: number;
@@ -32,9 +30,44 @@ type TimestampSummary = {
 
 type RoleTextIndex = Map<string, Map<string, TimestampSummary>>;
 
-function extractComparableText(message: unknown, role: string | undefined): string | undefined {
+// Claude records CLI-injected @cache-path suffixes as user text. Keep the
+// stored content intact; this normalized view is only for proving a redundant
+// imported row against the local turn that owns the durable media facts.
+function stripTrailingCliImageMentions(text: string): {
+  text: string;
+  stripped: boolean;
+} {
+  const lines = text.split("\n");
+  let end = lines.length;
+  while (end > 0) {
+    const line = lines[end - 1]?.trim() ?? "";
+    if (!line.startsWith("@") || !isOpenClawCliImageCachePath(line.slice(1))) {
+      break;
+    }
+    end -= 1;
+  }
+  return end === lines.length
+    ? { text, stripped: false }
+    : { text: lines.slice(0, end).join("\n").trimEnd(), stripped: true };
+}
+
+function isClaudeCliImportedUserMessage(message: unknown, role: string | undefined): boolean {
+  if (role !== "user") {
+    return false;
+  }
+  const meta = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
+  return normalizeOptionalString(meta?.importedFrom) === "claude-cli";
+}
+
+function extractComparableText(
+  message: unknown,
+  role: string | undefined,
+): {
+  hasCliImageMentions: boolean;
+  text?: string;
+} {
   if (!message || typeof message !== "object") {
-    return undefined;
+    return { hasCliImageMentions: false };
   }
   const record = message as { role?: unknown; text?: unknown; content?: unknown };
   const parts: string[] = [];
@@ -57,31 +90,39 @@ function extractComparableText(message: unknown, role: string | undefined): stri
     }
   }
   if (parts.length === 0) {
-    return undefined;
+    return { hasCliImageMentions: false };
   }
   const joined = parts.join("\n").trim();
   if (!joined) {
-    return undefined;
+    return { hasCliImageMentions: false };
   }
+  const stripResult = isClaudeCliImportedUserMessage(message, role)
+    ? stripTrailingCliImageMentions(joined)
+    : { text: joined, stripped: false };
   const visible = stripInlineDirectiveTagsForDisplay(
-    role === "user" ? stripInboundMetadata(joined) : joined,
+    role === "user" ? stripInboundMetadata(stripResult.text) : stripResult.text,
   ).text;
   const normalized = visible.replace(/\s+/g, " ").trim();
-  return normalized || undefined;
+  return {
+    hasCliImageMentions: stripResult.stripped,
+    ...(normalized ? { text: normalized } : {}),
+  };
 }
 
 function prepareComparableMessage(message: unknown, order: number): ComparableHistoryMessage {
   if (!message || typeof message !== "object") {
-    return { message, order };
+    return { message, order, hasCliImageMentions: false };
   }
   const record = message as { role?: unknown; timestamp?: unknown };
   const role = readStringValue(record.role);
+  const comparableText = extractComparableText(message, role);
   return {
     message,
     order,
     externalIdentityKey: resolveImportedExternalIdentityKey(message),
+    hasCliImageMentions: comparableText.hasCliImageMentions,
     role,
-    text: extractComparableText(message, role),
+    text: comparableText.text,
     timestamp: asFiniteNumber(record.timestamp),
   };
 }
@@ -174,29 +215,28 @@ function hasRoleTextCandidate(index: RoleTextIndex, entry: ComparableHistoryMess
   return summaryMatchesTimestamp(index.get(entry.role)?.get(entry.text), entry.timestamp);
 }
 
-// Imported user rows containing only CLI-injected image cache mentions (tagged
-// by the Claude importer) are redundant only when a local user row with image
-// media facts represents the same turn. Local history can be reset or lost
-// while the external JSONL persists, so redundancy is proven per-merge by a
-// media-bearing local row inside the dedupe timestamp window, never assumed.
-// Each local candidate is consumed once so partial local history cannot hide
-// multiple distinct imported image turns.
-function isCliImageMentionOnlyImport(message: unknown): boolean {
-  const meta = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
-  return meta?.cliImageMentionOnly === true;
-}
-
 function hasLocalImageMediaFacts(entry: ComparableHistoryMessage): boolean {
   if (entry.role !== "user") {
     return false;
   }
-  const meta = asOptionalRecord(asOptionalRecord(entry.message)?.["__openclaw"]);
-  const media = meta?.media;
-  if (!Array.isArray(media)) {
-    return false;
+  const message = asOptionalRecord(entry.message);
+  return message ? (readPersistedMediaFacts(message) ?? []).some(isImageMediaFact) : false;
+}
+
+function findLocalImageMediaMatch(
+  candidates: ComparableHistoryMessage[],
+  imported: ComparableHistoryMessage,
+): number {
+  if (!imported.hasCliImageMentions || imported.timestamp === undefined) {
+    return -1;
   }
-  // SAFETY: normalizeMediaFacts accepts loose MediaFactInput shapes and drops invalid entries.
-  return normalizeMediaFacts(media as readonly MediaFactInput[]).some(isImageMediaFact);
+  const importedTimestamp = imported.timestamp;
+  return candidates.findIndex(
+    (candidate) =>
+      candidate.timestamp !== undefined &&
+      Math.abs(candidate.timestamp - importedTimestamp) <= DEDUPE_TIMESTAMP_WINDOW_MS &&
+      (imported.text === undefined || candidate.text === imported.text),
+  );
 }
 
 function compareHistoryMessages(a: ComparableHistoryMessage, b: ComparableHistoryMessage): number {
@@ -218,7 +258,7 @@ export function mergeImportedChatHistoryMessages(params: {
   const exactExternalIdentityIndex = new Set<string>();
   const allMessageRoleTextIndex: RoleTextIndex = new Map();
   const identitylessRoleTextIndex: RoleTextIndex = new Map();
-  const localImageMediaTimestamps: number[] = [];
+  const localImageMediaCandidates: ComparableHistoryMessage[] = [];
   const indexEntry = (entry: ComparableHistoryMessage) => {
     if (entry.externalIdentityKey) {
       exactExternalIdentityIndex.add(entry.externalIdentityKey);
@@ -230,28 +270,27 @@ export function mergeImportedChatHistoryMessages(params: {
   for (const entry of merged) {
     indexEntry(entry);
     if (hasLocalImageMediaFacts(entry) && entry.timestamp !== undefined) {
-      localImageMediaTimestamps.push(entry.timestamp);
+      localImageMediaCandidates.push(entry);
     }
   }
   let nextOrder = merged.length;
   for (const message of params.importedMessages) {
     const imported = prepareComparableMessage(message, nextOrder);
-    const duplicate = imported.externalIdentityKey
-      ? exactExternalIdentityIndex.has(imported.externalIdentityKey) ||
-        hasRoleTextCandidate(identitylessRoleTextIndex, imported)
-      : hasRoleTextCandidate(allMessageRoleTextIndex, imported);
-    if (duplicate) {
+    if (
+      imported.externalIdentityKey &&
+      exactExternalIdentityIndex.has(imported.externalIdentityKey)
+    ) {
       continue;
     }
-    const importedTimestamp = imported.timestamp;
-    const localImageMediaIndex =
-      isCliImageMentionOnlyImport(message) && importedTimestamp !== undefined
-        ? localImageMediaTimestamps.findIndex(
-            (timestamp) => Math.abs(timestamp - importedTimestamp) <= DEDUPE_TIMESTAMP_WINDOW_MS,
-          )
-        : -1;
+    const localImageMediaIndex = findLocalImageMediaMatch(localImageMediaCandidates, imported);
     if (localImageMediaIndex !== -1) {
-      localImageMediaTimestamps.splice(localImageMediaIndex, 1);
+      localImageMediaCandidates.splice(localImageMediaIndex, 1);
+      continue;
+    }
+    const duplicate = imported.externalIdentityKey
+      ? hasRoleTextCandidate(identitylessRoleTextIndex, imported)
+      : hasRoleTextCandidate(allMessageRoleTextIndex, imported);
+    if (!imported.hasCliImageMentions && duplicate) {
       continue;
     }
     merged.push(imported);

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -487,7 +487,7 @@ describe("cli session history", () => {
     });
   });
 
-  it("strips CLI-injected image mention suffixes from imported user rows", async () => {
+  it("preserves CLI-injected image mentions until merge-time correlation", async () => {
     await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
       const workspaceMention = "@/Users/demo/workspace/.openclaw-cli-images/cafe01.png";
       const tmpMention = "@/tmp/openclaw/openclaw-cli-images/cafe02.jpg";
@@ -524,15 +524,16 @@ describe("cli session history", () => {
       const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
 
       expect(messages).toHaveLength(3);
-      expectFields(messages[0], { role: "user", content: "look at this" });
+      expectFields(messages[0], {
+        role: "user",
+        content: `look at this\n\n${workspaceMention}\n${tmpMention}`,
+      });
       expectFields(messages[1], { role: "user", content: workspaceMention });
-      expectFields(readRecord(messages[1])["__openclaw"], { cliImageMentionOnly: true });
-      expect(readRecord(messages[0])["__openclaw"]).not.toHaveProperty("cliImageMentionOnly");
       expectFields(messages[2], { role: "user", content: "check\n@/Users/demo/photos/pic.png" });
     });
   });
 
-  it("strips image mentions inside text blocks while preserving sibling blocks", async () => {
+  it("preserves image mentions inside text blocks before history merge", async () => {
     await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
       const mention = "@/Users/demo/workspace/.openclaw-cli-images/cafe03.png";
       await fs.writeFile(
@@ -570,13 +571,13 @@ describe("cli session history", () => {
 
       expect(messages).toHaveLength(2);
       const blocks = readRecord(messages[0]).content as Array<Record<string, unknown>>;
-      expect(blocks).toHaveLength(2);
-      expectFields(blocks[0], { type: "text", text: "caption" });
-      expectFields(blocks[1], { type: "image" });
+      expect(blocks).toHaveLength(3);
+      expectFields(blocks[0], { type: "text", text: `caption\n\n${mention}` });
+      expectFields(blocks[1], { type: "text", text: mention });
+      expectFields(blocks[2], { type: "image" });
       const mentionOnlyBlocks = readRecord(messages[1]).content as Array<Record<string, unknown>>;
       expect(mentionOnlyBlocks).toHaveLength(1);
       expectFields(mentionOnlyBlocks[0], { type: "text", text: mention });
-      expectFields(readRecord(messages[1])["__openclaw"], { cliImageMentionOnly: true });
     });
   });
 
@@ -600,6 +601,9 @@ describe("cli session history", () => {
           role: "user",
           content: "look at this",
           timestamp: Date.parse("2026-03-26T16:29:54.800Z"),
+          __openclaw: {
+            media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/cafe04.png" }],
+          },
         },
       ];
 
@@ -656,9 +660,9 @@ describe("cli session history", () => {
 
         expect(merged).toHaveLength(expectedLength);
         if (expectedLength === 1) {
-          expect(readRecord(merged[0])["__openclaw"]).not.toHaveProperty("cliImageMentionOnly");
+          expect(readRecord(readRecord(merged[0])["__openclaw"]).media).toHaveLength(1);
         } else {
-          expectFields(readRecord(merged[1])["__openclaw"], { cliImageMentionOnly: true });
+          expectFields(merged[1], { role: "user", content: mention });
         }
       });
     },
@@ -671,7 +675,11 @@ describe("cli session history", () => {
         role: "user",
         content: `@/Users/demo/workspace/.openclaw-cli-images/cafe0${index + 5}.png`,
         timestamp: timestamp + index * 60_000,
-        __openclaw: { externalId, cliImageMentionOnly: true },
+        __openclaw: {
+          importedFrom: "claude-cli",
+          cliSessionId: "session-1",
+          externalId,
+        },
       }),
     );
 
@@ -725,8 +733,59 @@ describe("cli session history", () => {
 
       expect(merged).toHaveLength(2);
       expectFields(merged[0], { role: "user", content: mention });
-      expectFields(readRecord(merged[0])["__openclaw"], { cliImageMentionOnly: true });
       expectFields(merged[1], { role: "assistant", content: "nice photo" });
+    });
+  });
+
+  it("retains captioned image mentions when no local media-bearing turn survives", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const content = "look at this\n\n@/Users/demo/workspace/.openclaw-cli-images/cafe07.png";
+      await fs.writeFile(
+        filePath,
+        [
+          {
+            type: "user",
+            uuid: "captioned-image-user",
+            timestamp: "2026-03-26T16:29:54.800Z",
+            message: { role: "user", content },
+          },
+          {
+            type: "assistant",
+            uuid: "assistant-1",
+            timestamp: "2026-03-26T16:29:55.800Z",
+            message: { role: "assistant", content: "nice photo" },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+        "utf-8",
+      );
+
+      const merged = augmentBoundClaudeHistory({
+        homeDir,
+        sessionId,
+        provider: "claude-cli",
+        localMessages: [],
+      });
+
+      expect(merged).toHaveLength(2);
+      expectFields(merged[0], { role: "user", content });
+      expectFields(merged[1], { role: "assistant", content: "nice photo" });
+
+      const captionOnlyLocal = augmentBoundClaudeHistory({
+        homeDir,
+        sessionId,
+        provider: "claude-cli",
+        localMessages: [
+          {
+            role: "user",
+            content: "look at this",
+            timestamp: Date.parse("2026-03-26T16:29:54.800Z"),
+          },
+        ],
+      });
+      expect(captionOnlyLocal).toHaveLength(3);
+      expect(captionOnlyLocal).toContainEqual(expect.objectContaining({ content }));
     });
   });
 

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -615,41 +615,54 @@ describe("cli session history", () => {
     });
   });
 
-  it("suppresses mention-only imported rows when a local media-bearing turn exists", async () => {
-    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
-      const mention = "@/Users/demo/workspace/.openclaw-cli-images/cafe05.png";
-      await fs.writeFile(
-        filePath,
-        JSON.stringify({
-          type: "user",
-          uuid: "image-only-user",
-          timestamp: "2026-03-26T16:29:54.800Z",
-          message: { role: "user", content: mention },
-        }),
-        "utf-8",
-      );
-      const localMessages = [
-        {
-          role: "user",
-          content: "",
-          timestamp: Date.parse("2026-03-26T16:29:54.500Z"),
-          __openclaw: {
-            media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/cafe05.png" }],
+  it.each([
+    ["timestamps correlate", Date.parse("2026-03-26T16:29:54.500Z"), "2026-03-26T16:29:54.800Z", 1],
+    ["local media timestamp is missing", undefined, "2026-03-26T16:29:54.800Z", 2],
+    ["imported timestamp is missing", Date.parse("2026-03-26T16:29:54.500Z"), undefined, 2],
+  ])(
+    "handles mention-only imported rows when %s",
+    async (_label, localTimestamp, importedTimestamp, expectedLength) => {
+      await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+        const mention = "@/Users/demo/workspace/.openclaw-cli-images/cafe05.png";
+        await fs.writeFile(
+          filePath,
+          JSON.stringify({
+            type: "user",
+            uuid: "image-only-user",
+            ...(importedTimestamp === undefined ? {} : { timestamp: importedTimestamp }),
+            message: { role: "user", content: mention },
+          }),
+          "utf-8",
+        );
+        const localMessages = [
+          {
+            role: "user",
+            content: "",
+            ...(localTimestamp === undefined ? {} : { timestamp: localTimestamp }),
+            __openclaw: {
+              media: [
+                { kind: "image", contentType: "image/png", path: "/media/inbound/cafe05.png" },
+              ],
+            },
           },
-        },
-      ];
+        ];
 
-      const merged = augmentBoundClaudeHistory({
-        homeDir,
-        sessionId,
-        provider: "claude-cli",
-        localMessages,
+        const merged = augmentBoundClaudeHistory({
+          homeDir,
+          sessionId,
+          provider: "claude-cli",
+          localMessages,
+        });
+
+        expect(merged).toHaveLength(expectedLength);
+        if (expectedLength === 1) {
+          expect(readRecord(merged[0])["__openclaw"]).not.toHaveProperty("cliImageMentionOnly");
+        } else {
+          expectFields(readRecord(merged[1])["__openclaw"], { cliImageMentionOnly: true });
+        }
       });
-
-      expect(merged).toHaveLength(1);
-      expect(readRecord(merged[0])["__openclaw"]).not.toHaveProperty("cliImageMentionOnly");
-    });
-  });
+    },
+  );
 
   it("retains mention-only imported rows when no local media-bearing turn survives", async () => {
     await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -736,6 +736,36 @@ describe("cli session history", () => {
     expect(merged).toEqual([localMessage, importedMessage]);
   });
 
+  it("retains legacy captioned imports near matching local image turns", () => {
+    const timestamp = Date.parse("2026-03-26T16:29:54.500Z");
+    const importedMessage = {
+      role: "user",
+      content: "look at this\n\n@/Users/demo/workspace/.openclaw-cli-images/cafe06.png",
+      timestamp: timestamp + 60_000,
+      __openclaw: {
+        importedFrom: "claude-cli",
+        cliSessionId: "session-1",
+        externalId: "legacy-captioned-image-user",
+      },
+    };
+    const localMessage = {
+      role: "user",
+      content: "look at this",
+      timestamp,
+      __openclaw: {
+        id: "local-captioned-image",
+        media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/cafe06.png" }],
+      },
+    };
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: [localMessage],
+      importedMessages: [importedMessage],
+    });
+
+    expect(merged).toEqual([localMessage, importedMessage]);
+  });
+
   it("matches same-caption image imports to their exact local turns", () => {
     const timestamp = Date.parse("2026-03-26T16:29:54.500Z");
     const localEntryId = "local-image-b";

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -523,9 +523,12 @@ describe("cli session history", () => {
 
       const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
 
-      expect(messages).toHaveLength(2);
+      expect(messages).toHaveLength(3);
       expectFields(messages[0], { role: "user", content: "look at this" });
-      expectFields(messages[1], { role: "user", content: "check\n@/Users/demo/photos/pic.png" });
+      expectFields(messages[1], { role: "user", content: workspaceMention });
+      expectFields(readRecord(messages[1])["__openclaw"], { cliImageMentionOnly: true });
+      expect(readRecord(messages[0])["__openclaw"]).not.toHaveProperty("cliImageMentionOnly");
+      expectFields(messages[2], { role: "user", content: "check\n@/Users/demo/photos/pic.png" });
     });
   });
 
@@ -565,11 +568,15 @@ describe("cli session history", () => {
 
       const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
 
-      expect(messages).toHaveLength(1);
+      expect(messages).toHaveLength(2);
       const blocks = readRecord(messages[0]).content as Array<Record<string, unknown>>;
       expect(blocks).toHaveLength(2);
       expectFields(blocks[0], { type: "text", text: "caption" });
       expectFields(blocks[1], { type: "image" });
+      const mentionOnlyBlocks = readRecord(messages[1]).content as Array<Record<string, unknown>>;
+      expect(mentionOnlyBlocks).toHaveLength(1);
+      expectFields(mentionOnlyBlocks[0], { type: "text", text: mention });
+      expectFields(readRecord(messages[1])["__openclaw"], { cliImageMentionOnly: true });
     });
   });
 
@@ -605,6 +612,80 @@ describe("cli session history", () => {
 
       expect(merged).toHaveLength(1);
       expectFields(merged[0], { role: "user", content: "look at this" });
+    });
+  });
+
+  it("suppresses mention-only imported rows when a local media-bearing turn exists", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const mention = "@/Users/demo/workspace/.openclaw-cli-images/cafe05.png";
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({
+          type: "user",
+          uuid: "image-only-user",
+          timestamp: "2026-03-26T16:29:54.800Z",
+          message: { role: "user", content: mention },
+        }),
+        "utf-8",
+      );
+      const localMessages = [
+        {
+          role: "user",
+          content: "",
+          timestamp: Date.parse("2026-03-26T16:29:54.500Z"),
+          __openclaw: {
+            media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/cafe05.png" }],
+          },
+        },
+      ];
+
+      const merged = augmentBoundClaudeHistory({
+        homeDir,
+        sessionId,
+        provider: "claude-cli",
+        localMessages,
+      });
+
+      expect(merged).toHaveLength(1);
+      expect(readRecord(merged[0])["__openclaw"]).not.toHaveProperty("cliImageMentionOnly");
+    });
+  });
+
+  it("retains mention-only imported rows when no local media-bearing turn survives", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const mention = "@/Users/demo/workspace/.openclaw-cli-images/cafe06.png";
+      await fs.writeFile(
+        filePath,
+        [
+          {
+            type: "user",
+            uuid: "image-only-user",
+            timestamp: "2026-03-26T16:29:54.800Z",
+            message: { role: "user", content: mention },
+          },
+          {
+            type: "assistant",
+            uuid: "assistant-1",
+            timestamp: "2026-03-26T16:29:55.800Z",
+            message: { role: "assistant", content: "nice photo" },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+        "utf-8",
+      );
+
+      const merged = augmentBoundClaudeHistory({
+        homeDir,
+        sessionId,
+        provider: "claude-cli",
+        localMessages: [],
+      });
+
+      expect(merged).toHaveLength(2);
+      expectFields(merged[0], { role: "user", content: mention });
+      expectFields(readRecord(merged[0])["__openclaw"], { cliImageMentionOnly: true });
+      expectFields(merged[1], { role: "assistant", content: "nice photo" });
     });
   });
 

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -487,6 +487,127 @@ describe("cli session history", () => {
     });
   });
 
+  it("strips CLI-injected image mention suffixes from imported user rows", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const workspaceMention = "@/Users/demo/workspace/.openclaw-cli-images/cafe01.png";
+      const tmpMention = "@/tmp/openclaw/openclaw-cli-images/cafe02.jpg";
+      await fs.writeFile(
+        filePath,
+        [
+          {
+            type: "user",
+            uuid: "image-user",
+            timestamp: "2026-03-26T16:29:54.800Z",
+            message: {
+              role: "user",
+              content: `look at this\n\n${workspaceMention}\n${tmpMention}`,
+            },
+          },
+          {
+            type: "user",
+            uuid: "image-only-user",
+            timestamp: "2026-03-26T16:29:55.800Z",
+            message: { role: "user", content: workspaceMention },
+          },
+          {
+            type: "user",
+            uuid: "plain-mention-user",
+            timestamp: "2026-03-26T16:29:56.800Z",
+            message: { role: "user", content: "check\n@/Users/demo/photos/pic.png" },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
+
+      expect(messages).toHaveLength(2);
+      expectFields(messages[0], { role: "user", content: "look at this" });
+      expectFields(messages[1], { role: "user", content: "check\n@/Users/demo/photos/pic.png" });
+    });
+  });
+
+  it("strips image mentions inside text blocks while preserving sibling blocks", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const mention = "@/Users/demo/workspace/.openclaw-cli-images/cafe03.png";
+      await fs.writeFile(
+        filePath,
+        [
+          {
+            type: "user",
+            uuid: "block-user",
+            timestamp: "2026-03-26T16:29:54.800Z",
+            message: {
+              role: "user",
+              content: [
+                { type: "text", text: `caption\n\n${mention}` },
+                { type: "text", text: mention },
+                { type: "image", source: { type: "base64", media_type: "image/png", data: "aa" } },
+              ],
+            },
+          },
+          {
+            type: "user",
+            uuid: "mention-only-block-user",
+            timestamp: "2026-03-26T16:29:55.800Z",
+            message: {
+              role: "user",
+              content: [{ type: "text", text: mention }],
+            },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
+
+      expect(messages).toHaveLength(1);
+      const blocks = readRecord(messages[0]).content as Array<Record<string, unknown>>;
+      expect(blocks).toHaveLength(2);
+      expectFields(blocks[0], { type: "text", text: "caption" });
+      expectFields(blocks[1], { type: "image" });
+    });
+  });
+
+  it("dedupes imported user rows whose text differs only by image mentions", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({
+          type: "user",
+          uuid: "image-user",
+          timestamp: "2026-03-26T16:29:54.800Z",
+          message: {
+            role: "user",
+            content: "look at this\n\n@/Users/demo/workspace/.openclaw-cli-images/cafe04.png",
+          },
+        }),
+        "utf-8",
+      );
+      const localMessages = [
+        {
+          role: "user",
+          content: "look at this",
+          timestamp: Date.parse("2026-03-26T16:29:54.800Z"),
+        },
+      ];
+
+      const merged = augmentBoundClaudeHistory({
+        homeDir,
+        sessionId,
+        provider: "claude-cli",
+        localMessages,
+      });
+
+      expect(merged).toHaveLength(1);
+      expectFields(merged[0], { role: "user", content: "look at this" });
+    });
+  });
+
   it("recovers the current user text from legacy reseed envelopes", async () => {
     await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
       const reseedPrompt = buildLegacyReseedPrompt();

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -664,6 +664,34 @@ describe("cli session history", () => {
     },
   );
 
+  it("consumes each local media-bearing turn only once", () => {
+    const timestamp = Date.parse("2026-03-26T16:29:54.500Z");
+    const importedMessages = ["first-image-only-user", "second-image-only-user"].map(
+      (externalId, index) => ({
+        role: "user",
+        content: `@/Users/demo/workspace/.openclaw-cli-images/cafe0${index + 5}.png`,
+        timestamp: timestamp + index * 60_000,
+        __openclaw: { externalId, cliImageMentionOnly: true },
+      }),
+    );
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: [
+        {
+          role: "user",
+          content: "",
+          timestamp,
+          __openclaw: {
+            media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/cafe05.png" }],
+          },
+        },
+      ],
+      importedMessages,
+    });
+
+    expect(merged).toEqual([expect.any(Object), importedMessages[1]]);
+  });
+
   it("retains mention-only imported rows when no local media-bearing turn survives", async () => {
     await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
       const mention = "@/Users/demo/workspace/.openclaw-cli-images/cafe06.png";

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -5,6 +5,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  formatCliImageTurnContext,
+  hashCliImageTurnEntryId,
+} from "../agents/cli-image-turn-correlation.js";
 import { hashCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
 import type { AgentMessage } from "../agents/runtime/index.js";
 import { redactTranscriptMessage } from "../agents/transcript-redact.js";
@@ -583,6 +587,7 @@ describe("cli session history", () => {
 
   it("dedupes imported user rows whose text differs only by image mentions", async () => {
     await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const localEntryId = "local-image-user";
       await fs.writeFile(
         filePath,
         JSON.stringify({
@@ -591,7 +596,7 @@ describe("cli session history", () => {
           timestamp: "2026-03-26T16:29:54.800Z",
           message: {
             role: "user",
-            content: "look at this\n\n@/Users/demo/workspace/.openclaw-cli-images/cafe04.png",
+            content: `look at this\n\n${formatCliImageTurnContext(hashCliImageTurnEntryId(localEntryId))}\n\n@/Users/demo/workspace/.openclaw-cli-images/cafe04.png`,
           },
         }),
         "utf-8",
@@ -602,6 +607,7 @@ describe("cli session history", () => {
           content: "look at this",
           timestamp: Date.parse("2026-03-26T16:29:54.800Z"),
           __openclaw: {
+            id: localEntryId,
             media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/cafe04.png" }],
           },
         },
@@ -620,13 +626,14 @@ describe("cli session history", () => {
   });
 
   it.each([
-    ["timestamps correlate", Date.parse("2026-03-26T16:29:54.500Z"), "2026-03-26T16:29:54.800Z", 1],
-    ["local media timestamp is missing", undefined, "2026-03-26T16:29:54.800Z", 2],
-    ["imported timestamp is missing", Date.parse("2026-03-26T16:29:54.500Z"), undefined, 2],
+    ["timestamps correlate", Date.parse("2026-03-26T16:29:54.500Z"), "2026-03-26T16:29:54.800Z"],
+    ["local media timestamp is missing", undefined, "2026-03-26T16:29:54.800Z"],
+    ["imported timestamp is missing", Date.parse("2026-03-26T16:29:54.500Z"), undefined],
   ])(
-    "handles captioned imported rows when %s",
-    async (_label, localTimestamp, importedTimestamp, expectedLength) => {
+    "dedupes exactly correlated captioned rows when %s",
+    async (_label, localTimestamp, importedTimestamp) => {
       await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+        const localEntryId = "local-captioned-image";
         const mention = "@/Users/demo/workspace/.openclaw-cli-images/cafe05.png";
         await fs.writeFile(
           filePath,
@@ -634,7 +641,10 @@ describe("cli session history", () => {
             type: "user",
             uuid: "image-only-user",
             ...(importedTimestamp === undefined ? {} : { timestamp: importedTimestamp }),
-            message: { role: "user", content: `look at this\n\n${mention}` },
+            message: {
+              role: "user",
+              content: `look at this\n\n${formatCliImageTurnContext(hashCliImageTurnEntryId(localEntryId))}\n\n${mention}`,
+            },
           }),
           "utf-8",
         );
@@ -644,6 +654,7 @@ describe("cli session history", () => {
             content: "look at this",
             ...(localTimestamp === undefined ? {} : { timestamp: localTimestamp }),
             __openclaw: {
+              id: localEntryId,
               media: [
                 { kind: "image", contentType: "image/png", path: "/media/inbound/cafe05.png" },
               ],
@@ -658,21 +669,18 @@ describe("cli session history", () => {
           localMessages,
         });
 
-        expect(merged).toHaveLength(expectedLength);
-        if (expectedLength === 1) {
-          expect(readRecord(readRecord(merged[0])["__openclaw"]).media).toHaveLength(1);
-        } else {
-          expectFields(merged[1], { role: "user", content: `look at this\n\n${mention}` });
-        }
+        expect(merged).toHaveLength(1);
+        expect(readRecord(readRecord(merged[0])["__openclaw"]).media).toHaveLength(1);
       });
     },
   );
 
   it("consumes each local media-bearing turn only once", () => {
     const timestamp = Date.parse("2026-03-26T16:29:54.500Z");
+    const localEntryId = "local-repeated-image";
     const importedMessages = ["first-image-user", "second-image-user"].map((externalId, index) => ({
       role: "user",
-      content: `look at this\n\n@/Users/demo/workspace/.openclaw-cli-images/cafe0${index + 5}.png`,
+      content: `look at this\n\n${formatCliImageTurnContext(hashCliImageTurnEntryId(localEntryId))}\n\n@/Users/demo/workspace/.openclaw-cli-images/cafe0${index + 5}.png`,
       timestamp: timestamp + index * 60_000,
       __openclaw: {
         importedFrom: "claude-cli",
@@ -688,6 +696,7 @@ describe("cli session history", () => {
           content: "look at this",
           timestamp,
           __openclaw: {
+            id: localEntryId,
             media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/cafe05.png" }],
           },
         },
@@ -725,6 +734,77 @@ describe("cli session history", () => {
     });
 
     expect(merged).toEqual([localMessage, importedMessage]);
+  });
+
+  it("matches same-caption image imports to their exact local turns", () => {
+    const timestamp = Date.parse("2026-03-26T16:29:54.500Z");
+    const localEntryId = "local-image-b";
+    const orphanedImport = {
+      role: "user",
+      content: `look at this\n\n${formatCliImageTurnContext(hashCliImageTurnEntryId("local-image-a"))}\n\n@/tmp/openclaw/openclaw-cli-images/${"a".repeat(64)}.png`,
+      timestamp,
+      __openclaw: {
+        importedFrom: "claude-cli",
+        cliSessionId: "session-1",
+        externalId: "image-a",
+      },
+    };
+    const matchedImport = {
+      role: "user",
+      content: `look at this\n\n${formatCliImageTurnContext(hashCliImageTurnEntryId(localEntryId))}\n\n@/tmp/openclaw/openclaw-cli-images/${"b".repeat(64)}.png`,
+      timestamp: timestamp + 60_000,
+      __openclaw: {
+        importedFrom: "claude-cli",
+        cliSessionId: "session-1",
+        externalId: "image-b",
+      },
+    };
+    const localMessage = {
+      role: "user",
+      content: "look at this",
+      timestamp: timestamp + 60_000,
+      __openclaw: {
+        id: localEntryId,
+        media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/b.png" }],
+      },
+    };
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: [localMessage],
+      importedMessages: [orphanedImport, matchedImport],
+    });
+
+    expect(merged).toEqual([orphanedImport, localMessage]);
+  });
+
+  it("dedupes cache-only imports against their exact local turns", () => {
+    const localEntryId = "local-image-only";
+    const localMessage = {
+      role: "user",
+      content: "",
+      timestamp: Date.parse("2026-03-26T16:29:54.500Z"),
+      __openclaw: {
+        id: localEntryId,
+        media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/a.png" }],
+      },
+    };
+    const importedMessage = {
+      role: "user",
+      content: `${formatCliImageTurnContext(hashCliImageTurnEntryId(localEntryId))}\n\n@/tmp/openclaw/openclaw-cli-images/${"a".repeat(64)}.png`,
+      timestamp: Date.parse("2026-03-26T16:29:54.800Z"),
+      __openclaw: {
+        importedFrom: "claude-cli",
+        cliSessionId: "session-1",
+        externalId: "image-only",
+      },
+    };
+
+    expect(
+      mergeImportedChatHistoryMessages({
+        localMessages: [localMessage],
+        importedMessages: [importedMessage],
+      }),
+    ).toEqual([localMessage]);
   });
 
   it("retains mention-only imported rows when no local media-bearing turn survives", async () => {
@@ -767,6 +847,7 @@ describe("cli session history", () => {
   it("retains captioned image mentions when no local media-bearing turn survives", async () => {
     await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
       const content = "look at this\n\n@/Users/demo/workspace/.openclaw-cli-images/cafe07.png";
+      const importedContent = `look at this\n\n${formatCliImageTurnContext(hashCliImageTurnEntryId("missing-local-turn"))}\n\n@/Users/demo/workspace/.openclaw-cli-images/cafe07.png`;
       await fs.writeFile(
         filePath,
         [
@@ -774,7 +855,7 @@ describe("cli session history", () => {
             type: "user",
             uuid: "captioned-image-user",
             timestamp: "2026-03-26T16:29:54.800Z",
-            message: { role: "user", content },
+            message: { role: "user", content: importedContent },
           },
           {
             type: "assistant",

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -624,7 +624,7 @@ describe("cli session history", () => {
     ["local media timestamp is missing", undefined, "2026-03-26T16:29:54.800Z", 2],
     ["imported timestamp is missing", Date.parse("2026-03-26T16:29:54.500Z"), undefined, 2],
   ])(
-    "handles mention-only imported rows when %s",
+    "handles captioned imported rows when %s",
     async (_label, localTimestamp, importedTimestamp, expectedLength) => {
       await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
         const mention = "@/Users/demo/workspace/.openclaw-cli-images/cafe05.png";
@@ -634,14 +634,14 @@ describe("cli session history", () => {
             type: "user",
             uuid: "image-only-user",
             ...(importedTimestamp === undefined ? {} : { timestamp: importedTimestamp }),
-            message: { role: "user", content: mention },
+            message: { role: "user", content: `look at this\n\n${mention}` },
           }),
           "utf-8",
         );
         const localMessages = [
           {
             role: "user",
-            content: "",
+            content: "look at this",
             ...(localTimestamp === undefined ? {} : { timestamp: localTimestamp }),
             __openclaw: {
               media: [
@@ -662,7 +662,7 @@ describe("cli session history", () => {
         if (expectedLength === 1) {
           expect(readRecord(readRecord(merged[0])["__openclaw"]).media).toHaveLength(1);
         } else {
-          expectFields(merged[1], { role: "user", content: mention });
+          expectFields(merged[1], { role: "user", content: `look at this\n\n${mention}` });
         }
       });
     },
@@ -670,24 +670,22 @@ describe("cli session history", () => {
 
   it("consumes each local media-bearing turn only once", () => {
     const timestamp = Date.parse("2026-03-26T16:29:54.500Z");
-    const importedMessages = ["first-image-only-user", "second-image-only-user"].map(
-      (externalId, index) => ({
-        role: "user",
-        content: `@/Users/demo/workspace/.openclaw-cli-images/cafe0${index + 5}.png`,
-        timestamp: timestamp + index * 60_000,
-        __openclaw: {
-          importedFrom: "claude-cli",
-          cliSessionId: "session-1",
-          externalId,
-        },
-      }),
-    );
+    const importedMessages = ["first-image-user", "second-image-user"].map((externalId, index) => ({
+      role: "user",
+      content: `look at this\n\n@/Users/demo/workspace/.openclaw-cli-images/cafe0${index + 5}.png`,
+      timestamp: timestamp + index * 60_000,
+      __openclaw: {
+        importedFrom: "claude-cli",
+        cliSessionId: "session-1",
+        externalId,
+      },
+    }));
 
     const merged = mergeImportedChatHistoryMessages({
       localMessages: [
         {
           role: "user",
-          content: "",
+          content: "look at this",
           timestamp,
           __openclaw: {
             media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/cafe05.png" }],
@@ -698,6 +696,35 @@ describe("cli session history", () => {
     });
 
     expect(merged).toEqual([expect.any(Object), importedMessages[1]]);
+  });
+
+  it("retains mention-only imports near unrelated local image turns", () => {
+    const timestamp = Date.parse("2026-03-26T16:29:54.500Z");
+    const importedMessage = {
+      role: "user",
+      content: "@/Users/demo/workspace/.openclaw-cli-images/cafe06.png",
+      timestamp: timestamp + 60_000,
+      __openclaw: {
+        importedFrom: "claude-cli",
+        cliSessionId: "session-1",
+        externalId: "orphaned-image-user",
+      },
+    };
+    const localMessage = {
+      role: "user",
+      content: "",
+      timestamp,
+      __openclaw: {
+        media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/other.png" }],
+      },
+    };
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: [localMessage],
+      importedMessages: [importedMessage],
+    });
+
+    expect(merged).toEqual([localMessage, importedMessage]);
   });
 
   it("retains mention-only imported rows when no local media-bearing turn survives", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending images to a Claude CLI-backed session would see the image appear in WebChat/Control UI chat history as a raw path link (for example `@/…/.openclaw-cli-images/<sha>.png`) instead of the inline thumbnail preview that API-backed models show, plus a duplicate user row for the same turn.

## Why This Change Was Made

The CLI runner cannot pass structured image blocks to the Claude CLI, so it appends `@<image cache path>` mention lines to the prompt it hands the CLI. Claude Code records that mutated prompt as its user message, and the transcript importer merges it back into chat history, where it does not text-dedupe against OpenClaw's local media-bearing user row.

For new image turns, the runner now adds an opaque correlation key derived from the persisted local transcript entry ID. The Claude transcript importer records that key, and history merge suppresses the imported cache-path row only when it exactly matches the local media-bearing turn. Genuine user-typed `@path` mentions outside the cache directories are untouched. Ambiguous rows, malformed markers, repeated candidates, and imported rows whose local counterpart no longer exists all fail open and remain visible.

Pre-marker Claude transcript rows cannot be correlated safely. They are intentionally retained, even when caption and timestamp resemble a local image turn, because inference could suppress a distinct user turn. This is a prospective exact-correlation fix rather than a migration or self-healing policy for legacy rows.

## User Impact

New images sent to Claude CLI-backed conversations render as inline previews in chat history without a duplicate raw cache-path user row. Sessions whose local transcript was reset or lost keep their imported image turns visible. Existing pre-marker conversations retain their legacy raw-path rows until a separate loss-safe legacy policy exists.

## Evidence

### Live before/after on an isolated dev gateway

Procedure: isolated profile (`--profile evd`, own state dir, port 23117, never the operator gateway), model `claude-cli/claude-sonnet-5`. One real image turn sent through `chat.send` (the same RPC the composer uses); the Claude CLI ran, wrote the content-addressed cache image, recorded the `@path`-mutated prompt in its project JSONL, and the session got its `claude-cli` binding.

**Before** — gateway built from the PR's merge base (`116f364b505`): the imported CLI transcript row fails dedupe and renders as a duplicate user bubble with the raw cache filename link:

![before](https://github.com/user-attachments/assets/881fb3b6-66ed-40d6-8cf0-6c0a5bb56e60)

**Target rendering** — the correlated row is removed and the local media-bearing row renders as one user bubble with the inline thumbnail; the assistant reply remains intact:

![after](https://github.com/user-attachments/assets/14ec25fc-ae98-49ea-a4bb-f85ec951a8ad)

These captures predate the final exact-correlation refinement. They demonstrate the original defect and target rendering, while current-head automated coverage proves marker-bearing suppression and intentional legacy-row retention. They do not claim that pre-marker histories self-heal.

### Tests and checks

- `src/gateway/cli-session-history.test.ts` covers exact producer-marker correlation, same-caption disambiguation, one-time candidate consumption, malformed markers, orphan retention, mention stripping in string/text-block content, and legacy captioned/cache-only rows retained beside nearby local media-bearing turns.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/cli-session-history.test.ts` — 198 passed across the gateway core/server/client projects.
- `node scripts/run-tsgo-core-test-shards.mjs src` — clean; `oxlint` and `oxfmt --check` clean on changed files.
- Mandatory uncommitted-diff autoreview after the legacy-retention test addition: clean, no accepted or actionable findings.

