### PR TITLE
fix: dedupe replies against their resolved delivery thread

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -97,16 +97,20 @@ describe("buildReplyPayloads media filter integration", () => {
               resolveReplyTransport: ({
                 threadId,
                 replyToId,
+                replyToIsExplicit,
                 replyDelivery,
-              }: ResolveReplyTransportParams) => ({
-                replyToId:
-                  replyDelivery?.replyToMode === "off"
-                    ? threadId != null
-                      ? String(threadId)
-                      : undefined
-                    : (replyToId ?? (threadId != null ? String(threadId) : undefined)),
-                threadId: null,
-              }),
+              }: ResolveReplyTransportParams) => {
+                const allowedReply = replyDelivery?.replyToMode === "off" ? undefined : replyToId;
+                // Slack uses the known root for inherited replies, but explicit targets win.
+                const resolved =
+                  replyToIsExplicit === false
+                    ? (threadId ?? allowedReply)
+                    : (allowedReply ?? threadId);
+                return {
+                  replyToId: resolved == null ? undefined : String(resolved),
+                  threadId: null,
+                };
+              },
             },
           },
           source: "test",

--- a/src/auto-reply/reply/followup-delivery.channel.test.ts
+++ b/src/auto-reply/reply/followup-delivery.channel.test.ts
@@ -168,10 +168,17 @@ describe("follow-up delivery channel boundary", () => {
   it("dedupes later Slack replies against their actual first-mode transport thread", () => {
     const slack = createChannelPlugin("slack");
     slack.threading = {
-      resolveReplyTransport: ({ threadId, replyToId, replyToIsExplicit }) => ({
-        threadId: null,
-        replyToId: replyToIsExplicit ? replyToId : threadId == null ? undefined : String(threadId),
-      }),
+      resolveReplyTransport: ({ threadId, replyToId, replyToIsExplicit }) => {
+        const inheritedThread = threadId == null ? undefined : String(threadId);
+        // First-mode can clear replyToId; Slack still falls back to the inherited thread.
+        return {
+          threadId: null,
+          replyToId:
+            replyToIsExplicit === false
+              ? (inheritedThread ?? replyToId)
+              : (replyToId ?? inheritedThread),
+        };
+      },
     };
     setActivePluginRegistry(
       createTestRegistry([{ pluginId: "slack", plugin: slack, source: "test" }]),

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -200,14 +200,12 @@ function resolveOriginThreadIdForPayload(params: {
   replyDelivery?: ReplyDeliveryContext;
 }): string | undefined {
   const originThreadId = normalizeThreadIdForComparison(params.originatingThreadId);
-  if (originThreadId && !params.replyToIsExplicit) {
-    return originThreadId;
-  }
   const replyToId = normalizeThreadIdForComparison(params.replyToId);
   const resolveReplyTransport = getChannelPlugin(params.provider)?.threading?.resolveReplyTransport;
-  if (!replyToId || !params.config || !resolveReplyTransport) {
+  if (!params.config || !resolveReplyTransport) {
     return originThreadId;
   }
+  // Implicit replies can leave the inbound thread; dedupe must use the same transport as delivery.
   const transport = resolveReplyTransport({
     cfg: params.config,
     accountId: params.accountId,

--- a/src/auto-reply/reply/reply-payloads-transport-dedupe.test.ts
+++ b/src/auto-reply/reply/reply-payloads-transport-dedupe.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import type { ChannelThreadingAdapter } from "../../channels/plugins/types.public.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
@@ -20,7 +21,7 @@ describe("reply dedupe uses the plugin's delivery destination", () => {
             threading: {
               resolveReplyTransport: ({ replyDelivery }) =>
                 replyDelivery?.replyToMode === "off" ? { threadId: null, replyToId: null } : null,
-            },
+            } satisfies ChannelThreadingAdapter,
           },
         },
       ]),

--- a/src/auto-reply/reply/reply-payloads-transport-dedupe.test.ts
+++ b/src/auto-reply/reply/reply-payloads-transport-dedupe.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
+import { buildReplyPayloads } from "./agent-runner-payloads.js";
+import { resolveFollowupDeliveryPayloads } from "./followup-delivery-payloads.js";
+
+describe("reply dedupe uses the plugin's delivery destination", () => {
+  beforeEach(() => {
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "test-flat",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "test-flat" }),
+            threading: {
+              resolveReplyTransport: ({ replyDelivery }) =>
+                replyDelivery?.replyToMode === "off" ? { threadId: null, replyToId: null } : null,
+            },
+          },
+        },
+      ]),
+    );
+  });
+
+  it.each([
+    { mode: "off", toolThread: undefined, count: 0 },
+    { mode: "off", toolThread: "inbound-thread", count: 1 },
+    { mode: "all", toolThread: undefined, count: 1 },
+    { mode: "all", toolThread: "inbound-thread", count: 0 },
+  ] as const)(
+    "mode=$mode toolThread=$toolThread across immediate and queued replies",
+    async ({ mode, toolThread, count }) => {
+      const payloads = [{ text: "The completed answer." }];
+      const targets = [
+        {
+          tool: "message",
+          provider: "test-flat",
+          to: "room",
+          threadId: toolThread,
+          text: "The completed answer.",
+        },
+      ];
+      const result = await buildReplyPayloads({
+        config: {},
+        payloads,
+        isHeartbeat: false,
+        didLogHeartbeatStrip: false,
+        blockStreamingEnabled: false,
+        blockReplyPipeline: null,
+        replyToMode: mode,
+        replyToChannel: "test-flat",
+        currentMessageId: "current-message",
+        messageProvider: "test-flat",
+        originatingTo: "room",
+        originatingThreadId: "inbound-thread",
+        messagingToolSentTargets: targets,
+      });
+      expect(result.replyPayloads).toHaveLength(count);
+      expect(
+        resolveFollowupDeliveryPayloads({
+          cfg: {},
+          payloads,
+          messageProvider: "test-flat",
+          originatingTo: "room",
+          originatingThreadId: "inbound-thread",
+          originatingReplyToMode: mode,
+          sentTargets: targets,
+        }),
+      ).toHaveLength(count);
+    },
+  );
+});


### PR DESCRIPTION
Related: #120339. AI-assisted maintainer repair, kept separate from the Buzz presentation feature.

## What Problem This Solves

Fixes an issue where a message-tool send can suppress the wrong automatic reply, or leave a duplicate reply, when a channel resolves automatic delivery to a different thread from the incoming message.

## Why This Change Was Made

Duplicate suppression now asks the existing channel reply-transport hook for the final destination before comparing it with message-tool deliveries. Two premature bypasses used the inherited input thread or skipped resolution when there was no reply ID. Removing those bypasses gives delivery and duplicate suppression the same owner. Channels without a hook keep their existing inherited-thread behavior.

## User Impact

Automatic replies and explicit message-tool sends are compared by where they will actually be delivered. This is a generic prerequisite for flat Buzz replies; it contains no Buzz-specific condition or new SDK contract.

Release-note context: compare message-tool duplicate suppression against the resolved automatic-reply destination.

## Evidence

Four cases cover flat/threaded automatic delivery against top-level/threaded tool sends. On the baseline, both flat cases fail and both threaded controls pass; the fix passes all four. The adjacent payload, route-reply, follow-up, and channel-boundary suites pass together: 5 files, 191 tests, rerun successfully on the independently installed native checkout. The Slack fixtures now match the real Slack transport resolver while preserving their expected dedupe assertions. Production delta: 2 additions, 4 deletions (net −2); tests: 102 additions, 13 deletions.

The already-landed lifecycle parent has been removed from this PR's stack; this PR changes only four core deduplication/test paths. The initial full check caught a missing contextual type in the new test fixture; the fixture now satisfies the existing `ChannelThreadingAdapter` contract. Core-test types, 191 focused tests, and changed-file checks pass for the final tree committed as `930e3e4c5345b0e2de1d9f57c7944799a13a2738` (the full original three-file gate, followed by the complete changed gate for the additional Slack fixture):

```sh
pnpm tsgo:core:test
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/reply-payloads-transport-dedupe.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/route-reply.test.ts src/auto-reply/reply/followup-delivery.test.ts src/auto-reply/reply/followup-delivery.channel.test.ts
node scripts/check-changed.mjs -- src/auto-reply/reply/reply-payloads-dedupe.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-payloads-transport-dedupe.test.ts
node scripts/check-changed.mjs -- src/auto-reply/reply/followup-delivery.channel.test.ts
```

Hosted CI run [33026603577](https://github.com/openclaw/openclaw/actions/runs/33026603577) exposed a second inaccurate Slack fixture: first-reply mode clears a later explicit reply ID, but real Slack still falls back to the inherited thread. The fixture omitted that fallback. The same failure was reproduced locally; correcting the fixture preserves the exact single-answer expectation and makes all 191 focused tests pass. Production is unchanged by this follow-up. Its changed checks, P0–P2 review, and independent bounded verification pass; [final-head CI run 33027771696](https://github.com/openclaw/openclaw/actions/runs/33027771696) completed successfully.

Fresh full-priority source review, the bounded type-fixture review, and independent immutable-head review of the initial repair are clean. The separate Buzz feature in #130511 owns the actual authenticated relay placement proof; the owner-boundary tests here are not live model-tool proof.

Provenance: the two shortcuts were introduced with thread-scoped deduplication in [#90943](https://github.com/openclaw/openclaw/pull/90943), authored by @sandieman2 and merged by @steipete on June 14, 2026. This repair preserves its cross-thread suppression protection while removing the shortcuts made incorrect by transport-specific reply placement.
