### PR TITLE
fix(exec): preserve approved export completion during Gateway drain

### DIFF
--- a/docs/gateway/diagnostics.md
+++ b/docs/gateway/diagnostics.md
@@ -46,9 +46,13 @@ Gateway export as one copy-pasteable support report:
 
 In group chats, an owner can still run `/diagnostics`, but OpenClaw sends the
 export result, approval prompts, and Codex session/thread breakdown to the
-owner privately. The group only sees a short notice that diagnostics were sent
-privately. If no private owner route exists, the command fails closed and asks
+owner privately. The group sees either a pending-approval notice or confirmation
+that the export status was delivered privately. If no private owner route exists, the command fails closed and asks
 the owner to run it from a DM.
+
+Running, completed, failed, and unavailable exports report their current status
+without requesting another approval. If execution could not be confirmed,
+inspect the existing run before trying again.
 
 When the active session uses the native OpenAI Codex harness, the same exec
 approval also covers an OpenAI feedback upload for the Codex threads OpenClaw

--- a/docs/tools/trajectory.md
+++ b/docs/tools/trajectory.md
@@ -54,6 +54,10 @@ bundle; do not use allow-all. In group chats, OpenClaw sends the approval
 prompt and export result to the owner privately instead of posting trajectory
 details back to the shared room.
 
+The command reports the current export status. Only a pending approval asks you
+to approve; a running or completed export does not need another approval. If
+execution could not be confirmed, inspect the existing run before trying again.
+
 For local inspection or support workflows, run the underlying CLI command
 directly:
 

--- a/src/agents/bash-tools.exec-approval-followup-routing.test-support.ts
+++ b/src/agents/bash-tools.exec-approval-followup-routing.test-support.ts
@@ -1,0 +1,88 @@
+// Captured-route tests share the sender suite's external transport mocks.
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
+import type { GatewayRequestContext } from "../gateway/server-methods/types.js";
+import { registerGatewayRecoveryRuntime } from "../gateway/server-recovery-runtime-context.js";
+import { withPluginRuntimeGatewayContextResolver } from "../plugins/runtime/gateway-request-scope.js";
+import { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
+import { buildExecApprovalFollowupTarget } from "./bash-tools.exec-host-shared.js";
+import { callGatewayTool } from "./tools/gateway.js";
+
+describe("exec approval followup routing", () => {
+  it.each(["live", "missing", "throwing", "replaced"] as const)(
+    "retains the captured Gateway route: %s",
+    async (liveness) => {
+      const dispatchA = vi.fn(async () => ({ status: "accepted", runId: "followup-a" }));
+      const waitA = vi.fn(async () => ({ status: "ok", endedAt: 1 }));
+      const dispatchB = vi.fn(async () => ({ status: "ok" }));
+      const runtimeA = {
+        dispatchAgent: dispatchA,
+        waitForAgent: waitA,
+      } as unknown as GatewayRecoveryRuntime;
+      const runtimeB = {
+        dispatchAgent: dispatchB,
+        waitForAgent: vi.fn(),
+      } as unknown as GatewayRecoveryRuntime;
+      const contextA = { recoveryRuntime: runtimeA } as GatewayRequestContext;
+      const contextB = { recoveryRuntime: runtimeB } as GatewayRequestContext;
+      let context: GatewayRequestContext | undefined = contextA;
+      let throws = false;
+      const target = withPluginRuntimeGatewayContextResolver(
+        () => {
+          if (throws) {
+            throw new Error("instance retired");
+          }
+          return context;
+        },
+        () =>
+          buildExecApprovalFollowupTarget({ approvalId: "route-a", sessionKey: "agent:main:main" }),
+      );
+      const release = registerGatewayRecoveryRuntime(runtimeB);
+      if (liveness === "missing") {
+        context = undefined;
+      }
+      if (liveness === "replaced") {
+        context = contextB;
+      }
+      throws = liveness === "throwing";
+      try {
+        const pending = sendExecApprovalFollowup({
+          ...target,
+          resultText: "Exec finished (code 0)\ndone",
+        });
+        if (liveness === "live") {
+          await expect(pending).resolves.toBe(true);
+          expect(dispatchA).toHaveBeenCalledOnce();
+          expect(waitA).toHaveBeenCalledOnce();
+        } else {
+          await expect(pending).rejects.toThrow();
+          expect(dispatchA).not.toHaveBeenCalled();
+          expect(waitA).not.toHaveBeenCalled();
+        }
+        expect(dispatchB).not.toHaveBeenCalled();
+        expect(callGatewayTool).not.toHaveBeenCalled();
+      } finally {
+        release();
+      }
+    },
+  );
+
+  it("keeps the socket route selected before an in-process Gateway appears", async () => {
+    const target = buildExecApprovalFollowupTarget({
+      approvalId: "socket-a",
+      sessionKey: "agent:main:main",
+    });
+    const dispatch = vi.fn(async () => ({ status: "ok" }));
+    const release = registerGatewayRecoveryRuntime({
+      dispatchAgent: dispatch,
+    } as unknown as GatewayRecoveryRuntime);
+    vi.mocked(callGatewayTool).mockResolvedValue({ status: "ok" });
+    try {
+      await sendExecApprovalFollowup({ ...target, resultText: "Exec finished (code 0)\ndone" });
+      expect(callGatewayTool).toHaveBeenCalledOnce();
+      expect(dispatch).not.toHaveBeenCalled();
+    } finally {
+      release();
+    }
+  });
+});

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -26,7 +26,10 @@ import {
   type DiagnosticEventPayload,
 } from "../infra/diagnostic-events.js";
 import { sendMessage } from "../infra/outbound/message.js";
-import { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
+import {
+  captureExecApprovalFollowupGateway,
+  sendExecApprovalFollowup,
+} from "./bash-tools.exec-approval-followup.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 const tempStoreDirs: string[] = [];
@@ -123,6 +126,7 @@ function expectAuthenticatedHandoff(
     sourceSessionKey: expected.sessionKey,
     sourceTool: "exec_approval_followup",
   });
+  expect(params).not.toHaveProperty("callGateway");
   expect(params.internalRuntimeHandoffId).toEqual(expect.any(String));
   expect(params.idempotencyKey).toEqual(expect.any(String));
   expect(params.idempotencyKey).toMatch(
@@ -148,6 +152,7 @@ function expectStableDirectDelivery(params: Record<string, unknown>, approvalId:
 describe("exec approval followup", () => {
   it("carries the prepared agent owner for a bare session key", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-bare-owner",
       agentId: "research",
       sessionKey: "global",
@@ -159,6 +164,7 @@ describe("exec approval followup", () => {
 
   it("uses an explicit denial prompt when the command did not run", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-1",
       sessionKey: "agent:main:main",
       resultText: "Exec denied (gateway id=req-1, user-denied): uname -a",
@@ -173,6 +179,7 @@ describe("exec approval followup", () => {
 
   it("uses the denied followup branch for nested-parentheses denial metadata", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-1",
       sessionKey: "agent:main:main",
       resultText: "Exec denied (gateway id=req-1, approval-timeout (allowlist-miss)): uname -a",
@@ -187,6 +194,7 @@ describe("exec approval followup", () => {
 
   it("carries a compact fallback alongside the authenticated runtime handoff", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-1",
       sessionKey: "agent:main:main",
       resultText: "Exec finished (gateway id=req-1, code 0)\nok",
@@ -203,6 +211,7 @@ describe("exec approval followup", () => {
 
   it("warns the agent not to rerun an outcome-unknown command", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-unknown",
       sessionKey: "agent:main:main",
       resultText: [
@@ -225,6 +234,7 @@ describe("exec approval followup", () => {
 
   it("tells the agent a proven not-dispatched command did not run", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-not-dispatched",
       sessionKey: "agent:main:main",
       resultText: [
@@ -253,6 +263,7 @@ describe("exec approval followup", () => {
     ].join("\n");
 
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-direct-unknown",
       direct: true,
       turnSourceChannel: "telegram",
@@ -266,6 +277,7 @@ describe("exec approval followup", () => {
 
   it("keeps followups internal when no external route is available", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-1",
       sessionKey: "agent:main:main",
       resultText: "Exec completed: echo ok",
@@ -282,6 +294,7 @@ describe("exec approval followup", () => {
 
   it("forwards the approval-time session id so the gateway can drop stale followups", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-pin-59349",
       sessionKey: "agent:main:main",
       expectedSessionId: "session-original",
@@ -296,6 +309,7 @@ describe("exec approval followup", () => {
 
   it("omits the expected session id when none was captured", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-no-pin",
       sessionKey: "agent:main:main",
       resultText: "Exec completed: echo ok",
@@ -315,6 +329,7 @@ describe("exec approval followup", () => {
     });
 
     const result = await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-denied-rebound",
       sessionKey: "agent:main:main",
       expectedSessionId: "session-original",
@@ -345,6 +360,7 @@ describe("exec approval followup", () => {
     });
 
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-denied-same",
       sessionKey: "agent:main:main",
       expectedSessionId: "session-original",
@@ -369,6 +385,7 @@ describe("exec approval followup", () => {
     });
 
     const result = await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-finished-rebound",
       sessionKey: "agent:main:main",
       expectedSessionId: "session-original",
@@ -395,6 +412,7 @@ describe("exec approval followup", () => {
 
   it("routes denied followups through the originating main session", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-denied-main",
       sessionKey: "agent:main:main",
       turnSourceChannel: "webchat",
@@ -440,6 +458,7 @@ describe("exec approval followup", () => {
     },
   ])("uses agent continuation for $channel followups when a session exists", async (target) => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: `req-${target.channel}`,
       sessionKey: target.sessionKey,
       turnSourceChannel: target.channel,
@@ -467,6 +486,7 @@ describe("exec approval followup", () => {
 
   it("preserves the originating routing target for non-built-in plugin channels", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-plugin",
       sessionKey: "agent:main:lansenger:dm:U1",
       turnSourceChannel: "lansenger",
@@ -503,6 +523,7 @@ describe("exec approval followup", () => {
       });
 
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-wait",
       sessionKey: "agent:main:telegram:direct:123",
       turnSourceChannel: "telegram",
@@ -553,6 +574,7 @@ describe("exec approval followup", () => {
       });
 
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-ambiguous",
       sessionKey: "agent:main:telegram:direct:123",
       turnSourceChannel: "telegram",
@@ -612,6 +634,7 @@ describe("exec approval followup", () => {
 
     await expect(
       sendExecApprovalFollowup({
+        callGateway: captureExecApprovalFollowupGateway(),
         approvalId: "req-ambiguous-release",
         sessionKey: "agent:main:telegram:direct:123",
         turnSourceChannel: "telegram",
@@ -639,6 +662,7 @@ describe("exec approval followup", () => {
       });
 
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-wait-retry",
       sessionKey: "agent:main:telegram:direct:123",
       turnSourceChannel: "telegram",
@@ -672,6 +696,7 @@ describe("exec approval followup", () => {
     try {
       await expect(
         sendExecApprovalFollowup({
+          callGateway: captureExecApprovalFollowupGateway(),
           approvalId: "req-observer-deadline",
           sessionKey: "agent:main:telegram:direct:123",
           turnSourceChannel: "telegram",
@@ -720,6 +745,7 @@ describe("exec approval followup", () => {
       });
 
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-terminal",
       sessionKey: "agent:main:telegram:direct:123",
       turnSourceChannel: "telegram",
@@ -749,6 +775,7 @@ describe("exec approval followup", () => {
 
   it("falls back to sanitized direct external delivery only when no session exists", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-no-session",
       turnSourceChannel: "discord",
       turnSourceTo: "123",
@@ -792,6 +819,7 @@ describe("exec approval followup", () => {
 
       await expect(
         sendExecApprovalFollowup({
+          callGateway: captureExecApprovalFollowupGateway(),
           approvalId: `req-${suppressionReason}`,
           turnSourceChannel: "discord",
           turnSourceTo: "123",
@@ -805,6 +833,7 @@ describe("exec approval followup", () => {
     const secret = "sk-abcdefghijklmnopqrstuvwxyz123456";
 
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-redacted",
       turnSourceChannel: "discord",
       turnSourceTo: "123",
@@ -823,6 +852,7 @@ describe("exec approval followup", () => {
 
   it("can force direct delivery even when a session key exists", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-direct",
       agentId: "research",
       sessionKey: "global",
@@ -849,6 +879,7 @@ describe("exec approval followup", () => {
     vi.mocked(callGatewayTool).mockRejectedValueOnce(new Error("session missing"));
 
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-session-resume-failed",
       sessionKey: "agent:main:discord:channel:123",
       turnSourceChannel: "discord",
@@ -867,6 +898,7 @@ describe("exec approval followup", () => {
 
   it("uses a generic summary when a no-session completion has no user-visible output", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-no-session-empty",
       turnSourceChannel: "discord",
       turnSourceTo: "123",
@@ -885,6 +917,7 @@ describe("exec approval followup", () => {
     vi.mocked(callGatewayTool).mockRejectedValueOnce(new Error("session missing"));
 
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-denied-resume-failed",
       sessionKey: "agent:main:telegram:-100123",
       turnSourceChannel: "telegram",
@@ -905,6 +938,7 @@ describe("exec approval followup", () => {
     vi.mocked(callGatewayTool).mockRejectedValueOnce(new Error("session missing"));
 
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-denied-resume-failed-nested",
       sessionKey: "agent:main:telegram:-100123",
       turnSourceChannel: "telegram",
@@ -925,6 +959,7 @@ describe("exec approval followup", () => {
   it("suppresses denied followups for subagent sessions", async () => {
     await expect(
       sendExecApprovalFollowup({
+        callGateway: captureExecApprovalFollowupGateway(),
         approvalId: "req-denied-subagent",
         sessionKey: "agent:main:subagent:test",
         turnSourceChannel: "telegram",
@@ -944,6 +979,7 @@ describe("exec approval followup", () => {
   ])("does not mirror raw denied followups without a session: %s", async (resultText) => {
     await expect(
       sendExecApprovalFollowup({
+        callGateway: captureExecApprovalFollowupGateway(),
         approvalId: "req-denied-nosession",
         turnSourceChannel: "telegram",
         turnSourceTo: "123",
@@ -959,6 +995,7 @@ describe("exec approval followup", () => {
   it("preserves turnSourceChannel as messageProvider on the followup run when no deliverable route exists", async () => {
     // Regression: #74646 — tools.elevated.allowFrom.<provider> fails in approval followup
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-elevated-74646",
       sessionKey: "agent:main:telegram:-100123",
       turnSourceChannel: "telegram",
@@ -975,6 +1012,7 @@ describe("exec approval followup", () => {
 
   it("carries the runtime handoff separately from idempotency without exposing elevated defaults", async () => {
     await sendExecApprovalFollowup({
+      callGateway: captureExecApprovalFollowupGateway(),
       approvalId: "req-elevated-75832",
       sessionKey: "agent:main:telegram:direct:123",
       turnSourceChannel: "telegram",
@@ -1002,6 +1040,7 @@ describe("exec approval followup", () => {
   it("throws when neither a session nor a deliverable route is available", async () => {
     await expect(
       sendExecApprovalFollowup({
+        callGateway: captureExecApprovalFollowupGateway(),
         approvalId: "req-missing",
         turnSourceChannel: "slack",
         resultText: "Exec completed: echo ok",
@@ -1009,3 +1048,5 @@ describe("exec approval followup", () => {
     ).rejects.toThrow("Session key or deliverable origin route is required");
   });
 });
+
+await import("./bash-tools.exec-approval-followup-routing.test-support.js");

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -10,6 +10,7 @@ import {
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
+import type { GatewayRequestContext } from "../gateway/server-methods/types.js";
 import { getGatewayRecoveryRuntime } from "../gateway/server-recovery-runtime-context.js";
 import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import {
@@ -20,6 +21,7 @@ import { sendMessage } from "../infra/outbound/message.js";
 import { redactToolPayloadText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { stringifyRouteThreadId } from "../plugin-sdk/channel-route.js";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
 import { isGatewayMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
@@ -38,6 +40,7 @@ import {
   isExecDeniedResultText,
   parseExecApprovalResultText,
 } from "./exec-approval-result.js";
+import { getGatewayToolCallerIdentity } from "./tools/gateway-caller-context.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 const log = createSubsystemLogger("agents/exec-approval-followup");
@@ -54,27 +57,46 @@ const AGENT_FOLLOWUP_WAIT_RETRY_DELAY_MS = 1_000;
 const AGENT_FOLLOWUP_OBSERVATION_TIMEOUT_MS =
   AGENT_FOLLOWUP_RUN_TIMEOUT_SECONDS * 1_000 + AGENT_FOLLOWUP_WAIT_TIMEOUT_MS;
 
-async function callExecApprovalFollowupGateway(
+type ExecApprovalFollowupGateway = (
   method: "agent" | "agent.wait",
   timeoutMs: number,
   params: Record<string, unknown>,
-): Promise<Record<string, unknown>> {
-  const gatewayRuntime = getGatewayRecoveryRuntime();
-  if (gatewayRuntime) {
-    return method === "agent"
-      ? await gatewayRuntime.dispatchAgent(
-          params as Parameters<typeof gatewayRuntime.dispatchAgent>[0],
-          timeoutMs,
-        )
-      : await gatewayRuntime.waitForAgent(
-          params as Parameters<typeof gatewayRuntime.waitForAgent>[0],
-          timeoutMs,
-        );
+) => Promise<Record<string, unknown>>;
+
+/** Captures routing only; the retained instance still owns authorization and liveness. */
+export function captureExecApprovalFollowupGateway(): ExecApprovalFollowupGateway {
+  const resolveContext =
+    getGatewayToolCallerIdentity()?.gatewayContextResolver ??
+    getPluginRuntimeGatewayRequestScope()?.resolveGatewayContext;
+  let context: GatewayRequestContext | undefined;
+  try {
+    context = resolveContext?.();
+  } catch {
+    /* Retain a refusing bound route. */
   }
-  return await callGatewayTool(method, { timeoutMs }, params);
+  const gatewayRuntime = resolveContext ? context?.recoveryRuntime : getGatewayRecoveryRuntime();
+  return async (method, timeoutMs, params) => {
+    // A retired binding never transfers this continuation to a replacement or socket.
+    if (resolveContext && (!context || resolveContext() !== context || !gatewayRuntime)) {
+      throw new Error(`Gateway instance followup dispatch unavailable for ${method}`);
+    }
+    if (gatewayRuntime) {
+      return method === "agent"
+        ? await gatewayRuntime.dispatchAgent(
+            params as Parameters<typeof gatewayRuntime.dispatchAgent>[0],
+            timeoutMs,
+          )
+        : await gatewayRuntime.waitForAgent(
+            params as Parameters<typeof gatewayRuntime.waitForAgent>[0],
+            timeoutMs,
+          );
+    }
+    return await callGatewayTool(method, { timeoutMs }, params);
+  };
 }
 
 type ExecApprovalFollowupParams = {
+  callGateway: ExecApprovalFollowupGateway;
   approvalId: string;
   agentId?: string;
   sessionKey?: string;
@@ -266,6 +288,7 @@ function hasTerminalFollowupEvidence(value: unknown): boolean {
 }
 
 async function waitForAgentFollowupRun(params: {
+  callGateway: ExecApprovalFollowupGateway;
   runId: string;
   timeoutMs: number;
 }): Promise<
@@ -283,7 +306,7 @@ async function waitForAgentFollowupRun(params: {
     const waitTimeoutMs = Math.max(1, Math.min(params.timeoutMs, remainingMs));
     let wait: Record<string, unknown>;
     try {
-      wait = await callExecApprovalFollowupGateway("agent.wait", waitTimeoutMs + 2_000, {
+      wait = await params.callGateway("agent.wait", waitTimeoutMs + 2_000, {
         runId: params.runId,
         timeoutMs: waitTimeoutMs,
       });
@@ -506,7 +529,7 @@ export async function sendExecApprovalFollowup(
         internalRuntimeHandoffId,
         idempotencyKey,
       });
-      const accepted = await callExecApprovalFollowupGateway("agent", 60_000, agentArgs);
+      const accepted = await params.callGateway("agent", 60_000, agentArgs);
       const status = readGatewayStatus(accepted);
       if (isSuccessfulFollowupStatus(status)) {
         return true;
@@ -518,6 +541,7 @@ export async function sendExecApprovalFollowup(
           throw buildFollowupWaitError({ status: "missing-run-id" });
         }
         const waitResult = await waitForAgentFollowupRun({
+          callGateway: params.callGateway,
           runId,
           timeoutMs: AGENT_FOLLOWUP_WAIT_TIMEOUT_MS,
         });

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -2920,83 +2920,119 @@ EOF`,
     },
   );
 
-  it("waits outside admission, then atomically hands an approved process to the registry", async () => {
-    let resolveApproval: (decision: ExecApprovalDecision) => void = () => {};
-    const approval = new Promise<ExecApprovalDecision>((resolve) => {
-      resolveApproval = resolve;
-    });
-    let resolveOutcome: (outcome: ExecApprovalFollowupOutcome) => void = () => {};
-    const outcome = new Promise<ExecApprovalFollowupOutcome>((resolve) => {
-      resolveOutcome = resolve;
-    });
-    let allowSpawn: () => void = () => {};
-    const spawnAllowed = new Promise<void>((resolve) => {
-      allowSpawn = resolve;
-    });
-    let announceSpawn: () => void = () => {};
-    const spawnStarted = new Promise<void>((resolve) => {
-      announceSpawn = resolve;
-    });
-    resolveApprovalDecisionOrUndefinedMock.mockReturnValue(approval);
-    createExecApprovalDecisionStateMock.mockReturnValue({
-      baseDecision: { timedOut: false },
-      approvedByAsk: true,
-      deniedReason: null,
-    });
-    commitExecAuthorizationMock.mockImplementation(async () => {
-      expect(getActiveGatewayRootWorkCount()).toBe(1);
-    });
-    runExecProcessMock.mockImplementation(async () => {
-      expect(getActiveGatewayRootWorkCount()).toBe(1);
-      announceSpawn();
-      await spawnAllowed;
-      return { session: { id: "sess-atomic" }, promise: outcome };
-    });
-    markBackgroundedMock.mockImplementation(() => {
-      expect(getActiveGatewayRootWorkCount()).toBe(1);
-    });
-    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+  it.each(["completed", "sender failed"] as const)(
+    "retains approved exec admission through child, factory, and sender settlement: %s",
+    async (senderOutcome) => {
+      let resolveApproval: (decision: ExecApprovalDecision) => void = () => {};
+      const approval = new Promise<ExecApprovalDecision>((resolve) => {
+        resolveApproval = resolve;
+      });
+      let resolveOutcome: (outcome: ExecApprovalFollowupOutcome) => void = () => {};
+      const outcome = new Promise<ExecApprovalFollowupOutcome>((resolve) => {
+        resolveOutcome = resolve;
+      });
+      let allowSpawn: () => void = () => {};
+      const spawnAllowed = new Promise<void>((resolve) => {
+        allowSpawn = resolve;
+      });
+      let announceSpawn: () => void = () => {};
+      const spawnStarted = new Promise<void>((resolve) => {
+        announceSpawn = resolve;
+      });
+      let finishFactory!: () => void;
+      const factoryGate = new Promise<void>((resolve) => {
+        finishFactory = resolve;
+      });
+      const approvalFollowup = vi.fn(async () => {
+        await factoryGate;
+        return "followup";
+      });
+      let finishSender!: () => void;
+      const senderGate = new Promise<void>((resolve) => {
+        finishSender = resolve;
+      });
+      sendExecApprovalFollowupResultMock.mockImplementation(async () => {
+        await senderGate;
+        if (senderOutcome === "sender failed") {
+          throw new Error("gateway is draining for restart");
+        }
+      });
+      resolveApprovalDecisionOrUndefinedMock.mockReturnValue(approval);
+      createExecApprovalDecisionStateMock.mockReturnValue({
+        baseDecision: { timedOut: false },
+        approvedByAsk: true,
+        deniedReason: null,
+      });
+      commitExecAuthorizationMock.mockImplementation(async () => {
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
+      });
+      runExecProcessMock.mockImplementation(async () => {
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
+        announceSpawn();
+        await spawnAllowed;
+        return { session: { id: "sess-atomic" }, promise: outcome };
+      });
+      markBackgroundedMock.mockImplementation(() => {
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
+      });
+      buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
 
-    const result = await runGatewayAllowlist({
-      command: "find . -maxdepth 1",
-      turnSourceChannel: "feishu",
-    });
-    expect(result.pendingResult?.details.status).toBe("approval-pending");
-    await vi.waitFor(() => {
-      expect(resolveApprovalDecisionOrUndefinedMock).toHaveBeenCalledOnce();
-    });
-    expect(getActiveGatewayRootWorkCount()).toBe(0);
+      try {
+        const result = await runGatewayAllowlist({
+          command: "find . -maxdepth 1",
+          turnSourceChannel: "feishu",
+          approvalFollowup,
+        });
+        expect(result.pendingResult?.details.status).toBe("approval-pending");
+        await vi.waitFor(() => {
+          expect(resolveApprovalDecisionOrUndefinedMock).toHaveBeenCalledOnce();
+        });
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
 
-    const suspension = tryBeginGatewaySuspendAdmission(() => {});
-    expect(suspension?.commit()).toBe(true);
-    resolveApproval("allow-once");
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(commitExecAuthorizationMock).not.toHaveBeenCalled();
-    expect(runExecProcessMock).not.toHaveBeenCalled();
-    expect(markBackgroundedMock).not.toHaveBeenCalled();
+        const suspension = tryBeginGatewaySuspendAdmission(() => {});
+        expect(suspension?.commit()).toBe(true);
+        resolveApproval("allow-once");
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(commitExecAuthorizationMock).not.toHaveBeenCalled();
+        expect(runExecProcessMock).not.toHaveBeenCalled();
+        expect(markBackgroundedMock).not.toHaveBeenCalled();
 
-    suspension?.release();
-    await spawnStarted;
-    expect(getActiveGatewayRootWorkCount()).toBe(1);
-    allowSpawn();
-    await vi.waitFor(() => {
-      expect(markBackgroundedMock).toHaveBeenCalledOnce();
-      expect(getActiveGatewayRootWorkCount()).toBe(0);
-    });
-    expect(commitExecAuthorizationMock).toHaveBeenCalledOnce();
-    expect(runExecProcessMock).toHaveBeenCalledOnce();
+        suspension?.release();
+        await spawnStarted;
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
+        allowSpawn();
+        await vi.waitFor(() => {
+          expect(markBackgroundedMock).toHaveBeenCalledOnce();
+          expect(getActiveGatewayRootWorkCount()).toBe(1);
+        });
+        expect(commitExecAuthorizationMock).toHaveBeenCalledOnce();
+        expect(runExecProcessMock).toHaveBeenCalledOnce();
 
-    resolveOutcome({
-      status: "completed",
-      exitCode: 0,
-      timedOut: false,
-      aggregated: "done",
-    });
-    await vi.waitFor(() => {
-      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledOnce();
-    });
-  });
+        resolveOutcome({
+          status: "completed",
+          exitCode: 0,
+          timedOut: false,
+          aggregated: "done",
+        });
+        await vi.waitFor(() => expect(approvalFollowup).toHaveBeenCalledOnce());
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
+        finishFactory();
+        await vi.waitFor(() => expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledOnce());
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
+        finishSender();
+        await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+        expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledOnce();
+      } finally {
+        allowSpawn();
+        resolveApproval("allow-once");
+        resolveOutcome({ status: "completed", exitCode: 0, timedOut: false, aggregated: "done" });
+        finishFactory();
+        finishSender();
+        await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+      }
+    },
+  );
 
   it.each([
     { name: "denies drift", mutate: true },

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1450,7 +1450,7 @@ export async function processGatewayAllowlist(
       }
 
       let admitted:
-        | { status: "started"; run: Awaited<ReturnType<typeof runExecProcess>> }
+        | { status: "completed" }
         | { status: "approval-state-write-failed" }
         | { status: "operand-drift"; message: string }
         | { status: "run-aborted" }
@@ -1533,12 +1533,35 @@ export async function processGatewayAllowlist(
             return { status: "spawn-failed" as const };
           }
 
-          // Keep the admitted root until the registry owns the live process.
-          // Suspension must observe one side of this handoff at every instant.
+          // The process registry releases at child finalization. This root also
+          // owns the dynamic follow-up and its dispatch/observation after that.
           markBackgrounded(run.session);
-          return { status: "started" as const, run };
+          const outcome = await run.promise;
+          const dynamicFollowupText = await resolveGatewayExecApprovalFollowupText({
+            approvalFollowup: params.approvalFollowup,
+            approvalId,
+            sessionId: run.session.id,
+            trigger: params.trigger,
+            outcome,
+          });
+          const approvalFollowupText = normalizeStringEntries([
+            params.approvalFollowupText ?? "",
+            dynamicFollowupText ?? "",
+          ]).join("\n\n");
+          const summary = buildGatewayExecApprovalFollowupSummary({
+            approvalId,
+            sessionId: run.session.id,
+            outcome,
+            trigger: params.trigger,
+            approvalFollowupText,
+          });
+          await sendExecApprovalFollowupResult(followupTarget, summary);
+          return { status: "completed" as const };
         });
       } catch (error) {
+        if (gatewayInvocationStarted) {
+          throw error;
+        }
         if (
           error instanceof GatewayDrainingError ||
           (error instanceof Error && error.message === "gateway is draining for restart")
@@ -1571,31 +1594,7 @@ export async function processGatewayAllowlist(
           followupTarget,
           `Exec denied (gateway id=${approvalId}, spawn-failed): ${params.command}`,
         );
-        return;
       }
-
-      const { run } = admitted;
-
-      const outcome = await run.promise;
-      const dynamicFollowupText = await resolveGatewayExecApprovalFollowupText({
-        approvalFollowup: params.approvalFollowup,
-        approvalId,
-        sessionId: run.session.id,
-        trigger: params.trigger,
-        outcome,
-      });
-      const approvalFollowupText = normalizeStringEntries([
-        params.approvalFollowupText ?? "",
-        dynamicFollowupText ?? "",
-      ]).join("\n\n");
-      const summary = buildGatewayExecApprovalFollowupSummary({
-        approvalId,
-        sessionId: run.session.id,
-        outcome,
-        trigger: params.trigger,
-        approvalFollowupText,
-      });
-      await sendExecApprovalFollowupResult(followupTarget, summary);
     })()
       .catch(async (): Promise<void> => {
         // Once dispatch starts, a delivery failure cannot mean execution was denied.

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -5,6 +5,10 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  createPluginMetadataSnapshot,
+  makeRegistry,
+} from "../config/plugin-auto-enable.test-helpers.js";
+import {
   claimExecApprovalFollowupRuntimeHandoff,
   finalizeExecApprovalFollowupRuntimeHandoff,
   isExecApprovalFollowupSessionRebound,
@@ -13,11 +17,20 @@ import {
 import {
   buildExecApprovalPendingToolResult,
   buildHeadlessExecApprovalDeniedMessage,
+  buildExecApprovalFollowupTarget,
   createExecApprovalRequestRoute,
   resolveExecApprovalWaitOutcome,
   resolveExecHostApprovalContext,
   sendExecApprovalFollowupResult,
 } from "./bash-tools.exec-host-shared.js";
+import {
+  getPreparedModelRuntimePluginGeneration,
+  withPreparedModelRuntimePluginGenerationScope,
+} from "./prepared-model-runtime-generation-scope.js";
+import {
+  getGatewayToolCallerIdentity,
+  withGatewayToolCallerIdentity,
+} from "./tools/gateway-caller-context.js";
 
 const mocks = vi.hoisted(() => ({
   resolveExecApprovals: vi.fn(async () => ({
@@ -61,6 +74,36 @@ vi.mock("./bash-tools.exec-approval-request.js", async (importOriginal) => {
 describe("sendExecApprovalFollowupResult", () => {
   const sendExecApprovalFollowup = vi.fn();
   const logWarn = vi.fn();
+
+  it("leaves only the inherited model scope at the followup turn boundary", async () => {
+    const generation = {
+      inlineProviderModels: [],
+      configuredCatalogEntries: [],
+      pluginMetadataSnapshot: createPluginMetadataSnapshot({ manifestRegistry: makeRegistry([]) }),
+    };
+    await withGatewayToolCallerIdentity(
+      { agentId: "main", sessionKey: "agent:main:main" },
+      async () => {
+        const caller = getGatewayToolCallerIdentity();
+        await withPreparedModelRuntimePluginGenerationScope(generation, async () => {
+          await sendExecApprovalFollowupResult(
+            buildExecApprovalFollowupTarget({ approvalId: "scope", sessionKey: "agent:main:main" }),
+            "Exec finished",
+            {
+              sendExecApprovalFollowup: async () => {
+                expect(getPreparedModelRuntimePluginGeneration()).toBeUndefined();
+                expect(getGatewayToolCallerIdentity()).toBe(caller);
+                return true;
+              },
+              logWarn,
+            },
+          );
+          expect(logWarn).not.toHaveBeenCalled();
+          expect(getPreparedModelRuntimePluginGeneration()).toBe(generation);
+        });
+      },
+    );
+  });
 
   beforeEach(() => {
     sendExecApprovalFollowup.mockReset();
@@ -108,10 +151,10 @@ describe("sendExecApprovalFollowupResult", () => {
   it("logs repeated followup dispatch failures once per approval id and error message", async () => {
     sendExecApprovalFollowup.mockRejectedValue(new Error("Channel is required"));
 
-    const target = {
+    const target = buildExecApprovalFollowupTarget({
       approvalId: "approval-log-once",
       sessionKey: "agent:main:main",
-    };
+    });
     const deps = { sendExecApprovalFollowup, logWarn };
     await sendExecApprovalFollowupResult(target, "Exec finished", deps);
     await sendExecApprovalFollowupResult(target, "Exec finished", deps);
@@ -144,10 +187,10 @@ describe("sendExecApprovalFollowupResult", () => {
     sendExecApprovalFollowup.mockRejectedValue(error);
 
     await sendExecApprovalFollowupResult(
-      {
+      buildExecApprovalFollowupTarget({
         approvalId: "approval-expired",
         sessionKey: "agent:main:main",
-      },
+      }),
       "Exec finished",
       { sendExecApprovalFollowup, logWarn },
     );
@@ -162,19 +205,19 @@ describe("sendExecApprovalFollowupResult", () => {
 
     for (let i = 0; i < failureKeysBeyondDedupeWindow; i += 1) {
       await sendExecApprovalFollowupResult(
-        {
+        buildExecApprovalFollowupTarget({
           approvalId: `approval-${i}`,
           sessionKey: "agent:main:main",
-        },
+        }),
         "Exec finished",
         deps,
       );
     }
     await sendExecApprovalFollowupResult(
-      {
+      buildExecApprovalFollowupTarget({
         approvalId: "approval-0",
         sessionKey: "agent:main:main",
-      },
+      }),
       "Exec finished",
       deps,
     );
@@ -194,12 +237,12 @@ describe("sendExecApprovalFollowupResult", () => {
     };
 
     await sendExecApprovalFollowupResult(
-      {
+      buildExecApprovalFollowupTarget({
         approvalId: "approval-elevated-75832",
         sessionKey: "agent:main:telegram:direct:123",
         turnSourceChannel: "telegram",
         bashElevated,
-      },
+      }),
       "Exec finished",
       { sendExecApprovalFollowup, logWarn },
     );
@@ -281,12 +324,12 @@ describe("sendExecApprovalFollowupResult", () => {
     };
 
     await sendExecApprovalFollowupResult(
-      {
+      buildExecApprovalFollowupTarget({
         approvalId: "approval-denied-elevated-75832",
         sessionKey: "agent:main:telegram:direct:123",
         turnSourceChannel: "telegram",
         bashElevated,
-      },
+      }),
       "Exec denied (gateway id=approval-denied-elevated-75832, user-denied): uname -a",
       { sendExecApprovalFollowup, logWarn },
     );
@@ -301,11 +344,11 @@ describe("sendExecApprovalFollowupResult", () => {
     sendExecApprovalFollowup.mockResolvedValue(true);
 
     await sendExecApprovalFollowupResult(
-      {
+      buildExecApprovalFollowupTarget({
         approvalId: "approval-normal-75832",
         sessionKey: "agent:main:telegram:direct:123",
         turnSourceChannel: "telegram",
-      },
+      }),
       "Exec finished",
       { sendExecApprovalFollowup, logWarn },
     );
@@ -346,12 +389,12 @@ describe("sendExecApprovalFollowupResult", () => {
     sendExecApprovalFollowup.mockResolvedValue(true);
 
     await sendExecApprovalFollowupResult(
-      {
+      buildExecApprovalFollowupTarget({
         approvalId: "approval-session-pin-59349",
         sessionKey: "agent:main:telegram:direct:123",
         expectedSessionId: "session-original",
         turnSourceChannel: "telegram",
-      },
+      }),
       "Exec finished",
       { sendExecApprovalFollowup, logWarn },
     );
@@ -363,11 +406,11 @@ describe("sendExecApprovalFollowupResult", () => {
     sendExecApprovalFollowup.mockResolvedValue(true);
 
     await sendExecApprovalFollowupResult(
-      {
+      buildExecApprovalFollowupTarget({
         approvalId: "approval-bare-owner",
         agentId: "research",
         sessionKey: "global",
-      },
+      }),
       "Exec finished",
       { sendExecApprovalFollowup, logWarn },
     );

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -25,7 +25,10 @@ import {
 } from "../infra/exec-approvals.js";
 import { logWarn } from "../logger.js";
 import { registerExecApprovalFollowupRuntimeHandoff } from "./bash-tools.exec-approval-followup-state.js";
-import { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
+import {
+  captureExecApprovalFollowupGateway,
+  sendExecApprovalFollowup,
+} from "./bash-tools.exec-approval-followup.js";
 import {
   type ExecApprovalRegistration,
   isExecApprovalRunAbortedError,
@@ -37,6 +40,7 @@ import {
 } from "./bash-tools.exec-runtime.js";
 import type { ExecElevatedDefaults, ExecToolDetails } from "./bash-tools.exec-types.js";
 import { isExecDeniedResultText } from "./exec-approval-result.js";
+import { runOutsidePreparedModelRuntimePluginGenerationScope } from "./prepared-model-runtime-generation-scope.js";
 import type { AgentToolResult } from "./runtime/index.js";
 
 /** Cap for deduplicating repeated follow-up dispatch failure log keys. */
@@ -100,6 +104,7 @@ type RegisteredExecApprovalRequestContext = {
 
 /** Destination and context for async exec approval follow-up delivery. */
 type ExecApprovalFollowupTarget = {
+  callGateway: ReturnType<typeof captureExecApprovalFollowupGateway>;
   approvalId: string;
   agentId?: string;
   sessionKey?: string;
@@ -320,9 +325,10 @@ async function createAndRegisterDefaultExecApprovalRequest(
 
 /** Builds the immutable follow-up target passed to async approval continuations. */
 export function buildExecApprovalFollowupTarget(
-  params: ExecApprovalFollowupTarget,
+  params: Omit<ExecApprovalFollowupTarget, "callGateway">,
 ): ExecApprovalFollowupTarget {
   return {
+    callGateway: captureExecApprovalFollowupGateway(),
     approvalId: params.approvalId,
     ...(params.agentId ? { agentId: params.agentId } : {}),
     sessionKey: params.sessionKey,
@@ -544,25 +550,28 @@ export async function sendExecApprovalFollowupResult(
           bashElevated: target.bashElevated,
           resultText,
         });
-  await send({
-    approvalId: target.approvalId,
-    ...(target.agentId ? { agentId: target.agentId } : {}),
-    sessionKey: target.sessionKey,
-    expectedSessionId: target.expectedSessionId,
-    sessionStore: target.sessionStore,
-    turnSourceChannel: target.turnSourceChannel,
-    turnSourceTo: target.turnSourceTo,
-    turnSourceAccountId: target.turnSourceAccountId,
-    turnSourceThreadId: target.turnSourceThreadId,
-    resultText,
-    direct: target.direct,
-    ...(runtimeHandoff
-      ? {
-          internalRuntimeHandoffId: runtimeHandoff.handoffId,
-          idempotencyKey: runtimeHandoff.idempotencyKey,
-        }
-      : {}),
-  }).catch((error: unknown) => {
+  await runOutsidePreparedModelRuntimePluginGenerationScope(() =>
+    send({
+      callGateway: target.callGateway,
+      approvalId: target.approvalId,
+      ...(target.agentId ? { agentId: target.agentId } : {}),
+      sessionKey: target.sessionKey,
+      expectedSessionId: target.expectedSessionId,
+      sessionStore: target.sessionStore,
+      turnSourceChannel: target.turnSourceChannel,
+      turnSourceTo: target.turnSourceTo,
+      turnSourceAccountId: target.turnSourceAccountId,
+      turnSourceThreadId: target.turnSourceThreadId,
+      resultText,
+      direct: target.direct,
+      ...(runtimeHandoff
+        ? {
+            internalRuntimeHandoffId: runtimeHandoff.handoffId,
+            idempotencyKey: runtimeHandoff.idempotencyKey,
+          }
+        : {}),
+    }),
+  ).catch((error: unknown) => {
     if (isApprovalNotFoundError(error)) {
       return;
     }

--- a/src/auto-reply/reply/commands-diagnostics.test.ts
+++ b/src/auto-reply/reply/commands-diagnostics.test.ts
@@ -12,6 +12,7 @@ import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shar
 type PluginCommandHandler = OpenClawPluginCommandDefinition["handler"];
 import type { MsgContext } from "../templating.js";
 import { handleDiagnosticsCommand as defaultDiagnosticsCommandHandler } from "./commands-diagnostics.js";
+import { exportExecOutcomeCases } from "./commands-export-test-mocks.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
 const diagnosticsCommandMocks = vi.hoisted(() => ({
@@ -300,6 +301,29 @@ afterEach(() => {
 });
 
 describe("diagnostics command", () => {
+  it.each(exportExecOutcomeCases)(
+    "reports typed export status: $name",
+    async ({ name, details, lead }) => {
+      const { handleDiagnosticsCommand } = createDiagnosticsHandlerForTest({
+        execResult: { content: [{ type: "text", text: "untyped output" }], details },
+      });
+      if (name === "thrown") {
+        diagnosticsCommandMocks.createExecTool.mockReturnValue({
+          execute: async () => {
+            throw new Error("transport interrupted");
+          },
+        });
+      }
+      const result = await handleDiagnosticsCommand(buildDiagnosticsParams("/diagnostics"), true);
+      expect(result?.reply?.text).toContain(lead);
+      expect(result?.reply?.text).not.toContain("Approve once");
+      expect(result?.reply?.text).not.toContain("approval prompts");
+      if (details && "aggregated" in details) {
+        expect(result?.reply?.text).toContain("typed output");
+      }
+    },
+  );
+
   it("requests Gateway diagnostics approval without a duplicate pending chat reply", async () => {
     const { execCalls, handleDiagnosticsCommand } = createDiagnosticsHandlerForTest();
     const result = await handleDiagnosticsCommand(buildDiagnosticsParams("/diagnostics"), true);
@@ -541,7 +565,7 @@ describe("diagnostics command", () => {
 
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toBe(
-      "Diagnostics are sensitive. I sent the diagnostics details and approval prompts to the owner privately.",
+      "Diagnostics approval is pending. Use the private owner approval route to review it.",
     );
     expect(result?.reply?.text).not.toContain("codex-thread-1");
     expect(privateReplies).toHaveLength(0);
@@ -608,7 +632,7 @@ describe("diagnostics command", () => {
     );
 
     expect(result?.reply?.text).toBe(
-      "Diagnostics are sensitive. I sent the diagnostics details and approval prompts to the owner privately.",
+      "Diagnostics are sensitive. I sent the export status to the owner privately.",
     );
     expect(privateReplies).toHaveLength(1);
     expect(privateReplies[0]?.targets).toEqual([

--- a/src/auto-reply/reply/commands-diagnostics.ts
+++ b/src/auto-reply/reply/commands-diagnostics.ts
@@ -2,7 +2,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { createExecTool } from "../../agents/bash-tools.js";
-import type { ExecToolDetails } from "../../agents/bash-tools.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -19,6 +18,7 @@ import {
 } from "../../utils/delivery-context.shared.js";
 import type { ReplyPayload } from "../types.js";
 import { rejectNonOwnerCommand } from "./command-gates.js";
+import { formatExportExecResult } from "./commands-export-common.js";
 import { buildCurrentOpenClawCliExecRequest } from "./commands-openclaw-cli.js";
 import {
   deliverPrivateCommandReply,
@@ -34,12 +34,11 @@ import type { CommandHandler, HandleCommandsParams } from "./commands-types.js";
 const DIAGNOSTICS_COMMAND = "/diagnostics";
 const CODEX_DIAGNOSTICS_COMMAND = "/codex diagnostics";
 const DIAGNOSTICS_DOCS_URL = "https://docs.openclaw.ai/gateway/diagnostics";
-const GATEWAY_DIAGNOSTICS_EXPORT_JSON_LABEL = "openclaw gateway diagnostics export --json";
 const DIAGNOSTICS_EXEC_SCOPE_KEY = "chat:diagnostics";
 const DIAGNOSTICS_PRIVATE_ROUTE_UNAVAILABLE =
   "I couldn't find a private owner approval route for diagnostics. Run /diagnostics from an owner DM so the sensitive diagnostics details are not posted in this chat.";
 const DIAGNOSTICS_PRIVATE_ROUTE_ACK =
-  "Diagnostics are sensitive. I sent the diagnostics details and approval prompts to the owner privately.";
+  "Diagnostics are sensitive. I sent the export status to the owner privately.";
 
 type DiagnosticsCommandDeps = {
   createExecTool: typeof createExecTool;
@@ -134,7 +133,9 @@ async function handleDiagnosticsCommandWithDeps(
     if (!privateReply) {
       return {
         shouldContinue: false,
-        reply: { text: DIAGNOSTICS_PRIVATE_ROUTE_ACK },
+        reply: {
+          text: "Diagnostics approval is pending. Use the private owner approval route to review it.",
+        },
       };
     }
     return await deliverGroupDiagnosticsReplyPrivately(deps, params, privateReply, privateTarget);
@@ -321,11 +322,7 @@ async function requestGatewayDiagnosticsExportApproval(
         ? await codexDiagnostics.approvalFollowup?.()
         : undefined;
     const lines = buildDiagnosticsPreamble();
-    lines.push(
-      "",
-      `Local Gateway bundle: requested \`${GATEWAY_DIAGNOSTICS_EXPORT_JSON_LABEL}\` through exec approval. Approve once to create the bundle; do not use allow-all for diagnostics.`,
-      formatExecToolResultForDiagnostics(result),
-    );
+    lines.push("", formatExportExecResult("Gateway diagnostics export", result));
     if (codexFollowupText) {
       lines.push("", codexFollowupText);
     }
@@ -334,8 +331,9 @@ async function requestGatewayDiagnosticsExportApproval(
     const lines = buildDiagnosticsPreamble();
     lines.push(
       "",
-      `Local Gateway bundle: could not request exec approval for \`${GATEWAY_DIAGNOSTICS_EXPORT_JSON_LABEL}\`.`,
-      formatExecDiagnosticsText(formatErrorMessage(error)),
+      formatExportExecResult("Gateway diagnostics export", {
+        content: [{ type: "text", text: formatErrorMessage(error) }],
+      }),
     );
     return { status: "reply", reply: { text: lines.join("\n") } };
   }
@@ -531,44 +529,6 @@ function resolveDiagnosticsSessionChannelId(
     normalizeOptionalString(sessionDeliveryOrigin(entry)?.nativeChannelId) ??
     (sessionKey === params.sessionKey ? params.command.channelId : undefined)
   );
-}
-
-function formatExecToolResultForDiagnostics(result: {
-  content?: Array<{ type: string; text?: string }>;
-  details?: ExecToolDetails;
-}): string {
-  const text = result.content
-    ?.map((chunk) => (chunk.type === "text" && typeof chunk.text === "string" ? chunk.text : ""))
-    .filter(Boolean)
-    .join("\n")
-    .trim();
-  if (text) {
-    return formatExecDiagnosticsText(text);
-  }
-  const details = result.details;
-  if (details?.status === "approval-pending") {
-    const decisions = details.allowedDecisions?.join(", ") || "allow-once, deny";
-    return formatExecDiagnosticsText(
-      `Exec approval pending (${details.approvalSlug}). Allowed decisions: ${decisions}.`,
-    );
-  }
-  if (details?.status === "running") {
-    return formatExecDiagnosticsText(
-      `Gateway diagnostics export is running (exec session ${details.sessionId}).`,
-    );
-  }
-  if (details?.status === "completed" || details?.status === "failed") {
-    return formatExecDiagnosticsText(details.aggregated);
-  }
-  return "(no exec details returned)";
-}
-
-function formatExecDiagnosticsText(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return "(no exec output)";
-  }
-  return trimmed;
 }
 
 function rewriteCodexDiagnosticsResult(result: PluginCommandResult): PluginCommandResult {

--- a/src/auto-reply/reply/commands-export-common.ts
+++ b/src/auto-reply/reply/commands-export-common.ts
@@ -1,4 +1,6 @@
 /** Shared export-command parsing and target session resolution helpers. */
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { ExecToolDetails } from "../../agents/bash-tools.exec-types.js";
 import {
   resolveDefaultSessionStorePath,
   resolveSessionFilePathCore,
@@ -7,6 +9,10 @@ import {
 import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import {
+  buildExecApprovalPendingReplyPayload,
+  buildExecApprovalUnavailableReplyPayload,
+} from "../../infra/exec-approval-reply.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { escapeRegExp } from "../../shared/regexp.js";
 import type { ReplyPayload } from "../types.js";
@@ -89,4 +95,69 @@ export function isReplyPayload(
   value: ExportCommandSessionTarget | ReplyPayload,
 ): value is ReplyPayload {
   return "text" in value;
+}
+
+/** Typed exec state owns the lead; command output cannot establish approval or dispatch. */
+export function formatExportExecResult(
+  label: string,
+  result: {
+    content?: Array<{ type: string; text?: string }>;
+    details?: ExecToolDetails;
+  },
+): string {
+  const details = result.details;
+  let lead: string;
+  let output: string | undefined;
+  switch (details?.status) {
+    case "approval-pending": {
+      const decisions = details.allowedDecisions ?? (["allow-once", "deny"] as const);
+      lead = `${label}: pending through exec approval (${details.approvalSlug}). Allowed decisions: ${decisions.join(", ")}.`;
+      if (decisions.includes("allow-once")) {
+        lead += " Approve once to create the bundle; do not use allow-all for exports.";
+      }
+      output = buildExecApprovalPendingReplyPayload({
+        ...details,
+        allowedDecisions: decisions,
+      }).text;
+      break;
+    }
+    case "approval-unavailable":
+      lead = `${label}: approval is unavailable; approval and execution are not confirmed.`;
+      output = buildExecApprovalUnavailableReplyPayload(details).text;
+      break;
+    case "running":
+      lead = `${label} is running (exec session ${details.sessionId}).`;
+      output = details.tail;
+      break;
+    case "completed":
+      lead = `${label} completed (exit code ${details.exitCode ?? "unknown"}).`;
+      output = details.aggregated;
+      break;
+    case "failed":
+      switch (details.reason) {
+        case "not-dispatched":
+          lead = `${label} was not dispatched.`;
+          break;
+        case "outcome-unknown":
+          lead = `${label} outcome is unknown; check before rerunning.`;
+          break;
+        case "policy-denied":
+          lead = `${label} was denied by policy.`;
+          break;
+        case undefined:
+          lead = `${label} failed (exit code ${details.exitCode ?? "unknown"}).`;
+          break;
+      }
+      output = details.aggregated;
+      break;
+    case undefined:
+      lead = `${label}: approval and execution could not be confirmed; check before rerunning.`;
+      output = result.content
+        ?.filter((chunk) => chunk.type === "text")
+        .map((chunk) => chunk.text ?? "")
+        .join("\n");
+      break;
+  }
+  const boundedOutput = sliceUtf16Safe(output?.trim() ?? "", 0, 4_000);
+  return boundedOutput ? `${lead}\n\n${boundedOutput}` : lead;
 }

--- a/src/auto-reply/reply/commands-export-test-mocks.ts
+++ b/src/auto-reply/reply/commands-export-test-mocks.ts
@@ -22,3 +22,63 @@ export function createExportCommandSessionMocks(viInstance: ViLike) {
     ),
   };
 }
+
+/** Command-boundary outcomes: text alone must never imply approval or dispatch. */
+export const exportExecOutcomeCases = [
+  {
+    name: "running",
+    details: { status: "running", sessionId: "exec-1", startedAt: 1, tail: "typed output" },
+    lead: "is running",
+  },
+  {
+    name: "completed",
+    details: { status: "completed", exitCode: 0, durationMs: 1, aggregated: "typed output" },
+    lead: "completed (exit code 0)",
+  },
+  ...(["not-dispatched", "outcome-unknown", "policy-denied", undefined] as const).map((reason) => ({
+    name: reason ?? "failed",
+    details: {
+      status: "failed" as const,
+      exitCode: null,
+      durationMs: 1,
+      aggregated: "typed output",
+      reason,
+    },
+    lead:
+      reason === "not-dispatched"
+        ? "was not dispatched"
+        : reason === "outcome-unknown"
+          ? "outcome is unknown"
+          : reason === "policy-denied"
+            ? "denied by policy"
+            : "failed",
+  })),
+  {
+    name: "unavailable",
+    details: {
+      status: "approval-unavailable",
+      reason: "no-approval-route",
+      host: "gateway",
+      command: "export",
+    },
+    lead: "approval is unavailable",
+  },
+  // Synthetic typed control: the current exec-host producer records false, not real DM proof.
+  {
+    name: "unavailable with a synthetic recorded approver-DM fact",
+    details: {
+      status: "approval-unavailable",
+      reason: "no-approval-route",
+      host: "gateway",
+      command: "export",
+      sentApproverDms: true,
+    },
+    lead: "I sent approval DMs to the approvers for this account.",
+  },
+  { name: "missing", details: undefined, lead: "approval and execution could not be confirmed" },
+  { name: "thrown", details: undefined, lead: "approval and execution could not be confirmed" },
+] satisfies Array<{
+  name: string;
+  details: import("../../agents/bash-tools.exec-types.js").ExecToolDetails | undefined;
+  lead: string;
+}>;

--- a/src/auto-reply/reply/commands-export-trajectory.test-support.ts
+++ b/src/auto-reply/reply/commands-export-trajectory.test-support.ts
@@ -1,6 +1,7 @@
 // Tests trajectory export command approval routing.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { exportExecOutcomeCases } from "./commands-export-test-mocks.js";
 import { buildExportTrajectoryCommandReply } from "./commands-export-trajectory.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
@@ -128,6 +129,27 @@ describe("buildExportTrajectoryCommandReply", () => {
     vi.clearAllMocks();
   });
 
+  it.each(exportExecOutcomeCases)(
+    "reports typed export status: $name",
+    async ({ name, details, lead }) => {
+      const { deps } = createExecDeps();
+      const execute = vi.fn(async () => {
+        if (name === "thrown") {
+          throw new Error("transport interrupted");
+        }
+        return { content: [{ type: "text", text: "untyped output" }], details };
+      });
+      deps.createExecTool = vi.fn(() => ({ execute })) as never;
+      const reply = await buildExportTrajectoryCommandReply(makeParams(), deps);
+      expect(reply.text).toContain(lead);
+      expect(reply.text).not.toContain("Approve once");
+      expect(reply.text).not.toContain("approval prompt");
+      if (details && "aggregated" in details) {
+        expect(reply.text).toContain("typed output");
+      }
+    },
+  );
+
   it("requests per-run exec approval for trajectory exports", async () => {
     const { execCalls, deps } = createExecDeps();
     const params = makeParams();
@@ -249,7 +271,7 @@ describe("buildExportTrajectoryCommandReply", () => {
     const reply = await buildExportTrajectoryCommandReply(params, deps);
 
     expect(reply.text).toBe(
-      "Trajectory exports are sensitive. I sent the export request and approval prompt to the owner privately.",
+      "Trajectory exports are sensitive. I sent the export status to the owner privately.",
     );
     expect(reply.text).not.toContain("agent:target:session");
     expect(privateReplies).toHaveLength(1);

--- a/src/auto-reply/reply/commands-export-trajectory.ts
+++ b/src/auto-reply/reply/commands-export-trajectory.ts
@@ -1,11 +1,10 @@
 // Implements trajectory export command packaging for the active session agent.
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { createExecTool } from "../../agents/bash-tools.js";
-import type { ExecToolDetails } from "../../agents/bash-tools.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { ExecApprovalRequest } from "../../infra/exec-approvals.js";
 import type { ReplyPayload } from "../types.js";
-import { parseExportCommandOutputPath } from "./commands-export-common.js";
+import { formatExportExecResult, parseExportCommandOutputPath } from "./commands-export-common.js";
 import { buildCurrentOpenClawCliExecRequest } from "./commands-openclaw-cli.js";
 import {
   deliverPrivateCommandReply,
@@ -24,7 +23,7 @@ const MAX_TRAJECTORY_EXPORT_ENCODED_REQUEST_CHARS = 8192;
 const EXPORT_TRAJECTORY_PRIVATE_ROUTE_UNAVAILABLE =
   "I couldn't find a private owner approval route for the trajectory export. Run /export-trajectory from an owner DM so the sensitive trajectory bundle is not posted in this chat.";
 const EXPORT_TRAJECTORY_PRIVATE_ROUTE_ACK =
-  "Trajectory exports are sensitive. I sent the export request and approval prompt to the owner privately.";
+  "Trajectory exports are sensitive. I sent the export status to the owner privately.";
 
 type ExportTrajectoryCommandDeps = {
   createExecTool: typeof createExecTool;
@@ -202,54 +201,12 @@ async function requestTrajectoryExportApproval(
       background: true,
       timeoutSeconds: timeoutSec,
     });
-    return [
-      `Trajectory bundle: requested \`${request.displayCommand}\` through exec approval. Approve once to create the bundle; do not use allow-all for trajectory exports.`,
-      formatExecToolResultForTrajectory(result),
-    ].join("\n");
+    return formatExportExecResult("Trajectory export", result);
   } catch (error) {
-    return [
-      `Trajectory bundle: could not request exec approval for \`${request.displayCommand}\`.`,
-      formatExecTrajectoryText(formatErrorMessage(error)),
-    ].join("\n");
+    return formatExportExecResult("Trajectory export", {
+      content: [{ type: "text", text: formatErrorMessage(error) }],
+    });
   }
-}
-
-function formatExecToolResultForTrajectory(result: {
-  content?: Array<{ type: string; text?: string }>;
-  details?: ExecToolDetails;
-}): string {
-  const text = result.content
-    ?.map((chunk) => (chunk.type === "text" && typeof chunk.text === "string" ? chunk.text : ""))
-    .filter(Boolean)
-    .join("\n")
-    .trim();
-  if (text) {
-    return formatExecTrajectoryText(text);
-  }
-  const details = result.details;
-  if (details?.status === "approval-pending") {
-    const decisions = details.allowedDecisions?.join(", ") || "allow-once, deny";
-    return formatExecTrajectoryText(
-      `Exec approval pending (${details.approvalSlug}). Allowed decisions: ${decisions}.`,
-    );
-  }
-  if (details?.status === "running") {
-    return formatExecTrajectoryText(
-      `Trajectory export is running (exec session ${details.sessionId}).`,
-    );
-  }
-  if (details?.status === "completed" || details?.status === "failed") {
-    return formatExecTrajectoryText(details.aggregated);
-  }
-  return "(no exec details returned)";
-}
-
-function formatExecTrajectoryText(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return "(no exec output)";
-  }
-  return trimmed;
 }
 
 type TrajectoryExportCliRequest = {
@@ -264,7 +221,6 @@ type TrajectoryExportExecRequest = {
   argv: string[];
   command: string;
   env: Record<string, string> | undefined;
-  displayCommand: string;
   encodedRequest: string;
   request: TrajectoryExportCliRequest;
 };
@@ -293,7 +249,6 @@ function buildTrajectoryExportExecRequest(
   const args = ["sessions", "export-trajectory", "--request-json-base64", encodedRequest, "--json"];
   return {
     ...buildCurrentOpenClawCliExecRequest(args),
-    displayCommand: ["openclaw", ...args].join(" "),
     encodedRequest,
     request,
   };

--- a/src/gateway/gateway-trajectory-export.live.test.ts
+++ b/src/gateway/gateway-trajectory-export.live.test.ts
@@ -5,8 +5,12 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { GATEWAY_CLIENT_CAPS } from "../../packages/gateway-protocol/src/client-info.js";
 import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
+import { listFinishedSessions, waitForExecScope } from "../agents/bash-process-registry.js";
+import { parseExecApprovalFollowupApprovalId } from "../agents/bash-tools.exec-approval-followup-state.js";
 import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { onAgentEvent } from "../infra/agent-events.js";
+import { waitForGatewayActiveWork } from "../infra/gateway-active-work.js";
 import { setTestEnvValue } from "../test-utils/env.js";
 import { loadSqliteTrajectoryRuntimeEvents } from "../trajectory/runtime-store.sqlite.js";
 import { GatewayClient } from "./client.js";
@@ -16,7 +20,12 @@ import {
   ensurePairedTestGatewayClientIdentity,
   getCliBackendPortBlock,
 } from "./gateway-cli-backend.live-helpers.js";
-import { restoreLiveEnv, snapshotLiveEnv, type LiveEnvSnapshot } from "./live-env-test-helpers.js";
+import {
+  createTrajectoryExportFixture,
+  joinBeforeDeadline,
+  remainingCompletionMs,
+  settleTrajectoryExportWork,
+} from "./gateway-trajectory-export.test-support.js";
 import { loadSessionEntry } from "./session-utils.js";
 import { extractPayloadText } from "./test-helpers.agent-results.js";
 
@@ -53,7 +62,7 @@ type TrajectoryExportApprovalSummary = {
 };
 
 type TrajectoryExportSignal = {
-  approvalId?: string;
+  approvalId: string;
   instructionText: string;
 };
 
@@ -63,35 +72,6 @@ function logLiveStep(step: string, details?: Record<string, unknown>): void {
   }
   const suffix = details && Object.keys(details).length > 0 ? ` ${JSON.stringify(details)}` : "";
   console.error(`[gateway-trajectory-live] ${step}${suffix}`);
-}
-
-function snapshotEnv(): LiveEnvSnapshot {
-  return snapshotLiveEnv(["OPENCLAW_TRAJECTORY", "OPENCLAW_TRAJECTORY_DIR"]);
-}
-
-function restoreEnv(snapshot: LiveEnvSnapshot): void {
-  restoreLiveEnv(snapshot);
-}
-
-async function removeLiveTempDir(dir: string): Promise<void> {
-  let lastError: unknown;
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    try {
-      await fs.rm(dir, { recursive: true, force: true });
-      return;
-    } catch (error) {
-      lastError = error;
-      const code = (error as { code?: unknown } | null)?.code;
-      if (code !== "EBUSY" && code !== "ENOTEMPTY" && code !== "EPERM" && code !== "EACCES") {
-        throw error;
-      }
-      await new Promise((resolve) => {
-        setTimeout(resolve, 100);
-      });
-    }
-  }
-  await fs.rm(dir, { recursive: true, force: true });
-  void lastError;
 }
 
 async function writeLiveGatewayConfig(params: {
@@ -148,6 +128,7 @@ async function connectGatewayClient(params: {
 async function requestAgentExactReply(params: {
   client: GatewayClient;
   expectedToken: string;
+  runId: string;
   message: string;
   sessionKey: string;
 }): Promise<string> {
@@ -155,7 +136,7 @@ async function requestAgentExactReply(params: {
     "agent",
     {
       sessionKey: params.sessionKey,
-      idempotencyKey: `idem-${randomUUID()}`,
+      idempotencyKey: params.runId,
       message: params.message,
       deliver: false,
       thinking: "low",
@@ -280,6 +261,7 @@ async function waitForTrajectoryExportSignal(params: {
   client: GatewayClient;
   events: EventFrame[];
   eventStartIndex: number;
+  onApproval: (approval: TrajectoryExportApprovalEntry) => void;
   expectedTexts: string[];
   initialTexts?: string[];
   runId: string;
@@ -293,6 +275,14 @@ async function waitForTrajectoryExportSignal(params: {
   let nextHistoryPollAt = 0;
   while (Date.now() < deadline) {
     const newEvents = params.events.slice(params.eventStartIndex);
+    const projectedApproval = newEvents
+      .filter((event) => event.event === "exec.approval.requested")
+      .map((event) => event.payload as TrajectoryExportApprovalEntry)
+      .find(isTrajectoryExportApproval);
+    if (projectedApproval && !approvalId) {
+      params.onApproval(projectedApproval);
+      approvalId = await approveTrajectoryExport(params.client, projectedApproval);
+    }
     finalTexts = newEvents
       .map((event) => extractChatFinalText(event, params.runId))
       .filter((text): text is string => typeof text === "string" && text.trim().length > 0);
@@ -300,8 +290,8 @@ async function waitForTrajectoryExportSignal(params: {
       [...(params.initialTexts ?? []), ...finalTexts, ...(assistantTexts ?? [])],
       params.expectedTexts,
     );
-    if (matchedText) {
-      return { ...(approvalId ? { approvalId } : {}), instructionText: matchedText };
+    if (matchedText && approvalId) {
+      return { approvalId, instructionText: matchedText };
     }
     if (Date.now() >= nextHistoryPollAt) {
       try {
@@ -318,23 +308,12 @@ async function waitForTrajectoryExportSignal(params: {
           [...(params.initialTexts ?? []), ...finalTexts, ...assistantTexts],
           params.expectedTexts,
         );
-        if (matchedHistoryText) {
-          return { ...(approvalId ? { approvalId } : {}), instructionText: matchedHistoryText };
+        if (matchedHistoryText && approvalId) {
+          return { approvalId, instructionText: matchedHistoryText };
         }
       } catch {
         assistantTexts = [];
       }
-      try {
-        const approvals = (await params.client.request(
-          "exec.approval.list",
-          {},
-          { timeoutMs: 10_000 },
-        )) as TrajectoryExportApprovalEntry[];
-        const approval = approvals.find(isTrajectoryExportApproval);
-        if (approval && !approvalId) {
-          approvalId = await approveTrajectoryExport(params.client, approval);
-        }
-      } catch {}
       nextHistoryPollAt = Date.now() + 2_000;
     }
     await new Promise((resolve) => {
@@ -410,30 +389,10 @@ function extractVisibleMessageText(message: unknown): string | undefined {
 
 async function approveTrajectoryExport(
   client: GatewayClient,
-  existingApproval?: TrajectoryExportApprovalEntry,
+  approval: TrajectoryExportApprovalEntry,
 ): Promise<string> {
-  const startedAt = Date.now();
-  let approval: TrajectoryExportApprovalEntry | undefined = existingApproval;
-  let lastApprovalSummaries: TrajectoryExportApprovalSummary[] = [];
-  while (!approval && Date.now() - startedAt < 60_000) {
-    const approvals = (await client.request(
-      "exec.approval.list",
-      {},
-      { timeoutMs: 10_000 },
-    )) as TrajectoryExportApprovalEntry[];
-    lastApprovalSummaries = approvals.map(summarizeTrajectoryExportApproval);
-    approval = approvals.find(isTrajectoryExportApproval);
-    if (approval) {
-      break;
-    }
-    await new Promise((resolve) => {
-      setTimeout(resolve, 500);
-    });
-  }
-  if (!approval?.id) {
-    throw new Error(
-      `expected trajectory export approval id; approvals=${JSON.stringify(lastApprovalSummaries)}`,
-    );
+  if (!approval.id) {
+    throw new Error("expected projected trajectory export approval id");
   }
   expect(isTrajectoryExportApproval(approval)).toBe(true);
   await client.request(
@@ -444,28 +403,40 @@ async function approveTrajectoryExport(
   return approval.id;
 }
 
+type FollowupTerminal = {
+  runId: string;
+  status: string;
+  endedAt?: number;
+  error?: string;
+  pendingError?: boolean;
+};
+
+function expectSuccessfulFollowup(result: FollowupTerminal, runId: string): void {
+  expect(result.runId).toBe(runId);
+  expect(result.status).toBe("ok");
+  expect(result.endedAt).toEqual(expect.any(Number));
+  expect(result.error).toBeUndefined();
+  expect(result.pendingError).not.toBe(true);
+}
+
 describeLive("gateway live trajectory export", () => {
-  const cleanup: Array<() => Promise<void>> = [];
+  let fixture: Awaited<ReturnType<typeof createTrajectoryExportFixture>> | undefined;
 
   afterEach(async () => {
-    for (const step of cleanup.splice(0).toReversed()) {
-      await step();
-    }
+    const ownedFixture = fixture;
+    fixture = undefined;
+    await ownedFixture?.cleanup();
   });
 
   it(
     "exports a combined runtime and transcript trajectory bundle through the live gateway",
     async () => {
+      const testDeadline = Date.now() + LIVE_TIMEOUT_MS;
       const { clearRuntimeConfigSnapshot } = await import("../config/config.js");
       const { startGatewayServer } = await import("./server.js");
 
-      const previousEnv = snapshotEnv();
-      const tempDir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-openclaw-trajectory-live-"));
-      cleanup.push(async () => {
-        restoreEnv(previousEnv);
-        clearRuntimeConfigSnapshot();
-        await removeLiveTempDir(tempDir);
-      });
+      fixture = await createTrajectoryExportFixture();
+      const { tempDir } = fixture;
 
       const stateDir = path.join(tempDir, "state");
       const trajectoryDir = path.join(tempDir, "runtime-traces");
@@ -507,9 +478,7 @@ describeLive("gateway live trajectory export", () => {
         controlUiEnabled: false,
       });
       logLiveStep("gateway-started", { port });
-      cleanup.push(async () => {
-        await server.close();
-      });
+      fixture.server = server;
 
       const gatewayEvents: EventFrame[] = [];
       const client = await connectGatewayClient({
@@ -520,17 +489,56 @@ describeLive("gateway live trajectory export", () => {
         },
       });
       logLiveStep("client-connected");
-      cleanup.push(async () => {
-        await client.stopAndWait({ timeoutMs: 5_000 });
-      });
+      fixture.client = client;
 
       const sessionKey = "agent:dev:live-trajectory-export";
+      const execScope = "chat:export-trajectory";
+      const firstRunId = `idem-${randomUUID()}`;
+      const exportRunId = `chat-export-${randomUUID()}`;
+      const ownedRunIds = new Set([firstRunId, exportRunId]);
+      let approvalId: string | undefined;
+      let approvedCommand: string | undefined;
+      const followupRunIds = new Set<string>();
+      let ambiguousFollowup = false;
+      let settled = false;
+      const stopAgentEvents = onAgentEvent((event) => {
+        if (!approvalId || parseExecApprovalFollowupApprovalId(event.runId) !== approvalId) {
+          return;
+        }
+        if (!followupRunIds.has(event.runId) && followupRunIds.size > 0) {
+          ambiguousFollowup = true;
+        }
+        // Only the exact approval is observed; retain at most two identities to detect ambiguity.
+        if (followupRunIds.size < 2) {
+          followupRunIds.add(event.runId);
+          ownedRunIds.add(event.runId);
+        }
+      });
+      fixture.settleOwnedWork = async () => {
+        try {
+          if (settled) {
+            return;
+          }
+          await settleTrajectoryExportWork({
+            client,
+            deadline: testDeadline,
+            execScope,
+            workspaceDir,
+            command: approvedCommand,
+            runIds: ownedRunIds,
+            sessionKey,
+          });
+        } finally {
+          stopAgentEvents();
+        }
+      };
       const replyToken = `TRAJECTORY-LIVE-${randomBytes(3).toString("hex").toUpperCase()}`;
       logLiveStep("agent-turn:start", { sessionKey, replyToken });
       const firstReply = await requestAgentExactReply({
         client,
         sessionKey,
         expectedToken: replyToken,
+        runId: firstRunId,
         message: `Reply with exactly ${replyToken} and nothing else.`,
       });
       logLiveStep("agent-turn:done", { firstReply });
@@ -553,7 +561,6 @@ describeLive("gateway live trajectory export", () => {
 
       const bundleDir = path.join(workspaceDir, ".openclaw", "trajectory-exports", "bundle");
       const beforeExport = new Set(await listDirectoryNames(tempDir));
-      const exportRunId = `chat-export-${randomUUID()}`;
       const exportEventStartIndex = gatewayEvents.length;
       logLiveStep("export:start", { bundleDir, exportRunId });
       const exportResponse = (await client.request(
@@ -575,6 +582,12 @@ describeLive("gateway live trajectory export", () => {
         client,
         events: gatewayEvents,
         eventStartIndex: exportEventStartIndex,
+        onApproval: (approval) => {
+          approvalId = approval.id;
+          approvedCommand = approval.request?.command ?? approval.command;
+          expect(approvalId).toEqual(expect.any(String));
+          expect(approvedCommand).toEqual(expect.any(String));
+        },
         expectedTexts: ["Trajectory exports can include", "through exec approval", "Approve once"],
         initialTexts:
           typeof exportResponse?.message === "object"
@@ -587,9 +600,13 @@ describeLive("gateway live trajectory export", () => {
       expect(exportSignal.instructionText).toContain("Trajectory exports can include");
       expect(exportSignal.instructionText).toContain("through exec approval");
       expect(exportSignal.instructionText).toContain("Approve once");
-      const approvalId = exportSignal.approvalId ?? (await approveTrajectoryExport(client));
+      expect(exportSignal.approvalId).toBe(approvalId);
+      const completionDeadline = Date.now() + 60_000;
       logLiveStep("export:approved", { approvalId });
-      await waitForPath(path.join(bundleDir, "events.jsonl"), 60_000);
+      await waitForPath(
+        path.join(bundleDir, "events.jsonl"),
+        remainingCompletionMs(completionDeadline),
+      );
       logLiveStep("export:done", { approvalId, finalText: exportSignal.instructionText });
       const bundleNames = await listDirectoryNames(bundleDir);
       for (const expectedName of [
@@ -630,6 +647,46 @@ describeLive("gateway live trajectory export", () => {
       expect(eventTypes.has("session.ended")).toBe(true);
       expect(eventTypes.has("user.message")).toBe(true);
       expect(eventTypes.has("assistant.message")).toBe(true);
+
+      await joinBeforeDeadline(waitForExecScope(execScope), completionDeadline);
+      const children = listFinishedSessions().filter(
+        (process) =>
+          process.scopeKey === execScope &&
+          process.cwd === workspaceDir &&
+          process.command === approvedCommand,
+      );
+      expect(children).toHaveLength(1);
+      const child = children[0]!;
+      expect(child.id).toEqual(expect.any(String));
+      expect(child).toMatchObject({ terminalStatus: "completed", exitCode: 0, exited: true });
+      expect(child.finalizing).not.toBe(true);
+      await expect
+        .poll(() => followupRunIds.size, { timeout: remainingCompletionMs(completionDeadline) })
+        .toBe(1);
+      expect(ambiguousFollowup).toBe(false);
+      const followupRunId = [...followupRunIds][0]!;
+      const terminal = await client.request<FollowupTerminal>(
+        "agent.wait",
+        {
+          runId: followupRunId,
+          timeoutMs: remainingCompletionMs(completionDeadline),
+        },
+        { timeoutMs: remainingCompletionMs(completionDeadline) },
+      );
+      expectSuccessfulFollowup(terminal, followupRunId);
+      const drained = await waitForGatewayActiveWork(remainingCompletionMs(completionDeadline));
+      expect(drained.drained).toBe(true);
+      expect(ambiguousFollowup).toBe(false);
+      const final = await client.request<FollowupTerminal>(
+        "agent.wait",
+        {
+          runId: followupRunId,
+          timeoutMs: 0,
+        },
+        { timeoutMs: remainingCompletionMs(completionDeadline) },
+      );
+      expectSuccessfulFollowup(final, followupRunId);
+      settled = true;
     },
     LIVE_TIMEOUT_MS,
   );

--- a/src/gateway/gateway-trajectory-export.test-support.test.ts
+++ b/src/gateway/gateway-trajectory-export.test-support.test.ts
@@ -1,0 +1,174 @@
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
+import {
+  addSession,
+  deleteSession,
+  hasActiveBackgroundExecSession,
+  markExited,
+  waitForExecScope,
+} from "../agents/bash-process-registry.js";
+import { createProcessSessionFixture } from "../agents/bash-process-registry.test-helpers.js";
+import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import {
+  createTrajectoryExportFixture,
+  settleTrajectoryExportWork,
+} from "./gateway-trajectory-export.test-support.js";
+
+function errorTree(error: unknown): unknown[] {
+  return error instanceof AggregateError ? [error, ...error.errors.flatMap(errorTree)] : [error];
+}
+
+describe("trajectory fixture cleanup", () => {
+  it.each(["settlement", "deadline", "client", "gateway"] as const)(
+    "retains evidence and closes remaining owners after %s failure",
+    async (failure) => {
+      const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+      const fixture = await createTrajectoryExportFixture();
+      const evidence = path.join(fixture.tempDir, "evidence.txt");
+      const bodyError = new Error("trajectory assertion failed");
+      const cleanupError = new Error(`${failure} failed`);
+      const phases: string[] = [];
+      // Real local transport handles prove the fixture releases resources; no model is involved.
+      const listener = net.createServer();
+      listener.listen(0, "127.0.0.1");
+      await once(listener, "listening");
+      const address = listener.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected TCP listener");
+      }
+      const accepted = new Promise<net.Socket>((resolve) => {
+        listener.once("connection", resolve);
+      });
+      const socket = net.createConnection(address.port, "127.0.0.1");
+      const peer = await accepted;
+      await fs.writeFile(evidence, "retained trajectory evidence");
+      setTestEnvValue("OPENCLAW_STATE_DIR", fixture.tempDir);
+      const pendingExec =
+        failure === "deadline"
+          ? createProcessSessionFixture({
+              id: "trajectory-deadline-exec",
+              cwd: fixture.tempDir,
+              command: "fixture-command",
+              backgrounded: true,
+            })
+          : undefined;
+      if (pendingExec) {
+        pendingExec.scopeKey = "trajectory-cleanup-regression";
+        addSession(pendingExec);
+      }
+      fixture.settleOwnedWork = async () => {
+        phases.push("settle");
+        if (failure === "deadline" || failure === "settlement") {
+          await settleTrajectoryExportWork({
+            client: {
+              request: async () => {
+                throw cleanupError;
+              },
+            },
+            deadline: Date.now() + (failure === "deadline" ? -1 : 5_000),
+            execScope: "trajectory-cleanup-regression",
+            workspaceDir: fixture.tempDir,
+            command: "fixture-command",
+            runIds: ["fixture-run"],
+            sessionKey: "agent:dev:trajectory-cleanup-regression",
+          });
+        }
+      };
+      fixture.client = {
+        async stopAndWait() {
+          phases.push("client");
+          const closed = once(socket, "close");
+          socket.end();
+          await closed;
+          if (failure === "client") {
+            throw cleanupError;
+          }
+        },
+      };
+      fixture.server = {
+        async close() {
+          phases.push("gateway");
+          await new Promise<void>((resolve, reject) => {
+            listener.close((error) => (error ? reject(error) : resolve()));
+          });
+          if (failure === "gateway") {
+            throw cleanupError;
+          }
+        },
+      };
+      try {
+        const result: unknown = await runQaGatewayFixture(async () => {
+          throw bodyError;
+        }, fixture.cleanup).catch((error: unknown) => error);
+        expect(phases).toEqual(["settle", "client", "gateway"]);
+        expect(socket.destroyed).toBe(true);
+        expect(listener.listening).toBe(false);
+        expect(process.env.OPENCLAW_STATE_DIR).toBe(previousStateDir);
+        expect(await fs.readFile(evidence, "utf8")).toBe("retained trajectory evidence");
+        const errors = errorTree(result);
+        expect(errors).toContain(bodyError);
+        if (failure === "deadline") {
+          expect(hasActiveBackgroundExecSession("trajectory-deadline-exec")).toBe(true);
+          expect(errors).toContainEqual(new Error("trajectory completion deadline exceeded"));
+        }
+        expect(errors).toContain(cleanupError);
+        expect(
+          errors.some((error) => error instanceof Error && error.message.includes(fixture.tempDir)),
+        ).toBe(true);
+      } finally {
+        if (pendingExec) {
+          markExited(pendingExec, null, null, "killed");
+          await waitForExecScope("trajectory-cleanup-regression");
+          deleteSession(pendingExec.id);
+        }
+        socket.destroy();
+        peer.destroy();
+        if (listener.listening) {
+          await new Promise<void>((resolve) => {
+            listener.close(() => resolve());
+          });
+        }
+        // The regression owns these fault-injection resources and has now joined them.
+        if (previousStateDir === undefined) {
+          deleteTestEnvValue("OPENCLAW_STATE_DIR");
+        } else {
+          setTestEnvValue("OPENCLAW_STATE_DIR", previousStateDir);
+        }
+        await fs.rm(fixture.tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "removes settled fixture state (resources acquired: %s)",
+    async (acquired) => {
+      const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+      const fixture = await createTrajectoryExportFixture();
+      setTestEnvValue("OPENCLAW_STATE_DIR", fixture.tempDir);
+      const phases: string[] = [];
+      if (acquired) {
+        fixture.settleOwnedWork = async () => {
+          phases.push("settle");
+        };
+        fixture.client = {
+          stopAndWait: async () => {
+            phases.push("client");
+          },
+        };
+        fixture.server = {
+          close: async () => {
+            phases.push("gateway");
+          },
+        };
+      }
+      await fixture.cleanup();
+      expect(phases).toEqual(acquired ? ["settle", "client", "gateway"] : []);
+      expect(process.env.OPENCLAW_STATE_DIR).toBe(previousStateDir);
+      await expect(fs.stat(fixture.tempDir)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+});

--- a/src/gateway/gateway-trajectory-export.test-support.ts
+++ b/src/gateway/gateway-trajectory-export.test-support.ts
@@ -1,0 +1,152 @@
+// Owns the live trajectory fixture environment and resource teardown.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect } from "vitest";
+import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
+import { listRunningSessions, waitForExecScope } from "../agents/bash-process-registry.js";
+import { clearRuntimeConfigSnapshot } from "../config/config.js";
+import { waitForGatewayActiveWork } from "../infra/gateway-active-work.js";
+import { getProcessSupervisor } from "../process/supervisor/index.js";
+import type { GatewayClient } from "./client.js";
+import { restoreLiveEnv, snapshotLiveEnv } from "./live-env-test-helpers.js";
+import type { GatewayServer } from "./server-public.js";
+
+export async function createTrajectoryExportFixture() {
+  const previousEnv = snapshotLiveEnv(["OPENCLAW_TRAJECTORY", "OPENCLAW_TRAJECTORY_DIR"]);
+  const tempDir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-openclaw-trajectory-live-"));
+  const fixture: {
+    tempDir: string;
+    server?: Pick<GatewayServer, "close">;
+    client?: Pick<GatewayClient, "stopAndWait">;
+    settleOwnedWork?: () => Promise<void>;
+    cleanup: () => Promise<void>;
+  } = {
+    tempDir,
+    async cleanup() {
+      let ownersStopped = false;
+      await runQaGatewayFixture(
+        async () => {
+          await runQaGatewayFixture(
+            async () => {
+              await fixture.settleOwnedWork?.();
+            },
+            async () => {
+              await fixture.client?.stopAndWait({ timeoutMs: 5_000 });
+            },
+            async () => {
+              await fixture.server?.close();
+            },
+          );
+          ownersStopped = true;
+        },
+        () => restoreLiveEnv(previousEnv),
+        clearRuntimeConfigSnapshot,
+        async () => {
+          // Closing the Gateway is not proof that timed-out work settled. Keep its
+          // state and evidence unless every owned cleanup phase completed.
+          if (!ownersStopped) {
+            throw new Error(
+              `trajectory fixture state retained at ${tempDir}: cleanup did not settle`,
+            );
+          }
+          await removeLiveTempDir(tempDir);
+        },
+      );
+    },
+  };
+  return fixture;
+}
+
+async function removeLiveTempDir(dir: string): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      lastError = error;
+      const code = (error as { code?: unknown } | null)?.code;
+      if (code !== "EBUSY" && code !== "ENOTEMPTY" && code !== "EPERM" && code !== "EACCES") {
+        throw error;
+      }
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+    }
+  }
+  await fs.rm(dir, { recursive: true, force: true });
+  void lastError;
+}
+
+export function remainingCompletionMs(deadline: number): number {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) {
+    throw new Error("trajectory completion deadline exceeded");
+  }
+  return remaining;
+}
+
+export async function joinBeforeDeadline<T>(work: Promise<T>, deadline: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("trajectory completion deadline exceeded")),
+          remainingCompletionMs(deadline),
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function settleTrajectoryExportWork(params: {
+  client: Pick<GatewayClient, "request">;
+  deadline: number;
+  execScope: string;
+  workspaceDir: string;
+  command?: string;
+  runIds: Iterable<string>;
+  sessionKey: string;
+}): Promise<void> {
+  const processes = listRunningSessions().filter(
+    (process) =>
+      process.scopeKey === params.execScope &&
+      process.cwd === params.workspaceDir &&
+      process.command === params.command,
+  );
+  await runQaGatewayFixture(
+    async () => {
+      const errors: unknown[] = [];
+      for (const process of processes) {
+        try {
+          getProcessSupervisor().cancel(process.id);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      for (const runId of params.runIds) {
+        try {
+          await params.client.request(
+            "chat.abort",
+            { runId, sessionKey: params.sessionKey },
+            { timeoutMs: Math.max(1, Math.min(5_000, params.deadline - Date.now())) },
+          );
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      if (errors.length > 0) {
+        throw new AggregateError(errors, "trajectory failure cleanup cancellation failed");
+      }
+    },
+    async () => {
+      await joinBeforeDeadline(waitForExecScope(params.execScope), params.deadline);
+      const drained = await waitForGatewayActiveWork(remainingCompletionMs(params.deadline));
+      expect(drained.drained).toBe(true);
+    },
+  );
+}

--- a/src/gateway/server-in-process-dispatch.abort.test.ts
+++ b/src/gateway/server-in-process-dispatch.abort.test.ts
@@ -107,6 +107,7 @@ describe("in-process paired-node invocation cancellation", () => {
     });
     expect(handleGatewayRequest).toHaveBeenCalledWith(
       expect.objectContaining({ signal: controller.signal }),
+      undefined,
     );
   });
 

--- a/src/gateway/server-in-process-dispatch.ts
+++ b/src/gateway/server-in-process-dispatch.ts
@@ -10,6 +10,7 @@ import type { GatewayRequestOptions } from "./server-methods/types.js";
 export type { GatewayMethodDispatchResponse } from "./server-in-process-dispatch.types.js";
 
 type InProcessGatewayDispatchOptions = {
+  assertContextCurrent?: () => void;
   client: GatewayRequestOptions["client"];
   context: GatewayRequestOptions["context"];
   expectFinal?: boolean;
@@ -156,32 +157,35 @@ export async function dispatchGatewayRequestInProcessRaw(
   });
   const deadlineMs = resolveDispatchDeadlineMs(options.timeoutMs);
   const { handleGatewayRequest } = await import("./server-methods.js");
-  void handleGatewayRequest({
-    req: {
-      type: "req",
-      id: `${options.requestIdPrefix ?? "in-process"}-${randomUUID()}`,
-      method,
-      params,
+  void handleGatewayRequest(
+    {
+      req: {
+        type: "req",
+        id: `${options.requestIdPrefix ?? "in-process"}-${randomUUID()}`,
+        method,
+        params,
+      },
+      client: options.client,
+      isWebchatConnect: options.isWebchatConnect ?? (() => false),
+      respond: (ok, payload, error, meta) => {
+        const response = { ok, payload, error, ...(meta ? { meta } : {}) };
+        if (!firstResponse) {
+          firstResponse = response;
+          resolveFirstResponse?.(response);
+          return;
+        }
+        if (!finalResponse) {
+          finalResponse = response;
+          resolveFinalResponse?.(response);
+        }
+      },
+      context: options.context,
+      methodRegistry: options.methodRegistry,
+      sessionMutationCommitGuard: options.sessionMutationCommitGuard,
+      ...(options.signal ? { signal: options.signal } : {}),
     },
-    client: options.client,
-    isWebchatConnect: options.isWebchatConnect ?? (() => false),
-    respond: (ok, payload, error, meta) => {
-      const response = { ok, payload, error, ...(meta ? { meta } : {}) };
-      if (!firstResponse) {
-        firstResponse = response;
-        resolveFirstResponse?.(response);
-        return;
-      }
-      if (!finalResponse) {
-        finalResponse = response;
-        resolveFinalResponse?.(response);
-      }
-    },
-    context: options.context,
-    methodRegistry: options.methodRegistry,
-    sessionMutationCommitGuard: options.sessionMutationCommitGuard,
-    ...(options.signal ? { signal: options.signal } : {}),
-  })
+    options.assertContextCurrent,
+  )
     .then(() => {
       if (!firstResponse) {
         rejectFirstResponse?.(

--- a/src/gateway/server-instance-runtime.test.ts
+++ b/src/gateway/server-instance-runtime.test.ts
@@ -1,3 +1,4 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "../../packages/gateway-client/src/timeouts.js";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
@@ -8,13 +9,21 @@ import {
   restoreActivePluginRegistrySnapshot,
   stageActivePluginRegistry,
 } from "../plugins/runtime.js";
-import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
+import {
+  getActiveGatewayRootWorkCount,
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
+  tryBeginGatewayRootWorkAdmission,
+} from "../process/gateway-work-admission.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { setGatewayDedupeEntry } from "./agent-turn/agent-job.js";
 import { captureAgentTurnPrincipal } from "./agent-turn/principal.js";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import { createGatewayMethodRegistry } from "./methods/registry.js";
 import { createGatewayInstanceRuntime } from "./server-instance-runtime.js";
+import { handleChatAbortRequest } from "./server-methods/chat-abort-handler.js";
+import { sendHandlers } from "./server-methods/send.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "./server-plugin-runtime-client.js";
 import { getGatewayRecoveryRuntime } from "./server-recovery-runtime-context.js";
@@ -45,6 +54,200 @@ function createRegistry(handlers: GatewayRequestHandlers) {
 }
 
 describe("createGatewayInstanceRuntime", () => {
+  describe.each(["live", "closed", "unavailable"] as const)(
+    "instance liveness after authorization: %s",
+    (liveness) => {
+      it.each(["shared dispatch", "dedicated dispatch", "wait"] as const)(
+        "%s stays bound to its available originating instance",
+        async (operation) => {
+          let available = true;
+          const context = createContext();
+          const runId = `instance-liveness-${liveness}-${operation}`;
+          const payload = { runId, status: "ok", summary: "originating instance" };
+          context.dedupe.set(`agent:${runId}`, { ts: Date.now(), ok: true, payload });
+          const registry = createRegistry({});
+          const runtime = createGatewayInstanceRuntime({
+            getContext: () => context,
+            getMethodRegistry: () => registry,
+            isDispatchAvailable: () => available,
+          });
+          context.resolveGatewayContext = () => (runtime.isAvailable() ? context : undefined);
+          context.recoveryRuntime = runtime.recovery;
+          const replacementContext = createContext();
+          replacementContext.dedupe.set(`agent:${runId}`, {
+            ts: Date.now(),
+            ok: true,
+            payload: { ...payload, summary: "replacement instance" },
+          });
+          const getReplacementContext = vi.fn(() => replacementContext);
+          const replacement = createGatewayInstanceRuntime({
+            getContext: getReplacementContext,
+            getMethodRegistry: () => registry,
+            isDispatchAvailable: () => true,
+          });
+          try {
+            expect(getGatewayRecoveryRuntime()).toBe(replacement.recovery);
+            const pending =
+              operation === "wait"
+                ? runtime.recovery.waitForAgent({ runId, timeoutMs: 0 })
+                : runtime.recovery.dispatchAgent(
+                    {
+                      message: "test",
+                      idempotencyKey: runId,
+                      ...(operation === "dedicated dispatch" ? { model: "test-model" } : {}),
+                    },
+                    undefined,
+                    { allowModelOverride: operation === "dedicated dispatch" },
+                  );
+            // The real authorization function has yielded, but no envelope owns work yet.
+            expect(getActiveGatewayRootWorkCount()).toBe(0);
+            if (liveness === "closed") {
+              runtime.close();
+            } else if (liveness === "unavailable") {
+              available = false;
+            }
+            if (liveness === "live") {
+              await expect(pending).resolves.toEqual(
+                operation === "wait"
+                  ? { runId, status: "timeout", timeoutPhase: "queue", providerStarted: false }
+                  : payload,
+              );
+            } else {
+              await expect(pending).rejects.toThrow("Gateway instance dispatch unavailable");
+            }
+          } finally {
+            runtime.close();
+            replacement.close();
+            expect(getReplacementContext).not.toHaveBeenCalled();
+            expect(getGatewayRecoveryRuntime()).toBeUndefined();
+            await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+          }
+        },
+      );
+    },
+  );
+
+  it.each(["fresh root", "retained root"] as const)(
+    "keeps the instance fence distinct from process drain: %s",
+    async (rootKind) => {
+      const context = createContext();
+      const runId = `instance-liveness-drain-${rootKind}`;
+      context.dedupe.set(`agent:${runId}`, {
+        ts: Date.now(),
+        ok: true,
+        payload: { runId, status: "ok" },
+      });
+      const runtime = createGatewayInstanceRuntime({
+        getContext: () => context,
+        getMethodRegistry: () => createRegistry({}),
+        isDispatchAvailable: () => true,
+      });
+      context.resolveGatewayContext = () => (runtime.isAvailable() ? context : undefined);
+      const root = rootKind === "retained root" ? tryBeginGatewayRootWorkAdmission() : undefined;
+      const dispatch = async () => {
+        const pending = runtime.recovery.dispatchAgent({ message: "test", idempotencyKey: runId });
+        markGatewayRestartDraining();
+        if (rootKind === "retained root") {
+          runtime.close();
+        }
+        await expect(pending).rejects.toThrow(
+          rootKind === "retained root"
+            ? "Gateway instance dispatch unavailable"
+            : "gateway restart",
+        );
+      };
+      try {
+        if (rootKind === "retained root") {
+          expect(root).toBeTruthy();
+        }
+        await (root ? root.run(dispatch) : dispatch());
+      } finally {
+        runtime.close();
+        root?.release();
+        await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+        resetGatewayWorkAdmission();
+      }
+    },
+  );
+
+  it("preserves an already-admitted wait when its instance closes", async () => {
+    const context = createContext();
+    const runId = "instance-liveness-admitted-wait";
+    const runtime = createGatewayInstanceRuntime({
+      getContext: () => context,
+      getMethodRegistry: () => createRegistry({}),
+      isDispatchAvailable: () => true,
+    });
+    context.resolveGatewayContext = () => (runtime.isAvailable() ? context : undefined);
+    const pending = runtime.recovery.waitForAgent({ runId });
+    const finish = () =>
+      setGatewayDedupeEntry({
+        dedupe: context.dedupe,
+        key: `agent:${runId}`,
+        entry: { ts: Date.now(), ok: true, payload: { runId, status: "ok" } },
+      });
+    try {
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(1));
+      runtime.close();
+      finish();
+      await expect(pending).resolves.toMatchObject({ runId, status: "ok" });
+    } finally {
+      finish();
+      await pending;
+      runtime.close();
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    }
+  });
+
+  it.each(["live", "closed", "unavailable"] as const)(
+    "checks instance liveness before the real abort handler: %s",
+    async (liveness) => {
+      await withOpenClawTestState({ layout: "state-only", prefix: "instance-abort-" }, async () => {
+        let available = true;
+        const context = createContext();
+        const runId = `instance-liveness-abort-${liveness}`;
+        const payload = {
+          runId,
+          status: "accepted",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+        };
+        context.dedupe.set(`agent:${runId}`, { ts: Date.now(), ok: true, payload });
+        const runtime = createGatewayInstanceRuntime({
+          getContext: () => context,
+          getMethodRegistry: () => createRegistry({ "chat.abort": handleChatAbortRequest }),
+          isDispatchAvailable: () => available,
+        });
+        context.resolveGatewayContext = () => (runtime.isAvailable() ? context : undefined);
+        try {
+          const pending = runtime.recovery.abortAgent({
+            agentId: "main",
+            runId,
+            sessionKey: payload.sessionKey,
+          });
+          if (liveness === "closed") {
+            runtime.close();
+          } else if (liveness === "unavailable") {
+            available = false;
+          }
+          if (liveness === "live") {
+            await expect(pending).resolves.toMatchObject({ aborted: true, runIds: [runId] });
+            expect(context.dedupe.get(`agent:${runId}`)?.payload).toMatchObject({
+              status: "timeout",
+              stopReason: "rpc",
+            });
+          } else {
+            await expect.soft(pending).rejects.toThrow("Gateway instance dispatch unavailable");
+            expect(context.dedupe.get(`agent:${runId}`)?.payload).toEqual(payload);
+          }
+        } finally {
+          runtime.close();
+          await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+        }
+      });
+    },
+  );
+
   it("uses the typed recovery path and fails closed when the owning instance closes", async () => {
     let available = false;
     const rawAgent = vi.fn<NonNullable<GatewayRequestHandlers["agent"]>>(({ respond }) => {
@@ -177,80 +380,119 @@ describe("createGatewayInstanceRuntime", () => {
     expect(recoveryPrincipal?.internal?.sessionCreation).toBeUndefined();
   });
 
-  it("sends recovery notices through normal outbound without invoking plugin actions", async () => {
-    await withOpenClawTestState({ layout: "state-only", prefix: "recovery-notice-" }, async () => {
-      const sendText = vi.fn(async () => ({ channel: "signal", messageId: "signal-message-1" }));
-      const handleAction = vi.fn(async () => {
-        throw new Error("recovery notice must not invoke message actions");
-      });
-      const plugin: ChannelPlugin = {
-        id: "signal",
-        meta: {
-          id: "signal",
-          label: "Signal",
-          selectionLabel: "Signal",
-          docsPath: "/channels/signal",
-          blurb: "Signal-shaped recovery test plugin.",
+  it.each([
+    ["recovery notice", "live"],
+    ["recovery notice", "closed"],
+    ["recovery notice", "unavailable"],
+    ["approval route", "live"],
+    ["approval route", "closed"],
+    ["approval route", "unavailable"],
+  ] as const)(
+    "checks instance liveness before normal outbound: %s / %s",
+    async (surface, liveness) => {
+      await withOpenClawTestState(
+        { layout: "state-only", prefix: "recovery-notice-" },
+        async () => {
+          const sendText = vi.fn(async () => ({
+            channel: "signal",
+            messageId: "signal-message-1",
+          }));
+          const handleAction = vi.fn(async () => {
+            throw new Error("recovery notice must not invoke message actions");
+          });
+          const plugin: ChannelPlugin = {
+            id: "signal",
+            meta: {
+              id: "signal",
+              label: "Signal",
+              selectionLabel: "Signal",
+              docsPath: "/channels/signal",
+              blurb: "Signal-shaped recovery test plugin.",
+            },
+            capabilities: { chatTypes: ["direct"] },
+            config: {
+              listAccountIds: () => ["work"],
+              resolveAccount: () => ({}),
+              isConfigured: () => true,
+            },
+            actions: {
+              describeMessageTool: () => ({ actions: ["send"] }),
+              supportsAction: () => false,
+              handleAction,
+            },
+            outbound: {
+              deliveryMode: "direct",
+              resolveTarget: ({ to }) => ({ ok: true, to: to?.trim() ?? "" }),
+              sendText,
+            },
+          };
+          const pluginRegistrySnapshot = captureActivePluginRegistrySnapshot();
+          stageActivePluginRegistry(
+            createTestRegistry([{ pluginId: "signal", source: "test", plugin }]),
+            null,
+            "default",
+          );
+          const context = {
+            ...createContext(),
+            getRuntimeConfig: () => ({
+              agents: { list: [{ id: "main" }] },
+              channels: { signal: { enabled: true } },
+            }),
+          } as GatewayRequestContext;
+          let available = true;
+          const runtime = createGatewayInstanceRuntime({
+            getContext: () => context,
+            getMethodRegistry: () =>
+              createRegistry({ send: expectDefined(sendHandlers.send, "send handler") }),
+            isDispatchAvailable: () => available,
+          });
+          context.resolveGatewayContext = () => (runtime.isAvailable() ? context : undefined);
+
+          try {
+            const payload = {
+              channel: "signal",
+              to: "+15551234567",
+              accountId: "work",
+              threadId: "thread-1",
+              idempotencyKey: `main-session-restart-recovery:${surface}:${liveness}`,
+            };
+            const pending =
+              surface === "recovery notice"
+                ? runtime.recovery.sendRecoveryNotice({ ...payload, text: "Recovery notice" })
+                : runtime.nativeApprovals.requestRoute("send", {
+                    ...payload,
+                    message: "Recovery notice",
+                  });
+            if (liveness === "closed") {
+              runtime.close();
+            } else if (liveness === "unavailable") {
+              available = false;
+            }
+            if (liveness === "live") {
+              await pending;
+              expect(sendText).toHaveBeenCalledOnce();
+              expect(sendText).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  to: "+15551234567",
+                  accountId: "work",
+                  threadId: "thread-1",
+                  text: "Recovery notice",
+                }),
+              );
+            } else {
+              await expect.soft(pending).rejects.toThrow("Gateway instance dispatch unavailable");
+              expect(sendText).not.toHaveBeenCalled();
+            }
+            expect(handleAction).not.toHaveBeenCalled();
+          } finally {
+            runtime.close();
+            await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+            restoreActivePluginRegistrySnapshot(pluginRegistrySnapshot);
+          }
         },
-        capabilities: { chatTypes: ["direct"] },
-        config: {
-          listAccountIds: () => ["work"],
-          resolveAccount: () => ({}),
-          isConfigured: () => true,
-        },
-        actions: {
-          describeMessageTool: () => ({ actions: ["send"] }),
-          supportsAction: () => false,
-          handleAction,
-        },
-        outbound: {
-          deliveryMode: "direct",
-          resolveTarget: ({ to }) => ({ ok: true, to: to?.trim() ?? "" }),
-          sendText,
-        },
-      };
-      const pluginRegistrySnapshot = captureActivePluginRegistrySnapshot();
-      stageActivePluginRegistry(
-        createTestRegistry([{ pluginId: "signal", source: "test", plugin }]),
-        null,
-        "default",
       );
-      const context = {
-        ...createContext(),
-        getRuntimeConfig: () => ({ channels: { signal: { enabled: true } } }),
-      } as GatewayRequestContext;
-      const runtime = createGatewayInstanceRuntime({
-        getContext: () => context,
-        getMethodRegistry: () => createRegistry({}),
-        isDispatchAvailable: () => true,
-      });
-
-      try {
-        await runtime.recovery.sendRecoveryNotice({
-          channel: "signal",
-          to: "+15551234567",
-          accountId: "work",
-          threadId: "thread-1",
-          text: "Recovery notice",
-          idempotencyKey: "main-session-restart-recovery:run-1:failed-notice",
-        });
-
-        expect(sendText).toHaveBeenCalledOnce();
-        expect(sendText).toHaveBeenCalledWith(
-          expect.objectContaining({
-            to: "+15551234567",
-            accountId: "work",
-            threadId: "thread-1",
-            text: "Recovery notice",
-          }),
-        );
-        expect(handleAction).not.toHaveBeenCalled();
-      } finally {
-        runtime.close();
-        restoreActivePluginRegistrySnapshot(pluginRegistrySnapshot);
-      }
-    });
-  });
+    },
+  );
 
   it("keeps approval subscribers isolated by Gateway instance and unregisters exactly once", () => {
     const registry = createRegistry({});

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -92,6 +92,7 @@ export function createGatewayInstanceRuntime(
       context: options.getContext(),
       methodRegistry: options.getMethodRegistry(),
       requestIdPrefix: "gateway-internal",
+      assertContextCurrent: () => assertDispatchAvailable(params.method),
       timeoutMs: params.timeoutMs,
     });
   };
@@ -176,10 +177,9 @@ export function createGatewayInstanceRuntime(
       return await recoveryAgentTurns.wait<T>(payload, timeoutMs);
     },
     sendRecoveryNotice: async (payload) => {
-      if (closed || !options.isDispatchAvailable()) {
-        throw new Error("Gateway instance dispatch unavailable for recovery notice");
-      }
+      assertDispatchAvailable("recovery notice");
       const { sendMessage } = await loadOutboundMessageRuntime();
+      assertDispatchAvailable("recovery notice");
       const context = options.getContext();
       const result = await sendMessage({
         cfg: context.getRuntimeConfig(),

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -679,6 +679,7 @@ export async function runWithGatewayRequestEnvelope<T>(
 /** Authorizes and dispatches one gateway JSON-RPC-style request. */
 export async function handleGatewayRequest(
   opts: GatewayRequestOptions & { extraHandlers?: GatewayRequestHandlers },
+  assertContextCurrent?: () => void,
 ): Promise<void> {
   const { req, respond, client, isWebchatConnect, context, signal } = opts;
   // Prefer the caller-attached registry when it owns the requested method so plugin dispatch
@@ -700,6 +701,9 @@ export async function handleGatewayRequest(
     respond(false, undefined, authorization.error);
     return;
   }
+  // Internal callers retain an instance owner across authorization's await.
+  // Check before admission; already-admitted work keeps its existing lifecycle.
+  assertContextCurrent?.();
   const handler = methodRegistry.getHandler(req.method) as GatewayRequestHandler | undefined;
   if (!handler) {
     respond(

--- a/src/gateway/server-plugin-in-process-dispatch.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.ts
@@ -298,6 +298,7 @@ export async function dispatchGatewayMethodInProcessRaw(
 ): Promise<GatewayMethodDispatchResponse> {
   return await withInProcessGatewayDispatch(method, options, async (resolved) => {
     return await dispatchGatewayRequestInProcessRaw(method, params, {
+      assertContextCurrent: resolved.assertContextCurrent,
       client: resolved.client,
       context: resolved.context,
       expectFinal: options?.expectFinal,


### PR DESCRIPTION
Related: [#130472 — live Gateway trajectory export times out before approval settlement](https://github.com/openclaw/openclaw/issues/130472).

**Not ready to merge:** the integrated source passes local tests, build, checks, and review. Required CI on the refreshed head and real Gateway/Codex trajectory success/failure-cleanup proof are still pending.

## What Problem This Solves

Resolves a problem where an approved background export could stop counting as active Gateway work before its completion follow-up finished. The continuation could also select a replacement Gateway instead of its originating instance. Export replies described an approval request even when the typed result said execution was already running, completed, denied, unavailable, or uncertain.

The live trajectory fixture also skipped remaining client, Gateway, and environment cleanup when an earlier cleanup step failed. The fixture's approval-renderer capability is already present on the base and is preserved here; this maintainer refresh extends the original projected-approval settlement contribution rather than duplicating that capability change.

## Why This Change Was Made

The existing independent work root now owns child finalization, dynamic follow-up creation, dispatch, and observation. One captured originating Gateway route serves both dispatch and wait. Raw internal requests retain the instance-liveness predicate across awaited authorization before new work is admitted; recovery notices recheck after lazy loading. Already-admitted work keeps its existing lifecycle. A new follow-up leaves only the predecessor's prepared-model generation scope, not its Gateway routing or delegated authority.

Integration preserves the [host-owned typed facade factory from #132430](https://github.com/openclaw/openclaw/pull/132430), [node-approval context from #131829](https://github.com/openclaw/openclaw/pull/131829), and [corrected headless-approval guidance from #132237](https://github.com/openclaw/openclaw/pull/132237). Redundant typed predicates from the initial local patch were removed, and the raw dispatcher uses the current resolver-owned predicate.

Diagnostics and trajectory export share one typed status formatter. The live fixture observes the exact projected approval and follow-up run, verifies child and canonical terminal completion, and reuses the existing ordered cleanup helper to attempt later shutdown steps while retaining state and errors whenever settlement is unproved. No configuration option, protocol field, store, schema, dependency, permission bypass, second completion registry, or compatibility path is added. Direct-result fallback and final platform-delivery policy are unchanged.

## User Impact

Approved exports remain visible to Gateway drain accounting through their completion work. Continuations stay with their originating instance rather than transferring to a replacement. Export status tells the operator what actually happened; only a pending approval asks them to approve once, and an uncertain result advises checking before rerunning.

The fixture keeps its real Gateway/model path and original timeout budgets. Failed cleanup preserves diagnostic state without skipping the remaining owned shutdown steps. Thanks to @jalehman for the original trajectory approval-settlement contribution.

## Evidence

Integrated source: `733ed66d6080eab35e66cc859be7bbfccde0fca0`, based on `662d3777551990b92df31b84d4997c9a78569363`.

- **705 tests passed in 24 files** across six sequential repository-wrapper shards, with at most two workers. This covers completion lifetime, captured routing, authorization/liveness, both export commands, cleanup, exec registry, active-work waiting, Gateway shutdown, and client behavior. The separate 91-test integration check is a subset, not an additional total.
- **Full `pnpm build` passed** on the integrated commit in 284.52 seconds. Scoped changed-file formatting, types, lint, architecture, and selected guards passed in 557.99 seconds. Source bytes remained unchanged throughout validation.
- **Fresh managed P0 review passed** on the resolved integration as one complete pass. An earlier supplemental-context preflight refused before a provider call; reducing only unchanged shutdown implementation context retained the complete patch and relevant owner/public contracts. No scanner or isolation bypass was used.
- Pre-fix owner regressions captured early root release, stale route selection, inherited generation scope, misleading export statuses, and instance closure during awaited admission. Canonical main now owns part of the typed-facade repair; this branch does not claim those overlapping lines as new fixes.
- Cleanup regression: **4 intended failures and 2 passing controls** against the original cleanup implementation, then passing with the repair. It uses real TCP handles, files, environment, and exec-registry scope joining with injected cancellation/shutdown failures. It does not establish extinction of a real provider child.

Exact integrated test command:

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-gateway.test.ts src/agents/bash-tools.exec-host-shared.test.ts src/agents/bash-tools.exec-approval-followup.test.ts src/gateway/server-instance-runtime.test.ts src/gateway/server-recovery-runtime-context.test.ts src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts src/gateway/agent-turn/internal-facade.test.ts src/gateway/server-in-process-dispatch.abort.test.ts src/gateway/server-in-process-dispatch.error-cause.test.ts src/gateway/server-methods.authorization.test.ts src/gateway/server-plugin-in-process-dispatch.authorization.test.ts src/agents/bash-tools.exec-host-node.test.ts src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-process-registry.test.ts src/auto-reply/reply/commands-export-session.test.ts src/auto-reply/reply/commands-diagnostics.test.ts src/gateway/gateway-trajectory-export.test-support.test.ts test/helpers/qa-gateway-cleanup.test.ts src/gateway/gateway.test-support.test.ts src/infra/exec-approval-reply.test.ts src/infra/gateway-active-work.test.ts src/gateway/server-close.test.ts src/gateway/server-shutdown.test.ts src/gateway/client.test.ts --reporter=dot
```

Integrated LOC: production **+220/-193 (net +27)**; tests/support **+1199/-259 (net +940)**; docs **+10/-2**. Production growth carries originating-instance routing and the existing liveness predicate across missing admission boundaries; the completion tail and duplicate formatters are simplified. Test-support movement is counted separately from production.

The earlier full-release command's unexplained outer exit 1 is not attributed to these repairs. Real trajectory proof and channel-visible/visual evidence remain pending. A successful `GatewayServer.close()` alone is not process-extinction proof, and no full-release recovery is claimed.

AI-assisted: yes.
