### PR TITLE
fix(openshell): allow managed host gateway ranges in E2E

### DIFF
--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -853,7 +853,6 @@ Native dependency policy:
   - `OPENCLAW_E2E_OPENSHELL=1` to enable the test when running the broader e2e suite manually
   - `OPENCLAW_E2E_OPENSHELL_COMMAND=/path/to/openshell` to point at a non-default CLI binary or wrapper script
   - `OPENCLAW_E2E_OPENSHELL_CONFIG_HOME=/path/to/config` to expose the registered gateway config to the isolated test
-  - `OPENCLAW_E2E_OPENSHELL_HOST_IP=172.18.0.1` to override the sandbox-visible `host.openshell.internal` address used by the network policy fixture; Docker Desktop may resolve this differently from the bridge gateway
 
 ### Live (real providers + real models)
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -854,6 +854,7 @@ Native dependency policy:
   - `OPENCLAW_E2E_OPENSHELL=1` to enable the test when running the broader e2e suite manually
   - `OPENCLAW_E2E_OPENSHELL_COMMAND=/path/to/openshell` to point at a non-default CLI binary or wrapper script
   - `OPENCLAW_E2E_OPENSHELL_CONFIG_HOME=/path/to/config` to expose the registered gateway config to the isolated test
+  - `OPENCLAW_E2E_OPENSHELL_HOST_IP=172.18.0.1` to replace the host policy fixture's default ranges with one explicit Docker gateway address and its existing `/32` suffix
 
 ### Live (real providers + real models)
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -848,7 +848,8 @@ Native dependency policy:
   - Opt-in only; not part of the default `pnpm test:e2e` run
   - Requires a local `openshell` CLI plus a working Docker daemon
   - Requires an active local OpenShell gateway and its config source
-  - Uses isolated `HOME` / `XDG_CONFIG_HOME`, then destroys the test sandbox
+  - Uses isolated `HOME` / `XDG_CONFIG_HOME`, then waits for durable sandbox absence before deleting the test workspace
+  - Reports cleanup failures, including failed inventory queries; it does not retry database errors
 - Useful overrides:
   - `OPENCLAW_E2E_OPENSHELL=1` to enable the test when running the broader e2e suite manually
   - `OPENCLAW_E2E_OPENSHELL_COMMAND=/path/to/openshell` to point at a non-default CLI binary or wrapper script

--- a/extensions/openshell/src/backend.e2e.test-support.test.ts
+++ b/extensions/openshell/src/backend.e2e.test-support.test.ts
@@ -1,5 +1,8 @@
-import { expect, it } from "vitest";
-import { runCommand } from "./backend.e2e.test-support.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { cleanupOpenShellWorkspace, runCommand } from "./backend.e2e.test-support.js";
 
 it.runIf(process.platform !== "win32")("reports a signal-killed probe as failure", async () => {
   const result = await runCommand({
@@ -9,4 +12,197 @@ it.runIf(process.platform !== "win32")("reports a signal-killed probe as failure
     timeoutMs: 10_000,
   });
   expect(result.code).not.toBe(0);
+});
+
+async function createCleanupFixture(
+  options: { mode?: string; inventory?: string; names?: string[] } = {},
+) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openshell-cleanup-test-"));
+  const stateFile = path.join(root, "state.json");
+  const command = path.join(root, "openshell");
+  const initial = {
+    names: ["first", "second"],
+    pending: "",
+    observations: 0,
+    listCalls: 0,
+    deletes: [] as string[],
+    workspaceDeletes: 0,
+    ...options,
+  };
+  await fs.writeFile(stateFile, JSON.stringify(initial));
+  await fs.writeFile(
+    command,
+    `#!${process.execPath}
+const fs = require("node:fs");
+const stateFile = process.env.FIXTURE_STATE;
+const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+const args = process.argv.slice(2);
+let failure;
+if (args[0] === "workspace") {
+  state.workspaceDeletes++;
+  if (state.names.length) failure = "workspace still contains durable sandbox records";
+  if (state.mode === "workspace-failure") failure = "workspace cleanup failed";
+} else if (args[3] === "delete") {
+  const name = args[4];
+  state.deletes.push(name);
+  state.pending = name;
+  state.observations = 0;
+  if (state.mode === "delete-failure" && name === "first") failure = "delete failed";
+} else if (args[3] === "list") {
+  state.listCalls++;
+  if (state.pending && ++state.observations >= 2 && state.mode !== "stuck") {
+    state.names = state.names.filter(name => name !== state.pending);
+    state.pending = "";
+  }
+  if (state.mode === "read-failure" && state.deletes.length) failure = "database is locked";
+  const limit = Number(args[args.indexOf("--limit") + 1]);
+  console.log(state.inventory ?? JSON.stringify(state.names.slice(0, limit).map(name => ({ name }))));
+} else {
+  throw new Error("unexpected fixture command");
+}
+fs.writeFileSync(stateFile + ".next", JSON.stringify(state));
+fs.renameSync(stateFile + ".next", stateFile);
+if (failure) {
+  console.error(failure);
+  process.exit(1);
+}
+if (state.mode === "slow-delete" && args[3] === "delete") {
+  const timer = setInterval(() => {
+    if (fs.existsSync(stateFile + ".release")) clearInterval(timer);
+  }, 10);
+}
+`,
+    { mode: 0o755 },
+  );
+  return {
+    cleanup: () =>
+      cleanupOpenShellWorkspace({
+        command,
+        env: { ...process.env, FIXTURE_STATE: stateFile },
+        workspace: "isolated",
+        sandboxNames: ["first", "second", "never-created"],
+      }),
+    read: async () => JSON.parse(await fs.readFile(stateFile, "utf8")) as typeof initial,
+    release: () => fs.writeFile(stateFile + ".release", ""),
+    dispose: () => fs.rm(root, { recursive: true, force: true }),
+  };
+}
+
+describe.runIf(process.platform !== "win32")("OpenShell workspace cleanup", () => {
+  it("waits for durable sandbox deletion before deleting its workspace", async () => {
+    const fixture = await createCleanupFixture();
+    try {
+      await fixture.cleanup();
+      expect(await fixture.read()).toMatchObject({
+        names: [],
+        deletes: ["first", "second"],
+        workspaceDeletes: 1,
+      });
+    } finally {
+      await fixture.dispose();
+    }
+  });
+
+  it("deletes an empty workspace without deleting never-created sandboxes", async () => {
+    const fixture = await createCleanupFixture({ names: [] });
+    try {
+      await fixture.cleanup();
+      expect(await fixture.read()).toMatchObject({
+        listCalls: 1,
+        deletes: [],
+        workspaceDeletes: 1,
+      });
+    } finally {
+      await fixture.dispose();
+    }
+  });
+
+  it.each([
+    ["non-JSON", "not json"],
+    ["non-array", "{}"],
+    ["null row", "[null]"],
+    ["missing name", "[{}]"],
+    ["empty name", '[{"name":""}]'],
+    ["unexpected sandbox", '[{"name":"someone-else"}]'],
+    ["duplicate sandbox", '[{"name":"first"},{"name":"first"}]'],
+    ["full page", '[{"name":"first"},{"name":"second"},{"name":"never-created"},{"name":"extra"}]'],
+  ])("rejects %s inventory without deleting resources", async (_label, inventory) => {
+    const fixture = await createCleanupFixture({ inventory });
+    try {
+      await expect(fixture.cleanup()).rejects.toThrow();
+      expect(await fixture.read()).toMatchObject({
+        listCalls: 1,
+        deletes: [],
+        workspaceDeletes: 0,
+      });
+    } finally {
+      await fixture.dispose();
+    }
+  });
+
+  it.each([
+    ["read-failure", "database is locked", 2],
+    ["delete-failure", "delete failed", 1],
+  ])(
+    "retains %s while attempting remaining owned deletes once",
+    async (mode, message, listCalls) => {
+      const fixture = await createCleanupFixture({ mode });
+      try {
+        const failure = await fixture.cleanup().catch((error: unknown) => error);
+        expect(failure).toBeInstanceOf(AggregateError);
+        expect((failure as AggregateError).errors).toEqual([
+          expect.objectContaining({ message: expect.stringContaining(message) }),
+        ]);
+        expect(await fixture.read()).toMatchObject({
+          listCalls,
+          deletes: ["first", "second"],
+          workspaceDeletes: 0,
+        });
+      } finally {
+        await fixture.dispose();
+      }
+    },
+  );
+
+  it.each(["slow-delete", "stuck"])("bounds %s by the original cleanup deadline", async (mode) => {
+    const fixture = await createCleanupFixture({ mode });
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const result = fixture.cleanup().catch((error: unknown) => error);
+    try {
+      await vi.waitFor(async () => {
+        const state = await fixture.read();
+        expect(mode === "slow-delete" ? state.deletes.length : state.observations).toBeGreaterThan(
+          0,
+        );
+      });
+      const { listCalls } = await fixture.read();
+      vi.advanceTimersByTime(120_000);
+      await fixture.release();
+      const failure = await result;
+      expect(failure).toBeInstanceOf(AggregateError);
+      expect((failure as AggregateError).errors).toContainEqual(
+        expect.objectContaining({ message: expect.stringContaining("120 seconds") }),
+      );
+      expect(await fixture.read()).toMatchObject({
+        listCalls,
+        deletes: ["first"],
+        workspaceDeletes: 0,
+      });
+    } finally {
+      await fixture.release();
+      await result;
+      vi.useRealTimers();
+      await fixture.dispose();
+    }
+  });
+
+  it("keeps workspace deletion failure visible after sandbox absence", async () => {
+    const fixture = await createCleanupFixture({ mode: "workspace-failure" });
+    try {
+      await expect(fixture.cleanup()).rejects.toThrow("workspace cleanup failed");
+      expect(await fixture.read()).toMatchObject({ names: [], workspaceDeletes: 1 });
+    } finally {
+      await fixture.dispose();
+    }
+  });
 });

--- a/extensions/openshell/src/backend.e2e.test-support.test.ts
+++ b/extensions/openshell/src/backend.e2e.test-support.test.ts
@@ -2,7 +2,42 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { cleanupOpenShellWorkspace, runCommand } from "./backend.e2e.test-support.js";
+import { parse } from "yaml";
+import {
+  buildOpenShellPolicyYaml,
+  cleanupOpenShellWorkspace,
+  runCommand,
+} from "./backend.e2e.test-support.js";
+
+describe("OpenShell host policy", () => {
+  const defaults = ["10.0.0.0/8", "172.0.0.0/8", "192.168.0.0/16", "fc00::/7"];
+  it.each([
+    { name: "default", hostIp: undefined, allowedIps: defaults },
+    { name: "blank override", hostIp: "  ", allowedIps: defaults },
+    { name: "custom IPv4 override", hostIp: " 198.51.100.42 ", allowedIps: ["198.51.100.42/32"] },
+    { name: "shipped IPv6 override", hostIp: "2001:db8::1", allowedIps: ["2001:db8::1/32"] },
+  ])("preserves $name without changing the endpoint or binary", ({ hostIp, allowedIps }) => {
+    const params = { port: 17680, binaryPath: "/usr/bin/curl", hostIp };
+    const policy: unknown = parse(buildOpenShellPolicyYaml(params));
+    expect(policy).toMatchObject({
+      network_policies: {
+        host_echo: {
+          endpoints: [
+            {
+              host: "host.openshell.internal",
+              port: 17680,
+              protocol: "rest",
+              enforcement: "enforce",
+              access: "full",
+              allowed_ips: allowedIps,
+            },
+          ],
+          binaries: [{ path: "/usr/bin/curl" }],
+        },
+      },
+    });
+  });
+});
 
 it.runIf(process.platform !== "win32")("reports a signal-killed probe as failure", async () => {
   const result = await runCommand({

--- a/extensions/openshell/src/backend.e2e.test-support.test.ts
+++ b/extensions/openshell/src/backend.e2e.test-support.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -101,10 +102,9 @@ if (failure) {
   console.error(failure);
   process.exit(1);
 }
-if (state.mode === "slow-delete" && args[3] === "delete") {
-  const timer = setInterval(() => {
-    if (fs.existsSync(stateFile + ".release")) clearInterval(timer);
-  }, 10);
+if ((state.mode === "slow-delete" && args[3] === "delete") ||
+    (state.mode === "stuck" && state.observations > 0)) {
+  fs.writeFileSync(stateFile + ".expired", "");
 }
 `,
     { mode: 0o755 },
@@ -118,7 +118,7 @@ if (state.mode === "slow-delete" && args[3] === "delete") {
         sandboxNames: ["first", "second", "never-created"],
       }),
     read: async () => JSON.parse(await fs.readFile(stateFile, "utf8")) as typeof initial,
-    release: () => fs.writeFile(stateFile + ".release", ""),
+    deadlineExpired: () => existsSync(stateFile + ".expired"),
     dispose: () => fs.rm(root, { recursive: true, force: true }),
   };
 }
@@ -201,32 +201,26 @@ describe.runIf(process.platform !== "win32")("OpenShell workspace cleanup", () =
 
   it.each(["slow-delete", "stuck"])("bounds %s by the original cleanup deadline", async (mode) => {
     const fixture = await createCleanupFixture({ mode });
-    vi.useFakeTimers({ toFake: ["Date"] });
-    const result = fixture.cleanup().catch((error: unknown) => error);
+    const startedAt = Date.now();
+    // Advance at the real child operation boundary, not a wall-clock poll that
+    // can expire before a loaded host starts the command.
+    const clock = vi
+      .spyOn(Date, "now")
+      .mockImplementation(() => startedAt + (fixture.deadlineExpired() ? 120_000 : 0));
     try {
-      await vi.waitFor(async () => {
-        const state = await fixture.read();
-        expect(mode === "slow-delete" ? state.deletes.length : state.observations).toBeGreaterThan(
-          0,
-        );
-      });
-      const { listCalls } = await fixture.read();
-      vi.advanceTimersByTime(120_000);
-      await fixture.release();
-      const failure = await result;
+      const failure = await fixture.cleanup().catch((error: unknown) => error);
       expect(failure).toBeInstanceOf(AggregateError);
       expect((failure as AggregateError).errors).toContainEqual(
         expect.objectContaining({ message: expect.stringContaining("120 seconds") }),
       );
       expect(await fixture.read()).toMatchObject({
-        listCalls,
+        listCalls: mode === "slow-delete" ? 1 : 2,
         deletes: ["first"],
+        observations: mode === "slow-delete" ? 0 : 1,
         workspaceDeletes: 0,
       });
     } finally {
-      await fixture.release();
-      await result;
-      vi.useRealTimers();
+      clock.mockRestore();
       await fixture.dispose();
     }
   });

--- a/extensions/openshell/src/backend.e2e.test-support.ts
+++ b/extensions/openshell/src/backend.e2e.test-support.ts
@@ -13,6 +13,49 @@ type ExecResult = {
   stderr: string;
 };
 
+export function buildOpenShellPolicyYaml(params: {
+  port: number;
+  binaryPath: string;
+  hostIp?: string;
+}): string {
+  const hostIp = params.hostIp?.trim();
+  // An explicit override keeps its shipped single-/32 policy; only the default
+  // uses NVIDIA's host_gateway_alias.rs ranges across managed Docker bridges.
+  // Upstream's 172.0.0.0/8 intentionally extends beyond RFC1918.
+  const allowedIps = hostIp
+    ? [`${hostIp}/32`]
+    : ["10.0.0.0/8", "172.0.0.0/8", "192.168.0.0/16", "fc00::/7"];
+  const networkPolicies = `  host_echo:
+    name: host-echo
+    endpoints:
+      - host: host.openshell.internal
+        port: ${params.port}
+        protocol: rest
+        enforcement: enforce
+        access: full
+        allowed_ips:
+${allowedIps.map((ip) => `          - "${ip}"`).join("\n")}
+    binaries:
+      - path: ${params.binaryPath}`;
+  return `version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only: [/usr, /lib, /proc, /dev/urandom, /app, /etc, /var/log, /opt]
+  read_write: [/sandbox, /tmp, /dev/null]
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+${networkPolicies}
+`;
+}
+
 export async function runCommand(params: {
   command: string;
   args: string[];

--- a/extensions/openshell/src/backend.e2e.test-support.ts
+++ b/extensions/openshell/src/backend.e2e.test-support.ts
@@ -1,9 +1,11 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import type { SandboxBackendHandle, SandboxFsBridge } from "openclaw/plugin-sdk/sandbox";
 import { expect } from "vitest";
+import { z } from "zod";
 
 type ExecResult = {
   code: number;
@@ -71,6 +73,85 @@ export async function runCommand(params: {
     });
 
     child.stdin.end(params.stdin);
+  });
+}
+
+export async function cleanupOpenShellWorkspace(params: {
+  command: string;
+  env: NodeJS.ProcessEnv;
+  workspace: string;
+  sandboxNames: string[];
+}): Promise<void> {
+  const deadline = Date.now() + 2 * 60_000;
+  const remainingMs = () => {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error("OpenShell sandbox cleanup did not complete within 120 seconds");
+    }
+    return remaining;
+  };
+  const ownedNames = new Set(params.sandboxNames);
+  const listNames = async () => {
+    const result = await runCommand({
+      command: params.command,
+      args: [
+        "--workspace",
+        params.workspace,
+        "sandbox",
+        "list",
+        "--limit",
+        String(ownedNames.size + 1),
+        "--output",
+        "json",
+      ],
+      env: params.env,
+      timeoutMs: remainingMs(),
+    });
+    remainingMs();
+    const sandboxes = z
+      .array(z.object({ name: z.string().min(1) }))
+      .parse(JSON.parse(result.stdout));
+    const names = sandboxes.map((sandbox) => sandbox.name);
+    // This isolated workspace contains only the fixture's owned sandboxes. An extra
+    // row or unexpected name must fail, never masquerade as a complete inventory.
+    if (
+      names.length > ownedNames.size ||
+      new Set(names).size !== names.length ||
+      names.some((name) => !ownedNames.has(name))
+    ) {
+      throw new Error("Unexpected sandbox inventory in OpenShell fixture workspace");
+    }
+    return names;
+  };
+  const presentNames = await listNames();
+  const failures: unknown[] = [];
+  for (const sandboxName of [...ownedNames].filter((name) => presentNames.includes(name))) {
+    try {
+      await runCommand({
+        command: params.command,
+        args: ["--workspace", params.workspace, "sandbox", "delete", sandboxName],
+        env: params.env,
+        timeoutMs: remainingMs(),
+      });
+      // OpenShell v0.0.109 acknowledges deletion before its controller removes the
+      // durable row. Observe absence before deleting the workspace; never retry errors.
+      if (failures.length === 0) {
+        while ((await listNames()).includes(sandboxName)) {
+          await delay(Math.min(250, remainingMs()));
+        }
+      }
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "OpenShell sandbox cleanup failed");
+  }
+  await runCommand({
+    command: params.command,
+    args: ["workspace", "delete", params.workspace],
+    env: params.env,
+    timeoutMs: 30_000,
   });
 }
 

--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -274,6 +274,8 @@ HTTPServer(("0.0.0.0", 8000), Handler).serve_forever()
 }
 
 function buildOpenShellPolicyYaml(params: { port: number; binaryPath: string }): string {
+  // Match NVIDIA's host_gateway_alias.rs fixture across managed Docker bridges.
+  // Its 172.0.0.0/8 range is intentionally broader than RFC1918.
   const networkPolicies = `  host_echo:
     name: host-echo
     endpoints:

--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -29,7 +29,6 @@ const OPENCLAW_OPENSHELL_COMMAND =
   process.env.OPENCLAW_E2E_OPENSHELL_COMMAND?.trim() || "openshell";
 const OPENCLAW_OPENSHELL_CONFIG_HOME =
   process.env.OPENCLAW_E2E_OPENSHELL_CONFIG_HOME?.trim() || null;
-const OPENCLAW_OPENSHELL_HOST_IP = process.env.OPENCLAW_E2E_OPENSHELL_HOST_IP?.trim() || null;
 
 const CUSTOM_IMAGE_DOCKERFILE = `FROM python:3.13-slim
 
@@ -140,46 +139,6 @@ async function dockerReady(): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-async function resolveOpenShellHostIp(): Promise<string> {
-  if (OPENCLAW_OPENSHELL_HOST_IP) {
-    return OPENCLAW_OPENSHELL_HOST_IP;
-  }
-  const networks = await runCommand({
-    command: "docker",
-    args: ["network", "ls", "--format", "{{.Name}}"],
-    timeoutMs: 20_000,
-  });
-  for (const network of networks.stdout.split(/\r?\n/u).map((value) => value.trim())) {
-    if (!network.startsWith("openshell")) {
-      continue;
-    }
-    const gateway = await runCommand({
-      command: "docker",
-      args: [
-        "run",
-        "--rm",
-        "--network",
-        network,
-        "--add-host",
-        "host.openshell.internal:host-gateway",
-        "python:3.13-alpine",
-        "python3",
-        "-c",
-        "import socket; print(socket.gethostbyname('host.openshell.internal'))",
-      ],
-      allowFailure: true,
-      timeoutMs: 60_000,
-    });
-    const hostIp = gateway.stdout.trim();
-    if (gateway.code === 0 && net.isIP(hostIp)) {
-      return hostIp;
-    }
-  }
-  throw new Error(
-    "OpenShell E2E could not resolve host.openshell.internal on the OpenShell Docker network; set OPENCLAW_E2E_OPENSHELL_HOST_IP",
-  );
 }
 
 async function allocatePort(): Promise<number> {
@@ -314,11 +273,7 @@ HTTPServer(("0.0.0.0", 8000), Handler).serve_forever()
   throw new Error("docker-backed host policy server did not become ready");
 }
 
-function buildOpenShellPolicyYaml(params: {
-  port: number;
-  binaryPath: string;
-  hostIp: string;
-}): string {
+function buildOpenShellPolicyYaml(params: { port: number; binaryPath: string }): string {
   const networkPolicies = `  host_echo:
     name: host-echo
     endpoints:
@@ -328,7 +283,10 @@ function buildOpenShellPolicyYaml(params: {
         enforcement: enforce
         access: full
         allowed_ips:
-          - "${params.hostIp}/32"
+          - "10.0.0.0/8"
+          - "172.0.0.0/8"
+          - "192.168.0.0/16"
+          - "fc00::/7"
     binaries:
       - path: ${params.binaryPath}`;
   return `version: 1
@@ -406,7 +364,6 @@ describe("openshell sandbox backend e2e", () => {
         );
       }
       const openshellConfigHome = OPENCLAW_OPENSHELL_CONFIG_HOME;
-      const hostIp = await resolveOpenShellHostIp();
       const gatewayName = await activeOpenShellGateway(OPENCLAW_OPENSHELL_COMMAND, {
         ...process.env,
         XDG_CONFIG_HOME: openshellConfigHome,
@@ -606,7 +563,14 @@ describe("openshell sandbox backend e2e", () => {
           buildOpenShellPolicyYaml({
             port: hostPolicyServer.port,
             binaryPath: "/usr/bin/false",
-            hostIp,
+          }),
+          "utf8",
+        );
+        await fs.writeFile(
+          allowPolicyPath,
+          buildOpenShellPolicyYaml({
+            port: hostPolicyServer.port,
+            binaryPath: "/usr/bin/curl",
           }),
           "utf8",
         );
@@ -639,23 +603,6 @@ describe("openshell sandbox backend e2e", () => {
           running: true,
           configLabelMatch: true,
         });
-
-        const curlPathResult = await runBackendExec({
-          backend,
-          command: "command -v curl",
-          timeoutMs: 60_000,
-        });
-        const curlPath = trimTrailingNewline(curlPathResult.stdout.trim());
-        expect(curlPath).toMatch(/^\/.+\/curl$/);
-        await fs.writeFile(
-          allowPolicyPath,
-          buildOpenShellPolicyYaml({
-            port: hostPolicyServer.port,
-            binaryPath: curlPath,
-            hostIp,
-          }),
-          "utf8",
-        );
 
         const sandbox = createSandboxTestContext({
           overrides: {

--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import {
+  buildOpenShellPolicyYaml,
   cleanupOpenShellWorkspace,
   runCommand,
   runBackendExec,
@@ -30,6 +31,7 @@ const OPENCLAW_OPENSHELL_COMMAND =
   process.env.OPENCLAW_E2E_OPENSHELL_COMMAND?.trim() || "openshell";
 const OPENCLAW_OPENSHELL_CONFIG_HOME =
   process.env.OPENCLAW_E2E_OPENSHELL_CONFIG_HOME?.trim() || null;
+const OPENCLAW_OPENSHELL_HOST_IP = process.env.OPENCLAW_E2E_OPENSHELL_HOST_IP;
 
 const CUSTOM_IMAGE_DOCKERFILE = `FROM python:3.13-slim
 
@@ -271,43 +273,6 @@ HTTPServer(("0.0.0.0", 8000), Handler).serve_forever()
     timeoutMs: 30_000,
   });
   throw new Error("docker-backed host policy server did not become ready");
-}
-
-function buildOpenShellPolicyYaml(params: { port: number; binaryPath: string }): string {
-  // Match NVIDIA's host_gateway_alias.rs fixture across managed Docker bridges.
-  // Its 172.0.0.0/8 range is intentionally broader than RFC1918.
-  const networkPolicies = `  host_echo:
-    name: host-echo
-    endpoints:
-      - host: host.openshell.internal
-        port: ${params.port}
-        protocol: rest
-        enforcement: enforce
-        access: full
-        allowed_ips:
-          - "10.0.0.0/8"
-          - "172.0.0.0/8"
-          - "192.168.0.0/16"
-          - "fc00::/7"
-    binaries:
-      - path: ${params.binaryPath}`;
-  return `version: 1
-
-filesystem_policy:
-  include_workdir: true
-  read_only: [/usr, /lib, /proc, /dev/urandom, /app, /etc, /var/log, /opt]
-  read_write: [/sandbox, /tmp, /dev/null]
-
-landlock:
-  compatibility: best_effort
-
-process:
-  run_as_user: sandbox
-  run_as_group: sandbox
-
-network_policies:
-${networkPolicies}
-`;
 }
 
 describe("OpenShell gateway discovery", () => {
@@ -566,6 +531,7 @@ describe("openshell sandbox backend e2e", () => {
           buildOpenShellPolicyYaml({
             port: hostPolicyServer.port,
             binaryPath: "/usr/bin/false",
+            hostIp: OPENCLAW_OPENSHELL_HOST_IP,
           }),
           "utf8",
         );
@@ -574,6 +540,7 @@ describe("openshell sandbox backend e2e", () => {
           buildOpenShellPolicyYaml({
             port: hostPolicyServer.port,
             binaryPath: "/usr/bin/curl",
+            hostIp: OPENCLAW_OPENSHELL_HOST_IP,
           }),
           "utf8",
         );

--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -610,16 +610,6 @@ describe("openshell sandbox backend e2e", () => {
           }),
           "utf8",
         );
-        await fs.writeFile(
-          allowPolicyPath,
-          buildOpenShellPolicyYaml({
-            port: hostPolicyServer.port,
-            binaryPath: "/usr/bin/curl",
-            hostIp,
-          }),
-          "utf8",
-        );
-
         const execResult = await runBackendExec({
           backend,
           command: "pwd && cat /opt/openshell-e2e-marker.txt && cat seed.txt",
@@ -655,7 +645,17 @@ describe("openshell sandbox backend e2e", () => {
           command: "command -v curl",
           timeoutMs: 60_000,
         });
-        expect(trimTrailingNewline(curlPathResult.stdout.trim())).toMatch(/^\/.+\/curl$/);
+        const curlPath = trimTrailingNewline(curlPathResult.stdout.trim());
+        expect(curlPath).toMatch(/^\/.+\/curl$/);
+        await fs.writeFile(
+          allowPolicyPath,
+          buildOpenShellPolicyYaml({
+            port: hostPolicyServer.port,
+            binaryPath: curlPath,
+            hostIp,
+          }),
+          "utf8",
+        );
 
         const sandbox = createSandboxTestContext({
           overrides: {

--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import {
+  cleanupOpenShellWorkspace,
   runCommand,
   runBackendExec,
   runPreparedBackendExec,
@@ -253,7 +254,6 @@ HTTPServer(("0.0.0.0", 8000), Handler).serve_forever()
           await runCommand({
             command: "docker",
             args: ["rm", "-f", containerId],
-            allowFailure: true,
             timeoutMs: 30_000,
           });
         },
@@ -481,6 +481,7 @@ describe("openshell sandbox backend e2e", () => {
         cfg: sandboxCfg,
       });
 
+      const failures: unknown[] = [];
       try {
         process.env.HOME = env.HOME;
         process.env.XDG_CONFIG_HOME = env.XDG_CONFIG_HOME;
@@ -867,53 +868,66 @@ describe("openshell sandbox backend e2e", () => {
             token: held.finalizeToken,
           });
         }
+      } catch (error) {
+        failures.push(error);
       } finally {
-        for (const sandboxName of [
-          backend.runtimeId,
-          mirrorBackend.runtimeId,
-          overlapBackend.runtimeId,
-          allowBackend.runtimeId,
-        ]) {
-          await runCommand({
-            command: OPENCLAW_OPENSHELL_COMMAND,
-            args: ["--workspace", openShellWorkspace, "sandbox", "delete", sandboxName],
-            env,
-            allowFailure: true,
-            timeoutMs: 2 * 60_000,
-          });
+        try {
+          if (workspaceCreated) {
+            await cleanupOpenShellWorkspace({
+              command: OPENCLAW_OPENSHELL_COMMAND,
+              env,
+              workspace: openShellWorkspace,
+              sandboxNames: [
+                backend.runtimeId,
+                mirrorBackend.runtimeId,
+                overlapBackend.runtimeId,
+                allowBackend.runtimeId,
+              ],
+            });
+          }
+        } catch (error) {
+          failures.push(error);
+        } finally {
+          try {
+            const socketServer = mirrorSocketServer;
+            if (socketServer) {
+              await new Promise<void>((resolve, reject) => {
+                socketServer.close((error) => (error ? reject(error) : resolve()));
+              });
+            }
+          } catch (error) {
+            failures.push(error);
+          }
+          try {
+            await hostPolicyServer?.close();
+          } catch (error) {
+            failures.push(error);
+          }
+          try {
+            await fs.rm(rootDir, { recursive: true, force: true });
+          } catch (error) {
+            failures.push(error);
+          } finally {
+            if (previousHome === undefined) {
+              delete process.env.HOME;
+            } else {
+              process.env.HOME = previousHome;
+            }
+            if (previousXdgConfigHome === undefined) {
+              delete process.env.XDG_CONFIG_HOME;
+            } else {
+              process.env.XDG_CONFIG_HOME = previousXdgConfigHome;
+            }
+            if (previousXdgCacheHome === undefined) {
+              delete process.env.XDG_CACHE_HOME;
+            } else {
+              process.env.XDG_CACHE_HOME = previousXdgCacheHome;
+            }
+          }
         }
-        if (workspaceCreated) {
-          await runCommand({
-            command: OPENCLAW_OPENSHELL_COMMAND,
-            args: ["workspace", "delete", openShellWorkspace],
-            env,
-            allowFailure: true,
-            timeoutMs: 30_000,
-          });
-        }
-        const socketServer = mirrorSocketServer;
-        if (socketServer) {
-          await new Promise<void>((resolve) => {
-            socketServer.close(() => resolve());
-          });
-        }
-        await hostPolicyServer?.close().catch(() => {});
-        await fs.rm(rootDir, { recursive: true, force: true });
-        if (previousHome === undefined) {
-          delete process.env.HOME;
-        } else {
-          process.env.HOME = previousHome;
-        }
-        if (previousXdgConfigHome === undefined) {
-          delete process.env.XDG_CONFIG_HOME;
-        } else {
-          process.env.XDG_CONFIG_HOME = previousXdgConfigHome;
-        }
-        if (previousXdgCacheHome === undefined) {
-          delete process.env.XDG_CACHE_HOME;
-        } else {
-          process.env.XDG_CACHE_HOME = previousXdgCacheHome;
-        }
+      }
+      if (failures.length > 0) {
+        throw new AggregateError(failures, "OpenShell E2E or cleanup failed");
       }
     },
   );

--- a/test/helpers/process-wait.test.ts
+++ b/test/helpers/process-wait.test.ts
@@ -1,12 +1,78 @@
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 import fsSync from "node:fs";
-import { afterEach, expect, it, vi } from "vitest";
-import { isProcessAlive, waitForChildClose, waitForDead } from "./process-wait.js";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isProcessAlive,
+  waitForChildClose,
+  waitForDead,
+  waitForFile,
+  waitForPidFile,
+} from "./process-wait.js";
 import { withTestTimeout } from "./promise.js";
+import { useAutoCleanupTempDirTracker } from "./temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
+});
+
+describe.each([
+  { name: "file", wait: waitForFile, expected: undefined },
+  { name: "PID", wait: waitForPidFile, expected: 42 },
+])("$name readiness", ({ wait, expected }) => {
+  it("observes readiness after a delayed wake crosses the deadline", async () => {
+    vi.useFakeTimers();
+    const file = path.join(tempDirs.make("openclaw-process-wait-"), "ready");
+    const result = wait(file, 20).catch((error: unknown) => error);
+
+    // The producer finishes while the waiting worker cannot run its pending poll.
+    fsSync.writeFileSync(file, "42\n");
+    vi.setSystemTime(Date.now() + 25);
+    await vi.advanceTimersByTimeAsync(5);
+    expect(await result).toBe(expected);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects a file still missing when the deadline passes", async () => {
+    vi.useFakeTimers();
+    const file = path.join(tempDirs.make("openclaw-process-wait-"), "missing");
+    const result = wait(file, 20).catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(await result).toMatchObject({ message: expect.stringContaining("timeout waiting for") });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+it.each(["", "invalid", "0", "-1"])("rejects PID contents %j at the deadline", async (contents) => {
+  vi.useFakeTimers();
+  const file = path.join(tempDirs.make("openclaw-process-wait-"), "pid");
+  fsSync.writeFileSync(file, contents);
+  const result = waitForPidFile(file, 20).catch((error: unknown) => error);
+  await vi.advanceTimersByTimeAsync(20);
+  expect(await result).toEqual(new Error(`timeout waiting for pid in ${file}`));
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("waits through an open-truncate window for valid PID contents", async () => {
+  vi.useFakeTimers();
+  const file = path.join(tempDirs.make("openclaw-process-wait-"), "pid");
+  fsSync.writeFileSync(file, "");
+  let settled = false;
+  const result = waitForPidFile(file, 20)
+    .finally(() => {
+      settled = true;
+    })
+    .catch((error: unknown) => error);
+  await vi.advanceTimersByTimeAsync(5);
+  expect(settled).toBe(false);
+  fsSync.writeFileSync(file, "42\n");
+  await vi.advanceTimersByTimeAsync(5);
+  expect(await result).toBe(42);
+  expect(vi.getTimerCount()).toBe(0);
 });
 
 it("stops waiting when a Linux process is a zombie", async () => {

--- a/test/helpers/process-wait.ts
+++ b/test/helpers/process-wait.ts
@@ -12,28 +12,30 @@ async function sleep(ms: number): Promise<void> {
 
 export async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
   const deadlineAt = Date.now() + timeoutMs;
-  while (Date.now() < deadlineAt) {
-    if (existsSync(filePath)) {
-      return;
+  // Observe readiness before the deadline: a delayed wake can outlive both.
+  while (!existsSync(filePath)) {
+    if (Date.now() >= deadlineAt) {
+      throw new Error(`timeout waiting for ${filePath}`);
     }
     await sleep(5);
   }
-  throw new Error(`timeout waiting for ${filePath}`);
 }
 
 // writeFileSync can expose an open-truncate window, so wait for valid contents, not existence.
 export async function waitForPidFile(filePath: string, timeoutMs: number): Promise<number> {
   const deadlineAt = Date.now() + timeoutMs;
-  while (Date.now() < deadlineAt) {
+  while (true) {
     if (existsSync(filePath)) {
       const pid = Number.parseInt(readFileSync(filePath, "utf8"), 10);
       if (Number.isInteger(pid) && pid > 0) {
         return pid;
       }
     }
+    if (Date.now() >= deadlineAt) {
+      throw new Error(`timeout waiting for pid in ${filePath}`);
+    }
     await sleep(5);
   }
-  throw new Error(`timeout waiting for pid in ${filePath}`);
 }
 
 export async function waitForDead(pid: number, timeoutMs: number): Promise<void> {

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -10,6 +10,7 @@ import {
   shouldSkipSparseTsgoGuardError,
 } from "../../scripts/lib/tsgo-sparse-guard.mts";
 import { resolveTsgoTimeoutMs } from "../../scripts/run-tsgo.mts";
+import { createBoundedChildOutput } from "../helpers/bounded-child-output.js";
 import {
   isProcessAlive,
   waitForChildClose,
@@ -365,10 +366,16 @@ child.once("message", () => process.exit(0));
         .toEqual([]);
     } finally {
       for (const pidFile of [descendantPidPath, path.join(cwd, "fake-tsgo.pid")]) {
-        if (!fs.existsSync(pidFile)) continue;
+        if (!fs.existsSync(pidFile)) {
+          continue;
+        }
         const pid = Number(fs.readFileSync(pidFile, "utf8"));
-        if (!Number.isSafeInteger(pid) || pid <= 1) continue;
-        if (isProcessAlive(pid)) process.kill(pid, "SIGKILL");
+        if (!Number.isSafeInteger(pid) || pid <= 1) {
+          continue;
+        }
+        if (isProcessAlive(pid)) {
+          process.kill(pid, "SIGKILL");
+        }
         await waitForDead(pid, 2_000);
       }
     }
@@ -466,13 +473,16 @@ syncBuiltinESMExports();
         [path.resolve("scripts/run-tsgo.mjs"), "-p", "tsconfig.extensions.json"],
         {
           cwd,
-          stdio: "ignore",
+          stdio: ["ignore", "ignore", "pipe"],
           env: {
             ...process.env,
             NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""}${phase === "spawn" ? ` --import=${pathToFileURL(preloadPath).href}` : ""}`,
           },
         },
       );
+      const stderr = createBoundedChildOutput();
+      wrapper.stderr.on("data", (chunk) => stderr.append(chunk));
+      wrapper.once("error", (error) => stderr.append(`wrapper spawn error: ${error.message}\n`));
       const wrapperClose = waitForChildClose(wrapper, 15_000);
 
       try {
@@ -487,6 +497,11 @@ syncBuiltinESMExports();
           { code: null, signal: "SIGTERM" },
         ]).toContainEqual(wrapperResult);
         await expect(waitForDead(compilerPid, 2_000)).resolves.toBeUndefined();
+      } catch (error) {
+        throw new Error(
+          `${String(error)}\nwrapper exitCode=${wrapper.exitCode}, signalCode=${wrapper.signalCode}\n${stderr.text()}`,
+          { cause: error },
+        );
       } finally {
         if (wrapper.exitCode === null && wrapper.signalCode === null) {
           wrapper.kill("SIGKILL");


### PR DESCRIPTION
Closes #130457

## What Problem This Solves

Repairs the OpenShell E2E fixture's host-gateway policy and cleanup ownership. The automatic single-address probe could select Docker's default bridge instead of the sandbox's managed bridge, denying a valid allow request. Cleanup also treated a delete acknowledgment as completed durable deletion.

## Why This Change Was Made

Use the upstream fixture's four CIDRs while retaining the exact host, port, executable and denial checks. Preserve the shipped explicit host-IP replacement behavior. The cleanup owner deletes only its known sandboxes, observes durable absence, and then deletes the workspace strictly within the existing budgets. No production sandbox policy or database behavior changes.

This refresh consumes the already-landed main UI type-shard split rather than publishing our duplicate implementation. It also includes the separately proven shared test-waiter repair: observe ready file/PID state before deciding that a delayed poll has timed out, with bounded compiler-startup diagnostics and unchanged deadlines.

## User Impact

No product runtime change. Maintainer release validation now follows the upstream network fixture and reports incomplete cleanup rather than silently succeeding. Josh Lehman's original two commits, author identities and credit are preserved; thanks @jalehman.

## Evidence

**Current source:** parent `4bd53eb3f7d185182570f1397e1480ae1449fb19` on frozen main `5fc71d3994e3694c6bf03acdaa9cbc280469b152`. Six OpenShell commits and the waiter repair were replayed with matching patch IDs, authors, dates and messages. The child remains stacked on this branch. The canonical UI split is [the main repair in 132193](https://github.com/openclaw/openclaw/pull/132193); its 720-root cap and exact-once coverage are unchanged.

**New local proof:** 34 original-order shard/compiler/installed-runner cases, 65 waiter/managed-process boundaries, 142 OpenShell cases and 314 child tooling cases passed: **555 cohort tests**, no filtered skips or failures. The parent changed gate additionally passed five doctor-contract cases. Both parent/child changed gates, workflow checks and source bindings passed. The parent SDK declaration cache was regenerated by its canonical owner after an interrupted earlier preparation. Frozen dependency relinking corrected the installed acpx version without declaration/lock changes; lifecycle scripts were disabled in that read-only proof phase to avoid changing shared Git hooks, so this is not package-install lifecycle proof. Actual installed Vitest patch behavior was checked, not inferred from its version.

The waiter defect has deterministic failing-first and passing-after evidence. The earlier spawn-timeout's exact PID/stderr state was not retained, so its historical cause remains unknown. No deadline, assertion, retry policy or process authority was weakened. Prior clean reviews carry only across verified identical code; there is no new broader review claim.

**Historical hosted recovery now verified:** [combined run 33219252669](https://github.com/openclaw/openclaw/actions/runs/33219252669/job/99010148464) passed all five real OpenShell cases without skips in 35.50s at validation/tooling `2772958d7fae33060893b4d9ef753e31b20dd29f`. Exact workspace cleanup and owned-network/container cleanup passed. The matching parent build measured **345165 B**, and combined build **344946 B**, both below the original **347037 B** gzip criterion; no budget relaxation was used. Parent normal CI failed only the then-combined UI test-root limit (724 > 720), now addressed by canonical main's split. These are source-bound historical receipts, not a new-head hosted pass.

**Next gate:** new exact-head normal CI and a fresh combined OpenShell dispatch must complete before native parent-first landing. No preparation or merge is claimed for this refreshed head. Original full release verification remains separately blocked.

**LOC versus this frozen base:** production runtime +0/-0; tests +378/-142; test support +132/-6; docs +3/-2. The waiter growth is all test/support. No dependency override, schema, configuration option, production fallback, changelog or test-budget change. Prior controlled policy/cleanup red-green proof, dependency contracts, explicit IPv6 override limitation and production prune/recreate follow-up remain below.

<details>
<summary>Earlier source-bound evidence and follow-ups (historical)</summary>

## Canonical-main refresh — CI recovery pending

Parent head `eb60af39465087c068b975c4328cc4cf3a6a05cd` is based on frozen main `486d0757939b3c33f56ca49b8a04e919205bac03`. Exactly six parent commits were replayed from actual old base `4bc4ad35fa1cc665070f111a9f9e821689937835`; range-diff marks all six patch-identical. Josh Lehman's two original commits and exact author identity remain intact; thanks @jalehman. The four parent file blobs are identical to old head `50c43924a6948b1fa93d70abade3fc4581bbcef1` and to the new integrated child.

The refresh consumes canonical UI source repair [#132124](https://github.com/openclaw/openclaw/pull/132124), commit `5b605da389460fd035d9a2031064ed949303b14f`, through immutable server main `486d0757939b3c33f56ca49b8a04e919205bac03`. No UI implementation, baseline, compression, manifest, dependency, timeout, policy, schema or assertion change was made by this refresh. Main's independently owned Usage repair and later baseline changes are carried unchanged.

**UI recovery criterion:** old parent CI [33210106646](https://github.com/openclaw/openclaw/actions/runs/33210106646) built merge `1e510feb884da4ab9a3acf86f9541d32b31a56cd`, not branch head `50c43924…`. Its four startup gzip measurements were 347231–347263 B against **347037 B**. Cached canonical-repair [build proof](https://github.com/openclaw/openclaw/actions/runs/33212212671/job/98988058967) shows actual checkout/workflow `605ace5c5ffc17e07504fc5d2610ecbc9cabce15` and **345110 B** under that original limit. The new OpenShell CI must still supply its actual build source and gzip measurement below **347037 B**; green alone is not the recovery evidence. Selected main now has a separately owned 345371 B baseline / 345947 B enforcement; this refresh did not alter it.

**Prior proof remains historical:** [run 33210416671/job98982737606](https://github.com/openclaw/openclaw/actions/runs/33210416671/job/98982737606) passed 5/5 without skips in 45.35s at old validation=tooling `954f8878ceed78cef5ebcb108b58ef7fa76296a4`, with strict workspace cleanup, exact network removal and zero remaining containers. Its sanitized tail covers only ~7.245 seconds; three PushSandboxLogs gRPC 13 responses do not prove a SQL cause or an upstream repair. Main now changes physical host-path lease canonicalization in the OpenShell backend, so a fresh combined run is required despite unchanged fixture and workflow assertions.

**New integrated proof:** [Run 33219252669](https://github.com/openclaw/openclaw/actions/runs/33219252669) was dispatched once with requested validation=tooling `2772958d7fae33060893b4d9ef753e31b20dd29f`, exact filter `openshell-e2e`, configured Blacksmith backend, no provider or release-path suites. Run metadata confirms that workflow head; selected-ref verification and the result are pending. This phase does not wait for completion.

Local Node 24 verification passed **142/142 parent fixture/backend/mirror/core tests** (including main's symlink-alias lease case) and **307/307 child tooling tests**. Workflow checks passed with the approved fixed actionlint binary, zizmor and composite input guard; docs listing and commit-range diff checks passed. The combined seven-file changed gate also passed on the exact frozen-base/new-child tuple, including five doctor-contract tests, zero unused-export entries, typechecks and lint. No reinstall or node_modules edit. Prior managed Codex P0 reviews carry under the verified mechanical, patch-identical rebase; no new semantic repair or wider review scope is claimed.

All host/port/executable constraints, explicit host-IP replacement semantics, deny assertions, overlap and FIFO/socket behavior, stress counts, four cleanup owners and the original 120000ms cleanup deadline are unchanged. Direct NVIDIA v0.0.109 source inspection confirms the [four CIDRs](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/e2e/rust/tests/host_gateway_alias.rs#L288), [durable inventory](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-server/src/grpc/sandbox.rs#L393), [strict workspace delete](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-server/src/grpc/workspace.rs#L287), [package lifecycle](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/deploy/deb/postinst.sh), and [shared TLS import](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-cli/src/commands/gateway.rs#L612) contracts. No production prune/recreate or upstream database fix is claimed.

**Normal CI:** [Run 33219223115](https://github.com/openclaw/openclaw/actions/runs/33219223115) is attached to `eb60af39465087c068b975c4328cc4cf3a6a05cd`. Observed state: in_progress; conclusion: pending. No generic CI wait or blind old-source rerun was performed.

**ClawSweeper follow-through:** latest inspected review is August 28, 2026 ~21:22 UTC. The pinned CIDR confirmation is complete; exact CI recovery and the original-limit measurement remain pending. No redundant re-review comment. Parent and child remain open/unmerged; no native prepare/merge was run in this phase. Existing native review artifacts still name old source and must be refreshed by the landing owner before preparation. Production runtime +0/-0; tests +291/-136; test support +124/-0; docs +3/-2; incremental refresh delta zero.

Child #131465 remains stacked on this parent. Original full release run 33154285571 remains blocked_complete; neither this source refresh nor the targeted dispatch is a full-release or original-package recovery claim.

## Historical evidence before this main-fix refresh

All earlier current/final/prepared claims below apply only to their named historical source.


Everything below describes its named older source. Earlier “current”, “final” and “prepared” claims are historical and do not supersede the status above.

Closes #130457

## Verified and prepared

The fixture repair has passed focused local gates, exact-head normal CI, the refreshed combined hosted OpenShell v0.0.109 Docker run with the bootstrap repair in #131465, and native preparation. It remains open and unmerged. The fixture head is `eca161714a3595dd54e3a9390061db9fa35b44bd`, based on `2169669140f17e01833aec48f8510d641a6c41cb`, resolving the actual conflict with #131360's mirror FIFO/socket coverage. Josh's two original commits and the upstream-context commit remain patch-identical; the two maintainer cleanup commits are consolidated with the new socket teardown ordering. A subsequent compatibility repair preserves the documented explicit host-IP input.

The previous investigation exposed both an asynchronous deletion acknowledgment race and separate control-plane failures during upstream SSH-session cleanup. This fixture now composes the existing deletion API correctly; it does not claim to repair upstream database contention. That investigation remains tracked in [NVIDIA/OpenShell #2999](https://github.com/NVIDIA/OpenShell/issues/2999). No dependency override, database setting/schema change, error retry, timeout increase, or production-policy workaround is included.

AI-assisted change. I reviewed the implementation and ran the repository autoreview workflow.

## What Problem This Solves

The host-gateway fixture probed Docker's `host-gateway` alias before creating managed sandboxes, then wrote that address as a `/32`. In the controlled OpenShell v0.0.109 run, the probe returned the default bridge address `172.17.0.1` even with the managed network selected, while the actual sandbox alias resolved to `172.18.0.1`. OpenShell rejected both baseline allow requests because the destination was outside `allowed_ips`.

Cleanup also treated a successful sandbox-delete acknowledgment as completed deletion and immediately deleted the workspace. OpenShell v0.0.109 may acknowledge before its controller removes the durable sandbox row and owned records. The old fixture ignored deletion failures; strict workspace deletion exposed that race.

## Why This Change Was Made

The default policy follows OpenShell's own host-gateway fixture: four CIDRs, with hostname, port, executable identity, and the deny assertion still constrained. It removes the faulty automatic single-address probe but preserves `OPENCLAW_E2E_OPENSHELL_HOST_IP`: nonblank input is trimmed and replaces the allowed-IP list with only that value plus its shipped `/32` suffix. Unset or blank input selects the four defaults. These are the upstream fixture ranges, not exclusively RFC1918 space: `172.0.0.0/8` is broader than RFC1918.

The test cleanup owner now reads a validated, workspace-scoped JSON inventory, deletes only its initially present owned names once, and observes durable absence before deleting the workspace. The query limit exceeds the fixture's known maximum of three sandboxes; malformed, duplicate, unexpected, or overfull inventories fail instead of implying absence. Successful presence observations may repeat, but command/query errors do not. One absolute 120-second budget covers all sandbox deletion and observation work; workspace deletion remains one strict 30-second command.

On a failure, the fixture retains it and attempts remaining known sandbox deletions within that budget without further inventory polling or workspace deletion. It preserves the original test failure alongside remote/local cleanup failures, and restores the process environment even if temporary-directory removal fails. If workspace creation failed, it does not issue remote cleanup commands. The full mirror and remote stress workloads are unchanged.

The conflict resolution retains main's real FIFO and Unix socket fixtures and their preservation assertions. Local teardown closes the owned socket before the host server and temporary directory, retaining any close failure alongside the other failures.

## User Impact

OpenShell validation follows the upstream gateway fixture and reports incomplete cleanup instead of passing silently. Production runtime behavior and dependency versions are unchanged. Thanks to @jalehman; Josh Lehman's original commits and authorship are preserved.

## Evidence

- Current combined candidate `c2b5d4180e0be705bd495f94f66523564ee1bc01` contains this exact fixture head with identical OpenShell source/docs blobs. [Hosted Docker run 33147687932](https://github.com/openclaw/openclaw/actions/runs/33147687932/job/98772573742) passed all five tests without skips in 88.43s on checksum-verified OpenShell v0.0.109: mirror 36.184s, remote 45.195s. Protected gateway readiness, real SSH execution, FIFO/socket preservation, both stress modes, durable sandbox-absence observation, and strict workspace cleanup passed. Each mode's reached assertions enforce 64 workflows, 32 commands, eight intentional failures, and exact 74 mirror/72 remote files; these are source-enforced counts, not printed telemetry. Owned network removal succeeded and graceful gateway shutdown reported zero remaining sandbox containers. Parent normal CI [33147636376](https://github.com/openclaw/openclaw/actions/runs/33147636376) passed on the exact fixture head, including the required `openclaw/ci-gate`.
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 130465` completed successfully after exact-head review-artifact validation. It verified hosted gates, retained `eca161714a3595dd54e3a9390061db9fa35b44bd`, and skipped pushing because the remote already matched. No additional rebase, dependency change, or merge occurred during preparation.
- The current [sanitized gateway artifact](https://github.com/openclaw/openclaw/actions/runs/33147687932/artifacts/9676576885) retains the final bounded 1 MiB input, approximately 24.5 seconds, not the whole run. Its tail shows remote list/delete-workspace success and clean shutdown. Three PushSandboxLogs gRPC INTERNAL stream responses occurred near teardown; their 41–43-second durations are stream lifetimes, not SQL timings. Their cause is unproven. This is verified fixture behavior and strict cleanup, not a claim that upstream database contention is fixed or every control-plane RPC was error-free.
- Controlled real-Docker policy reproduction: base `13941a030dd56e1e5da1d65b843fc6c1f76d88ef` failed both live cases with HTTP 403 (three parser tests passed); candidate `0e48b41a00519be09e6494b97681143fd15d333d` passed 5/5 without skips in 370.70s. Both used the same v0.0.109 CLI, mTLS gateway, managed network, and no host-IP override. This historical result proves command/data assertions, not automatic cleanup: that fixture ignored deletion errors.
- Cleanup regression captured before the behavior change: the existing created-workspace cleanup was mechanically extracted into its test-support owner. A disposable CLI child acknowledged deletion while retaining the durable row; workspace deletion then failed with `workspace still contains durable sandbox records` (one failed, one passed).
- The explicit override regression also failed before repair: the actual unchanged policy builder was mechanically moved into existing test support, and parsed-YAML assertions failed for an outside-default IPv4 address and the shipped IPv6 `/32` output (two failed, 18 passed). No production test seam was introduced.
- A second source review corrected an additive draft: stable semantics replace the allowed-IP list, so retaining the default CIDRs beside an explicit override would broaden it. Exact-list regression assertions failed against that draft (two failed, 18 passed) before the final replacement-semantics fix.
- On the final resolved tree, `node scripts/run-vitest.mjs extensions/openshell/src/backend.e2e.test-support.test.ts extensions/openshell/src/mirror.test.ts` passed all 33 tests: 16 cleanup/support, four policy cases, and 13 mirror tests, including real FIFO/socket preservation. Policy cases cover absent/blank input, a trimmed outside-default IPv4 address, and unchanged IPv6 formatting. Cleanup coverage includes delayed completion, partial/empty setup, malformed or incomplete inventory, visible query/delete errors without retries, remaining owned deletion attempts, stuck deletion, the deadline including delete execution, and strict workspace deletion failure. These are deterministic boundary tests, not live OpenShell proof.
- `env -u OPENCLAW_E2E_OPENSHELL OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs extensions/openshell/src/backend.e2e.test.ts` passed the three discovery/parser tests with both live cases disabled. This verifies parsing/collection only, not Docker behavior.
- `node scripts/check-changed.mjs -- docs/help/testing.md extensions/openshell/src/backend.e2e.test-support.ts extensions/openshell/src/backend.e2e.test-support.test.ts extensions/openshell/src/backend.e2e.test.ts` passed on the final replacement-semantics tree: formatting, ratchets/boundary/dependency guards, five doctor-contract tests, all unused-export scans with zero entries, extension-test typechecking, and changed extension lint.
- `pnpm docs:list` and `git diff --check` passed.
- Whole-PR isolated Codex autoreview at P0–P2 reported no actionable findings on the final replacement-semantics tree, including all CIDR, cleanup, and FIFO/socket integration changes. All four final file hashes remained identical through tests, review, gate, and commit `eca161714a3595dd54e3a9390061db9fa35b44bd`. An earlier timeout finding rested on a mistaken review-context premise: the approved contract is 120 seconds for sandbox cleanup plus the existing separate 30-second workspace command, not one combined deadline. That premise was corrected and the fresh review passed. Independent source review previously found no actionable P0–P2 issues in the cleanup contract; the lead also inspected the new FIFO/socket integration and stable override contract directly.
- Production LOC: +0/-0. Tests and test support: +416/-135. Docs: +3/-2. Test-support growth includes moving the existing policy builder out of the E2E file, not a new production surface.
- Previous combined candidate `b01cfe26dc19276e208ffc34ae22301b2813ebcd` passed all five real OpenShell v0.0.109 tests in 99.79s with strict automatic cleanup in [run 33144751236](https://github.com/openclaw/openclaw/actions/runs/33144751236/job/98763577222). It predates the new main mirror owner and explicit-override repair; the refreshed run above supersedes it for current-candidate proof. Its [sanitized gateway artifact](https://github.com/openclaw/openclaw/actions/runs/33144751236/artifacts/9675501437) retains only the final approximately 25 seconds; three PushSandboxLogs INTERNAL stream responses have no established cause, and are not proof of SQL contention or an error-free control plane.
- The previous strict fixture head `6953ce5cd4f77df0eef5c9fa8ebfe2b003f43caf` first completed both stress assertion sets but failed both cleanup checks; one error explicitly reported SQLite `database is locked` (code 5), with residual resources before shutdown. A later traced run passed 5/5 in 206.96s and strict automatic cleanup, retaining only the default workspace. Each stress mode completed 64 workflows, 32 commands and eight intentional command failures; mirror verified 74 files including count/ledger, remote verified 72 files.
- That traced historical pass was not a healthy-control-plane verdict: 542 individual SSH-session DELETEs overlapped 22 slow SQL operations and six GetSandboxConfig/GetInferenceBundle INTERNAL responses. Failed SELECTs took approximately five seconds; RPCs took 5.1–9.9 seconds. The exact SQLite error code was not captured for those six RPCs. Current-candidate proof and its narrower gateway-log limits are recorded above.

## Dependency contract and follow-ups

**ClawSweeper review disposition.** The documented host-IP compatibility finding is accepted and repaired, not waived. Stable [v2026.7.1-2 source](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/extensions/openshell/src/backend.e2e.test.ts#L197-L228) and [testing docs](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/docs/help/testing.md#L804-L808) expose that contract. The bot's output-matcher failure expected a suite label absent from successful Vitest output; its recorded command itself passed all 16 tests. Actual current combined Docker proof now passes as recorded above. No persistent OpenClaw data schema changes are present: serialized state in the regression tests belongs only to disposable fake CLI fixtures.

**Named follow-up: explicit IPv6 host-IP mask.** The shipped override unconditionally appends `/32`, including IPv6 input. This repair preserves that existing behavior rather than silently changing it to `/128` or adding new validation. Any move to exact-host IPv6 semantics needs a separate compatibility decision and dependency-backed proof; it is not claimed fixed here.

Directly inspected NVIDIA's pinned [host-gateway policy fixture](https://github.com/NVIDIA/OpenShell/blob/c4b500a7de64d0b66e3ee8098f58d14299092162/e2e/rust/tests/host_gateway_alias.rs#L298-L347) and [endpoint/binary matcher](https://github.com/NVIDIA/OpenShell/blob/c4b500a7de64d0b66e3ee8098f58d14299092162/crates/openshell-supervisor-network/data/sandbox-policy.rego#L92-L137). For deletion, the pinned v0.0.109 [post-ack path](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-server/src/compute/mod.rs#L2910-L2924) does not wait for durable absence; the [controller cleanup](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-server/src/compute/mod.rs#L2784-L2803) removes owned records before the sandbox row, and [workspace-scoped list](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-server/src/grpc/sandbox.rs#L393-L461) reads durable storage. Strict workspace deletion remains the final resource-cleanup oracle.

**Named follow-up: production OpenShell prune/recreate completion.** This is source-identified, not a new live product reproduction. Production [OpenShell `removeRuntime`](https://github.com/openclaw/openclaw/blob/9fd933f66cbafaba6d00e4c53f184b42d5a5dd3e/extensions/openshell/src/backend.ts#L258-L271) still returns after the CLI's asynchronous deletion acknowledgment. [Prune](https://github.com/openclaw/openclaw/blob/9fd933f66cbafaba6d00e4c53f184b42d5a5dd3e/src/agents/sandbox/prune.ts#L63-L66) and [manual removal/recreate](https://github.com/openclaw/openclaw/blob/9fd933f66cbafaba6d00e4c53f184b42d5a5dd3e/src/agents/sandbox/manage.ts#L98-L117) then remove the registry entry; the next scope initialization can reuse its [deterministic sandbox name](https://github.com/openclaw/openclaw/blob/9fd933f66cbafaba6d00e4c53f184b42d5a5dd3e/extensions/openshell/src/backend.ts#L1109-L1151) while the remote row is still Deleting. The fixture repair does not fix that production lifecycle owner. Follow-up work must prove the real prune/recreate ordering and establish terminal deletion before registry removal/name reuse. [NVIDIA/OpenShell #3001](https://github.com/NVIDIA/OpenShell/pull/3001) may eventually provide that terminal CLI contract in a released dependency; it is not an override or dependency change in this PR. [NVIDIA/OpenShell #3000](https://github.com/NVIDIA/OpenShell/pull/3000) separately addresses per-row SSH-session cleanup write amplification.

Historical hosted failures [33007261502](https://github.com/openclaw/openclaw/actions/runs/33007261502) and the curl-path-only alternative [33020136574](https://github.com/openclaw/openclaw/actions/runs/33020136574) used v0.0.106; the original [33023007386 pass](https://github.com/openclaw/openclaw/actions/runs/33023007386) used v0.0.109. They are not presented as a controlled pair. #131315's execution-owner/stress changes are included. The separate hosted bootstrap failure #131134 is addressed by companion #131465; current combined Docker proof and exact-head CI passed, and native preparation completed. Neither preparation nor this proof summary merges the PR.


</details>
