### PR TITLE
fix(ui): show frozen elapsed time for stopped goals

### DIFF
--- a/ui/src/e2e/chat-goal-elapsed.e2e.test.ts
+++ b/ui/src/e2e/chat-goal-elapsed.e2e.test.ts
@@ -1,0 +1,82 @@
+// Real-browser proof of frozen goal timing on the chat composer.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Control UI goal elapsed time" });
+const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const artifactDir = path.resolve(".artifacts/control-ui-e2e/goal-elapsed");
+
+suite.define(() => {
+  it("shows a paused goal's frozen duration before and after opening details and reloading", async () => {
+    if (captureProof) {
+      await mkdir(artifactDir, { recursive: true });
+    }
+    await suite.withPage(
+      {
+        colorScheme: "light",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { width: 1440, height: 900 },
+        ...(captureProof
+          ? { recordVideo: { dir: artifactDir, size: { width: 1440, height: 900 } } }
+          : {}),
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          sessionKey: "agent:main:main",
+          historyMessages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "Deployment checks are ready." }],
+            },
+          ],
+          methodResponses: {
+            "sessions.list": {
+              ts: 61_000,
+              path: "",
+              count: 1,
+              defaults: { model: "gpt-5.6-luna", modelProvider: "openai", contextTokens: 128_000 },
+              sessions: [
+                {
+                  key: "agent:main:main",
+                  kind: "direct",
+                  displayName: "Deployment checks",
+                  updatedAt: 61_000,
+                  goal: {
+                    schemaVersion: 1,
+                    id: "goal-timing",
+                    objective: "Verify the deployment",
+                    status: "paused",
+                    createdAt: 1_000,
+                    updatedAt: 61_000,
+                    pausedAt: 61_000,
+                    tokenStart: 0,
+                    tokensUsed: 100,
+                    continuationTurns: 0,
+                  },
+                },
+              ],
+            },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}chat/main`);
+        const goal = page.locator(".agent-chat__goal");
+        await goal.getByText("Goal paused", { exact: true }).waitFor();
+        if (captureProof) {
+          await page.screenshot({ path: path.join(artifactDir, "paused-goal.png") });
+        }
+        expect(await goal.locator(".agent-chat__goal-elapsed").textContent()).toBe("1m");
+        await goal.getByRole("button", { name: "Show goal details" }).click();
+        expect(await goal.locator(".agent-chat__goal-detail-meta").textContent()).toContain("1m");
+        await goal.getByRole("button", { name: "Hide goal details" }).click();
+        expect(await goal.locator(".agent-chat__goal-elapsed").textContent()).toBe("1m");
+        await page.reload();
+        await goal.getByText("Goal paused", { exact: true }).waitFor();
+        expect(await goal.locator(".agent-chat__goal-elapsed").textContent()).toBe("1m");
+      },
+    );
+  });
+});

--- a/ui/src/pages/chat/chat-composer-goal.test.ts
+++ b/ui/src/pages/chat/chat-composer-goal.test.ts
@@ -1,0 +1,101 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionGoal } from "../../api/types.ts";
+import { i18n } from "../../i18n/index.ts";
+import { renderChatGoal, clearGoalElapsedTimers } from "./components/chat-composer-goal.ts";
+import { getChatComposerState, resetChatComposerState } from "./components/chat-composer-state.ts";
+
+const goal: SessionGoal = {
+  schemaVersion: 1,
+  id: "goal-timing",
+  objective: "Verify the deployment",
+  status: "active",
+  createdAt: 1_000,
+  updatedAt: 61_000,
+  tokenStart: 0,
+  tokensUsed: 100,
+  continuationTurns: 0,
+};
+
+function mountGoal(initial: SessionGoal) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const state = getChatComposerState("goal-timing");
+  const draw = (value: SessionGoal | undefined) =>
+    render(renderChatGoal(state, value, { canAct: false, requestUpdate: () => {} }), container);
+  const part = draw(initial);
+  return {
+    container,
+    draw,
+    part,
+    elapsed: () => container.querySelector(".agent-chat__goal-elapsed")?.textContent,
+  };
+}
+
+describe("goal elapsed presentation", () => {
+  beforeEach(async () => {
+    await i18n.setLocale("en");
+    vi.useFakeTimers();
+    vi.setSystemTime(121_000);
+  });
+
+  afterEach(() => {
+    clearGoalElapsedTimers();
+    resetChatComposerState();
+    document.body.replaceChildren();
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ["active", "2m"],
+    ["paused", "1m"],
+    ["blocked", "1m"],
+    ["usage_limited", "1m"],
+    ["budget_limited", "1m"],
+    ["complete", "1m"],
+  ] as const)("renders elapsed time immediately for %s goals", (status, elapsed) => {
+    const view = mountGoal({ ...goal, status });
+    expect(view.elapsed()).toBe(elapsed);
+  });
+
+  it("replaces a live tick with the authoritative stop time and resumes ticking", () => {
+    const view = mountGoal(goal);
+    vi.advanceTimersByTime(1_000);
+    expect(view.elapsed()).toBe("2m");
+
+    view.draw({ ...goal, status: "paused", pausedAt: 46_000 });
+    expect(view.elapsed()).toBe("45s");
+    vi.advanceTimersByTime(60_000);
+    expect(view.elapsed()).toBe("45s");
+
+    view.draw(goal);
+    expect(view.elapsed()).toBe("3m");
+    vi.advanceTimersByTime(60_000);
+    expect(view.elapsed()).toBe("4m");
+
+    view.draw({ ...goal, status: "complete", completedAt: 151_000 });
+    expect(view.elapsed()).toBe("2m");
+    vi.advanceTimersByTime(60_000);
+    expect(view.elapsed()).toBe("2m");
+  });
+
+  it("retires the active timer when the goal is removed", () => {
+    const view = mountGoal(goal);
+    expect(vi.getTimerCount()).toBe(1);
+    view.draw(undefined);
+    expect(view.container.querySelector(".agent-chat__goal")).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("retires and resumes the active timer with the rendered host connection", () => {
+    const view = mountGoal(goal);
+    view.part.setConnected(false);
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(60_000);
+    view.part.setConnected(true);
+    expect(view.elapsed()).toBe("3m");
+    expect(vi.getTimerCount()).toBe(1);
+  });
+});

--- a/ui/src/pages/chat/components/chat-composer-goal.ts
+++ b/ui/src/pages/chat/components/chat-composer-goal.ts
@@ -35,11 +35,14 @@ function createGoalElapsedRef(goal: SessionGoal) {
       clearGoalElapsedTimer(bound);
       bound = null;
     }
-    if (!(element instanceof HTMLElement) || goal.status !== "active") {
+    if (!(element instanceof HTMLElement)) {
+      return;
+    }
+    element.textContent = formatGoalElapsed(goalElapsedMs(goal, Date.now()));
+    if (goal.status !== "active") {
       return;
     }
     bound = element;
-    element.textContent = formatGoalElapsed(goalElapsedMs(goal, Date.now()));
     const timer = setInterval(() => {
       // Tests and detached renders can drop the pill without a final ref call.
       if (!element.isConnected) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainer-editable branch in the upstream repository. AI-assisted with Codex.

</details>

## What Problem This Solves

Fixes an issue where users opening a paused, blocked, limited, or completed goal would see no elapsed time in the collapsed card above the chat composer. Stopping an already-visible active goal could instead leave its previous live duration in place.

Closes #130500.

## Why This Change Was Made

Initialize the elapsed label for every goal status in the existing rendering owner, then start the interval only for active goals. This keeps one owner for the DOM text and preserves timer retirement on status changes, goal removal, and host disconnection. Goal state, timestamps, storage, commands, and timing semantics are unchanged.

The existing formatter already freezes stopped goals at their corresponding status timestamp. Reintroducing a separate template text value would mix Lit child-part ownership with direct timer text updates, so this repair stays in the existing ref lifecycle.

## User Impact

Stopped goals immediately show their correct frozen duration, including after reload or an active-to-stopped transition. Active goals continue ticking, and expanding or collapsing details preserves the same duration.

## Evidence

- Before repair: six rendered failures across all five stopped states and an active-to-paused transition; three active/cleanup controls passed. The actual Chromium flow also failed with an empty paused-goal label.
- After repair: 85 focused tests across four files and one real Chromium E2E passed. Independent verification repeated those checks and observed 22 additional fixture-driven transitions, including timestamp fallbacks, resume, goal replacement/removal, and navigation.
- Full changed-file checks passed, including formatting, type checking, typed lint, UI styles, and all three unused-export scans. Authenticated Codex review reported no actionable findings.
- A fresh source-blind Chromium validator passed all five written behavior clauses with no findings: stopped-state timestamps and fallbacks, active ticking and pause, resume and replacement, details/reload, and removal/reintroduction/navigation. Fixture IDs, objectives, and durations were varied to rule out static labels. The validator used only normal UI interactions and the declared synthetic fixture API.

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs ui/src/pages/chat/chat-composer-goal.test.ts ui/src/lib/session-goal.test.ts ui/src/pages/chat/chat-composer-actions.test.ts ui/src/pages/chat/chat-composer.test.ts
OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-goal-elapsed.e2e.test.ts
node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-composer-goal.ts ui/src/pages/chat/chat-composer-goal.test.ts ui/src/e2e/chat-goal-elapsed.e2e.test.ts
```

Before: the paused card has no elapsed duration.

![Paused goal before the fix: duration missing](https://github.com/user-attachments/assets/2eb70e9a-d969-4dc0-8cf1-eb57bd3b00df)

After: the same paused card immediately shows its recorded one-minute duration.

![Paused goal after the fix: one-minute duration visible](https://github.com/user-attachments/assets/6823fc2e-66fe-4423-acfa-f0e2a3b85339)

Production LOC: +5/-2 (net +3), separating initialization for all statuses from active-only interval ownership. Tests: +183/-0. No new production helper, timer owner, configuration, or persisted state.

Provenance: source regression introduced by #124301 (64853b1a9d505dc3980e4bedfc39ee79c043ffbf), authored by @vyctorbrzezowski and merged by @steipete on August 25, 2026. Stable-release reachability was not established.

Proof boundary: the browser runs the real Control UI with synthetic session data and a declared mock Gateway. No operator Gateway, actual agent goal, or external model was modified or invoked.
