### PR TITLE
refactor(talk): share result completion tracking

### DIFF
--- a/src/gateway/talk-realtime-relay-provider-results.ts
+++ b/src/gateway/talk-realtime-relay-provider-results.ts
@@ -61,6 +61,25 @@ export function completeAfterToolResultSubmissions(
   return Promise.all(pending).then(complete);
 }
 
+function trackToolResultCompletion(
+  pending: Map<string, Promise<void>>,
+  callId: string,
+  completion: void | Promise<void>,
+): void | Promise<void> {
+  if (!completion) {
+    return;
+  }
+  const tracked = completion.finally(() => {
+    // An older completion can settle after a newer replacement is stored.
+    // Delete only the entry this completion still owns.
+    if (pending.get(callId) === tracked) {
+      pending.delete(callId);
+    }
+  });
+  pending.set(callId, tracked);
+  return tracked;
+}
+
 export function submitFinalProviderToolResult(params: {
   session: RelaySession;
   callId: string;
@@ -132,19 +151,16 @@ export function submitFinalProviderToolResult(params: {
     accept();
     return;
   }
-  const tracked = submission
-    .then((submitted) => {
-      if (submitted !== false) {
-        accept();
-      }
-    })
-    .finally(() => {
-      if (params.session.pendingProviderToolResults.get(params.callId) === tracked) {
-        params.session.pendingProviderToolResults.delete(params.callId);
-      }
-    });
-  params.session.pendingProviderToolResults.set(params.callId, tracked);
-  return tracked;
+  const completion = submission.then((submitted) => {
+    if (submitted !== false) {
+      accept();
+    }
+  });
+  return trackToolResultCompletion(
+    params.session.pendingProviderToolResults,
+    params.callId,
+    completion,
+  );
 }
 
 export function trackAgentFinalToolResult(
@@ -152,16 +168,7 @@ export function trackAgentFinalToolResult(
   callId: string,
   completion: void | Promise<void>,
 ): void | Promise<void> {
-  if (!completion) {
-    return;
-  }
-  const tracked = completion.finally(() => {
-    if (session.pendingFinalToolResults.get(callId) === tracked) {
-      session.pendingFinalToolResults.delete(callId);
-    }
-  });
-  session.pendingFinalToolResults.set(callId, tracked);
-  return tracked;
+  return trackToolResultCompletion(session.pendingFinalToolResults, callId, completion);
 }
 
 export function trackPendingWorkingToolResult(
@@ -169,16 +176,7 @@ export function trackPendingWorkingToolResult(
   callId: string,
   completion: void | Promise<void>,
 ): void | Promise<void> {
-  if (!completion) {
-    return;
-  }
-  const tracked = completion.finally(() => {
-    if (session.pendingWorkingToolResults.get(callId) === tracked) {
-      session.pendingWorkingToolResults.delete(callId);
-    }
-  });
-  session.pendingWorkingToolResults.set(callId, tracked);
-  return tracked;
+  return trackToolResultCompletion(session.pendingWorkingToolResults, callId, completion);
 }
 
 export function clearRelayAgentToolCall(session: RelaySession, callId: string): void {

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -3505,16 +3505,18 @@ describe("talk realtime gateway relay", () => {
       result: { phase: "second" },
       options: { willContinue: true },
     });
+    expect(submitToolResult).toHaveBeenCalledTimes(1);
+
+    firstAccepted.resolve();
+    await firstInterim;
+    expect(submitToolResult).toHaveBeenCalledTimes(2);
+
     const final = submitTalkRealtimeRelayToolResult({
       relaySessionId: session.relaySessionId,
       connId: "conn-1",
       callId: "call-1",
       result: { answer: "done" },
     });
-    expect(submitToolResult).toHaveBeenCalledTimes(1);
-
-    firstAccepted.resolve();
-    await vi.waitFor(() => expect(submitToolResult).toHaveBeenCalledTimes(2));
     expect(submitToolResult).not.toHaveBeenCalledWith("call-1", { answer: "done" }, undefined);
 
     secondAccepted.resolve();
@@ -3693,14 +3695,12 @@ describe("talk realtime gateway relay", () => {
   });
 
   it("supersedes a rejected in-flight final with canonical cancellation", async () => {
-    let rejectFinal: ((error: Error) => void) | undefined;
-    const rejectedFinal = new Promise<void>((_resolve, reject) => {
-      rejectFinal = reject;
-    });
+    const rejectedFinal = createDeferred();
+    const cancellationAccepted = createDeferred();
     const submitToolResult = vi
       .fn<RealtimeVoiceBridge["submitToolResult"]>()
-      .mockReturnValueOnce(rejectedFinal)
-      .mockReturnValueOnce(undefined);
+      .mockReturnValueOnce(rejectedFinal.promise)
+      .mockReturnValueOnce(cancellationAccepted.promise);
     const provider = createIdleRelayProvider();
     provider.createBridge = () =>
       makeRelayTransport({
@@ -3726,9 +3726,20 @@ describe("talk realtime gateway relay", () => {
       result: { error: "aborted" },
     });
 
-    rejectFinal?.(new Error("stale final rejected"));
+    rejectedFinal.reject(new Error("stale final rejected"));
     await expect(staleFinal).rejects.toThrow("stale final rejected");
-    await cancellation;
+    await vi.waitFor(() => expect(submitToolResult).toHaveBeenCalledTimes(2));
+
+    const duplicate = submitTalkRealtimeRelayToolResult({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-1",
+      callId: "call-1",
+      result: { error: "duplicate aborted" },
+    });
+    expect(submitToolResult).toHaveBeenCalledTimes(2);
+
+    cancellationAccepted.resolve();
+    await Promise.all([cancellation, duplicate]);
     expect(submitToolResult.mock.calls.map((call) => call[1])).toEqual([
       { answer: "stale" },
       {


### PR DESCRIPTION
## What Problem This Solves

The realtime relay duplicated the same replacement-safe promise-map lifecycle across provider, final-agent, and working-result completion maps.

## Why This Change Was Made

One owner-level tracker now stores the returned `finally` promise and removes an entry only when that exact promise still owns the call ID. The exported final and working wrappers remain separate semantic entry points, so provider, cancellation, and continuation policy stay with their existing owners.

## User Impact

No user-visible behavior change. Rejection propagation, unconditional replacement, cancellation, epoch fencing, and stale-settlement protection are preserved.

## Evidence

- Exact head: `841abfed13d9c8a9e142f3567417ee20ffeef602`.
- Local: `src/gateway/talk-realtime-relay.test.ts` passed 86/86; proportional changed dry-run and actual gate passed.
- Sol autoreview: `gpt-5.6-sol`, high reasoning, clean with no accepted/actionable findings.
- Hosted CI: exact-head `openclaw/ci-gate` succeeded in run `33022784485`.
- Blacksmith Testbox `tbx_01m119z1gc5rfateajh0mwp0sh`: expected/local/live/fetched/remote all matched the exact head; 86/86 tests and the changed gate passed; command 1,013,666 ms, total 1,015,803 ms, exit 0, `succeeded`; lease completed. Actions: https://github.com/openclaw/openclaw/actions/runs/33060279097. The backing Actions step was cancelled only by Blacksmith's external one-shot lease teardown after the successful wrapper receipt.
- Direct AWS Crabbox `cbx_5667299ba217`, run `run_d7250b4614a1`: expected/local/live/fetched/remote all matched the exact head; public network, no Tailscale, no instance role, no hydration, trusted fresh-PR bootstrap; 86/86 tests and the changed gate passed; command 505,503 ms, total 576,987 ms, end-to-end 588,503 ms, exit 0, `succeeded`; lease released. Run: https://crabbox.openclaw.ai/portal/runs/run_d7250b4614a1.
- The old Testbox run `33021508387` is rejected because it checked out the wrong SHA and was cancelled without proof.
- ClawSweeper reviewed the exact head at `2026-08-27T00:13:40Z`, reported no findings, and requested exact-head checks. That move is resolved by hosted CI plus both remote owner-boundary proofs; its earlier environment timeout is superseded.
- Production: `+31/-33`, net `-2`. Tests: `+23/-12`, net `+11`.
- No protocol, config, persistence, or user-visible behavior change. No changelog entry is required for this internal refactor.
