### PR TITLE
refactor(plugins): unify setup registration and artifact selection

### DIFF
--- a/src/plugins/plugin-runtime-artifact-resolution.ts
+++ b/src/plugins/plugin-runtime-artifact-resolution.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { resolveRealpathOrAbsolute } from "../infra/boundary-path.js";
 import type { OpenClawPackageManifest } from "./manifest.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
+import { resolvePreferredBuiltRuntimeArtifact } from "./plugin-runtime-artifact-selection.js";
 import type { PluginRegistry } from "./registry-types.js";
 import { getActivePluginRegistry, requireActivePluginRegistry } from "./runtime.js";
 
@@ -22,141 +23,6 @@ export function resolveCanonicalDistRuntimeSource(source: string): string {
   }
   const candidate = `${source.slice(0, index)}${path.sep}dist${path.sep}extensions${path.sep}${source.slice(index + marker.length)}`;
   return fs.existsSync(candidate) ? candidate : source;
-}
-
-function rewriteBundledRuntimeArtifactRelativePath(relativePath: string): string {
-  return relativePath.replace(/\.[^.]+$/u, ".js");
-}
-
-function listPackageLocalRuntimeArtifactOutputExtensions(sourceExt: string): string[] {
-  switch (sourceExt) {
-    case ".mts":
-    case ".mjs":
-      return [".mjs", ".js", ".cjs"];
-    case ".cts":
-    case ".cjs":
-      return [".cjs", ".js", ".mjs"];
-    default:
-      return [".js", ".mjs", ".cjs"];
-  }
-}
-
-function listPackageLocalRuntimeArtifactRelativePathBases(relativePath: string): string[] {
-  const ext = path.extname(relativePath).toLowerCase();
-  const withoutExt = ext ? relativePath.slice(0, -ext.length) : relativePath;
-  if (!withoutExt.startsWith(`src${path.sep}`) && !withoutExt.startsWith("src/")) {
-    return [withoutExt];
-  }
-  return [withoutExt.slice(4), withoutExt];
-}
-
-function listPackageLocalDistRuntimeArtifactRelativePaths(relativePath: string): string[] {
-  const ext = path.extname(relativePath).toLowerCase();
-  const candidates = new Set<string>();
-  for (const base of listPackageLocalRuntimeArtifactRelativePathBases(relativePath)) {
-    for (const outputExt of listPackageLocalRuntimeArtifactOutputExtensions(ext)) {
-      candidates.add(`${base}${outputExt}`);
-    }
-  }
-  return [...candidates];
-}
-
-function shouldPreferPackageLocalDistRuntimeArtifact(source: string): boolean {
-  switch (path.extname(source).toLowerCase()) {
-    case ".ts":
-    case ".tsx":
-    case ".mts":
-    case ".cts":
-      return true;
-    default:
-      return false;
-  }
-}
-
-function resolvePackageLocalDistRuntimeArtifact(params: {
-  source: string;
-  rootDir: string;
-}): string | null {
-  const relativeSource = path.relative(params.rootDir, params.source);
-  if (
-    !shouldPreferPackageLocalDistRuntimeArtifact(relativeSource) ||
-    relativeSource === "" ||
-    relativeSource.startsWith("..") ||
-    path.isAbsolute(relativeSource)
-  ) {
-    return null;
-  }
-  const artifactRoot = path.join(params.rootDir, "dist");
-  for (const artifactRelativePath of listPackageLocalDistRuntimeArtifactRelativePaths(
-    relativeSource,
-  )) {
-    const artifactSource = path.join(artifactRoot, artifactRelativePath);
-    if (fs.existsSync(artifactSource)) {
-      return resolveRealpathOrAbsolute(artifactSource);
-    }
-  }
-  return null;
-}
-
-function resolvePreferredBuiltRuntimeArtifact(params: {
-  source: string;
-  rootDir: string;
-  origin: PluginOrigin;
-  preferBuiltPluginArtifacts: boolean;
-  packageManifest?: OpenClawPackageManifest;
-}): { source: string; rootDir: string } {
-  const rootDir = resolveRealpathOrAbsolute(params.rootDir);
-  const source = resolveRealpathOrAbsolute(params.source);
-  if (!params.preferBuiltPluginArtifacts) {
-    return { source, rootDir };
-  }
-  if (params.origin !== "bundled") {
-    const artifactSource = resolvePackageLocalDistRuntimeArtifact({ source, rootDir });
-    if (artifactSource) {
-      return { source: artifactSource, rootDir };
-    }
-    return { source, rootDir };
-  }
-  // Source-external plugins keep source authoritative over package-local output;
-  // only the lifecycle-owned canonical root build may replace that pair.
-  const sourceExternal = params.packageManifest?.build?.bundledDist === false;
-  const packageLocalArtifactSource = sourceExternal
-    ? null
-    : resolvePackageLocalDistRuntimeArtifact({ source, rootDir });
-  if (packageLocalArtifactSource) {
-    return { source: packageLocalArtifactSource, rootDir };
-  }
-  const extensionsDir = path.dirname(rootDir);
-  if (path.basename(extensionsDir) !== "extensions") {
-    return { source, rootDir };
-  }
-  const packageRoot = path.dirname(extensionsDir);
-  if (path.basename(packageRoot) === "dist" || path.basename(packageRoot) === "dist-runtime") {
-    return { source, rootDir };
-  }
-  const relativeSource = path.relative(rootDir, source);
-  if (relativeSource === "" || relativeSource.startsWith("..") || path.isAbsolute(relativeSource)) {
-    return { source, rootDir };
-  }
-  const artifactRelativePath = rewriteBundledRuntimeArtifactRelativePath(relativeSource);
-  // Source-external packaging can replace the flat root build while leaving its
-  // staging wrapper behind, so only bundled artifacts may fall back to dist-runtime.
-  for (const artifactRootName of sourceExternal ? ["dist"] : ["dist-runtime", "dist"]) {
-    const artifactRoot = path.join(
-      packageRoot,
-      artifactRootName,
-      "extensions",
-      path.basename(rootDir),
-    );
-    const artifactSource = path.join(artifactRoot, artifactRelativePath);
-    if (fs.existsSync(artifactSource)) {
-      return {
-        source: resolveRealpathOrAbsolute(artifactSource),
-        rootDir: resolveRealpathOrAbsolute(artifactRoot),
-      };
-    }
-  }
-  return { source, rootDir };
 }
 
 /** Applies both loader selection phases in their runtime order. */

--- a/src/plugins/plugin-runtime-artifact-selection.ts
+++ b/src/plugins/plugin-runtime-artifact-selection.ts
@@ -1,0 +1,166 @@
+/** Selects built plugin artifacts without importing active runtime state. */
+import fs from "node:fs";
+import path from "node:path";
+import { resolveRealpathOrAbsolute } from "../infra/boundary-path.js";
+import type { OpenClawPackageManifest } from "./manifest.js";
+import type { PluginOrigin } from "./plugin-origin.types.js";
+
+function rewriteBundledRuntimeArtifactRelativePath(relativePath: string): string {
+  return relativePath.replace(/\.[^.]+$/u, ".js");
+}
+
+function listPackageLocalRuntimeArtifactOutputExtensions(sourceExt: string): string[] {
+  switch (sourceExt) {
+    case ".mts":
+    case ".mjs":
+      return [".mjs", ".js", ".cjs"];
+    case ".cts":
+    case ".cjs":
+      return [".cjs", ".js", ".mjs"];
+    default:
+      return [".js", ".mjs", ".cjs"];
+  }
+}
+
+function listPackageLocalRuntimeArtifactRelativePathBases(relativePath: string): string[] {
+  const ext = path.extname(relativePath).toLowerCase();
+  const withoutExt = ext ? relativePath.slice(0, -ext.length) : relativePath;
+  if (!withoutExt.startsWith(`src${path.sep}`) && !withoutExt.startsWith("src/")) {
+    return [withoutExt];
+  }
+  return [withoutExt.slice(4), withoutExt];
+}
+
+function listPackageLocalDistRuntimeArtifactRelativePaths(relativePath: string): string[] {
+  const ext = path.extname(relativePath).toLowerCase();
+  const candidates = new Set<string>();
+  for (const base of listPackageLocalRuntimeArtifactRelativePathBases(relativePath)) {
+    for (const outputExt of listPackageLocalRuntimeArtifactOutputExtensions(ext)) {
+      candidates.add(`${base}${outputExt}`);
+    }
+  }
+  return [...candidates];
+}
+
+function shouldPreferPackageLocalDistRuntimeArtifact(source: string): boolean {
+  switch (path.extname(source).toLowerCase()) {
+    case ".ts":
+    case ".tsx":
+    case ".mts":
+    case ".cts":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function resolvePackageLocalDistRuntimeArtifact(params: {
+  source: string;
+  rootDir: string;
+}): string | null {
+  const relativeSource = path.relative(params.rootDir, params.source);
+  if (
+    !shouldPreferPackageLocalDistRuntimeArtifact(relativeSource) ||
+    relativeSource === "" ||
+    relativeSource.startsWith("..") ||
+    path.isAbsolute(relativeSource)
+  ) {
+    return null;
+  }
+  const artifactRoot = path.join(params.rootDir, "dist");
+  for (const artifactRelativePath of listPackageLocalDistRuntimeArtifactRelativePaths(
+    relativeSource,
+  )) {
+    const artifactSource = path.join(artifactRoot, artifactRelativePath);
+    if (fs.existsSync(artifactSource)) {
+      return resolveRealpathOrAbsolute(artifactSource);
+    }
+  }
+  return null;
+}
+
+function resolvePreferredBundledRootArtifactFromCanonicalPaths(params: {
+  source: string;
+  rootDir: string;
+  packageManifest?: OpenClawPackageManifest;
+}): { source: string; rootDir: string } {
+  const { rootDir, source } = params;
+  const sourceExternal = params.packageManifest?.build?.bundledDist === false;
+  const extensionsDir = path.dirname(rootDir);
+  if (path.basename(extensionsDir) !== "extensions") {
+    return { source, rootDir };
+  }
+  const packageRoot = path.dirname(extensionsDir);
+  if (path.basename(packageRoot) === "dist" || path.basename(packageRoot) === "dist-runtime") {
+    return { source, rootDir };
+  }
+  const relativeSource = path.relative(rootDir, source);
+  if (relativeSource === "" || relativeSource.startsWith("..") || path.isAbsolute(relativeSource)) {
+    return { source, rootDir };
+  }
+  const artifactRelativePath = rewriteBundledRuntimeArtifactRelativePath(relativeSource);
+  // Source-external packaging can replace the flat root build while leaving its
+  // staging wrapper behind, so only bundled artifacts may fall back to dist-runtime.
+  for (const artifactRootName of sourceExternal ? ["dist"] : ["dist-runtime", "dist"]) {
+    const artifactRoot = path.join(
+      packageRoot,
+      artifactRootName,
+      "extensions",
+      path.basename(rootDir),
+    );
+    const artifactSource = path.join(artifactRoot, artifactRelativePath);
+    if (fs.existsSync(artifactSource)) {
+      return {
+        source: resolveRealpathOrAbsolute(artifactSource),
+        rootDir: resolveRealpathOrAbsolute(artifactRoot),
+      };
+    }
+  }
+  return { source, rootDir };
+}
+
+/** Selects the lifecycle-owned root build for one bundled source artifact. */
+export function resolvePreferredBundledRootArtifact(params: {
+  source: string;
+  rootDir: string;
+  packageManifest?: OpenClawPackageManifest;
+}): { source: string; rootDir: string } {
+  return resolvePreferredBundledRootArtifactFromCanonicalPaths({
+    source: resolveRealpathOrAbsolute(params.source),
+    rootDir: resolveRealpathOrAbsolute(params.rootDir),
+    packageManifest: params.packageManifest,
+  });
+}
+
+/** Applies source, package-local, and root-build preference without runtime memo state. */
+export function resolvePreferredBuiltRuntimeArtifact(params: {
+  source: string;
+  rootDir: string;
+  origin: PluginOrigin;
+  preferBuiltPluginArtifacts: boolean;
+  packageManifest?: OpenClawPackageManifest;
+}): { source: string; rootDir: string } {
+  // The stateful resolver canonicalizes both paths before memo-key construction.
+  const { rootDir, source } = params;
+  if (!params.preferBuiltPluginArtifacts) {
+    return { source, rootDir };
+  }
+  if (params.origin !== "bundled") {
+    const artifactSource = resolvePackageLocalDistRuntimeArtifact({ source, rootDir });
+    return artifactSource ? { source: artifactSource, rootDir } : { source, rootDir };
+  }
+  // Source-external plugins keep source authoritative over package-local output;
+  // only the lifecycle-owned canonical root build may replace that pair.
+  const sourceExternal = params.packageManifest?.build?.bundledDist === false;
+  const packageLocalArtifactSource = sourceExternal
+    ? null
+    : resolvePackageLocalDistRuntimeArtifact({ source, rootDir });
+  if (packageLocalArtifactSource) {
+    return { source: packageLocalArtifactSource, rootDir };
+  }
+  return resolvePreferredBundledRootArtifactFromCanonicalPaths({
+    source,
+    rootDir,
+    packageManifest: params.packageManifest,
+  });
+}

--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -11,6 +11,20 @@ import {
   resetRegistryJitiMocks,
 } from "./test-helpers/registry-jiti-mocks.js";
 
+const setupRegistryWarn = vi.hoisted(() => vi.fn());
+vi.mock("../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "plugins/setup-registry"
+        ? { ...logger, warn: setupRegistryWarn }
+        : logger;
+    },
+  };
+});
+
 // plugin-module-loader-cache prefers native require() for compiled .js before
 // falling back to jiti. These tests script plugin-loading behavior through the
 // source-transform mock, so force the fallback path and keep the fixture
@@ -258,6 +272,7 @@ describe("setup-registry module loader", () => {
 
   beforeEach(() => {
     resetRegistryJitiMocks();
+    setupRegistryWarn.mockReset();
     setPluginSetupRegistryModuleLoaderFactoryForTest(mocks.createJiti);
   });
 
@@ -283,30 +298,81 @@ describe("setup-registry module loader", () => {
     expect(firstRecordArg(mocks.loadPluginManifestRegistry).pluginIds).toEqual(["test-plugin"]);
   });
 
-  it("uses built setup artifacts for bundled source records when available", () => {
+  it.each([
+    {
+      name: "uses root builds for bundled source records",
+      artifactRootName: "dist",
+      packageManifest: undefined,
+      expectedLabel: "artifact",
+    },
+    {
+      name: "ignores stale staging builds for source-external records",
+      artifactRootName: "dist-runtime",
+      packageManifest: { build: { bundledDist: false as const } },
+      expectedLabel: "source",
+    },
+  ])("$name", ({ artifactRootName, packageManifest, expectedLabel }) => {
     const packageRoot = makeTempDir();
-    const pluginRoot = path.join(packageRoot, "extensions", "slack");
-    const sourceSetup = path.join(pluginRoot, "setup-entry.ts");
-    const builtSetup = path.join(packageRoot, "dist", "extensions", "slack", "setup-entry.js");
+    const pluginRoot = path.join(packageRoot, "extensions", "fixture");
+    const sourceSetup = path.join(pluginRoot, "setup-api.ts");
+    const artifactSetup = path.join(
+      packageRoot,
+      artifactRootName,
+      "extensions",
+      "fixture",
+      "setup-api.js",
+    );
     fs.mkdirSync(path.dirname(sourceSetup), { recursive: true });
-    fs.mkdirSync(path.dirname(builtSetup), { recursive: true });
+    fs.mkdirSync(path.dirname(artifactSetup), { recursive: true });
     fs.writeFileSync(sourceSetup, "export default {};\n", "utf-8");
-    fs.writeFileSync(builtSetup, "export default {};\n", "utf-8");
+    fs.writeFileSync(artifactSetup, "export default {};\n", "utf-8");
     mocks.loadPluginManifestRegistry.mockReturnValue({
       plugins: [
         {
-          id: "slack",
+          id: "fixture",
           origin: "bundled",
           rootDir: pluginRoot,
           setupSource: sourceSetup,
+          packageManifest,
+          setup: { providers: [{ id: "fixture" }] },
         },
       ],
       diagnostics: [],
     });
+    const artifactRealPath = fs.realpathSync(artifactSetup);
+    mocks.createJiti.mockImplementation(() => (modulePath: string) => ({
+      default: {
+        register(api: {
+          registerProvider: (provider: { id: string; label: string; auth: [] }) => void;
+        }) {
+          api.registerProvider({
+            id: "fixture",
+            label: modulePath === artifactRealPath ? "artifact" : "source",
+            auth: [],
+          });
+        },
+      },
+    }));
 
-    resolvePluginSetupRegistry({ env: {} });
+    expect(resolvePluginSetupProviderCore({ provider: "fixture", env: {} })?.label).toBe(
+      expectedLabel,
+    );
+  });
 
-    expect(mockArg(mocks.createJiti, 0, 0)).toBe(builtSetup);
+  it("keeps bundled setup artifact selection independent of active runtime state", () => {
+    const setupRegistrySource = fs.readFileSync(
+      new URL("./setup-registry.ts", import.meta.url),
+      "utf8",
+    );
+    const selectionSource = fs.readFileSync(
+      new URL("./plugin-runtime-artifact-selection.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(setupRegistrySource).not.toContain("plugin-runtime-artifact-resolution");
+    expect(setupRegistrySource).not.toContain('from "./runtime.js"');
+    expect(selectionSource).not.toContain("plugin-runtime-artifact-resolution");
+    expect(selectionSource).not.toMatch(/from ["']\.\/runtime(?:\.js|\/)/u);
   });
 
   it("skips setup-api loading when config has no relevant migration triggers", () => {
@@ -495,7 +561,8 @@ describe("setup-registry module loader", () => {
           register(api: {
             registerProvider: (provider: {
               id: string;
-              aliases: string[];
+              aliases?: string[];
+              hookAliases?: string[];
               label: string;
               auth: [];
             }) => void;
@@ -503,7 +570,13 @@ describe("setup-registry module loader", () => {
             api.registerProvider({
               id: "openai",
               aliases: ["openai"],
-              label: "OpenAI",
+              label: "OpenAI legacy match",
+              auth: [],
+            });
+            api.registerProvider({
+              id: "openai-current",
+              hookAliases: ["openai"],
+              label: "OpenAI current match",
               auth: [],
             });
           },
@@ -512,8 +585,8 @@ describe("setup-registry module loader", () => {
     });
 
     const provider = requireRecord(resolvePluginSetupProviderCore({ provider: "openai", env: {} }));
-    expect(provider.id).toBe("openai");
-    expect(provider.label).toBe("OpenAI");
+    expect(provider.id).toBe("openai-current");
+    expect(provider.label).toBe("OpenAI current match");
   });
 
   it("treats explicit descriptor-only setup as a runtime cutoff", () => {
@@ -888,6 +961,26 @@ describe("setup-registry module loader", () => {
     expect(registry.diagnostics).toMatchObject([
       { pluginId: "broken-entry", code: "setup-entry-load-failed" },
     ]);
+  });
+
+  it("surfaces setup entry load failures from targeted provider lookup", () => {
+    const brokenRoot = makeTempDir();
+    writeSetupApiStub(brokenRoot);
+    mockSinglePlugin({
+      id: "broken-provider",
+      rootDir: brokenRoot,
+      setup: { providers: [{ id: "broken-provider" }] },
+    });
+    mocks.createJiti.mockImplementation(() => () => {
+      throw new Error("targeted module parse failed");
+    });
+
+    expect(
+      resolvePluginSetupProviderCore({ provider: "broken-provider", env: {} }),
+    ).toBeUndefined();
+    expect(setupRegistryWarn).toHaveBeenCalledWith(
+      expect.stringContaining("setup-entry-load-failed"),
+    );
   });
 
   it("publishes each plugin setup registration atomically on synchronous success", () => {

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -22,6 +22,7 @@ import {
   getCachedPluginModuleLoader,
 } from "./plugin-module-loader-cache.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "./plugin-registry.js";
+import { resolvePreferredBundledRootArtifact } from "./plugin-runtime-artifact-selection.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { listSetupCliBackendIds, listSetupProviderIds } from "./setup-descriptors.js";
 import { pluginSetupRegistryLoaderState } from "./setup-registry-loader-state.js";
@@ -228,49 +229,21 @@ function resolveRegister(mod: OpenClawPluginModule): {
   return {};
 }
 
-function rewriteBundledSetupSourceToBuiltArtifact(
-  source: string,
-  record: PluginManifestRecord,
-): { source: string; rootDir: string } {
-  const sourceArtifact = { source, rootDir: record.rootDir };
-  if (record.origin !== "bundled") {
-    return sourceArtifact;
-  }
-  const rootDir = path.resolve(record.rootDir);
-  const sourcePath = path.resolve(source);
-  const extensionsDir = path.dirname(rootDir);
-  if (path.basename(extensionsDir) !== "extensions") {
-    return sourceArtifact;
-  }
-  const packageRoot = path.dirname(extensionsDir);
-  if (path.basename(packageRoot) === "dist" || path.basename(packageRoot) === "dist-runtime") {
-    return sourceArtifact;
-  }
-  const relativeSource = path.relative(rootDir, sourcePath);
-  if (relativeSource === "" || relativeSource.startsWith("..") || path.isAbsolute(relativeSource)) {
-    return sourceArtifact;
-  }
-  const artifactRelativePath = relativeSource.replace(/\.[^.]+$/u, ".js");
-  for (const artifactRootName of ["dist-runtime", "dist"] as const) {
-    const artifactRoot = path.join(
-      packageRoot,
-      artifactRootName,
-      "extensions",
-      path.basename(rootDir),
-    );
-    const candidate = path.join(artifactRoot, artifactRelativePath);
-    if (fs.existsSync(candidate)) {
-      return { source: candidate, rootDir: artifactRoot };
-    }
-  }
-  return sourceArtifact;
-}
-
 function resolveLoadableSetupRuntimeSource(
   record: PluginManifestRecord,
 ): { source: string; rootDir: string } | null {
   const source = record.setupSource ?? resolveSetupApiPath(record.rootDir);
-  return source ? rewriteBundledSetupSourceToBuiltArtifact(source, record) : null;
+  if (!source) {
+    return null;
+  }
+  if (record.origin !== "bundled") {
+    return { source, rootDir: record.rootDir };
+  }
+  return resolvePreferredBundledRootArtifact({
+    source,
+    rootDir: record.rootDir,
+    packageManifest: record.packageManifest,
+  });
 }
 
 function resolveDeclaredSetupRuntimeSource(record: PluginManifestRecord): string | null {
@@ -284,7 +257,7 @@ function resolveDeclaredSetupRuntimeSource(record: PluginManifestRecord): string
 
 function resolveSetupRegistration(
   record: PluginManifestRecord,
-  diagnostics?: PluginSetupRegistryDiagnostic[],
+  diagnostics: PluginSetupRegistryDiagnostic[],
 ): {
   setupSource: string;
   register: (api: ReturnType<typeof buildPluginApi>) => void | Promise<void>;
@@ -304,7 +277,7 @@ function resolveSetupRegistration(
   } catch (error) {
     // A broken setup entry silently removes the plugin's providers/CLI
     // backends/migrations from onboarding; record why instead of vanishing.
-    diagnostics?.push({
+    diagnostics.push({
       pluginId: record.id,
       code: "setup-entry-load-failed",
       message: `setup entry failed to load from ${setupSource}: ${String(error)}`,
@@ -523,6 +496,12 @@ function findUniqueSetupManifestOwner(params: {
   // Setup lookup can execute plugin code. Refuse ambiguous ownership instead of
   // depending on manifest ordering across bundled/workspace/global sources.
   return matches.length === 1 ? matches[0] : undefined;
+}
+
+function resolveSetupRegistryForManifestOwner(record: PluginManifestRecord): PluginSetupRegistry {
+  return resolvePluginSetupRegistry({
+    manifestRegistry: { plugins: [record], diagnostics: [] },
+  });
 }
 
 function mapNormalizedIds(ids: readonly string[]): Map<string, string> {
@@ -785,42 +764,9 @@ export function resolvePluginSetupProviderCore(params: {
   if (!record) {
     return undefined;
   }
-
-  const setupRegistration = resolveSetupRegistration(record);
-  if (!setupRegistration) {
-    return undefined;
-  }
-
-  let matchedProvider: ProviderPlugin | undefined;
-  const localProviderKeys = new Set<string>();
-  const api = buildSetupPluginApi({
-    record,
-    setupSource: setupRegistration.setupSource,
-    handlers: {
-      registerProvider(provider) {
-        const key = normalizeProviderId(provider.id);
-        if (localProviderKeys.has(key)) {
-          return;
-        }
-        localProviderKeys.add(key);
-        if (matchesProvider(provider, normalizedProvider)) {
-          matchedProvider = provider;
-        }
-      },
-      registerConfigMigration() {},
-      registerAutoEnableProbe() {},
-    },
-  });
-
-  if (
-    !runSetupRegistration(setupRegistration.register, api, (error) => {
-      log.warn(`plugin setup [${record.id}] setup-registration-failed: ${String(error)}`);
-    })
-  ) {
-    return undefined;
-  }
-
-  return matchedProvider;
+  return resolveSetupRegistryForManifestOwner(record).providers.findLast((entry) =>
+    matchesProvider(entry.provider, normalizedProvider),
+  )?.provider;
 }
 
 export function resolvePluginSetupCliBackend(params: {
@@ -848,44 +794,9 @@ export function resolvePluginSetupCliBackend(params: {
   if (!record) {
     return undefined;
   }
-
-  const setupRegistration = resolveSetupRegistration(record);
-  if (!setupRegistration) {
-    return undefined;
-  }
-
-  let matchedBackend: CliBackendPlugin | undefined;
-  const localBackendKeys = new Set<string>();
-  const api = buildSetupPluginApi({
-    record,
-    setupSource: setupRegistration.setupSource,
-    handlers: {
-      registerProvider() {},
-      registerConfigMigration() {},
-      registerAutoEnableProbe() {},
-      registerCliBackend(backend) {
-        const key = normalizeProviderId(backend.id);
-        if (localBackendKeys.has(key)) {
-          return;
-        }
-        localBackendKeys.add(key);
-        if (key === normalized) {
-          matchedBackend = backend;
-        }
-      },
-    },
-  });
-
-  if (
-    !runSetupRegistration(setupRegistration.register, api, (error) => {
-      log.warn(`plugin setup [${record.id}] setup-registration-failed: ${String(error)}`);
-    })
-  ) {
-    return undefined;
-  }
-
-  const resolvedEntry = matchedBackend ? { pluginId: record.id, backend: matchedBackend } : null;
-  return resolvedEntry ?? undefined;
+  return resolveSetupRegistryForManifestOwner(record).cliBackends.find(
+    (entry) => normalizeProviderId(entry.backend.id) === normalized,
+  );
 }
 
 export function runPluginSetupConfigMigrations(params: {


### PR DESCRIPTION
## What Problem This Solves

Plugin setup registration and runtime artifact selection duplicated the same ownership decisions across the registry and artifact resolver. The parallel layers made setup execution, artifact preference, and fallback ordering harder to keep consistent.

## Why This Change Was Made

The setup registry now uses one canonical artifact-selection contract shared with runtime resolution. The new internal selector owns candidate preference and fallback ordering, while the public setup/runtime surfaces and plugin activation boundaries remain unchanged.

## User Impact

There is no intended public API or configuration change. Plugin setup and runtime artifact resolution now follow the same deterministic registration contract with fewer private layers.

## Evidence

- Two focused regressions failed before the repair and pass afterward.
- Setup-registry owner and sibling coverage passes 175 tests.
- Exact changed-path type checks, lint, formatting, and full changed-gate checks pass.
- Fresh autoreview and independent review report no actionable findings.
- Production delta: +193/-250, net -57 lines; tests +106/-13.
- A task-owned exact-lock dependency overlay links workspace packages to this worktree's own build outputs. The recovered `runtime-postbuild` verifies 48 built modules across 11 phases, and full `pnpm build` passes end to end: tsdown 9/9, packages, 63 external plugins, CLI bootstrap, runtime postbuild, SDK 147, UI/build-info, and CLI metadata. No dependency or overlay change is committed.
