### PR TITLE
refactor(android): remove unused sidebar and mascot paths

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarComponents.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarComponents.kt
@@ -1,11 +1,8 @@
 package ai.openclaw.app.ui
 
-import ai.openclaw.app.GatewayAgentSummary
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.i18n.nativeString
-import ai.openclaw.app.ui.design.ClawAgentAvatar
 import ai.openclaw.app.ui.design.ClawTheme
-import ai.openclaw.app.ui.design.agentAvatarSource
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -113,49 +110,6 @@ internal fun SidebarSectionTitle(
     modifier = modifier.semantics { heading() }.padding(horizontal = 12.dp, vertical = 6.dp),
     maxLines = 1,
   )
-}
-
-@Composable
-internal fun SidebarAgentRow(
-  agent: GatewayAgentSummary,
-  selected: Boolean,
-  palette: SidebarPalette,
-  onClick: () -> Unit,
-) {
-  SidebarRowSurface(
-    selected = selected,
-    stateDescription = if (selected) nativeString("Selected") else null,
-    palette = palette,
-    onClick = onClick,
-  ) {
-    ClawAgentAvatar(source = agentAvatarSource(agent), size = 28.dp) {
-      Box(
-        modifier = Modifier.size(28.dp).clip(CircleShape).background(palette.elevated),
-        contentAlignment = Alignment.Center,
-      ) {
-        Text(
-          text = agent.emoji?.takeIf(String::isNotBlank) ?: sidebarAgentName(agent).take(1).uppercase(),
-          style = ClawTheme.type.caption,
-          color = palette.text,
-        )
-      }
-    }
-    Text(
-      text = sidebarAgentName(agent),
-      style = ClawTheme.type.body,
-      color = palette.text,
-      modifier = Modifier.weight(1f),
-      maxLines = 1,
-      overflow = TextOverflow.Ellipsis,
-    )
-    if (selected) {
-      Text(
-        text = nativeString("Selected"),
-        style = ClawTheme.type.caption.copy(fontSize = 11.sp),
-        color = palette.muted,
-      )
-    }
-  }
 }
 
 @Composable

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarContent.kt
@@ -137,8 +137,6 @@ private fun ChatSessionEntry.isDashboardSession(): Boolean {
 
 internal fun sidebarSessionTitle(session: ChatSessionEntry): String = sessionPresentationTitle(session) { session.key }
 
-internal fun sidebarAgentName(agent: GatewayAgentSummary): String = agentPickerName(agent)
-
 internal data class SidebarPalette(
   val background: Color,
   val elevated: Color,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/design/MascotAnimator.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/design/MascotAnimator.kt
@@ -12,7 +12,6 @@ private const val NONZERO_SEED: ULong = 0x9E37_79B9_7F4A_7C15uL
 private const val XORSHIFT_MULTIPLIER: ULong = 2_685_821_657_736_338_717uL
 private const val TAU = PI * 2.0
 private const val BLINK_DURATION = 0.16
-private const val CATCH_DURATION = 0.8
 
 private enum class Gesture {
   Wave,
@@ -109,9 +108,6 @@ class MascotAnimator(
   private var currentGaze = MascotGaze()
   private var nextClawSnapAt = 0.0
   private var nextMoodBeatAt = 0.0
-  private var teaseActive = false
-  private var teaseChangedAt = 0.0
-  private var catchStartedAt: Double? = null
 
   fun setMood(
     mood: MascotMood,
@@ -124,18 +120,6 @@ class MascotAnimator(
     activeGesture = null
     rescheduleMoodBeat(timeSeconds)
     entranceGesture(mood)?.let { startGesture(it, timeSeconds) }
-  }
-
-  fun setTease(
-    active: Boolean,
-    timeSeconds: Double,
-  ) {
-    teaseActive = active
-    teaseChangedAt = timeSeconds
-  }
-
-  fun playCatch(timeSeconds: Double) {
-    catchStartedAt = timeSeconds
   }
 
   fun poseAt(timeSeconds: Double): MascotPose {
@@ -156,23 +140,6 @@ class MascotAnimator(
         activeGesture = null
       } else {
         applyGesture(gesture, pose, progress)
-      }
-    }
-
-    if (teaseActive && timeSeconds >= teaseChangedAt) {
-      pose.mouthRound = max(pose.mouthRound, 0.5)
-      pose.gaze = MascotGaze(x = 0.0, y = 0.6)
-    }
-    catchStartedAt?.let { startedAt ->
-      val progress = (timeSeconds - startedAt) / CATCH_DURATION
-      if (progress >= 1.0) {
-        catchStartedAt = null
-      } else if (progress >= 0.0) {
-        val flash = bell(progress)
-        applyGesture(Gesture.ClawSnap, pose, clamp(progress / 0.75))
-        pose.happyEyes = max(pose.happyEyes, 0.9 * flash)
-        pose.mouthCurve = max(pose.mouthCurve, 0.7 * flash)
-        pose.blush = max(pose.blush, 0.65 * flash)
       }
     }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch, so maintainers can edit it through repository write access. GitHub's separate fork-collaboration switch applies only to cross-repository PRs.

</details>

## What Problem This Solves

Android retained an unused sidebar agent row after #128309 moved the live sidebar to the canonical agent picker. Its mascot animator also retained tease/catch controls that the Android owner never calls. These orphan paths add maintenance work without providing an app capability.

## Why This Change Was Made

Remove the unreachable sidebar row and its name wrapper, plus the animator's uncalled controls and exclusively owned state/branches. Whole-repository symbol searches, history, caller tracing, tests, application build configuration and resource/reflection checks show no Android entrypoint depends on them. The only Android animator instance stays local to `OpenClawMascot`, which uses `setMood` and `poseAt`; removing permanently inactive branches preserves scheduling and random-number consumption.

The live `AgentPicker`, sidebar/session navigation, all mascot moods, static/tinted rendering, pose clamps and existing tests are unchanged. Same-named live web mascot controls remain untouched. This application-internal deletion does not remove a published library contract.

Production LOC: **+0/-81 (net -81)** across three Kotlin files. Tests, generated resources, documentation and tooling: unchanged. No new tests are needed for deletion of unreachable paths; retained owner behavior is covered below.

## User Impact

No user-visible behavior or appearance changes. No screenshots apply to these unreachable source paths. No on-device interaction is claimed; no Android device was attached during this proof.

## Evidence

Proof used commit `4430fd236e7dd9f8b44ec9eaf6caaac8dd425c46`, based on `a482a50cda8850e9479d28a1ae29785a509841b2`, tree `a12556e44f06687b7d66590564b756807275e93a`. The normalized full-index patch SHA256 stayed `6a8e695d22d81a220cf53e4604a25ac57c436dc96adc494fddc54301c659ac84` through independent review, remote proof and commit.

Independent Codex review completed successfully with no findings. Actual execution proof ran in an isolated candidate checkout on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/33023561195), lease `tbx_01m106hegthzx4zjht80r8tbhq`. Base, complete patch hash and changed file blobs were attested before/after. Canonical dependency fingerprints matched, and actual workspace-package resolution was checked against candidate sources. The candidate checkout and lease were removed/stopped after proof.

Toolchain: Temurin Java 17.0.18, repository Gradle 9.7.0, pinned command-line tools archive 15859902, Android platform 37.0 revision 2, build-tools 36.0.0. SDK setup occurred only inside the ephemeral box.

All commands below completed with exit 0:

```sh
node --import tsx scripts/native-app-i18n.ts verify
```

Verified 4,298 native entries; `changed=false`.

```sh
node --import tsx scripts/run-android-gradle.mts \
  --no-daemon --build-cache \
  :app:testPlayDebugUnitTest \
  --tests ai.openclaw.app.ui.AgentPickerTest \
  --tests ai.openclaw.app.ui.SidebarShellLogicTest \
  --tests ai.openclaw.app.ui.design.MascotAnimatorTest \
  --tests ai.openclaw.app.ui.design.EffectiveMascotMoodTest \
  :app:testThirdPartyDebugUnitTest \
  --tests ai.openclaw.app.ui.AgentPickerTest \
  --tests ai.openclaw.app.ui.SidebarShellLogicTest \
  --tests ai.openclaw.app.ui.design.MascotAnimatorTest \
  --tests ai.openclaw.app.ui.design.EffectiveMascotMoodTest \
  :app:ktlintCheck
```

Both flavors passed all 23 selected tests each: **46 tests, zero failures/errors/skips**, verified from JUnit XML. App Kotlin lint passed. Coverage includes picker selection/fallback, sidebar session/navigation behavior, mascot mood bounds, seeded determinism, mood transitions, working effects and effective rendering mood.

```sh
node --import tsx scripts/run-android-gradle.mts \
  --no-daemon --build-cache \
  :app:assemblePlayDebug :app:assembleThirdPartyDebug \
  :app:lintPlayDebug :app:lintThirdPartyDebug
```

Both debug APKs assembled and both Android framework lint tasks passed.

```sh
node scripts/check-changed.mjs -- \
  apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarComponents.kt \
  apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarContent.kt \
  apps/android/app/src/main/java/ai/openclaw/app/ui/design/MascotAnimator.kt
git diff --check
```

Canonical changed-file checks passed. Its Linux lane explicitly skipped Swift app lint because SwiftLint was unavailable; no Swift files changed. Oxfmt matched no Kotlin files, so the actual app `ktlintCheck` above supplies Kotlin formatting proof.

An earlier full-checkout sync attempt on lease `tbx_01m105yrqpkkfbrd40e3jz6qfv` hit the provider's fixed file-sync timeout before executing the proof command. That lease was stopped. The supported detached remote checkout route above then completed all proof; no timeout increase or passing claim from the failed attempt.
