### PR TITLE
fix(browser): hidden selectors prematurely complete waits

### DIFF
--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -5,7 +5,6 @@ import { setTimeout as sleep } from "node:timers/promises";
  * Dispatches normalized actions to either Playwright-backed OpenClaw browser
  * control or Chrome MCP existing-session operations with navigation guards.
  */
-import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
 import {
   ChromeMcpDocumentUnavailableError,
@@ -202,33 +201,39 @@ function buildExistingSessionWaitPredicate(params: {
   loadState?: "load" | "domcontentloaded" | "networkidle";
   fn?: string;
 }): string | null {
-  const checks: string[] = [];
-  if (params.text) {
-    checks.push(`Boolean(document.body?.innerText?.includes(${JSON.stringify(params.text)}))`);
-  }
-  if (params.textGone) {
-    checks.push(`!document.body?.innerText?.includes(${JSON.stringify(params.textGone)})`);
-  }
-  if (params.selector) {
-    checks.push(`Boolean(document.querySelector(${JSON.stringify(params.selector)}))`);
-  }
-  if (params.loadState === "domcontentloaded") {
-    checks.push(`document.readyState === "interactive" || document.readyState === "complete"`);
-  } else if (params.loadState === "load") {
-    checks.push(`document.readyState === "complete"`);
-  }
-  if (params.fn) {
+  const checks = [
+    params.text && `Boolean(document.body?.innerText?.includes(${JSON.stringify(params.text)}))`,
+    params.textGone && `!document.body?.innerText?.includes(${JSON.stringify(params.textGone)})`,
+    params.selector &&
+      `(function visible(node) {
+      if (!node) return false;
+      if (node.nodeType === 1) {
+        // Like managed waits, display:contents is visible through rendered children.
+        if (getComputedStyle(node).display === "contents") {
+          return Array.from(node.childNodes).some(visible);
+        }
+        if (!node.checkVisibility({ visibilityProperty: true })) return false;
+      } else if (node.nodeType !== 3) {
+        return false;
+      }
+      const range = document.createRange();
+      range.selectNode(node);
+      const rect = node.nodeType === 1 ? node.getBoundingClientRect() : range.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    })(document.querySelector(${JSON.stringify(params.selector)}))`,
+    params.loadState === "domcontentloaded" &&
+      `document.readyState === "interactive" || document.readyState === "complete"`,
+    params.loadState === "load" && `document.readyState === "complete"`,
     // `fn` is admitted only by the same evaluateEnabled gate as evaluate.
     // Preserve its async semantics; document binding guards scheduler rebinding.
-    const source = normalizeBrowserEvaluateFunctionSource(params.fn);
-    checks.push(`Boolean(await (${source})())`);
-  }
-  if (checks.length === 0) {
-    return null;
-  }
-  return checks.length === 1
-    ? expectDefined(checks.at(0), "single existing-session condition")
-    : checks.map((check) => `(${check})`).join(" && ");
+    params.fn && `Boolean(await (${normalizeBrowserEvaluateFunctionSource(params.fn)})())`,
+  ];
+  return (
+    checks
+      .filter(Boolean)
+      .map((check) => `(${check})`)
+      .join(" && ") || null
+  );
 }
 
 async function waitForExistingSessionCondition(

--- a/extensions/browser/src/browser/routes/agent.act.wait-visibility.chromium.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.wait-visibility.chromium.test.ts
@@ -1,0 +1,139 @@
+import { setTimeout as sleep } from "node:timers/promises";
+import type { Browser, Page } from "playwright-core";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { getPlaywrightCore } from "../playwright-core.runtime.js";
+import { createExistingSessionAgentSharedModule } from "./existing-session.test-support.js";
+import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helpers.js";
+
+const browserState = vi.hoisted(() => ({ page: undefined as Page | undefined }));
+vi.mock("../chrome-mcp.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../chrome-mcp.js")>()),
+  withChromeMcpDocument: async (
+    _params: unknown,
+    task: (document: { evaluate: (fn: string) => Promise<unknown> }) => Promise<unknown>,
+  ) => {
+    const page = browserState.page;
+    if (!page) {
+      throw new Error("Chromium page is not initialized");
+    }
+    return await task({ evaluate: (fn) => page.evaluate(`(${fn})(document)`) });
+  },
+}));
+vi.mock("./agent.shared.js", () => createExistingSessionAgentSharedModule());
+
+const { registerBrowserAgentActRoutes } = await import("./agent.act.js");
+
+describe.runIf(process.env.OPENCLAW_BROWSER_WAIT_E2E === "1")(
+  "existing-session selector wait visibility in Chromium",
+  () => {
+    let browser: Browser;
+    let page: Page;
+    beforeAll(async () => {
+      browser = await getPlaywrightCore().chromium.launch({
+        headless: true,
+        executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+      });
+      page = await browser.newPage();
+      browserState.page = page;
+    });
+    afterAll(async () => {
+      browserState.page = undefined;
+      await browser?.close();
+    });
+
+    async function waitForSelector(selector: string, extra: Record<string, unknown> = {}) {
+      const { app, postHandlers } = createBrowserRouteApp();
+      registerBrowserAgentActRoutes(app, {
+        state: () => ({ resolved: { evaluateEnabled: true } }),
+      } as never);
+      const handler = postHandlers.get("/act");
+      if (!handler) {
+        throw new Error("Missing /act route");
+      }
+      const response = createBrowserRouteResponse();
+      await handler(
+        { params: {}, query: {}, body: { kind: "wait", selector, timeoutMs: 250, ...extra } },
+        response.res,
+      );
+      return response;
+    }
+
+    it.each([
+      ["display:none", '<button id="target" style="display:none">Ready</button>'],
+      ["visibility:hidden", '<button id="target" style="visibility:hidden">Ready</button>'],
+      ["hidden attribute", '<button id="target" hidden>Ready</button>'],
+      ["zero width", '<div id="target" style="width:0;height:10px"></div>'],
+      ["zero height", '<div id="target" style="width:10px;height:0"></div>'],
+      ["empty display:contents", '<div id="target" style="display:contents"></div>'],
+      [
+        "closed details",
+        '<details><summary>Open</summary><button id="target">Ready</button></details>',
+      ],
+      ["missing element", "<p>No target</p>"],
+    ])("does not report success for %s", async (_name, html) => {
+      await page.setContent(html);
+      await expect(waitForSelector("#target")).rejects.toThrow("Timed out waiting for condition");
+    });
+
+    it.each([
+      ["ordinary element", '<button id="target">Ready</button>'],
+      ["opacity zero", '<button id="target" style="opacity:0">Ready</button>'],
+      [
+        "offscreen element",
+        '<button id="target" style="position:absolute;left:-10000px">Ready</button>',
+      ],
+      [
+        "display:contents element child",
+        '<div id="target" style="display:contents"><button>Ready</button></div>',
+      ],
+      ["display:contents text child", '<div id="target" style="display:contents">Ready</div>'],
+    ])("accepts a visible %s", async (_name, html) => {
+      await page.setContent(html);
+      expect((await waitForSelector("#target")).statusCode).toBe(200);
+    });
+
+    it("waits for the first match to become visible rather than accepting another match", async () => {
+      await page.setContent(
+        '<button class="target" hidden>First</button><button class="target">Second</button>',
+      );
+      let settled = false;
+      const pending = waitForSelector(".target", { timeoutMs: 2_000 }).then((response) => {
+        settled = true;
+        return response;
+      });
+      try {
+        await sleep(400);
+        expect(settled).toBe(false);
+        await page
+          .locator(".target")
+          .first()
+          .evaluate((element) => element.removeAttribute("hidden"));
+        expect((await pending).statusCode).toBe(200);
+      } finally {
+        await pending;
+      }
+    });
+
+    it("preserves invalid-selector errors", async () => {
+      await expect(waitForSelector("[")).rejects.toThrow("not a valid selector");
+    });
+
+    it("preserves combined-condition short-circuiting and async function waits", async () => {
+      await page.setContent('<button id="target">Ready</button>');
+      await expect(
+        waitForSelector("#target", {
+          text: "Not ready",
+          fn: '() => { document.title = "should not run"; return true; }',
+        }),
+      ).rejects.toThrow("Timed out waiting for condition");
+      expect(await page.title()).not.toBe("should not run");
+      const ready = await waitForSelector("#target", {
+        text: "Ready",
+        textGone: "Not ready",
+        loadState: "load",
+        fn: "async () => { await Promise.resolve(); return true; }",
+      });
+      expect(ready.statusCode).toBe(200);
+    });
+  },
+);


### PR DESCRIPTION
Closes #130507

## What Problem This Solves

Fixes an issue where users waiting for a browser selector would receive success while its first matching element remained hidden in an existing-session profile.

## Why This Change Was Made

The existing-session wait checked only DOM presence, while the documented operation and managed browser implementation require visibility. The owning predicate now checks rendered visibility and a nonzero box, including rendered children of `display:contents`. Transparent and offscreen elements remain valid, matching the managed browser contract.

The ordered predicate builder is simplified into one canonical combination path. Document binding, navigation checks, function-evaluation permissions, asynchronous predicates, and condition short-circuiting are preserved. No runtime configuration, authentication, protocol, persistence, SDK, or dependency changes.

## User Impact

Existing-session selector waits now continue until the first matching element becomes visible or the wait fails. A later visible match no longer causes a hidden first match to be accepted.

## Evidence

- Actual pre-fix HTTP + Chrome MCP + isolated Chromium comparison: 28 requests covering 14 fixtures on existing-session and managed profiles. Seven hidden-element cases falsely succeeded only in existing-session mode.
- Repaired real-transport matrix: all 30 expected outcomes pass, including both drivers waiting for a delayed reveal of the first matching element.
- Fresh source-blind validation: all six behavior clauses pass on both transports (12 profile/contract checks, 32 actual wait requests), including varied case order, hidden-first/visible-second controls, delayed reveal, and successful reuse after timeout/invalid-selector failures.
- Focused owner/sibling tests: 72 passed across the Chromium regression, existing-session routes, navigation guards, and managed wait coverage. The final test-only lint cleanup was rechecked with the same 16 Chromium cases; these are overlapping reruns, not 88 unique tests.
- Independent owner/sibling verification: 84 tests passed.
- The added Chromium regression failed eight cases on the pre-fix owner. It executes the generated wait predicate in a real browser DOM; it does not mock visibility or predicate results. Its transport adapter is separate from the real Chrome MCP HTTP proof above.
- Targeted test types, typed lint, formatting, max-lines/environment ratchets, and whitespace checks pass.
- Authenticated whole-patch Codex review through P2 completed with no actionable findings.

Run the real-DOM regression with:

```sh
OPENCLAW_BROWSER_WAIT_E2E=1 OPENCLAW_VITEST_MAX_WORKERS=1 \
  node scripts/run-vitest.mjs extensions/browser/src/browser/routes/agent.act.wait-visibility.chromium.test.ts
```

Chromium must already be installed. The test is opt-in like adjacent browser Chromium fixtures; ordinary browser CI does not install a browser.

Scope note: existing-session HTTP wait overhead remains unchanged. The source-blind run measured roughly 1.8 seconds for immediate success and 2.7 seconds for a 700ms negative wait, also observed before the fix. This repair establishes selector visibility, not a new strict end-to-end HTTP deadline.

Production LOC: +31/-26 (net +5). Tests: +139. The extra production lines implement the existing visibility contract while removing the existence-only condition and redundant single-condition path.

Provenance: the existence check originated in `593964560ba7abf458c1069dc03e7ad35afa5dc2` (2026-03-13, Peter Steinberger as code author and committer), is present in stable tag `v2026.3.22`, and was carried into the browser plugin by `8eeb7f0829754cb3446a3bc7279fbf48d38edd3c`. No originating PR was identified by the bounded history search.
