### PR TITLE
fix(cli): honor selected port when tailing logs

### DIFF
--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -25,6 +25,7 @@ Tail Gateway file logs over RPC. Works in remote mode.
 ## Shared Gateway RPC options
 
 - `--url <url>`: Gateway WebSocket URL
+- `--port <port>`: select a local Gateway port, overriding the configured remote URL and `OPENCLAW_GATEWAY_URL`; cannot be combined with `--url`
 - `--token <token>`: Gateway token
 - `--timeout <ms>`: timeout in ms (default `30000`)
 - `--expect-final`: wait for a final response when the Gateway call is agent-backed
@@ -45,6 +46,7 @@ openclaw logs --plain
 openclaw logs --no-color
 openclaw logs --utc
 openclaw logs --follow --local-time
+openclaw logs --port 19083 --json
 openclaw logs --url ws://127.0.0.1:18789 --token "$OPENCLAW_GATEWAY_TOKEN"
 ```
 
@@ -59,6 +61,8 @@ profile uses `openclaw-YYYY-MM-DD.log`, while named profiles use
 - `--follow` does not fall back to that configured file after an implicit local Gateway RPC failure — a stale side-by-side file could mislead a live tail. On Linux it instead uses the active user-systemd Gateway journal by PID when available (prints the selected source); otherwise it keeps retrying the live Gateway.
 - During `--follow`, transient disconnects (WebSocket close, timeout, connection drop) trigger automatic reconnection with exponential backoff: up to 8 retries, capped at 30s between attempts. A warning prints to stderr on each retry, and a `[logs] gateway reconnected` notice prints once a poll succeeds. In `--json` mode both are emitted as `{"type":"notice"}` records on stderr. Non-recoverable errors (auth failure, bad configuration) still exit immediately.
 - In `--follow --json` mode, log-source transitions are emitted as `{"type":"meta"}` records. Track cursors per `sourceKind`: a stream can move from Gateway file output (`sourceKind: "file"`) to local journal fallback (`sourceKind: "journal"`, `localFallback: true`, with `service.pid`/`service.unit`) and back to Gateway file output after recovery. Do not assume one stable source or cursor for the whole session, and tolerate overlapping lines when recovery replays the Gateway file cursor.
+
+In `--json` mode, invalid `--port`, `--limit`, `--interval`, or `--max-bytes` values and conflicting `--url`/`--port` options produce the standard CLI failure envelope on stdout: `{"ok":false,"error":{"type":"cli_error","message":"..."}}`. Terminal log-fetch failures instead emit `{"type":"error",...}` on stderr. Both exit with status `1`.
 
 ## Related
 

--- a/src/cli/gateway-port-option.ts
+++ b/src/cli/gateway-port-option.ts
@@ -1,5 +1,6 @@
 // Shared parser for CLI flags that select a local Gateway TCP port.
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
+import type { GatewayRpcOpts } from "./gateway-rpc.types.js";
 
 const MAX_TCP_PORT = 65_535;
 
@@ -23,4 +24,14 @@ export function parseGatewayPortOption(raw: unknown, flagName = "--port"): numbe
     throw new Error(`${flagName} must be an integer between 1 and ${MAX_TCP_PORT}.`);
   }
   return parsed;
+}
+
+export function resolveGatewayLocalPortOverride(
+  opts: Pick<GatewayRpcOpts, "port" | "url"> & { localPortOverride?: number },
+): number | undefined {
+  const port = opts.localPortOverride ?? parseGatewayPortOption(opts.port);
+  if (port !== undefined && typeof opts.url === "string" && opts.url.trim()) {
+    throw new Error("Use either --url or --port, not both.");
+  }
+  return port;
 }

--- a/src/cli/gateway-rpc.runtime.ts
+++ b/src/cli/gateway-rpc.runtime.ts
@@ -5,7 +5,7 @@ import {
 } from "../../packages/gateway-protocol/src/client-info.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway, isImplicitLocalGatewayTarget } from "../gateway/call.js";
-import { parseGatewayPortOption } from "./gateway-port-option.js";
+import { resolveGatewayLocalPortOverride } from "./gateway-port-option.js";
 import type { GatewayRpcOpts } from "./gateway-rpc.types.js";
 import { parseTimeoutMsWithFallback } from "./parse-timeout.js";
 import { withProgress } from "./progress.js";
@@ -37,21 +37,13 @@ type GatewayCliTransportRpcOpts = Omit<GatewayRpcOpts, "timeout"> & {
 
 const DEFAULT_GATEWAY_RPC_TIMEOUT_MS = 30_000;
 
-function resolveLocalPortOverride(opts: GatewayCliTransportRpcOpts): number | undefined {
-  const port = opts.localPortOverride ?? parseGatewayPortOption(opts.port);
-  if (port !== undefined && typeof opts.url === "string" && opts.url.trim()) {
-    throw new Error("Use either --url or --port, not both.");
-  }
-  return port;
-}
-
 export async function isImplicitLocalGatewayTargetFromCliRuntime(
   opts: GatewayCliTransportRpcOpts,
 ): Promise<boolean> {
   return await isImplicitLocalGatewayTarget({
     config: opts.config,
     url: opts.url,
-    localPortOverride: resolveLocalPortOverride(opts),
+    localPortOverride: resolveGatewayLocalPortOverride(opts),
   });
 }
 
@@ -61,7 +53,7 @@ export async function callGatewayFromCliRuntime(
   params?: unknown,
   extra?: CallGatewayFromCliRuntimeExtra,
 ) {
-  const localPortOverride = resolveLocalPortOverride(opts);
+  const localPortOverride = resolveGatewayLocalPortOverride(opts);
   // Progress is disabled for JSON output so stdout stays parseable.
   const showProgress = extra?.progress ?? opts.json !== true;
   const timeoutMs =

--- a/src/cli/logs-cli.port.test.ts
+++ b/src/cli/logs-cli.port.test.ts
@@ -1,0 +1,185 @@
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import {
+  buildMinimalGatewayHelloOkPayload,
+  closeMinimalGatewayServer,
+  parseMinimalGatewayRequestFrame,
+  sendMinimalGatewayConnectChallenge,
+  sendMinimalGatewayResponse,
+} from "../gateway/minimal-gateway.test-helpers.js";
+import { defaultRuntime, ExitError } from "../runtime.js";
+import { runRegisteredCli } from "../test-utils/command-runner.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { registerLogsCli } from "./logs-cli.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+async function withLogsGateway(
+  options: { source?: "config" | "environment"; denied?: boolean },
+  run: (fixture: {
+    port: string;
+    requests: string[];
+    stdout: string[];
+    stderr: string[];
+  }) => Promise<void>,
+) {
+  await withOpenClawTestState(
+    {
+      label: "logs-port",
+      env: {
+        OPENCLAW_GATEWAY_URL:
+          options.source === "environment" ? "ws://remote.example:19001" : undefined,
+        OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: undefined,
+      },
+    },
+    async (state) => {
+      await state.writeConfig({
+        gateway: {
+          mode: options.source === "config" ? "remote" : "local",
+          auth: { mode: "none" },
+          ...(options.source === "config" ? { remote: { url: "ws://remote.example:19001" } } : {}),
+        },
+      });
+      const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+      const requests: string[] = [];
+      server.on("connection", (socket) => {
+        sendMinimalGatewayConnectChallenge(socket);
+        socket.on("message", (data) => {
+          const frame = parseMinimalGatewayRequestFrame(data);
+          if (!frame.id || !frame.method) {
+            return;
+          }
+          requests.push(frame.method);
+          if (frame.method === "connect") {
+            sendMinimalGatewayResponse(
+              socket,
+              frame.id,
+              buildMinimalGatewayHelloOkPayload({ methods: ["logs.tail"] }),
+            );
+          } else if (options.denied) {
+            socket.send(
+              JSON.stringify({
+                type: "res",
+                id: frame.id,
+                ok: false,
+                error: { code: "INVALID_REQUEST", message: "logs unavailable for this client" },
+              }),
+            );
+          } else {
+            sendMinimalGatewayResponse(socket, frame.id, {
+              file: "selected-gateway.log",
+              cursor: 1,
+              lines: ["selected local log"],
+            });
+          }
+        });
+      });
+      await once(server, "listening");
+      const port = String((server.address() as AddressInfo).port);
+      const stdout: string[] = [];
+      const stderr: string[] = [];
+      vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+        stdout.push(String(chunk));
+        return true;
+      });
+      vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+        stderr.push(String(chunk));
+        return true;
+      });
+      vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
+        throw new ExitError(code);
+      });
+      try {
+        await run({ port, requests, stdout, stderr });
+      } finally {
+        await closeMinimalGatewayServer(server);
+      }
+    },
+  );
+}
+
+async function runLogs(argv: string[]) {
+  await runRegisteredCli({ register: registerLogsCli, argv: ["logs", ...argv] });
+}
+
+describe("logs local port selection", () => {
+  it.each(["config", "environment"] as const)(
+    "tails the selected local port instead of validating the %s default URL",
+    async (source) => {
+      await withLogsGateway({ source }, async ({ port, requests, stdout }) => {
+        await runLogs(["--port", port, "--json", "--timeout", "1500"]);
+        expect(requests).toEqual(["connect", "logs.tail"]);
+        expect(stdout.join("")).toContain("selected local log");
+      });
+    },
+  );
+
+  it.each(["text", "json"])(
+    "reports the selected port when the RPC fails in %s mode",
+    async (mode) => {
+      await withLogsGateway({ denied: true }, async ({ port, requests, stderr }) => {
+        const args = [
+          "--port",
+          port,
+          "--timeout",
+          "1500",
+          ...(mode === "json" ? ["--json"] : ["--plain"]),
+        ];
+        await expect(runLogs(args)).rejects.toBeInstanceOf(ExitError);
+        expect(requests).toEqual(["connect", "logs.tail"]);
+        const output = stderr.join("");
+        if (mode === "json") {
+          expect(JSON.parse(output)).toMatchObject({
+            type: "error",
+            details: { url: `ws://127.0.0.1:${port}` },
+          });
+        } else {
+          expect(output).toContain(`Gateway target: ws://127.0.0.1:${port}`);
+        }
+      });
+    },
+  );
+
+  it("honors an explicit URL even with an unusable default URL", async () => {
+    await withLogsGateway({ source: "config" }, async ({ port, requests, stdout }) => {
+      await runLogs([
+        "--url",
+        `ws://127.0.0.1:${port}`,
+        "--token",
+        "fixture-token",
+        "--json",
+        "--timeout",
+        "1500",
+      ]);
+      expect(requests).toEqual(["connect", "logs.tail"]);
+      expect(stdout.join("")).toContain("selected local log");
+    });
+  });
+
+  it.each(["config", "environment"] as const)(
+    "still rejects an unsafe %s target without an override",
+    async (source) => {
+      await withLogsGateway({ source }, async ({ requests }) => {
+        await expect(runLogs(["--json"])).rejects.toThrow(
+          "uses plaintext ws:// to a non-loopback address",
+        );
+        expect(requests).toEqual([]);
+      });
+    },
+  );
+
+  it.each([
+    { args: ["--port", "65536"], message: "--port must be an integer between 1 and 65535." },
+    {
+      args: ["--port", "19083", "--url", "ws://127.0.0.1:19083"],
+      message: "Use either --url or --port, not both.",
+    },
+  ])("keeps target validation for $args", async ({ args, message }) => {
+    await withLogsGateway({}, async ({ requests }) => {
+      await expect(runLogs(args)).rejects.toThrow(message);
+      expect(requests).toEqual([]);
+    });
+  });
+});

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -35,7 +35,9 @@ import { redactSensitiveLines, resolveRedactOptions } from "../logging/redact.js
 import { formatTimestamp } from "../logging/timestamps.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatCliCommand } from "./command-format.js";
+import { resolveGatewayLocalPortOverride } from "./gateway-port-option.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "./gateway-rpc.js";
+import type { GatewayRpcOpts } from "./gateway-rpc.types.js";
 
 type LogsTailPayload = {
   file?: string;
@@ -87,20 +89,20 @@ async function loadLogsCliRuntime(): Promise<LogsCliRuntimeModule> {
   return await import("./logs-cli.runtime.js");
 }
 
-type LogsCliOptions = {
+type LogsCliOptions = GatewayRpcOpts & {
   limit?: string;
   maxBytes?: string;
   follow?: boolean;
   interval?: string;
-  json?: boolean;
   plain?: boolean;
   color?: boolean;
   localTime?: boolean;
   utc?: boolean;
-  url?: string;
-  token?: string;
-  timeout?: string;
-  expectFinal?: boolean;
+};
+
+type LogsRequestOptions = LogsCliOptions & {
+  localPortOverride?: number;
+  connection: GatewayConnectionDetails;
 };
 
 const LOCAL_FALLBACK_NOTICE = "Local Gateway RPC unavailable; reading configured file log instead.";
@@ -158,7 +160,7 @@ function buildLogMetaRecord(payload: LogsTailPayload): Record<string, unknown> {
 }
 
 async function fetchGatewayLogs(
-  opts: LogsCliOptions,
+  opts: LogsRequestOptions,
   gatewayCursor: number | undefined,
   showProgress: boolean,
   params: { limit: number; maxBytes: number; signal?: AbortSignal },
@@ -177,7 +179,7 @@ async function fetchGatewayLogs(
 }
 
 async function fetchLogs(
-  opts: LogsCliOptions,
+  opts: LogsRequestOptions,
   cursors: LogCursorState,
   showProgress: boolean,
   params: { limit: number; maxBytes: number },
@@ -210,7 +212,7 @@ async function fetchLogs(
   }
 }
 
-function shouldUseLocalLogsFallback(opts: LogsCliOptions, error: unknown): boolean {
+function shouldUseLocalLogsFallback(opts: LogsRequestOptions, error: unknown): boolean {
   // Fallback reads local files only for implicit loopback Gateway RPC failures.
   if (!isLocalGatewayRpcUnavailableError(error)) {
     return false;
@@ -218,15 +220,13 @@ function shouldUseLocalLogsFallback(opts: LogsCliOptions, error: unknown): boole
   if (typeof opts.url === "string" && opts.url.trim().length > 0) {
     return false;
   }
-  const connection = isGatewayTransportError(error)
-    ? error.connectionDetails
-    : buildGatewayConnectionDetails();
+  const connection = isGatewayTransportError(error) ? error.connectionDetails : opts.connection;
   return isImplicitLoopbackGatewayConnection(connection);
 }
 
-function buildLogsTailGatewayExtra(opts: LogsCliOptions, showProgress: boolean) {
+function buildLogsTailGatewayExtra(opts: LogsRequestOptions, showProgress: boolean) {
   const base = { progress: showProgress };
-  if (!shouldUsePassiveLocalLogsClient(opts)) {
+  if (opts.url?.trim() || !isImplicitLoopbackGatewayConnection(opts.connection)) {
     return base;
   }
   return {
@@ -235,13 +235,6 @@ function buildLogsTailGatewayExtra(opts: LogsCliOptions, showProgress: boolean) 
     mode: GATEWAY_CLIENT_MODES.BACKEND,
     deviceIdentity: null,
   };
-}
-
-function shouldUsePassiveLocalLogsClient(opts: LogsCliOptions): boolean {
-  if (typeof opts.url === "string" && opts.url.trim().length > 0) {
-    return false;
-  }
-  return isImplicitLoopbackGatewayConnection(buildGatewayConnectionDetails());
 }
 
 function isImplicitLoopbackGatewayConnection(connection: GatewayConnectionDetails): boolean {
@@ -483,7 +476,7 @@ function createLogWriters(onOutputClosed?: () => void) {
 
 async function emitGatewayError(
   err: unknown,
-  opts: LogsCliOptions,
+  opts: LogsRequestOptions,
   mode: "json" | "text",
   rich: boolean,
   emitJsonLine: (payload: Record<string, unknown>, toStdErr?: boolean) => boolean,
@@ -494,7 +487,7 @@ async function emitGatewayError(
   const errorText = redactSensitiveUrlLikeString(formatErrorMessage(err));
 
   const details = projectGatewayConnectionDetailsForDiagnostics(
-    buildGatewayConnectionDetails({ url: opts.url }),
+    isGatewayTransportError(err) ? err.connectionDetails : opts.connection,
   );
   if (mode === "json") {
     if (
@@ -544,7 +537,14 @@ export function registerLogsCli(program: Command) {
 
   addGatewayClientOptions(logs);
 
-  logs.action(async (opts: LogsCliOptions) => {
+  logs.action(async (rawOpts: LogsCliOptions) => {
+    const localPortOverride = resolveGatewayLocalPortOverride(rawOpts);
+    // Client identity, fallback, and diagnostics must describe the same selected target.
+    const opts: LogsRequestOptions = {
+      ...rawOpts,
+      localPortOverride,
+      connection: buildGatewayConnectionDetails({ url: rawOpts.url, localPortOverride }),
+    };
     let gatewayRecovery: GatewayRecoveryState = { kind: "idle" };
     const abortGatewayRecoveryProbe = () => {
       if (gatewayRecovery.kind === "probing") {


### PR DESCRIPTION
Closes #130512 (logs ignores the selected port in target preparation and diagnostics).

<details>
<summary>Additional instructions</summary>

Maintainers can push to this repository-owned branch.

</details>

## What Problem This Solves

Fixes an issue where users tailing logs with `--port` would be blocked by an unrelated remote default, or receive diagnostics naming the wrong Gateway. A safe local selection could fail with a plaintext-remote-URL error before the selected server received `logs.tail`.

The shared flag was added in #125474 (automation Gateway port options), but the logs command's target preparation, plain-error fallback classification, and diagnostic projection still reconstructed the default connection without that port.

## Why This Change Was Made

Prepare one canonical selected connection at the logs command boundary and carry it through client setup, fallback decisions and diagnostics. Reuse the existing strict port/conflict resolver in its owning port-option module; shared RPC still uses the same policy, and typed transport errors retain their actual connection details.

This removes the separate passive-target helper and repeated incomplete target reconstruction. It adds no config, dependencies, protocol, persistence or credential policy. Plaintext-remote validation, explicit-URL credential requirements and explicit-URL no-file-fallback behavior remain intact.

Production LOC: **+38/-35, net +3**. Tests: **+185/-0**. Docs: **+4/-0**. The small production increase records a prepared typed target and its ownership invariant; the resolver is moved rather than duplicated, and the logs owner itself remains line-neutral.

## User Impact

`openclaw logs --port <port>` consistently selects that local Gateway even when a different remote URL is configured or supplied through `OPENCLAW_GATEWAY_URL`. Terminal failures identify the selected server. Eligible one-shot local-file fallback uses that same target classification.

Usage-error clarification: invalid port values and `--url`/`--port` conflicts now use the root CLI's stdout JSON envelope (`ok:false`, `error.type:cli_error`) and exit 1, matching existing invalid log-limit/interval/byte-limit errors. They previously emitted a misleading Gateway-unreachable log event on stderr. Actual terminal log-fetch errors still emit `type:error` on stderr. The docs now explain this distinction and show `--port`. The shared port option's available release-tag ancestry is beta-only; no stable-release output compatibility claim is made.

## Evidence

Before editing production, two real Commander/Gateway WebSocket cases failed on main `25a16dd96c42876cc80b0ad754a612a75524b4eb`: both remote-config and environment-default scenarios rejected `ws://remote.example:19001` instead of querying the selected local fixture. The same cases pass after the repair.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cli/logs-cli.port.test.ts src/cli/logs-cli.test.ts src/cli/gateway-rpc.runtime.test.ts src/cli/gateway-port-option.test.ts
node --import tsx scripts/build-all.mts cliStartup
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cli/gateway-port-option.ts src/cli/gateway-rpc.runtime.ts src/cli/logs-cli.port.test.ts src/cli/logs-cli.ts
node scripts/check-docs-mdx.mjs docs/cli/logs.md
git diff --check
```

- **82 tests / four files passed**, independently rerun with the same result. The nine new cases exercise the real parser, configuration/connection builder and WebSocket client with no production module mocks.
- **Four independent narrow fault-injection probes passed**, retaining the real connection builder and isolated configured-file reader while injecting a plain transport-close error. These cover both config/environment defaults and JSON/plain fallback output.
- **Nine built-CLI subprocess scenarios passed**: selected-server log output despite ambient defaults, no contact with another listening default, JSON/plain target diagnostics, post-handshake close/file fallback and usage validation. A separate exact-baseline build confirmed the old/new usage-error envelopes.
- **Source-blind operator validation passed all five contracts across 35 commands and 72 fresh wire events**, with no accepted behavioral findings. It checked fresh per-server log markers, selected/unselected request deltas, failures, implicit versus explicit fallback, malformed ports and explicit URL controls without reading product or fixture source.
- **Fresh authenticated Codex whole-patch review, including docs: no actionable P0–P2 findings.**
- **Build, changed-file typed lint, docs MDX/format and diff checks passed.**

The full changed gate was attempted with:

```sh
node scripts/check-changed.mjs --base 25a16dd96c42876cc80b0ad754a612a75524b4eb -- src/cli/gateway-port-option.ts src/cli/gateway-rpc.runtime.ts src/cli/logs-cli.ts src/cli/logs-cli.port.test.ts
```

Its generic guards, dead-export scans, formatting and core production typecheck passed. Core-test typechecking stopped at unrelated `ui/vite.config.ts:9` with TS7016: this validation checkout's linked dependency donor resolves pako 1.0.11 without declarations, while the UI lockfile requires 3.0.1. No dependencies or unrelated UI files were changed, and this is **not** a claim of full-gate success; exact-head CI remains required.

All runtime proof used isolated temporary state, loopback protocol fixtures and fake credentials. It did not contact an operator Gateway or an external model/provider. Fixture processes were stopped, temporary state removed, and all five listening ports verified closed.

AI-assisted QA and repair.
