### PR TITLE
fix(packaging): report metadata for the final normalized archive

### DIFF
--- a/scripts/package-openclaw-for-docker.mts
+++ b/scripts/package-openclaw-for-docker.mts
@@ -511,22 +511,6 @@ export { run as runCommandForTest, runCapture as runCaptureForTest };
 
 async function newestOpenClawTarball(outputDir: string, packOutput: string) {
   let fromOutput = "";
-  try {
-    const parsed = JSON.parse(packOutput);
-    for (const entry of resolveNpmJsonEntries(parsed)) {
-      if (!entry || typeof entry !== "object" || !("filename" in entry)) {
-        continue;
-      }
-      const filenameValue = entry.filename;
-      if (typeof filenameValue !== "string") {
-        continue;
-      }
-      const filename = resolvePackedOpenClawFileName(filenameValue);
-      if (filename) {
-        fromOutput = filename;
-      }
-    }
-  } catch {}
   for (const line of packOutput.split(/\r?\n/u)) {
     const filename = resolvePackedOpenClawFileName(line);
     if (filename) {
@@ -557,12 +541,9 @@ async function newestOpenClawTarball(outputDir: string, packOutput: string) {
 async function writePackJson(
   packOutput: string,
   tarball: string,
-  packJsonPath: string | undefined,
+  packJsonPath: string,
   sourceDir: string,
 ) {
-  if (!packJsonPath) {
-    return;
-  }
   let parsed;
   try {
     parsed = JSON.parse(packOutput);
@@ -1023,26 +1004,18 @@ export async function packOpenClawPackageForDocker(
           ? ["pack", "--silent", "--config.ignore-scripts=true", "--pack-destination", outputPath]
           : [
               "pack",
-              ...(packageOptions.packJsonPath ? ["--json"] : []),
               "--silent",
               "--ignore-scripts",
               "--pack-destination",
               outputPath,
+              "--json=false",
             ];
-      if (packTool === "npm" && packageOptions.packJsonPath) {
-        packReceiptDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-npm-pack-receipt-"));
-      }
-      const packReceiptPath = packReceiptDir ? path.join(packReceiptDir, "pack.json") : undefined;
       packOutput = await runCaptureImpl(packTool, packArgs, sourcePath, {
-        stdoutFilePath: packReceiptPath,
         timeoutMs: resolveTimeoutMs(
           "OPENCLAW_DOCKER_PACKAGE_PACK_TIMEOUT_MS",
           DEFAULT_PACKAGE_PACK_TIMEOUT_MS,
         ),
       });
-      if (packReceiptPath) {
-        packOutput = await fs.readFile(packReceiptPath, "utf8");
-      }
     } finally {
       try {
         await cleanupBundledAiRuntime();
@@ -1069,7 +1042,30 @@ export async function packOpenClawPackageForDocker(
       }
     }
     await (packageOptions.normalizeTarballModes ?? normalizeOpenClawTarballModes)(tarball);
-    await writePackJson(packOutput, tarball, packageOptions.packJsonPath, sourcePath);
+    if (packageOptions.packJsonPath) {
+      // npm's original receipt predates normalization. Inspect the finished bytes;
+      // dry-run preserves the archive while npm owns hashes, modes, and inventory.
+      packReceiptDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-npm-pack-receipt-"));
+      const packReceiptPath = path.join(packReceiptDir, "pack.json");
+      await runCaptureImpl(
+        "npm",
+        ["pack", tarball, "--dry-run", "--json", "--ignore-scripts", "--offline", "--silent"],
+        sourcePath,
+        {
+          stdoutFilePath: packReceiptPath,
+          timeoutMs: resolveTimeoutMs(
+            "OPENCLAW_DOCKER_PACKAGE_PACK_TIMEOUT_MS",
+            DEFAULT_PACKAGE_PACK_TIMEOUT_MS,
+          ),
+        },
+      );
+      await writePackJson(
+        await fs.readFile(packReceiptPath, "utf8"),
+        tarball,
+        packageOptions.packJsonPath,
+        sourcePath,
+      );
+    }
     return tarball;
   } catch (error) {
     packageError = error;

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -1,5 +1,6 @@
 // Package OpenClaw For Docker tests cover QA Lab package artifact evidence.
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -21,6 +22,7 @@ import {
   runCommandForTest,
   writePackageInventoryForDocker,
 } from "../../../../scripts/package-openclaw-for-docker.mts";
+import { withEnvAsync } from "../../../../src/test-utils/env.js";
 import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
 
 const skipBundledAiRuntime = async (): Promise<() => Promise<void>> => async () => {};
@@ -497,7 +499,7 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it.skipIf(process.platform === "win32")(
-    "normalizes owner-only packed modes to world-readable entries",
+    "reports the final artifact after normalizing owner-only packed modes",
     async () => {
       const sourceDir = tempDirs.make("openclaw-package-modes-source-");
       const outputDir = tempDirs.make("openclaw-package-modes-output-");
@@ -519,21 +521,44 @@ describe("package-openclaw-for-docker", () => {
         })}\n`,
       );
 
-      const tarball = await packOpenClawPackageForDocker(sourceDir, outputDir, {
-        ...skipDocsMapLifecycle,
-        prepareBundledAiRuntime: skipBundledAiRuntime,
-        prepareChangelog: async () => {},
-        restoreChangelog: async () => {},
-      });
+      const tarball = await withEnvAsync({ npm_config_json: "true" }, async () =>
+        packOpenClawPackageForDocker(sourceDir, outputDir, {
+          ...skipDocsMapLifecycle,
+          outputName: "openclaw-current.tgz",
+          packJsonPath: path.join(outputDir, "pack.json"),
+          prepareBundledAiRuntime: skipBundledAiRuntime,
+          prepareChangelog: async () => {},
+          restoreChangelog: async () => {},
+        }),
+      );
 
       const entryModes = new Map<string, number>();
+      const files: Array<{ path: string; size: number; mode: number }> = [];
       await tar.t({
         file: tarball,
-        onentry: (entry) => entryModes.set(entry.path, (entry.mode ?? 0) & 0o777),
+        onentry: (entry) => {
+          const mode = (entry.mode ?? 0) & 0o777;
+          entryModes.set(entry.path, mode);
+          files.push({ path: entry.path.replace(/^package\//u, ""), size: entry.size, mode });
+        },
       });
       expect(entryModes.get("package/dist/index.js")).toBe(0o644);
       expect(entryModes.get("package/openclaw.mjs")).toBe(0o755);
       expect(entryModes.get("package/package.json")).toBe(0o644);
+      const bytes = fs.readFileSync(tarball);
+      const receipt = JSON.parse(fs.readFileSync(path.join(outputDir, "pack.json"), "utf8"));
+      expect(receipt).toEqual([
+        expect.objectContaining({
+          filename: path.basename(tarball),
+          size: bytes.length,
+          shasum: createHash("sha1").update(bytes).digest("hex"),
+          integrity: `sha512-${createHash("sha512").update(bytes).digest("base64")}`,
+          entryCount: files.length,
+          files: expect.arrayContaining(files),
+        }),
+      ]);
+      expect(receipt[0].files).toHaveLength(files.length);
+      expect(fs.readdirSync(outputDir).toSorted()).toEqual(["openclaw-current.tgz", "pack.json"]);
     },
   );
 
@@ -869,7 +894,7 @@ describe("package-openclaw-for-docker", () => {
     expect(calls).toEqual([
       "prepare-docs:/repo",
       "prepare:/repo",
-      "npm:pack --silent --ignore-scripts --pack-destination /out:/repo",
+      "npm:pack --silent --ignore-scripts --pack-destination /out --json=false:/repo",
       "restore-changelog:/repo",
       "restore-docs:/repo",
     ]);
@@ -1074,7 +1099,10 @@ describe("package-openclaw-for-docker", () => {
         prepareChangelog: async () => {},
         restoreChangelog: async () => {},
         runCaptureImpl: async (_command, _args, cwd, options) => {
-          fs.writeFileSync(path.join(outputDir, "openclaw-2026.5.28.tgz"), "package");
+          if (!options.stdoutFilePath) {
+            fs.writeFileSync(path.join(outputDir, "openclaw-2026.5.28.tgz"), "package");
+            return "openclaw-2026.5.28.tgz\n";
+          }
           return await runCaptureForTest(
             process.execPath,
             [
@@ -1127,10 +1155,15 @@ describe("package-openclaw-for-docker", () => {
             prepareChangelog: async () => {},
             restoreChangelog: async () => {},
             runCaptureImpl: async (_command, _args, _cwd, options) => {
+              if (!options.stdoutFilePath) {
+                fs.writeFileSync(path.join(outputDir, "openclaw-2026.5.28.tgz"), "package");
+                return "openclaw-2026.5.28.tgz\n";
+              }
               receiptPath = options.stdoutFilePath ?? "";
-              if (failure === "runner") throw new Error("npm pack failed");
+              if (failure === "runner") {
+                throw new Error("npm pack failed");
+              }
               fs.writeFileSync(receiptPath, "not json");
-              fs.writeFileSync(path.join(outputDir, "openclaw-2026.5.28.tgz"), "package");
               return "";
             },
           });
@@ -1149,7 +1182,9 @@ describe("package-openclaw-for-docker", () => {
           expect(receiptPath).not.toBe("");
         } finally {
           rmSpy.mockRestore();
-          if (receiptPath) fs.rmSync(path.dirname(receiptPath), { force: true, recursive: true });
+          if (receiptPath) {
+            fs.rmSync(path.dirname(receiptPath), { force: true, recursive: true });
+          }
         }
       }
     }
@@ -1466,7 +1501,9 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("restores source artifacts before exiting after receipt-read termination", async () => {
-    if (process.platform === "win32") return;
+    if (process.platform === "win32") {
+      return;
+    }
     const tempDir = tempDirs.make("openclaw-package-receipt-signal-");
     const markerPath = path.join(tempDir, "restored");
     const scriptUrl = pathToFileURL(path.resolve("scripts/package-openclaw-for-docker.mts")).href;
@@ -1476,7 +1513,7 @@ const readFile = fs.promises.readFile.bind(fs.promises);
 fs.promises.readFile = async (...args) => { if (String(args[0]).endsWith("/pack.json")) { process.kill(process.pid, "SIGTERM"); await new Promise((resolve) => setTimeout(resolve, 50)); } return await readFile(...args); };
 const { packOpenClawPackageForDocker } = await import(${JSON.stringify(scriptUrl)});
 try {
-  await packOpenClawPackageForDocker("/repo", ${JSON.stringify(tempDir)}, { packJsonPath: "result.json", prepareBundledAiRuntime: async () => async () => {}, prepareChangelog: async () => {}, prepareDocsMap: async () => {}, prepareManifest: async () => {}, restoreChangelog: async () => {}, restoreDocsMap: async () => { fs.writeFileSync(${JSON.stringify(markerPath)}, "done"); }, restoreManifest: async () => {}, runCaptureImpl: async (_command, _args, _cwd, options) => { fs.writeFileSync(options.stdoutFilePath, '[{"filename":"openclaw-2026.5.28.tgz"}]'); fs.writeFileSync(${JSON.stringify(path.join(tempDir, "openclaw-2026.5.28.tgz"))}, "package"); return ""; } });
+  await packOpenClawPackageForDocker("/repo", ${JSON.stringify(tempDir)}, { packJsonPath: "result.json", normalizeTarballModes: async () => {}, prepareBundledAiRuntime: async () => async () => {}, prepareChangelog: async () => {}, prepareDocsMap: async () => {}, prepareManifest: async () => {}, restoreChangelog: async () => {}, restoreDocsMap: async () => { fs.writeFileSync(${JSON.stringify(markerPath)}, "done"); }, restoreManifest: async () => {}, runCaptureImpl: async (_command, _args, _cwd, options) => { if (options.stdoutFilePath) fs.writeFileSync(options.stdoutFilePath, '[{"filename":"openclaw-2026.5.28.tgz"}]'); fs.writeFileSync(${JSON.stringify(path.join(tempDir, "openclaw-2026.5.28.tgz"))}, "package"); return "openclaw-2026.5.28.tgz\\n"; } });
 } catch (error) { process.exit(error.exitCode ?? 1); }
 `;
     const runner = spawn(process.execPath, ["--input-type=module", "-e", runnerScript]);


### PR DESCRIPTION
Closes #130484

## What Problem This Solves

Fixes an issue where installer and Docker package audits receive hashes, compressed size, file modes, and entry counts that no longer describe the returned tarball after permission normalization. The filename was updated correctly, but the rest of the receipt still described npm's earlier archive.

## Why This Change Was Made

Generate the receipt from the final renamed, normalized archive using npm's existing offline, script-disabled dry-run inspection. This keeps hashes and inventory in npm's canonical implementation and replaces the premature receipt path. Initial packing explicitly requests filename-only stdout, even when user npm configuration enables JSON; potentially large metadata is captured only into the existing temporary file-backed receipt path.

Remove the obsolete initial JSON filename reader and the now-redundant optional-output guard. Keep existing timeout, termination, source-restoration, receipt cleanup, JSON-shape normalization, and output-filename ownership. No new dependency, configuration surface, persistent store, provider call, or release publication.

## User Impact

`--pack-json` now describes the artifact that package consumers actually receive. npm 11 array output and npm 12 name-keyed output remain supported. Packaging without a requested receipt and the pnpm pack path keep their existing behavior. npm dry-run can use its ordinary cache and temporary extraction; it does not rewrite the final artifact.

Production **+26/-30 (net -4)**; tests **+52/-15 (net +37)**. The tests extend the existing real-archive regression, retain large-output/error/signal coverage, and clean up nearby test lint violations. No unrelated runtime changes are bundled.

## Evidence

- Frozen main baseline: `395e5db41b5c3f14cbb40114daa801135d2e6fde`. The archive rewrite was introduced by #130335 / `fc2724d831c8aaf5cb1d71fef1e81a67c1911826` (Peter Steinberger, August 26); no stable-release regression is claimed.
- Regression-first real npm/system-tar test: before the production change, the receipt reported **260 bytes / 3 entries**, while the final archive had **577 bytes / 5 entries**, different SHA-1/SHA-512 values, and normalized modes. The same extended test passes after the owner repair, including renamed output and inherited npm JSON configuration.
- Final focused package-builder suite: **37 passed, 3 Windows-only skipped, 40 total**, with real packing plus existing source restoration, large receipts, parse/runner/cleanup failures, timeout/process-group teardown, and receipt-read termination coverage.
- The focused local command used the canonical `vitest.package-docker.config.ts` through the existing private dependency resolver, not a new or exact-lock dependency installation. The normal test wrapper initially failed before tests on missing workspace dependencies; no production behavior or assertion was weakened.
- Formatting, direct AST lint, `git diff --check`, script erasability (**520 implementation files**), max-lines, and assertion-safety ratchets pass. The changed gate passed eight initial checks before missing local `oxfmt`; direct formatting passed separately. Local full typed gates remain unavailable: missing Node types and generated SDK artifacts. Exact-head hosted CI remains required.
- Direct installed npm source was inspected: npm `pack`, `libnpmpack`, `utils/tar`, and Pacote's local-file fetcher. Both npm 11.17.0 and 12.0.2 read the supplied archive bytes, compute metadata from them, skip lifecycle scripts, and avoid writing an output archive during dry-run.

- Three real no-mock packer runs pass on the final source, with `npm_config_json=true`: npm **11.17.0**, npm **12.0.2**, and npm **12.0.2 with 12,000 additional files**. The large lane produced a **2,172,943-byte receipt**, **12,006 archive entries**, and a **302,038-byte tarball**. Exact size/SHA-1/SHA-512, file modes, renamed output, real manifest sanitation and changelog trimming, source restoration, and cleanup were verified. The lead independently recomputed all three saved archive hashes. All child processes exited 0; temporary fixture homes, caches, and work directories were removed. These are real local packer proofs, not installed-application or Windows proof.
- Final source SHA-256: `970b05d7432da501d4700c44a6c6d7335c6d74c266e86f89dddd100ec7e6cb1f`; reviewed diff SHA-256: `f6049c8ef08414aff0c473324c5cd0e7d4619005c1b78a73dce09301afcca9fd`.

- Fresh final Codex autoreview completed successfully with no P0 findings; a separate independent source/dependency review found no actionable P0–P3 findings and confirmed the canonical owner repair. Both match the final diff. An initial review-tool compatibility failure was resolved using the already-installed compatible CLI, without changing the patch or weakening review isolation.
- [Exact-head hosted CI 33023966281](https://github.com/openclaw/openclaw/actions/runs/33023966281) completed **successfully** on attempt **2**, verified through the fresh run API at `2026-08-26T23:53:12Z` on `68248869be5ebd8773b0ae85325f4ffc4b5852e1`. The earlier skipped draft run is excluded. One retry targeted the failed Gateway test shard; no source, assertion, timeout, or gate was weakened.

CI follow-up: attempt 1 failed the unchanged `authenticated-request-dispatch.connection-liveness.test.ts:96` first case while waiting for handler entry within the default one-second polling limit. The unchanged file passed locally 2/2 (Vitest 4.1.10 versus CI 4.1.11), and the single same-head CI retry passed. Cold import timing is a hypothesis, not a proven root cause. Named follow-up: **Gateway connection-liveness test readiness synchronization** — reproduce the original shard order, then replace elapsed polling with explicit handler-entry/completion synchronization if confirmed. The original log is retained; this unrelated test was not speculatively changed in the packaging repair.

AI-assisted maintainer repair.

Latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/130489#issuecomment-5432469361) on the exact head has no actionable code/security findings; its exact-head CI rank-up is satisfied by the green second attempt. Its 30-second live-wrapper observation did not complete the suite, although captured output shows the changed real-archive test passing. The separately completed suite and real npm matrix above remain the proof. Its serialized-state heuristic describes the existing receipt export artifact; this PR does not change runtime SQLite/state/schema or migration behavior.
