### PR TITLE
feat(buzz): bound bot-to-bot room conversations

### DIFF
--- a/docs/channels/buzz.md
+++ b/docs/channels/buzz.md
@@ -339,6 +339,24 @@ routed agent can do after a message is accepted. Treat room messages as
 untrusted input, and configure that agent's [sandbox and tool policy](/gateway/sandbox-vs-tool-policy-vs-elevated)
 for the room's trust level.
 
+### Bot conversations
+
+Authorized room members with the relay-assigned **Bot** role can activate the
+agent under the same mention and sender rules. Within each Gateway, OpenClaw
+limits repeated exchanges between each bot pair in the same relay and room:
+the default budget is 20 accepted messages in 60 seconds, followed by a
+60-second cooldown. Changing threads does not reset the budget. Restarting the
+Gateway clears this in-memory budget; separate Gateways have separate budgets.
+Human messages are unaffected, and suppressed bot turns are logged without
+starting an agent run.
+
+Use the shared `channels.defaults.botLoopProtection` settings to adjust
+`maxEventsPerWindow`, `windowSeconds`, or `cooldownSeconds`. Setting
+`enabled: false` disables this protection. Bot classification comes from the latest
+received relay-signed room roster, never a display name or message content. If an
+authorized bot stops replying during a busy exchange, check the suppression log
+and allow the cooldown to expire before adjusting the budget.
+
 ## Manual configuration
 
 Guided setup is recommended. The equivalent configuration looks like:

--- a/extensions/buzz/src/directory-state.ts
+++ b/extensions/buzz/src/directory-state.ts
@@ -237,6 +237,16 @@ export class BuzzDirectoryState {
     return this.#rooms.get(parseBuzzTarget(roomId))?.archived === true;
   }
 
+  isBotMember(roomId: string, publicKey: string): boolean {
+    const normalizedRoomId = parseBuzzTarget(roomId);
+    const membership = this.#memberships.get(normalizedRoomId);
+    return (
+      !this.#rooms.get(normalizedRoomId)?.archived &&
+      membership?.members.has(publicKey) === true &&
+      membership.roles.get(publicKey) === "bot"
+    );
+  }
+
   applyProfileEvent(event: Event): boolean {
     const profile = parseBuzzDirectoryProfileEvent(event);
     if (

--- a/extensions/buzz/src/inbound.test.ts
+++ b/extensions/buzz/src/inbound.test.ts
@@ -1,4 +1,7 @@
-import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  buildChannelInboundEventContext,
+  runPreparedInboundReply,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
 // Buzz tests cover inbound room admission, mention gating, and reply delivery.
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
@@ -306,6 +309,79 @@ describe("handleBuzzInbound", () => {
 
     expect(runtime.channel.inbound.dispatch).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { role: "bot", enabled: true, dispatches: 1 },
+    { role: "member", enabled: true, dispatches: 2 },
+    { role: undefined, enabled: true, dispatches: 2 },
+    { role: "bot", enabled: false, dispatches: 2 },
+  ])(
+    "bounds current roster role $role with protection enabled=$enabled",
+    async ({ role, enabled, dispatches }) => {
+      const runtime = createPluginRuntimeMock();
+      const runDispatch = vi.fn(async () => ({
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 1 },
+      }));
+      const recordInboundSession = vi.fn(async () => undefined);
+      vi.mocked(runtime.channel.inbound.dispatch).mockImplementation(async (params) =>
+        runPreparedInboundReply({
+          ...params,
+          routeSessionKey: params.route.sessionKey,
+          storePath: "/unused/buzz-bot-loop",
+          recordInboundSession,
+          runDispatch,
+        }),
+      );
+      setBuzzRuntime(runtime);
+      const bus = createBus();
+      bus.directory.replaceMemberships(
+        new Map([
+          [
+            ROOM_ID,
+            {
+              roomId: ROOM_ID,
+              createdAt: 1_777_000_000,
+              eventId: "membership-bot-loop",
+              publisherPublicKey: OTHER_PUBLIC_KEY,
+              members: new Set([BOT_PUBLIC_KEY, SENDER_PUBLIC_KEY]),
+              roles: new Map(role ? [[SENDER_PUBLIC_KEY, role]] : []),
+            },
+          ],
+        ]),
+      );
+      const account = createAccount({ groups: { [ROOM_ID]: { requireMention: false } } });
+      const relayHost = `loop-${role ?? "unknown"}-${enabled}.example.test`;
+      account.relayUrl = `wss://${relayHost}/`;
+      const cfg = {
+        channels: {
+          defaults: {
+            botLoopProtection: {
+              enabled,
+              maxEventsPerWindow: 1,
+              windowSeconds: 60,
+              cooldownSeconds: 60,
+            },
+          },
+        },
+      } satisfies OpenClawConfig;
+      for (const [index, id] of ["loop-first", "loop-second"].entries()) {
+        if (index === 1) {
+          account.relayUrl = `wss://${relayHost.toUpperCase()}:443/`;
+        }
+        await handleBuzzInbound({
+          account,
+          cfg,
+          bus,
+          message: createMessage({ id, threadId: id, createdAt: 1_777_000_000 + index * 86_400 }),
+          ...createLifecycle(),
+        });
+      }
+
+      expect(runDispatch).toHaveBeenCalledTimes(dispatches);
+      expect(recordInboundSession).toHaveBeenCalledTimes(dispatches);
+    },
+  );
 
   it.each([
     {

--- a/extensions/buzz/src/inbound.ts
+++ b/extensions/buzz/src/inbound.ts
@@ -1,3 +1,4 @@
+import { normalizeURL } from "nostr-tools/utils";
 import {
   buildChannelInboundEventContext,
   resolveChannelInboundRouteEnvelope,
@@ -157,6 +158,24 @@ export async function handleBuzzInbound(params: {
       sessionKey: route.sessionKey,
     },
     ctxPayload,
+    botLoopProtection: bus.directory.isBotMember(channelId, message.senderPubkey)
+      ? {
+          // Reciprocal accounts share the relay/room pair budget. Threads and
+          // sender timestamps must not let a bot reset or evade that budget.
+          scopeId: `buzz:${normalizeURL(account.relayUrl)}`,
+          conversationId: channelId,
+          senderId: message.senderPubkey,
+          receiverId: bus.publicKey,
+          eventId: message.id,
+          defaultsConfig: cfg.channels?.defaults?.botLoopProtection,
+          defaultEnabled: true,
+        }
+      : undefined,
+    log: (event) => {
+      if (event.reason === "bot-loop-protection") {
+        log.warn(`[${account.accountId}] Buzz bot-pair loop suppressed in ${channelId}`);
+      }
+    },
     delivery: {
       deliver: async (payload) => {
         const text =


### PR DESCRIPTION
Related: #129599. Thanks to @TheAngryPit for the capability audit and bot-loop report. This is one focused follow-up; it does not close the broader capability issue.

Includes the validated room-roster and admission lifecycle landed in #130467. Head `ab019a891c69e35dd609c6a6dfe3f660c1b0564a` is a one-commit refresh onto current main; Git range-diff confirms the feature patch is unchanged. The landed reply-prefix documentation is preserved.

## What Problem This Solves

Authorized Buzz bots can repeatedly activate each other without a bounded conversation budget. Operators need ordinary bot collaboration to work while preventing an unattended exchange from continuing indefinitely.

## Why This Change Was Made

Buzz now supplies the existing shared bot-loop guard with the latest received relay-signed room role and the canonical relay, room, participant pair, and event ID. The guard runs after current admission is revalidated; neither display names nor message content classify a sender as a bot. This reuses the shared owner without adding a Buzz-specific policy or persistent state.

## User Impact

The default budget is 20 accepted bot messages per pair and room within each Gateway over 60 seconds, followed by a 60-second cooldown. Existing sender and mention rules still apply. Human messages are unaffected. Thread changes do not reset the budget, while a Gateway restart clears it. Operators can use the existing `channels.defaults.botLoopProtection` settings.

Release-note context: bound Buzz bot-to-bot exchanges using current signed room roles and the shared conversation guard.

## Evidence

The unchanged four-case regression test fails on the campaign baseline for the bot budget and passes with the production change; human, unknown-role, and explicitly disabled-guard controls pass. On head `1ecac0f85c5e8d22390b1a6681c318be0ba24c1b`, the native PR checkout installed its own frozen-lockfile dependencies, completed all 15 canonical private-QA build phases, passed all 31 Buzz test files / 218 tests, scoped lint, inherited test type-checking, and the canonical Buzz package-boundary compiler after declaration preparation. Fresh owner and separate immutable-head P0–P2 reviews found no actionable issues.

Production LOC: +29/-0; tests: +77/-1; docs: +18/-0, beyond the lifecycle prerequisite. The production growth adds the signed-role fact and connects Buzz to the existing shared guard; there is no new SDK, configuration, storage, or protocol contract.

Refreshed head `ab019a891c69e35dd609c6a6dfe3f660c1b0564a` independently completed its own frozen-lockfile install, canonical private-QA build (6m41s), full Buzz suite (31 files / 223 tests, including newly landed tests), declaration preparation and Buzz package-boundary compiler. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33026288840) is green. The complete authenticated two-Gateway owner sequence passed again on this build with AIMock 1.39.0, fresh state, and all 12 expected signed outputs observed. Counts were `[0,0] → [2,2] → [2,2] → [3,3] → [5,5] → [6,6]` across startup, bounded bot exchange, denied sender, human during cooldown, signed Bot-role budget, and restored human service. Both Gateways stopped and the service owner independently verified restored roles and health.

An actual two-Gateway authenticated Buzz run on that exact native build observed four distinct signed replies and exactly two provider requests per Gateway before suppression. Denied traffic caused no inference; human traffic passed during cooldown; a signed human-to-bot role change applied the budget, and restoring the human role restored replies. The controlled AIMock provider offered 32 distinct responses per Gateway and independently recorded every request. The loaded Buzz entry and implementation chunk matched the candidate build; workspace AI dependencies resolved inside the native checkout.

A separate source-blind validator passed all five prewritten behavior clauses on `1ecac0`, then repeated the entire validation freshly against exact refreshed head `ab019a891c69e35dd609c6a6dfe3f660c1b0564a`, using independently chosen native inputs, signed roster reads, signed output reads, model-request counts, and suppression logs. The fresh run observed 12 distinct signed outputs, six per Gateway, across the full scenario. Three different thread roots shared the same bot-pair allowance. The excluded sender produced no inference, and restored human traffic continued on the previously suppressed thread. Both Gateways stopped cleanly and the service role baseline was restored. The ready observation matched the new build, loaded Buzz implementation, and own AI artifact hashes.

Proof boundary: the relay was a real self-hosted official Buzz service with signed authenticated native traffic; the AI provider was deterministic AIMock, not a live paid model or hosted Buzz. The live allowance was two events per Gateway with 600-second window/cooldown. Defaults, explicitly disabled protection, and unknown roles have focused automated coverage; cooldown expiration, a distributed cross-Gateway budget, and clean-machine installation were not live-tested. Earlier mixed-workspace observations are retained only as diagnostics and are not the final proof.

## Review Follow-through

The ClawSweeper rank-up request for an isolated two-Gateway trace is addressed by the native owner run and independent source-blind run above. The installed `nostr-tools` 2.24.2 contract was directly inspected: `lib/esm/utils.js` normalizes host case, default ports, and URL syntax, and `lib/esm/abstract-relay.js` uses the same `normalizeURL` in the relay constructor. Executing the dependency normalized both `wss://relay.example.test/` and `wss://RELAY.EXAMPLE.TEST:443/` to the same relay key. The guard therefore uses the transport's existing canonicalization rather than a second URL policy.

The default-on shared budget is the accepted maintainer-directed feature scope, with the existing global opt-out preserved. The relay subscription files belonged to the already-landed lifecycle prerequisite; this feature adds no serialized or persisted state. The refreshed head's own build, authenticated integration, fresh source-blind validation, and hosted CI are green. Both current rank-up requests are addressed; no patch findings remain. Native prepare/merge is the final step. The original `1ecac0` evidence is retained separately, not relabeled as an `ab019a` run.
