### PR TITLE
fix(sandbox): stop retaining built-in backends across module reloads

### DIFF
--- a/src/agents/sandbox/backend.test.ts
+++ b/src/agents/sandbox/backend.test.ts
@@ -1,6 +1,6 @@
 // Sandbox backend registry tests cover pluggable backend factory and manager
 // lifecycle hooks.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   getSandboxBackendFactory,
   getSandboxBackendManager,
@@ -26,6 +26,75 @@ describe("sandbox backend registry", () => {
     expect(getSandboxBackendFactory("podman")).not.toBeNull();
     expect(getSandboxBackendManager("podman")).not.toBeNull();
     expect(getSandboxBackendWorkdirResolver("podman")).not.toBeNull();
+  });
+
+  it.each(["docker", "podman", "ssh"] as const)(
+    "preserves %s overrides through repeated module reloads and restores its defaults",
+    async (backendId) => {
+      const defaults = {
+        factory: getSandboxBackendFactory(backendId),
+        manager: getSandboxBackendManager(backendId),
+        resolveWorkdir: getSandboxBackendWorkdirResolver(backendId),
+      };
+      const registration = createGenerationRegistration(backendId);
+      const restore = registerSandboxBackend(backendId, registration);
+
+      try {
+        for (let reload = 0; reload < 2; reload++) {
+          vi.resetModules();
+          const fresh = await import("./backend.js");
+          expect(fresh.getSandboxBackendFactory(backendId)).toBe(registration.factory);
+          expect(fresh.getSandboxBackendManager(backendId)).toBe(registration.manager);
+          expect(fresh.getSandboxBackendWorkdirResolver(backendId)).toBe(
+            registration.resolveWorkdir,
+          );
+        }
+      } finally {
+        restore();
+      }
+
+      expect(getSandboxBackendFactory(backendId)).toBe(defaults.factory);
+      expect(getSandboxBackendManager(backendId)).toBe(defaults.manager);
+      expect(getSandboxBackendWorkdirResolver(backendId)).toBe(defaults.resolveWorkdir);
+
+      const fresh = await import("./backend.js");
+      const container = await import("./docker-backend.js");
+      const ssh = await import("./ssh-backend.js");
+      const { resolveSandboxConfigForAgent } = await import("./config.js");
+      const [factory, manager] = {
+        docker: [container.createDockerSandboxBackend, container.dockerSandboxBackendManager],
+        podman: [container.createPodmanSandboxBackend, container.podmanSandboxBackendManager],
+        ssh: [ssh.createSshSandboxBackend, ssh.sshSandboxBackendManager],
+      }[backendId];
+      expect(fresh.getSandboxBackendFactory(backendId)).toBe(factory);
+      expect(fresh.getSandboxBackendManager(backendId)).toBe(manager);
+      const cfg = resolveSandboxConfigForAgent();
+      const scopeKey = "agent:registry-test:main";
+      const workdir = fresh.getSandboxBackendWorkdirResolver(backendId)?.({
+        cfg,
+        sessionKey: scopeKey,
+        scopeKey,
+        workspaceDir: "/workspace",
+        agentWorkspaceDir: "/workspace",
+      });
+      expect(workdir).toBe(
+        backendId === "ssh"
+          ? ssh.resolveSshRuntimePaths(cfg.ssh.workspaceRoot, scopeKey).remoteWorkspaceDir
+          : cfg.docker.workdir,
+      );
+    },
+  );
+
+  it("does not inherit built-in management hooks for a factory-only override", () => {
+    const registration = createGenerationRegistration("docker");
+    const restore = registerSandboxBackend("docker", registration.factory);
+    try {
+      expect(getSandboxBackendFactory("docker")).toBe(registration.factory);
+      expect(getSandboxBackendManager("docker")).toBeNull();
+      expect(getSandboxBackendWorkdirResolver("docker")).toBeNull();
+    } finally {
+      restore();
+    }
   });
 
   it("registers and restores backend factories", () => {

--- a/src/agents/sandbox/backend.ts
+++ b/src/agents/sandbox/backend.ts
@@ -51,8 +51,8 @@ type SandboxBackendRegistrationGeneration = {
   retired: boolean;
 };
 
-// Process-wide sandbox backend registry. Tests and plugins can install temporary
-// factories while core still auto-registers the bundled container and SSH backends.
+// Only explicit overrides need process-wide generations. Built-in defaults stay
+// module-local so repeated imports neither retain old graphs nor replace overrides.
 function getSandboxBackendFactories(): Map<SandboxBackendId, SandboxBackendRegistrationGeneration> {
   const globalStore = globalThis as typeof globalThis & {
     [SANDBOX_BACKEND_FACTORIES_STATE_KEY]?: Map<
@@ -110,24 +110,17 @@ export function registerSandboxBackend(
 
 /** Look up a sandbox backend factory by normalized backend id. */
 export function getSandboxBackendFactory(id: string): SandboxBackendFactory | null {
-  return (
-    getSandboxBackendFactories().get(normalizeSandboxBackendId(id))?.registration.factory ?? null
-  );
+  return resolveSandboxBackendRegistration(id)?.factory ?? null;
 }
 
 /** Look up optional lifecycle management hooks for a registered backend. */
 export function getSandboxBackendManager(id: string): SandboxBackendManager | null {
-  return (
-    getSandboxBackendFactories().get(normalizeSandboxBackendId(id))?.registration.manager ?? null
-  );
+  return resolveSandboxBackendRegistration(id)?.manager ?? null;
 }
 
 /** Look up optional backend workdir resolution that does not start the runtime. */
 export function getSandboxBackendWorkdirResolver(id: string): SandboxBackendWorkdirResolver | null {
-  return (
-    getSandboxBackendFactories().get(normalizeSandboxBackendId(id))?.registration.resolveWorkdir ??
-    null
-  );
+  return resolveSandboxBackendRegistration(id)?.resolveWorkdir ?? null;
 }
 
 /** Resolve a backend factory or throw the user-facing configuration error. */
@@ -144,21 +137,28 @@ export function requireSandboxBackendFactory(id: string): SandboxBackendFactory 
   );
 }
 
-registerSandboxBackend("docker", {
+const builtinSandboxBackends = new Map<SandboxBackendId, RegisteredSandboxBackend>();
+builtinSandboxBackends.set("docker", {
   factory: createDockerSandboxBackend,
   manager: dockerSandboxBackendManager,
   resolveWorkdir: ({ cfg }) => cfg.docker.workdir,
 });
-
-registerSandboxBackend("podman", {
+builtinSandboxBackends.set("podman", {
   factory: createPodmanSandboxBackend,
   manager: podmanSandboxBackendManager,
   resolveWorkdir: ({ cfg }) => cfg.docker.workdir,
 });
-
-registerSandboxBackend("ssh", {
+builtinSandboxBackends.set("ssh", {
   factory: createSshSandboxBackend,
   manager: sshSandboxBackendManager,
   resolveWorkdir: ({ cfg, scopeKey }) =>
     resolveSshRuntimePaths(cfg.ssh.workspaceRoot, scopeKey).remoteWorkspaceDir,
 });
+
+function resolveSandboxBackendRegistration(id: string): RegisteredSandboxBackend | undefined {
+  const normalizedId = normalizeSandboxBackendId(id);
+  return (
+    getSandboxBackendFactories().get(normalizedId)?.registration ??
+    builtinSandboxBackends.get(normalizedId)
+  );
+}


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a one-worker iMessage test shard exhausts its 4 GB JavaScript heap when tests repeatedly reload runtime modules. Reloading the sandbox backend module also replaces an active explicit override of a built-in backend.

## Why This Change Was Made

The sandbox registry stores disposable registration generations process-wide. Its import-time Docker, Podman, and SSH registrations discarded their disposers, so every reload retained another generation and its captured module graph. This became visible after the generation-retirement change in #130031.

Keep built-in definitions module-local and reserve global generations for explicit registrations. All three lookups select a whole explicit registration before considering defaults, so a factory-only override never inherits a built-in manager or workdir resolver. The existing out-of-order disposal logic is unchanged. Production LOC: +17/-17; tests: +70/-1.

## User Impact

Repeated runtime module loading no longer retains an unbounded history of built-in sandbox backends or replaces explicit overrides. Docker, Podman, SSH, custom-backend defaults, and existing disposal semantics remain unchanged. No configuration, protocol, persistence, dependency, heap-limit, timeout, or isolation changes.

## Evidence

Local validation is complete; exact-head CI remains the final gate. Native source/build proof uses this PR's own frozen-lockfile dependency installation, Node 26.7.0 and Vitest 4.1.11. The earlier pre-fix diagnostic used an immutable matching installation on the reproduction checkout; its provenance is kept separate.

- New regression fails on the original production code for Docker, Podman, and SSH: module reload returns the built-in factory instead of the explicit override. The repaired registry passes all 13 cases, including fresh-reader restoration and factory-only hook isolation.
- The original whole iMessage shape, `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/imessage --reporter=verbose --logHeapUsage`, reproduced `ERR_WORKER_OUT_OF_MEMORY` at approximately 4,063 MB. The own-native repaired run passes 52 files / 1,173 tests in 162.67 seconds. A second own-native run replays the seven-file prefix actually observed before the baseline crash, then completes the remaining 45 files from the fixed baseline's schedule: all 1,173 pass in 183.62 seconds. The replay uses a private external sequencer; no repository config, iMessage tests, heap limits, timeouts, or isolation settings changed.
- Private same-worker heap snapshots show each built-in generation chain growing from 1 to 8 before repair, retaining over two million objects through old SSH factories and configuration schemas. After repair, the sandbox-global retaining path is absent. Native default-order and prefix-replay runs sample maximum heaps of 2,585 MB and 2,475 MB, respectively, with zero built-in global generations at every sample. Raw snapshots remain private. Local Node 26/max-workers-1 reproduction is not claimed to be CI's Node 24/multi-worker shape.
- Own-native registry, Docker/Podman, SSH, pruning, provisioning-error, and MXC registration coverage passes 65 tests. `node scripts/check-changed.mjs -- src/agents/sandbox/backend.ts src/agents/sandbox/backend.test.ts` passes all selected type, lint, dead-export, import-cycle and guard checks. Formatting and diff checks pass. Independent source challenge and two fresh structured Codex reviews, including a distinct exact-head review, found no actionable defects.
- Canonical `pnpm build` passes in 11m27s, including all 147 public SDK exports and Control UI performance ratchets. There are no ineffective-dynamic-import warnings.
- Built public SDK owner proof passes with three byte-identical copies of the candidate compiled graph, using only this checkout's dependencies and isolated state/config. All three built-in overrides survive two actual owner reevaluations; factory, manager and workdir authority remain coherent; stale disposers do not revive old authority; old/fresh defaults return; factory-only overrides inherit no hooks. Selected factories execute owned local child markers, and their managers observe and remove those markers. Compiled artifacts and source/lock/HEAD hashes are unchanged before/after. This proves the compiled registry/lifecycle boundary, not Docker, Podman or SSH transport integration.

The scope is the three implicit built-in registration lifetimes. Explicit plugin registration cleanup, including the separate OpenShell registration-disposer follow-up, is not claimed fixed here.
