### PR TITLE
Restore Codex completion notifications after reconnecting

### DIFF
--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -190,6 +190,7 @@ export type CodexThreadStartParams = JsonObject & {
 
 export type CodexThreadResumeParams = JsonObject & {
   threadId: string;
+  experimentalRawEvents?: boolean;
   cwd?: string | null;
   runtimeWorkspaceRoots?: string[] | null;
   model?: string;

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -6347,6 +6347,7 @@ describe("runCodexAppServerAttempt", () => {
       approvalsReviewer: "guardian_subagent",
       sandbox: "danger-full-access",
       serviceTier: "priority",
+      experimentalRawEvents: true,
     });
     const resumeRequest = requests.find((request) => request.method === "thread/resume");
     const resumeRequestParams = resumeRequest?.params as Record<string, unknown> | undefined;

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -277,6 +277,9 @@ export function buildThreadResumeParams(
       });
   return {
     threadId: options.threadId,
+    // Raw completion receipts are a live subscription, not persisted thread state.
+    // Re-enable them after reconnecting so native child results are not announced twice.
+    experimentalRawEvents: true,
     ...(options.cwd ? { cwd: options.cwd } : {}),
     ...(options.appServer.sessionRoot
       ? { runtimeWorkspaceRoots: [options.appServer.sessionRoot] }


### PR DESCRIPTION
OpenClaw enables raw Codex response events when starting a conversation, but does not request them when resuming one. A cold resume can therefore hide the native completion receipts used by the subagent monitor, causing a result that already reached the parent to be announced again.

Renew that opt-in in the shared resume request builder, including warm-resume bindings. This complements the completion-ownership fix in #130311 and #130347 without changing owner configuration, stored conversation history, or retry policy. Older app-server releases accept and ignore the field; restoring notifications requires an app-server release that supports the resume opt-in.
