### PR TITLE
fix(tui): show agent-scoped session example

### DIFF
--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -3,7 +3,6 @@ import { EventEmitter } from "node:events";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { AgentSelectionRequiredError } from "../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
@@ -380,7 +379,7 @@ describe("resolveInitialTuiAgentId", () => {
 
   it("keeps an ownerless explicit fleet selection-required", () => {
     expect(() => resolveInitialTuiAgentId({ cfg, cwd: "/var/tmp/unrelated" })).toThrow(
-      AgentSelectionRequiredError,
+      "Multiple agents are configured, but TUI startup has no explicit owner. Pass an agent-scoped --session key (e.g., 'openclaw tui --session agent:agentname:main').",
     );
   });
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -293,7 +293,7 @@ export function resolveInitialTuiAgentId(params: {
       tryResolveLegacyCompatibilityAgentId(params.cfg) ??
       resolveDefaultAgentId(params.cfg, {
         surface: "TUI startup",
-        hint: "Pass an agent-scoped --session key.",
+        hint: `Pass an agent-scoped --session key (e.g., '${formatCliCommand("openclaw tui --session agent:agentname:main")}').`,
       }),
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw tui` with multiple explicitly owned agents would be told to pass an agent-scoped `--session` key without being shown the supported syntax. The incomplete hint can lead users to try unsupported `--agentId` or `--agent` options.

## Why This Change Was Made

The TUI-specific startup diagnostic now includes the supported pattern: `openclaw tui --session agent:agentname:main`. This changes display text only; CLI options, agent resolution, session parsing, and fallback behavior remain unchanged.

AI-assisted: yes.

## User Impact

Users can act on the startup error directly instead of guessing unsupported flags.

## Evidence

Before (installed OpenClaw 2026.8.1 development cut at `ad24304`):

```text
Multiple agents are configured, but TUI startup has no explicit owner. Pass an agent-scoped --session key.
```

After (isolated checkout, using a synthetic two-agent configuration):

```text
Multiple agents are configured, but TUI startup has no explicit owner. Pass an agent-scoped --session key (e.g., 'openclaw tui --session agent:agentname:main').
```

- `pnpm test src/tui/tui.test.ts -- --reporter=dot` — 88 tests passed on the rebased PR commit
- `pnpm check:changed -- src/tui/tui.ts src/tui/tui.test.ts` — passed the classified core and core-test checks
- `pnpm build` — passed
- `autoreview --mode uncommitted` — clean, with no accepted/actionable findings
