### PR TITLE
test(skills): seed experience review transcript owner

### DIFF
--- a/src/skills/workshop/experience-review.live.test.ts
+++ b/src/skills/workshop/experience-review.live.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { isLiveTestEnabled } from "../../agents/live-test-helpers.js";
 import { resolveAgentRunSessionTarget } from "../../agents/run-session-target.js";
 import { SessionManager } from "../../agents/sessions/index.js";
+import { createSessionEntryWithTranscript } from "../../config/sessions/session-accessor.js";
 import type { Message } from "../../llm/types.js";
 import {
   createOpenClawTestState,
@@ -18,6 +19,22 @@ const describeLive = LIVE ? describe : describe.skip;
 const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
 let workspaceDir = "";
+
+beforeAll(async () => {
+  // Full home isolation: the embedded review resolves the shared-main auth
+  // store via HOME, and a real ~/.openclaw with pending doctor migration
+  // must never leak into (or fail) this live run.
+  testState = await createOpenClawTestState({
+    layout: "home",
+    prefix: "openclaw-live-skill-review-state-",
+  });
+  workspaceDir = await tempDirs.make("openclaw-live-skill-review-workspace-");
+});
+
+afterAll(async () => {
+  await testState.cleanup();
+  await tempDirs.cleanup();
+});
 
 async function candidate(
   runId: string,
@@ -96,22 +113,43 @@ async function candidate(
     sessionId,
     sessionKey,
   });
+  const created = await createSessionEntryWithTranscript(
+    target,
+    () => ({ ok: true, entry: { sessionId, updatedAt: Date.now() } }),
+    { cwd: workspaceDir },
+  );
+  if (!created.ok) {
+    throw new Error(`Failed to create live review session: ${created.error}`);
+  }
   for (const message of messages) {
     SessionManager.appendMessageToTranscript(target, message as Message, { config: result.config });
   }
   return result;
 }
 
+describe("skill experience review transcript fixture", () => {
+  it("persists messages through a canonical session", async () => {
+    const runId = "transcript-fixture";
+    const sessionId = `live-skill-review-${runId}`;
+    const sessionKey = `agent:main:${sessionId}`;
+    const message = { role: "user", content: "Review this completed task." };
+    const seeded = await candidate(runId, [message]);
+    const target = await resolveAgentRunSessionTarget({
+      agentId: "main",
+      config: seeded.config,
+      missingSessionKey: "resolve-existing",
+      sessionId,
+      sessionKey,
+    });
+
+    expect(SessionManager.open(target, workspaceDir).buildSessionContext().messages).toEqual([
+      message,
+    ]);
+  });
+});
+
 describeLive("skill experience review live OpenAI eval", () => {
   beforeAll(async () => {
-    // Full home isolation: the embedded review resolves the shared-main auth
-    // store via HOME, and a real ~/.openclaw with pending doctor migration
-    // must never leak into (or fail) this live run.
-    testState = await createOpenClawTestState({
-      layout: "home",
-      prefix: "openclaw-live-skill-review-state-",
-    });
-    workspaceDir = await tempDirs.make("openclaw-live-skill-review-workspace-");
     // Warm the plugin runtime outside the review lane: the first load compiles
     // extensions synchronously and can exceed the lane's no-progress watchdog
     // on a loaded machine.
@@ -123,11 +161,6 @@ describeLive("skill experience review live OpenAI eval", () => {
       workspaceDir,
     });
   }, 600_000);
-
-  afterAll(async () => {
-    await testState.cleanup();
-    await tempDirs.cleanup();
-  });
 
   it("proposes a recovered preflight procedure but ignores routine one-off work", async () => {
     const positiveMessages = [


### PR DESCRIPTION
## What Problem This Solves

Fixes the native-agents release failure where the experience-review live fixture appended a transcript message before creating the canonical session row. The SQLite transcript writer correctly rejected the orphan append.

## Why This Change Was Made

The fixture now creates the session and transcript through `createSessionEntryWithTranscript` before appending, preserving the writer's owner-boundary validation. Shared setup and cleanup cover both the deterministic transcript regression and the live evaluation.

Production LOC: +0/-0. Tests: +46/-13.

## User Impact

The native agents release shard exercises experience review with valid canonical session state instead of failing in test setup before model behavior can be evaluated.

## Evidence

- Exact release failure: https://github.com/openclaw/openclaw/actions/runs/33007261502/job/98305368830
- Regression fails before the repair because the canonical session row is absent; it passes after the fixture creates state through the session owner.
- 199 focused tests passed.
- Changed-file gate passed.
- Testbox patched test passed; the later shard stage failed because provider authentication was unavailable: https://github.com/openclaw/openclaw/actions/runs/33019015583
- Fresh Codex autoreview: clean, patch correct at 0.99 confidence.

AI-assisted: yes. No agent transcript is included.
