### PR TITLE
fix(code-mode): avoid repair mode for invalid nested calls

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2075,7 +2075,7 @@ src/agents/tool-result-error.ts	3
 src/agents/tool-schema-hints.ts	1
 src/agents/tool-search-catalog.ts	6
 src/agents/tool-search-directory.ts	1
-src/agents/tool-search-runtime.ts	6
+src/agents/tool-search-runtime.ts	4
 src/agents/tool-search-transcript.ts	3
 src/agents/tool-search.ts	1
 src/agents/tools-effective-inventory-build.ts	2

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -90,9 +90,8 @@ import {
 } from "./tool-result-error.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
-type BeforeToolCallWrapperOptions = {
+type BeforeToolCallWrapperOptions = BeforeToolCallDiagnosticOptions & {
   approvalMode?: "request" | "report" | "deny";
-  emitDiagnostics: boolean;
 };
 type ForwardedToolExecution = (...args: unknown[]) => ReturnType<AnyAgentTool["execute"]>;
 const MAX_TRACKED_ADJUSTED_PARAMS = 1024;
@@ -294,7 +293,7 @@ export function buildBlockedToolResult(params: {
 export function wrapToolWithBeforeToolCallHook(
   tool: AnyAgentTool,
   ctx?: HookContext,
-  options: { approvalMode?: "request" | "report" | "deny"; emitDiagnostics?: boolean } = {},
+  options: Partial<BeforeToolCallWrapperOptions> = {},
 ): AnyAgentTool {
   const execute = tool.execute;
   if (!execute) {
@@ -303,7 +302,7 @@ export function wrapToolWithBeforeToolCallHook(
   const toolName = tool.name || "tool";
   const diagnosticIdentity = resolveToolDiagnosticIdentity(tool);
   const hookOptions: BeforeToolCallWrapperOptions = {
-    ...(options.approvalMode ? { approvalMode: options.approvalMode } : {}),
+    ...options,
     emitDiagnostics: options.emitDiagnostics !== false,
   };
   const toolContentPolicy = resolveDiagnosticModelContentCapturePolicy(ctx?.config);
@@ -552,7 +551,8 @@ export function wrapToolWithBeforeToolCallHook(
             ...executionArgs,
           );
         } catch (error) {
-          throw tool.resultContentSource === "network" &&
+          throw hookOptions.protectNetworkErrors !== false &&
+            tool.resultContentSource === "network" &&
             getBeforeToolCallFailureDisposition(error) === undefined
             ? protectNetworkToolExecutionError(error, "Tool execution failed.", signal)
             : error;
@@ -698,7 +698,7 @@ export function wrapToolWithBeforeToolCallHook(
     enumerable: true,
   });
   Object.defineProperty(wrappedTool, BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS, {
-    value: hookOptions satisfies BeforeToolCallDiagnosticOptions,
+    value: hookOptions,
     enumerable: false,
   });
   Object.defineProperty(wrappedTool, BEFORE_TOOL_CALL_SOURCE_TOOL, {

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -69,6 +69,7 @@ import {
   BEFORE_TOOL_CALL_SOURCE_TOOL,
   BEFORE_TOOL_CALL_WRAPPED,
   clearBeforeToolCallWrappedMarker,
+  getBeforeToolCallDiagnosticOptions,
   getBeforeToolCallHookContext,
   getBeforeToolCallSourceTool,
   type BeforeToolCallDiagnosticOptions,
@@ -90,9 +91,6 @@ import {
 } from "./tool-result-error.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
-type BeforeToolCallWrapperOptions = BeforeToolCallDiagnosticOptions & {
-  approvalMode?: "request" | "report" | "deny";
-};
 type ForwardedToolExecution = (...args: unknown[]) => ReturnType<AnyAgentTool["execute"]>;
 const MAX_TRACKED_ADJUSTED_PARAMS = 1024;
 const INTERNAL_DISPOSED_RESULT = {
@@ -293,7 +291,7 @@ export function buildBlockedToolResult(params: {
 export function wrapToolWithBeforeToolCallHook(
   tool: AnyAgentTool,
   ctx?: HookContext,
-  options: Partial<BeforeToolCallWrapperOptions> = {},
+  options: Partial<BeforeToolCallDiagnosticOptions> = {},
 ): AnyAgentTool {
   const execute = tool.execute;
   if (!execute) {
@@ -301,7 +299,7 @@ export function wrapToolWithBeforeToolCallHook(
   }
   const toolName = tool.name || "tool";
   const diagnosticIdentity = resolveToolDiagnosticIdentity(tool);
-  const hookOptions: BeforeToolCallWrapperOptions = {
+  const hookOptions: BeforeToolCallDiagnosticOptions = {
     ...options,
     emitDiagnostics: options.emitDiagnostics !== false,
   };
@@ -716,12 +714,14 @@ export function wrapToolWithBeforeToolCallHook(
 export function rewrapToolWithBeforeToolCallHook(
   tool: AnyAgentTool,
   ctx?: HookContext,
-  options: { approvalMode?: "request" | "report" | "deny"; emitDiagnostics?: boolean } = {},
+  options: Partial<BeforeToolCallDiagnosticOptions> = {},
 ): AnyAgentTool {
   const preservedContext = getBeforeToolCallHookContext(tool);
   const sourceTool = getBeforeToolCallSourceTool(tool) ?? tool;
+  const preservedOptions = getBeforeToolCallDiagnosticOptions(tool);
+  const wrapperOptions = { ...preservedOptions, ...options };
   if (sourceTool === tool) {
-    return wrapToolWithBeforeToolCallHook(tool, ctx ?? preservedContext, options);
+    return wrapToolWithBeforeToolCallHook(tool, ctx ?? preservedContext, wrapperOptions);
   }
   // Preserve post-wrap schema/metadata while restoring the source execute function.
   const rewrapSource: AnyAgentTool = {
@@ -731,7 +731,7 @@ export function rewrapToolWithBeforeToolCallHook(
   clearBeforeToolCallWrappedMarker(rewrapSource);
   copyBeforeToolCallWrapperMetadata(tool, rewrapSource);
   copyAgentToolSourceExecutionGuard(tool, rewrapSource);
-  return wrapToolWithBeforeToolCallHook(rewrapSource, ctx ?? preservedContext, options);
+  return wrapToolWithBeforeToolCallHook(rewrapSource, ctx ?? preservedContext, wrapperOptions);
 }
 
 function recordPreExecutionBlockedToolCall(toolCallId?: string, runId?: string): void {

--- a/src/agents/before-tool-call-metadata.ts
+++ b/src/agents/before-tool-call-metadata.ts
@@ -4,6 +4,7 @@ import type { AnyAgentTool } from "./tools/common.js";
 export type BeforeToolCallDiagnosticOptions = {
   emitDiagnostics: boolean;
   protectNetworkErrors?: boolean;
+  approvalMode?: "request" | "report" | "deny";
 };
 
 export const BEFORE_TOOL_CALL_WRAPPED = Symbol("beforeToolCallWrapped");
@@ -45,6 +46,12 @@ export function setBeforeToolCallDiagnosticsEnabled(tool: AnyAgentTool, enabled:
   if (options) {
     options.emitDiagnostics = enabled;
   }
+}
+
+export function getBeforeToolCallDiagnosticOptions(
+  tool: AnyAgentTool,
+): BeforeToolCallDiagnosticOptions | undefined {
+  return withBeforeToolCallMetadata(tool)[BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS];
 }
 
 /** Copy before_tool_call marker metadata when another wrapper replaces a tool. */

--- a/src/agents/before-tool-call-metadata.ts
+++ b/src/agents/before-tool-call-metadata.ts
@@ -3,6 +3,7 @@ import type { AnyAgentTool } from "./tools/common.js";
 
 export type BeforeToolCallDiagnosticOptions = {
   emitDiagnostics: boolean;
+  protectNetworkErrors?: boolean;
 };
 
 export const BEFORE_TOOL_CALL_WRAPPED = Symbol("beforeToolCallWrapped");

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -84,6 +84,7 @@ export async function runCodeModeExec(params: {
   }
   const runtime = new ToolSearchRuntime(params.ctx, toToolSearchConfig(config), {
     prepareInput: true,
+    validateInput: true,
   });
   params.onRuntime?.(runtime);
   const bridgeDispatch = createCodeModeBridgeDispatchState();

--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -109,28 +109,6 @@ describe("headless Code Mode", () => {
     expect(second.execute).toHaveBeenCalledOnce();
   });
 
-  it("rejects schema-invalid nested input before headless tool execution", async () => {
-    const strict = fakeTool("headless_strict", async () => jsonResult({ unexpected: true }));
-    strict.parameters = {
-      type: "object",
-      properties: { value: { type: "string" } },
-      required: ["value"],
-      additionalProperties: false,
-    };
-
-    const result = expectFailed(
-      await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([strict]),
-        code: "return await headless_strict({ value: 42 });",
-        wallClockMs: 120_000,
-      }),
-    );
-
-    expect(result.error).toContain("value");
-    expect(result.toolCallCount).toBe(1);
-    expect(strict.execute).not.toHaveBeenCalled();
-  });
-
   it("keeps the headless race winner when the later-started tool settles first", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const events: string[] = [];

--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -109,6 +109,28 @@ describe("headless Code Mode", () => {
     expect(second.execute).toHaveBeenCalledOnce();
   });
 
+  it("rejects schema-invalid nested input before headless tool execution", async () => {
+    const strict = fakeTool("headless_strict", async () => jsonResult({ unexpected: true }));
+    strict.parameters = {
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+      additionalProperties: false,
+    };
+
+    const result = expectFailed(
+      await runCodeModeScriptHeadless({
+        ctx: createHeadlessHarness([strict]),
+        code: "return await headless_strict({ value: 42 });",
+        wallClockMs: 120_000,
+      }),
+    );
+
+    expect(result.error).toContain("value");
+    expect(result.toolCallCount).toBe(1);
+    expect(strict.execute).not.toHaveBeenCalled();
+  });
+
   it("keeps the headless race winner when the later-started tool settles first", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const events: string[] = [];

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -220,6 +220,7 @@ export async function runCodeModeScriptHeadless(params: {
     const codeModeRunId = `cm_headless_${randomUUID()}`;
     const runtime = new ToolSearchRuntime(params.ctx, toToolSearchConfig(config), {
       prepareInput: true,
+      validateInput: true,
     });
     const bridgeDispatch = createCodeModeBridgeDispatchState();
     const namespaceCatalog = runtime.namespaceEntries();

--- a/src/agents/code-mode-headless.validation.test.ts
+++ b/src/agents/code-mode-headless.validation.test.ts
@@ -1,0 +1,41 @@
+import { expect, it, vi } from "vitest";
+import { runCodeModeScriptHeadless } from "./code-mode.js";
+import {
+  createToolSearchCatalogRef,
+  registerHeadlessToolSearchCatalog,
+  type ToolSearchToolContext,
+} from "./tool-search.js";
+import { jsonResult, type AnyAgentTool } from "./tools/common.js";
+
+it("rejects schema-invalid nested input before headless tool execution", async () => {
+  const strict: AnyAgentTool = {
+    name: "headless_strict",
+    label: "headless_strict",
+    description: "Strict headless test tool",
+    parameters: {
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+      additionalProperties: false,
+    },
+    execute: vi.fn(async () => jsonResult({ unexpected: true })),
+  };
+  const config = { tools: { codeMode: { enabled: false, timeoutMs: 60_000 } } } as never;
+  const catalogRef = createToolSearchCatalogRef();
+  registerHeadlessToolSearchCatalog({ catalogRef, tools: [strict] });
+  const ctx: ToolSearchToolContext = { config, runtimeConfig: config, agentId: "main", catalogRef };
+
+  const result = await runCodeModeScriptHeadless({
+    ctx,
+    code: "return await headless_strict({ value: 42 });",
+    wallClockMs: 120_000,
+  });
+
+  expect(result.status).toBe("failed");
+  if (result.status !== "failed") {
+    throw new Error("expected headless Code Mode failure");
+  }
+  expect(result.error).toContain("value");
+  expect(result.toolCallCount).toBe(1);
+  expect(strict.execute).not.toHaveBeenCalled();
+});

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -325,10 +325,6 @@ function isPendingBridgeRequestReplaySafe(
   return binding ? runtime.isReplaySafeExactId(binding.id) : false;
 }
 
-function isPendingBridgeRequestSideEffectFree(request: PendingBridgeRequest): boolean {
-  return request.method === "nodes" && (request.args[0] === "list" || request.args[0] === "get");
-}
-
 function enforceSnapshotStateLimits(params: {
   snapshotBytes: Uint8Array;
   config: CodeModeConfig;
@@ -367,7 +363,12 @@ export function createPendingBridgeStates(params: {
     const target = params.catalogProjection.byCallableName.get(String(request.args[0]));
     const yieldRunSignal = target?.name === "sessions_yield" ? params.ctx.abortSignal : undefined;
     const tracksDispatch = request.method !== "sleep";
-    const sideEffectFree = isPendingBridgeRequestSideEffectFree(request);
+    // Exact catalog binding rejects shadowed or untrusted tools before core replay-safety applies.
+    const sideEffectFree =
+      (request.method === "nodes" &&
+        (request.args[0] === "list" || request.args[0] === "get")) ||
+      (request.method === "callValue" &&
+        isPendingBridgeRequestReplaySafe(request, params.runtime, params.catalogProjection));
     if (tracksDispatch) {
       params.bridgeDispatch.started = true;
       if (!sideEffectFree) {

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -363,15 +363,14 @@ export function createPendingBridgeStates(params: {
     const target = params.catalogProjection.byCallableName.get(String(request.args[0]));
     const yieldRunSignal = target?.name === "sessions_yield" ? params.ctx.abortSignal : undefined;
     const tracksDispatch = request.method !== "sleep";
-    // Exact catalog binding rejects shadowed or untrusted tools before core replay-safety applies.
-    const sideEffectFree =
-      (request.method === "nodes" &&
-        (request.args[0] === "list" || request.args[0] === "get")) ||
+    // Exact catalog binding rejects shadowed or untrusted tools before replay-safety applies.
+    const recoverySafe =
+      (request.method === "nodes" && (request.args[0] === "list" || request.args[0] === "get")) ||
       (request.method === "callValue" &&
         isPendingBridgeRequestReplaySafe(request, params.runtime, params.catalogProjection));
     if (tracksDispatch) {
       params.bridgeDispatch.started = true;
-      if (!sideEffectFree) {
+      if (!recoverySafe) {
         params.bridgeDispatch.potentiallyMutatingDispatches += 1;
       }
     }
@@ -399,7 +398,7 @@ export function createPendingBridgeStates(params: {
       ...request,
       promise: completion.then((settled) => {
         const trustedNoStart = tracksDispatch && consumeTrustedToolNoStartError(settled);
-        if (trustedNoStart && !sideEffectFree) {
+        if (trustedNoStart && !recoverySafe) {
           params.bridgeDispatch.potentiallyMutatingDispatches = Math.max(
             0,
             params.bridgeDispatch.potentiallyMutatingDispatches - 1,

--- a/src/agents/code-mode.agent-loop.test.ts
+++ b/src/agents/code-mode.agent-loop.test.ts
@@ -4,10 +4,11 @@ import {
   type Context,
   type Model,
 } from "openclaw/plugin-sdk/llm";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { applyCodeModeCatalog } from "./code-mode.js";
 import {
   createCodeModeHarness,
+  fakeTool,
   pluginToolWithExecute,
   resetCodeModeTestState,
 } from "./code-mode.test-support.js";
@@ -140,6 +141,65 @@ describe("Code Mode agent-loop error recovery", () => {
     });
   });
 
+  it("returns a schema-invalid nested call for ordinary recovery before execution", async () => {
+    const terminal = pluginToolWithExecute("terminal", "Open a terminal", async () =>
+      jsonResult({ unexpected: true }),
+    );
+    const recover = pluginToolWithExecute("recover_task", "Recover the task", async () =>
+      jsonResult({ recovered: true }),
+    );
+
+    const { agent, providerContexts, reconciliationCandidates } = await runCodeModeAgent({
+      hiddenTools: [terminal, recover],
+      programs: [
+        "return await terminal({ value: 42 });",
+        'return await recover_task({ value: "continue" });',
+      ],
+    });
+
+    expect(providerContexts).toHaveLength(3);
+    expect(providerContexts[1]?.messages).toContainEqual(
+      expect.objectContaining({
+        role: "toolResult",
+        toolName: "exec",
+        isError: true,
+        details: expect.objectContaining({
+          status: "failed",
+          failurePhase: "bridge",
+          bridgeDispatchStarted: true,
+          error: expect.stringContaining("value"),
+        }),
+      }),
+    );
+    expect(terminal.execute).not.toHaveBeenCalled();
+    expect(recover.execute).toHaveBeenCalledOnce();
+    expect(reconciliationCandidates).toBe(0);
+    expect(agent.state.messages.at(-1)).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "recovered" }],
+    });
+  });
+
+  it("returns an exact replay-safe post-dispatch failure for ordinary recovery", async () => {
+    const readOnly = fakeTool("sessions_history", "Read session history");
+    readOnly.execute = vi.fn(async () => {
+      throw new ToolInputError("read constraint rejected after dispatch");
+    }) as AnyAgentTool["execute"];
+    const recover = pluginToolWithExecute("recover_task", "Recover the task", async () =>
+      jsonResult({ recovered: true }),
+    );
+
+    const { providerContexts, reconciliationCandidates } = await runCodeModeAgent({
+      hiddenTools: [readOnly, recover],
+      programs: ["return await sessions_history({});", "return await recover_task({});"],
+    });
+
+    expect(providerContexts).toHaveLength(3);
+    expect(readOnly.execute).toHaveBeenCalledOnce();
+    expect(recover.execute).toHaveBeenCalledOnce();
+    expect(reconciliationCandidates).toBe(0);
+  });
+
   it("lets the model correct successive JavaScript syntax and runtime errors", async () => {
     const complete = pluginToolWithExecute("complete_task", "Complete the task", async () =>
       jsonResult({ completed: true }),
@@ -194,11 +254,11 @@ describe("Code Mode agent-loop error recovery", () => {
     expect(reconciliationCandidates).toBe(1);
   });
 
-  it("routes a partially applied mutation to restricted reconciliation without replay", async () => {
+  it("routes a partially applied mutation with an input error to restricted reconciliation", async () => {
     const appliedChanges: string[] = [];
     const applyPatch = pluginToolWithExecute("apply_patch", "Apply a patch", async () => {
       appliedChanges.push("first hunk applied");
-      throw new Error("second hunk is ambiguous");
+      throw new ToolInputError("second hunk input is ambiguous after applying the first");
     });
     const write = pluginToolWithExecute("write", "Repeat a mutation", async () =>
       jsonResult({ repeated: true }),

--- a/src/agents/code-mode.agent-loop.test.ts
+++ b/src/agents/code-mode.agent-loop.test.ts
@@ -5,6 +5,7 @@ import {
   type Model,
 } from "openclaw/plugin-sdk/llm";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { setPluginToolMeta } from "../plugins/tools.js";
 import { applyCodeModeCatalog } from "./code-mode.js";
 import {
   createCodeModeHarness,
@@ -198,6 +199,34 @@ describe("Code Mode agent-loop error recovery", () => {
     expect(readOnly.execute).toHaveBeenCalledOnce();
     expect(recover.execute).toHaveBeenCalledOnce();
     expect(reconciliationCandidates).toBe(0);
+  });
+
+  it("keeps replay-safe side-effecting plugin failures in restricted reconciliation", async () => {
+    const appliedChanges: string[] = [];
+    const mutation = pluginToolWithExecute("plugin_mutation", "Mutate plugin state", async () => {
+      appliedChanges.push("plugin state changed");
+      throw new ToolInputError("plugin rejected input after mutation");
+    });
+    setPluginToolMeta(mutation, {
+      pluginId: "side-effecting-replay-safe-test",
+      optional: false,
+      replaySafe: true,
+      sideEffecting: true,
+    });
+    const recover = pluginToolWithExecute("recover_task", "Recover the task", async () =>
+      jsonResult({ recovered: true }),
+    );
+
+    const { providerContexts, reconciliationCandidates } = await runCodeModeAgent({
+      hiddenTools: [mutation, recover],
+      programs: ["return await plugin_mutation({});", "return await recover_task({});"],
+    });
+
+    expect(providerContexts).toHaveLength(1);
+    expect(mutation.execute).toHaveBeenCalledOnce();
+    expect(recover.execute).not.toHaveBeenCalled();
+    expect(reconciliationCandidates).toBe(1);
+    expect(appliedChanges).toEqual(["plugin state changed"]);
   });
 
   it("lets the model correct successive JavaScript syntax and runtime errors", async () => {

--- a/src/agents/code-mode.bridge.lifecycle.test.ts
+++ b/src/agents/code-mode.bridge.lifecycle.test.ts
@@ -233,7 +233,7 @@ describe("Code Mode subscribed bridge lifecycle", () => {
           ),
         );
         expect(suspended.status).toBe("waiting");
-        expect(target.execute).toHaveBeenCalledOnce();
+        await vi.waitFor(() => expect(target.execute).toHaveBeenCalledOnce());
         expect(countActiveToolExecutions(harness.runId)).toBe(1);
 
         const parked = testing.activeRuns.get(suspended.runId as string);

--- a/src/agents/code-mode.guest.test.ts
+++ b/src/agents/code-mode.guest.test.ts
@@ -492,6 +492,12 @@ describe("Code Mode guest execution", () => {
       sessionKey: "agent:main:main",
       runId: "run-code-mode",
       catalogRef,
+      toolHookContext: {
+        agentId: "main",
+        sessionId: "session-code-mode",
+        sessionKey: "agent:main:main",
+        runId: "run-code-mode",
+      },
     });
 
     let result = await expectDefined(tools[0], "exec tool").execute("code-call-network-error", {

--- a/src/agents/tool-search-catalog.ts
+++ b/src/agents/tool-search-catalog.ts
@@ -190,6 +190,30 @@ function wrapCatalogTool(tool: AnyAgentTool, hookContext?: HookContext): AnyAgen
   return wrapToolWithBeforeToolCallHook(tool, hookContext);
 }
 
+export function prepareToolSearchCatalogExecutionTool(
+  entry: ToolSearchCatalogEntry,
+  options: { prepareInput?: boolean; validateInput?: boolean },
+): CatalogTool {
+  const prepareInput =
+    options.prepareInput &&
+    entry.source === "openclaw" &&
+    "prepareBeforeToolCallParams" in entry.tool &&
+    typeof entry.tool.prepareBeforeToolCallParams === "function";
+  const validateInput = options.validateInput && entry.source === "openclaw";
+  if (!prepareInput && !validateInput) {
+    return entry.tool;
+  }
+  // SAFETY: both gates above restrict wrapper execution to OpenClaw-owned catalog tools.
+  const tool = entry.tool as AnyAgentTool;
+  const wrapperOptions = options.prepareInput ? { protectNetworkErrors: false } : undefined;
+  if (!isToolWrappedWithBeforeToolCallHook(tool)) {
+    return wrapToolWithBeforeToolCallHook(tool, undefined, wrapperOptions);
+  }
+  return wrapperOptions
+    ? rewrapToolWithBeforeToolCallHook(tool, undefined, wrapperOptions)
+    : entry.tool;
+}
+
 function toCatalogEntry(
   tool: CatalogTool,
   sourceOverride?: CatalogSource,

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -649,9 +649,10 @@ export class ToolSearchRuntime {
       entry.source === "openclaw" &&
       "prepareBeforeToolCallParams" in entry.tool &&
       typeof entry.tool.prepareBeforeToolCallParams === "function";
+    const wrapperOptions = this.options.prepareInput ? { protectNetworkErrors: false } : undefined;
     const executionTool =
       (prepareInput || validateInput) && !isToolWrappedWithBeforeToolCallHook(entry.tool as never)
-        ? wrapToolWithBeforeToolCallHook(entry.tool as never)
+        ? wrapToolWithBeforeToolCallHook(entry.tool as never, undefined, wrapperOptions)
         : entry.tool;
     const runExecution = async () => {
       const parentToolCallId = options?.parentToolCallId ?? toolCallId;
@@ -707,11 +708,10 @@ export class ToolSearchRuntime {
         )
       : await runExecution();
     const acceptedResult = await acceptResultBeforeProjection(result);
-    const parentToolCallId = options?.parentToolCallId;
-    if (parentToolCallId) {
+    if (options?.parentToolCallId) {
       this.terminalTargetBatchByParent.set(
-        parentToolCallId,
-        this.terminalTargetBatchByParent.get(parentToolCallId) !== false &&
+        options.parentToolCallId,
+        this.terminalTargetBatchByParent.get(options.parentToolCallId) !== false &&
           acceptedResult.terminate === true,
       );
     }

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -596,7 +596,9 @@ export class ToolSearchRuntime {
     }
     const pluginMeta = getPluginToolMeta(entry.tool as Parameters<typeof getPluginToolMeta>[0]);
     if (pluginMeta) {
-      return pluginMeta.mcp ? false : pluginMeta.replaySafe === true;
+      return pluginMeta.mcp
+        ? false
+        : pluginMeta.replaySafe === true && pluginMeta.sideEffecting !== true;
     }
     if (getChannelAgentToolMeta(entry.tool as never)) {
       return false;

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -12,8 +12,6 @@ import { levenshteinDistance } from "../shared/levenshtein-distance.js";
 import {
   getBeforeToolCallFailureDisposition,
   isPreExecutionBlockedToolResult,
-  isToolWrappedWithBeforeToolCallHook,
-  wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
 import { runWithToolExecutionValidation } from "./agent-tools.execution-validation.js";
 import { getChannelAgentToolMeta } from "./channel-tool-metadata.js";
@@ -25,6 +23,7 @@ import {
 } from "./tool-result-error.js";
 import {
   compactToolSearchCatalogEntry,
+  prepareToolSearchCatalogExecutionTool,
   resolveCatalog,
   visibleCatalogEntries,
 } from "./tool-search-catalog.js";
@@ -644,16 +643,7 @@ export class ToolSearchRuntime {
       return snapshot;
     };
     const validateInput = this.options.validateInput && entry.source === "openclaw";
-    const prepareInput =
-      this.options.prepareInput &&
-      entry.source === "openclaw" &&
-      "prepareBeforeToolCallParams" in entry.tool &&
-      typeof entry.tool.prepareBeforeToolCallParams === "function";
-    const wrapperOptions = this.options.prepareInput ? { protectNetworkErrors: false } : undefined;
-    const executionTool =
-      (prepareInput || validateInput) && !isToolWrappedWithBeforeToolCallHook(entry.tool as never)
-        ? wrapToolWithBeforeToolCallHook(entry.tool as never, undefined, wrapperOptions)
-        : entry.tool;
+    const executionTool = prepareToolSearchCatalogExecutionTool(entry, this.options);
     const runExecution = async () => {
       const parentToolCallId = options?.parentToolCallId ?? toolCallId;
       const signal = options?.signal ?? this.ctx.abortSignal;


### PR DESCRIPTION
## What Problem This Solves

Fixes two ways a rejected nested Code Mode call can unnecessarily stop the active task and force the next turn into read-only reconciliation:

1. schema-invalid OpenClaw inputs could reach execution because Code Mode input validation had been replaced by input preparation; and
2. an exact, authoritatively replay-safe core tool such as `sessions_history` was still counted as potentially mutating before its read-only implementation ran.

This PR supersedes #130405 without adopting its blanket `ToolInputError` exemption.

## Summary

### High Level TLDR

Restore nested OpenClaw schema validation while retaining input preparation, and use the existing exact-tool replay-safety classification when Code Mode accounts for nested `callValue` dispatches.

Schema-invalid calls now fail before implementation start. Calls bound to an exact replay-safe core tool do not create mutation uncertainty merely because their read validation fails after dispatch. Unknown, shadowed, plugin-unsafe, and mutating tools remain fail-closed.

### Root Cause

Commit `844e781ca40952c98ee997b016e3cc5d2f12f9f3` from #128054 replaced `validateInput: true` with `prepareInput: true` in both Code Mode runtime constructors:

```diff
-    validateInput: true,
+    prepareInput: true,
```

`ToolSearchRuntime` treats those as independent options and supports both simultaneously. The replacement unintentionally disabled final schema validation for nested OpenClaw calls.

A second accounting gap remained in `src/agents/code-mode-state.ts`: every nested `callValue` dispatch was counted as potentially mutating even though the exact catalog/runtime binding already classifies trusted core tools such as `sessions_history` as replay-safe. The node bridge already had the equivalent action-aware exception for `list` and `get`.

### Change

- enable `validateInput: true` alongside `prepareInput: true` in normal Code Mode execution
- apply the same restoration to headless Code Mode execution
- classify an exact nested `callValue` dispatch as side-effect-free only when the existing runtime says that exact bound tool is replay-safe
- retain fail-closed accounting for unknown, shadowed, plugin-unsafe, or mutating tools
- leave tool implementations, configuration, and the trusted no-start lifecycle boundary unchanged

Production LOC: +9/-7 (net +2) | Tests: +85/-3 (net +82)

## User Impact

- A schema-invalid nested call, such as an unsupported `terminal` action, can return a correctable pre-execution error instead of ending the task.
- A read-only `sessions_history` validation error can return to the model without falsely claiming that a mutation may have partially applied.
- A started mutating or unknown tool failure still requires reconciliation.

## Evidence

### Redacted observed behavior before this change

A persisted private-channel session was inspected read-only. All session, chat, message, account, node, run, and transcript identifiers are omitted.

- 14 read-only repair prompts were injected between 2026-08-23 and 2026-08-26.
- At `2026-08-26T16:02:40Z`, guest code called `terminal` with unsupported `action: "open"` plus unsupported `command` and `cwd` fields. The tool schema allows only `read`, `list`, `resize`, `close`, and `input`, with additional properties disabled.
- The recorded failure was `terminal action unavailable; use list, read, resize, close, or input`, with `bridgeDispatchStarted: true`.
- At `2026-08-26T20:30:06Z`, a read-only `sessions_history` call failed with `sessionId requires messageId`, also with `bridgeDispatchStarted: true`.
- After both failures, the next turn received the repair instruction that a previous Code Mode mutation may have partially applied, and the authorized multi-step task stopped instead of correcting the input.
- Applied deployment overlays were checked during RCA; none modified the affected Code Mode execution, Tool Search runtime, or tool-error paths.

The `terminal` case is covered by restored schema validation before implementation start. The `sessions_history` case is covered by the existing exact core-tool replay-safety classification: it is read-only even though its cross-field validation currently occurs inside `execute`.

### Provenance

- pre-execution repair support and `validateInput: true` were added in `c3ec166cbcdd405d7baef29a235f6a5f06a133cd`
- #128054 / `844e781ca40952c98ee997b016e3cc5d2f12f9f3` replaced validation with preparation in both constructors on 2026-08-23
- #129427 established action-aware side-effect accounting for `nodes.list` and `nodes.get`
- the first observed repeated repair prompt occurred on 2026-08-23

### Security boundary

This does not infer lifecycle state from the `ToolInputError` class. A tool may throw that error after implementation start or after a partial side effect, so #130405's blanket exemption was not carried forward.

The read-only accounting path requires the exact catalog binding and `ToolSearchRuntime.isReplaySafeExactId()`. That boundary rejects unknown targets, non-OpenClaw entries, channel tools, MCP tools without a trusted replay-safe declaration, and mutating core tools. Those calls continue to increment mutation uncertainty before dispatch.

Codex's separate V8 Code Mode implementation was inspected at sibling checkout `2f108f9fd970ed73df7e984d3a661acc02f33abc` (`codex-rs/tools/src/code_mode.rs:36-66`, `codex-rs/code-mode/src/service.rs:663-697`). It forwards nested calls to a delegate and does not own this OpenClaw QuickJS/Tool Search validation boundary.

## Verification

- Parent proof at `dcb20658fca8d3a253181124def9352c5d20b72d`: the normal schema-rejection regression, exact `sessions_history` recovery regression, and headless schema-rejection regression all failed for the intended missing behavior.
- Exact head `d1ad6c019f3ae770c683254ae8c9be94fed1b33f`: 149 focused tests passed across `code-mode.agent-loop.test.ts`, `code-mode-headless.test.ts`, `code-mode.replay.test.ts`, `code-mode.preflight-repair.test.ts`, and `tool-search-runtime.test.ts`.
- The unsafe negative case now throws `ToolInputError` after recording a partial mutation and still enters restricted reconciliation.
- Changed-file checks passed through core production typecheck. The aggregate core-test typecheck was locally blocked by the unrelated shared-checkout dependency error `ui/vite.config.ts: Could not find a declaration file for module 'pako'`; no PR file touches that surface.
- Autoreview on the exact full branch diff reported no actionable findings: patch correct, confidence 0.98.
- Hosted exact-head CI: pending.

## Alternatives Considered

- **Treat every `ToolInputError` as no-start:** rejected because the error class does not prove lifecycle position or absence of side effects.
- **Special-case `sessions_history`:** rejected in favor of the existing exact-tool replay-safety owner, which already distinguishes trusted read-only tools from unsafe or unknown entries.
- **Disable Code Mode:** rejected as a workaround that removes the intended compact tool surface.
- **Hide `terminal` globally:** not part of this repair; it remains valid for managing operator-opened Control UI terminals.

## What Was Not Tested

- read-only classification behavior through a live provider/channel turn
- a managed Gateway deployment or channel-visible runtime capture

