### PR TITLE
refactor(plugins): make discovery invocation-owned

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -9,8 +9,9 @@ import {
   isPluginCandidateInstallOwnerAmbiguous,
   resolvePluginCandidateInstallOwner,
 } from "./candidate-install-owner.js";
-import { discoverOpenClawPlugins } from "./discovery.js";
+import { discoverConfiguredPluginLoadPaths, discoverOpenClawPlugins } from "./discovery.js";
 import * as pluginHardlinkPolicy from "./hardlink-policy.js";
+import { resolvePluginManifestInstallOwner } from "./manifest-install-owner.js";
 import { loadPluginManifestRegistryCore } from "./manifest-registry.js";
 import type { PackageManifest } from "./manifest.js";
 import { resolvePackageSetupSource } from "./package-entry-resolution.js";
@@ -1139,6 +1140,167 @@ describe("discoverOpenClawPlugins", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32" && canCreateDirectorySymlinks)(
+    "still scans sibling package entries beside a duplicate installed file alias",
+    () => {
+      const stateDir = makeTempDir();
+      const firstDir = path.join(stateDir, "extensions", "first");
+      const secondDir = path.join(stateDir, "extensions", "second");
+      const installedFile = path.join(firstDir, "index.js");
+      const aliasedFile = path.join(secondDir, "alias.js");
+      mkdirSafe(firstDir);
+      writePluginEntry(installedFile);
+      createPackagePluginWithEntry({
+        packageDir: secondDir,
+        packageName: "second",
+        pluginId: "second",
+        entryPath: "other.js",
+      });
+      fs.symlinkSync(installedFile, aliasedFile);
+      const result = discoverOpenClawPlugins({
+        env: buildDiscoveryEnv(stateDir),
+        installRecords: {
+          first: { source: "npm", installPath: installedFile },
+          alias: { source: "npm", installPath: aliasedFile },
+        },
+      });
+      expect(result.candidates.map((candidate) => candidate.idHint)).toEqual(["index", "second"]);
+      expect(isPluginCandidateInstallOwnerAmbiguous(result.candidates[0]!)).toBe(true);
+      expectDiagnostic({
+        diagnostics: result.diagnostics,
+        messageIncludes: "multiple plugin install records claim the same package path",
+      });
+    },
+  );
+
+  it.runIf(canCreateDirectorySymlinks).each([
+    { name: "official registry", overrides: {}, ambiguous: false, trusted: true },
+    {
+      name: "local archive",
+      overrides: { sourcePath: "/tmp/diffs.tgz", artifactKind: "npm-pack", artifactFormat: "tgz" },
+      ambiguous: false,
+      trusted: undefined,
+    },
+    { name: "conflicting owners", overrides: {}, ambiguous: true, trusted: undefined },
+  ] satisfies Array<{
+    name: string;
+    overrides: Partial<PluginInstallRecord>;
+    ambiguous: boolean;
+    trusted: true | undefined;
+  }>)("preserves $name trust through configured aliases and bundled ownership", (scenario) => {
+    const stateDir = makeTempDir();
+    const bundledDir = path.join(stateDir, "bundled");
+    const pluginDir = path.join(bundledDir, "diffs");
+    const aliasDir = path.join(stateDir, "diffs-link");
+    mkdirSafe(pluginDir);
+    writePluginPackageManifest({
+      packageDir: pluginDir,
+      packageName: "@openclaw/diffs",
+      extensions: ["./two.js", "./one.js"],
+    });
+    writePluginManifest({ pluginDir, id: "diffs" });
+    for (const entry of ["two.js", "one.js"]) {
+      fs.writeFileSync(
+        path.join(pluginDir, entry),
+        'throw new Error("must not evaluate metadata")',
+      );
+    }
+    symlinkDirectory(pluginDir, aliasDir);
+    const env = buildDiscoveryEnvWithOverrides(stateDir, {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+    });
+    const record: PluginInstallRecord = {
+      source: "npm",
+      spec: "@openclaw/diffs",
+      resolvedName: "@openclaw/diffs",
+      resolvedSpec: "@openclaw/diffs@2026.7.16",
+      installPath: pluginDir,
+      ...scenario.overrides,
+    };
+    const installRecords = {
+      diffs: record,
+      ...(scenario.ambiguous ? { other: { ...record, installPath: aliasDir } } : {}),
+    };
+    const extraPaths = [aliasDir, pluginDir];
+    const result = discoverOpenClawPlugins({ env, extraPaths, installRecords });
+    expect(
+      result.candidates.map((candidate) => ({
+        id: candidate.idHint,
+        source: candidate.source,
+        origin: candidate.origin,
+        owner: resolvePluginCandidateInstallOwner(candidate),
+        ambiguous: isPluginCandidateInstallOwnerAmbiguous(candidate),
+      })),
+    ).toEqual(
+      ["two", "one"].map((entry) => ({
+        id: `diffs/${entry}`,
+        source: fs.realpathSync(path.join(pluginDir, `${entry}.js`)),
+        origin: "config",
+        owner: scenario.ambiguous ? undefined : "diffs",
+        ambiguous: scenario.ambiguous,
+      })),
+    );
+    const registry = loadPluginManifestRegistryCore({ discovery: result, installRecords, env });
+    expect(
+      registry.plugins.map((plugin) => ({
+        id: plugin.id,
+        owner: resolvePluginManifestInstallOwner(plugin),
+        trusted: plugin.trustedOfficialInstall,
+      })),
+    ).toEqual(
+      ["two", "one"].map((entry) => ({
+        id: `diffs/${entry}`,
+        owner: scenario.ambiguous ? undefined : "diffs",
+        trusted: scenario.trusted,
+      })),
+    );
+    expect(result.diagnostics).toEqual(
+      scenario.ambiguous
+        ? [
+            {
+              level: "error",
+              source: aliasDir,
+              message:
+                "multiple plugin install records claim the same package path; refresh or reinstall the package before using managed lifecycle actions",
+            },
+          ]
+        : [],
+    );
+  });
+
+  it.runIf(canCreateDirectorySymlinks)(
+    "leaves explicit-only file aliases and diagnostics unfinalized",
+    () => {
+      const stateDir = makeTempDir();
+      const pluginDir = path.join(stateDir, "plugin");
+      const aliasDir = path.join(stateDir, "alias");
+      mkdirSafe(pluginDir);
+      writePluginManifest({ pluginDir, id: "plugin", requiresPlugins: ["missing"] });
+      writePluginEntry(path.join(pluginDir, "index.js"));
+      symlinkDirectory(pluginDir, aliasDir);
+      const missing = path.join(stateDir, "missing.js");
+      const loadPaths = [
+        path.join(aliasDir, "index.js"),
+        path.join(pluginDir, "index.js"),
+        missing,
+        missing,
+      ];
+      const env = buildDiscoveryEnv(stateDir);
+      const raw = discoverConfiguredPluginLoadPaths({ env, loadPaths });
+      expect(raw.candidates.map((candidate) => candidate.source)).toEqual(loadPaths.slice(0, 2));
+      expect(raw.diagnostics).toEqual(
+        [missing, missing].map((source) => ({
+          level: "error",
+          source,
+          message: `plugin path not found: ${source}`,
+        })),
+      );
+      const registry = loadPluginManifestRegistryCore({ discovery: raw, installRecords: {}, env });
+      expect(registry.plugins).toHaveLength(1);
+      expect(discoverOpenClawPlugins({ env, extraPaths: loadPaths }).candidates).toHaveLength(1);
+    },
+  );
+
   it("still requires compiled runtime output for tracked installed package plugins", async () => {
     const stateDir = makeTempDir();
     const pluginDir = path.join(stateDir, "extensions", "source-only-pack");
@@ -1180,39 +1342,44 @@ describe("discoverOpenClawPlugins", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("treats install record sourcePath dirs as managed during global scans", async () => {
-    const stateDir = makeTempDir();
-    const sourceDir = path.join(stateDir, "extensions", "source-path-pack");
-    const installDir = path.join(stateDir, "installed", "source-path-pack");
-    mkdirSafe(path.join(sourceDir, "src"));
-    mkdirSafe(installDir);
+  it.each([true, false])(
+    "treats sourcePath as managed with preferred install present=%s",
+    async (installed) => {
+      const stateDir = makeTempDir();
+      const sourceDir = path.join(stateDir, "extensions", "source-path-pack");
+      const installDir = path.join(stateDir, "installed", "source-path-pack");
+      mkdirSafe(path.join(sourceDir, "src"));
+      if (installed) {
+        mkdirSafe(installDir);
+      }
 
-    writePluginPackageManifest({
-      packageDir: sourceDir,
-      packageName: "@openclaw/source-path-pack",
-      extensions: ["./src/index.ts"],
-    });
-    writePluginEntry(path.join(sourceDir, "src", "index.ts"));
+      writePluginPackageManifest({
+        packageDir: sourceDir,
+        packageName: "@openclaw/source-path-pack",
+        extensions: ["./src/index.ts"],
+      });
+      writePluginEntry(path.join(sourceDir, "src", "index.ts"));
 
-    const installRecords = {
-      "source-path-pack": {
-        source: "path",
-        installPath: installDir,
-        sourcePath: sourceDir,
-      },
-    } satisfies Record<string, PluginInstallRecord>;
-    const result = await discoverWithStateDir(stateDir, { installRecords });
+      const installRecords = {
+        "source-path-pack": {
+          source: "path",
+          installPath: installDir,
+          sourcePath: sourceDir,
+        },
+      } satisfies Record<string, PluginInstallRecord>;
+      const result = await discoverWithStateDir(stateDir, { installRecords });
 
-    expectCandidateIds(result.candidates, { excludes: ["source-path-pack"] });
-    expectDiagnostic({
-      diagnostics: result.diagnostics,
-      level: "warn",
-      pluginId: "source-path-pack",
-      messageIncludes: "requires compiled runtime output",
-      source: sourceDir,
-    });
-    expect(result.diagnostics).toHaveLength(1);
-  });
+      expectCandidateIds(result.candidates, { excludes: ["source-path-pack"] });
+      expectDiagnostic({
+        diagnostics: result.diagnostics,
+        level: "warn",
+        pluginId: "source-path-pack",
+        messageIncludes: "requires compiled runtime output",
+        source: sourceDir,
+      });
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
 
   it.skipIf(!canCreateDirectorySymlinks)(
     "treats symlinked install record sourcePath dirs as managed during global scans",
@@ -2867,6 +3034,30 @@ describe("discoverOpenClawPlugins", () => {
     expect(candidates.map((candidate) => candidate.idHint)).not.toContain("pack");
   });
 
+  it.runIf(process.platform !== "win32")(
+    "rechecks a rejected configured path under bundled policy after deduplicating scoped attempts",
+    () => {
+      const stateDir = makeTempDir();
+      const bundledDir = path.join(stateDir, "bundled");
+      const pluginDir = path.join(bundledDir, "repairable");
+      createPackagePluginWithEntry({
+        packageDir: pluginDir,
+        packageName: "repairable",
+        entryPath: "index.js",
+      });
+      fs.chmodSync(pluginDir, 0o777);
+      const result = discoverOpenClawPlugins({
+        env: buildDiscoveryEnvWithOverrides(stateDir, { OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir }),
+        extraPaths: [pluginDir, pluginDir],
+      });
+      expect(result.candidates).toHaveLength(1);
+      expectCandidateFields(result.candidates[0]!, { idHint: "repairable", origin: "bundled" });
+      expect(result.diagnostics).toHaveLength(1);
+      expectDiagnostic({ diagnostics: result.diagnostics, messageIncludes: "world-writable path" });
+      expect(fs.statSync(pluginDir).mode & 0o777).toBe(0o755);
+    },
+  );
+
   it.runIf(process.platform !== "win32")("blocks world-writable plugin paths", async () => {
     const stateDir = makeTempDir();
     const pluginDir = path.join(stateDir, "extensions", "world-open");
@@ -3207,6 +3398,18 @@ describe("discoverOpenClawPlugins", () => {
       present: ["bundled-plugin", "global-plugin", "workspace-b-plugin"],
       absent: ["workspace-a-plugin"],
     });
+
+    const bundledOnly = withOpenClawPackageArgv(packageRoot, () =>
+      discoverWithEnv({
+        workspaceDir: workspaceA,
+        extraPaths: [path.join(stateDir, "missing-configured-plugin")],
+        installRecords: { missing: { source: "npm", installPath: stateDir } },
+        rootScope: "bundled",
+        env,
+      }),
+    );
+    expect(bundledOnly.candidates.map((candidate) => candidate.idHint)).toEqual(["bundled-plugin"]);
+    expect(bundledOnly.diagnostics).toEqual([]);
   });
 
   it.each([

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -382,13 +382,6 @@ function resolvesToSameDirectory(
   return path.resolve(left) === path.resolve(right);
 }
 
-function createDiscoveryResult(): PluginDiscoveryResult {
-  return {
-    candidates: [],
-    diagnostics: [],
-  };
-}
-
 function mergeCandidateInstallOwner(
   existing: PluginCandidate,
   candidateOwner: string | undefined,
@@ -404,44 +397,6 @@ function mergeCandidateInstallOwner(
     recordPluginCandidateInstallOwner(existing, undefined, true);
   } else if (candidateOwner) {
     recordPluginCandidateInstallOwner(existing, candidateOwner);
-  }
-}
-
-function mergeDiscoveryResult(
-  target: PluginDiscoveryResult,
-  source: PluginDiscoveryResult,
-  candidatesBySource: Map<string, PluginCandidate>,
-  seenDiagnostics: Set<string>,
-  realpathCache: Map<string, string>,
-): void {
-  for (const candidate of source.candidates) {
-    // Configured aliases keep their precedence, but lifecycle ownership follows
-    // the one physical package entry rather than its textual path spelling.
-    const key = safeRealpathSync(candidate.source, realpathCache) ?? path.resolve(candidate.source);
-    const existing = candidatesBySource.get(key);
-    if (existing) {
-      mergeCandidateInstallOwner(
-        existing,
-        resolvePluginCandidateInstallOwner(candidate),
-        isPluginCandidateInstallOwnerAmbiguous(candidate),
-      );
-      continue;
-    }
-    candidatesBySource.set(key, candidate);
-    target.candidates.push(candidate);
-  }
-  for (const diagnostic of source.diagnostics) {
-    const key = [
-      diagnostic.level,
-      diagnostic.pluginId ?? "",
-      diagnostic.source ?? "",
-      diagnostic.message,
-    ].join("\0");
-    if (seenDiagnostics.has(key)) {
-      continue;
-    }
-    seenDiagnostics.add(key);
-    target.diagnostics.push(diagnostic);
   }
 }
 
@@ -502,53 +457,41 @@ type InstalledPluginRecordPath = {
   installOwnerAmbiguous?: true;
 };
 
-function isLinkedLocalPluginRecord(params: {
-  record: PluginInstallRecord;
-  env: NodeJS.ProcessEnv;
-  realpathCache: Map<string, string>;
-}): boolean {
-  if (params.record.source !== "path") {
-    return false;
-  }
-  if (
-    typeof params.record.sourcePath !== "string" ||
-    !params.record.sourcePath.trim() ||
-    typeof params.record.installPath !== "string" ||
-    !params.record.installPath.trim()
-  ) {
-    return false;
-  }
-  return resolvesToSameDirectory(
-    resolveUserPath(params.record.sourcePath, params.env),
-    resolveUserPath(params.record.installPath, params.env),
-    params.realpathCache,
-  );
-}
-
-function collectInstalledPluginRecordPaths(
+function prepareInstalledPluginPaths(
   installRecords: Record<string, PluginInstallRecord> | undefined,
   env: NodeJS.ProcessEnv,
   realpathCache: Map<string, string>,
   diagnostics: PluginDiagnostic[],
-): InstalledPluginRecordPath[] {
-  const paths: InstalledPluginRecordPath[] = [];
+) {
   const byPath = new Map<string, InstalledPluginRecordPath>();
+  const installedPluginDirKeys = new Set<string>();
+  const managedPluginDirs = new Set<string>();
+  const resolveRecordPath = (rawPath: string | undefined) =>
+    typeof rawPath === "string" && rawPath.trim() ? resolveUserPath(rawPath, env) : undefined;
   for (const [installOwner, record] of Object.entries(installRecords ?? {})) {
-    const rawPath =
-      typeof record.installPath === "string" && record.installPath.trim()
-        ? record.installPath
-        : typeof record.sourcePath === "string" && record.sourcePath.trim()
-          ? record.sourcePath
-          : undefined;
-    if (!rawPath) {
-      continue;
+    const installPath = resolveRecordPath(record.installPath);
+    const sourcePath = resolveRecordPath(record.sourcePath);
+    // Discovery follows the preferred install path, even when it is missing.
+    // Both paths remain managed so a source copy cannot bypass built-entry checks.
+    for (const recordedPath of [installPath, sourcePath]) {
+      if (recordedPath && fs.existsSync(recordedPath)) {
+        const key = resolveManagedPluginDirKey(recordedPath, realpathCache);
+        if (key) {
+          managedPluginDirs.add(key);
+        }
+      }
     }
-    const resolved = resolveUserPath(rawPath, env);
-    if (!fs.existsSync(resolved)) {
+    const resolved = installPath ?? sourcePath;
+    if (!resolved || !fs.existsSync(resolved)) {
       continue;
     }
     const pathKey = safeRealpathSync(resolved, realpathCache) ?? path.resolve(resolved);
-    const requireBuiltRuntimeEntry = !isLinkedLocalPluginRecord({ record, env, realpathCache });
+    const requireBuiltRuntimeEntry = !(
+      record.source === "path" &&
+      installPath &&
+      sourcePath &&
+      resolvesToSameDirectory(installPath, sourcePath, realpathCache)
+    );
     const existing = byPath.get(pathKey);
     if (existing) {
       existing.requireBuiltRuntimeEntry ||= requireBuiltRuntimeEntry;
@@ -562,42 +505,17 @@ function collectInstalledPluginRecordPaths(
             "multiple plugin install records claim the same package path; refresh or reinstall the package before using managed lifecycle actions",
         });
       }
-      continue;
-    }
-    const installedPath: InstalledPluginRecordPath = {
-      path: resolved,
-      requireBuiltRuntimeEntry,
-      installOwner,
-    };
-    byPath.set(pathKey, installedPath);
-    paths.push(installedPath);
-  }
-  return paths;
-}
-
-// Discovery follows the install ledger's primary path choice; managed
-// classification needs every recorded path so a sourcePath under the global
-// extensions root does not get rescanned as an untracked local plugin.
-function collectManagedPluginRecordPaths(
-  installRecords: Record<string, PluginInstallRecord> | undefined,
-  env: NodeJS.ProcessEnv,
-): string[] {
-  const paths: string[] = [];
-  const seen = new Set<string>();
-  for (const record of Object.values(installRecords ?? {})) {
-    for (const rawPath of [record.installPath, record.sourcePath]) {
-      if (typeof rawPath !== "string" || !rawPath.trim()) {
-        continue;
+    } else {
+      byPath.set(pathKey, { path: resolved, requireBuiltRuntimeEntry, installOwner });
+      // Only the retained entry was explicitly scanned. A discarded file alias's
+      // parent may contain other plugins that still need global discovery.
+      const dirKey = resolveManagedPluginDirKey(resolved, realpathCache);
+      if (dirKey) {
+        installedPluginDirKeys.add(dirKey);
       }
-      const resolved = resolveUserPath(rawPath, env);
-      if (seen.has(resolved) || !fs.existsSync(resolved)) {
-        continue;
-      }
-      seen.add(resolved);
-      paths.push(resolved);
     }
   }
-  return paths;
+  return { installedPaths: [...byPath.values()], installedPluginDirKeys, managedPluginDirs };
 }
 
 function resolveManagedPluginDirKey(
@@ -610,20 +528,6 @@ function resolveManagedPluginDirKey(
   }
   const pluginDir = stat.isFile() ? path.dirname(installedPath) : installedPath;
   return safeRealpathSync(pluginDir, realpathCache) ?? path.resolve(pluginDir);
-}
-
-function collectManagedPluginDirKeys(
-  installedPaths: readonly string[],
-  realpathCache: Map<string, string>,
-): Set<string> {
-  const dirs = new Set<string>();
-  for (const installedPath of installedPaths) {
-    const key = resolveManagedPluginDirKey(installedPath, realpathCache);
-    if (key) {
-      dirs.add(key);
-    }
-  }
-  return dirs;
 }
 
 function isManagedPluginDir(params: {
@@ -783,169 +687,6 @@ function resolveCandidateManifest(
     : undefined;
 }
 
-function addCandidate(params: {
-  candidates: PluginCandidate[];
-  diagnostics: PluginDiagnostic[];
-  seen: Set<string>;
-  idHint: string;
-  effectivePluginId?: string;
-  installOwner?: string;
-  installOwnerAmbiguous?: true;
-  diagnosticIdHint?: string;
-  source: string;
-  setupSource?: string;
-  rootDir: string;
-  origin: PluginOrigin;
-  format?: PluginFormat;
-  bundleFormat?: PluginBundleFormat;
-  ownershipUid?: number | null;
-  workspaceDir?: string;
-  manifest?: PackageManifest | null;
-  packageDir?: string;
-  bundledManifestId?: string;
-  bundledManifest?: PluginManifest;
-  bundledManifestPath?: string;
-  requiredPluginIds?: string[];
-  requiredPluginSource?: string;
-  realpathCache: Map<string, string>;
-}) {
-  const resolved = path.resolve(params.source);
-  if (params.seen.has(resolved)) {
-    const existing = params.candidates.find((candidate) => candidate.source === resolved);
-    if (existing) {
-      mergeCandidateInstallOwner(
-        existing,
-        params.installOwner,
-        params.installOwnerAmbiguous === true,
-      );
-    }
-    return;
-  }
-  const resolvedRoot =
-    safeRealpathSync(params.rootDir, params.realpathCache) ?? path.resolve(params.rootDir);
-  if (
-    isUnsafePluginCandidate({
-      source: resolved,
-      rootDir: resolvedRoot,
-      origin: params.origin,
-      pluginId: params.idHint,
-      diagnostics: params.diagnostics,
-      ownershipUid: params.ownershipUid,
-      realpathCache: params.realpathCache,
-    })
-  ) {
-    params.seen.add(resolved);
-    return;
-  }
-  params.seen.add(resolved);
-  const manifest = params.manifest ?? null;
-  const packageManifest = getPackageManifestMetadata(manifest ?? undefined);
-  const packageDependencies = normalizePluginDependencySpecs({
-    dependencies: manifest?.dependencies,
-    optionalDependencies: manifest?.optionalDependencies,
-  });
-  const candidate = {
-    idHint: params.idHint,
-    ...(params.effectivePluginId ? { effectivePluginId: params.effectivePluginId } : {}),
-    ...(params.diagnosticIdHint && params.diagnosticIdHint !== params.idHint
-      ? { diagnosticIdHint: params.diagnosticIdHint }
-      : {}),
-    source: resolved,
-    setupSource: params.setupSource,
-    rootDir: resolvedRoot,
-    origin: params.origin,
-    format: params.format ?? "openclaw",
-    bundleFormat: params.bundleFormat,
-    workspaceDir: params.workspaceDir,
-    packageName: normalizeOptionalString(manifest?.name),
-    packageVersion: normalizeOptionalString(manifest?.version),
-    packageDescription: normalizeOptionalString(manifest?.description),
-    packageDir: params.packageDir,
-    packageManifest,
-    packageDependencies: packageDependencies.dependencies,
-    packageOptionalDependencies: packageDependencies.optionalDependencies,
-    rawPackageManifest: manifest ?? undefined,
-    bundledManifestId: params.bundledManifestId,
-    bundledManifest: params.bundledManifest,
-    bundledManifestPath: params.bundledManifestPath,
-    ...(params.requiredPluginIds && params.requiredPluginIds.length > 0
-      ? { requiredPluginIds: params.requiredPluginIds }
-      : {}),
-    ...(params.requiredPluginSource ? { requiredPluginSource: params.requiredPluginSource } : {}),
-  } satisfies PluginCandidate;
-  params.candidates.push(
-    recordPluginCandidateInstallOwner(
-      candidate,
-      params.installOwner,
-      params.installOwnerAmbiguous === true,
-    ),
-  );
-}
-
-function discoverBundleInRoot(params: {
-  rootDir: string;
-  origin: PluginOrigin;
-  env: NodeJS.ProcessEnv;
-  ownershipUid?: number | null;
-  workspaceDir?: string;
-  installOwner?: string;
-  installOwnerAmbiguous?: true;
-  manifest?: PackageManifest | null;
-  candidates: PluginCandidate[];
-  diagnostics: PluginDiagnostic[];
-  seen: Set<string>;
-  realpathCache: Map<string, string>;
-}): "added" | "invalid" | "none" {
-  return withPluginScanExistenceCache(() => {
-    const bundleFormat = detectBundleManifestFormat(params.rootDir);
-    if (!bundleFormat) {
-      return "none";
-    }
-    const rootRealPath = safeRealpathSync(params.rootDir, params.realpathCache) ?? undefined;
-    const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
-      origin: params.origin,
-      rootDir: params.rootDir,
-      env: params.env,
-      realpathCache: params.realpathCache,
-    });
-    const bundleManifest = loadBundleManifest({
-      rootDir: params.rootDir,
-      ...(rootRealPath !== undefined ? { rootRealPath } : {}),
-      bundleFormat,
-      rejectHardlinks,
-    });
-    if (!bundleManifest.ok) {
-      params.diagnostics.push({
-        level: "error",
-        message: bundleManifest.error,
-        source: bundleManifest.manifestPath,
-      });
-      return "invalid";
-    }
-    addCandidate({
-      candidates: params.candidates,
-      diagnostics: params.diagnostics,
-      seen: params.seen,
-      idHint: bundleManifest.manifest.id,
-      source: params.rootDir,
-      rootDir: params.rootDir,
-      origin: params.origin,
-      format: "bundle",
-      bundleFormat,
-      ownershipUid: params.ownershipUid,
-      workspaceDir: params.workspaceDir,
-      ...(params.installOwner ? { installOwner: params.installOwner } : {}),
-      ...(params.installOwnerAmbiguous ? { installOwnerAmbiguous: true } : {}),
-      manifest: params.manifest,
-      packageDir: params.rootDir,
-      bundledManifestId: bundleManifest.manifest.id,
-      bundledManifestPath: bundleManifest.manifestPath,
-      realpathCache: params.realpathCache,
-    });
-    return "added";
-  });
-}
-
 function addLegacyNpmDeclarationDiagnostic(params: {
   pluginDir: string;
   diagnostics: PluginDiagnostic[];
@@ -999,305 +740,6 @@ function shouldSkipIncompatiblePackagePluginApi(params: {
     pluginId: params.pluginId,
   });
   return true;
-}
-
-type PluginDirectoryDiscoveryParams = {
-  dir: string;
-  rootRealPath: string | undefined;
-  origin: PluginOrigin;
-  env: NodeJS.ProcessEnv;
-  ownershipUid?: number | null;
-  workspaceDir?: string;
-  installOwner?: string;
-  installOwnerAmbiguous?: true;
-  requireBuiltRuntimeEntry?: boolean;
-  managedPluginDirs?: Set<string>;
-  candidates: PluginCandidate[];
-  diagnostics: PluginDiagnostic[];
-  seen: Set<string>;
-  realpathCache: Map<string, string>;
-  packageManifestCache?: Map<string, PackageManifest | null>;
-};
-
-function discoverPluginDirectory(params: PluginDirectoryDiscoveryParams): boolean {
-  const { dir, rootRealPath } = params;
-  const requireBuiltRuntimeEntry =
-    params.requireBuiltRuntimeEntry ??
-    isManagedPluginDir({
-      dir,
-      realpath: rootRealPath,
-      managedPluginDirs: params.managedPluginDirs,
-      realpathCache: params.realpathCache,
-    });
-  const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
-    origin: params.origin,
-    rootDir: dir,
-    env: params.env,
-    realpathCache: params.realpathCache,
-  });
-  const manifest = readCandidatePackageManifest({
-    dir,
-    origin: params.origin,
-    rejectHardlinks,
-    ...(rootRealPath !== undefined ? { rootRealPath } : {}),
-    packageManifestCache: params.packageManifestCache,
-  });
-  const packageMetadata = getPackageManifestMetadata(manifest ?? undefined);
-  // Compatibility can return early, so resolve one canonical diagnostic owner before every check.
-  const candidateManifest = resolveCandidateManifest(dir, rejectHardlinks, rootRealPath);
-  const manifestId = candidateManifest?.manifest.id;
-  const pluginIdHint =
-    normalizeOptionalString(manifestId) ??
-    normalizeOptionalString(packageMetadata?.plugin?.id) ??
-    normalizeOptionalString(packageMetadata?.channel?.id) ??
-    derivePackagePluginIdHint(manifest?.name) ??
-    path.basename(dir);
-  if (
-    shouldSkipIncompatiblePackagePluginApi({
-      origin: params.origin,
-      packageManifest: packageMetadata,
-      pluginId: pluginIdHint,
-      packageDir: dir,
-      env: params.env,
-      diagnostics: params.diagnostics,
-    })
-  ) {
-    return true;
-  }
-  const extensionResolution = resolvePackageExtensionEntries(manifest ?? undefined);
-  if (
-    pushInvalidPackageExtensionDiagnostic({
-      resolution: extensionResolution,
-      source: dir,
-      pluginId: pluginIdHint,
-      diagnostics: params.diagnostics,
-    })
-  ) {
-    return true;
-  }
-  const extensions = extensionResolution.status === "ok" ? extensionResolution.entries : [];
-  const setupSource = resolvePackageSetupSource({
-    packageDir: dir,
-    ...(rootRealPath !== undefined ? { packageRootRealPath: rootRealPath } : {}),
-    manifest,
-    pluginIdHint,
-    origin: params.origin,
-    requireBuiltRuntimeEntry,
-    sourceLabel: dir,
-    diagnostics: params.diagnostics,
-    rejectHardlinks,
-  });
-  const addPackageCandidate = (
-    source: string,
-    idHint: string,
-    effectivePluginId?: string,
-  ): void => {
-    addCandidate({
-      candidates: params.candidates,
-      diagnostics: params.diagnostics,
-      seen: params.seen,
-      idHint,
-      ...(effectivePluginId ? { effectivePluginId } : {}),
-      diagnosticIdHint: pluginIdHint,
-      source,
-      ...(setupSource ? { setupSource } : {}),
-      rootDir: dir,
-      origin: params.origin,
-      ownershipUid: params.ownershipUid,
-      workspaceDir: params.workspaceDir,
-      ...(params.installOwner ? { installOwner: params.installOwner } : {}),
-      ...(params.installOwnerAmbiguous ? { installOwnerAmbiguous: true } : {}),
-      manifest,
-      packageDir: dir,
-      requiredPluginIds: candidateManifest?.manifest.requiresPlugins,
-      requiredPluginSource: candidateManifest?.manifestPath,
-      realpathCache: params.realpathCache,
-    });
-  };
-
-  if (extensions.length > 0) {
-    const resolvedRuntimeSources = resolvePackageRuntimeExtensionSources({
-      packageDir: dir,
-      ...(rootRealPath !== undefined ? { packageRootRealPath: rootRealPath } : {}),
-      manifest,
-      extensions,
-      origin: params.origin,
-      pluginIdHint,
-      requireBuiltRuntimeEntry,
-      sourceLabel: dir,
-      diagnostics: params.diagnostics,
-      rejectHardlinks,
-    });
-    // Entry ids derive from basenames, so ./a/index.js and ./b/index.js would
-    // both become <pack>/index and one entry would silently vanish in the
-    // registry's same-id dedupe. Reject the colliding entries loudly instead.
-    const entryIdSources = new Map<string, string[]>();
-    for (const source of resolvedRuntimeSources) {
-      const idHint = deriveIdHint({
-        filePath: source,
-        manifestId: manifestId ?? normalizeOptionalString(packageMetadata?.plugin?.id),
-        packageName: manifest?.name,
-        fallbackId: path.basename(dir),
-        hasMultipleExtensions: extensions.length > 1,
-      });
-      const sources = entryIdSources.get(idHint);
-      if (sources) {
-        sources.push(source);
-      } else {
-        entryIdSources.set(idHint, [source]);
-      }
-    }
-    for (const [idHint, sources] of entryIdSources) {
-      if (extensions.length > 1 && sources.length > 1) {
-        params.diagnostics.push({
-          level: "error",
-          pluginId: idHint,
-          source: dir,
-          message:
-            `plugin package entries collide on derived id "${idHint}" ` +
-            `(${sources.map((s) => path.relative(dir, s)).join(", ")}); ` +
-            "rename the entry files to unique basenames",
-        });
-        continue;
-      }
-      for (const source of sources) {
-        addPackageCandidate(source, idHint, extensions.length > 1 ? idHint : undefined);
-      }
-    }
-    return true;
-  }
-
-  if (
-    discoverBundleInRoot({
-      rootDir: dir,
-      origin: params.origin,
-      env: params.env,
-      ownershipUid: params.ownershipUid,
-      workspaceDir: params.workspaceDir,
-      ...(params.installOwner ? { installOwner: params.installOwner } : {}),
-      ...(params.installOwnerAmbiguous ? { installOwnerAmbiguous: true } : {}),
-      manifest,
-      candidates: params.candidates,
-      diagnostics: params.diagnostics,
-      seen: params.seen,
-      realpathCache: params.realpathCache,
-    }) === "added"
-  ) {
-    return true;
-  }
-
-  const indexFile = [...DEFAULT_PLUGIN_ENTRY_CANDIDATES]
-    .map((candidate) => path.join(dir, candidate))
-    .find((candidate) => fs.existsSync(candidate));
-  if (indexFile && isExtensionFile(indexFile)) {
-    addPackageCandidate(indexFile, manifestId ?? path.basename(dir));
-    return true;
-  }
-  return addLegacyNpmDeclarationDiagnostic({ pluginDir: dir, diagnostics: params.diagnostics });
-}
-
-function discoverInDirectory(params: {
-  dir: string;
-  origin: PluginOrigin;
-  env: NodeJS.ProcessEnv;
-  ownershipUid?: number | null;
-  workspaceDir?: string;
-  installOwner?: string;
-  installOwnerAmbiguous?: true;
-  requireBuiltRuntimeEntry?: boolean;
-  managedPluginDirs?: Set<string>;
-  skipRootDirKeys?: Set<string>;
-  candidates: PluginCandidate[];
-  diagnostics: PluginDiagnostic[];
-  seen: Set<string>;
-  realpathCache: Map<string, string>;
-  packageManifestCache?: Map<string, PackageManifest | null>;
-  scanFiles?: boolean;
-  recurseDirectories?: boolean;
-  skipDirectories?: Set<string>;
-  visitedDirectories?: Set<string>;
-}) {
-  if (!fs.existsSync(params.dir)) {
-    return;
-  }
-  const resolvedDir =
-    safeRealpathSync(params.dir, params.realpathCache) ?? path.resolve(params.dir);
-  if (params.recurseDirectories) {
-    if (params.visitedDirectories?.has(resolvedDir)) {
-      return;
-    }
-    params.visitedDirectories?.add(resolvedDir);
-  }
-  let entries: fs.Dirent[];
-  try {
-    entries = fs
-      .readdirSync(params.dir, { withFileTypes: true })
-      .toSorted((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
-  } catch (err) {
-    params.diagnostics.push({
-      level: "warn",
-      message: `failed to read extensions dir: ${params.dir} (${String(err)})`,
-      source: params.dir,
-    });
-    return;
-  }
-
-  for (const entry of entries) {
-    const fullPath = path.join(params.dir, entry.name);
-    const entryType = resolveScannedEntryType(entry, fullPath);
-    if (entryType === "file") {
-      const shouldScanFile = params.scanFiles ?? params.origin === "bundled";
-      if (!shouldScanFile || !isExtensionFile(fullPath)) {
-        continue;
-      }
-      addCandidate({
-        candidates: params.candidates,
-        diagnostics: params.diagnostics,
-        seen: params.seen,
-        idHint: path.basename(entry.name, path.extname(entry.name)),
-        source: fullPath,
-        rootDir: path.dirname(fullPath),
-        origin: params.origin,
-        ownershipUid: params.ownershipUid,
-        workspaceDir: params.workspaceDir,
-        ...(params.installOwner ? { installOwner: params.installOwner } : {}),
-        ...(params.installOwnerAmbiguous ? { installOwnerAmbiguous: true } : {}),
-        realpathCache: params.realpathCache,
-      });
-      continue;
-    }
-    if (entryType !== "directory") {
-      continue;
-    }
-    if (params.skipDirectories?.has(entry.name)) {
-      continue;
-    }
-    if (shouldIgnoreScannedDirectory(entry.name)) {
-      continue;
-    }
-
-    const fullPathRealPath = safeRealpathSync(fullPath, params.realpathCache) ?? undefined;
-    const fullPathDirKey = fullPathRealPath ?? path.resolve(fullPath);
-    if (params.skipRootDirKeys?.has(fullPathDirKey)) {
-      continue;
-    }
-    if (
-      discoverPluginDirectory({
-        ...params,
-        dir: fullPath,
-        rootRealPath: fullPathRealPath,
-      })
-    ) {
-      continue;
-    }
-
-    if (params.recurseDirectories) {
-      discoverInDirectory({
-        ...params,
-        dir: fullPath,
-      });
-    }
-  }
 }
 
 function isSourceCheckoutExtensionsDir(extensionsDir: string): boolean {
@@ -1355,127 +797,534 @@ function readBundledDistOptOutDirectoryNames(sourceExtensionsDir: string | undef
   return names;
 }
 
-function discoverFromPath(params: {
-  rawPath: string;
+type PluginDirectoryDiscoveryParams = {
+  dir: string;
+  rootRealPath: string | undefined;
   origin: PluginOrigin;
-  ownershipUid?: number | null;
   workspaceDir?: string;
   installOwner?: string;
   installOwnerAmbiguous?: true;
   requireBuiltRuntimeEntry?: boolean;
   managedPluginDirs?: Set<string>;
-  skipRootDirKeys?: Set<string>;
-  scanFiles?: boolean;
-  env: NodeJS.ProcessEnv;
-  candidates: PluginCandidate[];
-  diagnostics: PluginDiagnostic[];
-  seen: Set<string>;
-  realpathCache: Map<string, string>;
-  packageManifestCache?: Map<string, PackageManifest | null>;
-}) {
-  const resolved = resolveUserPath(params.rawPath, params.env);
-  if (!fs.existsSync(resolved)) {
-    params.diagnostics.push({
-      level: "error",
-      message: `plugin path not found: ${resolved}`,
-      source: resolved,
+};
+
+function createPluginScanner(env: NodeJS.ProcessEnv, ownershipUid?: number | null) {
+  const result: PluginDiscoveryResult = { candidates: [], diagnostics: [] };
+  const { candidates, diagnostics } = result;
+  const realpathCache = new Map<string, string>();
+  const packageManifestCache = new Map<string, PackageManifest | null>();
+  // Rejected configured paths must still receive independent bundled validation.
+  // Keep textual attempts phase-local; physical aliases merge only after acceptance.
+  const attemptedSources = new Map<string, PluginCandidate | undefined>();
+
+  function addCandidate(params: {
+    idHint: string;
+    effectivePluginId?: string;
+    installOwner?: string;
+    installOwnerAmbiguous?: true;
+    diagnosticIdHint?: string;
+    source: string;
+    setupSource?: string;
+    rootDir: string;
+    origin: PluginOrigin;
+    format?: PluginFormat;
+    bundleFormat?: PluginBundleFormat;
+    workspaceDir?: string;
+    manifest?: PackageManifest | null;
+    packageDir?: string;
+    bundledManifestId?: string;
+    bundledManifest?: PluginManifest;
+    bundledManifestPath?: string;
+    requiredPluginIds?: string[];
+    requiredPluginSource?: string;
+  }) {
+    const resolved = path.resolve(params.source);
+    if (attemptedSources.has(resolved)) {
+      const existing = attemptedSources.get(resolved);
+      if (existing) {
+        mergeCandidateInstallOwner(
+          existing,
+          params.installOwner,
+          params.installOwnerAmbiguous === true,
+        );
+      }
+      return;
+    }
+    const resolvedRoot =
+      safeRealpathSync(params.rootDir, realpathCache) ?? path.resolve(params.rootDir);
+    if (
+      isUnsafePluginCandidate({
+        source: resolved,
+        rootDir: resolvedRoot,
+        origin: params.origin,
+        pluginId: params.idHint,
+        diagnostics,
+        ownershipUid,
+        realpathCache,
+      })
+    ) {
+      attemptedSources.set(resolved, undefined);
+      return;
+    }
+    const manifest = params.manifest ?? null;
+    const packageManifest = getPackageManifestMetadata(manifest ?? undefined);
+    const packageDependencies = normalizePluginDependencySpecs({
+      dependencies: manifest?.dependencies,
+      optionalDependencies: manifest?.optionalDependencies,
     });
-    return;
+    const candidate = {
+      idHint: params.idHint,
+      ...(params.effectivePluginId ? { effectivePluginId: params.effectivePluginId } : {}),
+      ...(params.diagnosticIdHint && params.diagnosticIdHint !== params.idHint
+        ? { diagnosticIdHint: params.diagnosticIdHint }
+        : {}),
+      source: resolved,
+      setupSource: params.setupSource,
+      rootDir: resolvedRoot,
+      origin: params.origin,
+      format: params.format ?? "openclaw",
+      bundleFormat: params.bundleFormat,
+      workspaceDir: params.workspaceDir,
+      packageName: normalizeOptionalString(manifest?.name),
+      packageVersion: normalizeOptionalString(manifest?.version),
+      packageDescription: normalizeOptionalString(manifest?.description),
+      packageDir: params.packageDir,
+      packageManifest,
+      packageDependencies: packageDependencies.dependencies,
+      packageOptionalDependencies: packageDependencies.optionalDependencies,
+      rawPackageManifest: manifest ?? undefined,
+      bundledManifestId: params.bundledManifestId,
+      bundledManifest: params.bundledManifest,
+      bundledManifestPath: params.bundledManifestPath,
+      ...(params.requiredPluginIds && params.requiredPluginIds.length > 0
+        ? { requiredPluginIds: params.requiredPluginIds }
+        : {}),
+      ...(params.requiredPluginSource ? { requiredPluginSource: params.requiredPluginSource } : {}),
+    } satisfies PluginCandidate;
+    recordPluginCandidateInstallOwner(
+      candidate,
+      params.installOwner,
+      params.installOwnerAmbiguous === true,
+    );
+    candidates.push(candidate);
+    attemptedSources.set(resolved, candidate);
   }
 
-  const stat = fs.statSync(resolved);
-  if (stat.isFile()) {
-    if (!isExtensionFile(resolved)) {
-      params.diagnostics.push({
+  function discoverBundleInRoot(params: {
+    rootDir: string;
+    origin: PluginOrigin;
+    workspaceDir?: string;
+    installOwner?: string;
+    installOwnerAmbiguous?: true;
+    manifest?: PackageManifest | null;
+  }): "added" | "invalid" | "none" {
+    return withPluginScanExistenceCache(() => {
+      const bundleFormat = detectBundleManifestFormat(params.rootDir);
+      if (!bundleFormat) {
+        return "none";
+      }
+      const rootRealPath = safeRealpathSync(params.rootDir, realpathCache) ?? undefined;
+      const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
+        origin: params.origin,
+        rootDir: params.rootDir,
+        env,
+        realpathCache,
+      });
+      const bundleManifest = loadBundleManifest({
+        rootDir: params.rootDir,
+        ...(rootRealPath !== undefined ? { rootRealPath } : {}),
+        bundleFormat,
+        rejectHardlinks,
+      });
+      if (!bundleManifest.ok) {
+        diagnostics.push({
+          level: "error",
+          message: bundleManifest.error,
+          source: bundleManifest.manifestPath,
+        });
+        return "invalid";
+      }
+      addCandidate({
+        idHint: bundleManifest.manifest.id,
+        source: params.rootDir,
+        rootDir: params.rootDir,
+        origin: params.origin,
+        format: "bundle",
+        bundleFormat,
+        workspaceDir: params.workspaceDir,
+        ...(params.installOwner ? { installOwner: params.installOwner } : {}),
+        ...(params.installOwnerAmbiguous ? { installOwnerAmbiguous: true } : {}),
+        manifest: params.manifest,
+        packageDir: params.rootDir,
+        bundledManifestId: bundleManifest.manifest.id,
+        bundledManifestPath: bundleManifest.manifestPath,
+      });
+      return "added";
+    });
+  }
+
+  function discoverPluginDirectory(params: PluginDirectoryDiscoveryParams): boolean {
+    const { dir, rootRealPath } = params;
+    const requireBuiltRuntimeEntry =
+      params.requireBuiltRuntimeEntry ??
+      isManagedPluginDir({
+        dir,
+        realpath: rootRealPath,
+        managedPluginDirs: params.managedPluginDirs,
+        realpathCache,
+      });
+    const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
+      origin: params.origin,
+      rootDir: dir,
+      env,
+      realpathCache,
+    });
+    const manifest = readCandidatePackageManifest({
+      dir,
+      origin: params.origin,
+      rejectHardlinks,
+      ...(rootRealPath !== undefined ? { rootRealPath } : {}),
+      packageManifestCache,
+    });
+    const packageMetadata = getPackageManifestMetadata(manifest ?? undefined);
+    // Compatibility can return early, so resolve one canonical diagnostic owner before every check.
+    const candidateManifest = resolveCandidateManifest(dir, rejectHardlinks, rootRealPath);
+    const manifestId = candidateManifest?.manifest.id;
+    const pluginIdHint =
+      normalizeOptionalString(manifestId) ??
+      normalizeOptionalString(packageMetadata?.plugin?.id) ??
+      normalizeOptionalString(packageMetadata?.channel?.id) ??
+      derivePackagePluginIdHint(manifest?.name) ??
+      path.basename(dir);
+    if (
+      shouldSkipIncompatiblePackagePluginApi({
+        origin: params.origin,
+        packageManifest: packageMetadata,
+        pluginId: pluginIdHint,
+        packageDir: dir,
+        env,
+        diagnostics,
+      })
+    ) {
+      return true;
+    }
+    const extensionResolution = resolvePackageExtensionEntries(manifest ?? undefined);
+    if (
+      pushInvalidPackageExtensionDiagnostic({
+        resolution: extensionResolution,
+        source: dir,
+        pluginId: pluginIdHint,
+        diagnostics,
+      })
+    ) {
+      return true;
+    }
+    const extensions = extensionResolution.status === "ok" ? extensionResolution.entries : [];
+    const setupSource = resolvePackageSetupSource({
+      packageDir: dir,
+      ...(rootRealPath !== undefined ? { packageRootRealPath: rootRealPath } : {}),
+      manifest,
+      pluginIdHint,
+      origin: params.origin,
+      requireBuiltRuntimeEntry,
+      sourceLabel: dir,
+      diagnostics,
+      rejectHardlinks,
+    });
+    const addPackageCandidate = (
+      source: string,
+      idHint: string,
+      effectivePluginId?: string,
+    ): void => {
+      addCandidate({
+        idHint,
+        ...(effectivePluginId ? { effectivePluginId } : {}),
+        diagnosticIdHint: pluginIdHint,
+        source,
+        ...(setupSource ? { setupSource } : {}),
+        rootDir: dir,
+        origin: params.origin,
+        workspaceDir: params.workspaceDir,
+        ...(params.installOwner ? { installOwner: params.installOwner } : {}),
+        ...(params.installOwnerAmbiguous ? { installOwnerAmbiguous: true } : {}),
+        manifest,
+        packageDir: dir,
+        requiredPluginIds: candidateManifest?.manifest.requiresPlugins,
+        requiredPluginSource: candidateManifest?.manifestPath,
+      });
+    };
+
+    if (extensions.length > 0) {
+      const resolvedRuntimeSources = resolvePackageRuntimeExtensionSources({
+        packageDir: dir,
+        ...(rootRealPath !== undefined ? { packageRootRealPath: rootRealPath } : {}),
+        manifest,
+        extensions,
+        origin: params.origin,
+        pluginIdHint,
+        requireBuiltRuntimeEntry,
+        sourceLabel: dir,
+        diagnostics,
+        rejectHardlinks,
+      });
+      // Entry ids derive from basenames, so ./a/index.js and ./b/index.js would
+      // both become <pack>/index and one entry would silently vanish in the
+      // registry's same-id dedupe. Reject the colliding entries loudly instead.
+      const entryIdSources = new Map<string, string[]>();
+      for (const source of resolvedRuntimeSources) {
+        const idHint = deriveIdHint({
+          filePath: source,
+          manifestId: manifestId ?? normalizeOptionalString(packageMetadata?.plugin?.id),
+          packageName: manifest?.name,
+          fallbackId: path.basename(dir),
+          hasMultipleExtensions: extensions.length > 1,
+        });
+        const sources = entryIdSources.get(idHint);
+        if (sources) {
+          sources.push(source);
+        } else {
+          entryIdSources.set(idHint, [source]);
+        }
+      }
+      for (const [idHint, sources] of entryIdSources) {
+        if (extensions.length > 1 && sources.length > 1) {
+          diagnostics.push({
+            level: "error",
+            pluginId: idHint,
+            source: dir,
+            message:
+              `plugin package entries collide on derived id "${idHint}" ` +
+              `(${sources.map((s) => path.relative(dir, s)).join(", ")}); ` +
+              "rename the entry files to unique basenames",
+          });
+          continue;
+        }
+        for (const source of sources) {
+          addPackageCandidate(source, idHint, extensions.length > 1 ? idHint : undefined);
+        }
+      }
+      return true;
+    }
+
+    if (
+      discoverBundleInRoot({
+        rootDir: dir,
+        origin: params.origin,
+        workspaceDir: params.workspaceDir,
+        ...(params.installOwner ? { installOwner: params.installOwner } : {}),
+        ...(params.installOwnerAmbiguous ? { installOwnerAmbiguous: true } : {}),
+        manifest,
+      }) === "added"
+    ) {
+      return true;
+    }
+
+    const indexFile = [...DEFAULT_PLUGIN_ENTRY_CANDIDATES]
+      .map((candidate) => path.join(dir, candidate))
+      .find((candidate) => fs.existsSync(candidate));
+    if (indexFile && isExtensionFile(indexFile)) {
+      addPackageCandidate(indexFile, manifestId ?? path.basename(dir));
+      return true;
+    }
+    return addLegacyNpmDeclarationDiagnostic({ pluginDir: dir, diagnostics });
+  }
+
+  function discoverInDirectory(params: {
+    dir: string;
+    origin: PluginOrigin;
+    workspaceDir?: string;
+    installOwner?: string;
+    installOwnerAmbiguous?: true;
+    requireBuiltRuntimeEntry?: boolean;
+    managedPluginDirs?: Set<string>;
+    skipRootDirKeys?: Set<string>;
+    scanFiles?: boolean;
+    skipDirectories?: Set<string>;
+  }) {
+    if (!fs.existsSync(params.dir)) {
+      return;
+    }
+    let entries: fs.Dirent[];
+    try {
+      entries = fs
+        .readdirSync(params.dir, { withFileTypes: true })
+        .toSorted((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+    } catch (err) {
+      diagnostics.push({
+        level: "warn",
+        message: `failed to read extensions dir: ${params.dir} (${String(err)})`,
+        source: params.dir,
+      });
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(params.dir, entry.name);
+      const entryType = resolveScannedEntryType(entry, fullPath);
+      if (entryType === "file") {
+        const shouldScanFile = params.scanFiles ?? params.origin === "bundled";
+        if (!shouldScanFile || !isExtensionFile(fullPath)) {
+          continue;
+        }
+        addCandidate({
+          idHint: path.basename(entry.name, path.extname(entry.name)),
+          source: fullPath,
+          rootDir: path.dirname(fullPath),
+          origin: params.origin,
+          workspaceDir: params.workspaceDir,
+          ...(params.installOwner ? { installOwner: params.installOwner } : {}),
+          ...(params.installOwnerAmbiguous ? { installOwnerAmbiguous: true } : {}),
+        });
+        continue;
+      }
+      if (entryType !== "directory") {
+        continue;
+      }
+      if (params.skipDirectories?.has(entry.name)) {
+        continue;
+      }
+      if (shouldIgnoreScannedDirectory(entry.name)) {
+        continue;
+      }
+
+      const fullPathRealPath = safeRealpathSync(fullPath, realpathCache) ?? undefined;
+      const fullPathDirKey = fullPathRealPath ?? path.resolve(fullPath);
+      if (params.skipRootDirKeys?.has(fullPathDirKey)) {
+        continue;
+      }
+      discoverPluginDirectory({
+        ...params,
+        dir: fullPath,
+        rootRealPath: fullPathRealPath,
+      });
+    }
+  }
+
+  function discoverFromPath(params: {
+    rawPath: string;
+    origin: PluginOrigin;
+    workspaceDir?: string;
+    installOwner?: string;
+    installOwnerAmbiguous?: true;
+    requireBuiltRuntimeEntry?: boolean;
+    managedPluginDirs?: Set<string>;
+    skipRootDirKeys?: Set<string>;
+    scanFiles?: boolean;
+  }) {
+    const resolved = resolveUserPath(params.rawPath, env);
+    if (!fs.existsSync(resolved)) {
+      diagnostics.push({
         level: "error",
-        message: `plugin path is not a supported file: ${resolved}`,
+        message: `plugin path not found: ${resolved}`,
         source: resolved,
       });
       return;
     }
-    addCandidate({
-      candidates: params.candidates,
-      diagnostics: params.diagnostics,
-      seen: params.seen,
-      idHint: path.basename(resolved, path.extname(resolved)),
-      source: resolved,
-      rootDir: path.dirname(resolved),
-      origin: params.origin,
-      ownershipUid: params.ownershipUid,
-      workspaceDir: params.workspaceDir,
-      ...(params.installOwner ? { installOwner: params.installOwner } : {}),
-      ...(params.installOwnerAmbiguous ? { installOwnerAmbiguous: true } : {}),
-      realpathCache: params.realpathCache,
-    });
-    return;
-  }
 
-  if (stat.isDirectory()) {
-    if (
-      discoverPluginDirectory({
-        ...params,
-        dir: resolved,
-        rootRealPath: safeRealpathSync(resolved, params.realpathCache) ?? undefined,
-      })
-    ) {
+    const stat = fs.statSync(resolved);
+    if (stat.isFile()) {
+      if (!isExtensionFile(resolved)) {
+        diagnostics.push({
+          level: "error",
+          message: `plugin path is not a supported file: ${resolved}`,
+          source: resolved,
+        });
+        return;
+      }
+      addCandidate({
+        idHint: path.basename(resolved, path.extname(resolved)),
+        source: resolved,
+        rootDir: path.dirname(resolved),
+        origin: params.origin,
+        workspaceDir: params.workspaceDir,
+        ...(params.installOwner ? { installOwner: params.installOwner } : {}),
+        ...(params.installOwnerAmbiguous ? { installOwnerAmbiguous: true } : {}),
+      });
       return;
     }
 
-    discoverInDirectory({
-      dir: resolved,
-      origin: params.origin,
-      env: params.env,
-      ownershipUid: params.ownershipUid,
-      workspaceDir: params.workspaceDir,
-      candidates: params.candidates,
-      diagnostics: params.diagnostics,
-      seen: params.seen,
-      realpathCache: params.realpathCache,
-      packageManifestCache: params.packageManifestCache,
-      ...(params.scanFiles !== undefined || params.origin === "config"
-        ? { scanFiles: params.scanFiles ?? true }
-        : {}),
-      ...(params.requireBuiltRuntimeEntry !== undefined
-        ? { requireBuiltRuntimeEntry: params.requireBuiltRuntimeEntry }
-        : {}),
-      ...(params.managedPluginDirs ? { managedPluginDirs: params.managedPluginDirs } : {}),
-      ...(params.skipRootDirKeys ? { skipRootDirKeys: params.skipRootDirKeys } : {}),
-    });
-  }
-}
+    if (stat.isDirectory()) {
+      if (
+        discoverPluginDirectory({
+          ...params,
+          dir: resolved,
+          rootRealPath: safeRealpathSync(resolved, realpathCache) ?? undefined,
+        })
+      ) {
+        return;
+      }
 
-function discoverConfiguredPluginLoadPathsInto(params: {
-  loadPaths: readonly string[];
-  bundledRoot?: string;
-  ownershipUid?: number | null;
-  workspaceDir?: string;
-  env: NodeJS.ProcessEnv;
-  result: PluginDiscoveryResult;
-  seen: Set<string>;
-  realpathCache: Map<string, string>;
-  packageManifestCache: Map<string, PackageManifest | null>;
-}): void {
-  for (const loadPath of params.loadPaths) {
-    if (typeof loadPath !== "string") {
-      continue;
+      discoverInDirectory({
+        dir: resolved,
+        origin: params.origin,
+        workspaceDir: params.workspaceDir,
+        ...(params.scanFiles !== undefined || params.origin === "config"
+          ? { scanFiles: params.scanFiles ?? true }
+          : {}),
+        ...(params.requireBuiltRuntimeEntry !== undefined
+          ? { requireBuiltRuntimeEntry: params.requireBuiltRuntimeEntry }
+          : {}),
+        ...(params.managedPluginDirs ? { managedPluginDirs: params.managedPluginDirs } : {}),
+        ...(params.skipRootDirKeys ? { skipRootDirKeys: params.skipRootDirKeys } : {}),
+      });
     }
-    const trimmed = loadPath.trim();
-    if (!trimmed) {
-      continue;
-    }
-    discoverFromPath({
-      rawPath: trimmed,
-      origin: "config",
-      ownershipUid: params.ownershipUid,
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-      candidates: params.result.candidates,
-      diagnostics: params.result.diagnostics,
-      seen: params.seen,
-      realpathCache: params.realpathCache,
-      packageManifestCache: params.packageManifestCache,
-    });
   }
+
+  function discoverConfiguredPaths(loadPaths: readonly string[], workspaceDir?: string): void {
+    for (const loadPath of loadPaths) {
+      if (typeof loadPath === "string" && loadPath.trim()) {
+        discoverFromPath({ rawPath: loadPath.trim(), origin: "config", workspaceDir });
+      }
+    }
+  }
+  function finish(): PluginDiscoveryResult {
+    const candidatesBySource = new Map<string, PluginCandidate>();
+    const seenDiagnostics = new Set<string>();
+    const uniqueDiagnostics: PluginDiagnostic[] = [];
+    for (const candidate of candidates) {
+      // Configured aliases keep their precedence, but lifecycle ownership follows
+      // the one physical package entry rather than its textual path spelling.
+      const key =
+        safeRealpathSync(candidate.source, realpathCache) ?? path.resolve(candidate.source);
+      const existing = candidatesBySource.get(key);
+      if (existing) {
+        mergeCandidateInstallOwner(
+          existing,
+          resolvePluginCandidateInstallOwner(candidate),
+          isPluginCandidateInstallOwnerAmbiguous(candidate),
+        );
+        continue;
+      }
+      candidatesBySource.set(key, candidate);
+    }
+    for (const diagnostic of diagnostics) {
+      const key = [
+        diagnostic.level,
+        diagnostic.pluginId ?? "",
+        diagnostic.source ?? "",
+        diagnostic.message,
+      ].join("\0");
+      if (seenDiagnostics.has(key)) {
+        continue;
+      }
+      seenDiagnostics.add(key);
+      uniqueDiagnostics.push(diagnostic);
+    }
+
+    result.candidates = [...candidatesBySource.values()];
+    result.diagnostics = uniqueDiagnostics;
+    addMissingRequiredPluginDiagnostics(result, { env, realpathCache });
+    return result;
+  }
+  return {
+    result,
+    realpathCache,
+    discoverConfiguredPaths,
+    discoverFromPath,
+    discoverInDirectory,
+    finish,
+    startSharedPhase: () => attemptedSources.clear(),
+  };
 }
 
 /** Discovers only explicit plugins.load.paths candidates without scanning shared roots. */
@@ -1485,23 +1334,10 @@ export function discoverConfiguredPluginLoadPaths(params: {
   ownershipUid?: number | null;
   env?: NodeJS.ProcessEnv;
 }): PluginDiscoveryResult {
-  const env = params.env ?? process.env;
-  const workspaceDir = normalizeOptionalString(params.workspaceDir);
-  const workspaceRoot = workspaceDir ? resolveUserPath(workspaceDir, env) : undefined;
-  const roots = resolvePluginSourceRoots({ workspaceDir: workspaceRoot, env });
-  const result = createDiscoveryResult();
-  discoverConfiguredPluginLoadPathsInto({
-    loadPaths: params.loadPaths,
-    bundledRoot: roots.stock,
-    ownershipUid: params.ownershipUid,
-    workspaceDir,
-    env,
-    result,
-    seen: new Set<string>(),
-    realpathCache: new Map<string, string>(),
-    packageManifestCache: new Map<string, PackageManifest | null>(),
-  });
-  return result;
+  const scanner = createPluginScanner(params.env ?? process.env, params.ownershipUid);
+  scanner.discoverConfiguredPaths(params.loadPaths, normalizeOptionalString(params.workspaceDir));
+  // Doctor needs raw alias counts and diagnostics, not the full scan's publication pass.
+  return scanner.result;
 }
 
 export function discoverOpenClawPlugins(params: {
@@ -1516,58 +1352,36 @@ export function discoverOpenClawPlugins(params: {
   const workspaceDir = normalizeOptionalString(params.workspaceDir);
   const workspaceRoot = workspaceDir ? resolveUserPath(workspaceDir, env) : undefined;
   const roots = resolvePluginSourceRoots({ workspaceDir: workspaceRoot, env });
-  const realpathCache = new Map<string, string>();
-  const packageManifestCache = new Map<string, PackageManifest | null>();
-  const scopedResult =
-    params.rootScope === "bundled"
-      ? createDiscoveryResult()
-      : tracePluginLifecyclePhase(
-          "discovery scan",
-          () => {
-            const result = createDiscoveryResult();
-            const seen = new Set<string>();
-            discoverConfiguredPluginLoadPathsInto({
-              loadPaths: params.extraPaths ?? [],
-              bundledRoot: roots.stock,
-              ownershipUid: params.ownershipUid,
-              workspaceDir,
-              env,
-              result,
-              seen,
-              realpathCache,
-              packageManifestCache,
-            });
-            const workspaceMatchesBundledRoot = resolvesToSameDirectory(
-              workspaceRoot,
-              roots.stock,
-              realpathCache,
-            );
-            if (roots.workspace && workspaceRoot && !workspaceMatchesBundledRoot) {
-              // Keep workspace auto-discovery constrained to the OpenClaw extensions root.
-              // Recursively scanning the full workspace treats arbitrary project folders as
-              // plugin candidates and causes noisy "plugin manifest not found" validation failures.
-              discoverInDirectory({
-                dir: roots.workspace,
-                origin: "workspace",
-                env,
-                ownershipUid: params.ownershipUid,
-                workspaceDir: workspaceRoot,
-                candidates: result.candidates,
-                diagnostics: result.diagnostics,
-                seen,
-                realpathCache,
-                packageManifestCache,
-              });
-            }
-            return result;
-          },
-          { scope: "scoped", extraPathCount: params.extraPaths?.length ?? 0 },
+  const scanner = createPluginScanner(env, params.ownershipUid);
+  const { result, realpathCache, discoverFromPath, discoverInDirectory } = scanner;
+  if (params.rootScope !== "bundled") {
+    tracePluginLifecyclePhase(
+      "discovery scan",
+      () => {
+        scanner.discoverConfiguredPaths(params.extraPaths ?? [], workspaceDir);
+        const workspaceMatchesBundledRoot = resolvesToSameDirectory(
+          workspaceRoot,
+          roots.stock,
+          realpathCache,
         );
-  const sharedResult = tracePluginLifecyclePhase(
+        if (roots.workspace && workspaceRoot && !workspaceMatchesBundledRoot) {
+          // Keep workspace auto-discovery constrained to the OpenClaw extensions root.
+          // Recursively scanning the full workspace treats arbitrary project folders as
+          // plugin candidates and causes noisy "plugin manifest not found" validation failures.
+          discoverInDirectory({
+            dir: roots.workspace,
+            origin: "workspace",
+            workspaceDir: workspaceRoot,
+          });
+        }
+      },
+      { scope: "scoped", extraPathCount: params.extraPaths?.length ?? 0 },
+    );
+  }
+  scanner.startSharedPhase();
+  tracePluginLifecyclePhase(
     "discovery scan",
     () => {
-      const result = createDiscoveryResult();
-      const seen = new Set<string>();
       for (const sourceOverlayDir of listBundledSourceOverlayDirs({
         bundledRoot: roots.stock,
         env,
@@ -1575,14 +1389,7 @@ export function discoverOpenClawPlugins(params: {
         discoverFromPath({
           rawPath: sourceOverlayDir,
           origin: "bundled",
-          ownershipUid: params.ownershipUid,
           workspaceDir,
-          env,
-          candidates: result.candidates,
-          diagnostics: result.diagnostics,
-          seen,
-          realpathCache,
-          packageManifestCache,
         });
         result.diagnostics.push({
           level: "warn",
@@ -1608,14 +1415,7 @@ export function discoverOpenClawPlugins(params: {
           discoverFromPath({
             rawPath: path.join(sourceCheckoutExtensionsDir, dirName),
             origin: "bundled",
-            ownershipUid: params.ownershipUid,
             workspaceDir,
-            env,
-            candidates: result.candidates,
-            diagnostics: result.diagnostics,
-            seen,
-            realpathCache,
-            packageManifestCache,
           });
         }
       }
@@ -1623,13 +1423,6 @@ export function discoverOpenClawPlugins(params: {
         discoverInDirectory({
           dir: roots.stock,
           origin: "bundled",
-          env,
-          ownershipUid: params.ownershipUid,
-          candidates: result.candidates,
-          diagnostics: result.diagnostics,
-          seen,
-          realpathCache,
-          packageManifestCache,
           skipDirectories: bundledDistOptOutDirectories,
         });
       }
@@ -1642,48 +1435,27 @@ export function discoverOpenClawPlugins(params: {
         discoverInDirectory({
           dir: sourceCheckoutExtensionsDir,
           origin: "bundled",
-          env,
-          ownershipUid: params.ownershipUid,
-          candidates: result.candidates,
-          diagnostics: result.diagnostics,
-          seen,
-          realpathCache,
-          packageManifestCache,
           skipDirectories: readChildDirectoryNames(roots.stock),
         });
       }
       if (params.rootScope !== "bundled") {
-        const installedPaths = collectInstalledPluginRecordPaths(
-          params.installRecords,
-          env,
-          realpathCache,
-          result.diagnostics,
-        );
-        const installedPluginDirKeys = collectManagedPluginDirKeys(
-          installedPaths.map((installedPath) => installedPath.path),
-          realpathCache,
-        );
-        const managedPluginDirs = collectManagedPluginDirKeys(
-          collectManagedPluginRecordPaths(params.installRecords, env),
-          realpathCache,
-        );
+        const { installedPaths, installedPluginDirKeys, managedPluginDirs } =
+          prepareInstalledPluginPaths(
+            params.installRecords,
+            env,
+            realpathCache,
+            result.diagnostics,
+          );
         for (const installedPath of installedPaths) {
           discoverFromPath({
             rawPath: installedPath.path,
             origin: "global",
-            ownershipUid: params.ownershipUid,
             workspaceDir,
             ...(installedPath.installOwner ? { installOwner: installedPath.installOwner } : {}),
             ...(installedPath.installOwnerAmbiguous ? { installOwnerAmbiguous: true } : {}),
             requireBuiltRuntimeEntry: installedPath.requireBuiltRuntimeEntry,
             managedPluginDirs,
             scanFiles: true,
-            env,
-            candidates: result.candidates,
-            diagnostics: result.diagnostics,
-            seen,
-            realpathCache,
-            packageManifestCache,
           });
         }
         // Keep auto-discovered global extensions behind bundled plugins.
@@ -1691,27 +1463,13 @@ export function discoverOpenClawPlugins(params: {
         discoverInDirectory({
           dir: roots.global,
           origin: "global",
-          env,
-          ownershipUid: params.ownershipUid,
           managedPluginDirs,
           skipRootDirKeys: installedPluginDirKeys,
-          candidates: result.candidates,
-          diagnostics: result.diagnostics,
-          seen,
-          realpathCache,
-          packageManifestCache,
         });
       }
-      return result;
     },
     { scope: "shared" },
   );
-  const result = createDiscoveryResult();
-  const candidatesBySource = new Map<string, PluginCandidate>();
-  const seenDiagnostics = new Set<string>();
-  mergeDiscoveryResult(result, scopedResult, candidatesBySource, seenDiagnostics, realpathCache);
-  mergeDiscoveryResult(result, sharedResult, candidatesBySource, seenDiagnostics, realpathCache);
-  addMissingRequiredPluginDiagnostics(result, { env, realpathCache });
-  return result;
+  return scanner.finish();
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Plugin discovery still assembles and merges separate scoped/shared result objects after the caches that needed them were removed. It also carries traversal state for recursion that has no remaining caller. This maintainer-requested structural cleanup removes those obsolete flows without changing which plugins operators can load.

## Why This Change Was Made

One private, invocation-owned scanner now owns candidates, diagnostics, filesystem/package facts and phase-local attempted paths. The old result containers, merge protocol, unreachable recursive traversal and repeated state plumbing are deleted. Installed-path preparation has one owner while preserving the important distinction between preferred scan paths, all managed paths and auto-scan exclusion directories.

The two acceptance phases remain deliberately separate: a configured-path rejection must not prevent later bundled permission repair and acceptance. Physical aliases are normalized only after acceptance; the first candidate retains its origin and fields while symbol-backed install-owner/ambiguity facts merge. Configured-only discovery stays raw for Doctor's count-sensitive check. Registry duplicate-ID selection, official-install trust, package/runtime boundary checks, root ordering and metadata-cache lifecycle are unchanged.

Deleting recursion alone would leave the obsolete split-result owner. A generic discovery framework would add abstractions without replacing OpenClaw's origin-sensitive policy. This change instead consolidates the existing private owner and preserves both public entry points.

## User Impact

No intended user-visible behavior or configuration change. Existing native, bundled, linked-source and bundle-style plugin discovery retains its ordering, diagnostics and safety checks. No dependency, SDK export, schema, persistence or protocol change.

Production LOC: +573/-815 (net -242). Tests: +234/-31 (net +203). Only `src/plugins/discovery.ts` and its existing test file change.

## Evidence

Baseline: `86e208310ff2f7a66e4f0c5968e74b319234f6aa`. Reviewed and proven commit: `0dd08aa6643d5635ccaf092f063a1bb7e7c3a4a3`.

- Before production editing, clean-machine discovery/registry/path suites passed 295 tests. Final identical-order baseline and candidate runs each passed 317 tests across nine files, including Doctor.
- Added real filesystem and registry cases cover configured rejection followed by bundled repair, raw configured aliases/diagnostics, multi-entry ownership, official registry trust versus local archive/ambiguous ownership, missing preferred installs and managed source copies. The official-trust assertions use real discovery-to-registry fixtures, not a published official-package installation.
- Independent review caught a candidate-only regression: collecting excluded parent directories before physical installed-path deduplication could hide a neighboring plugin. The regression failed on the initial refactor and passed after restoring the retained-path rule. This is not claimed as a pre-existing shipped bug.
- `node scripts/check-changed.mjs -- src/plugins/discovery.ts src/plugins/discovery.test.ts` passed completely, including formatting, production/test types, lint, dead exports and selected guards. Fresh full-change P1 autoreview is clean; independent source/test review is PASS.
- The corrected full clean-machine build passed in 10m40.3s. The real dist-backed CLI packed and installed a native plugin, linked a TypeScript plugin, listed/inspected both plus a Claude-style bundle, and started an isolated loopback Gateway. Both native plugins registered in the actual Gateway process. After changing the linked source, a stopped-and-restarted Gateway loaded its new revision. This live flow passed in 65.611s; owned processes/temp state and the Testbox lease were cleaned up.
- Clean-machine proof used [Testbox run 33020081680](https://github.com/openclaw/openclaw/actions/runs/33020081680). The prepared runner Git HEAD is not the candidate identity: all 22,715 tracked files excluding `*.test.ts` were fingerprinted by content/symlink-target bytes and matched the frozen candidate. Final committed source/test blobs match the reviewed local files. The earlier remote test snapshot differs only in a Windows symlink-test guard; Linux behavior is unchanged. Workflow cleanup may mark the infrastructure run canceled; the proof command itself ended with `exitCode: 0`.
- One build attempt lost its SSH connection; the recovered full build passed. The first live script then correctly hit the local-plugin trust confirmation because its linked-install command omitted `--force`. After explicitly acknowledging the reviewed synthetic fixture, the live-only rerun passed. Neither retry required production changes.
- Independent final source/proof approval is bound to the exact commit above. Exact pushed-head GitHub CI and the native maintainer landing gates remain required.

The final suite command was `node scripts/run-vitest.mjs src/plugins/discovery.test.ts src/plugins/discovery-threading.test.ts src/plugins/plugin-discovery-ordering.test.ts src/plugins/hardlink-policy.test.ts src/plugins/package-compat.test.ts src/plugins/manifest-registry.test.ts src/plugins/manifest-registry-installed.test.ts src/plugins/installed-plugin-index.test.ts src/commands/doctor/shared/pristine-startup-state.test.ts`.

AI-assisted implementation with independent design and source review.
