### PR TITLE
fix(feishu): preserve commands in select fallback cards

### DIFF
--- a/docs/plugins/message-presentation.md
+++ b/docs/plugins/message-presentation.md
@@ -558,8 +558,8 @@ keeping opaque callback data private:
   `webApp` / `web_app`** inputs render the URL text alongside the button label,
   since the URL is user-facing. Hosted-widget-only actions render label-only on
   channels without a native widget launch.
-- **Select options** render as label-only. The underlying option value is not
-  exposed in fallback text.
+- **Select options** follow the same rule: typed commands include the command
+  text; opaque callback actions and legacy values remain label-only.
 
 Channel adapters that add manual-command guidance in their fallback UI (e.g.
 Feishu document-comment instructions) must derive the command-present check

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -1336,40 +1336,49 @@ describe("feishuPlugin actions", () => {
     ]);
   });
 
-  it("renders presentation select labels into the card fallback", async () => {
-    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
+  it.each(["send", "thread-reply"] as const)(
+    "preserves select commands in the %s card fallback without exposing callback values",
+    async (action) => {
+      sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
 
-    await feishuPlugin.actions?.handleAction?.({
-      action: "send",
-      params: {
-        to: "chat:oc_group_1",
-        presentation: {
-          blocks: [
-            {
-              type: "select",
-              placeholder: "Pick one",
-              options: [{ label: "Option A", value: "a" }],
-            },
-          ],
+      await feishuPlugin.actions?.handleAction?.({
+        action,
+        params: {
+          to: "chat:oc_group_1",
+          ...(action === "thread-reply" ? { messageId: "om_root" } : {}),
+          presentation: {
+            blocks: [
+              {
+                type: "select",
+                placeholder: "Pick <one> & continue",
+                options: [
+                  { label: "Status <one>", action: { type: "command", command: "/status" } },
+                  { label: "Callback", action: { type: "callback", value: "/opaque-callback" } },
+                  { label: "Legacy", value: "/opaque-legacy" },
+                ],
+              },
+            ],
+          },
         },
-      },
-      cfg,
-      accountId: undefined,
-      toolContext: {},
-    } as never);
+        cfg,
+        accountId: undefined,
+        toolContext: {},
+      } as never);
 
-    const sendCardArgs = requireRecord(
-      mockCallArg(sendCardFeishuMock, 0, 0, "sendCardFeishu"),
-      "send card args",
-    );
-    const card = requireRecord(sendCardArgs.card, "card");
-    expect(requireRecord(card.body, "card body").elements).toEqual([
-      {
-        tag: "markdown",
-        content: "Pick one:\n- Option A",
-      },
-    ]);
-  });
+      const sendCardArgs = requireRecord(
+        mockCallArg(sendCardFeishuMock, 0, 0, "sendCardFeishu"),
+        "send card args",
+      );
+      const card = requireRecord(sendCardArgs.card, "card");
+      expect(requireRecord(card.body, "card body").elements).toEqual([
+        {
+          tag: "markdown",
+          content:
+            "Pick &lt;one&gt; &amp; continue:\n- Status &lt;one&gt;: `/status`\n- Callback\n- Legacy",
+        },
+      ]);
+    },
+  );
 
   it.each(
     [

--- a/extensions/feishu/src/presentation-card.ts
+++ b/extensions/feishu/src/presentation-card.ts
@@ -229,13 +229,12 @@ function buildFeishuCardElementsForBlock(
       },
     ];
   }
-  const labels = block.options.map((option) => `- ${option.label}`).join("\n");
   return [
     {
       tag: "markdown",
-      content: `${escapeFeishuCardMarkdownText(
-        block.placeholder?.trim() || "Options",
-      )}:\n${escapeFeishuCardMarkdownText(labels)}`,
+      content: escapeFeishuCardMarkdownText(
+        renderMessagePresentationFallbackText({ presentation: { blocks: [block] } }),
+      ),
     },
   ];
 }


### PR DESCRIPTION
Closes #130514

## What Problem This Solves

Fixes an issue where users receiving Feishu select fallback cards would see option labels without the copyable command when a presentation was sent through native send or thread-reply actions.

## Why This Change Was Made

Feishu kept its own label-only select fallback after the shared presentation formatter learned to preserve explicitly typed commands. Reuse that existing block formatter at the native card owner, retaining Feishu's Markdown escaping. This deletes duplicate rendering logic and corrects the stale select-fallback documentation.

Production LOC: +3/−4 (net −1). Tests: +40/−31 (net +9). Docs: +2/−2. No new configuration, protocol, SDK surface, dependency, persistence, or native select capability.

## User Impact

Select fallback cards now retain the command beside its label so recipients can copy it. Callback data and legacy values remain hidden, including opaque values beginning with `/`. Heading and label escaping remains intact. This is a current-main behavior repair, not a claim of a stable-release regression.

## Evidence

AI-assisted; fresh Codex P0–P2 review completed with no actionable findings. Independent source review confirmed the Gateway dispatch reaches the native Feishu action without generic fallback adaptation.

- Before production edits, the native send/thread-reply regression cases both failed solely because `/status` was missing from the card.
- Focused owner/sibling proof: 389 tests passed (344 Feishu, 45 shared payload).
- Full changed-file gate passed: formatting, lint, extension and extension-test typechecks, dead-export scans, plugin boundaries, applicable guards, five doctor-contract tests, and import-cycle checks.
- Actual built Gateway, authenticated WebSocket `message.action`, real Feishu plugin and Lark SDK 1.73.0, with provider HTTP redirected to a local loopback service. Initial send and thread-reply both emitted the expected interactive card.
- Independent source-blind validation: five clauses passed, seven fresh cards and seven distinct successful receipts across four sends and three thread replies. Cases varied the command, labels, heading, opaque values, and opaque-only options.

```json
{"verdict":"pass","transport":"authenticated built Gateway + real Feishu SDK + mock provider HTTP","sourceBlind":true,"passedClauses":5,"failedClauses":0,"freshCards":7,"uniqueReceipts":7,"sends":4,"threadReplies":3}
```

Commands:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts -t 'preserves select commands'
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts extensions/feishu/src/presentation-card.test.ts extensions/feishu/src/outbound.test.ts src/interactive/payload.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/check-changed.mjs -- extensions/feishu/src/presentation-card.ts extensions/feishu/src/channel.test.ts docs/plugins/message-presentation.md
git diff --check
```

Proof limits: no live Feishu UI/SaaS delivery, command execution, or callback execution is claimed. An initial harness activation failure was corrected only in the fixture: channel-skipping flags intentionally remove channel configuration, so the proof instead started the real Feishu webhook listener on an isolated port with synthetic credentials. No product workaround was added.

Separate source-only follow-up hypotheses were recorded for disabled native buttons and mixed callback-only button rows; neither is established or fixed by this select repair. Existing table, card envelope, outbound, and document-comment behavior remains covered by the passing sibling suites.
