### PR TITLE
fix(oc-path): quote positional JSONC keys

### DIFF
--- a/extensions/oc-path/src/oc-path/find.ts
+++ b/extensions/oc-path/src/oc-path/find.ts
@@ -11,6 +11,7 @@ import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { isMap, isScalar, isSeq, type Node, type Pair } from "yaml";
 import type { MdAst } from "./ast.js";
 import type { JsoncValue } from "./jsonc/ast.js";
+import { resolveJsoncPositionalSegment } from "./jsonc/resolve-value.js";
 import type { JsonlAst, JsonlLine } from "./jsonl/ast.js";
 import { pickJsonlLine } from "./jsonl/line.js";
 import type { OcPath, PredicateSpec } from "./oc-path.js";
@@ -303,11 +304,15 @@ const jsoncOps: WalkOps<JsoncValue> = {
     return null;
   },
   positional(node, seg) {
-    const concrete = positionalForJsoncNode(node, seg);
+    const concrete = resolveJsoncPositionalSegment(node, seg);
     if (concrete === null) {
       return null;
     }
-    return jsoncOps.lookup(node, concrete);
+    const match = jsoncOps.lookup(node, concrete);
+    if (match === null || node.kind !== "object") {
+      return match;
+    }
+    return { keySub: quoteSeg(concrete), child: match.child };
   },
   *predicate(node, pred) {
     if (node.kind === "object") {
@@ -326,17 +331,6 @@ const jsoncOps: WalkOps<JsoncValue> = {
   },
   walk: walkJsonc,
 };
-
-function positionalForJsoncNode(node: JsoncValue, seg: string): string | null {
-  if (node.kind === "object") {
-    const keys = node.entries.map((e) => e.key);
-    return resolvePositionalSeg(seg, { indexable: false, size: keys.length, keys });
-  }
-  if (node.kind === "array") {
-    return resolvePositionalSeg(seg, { indexable: true, size: node.items.length });
-  }
-  return null;
-}
 
 // ---------- JSONL walker ---------------------------------------------------
 

--- a/extensions/oc-path/src/oc-path/jsonc/edit.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/edit.ts
@@ -5,13 +5,13 @@ import {
   isPositionalSeg,
   isQuotedSeg,
   parseArrayIndexSegment,
-  resolvePositionalSeg,
   splitRespectingBrackets,
   unquoteSeg,
 } from "../oc-path.js";
 import { OcEmitSentinelError, REDACTED_SENTINEL } from "../sentinel.js";
 import type { JsoncAst, JsoncValue } from "./ast.js";
 import { parseJsonc } from "./parse.js";
+import { resolveJsoncPositionalSegment } from "./resolve-value.js";
 
 type JsoncEditPath = Array<string | number>;
 type JsoncEditTarget = { readonly path: JsoncEditPath; readonly value: JsoncValue };
@@ -126,7 +126,7 @@ function resolveEditTarget(root: JsoncValue, segments: readonly string[]): Jsonc
       return null;
     }
     if (isPositionalSeg(segment)) {
-      const concrete = positionalForJsonc(current, segment);
+      const concrete = resolveJsoncPositionalSegment(current, segment);
       if (concrete !== null) {
         segment = concrete;
       }
@@ -152,17 +152,6 @@ function resolveEditTarget(root: JsoncValue, segments: readonly string[]): Jsonc
     return null;
   }
   return { path: out, value: current };
-}
-
-function positionalForJsonc(node: JsoncValue, segment: string): string | null {
-  if (node.kind === "object") {
-    const keys = node.entries.map((entry) => entry.key);
-    return resolvePositionalSeg(segment, { indexable: false, size: keys.length, keys });
-  }
-  if (node.kind === "array") {
-    return resolvePositionalSeg(segment, { indexable: true, size: node.items.length });
-  }
-  return null;
 }
 
 function jsoncValueToJson(value: JsoncValue): unknown {

--- a/extensions/oc-path/src/oc-path/jsonc/resolve-value.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/resolve-value.ts
@@ -23,7 +23,7 @@ export function resolveJsoncValueOcPath(
       return null;
     }
     if (isPositionalSeg(seg)) {
-      const concrete = positionalForJsonc(current, seg);
+      const concrete = resolveJsoncPositionalSegment(current, seg);
       if (concrete !== null) {
         seg = concrete;
       }
@@ -60,7 +60,7 @@ export function resolveJsoncValueOcPath(
   return { kind: "value", node: current, path: walked };
 }
 
-function positionalForJsonc(node: JsoncValue, seg: string): string | null {
+export function resolveJsoncPositionalSegment(node: JsoncValue, seg: string): string | null {
   if (node.kind === "object") {
     const keys = node.entries.map((e) => e.key);
     return resolvePositionalSeg(seg, { indexable: false, size: keys.length, keys });

--- a/extensions/oc-path/src/oc-path/tests/find.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/find.test.ts
@@ -117,6 +117,31 @@ describe("findOcPaths — JSONC kind", () => {
       }
     }
   });
+
+  it.each([
+    {
+      name: "quotes positional object keys",
+      raw: '{"items":{"zeta.key":10,"alpha":20}}',
+      pattern: "oc://config/items/$first",
+      expectedPath: 'oc://config/items/"zeta.key"',
+      expectedValue: "10",
+    },
+    {
+      name: "emits positional array indexes",
+      raw: '{"items":[10,20,30]}',
+      pattern: "oc://config/items/$last",
+      expectedPath: "oc://config/items/2",
+      expectedValue: "30",
+    },
+  ])("$name", ({ raw, pattern, expectedPath, expectedValue }) => {
+    const ast = parseJsonc(raw).ast;
+    const out = findOcPaths(ast, parseOcPath(pattern));
+
+    expect(out).toHaveLength(1);
+    const result = requireFirstResult(out);
+    expect(formatOcPath(result.path)).toBe(expectedPath);
+    expect(result.match.kind === "leaf" && result.match.valueText).toBe(expectedValue);
+  });
 });
 
 describe("findOcPaths — slash-deep JSONC paths", () => {


### PR DESCRIPTION
## Summary

- reuse one JSONC positional-segment resolver across find, edit, and value resolution
- quote object-key substitutions emitted by `findOcPaths`
- preserve numeric positional paths for JSONC arrays

## Why

`findOcPaths` emitted positional JSONC object keys as bare OC Path segments. Keys containing path syntax such as `zeta.key` therefore produced a path that could not resolve back to the matched value, and the lookup returned no result. The JSONC owner now resolves positional segments once and applies the existing OC Path quoting contract when emitting object keys.

## Verification

- current-main reproduction: the dotted positional key returned no result (`count: 0`)
- exact-head focused tests: 63 passed
- native owner/sibling review selection: 315 passed
- exact-head Blacksmith Testbox: 63 passed on `tbx_01m10wbc2zf30308nga0etbwp9` (https://github.com/openclaw/openclaw/actions/runs/33043827176)
- Testbox SHA sync: expected, local, live PR head, fetched PR head, and remote checkout all `73bd5efeb27d1b9d8443badb703dad37ee0ca154`; remote fetch synchronized
- Testbox result: `exitCode: 0`, `runStatus: succeeded`
- fresh structured autoreview: clean, 0.87
- `git diff --check`

## ClawSweeper disposition

- reviewed exact head `73bd5efeb27d1b9d8443badb703dad37ee0ca154` with no findings
- merge-risk move: zero touched-file drift against current main and a clean merge tree; no rebase warranted
- next-step move: ordinary maintainer handling is being completed through the native `scripts/pr` prepare and squash-merge flow

## Surface

- production: +11/-28 (net -17)
- tests: +25/-0
- no config, persistence, protocol, or compatibility change

No `CHANGELOG.md` edit: release-only per repository policy; the landing flow owns the user-facing entry.
