### PR TITLE
fix(gateway): recover admitted turns across restart

### DIFF
--- a/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveGatewaySessionStoreTarget } from "../../gateway/session-utils.js";
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { listAgentRunsForSession } from "../../infra/agent-run-registry.js";
+import { collectActiveSessionWorkAdmissions } from "../../sessions/session-lifecycle-admission.js";
 import {
   listActiveEmbeddedRunSessionIds,
   listActiveEmbeddedRunSessionKeys,
@@ -37,7 +38,13 @@ async function markRecoveryStore(params: {
     entry: SessionEntry,
     sessionKey: string,
   ) =>
-    | { action: "mark"; replaceRuns?: boolean; resetRuntime?: boolean; runs?: RestartRecoveryRun[] }
+    | {
+        action: "mark";
+        forceRestartSafeTools?: boolean;
+        replaceRuns?: boolean;
+        resetRuntime?: boolean;
+        runs?: RestartRecoveryRun[];
+      }
     | { action: "retire_terminal" }
     | undefined;
 }) {
@@ -70,6 +77,9 @@ async function markRecoveryStore(params: {
         }
         if (plan.replaceRuns) {
           entry.restartRecoveryRuns = plan.runs;
+        }
+        if (plan.forceRestartSafeTools) {
+          entry.restartRecoveryForceSafeTools = true;
         }
         transitionMainSessionRecovery(entry, {
           kind: "mark_interrupted",
@@ -121,7 +131,15 @@ export async function markRestartAbortedMainSessions(params: {
     .filter((run) => run.runId && run.lifecycleGeneration && (run.sessionKey || run.sessionId));
   const currentLifecycleGeneration = getAgentEventLifecycleGeneration();
   const result = { marked: 0, skipped: 0 };
-  if (sessionKeys.size === 0 && sessionIds.size === 0) {
+  // Channel work can outlive its chat-run registration. The admission owner
+  // retains the authoritative store and session identities until the turn releases.
+  const activeAdmissions = collectActiveSessionWorkAdmissions();
+  if (
+    sessionKeys.size === 0 &&
+    sessionIds.size === 0 &&
+    activeRuns.length === 0 &&
+    activeAdmissions.size === 0
+  ) {
     return result;
   }
 
@@ -169,7 +187,11 @@ export async function markRestartAbortedMainSessions(params: {
     storePaths.add(path.join(sessionsDir, "sessions.json"));
   }
 
+  for (const storePath of activeAdmissions.keys()) {
+    storePaths.add(storePath);
+  }
   for (const storePath of storePaths) {
+    const activeAdmissionIdentities = activeAdmissions.get(storePath) ?? new Set<string>();
     const storeResult = await markRecoveryStore({
       storePath,
       plan: (entry, sessionKey) => {
@@ -190,14 +212,20 @@ export async function markRestartAbortedMainSessions(params: {
         if (
           entry.status !== "running" &&
           matchingActiveRuns.length === 0 &&
-          registeredActiveRuns.length === 0
+          registeredActiveRuns.length === 0 &&
+          !activeAdmissionIdentities.has(sessionKey) &&
+          !activeAdmissionIdentities.has(entry.sessionId)
         ) {
           return undefined;
         }
+        const matchedActiveAdmission =
+          activeAdmissionIdentities.has(sessionKey) ||
+          activeAdmissionIdentities.has(entry.sessionId);
         const matches =
-          typeof entry.sessionId === "string" && sessionIds.has(entry.sessionId)
+          matchedActiveAdmission ||
+          (typeof entry.sessionId === "string" && sessionIds.has(entry.sessionId)
             ? true
-            : !preferSessionIdMatch && sessionKeys.has(sessionKey);
+            : !preferSessionIdMatch && sessionKeys.has(sessionKey));
         if (!matches) {
           return undefined;
         }
@@ -212,7 +240,13 @@ export async function markRestartAbortedMainSessions(params: {
             lifecycleGeneration,
           })),
         ]);
-        return { action: "mark", replaceRuns: true, resetRuntime: !wasRunning, runs };
+        return {
+          action: "mark",
+          forceRestartSafeTools: matchedActiveAdmission,
+          replaceRuns: true,
+          resetRuntime: !wasRunning,
+          runs,
+        };
       },
     });
     result.marked += storeResult.marked;

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -52,6 +52,7 @@ import {
   tryBeginGatewayRootWorkAdmission,
 } from "../../process/gateway-work-admission.js";
 import {
+  beginSessionWorkAdmission,
   interruptSessionWorkAdmissions,
   isSessionLifecycleMutationActive,
   isSessionWorkAdmissionActive,
@@ -538,6 +539,34 @@ describe("main-session-restart-recovery", () => {
       { runId: "key-only-run", lifecycleGeneration },
       { runId: "restart-run", lifecycleGeneration },
     ]);
+  });
+
+  it("marks an admitted channel turn when no chat run remains", async () => {
+    const storePath = path.join(tmpDir, "admitted-channel", "sessions.json");
+    const sessionKey = "agent:main:main";
+    const sessionId = "admitted-channel-session";
+    await writeStorePath(storePath, {
+      [sessionKey]: runningSessionEntry(sessionId),
+    });
+    const admission = await beginSessionWorkAdmission({
+      scope: storePath,
+      identities: [sessionKey, sessionId],
+      assertAllowed: () => undefined,
+    });
+
+    try {
+      await expect(markRestartAbortedMainSessions({ stateDir: tmpDir })).resolves.toEqual({
+        marked: 1,
+        skipped: 0,
+      });
+      expect(readStore(storePath)[sessionKey]).toMatchObject({
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryForceSafeTools: true,
+      });
+    } finally {
+      admission.release();
+    }
   });
 
   it("does not scan stale stores for agents absent from the configured roster", async () => {

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
-  collectActiveSessionWorkAdmissionIdentities,
+  collectActiveSessionWorkAdmissions,
   runExclusiveSessionLifecycleMutation,
 } from "../../sessions/session-lifecycle-admission.js";
 import { runQueuedStoreWrite, type StoreWriterQueue } from "../../shared/store-writer-queue.js";
@@ -230,7 +230,8 @@ export function collectAdmissionProtectedSessionIds(params: {
   storePath: string;
 }): Set<string> {
   const protectedSessionIds = new Set<string>();
-  const admissionIdentities = collectActiveSessionWorkAdmissionIdentities(params.storePath);
+  const admissionIdentities =
+    collectActiveSessionWorkAdmissions().get(params.storePath) ?? new Set<string>();
   if (admissionIdentities.size === 0) {
     return protectedSessionIds;
   }

--- a/src/config/sessions/store-maintenance-preserve.ts
+++ b/src/config/sessions/store-maintenance-preserve.ts
@@ -1,5 +1,5 @@
 // Maintenance preserve providers protect runtime-owned sessions from pruning/capping.
-import { collectActiveSessionWorkAdmissionIdentities } from "../../sessions/session-lifecycle-admission.js";
+import { collectActiveSessionWorkAdmissions } from "../../sessions/session-lifecycle-admission.js";
 import { normalizeStoreSessionKey } from "./store-entry.js";
 import type { SessionEntry } from "./types.js";
 
@@ -58,7 +58,8 @@ export function collectActiveSessionWorkAdmissionKeys(params: {
   storePath: string;
   store: Record<string, SessionEntry>;
 }): Set<string> | undefined {
-  const activeIdentities = collectActiveSessionWorkAdmissionIdentities(params.storePath);
+  const activeIdentities =
+    collectActiveSessionWorkAdmissions().get(params.storePath) ?? new Set<string>();
   if (activeIdentities.size === 0) {
     return undefined;
   }

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -835,6 +835,32 @@ describe("createGatewayCloseHandler", () => {
     ).toBe(true);
   });
 
+  it("marks pending reply work after its chat run registration is gone", async () => {
+    const markMainSessionsAbortedForRestart = vi.fn<MarkMainSessionsAbortedForRestart>();
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        getPendingReplyCount: () => 1,
+        markMainSessionsAbortedForRestart,
+      }),
+    );
+
+    const result = await close({
+      reason: "gateway restarting",
+      restartExpectedMs: 123,
+      drainTimeoutMs: 0,
+    });
+
+    expect(result.warnings).toContain("restart-reply-drain");
+    expect(markMainSessionsAbortedForRestart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKeys: new Set(),
+        sessionIds: new Set(),
+        activeRuns: [],
+        reason: "gateway restart shutdown",
+      }),
+    );
+  });
+
   it("aborts active runs when restart reply drain times out", async () => {
     vi.useFakeTimers();
     const controller = new AbortController();
@@ -1340,7 +1366,7 @@ describe("createGatewayCloseHandler", () => {
     expect(nodeSendToSession).not.toHaveBeenCalled();
   });
 
-  it("awaits terminal persistence before deciding restart recovery", async () => {
+  it("awaits terminal persistence before deferring restart recovery to its owner", async () => {
     const controller = new AbortController();
     const markMainSessionsAbortedForRestart = vi.fn<MarkMainSessionsAbortedForRestart>();
     const chatAbortControllers = new Map([
@@ -1374,7 +1400,13 @@ describe("createGatewayCloseHandler", () => {
       drainTimeoutMs: 0,
     });
 
-    expect(markMainSessionsAbortedForRestart).not.toHaveBeenCalled();
+    expect(markMainSessionsAbortedForRestart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKeys: new Set(),
+        sessionIds: new Set(),
+        activeRuns: [],
+      }),
+    );
     expect(controller.signal.aborted).toBe(true);
     expect(chatAbortControllers.size).toBe(0);
   });

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -375,9 +375,6 @@ async function markActiveRunsForRestartRecovery(
   }
   await settleTerminalSessionPersistenceForRestart(params.chatAbortControllers);
   const refs = collectActiveRestartSessionRefs(params);
-  if (refs.sessionKeys.size === 0 && refs.sessionIds.size === 0) {
-    return;
-  }
   try {
     const markerTimeout = createTimeoutRace(
       RESTART_MARKER_SLOW_WARNING_MS,
@@ -521,14 +518,6 @@ async function drainRestartPendingRepliesForShutdown(
   const abortedQueuedTurns = abortQueuedTurnsForRestart(params);
   if (abortedQueuedTurns > 0) {
     shutdownLog.warn(`aborted ${abortedQueuedTurns} queued turn(s) during restart shutdown`);
-  }
-
-  if (
-    drainResult.counts.activeRuns <= 0 &&
-    (params.restartRecoveryCandidates?.size ?? 0) === 0 &&
-    listRestartRecoveryRuns(params.chatAbortControllers).length === 0
-  ) {
-    return;
   }
 
   await markActiveRunsForRestartRecovery({

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -535,9 +535,6 @@ export async function prepareGatewayLifecycle(params: {
         reason,
         isActiveRun,
       }) => {
-        if (sessionKeys.size === 0 && sessionIds.size === 0) {
-          return;
-        }
         await shutdownRuntime.markRestartAbortedMainSessions({
           cfg: getRuntimeConfig(),
           sessionKeys,

--- a/src/sessions/session-lifecycle-admission.ts
+++ b/src/sessions/session-lifecycle-admission.ts
@@ -377,23 +377,22 @@ export function getSessionWorkAdmissionRelease(
   );
 }
 
-/** Active session identities for one store/lifecycle scope. */
-export function collectActiveSessionWorkAdmissionIdentities(scope: string): Set<string> {
-  const normalizedScope = scope.trim();
-  if (!normalizedScope) {
-    throw new Error("session lifecycle scope is required");
-  }
-  const identities = new Set<string>();
+/** Active session identities grouped by their authoritative store/lifecycle scope. */
+export function collectActiveSessionWorkAdmissions(): Map<string, Set<string>> {
+  const targets = new Map<string, Set<string>>();
   for (const [normalizedIdentity, admissions] of ACTIVE_SESSION_WORK_ADMISSIONS) {
     if (admissions.size === 0) {
       continue;
     }
     const decoded = decodeSessionIdentity(normalizedIdentity);
-    if (decoded?.scope === normalizedScope) {
-      identities.add(decoded.identity);
+    if (!decoded) {
+      continue;
     }
+    const identities = targets.get(decoded.scope) ?? new Set<string>();
+    identities.add(decoded.identity);
+    targets.set(decoded.scope, identities);
   }
-  return identities;
+  return targets;
 }
 
 /** Unique admitted turns; one lease can be indexed under several identities. */


### PR DESCRIPTION
## What Problem This Solves

Fixes #130485. A forced Gateway restart could miss an admitted in-flight turn after chat-run cleanup, so startup never dispatched the required restart-safe recovery.

## Why This Change Was Made

Restart recovery now derives interrupted-session marking from the authoritative session-work admission owner instead of the narrower chat-run and recovery-candidate maps. Shutdown and maintenance callers share that canonical marking flow, and obsolete duplicate lifecycle plumbing is removed.

Production LOC: +55/-34 (net +21). Tests: +63/-2. The production growth records the missing owner-boundary state and removes the prior narrower path.

## User Impact

In-flight channel turns survive forced Gateway restarts through the intended restart-safe recovery policy instead of silently missing the first recovery dispatch.

## Evidence

- Exact release failure: https://github.com/openclaw/openclaw/actions/runs/33007261502/job/98304487481
- Focused 2026.9.1 beta reproduction: https://github.com/openclaw/openclaw/actions/runs/33042001796. Only restart 1 occurred; checkpoint 2 timed out before outbound-delivery verification, and startup never logged `dispatching restart-safe recovery`.
- The admission-owner regression fails on current `main` with `{ marked: 0, skipped: 0 }` and passes on this head with `{ marked: 1, skipped: 0 }`.
- Focused restart-recovery and server-close suites pass (`172` and `56` tests).
- QA runtime-pair lane: 25/25 scenarios passed, including `gateway-restart-inflight-run`.
- Changed-file gates passed.
- Author Codex autoreview: clean, patch correct at 0.98 confidence.
- Fresh maintainer isolated Claude autoreview on August 27, 2026: no accepted or actionable findings.

AI-assisted: yes. No agent transcript is included.
