### PR TITLE
fix(cron): preserve authored speech in text announcements

### DIFF
--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -376,7 +376,7 @@ describe("resolveCronPayloadOutcome", () => {
       isError: true,
     },
   ])("keeps only speech facts owned by the $name", ({ texts, finalText, speech, isError }) => {
-    const tts = { tagged: true, text: "Authored spoken report" };
+    const tts = { tagged: true as const, text: "Authored spoken report" };
     const payloads = texts.map((text) =>
       setReplyPayloadMetadata<ReplyPayload>(
         { text, ...(isError ? { isError } : {}) },

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -1,6 +1,10 @@
 // Isolated agent helper tests cover utility behavior used by cron agent runs.
 import { describe, expect, it } from "vitest";
-import { setReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
+import {
+  getReplyPayloadMetadata,
+  setReplyPayloadMetadata,
+  type ReplyPayload,
+} from "../auto-reply/reply-payload.js";
 import { resolveCronPayloadOutcome } from "./isolated-agent/helpers.js";
 
 describe("resolveCronPayloadOutcome", () => {
@@ -301,12 +305,16 @@ describe("resolveCronPayloadOutcome", () => {
     ]);
   });
 
-  it("truncates long summaries", () => {
+  it.each([
+    ["a".repeat(2001), `${"a".repeat(2000)}…`],
+    [`${"a".repeat(1999)}🦞`, `${"a".repeat(1999)}…`],
+  ])("bounds summaries without truncating the selected output", (text, summary) => {
     const result = resolveCronPayloadOutcome({
-      payloads: [{ text: "a".repeat(2001) }],
+      payloads: [{ text }],
     });
 
-    expect(result.summary ?? "").toMatch(/…$/);
+    expect(result.summary).toBe(summary);
+    expect(result.outputText).toBe(text);
   });
 
   it("preserves all successful deliverable payloads when no final assistant text is available", () => {
@@ -338,6 +346,66 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.synthesizedText).toBe("section 1\nsection 2");
     expect(result.deliveryPayloads).toEqual([{ text: "section 1\nsection 2" }]);
     expect(result.deliveryPayload).toEqual({ text: "section 2" });
+  });
+
+  it.each([
+    {
+      name: "matching final answer",
+      texts: ["Final report"],
+      finalText: "Final report",
+      speech: true,
+    },
+    { name: "replaced answer", texts: ["Draft report"], finalText: "Final report", speech: false },
+    {
+      name: "earlier matching answer",
+      texts: ["Final report", "Later answer"],
+      finalText: "Final report",
+      speech: false,
+    },
+    {
+      name: "merged partial answers",
+      texts: ["section 1", "section 2"],
+      finalText: "section 1\nsection 2",
+      speech: false,
+    },
+    {
+      name: "matching recovered tool warning",
+      texts: ["⚠️ 🛠️ Exec failed"],
+      finalText: "⚠️ 🛠️ Exec failed",
+      speech: false,
+      isError: true,
+    },
+  ])("keeps only speech facts owned by the $name", ({ texts, finalText, speech, isError }) => {
+    const tts = { tagged: true, text: "Authored spoken report" };
+    const payloads = texts.map((text) =>
+      setReplyPayloadMetadata<ReplyPayload>(
+        { text, ...(isError ? { isError } : {}) },
+        {
+          tts,
+          sourceReplyTranscriptMirror: { sessionKey: "agent:main:source" },
+          pendingFinalDeliveryCompletion: {
+            deliveryId: "delivery-1",
+            intentId: "intent-1",
+            sessionId: "session-1",
+            sessionKey: "agent:main:source",
+            storePath: "/tmp/cron-speech-test.sqlite",
+          },
+          deliverDespiteSourceReplySuppression: true,
+        },
+      ),
+    );
+    const result = resolveCronPayloadOutcome({
+      payloads,
+      finalAssistantVisibleText: finalText,
+      preferFinalAssistantVisibleText: true,
+    });
+
+    expect(result.deliveryPayloads).toEqual([{ text: finalText }]);
+    const metadata = getReplyPayloadMetadata(result.deliveryPayloads[0]!);
+    expect(metadata?.tts).toEqual(speech ? tts : undefined);
+    expect(metadata?.sourceReplyTranscriptMirror).toBeUndefined();
+    expect(metadata?.pendingFinalDeliveryCompletion).toBeUndefined();
+    expect(metadata?.deliverDespiteSourceReplySuppression).toBeUndefined();
   });
 
   it("keeps structured-content detection scoped to the last delivery payload", () => {

--- a/src/cron/isolated-agent/delivery-payload-normalization.test.ts
+++ b/src/cron/isolated-agent/delivery-payload-normalization.test.ts
@@ -1,0 +1,119 @@
+import { randomUUID } from "node:crypto";
+import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildPayloads } from "../../agents/embedded-agent-runner/run/payloads.test-helpers.js";
+import {
+  getReplyPayloadMetadata,
+  setReplyPayloadMetadata,
+} from "../../auto-reply/reply-payload.js";
+import type { TtsStatusEntry } from "../../tts/tts-runtime-types.js";
+import {
+  clearRuntimeConfigSnapshot,
+  createMockSpeechProvider,
+  createTtsConfig,
+  installSpeechProviders,
+  maybeApplyTtsToPayloadCore,
+  prepareSynthesisMock,
+  setTtsMachinePrefsPathResolver,
+  synthesizeMock,
+  transcodeAudioBufferMock,
+} from "../../tts/tts-runtime.test-support.js";
+import { maybeApplyTtsToCronPayloads } from "./delivery-dispatch-policy.js";
+import { normalizeDirectCronDeliveryPayloads } from "./delivery-payload-normalization.js";
+import { resolveCronPayloadOutcome } from "./helpers.js";
+
+// Keep the production TTS policy and provider adapter; only audio persistence
+// is replaced so this owner-boundary proof creates no media or channel sends.
+vi.mock("../../tts/tts.runtime.js", () => ({
+  maybeApplyTtsToPayload: (params: Parameters<typeof maybeApplyTtsToPayloadCore>[0]) =>
+    maybeApplyTtsToPayloadCore(params, async () => "/tmp/cron-speech-proof.ogg"),
+}));
+
+describe("cron canonical speech payload delivery", () => {
+  let previousTtsAttempt: TtsStatusEntry | undefined;
+
+  beforeEach(async () => {
+    const { getLastTtsAttempt } = await import("../../tts/tts-payload.js");
+    previousTtsAttempt = getLastTtsAttempt();
+    synthesizeMock.mockClear();
+    prepareSynthesisMock.mockClear();
+    transcodeAudioBufferMock.mockClear();
+    installSpeechProviders([createMockSpeechProvider()]);
+  });
+
+  afterEach(async () => {
+    const { setLastTtsAttempt } = await import("../../tts/tts-payload.js");
+    setLastTtsAttempt(previousTtsAttempt);
+    setTtsMachinePrefsPathResolver();
+    clearRuntimeConfigSnapshot();
+    vi.restoreAllMocks();
+  });
+
+  it.each(["Report complete.", "NO_REPLY\nReport complete."])(
+    "preserves direct-delivery ownership while normalizing %j",
+    (text) => {
+      const metadata = {
+        tts: { tagged: true, text: "The report is complete." },
+        channelReplyTransformOwner: {},
+        sourceReplyTranscriptMirror: { sessionKey: "agent:main:source" },
+      };
+      const source = setReplyPayloadMetadata({ text }, metadata);
+      const normalized = normalizeDirectCronDeliveryPayloads({ deliveryPayloads: [source] });
+
+      expect(normalized.kind).toBe("deliver");
+      if (normalized.kind !== "deliver") {
+        throw new Error("expected visible report after normalization");
+      }
+      expect(normalized.payload).toEqual([{ text: "Report complete." }]);
+      expect(getReplyPayloadMetadata(normalized.payload[0]!)).toEqual(metadata);
+      expect(source.text).toBe(text);
+    },
+  );
+
+  it.each(
+    ["whatsapp", "telegram", "discord", "slack"].flatMap((channel) =>
+      (["tagged", "always"] as const).map((auto) => ({ channel, auto })),
+    ),
+  )("preserves authored speech for $channel with $auto TTS", async ({ channel, auto }) => {
+    const visibleText = "Your report is ready.";
+    const spokenText = "The report has finished successfully.";
+    const payloads = buildPayloads({
+      isCronTrigger: true,
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: visibleText }],
+        openclawDelivery: { tts: { tagged: true, text: spokenText } },
+      } as AssistantMessage,
+    });
+    const outcome = resolveCronPayloadOutcome({
+      payloads,
+      finalAssistantVisibleText: visibleText,
+      preferFinalAssistantVisibleText: channel !== "whatsapp",
+    });
+    const normalized = normalizeDirectCronDeliveryPayloads(outcome);
+    expect(normalized.kind).toBe("deliver");
+    if (normalized.kind !== "deliver") {
+      throw new Error("expected the canonical cron reply to remain deliverable");
+    }
+
+    const result = await maybeApplyTtsToCronPayloads({
+      cfg: createTtsConfig(`openclaw-cron-speech-${randomUUID()}`),
+      payloads: normalized.payload,
+      delivery: { ok: true, channel, to: "test-recipient", mode: "explicit" },
+      agentId: "main",
+      ttsAuto: auto,
+    });
+
+    expect(synthesizeMock).toHaveBeenCalledTimes(1);
+    expect(synthesizeMock.mock.calls[0]?.[0].text).toBe(spokenText);
+    expect(result).toEqual([
+      expect.objectContaining({
+        text: visibleText,
+        spokenText,
+        mediaUrl: "/tmp/cron-speech-proof.ogg",
+      }),
+    ]);
+    expect(getReplyPayloadMetadata(payloads[0]!)?.tts?.text).toBe(spokenText);
+  });
+});

--- a/src/cron/isolated-agent/delivery-payload-normalization.test.ts
+++ b/src/cron/isolated-agent/delivery-payload-normalization.test.ts
@@ -53,7 +53,7 @@ describe("cron canonical speech payload delivery", () => {
     "preserves direct-delivery ownership while normalizing %j",
     (text) => {
       const metadata = {
-        tts: { tagged: true, text: "The report is complete." },
+        tts: { tagged: true as const, text: "The report is complete." },
         channelReplyTransformOwner: {},
         sourceReplyTranscriptMirror: { sessionKey: "agent:main:source" },
       };

--- a/src/cron/isolated-agent/delivery-payload-normalization.ts
+++ b/src/cron/isolated-agent/delivery-payload-normalization.ts
@@ -16,10 +16,10 @@ type CronChannelTransform = {
 function normalizeDirectPayload(payload: ReplyPayload): ReplyPayload {
   const normalized = payload.text ? normalizeSilentReplyText(payload.text) : undefined;
   return normalized
-    ? {
+    ? copyReplyPayloadMetadata(payload, {
         ...payload,
         text: normalized.strippedTrailingSilentToken ? undefined : normalized.text,
-      }
+      })
     : payload;
 }
 

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -2,8 +2,11 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import { isHeartbeatAcknowledgementText } from "../../auto-reply/heartbeat.js";
-import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import {
+  getReplyPayloadMetadata,
+  setReplyPayloadMetadata,
+  type ReplyPayload,
+} from "../../auto-reply/reply-payload.js";
 import { isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
 import { truncateUtf16Safe } from "../../utils.js";
 
@@ -93,31 +96,6 @@ export function pickSummaryFromOutput(text: string | undefined) {
   }
   const limit = 2000;
   return clean.length > limit ? `${truncateUtf16Safe(clean, limit)}…` : clean;
-}
-
-/** Picks the last non-error payload text suitable for cron run summaries. */
-function pickSummaryFromPayloads(
-  payloads: Array<{ text?: string | undefined; isError?: boolean }>,
-) {
-  for (let i = payloads.length - 1; i >= 0; i--) {
-    if (payloads[i]?.isError) {
-      continue;
-    }
-    const summary = pickSummaryFromOutput(payloads[i]?.text);
-    if (summary) {
-      return summary;
-    }
-  }
-  for (let i = payloads.length - 1; i >= 0; i--) {
-    if (isNonTerminalToolErrorWarning(payloads[i])) {
-      continue;
-    }
-    const summary = pickSummaryFromOutput(payloads[i]?.text);
-    if (summary) {
-      return summary;
-    }
-  }
-  return undefined;
 }
 
 /** Picks the last non-empty payload text while ignoring terminal error payloads first. */
@@ -264,11 +242,8 @@ export function resolveCronPayloadOutcome(params: {
   finalAssistantVisibleText?: string | undefined;
   preferFinalAssistantVisibleText?: boolean;
 }): CronPayloadOutcome {
-  const firstText =
-    params.payloads.find((payload) => !isNonTerminalToolErrorWarning(payload))?.text ?? "";
-  const fallbackSummary =
-    pickSummaryFromPayloads(params.payloads) ?? pickSummaryFromOutput(firstText);
   const fallbackOutputText = pickLastNonEmptyTextFromPayloads(params.payloads);
+  const fallbackSummary = pickSummaryFromOutput(fallbackOutputText);
   const deliveryPayload = pickLastDeliverablePayload(params.payloads);
   const selectedDeliveryPayloads = pickDeliverablePayloads(params.payloads);
   const deliveryPayloadHasStructuredContent = payloadHasStructuredDeliveryContent(deliveryPayload);
@@ -347,8 +322,24 @@ export function resolveCronPayloadOutcome(params: {
     ? normalizedFinalAssistantVisibleText
     : fallbackOutputText;
   const synthesizedText = normalizeOptionalString(outputText) ?? normalizeOptionalString(summary);
-  const resolvedDeliveryPayloads = shouldUseFinalAssistantVisibleText
-    ? [{ text: normalizedFinalAssistantVisibleText }]
+  const finalDeliveryPayload = shouldUseFinalAssistantVisibleText
+    ? { text: normalizedFinalAssistantVisibleText }
+    : undefined;
+  if (
+    finalDeliveryPayload &&
+    deliveryPayload &&
+    deliveryPayload.isError !== true &&
+    deliveryPayload.text === normalizedFinalAssistantVisibleText
+  ) {
+    // A replacement or assembled answer must not inherit another payload's
+    // speech. This fresh text projection never inherits transcript or custody ownership.
+    const tts = getReplyPayloadMetadata(deliveryPayload)?.tts;
+    if (tts) {
+      setReplyPayloadMetadata(finalDeliveryPayload, { tts });
+    }
+  }
+  const resolvedDeliveryPayloads = finalDeliveryPayload
+    ? [finalDeliveryPayload]
     : selectedDeliveryPayloads.length > 0
       ? selectedDeliveryPayloads
       : synthesizedText


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users delivering text-bearing cron announcements with authored speech would receive no audio in tagged TTS mode, or hear the visible message instead of the authored speech in always-on mode.

The direct-delivery path affects channels such as WhatsApp. Channels that prefer the canonical final answer, including Telegram, Discord, and Slack, also lose speech when selecting that answer.

## Why This Change Was Made

The runtime already records authored speech as canonical reply metadata. Cron was dropping those facts in two places: cloning a payload during silent-token normalization, and constructing a fresh preferred-final-text payload. Preserve metadata with the existing canonical copy helper for ordinary normalization; transfer only `tts` facts into a fresh final-text projection when the selected last deliverable payload is successful and has exactly the same body.

The fresh projection must not inherit transcript, custody, or source-suppression ownership. Earlier matching answers, replacement or assembled text, and error payloads cannot donate speech facts. Existing silence, channel-veto, and duplicate-delivery decisions remain unchanged.

The same selection owner also had duplicate summary-selection loops. Select canonical output once and truncate only its summary, preserving error/warning precedence and UTF-16-safe truncation while removing the redundant selector and fallback.

Production LOC: **+26/-35 (net -9)**. Tests: **+191/-4** across the existing helper suite and one new owner-composition suite. No config, defaults, persistence, protocol, provider API, or channel policy changes.

Provenance: the direct-normalization clone was introduced by #121159, authored and merged by @steipete on August 11. The speech loss became visible with structured speech facts in #124913, also authored and merged by @steipete on August 17 UTC. The preferred-final-text projection predates the available local history boundary. This is proven against the frozen main baseline below, not claimed as a verified stable-release regression.

## User Impact

Text-bearing cron announcements retain their authored speech through direct delivery and preferred-final-answer selection. Tagged mode can synthesize the intended speech, and always-on mode uses the authored speech rather than substituting the visible text. The visible announcement and its delivery/suppression ownership stay unchanged.

Named follow-up: **cron metadata-only speech with no visible body**. The producer can retain speech-only metadata, but cron content selection and pre-TTS suppression still discard it. Resolving that requires a shared content/silence-policy investigation, including disabled or unavailable TTS; this PR deliberately makes no claim to fix that separate path.

## Evidence

Baseline: `8e9db5e16689a73c6a6bf501efabc8f32704d0f1`.

- Before the production fix, the regression run had **9 intended failures**: four tagged-mode cases never called synthesis; four always-on cases synthesized visible text instead of authored speech; one preferred-final projection lost the canonical speech facts. The same focused run passed after the fix.
- **204 tests passed across five owner/sibling files**, covering cron selection, normalization, dispatch/double-announcement behavior, and runtime payload delivery recovery. Controls cover exact-current matches, earlier matches, replacement/merged/error text, custody/source-suppression exclusions, summary selection, full-output preservation, and summary truncation.
- After the final test-only singleton cleanup, **51 tests passed in one worker with `isolate=false`**: 41 existing TTS status/fallback tests followed by the 10 new cron cases. The new suite captures and restores the exact previous `lastTtsAttempt`; lifecycle imports let the shared TTS fixture initialize before the real consumer. An earlier eager-import probe was interrupted during prolonged CPU-active import, not an assertion failure.
- Changed-file formatting, scoped oxlint, and `git diff --check` passed. Structured autoreview and a separate read-only source-aware review completed with no actionable P0/P1/P2 findings.
- Initial exact-head CI caught two test-fixture type errors: `TS2322` in `isolated-agent.helpers.test.ts` and `TS2345` in `delivery-payload-normalization.test.ts`. The fixtures widened `tagged: true` to `boolean`; the canonical speech contract requires the literal `true`. The follow-up preserves that literal with `as const` in exactly two test lines, without changing runtime values, assertions, or production code. The canonical services test-type shard reproduced both diagnostics before the correction and removed exactly those two afterward, with no added diagnostics. Its 11 unrelated local dependency diagnostics remained unchanged; this is not a green full local typecheck.
- After the fixture correction, the original shared-process run passed **51/51**, the helper suite passed **46/46**, formatting/scoped lint/diff-check passed, and fresh structured plus independent read-only reviews of the **complete four-file patch** found no actionable P0/P1/P2 defects. Separately, ClawSweeper's Linux terminal proof ran all 10 normalization cases twice successfully under Vitest 4.1.11 on the original head; that remains mock-provider composition proof, not live channel delivery.
- Final pinned evidence: [CI run 33027848369](https://github.com/openclaw/openclaw/actions/runs/33027848369) completed successfully for corrected head `fba20392416ea4cbc79c81f5540f29cd84f8d1c8`, including the formerly failing test-type check. Its [completed cron job](https://github.com/openclaw/openclaw/actions/runs/33027848369/job/98373560667) passed **53 files / 756 tests**, including all 10 normalization and 46 helper cases, and recorded outer canonical-shard exit zero. Checkout logs bind its merge ref to this exact corrected head.
- The latest optional ClawSweeper terminal-driver artifact is **failed and not counted as passing proof**: it reported the command still active after 30 seconds despite capturing 10 passing tests and a passed Vitest shard in 17.53 seconds; its subsequent output assertion was not run. This leaves that driver's outer-completion evidence incomplete. The separate hosted cron job above provides completed, exact-head owner/sibling proof. The latest exact-head source review has no findings, security concerns, or rank-up requests. No claim is made that all optional live-proof tooling passed.

Owner/sibling command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/cron/isolated-agent.helpers.test.ts \
  src/cron/isolated-agent/helpers.test.ts \
  src/cron/isolated-agent/delivery-payload-normalization.test.ts \
  src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts \
  src/agents/embedded-agent-runner/run/payloads.delivery-recovery.test.ts
```

The shared-order check used the existing `createScopedVitestConfig` factory with the TTS status/fallback suite and new cron suite together, `isolate: false`, `fileParallelism: false`, `excludeUnitFastTests: false`, and one worker; the normal wrapper routes these suites into separate processes.

Proof boundary: this exercises the production payload builder → cron selection → direct normalization → actual TTS policy core, using the existing mock registered speech provider, mocked channel capabilities/transcoding, and fake audio persistence. It sends no external audio and is **not live Gateway/channel proof**. External transport/provider behavior is unchanged and was not revalidated here.

Local verification used the existing shared dependency installation, which is not lockfile-aligned: Vitest 4.1.10 versus pinned 4.1.11, tsx 4.23.1 versus 4.23.12, Vite 8.1.5 versus 8.2.1, and oxlint 1.75.0 versus 1.78.0. The remaining local type diagnostics concern installed Google genai 2.13.0 versus pinned 2.17.1, markdown-it 14.3.0 versus 15.0.0, and pi-tui 0.82.1 versus 0.84.2. The native-preview typechecker itself matches the pinned 7.0.0-dev.20260707.2. Runtime normalization aliases resolve to this worktree's source. **Lockfile-aligned hosted checks on corrected head `fba20392416ea4cbc79c81f5540f29cd84f8d1c8` are now green; this does not relabel the local full typecheck as green.**

ClawSweeper rank-up response: its review found no actionable code or security findings and requested refreshing against main as needed plus completing exact-head checks. No freshness-only rebase is being performed: GitHub reports the branch mergeable, and no conflict, failing native guard, or material stale-base risk has been identified. The reviewed fixture-only correction is being published on the existing branch; required checks must pass on its resulting head before merge. Refresh remains appropriate if a concrete conflict or guard failure appears.
