### PR TITLE
fix(gateway): connection-liveness tests flake under cold-cache CI shards

### DIFF
--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
@@ -64,11 +64,28 @@ describe.sequential("authenticated request connection liveness", () => {
     const held = new Promise<void>((resolve) => {
       releaseHandler = resolve;
     });
-    runtime.beforeHandler.mockReturnValue(held);
+    // Dispatch is fire-and-forget behind a shared lazy import, so the handler
+    // may start well after dispatch() resolves. Synchronize on the handler's
+    // own entry/response signals instead of polling call counts on a clock.
+    let handlerStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      handlerStarted = resolve;
+    });
+    runtime.beforeHandler.mockImplementation(() => {
+      handlerStarted();
+      return held;
+    });
     const state = createGatewayConnectionState({ cfg: {} });
     const client = createClient();
     state.clients.add(client);
-    const send = vi.fn((_frame: unknown) => ({ kind: "sent" }) as const);
+    let respondToRequest!: (frame: unknown) => void;
+    const response = new Promise<unknown>((resolve) => {
+      respondToRequest = resolve;
+    });
+    const send = vi.fn((frame: unknown) => {
+      respondToRequest(frame);
+      return { kind: "sent" } as const;
+    });
     const context = {
       getRuntimeConfig: () => ({}),
       logGateway: { error: vi.fn() },
@@ -93,15 +110,15 @@ describe.sequential("authenticated request connection liveness", () => {
       { type: "req", id: testCase.method, method: testCase.method, params: testCase.params },
       client,
     );
-    await vi.waitFor(() => expect(runtime.beforeHandler).toHaveBeenCalledOnce());
+    await started;
 
     state.clients.delete(client);
     state.sessionEventSubscribers.unsubscribe(client.connId);
     state.sessionMessageSubscribers.unsubscribeAll(client.connId);
     releaseHandler();
 
-    await vi.waitFor(() =>
-      expect(send).toHaveBeenCalledWith(expect.objectContaining({ id: testCase.method, ok: true })),
+    await expect(response).resolves.toEqual(
+      expect.objectContaining({ id: testCase.method, ok: true }),
     );
     testCase.assertEmpty(state);
   });


### PR DESCRIPTION
Related: #130427

## What Problem This Solves

Fixes an issue where CI runs would intermittently fail the gateway connection-liveness suite (`authenticated-request-dispatch.connection-liveness.test.ts`) when a shard ran with a cold transform cache or under heavy load. Both disconnect-cleanup tests failed together with the signature pair "expected vi.fn() to be called once, but got 0 times" then "got 2 times" (seen on #130427 head `63b6739`, job `checks-node-compact-large-10`, shard `agentic-gateway-core-3`; attempt 2 passed). This is test nondeterminism reproduced and fixed at its root cause, not a failure that is red on `main`.

## Why This Change Was Made

The tests polled mock call counts with `vi.waitFor`, whose default 1s timeout is wall-clock-bound. Dispatch is fire-and-forget behind a single shared lazy dynamic import (`createLazyPromise` in `authenticated-request-dispatch.ts`), and the test's `vi.mock` factory transforms the `sessions-subscriptions` module graph inside that import — so on a cold cache the handler regularly starts after the 1s cap. Test 1 then fails with 0 calls and leaves a dangling in-flight dispatch; when the shared import resolves, that straggler and test 2's request resume in the same tick, so test 2's freshly-reset counter jumps 0→2 between polls. The fix replaces both clock-capped count polls with synchronization on signals the code under test produces: a deferred resolved at handler entry and a deferred resolved with the response frame. The asserted invariant (a late subscribe after disconnect cleanup responds `ok: true` but registers nothing, per #124771) is unchanged.

## User Impact

No product behavior changes; the diff is confined to one test file. Developers and maintainers stop seeing spurious red CI on unrelated PRs from this suite.

## Evidence

Reproduced before fixing:

- A genuinely cold run (first run after `pnpm install`, `import 99.9s`) failed both tests locally at the `vi.waitFor` line, matching CI.
- Simulating the slow import deterministically (temporary 1.2s delay in the `vi.mock` factory) produced the exact CI pair: test 1 "expected once, got 0 times", test 2 "got 2 times", both at the same line.

Verified after fixing:

- The fixed tests pass with that same 1.2s simulated slow import in place.
- With the simulation removed and `node_modules/.vite/vitest` cleared, 12/12 repeat runs passed, each alongside six 25s CPU-burner processes to simulate shard contention:

```sh
for i in $(seq 1 12); do
  for j in 1 2 3 4 5 6; do node -e 'const t=Date.now();while(Date.now()-t<25000){Math.sqrt(Math.random())}' & done
  node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-core.config.ts \
    src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
  wait
done
# passes=12 failures=0
```

- `oxfmt --check` and `tsc --noEmit` are clean; autoreview (Codex) reported no actionable findings.

AI-assisted: investigated and authored with Claude Code (Claude Fable 5), directed and reviewed by @jalehman.
