### PR TITLE
fix(models): model browsing fails after automatic plugin activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway model browsing:** preserve the published plugin metadata across catalog workers so multi-agent workspaces and automatic plugin activation do not break model browsing or auth refresh.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway model browsing:** preserve the published plugin metadata across catalog workers so multi-agent workspaces and automatic plugin activation do not break model browsing or auth refresh.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -10,6 +10,7 @@ import {
   loadGatewayModelCatalogSnapshot,
   loadPreparedGatewayModelCatalogSnapshot,
 } from "../gateway/server-model-catalog.js";
+import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { OPENAI_CODEX_DEFAULT_PROFILE_ID } from "./auth-profiles/constants.js";
 import { getRuntimeExternalCliProfileIds } from "./auth-profiles/runtime-external-profile-references.js";
@@ -201,7 +202,10 @@ module.exports = {
 async function createStaticSnapshot(
   spinMs: number,
   envOverride: NodeJS.ProcessEnv = {},
-  options?: { hydrateExternalCliProviderIds?: readonly string[] },
+  options?: {
+    hydrateExternalCliProviderIds?: readonly string[];
+    metadataWorkspace?: "gateway" | "none" | "activation";
+  },
 ) {
   const root = tempDirs.make("openclaw-model-catalog-worker-");
   const stateDir = path.join(root, "state");
@@ -293,6 +297,20 @@ async function createStaticSnapshot(
     30_000,
     "static",
     () => current,
+    false,
+    undefined,
+    options?.metadataWorkspace
+      ? loadPluginMetadataSnapshot({
+          config:
+            options.metadataWorkspace === "activation"
+              ? { ...config, plugins: { ...config.plugins, entries: {} } }
+              : config,
+          env,
+          ...(options.metadataWorkspace === "gateway"
+            ? { workspaceDir: path.join(root, "gateway-workspace") }
+            : {}),
+        })
+      : undefined,
   ).pending;
   return {
     agentDir,
@@ -314,6 +332,32 @@ async function waitForMarker(marker: string): Promise<void> {
 }
 
 describe("prepared model catalog worker boundary", () => {
+  it.each([
+    ["gateway", "catalog"],
+    ["gateway", "auth-refresh"],
+    ["none", "catalog"],
+    ["none", "auth-refresh"],
+    ["activation", "catalog"],
+    ["activation", "auth-refresh"],
+  ] as const)(
+    "keeps %s metadata discovery scope with %s first",
+    async (metadataWorkspace, first) => {
+      const fixture = await createStaticSnapshot(0, {}, { metadataWorkspace });
+      if (first === "auth-refresh") {
+        const auth = await loadPreparedModelRuntimeAuth(fixture.snapshot, {
+          providerIds: [PROVIDER_ID],
+        });
+        expect(auth?.authStore.profiles[EXTERNAL_AUTH_PROFILE_ID]).toMatchObject({
+          access: "v1:A",
+        });
+      }
+      const catalog = await fixture.snapshot.loadFullModelCatalog?.();
+      expect(catalog?.entries).toContainEqual(
+        expect.objectContaining({ provider: PROVIDER_ID, id: "plugin-generation-v1" }),
+      );
+    },
+  );
+
   it("publishes account-scoped harness models only in the full catalog", async () => {
     const fixture = await createStaticSnapshot(0);
 

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -25,6 +25,7 @@ export type PreparedModelCatalogWorkerInput = Readonly<{
   input: PreparedModelRuntimeInput;
   authStore: AuthProfileStore;
   providerIds: readonly string[];
+  pluginMetadataSnapshot: Omit<PluginMetadataSnapshot, "normalizePluginId">;
 }>;
 
 export type PreparedModelWorkerRequest =
@@ -115,6 +116,8 @@ export function createPreparedModelCatalogWorkerInput(params: {
   };
   const authStore = cloneAuthProfileStore(params.agentFacts.authStore);
   const providerIds = [...params.agentFacts.providerIds];
+  const { normalizePluginId: _normalizePluginId, ...pluginMetadataSnapshot } =
+    params.pluginMetadataSnapshot;
   return {
     kind: "catalog",
     generationFingerprint: fingerprintPreparedModelCatalogGeneration({
@@ -126,6 +129,7 @@ export function createPreparedModelCatalogWorkerInput(params: {
     input,
     authStore,
     providerIds,
+    pluginMetadataSnapshot,
   };
 }
 

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -1,5 +1,6 @@
 /** Worker-thread entrypoint for complete model-catalog discovery. */
 import { parentPort, workerData } from "node:worker_threads";
+import { restorePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
 import {
@@ -77,7 +78,17 @@ function refreshAuthStore(params: {
 
 async function prepareWorkerGeneration(value: PreparedModelCatalogWorkerInput) {
   const { prepareWorkspaceBuildGroup } = await import("./prepared-model-runtime.facts.js");
-  const prepared = await prepareWorkspaceBuildGroup([value.input], "live");
+  // Rediscovery under agent workspaces or runtime activation overlays loses the owner's
+  // metadata generation. Transfer its facts and restore only process-local behavior.
+  const metadata = restorePluginMetadataSnapshot(value.pluginMetadataSnapshot);
+  const prepared = await prepareWorkspaceBuildGroup(
+    [value.input],
+    "live",
+    {},
+    undefined,
+    undefined,
+    metadata,
+  );
   const agentFacts = prepared.agentFacts[0];
   if (!agentFacts) {
     throw new Error("prepared model catalog worker produced no agent facts");

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -13,6 +13,7 @@ import {
   completePluginMetadataSnapshot,
   loadPluginMetadataSnapshot,
   resolvePluginMetadataSnapshot,
+  restorePluginMetadataSnapshot,
 } from "./plugin-metadata-snapshot.js";
 
 const { loadPluginRegistrySnapshotWithMetadata, loadPluginManifestRegistryForInstalledIndex } =
@@ -684,25 +685,35 @@ describe("plugin metadata snapshot", () => {
     });
   });
 
-  it("freezes a cloned index instead of caller-owned records", () => {
-    const index = makeIndex();
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: index,
-      diagnostics: [],
-    });
+  it.each([false, true])(
+    "freezes a cloned index instead of caller-owned records (worker: %s)",
+    (worker) => {
+      const index = makeIndex();
+      loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+        source: "provided",
+        snapshot: index,
+        diagnostics: [],
+      });
 
-    const snapshot = loadPluginMetadataSnapshot({ config: {}, env: {}, index });
-    const callerRecord = index.plugins[0];
-    const snapshotRecord = snapshot.index.plugins[0];
-    if (!callerRecord || !snapshotRecord) {
-      throw new Error("expected metadata records");
-    }
+      const loaded = loadPluginMetadataSnapshot({ config: {}, env: {}, index });
+      const { normalizePluginId: _normalizePluginId, ...transfer } = loaded;
+      const snapshot = worker ? restorePluginMetadataSnapshot(structuredClone(transfer)) : loaded;
+      expect(snapshot.normalizePluginId(" DEMO ")).toBe("demo");
+      expect(snapshot.owners.providers.get("demo")).toEqual(["demo"]);
+      expect(() => (snapshot.owners.providers as Map<string, string[]>).set("other", [])).toThrow(
+        "Plugin metadata snapshots are immutable",
+      );
+      const callerRecord = index.plugins[0];
+      const snapshotRecord = snapshot.index.plugins[0];
+      if (!callerRecord || !snapshotRecord) {
+        throw new Error("expected metadata records");
+      }
 
-    callerRecord.pluginId = "caller-mutated";
-    expect(snapshotRecord.pluginId).toBe("demo");
-    expect(() => {
-      snapshotRecord.pluginId = "snapshot-mutated";
-    }).toThrow();
-  });
+      callerRecord.pluginId = "caller-mutated";
+      expect(snapshotRecord.pluginId).toBe("demo");
+      expect(() => {
+        snapshotRecord.pluginId = "snapshot-mutated";
+      }).toThrow();
+    },
+  );
 });

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -122,6 +122,18 @@ function indexesMatch(
   );
 }
 
+/** Restores process-local behavior and immutability after a snapshot crosses a worker boundary. */
+export function restorePluginMetadataSnapshot(
+  snapshot: Omit<PluginMetadataSnapshot, "normalizePluginId">,
+): PluginMetadataSnapshot {
+  return freezeSnapshotValue({
+    ...snapshot,
+    normalizePluginId: createPluginRegistryIdNormalizer(snapshot.index, {
+      manifestRegistry: snapshot.manifestRegistry,
+    }),
+  });
+}
+
 function resolvePluginMetadataSnapshotPluginIds(params: {
   index: InstalledPluginIndex;
   params: LoadPluginMetadataSnapshotParams;
@@ -308,7 +320,7 @@ export function loadPluginMetadataSnapshot(
   );
   return measureDiagnosticsTimelineSpanSync(
     "plugins.metadata.freeze",
-    () => freezeSnapshotValue(snapshot),
+    () => restorePluginMetadataSnapshot(snapshot),
     {
       phase: activeTimelineSpan?.phase ?? "startup",
       config: params.config,
@@ -417,7 +429,7 @@ export function resolvePluginMetadataSnapshot(
 
 function loadPluginMetadataSnapshotImpl(
   params: LoadPluginMetadataSnapshotParams,
-): PluginMetadataSnapshot {
+): Omit<PluginMetadataSnapshot, "normalizePluginId"> {
   const totalStartedAt = performance.now();
   const registryStartedAt = performance.now();
   const registryResult = loadPluginRegistrySnapshotWithMetadata({
@@ -448,7 +460,6 @@ function loadPluginMetadataSnapshotImpl(
     includeDisabled: true,
   });
   const manifestRegistryMs = performance.now() - manifestStartedAt;
-  const normalizePluginId = createPluginRegistryIdNormalizer(index, { manifestRegistry });
   const byPluginId = new Map(manifestRegistry.plugins.map((plugin) => [plugin.id, plugin]));
   const ownerMapsStartedAt = performance.now();
   const owners = buildPluginMetadataOwnerMaps(manifestRegistry.plugins);
@@ -473,7 +484,6 @@ function loadPluginMetadataSnapshotImpl(
     plugins: manifestRegistry.plugins,
     diagnostics: manifestRegistry.diagnostics,
     byPluginId,
-    normalizePluginId,
     owners,
     metrics: {
       registrySnapshotMs,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users browsing models or refreshing model authentication receive `prepared model catalog worker reconstructed a different runtime generation` on an otherwise healthy Gateway. A fresh multi-agent Gateway with automatic provider activation reproduces this without changing any plugin files.

## Why This Change Was Made

The Gateway publishes one lifecycle-owned plugin metadata snapshot, but the catalog worker discarded it and rediscovered metadata using an individual agent's workspace and runtime activation config. Those inputs need not match the source metadata's workspace or policy. Passing only the original workspace fixed four regression cases but still failed the real Gateway's activation-overlay case.

Transfer the exact metadata graph, including the paired inventory, manifests, scope, and owner maps. The plugin metadata owner restores its process-local ID normalizer and immutability; ordinary metadata loads share that finalization path. Keep the existing generation fingerprint and parent-lifetime checks. No consumer retries, new config, storage changes, or provider-specific branches.

Production LOC: +30/-5 (net +25). The growth implements the missing worker ownership handoff and restores non-cloneable behavior; copying only inventory or weakening identity checks would lose the paired metadata contract. Tests: +75/-20 (includes reindent of an existing table-driven test). Release-note context is in this body; the root changelog remains release-owned.

Provenance: likely made visible by #125596, authored and merged by @steipete on 2026-08-18 (`fd216cb5509e`), which made Gateway metadata explicitly shared across prepared agent owners. The worker's independent reconstruction predates that change.

Related: #126108 and #126224. The latter is assigned to @jalehman and addresses recovery after plugin changes. This fixes the initial unchanged-plugin metadata handoff, not that recovery contract; neither item is closed by this PR. Metadata identity is not executable-byte pinning: the first worker still imports the selected plugin paths, and replacing plugin code before that import is not claimed fixed here.

## User Impact

Model browsing and auth refresh use the Gateway's published plugin metadata even when agents have separate workspaces or startup enables a provider in memory. Existing session/agent/global model-selection behavior remains intact.

## Evidence

- Before: a real built Gateway with temporary HOME/state, two agents, loopback-only transport, and Anthropic auto-activation returned `UNAVAILABLE` from `models.list` with `view: "all"`.
- Failing-first regressions: four distinct/absent metadata-workspace cases failed on original code; two source/runtime activation-policy cases also failed on the workspace-only intermediate patch. The final real-worker suite passes all 16 tests, including auth refresh, SecretRef preservation, shared discovery, and generation retirement.
- Metadata owner suite: 25 tests pass, including structured-clone round-trip normalization and immutable owner Maps.
- After: five fresh built Gateways completed actual model browsing and an admin `sessions.patch`, then verified persisted config after shutdown: session, agent, global, default-main, and default-overridden-agent scopes. No provider inference or external credentials were used; this is real Gateway/CLI/RPC and persistence proof, not authenticated provider proof.
- Build passes. Independent Codex autoreview found no actionable findings.
- Full local `check:changed` passes, including core production/test typechecks, changed-file lint, formatting, import-cycle, dead-export, plugin-boundary, and storage guards. The first remote changed-gate attempt failed during Testbox file sync and stopped its lease; it did not produce a passing check result.
- Final-head hosted [CI 33023800497, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33023800497) completed successfully at `ccadcbb749b8d6045ebb2f5b22dab7dccf214496`, including `openclaw/ci-gate`. Attempt 1 had one failure in the unrelated 50-worker retention test newly added to main by #130449; that test is absent from this PR head. One targeted unchanged-shard rerun passed; no assertions, concurrency, or timeout were weakened. The earlier source head also passed full CI 33022280478 before the changelog-only removal.
- CI investigation follow-up #130504 records independently reproduced subprocess hard-deadline output loss. Its connection to the stress test's empty-SHA failure remains unproven; this PR does not claim to fix it.
- Named follow-up: `prepared-model-runtime.plugin-context.test.ts`'s no-current-metadata-probe assertion fails identically on untouched main `d27b0e96204a` and this patch (one bundled-channel metadata lookup). The remaining nine tests in that owner group pass. A clean independently installed/built baseline reproduced the failure; the assertion was not weakened. Cold broad-suite startup also stalled on both revisions; the real-worker and metadata-owner suites above completed separately. These are not reported as green full-suite proof.
